### PR TITLE
Override default behavior of travis to use `bundle install` and uses rake test:core instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ rvm:
   - jruby-1.7.25
 jdk:
   - oraclejdk8
-before_script:
+install:
   - rake test:install-core
+before_script:
   - echo "--order rand" > .rspec
   - echo "--format documentation" >> .rspec
 script: rake test:core


### PR DESCRIPTION
This PR fixes the issue discovered in https://github.com/elastic/logstash/pull/5782#issuecomment-241070120

When we set the language to ruby and if Travis detects a Gemfile, it will automagically run bundle install, in the PR this is where it failed.