### PR TITLE
Make the default list of plugins bundled with logstash a json file

### DIFF
--- a/lib/bootstrap/environment.rb
+++ b/lib/bootstrap/environment.rb
@@ -16,7 +16,7 @@ module LogStash
     BUNDLE_DIR = ::File.join(LOGSTASH_HOME, "vendor", "bundle")
     GEMFILE_PATH = ::File.join(LOGSTASH_HOME, "Gemfile")
     LOCAL_GEM_PATH = ::File.join(LOGSTASH_HOME, 'vendor', 'local_gems')
-    CACHE_PATH = File.join(LOGSTASH_HOME, "vendor", "cache")
+    CACHE_PATH = ::File.join(LOGSTASH_HOME, "vendor", "cache")
 
     # @return [String] the ruby version string bundler uses to craft its gem path
     def gem_ruby_version

--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -1,142 +1,7 @@
+require "logstash/json"
+
 module LogStash
   module RakeLib
-
-    # plugins included by default in the logstash distribution
-    DEFAULT_PLUGINS = %w(
-      logstash-input-heartbeat
-      logstash-codec-collectd
-      logstash-output-xmpp
-      logstash-codec-dots
-      logstash-codec-edn
-      logstash-codec-edn_lines
-      logstash-codec-fluent
-      logstash-codec-es_bulk
-      logstash-codec-graphite
-      logstash-codec-json
-      logstash-codec-json_lines
-      logstash-codec-line
-      logstash-codec-msgpack
-      logstash-codec-multiline
-      logstash-codec-netflow
-      logstash-codec-plain
-      logstash-codec-rubydebug
-      logstash-filter-clone
-      logstash-filter-csv
-      logstash-filter-date
-      logstash-filter-dns
-      logstash-filter-drop
-      logstash-filter-fingerprint
-      logstash-filter-geoip
-      logstash-filter-grok
-      logstash-filter-json
-      logstash-filter-kv
-      logstash-filter-metrics
-      logstash-filter-mutate
-      logstash-filter-ruby
-      logstash-filter-sleep
-      logstash-filter-split
-      logstash-filter-syslog_pri
-      logstash-filter-throttle
-      logstash-filter-urldecode
-      logstash-filter-useragent
-      logstash-filter-uuid
-      logstash-filter-xml
-      logstash-input-couchdb_changes
-      logstash-input-elasticsearch
-      logstash-input-exec
-      logstash-input-file
-      logstash-input-ganglia
-      logstash-input-gelf
-      logstash-input-generator
-      logstash-input-graphite
-      logstash-input-http
-      logstash-input-http_poller
-      logstash-input-imap
-      logstash-input-irc
-      logstash-input-jdbc
-      logstash-input-log4j
-      logstash-input-lumberjack
-      logstash-input-pipe
-      logstash-input-rabbitmq
-      logstash-input-redis
-      logstash-input-s3
-      logstash-input-snmptrap
-      logstash-input-sqs
-      logstash-input-stdin
-      logstash-input-syslog
-      logstash-input-tcp
-      logstash-input-twitter
-      logstash-input-udp
-      logstash-input-unix
-      logstash-input-xmpp
-      logstash-input-kafka
-      logstash-input-beats
-      logstash-output-cloudwatch
-      logstash-output-csv
-      logstash-output-elasticsearch
-      logstash-output-file
-      logstash-output-graphite
-      logstash-output-http
-      logstash-output-irc
-      logstash-output-kafka
-      logstash-output-nagios
-      logstash-output-null
-      logstash-output-pagerduty
-      logstash-output-pipe
-      logstash-output-rabbitmq
-      logstash-output-redis
-      logstash-output-s3
-      logstash-output-sns
-      logstash-output-sqs
-      logstash-output-statsd
-      logstash-output-stdout
-      logstash-output-tcp
-      logstash-output-udp
-      logstash-output-webhdfs
-    )
-
-    # plugins required to run the logstash core specs
-    CORE_SPECS_PLUGINS = %w(
-      logstash-filter-clone
-      logstash-filter-mutate
-      logstash-filter-multiline
-      logstash-input-generator
-      logstash-input-stdin
-      logstash-input-tcp
-      logstash-output-stdout
-    )
-
-    TEST_JAR_DEPENDENCIES_PLUGINS = %w(
-      logstash-input-kafka
-    )
-
-    TEST_VENDOR_PLUGINS = %w(
-      logstash-codec-collectd
-    )
-
-    ALL_PLUGINS_SKIP_LIST = Regexp.union([
-      /^logstash-filter-yaml$/,
-      /example$/,
-      /drupal/i,
-      /^logstash-output-logentries$/,
-      /^logstash-input-jdbc$/,
-      /^logstash-output-newrelic$/,
-      /^logstash-output-slack$/,
-      /^logstash-input-neo4j$/,
-      /^logstash-output-neo4j$/,
-      /^logstash-input-perfmon$/,
-      /^logstash-output-webhdfs$/,
-      /^logstash-input-rackspace$/,
-      /^logstash-output-rackspace$/,
-      /^logstash-input-dynamodb$/,
-      /^logstash-filter-language$/,
-      /^logstash-input-heroku$/,
-      /^logstash-output-google_cloud_storage$/,
-      /^logstash-input-journald$/,
-      /^logstash-input-log4j2$/,
-      /^logstash-codec-cloudtrail$/
-    ])
-
 
     # @return [Array<String>] list of all plugin names as defined in the logstash-plugins github organization, minus names that matches the ALL_PLUGINS_SKIP_LIST
     def self.fetch_all_plugins
@@ -152,5 +17,24 @@ module LogStash
       require 'gems'
       Gems.info(plugin) != "This rubygem could not be found."
     end
+
+    def self.fetch_plugins_for(type)
+      LogStash::Json.load(::File.read("rakelib/plugins-metadata.json")).select do |_, metadata|
+        metadata[type]
+      end.keys
+    end
+
+    # plugins included by default in the logstash distribution
+    DEFAULT_PLUGINS = self.fetch_plugins_for("default-plugins").freeze
+
+    # plugins required to run the logstash core specs
+    CORE_SPECS_PLUGINS = self.fetch_plugins_for("core-specs").freeze
+
+    TEST_JAR_DEPENDENCIES_PLUGINS = self.fetch_plugins_for("test-jar-dependencies").freeze
+
+    TEST_VENDOR_PLUGINS = self.fetch_plugins_for("test-vendor-plugin").freeze
+
+    ALL_PLUGINS_SKIP_LIST = Regexp.union(self.fetch_plugins_for("skip-list")).freeze
+
   end
 end

--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -1,0 +1,786 @@
+{
+	"logstash-input-heartbeat": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-codec-collectd": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": true,
+		"skip-list": false
+	},
+	"logstash-output-xmpp": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-codec-dots": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-codec-edn": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-codec-edn_lines": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-codec-fluent": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-codec-es_bulk": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-codec-graphite": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-codec-json": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-codec-json_lines": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-codec-line": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-codec-msgpack": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-codec-multiline": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-codec-netflow": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-codec-plain": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-codec-rubydebug": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-clone": {
+		"default-plugins": true,
+		"core-specs": true,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-csv": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-date": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-dns": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-drop": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-fingerprint": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-geoip": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-grok": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-json": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-kv": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-metrics": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-mutate": {
+		"default-plugins": true,
+		"core-specs": true,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-ruby": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-sleep": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-split": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-syslog_pri": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-throttle": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-urldecode": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-useragent": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-uuid": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-xml": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-couchdb_changes": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-elasticsearch": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-exec": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-file": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-ganglia": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-gelf": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-generator": {
+		"default-plugins": true,
+		"core-specs": true,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-graphite": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-http": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-http_poller": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-imap": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-irc": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-jdbc": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	},
+	"logstash-input-log4j": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-lumberjack": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-pipe": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-rabbitmq": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-redis": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-s3": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-snmptrap": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-sqs": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-stdin": {
+		"default-plugins": true,
+		"core-specs": true,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-syslog": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-tcp": {
+		"default-plugins": true,
+		"core-specs": true,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-twitter": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-udp": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-unix": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-xmpp": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-kafka": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": true,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-input-beats": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-cloudwatch": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-csv": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-elasticsearch": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-file": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-graphite": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-http": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-irc": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-kafka": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-nagios": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-null": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-pagerduty": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-pipe": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-rabbitmq": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-redis": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-s3": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-sns": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-sqs": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-statsd": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-stdout": {
+		"default-plugins": true,
+		"core-specs": true,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-tcp": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-udp": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-webhdfs": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	},
+	"logstash-filter-multiline": {
+		"default-plugins": false,
+		"core-specs": true,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-yaml": {
+		"default-plugins": false,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	},
+	"logstash-input-example": {
+		"default-plugins": false,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	},
+	"logstash-codec-example": {
+		"default-plugins": false,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	},
+	"logstash-filter-example": {
+		"default-plugins": false,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	},
+	"logstash-output-example": {
+		"default-plugins": false,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	},
+	"logstash-input-drupal_dblog": {
+		"default-plugins": false,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	},
+	"logstash-output-logentries": {
+		"default-plugins": false,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	},
+	"logstash-output-newrelic": {
+		"default-plugins": false,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	},
+	"logstash-output-slack": {
+		"default-plugins": false,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	},
+	"logstash-input-neo4j": {
+		"default-plugins": false,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	},
+	"logstash-output-neo4j": {
+		"default-plugins": false,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	},
+	"logstash-input-perfmon": {
+		"default-plugins": false,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	},
+	"logstash-input-rackspace": {
+		"default-plugins": false,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	},
+	"logstash-output-rackspace": {
+		"default-plugins": false,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	},
+	"logstash-input-dynamodb": {
+		"default-plugins": false,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	},
+	"logstash-filter-language": {
+		"default-plugins": false,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	},
+	"logstash-input-heroku": {
+		"default-plugins": false,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	},
+	"logstash-output-google_cloud_storage": {
+		"default-plugins": false,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	},
+	"logstash-input-journald": {
+		"default-plugins": false,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	},
+	"logstash-input-log4j2": {
+		"default-plugins": false,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	},
+	"logstash-codec-cloudtrail": {
+		"default-plugins": false,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": true
+	}
+}


### PR DESCRIPTION
So it can be consumed either by LS or external entities that might be interested to know the list of default plugins (for example the new plugins CI status page)

@ph your thoughts here? this basically implements your proposal to have the logstash-ci status page split re plugins.