### PR TITLE
digest/sha2 was required for sqs to connect successfully

### DIFF
--- a/lib/logstash/inputs/sqs.rb
+++ b/lib/logstash/inputs/sqs.rb
@@ -1,6 +1,7 @@
 require "logstash/inputs/threadable"
 require "logstash/namespace"
 require "logstash/plugin_mixins/aws_config"
+require "digest/sha2"
 
 # Pull events from an Amazon Web Services Simple Queue Service (SQS) queue.
 #

--- a/lib/logstash/outputs/sqs.rb
+++ b/lib/logstash/outputs/sqs.rb
@@ -2,6 +2,7 @@ require "logstash/outputs/base"
 require "logstash/namespace"
 require "logstash/plugin_mixins/aws_config"
 require "stud/buffer"
+require "digest/sha2"
 
 # Push events to an Amazon Web Services Simple Queue Service (SQS) queue.
 #


### PR DESCRIPTION
https://logstash.jira.com/browse/LOGSTASH-1565

My colleague Zach Walls noticed this error with the 1.2.2 jars available:

Unable to access SQS queue 'Logstash_Testing_Queue': uninitialized constant Digest::SHA256 {:level=>:error}

We ended up trying the latest source and had the same issue. Eventually added digest/sha2 requirements to both input and output sqs.rb file which allowed us to connect to SQS again.
