### PR TITLE
Fix config_string i18n

### DIFF
--- a/lib/logstash/agent.rb
+++ b/lib/logstash/agent.rb
@@ -5,12 +5,17 @@ require "logstash/errors"
 require "i18n"
 
 class LogStash::Agent < Clamp::Command
+  ### these need to come first so I18n can see them
+  DEFAULT_INPUT = "input { stdin { type => stdin } }"
+  DEFAULT_OUTPUT = "output { stdout { codec => rubydebug } }"
+
   option ["-f", "--config"], "CONFIG_PATH",
     I18n.t("logstash.agent.flag.config"),
     :attribute_name => :config_path
 
   option "-e", "CONFIG_STRING",
-    I18n.t("logstash.agent.flag.config-string"),
+    I18n.t("logstash.agent.flag.config-string",
+           :default_input => DEFAULT_INPUT, :default_output => DEFAULT_OUTPUT),
     :default => "", :attribute_name => :config_string
 
   option ["-w", "--filterworkers"], "COUNT",
@@ -100,11 +105,11 @@ class LogStash::Agent < Clamp::Command
     else
       # include a default stdin input if no inputs given
       if @config_string !~ /input *{/
-        @config_string += "input { stdin { type => stdin } }"
+        @config_string += DEFAULT_INPUT
       end
       # include a default stdout output if no outputs given
       if @config_string !~ /output *{/
-        @config_string += "output { stdout { codec => rubydebug } }"
+        @config_string += DEFAULT_OUTPUT
       end
     end
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -138,6 +138,9 @@ en:
           "%{default_output}"
           If you wish to use both defaults, please use
           the empty string for the '-e' flag.
+        configtest: |+
+          Ensures the provided configuration is
+          technically sound.
         filterworkers: |+
           Sets the number of filter workers to run.
         watchdog-timeout: |+

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -117,7 +117,7 @@ en:
           This is often a permissions issue, or the wrong 
           path was specified?
       flag:
-        # Note: Wrap these at 45 chars so they display nicely when clamp emits
+        # Note: Wrap these at 55 chars so they display nicely when clamp emits
         # them in an 80-character terminal
         config: |+
           Load the logstash config from a specific file
@@ -130,10 +130,14 @@ en:
         config-string: |+
           Use the given string as the configuration
           data. Same syntax as the config file. If not
-          input is specified, then 'stdin { type =>
-          stdin }' is the default input. If no output
-          is specified, then 'stdout { debug => true
-          }}' is default output.
+          input is specified, then the following is
+          used as the default input:
+          "%{default_input}"
+          and if no output is specified, then the
+          following is used as the default output:
+          "%{default_output}"
+          If you wish to use both defaults, please use
+          the empty string for the '-e' flag.
         filterworkers: |+
           Sets the number of filter workers to run.
         watchdog-timeout: |+


### PR DESCRIPTION
The prior `en.yml` localization of the `-e` "config_string" flag contained invalid configuration text; i.e. if one were to insert the specified defaults into the `-e` flag, Logstash would produce an error.

This PR relocates those defaults to a constant and then references those constants in the `I18n` invocation, ensuring that they will stay in sync for the future.

As a minor aside, the way the English reads, it seems that because config_string has defaults that one could invoke `bin/logstash agent` with no arguments and it will use the defaults. But that is not the actual behavior. So I also updated the text to indicate to the user if they want to just run logstash in "default mode", they must provide an empty string to the `-e` flag.

Also, while I was in the `en.yml` file I fixed a missing localization which produced the following text when invoking `agent --help`: `translation missing: en.logstash.agent.flag.configtest`. As is mentioned in the commit message, I recognize that is likely not the desired English text, but it is surely better than the error text.

*I realize it is bad form to include two different purposed commits in a single PR, but the missing key change is so small I wouldn't think you'd want a separate PR for it.*