### PR TITLE
Correct syntax in the conditional mutate example

### DIFF
--- a/docs/static/configuration.asciidoc
+++ b/docs/static/configuration.asciidoc
@@ -387,7 +387,7 @@ For example, the following conditional uses the mutate filter to remove the fiel
 ----------------------------------
 filter {
   if [action] == "login" {
-    mutate { remove => "secret" }
+    mutate { remove_field => "secret" }
   }
 }
 ----------------------------------


### PR DESCRIPTION
The example as an incorrect syntax. As per https://www.elastic.co/guide/en/logstash/current/plugins-filters-mutate.html#plugins-filters-mutate-remove_field it should be `remove_field` and not `remove`