### PR TITLE
LOGSTASH-1106 file output log rotation date fix

### DIFF
--- a/lib/logstash/outputs/file.rb
+++ b/lib/logstash/outputs/file.rb
@@ -13,6 +13,11 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
 
   # The path to the file to write. Event fields can be used here, 
   # like "/var/log/logstash/%{@source_host}/%{application}"
+  # One may also utilize the path option for date-based log 
+  # rotation via the joda time format. This will use the event
+  # timestamp.
+  # E.g.: path => "./test-%{+YYYY-MM-dd}.txt" to create 
+  # ./test-2013-05-29.txt 
   config :path, :validate => :string, :required => true
 
   # The maximum size of file to write. When the file exceeds this


### PR DESCRIPTION
Added additional documentation to path option in lib/outputs/file.rb highlighting non-documented functionality of path variable (AKA provided documentation on the use of path to provide date-based log rotation). 
