### PR TITLE
Don't open an extra log subscriber to STDOUT on HUP

### DIFF
--- a/lib/logstash/agent.rb
+++ b/lib/logstash/agent.rb
@@ -250,7 +250,8 @@ class LogStash::Agent < Clamp::Command
       @logger.unsubscribe(@logger_subscription) if @logger_subscription
       @logger_subscription = @logger.subscribe(@log_fd)
     else
-      @logger.subscribe(STDOUT)
+      @logger.unsubscribe(@logger_subscription) if @logger_subscription
+      @logger_subscription = @logger.subscribe(STDOUT) 
     end
 
     # TODO(sissel): redirect stdout/stderr to the log as well


### PR DESCRIPTION
Currently sending a HUP signal to logstash when logging to STDOUT adds and it as a subscriber again resulting in extra log messages for each HUP signal sent which is very confusing...
