### PR TITLE
Update docs to point to the new, elasticsearch-hosted download

### DIFF
--- a/docs/index.html.erb
+++ b/docs/index.html.erb
@@ -6,7 +6,7 @@ layout: content_right
 
   <h3> for users </h3>
   <ul>
-    <li> <a href="https://logstash.objects.dreamhost.com/release/logstash-%VERSION%-flatjar.jar"> download logstash %VERSION% </a> </li>
+    <li> <a href="https://download.elasticsearch.org/logstash/logstash/logstash-%VERSION%-flatjar.jar"> download logstash %VERSION% </a> </li>
     <li> <a href="configuration"> configuration file overview </a> </li>
     <li> <a href="configuration#conditionals">conditionals</a> </li>
     <li> <a href="configuration#fieldreferences">referring to fields [like][this]</a> </li>

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -38,7 +38,7 @@ for such things, that works for me, too.)
 
 ## Download It
 
-[Download logstash-%VERSION%](https://logstash.objects.dreamhost.com/release/logstash-%VERSION%-flatjar.jar)
+[Download logstash-%VERSION%](https://download.elasticsearch.org/logstash/logstash/logstash-%VERSION%-flatjar.jar)
 
 ## What's next?
 

--- a/docs/tutorials/10-minute-walkthrough/index.md
+++ b/docs/tutorials/10-minute-walkthrough/index.md
@@ -8,7 +8,7 @@ layout: content_right
 
 ### Download logstash:
 
-* [logstash-%VERSION%-flatjar.jar](http://logstash.objects.dreamhost.com/release/logstash-%VERSION%-flatjar.jar)
+* [logstash-%VERSION%-flatjar.jar](https://download.elasticsearch.org/logstash/logstash/logstash-%VERSION%-flatjar.jar)
 
 ### Requirements:
 

--- a/docs/tutorials/getting-started-centralized.md
+++ b/docs/tutorials/getting-started-centralized.md
@@ -75,7 +75,7 @@ ready to configure logstash.
 Download the logstash release jar file. The package contains all
 required dependencies to save you time chasing down requirements.
 
-Follow [this link to download logstash-%VERSION%](http://logstash.objects.dreamhost.com/release/logstash-%VERSION%-flatjar.jar).
+Follow [this link to download logstash-%VERSION%](https://download.elasticsearch.org/logstash/logstash/logstash-%VERSION%-flatjar.jar).
 
 Since we're doing a centralized configuration, you'll have two main
 logstash agent roles: a shipper and an indexer. You will ship logs from

--- a/docs/tutorials/getting-started-simple.md
+++ b/docs/tutorials/getting-started-simple.md
@@ -27,7 +27,7 @@ If you have problems, feel free to email the users list
 
 You should download the logstash jar file - if you haven't yet,
 [download it
-now](http://logstash.objects.dreamhost.com/release/logstash-%VERSION%-flatjar.jar).
+now](https://download.elasticsearch.org/logstash/logstash/logstash-%VERSION%-flatjar.jar).
 This package includes most of the dependencies for logstash in it and
 helps you get started quicker.
 


### PR DESCRIPTION
Several links in the docs were incorrect, this should resolve this.
