### PR TITLE
 First start of logstash-web always return 2

### DIFF
--- a/pkg/logstash-web.sysv
+++ b/pkg/logstash-web.sysv
@@ -121,6 +121,7 @@ case "$1" in
       echo "$name is already running"
     else
       start
+      code=$?
     fi
     exit $code
     ;;


### PR DESCRIPTION
 First start of logstash-web always returns 2 since return "code" was not being recaptured after the "start" command.
