### PR TITLE
[WIP] update to JRuby 1.7.25 snapshot

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "concurrent-ruby", "1.0.0"
   gem.add_runtime_dependency "sinatra", '~> 1.4', '>= 1.4.6'
   gem.add_runtime_dependency 'puma', '~> 2.16', '>= 2.16.0'
-  gem.add_runtime_dependency "jruby-openssl", "0.9.13" # Required to support TLSv1.2
+  gem.add_runtime_dependency "jruby-openssl", "0.9.16" # > 0.9.13 Required to support TLSv1.2
   gem.add_runtime_dependency "chronic_duration", "0.10.6"
   gem.add_runtime_dependency "jruby-monitoring", '~> 0.3.1'
 

--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -1,6 +1,6 @@
 namespace "vendor" do
   VERSIONS = {
-    "jruby" => { "version" => "1.7.23", "sha1" => "2b5e796feeed2bcfab02f8bf2ff3d77ca318e310" },
+    "jruby" => { "version" => "1.7.25-SNAPSHOT", "sha1" => "c831fd8c353899d8e5964729931f599e0c1104cf" },
   }
 
   def vendor(*args)
@@ -73,7 +73,8 @@ namespace "vendor" do
       /lib\/ruby\/shared\/rdoc/,
     ])
 
-    url = "http://jruby.org.s3.amazonaws.com/downloads/#{version}/jruby-bin-#{version}.tar.gz"
+    # url = "http://jruby.org.s3.amazonaws.com/downloads/#{version}/jruby-bin-#{version}.tar.gz"
+    url = "http://ci.jruby.org/snapshots/jruby-1_7/jruby-bin-#{version}.tar.gz"
     download = file_fetch(url, info["sha1"])
 
     parent = vendor(name).gsub(/\/$/, "")


### PR DESCRIPTION
Test master with JRuby 1.7.25 snapshot release. Only jruby-openssl in logstash-core needed to be pinned at 0.9.16 to match JRuby. 

- This PR is not really meant to be merged, we'll create a new one once 1.7.25 is GA.
- A few plugin tests are failing but this is not JRuby releated.

This need to be validated:

- [x] fix for the JRuby 1.7.24 regex thread safety regression
- [x]  fix for the JRuby 1.7.23 File.stat on 32 bits JVM on windows https://github.com/logstash-plugins/logstash-input-file/issues/82
- [x]  fix for the JRuby 1.7.23 io/console warning on Windows https://github.com/elastic/logstash/issues/3087
- [x] fix for #stat.writable? per jruby/jruby#3505 @jsvd ?
- [x] no jruby-openssl 0.9.16 update regressions
