### PR TITLE
Remove constant redefinition

### DIFF
--- a/logstash-core/lib/logstash/api/init.ru
+++ b/logstash-core/lib/logstash/api/init.ru
@@ -1,6 +1,6 @@
-ROOT = File.expand_path(File.dirname(__FILE__))
-$LOAD_PATH.unshift File.join(ROOT, 'lib')
-Dir.glob('lib/**').each{ |d| $LOAD_PATH.unshift(File.join(ROOT, d)) }
+api_root = File.expand_path(File.dirname(__FILE__))
+$LOAD_PATH.unshift File.join(api_root, 'lib')
+Dir.glob('lib/**').each{ |d| $LOAD_PATH.unshift(File.join(api_root, d)) }
 
 require 'sinatra'
 require 'app/root'


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

The Rack config was redefining a constant in the configuration, since
this value isn't used anywhere else there was no need to use a constant.

The conflicting ROOT contants was defined in `lib/logstash/patches/profile_require_calls.rb`

Fixes: #5163