### PR TITLE
The "type" event field is not set

### DIFF
--- a/spec/inputs/base.rb
+++ b/spec/inputs/base.rb
@@ -1,0 +1,52 @@
+require "test_utils"
+
+class LogStash::Inputs::Testbaseinput < LogStash::Inputs::Base
+  config_name "testbaseinput"
+  milestone 1
+  default :codec, "plain"
+
+  config :message, :validate => :string
+
+  def register
+  end
+
+  def run(queue)
+    codec.decode(message) do |event|
+      queue << event
+    end
+  end
+end
+
+describe "inputs/base" do
+  extend LogStash::RSpec
+
+  before do
+    LogStash::Plugin.stub(:require).and_call_original
+    LogStash::Plugin.stub(:require).with('logstash/inputs/testbaseinput').and_return(true)
+    Time.stub(:now).and_return(Time.at(1))
+  end
+
+  describe "generate events" do
+    config <<-CONFIG
+      input {
+        testbaseinput {
+          type => "blah"
+          message => "hello base test"
+        }
+      }
+    CONFIG
+
+    input do |pipeline, queue|
+      Thread.new { pipeline.run }
+
+      event = queue.pop
+
+      insist { event["@version"] } == "1"
+      insist { event["@timestamp"] } == Time.at(1).utc
+      insist { event["type"] } == "blah"
+      insist { event["message"] } == "hello base test"
+
+      pipeline.shutdown
+    end # input
+  end
+end


### PR DESCRIPTION
This probably went away with commit 8b34a61. (`#to_event` deprecation)

Events generated by inputs that have the "type" option enabled in the configuration but do not set the "type" attribute explicitly in the plugin code are currently broken.

I haven't found a way to set the "type" on the event in a central location. So I guess each plugin author has to remember to set the "type" explicitly for now and all existing plugins have to be adjusted to do that.

Any other ideas?

I created a failing test case for that.
