### PR TITLE
on broken pipes - ie program exit, EBADF can will be used instead of EPI...

### DIFF
--- a/lib/logstash/outputs/pipe.rb
+++ b/lib/logstash/outputs/pipe.rb
@@ -46,7 +46,7 @@ class LogStash::Outputs::Pipe < LogStash::Outputs::Base
 
     begin
       pipe.puts(output)
-    rescue IOError, Errno::EPIPE => e
+    rescue IOError, Errno::EPIPE, Errno::EBADF => e
       @logger.error("Error writing to pipe, closing pipe.", :command => command, :pipe => pipe)
       drop_pipe(command)
     end


### PR DESCRIPTION
...PE. This commit will allow pipe command to be restarted.

https://logstash.jira.com/browse/LOGSTASH-1820
