### PR TITLE
Fix for a documentation bug I encountered.

### DIFF
--- a/lib/logstash/filters/multiline.rb
+++ b/lib/logstash/filters/multiline.rb
@@ -41,7 +41,7 @@ require "logstash/namespace"
 #     filter {
 #       multiline {
 #         type => "somefiletype"
-#         pattern => "^\\s"
+#         pattern => "^\s"
 #         what => "previous"
 #       }
 #     }


### PR DESCRIPTION
[doc]  Fixing multiline example of backtrace filter. Additional backslash prevented match of indented log lines.
