### PR TITLE
Enhance stomp input/output with an optional vhost param.

### DIFF
--- a/lib/logstash/inputs/stomp.rb
+++ b/lib/logstash/inputs/stomp.rb
@@ -23,6 +23,9 @@ class LogStash::Inputs::Stomp < LogStash::Inputs::Base
   # Example: "/topic/logstash"
   config :destination, :validate => :string, :required => true
 
+  # The vhost to use
+  config :vhost, :validate => :string, :default => nil
+
   # Enable debugging output?
   config :debug, :validate => :boolean, :default => false
 
@@ -42,8 +45,9 @@ class LogStash::Inputs::Stomp < LogStash::Inputs::Base
   def register
     require "onstomp"
     @client = OnStomp::Client.new("stomp://#{@host}:#{@port}", :login => @user, :passcode => @password.value)
+    @client.host = @vhost if @vhost
     @stomp_url = "stomp://#{@user}:#{@password}@#{@host}:#{@port}/#{@destination}"
-    
+
     # Handle disconnects 
     @client.on_connection_closed {
       connect

--- a/lib/logstash/outputs/stomp.rb
+++ b/lib/logstash/outputs/stomp.rb
@@ -23,6 +23,9 @@ class LogStash::Outputs::Stomp < LogStash::Outputs::Base
   # Example: "/topic/logstash"
   config :destination, :validate => :string, :required => true
 
+  # The vhost to use
+  config :vhost, :validate => :string, :default => nil
+
   # Enable debugging output?
   config :debug, :validate => :boolean, :default => false
 
@@ -44,6 +47,7 @@ class LogStash::Outputs::Stomp < LogStash::Outputs::Base
   def register
     require "onstomp"
     @client = OnStomp::Client.new("stomp://#{@host}:#{@port}", :login => @user, :passcode => @password.value)
+    @client.host = @vhost if @vhost
 
     # Handle disconnects
     @client.on_connection_closed {


### PR DESCRIPTION
Currently the STOMP plugins don't allow overriding the Host: parameter which causes problems when trying to connect to a RabbitMQ broker over STOMP as the default vhost is /.

This pull request gives both STOMP plugins an optional vhost parameter (nil by default so it shouldn't affect any existing setups).
