### PR TITLE
Adding delaycompress to logrotate

### DIFF
--- a/pkg/logrotate.conf
+++ b/pkg/logrotate.conf
@@ -3,6 +3,7 @@
         rotate 7
         copytruncate
         compress
+        delaycompress
         missingok
         notifempty
 }


### PR DESCRIPTION
To avoid issues like:

/etc/cron.daily/logrotate:
gzip: stdin: file size changed while zipping

This change is harmless and will prevent errors like this one
