### PR TITLE
Clarified debug output for incorrect syslog input, invalid syslog now ta...

### DIFF
--- a/lib/logstash/inputs/syslog.rb
+++ b/lib/logstash/inputs/syslog.rb
@@ -56,6 +56,7 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
     @grok_filter = LogStash::Filters::Grok.new(
       "overwrite" => "message",
       "match" => { "message" => "<%{POSINT:priority}>%{SYSLOGLINE}" },
+      "tag_on_failure" => ['_sysloggrokparsefailure'],
     )
 
     @date_filter = LogStash::Filters::Date.new(


### PR DESCRIPTION
Added helpful tag to clarify source of _grokparsefailure errors. This was after exhausting all docs and wasting a lot of time troubleshooting custom patterns, only to find that the problem was invalid syslog input to the internal grok filter used by the syslog input. I'm game for a different tagname if you don't like this one, but this would have saved me several hours if it had been in here a week ago :)
