### PR TITLE
Fix starting logstash from command-line

### DIFF
--- a/config/jvm.options
+++ b/config/jvm.options
@@ -40,7 +40,7 @@
 ## basic
 
 # set the I/O temp directory
--Djava.io.tmpdir=$HOME
+#-Djava.io.tmpdir=$HOME
 
 # set to headless, just in case
 -Djava.awt.headless=true

--- a/pkg/centos/after-install.sh
+++ b/pkg/centos/after-install.sh
@@ -1,7 +1,9 @@
-# /sbin/chkconfig --add logstash
-
 chown -R logstash:logstash /usr/share/logstash
 chown logstash /var/log/logstash
 chown logstash:logstash /var/lib/logstash
 chmod 0644 /etc/logrotate.d/logstash
+sed -i \
+  -e 's|# path.config:|path.config: /etc/logstash/conf.d|' \
+  -e 's|# path.log:|path.log: /var/log/logstash/logstash.log|' \
+  /etc/logstash/logstash.yml
 /usr/share/logstash/bin/system-install /etc/logstash/startup.options

--- a/pkg/debian/after-install.sh
+++ b/pkg/debian/after-install.sh
@@ -5,4 +5,8 @@ chown logstash /var/log/logstash
 chown logstash:logstash /var/lib/logstash
 chmod 755 /etc/logstash
 chmod 0644 /etc/logrotate.d/logstash
+sed -i \
+  -e 's|# path.config:|path.config: /etc/logstash/conf.d|' \
+  -e 's|# path.log:|path.log: /var/log/logstash/logstash.log|' \
+  /etc/logstash/logstash.yml
 /usr/share/logstash/bin/system-install /etc/logstash/startup.options

--- a/pkg/jvm.options
+++ b/pkg/jvm.options
@@ -40,7 +40,7 @@
 ## basic
 
 # set the I/O temp directory
--Djava.io.tmpdir=$HOME
+#-Djava.io.tmpdir=$HOME
 
 # set to headless, just in case
 -Djava.awt.headless=true

--- a/pkg/ubuntu/after-install.sh
+++ b/pkg/ubuntu/after-install.sh
@@ -4,4 +4,8 @@ chown -R logstash:logstash /usr/share/logstash
 chown logstash /var/log/logstash
 chown logstash:logstash /var/lib/logstash
 chmod 0644 /etc/logrotate.d/logstash
+sed -i \
+  -e 's|# path.config:|path.config: /etc/logstash/conf.d|' \
+  -e 's|# path.log:|path.log: /var/log/logstash/logstash.log|' \
+  /etc/logstash/logstash.yml
 /usr/share/logstash/bin/system-install /etc/logstash/startup.options


### PR DESCRIPTION
This fix is for packages only (RPM/DEB)

This puts the requisite changes into /etc/logstash/logstash.yml so that starting logstash from the command-line, e.g. `/usr/share/logstash/bin/logstash --path.settings /etc/logstash` will read the pipeline from `/etc/logstash/conf.d` and log to `/var/log/logstash/logstash.log`.

fixes #5379