### PR TITLE
Fix #3100 and one other bug

### DIFF
--- a/lib/logstash/config/config_ast.rb
+++ b/lib/logstash/config/config_ast.rb
@@ -233,7 +233,14 @@ module LogStash; module Config; module AST
       when "filter"
         return <<-CODE
           #{variable_name}.filter(event) {|new_event| events << new_event }
+
+          # Break early if the event was cancelled
+          return [] if events.all?(&:cancelled?)
         CODE
+        # TODO(sissel): The above break-early is probably not the best
+        # implementation because a filter could possibly emit many events and
+        # only cancel one of them. I don't know of any plugins that do this,
+        # though.
       when "output"
         return "#{variable_name}.handle(event)\n"
       when "codec"

--- a/lib/logstash/config/config_ast.rb
+++ b/lib/logstash/config/config_ast.rb
@@ -155,7 +155,9 @@ module LogStash; module Config; module AST
 
               @logger.debug? && @logger.debug(\"Flushing\", :plugin => #{name}, :events => events)
 
-              #{plugin.compile_starting_here.gsub(/^/, "  ")}
+              events.each do |event|
+                #{plugin.compile_starting_here.gsub(/^/, "  ")}
+              end
 
               events.each{|e| block.call(e)}
             end


### PR DESCRIPTION
This PR fixes #3100 and another bug.

#3100 is a bug triggered when you have any filter occurring after a previous filter, when that previous filter uses flushing. For example:

```
filter {
  multiline { ... }
  mutate { }
}
```

You would crash with `NameError: undefined local variable or method `event'`

The 2nd bug is that event cancellation is only checked when deciding what to send to the output queue. In this case, you could have `drop { } multiline { }` and the multiline filter would _still_ receive the event even though `drop { }` marked it as cancelled. 

Both bugs should now be fixed in this PR.