### PR TITLE
Increase lumberjack gemspec version for protocol backwards compatibility fixes

### DIFF
--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "statsd-ruby", ["1.2.0"]           #(MIT license)
   gem.add_runtime_dependency "xml-simple"                       #(ruby license?)
   gem.add_runtime_dependency "xmpp4r", ["0.5"]                  #(ruby license)
-  gem.add_runtime_dependency "jls-lumberjack", [">=0.0.19"]     #(Apache 2.0 license)
+  gem.add_runtime_dependency "jls-lumberjack", [">=0.0.20"]     #(Apache 2.0 license)
   gem.add_runtime_dependency "geoip", [">= 1.3.2"]              #(GPL license)
   gem.add_runtime_dependency "beefcake", "0.3.7"                #(MIT license)
   gem.add_runtime_dependency "murmurhash3"                      #(MIT license)


### PR DESCRIPTION
Hi,

Currently if the lumberjack protocol is improved (new frame types etc) there is no way for a client to tell. It means no backwards compatibility possible. 

The counterpart to this which is required is there: https://github.com/elasticsearch/logstash-forwarder/pull/173
Someone should check I'm doing the gem bit right though... gem-n00b sorry.

The patch itself is minor but would mean if logstash-forwarder was improved and protocol was improved, it would still work out of the box as of the version this is merged to. 1.4.0 sounds good :-) But it would mean we don't worry about new logstash-forwarder crashing the "current" LogStash - I think it important the current LogStash can work with future logstash-forwarder, for user experience.

Thanks! All feedback, good and bad, welcome.

Jason

FYI: I am currently working on a new protocol for logstash-forwarder, specifically partial ACKs and such - and also improving the server gem so redis congestion doesn't cause "Too many open files" crashes or constant disconnects etc. and the connection gracefully waits - most is done just testing and tweaking.
