### PR TITLE
fix nil value field reference assignment in Java Event

### DIFF
--- a/logstash-core-event-java/spec/event_spec.rb
+++ b/logstash-core-event-java/spec/event_spec.rb
@@ -90,6 +90,12 @@ describe LogStash::Event do
       expect(e["[foo][2]"]).to eq(1.0)
       expect(e["[foo][3]"]).to be_nil
     end
+
+    it "should add key when setting nil value" do
+      e = LogStash::Event.new()
+      e["[foo]"] = nil
+      expect(e.to_hash).to include("foo" => nil)
+    end
   end
 
   context "timestamp" do

--- a/logstash-core-event-java/src/main/java/com/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core-event-java/src/main/java/com/logstash/ext/JrubyEventExtLibrary.java
@@ -155,6 +155,8 @@ public class JrubyEventExtLibrary implements Library {
                     this.event.setField(r, RubyToJavaConverter.convertToList((RubyArray) value));
                 } else if (value instanceof RubyHash) {
                     this.event.setField(r, RubyToJavaConverter.convertToMap((RubyHash) value));
+                } else if (value.isNil()) {
+                    this.event.setField(r, null);
                 } else {
                     throw context.runtime.newTypeError("wrong argument type " + value.getMetaClass());
                 }

--- a/logstash-core-event/spec/logstash/event_spec.rb
+++ b/logstash-core-event/spec/logstash/event_spec.rb
@@ -44,6 +44,11 @@ describe LogStash::Event do
         subject["@metadata"] = { "action" => "index" }
         expect(subject["[@metadata][action]"]).to eq("index")
       end
+
+      it "should add key when setting nil value" do
+        subject["[baz]"] = nil
+        expect(subject.to_hash).to include("baz" => nil)
+      end
     end
 
     context "#sprintf" do


### PR DESCRIPTION
this PR builds on top of #4263 

and also add related missing spec in Ruby Event
this relates to #4264 and #4191 and is required to have the filter grok specs pass with the Java Event.