### PR TITLE
fix commands still using bin/plugin and not the new logstash-plugin

### DIFF
--- a/lib/pluginmanager/main.rb
+++ b/lib/pluginmanager/main.rb
@@ -38,7 +38,7 @@ end
 
 if $0 == __FILE__
   begin
-    LogStash::PluginManager::Main.run("bin/plugin", ARGV)
+    LogStash::PluginManager::Main.run("bin/logstash-plugin", ARGV)
   rescue LogStash::PluginManager::Error => e
     $stderr.puts(e.message)
     exit(1)

--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -3,7 +3,7 @@ require_relative "default_plugins"
 namespace "plugin" do
 
   def install_plugins(*args)
-    system("bin/plugin", "install", *args)
+    system("bin/logstash-plugin", "install", *args)
     raise(RuntimeError, $!.to_s) unless $?.success?
   end
 


### PR DESCRIPTION
 feedback to users when errors happen got strange, still requiring to use `bin/plugin`

this happen on the 2.x branch.

Fixes #4942