### PR TITLE
Doc: Rename "Event Dependent Configuration" Chapter.

### DIFF
--- a/docs/static/configuration.asciidoc
+++ b/docs/static/configuration.asciidoc
@@ -278,7 +278,7 @@ input { # comments can appear at the end of a line, too
 ----------------------------------
 
 [[event-dependent-configuration]]
-=== Event Dependent Configuration
+=== Accessing Event Data and Fields
 
 The logstash agent is a processing pipeline with 3 stages: inputs -> filters ->
 outputs. Inputs generate events, filters modify them, outputs ship them


### PR DESCRIPTION
The current chapter title does not reflect the contents so it's hard to find it again later on when you're looking for info about accessing fields.
