### PR TITLE
Add encode/decode filters

### DIFF
--- a/lib/logstash/filters/decode.rb
+++ b/lib/logstash/filters/decode.rb
@@ -1,0 +1,88 @@
+require 'logstash/namespace'
+require 'logstash/filters/base'
+
+# Decode filter. Applies a codec in decode mode to the specified event field
+class LogStash::Filters::Decode < LogStash::Filters::Base
+
+  config_name 'decode'
+  milestone   1
+
+  # Set the codec to apply
+  #
+  #     codec => some_codec { ... }
+  #
+  # For example, to decode JSON from the "message" field:
+  #
+  # filter {
+  #   decode {
+  #     codec => json { }
+  #   }
+  # }
+
+  config :codec,  :validate => :codec,  :required => true
+
+  # Set the source field (field to decode from).
+  # Default: message
+  #
+  #     source => source_field
+  #
+  # For example, to decode JSON from the "data" field:
+  #
+  # filter {
+  #   decode {
+  #     codec  => json { }
+  #     source => "data"
+  #   }
+  # }
+
+  config :source, :validate => :string, :default  => 'message'
+
+  # Set the target for storing the decoded data.
+  # Default: message
+  #
+  #     target => some_field
+  #
+  # For example, to decode JSON into into the "data" field:
+  #
+  # filter {
+  #   decode {
+  #     codec  => json { }
+  #     target => "data"
+  #   }
+  # }
+  #
+  # Note: The target field will be overwritten if present.
+
+  config :target, :validate => :string, :default => 'message'
+
+  def register
+  end # def register
+
+  def filter(event)
+    return unless filter?(event)
+
+    ctx         = @logger.context
+    ctx[:codec] = @codec
+    @logger.debug? && @logger.debug('Decode filter: decoding event', :source => @source, :target => @target)
+
+    begin
+      @codec.decode(event[@source]) do |ev|
+        event[@target] = ev['message']
+      end
+
+      @logger.debug? && @logger.debug('Decode filter: decoded event')
+      filter_matched(event)
+    rescue => e
+      event.tag('_decodefailure')
+      @logger.warn('Trouble decoding', :source => @source, :raw => event[@source], :exception => e)
+    end
+
+    @logger.debug? && @logger.debug('Event after decoding', :event => event)
+    ctx.clear
+
+  end # def filter
+
+  public :register, :filter
+
+end # class LogStash::Filters::Decode
+

--- a/lib/logstash/filters/encode.rb
+++ b/lib/logstash/filters/encode.rb
@@ -1,0 +1,85 @@
+require 'logstash/namespace'
+require 'logstash/filters/base'
+
+# Encode filter. Applies a codec in encode mode to the specified event field
+class LogStash::Filters::Encode < LogStash::Filters::Base
+
+  config_name 'encode'
+  milestone   1
+
+  # Set the codec to apply
+  #
+  #     codec => some_codec { ... }
+  #
+  # For example, to encode the "message" field as JSON:
+  #
+  # filter {
+  #   encode {
+  #     codec => json { }
+  #   }
+  # }
+
+  config :codec,  :validate => :codec,  :required => true
+
+  # Set the source field (field to encode from).
+  # Default: message
+  #
+  #     source => source_field
+  #
+  # For example, to encode the "data" field as JSON:
+  #
+  # filter {
+  #   encode {
+  #     codec  => json { }
+  #     source => "data"
+  #   }
+  # }
+
+  config :source, :validate => :string, :default  => 'message'
+
+  # Set the target for storing the encoded data.
+  # Default: message
+  #
+  #     target => some_field
+  #
+  # For example, to encode JSON into into the "data" field:
+  #
+  # filter {
+  #   encode {
+  #     codec  => json { }
+  #     target => "data"
+  #   }
+  # }
+  #
+  # Note: The target field will be overwritten if present.
+
+  config :target, :validate => :string, :default  => 'message'
+
+  def register
+    @codec.on_event{ |payload| payload }
+  end # def register
+
+  def filter(event)
+    return unless filter?(event)
+
+    ctx         = @logger.context
+    ctx[:codec] = @codec
+    @logger.debug? && @logger.debug('Encode filter: encoding event', :source => @source, :target => @target)
+
+    begin
+      event[@target] = @codec.encode(event[@source])
+      @logger.debug? && @logger.debug('Encode filter: encoded event')
+      filter_matched(event)
+    rescue => e
+      event.tag('_encodefailure')
+      @logger.warn('Trouble encoding', :source => @source, :raw => event[@source], :exception => e)
+    end
+
+    @logger.debug? && @logger.debug('Event after encoding', :event => event)
+    ctx.clear
+  end # def filter
+
+  public :register, :filter
+
+end # class LogStash::Filters::Encode
+


### PR DESCRIPTION
This is a first stab at allowing arbitrary codecs to be applied to
individual message fields. It has the potential, long-term, to
encapsulate behaviour provided by things like the json filter, and
promotes the migration of many data formats into codecs. It also allows
for things like utilizing the oldlogstashjson codec on a particular
event field.
