### PR TITLE
escape tilde in doc

### DIFF
--- a/docs/asciidoc/static/configuration.asciidoc
+++ b/docs/asciidoc/static/configuration.asciidoc
@@ -358,7 +358,7 @@ What's an expression? Comparison tests, boolean logic, and so on!
 You can use the following comparison operators:
 
 * equality: ==,  !=,  <,  >,  <=,  >=
-* regexp: =~, !~
+* regexp: =\~, !~
 * inclusion: in, not in
 
 The supported boolean operators are:


### PR DESCRIPTION
Tilde in conditional operator was not rendering since it wasn't escaped per asciidoc syntax