### PR TITLE
Change in the default of the metric feature.

### DIFF
--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -17,8 +17,9 @@ class LogStash::Plugin
   include LogStash::Config::Mixin
 
   # Disable or enable metric logging for this specific plugin instance
-  # by default only the core pipeline metrics will be recorded.
-  config :enable_metric, :validate => :boolean, :default => false
+  # by default we record all the metrics we can, but you can disable metrics collection
+  # for a specific plugin.
+  config :enable_metric, :validate => :boolean, :default => true
 
   # Under which name you want to collect metric for this plugin?
   # This will allow you to compare the performance of the configuration change, this

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -75,11 +75,6 @@ class LogStash::Runner < Clamp::Command
     I18n.t("logstash.runner.flag.rubyshell"),
     :attribute_name => :ruby_shell
 
-  option ["-m", "--metric"], :flag,
-    I18n.t("logstash.runner.flag.metric"),
-           :attribute_name => :metric,
-           :default => false
-
   option ["-n", "--node-name"], "NAME",
     I18n.t("logstash.runner.flag.node_name"),
     :attribute_name => :node_name
@@ -122,7 +117,8 @@ class LogStash::Runner < Clamp::Command
     # make sure the logger has the correct settings and the log level is correctly defined.
     configure_logging(log_file)
 
-    @agent = LogStash::Agent.new({ :collect_metric => metric?, :logger => @logger, :debug => debug?, :node_name => node_name })
+    @agent = LogStash::Agent.new({ :collect_metric => true,
+       :logger => @logger, :debug => debug?, :node_name => node_name })
 
     LogStash::Util::set_thread_name(self.class.name)
 

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -1,10 +1,10 @@
 # YAML notes
 #   |- means 'scalar block' useful for formatted text
-#   > means 'scalar block' but it chomps all newlines. Useful 
+#   > means 'scalar block' but it chomps all newlines. Useful
 #     for unformatted text.
 en:
   oops: |-
-    The error reported is: 
+    The error reported is:
       %{error}
   logstash:
     error: >-
@@ -127,18 +127,18 @@ en:
           after %{after}
         invalid_plugin_register: >-
           Cannot register %{plugin} %{type} plugin.
-          The error reported is: 
+          The error reported is:
             %{error}
         plugin_path_missing: >-
           You specified a plugin path that does not exist: %{path}
         no_plugins_found: |-
           Could not find any plugins in "%{path}"
-          I tried to find files matching the following, but found none: 
+          I tried to find files matching the following, but found none:
             %{plugin_glob}
         log_file_failed: |-
           Failed to open %{path} for writing: %{error}
 
-          This is often a permissions issue, or the wrong 
+          This is often a permissions issue, or the wrong
           path was specified?
       flag:
         # Note: Wrap these at 55 chars so they display nicely when clamp emits
@@ -193,10 +193,10 @@ en:
           'inputs' 'filters', 'outputs' or 'codecs'
           and NAME is the name of the plugin.
         quiet: |+
-          Quieter logstash logging. This causes only 
+          Quieter logstash logging. This causes only
           errors to be emitted.
         verbose: |+
-          More verbose logging. This causes 'info' 
+          More verbose logging. This causes 'info'
           level logs to be emitted.
         debug: |+
           Most verbose logging. This causes 'debug'
@@ -209,8 +209,6 @@ en:
         rubyshell: |+
           Drop to shell instead of running as normal.
           Valid shells are "irb" and "pry"
-        metric: |+
-          Record pipeline metrics
         node_name: |+
           Specify the name of this logstash instance, if no value is given
           it will default to the current hostname.

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -112,6 +112,8 @@ describe LogStash::Runner do
     context "when pipeline workers is not defined by the user" do
       it "should not pass the value to the pipeline" do
         expect(LogStash::Pipeline).to receive(:new).with(pipeline_string, hash_including(:pipeline_id => "base", :metric => anything)).and_return(pipeline)
+        expect(LogStash::Pipeline).to receive(:new).with(anything, hash_including(:pipeline_id => :metric)).and_return(pipeline)
+
         args = ["-e", pipeline_string]
         subject.run("bin/logstash", args)
       end
@@ -121,6 +123,7 @@ describe LogStash::Runner do
       it "should pass the value to the pipeline" do
         base_pipeline_settings[:pipeline_workers] = 2
         expect(LogStash::Pipeline).to receive(:new).with(pipeline_string, hash_including(:pipeline_id => "base", :pipeline_workers => 2, :metric => anything)).and_return(pipeline)
+        expect(LogStash::Pipeline).to receive(:new).with(anything, hash_including(:pipeline_id => :metric)).and_return(pipeline)
         args = ["-w", "2", "-e", pipeline_string]
         subject.run("bin/logstash", args)
       end


### PR DESCRIPTION
Metric will be on by default for the pipelines and the plugins,
Its not possible to turn it off for the pipeline but you can turn
off metrics collection for specific plugin.

fixes: #4502