### PR TITLE
Fix broken congestion_interval

### DIFF
--- a/lib/logstash/outputs/redis.rb
+++ b/lib/logstash/outputs/redis.rb
@@ -188,7 +188,7 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
         @logger.warn? and @logger.warn("Redis key size has hit a congestion threshold #{@congestion_threshold} suspending output for #{@congestion_interval} seconds")
         sleep @congestion_interval
       end
-      @congestion_check_time = Time.now.to_i
+      @congestion_check_times[key] = Time.now.to_i
     end
   end
 


### PR DESCRIPTION
Congestion check seems to run for redis for every single even passing through, or for every batch if using batches. I reproduced the issue on my platform and fixed it. Seems it didn't affect me as much as I was using large batches.

This was reported on the mailing list and here is the fix, which I've tested on my platform.
