### PR TITLE
Correctly set nice and ulimit -n

### DIFF
--- a/pkg/logstash.sysv
+++ b/pkg/logstash.sysv
@@ -49,10 +49,13 @@ start() {
 
   JAVA_OPTS=${LS_JAVA_OPTS}
   export PATH HOME JAVA_OPTS LS_HEAP_SIZE LS_JAVA_OPTS LS_USE_GC_LOGGING
+
+  # set ulimit as (root, presumably) first, before we drop privileges
+  ulimit -n ${LS_OPEN_FILES}
+
   # Run the program!
-  chroot --userspec $LS_USER:$LS_GROUP / sh -c "
+  nice -n ${LS_NICE} chroot --userspec $LS_USER:$LS_GROUP / sh -c "
     cd $LS_HOME
-    nice ${LS_NICE}
     ulimit -n ${LS_OPEN_FILES}
     exec \"$program\" $args
   " > "${LS_LOG_DIR}/$name.stdout" 2> "${LS_LOG_DIR}/$name.err" &


### PR DESCRIPTION
Previously, 'nice' was invoked incorrectly, and 'ulimit -n' would often
fail because growing it as a non-privileged user is denied.
