### PR TITLE
Better implementation of the no .bundle/config that respect the bundler contract in a running process

### DIFF
--- a/lib/bootstrap/bundler.rb
+++ b/lib/bootstrap/bundler.rb
@@ -16,6 +16,13 @@ module LogStash
       # of the application
       ::Bundler::Settings.module_exec do
         def set_key(key, value, hash, file)
+          key = key_for(key)
+
+          unless hash[key] == value
+            hash[key] = value
+            hash.delete(key) if value.nil?
+          end
+
           value
         end
       end
@@ -69,7 +76,6 @@ module LogStash
 
       require "bundler"
       require "bundler/cli"
-      # require "logstash/patches/bundler"
       LogStash::Bundler.patch!
 
       # force Rubygems sources to our Gemfile sources

--- a/lib/logstash/patches/bundler.rb
+++ b/lib/logstash/patches/bundler.rb
@@ -13,6 +13,13 @@ module ::Bundler
   # of the application
   class Settings
     def set_key(key, value, hash, file)
+      key = key_for(key)
+
+      unless hash[key] == value
+        hash[key] = value
+        hash.delete(key) if value.nil?
+      end
+
       value
     end
   end

--- a/spec/lib/logstash/bundler_spec.rb
+++ b/spec/lib/logstash/bundler_spec.rb
@@ -30,6 +30,7 @@ describe LogStash::Bundler do
     original_stderr = $stderr
 
     subject { LogStash::Bundler.invoke!(options) }
+
     # by default we want to fail fast on the test
     let(:options) { { :install => true, :max_tries => 0, :without => [:development]} }
     let(:bundler_args) { LogStash::Bundler.bundler_arguments(options) }
@@ -41,9 +42,9 @@ describe LogStash::Bundler do
     end
 
     after do
-      expect(::Bundler.settings[:path]).to eq(nil)
-      expect(::Bundler.settings[:gemfile]).to eq(nil)
-      expect(::Bundler.settings[:without]).to eq(nil)
+      expect(::Bundler.settings[:path]).to eq(LogStash::Environment::BUNDLE_DIR)
+      expect(::Bundler.settings[:gemfile]).to eq(LogStash::Environment::GEMFILE_PATH)
+      expect(::Bundler.settings[:without]).to eq(options.fetch(:without, []).join(':'))
 
       expect(ENV['GEM_PATH']).to eq(LogStash::Environment.logstash_gem_home)
 


### PR DESCRIPTION
The previous fix for disabling the `.bundle/config` wasn't not respecting the bundler contract. 
The failling tests were not wrong, in fact they exposed the issue that the configuration was transient and the underlying hash of bundler was not correctly keeping the updated values.

This patch make sure the hash is updated with the new or deleted value without persisting the change to disk.