### PR TITLE
Point to CLI docs for info about setting port for monitoring API

### DIFF
--- a/docs/static/monitoring-apis.asciidoc
+++ b/docs/static/monitoring-apis.asciidoc
@@ -31,6 +31,10 @@ Example response:
   }
 --------------------------------------------------
 
+NOTE: By default, the monitoring API attempts to bind to `tcp:9600`. If this port is already in use by another Logstash
+instance, you need to launch Logstash with the `--http-port` flag specified to bind to a different port. See 
+<<command-line-flags>> for more information.
+
 [float]
 [[monitoring-common-options]]
 === Common Options


### PR DESCRIPTION
Doc fix for #5285 - the settings are documented, but users are overlooking the doc. Added a short note and link to help users find the doc.