### PR TITLE
Fix for LOGSTASH-1920

### DIFF
--- a/bin/logstash
+++ b/bin/logstash
@@ -18,7 +18,8 @@
 # Defaults you can override with environment variables
 LS_HEAP_SIZE="${LS_HEAP_SIZE:=500m}"
 
-basedir=$(cd `dirname $0`/.. >/dev/null; pwd)
+unset CDPATH
+basedir=$(cd `dirname $0`/..; pwd)
 . ${basedir}/bin/logstash.lib.sh
 
 setup


### PR DESCRIPTION
`bin/logstash` breaks if CDPATH env var is set causing cd to emit dir name:

```
$ logstash/bin/logstash --help
logstash/bin/logstash: line 22: .: /home/tim/trunk/comp/support_logstash/logstash: is a directory
logstash/bin/logstash: line 24: setup: command not found
logstash/bin/logstash: line 31: exec: -I: invalid option
```

This fixes it by sending the output to `/dev/null`
