### PR TITLE
Change how we set the max heap size

### DIFF
--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -3,7 +3,7 @@ LOGSTASH_HOME=$(cd `dirname $0`/..; pwd)
 export LOGSTASH_HOME
 
 # Defaults you can override with environment variables
-LS_HEAP_SIZE="${LS_HEAP_SIZE:=500m}"
+LS_HEAP_SIZE="${LS_HEAP_SIZE:=1g}"
 
 setup_java() {
   if [ -z "$JAVACMD" ] ; then

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -18,15 +18,11 @@ REM setup_java()
 if not defined JAVA_HOME goto missing_java_home
 REM ***** JAVA options *****
 
-if "%LS_MIN_MEM%" == "" (
-set LS_MIN_MEM=256m
+if "%LS_HEAP_SIZE%" == "" (
+set LS_HEAP_SIZE=1g
 )
 
-if "%LS_MAX_MEM%" == "" (
-set LS_MAX_MEM=1g
-)
-
-set JAVA_OPTS=%JAVA_OPTS% -Xms%LS_MIN_MEM% -Xmx%LS_MAX_MEM%
+set JAVA_OPTS=%JAVA_OPTS% -Xmx%LS_HEAP_SIZE%
 
 REM Enable aggressive optimizations in the JVM
 REM    - Disabled by default as it might cause the JVM to crash


### PR DESCRIPTION
This PR change the name of the variable to set to change the maximum
heap size on window to `LS_HEAP_SIZE` this replace the LS_MIN_MEM and
LS_MAX_MEM option.

Also We change the default size of the heap from 500m to 1g

Fixes #3134 