### PR TITLE
pipeline.abort_on_error setting to abort on unexpected errors (enabled by default)

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -57,15 +57,18 @@
 #
 # pipeline.unsafe_shutdown: false
 #
-# Catch all unexpected errors in the pipeline without terminating logstash.
+# By default, logstash will immediately exit when presented with an unexcepted
+# exception. This is due to the fact that an unknown exception can have an
+# unpredictable effect on filter/output state and data flow.
+#
+# Disabling abort_on_error makes Logstash catch all unexpected errors in the
+# pipeline without terminating logstash.
 # Logstash will do all of the following: drop the erroring event,
 # log an error-level message, and continue processing. This will also increment
 # the 'errored' count in the pipeline stats API at /_node/pipeline/events.
 #
-# If set to false logstash will immediately exit with an error in these
-# conditions, which may be more safe since potentially fewer events would be dropped.
 #
-# pipeline.continue_on_error: false
+# pipeline.abort_on_error: true
 #
 #
 # ------------ Pipeline Configuration Settings --------------

--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -57,6 +57,18 @@
 #
 # pipeline.unsafe_shutdown: false
 #
+# Defaults to false. Setting this to true will catch all unexpected errors in the
+# pipeline without terminating logstash.
+# Logstash will do all of the following: drop the erroring event,
+# log an error-level message, and continue processing. This will also increment
+# the 'errored' count in the pipeline stats API at /_node/pipeline/events.
+#
+# If set to false logstash will immediately exit with an error in these
+# conditions, which may be more safe since potentially fewer events would be dropped.
+#
+# pipeline.continue_on_error: true
+#
+#
 # ------------ Pipeline Configuration Settings --------------
 #
 # Where to fetch the pipeline configuration for the main pipeline

--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -57,8 +57,7 @@
 #
 # pipeline.unsafe_shutdown: false
 #
-# Defaults to false. Setting this to true will catch all unexpected errors in the
-# pipeline without terminating logstash.
+# Catch all unexpected errors in the pipeline without terminating logstash.
 # Logstash will do all of the following: drop the erroring event,
 # log an error-level message, and continue processing. This will also increment
 # the 'errored' count in the pipeline stats API at /_node/pipeline/events.
@@ -66,7 +65,7 @@
 # If set to false logstash will immediately exit with an error in these
 # conditions, which may be more safe since potentially fewer events would be dropped.
 #
-# pipeline.continue_on_error: true
+# pipeline.continue_on_error: false
 #
 #
 # ------------ Pipeline Configuration Settings --------------

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -32,7 +32,7 @@ module LogStash
         def events
           extract_metrics(
             [:stats, :events],
-            :in, :filtered, :out
+            :in, :filtered, :out, :errored
           )
         end
 

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -21,7 +21,7 @@ module LogStash
            Setting::Numeric.new("pipeline.batch.size", 125),
            Setting::Numeric.new("pipeline.batch.delay", 5), # in milliseconds
            Setting::Boolean.new("pipeline.unsafe_shutdown", false),
-           Setting::Boolean.new("pipeline.continue_on_error", false),
+           Setting::Boolean.new("pipeline.abort_on_error", true),
                     Setting.new("path.plugins", Array, []),
             Setting::String.new("interactive", nil, false),
            Setting::Boolean.new("config.debug", false),

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -21,6 +21,7 @@ module LogStash
            Setting::Numeric.new("pipeline.batch.size", 125),
            Setting::Numeric.new("pipeline.batch.delay", 5), # in milliseconds
            Setting::Boolean.new("pipeline.unsafe_shutdown", false),
+           Setting::Boolean.new("pipeline.continue_on_error", false),
                     Setting.new("path.plugins", Array, []),
             Setting::String.new("interactive", nil, false),
            Setting::Boolean.new("config.debug", false),

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -49,7 +49,7 @@ module LogStash; class Pipeline
     @settings = settings
     @pipeline_id = @settings.get_value("pipeline.id") || self.object_id
     @reporter = LogStash::PipelineReporter.new(@logger, self)
-    @continue_on_error = LogStash::SETTINGS.get("pipeline.continue_on_error")
+    @abort_on_error = LogStash::SETTINGS.get("pipeline.abort_on_error")
 
     @inputs = nil
     @filters = nil
@@ -327,9 +327,9 @@ module LogStash; class Pipeline
     namespace_events.increment(:errored, events.size)
     namespace_pipeline.increment(:errored, events.size)
 
-    # if @continue_on_error is enabled this will be handled
+    # if @abort_on_error is disabled this exception is handled
     # and logged by the pipeline higher in the stack.
-    raise unless @continue_on_error
+    raise if @abort_on_error
 
     logger_opts = {:exception_message => e.message, :class => e.class.name}
     logger_opts[:events] = events.map(&:to_hash) if @logger.info?

--- a/logstash-core/spec/api/lib/api/node_stats_spec.rb
+++ b/logstash-core/spec/api/lib/api/node_stats_spec.rb
@@ -11,8 +11,8 @@ describe LogStash::Api::Modules::NodeStats do
 
   # DSL describing response structure
   root_structure = {
-    "jvm"=>{
-      "threads"=>{
+    "jvm"=> {
+      "threads"=> {
         "count"=>Numeric,
         "peak_count"=>Numeric
       },
@@ -45,26 +45,26 @@ describe LogStash::Api::Modules::NodeStats do
         }
       }
     },
-    "process"=>{
+    "process"=> {
       "peak_open_file_descriptors"=>Numeric,
       "max_file_descriptors"=>Numeric,
       "open_file_descriptors"=>Numeric,
-      "mem"=>{
+      "mem"=> {
         "total_virtual_in_bytes"=>Numeric
       },
-      "cpu"=>{
+      "cpu"=> {
         "total_in_millis"=>Numeric,
         "percent"=>Numeric
       }
     },
-   "pipeline" => {
-     "events" => {
+    "pipeline" => {
+      "events" => {
         "in" => Numeric,
         "filtered" => Numeric,
-        "out" => Numeric
-     } 
-    } 
+        "out" => Numeric,
+        "errored"=>Numeric
+      }
+    }
   }
-  
   test_api_and_resources(root_structure)
 end

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -131,11 +131,11 @@ describe LogStash::Pipeline do
 
     let(:pipeline) { TestPipeline.new(config, pipeline_settings_obj) }
 
-    context "when pipeline.continue_on_error is false" do
+    context "when pipeline.abort_on_error is true" do
       before(:each) do
-        pipeline_settings_obj.set("pipeline.continue_on_error", false)
+        pipeline_settings_obj.set("pipeline.abort_on_error", true)
       end
-      
+
       it "should raise an exception when filtering bad events" do
         expect do
           pipeline.filter_batch([LogStash::Event.new])
@@ -149,11 +149,11 @@ describe LogStash::Pipeline do
       end
     end
 
-    context "when pipeline.continue_on_error is true" do
+    context "when pipeline.abort_on_error is false" do
       before(:each) do
-        pipeline_settings_obj.set("pipeline.continue_on_error", true)
+        pipeline_settings_obj.set("pipeline.abort_on_error", false)
       end
-      
+
       it "should raise an exception when filtering bad events" do
         expect do
           pipeline.filter_batch([LogStash::Event.new])

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -100,6 +100,90 @@ describe LogStash::Pipeline do
     pipeline_settings_obj.reset
   end
 
+  describe "rescuing pipeline exceptions" do
+    before(:each) do
+      allow(LogStash::Plugin).to receive(:lookup).with("input", "dummyinput").and_return(DummyInput)
+      allow(LogStash::Plugin).to receive(:lookup).with("codec", "plain").and_return(DummyCodec)
+      allow(LogStash::Plugin).to receive(:lookup).with("output", "dummyoutput").and_return(DummyOutput)
+      allow(LogStash::Plugin).to receive(:lookup).with("filter", "dummyfilter").and_return(DummyFilter)
+      allow(LogStash::Plugin).to receive(:lookup).with("filter", "dummysafefilter").and_return(DummySafeFilter)
+    end
+
+    let(:config) do
+      <<-eos
+        input {
+          dummyinput {}
+        }
+
+        filter {
+          if [foo] > 2 { # Intentionally omit nil check
+            dummyfilter {}
+          }
+        }
+
+        output {
+          if [foo] > 2 {
+             dummyoutput {}
+          }
+        }
+        eos
+    end
+
+    let(:pipeline) { TestPipeline.new(config, pipeline_settings_obj) }
+
+    context "when pipeline.continue_on_error is false" do
+      before(:each) do
+        pipeline_settings_obj.set("pipeline.continue_on_error", false)
+      end
+      
+      it "should raise an exception when filtering bad events" do
+        expect do
+          pipeline.filter_batch([LogStash::Event.new])
+        end.to raise_error(NoMethodError)
+      end
+
+      it "should raise an exception when outputting bad events" do
+        expect do
+          pipeline.output_batch([LogStash::Event.new])
+        end.to raise_error(NoMethodError)
+      end
+    end
+
+    context "when pipeline.continue_on_error is true" do
+      before(:each) do
+        pipeline_settings_obj.set("pipeline.continue_on_error", true)
+      end
+      
+      it "should raise an exception when filtering bad events" do
+        expect do
+          pipeline.filter_batch([LogStash::Event.new])
+        end.not_to raise_error
+      end
+
+      it "should raise an exception when outputting bad events" do
+        expect do
+          pipeline.output_batch([LogStash::Event.new])
+        end.not_to raise_error
+      end
+
+      describe "metrics" do
+        before(:each) do
+          allow(pipeline.namespace_events).to receive(:increment).with(any_args)
+          allow(pipeline.namespace_pipeline).to receive(:increment).with(any_args)
+          pipeline.output_batch([LogStash::Event.new])
+        end
+        
+        it "should increment the global errored count for metrics" do
+          expect(pipeline.namespace_events).to have_received(:increment).with(:errored, 1)
+        end
+
+        it "should increment the pipeline specific errored count for metrics" do
+          expect(pipeline.namespace_pipeline).to have_received(:increment).with(:errored, 1)
+        end
+      end
+    end
+  end
+
   describe "defaulting the pipeline workers based on thread safety" do
     before(:each) do
       allow(LogStash::Plugin).to receive(:lookup).with("input", "dummyinput").and_return(DummyInput)


### PR DESCRIPTION
This will rescue any plugin or pipeline config lang errors. This setting is only settable in the YAML.

Fixes #5547 and #1637 

a continuation/replacement of  https://github.com/elastic/logstash/pull/5562