### PR TITLE
Sync 2.x branch with doc changes in 2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ You can install the default set of plugins included in the logstash package or a
     rake test:install-all
 
 ---
-Note that if a plugin is installed using the plugin manager `bin/plugin install ...` do not forget to also install the plugins development dependencies using the following command after the plugin installation:
+Note that if a plugin is installed using the plugin manager `bin/logstash-plugin install ...` do not forget to also install the plugins development dependencies using the following command after the plugin installation:
 
-    bin/plugin install --development
+    bin/logstash-plugin install --development
 
 ## Developing plugins
 

--- a/docs/plugin-doc.asciidoc.erb
+++ b/docs/plugin-doc.asciidoc.erb
@@ -3,7 +3,7 @@
 === <%= name %>
 
 <% unless default_plugin %>
-NOTE: This is a community-maintained plugin! It does not ship with Logstash by default, but it is easy to install by running `bin/plugin install logstash-<%= section %>-<%= plugin_name %>`.
+NOTE: This is a community-maintained plugin! It does not ship with Logstash by default, but it is easy to install by running `bin/logstash-plugin install logstash-<%= section %>-<%= plugin_name %>`.
 <% end %>
 
 <%= description %>

--- a/docs/static/configuration.asciidoc
+++ b/docs/static/configuration.asciidoc
@@ -638,6 +638,9 @@ output {
 
 [[environment-variables]]
 === Using Environment Variables in Configuration
+
+This feature is _experimental_, to enable it you will need to run logstash with the `--allow-env` flag.
+
 ==== Overview
 
 * You can set environment variable references into Logstash plugins configuration using `${var}` or `$var`.

--- a/docs/static/configuration.asciidoc
+++ b/docs/static/configuration.asciidoc
@@ -656,21 +656,6 @@ This feature is _experimental_, to enable it you will need to run logstash with 
 [cols="a,a,a"]
 |==================================
 |Logstash config source	|Environment 	|Logstash config result
-
-|
-[source,shell]
-----
-export TCP_PORT=12345
-----
-|
-[source,ruby]
-----
-input {
-  tcp {
-    port => 12345
-  }
-}
-----
 |
 [source,ruby]
 ----

--- a/docs/static/configuration.asciidoc
+++ b/docs/static/configuration.asciidoc
@@ -643,7 +643,7 @@ This feature is _experimental_, to enable it you will need to run logstash with 
 
 ==== Overview
 
-* You can set environment variable references into Logstash plugins configuration using `${var}` or `$var`.
+* You can set environment variable references into Logstash plugins configuration using `${var}`.
 * Each reference will be replaced by environment variable value at Logstash startup.
 * The replacement is case-sensitive.
 * References to undefined variables raise a Logstash configuration error.
@@ -656,16 +656,6 @@ This feature is _experimental_, to enable it you will need to run logstash with 
 [cols="a,a,a"]
 |==================================
 |Logstash config source	|Environment 	|Logstash config result
-
-|
-[source,ruby]
-----
-input {
-  tcp {
-    port => "$TCP_PORT"
-  }
-}
-----
 
 |
 [source,shell]

--- a/docs/static/include/pluginbody.asciidoc
+++ b/docs/static/include/pluginbody.asciidoc
@@ -846,7 +846,7 @@ Gem::Specification.new do |s|
   s.version = '0.1.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = "This {plugintype} does x, y, z in Logstash"
-  s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
+  s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
   s.authors = ["Elastic"]
   s.email = 'info@elastic.co'
   s.homepage = "http://www.elastic.co/guide/en/logstash/current/index.html"
@@ -1052,7 +1052,7 @@ environment, and `0.1.0` with the correct version number from the gemspec file.
 [source,sh]
 [subs="attributes"]
 ----------------------------------
-bin/plugin install /my/logstash/plugins/logstash-{plugintype}-{pluginname}/logstash-{plugintype}-{pluginname}-0.1.0.gem
+bin/logstash-plugin install /my/logstash/plugins/logstash-{plugintype}-{pluginname}/logstash-{plugintype}-{pluginname}-0.1.0.gem
 ----------------------------------
 +
 * After running this, you should see feedback from Logstash that it was
@@ -1073,7 +1073,7 @@ currently available:
 
 [source,sh]
 ----------------------------------
-bin/plugin list
+bin/logstash-plugin list
 ----------------------------------
 Depending on what you have installed, you might see a short or long list of
 plugins: inputs, codecs, filters and outputs.
@@ -1276,7 +1276,7 @@ by running:
 [source,sh]
 [subs="attributes"]
 ----------------------------------
-bin/plugin install logstash-{plugintype}-mypluginname
+bin/logstash-plugin install logstash-{plugintype}-mypluginname
 ----------------------------------
 
 ==== Contributing your source code to https://github.com/logstash-plugins[logstash-plugins]

--- a/docs/static/offline-plugins.asciidoc
+++ b/docs/static/offline-plugins.asciidoc
@@ -20,18 +20,18 @@ all available plugins. You can distribute this bundle to all nodes without furth
 Working with offline plugins requires you to create an _offline package_, which is a compressed file that contains all of
 the plugins your offline Logstash installation requires, along with the dependencies for those plugins.
 
-. Create the offline package with the `bin/plugin pack` subcommand.
+. Create the offline package with the `bin/logstash-plugin pack` subcommand.
 +
-When you run the `bin/plugin pack` subcommand, Logstash creates a compressed bundle that contains all of the currently
+When you run the `bin/logstash-plugin pack` subcommand, Logstash creates a compressed bundle that contains all of the currently
 installed plugins and the dependencies for those plugins. By default, the compressed bundle is a GZipped TAR file when you
-run the `bin/plugin pack` subcommand on a UNIX machine. By default, when you run the `bin/plugin pack` subcommand on a
+run the `bin/logstash-plugin pack` subcommand on a UNIX machine. By default, when you run the `bin/logstash-plugin pack` subcommand on a
 Windows machine, the compressed bundle is a ZIP file. See <<managing-packs,Managing Plugin Packs>> for details on changing
 these default behaviors.
 +
 NOTE: Downloading all dependencies for the specified plugins may take some time, depending on the plugins listed.
 
 . Move the compressed bundle to the offline machines that are the source for offline plugin installation, then use the
-`bin/plugin unpack` subcommand to make the packaged plugins available.
+`bin/logstash-plugin unpack` subcommand to make the packaged plugins available.
 
 [float]
 === Install or Update a local plugin
@@ -41,24 +41,24 @@ examples:
 
 .Installing a local plugin
 ============
-`bin/plugin install --local logstash-input-jdbc`
+`bin/logstash-plugin install --local logstash-input-jdbc`
 ============
 
 .Updating a local plugin
 ============
-`bin/plugin update --local logstash-input-jdbc`
+`bin/logstash-plugin update --local logstash-input-jdbc`
 ============
 
 .Updating all local plugins in one command
 ============
-`bin/plugin update --local`
+`bin/logstash-plugin update --local`
 ============
 
 [float]
 [[managing-packs]]
 === Managing Plugin Packs
 
-The `pack` and `unpack` subcommands for `bin/plugin` take the following options:
+The `pack` and `unpack` subcommands for `bin/logstash-plugin` take the following options:
 
 [horizontal]
 `--tgz`:: Generate the offline package as a GZipped TAR file. The default behavior on UNIX systems.

--- a/docs/static/plugin-generator.asciidoc
+++ b/docs/static/plugin-generator.asciidoc
@@ -1,9 +1,9 @@
 [[plugin-generator]]
-== Generating Plugins
+=== Generating Plugins
 
 You can now create your own Logstash plugin in seconds! The generate subcommand of `bin/logstash-plugin` creates the foundation 
-for a new Logstash plugin with templatized files. It creates the right directory structure, gemspec files and dependencies so you 
-can start adding custom code process data with Logstash.
+for a new Logstash plugin with templatized files. It creates the correct directory structure, gemspec files, and dependencies so you 
+can start adding custom code to process data with Logstash.
 
 **Example Usage**
 
@@ -12,8 +12,8 @@ can start adding custom code process data with Logstash.
 bin/logstash-plugin generate --type input --name xkcd --path ~/ws/elastic/plugins
 -------------------------------------------
 
-* `--type`: Type of plugin - input, filter, output and codec
+* `--type`: Type of plugin - input, filter, output, or codec
 * `--name`: Name for the new plugin
-* `--path`: Directory path where the new plugin structure will be created. If not specified, it will be '
+* `--path`: Directory path where the new plugin structure will be created. If not specified, it will be
 created in the current directory.
 

--- a/docs/static/plugin-manager.asciidoc
+++ b/docs/static/plugin-manager.asciidoc
@@ -2,7 +2,7 @@
 == Working with plugins
 
 Logstash has a rich collection of input, filter, codec and output plugins. Plugins are available as self-contained
-packages called gems and hosted on RubyGems.org. The plugin manager accesed via `bin/plugin` script is used to manage the
+packages called gems and hosted on RubyGems.org. The plugin manager accesed via `bin/logstash-plugin` script is used to manage the
 lifecycle of plugins in your Logstash deployment. You can install, uninstall and upgrade plugins using these Command Line
 Interface (CLI) described below.
 
@@ -15,10 +15,10 @@ available in your deployment:
 
 [source,shell]
 ----------------------------------
-bin/plugin list <1>
-bin/plugin list --verbose <2>
-bin/plugin list *namefragment* <3>
-bin/plugin list --group output <4>
+bin/logstash-plugin list <1>
+bin/logstash-plugin list --verbose <2>
+bin/logstash-plugin list *namefragment* <3>
+bin/logstash-plugin list --group output <4>
 ----------------------------------
 <1> Will list all installed plugins
 
@@ -38,7 +38,7 @@ installation.
 
 [source,shell]
 ----------------------------------
-bin/plugin install logstash-output-kafka
+bin/logstash-plugin install logstash-output-kafka
 ----------------------------------
 
 Once the plugin is successfully installed, you can start using it in your configuration file.
@@ -52,7 +52,7 @@ provides you the option to install a locally built plugin which is packaged as a
 
 [source,shell]
 ----------------------------------
-bin/plugin install /path/to/logstash-output-kafka-1.0.0.gem
+bin/logstash-plugin install /path/to/logstash-output-kafka-1.0.0.gem
 ----------------------------------
 
 [[installing-local-plugins-path]]
@@ -76,8 +76,8 @@ subcommand you can get the latest or update to a particular version of the plugi
 
 [source,shell]
 ----------------------------------
-bin/plugin update <1>
-bin/plugin update logstash-output-kafka <2>
+bin/logstash-plugin update <1>
+bin/logstash-plugin update logstash-output-kafka <2>
 ----------------------------------
 <1> will update all installed plugins
 
@@ -91,7 +91,7 @@ If you need to remove plugins from your Logstash installation:
 
 [source,shell]
 ----------------------------------
-bin/plugin uninstall logstash-output-kafka
+bin/logstash-plugin uninstall logstash-output-kafka
 ----------------------------------
 
 [[proxy-plugins]]
@@ -106,7 +106,7 @@ Proxy is used to handle HTTP requests. Logstash Plugins can be installed and upd
 ----------------------------------
 export HTTP_PROXY=http://127.0.0.1:3128
 
-bin/plugin install logstash-output-kafka
+bin/logstash-plugin install logstash-output-kafka
 ----------------------------------
 
 Once set, plugin commands install, update can be used through this proxy.

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -3,188 +3,29 @@
 
 This section summarizes the changes in each release.
 
-* <<logstash-2-3-4,Logstash 2.3.4>>
-* <<logstash-2-3-3,Logstash 2.3.3>>
-* <<logstash-2-3-2,Logstash 2.3.2>>
-* <<logstash-2-3-1,Logstash 2.3.1>>
-* <<logstash-2-3,Logstash 2.3>>
+* <<logstash-2-4,Logstash 2.4>>
 
-[[logstash-2-3-4]]
-=== Logstash 2.3.4 Release Notes
-
-[float]
-==== Output Plugins
-
-*`Elasticsearch`*:
-
-* Fixed an issue where unnecessary information from HTTP headers was being logged. 
-
-[[logstash-2-3-3]]
-=== Logstash 2.3.3 Release Notes
-
-* Fixed a bug where the dynamic config reload feature could use excessive amounts of memory, leading to a crash ({lsissue}5235[Issue 5235]).
-* Fixed a bug where Logstash would not stop even when `KILL_ON_STOP_TIMEOUT` was specified ({lsissue}5427[Issue 5427]).
+[[logstash-2-4]]
+=== Logstash 2.4 Release Notes
 
 [float]
 ==== Input Plugins
 
-*`TCP`*:
+*`Plugin`*:
 
-* Changed the log level of the SSLError for the handshake from `error` to `debug`.
-
-*`RabbitMQ`*:
-
-* Fixed the `ssl` option to be boolean again (https://github.com/logstash-plugins/logstash-input-rabbitmq/issues/82[Issue 82]).
-* Added a separate `ssl_version` parameter.
-* Marked the `verify_ssl` parameter as obsolete because it never worked.
-* Added better checks for SSL argument consistency.
+* Description of change (link to issue).
 
 [float]
 ==== Filter Plugins
 
-*`KV`*:
+*`Plugin`*:
 
-* Added `:transform_value` and `:transform_key` options to lowercase/uppercase or capitalize all keys/values.
-
-*`XML`*:
-
-* Added a new configuration option called `suppress_empty`. By default the filter creates an empty hash from empty
-XML elements (`suppress_empty => false`). You can now set `supress_empty => true` so that the filter does not create
-event fields from empty XML elements.
-* Added a new configuration option called `force_content`. By default, the filter expands attributes differently for content in XML elements. This option allows you to force text content and attributes to always parse to a hash value.
-* Fixed a bug that ensures that a target is set when storing XML content in the event (`store_xml => true`).
+* Description of change (link to issue).
 
 [float]
 ==== Output Plugins
 
-*`Elasticsearch`*:
+*`Plugin`*:
 
-* Added a pipeline configuration option for setting an ingest pipeline to run upon indexing.
-
-[[logstash-2-3-2]]
-=== Logstash 2.3.2 Release Notes
-
-* Added reload support to the init script so you can do `service logstash reload`.
-* The original intent of `"%{foo}"` syntax was to always produce a string, but the previous 2.x and 1.5.x versions
-returned a float (underlying value). Starting in release 2.3.0, Logstash returned the underlying value type for
-field references. In 2.3.2 we are returning back to the 2.x and 1.5.x behavior of returning a float because changing
-the behavior broke compatibility in a minor release ({lsissue}5114[Issue 5114]).
-* Fixed use of the `KILL_ON_STOP_TIMEOUT` variable in init scripts, which allows Logstash to force stop ({lsissue}4991[Issue 4991]).
-   
-[float]
-==== Input Plugins
-
-*`Beats`*:
-
-* Fixed an issue encountered when the time-based flush feature was used with the multiline codec
-(https://github.com/logstash-plugins/logstash-input-beats/issues/73[Issue 73]).
-
-*`HTTP Poller`*:
-
-* Fixed the `ssl_certificate_validation` option so that it actually lets you disable cert validation 
-(https://github.com/logstash-plugins/logstash-input-http_poller/issues/48[Issue 48]).
-
-[float]
-==== Filter Plugins
-
-*`XML`*:
-
-* Added a setting called `force_array` that when set to false prevents storing single elements in arrays
-(https://github.com/logstash-plugins/logstash-filter-xml/issues/27[Issue 27]).
-
-[float]
-==== Output Plugins
-
-*`Redis`*:
-
-* Fixed a flood of runtime warnings that were logged when the Redis output was used (https://github.com/logstash-plugins/logstash-output-redis/issues/26[Issue 26]).
-
-[[logstash-2-3-1]]
-=== Logstash 2.3.1 Release Notes
-
-* Fixed a JRuby thread safety issue that was encountered when using regular expressions under multiple workers
-({lsissue}4977[Issue 4977]).
-* Disabled environment variables interpolation by default. This feature is experimental in Logstash 2.3.1. To turn it on use the `--allow-env` flag ({lsissue}4958[Issue 4958]). 
-* Changed the Logstash shutdown process to hide sensitive data from the log when shutting down a stale Logstash
-({lsissue}4952[Issue 4952]).
-* Disabled the default behavior of outputting the Configuration AST when running Logstash in debug mode. Introduced the `--debug-config` flag to display the AST ({lsissue}4965[Issue 4965]).
-* Fixed an error encountered when running Logstash with the `--config-test` flag ({lsissue}4933[Issue 4933]).
-* Made filter conditionals work when running Logstash with automatic configuration reloading ({lsissue}4968[Issue 4968]).
-* Fixed the stop command of the Ubuntu init script ({lsissue}4940[Issue 4940]).
-
-[float]
-==== Input Plugins
-
-*`Beats`*:
-
-* Changed when the identity map is used. Now it's only used when the configuration specifies the multiline codec 
-(https://github.com/logstash-plugins/logstash-input-beats/pull/70[Issue 70]).
-
-
-[[logstash-2-3]]
-=== Logstash 2.3 Release Notes
-
-* Added dynamic config, a new feature to track config file for changes and restart the 
-  pipeline (same process) with updated config changes. This feature can be enabled in two 
-  ways: Passing a CLI long-form option `--auto-reload` or with short-form `-r`. Another 
-  option, `--reload-interval <seconds>` controls how often LS should check the config files 
-  for changes. Alternatively, if you don't start with the CLI option, you can send SIGHUP 
-  or `kill -1` signal to LS to reload the config file, and restart the pipeline ({lsissue}4513[Issue 4513]).
-* Added support to evaluate environment variables inside the Logstash config. You can also specify a 
-  default if the variable is not defined. The syntax is `${myVar:default}` ({lsissue}3944[Issue 3944]).
-* Added ability to configure custom garbage collection log file using `$LS_LOG_DIR`.
-* Deprecated `bin/plugin` in favor of `bin/logstash-plugin`. In the next major version `bin/plugin` will 
-  be removed to prevent `PATH` being polluted when other components of the Elastic stack are installed on 
-  the same instance ({lsissue}4891[Issue 4891]).
-* Fixed a bug where new pipeline might break plugins by calling the `register` method twice causing 
-  undesired behavior ({lsissue}4851[Issue 4851]).
-* Made `JAVA_OPTS` and `LS_JAVA_OPTS` work consistently on Windows ({lsissue}4758[Issue 4758]).
-* Fixed a bug where specifying JMX parameters in `LS_JAVA_OPTS` caused Logstash not to restart properly
-  ({lsissue}4319[Issue 4319]).
-* Fixed a bug where upgrading plugins with Manticore threw an error and sometimes corrupted installation ({lsissue}4818[Issue 4818]).
-* Removed milestone warning that was displayed when the `--pluginpath` option was used to load plugins ({lsissue}4562[Issue 4562]).
-* Upgraded to JRuby 1.7.24.
-* Reverted default output workers to 1. Previously we had made output workers the same as number of pipeline workers ({lsissue}4877[Issue 4877]). 
-
-[float]
-==== Input Plugins
-
-*`Beats`*:
-
-* Enhanced to verify client certificates against CA (https://github.com/logstash-plugins/logstash-input-beats/issues/8[Issue 8]).
-
-*`RabbitMQ`*:
-
-* Breaking Change: Metadata is now disabled by default because it was regressing performance.
-* Improved performance by using an internal queue and bulk ACKs.
-
-*`Redis`*:
-
-* Increased the batch_size to 100 by default. This provides a big jump in throughput and 
-  reduction in CPU utilization (https://github.com/logstash-plugins/logstash-input-redis/issues/25[Issue 25]).
-
-*`JDBC`*:
-
-* Added retry connection feature (https://github.com/logstash-plugins/logstash-input-http/issues/33[Issue 33]).
-
-[float]
-==== Filter Plugins
-
-*`DNS`*:
-
-* Improved performance by adding caches to both successful and failed requests.
-* Added support for retrying with the `:max_retries` setting.
-* Lowered the default value of timeout from 2 to 0.5 seconds.
-
-[float]
-==== Output Plugins
-
-*`Elasticsearch`*:
-
-* Bumped minimum Manticore version to 0.5.4 which fixes a memory leak when sniffing 
-  is used (https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/392[Issue 392]).
-* Fixed bug when updating documents with doc_as_upsert and scripting.   
-* Made error messages more verbose and easier to parse by humans.
-* Retryable failures are now logged at the info level instead of warning.
-
+* Description of change (link to issue).
 

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -1,5 +1,128 @@
 [[releasenotes]]
-== Logstash 2.3 Release Notes
+== Release Notes
+
+This section summarizes the changes in each release.
+
+* <<logstash-2-3-4,Logstash 2.3.4>>
+* <<logstash-2-3-3,Logstash 2.3.3>>
+* <<logstash-2-3-2,Logstash 2.3.2>>
+* <<logstash-2-3-1,Logstash 2.3.1>>
+* <<logstash-2-3,Logstash 2.3>>
+
+[[logstash-2-3-4]]
+=== Logstash 2.3.4 Release Notes
+
+[float]
+==== Output Plugins
+
+*`Elasticsearch`*:
+
+* Fixed an issue where unnecessary information from HTTP headers was being logged. 
+
+[[logstash-2-3-3]]
+=== Logstash 2.3.3 Release Notes
+
+* Fixed a bug where the dynamic config reload feature could use excessive amounts of memory, leading to a crash ({lsissue}5235[Issue 5235]).
+* Fixed a bug where Logstash would not stop even when `KILL_ON_STOP_TIMEOUT` was specified ({lsissue}5427[Issue 5427]).
+
+[float]
+==== Input Plugins
+
+*`TCP`*:
+
+* Changed the log level of the SSLError for the handshake from `error` to `debug`.
+
+*`RabbitMQ`*:
+
+* Fixed the `ssl` option to be boolean again (https://github.com/logstash-plugins/logstash-input-rabbitmq/issues/82[Issue 82]).
+* Added a separate `ssl_version` parameter.
+* Marked the `verify_ssl` parameter as obsolete because it never worked.
+* Added better checks for SSL argument consistency.
+
+[float]
+==== Filter Plugins
+
+*`KV`*:
+
+* Added `:transform_value` and `:transform_key` options to lowercase/uppercase or capitalize all keys/values.
+
+*`XML`*:
+
+* Added a new configuration option called `suppress_empty`. By default the filter creates an empty hash from empty
+XML elements (`suppress_empty => false`). You can now set `supress_empty => true` so that the filter does not create
+event fields from empty XML elements.
+* Added a new configuration option called `force_content`. By default, the filter expands attributes differently for content in XML elements. This option allows you to force text content and attributes to always parse to a hash value.
+* Fixed a bug that ensures that a target is set when storing XML content in the event (`store_xml => true`).
+
+[float]
+==== Output Plugins
+
+*`Elasticsearch`*:
+
+* Added a pipeline configuration option for setting an ingest pipeline to run upon indexing.
+
+[[logstash-2-3-2]]
+=== Logstash 2.3.2 Release Notes
+
+* Added reload support to the init script so you can do `service logstash reload`.
+* The original intent of `"%{foo}"` syntax was to always produce a string, but the previous 2.x and 1.5.x versions
+returned a float (underlying value). Starting in release 2.3.0, Logstash returned the underlying value type for
+field references. In 2.3.2 we are returning back to the 2.x and 1.5.x behavior of returning a float because changing
+the behavior broke compatibility in a minor release ({lsissue}5114[Issue 5114]).
+* Fixed use of the `KILL_ON_STOP_TIMEOUT` variable in init scripts, which allows Logstash to force stop ({lsissue}4991[Issue 4991]).
+   
+[float]
+==== Input Plugins
+
+*`Beats`*:
+
+* Fixed an issue encountered when the time-based flush feature was used with the multiline codec
+(https://github.com/logstash-plugins/logstash-input-beats/issues/73[Issue 73]).
+
+*`HTTP Poller`*:
+
+* Fixed the `ssl_certificate_validation` option so that it actually lets you disable cert validation 
+(https://github.com/logstash-plugins/logstash-input-http_poller/issues/48[Issue 48]).
+
+[float]
+==== Filter Plugins
+
+*`XML`*:
+
+* Added a setting called `force_array` that when set to false prevents storing single elements in arrays
+(https://github.com/logstash-plugins/logstash-filter-xml/issues/27[Issue 27]).
+
+[float]
+==== Output Plugins
+
+*`Redis`*:
+
+* Fixed a flood of runtime warnings that were logged when the Redis output was used (https://github.com/logstash-plugins/logstash-output-redis/issues/26[Issue 26]).
+
+[[logstash-2-3-1]]
+=== Logstash 2.3.1 Release Notes
+
+* Fixed a JRuby thread safety issue that was encountered when using regular expressions under multiple workers
+({lsissue}4977[Issue 4977]).
+* Disabled environment variables interpolation by default. This feature is experimental in Logstash 2.3.1. To turn it on use the `--allow-env` flag ({lsissue}4958[Issue 4958]). 
+* Changed the Logstash shutdown process to hide sensitive data from the log when shutting down a stale Logstash
+({lsissue}4952[Issue 4952]).
+* Disabled the default behavior of outputting the Configuration AST when running Logstash in debug mode. Introduced the `--debug-config` flag to display the AST ({lsissue}4965[Issue 4965]).
+* Fixed an error encountered when running Logstash with the `--config-test` flag ({lsissue}4933[Issue 4933]).
+* Made filter conditionals work when running Logstash with automatic configuration reloading ({lsissue}4968[Issue 4968]).
+* Fixed the stop command of the Ubuntu init script ({lsissue}4940[Issue 4940]).
+
+[float]
+==== Input Plugins
+
+*`Beats`*:
+
+* Changed when the identity map is used. Now it's only used when the configuration specifies the multiline codec 
+(https://github.com/logstash-plugins/logstash-input-beats/pull/70[Issue 70]).
+
+
+[[logstash-2-3]]
+=== Logstash 2.3 Release Notes
 
 * Added dynamic config, a new feature to track config file for changes and restart the 
   pipeline (same process) with updated config changes. This feature can be enabled in two 
@@ -14,17 +137,17 @@
   be removed to prevent `PATH` being polluted when other components of the Elastic stack are installed on 
   the same instance ({lsissue}4891[Issue 4891]).
 * Fixed a bug where new pipeline might break plugins by calling the `register` method twice causing 
-  undesired behavior ({lsissue}4851[Issue 4851])).
+  undesired behavior ({lsissue}4851[Issue 4851]).
 * Made `JAVA_OPTS` and `LS_JAVA_OPTS` work consistently on Windows ({lsissue}4758[Issue 4758]).
 * Fixed a bug where specifying JMX parameters in `LS_JAVA_OPTS` caused Logstash not to restart properly
   ({lsissue}4319[Issue 4319]).
 * Fixed a bug where upgrading plugins with Manticore threw an error and sometimes corrupted installation ({lsissue}4818[Issue 4818]).
 * Removed milestone warning that was displayed when the `--pluginpath` option was used to load plugins ({lsissue}4562[Issue 4562]).
 * Upgraded to JRuby 1.7.24.
-* Reverted default output workers to 1. Previously we had made output workers the same as number of pipeline workers (#4877). 
+* Reverted default output workers to 1. Previously we had made output workers the same as number of pipeline workers ({lsissue}4877[Issue 4877]). 
 
 [float]
-== Input Plugins
+==== Input Plugins
 
 *`Beats`*:
 
@@ -38,14 +161,14 @@
 *`Redis`*:
 
 * Increased the batch_size to 100 by default. This provides a big jump in throughput and 
-  reduction in CPU utilization (https://github.com/logstash-plugins/logstash-input-redis/issues/25[Issue 25])
+  reduction in CPU utilization (https://github.com/logstash-plugins/logstash-input-redis/issues/25[Issue 25]).
 
 *`JDBC`*:
 
-* Added retry connection feature (https://github.com/logstash-plugins/logstash-input-http/issues/33[Issue 33])
+* Added retry connection feature (https://github.com/logstash-plugins/logstash-input-http/issues/33[Issue 33]).
 
 [float]
-== Filter Plugins
+==== Filter Plugins
 
 *`DNS`*:
 
@@ -54,11 +177,11 @@
 * Lowered the default value of timeout from 2 to 0.5 seconds.
 
 [float]
-== Output Plugins
+==== Output Plugins
 
 *`Elasticsearch`*:
 
-* Bumped minimum manticore version to 0.5.4 which fixes a memory leak when sniffing 
+* Bumped minimum Manticore version to 0.5.4 which fixes a memory leak when sniffing 
   is used (https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/392[Issue 392]).
 * Fixed bug when updating documents with doc_as_upsert and scripting.   
 * Made error messages more verbose and easier to parse by humans.

--- a/docs/static/submitting-a-plugin.asciidoc
+++ b/docs/static/submitting-a-plugin.asciidoc
@@ -65,7 +65,7 @@ by running:
 [source,sh]
 [subs="attributes"]
 ----------------------------------
-bin/plugin install logstash-{plugintype}-mypluginname
+bin/logstash-plugin install logstash-{plugintype}-mypluginname
 ----------------------------------
 
 ==== Contributing your source code to https://github.com/logstash-plugins[logstash-plugins]

--- a/docs/static/upgrading.asciidoc
+++ b/docs/static/upgrading.asciidoc
@@ -69,7 +69,7 @@ These plugin updates are available for Logstash 2.0. To upgrade to the latest ve
 plugins, the command is:
 
 [source,shell]
-bin/plugin update <plugin_name>
+bin/logstash-plugin update <plugin_name>
 
 **Multiline Filter:** If you are using the Multiline Filter in your configuration and upgrade to Logstash 2.0,
 you will get an error. Make sure to explicitly set the number of filter workers (`-w`) to `1`. You can set the number

--- a/lib/bootstrap/environment.rb
+++ b/lib/bootstrap/environment.rb
@@ -57,7 +57,7 @@ module LogStash
 end
 
 
-# when launched as a script, not require'd, (currently from bin/logstash and bin/plugin) the first
+# when launched as a script, not require'd, (currently from bin/logstash and bin/logstash-plugin) the first
 # argument is the path of a Ruby file to require and a LogStash::Runner class is expected to be
 # defined and exposing the LogStash::Runner#main instance method which will be called with the current ARGV
 # currently lib/logstash/runner.rb and lib/pluginmanager/main.rb are called using this.

--- a/lib/pluginmanager/install.rb
+++ b/lib/pluginmanager/install.rb
@@ -11,7 +11,7 @@ class LogStash::PluginManager::Install < LogStash::PluginManager::Command
   option "--[no-]verify", :flag, "verify plugin validity before installation", :default => true
   option "--preserve", :flag, "preserve current gem options", :default => false
   option "--development", :flag, "install all development dependencies of currently installed plugins", :default => false
-  option "--local", :flag, "force local-only plugin installation. see bin/plugin package|unpack", :default => false
+  option "--local", :flag, "force local-only plugin installation. see bin/logstash-plugin package|unpack", :default => false
 
   # the install logic below support installing multiple plugins with each a version specification
   # but the argument parsing does not support it for now so currently if specifying --version only
@@ -121,7 +121,7 @@ class LogStash::PluginManager::Install < LogStash::PluginManager::Command
 
   # Extract the specified local gems in a predefined local path
   # Update the gemfile to use a relative path to this plugin and run
-  # Bundler, this will mark the gem not updatable by `bin/plugin update`
+  # Bundler, this will mark the gem not updatable by `bin/logstash-plugin update`
   # This is the most reliable way to make it work in bundler without
   # hacking with `how bundler works`
   #

--- a/lib/pluginmanager/list.rb
+++ b/lib/pluginmanager/list.rb
@@ -6,7 +6,7 @@ class LogStash::PluginManager::List < LogStash::PluginManager::Command
 
   parameter "[PLUGIN]", "Part of plugin name to search for, leave empty for all plugins"
 
-  option "--installed", :flag, "List only explicitly installed plugins using bin/plugin install ...", :default => false
+  option "--installed", :flag, "List only explicitly installed plugins using bin/logstash-plugin install ...", :default => false
   option "--verbose", :flag, "Also show plugin version number", :default => false
   option "--group", "NAME", "Filter plugins per group: input, output, filter or codec" do |arg|
     raise(ArgumentError, "should be one of: input, output, filter or codec") unless ['input', 'output', 'filter', 'codec'].include?(arg)

--- a/lib/pluginmanager/unpack.rb
+++ b/lib/pluginmanager/unpack.rb
@@ -14,7 +14,7 @@ class LogStash::PluginManager::Unpack < LogStash::PluginManager::PackCommand
     validate_cache_location
     archive_manager.extract(package_file, LogStash::Environment::CACHE_PATH)
     puts("Unpacked at #{LogStash::Environment::CACHE_PATH}")
-    puts("The unpacked plugins can now be installed in local-only mode using bin/plugin install --local [plugin name]")
+    puts("The unpacked plugins can now be installed in local-only mode using bin/logstash-plugin install --local [plugin name]")
   end
 
   private

--- a/lib/pluginmanager/update.rb
+++ b/lib/pluginmanager/update.rb
@@ -9,7 +9,7 @@ class LogStash::PluginManager::Update < LogStash::PluginManager::Command
 
   parameter "[PLUGIN] ...", "Plugin name(s) to upgrade to latest version", :attribute_name => :plugins_arg
   option "--[no-]verify", :flag, "verify plugin validity before installation", :default => true
-  option "--local", :flag, "force local-only plugin update. see bin/plugin package|unpack", :default => false
+  option "--local", :flag, "force local-only plugin update. see bin/logstash-plugin package|unpack", :default => false
 
   def execute
     local_gems = gemfile.locally_installed_gems

--- a/rakelib/package.rake
+++ b/rakelib/package.rake
@@ -1,7 +1,7 @@
 namespace "package" do
 
   task "bundle" do
-    system("bin/plugin", "pack")
+    system("bin/logstash-plugin", "pack")
     raise(RuntimeError, $!.to_s) unless $?.success?
   end
 


### PR DESCRIPTION
Includes:
* Doc-related changes that were made in 2.3, but didn't get merged into 2.x
* Doc edits made in 5.0 on feature that was ported to 2.x, but the doc edits didn't get merged.

@suyograo There are a few changes here that affect the code (because I cherry-picked commit  	222be3b).