### PR TITLE
Solve the problem of 8 hours time zone difference

### DIFF
--- a/lib/logstash/event.rb
+++ b/lib/logstash/event.rb
@@ -217,7 +217,7 @@ class LogStash::Event
       elsif key[0,1] == "+"
         t = @data[TIMESTAMP]
         formatter = org.joda.time.format.DateTimeFormat.forPattern(key[1 .. -1])\
-          .withZone(org.joda.time.DateTimeZone::UTC)
+          .withZone(org.joda.time.DateTimeZone.getDefault())
         #next org.joda.time.Instant.new(t.tv_sec * 1000 + t.tv_usec / 1000).toDateTime.toString(formatter)
         # Invoke a specific Instant constructor to avoid this warning in JRuby
         #  > ambiguous Java methods found, using org.joda.time.Instant(long)


### PR DESCRIPTION
Output per day to elasticsearch index, because use utc, from 8:00 to create index on the same day, every day while before 8:00 data output to the yesterday's index, the configuration is as follows

output {
  elasticsearch {
    host => "sea2"
    index => "soa_logs-%{+YYYY.MM.dd}"
  }
}
Because the time zone problem will index at 8:00 to create

drwxrwxr-x 8 hadoop hadoop 4096 Sep 17 08:00 soa_logs-2014.09.17
drwxrwxr-x 8 hadoop hadoop 4096 Sep 18 08:00 soa_logs-2014.09.18
drwxrwxr-x 8 hadoop hadoop 4096 Sep 19 08:00 soa_logs-2014.09.19
drwxrwxr-x 8 hadoop hadoop 4096 Sep 20 08:00 soa_logs-2014.09.20
drwxrwxr-x 8 hadoop hadoop 4096 Sep 21 08:00 soa_logs-2014.09.21

Check the joda source code, a DateTimeZone have access to the system default time zone method.getDefault ()
The solution：
WithZone (org. Joda. Time. DateTimeZone: : UTC)
Modified to
WithZone (org. Joda. Time. DateTimeZone.getDefault ())