### PR TITLE
make gelf output work with syslog_pri

### DIFF
--- a/lib/logstash/outputs/gelf.rb
+++ b/lib/logstash/outputs/gelf.rb
@@ -30,9 +30,12 @@ class LogStash::Outputs::Gelf < LogStash::Outputs::Base
   # as the gelf level/severity.
   #
   # Values here can be integers [0..7] inclusive or any of
-  # "debug", "info", "warn", "error", "fatal", "unknown" (case insensitive).
+  # "debug", "info", "warn", "error", "fatal" (case insensitive).
   # Single-character versions of these are also valid, "d", "i", "w", "e", "f",
   # "u"
+  # The following additional severity_labels from logstash's  syslog_pri filter
+  # are accepted: "emergency", "alert", "critical",  "warning", "notice", and 
+  # "informational"
   config :level, :validate => :array, :default => [ "%{severity}", "INFO" ]
 
   # The GELF facility. Dynamic values like %{foo} are permitted here; this
@@ -103,9 +106,10 @@ class LogStash::Outputs::Gelf < LogStash::Outputs::Base
     @gelf.collect_file_and_line = false
 
     # these are syslog words and abbreviations mapped to RFC 5424 integers
+    # and logstash's syslog_pri filter
     @level_map = {
       "debug" => 7, "d" => 7,
-      "info" => 6, "i" => 6,
+      "info" => 6, "i" => 6, "informational" => 6,
       "notice" => 5, "n" => 5,
       "warn" => 4, "w" => 4, "warning" => 4,
       "error" => 3, "e" => 3,


### PR DESCRIPTION
syslog_pri filter sets severity to "informational", the gelf output should support this string.

i updated the comment near the map and the documentation comment near the config :level.

lastly, i removed "unknown" from the list of possible values for the config :level since we don't support that value in the level_map and we'd just fall through to the default level (0).
