### PR TITLE
Further validate date filter within register method

### DIFF
--- a/lib/logstash/filters/date.rb
+++ b/lib/logstash/filters/date.rb
@@ -125,6 +125,11 @@ class LogStash::Filters::Date < LogStash::Filters::Base
   public
   def register
     require "java"
+    if @match.length < 2
+      raise LogStash::ConfigurationError, I18n.t("logstash.agent.configuration.invalid_plugin_register", 
+        :plugin => "filter", :type => "date",
+        :error => "The match setting should contains first a field name and at least one date format, current value is #{@match}")
+    end
     # TODO(sissel): Need a way of capturing regexp configs better.
     locale = parseLocale(@config["locale"][0]) if @config["locale"] != nil and @config["locale"][0] != nil
     setupMatcher(@config["match"].shift, locale, @config["match"] )

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -89,6 +89,10 @@ en:
             }
         invalid_plugin_settings: >-
           Something is wrong with your configuration.
+        invalid_plugin_register: >-
+          Cannot register %{plugin} %{type} plugin.
+          The error reported is: 
+            %{error}
         plugin_path_missing: >-
           You specified a plugin path that does not exist: %{path}
         no_plugins_found: |-

--- a/spec/filters/date.rb
+++ b/spec/filters/date.rb
@@ -5,6 +5,21 @@ puts "Skipping date performance tests because this ruby is not jruby" if RUBY_EN
 RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
   extend LogStash::RSpec
 
+  describe "giving an invalid match config, raise a configuration error" do
+    config <<-CONFIG
+      filter {
+        date {
+          match => [ "mydate"]
+        }
+      }
+    CONFIG
+
+    sample "not_really_important" do
+      insist {subject}.raises LogStash::ConfigurationError
+    end
+
+  end
+
   describe "parsing with ISO8601" do
     config <<-CONFIG
       filter {


### PR DESCRIPTION
As mentioned in LOGSTASH-1149, the date filter should further validate the match settings from its config to ensure it contains at least two elements for field name and date format.
