### PR TITLE
Grok captures name even when matching the whole line

### DIFF
--- a/lib/logstash/filters/grok.rb
+++ b/lib/logstash/filters/grok.rb
@@ -363,7 +363,7 @@ class LogStash::Filters::Grok < LogStash::Filters::Base
           end
 
           # Special casing to skip captures that represent the entire log message.
-          if fieldvalue == value and field == "@message"
+          if fieldvalue == value and field == "@message" and key.nil?
             # Skip patterns that match the entire message
             @logger.debug? and @logger.debug("Skipping capture since it matches the whole line.", :field => key)
             next

--- a/spec/filters/grok.rb
+++ b/spec/filters/grok.rb
@@ -26,6 +26,21 @@ describe LogStash::Filters::Grok do
     end
   end
 
+  describe "create fields event if grok matches all messages and a key is specified" do
+    config <<-CONFIG
+      filter {
+        grok {
+          pattern => "%{DATE_EU:stimestamp}"
+        }
+      }
+    CONFIG
+
+    sample "2011/01/01" do
+      insist { subject["stimestamp"] } == "2011/01/01"
+    end
+  end
+
+
   describe "parsing an event with multiple messages (array of strings)" do 
     config <<-CONFIG
       filter {


### PR DESCRIPTION
As of today when the grok capture matches the whole line, the named capture is skipped.

The error was related by a user on the [google group](https://groups.google.com/forum/?fromgroups=#!topic/logstash-users/RdNwjmO-wn4) last week

So using this configuration file :

```
input {
    stdin {
        type => "myin"
    }
}

filter {
    grok {
        type => "myin"
        pattern => "%{DATE_EU:test}"
    }
}

output {
    stdout {
        debug => true
         debug_format => "json"
    }
}
```

will always result in an empty `@fields` element. This commit fixes that.

**Before**

`{"@source":"stdin://kibana/","@tags":[],"@fields":{},"@timestamp":"2013-03-10T15:14:38.137Z","@source_host":"kibana","@source_path":"/","@message":"2011/01/01","@type":"myin"}`

**After**

`{"@source":"stdin://kibana/","@tags":[],"@fields":{"test":["2011/01/01"]},"@timestamp":"2013-03-10T15:08:18.330Z","@source_host":"kibana","@source_path":"/","@message":"2011/01/01","@type":"myin"}`

Also a spec test has been added, I did not manage to find out how to run the test suite, but based on what the other test are making it should work correctly.
