### PR TITLE
LOGSTASH-689: prefix OpenTSDB message with 'put '

### DIFF
--- a/lib/logstash/outputs/opentsdb.rb
+++ b/lib/logstash/outputs/opentsdb.rb
@@ -55,7 +55,7 @@ class LogStash::Outputs::Opentsdb < LogStash::Outputs::Base
   def receive(event)
     return unless output?(event)
 
-    # Opentsdb message format: metric timestamp value tagname=tagvalue tag2=value2\n
+    # Opentsdb message format: put metric timestamp value tagname=tagvalue tag2=value2\n
 
     # Catch exceptions like ECONNRESET and friends, reconnect on failure.
     begin
@@ -64,7 +64,8 @@ class LogStash::Outputs::Opentsdb < LogStash::Outputs::Base
       tags = metrics[2..-1]
 
       # The first part of the message
-      message = [event.sprintf(name),
+      message = ['put',
+                 event.sprintf(name),
                  event.sprintf("%{+%s}"),
                  event.sprintf(value),
       ].join(" ")


### PR DESCRIPTION
Fixes sending metrics to OpenTSDB, as per the bug description. Have tested, and it works with the following configuration:

```
  opentsdb { tags => [ "metric" ] debug => true host => "localhost" port => 4242 
             metrics => ["log.messages", "%{INFO.count}", "severity","info" ]
           } 
  opentsdb { tags => [ "metric" ] debug => true host => "localhost" port => 4242 
             metrics => ["log.messages", "%{DEBUG.count}", "severity","debug" ]
           } 
```

Sample messages sent to OpenTSDB:

```
put log.messages 1358206603 37 severity=info
put log.messages 1358206603 446 severity=debug
```
