### PR TITLE
Alter dependency for Java on Debian

### DIFF
--- a/pkg/build.sh
+++ b/pkg/build.sh
@@ -102,7 +102,7 @@ case $os in
       -a all --iteration "${os}1${REVISION}" \
       --url "http://logstash.net" \
       --description "An extensible logging pipeline" \
-      -d "default-jre" \
+      -d "java6-runtime-headless | java7-runtime-headless" \
       --deb-user root --deb-group root \
       --before-install $os/before-install.sh \
       --before-remove $os/before-remove.sh \


### PR DESCRIPTION
- We don't want to pull in java6 when java7 is already installed

With the previous dependency, logstash would pull in java6 even if java7 was installed because default-jre doesn't depend on java7-runtime.

Also, logstash doesn't need all that graphical stuff, so pull in -headless only
