### PR TITLE
[WIP] add simulate flag to replace all inputs and outputs with stdin/stdout

### DIFF
--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -24,6 +24,7 @@ module LogStash
                     Setting.new("path.plugins", Array, []),
             Setting::String.new("interactive", nil, false),
            Setting::Boolean.new("config.debug", false),
+           Setting::Boolean.new("config.simulate", false),
             Setting::String.new("log.level", "warn", true, ["quiet", "verbose", "warn", "debug"]),
            Setting::Boolean.new("version", false),
            Setting::Boolean.new("help", false),

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -132,6 +132,11 @@ class LogStash::Runner < Clamp::StrictCommand
     :attribute_name => "path.settings",
     :default => LogStash::SETTINGS.get_default("path.settings")
 
+  option ["--config.simulate"], :flag,
+    I18n.t("logstash.runner.flag.config_simulate"),
+    :attribute_name => "config.simulate",
+    :default => LogStash::SETTINGS.get_default("config.simulate")
+
   attr_reader :agent
 
   def initialize(*args)


### PR DESCRIPTION
Sometimes it would be nice to leave an existing config the same, but just to test the pipeline filter behavior. Right now we comment out certain inputs and outputs and replace them with stdin/stdout sometimes to gain insight into the effects of the pipeline on the input. It would be nice to just replace all inputs and outputs with stdin/stdout so we can test pipeline control flow and such without touching the existing pipeline configuration.