### PR TITLE
update pipeline to call teardown of output workers when :workers > 1

### DIFF
--- a/lib/logstash/pipeline.rb
+++ b/lib/logstash/pipeline.rb
@@ -225,12 +225,16 @@ class LogStash::Pipeline
   def outputworker
     LogStash::Util::set_thread_name(">output")
     @outputs.each(&:worker_setup)
+
     while true
       event = @filter_to_output.pop
       break if event.is_a?(LogStash::ShutdownEvent)
       output(event)
     end # while true
-    @outputs.each(&:teardown)
+
+    @outputs.each do |output|
+      output.worker_plugins.each(&:teardown)
+    end
   end # def outputworker
 
   # Shutdown this pipeline.

--- a/spec/core/pipeline_spec.rb
+++ b/spec/core/pipeline_spec.rb
@@ -1,0 +1,117 @@
+require "logstash/devutils/rspec/spec_helper"
+
+class DummyInput < LogStash::Inputs::Base
+  config_name "dummyinput"
+  milestone 2
+
+  def register
+  end
+
+  def run(queue)
+  end
+
+  def teardown
+  end
+end
+
+class DummyCodec < LogStash::Codecs::Base
+  config_name "dummycodec"
+  milestone 2
+
+  def decode(data) 
+    data
+  end
+
+  def encode(event) 
+    event
+  end
+
+  def teardown
+  end
+end
+
+class DummyOutput < LogStash::Outputs::Base
+  config_name "dummyoutput"
+  milestone 2
+  
+  attr_reader :num_teardowns
+
+  def initialize(params={})
+    super
+    @num_teardowns = 0
+  end
+
+  def register
+  end
+
+  def receive(event)
+  end
+
+  def teardown
+    @num_teardowns += 1
+  end
+end
+
+class TestPipeline < LogStash::Pipeline
+  attr_reader :outputs
+end
+
+describe LogStash::Pipeline do
+
+  before(:each) do
+    LogStash::Plugin.stub(:lookup)
+      .with("input", "dummyinput").and_return(DummyInput)
+    LogStash::Plugin.stub(:lookup)
+      .with("codec", "plain").and_return(DummyCodec)
+    LogStash::Plugin.stub(:lookup)
+      .with("output", "dummyoutput").and_return(DummyOutput)
+  end
+
+  let(:test_config_without_output_workers) {
+    <<-eos
+    input {
+      dummyinput {}
+    }
+  
+    output {
+      dummyoutput {}
+    }
+    eos
+  }
+
+  let(:test_config_with_output_workers) {
+    <<-eos
+    input {
+      dummyinput {}
+    }
+  
+    output {
+      dummyoutput {
+        workers => 2
+      }
+    }
+    eos
+  }
+
+  context "output teardown" do
+    it "should call teardown of output without output-workers" do
+      pipeline = TestPipeline.new(test_config_without_output_workers)
+      pipeline.run
+
+      insist { pipeline.outputs.size } == 1
+      insist { pipeline.outputs.first.worker_plugins.size } == 1
+      insist { pipeline.outputs.first.worker_plugins.first.num_teardowns } == 1
+    end
+
+    it "should call output teardown correctly with output workers" do
+      pipeline = TestPipeline.new(test_config_with_output_workers)
+      pipeline.run
+
+      insist { pipeline.outputs.size } == 1
+      insist { pipeline.outputs.first.num_teardowns } == 0
+      pipeline.outputs.first.worker_plugins.each do |plugin|
+        insist { plugin.num_teardowns } == 1
+      end
+    end
+  end
+end


### PR DESCRIPTION
fixes https://github.com/elasticsearch/logstash/issues/2178
