### PR TITLE
fix leading whitespace in repo docs

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -12,24 +12,24 @@ Our public signing key can be found on the [Elasticsearch packages apt GPG signi
 
 Add the key:
 
-     wget -O - https://packages.elasticsearch.org/GPG-KEY-elasticsearch | apt-key add -
+    wget -O - https://packages.elasticsearch.org/GPG-KEY-elasticsearch | apt-key add -
 
 Add the repo to /etc/apt/sources.list
 
-     deb http://packages.elasticsearch.org/logstash/1.4/debian stable main
+    deb http://packages.elasticsearch.org/logstash/1.4/debian stable main
 
 
 ## YUM based distributions
 
 Add the key:
 
-     rpm --import https://packages.elasticsearch.org/GPG-KEY-elasticsearch
+    rpm --import https://packages.elasticsearch.org/GPG-KEY-elasticsearch
 
 Add the repo to /etc/yum.repos.d/ directory
 
-     [logstash-1.4]
-     name=logstash repository for 1.4.x packages
-     baseurl=https://packages.elasticsearch.org/logstash/1.4/centos
-     gpgcheck=1
-     gpgkey=https://packages.elasticsearch.org/GPG-KEY-elasticsearch
-     enabled=1
+    [logstash-1.4]
+    name=logstash repository for 1.4.x packages
+    baseurl=https://packages.elasticsearch.org/logstash/1.4/centos
+    gpgcheck=1
+    gpgkey=https://packages.elasticsearch.org/GPG-KEY-elasticsearch
+    enabled=1


### PR DESCRIPTION
There were 5 leading spaces instead of 4. When rendered as markdown to
HTML it would result in each line starting with a space, so if you
copy/paste into a file you get an invalid logstash-1.4.repo file.