### PR TITLE
fix string interpolation cache api and related specs

### DIFF
--- a/logstash-core-event-java/lib/logstash/event.rb
+++ b/logstash-core-event-java/lib/logstash/event.rb
@@ -2,6 +2,7 @@
 
 require "logstash/namespace"
 require "logstash/json"
+require "logstash/string_interpolation"
 
 # transcient pipeline events for normal in-flow signaling as opposed to
 # flow altering exceptions. for now having base classes is adequate and

--- a/logstash-core-event-java/lib/logstash/string_interpolation.rb
+++ b/logstash-core-event-java/lib/logstash/string_interpolation.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+
+module LogStash
+  module StringInterpolation
+    extend self
+
+    # clear the global compiled templates cache
+    def clear_cache
+      Java::ComLogstash::StringInterpolation.get_instance.clear_cache;
+    end
+
+    # @return [Fixnum] the compiled templates cache size
+    def cache_size
+      Java::ComLogstash::StringInterpolation.get_instance.cache_size;
+    end
+  end
+end
+

--- a/logstash-core-event-java/src/main/java/com/logstash/Event.java
+++ b/logstash-core-event-java/src/main/java/com/logstash/Event.java
@@ -196,13 +196,13 @@ public class Event implements Cloneable, Serializable {
     }
 
     public String toString() {
-        // TODO: until we have sprintf
-        String host = (String)this.data.getOrDefault("host", "%{host}");
-        String message = (String)this.data.getOrDefault("message", "%{message}");
+        // TODO: (colin) clean this IOException handling, not sure why we bubble IOException here
         try {
-            return getTimestamp().toIso8601() + " " + host + " " + message;
+            return (getTimestamp().toIso8601() + " " + this.sprintf("%{host} %{message}"));
         } catch (IOException e) {
-            return host + " " + message;
+            String host = (String)this.data.getOrDefault("host", "%{host}");
+            String message = (String)this.data.getOrDefault("message", "%{message}");
+            return (host + " " + message);
         }
     }
 

--- a/logstash-core-event-java/src/main/java/com/logstash/StringInterpolation.java
+++ b/logstash-core-event-java/src/main/java/com/logstash/StringInterpolation.java
@@ -29,6 +29,14 @@ public class StringInterpolation {
         this.cache = new ConcurrentHashMap<>();
     }
 
+    public void clearCache() {
+        this.cache.clear();
+    }
+
+    public int cacheSize() {
+        return this.cache.size();
+    }
+
     public String evaluate(Event event, String template) throws IOException {
         TemplateNode compiledTemplate = (TemplateNode) this.cache.get(template);
 

--- a/logstash-core-event/lib/logstash/string_interpolation.rb
+++ b/logstash-core-event/lib/logstash/string_interpolation.rb
@@ -4,7 +4,7 @@ require "forwardable"
 
 module LogStash
   module StringInterpolation
-    extend self 
+    extend self
 
     # Floats outside of these upper and lower bounds are forcibly converted
     # to scientific notation by Float#to_s
@@ -25,6 +25,16 @@ module LogStash
 
       compiled = CACHE.get_or_default(template, nil) || CACHE.put(template, compile_template(template))
       compiled.evaluate(event)
+    end
+
+    # clear the global compiled templates cache
+    def clear_cache
+      CACHE.clear
+    end
+
+    # @return [Fixnum] the compiled templates cache size
+    def cache_size
+      CACHE.size
     end
 
     private

--- a/logstash-core-event/spec/logstash/event_spec.rb
+++ b/logstash-core-event/spec/logstash/event_spec.rb
@@ -506,11 +506,11 @@ describe LogStash::Event do
     let(:event2) { LogStash::Event.new({ "host" => "bar", "message" => "foo"}) }
 
     it "should cache only one template" do
-      LogStash::StringInterpolation::CACHE.clear
+      LogStash::StringInterpolation.clear_cache
       expect {
         event1.to_s
         event2.to_s
-      }.to change { LogStash::StringInterpolation::CACHE.size }.by(1)
+      }.to change { LogStash::StringInterpolation.cache_size }.by(1)
     end
 
     it "return the string containing the timestamp, the host and the message" do


### PR DESCRIPTION
- adds the `cache_size` and `clear_cache` methods to StringInterpolation
- use these methods in specs
- support methods in the Java Event

Fixes #4249 and relates to elastic/logstash#4191 and #4229 