### PR TITLE
[1.4] Dont allow creating new files outside the document root

### DIFF
--- a/lib/logstash/outputs/file.rb
+++ b/lib/logstash/outputs/file.rb
@@ -1,22 +1,27 @@
 # encoding: utf-8
 require "logstash/namespace"
 require "logstash/outputs/base"
+require "logstash/errors"
 require "zlib"
 
 # This output will write events to files on disk. You can use fields
 # from the event as parts of the filename and/or path.
 class LogStash::Outputs::File < LogStash::Outputs::Base
+  FIELD_REF = /%\{[^}]+\}/
 
   config_name "file"
   milestone 2
 
-  # The path to the file to write. Event fields can be used here, 
-  # like "/var/log/logstash/%{host}/%{application}"
-  # One may also utilize the path option for date-based log 
+  # The path to the file to write. Event fields can be used here,
+  # like `/var/log/logstash/%{host}/%{application}`
+  # One may also utilize the path option for date-based log
   # rotation via the joda time format. This will use the event
   # timestamp.
-  # E.g.: path => "./test-%{+YYYY-MM-dd}.txt" to create 
-  # ./test-2013-05-29.txt 
+  # E.g.: `path => "./test-%{+YYYY-MM-dd}.txt"` to create
+  # `./test-2013-05-29.txt`
+  #
+  # If you use an absolute path you cannot start with a dynamic string.
+  # E.g: `/%{myfield}/`, `/test-%{myfield}/` are not valid paths
   config :path, :validate => :string, :required => true
 
   # The maximum size of file to write. When the file exceeds this
@@ -28,19 +33,23 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
   config :max_size, :validate => :string
 
   # The format to use when writing events to the file. This value
-  # supports any string and can include %{name} and other dynamic
+  # supports any string and can include `%{name}` and other dynamic
   # strings.
   #
   # If this setting is omitted, the full json representation of the
   # event will be written as a single line.
   config :message_format, :validate => :string
 
-  # Flush interval (in seconds) for flushing writes to log files. 
+  # Flush interval (in seconds) for flushing writes to log files.
   # 0 will flush on every message.
   config :flush_interval, :validate => :number, :default => 2
 
   # Gzip the output stream before writing to disk.
   config :gzip, :validate => :boolean, :default => false
+
+  # If the generated path is invalid, the events will be saved
+  # into this file and inside the defined path.
+  config :filename_failure, :validate => :string, :default => '_filepath_failures'
 
   public
   def register
@@ -49,35 +58,58 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
     workers_not_supported
 
     @files = {}
+    
+    @path = File.expand_path(path)
+
+    validate_path
+
+    if path_with_field_ref?
+      @file_root = extract_file_root
+      @failure_path = File.join(@file_root, @filename_failure)
+    end
+
     now = Time.now
     @last_flush_cycle = now
     @last_stale_cleanup_cycle = now
-    flush_interval = @flush_interval.to_i
+    @flush_interval = @flush_interval.to_i
     @stale_cleanup_interval = 10
   end # def register
+
+  private
+  def validate_path
+    if (root_directory =~ FIELD_REF) != nil
+      @logger.error("File: The starting part of the path should not be dynamic.", :path => @path)
+      raise LogStash::ConfigurationError.new("The starting part of the path should not be dynamic.")
+    end
+  end
+
+  private
+  def root_directory
+    parts = @path.split(File::SEPARATOR).select { |item| !item.empty?  }
+    if Gem.win_platform?
+      # First part is the drive letter
+      parts[1]
+    else
+      parts.first
+    end
+  end
 
   public
   def receive(event)
     return unless output?(event)
 
-    path = event.sprintf(@path)
-    fd = open(path)
+    file_output_path = generate_filepath(event)
 
-    # TODO(sissel): Check if we should rotate the file.
-
-    if @message_format
-      output = event.sprintf(@message_format)
-    else
-      output = event.to_json
+    if path_with_field_ref? && !inside_file_root?(file_output_path)
+      @logger.warn("File: the event tried to write outside the files root, writing the event to the failure file",  :event => event, :filename => @failure_path)
+      file_output_path = @failure_path
     end
 
-    fd.write(output)
-    fd.write("\n")
-
-    flush(fd)
-    close_stale_files
+    output = format_message(event)
+    write_event(file_output_path, output)
   end # def receive
 
+  public
   def teardown
     @logger.debug("Teardown: closing files")
     @files.each do |path, fd|
@@ -85,10 +117,55 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
         fd.close
         @logger.debug("Closed file #{path}", :fd => fd)
       rescue Exception => e
-        @logger.error("Excpetion while flushing and closing files.", :exception => e)
+        @logger.error("Exception while flushing and closing files.", :exception => e)
       end
     end
     finished
+  end
+
+  private
+  def inside_file_root?(log_path)
+    target_file = File.expand_path(log_path)
+    return target_file.start_with?("#{@file_root.to_s}/")
+  end
+
+  private
+  def write_event(log_path, event)
+    @logger.debug("File, writing event to file.", :filename => log_path)
+    fd = open(log_path)
+
+    # TODO(sissel): Check if we should rotate the file.
+
+    fd.write(event)
+    fd.write("\n")
+
+    flush(fd)
+    close_stale_files
+  end
+
+  private
+  def generate_filepath(event)
+    event.sprintf(@path)
+  end
+
+  private
+  def path_with_field_ref?
+    path =~ FIELD_REF
+  end
+
+  private
+  def format_message(event)
+    if @message_format
+      event.sprintf(@message_format)
+    else
+      event.to_json
+    end
+  end
+
+  private
+  def extract_file_root
+    parts = File.expand_path(path).split(File::SEPARATOR)
+    parts.take_while { |part| part !~ FIELD_REF }.join(File::SEPARATOR)
   end
 
   private
@@ -101,6 +178,7 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
   end
 
   # every flush_interval seconds or so (triggered by events, but if there are no events there's no point flushing files anyway)
+  private
   def flush_pending_files
     return unless Time.now - @last_flush_cycle >= flush_interval
     @logger.debug("Starting flush cycle")
@@ -112,6 +190,7 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
   end
 
   # every 10 seconds or so (triggered by events, but if there are no events there's no point closing files anyway)
+  private
   def close_stale_files
     now = Time.now
     return unless now - @last_stale_cleanup_cycle >= @stale_cleanup_interval
@@ -128,6 +207,7 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
     @last_stale_cleanup_cycle = now
   end
 
+  private
   def open(path)
     return @files[path] if @files.include?(path) and not @files[path].nil?
 
@@ -136,7 +216,7 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
     dir = File.dirname(path)
     if !Dir.exists?(dir)
       @logger.info("Creating directory", :directory => dir)
-      FileUtils.mkdir_p(dir) 
+      FileUtils.mkdir_p(dir)
     end
 
     # work around a bug opening fifos (bug JRUBY-6280)

--- a/spec/outputs/file.rb
+++ b/spec/outputs/file.rb
@@ -1,6 +1,8 @@
+# encoding: utf-8
 require "test_utils"
 require "logstash/outputs/file"
 require "tempfile"
+require "stud/temporary"
 
 describe LogStash::Outputs::File do
   extend LogStash::RSpec
@@ -68,5 +70,175 @@ describe LogStash::Outputs::File do
       end
       insist {line_num} == event_count
     end # agent
+  end
+
+  describe "#register" do
+    let(:path) { '/%{name}' }
+    let(:output) { LogStash::Outputs::File.new({ "path" => path }) }
+
+    it 'doesnt allow the path to start with a dynamic string' do
+      expect { output.register }.to raise_error(LogStash::ConfigurationError)
+      output.teardown
+    end
+
+    context 'doesnt allow the root directory to have some dynamic part' do
+      ['/a%{name}/',
+       '/a %{name}/',
+       '/a- %{name}/',
+       '/a- %{name}'].each do |test_path|
+         it "with path: #{test_path}" do
+           path = test_path
+           expect { output.register }.to raise_error(LogStash::ConfigurationError)
+           output.teardown
+         end
+       end
+    end
+
+    it 'allow to have dynamic part after the file root' do
+      path = '/tmp/%{name}'
+      output = LogStash::Outputs::File.new({ "path" => path })
+      expect { output.register }.not_to raise_error
+    end
+  end
+
+  describe "receiving events" do
+    context "when using an interpolated path" do
+      context "when trying to write outside the files root directory" do
+        let(:bad_event) do
+          event = LogStash::Event.new
+          event['error'] = '../uncool/directory'
+          event
+        end
+
+        it 'writes the bad event in the specified error file' do
+          Stud::Temporary.directory('filepath_error') do |path|
+            config = { 
+              "path" => "#{path}/%{error}",
+              "filename_failure" => "_error"
+            }
+
+            # Trying to write outside the file root
+            outside_path = "#{'../' * path.split(File::SEPARATOR).size}notcool"
+            bad_event["error"] = outside_path
+
+
+            output = LogStash::Outputs::File.new(config)
+            output.register
+            output.receive(bad_event)
+
+            error_file = File.join(path, config["filename_failure"])
+
+            expect(File.exist?(error_file)).to eq(true)
+            output.teardown
+          end
+        end
+
+        it 'doesnt decode relatives paths urlencoded' do
+          Stud::Temporary.directory('filepath_error') do |path|
+            encoded_once = "%2E%2E%2ftest"  # ../test
+            encoded_twice = "%252E%252E%252F%252E%252E%252Ftest" # ../../test
+
+            output = LogStash::Outputs::File.new({ "path" =>  "/#{path}/%{error}"})
+            output.register
+
+            bad_event['error'] = encoded_once
+            output.receive(bad_event)
+
+            bad_event['error'] = encoded_twice
+            output.receive(bad_event)
+
+            expect(Dir.glob(File.join(path, "*")).size).to eq(2)
+            output.teardown
+          end
+        end
+
+        it 'doesnt write outside the file if the path is double escaped' do
+          Stud::Temporary.directory('filepath_error') do |path|
+            output = LogStash::Outputs::File.new({ "path" =>  "/#{path}/%{error}"})
+            output.register
+
+            bad_event['error'] = '../..//test'
+            output.receive(bad_event)
+
+            expect(Dir.glob(File.join(path, "*")).size).to eq(1)
+            output.teardown
+          end
+        end
+      end
+
+      context 'when trying to write inside the file root directory' do
+        it 'write the event to the generated filename' do
+          good_event = LogStash::Event.new
+          good_event['error'] = '42.txt'
+
+          Stud::Temporary.directory do |path|
+            config = { "path" => "#{path}/%{error}" }
+            output = LogStash::Outputs::File.new(config)
+            output.register
+            output.receive(good_event)
+
+            good_file = File.join(path, good_event['error'])
+            expect(File.exist?(good_file)).to eq(true)
+            output.teardown
+          end
+        end
+
+        it 'write the events to a file when some part of a folder or file is dynamic' do
+          t = Time.now
+          good_event = LogStash::Event.new("@timestamp" => t)
+
+          Stud::Temporary.directory do |path|
+            dynamic_path = "#{path}/failed_syslog-%{+YYYY-MM-dd}"
+            expected_path = "#{path}/failed_syslog-#{t.strftime("%Y-%m-%d")}"
+
+            config = { "path" => dynamic_path }
+            output = LogStash::Outputs::File.new(config)
+            output.register
+            output.receive(good_event)
+
+            expect(File.exist?(expected_path)).to eq(true)
+            output.teardown
+          end
+        end
+
+        it 'write the events to the generated path containing multiples fieldref' do
+          t = Time.now
+          good_event = LogStash::Event.new("error" => 42,
+                                           "@timestamp" => t,
+                                           "level" => "critical",
+                                           "weird_path" => '/inside/../deep/nested')
+
+          Stud::Temporary.directory do |path|
+            dynamic_path = "#{path}/%{error}/%{level}/%{weird_path}/failed_syslog-%{+YYYY-MM-dd}"
+            expected_path = "#{path}/42/critical/deep/nested/failed_syslog-#{t.strftime("%Y-%m-%d")}"
+
+            config = { "path" => dynamic_path }
+
+            output = LogStash::Outputs::File.new(config)
+            output.register
+            output.receive(good_event)
+
+            expect(File.exist?(expected_path)).to eq(true)
+            output.teardown
+          end
+        end
+
+        it 'write the event to the generated filename with multiple deep' do
+          good_event = LogStash::Event.new
+          good_event['error'] = '/inside/errors/42.txt'
+
+          Stud::Temporary.directory do |path|
+            config = { "path" => "#{path}/%{error}" }
+            output = LogStash::Outputs::File.new(config)
+            output.register
+            output.receive(good_event)
+
+            good_file = File.join(path, good_event['error'])
+            expect(File.exist?(good_file)).to eq(true)
+            output.teardown
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Before this Fix, people were able to use the string interpolation of the event (Event#sprintf)
to generate files outside the defined path. This pull request try to extract a document
root from the configuration and sandbox the creation of new file in that environment.
