### PR TITLE
Make metrics filter thread-safe

### DIFF
--- a/lib/logstash/filters/metrics.rb
+++ b/lib/logstash/filters/metrics.rb
@@ -61,18 +61,20 @@ require "logstash/namespace"
 #     }
 #
 #     filter {
-#       metrics {
-#         type => "generated"
-#         meter => "events"
-#         add_tag => "metric"
+#       if [type] == "generated" {
+#         metrics {
+#           meter => "events"
+#           add_tag => "metric"
+#         }
 #       }
 #     }
 #
 #     output {
-#       stdout {
-#         # only emit events with the 'metric' tag
-#         tags => "metric"
-#         message => "rate: %{events.rate_1m}"
+#       # only emit events with the 'metric' tag
+#       if "metric" in [tags] {
+#         stdout {
+#           message => "rate: %{events.rate_1m}"
+#         }
 #       }
 #     }
 #


### PR DESCRIPTION
This is an attempt to make the metrics filter thread-safe by using thread-safe data structures for variables that change during runtime. It would be great if someone can review this to see if I catched everything. Thanks!
