### PR TITLE
Updating JAVASTACKTRACEPART to recognise native methods and methods with numbers

### DIFF
--- a/patterns/java
+++ b/patterns/java
@@ -1,3 +1,3 @@
 JAVACLASS (?:[a-zA-Z0-9-]+\.)+[A-Za-z0-9$_]+
 JAVAFILE (?:[A-Za-z0-9_. -]+)
-JAVASTACKTRACEPART at %{JAVACLASS:class}\.%{WORD:method}\(%{JAVAFILE:file}:%{NUMBER:line}\)
+JAVASTACKTRACEPART at %{JAVACLASS:class}\.(?<method>[a-zA-Z_$][a-zA-Z0-9_$]*)\(((Native Method)|(Unknown Source)|(%{JAVAFILE:file}:%{NUMBER:line}))\)


### PR DESCRIPTION
For example:

```
    at sun.nio.ch.FileDispatcherImpl.read0(Native Method)
```

This does not have a filename or line number, and the method name
'read0' does not match the WORD pattern.
