### PR TITLE
fixed haproxy pattern for httplog and tcplog

### DIFF
--- a/patterns/haproxy
+++ b/patterns/haproxy
@@ -1,5 +1,37 @@
-HAPROXYDATE %{MONTHDAY}/%{MONTH}/%{YEAR}:%{TIME}.%{INT:milliseconds}
-HAPROXYTERMINATIONSTATE [CAPRIcs-][RQCHDLT-][NIDV-][NIPRD-]
+## These patterns were tested w/ haproxy-1.4.15
 
-# parse an haproxy 'httplog' line
-HAPROXYHTTP %{SYSLOGTIMESTAMP:timestamp} %{IPORHOST:server} %{SYSLOGPROG}: %{IP:clientip}:%{INT:clientport} \[%{HAPROXYDATE:haproxydate}\] %{NOTSPACE:proxyname} %{NOTSPACE}/%{IPORHOST:backend} %{INT:time_request}/%{INT:time_queue}/%{INT:time_backend_connect}/%{INT:time_backend_response}/%{INT:time_duration} %{INT:response} %{INT:bytes} - - %{HAPROXYTERMINATIONSTATE:terminationstate} %{INT:actconn}/%{INT:feconn}/%{INT:beconn}/%{INT:srvconn} %{INT:srv_queue}/%{INT:backend_queue} "%{WORD:verb} %{URIPATHPARAM:request} HTTP/%{NUMBER:version}"
+## Documentation of the haproxy log formats can be found at the following links:
+## http://code.google.com/p/haproxy-docs/wiki/HTTPLogFormat
+## http://code.google.com/p/haproxy-docs/wiki/TCPLogFormat
+
+HAPROXYTIME (?!<[0-9])%{HOUR:haproxy_hour}:%{MINUTE:haproxy_minute}(?::%{SECOND:haproxy_second})(?![0-9])
+HAPROXYDATE %{MONTHDAY:haproxy_monthday}/%{MONTH:haproxy_month}/%{YEAR:haproxy_year}:%{HAPROXYTIME:haproxy_time}.%{INT:haproxy_milliseconds}
+
+# Override these default patterns to parse out what is captured in your haproxy.cfg
+HAPROXYCAPTUREDREQUESTHEADERS %{DATA:captured_request_headers}
+HAPROXYCAPTUREDRESPONSEHEADERS %{DATA:captured_response_headers}
+
+# Example:
+#  These haproxy config lines will add data to the logs that are captured
+#  by the patterns below. Place them in your custom patterns directory to 
+#  override the defaults.  
+#
+#  capture request header Host len 40
+#  capture request header X-Forwarded-For len 50
+#  capture request header Accept-Language len 50
+#  capture request header Referer len 200
+#  capture request header User-Agent len 200
+#
+#  capture response header Content-Type len 30
+#  capture response header Content-Encoding len 10
+#  capture response header Cache-Control len 200
+#  capture response header Last-Modified len 200
+# 
+# HAPROXYCAPTUREDREQUESTHEADERS %{DATA:request_header_host}\|%{DATA:request_header_x_forwarded_for}\|%{DATA:request_header_accept_language}\|%{DATA:request_header_referer}\|%{DATA:request_header_user_agent}
+# HAPROXYCAPTUREDRESPONSEHEADERS %{DATA:response_header_content_type}\|%{DATA:response_header_content_encoding}\|%{DATA:response_header_cache_control}\|%{DATA:response_header_last_modified}
+
+# parse a haproxy 'httplog' line 
+HAPROXYHTTP %{SYSLOGTIMESTAMP:syslog_timestamp} %{IPORHOST:syslog_server} %{SYSLOGPROG}: %{IP:client_ip}:%{INT:client_port} \[%{HAPROXYDATE:accept_date}\] %{NOTSPACE:frontend_name} %{NOTSPACE:backend_name}/%{NOTSPACE:server_name} %{INT:time_request}/%{INT:time_queue}/%{INT:time_backend_connect}/%{INT:time_backend_response}/%{NOTSPACE:time_duration} %{INT:http_status_code} %{NOTSPACE:bytes_read} %{DATA:captured_request_cookie} %{DATA:captured_response_cookie} %{NOTSPACE:termination_state} %{INT:actconn}/%{INT:feconn}/%{INT:beconn}/%{INT:srvconn}/%{NOTSPACE:retries} %{INT:srv_queue}/%{INT:backend_queue} \{%{HAPROXYCAPTUREDREQUESTHEADERS}\} \{%{HAPROXYCAPTUREDRESPONSEHEADERS}\} "%{WORD:http_verb} %{URIPATHPARAM:http_request} HTTP/%{NUMBER:http_version}"
+
+# parse a haproxy 'tcplog' line
+HAPROXYTCP %{SYSLOGTIMESTAMP:syslog_timestamp} %{IPORHOST:syslog_server} %{SYSLOGPROG}: %{IP:client_ip}:%{INT:client_port} \[%{HAPROXYDATE:accept_date}\] %{NOTSPACE:frontend_name} %{NOTSPACE:backend_name}/%{NOTSPACE:server_name} %{INT:time_queue}/%{INT:time_backend_connect}/%{NOTSPACE:time_duration} %{NOTSPACE:bytes_read} %{NOTSPACE:termination_state} %{INT:actconn}/%{INT:feconn}/%{INT:beconn}/%{INT:srvconn}/%{NOTSPACE:retries} %{INT:srv_queue}/%{INT:backend_queue}


### PR DESCRIPTION
The haproxy httplog pattern was missing a few fields and did not work out of the box. I fixed it.

New functionality in this patch:
- Closely matched the field names to the haproxy documentation where it made sense.
- Added working tcplog pattern.
- Added documentation on how to override a part of the the default pattern to capture additional header fields as specified in your own haproxy.cfg.

I tested this initially w/ 1.0.17 and again against logstash-HEAD earlier today.

I originally submitted this patch but ended up restructuring my fork and resubmitting the pull request from a feature branch. Here's the same pull request as before.
