### PR TITLE
updates docs to fix #2240

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -16,7 +16,7 @@ Add the key:
 
 Add the repo to /etc/apt/sources.list
 
-     deb https://packages.elasticsearch.org/logstash/1.4/debian stable main
+     deb http://packages.elasticsearch.org/logstash/1.4/debian stable main
 
 
 ## YUM based distributions


### PR DESCRIPTION
package urls in docs now use https to fix #2240 
