### PR TITLE
The match option is required for the email output plugin

### DIFF
--- a/lib/logstash/outputs/email.rb
+++ b/lib/logstash/outputs/email.rb
@@ -9,7 +9,7 @@ class LogStash::Outputs::Email < LogStash::Outputs::Base
 
   # the registered fields that we want to monitor
   # A hash of matches of field => value
-  config :match, :validate => :hash
+  config :match, :validate => :hash, :required => true
 
   # the To address setting - fully qualified email address to send to
   config :to, :validate => :string, :required => true


### PR DESCRIPTION
Whilst modifying the plugin to support sendmail delivery
the requirement for the match option was removed.

The change was made in this commit:

ef280184946ae974d6185db674e60d43dce4ea21

This causes the email plugin to fail with the following error:

undefined method `each' for nil:NilClass

Tracing back to:

/opt/logstash/logstash.jar!/logstash/outputs/email.rb:173:in `receive'"

This commit reverts that change and marks the match option as
required.
