### PR TITLE
Added '?' to URIPARAM to handle edge case

### DIFF
--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -42,7 +42,7 @@ URIHOST %{IPORHOST}(?::%{POSINT:port})?
 # doesn't turn into %XX
 URIPATH (?:/[A-Za-z0-9$.+!*'(){},~:;=#%_-]*)+
 #URIPARAM \?(?:[A-Za-z0-9]+(?:=(?:[^&]*))?(?:&(?:[A-Za-z0-9]+(?:=(?:[^&]*))?)?)*)?
-URIPARAM \?[A-Za-z0-9$.+!*'|(){},~#%&/=:;_-]*
+URIPARAM \?[A-Za-z0-9$.+!*'|(){},~#%&/=:;_?-]*
 URIPATHPARAM %{URIPATH}(?:%{URIPARAM})?
 URI %{URIPROTO}://(?:%{USER}(?::[^@]*)?@)?(?:%{URIHOST})?(?:%{URIPATHPARAM})?
 


### PR DESCRIPTION
Added the '?' character to URIPARAM to handle an edge case. An example line: https://gist.github.com/03db31b0ec2440eae0e2
