### PR TITLE
Make sure jvm info in _stats and _node/stats follow the same format

### DIFF
--- a/logstash-core/lib/logstash/api/lib/app/modules/node_stats.rb
+++ b/logstash-core/lib/logstash/api/lib/app/modules/node_stats.rb
@@ -11,12 +11,11 @@ module LogStash::Api
     # retrieved and show
     get "/" do
       events_command = factory.build(:events_command)
-      memory_command = factory.build(:memory_command)
       payload = {
         :events => events_command.run,
-        :start_time_in_millis => events_command.started_at,
-        :jvm => { :memory => memory_command.run }
+        :jvm => jvm_payload
       }
+
       respond_with payload
     end
 
@@ -35,9 +34,18 @@ module LogStash::Api
 
     # return hot threads information
     get "/jvm" do
-      command = factory.build(:memory_command)
-      respond_with({ :memory => command.run })
+      respond_with jvm_payload
     end
 
+    private
+
+    def jvm_payload
+      command = factory.build(:memory_command)
+      {
+        :timestamp => command.started_at,
+        :uptime_in_millis => command.uptime,
+        :mem => command.run
+      }
+    end
   end
 end

--- a/logstash-core/spec/api/lib/api/node_stats_spec.rb
+++ b/logstash-core/spec/api/lib/api/node_stats_spec.rb
@@ -28,6 +28,8 @@ describe LogStash::Api::NodeStats do
 
   it "respond to the jvm resource" do
     expect_any_instance_of(LogStash::Api::JvmMemoryCommand).to receive(:run).and_return(mem)
+    expect_any_instance_of(LogStash::Api::JvmMemoryCommand).to receive(:started_at).and_return(10)
+    expect_any_instance_of(LogStash::Api::JvmMemoryCommand).to receive(:uptime).and_return(100)
     get "jvm"
     expect(last_response).to be_ok
   end


### PR DESCRIPTION
Small PR to improve data consistency change to make sure all jvm info follow the same format in `_stats` or `_node/stats`.

Please don't focus too much on test, this will be improve with #4667, I mean I now they are bad right now :+1:  