### PR TITLE
Remove XIT for metric test in the agent_spec.

### DIFF
--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -373,7 +373,7 @@ describe LogStash::Agent do
       @t.join
     end
 
-    xit "resets the metric collector" do
+    it "resets the metric collector" do
       # We know that the store has more events coming in.
       sleep(0.01) while dummy_output.events.size < new_config_generator_counter
       snapshot = LogStash::Instrument::Collector.instance.snapshot_metric


### PR DESCRIPTION
The XIT was added to make sure we were able to build LS packages.
This PR revert the xit since the bug was fixed in #5307

Fixes: #5371