### PR TITLE
update roadmap with post-1.5 status and most recent planning

### DIFF
--- a/docs/asciidoc/static/roadmap/index.asciidoc
+++ b/docs/asciidoc/static/roadmap/index.asciidoc
@@ -159,7 +159,7 @@ serialization and deserialization. In future releases of Logstash, we plan to
 incorporate additional JRuby optimizations to make the code even more efficient.
 We also plan to seek community feedback in terms of prioritizing other aspects
 of performance, such as startup time, resource utilization, and pipeline
-latency.
+latency. You can follow our benchmarking and performance improvements in this issue ({ISSUES}3499[#3499]).
 
 == Windows Support
 [float]

--- a/docs/asciidoc/static/roadmap/index.asciidoc
+++ b/docs/asciidoc/static/roadmap/index.asciidoc
@@ -17,63 +17,6 @@ adjustments to our timelines based on community feedback. For the latest release
 status information, please search for the {LABELS}roadmap[roadmap] tag in
 GitHub.
 
-== Logstash 1.5-GA status
-
-We recently released
-http://www.elasticsearch.org/blog/logstash-1-5-0-beta1-released/[Logstash 1.5 beta1],
-http://www.elasticsearch.org/blog/announcing-logstash-1-5-0-release-candidate/[Logstash 1.5 RC1],
-and http://www.elasticsearch.org/blog/logstash-1-5-0-rc2-released/[Logstash 1.5 RC2]!
-The main themes of this release are improved plugin management, increased
-performance, and Apache Kafka integration (see more details in the Logstash 1.5
-beta1 announcement). We are currently working to incorporate community feedback
-and to release Logstash 1.5 GA. You can track our progress on GitHub by looking
-at issues with the milestone
-https://github.com/elastic/logstash/issues?q=is%3Aopen+is%3Aissue+milestone%3Av1.5.0[v1.5.0].
-
-== Plugin Framework
-[float]
-=== status: ongoing; v1.5
-
-Logstash has a rich collection of 165+ plugins, which are developed by
-Elasticsearch and contributed by the community. Previously, most commonly-used
-plugins were bundled with Logstash to make the getting started experience
-easier. However, there was no way to update plugins outside of the Logstash
-release cycle. In Logstash 1.5, we created a powerful plugin framework based on
-https://rubygems.org/[RubyGems.org] to facilitate per-plugin installation and
-updates. We will continue to distribute commonly-used plugins with Logstash, but
-now users will be able to install new plugins and receive plugin updates at any
-time. Read more about these changes in the
-http://www.elastic.co/blog/plugin-ecosystem-changes/[Logstash Plugin Ecosystem Changes]
-announcement.
-
-== Windows Support
-[float]
-=== status: ongoing; v1.5, v2.x
-
-Leading up to the 1.5 release, we greatly improved automated Windows testing of
-Logstash. As a result of this testing, we identified and
-https://github.com/elastic/logstash/issues?q=is%3Aissue+label%3Awindows+is%3Aclosed[resolved]
-a number of critical issues affecting the Windows platform, pertaining to
-initial setup, upgrade, and file input plugin. You can follow the outstanding
-issues we are still working on using the GitHub
-https://github.com/elastic/logstash/issues?q=is%3Aissue+label%3Awindows+is%3Aopen[windows]
-label.
-
-
-== Performance
-[float]
-=== status: ongoing; v1.5, v2.x
-
-In the 1.5 release, we significantly improved the performance of the Grok
-filter, which is used to parse text via regular expressions. Based on our
-internal benchmarks, parsing common log formats, such as Apache logs, was 2x
-faster in Logstash 1.5 compared to previous versions. We also sped up JSON
-serialization and deserialization. In future releases of Logstash, we plan to
-incorporate additional JRuby optimizations to make the code even more efficient.
-We also plan to seek community feedback in terms of prioritizing other aspects
-of performance, such as startup time, resource utilization, and pipeline
-latency.
-
 == Resiliency
 [float]
 === status: ongoing; v2.x
@@ -144,6 +87,8 @@ that makes administration of Logstash more efficient and less error-prone. You
 can follow this effort on GitHub by searching for issues that have the
 {LABELS}manageability[manageability] tag.
 
+*Better Defaults.*  Today, some Logstash defaults are geared toward the development experience, rather than production environments. We plan to audit and re-evaluate a number of defaults to alleviate the burden of tuning Logstash performance in production ({ISSUES}1512[#1512]). In addition, we are undertaking additional benchmarking to evaluate the performance of node, transport, and HTTP protocols in the Elasticsearch output to provide additional confirmation for our proposal to switch the default from node to HTTP (https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/150[#150]).
+
 *Logstash Monitoring API ({ISSUES}2611[#2611]).* Today, most Logstash monitoring
 functions are accomplished by tailing logs or outputting debug messages. As a
 result, it is hard to monitor the Logstash health and track success or failure
@@ -202,6 +147,49 @@ Logstash Forwarder. We recently delivered
 http://www.elasticsearch.org/blog/logstash-forwarder-0-4-0-released/[Logstash Forwarder 0.4.0],
 which addressed many existing issues our users have been reporting.
 
+== Performance
+[float]
+=== status: ongoing; v1.5, v2.x
+
+In the 1.5 release, we significantly improved the performance of the Grok
+filter, which is used to parse text via regular expressions. Based on our
+internal benchmarks, parsing common log formats, such as Apache logs, was 2x
+faster in Logstash 1.5 compared to previous versions. We also sped up JSON
+serialization and deserialization. In future releases of Logstash, we plan to
+incorporate additional JRuby optimizations to make the code even more efficient.
+We also plan to seek community feedback in terms of prioritizing other aspects
+of performance, such as startup time, resource utilization, and pipeline
+latency.
+
+== Windows Support
+[float]
+=== status: ongoing; v1.5, v2.x
+
+Leading up to the 1.5 release, we greatly improved automated Windows testing of
+Logstash. As a result of this testing, we identified and
+https://github.com/elastic/logstash/issues?q=is%3Aissue+label%3Awindows+is%3Aclosed[resolved]
+a number of critical issues affecting the Windows platform, pertaining to
+initial setup, upgrade, and file input plugin. You can follow the outstanding
+issues we are still working on using the GitHub
+https://github.com/elastic/logstash/issues?q=is%3Aissue+label%3Awindows+is%3Aopen[windows]
+label.
+
+== Plugin Framework
+[float]
+=== status: completed; v1.5
+
+Logstash has a rich collection of 165+ plugins, which are developed by
+Elasticsearch and contributed by the community. Previously, most commonly-used
+plugins were bundled with Logstash to make the getting started experience
+easier. However, there was no way to update plugins outside of the Logstash
+release cycle. In Logstash 1.5, we created a powerful plugin framework based on
+https://rubygems.org/[RubyGems.org] to facilitate per-plugin installation and
+updates. We will continue to distribute commonly-used plugins with Logstash, but
+now users will be able to install new plugins and receive plugin updates at any
+time. Read more about these changes in the
+http://www.elastic.co/blog/plugin-ecosystem-changes/[Logstash Plugin Ecosystem Changes]
+announcement.
+
 == New Plugins
 [float]
 === status: ongoing
@@ -212,8 +200,7 @@ include https://github.com/logstash-plugins?query=kafka[Kafka],
 https://github.com/logstash-plugins?query=couchdb[CouchDB], and
 https://github.com/logstash-plugins/logstash-input-rss[RSS], just to name a few.
 In Logstash 1.5, we made it easier than ever to add and maintain plugins by
-putting each plugin into its own repository (read more about that in
-http://www.elasticsearch.org/blog/plugin-ecosystem-changes/[Logstash Plugin Ecosystem Changes]).
+putting each plugin into its own repository (see "Plugin Framework" section).
 We also greatly improved the S3, Twitter, RabbitMQ plugins. To follow requests
 for new Logstash plugins or contribute to the discussion, look for issues that
 have the {LABELS}new-plugin[new-plugin] tag in Github.


### PR DESCRIPTION
A couple of changes:
* Remove 1.5 status, since that is GA now
* Move some ongoing items toward the bottom (e.g. "Windows", "Performance")
* Add a "Better Defaults" section in "Manageability"