### PR TITLE
Add an rspec shim

### DIFF
--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path(File.join("__FILE__", "..", "lib"))
+$LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), "../spec"))
+
+require "logstash/environment"
+require "logstash/bundler"
+LogStash::Bundler.setup!
+
+require "rspec/core"
+require "rspec"
+
+status = RSpec::Core::Runner.run(ARGV).to_i
+exit status if status != 0

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -23,6 +23,7 @@ namespace "artifact" do
     @exclude_paths << "**/test/files/slow-xpath.xml"
     @exclude_paths << "**/logstash-*/spec"
     @exclude_paths << "bin/bundle"
+    @exclude_paths << "bin/rspec"
 
     @exclude_paths
   end


### PR DESCRIPTION
In the spirit of https://github.com/elastic/logstash/pull/3037, this PR adds a new rspec shim so users can run test in the same way as they do with the command provided by rspec.