### PR TITLE
- Add 'protocol' setting to allow users to use the 'Transport' client in

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -63,6 +63,11 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # The name/address of the host to bind to for ElasticSearch clustering
   config :bind_host, :validate => :string
 
+  # This is only valid for the 'node' protocol.
+  #
+  # The port for the node to listen on.
+  config :bind_port, :validate => :number
+
   # Run the elasticsearch server embedded in this process.
   # This option is useful if you want to run a single logstash process that
   # handles log processing and indexing; it saves you from needing to run
@@ -88,6 +93,18 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
   # The amount of time since last flush before a flush is forced.
   config :idle_flush_time, :validate => :number, :default => 1
+
+  # Choose the protocol used to talk to elasticsearch.
+  #
+  # The 'node' protocol will connect to the cluster as a normal elasticsearch
+  # node (but will not store data). This allows you to use things like
+  # multicast discovery.
+  #
+  # The 'transport' protocol will connect to the host you specify and will
+  # not show up as a 'node' in the elasticsearch cluster. This is useful
+  # in situations where you cannot permit connections outbound from the
+  # elasticsearch cluster to this logstash server.
+  config :protocol, :validate => [ "node", "transport" ], :default => "node"
 
   public
   def register
@@ -123,8 +140,13 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
       :node_name => @node_name,
     }
 
-    # TODO(sissel): Support 'transport client'
-    options[:type] = :node
+    # :node or :transport protocols
+    options[:type] = @protocol.to_sym 
+
+    options[:bind_port] = @bind_port unless @bind_port.nil?
+
+    # TransportClient requires a number for a port.
+    options[:port] = options[:port].to_i if options[:type] == :transport
 
     @client = ElasticSearch::Client.new(options)
 

--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -80,7 +80,7 @@ Gem::Specification.new do |gem|
 
   if RUBY_PLATFORM == 'java'
     gem.platform = RUBY_PLATFORM
-    gem.add_runtime_dependency "jruby-elasticsearch", ["0.0.15"]  #(BSD license)
+    gem.add_runtime_dependency "jruby-elasticsearch", ["0.0.16"]  #(BSD license)
     gem.add_runtime_dependency "jruby-httpclient"                 #(Apache 2.0 license)
     gem.add_runtime_dependency "bouncy-castle-java", "1.5.0147"   #(MIT license)
     gem.add_runtime_dependency "jruby-openssl", "0.8.7"           #(CPL/GPL/LGPL license)


### PR DESCRIPTION
elasticsearch. (LOGSTASH-102)
- Add 'bind_port' setting to allow users with the default node protocol
  to choose what local port is used. (LOGSTASH-1453)
