### PR TITLE
Fix link to FPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To update a flat jar previously built with 'make flatjar', run:
     make update-flatjar
 
 
-You can build rpms and debs, if you need those. Building rpms requires you have [fpm](github.com/jordansissel/fpm), then do this:
+You can build rpms and debs, if you need those. Building rpms requires you have [fpm](https://github.com/jordansissel/fpm), then do this:
 
     make package
 


### PR DESCRIPTION
GitHub displayed the link as "https://github.com/logstash/logstash/blob/master/github.com/jordansissel/fpm".
