### PR TITLE
update lock file to 2.0.0.snapshot2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 # If you modify this file manually all comments and formatting will be lost.
 
 source "https://rubygems.org"
-gem "logstash-core", "2.0.0.beta1"
+gem "logstash-core", "2.0.0.snapshot2"
 gem "file-dependencies", "0.1.6"
 gem "ci_reporter_rspec", "1.0.0", :group => :development
 gem "simplecov", :group => :development

--- a/Gemfile.jruby-1.9.lock
+++ b/Gemfile.jruby-1.9.lock
@@ -151,9 +151,10 @@ GEM
     logstash-codec-rubydebug (1.0.0)
       awesome_print
       logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-core (2.0.0.beta1-java)
+    logstash-core (2.0.0.snapshot2-java)
       cabin (~> 0.7.0)
       clamp (~> 0.6.5)
+      concurrent-ruby (~> 0.9.1)
       filesize (= 0.0.4)
       gems (~> 0.8.3)
       i18n (= 0.6.9)
@@ -163,13 +164,14 @@ GEM
       stud (~> 0.0.19)
       thread_safe (~> 0.3.5)
       treetop (< 1.5.0)
-    logstash-devutils (0.0.15-java)
+    logstash-devutils (0.0.16-java)
       gem_publisher
       insist (= 1.0.0)
       kramdown
       minitar
       rake
       rspec (~> 3.1.0)
+      rspec-wait
       stud (>= 0.0.20)
     logstash-filter-anonymize (1.0.0)
       logstash-core (>= 1.4.0, < 2.0.0)
@@ -531,6 +533,8 @@ GEM
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
+    rspec-wait (0.0.7)
+      rspec (>= 2.11, < 3.4)
     ruby-maven (3.3.5)
       ruby-maven-libs (~> 3.3.1)
     ruby-maven-libs (3.3.3)
@@ -551,7 +555,7 @@ GEM
     spoon (0.0.4)
       ffi
     statsd-ruby (1.2.0)
-    stud (0.0.21)
+    stud (0.0.22)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
     thor (0.19.1)
@@ -605,7 +609,7 @@ DEPENDENCIES
   logstash-codec-oldlogstashjson
   logstash-codec-plain
   logstash-codec-rubydebug
-  logstash-core (= 2.0.0.beta1)
+  logstash-core (= 2.0.0.snapshot2)
   logstash-devutils (~> 0)
   logstash-filter-anonymize
   logstash-filter-checksum


### PR DESCRIPTION
while the version of core has been updated to snapshot2, the lock files are still depending on beta1