### PR TITLE
Make rubyzip a dependency installed via the Gemfile, so the artifact:zip task works as expected

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,4 @@ gem "rspec", "~> 2.14.0", :group => :development
 gem "octokit", "3.8.0", :group => :build
 gem "stud", "~> 0.0.19", :group => :build
 gem "fpm", "~> 1.3.3", :group => :build
+gem "rubyzip", "~> 1.1.7", :group => :build

--- a/Gemfile.jruby-1.9.lock
+++ b/Gemfile.jruby-1.9.lock
@@ -81,6 +81,7 @@ GEM
     rspec-expectations (2.14.5)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.6)
+    rubyzip (1.1.7)
     sawyer (0.6.0)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
@@ -113,5 +114,6 @@ DEPENDENCIES
   logstash-core (= 2.0.0.dev)!
   octokit (= 3.8.0)
   rspec (~> 2.14.0)
+  rubyzip (~> 1.1.7)
   simplecov
   stud (~> 0.0.19)

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -106,7 +106,6 @@ namespace "artifact" do
   end
 
   task "zip" => ["prepare"] do
-    Rake::Task["dependency:rubyzip"].invoke
     require 'zip'
     zippath = "build/logstash-#{LOGSTASH_VERSION}.zip"
     puts("[artifact:zip] building #{zippath}")


### PR DESCRIPTION
Fixes #3176 by using the same strategy as the one used to fix the other packages, adding the rubyzip in this case to the build group in the Gemfile.