### PR TITLE
Handling undefined $KILL_ON_STOP_TIMEOUT

### DIFF
--- a/pkg/logstash.sysv
+++ b/pkg/logstash.sysv
@@ -90,7 +90,7 @@ stop() {
     echo "Killing $name (pid $pid) with SIGTERM"
     kill -TERM $pid
     # Wait for it to exit.
-    for i in 1 2 3 4 5 6 7 8 9; do
+    for i in 1 2 3 4 5 6 7 8 9 ; do
       echo "Waiting $name (pid $pid) to die..."
       status || break
       sleep 1

--- a/pkg/logstash.sysv
+++ b/pkg/logstash.sysv
@@ -90,13 +90,13 @@ stop() {
     echo "Killing $name (pid $pid) with SIGTERM"
     kill -TERM $pid
     # Wait for it to exit.
-    for i in 1 2 3 4 5 ; do
+    for i in 1 2 3 4 5 6 7 8 9; do
       echo "Waiting $name (pid $pid) to die..."
       status || break
       sleep 1
     done
     if status ; then
-      if [ "$KILL_ON_STOP_TIMEOUT" -eq 1 ] ; then
+      if [[ $KILL_ON_STOP_TIMEOUT -eq 1 ]] ; then
         echo "Timeout reached. Killing $name (pid $pid) with SIGKILL. This may result in data loss."
         kill -KILL $pid
         echo "$name killed with SIGKILL."


### PR DESCRIPTION
#### What does this PR do?

Adjusts the logstash init script to not crash when the KILL_ON_STOP_TIMEOUT variable is undefined and the process takes too long to shut down. (For example, if the user has modified `/etc/sysconfig/logstash` to not define it for some reason.)

#### What are the relevant links?

- https://github.com/elastic/logstash/issues/4457
- https://github.com/elastic/logstash/blob/master/pkg/logstash.default#L40

#### Deployment/testing instructions?

- Not sure how to test this other than run it yourself. Are there init script tests in this repo?
- Consider adding a bit to the official help docs or these init script messages regarding slow shutdown and the KILL_ON_STOP_TIMEOUT option, to help people like myself and @ydnitin who experience a slowly-shutting-down logstash, hit Google, and come up with nothing.

**Edit:** Signed the CLA