### PR TITLE
Add SSL support for AMQP input/output plugins

### DIFF
--- a/lib/logstash/inputs/amqp.rb
+++ b/lib/logstash/inputs/amqp.rb
@@ -38,6 +38,12 @@ class LogStash::Inputs::Amqp < LogStash::Inputs::Base
   # Enable or disable debugging
   config :debug, :validate => :boolean, :default => false
 
+  # Enable or disable SSL
+  config :ssl, :validate => :boolean, :default => false
+
+  # Validate SSL certificate
+  config :verify_ssl, :validate => :boolean, :default => false
+
   public
   def initialize(params)
     super
@@ -63,6 +69,8 @@ class LogStash::Inputs::Amqp < LogStash::Inputs::Base
     @amqpsettings[:user] = @user if @user
     @amqpsettings[:pass] = @password.value if @password
     @amqpsettings[:logging] = @debug
+    @amqpsettings[:ssl] = @ssl if @ssl
+    @amqpsettings[:verify_ssl] = @verify_ssl if @verify_ssl
     @amqpurl = "amqp://"
     if @user or @password
       @amqpurl += "#{@user}:xxxxxx@"

--- a/lib/logstash/outputs/amqp.rb
+++ b/lib/logstash/outputs/amqp.rb
@@ -42,6 +42,12 @@ class LogStash::Outputs::Amqp < LogStash::Outputs::Base
   # Enable or disable debugging
   config :debug, :validate => :boolean, :default => false
 
+  # Enable or disable SSL
+  config :ssl, :validate => :boolean, :default => false
+
+  # Validate SSL certificate
+  config :verify_ssl, :validate => :boolean, :default => false
+
   public
   def register
     require "bunny" # rubygem 'bunny'
@@ -63,6 +69,8 @@ class LogStash::Outputs::Amqp < LogStash::Outputs::Base
     }
     amqpsettings[:user] = @user if @user
     amqpsettings[:pass] = @password.value if @password
+    amqpsettings[:ssl] = @ssl if @ssl
+    amqpsettings[:verify_ssl] = @verify_ssl if @verify_ssl
 
     begin
       @logger.debug(["Connecting to AMQP", amqpsettings, @exchange_type, @name])


### PR DESCRIPTION
With the latest version of RabbitMQ and bunny gem (how new? I've no clue), you can setup SSL on the broker and connect via SSL with the bunny gem.

This patch should add support for the ssl/verify_ssl options in bunny.
