### PR TITLE
Update Elasticsearch Output Plugin to retry bulk

### DIFF
--- a/lib/logstash/errors.rb
+++ b/lib/logstash/errors.rb
@@ -5,6 +5,7 @@ module LogStash
   class ConfigurationError < Error; end
   class PluginLoadingError < Error; end
   class ShutdownSignal < StandardError; end
+  class BulkSendError < Error; end
 
   class Bug < Error; end
   class ThisMethodWasRemoved < Bug; end


### PR DESCRIPTION
Some actions may fail within the ES client bulk call.
Now, some messages (specifically errors 429 and 503s) will be
retried up to 3 times. If there are still actions that are
unsuccessfully indexed, Stud Buffer will continue its current
behavior (to retry indefinitely).

Stud Buffer will replay all events it first attempted to flush
to Elasticsearch. This means duplicate events may find themselves
in Elasticsearch.

mostly fixes #1631
