### PR TITLE
bin/bundle shim

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+
+# This is basically a copy of the original bundler "bundle" shim
+# with the addition of the loading of our Bundler patches that
+# modifies the .lock file naming. Without this, using the original Bundler bundle
+# shim would result in creating or failing on a Gemfile.lock file.
+
+# Exit cleanly from an early interrupt
+Signal.trap("INT") { exit 1 }
+
+$LOAD_PATH.unshift(File.expand_path(File.join("__FILE__", "..", "lib")))
+
+require "logstash/environment"
+Gem.clear_paths
+Gem.paths = ENV['GEM_HOME'] = ENV['GEM_PATH'] = LogStash::Environment.logstash_gem_home
+
+require "bundler"
+require "bundler/cli"
+require "bundler/friendly_errors"
+require "logstash/patches/bundler"
+
+Bundler.with_friendly_errors do
+  Bundler::CLI.start(ARGV, :debug => true)
+end

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -16,16 +16,15 @@ namespace "artifact" do
 
   def exclude_paths
     return @exclude_paths if @exclude_paths
+
     @exclude_paths = []
-    #gitignore = File.join(File.dirname(__FILE__), "..", ".gitignore")
-    #if File.exists?(gitignore)
-      #@exclude_paths += File.read(gitignore).split("\n")
-    #end
     @exclude_paths << "spec/reports/**/*"
     @exclude_paths << "**/*.gem"
     @exclude_paths << "**/test/files/slow-xpath.xml"
     @exclude_paths << "**/logstash-*/spec"
-    return @exclude_paths
+    @exclude_paths << "bin/bundle"
+
+    @exclude_paths
   end
 
   def excludes


### PR DESCRIPTION
add the `bin/bundle` shim. this shim is essentially the same shim as the one supplied with the bundler gem but includes our bundler patches for the `.lock` file naming. 

this allow doing `bin/bundle exec rspec` for example, or any other bundle command. very useful. with that we can get rid of `bin/logstash rspec`. 