### PR TITLE
config if declare or not for rabbitmq input/output filters

### DIFF
--- a/lib/logstash/inputs/rabbitmq.rb
+++ b/lib/logstash/inputs/rabbitmq.rb
@@ -82,7 +82,6 @@ class LogStash::Inputs::RabbitMQ < LogStash::Inputs::Threadable
   # Passive queue creation? Useful for checking queue existance without modifying server state
   config :passive, :validate => :boolean, :default => false
 
-  config :declare, :validate => :boolean, :default => true
 
   #
   # (Optional) Exchange binding
@@ -101,6 +100,9 @@ class LogStash::Inputs::RabbitMQ < LogStash::Inputs::Threadable
   # * Routing keys are ignored on fanout exchanges.
   # * Wildcards are not valid on direct exchanges.
   config :key, :validate => :string, :default => "logstash"
+
+  # If declare the queue or Use the existed queue without declaration
+  config :declare, :validate => :boolean, :default => true
 
 
   def initialize(params)

--- a/lib/logstash/inputs/rabbitmq.rb
+++ b/lib/logstash/inputs/rabbitmq.rb
@@ -82,7 +82,7 @@ class LogStash::Inputs::RabbitMQ < LogStash::Inputs::Threadable
   # Passive queue creation? Useful for checking queue existance without modifying server state
   config :passive, :validate => :boolean, :default => false
 
-
+  config :declare, :validate => :boolean, :default => true
 
   #
   # (Optional) Exchange binding

--- a/lib/logstash/inputs/rabbitmq/march_hare.rb
+++ b/lib/logstash/inputs/rabbitmq/march_hare.rb
@@ -92,12 +92,22 @@ class LogStash::Inputs::RabbitMQ
 
       @arguments_hash = Hash[*@arguments]
 
-      @q = @ch.queue(@queue,
-        :durable     => @durable,
-        :auto_delete => @auto_delete,
-        :exclusive   => @exclusive,
-        :passive     => @passive,
-        :arguments   => @arguments)
+      if @declare
+        @q = @ch.queue(@queue,
+          :durable     => @durable,
+          :auto_delete => @auto_delete,
+          :exclusive   => @exclusive,
+          :passive     => @passive,
+          :arguments   => @arguments)
+      else
+        @q = MarchHare::Queue.new(@ch,@queue,
+          :durable     => @durable,
+          :auto_delete => @auto_delete,
+          :exclusive   => @exclusive,
+          :passive     => @passive,
+          :arguments   => @arguments)
+        @ch.register_queue(@q)
+      end
 
       # exchange binding is optional for the input
       if @exchange

--- a/lib/logstash/outputs/rabbitmq.rb
+++ b/lib/logstash/outputs/rabbitmq.rb
@@ -42,6 +42,9 @@ class LogStash::Outputs::RabbitMQ < LogStash::Outputs::Base
   # Validate SSL certificate
   config :verify_ssl, :validate => :boolean, :default => false
 
+  # If declare the exchange or Use the existed exchange without declaration
+  config :declare, :validate => :boolean, :default => true
+
   # Enable or disable logging
   config :debug, :validate => :boolean, :default => false, :deprecated => "Use the logstash --debug flag for this instead."
 

--- a/lib/logstash/outputs/rabbitmq/march_hare.rb
+++ b/lib/logstash/outputs/rabbitmq/march_hare.rb
@@ -132,6 +132,16 @@ class LogStash::Outputs::RabbitMQ
       @logger.debug("Declaring an exchange", :name => @exchange, :type => @exchange_type,
                     :durable => @durable)
       @x = @ch.exchange(@exchange, :type => @exchange_type.to_sym, :durable => @durable)
+      if @declare
+        @x = @ch.exchange(@exchange,
+          :type => @exchange_type.to_sym,
+          :durable     => @durable)
+      else
+        @x = MarchHare::Exchange.new(@ch,@exchange,
+          :type => @exchange_type.to_sym,
+          :durable     => @durable)
+        @ch.register_exchange(@x)
+      end
 
       # sets @connected to true during recovery. MK.
       @connected.set(true)

--- a/lib/logstash/outputs/rabbitmq/march_hare.rb
+++ b/lib/logstash/outputs/rabbitmq/march_hare.rb
@@ -129,14 +129,14 @@ class LogStash::Outputs::RabbitMQ
     end
 
     def declare_exchange
-      @logger.debug("Declaring an exchange", :name => @exchange, :type => @exchange_type,
-                    :durable => @durable)
-      @x = @ch.exchange(@exchange, :type => @exchange_type.to_sym, :durable => @durable)
       if @declare
+        @logger.debug("Declaring an exchange", :name => @exchange, :type => @exchange_type,
+                    :durable => @durable)
         @x = @ch.exchange(@exchange,
           :type => @exchange_type.to_sym,
           :durable     => @durable)
       else
+        @logger.debug("do not decalre the exchange")
         @x = MarchHare::Exchange.new(@ch,@exchange,
           :type => @exchange_type.to_sym,
           :durable     => @durable)


### PR DESCRIPTION
in rabbitmq input filter, we could choose to declare the queue or use a existed one.
in rabbitmq out filter, we could choose to declare the exchange or use a existed one.

I am not familiar with ruby , so just copy the code from original code and make some change. 

I have tested both the input and out filter. 
but my RUBY_ENGINE == "jruby", so ONLY test with march_hare, NOT bunny. 