### PR TITLE
Fix an issue where metric instance was nil when running test from a plugin

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -184,7 +184,11 @@ class LogStash::Agent
     begin
       LogStash::Pipeline.new(config, settings, metric)
     rescue => e
-      @logger.error("fetched an invalid config", :config => config, :reason => e.message)
+      if @logger.debug?
+        @logger.error("fetched an invalid config", :config => config, :reason => e.message, :backtrace => e.backtrace)
+      else
+        @logger.error("fetched an invalid config", :config => config, :reason => e.message)
+      end
       return
     end
   end

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -437,7 +437,9 @@ module LogStash; class Pipeline
     elsif plugin_type == "filter"
       LogStash::FilterDelegator.new(@logger, klass, pipeline_scoped_metric.namespace(:filters), *args)
     else
-      klass.new(*args)
+      new_plugin = klass.new(*args)
+      new_plugin.metric = pipeline_scoped_metric.namespace(:inputs)
+      new_plugin
     end
   end
 

--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -105,9 +105,17 @@ class LogStash::Plugin
   end
 
   def metric
-    @metric_plugin ||= enable_metric ? @metric : LogStash::Instrument::NullMetric.new
+    @metric_plugin ||= begin
+                         # We can disable metric per plugin if we want in the configuration
+                         # we will use the NullMetric in this case.
+                         if @enable_metric
+                           # Fallback when testing plugin and no metric collector are correctly configured.
+                           @metric.nil? ? LogStash::Instrument::NullMetric.new : @metric
+                         else
+                           LogStash::Instrument::NullMetric.new
+                         end
+                       end
   end
-
   # return the configured name of this plugin
   # @return [String] The name of the plugin defined by `config_name`
   def config_name

--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -105,15 +105,13 @@ class LogStash::Plugin
   end
 
   def metric
-    @metric_plugin ||= begin
-                         # We can disable metric per plugin if we want in the configuration
-                         # we will use the NullMetric in this case.
-                         if @enable_metric
-                           # Fallback when testing plugin and no metric collector are correctly configured.
-                           @metric.nil? ? LogStash::Instrument::NullMetric.new : @metric
-                         else
-                           LogStash::Instrument::NullMetric.new
-                         end
+    # We can disable metric per plugin if we want in the configuration
+    # we will use the NullMetric in this case.
+    @metric_plugin ||= if @enable_metric
+                         # Fallback when testing plugin and no metric collector are correctly configured.
+                         @metric.nil? ? LogStash::Instrument::NullMetric.new : @metric
+                       else
+                         LogStash::Instrument::NullMetric.new
                        end
   end
   # return the configured name of this plugin

--- a/logstash-core/spec/logstash/inputs/metrics_spec.rb
+++ b/logstash-core/spec/logstash/inputs/metrics_spec.rb
@@ -8,7 +8,7 @@ describe LogStash::Inputs::Metrics do
   let(:queue) { [] }
 
   before :each do
-    allow(subject).to receive(:metric).and_return(metric)
+    subject.metric = metric
   end
 
   describe "#run" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,9 @@ CoverageHelper.eager_load if ENV['COVERAGE']
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/logging/json"
 
+require "flores/rspec"
+require "flores/random"
+
 class JSONIOThingy < IO
   def initialize; end
   def flush; end
@@ -18,6 +21,7 @@ class JSONIOThingy < IO
 end
 
 RSpec.configure do |c|
+  Flores::RSpec.configure(c)
   c.before do
     # Force Cabin to always have a JSON subscriber.  The main purpose of this
     # is to catch crashes in json serialization for our logs. JSONIOThingy


### PR DESCRIPTION
This PR introduces a few changes:

- Make sure that a metric object is always available even if the plugin was not created from a pipeline see https://github.com/logstash-plugins/logstash-filter-geoip/pull/83#issuecomment-227852968 for more details
- When you run logstash in debug mode and an accepting occur we will display the stacktrace, this make debugging issues with the pipeline a bit easier to track.
- The metric object was not correctly setup for input plugin and would have make the metric collection fails for theses one.
- Flores is now setup in the Rspec.configure instead of a file basis.


When this PR is merged we need to release a new snapshot to make sure the plugin test correctly pass.