### PR TITLE
Add a micro benchmark runner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "simplecov", :group => :development
 gem "coveralls", :group => :development
 gem "rspec", "~> 3.1.0", :group => :development
 gem "logstash-devutils", "~> 0", :group => :development
+gem "benchmark-ips", :group => :development
 gem "octokit", "3.8.0", :group => :build
 gem "stud", "~> 0.0.19", :group => :build
 gem "fpm", "~> 1.3.3", :group => :build

--- a/Gemfile.jruby-1.9.lock
+++ b/Gemfile.jruby-1.9.lock
@@ -10,6 +10,7 @@ PATH
       minitar (~> 0.5.4)
       pry (~> 0.10.1)
       stud (~> 0.0.19)
+      thread_safe (~> 0.3.5)
       treetop (< 1.5.0)
 
 GEM
@@ -19,6 +20,7 @@ GEM
     arr-pm (0.0.10)
       cabin (> 0)
     backports (3.6.4)
+    benchmark-ips (2.2.0)
     builder (3.2.2)
     cabin (0.7.1)
     childprocess (0.5.6)
@@ -114,6 +116,7 @@ GEM
     term-ansicolor (1.3.0)
       tins (~> 1.0)
     thor (0.19.1)
+    thread_safe (0.3.5-java)
     tins (1.5.1)
     treetop (1.4.15)
       polyglot
@@ -124,6 +127,7 @@ PLATFORMS
   java
 
 DEPENDENCIES
+  benchmark-ips
   ci_reporter_rspec (= 1.0.0)
   coveralls
   file-dependencies (= 0.1.6)

--- a/benchmark/event_sprintf.rb
+++ b/benchmark/event_sprintf.rb
@@ -1,0 +1,50 @@
+require "benchmark/ips"
+require "lib/logstash/event"
+
+options = { :time => 10, :warmup => 10 }
+puts "Same Event instance"
+Benchmark.ips do |x|
+  x.config(options)
+  event = LogStash::Event.new("foo" => "bar",
+                    "foobar" => "morebar")
+
+  x.report("Complex cached: Event#sprintf") { event.sprintf("/first/%{foo}/%{foobar}/%{+YYY-mm-dd}") }
+  x.report("Date only cached: Event#sprintf") { event.sprintf("%{+YYY-mm-dd}") }
+  x.report("string only cached: Event#sprintf") { event.sprintf("bleh") }
+  x.report("key only cached: Event#sprintf") { event.sprintf("%{foo}") }
+  x.compare!
+end
+
+puts "New Event on each iteration"
+Benchmark.ips do |x|
+  x.config(options)
+
+
+  x.report("Complex cached: Event#sprintf") do
+    event = LogStash::Event.new("foo" => "bar",
+                                "foobar" => "morebar")
+    event.sprintf("/first/%{foo}/%{foobar}/%{+YYY-mm-dd}")
+  end
+
+
+  x.report("Date only cached: Event#sprintf") do
+    event = LogStash::Event.new("foo" => "bar",
+                                "foobar" => "morebar")
+
+    event.sprintf("%{+YYY-mm-dd}")
+  end
+
+  x.report("string only cached: Event#sprintf") do
+    event = LogStash::Event.new("foo" => "bar",
+                                "foobar" => "morebar")
+    event.sprintf("bleh")
+  end
+
+  x.report("key only cached: Event#sprintf") do
+    event = LogStash::Event.new("foo" => "bar",
+                                "foobar" => "morebar")
+    event.sprintf("%{foo}")
+  end
+
+  x.compare!
+end

--- a/rakelib/benchmark.rake
+++ b/rakelib/benchmark.rake
@@ -1,0 +1,8 @@
+namespace :benchmark do
+  desc "Run benchmark code in benchmark/*.rb"
+  task :run => ["test:setup"] do
+    path = File.join(LogStash::Environment::LOGSTASH_HOME, "benchmark", "*.rb")
+    Dir.glob(path).each { |f| require f }
+  end
+end
+task :benchmark => "benchmark:run"


### PR DESCRIPTION
Add `rake benchmark:run` task to run micro benchmark on specific part of
the code, it's uses the benchmark-ips gem to generate them.
See https://github.com/evanphx/benchmark-ips for usage