### PR TITLE
Added a filter to add fields from environment variables

### DIFF
--- a/lib/logstash/filters/environment.rb
+++ b/lib/logstash/filters/environment.rb
@@ -1,0 +1,26 @@
+require "logstash/filters/base"
+require "logstash/namespace"
+
+# Set fields from environment variables
+class LogStash::Filters::Environment < LogStash::Filters::Base
+  config_name "environment"
+  plugin_status "stable"
+
+  # Specify a hash of fields to the environment variable
+  # A hash of matches of field => environment variable
+  config :add_field_from_env, :validate => :hash, :default => {}
+
+  public
+  def register
+    # Nothing
+  end # def register
+
+  public
+  def filter(event)
+    return unless filter?(event)
+    @add_field_from_env.each do |field, env|
+      event.fields[field] = ENV[env]
+    end
+    filter_matched(event)
+  end # def filter
+end # class LogStash::Filters::Environment


### PR DESCRIPTION
I'm using logstash to read from stdin to avoid disk IO on some VMs.

I want to use environment variables to pass extra information to logstash, that will be sent on every message.

usage:

filter {
  environment {
    add_field_from_env ["path", "PATH"]
  }
}

Similar to: https://groups.google.com/forum/#!msg/logstash-users/rB8gFlSW2EE/mL4djTkl4awJ
