### PR TITLE
add LGPL as valid licence for logstash runtime dependencies

### DIFF
--- a/spec/license_spec.rb
+++ b/spec/license_spec.rb
@@ -11,7 +11,8 @@ describe "Project licenses" do
     Regexp.union([ /mit/,
                    /apache*/,
                    /bsd/,
-                   /ruby/])
+                   /ruby/,
+                   /lgpl/])
   }
 
   shared_examples "runtime license test" do


### PR DESCRIPTION
easy as the title say, fix the case of the geoip gem.

//cc @jordansissel @suyograo can you guys review and merge this one? thanks