### PR TITLE
Allow the ; character to be included in URIPATH

### DIFF
--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -38,7 +38,7 @@ URIPROTO [A-Za-z]+(\+[A-Za-z+]+)?
 URIHOST %{IPORHOST}(?::%{POSINT:port})?
 # uripath comes loosely from RFC1738, but mostly from what Firefox
 # doesn't turn into %XX
-URIPATH (?:/[A-Za-z0-9$.+!*'(),~:#%_-]*)+
+URIPATH (?:/[A-Za-z0-9$.+!*'(),~:;#%_-]*)+
 #URIPARAM \?(?:[A-Za-z0-9]+(?:=(?:[^&]*))?(?:&(?:[A-Za-z0-9]+(?:=(?:[^&]*))?)?)*)?
 URIPARAM \?[A-Za-z0-9$.+!*'(),~#%&/=:;_-]*
 URIPATHPARAM %{URIPATH}(?:%{URIPARAM})?


### PR DESCRIPTION
This apache access log does not parse with the standard patterns that come with logstash.

174.143.23.34 - - [17/Apr/2012:14:04:12 +0000] "GET /anaplan/framework.jsp;jsessionid=E638A1B6FF5DFFE0F246AE3C686BBA84?selectedWorkspaceId=402882f732e7d9c10132fdc6228a1a8e&ticket=ST-166546-9YaqwRlUYc5jFH3yBQbu-frontdoor HTTP/1.1" 302 - "-" "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.2; Trident/4.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.04506.648; .NET CLR 3.5.21022; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)"

I suspect this is because of the ";" character which is in the URI path, ie. before the "?".
