### PR TITLE
Metrics/refactor small improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "stud", "~> 0.0.22"
 gem "fpm", "~> 1.3.3", :group => :build
 gem "rubyzip", "~> 1.1.7", :group => :build
 gem "gems", "~> 0.8.3", :group => :build
-gem "rack-test", require: "rack/test", :group => :development
+gem "rack-test", :require => "rack/test", :group => :development
 gem "flores", "~> 0.0.6"
 gem "logstash-output-elasticsearch"
 gem "logstash-codec-plain", ">= 0"

--- a/Gemfile.jruby-1.9.lock
+++ b/Gemfile.jruby-1.9.lock
@@ -182,6 +182,8 @@ GEM
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
+    rack-test (0.6.3)
+      rack (>= 1.0)
     rake (10.4.2)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -255,6 +257,7 @@ DEPENDENCIES
   logstash-output-stdout
   longshoreman
   octokit (= 3.8.0)
+  rack-test
   rspec (~> 3.1.0)
   rubyzip (~> 1.1.7)
   simplecov

--- a/logstash-core/lib/logstash/filter_delegator.rb
+++ b/logstash-core/lib/logstash/filter_delegator.rb
@@ -1,0 +1,38 @@
+# encoding: utf-8
+#
+module LogStash
+  class FilterDelegator
+    extend Forwardable
+
+    def_delegators :@filter,
+      :register,
+      :close,
+      :multi_filter,
+      :threadsafe?,
+      :do_close,
+      :do_stop,
+      :periodic_flush
+
+    def initialize(logger, klass, metric, *args)
+      options = args.reduce({}, :merge)
+
+      @logger = logger
+      @klass = klass
+      @metric = metric
+      @filter = klass.new(options)
+
+      define_flush if @filter.respond_to?(:flush)
+    end
+
+    def config_name
+      @klass.config_name
+    end
+
+    private
+    def define_flush
+      define_singleton_method(:flush) do |options = {}|
+        @filter.flush(options)
+      end
+    end
+  end
+end

--- a/logstash-core/lib/logstash/inputs/metrics.rb
+++ b/logstash-core/lib/logstash/inputs/metrics.rb
@@ -44,9 +44,9 @@ module LogStash module Inputs
       #   - We can use a synchronization mechanism between the called thread (update method)
       #   and the plugin thread (run method)
       #   - How we handle back pressure here?
-      #   - one snashot should be only one event
-      snapshot.metric_store.to_events.each do |event|
-        @queue << event
+      #   - one snashot should be only one event ?
+      snapshot.metric_store.all.each do |metric|
+        @queue << LogStash::Event.new({ "@timestamp" => snapshot.created_at }.merge(metric.to_hash))
       end
     end
   end

--- a/logstash-core/lib/logstash/instrument/metric.rb
+++ b/logstash-core/lib/logstash/instrument/metric.rb
@@ -38,8 +38,8 @@ module LogStash module Instrument
       if block_given?
         start_time = Time.now
         content = block.call
-        duration = Time.now - start_time
-        gauge(key, duration)
+        duration = (Time.now - start_time) * 1000 # Records in Milliseconds
+        collector.push(namespace_information, key, :mean, :increment, duration)
         return content
       else
         raise MetricNoBlockProvided

--- a/logstash-core/lib/logstash/instrument/metric_store.rb
+++ b/logstash-core/lib/logstash/instrument/metric_store.rb
@@ -11,6 +11,8 @@ module LogStash module Instrument
     class NamespacesExpectedError < Exception; end
 
     def initialize
+      # We keep the structured cache to allow
+      # the api to search the content of the differents nodes
       @store = Concurrent::Map.new
     end
 
@@ -34,11 +36,11 @@ module LogStash module Instrument
       get_recursively(key_paths, @store)
     end
 
-    # Take all the individuals `MetricType` and convert them to `Logstash::Event`
+    # Return all the individuals Metric
     #
     # @return [Array] An array of all metric transformed in `Logstash::Event`
-    def to_events
-      to_events_recursively(@store).flatten
+    def each
+      all_metrics_recursively(@store).flatten
     end
 
     private
@@ -58,13 +60,13 @@ module LogStash module Instrument
       end
     end
 
-    def to_events_recursively(values)
+    def each_recursively(values)
       events = []
       values.each_value do |value|
         if value.is_a?(Concurrent::Map)
-          events << to_events_recursively(value) 
+          events << each_recursively(value) 
         else
-          events << value.to_event
+          events << value
         end
       end
       return events

--- a/logstash-core/lib/logstash/instrument/metric_type/counter.rb
+++ b/logstash-core/lib/logstash/instrument/metric_type/counter.rb
@@ -7,12 +7,6 @@ module LogStash module Instrument module MetricType
     def initialize(namespaces, key, value = 0)
       super(namespaces, key)
 
-      # TODO
-      # This should be a `LongAdder`,
-      # will have to create a rubyext for it and support jdk7
-      # look at the elasticsearch source code.
-      # LongAdder only support decrement of one?
-      # Most of the time we will be adding
       @counter = Concurrent::AtomicFixnum.new(value)
     end
 

--- a/logstash-core/lib/logstash/instrument/metric_type/mean.rb
+++ b/logstash-core/lib/logstash/instrument/metric_type/mean.rb
@@ -3,7 +3,7 @@ require "logstash/instrument/metric_type/base"
 require "concurrent"
 
 module LogStash module Instrument module MetricType
-  class Mean < LogStash::Instrument::MetricType::Base
+  class Mean < Base
     def initialize(namespaces, key)
       super(namespaces, key)
 
@@ -13,7 +13,7 @@ module LogStash module Instrument module MetricType
 
     def increment(value = 1)
       @counter.increment
-      @sum.increment(value = 1)
+      @sum.increment(value)
     end
 
     def decrement(value = 1)
@@ -22,7 +22,11 @@ module LogStash module Instrument module MetricType
     end
 
     def mean
-      @sum.value / @counter.value
+      if @counter > 0 
+        @sum.value / @counter.value
+      else
+        0
+      end
     end
 
     def to_hash

--- a/logstash-core/lib/logstash/instrument/null_metric.rb
+++ b/logstash-core/lib/logstash/instrument/null_metric.rb
@@ -1,6 +1,16 @@
 # encoding: utf-8
+require "logstash/instrument/metric"
+
 module LogStash module Instrument
  class NullMetric
+   class NullTimedExecution
+     def self.stop
+     end
+   end
+
+   # Allow to reuse the same variable when creating subnamespace
+   NULL_METRIC_INSTANCE = NullMetric.new
+
    attr_reader :collector, :namespace_information
    def initialize
    end
@@ -16,10 +26,18 @@ module LogStash module Instrument
    end
 
    def namespace(key)
-     NullMetric.new
+     NULL_METRIC_INSTANCE
    end
 
-   def time(key, &block)
+   def report_time(key, duration)
+   end
+
+   def time(key)
+     if block_given?
+       yield 
+     else
+       NullTimedExecution
+     end
    end
  end
 end; end

--- a/logstash-core/lib/logstash/output_delegator.rb
+++ b/logstash-core/lib/logstash/output_delegator.rb
@@ -12,11 +12,17 @@ module LogStash class OutputDelegator
 
   # The *args this takes are the same format that a Outputs::Base takes. A list of hashes with parameters in them
   # Internally these just get merged together into a single hash
-  def initialize(logger, klass, default_worker_count, *args)
+  def initialize(logger, klass, default_worker_count, metric, *args)
     @logger = logger
     @threadsafe = klass.threadsafe?
     @config = args.reduce({}, :merge)
     @klass = klass
+    
+    # Create an instance of the input so we can fetch the identifier
+    output = @klass.new(*args)
+    
+    # Scope the metrics to the plugin
+    @metric = metric.namespace(output.identifier_name)
 
     # We define this as an array regardless of threadsafety
     # to make reporting simpler, even though a threadsafe plugin will just have
@@ -39,6 +45,7 @@ module LogStash class OutputDelegator
 
     @workers += (@worker_count - 1).times.map do
       inst = @klass.new(*args)
+      inst.metric = @metric
       inst.register
       inst
     end
@@ -107,6 +114,7 @@ module LogStash class OutputDelegator
 
   def threadsafe_multi_receive(events)
     @events_received.increment(events.length)
+    @metric.increment(:events_in, events.length)
 
     @threadsafe_worker.multi_receive(events)
   end

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -18,6 +18,7 @@ require "logstash/instrument/metric"
 require "logstash/instrument/null_metric"
 require "logstash/instrument/collector"
 require "logstash/output_delegator"
+require "logstash/filter_delegator"
 
 module LogStash; class Pipeline
   attr_reader :inputs, :filters, :outputs, :worker_threads, :events_consumed, :events_filtered, :reporter, :pipeline_id, :metric, :logger
@@ -106,7 +107,7 @@ module LogStash; class Pipeline
     safe_filters, unsafe_filters = @filters.partition(&:threadsafe?)
 
     if unsafe_filters.any?
-      plugins = unsafe_filters.collect { |f| f.class.config_name }
+      plugins = unsafe_filters.collect { |f| f.config_name }
       case thread_count
       when nil
         # user did not specify a worker thread count
@@ -403,6 +404,8 @@ module LogStash; class Pipeline
 
     if plugin_type == "output"
       LogStash::OutputDelegator.new(@logger, klass, default_output_workers, *args)
+    elsif plugin_type == "filter"
+      LogStash::FilterDelegator.new(@logger, klass, metric, *args)
     else
       klass.new(*args)
     end

--- a/logstash-core/lib/logstash/util/duration_formatter.rb
+++ b/logstash-core/lib/logstash/util/duration_formatter.rb
@@ -1,0 +1,15 @@
+# encoding: utf-8
+require "chronic_duration"
+module LogStash::Util::DurationFormatter
+  CHRONIC_OPTIONS = { :format => :short }
+
+  # Take a duration in milliseconds and transform it into
+  # a format that a human can understand. This is currently used by
+  # the API.
+  #
+  # @param [Fixnum] Duration in milliseconds
+  # @return [String] Duration in human format
+  def self.human_format(duration)
+    ChronicDuration.output(duration / 1000, CHRONIC_OPTIONS)
+  end
+end

--- a/logstash-core/lib/logstash/webserver.rb
+++ b/logstash-core/lib/logstash/webserver.rb
@@ -5,7 +5,7 @@ require 'puma/binder'
 require 'puma/configuration'
 require 'puma/commonlogger'
 
-module LogStash
+module LogStash 
   class WebServer
 
   extend Forwardable
@@ -81,6 +81,4 @@ module LogStash
     @config.load
     @options = @config.options
   end
-
-  end
-end
+end; end

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "sinatra", '~> 1.4', '>= 1.4.6'
   gem.add_runtime_dependency "puma", '~> 2.15', '>= 2.15.3'
   gem.add_runtime_dependency "jruby-openssl", "0.9.13" # Required to support TLSv1.2
+  gem.add_runtime_dependency "chronic_duration", "0.10.6"
 
   # TODO(sissel): Treetop 1.5.x doesn't seem to work well, but I haven't
   # investigated what the cause might be. -Jordan

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -3,6 +3,16 @@ require "logstash/agent"
 require "spec_helper"
 
 describe LogStash::Agent do
+  let(:logger) { double("logger") }
+
+  before :each do
+    allow(logger).to receive(:fatal).with(any_args)
+    allow(logger).to receive(:debug).with(any_args)
+    allow(logger).to receive(:debug?).with(any_args)
+  end
+
+  subject { LogStash::Agent.new({ :logger => logger }) }
+
   context "#node_name" do
     let(:hostname) { "the-logstash" }
 
@@ -11,7 +21,7 @@ describe LogStash::Agent do
     end
 
     it "fallback to hostname when no name is provided" do
-      expect(LogStash::Agent.new.node_name).to be(hostname)
+      expect(subject.node_name).to be(hostname)
     end
 
     it "uses the user provided name" do
@@ -21,7 +31,19 @@ describe LogStash::Agent do
 
   context "#node_uuid" do
     it "create a unique uuid between agent instances" do
-      expect(LogStash::Agent.new.node_uuid).not_to be(LogStash::Agent.new.node_uuid)
+      expect(subject.node_uuid).not_to be(LogStash::Agent.new.node_uuid)
+    end
+  end
+
+  context "#started_at" do
+    it "return the start time when the agent is started" do
+      expect(subject.started_at).to be_kind_of(Time)
+    end
+  end
+
+  context "#uptime" do
+    it "return the number of milliseconds since start time" do
+      expect(subject.uptime).to be >= 0
     end
   end
 end

--- a/logstash-core/spec/logstash/instrument/metric_spec.rb
+++ b/logstash-core/spec/logstash/instrument/metric_spec.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/instrument/metric"
 require "logstash/instrument/collector"
+require_relative "../../support/matchers"
 require "spec_helper"
 
 describe LogStash::Instrument::Metric do
@@ -61,6 +62,24 @@ describe LogStash::Instrument::Metric do
 
     it "raise an exception if the key is nil" do
       expect { subject.gauge(nil, 20) }.to raise_error(LogStash::Instrument::MetricNoKeyProvided)
+    end
+  end
+
+  context "#time" do
+    let(:sleep_time) { 2 }
+    let(:sleep_time_ms) { sleep_time * 1000 }
+      
+    it "records the duration" do
+      subject.time(:duration_ms) { sleep(sleep_time) }
+      expect(collector.last).to be_within(sleep_time_ms).of(sleep_time_ms + 0.1)
+      expect(collector[0]).to match([:root])
+      expect(collector[1]).to be(:duration_ms)
+      expect(collector[2]).to be(:mean)
+    end
+
+    it "returns the value of the executed block" do
+      x = 1
+      expect(subject.time(:testing) { x + 1 }).to eq(2)
     end
   end
 

--- a/logstash-core/spec/logstash/instrument/metric_spec.rb
+++ b/logstash-core/spec/logstash/instrument/metric_spec.rb
@@ -67,19 +67,30 @@ describe LogStash::Instrument::Metric do
 
   context "#time" do
     let(:sleep_time) { 2 }
-    let(:sleep_time_ms) { sleep_time * 1000 }
+    let(:sleep_time_ms) { sleep_time * 1_000_000 }
       
     it "records the duration" do
       subject.time(:duration_ms) { sleep(sleep_time) }
-      expect(collector.last).to be_within(sleep_time_ms).of(sleep_time_ms + 0.1)
+
+      expect(collector.last).to be_within(sleep_time_ms).of(sleep_time_ms + 5000)
       expect(collector[0]).to match([:root])
       expect(collector[1]).to be(:duration_ms)
       expect(collector[2]).to be(:mean)
     end
 
     it "returns the value of the executed block" do
-      x = 1
-      expect(subject.time(:testing) { x + 1 }).to eq(2)
+      expect(subject.time(:testing) { "hello" }).to eq("hello")
+    end
+
+    it "return a TimedExecution" do
+      execution = subject.time(:duration_ms)
+      sleep(sleep_time)
+      execution.stop
+
+      expect(collector.last).to be_within(sleep_time_ms).of(sleep_time_ms + 0.1)
+      expect(collector[0]).to match([:root])
+      expect(collector[1]).to be(:duration_ms)
+      expect(collector[2]).to be(:mean)
     end
   end
 

--- a/logstash-core/spec/logstash/instrument/metric_store_spec.rb
+++ b/logstash-core/spec/logstash/instrument/metric_store_spec.rb
@@ -67,28 +67,4 @@ describe LogStash::Instrument::MetricStore do
       expect(metrics).to be_kind_of(LogStash::Instrument::MetricType::Base)
     end
   end
-
-  describe "#to_event" do
-    let(:metric_events) {
-      [
-        [[:node, :sashimi, :pipelines, :pipeline01, :plugins, :"logstash-output-elasticsearch"], :event_in, :increment],
-        [[:node, :sashimi, :pipelines, :pipeline01], :processed_events, :increment],
-      ]
-    }
-
-    before do
-      # Lets add a few metrics in the store before trying to convert them
-      metric_events.each do |namespaces, metric_key, action|
-        metric = subject.fetch_or_store(namespaces, metric_key, LogStash::Instrument::MetricType::Counter.new(namespaces, key))
-        metric.execute(action)
-      end
-    end
-
-    it "converts all metric to `Logstash::Event`" do
-      events = subject.to_events
-      events.each do |event|
-        expect(event).to be_kind_of(LogStash::Event)
-      end
-    end
-  end
 end

--- a/logstash-core/spec/logstash/instrument/null_metric_spec.rb
+++ b/logstash-core/spec/logstash/instrument/null_metric_spec.rb
@@ -7,4 +7,15 @@ describe LogStash::Instrument::NullMetric do
   it "defines the same interface as `Metric`" do
     expect(described_class).to implement_interface_of(LogStash::Instrument::Metric) 
   end
+
+  describe "#time" do
+    it "returns the value of the block without recording any metrics" do
+      expect(subject.time(:execution_time) { "hello" }).to eq("hello")
+    end
+
+    it "return a TimedExecution" do
+      execution = subject.time(:do_something)
+      expect { execution.stop }.not_to raise_error
+    end
+  end
 end

--- a/logstash-core/spec/logstash/output_delegator_spec.rb
+++ b/logstash-core/spec/logstash/output_delegator_spec.rb
@@ -7,18 +7,20 @@ describe LogStash::OutputDelegator do
   let(:events) { 7.times.map { LogStash::Event.new }}
   let(:default_worker_count) { 1 }
 
-  subject { described_class.new(logger, out_klass, default_worker_count) }
+  subject { described_class.new(logger, out_klass, default_worker_count, LogStash::Instrument::NullMetric.new ) }
 
   context "with a plain output plugin" do
     let(:out_klass) { double("output klass") }
     let(:out_inst) { double("output instance") }
 
-    before do
+    before :each do
       allow(out_klass).to receive(:new).with(any_args).and_return(out_inst)
       allow(out_klass).to receive(:threadsafe?).and_return(false)
       allow(out_klass).to receive(:workers_not_supported?).and_return(false)
       allow(out_inst).to receive(:register)
       allow(out_inst).to receive(:multi_receive)
+      allow(out_inst).to receive(:metric=).with(any_args)
+      allow(out_inst).to receive(:identifier_name).and_return("a-simple-plugin")
       allow(logger).to receive(:debug).with(any_args)
     end
 
@@ -57,6 +59,8 @@ describe LogStash::OutputDelegator do
         before do
           allow(out_klass).to receive(:threadsafe?).and_return(false)
           allow(out_klass).to receive(:workers_not_supported?).and_return(false)
+          allow(out_inst).to receive(:metric=).with(any_args)
+          allow(out_inst).to receive(:identifier_name).and_return("a-simple-plugin")
         end
 
         it "should instantiate multiple workers" do
@@ -72,6 +76,8 @@ describe LogStash::OutputDelegator do
       describe "threadsafe outputs" do
         before do
           allow(out_klass).to receive(:threadsafe?).and_return(true)
+          allow(out_inst).to receive(:metric=).with(any_args)
+          allow(out_inst).to receive(:identifier_name).and_return("a-simple-plugin")
           allow(out_klass).to receive(:workers_not_supported?).and_return(false)
         end
 

--- a/logstash-core/spec/logstash/util/duration_formatter_spec.rb
+++ b/logstash-core/spec/logstash/util/duration_formatter_spec.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+require "logstash/util/duration_formatter"
+require "spec_helper"
+
+describe LogStash::Util::DurationFormatter do
+  let(:duration) { 3600 * 1000 } # in milliseconds
+
+  it "returns a human format" do
+    expect(subject.human_format(duration)).to eq("1h")
+  end
+end


### PR DESCRIPTION
This PR contains:
- a few speed improvements for collecting metrics by removing unnecessary allocations.
- A way to get the uptime for a pipeline and the agent
- a filterdelegator to collect filter stats.