### PR TITLE
add spec_helper dependency to config_spec

### DIFF
--- a/spec/core/config_spec.rb
+++ b/spec/core/config_spec.rb
@@ -1,6 +1,6 @@
 # config syntax tests
 #
-
+require "spec_helper"
 require "logstash/config/grammar"
 require "logstash/config/config_ast"
 


### PR DESCRIPTION
`bin/logstash rspec` now passes
`bin/logstash rspec spec/**/*.rb` fails due to including `spec_helper.rb` in the spec run.
