### PR TITLE
fix string setting validation of possible values

### DIFF
--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -210,12 +210,6 @@ module LogStash
       end
     end
 
-    class String < Setting
-      def initialize(name, default=nil, strict=true)
-        super(name, ::String, default, strict)
-      end
-    end
-
     class Numeric < Setting
       def initialize(name, default=nil, strict=true)
         super(name, ::Numeric, default, strict)
@@ -241,11 +235,15 @@ module LogStash
 
     class String < Setting
       def initialize(name, default=nil, strict=true, possible_strings=[])
+        @possible_strings = possible_strings
         super(name, ::String, default, strict)
       end
 
       def validate(value)
-        super(value) && possible_strings.include?(value)
+        super(value)
+        unless @possible_strings.empty? || @possible_strings.include?(value)
+          raise ArgumentError.new("invalid value \"#{value}\". Options are: #{@possible_strings.inspect}")
+        end
       end
     end
 

--- a/logstash-core/spec/logstash/settings/string_spec.rb
+++ b/logstash-core/spec/logstash/settings/string_spec.rb
@@ -1,0 +1,21 @@
+# encoding: utf-8
+require "spec_helper"
+require "logstash/settings"
+
+describe LogStash::Setting::String do
+  let(:possible_values) { ["a", "b", "c"] }
+  subject { described_class.new("mytext", nil, false, possible_values) }
+  describe "#set" do
+    context "when a value is given outside of possible_values" do
+      it "should raise an ArgumentError" do
+        expect { subject.set("d") }.to raise_error(ArgumentError)
+      end
+    end
+    context "when a value is given within possible_values" do
+      it "should set the value" do
+        expect { subject.set("a") }.to_not raise_error
+        expect(subject.value).to eq("a")
+      end
+    end
+  end
+end


### PR DESCRIPTION
currently when a String setting is created with a range of possible values, this range is not properly checked, allowing a setting to have a value outside of the array.
This PR properly introduces validation and tests to confirm it works as it should