### PR TITLE
Add Support for Dynamic AMQP Routing Keys

### DIFF
--- a/lib/logstash/inputs/amqp.rb
+++ b/lib/logstash/inputs/amqp.rb
@@ -41,6 +41,12 @@ class LogStash::Inputs::Amqp < LogStash::Inputs::Base
   # Enable or disable debugging
   config :debug, :validate => :boolean, :default => false
 
+  # Enable or disable SSL
+  config :ssl, :validate => :boolean, :default => false
+
+  # Validate SSL certificate
+  config :verify_ssl, :validate => :boolean, :default => false
+
   public
   def initialize(params)
     super
@@ -66,6 +72,8 @@ class LogStash::Inputs::Amqp < LogStash::Inputs::Base
     @amqpsettings[:user] = @user if @user
     @amqpsettings[:pass] = @password.value if @password
     @amqpsettings[:logging] = @debug
+    @amqpsettings[:ssl] = @ssl if @ssl
+    @amqpsettings[:verify_ssl] = @verify_ssl if @verify_ssl
     @amqpurl = "amqp://"
     if @user or @password
       @amqpurl += "#{@user}:xxxxxx@"

--- a/lib/logstash/outputs/amqp.rb
+++ b/lib/logstash/outputs/amqp.rb
@@ -45,6 +45,12 @@ class LogStash::Outputs::Amqp < LogStash::Outputs::Base
   # Enable or disable debugging
   config :debug, :validate => :boolean, :default => false
 
+  # Enable or disable SSL
+  config :ssl, :validate => :boolean, :default => false
+
+  # Validate SSL certificate
+  config :verify_ssl, :validate => :boolean, :default => false
+
   public
   def register
     require "bunny" # rubygem 'bunny'
@@ -66,6 +72,8 @@ class LogStash::Outputs::Amqp < LogStash::Outputs::Base
     }
     amqpsettings[:user] = @user if @user
     amqpsettings[:pass] = @password.value if @password
+    amqpsettings[:ssl] = @ssl if @ssl
+    amqpsettings[:verify_ssl] = @verify_ssl if @verify_ssl
 
     begin
       @logger.debug(["Connecting to AMQP", amqpsettings, @exchange_type, @name])


### PR DESCRIPTION
Pretty straight forward for the input. You can set a routing key for the queue to bind to. For example:

<pre>key => "logstash.data.processed.#"</pre>

The output has an extra feature, it supports dynamic keys. For example I use: 

<pre>logstash.data.raw.{hostname}.{event type}</pre> 

To accomplish this the key param configured as:

<pre>key => "logstash.data.raw.%{@source_host}.%{@type}</pre>

