### PR TITLE
Retrieve JAVA_HOME from windows symlink

### DIFF
--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -15,6 +15,10 @@ goto finally
 
 :setup_jruby
 REM setup_java()
+if not defined JAVA_HOME IF EXIST %ProgramData%\Oracle\java\javapath\java.exe (
+    for /f "tokens=2 delims=[]" %%a in ('dir %ProgramData%\Oracle\java\javapath\java.exe') do @set JAVA_HOME=%%a
+)
+if defined JAVA_HOME set JAVA_HOME=%JAVA_HOME:\bin\java.exe=%
 if not defined JAVA_HOME goto missing_java_home
 REM ***** JAVA options *****
 

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -15,10 +15,15 @@ goto finally
 
 :setup_jruby
 REM setup_java()
+set JAVA_FROM_SYMLINK=
 if not defined JAVA_HOME IF EXIST %ProgramData%\Oracle\java\javapath\java.exe (
     for /f "tokens=2 delims=[]" %%a in ('dir %ProgramData%\Oracle\java\javapath\java.exe') do @set JAVA_HOME=%%a
+    set JAVA_FROM_SYMLINK=1
 )
 if defined JAVA_HOME set JAVA_HOME=%JAVA_HOME:\bin\java.exe=%
+if "%JAVA_FROM_SYMLINK%" == "1" (
+    echo Using JAVA_HOME=%JAVA_HOME% retrieved from %ProgramData%\Oracle\java\javapath\java.exe
+)
 if not defined JAVA_HOME goto missing_java_home
 REM ***** JAVA options *****
 

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -15,13 +15,11 @@ goto finally
 
 :setup_jruby
 REM setup_java()
-set JAVA_FROM_SYMLINK=
 if not defined JAVA_HOME IF EXIST %ProgramData%\Oracle\java\javapath\java.exe (
-    for /f "tokens=2 delims=[]" %%a in ('dir %ProgramData%\Oracle\java\javapath\java.exe') do @set JAVA_HOME=%%a
-    set JAVA_FROM_SYMLINK=1
+    for /f "tokens=2 delims=[]" %%a in ('dir %ProgramData%\Oracle\java\javapath\java.exe') do @set JAVA_EXE=%%a
 )
-if defined JAVA_HOME set JAVA_HOME=%JAVA_HOME:\bin\java.exe=%
-if "%JAVA_FROM_SYMLINK%" == "1" (
+if defined JAVA_EXE set JAVA_HOME=%JAVA_EXE:\bin\java.exe=%
+if defined JAVA_EXE (
     echo Using JAVA_HOME=%JAVA_HOME% retrieved from %ProgramData%\Oracle\java\javapath\java.exe
 )
 if not defined JAVA_HOME goto missing_java_home


### PR DESCRIPTION
I struggled today as the latest Chocolatey package to install Java on Windows does no longer set the JAVA_HOME environment automatically.

So I tried another approach to get rid of the JAVA_HOME environment variable ot start logstash on Windows.

I have seen that the Java MSI installs some symlinks on Windows with the path to the real java.exe which includes the path to the Java version installed.

```
Microsoft Windows [Version 10.0.10586]
(c) 2015 Microsoft Corporation. All rights reserved.

C:\Users\vagrant>where java
C:\ProgramData\Oracle\Java\javapath\java.exe

C:\Users\vagrant>dir %ProgramData%\Oracle\java\javapath
 Volume in drive C is Windows 10
 Volume Serial Number is 9C9F-63C7

 Directory of C:\ProgramData\Oracle\java\javapath

03/29/2016  11:32 AM    <DIR>          .
03/29/2016  11:32 AM    <DIR>          ..
03/29/2016  11:32 AM    <SYMLINK>      java.exe [C:\Program Files\Java\jre1.8.0_77\bin\java.exe]
03/29/2016  11:32 AM    <SYMLINK>      javaw.exe [C:\Program Files\Java\jre1.8.0_77\bin\javaw.exe]
03/29/2016  11:32 AM    <SYMLINK>      javaws.exe [C:\Program Files\Java\jre1.8.0_77\bin\javaws.exe]
               3 File(s)              0 bytes
               2 Dir(s)  49,970,565,120 bytes free

C:\Users\vagrant>dir %ProgramData%\Oracle\java\javapath\java.exe
 Volume in drive C is Windows 10
 Volume Serial Number is 9C9F-63C7

 Directory of C:\ProgramData\Oracle\java\javapath

03/29/2016  11:32 AM    <SYMLINK>      java.exe [C:\Program Files\Java\jre1.8.0_77\bin\java.exe]
               1 File(s)              0 bytes
               0 Dir(s)  48,065,687,552 bytes free
```

With the changes in setup.bat the batch script is able to generate JAVA_HOME from that symlink. Tested on Windows 7 and Windows 10 and Java 1.8.0_74 and 77.
