### PR TITLE
jruby version to match what's in Makefile

### DIFF
--- a/bin/logstash
+++ b/bin/logstash
@@ -15,7 +15,7 @@ if [ "$?" -eq 0 -a -z "$USE_JRUBY" ] ; then
   exec ruby "$basedir/lib/logstash/runner.rb" "$@"
 else
   # No ruby found, fetch JRuby and run.
-  jruby="vendor/jar/jruby-complete-1.7.3.jar"
+  jruby="vendor/jar/jruby-complete-1.7.4.jar"
   [ ! -f "$jruby" ] && make build-jruby
   exec java -jar "$jruby" "$basedir/lib/logstash/runner.rb" "$@"
 fi


### PR DESCRIPTION
`Makefile` calls for `jruby` version `1.7.4`,  fixing `bin/logstash` to use the same version.

should probably variabalize it,   or use a grep/awk or some shit to make sure it always matches Makefile version ..  but this at least will get it working again.
