### PR TITLE
Remove the `/bin/env` command before using sed and rely on $PATH

### DIFF
--- a/qa/rspec/commands/base.rb
+++ b/qa/rspec/commands/base.rb
@@ -36,7 +36,7 @@ module ServiceTester
 
     def replace_in_gemfile(pattern, replace, host)
       gemfile = File.join(LOGSTASH_PATH, "Gemfile")
-      cmd = "/bin/env sed -i.sedbak 's/#{pattern}/#{replace}/' #{gemfile}"
+      cmd = "sed -i.sedbak 's/#{pattern}/#{replace}/' #{gemfile}"
       run_command(cmd, host)
     end
 


### PR DESCRIPTION
related to a discussion in #5468