### PR TITLE
Fix problem in MONTHNUM and add DATESTAMP_EVENTLOG pattern

### DIFF
--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -47,6 +47,7 @@ URI %{URIPROTO}://(?:%{USER}(?::[^@]*)?@)?(?:%{URIHOST})?(?:%{URIPATHPARAM})?
 # Months: January, Feb, 3, 03, 12, December
 MONTH \b(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\b
 MONTHNUM (?:0?[1-9]|1[0-2])
+MONTHNUM2 (?:0[1-9]|1[0-2])
 MONTHDAY (?:(?:0[1-9])|(?:[12][0-9])|(?:3[01])|[1-9])
 
 # Days: Monday, Tue, Thu, etc...
@@ -70,6 +71,7 @@ DATESTAMP %{DATE}[- ]%{TIME}
 TZ (?:[PMCE][SD]T|UTC)
 DATESTAMP_RFC822 %{DAY} %{MONTH} %{MONTHDAY} %{YEAR} %{TIME} %{TZ}
 DATESTAMP_OTHER %{DAY} %{MONTH} %{MONTHDAY} %{TIME} %{TZ} %{YEAR}
+DATESTAMP_EVENTLOG %{YEAR}%{MONTHNUM2}%{MONTHDAY}%{HOUR}%{MINUTE}%{SECOND}
 
 # Syslog Dates: Month Day HH:MM:SS
 SYSLOGTIMESTAMP %{MONTH} +%{MONTHDAY} %{TIME}


### PR DESCRIPTION
Whilst trying to get Windows Event Log data into logstash I had some problems with the the timestamp format Windows uses.

Taking an example value (the TimeGenerated field provided by the eventlog input):

```
20131218141650.687853-000
```

And using:

```
%{YEAR}%{MONTHNUM}%{MONTHDAY}%{HOUR}%{MINUTE}%{SECOND}
```

I get a %{MONTHNUM} value of 1, but it should be 12. This is because the MONTHNUM pattern allows for single digit month values. I created a new pattern which removes this flexibility:

```
MONTHNUM2 (?:0[1-9]|1[0-2])
```

This, along with the new pattern below works as I would expect:

```
DATESTAMP_EVENTLOG %{YEAR}%{MONTHNUM2}%{MONTHDAY}%{HOUR}%{MINUTE}%{SECOND}
```

I'm sure there's a better way of implementing this but I think this is a genuine problem.
