### PR TITLE
Add teardown to flush elasticsearch on agent shutdown

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -334,4 +334,8 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     # retried.
   end # def flush
 
+  def teardown
+    buffer_flush(:final => true)
+  end
+
 end # class LogStash::Outputs::Elasticsearch


### PR DESCRIPTION
Prior to this, some events could be lost if logstash was shutdown.
