### PR TITLE
Fix doc execution

### DIFF
--- a/docs/asciidocgen.rb
+++ b/docs/asciidocgen.rb
@@ -6,6 +6,7 @@ $: << Dir.pwd
 $: << File.join(File.dirname(__FILE__), "..", "lib")
 $: << File.join(File.dirname(__FILE__), "..", "rakelib")
 
+require_relative "../lib/bootstrap/environment" #needed for LogStash::Environment constants LOGSTASH_HOME
 require "logstash/config/mixin"
 require "logstash/inputs/base"
 require "logstash/codecs/base"
@@ -161,7 +162,7 @@ class LogStashConfigAsciiDocGenerator
     load file
 
     # Get the correct base path
-    base = File.join(::LogStash::Environment::LOGSTASH_HOME,'lib/logstash', file.split("/")[-2])
+    base = File.join(::LogStash::Environment::LOGSTASH_HOME,'logstash-core/lib/logstash', file.split("/")[-2])
 
     # parse base first
     parse(File.new(File.join(base, "base.rb"), "r").read)


### PR DESCRIPTION
Working on https://github.com/logstash-plugins/logstash-filter-date/issues/60 I add to change **docs/asciidocgen.rb** to be able to execute such command `bin/bundle exec ruby docs/asciidocgen.rb -o asciidoc_generated /path/to/filter/source/date.rb`

@suyograo @ph can you please share your final status from abandoned https://github.com/elastic/logstash/pull/4496
Do you want me to include here the plugin-per-plugin execution in the rake task, or was it a bad idea ?