### PR TITLE
Quick fix for AMQP output

### DIFF
--- a/lib/logstash/outputs/amqp.rb
+++ b/lib/logstash/outputs/amqp.rb
@@ -30,7 +30,7 @@ class LogStash::Outputs::Amqp < LogStash::Outputs::Base
   config :name, :validate => :string, :required => true
   
   # Key to route to
-  config :key, :validate => :string#, :default => ""
+  config :key, :validate => :string
 
   # The vhost to use
   config :vhost, :validate => :string, :default => "/"


### PR DESCRIPTION
When i switched to using sprintf I forgot to check to see if the key was defined. Before this fix it would throw an error if the key was nil because you can't perform a gsub on a nil.
