### PR TITLE
fix missing methods in Java Timestamp

### DIFF
--- a/logstash-core-event-java/src/main/java/com/logstash/Timestamp.java
+++ b/logstash-core-event-java/src/main/java/com/logstash/Timestamp.java
@@ -13,7 +13,9 @@ import java.util.Date;
 @JsonSerialize(using = TimestampSerializer.class)
 public class Timestamp implements Cloneable {
 
+    // all methods setting the time object must set it in the UTC timezone
     private DateTime time;
+
     // TODO: is this DateTimeFormatter thread safe?
     private static DateTimeFormatter iso8601Formatter = ISODateTimeFormat.dateTime();
 
@@ -50,7 +52,7 @@ public class Timestamp implements Cloneable {
     }
 
     public void setTime(DateTime time) {
-        this.time = time;
+        this.time = time.toDateTime(DateTimeZone.UTC);
     }
 
     public static Timestamp now() {

--- a/logstash-core-event-java/src/main/java/com/logstash/ext/JrubyTimestampExtLibrary.java
+++ b/logstash-core-event-java/src/main/java/com/logstash/ext/JrubyTimestampExtLibrary.java
@@ -110,6 +110,12 @@ public class JrubyTimestampExtLibrary implements Library {
             return RubyFixnum.newFixnum(context.runtime, this.timestamp.getTime().getMillis() / 1000);
         }
 
+        @JRubyMethod(name = "to_f")
+        public IRubyObject ruby_to_f(ThreadContext context)
+        {
+            return RubyFloat.newFloat(context.runtime, this.timestamp.getTime().getMillis() / 1000.0d);
+        }
+
         @JRubyMethod(name = "to_s")
         public IRubyObject ruby_to_s(ThreadContext context)
         {
@@ -203,6 +209,18 @@ public class JrubyTimestampExtLibrary implements Library {
         public static IRubyObject ruby_now(ThreadContext context, IRubyObject recv)
         {
             return RubyTimestamp.newRubyTimestamp(context.runtime);
+        }
+
+        @JRubyMethod(name = "utc")
+        public IRubyObject ruby_utc(ThreadContext context)
+        {
+            return this;
+        }
+
+        @JRubyMethod(name = "gmtime")
+        public IRubyObject ruby_gmtime(ThreadContext context)
+        {
+            return this;
         }
     }
 }

--- a/logstash-core-event/spec/logstash/timestamp_spec.rb
+++ b/logstash-core-event/spec/logstash/timestamp_spec.rb
@@ -81,4 +81,29 @@ describe LogStash::Timestamp do
       expect(t - 10).to eq(current)
     end
   end
+
+  context "identity methods" do
+    subject { LogStash::Timestamp.new }
+
+    it "should support utc" do
+      expect(subject.utc).to eq(subject)
+    end
+
+    it "should support gmtime" do
+      expect(subject.gmtime).to eq(subject)
+    end
+  end
+
+  context "numeric casting methods" do
+    let (:now) {Time.now}
+    subject { LogStash::Timestamp.new(now) }
+
+    it "should support to_i" do
+      expect(subject.to_i).to eq(now.to_i)
+    end
+
+    it "should support to_f" do
+      expect(subject.to_f).to eq(now.to_f)
+    end
+  end
 end


### PR DESCRIPTION
this PR builds on top of #4265

- add missing `utc`, `gmtime` and `to_f` methods in the Java `Timestamp`
- add missing specs for these methods in the Ruby `Timestamp` specs to prevent future regressions

this relates to #4264 and #4191 and fixes sqs input specs under Java `Event`.