### PR TITLE
Possibility to use kv filter against a previously groked variable

### DIFF
--- a/lib/logstash/filters/kv.rb
+++ b/lib/logstash/filters/kv.rb
@@ -99,6 +99,9 @@ class LogStash::Filters::KV < LogStash::Filters::Base
     kv_keys=Hash.new
 
     @fields.each do |fieldname|
+      # If var we want to use kv against is
+      # the result of a previous grok
+      # the field should be passed as @fields.myvar
       field, variable = fieldname.split('.')
       if !variable.nil?
         value = event[field][variable]


### PR DESCRIPTION
Let's write a filter section that looks like this

```
grok {
    type => 'demo'
    pattern => "%{URIPATH:mypath}%{URIPARAM:myparams}"
}
kv {
    type => 'demo'
    fields => ???
    field_splut => "&?"
}
```

As of today if I want to use the kv filter against the `myparams` variable I got from grokking I can't. kv needs to received on of the top-level fields (ie. @source, @tags, @fields, etc...)

This pull request aims to make the preceding possible, with the following snippet

```
grok {
    type => 'demo'
    pattern => "%{URIPATH:mypath}%{URIPARAM:myparams}"
}
kv {
    type => 'demo'
    fields => ["@fields.myparams"]
    field_split => "&?"
}
```

I hope this make sense,
