### PR TITLE
Fix @source_host when it comes from json_event

### DIFF
--- a/lib/logstash/event.rb
+++ b/lib/logstash/event.rb
@@ -15,6 +15,7 @@ class LogStash::Event
     @cancelled = false
 
     @data = {
+      "@source_host" => false,
       "@source" => "unknown",
       "@tags" => [],
       "@fields" => {},
@@ -78,16 +79,19 @@ class LogStash::Event
 
   public
   def source; @data["@source"]; end # def source
-  def source=(val) 
+  def source=(val)
     uri = URI.parse(val) rescue nil
     val = uri if uri
     if val.is_a?(URI)
       @data["@source"] = val.to_s
-      @data["@source_host"] = val.host
+      maybe_new_source_host = val.host
       @data["@source_path"] = val.path
     else
       @data["@source"] = val
-      @data["@source_host"] = val
+      maybe_new_source_host = val
+    end
+    if !@data["@source_host"]
+      @data["@source_host"] = maybe_new_source_host
     end
   end # def source=
 


### PR DESCRIPTION
This is due to the change 1fc568e07d957ab9b629eab7550a1ae190db3c8a
which tries to get the @source value set sanely for json_event events which don't
have one.

However Logstash::Event unilaterally resets the @source_host when @source is set, which
is not what we want, at all. I have changed this so that @source_host is only set from
source in the case where @source_host was previously unset
