### PR TITLE
Added Jenkins depdency

### DIFF
--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -113,4 +113,7 @@ Gem::Specification.new do |gem|
   
   #Development Deps
   gem.add_development_dependency "coveralls"
+
+  #Jenkins Deps
+  gem.add_runtime_dependency "ci_reporter"
 end


### PR DESCRIPTION
ci_reporter is to generate test result in junit compatible format

jenkins is failing currently because of recent bundler modification.  The previous ci_reporter bolt on method is too fragile.

See http://build.elasticsearch.com/view/Logstash/job/logstash/132/jdk=JDK7,label=not-es/console
