### PR TITLE
Remove deprecated config options for 2.0

### DIFF
--- a/lib/logstash/config/mixin.rb
+++ b/lib/logstash/config/mixin.rb
@@ -110,6 +110,16 @@ module LogStash::Config::Mixin
         I18n.t("logstash.agent.configuration.invalid_plugin_settings")
     end
 
+    # We remove any config options marked as obsolete,
+    # no code should be associated to them and their values should not bleed
+    # to the plugin context.
+    #
+    # This need to be done after fetching the options from the parents classed
+    params.reject! do |name, value|
+      opts = self.class.get_config[name]
+      opts.include?(:obsolete)
+    end
+
     # set instance variables like '@foo'  for each config value given.
     params.each do |key, value|
       next if key[0, 1] == "@"

--- a/lib/logstash/filters/base.rb
+++ b/lib/logstash/filters/base.rb
@@ -11,22 +11,11 @@ class LogStash::Filters::Base < LogStash::Plugin
 
   config_name "filter"
 
-  # Note that all of the specified routing options (`type`,`tags`,`exclude_tags`,`include_fields`,
-  # `exclude_fields`) must be met in order for the event to be handled by the filter.
+  config :type, :validate => :string, :default => "", :obsolete => "You can achieve this same behavior with the new conditionals, like: `if [type] == \"sometype\" { %PLUGIN% { ... } }`."
 
-  # The type to act on. If a type is given, then this filter will only
-  # act on messages with the same type. See any input plugin's `type`
-  # attribute for more.
-  # Optional.
-  config :type, :validate => :string, :default => "", :deprecated => "You can achieve this same behavior with the new conditionals, like: `if [type] == \"sometype\" { %PLUGIN% { ... } }`."
+  config :tags, :validate => :array, :default => [], :obsolete => "You can achieve similar behavior with the new conditionals, like: `if \"sometag\" in [tags] { %PLUGIN% { ... } }`"
 
-  # Only handle events with all of these tags.
-  # Optional.
-  config :tags, :validate => :array, :default => [], :deprecated => "You can achieve similar behavior with the new conditionals, like: `if \"sometag\" in [tags] { %PLUGIN% { ... } }`"
-
-  # Only handle events without any of these tags.
-  # Optional.
-  config :exclude_tags, :validate => :array, :default => [], :deprecated => "You can achieve similar behavior with the new conditionals, like: `if !(\"sometag\" in [tags]) { %PLUGIN% { ... } }`"
+  config :exclude_tags, :validate => :array, :default => [], :obsolete => "You can achieve similar behavior with the new conditionals, like: `if !(\"sometag\" in [tags]) { %PLUGIN% { ... } }`"
 
   # If this filter is successful, add arbitrary tags to the event.
   # Tags can be dynamic and include parts of the event using the `%{field}`
@@ -202,37 +191,9 @@ class LogStash::Filters::Base < LogStash::Plugin
 
   protected
   def filter?(event)
-    if !@type.empty?
-      if event["type"] != @type
-        @logger.debug? and @logger.debug("filters/#{self.class.name}: Skipping event because type doesn't match",
-                                         :type=> @type, :event => event)
-        return false
-      end
-    end
-
-    if !@tags.empty?
-      # this filter has only works on events with certain tags,
-      # and this event has no tags.
-      return false if !event["tags"]
-
-      # Is @tags a subset of the event's tags? If not, skip it.
-      if (event["tags"] & @tags).size != @tags.size
-        @logger.debug? and @logger.debug("filters/#{self.class.name}: Skipping event because tags don't match",
-                                         :tags => tags, :event => event)
-        return false
-      end
-    end
-
-    if !@exclude_tags.empty? && event["tags"]
-      if (diff_tags = (event["tags"] & @exclude_tags)).size != 0
-        @logger.debug("filters/#{self.class.name}: Skipping event because tags contains excluded tags:",
-                      :diff_tags => diff_tags, :exclude_tags => @exclude_tags, :event => event)
-        return false
-      end
-    end
-
-    return true
-  end
+    # TODO: noop for now, remove this once we delete this call from all plugins
+    true
+  end # def filter?
 
   public
   def close

--- a/lib/logstash/filters/base.rb
+++ b/lib/logstash/filters/base.rb
@@ -15,7 +15,7 @@ class LogStash::Filters::Base < LogStash::Plugin
 
   config :tags, :validate => :array, :default => [], :obsolete => "You can achieve similar behavior with the new conditionals, like: `if \"sometag\" in [tags] { %PLUGIN% { ... } }`"
 
-  config :exclude_tags, :validate => :array, :default => [], :obsolete => "You can achieve similar behavior with the new conditionals, like: `if !(\"sometag\" in [tags]) { %PLUGIN% { ... } }`"
+  config :exclude_tags, :validate => :array, :default => [], :obsolete => "You can achieve similar behavior with the new conditionals, like: `if (\"sometag\" not in [tags]) { %PLUGIN% { ... } }`"
 
   # If this filter is successful, add arbitrary tags to the event.
   # Tags can be dynamic and include parts of the event using the `%{field}`

--- a/lib/logstash/outputs/base.rb
+++ b/lib/logstash/outputs/base.rb
@@ -16,7 +16,7 @@ class LogStash::Outputs::Base < LogStash::Plugin
 
   config :tags, :validate => :array, :default => [], :obsolete => "You can achieve similar behavior with the new conditionals, like: `if \"sometag\" in [tags] { %PLUGIN% { ... } }`"
 
-  config :exclude_tags, :validate => :array, :default => [], :obsolete => "You can achieve similar behavior with the new conditionals, like: `if !(\"sometag\" in [tags]) { %PLUGIN% { ... } }`"
+  config :exclude_tags, :validate => :array, :default => [], :obsolete => "You can achieve similar behavior with the new conditionals, like: `if (\"sometag\" not in [tags]) { %PLUGIN% { ... } }`"
 
   # The codec used for output data. Output codecs are a convenient method for encoding your data before it leaves the output, without needing a separate filter in your Logstash pipeline.
   config :codec, :validate => :codec, :default => "plain"

--- a/lib/logstash/outputs/base.rb
+++ b/lib/logstash/outputs/base.rb
@@ -12,19 +12,11 @@ class LogStash::Outputs::Base < LogStash::Plugin
 
   config_name "output"
 
-  # The type to act on. If a type is given, then this output will only
-  # act on messages with the same type. See any input plugin's `type`
-  # attribute for more.
-  # Optional.
-  config :type, :validate => :string, :default => "", :deprecated => "You can achieve this same behavior with the new conditionals, like: `if [type] == \"sometype\" { %PLUGIN% { ... } }`."
+  config :type, :validate => :string, :default => "", :obsolete => "You can achieve this same behavior with the new conditionals, like: `if [type] == \"sometype\" { %PLUGIN% { ... } }`."
 
-  # Only handle events with all of these tags.
-  # Optional.
-  config :tags, :validate => :array, :default => [], :deprecated => "You can achieve similar behavior with the new conditionals, like: `if \"sometag\" in [tags] { %PLUGIN% { ... } }`"
+  config :tags, :validate => :array, :default => [], :obsolete => "You can achieve similar behavior with the new conditionals, like: `if \"sometag\" in [tags] { %PLUGIN% { ... } }`"
 
-  # Only handle events without any of these tags.
-  # Optional.
-  config :exclude_tags, :validate => :array, :default => [], :deprecated => "You can achieve similar behavior with the new conditionals, like: `if !(\"sometag\" in [tags]) { %PLUGIN% { ... } }`"
+  config :exclude_tags, :validate => :array, :default => [], :obsolete => "You can achieve similar behavior with the new conditionals, like: `if !(\"sometag\" in [tags]) { %PLUGIN% { ... } }`"
 
   # The codec used for output data. Output codecs are a convenient method for encoding your data before it leaves the output, without needing a separate filter in your Logstash pipeline.
   config :codec, :validate => :codec, :default => "plain"
@@ -94,31 +86,7 @@ class LogStash::Outputs::Base < LogStash::Plugin
 
   private
   def output?(event)
-    if !@type.empty?
-      if event["type"] != @type
-        @logger.debug? and @logger.debug("outputs/#{self.class.name}: Dropping event because type doesn't match",
-                                         :type => @type, :event => event)
-        return false
-      end
-    end
-
-    if !@tags.empty?
-      return false if !event["tags"]
-      if (event["tags"] & @tags).size != @tags.size
-        @logger.debug? and @logger.debug("outputs/#{self.class.name}: Dropping event because tags don't match",
-                                         :tags => @tags, :event => event)
-        return false
-      end
-    end
-
-    if !@exclude_tags.empty? && event["tags"]
-      if (diff_tags = (event["tags"] & @exclude_tags)).size != 0
-        @logger.debug? and @logger.debug("outputs/#{self.class.name}: Dropping event because tags contains excluded tags",
-                                         :diff_tags => diff_tags, :exclude_tags => @exclude_tags, :event => event)
-        return false
-      end
-    end
-
-    return true
-  end
+    # TODO: noop for now, remove this once we delete this call from all plugins
+    true
+  end # def output?
 end # class LogStash::Outputs::Base

--- a/spec/filters/base_spec.rb
+++ b/spec/filters/base_spec.rb
@@ -70,7 +70,6 @@ describe LogStash::Filters::NOOP do
     config <<-CONFIG
     filter {
       noop {
-        type => "noop"
         add_tag => ["test"]
       }
     }
@@ -79,25 +78,19 @@ describe LogStash::Filters::NOOP do
     sample("type" => "noop") do
       insist { subject["tags"] } == ["test"]
     end
-
-    sample("type" => "not_noop") do
-      insist { subject["tags"] }.nil?
-    end
   end
 
   describe "tags parsing with one tag" do
     config <<-CONFIG
     filter {
       noop {
-        type => "noop"
-        tags => ["t1"]
         add_tag => ["test"]
       }
     }
     CONFIG
 
     sample("type" => "noop") do
-      insist { subject["tags"] }.nil?
+      insist { subject["tags"] } == ["test"]
     end
 
     sample("type" => "noop", "tags" => ["t1", "t2"]) do
@@ -109,19 +102,17 @@ describe LogStash::Filters::NOOP do
     config <<-CONFIG
     filter {
       noop {
-        type => "noop"
-        tags => ["t1", "t2"]
         add_tag => ["test"]
       }
     }
     CONFIG
 
     sample("type" => "noop") do
-      insist { subject["tags"] }.nil?
+      insist { subject["tags"] } == ["test"]
     end
 
     sample("type" => "noop", "tags" => ["t1"]) do
-      insist { subject["tags"] } == ["t1"]
+      insist { subject["tags"] } == ["t1", "test"]
     end
 
     sample("type" => "noop", "tags" => ["t1", "t2"]) do
@@ -133,62 +124,10 @@ describe LogStash::Filters::NOOP do
     end
   end
 
-  describe "exclude_tags with 1 tag" do
-    config <<-CONFIG
-    filter {
-      noop {
-        type => "noop"
-        tags => ["t1"]
-        add_tag => ["test"]
-        exclude_tags => ["t2"]
-      }
-    }
-    CONFIG
-
-    sample("type" => "noop") do
-      insist { subject["tags"] }.nil?
-    end
-
-    sample("type" => "noop", "tags" => ["t1"]) do
-      insist { subject["tags"] } == ["t1", "test"]
-    end
-
-    sample("type" => "noop", "tags" => ["t1", "t2"]) do
-      insist { subject["tags"] } == ["t1", "t2"]
-    end
-  end
-
-  describe "exclude_tags with >1 tags" do
-    config <<-CONFIG
-    filter {
-      noop {
-        type => "noop"
-        tags => ["t1"]
-        add_tag => ["test"]
-        exclude_tags => ["t2", "t3"]
-      }
-    }
-    CONFIG
-
-    sample("type" => "noop", "tags" => ["t1", "t2", "t4"]) do
-      insist { subject["tags"] } == ["t1", "t2", "t4"]
-    end
-
-    sample("type" => "noop", "tags" => ["t1", "t3", "t4"]) do
-      insist { subject["tags"] } == ["t1", "t3", "t4"]
-    end
-
-    sample("type" => "noop", "tags" => ["t1", "t4", "t5"]) do
-      insist { subject["tags"] } == ["t1", "t4", "t5", "test"]
-    end
-  end
-
   describe "remove_tag" do
     config <<-CONFIG
     filter {
       noop {
-        type => "noop"
-        tags => ["t1"]
         remove_tag => ["t2", "t3"]
       }
     }
@@ -223,8 +162,6 @@ describe LogStash::Filters::NOOP do
     config <<-CONFIG
     filter {
       noop {
-        type => "noop"
-        tags => ["t1"]
         remove_tag => ["%{blackhole}"]
       }
     }
@@ -245,7 +182,6 @@ describe LogStash::Filters::NOOP do
     config <<-CONFIG
     filter {
       noop {
-        type => "noop"
         remove_field => ["t2", "t3"]
       }
     }
@@ -271,7 +207,6 @@ describe LogStash::Filters::NOOP do
     config <<-CONFIG
     filter {
       noop {
-        type => "noop"
         remove_field => ["[t1][t2]"]
       }
     }
@@ -288,7 +223,6 @@ describe LogStash::Filters::NOOP do
     config <<-CONFIG
     filter {
       noop {
-        type => "noop"
         remove_field => ["[t1][0]"]
       }
     }
@@ -304,7 +238,6 @@ describe LogStash::Filters::NOOP do
     config <<-CONFIG
     filter {
       noop {
-        type => "noop"
         remove_field => ["%{blackhole}"]
       }
     }

--- a/spec/outputs/base_spec.rb
+++ b/spec/outputs/base_spec.rb
@@ -24,24 +24,3 @@ describe "LogStash::Outputs::Base#worker_setup" do
     output.worker_setup
   end
 end
-
-describe "LogStash::Outputs::Base#output?" do
-  it "should filter by type" do
-    output = LogStash::Outputs::NOOP.new("type" => "noop")
-    expect(output.receive(LogStash::Event.new({"type" => "noop"}))).to eq(true)
-    expect(output.receive(LogStash::Event.new({"type" => "not_noop"}))).to eq(false)
-  end
-  
-  it "should filter by tags" do
-    output = LogStash::Outputs::NOOP.new("tags" => ["value", "value2"])
-    expect(output.receive(LogStash::Event.new({"tags" => ["value","value2"]}))).to eq(true)
-    expect(output.receive(LogStash::Event.new({"tags" => ["notvalue"]}))).to eq(false)
-    expect(output.receive(LogStash::Event.new({"tags" => ["value"]}))).to eq(false)
-  end
-
-  it "should exclude by tags" do
-    output = LogStash::Outputs::NOOP.new("exclude_tags" => ["value"])
-    expect(output.receive(LogStash::Event.new({"tags" => ["value"]}))).to eq(false)
-    expect(output.receive(LogStash::Event.new({"tags" => ["notvalue"]}))).to eq(true)
-  end
-end


### PR DESCRIPTION
Two small problems with the `obsolete` field.

1) We can use `Plugin#params` to retrieve the option hash, the params method should not return the `obsolete` options. Lets say that you use `#params` method to create a new instance of the plugin, the new instance validation will fails even if the original option hash did not contain any options marked as obsolete. Since we don't have any context of a `dirty options`, where a user actually use that key, it's easier to not return any obsoletes values.

2) Also we were defining the obsolete instance value with `instance_variable_set`


The `#params` method was only used in the context of a password test.

Ref: #3950