### PR TITLE
JRUBY-6970 strikes again. This time patch Dir.glob

### DIFF
--- a/lib/logstash/JRUBY-6970.rb
+++ b/lib/logstash/JRUBY-6970.rb
@@ -84,3 +84,17 @@ class File
     end
   end
 end
+
+class Dir
+  class << self
+    alias_method :glob_JRUBY_6970_hack, :glob
+    def glob(path, flags=nil)
+      if path =~ /^jar:file:/
+        # Strip leading 'jar:' (LOGSTASH-1316)
+        return glob_JRUBY_6970_hack(path.gsub(/^jar:/, ""))
+      else
+        return glob_JRUBY_6970_hack(path)
+      end
+    end
+  end
+end

--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -46,7 +46,7 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
   def register
     require "geoip"
     if @database.nil?
-      if __FILE__ =~ /^file:\/.+!.+/
+      if __FILE__ =~ /^(jar:)?file:\/.+!.+/
         begin
           # Running from a jar, assume GeoLiteCity.dat is at the root.
           jar_path = [__FILE__.split("!").first, "/GeoLiteCity.dat"].join("!")


### PR DESCRIPTION
I believe this will resolve LOGSTASH-1316 and all related bugs
pertaining to 'pattern not defined' problems caused by JRuby telling
us that **FILE** is "jar:file:/..." and Dir.glob() isn't capable of
handling that kind of path.

Other dup bugs: LOGSTASH-1521, LOGSTASH-1490 
