### PR TITLE
Add `edn_lines` codec.

### DIFF
--- a/lib/logstash/codecs/edn_lines.rb
+++ b/lib/logstash/codecs/edn_lines.rb
@@ -1,0 +1,37 @@
+require "logstash/codecs/base"
+require "logstash/codecs/line"
+
+class LogStash::Codecs::EDNLines < LogStash::Codecs::Base
+  config_name "edn_lines"
+
+  milestone 1
+
+  def register
+    require "edn"
+  end
+
+  public
+  def initialize(params={})
+    super(params)
+    @lines = LogStash::Codecs::Line.new
+  end
+
+  public
+  def decode(data)
+
+    @lines.decode(data) do |event|
+      begin
+        yield LogStash::Event.new(EDN.read(data))
+      rescue e
+        @logger.info("EDN parse failure. Falling back to plain-text", :error => e, :data => data)
+        yield LogStash::Event.new("message" => data)
+      end
+    end
+  end
+
+  public
+  def encode(data)
+    @on_event.call(data.to_hash.to_edn + "\n")
+  end
+
+end

--- a/spec/codecs/edn_lines.rb
+++ b/spec/codecs/edn_lines.rb
@@ -1,0 +1,53 @@
+require "logstash/codecs/edn_lines"
+require "logstash/event"
+require "insist"
+require "edn"
+
+describe LogStash::Codecs::EDNLines do
+  subject do
+    next LogStash::Codecs::EDNLines.new
+  end
+
+  context "#decode" do
+    it "should return an event from edn data" do
+      data = {"foo" => "bar", "baz" => {"bah" => ["a", "b", "c"]}}
+      subject.decode(data.to_edn + "\n") do |event|
+        insist { event }.is_a?(LogStash::Event)
+        insist { event["foo"] } == data["foo"]
+        insist { event["baz"] } == data["baz"]
+        insist { event["bah"] } == data["bah"]
+      end
+    end
+
+    it "should return an event from edn data when a newline is recieved" do
+      data = {"foo" => "bar", "baz" => {"bah" => ["a","b","c"]}}
+      subject.decode(data.to_edn) do |event|
+        insist {false}
+      end
+      subject.decode("\n") do |event|
+        insist { event.is_a? LogStash::Event }
+        insist { event["foo"] } == data["foo"]
+        insist { event["baz"] } == data["baz"]
+        insist { event["bah"] } == data["bah"]
+      end
+    end
+  end
+
+  context "#encode" do
+    it "should return edn data" do
+      data = {"foo" => "bar", "baz" => {"bah" => ["a","b","c"]}}
+      event = LogStash::Event.new(data)
+      got_event = false
+      subject.on_event do |d|
+        insist { d.chomp } == LogStash::Event.new(data).to_hash.to_edn
+        insist { EDN.read(d)["foo"] } == data["foo"]
+        insist { EDN.read(d)["baz"] } == data["baz"]
+        insist { EDN.read(d)["bah"] } == data["bah"]
+        got_event = true
+      end
+      subject.encode(event)
+      insist { got_event }
+    end
+  end
+
+end


### PR DESCRIPTION
This adds the `edn_lines` codec, as was recommended in https://github.com/logstash/logstash/pull/778. The code is based on the `json_lines` codec.
