### PR TITLE
Initial .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
     - ~/.gradle/
 rvm:
   - jruby-1.7.25
-  - jruby-9.0.5.0
 jdk:
   - oraclejdk8
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: false
+language: ruby
+cache:
+  directories:
+    - vendor/bundle
+    - ~/.gradle/
+rvm:
+  - jruby-1.7.25
+  - jruby-9.0.5.0
+jdk:
+  - oraclejdk8
+before_script:
+  - rake test:install-core
+  - echo "--order rand" > .rspec
+  - echo "--format documentation" >> .rspec
+script: rake test:core

--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 ### Build status
 
-| Branch | master | 2.x | 2.1
+| Test | master | 5.0 | 2.3 |
 |---|---|---|---|
-| core | [![Build Status](http://build-eu-00.elastic.co/view/LS%20Master/job/logstash_regression_master/badge/icon)](http://build-eu-00.elastic.co/view/LS%20Master/job/logstash_regression_master/) | [![Build Status](http://build-eu-00.elastic.co/view/LS%202.x/job/logstash_regression_2x/badge/icon)](http://build-eu-00.elastic.co/view/LS%202.x/job/logstash_regression_2x/) | [![Build Status](http://build-eu-00.elastic.co/view/LS%202.x/job/logstash_regression_21/badge/icon)](http://build-eu-00.elastic.co/view/LS%202.x/job/logstash_regression_21/) |
-| integration | [![Build Status](http://build-eu-00.elastic.co/view/LS%20Master/job/Logstash_Master_Default_Plugins/badge/icon)](http://build-eu-00.elastic.co/view/LS%20Master/job/Logstash_Master_Default_Plugins/) | [![Build Status](http://build-eu-00.elastic.co/view/LS%202.x/job/Logstash_Default_Plugins_2x/badge/icon)](http://build-eu-00.elastic.co/view/LS%202.x/job/Logstash_Default_Plugins_2x/) | [![Build Status](http://build-eu-00.elastic.co/view/LS%202.x/job/Logstash_Default_Plugins_21/badge/icon)](http://build-eu-00.elastic.co/view/LS%202.x/job/Logstash_Default_Plugins_21/) |
+| core | [![Build Status](https://travis-ci.org/elastic/logstash.svg?branch=master)](https://travis-ci.org/elastic/logstash) | [![Build Status](https://travis-ci.org/elastic/logstash.svg?branch=2.3)](https://travis-ci.org/elastic/logstash) | [![Build Status](https://travis-ci.org/elastic/logstash.svg?branch=2.3)](https://travis-ci.org/elastic/logstash) |
 
 Logstash is a tool for managing events and logs. You can use it to collect
 logs, parse them, and store them for later use (like, for searching).  If you


### PR DESCRIPTION
This patch:

* Moves us to Travis for PR based pull requests
* Uses `rake test:install-core && rake test:core-fail-fast` rather than the `ci/*` scripts for simplicity. Travis starts clean ever time
* Caches the `vendor/bundle` and `.gradle` directories for speed. Infrequently running Jenkins jobs can check for issues the latest versions of gems.
* Updates README.md to point to the new tests, and hides buttons to the defunct all-plugins tests.