### PR TITLE
codec/line: do charset conversion on flush

### DIFF
--- a/lib/logstash/codecs/line.rb
+++ b/lib/logstash/codecs/line.rb
@@ -42,7 +42,7 @@ class LogStash::Codecs::Line < LogStash::Codecs::Base
   def flush(&block)
     remainder = @buffer.flush
     if !remainder.empty?
-      block.call(LogStash::Event.new({"message" => remainder}))
+      block.call(LogStash::Event.new("message" => @converter.convert(remainder)))
     end
   end
 

--- a/spec/codecs/line_spec.rb
+++ b/spec/codecs/line_spec.rb
@@ -48,4 +48,19 @@ describe LogStash::Codecs::Line do
       end
     end
   end
+
+  context "#flush" do
+    it "should convert charsets" do
+      garbage = [0xD0].pack("C")
+      subject.decode(garbage) do |e|
+        fail "Should not get here."
+      end
+      count = 0
+      subject.flush do |event|
+        count += 1
+        insist { event["message"].encoding } == Encoding::UTF_8
+      end
+      insist { count } == 1
+    end
+  end
 end


### PR DESCRIPTION
Also add tests to verify line codec does charset conversion on flush.

Related bugs:
- https://logstash.jira.com/browse/LOGSTASH-1789 (syslog input uses tcp input which defaults to line codec)
