### PR TITLE
Fix multiline filter filter_matched() execution logic

### DIFF
--- a/lib/logstash/filters/multiline.rb
+++ b/lib/logstash/filters/multiline.rb
@@ -217,7 +217,7 @@ class LogStash::Filters::Multiline < LogStash::Filters::Base
       @logger.warn("Unknown multiline 'what' value.", :what => @what)
     end # case @what
 
-    if !event.cancelled?
+    if match and !event.cancelled?
       filter_matched(event)
     end
   end # def filter

--- a/spec/filters/multiline.rb
+++ b/spec/filters/multiline.rb
@@ -90,4 +90,27 @@ describe LogStash::Filters::Multiline do
       end
     end
   end
+
+  describe "multiline add/remove tags and fields only when matched" do
+    config <<-CONFIG
+      filter {
+        mutate {
+          add_tag => "dummy"
+        }
+        multiline {
+          add_tag => [ "nope" ]
+          remove_tag => "dummy"
+          add_field => [ "dummy2", "value" ]
+          pattern => "an unlikely match"
+          what => previous
+        }
+      }
+    CONFIG
+
+    sample [ "120913 12:04:33 first line", "120913 12:04:33 second line" ] do
+      subject.each do |s|
+        insist { s.tags.find_index("nope").nil? && s.tags.find_index("dummy") != nil && !s.fields.has_key?("dummy2") } == true
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fix multiline filter filter_matched() execution logic
1. A multiline filter was called and had a pattern that did not match
   the event
2. If a pending event existed the current event was added to the pending
   list, the old pending event was resurrected
3. The resurrected pending event wasn't cancelled so filter_matched()
   was called even if the multiline did not, in fact, match
4. The resulting event object would have any tags added/removed and
   fields added that the non-matching multiline cared to specify
