### PR TITLE
Add 'configtest' option to agent to verify config and exit

### DIFF
--- a/lib/logstash/agent.rb
+++ b/lib/logstash/agent.rb
@@ -334,11 +334,7 @@ class LogStash::Agent
     # Load the config file
     @logger.info("Read config")
     config = read_config
-    if @configtest
-      puts "Config test passed.  Exiting..."
-      exit (0)
-    end
-
+    
     @logger.info("Start thread")
     @thread = Thread.new do
       LogStash::Util::set_thread_name(self.class.name)
@@ -395,6 +391,10 @@ class LogStash::Agent
   def run_with_config(config)
     @plugins_mutex.synchronize do
       @inputs, @filters, @outputs = parse_config(config)
+      if @configtest
+        puts "Config test passed.  Exiting..."
+        exit (0)
+      end
 
       # If we are given a config string (run usually with 'agent -e "some config string"')
       # then set up some defaults.


### PR DESCRIPTION
I'm using logstash with puppet and it is convenient to verify config syntax before restarting the service.  Puppet will not restart the service if configtest fails (thus leaving logstash running).

This is a small patch that adds an agent '-t' or '--configtest' boolean option to check config and then exit.  

Thanks,
-darren
