### PR TITLE
Handle spaces in paths

### DIFF
--- a/bin/logstash
+++ b/bin/logstash
@@ -12,7 +12,7 @@
 LS_HEAP_SIZE="${LS_HEAP_SIZE:=500m}"
 
 unset CDPATH
-basedir=$(cd `dirname $0`/..; pwd)
+basedir=$(cd "$(dirname "$0")"/..; pwd)
 . "${basedir}/bin/logstash.lib.sh"
 
 setup

--- a/bin/logstash-test
+++ b/bin/logstash-test
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-basedir=$(cd `dirname $0`/..; pwd)
-exec $basedir/bin/logstash rspec "$@"
+basedir=$(cd "$(dirname "$0")"/..; pwd)
+exec "$basedir/bin/logstash" rspec "$@"

--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -1,4 +1,4 @@
-basedir=$(cd `dirname $0`/..; pwd)
+basedir=$(cd "$(dirname "$0")"/..; pwd)
 
 setup_java() {
   if [ -z "$JAVACMD" ] ; then

--- a/bin/plugin
+++ b/bin/plugin
@@ -12,7 +12,7 @@
 LS_HEAP_SIZE="${LS_HEAP_SIZE:=500m}"
 
 unset CDPATH
-basedir=$(cd `dirname $0`/..; pwd)
+basedir=$(cd "$(dirname "$0")"/..; pwd)
 . "${basedir}/bin/logstash.lib.sh"
 
 setup


### PR DESCRIPTION
Clone repo to "logstash repo" directory or any directory with a path.
Try to run anything in bin/ from outside the repo.

```
./logstash\ repo/bin/plugin
```

You get the following output

```
dirname: extra operand `repo/bin/plugin'
Try `dirname --help' for more information.
./logstash repo/bin/plugin: line 16: //bin/logstash.lib.sh: No such file or directory
```
