### PR TITLE
Remove unnecessary dependancy to rake

### DIFF
--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/install.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/install.rb
@@ -2,7 +2,6 @@
 require_relative "../../../spec_helper"
 require "logstash/version"
 require "fileutils"
-require "logstash/devutils/rake"
 
 shared_examples "logstash install" do |logstash|
   before(:each) do


### PR DESCRIPTION
Initially the dependency to rake was introduced, according to @ph comments in #5259 to reuse the download function from devutils, however the code to download is actually done using wget, see

```
    def download(from, to, host)
      run_command("wget #{from} -O #{to}", host)
    end
```

as the dependency to rake actually make using `bundle exec rspec` syntax impossible is better to get it removed and can always come back when we approach proper reuse of devutils code.

//cc @ph @untergeek your thoughts are very welcome