### PR TITLE
Add artistic 2.x license to the list of accepted licenses

### DIFF
--- a/spec/license_spec.rb
+++ b/spec/license_spec.rb
@@ -12,6 +12,7 @@ describe "Project licenses" do
     Regexp.union([ /mit/,
                    /apache*/,
                    /bsd/,
+                   /artistic 2.*/,
                    /ruby/,
                    /lgpl/])
   }


### PR DESCRIPTION
As discussed in https://github.com/logstash-plugins/logstash-input-eventlog/issues/27 and requested by @suyograo this adds the artistic license to the list of accepted licenses. 