### PR TITLE
elasticsearch_http: Use source._id automatically

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -169,10 +169,11 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # What does each action do?
   #
   # - index: indexes a document (an event from logstash).
+  # - create: creates a document (fail when it already exists)
   # - delete: deletes a document by id
   #
   # For more details on actions, check out the [Elasticsearch bulk API documentation](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-bulk.html)
-  config :action, :validate => :string, :default => "index"
+  config :action, :validate => [ "index", "create", "delete" ], :default => "index"
 
   public
   def register
@@ -303,7 +304,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
     index = event.sprintf(@index)
 
-    document_id = @document_id ? event.sprintf(@document_id) : nil
+    document_id = @document_id ? event.sprintf(@document_id) : event["_id"]
     buffer_receive([event.sprintf(@action), { :_id => document_id, :_index => index, :_type => type }, event.to_hash])
   end # def receive
 

--- a/lib/logstash/outputs/elasticsearch_http.rb
+++ b/lib/logstash/outputs/elasticsearch_http.rb
@@ -94,7 +94,7 @@ class LogStash::Outputs::ElasticSearchHTTP < LogStash::Outputs::Base
   config :replication, :validate => ['async', 'sync'], :default => 'sync'
 
   # Indexer action to perform.
-  config :action, :validate => ['index', 'create', 'delete'], :default => 'create'
+  config :action, :validate => ['index', 'create', 'delete'], :default => 'index'
 
   public
   def register

--- a/lib/logstash/outputs/elasticsearch_http.rb
+++ b/lib/logstash/outputs/elasticsearch_http.rb
@@ -93,6 +93,9 @@ class LogStash::Outputs::ElasticSearchHTTP < LogStash::Outputs::Base
   # written.
   config :replication, :validate => ['async', 'sync'], :default => 'sync'
 
+  # Indexer action to perform.
+  config :action, :validate => ['index', 'create', 'delete'], :default => 'create'
+
   public
   def register
     require "ftw" # gem ftw
@@ -202,9 +205,13 @@ class LogStash::Outputs::ElasticSearchHTTP < LogStash::Outputs::Base
       else
         type = event.sprintf(@index_type)
       end
-      header = { "index" => { "_index" => index, "_type" => type } }
-      header["index"]["_id"] = event.sprintf(@document_id) if !@document_id.nil?
-
+      header = { "_index" => index, "_type" => type }
+      if !@document_id.nil?
+        header["_id"] = event.sprintf(@document_id)
+      elsif event["_id"]
+        header["_id"] = event["_id"]
+      end
+      header = { @action => header }
       [ LogStash::Json.dump(header), newline, event.to_json, newline ]
     end.flatten
 


### PR DESCRIPTION
This is an alternative to using document_id option.  Better suited to diverse deployments when some sources provide unique id and others don't.