### PR TITLE
fixed 2 references from "message" to "@message" in filter railsparallelrequest

### DIFF
--- a/lib/logstash/filters/railsparallelrequest.rb
+++ b/lib/logstash/filters/railsparallelrequest.rb
@@ -30,7 +30,7 @@ class LogStash::Filters::Railsparallelrequest < LogStash::Filters::Base
 
     event.tags << self.class.config_name
 
-    line = event["message"]
+    line = event["@message"]
 
     if line =~ /^\[(.*?)\]/
       uuid = $1
@@ -79,7 +79,7 @@ class LogStash::Filters::Railsparallelrequest < LogStash::Filters::Base
 
   private
   def merge_events(dest, source, uuid)
-    source["message"].gsub!("[#{uuid}]", "")
+    source["@message"].gsub!("[#{uuid}]", "")
     dest.append(source)
   end
 end


### PR DESCRIPTION
railparalllelreqeust.rb had to references to event["message"]. To the best of my knowledge it should be event["@message"].

/Lasse
