### PR TITLE
Pass correct HOME env into chroot

### DIFF
--- a/pkg/logstash.sysv
+++ b/pkg/logstash.sysv
@@ -48,6 +48,7 @@ start() {
 
 
   JAVA_OPTS=${LS_JAVA_OPTS}
+  HOME=${LS_HOME}
   export PATH HOME JAVA_OPTS LS_HEAP_SIZE LS_JAVA_OPTS LS_USE_GC_LOGGING
 
   # set ulimit as (root, presumably) first, before we drop privileges


### PR DESCRIPTION
Without this patch the logstash isn't able to start on Debian 7 while using file input, as both `HOME` and `SINCEDB_DIR` aren't set in chroot.

Simple `echo` claims that `HOME` isn't set before the export. At least on Debian. Also `chroot --userspec` doesn't change the `HOME` env either.
