### PR TITLE
Adds bind_host for node

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem "bunny" # for amqp support, MIT-style license
 gem "uuidtools" # for naming amqp queues, License ???
 gem "filewatch", "~> 0.2.3"  # for file tailing, BSD License
 gem "jls-grok", "~> 0.4.7" # for grok filter, BSD License
-gem "jruby-elasticsearch", "~> 0.0.7" # BSD License
+gem "jruby-elasticsearch", "~> 0.0.8" # BSD License
 gem "stomp" # for stomp protocol, Apache 2.0 License
 gem "json" # Ruby license
 gem "awesome_print" # MIT License

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -33,6 +33,9 @@ class LogStash::Outputs::Elasticsearch < LogStash::Outputs::Base
   # REST API port (normally 9200).
   config :port, :validate => :number, :default => 9300
 
+  # The name/address of the host to bind to for ElasticSearch clustering
+  config :bind_host, :validate => :string
+
   # TODO(sissel): Config for river?
 
   public
@@ -53,7 +56,8 @@ class LogStash::Outputs::Elasticsearch < LogStash::Outputs::Base
     @pending = []
     @callback = self.method(:receive_native)
     @client = ElasticSearch::Client.new(:cluster => @cluster,
-                                        :host => @host, :port => @port)
+                                        :host => @host, :port => @port,
+                                        :bind_host => @bind_host)
   end # def register
 
   # TODO(sissel): Needs migration to  jrubyland

--- a/lib/logstash/search/elasticsearch.rb
+++ b/lib/logstash/search/elasticsearch.rb
@@ -15,8 +15,11 @@ class LogStash::Search::ElasticSearch < LogStash::Search::Base
     @host = (settings[:host] || nil)
     @port = (settings[:port] || 9300).to_i
     @cluster = (settings[:cluster] || nil)
+    @bind_host = (settings[:bind_host] || nil)
     @logger = LogStash::Logger.new(STDOUT)
-    @client = ElasticSearch::Client.new(:host => @host, :port => @port, :cluster => @cluster)
+    @client = ElasticSearch::Client.new(:host => @host, :port => @port, 
+                                        :cluster => @cluster, 
+                                        :bind_host => @bind_host)
   end
 
   # See LogStash::Search;:Base#search

--- a/lib/logstash/web/server.rb
+++ b/lib/logstash/web/server.rb
@@ -64,7 +64,9 @@ class LogStash::Web::Server < Sinatra::Base
         @backend = LogStash::Search::ElasticSearch.new(
           :host => backend_url.host,
           :port => backend_url.port,
-          :cluster => cluster_name
+          :cluster => cluster_name,
+          :bind_host => settings.bind_host
+
         )
       when "twitter"
         require "logstash/search/twitter"
@@ -91,7 +93,7 @@ class LogStash::Web::Server < Sinatra::Base
 end # class LogStash::Web::Server
 
 require "optparse"
-Settings = Struct.new(:daemonize, :logfile, :address, :port, :backend_url)
+Settings = Struct.new(:daemonize, :logfile, :address, :port, :backend_url, :bind_host)
 settings = Settings.new
 
 settings.address = "0.0.0.0"
@@ -117,6 +119,10 @@ opts = OptionParser.new do |opts|
 
   opts.on("-p", "--port PORT", "Port on which to start webserver. Default is 9292.") do |port|
     settings.port = port.to_i
+  end
+
+  opts.on("-B", "--elasticsearch-bind-host ADDRESS", "Address on which to bind elastic search node.") do |addr|
+    settings.bind_host = addr
   end
 
   opts.on("-b", "--backend URL",


### PR DESCRIPTION
Allows user to specify bind host for ES node in both ES output and logstash-web.
