### PR TITLE
Mark "target" field as required in json filter

### DIFF
--- a/lib/logstash/filters/json.rb
+++ b/lib/logstash/filters/json.rb
@@ -38,7 +38,7 @@ class LogStash::Filters::Json < LogStash::Filters::Base
   # datastructure in the "target" field.
   #
   # Note: if the "target" field already exists, it will be overwritten.
-  config :target, :validate => :string
+  config :target, :validate => :string, :required => true
 
   public
   def register


### PR DESCRIPTION
Without it in config file logstash is throwing following error for completely valid JSON file:
:exception=>#<NoMethodError: undefined method `[]' for nil:NilClass>, :level=>:warn

Steps to reproduce:
echo '{ "attr": "val"}' | java -jar logstash-1.1.13-flatjar.jar agent -f logstash-simple.conf

logstash-simple.conf

<pre><code>
input { 
    stdin { type => "stdin-type"}
}

filter {
  json {
    source => "@message"
  }
}

output { stdout { debug => true debug_format => "json"}}
</code></pre>
