### PR TITLE
Collection of small fixes for the web api

### DIFF
--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -11,7 +11,8 @@ module LogStash
               [:jvm, :threads],
               :count,
               :peak_count
-            )
+            ),
+            :mem => memory
           }
         end
 

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -139,7 +139,7 @@ module LogStash
 
             {
               :events => stats[:events],
-              :pipeline => {
+              :plugins => {
                 :inputs => plugin_stats(stats, :inputs),
                 :filters => plugin_stats(stats, :filters),
                 :outputs => plugin_stats(stats, :outputs)

--- a/logstash-core/lib/logstash/api/modules/node_stats.rb
+++ b/logstash-core/lib/logstash/api/modules/node_stats.rb
@@ -20,7 +20,6 @@ module LogStash
             :events => events_payload,
             :jvm => jvm_payload,
             :process => process_payload,
-            :mem => mem_payload,
             :pipeline => pipeline_payload
           }
 
@@ -45,10 +44,6 @@ module LogStash
 
         get "/process" do
           respond_with :process => process_payload
-        end
-
-        get "/mem" do
-          respond_with :mem => mem_payload
         end
 
         get "/pipeline" do

--- a/logstash-core/lib/logstash/api/modules/node_stats.rb
+++ b/logstash-core/lib/logstash/api/modules/node_stats.rb
@@ -20,7 +20,8 @@ module LogStash
             :events => events_payload,
             :jvm => jvm_payload,
             :process => process_payload,
-            :mem => mem_payload
+            :mem => mem_payload,
+            :pipeline => pipeline_payload
           }
 
           respond_with payload

--- a/logstash-core/lib/logstash/api/modules/node_stats.rb
+++ b/logstash-core/lib/logstash/api/modules/node_stats.rb
@@ -17,25 +17,12 @@ module LogStash
         # retrieved and show
         get "/" do          
           payload = {
-            :events => events_payload,
             :jvm => jvm_payload,
             :process => process_payload,
             :pipeline => pipeline_payload
           }
 
           respond_with payload
-        end
-
-        # Show all events stats information
-        # (for ingested, emitted, dropped)
-        # - #events since startup
-        # - #data (bytes) since startup
-        # - events/s
-        # - bytes/s
-        # - dropped events/s
-        # - events in the pipeline
-        get "/events" do
-          respond_with({ :events => events_payload })
         end
 
         get "/jvm" do

--- a/logstash-core/spec/api/lib/api/node_stats_spec.rb
+++ b/logstash-core/spec/api/lib/api/node_stats_spec.rb
@@ -11,15 +11,38 @@ describe LogStash::Api::Modules::NodeStats do
 
   # DSL describing response structure
   root_structure = {
-    "events"=>{
-      "in"=>Numeric,
-      "filtered"=>Numeric,
-      "out"=>Numeric
-    },
     "jvm"=>{
       "threads"=>{
         "count"=>Numeric,
         "peak_count"=>Numeric
+      },
+      "mem" => {
+        "heap_used_in_bytes" => Numeric,
+        "heap_used_percent" => Numeric,
+        "heap_committed_in_bytes" => Numeric,
+        "heap_max_in_bytes" => Numeric,
+        "non_heap_used_in_bytes" => Numeric,
+        "non_heap_committed_in_bytes" => Numeric,
+        "pools" => {
+          "survivor" => {
+            "peak_used_in_bytes" => Numeric,
+            "used_in_bytes" => Numeric,
+            "peak_max_in_bytes" => Numeric,
+            "max_in_bytes" => Numeric
+          },
+          "old" => {
+            "peak_used_in_bytes" => Numeric,
+            "used_in_bytes" => Numeric,
+            "peak_max_in_bytes" => Numeric,
+            "max_in_bytes" => Numeric
+          },
+          "young" => {
+            "peak_used_in_bytes" => Numeric,
+            "used_in_bytes" => Numeric,
+            "peak_max_in_bytes" => Numeric,
+            "max_in_bytes" => Numeric
+          }
+        }
       }
     },
     "process"=>{
@@ -33,35 +56,14 @@ describe LogStash::Api::Modules::NodeStats do
         "total_in_millis"=>Numeric,
         "percent"=>Numeric
       }
-    },    
-    "mem" => {
-      "heap_used_in_bytes" => Numeric,
-      "heap_used_percent" => Numeric,
-      "heap_committed_in_bytes" => Numeric,
-      "heap_max_in_bytes" => Numeric,
-      "non_heap_used_in_bytes" => Numeric,
-      "non_heap_committed_in_bytes" => Numeric,
-      "pools" => {
-        "survivor" => {
-          "peak_used_in_bytes" => Numeric,
-          "used_in_bytes" => Numeric,
-          "peak_max_in_bytes" => Numeric,
-          "max_in_bytes" => Numeric
-        },
-        "old" => {
-          "peak_used_in_bytes" => Numeric,
-          "used_in_bytes" => Numeric,
-          "peak_max_in_bytes" => Numeric,
-          "max_in_bytes" => Numeric
-        },
-        "young" => {
-          "peak_used_in_bytes" => Numeric,
-          "used_in_bytes" => Numeric,
-          "peak_max_in_bytes" => Numeric,
-          "max_in_bytes" => Numeric
-        }
-      }
-    }
+    },
+   "pipeline" => {
+     "events" => {
+        "in" => Numeric,
+        "filtered" => Numeric,
+        "out" => Numeric
+     } 
+    } 
   }
   
   test_api_and_resources(root_structure)

--- a/logstash-core/spec/api/spec_helper.rb
+++ b/logstash-core/spec/api/spec_helper.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 API_ROOT = File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "lib", "logstash", "api"))
 
+require "stud/task"
 require "logstash/devutils/rspec/spec_helper"
 $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__)))
 require "lib/api/support/resource_dsl_methods"


### PR DESCRIPTION
List of errors fixed:

- [x] Pipeline stats from `/_node/stats/pipeline` should also be included in the parent `/_node/stats` resource for completeness; verbosity shouldn’t be an issue as this API should be for computers not humans
- [x] `/_node/stats/mem` resource should be removed and the object should instead be nested under `/_node/stats/jvm` along with the ‘thread’ stats
- [x] `/_node/stats/events` object+resource should be removed as these metrics now instead reside under the pipeline stats `/_node/stats/pipeline`
- [x] There is a bug in `/_node/stats/pipeline` where the plugin specific stats should be keyed by “plugins” and not “pipeline"

Fixes #5607 