### PR TITLE
Make sure all lookups using event.sprintf are returned as UTF-8

### DIFF
--- a/lib/logstash/string_interpolation.rb
+++ b/lib/logstash/string_interpolation.rb
@@ -17,9 +17,9 @@ module LogStash
       if template.is_a?(Float) && (template < MIN_FLOAT_BEFORE_SCI_NOT || template >= MAX_FLOAT_BEFORE_SCI_NOT)
         return ("%.15f" % template).sub(/0*$/,"")
       end
-      
+
       template = template.to_s
-      
+
       return template if not_cachable?(template)
 
       compiled = CACHE.get_or_default(template, nil) || CACHE.put(template, compile_template(template))
@@ -108,11 +108,11 @@ module LogStash
 
       case value
       when nil
-        "%{#{@key}}"
+        "%{#{@key}}".encode(Encoding::UTF_8)
       when Array
-        value.join(",")
+        value.join(",").encode(Encoding::UTF_8)
       when Hash
-        LogStash::Json.dump(value)
+        LogStash::Json.dump(value).encode(Encoding::UTF_8)
       else
         value
       end

--- a/lib/logstash/string_interpolation.rb
+++ b/lib/logstash/string_interpolation.rb
@@ -110,9 +110,9 @@ module LogStash
       when nil
         "%{#{@key}}".encode(Encoding::UTF_8)
       when Array
-        value.join(",").encode(Encoding::UTF_8)
+        value.join(",")
       when Hash
-        LogStash::Json.dump(value).encode(Encoding::UTF_8)
+        LogStash::Json.dump(value)
       else
         value
       end

--- a/lib/logstash/string_interpolation.rb
+++ b/lib/logstash/string_interpolation.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require "thread_safe"
 require "forwardable"
 
@@ -108,7 +110,7 @@ module LogStash
 
       case value
       when nil
-        "%{#{@key}}".encode(Encoding::UTF_8)
+        "%{#{@key}}"
       when Array
         value.join(",")
       when Hash

--- a/spec/core/event_spec.rb
+++ b/spec/core/event_spec.rb
@@ -99,6 +99,16 @@ describe LogStash::Event do
       it "should return a json string if the key is a hash" do
         expect(subject.sprintf("%{[j][k3]}")).to eq("{\"4\":\"m\"}")
       end
+
+      context "#encoding" do
+        it "should return known patterns as UTF-8" do
+          expect(subject.sprintf("%{message}").encoding).to eq(Encoding::UTF_8)
+        end
+
+        it "should return unknown patterns as UTF-8" do
+          expect(subject.sprintf("%{unkown_pattern}").encoding).to eq(Encoding::UTF_8)
+        end
+      end
     end
 
     context "#[]" do


### PR DESCRIPTION
The changes in this PR make sure all lookups done using event.sprintf are returned as UTF-8, before this PR, if the event was not there another encoding was used.