### PR TITLE
use bundler compatible ruby version string

### DIFF
--- a/gembag.rb
+++ b/gembag.rb
@@ -43,7 +43,7 @@ require "bundler/cli"
 module Bundler
   module SharedHelpers
     def default_lockfile
-      ruby = "#{LogStash::Environment.ruby_engine}-#{LogStash::Environment.ruby_abi_version}"
+      ruby = "#{LogStash::Environment.ruby_engine}-#{LogStash::Environment.gem_ruby_version}"
       return Pathname.new("#{default_gemfile}.#{ruby}.lock")
     end
   end

--- a/lib/logstash/environment.rb
+++ b/lib/logstash/environment.rb
@@ -29,7 +29,7 @@ module LogStash
     end
 
     def set_gem_paths!
-      gemdir = "#{gem_target}/#{ruby_engine}/#{ruby_abi_version}/"
+      gemdir = "#{gem_target}/#{ruby_engine}/#{gem_ruby_version}/"
       ENV["GEM_HOME"] = gemdir
       ENV["GEM_PATH"] = gemdir
     end
@@ -37,6 +37,11 @@ module LogStash
     # @return [String] major.minor ruby version, ex 1.9
     def ruby_abi_version
       RUBY_VERSION[/(\d+\.\d+)(\.\d+)*/, 1]
+    end
+
+    # @return [String] the ruby version string bundler uses to craft its gem path
+    def gem_ruby_version
+      RbConfig::CONFIG["ruby_version"]
     end
 
     # @return [String] jruby, ruby, rbx, ...


### PR DESCRIPTION
this fixes the invalid gem path with MRI. Bundler uses inconsistent version number schemes across Rubies: for example, JRuby 1.7.11 will have `1.9` in its gem path while MRI 2.1.0 will have `2.1.0`. in the #1437 refactor I wrongly assumed  the `major.minor` scheme was used across all Rubies.
