### PR TITLE
better rspec defaults to use documentation formatter in rake tasks and CI

### DIFF
--- a/ci/ci_setup.sh
+++ b/ci/ci_setup.sh
@@ -17,7 +17,4 @@ rm -rf spec/reports # no stale spec reports from previous executions
 rake bootstrap # Bootstrap your logstash instance
 
 
-# Set up some general options for the rspec runner
-#echo "--order rand" > .rspec
-#echo "--format progress" >> .rspec
-#echo "--format CI::Reporter::RSpecFormatter" >> .rspec
+# RSpec options are set in ci_test.sh

--- a/ci/ci_setup.sh
+++ b/ci/ci_setup.sh
@@ -16,7 +16,10 @@ rm -rf spec/reports # no stale spec reports from previous executions
 # Setup the environment
 rake bootstrap # Bootstrap your logstash instance
 
+
 # Set up some general options for the rspec runner
-echo "--order rand" > .rspec
-echo "--format progress" >> .rspec
-echo "--format CI::Reporter::RSpecFormatter" >> .rspec
+#echo "--order rand" > .rspec
+#echo "--format progress" >> .rspec
+#echo "--format CI::Reporter::RSpecFormatter" >> .rspec
+
+export RSPEC_OPTIONS="--order rand --format documentation --format CI::Reporter::RSpecFormatter"

--- a/ci/ci_setup.sh
+++ b/ci/ci_setup.sh
@@ -21,5 +21,3 @@ rake bootstrap # Bootstrap your logstash instance
 #echo "--order rand" > .rspec
 #echo "--format progress" >> .rspec
 #echo "--format CI::Reporter::RSpecFormatter" >> .rspec
-
-export RSPEC_OPTIONS="--order rand --format documentation --format CI::Reporter::RSpecFormatter"

--- a/ci/ci_test.sh
+++ b/ci/ci_test.sh
@@ -7,6 +7,8 @@
 
 SELECTED_TEST_SUITE=$1
 
+export RSPEC_OPTIONS="--order rand --format documentation --format CI::Reporter::RSpecFormatter"
+
 if [[ $SELECTED_TEST_SUITE == $"core-fail-fast" ]]; then
   echo "Running core-fail-fast tests"
   rake test:install-core    # Install core dependencies for testing.

--- a/ci/ci_test.sh
+++ b/ci/ci_test.sh
@@ -7,7 +7,7 @@
 
 SELECTED_TEST_SUITE=$1
 
-export RSPEC_OPTIONS="--order rand --format documentation --format CI::Reporter::RSpecFormatter"
+export SPEC_OPTS="--order rand --format documentation --format CI::Reporter::RSpecFormatter"
 
 if [[ $SELECTED_TEST_SUITE == $"core-fail-fast" ]]; then
   echo "Running core-fail-fast tests"

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -1,11 +1,6 @@
 # we need to call exit explicity  in order to set the proper exit code, otherwise
 # most common CI systems can not know whats up with this tests.
 
-# the tasks launching rspec will use environment var RSPEC_OPTIONS to pass
-# options to rspec and will ignore the tasks own default options.
-# Ex.: $ RSPEC_OPTIONS="-fp" rake test:core
-# will use progress format (dots)
-
 require "pluginmanager/util"
 
 namespace "test" do
@@ -44,11 +39,10 @@ namespace "test" do
 
   DEFAULT_RSPEC_FORMAT = "--format=documentation"
 
-  # @param options [Array<String> | String] default options to use if no options are in RSPEC_OPTIONS env var
+  # @param options [Array<String> | String] default options to use
   # @return [Array<String>] options as strings array to use by RSpec::Core::Runner.run
   def rspec_options(options = [])
-    env_options = ENV["RSPEC_OPTIONS"] ? ENV["RSPEC_OPTIONS"].to_s.split(/\s+/) : nil
-    env_options || ([DEFAULT_RSPEC_FORMAT] + Array(options))
+    [DEFAULT_RSPEC_FORMAT] + Array(options)
   end
 
   desc "run core specs"

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -44,6 +44,8 @@ namespace "test" do
 
   DEFAULT_RSPEC_FORMAT = "--format=documentation"
 
+  # @param options [Array<String> | String] default options to use if no options are in RSPEC_OPTIONS env var
+  # @return [Array<String>] options as strings array to use by RSpec::Core::Runner.run
   def rspec_options(options = [])
     env_options = ENV["RSPEC_OPTIONS"] ? ENV["RSPEC_OPTIONS"].to_s.split(/\s+/) : nil
     env_options || ([DEFAULT_RSPEC_FORMAT] + Array(options))
@@ -56,7 +58,7 @@ namespace "test" do
 
   desc "run core specs in fail-fast mode"
   task "core-fail-fast" => ["setup"] do
-    exit(RSpec::Core::Runner.run([*rspec_options("--fail-fast"), core_specs]))
+    exit(RSpec::Core::Runner.run([*rspec_options, "--fail-fast", core_specs]))
   end
 
   desc "run core specs on a single file"


### PR DESCRIPTION
- default to `--format=documentation` for all rspec tasks and when running CI tests

Some advantages of using `--format=documentation` 
- better/more verbose jenkins reports
- visual cue to exactly where a test stalls when it does
