### PR TITLE
Remove JMS from the skip list of plugins

### DIFF
--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -116,7 +116,6 @@ module LogStash
 
     ALL_PLUGINS_SKIP_LIST = Regexp.union([
       /^logstash-filter-yaml$/,
-      /jms$/,
       /example$/,
       /drupal/i,
       /^logstash-output-logentries$/,


### PR DESCRIPTION
The jms input and output were added to the skip list when they were in initial development, but got never removed from there. Now both gets full content repo and people using them, see https://discuss.elastic.co/t/why-logstash-output-jms-isnt-part-of-the-pluggins-in-the-official-documentation/53874/2 for more details.

This will bring back this plugins to the documentation and the all plugins bundle.

@jordansissel @markwalkom @suyograo