### PR TITLE
Fix logrotate permissions after install

### DIFF
--- a/pkg/centos/after-install.sh
+++ b/pkg/centos/after-install.sh
@@ -3,3 +3,4 @@
 chown -R logstash:logstash /opt/logstash
 chown logstash /var/log/logstash
 chown logstash:logstash /var/lib/logstash
+chmod 0644 /etc/logrotate.d/logstash


### PR DESCRIPTION
In some cases it seems that the file permissions for the logrotate
configuration file are not set properly.  This should address those
cases.

fixes #3490