### PR TITLE
input/collectd: Fix crash

### DIFF
--- a/lib/logstash/inputs/collectd.rb
+++ b/lib/logstash/inputs/collectd.rb
@@ -259,6 +259,7 @@ class LogStash::Inputs::Collectd < LogStash::Inputs::Base
 
   private
   def get_key(user)
+    return if @authmtime.nil? or @authfile.nil?
     # Validate that our auth data is still up-to-date
     parse_authfile if @authmtime < File.stat(@authfile).mtime
     key = @auth[user]


### PR DESCRIPTION
- The plugin would crash if an encrypted packet was received and no
  authfile was configured. This commit fixes this.
