### PR TITLE
Prevent config leak on output delegator close

### DIFF
--- a/logstash-core/lib/logstash/output_delegator.rb
+++ b/logstash-core/lib/logstash/output_delegator.rb
@@ -147,7 +147,7 @@ module LogStash class OutputDelegator
   end
 
   def do_close
-    @logger.debug("closing output delegator", :klass => self)
+    @logger.debug("closing output delegator", :klass => @klass)
 
     if @threadsafe
       @workers.each(&:do_close)


### PR DESCRIPTION
On shutdown logstash may leak config information for outputs including
plaintext passwords