### PR TITLE
call vendor-geoip instead of $(GEOIP) in prepare-tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ show:
 
 .PHONY: prepare-tarball
 prepare-tarball tarball zip: WORKDIR=build/tarball/logstash-$(VERSION)
-prepare-tarball: vendor/kibana $(ELASTICSEARCH) $(JRUBY) $(GEOIP) $(TYPESDB) vendor-gems
+prepare-tarball: vendor/kibana $(ELASTICSEARCH) $(JRUBY) vendor-geoip $(TYPESDB) vendor-gems
 prepare-tarball: vendor/ua-parser/regexes.yaml
 prepare-tarball:
 	@echo "=> Preparing tarball"


### PR DESCRIPTION
When the tarball is prepared GeoIPASNum.dat is excluded because $(GEOIP) is called instead of vendor-geoip.  This breaks the geoip tests and this pull request fixes that.
