### PR TITLE
Fix LOGSTASH_HOME having spaces in between

### DIFF
--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -23,7 +23,6 @@ else
   SOURCEPATH=$0
 fi
 
-#LOGSTASH_HOME=$(cd `dirname $SOURCEPATH`/..; pwd)
 DIR=`dirname "$SOURCEPATH"`
 cd "${DIR}/.."
 LOGSTASH_HOME="$(pwd)"
@@ -64,10 +63,11 @@ setup_java() {
     JAVA_OPTS="$JAVA_OPTS -XX:+UseCMSInitiatingOccupancyOnly"
     # Causes the JVM to dump its heap on OutOfMemory.
     JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
-    # The path to the heap dump location
-    # This variable needs to be isolated since it may contain spaces
-    HEAP_DUMP_PATH="-XX:HeapDumpPath=${LOGSTASH_HOME}/heapdump.hprof"
   fi
+
+  # The path to the heap dump location
+  # This variable needs to be isolated since it may contain spaces
+  HEAP_DUMP_PATH="-XX:HeapDumpPath=${LOGSTASH_HOME}/heapdump.hprof"
 
   if [ "$LS_JAVA_OPTS" ] ; then
     # The client set the variable LS_JAVA_OPTS, choosing his own

--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -1,7 +1,7 @@
 unset CDPATH
 # This unwieldy bit of scripting is to try to catch instances where Logstash
 # was launched from a symlink, rather than a full path to the Logstash binary
-if [ -L $0 ]; then
+if [ -L "$0" ]; then
   # Launched from a symlink
   # --Test for the readlink binary
   RL=$(which readlink)
@@ -23,7 +23,10 @@ else
   SOURCEPATH=$0
 fi
 
-LOGSTASH_HOME=$(cd `dirname $SOURCEPATH`/..; pwd)
+#LOGSTASH_HOME=$(cd `dirname $SOURCEPATH`/..; pwd)
+DIR=`dirname "$SOURCEPATH"`
+cd "${DIR}/.."
+LOGSTASH_HOME="$(pwd)"
 export LOGSTASH_HOME
 
 # Defaults you can override with environment variables

--- a/bin/plugin
+++ b/bin/plugin
@@ -1,7 +1,11 @@
 #!/bin/sh
 
 unset CDPATH
-. "$(cd `dirname $0`/..; pwd)/bin/logstash.lib.sh"
+DIR=`dirname "$0"`
+cd "${DIR}/.."
+LOGSTASH_ROOT=$(pwd)
+
+. "${LOGSTASH_ROOT}/bin/logstash.lib.sh"
 setup
 
 # bin/plugin is a short lived ruby script thus we can use aggressive "faster starting JRuby options"


### PR DESCRIPTION
There are issues when having spaces in the path, when using `$(cd `dirname $SOURCEPATH`/..; pwd)` if spaces are present the lookup gets wrong, this happen also when running tasks with rake like `rake test:install-core`

Proposed solution is break up the original expression so it could be made each operation space friendly. 

Fixes #4331 and #3224
