### PR TITLE
Remove the queue_name param, so that the river plugin will properly send messages

### DIFF
--- a/lib/logstash/outputs/elasticsearch_river.rb
+++ b/lib/logstash/outputs/elasticsearch_river.rb
@@ -99,7 +99,6 @@ class LogStash::Outputs::ElasticSearchRiver < LogStash::Outputs::Base
       "user" => [@user],
       "password" => [@password],
       "exchange_type" => [@exchange_type],
-      "queue_name" => [@name],
       "name" => [@exchange],
       "key" => [@key],
       "vhost" => [@vhost],


### PR DESCRIPTION
This fix will get the elasticsearch_river output working and prevent the following error in the HEAD.  I know there is other refactoring that might be going on here, but this would get things working today while that is looked at.

{:timestamp=>"2012-04-05T13:53:20.680000 -0700", :message=>"Unknown setting 'queue_name' for output/amqp", :level=>:error}{:timestamp=>"2012-04-05T13:53:20.685000 -0700", :message=>"Config validation failed.", :level=>:error}Exception in thread "LogStash::Runner" org.jruby.exceptions.RaiseException: (SystemExit) exit
        at org.jruby.RubyKernel.exit(org/jruby/RubyKernel.java:856)
        at org.jruby.RubyKernel.exit(org/jruby/RubyKernel.java:825)
        at Mixin.config_init(file:/usr/share/logstash/logstash-1.1.0.1-monolithic.jar!/logstash/config/mixin.rb:49)
        at Base.initialize(file:/usr/share/logstash/logstash-1.1.0.1-monolithic.jar!/logstash/outputs/base.rb:32)
        at ElasticSearchRiver.prepare_river(file:/usr/share/logstash/logstash-1.1.0.1-monolithic.jar!/logstash/outputs/elasticsearch_river.rb:110)
        at ElasticSearchRiver.register(file:/usr/share/logstash/logstash-1.1.0.1-monolithic.jar!/logstash/outputs/elasticsearch_river.rb:88)
        at Agent.run_output(file:/usr/share/logstash/logstash-1.1.0.1-monolithic.jar!/logstash/agent.rb:686)
        at Agent.run_output(file:/usr/share/logstash/logstash-1.1.0.1-monolithic.jar!/logstash/agent.rb:686)
        at Agent.start_output(file:/usr/share/logstash/logstash-1.1.0.1-monolithic.jar!/logstash/agent.rb:338)
