### PR TITLE
Added NONNEGINT to patterns

### DIFF
--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -7,6 +7,7 @@ BASE16NUM (?<![0-9A-Fa-f])(?:[+-]?(?:0x)?(?:[0-9A-Fa-f]+))
 BASE16FLOAT \b(?<![0-9A-Fa-f.])(?:[+-]?(?:0x)?(?:(?:[0-9A-Fa-f]+(?:\.[0-9A-Fa-f]*)?)|(?:\.[0-9A-Fa-f]+)))\b
 
 POSINT \b(?:[1-9][0-9]*)\b
+NONNEGINT \b(?:[0-9]+)\b
 WORD \b\w+\b
 NOTSPACE \S+
 SPACE \s*
@@ -31,7 +32,7 @@ HOSTPORT (?:%{IPORHOST=~/\./}:%{POSINT})
 PATH (?:%{UNIXPATH}|%{WINPATH})
 UNIXPATH (?:/(?:[\w_%!$@:.,-]+|\\.)*)+
 #UNIXPATH (?<![\w\/])(?:/[^\/\s?*]*)+
-LINUXTTY (?:/dev/pts/%{POSINT})
+LINUXTTY (?:/dev/pts/%{NONNEGINT})
 BSDTTY (?:/dev/tty[pq][a-z0-9])
 TTY (?:%{BSDTTY}|%{LINUXTTY})
 WINPATH (?:[A-Za-z]+:|\\)(?:\\[^\\?*]*)+


### PR DESCRIPTION
Commit e62536a introduced a complication: there are times when one
wants to match against zero as well as the positive integers (such
as in the LINUXTTY pattern).  For these times, NONNEGINT can be used.

Existing users of POSINT might continue to expect zero to match, so
this change should probably be mentioned in the release notes (on the
other hand, some could be using POSINT without wanting it to match
zero, as happened to me).

Ref: Paragraph 3 of http://en.wikipedia.org/wiki/Natural_number
