### PR TITLE
Retries and error strategy for outputs

### DIFF
--- a/lib/logstash/outputs/base.rb
+++ b/lib/logstash/outputs/base.rb
@@ -98,12 +98,12 @@ class LogStash::Outputs::Base < LogStash::Plugin
     begin
       receive(event)
     rescue Exception => e
-      if attempt <= retries
+      if attempt < retries
         safe_handle(event, attempt += 1)
-      elsif @on_error_strategy == "shutdown"
-        raise e
       elsif @on_error_strategy == "ignore"
         @logger.warn(I18n.t("logstash.pipeline.output-worker-ignore-error", :plugin => self.class.config_name, :event => event, :exception => e))
+      else
+        raise e
       end
     end
   end # def deal

--- a/lib/logstash/outputs/base.rb
+++ b/lib/logstash/outputs/base.rb
@@ -33,6 +33,16 @@ class LogStash::Outputs::Base < LogStash::Plugin
   # Note that this setting may not be useful for all outputs.
   config :workers, :validate => :number, :default => 1
 
+  # The number of retries if some exception happens.
+  # Optional.
+  config :retries, :validate => :number, :default => 0
+
+  # The strategy to use when an exception is raised.
+  # Use 'shutdown', default, to terminate logstash.
+  # Use 'ignore' to keep going and ignore and log the error.
+  # Optional.
+  config :on_error_strategy, :validate => :string, :default => "shutdown"
+
   attr_reader :worker_plugins
 
   public
@@ -84,8 +94,23 @@ class LogStash::Outputs::Base < LogStash::Plugin
   end
 
   public
+  def safe_handle(event, attempt = 0)
+    begin
+      receive(event)
+    rescue Exception => e
+      if attempt <= retries
+        safe_handle(event, attempt += 1)
+      elsif @on_error_strategy == "shutdown"
+        raise e
+      elsif @on_error_strategy == "ignore"
+        @logger.warn(I18n.t("logstash.pipeline.output-worker-ignore-error", :plugin => self.class.config_name, :event => event, :exception => e))
+      end
+    end
+  end # def deal
+
+  public
   def handle(event)
-    receive(event)
+    safe_handle(event)
   end # def handle
 
   def handle_worker(event)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -33,6 +33,11 @@ en:
         %{plugin} output plugin: setting 'workers => %{worker_count}' is not
         supported by this plugin. I will continue working as if you had not set
         this setting.
+      output-worker-ignore-error: >-
+        %{plugin} output plugin: when trying to send the event: '%{event}'
+        the error: '%{exception}' was raised.
+        As I am configured to ignore errors: 'on_error_strategy => "ignore"'
+        I will continue working as if nothing happened.
     plugin:
       deprecated_milestone: >-
         %{plugin} plugin is using the 'milestone' method to declare the version

--- a/spec/outputs/base_spec.rb
+++ b/spec/outputs/base_spec.rb
@@ -32,4 +32,40 @@ describe "LogStash::Outputs::Base#output?" do
     expect(output.receive(LogStash::Event.new({"tags" => ["value"]}))).to eq(false)
     expect(output.receive(LogStash::Event.new({"tags" => ["notvalue"]}))).to eq(true)
   end
+
+  it "should receive only one time with default 'retries'" do
+    output = LogStash::Outputs::NOOP.new()
+
+    output.should_receive(:receive).once
+
+    output.handle(LogStash::Event.new())
+
+  end
+
+  it "should call receive one time plus 'retries'" do
+    retries = 3
+    output = LogStash::Outputs::NOOP.new("retries" => retries)
+
+    output.stub(:receive) { raise "any unrescued error from the output" }
+    output.should_receive(:receive).exactly(1 + retries).times
+
+    expect{ output.handle(LogStash::Event.new()) }.to raise_error
+  end
+
+  it "should shutdown when exception is raised and on_error_strategy is default 'shutdown'" do
+    output = LogStash::Outputs::NOOP.new()
+
+    output.stub(:receive) { raise "any unrescued error from the output" }
+
+    expect{ output.handle(LogStash::Event.new()) }.to raise_error
+  end
+
+  it "should ignore when exception is raised and on_error_strategy is 'ignore'" do
+    output = LogStash::Outputs::NOOP.new("on_error_strategy" => "ignore")
+
+    output.stub(:receive) { raise "any unrescued error from the output" }
+
+    expect{ output.handle(LogStash::Event.new()) }.to_not raise_error
+  end
+
 end


### PR DESCRIPTION
Sometimes outputs can cause errors such as "ECONN REFUSED" errors or "Net:: HTTPFatalError: 502 "Bad Gateway".

This errors should be handled properly by each output plugin, but we know this is not always the case.

So, to avoid such problems, and sometimes they only happens few times a day, I think a retry policy and a error strategy can be very helpful. :)

Also, if nothing is specified, logstash will behave exactly as it always did. If an exception is raised, it will shutdown.

This implementation adds two new configurations to `lib/logstash/outputs/base.rb`

``` ruby
output{
  any_output{
    # The number of retries if some exception happens.
    # Optional.    
    retries => 10

    # The strategy to use when an exception is raised.
    # Use 'shutdown', default, to terminate logstash.
    # Use 'ignore' to keep going and ignore and log the error.
    # Optional.
    on_error_strategy => "ignore"
  }
}
```

I created the tests inside `spec/outputs/base_spec.rb` and tried to follow every step from logstash contributing guide. Please let me know if something can be improved, I'm glad to help.

Thanks,
