### PR TITLE
Expose duration of the Filter+Output part of the pipeline

### DIFF
--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -32,7 +32,7 @@ module LogStash
         def events
           extract_metrics(
             [:stats, :events],
-            :in, :filtered, :out
+            :in, :filtered, :out, :duration_in_millis
           )
         end
 

--- a/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
@@ -117,6 +117,7 @@ module LogStash; module Util
 
       def stop_clock
         @inflight_clocks[Thread.current].each(&:stop)
+        @inflight_clocks.delete(Thread.current)
       end
 
       def add_starting_metrics(batch)

--- a/logstash-core/spec/api/lib/api/node_stats_spec.rb
+++ b/logstash-core/spec/api/lib/api/node_stats_spec.rb
@@ -59,12 +59,13 @@ describe LogStash::Api::Modules::NodeStats do
     },
    "pipeline" => {
      "events" => {
+        "duration_in_millis" => Numeric,
         "in" => Numeric,
         "filtered" => Numeric,
         "out" => Numeric
-     } 
-    } 
+     }
+    }
   }
-  
+
   test_api_and_resources(root_structure)
 end

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -611,6 +611,7 @@ describe LogStash::Pipeline do
       let(:collected_metric) { metric_store.get_with_path("stats/events") }
 
       it "populates the different metrics" do
+        expect(collected_metric[:stats][:events][:duration_in_millis].value).not_to be_nil
         expect(collected_metric[:stats][:events][:in].value).to eq(number_of_events)
         expect(collected_metric[:stats][:events][:filtered].value).to eq(number_of_events)
         expect(collected_metric[:stats][:events][:out].value).to eq(number_of_events)
@@ -621,6 +622,7 @@ describe LogStash::Pipeline do
       let(:collected_metric) { metric_store.get_with_path("stats/pipelines/") }
 
       it "populates the pipelines core metrics" do
+        expect(collected_metric[:stats][:pipelines][:main][:events][:duration_in_millis].value).not_to be_nil
         expect(collected_metric[:stats][:pipelines][:main][:events][:in].value).to eq(number_of_events)
         expect(collected_metric[:stats][:pipelines][:main][:events][:filtered].value).to eq(number_of_events)
         expect(collected_metric[:stats][:pipelines][:main][:events][:out].value).to eq(number_of_events)

--- a/logstash-core/spec/logstash/util/wrapped_synchronous_queue_spec.rb
+++ b/logstash-core/spec/logstash/util/wrapped_synchronous_queue_spec.rb
@@ -49,6 +49,12 @@ describe LogStash::Util::WrappedSynchronousQueue do
         let(:queue) { DummyQueue.new }
         let(:write_client) { LogStash::Util::WrappedSynchronousQueue::WriteClient.new(queue)}
         let(:read_client)  { LogStash::Util::WrappedSynchronousQueue::ReadClient.new(queue)}
+
+        before :each do
+          read_client.set_events_metric(LogStash::Instrument::NullMetric.new)
+          read_client.set_pipeline_metric(LogStash::Instrument::NullMetric.new)
+        end
+
         it "appends batches to the queue" do
           batch = write_client.get_new_batch
           5.times {|i| batch.push("value-#{i}")}


### PR DESCRIPTION
This PR will expose the time spend of a batch in the filter + output

Ouput:
http://localhost:9600/_node/stats/pipeline
```
events: {
	duration_in_millis: 18364,
	in: 309325,
	filtered: 309325,
	out: 309325
},

```

Fixes: #5731