### PR TITLE
Bugfix from manual test of new plugin generator on master

### DIFF
--- a/lib/pluginmanager/generate.rb
+++ b/lib/pluginmanager/generate.rb
@@ -4,6 +4,7 @@ require "pluginmanager/templates/render_context"
 require "erb"
 require "ostruct"
 require "fileutils"
+require "pathname"
 
 class LogStash::PluginManager::Generate < LogStash::PluginManager::Command
 
@@ -19,12 +20,12 @@ class LogStash::PluginManager::Generate < LogStash::PluginManager::Command
 
   def execute
     source = File.join(File.dirname(__FILE__), "templates", "#{type}-plugin")
-    target_path = File.join(path, full_plugin_name)
-    FileUtils.mkdir(target_path)
-    puts " Creating #{target_path}"
+    @target_path = File.join(path, full_plugin_name)
+    FileUtils.mkdir(@target_path)
+    puts " Creating #{@target_path}"
 
     begin
-      create_scaffold(source, target_path)
+      create_scaffold(source, @target_path)
     rescue Errno::EACCES => exception
       report_exception("Permission denied when executing the plugin manager", exception)
     rescue => exception
@@ -55,7 +56,7 @@ class LogStash::PluginManager::Generate < LogStash::PluginManager::Command
         else
           FileUtils.cp(source_entry, target_entry)
         end
-        puts "\t create #{File.join(full_plugin_name, File.basename(target_entry))}"
+        puts "\t create #{File.join(full_plugin_name, Pathname.new(target_entry).relative_path_from(Pathname.new(@target_path)))}"
       end
     end
   end

--- a/lib/pluginmanager/generate.rb
+++ b/lib/pluginmanager/generate.rb
@@ -14,7 +14,7 @@ class LogStash::PluginManager::Generate < LogStash::PluginManager::Command
     arg
   end
 
-  option "--name", "PLUGIN", "Name of the new plugin"
+  option "--name", "PLUGIN", "Name of the new plugin", :required => true
   option "--path", "PATH", "Location where the plugin skeleton will be created", :default => Dir.pwd
 
   def execute

--- a/lib/pluginmanager/templates/filter-plugin/lib/logstash/filters/example.rb.erb
+++ b/lib/pluginmanager/templates/filter-plugin/lib/logstash/filters/example.rb.erb
@@ -34,7 +34,7 @@ class LogStash::Filters::<%= classify(plugin_name) %> < LogStash::Filters::Base
     if @message
       # Replace the event message with our message as configured in the
       # config file.
-      event["message"] = @message
+      event.set("message", @message)
     end
 
     # filter_matched should go in the last line of our successful code

--- a/lib/pluginmanager/templates/filter-plugin/logstash-filter-example.gemspec.erb
+++ b/lib/pluginmanager/templates/filter-plugin/logstash-filter-example.gemspec.erb
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.licenses      = ['Apache License (2.0)']
   s.summary       = 'TODO: Write a short summary, because Rubygems requires one.'
   s.description   = 'TODO: Write a longer description or delete this line.'
-  s.homepage      = 'TODO: Put your plugin's website or public repo URL here.'
+  s.homepage      = 'TODO: Put your plugin''s website or public repo URL here.'
   s.authors       = ['<%= author %>']
   s.email         = '<%= email %>'
   s.require_paths = ['lib']

--- a/lib/pluginmanager/templates/filter-plugin/spec/filters/example_spec.rb.erb
+++ b/lib/pluginmanager/templates/filter-plugin/spec/filters/example_spec.rb.erb
@@ -15,7 +15,7 @@ describe LogStash::Filters::<%= classify(plugin_name) %> do
 
     sample("message" => "some text") do
       expect(subject).to include("message")
-      expect(subject['message']).to eq('Hello World')
+      expect(subject.get('message')).to eq('Hello World')
     end
   end
 end

--- a/lib/pluginmanager/templates/input-plugin/lib/logstash/inputs/example.rb.erb
+++ b/lib/pluginmanager/templates/input-plugin/lib/logstash/inputs/example.rb.erb
@@ -9,7 +9,7 @@ require "socket" # for Socket.gethostname
 # This plugin is intented only as an example.
 
 class LogStash::Inputs::<%= classify(plugin_name) %> < LogStash::Inputs::Base
-  config_name "<%= @lugin_name %>"
+  config_name "<%= @plugin_name %>"
 
   # If undefined, Logstash will complain, even if codec is unused.
   default :codec, "plain"

--- a/lib/pluginmanager/templates/input-plugin/logstash-input-example.gemspec.erb
+++ b/lib/pluginmanager/templates/input-plugin/logstash-input-example.gemspec.erb
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.licenses      = ['Apache License (2.0)']
   s.summary       = 'TODO: Write a short summary, because Rubygems requires one.'
   s.description   = '{TODO: Write a longer description or delete this line.'
-  s.homepage      = 'TODO: Put your plugin's website or public repo URL here.'
+  s.homepage      = 'TODO: Put your plugin''s website or public repo URL here.'
   s.authors       = ['<%= author %>']
   s.email         = '<%= email %>'
   s.require_paths = ['lib']

--- a/lib/pluginmanager/templates/output-plugin/logstash-output-example.gemspec.erb
+++ b/lib/pluginmanager/templates/output-plugin/logstash-output-example.gemspec.erb
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.licenses      = ['Apache License (2.0)']
   s.summary       = 'TODO: Write a short summary, because Rubygems requires one.'
   s.description   = 'TODO: Write a longer description or delete this line.'
-  s.homepage      = 'TODO: Put your plugin's website or public repo URL here.'
+  s.homepage      = 'TODO: Put your plugin''s website or public repo URL here.'
   s.authors       = ['<%= author %>']
   s.email         = '<%= email %>'
   s.require_paths = ['lib']


### PR DESCRIPTION
Happy to be one of the first to test very sweet work by @purbon 
Here are some minor corrections

* fix to allow direct execution of 'bundle install' => direct run of bundler was throwing an error due to unescaped single quote in gemspec
* make plugin name parameter required => forgetting the --name param resulted in a cryptic error "cannot call downcase() on Nil", now report that --name is mandatory
* display correct path of created files, the listing of created file did not contains subfolders (i.e lib/logstash/...)			
* use new event api in generator filter template => bundle exec rspec was failing on master for filter plugin due to usage of old event api
* fix config_name for generated input plugin => typo in the template of the input for the config_name setting