### PR TITLE
Upgrade Logstash to use latest jruby9k released

### DIFF
--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -132,7 +132,6 @@ setup_ruby() {
 }
 
 jruby_opts() {
-  printf "%s" "--1.9"
   for i in $JAVA_OPTS ; do
     if [ -z "$i" ]; then
       printf "%s" " -J$i"

--- a/lib/bootstrap/bundler.rb
+++ b/lib/bootstrap/bundler.rb
@@ -46,8 +46,9 @@ module LogStash
       # make sure we use our own installed bundler
       LogStash::Rubygems.patch!
       ::Gem.clear_paths
-      ::Gem.paths = ENV['GEM_HOME'] = ENV['GEM_PATH'] = Environment.logstash_gem_home
 
+      ENV['GEM_HOME'] = ENV['GEM_PATH'] = LogStash::Environment.logstash_gem_paths
+      ::Gem.paths = ENV
       # set BUNDLE_GEMFILE ENV before requiring bundler to avoid bundler recurse and load unrelated Gemfile(s)
       ENV["BUNDLE_GEMFILE"] = Environment::GEMFILE_PATH
 
@@ -86,7 +87,9 @@ module LogStash
       # require "logstash/patches/rubygems" # patch rubygems before clear_paths
       LogStash::Rubygems.patch!
       ::Gem.clear_paths
-      ::Gem.paths = ENV['GEM_HOME'] = ENV['GEM_PATH'] = LogStash::Environment.logstash_gem_home
+
+      ENV['GEM_HOME'] = ENV['GEM_PATH'] = LogStash::Environment.logstash_gem_paths
+      ::Gem.paths = ENV
 
       # set BUNDLE_GEMFILE ENV before requiring bundler to avoid bundler recurse and load unrelated Gemfile(s).
       # in the context of calling Bundler::CLI this is not really required since Bundler::CLI will look at

--- a/lib/bootstrap/environment.rb
+++ b/lib/bootstrap/environment.rb
@@ -45,6 +45,10 @@ module LogStash
       ::File.join(BUNDLE_DIR, ruby_engine, gem_ruby_version)
     end
 
+    def logstash_gem_paths
+      ::Dir.glob(::File.join(BUNDLE_DIR, ruby_engine, "*")).join(":")
+    end
+
     def vendor_path(path)
       return ::File.join(LOGSTASH_HOME, "vendor", path)
     end

--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -1,6 +1,6 @@
 namespace "vendor" do
   VERSIONS = {
-    "jruby" => { "version" => "1.7.25", "sha1" => "cd15aef419f97cff274491e53fcfb8b88ec36785" },
+    "jruby" => { "version" => "9.1.2.0", "sha1" => "c04f347d620aded0b8df59e0407448f02b1e901f" },
   }
 
   def vendor(*args)

--- a/rakelib/z_rubycheck.rake
+++ b/rakelib/z_rubycheck.rake
@@ -31,7 +31,8 @@ if ENV['USE_RUBY'] != '1'
 
     # if required at this point system gems can be installed using the system_gem task, for example:
     # Rake::Task["vendor:system_gem"].invoke(jruby, "ffi", "1.9.6")
-
+    ENV['GEM_HOME'] = ENV['GEM_PATH'] = LogStash::Environment.logstash_gem_paths
+    ::Gem.paths = ENV
     exec(jruby, "-J-Xmx1g", "-S", rake, *ARGV)
   end
 end

--- a/spec/unit/bootstrap/bundler_spec.rb
+++ b/spec/unit/bootstrap/bundler_spec.rb
@@ -46,7 +46,7 @@ describe LogStash::Bundler do
       expect(::Bundler.settings[:gemfile]).to eq(LogStash::Environment::GEMFILE_PATH)
       expect(::Bundler.settings[:without]).to eq(options.fetch(:without, []).join(':'))
 
-      expect(ENV['GEM_PATH']).to eq(LogStash::Environment.logstash_gem_home)
+      expect(ENV['GEM_PATH']).to eq(LogStash::Environment.logstash_gem_paths)
 
       $stderr = original_stderr
     end

--- a/spec/unit/license_spec.rb
+++ b/spec/unit/license_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 require 'spec_helper'
-require 'rakelib/default_plugins'
+require File.expand_path(File.join(__FILE__, '..', '..', '..', 'rakelib','default_plugins'))
 
 describe "Project licenses" do
 


### PR DESCRIPTION
This PR include minimum changes necessary to adapt to the requirements of jruby 9k usage. This include the fact that jruby9k host 2.2.x and 2.3.x gems.

For now this build is broken until the jruby-event bug (#5617) is fixed.
