### PR TITLE
rpm+deb: make pre-releases sort lower than GA releases

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -201,7 +201,7 @@ namespace "artifact" do
     # TODO(sissel): Invoke Pleaserun to generate the init scripts/whatever
 
     out.name = "logstash"
-    out.version = LOGSTASH_VERSION
+    out.version = LOGSTASH_VERSION.gsub(/[.-]([[:alpha:]])/, '~\1')
     out.architecture = "all"
     # TODO(sissel): Include the git commit hash?
     out.iteration = "1" # what revision?


### PR DESCRIPTION
The current replacement works for rc and dev versions but is ineffective
for stuff like alpha and beta. We take a more generic method: whenever
we get a dot followed by an alphabetic character, we replace the `.` by
`~`.

    $ for v in 1.5.0 1.5.0.dev 1.5.0.beta2.dev ; do echo -n $v\ ; echo $v | sed 's/\.\([[:alpha:]]\)/~\1/g' ; done
    1.5.0 1.5.0
    1.5.0.dev 1.5.0~dev
    1.5.0.beta2.dev 1.5.0~beta2~dev