### PR TITLE
trigger input plugin shutdown using out of band call

### DIFF
--- a/lib/logstash/inputs/base.rb
+++ b/lib/logstash/inputs/base.rb
@@ -67,6 +67,7 @@ class LogStash::Inputs::Base < LogStash::Plugin
   def initialize(params={})
     super
     @threadable = false
+    @stop_called = Concurrent::AtomicBoolean.new(false)
     config_init(params)
     @tags ||= []
 
@@ -99,6 +100,20 @@ class LogStash::Inputs::Base < LogStash::Plugin
   def tag(newtag)
     @tags << newtag
   end # def tag
+
+  # if you override stop, don't forget to call super
+  # as the first action
+  public
+  def stop
+    @logger.debug("stopping", :plugin => self)
+    @stop_called.make_true
+  end
+
+  # stop? should never be overriden
+  private
+  def stop?
+    @stop_called.value
+  end
 
   protected
   def to_event(raw, source)

--- a/lib/logstash/inputs/base.rb
+++ b/lib/logstash/inputs/base.rb
@@ -110,7 +110,7 @@ class LogStash::Inputs::Base < LogStash::Plugin
   end
 
   # stop? should never be overriden
-  private
+  public
   def stop?
     @stop_called.value
   end

--- a/lib/logstash/pipeline.rb
+++ b/lib/logstash/pipeline.rb
@@ -178,7 +178,9 @@ class LogStash::Pipeline
     rescue => e
       # if plugin is stopping, ignore uncatched exceptions and exit worker
       if plugin.stop?
-        @logger.debug("Ignoring stopping plugin exception", :exception => e, "backtrace" => e.backtrace)
+        @logger.debug("Input plugin raised exception during shutdown, ignoring it.",
+                      :plugin => plugin.class.config_name, :exception => e,
+                      :backtrace => e.backtrace)
         return
       end
 

--- a/lib/logstash/pipeline.rb
+++ b/lib/logstash/pipeline.rb
@@ -193,6 +193,8 @@ class LogStash::Pipeline
                              :plugin => plugin.inspect, :error => e))
       end
 
+      # Assuming the failure that caused this exception is transient,
+      # let's sleep for a bit and execute #run again
       sleep(1)
       retry
     ensure

--- a/lib/logstash/plugin.rb
+++ b/lib/logstash/plugin.rb
@@ -3,6 +3,7 @@ require "logstash/namespace"
 require "logstash/logging"
 require "logstash/config/mixin"
 require "cabin"
+require "concurrent"
 
 class LogStash::Plugin
   attr_accessor :params
@@ -27,72 +28,14 @@ class LogStash::Plugin
     @logger = Cabin::Channel.get(LogStash)
   end
 
-  # This method is called when someone or something wants this plugin to shut
-  # down. When you successfully shutdown, you must call 'finished'
-  # You must also call 'super' in any subclasses.
-  public
-  def shutdown(queue)
-    # By default, shutdown is assumed a no-op for all plugins.
-    # If you need to take special efforts to shutdown (like waiting for
-    # an operation to complete, etc)
-    teardown
-    @logger.info("Received shutdown signal", :plugin => self)
-
-    @shutdown_queue = queue
-    if @plugin_state == :finished
-      finished
-    else
-      @plugin_state = :terminating
-    end
-  end # def shutdown
-
-  # You should call this method when you (the plugin) are done with work
-  # forever.
-  public
-  def finished
-    # TODO(sissel): I'm not sure what I had planned for this shutdown_queue
-    # thing
-    if @shutdown_queue
-      @logger.info("Sending shutdown event to agent queue", :plugin => self)
-      @shutdown_queue << self
-    end
-
-    if @plugin_state != :finished
-      @logger.info("Plugin is finished", :plugin => self)
-      @plugin_state = :finished
-    end
-  end # def finished
-
   # Subclasses should implement this teardown method if you need to perform any
   # special tasks during shutdown (like flushing, etc.)
+  # if you override teardown, don't forget to call super
   public
   def teardown
-    # nothing by default
-    finished
+    @logger.debug("closing", :plugin => self)
   end
 
-  # This method is called when a SIGHUP triggers a reload operation
-  public
-  def reload
-    # Do nothing by default
-  end
-
-  public
-  def finished?
-    return @plugin_state == :finished
-  end # def finished?
-
-  public
-  def running?
-    return @plugin_state != :finished
-  end # def finished?
-
-  public
-  def terminating?
-    return @plugin_state == :terminating
-  end # def terminating?
-
-  public
   def to_s
     return "#{self.class.name}: #{@params}"
   end

--- a/logstash-core.gemspec
+++ b/logstash-core.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "clamp", "~> 0.6.5" #(MIT license) for command line args/flags
   gem.add_runtime_dependency "filesize", "0.0.4" #(MIT license) for :bytes config validator
   gem.add_runtime_dependency "gems", "~> 0.8.3"  #(MIT license)
+  gem.add_runtime_dependency "concurrent-ruby", "~> 0.9.1"
 
   # TODO(sissel): Treetop 1.5.x doesn't seem to work well, but I haven't
   # investigated what the cause might be. -Jordan


### PR DESCRIPTION
Currently, during shutdown, the pipeline loops through input workers
and calls Thread.raise on each input thread. Plugins rescue that
exception to exit the `run` loop. Afterwards, `teardown` is called for
any additional bookkeeping.

This proposal exposes a `stop` call on the input plugin class to alert
an input that it should shutdown. It is the plugin job to frequently
poll an internal `stop?` method to know if it's time to exit and
terminate if so.

The `teardown` method remains to do the additional bookkeeping, and it
will be called by the inputworker when `run` terminates.

resolves #3210 and replaces #3211  