### PR TITLE
Nested classes are prefixed with $

### DIFF
--- a/patterns/java
+++ b/patterns/java
@@ -1,3 +1,3 @@
 JAVACLASS (?:[a-zA-Z0-9-]+\.)+[A-Za-z0-9$]+
-JAVAFILE (?:[A-Za-z0-9_.-]+)
+JAVAFILE (?:[A-Za-z0-9_.-$]+)
 JAVASTACKTRACEPART at %{JAVACLASS:class}\.%{WORD:method}\(%{JAVAFILE:file}:%{NUMBER:line}\)


### PR DESCRIPTION
Java's compiler generates names for nested classes by prefixing their enclosing class names and dollar sign characters to nested class names.
