### PR TITLE
Replace obsolete logstash startup message in 2.3 docs

### DIFF
--- a/docs/static/advanced-pipeline.asciidoc
+++ b/docs/static/advanced-pipeline.asciidoc
@@ -576,36 +576,30 @@ you start Logstash.
 ==== Stall Detection Example
 
 In this example, slow filter execution prevents the pipeline from clean shutdown. By starting Logstash with the
-`--allow-unsafe-shutdown` flag, quitting with *Ctrl+C* results in an eventual shutdown that loses 20 events.
+`--allow-unsafe-shutdown` flag, quitting with *Ctrl+C* results in an eventual shutdown that loses events.
 
 ========
 [source,shell]
-% bin/logstash -e 'input { generator { } } filter { ruby { code => "sleep 10000" } } \
-                     output { stdout { codec => dots } }' -w 1 --allow-unsafe-shutdown
-Default settings used: Filter workers: 1
-Logstash startup completed
-^CSIGINT received. Shutting down the pipeline. {:level=>:warn}
+bin/logstash -e 'input { generator { } } filter { ruby { code => "sleep 10000" } } 
+  output { stdout { codec => dots } }' -w 1 --allow-unsafe-shutdown
+Settings: User set pipeline workers: 1, Default pipeline workers: 8
+Pipeline main started
+^CSIGINT received. Shutting down the agent. {:level=>:warn}
+stopping pipeline {:id=>"main"}
 Received shutdown signal, but pipeline is still waiting for in-flight events
 to be processed. Sending another ^C will force quit Logstash, but this may cause
 data loss. {:level=>:warn}
- {:level=>:warn, "INFLIGHT_EVENT_COUNT"=>{"input_to_filter"=>20, "total"=>20},
- "STALLING_THREADS"=>
- {["LogStash::Filters::Ruby", {"code"=>"sleep 10000"}]=>[{"thread_id"=>15,
- "name"=>"|filterworker.0", "current_call"=>"
- (ruby filter code):1:in `sleep'"}]}}
-The shutdown process appears to be stalled due to busy or blocked plugins. Check
-    the logs for more information.
-{:level=>:error}
- {:level=>:warn, "INFLIGHT_EVENT_COUNT"=>{"input_to_filter"=>20, "total"=>20},
- "STALLING_THREADS"=>
- {["LogStash::Filters::Ruby", {"code"=>"sleep 10000"}]=>[{"thread_id"=>15,
- "name"=>"|filterworker.0", "current_call"=>"
- (ruby filter code):1:in `sleep'"}]}}
- {:level=>:warn, "INFLIGHT_EVENT_COUNT"=>{"input_to_filter"=>20, "total"=>20},
- "STALLING_THREADS"=>
- {["LogStash::Filters::Ruby", {"code"=>"sleep 10000"}]=>[{"thread_id"=>15,
- "name"=>"|filterworker.0", "current_call"=>"
- (ruby filter code):1:in `sleep'"}]}}
+{"inflight_count"=>125, "stalling_thread_info"=>{["LogStash::Filters::Ruby", 
+{"code"=>"sleep 10000"}]=>[{"thread_id"=>17, "name"=>"[main]>worker0", 
+"current_call"=>"(ruby filter code):1:in `sleep'"}]}} {:level=>:warn}
+The shutdown process appears to be stalled due to busy or blocked plugins. 
+Check the logs for more information. {:level=>:error}
+{"inflight_count"=>125, "stalling_thread_info"=>{["LogStash::Filters::Ruby", 
+{"code"=>"sleep 10000"}]=>[{"thread_id"=>17, "name"=>"[main]>worker0", 
+"current_call"=>"(ruby filter code):1:in `sleep'"}]}} {:level=>:warn}
+{"inflight_count"=>125, "stalling_thread_info"=>{["LogStash::Filters::Ruby", 
+{"code"=>"sleep 10000"}]=>[{"thread_id"=>17, "name"=>"[main]>worker0", 
+"current_call"=>"(ruby filter code):1:in `sleep'"}]}} {:level=>:warn}
 Forcefully quitting logstash.. {:level=>:fatal}
 ========
 

--- a/docs/static/configuration.asciidoc
+++ b/docs/static/configuration.asciidoc
@@ -491,12 +491,13 @@ Let's see what comes out:
 ----------------------------------
 
 $ bin/logstash -f ../test.conf
-Logstash startup completed
+Settings: Default pipeline workers: 8
+Pipeline main started
 asdf
 {
        "message" => "asdf",
       "@version" => "1",
-    "@timestamp" => "2015-03-18T23:09:29.595Z",
+    "@timestamp" => "2016-06-30T02:08:03.148Z",
           "host" => "example.com",
           "show" => "This data will be in the output"
 }
@@ -520,12 +521,13 @@ Let's see what the output looks like with this change:
 [source,ruby]
 ----------------------------------
 $ bin/logstash -f ../test.conf
-Logstash startup completed
+Settings: Default pipeline workers: 8
+Pipeline main started
 asdf
 {
        "message" => "asdf",
       "@version" => "1",
-    "@timestamp" => "2015-03-18T23:10:19.859Z",
+    "@timestamp" => "2016-06-30T02:10:25.044Z",
           "host" => "example.com",
           "show" => "This data will be in the output",
      "@metadata" => {
@@ -572,8 +574,8 @@ configuration a sample date string and see what comes out:
 [source,ruby]
 ----------------------------------
 $ bin/logstash -f ../test.conf
-Logstash startup completed
-02/Mar/2014:15:36:43 +0100
+Settings: Default pipeline workers: 8
+Pipeline main started
 {
        "message" => "02/Mar/2014:15:36:43 +0100",
       "@version" => "1",

--- a/docs/static/getting-started-with-logstash.asciidoc
+++ b/docs/static/getting-started-with-logstash.asciidoc
@@ -144,7 +144,7 @@ command line lets you quickly test configurations without having to edit a file 
 This pipeline takes input from the standard input, `stdin`, and moves that input to the standard output, `stdout`, in a
 structured format.
 
-Once "Logstash startup completed" is displayed, type hello world at the command prompt to see Logstash respond:
+Once "Pipeline main started" is displayed, type hello world at the command prompt to see Logstash respond:
 
 [source,shell]
 hello world


### PR DESCRIPTION
Doc changes to resolve issue #5372 in the 2.3 docs. I suspect the output messages might differ, so I'll submit a separate PR to get these changes merged into master and 5.0.