### PR TITLE
Remove the ability to run multiple commands

### DIFF
--- a/lib/logstash/runner.rb
+++ b/lib/logstash/runner.rb
@@ -85,12 +85,8 @@ class LogStash::Runner
 
     Stud::untrap("INT", @startup_interruption_trap)
 
-    if args.empty? then
-      exit(0)
-    else
-      task = run(args)
-      exit(task.wait)
-    end
+    task = run(args)
+    exit(task.wait)
   end # def self.main
 
   def run(args)
@@ -170,21 +166,20 @@ class LogStash::Runner
           $stderr.puts "No such command #{command.inspect}"
         end
       end
-      $stderr.puts "Usage: logstash <command> [command args]"
-      $stderr.puts "Run a command with the --help flag to see the arguments."
-      $stderr.puts "For example: logstash agent --help"
-      $stderr.puts
-      # hardcode the available commands to reduce confusion.
-      $stderr.puts "Available commands:"
-      $stderr.puts "  agent - runs the logstash agent"
-      $stderr.puts "  version - emits version info about this logstash"
-      $stderr.puts "  web - runs the logstash web ui (called Kibana)"
-      $stderr.puts "  rspec - runs tests"
-      #$stderr.puts commands.keys.map { |s| "  #{s}" }.join("\n")
-      exit 1
-    end
+      $stderr.puts %q[
+Usage: logstash <command> [command args]
+Run a command with the --help flag to see the arguments.
+For example: logstash agent --help
 
-    return args
+Available commands:
+  agent - runs the logstash agent
+  version - emits version info about this logstash
+  web - runs the logstash web ui (called Kibana)
+  rspec - runs tests
+      ]
+      #$stderr.puts commands.keys.map { |s| "  #{s}" }.join("\n")
+      return Stud::Task.new { 1 }
+    end
   end # def run
 
   # @return true if this file is the main file being run and not via rspec

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -22,6 +22,20 @@ describe LogStash::Runner do
       expect(subject.run(args).wait).to eq(0)
     end
 
+    it "should show help with no arguments" do
+      expect($stderr).to receive(:puts).once.and_return("No command given")
+      expect($stderr).to receive(:puts).once
+      args = []
+      expect(subject.run(args).wait).to eq(1)
+    end
+
+    it "should show help for unknown commands" do
+      expect($stderr).to receive(:puts).once.and_return("No such command welp")
+      expect($stderr).to receive(:puts).once
+      args = ["welp"]
+      expect(subject.run(args).wait).to eq(1)
+    end
+
     it "should run agent help and not run following commands" do
       expect(subject).to receive(:show_help).once.and_return(nil)
       args = ["agent", "-h", "web"]


### PR DESCRIPTION
Addresses #1747.
This removes the argument list iteration and spawning of multiple
tasks.
It's still possible to specify aditional arguments but now they're
ignored.
