### PR TITLE
Allow setting external encoding on a per input basis

### DIFF
--- a/lib/logstash/inputs/file.rb
+++ b/lib/logstash/inputs/file.rb
@@ -59,6 +59,9 @@ class LogStash::Inputs::File < LogStash::Inputs::Base
   # has no effect.
   config :start_position, :validate => [ "beginning", "end"], :default => "end"
 
+  # Set the encoding of the file.
+  config :encoding, :validate => :string
+
   public
   def initialize(params)
     super
@@ -127,7 +130,10 @@ class LogStash::Inputs::File < LogStash::Inputs::Base
 
     @tail.subscribe do |path, line|
       path = path
-      line = line.force_encoding("UTF-8")
+      if @encoding
+        line.force_encoding(@encoding).encode("UTF-8")
+      end
+
       source = Addressable::URI.new(:scheme => "file", :host => hostname, :path => path).to_s
       @logger.debug("Received line", :path => path, :line => line)
       e = to_event(line, source)

--- a/lib/logstash/inputs/stdin.rb
+++ b/lib/logstash/inputs/stdin.rb
@@ -12,15 +12,22 @@ class LogStash::Inputs::Stdin < LogStash::Inputs::Base
 
   plugin_status "beta"
 
+  # Set the encoding of the file.
+  config :encoding, :validate => :string
+
   public
   def register
     @host = Socket.gethostname
+
+    if @encoding
+      $stdin.set_encoding(@encoding)
+    end
   end # def register
 
   def run(queue)
     loop do
        begin
-         line = $stdin.readline.encode("UTF-8", :invalid => :replace).chomp
+         line = $stdin.readline.encode("UTF-8").chomp
          e = to_event(line, "stdin://#{@host}/")
        rescue EOFError => ex
          break


### PR DESCRIPTION
I'm stuck handling logfiles with different encodings.  This allows me to specify the external encoding in the config for each input and then encodes them to UTF-8.

The file input may be better if this was set as an option in File::Watcher.
