### PR TITLE
Bugfix for percentil calculation

### DIFF
--- a/lib/logstash/filters/metrics.rb
+++ b/lib/logstash/filters/metrics.rb
@@ -192,7 +192,7 @@ class LogStash::Filters::Metrics < LogStash::Filters::Base
       event["#{name}.mean"] = metric.mean
 
       @percentiles.each do |percentile|
-        event["#{name}.p#{percentile}"] = metric.snapshot.value(percentile / 100)
+        event["#{name}.p#{percentile}"] = metric.snapshot.value(percentile / 100.0)
       end
       metric.clear if should_clear?
     end


### PR DESCRIPTION
Floating point needed, otherwise you always get the for
metric.snapshot.value(0)

Current workaround - floating points like "[ 90.0, 95.0, 99.0]" in the array - results in ugly metricnames like "metricname.p90.0"
