### PR TITLE
Msgpack input support

### DIFF
--- a/lib/logstash/event_v0.rb
+++ b/lib/logstash/event_v0.rb
@@ -4,6 +4,7 @@ require "date"
 require "logstash/time_addon"
 require "logstash/namespace"
 require "uri"
+require "msgpack"
 
 # General event type. 
 # Basically a light wrapper on top of a hash.

--- a/lib/logstash/event_v1.rb
+++ b/lib/logstash/event_v1.rb
@@ -4,6 +4,7 @@ require "date"
 require "logstash/time_addon"
 require "logstash/namespace"
 require "uri"
+require "msgpack"
 
 # the logstash event object.
 #

--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -73,9 +73,11 @@ Gem::Specification.new do |gem|
     gem.add_runtime_dependency "jruby-openssl"
     gem.add_runtime_dependency "jruby-win32ole"
     gem.add_runtime_dependency "jdbc-mysql" # For input drupal_dblog
+    gem.add_runtime_dependency "msgpack-jruby"
   else
     gem.add_runtime_dependency "excon"
     gem.add_runtime_dependency "mysql2" # For input drupal_dblog
+    gem.add_runtime_dependency "msgpack"
   end
 
   if RUBY_VERSION >= '1.9.1'


### PR DESCRIPTION
Useful receiving logs from beaver (it already have msgpack support).

Msgpack is more compact, faster and does not drop events with broken UTF-8 likes JSON does.
