### PR TITLE
NameError: undefined local variable or method `settings' for #<LogStash::Agent:0x3fcac3fa>

### DIFF
--- a/lib/logstash/agent.rb
+++ b/lib/logstash/agent.rb
@@ -189,7 +189,7 @@ class LogStash::Agent
     end
 
     if @logfile
-      logfile = File.open(settings.logfile, "w")
+      logfile = File.open(@logfile, "w")
       STDOUT.reopen(logfile)
       STDERR.reopen(logfile)
     elsif @daemonize


### PR DESCRIPTION
Fixes:

<pre> # ./bin/logstash -f /etc/logstash/testing.yaml -l /home/naresh.ve/logstash.jruby.log
 I, [2011-03-21T13:09:55.481000 #7131]  INFO -- logstash: Adding "/home/naresh.ve/logstash/lib/logstash" to  ruby load path
 NameError: undefined local variable or method `settings' for #<LogStash::Agent:0x3fcac3fa>
   configure at /home/naresh.ve/logstash/lib/logstash/agent.rb:192
         run at /home/naresh.ve/logstash/lib/logstash/agent.rb:215
      (root) at ./bin/logstash:9
</pre>
