### PR TITLE
Fix Rakelib package.rake to use logstash-plugin pack

### DIFF
--- a/rakelib/package.rake
+++ b/rakelib/package.rake
@@ -1,7 +1,7 @@
 namespace "package" do
 
   task "bundle" do
-    system("bin/logstash-plugin", "package")
+    system("bin/logstash-plugin", "pack")
     raise(RuntimeError, $!.to_s) unless $?.success?
   end
 


### PR DESCRIPTION
 to generate the plugins bundle, so the command rake package:plugins-all and rake package:plugins-default works creating the offline bundle.

This should be merged to master and 5.0 branches