### PR TITLE
Add S3 input

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -214,14 +214,14 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
   def process_line(queue, metadata, line)
 
     if /#Version: .+/.match(line)
-      junk, version = line.split(/#Version: .+/)
+      junk, version = line.strip().split(/#Version: (.+)/)
       unless version.nil?
-        metadata[:version] = version.strip()
+        metadata[:version] = version
       end
     elsif /#Fields: .+/.match(line)
-      junk, format = line.split(/#Fields: .+/)
+      junk, format = line.strip().split(/#Fields: (.+)/)
       unless format.nil?
-        metadata[:format] = format.strip()
+        metadata[:format] = format
       end
     else
       @codec.decode(line) do |event|
@@ -239,7 +239,6 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
 
   end # def process_line
 
-
   private
   def sincedb_read()
 
@@ -251,7 +250,6 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     return since
 
   end # def sincedb_read
-
 
   private
   def sincedb_write(since=nil)


### PR DESCRIPTION
This input polls a S3 bucket, downloads new files from it (based on the Last Modified date compared to the one of the last file processed), then emits lines as events (except for two special cases that I plan to use in a filter for CloudFront log handling).
