### PR TITLE
[rabbitmq] Make Bunny and HotBunnies recovery in the output consistent

### DIFF
--- a/lib/logstash/outputs/rabbitmq/bunny.rb
+++ b/lib/logstash/outputs/rabbitmq/bunny.rb
@@ -45,6 +45,8 @@ class LogStash::Outputs::RabbitMQ
         return if terminating?
 
         sleep n
+        connect
+        declare_exchange
         retry
       end
     end

--- a/lib/logstash/outputs/rabbitmq/hot_bunnies.rb
+++ b/lib/logstash/outputs/rabbitmq/hot_bunnies.rb
@@ -56,6 +56,7 @@ class LogStash::Outputs::RabbitMQ
 
         connect
         declare_exchange
+        retry
       end
     end
 


### PR DESCRIPTION
This fixes RabbitMQ output connection recovery on CRuby. The same fix is already applied in the `1.1.x` backport submitted earlier today.
