### PR TITLE
Drupal DBLog: store logstash_last_wid serialized.

### DIFF
--- a/lib/logstash/inputs/drupal_dblog.rb
+++ b/lib/logstash/inputs/drupal_dblog.rb
@@ -254,6 +254,8 @@ class LogStash::Inputs::DrupalDblog < LogStash::Inputs::Base
 
   private
   def set_last_wid(wid, insert)
+    wid = PHP.serialize(wid.to_i)
+
     # Update last import wid variable
     if insert
       # Does not exist yet, so insert


### PR DESCRIPTION
This is to prevent a warning "can not unserialize" in Drupal 7,
since it requries all variables to be stored serialized.
