### PR TITLE
Obscure or unclear description of absent parameters

### DIFF
--- a/docs/asciidoc/static/breaking-changes.asciidoc
+++ b/docs/asciidoc/static/breaking-changes.asciidoc
@@ -21,11 +21,11 @@ Be sure to specify the correct value for the `--version` option during installat
 [float]
 ==== Configuration Changes
 
-The Elasticsearch output plugin configuration has the following changes:
+The [Elasticsearch output plugin](https://www.elastic.co/guide/en/logstash/2.0/plugins-outputs-elasticsearch.html) configuration has the following changes:
 
 * The `host` configuration option is now `hosts`, allowing you to specify multiple hosts and associated ports in the 
 `myhost:9200` format
-* New options: `bind_host`, `bind_port`, `cluster`, `embedded`, `embedded_http_port`, `port`, `sniffing_delay`
+* New options: `sniffing_delay`
 * The `max_inflight_requests` option, which was deprecated in the 1.5 release, is now removed
 * Since the `hosts` option allows specification of ports for the hosts, the redundant `port` option is now removed
 * The `node_name` and `protocol` options have been moved to the `elasticsearch_java` plugin


### PR DESCRIPTION
In a way there are no such options for plugins-outputs-elasticsearch plugin: `bind_host`, `bind_port`, `cluster`, `embedded`, `embedded_http_port`, `port` in the documentation for logstash 2.0.
Or did you mean some other plugin? Because it's unclear in the context.
Btw, why `cluster` has been taken away? How should cluster discovery happen now?