### PR TITLE
Support for redis sentinel in redis input and output

### DIFF
--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "mail"                             #(MIT license)
   gem.add_runtime_dependency "metriks"                          #(MIT license)
   gem.add_runtime_dependency "redis"                            #(MIT license)
+  gem.add_runtime_dependency "redis-sentinel"                   #(MIT license)
   gem.add_runtime_dependency "statsd-ruby", ["1.2.0"]           #(MIT license)
   gem.add_runtime_dependency "xml-simple"                       #(ruby license?)
   gem.add_runtime_dependency "xmpp4r", ["0.5"]                  #(ruby license)


### PR DESCRIPTION
Redis supports failover through a separate service called Sentinel (http://redis.io/topics/sentinel). I added support for it to the output and input modules using the redis-sentinel wrapper library (https://github.com/flyerhzm/redis-sentinel).
