### PR TITLE
Use packages.elastic.co instead

### DIFF
--- a/docs/asciidoc/static/repositories.asciidoc
+++ b/docs/asciidoc/static/repositories.asciidoc
@@ -24,14 +24,14 @@ Download and install the Public Signing Key:
 
 [source,sh]
 --------------------------------------------------
-wget -qO - https://packages.elasticsearch.org/GPG-KEY-elasticsearch | sudo apt-key add -
+wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
 --------------------------------------------------
 
 Add the repository definition to your `/etc/apt/sources.list` file:
 
 ["source","sh",subs="attributes,callouts"]
 --------------------------------------------------
-echo "deb http://packages.elasticsearch.org/logstash/{branch}/debian stable main" | sudo tee -a /etc/apt/sources.list
+echo "deb http://packages.elastic.co/logstash/{branch}/debian stable main" | sudo tee -a /etc/apt/sources.list
 --------------------------------------------------
 
 [WARNING]
@@ -62,7 +62,7 @@ Download and install the public signing key:
 
 [source,sh]
 --------------------------------------------------
-rpm --import https://packages.elasticsearch.org/GPG-KEY-elasticsearch
+rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch
 --------------------------------------------------
 
 Add the following in your `/etc/yum.repos.d/` directory
@@ -72,9 +72,9 @@ in a file with a `.repo` suffix, for example `logstash.repo`
 --------------------------------------------------
 [logstash-{branch}]
 name=Logstash repository for {branch}.x packages
-baseurl=http://packages.elasticsearch.org/logstash/{branch}/centos
+baseurl=http://packages.elastic.co/logstash/{branch}/centos
 gpgcheck=1
-gpgkey=http://packages.elasticsearch.org/GPG-KEY-elasticsearch
+gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
 enabled=1
 --------------------------------------------------
 


### PR DESCRIPTION
packages.elastic.co uses the same bucket as packages.elasticsearch.org.  We can use this now.