### PR TITLE
Add a JAVA_HOME to the packaged /etc/default/logstash

### DIFF
--- a/pkg/logstash.default
+++ b/pkg/logstash.default
@@ -43,3 +43,7 @@ LS_OPTS="--log ${LOG_FILE}"
 
 # Set a home directory
 HOME=/var/lib/logstash
+
+# Set a JAVA_HOME - this can cause some strange behaviour if not set
+JAVA_HOME=/usr/lib/jvm/java-6-openjdk-amd64
+


### PR DESCRIPTION
This seems to work around and resolve strange encoding errors of the following nature:

```
#<Encoding::ConverterNotFoundError: code converter not found (ASCII-8BIT to UTF-8)>
```

Despite there being no charset specified anywhere in the LogStash config. A similar patch may be needed to the /etc/sysconfig files for RedHat, but as I cannot test RH packages here I'm hesitant to mess with those.
