### PR TITLE
support for bare/ungemified local plugins using --pluginpath option

### DIFF
--- a/lib/logstash/environment.rb
+++ b/lib/logstash/environment.rb
@@ -99,6 +99,14 @@ module LogStash
       I18n.reload!
       fail "No locale? This is a bug." if I18n.available_locales.empty?
     end
+
+    # add path for bare/ungemified plugins lookups. the path must be the base path that will include
+    # the dir structure 'logstash/TYPE/NAME.rb' where TYPE is 'inputs' 'filters', 'outputs' or 'codecs'
+    # and NAME is the name of the plugin
+    # @param path [String] plugins path to add
+    def add_plugin_path(path)
+      $LOAD_PATH << path
+    end
   end
 end
 

--- a/spec/core/environment_spec.rb
+++ b/spec/core/environment_spec.rb
@@ -38,7 +38,18 @@ describe LogStash::Environment do
         allow(Dir).to receive(:glob).and_return([])
         expect { subject.load_runtime_jars! }.to raise_error
       end
+    end
+  end
 
+  context "add_plugin_path" do
+    let(:path) { "/some/path" }
+
+    before(:each) { expect($LOAD_PATH).to_not include(path) }
+    after(:each) { $LOAD_PATH.delete(path) }
+
+    it "should add the path to $LOAD_PATH" do
+      expect{subject.add_plugin_path(path)}.to change{$LOAD_PATH.size}.by(1)
+      expect($LOAD_PATH).to include(path)
     end
   end
 end

--- a/spec/logstash/agent_spec.rb
+++ b/spec/logstash/agent_spec.rb
@@ -22,7 +22,7 @@ describe LogStash::Agent do
         end
       end
     end
-    
+
     context "when remote" do
       context 'supported scheme' do
         let(:path) { "http://test.local/superconfig.conf" }
@@ -34,4 +34,28 @@ describe LogStash::Agent do
       end
     end
   end
+
+  context "--pluginpath" do
+    let(:single_path) { "/some/path" }
+    let(:multiple_paths) { ["/some/path1", "/some/path2"] }
+
+    it "should add single valid dir path to the environment" do
+      expect(File).to receive(:directory?).and_return(true)
+      expect(LogStash::Environment).to receive(:add_plugin_path).with(single_path)
+      subject.configure_plugin_paths(single_path)
+    end
+
+    it "should fail with single invalid dir path" do
+      expect(File).to receive(:directory?).and_return(false)
+      expect(LogStash::Environment).not_to receive(:add_plugin_path)
+      expect{subject.configure_plugin_paths(single_path)}.to raise_error(LogStash::ConfigurationError)
+    end
+
+    it "should add multiple valid dir path to the environment" do
+      expect(File).to receive(:directory?).exactly(multiple_paths.size).times.and_return(true)
+      multiple_paths.each{|path| expect(LogStash::Environment).to receive(:add_plugin_path).with(path)}
+      subject.configure_plugin_paths(multiple_paths)
+    end
+  end
 end
+


### PR DESCRIPTION
restore the `--pluginpath` option to support bare/ungemified local plugins

solves #3580 