### PR TITLE
Force the uninstall of a plugin at install or update time.

### DIFF
--- a/lib/logstash/pluginmanager/install.rb
+++ b/lib/logstash/pluginmanager/install.rb
@@ -49,7 +49,7 @@ class LogStash::PluginManager::Install < Clamp::Command
 
       puts ("removing existing plugin before installation")
       ::Gem.done_installing_hooks.clear
-      ::Gem::Uninstaller.new(gem_meta.name, {}).uninstall
+      ::Gem::Uninstaller.new(gem_meta.name, {:force => true}).uninstall
     end
 
     ::Gem.configuration.verbose = false

--- a/lib/logstash/pluginmanager/update.rb
+++ b/lib/logstash/pluginmanager/update.rb
@@ -59,7 +59,7 @@ class LogStash::PluginManager::Update < Clamp::Command
 
     if LogStash::PluginManager::Util.installed?(spec.name)
       ::Gem.done_installing_hooks.clear
-      ::Gem::Uninstaller.new(gem_meta.name, {}).uninstall
+      ::Gem::Uninstaller.new(gem_meta.name, {:force => true}).uninstall
     end
 
     ::Gem.configuration.verbose = false


### PR DESCRIPTION
It can happen we want to update a plugin that is a dependency for an other plugin
which will result in a warning and a manual action at uninstall phase of the install/update tasks
Since we are 100% sure in these cases that the plugin will be installed again we can force the uninstall part not to alert us about it.

This solves the issue we otherwise would get:

Gem::DependencyRemovalException: Uninstallation aborted due to dependent gem(s)
