### PR TITLE
Bump JrJackson gem to 0.2.9 to fix RubyBasicObject bug

### DIFF
--- a/Gemfile.jruby-1.9.lock
+++ b/Gemfile.jruby-1.9.lock
@@ -5,8 +5,9 @@ PATH
       cabin (~> 0.7.0)
       clamp (~> 0.6.5)
       filesize (= 0.0.4)
+      gems (~> 0.8.3)
       i18n (= 0.6.9)
-      jrjackson (~> 0.2.8)
+      jrjackson (~> 0.2.9)
       minitar (~> 0.5.4)
       pry (~> 0.10.1)
       stud (~> 0.0.19)
@@ -48,6 +49,7 @@ GEM
     file-dependencies (0.1.6)
       minitar
     filesize (0.0.4)
+    flores (0.0.4)
     fpm (1.3.3)
       arr-pm (~> 0.0.9)
       backports (>= 2.6.2)
@@ -62,7 +64,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.6.9)
     insist (1.0.0)
-    jrjackson (0.2.8)
+    jrjackson (0.2.9)
     json (1.8.2-java)
     logstash-devutils (0.0.14-java)
       gem_publisher
@@ -131,6 +133,7 @@ DEPENDENCIES
   ci_reporter_rspec (= 1.0.0)
   coveralls
   file-dependencies (= 0.1.6)
+  flores (~> 0.0.4)
   fpm (~> 1.3.3)
   gems (~> 0.8.3)
   logstash-core (= 2.0.0.dev)!

--- a/logstash-core.gemspec
+++ b/logstash-core.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |gem|
 
   if RUBY_PLATFORM == 'java'
     gem.platform = RUBY_PLATFORM
-    gem.add_runtime_dependency "jrjackson", "~> 0.2.8" #(Apache 2.0 license)
+    gem.add_runtime_dependency "jrjackson", "~> 0.2.9" #(Apache 2.0 license)
   else
     gem.add_runtime_dependency "oj" #(MIT-style license)
   end


### PR DESCRIPTION
JrJackson cannot encode objects inheriting from RubyBasicObject, which is blocking a fix for https://github.com/logstash-plugins/logstash-input-twitter/issues/15