### PR TITLE
Add LS_WORKER_THREADS to red hat init script

### DIFF
--- a/pkg/logstash.sysv.redhat
+++ b/pkg/logstash.sysv.redhat
@@ -40,6 +40,7 @@ LS_JAVA_OPTS="-Djava.io.tmpdir=${LS_HOME}"
 LS_LOG_FILE=/var/log/logstash/$NAME.log
 LS_CONF_DIR=/etc/logstash/conf.d
 LS_OPEN_FILES=16384
+LS_WORKER_THREADS=1
 LS_NICE=19
 LS_OPTS=""
 LS_PIDFILE=/var/run/$NAME/$NAME.pid
@@ -54,7 +55,7 @@ fi
 PID_FILE=${LS_PIDFILE}
 
 DAEMON="/opt/logstash/bin/logstash"
-DAEMON_OPTS="agent -f ${LS_CONF_DIR} -l ${LS_LOG_FILE} ${LS_OPTS}"
+DAEMON_OPTS="agent -f ${LS_CONF_DIR} -l ${LS_LOG_FILE} -w ${LS_WORKER_THREADS} ${LS_OPTS}"
 
 #
 # Function that starts the daemon/service


### PR DESCRIPTION
LS_WORKER_THREADS configuration variable was not present in init.d
script and therefore logstash couldn’t start with more than 1 worker
thread.
