### PR TITLE
Add Support for Dynamic AMQP Routing Keys

### DIFF
--- a/lib/logstash/inputs/amqp.rb
+++ b/lib/logstash/inputs/amqp.rb
@@ -28,6 +28,9 @@ class LogStash::Inputs::Amqp < LogStash::Inputs::Base
 
   # The name of the exchange
   config :name, :validate => :string, :required => true
+  
+  # The routing key to bind to
+  config :key, :validate => :string
 
   # The vhost to use
   config :vhost, :validate => :string, :default => "/"
@@ -79,8 +82,8 @@ class LogStash::Inputs::Amqp < LogStash::Inputs::Base
 
       @queue = @bunny.queue(@name, :durable => @durable)
       exchange = @bunny.exchange(@name, :type => @exchange_type.to_sym, :durable => @durable)
-      @queue.bind(exchange)
-
+      @queue.bind(exchange, :key => @key)
+      
       @queue.subscribe do |data|
         e = to_event(data[:payload], @amqpurl)
         if e


### PR DESCRIPTION
Pretty straight forward for the input. You can set a routing key for the queue to bind to. For example:

<pre>key => "logstash.data.processed.#"</pre>

The output is a little more complicated. I wanted to add support for dynamic keys. For example I use: 

<pre>logstash.data.raw.{hostname}.{event type}</pre> 

To accomplish this the key param is an array. The example routing key would be configured as:

<pre>key => ['logstash', 'data', 'raw', ':hostname', ':type']</pre>

The colon denotes a variable which is set in a hash. Currently there is only support for the hostname and event type but it would be trivial to add more.

I don't see a reason to add dynamic support to the input as queues tend to be pretty static. 
