### PR TITLE
Added @message to eventlog input

### DIFF
--- a/lib/logstash/inputs/eventlog.rb
+++ b/lib/logstash/inputs/eventlog.rb
@@ -91,6 +91,7 @@ class LogStash::Inputs::EventLog < LogStash::Inputs::Base
           data = unwrap_racob_variant_array(event.Data)
           # Data is an array of signed shorts, so convert to bytes and pack a string
           e["Data"] = data.map{|byte| (byte > 0) ? byte : 256 + byte}.pack("c*")
+          e.message = event.Message
           queue << e
           # Update the newest-record pointer if I'm shipping the newest record in this batch
           next_newest_shipped_event = event.RecordNumber if (event_index += 1) == 1


### PR DESCRIPTION
I noticed on Kibana that my eventlog inputs had nil @message data, it just showed timestamp. Looking in the metadata for the event, I saw the message in the @field.Message field. When debugging eventlog output, I didn't see the @message field... so I added!
