### PR TITLE
Fix permissions after install (debian package)

### DIFF
--- a/pkg/debian/after-install.sh
+++ b/pkg/debian/after-install.sh
@@ -3,3 +3,4 @@
 chown -R logstash:logstash /opt/logstash
 chown logstash /var/log/logstash
 chown logstash:logstash /var/lib/logstash
+chmod 755 /etc/logstash


### PR DESCRIPTION
/etc/logstash was getting 775 perms in the debian package.

This manually sets 755 to /etc/logstash

fixes #3305