### PR TITLE
Fix 2.0 branch test by updating the Gemfile and the lock file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 # If you modify this file manually all comments and formatting will be lost.
 
 source "https://rubygems.org"
-gem "logstash-core", "2.0.0.beta1"
+gem "logstash-core", "2.0.0.snapshot2"
 gem "file-dependencies", "0.1.6"
 gem "ci_reporter_rspec", "1.0.0", :group => :development
 gem "simplecov", :group => :development

--- a/Gemfile.jruby-1.9.lock
+++ b/Gemfile.jruby-1.9.lock
@@ -8,12 +8,12 @@ GEM
     avl_tree (1.2.1)
       atomic (~> 1.1)
     awesome_print (1.6.1)
-    aws-sdk (2.1.21)
-      aws-sdk-resources (= 2.1.21)
-    aws-sdk-core (2.1.21)
+    aws-sdk (2.1.23)
+      aws-sdk-resources (= 2.1.23)
+    aws-sdk-core (2.1.23)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.1.21)
-      aws-sdk-core (= 2.1.21)
+    aws-sdk-resources (2.1.23)
+      aws-sdk-core (= 2.1.23)
     aws-sdk-v1 (1.66.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
@@ -74,11 +74,6 @@ GEM
       clamp (~> 0.6)
       ffi
       json (>= 1.7.7)
-    ftw (0.0.44)
-      addressable
-      backports (>= 2.6.2)
-      cabin (> 0)
-      http_parser.rb (~> 0.6)
     gelf (1.3.2)
       json
     gelfd (0.2.0)
@@ -86,20 +81,25 @@ GEM
     gems (0.8.3)
     geoip (1.6.1)
     gmetric (0.1.3)
+    hipchat (1.5.2)
+      httparty
+      mimemagic
     hitimes (1.2.3-java)
     http (0.6.4)
       http_parser.rb (~> 0.6.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     http_parser.rb (0.6.0-java)
+    httparty (0.13.7)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
     i18n (0.6.9)
     insist (1.0.0)
-    jar-dependencies (0.2.1)
+    jar-dependencies (0.2.2)
     jls-grok (0.11.2)
       cabin (>= 0.6.0)
     jls-lumberjack (0.0.24)
-    jmespath (1.0.2)
-      multi_json (~> 1.0)
+    jmespath (1.1.3)
     jrjackson (0.2.9)
     jruby-kafka (1.4.0-java)
       jar-dependencies (~> 0)
@@ -107,53 +107,54 @@ GEM
     jruby-win32ole (0.8.5)
     json (1.8.3-java)
     kramdown (1.8.0)
-    logstash-codec-collectd (1.0.1)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-codec-dots (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-codec-edn (1.0.0)
+    logstash-codec-collectd (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-codec-dots (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-codec-edn (2.0.0)
       edn
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-codec-edn_lines (1.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-codec-edn_lines (2.0.0)
       edn
       logstash-codec-line
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-codec-es_bulk (1.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-codec-es_bulk (2.0.0)
       logstash-codec-line
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-codec-fluent (1.0.0-java)
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-codec-fluent (2.0.0-java)
+      logstash-core (~> 2.0.0.snapshot)
       msgpack-jruby
-    logstash-codec-graphite (1.0.0)
+    logstash-codec-graphite (2.0.0)
       logstash-codec-line
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-codec-json (1.0.1)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-codec-json_lines (1.0.1)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-codec-json (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-codec-json_lines (2.0.0)
       logstash-codec-line
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-codec-line (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-codec-msgpack (1.0.0-java)
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-codec-line (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-codec-msgpack (2.0.0-java)
+      logstash-core (~> 2.0.0.snapshot)
       msgpack-jruby
-    logstash-codec-multiline (1.0.0)
+    logstash-codec-multiline (2.0.0)
       jls-grok (~> 0.11.1)
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       logstash-patterns-core
-    logstash-codec-netflow (1.0.0)
+    logstash-codec-netflow (2.0.0)
       bindata (>= 1.5.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-codec-oldlogstashjson (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-codec-plain (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-codec-rubydebug (1.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-codec-oldlogstashjson (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-codec-plain (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-codec-rubydebug (2.0.0)
       awesome_print
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-core (2.0.0.beta1-java)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-core (2.0.0.snapshot2-java)
       cabin (~> 0.7.0)
       clamp (~> 0.6.5)
+      concurrent-ruby (~> 0.9.1)
       filesize (= 0.0.4)
       gems (~> 0.8.3)
       i18n (= 0.6.9)
@@ -163,183 +164,192 @@ GEM
       stud (~> 0.0.19)
       thread_safe (~> 0.3.5)
       treetop (< 1.5.0)
-    logstash-devutils (0.0.15-java)
+    logstash-devutils (0.0.16-java)
       gem_publisher
       insist (= 1.0.0)
       kramdown
       minitar
       rake
       rspec (~> 3.1.0)
+      rspec-wait
       stud (>= 0.0.20)
-    logstash-filter-anonymize (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
+    logstash-filter-anonymize (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       murmurhash3
-    logstash-filter-checksum (1.0.1)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-filter-clone (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-filter-csv (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-filter-date (1.0.0)
+    logstash-filter-checksum (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-filter-clone (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-filter-csv (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-filter-date (2.0.0)
       logstash-codec-json
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       logstash-input-generator
       logstash-output-null
-    logstash-filter-dns (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-filter-drop (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-filter-fingerprint (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
+    logstash-filter-dns (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-filter-drop (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-filter-fingerprint (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       murmurhash3
-    logstash-filter-geoip (1.1.1)
+    logstash-filter-geoip (2.0.0)
       geoip (>= 1.3.2)
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       lru_redux (~> 1.1.0)
-    logstash-filter-grok (1.0.0)
+    logstash-filter-grok (2.0.0)
       jls-grok (~> 0.11.1)
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       logstash-patterns-core
-    logstash-filter-json (1.0.1)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-filter-kv (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-filter-metrics (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
+    logstash-filter-json (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-filter-kv (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-filter-metrics (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       metriks
       thread_safe
-    logstash-filter-multiline (1.0.0)
+    logstash-filter-multiline (2.0.0)
       jls-grok (~> 0.11.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       logstash-filter-mutate
       logstash-patterns-core
-    logstash-filter-mutate (1.0.2)
-      logstash-core (>= 1.4.0, < 2.0.0)
+    logstash-filter-mutate (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       logstash-filter-grok
       logstash-patterns-core
-    logstash-filter-ruby (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
+    logstash-filter-ruby (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       logstash-filter-date
-    logstash-filter-sleep (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-filter-split (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-filter-syslog_pri (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-filter-throttle (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-filter-urldecode (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-filter-useragent (1.1.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
+    logstash-filter-sleep (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-filter-split (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-filter-syslog_pri (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-filter-throttle (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-filter-urldecode (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-filter-useragent (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       lru_redux (~> 1.1.0)
       user_agent_parser (>= 2.0.0)
-    logstash-filter-uuid (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-filter-xml (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
+    logstash-filter-uuid (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-filter-xml (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       nokogiri
       xml-simple
-    logstash-input-couchdb_changes (1.0.0)
+    logstash-input-couchdb_changes (2.0.0)
       json
       logstash-codec-plain
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-input-elasticsearch (1.0.2)
+      logstash-core (~> 2.0.0.snapshot)
+      stud (>= 0.0.22)
+    logstash-input-elasticsearch (2.0.0)
       elasticsearch (~> 1.0, >= 1.0.6)
       logstash-codec-json
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-input-eventlog (1.0.0-java)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-input-eventlog (2.0.0-java)
       jruby-win32ole
       logstash-codec-plain
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-input-exec (1.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-input-exec (2.0.0)
       logstash-codec-plain
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-input-file (1.0.1)
+      logstash-core (~> 2.0.0.snapshot)
+      stud (~> 0.0.22)
+    logstash-input-file (2.0.0)
       addressable
       filewatch (~> 0.6, >= 0.6.5)
       logstash-codec-plain
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-input-ganglia (1.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-input-ganglia (2.0.0)
       logstash-codec-plain
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-input-gelf (1.0.0)
-      gelf (= 1.3.2)
+      logstash-core (~> 2.0.0.snapshot)
+      stud (~> 0.0.22)
+    logstash-input-gelf (2.0.0)
       gelfd (= 0.2.0)
       logstash-codec-plain
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-input-generator (1.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+      stud (~> 0.0.22)
+    logstash-input-generator (2.0.0)
       logstash-codec-plain
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-input-graphite (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-input-graphite (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       logstash-input-tcp
-    logstash-input-heartbeat (1.0.0)
+    logstash-input-heartbeat (2.0.0)
       logstash-codec-plain
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       stud
-    logstash-input-http (1.0.3)
+    logstash-input-http (2.0.0)
       logstash-codec-plain
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       puma (~> 2.11.3)
       stud
-    logstash-input-imap (1.0.0)
+    logstash-input-imap (2.0.0)
       logstash-codec-plain
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       mail
-      stud
-    logstash-input-irc (1.0.0)
+      stud (~> 0.0.22)
+    logstash-input-irc (2.0.0)
       cinch
       logstash-codec-plain
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-input-kafka (1.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+      stud (~> 0.0.22)
+    logstash-input-kafka (2.0.0)
       jruby-kafka (>= 1.2.0, < 2.0.0)
       logstash-codec-json
       logstash-codec-plain
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-input-log4j (1.0.0-java)
+      logstash-core (~> 2.0.0.snapshot)
+      stud (>= 0.0.22, < 0.1.0)
+    logstash-input-log4j (2.0.0-java)
       logstash-codec-plain
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
     logstash-input-lumberjack (1.0.5)
       concurrent-ruby
       jls-lumberjack (>= 0.0.24)
       logstash-codec-plain
       logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-input-pipe (1.0.0)
+    logstash-input-pipe (2.0.0)
       logstash-codec-plain
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-input-rabbitmq (1.1.1-java)
+      logstash-core (~> 2.0.0.snapshot)
+      stud (~> 0.0.22)
+    logstash-input-rabbitmq (3.0.0)
       logstash-codec-json
-      logstash-core (>= 1.4.0, < 2.0.0)
-      march_hare (~> 2.12.0)
-    logstash-input-redis (1.0.3)
+      logstash-core (~> 2.0.0.snapshot)
+      logstash-mixin-rabbitmq_connection (>= 1.0.0, < 2.0.0)
+    logstash-input-redis (2.0.0)
       logstash-codec-json
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       redis
-    logstash-input-s3 (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
+    logstash-input-s3 (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       logstash-mixin-aws
       stud (~> 0.0.18)
-    logstash-input-snmptrap (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
+    logstash-input-snmptrap (2.0.0)
+      logstash-codec-plain
+      logstash-core (~> 2.0.0.snapshot)
       snmp
-    logstash-input-sqs (1.1.0)
+    logstash-input-sqs (2.0.0)
       logstash-codec-json
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       logstash-mixin-aws (>= 1.0.0)
-    logstash-input-stdin (1.0.0)
+    logstash-input-stdin (2.0.0)
       concurrent-ruby
       logstash-codec-json
       logstash-codec-json_lines
       logstash-codec-line
       logstash-codec-plain
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-input-syslog (1.0.1)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-input-syslog (2.0.0)
       concurrent-ruby
       logstash-codec-plain
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       logstash-filter-date
       logstash-filter-grok
+      stud (>= 0.0.22, < 0.1.0)
       thread_safe
     logstash-input-tcp (1.0.0)
       logstash-codec-json
@@ -347,145 +357,158 @@ GEM
       logstash-codec-line
       logstash-codec-plain
       logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-input-twitter (1.0.1)
-      logstash-core (>= 1.4.0, < 2.0.0)
+    logstash-input-twitter (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+      stud (>= 0.0.22, < 0.1)
       twitter (= 5.12.0)
     logstash-input-udp (1.0.0)
       logstash-codec-plain
       logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-input-unix (1.0.0)
+    logstash-input-unix (2.0.0)
       logstash-codec-line
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-input-xmpp (1.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-input-xmpp (2.0.0)
       logstash-codec-plain
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       xmpp4r (= 0.5)
-    logstash-input-zeromq (1.0.0)
+    logstash-input-zeromq (2.0.0)
       ffi-rzmq (~> 2.0.4)
       logstash-codec-json
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-mixin-aws (1.0.1)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-mixin-aws (2.0.0)
       aws-sdk (~> 2.1.0)
       aws-sdk-v1 (>= 1.61.0)
       logstash-codec-plain
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
     logstash-mixin-http_client (1.0.2)
       logstash-codec-plain
       logstash-core (>= 1.4.0, < 2.0.0)
       manticore (>= 0.4.1)
-    logstash-output-cloudwatch (1.0.0)
-      aws-sdk
+    logstash-mixin-rabbitmq_connection (1.0.0-java)
       logstash-core (>= 1.4.0, < 2.0.0)
+      march_hare (~> 2.11.0)
+      stud (~> 0.0.22)
+    logstash-output-cloudwatch (2.0.0)
+      aws-sdk
+      logstash-core (~> 2.0.0.snapshot)
       logstash-mixin-aws
       rufus-scheduler (~> 3.0.9)
-    logstash-output-csv (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
+    logstash-output-csv (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       logstash-filter-json
       logstash-output-file
-    logstash-output-elasticsearch (2.0.0.beta6-java)
+    logstash-output-elasticsearch (1.0.7-java)
       cabin (~> 0.6)
       concurrent-ruby
-      elasticsearch (~> 1.0, >= 1.0.13)
+      elasticsearch (~> 1.0, >= 1.0.10)
       logstash-core (>= 1.4.0, < 2.0.0)
       manticore (~> 0.4.2)
       stud (~> 0.0, >= 0.0.17)
-    logstash-output-email (2.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
+    logstash-output-email (3.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       mail (~> 2.6.0, >= 2.6.3)
-    logstash-output-exec (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-output-file (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
+    logstash-output-exec (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-output-file (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       logstash-input-generator
-    logstash-output-ganglia (1.0.0)
+    logstash-output-ganglia (2.0.0)
       gmetric (= 0.1.3)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-output-gelf (1.0.0)
+      logstash-codec-plain
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-output-gelf (2.0.0)
       gelf (= 1.3.2)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-output-graphite (1.0.2)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-output-hipchat (1.0.0)
-      ftw (~> 0.0.40)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-output-http (1.1.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-codec-plain
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-output-graphite (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-output-hipchat (3.0.0)
+      hipchat
+      logstash-codec-plain
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-output-http (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       logstash-mixin-http_client (>= 1.0.1, < 2.0.0)
-    logstash-output-irc (1.0.0)
+    logstash-output-irc (2.0.0)
       cinch
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-output-juggernaut (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-codec-plain
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-output-juggernaut (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       redis
-    logstash-output-kafka (2.0.0.beta.1)
-      jruby-kafka (>= 1.4.0, < 2.0.0)
+    logstash-output-kafka (1.0.0)
+      jruby-kafka (>= 1.1.0, < 2.0.0)
       logstash-codec-json
       logstash-codec-plain
       logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-output-lumberjack (1.0.2)
+    logstash-output-lumberjack (2.0.0)
       jls-lumberjack (>= 0.0.24)
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       stud
-    logstash-output-nagios (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-output-nagios_nsca (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-output-null (1.0.1)
+    logstash-output-nagios (2.0.0)
       logstash-codec-plain
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-output-opentsdb (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-output-pagerduty (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-output-pipe (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-output-rabbitmq (1.1.2-java)
-      logstash-core (>= 1.4.0, < 2.0.0)
-      march_hare (~> 2.12.0)
-    logstash-output-redis (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-output-nagios_nsca (2.0.0)
+      logstash-codec-plain
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-output-null (2.0.0)
+      logstash-codec-plain
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-output-opentsdb (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-output-pagerduty (2.0.0)
+      logstash-codec-plain
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-output-pipe (2.0.0)
+      logstash-codec-plain
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-output-rabbitmq (3.0.0-java)
+      logstash-core (~> 2.0.0.snapshot)
+      logstash-mixin-rabbitmq_connection (>= 1.0.0, < 2.0.0)
+    logstash-output-redis (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       redis
       stud
-    logstash-output-s3 (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
+    logstash-output-s3 (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       logstash-mixin-aws
-      stud (~> 0.0.18)
-    logstash-output-sns (2.0.1)
-      logstash-core (>= 1.4.0, < 2.0.0)
+      stud (~> 0.0.22)
+    logstash-output-sns (3.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       logstash-mixin-aws (>= 1.0.0)
-    logstash-output-sqs (1.0.0)
+    logstash-output-sqs (2.0.0)
       aws-sdk
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       logstash-mixin-aws
       stud
-    logstash-output-statsd (1.1.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
+    logstash-output-statsd (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       logstash-input-generator
       statsd-ruby (= 1.2.0)
-    logstash-output-stdout (1.0.0)
+    logstash-output-stdout (2.0.0)
       logstash-codec-line
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-output-tcp (1.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-output-tcp (2.0.0)
       logstash-codec-json
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       stud
-    logstash-output-udp (1.0.0)
+    logstash-output-udp (2.0.0)
       logstash-codec-json
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-output-xmpp (1.0.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-output-xmpp (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
       xmpp4r (= 0.5)
-    logstash-output-zeromq (1.0.0)
+    logstash-output-zeromq (2.0.0)
       ffi-rzmq (~> 2.0.4)
       logstash-codec-json
-      logstash-core (>= 1.4.0, < 2.0.0)
-    logstash-patterns-core (0.4.0)
-      logstash-core (>= 1.4.0, < 2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
+    logstash-patterns-core (2.0.0)
+      logstash-core (~> 2.0.0.snapshot)
     lru_redux (1.1.0)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     manticore (0.4.4-java)
-    march_hare (2.12.0-java)
+    march_hare (2.11.0-java)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     method_source (0.8.2)
@@ -494,9 +517,11 @@ GEM
       avl_tree (~> 1.2.0)
       hitimes (~> 1.1)
     mime-types (2.6.2)
+    mimemagic (0.3.0)
     minitar (0.5.4)
     msgpack-jruby (1.4.1-java)
     multi_json (1.11.2)
+    multi_xml (0.5.5)
     multipart-post (2.0.0)
     murmurhash3 (0.1.6-java)
     naught (1.1.0)
@@ -531,6 +556,8 @@ GEM
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
+    rspec-wait (0.0.7)
+      rspec (>= 2.11, < 3.4)
     ruby-maven (3.3.5)
       ruby-maven-libs (~> 3.3.1)
     ruby-maven-libs (3.3.3)
@@ -551,7 +578,7 @@ GEM
     spoon (0.0.4)
       ffi
     statsd-ruby (1.2.0)
-    stud (0.0.21)
+    stud (0.0.22)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
     thor (0.19.1)
@@ -586,7 +613,7 @@ DEPENDENCIES
   ci_reporter_rspec (= 1.0.0)
   coveralls
   file-dependencies (= 0.1.6)
-  flores (~> 0.0.6)
+  flores
   fpm (~> 1.3.3)
   gems (~> 0.8.3)
   logstash-codec-collectd
@@ -605,8 +632,8 @@ DEPENDENCIES
   logstash-codec-oldlogstashjson
   logstash-codec-plain
   logstash-codec-rubydebug
-  logstash-core (= 2.0.0.beta1)
-  logstash-devutils (~> 0)
+  logstash-core (= 2.0.0.snapshot2)
+  logstash-devutils
   logstash-filter-anonymize
   logstash-filter-checksum
   logstash-filter-clone
@@ -697,4 +724,4 @@ DEPENDENCIES
   rspec (~> 3.1.0)
   rubyzip (~> 1.1.7)
   simplecov
-  stud (~> 0.0.21)
+  stud (~> 0.0.19)


### PR DESCRIPTION
This fix #3946 by updating the Gemfile and the lock file to fetch the last released plugins.

Issues are explained at https://github.com/elastic/logstash/issues/3946#issuecomment-142888343

## Important

This PR should only be merged and tested with 2.0 branch.