### PR TITLE
Fix tins to 1.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,10 @@ gem "file-dependencies", "0.1.6"
 gem "ci_reporter_rspec", "1.0.0", :group => :development
 gem "simplecov", :group => :development
 gem "coveralls", :group => :development
+# Tins 1.7 requires the ruby 2.0 platform to install,
+# this gem is a dependency of term-ansi-color which is a dependency of coveralls.
+# 1.6 is the last supported version on jruby.
+gem "tins", "1.6", :group => :development
 gem "rspec", "~> 3.1.0", :group => :development
 gem "logstash-devutils", "~> 0.0.15", :group => :development
 gem "benchmark-ips", :group => :development


### PR DESCRIPTION
The 1.6 release is the latest release to support ruby 1.9

Fixes: #4163