### PR TITLE
Upgrade lumberjack to ensure client validates server cert.

### DIFF
--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "statsd-ruby", ["1.2.0"]           #(MIT license)
   gem.add_runtime_dependency "xml-simple"                       #(ruby license?)
   gem.add_runtime_dependency "xmpp4r", ["0.5"]                  #(ruby license)
-  gem.add_runtime_dependency "jls-lumberjack", [">=0.0.22"]     #(Apache 2.0 license)
+  gem.add_runtime_dependency "jls-lumberjack", [">=0.0.23"]     #(Apache 2.0 license)
   gem.add_runtime_dependency "geoip", [">= 1.3.2"]              #(GPL license)
   gem.add_runtime_dependency "beefcake", "0.3.7"                #(MIT license)
   gem.add_runtime_dependency "murmurhash3"                      #(MIT license)

--- a/tools/Gemfile.jruby-1.9.lock
+++ b/tools/Gemfile.jruby-1.9.lock
@@ -51,6 +51,7 @@ GEM
     ffi-rzmq (1.0.0)
       ffi
     filewatch (0.5.1)
+    flores (0.0.6)
     ftw (0.0.42)
       addressable
       backports (>= 2.6.2)
@@ -69,7 +70,7 @@ GEM
     insist (1.0.0)
     jls-grok (0.10.12)
       cabin (>= 0.6.0)
-    jls-lumberjack (0.0.22)
+    jls-lumberjack (0.0.23)
     jruby-httpclient (1.1.1-java)
     jruby-openssl (0.8.7)
       bouncy-castle-java (>= 1.5.0147)
@@ -201,6 +202,7 @@ DEPENDENCIES
   ffi
   ffi-rzmq (= 1.0.0)
   filewatch (= 0.5.1)
+  flores (~> 0.0.6)
   ftw (~> 0.0.42)
   gelf (= 1.3.2)
   gelfd (= 0.2.0)
@@ -209,7 +211,7 @@ DEPENDENCIES
   i18n (>= 0.6.6)
   insist (= 1.0.0)
   jls-grok (= 0.10.12)
-  jls-lumberjack (>= 0.0.22)
+  jls-lumberjack (>= 0.0.23)
   jruby-httpclient
   jruby-openssl (= 0.8.7)
   json
@@ -239,3 +241,6 @@ DEPENDENCIES
   user_agent_parser (>= 2.0.0)
   xml-simple
   xmpp4r (= 0.5)
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
This is a backport of
logstash-plugins/logstash-output-lumberjack@e356f30bde43b68019b98bd7cc16af582a79208e
from https://github.com/logstash-plugins/logstash-output-lumberjack/pull/6.