### PR TITLE
Make ES index requests synchronous. Prior to this, I had incorrectly

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -164,8 +164,10 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
       end
     end
 
-    request.on(:success) { }
-    request.execute
+    request.execute!
+    # TODO(sissel): Handle errors. Since bulk requests could mostly succeed
+    # (aka partially fail), we need to figure out what documents need to be
+    # retried.
   end # def flush
 
 end # class LogStash::Outputs::Elasticsearch


### PR DESCRIPTION
assumed that elasticsearch acting as a client had a fixed-size thread
pool to limit the number of active bulk index requests. This now
executes bulk index requests one at a time.
