### PR TITLE
search through nested directory structure for jars in vendor directory

### DIFF
--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -33,11 +33,11 @@ module LogStash
     end
 
     def load_runtime_jars!(dir_name="vendor", package="jar-dependencies")
-      load_jars!(::File.join(runtime_jars_root(dir_name, package), "*.jar"))
+      load_jars!(::File.join(runtime_jars_root(dir_name, package), "**", "*.jar"))
     end
 
     def load_test_jars!(dir_name="vendor", package="jar-dependencies")
-      load_jars!(::File.join(test_jars_root(dir_name, package), "*.jar"))
+      load_jars!(::File.join(test_jars_root(dir_name, package), "**", "*.jar"))
     end
 
     def load_jars!(pattern)


### PR DESCRIPTION
It is not always the case that jars will be located in one level within the `runtime-jars` and `test-jars` directory. For example, when a project's jar dependencies is vendored using [jar-dependencies](https://github.com/mkristian/jar-dependencies), the jars are nested.