### PR TITLE
Use the newer { "fieldname" => "pattern" } for grok filters.

### DIFF
--- a/lib/logstash/filters/grok.rb
+++ b/lib/logstash/filters/grok.rb
@@ -66,7 +66,7 @@ require "set"
 #     }
 #     filter {
 #       grok {
-#         match => [ "message", "%{IP:client} %{WORD:method} %{URIPATHPARAM:request} %{NUMBER:bytes} %{NUMBER:duration}" ]
+#         match => { "message" => "%{IP:client} %{WORD:method} %{URIPATHPARAM:request} %{NUMBER:bytes} %{NUMBER:duration}" }
 #       }
 #     }
 #
@@ -120,7 +120,7 @@ require "set"
 #     filter {
 #       grok {
 #         patterns_dir => "./patterns"
-#         match => [ "message", "%{SYSLOGBASE} %{POSTFIX_QUEUEID:queue_id}: %{GREEDYDATA:syslog_message}" ]
+#         match => { "message" => "%{SYSLOGBASE} %{POSTFIX_QUEUEID:queue_id}: %{GREEDYDATA:syslog_message}" }
 #       }
 #     }
 #
@@ -150,9 +150,13 @@ class LogStash::Filters::Grok < LogStash::Filters::Base
   # For example:
   #
   #     filter {
-  #       grok {
-  #         match => [ "message", "Duration: %{NUMBER:duration}" ]
-  #       }
+  #       grok { match => { "message" => "Duration: %{NUMBER:duration}" } }
+  #     }
+  #
+  # Alternatively, using the old array syntax:
+  #
+  #     filter {
+  #       grok { match => [ "message", "Duration: %{NUMBER:duration}" ] }
   #     }
   #
   config :match, :validate => :hash, :default => {}
@@ -203,10 +207,7 @@ class LogStash::Filters::Grok < LogStash::Filters::Base
   #
   #     filter {
   #       grok {
-  #         match => [
-  #           "message",
-  #           "%{SYSLOGBASE} %{DATA:message}"
-  #         ]
+  #         match => { "message" => "%{SYSLOGBASE} %{DATA:message}" }
   #         overwrite => [ "message" ]
   #       }
   #     }

--- a/spec/filters/grok.rb
+++ b/spec/filters/grok.rb
@@ -12,7 +12,7 @@ describe LogStash::Filters::Grok do
     config <<-CONFIG
       filter {
         grok {
-          match => [ "message", "%{SYSLOGLINE}" ]
+          match => { "message" => "%{SYSLOGLINE}" }
           singles => true
           overwrite => [ "message" ]
         }
@@ -35,7 +35,7 @@ describe LogStash::Filters::Grok do
     config <<-CONFIG
       filter {
         grok {
-          match => [ "message",  "%{SYSLOG5424LINE}" ]
+          match => { "message" => "%{SYSLOG5424LINE}" }
           singles => true
         }
       }
@@ -163,7 +163,7 @@ describe LogStash::Filters::Grok do
     config <<-CONFIG
       filter {
         grok {
-          match => [ "message",  "(?:hello|world) %{NUMBER}" ]
+          match => { "message" => "(?:hello|world) %{NUMBER}" }
           named_captures_only => false
         }
       }
@@ -178,7 +178,7 @@ describe LogStash::Filters::Grok do
     config <<-CONFIG
       filter {
         grok {
-          match => [ "message",  "%{NUMBER:foo:int} %{NUMBER:bar:float}" ]
+          match => { "message" => "%{NUMBER:foo:int} %{NUMBER:bar:float}" }
           singles => true
         }
       }
@@ -196,7 +196,7 @@ describe LogStash::Filters::Grok do
     config <<-CONFIG
       filter {
         grok {
-          match => [ "message",  "%{FIZZLE=\\d+}" ]
+          match => { "message" => "%{FIZZLE=\\d+}" }
           named_captures_only => false
           singles => true
         }
@@ -212,8 +212,8 @@ describe LogStash::Filters::Grok do
     config <<-CONFIG
       filter {
         grok {
-          match => [ "message",  "%{WORD:word}" ]
-          match => [ "examplefield", "%{NUMBER:num}" ]
+          match => { "message" => "%{WORD:word}" }
+          match => { "examplefield" => "%{NUMBER:num}" }
           break_on_match => false
           singles => true
         }
@@ -230,7 +230,7 @@ describe LogStash::Filters::Grok do
     config <<-CONFIG
       filter {
         grok {
-          match => [ "message",  "matchme %{NUMBER:fancy}" ]
+          match => { "message" => "matchme %{NUMBER:fancy}" }
           singles => true
           add_field => [ "new_field", "%{fancy}" ]
         }
@@ -253,7 +253,7 @@ describe LogStash::Filters::Grok do
       config <<-CONFIG
         filter {
           grok {
-            match => [ "message",  "1=%{WORD:foo1} *(2=%{WORD:foo2})?" ]
+            match => { "message" => "1=%{WORD:foo1} *(2=%{WORD:foo2})?" }
           }
         }
       CONFIG
@@ -271,7 +271,7 @@ describe LogStash::Filters::Grok do
       config <<-CONFIG
         filter {
           grok {
-            match => [ "message",  "1=%{WORD:foo1} *(2=%{WORD:foo2})?" ]
+            match => { "message" => "1=%{WORD:foo1} *(2=%{WORD:foo2})?" }
             keep_empty_captures => true
           }
         }
@@ -292,7 +292,7 @@ describe LogStash::Filters::Grok do
     config <<-CONFIG
       filter {
         grok {
-          match => [ "message",  "Hello %{WORD}. %{WORD:foo}" ]
+          match => { "message" => "Hello %{WORD}. %{WORD:foo}" }
           named_captures_only => false
           singles => true
         }
@@ -313,7 +313,7 @@ describe LogStash::Filters::Grok do
         filter {
           grok {
             singles => true
-            match => [ "message",  "(?<foo>\w+)" ]
+            match => { "message" => "(?<foo>\w+)" }
           }
         }
       CONFIG
@@ -328,7 +328,7 @@ describe LogStash::Filters::Grok do
         filter {
           grok {
             singles => true
-            match => [ "message",  "(?<timestamp>%{DATE_EU} %{TIME})" ]
+            match => { "message" => "(?<timestamp>%{DATE_EU} %{TIME})" }
           }
         }
       CONFIG
@@ -344,7 +344,7 @@ describe LogStash::Filters::Grok do
     config <<-'CONFIG'
       filter {
         grok {
-          match => [ "status", "^403$" ]
+          match => { "status" => "^403$" }
           add_tag => "four_oh_three"
         }
       }
@@ -360,7 +360,7 @@ describe LogStash::Filters::Grok do
     config <<-'CONFIG'
       filter {
         grok {
-          match => [ "version", "^1.0$" ]
+          match => { "version" => "^1.0$" }
           add_tag => "one_point_oh"
         }
       }
@@ -404,7 +404,7 @@ describe LogStash::Filters::Grok do
     config <<-CONFIG
       filter {
         grok {
-          match => [ "message",  "matchme %{NUMBER:fancy}" ]
+          match => { "message" => "matchme %{NUMBER:fancy}" }
           tag_on_failure => false
         }
       }
@@ -423,7 +423,7 @@ describe LogStash::Filters::Grok do
     config <<-CONFIG
       filter {
         grok {
-          match => [ "message",  "%{DATE_EU:stimestamp}" ]
+          match => { "message" => "%{DATE_EU:stimestamp}" }
           singles => true
         }
       }
@@ -438,7 +438,7 @@ describe LogStash::Filters::Grok do
     config <<-CONFIG
       filter {
         grok {
-          match => [ "message",  "%{WORD:foo-bar}" ]
+          match => { "message" => "%{WORD:foo-bar}" }
           singles => true
         }
       }
@@ -464,7 +464,7 @@ describe LogStash::Filters::Grok do
       }
       filter {
         grok {
-          match => [ "message", "%{SYSLOGLINE}" ]
+          match => { "message" => "%{SYSLOGLINE}" }
           singles => true
           overwrite => [ "message" ]
         }
@@ -486,7 +486,7 @@ describe LogStash::Filters::Grok do
     config <<-CONFIG
       filter {
         grok {
-          match => [ "message", "%{INT:foo}|%{WORD:foo}" ]
+          match => { "message" => "%{INT:foo}|%{WORD:foo}" }
           singles => true
         }
       }

--- a/spec/filters/grok/timeout2.rb
+++ b/spec/filters/grok/timeout2.rb
@@ -9,7 +9,7 @@ describe "grok known timeout failures" do
     config <<-'CONFIG'
       filter {
         grok {
-         match  => [ "message", "%{SYSLOGBASE:ts1} \[\#\|%{TIMESTAMP_ISO8601:ts2}\|%{DATA} for %{PATH:url} = %{POSINT:delay} ms.%{GREEDYDATA}" ]
+         match  => { "message" => "%{SYSLOGBASE:ts1} \[\#\|%{TIMESTAMP_ISO8601:ts2}\|%{DATA} for %{PATH:url} = %{POSINT:delay} ms.%{GREEDYDATA}" }
         }
       }
     CONFIG

--- a/spec/filters/mutate.rb
+++ b/spec/filters/mutate.rb
@@ -136,7 +136,7 @@ describe LogStash::Filters::Mutate do
     config <<-CONFIG
       filter {
         grok {
-          match => [ "message", "%{WORD:foo}" ]
+          match => { "message" => "%{WORD:foo}" }
         }
         mutate {
           lowercase => "foo"


### PR DESCRIPTION
Use the newer { "fieldname" => "pattern" } for grok filters.

Replace the older grok style:

```
{ match => [ "fieldname", "pattern" ] }
```

With the newer one:

```
{ match => { "fieldname" => "pattern" } }
```

Also see https://github.com/elasticsearch/logstash/issues/1499
for more examples.
