### PR TITLE
avoid inserting duplicate tags

### DIFF
--- a/lib/logstash/event_v0.rb
+++ b/lib/logstash/event_v0.rb
@@ -117,7 +117,7 @@ module LogStash::EventV0
 
   public
   def tags; @data["@tags"]; end # def tags
-  def tags=(val); @data["@tags"] = val; end # def tags=
+  def tags=(val); @data["@tags"] = val.to_set; end # def tags=
 
   def id; @data["@id"]; end # def id
   def id=(val); @data["@id"] = val; end # def id=


### PR DESCRIPTION
there is no reason for duplicate @tags, but it did happen then i was reading json_event data from file which already had a tag set and file input added a duplicate tag
