### PR TITLE
fix gelf input for the LOGSTASH-1595 utf-8 decoding issue

### DIFF
--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -14,7 +14,8 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
   config_name "gelf"
   milestone 2
 
-  default :codec, "plain"
+  # The gelf payload is utf-8-encoded json by specification, so this should normally not be changed
+  default :codec, "json"
 
   # The IP address or hostname to listen on.
   config :host, :validate => :string, :default => "0.0.0.0"
@@ -89,16 +90,17 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
       # Gelfd parser outputs null if it received and cached a non-final chunk
       next if data.nil?
 
-      event = LogStash::Event.new(JSON.parse(data))
-      event["source_host"] = client[3]
-      if event["timestamp"].is_a?(Numeric)
-        event["@timestamp"] = Time.at(event["timestamp"]).gmtime
-        event.remove("timestamp")
+      @codec.decode(data) do |event| 
+        event["source_host"] = client[3]
+        if event["timestamp"].is_a?(Numeric)
+          event["@timestamp"] = Time.at(event["timestamp"]).gmtime
+          event.remove("timestamp")
+        end
+        remap_gelf(event) if @remap
+        strip_leading_underscore(event) if @strip_leading_underscore
+        decorate(event)
+        output_queue << event
       end
-      remap_gelf(event) if @remap
-      strip_leading_underscore(event) if @strip_leading_underscore
-      decorate(event)
-      output_queue << event
     end
   rescue LogStash::ShutdownSignal
     # Do nothing, shutdown.
@@ -131,5 +133,5 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
        event[key[1..-1]] = event[key]
        event.remove(key)
      end
-  end # deef removing_leading_underscores
+  end # def strip_leading_underscore
 end # class LogStash::Inputs::Gelf

--- a/spec/inputs/gelf.rb
+++ b/spec/inputs/gelf.rb
@@ -6,7 +6,7 @@ describe "inputs/gelf" do
 
   describe "reads chunked gelf messages " do
     port = 12209
-    host = "127.0.0.1"
+    host = "127.0.111.1"
     chunksize = 1420
     gelfclient = GELF::Notifier.new(host,port,chunksize)
 
@@ -34,7 +34,8 @@ input {
       [ "hello", 
         "world", 
         large_random, 
-        "we survived gelf!" 
+        "we survived gelf!",
+        "some UTF chars too: h\u{20AC}ll\u{C3B3} japale\u{C3B1}o ..."
       ].each do |m| 
   	gelfclient.notify!( "short_message" => m )
         # poll at most 10 times 


### PR DESCRIPTION
This patch fixes the gelf input for https://logstash.jira.com/browse/LOGSTASH-1595, by migrating it to the 1.2 codec mechanism, and reusing the json codec.