### PR TITLE
Revert #4425

### DIFF
--- a/logstash-core-event/lib/logstash/event.rb
+++ b/logstash-core-event/lib/logstash/event.rb
@@ -16,9 +16,6 @@ require "logstash/string_interpolation"
 class LogStash::ShutdownEvent; end
 class LogStash::FlushEvent; end
 
-# Custom exceptions
-class InvalidOperationException < StandardError; end
-
 module LogStash
   FLUSH = LogStash::FlushEvent.new
 
@@ -182,9 +179,6 @@ class LogStash::Event
 
   # Remove a field or field reference. Returns the value of that field when deleted
   def remove(fieldref)
-    if fieldref == TIMESTAMP || fieldref == "[#{TIMESTAMP}]"
-      raise InvalidOperationException, "The field '@timestamp' must not be removed"
-    end
     @accessors.del(fieldref)
   end
 

--- a/logstash-core-event/spec/logstash/event_spec.rb
+++ b/logstash-core-event/spec/logstash/event_spec.rb
@@ -101,7 +101,7 @@ describe LogStash::Event do
       it "should raise error when formatting %{+%s} when @timestamp field is missing" do
         str = "hello-%{+%s}"
         subj = subject.clone
-        subj.instance_variable_get(:@accessors).del("[@timestamp]")
+        subj.remove("[@timestamp]")
         expect{ subj.sprintf(str) }.to raise_error(LogStash::Error)
       end
 
@@ -118,7 +118,7 @@ describe LogStash::Event do
       it "should raise error with %{+format} syntax when @timestamp field is missing", :if => RUBY_ENGINE == "jruby" do
         str = "logstash-%{+YYYY}"
         subj = subject.clone
-        subj.instance_variable_get(:@accessors).del("[@timestamp]")
+        subj.remove("[@timestamp]")
         expect{ subj.sprintf(str) }.to raise_error(LogStash::Error)
       end
 
@@ -334,16 +334,6 @@ describe LogStash::Event do
         end
       end
 
-      context "remove" do
-        it "should raise an exception if you attempt to remove @timestamp" do
-          expect{subject.remove("@timestamp")}.to raise_error(InvalidOperationException)
-        end
-        it "should not raise an exception if you attempt to remove timestamp" do
-          subject["timestamp"] = 1456933880
-          expect{subject.remove("timestamp")}.not_to raise_error
-          expect(subject["timestamp"]).to be_nil
-        end
-      end
     end
 
     it "timestamp parsing speed", :performance => true do


### PR DESCRIPTION
 #4425 introduced protection against removing `@timestamp` but there
 are a lot of tests that fail now. Reverting until we fix this properly