### PR TITLE
Hide sensitive AST/config data unless --debug-config argument passed

### DIFF
--- a/docs/static/command-line-flags.asciidoc
+++ b/docs/static/command-line-flags.asciidoc
@@ -42,6 +42,11 @@ Logstash has the following flags. You can use the `--help` flag to display this 
 --debug
  Increase verbosity to the last level (trace), more verbose.
 
+--debug-config
+ Print the compiled config ruby code out as a debug log (you must also have --debug enabled).
+ WARNING: This will include any 'password' options passed to plugin configs as plaintext, and may result
+ in plaintext passwords appearing in your logs!
+
 -V, --version
   Display the version of Logstash.
 

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -9,6 +9,7 @@ require "logstash/pipeline"
 LogStash::Environment.load_locale!
 
 class LogStash::Agent < Clamp::Command
+
   DEFAULT_INPUT = "input { stdin { type => stdin } }"
   DEFAULT_OUTPUT = "output { stdout { codec => rubydebug } }"
 
@@ -52,6 +53,10 @@ class LogStash::Agent < Clamp::Command
   option "--quiet", :flag, I18n.t("logstash.agent.flag.quiet")
   option "--verbose", :flag, I18n.t("logstash.agent.flag.verbose")
   option "--debug", :flag, I18n.t("logstash.agent.flag.debug")
+
+  option "--debug-config", :flag,
+    I18n.t("logstash.runner.flag.debug_config"),
+    :attribute_name => :debug_config, :default => false
 
   option ["-V", "--version"], :flag,
     I18n.t("logstash.agent.flag.version")
@@ -263,6 +268,7 @@ class LogStash::Agent < Clamp::Command
   #
   # Log file stuff, plugin path checking, etc.
   def configure
+    @pipeline_settings[:debug_config] = debug_config?
     configure_logging(log_file)
     configure_plugin_paths(plugin_paths)
   end # def configure

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -24,7 +24,8 @@ module LogStash; class Pipeline
     :pipeline_batch_size => 125,
     :pipeline_batch_delay => 5, # in milliseconds
     :flush_interval => 5, # in seconds
-    :flush_timeout_interval => 60 # in seconds
+    :flush_timeout_interval => 60, # in seconds
+    :debug_config => false 
   }
   MAX_INFLIGHT_WARN_THRESHOLD = 10_000
 
@@ -52,7 +53,9 @@ module LogStash; class Pipeline
     code = @config.compile
     # The config code is hard to represent as a log message...
     # So just print it.
-    @logger.debug? && @logger.debug("Compiled pipeline code:\n#{code}")
+    if @settings[:debug_config]
+      @logger.debug? && @logger.debug("Compiled pipeline code:\n#{code}")
+    end
     begin
       eval(code)
     rescue => e
@@ -479,4 +482,18 @@ module LogStash; class Pipeline
       .each {|t| t.delete("blocked_on") }
       .each {|t| t.delete("status") }
   end
+
+  # Sometimes we log stuff that will dump the pipeline which may contain
+  # sensitive information (like the raw syntax tree which can contain passwords)
+  # We want to hide most of what's in here
+  def inspect
+    {
+      :pipeline_id => @pipeline_id,
+      :settings => @settings.inspect,
+      :ready => @ready,
+      :running => @running,
+      :flushing => @flushing
+    }
+  end
+
 end end

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -193,6 +193,10 @@ en:
         debug: |+
           Most verbose logging. This causes 'debug'
           level logs to be emitted.
+        debug-config: |+
+          Print the compiled config ruby code out as a debug log (you must also have --debug enabled).
+          WARNING: This will include any 'password' options passed to plugin configs as plaintext, and may result
+          in plaintext passwords appearing in your logs!  
         unsafe_shutdown: |+
           Force logstash to exit during shutdown even
           if there are still inflight events in memory.

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -58,5 +58,28 @@ describe LogStash::Agent do
       subject.configure_plugin_paths(multiple_paths)
     end
   end
-end
 
+  describe "debug_config" do
+    let(:pipeline_string) { "input {} output {}" }
+    let(:pipeline) { double("pipeline") }
+
+    before(:each) do
+      allow(pipeline).to receive(:run)
+    end
+    it "should set 'debug_config' to false by default" do
+      expect(LogStash::Pipeline).to receive(:new).
+        with(anything,hash_including(:debug_config => false)).
+        and_return(pipeline)
+      args = ["--debug", "-e", pipeline_string]
+      subject.run(args)
+    end
+
+    it "should allow overriding debug_config" do
+      expect(LogStash::Pipeline).to receive(:new).
+        with(anything, hash_including(:debug_config => true))
+        .and_return(pipeline)
+      args = ["--debug", "--debug-config",  "-e", pipeline_string]
+      subject.run(args)
+    end
+  end
+end

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -416,7 +416,7 @@ describe LogStash::Pipeline do
       Thread.new { pipeline.run }
       sleep 0.1 while !pipeline.ready?
       # give us a bit of time to flush the events
-      wait(5).for do
+      wait(15).for do
         next unless output && output.events && output.events.first
         output.events.first["message"].split("\n").count
       end.to eq(number_of_events)

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -40,7 +40,7 @@ describe LogStash::Runner do
 
   describe "pipeline settings" do
     let(:pipeline_string) { "input { stdin {} } output { stdout {} }" }
-    let(:base_pipeline_settings) { { :pipeline_id => "base" } }
+    let(:base_pipeline_settings) { { :pipeline_id => "base", :debug_config => false } }
     let(:pipeline) { double("pipeline") }
 
     before(:each) do


### PR DESCRIPTION
We now hide this because displaying it is dangerous. Generated code
and other AST data may contain plaintext copies of 'password' type fields.
Users can force this to appear with the --debug-config flag.

Fixes https://github.com/elastic/logstash/issues/4964