### PR TITLE
[backport] 2.x Add Environment Variable Support Flag (--allow-env)

### DIFF
--- a/docs/static/command-line-flags.asciidoc
+++ b/docs/static/command-line-flags.asciidoc
@@ -64,6 +64,9 @@ Logstash has the following flags. You can use the `--help` flag to display this 
   
 -r, --[no-]auto-reload
   Monitor configuration changes and reload the configuration whenever it is changed.
+
+--allow-env
+  EXPERIMENTAL: Enable environment variable templating within configuration parameters.
   
 --reload-interval RELOAD_INTERVAL
   Specifies how often Logstash checks the config files for changes. The default is every 3 seconds.

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -87,6 +87,10 @@ class LogStash::Agent < Clamp::Command
     I18n.t("logstash.agent.flag.reload_interval"),
     :attribute_name => :reload_interval, :default => 3, &:to_i
 
+  option ["--allow-env"], :flag,
+    I18n.t("logstash.agent.flag.allow-env"),
+    :attribute_name => :allow_env, :default => false
+
   def initialize(*params)
     super(*params)
     @logger = Cabin::Channel.get(LogStash)
@@ -190,7 +194,8 @@ class LogStash::Agent < Clamp::Command
     register_pipeline("main", @pipeline_settings.merge({
                           :config_string => config_string,
                           :config_path => config_path,
-                          :debug_config => debug_config?
+                          :debug_config => debug_config?,
+                          :allow_env => allow_env?
                           }))
 
     sigint_id = trap_sigint()

--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -38,7 +38,8 @@ module LogStash::Config::Mixin
   PLUGIN_VERSION_1_0_0 = LogStash::Util::PluginVersion.new(1, 0, 0)
   PLUGIN_VERSION_0_9_0 = LogStash::Util::PluginVersion.new(0, 9, 0)
 
-  ENV_PLACEHOLDER_REGEX = /\$(?<name>\w+)|\$\{(?<name>\w+)(\:(?<default>[^}]*))?\}/
+  ALLOW_ENV_FLAG = "__ALLOW_ENV__"
+  ENV_PLACEHOLDER_REGEX = /\$\{(?<name>\w+)(\:(?<default>[^}]*))?\}/
 
   # This method is called when someone does 'include LogStash::Config'
   def self.included(base)
@@ -47,6 +48,14 @@ module LogStash::Config::Mixin
   end
 
   def config_init(params)
+    # HACK(talevy): https://github.com/elastic/logstash/issues/4958
+    # Currently, the regular plugins params argument is hijacked
+    # to pass along the `allow_env` configuration variable. This was done as to 
+    # not change the method signature of Plugin. This also makes it difficul to 
+    # reason about at the same time. ALLOW_ENV_FLAG is a special param that users 
+    # are now forbidden to set in their configuration definitions.
+    allow_env = params.delete(LogStash::Config::Mixin::ALLOW_ENV_FLAG) { false }
+
     # Validation will modify the values inside params if necessary.
     # For example: converting a string to a number, etc.
     
@@ -102,21 +111,24 @@ module LogStash::Config::Mixin
     end
 
     # Resolve environment variables references
-    params.each do |name, value|
-      if (value.is_a?(Hash))
-        value.each do |valueHashKey, valueHashValue|
-          value[valueHashKey.to_s] = replace_env_placeholders(valueHashValue)
-        end
-      else
-        if (value.is_a?(Array))
-          value.each_index do |valueArrayIndex|
-            value[valueArrayIndex] = replace_env_placeholders(value[valueArrayIndex])
+    if allow_env
+        params.each do |name, value|
+        if (value.is_a?(Hash))
+          value.each do |valueHashKey, valueHashValue|
+            value[valueHashKey.to_s] = replace_env_placeholders(valueHashValue)
           end
         else
-          params[name.to_s] = replace_env_placeholders(value)
+          if (value.is_a?(Array))
+            value.each_index do |valueArrayIndex|
+              value[valueArrayIndex] = replace_env_placeholders(value[valueArrayIndex])
+            end
+          else
+            params[name.to_s] = replace_env_placeholders(value)
+          end
         end
       end
     end
+
 
     if !self.class.validate(params)
       raise LogStash::ConfigurationError,
@@ -154,7 +166,6 @@ module LogStash::Config::Mixin
   # Process following patterns : $VAR, ${VAR}, ${VAR:defaultValue}
   def replace_env_placeholders(value)
     return value unless value.is_a?(String)
-    #raise ArgumentError, "Cannot replace ENV placeholders on non-strings. Got #{value.class}" if !value.is_a?(String)
 
     value.gsub(ENV_PLACEHOLDER_REGEX) do |placeholder|
       # Note: Ruby docs claim[1] Regexp.last_match is thread-local and scoped to
@@ -168,7 +179,6 @@ module LogStash::Config::Mixin
       if replacement.nil?
         raise LogStash::ConfigurationError, "Cannot evaluate `#{placeholder}`. Environment variable `#{name}` is not set and there is no default value given."
       end
-      @logger.info? && @logger.info("Evaluating environment variable placeholder", :placeholder => placeholder, :replacement => replacement)
       replacement
     end
   end # def replace_env_placeholders

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -27,7 +27,8 @@ module LogStash; class Pipeline
     :pipeline_batch_delay => 5, # in milliseconds
     :flush_interval => 5, # in seconds
     :flush_timeout_interval => 60, # in seconds
-    :debug_config => false
+    :debug_config => false,
+    :allow_env => false
   }
   MAX_INFLIGHT_WARN_THRESHOLD = 10_000
 
@@ -43,6 +44,7 @@ module LogStash; class Pipeline
     @settings = DEFAULT_SETTINGS.clone
     settings.each {|setting, value| configure(setting, value) }
     @reporter = LogStash::PipelineReporter.new(@logger, self)
+    @allow_env = settings[:allow_env]
 
     @inputs = nil
     @filters = nil
@@ -405,6 +407,7 @@ module LogStash; class Pipeline
 
   def plugin(plugin_type, name, *args)
     args << {} if args.empty?
+    args.first.merge!(LogStash::Config::Mixin::ALLOW_ENV_FLAG => @allow_env)
 
     klass = LogStash::Plugin.lookup(plugin_type, name)
 

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -163,6 +163,10 @@ en:
           the empty string for the '-e' flag.
         configtest: |+
           Check configuration for valid syntax and then exit.
+        allow-env: |+
+          EXPERIMENTAL. Enables templating of environment variable
+          values. Instances of "${VAR}" in strings will be replaced
+          with the respective environment variable value named "VAR".
         pipeline-workers: |+
           Sets the number of pipeline workers to run.
         filterworkers: |+

--- a/logstash-core/spec/logstash/config/mixin_spec.rb
+++ b/logstash-core/spec/logstash/config/mixin_spec.rb
@@ -165,6 +165,10 @@ describe LogStash::Config::Mixin do
         config :oneNumber, :validate => :number
         config :oneArray, :validate => :array
         config :oneHash, :validate => :hash
+
+        def initialize(params)
+          super(params.merge(LogStash::Config::Mixin::ALLOW_ENV_FLAG => true))
+        end
       end
     end
 
@@ -217,7 +221,7 @@ describe LogStash::Config::Mixin do
           "oneString" => "${FunString:foo}",
           "oneBoolean" => "${FunBool:false}",
           "oneArray" => [ "first array value", "${FunString:foo}" ],
-          "oneHash" => { "key1" => "${FunString:foo}", "key2" => "$FunString is ${FunBool}", "key3" => "${FunBool:false} or ${funbool:false}" }
+          "oneHash" => { "key1" => "${FunString:foo}", "key2" => "${FunString} is ${FunBool}", "key3" => "${FunBool:false} or ${funbool:false}" }
         )
       end
 


### PR DESCRIPTION
backport of: https://github.com/elastic/logstash/pull/4963

for merging into 2.x and 2.3 branches