### PR TITLE
clean trailing whitespace in elasticsearch output modules.

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -49,8 +49,8 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   config :index_type, :validate => :string
 
   # Starting in Logstash 1.3 (unless you set option "manage_template" to false)
-  # a default mapping template for Elasticsearch will be applied, if you do not 
-  # already have one set to match the index pattern defined (default of 
+  # a default mapping template for Elasticsearch will be applied, if you do not
+  # already have one set to match the index pattern defined (default of
   # "logstash-%{+YYYY.MM.dd}"), minus any variables.  For example, in this case
   # the template will be applied to all indices starting with logstash-*
   #
@@ -66,11 +66,11 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # where OldTemplateName is whatever the former setting was.
   config :template_name, :validate => :string, :default => "logstash"
 
-  # You can set the path to your own template here, if you so desire.  
+  # You can set the path to your own template here, if you so desire.
   # If not set, the included template will be used.
   config :template, :validate => :path
 
-  # Overwrite the current template with whatever is configured 
+  # Overwrite the current template with whatever is configured
   # in the template and template_name directives.
   config :template_overwrite, :validate => :boolean, :default => false
 
@@ -150,7 +150,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # configured).
   #
   # The 'transport' protocol will connect to the host you specify and will
-  # not show up as a 'node' in the Elasticsearch cluster. This is useful 
+  # not show up as a 'node' in the Elasticsearch cluster. This is useful
   # in situations where you cannot permit connections outbound from the
   # Elasticsearch cluster to this Logstash server.
   #
@@ -158,7 +158,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # `protocol` on non-java rubies is "http"
   config :protocol, :validate => [ "node", "transport", "http" ]
 
-  # The Elasticsearch action to perform. Valid actions are: `index`, `delete`. 
+  # The Elasticsearch action to perform. Valid actions are: `index`, `delete`.
   #
   # Use of this setting *REQUIRES* you also configure the `document_id` setting
   # because `delete` actions all require a document id.
@@ -252,8 +252,8 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     if @manage_template
       @logger.info("Automatic template management enabled", :manage_template => @manage_template.to_s)
       @client.template_install(@template_name, get_template, @template_overwrite)
-    end # if @manage_templates  
-    
+    end # if @manage_templates
+
     buffer_initialize(
       :max_items => @flush_size,
       :max_interval => @idle_flush_time,

--- a/lib/logstash/outputs/elasticsearch_http.rb
+++ b/lib/logstash/outputs/elasticsearch_http.rb
@@ -26,10 +26,10 @@ class LogStash::Outputs::ElasticSearchHTTP < LogStash::Outputs::Base
   config :index_type, :validate => :string
 
   # Starting in Logstash 1.3 (unless you set option "manage_template" to false)
-  # a default mapping template for Elasticsearch will be applied, if you do not 
-  # already have one set to match the index pattern defined (default of 
+  # a default mapping template for Elasticsearch will be applied, if you do not
+  # already have one set to match the index pattern defined (default of
   # "logstash-%{+YYYY.MM.dd}"), minus any variables.  For example, in this case
-  # the template will be applied to all indices starting with logstash-* 
+  # the template will be applied to all indices starting with logstash-*
   #
   # If you have dynamic templating (e.g. creating indices based on field names)
   # then you should set "manage_template" to false and use the REST API to upload
@@ -43,11 +43,11 @@ class LogStash::Outputs::ElasticSearchHTTP < LogStash::Outputs::Base
   # where OldTemplateName is whatever the former setting was.
   config :template_name, :validate => :string, :default => "logstash"
 
-  # You can set the path to your own template here, if you so desire.  
+  # You can set the path to your own template here, if you so desire.
   # If not the included template will be used.
   config :template, :validate => :path
 
-  # Overwrite the current template with whatever is configured 
+  # Overwrite the current template with whatever is configured
   # in the template and template_name directives.
   config :template_overwrite, :validate => :boolean, :default => false
 
@@ -131,7 +131,7 @@ class LogStash::Outputs::ElasticSearchHTTP < LogStash::Outputs::Base
         if !results.any? { |k,v| v["template"] == template_idx_name || v["template"] == alt_template_idx_name }
           @logger.debug("No template found in Elasticsearch", :has_template => has_template, :name => template_idx_name, :alt => alt_template_idx_name)
           get_template_json
-          template_action('put')      
+          template_action('put')
         end
       else #=> Some other status code?
         @logger.error("Could not check for existing template.  Check status code.", :status => response.status.to_s)
@@ -143,8 +143,8 @@ class LogStash::Outputs::ElasticSearchHTTP < LogStash::Outputs::Base
       :logger => @logger
     )
   end # def register
-  
-  public 
+
+  public
   def template_action(command)
     begin
       if command == 'delete'
@@ -168,8 +168,8 @@ class LogStash::Outputs::ElasticSearchHTTP < LogStash::Outputs::Base
     @logger.info("Successfully deleted template", :template_url => @template_url) if command == 'delete'
     @logger.info("Successfully applied template", :template_url => @template_url) if command == 'put'
   end # def template_action
-  
-  
+
+
   public
   def get_template_json
     if @template.nil?

--- a/lib/logstash/outputs/elasticsearch_river.rb
+++ b/lib/logstash/outputs/elasticsearch_river.rb
@@ -40,7 +40,7 @@ class LogStash::Outputs::ElasticSearchRiver < LogStash::Outputs::Base
 
   # ElasticSearch river configuration: bulk timeout in milliseconds
   config :es_bulk_timeout_ms, :validate => :number, :default => 100
-  
+
   # ElasticSearch river configuration: is ordered?
   config :es_ordered, :validate => :boolean, :default => false
 
@@ -61,7 +61,7 @@ class LogStash::Outputs::ElasticSearchRiver < LogStash::Outputs::Base
 
   # RabbitMQ queue name
   config :queue, :validate => :string, :default => "elasticsearch"
-  
+
   # RabbitMQ exchange name
   config :exchange, :validate => :string, :default => "elasticsearch"
 
@@ -123,10 +123,10 @@ class LogStash::Outputs::ElasticSearchRiver < LogStash::Outputs::Base
       # Name the river by our hostname
       require "socket"
       hostname = Socket.gethostname
-      
+
       # Replace spaces with hyphens and remove all non-alpha non-dash non-underscore characters
       river_name = "#{hostname} #{@queue}".gsub(' ', '-').gsub(/[^\w-]/, '')
-      
+
       api_path = "/_river/logstash-#{river_name}/_meta"
       @status_path = "/_river/logstash-#{river_name}/_status"
 


### PR DESCRIPTION
I cleaned up all the trailing whitespace in the elasticsearch output modules.
