### PR TITLE
No need to force_encoding to utf8 twice

### DIFF
--- a/lib/logstash/filters/useragent.rb
+++ b/lib/logstash/filters/useragent.rb
@@ -86,7 +86,7 @@ class LogStash::Filters::UserAgent < LogStash::Filters::Base
 
       # UserAgentParser outputs as US-ASCII.
 
-      target[@prefix + "name"] = ua_data.name.force_encoding(Encoding::UTF_8).force_encoding(Encoding::UTF_8)
+      target[@prefix + "name"] = ua_data.name.force_encoding(Encoding::UTF_8)
 
       #OSX, Andriod and maybe iOS parse correctly, ua-agent parsing for Windows does not provide this level of detail
       unless ua_data.os.nil?


### PR DESCRIPTION
Looks like it was a copy and paste mistake introduced in commit 5d5d8e22.
