### PR TITLE
Different fixes for the S3 input and output plugins

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -30,6 +30,12 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
   # The AWS region for your bucket.
   config :region, :validate => ["us-east-1", "us-west-1", "us-west-2",
                                 "eu-west-1", "ap-southeast-1", "ap-southeast-2",
+                                "ap-northeast-1", "sa-east-1", "us-gov-west-1"],
+                                :deprecated => "'region' has been deprecated in favor of 'region_endpoint'"
+
+  # The AWS region for your bucket.
+  config :region_endpoint, :validate => ["us-east-1", "us-west-1", "us-west-2",
+                                "eu-west-1", "ap-southeast-1", "ap-southeast-2",
                                 "ap-northeast-1", "sa-east-1", "us-gov-west-1"], :default => "us-east-1"
 
   # If specified, the prefix the filenames in the bucket must match (not a regexp)
@@ -55,9 +61,13 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
 
   public
   def register
-    @logger.info("Registering s3 input", :bucket => @bucket)
-
     require "digest/md5"
+
+    @region_endpoint = @region if !@region.empty?
+
+    @region_endpoint == 'us-east-1' ? @region_endpoint = 's3.amazonaws.com' : @region_endpoint = 's3-'+@region_endpoint+'.amazonaws.com'
+
+    @logger.info("Registering s3 input", :bucket => @bucket, :region_endpoint => @region_endpoint)
 
     if @credentials.nil?
       @access_key_id = ENV['AWS_ACCESS_KEY_ID']
@@ -104,8 +114,9 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     s3 = AWS::S3.new(
       :access_key_id => @access_key_id,
       :secret_access_key => @secret_access_key,
-      :region => @region
+      :region => @region_endpoint
     )
+
     @s3bucket = s3.buckets[@bucket]
 
     unless @backup_to_bucket.nil?
@@ -267,4 +278,3 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
   end # def sincedb_write
 
 end # class LogStash::Inputs::S3
-

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -118,7 +118,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
  config :endpoint_region, :validate => ["us-east-1", "us-west-1", "us-west-2",
                                         "eu-west-1", "ap-southeast-1", "ap-southeast-2",
                                         "ap-northeast-1", "sa-east-1", "us-gov-west-1"], :default => "us-east-1"
- 
+
  # Set the size of file in KB, this means that files on bucket when have dimension > file_size, they are stored in two or more file. 
  # If you have tags then it will generate a specific size file for every tags
  ##NOTE: define size of file is the better thing, because generate a local temporary file on disk and then put it in bucket. 
@@ -141,12 +141,15 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
 
  # Method to set up the aws configuration and establish connection
  def aws_s3_config
-  
-  @logger.debug "S3: waiting for establishing connection..."
+
+  @region_endpoint == 'us-east-1' ? @region_endpoint = 's3.amazonaws.com' : @region_endpoint = 's3-'+@region_endpoint+'.amazonaws.com'
+
+  @logger.info("Registering s3 output", :bucket => @bucket, :region_endpoint => @region_endpoint)
+
   AWS.config(
     :access_key_id => @access_key_id,
     :secret_access_key => @secret_access_key,
-    :s3_endpoint => 's3-'+@endpoint_region+'.amazonaws.com'
+    :s3_endpoint => @endpoint_region
   )
   @s3 = AWS::S3.new 
 


### PR DESCRIPTION
- Input: Renaming the region config variable into region_endpoint to be inline with the output
- Input/Output: Making sure the endpoint urls are correct for all regions. ( based on PR #632 & #634 )
- Input/Output: added some extra logging info
