### PR TITLE
Add workaround for slow openssl loading (LOGSTASH-1223)

### DIFF
--- a/lib/logstash/JRUBY-6970.rb
+++ b/lib/logstash/JRUBY-6970.rb
@@ -3,9 +3,18 @@ module Kernel
   alias_method :require_JRUBY_6970_hack, :require
 
   def require(path)
+    old_load_path = nil
+
     if path =~ /^jar:file:.+!.+/
       path = path.gsub(/^jar:/, "")
       puts "JRUBY-6970: require(#{path})" if ENV["REQUIRE_DEBUG"] == "1"
+    end
+
+    # Work around slow openssl load times in flatjar. (LOGSTASH-1223)
+    if __FILE__ =~ /^(?:jar:)?file:.+!.+/ && path == "openssl"
+      old_load_path = $LOAD_PATH.dup
+      # For some reason loading openssl with an empty LOAD_PATH is fast.
+      $LOAD_PATH.clear
     end
 
     # JRUBY-7065
@@ -17,6 +26,8 @@ module Kernel
       require "logstash/JRUBY-6970-openssl"
     end
     return rc
+  ensure
+    $LOAD_PATH.replace(old_load_path) if old_load_path
   end
 end
 


### PR DESCRIPTION
Loading `openssl` within the flatjar is super slow. For some reason it is fast with an empty `$LOAD_PATH`. No idea what's going on, yet.

I ran into this while testing the 1.2 release. It's not pretty but removes a 45 second delay while starting logstash on my i7 notebook.

I ran the `jar` and `flatjar` testsuites, they are fine.

(I would update LOGSTASH-1223 but I cannot create a JIRA account at the moment - captcha broken...)
