### PR TITLE
Update default plugins for 5.0

### DIFF
--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -4,7 +4,6 @@ module LogStash
     # plugins included by default in the logstash distribution
     DEFAULT_PLUGINS = %w(
       logstash-input-heartbeat
-      logstash-output-zeromq
       logstash-codec-collectd
       logstash-output-xmpp
       logstash-codec-dots
@@ -18,10 +17,8 @@ module LogStash
       logstash-codec-line
       logstash-codec-msgpack
       logstash-codec-multiline
-      logstash-codec-netflow
       logstash-codec-plain
       logstash-codec-rubydebug
-      logstash-filter-anonymize
       logstash-filter-checksum
       logstash-filter-clone
       logstash-filter-csv
@@ -34,7 +31,6 @@ module LogStash
       logstash-filter-json
       logstash-filter-kv
       logstash-filter-metrics
-      logstash-filter-multiline
       logstash-filter-mutate
       logstash-filter-ruby
       logstash-filter-sleep
@@ -47,7 +43,6 @@ module LogStash
       logstash-filter-xml
       logstash-input-couchdb_changes
       logstash-input-elasticsearch
-      logstash-input-eventlog
       logstash-input-exec
       logstash-input-file
       logstash-input-ganglia
@@ -74,7 +69,6 @@ module LogStash
       logstash-input-udp
       logstash-input-unix
       logstash-input-xmpp
-      logstash-input-zeromq
       logstash-input-kafka
       logstash-input-beats
       logstash-output-cloudwatch
@@ -86,15 +80,11 @@ module LogStash
       logstash-output-ganglia
       logstash-output-gelf
       logstash-output-graphite
-      logstash-output-hipchat
       logstash-output-http
       logstash-output-irc
-      logstash-output-juggernaut
-      logstash-output-lumberjack
       logstash-output-nagios
       logstash-output-nagios_nsca
       logstash-output-null
-      logstash-output-opentsdb
       logstash-output-pagerduty
       logstash-output-pipe
       logstash-output-rabbitmq

--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -17,9 +17,9 @@ module LogStash
       logstash-codec-line
       logstash-codec-msgpack
       logstash-codec-multiline
+      logstash-codec-netflow
       logstash-codec-plain
       logstash-codec-rubydebug
-      logstash-filter-checksum
       logstash-filter-clone
       logstash-filter-csv
       logstash-filter-date
@@ -74,16 +74,12 @@ module LogStash
       logstash-output-cloudwatch
       logstash-output-csv
       logstash-output-elasticsearch
-      logstash-output-email
-      logstash-output-exec
       logstash-output-file
-      logstash-output-ganglia
-      logstash-output-gelf
       logstash-output-graphite
       logstash-output-http
       logstash-output-irc
+      logstash-output-kafka
       logstash-output-nagios
-      logstash-output-nagios_nsca
       logstash-output-null
       logstash-output-pagerduty
       logstash-output-pipe
@@ -96,7 +92,7 @@ module LogStash
       logstash-output-stdout
       logstash-output-tcp
       logstash-output-udp
-      logstash-output-kafka
+      logstash-output-webhdfs
     )
 
     # plugins required to run the logstash core specs


### PR DESCRIPTION
5.0 is a chance for us to review and remove any plugins that we don't have to bundle by default. These plugins are still supported and maintained, but the default package should only contain most popular, most used plugins. 

**Removed plugins:**

logstash-filter-anonymize: Replaced with newer logstash-filter-fingerprint
logstash-input-zeromq/output: Not a lot of users. Most users seem to prefer rabbitmq, redis, kafka as broker
logstash-codec-netflow: not sure about this.
logstash-filter-multiline: deprecated
logstash-output-hipchat: not maintained. Still at v1 of API.
logstash-output-juggernaut: less usage

Please comment if you'd like to remove more/less

/cc @acchen97 @jordansissel 