### PR TITLE
Added option to disable certificate validation in the IMAP input

### DIFF
--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -35,6 +35,10 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
     require "net/imap" # in stdlib
     require "mail" # gem 'mail'
 
+    if @secure and not @verify_cert
+      @logger.warn("Running IMAP without verifying the certificate may grant attackers unauthorized access to your mailbox or data")
+    end
+
     if @port.nil?
       if @secure
         @port = 993


### PR DESCRIPTION
If a IMAP-server is using a self-signed certificate, this patch adds a "verify_cert" option to the module that is by default set to true (old behavior), but if set to false it will disable the verification check. The result is that IMAP TLS with self-signed certificate will not crash logstash.
