### PR TITLE
Bump ffi-rzmq to 2.0.1

### DIFF
--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "addressable"                      #(Apache 2.0 license)
   gem.add_runtime_dependency "extlib", ["0.9.16"]               #(MIT license)
   gem.add_runtime_dependency "ffi"                              #(LGPL-3 license)
-  gem.add_runtime_dependency "ffi-rzmq", ["1.0.0"]              #(MIT license)
+  gem.add_runtime_dependency "ffi-rzmq", ["2.0.1"]              #(MIT license)
   gem.add_runtime_dependency "filewatch", ["0.5.1"]             #(BSD license)
   gem.add_runtime_dependency "gelfd", ["0.2.0"]                 #(Apache 2.0 license)
   gem.add_runtime_dependency "gelf", ["1.3.2"]                  #(MIT license)


### PR DESCRIPTION
The [documentation for using ZeroMQ as an input](http://logstash.net/docs/1.4.0/inputs/zeromq) states that only version 2.1.x of ZeroMQ is supported. ZeroMQ is now on version 4 and by bumping the `ffi-rzmq` dependency we should be able to support the latest version of ZeroMQ as well.

I was able to make this work locally by replacing the `ffi-rzmq` directory in `vendor/bundle/jruby/1.9/gems` with `ffi-rzmq` 2.0.1 built on JRuby 1.7.9 using `jruby -S gem install ffi-rzmq`. I also had to copy over `ffi-rzmq-core`, but core is a dependency of `ffi-rzmq` so as long as this gets bumped it should resolve that as well when everything gets built.
