### PR TITLE
Support codecs loading from pluginpath

### DIFF
--- a/lib/logstash/agent.rb
+++ b/lib/logstash/agent.rb
@@ -271,8 +271,8 @@ class LogStash::Agent < Clamp::Command
       end
 
       # TODO(sissel): Verify the path looks like the correct form.
-      # aka, there must be file in path/logstash/{filters,inputs,outputs}/*.rb
-      plugin_glob = File.join(path, "logstash", "{inputs,filters,outputs}", "*.rb")
+      # aka, there must be file in path/logstash/{inputs,codecs,filters,outputs}/*.rb
+      plugin_glob = File.join(path, "logstash", "{inputs,codecs,filters,outputs}", "*.rb")
       if Dir.glob(plugin_glob).empty?
         @logger.warn(I18n.t("logstash.agent.configuration.no_plugins_found",
                     :path => path, :plugin_glob => plugin_glob))


### PR DESCRIPTION
For now it's hardly possible to use custom codecs without repackaging logstash-xxx-flatjar.jar. 
This patch allows to load codecs from pluginpath as well as inputs, outputs and filters

Regards,
Sergey
