### PR TITLE
Fix logstash #1738 

### DIFF
--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -110,7 +110,6 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
     end
     require 'jruby-kafka'
     options = {
-      :topic_id => @topic_id,
       :broker_list => @broker_list,
       :compression_codec => @compression_codec,
       :compressed_topics => @compressed_topics,


### PR DESCRIPTION
Addresses #1738 where the topic.id is being included in producer config.
