### PR TITLE
Support installing plugin with MRI

### DIFF
--- a/lib/logstash/pluginmanager/util.rb
+++ b/lib/logstash/pluginmanager/util.rb
@@ -22,7 +22,8 @@ class LogStash::PluginManager::Util
       return false
     end
     spec, source = specs_and_sources.max_by { |s,| s.version }
-    path = source.download( spec, java.lang.System.getProperty("java.io.tmpdir"))
+    require 'tmpdir'
+    path = source.download( spec, Dir.tmpdir() )
     path
   end
 

--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -33,10 +33,11 @@ Gem::Specification.new do |gem|
 
   # Plugin manager dependencies
 
-  # jar-dependencies 0.1.2 is included in jruby 1.7.6 no need to include here and
-  # this avoids the gemspec jar path parsing issue of jar-dependencies 0.1.2
-  #
-  # gem.add_runtime_dependency "jar-dependencies", [">= 0.1.2"]   #(MIT license)
+  if RUBY_PLATFORM == 'java'
+    # jar-dependencies is included in jruby, no need to include here
+  else
+    gem.add_runtime_dependency "jar-dependencies", [">= 0.1.4"]   #(MIT license)
+  end
 
   gem.add_runtime_dependency "ruby-maven"                       #(EPL license)
   gem.add_runtime_dependency "minitar"


### PR DESCRIPTION
When using USE_RUBY=1 with a non-jruby I got the following errors trying to install plugins
1. unresolved require of jar-dependencies => fixed by modifying the gemspec for non-jruby rubies
2. undefined **java** constant in  lib/logstash/pluginmanager/util.rb => proposed fix is to use **Dir.tmpdir()** 

@electrical waiting for your review
