### PR TITLE
Revert geoip filter to 2.x

### DIFF
--- a/Gemfile.jruby-1.9.lock
+++ b/Gemfile.jruby-1.9.lock
@@ -80,6 +80,7 @@ GEM
     gelfd (0.2.0)
     gem_publisher (1.5.0)
     gems (0.8.3)
+    geoip (1.6.1)
     gmetric (0.1.3)
     hipchat (1.5.3)
       httparty
@@ -206,8 +207,10 @@ GEM
     logstash-filter-fingerprint (2.0.5)
       logstash-core-plugin-api (~> 1.0)
       murmurhash3
-    logstash-filter-geoip (3.0.1-java)
+    logstash-filter-geoip (2.0.7)
+      geoip (>= 1.3.2)
       logstash-core-plugin-api (~> 1.0)
+      lru_redux (~> 1.1.0)
     logstash-filter-grok (2.0.5)
       jls-grok (~> 0.11.1)
       logstash-core-plugin-api (~> 1.0)


### PR DESCRIPTION
Previous update had included 3.x of geoip filter which was a rewrite for GeoIP2. This should not be included in a bug fix release, so reverting to 2.x