### PR TITLE
Add badges to plugin page

### DIFF
--- a/docs/asciidocgen.rb
+++ b/docs/asciidocgen.rb
@@ -170,6 +170,9 @@ class LogStashConfigAsciiDocGenerator
     # Now parse the real library
     code = File.new(file).read
 
+    # Read the plugin version from its gemspec
+    bundled_version = Gem::Specification::load(Dir.glob(File.join(File.dirname(file), "..", "..", "..", "*.gemspec"))[0]).version
+
     # inputs either inherit from Base or Threadable.
     if code =~ /\< ::LogStash::Inputs::Threadable/
       parse(File.new(File.join(base, "threadable.rb"), "r").read)

--- a/docs/plugin-doc.asciidoc.erb
+++ b/docs/plugin-doc.asciidoc.erb
@@ -2,7 +2,12 @@
 [[plugins-<%= section %>s-<%= name %>]]
 === <%= name %>
 
-<% unless default_plugin %>
+<% if default_plugin %>
+image:https://img.shields.io/gem/v/logstash-<%= section %>-<%= name %>.svg["Gem Version", link="https://rubygems.org/gems/logstash-<%= section %>-<%= name %>"]
+image:https://img.shields.io/badge/bundled%20in%20release%20-<%= bundled_version %>-brightgreen.svg["Gem Version"]
+<% else %>
+image:https://img.shields.io/gem/v/logstash-<%= section %>-<%= name %>.svg["Gem Version", link="https://rubygems.org/gems/logstash-<%= section %>-<%= name %>"]
+
 NOTE: This is a community-maintained plugin! It does not ship with Logstash by default, but it is easy to install by running `bin/logstash-plugin install logstash-<%= section %>-<%= plugin_name %>`.
 <% end %>
 


### PR DESCRIPTION
As a user it is difficult to know which version of the plugin is bundled in a specific logstash release and to check if this is the latest one.
This PR is to discuss if this is a good feature to add and the correct way to add it to achieve something like a clear statement: 
_last release of logstash use v2.1.2 of date filter but a new version of the gem is available_
![plugin-badges](https://cloud.githubusercontent.com/assets/659227/14017751/f53acabc-f1c9-11e5-87a5-fa919b10ada1.png)

My understanding is that the documentation package is build by a specific version of logstash, so reading the installed gemspec file for each plugin seems the easiest, thoughts ?
