### PR TITLE
Update jruby dependency to create a workable build for OpenBSD

### DIFF
--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -3,7 +3,7 @@ DOWNLOADS = {
   "elasticsearch" => { "version" => "1.3.0", "sha1" => "f9e02e2cdcb55e7e8c5c60e955f793f68b7dec75" },
   "collectd" => { "version" => "5.4.0", "sha1" => "a90fe6cc53b76b7bdd56dc57950d90787cb9c96e" },
   #"jruby" => { "version" => "1.7.13", "sha1" => "0dfca68810a5eed7f12ae2007dc2cc47554b4cc6" }, # jruby-complete
-  "jruby" => { "version" => "1.7.16", "sha1" => "4c912b648f6687622ba590ca2a28746d1cd5d550" },
+  "jruby" => { "version" => "1.7.17", "sha1" => "e4621bbcc51242061eaa9b62caee69c2a2b433f0" },
   "kibana" => { "version" => "3.1.2", "sha1" => "a59ea4abb018a7ed22b3bc1c3bcc6944b7009dc4" },
   "geoip" => {
     "GeoLiteCity" => { "version" => "2013-01-18", "sha1" => "15aab9a90ff90c4784b2c48331014d242b86bf82", },


### PR DESCRIPTION
jruby 1.7.17 includes several fixes which are needed in order to run
on OpenBSD with 64-bit time_t (OpenBSD 5.5 and later).

There is still the issue of LOGSTASH-665 that's also affecting OpenBSD, but manually patching the files as suggested by Aldian works around it.
