### PR TITLE
When checking status of daemon, exit with proper exit code.

### DIFF
--- a/pkg/logstash.sysv.redhat
+++ b/pkg/logstash.sysv.redhat
@@ -146,6 +146,7 @@ case "$1" in
   status)
     echo -n "$DESC"
     status -p $PID_FILE
+    exit $?
     ;;
   *)
     echo "Usage: $SCRIPTNAME {start|stop|status|restart}" >&2


### PR DESCRIPTION
Update logstash.sysv.redhat to use exit code on status check.
