### PR TITLE
Improve windows first usage experience

### DIFF
--- a/bin/logstash.bat
+++ b/bin/logstash.bat
@@ -69,10 +69,21 @@ goto missing_jruby
 :EXEC
 REM run logstash
 set RUBYLIB=%LS_HOME%\lib
-if "%VENDORED_JRUBY%" == "" (
-%RUBYCMD% "%LS_HOME%\lib\logstash\runner.rb" %*
+REM is the first argument a flag? If so, assume 'agent'
+set first_arg=%1
+setlocal EnableDelayedExpansion
+if "!first_arg:~0,1!" equ "-" (
+  if "%VENDORED_JRUBY%" == "" (
+    %RUBYCMD% "%LS_HOME%\lib\logstash\runner.rb" agent %*
+  ) else (
+    %JRUBY_BIN% %jruby_opts% "%LS_HOME%\lib\logstash\runner.rb" agent %*
+  )
 ) else (
-%JRUBY_BIN% %jruby_opts% "%LS_HOME%\lib\logstash\runner.rb" %*
+  if "%VENDORED_JRUBY%" == "" (
+    %RUBYCMD% "%LS_HOME%\lib\logstash\runner.rb" %*
+  ) else (
+    %JRUBY_BIN% %jruby_opts% "%LS_HOME%\lib\logstash\runner.rb" %*
+  )
 )
 goto finally
 


### PR DESCRIPTION
The current getting started guide makes heavy use of the -e flag and the fact that "agent" is supposed by the logstash.sh script.
It was not the case in windows bat 

Also, I suppose most windows user will easily replace "bin/logstash" with "bin\logstash" however using single quote on the doc for -e will never work for them. Would you mind switching to double quote, at least in the getting started guide to ease the copy-paste testing.
