### PR TITLE
Download contrib plugins tarball file only it's necessary.

### DIFF
--- a/bin/plugin
+++ b/bin/plugin
@@ -15,9 +15,9 @@ CURL=$(which curl 2>/dev/null)
 URLSTUB="http://download.elasticsearch.org/logstash/logstash/"
 
 if [ "x$WGET" != "x" ]; then
-	DOWNLOAD_COMMAND="wget -q --no-check-certificate -O"
+	DOWNLOAD_COMMAND="wget -c --no-check-certificate -O"
 elif [ "x$CURL" != "x" ]; then
-    DOWNLOAD_COMMAND="curl -s -L -k -o"
+    DOWNLOAD_COMMAND="curl -C - -L -k -o"
 else
 	echo "wget or curl are required."
 	exit 1
@@ -46,15 +46,24 @@ TARGET="${TARGETDIR}/${FILENAME}"
 
 case $1 in
   install)
-  	$DOWNLOAD_COMMAND ${TARGET} ${URLSTUB}${FILENAME}
-  	if [ ! -f "${TARGET}" ]; then
-	  	echo "ERROR: Unable to download ${URLSTUB}${FILENAME}"
-	  	echo "Exiting."
-	  	exit 1
-	fi
+    if gzip -t ${TARGET} >/dev/null 2>&1; then
+        echo "${FILENAME} exist."
+    else
+        echo "Downloading ${FILENAME}"
+      	if $DOWNLOAD_COMMAND ${TARGET} ${URLSTUB}${FILENAME}; then
+            echo "${FILENAME} has been downloaded."
+        else
+    	  	echo "ERROR: Unable to download ${URLSTUB}${FILENAME}"
+    	  	echo "Exiting."
+    	  	exit 1
+    	fi
+    fi
+    # Tarball has been download and valid.
   	gzip -dc ${TARGET} | tar -xC $TARGETDIR
-  	cp -R ${TARGETDIR}/$FILEPATH/* .  ;; # Copy contents to local directory, adding on top of existing install
-  *) 
+  	cp -R ${TARGETDIR}/$FILEPATH/* . # Copy contents to local directory, adding on top of existing install
+    echo "Contrib plugins install successful."
+    ;;
+  *)
   	echo "Usage: bin/plugin install contrib"
 	exit 0
 	;;


### PR DESCRIPTION
Check if target tarball exist and valid. good for offline deploy and intranet deploy. And provide more feedback to user while bin/plugin doing its job.
