### PR TITLE
Revert #5125 from 2.3

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -226,9 +226,6 @@ namespace "artifact" do
 
     case platform
       when "redhat", "centos"
-        # produce: logstash-5.0.0-alpha1.noarch.rpm
-        package_filename = "logstash-#{LOGSTASH_VERSION}.ARCH.TYPE"
-
         File.join(basedir, "pkg", "logrotate.conf").tap do |path|
           dir.input("#{path}=/etc/logrotate.d/logstash")
         end
@@ -248,9 +245,6 @@ namespace "artifact" do
         out.config_files << "etc/logrotate.d/logstash"
         out.config_files << "/etc/init.d/logstash"
       when "debian", "ubuntu"
-        # produce: logstash-5.0.0-alpha1_all.deb"
-        package_filename = "logstash-#{LOGSTASH_VERSION}_ARCH.TYPE"
-
         File.join(basedir, "pkg", "logstash.default").tap do |path|
           dir.input("#{path}=/etc/default/logstash")
         end
@@ -315,7 +309,7 @@ namespace "artifact" do
 
     out.attributes[:force?] = true # overwrite the rpm/deb/etc being created
     begin
-      path = File.join(basedir, "build", out.to_s(package_filename))
+      path = File.join(basedir, "build", out.to_s)
       x = out.output(path)
       puts "Completed: #{path}"
     ensure


### PR DESCRIPTION
Some users may have scripted the download location, so I don't
feel right in breaking this name in a bug fix version. This change should
be documented as breaking, IMO

#5125 introduced:
logstash-2.3.2_all.deb
logstash-2.3.2.tar.gz
logstash-2.3.2.zip
logstash-2.3.2.noarch.rpm

v2.3.1 files:
logstash_2.3.1-1_all.deb
logstash-2.3.2.tar.gz
logstash-2.3.2.zip
logstash-2.3.1-1.noarch.rpm