### PR TITLE
Fix for LOGSTASH-902 - Added optional username and password to elasticsearch_http output plugin

### DIFF
--- a/lib/logstash/outputs/elasticsearch_http.rb
+++ b/lib/logstash/outputs/elasticsearch_http.rb
@@ -34,7 +34,7 @@ class LogStash::Outputs::ElasticSearchHTTP < LogStash::Outputs::Base
   config :username, :validate => :string, :default => nil
 
   # The HTTP Basic Auth password used to access your elasticsearch server.
-  config :password, :validate => :string, :default => nil
+  config :password, :validate => :password, :default => nil
 
   # Set the number of events to queue up before writing to elasticsearch.
   config :flush_size, :validate => :number, :default => 100
@@ -59,7 +59,7 @@ class LogStash::Outputs::ElasticSearchHTTP < LogStash::Outputs::Base
     @agent = FTW::Agent.new
     @queue = []
 
-    auth = @username && @password ? "#{@username}:#{@password}@" : ""
+    auth = @username && @password ? "#{@username}:#{@password.value}@" : ""
     @bulk_url = "http://#{auth}#{@host}:#{@port}/_bulk?replication=#{@replication}"
 
     buffer_initialize(


### PR DESCRIPTION
This patch will allow a user to set an option username and password in the elasticsearch_http output config.

This will be used in the post request to authenticate against an ES server that is sitting behind a proxy.

https://logstash.jira.com/browse/LOGSTASH-902
