### PR TITLE
Allow init script to be symlinked

### DIFF
--- a/pkg/logstash.sysv.redhat
+++ b/pkg/logstash.sysv.redhat
@@ -42,7 +42,7 @@ LS_CONF_DIR=/etc/logstash/conf.d
 LS_OPEN_FILES=16384
 LS_NICE=19
 LS_OPTS=""
-LS_PIDFILE=/var/run/$NAME/$NAME.pid
+LS_PIDFILE=/var/run/logstash/$NAME.pid
 
 # End of variables that can be overwritten in $DEFAULT
 


### PR DESCRIPTION
Get name of service from name of file - this allows to simply symlink init script to have multiple services, eg. separate shipper and indexer services on same host.
