### PR TITLE
Remove the if branch the tests still passes..

### DIFF
--- a/lib/logstash/event.rb
+++ b/lib/logstash/event.rb
@@ -295,11 +295,7 @@ class LogStash::Event
 
   public
   def to_hash_with_metadata
-    if @metadata.nil?
-      to_hash
-    else
-      to_hash.merge(METADATA => @metadata)
-    end
+    @metadata.empty? ? to_hash : to_hash.merge(METADATA => @metadata)
   end
 
   public

--- a/spec/core/event_spec.rb
+++ b/spec/core/event_spec.rb
@@ -409,6 +409,10 @@ describe LogStash::Event do
         it "should still allow normal field access" do
           expect(subject["foo"]).to eq("bar")
         end
+
+        it "should not include the @metadata key" do
+          expect(subject.to_hash_with_metadata).not_to include("@metadata")
+        end
       end
     end
 


### PR DESCRIPTION
When investigating this https://github.com/logstash-plugins/logstash-filter-multiline/issues/10 issue I found out that we always set @metadata to a hash and it cant be nil. The tests was actually checking if the metadata was empty.