### PR TITLE
Fix for chroot not getting supplemental groups

### DIFF
--- a/pkg/logstash.sysv
+++ b/pkg/logstash.sysv
@@ -52,7 +52,7 @@ start() {
 
   # chown doesn't grab the suplimental groups when setting the user:group - so we have to do it for it.
   # Boy, I hope we're root here. 
-  SGROUPS=$(grep "$LS_USER" /etc/group | grep -v "^$LS_GROUP" | cut -d: -f1 | tr "\\n" "," | sed 's/,$//'; echo '')
+  SGROUPS=$(id -Gn "$LS_USER" | tr " " "," | sed 's/,$//'; echo '')
 
   if [ ! -z $SGROUPS ]
   then

--- a/pkg/logstash.sysv
+++ b/pkg/logstash.sysv
@@ -54,11 +54,16 @@ start() {
   # Boy, I hope we're root here. 
   SGROUPS=$(grep "$LS_USER" /etc/group | grep -v "^$LS_GROUP" | cut -d: -f1 | tr "\\n" "," | sed 's/,$//'; echo '')
 
+  if [ ! -z $SGROUPS ]
+  then
+	EXTRA_GROUPS="--groups $SGROUPS"
+  fi
+
   # set ulimit as (root, presumably) first, before we drop privileges
   ulimit -n ${LS_OPEN_FILES}
 
   # Run the program!
-  nice -n ${LS_NICE} chroot --userspec $LS_USER:$LS_GROUP --groups $SGROUPS / sh -c "
+  nice -n ${LS_NICE} chroot --userspec $LS_USER:$LS_GROUP $EXTRA_GROUPS / sh -c "
     cd $LS_HOME
     ulimit -n ${LS_OPEN_FILES}
     exec \"$program\" $args

--- a/pkg/logstash.sysv
+++ b/pkg/logstash.sysv
@@ -50,11 +50,15 @@ start() {
   JAVA_OPTS=${LS_JAVA_OPTS}
   export PATH HOME JAVA_OPTS LS_HEAP_SIZE LS_JAVA_OPTS LS_USE_GC_LOGGING
 
+  # chown doesn't grab the suplimental groups when setting the user:group - so we have to do it for it.
+  # Boy, I hope we're root here. 
+  SGROUPS=$(grep "$LS_USER" /etc/group | grep -v "^$LS_GROUP" | cut -d: -f1 | tr "\\n" "," | sed 's/,$//'; echo '')
+
   # set ulimit as (root, presumably) first, before we drop privileges
   ulimit -n ${LS_OPEN_FILES}
 
   # Run the program!
-  nice -n ${LS_NICE} chroot --userspec $LS_USER:$LS_GROUP / sh -c "
+  nice -n ${LS_NICE} chroot --userspec $LS_USER:$LS_GROUP --groups $SGROUPS / sh -c "
     cd $LS_HOME
     ulimit -n ${LS_OPEN_FILES}
     exec \"$program\" $args


### PR DESCRIPTION
linux chroot doesn't get the supplemental groups before dropping privileges. As such, we need to pull it from /etc/group and tweak it so that we can send them to chroot. 

Original report came from @spuder on irc -- here is his GIST report: 

https://gist.github.com/spuder/a1c3c7d10ce129507858

Spuder tested this and reported it working. Should work on other systems that use sysv init. 