### PR TITLE
logstash boot sequence cleanup & drip support fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ vendor-gems: | vendor/bundle
 .PHONY: vendor/bundle
 vendor/bundle: | vendor $(JRUBY)
 	@echo "=> Ensuring ruby gems dependencies are in $@..."
-	$(QUIET)USE_JRUBY=1 bin/logstash deps $(QUIET_OUTPUT)
+	$(QUIET)bin/logstash deps $(QUIET_OUTPUT)
 	@# Purge any junk that fattens our jar without need!
 	@# The riak gem includes previous gems in the 'pkg' dir. :(
 	-$(QUIET)rm -rf $@/jruby/1.9/gems/riak-client-1.0.3/pkg
@@ -220,7 +220,7 @@ vendor/ua-parser/regexes.yaml: | vendor/ua-parser/
 .PHONY: test
 test: QUIET_OUTPUT=
 test: | $(JRUBY) vendor-elasticsearch vendor-geoip vendor-collectd vendor-gems
-	$(SPEC_ENV) USE_JRUBY=1 bin/logstash rspec $(SPEC_OPTS) --order rand --fail-fast $(TESTS)
+	$(SPEC_ENV) bin/logstash rspec $(SPEC_OPTS) --order rand --fail-fast $(TESTS)
 
 .PHONY: reporting-test
 reporting-test: SPEC_ENV=JRUBY_OPTS=--debug
@@ -382,4 +382,4 @@ tarball-test: #build/logstash-$(VERSION).tar.gz
 	$(QUIET)-rm -rf build/test-tarball/
 	$(QUIET)mkdir -p build/test-tarball/
 	tar -C build/test-tarball --strip-components 1 -xf build/logstash-$(VERSION).tar.gz
-	(cd build/test-tarball; USE_JRUBY=1 bin/logstash rspec $(TESTS) --fail-fast)
+	(cd build/test-tarball; bin/logstash rspec $(TESTS) --fail-fast)

--- a/README.md
+++ b/README.md
@@ -29,11 +29,7 @@ You can also find documentation on the <http://logstash.net> site.
 
 ## Developing
 
-If you don't have JRuby already (or don't use rvm, rbenv, etc), you can have `bin/logstash` fetch it for you by setting `USE_JRUBY`:
-
-    USE_JRUBY=1 bin/logstash ...
-
-Otherwise, here's how to get started with rvm:
+Here's how to get started with rvm:
 
     # Install JRuby with rvm
     rvm install jruby-1.7.11

--- a/bin/logstash
+++ b/bin/logstash
@@ -10,10 +10,6 @@
 #
 # NOTE: One extra command is available 'deps'
 # The 'deps' command will install dependencies for logstash.
-#
-# If you do not have ruby installed, you can set "USE_JRUBY=1"
-# in your environment and this script will download and use
-# a release of JRuby for you.
 
 # Defaults you can override with environment variables
 LS_HEAP_SIZE="${LS_HEAP_SIZE:=500m}"
@@ -32,18 +28,16 @@ case $1 in
   env) env "$@" ;;
   -*)
     if [ -z "$VENDORED_JRUBY" ] ; then
-      exec "${RUBYCMD}" "-I${RUBYLIB}" "${basedir}/lib/logstash/runner.rb" "agent" "$@"
+      exec "${RUBYCMD}" "${basedir}/lib/logstash/runner.rb" "agent" "$@"
     else
-      exec "${JAVACMD}" $JAVA_OPTS "-jar" "$JRUBY_JAR" "-I${RUBYLIB}" "${basedir}/lib/logstash/runner.rb" "agent" "$@"
+      exec "${JAVACMD}" $JAVA_OPTS "-jar" "$JRUBY_JAR" "${basedir}/lib/logstash/runner.rb" "agent" "$@"
     fi
     ;;
   *)
     if [ -z "$VENDORED_JRUBY" ] ; then
-      exec "${RUBYCMD}" "-I${RUBYLIB}" "${basedir}/lib/logstash/runner.rb" "$@"
+      exec "${RUBYCMD}" "${basedir}/lib/logstash/runner.rb" "$@"
     else
-      exec "${JAVACMD}" $JAVA_OPTS "-jar" "$JRUBY_JAR" "-I${RUBYLIB}" "${basedir}/lib/logstash/runner.rb" "$@"
+      exec "${JAVACMD}" $JAVA_OPTS "-jar" "$JRUBY_JAR" "${basedir}/lib/logstash/runner.rb" "$@"
     fi
     ;;
 esac
-
-

--- a/dripmain.rb
+++ b/dripmain.rb
@@ -1,0 +1,29 @@
+# dripmain.rb is called by org.jruby.main.DripMain to further warm the JVM with any preloading
+# that we can do to speedup future startup using drip.
+
+# we are out of the application context here so setup the load path and gem paths
+lib_path = File.expand_path(File.join(File.dirname(__FILE__), "./lib"))
+$:.unshift(lib_path)
+
+require "logstash/environment"
+LogStash::Environment.set_gem_paths!
+
+# typical required gems and libs
+require "i18n"
+I18n.enforce_available_locales = true
+I18n.load_path << LogStash::Environment.locales_path("en.yml")
+require "cabin"
+require "stud/trap"
+require "stud/task"
+require "clamp"
+require "rspec"
+require "rspec/core/runner"
+
+require "logstash/namespace"
+require "logstash/program"
+require "logstash/agent"
+require "logstash/kibana"
+require "logstash/util"
+require "logstash/errors"
+require "logstash/pipeline"
+require "logstash/plugin"

--- a/gembag.rb
+++ b/gembag.rb
@@ -1,12 +1,7 @@
 #!/usr/bin/env ruby
 
-require "rbconfig"
-
-rubyabi = RbConfig::CONFIG["ruby_version"]
-target = "#{Dir.pwd}/vendor/bundle"
-gemdir = "#{target}/#{RUBY_ENGINE}/#{rubyabi}/"
-ENV["GEM_HOME"] = gemdir
-ENV["GEM_PATH"] = ""
+require "logstash/environment"
+LogStash::Environment.set_gem_paths!
 
 require "rubygems/specification"
 require "rubygems/commands/install_command"
@@ -48,13 +43,13 @@ require "bundler/cli"
 module Bundler
   module SharedHelpers
     def default_lockfile
-      ruby = "#{RUBY_ENGINE}-#{RbConfig::CONFIG["ruby_version"]}"
+      ruby = "#{LogStash::Environment.ruby_engine}-#{LogStash::Environment.ruby_abi_version}"
       return Pathname.new("#{default_gemfile}.#{ruby}.lock")
     end
   end
 end
 
-if RUBY_ENGINE == "rbx"
+if LogStash::Environment.ruby_engine == "rbx"
   begin
     gem("rubysl")
   rescue Gem::LoadError => e
@@ -65,7 +60,7 @@ end
 # Try installing a few times in case we hit the "bad_record_mac" ssl error during installation.
 10.times do
   begin
-    Bundler::CLI.start(["install", "--gemfile=tools/Gemfile", "--path", target, "--clean", "--without", "development"])
+    Bundler::CLI.start(["install", "--gemfile=tools/Gemfile", "--path", LogStash::Environment.gem_target, "--clean", "--without", "development"])
     break
   rescue Gem::RemoteFetcher::FetchError => e
     puts e.message

--- a/lib/logstash/environment.rb
+++ b/lib/logstash/environment.rb
@@ -24,8 +24,28 @@ module LogStash
       end
     end
 
+    def gem_target
+      "#{LOGSTASH_HOME}/vendor/bundle"
+    end
+
+    def set_gem_paths!
+      gemdir = "#{gem_target}/#{ruby_engine}/#{ruby_abi_version}/"
+      ENV["GEM_HOME"] = gemdir
+      ENV["GEM_PATH"] = gemdir
+    end
+
+    # @return [String] major.minor ruby version, ex 1.9
+    def ruby_abi_version
+      RUBY_VERSION[/(\d+\.\d+)(\.\d+)*/, 1]
+    end
+
+    # @return [String] jruby, ruby, rbx, ...
+    def ruby_engine
+      RUBY_ENGINE
+    end
+
     def jruby?
-      RUBY_PLATFORM == "java"
+      @jruby ||= !!(RUBY_PLATFORM == "java")
     end
 
     def vendor_path(path)
@@ -38,6 +58,10 @@ module LogStash
 
     def pattern_path(path)
       return ::File.join(LOGSTASH_HOME, "patterns", path)
+    end
+
+    def locales_path(path)
+      return ::File.join(LOGSTASH_HOME, "locales", path)
     end
   end
 end

--- a/lib/logstash/runner.rb
+++ b/lib/logstash/runner.rb
@@ -4,6 +4,9 @@ Encoding.default_external = Encoding::UTF_8
 $START = Time.now
 $DEBUGLIST = (ENV["DEBUG"] || "").split(",")
 
+require "logstash/environment"
+LogStash::Environment.set_gem_paths!
+
 Thread.abort_on_exception = true
 if ENV["PROFILE_BAD_LOG_CALLS"] || $DEBUGLIST.include?("log")
   # Set PROFILE_BAD_LOG_CALLS=1 in your environment if you want
@@ -43,11 +46,10 @@ end # PROFILE_BAD_LOG_CALLS
 require "logstash/monkeypatches-for-debugging"
 require "logstash/namespace"
 require "logstash/program"
-require "i18n" # gem 'i18n'
+
+require "i18n"
 I18n.enforce_available_locales = true
-I18n.load_path << File.expand_path(
-  File.join(File.dirname(__FILE__), "../../locales/en.yml")
-)
+I18n.load_path << LogStash::Environment.locales_path("en.yml")
 
 class LogStash::RSpecsRunner
   def initialize(args)

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -38,8 +38,8 @@ docs() {
 }
 
 tests() {
-  USE_JRUBY=1 make -C $logstash test QUIET=
-  USE_JRUBY=1 make -C $logstash tarball test QUIET=
+  make -C $logstash test QUIET=
+  make -C $logstash tarball test QUIET=
 }
 
 packages() {


### PR DESCRIPTION
- big cleanup of boot shell scripts
- fixed drip support, works with both vendored JRuby and using local JRuby
- deprecated USE_JRUBY environment var
- added USE_RUBY and USE_DRIP environment vars
- centralized gem path handling in LogStash::Environment
- added a `dripmain.rb` file for a good JVM warmup. see https://github.com/ninjudd/drip/wiki/JRuby and https://github.com/jruby/jruby/blob/master/core/src/main/java/org/jruby/main/DripMain.java

Now vendored JRuby mode is the default, the `USE_RUBY=1` environment var allows to use the local ruby interpreter (whichever Ruby it is inclusing JRuby)

To use Drip, either set the `USE_DRIP=1` environment var or set `JAVACMD=`which drip`.

In my environment, the fastest dev setup for running tests and specs is having JRuby locally installed (I personnaly use rbenv) and launch logstash with `USE_RUBY=1`. To add drip I use both `USE_RUBY=1` and `USE_DRIP=1`.

One caveat with drip I noticed is that unlike nailgun, drip does not reuse the same JVM, once your app quits, drip will launch another JVM. This means that if, for example, the JVM starup+warming takes 5 seconds, it will take another five seconds after your app exited for the drip JVM to be ready. This means that if you try to re-run logstash right after it exited, you might still have a startup delay. There 

I check the drip bin in https://github.com/ninjudd/drip/blob/master/bin/drip and setting the `DRIP_POOL` var to > 1 actually works and spins multiple JVMs, but the initial startup time will take `DRIP_POOL` \* the JVM startup time.  `DRIP_POOL` is not externally settable, you have to edit the shell script.
