### PR TITLE
Fix wrong content in Lucene's java service files when updating to ElasticSearch 0.90.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #   wget or curl
 #
 JRUBY_VERSION=1.7.3
-ELASTICSEARCH_VERSION=0.20.6
+ELASTICSEARCH_VERSION=0.90.0
 #VERSION=$(shell ruby -r./lib/logstash/version -e 'puts LOGSTASH_VERSION')
 VERSION=$(shell awk -F\" '/LOGSTASH_VERSION/ {print $$2}' lib/logstash/version.rb)
 
@@ -165,6 +165,8 @@ build/monolith: compile copy-ruby-files vendor/jar/graphtastic-rmiclient.jar
 	@# Unpack all the 3rdparty jars and any jars in gems
 	$(QUIET)find $$PWD/vendor/bundle $$PWD/vendor/jar -name '*.jar' \
 	| (cd $@; xargs -n1 jar xf)
+	@# Merge all service file in all 3rdparty jars
+	$(QUITE)./merge_services_files.sh $@ vendor/bundle vendor/jar
 	@# copy openssl/lib/shared folders/files to root of jar - need this for openssl to work with JRuby
 	$(QUIET)mkdir -p $@/openssl
 	$(QUIET)mkdir -p $@/jopenssl

--- a/merge_services_files.sh
+++ b/merge_services_files.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+build_jar=build/jar
+build_services=build/META-INF/services
+build_monolith=${1}
+shift
+
+mkdir -p ${build_jar}
+
+# echo "******$(pwd)"
+# echo "******${build_monolith}"
+
+# Unpack META-INF/services in jars into individual directories
+for jar in $(find "$@" -name \*.jar)
+do
+    # echo "******${jar}"
+    dir="${jar##*/}"
+    mkdir -p "${build_jar}/${dir}"
+    pushd "${build_jar}/${dir}" &>/dev/null
+    jar xf "../../../${jar}" META-INF/services
+    popd &>/dev/null
+done
+
+# Merge all files under META-INF/services in jars
+mkdir -p ${build_services}
+rm -f ${build_services}/*
+for src in $(find ${build_jar} -type f)
+do
+    dest=${src##*/}
+    if [ -e "${build_services}/${dest}" ]
+    then
+	cat "${src}" >> "${build_services}/${dest}"
+    else
+	cp "${src}" ${build_services}
+    fi
+done
+
+cp -f ${build_services}/* ${build_monolith}/META-INF/services/


### PR DESCRIPTION
Lucene 4.x and ElasticSearch 0.90.0 have some service files with naming conflicts if put them in a single jar. This patch merges java service files with naming conflicts in jar when building monolith jar.
