### PR TITLE
Add missing 'require "socket"'

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -2,6 +2,7 @@
 require "logstash/namespace"
 require "logstash/outputs/base"
 require "stud/buffer"
+require "socket" # for Socket.gethostname
 
 # This output lets you store logs in Elasticsearch and is the most recommended
 # output for Logstash. If you plan on using the Kibana web interface, you'll

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/outputs/base"
 require "logstash/namespace"
+require "socket" # for Socket.gethostname
 
 # TODO integrate aws_config in the future 
 #require "logstash/plugin_mixins/aws_config"


### PR DESCRIPTION
Audited files using 'Socket.gethostname' but didn't require "socket"
using the following command:

```
ack -L 'require "socket"' $(ack -l 'Socket.gethostname' lib)
```

Fixes LOGSTASH-1974
