### PR TITLE
LOGSTASH-1066 - refactor Windows jar path wrangling into its own method

### DIFF
--- a/lib/logstash/JRUBY-6970.rb
+++ b/lib/logstash/JRUBY-6970.rb
@@ -41,16 +41,7 @@ class File
           return expand_path_JRUBY_6970(path, dir)
         else
           resource = expand_path_JRUBY_6970(resource, dir)
-          # TODO(sissel): use LogStash::Util::UNAME
-          if RbConfig::CONFIG["host_os"] == "mswin32"
-            # 'expand_path' on "/" will return "C:/" on windows.
-            # So like.. we don't want that because technically this
-            # is the root of the jar, not of a disk.
-            puts :expand_path => [path, "#{jar}!#{resource.gsub(/^[A-Za-z]:/, "")}"]
-            return "#{jar}!#{resource.gsub(/^[A-Za-z]:/, "")}"
-          else
-            return "#{jar}!#{resource}"
-          end
+          return fix_jar_path(jar, resource)
         end
       elsif dir =~ /(jar:)?file:\/.*\.jar!/
         jar, dir = dir.split("!", 2)
@@ -58,11 +49,26 @@ class File
           # sometimes the original dir is just 'file:/foo.jar!'
           return File.join("#{jar}!", path) 
         end
-        return "#{jar}!#{expand_path_JRUBY_6970(path, dir)}"
+        dir = expand_path_JRUBY_6970(path, dir)
+		return fix_jar_path(jar, dir)
       else
         return expand_path_JRUBY_6970(path, dir)
       end
     end
   end
+  
+  protected
+  
+  def self.fix_jar_path(jar, resource)
+    # TODO(sissel): use LogStash::Util::UNAME
+    if RbConfig::CONFIG["host_os"] == "mswin32"
+      # 'expand_path' on "/" will return "C:/" on windows.
+      # So like.. we don't want that because technically this
+      # is the root of the jar, not of a disk.
+      puts :expand_path => [path, "#{jar}!#{resource.gsub(/^[A-Za-z]:/, "")}"]
+      return "#{jar}!#{resource.gsub(/^[A-Za-z]:/, "")}"
+    else
+      return "#{jar}!#{resource}"
+    end
+  end
 end
-


### PR DESCRIPTION
I ran into LOGSTASH-1066 when trying to use the elasticsearch_http output on Windows - looks like the fix is to use the regexp on the path in both the "dir" branch and "jar" branch of expand_path in JRUBY-6970.rb, so I refactored the regexp code into its own protected method and called it from both places.

I did test runs on both Windows and Ubuntu with my logstash config and my change appears to work in both environments.
