### PR TITLE
wrong link for the config type `:bytes` documentation

### DIFF
--- a/lib/logstash/config/mixin.rb
+++ b/lib/logstash/config/mixin.rb
@@ -472,7 +472,7 @@ module LogStash::Config::Mixin
               bytes = Integer(value.first) rescue nil
               result = bytes || Filesize.from(value.first).to_i
             rescue ArgumentError
-              return false, "Unparseable filesize: #{value.first}. possible units (KiB, MiB, ...) e.g. '10 KiB'. doc reference: http://www.elasticsearch.org/guide/en/logstash/current/_logstash_config_language.html#bytes"
+              return false, "Unparseable filesize: #{value.first}. possible units (KiB, MiB, ...) e.g. '10 KiB'. doc reference: http://www.elastic.co/guide/en/logstash/current/configuration.html#bytes"
             end
           else
             return false, "Unknown validator symbol #{validator}"


### PR DESCRIPTION
When fixing https://github.com/logstash-plugins/logstash-codec-multiline/pull/7 I found the link was wrong