### PR TITLE
Update 2.1 lock file with latest changes

### DIFF
--- a/Gemfile.jruby-1.9.lock
+++ b/Gemfile.jruby-1.9.lock
@@ -8,38 +8,39 @@ GEM
     avl_tree (1.2.1)
       atomic (~> 1.1)
     awesome_print (1.6.1)
-    aws-sdk (2.1.30)
-      aws-sdk-resources (= 2.1.30)
-    aws-sdk-core (2.1.30)
+    aws-sdk (2.1.36)
+      aws-sdk-resources (= 2.1.36)
+    aws-sdk-core (2.1.36)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.1.30)
-      aws-sdk-core (= 2.1.30)
+    aws-sdk-resources (2.1.36)
+      aws-sdk-core (= 2.1.36)
     aws-sdk-v1 (1.66.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
-    backports (3.6.6)
+    backports (3.6.7)
     benchmark-ips (2.3.0)
     bindata (2.1.0)
     buftok (0.2.0)
     builder (3.2.2)
-    cabin (0.7.1)
-    childprocess (0.5.6)
+    cabin (0.7.2)
+    childprocess (0.5.8)
       ffi (~> 1.0, >= 1.0.11)
     ci_reporter (2.0.0)
       builder (>= 2.1.2)
     ci_reporter_rspec (1.0.0)
       ci_reporter (~> 2.0)
       rspec (>= 2.14, < 4)
-    cinch (2.2.7)
+    cinch (2.3.1)
     clamp (0.6.5)
     coderay (1.1.0)
     concurrent-ruby (0.9.1-java)
-    coveralls (0.8.3)
+    coveralls (0.8.9)
       json (~> 1.8)
       rest-client (>= 1.6.8, < 2)
       simplecov (~> 0.10.0)
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
+      tins (~> 1.6.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
     domain_name (0.5.25)
@@ -64,7 +65,7 @@ GEM
     file-dependencies (0.1.6)
       minitar
     filesize (0.0.4)
-    filewatch (0.6.5)
+    filewatch (0.6.6)
     flores (0.0.6)
     fpm (1.3.3)
       arr-pm (~> 0.0.9)
@@ -95,18 +96,17 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (0.6.9)
     insist (1.0.0)
-    jar-dependencies (0.2.2)
+    jar-dependencies (0.2.6)
     jls-grok (0.11.2)
       cabin (>= 0.6.0)
     jls-lumberjack (0.0.26)
       concurrent-ruby
     jmespath (1.1.3)
-    jrjackson (0.3.6)
+    jrjackson (0.3.7)
     jruby-kafka (1.4.0-java)
       jar-dependencies (~> 0)
       ruby-maven (~> 3.1)
     jruby-openssl (0.9.12-java)
-    jruby-win32ole (0.8.5)
     json (1.8.3-java)
     kramdown (1.9.0)
     logstash-codec-collectd (2.0.2)
@@ -129,7 +129,7 @@ GEM
     logstash-codec-graphite (2.0.2)
       logstash-codec-line
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
-    logstash-codec-json (2.0.2)
+    logstash-codec-json (2.0.3)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
     logstash-codec-json_lines (2.0.2)
       logstash-codec-line
@@ -139,7 +139,7 @@ GEM
     logstash-codec-msgpack (2.0.2-java)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       msgpack-jruby
-    logstash-codec-multiline (2.0.2)
+    logstash-codec-multiline (2.0.3)
       jls-grok (~> 0.11.1)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       logstash-patterns-core
@@ -150,7 +150,7 @@ GEM
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
     logstash-codec-plain (2.0.2)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
-    logstash-codec-rubydebug (2.0.3)
+    logstash-codec-rubydebug (2.0.4)
       awesome_print
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
     logstash-core (2.0.0.beta3-java)
@@ -181,7 +181,7 @@ GEM
       murmurhash3
     logstash-filter-checksum (2.0.2)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
-    logstash-filter-clone (2.0.3)
+    logstash-filter-clone (2.0.4)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
     logstash-filter-csv (2.0.2)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
@@ -197,7 +197,7 @@ GEM
     logstash-filter-fingerprint (2.0.2)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       murmurhash3
-    logstash-filter-geoip (2.0.2)
+    logstash-filter-geoip (2.0.3)
       geoip (>= 1.3.2)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       lru_redux (~> 1.1.0)
@@ -209,7 +209,7 @@ GEM
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
     logstash-filter-kv (2.0.2)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
-    logstash-filter-metrics (2.0.3)
+    logstash-filter-metrics (3.0.0)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       metriks
       thread_safe
@@ -245,9 +245,8 @@ GEM
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       nokogiri
       xml-simple
-    logstash-input-beats (0.9)
-      concurrent-ruby
-      jls-lumberjack (>= 0.0.26)
+    logstash-input-beats (0.9.6)
+      concurrent-ruby (= 0.9.1)
       logstash-codec-plain
       logstash-core (>= 1.5.4, < 3.0.0)
     logstash-input-couchdb_changes (2.0.2)
@@ -259,10 +258,11 @@ GEM
       elasticsearch (~> 1.0, >= 1.0.6)
       logstash-codec-json
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
-    logstash-input-eventlog (2.0.3-java)
-      jruby-win32ole
+    logstash-input-eventlog (3.0.1)
       logstash-codec-plain
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
+      stud (~> 0.0.22)
+      win32-eventlog (~> 0.6.5)
     logstash-input-exec (2.0.4)
       logstash-codec-plain
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
@@ -324,10 +324,10 @@ GEM
       logstash-codec-plain
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       stud (~> 0.0.22)
-    logstash-input-rabbitmq (3.0.3)
+    logstash-input-rabbitmq (3.1.1)
       logstash-codec-json
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
-      logstash-mixin-rabbitmq_connection (>= 2.0.1, < 3.0.0)
+      logstash-mixin-rabbitmq_connection (>= 2.2.0, < 3.0.0)
     logstash-input-redis (2.0.2)
       logstash-codec-json
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
@@ -365,10 +365,10 @@ GEM
       logstash-codec-line
       logstash-codec-plain
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
-    logstash-input-twitter (2.0.2)
+    logstash-input-twitter (2.1.0)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       stud (>= 0.0.22, < 0.1)
-      twitter (= 5.12.0)
+      twitter (= 5.14.0)
     logstash-input-udp (2.0.3)
       logstash-codec-plain
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
@@ -393,7 +393,7 @@ GEM
       logstash-codec-plain
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       manticore (>= 0.4.1)
-    logstash-mixin-rabbitmq_connection (2.0.2-java)
+    logstash-mixin-rabbitmq_connection (2.2.0-java)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       march_hare (~> 2.11.0)
       stud (~> 0.0.22)
@@ -406,7 +406,7 @@ GEM
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       logstash-filter-json
       logstash-output-file
-    logstash-output-elasticsearch (2.1.1-java)
+    logstash-output-elasticsearch (2.1.2-java)
       cabin (~> 0.6)
       concurrent-ruby
       elasticsearch (~> 1.0, >= 1.0.13)
@@ -472,9 +472,9 @@ GEM
     logstash-output-pipe (2.0.2)
       logstash-codec-plain
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
-    logstash-output-rabbitmq (3.0.4-java)
+    logstash-output-rabbitmq (3.0.6-java)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
-      logstash-mixin-rabbitmq_connection (>= 2.0.1, < 3.0.0)
+      logstash-mixin-rabbitmq_connection (>= 2.2.0, < 3.0.0)
     logstash-output-redis (2.0.2)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       redis
@@ -495,7 +495,7 @@ GEM
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       logstash-input-generator
       statsd-ruby (= 1.2.0)
-    logstash-output-stdout (2.0.2)
+    logstash-output-stdout (2.0.3)
       logstash-codec-line
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
     logstash-output-tcp (2.0.2)
@@ -535,8 +535,8 @@ GEM
     multipart-post (2.0.0)
     murmurhash3 (0.1.6-java)
     naught (1.1.0)
-    netrc (0.10.3)
-    nokogiri (1.6.6.2-java)
+    netrc (0.11.0)
+    nokogiri (1.6.6.3-java)
     octokit (3.8.0)
       sawyer (~> 0.6.0, >= 0.5.3)
     polyglot (0.3.5)
@@ -549,7 +549,7 @@ GEM
       rack (>= 1.1, < 2.0)
     rack (1.6.4)
     rake (10.4.2)
-    redis (3.2.1)
+    redis (3.2.2)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
@@ -566,9 +566,9 @@ GEM
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
-    rspec-wait (0.0.7)
-      rspec (>= 2.11, < 3.4)
-    ruby-maven (3.3.5)
+    rspec-wait (0.0.8)
+      rspec (>= 2.11, < 3.5)
+    ruby-maven (3.3.8)
       ruby-maven-libs (~> 3.3.1)
     ruby-maven-libs (3.3.3)
     rubyzip (1.1.7)
@@ -597,7 +597,7 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    twitter (5.12.0)
+    twitter (5.14.0)
       addressable (~> 2.3)
       buftok (~> 0.2.0)
       equalizer (~> 0.0.9)
@@ -612,6 +612,8 @@ GEM
       thread_safe (~> 0.1)
     unf (0.1.4-java)
     user_agent_parser (2.3.0)
+    win32-eventlog (0.6.5)
+      ffi
     xml-simple (1.1.5)
     xmpp4r (0.5)
 
@@ -736,3 +738,4 @@ DEPENDENCIES
   rubyzip (~> 1.1.7)
   simplecov
   stud (~> 0.0.21)
+  tins (= 1.6)

--- a/spec/plugin_manager/update_spec.rb
+++ b/spec/plugin_manager/update_spec.rb
@@ -8,7 +8,7 @@ describe LogStash::PluginManager::Update do
 
   before(:each) do
     expect(cmd).to receive(:find_latest_gem_specs).and_return({})
-    expect(cmd).to receive(:warn_local_gems).and_return(nil)
+    allow(cmd).to receive(:warn_local_gems).and_return(nil)
     expect(cmd).to receive(:display_updated_plugins).and_return(nil)
     expect_any_instance_of(LogStash::Bundler).to receive(:invoke!).with(:clean => true)
   end


### PR DESCRIPTION
specially  in plugins and dependencies, fixing the concurrent ruby issue.

Fix http://build-eu-00.elastic.co/view/LS%202.1/job/logstash_regression_21/jdk=JDK7,label=metal-pool/3/console by updating the lock file.

```
Successfully installed bundler-1.9.10
Invoking bundler install...
Plugin version conflict, aborting
rake aborted!
Bundler could not find compatible versions for gem "concurrent-ruby":
  In snapshot (Gemfile.lock):
    concurrent-ruby (= 0.9.1)

  In Gemfile:
    logstash-core (>= 0) java depends on
      concurrent-ruby (= 0.9.2) java

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
``` 

Similar fix should be applied to 2.0 branch, this will come in another pr.

https://github.com/purbon/logstash/commit/3a25f5a99827dd8fed8ceb69f73bbcdadff6301e was added only as a compliment, so the test pass,  but better check #4212 for a general version of it that is the one that will be merged.

relates to #4212 && #4206 , where  3a25f5a99827dd8fed8ceb69f73bbcdadff6301e gets also introduced.