### PR TITLE
add the perfmon plugin to the skip list

### DIFF
--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -137,7 +137,8 @@ module LogStash
       /^logstash-output-slack$/,
       /^logstash-input-neo4j$/,
       /^logstash-output-neo4j$/,
-      /^logstash-input-perfmon$/
+      /^logstash-input-perfmon$/,
+      /^logstash-input-http$/
     ])
 
 

--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -137,6 +137,7 @@ module LogStash
       /^logstash-output-slack$/,
       /^logstash-input-neo4j$/,
       /^logstash-output-neo4j$/,
+      /^logstash-input-perfmon$/
     ])
 
 


### PR DESCRIPTION
this plugin is released, by the original author, and as we created a repo to be in logstash-plugins before we merge this plugin in, we need to add it to the skip list so the all plugins test is not complaining.