### PR TITLE
Force the default string encoding to be UTF-8.

### DIFF
--- a/lib/logstash/runner.rb
+++ b/lib/logstash/runner.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+Encoding.default_external = "UTF-8"
 $START = Time.now
 $DEBUGLIST = (ENV["DEBUG"] || "").split(",")
 


### PR DESCRIPTION
This helps solve this common problem:
- User environment is LANG=C (Ruby says US-ASCII)
- User sends JSON with non-english characters like "Andrés" (e with
  accent).
- The above two things clash, since 'é' in bytes is 0xc3 0xa9, you will
  get Encoding::InvalidByteSequenceError.

You can reproduce this theory simply in ruby as:

```
>> "é".force_encoding("US-ASCII").encode("UTF-8")
Encoding::InvalidByteSequenceError: "\xC3" on US-ASCII
```

This change _should_ fix a big bucket of JIRA tickets related to
UTF-8-encoded text being sent to logstash which was incorrectly
defaulting to US-ASCII encoding.
