### PR TITLE
[rabbitmq] Disable automatic connection recovery for output

### DIFF
--- a/lib/logstash/outputs/rabbitmq/hot_bunnies.rb
+++ b/lib/logstash/outputs/rabbitmq/hot_bunnies.rb
@@ -89,7 +89,8 @@ class LogStash::Outputs::RabbitMQ
         :vhost => @vhost,
         :host  => @host,
         :port  => @port,
-        :user  => @user
+        :user  => @user,
+        :automatic_recovery => false
       }
       @settings[:pass]      = if @password
                                 @password.value


### PR DESCRIPTION
Related to LGOSTASH-1350 and #641.
