### PR TITLE
Use jruby to run 'make test'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ vendor/ua-parser/regexes.yaml: | vendor/ua-parser/
 .PHONY: test
 test: QUIET_OUTPUT=
 test: | $(JRUBY) vendor-elasticsearch vendor-geoip vendor-collectd vendor-gems
-	$(SPEC_ENV) bin/logstash rspec $(SPEC_OPTS) --order rand --fail-fast $(TESTS)
+	$(SPEC_ENV) USE_JRUBY=1 bin/logstash rspec $(SPEC_OPTS) --order rand --fail-fast $(TESTS)
 
 .PHONY: reporting-test
 reporting-test: SPEC_ENV=JRUBY_OPTS=--debug COVERAGE=TRUE


### PR DESCRIPTION
Since the 'test' target depends on jruby installation targets it seems like the original intention.
Without this `make test` doesn't work out of the box (as described in README and CONTRIBUTING).

It tries to use my other ruby which errors for being the wrong version or not having required gems installed (even though the make command appears to install the necessary deps (they're just not getting used)).

Alternatively, if it makes more sense, maybe `USE_JRUBY=1` should be set globally in the Makefile
or maybe there should be a separate Makefile var for `LOGSTASH_CMD=USE_JRUBY=1 bin/logstash`.

Does this make sense?  Other thoughts?
Thanks!
