### PR TITLE
Add provision for worker threads based on threadsafe workers

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -23,7 +23,7 @@ class LogStash::Agent < Clamp::Command
   option ["-w", "--filterworkers"], "COUNT",
     I18n.t("logstash.agent.flag.filterworkers"),
     :attribute_name => :filter_workers,
-    :default => LogStash::Config::CpuCoreStrategy.fifty_percent, &:to_i
+    :default => 0, &:to_i
 
   option ["-l", "--log"], "FILE",
     I18n.t("logstash.agent.flag.log"),
@@ -143,7 +143,7 @@ class LogStash::Agent < Clamp::Command
       configure_logging(log_file)
     end
 
-    pipeline.configure("filter-workers", filter_workers)
+    pipeline.configure("filter-workers", filter_workers) if filter_workers > 0
 
     # Stop now if we are only asking for a config test.
     if config_test?

--- a/logstash-core/lib/logstash/util/defaults_printer.rb
+++ b/logstash-core/lib/logstash/util/defaults_printer.rb
@@ -20,7 +20,7 @@ module LogStash module Util class DefaultsPrinter
     @printers.each do |printer|
       printer.visit(collector)
     end
-    "Default settings used: " + collector.join(', ')
+    "Settings: " + collector.join(', ')
   end
 
   private

--- a/logstash-core/lib/logstash/util/worker_threads_default_printer.rb
+++ b/logstash-core/lib/logstash/util/worker_threads_default_printer.rb
@@ -6,11 +6,23 @@ require "logstash/util"
 module LogStash module Util class WorkerThreadsDefaultPrinter
 
   def initialize(settings)
-    @setting = settings.fetch('filter-workers', 1)
+    @setting = settings.fetch('filter-workers', 0)
+    @default = settings.fetch('default-filter-workers', 0)
   end
 
   def visit(collector)
-    collector.push "Filter workers: #{@setting}"
+    visit_setting(collector)
+    visit_default(collector)
+  end
+
+  def visit_setting(collector)
+    return if @setting == 0
+    collector.push("User set filter workers: #{@setting}")
+  end
+
+  def visit_default(collector)
+    return if @default == 0
+    collector.push "Default filter workers: #{@default}"
   end
 
 end end end

--- a/logstash-core/spec/logstash/util/defaults_printer_spec.rb
+++ b/logstash-core/spec/logstash/util/defaults_printer_spec.rb
@@ -10,7 +10,7 @@ describe LogStash::Util::DefaultsPrinter do
   end
 
   let(:workers)  { 1 }
-  let(:expected) { "Default settings used: Filter workers: #{workers}" }
+  let(:expected) { "Settings: User set filter workers: #{workers}" }
   let(:settings) { {} }
 
   describe 'class methods API' do
@@ -19,13 +19,13 @@ describe LogStash::Util::DefaultsPrinter do
     end
 
     context 'when the settings hash is empty' do
+      let(:expected) { "Settings: " }
       it_behaves_like "a defaults printer"
     end
 
     context 'when the settings hash has content' do
       let(:workers) { 42 }
       let(:settings) { {'filter-workers' => workers} }
-
       it_behaves_like "a defaults printer"
     end
   end
@@ -36,6 +36,7 @@ describe LogStash::Util::DefaultsPrinter do
     end
 
     context 'when the settings hash is empty' do
+      let(:expected) { "Settings: " }
       it_behaves_like "a defaults printer"
     end
 

--- a/logstash-core/spec/logstash/util/worker_threads_default_printer_spec.rb
+++ b/logstash-core/spec/logstash/util/worker_threads_default_printer_spec.rb
@@ -3,24 +3,43 @@ require "spec_helper"
 require "logstash/util/worker_threads_default_printer"
 
 describe LogStash::Util::WorkerThreadsDefaultPrinter do
-  let(:settings) { {} }
+  let(:settings)  { {} }
   let(:collector) { [] }
 
   subject { described_class.new(settings) }
 
-  context 'when the settings hash is empty' do
-    it 'the #visit method returns a string with 1 filter worker' do
-      subject.visit(collector)
-      expect(collector.first).to eq("Filter workers: 1")
+  before { subject.visit(collector) }
+
+  describe "the #visit method" do
+    context 'when the settings hash is empty' do
+      it 'adds nothing to the collector' do
+        subject.visit(collector)
+        expect(collector).to eq([])
+      end
     end
-  end
 
-  context 'when the settings hash has content' do
-    let(:settings) { {'filter-workers' => 42} }
+    context 'when the settings hash has both user and default content' do
+      let(:settings) { {'filter-workers' => 42, 'default-filter-workers' => 5} }
 
-    it 'the #visit method returns a string with 42 filter workers' do
-      subject.visit(collector)
-      expect(collector.first).to eq("Filter workers: 42")
+      it 'adds two strings' do
+        expect(collector).to eq(["User set filter workers: 42", "Default filter workers: 5"])
+      end
+    end
+
+    context 'when the settings hash has only user content' do
+      let(:settings) { {'filter-workers' => 42} }
+
+      it 'adds a string with user set filter workers' do
+        expect(collector.first).to eq("User set filter workers: 42")
+      end
+    end
+
+    context 'when the settings hash has only default content' do
+      let(:settings) { {'default-filter-workers' => 5} }
+
+      it 'adds a string with default filter workers' do
+        expect(collector.first).to eq("Default filter workers: 5")
+      end
     end
   end
 end


### PR DESCRIPTION
**Notes to reviewers:**
- Allow the default to be set as a function of cores without checking thread safety of filters. 
- Allow the command line setting of `-w 6` without checking as above.
- Move the check and alteration of thread_count into the `start_filters` because this allows for dynamic changes to the config. Before, it was only checked at pipeline start.

After PH and Colin initial review:
- override logic from -w command line args refactored, see agent.rb and pipeline.rb

Fixes #4130