### PR TITLE
Clarify basic instructions in getting started guide

### DIFF
--- a/docs/static/getting-started-with-logstash.asciidoc
+++ b/docs/static/getting-started-with-logstash.asciidoc
@@ -44,7 +44,9 @@ bin/logstash -e 'input { stdin { } } output { stdout {} }'
 The `-e` flag enables you to specify a configuration directly from the command line. Specifying configurations at the
 command line lets you quickly test configurations without having to edit a file between iterations.
 This pipeline takes input from the standard input, `stdin`, and moves that input to the standard output, `stdout`, in a
-structured format. Type hello world at the command prompt to see Logstash respond:
+structured format.
+
+Once "Logstash startup completed" is displayed, type hello world at the command prompt to see Logstash respond:
 
 [source,shell]
 hello world


### PR DESCRIPTION
On machines with limited resources (small EC2 instances, for example), Logstash can take a considerable amount of time to start. As a first-time user following the guide, I was unaware of this and opened a bug (https://github.com/elastic/logstash/issues/4826), before realizing I need to wait for the "Logstash startup completed" message.

This clarifies the docs so hopefully no one else encounters this issue and gives up :)