### PR TITLE
Don't try to close an already closed socket

### DIFF
--- a/lib/logstash/inputs/udp.rb
+++ b/lib/logstash/inputs/udp.rb
@@ -48,7 +48,7 @@ class LogStash::Inputs::Udp < LogStash::Inputs::Base
   def udp_listener(output_queue)
     @logger.info("Starting UDP listener", :address => "#{@host}:#{@port}")
 
-    if @udp 
+    if @udp && ! @udp.closed?
       @udp.close
     end
 


### PR DESCRIPTION
Had a problem where UDP listener gets stuck an a loop if @udp somehow gets closed @udp.close raises another exception...
