### PR TITLE
Fix build in version branches by stub the warn_local_gems call in the update command 

### DIFF
--- a/spec/plugin_manager/update_spec.rb
+++ b/spec/plugin_manager/update_spec.rb
@@ -8,7 +8,7 @@ describe LogStash::PluginManager::Update do
 
   before(:each) do
     expect(cmd).to receive(:find_latest_gem_specs).and_return({})
-    expect(cmd).to receive(:warn_local_gems).and_return(nil)
+    allow(cmd).to receive(:warn_local_gems).and_return(nil)
     expect(cmd).to receive(:display_updated_plugins).and_return(nil)
     expect_any_instance_of(LogStash::Bundler).to receive(:invoke!).with(:clean => true)
   end


### PR DESCRIPTION
This is necessary, not for master, but for the version branches where we actually use no local gems, so this call will never be called.

Fixes the broken build in jenkins errors after #4210 is merged.