### PR TITLE
Fix dependency loading for Linux and old releases of JDK7.

### DIFF
--- a/lib/pluginmanager/install.rb
+++ b/lib/pluginmanager/install.rb
@@ -1,3 +1,4 @@
+require "pluginmanager/command"
 require "jar-dependencies"
 require "jar_install_post_install_hook"
 require "file-dependencies/gem"

--- a/lib/pluginmanager/list.rb
+++ b/lib/pluginmanager/list.rb
@@ -1,4 +1,5 @@
 require 'rubygems/spec_fetcher'
+require "pluginmanager/command"
 
 class LogStash::PluginManager::List < LogStash::PluginManager::Command
 

--- a/lib/pluginmanager/main.rb
+++ b/lib/pluginmanager/main.rb
@@ -11,7 +11,6 @@ module LogStash
 end
 
 require "clamp"
-require "pluginmanager/command"
 require "pluginmanager/util"
 require "pluginmanager/gemfile"
 require "pluginmanager/install"

--- a/lib/pluginmanager/uninstall.rb
+++ b/lib/pluginmanager/uninstall.rb
@@ -1,4 +1,7 @@
+require "pluginmanager/command"
+
 class LogStash::PluginManager::Uninstall < LogStash::PluginManager::Command
+
   parameter "PLUGIN", "plugin name"
 
   def execute

--- a/lib/pluginmanager/update.rb
+++ b/lib/pluginmanager/update.rb
@@ -1,3 +1,4 @@
+require "pluginmanager/command"
 require "jar-dependencies"
 require "jar_install_post_install_hook"
 require "file-dependencies/gem"

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -10,24 +10,13 @@ module CoverageHelper
   ##
   SKIP_LIST = Regexp.union([
     /^lib\/bootstrap\/rspec.rb$/,
-    /^lib\/logstash\/util\/prctl.rb$/,
-    /^lib\/pluginmanager/
+    /^lib\/logstash\/util\/prctl.rb$/
   ])
-
-  ##
-  # List of files going to be loaded directly, this files
-  # are already loading their dependencies in the necessary
-  # order so everything is setup properly.
-  ##
-  DIRECT_LOADING_MODULES = [ "lib/pluginmanager/main.rb" ]
 
   def self.eager_load
     Dir.glob("lib/**/*.rb") do |file|
       next if file =~ SKIP_LIST
       require file
-    end
-    DIRECT_LOADING_MODULES.each do |_module|
-      require _module
     end
   end
 

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -2,12 +2,32 @@
 # running coverage analysis
 module CoverageHelper
 
-  SKIP_LIST = ["lib/bootstrap/rspec.rb", "lib/logstash/util/prctl.rb"]
+  ##
+  # Skip list used to avoid loading certain patterns within
+  # the logstash directories, this patterns are excluded becuause
+  # of potential problems or because they are going to be loaded
+  # in another way.
+  ##
+  SKIP_LIST = Regexp.union([
+    /^lib\/bootstrap\/rspec.rb$/,
+    /^lib\/logstash\/util\/prctl.rb$/,
+    /^lib\/pluginmanager/
+  ])
+
+  ##
+  # List of files going to be loaded directly, this files
+  # are already loading their dependencies in the necessary
+  # order so everything is setup properly.
+  ##
+  DIRECT_LOADING_MODULES = [ "lib/pluginmanager/main.rb" ]
 
   def self.eager_load
     Dir.glob("lib/**/*.rb") do |file|
-      next if SKIP_LIST.include?(file)
+      next if file =~ SKIP_LIST
       require file
+    end
+    DIRECT_LOADING_MODULES.each do |_module|
+      require _module
     end
   end
 


### PR DESCRIPTION
As seen in CI, JDK7, specially Java HotSpot(TM) 64-Bit Server VM 1.7.0_60-b19 has a different behaviour than expected when loading classes with ```Dir.glob```. This has been addressed in this PR.

CI test can be seen at: http://build-eu-00.elastic.co/job/Logstash_regression_Master_(coverage_fix)/

