### PR TITLE
Replace Time.parse with Time.iso8601

### DIFF
--- a/lib/logstash/time_addon.rb
+++ b/lib/logstash/time_addon.rb
@@ -17,9 +17,8 @@ module LogStash::Time
     end
   else
     def self.parse_iso8601(t)
-      # Warning, ruby's Time.parse is *really* terrible and slow.
       return unless t.is_a?(String)
-      return Time.parse(t).gmtime
+      return Time.iso8601(t).gmtime
     end
   end
 end # module LogStash::Time


### PR DESCRIPTION
I noticed that the `LogStash::Event` constructor calls `LogStash::Time.parse_iso8601`. In MRI, this calls `Time.parse`. The comment says it all: "Warning, ruby's Time.parse is *really* terrible and slow." Luckily, Ruby has an ISO8601 parsing method built into the standard library: `Time.iso8601`.

I ran the event RSpec benchmarks in MRI Ruby 2.1.2 and here are the results:

Before: `event @timestamp parse rate: 30851/sec, elapsed: 32.413648s`
After: `event @timestamp parse rate: 71543/sec, elapsed: 13.977632s`

So the rate more than doubled.

I also created a [Gist](https://gist.github.com/dwbutler/51657198746c93103e08) benchmarking `Time.parse` vs `Time.iso8601` in MRI and JRuby, vs the Joda implementation in JRuby.