### PR TITLE
Track wallclock time spent in filters and outputs. 

### DIFF
--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -34,7 +34,8 @@ module LogStash
         end
 
         def pipeline
-          service.get_shallow(:stats, :pipelines)
+          stats = service.get_shallow(:stats, :pipelines)
+          PluginsStats.report(stats)
         end
 
         def memory
@@ -53,7 +54,98 @@ module LogStash
               acc
             end
           }
-        end       
+        end
+
+        def hot_threads(options={})
+          HotThreadsReport.new(self, options)
+        end
+
+        class HotThreadsReport
+          HOT_THREADS_STACK_TRACES_SIZE_DEFAULT = 10.freeze
+          
+          def initialize(cmd, options)
+            @cmd = cmd
+            filter = { :stacktrace_size => options.fetch(:stacktrace_size, HOT_THREADS_STACK_TRACES_SIZE_DEFAULT) }
+            jr_dump = JRMonitor.threads.generate(filter)
+            @thread_dump = ::LogStash::Util::ThreadDump.new(options.merge(:dump => jr_dump))
+          end
+          
+          def to_s
+            hash = to_hash
+            report =  "#{I18n.t("logstash.web_api.hot_threads.title", :hostname => hash[:hostname], :time => hash[:time], :top_count => @thread_dump.top_count )} \n"
+            report << '=' * 80
+            report << "\n"
+            hash[:threads].each do |thread|
+              thread_report = ""
+              thread_report = "#{I18n.t("logstash.web_api.
+                                hot_threads.thread_title", :percent_of_cpu_time => thread[:percent_of_cpu_time], :thread_state => thread[:state], :thread_name => thread[:name])} \n"
+              thread_report = "#{thread[:percent_of_cpu_time]} % of of cpu usage by #{thread[:state]} thread named '#{thread[:name]}'\n"
+              thread_report << "#{thread[:path]}\n" if thread[:path]
+              thread[:traces].each do |trace|
+                thread_report << "\t#{trace}\n"
+              end
+              report << thread_report
+              report << '-' * 80
+              report << "\n"
+            end
+            report
+          end
+
+          def to_hash
+            hash = { :hostname => @cmd.hostname, :time => Time.now.iso8601, :busiest_threads => @thread_dump.top_count, :threads => [] }
+            @thread_dump.each do |thread_name, _hash|
+              thread_name, thread_path = _hash["thread.name"].split(": ")
+              thread = { :name => thread_name,
+                         :percent_of_cpu_time => cpu_time_as_percent(_hash),
+                         :state => _hash["thread.state"]
+                       }
+              thread[:path] = thread_path if thread_path
+              traces = []
+              _hash["thread.stacktrace"].each do |trace|
+                traces << trace
+              end
+              thread[:traces] = traces unless traces.empty?
+              hash[:threads] << thread
+            end
+            hash
+          end
+
+          def cpu_time_as_percent(hash)
+            (((cpu_time(hash) / @cmd.uptime * 1.0)*10000).to_i)/100.0
+          end
+
+          def cpu_time(hash)
+            hash["cpu.time"] / 1000000.0
+          end
+        end # class HotThreadsReport
+
+        module PluginsStats
+          module_function
+
+          def plugin_stats(stats, plugin_type)
+            # Turn the `plugins` stats hash into an array of [ {}, {}, ... ]
+            # This is to produce an array of data points, one point for each
+            # plugin instance.
+            return [] unless stats[:plugins].include?(plugin_type)
+            stats[:plugins][plugin_type].collect do |id, data|
+              { :id => id }.merge(data)
+            end
+          end
+
+          def report(stats)
+            # Only one pipeline right now.
+            stats = stats[:main]
+
+            {
+              :events => stats[:events],
+              :pipeline => {
+                :inputs => plugin_stats(stats, :inputs),
+                :filters => plugin_stats(stats, :filters),
+                :outputs => plugin_stats(stats, :outputs)
+              }
+            }
+          end
+        end # module PluginsStats
       end
     end
   end

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -33,6 +33,10 @@ module LogStash
           )
         end
 
+        def pipeline
+          service.get_shallow(:stats, :pipelines)
+        end
+
         def memory
           memory = service.get_shallow(:jvm, :memory)
           {

--- a/logstash-core/lib/logstash/api/modules/node_stats.rb
+++ b/logstash-core/lib/logstash/api/modules/node_stats.rb
@@ -50,6 +50,10 @@ module LogStash
           respond_with :mem => mem_payload
         end
 
+        get "/pipeline" do
+          respond_with :pipeline => pipeline_payload
+        end
+
         private
 
         def events_payload
@@ -66,6 +70,10 @@ module LogStash
 
         def mem_payload
           @stats.memory
+        end
+
+        def pipeline_payload
+          @stats.pipeline
         end
       end
     end

--- a/logstash-core/lib/logstash/filter_delegator.rb
+++ b/logstash-core/lib/logstash/filter_delegator.rb
@@ -39,7 +39,7 @@ module LogStash
 
       start = Time.now
       new_events = @filter.multi_filter(events)
-      @filter.metric.increment(:time_ms, ((Time.now - start)*1000).to_i)
+      @filter.metric.increment(:duration_in_millis, ((Time.now - start)*1000).to_i)
 
       # There is no garantee in the context of filter
       # that EVENTS_INT == EVENTS_OUT, see the aggregates and

--- a/logstash-core/lib/logstash/filter_delegator.rb
+++ b/logstash-core/lib/logstash/filter_delegator.rb
@@ -37,7 +37,9 @@ module LogStash
     def multi_filter(events)
       @metric_events.increment(:in, events.size)
 
+      start = Time.now
       new_events = @filter.multi_filter(events)
+      @filter.metric.increment(:time_ms, ((Time.now - start)*1000).to_i)
 
       # There is no garantee in the context of filter
       # that EVENTS_INT == EVENTS_OUT, see the aggregates and

--- a/logstash-core/lib/logstash/filter_delegator.rb
+++ b/logstash-core/lib/logstash/filter_delegator.rb
@@ -24,8 +24,8 @@ module LogStash
       namespaced_metric = metric.namespace(@filter.plugin_unique_name.to_sym)
       @filter.metric = metric
 
-      namespaced_metric.gauge(:name, config_name)
       @metric_events = namespaced_metric.namespace(:events)
+      namespaced_metric.gauge(:name, config_name)
 
       # Not all the filters will do bufferings
       define_flush_method if @filter.respond_to?(:flush)
@@ -38,7 +38,7 @@ module LogStash
     def multi_filter(events)
       @metric_events.increment(:in, events.size)
 
-      clock = @filter.metric.time(:duration_in_millis)
+      clock = @metric_events.time(:duration_in_millis)
       new_events = @filter.multi_filter(events)
       clock.stop
 

--- a/logstash-core/lib/logstash/filter_delegator.rb
+++ b/logstash-core/lib/logstash/filter_delegator.rb
@@ -24,6 +24,7 @@ module LogStash
       namespaced_metric = metric.namespace(@filter.plugin_unique_name.to_sym)
       @filter.metric = metric
 
+      namespaced_metric.gauge(:name, config_name)
       @metric_events = namespaced_metric.namespace(:events)
 
       # Not all the filters will do bufferings

--- a/logstash-core/lib/logstash/filter_delegator.rb
+++ b/logstash-core/lib/logstash/filter_delegator.rb
@@ -37,9 +37,9 @@ module LogStash
     def multi_filter(events)
       @metric_events.increment(:in, events.size)
 
-      start = Time.now
+      clock = @filter.metric.time(:duration_in_millis)
       new_events = @filter.multi_filter(events)
-      @filter.metric.increment(:duration_in_millis, ((Time.now - start)*1000).to_i)
+      clock.stop
 
       # There is no garantee in the context of filter
       # that EVENTS_INT == EVENTS_OUT, see the aggregates and

--- a/logstash-core/lib/logstash/instrument/metric.rb
+++ b/logstash-core/lib/logstash/instrument/metric.rb
@@ -46,7 +46,7 @@ module LogStash module Instrument
     end
 
     def report_time(namespace, key, duration)
-      collector.push(namespace, key, :mean, :increment, duration)
+      collector.push(namespace, key, :counter, :increment, duration)
     end
 
     # This method return a metric instance tied to a specific namespace
@@ -81,7 +81,7 @@ module LogStash module Instrument
     #
     # @see LogStash::Instrument::Metric#time
     class TimedExecution
-      MILLISECONDS = 1_000_000.0.freeze
+      MILLISECONDS = 1_000.0.freeze
 
       def initialize(metric, namespace, key)
         @metric = metric

--- a/logstash-core/spec/logstash/filter_delegator_spec.rb
+++ b/logstash-core/spec/logstash/filter_delegator_spec.rb
@@ -68,8 +68,9 @@ describe LogStash::FilterDelegator do
 
     context "when the filter buffer events" do
       it "doesn't increment out" do
+        allow(metric).to receive(:increment).with(:time_ms, anything)
         expect(metric).to receive(:increment).with(:in, events.size)
-        expect(metric).not_to receive(:increment)
+        expect(metric).not_to receive(:increment).with(:out, anything)
 
         subject.multi_filter(events)
       end
@@ -92,6 +93,7 @@ describe LogStash::FilterDelegator do
       end
 
       it "increments the in/out of the metric" do
+        allow(metric).to receive(:increment).with(:time_ms, anything)
         expect(metric).to receive(:increment).with(:in, events.size)
         expect(metric).to receive(:increment).with(:out, events.size * 2)
 
@@ -117,6 +119,7 @@ describe LogStash::FilterDelegator do
     end
 
     it "increments the in/out of the metric" do
+      allow(metric).to receive(:increment).with(:time_ms, anything)
       expect(metric).to receive(:increment).with(:in, events.size)
       expect(metric).to receive(:increment).with(:out, events.size)
 

--- a/logstash-core/spec/logstash/filter_delegator_spec.rb
+++ b/logstash-core/spec/logstash/filter_delegator_spec.rb
@@ -67,11 +67,17 @@ describe LogStash::FilterDelegator do
     end
 
     context "when the filter buffer events" do
-      it "doesn't increment out" do
-        allow(metric).to receive(:increment).with(:time_ms, anything)
-        expect(metric).to receive(:increment).with(:in, events.size)
-        expect(metric).not_to receive(:increment).with(:out, anything)
+      before do
+        allow(metric).to receive(:increment).with(anything, anything)
+      end
 
+      it "has incremented :in" do
+        expect(metric).to receive(:increment).with(:in, events.size)
+        subject.multi_filter(events)
+      end
+
+      it "has not incremented :out" do
+        expect(metric).not_to receive(:increment).with(:out, anything)
         subject.multi_filter(events)
       end
     end
@@ -92,8 +98,11 @@ describe LogStash::FilterDelegator do
         end
       end
 
+      before do
+        allow(metric).to receive(:increment).with(anything, anything)
+      end
+
       it "increments the in/out of the metric" do
-        allow(metric).to receive(:increment).with(:time_ms, anything)
         expect(metric).to receive(:increment).with(:in, events.size)
         expect(metric).to receive(:increment).with(:out, events.size * 2)
 
@@ -114,12 +123,15 @@ describe LogStash::FilterDelegator do
       end
     end
 
+    before do
+      allow(metric).to receive(:increment).with(anything, anything)
+    end
+
     it "doesnt define a flush method" do
       expect(subject.respond_to?(:flush)).to be_falsey
     end
 
     it "increments the in/out of the metric" do
-      allow(metric).to receive(:increment).with(:time_ms, anything)
       expect(metric).to receive(:increment).with(:in, events.size)
       expect(metric).to receive(:increment).with(:out, events.size)
 

--- a/logstash-core/spec/logstash/filter_delegator_spec.rb
+++ b/logstash-core/spec/logstash/filter_delegator_spec.rb
@@ -82,7 +82,7 @@ describe LogStash::FilterDelegator do
       end
     end
 
-    context "when the fitler create more events" do
+    context "when the filter create more events" do
       let(:plugin_klass) do
         Class.new(LogStash::Filters::Base) do
           config_name "super_plugin"

--- a/logstash-core/spec/logstash/instrument/metric_spec.rb
+++ b/logstash-core/spec/logstash/instrument/metric_spec.rb
@@ -67,15 +67,15 @@ describe LogStash::Instrument::Metric do
 
   context "#time" do
     let(:sleep_time) { 2 }
-    let(:sleep_time_ms) { sleep_time * 1_000_000 }
+    let(:sleep_time_ms) { sleep_time * 1_000 }
 
     it "records the duration" do
       subject.time(:root, :duration_ms) { sleep(sleep_time) }
 
-      expect(collector.last).to be_within(sleep_time_ms).of(sleep_time_ms + 5000)
+      expect(collector.last).to be_within(sleep_time_ms).of(sleep_time_ms + 5)
       expect(collector[0]).to match(:root)
       expect(collector[1]).to be(:duration_ms)
-      expect(collector[2]).to be(:mean)
+      expect(collector[2]).to be(:counter)
     end
 
     it "returns the value of the executed block" do
@@ -90,7 +90,7 @@ describe LogStash::Instrument::Metric do
       expect(collector.last).to be_within(sleep_time_ms).of(sleep_time_ms + 0.1)
       expect(collector[0]).to match(:root)
       expect(collector[1]).to be(:duration_ms)
-      expect(collector[2]).to be(:mean)
+      expect(collector[2]).to be(:counter)
     end
   end
 

--- a/logstash-core/spec/logstash/output_delegator_spec.rb
+++ b/logstash-core/spec/logstash/output_delegator_spec.rb
@@ -19,6 +19,7 @@ describe LogStash::OutputDelegator do
       allow(out_klass).to receive(:threadsafe?).and_return(false)
       allow(out_klass).to receive(:workers_not_supported?).and_return(false)
       allow(out_klass).to receive(:name).and_return("example")
+      allow(out_klass).to receive(:config_name)
       allow(out_inst).to receive(:register)
       allow(out_inst).to receive(:multi_receive)
       allow(out_inst).to receive(:metric=).with(any_args)


### PR DESCRIPTION
This PR adds time tracking (wallclock) to all individual filter instances. The goal is to help identify what plugin configurations are consuming the most time.

This data is stored in the internal metrics system and made available via the `/_node/stats/pipelines` HTTP endpoint.