### PR TITLE
Avoid static file corruption (small.png) on Windows

### DIFF
--- a/lib/logstash/kibana.rb
+++ b/lib/logstash/kibana.rb
@@ -42,7 +42,7 @@ module LogStash::Kibana
       if File.exists?(path)
         ext = path.split(".").last
         content_type MIME::Types.type_for(ext).first.to_s
-        body File.new(path, "r").read
+        body File.new(path, "rb").read
       else
         status 404
         content_type "text/plain"


### PR DESCRIPTION
When using `logstash web` on Windows the Kibana Logo on the dashboard is broken. This is because it will return small.png with 479 instead of 480 bytes (removing a 0x0d).
