### PR TITLE
WiP: make minitar a non runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,5 @@ gem "stud", "~> 0.0.19", :group => :build
 gem "fpm", "~> 1.3.3", :group => :build
 gem "rubyzip", "~> 1.1.7", :group => :build
 gem "gems", "~> 0.8.3", :group => :build
+gem "minitar", "~> 0.5.4", :group => :build
+

--- a/Gemfile.jruby-1.9.lock
+++ b/Gemfile.jruby-1.9.lock
@@ -7,7 +7,6 @@ PATH
       filesize (= 0.0.4)
       i18n (= 0.6.9)
       jrjackson (~> 0.2.8)
-      minitar (~> 0.5.4)
       pry (~> 0.10.1)
       stud (~> 0.0.19)
       treetop (< 1.5.0)
@@ -66,7 +65,7 @@ GEM
       rake
       rspec (~> 2.14.0)
     method_source (0.8.2)
-    mime-types (2.5)
+    mime-types (2.6.1)
     minitar (0.5.4)
     multipart-post (2.0.0)
     netrc (0.10.3)
@@ -124,6 +123,7 @@ DEPENDENCIES
   gems (~> 0.8.3)
   logstash-core (= 2.0.0.dev)!
   logstash-devutils (~> 0)
+  minitar (~> 0.5.4)
   octokit (= 3.8.0)
   rspec (~> 2.14.0)
   rubyzip (~> 1.1.7)

--- a/logstash-core.gemspec
+++ b/logstash-core.gemspec
@@ -30,9 +30,6 @@ Gem::Specification.new do |gem|
   # upgrade i18n only post 0.6.11, see https://github.com/svenfuchs/i18n/issues/270
   gem.add_runtime_dependency "i18n", "= 0.6.9" #(MIT license)
 
-  # filetools and rakelib
-  gem.add_runtime_dependency "minitar", "~> 0.5.4"
-
   if RUBY_PLATFORM == 'java'
     gem.platform = RUBY_PLATFORM
     gem.add_runtime_dependency "jrjackson", "~> 0.2.8" #(Apache 2.0 license)

--- a/rakelib/bootstrap.rake
+++ b/rakelib/bootstrap.rake
@@ -1,2 +1,1 @@
-
-task "bootstrap" => [ "vendor:all", "compile:all" ]
+task "bootstrap" => [ "vendor:gems", "vendor:all", "compile:all" ]

--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -13,7 +13,6 @@ namespace "vendor" do
   # * nil to skip this file
   # * or, the desired string filename to write the file to.
   def self.untar(tarball, &block)
-    Rake::Task["dependency:archive-tar-minitar"].invoke
     require "archive/tar/minitar"
     tgz = Zlib::GzipReader.new(File.open(tarball,"rb"))
     tar = Archive::Tar::Minitar::Input.open(tgz)
@@ -61,7 +60,7 @@ namespace "vendor" do
     tar.close
   end # def untar
 
-  task "jruby" do |task, args|
+  task "jruby" => [ "vendor:gems" ] do |task, args|
     name = task.name.split(":")[1]
     info = VERSIONS[name]
     version = info["version"]
@@ -135,7 +134,7 @@ namespace "vendor" do
     puts(output)
     raise(exception) if exception
   end # task gems
-  task "all" => "gems"
+  #task "all" => "gems"
 
   desc "Clean the vendored files"
   task :clean do


### PR DESCRIPTION
Minitar is only used for the build process, so it should be listed in the gemfile as build dependency and not included in the ```logstash-core.gemspec```.

This PR try to fix this.