### PR TITLE
filter/date: apply on_success actions only when date parsing succeed

### DIFF
--- a/lib/logstash/filters/date.rb
+++ b/lib/logstash/filters/date.rb
@@ -208,6 +208,7 @@ class LogStash::Filters::Date < LogStash::Filters::Base
           #event[@target] = Time.at(epochmillis / 1000.0).utc
 
           @logger.debug? && @logger.debug("Date parsing done", :value => value, :timestamp => event[@target])
+          filter_matched(event)
         rescue StandardError, JavaException => e
           @logger.warn("Failed parsing date from field", :field => field,
                        :value => value, :exception => e)
@@ -219,7 +220,6 @@ class LogStash::Filters::Date < LogStash::Filters::Base
       end # fieldvalue.each 
     end # @parsers.each
 
-    filter_matched(event) if !event.cancelled?
     return event
   end # def filter
 end # class LogStash::Filters::Date

--- a/spec/filters/date.rb
+++ b/spec/filters/date.rb
@@ -246,6 +246,38 @@ RUBY_ENGINE == "jruby" and describe LogStash::Filters::Date do
     end
   end
 
+   describe "success to parse should apply on_success config(add_tag,add_field...)" do
+    config <<-CONFIG
+      filter { 
+        date {
+          match => [ "thedate", "yyyy/MM/dd" ]
+          add_tag => "tagged"
+        }
+      }
+    CONFIG
+
+    sample("thedate" => "2013/04/21") do
+      insist { subject["@timestamp"] } != "2013-04-21T00:00:00.000Z"
+      insist { subject["tags"] } == ["tagged"]
+    end
+  end
+
+   describe "failing to parse should not apply on_success config(add_tag,add_field...)" do
+    config <<-CONFIG
+      filter { 
+        date {
+          match => [ "thedate", "yyyy/MM/dd" ]
+          add_tag => "tagged"
+        }
+      }
+    CONFIG
+
+    sample("thedate" => "2013/Apr/21") do
+      insist { subject["@timestamp"] } != "2013-04-21T00:00:00.000Z"
+      insist { subject["tags"] } == nil
+    end
+  end
+
   describe "parsing with timezone parameter" do
     config <<-CONFIG
       filter {


### PR DESCRIPTION
Bugfix and spec. 
Resolve #1237 and LOGSTASH-2100
