### PR TITLE
Logstash fails to start when HEAP_DUMP_PATH not specified

### DIFF
--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -153,15 +153,17 @@ setup() {
       USE_DRIP=1
     fi
   fi
-  if [ "$USE_DRIP" = "1" ] ; then
-    setup_drip
-  fi
 
   if [ "$USE_RUBY" = "1" ] ; then
     setup_ruby
   else
     setup_java
     setup_vendored_jruby
+  fi
+
+  # drip extends current JAVA_OPTS and therefore needs to run after setup_java
+  if [ "$USE_DRIP" = "1" ] ; then
+    setup_drip
   fi
 }
 

--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -180,9 +180,15 @@ ruby_exec() {
 
     # $VENDORED_JRUBY is non-empty so use the vendored JRuby
 
-    if [ "$DEBUG" ] ; then
-      echo "DEBUG: exec ${JRUBY_BIN} $(jruby_opts) "-J$HEAP_DUMP_PATH" $@"
+    if [ -z "$HEAP_DUMP_PATH" ] ; then
+        HEAP_DUMP_PATH_OPT=''
+    else
+        HEAP_DUMP_PATH_OPT="-J$HEAP_DUMP_PATH"
     fi
-    exec "${JRUBY_BIN}" $(jruby_opts) "-J$HEAP_DUMP_PATH" "$@"
+
+    if [ "$DEBUG" ] ; then
+      echo "DEBUG: exec ${JRUBY_BIN} $(jruby_opts) "$HEAP_DUMP_PATH_OPT" $@"
+    fi
+    exec "${JRUBY_BIN}" $(jruby_opts) "$HEAP_DUMP_PATH_OPT" "$@"
   fi
 }


### PR DESCRIPTION
In the ruby_exec function HEAP_DUMP_PATH is a mandatory field
```
    if [ "$DEBUG" ] ; then
      echo "DEBUG: exec ${JRUBY_BIN} $(jruby_opts) "-J$HEAP_DUMP_PATH" $@"
    fi
    exec "${JRUBY_BIN}" $(jruby_opts) "-J$HEAP_DUMP_PATH" "$@"
  fi
```
However, this fails when set_java is called and the JAVA_OPTS environment variable already exists:
```
  if [ "$JAVA_OPTS" ] ; then
    echo "WARNING: Default JAVA_OPTS will be overridden by the JAVA_OPTS defined in the environment. Environment JAVA_OPTS are $JAVA_OPTS"  1>&2
  else
#############################
    # The path to the heap dump location
    # This variable needs to be isolated since it may contain spaces
    HEAP_DUMP_PATH="-XX:HeapDumpPath=${LOGSTASH_HOME}/heapdump.hprof"
  fi
```
In which case Logstash will be started with:
+ exec /opt/logstash/vendor/jruby/bin/jruby --1.9 -J-XX:+UseParNewGC -J-XX:+UseConcMarkSweepGC -J-Djava.awt.headless=true -J-XX:CMSInitiatingOccupancyFraction=75 -J-XX:+UseCMSInitiatingOccupancyOnly -J-XX:+HeapDumpOnOutOfMemoryError -J-Xmx1g -J**____** /opt/logstash/lib/bootstrap/environment.rb logstash/runner.rb

Instead of:
+ exec /opt/logstash/vendor/jruby/bin/jruby --1.9 -J-XX:+UseParNewGC -J-XX:+UseConcMarkSweepGC -J-Djava.awt.headless=true -J-XX:CMSInitiatingOccupancyFraction=75 -J-XX:+UseCMSInitiatingOccupancyOnly -J-XX:+HeapDumpOnOutOfMemoryError -J-Xmx1g -J**-XX:HeapDumpPath=/opt/logstash/heapdump.hprof** /opt/logstash/lib/bootstrap/environment.rb logstash/runner.rb
