### PR TITLE
Add config file output to --configtest

### DIFF
--- a/lib/logstash/agent.rb
+++ b/lib/logstash/agent.rb
@@ -312,18 +312,26 @@ class LogStash::Agent < Clamp::Command
     Dir.glob(path).sort.each do |file|
       next unless File.file?(file)
       if file.match(/~$/)
-        @logger.debug("NOT reading config file because it is a temp file", :file => file)
+        @logger.debug("NOT reading config file because it is a temp file", :config_file => file)
         next
       end
-      @logger.debug("Reading config file", :file => file)
+      @logger.debug("Reading config file", :config_file => file)
       cfg = File.read(file)
       if !cfg.ascii_only? && !cfg.valid_encoding?
         encoding_issue_files << file
       end
       config << cfg + "\n"
+      if config_test?
+        @logger.debug? && @logger.debug("\nThe following is the content of a file", :config_file => file.to_s)
+        @logger.debug? && @logger.debug("\n" + cfg + "\n\n")
+      end
     end
     if (encoding_issue_files.any?)
       fail("The following config files contains non-ascii characters but are not UTF-8 encoded #{encoding_issue_files}")
+    end
+    if config_test?
+      @logger.debug? && @logger.debug("\nThe following is the merged configuration")
+      @logger.debug? && @logger.debug("\n" + config + "\n\n")
     end
     return config
   end # def load_config


### PR DESCRIPTION
This only works when the `--debug` flag is also enabled.

fixes #3243