### PR TITLE
Unbreak #to_epoch method in datadog output plugin. (LOGSTASH-1427)

### DIFF
--- a/lib/logstash/outputs/datadog_metrics.rb
+++ b/lib/logstash/outputs/datadog_metrics.rb
@@ -116,7 +116,7 @@ class LogStash::Outputs::DatadogMetrics < LogStash::Outputs::Base
 
   private
   def to_epoch(t)
-    return Time.parse(t).to_i
+    return t.is_a?(Time) ? t.to_i : Time.parse(t).to_i
   end # def to_epoch
 
 end # class LogStash::Outputs::DatadogMetrics


### PR DESCRIPTION
The event timestamp might already be a Time object.
