### PR TITLE
filter/xml fix for LOGSTASH-2246: extract non-ascii content with xpath

### DIFF
--- a/lib/logstash/filters/xml.rb
+++ b/lib/logstash/filters/xml.rb
@@ -115,7 +115,7 @@ class LogStash::Filters::Xml < LogStash::Filters::Base
           unless value.nil?
             matched = true
             event[xpath_dest] ||= []
-            event[xpath_dest] << value.to_s
+            event[xpath_dest] << value.to_str
           end
         end # XPath.each
       end # @xpath.each

--- a/spec/filters/xml.rb
+++ b/spec/filters/xml.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "test_utils"
 require "logstash/filters/xml"
 
@@ -151,6 +152,24 @@ describe LogStash::Filters::Xml do
     sample("xmldata" => '<foo><key>value1</key><key>value2</key></foo>') do
       insist { subject["tags"] }.nil?
       insist { subject["xpath_field"]} == ["value1","value2"]
+    end
+  end
+
+  describe "parse correctly non ascii content with xpath" do
+    config <<-CONFIG
+    filter {
+      xml {
+        source => "xmldata"
+        target => "data"
+        xpath => [ "/foo/key/text()", "xpath_field" ]
+      }
+    }
+    CONFIG
+
+    # Single value
+    sample("xmldata" => '<foo><key>Français</key></foo>') do
+      insist { subject["tags"] }.nil?
+      insist { subject["xpath_field"]} == ["Français"]
     end
   end
 


### PR DESCRIPTION
As reported in [LOGSTASH-2246](https://logstash.jira.com/browse/LOGSTASH-2246), xml filter xpath fails with non-ascii content,
here is a test case and fix.

It is due to Nokogiri [to_s](http://nokogiri.org/Nokogiri/XML/Node.html#method-i-to_s) calling to_xhml or to_xml without encoding parameters.
using the to_str method extract the content differently (hidden in the C or Java implementation) and do not suffer encoding issue
