### PR TITLE
Initialize the `metadata_accessors` when setting the @metadata with a hash

### DIFF
--- a/lib/logstash/event.rb
+++ b/lib/logstash/event.rb
@@ -141,6 +141,7 @@ class LogStash::Event
       @metadata_accessors.set(fieldref[METADATA_BRACKETS.length .. -1], value)
     elsif fieldref == METADATA
       @metadata = value
+      @metadata_accessors = LogStash::Util::Accessors.new(@metadata)
     else
       @accessors.set(fieldref, value)
     end

--- a/spec/core/event_spec.rb
+++ b/spec/core/event_spec.rb
@@ -38,6 +38,11 @@ describe LogStash::Event do
         expect(subject["[foo][bar]"] = "zab").to eq("zab")
         expect(subject["[foo][bar]"]).to eq("zab")
       end
+
+      it "allow to set the @metadata key to a hash" do
+        subject["@metadata"] = { "action" => "index" }
+        expect(subject["[@metadata][action]"]).to eq("index")
+      end
     end
 
     context "#sprintf" do


### PR DESCRIPTION
When we set the @metadata key with a hash we need to setup the accessor class or our access logic will not work.

Fixes https://github.com/elastic/logstash/issues/3195