### PR TITLE
Fix master after we published all the 2.0 plugins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 # If you modify this file manually all comments and formatting will be lost.
 
 source "https://rubygems.org"
-gem "logstash-core", "2.0.0.dev", :path => "."
+gem "logstash-core", "2.0.0.snapshot100", :path => "."
 gem "file-dependencies", "0.1.6"
 gem "ci_reporter_rspec", "1.0.0", :group => :development
 gem "simplecov", :group => :development

--- a/Gemfile.jruby-1.9.lock
+++ b/Gemfile.jruby-1.9.lock
@@ -1,9 +1,10 @@
 PATH
   remote: .
   specs:
-    logstash-core (2.0.0.dev-java)
+    logstash-core (2.0.0.snapshot100-java)
       cabin (~> 0.7.0)
       clamp (~> 0.6.5)
+      concurrent-ruby (~> 0.9.1)
       filesize (= 0.0.4)
       gems (~> 0.8.3)
       i18n (= 0.6.9)
@@ -20,8 +21,8 @@ GEM
     addressable (2.3.8)
     arr-pm (0.0.10)
       cabin (> 0)
-    backports (3.6.4)
-    benchmark-ips (2.2.0)
+    backports (3.6.6)
+    benchmark-ips (2.3.0)
     builder (3.2.2)
     cabin (0.7.1)
     childprocess (0.5.6)
@@ -33,7 +34,8 @@ GEM
       rspec (>= 2.14, < 4)
     clamp (0.6.5)
     coderay (1.1.0)
-    coveralls (0.8.1)
+    concurrent-ruby (0.9.1-java)
+    coveralls (0.8.3)
       json (~> 1.8)
       rest-client (>= 1.6.8, < 2)
       simplecov (~> 0.10.0)
@@ -45,7 +47,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.8-java)
+    ffi (1.9.10-java)
     file-dependencies (0.1.6)
       minitar
     filesize (0.0.4)
@@ -65,25 +67,26 @@ GEM
     i18n (0.6.9)
     insist (1.0.0)
     jrjackson (0.2.9)
-    json (1.8.2-java)
-    kramdown (1.8.0)
-    logstash-devutils (0.0.15-java)
+    json (1.8.3-java)
+    kramdown (1.9.0)
+    logstash-devutils (0.0.16-java)
       gem_publisher
       insist (= 1.0.0)
       kramdown
       minitar
       rake
       rspec (~> 3.1.0)
+      rspec-wait
       stud (>= 0.0.20)
     method_source (0.8.2)
-    mime-types (2.5)
+    mime-types (2.6.2)
     minitar (0.5.4)
     multipart-post (2.0.0)
     netrc (0.10.3)
     octokit (3.8.0)
       sawyer (~> 0.6.0, >= 0.5.3)
     polyglot (0.3.5)
-    pry (0.10.1-java)
+    pry (0.10.2-java)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
@@ -105,6 +108,8 @@ GEM
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
+    rspec-wait (0.0.7)
+      rspec (>= 2.11, < 3.4)
     rubyzip (1.1.7)
     sawyer (0.6.0)
       addressable (~> 2.3.5)
@@ -117,12 +122,12 @@ GEM
     slop (3.6.0)
     spoon (0.0.4)
       ffi
-    stud (0.0.21)
-    term-ansicolor (1.3.0)
+    stud (0.0.22)
+    term-ansicolor (1.3.2)
       tins (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5-java)
-    tins (1.5.1)
+    tins (1.6.0)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -139,7 +144,7 @@ DEPENDENCIES
   flores (~> 0.0.6)
   fpm (~> 1.3.3)
   gems (~> 0.8.3)
-  logstash-core (= 2.0.0.dev)!
+  logstash-core (= 2.0.0.snapshot100)!
   logstash-devutils (~> 0.0.15)
   octokit (= 3.8.0)
   rspec (~> 3.1.0)

--- a/lib/logstash/version.rb
+++ b/lib/logstash/version.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 # The version of logstash.
-LOGSTASH_VERSION = "2.0.0.dev"
+LOGSTASH_VERSION = "2.0.0.snapshot100"
 
 # Note to authors: this should not include dashes because 'gem' barfs if
 # you include a dash in the version string.

--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -78,7 +78,6 @@ module LogStash
       logstash-output-cloudwatch
       logstash-output-csv
       logstash-output-elasticsearch
-      logstash-output-elasticsearch_http
       logstash-output-email
       logstash-output-exec
       logstash-output-file


### PR DESCRIPTION
Today we can't install any 2.0 plugins on master because of the logstash-core constraint in plugin's gemspec

```
s.add_runtime_dependency "logstash-core", "~> 2.0.0.snapshot"
```

This `~` allows only snapshot versions. This is a stop-gap for now so we can get tests running on master. After the beta2 we will be changing the constraint to ` > 2.0.0` and do a mass update, which will allow us to make master's version `3.0.0.dev`. 

This PR will un-hose the master branch