### PR TITLE
revert to logstash-core-event 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@
 
 source "https://rubygems.org"
 gem "logstash-core", "3.0.0.dev", :path => "./logstash-core"
-# gem "logstash-core-event", "3.0.0.dev", :path => "./logstash-core-event"
-gem "logstash-core-event-java", "3.0.0.dev", :path => "./logstash-core-event-java"
+gem "logstash-core-event", "3.0.0.dev", :path => "./logstash-core-event"
+# gem "logstash-core-event-java", "3.0.0.dev", :path => "./logstash-core-event-java"
 gem "logstash-core-plugin-api", "1.0.0", :path => "./logstash-core-plugin-api"
 gem "file-dependencies", "0.1.6"
 gem "ci_reporter_rspec", "1.0.0", :group => :development

--- a/Gemfile.jruby-1.9.lock
+++ b/Gemfile.jruby-1.9.lock
@@ -10,7 +10,7 @@ PATH
       i18n (= 0.6.9)
       jrjackson (~> 0.3.7)
       jruby-openssl (= 0.9.13)
-      logstash-core-event (~> 3.0.0.dev)
+      logstash-core-event (= 3.0.0.dev)
       minitar (~> 0.5.4)
       pry (~> 0.10.1)
       rubyzip (~> 1.1.7)
@@ -23,14 +23,20 @@ PATH
   specs:
     logstash-core-event (3.0.0.dev-java)
 
+PATH
+  remote: ./logstash-core-plugin-api
+  specs:
+    logstash-core-plugin-api (1.0.0-java)
+      logstash-core (>= 2.0.0, <= 3.0.0.dev)
+
 GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.8)
     arr-pm (0.0.10)
       cabin (> 0)
-    backports (3.6.7)
-    benchmark-ips (2.3.0)
+    backports (3.6.8)
+    benchmark-ips (2.5.0)
     builder (3.2.2)
     cabin (0.8.1)
     childprocess (0.5.9)
@@ -41,19 +47,16 @@ GEM
       ci_reporter (~> 2.0)
       rspec (>= 2.14, < 4)
     clamp (0.6.5)
-    coderay (1.1.0)
+    coderay (1.1.1)
     concurrent-ruby (0.9.2-java)
-    coveralls (0.8.10)
+    coveralls (0.8.13)
       json (~> 1.8)
-      rest-client (>= 1.6.8, < 2)
       simplecov (~> 0.11.0)
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
       tins (~> 1.6.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.25)
-      unf (>= 0.0.5, < 1.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.10-java)
@@ -71,14 +74,12 @@ GEM
       json (>= 1.7.7)
     gem_publisher (1.5.0)
     gems (0.8.3)
-    http-cookie (1.0.2)
-      domain_name (~> 0.5)
     i18n (0.6.9)
     insist (1.0.0)
     jrjackson (0.3.8)
     jruby-openssl (0.9.13-java)
     json (1.8.3-java)
-    kramdown (1.9.0)
+    kramdown (1.10.0)
     logstash-devutils (0.0.18-java)
       gem_publisher
       insist (= 1.0.0)
@@ -89,10 +90,8 @@ GEM
       rspec-wait
       stud (>= 0.0.20)
     method_source (0.8.2)
-    mime-types (2.99)
     minitar (0.5.4)
     multipart-post (2.0.0)
-    netrc (0.11.0)
     octokit (3.8.0)
       sawyer (~> 0.6.0, >= 0.5.3)
     polyglot (0.3.5)
@@ -101,11 +100,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
       spoon (~> 0.0)
-    rake (10.4.2)
-    rest-client (1.8.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+    rake (11.1.2)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)
@@ -124,7 +119,7 @@ GEM
     sawyer (0.6.0)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
-    simplecov (0.11.1)
+    simplecov (0.11.2)
       docile (~> 1.1.0)
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
@@ -141,7 +136,6 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    unf (0.1.4-java)
 
 PLATFORMS
   java
@@ -156,6 +150,7 @@ DEPENDENCIES
   gems (~> 0.8.3)
   logstash-core (= 3.0.0.dev)!
   logstash-core-event (= 3.0.0.dev)!
+  logstash-core-plugin-api (= 1.0.0)!
   logstash-devutils (~> 0.0.15)
   octokit (= 3.8.0)
   rspec (~> 3.1.0)

--- a/logstash-core-event/logstash-core-event.gemspec
+++ b/logstash-core-event/logstash-core-event.gemspec
@@ -4,8 +4,8 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'logstash-core-event/version'
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Jordan Sissel", "Pete Fritchman", "Elasticsearch"]
-  gem.email         = ["jls@semicomplete.com", "petef@databits.net", "info@elasticsearch.com"]
+  gem.authors       = ["Elastic"]
+  gem.email         = ["info@elastic.co"]
   gem.description   = %q{The core event component of logstash, the scalable log and event management tool}
   gem.summary       = %q{logstash-core-event - The core event component of logstash}
   gem.homepage      = "http://www.elastic.co/guide/en/logstash/current/index.html"

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -4,8 +4,8 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'logstash-core/version'
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Jordan Sissel", "Pete Fritchman", "Elasticsearch"]
-  gem.email         = ["jls@semicomplete.com", "petef@databits.net", "info@elasticsearch.com"]
+  gem.authors       = ["Elastic"]
+  gem.email         = ["info@elastic.co"]
   gem.description   = %q{The core components of logstash, the scalable log and event management tool}
   gem.summary       = %q{logstash-core - The core components of logstash}
   gem.homepage      = "http://www.elastic.co/guide/en/logstash/current/index.html"
@@ -17,7 +17,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = LOGSTASH_CORE_VERSION
 
-  gem.add_runtime_dependency "logstash-core-event-java", "~> 3.0.0.dev"
+  gem.add_runtime_dependency "logstash-core-event", "3.0.0.dev"
+  # gem.add_runtime_dependency "logstash-core-event-java", "3.0.0.dev"
 
   gem.add_runtime_dependency "cabin", "~> 0.8.0" #(Apache 2.0 license)
   gem.add_runtime_dependency "pry", "~> 0.10.1"  #(Ruby license)


### PR DESCRIPTION
logstash-core-event-java introduces backward compatibility problems with ruby filter scripts and custom plugins.

before merging, these 2 specs errors need to be addressed

```
  1) LogStash::Timestamp at with BigDecimal epoch should return usec with a minimum of millisec precision
     Failure/Error: expect(LogStash::Timestamp.at(BigDecimal.new("946702800.123456")).usec).to be_within(1000).of(123456)
       expected 0 to be within 1000 of 123456
     # ./logstash-core-event/spec/logstash/timestamp_spec.rb:144:in `(root)'
     # ./vendor/bundle/jruby/1.9/gems/rspec-wait-0.0.8/lib/rspec/wait.rb:46:in `(root)'
     # ./rakelib/test.rake:42:in `(root)'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/task.rb:248:in `execute'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/task.rb:243:in `execute'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/task.rb:187:in `invoke_with_call_chain'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/task.rb:180:in `invoke_with_call_chain'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/task.rb:173:in `invoke'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/application.rb:150:in `invoke_task'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/application.rb:106:in `top_level'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/application.rb:106:in `top_level'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/application.rb:115:in `run_with_threads'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/application.rb:100:in `top_level'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/application.rb:78:in `run'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/application.rb:176:in `standard_exception_handling'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/application.rb:75:in `run'

  2) LogStash::Timestamp at with BigDecimal epoch should convert to correct date
     Failure/Error: expect(LogStash::Timestamp.at(BigDecimal.new("946702800.123456")).to_iso8601).to eq("2000-01-01T05:00:00.123Z")

       expected: "2000-01-01T05:00:00.123Z"
            got: "2000-01-01T05:00:00.000Z"

       (compared using ==)
     # ./logstash-core-event/spec/logstash/timestamp_spec.rb:138:in `(root)'
     # ./vendor/bundle/jruby/1.9/gems/rspec-wait-0.0.8/lib/rspec/wait.rb:46:in `(root)'
     # ./rakelib/test.rake:42:in `(root)'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/task.rb:248:in `execute'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/task.rb:243:in `execute'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/task.rb:187:in `invoke_with_call_chain'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/task.rb:180:in `invoke_with_call_chain'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/task.rb:173:in `invoke'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/application.rb:150:in `invoke_task'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/application.rb:106:in `top_level'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/application.rb:106:in `top_level'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/application.rb:115:in `run_with_threads'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/application.rb:100:in `top_level'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/application.rb:78:in `run'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/application.rb:176:in `standard_exception_handling'
     # ./vendor/bundle/jruby/1.9/gems/rake-11.1.2/lib/rake/application.rb:75:in `run'

Finished in 16.5 seconds (files took 3.21 seconds to load)
1441 examples, 2 failures

Failed examples:

rspec ./logstash-core-event/spec/logstash/timestamp_spec.rb:141 # LogStash::Timestamp at with BigDecimal epoch should return usec with a minimum of millisec precision
rspec ./logstash-core-event/spec/logstash/timestamp_spec.rb:137 # LogStash::Timestamp at with BigDecimal epoch should convert to correct date

Randomized with seed 12654
```