### PR TITLE
Enable the LogStash dashboard when we vendora Kibana

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -364,3 +364,4 @@ package:
 vendor/kibana: | build
 	$(QUIET)mkdir vendor/kibana || true
 	$(DOWNLOAD_COMMAND) - $(KIBANA_URL) | tar -C $@ -zx --strip-components=1
+	$(QUIET)mv vendor/kibana/dashboards/logstash.json vendor/kibana/dashboards/default.json


### PR DESCRIPTION
This enables the LogStash dashboard for Kibana when it gets vendored in.
