### PR TITLE
Fix a regression where untyped fields would return null values

### DIFF
--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -430,7 +430,7 @@ module LogStash::Config::Mixin
       result = nil
 
       if validator.nil?
-        return true
+        return true, value
       elsif validator.is_a?(Array)
         value = [*value]
         if value.size > 1


### PR DESCRIPTION
This patch fixes a bug where config fields declared without a type
would just return null.