### PR TITLE
Use FQDN instead of short hostname for the source_host of a file input.

### DIFF
--- a/lib/logstash/inputs/file.rb
+++ b/lib/logstash/inputs/file.rb
@@ -124,7 +124,7 @@ class LogStash::Inputs::File < LogStash::Inputs::Base
     @tail = FileWatch::Tail.new(@tail_config)
     @tail.logger = @logger
     @path.each { |path| @tail.tail(path) }
-    hostname = Socket.gethostname
+    hostname = Socket.gethostbyname(Socket.gethostname).first
 
     @tail.subscribe do |path, line|
       @logger.debug? && @logger.debug("Received line", :path => path, :text => line)


### PR DESCRIPTION
I'd like to use the FQDN as the source_host; in our environment we have multiple domains. I searched the docs (http://logstash.net/docs/1.2.2/inputs/file) and couldn't find a way to specify this in the config file. 

Is there a better way to implement this and get this upstream?
