### PR TITLE
fix jar generation for artifact packaging

### DIFF
--- a/logstash-core-event-java/build.gradle
+++ b/logstash-core-event-java/build.gradle
@@ -43,17 +43,17 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 
 task copyGemjar(type: Copy, dependsOn: sourcesJar) {
     from project.jar
-    into project.file('lib/')
+    into project.file('lib/logstash-core-event-java/')
 }
 
 task cleanGemjar {
-    delete fileTree(project.file('lib/')) {
+    delete fileTree(project.file('lib/logstash-core-event-java/')) {
         include '*.jar'
     }
 }
 
 clean.dependsOn(cleanGemjar)
-build.finalizedBy(copyGemjar)
+jar.finalizedBy(copyGemjar)
 
 configurations.create('sources')
 configurations.create('javadoc')

--- a/logstash-core-event-java/lib/logstash-core-event-java/logstash-core-event-java.rb
+++ b/logstash-core-event-java/lib/logstash-core-event-java/logstash-core-event-java.rb
@@ -16,11 +16,9 @@ if File.directory?(classes_dir)
 else
   # otherwise use included jar
   begin
-    jar = Dir[File.dirname(__FILE__) + "/logstash-core-event-java*.jar"].first
-    raise("No logstash-core-event-java jar file found") unless jar
-    require jar
+    require "logstash-core-event-java/logstash-core-event-java.jar"
   rescue Exception => e
-    raise("Error loading logstash-core-event-java jar file, cause: #{e.message}")
+    raise("Error loading logstash-core-event-java/logstash-core-event-java.jar file, cause: #{e.message}")
   end
 end
 


### PR DESCRIPTION
- attach jar copy hook to the jar generation and not build
- change location of jar into `lib/logstash-core-event-java/`
- simplify jar `require`

fixes #4578 