### PR TITLE
Lookup metrics percentiles using a float, not an integer.

### DIFF
--- a/lib/logstash/filters/metrics.rb
+++ b/lib/logstash/filters/metrics.rb
@@ -48,6 +48,7 @@ require "logstash/namespace"
 # * "thing.max" - the maximum value seen for this metric
 # * "thing.stddev" - the standard deviation for this metric
 # * "thing.mean" - the mean for this metric
+# * "thing.pXX" - the XXth percentile for this metric (see `percentiles`)
 #
 # #### Example: computing event rate
 #
@@ -192,7 +193,7 @@ class LogStash::Filters::Metrics < LogStash::Filters::Base
       event["#{name}.mean"] = metric.mean
 
       @percentiles.each do |percentile|
-        event["#{name}.p#{percentile}"] = metric.snapshot.value(percentile / 100)
+        event["#{name}.p#{percentile}"] = metric.snapshot.value(percentile / 100.0)
       end
       metric.clear if should_clear?
     end


### PR DESCRIPTION
The `metrics` filter was producing `0.0` for all percentiles except the 100th. I found [this post on the mailing list](https://groups.google.com/forum/#!topic/logstash-users/MxBDaWyzD9w) with the same issue.

This small change forces the parameter to `Snapshot.value()` to be a float rather than an integer. It seems to fix the issue for me in our setup. Unfortunately, the tests would not run on my Mac -- I assume this change to be simple enough to submit without running the tests.
