### PR TITLE
Bug // Spool codec will no longer drop messages - issue#1725

### DIFF
--- a/lib/logstash/codecs/spool.rb
+++ b/lib/logstash/codecs/spool.rb
@@ -18,13 +18,13 @@ class LogStash::Codecs::Spool < LogStash::Codecs::Base
   public
   def encode(event)
     @buffer ||= []
+    @buffer << event
+
     #buffer size is hard coded for now until a
     #better way to pass args into codecs is implemented
     if @buffer.length >= @spool_size
       @on_event.call @buffer
       @buffer = []
-    else
-      @buffer << event
     end
   end # def encode
 


### PR DESCRIPTION
This would drop the last message before sending out the spool. This
patch remedies this by always adding the message to the spool before
sending it all out.
