### PR TITLE
Update windows hack in JRUBY-6970 patch to handle case insensitive roots

### DIFF
--- a/lib/logstash/JRUBY-6970.rb
+++ b/lib/logstash/JRUBY-6970.rb
@@ -46,8 +46,8 @@ class File
             # 'expand_path' on "/" will return "C:/" on windows.
             # So like.. we don't want that because technically this
             # is the root of the jar, not of a disk.
-            puts :expand_path => [path, "#{jar}!#{resource.gsub(/^[A-Z]:/, "")}"]
-            return "#{jar}!#{resource.gsub(/^[A-Z]:/, "")}"
+            puts :expand_path => [path, "#{jar}!#{resource.gsub(/^[A-Za-z]:/, "")}"]
+            return "#{jar}!#{resource.gsub(/^[A-Za-z]:/, "")}"
           else
             return "#{jar}!#{resource}"
           end


### PR DESCRIPTION
Some windows systems return 'C:\' and some return 'c:\' for the root of the C drive.  This makes the patch work sometimes and not others.  This fixes the case sensitivity problem.
