### PR TITLE
input elasticsearch: optionally capture document metadata (document type...

### DIFF
--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -16,8 +16,6 @@ require "logstash/util/socket_peer"
 #       }
 #     }
 #
-# * TODO(sissel): configurable scroll timeout
-# * TODO(sissel): Option to keep the index, type, and doc id so we can do reindexing?
 class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   config_name "elasticsearch"
   milestone 1
@@ -47,6 +45,42 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   # The timeout applies per round trip (i.e. between the previous scan scroll request, to the next).
   config :scroll, :validate => :string, :default => "1m"
 
+  # If true, the event will include meta data of the original elastic document: index ('_index') , document ('_type') and document id ('_id'). By default storted in an 'es_meta' field.
+  # This metadata can be used to in reindexing scenarios to update rather than append existing indices 
+  #
+  # Example
+  #      input {
+  #        elasticsearch {
+  #           host => "es.production.mysite.org"
+  #           index => "mydata-2018.09.*"
+  #           query => "*"
+  #           size => 500
+  #           scroll => "5m"
+  #           include_meta => true
+  #           meta_field => "es_orig"
+  #        }
+  #      }
+  #      output {
+  #        elasticsearch_http {
+  #          host => "localhost"
+  #          index => "copy-of-production.%{[es_orig][_index]}"
+  #          index_type => "%{[es_orig][_type]}"
+  #          document_id => "%{[es_orig][_id]}"
+  #        }
+  #      }
+  # ( TODO : make the list of metadata fields configurable (?document version field)  )
+  # ( TODO : elasticsearch output might need to use the bulk/create API instead
+  #          of bulk/index API to avoid overwriting existing documents in the target index (idempotency)
+  #          This is not yet supported in the elasticsearch outputs )
+  # ( TODO : this solution stores the metadata as normal data on the target index. 
+  #          consider alternative approach: include_meta will take the 'hit' document (including metadata) 
+  #          and configure a custom output codec for elastic to index only the '_source' field )
+  config :include_meta, :validate=> :boolean, :default => false
+  
+  # The (fixed) field name under which metadata of the original elastic document is stored
+  # ( TODO : should this be a dynamic sprintf field ?) 
+  config :meta_field, :validate=> :string, :default => "es_meta"
+
   public
   def register
     require "ftw"
@@ -72,23 +106,26 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   public
   def run(output_queue)
 
+    @logger.debug("scroll initialization",:request => @url)
     # Execute the search request
     response = @agent.get!(@url)
     json = ""
     response.read_body { |c| json << c }
     result = JSON.parse(json)
-    scroll_id = result["_scroll_id"]
+    scroll_url = @url
 
     # When using the search_type=scan we don't get an initial result set.
     # So we do it here.
-    if @scan
-
+    if @scan and not result.nil? and not result["_scroll_id"].nil?    
+      scroll_id = result["_scroll_id"]
       scroll_params = {
         "scroll_id" => scroll_id,
         "scroll" => @scroll
       }
 
       scroll_url = "http://#{@host}:#{@port}/_search/scroll?#{encode(scroll_params)}"
+      @logger.debug("initial scan",:request => scroll_url)
+      
       response = @agent.get!(scroll_url)
       json = ""
       response.read_body { |c| json << c }
@@ -98,12 +135,23 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
 
     while true
       break if result.nil?
+      if result["error"]
+        @logger.warn(result["error"], :request => scroll_url)
+        break
+      end
+      
       hits = result["hits"]["hits"]
       break if hits.empty?
 
       hits.each do |hit|
         event = hit["_source"]
-
+        if @include_meta 
+           event[@meta_field] = { 
+               '_index' => hit['_index'],
+               '_type' => hit['_type'],
+               '_id' => hit['_id']
+           }
+        end
         # Hack to make codecs work
         @codec.decode(event.to_json) do |event|
           decorate(event)
@@ -113,6 +161,10 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
 
       # Get the scroll id from the previous result set and use it for getting the next data set
       scroll_id = result["_scroll_id"]
+      if scroll_id.nil?
+         @logger.warn("no _scroll_id in result", :request => scroll_url)
+         break 
+      end
 
       # Fetch the next result set
       scroll_params = {
@@ -120,18 +172,11 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
         "scroll" => @scroll
       }
       scroll_url = "http://#{@host}:#{@port}/_search/scroll?#{encode(scroll_params)}"
-
+      @logger.debug("scroll request",:request => scroll_url)
       response = @agent.get!(scroll_url)
       json = ""
       response.read_body { |c| json << c }
       result = JSON.parse(json)
-
-      if result["error"]
-        @logger.warn(result["error"], :request => scroll_url)
-        # TODO(sissel): raise an error instead of breaking
-        break
-      end
-
     end
   rescue LogStash::ShutdownSignal
     # Do nothing, let us quit.


### PR DESCRIPTION
..., index, document id)
The patch also contains some debug and failure handling for the previous fix  https://github.com/logstash/logstash/pull/670 on the scroll id
