### PR TITLE
Restore default type and tags in test_utils

### DIFF
--- a/spec/examples/syslog.rb
+++ b/spec/examples/syslog.rb
@@ -2,7 +2,7 @@ require "test_utils"
 
 describe "parse syslog", :if => RUBY_ENGINE == "jruby" do
   extend LogStash::RSpec
-
+  type "syslog"
   config <<-'CONFIG'
     filter {
       grok {
@@ -32,14 +32,14 @@ describe "parse syslog", :if => RUBY_ENGINE == "jruby" do
     }
   CONFIG
 
-  sample("message" => "<164>Oct 26 15:19:25 1.2.3.4 %ASA-4-106023: Deny udp src DRAC:10.1.2.3/43434 dst outside:192.168.0.1/53 by access-group \"acl_drac\" [0x0, 0x0]", "type" => "syslog") do
+  sample "<164>Oct 26 15:19:25 1.2.3.4 %ASA-4-106023: Deny udp src DRAC:10.1.2.3/43434 dst outside:192.168.0.1/53 by access-group \"acl_drac\" [0x0, 0x0]" do
     insist { subject["type"] } == "syslog"
     insist { subject["tags"] }.nil?
     insist { subject["syslog_pri"] } == "164"
   end
 
   # Single digit day
-  sample("message" => "<164>Oct  6 15:19:25 1.2.3.4 %ASA-4-106023: Deny udp src DRAC:10.1.2.3/43434 dst outside:192.168.0.1/53 by access-group \"acl_drac\" [0x0, 0x0]", "type" => "syslog") do
+  sample "<164>Oct  6 15:19:25 1.2.3.4 %ASA-4-106023: Deny udp src DRAC:10.1.2.3/43434 dst outside:192.168.0.1/53 by access-group \"acl_drac\" [0x0, 0x0]" do
     insist { subject["type"] } == "syslog"
     insist { subject["tags"] }.nil?
     insist { subject["syslog_pri"] } == "164"

--- a/spec/test_utils.rb
+++ b/spec/test_utils.rb
@@ -61,6 +61,12 @@ module LogStash
           sample_event = [sample_event] unless sample_event.is_a?(Array)
           next sample_event.collect do |e|
             e = { "message" => e } if e.is_a?(String)
+            if e["type"].nil? && defined?default_type
+              e["type"] = default_type
+            end
+            if e["tags"].nil? && defined?default_tags
+              e["tags"] = default_tags
+            end
             next LogStash::Event.new(e)
           end
         end


### PR DESCRIPTION
Restore the possibility to define default type and tags within a test, more useful for example and integration tests than unit tests, but still very useful.
I simplified the syslog example as an example
