### PR TITLE
Add negate_expression option to grep filter

### DIFF
--- a/lib/logstash/filters/grep.rb
+++ b/lib/logstash/filters/grep.rb
@@ -25,6 +25,13 @@ class LogStash::Filters::Grep < LogStash::Filters::Base
   # through.
   config :negate, :validate => :boolean, :default => false
 
+  #Negate the entire expression
+  #
+  #If this is set to true the entire match expression is negated instead of
+  #the individual components.  This allows for dropping lines where all of the
+  #components are false insead of just one of them.
+  config :negate_expression, :validate => :boolean, :default => false
+
   # A hash of matches of field => regexp.  If multiple matches are specified,
   # all must match for the grep to be considered successful.  Normal regular
   # expressions are supported here.
@@ -135,7 +142,7 @@ class LogStash::Filters::Grep < LogStash::Filters::Base
       end # match["match"].each
     end # @patterns.each
 
-    if matches == @patterns.length
+    if (matches == @patterns.length) ^ @negate_expression
       filter_matched(event)
     else
       if @drop == true

--- a/spec/filters/grep.rb
+++ b/spec/filters/grep.rb
@@ -325,6 +325,63 @@ describe LogStash::Filters::Grep do
     end
   end
 
+  describe "repeat a field in match config, negate the entire match expression not the individual components" do
+    config <<-CONFIG
+    filter {
+      grep {
+        match => ["message", "hello", "message", "world"]
+        negate_expression => true
+      }
+    }
+    CONFIG
+
+    #both match
+    sample "hello world" do
+      insist { subject }.nil?
+    end
+    #one match
+    sample "bye world" do
+      reject { subject }.nil?
+    end
+    #one match
+    sample "hello Jordan" do
+      reject { subject }.nil?
+    end
+    #no match
+    sample "WTF" do
+      reject { subject }.nil?
+    end
+  end
+
+  describe "repeat a field in match config, negate expression and components results in or" do
+    config <<-CONFIG
+    filter {
+      grep {
+        match => ["message", "hello", "message", "world"]
+        negate_expression => true
+        negate => true
+      }
+    }
+    CONFIG
+
+    #both match
+    sample "hello world" do
+      reject { subject }.nil?
+    end
+    #one match
+    sample "bye world" do
+      reject { subject }.nil?
+    end
+    #one match
+    sample "hello Jordan" do
+      reject { subject }.nil?
+    end
+    #no match
+    sample "WTF" do
+      insist { subject }.nil?
+    end
+  end
+
   describe "case-insensitive matching" do
     config <<-CONFIG
       filter {


### PR DESCRIPTION
This options allows you to negate the original match in whole and not the individual components.  This is useful if you want to reject events that match all of several components.  In my case I want to discard events from a certain syslog program that has DEBUG in the message, but keep all the other messages from that program.  This is hard to do with current negate option.

As a sort of plus if you set both negate and negate expression to true you can get OR matching of your components instead of AND. 
