### PR TITLE
Cleanup OutputDelegatorStrategy refactor

### DIFF
--- a/logstash-core-plugin-api/lib/logstash-core-plugin-api/version.rb
+++ b/logstash-core-plugin-api/lib/logstash-core-plugin-api/version.rb
@@ -1,2 +1,2 @@
 # encoding: utf-8
-LOGSTASH_CORE_PLUGIN_API = "2.1.7"
+LOGSTASH_CORE_PLUGIN_API = "2.1.12"

--- a/logstash-core/lib/logstash/output_delegator.rb
+++ b/logstash-core/lib/logstash/output_delegator.rb
@@ -12,7 +12,8 @@ module LogStash class OutputDelegator
     @output_class = output_class
     @metric = metric
     @plugin_args = plugin_args
-    @strategy_registry ||= ::LogStash::OutputDelegatorStrategyRegistry.instance
+    @strategy_registry = strategy_registry
+    raise ArgumentError, "No strategy registry specified" unless strategy_registry
     raise ArgumentError, "No ID specified! Got args #{plugin_args}" unless id
     
     build_strategy!

--- a/logstash-core/lib/logstash/output_delegator_strategies/legacy.rb
+++ b/logstash-core/lib/logstash/output_delegator_strategies/legacy.rb
@@ -2,7 +2,7 @@
 module LogStash module OutputDelegatorStrategies class Legacy
   attr_reader :worker_count, :workers
   
-  def initialize(logger, klass, metric, plugin_args={})
+  def initialize(logger, klass, metric, plugin_args)
     @worker_count = (plugin_args["workers"] || 1).to_i
     @workers = @worker_count.times.map {|t| klass.new(plugin_args)}
     @worker_queue = SizedQueue.new(@worker_count)

--- a/logstash-core/lib/logstash/output_delegator_strategies/shared.rb
+++ b/logstash-core/lib/logstash/output_delegator_strategies/shared.rb
@@ -1,5 +1,5 @@
 module LogStash module OutputDelegatorStrategies class Shared
-  def initialize(logger, klass, metric, xopts={}, plugin_args={})
+  def initialize(logger, klass, metric, plugin_args)
     @output = klass.new(plugin_args)
   end
   

--- a/logstash-core/lib/logstash/output_delegator_strategies/single.rb
+++ b/logstash-core/lib/logstash/output_delegator_strategies/single.rb
@@ -1,5 +1,5 @@
 module LogStash module OutputDelegatorStrategies class Single
-  def initialize(logger, klass, metric, xopts={}, plugin_args={})
+  def initialize(logger, klass, metric, plugin_args)
     @output = klass.new(plugin_args)
     @mutex = Mutex.new
   end

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -416,7 +416,7 @@ module LogStash; class Pipeline
     type_scoped_metric = pipeline_scoped_metric.namespace("#{plugin_type}s".to_sym)
     plugin = if plugin_type == "output"
                OutputDelegator.new(@logger, klass, type_scoped_metric,
-                                   {:strategy_registry => ::LogStash::OutputDelegatorStrategyRegistry.instance},
+                                   ::LogStash::OutputDelegatorStrategyRegistry.instance,
                                    args)
              elsif plugin_type == "filter"
                LogStash::FilterDelegator.new(@logger, klass, type_scoped_metric, args)

--- a/logstash-core/spec/logstash/output_delegator_spec.rb
+++ b/logstash-core/spec/logstash/output_delegator_spec.rb
@@ -5,8 +5,9 @@ require 'spec_helper'
 describe LogStash::OutputDelegator do
   let(:logger) { double("logger") }
   let(:events) { 7.times.map { LogStash::Event.new }}
+  let(:plugin_args) { {"id" => "foo", "arg1" => "val1"} }
 
-  subject { described_class.new(logger, out_klass, LogStash::Instrument::NullMetric.new, {}, "id" => "foo") }
+  subject { described_class.new(logger, out_klass, LogStash::Instrument::NullMetric.new, ::LogStash::OutputDelegatorStrategyRegistry.instance, plugin_args) }
 
   context "with a plain output plugin" do
     let(:out_klass) { double("output klass") }
@@ -81,6 +82,10 @@ describe LogStash::OutputDelegator do
           
           it "should find the correct Strategy class for the worker" do
             expect(subject.strategy).to be_a(klass)
+          end
+
+          it "should set the correct parameters on the instance" do
+            expect(out_klass).to have_received(:new).with(plugin_args)
           end
 
           [[:register], [:do_close], [:multi_receive, [[]] ] ].each do |method, args|

--- a/versions.yml
+++ b/versions.yml
@@ -3,4 +3,4 @@ logstash: 5.0.0-alpha6
 logstash-core: 5.0.0-alpha6
 logstash-core-event: 5.0.0-alpha6
 logstash-core-event-java: 5.0.0-alpha6
-logstash-core-plugin-api: 2.1.7
+logstash-core-plugin-api: 2.1.12


### PR DESCRIPTION
This fixes two issues:

1. This fully removes the xopts parameter which for Shared and Single concurrency would prevent outputs from receiving their parameters
2. This cleans up the injection of the OutputDelegatorStrategyRegistry.

This also bumps the plugin api version to 2.1.12