### PR TITLE
make acceptance test framework pick snapshot rpm/deb builds

### DIFF
--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/install.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/install.rb
@@ -5,7 +5,7 @@ require "fileutils"
 
 shared_examples "logstash install" do |logstash|
   before(:each) do
-    logstash.install(LOGSTASH_VERSION)
+    logstash.install({:version => LOGSTASH_VERSION})
   end
 
   after(:each) do

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/list.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/list.rb
@@ -6,7 +6,7 @@ require "fileutils"
 shared_examples "logstash list" do |logstash|
   describe "logstash-plugin list on #{logstash.hostname}" do
     before(:all) do
-      logstash.install(LOGSTASH_VERSION)
+      logstash.install({:version => LOGSTASH_VERSION})
     end
 
     after(:all) do

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/uninstall.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/uninstall.rb
@@ -6,7 +6,7 @@ require "fileutils"
 shared_examples "logstash uninstall" do |logstash|
   describe "logstash uninstall on #{logstash.hostname}" do
     before :each do
-      logstash.install(LOGSTASH_VERSION)
+      logstash.install({:version => LOGSTASH_VERSION})
     end
 
     after :each do

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/update.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/update.rb
@@ -5,7 +5,7 @@ require "logstash/version"
 shared_examples "logstash update" do |logstash|
   describe "logstash update on #{logstash.hostname}" do
     before :each do
-      logstash.install(LOGSTASH_VERSION)
+      logstash.install({:version => LOGSTASH_VERSION})
     end
 
     after :each do

--- a/qa/acceptance/spec/shared_examples/cli/logstash/version.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash/version.rb
@@ -5,7 +5,7 @@ require "logstash/version"
 shared_examples "logstash version" do |logstash|
   describe "logstash --version" do
     before :all do
-      logstash.install(LOGSTASH_VERSION)
+      logstash.install({:version => LOGSTASH_VERSION})
     end
 
     after :all do

--- a/qa/acceptance/spec/shared_examples/installed.rb
+++ b/qa/acceptance/spec/shared_examples/installed.rb
@@ -5,7 +5,7 @@ require          'logstash/version'
 RSpec.shared_examples "installable" do |logstash|
 
   before(:each) do
-    logstash.install(LOGSTASH_VERSION)
+    logstash.install({:version => LOGSTASH_VERSION})
   end
 
   it "is installed on #{logstash.hostname}" do

--- a/qa/acceptance/spec/shared_examples/running.rb
+++ b/qa/acceptance/spec/shared_examples/running.rb
@@ -5,7 +5,7 @@ require          'logstash/version'
 RSpec.shared_examples "runnable" do |logstash|
 
   before(:each) do
-    logstash.install(LOGSTASH_VERSION)
+    logstash.install({:version => LOGSTASH_VERSION})
   end
 
   it "is running on #{logstash.hostname}" do

--- a/qa/acceptance/spec/shared_examples/updated.rb
+++ b/qa/acceptance/spec/shared_examples/updated.rb
@@ -11,12 +11,14 @@ RSpec.shared_examples "updated" do |logstash|
   end
 
   before(:each) do
-    logstash.install(LOGSTASH_LATEST_VERSION, "./") # make sure latest version is installed
+    options={:version => LOGSTASH_LATEST_VERSION, :snapshot => false, :base => "./" }
+    logstash.install(options) # make sure latest version is installed
   end
 
   it "can be updated an run on #{logstash.hostname}" do
+    expect(logstash).to be_installed
     # Performing the update
-    logstash.install(LOGSTASH_VERSION)
+    logstash.install({:version => LOGSTASH_VERSION})
     expect(logstash).to be_installed
     # starts the service to be sure it runs after the upgrade
     logstash.start_service

--- a/qa/rspec/commands.rb
+++ b/qa/rspec/commands.rb
@@ -56,8 +56,9 @@ module ServiceTester
       client.stop_service(name, host)
     end
 
-    def install(version, base=ServiceTester::Base::LOCATION)
-      package = client.package_for(version, base)
+    def install(options={})
+      base      = options.fetch(:base, ServiceTester::Base::LOCATION)
+      package   = client.package_for(filename(options), base)
       client.install(package, host)
     end
 
@@ -91,6 +92,13 @@ module ServiceTester
 
     def to_s
       "Artifact #{name}@#{host}"
+    end
+
+    private
+
+    def filename(options={})
+      snapshot  = options.fetch(:snapshot, true)
+      "logstash-#{options[:version]}#{(snapshot ?  "-SNAPSHOT" : "")}"
     end
   end
 

--- a/qa/rspec/commands/debian.rb
+++ b/qa/rspec/commands/debian.rb
@@ -17,7 +17,7 @@ module ServiceTester
     end
 
     def package_for(version, base=ServiceTester::Base::LOCATION)
-      File.join(base, "logstash-#{version}.deb")
+      File.join(base, "logstash-#{version}-SNAPSHOT.deb")
     end
 
     def install(package, host=nil)

--- a/qa/rspec/commands/debian.rb
+++ b/qa/rspec/commands/debian.rb
@@ -16,14 +16,14 @@ module ServiceTester
       stdout.match(/^Status: install ok installed$/)
     end
 
-    def package_for(version, base=ServiceTester::Base::LOCATION)
-      File.join(base, "logstash-#{version}-SNAPSHOT.deb")
+    def package_for(filename, base=ServiceTester::Base::LOCATION)
+      File.join(base, "#{filename}.deb")
     end
 
     def install(package, host=nil)
       hosts = (host.nil? ? servers : Array(host))
       at(hosts, {in: :serial}) do |_|
-        sudo_exec!("dpkg -i  #{package}")
+        cmd = sudo_exec!("dpkg -i  #{package}")
       end
     end
 

--- a/qa/rspec/commands/redhat.rb
+++ b/qa/rspec/commands/redhat.rb
@@ -16,8 +16,8 @@ module ServiceTester
       stdout.match(/^logstash.noarch/)
     end
 
-    def package_for(version, base=ServiceTester::Base::LOCATION)
-      File.join(base, "logstash-#{version}-SNAPSHOT.rpm")
+    def package_for(filename, base=ServiceTester::Base::LOCATION)
+      File.join(base, "#{filename}.rpm")
     end
 
     def install(package, host=nil)

--- a/qa/rspec/commands/redhat.rb
+++ b/qa/rspec/commands/redhat.rb
@@ -17,7 +17,7 @@ module ServiceTester
     end
 
     def package_for(version, base=ServiceTester::Base::LOCATION)
-      File.join(base, "logstash-#{version}.rpm")
+      File.join(base, "logstash-#{version}-SNAPSHOT.rpm")
     end
 
     def install(package, host=nil)

--- a/qa/rspec/commands/suse.rb
+++ b/qa/rspec/commands/suse.rb
@@ -13,8 +13,8 @@ module ServiceTester
       stdout.match(/^i | logstash | An extensible logging pipeline | package$/)
     end
 
-    def package_for(version, base=ServiceTester::Base::LOCATION)
-      File.join(base, "logstash-#{version}-SNAPSHOT.rpm")
+    def package_for(filename, base=ServiceTester::Base::LOCATION)
+      File.join(base, "#{filename}.rpm")
     end
 
     def install(package, host=nil)

--- a/qa/rspec/commands/suse.rb
+++ b/qa/rspec/commands/suse.rb
@@ -14,7 +14,7 @@ module ServiceTester
     end
 
     def package_for(version, base=ServiceTester::Base::LOCATION)
-      File.join(base, "logstash-#{version}.rpm")
+      File.join(base, "logstash-#{version}-SNAPSHOT.rpm")
     end
 
     def install(package, host=nil)


### PR DESCRIPTION
by default, logstash will generate rpm/deb files called logstash-#{LOGSTASH_VERSION}-SNAPSHOT.rpm/deb

this PR reflects that change so that acceptance tests can be executed correctly