### PR TITLE
Stop filterworker and outputworker from crashing

### DIFF
--- a/lib/logstash/pipeline.rb
+++ b/lib/logstash/pipeline.rb
@@ -220,9 +220,13 @@ class LogStash::Pipeline
     @outputs.each(&:register)
     @outputs.each(&:worker_setup)
     while true
-      event = @filter_to_output.pop
-      break if event == LogStash::ShutdownSignal
-      output(event)
+      begin
+        event = @filter_to_output.pop
+        break if event == LogStash::ShutdownSignal
+        output(event)
+      rescue => e
+        @logger.error("Exception in outputworker", "exception" => e, "backtrace" => e.backtrace)
+      end
     end # while true
     @outputs.each(&:teardown)
   end # def outputworker

--- a/lib/logstash/pipeline.rb
+++ b/lib/logstash/pipeline.rb
@@ -186,8 +186,8 @@ class LogStash::Pipeline
 
   def filterworker
     LogStash::Util::set_thread_name("|worker")
-    begin
-      while true
+    while true
+      begin
         event = @input_to_filter.pop
         if event == LogStash::ShutdownSignal
           @input_to_filter.push(event)
@@ -207,9 +207,9 @@ class LogStash::Pipeline
           next if event.cancelled?
           @filter_to_output.push(event)
         end
+      rescue => e
+        @logger.error("Exception in filterworker", "exception" => e, "backtrace" => e.backtrace)
       end
-    rescue => e
-      @logger.error("Exception in filterworker", "exception" => e, "backtrace" => e.backtrace)
     end
 
     @filters.each(&:teardown)


### PR DESCRIPTION
When an exception is thrown during event processing, logstash may stop accepting data or crash altogether (cf. LOGSTASH-1353, LOGSTASH-1440 or LOGSTASH-1872).

I have commited two changes that make logstash continue working after encountering an exception. To test the patches, you can use the following configs.

For the filterworker case:

```
input {
  generator {
    lines => [
      "A%C3O",
      "foobar"
    ]
    count => 1
  }
}
filter {
  urldecode { }
  kv { }
}
output {
  stdout { }
}
```

For the outputworker case:

```
input {
  generator {
    lines => [
      "A%C3O",
      "foobar"
    ]
    count => 1
  }
}
filter {
  urldecode { }
}
output {
  stdout { codec => json {} }
}
```

Please consider including these patches in the next release. Thanks.
