### PR TITLE
Fix backward compatibility break with fieldref and Float/Fixnum

### DIFF
--- a/logstash-core-event/lib/logstash/string_interpolation.rb
+++ b/logstash-core-event/lib/logstash/string_interpolation.rb
@@ -124,9 +124,15 @@ module LogStash
         value.join(",")
       when Hash
         LogStash::Json.dump(value)
+      when Numeric
+        value
+      when TrueClass
+        value
+      when FalseClass
+        value
       else
-        # Make sure we dont work on the refence of the value
-        # The Java Event implementation was always returning a string.
+        # If we dont know how to deal with the type we return a string
+        # to make sure we don't return a reference.
         "#{value}"
       end
     end

--- a/logstash-core-event/spec/logstash/event_spec.rb
+++ b/logstash-core-event/spec/logstash/event_spec.rb
@@ -82,12 +82,40 @@ describe LogStash::Event do
         expect(event["reference_test"]).not_to eq(data)
       end
 
-      it "should not return a Fixnum reference" do
+      # TODO: This was a bug and should only be true in the context of 2.3.X
+      # see https://github.com/elastic/logstash/issues/5114 for more details.
+      it "should return a Fixnum" do
         data = 1
         event = LogStash::Event.new({ "reference" => data })
         LogStash::Util::Decorators.add_fields({"reference_test" => "%{reference}"}, event, "dummy-plugin")
-        data += 41
-        expect(event["reference_test"]).to eq("1")
+        expect(event["reference_test"]).to eq(1)
+      end
+
+      # TODO: This was a bug and should only be true in the context of 2.3.X
+      # see https://github.com/elastic/logstash/issues/5114 for more details.
+      it "should return a Float" do
+        data = 1.999
+        event = LogStash::Event.new({ "reference" => data })
+        LogStash::Util::Decorators.add_fields({"reference_test" => "%{reference}"}, event, "dummy-plugin")
+        expect(event["reference_test"]).to eq(1.999)
+      end
+
+      # TODO: This was a bug and should only be true in the context of 2.3.X
+      # see https://github.com/elastic/logstash/issues/5114 for more details.
+      it "should return true" do
+        data = true
+        event = LogStash::Event.new({ "reference" => data })
+        LogStash::Util::Decorators.add_fields({"reference_test" => "%{reference}"}, event, "dummy-plugin")
+        expect(event["reference_test"]).to be_kind_of(TrueClass)
+      end
+
+      # TODO: This was a bug and should only be true in the context of 2.3.X
+      # see https://github.com/elastic/logstash/issues/5114 for more details.
+      it "should return false" do
+        data = false
+        event = LogStash::Event.new({ "reference" => data })
+        LogStash::Util::Decorators.add_fields({"reference_test" => "%{reference}"}, event, "dummy-plugin")
+        expect(event["reference_test"]).to be_kind_of(FalseClass)
       end
 
       it "should report a unix timestamp for %{+%s}" do


### PR DESCRIPTION
The change introduced with https://github.com/elastic/logstash/issues/4592 to deal with reference had
a side effect to break existing configuration when using fieldref accessing a Fixnum or a Float.

The problem was instead of returning the original type , the value
was converted to a string. This string could break some mappings that
were expecting a float.

Fixes #4961