### PR TITLE
Missing translation when running Logstash with a wrong path for `-f`

### DIFF
--- a/logstash-core/lib/logstash/config/loader.rb
+++ b/logstash-core/lib/logstash/config/loader.rb
@@ -40,7 +40,7 @@ module LogStash; module Config; class Loader
       when "file" then
         local_config(uri.path)
       else
-        fail(I18n.t("logstash.runner.configuration.scheme-not-supported", :path => path))
+        fail(I18n.t("logstash.agent.configuration.scheme-not-supported", :path => path))
       end
     rescue URI::InvalidURIError
       # fallback for windows.


### PR DESCRIPTION
Fixes #5118