### PR TITLE
[rake] Fix broken doc generation

### DIFF
--- a/docs/asciidocgen.rb
+++ b/docs/asciidocgen.rb
@@ -3,7 +3,7 @@ require "erb"
 require "optparse"
 
 $: << Dir.pwd
-$: << File.join(File.dirname(__FILE__), "..", "lib")
+$: << File.join(File.dirname(__FILE__), "..", "logstash-core/lib")
 $: << File.join(File.dirname(__FILE__), "..", "rakelib")
 
 require "logstash/config/mixin"
@@ -161,7 +161,7 @@ class LogStashConfigAsciiDocGenerator
     load file
 
     # Get the correct base path
-    base = File.join(::LogStash::Environment::LOGSTASH_HOME,'lib/logstash', file.split("/")[-2])
+    base = File.join(::LogStash::Environment::LOGSTASH_HOME,'logstash-core/lib/logstash', file.split("/")[-2])
 
     # parse base first
     parse(File.new(File.join(base, "base.rb"), "r").read)

--- a/rakelib/docs.rake
+++ b/rakelib/docs.rake
@@ -9,10 +9,20 @@ namespace "docs" do
 
   task "generate-docs" do
     require "bootstrap/environment"
-    pattern = "#{LogStash::Environment.logstash_gem_home}/gems/logstash-*/lib/logstash/{input,output,filter,codec}s/*.rb"
-    list    = Dir.glob(pattern).join(" ")
-    cmd     = "bin/bundle exec ruby docs/asciidocgen.rb -o asciidoc_generated #{list}"
-    system(cmd)
+    pattern = "#{LogStash::Environment.logstash_gem_home}/gems/logstash-*/lib/logstash/{input,output,filter,codec}s/[!base]*.rb"
+    puts "Generated asciidoc is under dir LS_HOME/asciidoc_generated"
+    files = Dir.glob(pattern)
+    files.each do | file|
+      begin
+        cmd = "bin/logstash docgen -o asciidoc_generated #{file}"
+        # this is a bit slow, but is more resilient to failures
+        system(cmd)
+      rescue
+        # there are some plugins which will not load, so move on..
+        puts "Unable to generate docs for file #{file}"
+        next
+      end
+    end
   end
 
   task "generate-index" do


### PR DESCRIPTION
Doc generation was not updated after the changes to event and logstash-core
lib dir structure. Also, the rake task now ignores plugins whose doc cannot
be generated instead of bailing out in entirely, and having to start from
scratch again.