### PR TITLE
Add codecs to the plugin generator

### DIFF
--- a/lib/pluginmanager/generate.rb
+++ b/lib/pluginmanager/generate.rb
@@ -8,9 +8,9 @@ require "pathname"
 
 class LogStash::PluginManager::Generate < LogStash::PluginManager::Command
 
-  TYPES = [ "input", "filter", "output" ]
+  TYPES = [ "input", "filter", "output", "codec" ]
 
-  option "--type", "TYPE", "Type of the plugin {input, filter, output}s", :required => true
+  option "--type", "TYPE", "Type of the plugin {input, filter, codec, output}s", :required => true
   option "--name", "PLUGIN", "Name of the new plugin", :required => true
   option "--path", "PATH", "Location where the plugin skeleton will be created", :default => Dir.pwd
 
@@ -33,7 +33,7 @@ class LogStash::PluginManager::Generate < LogStash::PluginManager::Command
   private
 
   def validate_params
-    raise(ArgumentError, "should be one of: input, output or filter") unless TYPES.include?(type)
+    raise(ArgumentError, "should be one of: input, filter, codec or output") unless TYPES.include?(type)
   end
 
   def create_scaffold(source, target)

--- a/lib/pluginmanager/templates/codec-plugin/CHANGELOG.md
+++ b/lib/pluginmanager/templates/codec-plugin/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 0.1.0
+  - Plugin created with the logstash plugin generator

--- a/lib/pluginmanager/templates/codec-plugin/CONTRIBUTORS.erb
+++ b/lib/pluginmanager/templates/codec-plugin/CONTRIBUTORS.erb
@@ -1,0 +1,10 @@
+The following is a list of people who have contributed ideas, code, bug
+reports, or in general have helped logstash along its way.
+
+Contributors:
+* <%= author %> - <%= email %>
+
+Note: If you've sent us patches, bug reports, or otherwise contributed to
+Logstash, and you aren't on the list above and want to be, please let us know
+and we'll make sure you're here. Contributions from folks like you are what make
+open source awesome.

--- a/lib/pluginmanager/templates/codec-plugin/DEVELOPER.md.erb
+++ b/lib/pluginmanager/templates/codec-plugin/DEVELOPER.md.erb
@@ -1,0 +1,2 @@
+# logstash-codec-<%= plugin_name %>
+Example codec plugin. This should help bootstrap your effort to write your own codec plugin!

--- a/lib/pluginmanager/templates/codec-plugin/Gemfile
+++ b/lib/pluginmanager/templates/codec-plugin/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gemspec
+

--- a/lib/pluginmanager/templates/codec-plugin/LICENSE
+++ b/lib/pluginmanager/templates/codec-plugin/LICENSE
@@ -1,0 +1,11 @@
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/lib/pluginmanager/templates/codec-plugin/README.md
+++ b/lib/pluginmanager/templates/codec-plugin/README.md
@@ -1,0 +1,86 @@
+# Logstash Plugin
+
+This is a plugin for [Logstash](https://github.com/elastic/logstash).
+
+It is fully free and fully open source. The license is Apache 2.0, meaning you are pretty much free to use it however you want in whatever way.
+
+## Documentation
+
+Logstash provides infrastructure to automatically generate documentation for this plugin. We use the asciidoc format to write documentation so any comments in the source code will be first converted into asciidoc and then into html. All plugin documentation are placed under one [central location](http://www.elastic.co/guide/en/logstash/current/).
+
+- For formatting code or config example, you can use the asciidoc `[source,ruby]` directive
+- For more asciidoc formatting tips, see the excellent reference here https://github.com/elastic/docs#asciidoc-guide
+
+## Need Help?
+
+Need help? Try #logstash on freenode IRC or the https://discuss.elastic.co/c/logstash discussion forum.
+
+## Developing
+
+### 1. Plugin Developement and Testing
+
+#### Code
+- To get started, you'll need JRuby with the Bundler gem installed.
+
+- Create a new plugin or clone and existing from the GitHub [logstash-plugins](https://github.com/logstash-plugins) organization. We also provide [example plugins](https://github.com/logstash-plugins?query=example).
+
+- Install dependencies
+```sh
+bundle install
+```
+
+#### Test
+
+- Update your dependencies
+
+```sh
+bundle install
+```
+
+- Run tests
+
+```sh
+bundle exec rspec
+```
+
+### 2. Running your unpublished Plugin in Logstash
+
+#### 2.1 Run in a local Logstash clone
+
+- Edit Logstash `Gemfile` and add the local plugin path, for example:
+```ruby
+gem "logstash-codec-awesome", :path => "/your/local/logstash-codec-awesome"
+```
+- Install plugin
+```sh
+bin/logstash-plugin install --no-verify
+```
+- Run Logstash with your plugin
+```sh
+bin/logstash -e 'codec {awesome {}}'
+```
+At this point any modifications to the plugin code will be applied to this local Logstash setup. After modifying the plugin, simply rerun Logstash.
+
+#### 2.2 Run in an installed Logstash
+
+You can use the same **2.1** method to run your plugin in an installed Logstash by editing its `Gemfile` and pointing the `:path` to your local plugin development directory or you can build the gem and install it using:
+
+- Build your plugin gem
+```sh
+gem build logstash-codec-awesome.gemspec
+```
+- Install the plugin from the Logstash home
+```sh
+bin/logstash-plugin install /your/local/plugin/logstash-codec-awesome.gem
+```
+- Start Logstash and proceed to test the plugin
+
+## Contributing
+
+All contributions are welcome: ideas, patches, documentation, bug reports, complaints, and even something you drew up on a napkin.
+
+Programming is not a required skill. Whatever you've seen about open source and maintainers or community members  saying "send patches or die" - you will not see that here.
+
+It is more important to the community that you are able to contribute.
+
+For more information about contributing, see the [CONTRIBUTING](https://github.com/elastic/logstash/blob/master/CONTRIBUTING.md) file.

--- a/lib/pluginmanager/templates/codec-plugin/Rakefile
+++ b/lib/pluginmanager/templates/codec-plugin/Rakefile
@@ -1,0 +1,1 @@
+require "logstash/devutils/rake"

--- a/lib/pluginmanager/templates/codec-plugin/lib/logstash/codecs/example.rb.erb
+++ b/lib/pluginmanager/templates/codec-plugin/lib/logstash/codecs/example.rb.erb
@@ -1,0 +1,44 @@
+# encoding: utf-8
+require "logstash/codecs/base"
+require "logstash/namespace"
+
+# This <%= @plugin_name %> codec will append a string to the message field
+# of an event, either in the decoding or encoding methods
+#
+# This is only intended to be used as an example.
+#
+# input {
+#   stdin { codec => <%= @plugin_name %> }
+# }
+#
+# or
+#
+# output {
+#   stdout { codec => <%= @plugin_name %> }
+# }
+#
+class LogStash::Codecs::<%= classify(plugin_name) %> < LogStash::Codecs::Base
+
+  # The codec name
+  config_name "<%= plugin_name %>"
+
+  # Append a string to the message
+  config :append, :validate => :string, :default => ', Hello World!'
+
+  def register
+    @lines = LogStash::Codecs::Line.new
+    @lines.charset = "UTF-8"
+  end # def register
+
+  def decode(data)
+    @lines.decode(data) do |line|
+      replace = { "message" => line.get("message").to_s + @append }
+      yield LogStash::Event.new(replace)
+    end
+  end # def decode
+
+  def encode(event)
+    @on_event.call(event, event.get("message").to_s + @append + NL)
+  end # def encode
+
+end # class LogStash::Codecs::<%= classify(plugin_name) %>

--- a/lib/pluginmanager/templates/codec-plugin/logstash-codec-example.gemspec.erb
+++ b/lib/pluginmanager/templates/codec-plugin/logstash-codec-example.gemspec.erb
@@ -1,0 +1,24 @@
+Gem::Specification.new do |s|
+  s.name          = 'logstash-codec-<%= plugin_name %>'
+  s.version       = '0.1.0'
+  s.licenses      = ['Apache License (2.0)']
+  s.summary       = 'TODO: Write a short summary, because Rubygems requires one.'
+  s.description   = 'TODO: Write a longer description or delete this line.'
+  s.homepage      = 'TODO: Put your plugin''s website or public repo URL here.'
+  s.authors       = ['<%= author %>']
+  s.email         = '<%= email %>'
+  s.require_paths = ['lib']
+
+  # Files
+  s.files = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
+   # Tests
+  s.test_files = s.files.grep(%r{^(test|spec|features)/})
+
+  # Special flag to let us know this is actually a logstash plugin
+  s.metadata = { "logstash_plugin" => "true", "logstash_group" => "codec" }
+
+  # Gem dependencies
+  s.add_runtime_dependency 'logstash-core-plugin-api', "~> <%= min_version %>"
+  s.add_runtime_dependency 'logstash-codec-line'
+  s.add_development_dependency 'logstash-devutils'
+end

--- a/lib/pluginmanager/templates/codec-plugin/spec/codecs/example_spec.rb.erb
+++ b/lib/pluginmanager/templates/codec-plugin/spec/codecs/example_spec.rb.erb
@@ -1,0 +1,3 @@
+# encoding: utf-8
+require_relative '../spec_helper'
+require "logstash/codecs/<%= plugin_name %>"

--- a/lib/pluginmanager/templates/codec-plugin/spec/spec_helper.rb
+++ b/lib/pluginmanager/templates/codec-plugin/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+# encoding: utf-8
+require "logstash/devutils/rspec/spec_helper"


### PR DESCRIPTION
Initially as the codec example repo was empty, codecs were not added to the plugin generator, however It makes a lot of sense to have them here, so here they are.

This PR adds what is into https://github.com/logstash-plugins/logstash-codec-example/pull/1 as initial PR for the codecs example, I'm sure we can iterate over the example meaning and composition, but i focused to provide the same content.

@untergeek as you made the example codec, your thoughts to what do here are very welcome.

This helps fixing #5412 together with #5419.