### PR TITLE
Updated comment on metric parameter for graphite output

### DIFF
--- a/lib/logstash/outputs/graphite.rb
+++ b/lib/logstash/outputs/graphite.rb
@@ -31,7 +31,7 @@ class LogStash::Outputs::Graphite < LogStash::Outputs::Base
   # for metric names and also for values. This is a hash field with key 
   # of the metric name, value of the metric value. Example:
   #
-  #     [ "%{@source_host}/uptime", %{uptime_1m} " ]
+  #     [ "%{@source_host}/uptime", "%{uptime_1m}" ]
   #
   # The value will be coerced to a floating point value. Values which cannot be
   # coerced will zero (0)


### PR DESCRIPTION
Fixed comment where example metric was:

[ "%{@source_host}/uptime", %{uptime_1m} " ]

This syntax will cause an error every time. Updated to:

[ "%{@source_host}/uptime", "%{uptime_1m}" ]
