### PR TITLE
ES 1.0 template

### DIFF
--- a/lib/logstash/outputs/elasticsearch/elasticsearch-template.json
+++ b/lib/logstash/outputs/elasticsearch/elasticsearch-template.json
@@ -1,15 +1,7 @@
 {
   "template" : "logstash-*",
   "settings" : {
-    "index.refresh_interval" : "5s",
-    "analysis" : {
-      "analyzer" : {
-        "default" : {
-          "type" : "standard",
-          "stopwords" : "_none_"
-        }
-      }
-    }
+    "index.refresh_interval" : "5s"
   },
   "mappings" : {
     "_default_" : {


### PR DESCRIPTION
Update template to fit ES 1.0 API changes
### `multi_field`

http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/_multi_fields.html

> Multi-fields are dead! Long live multi-fields! Well, the field type multi_field has been removed. Instead, any of the core field types (excluding object and nested) now accept a fields parameter.
### `analyzer`

The analyzer section is no longer needed as the defaults cover this now:
http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/_stopwords.html

> Previously, the standard and pattern analyzers used the list of English stopwords by default, which caused some hard to debug indexing issues. Now they are set to use the empty stopwords list (ie _none_) instead.
