### PR TITLE
Use 4560 (log4j default) as default port

### DIFF
--- a/lib/logstash/inputs/log4j.rb
+++ b/lib/logstash/inputs/log4j.rb
@@ -19,7 +19,7 @@ class LogStash::Inputs::Log4j < LogStash::Inputs::Base
 
   # When mode is `server`, the port to listen on.
   # When mode is `client`, the port to connect to.
-  config :port, :validate => :number, :required => true
+  config :port, :validate => :number, :default => 4560
 
   # Read timeout in seconds. If a particular tcp connection is
   # idle for more than this timeout period, we will assume


### PR DESCRIPTION
Log4j uses 4560 as default port. I suggest the "port" parameter of the log4j input uses that.
