### PR TITLE
remove spool codec from default_plugins

### DIFF
--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -16,7 +16,6 @@ logstash-codec-netflow
 logstash-codec-oldlogstashjson
 logstash-codec-plain
 logstash-codec-rubydebug
-logstash-codec-spool
 logstash-output-udp
 logstash-filter-anonymize
 logstash-filter-checksum


### PR DESCRIPTION
This plugin is to be deleted and thus doesn't make sense to have it installed by default. More on why here: https://github.com/logstash-plugins/logstash-codec-spool/issues/1
