### PR TITLE
LOGSTASH-1799 Don't always restart pipe commands.

### DIFF
--- a/lib/logstash/inputs/pipe.rb
+++ b/lib/logstash/inputs/pipe.rb
@@ -60,7 +60,7 @@ class LogStash::Inputs::Pipe < LogStash::Inputs::Base
         relaunch = @restart == "always"
       rescue Exception => e
         @logger.error("Exception while running command", :e => e, :backtrace => e.backtrace)
-        should_restart = @restart == "error"
+        relaunch = @restart == "error"
       end
     end while relaunch && sleep(10) > 0
   end # def run


### PR DESCRIPTION
Allow the pipe to be configurable about what should happen when the command exists. Valid things todo are restart, restart on errors and never restart.
