### PR TITLE
Adjust help output to match actual searched paths for plugins

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -159,8 +159,8 @@ en:
           multiple paths. Plugins are expected to be
           in a specific directory hierarchy:
           'PATH/logstash/TYPE/NAME.rb' where TYPE is
-          'input' 'filter' or 'output' and NAME is the
-          name of the plugin.
+          'inputs' 'filters', 'outputs' or 'codecs'
+          and NAME is the name of the plugin.
         quiet: |+
           Quieter logstash logging. This causes only 
           errors to be emitted.


### PR DESCRIPTION
The help text of '--pluginpath' for the agent doesn't match what the code actually searches for, as per https://github.com/elasticsearch/logstash/blob/master/lib/logstash/agent.rb#L276
