### PR TITLE
Start of remote plugin support

### DIFF
--- a/bin/plugin
+++ b/bin/plugin
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 # Install contrib plugins.
 #
 # Usage:


### PR DESCRIPTION
Some changes to the bin/plugin script that allows one to pass a full URL to a plugin file which installs over top of the logstash directory. 

Test: 'bin/plugin install https://coolacid.net/ls/logstash-pluginname-1.4.1.dev.tar.gz'

which downloads my base plugin file (generated from: https://github.com/coolacid/logstash-pluginbase) and installs it overtop of the logstash enviroment (You'll only find place holder files - since it doesn't actually DO anything) 
