### PR TITLE
Strip line terminators when writing the comment for a branch

### DIFF
--- a/lib/logstash/config/config_ast.rb
+++ b/lib/logstash/config/config_ast.rb
@@ -412,7 +412,7 @@ module LogStash; module Config; module AST
   class If < BranchEntry
     def compile
       children = recursive_inject { |e| e.is_a?(Branch) || e.is_a?(Plugin) }
-      return "if #{condition.compile} # if #{condition.text_value}\n" \
+      return "if #{condition.compile} # if #{condition.text_value.gsub(/[\r\n]/, " ")}\n" \
         << children.collect(&:compile).map { |s| s.split("\n", -1).map { |l| "  " + l }.join("\n") }.join("") << "\n"
     end
   end

--- a/spec/core/config_spec.rb
+++ b/spec/core/config_spec.rb
@@ -48,6 +48,24 @@ describe LogStashConfigParser do
   end
 
   context "#compile" do
+    context "with multiline conditionals" do
+      let(:config) { <<-CONFIG }
+        filter {
+          if [something]
+             or [anotherthing]
+             or [onemorething] {
+          }
+        }
+      CONFIG
+      subject { LogStashConfigParser.new }
+         
+      it "should compile successfully" do
+        result = subject.parse(config)
+        expect(result).not_to(be_nil)
+        expect { eval(result.compile) }.not_to(raise_error)
+      end
+    end
+
     context "invalid configuration" do
       it "rejects duplicate hash key" do
         parser = LogStashConfigParser.new


### PR DESCRIPTION
Logstash's config compiler adds a comment to the compiled code, like

    if ..... # if [your] and [conditional]

The idea is to to help aid in reading the compiled logstash config.
However, if a conditional has newlines in it, the `#text_value` of
that conditional will have newlines, and we'll accidentally create
invalid ruby code which will fail with SyntaxError.

Prior to this change, the following Logstash config, under 1.5.0,
would cause a crash on startup:

    if [some]
      or [condition] {
      ...
    }

The cause was that Logstash would compile this to:

    if event("[some]"]) || event("[condition]") # if [some]
    or [condition]
      ...
    end

The 2nd line there `or [condition]` was intended to be on the line
above.

This change strips the line terminators \r and \n, just in case, and
provides a test case to cover.

I verified that this test case _fails_ without the config_ast.rb patch
and _succeeds_ with the patch.

Fixes #2850