### PR TITLE
add user so it doesn't always use the default

### DIFF
--- a/lib/logstash/inputs/rabbitmq/hot_bunnies.rb
+++ b/lib/logstash/inputs/rabbitmq/hot_bunnies.rb
@@ -13,7 +13,8 @@ class LogStash::Inputs::RabbitMQ
       @settings = {
         :vhost => @vhost,
         :host  => @host,
-        :port  => @port
+        :port  => @port,
+        :user  => @user
       }
       @settings[:pass]      = @password.value if @password
       @settings[:tls]       = @ssl if @ssl

--- a/lib/logstash/outputs/rabbitmq/hot_bunnies.rb
+++ b/lib/logstash/outputs/rabbitmq/hot_bunnies.rb
@@ -87,7 +87,8 @@ class LogStash::Outputs::RabbitMQ
       @settings = {
         :vhost => @vhost,
         :host  => @host,
-        :port  => @port
+        :port  => @port,
+        :user  => @user
       }
       @settings[:pass]      = if @password
                                 @password.value


### PR DESCRIPTION
Fix for the following bug;

@4000000051e5251b21a6b924 {:timestamp=>"2013-07-16T05:48:49.563000-0500", :message=>"RabbitMQ connection error: RabbitMQ closed TCP connection before authentication succeeded: this usually means authentication failure due to misconfiguration or that RabbitMQ version does not support AMQP 0.9.1. Please check your configuration. Username: guest, vhost: logstash-vhost, password length: 28. Will attempt to reconnect in 10 seconds...", :exception=>#<HotBunnies::PossibleAuthenticationFailureError: RabbitMQ closed TCP connection before authentication succeeded: this usually means authentication failure due to misconfiguration or that RabbitMQ version does not support AMQP 0.9.1. Please check your configuration. Username: guest, vhost: logstash-vhost, password length: 28>, :backtrace=>["file:/data/logstash-shipper0/download/logstash-1.2.0.dev-flatjar.jar!/hot_bunnies/session.rb:254:in `converting_rjc_exceptions_to_ruby'", "file:/data/logstash-shipper0/download/logstash-1.2.0.dev-flatjar.jar!/hot_bunnies/session.rb:248:in`converting_rjc_exceptions_to_ruby'", "file:/data/logstash-shipper0/download/logstash-1.2.0.dev-flatjar.jar!/hot_bunnies/session.rb:260:in `new_connection'", "file:/data/logstash-shipper0/download/logstash-1.2.0.dev-flatjar.jar!/hot_bunnies/session.rb:81:in`initialize'", "org/jruby/RubyProc.java:255:in `call'", "file:/data/logstash-shipper0/download/logstash-1.2.0.dev-flatjar.jar!/hot_bunnies/session.rb:248:in`converting_rjc_exceptions_to_ruby'", "file:/data/logstash-shipper0/download/logstash-1.2.0.dev-flatjar.jar!/hot_bunnies/session.rb:80:in `initialize'", "file:/data/logstash-shipper0/download/logstash-1.2.0.dev-flatjar.jar!/hot_bunnies/session.rb:68:in`connect'", "file:/data/logstash-shipper0/download/logstash-1.2.0.dev-flatjar.jar!/hot_bunnies.rb:21:in `connect'", "file:/data/logstash-shipper0/download/logstash-1.2.0.dev-flatjar.jar!/logstash/outputs/rabbitmq/hot_bunnies.rb:107:in`connect'", "file:/data/logstash-shipper0/download/logstash-1.2.0.dev-flatjar.jar!/logstash/outputs/rabbitmq/hot_bunnies.rb:17:in `register'", "org/jruby/RubyArray.java:1617:in`each'", "file:/data/logstash-shipper0/download/logstash-1.2.0.dev-flatjar.jar!/logstash/pipeline.rb:186:in `outputworker'", "file:/data/logstash-shipper0/download/logstash-1.2.0.dev-flatjar.jar!/logstash/pipeline.rb:130:in`start_outputs'"], :level=>:error}
