### PR TITLE
Remove the "how to get help" banner because nobody reads it.

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -4,16 +4,6 @@
 #     for unformatted text.
 en:
   oops: |-
-    +---------------------------------------------------------+
-    | An unexpected error occurred. This is probably a bug.   |
-    | You can find help with this problem in a few places:    |
-    |                                                         |
-    | * chat: #logstash IRC channel on freenode irc.          |
-    |     IRC via the web: http://goo.gl/TI4Ro                |
-    | * email: logstash-users@googlegroups.com                |
-    | * bug system: https://logstash.jira.com/                |
-    |                                                         |
-    +---------------------------------------------------------+
     The error reported is: 
       %{error}
   logstash:


### PR DESCRIPTION
There's several indications that folks don't actually read this banner
when unexpected errors occur. If nobody's reading it, then it's just
wasting space in the output.

I would cite references, but will not because there's no need to shame
anyone.
