### PR TITLE
allow forced termination through multiple SIGINT

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -66,6 +66,11 @@ en:
         SIGINT received. Shutting down the pipeline.
       sigterm: >-
         SIGTERM received. Shutting down the pipeline.
+      slow_shutdown: |-
+        Shutdown still ocurring. Send another ^C to force termination..
+        Warning: Data loss may occur if shutdown is forced!
+      forced_sigint: >-
+        SIGINT received. Terminating immediately..
       configtest-flag-information: |-
         You may be interested in the '--configtest' flag which you can
         use to validate logstash's configuration before you choose


### PR DESCRIPTION
Create the ability to force logstash to exit in a stalled situation:

```shell
% bin/logstash -e 'input { generator { count => 21 message => "1"} } filter { ruby { code => "sleep 1000" } } output { stdout { }}'
Logstash startup completed
^CSIGINT received. Shutting down the pipeline. {:level=>:warn}
    #  ... after 5 seconds ...
Shutdown still ocurring. Send another ^C to force termination..
Warning: Data loss may occur if shutdown is forced! {:level=>:warn}
^CSIGINT received. Terminating immediately.. {:level=>:fatal}
%                                                 
```