### PR TITLE
Add libc6-dev dependency to the deb package

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -180,6 +180,7 @@ namespace "artifact" do
         out.attributes[:deb_user] = "root"
         out.attributes[:deb_group] = "root"
         out.attributes[:deb_suggests] = "java7-runtime-headless"
+        out.dependencies << "libc6-dev"
         out.config_files << "/etc/default/logstash"
         out.config_files << "/etc/logrotate.d/logstash"
         out.config_files << "/etc/init.d/logstash"


### PR DESCRIPTION
This is required to resolve a Java 8 + JRuby FFI bug which causes
File::Stat#dev_minor and similar functions to raise this exception:

> NotImplementedError: block device detection unsupported or native
> support failed to load

References
* https://github.com/elastic/logstash/issues/3127
* https://github.com/jruby/jruby/issues/2913

Fixes #3216