### PR TITLE
Bug fix: Test for Java methods for template management

### DIFF
--- a/lib/logstash/outputs/elasticsearch_http.rb
+++ b/lib/logstash/outputs/elasticsearch_http.rb
@@ -101,7 +101,7 @@ class LogStash::Outputs::ElasticSearchHTTP < LogStash::Outputs::Base
     auth = @user && @password ? "#{@user}:#{@password.value}@" : ""
     @bulk_url = "http://#{auth}#{@host}:#{@port}/_bulk?replication=#{@replication}"
     if @manage_template
-      @logger.info("Automatic template configuration enabled", :manage_template => @manage_template.to_s)
+      @logger.info("Automatic template management enabled", :manage_template => @manage_template.to_s)
       template_search_url = "http://#{auth}#{@host}:#{@port}/_template/*"
       @template_url = "http://#{auth}#{@host}:#{@port}/_template/#{@template_name}"
       if @template_overwrite


### PR DESCRIPTION
Bug fix: Test for Java methods for template management
Template management will not work for versions of Elasticsearch older than 0.90.5
This patch now checks for template management capability and logs on fail

Updated docs in both elasticsearch outputs to remain in sync
