### PR TITLE
render @sender in statsd output without overwriting the configuration

### DIFF
--- a/lib/logstash/outputs/statsd.rb
+++ b/lib/logstash/outputs/statsd.rb
@@ -75,21 +75,21 @@ class LogStash::Outputs::Statsd < LogStash::Outputs::Base
 
     @client.namespace = event.sprintf(@namespace)
     logger.debug("Original sender: #{@sender}")
-    @sender = event.sprintf(@sender)
-    logger.debug("Munged sender: #{@sender}")
+    sender = event.sprintf(@sender)
+    logger.debug("Munged sender: #{sender}")
     logger.debug("Event: #{event}")
     @increment.each do |metric|
-      @client.increment(build_stat(event.sprintf(metric)), @sample_rate)
+      @client.increment(build_stat(event.sprintf(metric), sender), @sample_rate)
     end
     @decrement.each do |metric|
-      @client.decrement(build_stat(event.sprintf(metric)), @sample_rate)
+      @client.decrement(build_stat(event.sprintf(metric), sender), @sample_rate)
     end
     @count.each do |metric, val|
-      @client.count(build_stat(event.sprintf(metric)), 
+      @client.count(build_stat(event.sprintf(metric), sender),
                     event.sprintf(val).to_f, @sample_rate)
     end
     @timing.each do |metric, val|
-      @client.timing(build_stat(event.sprintf(metric)),
+      @client.timing(build_stat(event.sprintf(metric), sender),
                      event.sprintf(val).to_f, @sample_rate)
     end
   end # def receive


### PR DESCRIPTION
This resolves LOGSTASH-181

Copy and paste from the jira:
The statsd output overwrites its own @sender configuration with a rendered value on each event:

```
@sender = event.sprintf(@sender)
```

If a field reference is given for the value of @sender (as is the default: "%{@source_host}"), the value will be rendered properly on the first even received, and then stuck at this value for all remaining events.

In the default configuration, this means that every event will be sent from the same sender, regardless of where the actual log events came from.
