### PR TITLE
Fix the documentation generation

### DIFF
--- a/docs/asciidocgen.rb
+++ b/docs/asciidocgen.rb
@@ -20,7 +20,7 @@ class LogStashConfigAsciiDocGenerator
   def initialize
     @rules = {
       COMMENT_RE => lambda { |m| add_comment(m[1]) },
-      /^ *class.*< *::LogStash::(Outputs|Filters|Inputs|Codecs)::(Base|Threadable)/ => \
+      /^ *class.*< *(::)?LogStash::(Outputs|Filters|Inputs|Codecs)::(Base|Threadable)/ => \
         lambda { |m| set_class_description },
       /^ *config +[^=].*/ => lambda { |m| add_config(m[0]) },
       /^ *milestone .*/ => lambda { |m| set_milestone(m[0]) },

--- a/rakelib/docs.rake
+++ b/rakelib/docs.rake
@@ -1,7 +1,6 @@
 namespace "docs" do
 
   task "generate" do
-    Rake::Task['dependency:octokit'].invoke
     Rake::Task['plugin:install-all'].invoke
     Rake::Task['docs:generate-docs'].invoke
     Rake::Task['docs:generate-index'].invoke
@@ -9,9 +8,9 @@ namespace "docs" do
 
   task "generate-docs" do
     require "bootstrap/environment"
-
-    list = Dir.glob("#{LogStash::Environment.logstash_gem_home}/gems/logstash-*/lib/logstash/{input,output,filter,codec}s/*.rb").join(" ")
-    cmd = "bin/logstash docgen -o asciidoc_generated #{list}"
+    pattern = "#{LogStash::Environment.logstash_gem_home}/gems/logstash-*/lib/logstash/{input,output,filter,codec}s/*.rb"
+    list    = Dir.glob(pattern).join(" ")
+    cmd     = "bin/logstash docgen -o asciidoc_generated #{list}"
     system(cmd)
   end
 


### PR DESCRIPTION
Fix #3184 by fixing the pattern for the class definition line, otherwise sometimes there is no need to have it defined like ```::LogStash:...```, so the first ```::``` should be optional.

This leats the generation process create the class description again.

I generated all the docs and check a few and saw this part always generated.

As a side efect, it cleanup a bit the rake task used to generate the documentation as the pattern used was very long.

