### PR TITLE
Unbreak "require 'logstash-event'"

### DIFF
--- a/lib/logstash-event.rb
+++ b/lib/logstash-event.rb
@@ -1,3 +1,1 @@
 require "logstash/event"
-require "logstash/version"
-

--- a/logstash-event.gemspec
+++ b/logstash-event.gemspec
@@ -1,6 +1,4 @@
 # -*- encoding: utf-8 -*-
-require File.expand_path('../lib/logstash/version', __FILE__)
-
 Gem::Specification.new do |gem|
   gem.authors       = ["Jordan Sissel"]
   gem.email         = ["jls@semicomplete.com"]


### PR DESCRIPTION
Do not require logstash/version.rb in logstash-event.rb because that is not
shipped anymore.

Also remove unused require in the logstash-event.gemspec.
