### PR TITLE
gsub for the mutate filter

### DIFF
--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -98,6 +98,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
     @gsub.nil? or @gsub.each_slice(3) do |field, needle, replacement|
       if [field, needle, replacement].any? {|n| n.nil?}
         @logger.error("Invalid gsub configuration. gsub has to define 3 elements per config entry", :file => file, :needle => needle, :replacement => replacement)
+        raise "Bad configuration, aborting."
       end
       @gsub_parsed << {
         :field        => field,


### PR DESCRIPTION
added the gsub mutation to the mutate filter

configuration example:

mutate {
     gsub => [
          "field", "NEEDLE_REGEXP", "REPLACEMENT",
          "field", "NEEDLE_REGEXP", "REPLACEMENT",
          …
     ]
}

PS:this is a redo of https://github.com/logstash/logstash/pull/101 because i messed the original up and couldn't fix it :(
