### PR TITLE
fix interactive prompt issues for tests in the QA acceptance layer.

### DIFF
--- a/qa/rspec/commands/debian.rb
+++ b/qa/rspec/commands/debian.rb
@@ -23,7 +23,7 @@ module ServiceTester
     def install(package, host=nil)
       hosts = (host.nil? ? servers : Array(host))
       at(hosts, {in: :serial}) do |_|
-        cmd = sudo_exec!("dpkg -i  #{package}")
+        sudo_exec!("dpkg -i --force-confnew #{package}")
       end
     end
 


### PR DESCRIPTION
add --force-confnew to pick automatically new config when updating packages for debians, this avoid interactive prompt issues

Fixes #5557 