### PR TITLE
Update CRON_ACTION pattern

### DIFF
--- a/patterns/linux-syslog
+++ b/patterns/linux-syslog
@@ -3,7 +3,7 @@ SYSLOG5424PRINTASCII [!-~]+
 SYSLOGBASE2 (?:%{SYSLOGTIMESTAMP:timestamp}|%{TIMESTAMP_ISO8601:timestamp8601}) (?:%{SYSLOGFACILITY} )?%{SYSLOGHOST:logsource} %{SYSLOGPROG}:
 SYSLOGPAMSESSION %{SYSLOGBASE} (?=%{GREEDYDATA:message})%{WORD:pam_module}\(%{DATA:pam_caller}\): session %{WORD:pam_session_state} for user %{USERNAME:username}(?: by %{GREEDYDATA:pam_by})?
 
-CRON_ACTION [A-Z ]+
+CRON_ACTION [A-Za-z ]+
 CRONLOG %{SYSLOGBASE} \(%{USER:user}\) %{CRON_ACTION:action} \(%{DATA:message}\)
 
 SYSLOGLINE %{SYSLOGBASE2} %{GREEDYDATA:message}


### PR DESCRIPTION
Here is the sample message the original pattern doesn't parse:
`(CRON) info (No MTA installed, discarding output)`

This patch allows to parse these messages properly.