### PR TITLE
Doc: fix quoting in shell source.

### DIFF
--- a/docs/static/upgrading.asciidoc
+++ b/docs/static/upgrading.asciidoc
@@ -76,7 +76,7 @@ you will get an error. Make sure to explicitly set the number of filter workers 
 of workers by passing a command line flag such as:
 
 [source,shell]
-bin/logstash `-w 1`
+bin/logstash -w 1
 
 [[upgrading-logstash-2.2]]
 === Upgrading Logstash to 2.2


### PR DESCRIPTION
Logstash can be invoked this way: "bin/logstash -w 1", so the example should be made to look like that.