### PR TITLE
Add support for hostname:port syntax to SafeURI class

### DIFF
--- a/logstash-core/lib/logstash/util/safe_uri.rb
+++ b/logstash-core/lib/logstash/util/safe_uri.rb
@@ -6,6 +6,7 @@ require "logstash/util"
 # logged, you don't accidentally print the password itself.
 class LogStash::Util::SafeURI
   PASS_PLACEHOLDER = "xxxxxx".freeze
+  HOSTNAME_PORT_REGEX=/\A(?<hostname>([A-Za-z0-9\.\-]+)|\[[0-9A-Fa-f\:]+\])(:(?<port>\d+))?\Z/
   
   extend Forwardable
   
@@ -17,6 +18,7 @@ class LogStash::Util::SafeURI
   def initialize(arg)    
     @uri = case arg
            when String
+             arg = "//#{arg}" if HOSTNAME_PORT_REGEX.match(arg)
              URI.parse(arg)
            when URI
              arg

--- a/logstash-core/spec/logstash/config/mixin_spec.rb
+++ b/logstash-core/spec/logstash/config/mixin_spec.rb
@@ -178,19 +178,13 @@ describe LogStash::Config::Mixin do
       end
     end
 
-    shared_examples("safe URI") do            
+    shared_examples("safe URI") do |options|
+      options ||= {}
+      
       subject { klass.new("uri" => uri_str) }
 
       it "should be a SafeURI object" do
         expect(subject.uri).to(be_a(LogStash::Util::SafeURI))
-      end
-
-      it "should make password values hidden with #to_s" do
-        expect(subject.uri.to_s).to eql(uri_hidden)
-      end
-
-      it "should make password values hidden with #inspect" do
-        expect(subject.uri.inspect).to eql(uri_hidden)
       end
 
       it "should correctly copy URI types" do
@@ -206,6 +200,18 @@ describe LogStash::Config::Mixin do
         expect(subject.original_params['uri']).to(be_a(LogStash::Util::SafeURI))
       end
 
+      if !options[:exclude_password_specs]
+        describe "passwords" do
+          it "should make password values hidden with #to_s" do
+            expect(subject.uri.to_s).to eql(uri_hidden)
+          end
+
+          it "should make password values hidden with #inspect" do
+            expect(subject.uri.inspect).to eql(uri_hidden)
+          end
+        end
+      end
+
       context "attributes" do
         [:scheme, :user, :password, :hostname, :path].each do |attr|
           it "should make #{attr} available" do
@@ -213,6 +219,19 @@ describe LogStash::Config::Mixin do
           end
         end
       end
+    end
+
+    context "with a host:port combination" do
+      let(:scheme) { nil }
+      let(:user) { nil }
+      let(:password) { nil }
+      let(:hostname) { "myhostname" }
+      let(:port) { 1234 }
+      let(:path) { "" }
+      let(:uri_str) { "#{hostname}:#{port}" }
+      let(:uri_hidden) { "//#{hostname}:#{port}" }
+
+      include_examples("safe URI", :exclude_password_specs => true)
     end
 
     context "with a username / password" do


### PR DESCRIPTION
This is a deviation from what the ruby URI class normally allows.
With this patch users can use "myhost:123" as an option and have it do the
right thing, as opposed to before where they'd get an error and have to
use "//myhost:123".