### PR TITLE
Update useragent filter for new user_agent_parser

### DIFF
--- a/lib/logstash/filters/useragent.rb
+++ b/lib/logstash/filters/useragent.rb
@@ -40,14 +40,14 @@ class LogStash::Filters::UserAgent < LogStash::Filters::Base
           tmp_file = Tempfile.new('logstash-uaparser-regexes')
           tmp_file.write(File.read(jar_path))
           tmp_file.close # this file is reaped when ruby exits
-          @parser = UserAgentParser::Parser.new(tmp_file.path)
+          @parser = UserAgentParser::Parser.new(patterns_path: tmp_file.path)
         rescue => ex
           raise "Failed to cache, due to: #{ex}\n#{ex.backtrace}"
         end
       end
     else
       @logger.info("Using user agent regexes", :regexes => @regexes)
-      @parser = UserAgentParser::Parser.new(@regexes)
+      @parser = UserAgentParser::Parser.new(patterns_path: @regexes)
     end
   end #def register
 

--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -63,7 +63,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "php-serialize" # For input drupal_dblog
   gem.add_runtime_dependency "murmurhash3"
   gem.add_runtime_dependency "rufus-scheduler"
-  #gem.add_runtime_dependency "user_agent_parser", [">= 2.0.0"]
+  gem.add_runtime_dependency "user_agent_parser", [">= 2.0.0"]
   gem.add_runtime_dependency "snmp"
 
   if RUBY_PLATFORM == 'java'


### PR DESCRIPTION
The 2.0.0 release of user_agent_parser changed the constructor syntax slightly. It's also been released to rubygems.org now. So hopefully this is ready to release with logstash as well.
