### PR TITLE
Addition: statsd output plugin gauge metric type

### DIFF
--- a/lib/logstash/outputs/statsd.rb
+++ b/lib/logstash/outputs/statsd.rb
@@ -93,6 +93,10 @@ class LogStash::Outputs::Statsd < LogStash::Outputs::Base
       @client.timing(build_stat(event.sprintf(metric), sender),
                      event.sprintf(val).to_f, @sample_rate)
     end
+  @gauge.each do |metric, val|
+      @client.gauge(build_stat(event.sprintf(metric), sender),
+                    event.sprintf(val).to_f, @sample_rate)
+    end
   end # def receive
 
   def build_stat(metric, sender=@sender)


### PR DESCRIPTION
This pull request should provide the ability to use the gauge metric type with the statsd output plugin.
