### PR TITLE
Riemann now supports arbitrary key value pairs 

### DIFF
--- a/lib/logstash/outputs/riemann.rb
+++ b/lib/logstash/outputs/riemann.rb
@@ -83,11 +83,6 @@ class LogStash::Outputs::Riemann < LogStash::Outputs::Base
     r_event[:description] = event.message
     if @riemann_event
       @riemann_event.each do |key, val|
-        # Catch invalid options since hash syntax doesn't support it
-        unless ["description","state","metric","ttl", "service"].include?(key) 
-          @logger.warn("Invalid key specified in riemann_event", :key => key)
-          next
-        end
         if ["ttl","metric"].include?(key)
           r_event[key.to_sym] = event.sprintf(val).to_f
         else

--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "onstomp"                          #(Apache 2.0 license)
   gem.add_runtime_dependency "redis"                            #(MIT license)
   gem.add_runtime_dependency "riak-client", ["1.0.3"]           #(Apache 2.0 license)
-  gem.add_runtime_dependency "riemann-client", ["0.0.6"]        #(MIT license)
+  gem.add_runtime_dependency "riemann-client", ["0.2.1"]        #(MIT license)
   gem.add_runtime_dependency "statsd-ruby", ["0.3.0"]           #(MIT license)
   gem.add_runtime_dependency "uuidtools"                        # For generating amqp queue names (Apache 2.0 license)
   gem.add_runtime_dependency "xml-simple"                       #(ruby license?)


### PR DESCRIPTION
Bumped riemann client version and removed check for supported event keys
