### PR TITLE
New filter plugin: edn

### DIFF
--- a/lib/logstash/filters/edn.rb
+++ b/lib/logstash/filters/edn.rb
@@ -1,0 +1,107 @@
+# encoding: utf-8
+require "logstash/filters/base"
+require "logstash/namespace"
+
+# This is a EDN parsing filter. It takes an existing field which contains EDN and
+# expands it into an actual data structure within the Logstash event.
+#
+# Based on the code from 'json' filter.
+#
+class LogStash::Filters::Edn < LogStash::Filters::Base
+
+  config_name "edn"
+  milestone 1
+
+#
+# Usage example: when you have an 'edn' string as a remaining part of your log line:
+#
+#    input {
+#       file {
+#         type => "jetty"
+#         path => "/var/log/jetty/*log"
+#       }
+#    }
+#
+#    filter {
+#
+#      grok {
+#        type    => "jetty"
+#        match   => [ "message", "%{TIMESTAMP_ISO8601}\s+%{LOGLEVEL:log_level}\s+%{GREEDYDATA:edn_msg}" ]
+#        add_tag => [ "jetty", "grokked"]
+#      }
+#
+#      edn {
+#        source  => "edn_msg"
+#      }
+#
+#    }
+#
+
+  config :source, :validate => :string, :required => true
+  # NOTE: if the `target` field already exists, it will be overwritten!
+  config :target, :validate => :string
+
+
+  TIMESTAMP = "timestamp"
+
+  public
+  def register
+    require 'edn'
+  end # def register
+
+  public
+  def filter(event)
+
+    return unless filter?(event)
+
+    @logger.debug("Running json filter", :event => event)
+
+    return unless event.include?(@source)
+
+    source = event[@source]
+
+    if @target.nil?
+      # Default: to write to the root of the 'event'.
+      dest = event.to_hash
+    else
+      if @target == @source
+        # Overwrite source
+        dest = event[@target] = {}
+      else
+        dest = event[@target] ||= {}
+      end
+    end
+
+    begin
+
+      # prevent EDN keys to be treated as Symbols
+      edn = Hash[ EDN.read(source).map{ |(k,v)| [k.to_s,v] } ]
+
+      # New entries into the destination
+      dest.merge!(edn)
+
+      # Same fix from the 'json' filter plugin....
+      # If no @target, we target the root of the event object. This can allow
+      # you to overwrite @timestamp. If so, let's parse it as a timestamp!
+      if !@target && event[TIMESTAMP].is_a?(String)
+        # This is a hack to help folks who are mucking with @timestamp during
+        # their edn filter. You aren't supposed to do anything with
+        # "@timestamp" outside of the date filter, but nobody listens... ;)
+        event[TIMESTAMP] = Time.parse(event[TIMESTAMP]).utc
+      end
+
+      filter_matched(event)
+
+    rescue => e
+      event.tag("_ednparsefailure")
+      @logger.warn("Trouble parsing edn", :source => @source, :raw => event[@source], :exception => e)
+      return
+
+    end
+
+    @logger.debug("Event after edn filter", :event => event)
+
+  end # def filter
+
+end # class LogStash::Filters::Edn
+

--- a/lib/logstash/filters/edn.rb
+++ b/lib/logstash/filters/edn.rb
@@ -32,6 +32,7 @@ class LogStash::Filters::Edn < LogStash::Filters::Base
 #
 #      edn {
 #        source  => "edn_msg"
+#        target  => "edn_key"
 #      }
 #
 #    }

--- a/spec/filters/edn.rb
+++ b/spec/filters/edn.rb
@@ -1,0 +1,88 @@
+require "test_utils"
+require "logstash/filters/edn"
+
+describe LogStash::Filters::Edn do
+  extend LogStash::RSpec
+
+  describe "parse message into the event" do
+    config <<-CONFIG
+      filter {
+        edn {
+          # Parse message as EDN
+          source => "message"
+        }
+      }
+    CONFIG
+
+    sample '{ :hello "world", :list [ 1 2 3 ] , :hash { :k "v" } }' do
+      insist { subject["hello"] } == "world"
+      insist { subject["list" ] } == [1,2,3]
+      insist { subject["hash"]  } == { :k => "v" }
+    end
+  end
+
+  describe "parse message into a target field" do
+    config <<-CONFIG
+      filter {
+        edn {
+          # Parse message as EDN, store the results in the 'data' field'
+          source => "message"
+          target => "data"
+        }
+      }
+    CONFIG
+
+    sample '{ :hello "world", :list [ 1 2 3 ], :hash { :k "v" } }' do
+      insist { subject["data"]["hello"] } == "world"
+      insist { subject["data"]["list" ] } == [1,2,3]
+      insist { subject["data"]["hash"]  } == { :k => "v" }
+    end
+  end
+
+  describe "tag invalid edn" do
+    config <<-CONFIG
+      filter {
+        edn {
+          # Parse message as EDN, store the results in the 'data' field'
+          source => "message"
+          target => "data"
+        }
+      }
+    CONFIG
+
+    sample "invalid edn" do
+      insist { subject["tags"] }.include?("_ednparsefailure")
+    end
+  end
+
+  describe "fixing @timestamp (#pull 733)" do
+    config <<-CONFIG
+      filter {
+        edn {
+          source => "message"
+        }
+      }
+    CONFIG
+
+    sample "{ :timestamp \"2013-10-19T00:14:32.996Z\" }" do
+      insist { subject["timestamp"] }.is_a?(Time)
+    end
+  end
+
+  describe "source == target" do
+    config <<-CONFIG
+      filter {
+        edn {
+          source => "example"
+          target => "example"
+        }
+      }
+    CONFIG
+
+    sample({ "example" => "{ :hello \"world\" }" }) do
+      insist { subject["example"] }.is_a?(Hash)
+      insist { subject["example"]["hello"] } == "world"
+    end
+  end
+
+end

--- a/spec/filters/edn.rb
+++ b/spec/filters/edn.rb
@@ -55,20 +55,6 @@ describe LogStash::Filters::Edn do
     end
   end
 
-  describe "fixing @timestamp (#pull 733)" do
-    config <<-CONFIG
-      filter {
-        edn {
-          source => "message"
-        }
-      }
-    CONFIG
-
-    sample "{ :timestamp \"2013-10-19T00:14:32.996Z\" }" do
-      insist { subject["timestamp"] }.is_a?(Time)
-    end
-  end
-
   describe "source == target" do
     config <<-CONFIG
       filter {

--- a/spec/filters/edn.rb
+++ b/spec/filters/edn.rb
@@ -15,9 +15,9 @@ describe LogStash::Filters::Edn do
     CONFIG
 
     sample '{ :hello "world", :list [ 1 2 3 ] , :hash { :k "v" } }' do
-      insist { subject["hello"] } == "world"
-      insist { subject["list" ] } == [1,2,3]
-      insist { subject["hash"]  } == { :k => "v" }
+      insist { subject[:hello] } == "world"
+      insist { subject[:list ] } == [1,2,3]
+      insist { subject[:hash]  } == { :k => "v" }
     end
   end
 
@@ -33,9 +33,9 @@ describe LogStash::Filters::Edn do
     CONFIG
 
     sample '{ :hello "world", :list [ 1 2 3 ], :hash { :k "v" } }' do
-      insist { subject["data"]["hello"] } == "world"
-      insist { subject["data"]["list" ] } == [1,2,3]
-      insist { subject["data"]["hash"]  } == { :k => "v" }
+      insist { subject["data"][:hello] } == "world"
+      insist { subject["data"][:list]  } == [1,2,3]
+      insist { subject["data"][:hash]  } == { :k => "v" }
     end
   end
 
@@ -81,7 +81,7 @@ describe LogStash::Filters::Edn do
 
     sample({ "example" => "{ :hello \"world\" }" }) do
       insist { subject["example"] }.is_a?(Hash)
-      insist { subject["example"]["hello"] } == "world"
+      insist { subject["example"][:hello] } == "world"
     end
   end
 


### PR DESCRIPTION
Hi,

I have implemented a new filter to parse edn values, based on the json filter plugin:

```
filter {
  grok {
    type    => "jetty"
    match   => [ "message", "%{TIMESTAMP_ISO8601}\s+%{LOGLEVEL:log_level}\s+%{GREEDYDATA:edn_msg}" ]
    add_tag => [ "jetty", "grokked"]
  }
  edn {
    source  => "edn_msg"
    target  => "edn_key"
  }
}
```
