### PR TITLE
Provide feedback to users when trying to uninstall plugins that are dependencies of others.

### DIFF
--- a/integration/plugin_manager/logstash_spec.rb
+++ b/integration/plugin_manager/logstash_spec.rb
@@ -1,10 +1,10 @@
 # Encoding: utf-8
 require_relative "../spec_helper"
-require_relative "../../lib/logstash/version"
+require_relative "../../logstash-core/lib/logstash/version"
 
 describe "bin/logstash" do
   it "returns the logstash version" do
-    result = command("bin/logstash version")
+    result = command("bin/logstash --version")
     expect(result.exit_status).to eq(0)
     expect(result.stdout).to match(/^logstash\s#{LOGSTASH_VERSION}/)
   end

--- a/integration/plugin_manager/plugin_uninstall_spec.rb
+++ b/integration/plugin_manager/plugin_uninstall_spec.rb
@@ -20,5 +20,12 @@ describe "bin/plugin uninstall" do
       expect(result.stdout).to match(/^Uninstalling logstash-filter-ruby/)
       expect(result.exit_status).to eq(0)
     end
+
+    it "fails if has dependencies" do
+      result  = command("bin/plugin uninstall logstash-input-tcp")
+      message = "logstash-input-tcp is a dependency of logstash-input-graphite."
+      expect(result.stderr).to match(/ERROR: Uninstall Aborted, message: #{message}/)
+      expect(result.exit_status).to eq(1)
+    end
   end
 end

--- a/integration/spec_helper.rb
+++ b/integration/spec_helper.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 require_relative "support/integration_test_helpers"
-require_relative "../lib/logstash/environment"
+require_relative "../logstash-core/lib/logstash/environment"
 require "fileutils"
 
 if LogStash::Environment.windows?

--- a/lib/pluginmanager/command.rb
+++ b/lib/pluginmanager/command.rb
@@ -4,6 +4,10 @@ class LogStash::PluginManager::Command < Clamp::Command
     @gemfile ||= LogStash::Gemfile.new(File.new(LogStash::Environment::GEMFILE_PATH, 'r+')).load
   end
 
+  def gemfilelock
+    @gemfilelock ||= LogStash::GemfileLock.parse(Bundler.default_lockfile)
+  end
+
   # If set in debug mode we will raise an exception and display the stacktrace
   def report_exception(readable_message, exception)
     if ENV["DEBUG"]

--- a/lib/pluginmanager/gemfilelock.rb
+++ b/lib/pluginmanager/gemfilelock.rb
@@ -1,0 +1,164 @@
+# encoding: utf-8
+module LogStash
+  class GemfileLock
+
+    HEADERS = [ "PATH", "GEM", "DEPENDENCIES" ]
+
+    attr_reader :lock_file, :dependency_graph
+
+    def initialize(lock_file)
+      @lock_file        = lock_file
+      @dependency_graph = DependencyGraph.new(lock_file)
+    end
+
+    def self.parse(file)
+      lock_file = []
+      File.open(file, "r") do |file|
+        parsing, specs  = false, false
+        section = {}
+        file.each_line do |line|
+          if HEADERS.include?(line.strip)
+            parsing = true
+            section = { type: line.strip, remote: "", specs: [] }
+          elsif line == "\n"
+            parsing, specs = false, false
+            lock_file << section
+          elsif parsing
+            line = line[2..-1]
+            if line.start_with?("remote:")
+              remote = line.gsub("remote:","").strip
+              section[:remote] << remote
+            elsif line.start_with?("specs:")
+              specs = true
+            else
+              line = line[2..-1].rstrip if section[:type] != "DEPENDENCIES"
+              if !line[0..1].strip.empty?
+                section[:specs] << { :gem => Gems.parse(line), :deps => [] }
+              else
+                # dependency
+                section[:specs].last[:deps] << Gems.parse(line.strip)
+              end
+            end
+          end
+        end
+        if section[:type] == "DEPENDENCIES" && !section[:specs].empty?
+          lock_file << section
+        end
+      end
+      self.new(lock_file)
+    end
+
+    def find_dependencies(plugin)
+      dependency_graph.index[plugin].in.map { |e| e.from }
+    end
+
+    def has_dependencies?(plugin)
+      entry = dependency_graph.index[plugin]
+      !entry.nil? && !entry.in.empty?
+    end
+
+  end
+
+  class DependencyGraph
+
+    attr_reader :index, :dependencies
+
+    class Node
+      attr_reader :gem, :edges
+
+      def initialize(gem)
+        @gem       = gem
+        @edges = []
+      end
+
+      def add_edge(edge, direction)
+        @edges << { :edge => edge, :dir => direction }
+      end
+
+      def out
+        @edges.select { |edge| edge[:dir] == :out }.map { |e| e[:edge] }
+      end
+
+      def in
+        @edges.select { |edge| edge[:dir] == :in }.map { |e| e[:edge] }
+      end
+
+      def to_s
+        "#{gem}"
+      end
+    end
+
+    class Edge
+      attr_reader :from, :to
+      def initialize(from, to)
+        @from = from
+        @to   = to
+      end
+
+      def to_s
+        "#{from} --> #{to}"
+      end
+    end
+
+    def initialize(lock_file)
+      @lock_file    = lock_file
+      @dependencies = extract_dependencies(lock_file)
+      @dag          = build_dag(lock_file)
+    end
+
+    def build_dag(lock_file)
+      @index = Hash.new
+      gems = lock_file.select { |section| section[:type] == "GEM" }.first
+      gems[:specs].each do |spec|
+        gem  = spec[:gem]
+        next unless dependencies.include?(gem.name)
+        node = fetch_or_create_node(gem.name)
+        spec[:deps].each do |dep|
+          next unless dependencies.include?(dep.name)
+          dep_node = fetch_or_create_node(dep.name)
+          node.add_edge(Edge.new(node, dep_node), :out)
+          dep_node.add_edge(Edge.new(node, dep_node), :in)
+        end
+      end
+    end
+
+    def extract_dependencies(lock_file)
+      dependencies = lock_file.select { |section| section[:type] == "DEPENDENCIES" }.first
+      dependencies[:specs].map do |spec|
+        spec[:gem].name
+      end
+    end
+
+    private
+
+    def fetch_or_create_node(name)
+      return index[name] if index[name]
+      index[name] = Node.new(name)
+      index[name]
+    end
+
+  end
+
+  class Gems
+
+    attr_reader :name, :requirements
+
+    def initialize(name, requirements=[])
+      @name = name
+      @requirements = requirements
+    end
+
+    def self.parse(definition)
+      parts = definition.split(" ")
+      name  = parts[0]
+      requirements = parts[1..-1].join(' ').gsub(/\(|\)/,"").split(",")
+      self.new(name, requirements)
+    end
+
+    def to_s
+      "#{@name} #{@requirements}"
+    end
+
+  end
+
+end

--- a/lib/pluginmanager/main.rb
+++ b/lib/pluginmanager/main.rb
@@ -14,6 +14,7 @@ end
 require "clamp"
 require "pluginmanager/util"
 require "pluginmanager/gemfile"
+require "pluginmanager/gemfilelock"
 require "pluginmanager/install"
 require "pluginmanager/uninstall"
 require "pluginmanager/list"

--- a/lib/pluginmanager/uninstall.rb
+++ b/lib/pluginmanager/uninstall.rb
@@ -19,6 +19,11 @@ class LogStash::PluginManager::Uninstall < LogStash::PluginManager::Command
     # it is not possible to uninstall a dependency not listed in the Gemfile, for example a dependent codec
     signal_error("This plugin has not been previously installed, aborting") unless LogStash::PluginManager.installed_plugin?(plugin, gemfile)
 
+    if gemfilelock.has_dependencies?(plugin)
+      dependencies = gemfilelock.find_dependencies(plugin)
+      signal_error("#{plugin} is a dependency of #{dependencies.join(',')}.")
+    end
+
     # since we previously did a gemfile.find(plugin) there is no reason why
     # remove would not work (return nil) here
     if gemfile.remove(plugin)


### PR DESCRIPTION
Add a way to detect dependencies for plugins when uninstalling, this provides feedback to users when hitting #3152. It provides this by building an initial version of a dependency graph from the Gemfile.lock in a similar way and strategy as we deal with the Gemfile.

**_Some notes**_

The dependency graph will let us do a lot of more things, but for now the implementation is general enough, in some way, and simple enough, in another to fit this use case. Keep this in mind when reviewing.

This add a warning to the user when doing uninstall, I chose this path as the less intrusive one from the many options possible.

Let me know what do you think,
