### PR TITLE
Make Java 8 as minimum required

### DIFF
--- a/logstash-core/lib/logstash/util/java_version.rb
+++ b/logstash-core/lib/logstash/util/java_version.rb
@@ -9,7 +9,7 @@ module LogStash::Util::JavaVersion
   # Print a warning if we're on a bad version of java
   def self.warn_on_bad_java_version
     if self.bad_java_version?(self.version)
-      msg = "!!! Please upgrade your java version, the current version '#{self.version}' may cause problems. We recommend a minimum version of 1.7.0_51"
+      msg = "!!! Please upgrade your java version, the current version '#{self.version}' is not supported. We recommend a minimum version of Java 8"
       STDERR.puts(msg)
       logger.warn(msg)
     end
@@ -55,9 +55,7 @@ module LogStash::Util::JavaVersion
     parsed = parse_java_version(version_string)
     return false unless parsed
 
-    if parsed[:major] == 1 && parsed[:minor] == 7 && parsed[:patch] == 0 && parsed[:update] < 51
-      true
-    elsif parsed[:major] == 1 && parsed[:minor] < 7
+    if parsed[:major] == 1 && parsed[:minor] < 8
       true
     else
       false

--- a/logstash-core/spec/logstash/util/java_version_spec.rb
+++ b/logstash-core/spec/logstash/util/java_version_spec.rb
@@ -19,10 +19,18 @@ describe "LogStash::Util::JavaVersion" do
     expect(mod.bad_java_version?("1.6.0")).to be_truthy
   end
 
-  it "should mark a good standard java version as good" do
-    expect(mod.bad_java_version?("1.7.0_51")).to be_falsey
+  it "should mark java 7 version as bad" do
+    expect(mod.bad_java_version?("1.7.0_51")).to be_truthy
   end
-
+  
+  it "should mark java version 8 as good" do
+    expect(mod.bad_java_version?("1.8.0")).to be_falsey
+  end
+  
+  it "should mark a good standard java version as good" do
+    expect(mod.bad_java_version?("1.8.0_65")).to be_falsey
+  end
+  
   it "should mark a good beta version as good" do
     expect(mod.bad_java_version?("1.8.0-beta")).to be_falsey
   end


### PR DESCRIPTION
Oracle marked the EOL of Java 7 in April 2015, and as of July 2015 they no longer provide downloads for Java 7.

Fixes #3877