### PR TITLE
Fix namespacing for unicode trimmer

### DIFF
--- a/lib/logstash/util/unicode_trimmer.rb
+++ b/lib/logstash/util/unicode_trimmer.rb
@@ -1,4 +1,4 @@
-module UnicodeTrimmer
+module LogStash::Util::UnicodeTrimmer
   # The largest possible unicode chars are 4 bytes
   # http://stackoverflow.com/questions/9533258/what-is-the-maximum-number-of-bytes-for-a-utf-8-encoded-character
   # http://tools.ietf.org/html/rfc3629

--- a/spec/util/unicode_trimmer_spec.rb
+++ b/spec/util/unicode_trimmer_spec.rb
@@ -9,19 +9,21 @@ RSpec.configure do |config|
 end
 
 describe "truncating unicode strings correctly" do
+  subject { LogStash::Util::UnicodeTrimmer }
+
   context "with extra bytes before the snip" do
     let(:ustr) { "Testing «ταБЬℓσ»: 1<2 & 4+1>3, now 20% off!" }
 
     it "should truncate to exact byte boundaries when possible" do
-      expect(UnicodeTrimmer.trim_bytes(ustr, 21).bytesize).to eql(21)
+      expect(subject.trim_bytes(ustr, 21).bytesize).to eql(21)
     end
 
     it "should truncate below the bytesize when splitting a byte" do
-      expect(UnicodeTrimmer.trim_bytes(ustr, 20).bytesize).to eql(18)
+      expect(subject.trim_bytes(ustr, 20).bytesize).to eql(18)
     end
 
     it "should not truncate the string when the bytesize is already OK" do
-      expect(UnicodeTrimmer.trim_bytes(ustr, ustr.bytesize)).to eql(ustr)
+      expect(subject.trim_bytes(ustr, ustr.bytesize)).to eql(ustr)
     end
   end
 
@@ -29,15 +31,15 @@ describe "truncating unicode strings correctly" do
     let(:ustr) { ": 1<2 & 4+1>3, now 20% off! testing «ταБЬℓσ»" }
 
     it "should truncate to exact byte boundaries when possible" do
-      expect(UnicodeTrimmer.trim_bytes(ustr, 21).bytesize).to eql(21)
+      expect(subject.trim_bytes(ustr, 21).bytesize).to eql(21)
     end
 
     it "should truncate below the bytesize when splitting a byte" do
-      expect(UnicodeTrimmer.trim_bytes(ustr, 52).bytesize).to eql(51)
+      expect(subject.trim_bytes(ustr, 52).bytesize).to eql(51)
     end
 
     it "should not truncate the string when the bytesize is already OK" do
-      expect(UnicodeTrimmer.trim_bytes(ustr, ustr.bytesize)).to eql(ustr)
+      expect(subject.trim_bytes(ustr, ustr.bytesize)).to eql(ustr)
     end
   end
 
@@ -47,7 +49,7 @@ describe "truncating unicode strings correctly" do
     let(:expected_range) { (size - 4)..size }
 
     stress_it "should be near the boundary of requested size" do
-      expect(expected_range).to include(UnicodeTrimmer.trim_bytes(text, size).bytesize)
+      expect(expected_range).to include(subject.trim_bytes(text, size).bytesize)
     end
   end
 end


### PR DESCRIPTION
This fixes an issue where the `UnicodeTrimmer` used the root namespace.