### PR TITLE
tcp: gives the hostname of the localmachine not the ip of remote machine...

### DIFF
--- a/tools/Gemfile.jruby-1.9.lock
+++ b/tools/Gemfile.jruby-1.9.lock
@@ -5,7 +5,6 @@ GEM
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     addressable (2.3.5)
-    atomic (1.1.15)
     atomic (1.1.15-java)
     avl_tree (1.1.3)
     awesome_print (1.2.0)
@@ -47,7 +46,6 @@ GEM
     extlib (0.9.16)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.3)
     ffi (1.9.3-java)
     ffi-rzmq (1.0.0)
       ffi
@@ -62,11 +60,9 @@ GEM
     gelfd (0.2.0)
     geoip (1.3.5)
     gmetric (0.1.3)
-    hitimes (1.2.1)
     hitimes (1.2.1-java)
     http (0.5.0)
       http_parser.rb
-    http_parser.rb (0.5.3)
     http_parser.rb (0.5.3-java)
     i18n (0.6.9)
     insist (1.0.0)
@@ -76,8 +72,8 @@ GEM
     jruby-httpclient (1.1.1-java)
     jruby-openssl (0.8.7)
       bouncy-castle-java (>= 1.5.0147)
-    json (1.8.1)
     json (1.8.1-java)
+    kramdown (1.3.3)
     mail (2.5.3)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
@@ -98,17 +94,11 @@ GEM
     multi_json (1.8.4)
     multipart-post (2.0.0)
     murmurhash3 (0.1.4)
-    nokogiri (1.6.1)
-      mini_portile (~> 0.5.0)
     nokogiri (1.6.1-java)
       mini_portile (~> 0.5.0)
     parslet (1.4.0)
       blankslate (~> 2.0)
     polyglot (0.3.4)
-    pry (0.9.12.6)
-      coderay (~> 1.0)
-      method_source (~> 0.8)
-      slop (~> 3.4)
     pry (0.9.12.6-java)
       coderay (~> 1.0)
       method_source (~> 0.8)
@@ -161,8 +151,6 @@ GEM
     term-ansicolor (1.3.0)
       tins (~> 1.0)
     thor (0.18.1)
-    thread_safe (0.2.0)
-      atomic (>= 1.1.7, < 2)
     thread_safe (0.2.0-java)
       atomic (>= 1.1.7, < 2)
     tilt (1.4.1)
@@ -217,6 +205,7 @@ DEPENDENCIES
   jruby-httpclient
   jruby-openssl (= 0.8.7)
   json
+  kramdown
   mail
   march_hare (~> 2.1.0)
   metriks


### PR DESCRIPTION
... which for input this may work better, unix and zeromq now both support chmod, chgrp, and chown since sockets need the option to change permissions

Not sure if this is all okay with everyone else but what i do to run it. Because the logstash processes is started by a user that is not also the user that is generating the logs this is better then trying to always change the permisions all the time. 