### PR TITLE
WIP: Add stream identity support to LS

### DIFF
--- a/lib/logstash/codecs/identity_map_codec.rb
+++ b/lib/logstash/codecs/identity_map_codec.rb
@@ -1,0 +1,176 @@
+# encoding: utf-8
+require "logstash/namespace"
+require "concurrent"
+
+# This class is a Codec duck type
+# Using Composition, it maps from a stream identity to
+# a cloned codec instance via the same API as a Codec
+
+module LogStash module Codecs class IdentityMapCodec
+  # subclass of Exception, LS has more than limit (100) active streams
+  class IdentityMapUpperLimitException < Exception; end
+
+  module EightyPercentWarning
+    extend self
+    def visit(imc)
+      current_size, limit = imc.current_size_and_limit
+      return if current_size < (limit * 0.8)
+      imc.logger.warn("IdentityMapCodec has reached 80% capacity",
+        :current_size => current_size, :upper_limit => limit)
+    end
+  end
+
+  module UpperLimitReached
+    extend self
+    def visit(imc)
+      current_size, limit = imc.current_size_and_limit
+      return if current_size < limit
+      current_size, limit = imc.map_cleanup
+      return if current_size < limit
+      imc.logger.error("IdentityMapCodec has reached 100% capacity",
+          :current_size => current_size, :upper_limit => limit)
+      raise IdentityMapUpperLimitException.new
+    end
+  end
+
+  class MapCleaner
+    def initialize(imc, interval)
+      @running = true
+      @imc, @interval = imc, interval
+    end
+
+    def run
+      @thread = Thread.new(@imc) do |imc|
+        loop do
+          sleep @interval
+          break if !@running
+          imc.map_cleanup
+        end
+      end
+      self
+    end
+
+    def stop
+      @running = false
+      @thread.wakeup
+    end
+  end
+
+  MAX_IDENTITIES = 100
+  EVICT_TIMEOUT = 60 * 60 * 4 # 4 hours
+  CLEANER_INTERVAL = 60 * 5 # 5 minutes
+
+  attr_reader :identity_map, :usage_map
+  attr_accessor :base_codec, :logger, :cleaner
+
+  def initialize(codec, logger)
+    @base_codec = codec
+    @base_values = [codec]
+    @identity_map = Hash.new &method(:codec_builder)
+    # @identity_map = Concurrent::Hash.new &method(:codec_builder)
+    @usage_map = Hash.new
+    # @usage_map = Concurrent::Hash.new
+    @logger = logger
+    @max_identities = MAX_IDENTITIES
+    @evict_timeout = EVICT_TIMEOUT
+    @cleaner = MapCleaner.new(self, CLEANER_INTERVAL).run
+  end
+
+  def max_identities(max)
+    @max_identities = max.to_i.abs
+    self
+  end
+
+  def evict_timeout(timeout)
+    @evict_timeout = timeout.to_i.abs
+    self
+  end
+
+  def cleaner_interval(interval)
+    @cleaner.stop
+    @cleaner = MapCleaner.new(self, interval.to_i.abs).run
+    self
+  end
+
+  def stream_codec(identity)
+    return base_codec if identity.nil?
+    track_identity_usage(identity)
+    identity_map[identity]
+  end
+
+  def decode(data, identity = nil, &block)
+    stream_codec(identity).decode(data, &block)
+  end
+
+  alias_method :<<, :decode
+
+  def encode(event, identity = nil)
+    stream_codec(identity).encode(event)
+  end
+
+  # this method should not be called from
+  # the input or the pipeline
+  def flush(&block)
+    map_values.each do |codec|
+      #let ruby do its default args thing
+      block.nil? ? codec.flush : codec.flush(&block)
+    end
+  end
+
+  def close()
+    cleaner.stop
+    map_values.each(&:close)
+  end
+
+  def map_values
+    no_streams? ? @base_values : identity_map.values
+  end
+
+  def max_limit
+    @max_identities
+  end
+
+  def size
+    identity_map.size
+  end
+
+  # support cleaning of stale codecs
+  def map_cleanup
+    cut_off = Time.now.to_i
+    candidates, rest = usage_map.partition {|identity, timeout| timeout <= cut_off }
+    candidates.each do |identity, timeout|
+      identity_map.delete(identity).flush
+      usage_map.delete(identity)
+    end
+    current_size_and_limit
+  end
+
+  def current_size_and_limit
+    [size, max_limit]
+  end
+
+  private
+
+  def track_identity_usage(identity)
+    check_map_limits
+    usage_map.store(identity, eviction_timestamp)
+  end
+
+  def eviction_timestamp
+    Time.now.to_i + @evict_timeout
+  end
+
+  def check_map_limits
+    UpperLimitReached.visit(self)
+    EightyPercentWarning.visit(self)
+  end
+
+  def codec_builder(hash, k)
+    codec = hash.empty? ? @base_codec : @base_codec.clone
+    hash.store(k, codec)
+  end
+
+  def no_streams?
+    identity_map.empty?
+  end
+end end end

--- a/spec/codecs/identity_map_codec_spec.rb
+++ b/spec/codecs/identity_map_codec_spec.rb
@@ -1,0 +1,207 @@
+# encoding: utf-8
+require "spec_helper"
+
+require "logstash/codecs/identity_map_codec"
+
+class IdentityMapCodecTracer
+  def initialize() @tracer = []; end
+  def clone() self.class.new; end
+  def decode(data) @tracer.push [:decode, data]; end
+  def encode(event) @tracer.push [:encode, event]; end
+  def flush(&block) @tracer.push [:flush, true]; end
+  def close() @tracer.push [:close, true]; end
+
+  def trace_for(symbol)
+    params = @tracer.assoc(symbol)
+    params.nil? ? false : params.last
+  end
+end
+
+class LogTracer
+  def initialize() @tracer = []; end
+  def warn(*args) @tracer.push [:warn, args]; end
+  def error(*args) @tracer.push [:error, args]; end
+
+  def trace_for(symbol)
+    params = @tracer.assoc(symbol)
+    params.nil? ? false : params.last
+  end
+end
+
+describe LogStash::Codecs::IdentityMapCodec do
+  let(:codec)   { IdentityMapCodecTracer.new }
+  let(:logger)  { LogTracer.new }
+  let(:demuxer) { described_class.new(codec, logger) }
+  let(:stream1) { "stream-a" }
+  let(:codec1)  { demuxer.stream_codec(stream1) }
+  let(:arg1)    { "data-a" }
+
+  after do
+    codec.close
+  end
+
+  describe "operating without stream identity" do
+    let(:stream1) { nil }
+
+    it "transparently refers to the original codec" do
+      expect(codec).to eql(codec1)
+    end
+  end
+
+  describe "operating with stream identity" do
+
+    before { demuxer.decode(arg1, stream1) }
+
+    it "the first identity refers to the original codec" do
+      expect(codec).to eql(codec1)
+    end
+  end
+
+  describe "#decode" do
+    context "when no identity is used" do
+      let(:stream1) { nil }
+
+      it "calls the method on the original codec" do
+        demuxer.decode(arg1, stream1)
+
+        expect(codec.trace_for(:decode)).to eq(arg1)
+      end
+    end
+
+    context "when multiple identities are used" do
+      let(:stream2) { "stream-b" }
+      let(:codec2) { demuxer.stream_codec(stream2) }
+      let(:arg2)   { "data-b" }
+
+      it "calls the method on the appropriate codec" do
+        demuxer.decode(arg1, stream1)
+        demuxer.decode(arg2, stream2)
+
+        expect(codec1.trace_for(:decode)).to eq(arg1)
+        expect(codec2.trace_for(:decode)).to eq(arg2)
+      end
+    end
+  end
+
+  describe "#encode" do
+    context "when no identity is used" do
+      let(:stream1) { nil }
+      let(:arg1) { LogStash::Event.new({"type" => "file"}) }
+
+      it "calls the method on the original codec" do
+        demuxer.encode(arg1, stream1)
+
+        expect(codec.trace_for(:encode)).to eq(arg1)
+      end
+    end
+
+    context "when multiple identities are used" do
+      let(:stream2) { "stream-b" }
+      let(:codec2) { demuxer.stream_codec(stream2) }
+      let(:arg2)   { LogStash::Event.new({"type" => "file"}) }
+
+      it "calls the method on the appropriate codec" do
+        demuxer.encode(arg1, stream1)
+        demuxer.encode(arg2, stream2)
+
+        expect(codec1.trace_for(:encode)).to eq(arg1)
+        expect(codec2.trace_for(:encode)).to eq(arg2)
+      end
+    end
+  end
+
+  describe "#close" do
+    context "when no identity is used" do
+      before do
+        demuxer.decode(arg1)
+      end
+
+      it "calls the method on the original codec" do
+        demuxer.close
+        expect(codec.trace_for(:close)).to be_truthy
+      end
+    end
+
+    context "when multiple identities are used" do
+      let(:stream2) { "stream-b" }
+      let(:codec2) { demuxer.stream_codec(stream2) }
+      let(:arg2)   { LogStash::Event.new({"type" => "file"}) }
+
+      before do
+        demuxer.decode(arg1, stream1)
+        demuxer.decode(arg2, stream2)
+      end
+
+      it "calls the method on all codecs" do
+        demuxer.close
+
+        expect(codec1.trace_for(:close)).to be_truthy
+        expect(codec2.trace_for(:close)).to be_truthy
+      end
+    end
+  end
+
+  describe "over capacity protection" do
+    let(:demuxer) { described_class.new(codec, logger).max_identities(limit) }
+
+    context "when capacity at 80% or higher" do
+      let(:limit) { 10 }
+
+      it "a warning is logged" do
+        limit.pred.times do |i|
+          demuxer.decode(Object.new, "stream#{i}")
+        end
+
+        expect(logger.trace_for(:warn).first).to match %r|has reached 80% capacity|
+      end
+    end
+
+    context "when capacity is exceeded" do
+      let(:limit) { 2 }
+      let(:error_class) { LogStash::Codecs::IdentityMapCodec::IdentityMapUpperLimitException }
+
+      it "an exception is raised" do
+        limit.times do |i|
+          demuxer.decode(Object.new, "stream#{i}")
+        end
+        expect { demuxer.decode(Object.new, "stream4") }.to raise_error(error_class)
+      end
+
+      context "initially but some streams are idle and can be evicted" do
+        let(:demuxer) { described_class.new(codec, logger).max_identities(limit).evict_timeout(1) }
+
+        it "an exception is NOT raised" do
+          demuxer.decode(Object.new, "stream1")
+          sleep(1.2)
+          demuxer.decode(Object.new, "stream2")
+          expect(demuxer.size).to eq(limit)
+          expect { demuxer.decode(Object.new, "stream4") }.not_to raise_error
+        end
+      end
+    end
+  end
+
+  describe "usage tracking" do
+    let(:demuxer) { described_class.new(codec, logger).evict_timeout(10) }
+    context "when an operation is performed by identity" do
+      it "the new eviction time for that identity is recorded" do
+        demuxer.decode(Object.new, "stream1")
+        current_eviction = demuxer.usage_map["stream1"]
+        sleep(2)
+        demuxer.decode(Object.new, "stream1")
+        expect(demuxer.usage_map["stream1"]).to be >= current_eviction + 2
+      end
+    end
+  end
+
+  describe "codec eviction" do
+    let(:demuxer) { described_class.new(codec, logger).evict_timeout(1).cleaner_interval(1) }
+    context "when an identity has become stale" do
+      it "the cleaner evicts the codec" do
+        demuxer.decode(Object.new, "stream1")
+        sleep(2.1)
+        expect(demuxer.identity_map.keys).not_to include("stream1")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This after discussion on #4074.

Notes for reviewers:

You will see commented out lines that use Concurrent::Hash.  They are so because I could not seem to require the correct path to make the Hash class appear in the Concurrent module. The intention is still to use Concurrent::Hash.

There are some inner classes and modules, done so to keep it self contained.


