### PR TITLE
Show errors encountered when validating a plugin rather than saying it does not exist

### DIFF
--- a/lib/pluginmanager/util.rb
+++ b/lib/pluginmanager/util.rb
@@ -17,7 +17,10 @@ module LogStash::PluginManager
       end
     else
       dep = Gem::Dependency.new(plugin, version || Gem::Requirement.default)
-      specs, error = Gem::SpecFetcher.fetcher.spec_for_dependency(dep)
+      specs, errors = Gem::SpecFetcher.fetcher.spec_for_dependency(dep)
+
+      # dump errors
+      errors.each { |error| $stderr.puts(error.wordy) }
 
       # depending on version requirements, multiple specs can be returned in which case
       # we will grab the one with the highest version number
@@ -27,7 +30,7 @@ module LogStash::PluginManager
         end
         return valid
       else
-        $stderr.puts("Plugin #{plugin}" + (version ? " version #{version}" : "") + " does not exist")
+        $stderr.puts("Plugin #{plugin}" + (version ? " version #{version}" : "") + " does not exist") if errors.empty?
         return false
       end
     end


### PR DESCRIPTION
Currently, if you attempt to install a plugin and an error occurs, the plugin installer just reports the plugin does not exist. For example, if I turn off my internet connection:

```
$ bin/plugin install logstash-input-courier
Validating logstash-input-courier
Plugin logstash-input-courier does not exist
ERROR: Installation aborted, verification failed for logstash-input-courier 
```

This PR reports the errors if there are any, instead of reporting the plugin does not exist. For example, the above scenario would now report:

```
$ bin/plugin install logstash-input-courier
Validating logstash-input-courier
Unable to download data from https://rubygems.org - SocketError: initialize: name or service not known (https://rubygems.org/latest_specs.4.8.gz)
ERROR: Installation aborted, verification failed for logstash-input-courier 
```