### PR TITLE
broken link to mongodb at page "Extending logstash" ( #1265 )

### DIFF
--- a/docs/extending/index.md
+++ b/docs/extending/index.md
@@ -12,7 +12,7 @@ If you're looking to extend logstash today, please look at the existing plugins.
 
 * [inputs/tcp](https://github.com/logstash/logstash/blob/master/lib/logstash/inputs/tcp.rb)
 * [filters/multiline](https://github.com/logstash/logstash/blob/master/lib/logstash/filters/multiline.rb)
-* [outputs/mongodb](https://github.com/logstash/logstash/blob/master/lib/logstash/outputs/mongodb.rb)
+* [outputs/mongodb](https://github.com/elasticsearch/logstash-contrib/blob/master/lib/logstash/outputs/mongodb.rb)
 
 ## Common concepts
 


### PR DESCRIPTION
broken link to mongodb at page "Extending logstash" ( #1265 )
