### PR TITLE
Update elasticsearch output to respect the 'index' in templates

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -177,6 +177,14 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # For more details on actions, check out the [Elasticsearch bulk API documentation](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-bulk.html)
   config :action, :validate => :string, :default => "index"
 
+  # helper function to replace placeholders
+  # in index names to wildcards
+  # example:
+  #    "logs-%{YYYY}" -> "logs-*" 
+  def wildcard_substitute(name)
+    name.gsub(/%\{[^}]+\}/, "*")
+  end
+
   public
   def register
     client_settings = {}
@@ -303,8 +311,10 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
       end
     end
     template_json = IO.read(@template).gsub(/\n/,'')
-    @logger.info("Using mapping template", :template => template_json)
-    return LogStash::Json.load(template_json)
+    template = LogStash::Json.load(template_json)
+    template['template'] = wildcard_substitute(@index)
+    @logger.info("Using mapping template", :template => template)
+    return template
   end # def get_template
 
   protected

--- a/spec/outputs/elasticsearch_spec.rb
+++ b/spec/outputs/elasticsearch_spec.rb
@@ -14,6 +14,18 @@ describe "outputs/elasticsearch" do
     expect {output.register}.to_not raise_error
   end
 
+  describe "wildcard_subsitute" do
+    output = LogStash::Plugin.lookup("output", "elasticsearch").new("embedded" => "false", "protocol" => "transport", "manage_template" => "false")
+
+    it "should substitude placeholders" do
+      insist { output.wildcard_substitute("%{MM}-test-%{YYYY}") } == "*-test-*"
+    end
+
+    it "should do nothing to strings without placeholders" do
+      insist { output.wildcard_substitute("logs-index") } == "logs-index"
+    end
+  end
+
   describe "ship lots of events w/ default index_type", :elasticsearch => true do
     # Generate a random index name
     index = 10.times.collect { rand(10).to_s }.join("")


### PR DESCRIPTION
Now the elasticsearch output plugin will respect the
'index' plugin setting and override the default index
template to update the indexes it matches on based on
the 'index' setting.

Any placeholders ("%{...}") will be translated to '*' so the
template matching pattern is generic and in line with elasticsearch
wildcarding.

e.g

index: "newindex-%{YYYY}" will update template to include...

```
{
template: "newindex-*"
...
}
```
