### PR TITLE
extract SNMP varbind data from SNMP trap as strings

### DIFF
--- a/lib/logstash/inputs/snmptrap.rb
+++ b/lib/logstash/inputs/snmptrap.rb
@@ -3,13 +3,11 @@ require "logstash/namespace"
 
 # Read snmp trap messages as events
 #
-# SNMP varbinds are coerced to 'name=value' string pairs, separated by newlines.
-# This results in a @message that looks like:
-#   "SNMPv2-MIB::sysUpTime.0=134 days, 10:12:47.90\nSNMPv2-MIB::snmpTrapOID.0=SNMPv2-SMI::enterprises.5951.1.1.0.9"
-#
-# You can transform this into useful @fields with a filter like:
-#
-# filter { kv { field_split => "\n"} }
+# Resulting @message looks like :
+#   #<SNMP::SNMPv1_Trap:0x6f1a7a4 @varbind_list=[#<SNMP::VarBind:0x2d7bcd8f @value="teststring", 
+#   @name=[1.11.12.13.14.15]>], @timestamp=#<SNMP::TimeTicks:0x1af47e9d @value=55>, @generic_trap=6, 
+#   @enterprise=[1.2.3.4.5.6], @source_ip="127.0.0.1", @agent_addr=#<SNMP::IpAddress:0x29a4833e @value="\xC0\xC1\xC2\xC3">, 
+#   @specific_trap=99>
 #
 
 class LogStash::Inputs::Snmptrap < LogStash::Inputs::Base
@@ -56,11 +54,10 @@ class LogStash::Inputs::Snmptrap < LogStash::Inputs::Base
     @snmptrap = SNMP::TrapListener.new(:Port => @port, :Community => @community, :Host => @host) 
     @snmptrap.on_trap_default do |trap|
       begin
-        varbind_pairs = []
+        event = to_event(trap.inspect, trap.source_ip)
         trap.each_varbind do |vb|
-          varbind_pairs << "#{vb.name.to_s}=#{vb.value.to_s}"
+          event[vb.name.to_s] = vb.value.to_s
         end
-        event = to_event(varbind_pairs.join("\n"), trap.source_ip)
         @logger.debug("SNMP Trap received: ", :trap_object => trap.inspect)
         output_queue << event if event
       rescue => event


### PR DESCRIPTION
Current @message is generated by inspect, so it's full of object addresses which are ungrokable.

This patch sets the message to "name1=val1\nname2=val2\n" etc. so a simple kv filter can
extract them.

(

is it better to apply that data as top-level fields on event itself? 

i.e. event[name1] = val  and so on?

If so I'm not sure what to set as a meaningful @message

)
