### PR TITLE
Disambiguous between config using event.sprintf and static ones

### DIFF
--- a/docs/plugin-doc.html.erb
+++ b/docs/plugin-doc.html.erb
@@ -68,6 +68,9 @@ input {
 <% elsif config[:validate].is_a?(Array) -%>
   <li> Value can be any of: <%= config[:validate].map(&:inspect).join(", ") %> </li>
 <% end -%>
+<% if config[:allow_dynamic] -%>
+  <li> This config item allow usage of dynamic value aka <a href="../configuration#sprintf">sprintf format</a> </li>
+<% end -%>
 <% if config.include?(:default) -%>
   <li> Default value is <%= config[:default].inspect %> </li>
 <% else -%>

--- a/lib/logstash/config/mixin.rb
+++ b/lib/logstash/config/mixin.rb
@@ -274,7 +274,7 @@ module LogStash::Config::Mixin
                       || (config_key.is_a?(String) && key == config_key)
           config_val = @config[config_key][:validate]
           #puts "  Key matches."
-          success, result = validate_value(value, config_val)
+          success, result = validate_value(value, config_val, @config[config_key][:allow_dynamic])
           if success 
             # Accept coerced value if success
             # Used for converting values in the config to proper objects.
@@ -306,7 +306,7 @@ module LogStash::Config::Mixin
       return nil
     end
 
-    def validate_value(value, validator)
+    def validate_value(value, validator, allow_dynamic)
       # Validator comes from the 'config' pieces of plugins.
       # They look like this
       #   config :mykey => lambda do |value| ... end
@@ -369,6 +369,11 @@ module LogStash::Config::Mixin
               return false, "Expected string, got #{value.inspect}"
             end
             result = value.first
+            #TODO It would be better to include the nil case by doing if !allow_dynamic
+            #but this could break existing config, so let's be prudent
+            if allow_dynamic == false && result =~ /%{.*}/
+              return false, "This setting does not support dynamic value, got #{result.inspect}"
+            end
           when :number
             if value.size > 1 # only one value wanted
               return false, "Expected number, got #{value.inspect} (type #{value.class})"

--- a/lib/logstash/outputs/elasticsearch_http.rb
+++ b/lib/logstash/outputs/elasticsearch_http.rb
@@ -20,11 +20,11 @@ class LogStash::Outputs::ElasticSearchHTTP < LogStash::Outputs::Base
   # The index to write events to. This can be dynamic using the %{foo} syntax.
   # The default value will partition your indices by day so you can more easily
   # delete old data or only search specific date ranges.
-  config :index, :validate => :string, :default => "logstash-%{+YYYY.MM.dd}"
+  config :index, :validate => :string, :allow_dynamic => true, :default => "logstash-%{+YYYY.MM.dd}"
 
   # The index type to write events to. Generally you should try to write only
   # similar events to the same 'type'. String expansion '%{foo}' works here.
-  config :index_type, :validate => :string
+  config :index_type, :validate => :string, :allow_dynamic => true
 
   # Starting in Logstash 1.3 (unless you set option "manage_template" to false)
   # a default mapping template for Elasticsearch will be applied, if you do not
@@ -53,7 +53,7 @@ class LogStash::Outputs::ElasticSearchHTTP < LogStash::Outputs::Base
   config :template_overwrite, :validate => :boolean, :default => false
 
   # The hostname or IP address to reach your Elasticsearch server.
-  config :host, :validate => :string, :required => true
+  config :host, :validate => :string, :allow_dynamic => false, :required => true
 
   # The port for Elasticsearch HTTP interface to use.
   config :port, :validate => :number, :default => 9200
@@ -84,7 +84,7 @@ class LogStash::Outputs::ElasticSearchHTTP < LogStash::Outputs::Base
 
   # The document ID for the index. Useful for overwriting existing entries in
   # Elasticsearch with the same ID.
-  config :document_id, :validate => :string, :default => nil
+  config :document_id, :validate => :string, :allow_dynamic => true, :default => nil
 
   # Set the type of Elasticsearch replication to use. If async
   # the index request to Elasticsearch to return after the primary


### PR DESCRIPTION
Here is an idea following a discussion on logstash-user groups where someone tried to dynamicly set the host parameter of elasticsearch_http output from event field, 

This proposal tag the config items that can (or cannot) use _dynamic value_ aka sprintf under the hood.
Example done on the elasticsearch_http, we can do the full scan afterwards...

HTH

PS: I silly dreamt that reaching the 200th Pull Request would trigger the next merge party on your side, pretty please... ;°)
