### PR TITLE
revert to logstash-core-event in 2.3 branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 
 source "https://rubygems.org"
 gem "logstash-core", "2.3.0"
-gem "logstash-core-event-java", "2.3.0"
+gem "logstash-core-event", "2.3.0"
 gem "logstash-core-plugin-api", "1.3.0"
 gem "file-dependencies", "0.1.6"
 gem "ci_reporter_rspec", "1.0.0", :group => :development

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = LOGSTASH_CORE_VERSION
 
-  gem.add_runtime_dependency "logstash-core-event-java", "2.3.0"
+  gem.add_runtime_dependency "logstash-core-event", "2.3.0"
 
   gem.add_runtime_dependency "cabin", "~> 0.8.0" #(Apache 2.0 license)
   gem.add_runtime_dependency "pry", "~> 0.10.1"  #(Ruby license)


### PR DESCRIPTION
revert to logstash-core-event in the 2.3 branch. 
to complete this we will need to move forward with a snapshot release and publish a new logstash-core gem which will drop the dependency on logstash-core-event-java and generate a new .lock file and update it in the 2.3 branch.