### PR TITLE
pass the settings file location as required by the new package structure

### DIFF
--- a/qa/acceptance/spec/shared_examples/cli/logstash/version.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash/version.rb
@@ -14,7 +14,7 @@ shared_examples "logstash version" do |logstash|
 
     context "on #{logstash.hostname}" do
       it "returns the right logstash version" do
-        result = logstash.run_command_in_path("bin/logstash --version")
+        result = logstash.run_command_in_path("bin/logstash --path.settings=/etc/logstash --version")
         expect(result).to run_successfully_and_output(/#{LOGSTASH_VERSION}/)
       end
     end


### PR DESCRIPTION
Fix the version test to actually give the setting file location, this is due to the requirements introduced by the new package schema.