### PR TITLE
Grep filter for numerical fields

### DIFF
--- a/lib/logstash/filters/grep.rb
+++ b/lib/logstash/filters/grep.rb
@@ -80,6 +80,7 @@ class LogStash::Filters::Grep < LogStash::Filters::Base
         end
 
         (event[field].is_a?(Array) ? event[field] : [event[field]]).each do |value|
+          value = value.to_s if value.is_a?(Fixnum)
           if @negate
             @logger.debug("negate match", :regexp => re, :value => value)
             next if re.match(value)


### PR DESCRIPTION
Hi,

I've been running into problems when trying to filter on numerical event fields, such as severity and facility for syslog events. This causes an exception when the regexp is applied to a Fixnum.

I've attached a simple patch to convert numerical fields to strings before matching - not sure if this is useful or not.

Cheers,
Phil
