### PR TITLE
Revert accidentally altered Gemfiles in ng_pipeline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,13 +4,17 @@
 source "https://rubygems.org"
 gem "logstash-core", "3.0.0.dev", :path => "./logstash-core"
 gem "logstash-core-event", "3.0.0.dev", :path => "./logstash-core-event"
+# gem "logstash-core-event-java", "3.0.0.dev", :path => "./logstash-core-event-java"
 gem "file-dependencies", "0.1.6"
 gem "ci_reporter_rspec", "1.0.0", :group => :development
 gem "simplecov", :group => :development
 gem "coveralls", :group => :development
+# Tins 1.7 requires the ruby 2.0 platform to install,
+# this gem is a dependency of term-ansi-color which is a dependency of coveralls.
+# 1.6 is the last supported version on jruby.
 gem "tins", "1.6", :group => :development
 gem "rspec", "~> 3.1.0", :group => :development
-gem "logstash-devutils", ">= 0"
+gem "logstash-devutils", "~> 0.0.15", :group => :development
 gem "benchmark-ips", :group => :development
 gem "octokit", "3.8.0", :group => :build
 gem "stud", "~> 0.0.21", :group => :build
@@ -18,10 +22,3 @@ gem "fpm", "~> 1.3.3", :group => :build
 gem "rubyzip", "~> 1.1.7", :group => :build
 gem "gems", "~> 0.8.3", :group => :build
 gem "flores", "~> 0.0.6", :group => :development
-gem "logstash-filter-clone"
-gem "logstash-filter-mutate"
-gem "logstash-filter-multiline"
-gem "logstash-input-generator"
-gem "logstash-input-stdin"
-gem "logstash-input-tcp"
-gem "logstash-output-stdout"

--- a/Gemfile.jruby-1.9.lock
+++ b/Gemfile.jruby-1.9.lock
@@ -13,7 +13,6 @@ PATH
       logstash-core-event (~> 3.0.0.dev)
       minitar (~> 0.5.4)
       pry (~> 0.10.1)
-      rubyzip (~> 1.1.7)
       stud (~> 0.0.19)
       thread_safe (~> 0.3.5)
       treetop (< 1.5.0)
@@ -75,21 +74,10 @@ GEM
       domain_name (~> 0.5)
     i18n (0.6.9)
     insist (1.0.0)
-    jls-grok (0.11.2)
-      cabin (>= 0.6.0)
     jrjackson (0.3.7)
     jruby-openssl (0.9.12-java)
     json (1.8.3-java)
     kramdown (1.9.0)
-    logstash-codec-json (2.0.2)
-      logstash-core (>= 2.0.0.beta2, < 3.0.0)
-    logstash-codec-json_lines (2.0.2)
-      logstash-codec-line
-      logstash-core (>= 2.0.0.beta2, < 3.0.0)
-    logstash-codec-line (2.0.2)
-      logstash-core (>= 2.0.0.beta2, < 3.0.0)
-    logstash-codec-plain (2.0.2)
-      logstash-core (>= 2.0.0.beta2, < 3.0.0)
     logstash-devutils (0.0.18-java)
       gem_publisher
       insist (= 1.0.0)
@@ -99,42 +87,6 @@ GEM
       rspec (~> 3.1.0)
       rspec-wait
       stud (>= 0.0.20)
-    logstash-filter-clone (2.0.3)
-      logstash-core (>= 2.0.0.beta2, < 3.0.0)
-    logstash-filter-grok (2.0.2)
-      jls-grok (~> 0.11.1)
-      logstash-core (>= 2.0.0.beta2, < 3.0.0)
-      logstash-patterns-core
-    logstash-filter-multiline (2.0.2)
-      jls-grok (~> 0.11.0)
-      logstash-core (>= 2.0.0.beta2, < 3.0.0)
-      logstash-filter-mutate
-      logstash-patterns-core
-    logstash-filter-mutate (2.0.2)
-      logstash-core (>= 2.0.0.beta2, < 3.0.0)
-      logstash-filter-grok
-      logstash-patterns-core
-    logstash-input-generator (2.0.2)
-      logstash-codec-plain
-      logstash-core (>= 2.0.0.beta2, < 3.0.0)
-    logstash-input-stdin (2.0.2)
-      concurrent-ruby
-      logstash-codec-json
-      logstash-codec-json_lines
-      logstash-codec-line
-      logstash-codec-plain
-      logstash-core (>= 2.0.0.beta2, < 3.0.0)
-    logstash-input-tcp (2.0.4)
-      logstash-codec-json
-      logstash-codec-json_lines
-      logstash-codec-line
-      logstash-codec-plain
-      logstash-core (>= 2.0.0.beta2, < 3.0.0)
-    logstash-output-stdout (2.0.2)
-      logstash-codec-line
-      logstash-core (>= 2.0.0.beta2, < 3.0.0)
-    logstash-patterns-core (2.0.2)
-      logstash-core (>= 2.0.0.beta2, < 3.0.0)
     method_source (0.8.2)
     mime-types (2.6.2)
     minitar (0.5.4)
@@ -203,14 +155,7 @@ DEPENDENCIES
   gems (~> 0.8.3)
   logstash-core (= 3.0.0.dev)!
   logstash-core-event (= 3.0.0.dev)!
-  logstash-devutils
-  logstash-filter-clone
-  logstash-filter-multiline
-  logstash-filter-mutate
-  logstash-input-generator
-  logstash-input-stdin
-  logstash-input-tcp
-  logstash-output-stdout
+  logstash-devutils (~> 0.0.15)
   octokit (= 3.8.0)
   rspec (~> 3.1.0)
   rubyzip (~> 1.1.7)


### PR DESCRIPTION
The ng pipeline merge accidentally included a Gemfile altered by `rake test:install-core`. This reverts that change to `e390d105e4db9cc832a4613244707def2f331f5d` (https://github.com/elastic/logstash/commit/e390d105e4db9cc832a4613244707def2f331f5d)