### PR TITLE
Allow the prefix key to come from a previous variable

### DIFF
--- a/lib/logstash/filters/kv.rb
+++ b/lib/logstash/filters/kv.rb
@@ -203,7 +203,7 @@ class LogStash::Filters::KV < LogStash::Filters::Base
     text.scan(@scan_re) do |key, v1, v2, v3|
       value = v1 || v2 || v3
       key = @trimkey.nil? ? key : key.gsub(@trimkey_re, "")      
-      key = @prefix + key
+      key = event.sprintf(@prefix) + key
       next if not @include_keys.empty? and not @include_keys.include?(key)
       next if @exclude_keys.include?(key)
       value = @trim.nil? ? value : value.gsub(@trim_re, "")


### PR DESCRIPTION
On request of LOGSTASH-913
This allows to use a variable name in the key prefix.
