### PR TITLE
Read socket line by line

### DIFF
--- a/lib/logstash/inputs/unix.rb
+++ b/lib/logstash/inputs/unix.rb
@@ -75,10 +75,10 @@ class LogStash::Inputs::Unix < LogStash::Inputs::Base
         # or socket dies
         # TODO(sissel): Why do we have a timeout here? What's the point?
         if @data_timeout == -1
-          buf = socket.readpartial(16384)
+          buf = socket.gets()
         else
           Timeout::timeout(@data_timeout) do
-            buf = socket.readpartial(16384)
+            buf = socket.gets()
           end
         end
         @codec.decode(buf) do |event|


### PR DESCRIPTION
The documentation states:
"Like stdin and file inputs, each event is assumed to be one line of text."

However the current implementation does not honour that by using readpartial()
without any line delimiter splitting afterwards.
Why not using gets() instead ?
