### PR TITLE
Fix for ubuntu package stop function 

### DIFF
--- a/pkg/logstash.sysv
+++ b/pkg/logstash.sysv
@@ -96,7 +96,7 @@ stop() {
       sleep 1
     done
     if status ; then
-      if [[ $KILL_ON_STOP_TIMEOUT -eq 1 ]] ; then
+      if [ $KILL_ON_STOP_TIMEOUT -eq 1 ] ; then
         echo "Timeout reached. Killing $name (pid $pid) with SIGKILL. This may result in data loss."
         kill -KILL $pid
         echo "$name killed with SIGKILL."


### PR DESCRIPTION
by having use proper portable `[` command instead of the bash `[[` based one when stop checks for `KILL_ON_STOP_TIMEOUT` env to be set.

Fixes #4940

As of a solution I when for using the posix `[` command, instead of moving the hole scripts to bash due to the reasons explained in:

* https://wiki.ubuntu.com/DashAsBinSh#A.5B
* and due to the reason that in this script this was actually an exception command, as rest of the similar checks were using the `[` options.

> The major reason to switch the default shell was efficiency. bash is an excellent full-featured shell appropriate for interactive use; indeed, it is still the default login shell. However, it is rather large and slow to start up and operate by comparison with dash.

From the same ubuntu people, notice that in ubuntu now `bin/sh` -> `bin/dash`

related issue: #4991
