### PR TITLE
Revert "fix string interpolation error when transforming characters"

### DIFF
--- a/lib/logstash/config/config_ast.rb
+++ b/lib/logstash/config/config_ast.rb
@@ -300,7 +300,7 @@ module LogStash; module Config; module AST
 
   module Unicode
     def self.wrap(text)
-      return "('#{text.force_encoding(Encoding::UTF_8)}')"
+      return "(" + text.force_encoding(Encoding::UTF_8).inspect + ")"
     end
   end
 

--- a/spec/core/config_spec.rb
+++ b/spec/core/config_spec.rb
@@ -106,16 +106,3 @@ describe LogStashConfigParser do
     end
   end
 end
-
-describe LogStash::Config::AST do
-
-  context "when doing unicode transformations" do
-    subject(:unicode) { LogStash::Config::AST::Unicode }
-
-    it "convert newline characters without modifying them" do
-      expect(unicode.wrap("\\n")).to eq("('\\n')")
-    end
-
-  end
-
-end


### PR DESCRIPTION
This reverts commit 65c789a24c5d9c11323c00a2b3554677626ab638 as it fix one thing, but was not fixing the hole ```\n``` issue.

Requested after talking to @jordansissel about the way the config_ast is working and expected to work.