### PR TITLE
Fix all plugins test check for non released plugins

### DIFF
--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -152,7 +152,7 @@ module LogStash
 
     def self.is_released?(plugin)
       require 'gems'
-      !Gems.search(plugin).reject{ |h| h['name'] != plugin }.empty?
+      Gems.info(plugin) != "This rubygem could not be found."
     end
   end
 end

--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -152,7 +152,7 @@ module LogStash
 
     def self.is_released?(plugin)
       require 'gems'
-      !Gems.search(plugin).empty?
+      !Gems.search(plugin).reject{ |h| h['name'] != plugin }.empty?
     end
   end
 end


### PR DESCRIPTION
  fix the case where a plugin is released and has a similar name to one still not released, fixing failured on the all plugins test.

For example: http://build-eu-00.elastic.co/job/logstash_integration_all_plugins/533/console as it has been there for long time now.