### PR TITLE
slim down the skip list from plugins that are now released and accesible

### DIFF
--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -127,10 +127,6 @@ module LogStash
     )
 
     ALL_PLUGINS_SKIP_LIST = Regexp.union([
-      /^logstash-codec-cef$/,
-      /^logstash-input-gemfire$/,
-      /^logstash-output-gemfire$/,
-      /^logstash-filter-metricize$/,
       /^logstash-filter-yaml$/,
       /jms$/,
       /example$/,
@@ -138,9 +134,7 @@ module LogStash
       /^logstash-output-logentries$/,
       /^logstash-input-jdbc$/,
       /^logstash-output-newrelic$/,
-      /^logstash-output-slack$/,
-      /^logstash-input-neo4j$/,
-      /^logstash-output-neo4j$/
+      /^logstash-output-slack$/
     ])
 
 


### PR DESCRIPTION
This list was intended to be used to keep away empty plugins, however some of them got now graduated, so are fully released and testable in our infrastructure.  This PR aims to have this plugins up and running as expected for our configuration.

- purbon