### PR TITLE
Fix Rakelib package.rake to use bin/plugin pack

### DIFF
--- a/rakelib/package.rake
+++ b/rakelib/package.rake
@@ -1,7 +1,7 @@
 namespace "package" do
 
   task "bundle" do
-    system("bin/plugin", "package")
+    system("bin/plugin", "pack")
     raise(RuntimeError, $!.to_s) unless $?.success?
   end
 


### PR DESCRIPTION
 to generate the plugins bundle, so rake package:plugins-all and rake package:plugins-default works as expected generating the bundles for offline installation.

This should be merged with branches < 5.0 as they still use the old `bin/plugin` command.