### PR TITLE
Redis (tested with 2.8.7) log might have * or # in their logs. Those wit...

### DIFF
--- a/patterns/redis
+++ b/patterns/redis
@@ -1,3 +1,3 @@
 REDISTIMESTAMP %{MONTHDAY} %{MONTH} %{TIME}
-REDISLOG \[%{POSINT:pid}\] %{REDISTIMESTAMP:timestamp} \* 
+REDISLOG \[%{POSINT:pid}\] %{REDISTIMESTAMP:timestamp} (?:\*|#) 
 


### PR DESCRIPTION
Matcher for # were missing, so even more important log messages were not parsed. 

Example log file:
```
[13327] 17 Mar 16:06:38.019 # Failed opening .rdb for saving: Permission denied
[3937] 17 Mar 16:06:38.119 # Background saving error
[13711] 17 Mar 16:07:02.072 # Failed opening .rdb for saving: Permission denied
[3937] 17 Mar 16:07:02.172 # Background saving error
[3937] 01 Apr 07:27:36.735 * 10000 changes in 60 seconds. Saving...
[3937] 01 Apr 07:27:36.735 * Background saving started by pid 18344
[18344] 01 Apr 07:27:36.738 * DB saved on disk
[18344] 01 Apr 07:27:36.738 * RDB: 4 MB of memory used by copy-on-write
[3937] 01 Apr 07:27:36.836 * Background saving terminated with success
[3937] 01 Apr 14:24:18.603 * 10000 changes in 60 seconds. Saving...
[3937] 01 Apr 14:24:18.604 * Background saving started by pid 7330
[7330] 01 Apr 14:24:18.606 * DB saved on disk
[7330] 01 Apr 14:24:18.606 * RDB: 4 MB of memory used by copy-on-write
[3937] 01 Apr 14:24:18.704 * Background saving terminated with success
[3631] 14 Mar 15:04:47.761 # Server started, Redis version 2.8.7
[3919] 17 Mar 11:08:56.310 # Failed opening .rdb for saving: Permission denied
[3937] 17 Mar 11:08:56.410 # Background saving error
[3930] 17 Mar 11:09:02.028 # Failed opening .rdb for saving: Permission denied
[3937] 17 Mar 11:09:02.128 # Background saving error
```
