### PR TITLE
Fix script execution under ubuntu environments

### DIFF
--- a/ci/ci_acceptance.sh
+++ b/ci/ci_acceptance.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 # Since we are using the system jruby, we need to make sure our jvm process


### PR DESCRIPTION
As the CI scripts are going to be run inside logstash-ci what is basically an ubuntu machine, as the default shell is dash (see https://wiki.ubuntu.com/DashAsBinSh ) we have to specifically make it use bash.

See https://wiki.ubuntu.com/DashAsBinSh#A.5B.5B for more details.

Fixes #5397