### PR TITLE
bump logstash-output-rabbitmq due to gem yank

### DIFF
--- a/Gemfile.jruby-1.9.lock
+++ b/Gemfile.jruby-1.9.lock
@@ -462,7 +462,7 @@ GEM
     logstash-output-pipe (2.0.0)
       logstash-codec-plain
       logstash-core (~> 2.0.0.snapshot)
-    logstash-output-rabbitmq (3.0.0-java)
+    logstash-output-rabbitmq (3.0.1-java)
       logstash-core (~> 2.0.0.snapshot)
       logstash-mixin-rabbitmq_connection (>= 1.0.0, < 2.0.0)
     logstash-output-redis (2.0.0)


### PR DESCRIPTION
logstash-output-rabbitmq 3.0.0 was [yanked](https://rubygems.org/gems/logstash-output-rabbitmq/versions) so this needs to be updated:

```
~/projects/logstash (git)-[2.0] % rake test:install-default
WARN: Unresolved specs during Gem::Specification.reset:
      ffi (>= 0)
WARN: Clearing out unresolved specs.
Please report a bug if this causes problems.
Invoking bundler install...
Plugin not found, aborting
rake aborted!
Bundler::GemNotFound: Could not find logstash-output-rabbitmq-3.0.0-java in any of the sources
```