### PR TITLE
shorten/cleanup/fix TTY-pattern

### DIFF
--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -32,9 +32,7 @@ HOSTPORT (?:%{IPORHOST=~/\./}:%{POSINT})
 PATH (?:%{UNIXPATH}|%{WINPATH})
 UNIXPATH (?>/(?>[\w_%!$@:.,-]+|\\.)*)+
 #UNIXPATH (?<![\w\/])(?:/[^\/\s?*]*)+
-LINUXTTY (?>/dev/pts/%{NONNEGINT})
-BSDTTY (?>/dev/tty[pq][a-z0-9])
-TTY (?:%{BSDTTY}|%{LINUXTTY})
+TTY (?:/dev/(pts|tty([pq])?(\w+)?)(/%{NONNEGINT})
 WINPATH (?>[A-Za-z]+:|\\)(?:\\[^\\?*]*)+
 URIPROTO [A-Za-z]+(\+[A-Za-z+]+)?
 URIHOST %{IPORHOST}(?::%{POSINT:port})?


### PR DESCRIPTION
removed BSD/Linux-specific TTYS, as there are several more TTY-names under even under linux than /dev/pts/${NONNEGINT}.
This also allows
- "/dev/ttyUSB0"
- "/dev/ttyS0"
