### PR TITLE
Add remote option to wmi input.

### DIFF
--- a/lib/logstash/inputs/wmi.rb
+++ b/lib/logstash/inputs/wmi.rb
@@ -18,6 +18,12 @@ require "socket"
 #       wmi {
 #         query => "select PercentProcessorTime from Win32_PerfFormattedData_PerfOS_Processor where name = '_Total'"
 #       }
+#       wmi { # Connect to a remote host
+#         query => "select * from Win32_Process"
+#         host => "MyRemoteHost"
+#         user => "mydomain\myuser"
+#         password => "Password"
+#        }
 #     }
 class LogStash::Inputs::WMI < LogStash::Inputs::Base
 
@@ -29,6 +35,19 @@ class LogStash::Inputs::WMI < LogStash::Inputs::Base
   # Polling interval
   config :interval, :validate => :number, :default => 10
   
+  # Host to connect to ( Defaults to localhost )
+  config :host, :validate => :string, :default => 'localhost'
+
+  # Username when doing remote connections
+  config :user, :validate => :string
+
+  # Password when doing remote connections
+  config :password, :validate => :password
+
+  # Namespace when doing remote connections
+  config :namespace, :validate => :string, :default => 'root\cimv2'
+
+
   public
   def register
 
@@ -42,12 +61,22 @@ class LogStash::Inputs::WMI < LogStash::Inputs::Base
     else
       require "win32ole"
     end
+
+    # If host is localhost do a local connection
+    if (@host == "127.0.0.1" || @host == "localhost" || @host == "::1")
+      @wmi = WIN32OLE.connect('winmgmts:')
+      @host = Socket.gethostname
+    else
+      locator = WIN32OLE.new("WbemScripting.SWbemLocator")
+      @host = Socket.gethostbyname(@host).first
+      @wmi = locator.ConnectServer(@host, @namespace, @user, @password.value)
+    end
+
   end # def register
 
   public
   def run(queue)
-    @wmi = WIN32OLE.connect("winmgmts://")
-    
+
     begin
       @logger.debug("Executing WMI query '#{@query}'")
       loop do


### PR DESCRIPTION
based on code from https://logstash.jira.com/browse/LOGSTASH-1747
This allows any logstash instance to connect to WMI remotely.
