### PR TITLE
let maven-tools get latest, fixes in 1.0.7 present

### DIFF
--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |gem|
   # gem.add_runtime_dependency "jar-dependencies", [">= 0.1.2"]   #(MIT license)
 
   gem.add_runtime_dependency "ruby-maven"                       #(EPL license)
-  gem.add_runtime_dependency "maven-tools", "= 1.0.5"
+  gem.add_runtime_dependency "maven-tools"
   gem.add_runtime_dependency "minitar"
 
   if RUBY_PLATFORM == 'java'


### PR DESCRIPTION
The latest release of maven-tools-1.0.7 fixes a regression where some of our java dependent plugins 
would fail to build because of our naming convention for the apache license string (silly). Now that the fix for this 
regression is present in rubygems. no need to lock the version to 1.0.5
