### PR TITLE
Fix URIPARAM to allow square brackets

### DIFF
--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -42,7 +42,7 @@ URIHOST %{IPORHOST}(?::%{POSINT:port})?
 # doesn't turn into %XX
 URIPATH (?:/[A-Za-z0-9$.+!*'(){},~:;=#%_-]*)+
 #URIPARAM \?(?:[A-Za-z0-9]+(?:=(?:[^&]*))?(?:&(?:[A-Za-z0-9]+(?:=(?:[^&]*))?)?)*)?
-URIPARAM \?[A-Za-z0-9$.+!*'|(){},~#%&/=:;_?-]*
+URIPARAM \?[A-Za-z0-9$.+!*'|(){},~#%&/=:;_?-\[\]]*
 URIPATHPARAM %{URIPATH}(?:%{URIPARAM})?
 URI %{URIPROTO}://(?:%{USER}(?::[^@]*)?@)?(?:%{URIHOST})?(?:%{URIPATHPARAM})?
 


### PR DESCRIPTION
Fix URIPARAM to allow square brackets. PHP uses these everywhere.
