### PR TITLE
filters: elasticsearch: new filter for querying es

### DIFF
--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -1,0 +1,73 @@
+require "logstash/filters/base"
+require "logstash/namespace"
+require "logstash/util/fieldreference"
+
+# Search elasticsearch for a previous log event and copy some fields from it
+# into the current event.  Below is a complete example of how this filter might
+# be used.  Whenever logstash receives an "end" event, it uses this elasticsearch
+# filter to find the matching "start" event based on some operation identifier.
+# Then it copies the @timestamp field from the "start" event into a new field on
+# the "end" event.  Finally, using a combination of the "date" filter and the
+# "ruby" filter, we calculate the time duration in hours between the two events.
+#
+#       if [type] == "end" {
+#          elasticsearch {
+#             hosts => ["es-server"]
+#             query => "type:start AND operation:%{[opid]}"
+#             fields => ["@timestamp", "started"]
+#          }
+#
+#          date {
+#             match => ["[started]", "ISO8601"]
+#             target => "[started]"
+#          }
+#
+#          ruby {
+#             code => "event['duration_hrs'] = (event['@timestamp'] - event['started']) / 3600 rescue nil"
+#          }
+#       }
+#
+class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
+  config_name "elasticsearch"
+  milestone 1
+
+  # List of elasticsearch hosts to use for querying.
+  config :hosts, :validate => :array
+
+  # Elasticsearch query string
+  config :query, :validate => :string
+
+  # Comma-delimited list of <field>:<direction> pairs that define the sort order
+  config :sort, :validate => :string, :default => "@timestamp:desc"
+
+  # Hash of fields to copy from old event (found via elasticsearch) into new event
+  config :fields, :validate => :hash, :default => {}
+
+  public
+  def register
+    require "elasticsearch"
+
+    @logger.info("New ElasticSearch filter", :hosts => @hosts)
+    @client = Elasticsearch::Client.new hosts: @hosts
+  end # def register
+
+  public
+  def filter(event)
+    return unless filter?(event)
+
+    begin
+      query_str = event.sprintf(@query)
+
+      results = @client.search q: query_str, sort: @sort, size: 1
+
+      @fields.each do |old, new|
+        event[new] = results['hits']['hits'][0]['_source'][old]
+      end
+
+      filter_matched(event)
+    rescue => e
+      @logger.warn("Failed to query elasticsearch for previous event",
+                   :query => query_str, :event => event, :error => e)
+    end
+  end # def filter
+end # class LogStash::Filters::Elasticsearch

--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "heroku"                           #(MIT license)
   gem.add_runtime_dependency "addressable"                      #(Apache 2.0 license)
   gem.add_runtime_dependency "extlib", ["0.9.16"]               #(MIT license)
+  gem.add_runtime_dependency "elasticsearch"                    #(Apache 2.0 license)
   gem.add_runtime_dependency "ffi"                              #(LGPL-3 license)
   gem.add_runtime_dependency "ffi-rzmq", ["1.0.0"]              #(MIT license)
   gem.add_runtime_dependency "filewatch", ["0.5.1"]             #(BSD license)


### PR DESCRIPTION
Sometimes it's useful to be able to correlate new events with previous
events (e.g., to calculate time duration between events).  This filter
queries an elasticsearch host to find the top event matching the given
search criteria and copies specific fields from that event into the new
event.

Here's an example that will determine when an operation started and
store that timestamp into the ending event:

```
   if [type] == "end" {
      elasticsearch {
         host => "es-server"
         cluster => "es-cluster"
         query => "type:start AND operation:%{[opid]}"
         fields => ["@timestamp", "started"]
      }

      date {
         match => ["[started]", "ISO8601"]
         target => "[started]"
      }
   }
```
