### PR TITLE
expose reload_interval in Runner

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -82,6 +82,10 @@ class LogStash::Runner < Clamp::Command
     I18n.t("logstash.runner.flag.auto_reload"),
     :attribute_name => :auto_reload, :default => false
 
+  option ["--reload-interval"], "RELOAD_INTERVAL",
+    I18n.t("logstash.runner.flag.reload_interval"),
+    :attribute_name => :reload_interval, :default => 3, &:to_i
+
   option ["--http-host"], "WEB_API_HTTP_HOST",
     I18n.t("logstash.web_api.flag.http_host"),
     :attribute_name => :web_api_http_host, :default => "127.0.0.1"
@@ -176,6 +180,7 @@ class LogStash::Runner < Clamp::Command
 
     @agent = create_agent(:logger => @logger,
                           :auto_reload => @auto_reload,
+                          :reload_interval => @reload_interval,
                           :collect_metric => true,
                           :debug => debug?,
                           :node_name => node_name,

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -186,6 +186,9 @@ en:
           Monitor configuration changes and reload
           whenever it is changed.
           NOTE: use SIGHUP to manually reload the config
+        reload_interval: |+
+          How frequently to poll the configuration location
+          for changes, in seconds.
         log: |+
           Write logstash internal logs to the given
           file. Without this flag, logstash will emit


### PR DESCRIPTION
LogStash::Agent already accepts a :reload_interval param, but it wasn't exposed in the Runner cli args, this PR fixes this problem.