### PR TITLE
input file: don't overwrite host field

### DIFF
--- a/lib/logstash/inputs/file.rb
+++ b/lib/logstash/inputs/file.rb
@@ -130,7 +130,7 @@ class LogStash::Inputs::File < LogStash::Inputs::Base
       @logger.debug? && @logger.debug("Received line", :path => path, :text => line)
       @codec.decode(line) do |event|
         decorate(event)
-        event["host"] = hostname
+        event["host"] = hostname if !event.include?("host")
         event["path"] = path
         queue << event
       end


### PR DESCRIPTION
When reading file input in json (logstash-event1) format the host field is overwritten with the current hostname. If the file is generated on a different system and transported to the LS server and then imported the host field contains the wrong value.

This patch checks if the host field is already present, if so it doesn't overwrite the value.

I've run the test and signed the CLA.
