### PR TITLE
Bring back accidentally deleted regexp param required validation

### DIFF
--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -342,6 +342,10 @@ module LogStash::Config::Mixin
       @config.each do |config_key, config|
         next unless config[:required]
 
+        if config_key.is_a?(Regexp) && !params.keys.any? { |k| k =~ config_key }
+          is_valid = false
+        end
+
         value = params[config_key]
         if value.nil? || (config[:list] && Array(value).empty?)
           @logger.error(I18n.t("logstash.runner.configuration.setting_missing",


### PR DESCRIPTION
This brings back the regexp style param validation that was removed in https://github.com/elastic/logstash/pull/5453/commits/1a4945b328f2f210a72a929ce745e599ef37c969#diff-a6e4c05968a280041313edf9363cf1b0L337

This needs to be merged ONLY into 5.0 and master, 2.x is fine.

