### PR TITLE
Make configurable the filter flush opportunity interval

### DIFF
--- a/lib/logstash/agent.rb
+++ b/lib/logstash/agent.rb
@@ -2,6 +2,7 @@
 require "clamp" # gem 'clamp'
 require "logstash/environment"
 require "logstash/errors"
+require "logstash/pipeline"
 require "uri"
 require "net/http"
 LogStash::Environment.load_locale!
@@ -17,7 +18,11 @@ class LogStash::Agent < Clamp::Command
 
   option ["-w", "--filterworkers"], "COUNT",
     I18n.t("logstash.agent.flag.filterworkers"),
-    :attribute_name => :filter_workers, :default => 1, &:to_i
+    :attribute_name => :filter_workers, &:to_i
+
+  option ["--filter-flush-opportunity-interval"], "SECONDS",
+    I18n.t("logstash.agent.flag.filter-flush-opportunity-interval"),
+    :attribute_name => :filter_flush_opportunity_interval, :default => LogStash::Pipeline::DEFAULTS[LogStash::Pipeline::FILTER_FLUSH_OPPORTUNITY_INTERVAL], &:to_f
 
   option "--watchdog-timeout", "SECONDS",
     I18n.t("logstash.agent.flag.watchdog-timeout"),
@@ -127,7 +132,8 @@ class LogStash::Agent < Clamp::Command
       configure_logging(log_file)
     end
 
-    pipeline.configure("filter-workers", filter_workers)
+    pipeline.configure(LogStash::Pipeline::FILTER_WORKERS, filter_workers) if filter_workers
+    pipeline.configure(LogStash::Pipeline::FILTER_FLUSH_OPPORTUNITY_INTERVAL, filter_flush_opportunity_interval)
 
     # Stop now if we are only asking for a config test.
     if config_test?

--- a/lib/logstash/pipeline.rb
+++ b/lib/logstash/pipeline.rb
@@ -12,6 +12,13 @@ require "logstash/outputs/base"
 class LogStash::Pipeline
 
   FLUSH_EVENT = LogStash::FlushEvent.new
+  FILTER_FLUSH_OPPORTUNITY_INTERVAL = "filter-flush-opportunity-interval"
+  FILTER_WORKERS = "filter-workers"
+
+  DEFAULTS = {
+    FILTER_WORKERS => 1,
+    FILTER_FLUSH_OPPORTUNITY_INTERVAL => 5
+  }
 
   def initialize(configstr)
     @logger = Cabin::Channel.get(LogStash)
@@ -43,7 +50,8 @@ class LogStash::Pipeline
       @filter_to_output = SizedQueue.new(20)
     end
     @settings = {
-      "filter-workers" => 1,
+      FILTER_WORKERS => DEFAULTS[FILTER_WORKERS],
+      FILTER_FLUSH_OPPORTUNITY_INTERVAL => DEFAULTS[FILTER_FLUSH_OPPORTUNITY_INTERVAL]
     }
   end # def initialize
 
@@ -56,7 +64,7 @@ class LogStash::Pipeline
   end
 
   def configure(setting, value)
-    if setting == "filter-workers"
+    if setting == FILTER_WORKERS
       # Abort if we have any filters that aren't threadsafe
       if value > 1 && @filters.any? { |f| !f.threadsafe? }
         plugins = @filters.select { |f| !f.threadsafe? }.collect { |f| f.class.config_name }
@@ -146,12 +154,19 @@ class LogStash::Pipeline
 
   def start_filters
     @filters.each(&:register)
-    @filter_threads = @settings["filter-workers"].times.collect do
+    @filter_threads = @settings[FILTER_WORKERS].times.collect do
       Thread.new { filterworker }
     end
 
     @flusher_lock = Mutex.new
-    @flusher_thread = Thread.new { Stud.interval(5) { @flusher_lock.synchronize { @input_to_filter.push(FLUSH_EVENT) } } }
+    @flusher_thread = Thread.new do
+      Stud.interval(@settings[FILTER_FLUSH_OPPORTUNITY_INTERVAL]) do
+        @flusher_lock.synchronize do
+          @logger.debug? && @logger.debug("Signalling flush opportunity")
+          @input_to_filter.push(FLUSH_EVENT)
+        end
+      end
+    end
   end
 
   def start_outputs

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -136,6 +136,9 @@ en:
           Check configuration, then exit.
         filterworkers: |+
           Sets the number of filter workers to run.
+        filter-flush-opportunity-interval: |+
+          Set the interval (in seconds) on which 
+          filters are given the opportunity to flush.
         watchdog-timeout: |+
           Set the filter watchdog timeout (in seconds).
           This timeout is used to detect stuck filters;


### PR DESCRIPTION
This exposes a previously-constant setting as the
--filter-flush-opportunity-interval flag. The default value is the
previous default of 5 seconds. This will not be a common setting
for users to change.

I also cleaned up a bit of the pipeline settings to make the
configuration keys into constants.

Fixes #1231