### PR TITLE
Close LOGSTASH-1933:

### DIFF
--- a/lib/logstash/outputs/irc.rb
+++ b/lib/logstash/outputs/irc.rb
@@ -46,7 +46,7 @@ class LogStash::Outputs::Irc < LogStash::Outputs::Base
   # Static string before event
   config :pre_string, :validate => :string, :required => false
   
-  # Static string before event
+  # Static string after event
   config :post_string, :validate => :string, :required => false
 
   public


### PR DESCRIPTION
Add two (2) new config stanzas to IRC output:

pre_string: Message you want emitted to IRC server before the event text
post_string: Message you want emitted to the IRC server after the event text

[12:32]  <logstash> This is a pre message
[12:32]  <logstash> This is the actual message
[12:32]  <logstash> Tis is a post message

In both cases, they are sent as seperate messages to the IRC server, leaving the
event text unmodified.

(N.B. My 1st real modification to the ruby codebase, so someone who knows ruby
should really validate I did this correctly.)
