### PR TITLE
LOGSTASH-1913: Fix dependency error in flatjar so flatjar-test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,10 @@ vendor:
 vendor/jar: | vendor
 	$(QUIET)mkdir $@
 
+.PHONY: vendor-jruby
 vendor-jruby: $(JRUBY)
+	@echo "=> Pulling the jars out of $<"
+	$(QUIET)unzip -o -d vendor/jar/ -j $< META-INF/jruby.home/lib/ruby/shared/bc*.jar
 
 $(JRUBY): | vendor/jar
 	$(QUIET)echo " ==> Downloading jruby $(JRUBY_VERSION)"
@@ -193,7 +196,7 @@ fix-bundler:
 vendor-gems: | vendor/bundle
 
 .PHONY: vendor/bundle
-vendor/bundle: | vendor $(JRUBY)
+vendor/bundle: | vendor $(JRUBY) vendor-jruby
 	@echo "=> Ensuring ruby gems dependencies are in $@..."
 	$(QUIET)USE_JRUBY=1 bin/logstash deps $(QUIET_OUTPUT)
 	@# Purge any junk that fattens our jar without need!

--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -56,7 +56,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "rufus-scheduler", "~> 2.0.24"     #(MIT license)
   gem.add_runtime_dependency "user_agent_parser", [">= 2.0.0"]  #(MIT license)
   gem.add_runtime_dependency "snmp"                             #(ruby license)
-  gem.add_runtime_dependency "mail"                             #(MIT license)
   gem.add_runtime_dependency "rbnacl"                           #(MIT license)
   gem.add_runtime_dependency "bindata", [">= 1.5.0"]            #(ruby license)
   gem.add_runtime_dependency "twitter", "5.0.0.rc.1"            #(MIT license)


### PR DESCRIPTION
Fixes flatjar-test on linux.
