### PR TITLE
fix callout numbering

### DIFF
--- a/docs/static/advanced-pipeline.asciidoc
+++ b/docs/static/advanced-pipeline.asciidoc
@@ -399,7 +399,7 @@ filebeat:
   prospectors:
     -
       paths:
-        - "/path/to/sample-log" <2>
+        - "/path/to/sample-log" <1>
       fields:
         type: syslog
 output:
@@ -410,10 +410,10 @@ output:
     certificate_key: /path/to/ssl-certificate.key
     certificate_authorities: /path/to/ssl-certificate.crt
     timeout: 15
+--------------------------------------------------------------------------------
 
 <1> Path to the file or files that Filebeat processes.
 <2> Path to the SSL certificate for the Logstash instance.
---------------------------------------------------------------------------------
 
 Save this configuration file as `filebeat.yml`.
 


### PR DESCRIPTION
GitHub's rendering is quite ok, just a single callout number is wrong. On https://www.elastic.co/guide/en/logstash/current/advanced-pipeline.html#configuring-lsf the rendered numbering gets quite confusing.