### PR TITLE
add unique tag for grok parser in module input

### DIFF
--- a/lib/logstash/inputs/syslog.rb
+++ b/lib/logstash/inputs/syslog.rb
@@ -56,6 +56,7 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
     @grok_filter = LogStash::Filters::Grok.new(
       "overwrite" => "message",
       "match" => { "message" => "<%{POSINT:priority}>%{SYSLOGLINE}" },
+      "tag_on_failure" => ["_grokparsefailure_sysloginputplugin"],
     )
 
     @date_filter = LogStash::Filters::Date.new(


### PR DESCRIPTION
how are syslog input tests executed and where? because for the command "make test" the tests are excluded. when I executed them (setting :socket => false ) I get a jruby exception:

Exception in thread "Ruby-0-Thread-109: /Users/simon/Workspaces/logstash/lib/logstash/inputs/syslog.rb:89" org.jruby.exceptions.JumpException$BreakJump

I added a new tests for the tag and also improved a little bit the old one.
