### PR TITLE
revert back to using Ruby Logstash Event from Java Event in logstash-core

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,9 @@
 
 source "https://rubygems.org"
 gem "logstash-core", "3.0.0.dev", :path => "./logstash-core"
-# gem "logstash-core-event", "3.0.0.dev", :path => "./logstash-core-event"
-gem "logstash-core-event-java", "3.0.0.dev", :path => "./logstash-core-event-java"
+# Revert back to using Ruby Logstash Event
+gem "logstash-core-event", "3.0.0.dev", :path => "./logstash-core-event"
+#gem "logstash-core-event-java", "3.0.0.dev", :path => "./logstash-core-event-java"
 gem "logstash-core-plugin-api", "1.0.0", :path => "./logstash-core-plugin-api"
 gem "file-dependencies", "0.1.6"
 gem "ci_reporter_rspec", "1.0.0", :group => :development

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -17,7 +17,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = LOGSTASH_CORE_VERSION
 
-  gem.add_runtime_dependency "logstash-core-event-java", "~> 3.0.0.dev"
+  # Reverting back to using ruby java event
+  # gem.add_runtime_dependency "logstash-core-event-java", "~> 3.0.0.dev"
+  gem.add_runtime_dependency "logstash-core-event", "~> 3.0.0.dev"
 
   gem.add_runtime_dependency "cabin", "~> 0.8.0" #(Apache 2.0 license)
   gem.add_runtime_dependency "pry", "~> 0.10.1"  #(Ruby license)


### PR DESCRIPTION
There are some incompatibilities between ruby-event and java-event. Mainly being support around 
in-place object mutability. This caused some breaking changes with plugins that may have relied on this capability of the Logstash Event.