### PR TITLE
Single-thread the TCP input's server

### DIFF
--- a/lib/logstash/inputs/tcp.rb
+++ b/lib/logstash/inputs/tcp.rb
@@ -84,6 +84,7 @@ class LogStash::Inputs::Tcp < LogStash::Inputs::Base
       @logger.info("Starting tcp input listener", :address => "#{@host}:#{@port}")
       begin
         @server_socket = TCPServer.new(@host, @port)
+        @server_socket.listen(20) # apply backpressure to clients by hinting to the OS that it shouldn't keep too large of a connection backlog
       rescue Errno::EADDRINUSE
         @logger.error("Could not start TCP server: Address in use",
                       :host => @host, :port => @port)
@@ -155,23 +156,18 @@ class LogStash::Inputs::Tcp < LogStash::Inputs::Base
 
   def run_server(output_queue)
     @thread = Thread.current
-    @client_threads = []
     loop do
-      # Start a new thread for each connection.
       begin
-        @client_threads << Thread.start(@server_socket.accept) do |s|
-          # TODO(sissel): put this block in its own method.
-
-          # monkeypatch a 'peer' method onto the socket.
-          s.instance_eval { class << self; include ::LogStash::Util::SocketPeer end }
-          @logger.debug("Accepted connection", :client => s.peer,
-                        :server => "#{@host}:#{@port}")
-          begin
-            handle_socket(s, s.peer, output_queue, @codec.clone)
-          rescue Interrupted
-            s.close rescue nil
-          end
-        end # Thread.start
+        s = @server_socket.accept
+        # monkeypatch a 'peer' method onto the socket.
+        s.instance_eval { class << self; include ::LogStash::Util::SocketPeer end }
+        @logger.debug("Accepted connection", :client => s.peer,
+                      :server => "#{@host}:#{@port}")
+        begin
+          handle_socket(s, s.peer, output_queue, @codec.clone)
+        rescue Interrupted
+          s.close rescue nil
+        end
       rescue OpenSSL::SSL::SSLError => ssle
         # NOTE(mrichar1): This doesn't return a useful error message for some reason
         @logger.error("SSL Error", :exception => ssle,
@@ -180,9 +176,6 @@ class LogStash::Inputs::Tcp < LogStash::Inputs::Base
         if @interrupted
           # Intended shutdown, get out of the loop
           @server_socket.close
-          @client_threads.each do |thread|
-            thread.raise(LogStash::ShutdownSignal)
-          end
           break
         else
           # Else it was a genuine IOError caused by something else, so propagate it up..
@@ -196,8 +189,7 @@ class LogStash::Inputs::Tcp < LogStash::Inputs::Base
     @server_socket.close
   end # def run_server
 
-  def run_client(output_queue) 
-    @thread = Thread.current
+  def run_client(output_queue)
     while true
       client_socket = TCPSocket.new(@host, @port)
       if @ssl_enable


### PR DESCRIPTION
Should address https://logstash.jira.com/browse/LOGSTASH-922

We ran into that issue on our systems, where we had multiple thousands of TCP connections in TIME_WAIT state (indicating that our client process had sent its data and closed its end of the connection) and a logstash thread to match. The root problem was that our output was sluggish and the queue was filling up, but logstash wasn't applying back pressure well. Since the TCP input was accepting new connections as fast as it could fork threads, we were extending the SizedQueue into the kernel's run queue up to the process' thread limit by way of blocked threads.

After applying this patch, we saw only hundreds of outstanding connections – TCP implementations offer relatively poor control over the sizing of the connect queue from the application level – but only a single TCP thread that was blocked on the SizedQueue. In other words, this change allows us to implement back pressure more effectively (catching connection failures in the client and retrying with a back off) by refusing connections earlier when we got backed up and without killing the logstash process or overloading the scheduler.