### PR TITLE
bug fix, changed == to =

### DIFF
--- a/pkg/logstash.sysv
+++ b/pkg/logstash.sysv
@@ -97,7 +97,7 @@ stop() {
       sleep 1
     done
     if status ; then
-      if [ "$KILL_ON_STOP_TIMEOUT" == 1 ] ; then
+      if [ "$KILL_ON_STOP_TIMEOUT" = 1 ] ; then
         echo "Timeout reached. Killing $name (pid $pid) with SIGKILL. This may result in data loss."
         kill -KILL $pid
         echo "$name killed with SIGKILL."


### PR DESCRIPTION
double equals only works in BASH, not /bin/sh which may only be a subset of BASH.