### PR TITLE
Updated to work when not using a proxy.

### DIFF
--- a/lib/logstash/outputs/loggly.rb
+++ b/lib/logstash/outputs/loggly.rb
@@ -55,7 +55,7 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
   config :proxy_user, :validate => :string
 
   # Proxy Password
-  config :proxy_password, :validate => :password
+  config :proxy_password, :validate => :password, :default => ""
 
 
   public
@@ -75,7 +75,7 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
     # Send the event over http.
     url = URI.parse("#{@proto}://#{@host}/inputs/#{event.sprintf(@key)}")
     @logger.info("Loggly URL", :url => url)
-    http = Net::HTTP::Proxy(@proxy_host, @proxy_port, @proxy_user, @proxy_password.value).new(uri.host, uri.port)
+    http = Net::HTTP::Proxy(@proxy_host, @proxy_port, @proxy_user, @proxy_password.value).new(url.host, url.port)
     if url.scheme == 'https'
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE


### PR DESCRIPTION
The proxy support added does not work when you are not using a proxy. Modifications:
- updated the "proxy_password" variable to default to the empty string;
- fixed issue where the variable "uri" was referenced when it should be "url".
