### PR TITLE
update metrics docs, base handle needs to guard against empty worker_queue

### DIFF
--- a/lib/logstash/filters/metrics.rb
+++ b/lib/logstash/filters/metrics.rb
@@ -51,29 +51,28 @@ require "logstash/namespace"
 # #### Example: computing event rate
 #
 # For a simple example, let's track how many events per second are running
-# through logstash:
-#
-#     input {
-#       generator {
-#         type => "generated"
-#       }
+# input {
+#   generator {
+#     type => "generated"
+#   }
+# }
+
+# filter {
+#   if [type] == "generated" {
+#     metrics {
+#       meter => ["events"]
+#       add_field => [ "type", "metric" ]
 #     }
-#
-#     filter {
-#       metrics {
-#         type => "generated"
-#         meter => "events"
-#         add_tag => "metric"
-#       }
+#   }
+# }
+
+# output {
+#   if [type] == "metric" {
+#     stdout{
+#       message => "rate: %{events.rate_1m}"
 #     }
-#
-#     output {
-#       stdout {
-#         # only emit events with the 'metric' tag
-#         tags => "metric"
-#         message => "rate: %{events.rate_1m}"
-#       }
-#     }
+#   }
+# }
 #
 # Running the above:
 #

--- a/lib/logstash/outputs/base.rb
+++ b/lib/logstash/outputs/base.rb
@@ -70,13 +70,13 @@ class LogStash::Outputs::Base < LogStash::Plugin
 
   public
   def handle(event)
-    #if @worker_queue
+    if @worker_queue
       handle_worker(event)
-    #else
-      #receive(event)
-    #end
+    else
+      receive(event)
+    end
   end # def handle
-  
+
   def handle_worker(event)
     @worker_queue.push(event)
   end


### PR DESCRIPTION
This work requires something calling flush on filters. Otherwise the metrics filter doesn't work, as they are never flushed. I tested by merging my branch with logstash#689, I didn't include that in this commit.
