### PR TITLE
Use echo instead of trace or emit.

### DIFF
--- a/pkg/logstash.sysv
+++ b/pkg/logstash.sysv
@@ -92,14 +92,14 @@ stop() {
     done
     if status ; then
       if [ "$KILL_ON_STOP_TIMEOUT" -eq 1 ] ; then
-        trace "Timeout reached. Killing $name (pid $pid) with SIGKILL.  This may result in data loss."
+        echo "Timeout reached. Killing $name (pid $pid) with SIGKILL. This may result in data loss."
         kill -KILL $pid
-        emit "$name killed with SIGKILL."
+        echo "$name killed with SIGKILL."
       else
-        emit "$name stop failed; still running."
+        echo "$name stop failed; still running."
       fi
     else
-      emit "$name stopped."
+      echo "$name stopped."
     fi
   fi
 }


### PR DESCRIPTION
This should fix a test failure on CentOS 6 where 'emit' gives 'command
not found' which, as the last command run in stop(), causes stop() to
always return exit code 127.