### PR TITLE
bin\rspec windows support

### DIFF
--- a/bin/rspec.bat
+++ b/bin/rspec.bat
@@ -1,0 +1,15 @@
+@echo off
+
+SETLOCAL
+
+set SCRIPT_DIR=%~dp0
+CALL %SCRIPT_DIR%\setup.bat
+
+:EXEC
+if "%VENDORED_JRUBY%" == "" (
+  %RUBYCMD% "%LS_HOME%\lib\bootstrap\rspec.rb" %*
+) else (
+  %JRUBY_BIN% %jruby_opts% "%LS_HOME%\lib\bootstrap\rspec.rb" %*
+)
+
+ENDLOCAL


### PR DESCRIPTION
- support running `bin\rspec` in Windows
- tested in Windows 8.1

related to #3229 and #2776 