### PR TITLE
Added optional base64 and base64url encoding options to fingerprint.

### DIFF
--- a/lib/logstash/filters/fingerprint.rb
+++ b/lib/logstash/filters/fingerprint.rb
@@ -15,8 +15,8 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
   # will overwrite current value of a field if it exists.
   config :target, :validate => :string, :default => 'fingerprint'
 
-  # Hash encoding. Valid values are 'hex', 'base64' and 'base64url'.
-  config :encoding, :validate => :string, :default => 'hex'
+  # Hash encoding for OpenSSL hashes.
+  config :encoding, :validate => [ 'hex', 'base64', 'base64url' ], :default => 'hex'
 
   # When used with IPV4_NETWORK method fill in the subnet prefix length
   # Not required for MURMUR3 or UUID methods

--- a/lib/logstash/filters/fingerprint.rb
+++ b/lib/logstash/filters/fingerprint.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/filters/base"
 require "logstash/namespace"
+require "base64"
 
 #  Fingerprint fields using by replacing values with a consistent hash.
 class LogStash::Filters::Fingerprint < LogStash::Filters::Base
@@ -13,6 +14,9 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
   # Target field.
   # will overwrite current value of a field if it exists.
   config :target, :validate => :string, :default => 'fingerprint'
+
+  # Hash encoding. Valid values are 'hex', 'base64' and 'base64url'.
+  config :encoding, :validate => :string, :default => 'hex'
 
   # When used with IPV4_NETWORK method fill in the subnet prefix length
   # Not required for MURMUR3 or UUID methods
@@ -90,7 +94,13 @@ class LogStash::Filters::Fingerprint < LogStash::Filters::Base
   def anonymize_openssl(data)
     digest = encryption_algorithm()
     # in JRuby 1.7.11 outputs as ASCII-8BIT
-    OpenSSL::HMAC.hexdigest(digest, @key, data).force_encoding(Encoding::UTF_8)
+    if @encoding == 'base64'
+      Base64.strict_encode64(OpenSSL::HMAC.digest(digest, @key, data)).force_encoding(Encoding::UTF_8)
+    elsif @encoding == 'base64url'
+      Base64.urlsafe_encode64(OpenSSL::HMAC.digest(digest, @key, data)).force_encoding(Encoding::UTF_8)
+    else
+      OpenSSL::HMAC.hexdigest(digest, @key, data).force_encoding(Encoding::UTF_8)
+    end
   end
 
   def anonymize_murmur3(value)

--- a/spec/filters/fingerprint.rb
+++ b/spec/filters/fingerprint.rb
@@ -37,7 +37,7 @@ describe LogStash::Filters::Fingerprint do
     end
   end
 
-   describe "fingerprint string with SHA1 alogrithm" do
+   describe "fingerprint string with SHA1 alogrithm and default hex encoding" do
     config <<-CONFIG
       filter {
         fingerprint {
@@ -50,6 +50,40 @@ describe LogStash::Filters::Fingerprint do
 
     sample("clientip" => "123.123.123.123") do
       insist { subject["fingerprint"] } == "fdc60acc4773dc5ac569ffb78fcb93c9630797f4"
+    end
+  end
+
+  describe "fingerprint string with SHA1 algorithm and base64 encoding" do
+    config <<-CONFIG
+      filter {
+        fingerprint {
+          source => ["clientip"]
+          key => "longencryptionkey"
+          method => 'SHA1'
+          encoding => 'base64'
+        }
+      }
+    CONFIG
+
+    sample("clientip" => "123.123.123.123") do
+      insist { subject["fingerprint"] } == "/cYKzEdz3FrFaf+3j8uTyWMHl/Q="
+    end
+  end
+
+  describe "fingerprint string with SHA1 algorithm and base64url encoding" do
+    config <<-CONFIG
+      filter {
+        fingerprint {
+          source => ["clientip"]
+          key => "longencryptionkey"
+          method => 'SHA1'
+          encoding => 'base64url'
+        }
+      }
+    CONFIG
+
+    sample("clientip" => "123.123.123.123") do
+      insist { subject["fingerprint"] } == "_cYKzEdz3FrFaf-3j8uTyWMHl_Q="
     end
   end
 


### PR DESCRIPTION
Added a new configuration parameter named `encoding` that allows fingerprint hash values to be created using a more compact base64 encoding in addition to the default hex encoding. Both standard base64 (`base64`) as well as URL and file name safe base64 encoding (`base64url`) are supported.

