### PR TITLE
add done filter by-pass

### DIFF
--- a/lib/logstash/config/config_ast.rb
+++ b/lib/logstash/config/config_ast.rb
@@ -173,6 +173,7 @@ module LogStash; module Config; module AST
             "  extra_events.each(&block)",
             "  return",
             "end",
+            "return if event.done?",
           ].map { |l| "#{l}\n" }.join("")
         when "output"
           return "#{variable_name}.receive(event)\n"

--- a/lib/logstash/event.rb
+++ b/lib/logstash/event.rb
@@ -44,6 +44,7 @@ class LogStash::Event
   public
   def initialize(data={})
     @cancelled = false
+    @done = false
 
     @data = data
     if data.include?("@timestamp")
@@ -84,6 +85,16 @@ class LogStash::Event
   def cancelled?
     return @cancelled
   end # def cancelled?
+
+  public
+  def done
+    @done = true
+  end # def done
+
+  public
+  def done?
+    return @done
+  end # def done?
 
   # Create a deep-ish copy of this event.
   public

--- a/lib/logstash/filters/base.rb
+++ b/lib/logstash/filters/base.rb
@@ -84,7 +84,19 @@ class LogStash::Filters::Base < LogStash::Plugin
   # would remove the field with name "foo_hello" if it is present
   config :remove_field, :validate => :array, :default => []
 
-  RESERVED = ["type", "tags", "exclude_tags", "include_fields", "exclude_fields", "add_tag", "remove_tag", "add_field", "remove_field", "include_any", "exclude_any"]
+  # If this filter is successful, event is good to output
+  # This will save unneed/unwanted filter treatments
+  # Example:
+  #
+  #     filter {
+  #       %PLUGIN% {
+  #         done => true
+  #       }
+  #     }
+  #
+  config :done, :validate => :boolean, :default => false
+
+  RESERVED = ["type", "tags", "exclude_tags", "include_fields", "exclude_fields", "add_tag", "remove_tag", "add_field", "remove_field", "include_any", "exclude_any", "done_on_success"]
 
   public
   def initialize(params)
@@ -152,6 +164,11 @@ class LogStash::Filters::Base < LogStash::Plugin
       @logger.debug? and @logger.debug("filters/#{self.class.name}: removing tag",
                                        :tag => tag)
       event.tags.delete(tag)
+    end
+
+    if @done
+      event.done
+      @logger.debug? and @logger.debug("filters/#{self.class.name}: event is done")
     end
   end # def filter_matched
 

--- a/spec/done.rb
+++ b/spec/done.rb
@@ -1,0 +1,33 @@
+require "test_utils"
+
+describe "done" do
+  extend LogStash::RSpec
+
+  #if done works, ip sample should pass and not fail at host test
+  config <<-CONFIG
+    filter {
+      grok {
+        pattern => "%{IP:ipaddress}"
+        singles => true
+        done => true
+      }
+      grok {
+        pattern => "%{HOST:hostname}"
+        singles => true
+      }
+    }
+  CONFIG
+
+  sample "10.0.0.0" do
+    insist { subject["ipaddress"] } == "10.0.0.0"
+    insist { subject["hostname"] }.nil?
+    insist { subject["tags"] }.nil?
+  end
+
+  sample "www.example.org" do
+    insist { subject["ipaddress"] }.nil?
+    insist { subject["hostname"] } == "www.example.org"
+    insist { subject["tags"] }.include?("_grokparsefailure")
+  end
+end
+


### PR DESCRIPTION
It's like syslog-ng's "flag final"

For long multi-case configurations, it make configuration more clear avoiding multiple exclude tag or conditionnals.

if an event is good for ouput at the second filter, I don't have to care about on the several others.

Not sure, but it should improve, a little, performance for these kind of use-case.
