### PR TITLE
Add the missing magic header # encoding: utf-8

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# encoding: utf-8
 
 $: << File.join(File.dirname(__FILE__), "lib")
 

--- a/lib/bootstrap/bundler.rb
+++ b/lib/bootstrap/bundler.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 module LogStash
   module Bundler
     extend self

--- a/lib/bootstrap/environment.rb
+++ b/lib/bootstrap/environment.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # bootstrap.rb contains the minimal code to be able to launch Bundler to eventually be able
 # to retrieve the core code in the logstash-core gem which can live under different paths
 # depending on the launch context (local dev, packaged, etc)

--- a/lib/bootstrap/rspec.rb
+++ b/lib/bootstrap/rspec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require_relative "environment"
 LogStash::Bundler.setup!({:without => [:build]})
 require "logstash/environment"

--- a/lib/bootstrap/rubygems.rb
+++ b/lib/bootstrap/rubygems.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 module LogStash
   module Rubygems
     extend self

--- a/lib/logstash-core.rb
+++ b/lib/logstash-core.rb
@@ -1,2 +1,3 @@
+# encoding: utf-8
 module LogStash
 end

--- a/lib/logstash/config/mixin.rb
+++ b/lib/logstash/config/mixin.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-
 require "logstash/namespace"
 require "logstash/config/registry"
 require "logstash/logging"

--- a/lib/logstash/environment.rb
+++ b/lib/logstash/environment.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "logstash/errors"
 require "logstash/version"
 

--- a/lib/logstash/java_integration.rb
+++ b/lib/logstash/java_integration.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "java"
 
 # this is mainly for usage with JrJackson json parsing in :raw mode which genenerates

--- a/lib/logstash/namespace.rb
+++ b/lib/logstash/namespace.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-
 module LogStash
   module Inputs; end
   module Outputs; end

--- a/lib/logstash/patches.rb
+++ b/lib/logstash/patches.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "logstash/patches/bugfix_jruby_2558"
 require "logstash/patches/cabin"
 require "logstash/patches/profile_require_calls"

--- a/lib/logstash/patches/bugfix_jruby_2558.rb
+++ b/lib/logstash/patches/bugfix_jruby_2558.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "logstash/environment"
 
 if LogStash::Environment.windows? && LogStash::Environment.jruby?

--- a/lib/logstash/patches/bundler.rb
+++ b/lib/logstash/patches/bundler.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # Bundler monkey patches
 module ::Bundler
   # Patch bundler to write a .lock file specific to the version of ruby.

--- a/lib/logstash/patches/cabin.rb
+++ b/lib/logstash/patches/cabin.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 if ENV["PROFILE_BAD_LOG_CALLS"] || ($DEBUGLIST || []).include?("log")
   # Set PROFILE_BAD_LOG_CALLS=1 in your environment if you want
   # to track down logger calls that cause performance problems

--- a/lib/logstash/patches/rubygems.rb
+++ b/lib/logstash/patches/rubygems.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # monkey patch RubyGems to silence ffi warnings:
 #
 # WARN: Unresolved specs during Gem::Specification.reset:

--- a/lib/logstash/patches/stronger_openssl_defaults.rb
+++ b/lib/logstash/patches/stronger_openssl_defaults.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "openssl"
 
 # :nodoc:

--- a/lib/logstash/program.rb
+++ b/lib/logstash/program.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-
 require "logstash/namespace"
 
 module LogStash::Program

--- a/lib/logstash/runner.rb
+++ b/lib/logstash/runner.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-
 Thread.abort_on_exception = true
 Encoding.default_external = Encoding::UTF_8
 $DEBUGLIST = (ENV["DEBUG"] || "").split(",")

--- a/lib/logstash/string_interpolation.rb
+++ b/lib/logstash/string_interpolation.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-
 require "thread_safe"
 require "forwardable"
 

--- a/lib/logstash/util/accessors.rb
+++ b/lib/logstash/util/accessors.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-
 require "logstash/namespace"
 require "logstash/util"
 require "thread_safe"

--- a/lib/logstash/util/decorators.rb
+++ b/lib/logstash/util/decorators.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-
 require "logstash/namespace"
 require "logstash/util"
 

--- a/lib/logstash/util/filetools.rb
+++ b/lib/logstash/util/filetools.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "net/http"
 require "uri"
 require "digest/sha1"

--- a/lib/logstash/util/java_version.rb
+++ b/lib/logstash/util/java_version.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'cabin'
 
 module LogStash::Util::JavaVersion

--- a/lib/logstash/util/plugin_version.rb
+++ b/lib/logstash/util/plugin_version.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'logstash/errors'
 require 'rubygems/version'
 require 'forwardable'

--- a/lib/logstash/util/prctl.rb
+++ b/lib/logstash/util/prctl.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-
 module LibC
   require "ffi"
   extend FFI::Library

--- a/lib/logstash/util/reporter.rb
+++ b/lib/logstash/util/reporter.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 class InflightEventsReporter
   def self.logger=(logger)
     @logger = logger

--- a/lib/logstash/util/retryable.rb
+++ b/lib/logstash/util/retryable.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 module LogStash
   module Retryable
     # execute retryable code block

--- a/lib/logstash/util/unicode_trimmer.rb
+++ b/lib/logstash/util/unicode_trimmer.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 module LogStash::Util::UnicodeTrimmer
   # The largest possible unicode chars are 4 bytes
   # http://stackoverflow.com/questions/9533258/what-is-the-maximum-number-of-bytes-for-a-utf-8-encoded-character

--- a/lib/pluginmanager/command.rb
+++ b/lib/pluginmanager/command.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 class LogStash::PluginManager::Command < Clamp::Command
   def gemfile
     @gemfile ||= LogStash::Gemfile.new(File.new(LogStash::Environment::GEMFILE_PATH, 'r+')).load

--- a/lib/pluginmanager/gemfile.rb
+++ b/lib/pluginmanager/gemfile.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 module LogStash
   class GemfileError < StandardError; end
 

--- a/lib/pluginmanager/install.rb
+++ b/lib/pluginmanager/install.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "pluginmanager/command"
 require "jar-dependencies"
 require "jar_install_post_install_hook"

--- a/lib/pluginmanager/list.rb
+++ b/lib/pluginmanager/list.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'rubygems/spec_fetcher'
 require "pluginmanager/command"
 

--- a/lib/pluginmanager/main.rb
+++ b/lib/pluginmanager/main.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 $LOAD_PATH.unshift(File.expand_path(File.join(__FILE__, "..", "..")))
 
 require "bootstrap/environment"

--- a/lib/pluginmanager/uninstall.rb
+++ b/lib/pluginmanager/uninstall.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "pluginmanager/command"
 
 class LogStash::PluginManager::Uninstall < LogStash::PluginManager::Command

--- a/lib/pluginmanager/update.rb
+++ b/lib/pluginmanager/update.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "pluginmanager/command"
 require "jar-dependencies"
 require "jar_install_post_install_hook"

--- a/lib/pluginmanager/util.rb
+++ b/lib/pluginmanager/util.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "rubygems/package"
 
 module LogStash::PluginManager

--- a/rakelib/bootstrap.rake
+++ b/rakelib/bootstrap.rake
@@ -1,2 +1,1 @@
-
 task "bootstrap" => [ "vendor:all", "compile:all" ]

--- a/spec/core/conditionals_spec.rb
+++ b/spec/core/conditionals_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'spec_helper'
 
 module ConditionalFanciness

--- a/spec/core/config_mixin_spec.rb
+++ b/spec/core/config_mixin_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "spec_helper"
 require "logstash/config/mixin"
 

--- a/spec/core/environment_spec.rb
+++ b/spec/core/environment_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "spec_helper"
 require "logstash/environment"
 

--- a/spec/core/pipeline_spec.rb
+++ b/spec/core/pipeline_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "spec_helper"
 
 class DummyInput < LogStash::Inputs::Base

--- a/spec/core/plugin_spec.rb
+++ b/spec/core/plugin_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "spec_helper"
 require "logstash/plugin"
 

--- a/spec/core/runner_spec.rb
+++ b/spec/core/runner_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "spec_helper"
 require "logstash/runner"
 require "stud/task"

--- a/spec/core/timestamp_spec.rb
+++ b/spec/core/timestamp_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "spec_helper"
 require "logstash/timestamp"
 

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # Useful module to help loading all logstash content when
 # running coverage analysis
 module CoverageHelper

--- a/spec/license_spec.rb
+++ b/spec/license_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'spec_helper'
 require 'rakelib/default_plugins'
 

--- a/spec/logstash/agent_spec.rb
+++ b/spec/logstash/agent_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'spec_helper'
 
 describe LogStash::Agent do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require_relative 'coverage_helper'
 # In order to archive an expected coverage analysis we need to eager load
 # all logstash code base, otherwise it will not get a good analysis.

--- a/spec/util/java_version_spec.rb
+++ b/spec/util/java_version_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'spec_helper'
 require 'logstash/util/java_version'
 

--- a/spec/util/plugin_version_spec.rb
+++ b/spec/util/plugin_version_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "spec_helper"
 require "logstash/util/plugin_version"
 

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'spec_helper'
 
 require "logstash/util"


### PR DESCRIPTION
… so all internal strings are UTF-8 in Ruby < 2.0, this has been found thanks to the work on #3718, we might like to work on internal check for this, probably with the inclusion of rubocop or other kind of changes.