### PR TITLE
Fixed RabbitMQ input (tested with Bigwig) and s3 output plugins

### DIFF
--- a/lib/logstash/inputs/rabbitmq.rb
+++ b/lib/logstash/inputs/rabbitmq.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+1# encoding: utf-8
 require "logstash/inputs/threadable"
 require "logstash/namespace"
 
@@ -14,7 +14,7 @@ require "logstash/namespace"
 # * March Hare: <http://rubymarchhare.info>
 # * Bunny - <https://github.com/ruby-amqp/bunny>
 class LogStash::Inputs::RabbitMQ < LogStash::Inputs::Threadable
-
+  EXCHANGE_TYPES = ["fanout", "direct", "topic"]
   config_name "rabbitmq"
   milestone 1
 
@@ -87,6 +87,8 @@ class LogStash::Inputs::RabbitMQ < LogStash::Inputs::Threadable
   #
   # (Optional) Exchange binding
   #
+  # The exchange type (fanout, topic, direct)
+  config :exchange_type, :validate => EXCHANGE_TYPES
 
   # Optional.
   #

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -120,6 +120,9 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
  # S3 bucket
  config :bucket, :validate => :string
 
+ # Dir for temp files
+ config :temp_directory, :validate => :string
+
  # Aws endpoint_region
  config :endpoint_region, :validate => ["us-east-1", "us-west-1", "us-west-2",
                                         "eu-west-1", "ap-southeast-1", "ap-southeast-2",
@@ -145,6 +148,8 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
  ## for example if you have single Instance.
  config :restore, :validate => :boolean, :default => false
 
+ config :use_ssl, :validate => :boolean, :default => false
+
  # Aws canned ACL
  config :canned_acl, :validate => ["private", "public_read", "public_read_write", "authenticated_read"],
         :default => "private"
@@ -159,7 +164,8 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   AWS.config(
     :access_key_id => @access_key_id,
     :secret_access_key => @secret_access_key,
-    :s3_endpoint => @endpoint_region
+    :s3_endpoint => @endpoint_region,
+    :use_ssl => @use_ssl
   )
   @s3 = AWS::S3.new
 
@@ -253,7 +259,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
  public
  def register
    require "aws-sdk"
-   @temp_directory = "/opt/logstash/S3_temp/"
+   @temp_directory ||= "/var/tmp/"
 
    if (@tags.size != 0)
        @tag_path = ""


### PR DESCRIPTION
Fixed RabbitMQ input plugin:
- Added exchange_type (direct,fanout,topic) to config
- Fixed connection parameters for :password and :ssl fields
- Added logic to connect to the right exchange type

Enhanced s3 output plugin:
- honors use_ssl param in aws-sdk
- set default tempfile location to /var/tmp/
- add configuration word temp_directory to specify location for tempfiles from configuration
