### PR TITLE
Update sqs doc

### DIFF
--- a/lib/logstash/outputs/sqs.rb
+++ b/lib/logstash/outputs/sqs.rb
@@ -61,6 +61,7 @@ require "digest/sha2"
 #  * sqs:ListQueues
 #  * sqs:ChangeMessageVisibilityBatch
 #  * sqs:SendMessage
+#
 # A sample policy is as follows:
 #
 #      {

--- a/lib/logstash/outputs/sqs.rb
+++ b/lib/logstash/outputs/sqs.rb
@@ -56,8 +56,32 @@ require "digest/sha2"
 #        ]
 #      }
 #
-# See http://aws.amazon.com/iam/ for more details on setting up AWS identities.
+# The "source" identity shipping logs must have the following permissions on the queue:
 #
+#  * sqs:ListQueues
+#  * sqs:ChangeMessageVisibilityBatch
+#  * sqs:SendMessage
+# A sample policy is as follows:
+#
+#      {
+#        "Statement": [
+#          {
+#            "Sid": "Stmt1347986764948",
+#            "Action": [
+#              "sqs:ListQueues",
+#              "sqs:ChangeMessageVisibilityBatch",
+#              "sqs:SendMessage"
+#            ],
+#            "Effect": "Allow",
+#            "Resource": [
+#              "arn:aws:sqs:us-east-1:200850199751:Logstash"
+#            ]
+#          }
+#        ]
+#      }
+#
+# See http://aws.amazon.com/iam/ for more details on setting up AWS identities.
+
 class LogStash::Outputs::SQS < LogStash::Outputs::Base
   include LogStash::PluginMixins::AwsConfig
   include Stud::Buffer


### PR DESCRIPTION
Something helpful for setup using the SQS plugin for Logstash is to have the IAM policy for the *shipper* of messages. The "consumer" policy provided obviously doesn't work for this, since it can't submit to the SQS queue. Committed here is the addition of the shipper or "source" IAM policy necessary to send messages to the queue.