### PR TITLE
Avoid loading emacs temp files from config path

### DIFF
--- a/lib/logstash/agent.rb
+++ b/lib/logstash/agent.rb
@@ -292,8 +292,10 @@ class LogStash::Agent < Clamp::Command
     config = ""
     Dir.glob(path).sort.each do |file|
       next unless File.file?(file)
-      # ignore emacs temporary files
-      next if file.match(/~$/)
+      if file.match(/~$/)
+        @logger.debug("NOT reading config file because it is a temp file", :file => file)
+        next
+      end
       @logger.debug("Reading config file", :file => file)
       config << File.read(file) + "\n"
     end


### PR DESCRIPTION
Emacs can create temporary files in the config path and logstash will load them with duplicate directives. This can result in cryptic failures such as

{:message=>"syslog tcp listener died", :address=>"0.0.0.0:5544", :exception=>#<Errno::EADDRINUSE: Address already in use - bind - Address already in use>, :backtrace=>["org/jruby/ext/socket/RubyTCPServer.java:118:in `initialize'", "org/jruby/RubyIO.java:876:in`new'", "file:/usr/local/bin/logstash-1.1.5-monolithic.jar!/logstash/inputs/syslog.rb:139:in `tcp_listener'", "file:/usr/local/bin/logstash-1.1.5-monolithic.jar!/logstash/inputs/syslog.rb:94:in`run'"], :level=>:warn}
