### PR TITLE
Make metric filter's rate and percentiles configurable

### DIFF
--- a/lib/logstash/filters/metrics.rb
+++ b/lib/logstash/filters/metrics.rb
@@ -142,6 +142,9 @@ class LogStash::Filters::Metrics < LogStash::Filters::Base
     @last_flush = 0 # how many seconds ago the metrics where flushed.
     @last_clear = 0 # how many seconds ago the metrics where cleared.
     @random_key_preffix = SecureRandom.hex
+    unless (@rates - [1, 5, 15]).empty?
+      raise LogStash::ConfigurationError, "Invalid rates configuration. possible rates are 1, 5, 15. Rates: #{rates}."
+    end
     initialize_metrics
   end # def register
 


### PR DESCRIPTION
There was a TODO message on the code for this. I hope the implementation and tests are ok.
-      # TODO(sissel): Maybe make this configurable?
-      #   percentiles => [ 0, 1, 5, 95 99 100 ]
