### PR TITLE
Add elasticsearch_http output plugin for easy upgrade path

### DIFF
--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -77,6 +77,7 @@ module LogStash
       logstash-output-cloudwatch
       logstash-output-csv
       logstash-output-elasticsearch
+      logstash-output-elasticsearch_http
       logstash-output-email
       logstash-output-exec
       logstash-output-file


### PR DESCRIPTION
Adding this plugin give the user an upgrade path to the new elasticsearch output.

- The plugin repository is located at https://github.com/logstash-plugins/logstash-output-elasticsearch_http
- The gem is already published.

Fixes: https://github.com/elastic/logstash/issues/1757