### PR TITLE
Improve RFC-5424 app and proc names matching

### DIFF
--- a/patterns/linux-syslog
+++ b/patterns/linux-syslog
@@ -1,3 +1,5 @@
+SYSLOG5424PRINTASCII [!-~]+
+
 SYSLOGBASE2 (?:%{SYSLOGTIMESTAMP:timestamp}|%{TIMESTAMP_ISO8601:timestamp8601}) (?:%{SYSLOGFACILITY} )?%{SYSLOGHOST:logsource} %{SYSLOGPROG}:
 SYSLOGPAMSESSION %{SYSLOGBASE} (?=%{GREEDYDATA:message})%{WORD:pam_module}\(%{DATA:pam_caller}\): session %{WORD:pam_session_state} for user %{USERNAME:username}(?: by %{GREEDYDATA:pam_by})?
 
@@ -9,6 +11,6 @@ SYSLOGLINE %{SYSLOGBASE2} %{GREEDYDATA:message}
 # IETF 5424 syslog(8) format (see http://www.rfc-editor.org/info/rfc5424)
 SYSLOG5424PRI <%{NONNEGINT:syslog5424_pri}>
 SYSLOG5424SD \[%{DATA}\]+
-SYSLOG5424BASE %{SYSLOG5424PRI}%{NONNEGINT:syslog5424_ver} +(?:%{TIMESTAMP_ISO8601:syslog5424_ts}|-) +(?:%{HOSTNAME:syslog5424_host}|-) +(?:%{WORD:syslog5424_app}|-) +(?:%{WORD:syslog5424_proc}|-) +(?:%{WORD:syslog5424_msgid}|-) +(?:%{SYSLOG5424SD:syslog5424_sd}|-|)
+SYSLOG5424BASE %{SYSLOG5424PRI}%{NONNEGINT:syslog5424_ver} +(?:%{TIMESTAMP_ISO8601:syslog5424_ts}|-) +(?:%{HOSTNAME:syslog5424_host}|-) +(-|%{SYSLOG5424PRINTASCII:syslog5424_app}) +(-|%{SYSLOG5424PRINTASCII:syslog5424_proc}) +(-|%{SYSLOG5424PRINTASCII:syslog5424_msgid}) +(?:%{SYSLOG5424SD:syslog5424_sd}|-|)
 
 SYSLOG5424LINE %{SYSLOG5424BASE} +%{GREEDYDATA:syslog5424_msg}

--- a/spec/filters/grok.rb
+++ b/spec/filters/grok.rb
@@ -131,6 +131,32 @@ describe LogStash::Filters::Grok do
       insist { subject["syslog5424_sd"] } == nil
       insist { subject["syslog5424_msg"] } == "Additional spaces and missing SD."
     end
+
+    sample "<30>1 2014-04-04T16:44:07+02:00 osctrl01 dnsmasq-dhcp 8048 - -  Appname contains a dash" do
+      insist { subject["tags"] }.nil?
+      insist { subject["syslog5424_pri"] } == "30"
+      insist { subject["syslog5424_ver"] } == "1"
+      insist { subject["syslog5424_ts"] } == "2014-04-04T16:44:07+02:00"
+      insist { subject["syslog5424_host"] } == "osctrl01"
+      insist { subject["syslog5424_app"] } == "dnsmasq-dhcp"
+      insist { subject["syslog5424_proc"] } == "8048"
+      insist { subject["syslog5424_msgid"] } == nil
+      insist { subject["syslog5424_sd"] } == nil
+      insist { subject["syslog5424_msg"] } == "Appname contains a dash"
+    end
+
+    sample "<30>1 2014-04-04T16:44:07+02:00 osctrl01 - 8048 - -  Appname is nil" do
+      insist { subject["tags"] }.nil?
+      insist { subject["syslog5424_pri"] } == "30"
+      insist { subject["syslog5424_ver"] } == "1"
+      insist { subject["syslog5424_ts"] } == "2014-04-04T16:44:07+02:00"
+      insist { subject["syslog5424_host"] } == "osctrl01"
+      insist { subject["syslog5424_app"] } == nil
+      insist { subject["syslog5424_proc"] } == "8048"
+      insist { subject["syslog5424_msgid"] } == nil
+      insist { subject["syslog5424_sd"] } == nil
+      insist { subject["syslog5424_msg"] } == "Appname is nil"
+    end
   end
 
   describe "parsing an event with multiple messages (array of strings)", :if => false do


### PR DESCRIPTION
This commit makes its possible for the SYSLOG5424BASE pattern to match logs whose app or proc fields contain dashes.
