### PR TITLE
Allow appname, procid, and msgid to be format strings.

### DIFF
--- a/lib/logstash/outputs/syslog.rb
+++ b/lib/logstash/outputs/syslog.rb
@@ -111,6 +111,8 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
   def receive(event)
     return unless output?(event)
 
+    appname = event.sprintf(@appname)
+    procid = event.sprintf(@procid)
     sourcehost = event.sprintf(@sourcehost)
 
     facility_code = FACILITY_LABELS.index(@facility)
@@ -121,19 +123,21 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
 
     if rfc3164?
        timestamp = DateTime.iso8601(event.sprintf(@timestamp)).strftime("%b %e %H:%M:%S")
-       syslog_msg = "<"+priority.to_s()+">"+timestamp+" "+sourcehost+" "+@appname+"["+@procid+"]: "+event.message
+       syslog_msg = "<"+priority.to_s()+">"+timestamp+" "+sourcehost+" "+appname+"["+procid+"]: "+event.message
     else
+       msgid = event.sprintf(@msgid)
        timestamp = DateTime.iso8601(event.sprintf(@timestamp)).rfc3339()
-       syslog_msg = "<"+priority.to_s()+">1 "+timestamp+" "+sourcehost+" "+@appname+" "+@procid+" "+@msgid+" - "+event.message
+       syslog_msg = "<"+priority.to_s()+">1 "+timestamp+" "+sourcehost+" "+appname+" "+procid+" "+msgid+" - "+event.message
     end
 
-      begin
-        connect unless @client_socket
-        @client_socket.write(syslog_msg + "\n")
-      rescue => e
-        @logger.warn(@protocol+" output exception", :host => @host, :port => @port,
-                     :exception => e, :backtrace => e.backtrace)
-        @client_socket.close
-      end
+    begin
+      connect unless @client_socket
+      @client_socket.write(syslog_msg + "\n")
+    rescue => e
+      @logger.warn(@protocol+" output exception", :host => @host, :port => @port,
+                 :exception => e, :backtrace => e.backtrace)
+      @client_socket.close
+    end
   end
 end
+


### PR DESCRIPTION
Handy if your Logstash agent is parsing from multiple application sources to send to a single syslog instance.
