### PR TITLE
update documentation; sincedb_path = path+filename

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -44,6 +44,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
   # Where to write the since database (keeps track of the date
   # the last handled file was added to S3). The default will write
   # sincedb files to some path matching "$HOME/.sincedb*"
+  # Should be a path with filename not just a directory.
   config :sincedb_path, :validate => :string, :default => nil
 
   # Name of a S3 bucket to backup processed files to.


### PR DESCRIPTION
fixes the following:

```
:message=>"A plugin had an unrecoverable error. Will restart this plugin.
Plugin: <LogStash::Inputs::S3 [...] sincedb_path=>\"/opt/mypath\", region_endpoint=>\"us-east-1\">
Error: Is a directory - /opt/mypath", :level=>:error
```
