### PR TITLE
Grok filter improvements

### DIFF
--- a/lib/logstash/filters/grok.rb
+++ b/lib/logstash/filters/grok.rb
@@ -201,6 +201,16 @@ class LogStash::Filters::Grok < LogStash::Filters::Base
               value = value.to_f
           end
 
+	  # try automatic coercion to int if possible
+	  valueint = value.to_i
+	  # check if it is reversible (no loss)
+	  if valueint.to_s == value
+	    coercedvalue = valueint
+	  else
+	    coercedvalue = value
+	  end
+	  value = coercedvalue
+
           if fieldvalue == value and field == "@message"
             # Skip patterns that match the entire message
             @logger.debug("Skipping capture '#{key}' since it matches the whole line.")


### PR DESCRIPTION
These were implemented for our specific use case, I am not sure if they are appropriate for upstream logstash. At least there should be a configuration directive, I think.

First commit removes the surrounding array from single value fields. Motivation for this is simple: I was told by our analytics guy that it is not possible to do range queries via the ElasticSearch REST API if the single value is inside an array.

Second commit is also specific to our use case: we have log entries where the first fields are fixed (including the event name), but they are followed by a variable number of entries, that could be int or string. For this reason, we could not use the :int coercion option. The solution was to always cast to int if the coercion is revestible, to prevent data loss.

As mentioned above, maybe these are too specific for upstream, but I wanted to share anyway.
