### PR TITLE
Add optional target field for geoip filter

### DIFF
--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -36,6 +36,11 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
   # dma_code, ip, latitude, longitude, postal_code, region_name, timezone
   config :fields, :validate => :array
 
+  # Specify into what field you want the geoip data.
+  # This can be useful for example if you have a src_ip and dst_ip and want
+  # information of both IP's
+  config :target, :validate => :string, :default => 'geoip'
+
   public
   def register
     require "geoip"
@@ -96,17 +101,17 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
 
     geo_data_hash = geo_data.to_hash
     geo_data_hash.delete(:request)
-    event["geoip"] = {} if event["geoip"].nil?
+    event[@target] = {} if event[@target].nil?
     geo_data_hash.each do |key, value|
       if @fields.nil? || @fields.empty?
         # no fields requested, so add all geoip hash items to
         # the event's fields.
         # convert key to string (normally a Symbol)
-        event["geoip"][key.to_s] = value
+        event[@target][key.to_s] = value
       elsif @fields.include?(key.to_s)
         # Check if the key is in our fields array
         # convert key to string (normally a Symbol)
-        event["geoip"][key.to_s] = value
+        event[@target][key.to_s] = value
       end
     end # geo_data_hash.each
     filter_matched(event)

--- a/spec/filters/geoip.rb
+++ b/spec/filters/geoip.rb
@@ -29,4 +29,33 @@ describe LogStash::Filters::GeoIP do
       reject { subject }.include?("geoip")
     end
   end
+
+  describe "Specify the target" do
+    config <<-CONFIG
+      filter {
+        geoip { 
+          source => "ip"
+          database => "vendor/geoip/GeoLiteCity.dat"
+          target => src_ip
+        }
+      }
+    CONFIG
+
+    sample({ "@fields" => { "ip" => "8.8.8.8" } }) do
+      insist { subject }.include?("src_ip")
+
+      expected_fields = %w(ip country_code2 country_code3 country_name
+                           continent_code region_name city_name postal_code
+                           latitude longitude dma_code area_code timezone)
+      expected_fields.each do |f|
+        insist { subject["src_ip"] }.include?(f)
+      end
+    end
+
+    sample({ "@fields" => { "ip" => "127.0.0.1" } }) do
+      # assume geoip fails on localhost lookups
+      reject { subject }.include?("src_ip")
+    end
+  end
+
 end


### PR DESCRIPTION
For cases that a user wants to process 2 ip/host fields ( src_ip, dst_ip for example ) for 1 event.
