### PR TITLE
Add GC stats to the api

### DIFF
--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -14,7 +14,8 @@ module LogStash
               :count,
               :peak_count
             ),
-            :mem => memory
+            :mem => memory,
+            :gc => gc
           }
         end
 
@@ -57,6 +58,10 @@ module LogStash
               acc
             end
           }
+        end
+
+        def gc
+          service.get_shallow(:jvm, :gc)
         end
 
         def hot_threads(options={})

--- a/logstash-core/lib/logstash/api/modules/node_stats.rb
+++ b/logstash-core/lib/logstash/api/modules/node_stats.rb
@@ -12,7 +12,7 @@ module LogStash
           payload = {
             :jvm => jvm_payload,
             :process => process_payload,
-            :pipeline => pipeline_payload
+            :pipeline => pipeline_payload,
           }
           respond_with(payload, {:filter => params["filter"]})
         end

--- a/logstash-core/spec/api/lib/api/node_stats_spec.rb
+++ b/logstash-core/spec/api/lib/api/node_stats_spec.rb
@@ -16,6 +16,18 @@ describe LogStash::Api::Modules::NodeStats do
         "count"=>Numeric,
         "peak_count"=>Numeric
       },
+      "gc" => {
+        "collectors" => {
+          "young" => {
+            "collection_count" => Numeric,
+            "collection_time_in_millis" => Numeric
+          },
+          "old" => {
+            "collection_count" => Numeric,
+            "collection_time_in_millis" => Numeric
+          }
+        }
+      },
       "mem" => {
         "heap_used_in_bytes" => Numeric,
         "heap_used_percent" => Numeric,

--- a/logstash-core/spec/logstash/instrument/periodic_poller/jvm_spec.rb
+++ b/logstash-core/spec/logstash/instrument/periodic_poller/jvm_spec.rb
@@ -3,18 +3,41 @@ require "spec_helper"
 require "logstash/instrument/periodic_poller/jvm"
 require "logstash/instrument/collector"
 
+describe LogStash::Instrument::PeriodicPoller::JVM::GarbageCollectorName do
+  subject { LogStash::Instrument::PeriodicPoller::JVM::GarbageCollectorName }
+
+  context "when the gc is of young type" do
+    LogStash::Instrument::PeriodicPoller::JVM::GarbageCollectorName::YOUNG_GC_NAMES.each do |name|
+      it "returns young for #{name}" do
+        expect(subject.get(name)).to eq(:young)
+      end
+    end
+  end
+
+  context "when the gc is of old type" do
+    LogStash::Instrument::PeriodicPoller::JVM::GarbageCollectorName::OLD_GC_NAMES.each do |name|
+      it "returns old for #{name}" do
+        expect(subject.get(name)).to eq(:old)
+      end
+    end
+  end
+
+  it "returns `nil` when we dont know the gc name" do
+      expect(subject.get("UNKNOWN GC")).to be_nil
+  end
+end
+
 describe LogStash::Instrument::PeriodicPoller::JVM do
   let(:metric) { LogStash::Instrument::Metric.new(LogStash::Instrument::Collector.new) }
   let(:options) { {} }
   subject(:jvm) { described_class.new(metric, options) }
-  
+
   it "should initialize cleanly" do
     expect { jvm }.not_to raise_error
   end
 
   describe "collections" do
     subject(:collection) { jvm.collect }
-    
     it "should run cleanly" do
       expect { collection }.not_to raise_error
     end
@@ -22,21 +45,25 @@ describe LogStash::Instrument::PeriodicPoller::JVM do
     describe "metrics" do
       before(:each) { jvm.collect }
       let(:snapshot_store) { metric.collector.snapshot_metric.metric_store }
-      subject(:jvm_metrics) { snapshot_store.get_shallow(:jvm, :process) }
+      subject(:jvm_metrics) { snapshot_store.get_shallow(:jvm) }
 
       # Make looking up metric paths easy when given varargs of keys
       # e.g. mval(:parent, :child)
       def mval(*metric_path)
         metric_path.reduce(jvm_metrics) {|acc,k| acc[k]}.value
-      end          
+      end
 
       [
-        :max_file_descriptors,
-        :open_file_descriptors,
-        :peak_open_file_descriptors,
-        [:mem, :total_virtual_in_bytes],
-        [:cpu, :total_in_millis],
-        [:cpu, :percent]
+        [:process, :max_file_descriptors],
+        [:process, :open_file_descriptors],
+        [:process, :peak_open_file_descriptors],
+        [:process, :mem, :total_virtual_in_bytes],
+        [:process, :cpu, :total_in_millis],
+        [:process, :cpu, :percent],
+        [:gc, :collectors, :young, :collection_count],
+        [:gc, :collectors, :young, :collection_time_in_millis],
+        [:gc, :collectors, :old, :collection_count],
+        [:gc, :collectors, :old, :collection_time_in_millis]
       ].each do |path|
         path = Array(path)
         it "should have a value for #{path} that is Numeric" do


### PR DESCRIPTION
This PR introduce GC stats in the form of `collection_time` and `collection_count`, it takes the configured gc and categorize them into old and young.

Example output:

```
gc: {
  collectors: {
    young: {
      collection_time_in_millis: 22101,
      collection_count: 5452
    },
    old: {
      collection_time_in_millis: 57,
      collection_count: 1
    }
  }
}
```

Fixes: #5730