### PR TITLE
Normalize the name of the generated artifacts

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -226,6 +226,9 @@ namespace "artifact" do
 
     case platform
       when "redhat", "centos"
+        # produce: logstash-5.0.0-alpha1.noarch.rpm
+        package_filename = "logstash-#{LOGSTASH_VERSION}.ARCH.TYPE"
+
         File.join(basedir, "pkg", "logrotate.conf").tap do |path|
           dir.input("#{path}=/etc/logrotate.d/logstash")
         end
@@ -245,6 +248,9 @@ namespace "artifact" do
         out.config_files << "etc/logrotate.d/logstash"
         out.config_files << "/etc/init.d/logstash"
       when "debian", "ubuntu"
+        # produce: logstash-5.0.0-alpha1_all.deb"
+        package_filename = "logstash-#{LOGSTASH_VERSION}_ARCH.TYPE"
+
         File.join(basedir, "pkg", "logstash.default").tap do |path|
           dir.input("#{path}=/etc/default/logstash")
         end
@@ -309,7 +315,7 @@ namespace "artifact" do
 
     out.attributes[:force?] = true # overwrite the rpm/deb/etc being created
     begin
-      path = File.join(basedir, "build", out.to_s)
+      path = File.join(basedir, "build", out.to_s(package_filename))
       x = out.output(path)
       puts "Completed: #{path}"
     ensure


### PR DESCRIPTION
This PR introduce a unified naming scheme for all our artifacts and will
produce the following files:

logstash-5.0.0-alpha1_all.deb
logstash-5.0.0-alpha1.tar.gz
logstash-5.0.0-alpha1.zip
logstash-5.0.0-alpha1.noarch.rpm

Fix #5100