### PR TITLE
New Lucene docs link

### DIFF
--- a/lib/logstash/web/views/search/results.haml
+++ b/lib/logstash/web/views/search/results.haml
@@ -12,7 +12,7 @@
 %i
   You can click on any search result to see what kind of fields we know about
   for that event. You can also click on the graph to zoom to that time period.
-  The query language is that of Lucene's string query (<a href="http://lucene.apache.org/java/2_4_0/queryparsersyntax.html">docs</a>).
+  The query language is that of Lucene's string query (<a href="http://lucene.apache.org/java/3_4_0/queryparsersyntax.html">docs</a>).
 
 
 #visual


### PR DESCRIPTION
The copy of Logstash that I recently downloaded has a a broken link to the Lucene syntax docs.  I guess they took down the older versions.  I'm not sure if the syntax has changed much, but I made this little change to fix the broken link by pointing to the most recent Lucene docs.  
