### PR TITLE
Allow spaces in directory names - bash launch scripts

### DIFF
--- a/bin/logstash
+++ b/bin/logstash
@@ -20,7 +20,7 @@ LS_HEAP_SIZE="${LS_HEAP_SIZE:=500m}"
 
 unset CDPATH
 basedir=$(cd `dirname $0`/..; pwd)
-. ${basedir}/bin/logstash.lib.sh
+. "${basedir}/bin/logstash.lib.sh"
 
 setup
 
@@ -33,10 +33,10 @@ case $1 in
   -*) 
     # is the first argument a flag? If so, assume 'agent'
     program="$basedir/lib/logstash/runner.rb"
-    exec $RUBYCMD -I$RUBYLIB "$program" agent "$@"
+    exec $RUBYCMD "$JARFILE" -I"$RUBYLIB" "$program" agent "$@"
     ;;
   *)
     program="$basedir/lib/logstash/runner.rb"
-    exec $RUBYCMD -I$RUBYLIB "$program" "$@"
+    exec $RUBYCMD "$JARFILE" -I"$RUBYLIB" "$program" "$@"
     ;;
 esac

--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -66,7 +66,8 @@ setup_java() {
 setup_vendored_jruby() {
   RUBYVER=1.9
   RUBY=jruby
-  RUBYCMD="$JAVACMD $JAVA_OPTS -jar $basedir/vendor/jar/jruby-complete-*.jar"
+  RUBYCMD="$JAVACMD $JAVA_OPTS -jar"
+  JARFILE=$(ls "$basedir"/vendor/jar/jruby-complete-*.jar)
 }
 
 setup() {


### PR DESCRIPTION
First crack at a fix for LOGSTASH-1983

Two possible issues:

1 - This might break dev using ruby, since we'd be introducing an extra variable. 
2 - If someone does an inplace upgrade with an extra version of jruby getting the jar file will break. Maybe check for more then one item, and error? or find a more elegant way to pick the jar file. 

For the record, can't pass the \* into the exec as it won't be expanded correctly. 
