### PR TITLE
Allow single digit hour in HOUR pattern

### DIFF
--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -61,7 +61,7 @@ YEAR [0-9]+
 # I'm still on the fence about using grok to perform the time match,
 # since it's probably slower.
 # TIME %{POSINT<24}:%{POSINT<60}(?::%{POSINT<60}(?:\.%{POSINT})?)?
-HOUR (?:2[0123]|[01][0-9])
+HOUR (?:2[0123]|[01][0-9]|[0-9])
 MINUTE (?:[0-5][0-9])
 # '60' is a leap second in most time standards and thus is valid.
 SECOND (?:(?:[0-5][0-9]|60)(?:[.,][0-9]+)?)


### PR DESCRIPTION
When working with a single H pattern in hour (from SimpleDateFormat) the hour can be single digit. 
"MMM d, yyyy H:mm:ss"  gives Aug 28, 2012 8:18:18
but this is not matched by the HOUR and thus TIME grok pattern.
