### PR TITLE
Typo

### DIFF
--- a/lib/logstash/outputs/base.rb
+++ b/lib/logstash/outputs/base.rb
@@ -51,7 +51,7 @@ class LogStash::Outputs::Base < LogStash::Plugin
   private
   def output?(event)
     if !@type.empty?
-      if event.type != !type
+      if event.type != @type
         @logger.debug(["Dropping event because type doesn't match #{@type}", event])
         return false
       end


### PR DESCRIPTION
What a difference one little key makes. This resolves events with matching type being dropped erroneously.
