### PR TITLE
[Tests] Elasticsearch: Remove the rescue so we can see what errors we get

### DIFF
--- a/spec/outputs/elasticsearch_spec.rb
+++ b/spec/outputs/elasticsearch_spec.rb
@@ -281,8 +281,7 @@ describe "outputs/elasticsearch" do
           @es = Elasticsearch::Client.new
           @es.indices.delete_template(:name => "*")
 
-          # This can fail if there are no indexes, ignore failure.
-          @es.indices.delete(:index => "*") rescue nil
+          @es.indices.delete(:index => "*")
 
           subject.register
 


### PR DESCRIPTION
`@es.indices.delete(:index => "*")` will not fail if there are no indices

See

```
~/ws/logstash (master)$ curl localhost:9200/_cat/indices
~/ws/logstash (master)$ curl -XDELETE localhost:9200/*
{"acknowledged":true}
```

it will only fail if we have a genuine issue like `{"error":"ElasticsearchIllegalArgumentException[Wildcard expressions or all indices are not allowed]","status":400}` which would be good to surface than just failing the test.
