### PR TITLE
LOGSTASH-1886: intercept exception raised by march_hare

### DIFF
--- a/lib/logstash/outputs/rabbitmq/march_hare.rb
+++ b/lib/logstash/outputs/rabbitmq/march_hare.rb
@@ -44,7 +44,7 @@ class LogStash::Outputs::RabbitMQ
         else
           @logger.warn("Tried to send a message, but not connected to RabbitMQ.")
         end
-      rescue MarchHare::Exception, com.rabbitmq.client.AlreadyClosedException => e
+      rescue MarchHare::Exception, IOError, com.rabbitmq.client.AlreadyClosedException => e
         @connected.set(false)
         n = 10
 


### PR DESCRIPTION
Since ae867bc64, the march_hare version we use raises an error when the
network link is broken while the socket is idle. This case must be
handled by logstash to initiate the reconnection process.
