### PR TITLE
Fix Loading Error when trying to use OpenSSL in JRuby-in-a-JAR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #   cpio
 #   wget
 #
-JRUBY_VERSION=1.6.5
+JRUBY_VERSION=1.6.7
 ELASTICSEARCH_VERSION=0.18.7
 JODA_VERSION=2.1
 VERSION=$(shell ruby -r./lib/logstash/version -e 'puts LOGSTASH_VERSION')
@@ -150,6 +150,12 @@ build/monolith: compile copy-ruby-files vendor/jar/graphtastic-rmiclient.jar
 	@# Unpack all the 3rdparty jars and any jars in gems
 	$(QUIET)find $$PWD/vendor/bundle $$PWD/vendor/jar -name '*.jar' \
 	| (cd $@; xargs -tn1 jar xf)
+	@# copy openssl/lib/shared folders/files to root of jar - need this for openssl to work with JRuby
+	$(QUIET)mkdir -p $@/openssl
+	$(QUIET)mkdir -p $@/jopenssl
+	$(QUIET)cp -r $$PWD/vendor/bundle/jruby/1.9/gems/jruby-openss*/lib/shared/openssl/* $@/openssl
+	$(QUIET)cp -r $$PWD/vendor/bundle/jruby/1.9/gems/jruby-openss*/lib/shared/jopenssl/* $@/jopenssl
+	$(QUIET)cp -r $$PWD/vendor/bundle/jruby/1.9/gems/jruby-openss*/lib/shared/openssl.rb $@/openssl.rb
 	@# Make sure joda-time gets unpacked last, so it overwrites the joda jruby
 	@# ships with.
 	$(QUIET)find $$PWD/vendor/jar/joda-time-$(JODA_VERSION) -name '*.jar' \


### PR DESCRIPTION
Had some problems as discussed on these issues: 

https://logstash.jira.com/browse/LOGSTASH-215
https://github.com/logstash/logstash/pull/123

The required fix is to copy the jruby-openssl/lib/shared folders/files to the root of the jar, which is already being done for the jar that is in this directory.  Have verified that this problem is fixed, openssl loads and works as expected. 
