### PR TITLE
make the plugin incompatibility tests less deterministic

### DIFF
--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -82,7 +82,7 @@ describe LogStash::Agent do
         context "with a config that contains reload incompatible plugins" do
           let(:second_pipeline_config) { "input { stdin {} } filter { } output { }" }
 
-          it "does not reload if new config contains reload incompatible plugins" do
+          it "does not upgrade the new config" do
             t = Thread.new { subject.execute }
             sleep 0.01 until subject.running_pipelines? && subject.pipelines.values.first.ready?
             expect(subject).to_not receive(:upgrade_pipeline)
@@ -97,10 +97,10 @@ describe LogStash::Agent do
         context "with a config that does not contain reload incompatible plugins" do
           let(:second_pipeline_config) { "input { generator { } } filter { } output { }" }
 
-          it "does not reload if new config contains reload incompatible plugins" do
+          it "does upgrade the new config" do
             t = Thread.new { subject.execute }
             sleep 0.01 until subject.running_pipelines? && subject.pipelines.values.first.ready?
-            expect(subject).to receive(:upgrade_pipeline)
+            expect(subject).to receive(:upgrade_pipeline).once.and_call_original
             File.open(config_file, "w") { |f| f.puts second_pipeline_config }
             subject.send(:reload_state!)
             sleep 0.1
@@ -136,7 +136,7 @@ describe LogStash::Agent do
         context "with a config that contains reload incompatible plugins" do
           let(:second_pipeline_config) { "input { stdin {} } filter { } output { }" }
 
-          it "does not reload if new config contains reload incompatible plugins" do
+          it "does not upgrade the new config" do
             t = Thread.new { subject.execute }
             sleep 0.01 until subject.running_pipelines? && subject.pipelines.values.first.ready?
             expect(subject).to_not receive(:upgrade_pipeline)
@@ -150,10 +150,10 @@ describe LogStash::Agent do
         context "with a config that does not contain reload incompatible plugins" do
           let(:second_pipeline_config) { "input { generator { } } filter { } output { }" }
 
-          it "does not reload if new config contains reload incompatible plugins" do
+          it "does upgrade the new config" do
             t = Thread.new { subject.execute }
             sleep 0.01 until subject.running_pipelines? && subject.pipelines.values.first.ready?
-            expect(subject).to receive(:upgrade_pipeline).at_least(2).times
+            expect(subject).to receive(:upgrade_pipeline).once.and_call_original
             File.open(config_file, "w") { |f| f.puts second_pipeline_config }
             sleep 0.1
             Stud.stop!(t)


### PR DESCRIPTION
upgrade_pipeline has the nasty side effect of..upgrading the pipeline. This test checks that upgrade_pipeline is called and, since the configuration changed ONCE, upgrade_pipeline should be called ONCE.

When I did the test I relaxed this concern because the expectation of calling a method mocks it. Which means the original isn't called, which means the pipeline isn't upgraded so, in next cycle of reloading, the upgrade is tried again.

By ensuring the method is actually called and performs its side effect, we can deterministically test that upgrade_pipeline should be called once and only once.

fixes https://github.com/elastic/logstash/issues/5160