### PR TITLE
Imap input mark read

### DIFF
--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -54,7 +54,7 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
     # EOFError, OpenSSL::SSL::SSLError
     imap = connect
     imap.select("INBOX")
-    ids = imap.search("ALL")
+    ids = imap.search("NOT SEEN")
 
     ids.each_slice(@fetch_count) do |id_set|
       items = imap.fetch(id_set, "RFC822")
@@ -62,6 +62,7 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
         mail = Mail.read_from_string(item.attr["RFC822"])
         queue << mail_to_event(mail)
       end
+      imap.store(id_set, '+FLAGS', :Seen)
     end
 
     imap.close


### PR DESCRIPTION
This "fixes" https://twitter.com/rafschmid/status/353144884225523712 .

I had to add `require "stud/interval"` otherwhise it could not start:

```
bin/logstash agent -e 'input { imap { type => mail  host => "mail.example.org" user => "raftest@example.org" password => pass123 } }'

Using milestone 1 input plugin 'imap'. This plugin should work, but would benefit from use by folks like you. Please let us know if you find bugs or have suggestions on how to improve this plugin.  For more information on plugin milestones, see http://logstash.net/docs/1.2.0.dev/plugin-milestones {:level=>:warn}
A plugin had an unrecoverable error. Will restart this plugin.
  Plugin: <LogStash::Inputs::IMAP type=>"mail", host=>"mail.nine.ch", user=>"raftest@nine.ch", charset=>"UTF-8">
  Error: undefined method `interval' for Stud:Module {:level=>:error}
A plugin had an unrecoverable error. Will restart this plugin.
  Plugin: <LogStash::Inputs::IMAP type=>"mail", host=>"mail.nine.ch", user=>"raftest@nine.ch", charset=>"UTF-8">
  Error: undefined method `interval' for Stud:Module {:level=>:error}
```
