### PR TITLE
Don't override $basedir if already assigned.

### DIFF
--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -1,4 +1,4 @@
-basedir=$(cd `dirname $0`/..; pwd)
+basedir=${basedir:-$(cd `dirname $0`/..; pwd)}
 
 setup_ruby() {
   export RUBYLIB="$basedir/lib"


### PR DESCRIPTION
A library shouldn't change the outside environment without being asked to.