### PR TITLE
Initialize the `path.settings` inside the runner class

### DIFF
--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -13,7 +13,6 @@ module LogStash
            Setting::Boolean.new("config.reload.automatic", false),
            Setting::Numeric.new("config.reload.interval", 3),
            Setting::Boolean.new("metric.collect", true) {|v| v == true }, # metric collection cannot be disabled
-            Setting::String.new("path.settings", ::File.join(Environment::LOGSTASH_HOME, "config")),
             Setting::String.new("pipeline.id", "main"),
            Setting::Numeric.new("pipeline.workers", LogStash::Config::CpuCoreStrategy.maximum),
            Setting::Numeric.new("pipeline.output.workers", 1),


### PR DESCRIPTION
The `path.settings` requires the LOGSTASH_HOME constant to be defined,
the problem is that constant is only defined when you are actually
inside the logstash application, This was causing a bug when you were
testing plugin individually because that constant wasn't defined.

Fixes: #5361