### PR TITLE
Fix an issue with the logstash-plugin list acceptance test

### DIFF
--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/list.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/list.rb
@@ -27,7 +27,7 @@ shared_examples "logstash list" do |logstash|
       it "list the plugins with their versions" do
         result = logstash.run_command_in_path("bin/logstash-plugin list --verbose")
         result.stdout.split("\n").each do |plugin|
-          expect(plugin).to match(/^logstash-\w+-\w+\s\(\d+\.\d+.\d+\)/)
+          expect(plugin).to match(/^logstash-\w+-\w+\s\(\d+\.\d+.\d+(.\w+)?\)/)
         end
       end
     end


### PR DESCRIPTION
The previous regexp used to match the version did not take into
consideration pre-release version.

Will fix this specific error:

```
  4) CLI operation behaves like logstash list logstash-plugin list on oel-7 without a specific plugin list the plugins with their versions
     Failure/Error: expect(plugin).to match(/^logstash-\w+-\w+\s\(\d+\.\d+.\d+\)/)
       expected "logstash-input-beats (3.1.0.beta3)" to match /^logstash-\w+-\w+\s\(\d+\.\d+.\d+\)/
       Diff:
       @@ -1,2 +1,2 @@
       -/^logstash-\w+-\w+\s\(\d+\.\d+.\d+\)/
       +"logstash-input-beats (3.1.0.beta3)"
     Shared Example Group: "logstash list" called from /var/lib/jenkins/workspace/elastic+logstash+5.0+multijob-acceptance/label/metal/suite/redhat/qa/acceptance/spec/lib/cli_operation_spec.rb:17
     # /var/lib/jenkins/workspace/elastic+logstash+5.0+multijob-acceptance/label/metal/suite/redhat/qa/acceptance/spec/shared_examples/cli/logstash-plugin/list.rb:30:in `(root)'
     # /var/lib/jenkins/workspace/elastic+logstash+5.0+multijob-acceptance/label/metal/suite/redhat/qa/acceptance/spec/shared_examples/cli/logstash-plugin/list.rb:29:in `(root)'
     # /var/lib/jenkins/workspace/elastic+logstash+5.0+multijob-acceptance/label/metal/suite/redhat/qa/Rakefile:64:in `(root)'
```