### PR TITLE
Metrics: fix for [LOGSTASH-1171]

### DIFF
--- a/lib/logstash/filters/metrics.rb
+++ b/lib/logstash/filters/metrics.rb
@@ -125,7 +125,7 @@ class LogStash::Filters::Metrics < LogStash::Filters::Base
     @metrics_timers_mutex = Mutex.new
 
     @metric_meters = Hash.new { |h,k| @metrics_meters_mutex.synchronize { h[k] = Metriks.meter(k) } }
-    @metric_timers = Hash.new { |h,k| @metrics_times_mutex.synchronize { h[k] = Metriks.timer(k) } }
+    @metric_timers = Hash.new { |h,k| @metrics_timers_mutex.synchronize { h[k] = Metriks.timer(k) } }
   end # def register
 
   def filter(event)


### PR DESCRIPTION
The metrics filter spawns these kind of exceptions:

```
Exception during filter {:event=>#<LogStash::Event:0x7b25ba81 @data={"@source"=>"generator://0.0.0.0/", "@tags"=>[], "@fields"=>{"sequence"=>953293}, "@timestamp"=>"2013-06-22T13:27:41.333Z", "@source_host"=>"0.0.0.0", "@source_path"=>"/", "@message"=>"Hello world!", "@type"=>"foo"}, @cancelled=false>, :exception=>#<RuntimeError: can't add a new key into hash during iteration>, :backtrace=>["org/jruby/RubyHash.java:954:in `[]='", "file:/home/decausma/playground/logstash/metrics_race/logstash-1.1.13-flatjar.jar!/logstash/filters/metrics.rb:124:in `register'", "org/jruby/RubyProc.java:249:in `call'", "org/jruby/RubyHash.java:681:in `default'", "org/jruby/RubyHash.java:1070:in `[]'", "file:/home/decausma/playground/logstash/metrics_race/logstash-1.1.13-flatjar.jar!/logstash/filters/metrics.rb:137:in `filter'", "org/jruby/RubyArray.java:1613:in `each'", "file:/home/decausma/playground/logstash/metrics_race/logstash-1.1.13-flatjar.jar!/logstash/filters/metrics.rb:136:in `filter'", "file:/home/decausma/playground/logstash/metrics_race/logstash-1.1.13-flatjar.jar!/logstash/filters/base.rb:89:in `execute'", "file:/home/decausma/playground/logstash/metrics_race/logstash-1.1.13-flatjar.jar!/logstash/filterworker.rb:98:in `filter'", "file:/home/decausma/playground/logstash/metrics_race/logstash-1.1.13-flatjar.jar!/logstash/filterworker.rb:96:in `filter'", "org/jruby/RubyArray.java:1613:in `each'", "file:/home/decausma/playground/logstash/metrics_race/logstash-1.1.13-flatjar.jar!/logstash/filterworker.rb:88:in `filter'", "org/jruby/RubyArray.java:1613:in `each'", "file:/home/decausma/playground/logstash/metrics_race/logstash-1.1.13-flatjar.jar!/logstash/filterworker.rb:87:in `filter'", "file:/home/decausma/playground/logstash/metrics_race/logstash-1.1.13-flatjar.jar!/logstash/filterworker.rb:46:in `run'", "file:/home/decausma/playground/logstash/metrics_race/logstash-1.1.13-flatjar.jar!/logstash/agent.rb:785:in `run_filter'", "file:/home/decausma/playground/logstash/metrics_race/logstash-1.1.13-flatjar.jar!/logstash/agent.rb:492:in `run_with_config'"], :filter=><LogStash::Filters::Metrics type=>"foo", meter=>["test.%{@timestamp}"], add_tag=>["metric"]>, :level=>:warn}
```

This happens when new keys are added to the metrics hashes while iterating over them (in another thread).

This puil request synchronizes the parts where new keys are added to the metrics hashes and the parts where the hashes are iterated.
