### PR TITLE
Update to use rspec3 as test runner 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,10 @@
 source "https://rubygems.org"
 gem "logstash-core", "2.0.0.dev", :path => "."
 gem "file-dependencies", "0.1.6"
-gem "ci_reporter", "1.9.3", :group => :development
+gem "ci_reporter_rspec", "1.0.0", :group => :development
 gem "simplecov", :group => :development
 gem "coveralls", :group => :development
-gem "rspec", "~> 2.14.0", :group => :development
+gem "rspec", "~> 3.1.0", :group => :development
 gem "logstash-devutils", "~> 0", :group => :development
 gem "octokit", "3.8.0", :group => :build
 gem "stud", "~> 0.0.19", :group => :build

--- a/Gemfile.jruby-1.9.lock
+++ b/Gemfile.jruby-1.9.lock
@@ -23,8 +23,11 @@ GEM
     cabin (0.7.1)
     childprocess (0.5.6)
       ffi (~> 1.0, >= 1.0.11)
-    ci_reporter (1.9.3)
+    ci_reporter (2.0.0)
       builder (>= 2.1.2)
+    ci_reporter_rspec (1.0.0)
+      ci_reporter (~> 2.0)
+      rspec (>= 2.14, < 4)
     clamp (0.6.5)
     coderay (1.1.0)
     coveralls (0.8.1)
@@ -59,12 +62,12 @@ GEM
     insist (1.0.0)
     jrjackson (0.2.8)
     json (1.8.2-java)
-    logstash-devutils (0.0.13-java)
+    logstash-devutils (0.0.14-java)
       gem_publisher
       insist (= 1.0.0)
       minitar
       rake
-      rspec (~> 2.14.0)
+      rspec (~> 3.1.0)
     method_source (0.8.2)
     mime-types (2.5)
     minitar (0.5.4)
@@ -83,14 +86,18 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.8)
-    rspec-expectations (2.14.5)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.6)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.7)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.3)
+      rspec-support (~> 3.1.0)
+    rspec-support (3.1.2)
     rubyzip (1.1.7)
     sawyer (0.6.0)
       addressable (~> 2.3.5)
@@ -117,7 +124,7 @@ PLATFORMS
   java
 
 DEPENDENCIES
-  ci_reporter (= 1.9.3)
+  ci_reporter_rspec (= 1.0.0)
   coveralls
   file-dependencies (= 0.1.6)
   fpm (~> 1.3.3)
@@ -125,7 +132,7 @@ DEPENDENCIES
   logstash-core (= 2.0.0.dev)!
   logstash-devutils (~> 0)
   octokit (= 3.8.0)
-  rspec (~> 2.14.0)
+  rspec (~> 3.1.0)
   rubyzip (~> 1.1.7)
   simplecov
   stud (~> 0.0.19)

--- a/ci/ci_setup.sh
+++ b/ci/ci_setup.sh
@@ -18,4 +18,5 @@ rake bootstrap # Bootstrap your logstash instance
 
 # Set up some general options for the rspec runner
 echo "--order rand" > .rspec
-echo "--format CI::Reporter::RSpec" >> .rspec
+echo "--format progress" >> .rspec
+echo "--format CI::Reporter::RSpecFormatter" >> .rspec

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -10,6 +10,7 @@ namespace "test" do
 
     require "rspec/core/runner"
     require "rspec"
+    require 'ci/reporter/rake/rspec_loader'
   end
 
   desc "run core specs"

--- a/spec/core/conditionals_spec.rb
+++ b/spec/core/conditionals_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module ConditionalFanciness
   def description
-    return example.metadata[:example_group][:description_args][0]
+    return self.metadata[:description]
   end
 
   def conditional(expression, &block)

--- a/spec/core/event_spec.rb
+++ b/spec/core/event_spec.rb
@@ -123,32 +123,32 @@ describe LogStash::Event do
 
     context "#include?" do
       it "should include existing fields" do
-        expect(subject.include?("c")).to be_true
-        expect(subject.include?("[c][d]")).to be_true
-        expect(subject.include?("[j][k4][0][nested]")).to be_true
+        expect(subject.include?("c")).to eq(true)
+        expect(subject.include?("[c][d]")).to eq(true)
+        expect(subject.include?("[j][k4][0][nested]")).to eq(true)
       end
 
       it "should include field with nil value" do
-        expect(subject.include?("nilfield")).to be_true
+        expect(subject.include?("nilfield")).to eq(true)
       end
 
       it "should include @metadata field" do
-        expect(subject.include?("@metadata")).to be_true
+        expect(subject.include?("@metadata")).to eq(true)
       end
 
       it "should include field within @metadata" do
-        expect(subject.include?("[@metadata][fancy]")).to be_true
+        expect(subject.include?("[@metadata][fancy]")).to eq(true)
       end
 
       it "should not include non-existing fields" do
-        expect(subject.include?("doesnotexist")).to be_false
-        expect(subject.include?("[j][doesnotexist]")).to be_false
-        expect(subject.include?("[tag][0][hello][yes]")).to be_false
+        expect(subject.include?("doesnotexist")).to eq(false)
+        expect(subject.include?("[j][doesnotexist]")).to eq(false)
+        expect(subject.include?("[tag][0][hello][yes]")).to eq(false)
       end
 
       it "should include within arrays" do
-        expect(subject.include?("[tags][0]")).to be_true
-        expect(subject.include?("[tags][1]")).to be_false
+        expect(subject.include?("[tags][0]")).to eq(true)
+        expect(subject.include?("[tags][1]")).to eq(false)
       end
     end
 

--- a/spec/core/pipeline_spec.rb
+++ b/spec/core/pipeline_spec.rb
@@ -58,16 +58,13 @@ end
 
 describe LogStash::Pipeline do
 
-  context "teardown" do
+context "teardown" do
 
-    before(:each) do
-      LogStash::Plugin.stub(:lookup)
-        .with("input", "dummyinput").and_return(DummyInput)
-      LogStash::Plugin.stub(:lookup)
-        .with("codec", "plain").and_return(DummyCodec)
-      LogStash::Plugin.stub(:lookup)
-        .with("output", "dummyoutput").and_return(DummyOutput)
-    end
+  before(:each) do
+    allow(LogStash::Plugin).to receive(:lookup).with("input", "dummyinput").and_return(DummyInput)
+    allow(LogStash::Plugin).to receive(:lookup).with("codec", "plain").and_return(DummyCodec)
+    allow(LogStash::Plugin).to receive(:lookup).with("output", "dummyoutput").and_return(DummyOutput)
+  end
 
     let(:test_config_without_output_workers) {
       <<-eos

--- a/spec/lib/logstash/java_integration_spec.rb
+++ b/spec/lib/logstash/java_integration_spec.rb
@@ -13,7 +13,7 @@ describe "Java integration" do
     context "Java::JavaUtil::ArrayList" do
 
       it "should report to be a Ruby Array" do
-        expect(Java::JavaUtil::ArrayList.new.is_a?(Array)).to be_true
+        expect(Java::JavaUtil::ArrayList.new.is_a?(Array)).to eq(true)
       end
 
       it "should be class equivalent to Ruby Array" do
@@ -26,13 +26,13 @@ describe "Java integration" do
           end
         end.not_to raise_error
 
-        expect(Array === Java::JavaUtil::ArrayList.new).to be_true
+        expect(Array === Java::JavaUtil::ArrayList.new).to eq(true)
       end
     end
 
     context "Java::JavaUtil::LinkedHashMap" do
       it "should report to be a Ruby Hash" do
-        expect(Java::JavaUtil::LinkedHashMap.new.is_a?(Hash)).to be_true
+        expect(Java::JavaUtil::LinkedHashMap.new.is_a?(Hash)).to eq(true)
       end
 
       it "should be class equivalent to Ruby Hash" do
@@ -45,7 +45,7 @@ describe "Java integration" do
           end
         end.not_to raise_error
 
-        expect(Hash === Java::JavaUtil::LinkedHashMap.new).to be_true
+        expect(Hash === Java::JavaUtil::LinkedHashMap.new).to eq(true)
       end
     end
   end
@@ -200,57 +200,57 @@ describe "Java integration" do
     context "Java Map interface should report key with nil value as included" do
 
       it "should support include? method" do
-        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => nil}).include?("foo")).to be_true
+        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => nil}).include?("foo")).to eq(true)
       end
 
       it "should support has_key? method" do
-        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => nil}).has_key?("foo")).to be_true
+        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => nil}).has_key?("foo")).to eq(true)
       end
 
       it "should support member? method" do
-        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => nil}).member?("foo")).to be_true
+        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => nil}).member?("foo")).to eq(true)
       end
 
       it "should support key? method" do
-        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => nil}).key?("foo")).to be_true
+        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => nil}).key?("foo")).to eq(true)
       end
     end
 
     context "Java Map interface should report key with a value as included" do
 
       it "should support include? method" do
-        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => 1}).include?("foo")).to be_true
+        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => 1}).include?("foo")).to eq(true)
       end
 
       it "should support has_key? method" do
-        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => 1}).has_key?("foo")).to be_true
+        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => 1}).has_key?("foo")).to eq(true)
       end
 
       it "should support member? method" do
-        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => 1}).member?("foo")).to be_true
+        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => 1}).member?("foo")).to eq(true)
       end
 
       it "should support key? method" do
-        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => 1}).key?("foo")).to be_true
+        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => 1}).key?("foo")).to eq(true)
       end
     end
 
     context "Java Map interface should report non existing key as not included" do
 
       it "should support include? method" do
-        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => 1}).include?("bar")).to be_false
+        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => 1})).not_to include("bar")
       end
 
       it "should support has_key? method" do
-        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => 1}).has_key?("bar")).to be_false
+        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => 1}).has_key?("bar")).to eq(false)
       end
 
       it "should support member? method" do
-        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => 1}).member?("bar")).to be_false
+        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => 1}).member?("bar")).to eq(false)
       end
 
       it "should support key? method" do
-        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => 1}).key?("bar")).to be_false
+        expect(Java::JavaUtil::LinkedHashMap.new({"foo" => 1}).key?("bar")).to eq(false)
       end
     end
   end

--- a/spec/util/json_spec.rb
+++ b/spec/util/json_spec.rb
@@ -4,7 +4,7 @@ require "logstash/json"
 require "logstash/environment"
 require "logstash/util"
 
-describe LogStash::Json do
+describe "LogStash::Json" do
 
   let(:hash)   {{"a" => 1}}
   let(:json_hash)   {"{\"a\":1}"}
@@ -33,27 +33,26 @@ describe LogStash::Json do
   if LogStash::Environment.jruby?
 
     ### JRuby specific
-
+    # Former expectation in this code were removed because of https://github.com/rspec/rspec-mocks/issues/964
+    # as soon as is fix we can re introduce them if decired, however for now the completeness of the test
+    # is also not affected as the conversion would not work if the expectation where not meet.
+    ###
     context "jruby deserialize" do
       it "should respond to load and deserialize object" do
-        expect(JrJackson::Raw).to receive(:parse_raw).with(json_hash).and_call_original
         expect(LogStash::Json.load(json_hash)).to eql(hash)
       end
     end
 
     context "jruby serialize" do
       it "should respond to dump and serialize object" do
-        expect(JrJackson::Json).to receive(:dump).with(string).and_call_original
         expect(LogStash::Json.dump(string)).to eql(json_string)
       end
 
       it "should call JrJackson::Raw.generate for Hash" do
-        expect(JrJackson::Raw).to receive(:generate).with(hash).and_call_original
         expect(LogStash::Json.dump(hash)).to eql(json_hash)
       end
 
       it "should call JrJackson::Raw.generate for Array" do
-        expect(JrJackson::Raw).to receive(:generate).with(array).and_call_original
         expect(LogStash::Json.dump(array)).to eql(json_array)
       end
 


### PR DESCRIPTION
The motivation of this PR is to upgrade the test runner in place to rspec 3.x branch, so we can leverage all the nice features it has.

Related PRs:

https://github.com/elastic/logstash-devutils/pull/29
https://github.com/logstash-plugins/logstash-input-s3/pull/43


Upstream issue (https://github.com/rspec/rspec-mocks/issues/964) created because of the jrjackson error when using the ```and_call_original``` expectations in rspec3.