### PR TITLE
Add exec output plugin

### DIFF
--- a/lib/logstash/outputs/exec.rb
+++ b/lib/logstash/outputs/exec.rb
@@ -1,0 +1,28 @@
+require "logstash/namespace"
+require "logstash/outputs/base"
+
+# Exec output.
+#
+# Run subprocesses via system ruby function
+# WARNING: if you want it non-blocking you should use & or dtach or other such techniques
+class LogStash::Outputs::Exec < LogStash::Outputs::Base
+
+  config_name "exec"
+  plugin_status "experimental"
+
+  # Command line to execute via subprocess. Use dtach or screen to make it non blocking
+  config :command, :validate => :string, :required => true
+
+  public
+  def register
+    @logger.debug("exec output registered", :config => @config)
+  end # def register
+
+  public
+  def receive(event)
+    return unless output?(event)
+    @logger.debug("running exec command", :command => event.sprintf(@command))
+    system(event.sprintf(@command))
+  end # def receive
+
+end


### PR DESCRIPTION
Forked from the pipe output and meant to be easier to use.

I know it's just a prototype but as it is right now it's already definitely useful in our scenario and I think there should be an output like this shipped by default with logstash
