### PR TITLE
LOGSTASH-1990: Fix the ganglia input so it works with Hadoop.  Add unit test.

### DIFF
--- a/lib/logstash/inputs/ganglia.rb
+++ b/lib/logstash/inputs/ganglia.rb
@@ -115,9 +115,16 @@ class LogStash::Inputs::Ganglia < LogStash::Inputs::Base
 
       data["program"] = "ganglia"
       event["log_host"] = data["hostname"]
-      %w{dmax tmax slope type units}.each do |info|
+      # Fields in the data packet itself
+      %w{name val}.each do |info|
+        event[info] = data[info]
+      end
+      # Fields that are from MetaData
+      %w{dmax tmax slope units}.each do |info|
         event[info] = @metadata[data["name"]][info]
       end
+      # Change the Ganglia metadata type to vtype, so the event can be decorated() later.
+      event["vtype"] = @metadata[data["name"]]["type"]
       return event
     else
       # Skipping unknown packet types

--- a/lib/logstash/inputs/ganglia/gmondpacket.rb
+++ b/lib/logstash/inputs/ganglia/gmondpacket.rb
@@ -12,27 +12,36 @@ require 'stringio'
 
 class GmonPacket
 
+  GMETADATA_FULL = 128
+  GMETRIC_USHORT = 129
+  GMETRIC_SHORT  = 130
+  GMETRIC_INT    = 131
+  GMETRIC_UINT   = 132
+  GMETRIC_STRING = 133
+  GMETRIC_FLOAT  = 134
+  GMETRIC_DOUBLE = 136
+  GMETADATA_REQ  = 137
+
   def initialize(packet)
     @xdr=XDR::Reader.new(StringIO.new(packet))
 
     # Read packet type
-    type=@xdr.uint32
-    case type
-    when 128
+    @ptype=@xdr.uint32
+    case @ptype
+    when GMETADATA_FULL
       @type=:meta
-    when 132
-      @type=:heartbeat
-    when 133..134
+    when GMETRIC_USHORT..GMETRIC_DOUBLE
       @type=:data
-    when 135
-      @type=:gexec
+    when GMETADATA_REQ
+      @type=:req
     else
+      @logger.warning("GmonPacket: Received unknown packet of type #{@ptype}")
       @type=:unknown
     end
   end
 
   def heartbeat?
-    @type == :hearbeat
+    @type == :req
   end
 
   def data?
@@ -82,8 +91,8 @@ class GmonPacket
     return meta
   end
 
-  # Parsing a data packet : type 133..135
-  # Requires metadata to be available for correct parsing of the value
+  # Parsing a data packet : type 129..136
+  # Requires metadata to be available for correct interpretation of the value
   def parse_data(metadata)
     data=Hash.new
     data['hostname']=@xdr.string
@@ -98,11 +107,11 @@ class GmonPacket
 
     if metrictype.nil?
       # Probably we got a data packet before a metadata packet
-      #puts "Received datapacket without metadata packet"
+      @logger.debug("GmonPacket: Received datapacket without metadata packet")
       return nil
     end
 
-    data['val']=parse_value(metrictype)
+    data['val']=parse_value()
 
     # If we received a packet, last update was 0 time ago
     data['tn']=0
@@ -110,26 +119,26 @@ class GmonPacket
   end
 
   # Parsing a specific value of type
-  # https://github.com/ganglia/monitor-core/blob/master/gmond/gmond.c#L1527
-  def parse_value(type)
+  # This depends on the packet type, not the logical data type in the metadata.
+  def parse_value()
     value=:unknown
-    case type
-    when "int16"
+    case @ptype
+    when GMETRIC_SHORT
       value=@xdr.int16
-    when "uint16"
+    when GMETRIC_USHORT
       value=@xdr.uint16
-    when "uint32"
+    when GMETRIC_UINT
       value=@xdr.uint32
-    when "int32"
+    when GMETRIC_INT
       value=@xdr.int32
-    when "float"
+    when GMETRIC_FLOAT
       value=@xdr.float32
-    when "double"
+    when GMETRIC_DOUBLE
       value=@xdr.float64
-    when "string"
+    when GMETRIC_STRING
       value=@xdr.string
     else
-      #puts "Received unknown type #{type}"
+      @logger.error("GmonPacket: Received unknown type #{@ptype}")
     end
     return value
   end

--- a/spec/inputs/ganglia.rb
+++ b/spec/inputs/ganglia.rb
@@ -1,0 +1,120 @@
+require "test_utils"
+require "gmetric"
+require "socket"
+
+describe "inputs/ganglia" do
+  extend LogStash::RSpec
+
+  describe "read gmetric_ganglia_packets" do
+    port = 8649
+    host = "127.0.0.1"
+    config <<-CONFIG
+      input {
+        ganglia {
+          port => #{port}
+          host => "#{host}"
+          type => "ganglion"
+        }
+      }
+    CONFIG
+
+    # 
+    canned = [
+        {:hostname => "contoso.com" , :name => "pageviews", :units => "req/min", :type => "int32", :value => 7000, :tmax => 60, :dmax => 300, :group => "test"},
+        {:hostname => "contoso.com" , :name => "jvm.metrics.memNonHeapUsedM", :type => "float", :value => 1, :tmax => 60, :dmax => 0, :slope => "both" , :group => "jvm"}
+        ]
+    expected = [
+        {"log_host"=>"contoso.com", "name"=>"pageviews", "val"=>"7000", "dmax"=>300, "tmax"=>60, "slope"=>"both", "units"=>"req/min", "vtype"=>"int32", "type"=> "ganglion", "host"=>"127.0.0.1"},
+        {"log_host"=>"contoso.com", "name"=>"jvm.metrics.memNonHeapUsedM", "val"=>"1", "dmax"=>0, "tmax"=>60, "slope"=>"both", "units"=>"", "vtype"=>"float", "type"=> "ganglion", "host"=>"127.0.0.1"}
+        ]
+
+   
+    input do |pipeline, queue|
+      # Start the pipeline
+      Thread.new { pipeline.run }
+      sleep 0.1 while !pipeline.ready?
+
+      # Take each of canned hashes and send a metric
+      canned.each do |params|
+        Ganglia::GMetric.send(host,port,params)
+      end
+ 
+      # Compare with the fields we care out to prove they went through the system
+      events = expected.length.times.collect { queue.pop }
+      # TODO(Ludovicus): Figure out how to do pop with timeout.  pop(true) is not good enough. Stud.try?
+      insist { events.length } == expected.length
+      events.length.times do |i|
+        puts(events[i].to_hash)
+        puts(expected[i])
+        expected[i].each do |key,val|
+            insist { events[i][key] } == val
+        end
+      end
+      
+    end # input
+  end
+  
+    describe "read hadoop_ganglia_packets" do
+    port = 8650
+    host = "127.0.0.1"
+    config <<-CONFIG
+      input {
+        ganglia {
+          port => #{port}
+          host => "#{host}"
+          type => "o-negative"
+        }
+      }
+    CONFIG
+
+    # 
+    canned = [
+        # Metadata for ugi.ugi.loginSuccess_num_ops
+        "000000800000001f75732d776573742d322e636f6d707574652e616d617a6f6e6177732e636f6d000000001c7567692e7567692e6c6f67696e537563636573735f6e756d5f6f70730000000000000005666c6f61740000000000001c7567692e7567692e6c6f67696e537563636573735f6e756d5f6f707300000000000000010000003c00000000000000010000000547524f5550000000000000077567692e75676900",
+        # Data Packet for ugi. ugi.loginSuccess_num_ops
+        "000000850000001f75732d776573742d322e636f6d707574652e616d617a6f6e6177732e636f6d000000001c7567692e7567692e6c6f67696e537563636573735f6e756d5f6f70730000000000000002257300000000000139000000",
+        # Metadata for jvm.metrics.memNonHeapUsedM
+        "000000800000001f75732d776573742d322e636f6d707574652e616d617a6f6e6177732e636f6d000000001b6a766d2e6d6574726963732e6d656d4e6f6e48656170557365644d000000000000000005666c6f61740000000000001b6a766d2e6d6574726963732e6d656d4e6f6e48656170557365644d0000000000000000030000003c00000000000000010000000547524f55500000000000000b6a766d2e6d65747269637300",
+        # Data Packet for jvm.metrics.memNonHeapUsedM
+        "000000850000001f75732d776573742d322e636f6d707574652e616d617a6f6e6177732e636f6d000000001b6a766d2e6d6574726963732e6d656d4e6f6e48656170557365644d000000000000000002257300000000000932322e393336363135000000",
+        # Data Packet for jvm.metrics.memNonHeapCommittedM
+        "000000850000001f75732d776573742d322e636f6d707574652e616d617a6f6e6177732e636f6d00000000206a766d2e6d6574726963732e6d656d4e6f6e48656170436f6d6d69747465644d0000000000000002257300000000000533392e3735000000",
+        ]
+    expected = [
+        {"log_host"=>"us-west-2.compute.amazonaws.com", "name"=>"ugi.ugi.loginSuccess_num_ops", "val"=>"9", "dmax"=>0, "tmax"=>60, "slope"=>"positive", "units"=>"", "vtype"=>"float", "type"=> "o-negative", "host"=>"127.0.0.1" },
+        {"log_host"=>"us-west-2.compute.amazonaws.com", "name"=>"jvm.metrics.memNonHeapUsedM", "val"=>"22.936615", "dmax"=>0, "tmax"=>60, "slope"=>"both", "units"=>"", "vtype"=>"float", "type"=> "o-negative", "host"=>"127.0.0.1"}
+        ]
+
+   
+    input do |pipeline, queue|
+      # Start the pipeline
+      Thread.new { pipeline.run }
+      sleep 0.1 while !pipeline.ready?
+
+      # Create a UDP socket and connect it to the rendezvous host:port
+      socket = Stud.try(5.times) { UDPSocket.new(Socket::AF_INET) }
+      socket.connect(host, port)
+
+      # Take each of the horrid hex strings, convert to binary and send it to the ganglia input
+      canned.each do |hexystr|
+        binpkt = [ hexystr ].pack("H*")
+        socket.send(binpkt,0)
+      end
+      socket.close
+ 
+      # Though we sent 5 packets, we expect the metadata to be absorbed and the one data packet sans metadata to disappear
+      # Compare with the fields we care out to prove they went through the system
+      events = expected.length.times.collect { queue.pop }
+      insist { events.length } == expected.length
+      events.length.times do |i|
+        puts(events[i].to_hash)
+        expected[i].each do |key,val|
+            insist { events[i][key] } == val
+        end
+      end
+      # TODO(Ludovicus): How can we check there are no remaining packets on the queue?
+    end # input
+  end
+end
+
+


### PR DESCRIPTION
Running:
```
lfo$ ruby -rgmetric -e 'Ganglia::GMetric.send("127.0.0.1", 8649, { :name => "pageviews", :units => "req/min", :type => "uint16", :value => 7000, :tmax => 60, :dmax => 300, :group => "test" })'
```

Now yields:
```
lfo$ bin/logstash agent -e 'input { ganglia { type => "nerve" } }'
Using milestone 1 input plugin 'ganglia'. This plugin should work, but would benefit from use by folks like you. Please let us know if you find bugs or have suggestions on how to improve this plugin.  For more information on plugin milestones, see http://logstash.net/docs/1.4.0.rc1/plugin-milestones {:level=>:warn}
{
      "@version" => "1",
    "@timestamp" => "2014-03-14T21:47:31.350Z",
      "log_host" => "",
          "name" => "pageviews",
           "val" => "7000",
          "dmax" => 300,
          "tmax" => 60,
         "slope" => "both",
         "units" => "req/min",
         "vtype" => "uint16",
          "type" => "nerve",
          "host" => "127.0.0.1"
}
^C
```

Note the "val" field has a 7000 and that "uint16" is the value of "vtype" and "type" is "nerve".
