### PR TITLE
remove version command from runner

### DIFF
--- a/lib/logstash/runner.rb
+++ b/lib/logstash/runner.rb
@@ -40,14 +40,6 @@ class LogStash::Runner
   def run(args)
     command = args.shift
     commands = {
-      "version" => lambda do
-        require "logstash/agent"
-        agent_args = ["--version"]
-        if args.include?("--verbose")
-          agent_args << "--verbose"
-        end
-        return LogStash::Agent.run($0, agent_args)
-      end,
       "irb" => lambda do
         require "irb"
         return IRB.start(__FILE__)

--- a/lib/logstash/runner.rb
+++ b/lib/logstash/runner.rb
@@ -96,7 +96,7 @@ class LogStash::Runner
         end
       end
       require "logstash/agent"
-      puts LogStash::Agent.help("bin/logstash")
+      $stderr.puts LogStash::Agent.help("bin/logstash")
       return Stud::Task.new { 1 }
     end
   end # def run

--- a/lib/logstash/runner.rb
+++ b/lib/logstash/runner.rb
@@ -95,16 +95,8 @@ class LogStash::Runner
           $stderr.puts "No such command #{command.inspect}"
         end
       end
-      $stderr.puts %q[
-Usage: logstash <command> [command args]
-Run a command with the --help flag to see the arguments.
-For example: logstash agent --help
-
-Available commands:
-  agent - runs the logstash agent
-  version - emits version info about this logstash
-]
-      #$stderr.puts commands.keys.map { |s| "  #{s}" }.join("\n")
+      require "logstash/agent"
+      puts LogStash::Agent.help("bin/logstash")
       return Stud::Task.new { 1 }
     end
   end # def run

--- a/spec/core/runner_spec.rb
+++ b/spec/core/runner_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 require "logstash/runner"
 require "stud/task"
+require "logstash/agent"
 
 class NullRunner
   def run(args); end
@@ -21,19 +22,24 @@ describe LogStash::Runner do
       expect(subject.run(args).wait).to eq(0)
     end
 
-    it "should show help with no arguments" do
-      expect($stderr).to receive(:puts).once.and_return("No command given")
-      expect($stderr).to receive(:puts).once
+    context "empty arguments" do
       args = []
-      expect(subject.run(args).wait).to eq(1)
+      it "should show agent help" do
+        expect(LogStash::Agent).to receive(:help).once
+        expect($stderr).to receive(:puts).once.with("No command given")
+        expect($stderr).to receive(:puts).once
+        expect(subject.run(args).wait).to eq(1)
+      end
     end
 
-    it "should show help for unknown commands" do
-      expect($stderr).to receive(:puts).once.and_return("No such command welp")
-      expect($stderr).to receive(:puts).once
+    context "unknown command" do
       args = ["welp"]
-      expect(subject.run(args).wait).to eq(1)
+      it "should show agent help" do
+        expect(LogStash::Agent).to receive(:help).once
+        expect($stderr).to receive(:puts).once.with("No such command \"welp\"")
+        expect($stderr).to receive(:puts).once
+        expect(subject.run(args).wait).to eq(1)
+      end
     end
-
   end
 end


### PR DESCRIPTION
bin/logstash -V is now [handled by the agent](https://github.com/elastic/logstash/blob/master/lib/logstash/agent.rb#L39-L40) so this code is not needed

test: apply this patch and run bin/logstash -V