### PR TITLE
Fix LOGSTASH-1936

### DIFF
--- a/bin/plugin
+++ b/bin/plugin
@@ -52,7 +52,7 @@ case $1 in
 	  	echo "Exiting."
 	  	exit 1
 	fi
-  	gzip -dc ${TARGETDIR}${FILENAME} | tar -xC $TARGETDIR
+  	gzip -dc ${TARGET} | tar -xC $TARGETDIR
   	cp -R ${TARGETDIR}/$FILEPATH/* .  ;; # Copy contents to local directory, adding on top of existing install
   *) 
   	echo "Usage: bin/plugin install contrib"


### PR DESCRIPTION
Plugin script failed because it was trying to gzip -dc ${TARGETDIR}${FILENAME},

This was missing a / between the directory and the filename, so it was trying to
uncompress: /opt/logstash/logstash-1.4.0.beta1/vendor/logstashlogstash-contrib-1.4.0.beta1.tar.gz

Changed to uncompress ${TARGET}, which is defined as: ${TARGETDIR}/${FILENAME}
