### PR TITLE
Fix event::overwrite to copy timestamp properly

### DIFF
--- a/lib/logstash/event.rb
+++ b/lib/logstash/event.rb
@@ -176,8 +176,8 @@ class LogStash::Event
   def overwrite(event)
     @data = event.to_hash
     #convert timestamp if it is a String
-    if @data["@timestamp"].is_a?(String)
-      @data["@timestamp"] = LogStash::Time.parse_iso8601(@data["@timestamp"])
+    if @data[TIMESTAMP].is_a?(String)
+      @data[TIMESTAMP] = LogStash::Time.parse_iso8601(@data[TIMESTAMP])
     end
   end
 


### PR DESCRIPTION
Splitting this out of https://github.com/elasticsearch/logstash/pull/976 after the 1.4.0 split. This is required for the zeromq filter to work properly. This change was added as per conversation with whack on irc channel Jan 29. Events coming back from zeromq, and possibly other filters end up with a String as @timestamp instead of a Time object, thus Logstash::Event#overwrite needs to deal with that.
