### PR TITLE
Add pipeline.continue_on_error setting to allow logstash to rescue arbitrary…

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -50,6 +50,18 @@
 #
 # pipeline.unsafe_shutdown: false
 #
+# Defaults to false. Setting this to true will catch all unexpected errors in the
+# pipeline without terminating logstash.
+# Logstash will do all of the following: drop the erroring event,
+# log an error-level message, and continue processing. This will also increment
+# the 'errored' count in the pipeline stats API at /_node/pipeline/events.
+#
+# If set to false logstash will immediately exit with an error in these
+# conditions, which may be more safe since potentially fewer events would be dropped.
+#
+# pipeline.continue_on_error: true
+#
+#
 # ------------ Pipeline Configuration Settings --------------
 #
 # Where to fetch the pipeline configuration for the main pipeline

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -29,7 +29,7 @@ module LogStash
         def events
           extract_metrics(
             [:stats, :events],
-            :in, :filtered, :out
+            :in, :filtered, :out, :errored
           )
         end
 

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -20,6 +20,7 @@ module LogStash
            Setting::Numeric.new("pipeline.batch.size", 125),
            Setting::Numeric.new("pipeline.batch.delay", 5), # in milliseconds
            Setting::Boolean.new("pipeline.unsafe_shutdown", false),
+           Setting::Boolean.new("pipeline.continue_on_error", false),
                     Setting.new("path.plugins", Array, []),
             Setting::String.new("interactive", nil, false),
            Setting::Boolean.new("config.debug", false),

--- a/logstash-core/spec/api/lib/api/node_stats_spec.rb
+++ b/logstash-core/spec/api/lib/api/node_stats_spec.rb
@@ -14,7 +14,8 @@ describe LogStash::Api::Modules::NodeStats do
     "events"=>{
       "in"=>Numeric,
       "filtered"=>Numeric,
-      "out"=>Numeric
+      "out"=>Numeric,
+      "errored"=>Numeric
     },
     "jvm"=>{
       "threads"=>{

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -100,6 +100,90 @@ describe LogStash::Pipeline do
     pipeline_settings_obj.reset
   end
 
+  describe "rescuing pipeline exceptions" do
+    before(:each) do
+      allow(LogStash::Plugin).to receive(:lookup).with("input", "dummyinput").and_return(DummyInput)
+      allow(LogStash::Plugin).to receive(:lookup).with("codec", "plain").and_return(DummyCodec)
+      allow(LogStash::Plugin).to receive(:lookup).with("output", "dummyoutput").and_return(DummyOutput)
+      allow(LogStash::Plugin).to receive(:lookup).with("filter", "dummyfilter").and_return(DummyFilter)
+      allow(LogStash::Plugin).to receive(:lookup).with("filter", "dummysafefilter").and_return(DummySafeFilter)
+    end
+
+    let(:config) do
+      <<-eos
+        input {
+          dummyinput {}
+        }
+
+        filter {
+          if [foo] > 2 { # Intentionally omit nil check
+            dummyfilter {}
+          }
+        }
+
+        output {
+          if [foo] > 2 {
+             dummyoutput {}
+          }
+        }
+        eos
+    end
+
+    let(:pipeline) { TestPipeline.new(config, pipeline_settings_obj) }
+
+    context "when pipeline.continue_on_error is false" do
+      before(:each) do
+        pipeline_settings_obj.set("pipeline.continue_on_error", false)
+      end
+      
+      it "should raise an exception when filtering bad events" do
+        expect do
+          pipeline.filter_batch([LogStash::Event.new])
+        end.to raise_error(NoMethodError)
+      end
+
+      it "should raise an exception when outputting bad events" do
+        expect do
+          pipeline.output_batch([LogStash::Event.new])
+        end.to raise_error(NoMethodError)
+      end
+    end
+
+    context "when pipeline.continue_on_error is true" do
+      before(:each) do
+        pipeline_settings_obj.set("pipeline.continue_on_error", true)
+      end
+      
+      it "should raise an exception when filtering bad events" do
+        expect do
+          pipeline.filter_batch([LogStash::Event.new])
+        end.not_to raise_error
+      end
+
+      it "should raise an exception when outputting bad events" do
+        expect do
+          pipeline.output_batch([LogStash::Event.new])
+        end.not_to raise_error
+      end
+
+      describe "metrics" do
+        before(:each) do
+          allow(pipeline.namespace_events).to receive(:increment).with(any_args)
+          allow(pipeline.namespace_pipeline).to receive(:increment).with(any_args)
+          pipeline.output_batch([LogStash::Event.new])
+        end
+        
+        it "should increment the global errored count for metrics" do
+          expect(pipeline.namespace_events).to have_received(:increment).with(:errored, 1)
+        end
+
+        it "should increment the pipeline specific errored count for metrics" do
+          expect(pipeline.namespace_pipeline).to have_received(:increment).with(:errored, 1)
+        end
+      end
+    end
+  end
+
   describe "defaulting the pipeline workers based on thread safety" do
     before(:each) do
       allow(LogStash::Plugin).to receive(:lookup).with("input", "dummyinput").and_return(DummyInput)


### PR DESCRIPTION
This will rescue any plugin or pipeline config lang errors. This setting is only settable in the YAML.

Fixes #5547 and #1637