### PR TITLE
Fix LOGSTASH-486 - Set zabbix host/item to the first element only if it is an array

### DIFF
--- a/lib/logstash/outputs/zabbix.rb
+++ b/lib/logstash/outputs/zabbix.rb
@@ -77,6 +77,7 @@ class LogStash::Outputs::Zabbix < LogStash::Outputs::Base
                    :missed_event => event)
       return
     end
+    host = host.first if host.is_a?(Array)
  
     item = event.fields["zabbix_item"]
     if !item
@@ -84,6 +85,7 @@ class LogStash::Outputs::Zabbix < LogStash::Outputs::Base
                    :missed_event => event)
       return
     end
+    item = item.first if item.is_a?(Array)
  
     zmsg = event.message
     zmsg = zmsg.gsub("\n", "\\n")


### PR DESCRIPTION
Tested this fixes zabbix_host and zabbix_item being sent as lists to zabbix_sender instead of strings.  Probably need to move these fields to be params of the zabbix plugin, but I'll have to dive a bit deeper into logstash first.

This is my first pull request so let me know if I did something stupid. :)
