### PR TITLE
Use bundler.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,11 @@ clean:
 	@echo "=> Cleaning up"
 	-$(QUIET)rm -rf .bundle
 	-$(QUIET)rm -rf build
-	-$(QUIET)rm -rf vendor
 	-$(QUIET)rm -f pkg/*.deb
+
+.PHONY: clean-vendor
+clean-vendor:
+	-$(QUIET)rm -rf vendor
 
 .PHONY: compile
 compile: compile-grammar compile-runner | build/ruby
@@ -165,9 +168,8 @@ vendor-gems: | vendor/bundle
 
 .PHONY: vendor/bundle
 vendor/bundle: | vendor $(JRUBY)
-	@echo "=> Installing gems to $@..."
-	@#$(QUIET)GEM_HOME=$(GEM_HOME) $(JRUBY_CMD) --1.9 $(GEM_HOME)/bin/bundle install --deployment
-	$(QUIET)GEM_HOME=./vendor/bundle/jruby/1.9/ GEM_PATH= $(JRUBY_CMD) --1.9 ./gembag.rb logstash.gemspec $(QUIET_OUTPUT)
+	@echo "=> Ensuring ruby gems dependencies are in $@..."
+	$(QUIET)bin/logstash deps $(QUIET_OUTPUT)
 	@# Purge any junk that fattens our jar without need!
 	@# The riak gem includes previous gems in the 'pkg' dir. :(
 	-$(QUIET)rm -rf $@/jruby/1.9/gems/riak-client-1.0.3/pkg

--- a/bin/logstash
+++ b/bin/logstash
@@ -25,7 +25,7 @@ setup_ruby() {
     exit 1
   fi
 
-  eval $(ruby -e 'puts "RUBYVER=#{RUBY_VERSION.split(".")[0..1].join(".")}"; puts "RUBY=#{RUBY_ENGINE}"')
+  eval $(ruby -rrbconfig -e 'puts "RUBYVER=#{RbConfig::CONFIG["ruby_version"]}"; puts "RUBY=#{RUBY_ENGINE}"')
   RUBYCMD="ruby"
 }
 

--- a/tools/Gemfile
+++ b/tools/Gemfile
@@ -1,5 +1,5 @@
-source :rubygems
-gemspec :name => "logstash"
+source "https://rubygems.org"
+gemspec(:name => "logstash", :path => "../")
 
 group :development do
   gem "insist"

--- a/tools/Gemfile.lock
+++ b/tools/Gemfile.lock
@@ -1,0 +1,369 @@
+PATH
+  remote: /home/jls/projects/logstash
+  specs:
+    logstash (1.2.3.dev)
+      cabin (>= 0.6.0)
+      i18n
+      json
+      pry
+      stud
+    logstash (1.2.3.dev-java)
+      addressable
+      awesome_print
+      aws-sdk
+      beefcake (= 0.3.7)
+      bindata (>= 1.5.0)
+      bouncy-castle-java (= 1.5.0147)
+      cabin (>= 0.6.0)
+      cinch
+      clamp
+      edn
+      elasticsearch
+      extlib (= 0.9.16)
+      ffi
+      ffi-rzmq (= 1.0.0)
+      filewatch (= 0.5.1)
+      ftw (~> 0.0.36)
+      gelf (= 1.3.2)
+      gelfd (= 0.2.0)
+      geoip (>= 1.3.2)
+      gmetric (= 0.1.3)
+      google-api-client
+      haml
+      heroku
+      hot_bunnies (~> 2.0.0.pre12)
+      i18n
+      insist (= 1.0.0)
+      jdbc-mysql
+      jdbc-sqlite3
+      jiralicious (= 0.2.2)
+      jls-grok (= 0.10.12)
+      jls-lumberjack (>= 0.0.19)
+      jruby-elasticsearch (= 0.0.15)
+      jruby-httpclient
+      jruby-openssl (= 0.8.7)
+      jruby-win32ole
+      json
+      mail
+      mail
+      metriks
+      mime-types
+      minitest
+      mocha
+      mongo
+      msgpack-jruby
+      murmurhash3
+      onstomp
+      php-serialize
+      pry
+      rack
+      rbnacl
+      redis
+      riak-client (= 1.0.3)
+      riemann-client (= 0.2.1)
+      rsolr
+      rspec
+      rufus-scheduler (~> 2.0.24)
+      rumbster
+      sass
+      sequel
+      shoulda
+      sinatra
+      snmp
+      spoon
+      statsd-ruby (= 1.2.0)
+      stud
+      twitter (= 5.0.0.rc.1)
+      user_agent_parser (>= 2.0.0)
+      uuidtools
+      varnish-rb
+      xml-simple
+      xmpp4r (= 0.5)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (3.2.15)
+      i18n (~> 0.6, >= 0.6.4)
+      multi_json (~> 1.0)
+    addressable (2.3.5)
+    atomic (1.1.14)
+    atomic (1.1.14-java)
+    autoparse (0.3.3)
+      addressable (>= 2.3.1)
+      extlib (>= 0.9.15)
+      multi_json (>= 1.0.0)
+    avl_tree (1.1.3)
+    awesome_print (1.2.0)
+    aws-sdk (1.29.0)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
+      uuidtools (~> 2.1)
+    backports (3.3.5)
+    beefcake (0.3.7)
+    bindata (1.6.0)
+    blankslate (2.1.2.4)
+    bouncy-castle-java (1.5.0147)
+    bson (1.9.2-java)
+    buftok (0.1)
+    builder (3.2.2)
+    cabin (0.6.1)
+    celluloid (0.15.2)
+      timers (~> 1.1.0)
+    cinch (2.0.10)
+    clamp (0.6.3)
+    coderay (1.1.0)
+    coveralls (0.7.0)
+      multi_json (~> 1.3)
+      rest-client
+      simplecov (>= 0.7)
+      term-ansicolor
+      thor
+    crack (0.1.8)
+    diff-lcs (1.2.5)
+    docile (1.1.0)
+    edn (1.0.2)
+      parslet (~> 1.4.0)
+    elasticsearch (0.4.1)
+      elasticsearch-api (= 0.4.1)
+      elasticsearch-transport (= 0.4.1)
+    elasticsearch-api (0.4.1)
+      multi_json
+    elasticsearch-transport (0.4.1)
+      faraday
+      multi_json
+    excon (0.25.3)
+    extlib (0.9.16)
+    faraday (0.8.8)
+      multipart-post (~> 1.2.0)
+    ffi (1.9.3)
+    ffi (1.9.3-java)
+    ffi-rzmq (1.0.0)
+      ffi
+    filewatch (0.5.1)
+    formatador (0.2.4)
+    ftw (0.0.36)
+      addressable
+      backports (>= 2.6.2)
+      cabin (> 0)
+      http_parser.rb (= 0.5.3)
+    gelf (1.3.2)
+      json
+    gelfd (0.2.0)
+    geoip (1.3.3)
+    gmetric (0.1.3)
+    google-api-client (0.6.4)
+      addressable (>= 2.3.2)
+      autoparse (>= 0.3.3)
+      extlib (>= 0.9.15)
+      faraday (~> 0.8.4)
+      jwt (>= 0.1.5)
+      launchy (>= 2.1.1)
+      multi_json (>= 1.0.0)
+      signet (~> 0.4.5)
+      uuidtools (>= 2.1.0)
+    guard (2.2.4)
+      formatador (>= 0.2.4)
+      listen (~> 2.1)
+      lumberjack (~> 1.0)
+      pry (>= 0.9.12)
+      thor (>= 0.18.1)
+    guard-rspec (4.0.4)
+      guard (>= 2.1.1)
+      rspec (~> 2.14)
+    haml (4.0.4)
+      tilt
+    hashie (2.0.5)
+    heroku (3.1.0)
+      heroku-api (~> 0.3.7)
+      launchy (>= 0.3.2)
+      netrc (~> 0.7.7)
+      rest-client (~> 1.6.1)
+      rubyzip
+    heroku-api (0.3.15)
+      excon (~> 0.25.1)
+    hitimes (1.2.1)
+    hitimes (1.2.1-java)
+    hot_bunnies (2.0.0.pre13-java)
+    http (0.5.0)
+      http_parser.rb
+    http_parser.rb (0.5.3-java)
+    httparty (0.11.0)
+      multi_json (~> 1.0)
+      multi_xml (>= 0.5.2)
+    i18n (0.6.5)
+    insist (1.0.0)
+    jdbc-mysql (5.1.27)
+    jdbc-sqlite3 (3.7.2.1)
+    jiralicious (0.2.2)
+      crack (~> 0.1.8)
+      hashie (>= 1.1)
+      httparty (>= 0.10, < 0.12.0)
+      json (>= 1.6, < 1.9.0)
+    jls-grok (0.10.12)
+      cabin (>= 0.6.0)
+    jls-lumberjack (0.0.19)
+    jruby-elasticsearch (0.0.15)
+    jruby-httpclient (1.1.1-java)
+    jruby-openssl (0.8.7)
+      bouncy-castle-java (>= 1.5.0147)
+    jruby-win32ole (0.8.5)
+    json (1.8.1)
+    json (1.8.1-java)
+    jwt (0.1.8)
+      multi_json (>= 1.5)
+    launchy (2.4.2)
+      addressable (~> 2.3)
+    listen (2.2.0)
+      celluloid (>= 0.15.2)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+    lumberjack (1.0.4)
+    mail (2.5.3)
+      i18n (>= 0.4.0)
+      mime-types (~> 1.16)
+      treetop (~> 1.4.8)
+    metaclass (0.0.1)
+    method_source (0.8.2)
+    metriks (0.9.9.5)
+      atomic (~> 1.0)
+      avl_tree (~> 1.1.2)
+      hitimes (~> 1.1)
+    mime-types (1.25)
+    mini_portile (0.5.2)
+    minitest (5.0.8)
+    mocha (0.14.0)
+      metaclass (~> 0.0.1)
+    mongo (1.9.2)
+      bson (~> 1.9.2)
+    msgpack-jruby (1.3.2-java)
+    mtrc (0.0.4)
+    multi_json (1.8.2)
+    multi_xml (0.5.5)
+    multipart-post (1.2.0)
+    murmurhash3 (0.1.3)
+    netrc (0.7.7)
+    nokogiri (1.6.0-java)
+      mini_portile (~> 0.5.0)
+    onstomp (1.0.7)
+    parallel (0.9.1)
+    parallel_tests (0.16.5)
+      parallel
+    parslet (1.4.0)
+      blankslate (~> 2.0)
+    php-serialize (1.1.0)
+    polyglot (0.3.3)
+    pry (0.9.12.4)
+      coderay (~> 1.0)
+      method_source (~> 0.8)
+      slop (~> 3.4)
+    pry (0.9.12.4-java)
+      coderay (~> 1.0)
+      method_source (~> 0.8)
+      slop (~> 3.4)
+      spoon (~> 0.0)
+    rack (1.5.2)
+    rack-protection (1.5.1)
+      rack
+    rb-fsevent (0.9.3)
+    rb-inotify (0.9.2)
+      ffi (>= 0.5.0)
+    rbnacl (2.0.0)
+      ffi
+    redis (3.0.6)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
+    riak-client (1.0.3)
+      beefcake (~> 0.3.7)
+      builder (>= 2.1.2)
+      i18n (>= 0.4.0)
+      multi_json (~> 1.0)
+    riemann-client (0.2.1)
+      beefcake (>= 0.3.5)
+      mtrc (>= 0.0.4)
+      trollop (>= 1.16.2)
+    rsolr (1.0.9)
+      builder (>= 2.1.2)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.7)
+    rspec-expectations (2.14.4)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.4)
+    rubyzip (1.1.0)
+    rufus-scheduler (2.0.24)
+      tzinfo (>= 0.3.22)
+    rumbster (1.1.1)
+      mail (= 2.5.3)
+    sass (3.2.12)
+    sequel (4.5.0)
+    shoulda (3.5.0)
+      shoulda-context (~> 1.0, >= 1.0.1)
+      shoulda-matchers (>= 1.4.1, < 3.0)
+    shoulda-context (1.1.6)
+    shoulda-matchers (2.4.0)
+      activesupport (>= 3.0.0)
+    signet (0.4.5)
+      addressable (>= 2.2.3)
+      faraday (~> 0.8.1)
+      jwt (>= 0.1.5)
+      multi_json (>= 1.0.0)
+    simple_oauth (0.2.0)
+    simplecov (0.8.2)
+      docile (~> 1.1.0)
+      multi_json
+      simplecov-html (~> 0.8.0)
+    simplecov-html (0.8.0)
+    sinatra (1.4.4)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    slop (3.4.7)
+    snmp (1.1.1)
+    spoon (0.0.4)
+      ffi
+    statsd-ruby (1.2.0)
+    stud (0.0.17)
+      ffi
+      metriks
+    term-ansicolor (1.2.2)
+      tins (~> 0.8)
+    thor (0.18.1)
+    thread_safe (0.1.3-java)
+      atomic
+    tilt (1.4.1)
+    timers (1.1.0)
+    tins (0.13.1)
+    treetop (1.4.15)
+      polyglot
+      polyglot (>= 0.3.1)
+    trollop (2.0)
+    twitter (5.0.0.rc.1)
+      buftok (~> 0.1.0)
+      faraday (>= 0.8, < 0.10)
+      http (>= 0.5.0.pre2, < 0.6)
+      http_parser.rb (~> 0.5.0)
+      json (~> 1.8)
+      simple_oauth (~> 0.2.0)
+    tzinfo (1.1.0)
+      thread_safe (~> 0.1)
+    user_agent_parser (2.1.1)
+    uuidtools (2.1.4)
+    varnish-rb (0.2.0)
+      ffi
+    xml-simple (1.1.2)
+    xmpp4r (0.5)
+
+PLATFORMS
+  java
+  ruby
+
+DEPENDENCIES
+  coveralls
+  guard
+  guard-rspec
+  insist
+  logstash!
+  parallel_tests


### PR DESCRIPTION
'bundle install' when already installed should be faster than the
previous gembag. More importantly, it is also more accurate in terms of
dependencies.

Bonus points that we can do 'clean' which will purge any unknown gems
and keep our gems directory nice and tidy.

The main purpose is to speed up repetitive build invocations. Bundler's
dependency resolver is better than that of the previous gembag.rb, and
its 'clean' feature lets bundler manage the gems listing - even between
builds. This lets not have to 'rm -rf vendor' between builds on jenkins
to ensure quality testing :)

Other changes:
- Hide the Gemfile and Gemfile.lock in the 'tools' directory. This
  should hopefully prevent users from accidentally updating these files
  and thus avoiding merge conflicts later.
- Minor patch to use RbConfig::CONFIG['ruby_version'] instead of
  RUBY_VERSION. Confusing, I know. The former is the 'ruby abi' version,
  it seems, and the latter is the actual ruby implementation version.
  Example, on MRI 1.9.3, the former is 1.9.1 and latter is 1.9.3. On
  JRuby, the former is 1.9 and latter is 1.9.3. COMPUTERS. HELP.
