### PR TITLE
fix update plugins list to not include uninstalled but not purged plugins

### DIFF
--- a/lib/pluginmanager/update.rb
+++ b/lib/pluginmanager/update.rb
@@ -107,7 +107,7 @@ class LogStash::PluginManager::Update < LogStash::PluginManager::Command
   # retrieve only the latest spec for all locally installed plugins
   # @return [Hash] result hash {plugin_name.downcase => plugin_spec}
   def find_latest_gem_specs
-    LogStash::PluginManager.find_plugins_gem_specs.inject({}) do |result, spec|
+    LogStash::PluginManager.all_installed_plugins_gem_specs(gemfile).inject({}) do |result, spec|
       previous = result[spec.name.downcase]
       result[spec.name.downcase] = previous ? [previous, spec].max_by{|s| s.version} : spec
       result


### PR DESCRIPTION
This PR is the first attempt to provide a closure to #3678 to users are able to clean stale dependencies left behind by the plugin manager.

## Comments
Having a clean command is not the best solution, we should be able to actually let Bundler know we aim to clean from a given environment, actually this only happen to me when another process is kick in so the environment is fresh.

Possible solutions:

- use ```Bundler.with_clean_env``` if possible.
- use new process.
- Remove stale dependencies by code.

After doing some investigation on 1, and 2, the solution was either not working as expected, or having a too complicated setup. I end up implementing 3 + the proposed solution by @colinsurprenant in the review process, so now we've a clean environment after uninstall (my expectation) and update works only with the gems available in the gemfile.

Test has been added to logstash-kitchen project.

Fixes #3678