### PR TITLE
rework the acceptance update scenario to avoid using snapshort/restore

### DIFF
--- a/qa/acceptance/spec/shared_examples/updated.rb
+++ b/qa/acceptance/spec/shared_examples/updated.rb
@@ -4,19 +4,22 @@ require          'logstash/version'
 # This test checks if the current package could used to update from the latest version released.
 RSpec.shared_examples "updated" do |logstash|
 
-  before (:all) { logstash.snapshot }
-  after  (:all) { logstash.restore }
-
-  it "can update on #{logstash.hostname}" do
-    logstash.install(LOGSTASH_LATEST_VERSION, "./")
-    expect(logstash).to be_installed
-    logstash.install(LOGSTASH_VERSION)
-    expect(logstash).to be_installed
+  before(:all) { logstash.uninstall }
+  after(:all)  do
+    logstash.stop_service # make sure the service is stopped
+    logstash.uninstall #remove the package to keep uniform state
   end
 
-  it "can run on #{logstash.hostname}" do
+  before(:each) do
+    logstash.install(LOGSTASH_LATEST_VERSION, "./") # make sure latest version is installed
+  end
+
+  it "can be updated an run on #{logstash.hostname}" do
+    # Performing the update
+    logstash.install(LOGSTASH_VERSION)
+    expect(logstash).to be_installed
+    # starts the service to be sure it runs after the upgrade
     logstash.start_service
     expect(logstash).to be_running
-    logstash.stop_service
   end
 end


### PR DESCRIPTION
This might be a temporary solution for ssh issues in vagrant and ubuntu hosts, see https://github.com/elastic/logstash/issues/5324#issuecomment-224235456 for more details.

@ph @untergeek as I can not reproduce this in my machine, can you guys please validate this workaround is okey. Thanks a lot.

