### PR TITLE
Proof-of-concept SSL support in tcp input plugin

### DIFF
--- a/lib/logstash/inputs/tcp.rb
+++ b/lib/logstash/inputs/tcp.rb
@@ -13,8 +13,7 @@ require "openssl"
 # depending on `mode`.
 class LogStash::Inputs::Tcp < LogStash::Inputs::Base
   class Interrupted < StandardError; end
-  # NOTE(mrichar1): Temporary rename for testing
-  config_name "tcptls"
+  config_name "tcp"
   plugin_status "beta"
 
   # When mode is `server`, the address to listen on.


### PR DESCRIPTION
I've tweaked the tcp input plugin to add SSL support (encryption and verification).

A few things:
- I'm not a ruby programmer so while the code works, some of it might not be done in the proper ruby 'style'.  (Most) oddities should therefore be assumed to be glaring ones, not subtle coding decisions.
- With tcp in server mode, setting ssl_enable to true and providing a file to ssl_cert and ssl_key on the server side should be enough for encryption.  With ssl_verify set, you also need to set ssl_cacert and be sure the peer is offering up a 'client' certificate.  If verification is successful, @fields.sslsubject' is set to the peer's certificate subject (for later filter magic to compare with hostname etc to detect spoofing etc).
- I've tested client->server and server->client against the openssl s_server and s_client utilities.  I've done some tests with expired certificates, invalid signatures etc and it all seems to work as expected.  I'll be going on to test against rsyslog with gtls enabled.  Nevertheless, more testing is almost certainly a good idea!
- Only niggle (that I know of) is that in server mode OpenSSL exceptions always seem to return 'general SSLEngine problem' regardless of the reason the exception is thrown (in client mode it gives more pertinent error messages).  I don't know if this is a 'feature', bug, or just a lack of understanding of ruby exception handling on my part.
- I'm happy to make the same/similar changes to the output plugin too if these ones are considered useful.

Any comments/feedback greatly appreciated!
