### PR TITLE
    Fix bug LOGSTASH-1225 "Cannot Clone Fixnum"

### DIFF
--- a/lib/logstash/event.rb
+++ b/lib/logstash/event.rb
@@ -85,7 +85,7 @@ class LogStash::Event
     copy = {}
     @data.each do |k,v|
       # TODO(sissel): Recurse if this is a hash/array?
-      copy[k] = v.clone
+      copy[k] = begin v.clone rescue v end
     end
     return self.class.new(copy)
   end # def clone

--- a/spec/filters/clone.rb
+++ b/spec/filters/clone.rb
@@ -64,4 +64,20 @@ describe LogStash::Filters::Clone do
 
     end
   end
+
+  describe "Bug LOGSTASH-1225" do
+    ### LOGSTASH-1225: Cannot clone events containing numbers.
+    config <<-CONFIG
+      filter {
+        clone {
+          clones => [ 'clone1' ]
+        }
+      }
+    CONFIG
+
+    sample("type" => "bug-1225", "message" => "unused", "number" => 5) do
+      insist { subject[0]["number"] } == 5
+      insist { subject[1]["number"] } == 5
+    end
+  end
 end


### PR DESCRIPTION
```
The clone {} filter will throw an exception if any of the values in the
event map are numbers. Problem is that numbers are not clonable.

This is a single-line fix that wraps the .clone call in a try block and
does a simple set-by-value if the clone raises an exception.

Included under spec/filters/clone.rb is a test case that fails without
the change in lib/logstash/event.rb and passes with the fix applied.
```
