### PR TITLE
Use batch delete to delete from sqs

### DIFF
--- a/lib/logstash/inputs/sqs.rb
+++ b/lib/logstash/inputs/sqs.rb
@@ -111,8 +111,6 @@ class LogStash::Inputs::SQS < LogStash::Inputs::Threadable
   def run(output_queue)
     @logger.debug("Polling SQS queue", :queue => @queue)
 
-    batch_limit = 10
-    
     receive_opts = {
         :limit => @batch_events,
         :visibility_timeout => 30,


### PR DESCRIPTION
Single delete requests are both very slow and expensive in AWS service costs.
This change improved our sqs input performance approximately x10, and sqs costs are /10