### PR TITLE
[LOGSTASH-1630] Syslog 5424 patterns fail to match additional spaces

### DIFF
--- a/patterns/linux-syslog
+++ b/patterns/linux-syslog
@@ -9,5 +9,6 @@ SYSLOGLINE %{SYSLOGBASE2} %{GREEDYDATA:message}
 # IETF 5424 syslog(8) format (see http://www.rfc-editor.org/info/rfc5424)
 SYSLOG5424PRI <%{NONNEGINT:syslog5424_pri}>
 SYSLOG5424SD \[%{DATA}\]+
+SYSLOG5424BASE %{SYSLOG5424PRI}%{NONNEGINT:syslog5424_ver} +(?:%{TIMESTAMP_ISO8601:syslog5424_ts}|-) +(?:%{HOSTNAME:syslog5424_host}|-) +(?:%{WORD:syslog5424_app}|-) +(?:%{WORD:syslog5424_proc}|-) +(?:%{WORD:syslog5424_msgid}|-) +(?:%{SYSLOG5424SD:syslog5424_sd}|-|)
 
-SYSLOG5424LINE %{SYSLOG5424PRI}%{NONNEGINT:syslog5424_ver} (?:%{TIMESTAMP_ISO8601:syslog5424_ts}|-) (?:%{HOSTNAME:syslog5424_host}|-) (?:%{WORD:syslog5424_app}|-) (?:%{WORD:syslog5424_proc}|-) (?:%{WORD:syslog5424_msgid}|-) (?:%{SYSLOG5424SD:syslog5424_sd}|-) %{GREEDYDATA:syslog5424_msg}
+SYSLOG5424LINE %{SYSLOG5424BASE} +%{GREEDYDATA:syslog5424_msg}

--- a/spec/filters/grok.rb
+++ b/spec/filters/grok.rb
@@ -90,6 +90,45 @@ describe LogStash::Filters::Grok do
       insist { subject["syslog5424_sd"] } == nil
       insist { subject["syslog5424_msg"] } == "No PID or SD."
     end
+
+    sample "<191>1 2009-06-30T18:30:00+02:00 paxton.local grokdebug 4123 -  Missing structured data." do
+      insist { subject["tags"] }.nil?
+      insist { subject["syslog5424_pri"] } == "191"
+      insist { subject["syslog5424_ver"] } == "1"
+      insist { subject["syslog5424_ts"] } == "2009-06-30T18:30:00+02:00"
+      insist { subject["syslog5424_host"] } == "paxton.local"
+      insist { subject["syslog5424_app"] } == "grokdebug"
+      insist { subject["syslog5424_proc"] } == "4123"
+      insist { subject["syslog5424_msgid"] } == nil
+      insist { subject["syslog5424_sd"] } == nil
+      insist { subject["syslog5424_msg"] } == "Missing structured data."
+    end
+
+    sample "<191>1 2009-06-30T18:30:00+02:00 paxton.local grokdebug  4123 - - Additional spaces." do
+      insist { subject["tags"] }.nil?
+      insist { subject["syslog5424_pri"] } == "191"
+      insist { subject["syslog5424_ver"] } == "1"
+      insist { subject["syslog5424_ts"] } == "2009-06-30T18:30:00+02:00"
+      insist { subject["syslog5424_host"] } == "paxton.local"
+      insist { subject["syslog5424_app"] } == "grokdebug"
+      insist { subject["syslog5424_proc"] } == "4123"
+      insist { subject["syslog5424_msgid"] } == nil
+      insist { subject["syslog5424_sd"] } == nil
+      insist { subject["syslog5424_msg"] } == "Additional spaces."
+    end
+
+    sample "<191>1 2009-06-30T18:30:00+02:00 paxton.local grokdebug  4123 -  Additional spaces and missing SD." do
+      insist { subject["tags"] }.nil?
+      insist { subject["syslog5424_pri"] } == "191"
+      insist { subject["syslog5424_ver"] } == "1"
+      insist { subject["syslog5424_ts"] } == "2009-06-30T18:30:00+02:00"
+      insist { subject["syslog5424_host"] } == "paxton.local"
+      insist { subject["syslog5424_app"] } == "grokdebug"
+      insist { subject["syslog5424_proc"] } == "4123"
+      insist { subject["syslog5424_msgid"] } == nil
+      insist { subject["syslog5424_sd"] } == nil
+      insist { subject["syslog5424_msg"] } == "Additional spaces and missing SD."
+    end
   end
 
   describe "parsing an event with multiple messages (array of strings)", :if => false do


### PR DESCRIPTION
https://logstash.jira.com/browse/LOGSTASH-1630

Split the start of `SYSLOG5424LINE` out to `SYSLOG5424BASE`, in case people
want to create `PAM` or `CRON` patterns, similar to those available for `SYSLOG`

Also make syslog5424_sd optionally match nothing, since it seems to be 
ommitted entirely with rsyslog's `RSYSLOG_SyslogProtocol23Format` (ie - there
is no SD data, and it is not correctly replaced with a `-`).
