### PR TITLE
Remove long-deprecated/unused 'debug' setting for all plugins that do not use it

### DIFF
--- a/lib/logstash/inputs/base.rb
+++ b/lib/logstash/inputs/base.rb
@@ -25,8 +25,7 @@ class LogStash::Inputs::Base < LogStash::Plugin
   # when sent to another Logstash server.
   config :type, :validate => :string
 
-  # Set this to true to enable debugging on an input.
-  config :debug, :validate => :boolean, :default => false
+  config :debug, :validate => :boolean, :default => false, :deprecated => "This setting no longer has any effect. In past releases, it existed, but almost no plugin made use of it."
 
   # The format of input data (plain, json, json_event)
   config :format, :validate => ["plain", "json", "json_event", "msgpack_event"], :deprecated => "You should use the newer 'codec' setting instead."

--- a/lib/logstash/inputs/exec.rb
+++ b/lib/logstash/inputs/exec.rb
@@ -19,7 +19,7 @@ class LogStash::Inputs::Exec < LogStash::Inputs::Base
   default :codec, "plain"
   
   # Set this to true to enable debugging on an input.
-  config :debug, :validate => :boolean, :default => false
+  config :debug, :validate => :boolean, :default => false, :deprecated => "This setting was never used by this plugin. It will be removed soon."
   
   # Command to run. For example, "uptime"
   config :command, :validate => :string, :required => true
@@ -38,7 +38,7 @@ class LogStash::Inputs::Exec < LogStash::Inputs::Base
     hostname = Socket.gethostname
     loop do
       start = Time.now
-      @logger.info("Running exec", :command => @command) if @debug
+      @logger.info? && @logger.info("Running exec", :command => @command)
       out = IO.popen(@command)
       # out.read will block until the process finishes.
       @codec.decode(out.read) do |event|
@@ -49,10 +49,8 @@ class LogStash::Inputs::Exec < LogStash::Inputs::Base
       end
       
       duration = Time.now - start
-      if @debug
-        @logger.info("Command completed", :command => @command,
-                     :duration => duration)
-      end
+      @logger.info? && @logger.info("Command completed", :command => @command,
+                                    :duration => duration)
 
       # Sleep for the remainder of the interval, or 0 if the duration ran
       # longer than the interval.

--- a/lib/logstash/inputs/rabbitmq.rb
+++ b/lib/logstash/inputs/rabbitmq.rb
@@ -44,7 +44,7 @@ class LogStash::Inputs::RabbitMQ < LogStash::Inputs::Threadable
   config :verify_ssl, :validate => :boolean, :default => false
 
   # Enable or disable logging
-  config :debug, :validate => :boolean, :default => false
+  config :debug, :validate => :boolean, :default => false, :deprecated => "Use the logstash --debug flag for this instead."
 
 
 

--- a/lib/logstash/inputs/rabbitmq/bunny.rb
+++ b/lib/logstash/inputs/rabbitmq/bunny.rb
@@ -22,7 +22,7 @@ class LogStash::Inputs::RabbitMQ
                                 Bunny::DEFAULT_PASSWORD
                               end
 
-      @settings[:log_level] = if @debug
+      @settings[:log_level] = if @debug || @logger.debug?
                                 :debug
                               else
                                 :error

--- a/lib/logstash/inputs/stomp.rb
+++ b/lib/logstash/inputs/stomp.rb
@@ -30,7 +30,7 @@ class LogStash::Inputs::Stomp < LogStash::Inputs::Base
   config :vhost, :validate => :string, :default => nil
 
   # Enable debugging output?
-  config :debug, :validate => :boolean, :default => false
+  config :debug, :validate => :boolean, :default => false, :deprecated => "This setting was never used by this plugin. It will be removed soon."
 
   private
   def connect

--- a/lib/logstash/inputs/xmpp.rb
+++ b/lib/logstash/inputs/xmpp.rb
@@ -30,12 +30,12 @@ class LogStash::Inputs::Xmpp < LogStash::Inputs::Base
 
   # Set to true to enable greater debugging in XMPP. Useful for debugging
   # network/authentication erros.
-  config :debug, :validate => :boolean, :default => false
+  config :debug, :validate => :boolean, :default => false, :deprecated => "Use the logstash --debug flag for this instead."
 
   public
   def register
     require 'xmpp4r' # xmpp4r gem
-    Jabber::debug = true if @debug
+    Jabber::debug = true if @debug || @logger.debug?
 
     @client = Jabber::Client.new(Jabber::JID.new(@user))
     @client.connect(@host) # it is ok if host is nil

--- a/lib/logstash/outputs/elasticsearch_river.rb
+++ b/lib/logstash/outputs/elasticsearch_river.rb
@@ -20,8 +20,6 @@ class LogStash::Outputs::ElasticSearchRiver < LogStash::Outputs::Base
   config_name "elasticsearch_river"
   milestone 2
 
-  config :debug, :validate => :boolean, :default => false
-
   # The index to write events to. This can be dynamic using the %{foo} syntax.
   # The default value will partition your indeces by day so you can more easily
   # delete old data or only search specific date ranges.
@@ -113,7 +111,7 @@ class LogStash::Outputs::ElasticSearchRiver < LogStash::Outputs::Base
       "vhost" => [@vhost],
       "durable" => [@durable.to_s],
       "persistent" => [@persistent.to_s],
-      "debug" => [@debug.to_s],
+      "debug" => [@logger.debug?.to_s],
     }.reject {|k,v| v.first.nil?}
     @mq = LogStash::Outputs::RabbitMQ.new(params)
     @mq.register

--- a/lib/logstash/outputs/graphite.rb
+++ b/lib/logstash/outputs/graphite.rb
@@ -50,7 +50,7 @@ class LogStash::Outputs::Graphite < LogStash::Outputs::Base
   config :exclude_metrics, :validate => :array, :default => [ "%\{[^}]+\}" ]
 
   # Enable debug output
-  config :debug, :validate => :boolean, :default => false
+  config :debug, :validate => :boolean, :default => false, :deprecated => "This setting was never used by this plugin. It will be removed soon."
 
   # Defines format of the metric string. The placeholder '*' will be
   # replaced with the name of the actual metric.

--- a/lib/logstash/outputs/opentsdb.rb
+++ b/lib/logstash/outputs/opentsdb.rb
@@ -10,8 +10,8 @@ class LogStash::Outputs::Opentsdb < LogStash::Outputs::Base
   config_name "opentsdb"
   milestone 1
 
-  # Enable debugging. Tries to pretty-print the entire event object.
-  config :debug, :validate => :boolean
+  # Enable debugging.
+  config :debug, :validate => :boolean, :default => false, :deprecated => "This setting was never used by this plugin. It will be removed soon."
 
   # The address of the opentsdb server.
   config :host, :validate => :string, :default => "localhost"

--- a/lib/logstash/outputs/rabbitmq.rb
+++ b/lib/logstash/outputs/rabbitmq.rb
@@ -43,7 +43,7 @@ class LogStash::Outputs::RabbitMQ < LogStash::Outputs::Base
   config :verify_ssl, :validate => :boolean, :default => false
 
   # Enable or disable logging
-  config :debug, :validate => :boolean, :default => false
+  config :debug, :validate => :boolean, :default => false, :deprecated => "Use the logstash --debug flag for this instead."
 
 
 

--- a/lib/logstash/outputs/rabbitmq/bunny.rb
+++ b/lib/logstash/outputs/rabbitmq/bunny.rb
@@ -88,7 +88,7 @@ class LogStash::Outputs::RabbitMQ
                                 Bunny::DEFAULT_PASSWORD
                               end
 
-      @settings[:log_level] = if @debug
+      @settings[:log_level] = if @debug || @logger.debug?
                                 :debug
                               else
                                 :error

--- a/lib/logstash/outputs/riemann.rb
+++ b/lib/logstash/outputs/riemann.rb
@@ -69,7 +69,7 @@ class LogStash::Outputs::Riemann < LogStash::Outputs::Base
 
   #
   # Enable debugging output?
-  config :debug, :validate => :boolean, :default => false
+  config :debug, :validate => :boolean, :default => false, :deprecated => "This setting was never used by this plugin. It will be removed soon."
 
   public
   def register

--- a/lib/logstash/outputs/statsd.rb
+++ b/lib/logstash/outputs/statsd.rb
@@ -62,11 +62,8 @@ class LogStash::Outputs::Statsd < LogStash::Outputs::Base
   # The sample rate for the metric
   config :sample_rate, :validate => :number, :default => 1
 
-  # The final metric sent to statsd will look like the following (assuming defaults)
-  # logstash.sender.file_name
-  #
-  # Enable debugging output?
-  config :debug, :validate => :boolean, :default => false
+  # Enable debugging.
+  config :debug, :validate => :boolean, :default => false, :deprecated => "This setting was never used by this plugin. It will be removed soon."
 
   public
   def register

--- a/lib/logstash/outputs/stdout.rb
+++ b/lib/logstash/outputs/stdout.rb
@@ -13,29 +13,8 @@ class LogStash::Outputs::Stdout < LogStash::Outputs::Base
   
   default :codec, "line"
 
-  # Enable debugging. Tries to pretty-print the entire event object.
-  config :debug, :validate => :boolean, :default => false
-
-  # Debug output format: ruby (default), json
-  config :debug_format, :default => "ruby", :validate => ["ruby", "dots", "json"], :deprecated => true
-
-  # The message to emit to stdout.
-  config :message, :validate => :string, :deprecated => "You can use the 'line' codec instead. For example: output { stdout { codec => line { format => \"%{somefield} your message\" } } }"
-
   public
   def register
-    if @debug
-      require "logstash/codecs/rubydebug"
-      require "logstash/codecs/dots"
-      require "logstash/codecs/json"
-      case @debug_format
-        when "ruby"; @codec = LogStash::Codecs::RubyDebug.new
-        when "json"; @codec = LogStash::Codecs::JSON.new
-        when "dots"; @codec = LogStash::Codecs::Dots.new
-      end
-    elsif @message
-      @codec = LogStash::Codecs::Line.new("format" => @message)
-    end
     @codec.on_event do |event|
       $stdout.write(event)
     end

--- a/lib/logstash/outputs/stomp.rb
+++ b/lib/logstash/outputs/stomp.rb
@@ -27,8 +27,8 @@ class LogStash::Outputs::Stomp < LogStash::Outputs::Base
   # The vhost to use
   config :vhost, :validate => :string, :default => nil
 
-  # Enable debugging output?
-  config :debug, :validate => :boolean, :default => false
+  # Enable debugging output.
+  config :debug, :validate => :boolean, :default => false, :deprecated => "This setting was never used by this plugin. It will be removed soon."
 
   private
   def connect


### PR DESCRIPTION
Also deprecated the 'debug' setting for plugins that _do_ use it with
encouragement to use the --debug flag.
