### PR TITLE
Add more platforms to our Acceptance testing QA layer

### DIFF
--- a/qa/platforms.json
+++ b/qa/platforms.json
@@ -1,6 +1,13 @@
 { 
   "ubuntu-1204": { "box": "elastic/ubuntu-12.04-x86_64", "type": "debian" },
   "ubuntu-1404": { "box": "elastic/ubuntu-14.04-x86_64", "type": "debian" },
+  "ubuntu-1504": { "box": "elastic/ubuntu-15.04-x86_64", "type": "debian" },
   "centos-6": { "box": "elastic/centos-6-x86_64", "type": "redhat" },
-  "centos-7": { "box": "elastic/centos-7-x86_64", "type": "redhat" }
+  "centos-7": { "box": "elastic/centos-7-x86_64", "type": "redhat" },
+  "oel-6": { "box": "elastic/oraclelinux-6-x86_64", "type": "redhat" },
+  "oel-7": { "box": "elastic/oraclelinux-7-x86_64", "type": "redhat" },
+  "fedora-22": { "box": "elastic/fedora-22-x86_64", "type": "redhat" },
+  "debian-8": { "box": "elastic/debian-8-x86_64", "type": "debian" },
+  "opensuse-13": { "box": "elastic/opensuse-13-x86_64", "type": "suse" },
+  "sles-12": { "box": "elastic/sles-12-x86_64", "type": "suse" }
 }

--- a/qa/rspec/commands.rb
+++ b/qa/rspec/commands.rb
@@ -1,6 +1,8 @@
 # encoding: utf-8
 require_relative "./commands/debian"
+require_relative "./commands/ubuntu"
 require_relative "./commands/redhat"
+require_relative "./commands/suse"
 require "forwardable"
 
 module ServiceTester
@@ -13,9 +15,9 @@ module ServiceTester
     attr_reader :host, :client
 
     def initialize(host, options={})
-      @host     = host
-      @options  = options
-      @client = CommandsFactory.fetch(options["type"])
+      @host    = host
+      @options = options
+      @client  = CommandsFactory.fetch(options["type"], options["host"])
     end
 
     def name
@@ -50,10 +52,16 @@ module ServiceTester
 
   class CommandsFactory
 
-    def self.fetch(type)
+    def self.fetch(type, host)
       case type
       when "debian"
-        return DebianCommands.new
+        if host.start_with?("ubuntu")
+          return UbuntuCommands.new
+        else
+          return DebianCommands.new
+        end
+      when "suse"
+        return SuseCommands.new
       when "redhat"
         return RedhatCommands.new
       else

--- a/qa/rspec/commands/suse.rb
+++ b/qa/rspec/commands/suse.rb
@@ -2,47 +2,45 @@
 require_relative "base"
 
 module ServiceTester
-  class DebianCommands < Base
+  class SuseCommands < Base
 
     def installed?(hosts, package)
       stdout = ""
       at(hosts, {in: :serial}) do |host|
-        cmd = sudo_exec!("dpkg -s  #{package}")
+        cmd = exec!("zypper search #{package}")
         stdout = cmd.stdout
       end
-      stdout.match(/^Package: #{package}$/)
-      stdout.match(/^Status: install ok installed$/)
+      stdout.match(/^i | logstash | An extensible logging pipeline | package$/)
     end
 
     def package_for(version)
-      File.join(ServiceTester::Base::LOCATION, "logstash-#{version}_all.deb")
+      File.join(ServiceTester::Base::LOCATION, "logstash-#{version}.noarch.rpm")
     end
 
     def install(package, host=nil)
-      hosts = (host.nil? ? servers : Array(host))
-      at(hosts, {in: :serial}) do |_|
-        sudo_exec!("dpkg -i  #{package}")
+      hosts  = (host.nil? ? servers : Array(host))
+      errors = {}
+      at(hosts, {in: :serial}) do |_host|
+        cmd = sudo_exec!("zypper --no-gpg-checks --non-interactive install  #{package}")
+        errors[_host] = cmd.stderr unless cmd.stderr.empty?
       end
+      errors
     end
 
     def uninstall(package, host=nil)
       hosts = (host.nil? ? servers : Array(host))
       at(hosts, {in: :serial}) do |_|
-        sudo_exec!("dpkg -r #{package}")
-        sudo_exec!("dpkg --purge #{package}")
+        cmd = sudo_exec!("zypper --no-gpg-checks --non-interactive remove #{package}")
       end
     end
 
     def removed?(hosts, package)
       stdout = ""
       at(hosts, {in: :serial}) do |host|
-        cmd = sudo_exec!("dpkg -s #{package}")
-        stdout = cmd.stderr
+        cmd    = exec!("zypper search #{package}")
+        stdout = cmd.stdout
       end
-      (
-        stdout.match(/^Package `#{package}' is not installed and no info is available.$/) ||
-        stdout.match(/^dpkg-query: package '#{package}' is not installed and no information is available$/)
-      )
+      stdout.match(/No packages found/)
     end
 
     def running?(hosts, package)

--- a/qa/rspec/commands/ubuntu.rb
+++ b/qa/rspec/commands/ubuntu.rb
@@ -1,0 +1,17 @@
+# encoding: utf-8
+require_relative "debian"
+
+module ServiceTester
+  class UbuntuCommands < DebianCommands
+
+    def running?(hosts, package)
+      stdout = ""
+      at(hosts, {in: :serial}) do |host|
+        cmd = sudo_exec!("service #{package} status")
+        stdout = cmd.stdout
+      end
+      stdout.match(/^#{package} is running$/)
+    end
+
+  end
+end

--- a/qa/sys/suse/bootstrap.sh
+++ b/qa/sys/suse/bootstrap.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+zypper --non-interactive list-updates
+zypper --non-interactive --no-gpg-checks --quiet install --no-recommends java-1_8_0-openjdk-devel

--- a/qa/vagrant-helpers.rb
+++ b/qa/vagrant-helpers.rb
@@ -58,7 +58,9 @@ module LogStash
     end
 
     def self.fetch_config
-      CommandExecutor.run!("vagrant ssh-config")
+      cmd      = CommandExecutor.run!("vagrant status")
+      machines = cmd.stdout.split("\n").select { |m| m.include?("running") }.map { |s| s.split(" ")[0] }
+      CommandExecutor.run!("vagrant ssh-config #{machines.join(' ')}")
     end
 
     def self.parse(lines)


### PR DESCRIPTION
This PR adds:

* Makes sure the vagrant ssh-config usage is only done with running machines, so it does not complain when executed (Fix an issue)
* Add a more complete list of linux flavors to the QA system, this include latest ubuntu, oel, fedora, debian and suse.