### PR TITLE
bump jruby-monitoring version to >= 0.3.1 to include last fixes

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'puma', '~> 2.16', '>= 2.16.0'
   gem.add_runtime_dependency "jruby-openssl", "0.9.13" # Required to support TLSv1.2
   gem.add_runtime_dependency "chronic_duration", "0.10.6"
-  gem.add_runtime_dependency "jruby-monitoring", '~> 0.1'
+  gem.add_runtime_dependency "jruby-monitoring", '~> 0.3.1'
 
   # TODO(sissel): Treetop 1.5.x doesn't seem to work well, but I haven't
   # investigated what the cause might be. -Jordan


### PR DESCRIPTION
Forces to get, _min_ the jruby-monitoring with the fix for #4909