### PR TITLE
remove link to maintainer guide in contributing since already in index

### DIFF
--- a/docs/static/contributing-to-logstash.asciidoc
+++ b/docs/static/contributing-to-logstash.asciidoc
@@ -46,5 +46,3 @@ https://github.com/elastic/logstash/blob/master/CONTRIBUTING.md[contribution]
 guide, and the Logstash
 https://github.com/elastic/logstash/blob/master/README.md[readme]
 document.
-
-include::maintainer-guide.asciidoc[]


### PR DESCRIPTION
the maintainer guide is already included in https://github.com/elastic/logstash-docs/blob/master/docs/index.asciidoc so there's no need to also include in the contributing-to-logstash.
@palecur @suyograo is this the right approach to fix the double include?

Also..is there a reason to not have the index.asciidoc file of logstash-docs in this repo too?

fixes #4460 