### PR TITLE
Added worker thread support on redhat init script

### DIFF
--- a/pkg/logstash.sysv.redhat
+++ b/pkg/logstash.sysv.redhat
@@ -43,6 +43,7 @@ LS_OPEN_FILES=16384
 LS_NICE=19
 LS_OPTS=""
 LS_PIDFILE=/var/run/$NAME/$NAME.pid
+LS_WORKER_THREADS=1
 
 # End of variables that can be overwritten in $DEFAULT
 
@@ -54,7 +55,7 @@ fi
 PID_FILE=${LS_PIDFILE}
 
 DAEMON="/opt/logstash/bin/logstash"
-DAEMON_OPTS="agent -f ${LS_CONF_DIR} -l ${LS_LOG_FILE} ${LS_OPTS}"
+DAEMON_OPTS="agent -f ${LS_CONF_DIR} -l ${LS_LOG_FILE} -w ${LS_WORKER_THREADS} ${LS_OPTS}"
 
 #
 # Function that starts the daemon/service


### PR DESCRIPTION
On the default install of logstash rpm /etc/sysconfig/logstash has the LS_WORKER_THREADS variable, but it is not being threated on /etc/init.d/logstash. This patch fixes it and adds a default #workers of 1.
