### PR TITLE
Cherry pick doc changes to amend usage of env vars

### DIFF
--- a/docs/static/configuration.asciidoc
+++ b/docs/static/configuration.asciidoc
@@ -619,21 +619,6 @@ This feature is _experimental_, to enable it you will need to run logstash with 
 [cols="a,a,a"]
 |==================================
 |Logstash config source	|Environment 	|Logstash config result
-
-|
-[source,shell]
-----
-export TCP_PORT=12345
-----
-|
-[source,ruby]
-----
-input {
-  tcp {
-    port => 12345
-  }
-}
-----
 |
 [source,ruby]
 ----

--- a/docs/static/configuration.asciidoc
+++ b/docs/static/configuration.asciidoc
@@ -606,7 +606,7 @@ This feature is _experimental_, to enable it you will need to run logstash with 
 
 ==== Overview
 
-* You can set environment variable references into Logstash plugins configuration using `${var}` or `$var`.
+* You can set environment variable references into Logstash plugins configuration using `${var}`.
 * Each reference will be replaced by environment variable value at Logstash startup.
 * The replacement is case-sensitive.
 * References to undefined variables raise a Logstash configuration error.
@@ -619,16 +619,6 @@ This feature is _experimental_, to enable it you will need to run logstash with 
 [cols="a,a,a"]
 |==================================
 |Logstash config source	|Environment 	|Logstash config result
-
-|
-[source,ruby]
-----
-input {
-  tcp {
-    port => "$TCP_PORT"
-  }
-}
-----
 
 |
 [source,shell]

--- a/docs/static/configuration.asciidoc
+++ b/docs/static/configuration.asciidoc
@@ -601,6 +601,9 @@ output {
 
 [[environment-variables]]
 === Using Environment Variables in Configuration
+
+This feature is _experimental_, to enable it you will need to run logstash with the `--allow-env` flag.
+
 ==== Overview
 
 * You can set environment variable references into Logstash plugins configuration using `${var}` or `$var`.


### PR DESCRIPTION
Cherry picks changes that were made in the 2.3 docs, but are also relevant to the docs in 5.0 and master.