### PR TITLE
Add jruby-openssl to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "jruby-elasticsearch", "~> 0.0.10" # BSD License
 gem "stomp" # for stomp protocol, Apache 2.0 License
 gem "json" # Ruby license
 gem "awesome_print" # MIT License
+gem "jruby-openssl" # For enabling SSL support, CPL/GPL 2.0
 
 gem "rack" # License: MIT
 gem "mizuno" # License: Apache 2.0


### PR DESCRIPTION
OpenSSL in jruby requires jruby-openssl - adding it into the Gemfile.

Not sure if this presents any weirdness with packaging (looks like jruby-openssl is CPL/GPL 2.0 - I'm a complete newbie when it comes to these sort of licensing things).
