### PR TITLE
fix for LOGSTASH-1469

### DIFF
--- a/lib/logstash/inputs/redis.rb
+++ b/lib/logstash/inputs/redis.rb
@@ -252,13 +252,20 @@ EOF
 
   public
   def teardown
-    if @data_type == 'channel' and @redis
-      @redis.unsubscribe
-      @redis.quit
-      @redis = nil
-    end
-    if @data_type == 'pattern_channel' and @redis
-      @redis.punsubscribe
+    begin 
+      if @data_type == 'channel' and @redis
+        @redis.unsubscribe
+        @redis.quit
+        @redis = nil
+      end
+      if @data_type == 'pattern_channel' and @redis
+        @redis.punsubscribe
+        @redis.quit
+        @redis = nil
+      end
+    rescue => e
+      @logger.warn("Redis reconnection problem", :execption => e,
+                   :backtrace => e.backtrace)
       @redis.quit
       @redis = nil
     end


### PR DESCRIPTION
This will fix LOGSTASH-1469 by catching the exception thrown by the Redis gem in the case of trying to unsubscribe or punsubscribe to a not existent connection.