### PR TITLE
Add a `WrappedSynchronousQueue#offer` method

### DIFF
--- a/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
@@ -9,10 +9,24 @@ module LogStash; module Util
       @queue = java.util.concurrent.SynchronousQueue.new()
     end
 
+    # Push an object to the queue if the queue is full
+    # it will block until the object can be added to the queue.
+    #
+    # @param [Object] Object to add to the queue
     def push(obj)
       @queue.put(obj)
     end
     alias_method(:<<, :push)
+
+    # Offer an object to the queue, wait for the specified amout of time.
+    # If adding to the queue was successfull it wil return true, false otherwise.
+    #
+    # @param [Object] Object to add to the queue
+    # @param [Integer] Time in milliseconds to wait before giving up
+    # @return [Boolean] True if adding was successfull if not it return false
+    def offer(obj, timeout_ms)
+      @queue.offer(obj, timeout_ms, TimeUnit::MILLISECONDS)
+    end
 
     # Blocking
     def take

--- a/logstash-core/spec/logstash/util/wrapped_synchronous_queue_spec.rb
+++ b/logstash-core/spec/logstash/util/wrapped_synchronous_queue_spec.rb
@@ -1,0 +1,28 @@
+# encoding: utf-8
+require "spec_helper"
+require "logstash/util/wrapped_synchronous_queue"
+
+describe LogStash::Util::WrappedSynchronousQueue do
+ context "#offer" do
+   context "queue is blocked" do
+     it "fails and give feedback" do
+       expect(subject.offer("Bonjour", 2)).to be_falsey
+     end
+   end
+
+   context "queue is not blocked" do
+     before do
+       @consumer = Thread.new { loop { subject.take } }
+       sleep(0.1)
+     end
+
+     after do
+       @consumer.kill
+     end
+     
+     it "inserts successfully" do
+       expect(subject.offer("Bonjour", 20)).to be_truthy
+     end
+   end
+ end
+end


### PR DESCRIPTION
Expose the Java's `#offer` method of the `SynchronousQueue` class,
This method allow the input developper to correctly apply back pressure
to the network clients.

If you use `#push` it will block forever until the pipeline free some
space, this behavior is sufficient if the pipeline outputs are healthy.
But if the output stale the backpressure will be applied up to the input
(producers) when reading a file this scenario is fine since we will just
stop reading the file until the thread unblock again.

In the context of network clients, the story is a bit different the
clients will timeout and try to reconnect to restransmit their payload
creating multiple new connection thread block on the queue. In some case
this will lead into a OOM issues.

This PR is the first step to communicate that the queue is under
pressure.