### PR TITLE
Add http poller to default plugins list

### DIFF
--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -56,6 +56,7 @@ module LogStash
       logstash-input-generator
       logstash-input-graphite
       logstash-input-http
+      logstash-input-http_poller
       logstash-input-imap
       logstash-input-irc
       logstash-input-jdbc


### PR DESCRIPTION
This plugin is fairly popular, won't increase the bundle size at all, and should probably be a default plugin.

I'd like to target it for the 2.2 release if possible!