### PR TITLE
Fix oops backtrace logging

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -86,7 +86,7 @@ class LogStash::Agent
         begin
           reload_pipeline!(pipeline_id)
         rescue => e
-          @logger.error I18n.t("oops", :error => e, :backtrace => e.backtrace)
+          @logger.error(I18n.t("oops"), :message => e.message, :class => e.class.name, :backtrace => e.backtrace)
         end
       end
     end

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -4,8 +4,7 @@
 #     for unformatted text.
 en:
   oops: |-
-    The error reported is: 
-      %{error} %{backtrace}
+    An unexpected error occurred!
   logstash:
     error: >-
       Error: %{error}


### PR DESCRIPTION
'Oops' backtrace logging doesn't seem to actually dump anything useful (it REALLY needs a backtrace given that it only happens in bizarre circumstances). It also seems that the backtrace isn't properly formatted (see https://github.com/logstash-plugins/logstash-output-rabbitmq/issues/41 ).

At any rate, this should use structured logging.