### PR TITLE
Ensure @timestamp is always encoded correctly

### DIFF
--- a/lib/logstash/time.rb
+++ b/lib/logstash/time.rb
@@ -1,11 +1,8 @@
 # encoding: utf-8
 require "logstash/namespace"
 
-module LogStash::Time
+class ::LogStash::Time < ::Time
   ISO8601_STRFTIME = "%04d-%02d-%02dT%02d:%02d:%02d.%06d%+03d:00".freeze
-  def self.now
-    return Time.new.utc
-  end
 
   if RUBY_PLATFORM == "java"
     JODA_ISO8601_PARSER = org.joda.time.format.ISODateTimeFormat.dateTimeParser
@@ -13,13 +10,25 @@ module LogStash::Time
     UTC = org.joda.time.DateTimeZone.forID("UTC")
     def self.parse_iso8601(t)
       millis = JODA_ISO8601_PARSER.parseMillis(t)
-      return Time.at(millis / 1000, (millis % 1000) * 1000)
+      return ::LogStash::Time.at(millis / 1000, (millis % 1000) * 1000)
     end
   else
     def self.parse_iso8601(t)
       # Warning, ruby's Time.parse is *really* terrible and slow.
       return unless t.is_a?(String)
-      return Time.parse(t).gmtime
+      return ::LogStash::Time.parse(t).utc
     end
   end
-end # module LogStash::Time
+
+  def as_json(*)
+    iso8601(3)
+  end
+
+  def to_json(*args)
+    return as_json.to_json(*args)
+  end
+
+  def inspect
+    return to_json
+  end
+end # class LogStash::Time


### PR DESCRIPTION
A better (hopefully) alternative for elasticsearch/logstash#1145.
