### PR TITLE
Remove dependencies on jruby-httpclient

### DIFF
--- a/Gemfile.jruby-1.9.lock
+++ b/Gemfile.jruby-1.9.lock
@@ -10,7 +10,6 @@ PATH
       i18n (= 0.6.9)
       jar-dependencies (= 0.1.7)
       jrjackson
-      jruby-httpclient
       maven-tools (= 1.0.7)
       mime-types
       minitar
@@ -65,7 +64,6 @@ GEM
     insist (1.0.0)
     jar-dependencies (0.1.7)
     jrjackson (0.2.8)
-    jruby-httpclient (1.1.1-java)
     logstash-devutils (0.0.12-java)
       gem_publisher
       insist (= 1.0.0)

--- a/logstash-core.gemspec
+++ b/logstash-core.gemspec
@@ -56,7 +56,6 @@ Gem::Specification.new do |gem|
 
     # bouncy-castle-java 1.5.0147 and jruby-openssl 0.9.5 are included in jruby 1.7.6 no need to include here
     # and this avoids the gemspec jar path parsing issue of jar-dependencies 0.1.2
-    gem.add_runtime_dependency "jruby-httpclient"                    #(Apache 2.0 license)
     gem.add_runtime_dependency "jrjackson"                           #(Apache 2.0 license)
   else
     gem.add_runtime_dependency "excon"    #(MIT license)


### PR DESCRIPTION
This gem isn't used in any logstash plugins but the core still depends on it.
Fixes: #2931