### PR TITLE
Avoid monkey patching `Time#to_json`

### DIFF
--- a/lib/logstash/event.rb
+++ b/lib/logstash/event.rb
@@ -6,18 +6,6 @@ require "logstash/namespace"
 require "logstash/util/fieldreference"
 require "logstash/time_addon"
 
-# Use a custom serialization for jsonifying Time objects.
-# TODO(sissel): Put this in a separate file.
-class Time
-  def to_json(*args)
-    return iso8601(3).to_json(*args)
-  end
-
-  def inspect
-    return to_json
-  end
-end
-
 # the logstash event object.
 #
 # An event is simply a tuple of (timestamp, data).
@@ -165,7 +153,8 @@ class LogStash::Event
   
   public
   def to_json(*args)
-    return @data.to_json(*args) 
+    json_data = @data.merge(TIMESTAMP => timestamp.iso8601(3))
+    return json_data.to_json(*args) 
   end # def to_json
 
   def to_hash


### PR DESCRIPTION
While testing a gem dependent on logstash-event, I was encountering
intermittent anomolies in `LogStash::Event#to_json`. Sometimes it
encoded `@timestamp` with the patched version, i.e., `#iso8601(3)` and
other times it encoded it with the non-patched version, i.e.,
`#iso8601()`.

I was not able to discover what library was reverting the patched
version of `Time#to_json`, but I found that this change fixed the issue
for me. Admittedly, it adds a bit of overhead by cloning the `@data`,
but it seemed negligible in my testing, and I believe that avoiding the
monkey patch to `Time` is worth the cost.
