### PR TITLE
Fixes QA acceptance test update issue

### DIFF
--- a/lib/bootstrap/patches/gems.rb
+++ b/lib/bootstrap/patches/gems.rb
@@ -1,0 +1,16 @@
+# encoding: utf-8
+require "gems"
+
+# This patch is necessary to avoid encoding problems when Net:HTTP return stuff in ASCII format, but
+# consumer libraries, like the YAML parsers expect them to be in UTF-8. As we're using UTF-8 everywhere
+# and the usage of versions is minimal in our codebase, the patch is done here. If extended usage of this
+# is done in the feature, more proper fix should be implemented, including the creation of our own lib for
+# this tasks.
+module Gems
+  module Request
+    def get(path, data = {}, content_type = 'application/x-www-form-urlencoded', request_host = host)
+      request(:get, path, data, content_type, request_host).force_encoding("UTF-8")
+    end
+  end
+end
+

--- a/lib/bootstrap/rubygems.rb
+++ b/lib/bootstrap/rubygems.rb
@@ -43,6 +43,16 @@ module LogStash
       end
     end
 
+    ##
+    # Take a plugin name and get the latest versions available in the gem repository.
+    # @param [String] The plugin name
+    # @return [Hash] The collection of registered versions
+    ##
+    def versions(plugin)
+      require "gems"
+      require_relative "patches/gems"
+      Gems.versions(plugin)
+    end
     # Take a gem package and extract it to a specific target
     # @param [String] Gem file, this must be a path
     # @param [String, String] Return a Gem::Package and the installed path

--- a/lib/pluginmanager/util.rb
+++ b/lib/pluginmanager/util.rb
@@ -50,9 +50,8 @@ module LogStash::PluginManager
   # @option options [Boolean] :pre Include pre release versions in the search (default: false)
   # @return [Hash] The plugin version information as returned by rubygems
   def self.fetch_latest_version_info(plugin, options={})
-    require "gems"
     exclude_prereleases =  options.fetch(:pre, false)
-    versions = Gems.versions(plugin)
+    versions = LogStash::Rubygems.versions(plugin)
     raise ValidationError.new("Something went wrong with the validation. You can skip the validation with the --no-verify option") if !versions.is_a?(Array) || versions.empty?
     versions = versions.select { |version| !version["prerelease"] } if !exclude_prereleases
     versions.first

--- a/qa/config/platforms.json
+++ b/qa/config/platforms.json
@@ -1,5 +1,5 @@
 { 
-  "latest": "5.0.0-alpha2",
+  "latest": "5.0.0-alpha3",
   "platforms" : {
     "ubuntu-1204": { "box": "elastic/ubuntu-12.04-x86_64", "type": "debian" },
     "ubuntu-1404": { "box": "elastic/ubuntu-14.04-x86_64", "type": "debian", "specific": true },

--- a/qa/sys/debian/user_bootstrap.sh
+++ b/qa/sys/debian/user_bootstrap.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
 VERSION=`cat /vagrant/config/platforms.json | grep  latest | cut -d":" -f2 | sed 's/["\|,| ]//g'`
-LOGSTASH_FILENAME="logstash-${VERSION}_all.deb"
+LOGSTASH_FILENAME="logstash-${VERSION}.deb"
 wget -q https://download.elastic.co/logstash/logstash/packages/debian/$LOGSTASH_FILENAME
-mv $LOGSTASH_FILENAME "logstash-${VERSION}.deb" # necessary patch until new version with the standard name format are released

--- a/qa/sys/redhat/user_bootstrap.sh
+++ b/qa/sys/redhat/user_bootstrap.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
 VERSION=`cat /vagrant/config/platforms.json | grep  latest | cut -d":" -f2 | sed 's/["\|,| ]//g'`
-LOGSTASH_FILENAME="logstash-${VERSION}.noarch.rpm"
+LOGSTASH_FILENAME="logstash-${VERSION}.rpm"
 wget -q https://download.elastic.co/logstash/logstash/packages/centos/$LOGSTASH_FILENAME
-mv $LOGSTASH_FILENAME "logstash-${VERSION}.rpm" # necessary patch until new version with the standard name format are released

--- a/qa/sys/suse/user_bootstrap.sh
+++ b/qa/sys/suse/user_bootstrap.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 VERSION=`cat /vagrant/config/platforms.json | grep  latest | cut -d":" -f2 | sed 's/["\|,| ]//g'`
-LOGSTASH_FILENAME="logstash-${VERSION}.noarch.rpm"
+LOGSTASH_FILENAME="logstash-${VERSION}.rpm"
 wget -q https://download.elastic.co/logstash/logstash/packages/centos/$LOGSTASH_FILENAME
-mv $LOGSTASH_FILENAME "logstash-${VERSION}.rpm" # necessary patch until new version with the standard name format are released


### PR DESCRIPTION
For some platforms, the update command has been broken due to the fact that for one of the plugins involved (webhdfs output) the requested versions list got understood by `Net::HTTP` as being ASCII and not `UTF-8`. This PR proposes a fix for that that does not require lots of investment due to the small usage of this feature internally.

This PR also updates the latest logstash released to alpha3, and removed the patch introduced to uniformize the names, now all have no arch so it makes no more sense.

Fixes #5468