### PR TITLE
Use windows short path to support launching logstash from a path with spaces

### DIFF
--- a/bin/logstash.bat
+++ b/bin/logstash.bat
@@ -2,7 +2,9 @@
 
 SETLOCAL
 
-set SCRIPT_DIR=%~dp0
+REM get logstash/bin absolute path: d => drive letter, p => path, s => use short names (no-spaces)
+REM as explained on https://www.microsoft.com/resources/documentation/windows/xp/all/proddocs/en-us/percent.mspx?mfr=true
+set SCRIPT_DIR=%~dps0
 CALL %SCRIPT_DIR%\setup.bat
 
 :EXEC

--- a/bin/plugin.bat
+++ b/bin/plugin.bat
@@ -2,7 +2,9 @@
 
 SETLOCAL
 
-set SCRIPT_DIR=%~dp0
+REM get logstash/bin absolute path: d => drive letter, p => path, s => use short names (no-spaces)
+REM as explained on https://www.microsoft.com/resources/documentation/windows/xp/all/proddocs/en-us/percent.mspx?mfr=true
+set SCRIPT_DIR=%~dps0
 CALL %SCRIPT_DIR%\setup.bat
 
 :EXEC

--- a/bin/rspec.bat
+++ b/bin/rspec.bat
@@ -2,7 +2,9 @@
 
 SETLOCAL
 
-set SCRIPT_DIR=%~dp0
+REM get logstash/bin absolute path: d => drive letter, p => path, s => use short names (no-spaces)
+REM as explained on https://www.microsoft.com/resources/documentation/windows/xp/all/proddocs/en-us/percent.mspx?mfr=true
+set SCRIPT_DIR=%~dps0
 CALL %SCRIPT_DIR%\setup.bat
 
 :EXEC


### PR DESCRIPTION
Without this little `s` and a path with space
````
D:\tmp\logstash\release\logstash-1.5.0 release>bin\logstash
'D:\tmp\logstash\release\logstash-1.5.0' is not recognized as an internal or external command,
operable program or batch file.
The system cannot find the path specified.
````
With this, it will resolve the path to `D:\tmp\logstash\release\LOGSTA~1.0RE` thus avoiding the space issue

Or do you see another solution ?