### PR TITLE
Better bash test for file download fault.

### DIFF
--- a/bin/plugin
+++ b/bin/plugin
@@ -17,7 +17,7 @@ URLSTUB="http://download.elasticsearch.org/logstash/logstash/"
 if [ "x$WGET" != "x" ]; then
 	DOWNLOAD_COMMAND="wget -q --no-check-certificate -O"
 elif [ "x$CURL" != "x" ]; then
-    DOWNLOAD_COMMAND="curl -s -L -k -o"
+    DOWNLOAD_COMMAND="curl -f -s -L -k -o"
 else
 	echo "wget or curl are required."
 	exit 1


### PR DESCRIPTION
-f tests for the existence of a file... curl and wget will both create a 0 length file when attempting to download, satisfying this test.

One option is to change it to a -s which ensures that the file is of non-zero length.

Or we can just check the return code of curl and wget which I believe should both use 0 for success and >0 for anything else.
