### PR TITLE
Fix tagging so that logstash version resolves in example

### DIFF
--- a/docs/static/getting-started-with-logstash.asciidoc
+++ b/docs/static/getting-started-with-logstash.asciidoc
@@ -132,9 +132,11 @@ yum install logstash
 
 To test your Logstash installation, run the most basic Logstash pipeline:
 
-[source,shell]
+["source","sh",subs="attributes"]
+--------------------------------------------------
 cd logstash-{logstash_version}
 bin/logstash -e 'input { stdin { } } output { stdout {} }'
+--------------------------------------------------
 
 The `-e` flag enables you to specify a configuration directly from the command line. Specifying configurations at the
 command line lets you quickly test configurations without having to edit a file between iterations.


### PR DESCRIPTION
Added subs="attributes" so that the {logstash_version} variable resolves correctly in the output. 