### PR TITLE
Fixed class names in class 'end' tags in inputs + filters.

### DIFF
--- a/lib/logstash/filters/alter.rb
+++ b/lib/logstash/filters/alter.rb
@@ -169,4 +169,4 @@ class LogStash::Filters::Alter < LogStash::Filters::Base
     end # @coalesce_parsed.each
   end # def coalesce
   
-end
+end # class LogStash::Filters::Alter

--- a/lib/logstash/filters/checksum.rb
+++ b/lib/logstash/filters/checksum.rb
@@ -44,4 +44,4 @@ class LogStash::Filters::Checksum < LogStash::Filters::Base
     @logger.debug("Digested string", :digested_string => digested_string)
     event.fields['logstash_checksum'] = digested_string
   end
-end
+end # class LogStash::Filters::Checksum

--- a/lib/logstash/filters/clone.rb
+++ b/lib/logstash/filters/clone.rb
@@ -32,4 +32,4 @@ class LogStash::Filters::Clone < LogStash::Filters::Base
     end
   end
 
-end
+end # class LogStash::Filters::Clone

--- a/lib/logstash/filters/kv.rb
+++ b/lib/logstash/filters/kv.rb
@@ -170,4 +170,4 @@ class LogStash::Filters::KV < LogStash::Filters::Base
     end
     return kv_keys
   end
-end # class LogStash::Filter::KV
+end # class LogStash::Filters::KV

--- a/lib/logstash/filters/metrics.rb
+++ b/lib/logstash/filters/metrics.rb
@@ -181,4 +181,4 @@ class LogStash::Filters::Metrics < LogStash::Filters::Base
     filter_matched(event)
     return [event]
   end
-end # class LogStash::Filter::KV
+end # class LogStash::Filters::Metrics

--- a/lib/logstash/filters/multiline.rb
+++ b/lib/logstash/filters/multiline.rb
@@ -233,4 +233,4 @@ class LogStash::Filters::Multiline < LogStash::Filters::Base
     @pending.clear
     return events
   end # def flush
-end # class LogStash::Filters::Date
+end # class LogStash::Filters::Multiline

--- a/lib/logstash/filters/ruby.rb
+++ b/lib/logstash/filters/ruby.rb
@@ -38,4 +38,4 @@ class LogStash::Filters::Ruby < LogStash::Filters::Base
 
     filter_matched(event)
   end # def filter
-end
+end # class LogStash::Filters::Ruby

--- a/lib/logstash/filters/sleep.rb
+++ b/lib/logstash/filters/sleep.rb
@@ -86,4 +86,4 @@ class LogStash::Filters::Sleep < LogStash::Filters::Base
     end
     filter_matched(event)
   end # def filter
-end
+end # class LogStash::Filters::Sleep

--- a/lib/logstash/filters/split.rb
+++ b/lib/logstash/filters/split.rb
@@ -61,4 +61,4 @@ class LogStash::Filters::Split < LogStash::Filters::Base
     # Cancel this event, we'll use the newly generated ones above.
     event.cancel
   end # def filter
-end # class LogStash::Filters::Date
+end # class LogStash::Filters::Split

--- a/lib/logstash/inputs/generator.rb
+++ b/lib/logstash/inputs/generator.rb
@@ -84,4 +84,4 @@ class LogStash::Inputs::Generator < LogStash::Inputs::Threadable
   def teardown
     finished
   end # def teardown
-end # class LogStash::Inputs::Stdin
+end # class LogStash::Inputs::Generator

--- a/lib/logstash/inputs/graphite.rb
+++ b/lib/logstash/inputs/graphite.rb
@@ -39,4 +39,4 @@ class LogStash::Inputs::Graphite < LogStash::Inputs::Tcp
 
     @queue  << event
   end
-end
+end # class LogStash::Inputs::Graphite

--- a/lib/logstash/inputs/websocket.rb
+++ b/lib/logstash/inputs/websocket.rb
@@ -44,4 +44,4 @@ class LogStash::Inputs::Websocket < LogStash::Inputs::Base
     end # begin
   end # def run
 
-end # class LogStash::Inputs::Udp
+end # class LogStash::Inputs::Websocket

--- a/lib/logstash/inputs/xmpp.rb
+++ b/lib/logstash/inputs/xmpp.rb
@@ -68,4 +68,4 @@ class LogStash::Inputs::Xmpp < LogStash::Inputs::Base
     sleep
   end # def run
 
-end # def class LogStash:Inputs::Xmpp
+end # class LogStash::Inputs::Xmpp


### PR DESCRIPTION
Fixed class names in class 'end' tags. Only did inputs + filters.

I decided not to do the outputs, because they are nearly all missing the comment. If you want I can add them, but maybe you already decided against using such comments?
