### PR TITLE
Heartbeat input was missing from the official distribution

### DIFF
--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -3,6 +3,7 @@ module LogStash
 
     # plugins included by default in the logstash distribution
     DEFAULT_PLUGINS = %w(
+      logstash-input-heartbeat
       logstash-output-zeromq
       logstash-codec-collectd
       logstash-output-xmpp


### PR DESCRIPTION
Heartbeat is now in the default plugins list