### PR TITLE
Fixes 2987

### DIFF
--- a/lib/logstash/filters/base.rb
+++ b/lib/logstash/filters/base.rb
@@ -168,6 +168,10 @@ class LogStash::Filters::Base < LogStash::Plugin
         if event.include?(field)
           event[field] = [event[field]] if !event[field].is_a?(Array)
           event[field] << v
+        elsif v == 'true'
+          event[field] = true
+        elsif v == 'false'
+          event[field] = false
         else
           event[field] = v
         end

--- a/spec/filters/base_spec.rb
+++ b/spec/filters/base_spec.rb
@@ -47,6 +47,24 @@ describe LogStash::Filters::NOOP do
     end
   end
 
+  describe "add_field with string booleans" do
+    config <<-CONFIG
+    filter {
+      noop {
+        add_field => ["true_field", "true"]
+        add_field => ["false_field", "false"]
+      }
+    }
+    CONFIG
+    sample 'add_field => ["true_field", "true"]' do
+      expect(subject["true_field"]).to eq(true)
+    end
+
+    sample 'add_field => ["false_field", "false"]' do
+      expect(subject["false_field"]).to eq(false)
+    end
+  end
+
   describe "type parsing" do
     config <<-CONFIG
     filter {


### PR DESCRIPTION
This ensures that:

    add_field => [ "fieldname", true ]

and

    add_field => [ "fieldname", false ]

actually result in true boolean values.

fixes #2987