### PR TITLE
KV Filter: Don't warn on nil source

### DIFF
--- a/lib/logstash/filters/kv.rb
+++ b/lib/logstash/filters/kv.rb
@@ -135,6 +135,7 @@ class LogStash::Filters::KV < LogStash::Filters::Base
       value = event[fieldname]
 
       case value
+        when nil; #Nothing to do
         when String; kv_keys = parse(value, event, kv_keys)
         when Array; value.each { |v| kv_keys = parse(v, event, kv_keys) }
         else 

--- a/spec/filters/kv.rb
+++ b/spec/filters/kv.rb
@@ -305,4 +305,19 @@ describe LogStash::Filters::KV do
     end
   end
 
+  describe "test data from nil sub source, should not issue a warning" do
+    config <<-CONFIG
+      filter {
+        kv {
+          source => "non-exisiting-field"
+          target => "kv"
+        }
+      }
+    CONFIG
+    sample "" do
+      insist { subject["non-exisiting-field"] } == nil
+      insist { subject["kv"] } == nil
+    end
+  end
+
 end


### PR DESCRIPTION
Adding a simple kv filter to my config with a specific field as source config, I got my logstash logs filled with the following warning for all events without this field

```
kv filter has no support for this type of data {:type=>NilClass, :value=>nil, :level=>:warn}
```
