### PR TITLE
do not remove (a possibly) created user/group on rpm uninstallation

### DIFF
--- a/pkg/centos/before-remove.sh
+++ b/pkg/centos/before-remove.sh
@@ -27,11 +27,4 @@ if [ $1 -eq 0 ]; then
       rm /etc/systemd/system/logstash.service
     fi
   fi
-  if getent passwd logstash >/dev/null ; then
-    userdel logstash
-  fi
-
-  if getent group logstash > /dev/null ; then
-    groupdel logstash
-  fi
 fi

--- a/pkg/debian/before-remove.sh
+++ b/pkg/debian/before-remove.sh
@@ -28,11 +28,4 @@ if [ $1 = "remove" ]; then
       rm /etc/systemd/system/logstash.service
     fi
   fi
-  if getent passwd logstash >/dev/null ; then
-    userdel logstash
-  fi
-
-  if getent group logstash > /dev/null ; then
-    groupdel logstash
-  fi
 fi

--- a/pkg/ubuntu/before-remove.sh
+++ b/pkg/ubuntu/before-remove.sh
@@ -28,11 +28,4 @@ if [ $1 = "remove" ]; then
       rm /etc/systemd/system/logstash.service
     fi
   fi
-  if getent passwd logstash >/dev/null ; then
-    userdel logstash
-  fi
-
-  if getent group logstash > /dev/null ; then
-    groupdel logstash
-  fi
 fi


### PR DESCRIPTION
it would be better to not remove a (possibly) created user/group on uninstallation of logstash rpm.
let me explain why the removal is not a good option:
- user/group may not be created by rpm (see [here](https://fedoraproject.org/wiki/Packaging:UsersAndGroups) to see why)
- existing files on system (prior owned by logstash) will be possibly owned a later / newly created user (see [possibly security threa](https://ma.ttias.be/on-removing-users-with-postun-in-rpm-spec-files/))

within an organization managing multiple logstash server, sysadmins may want to have consistent uid/gid by either
- pre creating user/groups (rpm installation will correctly reuse these users)
- or using directory based users (freeipa, ...)

and thus uninstalling a package (at least for RedHat based systems) it is not the best way to remove a user.

thanks for having a few thoughts (and hopefully merge) about this situation. 
