### PR TITLE
Misleading example in Advance using --pluginpath.

### DIFF
--- a/docs/static/plugin-manager.asciidoc
+++ b/docs/static/plugin-manager.asciidoc
@@ -64,7 +64,7 @@ developers who are iterating on a custom plugin and want to test it before creat
 
 [source,shell]
 ----------------------------------
-bin/logstash --pluginpath /opt/shared/my-custom-plugin/lib/
+bin/logstash --pluginpath /opt/shared/my-custom-plugin/lib
 ----------------------------------
 
 Note: Logstash will install your plugin depending on your file and directory structure. For example the following structure `/opt/shared/my-custom-plugin/lib/logstash/input/new_plugin.rb` will load a plugin called `logstash-input-new_plugin`

--- a/docs/static/plugin-manager.asciidoc
+++ b/docs/static/plugin-manager.asciidoc
@@ -60,12 +60,14 @@ bin/plugin install /path/to/logstash-output-kafka-1.0.0.gem
 ==== Advanced: Using `--pluginpath`
 
 Using the `--pluginpath` flag, you can load a plugin source code located on your file system. Typically this is used by
-developers who are iterating on a custom plugin and want to test it before creating a ruby gem.
+developers who are iterating on a custom plugin and want to test it before creating a ruby gem. The path should be the root directory of the plugin. 
 
 [source,shell]
 ----------------------------------
-bin/logstash --pluginpath /opt/shared/lib/logstash/input/my-custom-plugin-code.rb
+bin/logstash --pluginpath /opt/shared/my-custom-plugin/lib/
 ----------------------------------
+
+Note: Logstash will install your plugin depending on your file and directory structure. For example the following structure `/opt/shared/my-custom-plugin/lib/logstash/input/new_plugin.rb` will load a plugin called `logstash-input-new_plugin`
 
 [[updating-plugins]]
 [float]


### PR DESCRIPTION
The example line indicates you should point to the plugin source code file. Doing this returns: "Error: You specified a plugin path that does not exist: ...".