### PR TITLE
fix "start" exit value for logstash-web init script

### DIFF
--- a/pkg/logstash-web.sysv
+++ b/pkg/logstash-web.sysv
@@ -121,6 +121,7 @@ case "$1" in
       echo "$name is already running"
     else
       start
+      code=$?
     fi
     exit $code
     ;;


### PR DESCRIPTION
Without this fix, the init script does not exit cleanly when a start succeeds.  Looks like it's the same fix that was applied to logstash.sysv earlier this year.
