### PR TITLE
Fix/1574

### DIFF
--- a/pkg/debian/after-install.sh
+++ b/pkg/debian/after-install.sh
@@ -4,3 +4,4 @@ chown -R logstash:logstash /opt/logstash
 chown logstash /var/log/logstash
 chown logstash:logstash /var/lib/logstash
 chmod 755 /etc/logstash
+chmod 0644 /etc/logrotate.d/logstash

--- a/pkg/logrotate.conf
+++ b/pkg/logrotate.conf
@@ -1,4 +1,4 @@
-/var/log/logstash/*.log {
+/var/log/logstash/*.log /var/log/logstash/*.err /var/log/logstash/*.stdout {
         daily
         rotate 7
         copytruncate

--- a/pkg/ubuntu/after-install.sh
+++ b/pkg/ubuntu/after-install.sh
@@ -3,3 +3,4 @@
 chown -R logstash:logstash /opt/logstash
 chown logstash /var/log/logstash
 chown logstash:logstash /var/lib/logstash
+chmod 0644 /etc/logrotate.d/logstash


### PR DESCRIPTION
In some cases it seems that the file permissions for the `logrotate` configuration file are not set properly. This should address those cases.

As suggested in #1574, rotate the `logstash.err` and `logstash.stdout` files also.

fixed #1574 