### PR TITLE
ensure LOGSTASH_HOME supports plugin spec runs

### DIFF
--- a/lib/logstash/environment.rb
+++ b/lib/logstash/environment.rb
@@ -7,14 +7,17 @@ module LogStash
 
     # rehydrate the bootstrap environment if the startup was not done by executing bootstrap.rb
     unless LogStash::Environment.const_defined?("LOGSTASH_HOME")
-      abort("ERROR: missing LOGSTASH_HOME environment variable") if ENV["LOGSTASH_HOME"].to_s.empty?
-      $LOAD_PATH << ::File.join(ENV["LOGSTASH_HOME"], "lib")
-      require "bootstrap/environment"
+      if ENV["LOGSTASH_HOME"].to_s.empty?
+        # if no constant or env var defined we can assume it's a plugin spec run
+        # so there is no package, therefore no LOGSTASH_HOME
+        LogStash::Environment::LOGSTASH_HOME = ""
+      else
+        $LOAD_PATH << ::File.join(ENV["LOGSTASH_HOME"], "lib")
+        require "bootstrap/environment"
+      end
     end
 
     LOGSTASH_CORE = ::File.expand_path(::File.join(::File.dirname(__FILE__), "..", ".."))
-    BUNDLE_CONFIG_PATH = ::File.join(LOGSTASH_HOME, ".bundle", "config")
-    BOOTSTRAP_GEM_PATH = ::File.join(LOGSTASH_HOME, 'build', 'bootstrap')
 
     LOGSTASH_ENV = (ENV["LS_ENV"] || 'production').to_s.freeze
 


### PR DESCRIPTION
currently running specs in a plugin will fail since LOGSTASH_HOME is expected to be defined when lib/logstash/environment.rb is loaded.

The pathways of loading environment.rb are:

1. through bin/logstash(.bat) => bootstrap/environment.rb is loaded first and it sets both LOGSTASH_HOME and the ENV["LOGSTASH_HOME"] variable => OK
2. through bin/plugin => pluginmanager/main.rb is loaded, which loads bootstrap/environment.rb => OK
3. through plugin specs => spec_helper.rb from devutils is loaded, which requires logstash/environment.rb. No code sets the constant and therefore [there's an exception](https://github.com/elastic/logstash/blob/master/lib/logstash/environment.rb#L9) => NOT OK

This PR assumes that if the code loading environment.rb hasn't set the constant nor the environment variable, then it's the situation described in 3. It will then set it to empty string since there is no package or LOGSTASH_HOME when running plugin specs

also removed 2 variables that are not used

fixes #3163 