### PR TITLE
Disable coverage for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ test: | $(JRUBY) vendor-elasticsearch vendor-geoip vendor-collectd vendor-gems
 	$(SPEC_ENV) USE_JRUBY=1 bin/logstash rspec $(SPEC_OPTS) --order rand --fail-fast $(TESTS)
 
 .PHONY: reporting-test
-reporting-test: SPEC_ENV=JRUBY_OPTS=--debug COVERAGE=TRUE
+reporting-test: SPEC_ENV=JRUBY_OPTS=--debug
 reporting-test: SPEC_OPTS=--format CI::Reporter::RSpec
 reporting-test: | test
 


### PR DESCRIPTION
This is to make tests run. Currently we are not using coverage reports,
and a recent fix to remove development dependencies from the normal
installation has caused coverage dependencies to be removed and thus
fail.

We will revert this once we figure out how to make tests run with
separate bundler groups.
