### PR TITLE
Remove ps command for checking init system type

### DIFF
--- a/docs/static/setting-up-logstash.asciidoc
+++ b/docs/static/setting-up-logstash.asciidoc
@@ -143,12 +143,7 @@ The settings files are already defined in the Logstash installation. Logstash in
 coming[5.0.0-alpha3]
 
 Logstash is not started automatically after installation. How to start and stop Logstash depends on whether your system
-uses systemd, upstart, or SysV. You can tell what your system using by running this command:
-
-[source,sh]
---------------------------------------------
-ps -p 1
--------------------------------------------
+uses systemd, upstart, or SysV. 
 
 [[running-logstash-systemd]]
 ==== Running Logstash by Using Systemd


### PR DESCRIPTION
Removed because the command only tells you whether systemd is used.