### PR TITLE
Set master's version to 5.0.0-alpha4

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -1,6 +1,6 @@
 ---
-logstash: 5.0.0
-logstash-core: 5.0.0
-logstash-core-event: 5.0.0
-logstash-core-event-java: 5.0.0
-logstash-core-plugin-api: 2.1.7
+logstash: 5.0.0-alpha4
+logstash-core: 5.0.0-alpha4
+logstash-core-event: 5.0.0-alpha4
+logstash-core-event-java: 5.0.0-alpha4
+logstash-core-plugin-api: 2.1.9


### PR DESCRIPTION
Set master branch's version to 5.0.0-alpha4 to match other projects like ES, Kibana and Beats. Alphas will be released from the master branch. This is to make the unified release consistently work across products