### PR TITLE
Fixing the vagrant cli error under bundler and a refactor of the vagrant call

### DIFF
--- a/qa/Rakefile
+++ b/qa/Rakefile
@@ -14,7 +14,7 @@ namespace :test do
   task :ssh_config do
     require "json"
     cd "acceptance" do
-      raw_ssh_config    = LogStash::VagrantHelpers.fetch_config[:stdout].split("\n");
+      raw_ssh_config    = LogStash::VagrantHelpers.fetch_config.stdout.split("\n");
       parsed_ssh_config = LogStash::VagrantHelpers.parse(raw_ssh_config)
       File.write("../.vm_ssh_config", parsed_ssh_config.to_json)
     end
@@ -27,7 +27,6 @@ namespace :test do
   end
 
   namespace :acceptance do
-
     desc "Run all acceptance"
     task :all do
       exit(RSpec::Core::Runner.run([Rake::FileList["acceptance/spec/**/*_spec.rb"]]))

--- a/qa/vagrant-helpers.rb
+++ b/qa/vagrant-helpers.rb
@@ -1,11 +1,12 @@
 # encoding: utf-8
 require "open3"
+require "bundler"
 
 module LogStash
-  class VagrantHelpers
+  class CommandExecutor
     class CommandError < StandardError; end
 
-    class ExecuteResponse
+    class CommandResponse
       attr_reader :stdin, :stdout, :stderr, :exitstatus
 
       def initialize(stdin, stdout, stderr, exitstatus)
@@ -20,12 +21,36 @@ module LogStash
       end
     end
 
+    def self.run(cmd)
+      # This block is require to be able to launch a ruby subprocess
+      # that use bundler.
+      Bundler.with_clean_env do
+        Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
+          CommandResponse.new(stdin, stdout.read.chomp, stderr.read.chomp, wait_thr.value.exitstatus)
+        end
+      end
+    end
+
+    # This method will raise an exception if the `CMD`
+    # was not run successfully and will display the content of STDERR
+    def self.run!(cmd)
+      response = run(cmd)
+    
+      unless response.success?
+        raise CommandError, "CMD: #{cmd} STDERR: #{response.stderr}"
+      end
+      response
+    end
+  end
+
+  class VagrantHelpers
+
     def self.bootstrap
-      execute_successfully("vagrant up")
+      CommandExecutor.run!("vagrant up")
     end
 
     def self.fetch_config
-      execute_successfully("vagrant ssh-config")
+      CommandExecutor.run!("vagrant ssh-config")
     end
 
     def self.parse(lines)
@@ -44,23 +69,6 @@ module LogStash
       end
       hosts << host
       hosts
-    end
-
-    private
-
-    def self.execute(cmd)
-      Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
-        ExecuteResponse.new(stdin, stdout.read.chomp, stderr.read.chomp, wait_thr.value.exitstatus)
-      end
-    end
-
-    def self.execute_successfully(cmd)
-      response = execute(cmd)
-    
-      unless response.success?
-        raise CommandError, "CMD: #{cmd} STDERR: #{response.stderr}"
-      end
-      response
     end
   end
 end


### PR DESCRIPTION
Vagrant is a ruby application and use bundler to manager his dependency,
when you invoke this kind of application inside a rake task you have to
clear the environment to make sure the application his able to run his
own dependency and not only the runner dependency.

This PR also introduce a small refactor of the Execution of local
command to allow the command to give better feedback when its actually
failling.

Fixes: #5176