### PR TITLE
Restore dependency to jruby-win32ole

### DIFF
--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -67,6 +67,7 @@ Gem::Specification.new do |gem|
     gem.add_runtime_dependency "jruby-httpclient"                 #(Apache 2.0 license)
     gem.add_runtime_dependency "bouncy-castle-java", "1.5.0147"   #(MIT license)
     gem.add_runtime_dependency "jruby-openssl", "0.8.7"           #(CPL/GPL/LGPL license)
+    gem.add_runtime_dependency "jruby-win32ole"                   #(unknown license)
     gem.add_runtime_dependency "msgpack-jruby"                    #(Apache 2.0 license)
   else
     gem.add_runtime_dependency "excon"    #(MIT license)


### PR DESCRIPTION
During the split between core and contrib, the jruby-win32ole dependency was removed in this commit
https://github.com/elasticsearch/logstash/commit/bc2e9b677bdee5faf72d1a18c4012602a94c76fc

However it is required by the eventlog input that is still a core plugin.
Fix LOGSTASH-2004 and LOGSTASH-2227
