### PR TITLE
Bring CHANGELOG.md up to date with 2.3 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,72 @@
+## 2.3.1 (Apr 4, 2016)
+### general
+ - Fix a JRuby thread safety issue when using regular expression under multiple workers ([#4977](https://github.com/elastic/logstash/issues/4977)).
+ - Disable environment variables interpolation by default, this feature is now experimental to turn it on use the `--allow-env` flag ([#4958](https://github.com/elastic/logstash/issues/4958)).
+ - Hide sensitive data from from the log when shutting down a stale Logstash ([#4952](https://github.com/elastic/logstash/pull/4952)).
+ - Do not output the Configuration AST by default when running Logstash in debug mode, introduce `--debug-config` flag to display the AST ([#4965](https://github.com/elastic/logstash/issues/4964)).
+ - Fix the crash with the `--config-test` flag ([#4933](https://github.com/elastic/logstash/issues/4933)).
+ - Make filter conditionals work when running Logstash with the automatic configuration reloading. ([#4968](https://github.com/elastic/logstash/issues/4968)).
+ - Fix the stop command of the Ubuntu init script ([#4940](https://github.com/elastic/logstash/issues/4940)
+
+## input
+ - Beats 
+  - Do not use the identity map if we don't explicitly use the multiline codec ([#70](https://github.com/logstash-plugins/logstash-input-beats/pull/70)).
+
+## 2.3.0 (Mar 29, 2016)
+### general
+ - Added dynamic config, a new feature to track config file for changes and restart the 
+   pipeline (same process) with updated config changes. This feature can be enabled in two 
+   ways: Passing a CLI long-form option `--auto-reload` or with short-form `-r`. Another 
+   option, `--reload-interval <seconds>` controls how often LS should check the config files 
+   for changes. Alternatively, if you don't start with the CLI option, you can send SIGHUP 
+   or `kill -1` signal to LS to reload the config file, and restart the pipeline ([#4513](https://github.com/elastic/logstash/issues/4513)).
+ - Added support to evaluate environment variables inside the Logstash config. You can also specify a 
+   default if the variable is not defined. The syntax is `${myVar:default}` ([#3944](https://github.com/elastic/logstash/issues/3944)).
+ - Improved throughput performance across the board (up by 2x in some configs) by implementing Event 
+   representation in Java. Event is the main object that encapsulates data as it flows through 
+   Logstash and provides APIs for the plugins to perform processing. This change also enables 
+   faster serialization for future persistence work ([4191](https://github.com/elastic/logstash/issues/4191)).
+ - Added ability to configure custom garbage collection log file using `$LS_LOG_DIR`.
+ - Deprecated `bin/plugin` in favor of `bin/logstash-plugin`. In the next major version `bin/plugin` will 
+   be removed to prevent `PATH` being polluted when other components of the Elastic stack are installed on 
+   the same instance ([#4891](https://github.com/elastic/logstash/pull/4891)).
+ - Fixed a bug where new pipeline might break plugins by calling the `register` method twice causing 
+   undesired behavior ([#4851](https://github.com/elastic/logstash/issues/4851)).
+ - Made `JAVA_OPTS` and `LS_JAVA_OPTS` work consistently on Windows  ([#4758](https://github.com/elastic/logstash/pull/4758)).
+ - Fixed bug where specifying JMX parameters in `LS_JAVA_OPTS` caused Logstash not to restart properly
+   ([#4319](https://github.com/elastic/logstash/issues/4319)).
+ - Fixed a bug where upgrading plugins with Manticore threw an error and sometimes corrupted installation ([#4818](https://github.com/elastic/logstash/issues/4818)).
+ - Removed milestone warning that was displayed when the `--pluginpath` option was used to load plugins ([#4562](https://github.com/elastic/logstash/issues/4562)).
+ - Upgraded to JRuby 1.7.24.
+ - Reverted default output workers to 1. Perviously we had made output workers the same as number of pipeline
+   workers ([#4877](https://github.com/elastic/logstash/issues/4877)).
+   
+### input
+ - Beats
+   - Enhanced to verify client certificates against CA ([#8](https://github.com/logstash-plugins/logstash-input-beats/issues/8)).
+ - RabbitMQ
+   - Breaking Change: Metadata is now disabled by default because it was regressing performance.
+   - Improved performance by using an internal queue and bulk ACKs.
+ - Redis
+   - Increased the batch_size to 100 by default. This provides a big jump in throughput and 
+     reduction in CPU utilization ([#25](https://github.com/logstash-plugins/logstash-input-redis/issues/25)).
+ - JDBC
+   - Added retry connection feature ([#91](https://github.com/logstash-plugins/logstash-input-jdbc/issues/91)).
+   
+### filter
+  - DNS: 
+    - Improved performance by adding caches to both successful and failed requests.
+    - Added support for retrying with the `:max_retries` setting.
+    - Lowered the default value of timeout from 2 to 0.5 seconds.
+
+### output   
+  - Elasticsearch
+    - Bumped minimum manticore version to 0.5.4 which fixes a memory leak when sniffing 
+      is used ([#392](https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/392)).
+    - Fixed bug when updating documents with doc_as_upsert and scripting.
+    - Made error messages more verbose and easier to parse by humans.
+    - Retryable failures are now logged at the info level instead of warning.
+
 ## 2.1.0 (Nov 24, 2015)
 ### general
  - Added ability to install and upgrade Logstash plugins without requiring internet connectivity (#2376). 


### PR DESCRIPTION
The 2.x branch had a very old changelog. This brings it up to date with the latest 2.3 branch