### PR TITLE
Add a `Plugin#id` that return an ID for a plugin

### DIFF
--- a/logstash-core/lib/logstash/filter_delegator.rb
+++ b/logstash-core/lib/logstash/filter_delegator.rb
@@ -20,7 +20,7 @@ module LogStash
       @filter = klass.new(options)
 
       # Scope the metrics to the plugin
-      @metric = metric.namespace(@filter.identifier_name)
+      @metric = metric.namespace(@filter.id.to_sym)
       @filter.metric = @metric
 
       define_flush_method if @filter.respond_to?(:flush)

--- a/logstash-core/lib/logstash/output_delegator.rb
+++ b/logstash-core/lib/logstash/output_delegator.rb
@@ -17,12 +17,12 @@ module LogStash class OutputDelegator
     @threadsafe = klass.threadsafe?
     @config = args.reduce({}, :merge)
     @klass = klass
-    
+
     # Create an instance of the input so we can fetch the identifier
     output = @klass.new(*args)
-    
+
     # Scope the metrics to the plugin
-    @metric = metric.namespace(output.identifier_name)
+    @metric = metric.namespace(output.id.to_sym)
 
     # We define this as an array regardless of threadsafety
     # to make reporting simpler, even though a threadsafe plugin will just have

--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -35,18 +35,15 @@ class LogStash::Plugin
   # If you don't explicitely set this variable Logstash will generate a unique name.
   config :id, :validate => :string, :default => ""
 
-  public
   def hash
     params.hash ^
     self.class.name.hash
   end
 
-  public
   def eql?(other)
     self.class.name == other.class.name && @params == other.params
   end
 
-  public
   def initialize(params=nil)
     @params = LogStash::Util.deep_clone(params)
     @logger = Cabin::Channel.get(LogStash)
@@ -64,7 +61,6 @@ class LogStash::Plugin
 
   # close is called during shutdown, after the plugin worker
   # main task terminates
-  public
   def do_close
     @logger.debug("closing", :plugin => self)
     close
@@ -72,7 +68,6 @@ class LogStash::Plugin
 
   # Subclasses should implement this close method if you need to perform any
   # special tasks during shutdown (like flushing, etc.)
-  public
   def close
     # ..
   end
@@ -81,7 +76,6 @@ class LogStash::Plugin
     return "#{self.class.name}: #{@params}"
   end
 
-  public
   def inspect
     if !@params.nil?
       description = @params
@@ -93,7 +87,6 @@ class LogStash::Plugin
     end
   end
 
-  public
   def debug_info
     [self.class.to_s, original_params]
   end
@@ -107,7 +100,6 @@ class LogStash::Plugin
   end
 
   # Look up a plugin by type and name.
-  public
   def self.lookup(type, name)
     path = "logstash/#{type}s/#{name}"
 

--- a/logstash-core/spec/logstash/output_delegator_spec.rb
+++ b/logstash-core/spec/logstash/output_delegator_spec.rb
@@ -20,7 +20,7 @@ describe LogStash::OutputDelegator do
       allow(out_inst).to receive(:register)
       allow(out_inst).to receive(:multi_receive)
       allow(out_inst).to receive(:metric=).with(any_args)
-      allow(out_inst).to receive(:identifier_name).and_return("a-simple-plugin")
+      allow(out_inst).to receive(:id).and_return("a-simple-plugin")
       allow(logger).to receive(:debug).with(any_args)
     end
 
@@ -60,7 +60,7 @@ describe LogStash::OutputDelegator do
           allow(out_klass).to receive(:threadsafe?).and_return(false)
           allow(out_klass).to receive(:workers_not_supported?).and_return(false)
           allow(out_inst).to receive(:metric=).with(any_args)
-          allow(out_inst).to receive(:identifier_name).and_return("a-simple-plugin")
+          allow(out_inst).to receive(:id).and_return("a-simple-plugin")
         end
 
         it "should instantiate multiple workers" do
@@ -77,7 +77,7 @@ describe LogStash::OutputDelegator do
         before do
           allow(out_klass).to receive(:threadsafe?).and_return(true)
           allow(out_inst).to receive(:metric=).with(any_args)
-          allow(out_inst).to receive(:identifier_name).and_return("a-simple-plugin")
+          allow(out_inst).to receive(:id).and_return("a-simple-plugin")
           allow(out_klass).to receive(:workers_not_supported?).and_return(false)
         end
 

--- a/logstash-core/spec/logstash/plugin_spec.rb
+++ b/logstash-core/spec/logstash/plugin_spec.rb
@@ -1,6 +1,10 @@
 # encoding: utf-8
 require "spec_helper"
 require "logstash/plugin"
+require "logstash/outputs/base"
+require "logstash/codecs/base"
+require "logstash/inputs/base"
+require "logstash/filters/base"
 
 describe LogStash::Plugin do
   it "should fail lookup on inexisting type" do
@@ -146,6 +150,58 @@ describe LogStash::Plugin do
       it "subclass #{klass.name} does not modify params" do
         instance = klass.new(args)
         expect(args).to be_empty
+      end
+    end
+  end
+
+  describe "#id" do
+    plugin_types = [
+                    LogStash::Filters::Base,
+                    LogStash::Codecs::Base,
+                    LogStash::Outputs::Base,
+                    LogStash::Inputs::Base
+                  ]
+
+    plugin_types.each do |plugin_type|
+      let(:plugin) do
+        Class.new(plugin_type) do
+          config_name "simple_plugin"
+
+          config :host, :validate => :string
+          config :export, :validte => :boolean
+
+          def register; end
+        end
+      end
+
+      let(:config) do
+        {
+          "host" => "127.0.0.1",
+          "export" => true
+        }
+      end
+
+      subject { plugin.new(config) }
+      
+      context "plugin type is #{plugin_type}" do
+        context "when there is not ID configured for the output" do
+          it "it uses a UUID to identify this plugins" do
+            expect(subject.id).not_to eq(nil)
+          end
+
+          it "will be different between instance of plugins" do
+            expect(subject.id).not_to eq(plugin.new(config).id)
+          end
+        end
+
+        context "When a user provide an ID for the plugin" do
+          let(:id) { "ABC" }
+          let(:config) { super.merge("id" => id) }
+
+          it "uses the user provided ID" do
+            expect(subject.id).to eq(id)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This method return an ID for the plugins and be configured by the users
in the configuration like this:

```
elasticsearch {
  id => "ABC"
  ...
}
```

This information will be used when collecting metrics for a specific
plugin. Allowing the user to change it allow to stick between restart.

Fixes #3892