### PR TITLE
Improved grok patterns for Java

### DIFF
--- a/patterns/java
+++ b/patterns/java
@@ -1,3 +1,4 @@
-JAVACLASS (?:[a-zA-Z0-9-]+\.)+[A-Za-z0-9$_]+
+JAVACLASS (?:[a-zA-Z0-9_-]+\.)+[A-Za-z0-9$_]+
+JAVAMETHOD (?:[\w<>]+)
 JAVAFILE (?:[A-Za-z0-9_. -]+)
-JAVASTACKTRACEPART at %{JAVACLASS:class}\.%{WORD:method}\(%{JAVAFILE:file}:%{NUMBER:line}\)
+JAVASTACKTRACEPART at %{JAVACLASS:class}\.%{JAVAMETHOD:method}\(%{JAVAFILE:file}:%{NUMBER:line}\)


### PR DESCRIPTION
I used logstash to parse our log files. Unfortunately this parsing failed for some special named classes and methods.

We allow the underscore character to be part of the package or the class name. This is not allowed in the grok pattern for Java classes. So I added this character to the JAVACLASS pattern.

Furthermore I have log lines containing the constructor of classes as method, which is logged as "<init>". So I introduced the grok pattern for a Java method that allows additionally to the WORD pattern the angle brackets und used that pattern in the JAVASTACKTRACEPART pattern.
