### PR TITLE
Fix string interpolation error when transforming characters to UTF8

### DIFF
--- a/lib/logstash/config/config_ast.rb
+++ b/lib/logstash/config/config_ast.rb
@@ -300,7 +300,7 @@ module LogStash; module Config; module AST
 
   module Unicode
     def self.wrap(text)
-      return "(" + text.force_encoding(Encoding::UTF_8).inspect + ")"
+      return "('#{text.force_encoding(Encoding::UTF_8)}')"
     end
   end
 

--- a/spec/core/config_spec.rb
+++ b/spec/core/config_spec.rb
@@ -106,3 +106,16 @@ describe LogStashConfigParser do
     end
   end
 end
+
+describe LogStash::Config::AST do
+
+  context "when doing unicode transformations" do
+    subject(:unicode) { LogStash::Config::AST::Unicode }
+
+    it "convert newline characters without modifying them" do
+      expect(unicode.wrap("\\n")).to eq("('\\n')")
+    end
+
+  end
+
+end


### PR DESCRIPTION
As we discover thanks to #3238 if into the configuration there are characters like ``` '\\n' ``` the transformation was not properly done. This caused that for example the regular expression used in the mutate plugin for the gsub where not working properly.

A reviewer can use the use case presented in #3238 to test this behaviour. 

PD: This was also happening in previous releases.

Fixes #3238 

 