### PR TITLE
- fix region_endpoint handling

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -65,8 +65,6 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
 
     @region_endpoint = @region if !@region.nil? && !@region.empty?
 
-    @region_endpoint == 'us-east-1' ? @region_endpoint = 's3.amazonaws.com' : @region_endpoint = 's3-'+@region_endpoint+'.amazonaws.com'
-
     @logger.info("Registering s3 input", :bucket => @bucket, :region_endpoint => @region_endpoint)
 
     if @credentials.nil?


### PR DESCRIPTION
We don't need to generate the hostname in @region_endpoint, we only need to send @region_endpoint as is to the S3 library, which will handle hostname generation.
