### PR TITLE
Modify AWS components to use the the AwsConfig mixin

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -1,5 +1,6 @@
 require "logstash/inputs/base"
 require "logstash/namespace"
+require "logstash/plugin_mixins/aws_config"
 
 require "aws-sdk"
 require "time"
@@ -10,6 +11,8 @@ require "tmpdir"
 # Each line from each file generates an event.
 # Files ending in '.gz' are handled as gzip'ed files.
 class LogStash::Inputs::S3 < LogStash::Inputs::Base
+  include LogStash::PluginMixins::AwsConfig
+
   config_name "s3"
   milestone 1
 
@@ -17,26 +20,8 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
   # support and readline usage). Support gzip through a gzip codec! ;)
   default :codec, "plain"
 
-  # The credentials of the AWS account used to access the bucket.
-  # Credentials can be specified:
-  # - As an ["id","secret"] array
-  # - As a path to a file containing AWS_ACCESS_KEY_ID=... and AWS_SECRET_ACCESS_KEY=...
-  # - In the environment (variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY)
-  config :credentials, :validate => :array, :default => nil
-
   # The name of the S3 bucket.
   config :bucket, :validate => :string, :required => true
-
-  # The AWS region for your bucket.
-  config :region, :validate => ["us-east-1", "us-west-1", "us-west-2",
-                                "eu-west-1", "ap-southeast-1", "ap-southeast-2",
-                                "ap-northeast-1", "sa-east-1", "us-gov-west-1"],
-                                :deprecated => "'region' has been deprecated in favor of 'region_endpoint'"
-
-  # The AWS region for your bucket.
-  config :region_endpoint, :validate => ["us-east-1", "us-west-1", "us-west-2",
-                                "eu-west-1", "ap-southeast-1", "ap-southeast-2",
-                                "ap-northeast-1", "sa-east-1", "us-gov-west-1"], :default => "us-east-1"
 
   # If specified, the prefix the filenames in the bucket must match (not a regexp)
   config :prefix, :validate => :string, :default => nil
@@ -63,42 +48,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
   def register
     require "digest/md5"
 
-    @region_endpoint = @region if !@region.empty?
-
-    @region_endpoint == 'us-east-1' ? @region_endpoint = 's3.amazonaws.com' : @region_endpoint = 's3-'+@region_endpoint+'.amazonaws.com'
-
-    @logger.info("Registering s3 input", :bucket => @bucket, :region_endpoint => @region_endpoint)
-
-    if @credentials.nil?
-      @access_key_id = ENV['AWS_ACCESS_KEY_ID']
-      @secret_access_key = ENV['AWS_SECRET_ACCESS_KEY']
-    elsif @credentials.is_a? Array
-      if @credentials.length ==1
-        File.open(@credentials[0]) { |f| f.each do |line|
-          unless (/^\#/.match(line))
-            if(/\s*=\s*/.match(line))
-              param, value = line.split('=', 2)
-              param = param.chomp().strip()
-              value = value.chomp().strip()
-              if param.eql?('AWS_ACCESS_KEY_ID')
-                @access_key_id = value
-              elsif param.eql?('AWS_SECRET_ACCESS_KEY')
-                @secret_access_key = value
-              end
-            end
-          end
-        end
-        }
-      elsif @credentials.length == 2
-        @access_key_id = @credentials[0]
-        @secret_access_key = @credentials[1]
-      else
-        raise ArgumentError.new('Credentials must be of the form "/path/to/file" or ["id", "secret"]')
-      end
-    end
-    if @access_key_id.nil? or @secret_access_key.nil?
-      raise ArgumentError.new('Missing AWS credentials')
-    end
+    @logger.info("Registering s3 input", :bucket => @bucket, :region => @region)
 
     if @bucket.nil?
       raise ArgumentError.new('Missing AWS bucket')
@@ -111,11 +61,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
       @sincedb_path = File.join(ENV["HOME"], ".sincedb_" + Digest::MD5.hexdigest("#{@bucket}+#{@prefix}"))
     end
 
-    s3 = AWS::S3.new(
-      :access_key_id => @access_key_id,
-      :secret_access_key => @secret_access_key,
-      :region => @region_endpoint
-    )
+    s3 = AWS::S3.new(aws_options_hash)
 
     @s3bucket = s3.buckets[@bucket]
 

--- a/lib/logstash/inputs/sqs.rb
+++ b/lib/logstash/inputs/sqs.rb
@@ -75,13 +75,6 @@ class LogStash::Inputs::SQS < LogStash::Inputs::Threadable
   config :sent_timestamp_field, :validate => :string
 
   public
-  def aws_service_endpoint(region)
-    return {
-        :sqs_endpoint => "sqs.#{region}.amazonaws.com"
-    }
-  end
-
-  public
   def register
     @logger.info("Registering SQS input", :queue => @queue)
     require "aws-sdk"

--- a/lib/logstash/outputs/sns.rb
+++ b/lib/logstash/outputs/sns.rb
@@ -47,13 +47,6 @@ class LogStash::Outputs::Sns < LogStash::Outputs::Base
   config :publish_boot_message_arn, :validate => :string
 
   public
-  def aws_service_endpoint(region)
-    return {
-        :sns_endpoint => "sns.#{region}.amazonaws.com"
-    }
-  end
-
-  public
   def register
     require "aws-sdk"
 
@@ -113,7 +106,7 @@ class LogStash::Outputs::Sns < LogStash::Outputs::Base
   def self.format_message(event)
     message =  "Date: #{event["@timestamp"]}\n"
     message << "Source: #{event["source"]}\n"
-    message << "Tags: #{event["tags"].join(', ')}\n"
+    message << "Tags: #{event["tags"].join(', ')}\n" if event["tags"]
     message << "Fields: #{event.to_hash.inspect}\n"
     message << "Message: #{event["message"]}"
 

--- a/lib/logstash/plugin_mixins/aws_config.rb
+++ b/lib/logstash/plugin_mixins/aws_config.rb
@@ -75,16 +75,7 @@ module LogStash::PluginMixins::AwsConfig
       opts[:proxy_uri] = @proxy_uri
     end
 
-    # The AWS SDK for Ruby doesn't know how to make an endpoint hostname from a region
-    # for example us-west-1 -> foosvc.us-west-1.amazonaws.com
-    # So our plugins need to know how to generate their endpoints from a region
-    # Furthermore, they need to know the symbol required to set that value in the AWS SDK
-    # Classes using this module must implement aws_service_endpoint(region:string)
-    # which must return a hash with one key, the aws sdk for ruby config symbol of the service
-    # endpoint, which has a string value of the service endpoint hostname
-    # for example, CloudWatch, { :cloud_watch_endpoint => "monitoring.#{region}.amazonaws.com" }
-    # For a list, see https://github.com/aws/aws-sdk-ruby/blob/master/lib/aws/core/configuration.rb
-    opts.merge!(self.aws_service_endpoint(@region))
+    opts[:region] = @region
     
     return opts
   end # def aws_options_hash


### PR DESCRIPTION
Modify the AWS components to all ensure the same usage of AwsConfig mixin. The latest AWS RubySDK configures the endpoint based upon the region specified in the AWS.Config(....) or the AWS:<component>.new(...)

See http://ruby.awsblog.com/post/TxVOTODBPHAEP9/Working-with-Regions for more details about working with Regions.

This PR also addresses two other small issues:
- The S3 Output plugin creation of the temp directory failing as Dir.mkdir(...) will not create directories recursively.
- If no tags are specified for an event, the format_message method will fail as it is calling .join(',') on Nil
