### PR TITLE
Fix configtest option in init scripts

### DIFF
--- a/pkg/logstash.sysv
+++ b/pkg/logstash.sysv
@@ -142,7 +142,7 @@ configtest() {
   fi
 
   HOME=${LS_HOME}
-  export PATH HOME JAVA_OPTS LS_HEAP_SIZE LS_JAVA_OPTS LS_USE_GC_LOGGING
+  export PATH HOME
 
   test_args="--configtest -f ${LS_CONF_DIR} ${LS_OPTS}"
   $program ${test_args}


### PR DESCRIPTION
No need to export all the `JAVA*` related environment variables
for configtest. It needs a minimal set of variables to execute
`bin/logstash --config-test`. This was indirectly causing issues
when used with JMX options in `LS_JAVA_OPTS`. JMX needs a remote port defined
and `configtest` was trying to connect to the port twice which caused
restart (#4319) to fail

Fixes #4319