### PR TITLE
Remove oldlogstashjson from the default plugin list

### DIFF
--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -19,7 +19,6 @@ module LogStash
       logstash-codec-msgpack
       logstash-codec-multiline
       logstash-codec-netflow
-      logstash-codec-oldlogstashjson
       logstash-codec-plain
       logstash-codec-rubydebug
       logstash-filter-anonymize


### PR DESCRIPTION
This plugins was used to migrate from logstash json schema 0 to 1.