### PR TITLE
restructure tasks to have one VM run at a time during acceptance testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ rspec.xml
 .vendor
 integration_run
 .mvn/
+qa/.vm_ssh_config
+qa/.vagrant
+qa/.rspec
+qa/acceptance/.vagrant
+qa/Gemfile.lock

--- a/qa/Gemfile
+++ b/qa/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+gem "runner-tool", :git => "https://github.com/purbon/runner-tool.git"
+gem "rspec", "~> 3.1.0"
+gem "rake"

--- a/qa/README.md
+++ b/qa/README.md
@@ -1,0 +1,34 @@
+## Acceptance test Framework
+
+Welcome to the acceptance test framework for logstash, in this small
+readme we're going to describe it's features and the the necessary steps you will need to
+follow to setup your environment.
+
+### Environment setup
+
+This test are based on a collection of Vagrant defined VM's where the
+different test are going to be executed, so first setup necessary is to
+have vagrant properly available, see https://www.vagrantup.com/ for
+details on how to install it.
+
+After you get vagrant installed, you will need to perform the next
+setups:
+
+* Cd into the acceptance directory
+* run the command `vagrant up`, this will provision all the machines
+  defined in the Vagrantfile (located in this directory).
+
+An alternative way would to run the task `rake test:setup` what will do
+basically the same.
+
+When this process is done your test can be executed, to do that you will
+need to:
+
+_Inside the `qa` directory_
+
+* Execute the command `bundle` this will pull the necessary dependencies in your environment.
+* Run `rake test:ssh_config` to dump the ssh configuration to access the different vagrant machines, this will generate a file named `.vm_ssh_config` that is going to be used for the tests.
+* Run `bundle exec rake test:acceptance:all` to run all acceptance test
+  at once, there is also detailed tasks for platforms:
+ * `rake test:acceptance:debian` for debian platforms.
+ * `rake test:acceptance:centos` for centos platforms.

--- a/qa/Rakefile
+++ b/qa/Rakefile
@@ -1,0 +1,53 @@
+require "rspec"
+require "rspec/core/runner"
+require "rspec/core/rake_task"
+require_relative "vagrant-helpers"
+
+task :spec    => 'spec:all'
+task :default => :spec
+
+namespace :test do
+
+  desc "Generate a valid ssh-config"
+  task :ssh_config do
+    require "json"
+    cd "acceptance" do
+      raw_ssh_config    = LogStash::VagrantHelpers.fetch_config[:stdout].split("\n");
+      parsed_ssh_config = LogStash::VagrantHelpers.parse(raw_ssh_config)
+      File.write("../.vm_ssh_config", parsed_ssh_config.to_json)
+    end
+  end
+
+  desc "Bootstrap all the VM's used for this tests"
+  task "setup" do
+    puts "bootstraping all VM's defined in acceptance/Vagrantfile"
+    cd "acceptance" do
+      LogStash::VagrantHelpers.bootstrap
+    end
+  end
+
+  namespace :acceptance do
+
+    desc "Run all acceptance"
+    task :all do
+      exit(RSpec::Core::Runner.run([Rake::FileList["acceptance/spec/**/*_spec.rb"]]))
+    end
+
+    desc "Run acceptance test in debian machines"
+    task :debian do
+      exit(RSpec::Core::Runner.run([Rake::FileList["acceptance/spec/debian/**/*_spec.rb"]]))
+    end
+
+    desc "Run acceptance test in centos machines"
+    task :centos do
+      exit(RSpec::Core::Runner.run([Rake::FileList["acceptance/spec/centos/**/*_spec.rb"]]))
+    end
+
+    desc "Run one single machine acceptance test"
+    task :single, :machine do  |t, args|
+      ENV['LS_VAGRANT_HOST'] = args[:machine]
+      platform = LogStash::VagrantHelpers.translate(args[:machine])
+      exit(RSpec::Core::Runner.run([Rake::FileList["acceptance/spec/**/*_spec.rb"]]))
+    end
+  end
+end

--- a/qa/Rakefile
+++ b/qa/Rakefile
@@ -18,36 +18,47 @@ namespace :test do
     end
   end
 
-  desc "Bootstrap all the VM's used for this tests"
-  task "setup" do
-    puts "bootstraping all VM's defined in acceptance/Vagrantfile"
-    cd "acceptance" do
-      LogStash::VagrantHelpers.bootstrap
-    end
-  end
-
   namespace :acceptance do
 
     desc "Run all acceptance"
     task :all do
-      exit(RSpec::Core::Runner.run([Rake::FileList["acceptance/spec/**/*_spec.rb"]]))
+      all_boxes = LogStash::VagrantHelpers::DEFAULT_CENTOS_BOXES + LogStash::VagrantHelpers::DEFAULT_DEBIAN_BOXES 
+      for box in all_boxes do
+        LogStash::VagrantHelpers.bootstrap(box)
+        exit(RSpec::Core::Runner.run([Rake::FileList["acceptance/spec/**/*_spec.rb"]]))
+        LogStash::VagrantHelpers.destroy(box)
+      end
     end
 
     desc "Run acceptance test in debian machines"
     task :debian do
-      exit(RSpec::Core::Runner.run([Rake::FileList["acceptance/spec/debian/**/*_spec.rb"]]))
+      for box in LogStash::VagrantHelpers::DEFAULT_DEBIAN_BOXES do
+        LogStash::VagrantHelpers.bootstrap(box)
+        exit(RSpec::Core::Runner.run([Rake::FileList["acceptance/spec/debian/**/*_spec.rb"]]))
+        LogStash::VagrantHelpers.destroy(box)
+      end
     end
 
     desc "Run acceptance test in centos machines"
     task :centos do
-      exit(RSpec::Core::Runner.run([Rake::FileList["acceptance/spec/centos/**/*_spec.rb"]]))
+      for box in LogStash::VagrantHelpers::DEFAULT_CENTOS_BOXES do
+        LogStash::VagrantHelpers.bootstrap(box)
+        exit(RSpec::Core::Runner.run([Rake::FileList["acceptance/spec/centos/**/*_spec.rb"]]))
+        LogStash::VagrantHelpers.destroy(box)
+      end
     end
 
     desc "Run one single machine acceptance test"
     task :single, :machine do  |t, args|
-      ENV['LS_VAGRANT_HOST'] = args[:machine]
-      platform = LogStash::VagrantHelpers.translate(args[:machine])
-      exit(RSpec::Core::Runner.run([Rake::FileList["acceptance/spec/**/*_spec.rb"]]))
+      machine = args[:machine]
+      ENV['LS_VAGRANT_HOST'] = machine
+      LogStash::VagrantHelpers.bootstrap(machine)
+      if LogStash::VagrantHelpers::DEFAULT_DEBIAN_BOXES.include? machine 
+        platform = "debian"
+      elsif LogStash::VagrantHelpers::DEFAULT_CENTOS_BOXES.include? machine
+        platform = "centos"
+      end
+      exit(RSpec::Core::Runner.run([Rake::FileList["acceptance/spec/#{platform}/**/*_spec.rb"]]))
     end
   end
 end

--- a/qa/acceptance/Vagrantfile
+++ b/qa/acceptance/Vagrantfile
@@ -1,0 +1,43 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+
+  config.vm.define "ubuntu-1204" do |machine|
+    machine.vm.box = "elastic/ubuntu-12.04-x86_64"
+    common_config(machine, "ubuntu")
+  end
+
+  config.vm.define "ubuntu-1404" do |machine|
+    machine.vm.box = "elastic/ubuntu-14.04-x86_64"
+    common_config(machine, "ubuntu")
+  end
+
+  config.vm.define "centos-6" do |machine|
+    machine.vm.box = "elastic/centos-6-x86_64"
+    common_config(machine, "ubuntu")
+  end
+
+  config.vm.define "centos-7" do |machine|
+    machine.vm.box = "elastic/centos-7-x86_64"
+    common_config(machine, "ubuntu")
+  end
+
+end
+
+def common_config(machine, type)
+  machine.vm.provider "virtualbox" do |v|
+    v.memory = 4096
+    v.cpus = 4
+  end
+  machine.vm.synced_folder "../../build", "/logstash-build", create: true
+  machine.vm.provision :shell do |sh|
+    sh.path = "sys/#{type}/bootstrap.sh"
+    sh.privileged = true
+  end
+
+  machine.vm.provision :shell do |sh|
+    sh.path = "sys/#{type}/user_bootstrap.sh"
+    sh.privileged = false
+  end
+end

--- a/qa/acceptance/Vagrantfile
+++ b/qa/acceptance/Vagrantfile
@@ -27,8 +27,8 @@ end
 
 def common_config(machine, type)
   machine.vm.provider "virtualbox" do |v|
-    v.memory = 4096
-    v.cpus = 4
+    v.memory = 2048
+    v.cpus = 3
   end
   machine.vm.synced_folder "../../build", "/logstash-build", create: true
   machine.vm.provision :shell do |sh|

--- a/qa/acceptance/spec/centos/lib/install_spec.rb
+++ b/qa/acceptance/spec/centos/lib/install_spec.rb
@@ -1,0 +1,33 @@
+# encoding: utf-8
+require_relative '../spec_helper'
+require          'logstash/version'
+
+describe "artifacts", :platform => :centos do
+
+  shared_examples "installable" do |host, name|
+
+    before(:each) do
+      install("/logstash-build/logstash-#{LOGSTASH_VERSION}.noarch.rpm", host)
+    end
+
+    it "is installed on #{name}" do
+      expect("logstash").to be_installed.on(host)
+    end
+
+    it "is running in #{name}" do
+      start_service("logstash", host)
+      expect("logstash").to be_running.on(host)
+      stop_service("logstash", host)
+    end
+
+    it "is removable on #{name}" do
+      uninstall("logstash", host)
+      expect("logstash").to be_removed.on(host)
+    end
+  end
+
+  config = ServiceTester.configuration
+  config.servers.each do |host|
+    it_behaves_like "installable", host, config.lookup[host]
+  end
+end

--- a/qa/acceptance/spec/centos/spec_helper.rb
+++ b/qa/acceptance/spec/centos/spec_helper.rb
@@ -1,0 +1,15 @@
+# encoding: utf-8
+require_relative '../spec_helper'
+
+def default_vagrant_boxes
+  [
+    "centos-6",
+    "centos-7"
+  ]
+end
+
+selected_boxes = SpecsHelper.find_selected_boxes(default_vagrant_boxes)
+
+SpecsHelper.configure(selected_boxes)
+
+puts "[Acceptance specs] running on #{ServiceTester.configuration.lookup.values}" if !selected_boxes.empty?

--- a/qa/acceptance/spec/centos/spec_helper.rb
+++ b/qa/acceptance/spec/centos/spec_helper.rb
@@ -1,14 +1,8 @@
 # encoding: utf-8
 require_relative '../spec_helper'
 
-def default_vagrant_boxes
-  [
-    "centos-6",
-    "centos-7"
-  ]
-end
 
-selected_boxes = SpecsHelper.find_selected_boxes(default_vagrant_boxes)
+selected_boxes = SpecsHelper.find_selected_boxes(LogStash::VagrantHelpers::DEFAULT_CENTOS_BOXES)
 
 SpecsHelper.configure(selected_boxes)
 

--- a/qa/acceptance/spec/config_helper.rb
+++ b/qa/acceptance/spec/config_helper.rb
@@ -1,0 +1,28 @@
+# encoding: utf-8
+require "json"
+
+module SpecsHelper
+
+  def self.find_selected_boxes(default_boxes=[])
+    if ENV.include?('LS_VAGRANT_HOST') then
+      default_boxes.include?(ENV['LS_VAGRANT_HOST']) ? ENV['LS_VAGRANT_HOST'] : []
+    else
+      default_boxes
+    end
+  end
+
+  def self.configure(vagrant_boxes)
+    setup_config = JSON.parse(File.read(".vm_ssh_config"))
+    ServiceTester.configure do |config|
+      config.servers = []
+      config.lookup  = {}
+      setup_config.each do |host_info|
+        next unless vagrant_boxes.include?(host_info["host"])
+        url = "#{host_info["hostname"]}:#{host_info["port"]}"
+        config.servers << url
+        config.lookup[url] = host_info["host"]
+      end
+    end
+  end
+
+end

--- a/qa/acceptance/spec/debian/lib/install_spec.rb
+++ b/qa/acceptance/spec/debian/lib/install_spec.rb
@@ -1,0 +1,33 @@
+# encoding: utf-8
+require_relative '../spec_helper'
+require          'logstash/version'
+
+describe "artifacts", :platform => :debian do
+
+  shared_examples "installable" do |host, name|
+
+    before(:each) do
+      install("/logstash-build/logstash-#{LOGSTASH_VERSION}_all.deb", host)
+    end
+
+    it "is installed on #{name}" do
+      expect("logstash").to be_installed.on(host)
+    end
+
+    it "is running on #{name}" do
+      start_service("logstash", host)
+      expect("logstash").to be_running.on(host)
+      stop_service("logstash", host)
+    end
+
+    it "is removable on #{name}" do
+      uninstall("logstash", host)
+      expect("logstash").to be_removed.on(host)
+    end
+  end
+
+  config = ServiceTester.configuration
+  config.servers.each do |host|
+    it_behaves_like "installable", host, config.lookup[host]
+  end
+end

--- a/qa/acceptance/spec/debian/spec_helper.rb
+++ b/qa/acceptance/spec/debian/spec_helper.rb
@@ -1,0 +1,15 @@
+# encoding: utf-8
+require_relative '../spec_helper'
+
+def default_vagrant_boxes
+  [
+    "ubuntu-1204",
+    "ubuntu-1404"
+  ]
+end
+
+selected_boxes = SpecsHelper.find_selected_boxes(default_vagrant_boxes)
+
+SpecsHelper.configure(selected_boxes)
+
+puts "[Acceptance specs] running on #{ServiceTester.configuration.lookup.values}" if !selected_boxes.empty?

--- a/qa/acceptance/spec/debian/spec_helper.rb
+++ b/qa/acceptance/spec/debian/spec_helper.rb
@@ -1,14 +1,7 @@
 # encoding: utf-8
 require_relative '../spec_helper'
 
-def default_vagrant_boxes
-  [
-    "ubuntu-1204",
-    "ubuntu-1404"
-  ]
-end
-
-selected_boxes = SpecsHelper.find_selected_boxes(default_vagrant_boxes)
+selected_boxes = SpecsHelper.find_selected_boxes(LogStash::VagrantHelpers::DEFAULT_DEBIAN_BOXES)
 
 SpecsHelper.configure(selected_boxes)
 

--- a/qa/acceptance/spec/spec_helper.rb
+++ b/qa/acceptance/spec/spec_helper.rb
@@ -1,0 +1,14 @@
+# encoding: utf-8
+require 'runner-tool'
+require_relative '../../rspec/helpers'
+require_relative '../../rspec/matchers'
+require_relative 'config_helper'
+
+ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..'))
+$LOAD_PATH.unshift File.join(ROOT, 'logstash-core/lib')
+
+RunnerTool.configure
+
+RSpec.configure do |c|
+  c.include ServiceTester
+end

--- a/qa/acceptance/spec/spec_helper.rb
+++ b/qa/acceptance/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 require 'runner-tool'
 require_relative '../../rspec/helpers'
 require_relative '../../rspec/matchers'
+require_relative '../../vagrant-helpers'
 require_relative 'config_helper'
 
 ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..'))

--- a/qa/acceptance/sys/centos/bootstrap.sh
+++ b/qa/acceptance/sys/centos/bootstrap.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+yum update
+yum install -y java-1.8.0-openjdk-devel.x86_64
+
+##
+# Install logstash manually from a URL
+##
+BRANCH=${LOGSTASH_BRANCH:-'master'}
+BUILD_URL='https://s3-eu-west-1.amazonaws.com/build-eu.elasticsearch.org/logstash'
+URL="$BUILD_URL/$BRANCH/nightly/JDK8/logstash-latest-SNAPSHOT.rpm"
+wget --no-verbose $URL

--- a/qa/acceptance/sys/centos/user_bootstrap.sh
+++ b/qa/acceptance/sys/centos/user_bootstrap.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+cd
+wget --no-verbose https://download.elastic.co/logstash/logstash/packages/centos/logstash-2.3.1-1.noarch.rpm

--- a/qa/acceptance/sys/ubuntu/bootstrap.sh
+++ b/qa/acceptance/sys/ubuntu/bootstrap.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+apt-get update
+apt-get install -y openjdk-7-jdk
+
+##
+# Install logstash manually from a URL
+##
+BRANCH=${LOGSTASH_BRANCH:-'master'}
+BUILD_URL='https://s3-eu-west-1.amazonaws.com/build-eu.elasticsearch.org/logstash'
+URL="$BUILD_URL/$BRANCH/nightly/JDK8/logstash-latest-SNAPSHOT.deb"
+wget --no-verbose $URL

--- a/qa/acceptance/sys/ubuntu/user_bootstrap.sh
+++ b/qa/acceptance/sys/ubuntu/user_bootstrap.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+cd
+wget --no-verbose https://download.elastic.co/logstash/logstash/packages/debian/logstash_2.3.1-1_all.deb

--- a/qa/rspec/centos/commands.rb
+++ b/qa/rspec/centos/commands.rb
@@ -1,0 +1,58 @@
+# encoding: utf-8
+module ServiceTester
+  class CentosCommands
+
+    def installed?(hosts, package)
+      stdout = ""
+      at(hosts, {in: :serial}) do |host|
+        cmd = exec!("yum list installed  #{package}")
+        stdout = cmd.stdout
+      end
+      stdout.match(/^Installed Packages$/)
+      stdout.match(/^logstash.noarch/)
+    end
+
+    def install(package, host=nil)
+      hosts  = (host.nil? ? servers : Array(host))
+      errors = {}
+      at(hosts, {in: :serial}) do |_host|
+        cmd = sudo_exec!("yum install -y  #{package}")
+        errors[_host] = cmd.stderr unless cmd.stderr.empty?
+      end
+      errors
+    end
+
+    def uninstall(package, host=nil)
+      hosts = (host.nil? ? servers : Array(host))
+      at(hosts, {in: :serial}) do |_|
+        sudo_exec!("yum remove -y #{package}")
+      end
+    end
+
+    def removed?(hosts, package)
+      stdout = ""
+      at(hosts, {in: :serial}) do |host|
+        cmd = sudo_exec!("yum list installed #{package}")
+        stdout = cmd.stderr
+      end
+      stdout.match(/^Error: No matching Packages to list$/)
+    end
+
+    def running?(hosts, package)
+      stdout = ""
+      at(hosts, {in: :serial}) do |host|
+        cmd = sudo_exec!("service #{package} status")
+        stdout = cmd.stdout
+      end
+      stdout.match(/^#{package} is running$/)
+    end
+
+    def service_manager(service, action, host=nil)
+      hosts = (host.nil? ? servers : Array(host))
+      at(hosts, {in: :serial}) do |host|
+        sudo_exec!("service #{service} #{action}")
+      end
+    end
+
+  end
+end

--- a/qa/rspec/commands.rb
+++ b/qa/rspec/commands.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+require_relative "./debian/commands"
+require_relative "./centos/commands"
+
+module ServiceTester
+  class CommandsFactory
+
+    def self.fetch(type)
+      case type
+      when :debian
+        return DebianCommands.new
+      when :centos
+        return CentosCommands.new
+      else
+        return
+      end
+    end
+  end
+end

--- a/qa/rspec/debian/commands.rb
+++ b/qa/rspec/debian/commands.rb
@@ -1,0 +1,59 @@
+# encoding: utf-8
+module ServiceTester
+  class DebianCommands
+
+    def installed?(hosts, package)
+      stdout = ""
+      at(hosts, {in: :serial}) do |host|
+        cmd = sudo_exec!("dpkg -s  #{package}")
+        stdout = cmd.stdout
+      end
+      stdout.match(/^Package: #{package}$/)
+      stdout.match(/^Status: install ok installed$/)
+    end
+
+    def install(package, host=nil)
+      hosts = (host.nil? ? servers : Array(host))
+      at(hosts, {in: :serial}) do |_|
+        sudo_exec!("dpkg -i  #{package}")
+      end
+    end
+
+    def uninstall(package, host=nil)
+      hosts = (host.nil? ? servers : Array(host))
+      at(hosts, {in: :serial}) do |_|
+        sudo_exec!("dpkg -r #{package}")
+        sudo_exec!("dpkg --purge #{package}")
+      end
+    end
+
+    def removed?(hosts, package)
+      stdout = ""
+      at(hosts, {in: :serial}) do |host|
+        cmd = sudo_exec!("dpkg -s #{package}")
+        stdout = cmd.stderr
+      end
+      (
+        stdout.match(/^Package `#{package}' is not installed and no info is available.$/) ||
+        stdout.match(/^dpkg-query: package '#{package}' is not installed and no information is available$/)
+      )
+    end
+
+    def running?(hosts, package)
+      stdout = ""
+      at(hosts, {in: :serial}) do |host|
+        cmd = sudo_exec!("service #{package} status")
+        stdout = cmd.stdout
+      end
+      stdout.match(/^#{package} is running$/)
+    end
+
+    def service_manager(service, action, host=nil)
+      hosts = (host.nil? ? servers : Array(host))
+      at(hosts, {in: :serial}) do |_|
+        sudo_exec!("service #{service} #{action}")
+      end
+    end
+
+  end
+end

--- a/qa/rspec/helpers.rb
+++ b/qa/rspec/helpers.rb
@@ -1,0 +1,50 @@
+# encoding: utf-8
+require_relative "commands"
+
+module ServiceTester
+
+  class Configuration
+    attr_accessor :servers, :lookup
+    def initialize
+      @servers  = []
+      @lookup   = {}
+    end
+  end
+
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configure
+    self.configuration ||= Configuration.new
+    yield(configuration) if block_given?
+  end
+
+  def servers
+    ServiceTester.configuration.servers
+  end
+
+  def install(package, host=nil)
+    select_client.install(package, host)
+  end
+
+  def uninstall(package, host=nil)
+    select_client.uninstall(package, host)
+  end
+
+  def start_service(service, host=nil)
+    select_client.service_manager(service, "start", host)
+  end
+
+  def stop_service(service, host=nil)
+    select_client.service_manager(service, "stop", host)
+  end
+
+  def select_client
+    CommandsFactory.fetch(current_example.metadata[:platform])
+  end
+
+  def current_example
+    RSpec.respond_to?(:current_example) ? RSpec.current_example : self.example
+  end
+end

--- a/qa/rspec/matchers.rb
+++ b/qa/rspec/matchers.rb
@@ -1,0 +1,3 @@
+# encoding: utf-8
+require_relative './matchers/be_installed'
+require_relative './matchers/be_running'

--- a/qa/rspec/matchers/be_installed.rb
+++ b/qa/rspec/matchers/be_installed.rb
@@ -1,0 +1,25 @@
+# encoding: utf-8
+require 'rspec/expectations'
+require_relative '../helpers'
+
+RSpec::Matchers.define :be_installed do
+
+  match do |actual|
+    select_client.installed?([@host], actual)
+  end
+
+  chain :on do |host|
+    @host = host
+  end
+end
+
+RSpec::Matchers.define :be_removed do
+
+  match do |actual|
+    select_client.removed?([@host], actual)
+  end
+
+  chain :on do |host|
+    @host = host
+  end
+end

--- a/qa/rspec/matchers/be_running.rb
+++ b/qa/rspec/matchers/be_running.rb
@@ -1,0 +1,14 @@
+# encoding: utf-8
+require 'rspec/expectations'
+require_relative '../helpers'
+
+RSpec::Matchers.define :be_running do
+
+  match do |actual|
+    select_client.running?([@host], actual)
+  end
+
+  chain :on do |host|
+    @host = host
+  end
+end

--- a/qa/vagrant-helpers.rb
+++ b/qa/vagrant-helpers.rb
@@ -1,0 +1,43 @@
+# encoding: utf-8
+require "open3"
+
+module LogStash
+  class VagrantHelpers
+
+    def self.bootstrap
+      execute("vagrant up")
+    end
+
+    def self.fetch_config
+      execute("vagrant ssh-config")
+    end
+
+    def self.parse(lines)
+      hosts, host = [], {}
+      lines.each do |line|
+        if line.match(/Host\s(.*)$/)
+          host = { :host => line.gsub("Host","").strip }
+        elsif line.match(/HostName\s(.*)$/)
+          host[:hostname] = line.gsub("HostName","").strip
+        elsif line.match(/Port\s(.*)$/)
+          host[:port]     = line.gsub("Port","").strip
+        elsif line.empty?
+          hosts << host
+          host = {}
+        end
+      end
+      hosts << host
+      hosts
+    end
+
+    private
+
+    def self.execute(cmd)
+      Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
+        { :stdout => stdout.read.chomp, :stderr => stderr.read.chomp,
+          :exit_status => wait_thr.value.exitstatus }
+      end
+    end
+
+  end
+end

--- a/qa/vagrant-helpers.rb
+++ b/qa/vagrant-helpers.rb
@@ -1,15 +1,26 @@
 # encoding: utf-8
 require "open3"
+require "json"
 
 module LogStash
   class VagrantHelpers
+    DEFAULT_CENTOS_BOXES = [ "centos-6", "centos-7" ]
+    DEFAULT_DEBIAN_BOXES = [ "ubuntu-1204", "ubuntu-1404"]
 
-    def self.bootstrap
-      execute("vagrant up")
+    def self.bootstrap(box)
+      Dir.chdir("acceptance") do
+        p execute("vagrant up #{box} --provider virtualbox")
+        raw_ssh_config    = execute("vagrant ssh-config")[:stdout].split("\n");
+        parsed_ssh_config = parse(raw_ssh_config)
+        File.write(".vm_ssh_config", parsed_ssh_config.to_json)
+      end
     end
 
-    def self.fetch_config
-      execute("vagrant ssh-config")
+    def self.destroy(box)
+      Dir.chdir("acceptance") do
+        execute("vagrant destroy #{box} -f")
+        File.delete(".vm_ssh_config")
+      end
     end
 
     def self.parse(lines)


### PR DESCRIPTION
My initial attempt at making the acceptance test infra run one virtual-machine at a time, and bootstrap and clean up after itself.