### PR TITLE
Fix human parameter processing

### DIFF
--- a/logstash-core/lib/logstash/api/app_helpers.rb
+++ b/logstash-core/lib/logstash/api/app_helpers.rb
@@ -7,11 +7,10 @@ module LogStash::Api::AppHelpers
     as     = options.fetch(:as, :json)
     pretty = params.has_key?("pretty")
 
-    unless options.include?(:exclude_default_metadata)
-      data = default_metadata.merge(data)
-    end
-    
     if as == :json
+      unless options.include?(:exclude_default_metadata)
+        data = default_metadata.merge(data)
+      end
       content_type "application/json"
       LogStash::Json.dump(data, {:pretty => pretty})
     else

--- a/logstash-core/lib/logstash/api/commands/node.rb
+++ b/logstash-core/lib/logstash/api/commands/node.rb
@@ -62,7 +62,7 @@ module LogStash
           end
           
           def to_s
-            hash = to_hash
+            hash = to_hash[:hot_threads]
             report =  "#{I18n.t("logstash.web_api.hot_threads.title", :hostname => hash[:hostname], :time => hash[:time], :top_count => @thread_dump.top_count )} \n"
             report << '=' * 80
             report << "\n"
@@ -98,7 +98,7 @@ module LogStash
               thread[:traces] = traces unless traces.empty?
               hash[:threads] << thread
             end
-            hash
+            { :hot_threads => hash }
           end
 
           def cpu_time_as_percent(hash)

--- a/logstash-core/lib/logstash/api/modules/node.rb
+++ b/logstash-core/lib/logstash/api/modules/node.rb
@@ -35,7 +35,7 @@ module LogStash
           options[:threads] = params["threads"].to_i if params.has_key?("threads")
 
           as = options[:human] ? :string : :json
-          respond_with({:hot_threads => node.hot_threads(options)}, {:as => as})
+          respond_with(node.hot_threads(options), {:as => as})
         end       
       end
     end


### PR DESCRIPTION
Add fixes for the human parameter processing, for now only related to hot threads api, but nothing prevents to have it for others resources in the feature.

Changes in this PR basically make sure that the `.to_s` method requested when the output should be in text is the right now and no extra information is in between.

Fixes #5563 
Related https://github.com/elastic/logstash/issues/5607