### PR TITLE
Update lib/logstash/outputs/elasticsearch.rb

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -155,7 +155,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
       #timer.stop
       decrement_inflight_request_count
     end.on(:failure) do |exception|
-      @logger.debug("Failed to index an event", :exception => exception,
+      @logger.warn("Failed to index an event", :exception => exception,
                     :event => event.to_hash)
       #timer.stop
       decrement_inflight_request_count


### PR DESCRIPTION
would it not make sense to upgrade that message to a warning, currently nothing is logged when elasticsearch is in various states of brokenness.
