### PR TITLE
Add '$' as valid character in java class name

### DIFF
--- a/patterns/java
+++ b/patterns/java
@@ -1,3 +1,3 @@
-JAVACLASS (?:[a-zA-Z0-9-]+\.)+[A-Za-z0-9]+
+JAVACLASS (?:[a-zA-Z0-9-]+\.)+[A-Za-z0-9$]+
 JAVAFILE (?:[A-Za-z0-9_.-]+)
 JAVASTACKTRACEPART at %{JAVACLASS:class}\.%{WORD:method}\(%{JAVAFILE:file}:%{NUMBER:line}\)


### PR DESCRIPTION
This definately exists at the leaf name, but I am unsure if it is allowed at higher levels.
