### PR TITLE
Stats default fields

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -20,7 +20,7 @@ LogStash::Environment.load_locale!
 class LogStash::Agent
   STARTED_AT = Time.now.freeze
 
-  attr_reader :metric, :node_name, :pipelines, :settings
+  attr_reader :metric, :node_name, :pipelines, :settings, :webserver
   attr_accessor :logger
 
   # initialize method for LogStash::Agent

--- a/logstash-core/lib/logstash/api/app_helpers.rb
+++ b/logstash-core/lib/logstash/api/app_helpers.rb
@@ -6,6 +6,11 @@ module LogStash::Api::AppHelpers
   def respond_with(data, options={})
     as     = options.fetch(:as, :json)
     pretty = params.has_key?("pretty")
+
+    unless options.include?(:exclude_default_metadata)
+      data = default_metadata.merge(data)
+    end
+    
     if as == :json
       content_type "application/json"
       LogStash::Json.dump(data, {:pretty => pretty})
@@ -19,5 +24,9 @@ module LogStash::Api::AppHelpers
     return true   if string == true   || string =~ (/(true|t|yes|y|1)$/i)
     return false  if string == false  || string.blank? || string =~ (/(false|f|no|n|0)$/i)
     raise ArgumentError.new("invalid value for Boolean: \"#{string}\"")
+  end
+
+  def default_metadata
+    @factory.build(:default_metadata).all
   end
 end

--- a/logstash-core/lib/logstash/api/command_factory.rb
+++ b/logstash-core/lib/logstash/api/command_factory.rb
@@ -4,6 +4,7 @@ require "logstash/api/commands/system/basicinfo_command"
 require "logstash/api/commands/system/plugins_command"
 require "logstash/api/commands/stats"
 require "logstash/api/commands/node"
+require "logstash/api/commands/default_metadata"
 
 
 module LogStash
@@ -17,7 +18,8 @@ module LogStash
           :system_basic_info => ::LogStash::Api::Commands::System::BasicInfo,
           :plugins_command => ::LogStash::Api::Commands::System::Plugins,
           :stats => ::LogStash::Api::Commands::Stats,
-          :node => ::LogStash::Api::Commands::Node
+          :node => ::LogStash::Api::Commands::Node,
+          :default_metadata => ::LogStash::Api::Commands::DefaultMetadata
         }
       end
 

--- a/logstash-core/lib/logstash/api/commands/base.rb
+++ b/logstash-core/lib/logstash/api/commands/base.rb
@@ -8,14 +8,10 @@ module LogStash
           @service = service
         end
 
-        def hostname
-          service.agent.node_name
-        end
-
         def uptime
           service.agent.uptime
         end
-
+        
         def started_at
           (LogStash::Agent::STARTED_AT.to_f * 1000.0).to_i
         end

--- a/logstash-core/lib/logstash/api/commands/default_metadata.rb
+++ b/logstash-core/lib/logstash/api/commands/default_metadata.rb
@@ -1,0 +1,25 @@
+require "logstash/api/commands/base"
+
+module LogStash
+  module Api
+    module Commands
+      class DefaultMetadata < Commands::Base
+        def all
+          {:host => host, :version => version, :http_address => http_address}
+        end
+        
+        def host
+          Socket.gethostname
+        end
+
+        def version
+          LOGSTASH_CORE_VERSION
+        end
+
+        def http_address
+          service.agent.webserver.address
+        end
+      end
+    end
+  end
+end

--- a/logstash-core/lib/logstash/api/commands/node.rb
+++ b/logstash-core/lib/logstash/api/commands/node.rb
@@ -9,7 +9,7 @@ module LogStash
             :pipeline => pipeline,
             :os => os,
             :jvm => jvm
-          }           
+          }
         end
         
         def pipeline
@@ -83,7 +83,7 @@ module LogStash
           end
 
           def to_hash
-            hash = { :hostname => @cmd.hostname, :time => Time.now.iso8601, :busiest_threads => @thread_dump.top_count, :threads => [] }
+            hash = { :time => Time.now.iso8601, :busiest_threads => @thread_dump.top_count, :threads => [] }
             @thread_dump.each do |thread_name, _hash|
               thread_name, thread_path = _hash["thread.name"].split(": ")
               thread = { :name => thread_name,

--- a/logstash-core/lib/logstash/api/commands/system/basicinfo_command.rb
+++ b/logstash-core/lib/logstash/api/commands/system/basicinfo_command.rb
@@ -10,10 +10,8 @@ module LogStash
         class BasicInfo < Commands::Base
 
           def run
-            {
-              "hostname" => hostname,
-              "version" => { "number" => LOGSTASH_VERSION }.merge(BUILD_INFO)
-            }
+            # Just merge this stuff with the defaults
+            BUILD_INFO
           end
         end
       end

--- a/logstash-core/lib/logstash/api/modules/base.rb
+++ b/logstash-core/lib/logstash/api/modules/base.rb
@@ -15,7 +15,7 @@ module LogStash
         set :raise_errors, true
         set :show_exceptions, false
 
-        attr_reader :factory
+        attr_reader :factory, :agent
 
         include LogStash::Util::Loggable
 
@@ -23,6 +23,7 @@ module LogStash
 
         def initialize(app=nil, agent)
           super(app)
+          @agent = agent
           @factory = ::LogStash::Api::CommandFactory.new(LogStash::Api::Service.new(agent))
         end
 

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -16,6 +16,7 @@ require "logstash/config/defaults"
 require "logstash/shutdown_watcher"
 require "logstash/patches/clamp"
 require "logstash/settings"
+require "logstash/version"
 
 class LogStash::Runner < Clamp::StrictCommand
   # The `path.settings` need to be defined in the runner instead of the `logstash-core/lib/logstash/environment.rb`
@@ -256,7 +257,6 @@ class LogStash::Runner < Clamp::StrictCommand
   end # def show_version
 
   def show_version_logstash
-    require "logstash/version"
     puts "logstash #{LOGSTASH_VERSION}"
   end # def show_version_logstash
 

--- a/logstash-core/lib/logstash/webserver.rb
+++ b/logstash-core/lib/logstash/webserver.rb
@@ -55,6 +55,10 @@ module LogStash
     def error(str)
       logger.error(str)
     end
+
+    def address
+      "#{http_host}:#{http_port}"
+    end
     
     # Empty method, this method is required because of the puma usage we make through
     # the Single interface, https://github.com/puma/puma/blob/master/lib/puma/single.rb#L82

--- a/logstash-core/spec/api/lib/api/node_spec.rb
+++ b/logstash-core/spec/api/lib/api/node_spec.rb
@@ -85,7 +85,6 @@ describe LogStash::Api::Modules::Node do
           }
         },
         "hot_threads"=> {
-          "hostname" => String,
           "time" => String,
           "busiest_threads" => Numeric,
           "threads" => Array

--- a/logstash-core/spec/api/lib/api/support/resource_dsl_methods.rb
+++ b/logstash-core/spec/api/lib/api/support/resource_dsl_methods.rb
@@ -23,6 +23,21 @@ module ResourceDSLMethods
       it "should respond OK" do
         expect(last_response).to be_ok
       end
+
+      
+      describe "the default metadata" do
+        it "should include the host" do
+          expect(payload["host"]).to eql(Socket.gethostname)
+        end
+
+        it "should include the version" do
+          expect(payload["version"]).to eql(LOGSTASH_CORE_VERSION)
+        end
+
+        it "should include the http address" do
+          expect(payload["http_address"]).to eql("#{Socket.gethostname}:#{::LogStash::WebServer::DEFAULT_PORT}")
+        end
+      end
       
       hash_to_mapping(expected).each do |resource_path,klass|
         dotted = resource_path.join(".")

--- a/logstash-core/spec/api/spec_helper.rb
+++ b/logstash-core/spec/api/spec_helper.rb
@@ -17,7 +17,9 @@ end
 
 module LogStash
   class DummyAgent < Agent
-    def start_webserver; end
+    def start_webserver
+      @webserver = Struct.new(:address).new("#{Socket.gethostname}:#{::LogStash::WebServer::DEFAULT_PORT}")
+    end
     def stop_webserver; end
   end
 end
@@ -92,7 +94,7 @@ shared_context "api setup" do
     @runner = LogStashRunner.new
     @runner.start
   end
-
+  
   after :all do
     @runner.stop
   end


### PR DESCRIPTION
This fixes #5450 and better conforms the API to #5475 

All API endpoints now return the following three fields:

* host
* http_address
* version