### PR TITLE
Ignore statsd namespace if an empty string is provided

### DIFF
--- a/lib/logstash/outputs/statsd.rb
+++ b/lib/logstash/outputs/statsd.rb
@@ -66,7 +66,7 @@ class LogStash::Outputs::Statsd < LogStash::Outputs::Base
   def receive(event)
     return unless output?(event)
 
-    @client.namespace = event.sprintf(@namespace)
+    @client.namespace = event.sprintf(@namespace) if not @namespace.empty?
     logger.debug("Original sender: #{@sender}")
     sender = event.sprintf(@sender)
     logger.debug("Munged sender: #{sender}")


### PR DESCRIPTION
Statsd doesn't require a namespace and in my use case with a zabbix backend it doesn't make sense.  This is a simple change to allow the config below to mean no namespace should be sent.  

<pre>output {
  statsd {
    namespace => ""
  }
}</pre>

I am currently using this and it works as desired.
