### PR TITLE
Internal gem cache rebuild and improved experience when doing updates.

### DIFF
--- a/lib/pluginmanager/pack.rb
+++ b/lib/pluginmanager/pack.rb
@@ -11,6 +11,8 @@ class LogStash::PluginManager::Pack < LogStash::PluginManager::PackCommand
     puts("Packaging plugins for offline usage")
 
     validate_target_file
+
+    LogStash::Bundler.rebuild_gem_cache
     LogStash::Bundler.invoke!({:package => true, :all => true})
     archive_manager.compress(LogStash::Environment::CACHE_PATH, target_file)
     FileUtils.rm_rf(LogStash::Environment::CACHE_PATH) if clean?


### PR DESCRIPTION
As we clean up the internal ruby gems cache, but keep the *.gemspec files around, the pack command gets confused expecting to have gem files it really does not have. This causes the usage of offline installation and update to be broken when there is a dependency mismatch.

This situation is raised when the user does, while working with an old version (not necessary too old, but that uses old dependencies), see #4651 for details:
- Run `bin/plugin update [plugin name]`. < could be with more than one plugin, or just one>
- Run `bin/plugin pack`

If for example plugin name depends on A version 1.0, but the new version actually can use a new version, lets say 2.0, the package will contain only 2.0 as is the _current state_ in the LS used to create the bundle. This will cause problems when using this package in a raw LS, there bundler might think it needs 1.0 version.  This might also happen if 2 or more plugins are updated, due to internal cache checkups done in Bundler, see https://github.com/bundler/bundler/blob/master/lib/bundler/cli/update.rb#L53 for more details.

To address this situation I recommend, for now and without disregarding feature improvements, to:
- Create an initial pack before doing the update. Name this file something like `initial_plugin_package.tar.gz`, so there are no override in the feature.
- Update the desired plugins.
- Create a new package, that will include the new plugins.
- Merge the initial and the new package into a single package.

The merged package will include old and new dependencies, making sure _all_ required dependencies are available to the offline environment. Complementary improvements in the document should be made, so this is known. This is useful if you only want to update 1 plugin, but got more updated in your package.

There is also the situation when you know and control which plugins are _new_ in your package for offline installation, then I recommend to use `bin/plugin update --local` as this will make sure bundler does the right internal dependency resolution.

This PR also makes sure errors for missing gems in case of doing an offline install are more clear, like this users could be aware of what is missing inside their `vendor/cache` directories. 

What do you think?

I tried my best to describe the situation here, but please don't hesitate to ask for clarification, I know the process is a bit tricky.

Related #4651
