### PR TITLE
[LOGSTASH-172] Accept ISO8601 timestamps in syslog inputs

### DIFF
--- a/lib/logstash/inputs/syslog.rb
+++ b/lib/logstash/inputs/syslog.rb
@@ -160,7 +160,7 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
     if !event.tags.include?("_grokparsefailure")
       # Per RFC3164, priority = (facility * 8) + severity
       #                       = (facility << 3) & (severity)
-      priority = event.fields['priority'].to_i rescue 13
+      priority = event.fields["priority"].first.to_i rescue 13
       severity = priority & 7   # 7 is 111 (3 bits)
       facility = priority >> 3
       event.fields["priority"] = priority


### PR DESCRIPTION
Some syslog daemons send high-precision timestamps in ISO8601, e.g. rsyslog with the RSYSLOG_ForwardFormat template. This should allow the syslog input to use those as-is for an event's timestamp. The regular expressions are yanked straight from Grok.
