### PR TITLE
Use __FILE__-relative path for the default template.

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -275,10 +275,13 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
       else
         if File.exists?("elasticsearch-template.json")
           @template = "elasticsearch-template.json"
-        elsif File.exists?("lib/logstash/outputs/elasticsearch/elasticsearch-template.json")
-          @template = "lib/logstash/outputs/elasticsearch/elasticsearch-template.json"
         else
-          raise "You must specify 'template => ...' in your elasticsearch_http output"
+          path = File.join(File.dirname(__FILE__), "elasticsearch/elasticsearch-template.json")
+          if File.exists?(path)
+            @template = path
+          else
+            raise "You must specify 'template => ...' in your elasticsearch_http output"
+          end
         end
       end
     end


### PR DESCRIPTION
Users reported this (or similar) error:
Errno::ENOENT: No such file or directory -
lib/logstash/outputs/elasticsearch/elasticsearch-template.json

This is because the file being searched-for was relative to $PWD, not
relative to the elasticsearch output plugin file itself.

Tested works like this:

```
% logstash/bin/logstash -e 'output { elasticsearch {  embedded => true } }'
```

Prior to this patch, the above command line would fail with this error:

```
Errno::ENOENT: No such file or directory - lib/logstash/outputs/elasticsearch/elasticsearch-template.json
...
    get_template at /home/jls/projects/logstash/lib/logstash/outputs/elasticsearch.rb:285
```
