### PR TITLE
rm entire package build directory prior to build

### DIFF
--- a/pkg/build.sh
+++ b/pkg/build.sh
@@ -26,8 +26,8 @@ echo "Building package for $os $release"
 destdir=build/$(echo "$os" | tr ' ' '_')
 prefix=/opt/logstash
 
-if [ "$destdir/$prefix" != "/" -a -d "$destdir/$prefix" ] ; then
-  rm -rf "$destdir/$prefix"
+if [ "$destdir" != "/" -a -d "$destdir" ] ; then
+  rm -rf "$destdir"
 fi
 
 mkdir -p $destdir/$prefix


### PR DESCRIPTION
The rest of the build script fully populates the directory; leaving
files from a previous build creates the possibility of incorrectly
assembling the package if any files installed later in the script have
been moved or removed since the last time the package was built. To be
safe, just remove the entire build directory, not just the contents of
the extracted tarball.