### PR TITLE
new filter 'translate'

### DIFF
--- a/lib/logstash/filters/translate.rb
+++ b/lib/logstash/filters/translate.rb
@@ -12,20 +12,21 @@ class LogStash::Filters::Translate < LogStash::Filters::Base
   plugin_status "experimental"
 
 
-  # The field containing the words you wish to translate.
-  # If this field is an array, only the first value will be used.
+  # The field containing a response code If this field is an
+  # array, only the first value will be used.
   config :field, :validate => :string, :required => true
-
-  # The destination you wish to populate with the translated text..    
-  # default is `translation`.  set to the same value as source
-  # if you want to do a substitution.
-  config :destination, :validate => :string, :default => "translation"
 
   # name with full path of external dictionary file.    
   # format of the table should be a YAML file. 
   # make sure you encase any integer based keys in quotes.
-  # if not specified will use embedded @dictionary below.
-  config :dictionary, :validate => :string
+  # For simple string search and replacements for just a few values
+  # use the gsub function of the mutate filter.
+  config :dictionary_path, :validate => :string, :required => true
+
+  # The destination you wish to populate with the response code.    
+  # default is http_response_code.  set to the same value as source
+  # if you want to do a substitution.
+  config :destination, :validate => :string, :default => "translation"
 
   # set to false if you want to match multiple terms.   
   # a large dictionary could get expensive if set to false.
@@ -35,29 +36,13 @@ class LogStash::Filters::Translate < LogStash::Filters::Base
 
   public
   def register
-    if @dictionary.nil?
-      @dictionary = 
-      { 
-        "100" => "continue",  "101" => "switching_protocols",  "102" => "processing",  "200" => "ok",  "201" => "created",  "202" => "accepted",  
-        "203" => "non_authoritative_information",  "204" => "no_content",  "205" => "reset_content",  "206" => "partial_content",  "207" => "multi_status",  
-        "226" => "im_used",  "300" => "multiple_choices",  "301" => "moved_permanently",  "302" => "found",  "303" => "see_other",  "304" => "not_modified",  
-        "305" => "use_proxy",  "307" => "temporary_redirect",  "400" => "bad_request",  "401" => "unauthorized",  "402" => "payment_required",  
-        "403" => "forbidden",  "404" => "not_found",  "405" => "method_not_allowed",  "406" => "not_acceptable",  "407" => "proxy_authentication_required",  
-        "408" => "request_timeout",  "409" => "conflict",  "410" => "gone",  "411" => "length_required",  "412" => "precondition_failed",  
-        "413" => "request_entity_too_large",  "414" => "request_uri_too_long",  "415" => "unsupported_media_type",  "416" => "requested_range_not_satisfiable",  
-        "417" => "expectation_failed",  "422" => "unprocessable_entity",  "423" => "locked",  "424" => "failed_dependency",  "426" => "upgrade_required",  
-        "500" => "internal_server_error",  "501" => "not_implemented",  "502" => "bad_gateway",  "503" => "service_unavailable",  "504" => "gateway_timeout",  
-        "505" => "http_version_not_supported",  "507" => "insufficient_storage",  "510" => "not_extended" 
-      }
-    else 
-      if File.exists?(@dictionary)
-        begin
-          @dictionary = YAML.load_file(@dictionary)
-        rescue Exception => e
-          raise "Bad Syntax in dictionary file" 
-        end
-      end # if File.exists?
-    end # if @dictionary.nil?
+    if File.exists?(@dictionary_path)
+      begin
+        @dictionary = YAML.load_file(@dictionary_path)
+      rescue Exception => e
+        raise "Bad Syntax in dictionary file" 
+      end
+    end # if File.exists?
     @logger.info("Dictionary - ", :dictionary => @dictionary)
     if @exact
       @logger.info("Dictionary translation method - Exact")
@@ -74,7 +59,7 @@ class LogStash::Filters::Translate < LogStash::Filters::Base
         source = source.first if source.is_a? Array # if array,  just use first value 
         source = source.to_s # make sure its a string.  Is this really needed?
         if @exact
-          translation = @dictionary[source] if defined? @dictionary[source]
+          translation = @dictionary[source] if @dictionary.include?(source)
         else 
           translation = source.gsub(Regexp.union(@dictionary.keys), @dictionary)
         end # if @exact


### PR DESCRIPTION
uses a `.yaml` file as a dictionary to translate words or phrases in a field.

default dictionary of `http response codes` included in the filter for ease of testing.

example dictionary file used to test yaml formatting -  `dictionary.yaml` containing 

```
"301": that shit is bananas
"GET": POOP
"wordpress": more like stupid press
```

tested both `exact` true/false matching ...   and made sure I could translate into the same field by setting the `field` and `destination` config parameters to be `@message`  which made for a rather opinionated apache log.

![translate_filter_output](https://f.cloud.github.com/assets/2488346/102038/20f1f1d6-690a-11e2-9112-009cb4a62e1f.png)

I guess the obvious next step would be to make a `l33t` or `Pirate` dictionary to be the default rather than response codes.
