### PR TITLE
Make 'if "something" not in [nonexistent] { ... }' succeed

### DIFF
--- a/lib/logstash/config/config_ast.rb
+++ b/lib/logstash/config/config_ast.rb
@@ -299,7 +299,7 @@ module LogStash; module Config; module AST
   module NotInExpression
     def compile
       item, list = recursive_select(LogStash::Config::AST::RValue)
-      return "(x = #{list.compile}; x.respond_to?(:include?) && !x.include?(#{item.compile}))"
+      return "(x = #{list.compile}; !x.respond_to?(:include?) || !x.include?(#{item.compile}))"
     end
   end
 

--- a/spec/conditionals/test.rb
+++ b/spec/conditionals/test.rb
@@ -162,6 +162,7 @@ describe "conditionals" do
         if !("foo" not in "foo") { mutate { add_tag => "notfoo" } }
         if "foo" not in [somelist] { mutate { add_tag => "notsomelist" } } 
         if "one" not in [somelist] { mutate { add_tag => "somelist" } }
+        if "foo" not in [alsomissing] { mutate { add_tag => "no string in missing field" } }
       }
     CONFIG
 
@@ -174,6 +175,7 @@ describe "conditionals" do
       insist { subject["tags"] }.include?("notfoo")
       insist { subject["tags"] }.include?("notsomelist")
       reject { subject["tags"] }.include?("somelist")
+      insist { subject["tags"] }.include?("no string in missing field")
     end
   end
 


### PR DESCRIPTION
My argument is checking for the absence of a value in a field that doesn't exist should return true, currently it is false.

This fixes the case where an event which has never been tagged now works with this logic:

```
grok {
  ...
}
if "_grokparsefailure" not in [tags] {
  ...
}
```

Tests updated and still pass, fixes [LOGSTASH-1412](https://logstash.jira.com/browse/LOGSTASH-1412).
