### PR TITLE
Include filter/output class name in skip/drop debug log messages

### DIFF
--- a/lib/logstash/filters/base.rb
+++ b/lib/logstash/filters/base.rb
@@ -159,7 +159,7 @@ class LogStash::Filters::Base < LogStash::Plugin
   def filter?(event)
     if !@type.empty?
       if event.type != @type
-        @logger.debug? and @logger.debug(["Skipping event because type doesn't match #{@type}", event])
+        @logger.debug? and @logger.debug(["filters/#{self.class.name}: Skipping event because type doesn't match #{@type}", event])
         return false
       end
     end
@@ -171,14 +171,14 @@ class LogStash::Filters::Base < LogStash::Plugin
 
       # Is @tags a subset of the event's tags? If not, skip it.
       if (event["tags"] & @tags).size != @tags.size
-        @logger.debug(["Skipping event because tags don't match #{@tags.inspect}", event])
+        @logger.debug(["filters/#{self.class.name}: Skipping event because tags don't match #{@tags.inspect}", event])
         return false
       end
     end
 
     if !@exclude_tags.empty? && event["tags"]
       if (diff_tags = (event["tags"] & @exclude_tags)).size != 0
-        @logger.debug(["Skipping event because tags contains excluded tags: #{diff_tags.inspect}", event])
+        @logger.debug(["filters/#{self.class.name}: Skipping event because tags contains excluded tags: #{diff_tags.inspect}", event])
         return false
       end
     end

--- a/lib/logstash/outputs/base.rb
+++ b/lib/logstash/outputs/base.rb
@@ -59,7 +59,7 @@ class LogStash::Outputs::Base < LogStash::Plugin
   def output?(event)
     if !@type.empty?
       if event.type != @type
-        @logger.debug? and @logger.debug(["Dropping event because type doesn't match #{@type}", event])
+        @logger.debug? and @logger.debug(["outputs/#{self.class.name}: Dropping event because type doesn't match #{@type}", event])
         return false
       end
     end
@@ -67,14 +67,14 @@ class LogStash::Outputs::Base < LogStash::Plugin
     if !@tags.empty?
       return false if !event["tags"]
       if !@tags.send(@include_method) {|tag| event["tags"].include?(tag)}
-        @logger.debug? and @logger.debug("Dropping event because tags don't match #{@tags.inspect}", event)
+        @logger.debug? and @logger.debug("outputs/#{self.class.name}: Dropping event because tags don't match #{@tags.inspect}", event)
         return false
       end
     end
 
     if !@exclude_tags.empty? && event["tags"]
       if @exclude_tags.send(@exclude_method) {|tag| event["tags"].include?(tag)}
-        @logger.debug? and @logger.debug("Dropping event because tags contains excluded tags: #{exclude_tags.inspect}", event)
+        @logger.debug? and @logger.debug("outputs/#{self.class.name}: Dropping event because tags contains excluded tags: #{exclude_tags.inspect}", event)
         return false
       end
     end


### PR DESCRIPTION
Bit distressing to see log messages like 'Skipping event' without seeing
_what_ is skipping it!
