### PR TITLE
Add bin/rspec and bin/rspec.bat to the packaging exclude list

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -46,6 +46,8 @@ namespace "artifact" do
     @exclude_paths << "**/test/files/slow-xpath.xml"
     @exclude_paths << "**/logstash-*/spec"
     @exclude_paths << "bin/bundle"
+    @exclude_paths << "bin/rspec"
+    @exclude_paths << "bin/rspec.bat"
 
     @exclude_paths
   end


### PR DESCRIPTION
To test this PR is necessary to build a package and see this files are not there anymore. Reasoning why this should be removed can be found at #5666.

Fixes #5666