### PR TITLE
elasticsearch: send scrollid in post body

### DIFF
--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -85,12 +85,11 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
     if @scan
 
       scroll_params = {
-        "scroll_id" => scroll_id,
         "scroll" => @scroll
       }
 
       scroll_url = "http://#{@host}:#{@port}/_search/scroll?#{encode(scroll_params)}"
-      response = @agent.get!(scroll_url)
+      response = @agent.post!(scroll_url, :body => scroll_id)
       json = ""
       response.read_body { |c| json << c }
       result = JSON.parse(json)
@@ -117,12 +116,11 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
 
       # Fetch the next result set
       scroll_params = {
-        "scroll_id" => scroll_id,
         "scroll" => @scroll
       }
       scroll_url = "http://#{@host}:#{@port}/_search/scroll?#{encode(scroll_params)}"
 
-      response = @agent.get!(scroll_url)
+      response = @agent.post!(scroll_url, :body => scroll_id)
       json = ""
       response.read_body { |c| json << c }
       result = JSON.parse(json)


### PR DESCRIPTION
Newer elasticsearch versions have extremely long scrollids which pass
the URL limit.  Send the scrollid as part of the post body to avoid this
problem.
