### PR TITLE
clean cache to empty previous entries

### DIFF
--- a/logstash-core-event/spec/logstash/event_spec.rb
+++ b/logstash-core-event/spec/logstash/event_spec.rb
@@ -506,6 +506,7 @@ describe LogStash::Event do
     let(:event2) { LogStash::Event.new({ "host" => "bar", "message" => "foo"}) }
 
     it "should cache only one template" do
+      LogStash::StringInterpolation::CACHE.clear
       expect {
         event1.to_s
         event2.to_s


### PR DESCRIPTION
this fixed intermittent core specs failures depending if `Event#to_s` was called before the `Event` specs.