### PR TITLE
Modified config to work with logstash-1.2.2-flatjar.jar

### DIFF
--- a/docs/tutorials/10-minute-walkthrough/apache-elasticsearch.conf
+++ b/docs/tutorials/10-minute-walkthrough/apache-elasticsearch.conf
@@ -1,4 +1,7 @@
 input {
+  file {
+    path => "/dev/null"
+  }
   tcp { 
     type => "apache"
     port => 3333
@@ -20,7 +23,7 @@ filter {
     date {
       # Try to pull the timestamp from the 'timestamp' field (parsed above with
       # grok). The apache time format looks like: "18/Aug/2011:05:44:34 -0700"
-      match => { "timestamp" => "dd/MMM/yyyy:HH:mm:ss Z" }
+      match => [ "timestamp", "dd/MMM/yyyy:HH:mm:ss Z" ]
     }
   }
 }


### PR DESCRIPTION
I just started with logstash and noticed, that the "10-minute Tutorial" doesn't work correctly.
So I made two changes: added file{path=>{"/dev/null"}} to allow logstash to start and changed date filter format according to documentation.
