### PR TITLE
Remove deprecated config options for 2.0

### DIFF
--- a/lib/logstash/filters/base.rb
+++ b/lib/logstash/filters/base.rb
@@ -183,6 +183,12 @@ class LogStash::Filters::Base < LogStash::Plugin
     end
   end # def filter_matched
 
+  protected
+  def filter?(event)
+    # TODO: noop for now, remove this once we delete this call from all plugins
+    true
+  end # def filter?
+
   public
   def close
     # Nothing to do by default.

--- a/lib/logstash/filters/base.rb
+++ b/lib/logstash/filters/base.rb
@@ -11,6 +11,12 @@ class LogStash::Filters::Base < LogStash::Plugin
 
   config_name "filter"
 
+  config :type, :validate => :string, :default => "", :obsolete => "You can achieve this same behavior with the new conditionals, like: `if [type] == \"sometype\" { %PLUGIN% { ... } }`."
+
+  config :tags, :validate => :array, :default => [], :obsolete => "You can achieve similar behavior with the new conditionals, like: `if \"sometag\" in [tags] { %PLUGIN% { ... } }`"
+
+  config :exclude_tags, :validate => :array, :default => [], :obsolete => "You can achieve similar behavior with the new conditionals, like: `if !(\"sometag\" in [tags]) { %PLUGIN% { ... } }`"
+
   # If this filter is successful, add arbitrary tags to the event.
   # Tags can be dynamic and include parts of the event using the `%{field}`
   # syntax.

--- a/lib/logstash/filters/base.rb
+++ b/lib/logstash/filters/base.rb
@@ -183,40 +183,6 @@ class LogStash::Filters::Base < LogStash::Plugin
     end
   end # def filter_matched
 
-  protected
-  def filter?(event)
-    if !@type.empty?
-      if event["type"] != @type
-        @logger.debug? and @logger.debug("filters/#{self.class.name}: Skipping event because type doesn't match",
-                                         :type=> @type, :event => event)
-        return false
-      end
-    end
-
-    if !@tags.empty?
-      # this filter has only works on events with certain tags,
-      # and this event has no tags.
-      return false if !event["tags"]
-
-      # Is @tags a subset of the event's tags? If not, skip it.
-      if (event["tags"] & @tags).size != @tags.size
-        @logger.debug? and @logger.debug("filters/#{self.class.name}: Skipping event because tags don't match",
-                                         :tags => tags, :event => event)
-        return false
-      end
-    end
-
-    if !@exclude_tags.empty? && event["tags"]
-      if (diff_tags = (event["tags"] & @exclude_tags)).size != 0
-        @logger.debug("filters/#{self.class.name}: Skipping event because tags contains excluded tags:",
-                      :diff_tags => diff_tags, :exclude_tags => @exclude_tags, :event => event)
-        return false
-      end
-    end
-
-    return true
-  end
-
   public
   def close
     # Nothing to do by default.

--- a/lib/logstash/filters/base.rb
+++ b/lib/logstash/filters/base.rb
@@ -11,23 +11,6 @@ class LogStash::Filters::Base < LogStash::Plugin
 
   config_name "filter"
 
-  # Note that all of the specified routing options (`type`,`tags`,`exclude_tags`,`include_fields`,
-  # `exclude_fields`) must be met in order for the event to be handled by the filter.
-
-  # The type to act on. If a type is given, then this filter will only
-  # act on messages with the same type. See any input plugin's `type`
-  # attribute for more.
-  # Optional.
-  config :type, :validate => :string, :default => "", :deprecated => "You can achieve this same behavior with the new conditionals, like: `if [type] == \"sometype\" { %PLUGIN% { ... } }`."
-
-  # Only handle events with all of these tags.
-  # Optional.
-  config :tags, :validate => :array, :default => [], :deprecated => "You can achieve similar behavior with the new conditionals, like: `if \"sometag\" in [tags] { %PLUGIN% { ... } }`"
-
-  # Only handle events without any of these tags.
-  # Optional.
-  config :exclude_tags, :validate => :array, :default => [], :deprecated => "You can achieve similar behavior with the new conditionals, like: `if !(\"sometag\" in [tags]) { %PLUGIN% { ... } }`"
-
   # If this filter is successful, add arbitrary tags to the event.
   # Tags can be dynamic and include parts of the event using the `%{field}`
   # syntax.

--- a/lib/logstash/inputs/base.rb
+++ b/lib/logstash/inputs/base.rb
@@ -26,6 +26,12 @@ class LogStash::Inputs::Base < LogStash::Plugin
   # when sent to another Logstash server.
   config :type, :validate => :string
 
+  config :debug, :validate => :boolean, :default => false, :obsolete => "This setting no longer has any effect. In past releases, it existed, but almost no plugin made use of it."
+
+  config :format, :validate => ["plain", "json", "json_event", "msgpack_event"], :obsolete => "You should use the newer 'codec' setting instead."
+
+  config :charset, :obsolete => "Use the codec setting instead. For example: input { %PLUGIN% { codec => plain { charset => \"UTF-8\" } }"
+
   # The codec used for input data. Input codecs are a convenient method for decoding your data before it enters the input, without needing a separate filter in your Logstash pipeline.
   config :codec, :validate => :codec, :default => "plain"
 

--- a/lib/logstash/inputs/base.rb
+++ b/lib/logstash/inputs/base.rb
@@ -47,25 +47,6 @@ class LogStash::Inputs::Base < LogStash::Plugin
     @stop_called = Concurrent::AtomicBoolean.new(false)
     config_init(params)
     @tags ||= []
-
-    if @charset && @codec.class.get_config.include?("charset")
-      # charset is deprecated on inputs, but provide backwards compatibility
-      # by copying the charset setting into the codec.
-
-      @logger.info("Copying input's charset setting into codec", :input => self, :codec => @codec)
-      charset = @charset
-      @codec.instance_eval { @charset = charset }
-    end
-
-    # Backwards compat for the 'format' setting
-    case @format
-      when "plain"; # do nothing
-      when "json"
-        @codec = LogStash::Plugin.lookup("codec", "json").new
-      when "json_event"
-        @codec = LogStash::Plugin.lookup("codec", "oldlogstashjson").new
-    end
-
   end # def initialize
 
   public

--- a/lib/logstash/inputs/base.rb
+++ b/lib/logstash/inputs/base.rb
@@ -32,6 +32,8 @@ class LogStash::Inputs::Base < LogStash::Plugin
 
   config :charset, :obsolete => "Use the codec setting instead. For example: input { %PLUGIN% { codec => plain { charset => \"UTF-8\" } }"
 
+  config :message_format, :validate => :string, :obsolete => "Setting is no longer valid."
+
   # The codec used for input data. Input codecs are a convenient method for decoding your data before it enters the input, without needing a separate filter in your Logstash pipeline.
   config :codec, :validate => :codec, :default => "plain"
 

--- a/lib/logstash/inputs/base.rb
+++ b/lib/logstash/inputs/base.rb
@@ -26,31 +26,8 @@ class LogStash::Inputs::Base < LogStash::Plugin
   # when sent to another Logstash server.
   config :type, :validate => :string
 
-  config :debug, :validate => :boolean, :default => false, :deprecated => "This setting no longer has any effect. In past releases, it existed, but almost no plugin made use of it."
-
-  # The format of input data (plain, json, json_event)
-  config :format, :validate => ["plain", "json", "json_event", "msgpack_event"], :deprecated => "You should use the newer 'codec' setting instead."
-
   # The codec used for input data. Input codecs are a convenient method for decoding your data before it enters the input, without needing a separate filter in your Logstash pipeline.
   config :codec, :validate => :codec, :default => "plain"
-
-  # The character encoding used in this input. Examples include `UTF-8`
-  # and `cp1252`
-  #
-  # This setting is useful if your log files are in `Latin-1` (aka `cp1252`)
-  # or in another character set other than `UTF-8`.
-  #
-  # This only affects `plain` format logs since json is `UTF-8` already.
-  config :charset, :deprecated => "Use the codec setting instead. For example: input { %PLUGIN% { codec => plain { charset => \"UTF-8\" } }"
-
-  # If format is `json`, an event `sprintf` string to build what
-  # the display `@message` should be given (defaults to the raw JSON).
-  # `sprintf` format strings look like `%{fieldname}`
-  #
-  # If format is `json_event`, ALL fields except for `@type`
-  # are expected to be present. Not receiving all fields
-  # will cause unexpected results.
-  config :message_format, :validate => :string, :deprecated => true
 
   # Add any number of arbitrary tags to your event.
   #

--- a/lib/logstash/outputs/base.rb
+++ b/lib/logstash/outputs/base.rb
@@ -12,20 +12,6 @@ class LogStash::Outputs::Base < LogStash::Plugin
 
   config_name "output"
 
-  # The type to act on. If a type is given, then this output will only
-  # act on messages with the same type. See any input plugin's `type`
-  # attribute for more.
-  # Optional.
-  config :type, :validate => :string, :default => "", :deprecated => "You can achieve this same behavior with the new conditionals, like: `if [type] == \"sometype\" { %PLUGIN% { ... } }`."
-
-  # Only handle events with all of these tags.
-  # Optional.
-  config :tags, :validate => :array, :default => [], :deprecated => "You can achieve similar behavior with the new conditionals, like: `if \"sometag\" in [tags] { %PLUGIN% { ... } }`"
-
-  # Only handle events without any of these tags.
-  # Optional.
-  config :exclude_tags, :validate => :array, :default => [], :deprecated => "You can achieve similar behavior with the new conditionals, like: `if !(\"sometag\" in [tags]) { %PLUGIN% { ... } }`"
-
   # The codec used for output data. Output codecs are a convenient method for encoding your data before it leaves the output, without needing a separate filter in your Logstash pipeline.
   config :codec, :validate => :codec, :default => "plain"
 

--- a/lib/logstash/outputs/base.rb
+++ b/lib/logstash/outputs/base.rb
@@ -12,6 +12,12 @@ class LogStash::Outputs::Base < LogStash::Plugin
 
   config_name "output"
 
+  config :type, :validate => :string, :default => "", :obsolete => "You can achieve this same behavior with the new conditionals, like: `if [type] == \"sometype\" { %PLUGIN% { ... } }`."
+
+  config :tags, :validate => :array, :default => [], :obsolete => "You can achieve similar behavior with the new conditionals, like: `if \"sometag\" in [tags] { %PLUGIN% { ... } }`"
+
+  config :exclude_tags, :validate => :array, :default => [], :obsolete => "You can achieve similar behavior with the new conditionals, like: `if !(\"sometag\" in [tags]) { %PLUGIN% { ... } }`"
+
   # The codec used for output data. Output codecs are a convenient method for encoding your data before it leaves the output, without needing a separate filter in your Logstash pipeline.
   config :codec, :validate => :codec, :default => "plain"
 

--- a/lib/logstash/outputs/base.rb
+++ b/lib/logstash/outputs/base.rb
@@ -78,33 +78,4 @@ class LogStash::Outputs::Base < LogStash::Plugin
     @worker_queue.push(event)
   end
 
-  private
-  def output?(event)
-    if !@type.empty?
-      if event["type"] != @type
-        @logger.debug? and @logger.debug("outputs/#{self.class.name}: Dropping event because type doesn't match",
-                                         :type => @type, :event => event)
-        return false
-      end
-    end
-
-    if !@tags.empty?
-      return false if !event["tags"]
-      if (event["tags"] & @tags).size != @tags.size
-        @logger.debug? and @logger.debug("outputs/#{self.class.name}: Dropping event because tags don't match",
-                                         :tags => @tags, :event => event)
-        return false
-      end
-    end
-
-    if !@exclude_tags.empty? && event["tags"]
-      if (diff_tags = (event["tags"] & @exclude_tags)).size != 0
-        @logger.debug? and @logger.debug("outputs/#{self.class.name}: Dropping event because tags contains excluded tags",
-                                         :diff_tags => diff_tags, :exclude_tags => @exclude_tags, :event => event)
-        return false
-      end
-    end
-
-    return true
-  end
 end # class LogStash::Outputs::Base

--- a/lib/logstash/outputs/base.rb
+++ b/lib/logstash/outputs/base.rb
@@ -78,4 +78,9 @@ class LogStash::Outputs::Base < LogStash::Plugin
     @worker_queue.push(event)
   end
 
+  private
+  def output?(event)
+    # TODO: noop for now, remove this once we delete this call from all plugins
+    true
+  end # def output?
 end # class LogStash::Outputs::Base

--- a/spec/filters/base_spec.rb
+++ b/spec/filters/base_spec.rb
@@ -70,7 +70,6 @@ describe LogStash::Filters::NOOP do
     config <<-CONFIG
     filter {
       noop {
-        type => "noop"
         add_tag => ["test"]
       }
     }
@@ -79,25 +78,19 @@ describe LogStash::Filters::NOOP do
     sample("type" => "noop") do
       insist { subject["tags"] } == ["test"]
     end
-
-    sample("type" => "not_noop") do
-      insist { subject["tags"] }.nil?
-    end
   end
 
   describe "tags parsing with one tag" do
     config <<-CONFIG
     filter {
       noop {
-        type => "noop"
-        tags => ["t1"]
         add_tag => ["test"]
       }
     }
     CONFIG
 
     sample("type" => "noop") do
-      insist { subject["tags"] }.nil?
+      insist { subject["tags"] } == ["test"]
     end
 
     sample("type" => "noop", "tags" => ["t1", "t2"]) do
@@ -109,19 +102,17 @@ describe LogStash::Filters::NOOP do
     config <<-CONFIG
     filter {
       noop {
-        type => "noop"
-        tags => ["t1", "t2"]
         add_tag => ["test"]
       }
     }
     CONFIG
 
     sample("type" => "noop") do
-      insist { subject["tags"] }.nil?
+      insist { subject["tags"] } == ["test"]
     end
 
     sample("type" => "noop", "tags" => ["t1"]) do
-      insist { subject["tags"] } == ["t1"]
+      insist { subject["tags"] } == ["t1", "test"]
     end
 
     sample("type" => "noop", "tags" => ["t1", "t2"]) do
@@ -133,62 +124,10 @@ describe LogStash::Filters::NOOP do
     end
   end
 
-  describe "exclude_tags with 1 tag" do
-    config <<-CONFIG
-    filter {
-      noop {
-        type => "noop"
-        tags => ["t1"]
-        add_tag => ["test"]
-        exclude_tags => ["t2"]
-      }
-    }
-    CONFIG
-
-    sample("type" => "noop") do
-      insist { subject["tags"] }.nil?
-    end
-
-    sample("type" => "noop", "tags" => ["t1"]) do
-      insist { subject["tags"] } == ["t1", "test"]
-    end
-
-    sample("type" => "noop", "tags" => ["t1", "t2"]) do
-      insist { subject["tags"] } == ["t1", "t2"]
-    end
-  end
-
-  describe "exclude_tags with >1 tags" do
-    config <<-CONFIG
-    filter {
-      noop {
-        type => "noop"
-        tags => ["t1"]
-        add_tag => ["test"]
-        exclude_tags => ["t2", "t3"]
-      }
-    }
-    CONFIG
-
-    sample("type" => "noop", "tags" => ["t1", "t2", "t4"]) do
-      insist { subject["tags"] } == ["t1", "t2", "t4"]
-    end
-
-    sample("type" => "noop", "tags" => ["t1", "t3", "t4"]) do
-      insist { subject["tags"] } == ["t1", "t3", "t4"]
-    end
-
-    sample("type" => "noop", "tags" => ["t1", "t4", "t5"]) do
-      insist { subject["tags"] } == ["t1", "t4", "t5", "test"]
-    end
-  end
-
   describe "remove_tag" do
     config <<-CONFIG
     filter {
       noop {
-        type => "noop"
-        tags => ["t1"]
         remove_tag => ["t2", "t3"]
       }
     }
@@ -223,8 +162,6 @@ describe LogStash::Filters::NOOP do
     config <<-CONFIG
     filter {
       noop {
-        type => "noop"
-        tags => ["t1"]
         remove_tag => ["%{blackhole}"]
       }
     }
@@ -245,7 +182,6 @@ describe LogStash::Filters::NOOP do
     config <<-CONFIG
     filter {
       noop {
-        type => "noop"
         remove_field => ["t2", "t3"]
       }
     }
@@ -271,7 +207,6 @@ describe LogStash::Filters::NOOP do
     config <<-CONFIG
     filter {
       noop {
-        type => "noop"
         remove_field => ["[t1][t2]"]
       }
     }
@@ -288,7 +223,6 @@ describe LogStash::Filters::NOOP do
     config <<-CONFIG
     filter {
       noop {
-        type => "noop"
         remove_field => ["[t1][0]"]
       }
     }
@@ -304,7 +238,6 @@ describe LogStash::Filters::NOOP do
     config <<-CONFIG
     filter {
       noop {
-        type => "noop"
         remove_field => ["%{blackhole}"]
       }
     }

--- a/spec/outputs/base_spec.rb
+++ b/spec/outputs/base_spec.rb
@@ -24,24 +24,3 @@ describe "LogStash::Outputs::Base#worker_setup" do
     output.worker_setup
   end
 end
-
-describe "LogStash::Outputs::Base#output?" do
-  it "should filter by type" do
-    output = LogStash::Outputs::NOOP.new("type" => "noop")
-    expect(output.receive(LogStash::Event.new({"type" => "noop"}))).to eq(true)
-    expect(output.receive(LogStash::Event.new({"type" => "not_noop"}))).to eq(false)
-  end
-  
-  it "should filter by tags" do
-    output = LogStash::Outputs::NOOP.new("tags" => ["value", "value2"])
-    expect(output.receive(LogStash::Event.new({"tags" => ["value","value2"]}))).to eq(true)
-    expect(output.receive(LogStash::Event.new({"tags" => ["notvalue"]}))).to eq(false)
-    expect(output.receive(LogStash::Event.new({"tags" => ["value"]}))).to eq(false)
-  end
-
-  it "should exclude by tags" do
-    output = LogStash::Outputs::NOOP.new("exclude_tags" => ["value"])
-    expect(output.receive(LogStash::Event.new({"tags" => ["value"]}))).to eq(false)
-    expect(output.receive(LogStash::Event.new({"tags" => ["notvalue"]}))).to eq(true)
-  end
-end


### PR DESCRIPTION
Will also make docs nicer. This PR is just to get a feel of what it takes to delete existing deprecated stuff from core plugins. there's a lot of core tests that refer this configuration/variables so it may be hairy to check and remove them. Not sure we can do a blind "global search and delete".
