### PR TITLE
Minor corrections to plugin doc

### DIFF
--- a/docs/asciidoc/static/include/pluginbody.asciidoc
+++ b/docs/asciidoc/static/include/pluginbody.asciidoc
@@ -807,7 +807,7 @@ TIP: See http://bundler.io/gemfile.html[Bundler's Gemfile page] for more details
 ----------------------------------
 source 'https://rubygems.org'
 gemspec
-gem "logstash", :github => "elasticsearch/logstash", :branch => "{branch}"
+gem "logstash", :github => "elastic/logstash", :branch => "{branch}"
 ----------------------------------
 
 [float]

--- a/docs/asciidoc/static/include/pluginbody.asciidoc
+++ b/docs/asciidoc/static/include/pluginbody.asciidoc
@@ -61,7 +61,7 @@ it before you copy the example.
 ----
 cd /path/to/logstash-{plugintype}-mypluginname
 mv logstash-{plugintype}-{pluginname}.gemspec logstash-{plugintype}-mypluginname.gemspec
-mv lib/logstash/{plugintype}/example.rb lib/logstash/{plugintype}/mypluginname.rb
+mv lib/logstash/{plugintype}s/example.rb lib/logstash/{plugintype}s/mypluginname.rb
 mv spec/{plugintype}s/{pluginname}_spec.rb spec/{plugintype}s/mypluginname_spec.rb
 ----
 


### PR DESCRIPTION
`mv lib/logstash/input/example.rb lib/logstash/input/mypluginname.rb` should be 
`mv lib/logstash/inputs/example.rb lib/logstash/inputs/mypluginname.rb`

Updated `:github => "elasticsearch/logstash"` to `:github => "elastic/logstash"`