### PR TITLE
Fix ssh dump config + suse boostrap user level script

### DIFF
--- a/qa/sys/suse/user_bootstrap.sh
+++ b/qa/sys/suse/user_bootstrap.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/qa/vagrant/helpers.rb
+++ b/qa/vagrant/helpers.rb
@@ -27,7 +27,8 @@ module LogStash
     end
 
     def self.fetch_config
-      CommandExecutor.run!("vagrant ssh-config")
+      machines = CommandExecutor.run!("vagrant status").stdout.split("\n").select { |l| l.include?("running") }.map { |r| r.split(' ')[0]}
+      CommandExecutor.run!("vagrant ssh-config #{machines.join(' ')}")
     end
 
     def self.parse(lines)


### PR DESCRIPTION
two simple fixes, that will make the bootstrap process work.

* ssh config should only fetch active machines.
* suse needs a non privileged bootstrap script (for now empty)