### PR TITLE
fix for accessors lut invalidation

### DIFF
--- a/logstash-core-event-java/src/test/java/com/logstash/AccessorsTest.java
+++ b/logstash-core-event-java/src/test/java/com/logstash/AccessorsTest.java
@@ -182,4 +182,28 @@ public class AccessorsTest {
 
         assertEquals(accessors.includes("nilfield"), true);
     }
+
+    @Test
+    public void testInvalidPath() throws Exception {
+        Map data = new HashMap();
+        Accessors accessors = new Accessors(data);
+
+        assertEquals(accessors.set("[foo]", 1), 1);
+        assertEquals(accessors.get("[foo][bar]"), null);
+    }
+
+    @Test
+    public void testStaleTargetCache() throws Exception {
+        Map data = new HashMap();
+
+        Accessors accessors = new Accessors(data);
+
+        assertEquals(accessors.get("[foo][bar]"), null);
+        assertEquals(accessors.set("[foo][bar]", "baz"), "baz");
+        assertEquals(accessors.get("[foo][bar]"), "baz");
+
+        assertEquals(accessors.set("[foo]", "boom"), "boom");
+        assertEquals(accessors.get("[foo][bar]"), null);
+        assertEquals(accessors.get("[foo]"), "boom");
+    }
 }

--- a/logstash-core-event/spec/logstash/event_spec.rb
+++ b/logstash-core-event/spec/logstash/event_spec.rb
@@ -602,4 +602,33 @@ describe LogStash::Event do
       expect(event1.to_s).to eq("#{timestamp.to_iso8601} #{event1["host"]} #{event1["message"]}")
     end
   end
+
+  describe "Event accessors" do
+    let(:event) { LogStash::Event.new({ "message" => "foo" }) }
+
+    it "should invalidate target caching" do
+      expect(event["[a][0]"]).to be_nil
+
+      expect(event["[a][0]"] = 42).to eq(42)
+      expect(event["[a][0]"]).to eq(42)
+      expect(event["[a]"]).to eq({"0" => 42})
+
+      expect(event["[a]"] = [42, 24]).to eq([42, 24])
+      expect(event["[a]"]).to eq([42, 24])
+
+      expect(event["[a][0]"]).to eq(42)
+
+      expect(event["[a]"] = [24, 42]).to eq([24, 42])
+      expect(event["[a][0]"]).to eq(24)
+
+      expect(event["[a][0]"] = {"a "=> 99, "b" => 98}).to eq({"a "=> 99, "b" => 98})
+      expect(event["[a][0]"]).to eq({"a "=> 99, "b" => 98})
+
+      expect(event["[a]"]).to eq([{"a "=> 99, "b" => 98}, 42])
+      expect(event["[a][0]"]).to eq({"a "=> 99, "b" => 98})
+      expect(event["[a][1]"]).to eq(42)
+      expect(event["[a][0][b]"]).to eq(98)
+    end
+  end
 end
+


### PR DESCRIPTION
This is a fix for the Accessors fieldref cache invalidation in the Ruby Event only. Before considering merging this we should assess the performance impact and see if using a hierarchical cache would provide better performance. Depending on the direction we choose for the fix, the same idea will have to be applied to the Java Event.

A stale cache spec has been added. 

Fixes #5127 

**[edit 04/20]**
Per comments below, we agreed that this fix is acceptable performance-wise and the same fix has been applied to the Java Event. Doing so uncovered another bug that resulted in a `expecting List or Map ` ClassCastException, also fixed and related test added.