### PR TITLE
Fix links causing build errors and add missing files

### DIFF
--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -5,7 +5,7 @@
 Although 2.2 is fully compatible with configurations from older versions, there are some architectural 
 changes to the pipeline that users need to take into consideration before deploying in production. 
 These changes are not strictly "breaking" in the semantic versioning sense, but they make Logstash behave differently 
-in runtime, and can also affect performance. We have compiled such a list in the <<_upgrading_logstash_to_2.2>> section. 
+in runtime, and can also affect performance. We have compiled such a list in the <<upgrading-logstash-2.2>> section. 
 Please review it before deploying 2.2 version.
 
 **Changes in 2.0**

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -1,61 +1,84 @@
 [[releasenotes]]
-== Logstash 2.1 Release Notes
+== Logstash 5.0-alpha1 Release Notes
 
-[float]
-== General
-
-* {lsissue}2376[Issue 2376]: Added ability to install and upgrade Logstash plugins without requiring internet
-connectivity.
-* {lsissue}3576[Issue 3576]: Support alternate or private Ruby gems server to install and update plugins.
-* {lsissue}3451[Issue 3451]: Added ability to reliably shutdown Logstash when there is a stall in event processing. This
-option can be enabled by passing `--allow-unsafe-shutdown` flag while starting Logstash. Please be aware that any in-
-flight events will be lost when shutdown happens.
-* {lsissue}4222[Issue 4222]: Fixed a memory leak which could be triggered when events having a date were serialized to
-string.
-* Added JDBC input to default package.
-* {lsissue}3243[Issue 3243]: Adding `--debug` to `--configtest` now shows the configuration in blocks annotated by source
-config file. Very useful when using multiple config files in a directory.
-* {lsissue}4130[Issue 4130]: Reset default worker threads to 1 when using non thread-safe filters like multiline.
-* Fixed file permissions for the `logrotate` configuration file.
-* {lsissue}3861[Issue 3861]: Changed the default heap size from 500MB to 1GB.
-* {lsissue}3645[Issue 3645]: Fixed config check option when starting Logstash through init scripts.
+* Added APIs to monitor the Logstash pipeline. You can now query information/stats about event flow, JVM, 
+  and hot_threads.
+* Added dynamic config, a new feature to track config file for changes and restart the 
+  pipeline (same process) with updated config changes. This feature can be enabled in two 
+  ways: Passing a CLI long-form option `--auto-reload` or with short-form `-r`. Another 
+  option, `--reload-interval <seconds>` controls how often LS should check the config files 
+  for changes. Alternatively, if you don't start with the CLI option, you can send SIGHUP 
+  or `kill -1` signal to LS to reload the config file, and restart the pipeline ({lsissue}4513[Issue 4513]).
+* Added support to evaluate environment variables inside the Logstash config. You can also specify a 
+  default if the variable is not defined. The syntax is `${myVar:default}` ({lsissue}3944[Issue 3944]).
+* Improved throughput performance across the board (up by 2x in some configs) by implementing Event 
+  representation in Java. Event is the main object that encapsulates data as it flows through 
+  Logstash and provides APIs for the plugins to perform processing. This change also enables 
+  faster serialization for future persistence work ({lsissue}4191[Issue 4191]).
+* Added ability to configure custom garbage collection log file using `$LS_LOG_DIR`.
+* Deprecated `bin/plugin` in favor of `bin/logstash-plugin`. In the next major version `bin/plugin` will 
+  be removed to prevent `PATH` being polluted when other components of the Elastic stack are installed on 
+  the same instance ({lsissue}4891[Issue 4891]).
+* Fixed a bug where new pipeline might break plugins by calling the `register` method twice causing 
+  undesired behavior ({lsissue}4851[Issue 4851])).
+* Made `JAVA_OPTS` and `LS_JAVA_OPTS` work consistently on Windows ({lsissue}4758[Issue 4758]).
+* Fixed bug where specifying JMX parameters in `LS_JAVA_OPTS` caused Logstash not to restart properly
+  ({lsissue}4319[Issue 4319]).
+* Fixed a bug where upgrading plugins with Manticore threw an error and sometimes corrupted installation ({lsissue}4818[Issue 4818]).
+* Removed milestone warning that was displayed when the `--pluginpath` option was used to load plugins ({lsissue}4562[Issue 4562]).
+* Upgraded to JRuby 1.7.24.
+* Reverted default output workers to 1. Previously we had made output workers the same as number of pipeline workers (#4877). 
 
 [float]
 == Input Plugins
 
-[float]
-=== Twitter
-* https://github.com/logstash-plugins/logstash-input-twitter/issues/21[Issue 21]: Added an option to fetch data from the
-sample Twitter streaming endpoint.
-* https://github.com/logstash-plugins/logstash-input-twitter/issues/22[Issue 22]: Added hashtags, symbols and
-user_mentions as data for the non extended tweet event.
-* https://github.com/logstash-plugins/logstash-input-twitter/issues/20[Issue 20]: Added an option to filter per location
-and language.
-* https://github.com/logstash-plugins/logstash-input-twitter/issues/11[Issue 11]: Added an option to stream data from a
-list of users.
+*`Kafka`:
+
+* Breaking: Added support for 0.9 consumer API. This plugin now supports SSL based encryption. 
+  This release changed a lot of configuration, so it is not backward compatible. Also, this version will not 
+  work with Kafka 0.8 broker
+
+*`Beats`*:
+
+* Enhanced to verify client certificates against CA (https://github.com/logstash-plugins/logstash-input-beats/issues/8[Issue 8]).
+
+*'RabbitMQ`*:
+
+* Breaking Change: Metadata is now disabled by default because it was regressing performance.
+* Improved performance by using an internal queue and bulk ACKs.
+
+*`Redis`*:
+
+* Increased the batch_size to 100 by default. This provides a big jump in throughput and 
+  reduction in CPU utilization (https://github.com/logstash-plugins/logstash-input-redis/issues/25[Issue 25])
+
+*`JDBC`*:
+
+* Added retry connection feature (https://github.com/logstash-plugins/logstash-input-http/issues/33[Issue 33])
 
 [float]
-=== Beats
-* https://github.com/logstash-plugins/logstash-input-beats/issues/10[Issue 10]: Properly handle multiline events from
-multiple sources, originating from Filebeat.
+== Filter Plugins
+
+*`DNS`*:
+
+* Improved performance by adding caches to both successful and failed requests.
+* Added support for retrying with the `:max_retries` setting.
+* Lowered the default value of timeout from 2 to 0.5 seconds.
 
 [float]
-=== File
-* https://github.com/logstash-plugins/logstash-input-file/issues/44[Issue 44]: Properly handle multiline events from
-multiple sources.
+== Output Plugins
 
-[float]
-=== Eventlog
-* https://github.com/logstash-plugins/logstash-input-eventlog/issues/11[Issue 11]: Change the underlying library to
-capture Event Logs from Windows more reliably.
+*`Elasticsearch`*:
 
-[float]
-== Output
+* Bumped minimum manticore version to 0.5.4 which fixes a memory leak when sniffing 
+  is used (https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/392[Issue 392]).
+* Fixed bug when updating documents with doc_as_upsert and scripting.   
+* Made error messages more verbose and easier to parse by humans.
+* Retryable failures are now logged at the info level instead of warning.
 
-[float]
-=== Elasticsearch
-* Improved the default template to use doc_values wherever possible.
-* Improved the default template to disable fielddata on analyzed string fields.
-* https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/260[Issue 260]: Added New setting: timeout.
-This lets you control the behavior of a slow/stuck request to Elasticsearch that could be, for example, caused by network,
-firewall, or load balancer issues.
+*`Kafka`*:
+
+Breaking: Added support for 0.9 API. This plugin now supports SSL based encryption. This release 
+changed a lot of configuration, so it is not backward compatible. Also, this version will not work 
+with Kafka 0.8 broker
+

--- a/docs/static/submitting-a-plugin.asciidoc
+++ b/docs/static/submitting-a-plugin.asciidoc
@@ -1,0 +1,107 @@
+[[submitting-plugin]]
+=== Submitting your plugin to RubyGems.org and the logstash-plugins repository
+
+Logstash uses http://rubygems.org[RubyGems.org] as its repository for all plugin
+artifacts. Once you have developed your new plugin, you can make it available to
+Logstash users by simply publishing it to RubyGems.org.
+
+==== Licensing
+Logstash and all its plugins are licensed under
+https://github.com/elasticsearch/logstash/blob/master/LICENSE[Apache License, version 2 ("ALv2")].
+If you make your plugin publicly available via http://rubygems.org[RubyGems.org],
+please make sure to have this line in your gemspec:
+
+* `s.licenses = ['Apache License (2.0)']`
+
+==== Publishing to http://rubygems.org[RubyGems.org]
+
+To begin, you’ll need an account on RubyGems.org
+
+* https://rubygems.org/sign_up[Sign-up for a RubyGems account].
+
+After creating an account,
+http://guides.rubygems.org/rubygems-org-api/#api-authorization[obtain] an API
+key from RubyGems.org. By default, RubyGems uses the file `~/.gem/credentials`
+to store your API key. These credentials will be used to publish the gem.
+Replace `username` and `password` with the credentials you created at
+RubyGems.org:
+
+[source,sh]
+----------------------------------
+curl -u username:password https://rubygems.org/api/v1/api_key.yaml > ~/.gem/credentials
+chmod 0600 ~/.gem/credentials
+----------------------------------
+
+Before proceeding, make sure you have the right version in your gemspec file
+and commit your changes.
+
+* `s.version = '0.1.0'`
+
+To publish version 0.1.0 of your new logstash gem:
+
+[source,sh]
+----------------------------------
+bundle install
+bundle exec rake vendor
+bundle exec rspec
+bundle exec rake publish_gem
+----------------------------------
+
+[NOTE]
+========
+Executing `rake publish_gem`:
+
+. Reads the version from the gemspec file (`s.version = '0.1.0'`)
+. Checks in your local repository if a tag exists for that version. If the tag
+already exists, it aborts the process. Otherwise, it creates a new version tag
+in your local repository.
+. Builds the gem
+. Publishes the gem to RubyGems.org
+========
+
+That's it! Your plugin is published! Logstash users can now install your plugin
+by running:
+
+[source,sh]
+[subs="attributes"]
+----------------------------------
+bin/plugin install logstash-{plugintype}-mypluginname
+----------------------------------
+
+==== Contributing your source code to https://github.com/logstash-plugins[logstash-plugins]
+
+It is not required to contribute your source code to
+https://github.com/logstash-plugins[logstash-plugins] github organization, but
+we always welcome new plugins!
+
+==== Benefits
+
+Some of the many benefits of having your plugin in the logstash-plugins
+repository are:
+
+* **Discovery** Your plugin will appear in the http://www.elasticsearch.org/guide/en/logstash/current/index.html[Logstash Reference],
+where Logstash users look first for plugins and documentation.
+* **Documentation** Your plugin documentation will automatically be added to the
+ http://www.elasticsearch.org/guide/en/logstash/current/index.html[Logstash Reference].
+* **Testing** With our testing infrastructure, your plugin will be continuously
+tested against current and future releases of Logstash.  As a result, users will
+have the assurance that if incompatibilities arise, they will be quickly
+discovered and corrected.
+
+==== Acceptance Guidelines
+
+* **Code Review** Your plugin must be reviewed by members of the community for
+coherence, quality, readability, stability and security.
+* **Tests** Your plugin must contain tests to be accepted.  These tests are also
+subject to code review for scope and completeness.  It's ok if you don't know
+how to write tests -- we will guide you. We are working on publishing a guide to
+creating tests for Logstash which will make it easier.  In the meantime, you can
+refer to http://betterspecs.org/ for examples.
+
+To begin migrating your plugin to logstash-plugins, simply create a new
+https://github.com/elasticsearch/logstash/issues[issue] in
+the Logstash repository. When the acceptance guidelines are completed, we will
+facilitate the move to the logstash-plugins organization using the recommended
+https://help.github.com/articles/transferring-a-repository/#transferring-from-a-user-to-an-organization[github process].
+
+pass::[<?edit_url?>]

--- a/docs/static/upgrading.asciidoc
+++ b/docs/static/upgrading.asciidoc
@@ -78,6 +78,7 @@ of workers by passing a command line flag such as:
 [source,shell]
 bin/logstash `-w 1`
 
+[[upgrading-logstash-2.2]]
 === Upgrading Logstash to 2.2
 
 Logstash 2.2 re-architected the pipeline stages to provide more performance and help future enhancements in resiliency.


### PR DESCRIPTION
The link issues were fixed in the logstash-docs repo, but not the logstash repo.

Also adding content changes that were made in the logstash-docs repo, but not the logstash repo.