### PR TITLE
correct description of pipeline.batch.delay from seconds to ms

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -45,7 +45,7 @@
 # pipeline.batch.size: 125
 #
 # How long to wait before dispatching an undersized batch to filters+workers
-# Value is in seconds.
+# Value is in milliseconds.
 #
 # pipeline.batch.delay: 5
 #


### PR DESCRIPTION
Confirmed with @ph that the description here is incorrect.