### PR TITLE
fix shutdown controller when using no filters

### DIFF
--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -53,6 +53,7 @@ module LogStash; class Pipeline
     # @ready requires thread safety since it is typically polled from outside the pipeline thread
     @ready = Concurrent::AtomicBoolean.new(false)
     @input_threads = []
+    @filter_threads = []
   end # def initialize
 
   def ready?
@@ -136,7 +137,7 @@ module LogStash; class Pipeline
   end
 
   def wait_filters
-    @filter_threads.each(&:join) if @filter_threads
+    @filter_threads.each(&:join)
   end
 
   def shutdown_outputs

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -299,4 +299,27 @@ describe LogStash::Pipeline do
       end
     end
   end
+
+  describe "stalling_threads" do
+    before(:each) do
+      allow(LogStash::Plugin).to receive(:lookup).with("input", "dummyinput").and_return(DummyInput)
+      allow(LogStash::Plugin).to receive(:lookup).with("codec", "plain").and_return(DummyCodec)
+      allow(LogStash::Plugin).to receive(:lookup).with("output", "dummyoutput").and_return(DummyOutput)
+    end
+
+    context "when the pipeline doesn't have filters" do
+      let(:pipeline_with_no_filters) do
+        <<-eos
+        input { dummyinput {} }
+        output { dummyoutput {} }
+        eos
+      end
+
+      it "doesn't raise an error" do
+        pipeline = TestPipeline.new(pipeline_with_no_filters)
+        pipeline.run
+        expect { pipeline.stalling_threads }.to_not raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
initializes @filter_threads to be an empty array so that the Shutdown controller can deal with no filters gracefully.

this needs to be merged into master, 2.x and 2.1

fixes #4271 