### PR TITLE
Removed duplicated mail dependency definition

### DIFF
--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -69,7 +69,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "user_agent_parser", [">= 2.0.0"]  #(MIT license)
   gem.add_runtime_dependency "snmp"                             #(ruby license)
   gem.add_runtime_dependency "varnish-rb"                       #(MIT license)
-  gem.add_runtime_dependency "mail"                             #(MIT license)
   gem.add_runtime_dependency "rbnacl"                           #(MIT license)
   gem.add_runtime_dependency "sequel"                           #(MIT license)
   gem.add_runtime_dependency "jdbc-sqlite3"                     #(MIT license)


### PR DESCRIPTION
Fixes warnings generated by gem when attempting to install dependencies.
