### PR TITLE
Fix the require_jar warning about jackson jars

### DIFF
--- a/logstash-core-event-java/build.gradle
+++ b/logstash-core-event-java/build.gradle
@@ -92,8 +92,8 @@ idea {
 }
 
 dependencies {
-    compile 'com.fasterxml.jackson.core:jackson-core:2.7.1'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.7.1-1'
+    compile 'com.fasterxml.jackson.core:jackson-core:2.7.3'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.7.3'
     provided 'org.jruby:jruby-core:1.7.25'
     testCompile 'junit:junit:4.12'
     testCompile 'net.javacrumbs.json-unit:json-unit:1.9.0'

--- a/logstash-core-event-java/lib/logstash-core-event-java_jars.rb
+++ b/logstash-core-event-java/lib/logstash-core-event-java_jars.rb
@@ -2,13 +2,13 @@
 begin
   require 'jar_dependencies'
 rescue LoadError
-  require 'com/fasterxml/jackson/core/jackson-core/2.7.1/jackson-core-2.7.1.jar'
-  require 'com/fasterxml/jackson/core/jackson-annotations/2.7.0/jackson-annotations-2.7.0.jar'
-  require 'com/fasterxml/jackson/core/jackson-databind/2.7.1-1/jackson-databind-2.7.1-1.jar'
+  require 'com/fasterxml/jackson/core/jackson-databind/2.7.3/jackson-databind-2.7.3.jar'
+  require 'com/fasterxml/jackson/core/jackson-annotations/2.7.3/jackson-annotations-2.7.3.jar'
+  require 'com/fasterxml/jackson/core/jackson-core/2.7.3/jackson-core-2.7.3.jar'
 end
 
 if defined? Jars
-  require_jar( 'com.fasterxml.jackson.core', 'jackson-core', '2.7.1' )
-  require_jar( 'com.fasterxml.jackson.core', 'jackson-annotations', '2.7.0' )
-  require_jar( 'com.fasterxml.jackson.core', 'jackson-databind', '2.7.1-1' )
+  require_jar( 'com.fasterxml.jackson.core', 'jackson-databind', '2.7.3' )
+  require_jar( 'com.fasterxml.jackson.core', 'jackson-annotations', '2.7.3' )
+  require_jar( 'com.fasterxml.jackson.core', 'jackson-core', '2.7.3' )
 end

--- a/logstash-core-event-java/logstash-core-event-java.gemspec
+++ b/logstash-core-event-java/logstash-core-event-java.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |gem|
   # which does not have this problem.
   gem.add_runtime_dependency "ruby-maven", "~> 3.3.9"
 
-  gem.requirements << "jar com.fasterxml.jackson.core:jackson-core, 2.7.1"
-  gem.requirements << "jar com.fasterxml.jackson.core:jackson-databind, 2.7.1-1"
+  gem.requirements << "jar com.fasterxml.jackson.core:jackson-core, 2.7.3"
+  gem.requirements << "jar com.fasterxml.jackson.core:jackson-databind, 2.7.3"
 end

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |gem|
 
   if RUBY_PLATFORM == 'java'
     gem.platform = RUBY_PLATFORM
-    gem.add_runtime_dependency "jrjackson", "~> 0.3.7" #(Apache 2.0 license)
+    gem.add_runtime_dependency "jrjackson", "~> 0.4.0" #(Apache 2.0 license)
   else
     gem.add_runtime_dependency "oj" #(MIT-style license)
   end


### PR DESCRIPTION
jrjackson was using 2.7.3 whereas core was using 2.7.0. Upgraded jrjackson
to 0.4.0 and core libs to match jars in jrjackson

Fixes #5159


```
suyog@machine:~/ws/elastic/logstash (fix/5159)$ bin/logstash -e 'input { generator { "message" => "this is a bats test for -e" count => 1 }} output { stdout {} }'
Pipeline main started
2016-08-10T00:48:46.085Z Suyogs-MBP-2 this is a bats test for -e
Pipeline main has been shutdown
```