### PR TITLE
Add support for case-insensitive patterns with grep filter.

### DIFF
--- a/lib/logstash/filters/grep.rb
+++ b/lib/logstash/filters/grep.rb
@@ -41,6 +41,11 @@ class LogStash::Filters::Grep < LogStash::Filters::Base
   # a regular expression.
   config :match, :validate => :hash, :default => {}
 
+  # Use case-insensitive matching. Similar to 'grep -i'
+  #
+  # If enabled, ignore case distinctions in the patterns.
+  config :ignore_case, :validate => :boolean, :default => false
+
   public
   def register
     @patterns = Hash.new { |h,k| h[k] = [] }
@@ -50,7 +55,7 @@ class LogStash::Filters::Grep < LogStash::Filters::Base
 
       pattern = [pattern] if pattern.is_a?(String)
       pattern.each do |p|
-        re = Regexp.new(p)
+        re = Regexp.new(p, @ignore_case ? Regexp::IGNORECASE : 0)
         @patterns[field] << re
         @logger.debug? and @logger.debug("Registered grep", :type => @type, :field => field,
                     :pattern => p, :regexp => re)

--- a/spec/filters/grep.rb
+++ b/spec/filters/grep.rb
@@ -324,4 +324,19 @@ describe LogStash::Filters::Grep do
       reject { subject }.nil?
     end
   end
+
+  describe "case-insensitive matching" do
+    config <<-CONFIG
+      filter {
+        grep {
+          ignore_case => true
+          match => [ "str", "test" ]
+        }
+      }
+    CONFIG
+
+    sample("str" => "tEsT: this should still be matched") do
+      reject { subject }.nil?
+    end
+  end
 end


### PR DESCRIPTION
I ran into a case where case-insensitivity would be very convenient with `grep`. It adds an `ignore_case` setting. See the updated `spec/filters/grep.rb`.

I'd appreciate feedback if you have better alternatives or suggestions. Thank you for your time!
