### PR TITLE
Improve performance for checksum filter

### DIFF
--- a/lib/logstash/filters/checksum.rb
+++ b/lib/logstash/filters/checksum.rb
@@ -26,6 +26,7 @@ class LogStash::Filters::Checksum < LogStash::Filters::Base
 
   public
   def register
+    @keys.sort!
     require 'openssl'
   end
 
@@ -36,7 +37,7 @@ class LogStash::Filters::Checksum < LogStash::Filters::Base
     @logger.debug("Running checksum filter", :event => event)
 
     to_checksum = ''
-    @keys.sort.each do |k|
+    @keys.each do |k|
       @logger.debug("Adding key to string", :current_key => k)
       to_checksum << "|#{k}|#{event[k]}"
     end


### PR DESCRIPTION
Hi there,

I have some performance improvements for the checksum filter.  Here are the results from trying it on my machine:

Before:

```
$ time yes 'a random sampling of a chunk of fake data' | head -20000 | ./bin/logstash agent -e 'input { stdin {} } filter { checksum { keys => "message" } } output { stdout {} }' >/dev/null
yes 'a random sampling of a chunk of fake data'  0.00s user 0.00s system 0% cpu 1:38.38 total
head -20000  0.00s user 0.00s system 0% cpu 1:38.38 total
./bin/logstash agent -e  > /dev/null  144.51s user 0.89s system 127% cpu 1:54.38 total
```

After:

```
$ time yes 'a random sampling of a chunk of fake data' | head -20000 | ./bin/logstash agent -e 'input { stdin {} } filter { checksum { keys => "message" } } output { stdout {} }' >/dev/null
yes 'a random sampling of a chunk of fake data'  0.00s user 0.00s system 0% cpu 17.883 total
head -20000  0.00s user 0.00s system 0% cpu 17.882 total
./bin/logstash agent -e  > /dev/null  44.35s user 1.51s system 250% cpu 18.288 total
```
