### PR TITLE
Translation missing for the `--allow-unsafe-shutdown`

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -67,7 +67,7 @@ class LogStash::Runner < Clamp::Command
     :attribute_name => :config_test
 
   option "--[no-]allow-unsafe-shutdown", :flag,
-    I18n.t("logstash.agent.flag.unsafe_shutdown"),
+    I18n.t("logstash.runner.flag.unsafe_shutdown"),
     :attribute_name => :unsafe_shutdown,
     :default => false
 


### PR DESCRIPTION
Fix the translation missing when running the `bin/logstash --help`
command