### PR TITLE
Fix metadata testing failures

### DIFF
--- a/lib/logstash/event.rb
+++ b/lib/logstash/event.rb
@@ -135,8 +135,6 @@ class LogStash::Event
   end # def []
 
   public
-  # keep []= implementation in sync with spec/test_utils.rb monkey patch
-  # which redefines []= but using @accessors.strict_set
   def []=(fieldref, value)
     if fieldref == TIMESTAMP && !value.is_a?(LogStash::Timestamp)
       raise TypeError, "The field '@timestamp' must be a (LogStash::Timestamp, not a #{value.class} (#{value})"
@@ -301,4 +299,19 @@ class LogStash::Event
     # ignore arguments to respect accepted to_json method signature
     LogStash::Json.dump(to_hash_with_metadata)
   end # def to_json
+
+  def self.validate_value(value)
+    case value
+    when String
+      raise("expected UTF-8 encoding for value=#{value}, encoding=#{value.encoding.inspect}") unless value.encoding == Encoding::UTF_8
+      raise("invalid UTF-8 encoding for value=#{value}, encoding=#{value.encoding.inspect}") unless value.valid_encoding?
+      value
+    when Array
+      value.each{|v| validate_value(v)} # don't map, return original object
+      value
+    else
+      value
+    end
+  end
+
 end # class LogStash::Event

--- a/lib/logstash/util/accessors.rb
+++ b/lib/logstash/util/accessors.rb
@@ -41,7 +41,7 @@ module LogStash::Util
     end
 
     def strict_set(accessor, value)
-      set(accessor, strict_value(value))
+      set(accessor, LogStash::Event.validate_value(value))
     end
 
     def del(accessor)
@@ -60,20 +60,5 @@ module LogStash::Util
       target = path.inject(@store) {|r, k| r[r.is_a?(Array) ? k.to_i : k] ||= {}}
       [target, key]
     end
-
-    def strict_value(value)
-      case value
-      when String
-        raise("expected UTF-8 encoding for value=#{value}, encoding=#{value.encoding.inspect}") unless value.encoding == Encoding::UTF_8
-        raise("invalid UTF-8 encoding for value=#{value}, encoding=#{value.encoding.inspect}") unless value.valid_encoding?
-        value
-      when Array
-        value.each{|v| strict_value(v)} # don't map, return original object
-        value
-      else
-        value
-      end
-    end
-
   end # class Accessors
 end # module LogStash::Util

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,11 +33,13 @@ puts("Using Accessor#strict_set for specs")
 # mokey path LogStash::Event to use strict_set in tests
 # ugly, I know, but this avoids adding conditionals in performance critical section
 class LogStash::Event
+  alias_method :setval, :[]=
   def []=(str, value)
     if str == TIMESTAMP && !value.is_a?(LogStash::Timestamp)
       raise TypeError, "The field '@timestamp' must be a LogStash::Timestamp, not a #{value.class} (#{value})"
     end
-    @accessors.strict_set(str, value)
+    LogStash::Event.validate_value(value)
+    setval(str, value)
   end # def []=
 end
 


### PR DESCRIPTION
This bug was introduced in the recent metadata patch. The problem was
caused by a testing-specific monkeypatch on LogStash::Event#[]=

I fixed this by moving the strict_set input validation from
LogStash::Util::Accessors to LogStash::Event as a class method.
Then monkeypatched the Event#[]=  to invoke validation before doing
the set operation. This now makes it call the original []= method
and should help keep future breakages from happening.
