### PR TITLE
Set the HEAP Size to 1gig when running rake tasks

### DIFF
--- a/ci/ci_integration.sh
+++ b/ci/ci_integration.sh
@@ -1,3 +1,9 @@
 #!/bin/sh
+
+# Since we are using the system jruby, we need to make sure our jvm process
+# uses at least 1g of memory, If we don't do this we can get OOM issues when
+# installing gems. See https://github.com/elastic/logstash/issues/5179
+export JRUBY_OPTS="-J-Xmx1g"
+
 rake test:install-default
 rake test:integration

--- a/ci/ci_setup.sh
+++ b/ci/ci_setup.sh
@@ -13,6 +13,11 @@ rm -rf vendor       # make sure there are no vendorized dependencies
 rm -rf .bundle
 rm -rf spec/reports # no stale spec reports from previous executions
 
+# Since we are using the system jruby, we need to make sure our jvm process
+# uses at least 1g of memory, If we don't do this we can get OOM issues when
+# installing gems. See https://github.com/elastic/logstash/issues/5179
+export JRUBY_OPTS="-J-Xmx1g"
+
 # Setup the environment
 rake bootstrap # Bootstrap your logstash instance
 

--- a/ci/ci_test.sh
+++ b/ci/ci_test.sh
@@ -5,6 +5,11 @@
 # running the test suites here.
 ##
 
+# Since we are using the system jruby, we need to make sure our jvm process
+# uses at least 1g of memory, If we don't do this we can get OOM issues when
+# installing gems. See https://github.com/elastic/logstash/issues/5179
+export JRUBY_OPTS="-J-Xmx1g"
+
 SELECTED_TEST_SUITE=$1
 
 if [[ $SELECTED_TEST_SUITE == $"core-fail-fast" ]]; then

--- a/rakelib/z_rubycheck.rake
+++ b/rakelib/z_rubycheck.rake
@@ -32,7 +32,7 @@ if ENV['USE_RUBY'] != '1'
     # if required at this point system gems can be installed using the system_gem task, for example:
     # Rake::Task["vendor:system_gem"].invoke(jruby, "ffi", "1.9.6")
 
-    exec(jruby, "-J-Xmx1024m", "-S", rake, *ARGV)
+    exec(jruby, "-J-Xmx1g", "-S", rake, *ARGV)
   end
 end
 

--- a/rakelib/z_rubycheck.rake
+++ b/rakelib/z_rubycheck.rake
@@ -32,7 +32,7 @@ if ENV['USE_RUBY'] != '1'
     # if required at this point system gems can be installed using the system_gem task, for example:
     # Rake::Task["vendor:system_gem"].invoke(jruby, "ffi", "1.9.6")
 
-    exec(jruby, "-S", rake, *ARGV)
+    exec(jruby, "-J-Xmx1024m", "-S", rake, *ARGV)
   end
 end
 


### PR DESCRIPTION
Logstash uses by default in the shell script 1 gig of memory for the
JVM. but when we use rake it uses the default settings of JRUBY and
start a vm with 500megs of memory. The recent changes in JRUBY and
JRuby-OpenSSL have increased the base memory and make the installing of
plugins fail with a OOM issues. This PR make sure the CI scripts and the rake
jruby launch uses the default of 1gig.

Fixes: #5179