### PR TITLE
[WiP] add a way to start a JMX monitor session 

### DIFF
--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -47,6 +47,13 @@ setup_java() {
     JAVA_OPTS="$JAVA_OPTS -Xmx${LS_HEAP_SIZE}"
   fi
 
+  if [ "$LS_JMX_MONIT_PORT" ] ; then
+    JAVA_OPTS="$JAVA_OPTS -J-Dcom.sun.management.jmxremote"
+    JAVA_OPTS="$JAVA_OPTS -J-Dcom.sun.management.jmxremote.authenticate=false"
+    JAVA_OPTS="$JAVA_OPTS -J-Dcom.sun.management.jmxremote.ssl=false"
+    JAVA_OPTS="$JAVA_OPTS -J-Dcom.sun.management.jmxremote.port=${LS_JMX_MONIT_PORT}"
+  fi
+
   if [ "$LS_USE_GC_LOGGING" ] ; then
     JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCDetails"
     JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCTimeStamps"


### PR DESCRIPTION
Add a way to start JMX monitoring for a Logstash instance without having to remember all the different options.