### PR TITLE
Hide milestone confusing message to the user

### DIFF
--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -147,7 +147,7 @@ module LogStash::Config::Mixin
     # inside the gemspec.
     def milestone(m = nil)
       @logger = Cabin::Channel.get(LogStash)
-      @logger.warn(I18n.t('logstash.plugin.deprecated_milestone', :plugin => config_name))
+      @logger.debug(I18n.t('logstash.plugin.deprecated_milestone', :plugin => config_name))
     end
 
     # Define a new configuration setting

--- a/logstash-core/spec/logstash/plugin_spec.rb
+++ b/logstash-core/spec/logstash/plugin_spec.rb
@@ -111,7 +111,7 @@ describe LogStash::Plugin do
 
 
     it 'logs a warning if the plugin use the milestone option' do
-      expect_any_instance_of(Cabin::Channel).to receive(:warn)
+      expect_any_instance_of(Cabin::Channel).to receive(:debug)
         .with(/stromae plugin is using the 'milestone' method/)
 
       class LogStash::Filters::Stromae < LogStash::Filters::Base


### PR DESCRIPTION
This PR change the log level when a user load a plugin with a milestone
option to debug instead of warn.

Fixes: #4562