### PR TITLE
Making the -f option multivalued

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -10,8 +10,9 @@ The logstash agent has the following flags (also try using the '--help' flag)
 
 <dl>
 <dt> -f, --config CONFIGFILE </dt>
-<dd> Load the logstash config from a specific file, directory, or a
-wildcard. If given a directory or wildcard, config files will be read
+<dd> Load the logstash config from a specific files, directories, or
+wildcards. This flag can be given multiple times to include multiple locations
+If given a directory or wildcard, config files will be read
 from the directory in alphabetical order. </dd>
 <dt> -e CONFIGSTRING </dt>
 <dd> Use the given string as the configuration data. Same syntax as the

--- a/lib/logstash/agent.rb
+++ b/lib/logstash/agent.rb
@@ -7,6 +7,7 @@ require "i18n"
 class LogStash::Agent < Clamp::Command
   option ["-f", "--config"], "CONFIG_PATH",
     I18n.t("logstash.agent.flag.config"),
+    :multivalued => true,
     :attribute_name => :config_path
 
   option "-e", "CONFIG_STRING",
@@ -284,24 +285,25 @@ class LogStash::Agent < Clamp::Command
     end
   end # def configure_plugin_path
 
-  def load_config(path)
-    path = File.join(path, "*") if File.directory?(path)
-
-    if Dir.glob(path).length == 0
-      fail(I18n.t("logstash.agent.configuration.file-not-found", :path => path))
-    end
-
+  def load_config(paths)
     config = ""
-    Dir.glob(path).sort.each do |file|
-      next unless File.file?(file)
-      if file.match(/~$/)
-        @logger.debug("NOT reading config file because it is a temp file", :file => file)
-        next
+    paths.each do |path|
+      path = File.join(path, "*") if File.directory?(path)
+
+      if Dir.glob(path).length == 0
+        fail(I18n.t("logstash.agent.configuration.file-not-found", :path => path))
       end
-      @logger.debug("Reading config file", :file => file)
-      config << File.read(file) + "\n"
+      Dir.glob(path).sort.each do |file|
+        next unless File.file?(file)
+        if file.match(/~$/)
+          @logger.debug("NOT reading config file because it is a temp file", :file => file)
+          next
+        end
+        @logger.debug("Reading config file", :file => file)
+        config << File.read(file) + "\n"
+      end
     end
     return config
   end # def load_config
-
+  
 end # class LogStash::Agent

--- a/pkg/build.sh
+++ b/pkg/build.sh
@@ -88,7 +88,7 @@ case $os in
       -a noarch --iteration "1_${RPM_REVISION}" \
       --url "$URL" \
       --description "$DESCRIPTION" \
-      -d "jre >= 1.6.0" \
+      -d "jdk >= 1.6.0" \
       --vendor "Elasticsearch" \
       --license "ASL 2.0" \
       --rpm-use-file-permissions \

--- a/pkg/build.sh
+++ b/pkg/build.sh
@@ -88,7 +88,7 @@ case $os in
       -a noarch --iteration "1_${RPM_REVISION}" \
       --url "$URL" \
       --description "$DESCRIPTION" \
-      -d "jdk >= 1.6.0" \
+      -d "jre >= 1.6.0" \
       --vendor "Elasticsearch" \
       --license "ASL 2.0" \
       --rpm-use-file-permissions \


### PR DESCRIPTION
Changing the flag -f to be multivalued. It's super useful when you want to package custom logstash configurations with your services

```
example:
bin/logstash -f '/etc/logstash/conf.d/*' -f '/services/*/logstash/conf.d/*'
```
