### PR TITLE
Problem with jls-grok-0.10.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem "bunny" # for amqp support, MIT-style license
 gem "uuidtools" # for naming amqp queues, License ???
 
 gem "filewatch", "0.3.3"  # for file tailing, BSD License
-gem "jls-grok", "0.10.4" # for grok filter, BSD License
+gem "jls-grok", "0.10.5" # for grok filter, BSD License
 gem "jruby-elasticsearch", "0.0.11", :platforms => :jruby # BSD License
 gem "stomp" # for stomp protocol, Apache 2.0 License
 gem "json" # Ruby license

--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "gelf" # outputs/gelf, # License: MIT-style
   spec.add_dependency "gmetric", "~> 0.1.3" # outputs/ganglia, # License: MIT
   spec.add_dependency "haml" # License: MIT
-  spec.add_dependency "jls-grok", "0.9.6" # for grok filter, BSD License
+  spec.add_dependency "jls-grok", "0.10.5" # for grok filter, BSD License
   spec.add_dependency "jruby-elasticsearch", "~> 0.0.11" # BSD License
   spec.add_dependency "jruby-openssl" # For enabling SSL support, CPL/GPL 2.0
   spec.add_dependency "json" # Ruby license


### PR DESCRIPTION
The gem jls-grok-0.10.4 was missing a namespace.rb file, updated to 10.5 and it is now fixed. Not sure about the .lock file, figured everyone could update that themselves.
