### PR TITLE
Fix running rake test after bootstrap the first time.

### DIFF
--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -1,6 +1,7 @@
 
 namespace "test" do
   task "default" => [ "bootstrap", "test:prep" ] do
+    Gem.clear_paths
     require "logstash/environment"
     LogStash::Environment.set_gem_paths!
     require 'rspec/core'
@@ -8,6 +9,7 @@ namespace "test" do
   end
 
   task "fail-fast" => [ "bootstrap", "test:prep" ] do
+    Gem.clear_paths
     require "logstash/environment"
     LogStash::Environment.set_gem_paths!
     require 'rspec/core'
@@ -30,4 +32,4 @@ namespace "test" do
 
 end
 
-task "test" => [ "test:default" ] 
+task "test" => [ "test:default" ]


### PR DESCRIPTION
Rake tasks can not find plugins installed throw the test:prep task the first time it's run, by clearing the gem paths this PR Fix #2219, so the rspec can find everything.
