### PR TITLE
added support to set a message format on http output

### DIFF
--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -47,8 +47,12 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
   # If form, then the body will be the mapping (or whole event) converted
   # into a query parameter string (foo=bar&baz=fizz...)
   #
+  # If message, then the body will be the result of formatting the event according to message
+  #
   # Otherwise, the event is sent as json.
-  config :format, :validate => ["json", "form"], :default => "json"
+  config :format, :validate => ["json", "form", "message"], :default => "json"
+
+  config :message, :validate => :string
 
   public
   def register
@@ -61,6 +65,17 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
       case @format
         when "form" ; @content_type = "application/x-www-form-urlencoded"
         when "json" ; @content_type = "application/json"
+      end
+    end
+    if @format == "message"
+      if @message.nil?
+        raise "message must be set if message format is used"
+      end
+      if @content_type.nil?
+        raise "content_type must be set if message format is used"
+      end
+      unless @mapping.nil?
+        @logger.warn "mapping is not supported and will be ignored if message format is used"
       end
     end
   end # def register
@@ -98,6 +113,8 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
     begin
       if @format == "json"
         request.body = evt.to_json
+      elsif @format == "message"
+        request.body = event.sprintf(@message)
       else
         request.body = encode(evt)
       end


### PR DESCRIPTION
this is basically the same support for formatting the payload as in
the stdout output

I use it for a quick hack to post to a collector of cube
http://square.github.com/cube
