### PR TITLE
support for plugins specs

### DIFF
--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($\)
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "logstash"
-  gem.require_paths = ["lib"]
+  gem.require_paths = ["lib", "spec"]
   gem.version       = LOGSTASH_VERSION
 
   # Core dependencies


### PR DESCRIPTION
add spec dir in require_paths so that plugins require "spec_helper" works.

see `logstash-codec-compress_spooler` for plugin-side configuration
