### PR TITLE
Add support for multiline conditionals with the `else if` statements

### DIFF
--- a/lib/logstash/config/config_ast.rb
+++ b/lib/logstash/config/config_ast.rb
@@ -76,7 +76,11 @@ module LogStash; module Config; module AST
     @defered_conditionals_index = val
   end
 
-  class Node < Treetop::Runtime::SyntaxNode; end
+  class Node < Treetop::Runtime::SyntaxNode
+    def text_value_for_comments
+      text_value.gsub(/[\r\n]/, " ")
+    end
+  end
 
   class Config < Node
     def compile
@@ -412,14 +416,14 @@ module LogStash; module Config; module AST
   class If < BranchEntry
     def compile
       children = recursive_inject { |e| e.is_a?(Branch) || e.is_a?(Plugin) }
-      return "if #{condition.compile} # if #{condition.text_value.gsub(/[\r\n]/, " ")}\n" \
+      return "if #{condition.compile} # if #{condition.text_value_for_comments}\n" \
         << children.collect(&:compile).map { |s| s.split("\n", -1).map { |l| "  " + l }.join("\n") }.join("") << "\n"
     end
   end
   class Elsif < BranchEntry
     def compile
       children = recursive_inject { |e| e.is_a?(Branch) || e.is_a?(Plugin) }
-      return "elsif #{condition.compile} # else if #{condition.text_value}\n" \
+      return "elsif #{condition.compile} # else if #{condition.text_value_for_comments}\n" \
         << children.collect(&:compile).map { |s| s.split("\n", -1).map { |l| "  " + l }.join("\n") }.join("") << "\n"
     end
   end

--- a/spec/core/config_spec.rb
+++ b/spec/core/config_spec.rb
@@ -48,7 +48,7 @@ describe LogStashConfigParser do
   end
 
   context "#compile" do
-    context "with multiline conditionals" do
+    context "if with multiline conditionals" do
       let(:config) { <<-CONFIG }
         filter {
           if [something]
@@ -65,6 +65,26 @@ describe LogStashConfigParser do
         expect { eval(result.compile) }.not_to(raise_error)
       end
     end
+
+    context "elsif with multiline conditionals" do
+      let(:config) { <<-CONFIG }
+        filter {
+          if [notathing] {
+          } else if [something]
+                or [anotherthing]
+                or [onemorething] {
+          }
+        }
+      CONFIG
+      subject { LogStashConfigParser.new }
+         
+      it "should compile successfully" do
+        result = subject.parse(config)
+        expect(result).not_to(be_nil)
+        expect { eval(result.compile) }.not_to(raise_error)
+      end
+    end
+
 
     context "invalid configuration" do
       it "rejects duplicate hash key" do


### PR DESCRIPTION
This is a followup of the issues #2850 and #3281.

The following configuration:

```
    if [condition] {

    } else if [condition1]
      or [condition2] {
        ..
    }
```
Was compiled to ruby like this:
```
     elsif condition or condition2 # else if [condition1]
       or [condition2]
```

and making the intepreter fails.