### PR TITLE
Correcting grep config in nagios doc/example

### DIFF
--- a/etc/examples/agent-nagios.conf
+++ b/etc/examples/agent-nagios.conf
@@ -6,9 +6,11 @@ filter {
   grep {
     type => "foo"
     match => [ "@message", ".*" ]
-    add_fields => [ "nagios_host", "%{@source_host}" ]
-    add_fields => [ "nagios_service", "example service" ]
-    add_fields => [ "nagios_annotation", "my annotation" ]
+    add_field => [ 
+      "nagios_host", "%{@source_host}",
+      "nagios_service", "example service",
+      "nagios_annotation", "my annotation" 
+    ]
   }
 }
 

--- a/lib/logstash/outputs/nagios.rb
+++ b/lib/logstash/outputs/nagios.rb
@@ -22,7 +22,7 @@ require "logstash/outputs/base"
 #         type => "linux-syslog"
 #         match => [ "@message", "(error|ERROR|CRITICAL)" ]
 #         add_tag => [ "nagios-update" ]
-#         add_fields => [
+#         add_field => [
 #           "nagios_host", "%{@source_host}",
 #           "nagios_service", "the name of your nagios service check"
 #         ]


### PR DESCRIPTION
Misuse of **add_fields** instead of **add_field** in grep config for nagios example
Fix LOGSTASH-384
