### PR TITLE
Added 'proxy_uri' option to AWS-based plugins.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,6 +36,7 @@
   - bugfix: elasticsearch: the default port range is now 9300-9305; the older
     range up to 9400 was unnecessary and could cause problems for the
     elasticsearch cluster in some cases.
+  - improvement: aws-based outputs (e.g. cloudwatch) now support proxy uri.
   - bugfix: rabbitmq: disable automatic connection recovery (LOGSTASH-1350)
     (#642)
   - bugfix: riemann: fixed tagging of riemann events (#631)

--- a/lib/logstash/plugin_mixins/aws_config.rb
+++ b/lib/logstash/plugin_mixins/aws_config.rb
@@ -35,6 +35,9 @@ module LogStash::PluginMixins::AwsConfig
     # The AWS SDK for Ruby defaults to SSL so we preserve that
     config :use_ssl, :validate => :boolean, :default => true
 
+    # URI to proxy server if required
+    config :proxy_uri, :validate => :string
+
     # Path to YAML file containing a hash of AWS credentials.   
     # This file will only be loaded if `access_key_id` and
     # `secret_access_key` aren't set. The contents of the
@@ -67,6 +70,10 @@ module LogStash::PluginMixins::AwsConfig
     end
 
     opts[:use_ssl] = @use_ssl
+
+    if (@proxy_uri)
+      opts[:proxy_uri] = @proxy_uri
+    end
 
     # The AWS SDK for Ruby doesn't know how to make an endpoint hostname from a region
     # for example us-west-1 -> foosvc.us-west-1.amazonaws.com


### PR DESCRIPTION
This is directly supported through the Ruby AWS STDK.
