### PR TITLE
Fix TOC and apply light edits to plugin generator topic

### DIFF
--- a/docs/static/plugin-generator.asciidoc
+++ b/docs/static/plugin-generator.asciidoc
@@ -1,9 +1,9 @@
 [[plugin-generator]]
-== Generating Plugins
+=== Generating Plugins
 
 You can now create your own Logstash plugin in seconds! The generate subcommand of `bin/logstash-plugin` creates the foundation 
-for a new Logstash plugin with templatized files. It creates the right directory structure, gemspec files and dependencies so you 
-can start adding custom code process data with Logstash.
+for a new Logstash plugin with templatized files. It creates the correct directory structure, gemspec files, and dependencies so you 
+can start adding custom code to process data with Logstash.
 
 **Example Usage**
 
@@ -12,8 +12,8 @@ can start adding custom code process data with Logstash.
 bin/logstash-plugin generate --type input --name xkcd --path ~/ws/elastic/plugins
 -------------------------------------------
 
-* `--type`: Type of plugin - input, filter, output and codec
+* `--type`: Type of plugin - input, filter, output, or codec
 * `--name`: Name for the new plugin
-* `--path`: Directory path where the new plugin structure will be created. If not specified, it will be '
+* `--path`: Directory path where the new plugin structure will be created. If not specified, it will be
 created in the current directory.
 


### PR DESCRIPTION
@suyograo I don't think you meant for the "Generating Plugins" topic to become a parent topic of "Offline Plugin Management" and "Private Gem Repositories" as it is here:

![generatingpluginstoc](https://cloud.githubusercontent.com/assets/14206422/16472755/6f405258-3e1b-11e6-8c57-61ef57b53b23.png)

So I've changed the heading level so that it appears nested under "Working with Plugins". I've also added a few edits since I had the file open.