### PR TITLE
pkg/debian: Fix versioning if upstream is dev/rc

### DIFF
--- a/pkg/build.sh
+++ b/pkg/build.sh
@@ -2,10 +2,6 @@
 
 
 VERSION="$(awk -F\" '/LOGSTASH_VERSION/ {print $2}' $(dirname $0)/../lib/logstash/version.rb)"
-if ! git show-ref --tags | grep -q "$(git rev-parse HEAD)"; then
-	# HEAD is not tagged, add the date, time and commit hash to the revision
-	REVISION="+$(date +%Y%m%d%H%M)~$(git rev-parse --short HEAD)"
-fi
 
 if [ "$#" -ne 2 ] ; then
   echo "Usage: $0 <os> <release>"
@@ -97,7 +93,19 @@ case $os in
       --after-install centos/after-install.sh \
       -f -C $destdir .
     ;;
-  ubuntu|debian) 
+  ubuntu|debian)
+    if ! echo $VERSION | grep -q '\.(dev\|rc.*)'; then
+      # This is a dev or RC version... So change the upstream version
+      # example: 1.2.2.dev => 1.2.2~dev
+      # This ensures a clean upgrade path.
+      VERSION="$(echo $VERSION | sed 's/\.\(dev\|rc.*\)/~\1/')"
+    fi
+
+    if ! git show-ref --tags | grep -q "$(git rev-parse HEAD)"; then
+      # HEAD is not tagged, add the date, time and commit hash to the revision
+      REVISION="+$(date -u +%Y%m%d%H%M)~$(git rev-parse --short HEAD)"
+    fi
+
     fpm -s dir -t deb -n logstash -v "$VERSION" \
       -a all --iteration "${os}1${REVISION}" \
       --url "http://logstash.net" \


### PR DESCRIPTION
An improvement/addition to pull request #658. The version number for logstash changed and it added .dev to the end of the version number. This commit ensures that the debian packages have a clean upgrade path from dev to rc to final.
- Change the upstream version from 'x.x.x.dev' and 'x.x.x.rcx' to 'x.x.x~dev' and 'x.x.x~rcx'
- Use UTC instead of local time in the debian version
