### PR TITLE
Remove the log parameter as web doesn't allow it

### DIFF
--- a/pkg/logstash-web.upstart.ubuntu
+++ b/pkg/logstash-web.upstart.ubuntu
@@ -36,7 +36,6 @@ script
 
   HOME="${HOME:-$LS_HOME}"
   JAVA_OPTS="${LS_JAVA_OPTS}"
-  [ -n "${LS_LOG_FILE}" ] && LS_OPTS="${LSOPTS} -l ${LS_LOG_FILE}"
   # Reset filehandle limit
   ulimit -n ${LS_OPEN_FILES}
   cd "${LS_HOME}"


### PR DESCRIPTION
When I run `/opt/logstash/bin/logstash web -h`, -l is not one of the allowed parameters. When it is started with it, it fails and upstart keeps restarting and failing…
