### PR TITLE
inputs: rabbitmq: fix optional exchange binding

### DIFF
--- a/lib/logstash/inputs/rabbitmq.rb
+++ b/lib/logstash/inputs/rabbitmq.rb
@@ -81,7 +81,7 @@ class LogStash::Inputs::RabbitMQ < LogStash::Inputs::Threadable
 
 
   #
-  # (Optional, backwards compatibility) Exchange binding
+  # (Optional) Exchange binding
   #
 
   # Optional.

--- a/lib/logstash/inputs/rabbitmq/hot_bunnies.rb
+++ b/lib/logstash/inputs/rabbitmq/hot_bunnies.rb
@@ -95,6 +95,11 @@ class LogStash::Inputs::RabbitMQ
         :auto_delete => @auto_delete,
         :exclusive   => @exclusive,
         :arguments   => @arguments)
+
+      # exchange binding is optional for the input
+      if @exchange
+        @q.bind(@exchange, :routing_key => @key)
+      end
     end
 
     def consume


### PR DESCRIPTION
Make hot_bunnies implementation behave the same as the bunny
implementation: optionally bind the input queue to the output exchange
if the "exchange" option is defined.  If it is not defined, some other
out-of-band process will need to setup the bindings.  Remove the
backward-compatibility reference, because this is actually a useful
feature to continue supporting.

LOGSTASH-1300
