### PR TITLE
add a periodic report of inflight events during shutdown

### DIFF
--- a/Gemfile.jruby-1.9.lock
+++ b/Gemfile.jruby-1.9.lock
@@ -5,11 +5,13 @@ PATH
       cabin (~> 0.7.0)
       clamp (~> 0.6.5)
       filesize (= 0.0.4)
+      gems (~> 0.8.3)
       i18n (= 0.6.9)
       jrjackson (~> 0.2.8)
       minitar (~> 0.5.4)
       pry (~> 0.10.1)
       stud (~> 0.0.19)
+      thread_safe (~> 0.3.5)
       treetop (< 1.5.0)
 
 GEM
@@ -114,6 +116,7 @@ GEM
     term-ansicolor (1.3.0)
       tins (~> 1.0)
     thor (0.19.1)
+    thread_safe (0.3.5-java)
     tins (1.5.1)
     treetop (1.4.15)
       polyglot

--- a/lib/logstash/outputs/base.rb
+++ b/lib/logstash/outputs/base.rb
@@ -33,7 +33,7 @@ class LogStash::Outputs::Base < LogStash::Plugin
   # Note that this setting may not be useful for all outputs.
   config :workers, :validate => :number, :default => 1
 
-  attr_reader :worker_plugins
+  attr_reader :worker_plugins, :worker_queue
 
   public
   def workers_not_supported(message=nil)

--- a/lib/logstash/pipeline.rb
+++ b/lib/logstash/pipeline.rb
@@ -252,6 +252,7 @@ class LogStash::Pipeline
   #
   # This method is intended to be called from another thread
   def shutdown
+    Thread.new { report_inflight_events(@input_to_filter, @filter_to_output, @outputs) }
     @input_threads.each do |thread|
       # Interrupt all inputs
       @logger.info("Sending shutdown signal to input thread", :thread => thread)
@@ -320,5 +321,22 @@ class LogStash::Pipeline
       end
     end
   end # flush_filters_to_output!
+
+  private
+  def report_inflight_events(input_to_filter, filter_to_output, outputs)
+    loop do
+      sleep 5
+      report = []
+      report << "*** BEGIN INFLIGHT EVENTS REPORT ****"
+      report << "input_to_filter => #{input_to_filter.size} events" if input_to_filter.size > 0
+      report << "filter_to_output => #{filter_to_output.size} events" if filter_to_output.size > 0
+      outputs.each do |output|
+        next unless output.worker_queue
+        report << "#{output} => #{output.worker_queue.size} events" if output.worker_queue.size > 0
+      end
+      report << "*** END INFLIGHT EVENTS REPORT ****"
+      @logger.warn report.join("\n")
+    end
+  end
 
 end # class Pipeline

--- a/lib/logstash/util/reporter.rb
+++ b/lib/logstash/util/reporter.rb
@@ -1,0 +1,27 @@
+class InflightEventsReporter
+  def self.logger=(logger)
+    @logger = logger
+  end
+
+  def self.start(input_to_filter, filter_to_output, outputs)
+    Thread.new do
+      loop do
+        sleep 5
+        report(input_to_filter, filter_to_output, outputs)
+      end
+    end
+  end
+
+  def self.report(input_to_filter, filter_to_output, outputs)
+    report = {
+      "input_to_filter" => input_to_filter.size,
+      "filter_to_output" => filter_to_output.size,
+      "outputs" => []
+    }
+    outputs.each do |output|
+      next unless output.worker_queue && output.worker_queue.size > 0
+      report["outputs"] << [output.inspect, output.worker_queue.size]
+    end
+    @logger.warn ["INFLIGHT_EVENTS_REPORT", Time.now.iso8601, report]
+  end
+end


### PR DESCRIPTION
Logstash can be prevented from exiting due to inflight messages that are residing between inputs and outputs.
Once pipeline.shutdown is called there will be a periodic report every 5 seconds showing which queues still have events. For example, starting logstash with the following config:

```
input { generator { count => 1000 } }
output {
  tcp { host => localhost port => 3333 workers => 2 }
  stdout {}
}
```
And then typing Ctrl+C, will report each 5 seconds:

```
*** BEGIN INFLIGHT EVENTS REPORT ****
input_to_filter => 20 events
filter_to_output => 20 events
LogStash::Outputs::Tcp: {"host"=>"localhost", "port"=>3333, "workers"=>2, "type"=>"", "tags"=>[], "exclude_tags"=>[], "codec"=><LogStash::Codecs::JSON charset=>"UTF-8">, "reconnect_interval"=>10, "mode"=>"client"} => 20 events
*** END INFLIGHT EVENTS REPORT **** {:level=>:warn, :file=>"logstash/pipeline.rb", :line=>"338", :method=>"report_inflight_events"} 
```