### PR TITLE
Proposed fix for  LOGSTASH-884 and LOGSTASH-1060

### DIFF
--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -80,7 +80,11 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
       line, client = @udp.recvfrom(8192)
       # Ruby uri sucks, so don't use it.
       source = "gelf://#{client[3]}/"
-      data = Gelfd::Parser.parse(line)
+      begin
+        data = Gelfd::Parser.parse(line)
+      rescue => ex
+        @logger.warn("Gelfd failed to parse a message skipping", :exception => ex, :backtrace => ex.backtrace)
+      end
 
       # The nil guard is needed to deal with chunked messages.
       # Gelfd::Parser.parse will only return the message when all chunks are


### PR DESCRIPTION
I've made this small modification to the Gelf input (against v1.1.12). I'm running it in production now to see if my problem goes away.
I tried it in my dev environment (using the unpatched jar) sending very large gziped data which would kill the gelf listener, followed by smaller data which go nowhere since the gelf listener was dead.
I then tried it in my dev environment (using the patched jar) sending very large gzipped data which would thrown a parse exception, followed by smaller data which would continue the path through the input -> parse -> output
