### PR TITLE
Added message_format to nagios_nsca plugin

### DIFF
--- a/lib/logstash/outputs/nagios_nsca.rb
+++ b/lib/logstash/outputs/nagios_nsca.rb
@@ -51,7 +51,9 @@ class LogStash::Outputs::NagiosNsca < LogStash::Outputs::Base
   # logstash internal variables.
   config :nagios_service, :validate => :string, :default => "LOGSTASH"
 
-  # The message format to send in the alert
+  # The format to use when writing events to nagios. This value
+  # supports any string and can include %{name} and other dynamic
+  # strings.
   config :message_format, :validate => :string, :default => "%{@timestamp} %{@source}: %{@message}"
 
   public


### PR DESCRIPTION
I needed to format the data I sent to Nagios via NSCA to not include the `@message` contents.  I followed the pattern in the `pipe` output and added a new attribute.  The default value is the same format as `event.to_s` uses currently.
