### PR TITLE
add --preserve option to plugin install

### DIFF
--- a/lib/pluginmanager/install.rb
+++ b/lib/pluginmanager/install.rb
@@ -9,6 +9,7 @@ class LogStash::PluginManager::Install < LogStash::PluginManager::Command
   parameter "[PLUGIN] ...", "plugin name(s) or file", :attribute_name => :plugins_arg
   option "--version", "VERSION", "version of the plugin to install"
   option "--[no-]verify", :flag, "verify plugin validity before installation", :default => true
+  option "--preserve", :flag, "preserve current gem options", :default => false
   option "--development", :flag, "install all development dependencies of currently installed plugins", :default => false
   option "--local", :flag, "force local-only plugin installation. see bin/logstash-plugin package|unpack", :default => false
 
@@ -90,7 +91,15 @@ class LogStash::PluginManager::Install < LogStash::PluginManager::Command
 
     # Add plugins/gems to the current gemfile
     puts("Installing" + (install_list.empty? ? "..." : " " + install_list.collect(&:first).join(", ")))
-    install_list.each { |plugin, version, options| gemfile.update(plugin, version, options) }
+    install_list.each do |plugin, version, options|
+      if preserve?
+        plugin_gem = gemfile.find(plugin)
+        puts("Preserving Gemfile gem options for plugin #{plugin}") if plugin_gem && !plugin_gem.options.empty?
+        gemfile.update(plugin, version, options)
+      else
+        gemfile.overwrite(plugin, version, options)
+      end
+    end
 
     # Sync gemfiles changes to disk to make them available to the `bundler install`'s API
     gemfile.save

--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -10,7 +10,7 @@ namespace "plugin" do
 
   task "install-development-dependencies" do
     puts("[plugin:install-development-dependencies] Installing development dependencies of all installed plugins")
-    install_plugins("--development")
+    install_plugins("--development",  "--preserve")
 
     task.reenable # Allow this task to be run again
   end
@@ -18,35 +18,35 @@ namespace "plugin" do
   task "install", :name do |task, args|
     name = args[:name]
     puts("[plugin:install] Installing plugin: #{name}")
-    install_plugins("--no-verify", name)
+    install_plugins("--no-verify", "--preserve", name)
 
     task.reenable # Allow this task to be run again
   end # task "install"
 
   task "install-default" do
     puts("[plugin:install-default] Installing default plugins")
-    install_plugins("--no-verify", *LogStash::RakeLib::DEFAULT_PLUGINS)
+    install_plugins("--no-verify", "--preserve", *LogStash::RakeLib::DEFAULT_PLUGINS)
 
     task.reenable # Allow this task to be run again
   end
 
   task "install-core" do
     puts("[plugin:install-core] Installing core plugins")
-    install_plugins("--no-verify", *LogStash::RakeLib::CORE_SPECS_PLUGINS)
+    install_plugins("--no-verify", "--preserve", *LogStash::RakeLib::CORE_SPECS_PLUGINS)
 
     task.reenable # Allow this task to be run again
   end
 
   task "install-jar-dependencies" do
     puts("[plugin:install-jar-dependencies] Installing jar_dependencies plugins for testing")
-    install_plugins("--no-verify", *LogStash::RakeLib::TEST_JAR_DEPENDENCIES_PLUGINS)
+    install_plugins("--no-verify", "--preserve", *LogStash::RakeLib::TEST_JAR_DEPENDENCIES_PLUGINS)
 
     task.reenable # Allow this task to be run again
   end
 
   task "install-vendor" do
     puts("[plugin:install-jar-dependencies] Installing vendor plugins for testing")
-    install_plugins("--no-verify", *LogStash::RakeLib::TEST_VENDOR_PLUGINS)
+    install_plugins("--no-verify", "--preserve", *LogStash::RakeLib::TEST_VENDOR_PLUGINS)
 
     task.reenable # Allow this task to be run again
   end
@@ -59,7 +59,7 @@ namespace "plugin" do
     # TODO Push this downstream to #install_plugins
     p.each do |plugin|
       begin
-        install_plugins("--no-verify", plugin)
+        install_plugins("--no-verify", "--preserve", plugin)
       rescue
         puts "Unable to install #{plugin}. Skipping"
         next


### PR DESCRIPTION
Allow using the `--preserve` option to the plugin install command to preserve any current gem options in the `Gemfile` for the installation of a plugin gem which is already in the `Gemfile`.

This is required by #5170 to support specifying plugin gems from a github repo/branch in the `Gemfile`. I believe this will also help avoiding the unnecessary publication of core plugins snapshots.

Ultimately this allows running the rake test:install* command by keeping current `Gemfile` gems options, for example a custom in-dev `:path` option, instead of overwriting them and forcing the use of the published gem.

