### PR TITLE
Reorder keys for better integrations.

### DIFF
--- a/logstash-core-event/lib/logstash/event.rb
+++ b/logstash-core-event/lib/logstash/event.rb
@@ -69,8 +69,8 @@ class LogStash::Event
 
   def initialize(data = {})
     @cancelled = false
-    @data = data
-    @accessors = LogStash::Util::Accessors.new(data)
+    @data = {TIMESTAMP => nil, VERSION => nil}.merge!(data)
+    @accessors = LogStash::Util::Accessors.new(@data)
     @data[VERSION] ||= VERSION_ONE
     ts = @data[TIMESTAMP]
     @data[TIMESTAMP] = ts ? init_timestamp(ts) : LogStash::Timestamp.now


### PR DESCRIPTION
In the current method, it'd be helpful to have the @vars (@timestamp, @version) be ordered ahead of the other keys. This fixes that.

I know it's a slight performance hit, but it allows for tools that heavily use the logstash text formats to pickup these key vars first.