### PR TITLE
Add Client Cert Auth to Lumberjack input.

### DIFF
--- a/lib/logstash/inputs/lumberjack.rb
+++ b/lib/logstash/inputs/lumberjack.rb
@@ -45,7 +45,9 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
     @logger.info("Starting lumberjack input listener", :address => "#{@host}:#{@port}")
     @lumberjack = Lumberjack::Server.new(:address => @host, :port => @port,
       :ssl_certificate => @ssl_certificate, :ssl_key => @ssl_key,
-      :ssl_key_passphrase => @ssl_key_passphrase)
+      :ssl_key_passphrase => @ssl_key_passphrase, :ssl_cacert => @ssl_cacert,
+      :ssl_include_system_ca => @ssl_include_system_ca,
+      :ssl_client_cert_check=> @ssl_client_cert_check )
   end # def register
 
   public

--- a/lib/logstash/inputs/lumberjack.rb
+++ b/lib/logstash/inputs/lumberjack.rb
@@ -29,7 +29,14 @@ class LogStash::Inputs::Lumberjack < LogStash::Inputs::Base
   # SSL key passphrase to use.
   config :ssl_key_passphrase, :validate => :password
 
-  # TODO(sissel): Add CA to authenticate clients with.
+  #SSL certificate authority
+  config :ssl_cacert, :validate => :path
+  
+  #SSL include system wide certificate authorities
+  config :ssl_include_system_ca, :default => false
+  
+  #SSL verify client certificates
+  config :ssl_client_cert_check, :default => false
 
   public
   def register

--- a/lib/logstash/outputs/lumberjack.rb
+++ b/lib/logstash/outputs/lumberjack.rb
@@ -13,6 +13,12 @@ class LogStash::Outputs::Lumberjack < LogStash::Outputs::Base
   # ssl certificate to use
   config :ssl_certificate, :validate => :path, :required => true
 
+  # ssl key to use
+  config :ssl_key, :validate => :path, :required => true
+
+  # ssl key password to use
+  config :ssl_key_passphrase, :validate => :string, :required => false
+
   # window size
   config :window_size, :validate => :number, :default => 5000
 
@@ -46,12 +52,14 @@ class LogStash::Outputs::Lumberjack < LogStash::Outputs::Base
   def connect
     require 'resolv'
     @logger.info("Connecting to lumberjack server.", :addresses => @hosts, :port => @port, 
-        :ssl_certificate => @ssl_certificate, :window_size => @window_size)
+        :ssl_certificate => @ssl_certificate, :ssl_key => @ssl_key, :ssl_key_passphrase => @ssl_key_passphrase,
+        :window_size => @window_size)
     begin
       ips = []
       @hosts.each { |host| ips += Resolv.getaddresses host }
       @client = Lumberjack::Client.new(:addresses => ips.uniq, :port => @port, 
-        :ssl_certificate => @ssl_certificate, :window_size => @window_size)
+        :ssl_certificate => @ssl_certificate, :ssl_key => @ssl_key, :ssl_key_passphrase => @ssl_key_passphrase,
+        :window_size => @window_size)
     rescue Exception => e
       @logger.error("All hosts unavailable, sleeping", :hosts => ips.uniq, :e => e, 
         :backtrace => e.backtrace)


### PR DESCRIPTION
Matches with https://github.com/elasticsearch/logstash-forwarder/pull/243

Three options, CA to match, if the system CAs are to be trusted, and if
we want to verify the clients signer. Three options because there may
be a case where someone wants to trust any client certs signed by the
system CAs.