### PR TITLE
Prevent field creation on filter operating on non-existent fields

### DIFF
--- a/lib/logstash/event.rb
+++ b/lib/logstash/event.rb
@@ -122,6 +122,10 @@ class LogStash::Event
       return @data["@fields"][key]
     end
   end # def []
+
+  def has_key?(key)
+    return @data["@fields"].has_key?(key)
+  end
   
   public
   def []=(key, value)

--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -155,6 +155,9 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
   def rename(event)
     # TODO(sissel): use event.sprintf on the field names?
     @rename.each do |old, new|
+      if !event.has_key?(old)
+        next
+      end
       event[new] = event[old]
       event.remove(old)
     end
@@ -164,12 +167,18 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
   def replace(event)
     # TODO(sissel): use event.sprintf on the field names?
     @replace.each do |field, newvalue|
+      if !event.has_key?(field)
+        next
+      end
       event[field] = event.sprintf(newvalue)
     end
   end # def replace
 
   def convert(event)
     @convert.each do |field, type|
+      if !event.has_key?(field)
+        next
+      end
       original = event[field]
 
       # calls convert_{string,integer,float} depending on type requested.


### PR DESCRIPTION
Hi !

I created a filter to convert a field I has from string to integer.
The issue what that if my field didn't exist, the convert filter would create the field with an empty value.

Example:

If my input is:

``` javascript
{"@source":"default","@tags":[],"@fields":{},"level":"info","message":"Got remotetime 1352395395839","timestamp":"2012-11-08T17:23:15.871Z","@timestamp":"2012-11-08T17:23:16.061Z","@message":"json_event","@source_host":null,"@source_path":"default","@type":"redis-input"}
```

And my filter is:

``` ruby
filter{
        mutate{
                convert => ["ThisFieldDoesntExist", "integer"]
        }
}
```

The output would have been:

``` javascript
{"@source":"default","@tags":[],"@fields":{},"level":"info","message":"Got remotetime 1352395395839","timestamp":"2012-11-08T17:23:15.871Z","@timestamp":"2012-11-08T17:23:16.061Z","@message":"json_event","@source_host":null,"@source_path":"default","@type":"redis-input", "ThisFieldDoesntExist":"0"}
```

Because `event[ThisFieldDoesntExist]` is `nil` and that nil converts to "0" in ruby apparently.

I am no ruby expert so my fix may be shitty ^^

Thanks for logstash !
