### PR TITLE
Add three options to elasticsearch_http.

### DIFF
--- a/lib/logstash/outputs/elasticsearch_http.rb
+++ b/lib/logstash/outputs/elasticsearch_http.rb
@@ -58,7 +58,7 @@ class LogStash::Outputs::ElasticSearchHTTP < LogStash::Outputs::Base
   # and at the end of the series of keys must be a hash/object/map.
   # If the schema changes such that @fields no longer exists, adjust
   # your document path by removing @fields.
-  config :document_path, :validate => :list, :default => []
+  config :document_path, :validate => :array, :default => []
 
   public
   def register


### PR DESCRIPTION
I've been trying to throw json blobs form redis into ElasticSearch.
ElasticSearch doesn't seem to do well with nulls or emtpy lists so I put
in options to remove those. I also wanted to be able to use a hash other
than the event as the document/record.

On branch feature/output-elasticsearch_http-deep-data-options
