### PR TITLE
Fix a warning in the tests

### DIFF
--- a/logstash-core/spec/logstash/shutdown_watcher_spec.rb
+++ b/logstash-core/spec/logstash/shutdown_watcher_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 require "logstash/shutdown_watcher"
 
 describe LogStash::ShutdownWatcher do
+  let(:channel) { Cabin::Channel.new }
 
   let(:check_every) { 0.01 }
   let(:check_threshold) { 100 }
@@ -13,6 +14,8 @@ describe LogStash::ShutdownWatcher do
   report_count = 0
 
   before :each do
+    LogStash::ShutdownWatcher.logger = channel
+
     allow(pipeline).to receive(:reporter).and_return(reporter)
     allow(reporter).to receive(:snapshot).and_return(reporter_snapshot)
     allow(reporter_snapshot).to receive(:o_simple_hash).and_return({})


### PR DESCRIPTION
When running the test for the `ShutdownWatcher` in the full suite, the
logger of the class was incorrectly setup, this PR make sure we use a
silent logger instead.

Fixes #4581