### PR TITLE
Add configcheck to init and make sure to check config before trying to start

### DIFF
--- a/pkg/logstash.sysv
+++ b/pkg/logstash.sysv
@@ -114,6 +114,27 @@ force_stop() {
   fi
 }
 
+config_test() {
+  # Check if a config file exists
+  if [ ! "$(ls -A $LS_CONF_DIR/*.conf 2> /dev/null)" ]; then
+    log_failure_msg "There aren't any configuration files in $LS_CONF_DIR"
+    exit 1
+  fi
+
+  JAVA_OPTS=${LS_JAVA_OPTS}
+  HOME=${LS_HOME}
+  export PATH HOME JAVA_OPTS LS_HEAP_SIZE LS_JAVA_OPTS LS_USE_GC_LOGGING
+
+  test_args="-f ${LS_CONF_DIR} --configtest ${LS_OPTS}"
+  if [ "$1" = '1' ]; then
+    $program ${test_args} 2>/dev/null >/dev/null
+  else
+    $program ${test_args}
+  fi
+  [ $? -eq 0 ] && return 0
+  # Program not configured
+  return 6
+}
 
 case "$1" in
   start)
@@ -122,8 +143,14 @@ case "$1" in
     if [ $code -eq 0 ]; then
       echo "$name is already running"
     else
-      start
+      config_test 1
       code=$?
+      if [ $code -ne 0 ]; then
+       echo "Invalid config for $name. Re-run with configtest to see what's wrong"
+      else
+       start
+       code=$?
+      fi
     fi
     exit $code
     ;;
@@ -143,8 +170,12 @@ case "$1" in
     
     stop && start 
     ;;
+  configtest)
+    config_test
+    exit $?
+    ;;
   *)
-    echo "Usage: $SCRIPTNAME {start|stop|force-stop|status|restart}" >&2
+    echo "Usage: $SCRIPTNAME {start|stop|force-stop|status|restart|configtest}" >&2
     exit 3
   ;;
 esac


### PR DESCRIPTION
Using the deb package (1.5RC2 and most likely RC3 and GA), when using 'service' to start logstash, it will tell you that it started correctly if you have an invalid configuration. Java did, logstash started but exited immediately because the config is invalid.

So, this patch add an option to check the config and it also makes sure to check the config before starting.

See elastic/logstash#2901

On a side note, in the headers, Required-Start doesn't need $syslog