### PR TITLE
Revert version change to 2.0.0.dev 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 # If you modify this file manually all comments and formatting will be lost.
 
 source "https://rubygems.org"
-gem "logstash-core", "3.0.0.dev", :path => "."
+gem "logstash-core", "2.0.0.dev", :path => "."
 gem "file-dependencies", "0.1.6"
 gem "ci_reporter_rspec", "1.0.0", :group => :development
 gem "simplecov", :group => :development

--- a/lib/logstash/version.rb
+++ b/lib/logstash/version.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 # The version of logstash.
-LOGSTASH_VERSION = "3.0.0.dev"
+LOGSTASH_VERSION = "2.0.0.dev"
 
 # Note to authors: this should not include dashes because 'gem' barfs if
 # you include a dash in the version string.


### PR DESCRIPTION
This is because plugins constraints check fails 

```
ERROR: Installation Aborted, message: Bundler could not find compatible versions for gem "logstash-core":
  In snapshot (Gemfile.lock):
    logstash-core (= 3.0.0.dev)

  In Gemfile:
    logstash-filter-multiline (>= 0) java depends on
      logstash-core (< 2.0.0, >= 1.4.0) java

    logstash-core (= 3.0.0.dev) java
```

Will wait for the mass publish #3846  to make this change.