### PR TITLE
Added configtest switch in init script

### DIFF
--- a/pkg/logstash.sysv
+++ b/pkg/logstash.sysv
@@ -90,6 +90,16 @@ stop() {
   fi
 }
 
+config_test() {
+  [ -x $program ] || return 4
+  $program -f ${LS_CONF_DIR} -l ${LS_LOG_FILE} ${LS_OPTS} --configtest
+  RETVAL=$?
+  if [ $RETVAL -eq 0 ]; then
+    echo "Syntax: OK" >&2
+  fi
+  return $RETVAL
+}
+
 status() {
   if [ -f "$pidfile" ] ; then
     pid=`cat "$pidfile"`
@@ -130,6 +140,7 @@ case "$1" in
     ;;
   stop) stop ;;
   force-stop) force_stop ;;
+  configtest) config_test ;;
   status) 
     status
     code=$?
@@ -145,7 +156,7 @@ case "$1" in
     stop && start 
     ;;
   *)
-    echo "Usage: $SCRIPTNAME {start|stop|force-stop|status|restart}" >&2
+    echo "Usage: $SCRIPTNAME {start|stop|force-stop|configtest|status|restart}" >&2
     exit 3
   ;;
 esac


### PR DESCRIPTION
Added configtest switch in init script. If syntax is ok the expected output is:

# service logstash configtest
Sending logstash logs to /var/log/logstash/logstash.log.
Configuration OK
Configuration OK
Syntax: OK

(and service is not started.)

If syntax is not ok then the expected output would be:

# service logstash configtest
Sending logstash logs to /var/log/logstash/logstash.log.
Error: Expected ..., { at line xx, column y (byte zzz) after # This is a comment. You should use comments to describe...
