### PR TITLE
Accept invalid json properly in oldlogstashjson codec

### DIFF
--- a/lib/logstash/codecs/oldlogstashjson.rb
+++ b/lib/logstash/codecs/oldlogstashjson.rb
@@ -13,7 +13,13 @@ class LogStash::Codecs::OldLogStashJSON < LogStash::Codecs::Base
 
   public
   def decode(data)
-    obj = JSON.parse(data.force_encoding("UTF-8"))
+    begin
+      obj = JSON.parse(data.force_encoding("UTF-8"))
+    rescue JSON::ParserError => e
+      @logger.info("JSON parse failure. Falling back to plain-text", :error => e, :data => data)
+      yield LogStash::Event.new("message" => data)
+      return
+    end
 
     h  = {}
 

--- a/spec/codecs/oldlogstashjson.rb
+++ b/spec/codecs/oldlogstashjson.rb
@@ -21,6 +21,12 @@ describe LogStash::Codecs::OldLogStashJSON do
         insist { event["path"] } == nil # @source_path not in v0 test data
       end
     end
+
+    it "should accept invalid json" do
+      subject.decode("some plain text") do |event|
+        insist { event["message"] } == "some plain text"
+      end
+    end
   end
 
   context "#encode" do


### PR DESCRIPTION
As the other json codecs do, take invalid json as simply a 'message'
field.

Added a test to cover this.

Fixes LOGSTASH-1534
