### PR TITLE
syslog output: ommit [pid] part if no pid is available in rfc3164

### DIFF
--- a/lib/logstash/outputs/syslog.rb
+++ b/lib/logstash/outputs/syslog.rb
@@ -124,7 +124,8 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
 
     if rfc3164?
       timestamp = event.sprintf("%{+MMM dd HH:mm:ss}")
-      syslog_msg = "<"+priority.to_s()+">"+timestamp+" "+sourcehost+" "+appname+"["+procid+"]: "+event["message"]
+      tag = appname+"["+Integer(procid).to_s+"]:" rescue appname+":"
+      syslog_msg = "<"+priority.to_s()+">"+timestamp+" "+sourcehost+" "+tag+" "+event["message"]
     else
       msgid = event.sprintf(@msgid)
       timestamp = event.sprintf("%{+YYYY-MM-dd'T'HH:mm:ss.SSSZ}")


### PR DESCRIPTION
This leaves the [pid] part off if no valid pid is given when using the rfc3164 output. 

The rfc is vague about what is allowed in the pid part, I check the pid to be an integer as I've never seen non-integers in the pid part in the wild and I have seen applications break when encountering non-integer values between the brackets.

