### PR TITLE
Add HTTP Auth and SSL to the ES output plugin

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -5,6 +5,7 @@ require "logstash/outputs/base"
 require "logstash/json"
 require "stud/buffer"
 require "socket" # for Socket.gethostname
+require "uri"
 
 # This output lets you store logs in Elasticsearch and is the most recommended
 # output for Logstash. If you plan on using the Kibana web interface, you'll
@@ -177,18 +178,28 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # For more details on actions, check out the [Elasticsearch bulk API documentation](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-bulk.html)
   config :action, :validate => :string, :default => "index"
 
+  # Username and password (HTTP only)
+  config :user, :validate => :string
+  config :password, :validate => :password
+
+  # SSL Configurations (HTTP only)
+  #
+  # Enable SSL
+  config :ssl, :validate => :boolean, :default => false
+
+  # The .cer or .pem file to validate the server's certificate
+  config :cacert, :validate => :path
+
+  # The JKS truststore to validate the server's certificate
+  # Use either :truststore or :cacert
+  config :truststore, :validate => :path
+
+  # Set the truststore password
+  config :truststore_password, :validate => :password
+
   public
   def register
     client_settings = {}
-    client_settings["cluster.name"] = @cluster if @cluster
-    client_settings["network.host"] = @bind_host if @bind_host
-    client_settings["transport.tcp.port"] = @bind_port if @bind_port
-
-    if @node_name
-      client_settings["node.name"] = @node_name
-    else
-      client_settings["node.name"] = "logstash-#{Socket.gethostname}-#{$$}-#{object_id}"
-    end
 
     if @protocol.nil?
       @protocol = LogStash::Environment.jruby? ? "node" : "http"
@@ -201,6 +212,16 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
       # setup log4j properties for Elasticsearch
       LogStash::Logger.setup_log4j(@logger)
+
+      client_settings["cluster.name"] = @cluster if @cluster
+      client_settings["network.host"] = @bind_host if @bind_host
+      client_settings["transport.tcp.port"] = @bind_port if @bind_port
+
+      if @node_name
+        client_settings["node.name"] = @node_name
+      else
+        client_settings["node.name"] = "logstash-#{Socket.gethostname}-#{$$}-#{object_id}"
+      end
     end
 
     require "logstash/outputs/elasticsearch/protocol"
@@ -217,12 +238,45 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
       @host = ["localhost"]
     end
 
+    if @ssl
+      if @protocol == "http"
+        @protocol = "https"
+        if @cacert && @truststore
+          raise(LogStash::ConfigurationError, "Use either \"cacert\" or \"truststore\" when configuring the CA certificate") if @truststore
+        end
+        ssl_options = {}
+        if @cacert then
+          @truststore, ssl_options[:truststore_password] = generate_jks @cacert
+        elsif @truststore
+          ssl_options[:truststore_password] = @truststore_password.value if @truststore_password
+        end
+        ssl_options[:truststore] = @truststore
+        client_settings[:ssl] = ssl_options
+      else
+        raise(LogStash::ConfigurationError, "SSL is not supported for '#{@protocol}'. Change the protocol to 'http' if you need SSL.")
+      end
+    end
+
+    common_options = {
+      :protocol => @protocol,
+      :client_settings => client_settings
+    }
+
+    if @user && @password
+      if @protocol =~ /http/
+        common_options[:user] = ::URI.escape(@user, "@:")
+        common_options[:password] = ::URI.escape(@password.value, "@:")
+      else
+        raise(LogStash::ConfigurationError, "User and password parameters are not supported for '#{@protocol}'. Change the protocol to 'http' if you need them.")
+      end
+    end
+
     client_class = case @protocol
       when "transport"
         LogStash::Outputs::Elasticsearch::Protocols::TransportClient
       when "node"
         LogStash::Outputs::Elasticsearch::Protocols::NodeClient
-      when "http"
+      when /http/
         LogStash::Outputs::Elasticsearch::Protocols::HTTPClient
     end
 
@@ -245,8 +299,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
       options = {
           :host => @host,
           :port => @port,
-          :client_settings => client_settings
-      }
+      }.merge(common_options)
       @client << client_class.new(options)
     else # if @protocol in ["transport","http"]
       @host.each do |host|
@@ -254,8 +307,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
           options = {
             :host => _host,
             :port => _port || @port,
-            :client_settings => client_settings
-          }
+          }.merge(common_options)
           @logger.info "Create client to elasticsearch server on #{_host}:#{_port}"
           @client << client_class.new(options)
       end # @host.each
@@ -322,6 +374,29 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     @embedded_elasticsearch.start
   end # def start_local_elasticsearch
 
+  private
+  def generate_jks cert_path
+
+    require 'securerandom'
+    require 'tempfile'
+    require 'java'
+    import java.io.FileInputStream
+    import java.io.FileOutputStream
+    import java.security.KeyStore
+    import java.security.cert.CertificateFactory
+
+    jks = java.io.File.createTempFile("cert", ".jks")
+
+    ks = KeyStore.getInstance "JKS"
+    ks.load nil, nil
+    cf = CertificateFactory.getInstance "X.509"
+    cert = cf.generateCertificate FileInputStream.new(cert_path)
+    ks.setCertificateEntry "cacert", cert
+    pwd = SecureRandom.urlsafe_base64(9)
+    ks.store FileOutputStream.new(jks), pwd.to_java.toCharArray
+    [jks.path, pwd]
+  end
+
   public
   def receive(event)
     return unless output?(event)
@@ -360,6 +435,9 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   end # def flush
 
   def teardown
+    if @cacert # remove temporary jks store created from the cacert
+      File.delete(@truststore)
+    end
     buffer_flush(:final => true)
   end
 

--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "bindata", [">= 1.5.0"]            #(Ruby license)
   gem.add_runtime_dependency "twitter", "5.0.0.rc.1"            #(MIT license)
   gem.add_runtime_dependency "edn"                              #(MIT license)
-  gem.add_runtime_dependency "elasticsearch"                    #(Apache 2.0 license)
+  gem.add_runtime_dependency "elasticsearch", "~> 1.0.6"        #(Apache 2.0 license)
 
   # Plugin manager dependencies
 
@@ -85,6 +85,7 @@ Gem::Specification.new do |gem|
     gem.add_runtime_dependency "msgpack-jruby"                       #(Apache 2.0 license)
     gem.add_runtime_dependency "jrjackson"                           #(Apache 2.0 license)
     gem.add_runtime_dependency "jruby-kafka", [">=0.1.0"]            #(Apache 2.0 license)
+    gem.add_runtime_dependency "manticore"                           #(Apache 2.0 license)
   else
     gem.add_runtime_dependency "excon"    #(MIT license)
     gem.add_runtime_dependency "msgpack"  #(Apache 2.0 license)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,6 @@ end
 
 RSpec.configure do |config|
   config.extend LogStashHelper
-  config.filter_run_excluding :redis => true, :socket => true, :performance => true, :elasticsearch => true, :broken => true, :export_cypher => true
+  config.filter_run_excluding :redis => true, :socket => true, :performance => true, :elasticsearch => true, :elasticsearch_secure => true, :broken => true, :export_cypher => true
 end
 


### PR DESCRIPTION
The typical use case is the placement of a transparent proxy in front of
ES. This PR enables basic Auth and HTTPS to be configured independently.

While the SSL configurations only allow the validation of the server's
certificate and specification of the CA cert, it's easy to add the
necessary options to send the client's certificate.

Also, this patch removes the use of FTW in the output plugin, sticking only to the elasticsearch-ruby client. If performance is an issue, a faster alternative to the faraday transport in es-ruby could be implemented.
