### PR TITLE
Making the Java class pattern stricter.

### DIFF
--- a/patterns/java
+++ b/patterns/java
@@ -1,3 +1,3 @@
-JAVACLASS (?:[a-zA-Z0-9-]+\.)+[A-Za-z0-9$_]+
+JAVACLASS (?:[a-zA-Z$_][a-zA-Z$_0-9]*\.)+[a-zA-Z$_][a-zA-Z$_0-9]*
 JAVAFILE (?:[A-Za-z0-9_. -]+)
 JAVASTACKTRACEPART at %{JAVACLASS:class}\.%{WORD:method}\(%{JAVAFILE:file}:%{NUMBER:line}\)


### PR DESCRIPTION
Previously, the pattern matched strings which start with numbers (e.g. "1foo") and strings which contain hyphens (e.g. "foo-bar"). Neither of these are legal Java class names, resulting in occasional incorrect log parsing.

See the Java language specification, section 3.8: http://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.8

Strictly speaking, it's also possible to use many non-ASCII characters in class names, but I've ignored that here.

(p.s I'm going through the process of approving CLA with legal, should be done soon. In the meantime, any feedback on the patch would be welcome.)
