### PR TITLE
Bump version to 2.2.0.snapshot2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,8 @@
 # If you modify this file manually all comments and formatting will be lost.
 
 source "https://rubygems.org"
-gem "logstash-core", "2.2.0", :path => "./logstash-core"
-gem "logstash-core-event", "2.2.0", :path => "./logstash-core-event"
-# gem "logstash-core-event-java", "2.2.0.dev", :path => "./logstash-core-event-java"
+gem "logstash-core", "2.2.0.snapshot2"
+gem "logstash-core-event", "2.2.0.snapshot2"
 gem "file-dependencies", "0.1.6"
 gem "ci_reporter_rspec", "1.0.0", :group => :development
 gem "simplecov", :group => :development
@@ -123,3 +122,4 @@ gem "logstash-output-stdout"
 gem "logstash-output-tcp"
 gem "logstash-output-udp"
 gem "logstash-output-kafka"
+gem "logstash-input-http_poller"

--- a/Gemfile.jruby-1.9.lock
+++ b/Gemfile.jruby-1.9.lock
@@ -1,28 +1,3 @@
-PATH
-  remote: ./logstash-core-event
-  specs:
-    logstash-core-event (2.2.0-java)
-
-PATH
-  remote: ./logstash-core
-  specs:
-    logstash-core (2.2.0-java)
-      cabin (~> 0.7.0)
-      clamp (~> 0.6.5)
-      concurrent-ruby (= 0.9.2)
-      filesize (= 0.0.4)
-      gems (~> 0.8.3)
-      i18n (= 0.6.9)
-      jrjackson (~> 0.3.7)
-      jruby-openssl (>= 0.9.11)
-      logstash-core-event (~> 2.2.0)
-      minitar (~> 0.5.4)
-      pry (~> 0.10.1)
-      rubyzip (~> 1.1.7)
-      stud (~> 0.0.19)
-      thread_safe (~> 0.3.5)
-      treetop (< 1.5.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -48,7 +23,7 @@ GEM
     buftok (0.2.0)
     builder (3.2.2)
     cabin (0.7.2)
-    childprocess (0.5.8)
+    childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
     ci_reporter (2.0.0)
       builder (>= 2.1.2)
@@ -90,7 +65,7 @@ GEM
     file-dependencies (0.1.6)
       minitar
     filesize (0.0.4)
-    filewatch (0.6.7)
+    filewatch (0.7.1)
     flores (0.0.6)
     fpm (1.3.3)
       arr-pm (~> 0.0.9)
@@ -132,10 +107,10 @@ GEM
       concurrent-ruby
     jmespath (1.1.3)
     jrjackson (0.3.8)
-    jruby-kafka (1.4.0-java)
+    jruby-kafka (1.5.0-java)
       jar-dependencies (~> 0)
-      ruby-maven (~> 3.1)
-    jruby-openssl (0.9.12-java)
+      ruby-maven (~> 3.3.8)
+    jruby-openssl (0.9.13-java)
     json (1.8.3-java)
     kramdown (1.9.0)
     logstash-codec-collectd (2.0.2)
@@ -168,7 +143,7 @@ GEM
     logstash-codec-msgpack (2.0.2-java)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       msgpack-jruby
-    logstash-codec-multiline (2.0.4)
+    logstash-codec-multiline (2.0.6)
       jls-grok (~> 0.11.1)
       logstash-core (>= 2.0.0, < 3.0.0)
       logstash-patterns-core
@@ -179,9 +154,26 @@ GEM
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
     logstash-codec-plain (2.0.2)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
-    logstash-codec-rubydebug (2.0.4)
+    logstash-codec-rubydebug (2.0.5)
       awesome_print
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
+    logstash-core (2.2.0.snapshot2-java)
+      cabin (~> 0.7.0)
+      clamp (~> 0.6.5)
+      concurrent-ruby (= 0.9.2)
+      filesize (= 0.0.4)
+      gems (~> 0.8.3)
+      i18n (= 0.6.9)
+      jrjackson (~> 0.3.7)
+      jruby-openssl (= 0.9.13)
+      logstash-core-event (~> 2.2.0.snapshot2)
+      minitar (~> 0.5.4)
+      pry (~> 0.10.1)
+      rubyzip (~> 1.1.7)
+      stud (~> 0.0.19)
+      thread_safe (~> 0.3.5)
+      treetop (< 1.5.0)
+    logstash-core-event (2.2.0.snapshot2-java)
     logstash-devutils (0.0.18-java)
       gem_publisher
       insist (= 1.0.0)
@@ -200,7 +192,7 @@ GEM
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
     logstash-filter-csv (2.1.1)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
-    logstash-filter-date (2.0.2)
+    logstash-filter-date (2.1.1)
       logstash-codec-json
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       logstash-input-generator
@@ -209,7 +201,7 @@ GEM
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
     logstash-filter-drop (2.0.2)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
-    logstash-filter-fingerprint (2.0.2)
+    logstash-filter-fingerprint (2.0.3)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       murmurhash3
     logstash-filter-geoip (2.0.5)
@@ -259,11 +251,12 @@ GEM
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       nokogiri
       xml-simple
-    logstash-input-beats (2.0.3)
+    logstash-input-beats (2.1.0)
       concurrent-ruby (~> 0.9.2)
-      logstash-codec-multiline (~> 2.0.3)
+      logstash-codec-multiline (~> 2.0.5)
       logstash-codec-plain
       logstash-core (>= 2.0.0, < 3.0.0)
+      thread_safe (~> 0.3.5)
     logstash-input-couchdb_changes (2.0.2)
       json
       logstash-codec-plain
@@ -282,12 +275,12 @@ GEM
       logstash-codec-plain
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       stud (~> 0.0.22)
-    logstash-input-file (2.0.3)
+    logstash-input-file (2.1.3)
       addressable
-      filewatch (~> 0.6, >= 0.6.5)
-      logstash-codec-multiline (~> 2.0.3)
+      filewatch (~> 0.7, >= 0.7.1)
+      logstash-codec-multiline (~> 2.0.5)
       logstash-codec-plain
-      logstash-core (>= 2.0.0.beta2, < 3.0.0)
+      logstash-core (>= 2.0.0, < 3.0.0)
     logstash-input-ganglia (2.0.4)
       logstash-codec-plain
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
@@ -312,6 +305,11 @@ GEM
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       puma (~> 2.11.3)
       stud
+    logstash-input-http_poller (2.0.3)
+      logstash-codec-plain
+      logstash-core (>= 2.0.0.beta2, < 3.0.0)
+      logstash-mixin-http_client (>= 2.1.0, < 3.0.0)
+      stud (~> 0.0.22)
     logstash-input-imap (2.0.3)
       logstash-codec-plain
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
@@ -322,7 +320,7 @@ GEM
       logstash-codec-plain
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       stud (~> 0.0.22)
-    logstash-input-jdbc (2.1.1)
+    logstash-input-jdbc (3.0.0)
       logstash-codec-plain
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       rufus-scheduler
@@ -335,7 +333,7 @@ GEM
       logstash-codec-plain
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       stud (>= 0.0.22, < 0.1.0)
-    logstash-input-log4j (2.0.4-java)
+    logstash-input-log4j (2.0.5-java)
       logstash-codec-plain
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
     logstash-input-lumberjack (2.0.5)
@@ -413,10 +411,10 @@ GEM
       aws-sdk-v1 (>= 1.61.0)
       logstash-codec-plain
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
-    logstash-mixin-http_client (2.1.0)
+    logstash-mixin-http_client (2.2.0)
       logstash-codec-plain
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
-      manticore (>= 0.4.1)
+      manticore (>= 0.5.2, < 1.0.0)
     logstash-mixin-rabbitmq_connection (2.3.0-java)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       march_hare (~> 2.15.0)
@@ -430,19 +428,19 @@ GEM
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       logstash-filter-json
       logstash-output-file
-    logstash-output-elasticsearch (2.3.0-java)
+    logstash-output-elasticsearch (2.4.0-java)
       cabin (~> 0.6)
       concurrent-ruby
       elasticsearch (~> 1.0, >= 1.0.13)
       logstash-core (>= 2.0.0, < 3.0.0)
-      manticore (~> 0.4.2)
+      manticore (>= 0.5.2, < 1.0.0)
       stud (~> 0.0, >= 0.0.17)
     logstash-output-email (3.0.2)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       mail (~> 2.6.0, >= 2.6.3)
     logstash-output-exec (2.0.2)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
-    logstash-output-file (2.2.1)
+    logstash-output-file (2.2.3)
       logstash-codec-json_lines
       logstash-codec-line
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
@@ -460,10 +458,9 @@ GEM
       hipchat
       logstash-codec-plain
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
-    logstash-output-http (2.0.5)
-      logstash-core (>= 2.0.0.beta2, < 3.0.0)
-      logstash-mixin-http_client (>= 2.0.2, < 3.0.0)
-      manticore (< 0.5.0)
+    logstash-output-http (2.1.0)
+      logstash-core (>= 2.0.0, < 3.0.0)
+      logstash-mixin-http_client (>= 2.2.0, < 3.0.0)
     logstash-output-irc (2.0.2)
       cinch
       logstash-codec-plain
@@ -504,7 +501,7 @@ GEM
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       redis
       stud
-    logstash-output-s3 (2.0.3)
+    logstash-output-s3 (2.0.4)
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       logstash-mixin-aws
       stud (~> 0.0.22)
@@ -520,7 +517,7 @@ GEM
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
       logstash-input-generator
       statsd-ruby (= 1.2.0)
-    logstash-output-stdout (2.0.3)
+    logstash-output-stdout (2.0.4)
       logstash-codec-line
       logstash-core (>= 2.0.0.beta2, < 3.0.0)
     logstash-output-tcp (2.0.2)
@@ -542,7 +539,8 @@ GEM
     lru_redux (1.1.0)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    manticore (0.4.4-java)
+    manticore (0.5.2-java)
+      jar-dependencies
     march_hare (2.15.0-java)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
@@ -552,7 +550,7 @@ GEM
       avl_tree (~> 1.2.0)
       hitimes (~> 1.1)
     mime-types (2.99)
-    mimemagic (0.3.0)
+    mimemagic (0.3.1)
     minitar (0.5.4)
     msgpack-jruby (1.4.1-java)
     multi_json (1.11.2)
@@ -602,7 +600,7 @@ GEM
     sawyer (0.6.0)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
-    sequel (4.29.0)
+    sequel (4.30.0)
     simple_oauth (0.3.1)
     simplecov (0.11.1)
       docile (~> 1.1.0)
@@ -672,8 +670,8 @@ DEPENDENCIES
   logstash-codec-oldlogstashjson
   logstash-codec-plain
   logstash-codec-rubydebug
-  logstash-core (= 2.2.0)!
-  logstash-core-event (= 2.2.0)!
+  logstash-core (= 2.2.0.snapshot2)
+  logstash-core-event (= 2.2.0.snapshot2)
   logstash-devutils (~> 0.0.15)
   logstash-filter-anonymize
   logstash-filter-checksum
@@ -711,6 +709,7 @@ DEPENDENCIES
   logstash-input-graphite
   logstash-input-heartbeat
   logstash-input-http
+  logstash-input-http_poller
   logstash-input-imap
   logstash-input-irc
   logstash-input-jdbc

--- a/logstash-core-event/lib/logstash-core-event/version.rb
+++ b/logstash-core-event/lib/logstash-core-event/version.rb
@@ -5,4 +5,4 @@
 # Note to authors: this should not include dashes because 'gem' barfs if
 # you include a dash in the version string.
 
-LOGSTASH_CORE_EVENT_VERSION = "2.2.0"
+LOGSTASH_CORE_EVENT_VERSION = "2.2.0.snapshot2"

--- a/logstash-core/lib/logstash-core/version.rb
+++ b/logstash-core/lib/logstash-core/version.rb
@@ -5,4 +5,4 @@
 # Note to authors: this should not include dashes because 'gem' barfs if
 # you include a dash in the version string.
 
-LOGSTASH_CORE_VERSION = "2.2.0"
+LOGSTASH_CORE_VERSION = "2.2.0.snapshot2"

--- a/logstash-core/lib/logstash/version.rb
+++ b/logstash-core/lib/logstash/version.rb
@@ -11,4 +11,4 @@
 #       eventually this file should be in the root logstash lib fir and dependencies in logstash-core should be
 #       fixed.
 
-LOGSTASH_VERSION = "2.2.0"
+LOGSTASH_VERSION = "2.2.0.snapshot2"

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = LOGSTASH_CORE_VERSION
 
-  gem.add_runtime_dependency "logstash-core-event", "~> 2.2.0"
+  gem.add_runtime_dependency "logstash-core-event", "~> 2.2.0.snapshot2"
 
   gem.add_runtime_dependency "cabin", "~> 0.7.0" #(Apache 2.0 license)
   gem.add_runtime_dependency "pry", "~> 0.10.1"  #(Ruby license)


### PR DESCRIPTION
Bump version, update gem and lock file to point to RubyGems.org
in preperation for 2.2.0 release