### PR TITLE
Make sure errors are reported also to terminal if show_startup_errors is true

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -133,7 +133,6 @@ class LogStash::Agent < Clamp::Command
   # Emit a warning message.
   def warn(message)
     # For now, all warnings are fatal.
-#    raise LogStash::ConfigurationError.new(message)
     signal_usage_error(message)
   end # def warn
 

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -133,11 +133,12 @@ class LogStash::Agent < Clamp::Command
   # Emit a warning message.
   def warn(message)
     # For now, all warnings are fatal.
-    raise LogStash::ConfigurationError, message
+#    raise LogStash::ConfigurationError.new(message)
+    signal_usage_error(message)
   end # def warn
 
   def fail(message)
-    raise LogStash::ConfigurationError, message
+    signal_usage_error(message)
   end # def fail
 
   # Run the agent. This method is invoked after clamp parses the
@@ -242,7 +243,10 @@ class LogStash::Agent < Clamp::Command
     end
     return 1
   rescue => e
-    @logger.unsubscribe(stdout_logs) if show_startup_errors
+    if show_startup_errors
+      @logger.terminal(e.message)
+      @logger.unsubscribe(stdout_logs)
+    end
     @logger.warn(I18n.t("oops"), :error => e, :class => e.class.name, :backtrace => e.backtrace)
     return 1
   ensure

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -255,7 +255,7 @@ describe LogStash::Agent do
     it "should fail with single invalid dir path" do
       expect(File).to receive(:directory?).and_return(false)
       expect(LogStash::Environment).not_to receive(:add_plugin_path)
-      expect{subject.configure_plugin_paths(single_path)}.to raise_error(LogStash::ConfigurationError)
+      expect{subject.configure_plugin_paths(single_path)}.to raise_error(Clamp::UsageError)
     end
 
     it "should add multiple valid dir path to the environment" do
@@ -293,7 +293,7 @@ describe LogStash::Agent do
     it "should fail with single invalid dir path" do
       expect(File).to receive(:directory?).and_return(false)
       expect(LogStash::Environment).not_to receive(:add_plugin_path)
-      expect{subject.configure_plugin_paths(single_path)}.to raise_error(LogStash::ConfigurationError)
+      expect{subject.configure_plugin_paths(single_path)}.to raise_error(Clamp::UsageError)
     end
   end
 


### PR DESCRIPTION
Fixes #5549 by not masquerading  reported errors that happen during bootstrap time inside the agent class, this is not the right place to do the reporting as it should happen in runner, but all this is already properly refactored for 5.0 branch. In this PR I tried to keep the same style and logic when proposing a fix.