### PR TITLE
String Interpolation skip the last character

### DIFF
--- a/lib/logstash/string_interpolation.rb
+++ b/lib/logstash/string_interpolation.rb
@@ -46,7 +46,7 @@ module LogStash
         position = match.offset(0).last
       end
 
-      if position < template.size - 1
+      if position < template.size
         nodes << StaticNode.new(template[position..-1])
       end
 

--- a/spec/core/event_spec.rb
+++ b/spec/core/event_spec.rb
@@ -50,6 +50,10 @@ describe LogStash::Event do
         expect(subject.sprintf("%{+%s}")).to eq("1356998400")
       end
 
+      it "should work if there is no fieldref in the string" do
+        expect(subject.sprintf("bonjour")).to eq("bonjour")
+      end
+
       it "should raise error when formatting %{+%s} when @timestamp field is missing" do
         str = "hello-%{+%s}"
         subj = subject.clone

--- a/spec/core/event_spec.rb
+++ b/spec/core/event_spec.rb
@@ -100,6 +100,10 @@ describe LogStash::Event do
         expect(subject.sprintf("%{[j][k3]}")).to eq("{\"4\":\"m\"}")
       end
 
+      it "should not strip last character" do
+        expect(subject.sprintf("%{type}%{message}|")).to eq("sprintfhello world|")
+      end
+
       context "#encoding" do
         it "should return known patterns as UTF-8" do
           expect(subject.sprintf("%{message}").encoding).to eq(Encoding::UTF_8)


### PR DESCRIPTION
This PR fix a problem when doing the interpolation with a string that
did not end with a fieldref but with a character. The interpolation was
ignoring the last character.

Example:
```
"%{type}|" => "syslog"
```

Fixes #3931