### PR TITLE
Add getters and setters for source_host and source_path

### DIFF
--- a/lib/logstash/event.rb
+++ b/lib/logstash/event.rb
@@ -94,6 +94,14 @@ class LogStash::Event
   end # def source=
 
   public
+  def source_host; @data["@source_host"]; end # def source_host
+  def source_host=(val); @data["@source_host"] = val; end # def source_host=
+
+  public
+  def source_path; @data["@source_path"]; end # def source_path
+  def source_path=(val); @data["@source_path"] = val; end # def source_path=
+
+  public
   def message; @data["@message"]; end # def message
   def message=(val); @data["@message"] = val; end # def message=
 


### PR DESCRIPTION
Add getters and setters for source_host and source_path on LogStash::Event so that they can be set directly on the event without having to pass a URL into the "source" attribute. Useful for situations where the user wishes to set these directly

The tests regarding event seem to be mainly for sprintf stuff and no tests exist for getters and setters so I was not sure if I should add tests for these two.
