### PR TITLE
Fix no. 2 for 4444: Too verbose deprecations warnings

### DIFF
--- a/logstash-core/lib/logstash/codecs/base.rb
+++ b/logstash-core/lib/logstash/codecs/base.rb
@@ -11,7 +11,7 @@ module LogStash::Codecs; class Base < LogStash::Plugin
 
   def initialize(params={})
     super
-    config_init(params)
+    config_init(@params)
     register if respond_to?(:register)
   end
 
@@ -27,7 +27,7 @@ module LogStash::Codecs; class Base < LogStash::Plugin
     raise "#{self.class}#encode must be overidden"
   end # def encode
 
-  public 
+  public
   def close; end;
 
   # @param block [Proc(event, data)] the callback proc passing the original event and the encoded event

--- a/logstash-core/lib/logstash/filters/base.rb
+++ b/logstash-core/lib/logstash/filters/base.rb
@@ -120,7 +120,7 @@ class LogStash::Filters::Base < LogStash::Plugin
   public
   def initialize(params)
     super
-    config_init(params)
+    config_init(@params)
     @threadsafe = true
   end # def initialize
 

--- a/logstash-core/lib/logstash/inputs/base.rb
+++ b/logstash-core/lib/logstash/inputs/base.rb
@@ -53,7 +53,7 @@ class LogStash::Inputs::Base < LogStash::Plugin
     super
     @threadable = false
     @stop_called = Concurrent::AtomicBoolean.new(false)
-    config_init(params)
+    config_init(@params)
     @tags ||= []
   end # def initialize
 

--- a/logstash-core/lib/logstash/outputs/base.rb
+++ b/logstash-core/lib/logstash/outputs/base.rb
@@ -60,7 +60,7 @@ class LogStash::Outputs::Base < LogStash::Plugin
   public
   def initialize(params={})
     super
-    config_init(params)
+    config_init(@params)
 
     # If we're running with a single thread we must enforce single-threaded concurrency by default
     # Maybe in a future version we'll assume output plugins are threadsafe

--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -24,7 +24,7 @@ class LogStash::Plugin
 
   public
   def initialize(params=nil)
-    @params = params
+    @params = LogStash::Util.deep_clone(params)
     @logger = Cabin::Channel.get(LogStash)
   end
 

--- a/logstash-core/lib/logstash/util.rb
+++ b/logstash-core/lib/logstash/util.rb
@@ -183,4 +183,21 @@ module LogStash::Util
       o
     end
   end
+
+  def self.deep_clone(o)
+    case o
+    when Hash
+      o.inject({}) {|h, (k,v)| h[k] = deep_clone(v); h }
+    when Array
+      o.map {|v| deep_clone(v) }
+    when Fixnum, Symbol, IO, TrueClass, FalseClass, NilClass
+      o
+    when LogStash::Codecs::Base
+      o.clone.tap {|c| c.register }
+    when String
+      o.clone #need to keep internal state e.g. frozen
+    else
+      Marshal.load(Marshal.dump(o))
+    end
+  end
 end # module LogStash::Util

--- a/logstash-core/spec/logstash/plugin_spec.rb
+++ b/logstash-core/spec/logstash/plugin_spec.rb
@@ -108,7 +108,7 @@ describe LogStash::Plugin do
 
       subject.validate({})
     end
-    
+
 
     it 'logs a warning if the plugin use the milestone option' do
       expect_any_instance_of(Cabin::Channel).to receive(:warn)
@@ -117,6 +117,35 @@ describe LogStash::Plugin do
       class LogStash::Filters::Stromae < LogStash::Filters::Base
         config_name "stromae"
         milestone 2
+      end
+    end
+  end
+
+  describe "subclass initialize" do
+    let(:args) { Hash.new }
+
+    [
+      StromaeCodec = Class.new(LogStash::Codecs::Base) do
+        config_name "stromae"
+        config :foo_tag, :validate => :string, :default => "bar"
+      end,
+      StromaeFilter = Class.new(LogStash::Filters::Base) do
+        config_name "stromae"
+        config :foo_tag, :validate => :string, :default => "bar"
+      end,
+      StromaeInput = Class.new(LogStash::Inputs::Base) do
+        config_name "stromae"
+        config :foo_tag, :validate => :string, :default => "bar"
+      end,
+      StromaeOutput = Class.new(LogStash::Outputs::Base) do
+        config_name "stromae"
+        config :foo_tag, :validate => :string, :default => "bar"
+      end
+    ].each do |klass|
+
+      it "subclass #{klass.name} does not modify params" do
+        instance = klass.new(args)
+        expect(args).to be_empty
       end
     end
   end


### PR DESCRIPTION
Better method of ensuring that args are not mutated by plugin initialize.

NOTE:
- I had to introduce `LogStash::Util.deep_clone` as `Marshal.load(Marshal.dump(o))` does not work directly on args because there is logger instance in args and Marshal can't dump IO.
- I had to alter all the codec, filter, input and output base.rb `initialize` to deep_clone params, as well as the plugin.rb `initialize` to do `config_init(@params)`.