### PR TITLE
Make sure the i18n gem is v0.6.6 or newer

### DIFF
--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "pry"                #(ruby license)
   gem.add_runtime_dependency "stud"               #(Apache 2.0 license)
   gem.add_runtime_dependency "clamp"              # for command line args/flags (MIT license)
-  gem.add_runtime_dependency "i18n"               #(MIT license)
+  gem.add_runtime_dependency "i18n", [">=0.6.6"]  #(MIT license)
 
   # Web dependencies
   gem.add_runtime_dependency "ftw", ["~> 0.0.39"] #(Apache 2.0 license)


### PR DESCRIPTION
Because lib/logstash/runner.rb uses `I18n.enforce_available_locales=` which isn't available until v0.6.6.
