### PR TITLE
Adds missing require `socket` to elasticsearch.rb

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -181,6 +181,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     if @node_name
       client_settings["node.name"] = @node_name
     else
+      require "socket"
       client_settings["node.name"] = "logstash-#{Socket.gethostname}-#{$$}-#{object_id}"
     end
 


### PR DESCRIPTION
This will fix `NameError: uninitialized constant LogStash::Outputs::ElasticSearch::Socket` that I getting on startup.
