### PR TITLE
New Options, delay and sequence logging options

### DIFF
--- a/lib/logstash/inputs/generator.rb
+++ b/lib/logstash/inputs/generator.rb
@@ -47,8 +47,14 @@ class LogStash::Inputs::Generator < LogStash::Inputs::Threadable
   # The default, 0, means generate an unlimited number of events.
   config :count, :validate => :number, :default => 0
 
+  # Set delay(seconds) between generated events.
+  #
+  # The default,  0, means generate events as quickly as possible.
   config :delay, :validate => :number, :default => 0
 
+  # Set whether to include sequence number of generated events in event
+  #
+  #The default, true, means each event will include field 'sequence' to indicate count of generated messages. 
   config :log_sequence, :validate => :boolean, :default => true
 
   public

--- a/lib/logstash/inputs/generator.rb
+++ b/lib/logstash/inputs/generator.rb
@@ -49,7 +49,7 @@ class LogStash::Inputs::Generator < LogStash::Inputs::Threadable
 
   # Set delay(seconds) between generated events.
   #
-  # The default,  0, means generate events as quickly as possible.
+  # The default, 0, means generate events as quickly as possible.
   config :delay, :validate => :number, :default => 0
 
   # Set whether to include sequence number of generated events in event


### PR DESCRIPTION
I use this modified generator plugin to trigger some custom filters every second as a heartbeat/pulse. 

Added two options:
delay => #in seconds, delay between each event generated. Default => 0
log_sequence => Wether to add sequence number to the event. Default => true

