### PR TITLE
Fix a string interpolation memory leak

### DIFF
--- a/logstash-core-event/lib/logstash/event.rb
+++ b/logstash-core-event/lib/logstash/event.rb
@@ -106,7 +106,7 @@ class LogStash::Event
 
   public
   def to_s
-    self.sprintf("#{timestamp.to_iso8601} %{host} %{message}")
+    "#{timestamp.to_iso8601} #{self.sprintf("%{host} %{message}")}"
   end # def to_s
 
   public

--- a/logstash-core-event/spec/logstash/event_spec.rb
+++ b/logstash-core-event/spec/logstash/event_spec.rb
@@ -498,4 +498,17 @@ describe LogStash::Event do
       subject{LogStash::Event.new(LogStash::Json.load(LogStash::Json.dump(event_hash)))}
     end
   end
+
+
+  describe "#to_s" do
+    let(:event1) { LogStash::Event.new({ "host" => "foo", "message" => "bar"}) }
+    let(:event2) { LogStash::Event.new({ "host" => "bar", "message" => "foo"}) }
+
+    it "should cache only one template" do
+      expect {
+        event1.to_s
+        event2.to_s
+      }.to change { LogStash::StringInterpolation::CACHE.size }.by(1)
+    end
+  end
 end

--- a/logstash-core-event/spec/logstash/event_spec.rb
+++ b/logstash-core-event/spec/logstash/event_spec.rb
@@ -501,7 +501,8 @@ describe LogStash::Event do
 
 
   describe "#to_s" do
-    let(:event1) { LogStash::Event.new({ "host" => "foo", "message" => "bar"}) }
+    let(:timestamp) { LogStash::Timestamp.new }
+    let(:event1) { LogStash::Event.new({ "@timestamp" => timestamp, "host" => "foo", "message" => "bar"}) }
     let(:event2) { LogStash::Event.new({ "host" => "bar", "message" => "foo"}) }
 
     it "should cache only one template" do
@@ -509,6 +510,10 @@ describe LogStash::Event do
         event1.to_s
         event2.to_s
       }.to change { LogStash::StringInterpolation::CACHE.size }.by(1)
+    end
+
+    it "return the string containing the timestamp, the host and the message" do
+      expect(event1.to_s).to eq("#{timestamp.to_iso8601} #{event1["host"]} #{event1["message"]}")
     end
   end
 end


### PR DESCRIPTION
When the event was serialized to string using a `to_s` call, mostly
happenning when doing logging. Each calls would generate a new template
each template was unique because it was containing the date.

The accumulation of templates was making logstash goes OOM.

We aren't cleaning the templates because they should stabilize to a
finite number.