### PR TITLE
Deprecation of bin/plugin command in 2.x branch releases, also introduction of bin/logstash-plugin

### DIFF
--- a/bin/logstash-plugin
+++ b/bin/logstash-plugin
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+unset CDPATH
+. "$(cd `dirname $0`/..; pwd)/bin/logstash.lib.sh"
+setup
+
+# bin/plugin is a short lived ruby script thus we can use aggressive "faster starting JRuby options"
+# see https://github.com/jruby/jruby/wiki/Improving-startup-time
+export JRUBY_OPTS="$JRUBY_OPTS -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -X-C -Xcompile.invokedynamic=false"
+
+ruby_exec "${LOGSTASH_HOME}/lib/pluginmanager/main.rb" "$@"

--- a/bin/logstash-plugin.bat
+++ b/bin/logstash-plugin.bat
@@ -1,0 +1,15 @@
+@echo off
+
+SETLOCAL
+
+set SCRIPT_DIR=%~dp0
+CALL "%SCRIPT_DIR%\setup.bat"
+
+:EXEC
+if "%VENDORED_JRUBY%" == "" (
+  %RUBYCMD% "%LS_HOME%\lib\pluginmanager\main.rb" %*
+) else (
+  %JRUBY_BIN% %jruby_opts% "%LS_HOME%\lib\pluginmanager\main.rb" %*
+)
+
+ENDLOCAL

--- a/bin/plugin
+++ b/bin/plugin
@@ -1,13 +1,6 @@
 #!/bin/sh
 
-echo "The use of bin/plugin is deprecated and will be removed in a feature release."
+echo "The use of bin/plugin is deprecated and will be removed in a feature release. Please use bin/logstash-plugin."
 
 unset CDPATH
-. "$(cd `dirname $0`/..; pwd)/bin/logstash.lib.sh"
-setup
-
-# bin/plugin is a short lived ruby script thus we can use aggressive "faster starting JRuby options"
-# see https://github.com/jruby/jruby/wiki/Improving-startup-time
-export JRUBY_OPTS="$JRUBY_OPTS -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -X-C -Xcompile.invokedynamic=false"
-
-ruby_exec "${LOGSTASH_HOME}/lib/pluginmanager/main.rb" "$@"
+sh "$(cd `dirname $0`/..; pwd)/bin/logstash-plugin" "$@"

--- a/bin/plugin
+++ b/bin/plugin
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+echo "The use of bin/plugin is deprecated and will be removed in a feature release."
+
 unset CDPATH
 . "$(cd `dirname $0`/..; pwd)/bin/logstash.lib.sh"
 setup

--- a/bin/plugin.bat
+++ b/bin/plugin.bat
@@ -2,14 +2,7 @@
 
 SETLOCAL
 
+ECHO "The use of bin/plugin is deprecated and will be removed in a feature release. Please use bin/logstash-plugin."
+
 set SCRIPT_DIR=%~dp0
-CALL "%SCRIPT_DIR%\setup.bat"
-
-:EXEC
-if "%VENDORED_JRUBY%" == "" (
-  %RUBYCMD% "%LS_HOME%\lib\pluginmanager\main.rb" %*
-) else (
-  %JRUBY_BIN% %jruby_opts% "%LS_HOME%\lib\pluginmanager\main.rb" %*
-)
-
-ENDLOCAL
+CALL "%SCRIPT_DIR%\logstash-plugin.bat" %*


### PR DESCRIPTION
* Add a deprecation notice for `bin/plugin`.
* Introduces `bin/logstash-plugin` as substitute.

Related #4872 #4874 #4871