### PR TITLE
Add sinatra gem. This was accidentally removed in a previous commit.

### DIFF
--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "ftw", ["~> 0.0.39"] #(Apache 2.0 license)
   gem.add_runtime_dependency "mime-types"         #(GPL 2.0)
   gem.add_runtime_dependency "rack"               # (MIT-style license)
+  gem.add_runtime_dependency "sinatra"            # (MIT-style license)
 
   # Input/Output/Filter dependencies
   #TODO Can these be optional?

--- a/tools/Gemfile.jruby-1.9.lock
+++ b/tools/Gemfile.jruby-1.9.lock
@@ -115,6 +115,8 @@ GEM
       slop (~> 3.4)
       spoon (~> 0.0)
     rack (1.5.2)
+    rack-protection (1.5.2)
+      rack
     rbnacl (2.0.0)
       ffi
     redis (3.0.7)
@@ -144,6 +146,10 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
+    sinatra (1.4.4)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
     slop (3.4.7)
     snmp (1.1.1)
     spoon (0.0.4)
@@ -159,6 +165,7 @@ GEM
       atomic (>= 1.1.7, < 2)
     thread_safe (0.2.0-java)
       atomic (>= 1.1.7, < 2)
+    tilt (1.4.1)
     tins (1.0.0)
     treetop (1.4.15)
       polyglot
@@ -226,6 +233,7 @@ DEPENDENCIES
   rufus-scheduler (~> 2.0.24)
   rumbster
   shoulda
+  sinatra
   snmp
   spoon
   statsd-ruby (= 1.2.0)


### PR DESCRIPTION
This fixes 'bin/logstash web' to run correctly (was broken in an earlier
1.4.0 beta)
