### PR TITLE
Fix zeromq filter for 1.1.4

### DIFF
--- a/lib/logstash/filters/zeromq.rb
+++ b/lib/logstash/filters/zeromq.rb
@@ -51,8 +51,8 @@ class LogStash::Filters::ZeroMQ < LogStash::Filters::Base
   config :sockopt, :validate => :hash
 
   public
-  def initialize
-    super
+  def initialize(params)
+    super(params)
 
     @threadsafe = false
   end


### PR DESCRIPTION
The initialize method in the zeromq filter was not updated to match the new call, so logstash won't initialize successfully if you use the zeromq filter.
