### PR TITLE
Don't install development gems.

### DIFF
--- a/gembag.rb
+++ b/gembag.rb
@@ -65,7 +65,7 @@ end
 # Try installing a few times in case we hit the "bad_record_mac" ssl error during installation.
 10.times do
   begin
-    Bundler::CLI.start(["install", "--gemfile=tools/Gemfile", "--path", target, "--clean"])
+    Bundler::CLI.start(["install", "--gemfile=tools/Gemfile", "--path", target, "--clean", "--without", "development"])
     break
   rescue Gem::RemoteFetcher::FetchError => e
     puts e.message


### PR DESCRIPTION
For whatever reason, the 'development' group is installed by default via
bundler. This was not intentiona.

The effect is that we might be unintentionally violating a dependency's
license (term-ansicolor is GPL2) by including it in our release.
Definitely do not wish such things.

With this patch, the next run of `bin/logstash deps` shows all dev
dependencies being removed:

```
Removing coveralls (0.7.0)
Removing docile (1.1.3)
Removing kramdown (1.3.3)
Removing rest-client (1.6.7)
Removing simplecov (0.8.2)
Removing simplecov-html (0.8.0)
Removing term-ansicolor (1.3.0)
Removing thor (0.18.1)
Removing tins (1.0.0)
```

Fixes #1372
