### PR TITLE
make -V/--version fast on *nix

### DIFF
--- a/bin/logstash
+++ b/bin/logstash
@@ -46,4 +46,11 @@ fi
 . "$(cd `dirname $SOURCEPATH`/..; pwd)/bin/logstash.lib.sh"
 setup
 
-ruby_exec "${LOGSTASH_HOME}/lib/bootstrap/environment.rb" "logstash/runner.rb" "$@"
+if [ "$1" = "-V" ] || [ "$1" = "--version" ];
+then
+  LOGSTASH_VERSION_FILE="${LOGSTASH_HOME}/logstash-core/lib/logstash/version.rb"
+  LOGSTASH_VERSION="$(sed -ne 's/^LOGSTASH_VERSION = "\([^*]*\)"$/\1/p' $LOGSTASH_VERSION_FILE)"
+  echo "logstash $LOGSTASH_VERSION"
+else
+  ruby_exec "${LOGSTASH_HOME}/lib/bootstrap/environment.rb" "logstash/runner.rb" "$@"
+fi

--- a/qa/acceptance/spec/shared_examples/cli/logstash/version.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash/version.rb
@@ -14,8 +14,14 @@ shared_examples "logstash version" do |logstash|
 
     context "on #{logstash.hostname}" do
       it "returns the right logstash version" do
-        result = logstash.run_command_in_path("bin/logstash --path.settings=/etc/logstash --version")
+        result = logstash.run_command_in_path("bin/logstash --version")
         expect(result).to run_successfully_and_output(/#{LOGSTASH_VERSION}/)
+      end
+      context "when also using the --path.settings argument" do
+        it "returns the right logstash version" do
+          result = logstash.run_command_in_path("bin/logstash --path.settings=/etc/logstash --version")
+          expect(result).to run_successfully_and_output(/#{LOGSTASH_VERSION}/)
+        end
       end
     end
   end


### PR DESCRIPTION
```
/tmp/logstash-5.0.0 % time bin/logstash -V
logstash 5.0.0
bin/logstash -V  27.79s user 1.34s system 270% cpu 10.773 total

/tmp/logstash-5.0.0 % patch -p1 < /tmp/patch
patching file bin/logstash

/tmp/logstash-5.0.0 % time bin/logstash -V
logstash 5.0.0
bin/logstash -V  0.01s user 0.02s system 101% cpu 0.029 total
```

Still figuring out how to do the same in Windows BAT scripts..