### PR TITLE
Have ci scripts abort if any command exits nonzero

### DIFF
--- a/ci/ci_integration.sh
+++ b/ci/ci_integration.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 # Since we are using the system jruby, we need to make sure our jvm process
 # uses at least 1g of memory, If we don't do this we can get OOM issues when

--- a/ci/ci_setup.sh
+++ b/ci/ci_setup.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 ##
 # Note this setup needs a system ruby to be available, this can not

--- a/ci/ci_test.sh
+++ b/ci/ci_test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 ##
 # Keep in mind to run ci/ci_setup.sh if you need to setup/clean up your environment before


### PR DESCRIPTION
This should fix scenarios where `rake bootstrap` fails due to bundler
failures and then some future command like `rake test:core` fails
because there's missing gems.