### PR TITLE
Improve acceptance tests execution time

### DIFF
--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/install.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/install.rb
@@ -32,10 +32,22 @@ shared_examples "logstash install" do |logstash|
         end
 
         context "when fetching a gem from rubygems" do
+
           it "successfully install the plugin" do
+            command = logstash.run_command_in_path("bin/logstash-plugin install logstash-filter-qatest")
+            expect(command).to install_successfully
+            expect(logstash).to have_installed?("logstash-filter-qatest")
+          end
+
+          it "successfully install the plugin when verification is disabled" do
             command = logstash.run_command_in_path("bin/logstash-plugin install --no-verify logstash-filter-qatest")
             expect(command).to install_successfully
             expect(logstash).to have_installed?("logstash-filter-qatest")
+          end
+
+          it "fails when installing a non logstash plugin" do
+            command = logstash.run_command_in_path("bin/logstash-plugin install  bundler")
+            expect(command).not_to install_successfully
           end
 
           it "allow to install a specific version" do

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/install.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/install.rb
@@ -33,13 +33,13 @@ shared_examples "logstash install" do |logstash|
 
         context "when fetching a gem from rubygems" do
           it "successfully install the plugin" do
-            command = logstash.run_command_in_path("bin/logstash-plugin install logstash-filter-qatest")
+            command = logstash.run_command_in_path("bin/logstash-plugin install --no-verify logstash-filter-qatest")
             expect(command).to install_successfully
             expect(logstash).to have_installed?("logstash-filter-qatest")
           end
 
           it "allow to install a specific version" do
-            command = logstash.run_command_in_path("bin/logstash-plugin install --version 0.1.0 logstash-filter-qatest")
+            command = logstash.run_command_in_path("bin/logstash-plugin install --no-verify --version 0.1.0 logstash-filter-qatest")
             expect(command).to install_successfully
             expect(logstash).to have_installed?("logstash-filter-qatest", "0.1.0")
           end

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/update.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/update.rb
@@ -16,7 +16,7 @@ shared_examples "logstash update" do |logstash|
     let(:previous_version) { "0.1.0" }
 
     before do
-      logstash.run_command_in_path("bin/logstash-plugin install --version #{previous_version} #{plugin_name}")
+      logstash.run_command_in_path("bin/logstash-plugin install --no-verify --version #{previous_version} #{plugin_name}")
       # Logstash wont update when we have a pinned versionin the gemfile so we remove them
       logstash.replace_in_gemfile(',\s"0.1.0"', "")
       expect(logstash).to have_installed?(plugin_name, previous_version)
@@ -24,7 +24,7 @@ shared_examples "logstash update" do |logstash|
 
     context "update a specific plugin" do
       it "has executed succesfully" do
-        cmd = logstash.run_command_in_path("bin/logstash-plugin update #{plugin_name}")
+        cmd = logstash.run_command_in_path("bin/logstash-plugin update --no-verify #{plugin_name}")
         expect(cmd.stdout).to match(/Updating #{plugin_name}/)
         expect(logstash).not_to have_installed?(plugin_name, previous_version)
       end
@@ -32,7 +32,7 @@ shared_examples "logstash update" do |logstash|
 
     context "update all the plugins" do
       it "has executed succesfully" do
-        logstash.run_command_in_path("bin/logstash-plugin update")
+        logstash.run_command_in_path("bin/logstash-plugin update --no-verify")
         expect(logstash).to have_installed?(plugin_name, "0.1.1")
       end
     end

--- a/qa/rspec/commands/base.rb
+++ b/qa/rspec/commands/base.rb
@@ -29,7 +29,7 @@ module ServiceTester
 
       response = nil
       at(hosts, {in: :serial}) do |_host|
-        response = sudo_exec!(cmd)
+        response = sudo_exec!("JARS_SKIP='true' #{cmd}")
       end
       response
     end


### PR DESCRIPTION
Hi,
  after performing some benchmarking for the install command in #5523, in this PR it basically disable jar dependencies and the plugin validation, this two are the biggest offenders in terms of execution time so CLI plugin manager test basically get an speedup of nearly 50% per platform.

See  `13 minutes 48 seconds` without this change, to  `6 minutes 48 seconds`  with this change.

A proper solution to make this two flags faster should be researched, but for now the effort for it is quite important, so decided to push this two small changes here to make our test suites faster sooner.