### PR TITLE
[rabbitmq] Bump Bunny to 1.1.7+

### DIFF
--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -74,7 +74,7 @@ Gem::Specification.new do |gem|
   end
 
   if RUBY_PLATFORM != 'java'
-    gem.add_runtime_dependency "bunny",       ["~> 1.1.0"]  #(MIT license)
+    gem.add_runtime_dependency "bunny",       ["~> 1.1.7"]  #(MIT license)
   else
     gem.add_runtime_dependency "march_hare", ["~> 2.1.0"] #(MIT license)
   end


### PR DESCRIPTION
Fixes a thread leak which affects apps that perform
manual recovery, including Logstash RabbitMQ plugin.

Plus this kind of latency improvements:

![](https://f.cloud.github.com/assets/1800798/2175168/ac09c4dc-95ba-11e3-93d9-a28fb25a8327.png)
