### PR TITLE
Feature/clone filter

### DIFF
--- a/lib/logstash/filters/clone.rb
+++ b/lib/logstash/filters/clone.rb
@@ -24,8 +24,10 @@ class LogStash::Filters::Clone < LogStash::Filters::Base
     @clones.each do |type|
       clone = event.clone
       clone.type = type
-      filter_matched(event_split)
+      filter_matched(clone)
       @logger.debug("Cloned event", :clone => clone, :event => event)
+
+      # Push this new event onto the stack at the LogStash::FilterWorker
       yield clone
     end
   end


### PR DESCRIPTION
A filter to clone events. It should leave the original event un-altered. All the default selectors should work for selecting the event. All the default event modifiers should only apply to the event clones. You'll be able to make an arbitrary number of clones. You can make an identical clone by giving your clones the same type as the original event.

This could use a spec test. I tried to write the spec test but it complained about my yield being out of block. The split filter did not work in tests either. I suspect the tests are not setup to yield events from filter.
