### PR TITLE
Update path to pid file

### DIFF
--- a/pkg/logstash.sysv.redhat
+++ b/pkg/logstash.sysv.redhat
@@ -65,7 +65,7 @@ if [ -f "$DEFAULT" ]; then
 fi
 
 # Define other required variables
-PID_FILE=/var/run/$NAME.pid
+PID_FILE=/var/run/logstash/$NAME.pid
 
 JAVA=`which java`
 JAR="${LS_HOME}/logstash.jar"


### PR DESCRIPTION
init script on CentOS 6 fails without that fix, please review.
