### PR TITLE
Fixes Event#include? to properly check for field

### DIFF
--- a/lib/logstash/event.rb
+++ b/lib/logstash/event.rb
@@ -176,8 +176,14 @@ class LogStash::Event
   end
 
   public
-  def include?(key)
-    return !self[key].nil?
+  def include?(fieldref)
+    if fieldref.start_with?(METADATA_BRACKETS)
+      @metadata_accessors.include?(fieldref[METADATA_BRACKETS.length .. -1])
+    elsif fieldref == METADATA
+      true
+    else
+      @accessors.include?(fieldref)
+    end
   end # def include?
 
   # Append an event to this one.

--- a/lib/logstash/util/accessors.rb
+++ b/lib/logstash/util/accessors.rb
@@ -53,6 +53,11 @@ module LogStash::Util
       end
     end
 
+    def include?(accessor)
+      target, key = lookup_path(accessor)
+      return target.include?(key)
+    end
+
     private
 
     def lookup(accessor)

--- a/spec/core/event_spec.rb
+++ b/spec/core/event_spec.rb
@@ -22,6 +22,7 @@ describe LogStash::Event do
           5 => 6,
           "5" => 7
       },
+      "nilfield" => nil,
       "@metadata" => { "fancy" => "pants", "have-to-go" => { "deeper" => "inception" } }
     )
   end
@@ -135,6 +136,30 @@ describe LogStash::Event do
         duration = Time.now - start
         puts "event #[] rate: #{"%02.0f/sec" % (count / duration)}, elapsed: #{duration}s"
       end
+    end
+  end
+
+  context "#include?" do
+    it "should include existing fields" do
+      expect(subject.include?("c")).to be_true
+      expect(subject.include?("[c][d]")).to be_true
+    end
+
+    it "should include field with nil value" do
+      expect(subject.include?("nilfield")).to be_true
+    end
+
+    it "should include @metadata field" do
+      expect(subject.include?("@metadata")).to be_true
+    end
+
+    it "should include field within @metadata" do
+      expect(subject.include?("[@metadata][fancy]")).to be_true
+    end
+
+    it "should not include non-existing fields" do
+      expect(subject.include?("doesnotexist")).to be_false
+      expect(subject.include?("[j][doesnotexist]")).to be_false
     end
   end
 


### PR DESCRIPTION
Beforehand, Event#include? would depend on a value of a certain
field to be non-nil as the signal that a field exists. This breaks
when a field's value is nil, even if the field exists. It is now
possible to check for existance of both normal and metadata fields.

Closes #2977.