### PR TITLE
Fix problem accessing array-indexed fields.

### DIFF
--- a/lib/logstash/util/accessors.rb
+++ b/lib/logstash/util/accessors.rb
@@ -57,7 +57,7 @@ module LogStash::Util
 
     def store_path(accessor)
       key, path = PathCache.get(accessor)
-      target = path.inject(@store) {|r, k| r[k] ||= {}}
+      target = path.inject(@store) {|r, k| r[r.is_a?(Array) ? k.to_i : k] ||= {}}
       [target, key]
     end
 

--- a/spec/util/accessors_spec.rb
+++ b/spec/util/accessors_spec.rb
@@ -146,6 +146,13 @@ describe LogStash::Util::Accessors, :if => true do
       insist { accessors.get("[hello][world][0]") } == data["hello"]["world"][0]
       insist { accessors.get("[hello][world][1]") } == data["hello"]["world"][1]
     end
+
+    it "should retrieve array item containing hash" do
+      data = { "hello" => { "world" => [ { "a" => 123 }, { "b" => 345 } ], "bar" => "baz" } }
+      accessors = LogStash::Util::Accessors.new(data)
+      insist { accessors.get("[hello][world][0][a]") } == data["hello"]["world"][0]["a"]
+      insist { accessors.get("[hello][world][1][b]") } == data["hello"]["world"][1]["b"]
+    end
   end
 
   context "using invalid encoding" do


### PR DESCRIPTION
This change fixes accessing fields of the form [list][0][key], where
[list] is an array, [0] is the numeric index into the array, and [key]
is the hash key into one of the items in the array.
