### PR TITLE
gem bundling refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #   rsync
 #   wget or curl
 #
-JRUBY_VERSION=1.7.11
+JRUBY_VERSION=1.7.16
 ELASTICSEARCH_VERSION=1.1.1
 
 WITH_JRUBY=java -jar $(shell pwd)/$(JRUBY) -S

--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -16,63 +16,75 @@ Gem::Specification.new do |gem|
   gem.version       = LOGSTASH_VERSION
 
   # Core dependencies
-  gem.add_runtime_dependency "cabin", [">=0.6.0"]   #(Apache 2.0 license)
-  gem.add_runtime_dependency "minitest"           # for running the tests from the jar, (MIT license)
-  gem.add_runtime_dependency "pry"                #(ruby license)
+  gem.add_runtime_dependency "cabin", [">=0.6.0"] #(Apache 2.0 license)
+  gem.add_runtime_dependency "minitest"           #(MIT license) for running the tests from the jar,
+  gem.add_runtime_dependency "pry"                #(Ruby license)
   gem.add_runtime_dependency "stud"               #(Apache 2.0 license)
-  gem.add_runtime_dependency "clamp"              # for command line args/flags (MIT license)
-  gem.add_runtime_dependency "i18n", [">=0.6.6"]  #(MIT license)
+  gem.add_runtime_dependency "clamp"              #(MIT license) for command line args/flags
+
+  # upgrade i18n only post 0.6.11, see https://github.com/svenfuchs/i18n/issues/270
+  gem.add_runtime_dependency "i18n", ["=0.6.9"]   #(MIT license)
 
   # Web dependencies
   gem.add_runtime_dependency "ftw", ["~> 0.0.39"] #(Apache 2.0 license)
   gem.add_runtime_dependency "mime-types"         #(GPL 2.0)
-  gem.add_runtime_dependency "rack"               # (MIT-style license)
-  gem.add_runtime_dependency "sinatra"            # (MIT-style license)
+  gem.add_runtime_dependency "rack"               #(MIT-style license)
+  gem.add_runtime_dependency "sinatra"            #(MIT-style license)
 
   # Input/Output/Filter dependencies
   #TODO Can these be optional?
   gem.add_runtime_dependency "awesome_print"                    #(MIT license)
-  gem.add_runtime_dependency "aws-sdk"                          #{Apache 2.0 license}
+  gem.add_runtime_dependency "aws-sdk"                          #(Apache 2.0 license)
   gem.add_runtime_dependency "addressable"                      #(Apache 2.0 license)
   gem.add_runtime_dependency "extlib", ["0.9.16"]               #(MIT license)
-  gem.add_runtime_dependency "ffi"                              #(LGPL-3 license)
+  gem.add_runtime_dependency "ffi", ["~> 1.9.5"]                #(LGPL-3 license)
   gem.add_runtime_dependency "ffi-rzmq", ["1.0.0"]              #(MIT license)
   gem.add_runtime_dependency "filewatch", ["0.5.1"]             #(BSD license)
   gem.add_runtime_dependency "gelfd", ["0.2.0"]                 #(Apache 2.0 license)
   gem.add_runtime_dependency "gelf", ["1.3.2"]                  #(MIT license)
   gem.add_runtime_dependency "gmetric", ["0.1.3"]               #(MIT license)
-  gem.add_runtime_dependency "jls-grok", ["0.11.0"]            #(BSD license)
+  gem.add_runtime_dependency "jls-grok", ["0.11.0"]             #(BSD license)
   gem.add_runtime_dependency "mail"                             #(MIT license)
   gem.add_runtime_dependency "metriks"                          #(MIT license)
   gem.add_runtime_dependency "redis"                            #(MIT license)
   gem.add_runtime_dependency "statsd-ruby", ["1.2.0"]           #(MIT license)
-  gem.add_runtime_dependency "xml-simple"                       #(ruby license?)
-  gem.add_runtime_dependency "xmpp4r", ["0.5"]                  #(ruby license)
+  gem.add_runtime_dependency "xml-simple"                       #(Ruby license?)
+  gem.add_runtime_dependency "xmpp4r", ["0.5"]                  #(Ruby license)
   gem.add_runtime_dependency "jls-lumberjack", [">=0.0.20"]     #(Apache 2.0 license)
   gem.add_runtime_dependency "geoip", [">= 1.3.2"]              #(GPL license)
   gem.add_runtime_dependency "beefcake", "0.3.7"                #(MIT license)
   gem.add_runtime_dependency "murmurhash3"                      #(MIT license)
   gem.add_runtime_dependency "rufus-scheduler", "~> 2.0.24"     #(MIT license)
   gem.add_runtime_dependency "user_agent_parser", [">= 2.0.0"]  #(MIT license)
-  gem.add_runtime_dependency "snmp"                             #(ruby license)
+  gem.add_runtime_dependency "snmp"                             #(Ruby license)
   gem.add_runtime_dependency "rbnacl"                           #(MIT license)
-  gem.add_runtime_dependency "bindata", [">= 1.5.0"]            #(ruby license)
+  gem.add_runtime_dependency "bindata", [">= 1.5.0"]            #(Ruby license)
   gem.add_runtime_dependency "twitter", "5.0.0.rc.1"            #(MIT license)
   gem.add_runtime_dependency "edn"                              #(MIT license)
-  gem.add_runtime_dependency "elasticsearch"                    #9Apache 2.0 license)
+  gem.add_runtime_dependency "elasticsearch"                    #(Apache 2.0 license)
 
   # Plugin manager dependencies
-  gem.add_runtime_dependency "jar-dependencies"                    #(MIT license)
-  gem.add_runtime_dependency "ruby-maven"                          #(EPL license)
+
+  # jar-dependencies 0.1.2 is included in jruby 1.7.6 no need to include here and
+  # this avoids the gemspec jar path parsing issue of jar-dependencies 0.1.2
+  #
+  # gem.add_runtime_dependency "jar-dependencies", [">= 0.1.2"]   #(MIT license)
+
+  gem.add_runtime_dependency "ruby-maven"                       #(EPL license)
 
   if RUBY_PLATFORM == 'java'
     gem.platform = RUBY_PLATFORM
-    gem.add_runtime_dependency "jruby-httpclient"                 #(Apache 2.0 license)
-    gem.add_runtime_dependency "bouncy-castle-java", "1.5.0147"   #(MIT license)
-    gem.add_runtime_dependency "jruby-openssl", "0.8.7"           #(CPL/GPL/LGPL license)
-    gem.add_runtime_dependency "msgpack-jruby"                    #(Apache 2.0 license)
-    gem.add_runtime_dependency "jrjackson"                        #(Apache 2.0 license)
-    gem.add_runtime_dependency "jruby-kafka", [">=0.1.0"]         #(Apache 2.0 license)
+
+    # bouncy-castle-java 1.5.0147 and jruby-openssl 0.9.5 are included in jruby 1.7.6 no need to include here
+    # and this avoids the gemspec jar path parsing issue of jar-dependencies 0.1.2
+    #
+    # gem.add_runtime_dependency "bouncy-castle-java", ["~> 1.5.0147"] #(MIT license)
+    # gem.add_runtime_dependency "jruby-openssl", ["~> 0.9.5"]         #(CPL/GPL/LGPL license)
+
+    gem.add_runtime_dependency "jruby-httpclient"                    #(Apache 2.0 license)
+    gem.add_runtime_dependency "msgpack-jruby"                       #(Apache 2.0 license)
+    gem.add_runtime_dependency "jrjackson"                           #(Apache 2.0 license)
+    gem.add_runtime_dependency "jruby-kafka", [">=0.1.0"]            #(Apache 2.0 license)
   else
     gem.add_runtime_dependency "excon"    #(MIT license)
     gem.add_runtime_dependency "msgpack"  #(Apache 2.0 license)
@@ -80,7 +92,7 @@ Gem::Specification.new do |gem|
   end
 
   if RUBY_PLATFORM != 'java'
-    gem.add_runtime_dependency "bunny",      ["~> 1.4.0"]  #(MIT license)
+    gem.add_runtime_dependency "bunny",      ["~> 1.4.0"] #(MIT license)
   else
     gem.add_runtime_dependency "march_hare", ["~> 2.5.1"] #(MIT license)
   end
@@ -99,16 +111,16 @@ Gem::Specification.new do |gem|
   end
 
   # These are runtime-deps so you can do 'java -jar logstash.jar rspec <test>'
-  gem.add_runtime_dependency "spoon"            #(Apache 2.0 license)
-  gem.add_runtime_dependency "mocha"            #(MIT license)
-  gem.add_runtime_dependency "shoulda"          #(MIT license)
-  gem.add_runtime_dependency "rspec", "~> 2.14.0"            #(MIT license)
-  gem.add_runtime_dependency "insist", "1.0.0"  #(Apache 2.0 license)
-  gem.add_runtime_dependency "rumbster"         # For faking smtp in email tests (Apache 2.0 license)
+  gem.add_runtime_dependency "spoon"              #(Apache 2.0 license)
+  gem.add_runtime_dependency "mocha"              #(MIT license)
+  gem.add_runtime_dependency "shoulda"            #(MIT license)
+  gem.add_runtime_dependency "rspec", "~> 2.14.0" #(MIT license)
+  gem.add_runtime_dependency "insist", "1.0.0"    #(Apache 2.0 license)
+  gem.add_runtime_dependency "rumbster"           #(Apache 2.0 license) For faking smtp in email tests
 
   # Development Deps
   gem.add_development_dependency "coveralls"
-  gem.add_development_dependency "kramdown"     # pure-ruby markdown parser (MIT license)
+  gem.add_development_dependency "kramdown"       #(MIT license) pure-ruby markdown parser
 
   # Jenkins Deps
   gem.add_runtime_dependency "ci_reporter"

--- a/tools/Gemfile
+++ b/tools/Gemfile
@@ -1,14 +1,5 @@
 source "https://rubygems.org"
-#gemspec(:name => "logstash", :path => "../")
+gemspec :path => File.expand_path(File.join(File.dirname(__FILE__), "..")), :name => "logstash", :development_group => :development
 
-gemspec = File.join(File.dirname(__FILE__), "..", "logstash.gemspec")
-spec = Gem::Specification.load(gemspec)
-spec.runtime_dependencies.each do |dep|
-  gem dep.name, dep.requirement.to_s
-end
-
-group :development do
-  spec.development_dependencies.each do |dep|
-    gem dep.name, dep.requirement.to_s
-  end
-end
+# in development if a local, unpublished gems is required, you must add it first in the gemspec without the :path option
+# and also add it here with the :path option.

--- a/tools/Gemfile.jruby-1.9.lock
+++ b/tools/Gemfile.jruby-1.9.lock
@@ -1,7 +1,65 @@
+PATH
+  remote: /Users/colin/dev/src/elasticsearch/logstash
+  specs:
+    logstash (1.5.0.dev-java)
+      addressable
+      awesome_print
+      aws-sdk
+      beefcake (= 0.3.7)
+      bindata (>= 1.5.0)
+      cabin (>= 0.6.0)
+      ci_reporter
+      cinch
+      clamp
+      edn
+      elasticsearch
+      extlib (= 0.9.16)
+      ffi (~> 1.9.5)
+      ffi-rzmq (= 1.0.0)
+      filewatch (= 0.5.1)
+      ftw (~> 0.0.39)
+      gelf (= 1.3.2)
+      gelfd (= 0.2.0)
+      geoip (>= 1.3.2)
+      gmetric (= 0.1.3)
+      i18n (= 0.6.9)
+      insist (= 1.0.0)
+      jls-grok (= 0.11.0)
+      jls-lumberjack (>= 0.0.20)
+      jrjackson
+      jruby-httpclient
+      jruby-kafka (>= 0.1.0)
+      mail
+      march_hare (~> 2.5.1)
+      metriks
+      mime-types
+      minitest
+      mocha
+      msgpack-jruby
+      murmurhash3
+      pry
+      rack
+      rbnacl
+      redis
+      rspec (~> 2.14.0)
+      ruby-maven
+      rufus-scheduler (~> 2.0.24)
+      rumbster
+      shoulda
+      sinatra
+      snmp
+      spoon
+      statsd-ruby (= 1.2.0)
+      stud
+      twitter (= 5.0.0.rc.1)
+      user_agent_parser (>= 2.0.0)
+      xml-simple
+      xmpp4r (= 0.5)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.1.1)
+    activesupport (4.1.6)
       i18n (~> 0.6, >= 0.6.9)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -11,48 +69,56 @@ GEM
     atomic (1.1.16-java)
     avl_tree (1.1.3)
     awesome_print (1.2.0)
-    aws-sdk (1.41.0)
+    aws-sdk (1.54.0)
+      aws-sdk-v1 (= 1.54.0)
+    aws-sdk-v1 (1.54.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
-    backports (3.6.0)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
+    backports (3.6.1)
     beefcake (0.3.7)
     bindata (2.1.0)
-    blankslate (2.1.2.4)
-    bouncy-castle-java (1.5.0147)
     buftok (0.1)
     builder (3.2.2)
     cabin (0.6.1)
-    ci_reporter (1.9.2)
+    ci_reporter (2.0.0)
       builder (>= 2.1.2)
     cinch (2.1.0)
     clamp (0.6.3)
     coderay (1.1.0)
-    coveralls (0.7.0)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
+    coveralls (0.7.1)
       multi_json (~> 1.3)
       rest-client
       simplecov (>= 0.7)
       term-ansicolor
       thor
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
-    docile (1.1.3)
-    edn (1.0.3)
-      parslet (~> 1.4.0)
-    elasticsearch (1.0.2)
-      elasticsearch-api (= 1.0.2)
-      elasticsearch-transport (= 1.0.2)
-    elasticsearch-api (1.0.2)
+    docile (1.1.5)
+    edn (1.0.6)
+    elasticsearch (1.0.5)
+      elasticsearch-api (= 1.0.5)
+      elasticsearch-transport (= 1.0.5)
+    elasticsearch-api (1.0.5)
       multi_json
-    elasticsearch-transport (1.0.2)
+    elasticsearch-transport (1.0.5)
       faraday
       multi_json
+    equalizer (0.0.9)
     extlib (0.9.16)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.3-java)
+    ffi (1.9.5-java)
     ffi-rzmq (1.0.0)
       ffi
     filewatch (0.5.1)
-    ftw (0.0.39)
+    ftw (0.0.40)
       addressable
       backports (>= 2.6.2)
       cabin (> 0)
@@ -62,27 +128,32 @@ GEM
     gelfd (0.2.0)
     geoip (1.4.0)
     gmetric (0.1.3)
-    hitimes (1.2.1-java)
-    http (0.5.0)
+    hitimes (1.2.2-java)
+    http (0.5.1)
       http_parser.rb
     http_parser.rb (0.5.3-java)
     i18n (0.6.9)
+    ice_nine (0.11.0)
     insist (1.0.0)
+    jbundler (0.5.5)
+      bundler (~> 1.5)
+      ruby-maven (>= 3.1.1.0.1, < 3.1.2)
     jls-grok (0.11.0)
       cabin (>= 0.6.0)
     jls-lumberjack (0.0.20)
     jrjackson (0.2.7)
     jruby-httpclient (1.1.1-java)
-    jruby-kafka (0.1.0)
-    jruby-openssl (0.8.7)
-      bouncy-castle-java (>= 1.5.0147)
+    jruby-kafka (0.2.1-java)
+      jbundler (= 0.5.5)
     json (1.8.1-java)
-    kramdown (1.3.3)
+    kramdown (1.4.2)
     mail (2.5.3)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    march_hare (2.1.2-java)
+    march_hare (2.5.1-java)
+    maven-tools (1.0.5)
+      virtus (~> 1.0)
     metaclass (0.0.4)
     method_source (0.8.2)
     metriks (0.9.9.6)
@@ -90,30 +161,30 @@ GEM
       avl_tree (~> 1.1.2)
       hitimes (~> 1.1)
     mime-types (1.25.1)
-    minitest (5.3.4)
+    minitest (5.4.2)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     msgpack-jruby (1.4.0-java)
     multi_json (1.10.1)
     multipart-post (2.0.0)
     murmurhash3 (0.1.4)
-    nokogiri (1.6.2.1-java)
-    parslet (1.4.0)
-      blankslate (~> 2.0)
-    polyglot (0.3.4)
-    pry (0.9.12.6-java)
-      coderay (~> 1.0)
-      method_source (~> 0.8)
+    netrc (0.7.7)
+    nokogiri (1.6.3.1-java)
+    polyglot (0.3.5)
+    pry (0.10.1-java)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
       slop (~> 3.4)
       spoon (~> 0.0)
     rack (1.5.2)
     rack-protection (1.5.3)
       rack
-    rbnacl (3.1.0)
+    rbnacl (3.1.2)
       ffi
-    redis (3.0.7)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    redis (3.1.0)
+    rest-client (1.7.2)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -122,6 +193,10 @@ GEM
     rspec-expectations (2.14.5)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.6)
+    ruby-maven (3.1.1.0.8)
+      maven-tools (~> 1.0.1)
+      ruby-maven-libs (= 3.1.1)
+    ruby-maven-libs (3.1.1)
     rufus-scheduler (2.0.24)
       tzinfo (>= 0.3.22)
     rumbster (1.1.1)
@@ -130,20 +205,20 @@ GEM
       shoulda-context (~> 1.0, >= 1.0.1)
       shoulda-matchers (>= 1.4.1, < 3.0)
     shoulda-context (1.2.1)
-    shoulda-matchers (2.6.1)
+    shoulda-matchers (2.7.0)
       activesupport (>= 3.0.0)
     simple_oauth (0.2.0)
-    simplecov (0.8.2)
+    simplecov (0.9.1)
       docile (~> 1.1.0)
-      multi_json
+      multi_json (~> 1.0)
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
     sinatra (1.4.5)
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
-    slop (3.5.0)
-    snmp (1.1.1)
+    slop (3.6.0)
+    snmp (1.2.0)
     spoon (0.0.4)
       ffi
     statsd-ruby (1.2.0)
@@ -153,11 +228,102 @@ GEM
     term-ansicolor (1.3.0)
       tins (~> 1.0)
     thor (0.19.1)
-    thread_safe (0.3.3-java)
+    thread_safe (0.3.4-java)
     tilt (1.4.1)
-    tins (1.3.0)
+    tins (1.3.3)
     treetop (1.4.15)
       polyglot
+      polyglot
+      polyglot
+      polyglot
+      polyglot
+      polyglot
+      polyglot
+      polyglot
+      polyglot
+      polyglot
+      polyglot
+      polyglot
+      polyglot
+      polyglot
+      polyglot
+      polyglot
+      polyglot
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
+      polyglot (>= 0.3.1)
       polyglot (>= 0.3.1)
     twitter (5.0.0.rc.1)
       buftok (~> 0.1.0)
@@ -166,69 +332,21 @@ GEM
       http_parser.rb (~> 0.5.0)
       json (~> 1.8)
       simple_oauth (~> 0.2.0)
-    tzinfo (1.2.0)
+    tzinfo (1.2.2)
       thread_safe (~> 0.1)
     user_agent_parser (2.1.5)
-    xml-simple (1.1.3)
+    virtus (1.0.3)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
+    xml-simple (1.1.4)
     xmpp4r (0.5)
 
 PLATFORMS
   java
 
 DEPENDENCIES
-  addressable
-  awesome_print
-  aws-sdk
-  beefcake (= 0.3.7)
-  bindata (>= 1.5.0)
-  bouncy-castle-java (= 1.5.0147)
-  cabin (>= 0.6.0)
-  ci_reporter
-  cinch
-  clamp
   coveralls
-  edn
-  elasticsearch
-  extlib (= 0.9.16)
-  ffi
-  ffi-rzmq (= 1.0.0)
-  filewatch (= 0.5.1)
-  ftw (~> 0.0.39)
-  gelf (= 1.3.2)
-  gelfd (= 0.2.0)
-  geoip (>= 1.3.2)
-  gmetric (= 0.1.3)
-  i18n (>= 0.6.6)
-  insist (= 1.0.0)
-  jls-grok (= 0.11.0)
-  jls-lumberjack (>= 0.0.20)
-  jrjackson
-  jruby-httpclient
-  jruby-kafka (>= 0.1.0)
-  jruby-openssl (= 0.8.7)
   kramdown
-  mail
-  march_hare (~> 2.1.0)
-  metriks
-  mime-types
-  minitest
-  mocha
-  msgpack-jruby
-  murmurhash3
-  pry
-  rack
-  rbnacl
-  redis
-  rspec
-  rufus-scheduler (~> 2.0.24)
-  rumbster
-  shoulda
-  sinatra
-  snmp
-  spoon
-  statsd-ruby (= 1.2.0)
-  stud
-  twitter (= 5.0.0.rc.1)
-  user_agent_parser (>= 2.0.0)
-  xml-simple
-  xmpp4r (= 0.5)
+  logstash!


### PR DESCRIPTION
- gem bundling now uses the standalone mechanism to generate a setup.rb file which add each individual gem into the load path. this considerably speeds up the logstash boot time. my tests shows it almost cut load time in half. 
- got rid of the custom Gemfile specs loading which did not work when trying to use a local unpublished gem.

after applying this you must:

``` sh
rm vendor/jar/jruby-complete-*.jar
make vendor-jruby
rm -rf vendor/bundle/jruby
bin/logstash deps
```
