### PR TITLE
Set of small fixes proposed with merge to master review

### DIFF
--- a/logstash-core/lib/logstash/api/lib/app.rb
+++ b/logstash-core/lib/logstash/api/lib/app.rb
@@ -27,7 +27,9 @@ module LogStash::Api
 
     not_found do
       status 404
-      respond_with({})
+      as   = params.has_key?("human") ? :string : :json
+      text = as == :string ? "" : {}
+      respond_with(text, :as => as)
     end
 
     error do

--- a/logstash-core/lib/logstash/api/lib/app.rb
+++ b/logstash-core/lib/logstash/api/lib/app.rb
@@ -25,6 +25,11 @@ module LogStash::Api
       @factory = CommandFactory.new(settings.service)
     end
 
+    not_found do
+      status 404
+      respond_with({})
+    end
+
     error do
       logger.error(env['sinatra.error'].message, :url => request.url, :ip => request.ip, :params => request.params)
     end

--- a/logstash-core/lib/logstash/api/lib/app/commands/stats/hotthreads_command.rb
+++ b/logstash-core/lib/logstash/api/lib/app/commands/stats/hotthreads_command.rb
@@ -18,7 +18,7 @@ class LogStash::Api::HotThreadsCommand < LogStash::Api::Command
   class ThreadDump
 
     SKIPPED_THREADS             = [ "Finalizer", "Reference Handler", "Signal Dispatcher" ].freeze
-    THREADS_COUNT_DEFAULT       = 10.freeze
+    THREADS_COUNT_DEFAULT       = 3.freeze
     IGNORE_IDLE_THREADS_DEFAULT = true.freeze
 
     attr_reader :top_count, :ignore, :dump
@@ -50,6 +50,7 @@ class LogStash::Api::HotThreadsCommand < LogStash::Api::Command
     def to_hash
       hash = { :hostname => hostname, :time => Time.now.iso8601, :busiest_threads => top_count, :threads => [] }
       each do |thread_name, _hash|
+        next if @ignore && _hash["thread.state"].include?("waiting")
         thread_name, thread_path = _hash["thread.name"].split(": ")
         thread = { :name => thread_name,
                    :percent_of_cpu_time => cpu_time_as_percent(_hash),

--- a/logstash-core/lib/logstash/api/lib/app/commands/system/basicinfo_command.rb
+++ b/logstash-core/lib/logstash/api/lib/app/commands/system/basicinfo_command.rb
@@ -8,7 +8,7 @@ class LogStash::Api::SystemBasicInfoCommand < LogStash::Api::Command
     {
       "hostname" => hostname,
       "version" => {
-        "number" => LOGSTASH_VERSION,
+        "number" => LOGSTASH_VERSION
       }
     }
   end

--- a/logstash-core/lib/logstash/api/lib/app/commands/system/basicinfo_command.rb
+++ b/logstash-core/lib/logstash/api/lib/app/commands/system/basicinfo_command.rb
@@ -8,7 +8,7 @@ class LogStash::Api::SystemBasicInfoCommand < LogStash::Api::Command
     {
       "hostname" => hostname,
       "version" => {
-        "number" => LOGSTASH_VERSION
+        "number" => LOGSTASH_VERSION,
       }
     }
   end

--- a/logstash-core/lib/logstash/api/lib/app/modules/node.rb
+++ b/logstash-core/lib/logstash/api/lib/app/modules/node.rb
@@ -14,6 +14,8 @@ module LogStash::Api
         :ignore_idle_threads => as_boolean(ignore_idle_threads),
         :human => params.has_key?("human")
       }
+      options[:threads] = params["threads"].to_i if params.has_key?("threads")
+
       command = factory.build(:hot_threads_command)
       as    = options[:human] ? :string : :json
       respond_with(command.run(options), {:as => as})

--- a/logstash-core/lib/logstash/webserver.rb
+++ b/logstash-core/lib/logstash/webserver.rb
@@ -62,7 +62,7 @@ module LogStash
         @runner.stop_blocked
       else
         @runner.stop
-      end rescue ""
+      end rescue nil
 
       @status = :stop
       log "=== puma shutdown: #{Time.now} ==="

--- a/logstash-core/lib/logstash/webserver.rb
+++ b/logstash-core/lib/logstash/webserver.rb
@@ -62,7 +62,8 @@ module LogStash
         @runner.stop_blocked
       else
         @runner.stop
-      end
+      end rescue ""
+
       @status = :stop
       log "=== puma shutdown: #{Time.now} ==="
     end


### PR DESCRIPTION
From https://github.com/elastic/logstash/pull/4653#issuecomment-181961527:

> about idle threads, we are actually ignoring (at my understanding) the idle threads ES id ignoring, do you propose to ignore all waiting threads?
about versions, yeah we can add both's this should not be complicated to archive.
about 404? I agree, we should return empty body with status 404.
thanks a lot for your time.

Basically adds this PR:

* default content for 404 errors
* bring back the threads param to select the number of threads to be shown in the web api.
* default the hot threads number to 3
* Ignore all threads that fall under one of the next criteria, an internal JVM thread, an internal JRuby thread pool thread, or an internal JRuby JIT thread. This will obviously be shown if the right flag is passed.