### PR TITLE
Allow TLSv1.2 for Lumberjack or TCP input connections

### DIFF
--- a/lib/logstash/patches/stronger_openssl_defaults.rb
+++ b/lib/logstash/patches/stronger_openssl_defaults.rb
@@ -61,7 +61,7 @@ class OpenSSL::SSL::SSLContext
   # For more details see: https://github.com/elastic/logstash/issues/3657
   remove_const(:DEFAULT_PARAMS) if const_defined?(:DEFAULT_PARAMS)
   DEFAULT_PARAMS = {
-    :ssl_version => "SSLv23",
+    :ssl_version => "TLS",
     :ciphers => MOZILLA_INTERMEDIATE_CIPHERS,
     :options => __default_options # Not a constant because it's computed at start-time.
   }

--- a/logstash-core.gemspec
+++ b/logstash-core.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "filesize", "0.0.4" #(MIT license) for :bytes config validator
   gem.add_runtime_dependency "gems", "~> 0.8.3"  #(MIT license)
   gem.add_runtime_dependency "concurrent-ruby", "~> 0.9.1"
+  gem.add_runtime_dependency "jruby-openssl", ">= 0.9.11" # Required to support TLSv1.2
 
   # TODO(sissel): Treetop 1.5.x doesn't seem to work well, but I haven't
   # investigated what the cause might be. -Jordan


### PR DESCRIPTION
This patch requires the use of the latest version of `jruby-openssl`
which support TLSv1.2. This PRs changes the monkeypatch to specify to
set the `ssl_version` to `TLS` which allow support of TLSv1, TLSv1.1 and
TLSv1.2.

Fixes #3955