### PR TITLE
[WIP] use closure table instead of ivars

### DIFF
--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -616,4 +616,20 @@ describe LogStash::Pipeline do
       end
     end
   end
+
+  context "Pipeline object" do
+    before do
+      allow(LogStash::Plugin).to receive(:lookup).with("input", "generator").and_return(LogStash::Inputs::Generator)
+      allow(LogStash::Plugin).to receive(:lookup).with("codec", "plain").and_return(DummyCodec)
+      allow(LogStash::Plugin).to receive(:lookup).with("filter", "dummyfilter").and_return(DummyFilter)
+      allow(LogStash::Plugin).to receive(:lookup).with("output", "dummyoutput").and_return(DummyOutput)
+    end
+
+    let(:pipeline1) { LogStash::Pipeline.new("input { generator {} } filter { dummyfilter {} } output { dummyoutput {}}") }
+    let(:pipeline2) { LogStash::Pipeline.new("input { generator {} } filter { dummyfilter {} } output { dummyoutput {}}") }
+
+    it "should not add ivars" do
+       expect(pipeline1.instance_variables).to eq(pipeline2.instance_variables)
+    end
+  end
 end


### PR DESCRIPTION
This is a quick & dirty patch to demonstrate the idea of using a `@closures` table instead of dynamically creating ivars which potentially leads to a slowdown when/if multiple pipelines are created.

Note that all core specs are passing with this patch. I did not run plugins tests and neither assessed performance impact.

If this idea has traction, feel free to dump this and integrate in another PR. 