### PR TITLE
Add sprintf ability to room_id field in hipchat output

### DIFF
--- a/lib/logstash/outputs/hipchat.rb
+++ b/lib/logstash/outputs/hipchat.rb
@@ -45,7 +45,7 @@ class LogStash::Outputs::HipChat < LogStash::Outputs::Base
     return unless output?(event)
 
     hipchat_data = Hash.new
-    hipchat_data['room_id'] = @room_id
+    hipchat_data['room_id'] = event.sprintf(@room_id)
     hipchat_data['from']    = @from
     hipchat_data['color']   = @color
     hipchat_data['notify']  = @trigger_notify ? "1" : "0"


### PR DESCRIPTION
We had a design requirement to be able to notify different rooms based on logstash inputs. This PR allows us to dynamically send exceptions to different hipchat rooms based off of tag values:

```
hipchat {
  token   => "12345"
  room_id => "%{env}-%{pod}"
}
```

I was unable to run the spec tests on my local mac, but I will try another run from another host soon.
