### PR TITLE
[Backport from master] Add new :list property to configuration parameters.

### DIFF
--- a/docs/static/configuration.asciidoc
+++ b/docs/static/configuration.asciidoc
@@ -83,25 +83,38 @@ The settings you can configure vary according to the plugin type. For informatio
 === Value Types
 
 A plugin can require that the value for a setting be a
-certain type, such as boolean or hash. The following value
+certain type, such as boolean, list, or hash. The following value
 types are supported.
 
 [[array]]
-[float]
 ==== Array
 
-An array can be a single string value or multiple values. If you specify the same
-setting multiple times, it appends to the array.
+This type is now mostly deprecated in favor of using a standard type like `string` with the plugin defining the `:list => true` property for better type checking. It is still needed to handle lists of hashes or mixed types where type checking is not desired.
+
+Example:
+
+[source,js]
+----------------------------------
+  users => [ {id => 1, name => bob}, {id => 2, name => jane} ]
+----------------------------------
+
+[[list]]
+[float]
+==== Lists
+
+Not a type in and of itself, but a property types can have.
+This makes it possible to type check multiple values.
+Plugin authors can enable list checking by specifying `:list => true` when declaring an argument.
 
 Example:
 
 [source,js]
 ----------------------------------
   path => [ "/var/log/messages", "/var/log/*.log" ]
-  path => "/data/mysql/mysql.log"
+  uris => [ "http://elastic.co", "http://example.net" ]
 ----------------------------------
 
-This example configures `path` to be an array that contains an element for each of the three strings.
+This example configures `path`, which is a `string` to be a list that contains an element for each of the three strings. It also will configure the `uris` parameter to be a list of URIs, failing if any of the URIs provided are not valid.
 
 
 [[boolean]]

--- a/docs/static/include/pluginbody.asciidoc
+++ b/docs/static/include/pluginbody.asciidoc
@@ -474,13 +474,14 @@ There are several configuration attributes:
 
 * `:validate` - allows you to enforce passing a particular data type to Logstash
 for this configuration option, such as `:string`, `:password`, `:boolean`,
-`:number`, `:array`, `:hash`, `:path` (a file-system path), `:codec` (since
+`:number`, `:array`, `:hash`, `:path` (a file-system path), `uri`, `:codec` (since
 1.2.0), `:bytes` (starting in 1.5.0).  Note that this also works as a coercion
 in that if I specify "true" for boolean (even though technically a string), it
 will become a valid boolean in the config.  This coercion works for the
 `:number` type as well where "1.2" becomes a float and "22" is an integer.
 * `:default` - lets you specify a default value for a parameter
 * `:required` - whether or not this parameter is mandatory (a Boolean `true` or
+* `:list` - whether or not this value should be a list of values. Will typecheck the list members, and convert scalars to one element lists. Note that this mostly obviates the array type, though if you need lists of complex objects that will be more suitable.
 `false`)
 * `:deprecated` - informational (also a Boolean `true` or `false`)
 * `:obsolete` - used to declare that a given setting has been removed and is no longer functioning. The idea is to provide an informed upgrade path to users who are still using a now-removed setting.

--- a/logstash-core/lib/logstash/util/safe_uri.rb
+++ b/logstash-core/lib/logstash/util/safe_uri.rb
@@ -40,5 +40,9 @@ class LogStash::Util::SafeURI
     safe.password = PASS_PLACEHOLDER
     safe
   end
+
+  def ==(other)
+    other.is_a?(::LogStash::Util::SafeURI) ? @uri == other.uri : false
+  end
 end
 


### PR DESCRIPTION
If set to try this will allow the user to specify one or more values.
This generally replaces the :array type, which had fewer type checks.

The array type is still needed for lists of complex objects, e.g. hashes.