### PR TITLE
Bugfix for rabbitmq input

### DIFF
--- a/lib/logstash/inputs/rabbitmq.rb
+++ b/lib/logstash/inputs/rabbitmq.rb
@@ -83,7 +83,7 @@ class LogStash::Inputs::RabbitMQ < LogStash::Inputs::Threadable
     super
 
     @format ||= "json_event"
-    @codec = "json"
+
   end # def initialize
 
   public


### PR DESCRIPTION
Got this error in the rabbitmq plugin:

Error: undefined method `decode' for \"json\":String"

Removing the instance variable declaration for codec fixed it.
