### PR TITLE
[syslog5424] do not capture chevrons with priority value

### DIFF
--- a/patterns/linux-syslog
+++ b/patterns/linux-syslog
@@ -7,7 +7,7 @@ CRONLOG %{SYSLOGBASE} \(%{USER:user}\) %{CRON_ACTION:action} \(%{DATA:message}\)
 SYSLOGLINE %{SYSLOGBASE2} %{GREEDYDATA:message}
 
 # IETF 5424 syslog(8) format (see http://www.rfc-editor.org/info/rfc5424)
-SYSLOG5424PRI (?:\<%{NONNEGINT}\>)
+SYSLOG5424PRI <%{NONNEGINT:syslog5424_pri}>
 SYSLOG5424SD \[%{DATA}\]+
 
-SYSLOG5424LINE %{SYSLOG5424PRI:syslog5424_pri}%{NONNEGINT:syslog5424_ver} (?:%{TIMESTAMP_ISO8601:syslog5424_ts}|-) (?:%{HOSTNAME:syslog5424_host}|-) (?:%{WORD:syslog5424_app}|-) (?:%{WORD:syslog5424_proc}|-) (?:%{WORD:syslog5424_msgid}|-) (?:%{SYSLOG5424SD:syslog5424_sd}|-) %{GREEDYDATA:syslog5424_msg}
+SYSLOG5424LINE %{SYSLOG5424PRI}%{NONNEGINT:syslog5424_ver} (?:%{TIMESTAMP_ISO8601:syslog5424_ts}|-) (?:%{HOSTNAME:syslog5424_host}|-) (?:%{WORD:syslog5424_app}|-) (?:%{WORD:syslog5424_proc}|-) (?:%{WORD:syslog5424_msgid}|-) (?:%{SYSLOG5424SD:syslog5424_sd}|-) %{GREEDYDATA:syslog5424_msg}

--- a/spec/filters/grok.rb
+++ b/spec/filters/grok.rb
@@ -41,7 +41,7 @@ describe LogStash::Filters::Grok do
 
     sample "<191>1 2009-06-30T18:30:00+02:00 paxton.local grokdebug 4123 - [id1 foo=\"bar\"][id2 baz=\"something\"] Hello, syslog." do
       insist { subject["tags"] }.nil?
-      insist { subject["syslog5424_pri"] } == "<191>"
+      insist { subject["syslog5424_pri"] } == "191"
       insist { subject["syslog5424_ver"] } == "1"
       insist { subject["syslog5424_ts"] } == "2009-06-30T18:30:00+02:00"
       insist { subject["syslog5424_host"] } == "paxton.local"
@@ -54,7 +54,7 @@ describe LogStash::Filters::Grok do
 
     sample "<191>1 2009-06-30T18:30:00+02:00 paxton.local grokdebug - - [id1 foo=\"bar\"] No process ID." do
       insist { subject["tags"] }.nil?
-      insist { subject["syslog5424_pri"] } == "<191>"
+      insist { subject["syslog5424_pri"] } == "191"
       insist { subject["syslog5424_ver"] } == "1"
       insist { subject["syslog5424_ts"] } == "2009-06-30T18:30:00+02:00"
       insist { subject["syslog5424_host"] } == "paxton.local"
@@ -67,7 +67,7 @@ describe LogStash::Filters::Grok do
 
     sample "<191>1 2009-06-30T18:30:00+02:00 paxton.local grokdebug 4123 - - No structured data." do
       insist { subject["tags"] }.nil?
-      insist { subject["syslog5424_pri"] } == "<191>"
+      insist { subject["syslog5424_pri"] } == "191"
       insist { subject["syslog5424_ver"] } == "1"
       insist { subject["syslog5424_ts"] } == "2009-06-30T18:30:00+02:00"
       insist { subject["syslog5424_host"] } == "paxton.local"
@@ -80,7 +80,7 @@ describe LogStash::Filters::Grok do
 
     sample "<191>1 2009-06-30T18:30:00+02:00 paxton.local grokdebug - - - No PID or SD." do
       insist { subject["tags"] }.nil?
-      insist { subject["syslog5424_pri"] } == "<191>"
+      insist { subject["syslog5424_pri"] } == "191"
       insist { subject["syslog5424_ver"] } == "1"
       insist { subject["syslog5424_ts"] } == "2009-06-30T18:30:00+02:00"
       insist { subject["syslog5424_host"] } == "paxton.local"


### PR DESCRIPTION
Priority is "191", not "<191>".  The `syslog_pri` filter expects a raw integer without the extra punctuation.
