### PR TITLE
Use Java 7 on debian if it's available

### DIFF
--- a/pkg/build.sh
+++ b/pkg/build.sh
@@ -126,7 +126,7 @@ case $os in
       --description "$DESCRIPTION" \
       --vendor "Elasticsearch" \
       --license "Apache 2.0" \
-      -d "java6-runtime-headless" \
+      -d "java7-runtime-headless | java6-runtime-headless" \
       --deb-user root --deb-group root \
       --before-install $os/before-install.sh \
       --before-remove $os/before-remove.sh \


### PR DESCRIPTION
This commit changes the dependency for java on debian/ubuntu to use 7 if it's available.
