### PR TITLE
Change JIT threads for pool threads in the hot_threads ignore_idle_threads filter

### DIFF
--- a/logstash-core/spec/api/lib/api/node_spec.rb
+++ b/logstash-core/spec/api/lib/api/node_spec.rb
@@ -69,7 +69,7 @@ describe LogStash::Api::Node do
 
       it "should return JIT threads" do
         thread_names = payload["threads"].map { |thread_info| thread_info["name"] }
-        expect(thread_names.grep(/JIT/)).not_to be_empty
+        expect(thread_names.grep(/pool/)).not_to be_empty
       end
     end
 


### PR DESCRIPTION
changes JIT threads for pool threads in the idle threads test, not sure why JIT threads don't show up in some situations, especially on linux machines. But we still need to check for the idle threads filter to work, so this test does it using the other jruby internal threads (skip as idle).

 Related to #4827