### PR TITLE
try to fix LOGSTASH-2225

### DIFF
--- a/pkg/logstash.sysv
+++ b/pkg/logstash.sysv
@@ -27,7 +27,6 @@ name=logstash
 pidfile="/var/run/$name.pid"
 
 LS_USER=logstash
-LS_GROUP=logstash
 LS_HOME=/var/lib/logstash
 LS_HEAP_SIZE="500m"
 LS_JAVA_OPTS="-Djava.io.tmpdir=${LS_HOME}"
@@ -54,17 +53,18 @@ start() {
   # set ulimit as (root, presumably) first, before we drop privileges
   ulimit -n ${LS_OPEN_FILES}
 
-  # Run the program!
-  nice -n ${LS_NICE} chroot --userspec $LS_USER:$LS_GROUP / sh -c "
+  # Run the program, take note of PID
+  pid=$(nice -n $LS_NICE /usr/bin/sudo -E -u $LS_USER /bin/sh -c "
     cd $LS_HOME
     ulimit -n ${LS_OPEN_FILES}
-    exec \"$program\" $args
-  " > "${LS_LOG_DIR}/$name.stdout" 2> "${LS_LOG_DIR}/$name.err" &
+    \"$program\" $args  > \"${LS_LOG_DIR}/$name.stdout\" 2> \"${LS_LOG_DIR}/$name.err\" &
+    echo \$!
+  ")
 
   # Generate the pidfile from here. If we instead made the forked process
   # generate it there will be a race condition between the pidfile writing
   # and a process possibly asking for status.
-  echo $! > $pidfile
+  echo $pid > $pidfile
 
   echo "$name started."
   return 0


### PR DESCRIPTION
Change logic from using "chroot --userspec" (which doesn't work
with RHEL5) to using "sudo". Side effects:
1. It's no longer possible to explictely set the group that LS
   will use (LS_GROUP variable removed).
2. Related to #1, supplemental groups for logstash will now work.
3. Due to the way that sudo behaves, I had to shift logfile
   creation to the non-privileged part, so on upgrades, if one
   doesn't explicitely chown existing logfiles, it will break.

Regarding #3: We could probably chown the logfiles to $LS_USER from
within the init script...
