### PR TITLE
LOGSTASH-2070 - Easily loading logstash-contrib

### DIFF
--- a/bin/logstash.bat
+++ b/bin/logstash.bat
@@ -46,7 +46,7 @@ REM The path to the heap dump location, note directory must exists and have enou
 REM space for a full heap dump.
 REM JAVA_OPTS=%JAVA_OPTS% -XX:HeapDumpPath=$LS_HOME/logs/heapdump.hprof
 
-set RUBYLIB=%LS_HOME%\lib
+if defined LS_CONTRIB (set RUBYLIB=%LS_HOME%\lib;%LS_CONTRIB%\lib) ELSE (set RUBYLIB=%LS_HOME%\lib)
 set GEM_HOME=%LS_HOME%\vendor\bundle\jruby\1.9\
 set GEM_PATH=%GEM_HOME%
 

--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -1,7 +1,12 @@
 basedir=$(cd `dirname $0`/..; pwd)
 
 setup_ruby() {
-  export RUBYLIB="$basedir/lib"
+  if [ -d "$LS_CONTRIB/lib" ] ; then
+    export RUBYLIB="$basedir/lib:$LS_CONTRIB/lib"
+  else
+    export RUBYLIB="$basedir/lib"
+  fi
+
   # Verify ruby works
   if ! ruby -e 'puts "HURRAY"' 2> /dev/null | grep -q "HURRAY" ; then
     echo "No ruby program found. Cannot start."
@@ -54,7 +59,11 @@ setup_java() {
 
   export JAVACMD
   export JAVA_OPTS
-  export RUBYLIB="$basedir/lib"
+  if [ -d "$LS_CONTRIB/lib" ] ; then
+    export RUBYLIB="$basedir/lib:$LS_CONTRIB/lib"
+  else
+    export RUBYLIB="$basedir/lib"
+  fi
   export GEM_HOME="$basedir/vendor/bundle/jruby/1.9"
   export GEM_PATH=
 }


### PR DESCRIPTION
This small patch enables use of a LS_CONTRIB env var which can point at the logstash-contrib project.  This makes developing plugins in logstash-contrib and running them with a logstash source tree very easy.

Read more about it: https://logstash.jira.com/browse/LOGSTASH-2070
