### PR TITLE
Do not include rackspace input/output in tests

### DIFF
--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -139,7 +139,9 @@ module LogStash
       /^logstash-output-neo4j$/,
       /^logstash-input-perfmon$/,
       /^logstash-input-http$/,
-      /^logstash-output-webhdfs$/
+      /^logstash-output-webhdfs$/,
+      /^logstash-input-rackspace$/,
+      /^logstash-output-rackspace$/
     ])
 
 


### PR DESCRIPTION
Block testing by regex.

fixes #3518