### PR TITLE
Fix the packaging issue caused by bundle and the jruby-kafka gem

### DIFF
--- a/lib/pluginmanager/main.rb
+++ b/lib/pluginmanager/main.rb
@@ -34,7 +34,6 @@ end
 
 if $0 == __FILE__
   begin
-    LogStash::Bundler.setup!({:without => [:build, :development]})
     LogStash::PluginManager::Main.run("bin/plugin", ARGV)
   rescue LogStash::PluginManager::Error => e
     $stderr.puts(e.message)

--- a/lib/pluginmanager/uninstall.rb
+++ b/lib/pluginmanager/uninstall.rb
@@ -4,6 +4,13 @@ class LogStash::PluginManager::Uninstall < LogStash::PluginManager::Command
   def execute
     signal_error("File #{LogStash::Environment::GEMFILE_PATH} does not exist or is not writable, aborting") unless File.writable?(LogStash::Environment::GEMFILE_PATH)
 
+    ##
+    # Need to setup the bundler status to enable uninstall of plugins
+    # installed as local_gems, otherwise gem:specification is not
+    # finding the plugins
+    ##
+    LogStash::Bundler.setup!({:without => [:build, :development]})
+
     # make sure this is an installed plugin and present in Gemfile.
     # it is not possible to uninstall a dependency not listed in the Gemfile, for example a dependent codec
     signal_error("This plugin has not been previously installed, aborting") unless LogStash::PluginManager.installed_plugin?(plugin, gemfile)


### PR DESCRIPTION
From: http://build-eu-00.elastic.co/job/logstash_create_zip_artifact_master/36/jdk=JDK7,label=metal-pool/console

```
[plugin:install-default] Installing default plugins
Installing logstash-input-heartbeat, logstash-output-zeromq, logstash-codec-collectd, logstash-output-xmpp, logstash-codec-dots, logstash-codec-edn, logstash-codec-edn_lines, logstash-codec-fluent, logstash-codec-es_bulk, logstash-codec-graphite, logstash-codec-json, logstash-codec-json_lines, logstash-codec-line, logstash-codec-msgpack, logstash-codec-multiline, logstash-codec-netflow, logstash-codec-oldlogstashjson, logstash-codec-plain, logstash-codec-rubydebug, logstash-filter-anonymize, logstash-filter-checksum, logstash-filter-clone, logstash-filter-csv, logstash-filter-date, logstash-filter-dns, logstash-filter-drop, logstash-filter-fingerprint, logstash-filter-geoip, logstash-filter-grok, logstash-filter-json, logstash-filter-kv, logstash-filter-metrics, logstash-filter-multiline, logstash-filter-mutate, logstash-filter-ruby, logstash-filter-sleep, logstash-filter-split, logstash-filter-syslog_pri, logstash-filter-throttle, logstash-filter-urldecode, logstash-filter-useragent, logstash-filter-uuid, logstash-filter-xml, logstash-input-couchdb_changes, logstash-input-elasticsearch, logstash-input-eventlog, logstash-input-exec, logstash-input-file, logstash-input-ganglia, logstash-input-gelf, logstash-input-generator, logstash-input-graphite, logstash-input-imap, logstash-input-irc, logstash-input-log4j, logstash-input-lumberjack, logstash-input-pipe, logstash-input-rabbitmq, logstash-input-redis, logstash-input-s3, logstash-input-snmptrap, logstash-input-sqs, logstash-input-stdin, logstash-input-syslog, logstash-input-tcp, logstash-input-twitter, logstash-input-udp, logstash-input-unix, logstash-input-xmpp, logstash-input-zeromq, logstash-input-kafka, logstash-output-cloudwatch, logstash-output-csv, logstash-output-elasticsearch, logstash-output-elasticsearch_http, logstash-output-email, logstash-output-exec, logstash-output-file, logstash-output-ganglia, logstash-output-gelf, logstash-output-graphite, logstash-output-hipchat, logstash-output-http, logstash-output-irc, logstash-output-juggernaut, logstash-output-lumberjack, logstash-output-nagios, logstash-output-nagios_nsca, logstash-output-null, logstash-output-opentsdb, logstash-output-pagerduty, logstash-output-pipe, logstash-output-rabbitmq, logstash-output-redis, logstash-output-s3, logstash-output-sns, logstash-output-sqs, logstash-output-statsd, logstash-output-stdout, logstash-output-tcp, logstash-output-udp, logstash-output-kafka
Error Bundler::InstallError, retrying 1/10
An error occurred while installing jruby-kafka (1.4.0), and Bundler cannot continue.
Make sure that `gem install jruby-kafka -v '1.4.0'` succeeds before bundling.
Error Bundler::InstallError, retrying 2/10
An error occurred while installing jruby-kafka (1.4.0), and Bundler cannot continue.
Make sure that `gem install jruby-kafka -v '1.4.0'` succeeds before bundling.
Error Bundler::InstallError, retrying 3/10
```
It can be reproduced locally, but just doing 

```
rake bootstrap
rake plugin:install-default
```
then jruby-kafka is complaining without this PR changes, looks like the way #3336 was fix, made ```logstash-input-kafka``` not to be so happy, but now it works as expected.
