### PR TITLE
fixing log4j.rb Java stacktrace reading - must call to_a before join

### DIFF
--- a/lib/logstash/inputs/log4j.rb
+++ b/lib/logstash/inputs/log4j.rb
@@ -68,7 +68,7 @@ class LogStash::Inputs::Log4j < LogStash::Inputs::Base
           "@message" => event_obj.getRenderedMessage() 
         }
         event_data["@fields"]["NDC"] = event_obj.getNDC() if event_obj.getNDC()
-        event_data["@fields"]["stack_trace"] = event_obj.getThrowableStrRep().join("\n") if event_obj.getThrowableInformation()
+        event_data["@fields"]["stack_trace"] = event_obj.getThrowableStrRep().to_a.join("\n") if event_obj.getThrowableInformation()
         
         # Add the MDC context properties to '@fields'
         if event_obj.getProperties()


### PR DESCRIPTION
Log4J's  
LoggingEvent.getThrowableStrRep returns String[], which in not a ruby array. Calling "join" on it resulted in error. Fixed by adding a call to "to_a".
