### PR TITLE
Ubuntu/Debian packages should depend on 'java6-runtime-headless'

### DIFF
--- a/pkg/build.sh
+++ b/pkg/build.sh
@@ -126,7 +126,7 @@ case $os in
       --description "$DESCRIPTION" \
       --vendor "Elasticsearch" \
       --license "Apache 2.0" \
-      -d "default-jre-headless" \
+      -d "java-runtime-headless" \
       --deb-user root --deb-group root \
       --before-install $os/before-install.sh \
       --before-remove $os/before-remove.sh \


### PR DESCRIPTION
This fixes #893. The previous dependency "default-jre-headless" is just
a metapackage pointing at openjre6, but "java6-runtime-headless" is a
'Provides' entry that openjdk packages seem to provide for java versions
6 and 7. This should ensure we are correctly requesting _any_ java 6+
implementation instead of requiring a specific java package.
