### PR TITLE
Fix gemspec to match bundler

### DIFF
--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "awesome_print" # MIT License
   spec.add_dependency "bunny" # for amqp support, MIT-style license
-  spec.add_dependency "cabin", "0.1.3" # for logging. apache 2 license
-  spec.add_dependency "filewatch", "~> 0.3.0"  # for file tailing, BSD License
+  spec.add_dependency "cabin", "0.3.1" # for logging. apache 2 license
+  spec.add_dependency "filewatch", "~> 0.3.3"  # for file tailing, BSD License
   spec.add_dependency "gelfd", "~> 0.2.0" #inputs/gelf, # License: Apache 2.0
   spec.add_dependency "gelf" # outputs/gelf, # License: MIT-style
   spec.add_dependency "gmetric", "~> 0.1.3" # outputs/ganglia, # License: MIT


### PR DESCRIPTION
Was having dependency issues when trying to build a gem. This should resolve said issues, I just updated the gemspec to reflect the Gemfile.
