### PR TITLE
Fix issue 1291 - redis output to ipv6 host is not parsed properly

### DIFF
--- a/lib/logstash/outputs/redis.rb
+++ b/lib/logstash/outputs/redis.rb
@@ -215,16 +215,10 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
   private
   def connect
 
-    # if @host[@host_idx] =~ /((?:(?:[0-9]{1,3}\.){3}[0-9]{1,3})|(?:\[[0-9a-fA-F:]+\])):(\d+)/
-    #   @current_host = $1
-    #   @current_port = $2
-    # else
-    #   @current_host, @current_port = @host[@host_idx].split(':')
-    # end
-    if @host[@host_idx] =~ /(?=^.{1,254}$)(^(?:(?!\d+\.|-)[a-zA-Z0-9_\-]{1,63}(?<!-)\.?)+(?:[a-zA-Z]{2,})(:\d+)*$)/i
+    if @host[@host_idx] =~ /(?=^.{1,254}$)(^(?:(?!\d+.|-)[a-zA-Z0-9_-]{1,63}(?<!-).?)+(?:[a-zA-Z]{2,})(:\d+)*$)/i
       @current_host = $1
       if $2
-        @current_port = $2
+        @current_port = $2[1..-1]
       end
     elsif @host[@host_idx] =~ /((?:(?:[0-9]{1,3}\.){3}[0-9]{1,3})|(?:\[[0-9a-fA-F:]+\])):(\d+)/
       @current_host = $1


### PR DESCRIPTION
This is to fix https://logstash.jira.com/browse/LOGSTASH-1291

instead of splitiing input on :, look for ipv4 address or ipv6address in pattern then split properly. ipv6 address has to follow convention of using square brackets []
