### PR TITLE
Don't explode when processing multiline events

### DIFF
--- a/lib/logstash/event.rb
+++ b/lib/logstash/event.rb
@@ -215,6 +215,10 @@ class LogStash::Event
         next @data["@timestamp"].to_i
       elsif key[0,1] == "+"
         t = @data["@timestamp"]
+        # Allows incoming multiline entries
+        if t.kind_of?(Array)
+          t = Time.parse(t[0])
+        end
         formatter = org.joda.time.format.DateTimeFormat.forPattern(key[1 .. -1])\
           .withZone(org.joda.time.DateTimeZone::UTC)
         #next org.joda.time.Instant.new(t.tv_sec * 1000 + t.tv_usec / 1000).toDateTime.toString(formatter)


### PR DESCRIPTION
I don't know ruby, there is likely a better solution for this, but it's a nasty problem that needs fixing.

This will allow processing of multiline events, otherwise you get

NoMethodError: undefined method `tv_sec' for #Array:0x7f8e1a98
        sprintf at /opt/logstash/lib/logstash/event.rb:223
           gsub at org/jruby/RubyString.java:3041
        sprintf at /opt/logstash/lib/logstash/event.rb:209
        receive at /opt/logstash/lib/logstash/outputs/elasticsearch.rb:324
         handle at /opt/logstash/lib/logstash/outputs/base.rb:86
     initialize at (eval):20
           call at org/jruby/RubyProc.java:271
         output at /opt/logstash/lib/logstash/pipeline.rb:266
   outputworker at /opt/logstash/lib/logstash/pipeline.rb:225
  start_outputs at /opt/logstash/lib/logstash/pipeline.rb:152

On my installation this error was getting swallowed entirely until I ran a debug config with a stdout {} section in output.  We'd been silently failing on all multiline events.
