### PR TITLE
bump core to 2.4.0.dev and make plugin_api to 1.20

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,10 @@
 # If you modify this file manually all comments and formatting will be lost.
 
 source "https://rubygems.org"
-gem "logstash-core", "3.0.0.dev", :path => "./logstash-core"
-gem "logstash-core-event", "3.0.0.dev", :path => "./logstash-core-event"
-# gem "logstash-core-event-java", "3.0.0.dev", :path => "./logstash-core-event-java"
-gem "logstash-core-plugin-api", "1.0.0", :path => "./logstash-core-plugin-api"
+gem "logstash-core", "2.4.0.dev", :path => "./logstash-core"
+gem "logstash-core-event", "2.4.0.dev", :path => "./logstash-core-event"
+# gem "logstash-core-event-java", "2.4.0.dev", :path => "./logstash-core-event-java"
+gem "logstash-core-plugin-api", "1.20.0", :path => "./logstash-core-plugin-api"
 gem "file-dependencies", "0.1.6"
 gem "ci_reporter_rspec", "1.0.0", :group => :development
 gem "simplecov", :group => :development

--- a/Gemfile.jruby-1.9.lock
+++ b/Gemfile.jruby-1.9.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ./logstash-core
   specs:
-    logstash-core (3.0.0.dev-java)
+    logstash-core (2.4.0.dev-java)
       cabin (~> 0.8.0)
       clamp (~> 0.6.5)
       concurrent-ruby (= 0.9.2)
@@ -9,8 +9,8 @@ PATH
       gems (~> 0.8.3)
       i18n (= 0.6.9)
       jrjackson (~> 0.3.7)
-      jruby-openssl (= 0.9.13)
-      logstash-core-event (= 3.0.0.dev)
+      jruby-openssl (= 0.9.16)
+      logstash-core-event (= 2.4.0.dev)
       minitar (~> 0.5.4)
       pry (~> 0.10.1)
       rubyzip (~> 1.1.7)
@@ -21,13 +21,13 @@ PATH
 PATH
   remote: ./logstash-core-event
   specs:
-    logstash-core-event (3.0.0.dev-java)
+    logstash-core-event (2.4.0.dev-java)
 
 PATH
   remote: ./logstash-core-plugin-api
   specs:
-    logstash-core-plugin-api (1.0.0-java)
-      logstash-core (>= 2.0.0, <= 3.0.0.dev)
+    logstash-core-plugin-api (1.20.0-java)
+      logstash-core (>= 2.4.0.alpha, < 3)
 
 GEM
   remote: https://rubygems.org/
@@ -36,7 +36,7 @@ GEM
     arr-pm (0.0.10)
       cabin (> 0)
     backports (3.6.8)
-    benchmark-ips (2.5.0)
+    benchmark-ips (2.6.1)
     builder (3.2.2)
     cabin (0.8.1)
     childprocess (0.5.9)
@@ -49,9 +49,9 @@ GEM
     clamp (0.6.5)
     coderay (1.1.1)
     concurrent-ruby (0.9.2-java)
-    coveralls (0.8.13)
-      json (~> 1.8)
-      simplecov (~> 0.11.0)
+    coveralls (0.8.14)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.12.0)
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
       tins (~> 1.6.0)
@@ -59,10 +59,11 @@ GEM
     docile (1.1.5)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.10-java)
+    ffi (1.9.13)
     file-dependencies (0.1.6)
       minitar
     filesize (0.0.4)
+    fivemat (1.3.2)
     flores (0.0.6)
     fpm (1.3.3)
       arr-pm (~> 0.0.9)
@@ -76,17 +77,18 @@ GEM
     gems (0.8.3)
     i18n (0.6.9)
     insist (1.0.0)
-    jrjackson (0.3.8)
-    jruby-openssl (0.9.13-java)
-    json (1.8.3-java)
-    kramdown (1.10.0)
-    logstash-devutils (0.0.18-java)
+    jrjackson (0.3.9-java)
+    jruby-openssl (0.9.16-java)
+    json (2.0.1-java)
+    kramdown (1.11.1)
+    logstash-devutils (0.0.22-java)
+      fivemat
       gem_publisher
       insist (= 1.0.0)
       kramdown
       minitar
       rake
-      rspec (~> 3.1.0)
+      rspec (~> 3.0)
       rspec-wait
       stud (>= 0.0.20)
     method_source (0.8.2)
@@ -100,7 +102,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
       spoon (~> 0.0)
-    rake (11.1.2)
+    rake (11.2.2)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)
@@ -119,9 +121,9 @@ GEM
     sawyer (0.6.0)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
-    simplecov (0.11.2)
+    simplecov (0.12.0)
       docile (~> 1.1.0)
-      json (~> 1.8)
+      json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
@@ -148,9 +150,9 @@ DEPENDENCIES
   flores (~> 0.0.6)
   fpm (~> 1.3.3)
   gems (~> 0.8.3)
-  logstash-core (= 3.0.0.dev)!
-  logstash-core-event (= 3.0.0.dev)!
-  logstash-core-plugin-api (= 1.0.0)!
+  logstash-core (= 2.4.0.dev)!
+  logstash-core-event (= 2.4.0.dev)!
+  logstash-core-plugin-api (= 1.20.0)!
   logstash-devutils (~> 0.0.15)
   octokit (= 3.8.0)
   rspec (~> 3.1.0)

--- a/logstash-core-event-java/lib/logstash-core-event-java/version.rb
+++ b/logstash-core-event-java/lib/logstash-core-event-java/version.rb
@@ -5,4 +5,4 @@
 # Note to authors: this should not include dashes because 'gem' barfs if
 # you include a dash in the version string.
 
-LOGSTASH_CORE_EVENT_JAVA_VERSION = "3.0.0.dev"
+LOGSTASH_CORE_EVENT_JAVA_VERSION = "2.4.0.dev"

--- a/logstash-core-event/lib/logstash-core-event/version.rb
+++ b/logstash-core-event/lib/logstash-core-event/version.rb
@@ -5,4 +5,4 @@
 # Note to authors: this should not include dashes because 'gem' barfs if
 # you include a dash in the version string.
 
-LOGSTASH_CORE_EVENT_VERSION = "3.0.0.dev"
+LOGSTASH_CORE_EVENT_VERSION = "2.4.0.dev"

--- a/logstash-core-plugin-api/lib/logstash-core-plugin-api/version.rb
+++ b/logstash-core-plugin-api/lib/logstash-core-plugin-api/version.rb
@@ -1,2 +1,2 @@
 # encoding: utf-8
-LOGSTASH_CORE_PLUGIN_API = "1.0.0"
+LOGSTASH_CORE_PLUGIN_API = "1.20.0"

--- a/logstash-core-plugin-api/logstash-core-plugin-api.gemspec
+++ b/logstash-core-plugin-api/logstash-core-plugin-api.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = LOGSTASH_CORE_PLUGIN_API
 
-  gem.add_runtime_dependency "logstash-core", ">= 2.0.0", "<= 3.0.0.dev"
+  gem.add_runtime_dependency "logstash-core", ">= 2.4.0.alpha", "< 3"
 
   # Make sure we dont build this gem from a non jruby
   # environment.

--- a/logstash-core/lib/logstash-core/version.rb
+++ b/logstash-core/lib/logstash-core/version.rb
@@ -5,4 +5,4 @@
 # Note to authors: this should not include dashes because 'gem' barfs if
 # you include a dash in the version string.
 
-LOGSTASH_CORE_VERSION = "3.0.0.dev"
+LOGSTASH_CORE_VERSION = "2.4.0.dev"

--- a/logstash-core/lib/logstash/version.rb
+++ b/logstash-core/lib/logstash/version.rb
@@ -11,4 +11,4 @@
 #       eventually this file should be in the root logstash lib fir and dependencies in logstash-core should be
 #       fixed.
 
-LOGSTASH_VERSION = "3.0.0.dev"
+LOGSTASH_VERSION = "2.4.0.dev"

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = LOGSTASH_CORE_VERSION
 
-  gem.add_runtime_dependency "logstash-core-event", "3.0.0.dev"
-  # gem.add_runtime_dependency "logstash-core-event-java", "3.0.0.dev"
+  gem.add_runtime_dependency "logstash-core-event", "2.4.0.dev"
+  # gem.add_runtime_dependency "logstash-core-event-java", "2.4.0.dev"
 
   gem.add_runtime_dependency "cabin", "~> 0.8.0" #(Apache 2.0 license)
   gem.add_runtime_dependency "pry", "~> 0.10.1"  #(Ruby license)


### PR DESCRIPTION
* bump logstash-core/logstash-core-event/logstash-core-event-java to 2.4.0.dev
* bump logstash-core-plugin-api to 1.20.0
  * provides both get/set and []/[]= events apis by allowing to be installed in logstash >= 2.4 and < 3
* minor bumps on gem dependencies