### PR TITLE
Add ignore_older option and related tip.

### DIFF
--- a/docs/static/advanced-pipeline.asciidoc
+++ b/docs/static/advanced-pipeline.asciidoc
@@ -59,6 +59,7 @@ input {
     file {
         path => "/path/to/logstash-tutorial.log"
         start_position => beginning <1>
+        ignore_older => 0 <2>
     }
 }
 --------------------------------------------------------------------------------
@@ -66,6 +67,7 @@ input {
 <1> The default behavior of the file input plugin is to monitor a file for new information, in a manner similar to the
 UNIX `tail -f` command. To change this default behavior and process the entire file, we need to specify the position
 where Logstash starts processing the file.
+<2> The default behavior of the file input plugin is to ignore files whose last modification is greater than 86400s. To change this default behavior and process the tutorial file (which date can be much older than a day), we need to specify to not ignore old files.
 
 Replace `/path/to/` with the actual path to the location of `logstash-tutorial.log` in your file system.
 


### PR DESCRIPTION
Add option to handle example file even if it is older than 86400s.