### PR TITLE
enable automatically mapping logstash fields to riemann event fields.

### DIFF
--- a/lib/logstash/outputs/riemann.rb
+++ b/lib/logstash/outputs/riemann.rb
@@ -67,8 +67,31 @@ class LogStash::Outputs::Riemann < LogStash::Outputs::Base
   # but can be overridden here.
   config :riemann_event, :validate => :hash
 
-  # If set to true automatically map all logstash
-  # defined fields to riemann event fields.
+  # If set to true automatically map all logstash defined fields to riemann event fields.
+  # All nested logstash fields will be mapped to riemann fields containing all parent keys
+  # separated by dots and the deepest value.
+  #
+  # As an example, the logstash event:
+  #    {
+  #      "@timestamp":"2013-12-10T14:36:26.151+0000",
+  #      "@version": 1,
+  #      "message":"log message",
+  #      "host": "host.domain.com",
+  #      "nested_field": {
+  #                        "key": "value"
+  #                      }
+  #    }
+  # Is mapped to this riemann event:
+  #   {
+  #     :time 1386686186,
+  #     :host host.domain.com,
+  #     :message log message,
+  #     :nested_field.key value
+  #   }
+  #
+  # It can be used in conjunction with or independent of the riemann_event option.
+  # When used with the riemann_event any duplicate keys receive their value from
+  # riemann_event instead of the logstash event itself.
   config :map_fields, :validate => :boolean, :default => false
 
   #
@@ -85,7 +108,7 @@ class LogStash::Outputs::Riemann < LogStash::Outputs::Base
   def map_fields(parent, fields)
     fields.each {|key, val|
       if !key.start_with?("@")
-        parent.nil? ? field = key.gsub(/_/,'-'):field = parent.gsub(/_/,'-')+'-'+key.gsub(/_/,'-')
+        field = parent.nil? ? key : parent + '.' + key
         contents = val                            
         if contents.is_a?(Hash)                                     
           map_fields(field, contents)                                       
@@ -117,11 +140,7 @@ class LogStash::Outputs::Riemann < LogStash::Outputs::Base
     end
     if @map_fields == true
       @my_event = Hash.new
-      if event.include?("@fields")
-        map_fields(nil, event["@fields"])
-      else
-        map_fields(nil, event)
-      end
+      map_fields(nil, event)
       r_event.merge!(@my_event) {|key, val1, val2| val1}
     end
     r_event[:tags] = event["tags"] if event["tags"].is_a?(Array)


### PR DESCRIPTION
this patch allows automatic mapping from logstash fields to riemann event fields via a new config directive (map_fields).  it recurses through all key value pairs in the event that don't start with '@', unless '@fields' is present, and maps them to a riemann field containing all parent keys separated by a dash and the deepest value.  it also subs out any underscores with dashes in the resulting field name as i think it falls in-line with the riemann philosophy(?).  here's an example of a logstash event transformed into a riemann event.

logstash_event = {"@timestamp":"2013-12-10T14:36:26.151+0000","@message":"log message","@fields"{"first_level_field":"first_level_string","first_level_hash":{"second_level_field":"second_level_string","second_level_hash":{"third_level_field":"third_level_string"},"second_level_array":["first_array_string","second_array_string"]}}}

riemann_event = {:host host.domain.com, :time 1386686186, :description log message, :first-level-field first_level_string, :first-level-hash-second-level-field second_level_string, :first-level-hash-second-level-hash-third-level-field third_level_string, :first-level-hash-second-level-array ["first_array_string","second_array_string"]}

it can be used in conjunction with or independent of the riemann_event option.  when used with the riemann_event any duplicates keys receive their value from riemann_event instead of the logstash event itself.


byron
