### PR TITLE
Fixed link to Lucene query docs

### DIFF
--- a/lib/logstash/web/views/search/results.haml
+++ b/lib/logstash/web/views/search/results.haml
@@ -12,7 +12,7 @@
 %i
   You can click on any search result to see what kind of fields we know about
   for that event. You can also click on the graph to zoom to that time period.
-  The query language is that of Lucene's string query (<a href="http://lucene.apache.org/java/3_4_0/queryparsersyntax.html">docs</a>).
+  The query language is that of Lucene's string query (<a href="http://lucene.apache.org/core/3_6_1/queryparsersyntax.html">docs</a>).
 
 
 #visual


### PR DESCRIPTION
The older link did not return the query docs. Updated to new URL.
