### PR TITLE
Exclude pre releases when checking for update in the plugins manager

### DIFF
--- a/lib/pluginmanager/update.rb
+++ b/lib/pluginmanager/update.rb
@@ -44,7 +44,7 @@ class LogStash::PluginManager::Update < LogStash::PluginManager::Command
     filtered_plugins = plugins.map { |plugin| gemfile.find(plugin) }
       .compact
       .reject { |plugin| REJECTED_OPTIONS.any? { |key| plugin.options.has_key?(key) } }
-      .select { |plugin| validate_major_version(plugin.name) }
+      .select { |plugin| validates_version(plugin.name) }
       .each   { |plugin| gemfile.update(plugin.name) }
 
     # force a disk sync before running bundler
@@ -67,16 +67,8 @@ class LogStash::PluginManager::Update < LogStash::PluginManager::Command
 
   # validate if there is any major version update so then we can ask the user if he is
   # sure to update or not.
-  def validate_major_version(plugin)
-    require "gems"
-    latest_version  = Gems.versions(plugin)[0]['number'].split(".")
-    current_version = Gem::Specification.find_by_name(plugin).version.version.split(".")
-    if (latest_version[0].to_i > current_version[0].to_i)
-      ## warn if users want to continue
-      puts("You are updating #{plugin} to a new version #{latest_version.join('.')}, which may not be compatible with #{current_version.join('.')}. are you sure you want to proceed (Y/N)?")
-      return ( "y" == STDIN.gets.strip.downcase ? true : false)
-    end
-    true
+  def validates_version(plugin)
+    LogStash::PluginManager.update_to_major_version?(plugin)
   end
 
   # create list of plugins to update

--- a/lib/pluginmanager/util.rb
+++ b/lib/pluginmanager/util.rb
@@ -37,6 +37,34 @@ module LogStash::PluginManager
     end
   end
 
+  # Fetch latest version information as in rubygems
+  # @param [String] The plugin name
+  # @param [Hash] Set of available options when fetching the information
+  # @option options [Boolean] :pre Include pre release versions in the search (default: false)
+  # @return [Hash] The plugin version information as returned by rubygems
+  def self.fetch_latest_version_info(plugin, options={})
+    require "gems"
+    exclude_prereleases =  options.fetch(:pre, false)
+    versions = Gems.versions(plugin)
+    versions = versions.select { |version| !version["prerelease"] } if !exclude_prereleases
+    versions.first
+  end
+
+  # Let's you decide to update to the last version of a plugin if this is a major version
+  # @param [String] A plugin name
+  # @return [Boolean] True in case the update is moving forward, false otherwise
+  def self.update_to_major_version?(plugin_name)
+    plugin_version  = fetch_latest_version_info(plugin_name)
+    latest_version  = plugin_version['number'].split(".")
+    current_version = Gem::Specification.find_by_name(plugin_name).version.version.split(".")
+    if (latest_version[0].to_i > current_version[0].to_i)
+      ## warn if users want to continue
+      puts("You are updating #{plugin_name} to a new version #{latest_version.join('.')}, which may not be compatible with #{current_version.join('.')}. are you sure you want to proceed (Y/N)?")
+      return ( "y" == STDIN.gets.strip.downcase ? true : false)
+    end
+    true
+  end
+
   # @param spec [Gem::Specification] plugin gem specification
   # @return [Boolean] true if this spec is for an installable logstash plugin
   def self.logstash_plugin_gem_spec?(spec)

--- a/spec/pluginmanager/util_spec.rb
+++ b/spec/pluginmanager/util_spec.rb
@@ -1,0 +1,42 @@
+# encoding: utf-8
+require "spec_helper"
+require "pluginmanager/util"
+require "gems"
+
+describe LogStash::PluginManager do
+
+  let(:plugin_name) { "logstash-output-elasticsearch" }
+
+  let(:version_data) do
+    [ { "authors"=>"Elastic", "built_at"=>"2015-08-11T00:00:00.000Z", "description"=>"Output events to elasticsearch",
+        "downloads_count"=>1638, "metadata"=>{"logstash_group"=>"output", "logstash_plugin"=>"true"}, "number"=>"2.0.0.pre",
+        "summary"=>"Logstash Output to Elasticsearch", "platform"=>"java", "ruby_version"=>">= 0", "prerelease"=>true,
+        "licenses"=>["apache-2.0"], "requirements"=>[], "sha"=>"194b27099c13605a882a3669e2363fdecccaab1de48dd44b0cda648dd5516799"},
+    { "authors"=>"Elastic", "built_at"=>"2015-08-10T00:00:00.000Z", "description"=>"Output events to elasticsearch",
+      "downloads_count"=>1638, "metadata"=>{"logstash_group"=>"output", "logstash_plugin"=>"true"}, "number"=>"1.0.7",
+      "summary"=>"Logstash Output to Elasticsearch", "platform"=>"java", "ruby_version"=>">= 0", "prerelease"=>false,
+      "licenses"=>["apache-2.0"], "requirements"=>[], "sha"=>"194b27099c13605a882a3669e2363fdecccaab1de48dd44b0cda648dd5516799"},
+    { "authors"=>"Elastic", "built_at"=>"2015-08-09T00:00:00.000Z", "description"=>"Output events to elasticsearch",
+      "downloads_count"=>1638, "metadata"=>{"logstash_group"=>"output", "logstash_plugin"=>"true"}, "number"=>"1.0.4",
+      "summary"=>"Logstash Output to Elasticsearch", "platform"=>"java", "ruby_version"=>">= 0", "prerelease"=>false,
+      "licenses"=>["apache-2.0"], "requirements"=>[], "sha"=>"194b27099c13605a882a3669e2363fdecccaab1de48dd44b0cda648dd5516799"} ]
+  end
+
+  before(:each) do
+    allow(Gems).to receive(:versions).with(plugin_name).and_return(version_data)
+  end
+
+  context "fetch plugin info" do
+
+    it "should search for the last version infomation non prerelease" do
+      version_info = LogStash::PluginManager.fetch_latest_version_info(plugin_name)
+      expect(version_info["number"]).to eq("1.0.7")
+    end
+
+
+    it "should search for the last version infomation with prerelease" do
+      version_info = LogStash::PluginManager.fetch_latest_version_info(plugin_name, :pre => true)
+      expect(version_info["number"]).to eq("2.0.0.pre")
+    end
+  end
+end


### PR DESCRIPTION
In the intention to provide a fix for #3818 this PR introduces some changes to exclude pre release versions from the filter/validation routine that's in place for the update process. This follows the actual bundler (out internal packet manager) of dealing with prereleases.

Bundler will always update (using the update command) to the last non prerelease version, in order to install a prerelease version actually the way is to change the name in the Gemfile + running bundler install. This could be archived in our setup by using ```bin/plugin install``` command with the right version (the pre release one)

We could add this to the update command, but __I would not recommend__ that for some reasons:
 * It breaks the bundler way of doing things, and we know, making bundler unhappy makes us unhappy.
 * I kinda understand the reason behind this, updating to a pre release is actually explicit, but throw uninstall/install.

Let me know what do you think :+1: 

/cheers

Fixes #3818 