### PR TITLE
add Bundler.reset! method which fixes the .lock file updates

### DIFF
--- a/rakelib/bundler_patch.rb
+++ b/rakelib/bundler_patch.rb
@@ -1,10 +1,20 @@
-# Patch bundler to write a .lock file specific to the version of ruby.
-# This keeps MRI/JRuby/RBX from conflicting over the Gemfile.lock updates
 module Bundler
+
+  # Patch bundler to write a .lock file specific to the version of ruby.
+  # This keeps MRI/JRuby/RBX from conflicting over the Gemfile.lock updates
   module SharedHelpers
     def default_lockfile
       ruby = "#{LogStash::Environment.ruby_engine}-#{LogStash::Environment.ruby_abi_version}"
       Pathname.new("#{default_gemfile}.#{ruby}.lock")
+    end
+  end
+
+  # Add the Bundler.reset! method which has been added in master but is not in 1.7.9.
+  class << self
+    unless self.method_defined?("reset!")
+      def reset!
+        @definition = nil
+      end
     end
   end
 end

--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -22,8 +22,7 @@ namespace "plugin" do
         ENV["GEM_PATH"] = LogStash::Environment.logstash_gem_home
         ENV["BUNDLE_PATH"] = LogStash::Environment.logstash_gem_home
         ENV["BUNDLE_GEMFILE"] = "tools/Gemfile.plugins"
-        # Bundler::Retry.attempts = 0
-        Bundler.definition(true)
+        Bundler.reset!
         Bundler::CLI.start(LogStash::Environment.bundler_install_command("tools/Gemfile.plugins", LogStash::Environment::BUNDLE_DIR))
         break
       rescue => e

--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -220,8 +220,7 @@ namespace "vendor" do
         ENV["GEM_PATH"] = LogStash::Environment.logstash_gem_home
         ENV["BUNDLE_PATH"] = LogStash::Environment.logstash_gem_home
         ENV["BUNDLE_GEMFILE"] = "tools/Gemfile"
-        # Bundler::Retry.attempts = 0
-        Bundler.definition(true)
+        Bundler.reset!
         Bundler::CLI.start(LogStash::Environment.bundler_install_command("tools/Gemfile", LogStash::Environment::BUNDLE_DIR))
         break
       rescue => e


### PR DESCRIPTION
this fixes the .lock file updating upon running the rake tasks which install the gem dependencies
