### PR TITLE
Coerce timestamp to DateTime in Logstash::Event#to_s

### DIFF
--- a/lib/logstash/event.rb
+++ b/lib/logstash/event.rb
@@ -92,7 +92,7 @@ class LogStash::Event
   else
     public
     def to_s
-      return self.sprintf("#{self["@timestamp"].iso8601} %{source} %{message}")
+      return self.sprintf("#{self["@timestamp"].to_datetime.iso8601} %{source} %{message}")
     end # def to_s
   end
 


### PR DESCRIPTION
`#iso8601` is only available on `DateTime` instances.
This leads the agent crash when `--debug` is used because somehow
`@timestamp` key value ends up being a `Time` instance.

When `DateTime` is loaded, both `DateTime` and `Time` provide `#to_dattime` so this solution is safe.
