### PR TITLE
Avoid having 'remote: /some/path' in the gemfile.locks

### DIFF
--- a/tools/Gemfile
+++ b/tools/Gemfile
@@ -1,9 +1,14 @@
 source "https://rubygems.org"
-gemspec(:name => "logstash", :path => "../")
+#gemspec(:name => "logstash", :path => "../")
+
+gemspec = File.join(File.dirname(__FILE__), "..", "logstash.gemspec")
+spec = Gem::Specification.load(gemspec)
+spec.runtime_dependencies.each do |dep|
+  gem dep.name, dep.requirement.to_s
+end
 
 group :development do
-  gem "insist"
-  gem "guard"
-  gem "guard-rspec"
-  gem "parallel_tests"
+  spec.development_dependencies.each do |dep|
+    gem dep.name, dep.requirement.to_s
+  end
 end

--- a/tools/Gemfile.jruby-1.9.lock
+++ b/tools/Gemfile.jruby-1.9.lock
@@ -1,80 +1,3 @@
-PATH
-  remote: /Users/jls/projects/logstash
-  specs:
-    logstash (1.2.3.dev-java)
-      addressable
-      awesome_print
-      aws-sdk
-      beefcake (= 0.3.7)
-      bindata (>= 1.5.0)
-      bouncy-castle-java (= 1.5.0147)
-      cabin (>= 0.6.0)
-      ci_reporter
-      cinch
-      clamp
-      edn
-      elasticsearch
-      extlib (= 0.9.16)
-      ffi
-      ffi-rzmq (= 1.0.0)
-      filewatch (= 0.5.1)
-      ftw (~> 0.0.36)
-      gelf (= 1.3.2)
-      gelfd (= 0.2.0)
-      geoip (>= 1.3.2)
-      gmetric (= 0.1.3)
-      google-api-client
-      haml
-      heroku
-      hot_bunnies (~> 2.0.0.pre12)
-      i18n
-      insist (= 1.0.0)
-      jdbc-mysql
-      jdbc-sqlite3
-      jiralicious (= 0.2.2)
-      jls-grok (= 0.10.12)
-      jls-lumberjack (>= 0.0.19)
-      jruby-elasticsearch (= 0.0.15)
-      jruby-httpclient
-      jruby-openssl (= 0.8.7)
-      jruby-win32ole
-      json
-      mail
-      mail
-      metriks
-      mime-types
-      minitest
-      mocha
-      mongo
-      msgpack-jruby
-      murmurhash3
-      onstomp
-      php-serialize
-      pry
-      rack
-      rbnacl
-      redis
-      riak-client (= 1.0.3)
-      riemann-client (= 0.2.1)
-      rsolr
-      rspec
-      rufus-scheduler (~> 2.0.24)
-      rumbster
-      sass
-      sequel
-      shoulda
-      sinatra
-      snmp
-      spoon
-      statsd-ruby (= 1.2.0)
-      stud
-      twitter (= 5.0.0.rc.1)
-      user_agent_parser (>= 2.0.0)
-      uuidtools
-      varnish-rb
-      xml-simple
-      xmpp4r (= 0.5)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -102,8 +25,6 @@ GEM
     buftok (0.1)
     builder (3.2.2)
     cabin (0.6.1)
-    celluloid (0.15.2)
-      timers (~> 1.1.0)
     ci_reporter (1.9.0)
       builder (>= 2.1.2)
     cinch (2.0.10)
@@ -136,8 +57,7 @@ GEM
     ffi-rzmq (1.0.0)
       ffi
     filewatch (0.5.1)
-    formatador (0.2.4)
-    ftw (0.0.36)
+    ftw (0.0.37)
       addressable
       backports (>= 2.6.2)
       cabin (> 0)
@@ -157,15 +77,6 @@ GEM
       multi_json (>= 1.0.0)
       signet (~> 0.4.5)
       uuidtools (>= 2.1.0)
-    guard (2.2.4)
-      formatador (>= 0.2.4)
-      listen (~> 2.1)
-      lumberjack (~> 1.0)
-      pry (>= 0.9.12)
-      thor (>= 0.18.1)
-    guard-rspec (4.2.0)
-      guard (>= 2.1.1)
-      rspec (>= 2.14, < 4.0)
     haml (4.0.4)
       tilt
     hashie (2.0.5)
@@ -207,11 +118,6 @@ GEM
       multi_json (>= 1.5)
     launchy (2.4.2)
       addressable (~> 2.3)
-    listen (2.3.1)
-      celluloid (>= 0.15.2)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9)
-    lumberjack (1.0.4)
     mail (2.5.3)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
@@ -239,9 +145,6 @@ GEM
     nokogiri (1.6.0-java)
       mini_portile (~> 0.5.0)
     onstomp (1.0.7)
-    parallel (0.9.1)
-    parallel_tests (0.16.5)
-      parallel
     parslet (1.4.0)
       blankslate (~> 2.0)
     php-serialize (1.1.0)
@@ -254,9 +157,6 @@ GEM
     rack (1.5.2)
     rack-protection (1.5.1)
       rack
-    rb-fsevent (0.9.3)
-    rb-inotify (0.9.2)
-      ffi (>= 0.5.0)
     rbnacl (2.0.0)
       ffi
     redis (3.0.6)
@@ -323,7 +223,6 @@ GEM
     thread_safe (0.1.3-java)
       atomic
     tilt (1.4.1)
-    timers (1.1.0)
     tins (0.13.1)
     treetop (1.4.15)
       polyglot
@@ -349,9 +248,75 @@ PLATFORMS
   java
 
 DEPENDENCIES
+  addressable
+  awesome_print
+  aws-sdk
+  beefcake (= 0.3.7)
+  bindata (>= 1.5.0)
+  bouncy-castle-java (= 1.5.0147)
+  cabin (>= 0.6.0)
+  ci_reporter
+  cinch
+  clamp
   coveralls
-  guard
-  guard-rspec
-  insist
-  logstash!
-  parallel_tests
+  edn
+  elasticsearch
+  extlib (= 0.9.16)
+  ffi
+  ffi-rzmq (= 1.0.0)
+  filewatch (= 0.5.1)
+  ftw (~> 0.0.36)
+  gelf (= 1.3.2)
+  gelfd (= 0.2.0)
+  geoip (>= 1.3.2)
+  gmetric (= 0.1.3)
+  google-api-client
+  haml
+  heroku
+  hot_bunnies (~> 2.0.0.pre12)
+  i18n
+  insist (= 1.0.0)
+  jdbc-mysql
+  jdbc-sqlite3
+  jiralicious (= 0.2.2)
+  jls-grok (= 0.10.12)
+  jls-lumberjack (>= 0.0.19)
+  jruby-elasticsearch (= 0.0.15)
+  jruby-httpclient
+  jruby-openssl (= 0.8.7)
+  jruby-win32ole
+  json
+  mail
+  metriks
+  mime-types
+  minitest
+  mocha
+  mongo
+  msgpack-jruby
+  murmurhash3
+  onstomp
+  php-serialize
+  pry
+  rack
+  rbnacl
+  redis
+  riak-client (= 1.0.3)
+  riemann-client (= 0.2.1)
+  rsolr
+  rspec
+  rufus-scheduler (~> 2.0.24)
+  rumbster
+  sass
+  sequel
+  shoulda
+  sinatra
+  snmp
+  spoon
+  statsd-ruby (= 1.2.0)
+  stud
+  twitter (= 5.0.0.rc.1)
+  user_agent_parser (>= 2.0.0)
+  uuidtools
+  varnish-rb
+  xml-simple
+  xmpp4r (= 0.5)

--- a/tools/Gemfile.ruby-1.9.1.lock
+++ b/tools/Gemfile.ruby-1.9.1.lock
@@ -1,76 +1,3 @@
-PATH
-  remote: /Users/jls/projects/logstash
-  specs:
-    logstash (1.2.3.dev)
-      addressable
-      awesome_print
-      aws-sdk
-      beefcake (= 0.3.7)
-      bindata (>= 1.5.0)
-      bunny (~> 1.0.0)
-      cabin (>= 0.6.0)
-      ci_reporter
-      cinch
-      clamp
-      edn
-      elasticsearch
-      excon
-      extlib (= 0.9.16)
-      ffi
-      ffi-rzmq (= 1.0.0)
-      filewatch (= 0.5.1)
-      ftw (~> 0.0.36)
-      gelf (= 1.3.2)
-      gelfd (= 0.2.0)
-      geoip (>= 1.3.2)
-      gmetric (= 0.1.3)
-      google-api-client
-      haml
-      heroku
-      i18n
-      insist (= 1.0.0)
-      jdbc-sqlite3
-      jiralicious (= 0.2.2)
-      jls-grok (= 0.10.12)
-      jls-lumberjack (>= 0.0.19)
-      json
-      mail
-      mail
-      metriks
-      mime-types
-      minitest
-      mocha
-      mongo
-      msgpack
-      murmurhash3
-      mysql2
-      onstomp
-      php-serialize
-      pry
-      rack
-      rbnacl
-      redis
-      riak-client (= 1.0.3)
-      riemann-client (= 0.2.1)
-      rsolr
-      rspec
-      rufus-scheduler (~> 2.0.24)
-      rumbster
-      sass
-      sequel
-      shoulda
-      sinatra
-      snmp
-      spoon
-      statsd-ruby (= 1.2.0)
-      stud
-      twitter (= 5.0.0.rc.1)
-      user_agent_parser (>= 2.0.0)
-      uuidtools
-      varnish-rb
-      xml-simple
-      xmpp4r (= 0.5)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -100,8 +27,6 @@ GEM
     bunny (1.0.5)
       amq-protocol (>= 1.9.0)
     cabin (0.6.1)
-    celluloid (0.15.2)
-      timers (~> 1.1.0)
     ci_reporter (1.9.0)
       builder (>= 2.1.2)
     cinch (2.0.10)
@@ -134,8 +59,7 @@ GEM
     ffi-rzmq (1.0.0)
       ffi
     filewatch (0.5.1)
-    formatador (0.2.4)
-    ftw (0.0.36)
+    ftw (0.0.37)
       addressable
       backports (>= 2.6.2)
       cabin (> 0)
@@ -155,15 +79,6 @@ GEM
       multi_json (>= 1.0.0)
       signet (~> 0.4.5)
       uuidtools (>= 2.1.0)
-    guard (2.2.4)
-      formatador (>= 0.2.4)
-      listen (~> 2.1)
-      lumberjack (~> 1.0)
-      pry (>= 0.9.12)
-      thor (>= 0.18.1)
-    guard-rspec (4.2.0)
-      guard (>= 2.1.1)
-      rspec (>= 2.14, < 4.0)
     haml (4.0.4)
       tilt
     hashie (2.0.5)
@@ -195,11 +110,6 @@ GEM
       multi_json (>= 1.5)
     launchy (2.4.2)
       addressable (~> 2.3)
-    listen (2.3.1)
-      celluloid (>= 0.15.2)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9)
-    lumberjack (1.0.4)
     mail (2.5.3)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
@@ -228,9 +138,6 @@ GEM
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)
     onstomp (1.0.7)
-    parallel (0.9.1)
-    parallel_tests (0.16.5)
-      parallel
     parslet (1.4.0)
       blankslate (~> 2.0)
     php-serialize (1.1.0)
@@ -242,9 +149,6 @@ GEM
     rack (1.5.2)
     rack-protection (1.5.1)
       rack
-    rb-fsevent (0.9.3)
-    rb-inotify (0.9.2)
-      ffi (>= 0.5.0)
     rbnacl (2.0.0)
       ffi
     redis (3.0.6)
@@ -311,7 +215,6 @@ GEM
     thread_safe (0.1.3)
       atomic
     tilt (1.4.1)
-    timers (1.1.0)
     tins (0.13.1)
     treetop (1.4.15)
       polyglot
@@ -337,9 +240,71 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  addressable
+  awesome_print
+  aws-sdk
+  beefcake (= 0.3.7)
+  bindata (>= 1.5.0)
+  bunny (~> 1.0.0)
+  cabin (>= 0.6.0)
+  ci_reporter
+  cinch
+  clamp
   coveralls
-  guard
-  guard-rspec
-  insist
-  logstash!
-  parallel_tests
+  edn
+  elasticsearch
+  excon
+  extlib (= 0.9.16)
+  ffi
+  ffi-rzmq (= 1.0.0)
+  filewatch (= 0.5.1)
+  ftw (~> 0.0.36)
+  gelf (= 1.3.2)
+  gelfd (= 0.2.0)
+  geoip (>= 1.3.2)
+  gmetric (= 0.1.3)
+  google-api-client
+  haml
+  heroku
+  i18n
+  insist (= 1.0.0)
+  jdbc-sqlite3
+  jiralicious (= 0.2.2)
+  jls-grok (= 0.10.12)
+  jls-lumberjack (>= 0.0.19)
+  json
+  mail
+  metriks
+  mime-types
+  minitest
+  mocha
+  mongo
+  msgpack
+  murmurhash3
+  mysql2
+  onstomp
+  php-serialize
+  pry
+  rack
+  rbnacl
+  redis
+  riak-client (= 1.0.3)
+  riemann-client (= 0.2.1)
+  rsolr
+  rspec
+  rufus-scheduler (~> 2.0.24)
+  rumbster
+  sass
+  sequel
+  shoulda
+  sinatra
+  snmp
+  spoon
+  statsd-ruby (= 1.2.0)
+  stud
+  twitter (= 5.0.0.rc.1)
+  user_agent_parser (>= 2.0.0)
+  uuidtools
+  varnish-rb
+  xml-simple
+  xmpp4r (= 0.5)


### PR DESCRIPTION
When using bundler's "gemspec" setting it hardcodes a
local path as the "remote". This causes every 'bundle install' or
similar invocation on any other workstation to change that file simply
because the remote has changed. Not good.

Work around it by evaluating the gemspec ourselves and generating the
gem dependency list from that.

Same effect, better result, I think.
