### PR TITLE
dependancy installs gjc which segfaults logstash

### DIFF
--- a/debian/debian/control
+++ b/debian/debian/control
@@ -8,7 +8,7 @@ Homepage: http://logstash.net
 
 Package: logstash
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, daemon, adduser, psmisc, java2-runtime
+Depends: ${shlibs:Depends}, ${misc:Depends}, daemon, adduser, psmisc, default-jre
 Description:  tool for managing events and logs
  logstash is a tool for managing events and logs. You can use it to collect logs,
  parse them, and store them for later use (like, for searching). Speaking of


### PR DESCRIPTION
I created the debian package, but java2-runtime install the gjc jave package on Debian Wheezy.  I propose to depend on default-jre which provides openjdk-jre.
