### PR TITLE
Fix multiline filter bug caused by get/set broken after overwrite() is called for an event

### DIFF
--- a/lib/logstash/event.rb
+++ b/lib/logstash/event.rb
@@ -53,8 +53,10 @@ class LogStash::Event
   def initialize(data={})
     @cancelled = false
 
+    # If we ever need to change the reference @data holds, always change the reference @accessors holds too
+    # These must BOTH match, or gets and sets will only affects data in the OLD reference
     @data = data
-    @accessors = LogStash::Util::Accessors.new(data)
+    @accessors = LogStash::Util::Accessors.new(@data)
 
     data[VERSION] = VERSION_ONE if !@data.include?(VERSION)
     if data.include?(TIMESTAMP)
@@ -154,7 +156,9 @@ class LogStash::Event
 
   public
   def overwrite(event)
+    # When changing the reference @data holds, always update the reference @accessors holds too [see initialise()]
     @data = event.to_hash
+    @accessors = LogStash::Util::Accessors.new(@data)
     #convert timestamp if it is a String
     if @data[TIMESTAMP].is_a?(String)
       @data[TIMESTAMP] = LogStash::Time.parse_iso8601(@data[TIMESTAMP])


### PR DESCRIPTION
The arrays happening in @ timestamp and causing crashes/failures/problems when using multiline filter is caused by the use of Event::overwrite()

Calling Event::overwrite() overwrites the local @ data reference to point to the new data, but it did not update the reference inside @ accessors. This meant that all gets to the Event returned the OLD data from before the overwrite, and sets updated the old data the gets returned too due to the use of @ accessors for this.

The problem manifests when Event::sprintf() is called - as this uses the local @ data object, which would be the new data. However, when using multiline filter this will have a @ timestamp array and trigger the bug. The multiline filter was meant to remove this array but it used the get/set and thus worked on the OLD data and was unable to fix up the @ data referenced by Event::sprintf()

The issue begun when the @ accessors was added, 14-03-2014, and the first release this appeared in is (I think) v1.4.0 release. So it was not present in rc1.

Commit: 6796736defb74c551a6acf05787753c2cffe51ef [6796736]
Parents: ef5af78893
Date: 12 March 2014 16.54.57 GMT
Commit Date: 14 March 2014 18.55.25 GMT
Fieldreference replacement
