### PR TITLE
from_json should not generate new Event on blank/empty json input

### DIFF
--- a/logstash-core-event-java/spec/event_spec.rb
+++ b/logstash-core-event-java/spec/event_spec.rb
@@ -247,18 +247,14 @@ describe LogStash::Event do
       expect(event["[bar]"]).to eq("baz")
     end
 
-    it "should consistently handle blank string" do
+    it "should ignore blank strings" do
       blank_strings.each do |s|
-        t = LogStash::Timestamp.new
-        expect(LogStash::Event.from_json(s).size).to eq(1)
-
-        event1 = LogStash::Event.from_json(s)[0]
-        event2 = LogStash::Event.new(LogStash::Json.load(s))
-        event1.timestamp = t
-        event2.timestamp = t
-
-        expect(event1.to_hash).to eq(event2.to_hash)
+        expect(LogStash::Event.from_json(s).size).to eq(0)
       end
+    end
+
+    it "should raise TypeError on nil string" do
+      expect{LogStash::Event.from_json(nil)}.to raise_error TypeError
     end
 
     it "should consistently handle nil" do

--- a/logstash-core-event-java/src/main/java/com/logstash/Event.java
+++ b/logstash-core-event-java/src/main/java/com/logstash/Event.java
@@ -162,12 +162,12 @@ public class Event implements Cloneable, Serializable {
     public static Event[] fromJson(String json)
             throws IOException
     {
-        Event[] result;
-
+        // empty/blank json string does not generate an event
         if (json == null || json.trim().isEmpty()) {
-            return new Event[]{ new Event() };
+            return new Event[]{ };
         }
 
+        Event[] result;
         Object o = mapper.readValue(json, Object.class);
         // we currently only support Map or Array json objects
         if (o instanceof Map) {
@@ -184,6 +184,7 @@ public class Event implements Cloneable, Serializable {
         } else {
             throw new IOException("incompatible json object type=" + o.getClass().getName() + " , only hash map or arrays are suppoted");
         }
+
         return result;
     }
 

--- a/logstash-core-event-java/src/test/java/com/logstash/EventTest.java
+++ b/logstash-core-event-java/src/test/java/com/logstash/EventTest.java
@@ -121,32 +121,20 @@ public class EventTest {
 
     @Test
     public void testFromJsonWithNull() throws Exception {
-        Map data1 = Event.fromJson(null)[0].toMap();
-        data1.remove("@timestamp");
-        Map data2 = new Event().toMap();
-        data2.remove("@timestamp");
-
-        assertEquals(data1, data2);
+        Event[] events = Event.fromJson(null);
+        assertEquals(0, events.length);
     }
 
     @Test
     public void testFromJsonWithEmptyString() throws Exception {
-        Map data1 = Event.fromJson("")[0].toMap();
-        data1.remove("@timestamp");
-        Map data2 = new Event().toMap();
-        data2.remove("@timestamp");
-
-        assertEquals(data1, data2);
+        Event[] events = Event.fromJson("");
+        assertEquals(0, events.length);
     }
 
     @Test
     public void testFromJsonWithBlankString() throws Exception {
-        Map data1 = Event.fromJson("   ")[0].toMap();
-        data1.remove("@timestamp");
-        Map data2 = new Event().toMap();
-        data2.remove("@timestamp");
-
-        assertEquals(data1, data2);
+        Event[] events = Event.fromJson("   ");
+        assertEquals(0, events.length);
     }
 
     @Test


### PR DESCRIPTION
`Event#from_json` was previously generating empty `Event` on blank/empty json input but it should just ignore it and not generate empty event.

This complements logstash-plugins/logstash-codec-json_lines/pull/22