### PR TITLE
implemented add_field within inputs

### DIFF
--- a/lib/logstash/inputs/base.rb
+++ b/lib/logstash/inputs/base.rb
@@ -113,7 +113,7 @@ class LogStash::Inputs::Base < LogStash::Plugin
       raise "unknown event format #{@format}, this should never happen"
     end
 
-    (@add_field or {}).each do |field, value|
+    @add_field.each do |field, value|
        event[field] ||= []
        event[field] = [event[field]] if !event[field].is_a?(Array)
        event[field] << event.sprintf(value)


### PR DESCRIPTION
I found the need to add fields onto events as they come in rather than by a filter.

Example

```
input {
  file {
    path => ["/var/log/somethingtolog"]
    type => "awesome-log"
    add_field => ["environment", "production"]
    add_field => ["logstash", "is awesome"]
  }
}
```
