### PR TITLE
- disable flush in multiline filter since the codec is preferred now and

### DIFF
--- a/lib/logstash/filters/multiline.rb
+++ b/lib/logstash/filters/multiline.rb
@@ -225,8 +225,10 @@ class LogStash::Filters::Multiline < LogStash::Filters::Base
   end # def filter
 
   # Flush any pending messages. This is generally used for unit testing only.
+  #
+  # Note: flush is disabled now; it is preferable to use the multiline codec.
   public
-  def flush
+  def __flush
     events = []
     @pending.each do |key, value|
       value.uncancel


### PR DESCRIPTION
the semantics of flushing have changed (#689)
