### PR TITLE
add missing to_json_with_metadata method found in ls-event-ruby

### DIFF
--- a/logstash-core-event-java/spec/event_spec.rb
+++ b/logstash-core-event-java/spec/event_spec.rb
@@ -34,6 +34,18 @@ describe LogStash::Event do
     end
   end
 
+  context "to_json_with_metadata" do
+    it "should serialize metadata" do
+      e = LogStash::Event.new({TIMESTAMP => "2015-05-28T23:02:05.350Z"})
+      e.set("foo", "bar")
+      e.set("bar", 1)
+      e.set("baz", 1.0)
+      e.set("[fancy][pants][socks]", "shoes")
+      e.set("[@metadata][foo", "bar")
+      expect(JSON.parse(e.to_json_with_metadata)).to eq(JSON.parse("{\"@metadata\":{\"foo\":\"bar\"},\"@timestamp\":\"2015-05-28T23:02:05.350Z\",\"@version\":\"1\",\"foo\":\"bar\",\"bar\":1,\"baz\":1.0,\"fancy\":{\"pants\":{\"socks\":\"shoes\"}}}"))
+    end
+  end
+
   context "[]" do
     it "should get simple values" do
       e = LogStash::Event.new({"foo" => "bar", "bar" => 1, "baz" => 1.0, TIMESTAMP => "2015-05-28T23:02:05.350Z"})

--- a/logstash-core-event-java/src/main/java/com/logstash/Event.java
+++ b/logstash-core-event-java/src/main/java/com/logstash/Event.java
@@ -153,10 +153,12 @@ public class Event implements Cloneable, Serializable {
         }
     }
 
-    public String toJson()
-            throws IOException
-    {
-        return mapper.writeValueAsString((Map<String, Object>)this.data);
+    public String toJson() throws IOException {
+        return mapper.writeValueAsString(this.data);
+    }
+
+    public String toJsonWithMetadata() throws IOException {
+        return mapper.writeValueAsString(this.toMapWithMetadata());
     }
 
     public static Event[] fromJson(String json)
@@ -189,7 +191,16 @@ public class Event implements Cloneable, Serializable {
     }
 
     public Map toMap() {
-        return this.data;
+        return Cloner.deep(this.data);
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map toMapWithMetadata() {
+        Map data = toMap();
+        if (!this.metadata.isEmpty()) {
+            data.put(Event.METADATA, Cloner.deep(this.metadata));
+        }
+        return data;
     }
 
     public Event overwrite(Event e) {

--- a/logstash-core-event-java/src/main/java/com/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core-event-java/src/main/java/com/logstash/ext/JrubyEventExtLibrary.java
@@ -245,19 +245,13 @@ public class JrubyEventExtLibrary implements Library {
         @JRubyMethod(name = "to_hash")
         public IRubyObject ruby_to_hash(ThreadContext context) throws IOException
         {
-            return Rubyfier.deep(context.runtime, this.event.toMap());
+            return Rubyfier.deep(context.runtime, this.event.getData());
         }
 
         @JRubyMethod(name = "to_hash_with_metadata")
         public IRubyObject ruby_to_hash_with_metadata(ThreadContext context) throws IOException
         {
-            Map data = this.event.toMap();
-            Map metadata = this.event.getMetadata();
-
-            if (!metadata.isEmpty()) {
-                data.put(Event.METADATA, metadata);
-            }
-            return Rubyfier.deep(context.runtime, data);
+            return Rubyfier.deep(context.runtime, this.event.toMapWithMetadata());
         }
 
         @JRubyMethod(name = "to_java")
@@ -271,6 +265,15 @@ public class JrubyEventExtLibrary implements Library {
         {
             try {
                 return RubyString.newString(context.runtime, event.toJson());
+            } catch (Exception e) {
+                throw new RaiseException(context.runtime, GENERATOR_ERROR, e.getMessage(), true);
+            }
+        }
+
+        @JRubyMethod(name = "to_json_with_metadata")
+        public IRubyObject ruby_to_json_with_metadata(ThreadContext context, IRubyObject[] args) {
+            try {
+                return RubyString.newString(context.runtime, event.toJsonWithMetadata());
             } catch (Exception e) {
                 throw new RaiseException(context.runtime, GENERATOR_ERROR, e.getMessage(), true);
             }


### PR DESCRIPTION
It would be nice to have a `to_json_with_metadata` in Java Event. It existed in the ruby version.

aside from that, some other small changes like fixing the `toMap` to return a copy, rather than a mutable reference to the original event's data