### PR TITLE
Don't overwrite the file event's path attribute

### DIFF
--- a/lib/logstash/inputs/file.rb
+++ b/lib/logstash/inputs/file.rb
@@ -134,8 +134,8 @@ class LogStash::Inputs::File < LogStash::Inputs::Base
       @logger.debug? && @logger.debug("Received line", :path => path, :text => line)
       @codec.decode(line) do |event|
         decorate(event)
-        event["host"] = hostname if !event.include?("host")
-        event["path"] = path
+        event["host"] = hostname unless event.include?("host")
+        event["path"] = path unless event.include?("path")
         queue << event
       end
     end


### PR DESCRIPTION
There is custom logic which doesn't overwrite the "host" attribute if it was
originally specified by the event. This commit adds it for the "path"
attribute as well.

This is especially useful, since handy Rails gems like Lograge [use the
"path" attribute for the request's path.][1]

[1]: https://github.com/roidrage/lograge/blob/c958aa9/lib/lograge/log_subscriber.rb#L34-L42