### PR TITLE
web: convert messages to string before calling force_encoding

### DIFF
--- a/lib/logstash/web/views/search/ajax.haml
+++ b/lib/logstash/web/views/search/ajax.haml
@@ -52,4 +52,4 @@
           %td.timestamp&= event.timestamp
           %td.message{ :"data-full" => event.to_json.to_s.force_encoding('UTF-8')  }
             %a{:href => "#"}
-              %pre&= event.message.force_encoding('UTF-8') 
+              %pre&= event.message.to_s.force_encoding('UTF-8') 


### PR DESCRIPTION
when sending messages as JSON, the event.message corresponds to a java
HashMap - which knows nothing of force_encoding.  Make sure to flatten
it to a string before making sure its UTF8.
