### PR TITLE
Document how to check for the presence of a field.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -258,6 +258,13 @@ You can also do multiple expressions in a single condition:
         }
       }
     }
+    
+You can test whether a field was present, regardless of its value:
+
+    if [exception_message] {
+      # If the event has an exception_message field, set the level
+      mutate { add_field => { "level" => "ERROR" } }
+    }
 
 Here are some examples for testing with the in conditional:
 


### PR DESCRIPTION
It's possible to write a conditional in the logstash configuration to check for the presence of a field. It's not obvious from the docs how to do this. This pull request documents this feature, and gives an example.

This is an updated version of #1368.