### PR TITLE
include hidden ruby-maven directory in packaging

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -13,6 +13,13 @@ namespace "artifact" do
       "lib/pluginmanager/**/*",
       "patterns/**/*",
       "vendor/??*/**/*",
+      # To include ruby-maven's hidden ".mvn" directory, we need to
+      # do add the line below. This directory contains a file called
+      # "extensions.xml", which loads the ruby DSL for POMs.
+      # Failing to include this file results in updates breaking for
+      # plugins which use jar-dependencies.
+      # See more in https://github.com/elastic/logstash/issues/4818
+      "vendor/??*/**/.mvn/**/*",
       "Gemfile",
       "Gemfile.jruby-1.9.lock",
     ]


### PR DESCRIPTION
ruby-maven ships a hidden directory called .mvn that
needs to be included in the package.
Currently the list of files to be packaged is generated using
Rake::FileList[globs] which excludes hidden files by default
(same happens with Dir.glob).

The fix is to ensure the contents of that directory are included
by explicitly referencing it.

For example, the file "extensions.xml", included in this directory,
is responsible for loading the ruby DSL for POMs. __Not carrying this
file in the logstash package breaks any plugin update that uses
jar-dependencies__, like elasticsearch output

fixes #4818