### PR TITLE
Add a punctuation filter

### DIFF
--- a/lib/logstash/filters/punct.rb
+++ b/lib/logstash/filters/punct.rb
@@ -2,20 +2,15 @@
 require "logstash/filters/base"
 require "logstash/namespace"
 
-# The split filter is for splitting multiline messages into separate events.
+# The punct filter is for strip all strings but punctutions.
 #
-# An example use case of this filter is for taking output from the 'exec' input
-# which emits one event for the whole output of a command and splitting that
-# output by newline - making each line an event.
-#
-# The end result of each split is a complete copy of the event 
-# with only the current split section of the given field changed.
+
 class LogStash::Filters::Punct < LogStash::Filters::Base
 
   config_name "punct"
   milestone 1
 
-  # The field which value is split by the terminator
+  # The field which value is strip to punctution.
   config :field, :validate => :string, :default => "message"
 
   public
@@ -27,14 +22,11 @@ class LogStash::Filters::Punct < LogStash::Filters::Base
   def filter(event)
     return unless filter?(event)
 
-    # events = []
-
     original_value = event[@field]
 
     # If for some reason the field is an array of values, take the first only.
     original_value = original_value.first if original_value.is_a?(Array)
     punct = original_value.tr('A-Za-z0-9 \t','')
     event["punct"] = punct
-    # event.cancel
   end # def filter
-end # class LogStash::Filters::Split
+end # class LogStash::Filters::Punct

--- a/spec/filters/punct.rb
+++ b/spec/filters/punct.rb
@@ -11,8 +11,8 @@ describe LogStash::Filters::Punct do
       }
     CONFIG
 
-    sample "PHP Warning:  json_encode() [<a href='function.json-encode'>function.json-encode</a>]: Invalid UTF-8 sequence in argument in /data1/sinawap/code/weibov4_wap/control/h5/main/trends.php on line 233" do
-      insist { subject["punct"] } == ":_()[<='.-'>.-</>]:-////_////."
+    sample "PHP Warning:  json_encode() [<a href='function.json-encode'>function.json-encode</a>]: Invalid UTF-8 sequence in argument in /var/www/htdocs/test.php on line 233" do
+      insist { subject["punct"] } == ":_()[<='.-'>.-</>]:-////."
     end
   end
 end


### PR DESCRIPTION
Strip all words and numbers, just remain punctuation in message, this is helpful when process logs and then we can sort errors and figure out which kind of log is growing too fast, so that we would aim the problem. 

Thanks
