### PR TITLE
[wip] Add `http_proxy` support back

### DIFF
--- a/lib/logstash/bundler.rb
+++ b/lib/logstash/bundler.rb
@@ -41,6 +41,15 @@ module LogStash
       $stdout = old_stdout
     end
 
+    def self.configure_http_proxy!
+      if ENV["http_proxy"]
+        # Since we are using the class ourself not all the setup is done
+        # we need to manually setup the http_proxy
+        Gem.configuration[:http_proxy] = ENV['http_proxy']
+        Gem.configuration[:proxy] = ENV['http_proxy'] # The old jar-dependencies is using the wrong params
+      end
+    end
+
     # execute bundle install and capture any $stdout output. any raised exception in the process will be trapped
     # and returned. logs errors to $stdout.
     # @param options [Hash] invoke options with default values, :max_tries => 10, :clean => false, :install => false, :update => false
@@ -52,6 +61,8 @@ module LogStash
       options[:update] = Array(options[:update]) if options[:update]
 
       ENV["GEM_PATH"] = LogStash::Environment.logstash_gem_home
+
+      configure_http_proxy!
 
       ::Bundler.settings[:path] = LogStash::Environment::BUNDLE_DIR
       ::Bundler.settings[:gemfile] = LogStash::Environment::GEMFILE_PATH

--- a/lib/logstash/pluginmanager/util.rb
+++ b/lib/logstash/pluginmanager/util.rb
@@ -1,11 +1,13 @@
+require "logstash/bundler"
 module LogStash::PluginManager
-
   # check for valid logstash plugin gem name & version or .gem file, logs errors to $stdout
   # uses Rubygems API and will remotely validated agains the current Gem.sources
   # @param plugin [String] plugin name or .gem file path
   # @param version [String] gem version requirement string
   # @return [Boolean] true if valid logstash plugin gem name & version or a .gem file
   def self.logstash_plugin?(plugin, version = nil)
+    LogStash::Bundler.configure_http_proxy!
+
     if plugin_file?(plugin)
       begin
         return logstash_plugin_gem_spec?(plugin_file_spec(plugin))


### PR DESCRIPTION
We are using the Gem's fetcher to verify if a gem is a logstash plugin or not so we need to make sure the gem configuration uses the `http_proxy`. 

Bundler is better citizen and uses the environment variable to configure the proxy correctly, but jar-dependencies is using the wrong key to access the proxy configuration.

http_proxy bundle install logstash-ouput-elasticsearch
Fixes: https://github.com/elastic/logstash/issues/2851