### PR TITLE
Preserve milliseconds for UNIX timestamps in date filter.

### DIFF
--- a/lib/logstash/filters/date.rb
+++ b/lib/logstash/filters/date.rb
@@ -93,7 +93,7 @@ class LogStash::Filters::Date < LogStash::Filters::Base
           joda_parser = org.joda.time.format.ISODateTimeFormat.dateTimeParser.withOffsetParsed
           parser = lambda { |date| joda_parser.parseDateTime(date) }
         when "UNIX" # unix epoch
-          parser = lambda { |date| org.joda.time.Instant.new(date.to_i * 1000).toDateTime }
+          parser = lambda { |date| org.joda.time.Instant.new((date.to_f * 1000).to_i).toDateTime }
         when "UNIX_MS" # unix epoch in ms
           parser = lambda { |date| org.joda.time.Instant.new(date.to_i).toDateTime }
         when "TAI64N" # TAI64 with nanoseconds, -10000 accounts for leap seconds


### PR DESCRIPTION
My input source has UNIX timestamps with microsecond precision. The current date filter however, first changes the input timestamp to an integer before multiplying by 1000 to get to milliseconds. This change preserves at least the millisecond precision by first converting to float, then multiply and finally convert to integer.
