### PR TITLE
Update Bunny to 0.10.4+

### DIFF
--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -88,7 +88,7 @@ Gem::Specification.new do |gem|
   end
 
   if RUBY_PLATFORM != 'java'
-    gem.add_runtime_dependency "bunny",       ["~> 0.9.8"]  #(MIT license)
+    gem.add_runtime_dependency "bunny",       ["~> 0.10.4"]  #(MIT license)
   else
     gem.add_runtime_dependency "hot_bunnies", ["~> 2.0.0.pre9"] #(MIT license)
   end


### PR DESCRIPTION
I believe RabbitMQ input/output do not need updating but
FTR, here's [the changelog](https://github.com/ruby-amqp/bunny/blob/0.10.x-stable/ChangeLog.md).
