### PR TITLE
Metrics/flexibility

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -22,7 +22,7 @@ class LogStash::Agent
 
   def initialize(options = {})
     @pipelines = {}
-     
+
     @node_name = options[:node_name] || Socket.gethostname
     @collect_metric = options.fetch(:collect_metric, false)
     @logger = options[:logger]
@@ -59,7 +59,7 @@ class LogStash::Agent
 
   def add_pipeline(pipeline_id, config_str, settings = {})
     settings.merge!(:pipeline_id => pipeline_id,
-                    :metric => metric.namespace(pipeline_id))
+                    :metric => metric)
 
     @pipelines[pipeline_id] = LogStash::Pipeline.new(config_str, settings)
   end
@@ -69,7 +69,7 @@ class LogStash::Agent
   end
 
   # Calculate the Logstash uptime in milliseconds
-  # 
+  #
   # @return [Fixnum] Uptime in milliseconds
   def uptime
     ((Time.now.to_f - started_at.to_f) * 1000.0).to_i
@@ -92,7 +92,7 @@ class LogStash::Agent
   def start_background_services
     if collect_metric?
       @logger.debug("Agent: Starting metric periodic pollers")
-      @periodic_pollers.start 
+      @periodic_pollers.start
     end
   end
 
@@ -106,7 +106,7 @@ class LogStash::Agent
   def configure_metric
     if collect_metric?
       @logger.debug("Agent: Configuring metric collection")
-      @metric = LogStash::Instrument::Metric.create(:root)
+      @metric = LogStash::Instrument::Metric.create
       add_metric_pipeline
     else
       @metric = LogStash::Instrument::NullMetric.new
@@ -131,7 +131,7 @@ class LogStash::Agent
       }
       output {
         elasticsearch {
-          flush_size => 10
+          flush_size => 1
           hosts => "127.0.0.1"
           index => "metrics-%{+YYYY.MM.dd}"
         }

--- a/logstash-core/lib/logstash/filter_delegator.rb
+++ b/logstash-core/lib/logstash/filter_delegator.rb
@@ -52,7 +52,10 @@ module LogStash
         # we also need to trace the number of events
         # coming from a specific filters.
         new_events = @filter.flush(options)
-        @metric_events.increment(:out, new_events.size) unless new_events.nil? # Logstash-filter-aggregates return nil.
+
+        # Filter plugins that does buffering or spooling of events like the
+        # `Logstash-filter-aggregates` can return `NIL` and will flush on the next flush ticks.
+        @metric_events.increment(:out, new_events.size) unless new_events.nil?
         new_events
       end
     end

--- a/logstash-core/lib/logstash/inputs/metrics.rb
+++ b/logstash-core/lib/logstash/inputs/metrics.rb
@@ -40,18 +40,8 @@ module LogStash module Inputs
       # scheduled task (running into his own thread) if something append to one of the listener it will
       # will timeout. In a sane pipeline, with a low traffic of events it shouldn't be a problems.
       snapshot.metric_store.each do |metric|
-        @queue << LogStash::Event.new({ "@timestamp" => snapshot.created_at }.merge(convert_to_hash(metric)))
+        @queue << LogStash::Event.new({ "@timestamp" => snapshot.created_at }.merge(metric.to_hash))
       end
-    end
-
-    # Transform the MetricType into a hash to create a new event
-    def convert_to_hash(metric)
-      {
-        "namespaces" => metric.namespaces,
-        "key" => metric.key,
-        "type" => metric.type,
-        "value" => metric.value
-      }
     end
   end
 end;end

--- a/logstash-core/lib/logstash/instrument/collector.rb
+++ b/logstash-core/lib/logstash/instrument/collector.rb
@@ -19,7 +19,7 @@ module LogStash module Instrument
     include Observable
     include Singleton
 
-    SNAPSHOT_ROTATION_TIME_SECS = 10 # seconds
+    SNAPSHOT_ROTATION_TIME_SECS = 1 # seconds
     SNAPSHOT_ROTATION_TIMEOUT_INTERVAL_SECS = 10 * 60 # seconds
 
     def initialize
@@ -34,9 +34,9 @@ module LogStash module Instrument
     # its the job of the collector to update the store with new metric
     # of update the metric
     #
-    # If there is a problem with the key or the type of metric we will record an error 
+    # If there is a problem with the key or the type of metric we will record an error
     # but we wont stop processing events, theses errors are not considered fatal.
-    # 
+    #
     def push(namespaces_path, key, type, *metric_type_params)
       begin
         metric = @metric_store.fetch_or_store(namespaces_path, key) do
@@ -69,7 +69,7 @@ module LogStash module Instrument
     # @param [Exception] Exception
     def update(time_of_execution, result, exception)
       return true if exception.nil?
-      logger.error("Collector: Something went wrong went sending data to the observers", 
+      logger.error("Collector: Something went wrong went sending data to the observers",
                    :execution_time => time_of_execution,
                    :result => result,
                    :exception => exception)
@@ -78,7 +78,7 @@ module LogStash module Instrument
     # Snapshot the current Metric Store and return it immediately,
     # This is useful if you want to get access to the current metric store without
     # waiting for a periodic call.
-    # 
+    #
     # @return [LogStash::Instrument::MetricStore]
     def snapshot_metric
       Snapshot.new(@metric_store)

--- a/logstash-core/lib/logstash/instrument/metric.rb
+++ b/logstash-core/lib/logstash/instrument/metric.rb
@@ -72,8 +72,8 @@ module LogStash module Instrument
     # Create a Metric instrance using the default Collector singleton reference
     #
     #
-    def self.create(namespace, collector = LogStash::Instrument::Collector.instance)
-      Metric.new(collector, namespace)
+    def self.create(collector = LogStash::Instrument::Collector.instance)
+      Metric.new(collector)
     end
 
     private

--- a/logstash-core/lib/logstash/instrument/metric_store.rb
+++ b/logstash-core/lib/logstash/instrument/metric_store.rb
@@ -55,7 +55,7 @@ module LogStash module Instrument
 
       if key_paths.empty?
         return map[key_candidate]
-      else 
+      else
         next_map = map[key_candidate]
 
         if next_map.is_a?(Concurrent::Map)
@@ -70,7 +70,7 @@ module LogStash module Instrument
       events = []
       values.each_value do |value|
         if value.is_a?(Concurrent::Map)
-          events << each_recursively(value) 
+          events << each_recursively(value)
         else
           events << value
         end
@@ -78,8 +78,8 @@ module LogStash module Instrument
       return events
     end
 
-    # This method iterate through the namespace path and try to find the corresponding 
-    # value for the path, if the any part of the path is not found it will 
+    # This method iterate through the namespace path and try to find the corresponding
+    # value for the path, if the any part of the path is not found it will
     # create it.
     #
     # @param [Array] The path where values should be located
@@ -107,7 +107,7 @@ module LogStash module Instrument
     #
     def fetch_or_store_namespace_recursively(map, namespaces_path, idx = 0)
       current = namespaces_path[idx]
-      
+
       # we are at the end of the namespace path, break out of the recursion
       return map if current.nil?
 

--- a/logstash-core/lib/logstash/instrument/metric_store.rb
+++ b/logstash-core/lib/logstash/instrument/metric_store.rb
@@ -11,11 +11,11 @@ module LogStash module Instrument
     class NamespacesExpectedError < StandardError; end
     class MetricNotFound < StandardError; end
 
-    KEY_PATH_SEPARATOR = "/"
+    KEY_PATH_SEPARATOR = "/".freeze
 
     # Lets me a bit flexible on the coma usage in the path
     # definition
-    FILTER_KEYS_SEPARATOR = /\s?*,\s*/
+    FILTER_KEYS_SEPARATOR = /\s?*,\s*/.freeze
 
     def initialize
       # We keep the structured cache to allow
@@ -58,7 +58,7 @@ module LogStash module Instrument
     def get(*key_paths)
       # Normalize the symbols access
       key_paths.map(&:to_sym)
-      new_hash = Hash.new({})
+      new_hash = Hash.new
 
       get_recursively(key_paths, @store, new_hash)
 
@@ -116,7 +116,7 @@ module LogStash module Instrument
       end.flatten
     end
 
-    def transform_to_hash(map, new_hash = Hash.new({}))
+    def transform_to_hash(map, new_hash = Hash.new)
       map.each_pair do |key, value|
         if value.is_a?(Concurrent::Map)
           new_hash[key] = {}

--- a/logstash-core/lib/logstash/instrument/metric_store.rb
+++ b/logstash-core/lib/logstash/instrument/metric_store.rb
@@ -36,7 +36,8 @@ module LogStash module Instrument
       get_recursively(key_paths, @store)
     end
 
-    # Return all the individuals Metric
+    # Return all the individuals Metric,
+    # This call mimic a Enum's each if a block is provided
     #
     # @return [Array] An array of all metric transformed in `Logstash::Event`, or in case of passing a block it yields
     # the expected value as other Enumerable implementations.
@@ -48,6 +49,7 @@ module LogStash module Instrument
         return data
       end
     end
+    alias_method :all, :each
 
     private
     def get_recursively(key_paths, map)

--- a/logstash-core/lib/logstash/instrument/metric_type.rb
+++ b/logstash-core/lib/logstash/instrument/metric_type.rb
@@ -12,7 +12,7 @@ module LogStash module Instrument
     }.freeze
 
     # Use the string to generate a concrete class for this metrics
-    # 
+    #
     # @param [String] The name of the class
     # @param [Array] Namespaces list
     # @param [String] The metric key

--- a/logstash-core/lib/logstash/instrument/metric_type/base.rb
+++ b/logstash-core/lib/logstash/instrument/metric_type/base.rb
@@ -19,7 +19,6 @@ module LogStash module Instrument module MetricType
       LogStash::Json.dump(value)
     end
 
-    protected
     def type
       @type ||= LogStash::Util.class_name(self).downcase
     end

--- a/logstash-core/lib/logstash/instrument/metric_type/base.rb
+++ b/logstash-core/lib/logstash/instrument/metric_type/base.rb
@@ -15,8 +15,17 @@ module LogStash module Instrument module MetricType
       "#{self.class.name} - namespaces: #{namespaces} key: #{key} value: #{value}"
     end
 
-    def to_json
-      LogStash::Json.dump(value)
+    def to_hash
+      {
+        "namespaces" => namespaces,
+        "key" => key,
+        "type" => type,
+        "value" => value
+      }
+    end
+
+    def to_json_data
+      value
     end
 
     def type

--- a/logstash-core/lib/logstash/instrument/metric_type/base.rb
+++ b/logstash-core/lib/logstash/instrument/metric_type/base.rb
@@ -1,21 +1,22 @@
 # encoding: utf-8
-require "logstash/instrument/metric_type/counter"
 require "logstash/event"
 require "logstash/util"
 
 module LogStash module Instrument module MetricType
   class Base
+    attr_reader :namespaces, :key
+
     def initialize(namespaces, key)
       @namespaces = namespaces
       @key = key
     end
 
-    def to_event(created_at = Time.now)
-      LogStash::Event.new(to_hash.merge({ "@timestamp" => created_at }))
+    def inspect
+      "#{self.class.name} - namespaces: #{namespaces} key: #{key} value: #{value}"
     end
 
-    def inspect
-      "#{self.class.name} - namespaces: #{@namespaces} key: #{@key} value: #{value}"
+    def to_json
+      LogStash::Json.dump(value)
     end
 
     protected

--- a/logstash-core/lib/logstash/instrument/metric_type/counter.rb
+++ b/logstash-core/lib/logstash/instrument/metric_type/counter.rb
@@ -25,14 +25,5 @@ module LogStash module Instrument module MetricType
     def value
       @counter.value
     end
-
-    def to_hash
-      { 
-        "namespaces" => @namespaces,
-        "key" => @key,
-        "type" => type,
-        "value" => value 
-      }
-    end
   end
 end; end; end

--- a/logstash-core/lib/logstash/instrument/metric_type/gauge.rb
+++ b/logstash-core/lib/logstash/instrument/metric_type/gauge.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/instrument/metric_type/base"
 require "concurrent/atomic_reference/mutex_atomic"
+require "logstash/json"
 
 module LogStash module Instrument module MetricType
   class Gauge < Base
@@ -16,15 +17,6 @@ module LogStash module Instrument module MetricType
 
     def value
       @gauge.get
-    end
-
-    def to_hash
-      { 
-        "namespaces" => @namespaces,
-        "key" => @key,
-        "type" => type,
-        "value" => value 
-      }
     end
   end
 end; end; end

--- a/logstash-core/lib/logstash/instrument/metric_type/mean.rb
+++ b/logstash-core/lib/logstash/instrument/metric_type/mean.rb
@@ -22,20 +22,12 @@ module LogStash module Instrument module MetricType
     end
 
     def mean
-      if @counter > 0 
+      if @counter > 0
         @sum.value / @counter.value
       else
         0
       end
     end
-
-    def to_hash
-      { 
-        "namespaces" => @namespaces,
-        "key" => @key,
-        "type" => type,
-        "value" => mean
-      }
-    end
+    alias_method :value, :mean
   end
 end; end; end

--- a/logstash-core/lib/logstash/instrument/namespaced_metric.rb
+++ b/logstash-core/lib/logstash/instrument/namespaced_metric.rb
@@ -1,0 +1,36 @@
+# encoding: utf-8
+require "logstash/instrument/metric"
+
+module LogStash module Instrument
+  # This class acts a a proxy between the metric library and the user calls.
+  #
+  # This is the class that plugins authors will use to interact with the `MetricStore`
+  # It has the same public interface as `Metric` class but doesnt require to send
+  # the namespace on every call.
+  #
+  # @see Logstash::Instrument::Metric
+  class NamespacedMetric
+    # Create metric with a specific namespace
+    #
+    # @param metric [LogStash::Instrument::Metric] The metric instance to proxy
+    # @param namespace [Array] The namespace to use
+    def initialize(metric, namespace)
+      @metric = metrics
+      @namespace = Array(namespace)
+    end
+
+    # Get only the instance methods defined in the class
+    # and not the whole hierarchy of methods.
+    LogStash::Instrument::Metric.public_instance_methods(false).each do |method|
+      define_method method do |key, *args|
+        metric.send(method, namespace, args)
+      end
+    end
+
+    def namespace(name)
+    end
+
+    private
+    attr_reader :metric, :namespace
+  end
+end; end

--- a/logstash-core/lib/logstash/instrument/namespaced_metric.rb
+++ b/logstash-core/lib/logstash/instrument/namespaced_metric.rb
@@ -20,12 +20,28 @@ module LogStash module Instrument
       @namespace_name = Array(namespace_name)
     end
 
-    # Get only the instance methods defined in the class
-    # and not the whole hierarchy of methods.
-    LogStash::Instrument::Metric.public_instance_methods(false).each do |method|
-      define_method method do |key, *args|
-        metric.send(method, namespace_name, key, *args)
-      end
+    def increment(key, value = 1)
+      @metric.increment(namespace_name, key, value)
+    end
+
+    def decrement(namespace, key, value = 1)
+      @metric.decrement(namespace_name, key, value)
+    end
+
+    def gauge(key, value)
+      @metric.gauge(namespace_name, key, value)
+    end
+
+    def report_time(key, duration)
+      @metric.report_time(namespace_name, key, duration)
+    end
+
+    def time(key, &block)
+      @metric.time(namespace_name, key, &block)
+    end
+
+    def collector
+      @metric.collector
     end
 
     def namespace(name)

--- a/logstash-core/lib/logstash/instrument/namespaced_metric.rb
+++ b/logstash-core/lib/logstash/instrument/namespaced_metric.rb
@@ -10,27 +10,29 @@ module LogStash module Instrument
   #
   # @see Logstash::Instrument::Metric
   class NamespacedMetric
+    attr_reader :namespace_name
     # Create metric with a specific namespace
     #
     # @param metric [LogStash::Instrument::Metric] The metric instance to proxy
     # @param namespace [Array] The namespace to use
-    def initialize(metric, namespace)
-      @metric = metrics
-      @namespace = Array(namespace)
+    def initialize(metric, namespace_name)
+      @metric = metric
+      @namespace_name = Array(namespace_name)
     end
 
     # Get only the instance methods defined in the class
     # and not the whole hierarchy of methods.
     LogStash::Instrument::Metric.public_instance_methods(false).each do |method|
       define_method method do |key, *args|
-        metric.send(method, namespace, args)
+        metric.send(method, namespace_name, key, *args)
       end
     end
 
     def namespace(name)
+      NamespacedMetric.new(metric, namespace_name.concat(Array(name)))
     end
 
     private
-    attr_reader :metric, :namespace
+    attr_reader :metric
   end
 end; end

--- a/logstash-core/lib/logstash/instrument/null_metric.rb
+++ b/logstash-core/lib/logstash/instrument/null_metric.rb
@@ -6,11 +6,12 @@ module LogStash module Instrument
  # for specific plugin to replace the `NamespacedMetric` class with this one
  # which doesn't produce any metric to the collector.
  class NullMetric
+    attr_reader :namespace_name
+
    # Get only the instance methods defined in the class
    # and not the whole hierarchy of methods.
    LogStash::Instrument::Metric.public_instance_methods(false).each do |method|
       define_method method do |key, *args|
-        metric.send(method, namespace, args)
       end
    end
 

--- a/logstash-core/lib/logstash/instrument/null_metric.rb
+++ b/logstash-core/lib/logstash/instrument/null_metric.rb
@@ -6,13 +6,18 @@ module LogStash module Instrument
  # for specific plugin to replace the `NamespacedMetric` class with this one
  # which doesn't produce any metric to the collector.
  class NullMetric
-    attr_reader :namespace_name
+   attr_reader :namespace_name, :collector
 
-   # Get only the instance methods defined in the class
-   # and not the whole hierarchy of methods.
-   LogStash::Instrument::Metric.public_instance_methods(false).each do |method|
-      define_method method do |key, *args|
-      end
+   def increment(key, value = 1)
+   end
+
+   def decrement(namespace, key, value = 1)
+   end
+
+   def gauge(key, value)
+   end
+
+   def report_time(key, duration)
    end
 
    # We have to manually redefine this method since it can return an

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -15,6 +15,7 @@ require "logstash/shutdown_watcher"
 require "logstash/util/wrapped_synchronous_queue"
 require "logstash/pipeline_reporter"
 require "logstash/instrument/metric"
+require "logstash/instrument/namespaced_metric"
 require "logstash/instrument/null_metric"
 require "logstash/instrument/collector"
 require "logstash/output_delegator"
@@ -54,11 +55,11 @@ module LogStash; class Pipeline
     @outputs = nil
 
     @worker_threads = []
-    
+
     # Metric object should be passed upstream, multiple pipeline share the same metric
     # and collector only the namespace will changes.
     # If no metric is given, we use a `NullMetric` for all internal calls.
-    # We also do this to make the changes backward compatible with previous testing of the 
+    # We also do this to make the changes backward compatible with previous testing of the
     # pipeline.
     #
     # This need to be configured before we evaluate the code to make
@@ -181,7 +182,7 @@ module LogStash; class Pipeline
     begin
       start_inputs
       @outputs.each {|o| o.register }
-      @filters.each {|f| f.register}
+      @filters.each {|f| f.register }
 
       pipeline_workers = safe_pipeline_worker_count
       batch_size = @settings[:pipeline_batch_size]
@@ -211,9 +212,12 @@ module LogStash; class Pipeline
   end
 
   # Main body of what a worker thread does
-  # Repeatedly takes batches off the queu, filters, then outputs them
+  # Repeatedly takes batches off the queue, filters, then outputs them
   def worker_loop(batch_size, batch_delay)
     running = true
+
+    namespace_events = metric.namespace([:stats, :events])
+    namespace_pipeline = metric.namespace([:stats, :pipelines, pipeline_id.to_s.to_sym, :events])
 
     while running
       # To understand the purpose behind this synchronize please read the body of take_batch
@@ -221,7 +225,9 @@ module LogStash; class Pipeline
       running = false if signal == LogStash::SHUTDOWN
 
       @events_consumed.increment(input_batch.size)
-      metric.increment(:events_in, input_batch.size)
+
+      namespace_events.increment(:in, input_batch.size)
+      namespace_pipeline.increment(:in, input_batch.size)
 
       filtered_batch = filter_batch(input_batch)
 
@@ -231,9 +237,14 @@ module LogStash; class Pipeline
       end
 
       @events_filtered.increment(filtered_batch.size)
-      metric.increment(:events_filtered, filtered_batch.size)
+
+      namespace_events.increment(:filtered, filtered_batch.size)
+      namespace_pipeline.increment(:filtered, filtered_batch.size)
 
       output_batch(filtered_batch)
+
+      namespace_events.increment(:out, filtered_batch.size)
+      namespace_pipeline.increment(:out, filtered_batch.size)
 
       inflight_batches_synchronize { set_current_thread_inflight_batch(nil) }
     end
@@ -412,12 +423,14 @@ module LogStash; class Pipeline
   def plugin(plugin_type, name, *args)
     args << {} if args.empty?
 
+    pipeline_scoped_metric = metric.namespace([:stats, :pipelines, pipeline_id.to_s.to_sym, :plugins])
+
     klass = LogStash::Plugin.lookup(plugin_type, name)
 
     if plugin_type == "output"
-      LogStash::OutputDelegator.new(@logger, klass, default_output_workers, metric, *args)
+      LogStash::OutputDelegator.new(@logger, klass, default_output_workers, pipeline_scoped_metric.namespace(:outputs), *args)
     elsif plugin_type == "filter"
-      LogStash::FilterDelegator.new(@logger, klass, metric, *args)
+      LogStash::FilterDelegator.new(@logger, klass, pipeline_scoped_metric.namespace(:filters), *args)
     else
       klass.new(*args)
     end
@@ -467,7 +480,7 @@ module LogStash; class Pipeline
   end
 
   # Calculate the uptime in milliseconds
-  # 
+  #
   # @return [Fixnum] Uptime in milliseconds, 0 if the pipeline is not started
   def uptime
     return 0 if started_at.nil?

--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -92,7 +92,7 @@ class LogStash::Plugin
   end
 
   def metric=(new_metric)
-    @metric = new_metric.namespace(@id)
+    @metric = new_metric
   end
 
   def metric

--- a/logstash-core/spec/logstash/instrument/metric_spec.rb
+++ b/logstash-core/spec/logstash/instrument/metric_spec.rb
@@ -8,60 +8,60 @@ describe LogStash::Instrument::Metric do
   let(:collector) { [] }
   let(:namespace) { :root }
 
-  subject { LogStash::Instrument::Metric.new(collector, namespace) }
+  subject { LogStash::Instrument::Metric.new(collector) }
 
   context "#increment" do
     it "a counter by 1" do
-      metric = subject.increment(:error_rate)
+      metric = subject.increment(:root, :error_rate)
       expect(collector).to be_a_metric_event([:root, :error_rate], :counter, :increment, 1)
     end
 
     it "a counter by a provided value" do
-      metric = subject.increment(:error_rate, 20)
+      metric = subject.increment(:root, :error_rate, 20)
       expect(collector).to be_a_metric_event([:root, :error_rate], :counter, :increment, 20)
     end
 
     it "raises an exception if the key is an empty string" do
-      expect { subject.increment("", 20) }.to raise_error(LogStash::Instrument::MetricNoKeyProvided)
+      expect { subject.increment(:root, "", 20) }.to raise_error(LogStash::Instrument::MetricNoKeyProvided)
     end
 
     it "raise an exception if the key is nil" do
-      expect { subject.increment(nil, 20) }.to raise_error(LogStash::Instrument::MetricNoKeyProvided)
+      expect { subject.increment(:root, nil, 20) }.to raise_error(LogStash::Instrument::MetricNoKeyProvided)
     end
   end
 
   context "#decrement" do
     it "a counter by 1" do
-      metric = subject.decrement(:error_rate)
+      metric = subject.decrement(:root, :error_rate)
       expect(collector).to be_a_metric_event([:root, :error_rate], :counter, :decrement, 1)
     end
 
     it "a counter by a provided value" do
-      metric = subject.decrement(:error_rate, 20)
+      metric = subject.decrement(:root, :error_rate, 20)
       expect(collector).to be_a_metric_event([:root, :error_rate], :counter, :decrement, 20)
     end
 
     it "raises an exception if the key is an empty string" do
-      expect { subject.decrement("", 20) }.to raise_error(LogStash::Instrument::MetricNoKeyProvided)
+      expect { subject.decrement(:root, "", 20) }.to raise_error(LogStash::Instrument::MetricNoKeyProvided)
     end
 
     it "raise an exception if the key is nil" do
-      expect { subject.decrement(nil, 20) }.to raise_error(LogStash::Instrument::MetricNoKeyProvided)
+      expect { subject.decrement(:root, nil, 20) }.to raise_error(LogStash::Instrument::MetricNoKeyProvided)
     end
   end
 
   context "#gauge" do
     it "set the value of a key" do
-      metric = subject.gauge(:size_queue, 20)
+      metric = subject.gauge(:root, :size_queue, 20)
       expect(collector).to be_a_metric_event([:root, :size_queue], :gauge, :set, 20)
     end
 
     it "raises an exception if the key is an empty string" do
-      expect { subject.gauge("", 20) }.to raise_error(LogStash::Instrument::MetricNoKeyProvided)
+      expect { subject.gauge(:root, "", 20) }.to raise_error(LogStash::Instrument::MetricNoKeyProvided)
     end
 
     it "raise an exception if the key is nil" do
-      expect { subject.gauge(nil, 20) }.to raise_error(LogStash::Instrument::MetricNoKeyProvided)
+      expect { subject.gauge(:root, nil, 20) }.to raise_error(LogStash::Instrument::MetricNoKeyProvided)
     end
   end
 
@@ -70,25 +70,25 @@ describe LogStash::Instrument::Metric do
     let(:sleep_time_ms) { sleep_time * 1_000_000 }
 
     it "records the duration" do
-      subject.time(:duration_ms) { sleep(sleep_time) }
+      subject.time(:root, :duration_ms) { sleep(sleep_time) }
 
       expect(collector.last).to be_within(sleep_time_ms).of(sleep_time_ms + 5000)
-      expect(collector[0]).to match([:root])
+      expect(collector[0]).to match(:root)
       expect(collector[1]).to be(:duration_ms)
       expect(collector[2]).to be(:mean)
     end
 
     it "returns the value of the executed block" do
-      expect(subject.time(:testing) { "hello" }).to eq("hello")
+      expect(subject.time(:root, :testing) { "hello" }).to eq("hello")
     end
 
     it "return a TimedExecution" do
-      execution = subject.time(:duration_ms)
+      execution = subject.time(:root, :duration_ms)
       sleep(sleep_time)
       execution.stop
 
       expect(collector.last).to be_within(sleep_time_ms).of(sleep_time_ms + 0.1)
-      expect(collector[0]).to match([:root])
+      expect(collector[0]).to match(:root)
       expect(collector[1]).to be(:duration_ms)
       expect(collector[2]).to be(:mean)
     end
@@ -98,12 +98,13 @@ describe LogStash::Instrument::Metric do
     let(:sub_key) { :my_sub_key }
 
     it "creates a new metric object and append the `sub_key` to the `base_key`" do
-      expect(subject.namespace(sub_key).namespace_information).to eq([namespace, sub_key])
+      expect(subject.namespace(sub_key).namespace_name).to eq([sub_key])
     end
 
     it "uses the same collector as the creator class" do
       child = subject.namespace(sub_key)
-      expect(subject.collector).to eq(child.collector)
+      metric = child.increment(:error_rate)
+      expect(collector).to be_a_metric_event([sub_key, :error_rate], :counter, :increment, 1)
     end
   end
 end

--- a/logstash-core/spec/logstash/instrument/metric_spec.rb
+++ b/logstash-core/spec/logstash/instrument/metric_spec.rb
@@ -68,7 +68,7 @@ describe LogStash::Instrument::Metric do
   context "#time" do
     let(:sleep_time) { 2 }
     let(:sleep_time_ms) { sleep_time * 1_000_000 }
-      
+
     it "records the duration" do
       subject.time(:duration_ms) { sleep(sleep_time) }
 

--- a/logstash-core/spec/logstash/instrument/metric_store_spec.rb
+++ b/logstash-core/spec/logstash/instrument/metric_store_spec.rb
@@ -75,9 +75,7 @@ describe LogStash::Instrument::MetricStore do
       end
 
       it "returns metric types" do
-        subject.each do |metric_type|
-          expect(metric_type).be kind_of(LogStash::Instrument::MetricType::Base)
-        end
+        expect { |b| subject.each(&b) }.to yield_successive_args(LogStash::Instrument::MetricType::Base, LogStash::Instrument::MetricType::Base, LogStash::Instrument::MetricType::Base)
       end
     end
   end

--- a/logstash-core/spec/logstash/instrument/metric_store_spec.rb
+++ b/logstash-core/spec/logstash/instrument/metric_store_spec.rb
@@ -3,7 +3,7 @@ require "logstash/instrument/metric_store"
 require "logstash/instrument/metric_type/base"
 
 describe LogStash::Instrument::MetricStore do
-  let(:namespaces) { [ :root, :pipelines, :pipeline_01 ] } 
+  let(:namespaces) { [ :root, :pipelines, :pipeline_01 ] }
   let(:key) { :events_in }
   let(:counter) { LogStash::Instrument::MetricType::Counter.new(namespaces, key) }
 
@@ -35,7 +35,7 @@ describe LogStash::Instrument::MetricStore do
     end
   end
 
-  describe "#get" do
+  context "retrieving events" do
     let(:metric_events) {
       [
         [[:node, :sashimi, :pipelines, :pipeline01, :plugins, :"logstash-output-elasticsearch"], :event_in, :increment],
@@ -52,19 +52,33 @@ describe LogStash::Instrument::MetricStore do
       end
     end
 
-    it "retrieves end of of a branch" do
-      metrics = subject.get(:node, :sashimi, :pipelines, :pipeline01, :plugins, :"logstash-output-elasticsearch")
-      expect(metrics).to be_kind_of(Concurrent::Map)
+    describe "#get" do
+      it "retrieves end of of a branch" do
+        metrics = subject.get(:node, :sashimi, :pipelines, :pipeline01, :plugins, :"logstash-output-elasticsearch")
+        expect(metrics).to be_kind_of(Concurrent::Map)
+      end
+
+      it "retrieves branch" do
+        metrics = subject.get(:node, :sashimi, :pipelines, :pipeline01)
+        expect(metrics).to be_kind_of(Concurrent::Map)
+      end
+
+      it "allow to retrieve a specific metrics" do
+        metrics = subject.get(:node, :sashimi, :pipelines, :pipeline01, :plugins, :"logstash-output-elasticsearch", :event_in)
+        expect(metrics).to be_kind_of(LogStash::Instrument::MetricType::Base)
+      end
     end
 
-    it "retrieves branch" do
-      metrics = subject.get(:node, :sashimi, :pipelines, :pipeline01)
-      expect(metrics).to be_kind_of(Concurrent::Map)
-    end
+    describe "#each" do
+      it "retrieves all the metric" do
+        expect(subject.each.size).to eq(metric_events.size)
+      end
 
-    it "allow to retrieve a specific metrics" do
-      metrics = subject.get(:node, :sashimi, :pipelines, :pipeline01, :plugins, :"logstash-output-elasticsearch", :event_in)
-      expect(metrics).to be_kind_of(LogStash::Instrument::MetricType::Base)
+      it "returns metric types" do
+        subject.each do |metric_type|
+          expect(metric_type).be kind_of(LogStash::Instrument::MetricType::Base)
+        end
+      end
     end
   end
 end

--- a/logstash-core/spec/logstash/instrument/metric_store_spec.rb
+++ b/logstash-core/spec/logstash/instrument/metric_store_spec.rb
@@ -48,7 +48,7 @@ describe LogStash::Instrument::MetricStore do
     before :each do
       # Lets add a few metrics in the store before trying to find them
       metric_events.each do |namespaces, metric_key, action|
-        metric = subject.fetch_or_store(namespaces, metric_key, LogStash::Instrument::MetricType::Counter.new(namespaces, key))
+        metric = subject.fetch_or_store(namespaces, metric_key, LogStash::Instrument::MetricType::Counter.new(namespaces, metric_key))
         metric.execute(action)
       end
     end
@@ -151,6 +151,12 @@ describe LogStash::Instrument::MetricStore do
         metrics = []
         subject.each { |i| metrics << i }
         expect(metrics.size).to eq(metric_events.size)
+      end
+
+      it "retrieves all the metrics from a specific branch" do
+        metrics = []
+        subject.each("node/sashimi/pipelines/pipeline01") { |i| metrics << i }
+        expect(metrics.size).to eq(3)
       end
     end
   end

--- a/logstash-core/spec/logstash/instrument/metric_type/counter_spec.rb
+++ b/logstash-core/spec/logstash/instrument/metric_type/counter_spec.rb
@@ -25,4 +25,16 @@ describe LogStash::Instrument::MetricType::Counter do
       expect(LogStash::Json.dump(subject)).to eq("0")
     end
   end
+
+  context "When creating a hash " do
+    it "creates the hash from all the values" do
+      metric_hash = {
+        "key" => key,
+        "namespaces" => namespaces,
+        "value" => 0,
+        "type" => "counter"
+      }
+      expect(subject.to_hash).to match(metric_hash)
+    end
+  end
 end

--- a/logstash-core/spec/logstash/instrument/metric_type/counter_spec.rb
+++ b/logstash-core/spec/logstash/instrument/metric_type/counter_spec.rb
@@ -20,12 +20,9 @@ describe LogStash::Instrument::MetricType::Counter do
     end
   end
 
-  describe "#to_hash" do
-    it "return the details of the counter" do
-      expect(subject.to_hash).to include({ "namespaces" => namespaces,
-                                           "key" => key,
-                                           "value" => 0,
-                                           "type" => "counter" })
+  context "When serializing to JSON" do
+    it "serializes the value" do
+      expect(LogStash::Json.dump(subject)).to eq("0")
     end
   end
 end

--- a/logstash-core/spec/logstash/instrument/metric_type/gauge_spec.rb
+++ b/logstash-core/spec/logstash/instrument/metric_type/gauge_spec.rb
@@ -25,4 +25,16 @@ describe LogStash::Instrument::MetricType::Gauge do
       expect(LogStash::Json.dump(subject)).to eq("\"#{value}\"")
     end
   end
+
+  context "When creating a hash " do
+    it "creates the hash from all the values" do
+      metric_hash = {
+        "key" => key,
+        "namespaces" => namespaces,
+        "value" => value,
+        "type" => "gauge"
+      }
+      expect(subject.to_hash).to match(metric_hash)
+    end
+  end
 end

--- a/logstash-core/spec/logstash/instrument/metric_type/gauge_spec.rb
+++ b/logstash-core/spec/logstash/instrument/metric_type/gauge_spec.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require "logstash/instrument/metric_type/gauge"
+require "logstash/json"
 require "spec_helper"
 
 describe LogStash::Instrument::MetricType::Gauge do
@@ -19,13 +20,9 @@ describe LogStash::Instrument::MetricType::Gauge do
     end
   end
 
-  describe "#to_hash" do
-
-    it "return the details of the gauge" do
-      expect(subject.to_hash).to include({ "namespaces" => namespaces,
-                                           "key" => key,
-                                           "value" => value,
-                                           "type" => "gauge" })
+  context "When serializing to JSON" do
+    it "serializes the value" do
+      expect(LogStash::Json.dump(subject)).to eq("\"#{value}\"")
     end
   end
 end

--- a/logstash-core/spec/logstash/instrument/namespaced_metric_spec.rb
+++ b/logstash-core/spec/logstash/instrument/namespaced_metric_spec.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+require "logstash/instrument/namespaced_metric"
+require "logstash/instrument/metric"
+require_relative "../../support/matchers"
+require "spec_helper"
+
+describe LogStash::Instrument::NamespacedMetric do
+  let(:namespace) { :stats }
+
+  it "defines the same interface as `Metric`" do
+    expect(described_class).to implement_interface_of(LogStash::Instrument::Metric)
+  end
+end

--- a/logstash-core/spec/logstash/instrument/namespaced_metric_spec.rb
+++ b/logstash-core/spec/logstash/instrument/namespaced_metric_spec.rb
@@ -6,8 +6,20 @@ require "spec_helper"
 
 describe LogStash::Instrument::NamespacedMetric do
   let(:namespace) { :stats }
+  let(:collector) { [] }
+  let(:metric) { LogStash::Instrument::Metric.new(collector) }
+
+  subject { described_class.new(metric, namespace) }
 
   it "defines the same interface as `Metric`" do
     expect(described_class).to implement_interface_of(LogStash::Instrument::Metric)
+  end
+
+  it "returns a TimedException when we call without a block" do
+    expect(subject.time(:duration_ms)).to be_kind_of(LogStash::Instrument::Metric::TimedExecution)
+  end
+
+  it "returns the value of the block" do
+    expect(subject.time(:duration_ms) { "hello" }).to eq("hello")
   end
 end

--- a/logstash-core/spec/logstash/instrument/null_metric_spec.rb
+++ b/logstash-core/spec/logstash/instrument/null_metric_spec.rb
@@ -1,11 +1,11 @@
 # encoding: utf-8
 require "logstash/instrument/null_metric"
-require "logstash/instrument/metric"
+require "logstash/instrument/namespaced_metric"
 require_relative "../../support/matchers"
 
 describe LogStash::Instrument::NullMetric do
   it "defines the same interface as `Metric`" do
-    expect(described_class).to implement_interface_of(LogStash::Instrument::Metric) 
+    expect(described_class).to implement_interface_of(LogStash::Instrument::NamespacedMetric)
   end
 
   describe "#time" do

--- a/logstash-core/spec/support/matchers.rb
+++ b/logstash-core/spec/support/matchers.rb
@@ -4,7 +4,7 @@ require "rspec/expectations"
 
 RSpec::Matchers.define :be_a_metric_event do |namespace, type, *args|
   match do
-    namespace == actual[0] << actual[1] && 
+    namespace == Array(actual[0]).concat(Array(actual[1])) &&
       type == actual[2] &&
       args == actual[3..-1]
   end
@@ -17,11 +17,11 @@ RSpec::Matchers.define :implement_interface_of do |type, key, value|
   end
 
   def missing_methods
-    expected.instance_methods - actual.instance_methods 
+    expected.instance_methods.select { |method| !actual.instance_methods.include?(method) }
   end
 
   def all_instance_methods_implemented?
-    missing_methods.empty?
+    expected.instance_methods.all? { |method| actual.instance_methods.include?(method) }
   end
 
   failure_message do


### PR DESCRIPTION
Refactoring of the metric:

- Conform to the metric defined in Follow #4492
- Better filtering of the metrics from the metric store Fixes #4461
- Hide the implementation details of the metric store It return an hash, Fixes #4529
- MetricStore#each now support a path to only fetch a subset on the metrics.