### PR TITLE
Added MDC to fields section in Log4j input

### DIFF
--- a/lib/logstash/inputs/log4j.rb
+++ b/lib/logstash/inputs/log4j.rb
@@ -69,6 +69,13 @@ class LogStash::Inputs::Log4j < LogStash::Inputs::Base
         }
         event_data["@fields"]["NDC"] = event_obj.getNDC() if event_obj.getNDC()
         event_data["@fields"]["stack_trace"] = event_obj.getThrowableStrRep().join("\n") if event_obj.getThrowableInformation()
+        
+        # Add the MDC context properties to '@fields'
+        if event_obj.getProperties()
+          event_obj.getPropertyKeySet().each do |key|
+            event_data["@fields"][key] = event_obj.getProperty(key)
+          end  
+        end  
 
         e = ::LogStash::Event.new event_data
         if e


### PR DESCRIPTION
Hi,

We're using Log4j MDC a lot. To let Logstash parse these properties as well. I did a little enhancement to the Log4J input class. 

```
    # Add the MDC context proeprties to '@fields'
    if event_obj.getProperties()
      event_obj.getPropertyKeySet().each do |key|
        event_data["@fields"][key] = event_obj.getProperty(key)
      end  
    end  
```

Regards, Jurjan
