### PR TITLE
centos should respect the logrotate.d directory too.

### DIFF
--- a/pkg/build.sh
+++ b/pkg/build.sh
@@ -45,7 +45,7 @@ case $os@$release in
     mkdir -p $destdir/var/run/logstash
     mkdir -p $destdir/var/log/logstash
     cp $os/sysconfig $destdir/etc/sysconfig/logstash
-    install -m644 logrotate.conf $destdir/etc/logrotate.d/
+    install -m644 logrotate.conf $destdir/etc/logrotate.d/logstash
     install -m755 logstash.sysv.redhat $destdir/etc/init.d/logstash
     ;;
   ubuntu@*)


### PR DESCRIPTION
This just seems to be an omission, the others already create a file called "logstash" rather than "logrotate.conf".
