### PR TITLE
Do @timestamp parsing if no @target

### DIFF
--- a/lib/logstash/filters/json.rb
+++ b/lib/logstash/filters/json.rb
@@ -41,6 +41,8 @@ class LogStash::Filters::Json < LogStash::Filters::Base
   # Note: if the "target" field already exists, it will be overwritten.
   config :target, :validate => :string
 
+  TIMESTAMP = "@timestamp"
+
   public
   def register
     # Nothing to do here
@@ -76,11 +78,11 @@ class LogStash::Filters::Json < LogStash::Filters::Base
 
       # If no target, we target the root of the event object. This can allow
       # you to overwrite @timestamp. If so, let's parse it as a timestamp!
-      if @target && event["@timestamp"].is_a?(String)
+      if !@target && event[TIMESTAMP].is_a?(String)
         # This is a hack to help folks who are mucking with @timestamp during
         # their json filter. You aren't supposed to do anything with
         # "@timestamp" outside of the date filter, but nobody listens... ;)
-        event["@timestamp"] = Time.parse(event["@timestamp"]).utc
+        event[TIMESTAMP] = Time.parse(event[TIMESTAMP]).utc
       end
 
       filter_matched(event)


### PR DESCRIPTION
This was a typo fix. Previously 'if @target' was incorrect. The comment
above it clearly said "If no target..." then we coded "If @target" ...

Typing is hard! ;)

Tests pass now.
