### PR TITLE
Path validation when it does not exist

### DIFF
--- a/lib/logstash/config/mixin.rb
+++ b/lib/logstash/config/mixin.rb
@@ -451,16 +451,22 @@ module LogStash::Config::Mixin
             end
 
             result = value.first.is_a?(::LogStash::Util::Password) ? value.first : ::LogStash::Util::Password.new(value.first)
+          when :file_or_dir
+            if value.size > 1 # Only 1 value wanted
+              return false, "Expected file_or_dir (one value), got #{value.size} values?"
+            end
+
+            if !File.exists?(value.first) # Check if the file exists
+              return false, "File or Directory does not exist or cannot be opened #{value.first}"
+            end
+
+            result = value.first
           when :path
             if value.size > 1 # Only 1 value wanted
               return false, "Expected path (one value), got #{value.size} values?"
             end
 
-            if !File.exists?(value.first) # Check if the file exists
-              return false, "File does not exist or cannot be opened #{value.first}"
-            end
-
-            result = value.first
+            result = value.first.is_a?(::Pathname) ? value.first : ::Pathname.new(value.first)
           when :bytes
             begin
               bytes = Integer(value.first) rescue nil

--- a/lib/logstash/config/mixin.rb
+++ b/lib/logstash/config/mixin.rb
@@ -456,11 +456,6 @@ module LogStash::Config::Mixin
               return false, "Expected path (one value), got #{value.size} values?"
             end
 
-            # Paths must be absolute
-            #if !Pathname.new(value.first).absolute?
-              #return false, "Require absolute path, got relative path #{value.first}?"
-            #end
-
             if !File.exists?(value.first) # Check if the file exists
               return false, "File does not exist or cannot be opened #{value.first}"
             end

--- a/spec/core/config_mixin_spec.rb
+++ b/spec/core/config_mixin_spec.rb
@@ -98,11 +98,11 @@ describe LogStash::Config::Mixin do
     end
   end
 
-  context "when validating :path" do
+  context "when validating :file_or_dir" do
     let(:klass) do
       Class.new(LogStash::Filters::Base) do
         config_name "cake"
-        config :file, :validate => :path, :default => "/foo/bar"
+        config :file, :validate => :file_or_dir, :default => "/foo/bar"
       end
     end
 
@@ -113,6 +113,25 @@ describe LogStash::Config::Mixin do
 
     it "raises an exception if the path does not exist" do
       expect { klass.new({}) }.to raise_error(LogStash::ConfigurationError)
+    end
+  end
+
+  context "when validating :path" do
+    let(:klass) do
+      Class.new(LogStash::Filters::Base) do
+        config_name "cake"
+        config :path, :validate => :path, :default => "foobar"
+      end
+    end
+
+    subject { klass.new({}) }
+
+    it "should be valid and exist" do
+      expect { klass.new({}) }.to_not raise_error
+    end
+
+    it "should be a pathname object" do
+      expect(subject.path).to be_a(Pathname)
     end
   end
 end

--- a/spec/core/config_mixin_spec.rb
+++ b/spec/core/config_mixin_spec.rb
@@ -97,4 +97,22 @@ describe LogStash::Config::Mixin do
       expect(clone.password.value).to(be == secret)
     end
   end
+
+  context "when validating :path" do
+    let(:klass) do
+      Class.new(LogStash::Filters::Base) do
+        config_name "cake"
+        config :file, :validate => :path, :default => "/foo/bar"
+      end
+    end
+
+    it "should be valid and exist" do
+      allow(File).to receive(:exists?).with("/foo/bar").and_return(true)
+      expect { klass.new({}) }.to_not raise_error
+    end
+
+    it "raises an exception if the path does not exist" do
+      expect { klass.new({}) }.to raise_error(LogStash::ConfigurationError)
+    end
+  end
 end


### PR DESCRIPTION
From doing work on the test for the nagios plugin I faced with the fact that the path validation expects the file to actually exist, however the semantics of this validation (even if useful for most of the current plugins) is not clear.

In this PR the changes introduced are:
- Introduce the `file_or_dir` validation to be used when you want to make sure a path is actually there, for example with the nagios command, or an ssl certificate.
- Remove the `File.exists?` validation from the path check, this will return now also an instance of `Pathname` so the plugin using this will be responsible of for example creating the file when need.

As soon as this gets green light, we should be sure to update related plugins who trust `:path` to be used actually to validate the file or dir exist.

Fixes #3793
