### PR TITLE
fix ipv6 support for geoip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ GEOIP=vendor/geoip/GeoLiteCity.dat
 GEOIP_URL=http://logstash.objects.dreamhost.com/maxmind/GeoLiteCity-2013-01-18.dat.gz
 GEOIP_ASN=vendor/geoip/GeoIPASNum.dat
 GEOIP_ASN_URL=http://logstash.objects.dreamhost.com/maxmind/GeoIPASNum-2014-02-12.dat.gz
+GEOIPV6=vendor/geoip/GeoLiteCityv6.dat
+GEOIPV6_URL=http://geolite.maxmind.com/download/geoip/database/GeoLiteCityv6-beta/GeoLiteCityv6.dat.gz
 KIBANA_URL=https://download.elasticsearch.org/kibana/kibana/kibana-3.0.1.tar.gz
 PLUGIN_FILES=$(shell find lib -type f| egrep '^lib/logstash/(inputs|outputs|filters|codecs)/[^/]+$$' | egrep -v '/(base|threadable).rb$$|/inputs/ganglia/')
 QUIET=@
@@ -160,7 +162,7 @@ vendor/geoip: | vendor
 	$(QUIET)mkdir $@
 
 .PHONY: vendor-geoip
-vendor-geoip: $(GEOIP) $(GEOIP_ASN)
+vendor-geoip: $(GEOIP) $(GEOIP_ASN) $(GEOIPV6)
 $(GEOIP): | vendor/geoip
 	$(QUIET)$(DOWNLOAD_COMMAND) $@.tmp.gz $(GEOIP_URL)
 	$(QUIET)gzip -dc $@.tmp.gz > $@.tmp
@@ -169,6 +171,12 @@ $(GEOIP): | vendor/geoip
 
 $(GEOIP_ASN): | vendor/geoip
 	$(QUIET)$(DOWNLOAD_COMMAND) $@.tmp.gz $(GEOIP_ASN_URL)
+	$(QUIET)gzip -dc $@.tmp.gz > $@.tmp
+	$(QUIET)rm "$@.tmp.gz"
+	$(QUIET)mv $@.tmp $@
+
+$(GEOIPV6): | vendor/geoip
+	$(QUIET)$(DOWNLOAD_COMMAND) $@.tmp.gz $(GEOIPV6_URL)
 	$(QUIET)gzip -dc $@.tmp.gz > $@.tmp
 	$(QUIET)rm "$@.tmp.gz"
 	$(QUIET)mv $@.tmp $@

--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -77,9 +77,9 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
     geoip_initialize = ::GeoIP.new(@database)
 
     @geoip_type = case geoip_initialize.database_type
-    when GeoIP::GEOIP_CITY_EDITION_REV0, GeoIP::GEOIP_CITY_EDITION_REV1
+    when GeoIP::GEOIP_CITY_EDITION_REV0, GeoIP::GEOIP_CITY_EDITION_REV1, GeoIP::GEOIP_CITY_EDITION_REV1_V6
       :city
-    when GeoIP::GEOIP_COUNTRY_EDITION
+    when GeoIP::GEOIP_COUNTRY_EDITION, GeoIP::GEOIP_COUNTRY_EDITION_V6
       :country
     when GeoIP::GEOIP_ASNUM_EDITION
       :asn


### PR DESCRIPTION
Simple fix to support the IPv6 databases in the filter.

Fixes 
- https://logstash.jira.com/browse/LOGSTASH-1100

and partly
- https://logstash.jira.com/browse/LOGSTASH-1124
- https://logstash.jira.com/browse/LOGSTASH-2163
