### PR TITLE
Adding PuppetFacter input

### DIFF
--- a/lib/logstash/inputs/puppet_facter.rb
+++ b/lib/logstash/inputs/puppet_facter.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 require "logstash/inputs/base"
 require "logstash/namespace"
-require "rubygems"
 require "json"
 
 # Connects to a puppet server and requests facts


### PR DESCRIPTION
https://logstash.jira.com/browse/LOGSTASH-1726: Adds an input for Logstash to contact a puppetmaster through Puppet's API, retrieve a list of nodes managed by the puppetmaster, and get all facts from those nodes and add to logstash.
