### PR TITLE
DNS Filter spec should always mock the call to the resolv library Fix: #...

### DIFF
--- a/spec/filters/dns_spec.rb
+++ b/spec/filters/dns_spec.rb
@@ -4,22 +4,14 @@ require "logstash/filters/dns"
 require "resolv"
 
 describe LogStash::Filters::DNS do
-
-  before(:all) do
-    begin
-      Resolv.new.getaddress("elasticsearch.com")
-    rescue Errno::ENOENT
-      $stderr.puts("DNS resolver error, no network? mocking resolver")
-      @mock_resolv = true
-    end
-  end
-
   before(:each) do
-    if @mock_resolv
-      allow_any_instance_of(Resolv).to receive(:getaddress).with("carrera.databits.net").and_return("199.192.228.250")
-      allow_any_instance_of(Resolv).to receive(:getaddress).with("does.not.exist").and_return(nil)
-      allow_any_instance_of(Resolv).to receive(:getname).with("199.192.228.250").and_return("carrera.databits.net")
-    end
+    allow_any_instance_of(Resolv).to receive(:getaddress).with("carrera.databits.net").and_return("199.192.228.250")
+    allow_any_instance_of(Resolv).to receive(:getaddress).with("does.not.exist").and_raise(Resolv::ResolvError)
+    allow_any_instance_of(Resolv).to receive(:getaddress).with("nonexistanthostname###.net").and_raise(Resolv::ResolvError)
+    allow_any_instance_of(Resolv).to receive(:getname).with("199.192.228.250").and_return("carrera.databits.net")
+    allow_any_instance_of(Resolv).to receive(:getname).with("127.0.0.1").and_return("localhost")
+    allow_any_instance_of(Resolv).to receive(:getname).with("128.0.0.1").and_raise(Resolv::ResolvError)
+    allow_any_instance_of(Resolv).to receive(:getname).with("199.192.228.250").and_return("carrera.databits.net")
   end
 
   describe "dns reverse lookup, replace (on a field)" do


### PR DESCRIPTION
Always mock rspec resolv calls for this filter, the integration test could use the real dns server
#1875
