### PR TITLE
Make the api port bind to a range between 9600 and 9700 (default)

### DIFF
--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -29,7 +29,7 @@ module LogStash
             Setting::String.new("path.log", nil, false),
             Setting::String.new("log.format", "plain", true, ["json", "plain"]),
             Setting::String.new("http.host", "127.0.0.1"),
-              Setting::Port.new("http.port", 9600),
+            Setting::Port.new("http.port", nil, false),
   ].each {|setting| SETTINGS.register(setting) }
 
   module Environment

--- a/logstash-core/lib/logstash/webserver.rb
+++ b/logstash-core/lib/logstash/webserver.rb
@@ -32,7 +32,7 @@ module LogStash
                                      :queue_requests => false
       })
 
-      logger.terminal("Binding Logstash WebAPI to tcp://#{http_host}:#{http_port}")
+      logger.terminal("Binding Logstash HTTP server to #{http_host}:#{http_port}")
 
       @status      = nil
       parse_options
@@ -89,9 +89,10 @@ module LogStash
           TCPServer.new(http_host, current_port).close
           return current_port
         rescue Errno::EADDRINUSE
+          log("Address #{http_host}:#{current_port} in use")
         end
       end
-      raise HostBindingError.new("Range #{range} is full")
+      raise HostBindingError.new("Unable to bind to the specified port range (#{range}) for HTTP server")
     end
 
     def env

--- a/logstash-core/lib/logstash/webserver.rb
+++ b/logstash-core/lib/logstash/webserver.rb
@@ -16,7 +16,7 @@ module LogStash
 
     def_delegator :@runner, :stats
 
-    DEFAULT_PORT_RANGE=(9600...9700).freeze
+    DEFAULT_PORT_RANGE=(9600..9700).freeze
 
     def initialize(logger, options={})
       @logger      = logger
@@ -83,10 +83,10 @@ module LogStash
 
     private
 
-    def pick_default_port(http_host, range=(9600...9700))
+    def pick_default_port(http_host, range=(9600..9700))
       range.step(1) do |current_port|
         begin
-          TCPServer.new(http_host, current_port)
+          TCPServer.new(http_host, current_port).close
           return current_port
         rescue Errno::EADDRINUSE
         end


### PR DESCRIPTION
It provides a fix for the proposal in #5326 making the webserver try to bind to the first free port between the range 9600 and 9700 (not included). If the port is specified in the settings file it used it.

Fixes #5326