### PR TITLE
Makefile: make the monolithic jar PHONY, so it builds everytime for the jar target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,8 @@ build/logstash-$(VERSION)-monolithic.jar:
 	$(QUIET)jar i $@
 	@echo "Created $@"
 
+.PHONY: build/logstash-$(VERSION)-monolithic.jar
+
 build/flatgems: | build vendor/bundle
 	mkdir $@
 	for i in $(VENDOR_DIR)/gems/*/lib $(VENDOR_DIR)/gems/*/data; do \


### PR DESCRIPTION
I noticed while iterating, that `make jar` was not updating the monolithic jar. and to run `make clean` was making a bunch of files have to be re-downloaded. By making the makefile target of the monolithic filename a PHONY target, it will cause it to be run everytime the 'jar' target depends on it.
