### PR TITLE
Typo in Getting Started Tutorial

### DIFF
--- a/docs/tutorials/getting-started-with-logstash.asciidoc
+++ b/docs/tutorials/getting-started-with-logstash.asciidoc
@@ -261,7 +261,7 @@ Now, let's configure something actually *useful*... apache2 access log files! We
 input {
   file {
     path => "/tmp/access_log"
-    start_position => beginning
+    start_position => "beginning"
   }
 }
 


### PR DESCRIPTION
String has to be enclosed in double quotes, this typo made me waste quite a lot of time while trying the "Getting Started" Tutorial. :blush:
