### PR TITLE
Fix exceptions from irc input due to server messages

### DIFF
--- a/lib/logstash/inputs/irc.rb
+++ b/lib/logstash/inputs/irc.rb
@@ -72,10 +72,12 @@ class LogStash::Inputs::Irc < LogStash::Inputs::Base
     end
     loop do
       msg = @irc_queue.pop
-      event = self.to_event(msg.message, "irc://#{@host}:#{@port}/#{msg.channel}")
-      event["channel"] = msg.channel
-      event["nick"] = msg.user.nick
-      output_queue << event
+      if msg.user
+        event = self.to_event(msg.message, "irc://#{@host}:#{@port}/#{msg.channel}")
+        event["channel"] = msg.channel
+        event["nick"] = msg.user.nick
+        output_queue << event
+      end
     end
   end # def run
 end # class LogStash::Inputs::Irc


### PR DESCRIPTION
Not all irc messages have a user / nickname

Blows up with:

Restarting input due to exception {:plugin=><LogStash::Inputs::Irc
    nick=>"logstash_fr", channels=>["#fr"], charset=>"UTF-8",
        host=>"localhost", type=>"irc", user=>"logstash",
        real=>"logstash">, :level=>:error}
        Input thread exception {:plugin=><LogStash::Inputs::Irc
            nick=>"logstash_infra", channels=>["#infra"],
                charset=>"UTF-8", host=>"localhost", type=>"irc",
                user=>"logstash", real=>"logstash">,
                :exception=>#<NoMethodError: undefined method `nick' for
                    nil:NilClass>,
                :backtrace=>["file:/opt/logstash-monolithic.jar!/logstash/inputs/irc.rb:77:in
                    `run'", "org/jruby/RubyKernel.java:1409:in`loop'",
                "file:/opt/logstash-monolithic.jar!/logstash/inputs/irc.rb:73:in
                    `run'",
                "file:/opt/logstash-monolithic.jar!/logstash/agent.rb:761:in
`run_input'",
                "file:/opt/logstash-monolithic.jar!/logstash/agent.rb:407:in
                    `start_input'"], :level=>:warn}
