### PR TITLE
Add multiline output to file

### DIFF
--- a/lib/logstash/outputs/file.rb
+++ b/lib/logstash/outputs/file.rb
@@ -72,7 +72,7 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
       output = event.to_json
     end
 
-    fd.write(output)
+    fd.write(output.gsub!(/\\n/, "\n"))
     fd.write("\n")
 
     flush(fd)


### PR DESCRIPTION
We use logstash to collect some logs in a file in some format. And we need to have a certain format logs, for example: "%{message}\n%{status}\n%{level}". But file output not supports this format, and all '\n' becomes '\\n'. 