### PR TITLE
Add missing decorate() calls to inputs

### DIFF
--- a/lib/logstash/inputs/drupal_dblog.rb
+++ b/lib/logstash/inputs/drupal_dblog.rb
@@ -205,6 +205,7 @@ class LogStash::Inputs::DrupalDblog < LogStash::Inputs::Base
         results.each do |row|
           event = build_event(row)
           if event
+            decorate(event)
             output_queue << event
             lastWid = row['wid'].to_s
           end

--- a/lib/logstash/inputs/eventlog.rb
+++ b/lib/logstash/inputs/eventlog.rb
@@ -84,6 +84,7 @@ class LogStash::Inputs::EventLog < LogStash::Inputs::Base
 
         e.message = event.Message
 
+        decorate(e)
         queue << e
 
       end # while

--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -88,6 +88,7 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
         event.remove("timestamp")
       end
       remap_gelf(event) if @remap
+      decorate(event)
       output_queue << event
     end
   rescue LogStash::ShutdownSignal

--- a/lib/logstash/inputs/generator.rb
+++ b/lib/logstash/inputs/generator.rb
@@ -77,6 +77,7 @@ class LogStash::Inputs::Generator < LogStash::Inputs::Threadable
 
     if @codec.respond_to?(:flush)
       @codec.flush do |event|
+        decorate(event)
         event["host"] = @hos
         queue << event
       end
@@ -87,6 +88,7 @@ class LogStash::Inputs::Generator < LogStash::Inputs::Threadable
   public
   def teardown
     @codec.flush do |event|
+      decorate(event)
       event["source"] = source
       queue << event
     end

--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -113,6 +113,8 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
       end
     end # mail.header_fields.each
 
+    decorate(event)
+
     return event
   end # def handle
 

--- a/lib/logstash/inputs/log4j.rb
+++ b/lib/logstash/inputs/log4j.rb
@@ -57,6 +57,7 @@ class LogStash::Inputs::Log4j < LogStash::Inputs::Base
         log4j_obj = ois.readObject
         event = LogStash::Event.new("message" => log4j_obj.getRenderedMessage,
                                     "source" => event_source)
+        decorate(event)
         event["host"] = socket.peer
         event["path"] = log4j_obj.getLoggerName
         event["priority"] = log4j_obj.getLevel.toString

--- a/lib/logstash/inputs/snmptrap.rb
+++ b/lib/logstash/inputs/snmptrap.rb
@@ -70,6 +70,7 @@ class LogStash::Inputs::Snmptrap < LogStash::Inputs::Base
     @snmptrap.on_trap_default do |trap|
       begin
         event = LogStash::Event.new("message" => trap.inspect, "host" => trap.source_ip)
+        decorate(event)
         trap.each_varbind do |vb|
           event[vb.name.to_s] = vb.value.to_s
         end

--- a/lib/logstash/inputs/sqlite.rb
+++ b/lib/logstash/inputs/sqlite.rb
@@ -154,6 +154,7 @@ class LogStash::Inputs::Sqlite < LogStash::Inputs::Base
           count += rows.count
           rows.each do |row| 
             event = LogStash::Event.new("host" => @host, "db" => @db)
+            decorate(event)
             # store each column as a field in the event.
             row.each do |column, element|
               next if column == :id

--- a/lib/logstash/inputs/syslog.rb
+++ b/lib/logstash/inputs/syslog.rb
@@ -142,6 +142,7 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
         begin
           client.each do |line|
             @codec.decode(line) do |event|
+              decorate(event)
               event["host"] = ip
               syslog_relay(event)
               output_queue << event

--- a/lib/logstash/inputs/tcp.rb
+++ b/lib/logstash/inputs/tcp.rb
@@ -118,6 +118,7 @@ class LogStash::Inputs::Tcp < LogStash::Inputs::Base
     end # loop do
   rescue => e
     codec.respond_to?(:flush) && codec.flush do |event|
+      decorate(event)
       event["source"] = event_source
       event["sslsubject"] = socket.peer_cert.subject if @ssl_enable && @ssl_verify
       output_queue << event

--- a/lib/logstash/inputs/twitter.rb
+++ b/lib/logstash/inputs/twitter.rb
@@ -73,6 +73,7 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
         "client" => status.source,
         "retweeted" => status.retweeted
       )
+      decorate(event)
       event["in-reply-to"] = status.in_reply_to_status_id  if status.in_reply_to_status_id
       #urls = tweet.urls.collect(&:expanded_url)
       #event["urls"] = urls if urls.size > 0

--- a/lib/logstash/inputs/varnishlog.rb
+++ b/lib/logstash/inputs/varnishlog.rb
@@ -27,6 +27,7 @@ class LogStash::Inputs::Varnishlog < LogStash::Inputs::Threadable
     begin
       str = ptr.read_string(len)
       event = LogStash::Event.new("message" => str, "host" => @host)
+      decorate(event)
       event["varnish_tag"] = tag
       event["varnish_fd"] = fd
       event["varnish_spec"] = spec

--- a/lib/logstash/inputs/xmpp.rb
+++ b/lib/logstash/inputs/xmpp.rb
@@ -66,6 +66,7 @@ class LogStash::Inputs::Xmpp < LogStash::Inputs::Base
       # accept normal msgs (skip presence updates, etc)
       if msg.body != nil
         @codec.decode(msg.body) do |event|
+          decorate(event)
           # Maybe "from" should just be a hash: 
           # { "node" => ..., "domain" => ..., "resource" => ... }
           event["from"] = "#{msg.from.node}@#{msg.from.domain}/#{msg.from.resource}"

--- a/lib/logstash/inputs/zenoss.rb
+++ b/lib/logstash/inputs/zenoss.rb
@@ -83,6 +83,7 @@ class LogStash::Inputs::Zenoss < LogStash::Inputs::RabbitMQ
           "host" => occurrence.actor.element_title,
           "message" => occurrence.message,
         )
+        decorate(event)
 
         # Direct mappings from summary.
         %w{uuid}.each do |property|


### PR DESCRIPTION
I added some missing `decorate` calls to inputs. Or have they been left out intentionally?
