### PR TITLE
fixing notify call so opts will be passed

### DIFF
--- a/lib/logstash/outputs/gelf.rb
+++ b/lib/logstash/outputs/gelf.rb
@@ -51,6 +51,6 @@ class LogStash::Outputs::Gelf < LogStash::Outputs::Base
       m["#{name}"] = value
     end
     m["timestamp"] = event.timestamp
-    @gelf.notify(m)
+    @gelf.notify!(m)
   end # def receive
 end # class LogStash::Outputs::Gelf


### PR DESCRIPTION
Noticed that my options weren't passing in. Looks like you have to use the ! version of notify for options to work.
