### PR TITLE
Fixing expansion of ELASTICSEARCH_VERSION variable in Getting Started tutorial

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,12 +253,14 @@ build/docs/tutorials/getting-started-with-logstash.md: build/docs/tutorials/gett
 		echo "layout: content_right"; \
 		echo "---"; \
 		pandoc -f docbook -t markdown $< \
-	) \
-	| sed -e 's/%VERSION%/$(VERSION)/g' \
-	| sed -e 's/%ELASTICSEARCH_VERSION%/$(ELASTICSEARCH_VERSION)/g' > $@
+	) > $@
 
 build/docs/tutorials/getting-started-with-logstash.xml: docs/tutorials/getting-started-with-logstash.asciidoc | build/docs/tutorials
-	$(QUIET)asciidoc -b docbook -o $@ $<
+	$(QUIET)( \
+		sed -e 's/%VERSION%/$(VERSION)/g' $< \
+		| sed -e 's/%ELASTICSEARCH_VERSION%/$(ELASTICSEARCH_VERSION)/g' \
+		| asciidoc -b docbook -o $@ - \
+	)
 
 build/docs/inputs/%.html: lib/logstash/inputs/%.rb docs/docgen.rb docs/plugin-doc.html.erb | build/docs/inputs
 	$(QUIET)$(JRUBY_CMD) docs/docgen.rb -o build/docs $<


### PR DESCRIPTION
The variables should be replaced before the markdown conversion, otherwise the "_" character will be escaped and the sed pattern won't replace it.

You can see the problem by going here:
http://logstash.net/docs/1.4.1/tutorials/getting-started-with-logstash

and looking by "ELASTICSEARCH_VERSION".
