### PR TITLE
Config option for hipchat server

### DIFF
--- a/lib/logstash/outputs/hipchat.rb
+++ b/lib/logstash/outputs/hipchat.rb
@@ -29,8 +29,8 @@ class LogStash::Outputs::HipChat < LogStash::Outputs::Base
   # Message format to send, event tokens are usable here.
   config :format, :validate => :string, :default => "%{message}"
 
-  # HipChat server to use
-  config :server, :validate => :string, :default => "api.hipchat.com"
+  # HipChat host to use
+  config :host, :validate => :string, :default => "api.hipchat.com"
 
   public
   def register
@@ -39,7 +39,7 @@ class LogStash::Outputs::HipChat < LogStash::Outputs::Base
 
     @agent = FTW::Agent.new
 
-    @url = "https://" + @server + "/v1/rooms/message?auth_token=" + @token
+    @url = "https://" + @host + "/v1/rooms/message?auth_token=" + @token
     @content_type = "application/x-www-form-urlencoded"
   end # def register
 


### PR DESCRIPTION
Hipchat server beta is open, this lets you specify an alternate server, could also be done as the full api url. Comments welcome.
