### PR TITLE
basic HTTP input plugin

### DIFF
--- a/lib/logstash/inputs/http.rb
+++ b/lib/logstash/inputs/http.rb
@@ -1,6 +1,5 @@
 require "openssl"
 require "webrick"
-require "webrick/ssl"
 require "logstash/namespace"
 require "logstash/inputs/base"
 require "thread"
@@ -29,6 +28,18 @@ class LogStash::Inputs::Http < LogStash::Inputs::Base
 	# The address to bind on. Default is 0.0.0.0
 	config :address, :validate => :string, :default => "0.0.0.0"
 
+	# The mode to run in. Use 'client' to pull requests from a specific url.
+	# Use 'server' to enable clients to push events to this plugin.
+	config :mode, :validate => :string, :default => 'server'
+
+	# The url to fetch the log events from when running in client mode.
+	# Currently supports only GET based requests.
+	config :url, :validate => :string, :required => false
+
+	# The interval between pull requests for new log events in milliseconds.
+	# By default polls every second for new data. Increase or decrease as needed.
+	config :interval, :validate => :number, :default => 1000
+
 	def register
 		options =  { :Port => @port, :BindAddress => @address }
 
@@ -37,6 +48,54 @@ class LogStash::Inputs::Http < LogStash::Inputs::Base
 	end
 
 	def run(output_queue)
+		if @mode == 'server'
+			runserver output_queue
+		else
+			runclient output_queue
+		end
+	end
+
+	def runclient(output_queue)
+		while not @interrupted do
+			begin
+
+				output_queue << pull_event
+
+				# Check if an interrupt came through.
+				# When it did, stop this process.
+				if @interrupted
+					break
+				end
+
+				# Wait for the interval to pass, rinse and repeat the whole process.
+				sleep @interval
+			rescue LogStash::ShutdownSignal
+				@interrupted = true
+				break
+			rescue Exception => error
+				@logger.debug("Failed to retrieve log data from source.")
+			end
+		end
+	end
+
+	def pull_event()
+		codec = @codec.clone
+
+		# Download potentially new log data from the specified URL
+		# Not using accept-type in the request, because we don't know the
+		# content-type until we process it using the codec.
+		response_body = HTTP.get @url
+
+		# Use the codec to decode the data into something useful.
+		codec.decode(response_body) do |event|
+			# Decorate the event with the mandatory logstash stuff.
+			decorate(event)
+
+			return event
+		end
+	end
+
+	def runserver(output_queue)
 		begin
 			@mutex = Mutex.new
 			@wait_handle = ConditionVariable.new
@@ -85,9 +144,14 @@ class LogStash::Inputs::Http < LogStash::Inputs::Base
 	end
 
 	def teardown
-		# Interrupt the listener and stop the process.
-		@mutex.synchronize do
-			@wait_handle.signal
+		if @mode == 'server'
+			# Interrupt the listener and stop the process.
+			@mutex.synchronize do
+				@wait_handle.signal
+			end
+		else
+			# Interrupt the client
+			@interrupted = true
 		end
 	end
 end

--- a/lib/logstash/inputs/http.rb
+++ b/lib/logstash/inputs/http.rb
@@ -1,0 +1,93 @@
+require "openssl"
+require "webrick"
+require "webrick/ssl"
+require "logstash/namespace"
+require "logstash/inputs/base"
+require "thread"
+
+# Reads log events from a http endpoint.
+#
+# Configuring this plugin can be done using the following basic configuration:
+#
+# input {
+#   http { }
+# }
+#
+# This will open a http server on port 8000 that accepts messages in the JSON
+# format. You can customize the port and bind address in the options of the
+# plugin.
+
+class LogStash::Inputs::Http < LogStash::Inputs::Base
+	config_name "http"
+	milestone 1
+
+	default :codec, "json"
+
+	# The port to listen on. Default is 8000.
+	config :port, :validate => :number, :default => 8000
+
+	# The address to bind on. Default is 0.0.0.0
+	config :address, :validate => :string, :default => "0.0.0.0"
+
+	def register
+		options =  { :Port => @port, :BindAddress => @address }
+
+		# Start a basic HTTP server to receive logging information.
+		@http_server = WEBrick::HTTPServer.new options
+	end
+
+	def run(output_queue)
+		begin
+			@mutex = Mutex.new
+			@wait_handle = ConditionVariable.new
+
+			# Register a custom procedure with the HTTP server so that we can receive log messages
+			# and process them using this plugin.
+			@http_server.mount_proc '/' do |req, res|
+				codec = @codec.clone
+
+				# Decode the incoming body and store it in the event queue.
+				codec.decode(req.body) do |event|
+					# Add additional logging data to the event
+					event["host"] = req.peeraddr
+
+					# Decorate the event with the mandatory logstash stuff.
+					decorate(event)
+
+					# Push the event in the output queue
+					output_queue << event
+				end
+
+				# Send a HTTP 100 continue response without content.
+				# This acknowledges the logger that the content was received.
+				res.status = 200
+				res.body = "{ \"status\": \"OK\" }"
+			end
+
+			# Start the webserver.
+			# Start a separate thread for the http server
+			@server_thread = Thread.new do
+				@http_server.start
+			end
+
+			@logger.info "HTTP listener registered on #{@address}:#{@port}."
+
+			# This somewhwat weird construction is required, because Logstash expects the run
+			# method to run forever. Which is the case right here ;-)
+			@mutex.synchronize do
+				@wait_handle.wait(@mutex)
+			end
+		ensure
+			# Close the HTTP server at the end of the run method.
+			# This ensures that the sockets used are closed.
+			@http_server.shutdown
+		end
+	end
+
+	def teardown
+		# Interrupt the listener and stop the process.
+		@mutex.synchronize do
+			@wait_handle.signal
+		end
+	end
+end

--- a/spec/examples/parse-apache-logs.rb
+++ b/spec/examples/parse-apache-logs.rb
@@ -54,8 +54,7 @@ describe "apache common log format", :if => RUBY_ENGINE == "jruby" do
     insist { subject["agent"] } == "\"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:14.0) Gecko/20100101 Firefox/14.0.1\""
 
     # Verify date parsing
-    #FIXME: Timestamp parsing somehow resets the timestamp to today.
-    #insist { subject.timestamp } == Time.iso8601("2012-08-30T00:17:38.000Z")
+    insist { subject.timestamp } == Time.iso8601("2012-08-30T00:17:38.000Z")
   end
 
   sample '61.135.248.195 - - [26/Sep/2012:11:49:20 -0400] "GET /projects/keynav/ HTTP/1.1" 200 18985 "" "Mozilla/5.0 (compatible; YodaoBot/1.0; http://www.yodao.com/help/webmaster/spider/; )"' do

--- a/spec/examples/parse-apache-logs.rb
+++ b/spec/examples/parse-apache-logs.rb
@@ -54,7 +54,8 @@ describe "apache common log format", :if => RUBY_ENGINE == "jruby" do
     insist { subject["agent"] } == "\"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:14.0) Gecko/20100101 Firefox/14.0.1\""
 
     # Verify date parsing
-    insist { subject.timestamp } == Time.iso8601("2012-08-30T00:17:38.000Z")
+    #FIXME: Timestamp parsing somehow resets the timestamp to today.
+    #insist { subject.timestamp } == Time.iso8601("2012-08-30T00:17:38.000Z")
   end
 
   sample '61.135.248.195 - - [26/Sep/2012:11:49:20 -0400] "GET /projects/keynav/ HTTP/1.1" 200 18985 "" "Mozilla/5.0 (compatible; YodaoBot/1.0; http://www.yodao.com/help/webmaster/spider/; )"' do

--- a/spec/inputs/http.rb
+++ b/spec/inputs/http.rb
@@ -1,0 +1,69 @@
+# coding: utf-8
+require "test_utils"
+require "socket"
+require "json"
+require "http"
+
+describe "inputs/http" do
+  extend LogStash::RSpec
+
+  describe "basic input configuration" do
+    config <<-CONFIG
+      input {
+        http {
+
+        }
+      }
+    CONFIG
+
+    input do |pipeline,queue|
+      Thread.new { pipeline.run }
+      sleep 0.1 while !pipeline.ready?
+
+      request_body = JSON.generate({ :message => "Hello Aafke" })
+      content_length = request_body.length
+
+      HTTP.post "http://localhost:8000/",
+        :body => request_body,
+        :headers => {
+          "Content-Length" => content_length,
+          "Content-Type" => "application/json"
+        }
+
+      event = queue.pop
+
+      insist { event } != nil
+      insist { event["message"] } == "Hello Aafke"
+    end
+  end
+
+  describe "custom configuration with plain codec" do
+    config <<-CONFIG
+    input {
+      http {
+        codec => "plain"
+      }
+    }
+    CONFIG
+
+    input do |pipeline,queue|
+      Thread.new { pipeline.run }
+      sleep 0.1 while !pipeline.ready?
+
+      request_body = "Hello Aafke"
+      content_length = request_body.length
+
+      HTTP.post "http://localhost:8000/",
+        :body => request_body,
+        :headers => {
+          "Content-Length" => content_length,
+          "Content-Type" => "text/plain"
+        }
+
+      event = queue.pop
+
+      insist { event } != nil
+      insist { event["message"] } == "Hello Aafke"
+    end
+  end
+end

--- a/tools/Gemfile.jruby-1.9.lock
+++ b/tools/Gemfile.jruby-1.9.lock
@@ -17,6 +17,7 @@ GEM
     beefcake (0.3.7)
     bindata (2.0.0)
     blankslate (2.1.2.4)
+    bluecloth (2.2.0)
     bouncy-castle-java (1.5.0147)
     buftok (0.1)
     builder (3.2.2)
@@ -47,7 +48,6 @@ GEM
     extlib (0.9.16)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.3)
     ffi (1.9.3-java)
     ffi-rzmq (1.0.0)
       ffi
@@ -62,11 +62,9 @@ GEM
     gelfd (0.2.0)
     geoip (1.3.5)
     gmetric (0.1.3)
-    hitimes (1.2.1)
     hitimes (1.2.1-java)
     http (0.5.0)
       http_parser.rb
-    http_parser.rb (0.5.3)
     http_parser.rb (0.5.3-java)
     i18n (0.6.9)
     insist (1.0.0)
@@ -105,10 +103,6 @@ GEM
     parslet (1.4.0)
       blankslate (~> 2.0)
     polyglot (0.3.4)
-    pry (0.9.12.6)
-      coderay (~> 1.0)
-      method_source (~> 0.8)
-      slop (~> 3.4)
     pry (0.9.12.6-java)
       coderay (~> 1.0)
       method_source (~> 0.8)
@@ -161,8 +155,6 @@ GEM
     term-ansicolor (1.3.0)
       tins (~> 1.0)
     thor (0.18.1)
-    thread_safe (0.2.0)
-      atomic (>= 1.1.7, < 2)
     thread_safe (0.2.0-java)
       atomic (>= 1.1.7, < 2)
     tilt (1.4.1)
@@ -193,6 +185,7 @@ DEPENDENCIES
   aws-sdk
   beefcake (= 0.3.7)
   bindata (>= 1.5.0)
+  bluecloth
   bouncy-castle-java (= 1.5.0147)
   cabin (>= 0.6.0)
   ci_reporter


### PR DESCRIPTION
Implemented basic version of an http input plugin.
Test code included for some basic verification.

This implements a fix for Jira issue LOGSTASH-871
Although not polling the HTTP server to read the logs, it instead provides access for clients to push events to the server by POSTing them to the Logstash instance.