### PR TITLE
continue the filter chain with new events if filter cancels original eve...

### DIFF
--- a/lib/logstash/config/config_ast.rb
+++ b/lib/logstash/config/config_ast.rb
@@ -61,7 +61,8 @@ module LogStash; module Config; module AST
         #definitions << "def #{type}(event)"
         definitions << "@#{type}_func = lambda do |event, &block|"
         if type == "filter"
-          definitions << "  extra_events = []"
+          definitions << "  events = [event]"
+          definitions << "  newevents = []"
         end
 
         definitions << "  @logger.debug? && @logger.debug(\"#{type} received\", :event => event.to_hash)"
@@ -70,7 +71,8 @@ module LogStash; module Config; module AST
         end
 
         if type == "filter"
-          definitions << "  extra_events.each(&block)"
+          definitions << "  events.delete(event)"
+          definitions << "  events.each(&block)"
         end
         definitions << "end"
       end
@@ -159,23 +161,15 @@ module LogStash; module Config; module AST
           # and this should simply compile to 
           #   #{variable_name}.filter(event)
           return [
-            "newevents = []",
-            "extra_events.each do |event|",
+            "events.each do |event|",
             "  #{variable_name}.filter(event) do |newevent|",
             "    newevents << newevent",
             "  end",
             "end",
-            "extra_events += newevents",
+            "events = (newevents + events).reject {|e| e.cancelled?}",
 
+            "return if events.empty?",
             "newevents = []",
-            "#{variable_name}.filter(event) do |newevent|",
-            "  newevents << newevent",
-            "end",
-            "extra_events += newevents",
-            "if event.cancelled? && newevents.empty?",
-            "  extra_events.each(&block)",
-            "  return",
-            "end",
           ].map { |l| "#{l}\n" }.join("")
         when "output"
           return "#{variable_name}.handle(event)\n"

--- a/spec/filters/split.rb
+++ b/spec/filters/split.rb
@@ -21,6 +21,61 @@ describe LogStash::Filters::Split do
     end
   end
 
+  describe "all defaults chain w/ other filter" do
+    config <<-CONFIG
+      filter {
+        split { }
+        mutate { replace => [ "message", "test" ] }
+      }
+    CONFIG
+
+    sample "big\nbird" do
+      insist { subject.length } == 2
+      insist { subject[0]["message"] } == "test"
+      insist { subject[1]["message"] } == "test"
+    end
+  end
+
+  describe "all defaults chain w/ many other filters" do
+    config <<-CONFIG
+      filter {
+        split { }
+        mutate { replace => [ "message", "test" ] }
+        mutate { replace => [ "message", "test2" ] }
+        mutate { replace => [ "message", "test3" ] }
+        mutate { replace => [ "message", "test4" ] }
+      }
+    CONFIG
+
+    sample "big\nbird" do
+      insist { subject.length } == 2
+      insist { subject[0]["message"] } == "test4"
+      insist { subject[1]["message"] } == "test4"
+    end
+  end
+
+  describe "all defaults chain w/ mutate and clone filters" do
+    config <<-CONFIG
+      filter {
+        split { }
+        mutate { replace => [ "message", "test" ] }
+        clone { clones => ['clone1', 'clone2'] }
+        mutate { replace => [ "message", "test2" ] }
+        mutate { replace => [ "message", "test3" ] }
+      }
+    CONFIG
+
+    sample "big\nbird" do
+      insist { subject.length } == 6
+      insist { subject[0]["message"] } == "test3"
+      insist { subject[1]["message"] } == "test3"
+      insist { subject[2]["message"] } == "test3"
+      insist { subject[3]["message"] } == "test3"
+      insist { subject[4]["message"] } == "test3"
+      insist { subject[5]["message"] } == "test3"
+    end
+  end
+
   describe "custome terminator" do
     config <<-CONFIG
       filter {


### PR DESCRIPTION
This is a proposed fix for #793.

It changes the return condition on the `filter` AST: only break the chain if the filter cancels the event AND the execution does not generate new events. Otherwise proceed with the accumulated events.

I added a test to the split filter that failed before but now passes.
