### PR TITLE
The spec "support/date-http" can fail on a non-english machine

### DIFF
--- a/spec/support/date-http.rb
+++ b/spec/support/date-http.rb
@@ -7,6 +7,7 @@ describe "http dates", :if => RUBY_ENGINE == "jruby" do
     filter {
       date {
         match => [ "timestamp", "dd/MMM/yyyy:HH:mm:ss Z" ]
+        locale => "en"
       }
     }
   CONFIG


### PR DESCRIPTION
Running `make test` or `./bin/logstash rspec spec/support/date-http.rb` failed on my (german) machine with the following error:

```
Failures:
  1) http dates "{"timestamp":"25/Mar/2013:20:33:56 +0000"}" when processed
     Failure/Error: Unable to find matching line from backtrace
     Insist::Failure:
       Expected "2013-03-25T20:33:56.000Z", but got "2013-12-30T17:09:27.660Z"
     # ./spec/support/date-http.rb:15:in `(root)'
     # ./lib/logstash/runner.rb:154:in `run'

Finished in 0.108 seconds
1 example, 1 failure

Failed examples:
rspec ./spec/test_utils.rb:88 # http dates "{"timestamp":"25/Mar/2013:20:33:56 +0000"}" when processed
```

The reason is that Joda fails to parse the month abbreviation `Mar` using the german locale, thus I added `locale => "en"` to ensure that the test doesn't fail.

I haven't checked the other `date`-tests yet; although they did not fail for me, there could be edge-cases for other locales.
