### PR TITLE
Upgrade to JRuby 1.7.24

### DIFF
--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -1,6 +1,6 @@
 namespace "vendor" do
   VERSIONS = {
-    "jruby" => { "version" => "1.7.23", "sha1" => "2b5e796feeed2bcfab02f8bf2ff3d77ca318e310" },
+    "jruby" => { "version" => "1.7.24", "sha1" => "0c321d2192768dfec419bee6b44c7190f4db32e1" },
   }
 
   def vendor(*args)


### PR DESCRIPTION
This release fix the following problems we have:
- File.stat on 32 bits JVM on windows https://github.com/logstash-plugins/logstash-input-file/issues/82
- Annoying io/console warning on Windows https://github.com/elastic/logstash/issues/3087

Full changelog http://jruby.org/2016/01/20/jruby-1-7-24.html