### PR TITLE
Added a bunch of Grok patterns for Cisco ASA firewall syslog messages.

### DIFF
--- a/patterns/firewalls
+++ b/patterns/firewalls
@@ -2,6 +2,7 @@
 NETSCREENSESSIONLOG %{SYSLOGTIMESTAMP:date} %{IPORHOST:device} %{IPORHOST}: NetScreen device_id=%{WORD:device_id}%{DATA}: start_time=%{QUOTEDSTRING:start_time} duration=%{INT:duration} policy_id=%{INT:policy_id} service=%{DATA:service} proto=%{INT:proto} src zone=%{WORD:src_zone} dst zone=%{WORD:dst_zone} action=%{WORD:action} sent=%{INT:sent} rcvd=%{INT:rcvd} src=%{IPORHOST:src_ip} dst=%{IPORHOST:dst_ip} src_port=%{INT:src_port} dst_port=%{INT:dst_port} src-xlated ip=%{IPORHOST:src_xlated_ip} port=%{INT:src_xlated_port} dst-xlated ip=%{IPORHOST:dst_xlated_ip} port=%{INT:dst_xlated_port} session_id=%{INT:session_id} reason=%{GREEDYDATA:reason}
 
 #== Cisco ASA ==
+CISCO_TAGGED_SYSLOG ^<%{POSINT:syslog_pri}>%{CISCOTIMESTAMP:timestamp}( %{SYSLOGHOST:sysloghost})?: %%{CISCOTAG:ciscotag}:
 CISCOTIMESTAMP %{MONTH} +%{MONTHDAY}(?: %{YEAR})? %{TIME}
 CISCOTAG [A-Z0-9]+-%{INT}-(?:[A-Z0-9_]+)
 # ASA-2-106001


### PR DESCRIPTION
- Confirmed to work:
  - ASA-6-106015
  - ASA-1-106021
  - ASA-4-106023
  - ASA-5-106100
  - ASA-6-110002
  - ASA-6-302010
  - ASA-6-302013
  - ASA-6-302014
  - ASA-6-302015
  - ASA-6-302016
  - ASA-6-302020
  - ASA-6-302021
  - ASA-3-313001
  - ASA-3-313004
  - ASA-4-313005
  - ASA-3-313008
  - ASA-4-402117
  - ASA-4-402119
  - ASA-4-419002
  - ASA-6-602303
  - ASA-6-602304
  - ASA-6-713172
  - ASA-4-733100
- Based on patterns found here(https://gist.github.com/dav3860/5345656) and documentation here(http://www.cisco.com/en/US/docs/security/asa/syslog-guide/logmsgs.html#wp4771036)
  - ASA-2-106001
  - ASA-2-106006
  - ASA-2-106007
  - ASA-2-106010
  - ASA-3-106014
  - ASA-4-419001
  - ASA-4-500004
  - ASA-6-305011
  - ASA-7-710001
  - ASA-7-710002
  - ASA-7-710003
  - ASA-7-710005
  - ASA-7-710006
