### PR TITLE
removes doubled :host parameter

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -32,9 +32,6 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   config_name "elasticsearch"
   milestone 3
 
-  # ElasticSearch server name. This is optional if your server is discoverable.
-  config :host, :validate => :string
-
   # The index to write events to. This can be dynamic using the %{foo} syntax.
   # The default value will partition your indices by day so you can more easily
   # delete old data or only search specific date ranges.


### PR DESCRIPTION
I got confused when I saw the two :host parameters and had to check out are they the same or there is any difference between them. It seems they are the same, are they?
