### PR TITLE
Add Msgpack feed unpacker codec

### DIFF
--- a/lib/logstash/codecs/msgpack_feed.rb
+++ b/lib/logstash/codecs/msgpack_feed.rb
@@ -1,0 +1,44 @@
+# encoding: utf-8
+require "logstash/codecs/base"
+
+class LogStash::Codecs::MsgpackFeed < LogStash::Codecs::Base
+  config_name "msgpack_feed"
+
+  milestone 1
+
+  config :format, :validate => :string, :default => nil
+
+  def initialize(params={})
+    super(params)
+    @unpacker = MessagePack::Unpacker.new
+  end
+
+  public
+  def register
+    require "msgpack"
+  end
+
+  public
+  def decode(data)
+    begin
+      @unpacker.feed_each(data) do |rawevent|
+        event = LogStash::Event.new(rawevent)
+        event["tags"] ||= []
+        if @format
+          event["message"] ||= event.sprintf(@format)
+        end
+        yield event
+      end
+    rescue => e
+      # Treat as plain text and try to do the best we can with it?
+      @logger.warn("Trouble parsing msgpack input, falling back to plain text",
+                   :input => data, :exception => e)
+      event = LogStash::Event.new
+      event["message"] = data.encode('utf-8', 'binary', :invalid => :replace,
+                                                        :replace => ' ')
+      event["tags"] ||= []
+      event["tags"] << "_msgpackparsefailure"
+      yield event
+    end
+  end # def decode
+end # class LogStash::Codecs::MsgpackFeed

--- a/spec/codecs/msgpack_feed.rb
+++ b/spec/codecs/msgpack_feed.rb
@@ -1,0 +1,38 @@
+require "logstash/codecs/msgpack_feed"
+require "logstash/event"
+require "insist"
+
+describe LogStash::Codecs::MsgpackFeed do
+  subject do
+    next LogStash::Codecs::MsgpackFeed.new
+  end
+
+  context "#decode" do
+    it "should return three events from a msgpack feed" do
+      # Msgpack of:
+      # {"message": "one"}{"message": "two"}{"message": "three"}
+      data = "\x81\xA7message\xA3one\x81\xA7message\xA3two\x81\xA7message\xA5three".bytes.to_a
+
+      res = Array.new
+      subject.decode(data[0..6].pack('c*')) do |event|
+        res.push event
+      end
+      subject.decode(data[7..-4].pack('c*')) do |event|
+        res.push event
+      end
+      subject.decode(data[-3..-1].pack('c*')) do |event|
+        res.push event
+      end
+
+      insist { res.size } == 3
+
+      expected = ["one", "two", "three"]
+      expected.each_index {|i|
+        event = res[i]
+        insist { event.is_a? LogStash::Event }
+        insist { event["message"] } == expected[i]
+      }
+    end
+  end
+
+end


### PR DESCRIPTION
For use with TCP or pipe inputs.  Could be refactored to be an option within the msgpack codec.  My Ruby could also be rusty.