### PR TITLE
Adds pre-aggregation for the metrics filter

### DIFF
--- a/lib/logstash/filters/metrics.rb
+++ b/lib/logstash/filters/metrics.rb
@@ -146,8 +146,11 @@ class LogStash::Filters::Metrics < LogStash::Filters::Base
       return
     end
 
+    # If there is a count attached to the event, we increment by that count
+    increment = event["count"].nil? ? 1 : event["count"]
+
     @meter.each do |m|
-      @metric_meters[event.sprintf(m)].mark
+      @metric_meters[event.sprintf(m)].mark(increment)
     end
 
     @timer.each do |name, value|

--- a/spec/filters/metrics.rb
+++ b/spec/filters/metrics.rb
@@ -21,12 +21,12 @@ describe LogStash::Filters::Metrics do
           filter = LogStash::Filters::Metrics.new config
           filter.register
           filter.filter LogStash::Event.new({"response" => 200})
-          filter.filter LogStash::Event.new({"response" => 200})
+          filter.filter LogStash::Event.new({"response" => 200, "count" => 2})
           filter.filter LogStash::Event.new({"response" => 404})
 
           events = filter.flush
           insist { events.length } == 1
-          insist { events.first["http.200.count"] } == 2
+          insist { events.first["http.200.count"] } == 3
           insist { events.first["http.404.count"] } == 1
         end
       end


### PR DESCRIPTION
This allows users to add a count to their events if they are already
pre-aggregated. This is useful when you have a lot of events that
Logstash could not process, coming from multiple places, and you want to
aggregate them without sending an event for each of them.

For example, in our situation, without this we would need to send around 120k events per second.

This is optimal for situations where you do not want per-event details but care more about the rate/speed of a huge amount of events.
