### PR TITLE
Fix hanging runner test

### DIFF
--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -105,6 +105,7 @@ describe LogStash::Runner do
     let(:pipeline) { double("pipeline") }
 
     before(:each) do
+      allow_any_instance_of(LogStash::Agent).to receive(:execute).and_return(true)
       task = Stud::Task.new { 1 }
       allow(pipeline).to receive(:run).and_return(task)
     end


### PR DESCRIPTION
by actually mocking out the agent execute call, so test execution are only testing the runner and not the following methods.

Fixes #4546