### PR TITLE
Add 'env' command

### DIFF
--- a/bin/logstash
+++ b/bin/logstash
@@ -29,6 +29,7 @@ export HOME SINCEDB_DIR
 
 case $1 in
   deps) install_deps ;;
+  env) env "$@" ;;
   -*) 
     # is the first argument a flag? If so, assume 'agent'
     program="$basedir/lib/logstash/runner.rb"


### PR DESCRIPTION
This aims to let developers run arbitrary commands with the logstash
environment setup (env vars for RUBYLIB, GEM_HOME, etc)
