### PR TITLE
Add support for first level response filtering in the webapi

### DIFF
--- a/logstash-core/lib/logstash/api/app_helpers.rb
+++ b/logstash-core/lib/logstash/api/app_helpers.rb
@@ -19,6 +19,10 @@ module LogStash::Api::AppHelpers
     end
   end
 
+  def extract_fields(filter_string)
+    (filter_string.empty? ? [] : filter_string.split(",").map { |s| s.strip.to_sym })
+  end
+
   def as_boolean(string)
     return true   if string == true   || string =~ (/(true|t|yes|y|1)$/i)
     return false  if string == false  || string.blank? || string =~ (/(false|f|no|n|0)$/i)

--- a/logstash-core/lib/logstash/api/app_helpers.rb
+++ b/logstash-core/lib/logstash/api/app_helpers.rb
@@ -5,9 +5,12 @@ module LogStash::Api::AppHelpers
 
   def respond_with(data, options={})
     as     = options.fetch(:as, :json)
+    filter = options.fetch(:filter, "")
     pretty = params.has_key?("pretty")
 
     if as == :json
+      selected_fields = extract_fields(filter.to_s.strip)
+      data.select! { |k,v| selected_fields.include?(k) } unless selected_fields.empty?
       unless options.include?(:exclude_default_metadata)
         data = default_metadata.merge(data)
       end

--- a/logstash-core/lib/logstash/api/commands/base.rb
+++ b/logstash-core/lib/logstash/api/commands/base.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 module LogStash
   module Api
     module Commands

--- a/logstash-core/lib/logstash/api/commands/default_metadata.rb
+++ b/logstash-core/lib/logstash/api/commands/default_metadata.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require "logstash/api/commands/base"
 
 module LogStash

--- a/logstash-core/lib/logstash/api/commands/hot_threads_reporter.rb
+++ b/logstash-core/lib/logstash/api/commands/hot_threads_reporter.rb
@@ -11,7 +11,7 @@ class HotThreadsReport
   end
 
   def to_s
-    hash = to_hash
+    hash = to_hash[:hot_threads]
     report =  "#{I18n.t("logstash.web_api.hot_threads.title", :hostname => hash[:hostname], :time => hash[:time], :top_count => @thread_dump.top_count )} \n"
     report << '=' * 80
     report << "\n"
@@ -47,7 +47,7 @@ class HotThreadsReport
       thread[:traces] = traces unless traces.empty?
       hash[:threads] << thread
     end
-    hash
+    { :hot_threads => hash }
   end
 
   def cpu_time_as_percent(hash)

--- a/logstash-core/lib/logstash/api/commands/hot_threads_reporter.rb
+++ b/logstash-core/lib/logstash/api/commands/hot_threads_reporter.rb
@@ -1,0 +1,61 @@
+# encoding: utf-8
+
+class HotThreadsReport
+  HOT_THREADS_STACK_TRACES_SIZE_DEFAULT = 10.freeze
+
+  def initialize(cmd, options)
+    @cmd = cmd
+    filter = { :stacktrace_size => options.fetch(:stacktrace_size, HOT_THREADS_STACK_TRACES_SIZE_DEFAULT) }
+    jr_dump = JRMonitor.threads.generate(filter)
+    @thread_dump = ::LogStash::Util::ThreadDump.new(options.merge(:dump => jr_dump))
+  end
+
+  def to_s
+    hash = to_hash
+    report =  "#{I18n.t("logstash.web_api.hot_threads.title", :hostname => hash[:hostname], :time => hash[:time], :top_count => @thread_dump.top_count )} \n"
+    report << '=' * 80
+    report << "\n"
+    hash[:threads].each do |thread|
+      thread_report = ""
+      thread_report = "#{I18n.t("logstash.web_api.
+                                hot_threads.thread_title", :percent_of_cpu_time => thread[:percent_of_cpu_time], :thread_state => thread[:state], :thread_name => thread[:name])} \n"
+      thread_report = "#{thread[:percent_of_cpu_time]} % of of cpu usage by #{thread[:state]} thread named '#{thread[:name]}'\n"
+      thread_report << "#{thread[:path]}\n" if thread[:path]
+      thread[:traces].each do |trace|
+        thread_report << "\t#{trace}\n"
+      end
+      report << thread_report
+      report << '-' * 80
+      report << "\n"
+    end
+    report
+  end
+
+  def to_hash
+    hash = { :time => Time.now.iso8601, :busiest_threads => @thread_dump.top_count, :threads => [] }
+    @thread_dump.each do |thread_name, _hash|
+      thread_name, thread_path = _hash["thread.name"].split(": ")
+      thread = { :name => thread_name,
+                 :percent_of_cpu_time => cpu_time_as_percent(_hash),
+                 :state => _hash["thread.state"]
+      }
+      thread[:path] = thread_path if thread_path
+      traces = []
+      _hash["thread.stacktrace"].each do |trace|
+        traces << trace
+      end
+      thread[:traces] = traces unless traces.empty?
+      hash[:threads] << thread
+    end
+    hash
+  end
+
+  def cpu_time_as_percent(hash)
+    (((cpu_time(hash) / @cmd.uptime * 1.0)*10000).to_i)/100.0
+  end
+
+  def cpu_time(hash)
+    hash["cpu.time"] / 1000000.0
+  end
+
+end

--- a/logstash-core/lib/logstash/api/commands/node.rb
+++ b/logstash-core/lib/logstash/api/commands/node.rb
@@ -1,10 +1,12 @@
+# encoding: utf-8
 require "logstash/api/commands/base"
+require_relative "hot_threads_reporter"
 
 module LogStash
   module Api
     module Commands
       class Node < Commands::Base
-       
+
         def all(selected_fields=[])
           payload = {
             :pipeline => pipeline,
@@ -14,7 +16,7 @@ module LogStash
           payload.select! { |k,v| selected_fields.include?(k) } unless selected_fields.empty?
           payload
         end
-        
+
         def pipeline
           extract_metrics(
             [:stats, :pipelines, :main, :config],
@@ -54,65 +56,6 @@ module LogStash
           HotThreadsReport.new(self, options)
         end
 
-        class HotThreadsReport
-          HOT_THREADS_STACK_TRACES_SIZE_DEFAULT = 10.freeze
-          
-          def initialize(cmd, options)
-            @cmd = cmd
-            filter = { :stacktrace_size => options.fetch(:stacktrace_size, HOT_THREADS_STACK_TRACES_SIZE_DEFAULT) }
-            jr_dump = JRMonitor.threads.generate(filter)
-            @thread_dump = ::LogStash::Util::ThreadDump.new(options.merge(:dump => jr_dump))
-          end
-          
-          def to_s
-            hash = to_hash[:hot_threads]
-            report =  "#{I18n.t("logstash.web_api.hot_threads.title", :hostname => hash[:hostname], :time => hash[:time], :top_count => @thread_dump.top_count )} \n"
-            report << '=' * 80
-            report << "\n"
-            hash[:threads].each do |thread|
-              thread_report = ""
-              thread_report = "#{I18n.t("logstash.web_api.
-                                hot_threads.thread_title", :percent_of_cpu_time => thread[:percent_of_cpu_time], :thread_state => thread[:state], :thread_name => thread[:name])} \n"
-              thread_report = "#{thread[:percent_of_cpu_time]} % of of cpu usage by #{thread[:state]} thread named '#{thread[:name]}'\n"
-              thread_report << "#{thread[:path]}\n" if thread[:path]
-              thread[:traces].each do |trace|
-                thread_report << "\t#{trace}\n"
-              end
-              report << thread_report
-              report << '-' * 80
-              report << "\n"
-            end
-            report
-          end
-
-          def to_hash
-            hash = { :time => Time.now.iso8601, :busiest_threads => @thread_dump.top_count, :threads => [] }
-            @thread_dump.each do |thread_name, _hash|
-              thread_name, thread_path = _hash["thread.name"].split(": ")
-              thread = { :name => thread_name,
-                         :percent_of_cpu_time => cpu_time_as_percent(_hash),
-                         :state => _hash["thread.state"]
-                       }
-              thread[:path] = thread_path if thread_path
-              traces = []
-              _hash["thread.stacktrace"].each do |trace|
-                traces << trace
-              end
-              thread[:traces] = traces unless traces.empty?
-              hash[:threads] << thread
-            end
-            { :hot_threads => hash }
-          end
-
-          def cpu_time_as_percent(hash)
-            (((cpu_time(hash) / @cmd.uptime * 1.0)*10000).to_i)/100.0
-          end
-
-          def cpu_time(hash)
-            hash["cpu.time"] / 1000000.0
-          end
-
-        end
       end
     end
   end

--- a/logstash-core/lib/logstash/api/commands/node.rb
+++ b/logstash-core/lib/logstash/api/commands/node.rb
@@ -4,12 +4,15 @@ module LogStash
   module Api
     module Commands
       class Node < Commands::Base
-        def all
-          {
+       
+        def all(selected_fields=[])
+          payload = {
             :pipeline => pipeline,
             :os => os,
             :jvm => jvm
           }
+          payload.select! { |k,v| selected_fields.include?(k) } unless selected_fields.empty?
+          payload
         end
         
         def pipeline

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -1,5 +1,7 @@
+# encoding: utf-8
 require "logstash/api/commands/base"
 require 'logstash/util/thread_dump'
+require_relative "hot_threads_reporter"
 
 module LogStash
   module Api
@@ -60,65 +62,6 @@ module LogStash
         def hot_threads(options={})
           HotThreadsReport.new(self, options)
         end
-
-        class HotThreadsReport
-          HOT_THREADS_STACK_TRACES_SIZE_DEFAULT = 10.freeze
-          
-          def initialize(cmd, options)
-            @cmd = cmd
-            filter = { :stacktrace_size => options.fetch(:stacktrace_size, HOT_THREADS_STACK_TRACES_SIZE_DEFAULT) }
-            jr_dump = JRMonitor.threads.generate(filter)
-            @thread_dump = ::LogStash::Util::ThreadDump.new(options.merge(:dump => jr_dump))
-          end
-          
-          def to_s
-            hash = to_hash
-            report =  "#{I18n.t("logstash.web_api.hot_threads.title", :hostname => hash[:hostname], :time => hash[:time], :top_count => @thread_dump.top_count )} \n"
-            report << '=' * 80
-            report << "\n"
-            hash[:threads].each do |thread|
-              thread_report = ""
-              thread_report = "#{I18n.t("logstash.web_api.
-                                hot_threads.thread_title", :percent_of_cpu_time => thread[:percent_of_cpu_time], :thread_state => thread[:state], :thread_name => thread[:name])} \n"
-              thread_report = "#{thread[:percent_of_cpu_time]} % of of cpu usage by #{thread[:state]} thread named '#{thread[:name]}'\n"
-              thread_report << "#{thread[:path]}\n" if thread[:path]
-              thread[:traces].each do |trace|
-                thread_report << "\t#{trace}\n"
-              end
-              report << thread_report
-              report << '-' * 80
-              report << "\n"
-            end
-            report
-          end
-
-          def to_hash
-            hash = { :hostname => @cmd.hostname, :time => Time.now.iso8601, :busiest_threads => @thread_dump.top_count, :threads => [] }
-            @thread_dump.each do |thread_name, _hash|
-              thread_name, thread_path = _hash["thread.name"].split(": ")
-              thread = { :name => thread_name,
-                         :percent_of_cpu_time => cpu_time_as_percent(_hash),
-                         :state => _hash["thread.state"]
-                       }
-              thread[:path] = thread_path if thread_path
-              traces = []
-              _hash["thread.stacktrace"].each do |trace|
-                traces << trace
-              end
-              thread[:traces] = traces unless traces.empty?
-              hash[:threads] << thread
-            end
-            hash
-          end
-
-          def cpu_time_as_percent(hash)
-            (((cpu_time(hash) / @cmd.uptime * 1.0)*10000).to_i)/100.0
-          end
-
-          def cpu_time(hash)
-            hash["cpu.time"] / 1000000.0
-          end
-        end # class HotThreadsReport
 
         module PluginsStats
           module_function

--- a/logstash-core/lib/logstash/api/modules/base.rb
+++ b/logstash-core/lib/logstash/api/modules/base.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "logstash/api/app_helpers"
 require "logstash/api/command_factory"
 

--- a/logstash-core/lib/logstash/api/modules/node.rb
+++ b/logstash-core/lib/logstash/api/modules/node.rb
@@ -8,23 +8,7 @@ module LogStash
         def node
           factory.build(:node)
         end
-        
-        get "/" do
-          respond_with node.all
-        end
 
-        get "/os" do
-          respond_with :os => node.os
-        end
-
-        get "/jvm" do
-          respond_with :jvm => node.jvm          
-        end
-
-        get "/pipeline" do
-          respond_with :pipeline => node.pipeline
-        end
-        
         get "/hot_threads" do
           ignore_idle_threads = params["ignore_idle_threads"] || true
 
@@ -36,7 +20,13 @@ module LogStash
 
           as = options[:human] ? :string : :json
           respond_with(node.hot_threads(options), {:as => as})
-        end       
+        end
+
+        get "/?:filter?" do
+          selected_fields = extract_fields(params["filter"].to_s.strip)
+          respond_with node.all(selected_fields)
+        end
+
       end
     end
   end

--- a/logstash-core/lib/logstash/api/modules/node_stats.rb
+++ b/logstash-core/lib/logstash/api/modules/node_stats.rb
@@ -9,15 +9,13 @@ module LogStash
         end
 
         get "/?:filter?" do
-          selected_fields = extract_fields(params["filter"].to_s.strip)
           payload = {
             :jvm => jvm_payload,
             :process => process_payload,
             :mem => mem_payload,
             :pipeline => pipeline_payload
           }
-          payload.select! { |k,v| selected_fields.include?(k) } unless selected_fields.empty?
-          respond_with payload
+          respond_with(payload, {:filter => params["filter"]})
         end
 
         private

--- a/logstash-core/lib/logstash/api/modules/node_stats.rb
+++ b/logstash-core/lib/logstash/api/modules/node_stats.rb
@@ -3,38 +3,21 @@ module LogStash
   module Api
     module Modules
       class NodeStats < ::LogStash::Api::Modules::Base
-        #set :environment, :test
-        #set :dump_errors, true
-        #set :raise_errors, true
-        #set :logging, Logger.new(STDERR)
-        
-        
+
         before do
           @stats = factory.build(:stats)
         end
 
-        # Global _stats resource where all information is
-        # retrieved and show
-        get "/" do          
+        get "/?:filter?" do
+          selected_fields = extract_fields(params["filter"].to_s.strip)
           payload = {
             :jvm => jvm_payload,
             :process => process_payload,
+            :mem => mem_payload,
             :pipeline => pipeline_payload
           }
-
+          payload.select! { |k,v| selected_fields.include?(k) } unless selected_fields.empty?
           respond_with payload
-        end
-
-        get "/jvm" do
-          respond_with :jvm => jvm_payload
-        end
-
-        get "/process" do
-          respond_with :process => process_payload
-        end
-
-        get "/pipeline" do
-          respond_with :pipeline => pipeline_payload
         end
 
         private

--- a/logstash-core/lib/logstash/api/modules/stats.rb
+++ b/logstash-core/lib/logstash/api/modules/stats.rb
@@ -8,39 +8,6 @@ module LogStash
           factory.build(:stats)
         end
 
-        # Global _stats resource where all information is 
-        # retrieved and show
-        get "/" do
-          payload = {
-            :events => stats_command.events,
-            :jvm => { :memory => stats_command.memory }
-          }
-          respond_with payload
-        end
-
-
-        # return hot threads information
-        get "/jvm" do
-          jvm_payload = {
-            :timestamp => stats_command.started_at,
-            :uptime_in_millis => stats_command.uptime,
-            :mem => stats_command.memory
-          }
-          respond_with({:jvm => jvm_payload})
-        end
-
-        # Show all events stats information
-        # (for ingested, emitted, dropped)
-        # - #events since startup
-        # - #data (bytes) since startup
-        # - events/s
-        # - bytes/s
-        # - dropped events/s
-        # - events in the pipeline
-        get "/events" do
-          respond_with({ :events => stats_command.events })
-        end
-
         # return hot threads information
         get "/jvm/hot_threads" do
           top_threads_count = params["threads"] || 3
@@ -57,6 +24,21 @@ module LogStash
         get "/jvm/memory" do
           respond_with({ :memory => stats_command.memory })
         end
+
+        get "/?:filter?" do
+          selected_fields = extract_fields(params["filter"].to_s.strip)
+          payload = {
+            :events => stats_command.events,
+            :jvm => {
+              :timestamp => stats_command.started_at,
+              :uptime_in_millis => stats_command.uptime,
+              :memory => stats_command.memory
+            }
+          }
+          payload.select! { |k,v| selected_fields.include?(k) } unless selected_fields.empty?
+          respond_with payload
+        end
+
       end
     end
   end

--- a/logstash-core/lib/logstash/api/modules/stats.rb
+++ b/logstash-core/lib/logstash/api/modules/stats.rb
@@ -26,7 +26,6 @@ module LogStash
         end
 
         get "/?:filter?" do
-          selected_fields = extract_fields(params["filter"].to_s.strip)
           payload = {
             :events => stats_command.events,
             :jvm => {
@@ -35,8 +34,7 @@ module LogStash
               :memory => stats_command.memory
             }
           }
-          payload.select! { |k,v| selected_fields.include?(k) } unless selected_fields.empty?
-          respond_with payload
+          respond_with(payload, {:filter => params["filter"]})
         end
 
       end


### PR DESCRIPTION
Hi,
  this PR provide a solution to filter the outcome of first level API responses in the webapi, in the same fashion of what ES is doing, with this changes you can now have urls like:

* `http://localhost:9600/_node/stats` that will respond with the complete hash answer

or 

* `http://localhost:9600/_node/stats/jvm,process` that will only show jvm and process information.

For sure the former  `http://localhost:9600/_node/stats/jvm` or `http://localhost:9600/_node/stats/process` are still an option.

Fixes #5609 #5629
Related to #5607  