### PR TITLE
skip metriks for event that are older than defined threshold

### DIFF
--- a/lib/logstash/filters/metrics.rb
+++ b/lib/logstash/filters/metrics.rb
@@ -101,6 +101,10 @@ class LogStash::Filters::Metrics < LogStash::Filters::Base
   # syntax: timer => [ "name of metric", "%{time_value}" ]
   config :timer, :validate => :hash, :default => {}
 
+  # skip events that have @timestamp older than @past_seconds, 0 means allways count
+  # this is usefull then logstash was down/restarted and metrics will get skewed by too many old events
+  config :past_seconds, :validate => :number, :default => 0
+
   def register
     require "metriks"
     require "socket"
@@ -111,6 +115,11 @@ class LogStash::Filters::Metrics < LogStash::Filters::Base
 
   def filter(event)
     return unless filter?(event)
+
+    if @past_seconds > 0 && Time.now - event.ruby_timestamp > @past_seconds
+      @logger.debug("Skipping metriks for old event", :event => event)
+      return
+    end
 
     @meter.each do |m|
       @metric_meters[event.sprintf(m)].mark


### PR DESCRIPTION
If logstash was was down/restarted , then there will be lots of events with too old timestamp
it will skew metrics that are relevant only for current short time window.
So events that are older than @past_seconds, will not be used my metriks.

<pre>metrics {
    tags         => [ "apache-accesslog" ]
    meter        => [ "http.%{appenv}.status.%{status}" ]
    add_tag      => [ "apache-metrics" ]
    past_seconds => 10
  }</pre>
