### PR TITLE
Fix the uninstall of plugins

### DIFF
--- a/lib/pluginmanager/main.rb
+++ b/lib/pluginmanager/main.rb
@@ -34,6 +34,7 @@ end
 
 if $0 == __FILE__
   begin
+    LogStash::Bundler.setup!({:without => [:build, :development]})
     LogStash::PluginManager::Main.run("bin/plugin", ARGV)
   rescue LogStash::PluginManager::Error => e
     $stderr.puts(e.message)


### PR DESCRIPTION
Fixes #3336 by doing a bundler setup call that was not done beforehand, like this bundler, and subsequently ```gem:specification```, is aware of plugins installed when invoking the ```bin/plugin``` command.

For now the way to test this is by building a plugin as a gem, by then installing it and uninstall it, so ```bin/plugin list --verbose``` is not showing it anymore.