### PR TITLE
Allow Logstash to be launched from a symlink

### DIFF
--- a/bin/logstash
+++ b/bin/logstash
@@ -19,7 +19,31 @@
 #   DEBUG=1 to output debugging information
 
 unset CDPATH
-. "$(cd `dirname $0`/..; pwd)/bin/logstash.lib.sh"
+# This unwieldy bit of scripting is to try to catch instances where Logstash
+# was launched from a symlink, rather than a full path to the Logstash binary
+if [ -L $0 ]; then
+  # Launched from a symlink
+  # --Test for the readlink binary
+  RL=$(which readlink)
+  if [ $? -eq 0 ]; then
+    # readlink exists
+    SOURCEPATH=$($RL $0)
+  else
+    # readlink not found, attempt to parse the output of stat
+    SOURCEPATH=$(stat -c %N $0 | awk '{print $3}' | sed -e 's/\‘//' -e 's/\’//')
+    if [ $? -ne 0 ]; then
+      # Failed to execute or parse stat
+      echo "Failed to find source library at path $(cd `dirname $0`/..; pwd)/bin/logstash.lib.sh"
+      echo "You may need to launch Logstash with a full path instead of a symlink."
+      exit 1
+    fi
+  fi
+else
+  # Not a symlink
+  SOURCEPATH=$0
+fi
+
+. "$(cd `dirname $SOURCEPATH`/..; pwd)/bin/logstash.lib.sh"
 setup
 
 ruby_exec "${LOGSTASH_HOME}/lib/bootstrap/environment.rb" "logstash/runner.rb" "$@"

--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -1,5 +1,29 @@
 unset CDPATH
-LOGSTASH_HOME=$(cd `dirname $0`/..; pwd)
+# This unwieldy bit of scripting is to try to catch instances where Logstash
+# was launched from a symlink, rather than a full path to the Logstash binary
+if [ -L $0 ]; then
+  # Launched from a symlink
+  # --Test for the readlink binary
+  RL=$(which readlink)
+  if [ $? -eq 0 ]; then
+    # readlink exists
+    SOURCEPATH=$($RL $0)
+  else
+    # readlink not found, attempt to parse the output of stat
+    SOURCEPATH=$(stat -c %N $0 | awk '{print $3}' | sed -e 's/\‘//' -e 's/\’//')
+    if [ $? -ne 0 ]; then
+      # Failed to execute or parse stat
+      echo "Failed to set LOGSTASH_HOME from $(cd `dirname $0`/..; pwd)/bin/logstash.lib.sh"
+      echo "You may need to launch Logstash with a full path instead of a symlink."
+      exit 1
+    fi
+  fi
+else
+  # Not a symlink
+  SOURCEPATH=$0
+fi
+
+LOGSTASH_HOME=$(cd `dirname $SOURCEPATH`/..; pwd)
 export LOGSTASH_HOME
 
 # Defaults you can override with environment variables


### PR DESCRIPTION
These changes allow Logstash to be launched from a symlink _only_ when the `readlink`, or suitable version of `stat` binaries are present. An error message will result if Logstash is launched from a symlink and the path cannot be discovered by one of these two methods.  The message will advise the user to use the full path instead of a symlink to launch Logstash.

fixes #4291