### PR TITLE
1.4 Only allow 20 MetricDatum items in single CloudWatch request at most

### DIFF
--- a/lib/logstash/outputs/cloudwatch.rb
+++ b/lib/logstash/outputs/cloudwatch.rb
@@ -228,13 +228,13 @@ class LogStash::Outputs::CloudWatch < LogStash::Outputs::Base
       end # data.each
 
       begin
-        metric_data.slice(20) do |sliced_metric_data|
+        metric_data.each_slice(20) do |sliced_metric_data|
           @cw.put_metric_data(
               :namespace => namespace,
               :metric_data => sliced_metric_data
           )
+          @logger.info("Sent data to AWS CloudWatch OK", :namespace => namespace, :metric_data => sliced_metric_data)
         end
-        @logger.info("Sent data to AWS CloudWatch OK", :namespace => namespace, :metric_data => metric_data)
       rescue Exception => e
         @logger.warn("Failed to send to AWS CloudWatch", :exception => e, :namespace => namespace, :metric_data => metric_data)
         break

--- a/lib/logstash/outputs/cloudwatch.rb
+++ b/lib/logstash/outputs/cloudwatch.rb
@@ -228,10 +228,12 @@ class LogStash::Outputs::CloudWatch < LogStash::Outputs::Base
       end # data.each
 
       begin
-        @cw.put_metric_data(
-            :namespace => namespace,
-            :metric_data => metric_data
-        )
+        metric_data.slice(20) do |sliced_metric_data|
+          @cw.put_metric_data(
+              :namespace => namespace,
+              :metric_data => sliced_metric_data
+          )
+        end
         @logger.info("Sent data to AWS CloudWatch OK", :namespace => namespace, :metric_data => metric_data)
       rescue Exception => e
         @logger.warn("Failed to send to AWS CloudWatch", :exception => e, :namespace => namespace, :metric_data => metric_data)


### PR DESCRIPTION
You can include a maximum of 20 MetricDatum items in one PutMetricData request. So I changed  a little bit on the cloudwatch output to compliant to this limit. Please have a look. 

http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_limits.html