### PR TITLE
remove duplicate config_loader creation when -t is enabled

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -182,8 +182,7 @@ class LogStash::Agent < Clamp::Command
     end
 
     if config_test?
-      config_loader = LogStash::Config::Loader.new(@logger)
-      config_str = config_loader.format_config(config_path, config_string)
+      config_str = @config_loader.format_config(config_path, config_string)
       begin
         # currently the best strategy to validate the configuration
         # is creating a pipeline instance and checking for exceptions

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -299,9 +299,9 @@ describe LogStash::Agent do
 
   describe "--config-test" do
     let(:cli_args) { ["-t", "-e", pipeline_string] }
+    let(:pipeline_string) { "input { } filter { } output { }" }
 
     context "with a good configuration" do
-      let(:pipeline_string) { "input { } filter { } output { }" }
       it "should exit successfuly" do
         expect(subject.run(cli_args)).to eq(0)
       end
@@ -312,6 +312,11 @@ describe LogStash::Agent do
       it "should fail by returning a bad exit code" do
         expect(subject.run(cli_args)).to eq(1)
       end
+    end
+
+    it "requests the config loader to format_config" do
+      expect(subject.config_loader).to receive(:format_config)
+      subject.run(cli_args)
     end
   end
 


### PR DESCRIPTION
fixes https://github.com/elastic/logstash/issues/5764