### PR TITLE
Issue #1590 Multiline filter and additional worker threads do not work together.

### DIFF
--- a/lib/logstash/filters/multiline.rb
+++ b/lib/logstash/filters/multiline.rb
@@ -10,6 +10,8 @@ require "set"
 # from files into a single event. For example - joining java exception and
 # stacktrace messages into a single event.
 #
+# NOTE: This filter will not work with multiple worker threads "-w 2" on the logstash command line.
+#
 # The config looks like this:
 #
 #     filter {


### PR DESCRIPTION
Simple documentation update to show this is a limitation with the filter.

https://github.com/elasticsearch/logstash/issues/1590
