### PR TITLE
Fixed year pattern.

### DIFF
--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -55,7 +55,7 @@ MONTHDAY (?:(?:0[1-9])|(?:[12][0-9])|(?:3[01])|[1-9])
 DAY (?:Mon(?:day)?|Tue(?:sday)?|Wed(?:nesday)?|Thu(?:rsday)?|Fri(?:day)?|Sat(?:urday)?|Sun(?:day)?)
 
 # Years?
-YEAR [0-9]+
+YEAR (?>\d\d){1,2}
 # Time: HH:MM:SS
 #TIME \d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?
 # I'm still on the fence about using grok to perform the time match,


### PR DESCRIPTION
Year was matching any digit, one or more times. This could lead to way
too eager matching.

Match years as either a group of 2, or a group of 4 digits.

Was already committed to https://github.com/logstash/grok-patterns/commit/6c9bd3b85ea03acb83d945e4b48e9f66956b553a, but not merged here.
