### PR TITLE
Force updating the certificate on the target vm

### DIFF
--- a/qa/Vagrantfile
+++ b/qa/Vagrantfile
@@ -17,6 +17,14 @@ Vagrant.configure(2) do |config|
         sh.path = "sys/#{platform.type}/bootstrap.sh"
         sh.privileged = true
       end
+
+      if platform.bootstrap
+        machine.vm.provision :shell do |sh|
+          sh.path = platform.bootstrap
+          sh.privileged = true
+        end
+      end
+
       machine.vm.provision :shell do |sh|
         sh.path = "sys/#{platform.type}/user_bootstrap.sh"
         sh.privileged = false

--- a/qa/config/platforms.json
+++ b/qa/config/platforms.json
@@ -2,7 +2,7 @@
   "latest": "5.0.0-alpha2",
   "platforms" : {
     "ubuntu-1204": { "box": "elastic/ubuntu-12.04-x86_64", "type": "debian" },
-    "ubuntu-1404": { "box": "elastic/ubuntu-14.04-x86_64", "type": "debian" },
+    "ubuntu-1404": { "box": "elastic/ubuntu-14.04-x86_64", "type": "debian", "bootstrap": "sys/ubuntu-1404/bootstrap.sh" },
     "ubuntu-1504": { "box": "elastic/ubuntu-15.04-x86_64", "type": "debian" },
     "centos-6": { "box": "elastic/centos-6-x86_64", "type": "redhat" },
     "centos-7": { "box": "elastic/centos-7-x86_64", "type": "redhat" },

--- a/qa/platform_config.rb
+++ b/qa/platform_config.rb
@@ -3,7 +3,7 @@ require "json"
 
 class PlatformConfig
 
-  Platform = Struct.new(:name, :box, :type)
+  Platform = Struct.new(:name, :box, :type, :bootstrap)
 
   DEFAULT_CONFIG_LOCATION = File.join(File.dirname(__FILE__), "config", "platforms.json").freeze
 
@@ -15,7 +15,7 @@ class PlatformConfig
 
     data = JSON.parse(File.read(@config_path))
     data["platforms"].each do |k, v|
-      @platforms << Platform.new(k, v["box"], v["type"])
+      @platforms << Platform.new(k, v["box"], v["type"], v["bootstrap"])
     end
     @platforms.sort! { |a, b| a.name <=> b.name }
     @latest = data["latest"]

--- a/qa/sys/ubuntu-1404/bootstrap.sh
+++ b/qa/sys/ubuntu-1404/bootstrap.sh
@@ -1,0 +1,1 @@
+update-ca-certificates -f


### PR DESCRIPTION
Ruby-maven tries to connect to an http host and the certificates shipped
with Ubuntu 1404 cannot verify it. This PR make this command run after
bootstrapping the debian machine.

```
sudo update-ca-certificates -f
```

This should work under all debian based distribution.

Fixes: #5325