### PR TITLE
base output ignore old events config option

### DIFF
--- a/lib/logstash/outputs/base.rb
+++ b/lib/logstash/outputs/base.rb
@@ -45,6 +45,9 @@ class LogStash::Outputs::Base < LogStash::Plugin
   # be handled. Defaults to all.
   config :exclude_any, :validate => :boolean, :default => true
 
+  # Don't send events that have @timestamp older than specified number of seconds.
+  config :ignore_older_than, :validate => :number, :default => 0
+
   public
   def initialize(params)
     super
@@ -114,6 +117,11 @@ class LogStash::Outputs::Base < LogStash::Plugin
         @logger.debug? and @logger.debug(["Dropping event because fields contain excluded fields #{@exclude_fields.inspect}", event])
         return false
       end
+    end
+
+    if @ignore_older_than > 0 && Time.now - event.ruby_timestamp > @ignore_older_than
+      @logger.debug? and @logger.debug("Skipping metriks for old event", :event => event)
+      return
     end
 
     return true

--- a/lib/logstash/outputs/statsd.rb
+++ b/lib/logstash/outputs/statsd.rb
@@ -61,9 +61,6 @@ class LogStash::Outputs::Statsd < LogStash::Outputs::Base
   # Enable debugging output?
   config :debug, :validate => :boolean, :default => false
 
-  # Don't send events that have @timestamp older than specified number of seconds.
-  config :ignore_older_than, :validate => :number, :default => 0
-
   public
   def register
     require "statsd"
@@ -73,12 +70,6 @@ class LogStash::Outputs::Statsd < LogStash::Outputs::Base
   public
   def receive(event)
     return unless output?(event)
-
-    # TODO(piavlo): This should probably move to base output plugin?
-    if @ignore_older_than > 0 && Time.now - event.ruby_timestamp > @ignore_older_than
-      @logger.debug? and @logger.debug("Skipping metriks for old event", :event => event)
-      return
-    end
 
     @client.namespace = event.sprintf(@namespace) if not @namespace.empty?
     @logger.debug? and @logger.debug("Original sender: #{@sender}")


### PR DESCRIPTION
move ignore_older_than from statsd to base output plugin
i think this is a generic option that is useful in all outputs that might require sending only realtime metrics/events
