### PR TITLE
Correctly set RUBYLIB for JRuby.

### DIFF
--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -54,6 +54,7 @@ setup_java() {
 
   export JAVACMD
   export JAVA_OPTS
+  export RUBYLIB="$basedir/lib"
   export GEM_HOME="$basedir/vendor/bundle/jruby/1.9"
 } 
 


### PR DESCRIPTION
When running

```
USE_JRUBY=1 bin/logstash agent -e 'input { pipe { command => "echo Hello World" }'
```

I would get the error:

```
Error opening script file: /Users/buckett/Documents/logstash/agent (No such file or directory)
```

adding `set -x` to `bin/logstash` you see the command getting executed is:

```
+ exec /usr/bin/java -Xmx500m -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -Djava.awt.headless=true -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -jar /Users/buckett/Documents/logstash/vendor/jar/jruby-complete-1.7.9.jar -I /Users/buckett/Documents/logstash/lib/logstash/runner.rb agent -e 'input { pipe { command => "echo Hello World" }'
```

which is missing the RUBYLIB, this adds it back.
