### PR TITLE
Update for windows to execute rake bootstrap and bin\logstash.bat

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -50,8 +50,7 @@ namespace "artifact" do
     require "archive/tar/minitar"
     require "logstash/version"
     tarpath = "build/logstash-#{LOGSTASH_VERSION}.tar.gz"
-    tarfile = File.new(tarpath, "wb")
-    gz = Zlib::GzipWriter.new(tarfile, Zlib::BEST_COMPRESSION)
+    gz = Zlib::GzipWriter.new(File.new(tarpath, "wb"), Zlib::BEST_COMPRESSION)
     tar = Archive::Tar::Minitar::Output.new(gz)
     files.each do |path|
       stat = File.lstat(path)
@@ -65,7 +64,7 @@ namespace "artifact" do
         tar.tar.mkdir(path_in_tar, opts)
       else
         tar.tar.add_file_simple(path_in_tar, opts) do |io|
-          File.open(path) do |fd|
+          File.open(path,'rb') do |fd|
             chunk = nil
             size = 0
             size += io.write(chunk) while chunk = fd.read(16384)

--- a/rakelib/fetch.rake
+++ b/rakelib/fetch.rake
@@ -34,7 +34,7 @@ end
 
 def file_sha1(path)
   digest = Digest::SHA1.new
-  fd = File.new(path, "r")
+  fd = File.new(path, "rb")
   while true
     begin
       digest << fd.sysread(16384)
@@ -57,7 +57,7 @@ def download(url, output)
       fail "HTTP fetch failed for #{url}. #{response}" if response.code != "200"
       size = (response["content-length"].to_i || -1).to_f
       count = 0
-      File.open(tmp, "w") do |fd|
+      File.open(tmp, "wb") do |fd|
         response.read_body do |chunk|
           fd.write(chunk)
           digest << chunk


### PR DESCRIPTION
With the switch to minitar, the rake bootstrap command was broken in windows, accessing file in binary mode resolves the issue.
Also cleaned up the logstash.bat script to mimic more the logstash shell script (remove deps command and USE_RUBY envvar)
Also update jruby to security release 1.7.16.1
