### PR TITLE
Force config folder files to end with .conf. This allows flexibility to ...

### DIFF
--- a/lib/logstash/agent.rb
+++ b/lib/logstash/agent.rb
@@ -302,7 +302,7 @@ class LogStash::Agent < Clamp::Command
   end
 
   def local_config(path)
-    path = File.join(path, "*") if File.directory?(path)
+    path = File.join(path, "*.conf") if File.directory?(path)
 
     if Dir.glob(path).length == 0
       fail(I18n.t("logstash.agent.configuration.file-not-found", :path => path))


### PR DESCRIPTION
...save backup copies of config files to the same folder. It also prevents logstash from reading non-config files that exist in the folder. On the other side, all config files should end with a .conf extension.
