### PR TITLE
Allow the Agent to define some identifiers

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -3,17 +3,22 @@ require "logstash/environment"
 require "logstash/errors"
 require "logstash/config/cpu_core_strategy"
 require "logstash/pipeline"
-require "uri"
 require "stud/trap"
+require "uri"
+require "socket"
+require "securerandom"
 
 LogStash::Environment.load_locale!
 
 class LogStash::Agent
 
   attr_writer :logger
+  attr_reader :node_name
 
-  def initialize
+  def initialize(options = {})
     @pipelines = {}
+     
+    @node_name = options[:node_name] || Socket.gethostname
   end
 
   def execute
@@ -34,6 +39,10 @@ class LogStash::Agent
 
   def add_pipeline(pipeline_id, config_str, settings = {})
     @pipelines[pipeline_id] = LogStash::Pipeline.new(config_str, settings.merge(:pipeline_id => pipeline_id))
+  end
+
+  def node_uuid
+    @node_uuid ||= SecureRandom.uuid
   end
 
   private

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -75,18 +75,19 @@ class LogStash::Runner < Clamp::Command
     I18n.t("logstash.runner.flag.rubyshell"),
     :attribute_name => :ruby_shell
 
-  attr_reader :agent
+  option ["-n", "--node-name"], "NAME", 
+    I18n.t("logstash.runner.flag.node_name"),
+    :attribute_name => :node_name
 
-  def initialize(*args)
-    @agent = LogStash::Agent.new
-    super(*args)
-  end
+  attr_reader :agent
 
   def execute
     require "logstash/util"
     require "logstash/util/java_version"
     require "stud/task"
     require "cabin" # gem 'cabin'
+
+    @agent = LogStash::Agent.new({ :node_name => node_name })
 
     @logger = Cabin::Channel.get(LogStash)
 

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -209,3 +209,6 @@ en:
         rubyshell: |+
           Drop to shell instead of running as normal.
           Valid shells are "irb" and "pry"
+        node_name: |+
+          Specify the name of this logstash instance, if no value is given
+          it will default to the current hostname.

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -1,5 +1,27 @@
 # encoding: utf-8
-require 'spec_helper'
+require "logstash/agent"
+require "spec_helper"
 
 describe LogStash::Agent do
+  context "#node_name" do
+    let(:hostname) { "the-logstash" }
+
+    before do
+      allow(Socket).to receive(:gethostname).and_return(hostname)
+    end
+
+    it "fallback to hostname when no name is provided" do
+      expect(LogStash::Agent.new.node_name).to be(hostname)
+    end
+
+    it "uses the user provided name" do
+      expect(LogStash::Agent.new({ :node_name => "a-name" }).node_name).to eq("a-name")
+    end
+  end
+
+  context "#node_uuid" do
+    it "create a unique uuid between agent instances" do
+      expect(LogStash::Agent.new.node_uuid).not_to be(LogStash::Agent.new.node_uuid)
+    end
+  end
 end

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -24,8 +24,8 @@ describe LogStash::Runner do
       let(:args) { ["-e", ""] }
 
       it "should execute the agent" do
-        expect(subject.agent).to receive(:add_pipeline).once
-        expect(subject.agent).to receive(:execute).once
+        expect_any_instance_of(LogStash::Agent).to receive(:add_pipeline).once
+        expect_any_instance_of(LogStash::Agent).to receive(:execute).once
         subject.run(args)
       end
     end


### PR DESCRIPTION
This PR allow the user to set the name of the logstash instance with the
`-n` or `--name` option, if no name is provided the agent will fallback
to the current hostname of the machine.

This PR also add the `node_uuid` to the agent which is unique between
each new instance of the agent, it will lazy generate a UUID v4 on
invocation.

Fixes: #4353