### PR TITLE
Add 'workers' setting to output plugins.

### DIFF
--- a/lib/logstash/codecs/base.rb
+++ b/lib/logstash/codecs/base.rb
@@ -43,6 +43,6 @@ module LogStash::Codecs; class Base < LogStash::Plugin
 
   public
   def clone
-    return self.class.new(@params)
+    return self.class.new(params)
   end
 end; end # class LogStash::Codecs::Base

--- a/lib/logstash/config/config_ast.rb
+++ b/lib/logstash/config/config_ast.rb
@@ -175,7 +175,7 @@ module LogStash; module Config; module AST
             "end",
           ].map { |l| "#{l}\n" }.join("")
         when "output"
-          return "#{variable_name}.receive(event)\n"
+          return "#{variable_name}.handle(event)\n"
         when "codec"
           settings = attributes.recursive_select(Attribute).collect(&:compile).reject(&:empty?)
           attributes_code = "LogStash::Util.hash_merge_many(#{settings.map { |c| "{ #{c} }" }.join(", ")})"

--- a/lib/logstash/config/mixin.rb
+++ b/lib/logstash/config/mixin.rb
@@ -29,6 +29,7 @@ require "i18n"
 #
 module LogStash::Config::Mixin
   attr_accessor :config
+  attr_accessor :original_params
 
   CONFIGSORT = {
     Symbol => 0,
@@ -45,6 +46,11 @@ module LogStash::Config::Mixin
   def config_init(params)
     # Validation will modify the values inside params if necessary.
     # For example: converting a string to a number, etc.
+    
+    # Keep a copy of the original config params so that we can later
+    # differentiate between explicit configuration and implicit (default)
+    # configuration.
+    @original_params = params.clone
     
     # store the plugin type, turns LogStash::Inputs::Base into 'input'
     @plugin_type = self.class.ancestors.find { |a| a.name =~ /::Base$/ }.config_name

--- a/lib/logstash/pipeline.rb
+++ b/lib/logstash/pipeline.rb
@@ -206,6 +206,7 @@ class LogStash::Pipeline
   def outputworker
     LogStash::Util::set_thread_name(">output")
     @outputs.each(&:register)
+    @outputs.each(&:worker_setup)
     while true
       event = @filter_to_output.pop
       break if event == LogStash::ShutdownSignal


### PR DESCRIPTION
This allows you to run multiple workers for a single output in cases
where CPU or network IO are bottlenecks in a single output. The
original use case was to help improve elasticsearch_http performance.

elasticsearch_http blocks until the index request gets a response, so
simply doing more requests in-flight at any given time will improve
performance assuming processing or network-time is your bottleneck,
which in most cases it is.

In testing this, for 1,000,000 events, it took 150 seconds with 1
worker, 100 seconds with 2 workers, and 70 seconds with 4 workers. The
test was done on an EC2 m3.2xlarge logstash node writing to a two-node
elasticsearch 0.90.5 cluster on the same instance type (3 nodes total)
