### PR TITLE
Common solution for loading custom jars

### DIFF
--- a/lib/logstash/environment.rb
+++ b/lib/logstash/environment.rb
@@ -15,13 +15,19 @@ module LogStash
     # loads currently embedded elasticsearch jars
     # @raise LogStash::EnvironmentError if not running under JRuby or if no jar files are found
     def load_elasticsearch_jars!
+      load_jars!(ELASTICSEARCH_DIR, "**","*.jar")
+    end
+
+    # loads specific jars located under vendor/jar
+    # @raise LogStash::EnvironmentError if not running under JRuby or if no jar files are found
+    def load_jars!(*jars_path)
       raise(LogStash::EnvironmentError, "JRuby is required") unless jruby?
 
       require "java"
-      jars_path = ::File.join(ELASTICSEARCH_DIR, "**", "*.jar")
+      jars_path = ::File.join(jars_subpath)
       jar_files = Dir.glob(jars_path)
 
-      raise(LogStash::EnvironmentError, "Could not find Elasticsearch jar files under #{ELASTICSEARCH_DIR}") if jar_files.empty?
+      raise(LogStash::EnvironmentError, "Could not find jar files under #{jars_path}") if jar_files.empty?
 
       jar_files.each do |jar|
         loaded = require jar

--- a/lib/logstash/environment.rb
+++ b/lib/logstash/environment.rb
@@ -18,7 +18,7 @@ module LogStash
       load_jars!(ELASTICSEARCH_DIR, "**","*.jar")
     end
 
-    # loads specific jars located under vendor/jar
+    # loads specific jars located under jars_path
     # @raise LogStash::EnvironmentError if not running under JRuby or if no jar files are found
     def load_jars!(*jars_path)
       raise(LogStash::EnvironmentError, "JRuby is required") unless jruby?

--- a/lib/logstash/environment.rb
+++ b/lib/logstash/environment.rb
@@ -24,7 +24,7 @@ module LogStash
       raise(LogStash::EnvironmentError, "JRuby is required") unless jruby?
 
       require "java"
-      jars_path = ::File.join(jars_subpath)
+      jars_path = ::File.join(jars_path)
       jar_files = Dir.glob(jars_path)
 
       raise(LogStash::EnvironmentError, "Could not find jar files under #{jars_path}") if jar_files.empty?

--- a/spec/util/environment_spec.rb
+++ b/spec/util/environment_spec.rb
@@ -17,11 +17,11 @@ describe LogStash::Environment do
   describe "load_jars!" do
 
     it "should load custom jars" do
-      expect{LogStash::Environment.load_jars!("/jruby-complete*.jar")}.to_not raise_error
+      expect{LogStash::Environment.load_jars!("jruby-complete*.jar")}.to_not raise_error
     end
 
     it "should raise when cannot find jars" do
-      expect{LogStash::Environment.load_jars!("/non-exisiting/jar.jar")}.to raise_error(LogStash::EnvironmentError)
+      expect{LogStash::Environment.load_jars!("non-exisiting","jar.jar")}.to raise_error(LogStash::EnvironmentError)
     end
   end
 end

--- a/spec/util/environment_spec.rb
+++ b/spec/util/environment_spec.rb
@@ -9,19 +9,18 @@ describe LogStash::Environment do
     end
 
     it "should raise when cannot find elasticsearch jars" do
-      stub_const("LogStash::Environment::JAR_DIR", "/some/invalid/path")
+      stub_const("LogStash::Environment::ELASTICSEARCH_DIR", "/some/invalid/path")
       expect{LogStash::Environment.load_elasticsearch_jars!}.to raise_error(LogStash::EnvironmentError)
     end
   end
 
   describe "load_jars!" do
-
     it "should load custom jars" do
-      expect{LogStash::Environment.load_jars!("jruby-complete*.jar")}.to_not raise_error
+      expect{LogStash::Environment.load_jars!(LogStash::Environment::LOGSTASH_HOME,"vendor","jruby","lib","jruby.jar")}.to_not raise_error
     end
 
     it "should raise when cannot find jars" do
-      expect{LogStash::Environment.load_jars!("non-exisiting","jar.jar")}.to raise_error(LogStash::EnvironmentError)
+      expect{LogStash::Environment.load_jars!(LogStash::Environment::LOGSTASH_HOME,"non-exisiting","jar.jar")}.to raise_error(LogStash::EnvironmentError)
     end
   end
 end

--- a/spec/util/environment_spec.rb
+++ b/spec/util/environment_spec.rb
@@ -2,4 +2,26 @@ require "logstash/environment"
 
 describe LogStash::Environment do
 
+  describe "load_elasticsearch_jars!" do
+
+    it "should load elasticsarch jars" do
+      expect{LogStash::Environment.load_elasticsearch_jars!}.to_not raise_error
+    end
+
+    it "should raise when cannot find elasticsearch jars" do
+      stub_const("LogStash::Environment::JAR_DIR", "/some/invalid/path")
+      expect{LogStash::Environment.load_elasticsearch_jars!}.to raise_error(LogStash::EnvironmentError)
+    end
+  end
+
+  describe "load_jars!" do
+
+    it "should load custom jars" do
+      expect{LogStash::Environment.load_jars!("/jruby-complete*.jar")}.to_not raise_error
+    end
+
+    it "should raise when cannot find jars" do
+      expect{LogStash::Environment.load_jars!("/non-exisiting/jar.jar")}.to raise_error(LogStash::EnvironmentError)
+    end
+  end
 end


### PR DESCRIPTION
Building on top of good work of @colinsurprenant in #1233, 
logstash can now almost propose a common solution for loading jars present under vendor/jar
I'm working on jdbc related plugin (input/filter) and this patch would permit me to load the required jar in one line in the register method like:
````
def register
  LogStash::Environment.load_jars!(@driver_jar)
  #Cannot use driver manager (https://jira.codehaus.org/browse/JRUBY-7174)
  @driver = Java::JavaClass.for_name(@driver_class).ruby_class.new
end
