### PR TITLE
Add headers parameter to websocket input plugin

### DIFF
--- a/lib/logstash/inputs/websocket.rb
+++ b/lib/logstash/inputs/websocket.rb
@@ -12,6 +12,9 @@ class LogStash::Inputs::Websocket < LogStash::Inputs::Base
   # The url to connect to or serve from
   config :url, :validate => :string, :default => "0.0.0.0"
 
+  # Additional headers
+  config :headers, :validate => :hash, :default => {}
+
   # Operate as a client or a server.
   #
   # Client mode causes this plugin to connect as a websocket client
@@ -31,7 +34,7 @@ class LogStash::Inputs::Websocket < LogStash::Inputs::Base
     # TODO(sissel): Implement server mode.
     agent = FTW::Agent.new
     begin
-      websocket = agent.websocket!(@url)
+      websocket = agent.websocket!(@url, { :headers => @headers })
       websocket.each do |payload|
         @codec.decode(payload) do |event|
           decorate(event)


### PR DESCRIPTION
I need this option to specify different header parameters needed by some websocket endpoints.

Websocket plugin has still an error in https://github.com/jordansissel/ruby-ftw/blob/master/lib/ftw/websocket.rb#L111, which is not avalible.
