### PR TITLE
add a runtime license test

### DIFF
--- a/spec/license_spec.rb
+++ b/spec/license_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'rakelib/default_plugins'
+
+describe "Plugin licenses" do
+
+  let(:common_licenses) {
+    Regexp.union([ /mit/,
+                   /apache*/,
+                   /bsd/,
+                   /ruby/])
+  }
+
+  shared_examples "a license test" do
+
+    subject(:gem_name) do |example|
+      example.metadata[:example_group][:parent_example_group][:description]
+    end
+
+    let(:spec) { Gem::Specification.find_all_by_name(gem_name)[0] }
+
+    it "should have an expected licenses" do
+      spec.licenses.each do |license|
+        expect(license.downcase).to match(common_licenses)
+      end
+    end
+
+    it "has runtime dependencies with expected licenses" do
+      spec.runtime_dependencies.map { |dep| dep.to_spec }.each do |runtime_spec|
+        next unless runtime_spec
+        runtime_spec.licenses.each do |license|
+          expect(license.downcase).to match(common_licenses)
+        end
+      end
+    end
+  end
+
+  describe "logstash-core" do
+    it_behaves_like "a license test"
+  end
+
+  installed_plugins.each do |default_plugin|
+    describe default_plugin do
+      it_behaves_like "a license test"
+    end
+  end
+
+end

--- a/spec/license_spec.rb
+++ b/spec/license_spec.rb
@@ -1,16 +1,16 @@
 require 'spec_helper'
 require 'rakelib/default_plugins'
 
-describe "Plugin licenses" do
+describe "Project licenses" do
 
-  let(:common_licenses) {
+  let(:expected_licenses) {
     Regexp.union([ /mit/,
                    /apache*/,
                    /bsd/,
                    /ruby/])
   }
 
-  shared_examples "a license test" do
+  shared_examples "runtime license test" do
 
     subject(:gem_name) do |example|
       example.metadata[:example_group][:parent_example_group][:description]
@@ -18,9 +18,9 @@ describe "Plugin licenses" do
 
     let(:spec) { Gem::Specification.find_all_by_name(gem_name)[0] }
 
-    it "should have an expected licenses" do
+    it "have an expected license" do
       spec.licenses.each do |license|
-        expect(license.downcase).to match(common_licenses)
+        expect(license.downcase).to match(expected_licenses)
       end
     end
 
@@ -28,19 +28,19 @@ describe "Plugin licenses" do
       spec.runtime_dependencies.map { |dep| dep.to_spec }.each do |runtime_spec|
         next unless runtime_spec
         runtime_spec.licenses.each do |license|
-          expect(license.downcase).to match(common_licenses)
+          expect(license.downcase).to match(expected_licenses)
         end
       end
     end
   end
 
   describe "logstash-core" do
-    it_behaves_like "a license test"
+    it_behaves_like "runtime license test"
   end
 
-  installed_plugins.each do |default_plugin|
-    describe default_plugin do
-      it_behaves_like "a license test"
+  installed_plugins.each do |plugin|
+    describe plugin do
+      it_behaves_like "runtime license test"
     end
   end
 

--- a/spec/license_spec.rb
+++ b/spec/license_spec.rb
@@ -4,6 +4,10 @@ require 'rakelib/default_plugins'
 describe "Project licenses" do
 
   let(:expected_licenses) {
+    ##
+    # Expected licenses are Apache License 2.0, BSD license, MIT license and the ruby one,
+    # this not exclude that this list change in the feature.
+    ##
     Regexp.union([ /mit/,
                    /apache*/,
                    /bsd/,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,5 @@
 require "logstash/devutils/rspec/spec_helper"
+
+def installed_plugins
+  Gem::Specification.find_all.select { |spec| spec.metadata["logstash_plugin"] }.map { |plugin| plugin.name }
+end


### PR DESCRIPTION
In the spirit of what Kibana https://github.com/elastic/kibana/blob/dc07a456cd146ec6a3deaf412520c66523602920/tasks/config/licenses.js has to check for dependency licenses I created this small test. 

With this we can test core, but also plugin dependencies in regular basis throw the CI environment.