### PR TITLE
Eventlog input timestamp fix and a few other minor fixes.

### DIFF
--- a/lib/logstash/inputs/eventlog.rb
+++ b/lib/logstash/inputs/eventlog.rb
@@ -36,6 +36,7 @@ class LogStash::Inputs::EventLog < LogStash::Inputs::Base
     @logger.info("Registering input eventlog://#{@hostname}/#{@logfile}")
 
     if RUBY_PLATFORM == "java"
+      require "logstash/inputs/eventlog/racob_fix"
       require "jruby-win32ole"
     else
       require "win32ole"
@@ -57,8 +58,7 @@ class LogStash::Inputs::EventLog < LogStash::Inputs::Base
         notification = events.NextEvent
         event = notification.TargetInstance
 
-        timestamp = DateTime.strptime(event.TimeGenerated, "%Y%m%d%H%M%S").iso8601
-        timestamp[19..-1] = DateTime.now.iso8601[19..-1] # Copy over the correct TZ offset
+        timestamp = to_timestamp(event.TimeGenerated)
 
         e = LogStash::Event.new({
             "@source" => "eventlog://#{@hostname}/#{@logfile}",
@@ -105,5 +105,26 @@ class LogStash::Inputs::EventLog < LogStash::Inputs::Base
     variants.map {|v| (v.respond_to? :getValue) ? v.getValue : v}
   end # def unwrap_racob_variant_array
 
+  # the event log timestamp is a utc string in the following format: yyyymmddHHMMSS.xxxxxx±UUU
+  # http://technet.microsoft.com/en-us/library/ee198928.aspx
+  private
+  def to_timestamp(wmi_time)
+    result = ""
+    # parse the utc date string
+    /(?<w_date>\d{8})(?<w_time>\d{6})\.\d{6}(?<w_sign>[+-])(?<w_diff>\d{3})/ =~ wmi_time
+    result = "#{w_date}T#{w_time}#{w_sign}"
+    # the offset is represented by the difference, in minutes, 
+    # between the local time zone and Greenwich Mean Time (GMT).
+    if w_diff.to_i > 0
+      # calculate the timezone offset in hours and minutes
+      h_offset = w_diff.to_i / 60
+      m_offset = w_diff.to_i - (h_offset * 60)
+      result.concat("%02d%02d" % [h_offset, m_offset])
+    else
+      result.concat("0000")
+    end
+  
+    return DateTime.strptime(result, "%Y%m%dT%H%M%S%z").iso8601
+  end
 end # class LogStash::Inputs::EventLog
 

--- a/lib/logstash/inputs/wmi.rb
+++ b/lib/logstash/inputs/wmi.rb
@@ -16,6 +16,7 @@ require "socket"
 #       }
 #       wmi {
 #         query => "select PercentProcessorTime from Win32_PerfFormattedData_PerfOS_Processor where name = '_Total'"
+#       }
 #     }
 class LogStash::Inputs::WMI < LogStash::Inputs::Base
 


### PR DESCRIPTION
Added missing racob_fix hack which was removed in last commit.
Fixing eventlog timestamp format as it was not setting the offset properly.
For example, a WMI timestamp of 20130612195854.000000-000 was being set to 2013-06-12T19:58:54-07:00 where it really should be 2013-06-12T19:58:54-00:00 since there was no offset (-000) in the timestamp.  The new logic takes the offset provided by the timestamp and handles it as necessary rather than just adding the offset of the current timezone.
Fixing typo in wmi input.
