### PR TITLE
added amqp attributes config for rabbitmq mirrored queues

### DIFF
--- a/lib/logstash/inputs/amqp.rb
+++ b/lib/logstash/inputs/amqp.rb
@@ -14,6 +14,9 @@ class LogStash::Inputs::Amqp < LogStash::Inputs::Base
   config_name "amqp"
   plugin_status "unstable"
 
+  # Your amqp broker's custom arguments. For mirrored queues in RabbitMQ: [ "x-ha-policy", "all" ]
+  config :arguments, :validate => :array, :default => []
+
   # Your amqp server address
   config :host, :validate => :string, :required => true
 
@@ -26,7 +29,7 @@ class LogStash::Inputs::Amqp < LogStash::Inputs::Base
   # Your amqp password
   config :password, :validate => :password, :default => "guest"
 
-  # The name of the queue. 
+  # The name of the queue.
   config :name, :validate => :string, :default => ''
 
   # The name of the exchange to bind the queue.
@@ -108,7 +111,9 @@ class LogStash::Inputs::Amqp < LogStash::Inputs::Base
       @bunny.start
       @bunny.qos({:prefetch_count => @prefetch_count})
 
-      @queue = @bunny.queue(@name, {:durable => @durable, :auto_delete => @auto_delete, :exclusive => @exclusive})
+      @arguments_hash = Hash[*@arguments]
+
+      @queue = @bunny.queue(@name, {:durable => @durable, :auto_delete => @auto_delete, :exclusive => @exclusive, :arguments => @arguments_hash })
       @queue.bind(@exchange, :key => @key)
 
       @queue.subscribe({:ack => @ack}) do |data|


### PR DESCRIPTION
RabbitMQ mirrored queues use the x-ha-policy argument upon queue creation and client connection. In order to pull from a mirrored queue I had to expose the arguments hash from the bunny gem to the logstash config. 

This is an example of how it's used. It uses the array format in lieu of a config parser for hashes.

The arguments array is in the format [ "key1", "value1", "key2", "value2", ... ]

input {
  amqp {
    # ship logs to the 'rawlogs' fanout queue.
    type => "all"
    host => "myhost"
    exchange => "rawlogs"
    name => "rawlogs"
    durable => true    exclusive => false
    auto_delete => false
    arguments => [ "x-ha-policy", "all" ]
  }
}
