### PR TITLE
Make require() threadsafe again.

### DIFF
--- a/lib/logstash/JRUBY-6970.rb
+++ b/lib/logstash/JRUBY-6970.rb
@@ -12,10 +12,14 @@ module Kernel
     end
 
     # Work around slow openssl load times in flatjar. (LOGSTASH-1223)
+    # I don't know why this works, I don't care either. This problem only
+    # exists in the 'jar' builds of logstash which are going to be going away
+    # soon in favor of the much-better tarball/zip releases!
     if __FILE__ =~ /^(?:jar:)?file:.+!.+/ && path == "openssl"
-      old_load_path = $LOAD_PATH.dup
-      # For some reason loading openssl with an empty LOAD_PATH is fast.
-      $LOAD_PATH.clear
+      # Loading shared/jruby-openssl first seems to make openssl load faster
+      # I have no idea. Computers.
+      require_JRUBY_6970_hack "shared/jruby-openssl"
+      return require_JRUBY_6970_hack "openssl"
     end
 
     # JRUBY-7065
@@ -27,8 +31,6 @@ module Kernel
       require "logstash/JRUBY-6970-openssl"
     end
     return rc
-  ensure
-    $LOAD_PATH.replace(old_load_path) if old_load_path
   end
 end
 


### PR DESCRIPTION
Is there a unicode glyph for facepalm? Probably should be. Put it here.
Take palm. Apply to my face.

The patch for LOGSTASH-1223 had a crazy hack to work around
'require("openssl")' taking a super long time. Unfortunately, it also
made require() not threadsafe. Oops.

While poking at the problem, I found that doing
'require("shared/jruby-openssl")' before require("openssl") actually
makes it as fast without the threadsafety problem.

This commit should fix the following many bugs:
  LOGSTASH-1310, LOGSTASH-1519, LOGSTASH-1325, LOGSTASH-1522

The reason 'openssl' is implicated here is because of the monkeypatch.
The common factor in user-reported problems is that using the tcp input
while also running the web interface in the same process, and tcp input
loads openssl, which does bad things (because of our monkeypatching) 
and causes the web interface to fail to load libraries it needs (like base64).

Data:

```
# Before this commit:
% java -jar build/*.jar irb
>> time { require("openssl") }
=> 1.763

# Without the patch for LOGSTASH-1223
% java -jar build/*.jar irb
>> time { require("openssl") }
=> 17.715

# With this change
% java -jar build/*.jar irb
>> time { require("shared/jruby-openssl"); require("openssl") }
=> 1.881
```

Similar performance solution without the thread safety problems.
