### PR TITLE
Include stud/try module to elasticsearch_spec test

### DIFF
--- a/spec/outputs/elasticsearch_spec.rb
+++ b/spec/outputs/elasticsearch_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 require "ftw"
 require "logstash/plugin"
 require "logstash/json"
+require "stud/try"
 
 describe "outputs/elasticsearch" do
 


### PR DESCRIPTION
Previously, a few elasticsearch integration tests relied on this module,
but the module could not be found.

to test this change I started-up an Elasticsearch instance 
with the following config change to allow wildcard deletion of 
indices for testing purposes.

```
action.destructive_requires_name: false
```

As well as running the rspec test with elasticsearch tag included:

```
$ ./bin/logstash rspec ./spec/outputs/elasticsearch_spec.rb --tag elasticsearch
Using Accessor#strict_set for specs
Run options:
  include {:elasticsearch=>true}
  exclude {:redis=>true, :socket=>true, :performance=>true, :broken=>true, :export_cypher=>true}
.....................

Finished in 45.5 seconds
21 examples, 0 failures
```
