### PR TITLE
Improved semantics for OutputDelegator

### DIFF
--- a/docs/static/include/pluginbody.asciidoc
+++ b/docs/static/include/pluginbody.asciidoc
@@ -262,7 +262,7 @@ endif::filter_method[]
 // Output (conditionally recognized by the presence of the receive_method
 // attribute)
 // /////////////////////////////////////////////////////////////////////////////
-ifdef::receive_method[]
+ifdef::multi_receive_method[]
 [source,ruby]
 [subs="attributes"]
 ----------------------------------
@@ -275,17 +275,43 @@ require "logstash/namespace"
 class LogStash::{pluginclass}::{pluginnamecap} < LogStash::{pluginclass}::Base
   config_name "example"
 
+  # If declared logstash will only allow a single instance of this plugin
+  # to exist, regardless of how many CPU cores logstash detects. This is best
+  # used in cases like the File output, where separate threads writing to a single
+  # File would only cause problems.
+  #
+  # respond_to? check needed for backwards compatibility with < 2.2 Logstashes
+  declare_workers_not_supported! if self.respond_to?(:workers_not_supported!)
+
+  # If declared threadsafe logstash will only ever create one
+  # instance of this plugin per pipeline.
+  # That instance will be shared across all workers
+  # It is up to the plugin author to correctly write concurrent code!
+  #
+  # respond_to? check needed for backwards compatibility with < 2.2 Logstashes
+  declare_threadsafe! if self.respond_to?(:declare_threadsafe!)
+
   public
   def register
+    # Does the same thing as declare_workers_not_supported!
+    # But works in < 2.2 logstashes
+    # workers_not_supported
   end # def register
 
   public
+  # Takes an array of events
+  def multi_receive(events)
+  end # def multi_receive
+
+  public
+  # Needed for logstash < 2.2 compatibility
+  # Takes events one at a time
   def receive(event)
   end # def receive
 
 end # class LogStash::{pluginclass}::{pluginnamecap}
 ----------------------------------
-endif::receive_method[]
+endif::multi_receive_method[]
 
 ==== Coding {plugintype} plugins
 
@@ -681,7 +707,7 @@ endif::blockinput[]
 endif::run_method[]
 
 // /////////////////////////////////////////////////////////////////////////////
-// If receive_method is defined (should only be for output plugin page)
+// If multi_receive_method is defined (should only be for output plugin page)
 // /////////////////////////////////////////////////////////////////////////////
 ifdef::receive_method[]
 

--- a/docs/static/output.asciidoc
+++ b/docs/static/output.asciidoc
@@ -1,5 +1,5 @@
 :register_method:	true
-:receive_method:	true
+:multi_receive_method:	true
 :plugintype:    	output
 :pluginclass:   	Outputs
 :pluginname:    	example
@@ -9,6 +9,6 @@
 
 :getstarted: Let's step through creating an {plugintype} plugin using the https://github.com/logstash-plugins/logstash-output-example/[example {plugintype} plugin].
 
-:methodheader: Logstash outputs must implement the `register` and `receive` methods.
+:methodheader: Logstash outputs must implement the `register` and `multi_receive` methods.
 
 include::include/pluginbody.asciidoc[]

--- a/logstash-core/lib/logstash/output_delegator.rb
+++ b/logstash-core/lib/logstash/output_delegator.rb
@@ -54,6 +54,7 @@ module LogStash; class OutputDelegator
     # The other 2% you get weird errors about rebinding to the same object
     # Until we switch to Jruby 9.x keep the define_singleton_method parts
     # the way they are, with a block
+    # See https://github.com/jruby/jruby/issues/3582
     if threadsafe?
       @threadsafe_worker = @workers.first
       define_singleton_method(:multi_receive) do |events|

--- a/logstash-core/lib/logstash/output_delegator.rb
+++ b/logstash-core/lib/logstash/output_delegator.rb
@@ -7,7 +7,7 @@ require "concurrent/atomic/atomic_fixnum"
 # of 'workers' the output plugin is configured with.
 #
 # This plugin also records some basic statistics
-module LogStash; class OutputDelegator
+module LogStash class OutputDelegator
   attr_reader :workers, :config, :worker_count, :threadsafe
 
   # The *args this takes are the same format that a Outputs::Base takes. A list of hashes with parameters in them
@@ -145,14 +145,6 @@ module LogStash; class OutputDelegator
   end
 
   private
-
-  # Needed for tests
-  def threadsafe_worker
-    @threadsafe_worker
-  end
-
-  # Needed for tests
-  def worker_queue
-    @worker_queue
-  end
+  # Needed for testing, so private
+  attr_reader :threadsafe_worker, :worker_queue
 end end

--- a/logstash-core/lib/logstash/output_delegator.rb
+++ b/logstash-core/lib/logstash/output_delegator.rb
@@ -113,7 +113,6 @@ module LogStash; class OutputDelegator
   def worker_multi_receive(events)
     @events_received.increment(events.length)
 
-    @logger.debug("worker queue pop")
     worker = @worker_queue.pop
     begin
       worker.multi_receive(events)

--- a/logstash-core/lib/logstash/output_delegator.rb
+++ b/logstash-core/lib/logstash/output_delegator.rb
@@ -31,6 +31,8 @@ module LogStash; class OutputDelegator
     # DO NOT move this statement before the instantiation of the first single instance
     # Read the note above to understand why
     @worker_count = calculate_worker_count(default_worker_count)
+    @logger.debug("Will start workers for output", :worker_count => @worker_count, :class => klass)
+
     warn_on_worker_override!
     # This queue is used to manage sharing across threads
     @worker_queue = SizedQueue.new(@worker_count)

--- a/logstash-core/lib/logstash/output_delegator.rb
+++ b/logstash-core/lib/logstash/output_delegator.rb
@@ -74,10 +74,12 @@ module LogStash; class OutputDelegator
     # The user has configured extra workers, but this plugin doesn't support it :(
     if worker_limits_overriden?
       message = @klass.workers_not_supported_message
+      warning_meta = {:plugin => @klass.config_name, :worker_count => @config["workers"]}
       if message
-        @logger.warn(I18n.t("logstash.pipeline.output-worker-unsupported-with-message", :plugin => @klass.config_name, :worker_count => @config["workers"], :message => message))
+        warning_meta[:message] = message
+        @logger.warn(I18n.t("logstash.pipeline.output-worker-unsupported-with-message", warning_meta))
       else
-        @logger.warn(I18n.t("logstash.pipeline.output-worker-unsupported", :plugin => @klass.config_name, :worker_count => @config["workers"], :message => message))
+        @logger.warn(I18n.t("logstash.pipeline.output-worker-unsupported", warning_meta))
       end
     end
   end

--- a/logstash-core/lib/logstash/outputs/base.rb
+++ b/logstash-core/lib/logstash/outputs/base.rb
@@ -25,7 +25,7 @@ class LogStash::Outputs::Base < LogStash::Plugin
   # Note that this setting may not be useful for all outputs.
   config :workers, :validate => :number, :default => 1
 
-  attr_reader :worker_plugins, :available_workers, :workers, :worker_plugins
+  attr_reader :worker_plugins, :available_workers, :workers, :worker_plugins, :workers_not_supported
 
   def self.declare_threadsafe!
     declare_workers_not_supported!
@@ -41,14 +41,20 @@ class LogStash::Outputs::Base < LogStash::Plugin
     @workers_not_supported = true
   end
 
+  def self.workers_not_supported_message
+    @workers_not_supported_message
+  end
+
   def self.workers_not_supported?
-    @workers_not_supported == true
+    !!@workers_not_supported
   end
 
   public
   # TODO: Remove this in the next major version after Logstash 2.x
+  # Post 2.x it should raise an error and tell people to use the class level
+  # declaration
   def workers_not_supported(message=nil)
-    raise ArgumentError, "Outputs::Base#workers_not_supported is no longer a valid part of the logstash API, please use the class method Outputs::Base.declare_workers_not_supported!"
+    self.class.declare_workers_not_supported!(message)
   end
 
   public

--- a/logstash-core/lib/logstash/outputs/base.rb
+++ b/logstash-core/lib/logstash/outputs/base.rb
@@ -27,15 +27,28 @@ class LogStash::Outputs::Base < LogStash::Plugin
 
   attr_reader :worker_plugins, :available_workers, :workers, :worker_plugins
 
+  def self.declare_threadsafe!
+    declare_workers_not_supported!
+    @threadsafe = true
+  end
+
+  def self.threadsafe?
+    @threadsafe == true
+  end
+
+  def self.declare_workers_not_supported!(message=nil)
+    @workers_not_supported_message = message
+    @workers_not_supported = true
+  end
+
+  def self.workers_not_supported?
+    @workers_not_supported == true
+  end
+
   public
+  # TODO: Remove this in the next major version after Logstash 2.x
   def workers_not_supported(message=nil)
-    return if @workers == 1
-    if message
-      @logger.warn(I18n.t("logstash.pipeline.output-worker-unsupported-with-message", :plugin => self.class.config_name, :worker_count => @workers, :message => message))
-    else
-      @logger.warn(I18n.t("logstash.pipeline.output-worker-unsupported", :plugin => self.class.config_name, :worker_count => @workers))
-    end
-    @workers = 1
+    raise ArgumentError, "Outputs::Base#workers_not_supported is no longer a valid part of the logstash API, please use the class method Outputs::Base.declare_workers_not_supported!"
   end
 
   public

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -30,6 +30,8 @@ module LogStash; class Pipeline
   def initialize(config_str, settings = {})
     @pipeline_id = settings[:pipeline_id] || self.object_id
     @logger = Cabin::Channel.get(LogStash)
+    @settings = DEFAULT_SETTINGS.clone
+    settings.each {|setting, value| configure(setting, value) }
     @reporter = LogStash::PipelineReporter.new(@logger, self)
 
     @inputs = nil
@@ -65,12 +67,10 @@ module LogStash; class Pipeline
     # in-flight buffers
     @input_queue_pop_mutex = Mutex.new
     @input_threads = []
-    @settings = DEFAULT_SETTINGS.clone
     # @ready requires thread safety since it is typically polled from outside the pipeline thread
     @ready = Concurrent::AtomicBoolean.new(false)
     @running = Concurrent::AtomicBoolean.new(false)
     @flushing = Concurrent::AtomicReference.new(false)
-    settings.each {|setting, value| configure(setting, value) }
 
     start_flusher
   end # def initialize
@@ -379,10 +379,14 @@ module LogStash; class Pipeline
     klass = LogStash::Plugin.lookup(plugin_type, name)
 
     if plugin_type == "output"
-      LogStash::OutputDelegator.new(@logger, klass, *args)
+      LogStash::OutputDelegator.new(@logger, klass, default_output_workers, *args)
     else
       klass.new(*args)
     end
+  end
+
+  def default_output_workers
+    @settings[:pipeline_workers] || @settings[:default_pipeline_workers]
   end
 
   # for backward compatibility in devutils for the rspec helpers, this method is not used

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -39,7 +39,7 @@ en:
       output-worker-unsupported-with-message: >-
         %{plugin} output plugin: setting 'workers => %{worker_count}' is not
         supported by this plugin. I will continue working as if you had not set
-        this setting.
+        this setting. Reason: %{message}
     plugin:
       deprecated_milestone: >-
         %{plugin} plugin is using the 'milestone' method to declare the version

--- a/logstash-core/spec/logstash/output_delegator_spec.rb
+++ b/logstash-core/spec/logstash/output_delegator_spec.rb
@@ -115,6 +115,10 @@ describe LogStash::OutputDelegator do
     let(:default_worker_count) { 2 }
     let(:out_klass) { LogStash::Outputs::NOOPDelLegacyNoWorkers }
 
+    before do
+      allow(logger).to receive(:debug).with(any_args)
+    end
+
     it "should only setup one worker" do
       expect(subject.worker_count).to eql(1)
     end

--- a/logstash-core/spec/logstash/output_delegator_spec.rb
+++ b/logstash-core/spec/logstash/output_delegator_spec.rb
@@ -1,51 +1,122 @@
 # encoding: utf-8
 require 'spec_helper'
 
-
-
 describe LogStash::OutputDelegator do
   let(:logger) { double("logger") }
-  let(:out_klass) { double("output klass") }
-  let(:out_inst) { double("output instance") }
+  let(:events) { 7.times.map { LogStash::Event.new }}
+  let(:default_worker_count) { 1 }
 
-  subject { described_class.new(logger, out_klass, 1) }
+  subject { described_class.new(logger, out_klass, default_worker_count) }
 
-  before do
-    allow(out_klass).to receive(:new).with(any_args).and_return(out_inst)
-    allow(out_klass).to receive(:threadsafe?).and_return(false)
-    allow(out_klass).to receive(:workers_not_supported?).and_return(false)
-    allow(out_inst).to receive(:register)
-    allow(logger).to receive(:debug).with(any_args)
-  end
-
-  it "should initialize cleanly" do
-    expect { subject }.not_to raise_error
-  end
-
-  context "after having received a batch of events" do
-    let(:events) { 7.times.map { LogStash::Event.new }}
+  context "with a plain output plugin" do
+    let(:out_klass) { double("output klass") }
+    let(:out_inst) { double("output instance") }
 
     before do
+      allow(out_klass).to receive(:new).with(any_args).and_return(out_inst)
+      allow(out_klass).to receive(:threadsafe?).and_return(false)
+      allow(out_klass).to receive(:workers_not_supported?).and_return(false)
+      allow(out_inst).to receive(:register)
       allow(out_inst).to receive(:multi_receive)
-      subject.multi_receive(events)
+      allow(logger).to receive(:debug).with(any_args)
     end
 
-    it "should pass the events through" do
-      expect(out_inst).to have_received(:multi_receive).with(events)
+    it "should initialize cleanly" do
+      expect { subject }.not_to raise_error
     end
 
-    it "should increment the number of events received" do
-      expect(subject.events_received).to eql(events.length)
+    context "after having received a batch of events" do
+      before do
+        subject.multi_receive(events)
+      end
+
+      it "should pass the events through" do
+        expect(out_inst).to have_received(:multi_receive).with(events)
+      end
+
+      it "should increment the number of events received" do
+        expect(subject.events_received).to eql(events.length)
+      end
+    end
+
+    it "should register all workers on register" do
+      expect(out_inst).to receive(:register)
+      subject.register
+    end
+
+    it "should close all workers when closing" do
+      expect(out_inst).to receive(:do_close)
+      subject.do_close
+    end
+
+    describe "concurrency and worker support" do
+      describe "non-threadsafe outputs that allow workers" do
+        let(:default_worker_count) { 3 }
+
+        before do
+          allow(out_klass).to receive(:threadsafe?).and_return(false)
+          allow(out_klass).to receive(:workers_not_supported?).and_return(false)
+        end
+
+        it "should instantiate multiple workers" do
+          expect(subject.workers.length).to eql(default_worker_count)
+        end
+
+        it "should send received events to the worker" do
+          expect(out_inst).to receive(:multi_receive).with(events)
+          subject.multi_receive(events)
+        end
+      end
+
+      describe "threadsafe outputs" do
+        before do
+          allow(out_klass).to receive(:threadsafe?).and_return(true)
+          allow(out_klass).to receive(:workers_not_supported?).and_return(false)
+        end
+
+        it "should return true when threadsafe? is invoked" do
+          expect(subject.threadsafe?).to eql(true)
+        end
+
+        it "should define a threadsafe_worker" do
+          expect(subject.send(:threadsafe_worker)).to eql(out_inst)
+        end
+
+        it "should utilize threadsafe_multi_receive" do
+          expect(subject.send(:threadsafe_worker)).to receive(:multi_receive).with(events)
+          subject.multi_receive(events)
+        end
+
+        it "should not utilize the worker queue" do
+          expect(subject.send(:worker_queue)).not_to receive(:pop)
+          subject.multi_receive(events)
+        end
+
+        it "should send received events to the worker" do
+          expect(out_inst).to receive(:multi_receive).with(events)
+          subject.multi_receive(events)
+        end
+      end
     end
   end
 
-  it "should register all workers on register" do
-    expect(out_inst).to receive(:register)
-    subject.register
+  # This may seem suspiciously similar to the class in outputs/base_spec
+  # but, in fact, we need a whole new class because using this even once
+  # will immutably modify the base class
+  class LogStash::Outputs::NOOPDelLegacyNoWorkers < ::LogStash::Outputs::Base
+    LEGACY_WORKERS_NOT_SUPPORTED_REASON = "legacy reason"
+
+    def register
+      workers_not_supported(LEGACY_WORKERS_NOT_SUPPORTED_REASON)
+    end
   end
 
-  it "should close all workers when closing" do
-    expect(out_inst).to receive(:do_close)
-    subject.do_close
+  describe "legacy output workers_not_supported" do
+    let(:default_worker_count) { 2 }
+    let(:out_klass) { LogStash::Outputs::NOOPDelLegacyNoWorkers }
+
+    it "should only setup one worker" do
+      expect(subject.worker_count).to eql(1)
+    end
   end
 end

--- a/logstash-core/spec/logstash/output_delegator_spec.rb
+++ b/logstash-core/spec/logstash/output_delegator_spec.rb
@@ -8,10 +8,12 @@ describe LogStash::OutputDelegator do
   let(:out_klass) { double("output klass") }
   let(:out_inst) { double("output instance") }
 
-  subject { described_class.new(logger, out_klass) }
+  subject { described_class.new(logger, out_klass, 1) }
 
   before do
     allow(out_klass).to receive(:new).with(any_args).and_return(out_inst)
+    allow(out_klass).to receive(:threadsafe?).and_return(false)
+    allow(out_klass).to receive(:workers_not_supported?).and_return(false)
     allow(out_inst).to receive(:register)
     allow(logger).to receive(:debug).with(any_args)
   end

--- a/logstash-core/spec/logstash/outputs/base_spec.rb
+++ b/logstash-core/spec/logstash/outputs/base_spec.rb
@@ -15,6 +15,14 @@ class LogStash::Outputs::NOOP < LogStash::Outputs::Base
   end
 end
 
+class LogStash::Outputs::NOOPLegacyNoWorkers < ::LogStash::Outputs::Base
+  LEGACY_WORKERS_NOT_SUPPORTED_REASON = "legacy reason"
+
+  def register
+    workers_not_supported(LEGACY_WORKERS_NOT_SUPPORTED_REASON)
+  end
+end
+
 describe "LogStash::Outputs::Base#new" do
   it "should instantiate cleanly" do
     params = { "dummy_option" => "potatoes", "codec" => "json", "workers" => 2 }
@@ -23,5 +31,10 @@ describe "LogStash::Outputs::Base#new" do
     expect do
       LogStash::Outputs::NOOP.new(params.dup)
     end.not_to raise_error
+  end
+
+  it "should move workers_not_supported declarations up to the class level" do
+    LogStash::Outputs::NOOPLegacyNoWorkers.new.register
+    expect(LogStash::Outputs::NOOPLegacyNoWorkers.workers_not_supported?).to eql(true)
   end
 end

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -209,7 +209,7 @@ describe LogStash::Pipeline do
         pipeline.run
 
         expect(pipeline.outputs.size ).to eq(1)
-        expect(pipeline.outputs.first.workers.size ).to eq(1)
+        expect(pipeline.outputs.first.workers.size ).to eq(pipeline.default_output_workers)
         expect(pipeline.outputs.first.workers.first.num_closes ).to eq(1)
       end
 


### PR DESCRIPTION
This commit greatly improves the semantics for the OutputDelegator. It
now:
* Has an API for declaring if an output is threadsafe which lets us economize on the number of instances (we only need one shared across N threads)
* By default sets the number of workers for an output to be == the
  number of pipeline workers (for non-threadsafe outputs)
* Moves the worker_safe API (which declares whether the plugin supports > 1 workers) to the class, not instance level
* Strongly enforces the worker safety API. Previously a warning would be logged but nothing else.
* Should Provide better performance for threadsafe plugins. A plugin like the file output should only need a mutex around the file write and could be written to be threadsafe. This opens the door to multiple threads running, say, their codecs simultaneously.

This commit is built on top of some of the ideas in https://github.com/elastic/logstash/issues/4367

