### PR TITLE
Handle more cases in COMBINEDAPACHELOG grok pattern

### DIFF
--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -89,4 +89,4 @@ QS %{QUOTEDSTRING}
 
 # Log formats
 SYSLOGBASE %{SYSLOGTIMESTAMP:timestamp} (?:%{SYSLOGFACILITY} )?%{SYSLOGHOST:logsource} %{SYSLOGPROG}:
-COMBINEDAPACHELOG %{IPORHOST:clientip} %{USER:ident} %{USER:auth} \[%{HTTPDATE:timestamp}\] "(?:%{WORD:verb} %{URIPATHPARAM:request} HTTP/%{NUMBER:httpversion}|-)" %{NUMBER:response} (?:%{NUMBER:bytes}|-) "(?:%{URI:referrer}|-)" %{QS:agent}
+COMBINEDAPACHELOG %{IPORHOST:clientip} %{USER:ident} %{USER:auth} \[%{HTTPDATE:timestamp}\] "(?:%{WORD:verb} %{URIPATHPARAM:request}(?: HTTP/%{NUMBER:httpversion})?|-)" %{NUMBER:response} (?:%{NUMBER:bytes}|-) "(?:%{URI:referrer}|-)" %{QS:agent}


### PR DESCRIPTION
Handle a few more cases in apache logs with the COMBINEDAPACHELOG grok pattern.
1. Requests with path segment parameters in the URI, by allowing /[=;]/ in addition to the existing characters in the regex.  An example of a URI with path segment parameters is:
   http://www.site.com/path1/path2;jsessionid=OI24B9ASD7BSSD?foo=bar
2. Cases where apache logs "-" for the request, such as when it logs a 408 on a timeout.
3. HTTP/1.0 requests, which don't include an HTTP version in the request string
