### PR TITLE
json_events should add tags defined in the config

### DIFF
--- a/lib/logstash/inputs/base.rb
+++ b/lib/logstash/inputs/base.rb
@@ -95,7 +95,7 @@ class LogStash::Inputs::Base < LogStash::Plugin
     when "json_event"
       begin
         event = LogStash::Event.from_json(raw)
-        event.tags.concat @tags.clone rescue []
+        event.tags += @tags
         if @message_format
           event.message ||= event.sprintf(@message_format)
         end


### PR DESCRIPTION
when using json_event inputs like redis tags defined in the config are ignored
