### PR TITLE
(2.x Backport) Hide sensitive AST/config data unless --debug-config argument passed

### DIFF
--- a/docs/static/command-line-flags.asciidoc
+++ b/docs/static/command-line-flags.asciidoc
@@ -41,6 +41,11 @@ Logstash has the following flags. You can use the `--help` flag to display this 
 --debug
  Increase verbosity to the last level (trace), more verbose.
 
+--debug-config
+ Print the compiled config ruby code out as a debug log (you must also have --debug enabled).
+ WARNING: This will include any 'password' options passed to plugin configs as plaintext, and may result
+ in plaintext passwords appearing in your logs!
+
 -V, --version
   Display the version of Logstash.
 

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -110,7 +110,7 @@ class LogStash::Agent < Clamp::Command
 
   def debug_config=(debug_config)
     @config_loader.debug_config = debug_config
-    @debug_config
+    @debug_config = true
   end
 
   def validate_positive_integer(str_arg)
@@ -190,7 +190,7 @@ class LogStash::Agent < Clamp::Command
     register_pipeline("main", @pipeline_settings.merge({
                           :config_string => config_string,
                           :config_path => config_path,
-                          :debug_config => @debug_config
+                          :debug_config => debug_config?
                           }))
 
     sigint_id = trap_sigint()

--- a/logstash-core/lib/logstash/config/loader.rb
+++ b/logstash-core/lib/logstash/config/loader.rb
@@ -1,8 +1,11 @@
 require "logstash/config/defaults"
 
 module LogStash; module Config; class Loader
-  def initialize(logger)
+  attr_reader :debug_config
+
+  def initialize(logger, debug_config=false)
     @logger = logger
+    @debug_config = debug_config
   end
 
   def format_config(config_path, config_string)
@@ -69,14 +72,18 @@ module LogStash; module Config; class Loader
         encoding_issue_files << file
       end
       config << cfg + "\n"
-      @logger.debug? && @logger.debug("\nThe following is the content of a file", :config_file => file.to_s)
-      @logger.debug? && @logger.debug("\n" + cfg + "\n\n")
+      if @debug_config
+        @logger.debug? && @logger.debug("\nThe following is the content of a file", :config_file => file.to_s)
+        @logger.debug? && @logger.debug("\n" + cfg + "\n\n")
+      end
     end
     if encoding_issue_files.any?
       fail("The following config files contains non-ascii characters but are not UTF-8 encoded #{encoding_issue_files}")
     end
-    @logger.debug? && @logger.debug("\nThe following is the merged configuration")
-    @logger.debug? && @logger.debug("\n" + config + "\n\n")
+    if @debug_config
+      @logger.debug? && @logger.debug("\nThe following is the merged configuration")
+      @logger.debug? && @logger.debug("\n" + config + "\n\n")
+    end
     return config
   end # def load_config
 

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -209,6 +209,10 @@ en:
         debug: |+
           Most verbose logging. This causes 'debug'
           level logs to be emitted.
+        debug-config: |+
+          Print the compiled config ruby code out as a debug log (you must also have --debug enabled).
+          WARNING: This will include any 'password' options passed to plugin configs as plaintext, and may result
+          in plaintext passwords appearing in your logs!
         unsafe_shutdown: |+
           Force logstash to exit during shutdown even
           if there are still inflight events in memory.

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -343,5 +343,25 @@ describe LogStash::Agent do
     end
   end
 
+  describe "debug_config" do
+    let(:pipeline_string) { "input {} output {}" }
+    let(:pipeline) { double("pipeline") }
+
+    it "should set 'debug_config' to false by default" do
+      expect(LogStash::Pipeline).to receive(:new).with(pipeline_string, hash_including(:debug_config => false)).and_return(pipeline)
+      args = ["--debug", "-e", pipeline_string]
+      subject.run(args)
+
+      expect(subject.config_loader.debug_config).to be_falsey
+    end
+
+    it "should allow overriding debug_config" do
+      expect(LogStash::Pipeline).to receive(:new).with(pipeline_string, hash_including(:debug_config => true)).and_return(pipeline)
+      args = ["--debug", "--debug-config",  "-e", pipeline_string]
+      subject.run(args)
+
+      expect(subject.config_loader.debug_config).to be_truthy
+    end
+  end
 end
 

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -16,7 +16,6 @@ describe LogStash::Runner do
     allow(Cabin::Channel).to receive(:get).with(LogStash).and_return(channel)
   end
 
-
   context "argument parsing" do
     it "should run agent" do
       expect(Stud::Task).to receive(:new).once.and_return(nil)
@@ -55,5 +54,4 @@ describe LogStash::Runner do
       end
     end
   end
-
 end


### PR DESCRIPTION
(This is a 2.x backport of https://github.com/elastic/logstash/pull/4965)

We now hide this because displaying it is dangerous. Generated code
and other AST data may contain plaintext copies of 'password' type fields.
Users can force this to appear with the --debug-config flag.

Fixes https://github.com/elastic/logstash/issues/4964