### PR TITLE
support live reloading of multiple pipelines

### DIFF
--- a/logstash-core/lib/logstash/config/defaults.rb
+++ b/logstash-core/lib/logstash/config/defaults.rb
@@ -6,6 +6,14 @@ module LogStash module Config module Defaults
 
   extend self
 
+  def input
+    "input { stdin { type => stdin } }"
+  end
+
+  def output
+    "output { stdout { codec => rubydebug } }"
+  end
+
   def cpu_cores
     Concurrent.processor_count
   end

--- a/logstash-core/lib/logstash/config/loader.rb
+++ b/logstash-core/lib/logstash/config/loader.rb
@@ -1,0 +1,90 @@
+require "logstash/config/defaults"
+
+module LogStash; module Config; class Loader
+  def initialize(logger)
+    @logger = logger
+  end
+
+  def format_config(config_path, config_string)
+    config_string = config_string.to_s
+    if config_path
+      # Append the config string.
+      # This allows users to provide both -f and -e flags. The combination
+      # is rare, but useful for debugging.
+      config_string = config_string + load_config(config_path)
+    else
+      # include a default stdin input if no inputs given
+      if config_string !~ /input *{/
+        config_string += LogStash::Config::Defaults.input
+      end
+      # include a default stdout output if no outputs given
+      if config_string !~ /output *{/
+        config_string += LogStash::Config::Defaults.output
+      end
+    end
+    config_string
+  end
+
+  def load_config(path)
+    begin
+      uri = URI.parse(path)
+
+      case uri.scheme
+      when nil then
+        local_config(path)
+      when /http/ then
+        fetch_config(uri)
+      when "file" then
+        local_config(uri.path)
+      else
+        fail(I18n.t("logstash.runner.configuration.scheme-not-supported", :path => path))
+      end
+    rescue URI::InvalidURIError
+      # fallback for windows.
+      # if the parsing of the file failed we assume we can reach it locally.
+      # some relative path on windows arent parsed correctly (.\logstash.conf)
+      local_config(path)
+    end
+  end
+
+  def local_config(path)
+    path = ::File.expand_path(path)
+    path = ::File.join(path, "*") if ::File.directory?(path)
+
+    if Dir.glob(path).length == 0
+      fail(I18n.t("logstash.runner.configuration.file-not-found", :path => path))
+    end
+
+    config = ""
+    encoding_issue_files = []
+    Dir.glob(path).sort.each do |file|
+      next unless ::File.file?(file)
+      if file.match(/~$/)
+        @logger.debug("NOT reading config file because it is a temp file", :config_file => file)
+        next
+      end
+      @logger.debug("Reading config file", :config_file => file)
+      cfg = ::File.read(file)
+      if !cfg.ascii_only? && !cfg.valid_encoding?
+        encoding_issue_files << file
+      end
+      config << cfg + "\n"
+      @logger.debug? && @logger.debug("\nThe following is the content of a file", :config_file => file.to_s)
+      @logger.debug? && @logger.debug("\n" + cfg + "\n\n")
+    end
+    if encoding_issue_files.any?
+      fail("The following config files contains non-ascii characters but are not UTF-8 encoded #{encoding_issue_files}")
+    end
+    @logger.debug? && @logger.debug("\nThe following is the merged configuration")
+    @logger.debug? && @logger.debug("\n" + config + "\n\n")
+    return config
+  end # def load_config
+
+  def fetch_config(uri)
+    begin
+      Net::HTTP.get(uri) + "\n"
+    rescue Exception => e
+      fail(I18n.t("logstash.runner.configuration.fetch-failed", :path => uri.to_s, :message => e.message))
+    end
+  end
+end end end

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -9,11 +9,15 @@ LogStash::Environment.load_locale!
 
 require "logstash/namespace"
 require "logstash/program"
+require "logstash/config/defaults"
 
 class LogStash::Runner
   include LogStash::Program
 
+  attr_reader :agent
+
   def main(args)
+
     require "logstash/util"
     require "logstash/util/java_version"
     require "stud/trap"
@@ -121,4 +125,5 @@ Available commands:
   def show_help(command)
     puts command.help
   end
+
 end # class LogStash::Runner

--- a/logstash-core/lib/logstash/shutdown_watcher.rb
+++ b/logstash-core/lib/logstash/shutdown_watcher.rb
@@ -34,8 +34,8 @@ module LogStash
     end
 
     def self.start(pipeline, cycle_period=CHECK_EVERY, report_every=REPORT_EVERY, abort_threshold=ABORT_AFTER)
-      watcher = self.new(pipeline, cycle_period, report_every, abort_threshold)
-      Thread.new(watcher) { |watcher| watcher.start }
+      controller = self.new(pipeline, cycle_period, report_every, abort_threshold)
+      Thread.new(controller) { |controller| controller.start }
     end
 
     def logger
@@ -47,6 +47,7 @@ module LogStash
       cycle_number = 0
       stalled_count = 0
       Stud.interval(@cycle_period) do
+        break unless @pipeline.thread.alive?
         @reports << pipeline_report_snapshot
         @reports.delete_at(0) if @reports.size > @report_every # expire old report
         if cycle_number == (@report_every - 1) # it's report time!

--- a/logstash-core/lib/logstash/special_agent.rb
+++ b/logstash-core/lib/logstash/special_agent.rb
@@ -1,0 +1,8 @@
+# encoding: utf-8
+require "logstash/agent"
+
+class LogStash::SpecialAgent < LogStash::Agent
+  def fetch_config(settings)
+    Net::HTTP.get(settings["remote.url"])
+  end
+end

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -59,12 +59,14 @@ en:
       missing-configuration: >-
         No configuration file was specified. Perhaps you forgot to provide
         the '-f yourlogstash.conf' flag?
+      reload-without-config-path: >-
+        Configuration reloading also requires passing a configuration path with '-f yourlogstash.conf'
       error: >-
         Error: %{error}
       sigint: >-
-        SIGINT received. Shutting down the pipeline.
+        SIGINT received. Shutting down the agent.
       sigterm: >-
-        SIGTERM received. Shutting down the pipeline.
+        SIGTERM received. Shutting down the agent.
       slow_shutdown: |-
         Received shutdown signal, but pipeline is still waiting for in-flight events
         to be processed. Sending another ^C will force quit Logstash, but this may cause
@@ -163,6 +165,10 @@ en:
         pipeline-batch-delay: |+
           When creating pipeline batches, how long to wait while polling
           for the next event.
+        auto_reload: |+
+          Monitor configuration changes and reload
+          whenever it is changed.
+          NOTE: use SIGHUP to manually reload the config
         log: |+
           Write logstash internal logs to the given
           file. Without this flag, logstash will emit

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -1,37 +1,165 @@
 # encoding: utf-8
 require 'spec_helper'
+require 'stud/temporary'
+require 'stud/task'
 
 describe LogStash::Agent do
-  subject { LogStash::Agent.new('') }
-  let(:dummy_config) { 'input {}' }
 
-  context "when loading the configuration" do
-    context "when local" do
-      before { expect(subject).to receive(:local_config).with(path) }
+  let(:logger) { double("logger") }
+  let(:agent_args) { [] }
+  subject { LogStash::Agent.new("", "") }
 
-      context "unix" do
-        let(:path) { './test.conf' }
-        it 'works with relative path' do
-          subject.load_config(path)
-        end
+  before :each do
+    [:log, :info, :warn, :error, :fatal, :debug].each do |level|
+      allow(logger).to receive(level)
+    end
+    [:info?, :warn?, :error?, :fatal?, :debug?].each do |level|
+      allow(logger).to receive(level)
+    end
+    allow(logger).to receive(:level=)
+    allow(logger).to receive(:subscribe)
+    subject.parse(agent_args)
+    subject.instance_variable_set("@reload_interval", 0.01)
+    subject.instance_variable_set("@logger", logger)
+  end
+
+  describe "register_pipeline" do
+    let(:pipeline_id) { "main" }
+    let(:settings) { {
+      :config_string => "input { } filter { } output { }",
+      :pipeline_workers => 4
+    } }
+
+    it "should delegate settings to new pipeline" do
+      expect(LogStash::Pipeline).to receive(:new).with(settings[:config_string], hash_including(settings))
+      subject.register_pipeline(pipeline_id, settings)
+    end
+  end
+
+  describe "#execute" do
+    let(:sample_config) { "input { generator { count => 100000 } } output { }" }
+    let(:config_file) { Stud::Temporary.pathname }
+
+    before :each do
+      File.open(config_file, "w") {|f| f.puts sample_config }
+    end
+
+    after :each do
+      File.unlink(config_file)
+    end
+
+    context "when auto_reload is false" do
+      let(:agent_args) { [ "--config", config_file] } #reload_interval => 0.01, :config_path => } }
+
+      before :each do
+        allow(subject).to receive(:sleep)
+        allow(subject).to receive(:clean_state?).and_return(false)
+        allow(subject).to receive(:running_pipelines?).and_return(true)
       end
 
-      context "windows" do
-        let(:path) { '.\test.conf' }
-        it 'work with relative windows path' do
-          subject.load_config(path)
+      context "if state is clean" do
+        it "should not reload_state!" do
+          expect(subject).to_not receive(:reload_state!)
+          t = Thread.new { subject.execute }
+          sleep 0.1
+          Stud.stop!(t)
+          t.join
         end
       end
     end
 
-    context "when remote" do
-      context 'supported scheme' do
-        let(:path) { "http://test.local/superconfig.conf" }
-
-        before { expect(Net::HTTP).to receive(:get) { dummy_config } }
-        it 'works with http' do
-          expect(subject.load_config(path)).to eq("#{dummy_config}\n")
+    context "when auto_reload is true" do
+      let(:agent_args) { [ "--auto-reload", "--config", config_file] } #reload_interval => 0.01, :config_path => } }
+      #let(:agent_args) { { :logger => logger, :auto_reload => false, :reload_interval => 0.01, :config_path => config_file } }
+      context "if state is clean" do
+        it "should periodically reload_state" do
+          allow(subject).to receive(:clean_state?).and_return(false)
+          expect(subject).to receive(:reload_state!).at_least(3).times
+          t = Thread.new { subject.execute }
+          sleep 0.1
+          Stud.stop!(t)
+          t.join
         end
+      end
+    end
+  end
+
+  describe "#reload_state!" do
+    let(:pipeline_id) { "main" }
+    let(:first_pipeline_config) { "input { } filter { } output { }" }
+    let(:second_pipeline_config) { "input { generator {} } filter { } output { }" }
+    let(:pipeline_settings) { {
+      :config_string => first_pipeline_config,
+      :pipeline_workers => 4
+    } }
+
+    before(:each) do
+      subject.register_pipeline(pipeline_id, pipeline_settings)
+    end
+
+    context "when fetching a new state" do
+      it "upgrades the state" do
+        expect(subject).to receive(:fetch_config).and_return(second_pipeline_config)
+        expect(subject).to receive(:upgrade_pipeline).with(pipeline_id, kind_of(LogStash::Pipeline))
+        subject.send(:reload_state!)
+      end
+    end
+    context "when fetching the same state" do
+      it "doesn't upgrade the state" do
+        expect(subject).to receive(:fetch_config).and_return(first_pipeline_config)
+        expect(subject).to_not receive(:upgrade_pipeline)
+        subject.send(:reload_state!)
+      end
+    end
+  end
+
+  describe "#upgrade_pipeline" do
+    let(:pipeline_id) { "main" }
+    let(:pipeline_config) { "input { } filter { } output { }" }
+    let(:pipeline_settings) { {
+      :config_string => pipeline_config,
+      :pipeline_workers => 4
+    } }
+    let(:new_pipeline_config) { "input { generator {} } output { }" }
+
+    before(:each) do
+      subject.register_pipeline(pipeline_id, pipeline_settings)
+    end
+
+    context "when the upgrade fails" do
+      before :each do
+        allow(subject).to receive(:fetch_config).and_return(new_pipeline_config)
+        allow(subject).to receive(:create_pipeline).and_return(nil)
+        allow(subject).to receive(:stop_pipeline)
+      end
+
+      it "leaves the state untouched" do
+        subject.send(:reload_state!)
+        expect(subject.pipelines[pipeline_id].config_str).to eq(pipeline_config)
+      end
+
+      context "and current state is empty" do
+        it "should not start a pipeline" do
+          expect(subject).to_not receive(:start_pipeline)
+          subject.send(:reload_state!)
+        end
+      end
+    end
+
+    context "when the upgrade succeeds" do
+      let(:new_config) { "input { generator { count => 1 } } output { }" }
+      before :each do
+        allow(subject).to receive(:fetch_config).and_return(new_config)
+        allow(subject).to receive(:stop_pipeline)
+      end
+      it "updates the state" do
+        subject.send(:reload_state!)
+        expect(subject.pipelines[pipeline_id].config_str).to eq(new_config)
+      end
+      it "starts the pipeline" do
+        expect(subject).to receive(:stop_pipeline)
+        expect(subject).to receive(:start_pipeline)
+        subject.send(:reload_state!)
       end
     end
   end
@@ -58,5 +186,67 @@ describe LogStash::Agent do
       subject.configure_plugin_paths(multiple_paths)
     end
   end
+
+  describe "#fetch_config" do
+    let(:file_config) { "input { generator { count => 100 } } output { }" }
+    let(:cli_config) { "filter { drop { } } " }
+    let(:tmp_config_path) { Stud::Temporary.pathname }
+    let(:agent_args) { [ "-e", "filter { drop { } } ", "-f", tmp_config_path ] }
+
+    before :each do
+      IO.write(tmp_config_path, file_config)
+    end
+
+    after :each do
+      File.unlink(tmp_config_path)
+    end
+
+    it "should join the config string and config path content" do
+      settings = { :config_path => tmp_config_path, :config_string => cli_config }
+      fetched_config = subject.send(:fetch_config, settings)
+      expect(fetched_config.strip).to eq(cli_config + IO.read(tmp_config_path))
+    end
+  end
+
+  context "--pluginpath" do
+    let(:single_path) { "/some/path" }
+    let(:multiple_paths) { ["/some/path1", "/some/path2"] }
+
+    it "should fail with single invalid dir path" do
+      expect(File).to receive(:directory?).and_return(false)
+      expect(LogStash::Environment).not_to receive(:add_plugin_path)
+      expect{subject.configure_plugin_paths(single_path)}.to raise_error(LogStash::ConfigurationError)
+    end
+  end
+
+  describe "pipeline settings" do
+    let(:pipeline_string) { "input { stdin {} } output { stdout {} }" }
+    let(:main_pipeline_settings) { { :pipeline_id => "main" } }
+    let(:pipeline) { double("pipeline") }
+
+    before(:each) do
+      task = Stud::Task.new { 1 }
+      allow(pipeline).to receive(:run).and_return(task)
+      allow(pipeline).to receive(:shutdown)
+    end
+
+    context "when :pipeline_workers is not defined by the user" do
+      it "should not pass the value to the pipeline" do
+        expect(LogStash::Pipeline).to receive(:new).once.with(pipeline_string, hash_excluding(:pipeline_workers)).and_return(pipeline)
+        args = ["-e", pipeline_string]
+        subject.run(args)
+      end
+    end
+
+    context "when :pipeline_workers is defined by the user" do
+      it "should pass the value to the pipeline" do
+        main_pipeline_settings[:pipeline_workers] = 2
+        expect(LogStash::Pipeline).to receive(:new).with(pipeline_string, hash_including(main_pipeline_settings)).and_return(pipeline)
+        args = ["-w", "2", "-e", pipeline_string]
+        subject.run(args)
+      end
+    end
+  end
+
 end
 

--- a/logstash-core/spec/logstash/config/loader_spec.rb
+++ b/logstash-core/spec/logstash/config/loader_spec.rb
@@ -1,0 +1,36 @@
+# encoding: utf-8
+require "spec_helper"
+require "logstash/config/loader"
+
+describe LogStash::Config::Loader do
+  subject { described_class.new(Cabin::Channel.get) }
+  context "when local" do
+    before { expect(subject).to receive(:local_config).with(path) }
+
+    context "unix" do
+      let(:path) { './test.conf' }
+      it 'works with relative path' do
+        subject.load_config(path)
+      end
+    end
+
+    context "windows" do
+      let(:path) { '.\test.conf' }
+      it 'work with relative windows path' do
+        subject.load_config(path)
+      end
+    end
+  end
+
+  context "when remote" do
+    context 'supported scheme' do
+      let(:path) { "http://test.local/superconfig.conf" }
+      let(:dummy_config) { 'input {}' }
+
+      before { expect(Net::HTTP).to receive(:get) { dummy_config } }
+      it 'works with http' do
+        expect(subject.load_config(path)).to eq("#{dummy_config}\n")
+      end
+    end
+  end
+end

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -10,6 +10,13 @@ end
 
 describe LogStash::Runner do
 
+  let(:channel) { Cabin::Channel.new }
+
+  before :each do
+    allow(Cabin::Channel).to receive(:get).with(LogStash).and_return(channel)
+  end
+
+
   context "argument parsing" do
     it "should run agent" do
       expect(Stud::Task).to receive(:new).once.and_return(nil)
@@ -38,31 +45,15 @@ describe LogStash::Runner do
     end
   end
 
-  describe "pipeline settings" do
-    let(:pipeline_string) { "input { stdin {} } output { stdout {} }" }
-    let(:base_pipeline_settings) { { :pipeline_id => "base" } }
-    let(:pipeline) { double("pipeline") }
+  context "--auto-reload" do
+    context "when -f is not given" do
 
-    before(:each) do
-      task = Stud::Task.new { 1 }
-      allow(pipeline).to receive(:run).and_return(task)
-    end
+      let(:args) { ["agent", "-r", "-e", "input {} output {}"] }
 
-    context "when pipeline workers is not defined by the user" do
-      it "should not pass the value to the pipeline" do
-        expect(LogStash::Pipeline).to receive(:new).with(pipeline_string, base_pipeline_settings).and_return(pipeline)
-        args = ["agent", "-e", pipeline_string]
-        subject.run(args).wait
-      end
-    end
-
-    context "when pipeline workers is defined by the user" do
-      it "should pass the value to the pipeline" do
-        base_pipeline_settings[:pipeline_workers] = 2
-        expect(LogStash::Pipeline).to receive(:new).with(pipeline_string, base_pipeline_settings).and_return(pipeline)
-        args = ["agent", "-w", "2", "-e", pipeline_string]
-        subject.run(args).wait
+      it "should exit immediately" do
+        expect(subject.run(args).wait).to eq(1)
       end
     end
   end
+
 end

--- a/logstash-core/spec/logstash/shutdown_watcher_spec.rb
+++ b/logstash-core/spec/logstash/shutdown_watcher_spec.rb
@@ -17,6 +17,7 @@ describe LogStash::ShutdownWatcher do
     LogStash::ShutdownWatcher.logger = channel
 
     allow(pipeline).to receive(:reporter).and_return(reporter)
+    allow(pipeline).to receive(:thread).and_return(Thread.current)
     allow(reporter).to receive(:snapshot).and_return(reporter_snapshot)
     allow(reporter_snapshot).to receive(:o_simple_hash).and_return({})
 


### PR DESCRIPTION
NOTE: this is a backport from master (pr #4520)

* reload config from files
* add reload config flag and allow reload through sighup
* move signal handling to runner
* add "-r" flag to detect changes in config and reload
* make SIGHUP reload config file
* make agent execute either loop to detect changes or sleep forever
* sigint/sigterm shut down the agent.execute task
* stop agent if pipeline terminates
* Better shutdown logic for controller and pipeline
* support multiple pipeline reloading and other cleanups
* serialize upgrade_state and running_pipelines?
* remove useless @thread from pipeline
* remove agent registry and cleanup
* reduce reload_interval from 5 to 3
* remove useless MissingAgentError class
* fix exit codes for reload_state failures
* explain why thread var exists in agent.rb
* properly pass backtrace exceptions to oops
* remove is_config_test from loader
* better documentation on agent/runner/pipeline methods