### PR TITLE
Make '{filter,output} received' log at debug level, not info.

### DIFF
--- a/lib/logstash/config/config_ast.rb
+++ b/lib/logstash/config/config_ast.rb
@@ -64,7 +64,7 @@ module LogStash; module Config; module AST
           definitions << "  extra_events = []"
         end
 
-        definitions << "  @logger.info? && @logger.info(\"#{type} received\", :event => event)"
+        definitions << "  @logger.debug? && @logger.debug(\"#{type} received\", :event => event.to_hash)"
         sections.select { |s| s.plugin_type.text_value == type }.each do |s|
           definitions << s.compile.split("\n", -1).map { |e| "  #{e}" }
         end


### PR DESCRIPTION
This should solve a common complaint that --verbose logs are too noisy.
