### PR TITLE
add show filter to facilitate debugging

### DIFF
--- a/lib/logstash/filters/show.rb
+++ b/lib/logstash/filters/show.rb
@@ -1,0 +1,40 @@
+require "logstash/filters/base"
+require "logstash/namespace"
+
+# Show a string composed from event
+# It's for debugging purpose, do not use it in production !
+class LogStash::Filters::Show < LogStash::Filters::Base
+  config_name "show"
+  milestone 1
+
+  # Specify text to show
+  config :text, :validate => :string, :default => "%{host} %{message}"
+
+  # Output to put the string: "logger", "stderr", "stdout", "filename"
+  config :output, :validate => :string, :default => "logger"
+
+  # if output if logger, set the loglevel [ "debug", "info", "warn", "error", "fatal" ]
+  config :loglevel, :validate => :string, :default => "warn"
+
+  public
+  def register
+    # Nothing
+  end # def register
+
+  public
+  def filter(event)
+    return unless filter?(event)
+    finaltext = event.sprintf(@text)
+    if @output == "logger"
+        #don't know if is needed
+        @logger.send(@loglevel, finaltext)
+    elsif @output == "stderr"
+        $stderr.puts finaltext
+    elsif @output == "stdout"
+        $stdout.puts finaltext
+    else 
+        File.open(@output, 'a') { |file| file.write("#{finaltext}\n") }
+    end
+    filter_matched(event)
+  end # def filter
+end # class LogStash::Filters::Environment


### PR DESCRIPTION
This is not a real filter , but more a tool to help you debug your conf.

When this filter if executed, it will show you through log, stdout/stderr, file a string you composed with the event data.

Helpful to show a string status before a f***ing grok filter that don't match as you expect.
