### PR TITLE
Check for plugins to be released

### DIFF
--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -142,10 +142,16 @@ module LogStash
     # @return [Array<String>] list of all plugin names as defined in the logstash-plugins github organization, minus names that matches the ALL_PLUGINS_SKIP_LIST
     def self.fetch_all_plugins
       require 'octokit'
-
       Octokit.auto_paginate = true
       repos = Octokit.organization_repositories("logstash-plugins")
-      repos.map(&:name).reject{|name| name =~ ALL_PLUGINS_SKIP_LIST}
+      repos.map(&:name).reject do |name|
+        name =~ ALL_PLUGINS_SKIP_LIST || !is_released?(name)
+      end
+    end
+
+    def self.is_released?(plugin)
+      require 'gems'
+      !Gems.search(plugin).empty?
     end
   end
 end

--- a/rakelib/dependency.rake
+++ b/rakelib/dependency.rake
@@ -29,4 +29,8 @@ namespace "dependency" do
     Rake::Task["gem:require"].invoke("octokit", ">= 0", LogStash::Environment.logstash_gem_home)
   end # task octokit
 
+  task "gems" do
+    Rake::Task["gem:require"].invoke("gems", ">= 0", LogStash::Environment.logstash_gem_home)
+  end # task gems
+
 end # namespace dependency

--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -50,7 +50,7 @@ namespace "plugin" do
     task.reenable # Allow this task to be run again
   end
 
-  task "install-all" => [ "dependency:octokit" ] do
+  task "install-all" => [ "dependency:octokit", "dependency:gems" ] do
     puts("[plugin:install-all] Installing all plugins from https://github.com/logstash-plugins")
     install_plugins("--no-verify", *LogStash::RakeLib.fetch_all_plugins)
 


### PR DESCRIPTION
Hi,
  one regular issue with the plugins test pipeline has been that we search for plugins in github, while most of them are released to rubygems and perse usable, some are not. This PR search rubygems and make sure there is a plugin with the name that can be installed.