### PR TITLE
Remove sized_queue.rb

### DIFF
--- a/logstash-core/lib/logstash/sized_queue.rb
+++ b/logstash-core/lib/logstash/sized_queue.rb
@@ -1,8 +1,0 @@
-# encoding: utf-8
-require "logstash/namespace"
-require "logstash/logging"
-
-require "thread" # for SizedQueue
-class LogStash::SizedQueue < SizedQueue
-  # TODO(sissel): Soon will implement push/pop stats, etc
-end


### PR DESCRIPTION
Since Logstash 2.2, we now use Java SynchronousQueue instead of ruby
sizequeue