### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Other commands:
     # If running bin/logstash agent yields complaints about log4j/other things
     # This will download the elasticsearch jars so logstash can use them.
     make vendor-elasticsearch
+    
+    # If running make test yeilds the following error:
+    # "You must specify 'database => ...' in your geoip filter"
+    make vendor/geoip/GeoLiteCity.dat
 
 ## Testing
 


### PR DESCRIPTION
running `make test` without having the Geoip database downloaded throws an error.

``` bash
~/src/logstash$ USE_JRUBY=1 make test
GEM_HOME= GEM_PATH= bin/logstash rspec --order rand --fail-fast spec/support/akamai-grok.rb spec/support/date-http.rb spec/support/LOGSTASH-733.rb spec/support/LOGSTASH-820.rb spec/support/postwait1.rb spec/support/pull375.rb spec/filters/alter.rb spec/filters/anonymize.rb spec/filters/clone.rb spec/filters/csv.rb spec/filters/date_performance.rb spec/filters/date.rb spec/filters/dns.rb spec/filters/drop.rb spec/filters/environment.rb spec/filters/geoip.rb spec/filters/grep.rb spec/filters/grok.rb spec/filters/json_encode.rb spec/filters/json.rb spec/filters/kv.rb spec/filters/mutate.rb spec/filters/noop.rb spec/filters/prune.rb spec/filters/railsparallelrequest.rb spec/filters/range.rb spec/filters/split.rb spec/filters/translate.rb spec/filters/useragent.rb spec/filters/xml.rb spec/examples/fail2ban.rb spec/examples/graphite-input.rb spec/examples/mysql-slow-query.rb spec/examples/parse-apache-logs.rb spec/examples/parse-haproxy-logs.rb spec/examples/syslog.rb spec/codecs/json.rb spec/codecs/json_spooler.rb spec/codecs/msgpack.rb spec/codecs/multiline.rb spec/codecs/plain.rb spec/codecs/spool.rb spec/conditionals/test.rb spec/event.rb spec/jar.rb
.....................................................................................................................................................................................................................F

Failures:

  1) LogStash::Filters::GeoIP Specify the target "{"ip":"127.0.0.1"}" when processed
     Failure/Error: pipeline.instance_eval { @filters.each(&:register) }
     RuntimeError:
       You must specify 'database => ...' in your geoip filter
     # ./lib/logstash/filters/geoip.rb:65:in `register'
     # ./spec/test_utils.rb:58:in `sample'
     # ./spec/test_utils.rb:58:in `sample'
     # ./spec/test_utils.rb:73:in `sample'
     # ./spec/filters/geoip.rb:57:in `(root)'
     # ./spec/filters/geoip.rb:57:in `(root)'
     # ./lib/logstash/runner.rb:148:in `run'

Finished in 11.48 seconds
214 examples, 1 failure

Failed examples:

rspec ./spec/test_utils.rb:75 # LogStash::Filters::GeoIP Specify the target "{"ip":"127.0.0.1"}" when processed

Randomized with seed 44506

make: *** [test] Error 1
```

steps:

``` bash
git clone https://github.com/logstash/logstash.git
cd logstash/
USE_JRUBY=1 bin/logstash
USE_JRUBY=1 bin/logstash deps
USE_JRUBY=1 make test
```
