### PR TITLE
Set 127.0.0.1 as the IP used in sending with gelf input tests.

### DIFF
--- a/spec/inputs/gelf.rb
+++ b/spec/inputs/gelf.rb
@@ -6,7 +6,7 @@ describe "inputs/gelf" do
 
   describe "reads chunked gelf messages " do
     port = 12209
-    host = "127.0.0.9"
+    host = "127.0.0.1"
     chunksize = 1420
     gelfclient = GELF::Notifier.new(host,port,chunksize)
 


### PR DESCRIPTION
Previously was 127.0.0.9, which isn't a typical 'localhost' address
found on machines.
