### PR TITLE
Sleep filter throws exception when using replay option

### DIFF
--- a/lib/logstash/filters/sleep.rb
+++ b/lib/logstash/filters/sleep.rb
@@ -92,7 +92,7 @@ class LogStash::Filters::Sleep < LogStash::Filters::Base
       if @last_clock
         delay = clock - @last_clock
         time = delay/time
-        if sleeptime > 0
+        if time > 0
           @logger.debug? && @logger.debug("Sleeping", :delay => time)
           sleep(time)
         end


### PR DESCRIPTION
wrong variable name leads to exceptions when using the sleep filter with
replay option
