### PR TITLE
JAVA_OPTS & LS_JAVA_OPTS parsing strategy

### DIFF
--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -15,27 +15,31 @@ setup_java() {
   fi
 
   if [ ! -x "$JAVACMD" ] ; then
-    echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME."
+    echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME." 1>&2
     exit 1
   fi
 
-  if [ "$LS_HEAP_SIZE" ] ; then
-    JAVA_OPTS="$JAVA_OPTS -Xmx${LS_HEAP_SIZE}"
-  fi
-
-  if [ -z "$LS_JAVA_OPTS" ] ; then
+  if [ "$JAVA_OPTS" ] ; then
+    echo "WARNING: Default JAVA_OPTS will be overridden by the JAVA_OPTS defined in the environment. Environment JAVA_OPTS are $JAVA_OPTS"  1>&2
+  else
     # There are no JAVA_OPTS set from the client, we set a predefined
     # set of options that think are good in general
-    JAVA_OPTS="$JAVA_OPTS -XX:+UseParNewGC"
+    JAVA_OPTS="-XX:+UseParNewGC"
     JAVA_OPTS="$JAVA_OPTS -XX:+UseConcMarkSweepGC"
     JAVA_OPTS="$JAVA_OPTS -Djava.awt.headless=true"
 
     JAVA_OPTS="$JAVA_OPTS -XX:CMSInitiatingOccupancyFraction=75"
     JAVA_OPTS="$JAVA_OPTS -XX:+UseCMSInitiatingOccupancyOnly"
-  else
+  fi
+
+  if [ "$LS_JAVA_OPTS" ] ; then
     # The client set the variable LS_JAVA_OPTS, choosing his own
     # set of java opts.
     JAVA_OPTS="$JAVA_OPTS $LS_JAVA_OPTS"
+  fi
+
+  if [ "$LS_HEAP_SIZE" ] ; then
+    JAVA_OPTS="$JAVA_OPTS -Xmx${LS_HEAP_SIZE}"
   fi
 
   if [ "$LS_USE_GC_LOGGING" ] ; then

--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -19,15 +19,26 @@ setup_java() {
     exit 1
   fi
 
-  JAVA_OPTS="$JAVA_OPTS -Xmx${LS_HEAP_SIZE}"
-  JAVA_OPTS="$JAVA_OPTS -XX:+UseParNewGC"
-  JAVA_OPTS="$JAVA_OPTS -XX:+UseConcMarkSweepGC"
-  JAVA_OPTS="$JAVA_OPTS -Djava.awt.headless=true"
+  if [ "$LS_HEAP_SIZE" ] ; then
+    JAVA_OPTS="$JAVA_OPTS -Xmx${LS_HEAP_SIZE}"
+  fi
 
-  JAVA_OPTS="$JAVA_OPTS -XX:CMSInitiatingOccupancyFraction=75"
-  JAVA_OPTS="$JAVA_OPTS -XX:+UseCMSInitiatingOccupancyOnly"
+  if [ -z "$LS_JAVA_OPTS" ] ; then
+    # There are no JAVA_OPTS set from the client, we set a predefined
+    # set of options that think are good in general
+    JAVA_OPTS="$JAVA_OPTS -XX:+UseParNewGC"
+    JAVA_OPTS="$JAVA_OPTS -XX:+UseConcMarkSweepGC"
+    JAVA_OPTS="$JAVA_OPTS -Djava.awt.headless=true"
 
-  if [ ! -z "$LS_USE_GC_LOGGING" ] ; then
+    JAVA_OPTS="$JAVA_OPTS -XX:CMSInitiatingOccupancyFraction=75"
+    JAVA_OPTS="$JAVA_OPTS -XX:+UseCMSInitiatingOccupancyOnly"
+  else
+    # The client set the variable LS_JAVA_OPTS, choosing his own
+    # set of java opts.
+    JAVA_OPTS="$JAVA_OPTS $LS_JAVA_OPTS"
+  fi
+
+  if [ "$LS_USE_GC_LOGGING" ] ; then
     JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCDetails"
     JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCTimeStamps"
     JAVA_OPTS="$JAVA_OPTS -XX:+PrintClassHistogram"
@@ -96,7 +107,7 @@ jruby_opts() {
 setup() {
   # first check if we want to use drip, which can be used in vendored jruby mode
   # and also when setting USE_RUBY=1 if the ruby interpretor is in fact jruby
-  if [ ! -z "$JAVACMD" ] ; then
+  if [ "$JAVACMD" ] ; then
     if [ "$(basename $JAVACMD)" = "drip" ] ; then
       DRIP_JAVACMD=1
       USE_DRIP=1

--- a/pkg/logstash.sysv
+++ b/pkg/logstash.sysv
@@ -46,11 +46,9 @@ args="agent -f ${LS_CONF_DIR} -l ${LS_LOG_FILE} ${LS_OPTS}"
 
 start() {
 
-  # Set JAVA_OPTS to avoid sharing configuration between other
-  # JVM based programs running on the same time
-  JAVA_OPTS="-Djava.io.tmpdir=${LS_HOME}"
+  LS_JAVA_OPTS="${LS_JAVA_OPTS} -Djava.io.tmpdir=${LS_HOME}"
   HOME=${LS_HOME}
-  export PATH HOME JAVA_OPTS LS_HEAP_SIZE LS_JAVA_OPTS LS_USE_GC_LOGGING
+  export PATH HOME LS_HEAP_SIZE LS_JAVA_OPTS LS_USE_GC_LOGGING
 
   # set ulimit as (root, presumably) first, before we drop privileges
   ulimit -n ${LS_OPEN_FILES}

--- a/pkg/logstash.sysv
+++ b/pkg/logstash.sysv
@@ -30,13 +30,13 @@ LS_USER=logstash
 LS_GROUP=logstash
 LS_HOME=/var/lib/logstash
 LS_HEAP_SIZE="500m"
-LS_JAVA_OPTS="-Djava.io.tmpdir=${LS_HOME}"
 LS_LOG_DIR=/var/log/logstash
 LS_LOG_FILE="${LS_LOG_DIR}/$name.log"
 LS_CONF_DIR=/etc/logstash/conf.d
 LS_OPEN_FILES=16384
 LS_NICE=19
 LS_OPTS=""
+
 
 [ -r /etc/default/$name ] && . /etc/default/$name
 [ -r /etc/sysconfig/$name ] && . /etc/sysconfig/$name
@@ -46,8 +46,9 @@ args="agent -f ${LS_CONF_DIR} -l ${LS_LOG_FILE} ${LS_OPTS}"
 
 start() {
 
-
-  JAVA_OPTS=${LS_JAVA_OPTS}
+  # Set JAVA_OPTS to avoid sharing configuration between other
+  # JVM based programs running on the same time
+  JAVA_OPTS="-Djava.io.tmpdir=${LS_HOME}"
   HOME=${LS_HOME}
   export PATH HOME JAVA_OPTS LS_HEAP_SIZE LS_JAVA_OPTS LS_USE_GC_LOGGING
 

--- a/pkg/logstash.sysv.debian
+++ b/pkg/logstash.sysv.debian
@@ -84,12 +84,10 @@ case "$1" in
       >/dev/null; then
          # Prepare environment
          HOME="${HOME:-$LS_HOME}"
-         # Set JAVA_OPTS to avoid sharing configuration between other
-         # JVM based programs running on the same time
-         JAVA_OPTS="-Djava.io.tmpdir=${LS_HOME}"
+         LS_JAVA_OPTS="${LS_JAVA_OPTS} -Djava.io.tmpdir=${LS_HOME}"
          ulimit -n ${LS_OPEN_FILES}
 	 cd "${LS_HOME}"
-         export PATH HOME JAVACMD JAVA_OPTS LS_HEAP_SIZE LS_JAVA_OPTS LS_USE_GC_LOGGING
+         export PATH HOME JAVACMD LS_HEAP_SIZE LS_JAVA_OPTS LS_USE_GC_LOGGING
 
          # Start Daemon
          start-stop-daemon --start -b --user "$LS_USER" -c "$LS_USER":"$LS_GROUP" \

--- a/pkg/logstash.sysv.debian
+++ b/pkg/logstash.sysv.debian
@@ -37,7 +37,6 @@ LS_USER=logstash
 LS_GROUP=logstash
 LS_HOME=/var/lib/logstash
 LS_HEAP_SIZE="500m"
-LS_JAVA_OPTS="-Djava.io.tmpdir=${LS_HOME}"
 LS_LOG_FILE=/var/log/logstash/$NAME.log
 LS_CONF_DIR=/etc/logstash/conf.d
 LS_OPEN_FILES=16384
@@ -85,7 +84,9 @@ case "$1" in
       >/dev/null; then
          # Prepare environment
          HOME="${HOME:-$LS_HOME}"
-         JAVA_OPTS="${LS_JAVA_OPTS}"
+         # Set JAVA_OPTS to avoid sharing configuration between other
+         # JVM based programs running on the same time
+         JAVA_OPTS="-Djava.io.tmpdir=${LS_HOME}"
          ulimit -n ${LS_OPEN_FILES}
 	 cd "${LS_HOME}"
          export PATH HOME JAVACMD JAVA_OPTS LS_HEAP_SIZE LS_JAVA_OPTS LS_USE_GC_LOGGING

--- a/pkg/logstash.sysv.redhat
+++ b/pkg/logstash.sysv.redhat
@@ -72,12 +72,10 @@ do_start()
 
   # Prepare environment
   HOME="${HOME:-$LS_HOME}"
-  # Set JAVA_OPTS to avoid sharing configuration between other
-  # JVM based programs running on the same time
-  JAVA_OPTS="-Djava.io.tmpdir=${LS_HOME}"
+  LS_JAVA_OPTS="${LS_JAVA_OPTS} -Djava.io.tmpdir=${LS_HOME}"
   ulimit -n ${LS_OPEN_FILES}
   cd "${LS_HOME}"
-  export PATH HOME JAVA_OPTS LS_HEAP_SIZE LS_JAVA_OPTS LS_USE_GC_LOGGING
+  export PATH HOME LS_HEAP_SIZE LS_JAVA_OPTS LS_USE_GC_LOGGING
   test -n "${JAVACMD}" && export JAVACMD
 
   nice -n ${LS_NICE} runuser -s /bin/sh -c "exec $DAEMON $DAEMON_OPTS" ${LS_USER} >> $LS_LOG_FILE 2>&1 < /dev/null &

--- a/pkg/logstash.sysv.redhat
+++ b/pkg/logstash.sysv.redhat
@@ -36,7 +36,6 @@ LS_USER=logstash
 LS_GROUP=logstash
 LS_HOME=/var/lib/logstash
 LS_HEAP_SIZE="500m"
-LS_JAVA_OPTS="-Djava.io.tmpdir=${LS_HOME}"
 LS_LOG_FILE=/var/log/logstash/$NAME.log
 LS_CONF_DIR=/etc/logstash/conf.d
 LS_OPEN_FILES=16384
@@ -73,7 +72,9 @@ do_start()
 
   # Prepare environment
   HOME="${HOME:-$LS_HOME}"
-  JAVA_OPTS="${LS_JAVA_OPTS}"
+  # Set JAVA_OPTS to avoid sharing configuration between other
+  # JVM based programs running on the same time
+  JAVA_OPTS="-Djava.io.tmpdir=${LS_HOME}"
   ulimit -n ${LS_OPEN_FILES}
   cd "${LS_HOME}"
   export PATH HOME JAVA_OPTS LS_HEAP_SIZE LS_JAVA_OPTS LS_USE_GC_LOGGING

--- a/pkg/logstash.upstart.ubuntu
+++ b/pkg/logstash.upstart.ubuntu
@@ -23,7 +23,6 @@ script
   PATH=/bin:/usr/bin
   LS_HOME=/var/lib/logstash
   LS_HEAP_SIZE="500m"
-  LS_JAVA_OPTS="-Djava.io.tmpdir=${LS_HOME}"
   LS_LOG_FILE=/var/log/logstash/logstash.log
   LS_USE_GC_LOGGING=""
   LS_CONF_DIR=/etc/logstash/conf.d
@@ -35,7 +34,9 @@ script
   [ -f /etc/default/logstash ] && . /etc/default/logstash
 
   HOME="${HOME:-$LS_HOME}"
-  JAVA_OPTS="${LS_JAVA_OPTS}"
+  # Set JAVA_OPTS to avoid sharing configuration between other
+  # JVM based programs running on the same time
+  JAVA_OPTS="-Djava.io.tmpdir=${LS_HOME}"
   # Reset filehandle limit
   ulimit -n ${LS_OPEN_FILES}
   cd "${LS_HOME}"

--- a/pkg/logstash.upstart.ubuntu
+++ b/pkg/logstash.upstart.ubuntu
@@ -34,15 +34,13 @@ script
   [ -f /etc/default/logstash ] && . /etc/default/logstash
 
   HOME="${HOME:-$LS_HOME}"
-  # Set JAVA_OPTS to avoid sharing configuration between other
-  # JVM based programs running on the same time
-  JAVA_OPTS="-Djava.io.tmpdir=${LS_HOME}"
+  LS_JAVA_OPTS="${LS_JAVA_OPTS} -Djava.io.tmpdir=${LS_HOME}"
   # Reset filehandle limit
   ulimit -n ${LS_OPEN_FILES}
   cd "${LS_HOME}"
 
   # Export variables
-  export PATH HOME JAVA_OPTS LS_HEAP_SIZE LS_JAVA_OPTS LS_USE_GC_LOGGING
+  export PATH HOME LS_HEAP_SIZE LS_JAVA_OPTS LS_USE_GC_LOGGING
   test -n "${JAVACMD}" && export JAVACMD
 
   exec nice -n ${LS_NICE} /opt/logstash/bin/logstash agent -f "${LS_CONF_DIR}" -l "${LS_LOG_FILE}" ${LS_OPTS}


### PR DESCRIPTION
From #2914 we discovered that the set of GC variables used where not really optimal for the Logstash use case, this PR aims to be a place where we can solve this as:

* Enabling the LS_JAVA_OPTS externally, so the end user can set their own JAVA_OPTS when he will.
* Use another set of GC configurations, more suitable for the LS use case.

The second option is still pending a decent benchmark, even some numbers has been gathered and the current ones seems not the best ones, specially because:

* We don't have sudden spikes of GC needs.
* Our YGC is more important than the rest.
* ...

will use this PR to write down benchmarks before we decide to with set of configs do we move.

Relates to #1763