### PR TITLE
Remove some plugins that failed the build when creating the tar.gz

### DIFF
--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -144,7 +144,13 @@ module LogStash
       /^logstash-output-webhdfs$/,
       /^logstash-input-rackspace$/,
       /^logstash-output-rackspace$/,
-      /^logstash-input-dynamodb$/
+      /^logstash-input-dynamodb$/,
+      /^logstash-filter-language$/,
+      /^logstash-input-heroku$/,
+      /^logstash-output-google_cloud_storage$/,
+      /^logstash-input-journald$/,
+      /^logstash-input-log4j2$/,
+      /^logstash-codec-cloudtrail$/
     ])
 
 


### PR DESCRIPTION
I removed some plugins that made the all plugins tar generation failed.

http://build-eu-1.elasticsearch.org/job/logstash_create_all_plugins_tar_artifact_23/jdk=JDK7,label=metal-pool/lastBuild/console

```
[artifact:install-logstash-core] using logstash-core from Rubygems
[artifact:install-logstash-core] using logstash-core-event-java from Rubygems
[artifact:tar] Building tar.gz of all plugins
[artifact:tar] building build/logstash-all-plugins-2.3.0.tar.gz
rake aborted!
Archive::Tar::Minitar::Writer::BoundedStream::FileOverflow
/home/jenkins/workspace/logstash_create_all_plugins_tar_artifact_23/jdk/JDK7/label/metal-pool/vendor/bundle/jruby/1.9/gems/minitar-0.5.4/lib/archive/tar/minitar.rb:285:in `write'
/home/jenkins/workspace/logstash_create_all_plugins_tar_artifact_23/jdk/JDK7/label/metal-pool/rakelib/artifacts.rake:141:in `build_tar'
org/jruby/RubyIO.java:1182:in `open'
/home/jenkins/workspace/logstash_create_all_plugins_tar_artifact_23/jdk/JDK7/label/metal-pool/rakelib/artifacts.rake:138:in `build_tar'
/home/jenkins/workspace/logstash_create_all_plugins_tar_artifact_23/jdk/JDK7/label/metal-pool/vendor/bundle/jruby/1.9/gems/minitar-0.5.4/lib/archive/tar/minitar.rb:344:in `add_file_simple'
/home/jenkins/workspace/logstash_create_all_plugins_tar_artifact_23/jdk/JDK7/label/metal-pool/rakelib/artifacts.rake:137:in `build_tar'
org/jruby/RubyArray.java:1613:in `each'
/home/jenkins/workspace/logstash_create_all_plugins_tar_artifact_23/jdk/JDK7/label/metal-pool/rakelib/artifacts.rake:126:in `build_tar'
/home/jenkins/workspace/logstash_create_all_plugins_tar_artifact_23/jdk/JDK7/label/metal-pool/rakelib/artifacts.rake:115:in `(root)'
org/jruby/RubyProc.java:281:in `call'
org/jruby/RubyArray.java:1613:in `each'
org/jruby/RubyArray.java:1613:in `each'
org/jruby/RubyKernel.java:1059:in `load'
Tasks: TOP => artifact:tar-all-plugins
(See full trace by running task with --trace)
```