### PR TITLE
Publishing a new set of gem for the 5.0.0-alphas

### DIFF
--- a/logstash-core-event-java/lib/logstash-core-event-java/version.rb
+++ b/logstash-core-event-java/lib/logstash-core-event-java/version.rb
@@ -5,4 +5,4 @@
 # Note to authors: this should not include dashes because 'gem' barfs if
 # you include a dash in the version string.
 
-LOGSTASH_CORE_EVENT_JAVA_VERSION = "5.0.0-alpha2"
+LOGSTASH_CORE_EVENT_JAVA_VERSION = "5.0.0-alpha3.snapshot1"

--- a/logstash-core-plugin-api/lib/logstash-core-plugin-api/version.rb
+++ b/logstash-core-plugin-api/lib/logstash-core-plugin-api/version.rb
@@ -1,3 +1,3 @@
 # encoding: utf-8
 
-LOGSTASH_CORE_PLUGIN_API = "2.0.0"
+LOGSTASH_CORE_PLUGIN_API = "1.14.0"

--- a/logstash-core-plugin-api/logstash-core-plugin-api.gemspec
+++ b/logstash-core-plugin-api/logstash-core-plugin-api.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = LOGSTASH_CORE_PLUGIN_API
 
-  gem.add_runtime_dependency "logstash-core", "5.0.0.alpha2"
+  gem.add_runtime_dependency "logstash-core", "5.0.0.alpha3.snapshot1"
 
   # Make sure we dont build this gem from a non jruby
   # environment.

--- a/logstash-core/lib/logstash-core/version.rb
+++ b/logstash-core/lib/logstash-core/version.rb
@@ -5,4 +5,4 @@
 # Note to authors: this should not include dashes because 'gem' barfs if
 # you include a dash in the version string.
 
-LOGSTASH_CORE_VERSION = "5.0.0-alpha2"
+LOGSTASH_CORE_VERSION = "5.0.0-alpha3.snapshot1"

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = LOGSTASH_CORE_VERSION.gsub(/-/, '.')
 
-  gem.add_runtime_dependency "logstash-core-event-java", "~> 5.0.0.alpha2"
+  gem.add_runtime_dependency "logstash-core-event-java", "5.0.0.alpha2"
 
   gem.add_runtime_dependency "cabin", "~> 0.8.0" #(Apache 2.0 license)
   gem.add_runtime_dependency "pry", "~> 0.10.1"  #(Ruby license)

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = LOGSTASH_CORE_VERSION.gsub(/-/, '.')
 
-  gem.add_runtime_dependency "logstash-core-event-java", "5.0.0.alpha2"
+  gem.add_runtime_dependency "logstash-core-event-java", "5.0.0.alpha3.snapshot1"
 
   gem.add_runtime_dependency "cabin", "~> 0.8.0" #(Apache 2.0 license)
   gem.add_runtime_dependency "pry", "~> 0.10.1"  #(Ruby license)


### PR DESCRIPTION
This Change is necessary to allow plugins 2.X to be build again.
Fixes #5273