### PR TITLE
rename pipeline-worker settings to symbols

### DIFF
--- a/logstash-core/lib/logstash/util/worker_threads_default_printer.rb
+++ b/logstash-core/lib/logstash/util/worker_threads_default_printer.rb
@@ -6,8 +6,8 @@ require "logstash/util"
 module LogStash module Util class WorkerThreadsDefaultPrinter
 
   def initialize(settings)
-    @setting = settings.fetch('pipeline-workers', 0)
-    @default = settings.fetch('default-pipeline-workers', 0)
+    @setting = settings.fetch(:pipeline_workers, 0)
+    @default = settings.fetch(:default_pipeline_workers, 0)
   end
 
   def visit(collector)

--- a/logstash-core/spec/logstash/util/defaults_printer_spec.rb
+++ b/logstash-core/spec/logstash/util/defaults_printer_spec.rb
@@ -25,7 +25,7 @@ describe LogStash::Util::DefaultsPrinter do
 
     context 'when the settings hash has content' do
       let(:worker_queue) { 42 }
-      let(:settings) { {'pipeline-workers' => workers} }
+      let(:settings) { {:pipeline_workers => workers} }
       it_behaves_like "a defaults printer"
     end
   end
@@ -42,7 +42,7 @@ describe LogStash::Util::DefaultsPrinter do
 
     context 'when the settings hash has content' do
       let(:workers) { 13 }
-      let(:settings) { {'pipeline-workers' => workers} }
+      let(:settings) { {:pipeline_workers => workers} }
 
       it_behaves_like "a defaults printer"
     end

--- a/logstash-core/spec/logstash/util/worker_threads_default_printer_spec.rb
+++ b/logstash-core/spec/logstash/util/worker_threads_default_printer_spec.rb
@@ -19,7 +19,7 @@ describe LogStash::Util::WorkerThreadsDefaultPrinter do
     end
 
     context 'when the settings hash has both user and default content' do
-      let(:settings) { {'pipeline-workers' => 42, 'default-pipeline-workers' => 5} }
+      let(:settings) { {:pipeline_workers => 42, :default_pipeline_workers => 5} }
 
       it 'adds two strings' do
         expect(collector).to eq(["User set pipeline workers: 42", "Default pipeline workers: 5"])
@@ -27,7 +27,7 @@ describe LogStash::Util::WorkerThreadsDefaultPrinter do
     end
 
     context 'when the settings hash has only user content' do
-      let(:settings) { {'pipeline-workers' => 42} }
+      let(:settings) { {:pipeline_workers => 42} }
 
       it 'adds a string with user set pipeline workers' do
         expect(collector.first).to eq("User set pipeline workers: 42")
@@ -35,7 +35,7 @@ describe LogStash::Util::WorkerThreadsDefaultPrinter do
     end
 
     context 'when the settings hash has only default content' do
-      let(:settings) { {'default-pipeline-workers' => 5} }
+      let(:settings) { {:default_pipeline_workers => 5} }
 
       it 'adds a string with default pipeline workers' do
         expect(collector.first).to eq("Default pipeline workers: 5")


### PR DESCRIPTION
The next generation pipeline PR changed the [pipeline settings to be symbols](https://github.com/elastic/logstash/blob/028576ba6f141f57c180c8f3dbffa14cb24967c0/logstash-core/lib/logstash/pipeline.rb#L23-L29), which made the defaults printer class not show the values of workers because it expected string instead.

This PR changes all references to settings in the Printer classes to be symbols too.

This targets master, 2.x and 2.2

Fixes #4429 