### PR TITLE
New plugin config attribute :obsolete

### DIFF
--- a/docs/asciidoc/static/include/pluginbody.asciidoc
+++ b/docs/asciidoc/static/include/pluginbody.asciidoc
@@ -439,7 +439,7 @@ endif::encode_method[]
 ==== Configuration Parameters
 [source,ruby]
 ----------------------------------
-  config :variable_name, :validate => :variable_type, :default => "Default value", :required => boolean, :deprecated => boolean
+  config :variable_name, :validate => :variable_type, :default => "Default value", :required => boolean, :deprecated => boolean, :obsolete => string
 ----------------------------------
 The configuration, or `config` section allows you to define as many (or as few)
 parameters as are needed to enable Logstash to process events.
@@ -457,6 +457,7 @@ will become a valid boolean in the config.  This coercion works for the
 * `:required` - whether or not this parameter is mandatory (a Boolean `true` or
 `false`)
 * `:deprecated` - informational (also a Boolean `true` or `false`)
+* `:obsolete` - used to declare that a given setting has been removed and is no longer functioning. The idea is to provide an informed upgrade path to users who are still using a now-removed setting.
 
 ==== Plugin Methods
 

--- a/docs/asciidocgen.rb
+++ b/docs/asciidocgen.rb
@@ -216,6 +216,7 @@ class LogStashConfigAsciiDocGenerator
     description = @class_description
 
     klass.get_config.each do |name, settings|
+      next if settings[:obsolete]
       @attributes[name].merge!(settings)
       default = klass.get_default(name)
       unless default.nil?

--- a/docs/extending/index.md
+++ b/docs/extending/index.md
@@ -46,8 +46,8 @@ so:
 
 The name of the option is specified, here `:host` and then the
 attributes of the option. They can include `:validate`, `:default`,
-`:required` (a Boolean `true` or `false`), and `:deprecated` (also a
-Boolean).  
+`:required` (a Boolean `true` or `false`), `:deprecated` (also a
+Boolean), and `:obsolete` (a String value).  
  
 ## Inputs
 

--- a/lib/logstash/config/mixin.rb
+++ b/lib/logstash/config/mixin.rb
@@ -76,6 +76,13 @@ module LogStash::Config::Mixin
                      "about this, please visit the #logstash channel " +
                      "on freenode irc.", :name => name, :plugin => self)
       end
+      if opts && opts[:obsolete]
+        extra = opts[:obsolete].is_a?(String) ? opts[:obsolete] : ""
+        extra.gsub!("%PLUGIN%", self.class.config_name)
+        raise LogStash::ConfigurationError,
+          I18n.t("logstash.agent.configuration.obsolete", :name => name,
+                 :plugin => self.class.config_name, :extra => extra)
+      end
     end
 
     # Set defaults from 'config :foo, :default => somevalue'

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -77,6 +77,10 @@ en:
         use to validate logstash's configuration before you choose
         to restart a running system.
       configuration:
+        obsolete: >-
+          The setting `%{name}` in plugin `%{plugin}` is obsolete and is no
+          longer available. %{extra} If you have any questions about this, you
+          are invited to visit https://discuss.elastic.co/c/logstash and ask.
         file-not-found: |-
           No config files found: %{path}
           Can you make sure this path is a logstash config file?

--- a/spec/core/config_mixin_spec.rb
+++ b/spec/core/config_mixin_spec.rb
@@ -97,4 +97,30 @@ describe LogStash::Config::Mixin do
       expect(clone.password.value).to(be == secret)
     end
   end
+
+  describe "obsolete settings" do
+    let(:plugin_class) do
+      Class.new(LogStash::Inputs::Base) do
+        include LogStash::Config::Mixin
+        config_name "example"
+        config :foo, :validate => :string, :obsolete => "This feature was removed."
+      end
+    end
+
+    context "when using an obsolete setting" do
+      it "should cause a configuration error" do
+        expect {
+          plugin_class.new("foo" => "hello")
+        }.to raise_error(LogStash::ConfigurationError)
+      end
+    end
+
+    context "when not using an obsolete setting" do
+      it "should not cause a configuration error" do
+        expect {
+          plugin_class.new({})
+        }.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
An obsolete setting is one that will cause a configuration error if it
is used.

The purpose of `:obsolete` is to help inform users when a setting has
been completely removed. The lifecycle of a plugin setting is now 4
phases: available, deprecated, obsolete, deleted.

Available is the default, and deprecated remains the same as it was
(logging a warning). The new obsolete will cause a configuration error
if such a setting is used. Then later, we can finally delete the config
setting after it's been obsolete for some time.

Fixes #3977