### PR TITLE
Updated to correct sub-field naming, and add 0.90.8+ feature

### DIFF
--- a/lib/logstash/outputs/elasticsearch/elasticsearch-template.json
+++ b/lib/logstash/outputs/elasticsearch/elasticsearch-template.json
@@ -21,8 +21,8 @@
            "mapping" : {
              "type" : "multi_field",
                "fields" : {
-                 "{name}" : {"type": "string", "index" : "analyzed", "omit_norms" : true, "index_options" : "docs"},
-                 "{name}.raw" : {"type": "string", "index" : "not_analyzed", "ignore_above" : 256}
+                 "{name}" : {"type": "string", "index" : "analyzed", "omit_norms" : true, "fielddata" : {"format": "disabled"}},
+                 "raw" : {"type": "string", "index" : "not_analyzed", "ignore_above" : 256}
                }
            }
          }


### PR DESCRIPTION
New type back ported from ES 1.0: "fielddata" : {"format": "disabled"} will prevent field data from the named field from being pulled into the field cache.  This forces using name.raw to get facets, hopefully reducing OOMs from innocently performing facet queries on analyzed fields.
