### PR TITLE
allow logstash to run in a dir with spaces

### DIFF
--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -38,7 +38,8 @@ setup_java() {
     # Causes the JVM to dump its heap on OutOfMemory.
     JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
     # The path to the heap dump location
-    JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=${LOGSTASH_HOME}/heapdump.hprof"
+    # This variable needs to be isolated since it may contain spaces
+    HEAP_DUMP_PATH="-XX:HeapDumpPath=${LOGSTASH_HOME}/heapdump.hprof"
   fi
 
   if [ "$LS_JAVA_OPTS" ] ; then
@@ -151,8 +152,8 @@ ruby_exec() {
     # $VENDORED_JRUBY is non-empty so use the vendored JRuby
 
     if [ "$DEBUG" ] ; then
-      echo "DEBUG: exec ${JRUBY_BIN} $(jruby_opts) $@"
+      echo "DEBUG: exec ${JRUBY_BIN} $(jruby_opts) "-J$HEAP_DUMP_PATH" $@"
     fi
-    exec "${JRUBY_BIN}" $(jruby_opts) "$@"
+    exec "${JRUBY_BIN}" $(jruby_opts) "-J$HEAP_DUMP_PATH" "$@"
   fi
 }


### PR DESCRIPTION
because HeapDumpPath is set, if it contains spaces the jruby_opts
function will create two strings appended by -J
even if the list of jruby opts is constructed using replacement
shell script will not escape the path correct to the heap dump path
option needs to be added as late as possible

this is a *nix fix only, windows is not affected

fixes #4283