### PR TITLE
unbreak documentation on s3 output

### DIFF
--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -3,7 +3,6 @@ require "logstash/outputs/base"
 require "logstash/namespace"
 require "socket" # for Socket.gethostname
 
-# TODO integrate aws_config in the future
 #require "logstash/plugin_mixins/aws_config"
 
 # INFORMATION:


### PR DESCRIPTION
Generated documentation is broken.

See here: http://logstash.net/docs/1.4.2/outputs/s3

Additionally, this TODO is captured lower in the file, in the section of TODOs.
