### PR TITLE
Use $! instead of pgrep to get PID

### DIFF
--- a/pkg/logstash.sysv.redhat
+++ b/pkg/logstash.sysv.redhat
@@ -111,7 +111,7 @@ do_start()
   $JAVA $ARGS > /dev/null 1>&1 &
 
   RETVAL=$?
-  local PID=`pgrep -f "${DAEMON} ${ARGS}"`
+  local PID=$!
   echo $PID > $PID_FILE
   success
 }


### PR DESCRIPTION
related: LOGSTASH-1806

Using $! as it works much better for getting the PID, especially if the executable path contains special characters.
