### PR TITLE
Updating ffi-rzmq

### DIFF
--- a/lib/logstash/inputs/zeromq.rb
+++ b/lib/logstash/inputs/zeromq.rb
@@ -5,7 +5,7 @@ require "socket"
 
 # Read events over a 0MQ SUB socket.
 #
-# You need to have the 0mq 2.1.x library installed to be able to use
+# You need to have the 0mq 3.2.x or 4.x library installed to be able to use
 # this input plugin.
 #
 # The default settings will create a subscriber binding to tcp://127.0.0.1:2120 

--- a/lib/logstash/inputs/zeromq.rb
+++ b/lib/logstash/inputs/zeromq.rb
@@ -59,8 +59,8 @@ class LogStash::Inputs::ZeroMQ < LogStash::Inputs::Base
 
   # 0mq socket options
   # This exposes zmq_setsockopt
-  # for advanced tuning
-  # see http://api.zeromq.org/2-1:zmq-setsockopt for details
+  # for advanced tuning.
+  # Read about zmq-setsockopt details on http://api.zeromq.org/, accordingly to you 0mq version.
   #
   # This is where you would set values like:
   # ZMQ::HWM - high water mark

--- a/lib/logstash/outputs/zeromq.rb
+++ b/lib/logstash/outputs/zeromq.rb
@@ -4,7 +4,7 @@ require "logstash/namespace"
 
 # Write events to a 0MQ PUB socket.
 #
-# You need to have the 0mq 2.1.x library installed to be able to use
+# You need to have the 0mq 3.2.x or 4.x library installed to be able to use
 # this output plugin.
 #
 # The default settings will create a publisher connecting to a subscriber
@@ -46,7 +46,7 @@ class LogStash::Outputs::ZeroMQ < LogStash::Outputs::Base
   config :mode, :validate => ["server", "client"], :default => "client"
 
   # This exposes zmq_setsockopt for advanced tuning.
-  # See http://api.zeromq.org/2-1:zmq-setsockopt for details.
+  # Read about zmq-setsockopt details on http://api.zeromq.org/, accordingly to you 0mq version.
   #
   # This is where you would set values like:
   #

--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "addressable"                      #(Apache 2.0 license)
   gem.add_runtime_dependency "extlib", ["0.9.16"]               #(MIT license)
   gem.add_runtime_dependency "ffi"                              #(LGPL-3 license)
-  gem.add_runtime_dependency "ffi-rzmq", ["1.0.0"]              #(MIT license)
+  gem.add_runtime_dependency "ffi-rzmq", ["2.0.1"]              #(MIT license)
   gem.add_runtime_dependency "filewatch", ["0.5.1"]             #(BSD license)
   gem.add_runtime_dependency "gelfd", ["0.2.0"]                 #(Apache 2.0 license)
   gem.add_runtime_dependency "gelf", ["1.3.2"]                  #(MIT license)


### PR DESCRIPTION
When testing logstash with zeromq input plugin, there was an incompatibility with libzmq, version 4.0.4:

./logstash agent -e "input { zeromq { topology => 'pubsub' mode => 'client' address => 'tcp://<ip>:<port>' } } output { stdout{} }"

Using milestone 2 input plugin 'zeromq'. This plugin should be stable, but if you see strange behavior, please let us know! For more information on plugin milestones, see http://logstash.net/docs/1.4.1/plugin-milestones {:level=>:warn}
LoadError: The libzmq version 4.0.4 is incompatible with ffi-rzmq.

This issue makes it impossible to use logstash with newer versions of 0MQ. Updating ffi-rzmq gem to version 2.0.1, which supports 0mq 4.x API, seems to solve the problem with zeromq plugin.