### PR TITLE
Removing extra backslashes from multiline filter examples

### DIFF
--- a/lib/logstash/filters/multiline.rb
+++ b/lib/logstash/filters/multiline.rb
@@ -53,7 +53,7 @@ require "logstash/namespace"
 #     filter {
 #       multiline {
 #         type => "somefiletype "
-#         pattern => "\$"
+#         pattern => "\\$"
 #         what => "next"
 #       }
 #     }


### PR DESCRIPTION
Hi folks,

I noticed that the examples in the docs for the multiline filter have Java-style double backslashes in the example regexes. This tripped me up a bit until I started searching the mailing list and found examples there with only single backslashes.

Best,

Dante
