### PR TITLE
Add release notes for Alpha4

### DIFF
--- a/docs/static/command-line-flags.asciidoc
+++ b/docs/static/command-line-flags.asciidoc
@@ -5,7 +5,7 @@ Logstash has the following flags. You can use the `--help` flag to display this 
 
 You can also control Logstash execution by specifying options in the Logstash settings file. For more info, see <<logstash-settings-file>>.  
 
-coming[5.0.0-alpha3, Command-line flags have dots instead of dashes in their names]
+added[5.0.0-alpha3, Command-line flags have dots instead of dashes in their names]
 
 *`-f, --path.config CONFIGFILE`*::
  Load the Logstash config from a specific file or directory, or a wildcard. If

--- a/docs/static/configuration.asciidoc
+++ b/docs/static/configuration.asciidoc
@@ -89,7 +89,7 @@ types are supported.
 [[array]]
 ==== Array
 
-This type is now mostly deprecated in favor of using a standard type like `string` with the plugin defining the `:list => true` property for better type checking. It is still needed to handle lists of hashes or mixed types where type checking is not desired. coming[5.0.0-alpha4,The :list property is available for better type checking] 
+This type is now mostly deprecated in favor of using a standard type like `string` with the plugin defining the `:list => true` property for better type checking. It is still needed to handle lists of hashes or mixed types where type checking is not desired. added[5.0.0-alpha4,The :list property is available for better type checking] 
 
 Example:
 
@@ -102,7 +102,7 @@ Example:
 [float]
 ==== Lists
 
-coming[5.0.0-alpha4,The :list property is available for better type checking]
+added[5.0.0-alpha4,The :list property is available for better type checking]
 
 Not a type in and of itself, but a property types can have.
 This makes it possible to type check multiple values.
@@ -222,7 +222,7 @@ Example:
 [float]
 ==== URI
 
-coming[5.0.0-alpha4]
+added[5.0.0-alpha4]
 
 A URI can be anything from a full URL like 'http://elastic.co/' to a simple identifier
 like 'foobar'. If the URI contains a password such as 'http://user:pass@example.net' the password

--- a/docs/static/include/pluginbody.asciidoc
+++ b/docs/static/include/pluginbody.asciidoc
@@ -481,7 +481,7 @@ will become a valid boolean in the config.  This coercion works for the
 `:number` type as well where "1.2" becomes a float and "22" is an integer.
 * `:default` - lets you specify a default value for a parameter
 * `:required` - whether or not this parameter is mandatory (a Boolean `true` or `false`)
-* `:list` - whether or not this value should be a list of values. Will typecheck the list members, and convert scalars to one element lists. Note that this mostly obviates the array type, though if you need lists of complex objects that will be more suitable. coming[5.0.0-alpha4,The :list property is available for better type checking]
+* `:list` - whether or not this value should be a list of values. Will typecheck the list members, and convert scalars to one element lists. Note that this mostly obviates the array type, though if you need lists of complex objects that will be more suitable. added[5.0.0-alpha4,The :list property is available for better type checking]
 * `:deprecated` - informational (also a Boolean `true` or `false`)
 * `:obsolete` - used to declare that a given setting has been removed and is no longer functioning. The idea is to provide an informed upgrade path to users who are still using a now-removed setting.
 

--- a/docs/static/monitoring-apis.asciidoc
+++ b/docs/static/monitoring-apis.asciidoc
@@ -69,7 +69,7 @@ consumption.  The default for the `human` flag is
 [[node-info-api]]
 === Node Info API
 
-coming[5.0.0-alpha4]
+added[5.0.0-alpha4]
 
 experimental[]
 
@@ -240,7 +240,7 @@ Gets JVM stats, including stats about threads. added[5.0.0-alpha3,Adds thread co
 `process`::
 Gets process stats, including stats about file descriptors, memory consumption, and CPU usage. added[5.0.0-alpha3] 
 `mem`::
-Gets memory usage stats. coming[5.0.0-alpha4] 
+Gets memory usage stats. added[5.0.0-alpha4] 
 
 ==== Event Stats
 
@@ -367,7 +367,7 @@ Logstash monitoring APIs.
 [[pipeline-stats-api]]
 === Pipeline Stats API
 
-coming[5.0.0-alpha4,Stats for input stages are not yet available]
+added[5.0.0-alpha4,Stats for input stages are not yet available]
 
 experimental[]
 

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -3,9 +3,64 @@
 
 This section summarizes the changes in each release.
 
+* <<alpha4,Logstash 5.0-alpha4>>
 * <<alpha3,Logstash 5.0-alpha3>>
 * <<alpha2,Logstash 5.0-alpha2>>
 * <<alpha1,Logstash 5.0-alpha1>>
+
+[[alpha4]]
+=== Logstash 5.0-alpha4 Release Notes
+
+* Created a new `LS_HOME/data` directory to store plugin states, Logstash instance UUID, and more. This directory 
+location is configurable via the `path.data` setting in the `logstash.yml` <<logstash-settings-file,settings file>> ({lsissue}5404[Issue 5404]).
+* Made `bin/logstash -V/--version` run faster on Unix platforms.
+* Ehanced the <<monitoring,monitoring APIs>> by adding `hostname`, `http_address`, and `version` as static fields for all APIs ({lsissue}5450[Issue 5450]).
+* Added time tracking (wall-clock) to all individual filter and output instances. The goal is to help identify 
+which plugin configurations are consuming the most time. These statics are exposed by the `/_node/stats/pipeline` endpoint. See the <<pipeline-stats-api, pipeline stats API>>.
+* Added the `/_node` endpoint, which provides static information for OS, JVM, and pipeline settings. See the <<node-info-api,node info API>>.
+* Moved the <<plugins-api,plugins API>> to the `_node/plugins` endpoint.
+* Moved the <<hot-threads-api,hot threads API>> to the `_node/hot_threads` endpoint.
+* Added a new `:list` property to the configuration parameters. This will allow the user to specify one or more values. 
+* Added a new URI config validator/type. This type allows plugins like the Elasticsearch output to safely log URIs for configuration. Any password information in the URI will be masked when the URI is logged.
+
+[float]
+==== Input Plugins
+
+*`Kafka`*:
+
+* Added support for Kafka broker 0.10.
+
+*`HTTP`*:
+
+* Fixed a bug where the HTTP input plugin blocked the node stats API (https://github.com/logstash-plugins/logstash-input-http/issues/51[Issue 51]). 
+
+[float]
+==== Output Plugins
+
+*`Elasticsearch`*:
+
+* Elasticserach output is now fully threadsafe. This means internal resources can be shared among multiple
+`output { elasticsearch {} }` instances.
+* Added sniffing improvements so any current connections don't have to be closed/reopened after a sniff round.
+* Introduced a connection pool to efficiently reuse connections to Elasticsearch backends.
+* Added exponential backoff to connection retries with a ceiling of `retry_max_interval`, which is the most time to 
+wait between retries, and `retry_initial_interval`,  which is the initial amount of time to wait. The value of
+`retry_initial_interval` increases exponentially between retries until a request succeeds.
+     
+*`Kafka`*:
+
+* Added support for Kafka broker 0.10.
+   
+[float]
+==== Filter Plugins
+
+*`Grok`*:
+
+* Added a stats counter on grok matches and failures. This is exposed in the `_node/stats/pipeline` endpoint.
+
+*`Date`*:
+
+* Added a stats counter on grok matches and failures. This is exposed in the `_node/stats/pipeline` endpoint.
 
 [[alpha3]]
 === Logstash 5.0-alpha3 Release Notes

--- a/docs/static/setting-up-logstash.asciidoc
+++ b/docs/static/setting-up-logstash.asciidoc
@@ -16,7 +16,7 @@ This section includes additional information on how to set up and run Logstash, 
 
 This section describes the default directory structure that is created when you unpack the Logstash installation packages.
 
-coming[5.0.0-alpha3, Includes breaking changes to the Logstash directory structure]
+added[5.0.0-alpha3, Includes breaking changes to the Logstash directory structure]
 
 [[zip-targz-layout]]
 ==== Directory Layout of `.zip` and `.tar.gz` Archives
@@ -118,7 +118,7 @@ See <<configuration>> for more info.
 
 ==== Settings Files
 
-coming[5.0.0-alpha3]
+added[5.0.0-alpha3]
 
 The settings files are already defined in the Logstash installation. Logstash includes the following settings files:
 
@@ -140,7 +140,7 @@ The settings files are already defined in the Logstash installation. Logstash in
 [[running-logstash]]
 === Running Logstash as a Service on Debian or RPM
 
-coming[5.0.0-alpha3]
+added[5.0.0-alpha3]
 
 Logstash is not started automatically after installation. How to start and stop Logstash depends on whether your system
 uses systemd, upstart, or SysV. 

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -1,10 +1,10 @@
 [[logstash-settings-file]]
 === Settings File
 
-coming[5.0.0-alpha3]
+added[5.0.0-alpha3]
 
-You can set options in the Logstash settings file, `logstash.yml`, to control Logstash execution. Each setting in the
-`logstash.yml` file corresponds to a <<command-line-flags,command-line flag>>. 
+You can set options in the Logstash settings file, `logstash.yml`, to control Logstash execution. Most of the settings in the
+`logstash.yml` file correspond to a <<command-line-flags,command-line flag>>. 
 
 Any flags that you set at the command line override the corresponding settings in the `logstash.yml` file. 
 


### PR DESCRIPTION
Also changed "coming" annotations to "added". To me, the "added' looks better (especially after the release goes live). 
