### PR TITLE
Allow empty arrays as values in grammar

### DIFF
--- a/lib/logstash/config/grammar.rl
+++ b/lib/logstash/config/grammar.rl
@@ -105,7 +105,10 @@ require "logstash/namespace"
   # TODO(sissel): allow use of this.
   regexp_literal = ( "/" ( ( (any - [\\'\n]) | "\\" any )* ) "/" )  ;
 
-  array = ( "[" ws ( string | numeric ) ws ("," ws (string | numeric ) ws)* "]" ) >array_init %array_push;
+  array = (
+    ( "[" ( ws | "" ) "]" )
+    | ( "[" ws ( string | numeric ) ws ("," ws (string | numeric ) ws)* "]" )
+  ) >array_init %array_push;
   # TODO(sissel): Implement hash syntax { key => value, ... }
   # TODO(sissel): hashes should support arrays as values.
 


### PR DESCRIPTION
Allow following config not to fail with parse error

<pre>
filter {
  grok {
    tags                => [ "apache-accesslog" ]
    patterns_dir        => [ "/opt/logstash/patterns" ]
    match               => [ "clientip", "%{IP}" ]
    break_on_match      => true
    named_captures_only => true
    tag_on_failure      => [ ]
  }
}
</pre>
