### PR TITLE
add gemspec and use it in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,58 +1,12 @@
 source :rubygems
 
-gem "cabin", "0.4.4" # for logging. apache 2 license
-gem "bunny" # for amqp support, MIT-style license
-gem "uuidtools" # for naming amqp queues, License ???
+gemspec
 
-gem "cinch" # for irc support
-gem "filewatch", "0.3.3"  # for file tailing, BSD License
-gem "jls-grok", "0.10.7" # for grok filter, BSD License
-gem "aws-sdk" # for AWS access: SNS and S3 log tailing.  Apache 2.0 License
-gem "jruby-elasticsearch", "0.0.14", :platforms => :jruby # BSD License
-gem "onstomp" # for stomp protocol, Apache 2.0 License
-gem "json" # Ruby license
-#gem "awesome_print" # MIT License
-gem "jruby-openssl", :platforms => :jruby # For enabling SSL support, CPL/GPL 2.0
-gem "mail" #outputs/email, # License: MIT License
-gem "xml-simple" # unknown license: http://xml-simple.rubyforge.org/
-
-gem "minitest" # License: Ruby
-gem "rack" # License: MIT
-gem "ftw", "~> 0.0.19"  # License: Apache 2.0
-gem "sinatra" # License: MIT-style
-gem "haml" # License: MIT
-gem "sass" # License: MIT
-gem "heroku" # License: MIT
-
-# TODO(sissel): Put this into a group that's only used for monolith packaging
-gem "mongo" # outputs/mongodb, License: Apache 2.0
-gem "redis" # outputs/redis, License: MIT-style
-gem "gelf", "1.3.2" # outputs/gelf, # License: MIT-style
-gem "statsd-ruby", "0.3.0" # outputs/statsd, # License: As-Is
-gem "gmetric", "0.1.3" # outputs/ganglia, # License: MIT
-gem "xmpp4r", "0.5" # outputs/xmpp, # License: As-Is
-gem "gelfd", "0.2.0" #inputs/gelf, # License: Apache 2.0
-gem "jruby-win32ole", :platforms => :jruby # inputs/eventlog, # License: JRuby
-gem "jruby-httpclient", :platforms => :jruby #outputs/http, # License: Apache 2.0
-gem "excon", :platforms => :ruby #outputs/http, # License: MIT License
-gem "pry"
-
-gem "ffi-rzmq", "0.9.0"
-gem "ffi"
-
-gem "riemann-client", "0.0.6" #outputs/riemann, License: MIT
-gem "riak-client", "1.0.3" #outputs/riak, License: Apache 2.0
-
-group :test do
-  gem "mocha"
-  gem "shoulda"
+platforms :jruby do
+  gem 'jruby-elasticsearch', '0.0.14'
+  gem 'jruby-httpclient'
+  gem 'jruby-win32ole'
 end
 
-# ruby-debug is broken in 1.9.x due, at a minimum, the following:
-#    Installing rbx-require-relative (0.0.5)
-#    Gem::InstallError: rbx-require-relative requires Ruby version ~> 1.8.7.
-#
-# ruby-debug wants linecache which wants rbx-require-relative which won't
-# install under 1.9.x. I never use ruby-debug anyway, so, kill it.
-#gem "ruby-debug", "0.10.4"
-#gem "mocha", "0.10.0"
+gem 'excon', :platforms => :ruby
+gem 'cinch', :platforms => :ruby_19

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,47 @@
+PATH
+  remote: .
+  specs:
+    logstash (1.1.1.rc3-java)
+      aws-sdk
+      bunny
+      cabin (= 0.4.4)
+      cinch
+      ffi
+      ffi-rzmq (= 0.9.3)
+      filewatch (= 0.3.3)
+      ftw (~> 0.0.19)
+      gelf (= 1.3.2)
+      gelfd (= 0.2.0)
+      gmetric (= 0.1.3)
+      haml
+      heroku
+      jls-grok (= 0.10.7)
+      jruby-elasticsearch (= 0.0.14)
+      jruby-httpclient
+      jruby-openssl
+      jruby-win32ole
+      json
+      mail
+      minitest
+      mongo
+      onstomp
+      pry
+      rack
+      redis
+      riak-client (= 1.0.3)
+      riemann-client (= 0.0.6)
+      sass
+      sinatra
+      statsd-ruby (= 0.3.0)
+      uuidtools
+      xml-simple
+      xmpp4r (= 0.5)
+
 GEM
   remote: http://rubygems.org/
   specs:
     addressable (2.2.6)
-    aws-sdk (1.5.2)
+    aws-sdk (1.5.6)
       httparty (~> 0.7)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
@@ -12,14 +51,15 @@ GEM
     bouncy-castle-java (1.5.0146.1)
     bson (1.6.4-java)
     builder (3.0.0)
-    bunny (0.7.9)
+    bunny (0.8.0)
     cabin (0.4.4)
       json
     cinch (2.0.3)
-    coderay (1.0.6)
-    excon (0.14.0)
+    coderay (1.0.7)
+    excon (0.14.3)
     ffi (1.0.11-java)
-    ffi-rzmq (0.9.0)
+    ffi-rzmq (0.9.3)
+      ffi
     filewatch (0.3.3)
     ftw (0.0.19)
       addressable (= 2.2.6)
@@ -33,14 +73,14 @@ GEM
     gelfd (0.2.0)
     gmetric (0.1.3)
     haml (3.1.6)
-    heroku (2.26.6)
-      heroku-api (~> 0.2.4)
+    heroku (2.28.12)
+      heroku-api (~> 0.2.8)
       launchy (>= 0.3.2)
-      netrc (~> 0.7.2)
+      netrc (~> 0.7.5)
       rest-client (~> 1.6.1)
       rubyzip
-    heroku-api (0.2.4)
-      excon (~> 0.14.0)
+    heroku-api (0.2.8)
+      excon (~> 0.14.3)
     http_parser.rb (0.5.3-java)
     httparty (0.8.3)
       multi_json (~> 1.0)
@@ -64,8 +104,8 @@ GEM
       treetop (~> 1.4.8)
     metaclass (0.0.1)
     method_source (0.7.1)
-    mime-types (1.18)
-    minitest (3.0.1)
+    mime-types (1.19)
+    minitest (3.2.0)
     mocha (0.11.4)
       metaclass (~> 0.0.1)
     mongo (1.6.4)
@@ -73,9 +113,9 @@ GEM
     mtrc (0.0.4)
     multi_json (1.3.6)
     multi_xml (0.5.1)
-    netrc (0.7.4)
-    nokogiri (1.5.3-java)
-    onstomp (1.0.6)
+    netrc (0.7.5)
+    nokogiri (1.5.5-java)
+    onstomp (1.0.7)
     polyglot (0.3.3)
     pry (0.9.9.6-java)
       coderay (~> 1.0.5)
@@ -97,8 +137,8 @@ GEM
       beefcake (>= 0.3.5)
       mtrc (>= 0.0.4)
       trollop (>= 1.16.2)
-    rubyzip (0.9.8)
-    sass (3.1.19)
+    rubyzip (0.9.9)
+    sass (3.1.20)
     shoulda (3.0.1)
       shoulda-context (~> 1.0.0)
       shoulda-matchers (~> 1.0.0)
@@ -122,42 +162,14 @@ GEM
 
 PLATFORMS
   java
+  ruby
 
 DEPENDENCIES
-  aws-sdk
-  bunny
-  cabin (= 0.4.4)
   cinch
   excon
-  ffi
-  ffi-rzmq (= 0.9.0)
-  filewatch (= 0.3.3)
-  ftw (~> 0.0.19)
-  gelf (= 1.3.2)
-  gelfd (= 0.2.0)
-  gmetric (= 0.1.3)
-  haml
-  heroku
-  jls-grok (= 0.10.7)
   jruby-elasticsearch (= 0.0.14)
   jruby-httpclient
-  jruby-openssl
   jruby-win32ole
-  json
-  mail
-  minitest
+  logstash!
   mocha
-  mongo
-  onstomp
-  pry
-  rack
-  redis
-  riak-client (= 1.0.3)
-  riemann-client (= 0.0.6)
-  sass
   shoulda
-  sinatra
-  statsd-ruby (= 0.3.0)
-  uuidtools
-  xml-simple
-  xmpp4r (= 0.5)

--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -1,0 +1,71 @@
+# -*- encoding: utf-8 -*-
+require File.expand_path('../lib/logstash/version', __FILE__)
+
+Gem::Specification.new do |gem|
+  gem.authors       = ["Jordan Sissel", "Pete Fritchman"]
+  gem.email         = ["jls@semicomplete.com", "petef@databits.net"]
+  gem.description   = %q{scalable log and event management (search, archive, pipeline)}
+  gem.summary       = %q{logstash - log and event management}
+  gem.homepage      = "http://logstash.net/"
+  gem.license       = "Apache License (2.0)"
+
+  gem.files         = `git ls-files`.split($\)
+  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+  gem.name          = "logstash"
+  gem.require_paths = ["lib"]
+  gem.version       = LOGSTASH_VERSION
+
+  # Core dependencies
+  gem.add_runtime_dependency "cabin", ["0.4.4"]
+  gem.add_runtime_dependency "json"
+  gem.add_runtime_dependency "minitest" # for running the tests from the jar
+  gem.add_runtime_dependency "pry"
+
+  # Server dependencies
+  gem.add_runtime_dependency "ftw", ["~> 0.0.19"]
+  gem.add_runtime_dependency "haml"
+  gem.add_runtime_dependency "heroku"
+  gem.add_runtime_dependency "rack"
+  gem.add_runtime_dependency "sass"
+  gem.add_runtime_dependency "sinatra"
+
+  # Input/Output/Filter dependencies
+  #TODO Can these be optional?
+  gem.add_runtime_dependency "aws-sdk"
+  gem.add_runtime_dependency "bunny"
+  gem.add_runtime_dependency "ffi"
+  gem.add_runtime_dependency "ffi-rzmq", ["0.9.3"]
+  gem.add_runtime_dependency "filewatch", ["0.3.3"]
+  gem.add_runtime_dependency "gelfd", ["0.2.0"]
+  gem.add_runtime_dependency "gelf", ["1.3.2"]
+  gem.add_runtime_dependency "gmetric", ["0.1.3"]
+  gem.add_runtime_dependency "jls-grok", ["0.10.7"]
+  gem.add_runtime_dependency "mail"
+  gem.add_runtime_dependency "mongo"
+  gem.add_runtime_dependency "onstomp"
+  gem.add_runtime_dependency "redis"
+  gem.add_runtime_dependency "riak-client", ["1.0.3"]
+  gem.add_runtime_dependency "riemann-client", ["0.0.6"]
+  gem.add_runtime_dependency "statsd-ruby", ["0.3.0"]
+  gem.add_runtime_dependency "uuidtools" # For generating amqp queue names
+  gem.add_runtime_dependency "xml-simple"
+  gem.add_runtime_dependency "xmpp4r", ["0.5"]
+
+  if RUBY_PLATFORM == 'java'
+    gem.platform = RUBY_PLATFORM
+    gem.add_runtime_dependency "jruby-elasticsearch", ["0.0.14"]
+    gem.add_runtime_dependency "jruby-httpclient"
+    gem.add_runtime_dependency "jruby-openssl"
+    gem.add_runtime_dependency "jruby-win32ole"
+  else
+    gem.add_runtime_dependency "excon"
+  end
+
+  if RUBY_VERSION >= '1.9.1'
+    gem.add_runtime_dependency "cinch" # cinch requires 1.9.1+
+  end
+
+  gem.add_development_dependency "mocha"
+  gem.add_development_dependency "shoulda"
+end


### PR DESCRIPTION
This moves the gem definitions out of the Gemfile and into a gemspec making it possible to build logstash as a gem.

The gemspec uses RUBY_PLATFORM to determine which gems to depend on at build-time. Gems need to be built separately for each supported platform.

The Gemfile on the other hand specifies install-time dependencies, so it needs to duplicate the platform-specific gems to remain platform independent. Fortunately the duplication is minimal.

The cinch gem only works on ruby 1.9, so it is only included on 1.9+ platforms. Specific gems for ruby versions are not supported by ruby gems, so this doesn't actually change anything. It just documents the 1.9 requirement of cinch and removes it if logstash decides to re-introduce 1.8 compatibility.
