### PR TITLE
Fixed RPM license linting error

### DIFF
--- a/pkg/build.sh
+++ b/pkg/build.sh
@@ -90,7 +90,7 @@ case $os in
       --description "$DESCRIPTION" \
       -d "jre >= 1.6.0" \
       --vendor "Elasticsearch" \
-      --license "Apache 2.0" \
+      --license "ASL 2.0" \
       --rpm-use-file-permissions \
       --rpm-user root --rpm-group root \
       --before-install centos/before-install.sh \


### PR DESCRIPTION
The correct license shortcut for Apache 2.0 is ASL 2.0.
