### PR TITLE
Update pipe.rb output - Fix LOGSTASH-1860

### DIFF
--- a/lib/logstash/outputs/pipe.rb
+++ b/lib/logstash/outputs/pipe.rb
@@ -46,7 +46,7 @@ class LogStash::Outputs::Pipe < LogStash::Outputs::Base
     begin
       pipe = get_pipe(command)
       pipe.puts(output)
-    rescue IOError, Errno::EPIPE => e
+    rescue IOError, Errno::EPIPE, Errno::EBADF => e
       @logger.error("Error writing to pipe, closing pipe.", :command => command, :pipe => pipe)
       drop_pipe(command)
       retry


### PR DESCRIPTION
This adds EBADF to the rescue block as that is what is being thrown when the pipe command gets shutdown (usually due to an error.) Verified that it will restart the pipe and requeue the event that noticed that the pipe had failed and that logstash does not crash due to the pipe command failing.
