### PR TITLE
Start ES embedded server before creating a client.

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -303,7 +303,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     #builder.local(true)
     builder.settings.put("cluster.name", @cluster) if @cluster
     builder.settings.put("node.name", @node_name) if @node_name
-    builder.settings.put("network.host") = @bind_host if @bind_host
+    builder.settings.put("network.host", @bind_host) if @bind_host
     builder.settings.put("http.port", @embedded_http_port)
 
     @embedded_elasticsearch = builder.node


### PR DESCRIPTION
This resolves a startup-delay problem where Node/Transport protocols
would attempt to find a master before continuing, having no master, would wait until a timeout before continuing (and then finally starting the embedded server!)

Manual test:

```
% time bin/logstash -e 'input { generator {  count => 1 } } output { elasticsearch { embedded => true } }'
```

Before this patch:

```
 WARN: org.elasticsearch.discovery: [logstash-ds4172-27071-2010]
 waited for 30s and no initial state was set by the discovery

 qbin/logstash -e   20.50s user 0.70s system 45% cpu 46.793 total
```

After this patch:

```
bin/logstash -e   21.53s user 0.52s system 115% cpu 19.070 total
```
