### PR TITLE
remove node_name cli argument

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -83,10 +83,6 @@ class LogStash::Agent < Clamp::Command
     I18n.t("logstash.agent.flag.reload_interval"),
     :attribute_name => :reload_interval, :default => 3, &:to_i
 
-  option ["-n", "--node-name"], "NAME",
-    I18n.t("logstash.runner.flag.node_name"),
-    :attribute_name => :node_name, :default => Socket.gethostname
-
   def initialize(*params)
     super(*params)
     @logger = Cabin::Channel.get(LogStash)


### PR DESCRIPTION
this argument is not used and was introduced by mistake in
the backport of the automatic configuration reloading

to be merged in 2.x and 2.3

replaces https://github.com/elastic/logstash/pull/4849