### PR TITLE
remove deprecation notices when output workers > 1

### DIFF
--- a/lib/logstash/outputs/base.rb
+++ b/lib/logstash/outputs/base.rb
@@ -69,7 +69,7 @@ class LogStash::Outputs::Base < LogStash::Plugin
     else
       define_singleton_method(:handle, method(:handle_worker))
       @worker_queue = SizedQueue.new(20)
-      @worker_plugins = @workers.times.map { self.class.new(@original_params.merge("workers" => 1, "codec" => @codec.clone)) }
+      @worker_plugins = @workers.times.map { self.class.new(@original_params.merge("workers" => 1)) }
       @worker_plugins.map.with_index do |plugin, i|
         Thread.new(original_params, @worker_queue) do |params, queue|
           LogStash::Util::set_thread_name(">#{self.class.config_name}.#{i}")

--- a/lib/logstash/outputs/base.rb
+++ b/lib/logstash/outputs/base.rb
@@ -69,7 +69,7 @@ class LogStash::Outputs::Base < LogStash::Plugin
     else
       define_singleton_method(:handle, method(:handle_worker))
       @worker_queue = SizedQueue.new(20)
-      @worker_plugins = @workers.times.map { self.class.new(params.merge("workers" => 1, "codec" => @codec.clone)) }
+      @worker_plugins = @workers.times.map { self.class.new(@original_params.merge("workers" => 1, "codec" => @codec.clone)) }
       @worker_plugins.map.with_index do |plugin, i|
         Thread.new(original_params, @worker_queue) do |params, queue|
           LogStash::Util::set_thread_name(">#{self.class.config_name}.#{i}")

--- a/spec/outputs/base_spec.rb
+++ b/spec/outputs/base_spec.rb
@@ -6,10 +6,22 @@ class LogStash::Outputs::NOOP < LogStash::Outputs::Base
   config_name "noop"
   milestone 2
 
+  config :dummy_option, :validate => :string
+
   def register; end
 
   def receive(event)
     return output?(event)
+  end
+end
+
+describe "LogStash::Outputs::Base#worker_setup" do
+  it "should create workers using original parameters except workers = 1" do
+    params = { "dummy_option" => "potatoes", "codec" => "json", "workers" => 2 }
+    worker_params = params.dup; worker_params["workers"] = 1
+    output = LogStash::Outputs::NOOP.new(params.dup)
+    expect(LogStash::Outputs::NOOP).to receive(:new).twice.with(worker_params).and_call_original
+    output.worker_setup
   end
 end
 


### PR DESCRIPTION
When workers is set to > 1, new plugin instances are created using a params hash
that contains both the user-specified config parameters and the default ones.
This causes deprecation notices to be printed, even though the user never specified
a deprecated config setting.
Thus, new workers should be created using only the "original" set of config parameters.

fixes #2865