### PR TITLE
skip language filter plugin that prevents all tar package

### DIFF
--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -134,6 +134,7 @@ module LogStash
       /jms$/,
       /example$/,
       /drupal/i,
+      /^logstash-filter-language$/,
       /^logstash-output-logentries$/,
       /^logstash-input-jdbc$/,
       /^logstash-output-newrelic$/,


### PR DESCRIPTION
due to logstash-filter-language's dependency on cld gem
that incudes a symlink in the .gem itself, the creation of the
all plugin tar package breaks minitar's archiving.

This PR fixes the problem by skipping this plugin