### PR TITLE
Create a virtual gem to handler the plugin dependency on core

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "logstash-core", "3.0.0.dev", :path => "./logstash-core"
 # gem "logstash-core-event", "3.0.0.dev", :path => "./logstash-core-event"
 gem "logstash-core-event-java", "3.0.0.dev", :path => "./logstash-core-event-java"
+gem "logstash-core-plugin-api", "1.0.0", :path => "./logstash-core-plugin-api"
 gem "file-dependencies", "0.1.6"
 gem "ci_reporter_rspec", "1.0.0", :group => :development
 gem "simplecov", :group => :development

--- a/logstash-core-plugin-api/lib/logstash-core-plugin-api/version.rb
+++ b/logstash-core-plugin-api/lib/logstash-core-plugin-api/version.rb
@@ -1,0 +1,2 @@
+# encoding: utf-8
+LOGSTASH_CORE_PLUGIN_API = "1.0.0"

--- a/logstash-core-plugin-api/logstash-core-plugin-api.gemspec
+++ b/logstash-core-plugin-api/logstash-core-plugin-api.gemspec
@@ -1,0 +1,29 @@
+# -*- encoding: utf-8 -*-
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "logstash-core-plugin-api/version"
+
+Gem::Specification.new do |gem|
+  gem.authors       = ["Elastic"]
+  gem.email         = ["info@elastic.co"]
+  gem.description   = %q{Logstash plugin API}
+  gem.summary       = %q{Define the plugin API that the plugin need to follow.}
+  gem.homepage      = "http://www.elastic.co/guide/en/logstash/current/index.html"
+  gem.license       = "Apache License (2.0)"
+
+  gem.files         = Dir.glob(["logstash-core-event.gemspec", "lib/**/*.rb", "spec/**/*.rb"])
+  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+  gem.name          = "logstash-core-plugin-api"
+  gem.require_paths = ["lib"]
+  gem.version       = LOGSTASH_CORE_PLUGIN_API
+
+  gem.add_runtime_dependency "logstash-core", ">= 2.0.0", "<= 3.0.0.dev"
+
+  # Make sure we dont build this gem from a non jruby
+  # environment.
+  if RUBY_PLATFORM == "java"
+    gem.platform = "java"
+  else
+    raise "The logstash-core-api need to be build on jruby"
+  end
+end


### PR DESCRIPTION
We have decided to create a gem that the plugins can depend on to make
sure they use the correct core, with that in mind this will reduce the
mass update required when releasing a major release of logstash if the
contract between logstash and the plugin didnt change. The first version
of this gem act as a virtual gem, future release will include the actual
plugins code of the contract.

This gem should follow the same convention as semver, a breaking change
in the api will mean a bump in the major version.  Plugins author are
encouraged to test they plugins with a specific version of the contract
and define their dependency as the following:

```
  s.add_runtime_dependency "logstash-code-plugin-api", "~> 2.0"
```

ref #4829