### PR TITLE
Add slope and metric group for ganglia output.

### DIFF
--- a/lib/logstash/outputs/ganglia.rb
+++ b/lib/logstash/outputs/ganglia.rb
@@ -35,6 +35,12 @@ class LogStash::Outputs::Ganglia < LogStash::Outputs::Base
   # Lifetime in seconds of this metric
   config :lifetime, :validate => :number, :default => 300
 
+  # Metric group
+  config :group, :validate => :string, :default => ""
+
+  # Metric slope, represents metric behavior
+  config :slope, :validate => %w{zero positive negative both unspecified}, :default => "both"
+
   def register
     require "gmetric"
   end # def register
@@ -59,8 +65,10 @@ class LogStash::Outputs::Ganglia < LogStash::Outputs::Base
       :units => @units,
       :type => @metric_type,
       :value => localvalue,
-      :tmax => @tmax,
-      :dmax => @dmax
+      :group => @group,
+      :slope => @slope,
+      :tmax => @max_interval,
+      :dmax => @lifetime
     })
   end # def receive
 end # class LogStash::Outputs::Ganglia


### PR DESCRIPTION
Ganglia output doesn't use all gmetric features. One of the most needed features is the slope, because it tells ganglia about the metric type (counter, rate, etc).
