### PR TITLE
add metaevent filter

### DIFF
--- a/lib/logstash/filters/metaevent.rb
+++ b/lib/logstash/filters/metaevent.rb
@@ -9,7 +9,7 @@ class LogStash::Filters::Metaevent < LogStash::Filters::Base
   config :followed_by_tags, :validate => :array, :required => true
 
   # syntax: `period => 60`
-  config :period, :validate => :number, :default => 30
+  config :period, :validate => :number, :default => 5
 
   def register
     @logger.debug("registering")
@@ -50,7 +50,7 @@ class LogStash::Filters::Metaevent < LogStash::Filters::Base
 
     event = LogStash::Event.new
     event.source_host = Socket.gethostname
-    event["tags"] = @add_tag
+    event.tags = @add_tag
 
     @metaevents << event
     @start_event = nil


### PR DESCRIPTION
@jordansissel

Working with @jessedavis at Monitorama hackfest on this proof of concept for a metaevent filter which looks for sequences of events.  You can configure like:

```
filter {
  metaevent {
    tags => [ "foo" ]
    followed_by_tags => [ "bar" ]
    add_tag => [ "baz" ]
  }
}
```

Additional things we'd like to add if this looks like a good direction would be `not_followed_by_tags` and inlining the original events in the synthesized event.  Just wanted to get feedback early.
