### PR TITLE
Changed the PROG pattern to match Cisco PROG name starting with a percen...

### DIFF
--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -77,7 +77,7 @@ DATESTAMP_OTHER %{DAY} %{MONTH} %{MONTHDAY} %{TIME} %{TZ} %{YEAR}
 
 # Syslog Dates: Month Day HH:MM:SS
 SYSLOGTIMESTAMP %{MONTH} +%{MONTHDAY} %{TIME}
-PROG (?:[\w._/-]+)
+PROG (?:[\w._/%-]+)
 SYSLOGPROG %{PROG:program}(?:\[%{POSINT:pid}\])?
 SYSLOGHOST %{IPORHOST}
 SYSLOGFACILITY <%{POSINT:facility}.%{POSINT:priority}>


### PR DESCRIPTION
...t (%).

Description : 
Usual syslog message :
<85>Jun 14 15:19:47 localhost sudo:     root : TTY=pts/1 ; PWD=/opt/logstash ; USER=root ; COMMAND=/bin/bash

Cisco typical message :
<166> Jun 14 15:30:00 10.100.252.52 %ASA-6-302021:  Teardown ICMP connection for faddr 10.100.120.120/0 gaddr 10.100.252.1/0 laddr 10.100.252.1/0

----> program name start with a %

Can be reproduced sending a manual syslog message with python script :

import logging
from logging.handlers import SysLogHandler
# message='Jun 14 15:19:47 localhost sudo:     root : TTY=pts/1 ; PWD=/opt/logstash ; USER=root ; COMMAND=/bin/bash'

message=' Jun 15 09:47:36 10.100.252.1 %ASA-6-111116:  Teardown UDP connection 6201992 for internet:192.168.1.1/1026 to interne:10.100.120.120/427 duration 0:02:04 bytes 588'

logger = logging.getLogger()
logger.setLevel(logging.INFO)
syslog = SysLogHandler(address=('localhost',5544))
# syslog = SysLogHandler(address='/dev/log')
# formatter = logging.Formatter('%(name)s: %(levelname)s %(message)s')
# syslog.setFormatter(formatter)

logger.addHandler(syslog)
logger.warning(message)

Leading to a "NOT SYSLOG" message in the logs and no @fields{} values

With this change the fields are OK and "NOT SYSLOG" message is gone. I still have a "@tags":["_grokparsefailure"], error though...
