### PR TITLE
fix init scripts so they use seperate log files for daemon and app

### DIFF
--- a/pkg/logstash-web.sysv.redhat
+++ b/pkg/logstash-web.sysv.redhat
@@ -37,7 +37,8 @@ LS_GROUP=logstash
 LS_HOME=/var/lib/logstash
 LS_HEAP_SIZE="500m"
 LS_JAVA_OPTS="-Djava.io.tmpdir=${LS_HOME}"
-LS_LOG_FILE=
+LS_LOG_FILE=/var/log/logstash/$NAME.log
+LS_INIT_LOG_FILE=/var/log/logstash/$NAME.init.log
 LS_CONF_DIR=/etc/logstash/conf.d
 LS_OPEN_FILES=2048
 LS_NICE=19
@@ -80,7 +81,7 @@ do_start()
   export PATH HOME JAVA_OPTS LS_HEAP_SIZE LS_JAVA_OPTS LS_USE_GC_LOGGING
   test -n "${JAVACMD}" && export JAVACMD
 
-  nice -n ${LS_NICE} runuser -s /bin/sh -c "exec $DAEMON $DAEMON_OPTS" ${LS_USER} > /dev/null 2>&1 < /dev/null &
+  nice -n ${LS_NICE} runuser -s /bin/sh -c "exec $DAEMON $DAEMON_OPTS" ${LS_USER} > $LS_INIT_LOG_FILE 2>&1 < /dev/null &
 
   RETVAL=$?
   local PID=$!

--- a/pkg/logstash.sysv.redhat
+++ b/pkg/logstash.sysv.redhat
@@ -38,6 +38,7 @@ LS_HOME=/var/lib/logstash
 LS_HEAP_SIZE="500m"
 LS_JAVA_OPTS="-Djava.io.tmpdir=${LS_HOME}"
 LS_LOG_FILE=/var/log/logstash/$NAME.log
+LS_INIT_LOG_FILE=/var/log/logstash/$NAME.init.log
 LS_CONF_DIR=/etc/logstash/conf.d
 LS_OPEN_FILES=16384
 LS_NICE=19
@@ -79,7 +80,7 @@ do_start()
   export PATH HOME JAVA_OPTS LS_HEAP_SIZE LS_JAVA_OPTS LS_USE_GC_LOGGING
   test -n "${JAVACMD}" && export JAVACMD
 
-  nice -n ${LS_NICE} runuser -s /bin/sh -c "exec $DAEMON $DAEMON_OPTS" ${LS_USER} >> $LS_LOG_FILE 2>&1 < /dev/null &
+  nice -n ${LS_NICE} runuser -s /bin/sh -c "exec $DAEMON $DAEMON_OPTS" ${LS_USER} >> $LS_INIT_LOG_FILE 2>&1 < /dev/null &
 
   RETVAL=$?
   local PID=$!


### PR DESCRIPTION
So this is to address that firstly, it'd be good to log the daemon log somewhere maybe. Secondly, it'd be good if that log was separate from the jvm log because the init script log is owned by root because the daemon is started as root, but the jvm is owned by logstash, so it's log will be owned by logstash. and most importantly, now logstash can actually start on first start with out hacking or configuration management to manage the ownership of log files.
