### PR TITLE
User/group deletion shouldn't be mandatory

### DIFF
--- a/pkg/debian/before-remove.sh
+++ b/pkg/debian/before-remove.sh
@@ -4,10 +4,10 @@ if [ $1 = "remove" ]; then
   service logstash stop >/dev/null 2>&1 || true
 
   if getent passwd logstash >/dev/null ; then
-    userdel logstash
+    userdel logstash || true
   fi
 
   if getent group logstash >/dev/null ; then
-    groupdel logstash
+    groupdel logstash || true
   fi
 fi


### PR DESCRIPTION
Currently, the debian prerm maintainer script for logstash demands to remove the logstash user/group from passwd/shadow files, and fails if it cannot do so.

Assuming that the logstash user is in passwd/shadow means that the logstash package will not finish uninstalling/removing/purging for systems with LDAP or any other user account database.

This change simply allows the maintainer script to complete (with error message) even if the user/group deletion requests fail. Then the package can finish uninstalling properly.
