### PR TITLE
Grok support for IETF 5424 syslog parsing

### DIFF
--- a/patterns/linux-syslog
+++ b/patterns/linux-syslog
@@ -7,7 +7,7 @@ CRONLOG %{SYSLOGBASE} \(%{USER:user}\) %{CRON_ACTION:action} \(%{DATA:message}\)
 SYSLOGLINE %{SYSLOGBASE2} %{GREEDYDATA:message}
 
 # IETF 5424 syslog(8) format (see http://www.rfc-editor.org/info/rfc5424)
-IETF_SYSLOG_PRI (?:\<%{NONNEGINT<192}\>)
-IETF_SYSLOG_SD (?:\[%{DATA}\]+|-)
+SYSLOG5424PRI (?:\<%{NONNEGINT}\>)
+SYSLOG5424SD (?:\[%{DATA}\]+|-)
 
-IETF_SYSLOG_LINE %{IETF_SYSLOG_PRI:ietf_syslog_pri}%{NONNEGINT:ietf_syslog_ver} (%{TIMESTAMP_ISO8601:ietf_syslog_ts}|-) (%{HOSTNAME:ietf_syslog_host}|-) (%{WORD:ietf_syslog_app}|-) (%{WORD:ietf_syslog_proc}|-) (%{WORD:ietf_syslog_msgid}|-) %{IETF_SYSLOG_SD:ietf_syslog_sd} %{GREEDYDATA:ietf_syslog_msg}
+SYSLOG5424LINE %{SYSLOG5424PRI:ietf_syslog_pri}%{NONNEGINT:syslog5424_ver} (%{TIMESTAMP_ISO8601:syslog5424_ts}|-) (%{HOSTNAME:syslog5424_host}|-) (%{WORD:syslog5424_app}|-) (%{WORD:syslog5424_proc}|-) (%{WORD:syslog5424_msgid}|-) %{SYSLOG5424SD:syslog5424_sd} %{GREEDYDATA:ietf_syslog_msg}

--- a/spec/filters/grok.rb
+++ b/spec/filters/grok.rb
@@ -32,7 +32,7 @@ describe LogStash::Filters::Grok do
     config <<-CONFIG
       filter {
         grok {
-          pattern => "%{IETF_SYSLOG LINE}"
+          pattern => "%{SYSLOG5424LINE}"
           singles => true
         }
       }
@@ -40,15 +40,15 @@ describe LogStash::Filters::Grok do
 
     sample "<191>1 2009-06-30T18:30:00+02:00 paxton.local grokdebug 4123 - [id1 foo="bar"][id2 baz="something"] Hello, syslog." do
       reject { subject["@tags"] }.include?("_grokparsefailure")
-      insist { subject["ietf_syslog_pri"] } == "<191>"
-      insist { subject["ietf_syslog_ver"] } == "1"
-      insist { subject["ietf_syslog_ts"] } == "2009-06-30T18:30:00+02:00"
-      insist { subject["ietf_syslog_host"] } == "paxton.local"
-      insist { subject["ietf_syslog_app"] } == "grokdebug"
-      insist { subject["ietf_syslog_proc"] } == "4123"
-      insist { subject["ietf_syslog_msgid"] } == null
-      insist { subject["ietf_syslog_sd"] } == "[id1 foo=\"bar\"][id2 baz=\"something\"]"
-      insist { subject["ietf_syslog_msg"] } == "Hello, syslog."
+      insist { subject["syslog5424_pri"] } == "<191>"
+      insist { subject["syslog5424_ver"] } == "1"
+      insist { subject["syslog5424_ts"] } == "2009-06-30T18:30:00+02:00"
+      insist { subject["syslog5424_host"] } == "paxton.local"
+      insist { subject["syslog5424_app"] } == "grokdebug"
+      insist { subject["syslog5424_proc"] } == "4123"
+      insist { subject["syslog5424_msgid"] } == nil
+      insist { subject["syslog5424_sd"] } == "[id1 foo=\"bar\"][id2 baz=\"something\"]"
+      insist { subject["syslog5424_msg"] } == "Hello, syslog."
     end
   end
 


### PR DESCRIPTION
Folks,

we are using the shiny IETF `syslog` format (as defined in [RFC 5424](http://www.rfc-editor.org/info/rfc5424)) instead cranky old BSD, and I thought some regex magic for grok to make parsing easier would be useful for the community as well. Note that making sense of the PRI value (i.e. understanding facility and severity) is left to the `syslog_pri` filter, and  `STRUCTURED-DATA` support is still pending (needing a corresponding filter implementation as well).

I have extended the tests in `spec/filters/grok.rb` accordingly.

Would be cool if you could add it to the mainline distro — and thanks for giving us awesome logstash!

Cheers,
Alexander
