### PR TITLE
Adds a Juggernaut output

### DIFF
--- a/lib/logstash/outputs/juggernaut.rb
+++ b/lib/logstash/outputs/juggernaut.rb
@@ -78,14 +78,12 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
       else
         formatted = event.to_json
       end
-      puts formatted
       juggernaut_message = { 
         "channels" => @channels.collect{ |x| event.sprintf(x) }, 
         "data" => event.message 
       }
       
       @redis.publish 'juggernaut', juggernaut_message.to_json
-      puts juggernaut_message.to_json
     rescue => e
       @logger.warn("Failed to send event to redis", :event => event,
                    :identity => identity, :exception => e,


### PR DESCRIPTION
This builds on top of the redis output to push messages to Juggernaut (https://github.com/maccman/juggernaut).  This provides push notifications including for browsers which do not support websockets.  The juggernaut server runs in node.js and listens to redis.  If there is something in either python or ruby, I'd be happy to integrate that as well/instead of juggernaut
