### PR TITLE
Add GC Strategy under /note/jvm

### DIFF
--- a/logstash-core/lib/logstash/api/commands/node.rb
+++ b/logstash-core/lib/logstash/api/commands/node.rb
@@ -35,6 +35,7 @@ module LogStash
 
         def jvm
           memory_bean = ManagementFactory.getMemoryMXBean()
+
           {
             :pid =>  ManagementFactory.getRuntimeMXBean().getName().split("@").first.to_i,
             :version => java.lang.System.getProperty("java.version"),
@@ -48,14 +49,14 @@ module LogStash
               :heap_max_in_bytes => (memory_bean.getHeapMemoryUsage().getMax() < 0 ? 0 : memory_bean.getHeapMemoryUsage().getMax()),
               :non_heap_init_in_bytes => (memory_bean.getNonHeapMemoryUsage().getInit() < 0 ? 0 : memory_bean.getNonHeapMemoryUsage().getInit()),
               :non_heap_max_in_bytes => (memory_bean.getNonHeapMemoryUsage().getMax() < 0 ? 0 : memory_bean.getNonHeapMemoryUsage().getMax())
-            }
+            },
+            :gc_collectors => ManagementFactory.getGarbageCollectorMXBeans().collect(&:getName)
           }
         end
 
         def hot_threads(options={})
           HotThreadsReport.new(self, options)
         end
-
       end
     end
   end

--- a/logstash-core/spec/api/lib/api/node_spec.rb
+++ b/logstash-core/spec/api/lib/api/node_spec.rb
@@ -82,7 +82,8 @@ describe LogStash::Api::Modules::Node do
             "heap_max_in_bytes" => Numeric,
             "non_heap_init_in_bytes" => Numeric,
             "non_heap_max_in_bytes" => Numeric
-          }
+        },
+        "gc_collectors" => Array
         },
         "hot_threads"=> {
           "time" => String,


### PR DESCRIPTION
Output:

```json

{
  "host" : "sashimi",
  "version" : "5.0.0-alpha6",
  "http_address" : "127.0.0.1:9600",
  "jvm" : {
    "pid" : 73627,
    "version" : "1.8.0_20",
    "vm_name" : "Java HotSpot(TM) 64-Bit Server VM",
    "vm_version" : "1.8.0_20",
    "vm_vendor" : "Oracle Corporation",
    "start_time_in_millis" : 1471462827633,
    "mem" : {
      "heap_init_in_bytes" : 268435456,
      "heap_max_in_bytes" : 1038876672,
      "non_heap_init_in_bytes" : 2555904,
      "non_heap_max_in_bytes" : 0
    },
    "gc_collectors" : [ "ParNew", "ConcurrentMarkSweep" ]
  }
}
```


Fixes: #5755