### PR TITLE
Revert commit 4f7299a

### DIFF
--- a/logstash-core-event-java/lib/logstash-core-event-java/version.rb
+++ b/logstash-core-event-java/lib/logstash-core-event-java/version.rb
@@ -5,4 +5,4 @@
 # Note to authors: this should not include dashes because 'gem' barfs if
 # you include a dash in the version string.
 
-LOGSTASH_CORE_EVENT_JAVA_VERSION = "5.0.0.dev"
+LOGSTASH_CORE_EVENT_JAVA_VERSION = "3.0.0.dev"

--- a/logstash-core-event/lib/logstash-core-event/version.rb
+++ b/logstash-core-event/lib/logstash-core-event/version.rb
@@ -5,4 +5,4 @@
 # Note to authors: this should not include dashes because 'gem' barfs if
 # you include a dash in the version string.
 
-LOGSTASH_CORE_EVENT_VERSION = "5.0.0.dev"
+LOGSTASH_CORE_EVENT_VERSION = "3.0.0.dev"

--- a/logstash-core/lib/logstash-core/version.rb
+++ b/logstash-core/lib/logstash-core/version.rb
@@ -5,4 +5,4 @@
 # Note to authors: this should not include dashes because 'gem' barfs if
 # you include a dash in the version string.
 
-LOGSTASH_CORE_VERSION = "5.0.0.dev"
+LOGSTASH_CORE_VERSION = "3.0.0.dev"

--- a/logstash-core/lib/logstash/version.rb
+++ b/logstash-core/lib/logstash/version.rb
@@ -11,4 +11,4 @@
 #       eventually this file should be in the root logstash lib fir and dependencies in logstash-core should be
 #       fixed.
 
-LOGSTASH_VERSION = "5.0.0.dev"
+LOGSTASH_VERSION = "3.0.0.dev"


### PR DESCRIPTION
Need to revert bump to 5.0.0.dev because individual plugins
will not install on top of this version.

In plugins' gemspec, the constraint is
`s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 3.0.0"`

This needs to be mass updated, and then bumped to 5.0.0