### PR TITLE
Add namespaced metrics for inputs

### DIFF
--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -438,7 +438,9 @@ module LogStash; class Pipeline
       LogStash::FilterDelegator.new(@logger, klass, pipeline_scoped_metric.namespace(:filters), *args)
     else
       new_plugin = klass.new(*args)
-      new_plugin.metric = pipeline_scoped_metric.namespace(:inputs)
+      inputs_metric = pipeline_scoped_metric.namespace(:inputs)
+      namespaced_metric = inputs_metric.namespace(new_plugin.plugin_unique_name.to_sym)
+      new_plugin.metric = namespaced_metric
       new_plugin
     end
   end


### PR DESCRIPTION
Inputs were not namespaced properly for the metrics, api, this PR fixes this so each inputs is namespaces like

<img width="507" alt="screen shot 2016-07-20 at 16 54 33" src="https://cloud.githubusercontent.com/assets/68540/16991072/aa6c8e48-4e9a-11e6-80a6-ab60a918403e.png">

being consistent with filters and outputs.

@ph @andrewvc your thoughts here are very welcome.