### PR TITLE
Bump major in to 5

### DIFF
--- a/lib/logstash/version.rb
+++ b/lib/logstash/version.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 # The version of logstash.
-LOGSTASH_VERSION = "3.0.0.dev"
+LOGSTASH_VERSION = "5.0.0.dev"
 
 # Note to authors: this should not include dashes because 'gem' barfs if
 # you include a dash in the version string.


### PR DESCRIPTION
The next major of Logstash will be version 5, not version 3. (2 to 5!)
The reasoning behind this is to help better-communicate compatibility
for the other Elastic projects which will also be 5 soon.