### PR TITLE
Output an error on unknown validation symbol

### DIFF
--- a/lib/logstash/config/mixin.rb
+++ b/lib/logstash/config/mixin.rb
@@ -443,6 +443,8 @@ module LogStash::Config::Mixin
             end
 
             result = value.first
+          else
+            return false, "Unknown validator symbol #{validator}"
         end # case validator
       else
         return false, "Unknown validator #{validator.class}"

--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -51,7 +51,7 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
   # versions was 'append' by accident.
 
   # resolv calls will be wrapped in a timeout instance
-  config :timeout, :validate => :int, :default => 2
+  config :timeout, :validate => :number, :default => 2
 
   public
   def register


### PR DESCRIPTION
The dns filter contained the following `config :timeout, :validate => :int, :default => 2`
However as the `:int` validation does not exist, it did not convert string config value to int as encountered
in https://logstash.jira.com/browse/LOGSTASH-1650

This PR add a default branch to the case statement to report unknown validator symbol 
- fix the dns using the correct `:validate => :number`
