### PR TITLE
Small fix for logstash/event.rb's sprintf method.

### DIFF
--- a/lib/logstash/event.rb
+++ b/lib/logstash/event.rb
@@ -201,6 +201,7 @@ class LogStash::Event
   # is an array (or hash?) should be. Join by comma? Something else?
   public
   def sprintf(format)
+    format = format.to_s
     if format.index("%").nil?
       return format
     end

--- a/spec/event.rb
+++ b/spec/event.rb
@@ -45,6 +45,10 @@ describe LogStash::Event do
       insist { subject.sprintf("%{[j][k1]}") } == "v"
       insist { subject.sprintf("%{[j][k2][0]}") } == "w"
     end
+
+    it "should be able to take a non-string for the format" do
+      insist { subject.sprintf(2) } == "2"
+    end
   end
   
   context "#[]" do


### PR DESCRIPTION
I found this with the riemann output - if you set it up with:
riemann_event => [ 'metric', 0 ]

Then the value gets sprintf'd, which utterly fails in this unquoted case, as 0
is a Fixnum, which doesn't have an index method.

This, we explicitly call .to_s in the sprintf method, to ensure that the
format is a string before call .index on it
