### PR TITLE
Workaround the version check for pre released plugins

### DIFF
--- a/lib/logstash/util/plugin_version.rb
+++ b/lib/logstash/util/plugin_version.rb
@@ -22,8 +22,14 @@ module LogStash::Util
 
     def self.find_version!(name)
       begin
-        specification = Gem::Specification.find_by_name(name)
-        new(specification.version)
+        spec = Gem::Specification.find_by_name(name)
+        if spec.nil?
+          # Checking for nil? is a workaround for situations where find_by_name
+          # is not able to find the real spec, as for example with pre releases
+          # of plugins
+          spec = Gem::Specification.find_all_by_name(name).first
+        end
+        new(spec.version)
       rescue Gem::LoadError
         # Rescuing the LoadError and raise a Logstash specific error.
         # Likely we can't find the gem in the current GEM_PATH
@@ -38,6 +44,12 @@ module LogStash::Util
 
     def <=>(other)
       version <=> other.version
+    end
+
+    private
+
+    def self.build_from_spec(spec)
+      new(spec.version)
     end
   end
 end

--- a/spec/util/plugin_version_spec.rb
+++ b/spec/util/plugin_version_spec.rb
@@ -1,18 +1,33 @@
 require "spec_helper"
 require "logstash/util/plugin_version"
 
-describe LogStash::Util::PluginVersion do
+describe "LogStash::Util::PluginVersion" do
+
   subject { LogStash::Util::PluginVersion }
 
   context "#find_version!" do
+
+    let(:gem)     { "bundler" }
+
     it 'raises an PluginNoVersionError if we cant find the plugin in the gem path' do
       dummy_name ='this-character-doesnt-exist-in-the-marvel-universe'
       expect { subject.find_version!(dummy_name) }.to raise_error(LogStash::PluginNoVersionError)
     end
 
     it 'returns the version of the gem' do
-      expect { subject.find_version!('bundler') }.not_to raise_error
+      expect { subject.find_version!(gem) }.not_to raise_error
     end
+
+    context "with a pre release gem" do
+
+      it 'return the version of the gem' do
+        # Gem::Specification.find_by_name return nil if the gem is not activated, as for
+        # example the pre release ones.
+        expect(Gem::Specification).to receive(:find_by_name).and_return(nil)
+        expect { subject.find_version!(gem) }.not_to raise_error
+      end
+    end
+
   end
 
   context "#new" do


### PR DESCRIPTION
This is because it looks like rubygems is not activating them by default, so ```Gem::Specification.find_by_name``` is not able to locate them by default.

This issue might be related to https://github.com/rubygems/rubygems/issues/988 and https://github.com/rubygems/rubygems/issues/938

Fixes #3449