### PR TITLE
Fix 'cleanup' step to properly delete all data.

### DIFF
--- a/spec/outputs/elasticsearch_http.rb
+++ b/spec/outputs/elasticsearch_http.rb
@@ -176,7 +176,7 @@ describe "outputs/elasticsearch_http" do
     before :each do
       require "elasticsearch"
       @es = Elasticsearch::Client.new
-      @es.indices.delete
+      @es.indices.delete(:index => "*")
 
       subject.receive(LogStash::Event.new("message" => "sample message here"))
       subject.receive(LogStash::Event.new("somevalue" => 100))


### PR DESCRIPTION
In elasticsearch 1.0, the "DELETE /" request is now rejected by default.
So instead, we will "DELETE /*"
