### PR TITLE
Don't crash when event has no tags

### DIFF
--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -347,7 +347,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
  def self.format_message(event)
     message = "Date: #{event["@timestamp"]}\n"
     message << "Source: #{event["source"]}\n"
-    message << "Tags: #{event["tags"].join(', ')}\n"
+    message << "Tags: #{Array(event["tags"]).join(', ')}\n"
     message << "Fields: #{event.to_hash.inspect}\n"
     message << "Message: #{event["message"]}"
  end


### PR DESCRIPTION
This is a fix for a crash (see below) when an event doesn't contain any tags.

```
Exception in thread "LogStash::Runner" org.jruby.exceptions.RaiseException: (NoMethodError) undefined method `join' for nil:NilClass
    at RUBY.format_message(file:/opt/logstash/agent/lib/logstash-1.3.3.jar!/logstash/outputs/s3.rb:349)
    at RUBY.receive(file:/opt/logstash/agent/lib/logstash-1.3.3.jar!/logstash/outputs/s3.rb:300)
    at RUBY.handle(file:/opt/logstash/agent/lib/logstash-1.3.3.jar!/logstash/outputs/base.rb:86)
    at RUBY.initialize((eval):24)
    at org.jruby.RubyProc.call(org/jruby/RubyProc.java:271)
    at RUBY.output(file:/opt/logstash/agent/lib/logstash-1.3.3.jar!/logstash/pipeline.rb:259)
    at RUBY.outputworker(file:/opt/logstash/agent/lib/logstash-1.3.3.jar!/logstash/pipeline.rb:218)
    at RUBY.start_outputs(file:/opt/logstash/agent/lib/logstash-1.3.3.jar!/logstash/pipeline.rb:145)
```
