### PR TITLE
Stomp Input & Output support using the OnStomp gem

### DIFF
--- a/lib/logstash/outputs/onstomp.rb
+++ b/lib/logstash/outputs/onstomp.rb
@@ -44,11 +44,11 @@ class LogStash::Outputs::Onstomp < LogStash::Outputs::Base
     require "onstomp"
     @client = OnStomp::Client.new("stomp://#{@host}:#{@port}", :login => @user, :passcode => @password.value)
 
-    @client.on_connection_closed do |client, connection, msg|
-      @logger.debug("Disconnected from stomp server, re-connecting")
+    # Handle disconnects
+    @client.on_connection_closed {
       connect
-    end
-
+    }
+    
     connect
   end # def register
   


### PR DESCRIPTION
This adds support for stomp input/output, but its called 'onstomp' instead, as I didn't know what to do with the existing stomp input/output classes: remove or rename them ? Your call. :) 

Note: The input only seems to work fine with plain format for messages.  Any suggestions how to make it usable with other formats ?  
