### PR TITLE
Fix invalid encoding conversion of event in INPUTS

### DIFF
--- a/lib/logstash/inputs/base.rb
+++ b/lib/logstash/inputs/base.rb
@@ -88,8 +88,7 @@ class LogStash::Inputs::Base < LogStash::Plugin
 
     case @format
     when "plain"
-      raw.force_encoding(@charset)
-      if @charset != "UTF-8"
+      if raw.encoding.name != "UTF-8"
         # Convert to UTF-8 if not in that character set.
         raw = raw.encode("UTF-8", :invalid => :replace, :undef => :replace)
       end


### PR DESCRIPTION
String::force_encoding only changes strings' encoding property, but not do conversion of bytes in String.

Use String::encoding property to convert encoding of message without config option @charset.
