### PR TITLE
Implement a NullMetric Object in the 2.X series of Logstash

### DIFF
--- a/logstash-core/lib/logstash/instrument/null_metric.rb
+++ b/logstash-core/lib/logstash/instrument/null_metric.rb
@@ -1,0 +1,45 @@
+# encoding: utf-8
+
+module LogStash module Instrument
+ # This class is used in the context when we disable the metric collection
+ # for specific plugin to replace the `NamespacedMetric` class with this one
+ # which doesn't produce any metric to the collector.
+ class NullMetric
+   attr_reader :namespace_name, :collector
+
+   def increment(key, value = 1)
+   end
+
+   def decrement(key, value = 1)
+   end
+
+   def gauge(key, value)
+   end
+
+   def report_time(key, duration)
+   end
+
+   # We have to manually redefine this method since it can return an
+   # object this object also has to be implemented as a NullObject
+   def time(key, &block)
+     if block_given?
+       yield
+     else
+       NullTimedExecution
+     end
+   end
+
+   def namespace(name)
+     self.class.new
+   end
+
+   private
+   # Null implementation of the internal timer class
+   #
+   # @see LogStash::Instrument::TimedExecution`
+   class NullTimedExecution
+     def self.stop
+     end
+   end
+ end
+end; end

--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -2,6 +2,7 @@
 require "logstash/namespace"
 require "logstash/logging"
 require "logstash/config/mixin"
+require "logstash/instrument/null_metric"
 require "cabin"
 require "concurrent"
 
@@ -26,6 +27,7 @@ class LogStash::Plugin
   def initialize(params=nil)
     @params = LogStash::Util.deep_clone(params)
     @logger = Cabin::Channel.get(LogStash)
+    @metric_plugin = LogStash::Instrument::NullMetric.new
   end
 
   # close is called during shutdown, after the plugin worker
@@ -45,6 +47,14 @@ class LogStash::Plugin
 
   def to_s
     return "#{self.class.name}: #{@params}"
+  end
+
+  # This is a shim to make sure that plugin
+  # that record metric still work with 2.4
+  #
+  # https://github.com/elastic/logstash/issues/5539
+  def metric
+    @metric_plugin
   end
 
   public

--- a/logstash-core/spec/logstash/instrument/null_metric_spec.rb
+++ b/logstash-core/spec/logstash/instrument/null_metric_spec.rb
@@ -1,0 +1,59 @@
+# encoding: utf-8
+require "logstash/instrument/null_metric"
+
+describe LogStash::Instrument::NullMetric do
+  let(:key) { "galaxy" }
+
+  describe "#increment" do
+    it "allows to increment a key with no amount" do
+      expect { subject.increment(key, 100) }.not_to raise_error
+    end
+
+    it "allow to increment a key" do
+      expect { subject.increment(key) }.not_to raise_error
+    end
+  end
+
+  describe "#decrement" do
+    it "allows to decrement a key with no amount" do
+      expect { subject.decrement(key, 100) }.not_to raise_error
+    end
+
+    it "allow to decrement a key" do
+      expect { subject.decrement(key) }.not_to raise_error
+    end
+  end
+
+  describe "#gauge" do
+    it "allows to set a value" do
+      expect { subject.gauge(key, "pluto") }.not_to raise_error
+    end
+  end
+
+  describe "#report_time" do
+    it "allow to record time" do
+      expect { subject.report_time(key, 1000) }.not_to raise_error
+    end
+  end
+
+  describe "#time" do
+    it "allow to record time with a block given" do
+      expect do
+        subject.time(key) { 1+1 }
+      end.not_to raise_error
+    end
+
+    it "allow to record time with no block given" do
+      expect do
+        clock = subject.time(key)
+        clock.stop
+      end.not_to raise_error
+    end
+  end
+
+  describe "#namespace" do
+    it "return a NullMetric" do
+      expect(subject.namespace(key)).to be_kind_of LogStash::Instrument::NullMetric
+    end
+  end
+end

--- a/logstash-core/spec/logstash/instrument/null_metric_spec.rb
+++ b/logstash-core/spec/logstash/instrument/null_metric_spec.rb
@@ -43,6 +43,10 @@ describe LogStash::Instrument::NullMetric do
       end.not_to raise_error
     end
 
+    it "when using a block it return the generated value" do
+      expect(subject.time(key) { 1+1 }).to eq(2)
+    end
+
     it "allow to record time with no block given" do
       expect do
         clock = subject.time(key)


### PR DESCRIPTION
This PR, backport the `NullMetric` class from the master branch into the
2.X series and allow to write plugin that can be run on both Logstash 5
and Logstash 2.X without changing the code and without having to check
if the metric object is set before capturing a metric.

Fixes: #5539