### PR TITLE
Clone metadata when Event#clone is called

### DIFF
--- a/logstash-core-event/lib/logstash/event.rb
+++ b/logstash-core-event/lib/logstash/event.rb
@@ -93,19 +93,8 @@ class LogStash::Event
 
   # Create a deep-ish copy of this event.
   def clone
-    copy = {}
-    @data.each do |k,v|
-      # TODO(sissel): Recurse if this is a hash/array?
-      copy[k] = begin v.clone rescue v end
-    end
-
-    cloned = self.class.new(copy)
-
-    # Clone metadata too
-    @metadata.each do |k,v|
-      cloned["@metadata"][k] = begin v.clone rescue v end
-    end
-    cloned
+    copy = LogStash::Util.deep_clone(@data)
+    self.class.new(copy.merge({ "@metadata" => LogStash::Util.deep_clone(@metadata.clone) }))
   end
 
   def to_s

--- a/logstash-core-event/lib/logstash/event.rb
+++ b/logstash-core-event/lib/logstash/event.rb
@@ -99,7 +99,13 @@ class LogStash::Event
       copy[k] = begin v.clone rescue v end
     end
 
-    self.class.new(copy)
+    cloned = self.class.new(copy)
+
+    # Clone metadata too
+    @metadata.each do |k,v|
+      cloned["@metadata"][k] = begin v.clone rescue v end
+    end
+    cloned
   end
 
   def to_s

--- a/logstash-core-event/spec/logstash/event_spec.rb
+++ b/logstash-core-event/spec/logstash/event_spec.rb
@@ -669,7 +669,7 @@ describe LogStash::Event do
     it "should clone metadata fields with multiple keys" do
       cloned = event5.clone
       expect(cloned.get(fieldref)).to eq("pants")
-      expect(cloned.get("[@metadata][smarty]").to eq("pants2")
+      expect(cloned.get("[@metadata][smarty]")).to eq("pants2")
       expect(cloned.to_hash_with_metadata).to include("@metadata")
     end
   end

--- a/logstash-core-event/spec/logstash/event_spec.rb
+++ b/logstash-core-event/spec/logstash/event_spec.rb
@@ -630,5 +630,48 @@ describe LogStash::Event do
       expect(event.get("[a][0][b]")).to eq(98)
     end
   end
+
+  describe "#clone" do
+    let(:fieldref) { "[@metadata][fancy]" }
+    let(:event1) { LogStash::Event.new("hello" => "world", "@metadata" => { "fancy" => "pants" }) }
+    let(:event2) { LogStash::Event.new("hello" => "world", "@metadata" => { "fancy" => {"fancy2" => "pants2"} }) }
+    let(:event3) { LogStash::Event.new("hello" => "world", "@metadata" => { "fancy" => {"fancy2" => {"fancy3" => "pants2"}} }) }
+    let(:event4) { LogStash::Event.new("hello" => "world", "@metadata" => { "fancy" => {"fancy2" => ["pants1", "pants2"]} }) }
+    let(:event5) { LogStash::Event.new("hello" => "world", "@metadata" => { "fancy" => "pants", "smarty" => "pants2" }) }
+
+    it "should clone metadata fields" do
+      cloned = event1.clone
+      expect(cloned[fieldref]).to eq("pants")
+      expect(cloned.to_hash_with_metadata).to include("@metadata")
+    end
+
+    it "should clone metadata fields with nested json" do
+      cloned = event2.clone
+      expect(cloned[fieldref]).to eq({"fancy2" => "pants2"})
+      expect(cloned["hello"]).to eq("world")
+      expect(cloned.to_hash).not_to include("@metadata")
+      expect(cloned.to_hash_with_metadata).to include("@metadata")
+    end
+
+    it "should clone metadata fields with 2-level nested json" do
+      cloned = event3.clone
+      expect(cloned[fieldref]).to eq({"fancy2" => {"fancy3" => "pants2"}})
+      expect(cloned.to_hash).not_to include("@metadata")
+      expect(cloned.to_hash_with_metadata).to include("@metadata")
+    end
+
+    it "should clone metadata fields with nested json and array value" do
+      cloned = event4.clone
+      expect(cloned[fieldref]).to eq({"fancy2" => ["pants1", "pants2"]})
+      expect(cloned.to_hash_with_metadata).to include("@metadata")
+    end
+
+    it "should clone metadata fields with multiple keys" do
+      cloned = event5.clone
+      expect(cloned[fieldref]).to eq("pants")
+      expect(cloned["[@metadata][smarty]"]).to eq("pants2")
+      expect(cloned.to_hash_with_metadata).to include("@metadata")
+    end
+  end
 end
 

--- a/logstash-core-event/spec/logstash/event_spec.rb
+++ b/logstash-core-event/spec/logstash/event_spec.rb
@@ -641,35 +641,35 @@ describe LogStash::Event do
 
     it "should clone metadata fields" do
       cloned = event1.clone
-      expect(cloned[fieldref]).to eq("pants")
+      expect(cloned.get(fieldref)).to eq("pants")
       expect(cloned.to_hash_with_metadata).to include("@metadata")
     end
 
     it "should clone metadata fields with nested json" do
       cloned = event2.clone
-      expect(cloned[fieldref]).to eq({"fancy2" => "pants2"})
-      expect(cloned["hello"]).to eq("world")
+      expect(cloned.get(fieldref)).to eq({"fancy2" => "pants2"})
+      expect(cloned.get("hello")).to eq("world")
       expect(cloned.to_hash).not_to include("@metadata")
       expect(cloned.to_hash_with_metadata).to include("@metadata")
     end
 
     it "should clone metadata fields with 2-level nested json" do
       cloned = event3.clone
-      expect(cloned[fieldref]).to eq({"fancy2" => {"fancy3" => "pants2"}})
+      expect(cloned.get(fieldref)).to eq({"fancy2" => {"fancy3" => "pants2"}})
       expect(cloned.to_hash).not_to include("@metadata")
       expect(cloned.to_hash_with_metadata).to include("@metadata")
     end
 
     it "should clone metadata fields with nested json and array value" do
       cloned = event4.clone
-      expect(cloned[fieldref]).to eq({"fancy2" => ["pants1", "pants2"]})
+      expect(cloned.get(fieldref)).to eq({"fancy2" => ["pants1", "pants2"]})
       expect(cloned.to_hash_with_metadata).to include("@metadata")
     end
 
     it "should clone metadata fields with multiple keys" do
       cloned = event5.clone
-      expect(cloned[fieldref]).to eq("pants")
-      expect(cloned["[@metadata][smarty]"]).to eq("pants2")
+      expect(cloned.get(fieldref)).to eq("pants")
+      expect(cloned.get("[@metadata][smarty]").to eq("pants2")
       expect(cloned.to_hash_with_metadata).to include("@metadata")
     end
   end


### PR DESCRIPTION
This partially fixes #4640, only for Ruby implementation. We need to
make a similar change to Java implementation