### PR TITLE
redis output rewrite with extra features

### DIFF
--- a/lib/logstash/outputs/redis.rb
+++ b/lib/logstash/outputs/redis.rb
@@ -130,8 +130,6 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
     # Mutex to syncronize threads access to @active_servers.
     @lb_mutex = Mutex.new
 
-    # Mutex to syncronize main plug
-
     @redis_pool = {}
     @host.each {|uri| @redis_pool[uri] = nil}
 


### PR DESCRIPTION
This is a very intrusive redis output rewrite with some features which I consider important for production environment, where multiple redis servers can be used as buffers and it's important not to OOM the redis processes if there is no one consuming the redis messages on the input side.

The redis output will load balance between the active redis hosts if @balance_hosts is enabled.

If a redis key to which output is trying to write to has more than @max_redis_events then plugin will not write to this redis key and disable this redis server  and try another redis  server in the active servers list.
If all redis servers have  more than @max_redis_events they will be disabled and redis output will stop trying to sending new events.
Once there are more than @max_buffered_events in memory of the plugin and no active servers, the thread will block, until woken up by other thread.

There is a dedicated thread that awakes every @reconnect_interval seconds and
tries to reconnects to all disabled redis servers, if there are enabled servers it will also wake up all blocked threads, so that they would retry writing to these active redis servers.

Threads blocking/wakup was used so that at most one thread would do it's dedicated part concurrently and as avoid over complicated mutex logic.
