### PR TITLE
Fix memory leak in syslog input. (tcp server)

### DIFF
--- a/lib/logstash/inputs/syslog.rb
+++ b/lib/logstash/inputs/syslog.rb
@@ -4,6 +4,7 @@ require "logstash/filters/date"
 require "logstash/inputs/base"
 require "logstash/namespace"
 require "socket"
+require "thread_safe"
 
 # Read syslog messages as events over the network.
 #
@@ -63,7 +64,7 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
     @grok_filter.register
     @date_filter.register
 
-    @tcp_clients = []
+    @tcp_clients = ThreadSafe::Array.new
   end # def register
 
   public
@@ -150,6 +151,8 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
             end
           end
         rescue Errno::ECONNRESET
+        ensure
+          @tcp_clients.delete(client)
         end
       end # Thread.new
     end # loop do


### PR DESCRIPTION
Remove the client from the clients list when the connection is closed.

I decided to use `ThreadSafe::Array` here because we get away with less code and it is faster than manually locking/unlocking a mutex. (given my benchmark isn't flawed -- see below)

```
# jruby 1.7.5 (1.9.3p392) 2013-10-07 74e9291 on Java HotSpot(TM) 64-Bit Server VM 1.7.0_40-b43 [linux-amd64]
       user     system      total        real
core  5.950000   1.510000   7.460000 (  3.815000)
ts    1.550000   0.160000   1.710000 (  0.601000)
```

https://gist.github.com/bernd/6881191

The `thread_safe` gem is pulled in via `tzinfo` and `activesupport` but we should add it to the gemspec if this goes it.

This issue was brought up by Clément Demonchy on logstash-users. (`Message-Id: <25bcc791-b596-45ea-9cba-38fda6df8bd1@googlegroups.com>`)
