### PR TITLE
allow deprecated quiet/debug/verbose flags to be set

### DIFF
--- a/logstash-core/lib/logstash/patches/clamp.rb
+++ b/logstash-core/lib/logstash/patches/clamp.rb
@@ -16,6 +16,16 @@ module Clamp
 
   module Option
 
+    module Declaration
+      def deprecated_option(switches, type, description, opts = {})
+        Option::Definition.new(switches, type, description, opts).tap do |option|
+          declared_options << option
+          block ||= option.default_conversion_block
+          define_deprecated_accessors_for(option, opts, &block)
+        end
+      end
+    end
+
     module StrictDeclaration
 
       include Clamp::Attribute::Declaration
@@ -37,6 +47,17 @@ module Clamp
         end
       end
 
+      def define_deprecated_accessors_for(option, opts, &block)
+        define_deprecated_writer_for(option, opts, &block)
+      end
+
+      def define_deprecated_writer_for(option, opts, &block)
+        define_method(option.write_method) do |value|
+          logger = Cabin::Channel.get(LogStash)
+          logger.warn "DEPRECATION WARNING: The flag #{option.switches} has been deprecated, please use \"--#{opts[:new_flag]}=#{opts[:new_value]}\" instead."
+          LogStash::SETTINGS.set(opts[:new_flag], opts[:new_value])
+        end
+      end
     end
 
     class Definition

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -132,6 +132,19 @@ class LogStash::Runner < Clamp::StrictCommand
     :attribute_name => "path.settings",
     :default => LogStash::SETTINGS.get_default("path.settings")
 
+  ### DEPRECATED FLAGS ###
+  deprecated_option ["--verbose"], :flag,
+    I18n.t("logstash.runner.flag.verbose"),
+    :new_flag => "log.level", :new_value => "verbose"
+
+  deprecated_option ["--debug"], :flag,
+    I18n.t("logstash.runner.flag.debug"),
+    :new_flag => "log.level", :new_value => "debug"
+
+  deprecated_option ["--quiet"], :flag,
+    I18n.t("logstash.runner.flag.quiet"),
+    :new_flag => "log.level", :new_value => "quiet"
+
   attr_reader :agent
 
   def initialize(*args)

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -252,3 +252,12 @@ en:
         log_format: |+
           Specify if Logstash should write its own logs in JSON form (one
           event per line) or in plain text (using Ruby's Object#inspect)
+        debug: |+
+          Set the log level to debug.
+          DEPRECATED: use --log.level=debug instead.
+        verbose: |+
+          Set the log level to info.
+          DEPRECATED: use --log.level=verbose instead.
+        quiet: |+
+          Set the log level to info.
+          DEPRECATED: use --log.level=quiet instead.

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -327,6 +327,48 @@ describe LogStash::Runner do
         expect(channel.level).to eq(:error)
       end
     end
+
+    context "deprecated flags" do
+      context "when using --quiet" do
+        it "should warn about the deprecated flag" do
+          expect(channel).to receive(:warn).with(/DEPRECATION WARNING/)
+          args = ["--quiet", "--version"]
+          subject.run("bin/logstash", args)
+        end
+
+        it "should still set the log level accordingly" do
+          args = ["--quiet", "--version"]
+          subject.run("bin/logstash", args)
+          expect(channel.level).to eq(:error)
+        end
+      end
+      context "when using --debug" do
+        it "should warn about the deprecated flag" do
+          expect(channel).to receive(:warn).with(/DEPRECATION WARNING/)
+          args = ["--debug", "--version"]
+          subject.run("bin/logstash", args)
+        end
+
+        it "should still set the log level accordingly" do
+          args = ["--debug", "--version"]
+          subject.run("bin/logstash", args)
+          expect(channel.level).to eq(:debug)
+        end
+      end
+      context "when using --verbose" do
+        it "should warn about the deprecated flag" do
+          expect(channel).to receive(:warn).with(/DEPRECATION WARNING/)
+          args = ["--verbose", "--version"]
+          subject.run("bin/logstash", args)
+        end
+
+        it "should still set the log level accordingly" do
+          args = ["--verbose", "--version"]
+          subject.run("bin/logstash", args)
+          expect(channel.level).to eq(:info)
+        end
+      end
+    end
   end
 
   describe "path.settings" do


### PR DESCRIPTION
fixes https://github.com/elastic/logstash/issues/5594

adds a few classes to clamp to allow creating deprecated options that warn about deprecations but set the proper new flags accordingly.