### PR TITLE
Add GeoJSON capability

### DIFF
--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -43,7 +43,7 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
 
   # Specify what type of coordinates to use:
   # geoip (default output of GeoIP), geojson ('location':[lon/lat])
-  config :coord_type, :validate => :string, :default => 'geoip'
+  config :coordinate_schema, :validate => :string, :default => 'geoip'
 
   public
   def register
@@ -71,6 +71,9 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
       end
     end
     @logger.info("Using geoip database", :path => @database)
+    if @coordinate_schema == 'geoip' 
+      @logger.warn("GeoJSON will soon be the default type.  Be sure to hard-code \"coordinate_schema => 'geoip'\" if you desire the GeoIP type.")
+    end
     @geoip = ::GeoIP.new(@database)
 
     @geoip_type = case @geoip.database_type
@@ -121,7 +124,7 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
         event[@target][key.to_s] = value
       end
     end # geo_data_hash.each
-    if @coord_type == 'geojson' 
+    if @coordinate_schema == 'geojson' 
       if event[@target].key?('latitude') && event[@target].key?('longitude')
         event['location'] = [ event[@target]["longitude"].to_f, event[@target]["latitude"].to_f ] 
         event[@target].delete('longitude')


### PR DESCRIPTION
Supersedes pull request #760

Updated to meet Jordan’s expectation of only 1 new setting and no duplicated data.
Data can be in ‘geoip’ format (current default) with geoip.latitude & geoip.longitude
or
geojson format, which is ‘location’: [lon,lat].  This works for Kibana’s bettermap and for Elasticsearch’s geo_point format (with appropriate mapping).
