### PR TITLE
rabbitmq: fix passive feature

### DIFF
--- a/lib/logstash/inputs/rabbitmq/bunny.rb
+++ b/lib/logstash/inputs/rabbitmq/bunny.rb
@@ -90,6 +90,7 @@ class LogStash::Inputs::RabbitMQ
                      :durable     => @durable,
                      :auto_delete => @auto_delete,
                      :exclusive   => @exclusive,
+                     :passive     => @passive,
                      :arguments   => @arguments)
 
       # exchange binding is optional for the input

--- a/lib/logstash/inputs/rabbitmq/march_hare.rb
+++ b/lib/logstash/inputs/rabbitmq/march_hare.rb
@@ -96,6 +96,7 @@ class LogStash::Inputs::RabbitMQ
         :durable     => @durable,
         :auto_delete => @auto_delete,
         :exclusive   => @exclusive,
+        :passive     => @passive,
         :arguments   => @arguments)
 
       # exchange binding is optional for the input


### PR DESCRIPTION
Pass the @passive parameter down to the rabbitmq library, so that
connecting to a read-only server works.  Without this option, the
rabbitmq library attempts to create the queue, causing an error if those
permissions are not enabled.
