### PR TITLE
Revert "upgrade to JRuby 1.7.25 and required jruby-openssl 0.9.16 to …"

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "concurrent-ruby", "1.0.0"
   gem.add_runtime_dependency "sinatra", '~> 1.4', '>= 1.4.6'
   gem.add_runtime_dependency 'puma', '~> 2.16', '>= 2.16.0'
-  gem.add_runtime_dependency "jruby-openssl", "0.9.16" # >= 0.9.13 Required to support TLSv1.2
+  gem.add_runtime_dependency "jruby-openssl", "0.9.13" # Required to support TLSv1.2
   gem.add_runtime_dependency "chronic_duration", "0.10.6"
   gem.add_runtime_dependency "jruby-monitoring", '~> 0.3.1'
 

--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -1,6 +1,6 @@
 namespace "vendor" do
   VERSIONS = {
-    "jruby" => { "version" => "1.7.25", "sha1" => "cd15aef419f97cff274491e53fcfb8b88ec36785" },
+    "jruby" => { "version" => "1.7.23", "sha1" => "2b5e796feeed2bcfab02f8bf2ff3d77ca318e310" },
   }
 
   def vendor(*args)


### PR DESCRIPTION
This reverts commit 5de3ce40d1c2f12395ecee4685ca98fa7b206032, that introduced a problem, still to be researched more in deep, see issue description at #5179 for all redhat based distros.

This PR is being generated to be merged just in case we don't get a proper fix soon enough for the next release. As a matter of fact, this has been the minim necessary rollback.