### PR TITLE
Fixes exceptional random issues with the JVM memory api detected during test

### DIFF
--- a/logstash-core/lib/logstash/api/lib/app/commands/stats/memory_command.rb
+++ b/logstash-core/lib/logstash/api/lib/app/commands/stats/memory_command.rb
@@ -5,20 +5,39 @@ require 'monitoring'
 class LogStash::Api::JvmMemoryCommand < LogStash::Api::Command
 
   def run
+    report = { :pools => {} }
     memory = LogStash::Json.load(service.get(:jvm_memory_stats))
-    {
-      :heap_used_in_bytes => memory["heap"]["used_in_bytes"],
-      :heap_used_percent => memory["heap"]["used_percent"],
-      :heap_committed_in_bytes => memory["heap"]["committed_in_bytes"],
-      :heap_max_in_bytes => memory["heap"]["max_in_bytes"],
-      :heap_used_in_bytes => memory["heap"]["used_in_bytes"],
-      :non_heap_used_in_bytes => memory["non_heap"]["used_in_bytes"],
-      :non_heap_committed_in_bytes => memory["non_heap"]["committed_in_bytes"],
-      :pools => memory["pools"].inject({}) do |acc, (type, hash)|
-          hash.delete("committed_in_bytes")
-          acc[type] = hash
-          acc
+
+    report.merge!(add_heap_report_data_using(memory))    if memory.keys.include?("heap")
+    report.merge!(add_nonheap_report_data_using(memory)) if memory.keys.include?("non_heap")
+    report[:pools].merge!(add_pools_data_using(memory))  if memory.keys.include?("pools")
+    report
+  end
+
+  private
+
+  def add_pools_data_using(memory)
+    memory["pools"].inject({}) do |acc, (type, hash)|
+      hash.delete("committed_in_bytes")
+      acc[type] = hash
+      acc
     end
+  end
+
+  def add_nonheap_report_data_using(memory)
+    {
+      :non_heap_used_in_bytes      => memory["non_heap"]["used_in_bytes"],
+      :non_heap_committed_in_bytes => memory["non_heap"]["committed_in_bytes"],
+    }
+  end
+
+  def add_heap_report_data_using(memory)
+    {
+      :heap_used_in_bytes      => memory["heap"]["used_in_bytes"],
+      :heap_used_percent       => memory["heap"]["used_percent"],
+      :heap_committed_in_bytes => memory["heap"]["committed_in_bytes"],
+      :heap_max_in_bytes       => memory["heap"]["max_in_bytes"],
+      :heap_used_in_bytes      => memory["heap"]["used_in_bytes"],
     }
   end
 


### PR DESCRIPTION
This PR it makes sure only reported data is provided back when using the jvm memory api. More detailed research should be provided to know why in such circumstances this happen, but for now this provided closure to this errors by making sure when for example non _"non_heap"_ memory information is provided, the expected resource is providing a proper answer.

This error only shows under some circumstances, for example one way to trigger this is by running the test multiple times (heavy load), for example using:

```bash
#!/bin/bash
for i in `seq 1 10`;
do
  rake test:core
  if [ "$?" -gt "0" ]
  then
    exit $?
  fi
done 
```

Fixes #5161

A follow up issue should be created, if agreed, to properly understand when this happen inside the JVM.