### PR TITLE
Non Oracle Javas are all detected as 'good'

### DIFF
--- a/lib/logstash/util/java_version.rb
+++ b/lib/logstash/util/java_version.rb
@@ -53,6 +53,7 @@ module LogStash::Util::JavaVersion
     return nil if version_string.nil?
 
     parsed = parse_java_version(version_string)
+    return nil unless parsed
 
     if parsed[:major] == 1 && parsed[:minor] == 7 && parsed[:patch] == 0 && parsed[:update] < 51
       true

--- a/lib/logstash/util/java_version.rb
+++ b/lib/logstash/util/java_version.rb
@@ -53,7 +53,7 @@ module LogStash::Util::JavaVersion
     return nil if version_string.nil?
 
     parsed = parse_java_version(version_string)
-    return nil unless parsed
+    return false unless parsed
 
     if parsed[:major] == 1 && parsed[:minor] == 7 && parsed[:patch] == 0 && parsed[:update] < 51
       true

--- a/spec/util/java_version_spec.rb
+++ b/spec/util/java_version_spec.rb
@@ -27,6 +27,10 @@ describe "LogStash::Util::JavaVersion" do
     expect(mod.bad_java_version?("1.8.0-beta")).to be_falsey
   end
 
+  it "should not mark non-standard javas as bad (IBM JDK)" do
+    expect(mod.bad_java_version?("pwi3270sr9fp10-20150708_01 (SR9 FP10)")).to be_falsey
+  end
+
   describe "parsing java versions" do
     it "should return nil on a nil version" do
       expect(mod.parse_java_version(nil)).to be_nil


### PR DESCRIPTION
Fixes #3677 (for real this time). This patch ensures that java versions that are unparseable (IBM JDK) still run.