### PR TITLE
Make AWS plugins use Cabin logger

### DIFF
--- a/lib/logstash/plugin_mixins/aws_config.rb
+++ b/lib/logstash/plugin_mixins/aws_config.rb
@@ -2,8 +2,7 @@ require "logstash/config/mixin"
 
 module LogStash::PluginMixins::AwsConfig
 
-  @logger = LogStash::Logger.new(STDOUT)
-  @logger.level = $DEBUG ? :debug : :warn
+  @logger = Cabin::Channel.get(LogStash)
 
   # This method is called when someone includes this module
   def self.included(base)


### PR DESCRIPTION
As per [LOGSTASH-238](https://logstash.jira.com/browse/LOGSTASH-238), everything should be logged using Cabin.

I'm not sure if the logger even needs to be configured in this mixin. I don't think so, because it's already done in `plugin.rb`.
