### PR TITLE
Fix '@tags' not in log4j input

### DIFF
--- a/lib/logstash/inputs/log4j.rb
+++ b/lib/logstash/inputs/log4j.rb
@@ -57,6 +57,7 @@ class LogStash::Inputs::Log4j < LogStash::Inputs::Base
         event_obj = ois.readObject()
         event_data = {
           "@type" => type,
+          "@tags" => tags,
           "@source" => event_source,
           "@source_host" => socket.peer,
           "@source_path" => event_obj.getLoggerName(),


### PR DESCRIPTION
Log4j input does not copy option 'tags' into event object. This patch fixes the problem.
