### PR TITLE
Consolidate java grok patterns + test,tests,tests

### DIFF
--- a/patterns/java
+++ b/patterns/java
@@ -1,3 +1,7 @@
-JAVACLASS (?:[a-zA-Z0-9-]+\.)+[A-Za-z0-9$_]+
+JAVACLASS (?:[a-zA-Z$_][a-zA-Z$_0-9]*\.)*[a-zA-Z$_][a-zA-Z$_0-9]*
+#Space is an allowed character to match special cases like 'Native Method' or 'Unknown Source'
 JAVAFILE (?:[A-Za-z0-9_. -]+)
-JAVASTACKTRACEPART at %{JAVACLASS:class}\.%{WORD:method}\(%{JAVAFILE:file}:%{NUMBER:line}\)
+#Allow special <init> method
+JAVAMETHOD (?:(<init>)|[a-zA-Z$_][a-zA-Z$_0-9]*)
+#Line number is optional in special cases 'Native method' or 'Unknown source'
+JAVASTACKTRACEPART %{SPACE}at %{JAVACLASS:class}\.%{JAVAMETHOD:method}\(%{JAVAFILE:file}(?::%{NUMBER:line})?\)

--- a/spec/filters/grok-patterns/java.rb
+++ b/spec/filters/grok-patterns/java.rb
@@ -1,0 +1,158 @@
+# encoding: utf-8
+require "test_utils"
+
+# Test suite for the grok patterns defined in patterns/java
+# For each pattern:
+#  - a sample is considered valid i.e. "should match"  where message == result
+#  - a sample is considered invalid i.e. "should NOT match"  where message != result
+#
+describe "java grok pattern" do
+  extend LogStash::RSpec
+
+  describe "JAVACLASS" do
+    config <<-CONFIG
+      filter {
+        grok {
+          match => { "message" => "%{JAVACLASS:result}" }
+        }
+      }
+    CONFIG
+
+    context "should match" do
+      [
+        "package.Class",
+        "package.class", #camel case is not mandatory
+        "package.subpackage.Class",
+        "package._subpackage.Class",
+        "package._.Class",
+        "package.Class$InnerClass", #java inner class
+        "classWithNoPackage",
+      ].each do |message|
+        sample message do 
+          insist {subject["result"]} == message
+        end
+      end
+    end
+
+    context "should NOT match" do
+      [
+        "package.Illegal!Class",
+        "illegal.!package.Class",
+        "package-with-hyphen.Class",
+        "123package.Class",
+        "package.123Class",
+      ].each do |message|
+        sample message do 
+          insist {subject["result"]} != message
+        end
+      end
+    end
+  end
+
+  describe "JAVAMETHOD" do
+    config <<-CONFIG
+      filter {
+        grok {
+          match => { "message" => "%{JAVAMETHOD:result}" }
+        }
+      }
+    CONFIG
+
+    context "should match" do
+      [
+        "methodName",
+        "method_name",
+        "methodWithNumber0",
+        "_method",
+        "_",
+        "<init>", # Special constructor method
+      ].each do |message|
+        sample message do 
+          insist {subject["result"]} == message
+        end
+      end
+    end
+
+    context "should NOT match" do
+      [
+        "method-name",
+        "method!name",
+        "method.name",
+        "method>name",
+        "<notinit>",
+        "-",
+        "123method",
+      ].each do |message|
+        sample message do 
+          insist {subject["result"]} != message
+        end
+      end
+    end
+  end
+
+  describe "JAVAFILE" do
+    config <<-CONFIG
+      filter {
+        grok {
+          match => { "message" => "%{JAVAFILE:result}" }
+        }
+      }
+    CONFIG
+
+    context "should match" do
+      [
+        "Wombat.java",
+        "CacheAwareContextLoaderDelegate.java",
+        "Native Method",
+        "Unknown Source",
+      ].each do |message|
+        sample message do 
+          insist {subject["result"]} == message
+        end
+      end
+    end
+
+    context "should NOT match" do
+      [
+         #Sorry no idea
+      ].each do |message|
+        sample message do 
+          insist {subject["result"]} != message
+        end
+      end
+    end
+  end
+
+  describe "JAVASTACKTRACEPART" do
+    config <<-CONFIG
+      filter {
+        grok {
+          match => { "message" => "%{JAVASTACKTRACEPART:result}" }
+        }
+      }
+    CONFIG
+
+    context "should match" do
+      [
+        "at com.xyz.Wombat(Wombat.java:57)",
+        "at org.springframework.test.context.CacheAwareContextLoaderDelegate.loadContext(CacheAwareContextLoaderDelegate.java:91)",
+        "at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)",
+        "at org.jnp.server.NamingServer_Stub.lookup(Unknown Source)",
+      ].each do |message|
+        sample message do 
+          insist {subject["result"]} == message
+        end
+      end
+    end
+
+    context "should NOT match" do
+      [
+        #Sorry no idea
+      ].each do |message|
+        sample message do 
+          insist {subject["result"]} != message
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Here is a proposal to update the JAVA grok patterns and a way to test them.
It contains or improves very good changes in other open PR #926 and #1384

here is the additional changes:
- Allow no_package classes
- Add comment in the pattern file about special cases
- Made Line Number in JAVASTACKTRACEPART  optional to cover special cases
- yummy tests...

I'm sure one could further improve the test_utils DSL in this particular case of grok single pattern testing, @jordansissel I'm looking at you :eyes: 
