### PR TITLE
Convention fixes for stomp input/output plugin

### DIFF
--- a/lib/logstash/inputs/stomp.rb
+++ b/lib/logstash/inputs/stomp.rb
@@ -2,8 +2,8 @@ require "logstash/inputs/base"
 require "logstash/namespace"
 require 'pp'
 
-class LogStash::Inputs::Onstomp < LogStash::Inputs::Base
-  config_name "onstomp"
+class LogStash::Inputs::Stomp < LogStash::Inputs::Base
+  config_name "stomp"
 
   # The address of the STOMP server.
   config :host, :validate => :string, :default => "localhost", :required => true
@@ -29,9 +29,9 @@ class LogStash::Inputs::Onstomp < LogStash::Inputs::Base
   def connect
     begin
       @client.connect
-      @logger.info("Connected to stomp server") if @client.connected?
+      @logger.debug("Connected to stomp server") if @client.connected?
     rescue => e
-      @logger.info("Failed to connect to stomp server: #{e}")
+      @logger.debug("Failed to connect to stomp server, will retry", :exception => e, :backtrace => e.backtrace)
       sleep 2
       retry
     end
@@ -68,5 +68,5 @@ class LogStash::Inputs::Onstomp < LogStash::Inputs::Base
     @output_queue = output_queue 
     subscription_handler
   end # def run
-end # class LogStash::Inputs::Onstomp
+end # class LogStash::Inputs::Stomp
 

--- a/lib/logstash/outputs/stomp.rb
+++ b/lib/logstash/outputs/stomp.rb
@@ -1,8 +1,8 @@
 require "logstash/outputs/base"
 require "logstash/namespace"
 
-class LogStash::Outputs::Onstomp < LogStash::Outputs::Base
-  config_name "onstomp"
+class LogStash::Outputs::Stomp < LogStash::Outputs::Base
+  config_name "stomp"
 
 
   # The address of the STOMP server.
@@ -57,5 +57,5 @@ class LogStash::Outputs::Onstomp < LogStash::Outputs::Base
       @logger.debug(["stomp sending event", { :host => @host, :event => event }])
       @client.send(event.sprintf(@destination), event.to_json)
   end # def receive
-end # class LogStash::Outputs::Onstomp
+end # class LogStash::Outputs::Stomp
 


### PR DESCRIPTION
use 'stomp' as config name, change class name, use cabin style logging in input code as well
