### PR TITLE
Corrected syntax error in apache timestamp match in 10-minute-walkthroug...

### DIFF
--- a/docs/tutorials/10-minute-walkthrough/apache-elasticsearch.conf
+++ b/docs/tutorials/10-minute-walkthrough/apache-elasticsearch.conf
@@ -20,7 +20,7 @@ filter {
     date {
       # Try to pull the timestamp from the 'timestamp' field (parsed above with
       # grok). The apache time format looks like: "18/Aug/2011:05:44:34 -0700"
-      match => { "timestamp" => "dd/MMM/yyyy:HH:mm:ss Z" }
+      match => [ "timestamp", "dd/MMM/yyyy:HH:mm:ss Z" ]
     }
   }
 }

--- a/docs/tutorials/10-minute-walkthrough/apache-parse.conf
+++ b/docs/tutorials/10-minute-walkthrough/apache-parse.conf
@@ -20,7 +20,7 @@ filter {
     date {
       # Try to pull the timestamp from the 'timestamp' field (parsed above with
       # grok). The apache time format looks like: "18/Aug/2011:05:44:34 -0700"
-      match => { "timestamp" => "dd/MMM/yyyy:HH:mm:ss Z" }
+      match => [ "timestamp", "dd/MMM/yyyy:HH:mm:ss Z" ]
     }
   }
 }


### PR DESCRIPTION
In original version date is never matched, and no error occurs - date is simply not matched/converted.
