### PR TITLE
Email output plugin should not use authentication by default for SMTP 

### DIFF
--- a/lib/logstash/outputs/email.rb
+++ b/lib/logstash/outputs/email.rb
@@ -123,19 +123,19 @@ class LogStash::Outputs::Email < LogStash::Outputs::Base
       end
       pass = @options.include?("password")
       if !pass
-        pass = ""
+        pass = nil
       else
         pass = @options.fetch("password")
       end
       userName = @options.include?("userName")
       if !userName
-        userName = ""
+        userName = nil
       else
         userName = @options.fetch("userName")
       end
       authenticationType = @options.include?("authenticationType")
       if !authenticationType
-        authenticationType = "plain"
+        authenticationType = nil
       else
         authenticationType = @options.fetch("authenticationType")
       end


### PR DESCRIPTION
This commit should resolve [LOGSTASH-559](https://logstash.jira.com/browse/LOGSTASH-559)

Since there is no way to set a nil value in the configuration, you can
not use the email plugin with an SMTP-server that does not use
authentication.
