### PR TITLE
Fixed type/tags system not working in nagios_nsca output

### DIFF
--- a/lib/logstash/outputs/nagios_nsca.rb
+++ b/lib/logstash/outputs/nagios_nsca.rb
@@ -55,6 +55,9 @@ class LogStash::Outputs::NagiosNsca < LogStash::Outputs::Base
 
   public
   def receive(event)
+    # exit if type or tags don't match
+    return unless output?(event)
+
     # catch logstash shutdown
     if event == LogStash::SHUTDOWN
       finished


### PR DESCRIPTION
I totally missed the way logstash deals with tags/type in outputs so I forgot it at first. So nagios_nsca output was not working correctly, it would send every event to the nsca daemon even if tags/type didn't match.

Sorry for the noise. I keep in mind that I should write some tests for the output, maybe for a future pull request.

Thanks
