### PR TITLE
Add common ci helper script to run acceptance test

### DIFF
--- a/ci/ci_acceptance.sh
+++ b/ci/ci_acceptance.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -e
+
+# Since we are using the system jruby, we need to make sure our jvm process
+# uses at least 1g of memory, If we don't do this we can get OOM issues when
+# installing gems. See https://github.com/elastic/logstash/issues/5179
+export JRUBY_OPTS="-J-Xmx1g"
+
+SELECTED_TEST_SUITE=$1
+
+if [[ $SELECTED_TEST_SUITE == $"centos" ]]; then
+  rake artifact:rpm
+  echo "Acceptance: Installing dependencies"
+  cd qa
+  bundle install
+
+  echo "Acceptance: Running the tests"
+  bundle exec rake test:setup
+  bundle exec rake test:ssh_config
+  bundle exec rake test:acceptance:centos
+elif [[ $SELECTED_TEST_SUITE == $"debian" ]]; then
+  rake artifact:deb
+  echo "Acceptance: Installing dependencies"
+  cd qa
+  bundle install
+
+  echo "Acceptance: Running the tests"
+  bundle exec rake test:setup
+  bundle exec rake test:ssh_config
+  bundle exec rake test:acceptance:debian
+elif [[ $SELECTED_TEST_SUITE == $"all" ]]; then
+  echo "Building Logstash artifacts"
+  rake artifact:all
+
+  echo "Acceptance: Installing dependencies"
+  cd qa
+  bundle install
+
+  echo "Acceptance: Running the tests"
+  bundle exec rake test:setup
+  bundle exec rake test:ssh_config
+  bundle exec rake test:acceptance:all
+  cd ..
+fi

--- a/ci/ci_acceptance.sh
+++ b/ci/ci_acceptance.sh
@@ -9,6 +9,7 @@ export JRUBY_OPTS="-J-Xmx1g"
 SELECTED_TEST_SUITE=$1
 
 if [[ $SELECTED_TEST_SUITE == $"centos" ]]; then
+  echo "Generating the RPM, make sure you start with a clean environment before generating other packages."
   rake artifact:rpm
   echo "Acceptance: Installing dependencies"
   cd qa
@@ -19,6 +20,7 @@ if [[ $SELECTED_TEST_SUITE == $"centos" ]]; then
   bundle exec rake test:ssh_config
   bundle exec rake test:acceptance:centos
 elif [[ $SELECTED_TEST_SUITE == $"debian" ]]; then
+  echo "Generating the DEB, make sure you start with a clean environment before generating other packages."
   rake artifact:deb
   echo "Acceptance: Installing dependencies"
   cd qa

--- a/qa/README.md
+++ b/qa/README.md
@@ -6,6 +6,11 @@ follow to setup your environment.
 
 ### Environment setup and Running Tests
 
+It is possible to run the full suite of the acceptance test with the codebase by 
+running the command `ci/ci_acceptance.sh`, this command will generate the artefacts, bootstrap
+the VM and run the tests.
+
+
 This test are based on a collection of Vagrant defined VM's where the
 different test are going to be executed, so first setup necessary is to
 have vagrant properly available, see https://www.vagrantup.com/ for

--- a/qa/Rakefile
+++ b/qa/Rakefile
@@ -15,7 +15,7 @@ namespace :test do
     require "json"
     raw_ssh_config    = LogStash::VagrantHelpers.fetch_config.stdout.split("\n");
     parsed_ssh_config = LogStash::VagrantHelpers.parse(raw_ssh_config)
-    File.write(".vm_ssh_config", parsed_ssh_config.to_json)
+    File.write(File.join(File.dirname(__FILE__), ".vm_ssh_config"), parsed_ssh_config.to_json)
   end
 
   desc "Bootstrap all the VM's used for this tests"

--- a/qa/Vagrantfile
+++ b/qa/Vagrantfile
@@ -12,15 +12,10 @@ Vagrant.configure(2) do |config|
         v.memory = 2096
         v.cpus = 4
       end
-      machine.vm.synced_folder "../../build", "/logstash-build", create: true
+      machine.vm.synced_folder "../build", "/logstash-build", create: true
       machine.vm.provision :shell do |sh|
         sh.path = "sys/#{platform.type}/bootstrap.sh"
         sh.privileged = true
-      end
-
-      machine.vm.provision :shell do |sh|
-        sh.path = "sys/#{platform.type}/user_bootstrap.sh"
-        sh.privileged = false
       end
     end
   end

--- a/qa/acceptance/spec/centos/lib/install_spec.rb
+++ b/qa/acceptance/spec/centos/lib/install_spec.rb
@@ -1,13 +1,13 @@
 # encoding: utf-8
-require_relative '../spec_helper'
-require          'logstash/version'
+require_relative "../spec_helper"
+require "logstash/version"
 
 describe "artifacts", :platform => :centos do
 
   shared_examples "installable" do |host, name|
 
     before(:each) do
-      install("/home/vagrant/logstash-latest-SNAPSHOT.rpm", host)
+      install("/logstash-build/logstash-#{LOGSTASH_VERSION}.noarch.rpm", host)
     end
 
     it "is installed on #{name}" do

--- a/qa/acceptance/spec/config_helper.rb
+++ b/qa/acceptance/spec/config_helper.rb
@@ -12,7 +12,8 @@ module SpecsHelper
   end
 
   def self.configure(vagrant_boxes)
-    setup_config = JSON.parse(File.read(".vm_ssh_config"))
+    setup_config = JSON.parse(File.read(File.join(File.dirname(__FILE__), "..", "..", ".vm_ssh_config")))
+
     ServiceTester.configure do |config|
       config.servers = []
       config.lookup  = {}
@@ -24,5 +25,4 @@ module SpecsHelper
       end
     end
   end
-
 end

--- a/qa/acceptance/spec/debian/lib/install_spec.rb
+++ b/qa/acceptance/spec/debian/lib/install_spec.rb
@@ -1,13 +1,13 @@
 # encoding: utf-8
-require_relative '../spec_helper'
-require          'logstash/version'
+require_relative "../spec_helper"
+require "logstash/version"
 
 describe "artifacts", :platform => :debian do
 
   shared_examples "installable" do |host, name|
 
     before(:each) do
-      install("/home/vagrant/logstash-latest-SNAPSHOT.deb", host)
+      install("/logstash-build/logstash-#{LOGSTASH_VERSION}_all.deb", host)
     end
 
     it "is installed on #{name}" do

--- a/qa/sys/centos/bootstrap.sh
+++ b/qa/sys/centos/bootstrap.sh
@@ -2,11 +2,3 @@
 
 yum update
 yum install -y java-1.8.0-openjdk-devel.x86_64
-
-##
-# Install logstash manually from a URL
-##
-BRANCH=${LOGSTASH_BRANCH:-'master'}
-BUILD_URL='https://s3-eu-west-1.amazonaws.com/build-eu.elasticsearch.org/logstash'
-URL="$BUILD_URL/$BRANCH/nightly/JDK8/logstash-latest-SNAPSHOT.rpm"
-wget --no-verbose $URL

--- a/qa/sys/centos/user_bootstrap.sh
+++ b/qa/sys/centos/user_bootstrap.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-cd
-wget --no-verbose https://download.elastic.co/logstash/logstash/packages/centos/logstash-2.3.1-1.noarch.rpm

--- a/qa/sys/debian/bootstrap.sh
+++ b/qa/sys/debian/bootstrap.sh
@@ -2,11 +2,3 @@
 
 apt-get update
 apt-get install -y openjdk-7-jdk
-
-##
-# Install logstash manually from a URL
-##
-BRANCH=${LOGSTASH_BRANCH:-'master'}
-BUILD_URL='https://s3-eu-west-1.amazonaws.com/build-eu.elasticsearch.org/logstash'
-URL="$BUILD_URL/$BRANCH/nightly/JDK8/logstash-latest-SNAPSHOT.deb"
-wget --no-verbose $URL

--- a/qa/sys/debian/user_bootstrap.sh
+++ b/qa/sys/debian/user_bootstrap.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-cd
-wget --no-verbose https://download.elastic.co/logstash/logstash/packages/debian/logstash_2.3.1-1_all.deb

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -53,6 +53,20 @@ namespace "artifact" do
     end.flatten.uniq
   end
 
+  task "all" => ["prepare"] do
+    Rake::Task["artifact:deb"].invoke
+    Rake::Task["artifact:rpm"].invoke
+    Rake::Task["artifact:zip"].invoke
+    Rake::Task["artifact:tar"].invoke
+  end
+
+  task "all-all-plugins" => ["prepare-all"] do
+    Rake::Task["artifact:deb"].invoke
+    Rake::Task["artifact:rpm"].invoke
+    Rake::Task["artifact:zip"].invoke
+    Rake::Task["artifact:tar"].invoke
+  end
+
   # We create an empty bundle config file
   # This will allow the deb and rpm to create a file
   # with the correct user group and permission.
@@ -120,6 +134,7 @@ namespace "artifact" do
   end
 
   task "prepare" => ["bootstrap", "plugin:install-default", "install-logstash-core", "install-logstash-core-event", "install-logstash-core-plugin-api", "clean-bundle-config"]
+
   task "prepare-all" => ["bootstrap", "plugin:install-all", "install-logstash-core", "install-logstash-core-event", "install-logstash-core-plugin-api", "clean-bundle-config"]
 
   desc "Build a tar.gz of default logstash plugins with all dependencies"


### PR DESCRIPTION
This change introduce a new command ci/ci_acceptance which is
responsable of building the packages, bootstraping the acceptance test
environment, launching the VMs and running the tests.

You can use the following command to target specific platform.

```
ci/ci_acceptance.sh all
ci/ci_acceptance.sh centos
ci/ci_acceptance.sh debian
```

This PR also add a new rake task to build all the artifacts in a single
run called rake artifact:all it make sure we only install the plugin
only once and make the build process faster.

Fixes: #5212
