### PR TITLE
update postfix queue example

### DIFF
--- a/lib/logstash/filters/grok.rb
+++ b/lib/logstash/filters/grok.rb
@@ -91,10 +91,10 @@ require "set"
 #
 #     (?<field_name>the pattern here)
 #
-# For example, postfix logs have a 'queue id' that is an 11-character
+# For example, postfix logs have a 'queue id' that is an 10 or 11-character
 # hexadecimal value. I can capture that easily like this:
 #
-#     (?<queue_id>[0-9A-F]{11})
+#     (?<queue_id>[0-9A-F]{10,11})
 #
 # Alternately, you can create a custom patterns file. 
 #
@@ -106,7 +106,7 @@ require "set"
 # For example, doing the postfix queue id example as above:
 #
 #     # in ./patterns/postfix 
-#     POSTFIX_QUEUEID [0-9A-F]{11}
+#     POSTFIX_QUEUEID [0-9A-F]{10,11}
 #
 # Then use the `patterns_dir` setting in this plugin to tell logstash where
 # your custom patterns directory is. Here's a full example with a sample log:


### PR DESCRIPTION
It looks like postfix on my machines are generating 10 character queue ids rather than the 11 in the grok example.  It appears both are legal [according to Wietse](http://tech.groups.yahoo.com/group/postfix-users/message/272316).  I get the impression from his comment less than 10 shouldn't happen, but more than 12 would be possible on disks with a very large number of inodes.
