### PR TITLE
Remove `mem` block from `/node` API response

### DIFF
--- a/logstash-core/lib/logstash/api/modules/node_stats.rb
+++ b/logstash-core/lib/logstash/api/modules/node_stats.rb
@@ -12,7 +12,6 @@ module LogStash
           payload = {
             :jvm => jvm_payload,
             :process => process_payload,
-            :mem => mem_payload,
             :pipeline => pipeline_payload
           }
           respond_with(payload, {:filter => params["filter"]})


### PR DESCRIPTION
Part of https://github.com/elastic/logstash/issues/5732 effort