### PR TITLE
Fixes debian-8 bootstrap plus add specific platform dependent loading scripts

### DIFF
--- a/qa/Vagrantfile
+++ b/qa/Vagrantfile
@@ -13,10 +13,20 @@ Vagrant.configure(2) do |config|
         v.cpus = 4
       end
       machine.vm.synced_folder "../build", "/logstash-build", create: true
+      if platform.specific
+        script_path = "sys/#{platform.type}/#{platform.name}/bootstrap.sh"
+      else
+        script_path = "sys/#{platform.type}/bootstrap.sh"
+      end
       machine.vm.provision :shell do |sh|
-        sh.path = "sys/#{platform.type}/bootstrap.sh"
+        sh.path = script_path
         sh.privileged = true
       end
+      ##
+      # for now the only specific boostrap scripts are ones need
+      # with privileged access level, whenever others are also
+      # required we can update this section as well with the same pattern.
+      ##
       machine.vm.provision :shell do |sh|
         sh.path = "sys/#{platform.type}/user_bootstrap.sh"
         sh.privileged = false

--- a/qa/Vagrantfile
+++ b/qa/Vagrantfile
@@ -13,22 +13,14 @@ Vagrant.configure(2) do |config|
         v.cpus = 4
       end
       machine.vm.synced_folder "../build", "/logstash-build", create: true
-      if platform.specific
-        script_path = "sys/#{platform.type}/#{platform.name}/bootstrap.sh"
-      else
-        script_path = "sys/#{platform.type}/bootstrap.sh"
-      end
+
       machine.vm.provision :shell do |sh|
-        sh.path = script_path
+        sh.path = platform.bootstrap.privileged
         sh.privileged = true
       end
-      ##
-      # for now the only specific boostrap scripts are ones need
-      # with privileged access level, whenever others are also
-      # required we can update this section as well with the same pattern.
-      ##
+
       machine.vm.provision :shell do |sh|
-        sh.path = "sys/#{platform.type}/user_bootstrap.sh"
+        sh.path = platform.bootstrap.non_privileged
         sh.privileged = false
       end
     end

--- a/qa/config/platforms.json
+++ b/qa/config/platforms.json
@@ -11,6 +11,6 @@
     "fedora-22": { "box": "elastic/fedora-22-x86_64", "type": "redhat" },
     "debian-8": { "box": "elastic/debian-8-x86_64", "type": "debian", "specific":  true },
     "opensuse-13": { "box": "elastic/opensuse-13-x86_64", "type": "suse" },
-    "sles-12": { "box": "elastic/sles-12-x86_64", "type": "suse" }
+    "sles-12": { "box": "elastic/sles-12-x86_64", "type": "suse", "specific": true }
   }
 }

--- a/qa/config/platforms.json
+++ b/qa/config/platforms.json
@@ -2,7 +2,7 @@
   "latest": "5.0.0-alpha2",
   "platforms" : {
     "ubuntu-1204": { "box": "elastic/ubuntu-12.04-x86_64", "type": "debian" },
-    "ubuntu-1404": { "box": "elastic/ubuntu-14.04-x86_64", "type": "debian" },
+    "ubuntu-1404": { "box": "elastic/ubuntu-14.04-x86_64", "type": "debian", "specific": true },
     "ubuntu-1504": { "box": "elastic/ubuntu-15.04-x86_64", "type": "debian" },
     "centos-6": { "box": "elastic/centos-6-x86_64", "type": "redhat" },
     "centos-7": { "box": "elastic/centos-7-x86_64", "type": "redhat" },

--- a/qa/config/platforms.json
+++ b/qa/config/platforms.json
@@ -9,7 +9,7 @@
     "oel-6": { "box": "elastic/oraclelinux-6-x86_64", "type": "redhat" },
     "oel-7": { "box": "elastic/oraclelinux-7-x86_64", "type": "redhat" },
     "fedora-22": { "box": "elastic/fedora-22-x86_64", "type": "redhat" },
-    "debian-8": { "box": "elastic/debian-8-x86_64", "type": "debian" },
+    "debian-8": { "box": "elastic/debian-8-x86_64", "type": "debian", "specific":  true },
     "opensuse-13": { "box": "elastic/opensuse-13-x86_64", "type": "suse" },
     "sles-12": { "box": "elastic/sles-12-x86_64", "type": "suse" }
   }

--- a/qa/platform_config.rb
+++ b/qa/platform_config.rb
@@ -3,7 +3,7 @@ require "json"
 
 class PlatformConfig
 
-  Platform = Struct.new(:name, :box, :type)
+  Platform = Struct.new(:name, :box, :type, :specific)
 
   DEFAULT_CONFIG_LOCATION = File.join(File.dirname(__FILE__), "config", "platforms.json").freeze
 
@@ -15,7 +15,7 @@ class PlatformConfig
 
     data = JSON.parse(File.read(@config_path))
     data["platforms"].each do |k, v|
-      @platforms << Platform.new(k, v["box"], v["type"])
+      @platforms << Platform.new(k, v["box"], v["type"], v["specific"])
     end
     @platforms.sort! { |a, b| a.name <=> b.name }
     @latest = data["latest"]

--- a/qa/platform_config.rb
+++ b/qa/platform_config.rb
@@ -13,12 +13,12 @@ class PlatformConfig
       @name = name
       @box  = data["box"]
       @type = data["type"]
-      initialize_bootstrap_scripts(data)
+      configure_bootstrap_scripts(data)
     end
 
     private
 
-    def initialize_bootstrap_scripts(data)
+    def configure_bootstrap_scripts(data)
       @bootstrap = OpenStruct.new(:privileged     => "sys/#{type}/bootstrap.sh",
                                   :non_privileged => "sys/#{type}/user_bootstrap.sh")
       ##

--- a/qa/platform_config.rb
+++ b/qa/platform_config.rb
@@ -1,9 +1,34 @@
 # encoding: utf-8
 require "json"
+require "ostruct"
 
 class PlatformConfig
 
-  Platform = Struct.new(:name, :box, :type, :specific)
+
+  class Platform
+
+    attr_reader :name, :box, :type, :bootstrap
+
+    def initialize(name, data)
+      @name = name
+      @box  = data["box"]
+      @type = data["type"]
+      initialize_bootstrap_scripts(data)
+    end
+
+    private
+
+    def initialize_bootstrap_scripts(data)
+      @bootstrap = OpenStruct.new(:privileged     => "sys/#{type}/bootstrap.sh",
+                                  :non_privileged => "sys/#{type}/user_bootstrap.sh")
+      ##
+      # for now the only specific boostrap scripts are ones need
+      # with privileged access level, whenever others are also
+      # required we can update this section as well with the same pattern.
+      ##
+      @bootstrap.privileged = "sys/#{type}/#{name}/bootstrap.sh" if data["specific"]
+    end
+  end
 
   DEFAULT_CONFIG_LOCATION = File.join(File.dirname(__FILE__), "config", "platforms.json").freeze
 
@@ -15,7 +40,7 @@ class PlatformConfig
 
     data = JSON.parse(File.read(@config_path))
     data["platforms"].each do |k, v|
-      @platforms << Platform.new(k, v["box"], v["type"], v["specific"])
+      @platforms << Platform.new(k, v)
     end
     @platforms.sort! { |a, b| a.name <=> b.name }
     @latest = data["latest"]

--- a/qa/sys/debian/debian-8/bootstrap.sh
+++ b/qa/sys/debian/debian-8/bootstrap.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo "deb http://http.debian.net/debian jessie-backports main" >> /etc/apt/sources.list
+apt-get update
+apt-get install -y openjdk-8-jdk

--- a/qa/sys/debian/ubuntu-1404/bootstrap.sh
+++ b/qa/sys/debian/ubuntu-1404/bootstrap.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+add-apt-repository ppa:openjdk-r/ppa
+apt-get update
+apt-get install -y openjdk-8-jdk
+update-alternatives --config java
+update-alternatives --config javac
+update-ca-certificates -f

--- a/qa/sys/debian/user_bootstrap.sh
+++ b/qa/sys/debian/user_bootstrap.sh
@@ -3,3 +3,4 @@
 VERSION=`cat /vagrant/config/platforms.json | grep  latest | cut -d":" -f2 | sed 's/["\|,| ]//g'`
 LOGSTASH_FILENAME="logstash-${VERSION}_all.deb"
 wget -q https://download.elastic.co/logstash/logstash/packages/debian/$LOGSTASH_FILENAME
+mv $LOGSTASH_FILENAME "logstash-${VERSION}.deb" # necessary patch until new version with the standard name format are released

--- a/qa/sys/redhat/user_bootstrap.sh
+++ b/qa/sys/redhat/user_bootstrap.sh
@@ -3,3 +3,4 @@
 VERSION=`cat /vagrant/config/platforms.json | grep  latest | cut -d":" -f2 | sed 's/["\|,| ]//g'`
 LOGSTASH_FILENAME="logstash-${VERSION}.noarch.rpm"
 wget -q https://download.elastic.co/logstash/logstash/packages/centos/$LOGSTASH_FILENAME
+mv $LOGSTASH_FILENAME "logstash-${VERSION}.rpm" # necessary patch until new version with the standard name format are released

--- a/qa/sys/suse/sles-12/bootstrap.sh
+++ b/qa/sys/suse/sles-12/bootstrap.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+zypper rr systemsmanagement_puppet
+zypper addrepo -t yast2 http://demeter.uni-regensburg.de/SLES12-x64/DVD1/ dvd1 || true
+zypper addrepo -t yast2 http://demeter.uni-regensburg.de/SLES12-x64/DVD2/ dvd2 || true
+zypper addrepo http://download.opensuse.org/repositories/Java:Factory/SLE_12/Java:Factory.repo || true
+zypper --no-gpg-checks --non-interactive refresh
+zypper --non-interactive list-updates
+zypper --non-interactive --no-gpg-checks --quiet install --no-recommends java-1_8_0-openjdk-devel

--- a/qa/sys/suse/user_bootstrap.sh
+++ b/qa/sys/suse/user_bootstrap.sh
@@ -1,1 +1,5 @@
 #!/usr/bin/env bash
+VERSION=`cat /vagrant/config/platforms.json | grep  latest | cut -d":" -f2 | sed 's/["\|,| ]//g'`
+LOGSTASH_FILENAME="logstash-${VERSION}.noarch.rpm"
+wget -q https://download.elastic.co/logstash/logstash/packages/centos/$LOGSTASH_FILENAME
+mv $LOGSTASH_FILENAME "logstash-${VERSION}.rpm" # necessary patch until new version with the standard name format are released


### PR DESCRIPTION
Hi,
 this PR provides a fix for #5338 by providing specific bootstrap script for debian-8, it also include small change necessary to make sure all packages use the new schema name (see #5100 for details).

This PR also adds:

* custom script for `sles-12` to make sure it gets the latest java8, including also a general suse bootstrap script to download latest rpm for it.
* custom script for `ubuntu-1404` to make sure it updates the CA certificates, basically providing the solution need for #5337

_Important:_

This way this PR solve the specific bootstrap scripts is different than the one proposed in #5337, before moving forward with both we should make sure to get a common solution for it.