### PR TITLE
reinstate standalone flag and remove .bundle in vendor task

### DIFF
--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -18,10 +18,9 @@ namespace "plugin" do
       "GEM_PATH" => [
         ENV['GEM_PATH'],
         ::File.join(LogStash::Environment::LOGSTASH_HOME, 'build/bootstrap'),
-        ::File.join(LogStash::Environment::LOGSTASH_HOME, 'vendor/bundle/jruby/1.9'),
-        ::File.join(LogStash::Environment::LOGSTASH_HOME, 'vendor/jruby/lib/ruby/gems/shared')
+        LogStash::Environment.gem_home
       ].join(":"),
-      "GEM_HOME" => ::File.join(LogStash::Environment::LOGSTASH_HOME, "vendor/plugins/jruby/1.9"),
+      "GEM_HOME" => LogStash::Environment.plugins_home,
       "BUNDLE_GEMFILE" => "tools/Gemfile.plugins"
     }
     if ENV['USE_RUBY'] != '1'

--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -243,7 +243,7 @@ namespace "vendor" do
         backup_gem_home = ENV['GEM_HOME']
         backup_gem_path = ENV['GEM_PATH']
         env = {
-          'GEM_HOME' => ::File.join(LogStash::Environment::LOGSTASH_HOME, LogStash::Environment.gem_home),
+          'GEM_HOME' => LogStash::Environment.gem_home,
           'GEM_PATH' => [
             ::File.join(LogStash::Environment::LOGSTASH_HOME, 'build/bootstrap'),
             ::File.join(LogStash::Environment::LOGSTASH_HOME, 'vendor/jruby/lib/ruby/gems/shared')


### PR DESCRIPTION
the "standalone" flag during rake bootstrap is needed to generate the bundler setup.rb flag.
However, that generates a "tools/.bundle/config" file that sets the BUNDLE_PATH and will later mess with `rake plugin:install-defaults`, forcing all plugins to be installed in "vendor/bundle" instead of "vendor/plugins".

Setting "--path" in `rake plugin:install-defaults` isn't an option because then gems from "vendor/bundle" will not be reused, generating many duplication and some installation errors.

The only option I could find was to remove the ".bundle" dir after running `rake vendor`'s "bundle install"

Closes #2183 
