### PR TITLE
Allow coercion of unix time to Timestamp

### DIFF
--- a/lib/logstash/timestamp.rb
+++ b/lib/logstash/timestamp.rb
@@ -36,7 +36,11 @@ module LogStash
     end
 
     # coerce tries different strategies based on the time object class to convert into a Timestamp.
-    # @param [String, Time, Timestamp] time the time object to try coerce
+    # Supports following types:
+    #   - String: ISO 8601 representations of timestamps.
+    #   - Numeric: Unix times in seconds
+    #   - Time: Standard Ruby time object
+    # @param [String, Time, Timestamp, Numeric] time the time object to try coerce
     # @return [Timestamp, nil] Timestamp will be returned if successful otherwise nil
     # @raise [TimestampParserError] on String with invalid format
     def self.coerce(time)
@@ -47,6 +51,8 @@ module LogStash
         time
       when Time
         LogStash::Timestamp.new(time)
+      when Numeric
+        Timestamp.new(::Time.at(time))
       else
         nil
       end

--- a/spec/core/timestamp_spec.rb
+++ b/spec/core/timestamp_spec.rb
@@ -25,6 +25,11 @@ describe LogStash::Timestamp do
     expect(LogStash::Timestamp.coerce(t).to_i).to eq(t.to_i)
   end
 
+  it "should coerce unix time" do
+    epoch_time = 1428713843 # ISO 8601: 2015-04-11T00:57:23Z
+    expect(LogStash::Timestamp.coerce(epoch_time).to_i).to eq(epoch_time)
+  end
+
   it "should raise on invalid string coerce" do
     expect{LogStash::Timestamp.coerce("foobar")}.to raise_error LogStash::TimestampParserError
   end


### PR DESCRIPTION
## WIP

Unsure what the best way of differentiating between millisecond epoch time and seconds epoch time.

Once that is figured out, I will add more documentation discussing supported types in the Event object
Closes #2929.