### PR TITLE
API: Hot Thread Human format fixes

### DIFF
--- a/logstash-core/lib/logstash/api/commands/hot_threads_reporter.rb
+++ b/logstash-core/lib/logstash/api/commands/hot_threads_reporter.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 class HotThreadsReport
+  STRING_SEPARATOR_LENGHT = 80.freeze
   HOT_THREADS_STACK_TRACES_SIZE_DEFAULT = 10.freeze
 
   def initialize(cmd, options)
@@ -13,19 +14,16 @@ class HotThreadsReport
   def to_s
     hash = to_hash[:hot_threads]
     report =  "#{I18n.t("logstash.web_api.hot_threads.title", :hostname => hash[:hostname], :time => hash[:time], :top_count => @thread_dump.top_count )} \n"
-    report << '=' * 80
+    report << '=' * STRING_SEPARATOR_LENGHT
     report << "\n"
     hash[:threads].each do |thread|
-      thread_report = ""
-      thread_report = "#{I18n.t("logstash.web_api.
-                                hot_threads.thread_title", :percent_of_cpu_time => thread[:percent_of_cpu_time], :thread_state => thread[:state], :thread_name => thread[:name])} \n"
-      thread_report = "#{thread[:percent_of_cpu_time]} % of of cpu usage by #{thread[:state]} thread named '#{thread[:name]}'\n"
+      thread_report = "#{I18n.t("logstash.web_api.hot_threads.thread_title", :percent_of_cpu_time => thread[:percent_of_cpu_time], :thread_state => thread[:state], :thread_name => thread[:name])} \n"
       thread_report << "#{thread[:path]}\n" if thread[:path]
       thread[:traces].each do |trace|
         thread_report << "\t#{trace}\n"
       end
       report << thread_report
-      report << '-' * 80
+      report << '-' * STRING_SEPARATOR_LENGHT
       report << "\n"
     end
     report
@@ -57,5 +55,4 @@ class HotThreadsReport
   def cpu_time(hash)
     hash["cpu.time"] / 1000000.0
   end
-
 end

--- a/logstash-core/lib/logstash/api/commands/hot_threads_reporter.rb
+++ b/logstash-core/lib/logstash/api/commands/hot_threads_reporter.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 class HotThreadsReport
-  STRING_SEPARATOR_LENGHT = 80.freeze
+  STRING_SEPARATOR_LENGTH = 80.freeze
   HOT_THREADS_STACK_TRACES_SIZE_DEFAULT = 10.freeze
 
   def initialize(cmd, options)
@@ -14,7 +14,7 @@ class HotThreadsReport
   def to_s
     hash = to_hash[:hot_threads]
     report =  "#{I18n.t("logstash.web_api.hot_threads.title", :hostname => hash[:hostname], :time => hash[:time], :top_count => @thread_dump.top_count )} \n"
-    report << '=' * STRING_SEPARATOR_LENGHT
+    report << '=' * STRING_SEPARATOR_LENGTH
     report << "\n"
     hash[:threads].each do |thread|
       thread_report = "#{I18n.t("logstash.web_api.hot_threads.thread_title", :percent_of_cpu_time => thread[:percent_of_cpu_time], :thread_state => thread[:state], :thread_name => thread[:name])} \n"
@@ -23,7 +23,7 @@ class HotThreadsReport
         thread_report << "\t#{trace}\n"
       end
       report << thread_report
-      report << '-' * STRING_SEPARATOR_LENGHT
+      report << '-' * STRING_SEPARATOR_LENGTH
       report << "\n"
     end
     report

--- a/logstash-core/lib/logstash/api/modules/base.rb
+++ b/logstash-core/lib/logstash/api/modules/base.rb
@@ -34,6 +34,11 @@ module LogStash
           text = as == :string ? "" : {}
           respond_with(text, :as => as)
         end
+
+        protected
+        def human?
+          params.has_key?("human") && (params["human"].nil? || as_boolean(params["human"]) == true)
+        end
       end
     end
   end

--- a/logstash-core/lib/logstash/api/modules/node.rb
+++ b/logstash-core/lib/logstash/api/modules/node.rb
@@ -26,7 +26,6 @@ module LogStash
           selected_fields = extract_fields(params["filter"].to_s.strip)
           respond_with node.all(selected_fields)
         end
-
       end
     end
   end

--- a/logstash-core/lib/logstash/api/modules/node.rb
+++ b/logstash-core/lib/logstash/api/modules/node.rb
@@ -14,7 +14,7 @@ module LogStash
 
           options = {
             :ignore_idle_threads => as_boolean(ignore_idle_threads),
-            :human => params.has_key?("human")
+            :human => human?
           }
           options[:threads] = params["threads"].to_i if params.has_key?("threads")
 
@@ -25,6 +25,11 @@ module LogStash
         get "/?:filter?" do
           selected_fields = extract_fields(params["filter"].to_s.strip)
           respond_with node.all(selected_fields)
+        end
+
+        protected
+        def human?
+          params.has_key?("human") && (params["human"].nil? || as_boolean(params["human"]) == true)
         end
       end
     end

--- a/logstash-core/lib/logstash/api/modules/node.rb
+++ b/logstash-core/lib/logstash/api/modules/node.rb
@@ -26,11 +26,6 @@ module LogStash
           selected_fields = extract_fields(params["filter"].to_s.strip)
           respond_with node.all(selected_fields)
         end
-
-        protected
-        def human?
-          params.has_key?("human") && (params["human"].nil? || as_boolean(params["human"]) == true)
-        end
       end
     end
   end

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -78,7 +78,7 @@ en:
           ::: {%{hostname}}
           Hot threads at %{time}, busiestThreads=%{top_count}:
         thread_title: |-
-            %{percent_of_cpu_time} % of cpu usage by %{thread_state} thread named '%{thread_name}'
+          %{percent_of_cpu_time} % of cpu usage, state: %{thread_state}, thread name: '%{thread_name}'
     runner:
       short-help: |-
         usage:

--- a/logstash-core/spec/api/lib/api/node_spec.rb
+++ b/logstash-core/spec/api/lib/api/node_spec.rb
@@ -64,7 +64,15 @@ describe LogStash::Api::Modules::Node do
 
     context "When asking for human output and threads count" do
       before(:all) do
+        # Make sure we have enough threads for this to work.
+        @threads = []
+        5.times { @threads << Thread.new { loop {} } }
+
         do_request { get "/hot_threads?human=t&threads=2"}
+      end
+
+      after(:all) do
+        @threads.each { |t| t.kill } rescue nil
       end
 
       let(:payload) { last_response.body }


### PR DESCRIPTION
This PR fixes the following:

- Make sure the `human=false` works
- Make sure that any other way of defining booleans in the query string works (true|false|t|f|0|1)
- A **human** key without a specific value will be considered as true.
- Add test around the number of threads and the human format.
- Fixes a typo in the Human text and make sure we use the localization files.

Related to #5732