### PR TITLE
Loggly UDP Support Added optional search tags, HTTP also extended to support optional search tags

### DIFF
--- a/lib/logstash/outputs/loggly.rb
+++ b/lib/logstash/outputs/loggly.rb
@@ -85,7 +85,7 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
   #                                         \---------->   key   <-------------/
   # A udp example is also shown under the rsyslog section on the same page.
   #   $template LogglyFormat,"<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% 
-  #   %app-name% %procid% %msgid% [e537a266-f8fe-420e-bccf-3acf326cebff@41058] %msg%\n"  
+  #   %app-name% %procid% %msgid% [abcdef12-3456-7890-abcd-ef0123456789@41058] %msg%\n"  
   #                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^|^^^^^
   #                                \---------->   key   <-------------/|\id/
   #


### PR DESCRIPTION
Added Loggly syslog support over UDP with or without tags. Also extended http to support tags. For values such as severity and facility which are needed for syslogs default values were used. If conditional validations are supported I can update the module to apply validations based on the selected protocol (i.e. HTTP or UDP). Lastly, effort was made to maintain backwards compatibility. I also ran manual tests for both HTTP and UDP with and without the optional search tags and found it to work as expected.  Please let me know if you would like me to make any changes.
