### PR TITLE
[elasticsearch_river] Fix undefined method receive_raw 

### DIFF
--- a/lib/logstash/outputs/elasticsearch_river.rb
+++ b/lib/logstash/outputs/elasticsearch_river.rb
@@ -208,6 +208,6 @@ class LogStash::Outputs::ElasticSearchRiver < LogStash::Outputs::Base
       header["index"]["_id"] = event.sprintf(@document_id)
     end
 
-    @mq.receive_raw(header.to_json + "\n" + event.to_json + "\n")
+    @mq.publish_serialized(header.to_json + "\n" + event.to_json + "\n")
   end # def receive
 end # LogStash::Outputs::ElasticSearchRiver


### PR DESCRIPTION
receive_raw is no longer available in RabbitMQ.

elasticsearch_river throw the exception "undefined method `receive_raw'"

This commit fix issues 1298 and 1384
