### PR TITLE
[DEB] Depend on java-runtime-headless

### DIFF
--- a/pkg/debian/debian/control
+++ b/pkg/debian/debian/control
@@ -8,7 +8,7 @@ Homepage: http://logstash.net
 
 Package: logstash
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, daemon, adduser, psmisc, default-jre
+Depends: ${shlibs:Depends}, ${misc:Depends}, daemon, adduser, psmisc, java-runtime-headless
 Description:  tool for managing events and logs
  logstash is a tool for managing events and logs. You can use it to collect logs,
  parse them, and store them for later use (like, for searching). Speaking of


### PR DESCRIPTION
On Debian Java packages consist from two parts, regular one with graphical dependencies and -headless part, which is suitable for servers and applications like logstash or elasticsearch.

Moreover `default-jre` on Wheezy depends on `openjdk-6-jre`. While `java-runtime-headless` is provided by both `openjdk-6-jre-headless` and `openjdk-7-jre-headless`. By default `openjdk-6-jre-headless` has higher priority so it will be installed. This allows to keep number of installed java packages at minimum.
