### PR TITLE
Remove hot_threads ignore_idle_threads test

### DIFF
--- a/logstash-core/spec/api/lib/api/node_spec.rb
+++ b/logstash-core/spec/api/lib/api/node_spec.rb
@@ -60,19 +60,5 @@ describe LogStash::Api::Node do
       end
     end
 
-    context "when requesting idle threads" do
-
-      before(:all) do
-        do_request { get "/hot_threads?ignore_idle_threads=false&threads=10" }
-      end
-
-      let(:payload) { LogStash::Json.load(last_response.body) }
-
-      it "should return JIT threads" do
-        thread_names = payload["threads"].map { |thread_info| thread_info["name"] }
-        expect(thread_names.grep(/pool/)).not_to be_empty
-      end
-    end
-
   end
 end


### PR DESCRIPTION
In #4833 I changed the `ignore_idle_threads` test from checking the `JIT` threads to check the `pool` threads, but looks like both are having the same randomly MIA behaviour, until we figure it out the right way to test for this threads I do recommend removing them for now.

Related #4852 #4833