### PR TITLE
[rabbitmq] Disable automatic connection recovery for input, fixes LGOSTASH-1350

### DIFF
--- a/lib/logstash/inputs/rabbitmq/hot_bunnies.rb
+++ b/lib/logstash/inputs/rabbitmq/hot_bunnies.rb
@@ -14,7 +14,8 @@ class LogStash::Inputs::RabbitMQ
         :vhost => @vhost,
         :host  => @host,
         :port  => @port,
-        :user  => @user
+        :user  => @user,
+        :automatic_recovery => false
       }
       @settings[:pass]      = @password.value if @password
       @settings[:tls]       = @ssl if @ssl


### PR DESCRIPTION
See LOGSTASH-1350.

Automatic recovery was added after the plugin was rewritten.
In logstash's case, full control over how recovery
is performed is probably more important than
removing some plugin code.
