### PR TITLE
Default to TLSv1.2

### DIFF
--- a/lib/logstash/patches/stronger_openssl_defaults.rb
+++ b/lib/logstash/patches/stronger_openssl_defaults.rb
@@ -61,7 +61,7 @@ class OpenSSL::SSL::SSLContext
   # For more details see: https://github.com/elastic/logstash/issues/3657
   remove_const(:DEFAULT_PARAMS) if const_defined?(:DEFAULT_PARAMS)
   DEFAULT_PARAMS = {
-    :ssl_version => "SSLv23",
+    :ssl_version => :TLSv1_2,
     :ciphers => MOZILLA_INTERMEDIATE_CIPHERS,
     :options => __default_options # Not a constant because it's computed at start-time.
   }

--- a/spec/logstash/patches_spec.rb
+++ b/spec/logstash/patches_spec.rb
@@ -85,6 +85,14 @@ describe "OpenSSL defaults" do
         ssl_client = OpenSSL::SSL::SSLSocket.new(socket, client_context)
         expect { ssl_client.connect }.not_to raise_error
       end
+
+      it "should connect with TLS 1.2" do
+        client_context = OpenSSL::SSL::SSLContext.new(:TLSv1_2)
+        socket = TCPSocket.new(server_address, server_port)
+        ssl_client = OpenSSL::SSL::SSLSocket.new(socket, client_context)
+        ssl_client.connect
+        expect(ssl_client.ssl_version).to eq "TLSv1.2"
+      end
     end
   end
 end


### PR DESCRIPTION
Change the monkeypatch to use TLSv1.2 as the new default.
Added a SSL test to explicitely check for the SSL_VERSION.

Fixes #3955