### PR TITLE
improve doc on settings file by describing options

### DIFF
--- a/docs/static/command-line-flags.asciidoc
+++ b/docs/static/command-line-flags.asciidoc
@@ -3,61 +3,68 @@
 
 Logstash has the following flags. You can use the `--help` flag to display this information.
 
-You can also control Logstash execution by specifying options in the Logstash settings file. For more info, see <<logstash-settings-file>>.  
+Instead of specifying options at the command line, we recommend that you control Logstash execution
+by specifying options in the Logstash <<logstash-settings-file,settings file>>. Using a settings file
+makes it easier for you to specify mutliple options, and it provides you with a single, versionable
+file that you can use to start up Logstash consistently for each run. 
+
+Any flags that you set at the command line override the corresponding settings in the Logstash
+<<logstash-settings-file,settings file>>. 
 
 added[5.0.0-alpha3, Command-line flags have dots instead of dashes in their names]
 
 *`-f, --path.config CONFIGFILE`*::
- Load the Logstash config from a specific file or directory, or a wildcard. If
- given a directory or wildcard, config files will be read from the directory in
+ Load the Logstash config from a specific file or directory. If
+ you specify a directory or wildcard, config files are read from the directory in
  alphabetical order.
 
 *`-e, --config.string CONFIGSTRING`*::
- Use the given string as the configuration data. Same syntax as the config file.
- If no input is specified, `stdin { type => stdin }` is default. If no output
- is specified, `stdout { codec => rubydebug }}` is default.
+ Use the given string as the configuration data. Use the same syntax as the config file.
+ If no input is specified, `stdin { type => stdin }` is used by default. If no output
+ is specified, `stdout { codec => rubydebug }}` is used by default.
 
 *`-w, --pipeline.workers COUNT`*::
- Sets the number of pipeline workers (threads) to run for filter processing (default: number of cores).
- If you find that events are backing up, or that the CPU is not saturated, consider increasing
- this number to better utilize machine processing power.
+ Set the number of workers that will, in parallel, execute the filter and output stages of the pipeline.  
+ This defaults to the number of the host's CPU cores. If you find that events are backing up, or that
+ the CPU is not saturated, consider increasing this number to better utilize machine processing power.
  
 *`-b, --pipeline.batch.size SIZE`*::
- This parameter defines the maximum number of events an individual worker thread will collect
- before attempting to execute its filters and outputs. Default is 125 events.
+ Define the maximum number of events an individual worker thread will collect from inputs
+ before attempting to execute its filters and outputs. The default is 125 events.
  Larger batch sizes are generally more efficient, but come at the cost of increased memory
  overhead. You may have to increase the JVM heap size by setting the `LS_HEAP_SIZE`
  variable to effectively use the option.
 
 *`-u, --pipeline.batch.delay DELAY_IN_MS`*::
- When creating pipeline event batches, how long to wait while polling for the next event.
- Default is 5ms.
+ When creating pipeline event batches, how long in milliseconds to wait before dispatching an undersized
+  batch to filters and workers.
+ The default is 5ms.
 
 *`-l, --path.log FILE`*::
- Log to a given path. Default is to log to stdout
+ Log to a given file. The default is to log to stdout
 
 *`--log.level`*::
- Set the log level to "quiet", "verbose", "warn" (default), or "debug".
+ Set the log level to "warn" (default), "quiet", "verbose", or "debug".
 
 *`--log.format FORMAT`*::
  Set to "json" to log in JSON format, or "plain" (default) to use `Object#.inspect`.
  
 *`--path.settings SETTINGS_DIR`*::
- Directory containing the `logstash.yml` <<logstash-settings-file,settings file>>.
+ Set the directory containing the `logstash.yml` <<logstash-settings-file,settings file>>.
  
 *`--node.name NAME`*::
- Set a descriptive name for the node. If no value is specified, defaults to the current hostname. 
+ Set a descriptive name for the node. If no value is specified, defaults to the machine's hostname. 
 
 *`--config.debug`*::
- Print the compiled config ruby code out as a debug log (you must also have `--log.level=debug` enabled).
- WARNING: This will include any 'password' options passed to plugin configs as plaintext, and may result
+ Show the fully compiled configuration as a debug log message (you must also have `--log.level=debug` enabled).
+ WARNING: The log message will include any 'password' options passed to plugin configs as plaintext, and may result
  in plaintext passwords appearing in your logs!
 
 *`-V, --version`*::
   Display the version of Logstash.
 
 *`-p, --path.plugins`*::
-  A path of where to find plugins. This flag can be given multiple times to include
+  Where to find custom plugins. This flag can be given multiple times to include
   multiple paths. Plugins are expected to be in a specific directory hierarchy:
   `PATH/logstash/TYPE/NAME.rb` where `TYPE` is `inputs`, `filters`, `outputs`, or `codecs`,
   and `NAME` is the name of the plugin.
@@ -70,21 +77,21 @@ added[5.0.0-alpha3, Command-line flags have dots instead of dashes in their name
   each config block with the source file it came from.
   
 *`-r, --config.reload.automatic`*::
-  Monitor configuration changes and reload the configuration whenever it is changed.
+  Periodically check if the configuration has changed and reload the configuration whenever it is changed.
 
 *`--config.reload.interval RELOAD_INTERVAL`*::
-  Specifies how often Logstash checks the config files for changes. The default is every 3 seconds.
+  Set how often in seconds Logstash checks the config files for changes. The default is every 3 seconds.
 
 *`--http.host HTTP_HOST`*::
-  Web API binding host (default: "127.0.0.1")
+  The bind address for the metrics REST endpoint. The default is "127.0.0.1".
 
 *`--http.port HTTP_PORT`*::
-  Web API http port (default: 9600)
+  The bind port for the metrics REST endpoint. The default is 9600.
 
 *`--pipeline.unsafe_shutdown`*::
   Force Logstash to exit during shutdown even if there are still inflight events
   in memory. By default, Logstash will refuse to quit until all received events
-  have been pushed to the outputs.
+  have been pushed to the outputs. Enabling this option can lead to data loss during shutdown.
 
 *`-h, --help`*::
   Print help

--- a/docs/static/command-line-flags.asciidoc
+++ b/docs/static/command-line-flags.asciidoc
@@ -43,8 +43,12 @@ added[5.0.0-alpha3, Command-line flags have dots instead of dashes in their name
 *`-l, --path.log FILE`*::
  Log to a given file. The default is to log to stdout
 
-*`--log.level`*::
- Set the log level to "warn" (default), "quiet", "verbose", or "debug".
+*`--log.level LEVEL`*::
+ Valid levels are:
+* `warn`: log warnings
+* `quiet`: log errors
+* `verbose`: log verbose info (for users)
+* `debug`: log debugging info (for developers)
 
 *`--log.format FORMAT`*::
  Set to "json" to log in JSON format, or "plain" (default) to use `Object#.inspect`.

--- a/docs/static/setting-up-logstash.asciidoc
+++ b/docs/static/setting-up-logstash.asciidoc
@@ -48,11 +48,6 @@ config and the logs directories so that you do not delete important data later o
   | `{extract.path}/config`
   | `path.settings`
 
-| logs
-  | Log files
-  | `{extract.path}/logs`
-  | `path.logs`
-
 | plugins
   | Local, non Ruby-Gem plugin files. Each plugin is contained in a subdirectory. Recommended for development only.
   | `{extract.path}/plugins`

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -31,80 +31,112 @@ pipeline.batch.delay: 5
 
 The `logstash.yml` file includes the following settings:
 
- *`node.name`*::
-  A descriptive name for the node. If no value is specified, the default is the machine's hostname.
- 
- *`path.data`*::
-  The directory that Logstash and its plugins use for any persistent needs. The default is `LOGSTASH_HOME/data`.
- 
- *`pipeline.workers`*::
-  The number of workers that will, in parallel, execute the filter and output stages of the pipeline. 
-  This defaults to the number of the host's CPU cores. If you find that events are backing up, or that the
+[options="header"]
+|=======================================================================
+| Setting | Description | Default value
+
+| `node.name`
+| A descriptive name for the node.
+| Machine's hostname
+
+| `path.data`
+| The directory that Logstash and its plugins use for any persistent needs.
+|`LOGSTASH_HOME/data`
+
+| `pipeline.workers`
+| The number of workers that will, in parallel, execute the filter and output stages of the pipeline. 
+  If you find that events are backing up, or that the
   CPU is not saturated, consider increasing this number to better utilize machine processing power.
- 
- *`pipeline.output.workers`*::
-  The number of workers to use per output plugin instance.
- 
- *`pipeline.batch.size`*::
-  The maximum number of events an individual worker thread will collect from inputs
-  before attempting to execute its filters and outputs. The default is 125 events.
+| Number of the host's CPU cores
+
+| `pipeline.output.workers`
+| The number of workers to use per output plugin instance.
+| `1`
+
+| `pipeline.batch.size`
+| The maximum number of events an individual worker thread will collect from inputs
+  before attempting to execute its filters and outputs. 
   Larger batch sizes are generally more efficient, but come at the cost of increased memory
   overhead. You may have to increase the JVM heap size by setting the `LS_HEAP_SIZE`
   variable to effectively use the option.
+| `125`
  
- *`pipeline.batch.delay`*::
-  When creating pipeline event batches, how long in milliseconds to wait before dispatching an undersized
-  batch to filters and workers. The default is 5ms.
+| `pipeline.batch.delay`
+| When creating pipeline event batches, how long in milliseconds to wait before dispatching an undersized
+  batch to filters and workers.
+| `5`
  
- *`pipeline.unsafe_shutdown`*::
-  When set to true, forces Logstash to exit during shutdown even if there are still inflight events
+| `pipeline.unsafe_shutdown`
+| When set to `true`, forces Logstash to exit during shutdown even if there are still inflight events
   in memory. By default, Logstash will refuse to quit until all received events
   have been pushed to the outputs. Enabling this option can lead to data loss during shutdown.
+| `false`
   
- *`path.config`*::
-  The path to the Logstash config for the main pipeline. If you specify a directory or wildcard,
+| `path.config`
+| The path to the Logstash config for the main pipeline. If you specify a directory or wildcard,
   config files are read from the directory in alphabetical order.
+| Platform-specific. See <<dir-layout>>.
+
+| `config.string`
+| A string that contains the pipeline configuration to use for the main pipeline. Use the same syntax as
+  the config file.
+| None
  
- *`config.string`*::
-  A string that contains the pipeline configuration to use for the main pipeline. Use the same syntax as
-  the config file. 
- 
- *`config.test_and_exit`*::
-  When set to true, checks that the configuration is valid and then exits. Note that grok patterns are not checked for
+| `config.test_and_exit`
+| When set to `true`, checks that the configuration is valid and then exits. Note that grok patterns are not checked for
   correctness with this setting. Logstash can read multiple config files from a directory. If you combine this
   setting with `log.level: debug`, Logstash will log the combined config file, annotating
   each config block with the source file it came from.
+| `false`
   
- *`config.reload.automatic`*::
-  When set to true, periodically checks if the configuration has changed and reloads the configuration whenever it is changed. 
-  This can also be triggered manually through the SIGHUP signal. 
+| `config.reload.automatic`
+| When set to `true`, periodically checks if the configuration has changed and reloads the configuration whenever it is changed. 
+  This can also be triggered manually through the SIGHUP signal.
+| `false`
   
-*`config.reload.interval`*::
-  How often in seconds Logstash checks the config files for changes. The default is every 3 seconds.
+| `config.reload.interval`
+| How often in seconds Logstash checks the config files for changes.
+| `3`
 
-*`config.debug`*::
-  When set to true, shows the fully compiled configuration as a debug log message. You must also set `log.level: debug`.
+| `config.debug`
+| When set to `true`, shows the fully compiled configuration as a debug log message. You must also set `log.level: debug`.
   WARNING: The log message will include any 'password' options passed to plugin configs as plaintext, and may result
-  in plaintext passwords appearing in your logs! 
+  in plaintext passwords appearing in your logs!
+| `false`
  
-*`http.host`*::
-  The bind address for the metrics REST endpoint. The default is "127.0.0.1".
+| `http.host`
+| The bind address for the metrics REST endpoint.
+| `"127.0.0.1"`
 
-*`http.port`*::
-  The bind port for the metrics REST endpoint. The default is 9600.
+| `http.port`
+| The bind port for the metrics REST endpoint. 
+| `9600`
   
-*`log.level`*::
-  The log level. Valid options are `warn` (default), `quiet`, `verbose`, or `debug`.
- 
-*`log.format`*::
-  The log format. Set to `json` to log in JSON format, or `plain` (default) to use `Object#.inspect`.
+| `log.level`
+a|
+The log level. Valid options are:
 
-*`path.log`*::
-  The file to log to. The default is to log to stdout.
+* `warn`: log warnings
+* `quiet`: log errors
+* `verbose`: log verbose info (for users)
+* `debug`: log debugging info (for developers)
+
+| `warn`
  
-*`path.plugins`*::
-  Where to find custom plugins. You can specify this setting multiple times to include
+| `log.format`
+| The log format. Set to `json` to log in JSON format, or `plain` to use `Object#.inspect`.
+| `plain`
+
+| `path.log`
+| The file to log to.
+| Logs to stdout
+ 
+| `path.plugins`
+| Where to find custom plugins. You can specify this setting multiple times to include
   multiple paths. Plugins are expected to be in a specific directory hierarchy:
   `PATH/logstash/TYPE/NAME.rb` where `TYPE` is `inputs`, `filters`, `outputs`, or `codecs`,
   and `NAME` is the name of the plugin.
+| Platform-specific. See <<dir-layout>>.
+  
+|=======================================================================
 

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -3,10 +3,11 @@
 
 added[5.0.0-alpha3]
 
-You can set options in the Logstash settings file, `logstash.yml`, to control Logstash execution. Each setting in the
-`logstash.yml` file corresponds to a <<command-line-flags,command-line flag>>. 
-
-Any flags that you set at the command line override the corresponding settings in the `logstash.yml` file. 
+You can set options in the Logstash settings file, `logstash.yml`, to control Logstash execution. For example,
+you can specify pipeline settings, the location of configuration files, logging options, and other settings.
+Most of the settings in the `logstash.yml` file are also available as <<command-line-flags,command-line flags>>
+when you run Logstash. Any flags that you set at the command line override the corresponding settings in the
+`logstash.yml` file. 
 
 The `logstash.yml` file, which is written in http://http://yaml.org/[YAML], is located in `LOGSTASH_HOME/config`. You can
 specify settings in hierarchical form or use flat keys. For example, to use hierarchical form to set the pipeline batch
@@ -28,4 +29,82 @@ pipeline.batch.size: 125
 pipeline.batch.delay: 5
 -------------------------------------------------------------------------------------
 
-See <<command-line-flags>> for a description of the available options.
+The `logstash.yml` file includes the following settings:
+
+ *`node.name`*::
+  A descriptive name for the node. If no value is specified, the default is the machine's hostname.
+ 
+ *`path.data`*::
+  The directory that Logstash and its plugins use for any persistent needs. The default is `LOGSTASH_HOME/data`.
+ 
+ *`pipeline.workers`*::
+  The number of workers that will, in parallel, execute the filter and output stages of the pipeline. 
+  This defaults to the number of the host's CPU cores. If you find that events are backing up, or that the
+  CPU is not saturated, consider increasing this number to better utilize machine processing power.
+ 
+ *`pipeline.output.workers`*::
+  The number of workers to use per output plugin instance.
+ 
+ *`pipeline.batch.size`*::
+  The maximum number of events an individual worker thread will collect from inputs
+  before attempting to execute its filters and outputs. The default is 125 events.
+  Larger batch sizes are generally more efficient, but come at the cost of increased memory
+  overhead. You may have to increase the JVM heap size by setting the `LS_HEAP_SIZE`
+  variable to effectively use the option.
+ 
+ *`pipeline.batch.delay`*::
+  When creating pipeline event batches, how long in milliseconds to wait before dispatching an undersized
+  batch to filters and workers. The default is 5ms.
+ 
+ *`pipeline.unsafe_shutdown`*::
+  When set to true, forces Logstash to exit during shutdown even if there are still inflight events
+  in memory. By default, Logstash will refuse to quit until all received events
+  have been pushed to the outputs. Enabling this option can lead to data loss during shutdown.
+  
+ *`path.config`*::
+  The path to the Logstash config for the main pipeline. If you specify a directory or wildcard,
+  config files are read from the directory in alphabetical order.
+ 
+ *`config.string`*::
+  A string that contains the pipeline configuration to use for the main pipeline. Use the same syntax as
+  the config file. 
+ 
+ *`config.test_and_exit`*::
+  When set to true, checks that the configuration is valid and then exits. Note that grok patterns are not checked for
+  correctness with this setting. Logstash can read multiple config files from a directory. If you combine this
+  setting with `log.level: debug`, Logstash will log the combined config file, annotating
+  each config block with the source file it came from.
+  
+ *`config.reload.automatic`*::
+  When set to true, periodically checks if the configuration has changed and reloads the configuration whenever it is changed. 
+  This can also be triggered manually through the SIGHUP signal. 
+  
+*`config.reload.interval`*::
+  How often in seconds Logstash checks the config files for changes. The default is every 3 seconds.
+
+*`config.debug`*::
+  When set to true, shows the fully compiled configuration as a debug log message. You must also set `log.level: debug`.
+  WARNING: The log message will include any 'password' options passed to plugin configs as plaintext, and may result
+  in plaintext passwords appearing in your logs! 
+ 
+*`http.host`*::
+  The bind address for the metrics REST endpoint. The default is "127.0.0.1".
+
+*`http.port`*::
+  The bind port for the metrics REST endpoint. The default is 9600.
+  
+*`log.level`*::
+  The log level. Valid options are `warn` (default), `quiet`, `verbose`, or `debug`.
+ 
+*`log.format`*::
+  The log format. Set to `json` to log in JSON format, or `plain` (default) to use `Object#.inspect`.
+
+*`path.log`*::
+  The file to log to. The default is to log to stdout.
+ 
+*`path.plugins`*::
+  Where to find custom plugins. You can specify this setting multiple times to include
+  multiple paths. Plugins are expected to be in a specific directory hierarchy:
+  `PATH/logstash/TYPE/NAME.rb` where `TYPE` is `inputs`, `filters`, `outputs`, or `codecs`,
+  and `NAME` is the name of the plugin.
+


### PR DESCRIPTION
This PR addresses the request in issue #5148 to improve the settings file.

I Frankensteined the descriptions of the CLI options and the comments from the logstash.yml file to come up with descriptions for the doc. I also edited the CLI doc (lightly) to make it more consistent with the descriptions I added for the settings file. I don't like (essentially) duplicating content, but reuse isn't really feasible due to the differences in how the values are specified in the YAML vs from the command line as flags. 
