### PR TITLE
Fixing test false positive 

### DIFF
--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -1,3 +1,10 @@
+##
+# In Logstash we use rspec throw the runner interface so we need to
+# call explicity to exit in order to set the proper exit code, otherwise
+# most common CI systems can not know whats up with this tests.
+# In general this is not a problem, because the most common rspec usage
+# is throw the rake task, where rspec sets this himself internally.
+##
 namespace "test" do
   def run_rspec(*args)
     require "logstash/environment"
@@ -8,15 +15,15 @@ namespace "test" do
   end
 
   task "core" do
-    run_rspec(Rake::FileList["spec/**/*_spec.rb"])
+    exit run_rspec(Rake::FileList["spec/**/*_spec.rb"])
   end
 
   task "core-fail-fast" do
-    run_rspec("--fail-fast", Rake::FileList["spec/**/*_spec.rb"])
+    exit run_rspec("--fail-fast", Rake::FileList["spec/**/*_spec.rb"])
   end
 
   task "plugins" do
-    run_rspec("--order", "rand", Rake::FileList[File.join(ENV["GEM_HOME"], "gems/logstash-*/spec/{input,filter,codec,output}s/*_spec.rb")])
+    exit run_rspec("--order", "rand", Rake::FileList[File.join(ENV["GEM_HOME"], "gems/logstash-*/spec/{input,filter,codec,output}s/*_spec.rb")])
   end
 
   task "install-core" => ["bootstrap", "plugin:install-core", "plugin:install-development-dependencies"]


### PR DESCRIPTION
There is, but probably been there for longer time, a condition that caused the test to pass always, causing a bit set of false positive.

This was because the rake task were not properly failing if the exit code was not zero, this PR basically fix this situation by explicitly call fail if this condition is set.

Fixes #2770