### PR TITLE
Normalize the exception behaviour for inputs outputs and filters

### DIFF
--- a/lib/logstash/pipeline.rb
+++ b/lib/logstash/pipeline.rb
@@ -184,7 +184,7 @@ class LogStash::Pipeline
         @logger.error(I18n.t("logstash.pipeline.worker-error",
                              :plugin => plugin.inspect, :error => e))
       end
-      puts e.backtrace if @logger.debug?
+      @logger.error("Exception in inputworker", "exception" => e, "backtrace" => e.backtrace)
     end
   rescue LogStash::ShutdownSignal
     # nothing
@@ -232,7 +232,7 @@ class LogStash::Pipeline
       output(event)
     end # while true
   rescue => e
-    puts e.backtrace if @logger.debug?
+    @logger.error("Exception in outputworker", "exception" => e, "backtrace" => e.backtrace)
   ensure
     @outputs.each do |output|
       output.worker_plugins.each(&:teardown)

--- a/lib/logstash/pipeline.rb
+++ b/lib/logstash/pipeline.rb
@@ -185,9 +185,6 @@ class LogStash::Pipeline
                              :plugin => plugin.inspect, :error => e))
       end
       puts e.backtrace if @logger.debug?
-      plugin.teardown
-      sleep 1
-      retry
     end
   rescue LogStash::ShutdownSignal
     # nothing
@@ -234,7 +231,9 @@ class LogStash::Pipeline
       break if event.is_a?(LogStash::ShutdownEvent)
       output(event)
     end # while true
-
+  rescue => e
+    puts e.backtrace if @logger.debug?
+  ensure
     @outputs.each do |output|
       output.worker_plugins.each(&:teardown)
     end

--- a/lib/logstash/runner.rb
+++ b/lib/logstash/runner.rb
@@ -9,40 +9,6 @@ LogStash::Environment.bundler_setup!
 LogStash::Environment.load_locale!
 
 Thread.abort_on_exception = false
-if ENV["PROFILE_BAD_LOG_CALLS"] || $DEBUGLIST.include?("log")
-  # Set PROFILE_BAD_LOG_CALLS=1 in your environment if you want
-  # to track down logger calls that cause performance problems
-  #
-  # Related research here:
-  #   https://github.com/jordansissel/experiments/tree/master/ruby/logger-string-vs-block
-  #
-  # Basically, the following is wastes tons of effort creating objects that are
-  # never used if the log level hides the log:
-  #
-  #     logger.debug("something happend", :what => Happened)
-  #
-  # This is shown to be 4x faster:
-  #
-  #     logger.debug(...) if logger.debug?
-  #
-  # I originally intended to use RubyParser and SexpProcessor to
-  # process all the logstash ruby code offline, but it was much
-  # faster to write this monkeypatch to warn as things are called.
-  require "cabin/mixins/logger"
-  module Cabin::Mixins::Logger
-    LEVELS.keys.each do |level|
-      m = "original_#{level}".to_sym
-      predicate = "#{level}?".to_sym
-      alias_method m, level
-      define_method(level) do |*args|
-        if !send(predicate)
-          warn("Unconditional log call", :location => caller[0])
-        end
-        send(m, *args)
-      end
-    end
-  end
-end # PROFILE_BAD_LOG_CALLS
 
 require "logstash/namespace"
 require "logstash/program"

--- a/lib/logstash/runner.rb
+++ b/lib/logstash/runner.rb
@@ -8,7 +8,41 @@ require "logstash/environment"
 LogStash::Environment.bundler_setup!
 LogStash::Environment.load_locale!
 
-Thread.abort_on_exception = true
+Thread.abort_on_exception = false
+if ENV["PROFILE_BAD_LOG_CALLS"] || $DEBUGLIST.include?("log")
+  # Set PROFILE_BAD_LOG_CALLS=1 in your environment if you want
+  # to track down logger calls that cause performance problems
+  #
+  # Related research here:
+  #   https://github.com/jordansissel/experiments/tree/master/ruby/logger-string-vs-block
+  #
+  # Basically, the following is wastes tons of effort creating objects that are
+  # never used if the log level hides the log:
+  #
+  #     logger.debug("something happend", :what => Happened)
+  #
+  # This is shown to be 4x faster:
+  #
+  #     logger.debug(...) if logger.debug?
+  #
+  # I originally intended to use RubyParser and SexpProcessor to
+  # process all the logstash ruby code offline, but it was much
+  # faster to write this monkeypatch to warn as things are called.
+  require "cabin/mixins/logger"
+  module Cabin::Mixins::Logger
+    LEVELS.keys.each do |level|
+      m = "original_#{level}".to_sym
+      predicate = "#{level}?".to_sym
+      alias_method m, level
+      define_method(level) do |*args|
+        if !send(predicate)
+          warn("Unconditional log call", :location => caller[0])
+        end
+        send(m, *args)
+      end
+    end
+  end
+end # PROFILE_BAD_LOG_CALLS
 
 require "logstash/namespace"
 require "logstash/program"

--- a/spec/core/pipeline_spec.rb
+++ b/spec/core/pipeline_spec.rb
@@ -68,6 +68,8 @@ end
 
 class TestPipeline < LogStash::Pipeline
   attr_reader :outputs
+  attr_reader :inputs
+  attr_reader :filters
 end
 
 describe LogStash::Pipeline do
@@ -143,52 +145,54 @@ describe LogStash::Pipeline do
 
     let(:bad_event) { LogStash::Event.new("message" => "bad message") }
     let(:good_event) { LogStash::Event.new("message" => "good message") }
-    let(:pipeline) { LogStash::Pipeline.new(dummy_config) }
+    let(:pipeline) { TestPipeline.new(dummy_config) }
+    let(:input) { pipeline.inputs.first }
+    let(:output) { pipeline.outputs.first }
+    let(:filter) { pipeline.filters.first }
 
     context "transient exceptions" do
       context "input" do
         it "should restart and generate more events" do
-          expect_any_instance_of(DummyInput).to receive(:run).and_return do |queue|
+          expect(input).to receive(:run).and_return do |queue|
             raise StandardError
           end
-          expect_any_instance_of(DummyInput).to receive(:run).and_return do |queue|
+          expect(input).to receive(:run).and_return do |queue|
             queue << good_event
           end
-          expect_any_instance_of(DummyOutput).to receive(:receive).once.with(good_event)
-          expect_any_instance_of(DummyInput).to receive(:teardown).once
+          expect(output).to receive(:receive).once.with(good_event)
+          expect(input).to receive(:teardown).once
           expect { pipeline.run }.to_not raise_error
         end
       end
 
       context "filter" do
         it "should restart and process the next event" do
-          expect_any_instance_of(DummyInput).to receive(:run).and_return do |queue|
+          expect(input).to receive(:run).and_return do |queue|
             queue << bad_event
             queue << good_event
           end
-          expect_any_instance_of(DummyFilter).to receive(:filter).with(bad_event).and_return do |event|
+          expect(filter).to receive(:filter).with(bad_event).and_return do |event|
             raise StandardError
           end
-          expect_any_instance_of(DummyFilter).to receive(:filter).with(good_event)
-          expect_any_instance_of(DummyOutput).to receive(:receive).once.with(good_event)
-          expect_any_instance_of(DummyFilter).to receive(:teardown).once
+          expect(filter).to receive(:filter).with(good_event)
+          expect(output).to receive(:receive).once.with(good_event)
           expect { pipeline.run }.to_not raise_error
         end
       end
 
       context "output" do
         it "should restart and process the next message" do
-          expect_any_instance_of(DummyInput).to receive(:run).and_return do |queue|
+          expect(input).to receive(:run).and_return do |queue|
             queue << bad_event
             queue << good_event
           end
-          expect_any_instance_of(DummyOutput).to receive(:receive).with(bad_event).and_return do |event|
+          expect(output).to receive(:receive).with(bad_event).and_return do |event|
             raise StandardError
           end
-          expect_any_instance_of(DummyOutput).to receive(:receive).with(good_event).and_return do |event|
+          expect(output).to receive(:receive).with(good_event).and_return do |event|
             # ...
           end
-          expect_any_instance_of(DummyOutput).to receive(:teardown).once
+          expect(output).to receive(:teardown).once
           expect { pipeline.run }.to_not raise_error
         end
       end
@@ -197,36 +201,39 @@ describe LogStash::Pipeline do
     context "fatal exceptions" do
       context "input" do
         it "should raise exception" do
-          expect_any_instance_of(DummyInput).to receive(:run).and_return do |queue|
+          expect(input).to receive(:run).and_return do |queue|
             raise Exception
           end
-          expect_any_instance_of(DummyFilter).to_not receive(:filter)
-          expect { pipeline.run }.to raise_error(Exception)
+          expect(filter).to_not receive(:filter)
+          expect(pipeline).to receive(:shutdown)
+          expect { pipeline.run }.to_not raise_error
         end
       end
 
       context "filter" do
         it "should raise exception" do
-          expect_any_instance_of(DummyInput).to receive(:run).and_return do |queue|
+          expect(input).to receive(:run).and_return do |queue|
             queue << bad_event
           end
-          expect_any_instance_of(DummyFilter).to receive(:filter).with(bad_event).and_return do |event|
+          expect(filter).to receive(:filter).with(bad_event).and_return do |event|
             raise Exception
           end
-          expect_any_instance_of(DummyOutput).to_not receive(:receive)
-          expect { pipeline.run }.to raise_error(Exception)
+          expect(output).to_not receive(:receive)
+          expect(pipeline).to receive(:shutdown)
+          expect { pipeline.run }.to_not raise_error
         end
       end
 
       context "output" do
         it "should raise exception" do
-          expect_any_instance_of(DummyInput).to receive(:run).and_return do |queue|
+          expect(input).to receive(:run).and_return do |queue|
             queue << bad_event
           end
-          expect_any_instance_of(DummyOutput).to receive(:receive).with(bad_event).and_return do |event|
+          expect(output).to receive(:receive).with(bad_event).and_return do |event|
             raise Exception
           end
-          expect { pipeline.run }.to raise_error(Exception)
+          expect(pipeline).to receive(:shutdown)
+          expect { pipeline.run }.to_not raise_error
         end
       end
     end

--- a/spec/core/pipeline_spec.rb
+++ b/spec/core/pipeline_spec.rb
@@ -133,7 +133,7 @@ describe LogStash::Pipeline do
 
   context "when plugins raise exceptions" do
 
-    let(:config_with_faulty_output) {
+    let(:dummy_config) {
       <<-eos
       input { dummyinput {} }
       filter { dummyfilter {} }
@@ -142,51 +142,40 @@ describe LogStash::Pipeline do
     }
 
     context "output" do
-
       it "should call teardown and not raise exceptions" do
-
-        expect_any_instance_of(DummyOutput).to receive(:receive).and_return do |event|
-          unknown_method(event)
-        end
-
         expect_any_instance_of(DummyInput).to receive(:run).and_return do |queue|
           queue << LogStash::Event.new("message" => "hello")
         end
-
+        expect_any_instance_of(DummyOutput).to receive(:receive).and_return do |event|
+          unknown_method(event)
+        end
         expect_any_instance_of(DummyOutput).to receive(:teardown).once
-        expect { TestPipeline.new(config_with_faulty_output).run }.to_not raise_error
+        expect { TestPipeline.new(dummy_config).run }.to_not raise_error
       end
     end
 
     context "input" do
       it "should call teardown and not raise exceptions" do
-
-        expect_any_instance_of(DummyOutput).to_not receive(:receive)
-
         expect_any_instance_of(DummyInput).to receive(:run).and_return do |queue|
           unknown_method(event)
         end
-
+        expect_any_instance_of(DummyOutput).to_not receive(:receive)
         expect_any_instance_of(DummyInput).to receive(:teardown).once
-        expect { TestPipeline.new(config_with_faulty_output).run }.to_not raise_error
+        expect { TestPipeline.new(dummy_config).run }.to_not raise_error
       end
     end
 
     context "filter" do
       it "should call teardown and not raise exceptions" do
-
         expect_any_instance_of(DummyInput).to receive(:run).and_return do |queue|
           queue << LogStash::Event.new("message" => "hello")
         end
-
         expect_any_instance_of(DummyFilter).to receive(:filter).and_return do |queue|
           unknown_method(event)
         end
-
         expect_any_instance_of(DummyOutput).to_not receive(:receive)
-
         expect_any_instance_of(DummyFilter).to receive(:teardown).once
-        expect { TestPipeline.new(config_with_faulty_output).run }.to_not raise_error
+        expect { TestPipeline.new(dummy_config).run }.to_not raise_error
       end
     end
   end

--- a/spec/core/pipeline_spec.rb
+++ b/spec/core/pipeline_spec.rb
@@ -131,7 +131,7 @@ describe LogStash::Pipeline do
     end
   end
 
-  context "when filters raise exceptions" do
+  context "when plugins raise exceptions" do
 
     let(:config_with_faulty_output) {
       <<-eos


### PR DESCRIPTION
Right now an exception on an input plugin will cause it to restart indefinitely, while an exception in an output plugin halts logstash immediately. 

[EDITED] Taking @jordansissel's comments into account, this pull request makes all plugins have the same behaviour:
If a plugin raises a StandardError, worker catches and retries the method. An Exception makes logstash crash.

This might not be the desired behaviour we want, so this PR is more a WIP, aiming at consistent behaviour across plugins.
Also this adds tests to the pipeline for this behaviour.

Issues related to this problem:
https://github.com/elasticsearch/logstash/issues/2152
https://github.com/elasticsearch/logstash/issues/2130
https://github.com/elasticsearch/logstash/issues/1250
https://github.com/elasticsearch/logstash/issues/1373

fixes https://github.com/elasticsearch/logstash/issues/2477
