### PR TITLE
bump FTW dependency to 0.0.40

### DIFF
--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "i18n", ["=0.6.9"]   #(MIT license)
 
   # Web dependencies
-  gem.add_runtime_dependency "ftw", ["~> 0.0.39"] #(Apache 2.0 license)
+  gem.add_runtime_dependency "ftw", ["~> 0.0.40"] #(Apache 2.0 license)
   gem.add_runtime_dependency "mime-types"         #(GPL 2.0)
   gem.add_runtime_dependency "rack"               #(MIT-style license)
   gem.add_runtime_dependency "sinatra"            #(MIT-style license)


### PR DESCRIPTION
FTW is used in many plugins, and had a file descriptor leak that was closed in 0.0.40
