### PR TITLE
FIX for 1931: plugin script doesn't complete

### DIFF
--- a/bin/plugin
+++ b/bin/plugin
@@ -46,7 +46,7 @@ TARGET="${TARGETDIR}/${FILENAME}"
 
 case $1 in
   install)
-  	exec $DOWNLOAD_COMMAND ${TARGET} ${URLSTUB}${FILENAME}
+  	$DOWNLOAD_COMMAND ${TARGET} ${URLSTUB}${FILENAME}
   	if [ ! -f "${TARGET}" ]; then
 	  	echo "ERROR: Unable to download ${URLSTUB}${FILENAME}"
 	  	echo "Exiting."


### PR DESCRIPTION
The plugin script wouldn't continue execution past the exec do the download command. There's no reason for this to be an exec. 
