### PR TITLE
Sanitize output/redis error logs

### DIFF
--- a/lib/logstash/outputs/redis.rb
+++ b/lib/logstash/outputs/redis.rb
@@ -246,7 +246,7 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
 
   # A string used to identify a Redis instance in log messages
   def identity
-    @name || "redis://#{@password}@#{@current_host}:#{@current_port}/#{@db} #{@data_type}:#{@key}"
+    @name || "redis://#{@current_host}:#{@current_port}/#{@db} #{@data_type}:#{@key}"
   end
 
 end


### PR DESCRIPTION
Redis output error logs should not report (redis) server passwords to the log entries which may be readable by non-authorized users.
