### PR TITLE
Added the code to set output to json format with stdout {codec=>rub…

### DIFF
--- a/docs/asciidoc/static/advanced-pipeline.asciidoc
+++ b/docs/asciidoc/static/advanced-pipeline.asciidoc
@@ -116,6 +116,14 @@ filter {
 }
 --------------------------------------------------------------------------------
 
+To set the stdout output to json format:
+[source,json]
+--------------------------------------------------------------------------------
+output {
+    stdout {codec=>rubydebug} 
+}
+--------------------------------------------------------------------------------
+
 After processing, the sample line has the following JSON representation:
 
 [source,json]


### PR DESCRIPTION
the example in this page shows the output in json format but does not explain how to set the stdout to show json.

output {
 stdout {codec=>rubydebug} 
}
