### PR TITLE
Fix the coverage analysis throw simplecov to take care of all files

### DIFF
--- a/lib/logstash/environment.rb
+++ b/lib/logstash/environment.rb
@@ -77,7 +77,7 @@ module LogStash
     end
 
     def windows?
-      Gem.win_platform?
+      ::Gem.win_platform?
     end
 
     def vendor_path(path)

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -4,7 +4,13 @@
 require "pluginmanager/util"
 
 namespace "test" do
+
   task "setup" do
+    # Need to be run here as because if run aftewarse (after the bundler.setup task) then the report got wrong
+    # numbers and misses files. There is an issue with our setup! method as this does not happen with the regular
+    # bundler.setup used in regular bundler flows.
+    Rake::Task["test:setup-simplecov"].invoke if ENV['COVERAGE']
+
     require "bootstrap/environment"
     LogStash::Bundler.setup!({:without => [:build]})
 
@@ -45,6 +51,30 @@ namespace "test" do
   task "install-vendor-plugins" => ["bootstrap", "plugin:install-vendor", "plugin:install-development-dependencies"]
 
   task "install-jar-dependencies-plugins" => ["bootstrap", "plugin:install-jar-dependencies", "plugin:install-development-dependencies"]
+
+  # Setup simplecov to group files per functional modules, like this is easier to spot places with small coverage
+  task "setup-simplecov" do
+    require "simplecov"
+    SimpleCov.start do
+      # Skip non core related directories and files.
+      ["vendor/", "spec/", "bootstrap/rspec", "Gemfile", "gemspec"].each do |pattern|
+        add_filter pattern
+      end
+
+      add_group "bootstrap", "bootstrap/" # This module is used during bootstraping of LS
+      add_group "plugin manager", "pluginmanager/" # Code related to the plugin manager
+      add_group "core" do |src_file| # The LS core codebase
+        /logstash\/\w+.rb/.match(src_file.filename)
+      end
+      add_group "core-util", "logstash/util" # Set of LS utils module
+      add_group "core-config", "logstash/config" # LS Configuration modules
+      add_group "core-patches", "logstash/patches" # Patches used to overcome known issues in dependencies.
+      # LS Core plugins code base.
+      add_group "core-plugins", [ "logstash/codecs", "logstash/filters", "logstash/outputs", "logstash/inputs" ]
+    end
+    task.reenable
+  end
+
 end
 
 task "test" => [ "test:core" ]

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -1,0 +1,14 @@
+# Useful module to help loading all logstash content when
+# running coverage analysis
+module CoverageHelper
+
+  SKIP_LIST = ["lib/bootstrap/rspec.rb", "lib/logstash/util/prctl.rb"]
+
+  def self.eager_load
+    Dir.glob("lib/**/*.rb") do |file|
+      next if SKIP_LIST.include?(file)
+      require file
+    end
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,8 @@
+require_relative 'coverage_helper'
+# In order to archive an expected coverage analysis we need to eager load
+# all logstash code base, otherwise it will not get a good analysis.
+CoverageHelper.eager_load if ENV['COVERAGE']
+
 require "logstash/devutils/rspec/spec_helper"
 
 def installed_plugins


### PR DESCRIPTION
Our actual coverage analysis report were not accurate mostly because of files not being really analyses by simplecov.

While this PR does not solve the source issue, it workaround the situation proving us back with reports in good shape.

This PR also add detailed groups and filters to the coverage configuration so the reports gets more clear, this configuration is logstash-core specific so I added it here.

--- Description of the error source ---

the problem actually life in doing the simplecov require before or after the ```LogStash::Bundler.setup!({:without => [:build]})```, still not clear who might be the offender, but doing the simplecov setup before this call overcome the error for now.