### PR TITLE
Update libs and dep versions to use cabin >= 0.6.0 and avoid conflicting

### DIFF
--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.version       = LOGSTASH_VERSION
 
   # Core dependencies
-  gem.add_runtime_dependency "cabin", ["0.5.0"]   #(Apache 2.0 license)
+  gem.add_runtime_dependency "cabin", [">=0.6.0"]   #(Apache 2.0 license)
   gem.add_runtime_dependency "json"               #(ruby license)
   gem.add_runtime_dependency "minitest"           # for running the tests from the jar, (MIT license)
   gem.add_runtime_dependency "pry"                #(ruby license)
@@ -48,7 +48,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "gelf", ["1.3.2"]                  #(MIT license)
   gem.add_runtime_dependency "gmetric", ["0.1.3"]               #(MIT license)
   gem.add_runtime_dependency "jiralicious", ["0.2.2"]		#(MIT license)
-  gem.add_runtime_dependency "jls-grok", ["0.10.11"]            #(BSD license)
+  gem.add_runtime_dependency "jls-grok", ["0.10.12"]            #(BSD license)
   gem.add_runtime_dependency "mail"                             #(MIT license)
   gem.add_runtime_dependency "mongo"                            #(Apache 2.0 license)
   gem.add_runtime_dependency "metriks"                          #(MIT license)


### PR DESCRIPTION
0.5 and 0.6 installs. (LOGSTASH-1497)

This was observed as a result of ugprading to jruby 1.7.5 (thus
upgrading rubygems). I believe the order of operations in dependency
resolution was changed to trigger this. Basically, ftw wants cabin>0,
logstash wanted cabin=0.5.0, and if ftw is satisfied first then
logstash's dep fails.
