### PR TITLE
Add jdbc input to default package list

### DIFF
--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -58,6 +58,7 @@ module LogStash
       logstash-input-http
       logstash-input-imap
       logstash-input-irc
+      logstash-input-jdbc
       logstash-input-log4j
       logstash-input-lumberjack
       logstash-input-pipe


### PR DESCRIPTION
JDBC input is a popular plugin and has been stable over the last
few releases.