### PR TITLE
HOSTPORT doesn't parse anything useful

### DIFF
--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -28,7 +28,7 @@ IP (?:%{IPV6}|%{IPV4})
 HOSTNAME \b(?:[0-9A-Za-z][0-9A-Za-z-]{0,62})(?:\.(?:[0-9A-Za-z][0-9A-Za-z-]{0,62}))*(\.?|\b)
 HOST %{HOSTNAME}
 IPORHOST (?:%{HOSTNAME}|%{IP})
-HOSTPORT (?:%{IPORHOST=~/\./}:%{POSINT})
+HOSTPORT %{IPORHOST}:%{POSINT}
 
 # paths
 PATH (?:%{UNIXPATH}|%{WINPATH})


### PR DESCRIPTION
Changed HOSTPORT to a simple combination of IPORHOST and POSINT. What was the old pattern supposed to do and what does =~ mean?
