### PR TITLE
Ignore the .VERSION.mk file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ data
 *.pyc
 etc/jira-output.conf
 coverage/*
+.VERSION.mk


### PR DESCRIPTION
The pulls from last night might create a version file  that shouldn't be in the repo. This small pull makes sure of that.
