### PR TITLE
Allow host to be set from UDP input

### DIFF
--- a/lib/logstash/inputs/udp.rb
+++ b/lib/logstash/inputs/udp.rb
@@ -62,7 +62,7 @@ class LogStash::Inputs::Udp < LogStash::Inputs::Base
       payload, client = @udp.recvfrom(@buffer_size)
       @codec.decode(payload) do |event|
         decorate(event)
-        event["host"] = client[3]
+        event["host"] ||= client[3]
         output_queue << event
       end
     end


### PR DESCRIPTION
This seems to be possible with other input types, so I thought it would
make sense here as well. Maybe I'm missing something?
