### PR TITLE
Fixed an issue with accidental multiple instantiation of plugins

### DIFF
--- a/logstash-core/lib/logstash/output_delegator.rb
+++ b/logstash-core/lib/logstash/output_delegator.rb
@@ -43,6 +43,7 @@ module LogStash class OutputDelegator
     # This queue is used to manage sharing across threads
     @worker_queue = SizedQueue.new(@worker_count)
 
+    # Register additional instances
     @workers += (@worker_count - 1).times.map do
       inst = @klass.new(*args)
       inst.metric = @metric
@@ -109,7 +110,8 @@ module LogStash class OutputDelegator
   end
 
   def register
-    @workers.each {|w| w.register}
+    # All instances should already be registered 
+    # @workers.each {|w| w.register}
   end
 
   def threadsafe_multi_receive(events)


### PR DESCRIPTION
I found this issue while fixing the websocket output plugin. It seems most plugins are accidentally instantiated more times than expected. This happens regardless of how you define your # of workers, if you define "workers_not_supported" or if you use the 2.2+ API with "declare_workers_not_supported".