### PR TITLE
Enable geoip file caching

### DIFF
--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -90,7 +90,7 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
     # not set as a global. The geoip module imposes a mutex, so the filter needs
     # to re-initialize this later in the filter() thread, and save that access
     # as a thread-local variable.
-    geoip_initialize = ::GeoIP.new(@database)
+    geoip_initialize = ::GeoIP.new(@database, :preload => true)
 
     @geoip_type = case geoip_initialize.database_type
     when GeoIP::GEOIP_CITY_EDITION_REV0, GeoIP::GEOIP_CITY_EDITION_REV1

--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "xml-simple"                       #(ruby license?)
   gem.add_runtime_dependency "xmpp4r", ["0.5"]                  #(ruby license)
   gem.add_runtime_dependency "jls-lumberjack", [">=0.0.20"]     #(Apache 2.0 license)
-  gem.add_runtime_dependency "geoip", [">= 1.3.2"]              #(GPL license)
+  gem.add_runtime_dependency "geoip", [">= 1.4.0"]              #(GPL license)
   gem.add_runtime_dependency "beefcake", "0.3.7"                #(MIT license)
   gem.add_runtime_dependency "murmurhash3"                      #(MIT license)
   gem.add_runtime_dependency "rufus-scheduler", "~> 2.0.24"     #(MIT license)


### PR DESCRIPTION
Enable geoip file caching, which increases performance by roughly 25%. I tested three scenarios:

1. No geoip lookups: ~1250 messages per second.
1. Geoip lookups with 1.4.0 setup (no caching): ~1000 messages per second.
1. Geoip lookups with caching as per this PR: ~1250 messages per second.

The fix is updating the geoip gem to 1.4.0, set option preload to true.

See issue https://logstash.jira.com/browse/LOGSTASH-2158