### PR TITLE
add Event#from_json method

### DIFF
--- a/logstash-core-event-java/build.gradle
+++ b/logstash-core-event-java/build.gradle
@@ -92,8 +92,8 @@ idea {
 }
 
 dependencies {
-    compile 'org.codehaus.jackson:jackson-mapper-asl:1.9.13'
-    compile 'org.codehaus.jackson:jackson-core-asl:1.9.13'
+    compile 'com.fasterxml.jackson.core:jackson-core:2.7.1'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.7.1-1'
     provided 'org.jruby:jruby-core:1.7.22'
     testCompile 'junit:junit:4.12'
     testCompile 'net.javacrumbs.json-unit:json-unit:1.9.0'

--- a/logstash-core-event-java/lib/logstash-core-event-java_jars.rb
+++ b/logstash-core-event-java/lib/logstash-core-event-java_jars.rb
@@ -1,5 +1,6 @@
 # this is a generated file, to avoid over-writing it just delete this comment
 require 'jar_dependencies'
 
-require_jar( 'org.codehaus.jackson', 'jackson-core-asl', '1.9.13' )
-require_jar( 'org.codehaus.jackson', 'jackson-mapper-asl', '1.9.13' )
+require_jar( 'com.fasterxml.jackson.core', 'jackson-core', '2.7.1' )
+require_jar( 'com.fasterxml.jackson.core', 'jackson-annotations', '2.7.0' )
+require_jar( 'com.fasterxml.jackson.core', 'jackson-databind', '2.7.1-1' )

--- a/logstash-core-event-java/logstash-core-event-java.gemspec
+++ b/logstash-core-event-java/logstash-core-event-java.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |gem|
   # which does not have this problem.
   gem.add_runtime_dependency "ruby-maven", "~> 3.3.9"
 
-  gem.requirements << "jar org.codehaus.jackson:jackson-mapper-asl, 1.9.13"
-  gem.requirements << "jar org.codehaus.jackson:jackson-core-asl, 1.9.13"
+  gem.requirements << "jar com.fasterxml.jackson.core:jackson-core, 2.7.1"
+  gem.requirements << "jar com.fasterxml.jackson.core:jackson-databind, 2.7.1-1"
 end
-

--- a/logstash-core-event-java/src/main/java/com/logstash/KeyNode.java
+++ b/logstash-core-event-java/src/main/java/com/logstash/KeyNode.java
@@ -1,7 +1,6 @@
 package com.logstash;
 
-import org.codehaus.jackson.JsonGenerationException;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.List;

--- a/logstash-core-event-java/src/main/java/com/logstash/TemplateNode.java
+++ b/logstash-core-event-java/src/main/java/com/logstash/TemplateNode.java
@@ -1,7 +1,5 @@
 package com.logstash;
 
-import org.codehaus.jackson.JsonGenerationException;
-
 import java.io.IOException;
 
 /**

--- a/logstash-core-event-java/src/main/java/com/logstash/Timestamp.java
+++ b/logstash-core-event-java/src/main/java/com/logstash/Timestamp.java
@@ -1,6 +1,6 @@
 package com.logstash;
 
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;

--- a/logstash-core-event-java/src/main/java/com/logstash/TimestampSerializer.java
+++ b/logstash-core-event-java/src/main/java/com/logstash/TimestampSerializer.java
@@ -1,8 +1,8 @@
 package com.logstash;
 
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.map.JsonSerializer;
-import org.codehaus.jackson.map.SerializerProvider;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
 
 import java.io.IOException;
 

--- a/logstash-core-event-java/src/main/java/com/logstash/ext/JrubyTimestampExtLibrary.java
+++ b/logstash-core-event-java/src/main/java/com/logstash/ext/JrubyTimestampExtLibrary.java
@@ -1,7 +1,6 @@
 package com.logstash.ext;
 
 import com.logstash.*;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.jruby.*;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;

--- a/logstash-core/spec/logstash/json_spec.rb
+++ b/logstash-core/spec/logstash/json_spec.rb
@@ -18,6 +18,9 @@ describe "LogStash::Json" do
   let(:multi) {
     [
       {:ruby => "foo bar baz", :json => "\"foo bar baz\""},
+      {:ruby => "foo   ", :json => "\"foo   \""},
+      {:ruby => " ", :json => "\" \""},
+      {:ruby => "   ", :json => "\"   \""},
       {:ruby => "1", :json => "\"1\""},
       {:ruby => {"a" => true}, :json => "{\"a\":true}"},
       {:ruby => {"a" => nil}, :json => "{\"a\":null}"},
@@ -92,5 +95,17 @@ describe "LogStash::Json" do
 
   it "should raise Json::ParserError on invalid json" do
     expect{LogStash::Json.load("abc")}.to raise_error LogStash::Json::ParserError
+  end
+
+  it "should return nil on empty string" do
+    o = LogStash::Json.load("")
+    expect(o).to be_nil
+  end
+
+  it "should return nil on blank string" do
+    o = LogStash::Json.load(" ")
+    expect(o).to be_nil
+    o = LogStash::Json.load("  ")
+    expect(o).to be_nil
   end
 end


### PR DESCRIPTION
will fix #4595 

This introduces `Event#from_json` which takes as argument a json string and returns a new `Event` object. The idea here is to update the json_lines codec to use this method to avoid double type conversion by first parsing the json to a Ruby structure then passing that structure to the Java Event and go through unnecessary type conversions. the POC has shown a ~50% performance increase using this. 

Note that this PR adds specs for the input corner cases behaviour of the current deserialization behaviour to make sure `from_json` behaves the same way.