### PR TITLE
[rabbitmq] Use Bunny 0.9.1+

### DIFF
--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -88,7 +88,7 @@ Gem::Specification.new do |gem|
   end
 
   if RUBY_PLATFORM != 'java'
-    gem.add_runtime_dependency "bunny",       ["~> 0.9.0.rc2"]  #(MIT license)
+    gem.add_runtime_dependency "bunny",       ["~> 0.9.1"]  #(MIT license)
   else
     gem.add_runtime_dependency "hot_bunnies", ["~> 2.0.0.pre8"] #(MIT license)
   end


### PR DESCRIPTION
Nothing major in `0.9.1` but I'd like Logstash to keep up with recent releases.
