### PR TITLE
Stick to rufus-scheduler 2.0.x versions

### DIFF
--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "beefcake", "0.3.7"                #(MIT license)
   gem.add_runtime_dependency "php-serialize"                    # For input drupal_dblog (MIT license)
   gem.add_runtime_dependency "murmurhash3"                      #(MIT license)
-  gem.add_runtime_dependency "rufus-scheduler"                  #(MIT license)
+  gem.add_runtime_dependency "rufus-scheduler", "~> 2.0.24"     #(MIT license)
   gem.add_runtime_dependency "user_agent_parser", [">= 2.0.0"]  #(MIT license)
   gem.add_runtime_dependency "snmp"                             #(ruby license)
   gem.add_runtime_dependency "varnish-rb"                       #(MIT license)


### PR DESCRIPTION
Unbreaks tests as seen in https://travis-ci.org/logstash/logstash/jobs/12047597

Since version 3 of rufus-scheduler is a complete rewrite, I decided to stick with the 2.x version for now instead of adjusting the code to work with version 3. Once v3 proved to be stable the code can be switched over.
