### PR TITLE
Add support for drip.

### DIFF
--- a/bin/logstash
+++ b/bin/logstash
@@ -28,10 +28,10 @@ case $1 in
   -*) 
     # is the first argument a flag? If so, assume 'agent'
     program="$basedir/lib/logstash/runner.rb"
-    exec $RUBYCMD "$program" agent "$@"
+    exec $RUBYCMD -I$RUBYLIB "$program" agent "$@"
     ;;
   *)
     program="$basedir/lib/logstash/runner.rb"
-    exec $RUBYCMD "$program" "$@"
+    exec $RUBYCMD -I$RUBYLIB "$program" "$@"
     ;;
 esac

--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -1,6 +1,7 @@
 basedir=$(cd `dirname $0`/..; pwd)
 
 setup_ruby() {
+  export RUBYLIB="$basedir/lib"
   # Verify ruby works
   if ! ruby -e 'puts "HURRAY"' 2> /dev/null | grep -q "HURRAY" ; then
     echo "No ruby program found. Cannot start."
@@ -9,20 +10,29 @@ setup_ruby() {
 
   eval $(ruby -rrbconfig -e 'puts "RUBYVER=#{RbConfig::CONFIG["ruby_version"]}"; puts "RUBY=#{RUBY_ENGINE}"')
   RUBYCMD="ruby"
+  export GEM_HOME="$basedir/vendor/bundle/${RUBY}/${RUBYVER}"
+  export GEM_PATH=
 }
 
 setup_java() {
-  if [ -z "$JAVA_HOME/bin/java" ] ; then
-    JAVA="$JAVA_HOME/bin/java"
-  else
-    JAVA=$(which java)
+  if [ -z "$JAVACMD" ] ; then
+    if [ -z "$JAVA_HOME/bin/java" ] ; then
+      JAVACMD="$JAVA_HOME/bin/java"
+    else
+      JAVACMD="java"
+    fi
+  elif [ "$(basename $JAVACMD)" = "drip" ] ; then
+    export DRIP_INIT_CLASS="org.jruby.main.DripMain"
+    export DRIP_INIT=
   fi
 
-  if [ ! -x "$JAVA" ] ; then
-    echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME."
-    exit 1
+  if [ ! -x "$JAVACMD" ] ; then
+    JAVACMD="$(which $JAVACMD 2> /dev/null)"
+    if [ ! -x "$JAVACMD" ] ; then
+      echo "Could not find any executable java binary (tried '$JAVACMD'). Please install java in your PATH or set JAVA_HOME."
+      exit 1
+    fi
   fi
-
 
   JAVA_OPTS="$JAVA_OPTS -Xmx${LS_HEAP_SIZE}"
   JAVA_OPTS="$JAVA_OPTS -XX:+UseParNewGC"
@@ -41,30 +51,25 @@ setup_java() {
     JAVA_OPTS="$JAVA_OPTS -Xloggc:./logstash-gc.log"
     echo "Writing garbage collection logs to ./logstash-gc.log"
   fi
+
+  export JAVACMD
+  export JAVA_OPTS
+  export GEM_HOME="$basedir/vendor/bundle/jruby/1.9"
 } 
 
 setup_vendored_jruby() {
   RUBYVER=1.9
   RUBY=jruby
-
-  setup_java
-
-  RUBYCMD="$JAVA $JAVA_OPTS -jar $basedir/vendor/jar/jruby-complete-*.jar"
+  RUBYCMD="$JAVACMD $JAVA_OPTS -jar $basedir/vendor/jar/jruby-complete-*.jar"
 }
 
 setup() {
+  setup_java
   if [ -z "$USE_JRUBY" -a \( -d "$basedir/.git" -o ! -z "$USE_RUBY" \) ] ; then
     setup_ruby
-    if [ "$RUBY" = "jruby" ] ; then
-      setup_java
-      export JAVA_OPTS
-    fi
   else
     setup_vendored_jruby
   fi
-  export GEM_HOME="$basedir/vendor/bundle/${RUBY}/${RUBYVER}"
-  export GEM_PATH=
-  export RUBYLIB="$basedir/lib"
 }
 
 install_deps() {


### PR DESCRIPTION
Drip allows for faster startup time by pre-starting JVMs and keeping a
pool of them around for use on-demand. More details here:
https://github.com/flatland/drip

It is _very_ important to note that this only improves startup time, not run-time. It is recommended _ONLY_ for testing/development iteration - not production.

Tested with this config:
- 'input { generator { count => 1 } } output { null { } }'

Without drip:

```
% time bin/logstash -e '...'
13.19s user 2.94s system 170% cpu 9.458 total
```

With drip (install drip, then set 'JAVACMD=drip' in env):

```
% time JAVACMD=drip bin/logstash -e '...'
0.03s user 0.46s system 6% cpu 7.008 total
```

2.5 seconds faster (27% faster). the nearly-zero user/system times are because 'time' only measures time spent in the 'drip' process, which at this point is simply a client telling a drip pool instance to execute.
