### PR TITLE
ensure cond_func methods are singletons

### DIFF
--- a/logstash-core/lib/logstash/config/config_ast.rb
+++ b/logstash-core/lib/logstash/config/config_ast.rb
@@ -391,7 +391,7 @@ module LogStash; module Config; module AST
       if type == "filter"
         i = LogStash::Config::AST.defered_conditionals_index += 1
         source = <<-CODE
-          def cond_func_#{i}(input_events)
+          define_singleton_method :cond_func_#{i} do |input_events|
             result = []
             input_events.each do |event|
               events = [event]


### PR DESCRIPTION
compiled filter condition functions are defined using the standard "def", which means that creating a new pipeline will redefine these functions for already existing pipelines.
This PR fixes this by using `define_singleton_method`, as it already happens with other generated methods.

fixes #4968 

this needs to be addressed on master too