### PR TITLE
Update apache-parse.conf (debug => true is not supported anymore?)

### DIFF
--- a/docs/tutorials/10-minute-walkthrough/apache-parse.conf
+++ b/docs/tutorials/10-minute-walkthrough/apache-parse.conf
@@ -28,6 +28,6 @@ filter {
 output {
   # Use stdout in debug mode again to see what logstash makes of the event.
   stdout {
-    debug => true
+    codec => rubydebug
   }
 }


### PR DESCRIPTION
Seems like debug => true is not supported anymore? I am getting "Unknown setting 'debug' for stdout {:level=>:error}" when I run it.. with "codec => rubydebug" it looks ok :)