### PR TITLE
ZeroMQ PUB/SUB input/output plugins

### DIFF
--- a/lib/logstash/inputs/zmq.rb
+++ b/lib/logstash/inputs/zmq.rb
@@ -1,0 +1,70 @@
+require "logstash/inputs/base"
+require "logstash/namespace"
+require "ffi-rzmq"
+require "timeout"
+require "logstash/util/zmq"
+
+# Read events over a 0MQ SUB socket.
+#
+# You need to have the 0mq 2.1.x library installed to be able to use
+# this input plugin.
+#
+# The default settings will create a subscriber binding to tcp://127.0.0.1:2120 
+# waiting for connecting publishers.
+#
+class LogStash::Inputs::Zmq < LogStash::Inputs::Base
+
+  config_name "zmq"
+
+  # 0mq socket address to connect or bind to
+  config :address, :validate => :string, :default => "tcp://127.0.0.1:2120"
+
+  # 0mq queue size
+  config :queue_size, :validate => :number, :default => 1000
+
+  # 0mq topic to subscribe to
+  config :queue, :validate => :string, :default => "" # default all
+
+  # wether to bind ("server") or connect ("client") to the socket
+  config :mode, :validate => [ "server", "client"], :default => "client"
+
+  @source = "0mq_#{@address}/#{@queue}"
+
+  public
+  def register
+    self.class.send(:include, Logstash::Util::Zmq)
+    @subscriber = context.socket(ZMQ::SUB)
+    error_check(@subscriber.setsockopt(ZMQ::HWM, @queue_length))
+    error_check(@subscriber.setsockopt(ZMQ::SUBSCRIBE, @queue))
+    error_check(@subscriber.setsockopt(ZMQ::LINGER, 1))
+    setup(@subscriber, @address)
+  end # def register
+
+  def teardown
+    error_check(@subscriber.close)
+  end
+
+  def server?
+    @mode == "server"
+  end
+
+  def run(output_queue)
+    begin
+      loop do
+        msg = ''
+        rc = @subscriber.recv_string(msg)
+        error_check(rc)
+        @logger.debug("0mq: receiving", :event => msg)
+        e = self.to_event(msg, @source)
+        if e
+          output_queue << e
+        end
+      end
+    rescue => e
+      @logger.debug("ZMQ Error", :subscriber => @subscriber,
+                    :exception => e, :backtrace => e.backtrace)
+    rescue Timeout::Error
+      @logger.debug("Read timeout", subscriber => @subscriber)
+    end # begin
+  end # def run
+end # class LogStash::Inputs::Zmq

--- a/lib/logstash/outputs/zmq.rb
+++ b/lib/logstash/outputs/zmq.rb
@@ -1,0 +1,59 @@
+require "logstash/outputs/base"
+require "logstash/namespace"
+require "ffi-rzmq"
+require "logstash/util/zmq"
+
+
+# Write events to a 0MQ PUB socket.
+#
+# You need to have the 0mq 2.1.x library installed to be able to use
+# this input plugin.
+#
+# The default settings will create a publisher connecting to a subscriber
+# bound to tcp://127.0.0.1:2120
+#
+class LogStash::Outputs::Zmq < LogStash::Outputs::Base
+
+  config_name "zmq"
+
+  # 0mq socket address to connect or bind to
+  config :address, :validate => :string, :default => "tcp://127.0.0.1:2120"
+
+  # 0mq topic
+  config :queue, :validate => :string, :default => ""
+
+  # wether to bind ("server") or connect ("client") to the socket
+  config :mode, :validate => [ "server", "client"], :default => "server"
+
+  public
+  def register
+    # unfortunately it's not possible to simply include at the class level
+    # because the Config mixin thinks we're the included module and not the base-class
+    self.class.send(:include, Logstash::Util::Zmq)
+    @publisher = context.socket(ZMQ::PUB)
+    error_check(@publisher.setsockopt(ZMQ::SUBSCRIBE, @queue)) if @queue != ""
+    error_check(@publisher.setsockopt(ZMQ::LINGER, 1))
+    setup(@publisher, @address)
+  end # def register
+
+  def teardown
+    error_check(@publisher.close)
+  end
+
+  def server?
+    @mode == "server"
+  end
+
+  def receive(event)
+    return unless output?(event)
+
+    wire_event = event.to_hash.to_json + "\n"
+
+    begin
+      @logger.debug("0mq: sending", :event => wire_event)
+      error_check(@publisher.send_string(wire_event))
+    rescue => e
+      @logger.warn("0mq output exception", :address => @address, :queue => @queue, :exception => e, :backtrace => e.backtrace)
+    end
+  end # def receive
+end # class LogStash::Outputs::Tcp

--- a/lib/logstash/util/zmq.rb
+++ b/lib/logstash/util/zmq.rb
@@ -1,0 +1,30 @@
+require 'ffi-rzmq'
+
+module Logstash
+  module Util
+    module Zmq
+
+      CONTEXT = ZMQ::Context.new
+
+      def context
+        CONTEXT
+      end
+
+      def setup(socket, address)
+        if server?
+          error_check(socket.bind(address))
+        else
+          error_check(socket.connect(address))
+        end
+        @logger.info("0mq: #{server? ? 'connected' : 'bound'}", :address => address)
+      end
+
+      def error_check(rc)
+        unless ZMQ::Util.resultcode_ok?(rc)
+          @logger.error("ZMQ error: ", { :error_code => rc })
+          raise "ZMQ Error"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi,

I'm proposing a set of ZeroMQ input/output plugins for logstash. This would be the perfect transport for log shipping IMHO.

This uses the already bundled ffi-rzmq (tested on jruby) and of course requires
the 0MQ native library to be installed.

This is a POC that certainly needs some more work, I'm looking for comments and improvements ideas.
Thanks! 
