### PR TITLE
Fix incorrect default aws region URI

### DIFF
--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -143,12 +143,18 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
  def aws_s3_config
   
   @logger.debug "S3: waiting for establishing connection..."
+
+  endpoint = 's3-'+@endpoint_region+'.amazonaws.com'
+  if @endpoint_region <=> "us_east_1"
+    endpoint = 's3.amazonaws.com'
+  end
+
   AWS.config(
     :access_key_id => @access_key_id,
     :secret_access_key => @secret_access_key,
-    :s3_endpoint => 's3-'+@endpoint_region+'.amazonaws.com'
+    :s3_endpoint => endpoint
   )
-  @s3 = AWS::S3.new 
+  @s3 = AWS::S3.new
 
  end
 


### PR DESCRIPTION
Fix issue when using "us_east_1" or default as the bucket region.
