### PR TITLE
[WiP] Refactoring the plugin manager

### DIFF
--- a/lib/pluginmanager/command.rb
+++ b/lib/pluginmanager/command.rb
@@ -1,39 +1,48 @@
 # encoding: utf-8
-class LogStash::PluginManager::Command < Clamp::Command
-  def gemfile
-    @gemfile ||= LogStash::Gemfile.new(File.new(LogStash::Environment::GEMFILE_PATH, 'r+')).load
-  end
+require "pluginmanager/util"
 
-  # If set in debug mode we will raise an exception and display the stacktrace
-  def report_exception(readable_message, exception)
-    if ENV["DEBUG"]
-      raise exception
-    else
-      signal_error("#{readable_message}, message: #{exception.message}")
+module LogStash
+  module PluginManager
+    class Command < Clamp::Command
+
+      include LogStash::PluginManager::Util
+
+      def gemfile
+        @gemfile ||= LogStash::Gemfile.new(File.new(LogStash::Environment::GEMFILE_PATH, 'r+')).load
+      end
+
+      # If set in debug mode we will raise an exception and display the stacktrace
+      def report_exception(readable_message, exception)
+        if ENV["DEBUG"]
+          raise exception
+        else
+          signal_error("#{readable_message}, message: #{exception.message}")
+        end
+      end
+
+      def display_bundler_output(output)
+        if ENV['DEBUG'] && output
+          # Display what bundler did in the last run
+          $stderr.puts("Bundler output")
+          $stderr.puts(output)
+        end
+      end
+
+
+      # Each plugin install for a gemfile create a path with a unique id.
+      # we must clear what is not currently used in the 
+      def remove_unused_locally_installed_gems!
+        used_path = gemfile.locally_installed_gems.collect { |gem| gem.options[:path] }
+
+        Dir.glob(File.join(LogStash::Environment::LOCAL_GEM_PATH, '*')) do |path|
+          FileUtils.rm_rf(relative_path(path)) if used_path.none? { |p| p.start_with?(relative_path(path)) }
+        end
+      end
+
+      def relative_path(path)
+        require "pathname"
+        ::Pathname.new(path).relative_path_from(::Pathname.new(LogStash::Environment::LOGSTASH_HOME)).to_s
+      end
     end
-  end
-
-  def display_bundler_output(output)
-    if ENV['DEBUG'] && output
-      # Display what bundler did in the last run
-      $stderr.puts("Bundler output")
-      $stderr.puts(output)
-    end
-  end
-
-
-  # Each plugin install for a gemfile create a path with a unique id.
-  # we must clear what is not currently used in the 
-  def remove_unused_locally_installed_gems!
-    used_path = gemfile.locally_installed_gems.collect { |gem| gem.options[:path] }
-
-    Dir.glob(File.join(LogStash::Environment::LOCAL_GEM_PATH, '*')) do |path|
-      FileUtils.rm_rf(relative_path(path)) if used_path.none? { |p| p.start_with?(relative_path(path)) }
-    end
-  end
-
-  def relative_path(path)
-    require "pathname"
-    ::Pathname.new(path).relative_path_from(::Pathname.new(LogStash::Environment::LOGSTASH_HOME)).to_s
   end
 end

--- a/lib/pluginmanager/command.rb
+++ b/lib/pluginmanager/command.rb
@@ -1,11 +1,13 @@
 # encoding: utf-8
 require "pluginmanager/util"
+require "pluginmanager/validators"
 
 module LogStash
   module PluginManager
     class Command < Clamp::Command
 
       include LogStash::PluginManager::Util
+      include LogStash::PluginManager::Validations
 
       def gemfile
         @gemfile ||= LogStash::Gemfile.new(File.new(LogStash::Environment::GEMFILE_PATH, 'r+')).load

--- a/lib/pluginmanager/install.rb
+++ b/lib/pluginmanager/install.rb
@@ -5,132 +5,136 @@ require "jar_install_post_install_hook"
 require "file-dependencies/gem"
 require "fileutils"
 
-class LogStash::PluginManager::Install < LogStash::PluginManager::Command
-  parameter "[PLUGIN] ...", "plugin name(s) or file", :attribute_name => :plugins_arg
-  option "--version", "VERSION", "version of the plugin to install"
-  option "--[no-]verify", :flag, "verify plugin validity before installation", :default => true
-  option "--development", :flag, "install all development dependencies of currently installed plugins", :default => false
+module LogStash
+  module PluginManager
+    class Install < Command
+      parameter "[PLUGIN] ...", "plugin name(s) or file", :attribute_name => :plugins_arg
+      option "--version", "VERSION", "version of the plugin to install"
+      option "--[no-]verify", :flag, "verify plugin validity before installation", :default => true
+      option "--development", :flag, "install all development dependencies of currently installed plugins", :default => false
 
-  # the install logic below support installing multiple plugins with each a version specification
-  # but the argument parsing does not support it for now so currently if specifying --version only
-  # one plugin name can be also specified.
-  def execute
-    validate_cli_options!
+      # the install logic below support installing multiple plugins with each a version specification
+      # but the argument parsing does not support it for now so currently if specifying --version only
+      # one plugin name can be also specified.
+      def execute
+        validate_cli_options!
 
-    if local_gems?
-      gems = extract_local_gems_plugins
-    elsif development?
-      gems = plugins_development_gems
-    else
-      gems = plugins_gems
-      verify_remote!(gems) if verify?
-    end
+        if local_gems?
+          gems = extract_local_gems_plugins
+        elsif development?
+          gems = plugins_development_gems
+        else
+          gems = plugins_gems
+          verify_remote!(gems) if verify?
+        end
 
-    install_gems_list!(gems)
-    remove_unused_locally_installed_gems!
-  end
-
-  private
-  def validate_cli_options!
-    if development?
-      signal_usage_error("Cannot specify plugin(s) with --development, it will add the development dependencies of the currently installed plugins") unless plugins_arg.empty?
-    else
-      signal_usage_error("No plugin specified") if plugins_arg.empty? && verify?
-      # TODO: find right syntax to allow specifying list of plugins with optional version specification for each
-      signal_usage_error("Only 1 plugin name can be specified with --version") if version && plugins_arg.size > 1
-    end
-    signal_error("File #{LogStash::Environment::GEMFILE_PATH} does not exist or is not writable, aborting") unless ::File.writable?(LogStash::Environment::GEMFILE_PATH)
-  end
-
-  # Check if the specified gems contains
-  # the logstash `metadata`
-  def verify_remote!(gems)
-    gems.each do |plugin, version|
-      puts("Validating #{[plugin, version].compact.join("-")}")
-      signal_error("Installation aborted, verification failed for #{plugin} #{version}") unless LogStash::PluginManager.logstash_plugin?(plugin, version)
-    end
-  end
-
-  def plugins_development_gems
-    # Get currently defined gems and their dev dependencies
-    specs = []
-
-    specs = LogStash::PluginManager.all_installed_plugins_gem_specs(gemfile)
-
-    # Construct the list of dependencies to add to the current gemfile
-    specs.each_with_object([]) do |spec, install_list|
-      dependencies = spec.dependencies
-        .select { |dep| dep.type == :development }
-        .map { |dep| [dep.name] + dep.requirement.as_list }
-
-      install_list.concat(dependencies)
-    end
-  end
-
-  def plugins_gems
-    version ? [plugins_arg << version] : plugins_arg.map { |plugin| [plugin, nil] }
-  end
-
-  # install_list will be an array of [plugin name, version, options] tuples, version it
-  # can be nil at this point we know that plugins_arg is not empty and if the
-  # --version is specified there is only one plugin in plugins_arg
-  #
-  def install_gems_list!(install_list)
-    # If something goes wrong during the installation `LogStash::Gemfile` will restore a backup version.
-    install_list = LogStash::PluginManager.merge_duplicates(install_list)
-
-    # Add plugins/gems to the current gemfile
-    puts("Installing" + (install_list.empty? ? "..." : " " + install_list.collect(&:first).join(", ")))
-    install_list.each { |plugin, version, options| gemfile.update(plugin, version, options) }
-
-    # Sync gemfiles changes to disk to make them available to the `bundler install`'s API
-    gemfile.save
-
-    bundler_options = {:install => true}
-    bundler_options[:without] = [] if development?
-    bundler_options[:rubygems_source] = gemfile.gemset.sources
-
-    output = LogStash::Bundler.invoke!(bundler_options)
-
-    puts("Installation successful")
-  rescue => exception
-    gemfile.restore!
-    report_exception("Installation Aborted", exception)
-  ensure
-    display_bundler_output(output)
-  end
-
-  # Extract the specified local gems in a predefined local path
-  # Update the gemfile to use a relative path to this plugin and run
-  # Bundler, this will mark the gem not updatable by `bin/plugin update`
-  # This is the most reliable way to make it work in bundler without
-  # hacking with `how bundler works`
-  #
-  # Bundler 2.0, will have support for plugins source we could create a .gem source
-  # to support it.
-  def extract_local_gems_plugins
-    plugins_arg.collect do |plugin|
-      # We do the verify before extracting the gem so we dont have to deal with unused path
-      if verify?
-        puts("Validating #{plugin}")
-        signal_error("Installation aborted, verification failed for #{plugin}") unless LogStash::PluginManager.logstash_plugin?(plugin, version)
+        install_gems_list!(gems)
+        remove_unused_locally_installed_gems!
       end
 
-      package, path = LogStash::Rubygems.unpack(plugin, LogStash::Environment::LOCAL_GEM_PATH)
-      [package.spec.name, package.spec.version, { :path => relative_path(path) }]
-    end
+      private
+      def validate_cli_options!
+        if development?
+          signal_usage_error("Cannot specify plugin(s) with --development, it will add the development dependencies of the currently installed plugins") unless plugins_arg.empty?
+        else
+          signal_usage_error("No plugin specified") if plugins_arg.empty? && verify?
+          # TODO: find right syntax to allow specifying list of plugins with optional version specification for each
+          signal_usage_error("Only 1 plugin name can be specified with --version") if version && plugins_arg.size > 1
+        end
+        signal_error("File #{LogStash::Environment::GEMFILE_PATH} does not exist or is not writable, aborting") unless ::File.writable?(LogStash::Environment::GEMFILE_PATH)
+      end
+
+      # Check if the specified gems contains
+      # the logstash `metadata`
+      def verify_remote!(gems)
+        gems.each do |plugin, version|
+          puts("Validating #{[plugin, version].compact.join("-")}")
+          signal_error("Installation aborted, verification failed for #{plugin} #{version}") unless LogStash::PluginManager.logstash_plugin?(plugin, version)
+        end
+      end
+
+      def plugins_development_gems
+        # Get currently defined gems and their dev dependencies
+        specs = []
+
+        specs = LogStash::PluginManager.all_installed_plugins_gem_specs(gemfile)
+
+        # Construct the list of dependencies to add to the current gemfile
+        specs.each_with_object([]) do |spec, install_list|
+          dependencies = spec.dependencies
+            .select { |dep| dep.type == :development }
+            .map { |dep| [dep.name] + dep.requirement.as_list }
+
+          install_list.concat(dependencies)
+        end
+      end
+
+      def plugins_gems
+        version ? [plugins_arg << version] : plugins_arg.map { |plugin| [plugin, nil] }
+      end
+
+      # install_list will be an array of [plugin name, version, options] tuples, version it
+      # can be nil at this point we know that plugins_arg is not empty and if the
+      # --version is specified there is only one plugin in plugins_arg
+      #
+      def install_gems_list!(install_list)
+        # If something goes wrong during the installation `LogStash::Gemfile` will restore a backup version.
+        install_list = LogStash::PluginManager.merge_duplicates(install_list)
+
+        # Add plugins/gems to the current gemfile
+        puts("Installing" + (install_list.empty? ? "..." : " " + install_list.collect(&:first).join(", ")))
+        install_list.each { |plugin, version, options| gemfile.update(plugin, version, options) }
+
+        # Sync gemfiles changes to disk to make them available to the `bundler install`'s API
+        gemfile.save
+
+        bundler_options = {:install => true}
+        bundler_options[:without] = [] if development?
+        bundler_options[:rubygems_source] = gemfile.gemset.sources
+
+        output = LogStash::Bundler.invoke!(bundler_options)
+
+        puts("Installation successful")
+      rescue => exception
+        gemfile.restore!
+        report_exception("Installation Aborted", exception)
+      ensure
+        display_bundler_output(output)
+      end
+
+      # Extract the specified local gems in a predefined local path
+      # Update the gemfile to use a relative path to this plugin and run
+      # Bundler, this will mark the gem not updatable by `bin/plugin update`
+      # This is the most reliable way to make it work in bundler without
+      # hacking with `how bundler works`
+      #
+      # Bundler 2.0, will have support for plugins source we could create a .gem source
+      # to support it.
+      def extract_local_gems_plugins
+        plugins_arg.collect do |plugin|
+          # We do the verify before extracting the gem so we dont have to deal with unused path
+          if verify?
+            puts("Validating #{plugin}")
+            signal_error("Installation aborted, verification failed for #{plugin}") unless LogStash::PluginManager.logstash_plugin?(plugin, version)
+          end
+
+          package, path = LogStash::Rubygems.unpack(plugin, LogStash::Environment::LOCAL_GEM_PATH)
+          [package.spec.name, package.spec.version, { :path => relative_path(path) }]
+        end
+      end
+
+      # We cannot install both .gem and normal plugin in one call of `plugin install`
+      def local_gems?
+        return false if plugins_arg.empty?
+
+        local_gem = plugins_arg.collect { |plugin| ::File.extname(plugin) == ".gem" }.uniq
+
+        if local_gem.size == 1
+          return local_gem.first
+        else
+          signal_usage_error("Mixed source of plugins, you can't mix local `.gem` and remote gems")
+        end
+      end
+    end # class Logstash::PluginManager
   end
-
-  # We cannot install both .gem and normal plugin in one call of `plugin install`
-  def local_gems?
-    return false if plugins_arg.empty?
-
-    local_gem = plugins_arg.collect { |plugin| ::File.extname(plugin) == ".gem" }.uniq
-
-    if local_gem.size == 1
-      return local_gem.first
-    else
-      signal_usage_error("Mixed source of plugins, you can't mix local `.gem` and remote gems")
-    end
-  end
-end # class Logstash::PluginManager
+end

--- a/lib/pluginmanager/install.rb
+++ b/lib/pluginmanager/install.rb
@@ -8,6 +8,7 @@ require "fileutils"
 module LogStash
   module PluginManager
     class Install < Command
+
       parameter "[PLUGIN] ...", "plugin name(s) or file", :attribute_name => :plugins_arg
       option "--version", "VERSION", "version of the plugin to install"
       option "--[no-]verify", :flag, "verify plugin validity before installation", :default => true
@@ -49,7 +50,7 @@ module LogStash
       def verify_remote!(gems)
         gems.each do |plugin, version|
           puts("Validating #{[plugin, version].compact.join("-")}")
-          signal_error("Installation aborted, verification failed for #{plugin} #{version}") unless LogStash::PluginManager.logstash_plugin?(plugin, version)
+          signal_error("Installation aborted, verification failed for #{plugin} #{version}") unless logstash_plugin?(plugin, version)
         end
       end
 
@@ -57,7 +58,7 @@ module LogStash
         # Get currently defined gems and their dev dependencies
         specs = []
 
-        specs = LogStash::PluginManager.all_installed_plugins_gem_specs(gemfile)
+        specs = all_installed_plugins_gem_specs(gemfile)
 
         # Construct the list of dependencies to add to the current gemfile
         specs.each_with_object([]) do |spec, install_list|
@@ -79,7 +80,7 @@ module LogStash
       #
       def install_gems_list!(install_list)
         # If something goes wrong during the installation `LogStash::Gemfile` will restore a backup version.
-        install_list = LogStash::PluginManager.merge_duplicates(install_list)
+        install_list = self.merge_duplicates(install_list)
 
         # Add plugins/gems to the current gemfile
         puts("Installing" + (install_list.empty? ? "..." : " " + install_list.collect(&:first).join(", ")))
@@ -115,7 +116,7 @@ module LogStash
           # We do the verify before extracting the gem so we dont have to deal with unused path
           if verify?
             puts("Validating #{plugin}")
-            signal_error("Installation aborted, verification failed for #{plugin}") unless LogStash::PluginManager.logstash_plugin?(plugin, version)
+            signal_error("Installation aborted, verification failed for #{plugin}") unless logstash_plugin?(plugin, version)
           end
 
           package, path = LogStash::Rubygems.unpack(plugin, LogStash::Environment::LOCAL_GEM_PATH)

--- a/lib/pluginmanager/list.rb
+++ b/lib/pluginmanager/list.rb
@@ -30,7 +30,7 @@ module LogStash
       def filtered_specs
         @filtered_specs ||= begin
                               # start with all locally installed plugin gems regardless of the Gemfile content
-                              specs = LogStash::PluginManager.find_plugins_gem_specs
+                              specs = find_plugins_gem_specs
 
                               # apply filters
                               specs = specs.select{|spec| gemfile.find(spec.name)} if installed?

--- a/lib/pluginmanager/list.rb
+++ b/lib/pluginmanager/list.rb
@@ -2,40 +2,44 @@
 require 'rubygems/spec_fetcher'
 require "pluginmanager/command"
 
-class LogStash::PluginManager::List < LogStash::PluginManager::Command
+module LogStash
+  module PluginManager
+    class List < Command
 
-  parameter "[PLUGIN]", "Part of plugin name to search for, leave empty for all plugins"
+      parameter "[PLUGIN]", "Part of plugin name to search for, leave empty for all plugins"
 
-  option "--installed", :flag, "List only explicitly installed plugins using bin/plugin install ...", :default => false
-  option "--verbose", :flag, "Also show plugin version number", :default => false
-  option "--group", "NAME", "Filter plugins per group: input, output, filter or codec" do |arg|
-    raise(ArgumentError, "should be one of: input, output, filter or codec") unless ['input', 'output', 'filter', 'codec'].include?(arg)
-    arg
-  end
+      option "--installed", :flag, "List only explicitly installed plugins using bin/plugin install ...", :default => false
+      option "--verbose", :flag, "Also show plugin version number", :default => false
+      option "--group", "NAME", "Filter plugins per group: input, output, filter or codec" do |arg|
+        raise(ArgumentError, "should be one of: input, output, filter or codec") unless ['input', 'output', 'filter', 'codec'].include?(arg)
+        arg
+      end
 
-  def execute
-    LogStash::Bundler.setup!({:without => [:build, :development]})
+      def execute
+        LogStash::Bundler.setup!({:without => [:build, :development]})
 
-    signal_error("No plugins found") if filtered_specs.empty?
+        signal_error("No plugins found") if filtered_specs.empty?
 
-    filtered_specs.sort_by{|spec| spec.name}.each do |spec|
-      line = "#{spec.name}"
-      line += " (#{spec.version})" if verbose?
-      puts(line)
+        filtered_specs.sort_by{|spec| spec.name}.each do |spec|
+          line = "#{spec.name}"
+          line += " (#{spec.version})" if verbose?
+          puts(line)
+        end
+      end
+
+      def filtered_specs
+        @filtered_specs ||= begin
+                              # start with all locally installed plugin gems regardless of the Gemfile content
+                              specs = LogStash::PluginManager.find_plugins_gem_specs
+
+                              # apply filters
+                              specs = specs.select{|spec| gemfile.find(spec.name)} if installed?
+                              specs = specs.select{|spec| spec.name =~ /#{plugin}/i} if plugin
+                              specs = specs.select{|spec| spec.metadata['logstash_group'] == group} if group
+
+                              specs
+                            end
+      end
     end
-  end
-
-  def filtered_specs
-    @filtered_specs ||= begin
-                          # start with all locally installed plugin gems regardless of the Gemfile content
-                          specs = LogStash::PluginManager.find_plugins_gem_specs
-
-                          # apply filters
-                          specs = specs.select{|spec| gemfile.find(spec.name)} if installed?
-                          specs = specs.select{|spec| spec.name =~ /#{plugin}/i} if plugin
-                          specs = specs.select{|spec| spec.metadata['logstash_group'] == group} if group
-
-                          specs
-                        end
   end
 end # class Logstash::PluginManager

--- a/lib/pluginmanager/uninstall.rb
+++ b/lib/pluginmanager/uninstall.rb
@@ -1,41 +1,45 @@
 # encoding: utf-8
 require "pluginmanager/command"
 
-class LogStash::PluginManager::Uninstall < LogStash::PluginManager::Command
+module LogStash
+  module PluginManager
+    class Uninstall < Command
 
-  parameter "PLUGIN", "plugin name"
+      parameter "PLUGIN", "plugin name"
 
-  def execute
-    signal_error("File #{LogStash::Environment::GEMFILE_PATH} does not exist or is not writable, aborting") unless File.writable?(LogStash::Environment::GEMFILE_PATH)
+      def execute
+        signal_error("File #{LogStash::Environment::GEMFILE_PATH} does not exist or is not writable, aborting") unless File.writable?(LogStash::Environment::GEMFILE_PATH)
 
-    ##
-    # Need to setup the bundler status to enable uninstall of plugins
-    # installed as local_gems, otherwise gem:specification is not
-    # finding the plugins
-    ##
-    LogStash::Bundler.setup!({:without => [:build, :development]})
+        ##
+        # Need to setup the bundler status to enable uninstall of plugins
+        # installed as local_gems, otherwise gem:specification is not
+        # finding the plugins
+        ##
+        LogStash::Bundler.setup!({:without => [:build, :development]})
 
-    # make sure this is an installed plugin and present in Gemfile.
-    # it is not possible to uninstall a dependency not listed in the Gemfile, for example a dependent codec
-    signal_error("This plugin has not been previously installed, aborting") unless LogStash::PluginManager.installed_plugin?(plugin, gemfile)
+        # make sure this is an installed plugin and present in Gemfile.
+        # it is not possible to uninstall a dependency not listed in the Gemfile, for example a dependent codec
+        signal_error("This plugin has not been previously installed, aborting") unless LogStash::PluginManager.installed_plugin?(plugin, gemfile)
 
-    # since we previously did a gemfile.find(plugin) there is no reason why
-    # remove would not work (return nil) here
-    if gemfile.remove(plugin)
-      gemfile.save
+        # since we previously did a gemfile.find(plugin) there is no reason why
+        # remove would not work (return nil) here
+        if gemfile.remove(plugin)
+          gemfile.save
 
-      puts("Uninstalling #{plugin}")
+          puts("Uninstalling #{plugin}")
 
-      # any errors will be logged to $stderr by invoke!
-      # output, exception = LogStash::Bundler.invoke!(:install => true, :clean => true)
-      output = LogStash::Bundler.invoke!(:install => true, :clean => true)
+          # any errors will be logged to $stderr by invoke!
+          # output, exception = LogStash::Bundler.invoke!(:install => true, :clean => true)
+          output = LogStash::Bundler.invoke!(:install => true, :clean => true)
 
-      remove_unused_locally_installed_gems!
+          remove_unused_locally_installed_gems!
+        end
+      rescue => exception
+        gemfile.restore!
+        report_exception("Uninstall Aborted", exception)
+      ensure
+        display_bundler_output(output)
+      end
     end
-  rescue => exception
-    gemfile.restore!
-    report_exception("Uninstall Aborted", exception)
-  ensure
-    display_bundler_output(output)
   end
 end

--- a/lib/pluginmanager/uninstall.rb
+++ b/lib/pluginmanager/uninstall.rb
@@ -19,7 +19,7 @@ module LogStash
 
         # make sure this is an installed plugin and present in Gemfile.
         # it is not possible to uninstall a dependency not listed in the Gemfile, for example a dependent codec
-        signal_error("This plugin has not been previously installed, aborting") unless LogStash::PluginManager.installed_plugin?(plugin, gemfile)
+        signal_error("This plugin has not been previously installed, aborting") unless installed_plugin?(plugin, gemfile)
 
         # since we previously did a gemfile.find(plugin) there is no reason why
         # remove would not work (return nil) here

--- a/lib/pluginmanager/update.rb
+++ b/lib/pluginmanager/update.rb
@@ -4,121 +4,125 @@ require "jar-dependencies"
 require "jar_install_post_install_hook"
 require "file-dependencies/gem"
 
-class LogStash::PluginManager::Update < LogStash::PluginManager::Command
-  REJECTED_OPTIONS = [:path, :git, :github]
+module LogStash
+  module PluginManager
+    class Update < Command
+      REJECTED_OPTIONS = [:path, :git, :github]
 
-  parameter "[PLUGIN] ...", "Plugin name(s) to upgrade to latest version", :attribute_name => :plugins_arg
+      parameter "[PLUGIN] ...", "Plugin name(s) to upgrade to latest version", :attribute_name => :plugins_arg
 
-  def execute
-    local_gems = gemfile.locally_installed_gems
+      def execute
+        local_gems = gemfile.locally_installed_gems
 
-    if local_gems.size > 0
-      if update_all?
-        plugins_with_path = local_gems.map(&:name)
-      else
-        plugins_with_path = plugins_arg & local_gems.map(&:name)
-      end
+        if local_gems.size > 0
+          if update_all?
+            plugins_with_path = local_gems.map(&:name)
+          else
+            plugins_with_path = plugins_arg & local_gems.map(&:name)
+          end
 
-      warn_local_gems(plugins_with_path)
-    end
-
-    update_gems!
-  end
-
-  private
-  def update_all?
-    plugins_arg.size == 0
-  end
-
-  def warn_local_gems(plugins_with_path)
-    puts("Update is not supported for manually defined plugins or local .gem plugin installations, skipping: #{plugins_with_path.join(", ")}")
-  end
-
-  def update_gems!
-    # If any error is raise inside the block the Gemfile will restore a backup of the Gemfile
-    previous_gem_specs_map = find_latest_gem_specs
-
-    # remove any version constrain from the Gemfile so the plugin(s) can be updated to latest version
-    # calling update without requiremend will remove any previous requirements
-    plugins = plugins_to_update(previous_gem_specs_map)
-    filtered_plugins = plugins.map { |plugin| gemfile.find(plugin) }
-      .compact
-      .reject { |plugin| REJECTED_OPTIONS.any? { |key| plugin.options.has_key?(key) } }
-      .select { |plugin| validate_major_version(plugin.name) }
-      .each   { |plugin| gemfile.update(plugin.name) }
-
-    # force a disk sync before running bundler
-    gemfile.save
-
-    puts("Updating #{filtered_plugins.collect(&:name).join(", ")}") unless filtered_plugins.empty?
-
-    # any errors will be logged to $stderr by invoke!
-    # Bundler cannot update and clean gems in one operation so we have to call the CLI twice.
-    output = LogStash::Bundler.invoke!(:update => plugins)
-    output = LogStash::Bundler.invoke!(:clean => true)
-
-    display_updated_plugins(previous_gem_specs_map)
-  rescue => exception
-    gemfile.restore!
-    report_exception("Updated Aborted", exception)
-  ensure
-    display_bundler_output(output)
-  end
-
-  # validate if there is any major version update so then we can ask the user if he is
-  # sure to update or not.
-  def validate_major_version(plugin)
-    require "gems"
-    latest_version  = Gems.versions(plugin)[0]['number'].split(".")
-    current_version = Gem::Specification.find_by_name(plugin).version.version.split(".")
-    if (latest_version[0].to_i > current_version[0].to_i)
-      ## warn if users want to continue
-      puts("You are updating #{plugin} to a new version #{latest_version.join('.')}, which may not be compatible with #{current_version.join('.')}. are you sure you want to proceed (Y/N)?")
-      return ( "y" == STDIN.gets.strip.downcase ? true : false)
-    end
-    true
-  end
-
-  # create list of plugins to update
-  def plugins_to_update(previous_gem_specs_map)
-    if update_all?
-      previous_gem_specs_map.values.map{|spec| spec.name}
-    else
-      # If the plugins isn't available in the gemspec or in 
-      # the gemfile defined with a local path, we assume the plugins is not
-      # installed.
-      not_installed = plugins_arg.select{|plugin| !previous_gem_specs_map.has_key?(plugin.downcase) && !gemfile.find(plugin) }
-      signal_error("Plugin #{not_installed.join(', ')} is not installed so it cannot be updated, aborting") unless not_installed.empty?
-      plugins_arg
-    end
-  end
-
-  # We compare the before the update and after the update
-  def display_updated_plugins(previous_gem_specs_map)
-    update_count = 0
-    find_latest_gem_specs.values.each do |spec|
-      name = spec.name.downcase
-      if previous_gem_specs_map.has_key?(name)
-        if spec.version != previous_gem_specs_map[name].version
-          puts("Updated #{spec.name} #{previous_gem_specs_map[name].version.to_s} to #{spec.version.to_s}")
-          update_count += 1
+          warn_local_gems(plugins_with_path)
         end
-      else
-        puts("Installed #{spec.name} #{spec.version.to_s}")
-        update_count += 1
+
+        update_gems!
       end
-    end
 
-    puts("No plugin updated") if update_count.zero?
-  end
+      private
+      def update_all?
+        plugins_arg.size == 0
+      end
 
-  # retrieve only the latest spec for all locally installed plugins
-  # @return [Hash] result hash {plugin_name.downcase => plugin_spec}
-  def find_latest_gem_specs
-    LogStash::PluginManager.find_plugins_gem_specs.inject({}) do |result, spec|
-      previous = result[spec.name.downcase]
-      result[spec.name.downcase] = previous ? [previous, spec].max_by{|s| s.version} : spec
-      result
+      def warn_local_gems(plugins_with_path)
+        puts("Update is not supported for manually defined plugins or local .gem plugin installations, skipping: #{plugins_with_path.join(", ")}")
+      end
+
+      def update_gems!
+        # If any error is raise inside the block the Gemfile will restore a backup of the Gemfile
+        previous_gem_specs_map = find_latest_gem_specs
+
+        # remove any version constrain from the Gemfile so the plugin(s) can be updated to latest version
+        # calling update without requiremend will remove any previous requirements
+        plugins = plugins_to_update(previous_gem_specs_map)
+        filtered_plugins = plugins.map { |plugin| gemfile.find(plugin) }
+          .compact
+          .reject { |plugin| REJECTED_OPTIONS.any? { |key| plugin.options.has_key?(key) } }
+          .select { |plugin| validate_major_version(plugin.name) }
+          .each   { |plugin| gemfile.update(plugin.name) }
+
+        # force a disk sync before running bundler
+        gemfile.save
+
+        puts("Updating #{filtered_plugins.collect(&:name).join(", ")}") unless filtered_plugins.empty?
+
+        # any errors will be logged to $stderr by invoke!
+        # Bundler cannot update and clean gems in one operation so we have to call the CLI twice.
+        output = LogStash::Bundler.invoke!(:update => plugins)
+        output = LogStash::Bundler.invoke!(:clean => true)
+
+        display_updated_plugins(previous_gem_specs_map)
+      rescue => exception
+        gemfile.restore!
+        report_exception("Updated Aborted", exception)
+      ensure
+        display_bundler_output(output)
+      end
+
+      # validate if there is any major version update so then we can ask the user if he is
+      # sure to update or not.
+      def validate_major_version(plugin)
+        require "gems"
+        latest_version  = Gems.versions(plugin)[0]['number'].split(".")
+        current_version = Gem::Specification.find_by_name(plugin).version.version.split(".")
+        if (latest_version[0].to_i > current_version[0].to_i)
+          ## warn if users want to continue
+          puts("You are updating #{plugin} to a new version #{latest_version.join('.')}, which may not be compatible with #{current_version.join('.')}. are you sure you want to proceed (Y/N)?")
+          return ( "y" == STDIN.gets.strip.downcase ? true : false)
+        end
+        true
+      end
+
+      # create list of plugins to update
+      def plugins_to_update(previous_gem_specs_map)
+        if update_all?
+          previous_gem_specs_map.values.map{|spec| spec.name}
+        else
+          # If the plugins isn't available in the gemspec or in 
+          # the gemfile defined with a local path, we assume the plugins is not
+          # installed.
+          not_installed = plugins_arg.select{|plugin| !previous_gem_specs_map.has_key?(plugin.downcase) && !gemfile.find(plugin) }
+          signal_error("Plugin #{not_installed.join(', ')} is not installed so it cannot be updated, aborting") unless not_installed.empty?
+          plugins_arg
+        end
+      end
+
+      # We compare the before the update and after the update
+      def display_updated_plugins(previous_gem_specs_map)
+        update_count = 0
+        find_latest_gem_specs.values.each do |spec|
+          name = spec.name.downcase
+          if previous_gem_specs_map.has_key?(name)
+            if spec.version != previous_gem_specs_map[name].version
+              puts("Updated #{spec.name} #{previous_gem_specs_map[name].version.to_s} to #{spec.version.to_s}")
+              update_count += 1
+            end
+          else
+            puts("Installed #{spec.name} #{spec.version.to_s}")
+            update_count += 1
+          end
+        end
+
+        puts("No plugin updated") if update_count.zero?
+      end
+
+      # retrieve only the latest spec for all locally installed plugins
+      # @return [Hash] result hash {plugin_name.downcase => plugin_spec}
+      def find_latest_gem_specs
+        LogStash::PluginManager.find_plugins_gem_specs.inject({}) do |result, spec|
+          previous = result[spec.name.downcase]
+          result[spec.name.downcase] = previous ? [previous, spec].max_by{|s| s.version} : spec
+          result
+        end
+      end
     end
   end
 end

--- a/lib/pluginmanager/update.rb
+++ b/lib/pluginmanager/update.rb
@@ -117,7 +117,7 @@ module LogStash
       # retrieve only the latest spec for all locally installed plugins
       # @return [Hash] result hash {plugin_name.downcase => plugin_spec}
       def find_latest_gem_specs
-        LogStash::PluginManager.find_plugins_gem_specs.inject({}) do |result, spec|
+        find_plugins_gem_specs.inject({}) do |result, spec|
           previous = result[spec.name.downcase]
           result[spec.name.downcase] = previous ? [previous, spec].max_by{|s| s.version} : spec
           result

--- a/lib/pluginmanager/update.rb
+++ b/lib/pluginmanager/update.rb
@@ -67,20 +67,6 @@ module LogStash
         display_bundler_output(output)
       end
 
-      # validate if there is any major version update so then we can ask the user if he is
-      # sure to update or not.
-      def validate_major_version(plugin)
-        require "gems"
-        latest_version  = Gems.versions(plugin)[0]['number'].split(".")
-        current_version = Gem::Specification.find_by_name(plugin).version.version.split(".")
-        if (latest_version[0].to_i > current_version[0].to_i)
-          ## warn if users want to continue
-          puts("You are updating #{plugin} to a new version #{latest_version.join('.')}, which may not be compatible with #{current_version.join('.')}. are you sure you want to proceed (Y/N)?")
-          return ( "y" == STDIN.gets.strip.downcase ? true : false)
-        end
-        true
-      end
-
       # create list of plugins to update
       def plugins_to_update(previous_gem_specs_map)
         if update_all?

--- a/lib/pluginmanager/util.rb
+++ b/lib/pluginmanager/util.rb
@@ -39,20 +39,10 @@ module LogStash
         end
       end
 
-      # validate if there is any major version update so then we can ask the user if he is
-      # sure to update or not.
-      # @param plugin [String] A plugin name
-      # @return [Boolean] true if updating to a major version is ok, false otherwise
-      def validate_major_version(plugin)
-        require "gems"
-        latest_version  = ::Gems.versions(plugin)[0]['number'].split(".")
-        current_version = ::Gem::Specification.find_by_name(plugin).version.version.split(".")
-        if (latest_version[0].to_i > current_version[0].to_i)
-          ## warn if users want to continue
-          puts("You are updating #{plugin} to a new version #{latest_version.join('.')}, which may not be compatible with #{current_version.join('.')}. are you sure you want to proceed (Y/N)?")
-          return ( "y" == STDIN.gets.strip.downcase ? true : false)
-        end
-        true
+      def filter_plugin(plugin)
+        self.class.validators.map do |validator|
+          validator.call(plugin)
+        end.reduce(true, :&)
       end
 
       # @param spec [Gem::Specification] plugin gem specification

--- a/lib/pluginmanager/util.rb
+++ b/lib/pluginmanager/util.rb
@@ -39,6 +39,22 @@ module LogStash
         end
       end
 
+      # validate if there is any major version update so then we can ask the user if he is
+      # sure to update or not.
+      # @param plugin [String] A plugin name
+      # @return [Boolean] true if updating to a major version is ok, false otherwise
+      def validate_major_version(plugin)
+        require "gems"
+        latest_version  = ::Gems.versions(plugin)[0]['number'].split(".")
+        current_version = ::Gem::Specification.find_by_name(plugin).version.version.split(".")
+        if (latest_version[0].to_i > current_version[0].to_i)
+          ## warn if users want to continue
+          puts("You are updating #{plugin} to a new version #{latest_version.join('.')}, which may not be compatible with #{current_version.join('.')}. are you sure you want to proceed (Y/N)?")
+          return ( "y" == STDIN.gets.strip.downcase ? true : false)
+        end
+        true
+      end
+
       # @param spec [Gem::Specification] plugin gem specification
       # @return [Boolean] true if this spec is for an installable logstash plugin
       def logstash_plugin_gem_spec?(spec)

--- a/lib/pluginmanager/util.rb
+++ b/lib/pluginmanager/util.rb
@@ -9,7 +9,7 @@ module LogStash
       # @param plugin [String] plugin name or .gem file path
       # @param version [String] gem version requirement string
       # @return [Boolean] true if valid logstash plugin gem name & version or a .gem file
-      def self.logstash_plugin?(plugin, version = nil)
+      def logstash_plugin?(plugin, version = nil)
         if plugin_file?(plugin)
           begin
             return logstash_plugin_gem_spec?(plugin_file_spec(plugin))
@@ -19,8 +19,8 @@ module LogStash
             return false
           end
         else
-          dep = Gem::Dependency.new(plugin, version || Gem::Requirement.default)
-          specs, errors = Gem::SpecFetcher.fetcher.spec_for_dependency(dep)
+          dep = ::Gem::Dependency.new(plugin, version || ::Gem::Requirement.default)
+          specs, errors = ::Gem::SpecFetcher.fetcher.spec_for_dependency(dep)
 
           # dump errors
           errors.each { |error| $stderr.puts(error.wordy) }
@@ -41,28 +41,28 @@ module LogStash
 
       # @param spec [Gem::Specification] plugin gem specification
       # @return [Boolean] true if this spec is for an installable logstash plugin
-      def self.logstash_plugin_gem_spec?(spec)
+      def logstash_plugin_gem_spec?(spec)
         spec.metadata && spec.metadata["logstash_plugin"] == "true"
       end
 
       # @param path [String] path to .gem file
       # @return [Gem::Specification] .get file gem specification
       # @raise [Exception] Gem::Package::FormatError will be raised on invalid .gem file format, might be other exceptions too
-      def self.plugin_file_spec(path)
-        Gem::Package.new(path).spec
+      def plugin_file_spec(path)
+        ::Gem::Package.new(path).spec
       end
 
       # @param plugin [String] the plugin name or the local path to a .gem file
       # @return [Boolean] true if the plugin is a local .gem file
-      def self.plugin_file?(plugin)
-        (plugin =~ /\.gem$/ && File.file?(plugin))
+      def plugin_file?(plugin)
+        (plugin =~ /\.gem$/ && ::File.file?(plugin))
       end
 
       # retrieve gem specs for all or specified name valid logstash plugins locally installed
       # @param name [String] specific plugin name to find or nil for all plungins
       # @return [Array<Gem::Specification>] all local logstash plugin gem specs
-      def self.find_plugins_gem_specs(name = nil)
-        specs = name ? Gem::Specification.find_all_by_name(name) : Gem::Specification.find_all
+      def find_plugins_gem_specs(name = nil)
+        specs = name ? ::Gem::Specification.find_all_by_name(name) : ::Gem::Specification.find_all
         specs.select{|spec| logstash_plugin_gem_spec?(spec)}
       end
 
@@ -71,7 +71,7 @@ module LogStash
       # specifically listed in the Gemfile.
       # @param gemfile [LogStash::Gemfile] the gemfile to validate against
       # @return [Array<Gem::Specification>] list of plugin specs
-      def self.all_installed_plugins_gem_specs(gemfile)
+      def all_installed_plugins_gem_specs(gemfile)
         # we start form the installed gemspecs so we can verify the metadata for valid logstash plugin
         # then filter out those not included in the Gemfile
         find_plugins_gem_specs.select{|spec| !!gemfile.find(spec.name)}
@@ -80,13 +80,13 @@ module LogStash
       # @param plugin [String] plugin name
       # @param gemfile [LogStash::Gemfile] the gemfile to validate against
       # @return [Boolean] true if the plugin is an installed logstash plugin and spefificed in the Gemfile
-      def self.installed_plugin?(plugin, gemfile)
+      def installed_plugin?(plugin, gemfile)
         !!gemfile.find(plugin) && find_plugins_gem_specs(plugin).any?
       end
 
       # @param plugin_list [Array] array of [plugin name, version] tuples
       # @return [Array] array of [plugin name, version, ...] tuples when duplciate names have been merged and non duplicate version requirements added
-      def self.merge_duplicates(plugin_list)
+      def merge_duplicates(plugin_list)
 
         # quick & dirty naive dedup for now
         # TODO: properly merge versions requirements

--- a/lib/pluginmanager/util.rb
+++ b/lib/pluginmanager/util.rb
@@ -1,93 +1,97 @@
 # encoding: utf-8
 require "rubygems/package"
 
-module LogStash::PluginManager
-  # check for valid logstash plugin gem name & version or .gem file, logs errors to $stdout
-  # uses Rubygems API and will remotely validated agains the current Gem.sources
-  # @param plugin [String] plugin name or .gem file path
-  # @param version [String] gem version requirement string
-  # @return [Boolean] true if valid logstash plugin gem name & version or a .gem file
-  def self.logstash_plugin?(plugin, version = nil)
-    if plugin_file?(plugin)
-      begin
-        return logstash_plugin_gem_spec?(plugin_file_spec(plugin))
-      rescue => e
-        $stderr.puts("Error reading plugin file #{plugin}, caused by #{e.class}")
-        $stderr.puts(e.message) if ENV["DEBUG"]
-        return false
-      end
-    else
-      dep = Gem::Dependency.new(plugin, version || Gem::Requirement.default)
-      specs, errors = Gem::SpecFetcher.fetcher.spec_for_dependency(dep)
+module LogStash
+  module PluginManager
+    module Util
+      # check for valid logstash plugin gem name & version or .gem file, logs errors to $stdout
+      # uses Rubygems API and will remotely validated agains the current Gem.sources
+      # @param plugin [String] plugin name or .gem file path
+      # @param version [String] gem version requirement string
+      # @return [Boolean] true if valid logstash plugin gem name & version or a .gem file
+      def self.logstash_plugin?(plugin, version = nil)
+        if plugin_file?(plugin)
+          begin
+            return logstash_plugin_gem_spec?(plugin_file_spec(plugin))
+          rescue => e
+            $stderr.puts("Error reading plugin file #{plugin}, caused by #{e.class}")
+            $stderr.puts(e.message) if ENV["DEBUG"]
+            return false
+          end
+        else
+          dep = Gem::Dependency.new(plugin, version || Gem::Requirement.default)
+          specs, errors = Gem::SpecFetcher.fetcher.spec_for_dependency(dep)
 
-      # dump errors
-      errors.each { |error| $stderr.puts(error.wordy) }
+          # dump errors
+          errors.each { |error| $stderr.puts(error.wordy) }
 
-      # depending on version requirements, multiple specs can be returned in which case
-      # we will grab the one with the highest version number
-      if latest = specs.map(&:first).max_by(&:version)
-        unless valid = logstash_plugin_gem_spec?(latest)
-          $stderr.puts("#{plugin} is not a Logstash plugin")
+          # depending on version requirements, multiple specs can be returned in which case
+          # we will grab the one with the highest version number
+          if latest = specs.map(&:first).max_by(&:version)
+            unless valid = logstash_plugin_gem_spec?(latest)
+              $stderr.puts("#{plugin} is not a Logstash plugin")
+            end
+            return valid
+          else
+            $stderr.puts("Plugin #{plugin}" + (version ? " version #{version}" : "") + " does not exist") if errors.empty?
+            return false
+          end
         end
-        return valid
-      else
-        $stderr.puts("Plugin #{plugin}" + (version ? " version #{version}" : "") + " does not exist") if errors.empty?
-        return false
+      end
+
+      # @param spec [Gem::Specification] plugin gem specification
+      # @return [Boolean] true if this spec is for an installable logstash plugin
+      def self.logstash_plugin_gem_spec?(spec)
+        spec.metadata && spec.metadata["logstash_plugin"] == "true"
+      end
+
+      # @param path [String] path to .gem file
+      # @return [Gem::Specification] .get file gem specification
+      # @raise [Exception] Gem::Package::FormatError will be raised on invalid .gem file format, might be other exceptions too
+      def self.plugin_file_spec(path)
+        Gem::Package.new(path).spec
+      end
+
+      # @param plugin [String] the plugin name or the local path to a .gem file
+      # @return [Boolean] true if the plugin is a local .gem file
+      def self.plugin_file?(plugin)
+        (plugin =~ /\.gem$/ && File.file?(plugin))
+      end
+
+      # retrieve gem specs for all or specified name valid logstash plugins locally installed
+      # @param name [String] specific plugin name to find or nil for all plungins
+      # @return [Array<Gem::Specification>] all local logstash plugin gem specs
+      def self.find_plugins_gem_specs(name = nil)
+        specs = name ? Gem::Specification.find_all_by_name(name) : Gem::Specification.find_all
+        specs.select{|spec| logstash_plugin_gem_spec?(spec)}
+      end
+
+      # list of all locally installed plugins specs specified in the Gemfile.
+      # note that an installed plugin dependecies like codecs will not be listed, only those
+      # specifically listed in the Gemfile.
+      # @param gemfile [LogStash::Gemfile] the gemfile to validate against
+      # @return [Array<Gem::Specification>] list of plugin specs
+      def self.all_installed_plugins_gem_specs(gemfile)
+        # we start form the installed gemspecs so we can verify the metadata for valid logstash plugin
+        # then filter out those not included in the Gemfile
+        find_plugins_gem_specs.select{|spec| !!gemfile.find(spec.name)}
+      end
+
+      # @param plugin [String] plugin name
+      # @param gemfile [LogStash::Gemfile] the gemfile to validate against
+      # @return [Boolean] true if the plugin is an installed logstash plugin and spefificed in the Gemfile
+      def self.installed_plugin?(plugin, gemfile)
+        !!gemfile.find(plugin) && find_plugins_gem_specs(plugin).any?
+      end
+
+      # @param plugin_list [Array] array of [plugin name, version] tuples
+      # @return [Array] array of [plugin name, version, ...] tuples when duplciate names have been merged and non duplicate version requirements added
+      def self.merge_duplicates(plugin_list)
+
+        # quick & dirty naive dedup for now
+        # TODO: properly merge versions requirements
+        plugin_list.uniq(&:first)
       end
     end
-  end
-
-  # @param spec [Gem::Specification] plugin gem specification
-  # @return [Boolean] true if this spec is for an installable logstash plugin
-  def self.logstash_plugin_gem_spec?(spec)
-    spec.metadata && spec.metadata["logstash_plugin"] == "true"
-  end
-
-  # @param path [String] path to .gem file
-  # @return [Gem::Specification] .get file gem specification
-  # @raise [Exception] Gem::Package::FormatError will be raised on invalid .gem file format, might be other exceptions too
-  def self.plugin_file_spec(path)
-    Gem::Package.new(path).spec
-  end
-
-  # @param plugin [String] the plugin name or the local path to a .gem file
-  # @return [Boolean] true if the plugin is a local .gem file
-  def self.plugin_file?(plugin)
-    (plugin =~ /\.gem$/ && File.file?(plugin))
-  end
-
-  # retrieve gem specs for all or specified name valid logstash plugins locally installed
-  # @param name [String] specific plugin name to find or nil for all plungins
-  # @return [Array<Gem::Specification>] all local logstash plugin gem specs
-  def self.find_plugins_gem_specs(name = nil)
-    specs = name ? Gem::Specification.find_all_by_name(name) : Gem::Specification.find_all
-    specs.select{|spec| logstash_plugin_gem_spec?(spec)}
-  end
-
-  # list of all locally installed plugins specs specified in the Gemfile.
-  # note that an installed plugin dependecies like codecs will not be listed, only those
-  # specifically listed in the Gemfile.
-  # @param gemfile [LogStash::Gemfile] the gemfile to validate against
-  # @return [Array<Gem::Specification>] list of plugin specs
-  def self.all_installed_plugins_gem_specs(gemfile)
-    # we start form the installed gemspecs so we can verify the metadata for valid logstash plugin
-    # then filter out those not included in the Gemfile
-    find_plugins_gem_specs.select{|spec| !!gemfile.find(spec.name)}
-  end
-
-  # @param plugin [String] plugin name
-  # @param gemfile [LogStash::Gemfile] the gemfile to validate against
-  # @return [Boolean] true if the plugin is an installed logstash plugin and spefificed in the Gemfile
-  def self.installed_plugin?(plugin, gemfile)
-    !!gemfile.find(plugin) && find_plugins_gem_specs(plugin).any?
-  end
-
-  # @param plugin_list [Array] array of [plugin name, version] tuples
-  # @return [Array] array of [plugin name, version, ...] tuples when duplciate names have been merged and non duplicate version requirements added
-  def self.merge_duplicates(plugin_list)
-
-    # quick & dirty naive dedup for now
-    # TODO: properly merge versions requirements
-    plugin_list.uniq(&:first)
   end
 end

--- a/lib/pluginmanager/validators.rb
+++ b/lib/pluginmanager/validators.rb
@@ -1,0 +1,42 @@
+# encoding: utf-8
+require "gems"
+require "pluginmanager/validators/version"
+
+module LogStash
+  module PluginManager
+
+    module Validations
+
+      def self.included(klass)
+        klass.class_eval do
+          extend ClassMethods
+        end
+      end
+
+      module ClassMethods
+
+        def filter_plugin_with(options)
+          validators << lambda do |plugin|
+            !options.any? { |key| plugin.options.has_key?(key) }
+          end
+        end
+
+        def validate_plugin_property_with(attribute, criteria={})
+          if :version == attribute
+            validators << validate_with(LogStash::PluginManager::VersionValidators, criteria)
+          end
+        end
+
+        def validate_with(klass, criteria)
+          klass.validates(criteria)
+        end
+
+        def validators
+          @@validators ||= []
+        end
+
+      end
+    end
+
+  end
+end

--- a/lib/pluginmanager/validators/version.rb
+++ b/lib/pluginmanager/validators/version.rb
@@ -1,0 +1,31 @@
+# encoding: utf-8
+require "gems"
+
+module LogStash
+  module PluginManager
+    class VersionValidators
+
+      def self.validates(criteria={})
+        check_for_major_version if criteria[:notice] == :major
+      end
+
+      # validate if there is any major version update so then we can ask the user if he is
+      # sure to update or not.
+      # @param plugin [String] A plugin name
+      # @return [Boolean] true if updating to a major version is ok, false otherwise
+      def self.check_for_major_version
+        lambda do |plugin|
+          latest_version  = ::Gems.versions(plugin.name)[0]['number'].split(".")
+          current_version = ::Gem::Specification.find_by_name(plugin.name).version.version.split(".")
+          if (latest_version[0].to_i > current_version[0].to_i)
+            ## warn if users want to continue
+            puts("You are updating #{plugin.name} to a new version #{latest_version.join('.')}, which may not be compatible with #{current_version.join('.')}. are you sure you want to proceed (Y/N)?")
+            return ( "y" == STDIN.gets.strip.downcase ? true : false)
+          end
+          true
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
**This PR is work in progress**

This PR aims to apply some pending refactorings and internal cleanups for the plugin manager. For now this provide a solution for:
- Refactor of `pluginmanger/utils.rb` #3746, including changes to the way namespaces are created to be using a more ruby style.
- Update validations, relates to #3744 by introduced a more formal way of filtering/validating input for update plugins and actually other inputs too.

Relates to: #3821
