### PR TITLE
Make documentation the default formatter for acceptance tests

### DIFF
--- a/qa/.rspec
+++ b/qa/.rspec
@@ -1,0 +1,2 @@
+--format
+documentation


### PR DESCRIPTION
Same way as regular tests in logstash, this PR make them run under the documentation level. This will help us debug errors in CI when they happen.