### PR TITLE
Add SSL and authentication support for the HTTP protocol of output elasticsearch

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -166,6 +166,15 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # `protocol` on non-java rubies is "http"
   config :protocol, :validate => [ "node", "transport", "http" ]
 
+  # FIXME
+  config :use_ssl, :validate => :boolean, :default => false
+
+  # The HTTP Basic Auth username used to access your elasticsearch server.
+  config :user, :validate => :string, :default => nil
+
+  # The HTTP Basic Auth password used to access your elasticsearch server.
+  config :password, :validate => :password, :default => nil
+
   # The Elasticsearch action to perform. Valid actions are: `index`, `delete`.
   #
   # Use of this setting *REQUIRES* you also configure the `document_id` setting

--- a/lib/logstash/outputs/elasticsearch/protocol.rb
+++ b/lib/logstash/outputs/elasticsearch/protocol.rb
@@ -63,9 +63,15 @@ module LogStash::Outputs::Elasticsearch
           :host => [options[:host], options[:port]].join(":")
         )
 
+        # Use SSL if asked
+        scheme = options[:use_ssl] ? "https" : "http"
+
+        # Use authentication if asked
+        auth = options[:user] && options[:password] ? "#{options[:user]}:#{options[:password]}@" : ""
+
         # Use FTW to do indexing requests, for now, until we
         # can identify and resolve performance problems of elasticsearch-ruby
-        @bulk_url = "http://#{options[:host]}:#{options[:port]}/_bulk"
+        @bulk_url = "#{scheme}://#{auth}#{options[:host]}:#{options[:port]}/_bulk"
         @agent = FTW::Agent.new
 
         return client


### PR DESCRIPTION
Should fix https://github.com/elasticsearch/logstash/issues/1453.

Due to the Faraday dependency, it seems on some version of Ruby, Faraday, OpenSSL and/or your HTTPS backend, the request will fail, even though the response stream seems OK.
