### PR TITLE
Improvements to plugin manager

### DIFF
--- a/lib/logstash/pluginmanager/install.rb
+++ b/lib/logstash/pluginmanager/install.rb
@@ -2,7 +2,7 @@ require 'clamp'
 require 'logstash/namespace'
 require 'logstash/pluginmanager'
 require 'logstash/pluginmanager/util'
-require 'rubygems/installer'
+require 'rubygems/dependency_installer'
 require 'rubygems/uninstaller'
 require 'jar-dependencies'
 require 'jar_install_post_install_hook'
@@ -16,6 +16,7 @@ class LogStash::PluginManager::Install < Clamp::Command
   option "--proxy", "PROXY", "Use HTTP proxy for remote operations"
 
   def execute
+    LogStash::PluginManager::Util.load_logstash_gemspec
 
     ::Gem.configuration.verbose = false
     ::Gem.configuration[:http_proxy] = proxy 
@@ -50,7 +51,11 @@ class LogStash::PluginManager::Install < Clamp::Command
     end
 
     ::Gem.configuration.verbose = false
-    specs, _ = ::Gem.install(plugin, version)
+    options = {}
+    options[:document] = []
+    inst = Gem::DependencyInstaller.new(options)
+    inst.install plugin, version
+    specs, _ = inst.installed_gems
     puts ("Successfully installed '#{specs.name}' with version '#{specs.version}'")
 
   end

--- a/lib/logstash/pluginmanager/update.rb
+++ b/lib/logstash/pluginmanager/update.rb
@@ -2,7 +2,7 @@ require 'clamp'
 require 'logstash/namespace'
 require 'logstash/pluginmanager'
 require 'logstash/pluginmanager/util'
-require 'rubygems/installer'
+require 'rubygems/dependency_installer'
 require 'rubygems/uninstaller'
 require 'jar-dependencies'
 require 'jar_install_post_install_hook'
@@ -17,6 +17,7 @@ class LogStash::PluginManager::Update < Clamp::Command
 
   def execute
 
+    LogStash::PluginManager::Util.load_logstash_gemspec
     ::Gem.configuration.verbose = false
     ::Gem.configuration[:http_proxy] = proxy
 
@@ -61,7 +62,11 @@ class LogStash::PluginManager::Update < Clamp::Command
     end
 
     ::Gem.configuration.verbose = false
-    ::Gem.install(spec.name, version)
+    options = {}
+    options[:document] = []
+    inst = Gem::DependencyInstaller.new(options)
+    inst.install spec.name, gem_meta.version
+    specs, _ = inst.installed_gems
     puts ("Update successful")
 
   end

--- a/lib/logstash/pluginmanager/util.rb
+++ b/lib/logstash/pluginmanager/util.rb
@@ -1,3 +1,5 @@
+require 'logstash/version'
+
 class LogStash::PluginManager::Util
 
   def self.logstash_plugin?(gem)
@@ -46,6 +48,22 @@ class LogStash::PluginManager::Util
           break
       end
     end
+  end
+
+  def self.load_logstash_gemspec
+    logstash_spec = Gem::Specification.new do |gem|
+      gem.authors       = ["Jordan Sissel", "Pete Fritchman"]
+      gem.email         = ["jls@semicomplete.com", "petef@databits.net"]
+      gem.description   = %q{scalable log and event management (search, archive, pipeline)}
+      gem.summary       = %q{logstash - log and event management}
+      gem.homepage      = "http://logstash.net/"
+      gem.license       = "Apache License (2.0)"
+
+      gem.name          = "logstash"
+      gem.version       = LOGSTASH_VERSION
+    end
+
+    Gem::Specification.add_spec logstash_spec
   end
 
 end


### PR DESCRIPTION
- Use better installer method to avoid documentation installation
  With the previous method it would install the documentation which didn't exist.
- Create Fake gemspec info for logstash to help dependency management for plugins
  Previously we would create a real gem and install it to aid in dependency management for plugins and logstash
  Now we create a fake gemspec on the fly with the real version of logstash avoiding having to build it every time.
