### PR TITLE
[1.4] Bump versions for ES, Kibana and JRuby

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,15 @@
 #   rsync
 #   wget or curl
 #
-JRUBY_VERSION=1.7.11
-ELASTICSEARCH_VERSION=1.1.1
+JRUBY_VERSION=1.7.17
+ELASTICSEARCH_VERSION=1.5.2
 
 WITH_JRUBY=java -jar $(shell pwd)/$(JRUBY) -S
 JRUBY=vendor/jar/jruby-complete-$(JRUBY_VERSION).jar
 JRUBY_URL=http://jruby.org.s3.amazonaws.com/downloads/$(JRUBY_VERSION)/jruby-complete-$(JRUBY_VERSION).jar
 JRUBY_CMD=bin/logstash env java -jar $(JRUBY)
 
-ELASTICSEARCH_URL=http://download.elasticsearch.org/elasticsearch/elasticsearch
+ELASTICSEARCH_URL=https://download.elastic.co/elasticsearch/elasticsearch
 ELASTICSEARCH=vendor/jar/elasticsearch-$(ELASTICSEARCH_VERSION)
 TYPESDB=vendor/collectd/types.db
 COLLECTD_VERSION=5.4.0
@@ -19,7 +19,7 @@ GEOIP=vendor/geoip/GeoLiteCity.dat
 GEOIP_URL=http://logstash.objects.dreamhost.com/maxmind/GeoLiteCity-2013-01-18.dat.gz
 GEOIP_ASN=vendor/geoip/GeoIPASNum.dat
 GEOIP_ASN_URL=http://logstash.objects.dreamhost.com/maxmind/GeoIPASNum-2014-02-12.dat.gz
-KIBANA_URL=https://download.elasticsearch.org/kibana/kibana/kibana-3.0.1.tar.gz
+KIBANA_URL=https://download.elastic.co/kibana/kibana/kibana-3.1.2.tar.gz
 PLUGIN_FILES=$(shell find lib -type f| egrep '^lib/logstash/(inputs|outputs|filters|codecs)/[^/]+$$' | egrep -v '/(base|threadable).rb$$|/inputs/ganglia/')
 QUIET=@
 ifeq (@,$(QUIET))

--- a/lib/logstash/version.rb
+++ b/lib/logstash/version.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 # The version of logstash.
-LOGSTASH_VERSION = "1.4.3.dev"
+LOGSTASH_VERSION = "1.4.3"
 
 # Note to authors: this should not include dashes because 'gem' barfs if
 # you include a dash in the version string.


### PR DESCRIPTION
ES 1.1.1 is not recommended, so would like to bump version to latest 1.5.2 and latest 3.x Kibana

Tested `node`, `transport` and `http` protocol with ES 1.5.2 and they work fine. 

`make test-tarball` fails consistenty:

```
Failures:

  1) LogStash::Filters::Fingerprint Timestamps OpenSSL Fingerprinting "{"@timestamp":"1970-01-01T00:00:00.000Z"}" when processed
     Failure/Error: Unable to find matching line from backtrace
     Insist::Failure:
       Expected "1d5379ec92d86a67cfc642d55aa050ca312d3b9a", but got "4ba81956baea50e3b625a0fcf2a33926abaf6143"
     # ./spec/filters/fingerprint.rb:182:in `(root)'
     # ./lib/logstash/runner.rb:58:in `run'
     # ./lib/logstash/runner.rb:136:in `run'
     # ./lib/logstash/runner.rb:175:in `run'
     # ./lib/logstash/runner.rb:92:in `main'
     # ./lib/logstash/runner.rb:215:in `(root)'

Finished in 5.98 seconds
249 examples, 1 failure

Failed examples:
```