### PR TITLE
Add more reporting to the QA acceptance test layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,5 @@ integration_run
 .mvn/
 qa/.vm_ssh_config
 qa/.vagrant
-qa/.rspec
 qa/acceptance/.vagrant
 qa/Gemfile.lock

--- a/qa/Rakefile
+++ b/qa/Rakefile
@@ -35,8 +35,9 @@ namespace :qa do
 
       puts user_feedback_string_for("bootstraping", args[:platform], machines, {"experimental" => experimental})
 
-      LogStash::VagrantHelpers.destroy(machines)
-      LogStash::VagrantHelpers.bootstrap(machines)
+      options = {:debug => ENV['LS_QA_DEBUG']}
+      LogStash::VagrantHelpers.destroy(machines, options)
+      LogStash::VagrantHelpers.bootstrap(machines, options)
     end
 
     desc "Halt all VM's involved in the acceptance test round"
@@ -46,8 +47,9 @@ namespace :qa do
       machines = config.select_names_for(args[:platform], {"experimental" => experimental})
 
       puts user_feedback_string_for("halting", args[:platform], machines, {"experimental" => experimental})
+      options = {:debug => ENV['LS_QA_DEBUG']}
 
-      LogStash::VagrantHelpers.halt(machines)
+      LogStash::VagrantHelpers.halt(machines, options)
     end
   end
 

--- a/qa/vagrant/command.rb
+++ b/qa/vagrant/command.rb
@@ -21,25 +21,51 @@ module LogStash
       end
     end
 
-    def self.run(cmd)
+    def self.run(cmd, debug=false)
       # This block is require to be able to launch a ruby subprocess
       # that use bundler.
       Bundler.with_clean_env do
-        Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
-          CommandResponse.new(stdin, stdout.read.chomp, stderr.read.chomp, wait_thr.value.exitstatus)
+        stdin, stdout, stderr, wait_thr = Open3.popen3(cmd)
+        stdout_acc, stderr_acc = "", ""
+        stdout_reporter = reporter(stdout, wait_thr) do |c|
+          stdout_acc << c
+          print c if debug
         end
+        reporter(stderr, wait_thr) do |c|
+          stderr_acc << c;
+          print c if debug
+        end
+        stdout_reporter.join
+        CommandResponse.new(stdin, stdout_acc, stderr_acc, wait_thr.value.exitstatus)
       end
     end
 
     # This method will raise an exception if the `CMD`
     # was not run successfully and will display the content of STDERR
-    def self.run!(cmd)
-      response = run(cmd)
+    def self.run!(cmd, debug=false)
+      response = run(cmd, debug)
 
       unless response.success?
         raise CommandError, "CMD: #{cmd} STDERR: #{response.stderr}"
       end
       response
     end
+
+    private
+
+    def self.reporter(io, wait_thr, &block)
+      Thread.new(io, wait_thr) do |_io, _wait_thr|
+        while (_wait_thr.status == "run")
+          begin
+            c = _io.read(1)
+            block.call(c) if c
+          rescue IO::WaitReadable
+            IO.select([_io])
+            retry
+          end
+        end
+      end
+    end
+
   end
 end

--- a/qa/vagrant/helpers.rb
+++ b/qa/vagrant/helpers.rb
@@ -6,16 +6,19 @@ require_relative "command"
 module LogStash
   class VagrantHelpers
 
-    def self.halt(machines="")
-      CommandExecutor.run!("vagrant halt #{machines.join(' ')}")
+    def self.halt(machines="", options={})
+      debug = options.fetch(:debug, false)
+      CommandExecutor.run!("vagrant halt #{machines.join(' ')}", debug)
     end
 
-    def self.destroy(machines="")
-      CommandExecutor.run!("vagrant destroy --force #{machines.join(' ')}") 
+    def self.destroy(machines="", options={})
+      debug = options.fetch(:debug, false)
+      CommandExecutor.run!("vagrant destroy --force #{machines.join(' ')}", debug) 
     end
 
-    def self.bootstrap(machines="")
-      CommandExecutor.run!("vagrant up #{machines.join(' ')}")
+    def self.bootstrap(machines="", options={})
+      debug = options.fetch(:debug, false)
+      CommandExecutor.run!("vagrant up #{machines.join(' ')}", debug)
     end
 
     def self.save_snapshot(machine="")


### PR DESCRIPTION
Till this PR the qa test layer was reporting vagrant commands only when they finished, so we could not spot issues with them when running the automated tests. This PR add's a flag to run them in debug mode, so all output from normal vagrant commands will also be shown when running like this. 

Not sure to make this default true, but this might be a good thing for CI infra. what do you think? 

Also fix the .gitignore file, so the .rspec, as this file was added in #5561should not be excluded from git.