### PR TITLE
Fix geoip filter with GeoLite ASN database. (LOGSTASH-1394)

### DIFF
--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "xml-simple"                       #(ruby license?)
   gem.add_runtime_dependency "xmpp4r", ["0.5"]                  #(ruby license)
   gem.add_runtime_dependency "jls-lumberjack", [">=0.0.19"]     #(Apache 2.0 license)
-  gem.add_runtime_dependency "geoip", [">= 1.1.0"]              #(GPL license)
+  gem.add_runtime_dependency "geoip", [">= 1.3.2"]              #(GPL license)
   gem.add_runtime_dependency "beefcake", "0.3.7"                #(MIT license)
   gem.add_runtime_dependency "php-serialize"                    # For input drupal_dblog (MIT license)
   gem.add_runtime_dependency "murmurhash3"                      #(MIT license)


### PR DESCRIPTION
For some reason, the GeoIP::ASN Struct in the geoip gem does not define
a to_hash method.

Pull request for geoip: cjheath/geoip#38
