### PR TITLE
logstash-event gemspec

### DIFF
--- a/lib/logstash-event.rb
+++ b/lib/logstash-event.rb
@@ -1,0 +1,3 @@
+require "logstash/event"
+require "logstash/version"
+

--- a/logstash-event.gemspec
+++ b/logstash-event.gemspec
@@ -1,0 +1,24 @@
+# -*- encoding: utf-8 -*-
+require File.expand_path('../lib/logstash/version', __FILE__)
+
+Gem::Specification.new do |gem|
+  gem.authors       = ["Jordan Sissel"]
+  gem.email         = ["jls@semicomplete.com"]
+  gem.description   = %q{Library that contains the classes required to create LogStash events}
+  gem.summary       = %q{Library that contains the classes required to create LogStash events}
+  gem.homepage      = "https://github.com/logstash/logstash"
+
+  gem.files = %w{
+    lib/logstash-event.rb
+    lib/logstash/event.rb
+    lib/logstash/namespace.rb
+    lib/logstash/time.rb
+    lib/logstash/version.rb
+    LICENSE
+  }
+
+  gem.test_files    = []
+  gem.name          = "logstash-event"
+  gem.require_paths = ["lib"]
+  gem.version       = LOGSTASH_VERSION
+end


### PR DESCRIPTION
This adds a gemspec to the repository so that the parts required for creating LogStash events can be published as their own gem and used in third-party solutions.

I haven't included any mechanism for publishing a gem as I didn't want to add a Rakefile to the project (which is how I usually do it) or register the gem myself as it should be an owner of the project who does that. However, if you want me to do either of these things then let me know.

This has worked fine for me when including it in a `Gemfile` as a git repository. The `gem.files` needs to be maintained by hand as it is a subset of the repository but that seems to be the only tricky part to maintaining this.
