### PR TITLE
Use hostname in the acceptance test descriptions

### DIFF
--- a/qa/acceptance/spec/shared_examples/installed.rb
+++ b/qa/acceptance/spec/shared_examples/installed.rb
@@ -7,17 +7,17 @@ RSpec.shared_examples "installable" do |logstash|
     logstash.install(LOGSTASH_VERSION)
   end
 
-  it "is installed on #{logstash.host}" do
+  it "is installed on #{logstash.hostname}" do
     expect(logstash).to be_installed
   end
 
-  it "is running on #{logstash.host}" do
+  it "is running on #{logstash.hostname}" do
     logstash.start_service
     expect(logstash).to be_running
     logstash.stop_service
   end
 
-  it "is removable on #{logstash.host}" do
+  it "is removable on #{logstash.hostname}" do
     logstash.uninstall
     expect(logstash).to be_removed
   end

--- a/qa/acceptance/spec/shared_examples/running.rb
+++ b/qa/acceptance/spec/shared_examples/running.rb
@@ -7,7 +7,7 @@ RSpec.shared_examples "runnable" do |logstash|
     logstash.install(LOGSTASH_VERSION)
   end
 
-  it "is running on #{logstash.host}" do
+  it "is running on #{logstash.hostname}" do
     logstash.start_service
     expect(logstash).to be_running
     logstash.stop_service

--- a/qa/acceptance/spec/shared_examples/updated.rb
+++ b/qa/acceptance/spec/shared_examples/updated.rb
@@ -6,14 +6,14 @@ RSpec.shared_examples "updated" do |logstash|
   before (:all) { logstash.snapshot }
   after  (:all) { logstash.restore }
 
-  it "can update on #{logstash.host}" do
+  it "can update on #{logstash.hostname}" do
     logstash.install(LOGSTASH_LATEST_VERSION, "./")
     expect(logstash).to be_installed
     logstash.install(LOGSTASH_VERSION)
     expect(logstash).to be_installed
   end
 
-  it "can run on #{logstash.host}" do
+  it "can run on #{logstash.hostname}" do
     logstash.start_service
     expect(logstash).to be_running
     logstash.stop_service

--- a/qa/rspec/commands.rb
+++ b/qa/rspec/commands.rb
@@ -20,6 +20,10 @@ module ServiceTester
       @client  = CommandsFactory.fetch(options["type"], options["host"])
     end
 
+    def hostname
+      @options["host"]
+    end
+
     def name
       "logstash"
     end


### PR DESCRIPTION
@ph think if this way is something you might also like to introduce for #5259, for all acceptance test definetly something better to have names than IP's, isn't?