### PR TITLE
drip extends current JAVA_OPTS and therefore needs to run after setup…

### DIFF
--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -153,15 +153,17 @@ setup() {
       USE_DRIP=1
     fi
   fi
-  if [ "$USE_DRIP" = "1" ] ; then
-    setup_drip
-  fi
 
   if [ "$USE_RUBY" = "1" ] ; then
     setup_ruby
   else
     setup_java
     setup_vendored_jruby
+  fi
+
+  # drip extends current JAVA_OPTS and therefore needs to run after setup_java
+  if [ "$USE_DRIP" = "1" ] ; then
+    setup_drip
   fi
 }
 


### PR DESCRIPTION
Currently the setup() function runs in the following order:

```
  if [ "$USE_DRIP" = "1" ] ; then
    setup_drip
  fi

  if [ "$USE_RUBY" = "1" ] ; then
    setup_ruby
  else
    setup_java
    setup_vendored_jruby
  fi
```

So, setup_drip is called first.
setup_drip contains the following code:

```
  else
    JAVA_OPTS="$JAVA_OPTS -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify"
  fi
```

So the current JAVA_OPTS is extended with these parameters.

However, since setup_drip is called before setup_java, these parameters will be overwritten when setup_java is called (when there are no JAVA_OPTS defined):

```
  else
    # There are no JAVA_OPTS set from the client, we set a predefined
    # set of options that think are good in general
    JAVA_OPTS="-XX:+UseParNewGC"
```
