### PR TITLE
Add access to HOSTNAME enviroment variable

### DIFF
--- a/bin/logstash
+++ b/bin/logstash
@@ -24,8 +24,15 @@ basedir=$(cd `dirname $0`/..; pwd)
 
 setup
 
+# If we don't have the HOSTNAME enviroment (which is BASH specific), grab it using hostname
+if [ ! -n "$HOSTNAME" ] 
+then
+    HOSTNAME=$(hostname)
+fi
+
 # Export these so that they can be picked up by file input (and others?).
-export HOME SINCEDB_DIR
+# Make HOSTNAME available to ENV
+export HOME SINCEDB_DIR HOSTNAME
 
 case $1 in
   deps) install_deps ;;


### PR DESCRIPTION
$HOSTNAME is a bash specific variable, and not exported by default.

This PR will check to see if the BASH $HOSTNAME is available, otherwise set it using the hostname command. 

Then, EXPORT this variable for access using the ENV filter. 
