### PR TITLE
Fix broken link

### DIFF
--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -5,7 +5,7 @@
 Although 2.2 is fully compatible with configurations from older versions, there are some architectural 
 changes to the pipeline that users need to take into consideration before deploying in production. 
 These changes are not strictly "breaking" in the semantic versioning sense, but they make Logstash behave differently 
-in runtime, and can also affect performance. We have compiled such a list in the <<_upgrading_logstash_to_2.2>> section. 
+in runtime, and can also affect performance. We have compiled such a list in the <<upgrading-logstash-2.2>> section. 
 Please review it before deploying 2.2 version.
 
 **Changes in 2.0**

--- a/docs/static/upgrading.asciidoc
+++ b/docs/static/upgrading.asciidoc
@@ -78,6 +78,7 @@ of workers by passing a command line flag such as:
 [source,shell]
 bin/logstash `-w 1`
 
+[[upgrading-logstash-2.2]]
 === Upgrading Logstash to 2.2
 
 Logstash 2.2 re-architected the pipeline stages to provide more performance and help future enhancements in resiliency.


### PR DESCRIPTION
It looks like this broken link was fixed in the logstash-docs repo, but not in logstash. Fixing it now so the problem doesn't persist. OK to merge?