### PR TITLE
Fix fail() invocation if no config file is given

### DIFF
--- a/lib/logstash/agent.rb
+++ b/lib/logstash/agent.rb
@@ -85,7 +85,7 @@ class LogStash::Agent < Clamp::Command
 
     # You must specify a config_string or config_path
     if config_string.nil? && config_path.nil?
-      fail(help + "\n", I18n.t("logstash.agent.missing-configuration"))
+      fail(help + "\n" + I18n.t("logstash.agent.missing-configuration"))
     end
 
     if @config_path


### PR DESCRIPTION
Fixes breakage introduced in 77bfd4ab.
