### PR TITLE
Fix for handling accessor sets on array elements.

### DIFF
--- a/lib/logstash/util/accessors.rb
+++ b/lib/logstash/util/accessors.rb
@@ -37,7 +37,7 @@ module LogStash::Util
 
     def set(accessor, value)
       target, key = lookup(accessor)
-      target[key] = value
+      target[target.is_a?(Array) ? key.to_i : key] = value
     end
 
     def strict_set(accessor, value)

--- a/spec/util/accessors_spec.rb
+++ b/spec/util/accessors_spec.rb
@@ -140,6 +140,14 @@ describe LogStash::Util::Accessors, :if => true do
       insist { data } == { "hello" => { "world" => ["foo", "bar"] } }
     end
 
+    it "should set element within array value" do
+      str = "[hello][0]"
+      data = {"hello" => ["foo", "bar"]}
+      accessors = LogStash::Util::Accessors.new(data)
+      insist { accessors.set(str, "world") } == "world"
+      insist { data } == {"hello" => ["world", "bar"]}
+    end
+
     it "should retrieve array item" do
       data = { "hello" => { "world" => ["a", "b"], "bar" => "baz" } }
       accessors = LogStash::Util::Accessors.new(data)


### PR DESCRIPTION
Previously: Filters like mutate would throw an exception when attempting
to convert an element within an array to a specific type. This was
raising an error because the index in the field reference was being
treated as a String instead of an integer representing the index of the
field to convert.

Now: Plugins like Mutate can access and convert elements within arrays
to specific types, or, updating their values.

related issue: https://github.com/elasticsearch/logstash/issues/1401
