### PR TITLE
Fixed varname for endpoint_region

### DIFF
--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -150,9 +150,9 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
  # Method to set up the aws configuration and establish connection
  def aws_s3_config
 
-  @region_endpoint == 'us-east-1' ? @region_endpoint = 's3.amazonaws.com' : @region_endpoint = 's3-'+@region_endpoint+'.amazonaws.com'
+  @endpoint_region == 'us-east-1' ? @endpoint_region = 's3.amazonaws.com' : @endpoint_region = 's3-'+@endpoint_region+'.amazonaws.com'
 
-  @logger.info("Registering s3 output", :bucket => @bucket, :region_endpoint => @region_endpoint)
+  @logger.info("Registering s3 output", :bucket => @bucket, :endpoint_region => @endpoint_region)
 
   AWS.config(
     :access_key_id => @access_key_id,


### PR DESCRIPTION
Var were  misnamed, therefore the plugin was failing on : 

Exception in thread "LogStash::Runner" org.jruby.exceptions.RaiseException: (TypeError) can't convert nil into String
    at org.jruby.RubyString.+(org/jruby/RubyString.java:1137)
    at RUBY.aws_s3_config(file:/opt/logstash/server/lib/logstash-1.2.2.dev-flatjar.jar!/logstash/outputs/s3.rb:153)
    at RUBY.write_on_bucket(file:/opt/logstash/server/lib/logstash-1.2.2.dev-flatjar.jar!/logstash/outputs/s3.rb:185)
    at RUBY.upFile(file:/opt/logstash/server/lib/logstash-1.2.2.dev-flatjar.jar!/logstash/outputs/s3.rb:221)
    at org.jruby.RubyArray.each(org/jruby/RubyArray.java:1617)
    at RUBY.upFile(file:/opt/logstash/server/lib/logstash-1.2.2.dev-flatjar.jar!/logstash/outputs/s3.rb:213)
    at RUBY.receive(file:/opt/logstash/server/lib/logstash-1.2.2.dev-flatjar.jar!/logstash/outputs/s3.rb:327)
    at RUBY.worker_setup(file:/opt/logstash/server/lib/logstash-1.2.2.dev-flatjar.jar!/logstash/outputs/base.rb:65)
