### PR TITLE
Upgrade ftw

### DIFF
--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "i18n"               #(MIT license)
 
   # Web dependencies
-  gem.add_runtime_dependency "ftw", ["~> 0.0.36"] #(Apache 2.0 license)
+  gem.add_runtime_dependency "ftw", ["~> 0.0.37"] #(Apache 2.0 license)
   gem.add_runtime_dependency "haml"               #(MIT license)
   gem.add_runtime_dependency "rack"               #(MIT license)
   gem.add_runtime_dependency "sass"               #(MIT license)


### PR DESCRIPTION
The only change in ftw is that it now only loads backports on ruby 1.8,
which should help speed up the startup time of any plugins (and web)
that use ftw.
