### PR TITLE
Make sure to use non existence plugins in registry test

### DIFF
--- a/logstash-core/spec/logstash/plugins/registry_spec.rb
+++ b/logstash-core/spec/logstash/plugins/registry_spec.rb
@@ -25,10 +25,10 @@ describe LogStash::Registry do
     end
 
     it "should raise an error if can not find the plugin class" do
-      expect(LogStash::Registry::Plugin).to receive(:new).with("input", "elasticsearch").and_return(plugin)
-      expect(plugin).to receive(:path).and_return("logstash/input/elasticsearch").twice
+      expect(LogStash::Registry::Plugin).to receive(:new).with("input", "elastic").and_return(plugin)
+      expect(plugin).to receive(:path).and_return("logstash/input/elastic").twice
       expect(plugin).to receive(:installed?).and_return(true)
-      expect { registry.lookup("input", "elasticsearch") }.to raise_error(LoadError)
+      expect { registry.lookup("input", "elastic") }.to raise_error(LoadError)
     end
 
     it "should load from registry is already load" do
@@ -49,7 +49,7 @@ describe LogStash::Registry do
 
   context "when plugin is not installed and not defined" do
     it "should raise an error" do
-      expect { registry.lookup("input", "elasticsearch") }.to raise_error(LoadError)
+      expect { registry.lookup("input", "elastic") }.to raise_error(LoadError)
     end
   end
 


### PR DESCRIPTION
This helps fixing one of the issues having in CI when a branch already had a release as in that case the elasticsearch input plugin will be there for sure.

For other issues in https://logstash-ci.elastic.co/job/elastic+logstash+5.0+multijob-intake/, we should make sure to release a new snapshot, until this does not happen the build is going to be red ( due to the way test works ). Waiting for something like #5063 to be merged and then we could run test with not released code.

// @suyograo 