### PR TITLE
Fix LOGSTASH-1886 by updating march_hare

### DIFF
--- a/lib/logstash/outputs/rabbitmq/march_hare.rb
+++ b/lib/logstash/outputs/rabbitmq/march_hare.rb
@@ -44,7 +44,7 @@ class LogStash::Outputs::RabbitMQ
         else
           @logger.warn("Tried to send a message, but not connected to RabbitMQ.")
         end
-      rescue MarchHare::Exception, com.rabbitmq.client.AlreadyClosedException => e
+      rescue MarchHare::Exception, IOError, com.rabbitmq.client.AlreadyClosedException => e
         @connected.set(false)
         n = 10
 

--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -76,7 +76,7 @@ Gem::Specification.new do |gem|
   if RUBY_PLATFORM != 'java'
     gem.add_runtime_dependency "bunny",       ["~> 1.1.8"]  #(MIT license)
   else
-    gem.add_runtime_dependency "march_hare", ["~> 2.1.0"] #(MIT license)
+    gem.add_runtime_dependency "march_hare", ["~> 2.2.0"] #(MIT license)
   end
 
   if RUBY_VERSION >= '1.9.1'


### PR DESCRIPTION
Logstash crashed because under certain conditions, an exception wasn't
handled properly in march_hare. This has been corrected in version
2.2.0.
