### PR TITLE
pkg/debian: Correctly check existence of conffiles

### DIFF
--- a/pkg/debian/debian/logstash.init
+++ b/pkg/debian/debian/logstash.init
@@ -99,8 +99,8 @@ case "$1" in
          exit 1
       fi
 
-      # Check if a config file exists
-      if ! test -e $CONF_DIR/*.conf; then
+      # Check if at least one config file exists
+      if [ ! "$(ls -A $CONF_DIR/*.conf)" ]; then
          log_failure_msg "There aren't any configuration files in $CONF_DIR"
          exit 1
       fi


### PR DESCRIPTION
The init-script for debian returned an error when multiple config-files were found in $CONFDIR, even though logstash supports this (https://logstash.jira.com/browse/LOGSTASH-856).

This patch fixes that.
