### PR TITLE
Fix json codec

### DIFF
--- a/spec/codecs/json.rb
+++ b/spec/codecs/json.rb
@@ -10,7 +10,20 @@ describe LogStash::Codecs::JSON do
   context "#decode" do
     it "should return an event from json data" do
       data = {"foo" => "bar", "baz" => {"bah" => ["a","b","c"]}}
+      subject.decode(data.to_json+"\n") do |event|
+        insist { event.is_a? LogStash::Event }
+        insist { event["foo"] } == data["foo"]
+        insist { event["baz"] } == data["baz"]
+        insist { event["bah"] } == data["bah"]
+      end
+    end
+    
+    it "should return an event from json data when a newline is recieved" do
+      data = {"foo" => "bar", "baz" => {"bah" => ["a","b","c"]}}
       subject.decode(data.to_json) do |event|
+        insist {false}
+      end
+      subject.decode("\n") do |event|
         insist { event.is_a? LogStash::Event }
         insist { event["foo"] } == data["foo"]
         insist { event["baz"] } == data["baz"]


### PR DESCRIPTION
Json codec should now properly parse json hashes delimited by newline.
