### PR TITLE
[imap] configurable content-type selection for multipart messages

### DIFF
--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -24,6 +24,10 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
   config :check_interval, :validate => :number, :default => 300
   config :delete, :validate => :boolean, :default => false
 
+  # For multipart messages, use the first part that has this
+  # content-type as the event message.
+  config :content_type, :validate => :string, :default => "text/plain"
+
   public
   def register
     require "net/imap" # in stdlib
@@ -36,6 +40,8 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
         @port = 143
       end
     end
+
+    @content_type_re = Regexp.new("^" + @content_type)
   end # def register
 
   def connect
@@ -79,7 +85,7 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
       message = mail.body.decoded
     else
       # Multipart message; use the first text/plain part we find
-      part = mail.parts.find { |p| p.content_type =~ /^text\/plain/ } || mail.parts.first
+      part = mail.parts.find { |p| p.content_type.match @content_type_re } || mail.parts.first
       message = part.decoded
     end
 

--- a/spec/inputs/imap.rb
+++ b/spec/inputs/imap.rb
@@ -1,0 +1,47 @@
+require "logstash/inputs/imap"
+require "mail"
+
+describe LogStash::Inputs::IMAP do
+  user = "logstash"
+  password = "secret"
+  msg_time = Time.new
+  msg_text = "foo\nbar\nbaz"
+  msg_html = "<p>a paragraph</p>\n\n"
+
+  msg = Mail.new do
+    from     "me@example.com"
+    to       "you@example.com"
+    subject  "logstash imap input test"
+    date     msg_time
+    body     msg_text
+    add_file :filename => "some.html", :content => msg_html
+  end
+
+  context "with both text and html parts" do
+    context "when no content-type selected" do
+      it "should select text/plain part" do
+        config = {"type" => "imap", "host" => "localhost",
+                  "user" => "#{user}", "password" => "#{password}"}
+
+        input = LogStash::Inputs::IMAP.new config
+        input.register
+        event = input.parse_mail(msg)
+        insist { event["message"] } == msg_text
+      end
+    end
+
+    context "when text/html content-type selected" do
+      it "should select text/html part" do
+        config = {"type" => "imap", "host" => "localhost",
+                  "user" => "#{user}", "password" => "#{password}",
+                  "content_type" => "text/html"}
+
+        input = LogStash::Inputs::IMAP.new config
+        input.register
+        event = input.parse_mail(msg)
+        insist { event["message"] } == msg_html
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
User can now select which content-type in multipart messages should be used as the event message.  Default behavior for multipart messages is still to select first part with text/plain content-type.

Use case:
Third party system is sending non-multipart email with HTML body to mailman list.  mailman converts the email to multipart with `text/html` part for original body plus `plain/text` part for the list footer.

Would appreciate a second set of eyes on the tests.  I rarely use ruby and this my first dance with rspec.
