### PR TITLE
Add a message_id debug line so we know what email killed LS

### DIFF
--- a/lib/logstash/inputs/imap.rb
+++ b/lib/logstash/inputs/imap.rb
@@ -91,6 +91,8 @@ class LogStash::Inputs::IMAP < LogStash::Inputs::Base
   end # def run
 
   def parse_mail(mail)
+    # Add a debug message so we can track what message might cause an error later
+    @logger.debug("Working with message_id", :message_id => mail.message_id)
     # TODO(sissel): What should a multipart message look like as an event?
     # For now, just take the plain-text part and set it as the message.
     if mail.parts.count == 0


### PR DESCRIPTION
A lot of the time we don't know what email caused an error in parsing. Thus, as soon as we start parsing an email, lets debug log the message_id so we can identify and remediate. 
