### PR TITLE
On config failure, tell users about --configtest

### DIFF
--- a/lib/logstash/agent.rb
+++ b/lib/logstash/agent.rb
@@ -135,6 +135,9 @@ class LogStash::Agent < Clamp::Command
   rescue LogStash::ConfigurationError => e
     @logger.unsubscribe(stdout_logs) if show_startup_errors
     report I18n.t("logstash.agent.error", :error => e)
+    if !config_test?
+      report I18n.t("logstash.agent.configtest-flag-information")
+    end
     return 1
   rescue => e
     @logger.unsubscribe(stdout_logs) if show_startup_errors

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -71,6 +71,10 @@ en:
         Error: %{error}
       interrupted: >-
         Interrupt received. Shutting down the pipeline.
+      configtest-flag-information: |-
+        You may be interested in the '--configtest' flag which you can
+        use to validate logstash's configuration before you choose
+        to restart a running system.
       configuration:
         file-not-found: |-
           No config files found: %{path}


### PR DESCRIPTION
I'm not sure this is the best approach, but notifying users about it
can't hurt I suppose. Suggestion from @jamtur01
