### PR TITLE
Fix some bugs under MRI

### DIFF
--- a/lib/logstash/JRUBY-PR1448.rb
+++ b/lib/logstash/JRUBY-PR1448.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # This patch fixes a problem that exists in JRuby prior to 1.7.11 where the
 # ruby binary path used by rubygems is malformed on Windows, causing
 # dependencies to not install cleanly when using `.\bin\logstash.bat deps`.

--- a/lib/logstash/environment.rb
+++ b/lib/logstash/environment.rb
@@ -1,5 +1,6 @@
 require "logstash/errors"
 require 'logstash/version'
+require "tmpdir"
 
 module LogStash
   module Environment
@@ -62,6 +63,14 @@ module LogStash
 
     def jruby?
       @jruby ||= !!(RUBY_PLATFORM == "java")
+    end
+
+    def tmpdir
+      if jruby?
+        java.lang.System.getProperty("java.io.tmpdir")
+      else
+        Dir.tmpdir
+      end
     end
 
     def vendor_path(path)

--- a/lib/logstash/environment.rb
+++ b/lib/logstash/environment.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "logstash/errors"
 require 'logstash/version'
 require "tmpdir"

--- a/lib/logstash/java_integration.rb
+++ b/lib/logstash/java_integration.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "java"
 
 # this is mainly for usage with JrJackson json parsing in :raw mode which genenerates

--- a/lib/logstash/pluginmanager.rb
+++ b/lib/logstash/pluginmanager.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "logstash/namespace"
 
 module LogStash::PluginManager

--- a/lib/logstash/pluginmanager/install.rb
+++ b/lib/logstash/pluginmanager/install.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'clamp'
 require 'logstash/namespace'
 require 'logstash/environment'

--- a/lib/logstash/pluginmanager/list.rb
+++ b/lib/logstash/pluginmanager/list.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'clamp'
 require 'logstash/namespace'
 require 'logstash/pluginmanager'

--- a/lib/logstash/pluginmanager/main.rb
+++ b/lib/logstash/pluginmanager/main.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "logstash/namespace"
 require "logstash/errors"
 require 'clamp'

--- a/lib/logstash/pluginmanager/uninstall.rb
+++ b/lib/logstash/pluginmanager/uninstall.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "logstash/namespace"
 require "logstash/logging"
 require "logstash/errors"

--- a/lib/logstash/pluginmanager/update.rb
+++ b/lib/logstash/pluginmanager/update.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'clamp'
 require 'logstash/namespace'
 require 'logstash/pluginmanager'

--- a/lib/logstash/pluginmanager/update.rb
+++ b/lib/logstash/pluginmanager/update.rb
@@ -4,8 +4,11 @@ require 'logstash/pluginmanager'
 require 'logstash/pluginmanager/util'
 require 'rubygems/dependency_installer'
 require 'rubygems/uninstaller'
-require 'jar-dependencies'
-require 'jar_install_post_install_hook'
+
+if LogStash::Environment.jruby?
+  require 'jar-dependencies'
+  require 'jar_install_post_install_hook'
+end
 
 class LogStash::PluginManager::Update < Clamp::Command
 

--- a/lib/logstash/pluginmanager/util.rb
+++ b/lib/logstash/pluginmanager/util.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 
 class LogStash::PluginManager::Util
 

--- a/lib/logstash/pluginmanager/util.rb
+++ b/lib/logstash/pluginmanager/util.rb
@@ -22,8 +22,7 @@ class LogStash::PluginManager::Util
       return false
     end
     spec, source = specs_and_sources.max_by { |s,| s.version }
-    path = source.download( spec, java.lang.System.getProperty("java.io.tmpdir"))
-    path
+    source.download( spec, LogStash::Environment.tmpdir)
   end
 
   def self.installed?(name)

--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -3,7 +3,7 @@ namespace "plugin" do
     name = args[:name]
     puts "[plugin] Installing plugin: #{name}"
 
-    cmd = ['bin/logstash', 'plugin', 'install', name ]
+    cmd = ['bin/logstash', 'plugin', 'install', *name ]
     system(*cmd)
     raise RuntimeError, $!.to_s unless $?.success?
 

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -23,9 +23,7 @@ namespace "test" do
      'logstash-input-tcp',
      'logstash-output-stdout'
     ]
-    plugins.each do |plugin|
-      Rake::Task["plugin:install"].invoke(plugin)
-    end
+    Rake::Task["plugin:install"].invoke(plugins)
   end
 
 end

--- a/spec/core/conditionals_spec.rb
+++ b/spec/core/conditionals_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "spec_helper"
 
 module ConditionalFanciness

--- a/spec/core/config_spec.rb
+++ b/spec/core/config_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # config syntax tests
 #
 

--- a/spec/core/runner_spec.rb
+++ b/spec/core/runner_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "logstash/runner"
 require "logstash/agent"
 require "logstash/kibana"

--- a/spec/core/timestamp_spec.rb
+++ b/spec/core/timestamp_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "logstash/timestamp"
 
 describe LogStash::Timestamp do

--- a/spec/core/web_spec.rb
+++ b/spec/core/web_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "insist"
 
 describe "web tests" do

--- a/spec/logstash_helpers.rb
+++ b/spec/logstash_helpers.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "logstash/agent"
 require "logstash/pipeline"
 require "logstash/event"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "logstash/logging"
 require 'logstash_helpers'
 require "insist"

--- a/spec/util/environment_spec.rb
+++ b/spec/util/environment_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "logstash/environment"
 
 describe LogStash::Environment do

--- a/spec/util/fieldeval_spec.rb
+++ b/spec/util/fieldeval_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "spec_helper"
 require "logstash/util/fieldreference"
 

--- a/spec/util/jar_spec.rb
+++ b/spec/util/jar_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "insist"
 
 describe "logstash jar features", :if => (__FILE__ =~ /file:.*!/) do

--- a/spec/util/json_spec.rb
+++ b/spec/util/json_spec.rb
@@ -63,13 +63,13 @@ describe LogStash::Json do
     ### MRI specific
 
     it "should respond to load and deserialize object on mri" do
-      expect(Oj).to receive(:load).with(json).and_call_original
-      expect(LogStash::Json.load(json)).to eql(hash)
+      expect(Oj).to receive(:load).with(json_hash).and_call_original
+      expect(LogStash::Json.load(json_hash)).to eql(hash)
     end
 
     it "should respond to dump and serialize object on mri" do
       expect(Oj).to receive(:dump).with(hash, anything).and_call_original
-      expect(LogStash::Json.dump(hash)).to eql(json)
+      expect(LogStash::Json.dump(hash)).to eql(json_hash)
     end
   end
 

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "logstash/util"
 
 


### PR DESCRIPTION
* `bin/plugin install` works now
* most specs pass

The only specs that don't pass are ones that are broken under MRI due to #2024 not being fixed.

```
% USE_RUBY=1 bin/logstash rspec -f d spec | grep FAIL
    includes YYYY-MM-dd'T'HH:mm:ss.SSSZ (FAILED - 1)
    includes YYYY-MM-dd'T'HH:mm:ss.SSSSSSZ (FAILED - 2)
    includes YYYY-MM-dd'T'HH:mm:ss.SSS (FAILED - 3)
    includes YYYY-MM-dd'T'HH:mm:ss (FAILED - 4)
    includes YYYY-MM-dd'T'HH:mm:ssZ (FAILED - 5)
```

```
Finished in 1.77 seconds
182 examples, 5 failures
```

Fixes #2022 and #2023