### PR TITLE
relp: add missing socket param to serverclose

### DIFF
--- a/lib/logstash/util/relp.rb
+++ b/lib/logstash/util/relp.rb
@@ -79,7 +79,7 @@ class Relp#This isn't much use on its own, but gives RelpServer and RelpClient t
     end
     if ! self.valid_command?(frame['command'])#TODO: is this enough to catch framing errors?
       if self.server?
-        self.serverclose
+        self.serverclose(socket)
       else
         self.close
       end


### PR DESCRIPTION
This add the missing socket param when calling serverclose on RELP
