### PR TITLE
Fix "incompatible character encodings" error

### DIFF
--- a/lib/logstash/web/server.rb
+++ b/lib/logstash/web/server.rb
@@ -19,6 +19,9 @@ require "optparse"
 require "rack" # gem rack
 require "sinatra/base" # gem sinatra
 
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
+
 class LogStash::Web::Server < Sinatra::Base
 
   mime_type :html, "text/html"
@@ -35,7 +38,7 @@ class LogStash::Web::Server < Sinatra::Base
 
   helpers Sinatra::RequireParam # logstash/web/helpers/require_param
 
-  set :haml, :format => :html5
+  set :haml, :format => :html5, :encoding => 'utf-8'
   set :logging, true
   set :views, "#{File.dirname(__FILE__)}/views"
 

--- a/lib/logstash/web/views/search/ajax.haml
+++ b/lib/logstash/web/views/search/ajax.haml
@@ -50,6 +50,6 @@
       - @results.events.reverse.each do |event|
         %tr.event
           %td.timestamp&= event.timestamp
-          %td.message{ :"data-full" => event.to_json }
+          %td.message{ :"data-full" => event.to_json.to_s.force_encoding('UTF-8')  }
             %a{:href => "#"}
-              %pre&= event.message
+              %pre&= event.message.force_encoding('UTF-8') 


### PR DESCRIPTION
HAML by default uses ASCII instead of UTF-8, this patch configures it to use UTF-8 and also forces the encodings on the strings just to be sure.

Fixes:
- https://logstash.jira.com/browse/LOGSTASH-282
- https://logstash.jira.com/browse/LOGSTASH-280
