### PR TITLE
Remove dependency on presence of region field.

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -64,7 +64,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     require "digest/md5"
     require "aws-sdk"
 
-    @region_endpoint = @region if !@region.empty?
+    @region_endpoint = @region if @region && !@region.empty?
 
     @logger.info("Registering s3 input", :bucket => @bucket, :region_endpoint => @region_endpoint)
 


### PR DESCRIPTION
The region field for the S3 input is deprecated in favor of region_endpoint, however logstash will fail calling .empty? on nil if the field is not present. This simply checks that @region is not nil before checking if it is empty.

Before this patch:

irb(main):015:0> @region_endpoint = @region if !@region.empty?
NoMethodError: undefined method `empty?' for nil:NilClass
