### PR TITLE
Fix doc generation for obsolete settings

### DIFF
--- a/docs/asciidocgen.rb
+++ b/docs/asciidocgen.rb
@@ -216,7 +216,6 @@ class LogStashConfigAsciiDocGenerator
     description = @class_description
 
     klass.get_config.each do |name, settings|
-      next if settings[:obsolete]
       @attributes[name].merge!(settings)
       default = klass.get_default(name)
       unless default.nil?

--- a/docs/plugin-doc.asciidoc.erb
+++ b/docs/plugin-doc.asciidoc.erb
@@ -28,6 +28,7 @@ This plugin has no configuration options.
 
 <% sorted_attributes.each do |name, config| -%>
 <%
+     next if config[:obsolete]
      if name.is_a?(Regexp)
        name = "/" + name.to_s.gsub(/^\(\?-mix:/, "").gsub(/\)$/, "") + "/"
        is_regexp = true

--- a/docs/plugin-synopsis.asciidoc.erb
+++ b/docs/plugin-synopsis.asciidoc.erb
@@ -27,6 +27,7 @@ Available configuration options:
 |=======================================================================
 |Setting |Input type|Required|Default value
 <% sorted_attributes.each do |name, config|
+   next if config[:obsolete]
    next if config[:deprecated]
    if config[:validate].is_a?(Array)
      annotation = "|<<string,string>>, one of `#{config[:validate].inspect}`"


### PR DESCRIPTION
We introduced `obsolete` in #3977 which means we need to remove these obsolete configs from docs. Previous fix was broken, this one properly removes configs which are obsolete. See https://www.elastic.co/guide/en/logstash/2.0/plugins-outputs-elasticsearch.html

New docs pushed to elastic.co