### PR TITLE
fix race condition in agent spec

### DIFF
--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -123,6 +123,7 @@ describe LogStash::Agent do
           allow(subject).to receive(:clean_state?).and_return(false)
           expect(subject).to receive(:reload_state!).at_least(3).times
           t = Thread.new { subject.execute }
+          sleep 0.01 until subject.running_pipelines? && subject.pipelines.values.first.ready?
           sleep 0.1
           Stud.stop!(t)
           t.join


### PR DESCRIPTION
fixes build failures like https://logstash-ci.elastic.co/job/elastic+logstash+master+multijob-os-compatibility/os=ubuntu/lastBuild/console, similar to https://github.com/elastic/logstash/pull/4855