### PR TITLE
Fixing the faillings metrics tests

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -45,7 +45,7 @@ class LogStash::Agent
 
     @collect_metric = setting("metric.collect")
     @metric = create_metric_collector
-    @periodic_pollers = LogStash::Instrument::PeriodicPollers.new(metric)
+    @periodic_pollers = LogStash::Instrument::PeriodicPollers.new(create_metric_collector)
   end
 
   def execute
@@ -83,7 +83,6 @@ class LogStash::Agent
 
     pipeline = create_pipeline(pipeline_settings)
     return unless pipeline.is_a?(LogStash::Pipeline)
-    pipeline.metric = @metric
     if @auto_reload && pipeline.non_reloadable_plugins.any?
       @logger.error(I18n.t("logstash.agent.non_reloadable_config_register"),
                     :pipeline_id => pipeline_id,

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -54,17 +54,9 @@ module LogStash; class Pipeline
 
     @worker_threads = []
 
-    # Metric object should be passed upstream, multiple pipeline share the same metric
-    # and collector only the namespace will changes.
-    # If no metric is given, we use a `NullMetric` for all internal calls.
-    # We also do this to make the changes backward compatible with previous testing of the
-    # pipeline.
-    #
     # This needs to be configured before we evaluate the code to make
-    # sure the metric instance is correctly send to the plugin.
-    # NOTE: It is the responsibility of the Agent to set this externally with a setter
-    # if there's an intent of this not being a NullMetric
-    @metric = Instrument::NullMetric.new
+    # sure the metric instance is correctly send to the plugins to make the namespace scoping work
+    @metric = settings.get_value("metric.collect") ? Instrument::Metric.new : Instrument::NullMetric.new 
 
     grammar = LogStashConfigParser.new
     @config = grammar.parse(config_str)
@@ -80,7 +72,7 @@ module LogStash; class Pipeline
     # The config code is hard to represent as a log message...
     # So just print it.
 
-    if @settings.get("config.debug") && logger.debug?
+    if @settings.get_value("config.debug") && logger.debug?
       logger.debug("Compiled pipeline code", :code => code)
     end
 

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -98,6 +98,7 @@ describe LogStash::Agent do
           sleep 0.1
           Stud.stop!(t)
           t.join
+          subject.shutdown
         end
       end
 
@@ -114,6 +115,7 @@ describe LogStash::Agent do
             sleep 0.1
             Stud.stop!(t)
             t.join
+            subject.shutdown
           end
         end
 
@@ -129,6 +131,8 @@ describe LogStash::Agent do
             sleep 0.1
             Stud.stop!(t)
             t.join
+
+            subject.shutdown
           end
         end
       end
@@ -157,6 +161,7 @@ describe LogStash::Agent do
           sleep 0.1
           Stud.stop!(t)
           t.join
+          subject.shutdown
         end
       end
 
@@ -172,6 +177,7 @@ describe LogStash::Agent do
             sleep 0.1
             Stud.stop!(t)
             t.join
+            subject.shutdown
           end
         end
 
@@ -186,6 +192,7 @@ describe LogStash::Agent do
             sleep 0.1
             Stud.stop!(t)
             t.join
+            subject.shutdown
           end
         end
       end
@@ -361,6 +368,7 @@ describe LogStash::Agent do
     end
 
     after :each do
+      subject.shutdown
       Stud.stop!(@t)
       @t.join
     end

--- a/logstash-core/spec/logstash/pipeline_reporter_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_reporter_spec.rb
@@ -47,6 +47,10 @@ describe LogStash::PipelineReporter do
     @post_snapshot = reporter.snapshot
   end
 
+  after do
+    pipeline.shutdown
+  end
+
   describe "events filtered" do
     it "should start at zero" do
       expect(@pre_snapshot.events_filtered).to eql(0)


### PR DESCRIPTION
This PR make sure that all the tests using the agent or the pipeline are
correctly shutting down their pipelines to make sure the metrics state
are coherent with the config defined in the test.

Fixes: #5291