### PR TITLE
Using 'make jar' didn't work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 #
 JRUBY_VERSION=1.6.5
 ELASTICSEARCH_VERSION=0.18.7
+JODA_VERSION=1.6.2
 VERSION=$(shell ruby -r./lib/logstash/version -e 'puts LOGSTASH_VERSION')
 
 JRUBY_CMD=build/jruby/jruby-$(JRUBY_VERSION)/bin/jruby
@@ -14,6 +15,8 @@ JRUBY=vendor/jar/jruby-complete-$(JRUBY_VERSION).jar
 JRUBYC=java -Djruby.compat.version=RUBY1_9 -jar $(PWD)/$(JRUBY) -S jrubyc
 ELASTICSEARCH_URL=http://github.com/downloads/elasticsearch/elasticsearch
 ELASTICSEARCH=vendor/jar/elasticsearch-$(ELASTICSEARCH_VERSION)
+JODA_URL=http://downloads.sourceforge.net/project/joda-time/joda-time/$(JODA_VERSION)/joda-time-$(JODA_VERSION)-bin.tar.gz
+JODA=vendor/jar/joda-time-$(JODA_VERSION)
 PLUGIN_FILES=$(shell git ls-files | egrep '^lib/logstash/(inputs|outputs|filters)/' | egrep -v '/base.rb$$')
 GEM_HOME=build/gems
 QUIET=@
@@ -99,10 +102,13 @@ $(ELASTICSEARCH): $(ELASTICSEARCH).tar.gz | vendor/jar
 	$(QUIET)tar -C $(shell dirname $@) -xf $< $(TAR_OPTS) --exclude '*sigar*' \
 		'elasticsearch-$(ELASTICSEARCH_VERSION)/lib/*.jar'
 
-vendor/jar/joda-time-$(JODA_VERSION)-dist.tar.gz: | vendor/jar
-	wget -O $@ "http://downloads.sourceforge.net/project/joda-time/joda-time/$(JODA_VERSION)/joda-time-$(JODA_VERSION)-dist.tar.gz"
+$(JODA): $(JODA)/joda-time-$(JODA_VERSION).jar | vendor/jar
 
-vendor/jar/joda-time-$(JODA_VERSION)/joda-time-$(JODA_VERSION).jar: vendor/jar/joda-time-$(JODA_VERSION)-dist.tar.gz | vendor/jar
+$(JODA)-dist.tar.gz: | vendor/jar
+       @echo "=> Fetching joda-time"
+       wget -O $@ "$(JODA_URL)"
+
+$(JODA)/joda-time-$(JODA_VERSION).jar: $(JODA)-dist.tar.gz | vendor/jar
 	tar -C vendor/jar -zxf $< joda-time-$(JODA_VERSION)/joda-time-$(JODA_VERSION).jar
 
 # Always run vendor/bundle
@@ -137,7 +143,7 @@ build/ruby: | build
 # TODO(sissel): Skip sigar?
 # Run this one always? Hmm..
 .PHONY: build/monolith
-build/monolith: $(ELASTICSEARCH) $(JRUBY) vendor-gems | build
+build/monolith: $(ELASTICSEARCH) $(JRUBY) $(JODA) vendor-gems | build
 build/monolith: compile copy-ruby-files
 	-$(QUIET)mkdir -p $@
 	@# Unpack all the 3rdparty jars and any jars in gems


### PR DESCRIPTION
`make jar` failed with

> [...]
> jar xf /usr/local/src/logstash/vendor/jar/jruby-complete-1.6.5.jar 
> find: `/usr/local/src/logstash/vendor/jar/joda-time-': No such file or directory
> jar xf 
> Usage: jar {ctxui}[vfm0Me] [jar-file] [manifest-file] [entry-point] [-C dir] files ...
> Options:
>     -c  create new archive
>     -t  list table of contents for archive
>     -x  extract named (or all) files from archive
>     -u  update existing archive
>     -v  generate verbose output on standard output
>     -f  specify archive file name
>     -m  include manifest information from specified manifest file
>     -e  specify application entry point for stand-alone application 
>         bundled into an executable jar file
>     -0  store only; use no ZIP compression
>     -M  do not create a manifest file for the entries
>     -i  generate index information for the specified jar files
>     -C  change to the specified directory and include the following file
> If any file is a directory then it is processed recursively.
> The manifest file name, the archive file name and the entry point name are
> specified in the same order as the 'm', 'f' and 'e' flags.
> 
> Example 1: to archive two class files into an archive called classes.jar: 
>        jar cvf classes.jar Foo.class Bar.class 
> Example 2: use an existing manifest file 'mymanifest' and archive all the
>            files in the foo/ directory into 'classes.jar': 
>        jar cvfm classes.jar mymanifest -C foo/ .
> 
> make: **\* [build/monolith] Error 123

so I had a look into the monolithic jar provided at logstash.net, used the version of joda-time mentioned there (1.6.2) and fixed the Makefile. Commit https://github.com/logstash/logstash/commit/d595a882dfdd5deb16e900a3cd02ae8be2e506d1#Makefile just doesn't work that way.
