### PR TITLE
Bind the input queue to the exchange correctly in rabbitmq input

### DIFF
--- a/lib/logstash/inputs/rabbitmq/hot_bunnies.rb
+++ b/lib/logstash/inputs/rabbitmq/hot_bunnies.rb
@@ -95,6 +95,11 @@ class LogStash::Inputs::RabbitMQ
         :auto_delete => @auto_delete,
         :exclusive   => @exclusive,
         :arguments   => @arguments)
+
+      # exchange binding is optional for the input
+      if @exchange
+        @q.bind(@exchange, :routing_key => @key)
+      end
     end
 
     def consume


### PR DESCRIPTION
The Bunny implementation was doing it but not the HotBunny one.
