### PR TITLE
- add lonlat field to geoip filter

### DIFF
--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -34,6 +34,9 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
   # For the built in GeoLiteCity database, the following are available:
   # city\_name, continent\_code, country\_code2, country\_code3, country\_name,
   # dma\_code, ip, latitude, longitude, postal\_code, region\_name, timezone
+  #
+  # The lonlat field is manually added to ease integration with
+  # GeoJSON apps, like Kibana3's bettermap panel.
   config :fields, :validate => :array
 
   # Specify into what field you want the geoip data.
@@ -104,6 +107,7 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
     geo_data_hash = geo_data.to_hash
     geo_data_hash.delete(:request)
     event[@target] = {} if event[@target].nil?
+    geo_data_hash[:lonlat] = [geo_data[:longitude], geo_data[:latitude]]
     geo_data_hash.each do |key, value|
       if @fields.nil? || @fields.empty?
         # no fields requested, so add all geoip hash items to

--- a/spec/filters/geoip.rb
+++ b/spec/filters/geoip.rb
@@ -18,7 +18,7 @@ describe LogStash::Filters::GeoIP do
 
       expected_fields = %w(ip country_code2 country_code3 country_name
                            continent_code region_name city_name postal_code
-                           latitude longitude dma_code area_code timezone)
+                           latitude longitude lonlat dma_code area_code timezone)
       expected_fields.each do |f|
         insist { subject["geoip"] }.include?(f)
       end


### PR DESCRIPTION
Duplicate longitude and latitude into a GeoJSON-friendly `lonlat` field.

I struggled to setup logstash with Kibana3 and its bettermap panel.  Apparently I'm not the only one:
elasticsearch/kibana#237
http://comments.gmane.org/gmane.comp.sysutils.logstash.user/4049

This change is a hack because it duplicates latitude and longitude in the event.  Might be better for the behavior to be configurable and off by default.

FWIW, prior to this change, my solution to the "lonlat problem" was:

```
ruby {
  type => "nginx"
  tags => [ "geoip" ]
  code => "event['lonlat'] = [event['geoip.longitude'].to_f, event['geoip.latitude'].to_f]"
}
```

@jordansissel's recommendation on logstash-user did not work for me, even after updating ElasticSearch's mappings--I was probably doing something wrong--and the ruby filter solutions seems less of a hack than the one in elasticsearch/kibana#237.
