### PR TITLE
Make bundler to never save a `bundler/config`

### DIFF
--- a/lib/bootstrap/bundler.rb
+++ b/lib/bootstrap/bundler.rb
@@ -11,6 +11,14 @@ module LogStash
           Pathname.new("#{default_gemfile}.#{ruby}.lock")
         end
       end
+
+      # Patch to prevent Bundler to save a .bundle/config file in the root 
+      # of the application
+      ::Bundler::Settings.module_exec do
+        def set_key(key, value, hash, file)
+          value
+        end
+      end
     end
 
     def setup!(options = {})

--- a/lib/logstash/patches/bundler.rb
+++ b/lib/logstash/patches/bundler.rb
@@ -9,6 +9,14 @@ module ::Bundler
     end
   end
 
+  # Patch to prevent Bundler to save a .bundle/config file in the root 
+  # of the application
+  class Settings
+    def set_key(key, value, hash, file)
+      value
+    end
+  end
+
   # Add the Bundler.reset! method which has been added in master but is not in 1.7.9.
   class << self
     unless self.method_defined?("reset!")


### PR DESCRIPTION
Make sure our logstash application is stateless and doesn't write on disk the bundler configuration.