### PR TITLE
fix of redhat init-scripts, closes #LOGSTASH-2040 and #LOGSTASH-2062

### DIFF
--- a/pkg/logstash-web.sysv.redhat
+++ b/pkg/logstash-web.sysv.redhat
@@ -80,7 +80,7 @@ do_start()
   export PATH HOME JAVA_OPTS LS_HEAP_SIZE LS_JAVA_OPTS LS_USE_GC_LOGGING
   test -n "${JAVACMD}" && export JAVACMD
 
-  nice -n ${LS_NICE} runuser -s /bin/sh -c "exec $DAEMON $DAEMON_OPTS" ${LS_USER} > /dev/null 1>&1 < /dev/null &
+  nice -n ${LS_NICE} runuser -s /bin/sh -c "exec $DAEMON $DAEMON_OPTS" ${LS_USER} > /dev/null 2>&1 < /dev/null &
 
   RETVAL=$?
   local PID=$!
@@ -89,7 +89,7 @@ do_start()
   JAVA_PID=$(ps axo ppid,pid | awk -v "ppid=$PID" '$1==ppid {print $2}')
   PID=${JAVA_PID:-$PID}
   echo $PID > $PID_FILE
-  [ $PID = $JAVA_PID ] && success
+  [ "$PID" = "$JAVA_PID" ] && success
 }
 
 #

--- a/pkg/logstash.sysv.redhat
+++ b/pkg/logstash.sysv.redhat
@@ -79,7 +79,7 @@ do_start()
   export PATH HOME JAVA_OPTS LS_HEAP_SIZE LS_JAVA_OPTS LS_USE_GC_LOGGING
   test -n "${JAVACMD}" && export JAVACMD
 
-  nice -n ${LS_NICE} runuser -s /bin/sh -c "exec $DAEMON $DAEMON_OPTS" ${LS_USER} > /dev/null 1>&1 < /dev/null &
+  nice -n ${LS_NICE} runuser -s /bin/sh -c "exec $DAEMON $DAEMON_OPTS" ${LS_USER} > /dev/null 2>&1 < /dev/null &
 
   RETVAL=$?
   local PID=$!
@@ -88,7 +88,7 @@ do_start()
   JAVA_PID=$(ps axo ppid,pid | awk -v "ppid=$PID" '$1==ppid {print $2}')
   PID=${JAVA_PID:-$PID}
   echo $PID > $PID_FILE
-  [ $PID = $JAVA_PID ] && success
+  [ "$PID" = "$JAVA_PID" ] && success
 }
 
 #


### PR DESCRIPTION
closes #LOGSTASH-2040
- stdout and stderror of the logstash process should be redirected to /dev/null, so automation tools can quit cleanly

closes #LOGSTASH-2062
- according to the Linux Standard Base Core Specification starting a running service should return 0
  -see http://refspecs.linuxbase.org/LSB_3.1.1/LSB-Core-generic/LSB-Core-generic/iniscrptact.html
