### PR TITLE
explicitly close IO instance after read

### DIFF
--- a/lib/logstash/inputs/exec.rb
+++ b/lib/logstash/inputs/exec.rb
@@ -17,16 +17,16 @@ class LogStash::Inputs::Exec < LogStash::Inputs::Base
   milestone 2
 
   default :codec, "plain"
-  
+
   # Set this to true to enable debugging on an input.
   config :debug, :validate => :boolean, :default => false, :deprecated => "This setting was never used by this plugin. It will be removed soon."
-  
+
   # Command to run. For example, "uptime"
   config :command, :validate => :string, :required => true
-  
+
   # Interval to run the command. Value is in seconds.
   config :interval, :validate => :number, :required => true
-  
+
   public
   def register
     @logger.info("Registering Exec Input", :type => @type,
@@ -47,7 +47,8 @@ class LogStash::Inputs::Exec < LogStash::Inputs::Base
         event["command"] = @command
         queue << event
       end
-      
+      out.close
+
       duration = Time.now - start
       @logger.info? && @logger.info("Command completed", :command => @command,
                                     :duration => duration)


### PR DESCRIPTION
The exec input plugin currently relies on GC to autoclose files associated with IO instances. This can lead to the open file limit beeing reached before the IOs are closed and the plugin to stop working.

The behaviour can easily be reproduced by using an exec input with a low interval and count open files of the logstash process.

example log entry:
{:timestamp=>"2013-11-19T23:03:05.025000+0100", :message=>"A plugin had an unrecoverable error. Will restart this plugin.\n Plugin: \"system-memory-usage\", command=>\"free -b | grep Mem | awk '{print $3/$2*100}'\">\n Error: Cannot run program \"/bin/sh\" (in directory \"/\"): java.io.IOException: error=24, Too many open files", :level=>:error}
