### PR TITLE
Cleanup ruby-maven and ruby-maven-libs from the artifacts

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -26,6 +26,9 @@ namespace "artifact" do
     @exclude_paths << "**/test/files/slow-xpath.xml"
     @exclude_paths << "**/logstash-*/spec"
     @exclude_paths << "bin/bundle"
+    @exclude_paths << "vendor/jruby/lib/ruby/maven-home/**"
+    @exclude_paths << "vendor/jruby/lib/ruby/gems/shared/gems/ruby-maven*"
+    @exclude_paths << "vendor/jruby/lib/ruby/gems/shared/specifications/default/ruby-maven*"
 
     @exclude_paths
   end


### PR DESCRIPTION
Fixes #3847 

The answer to this is no, we don't need as they are only used by jar-dependencies and we're not using them. We should not cleanup jar-dependencies as is used by other internal dependencies in JRuby.

Size without jars: 

```-rw-r--r--  1 purbon staff  74M Sep  3 15:44 logstash-2.0.0.dev.tar.gz```

With the jars:

``` -rw-r--r-- 1 purbon staff 82M Sep  3 16:10 logstash-2.0.0.dev.tar.gz```
