### PR TITLE
Make sure the `name` of the plugin is saved in the metric store

### DIFF
--- a/logstash-core/lib/logstash/output_delegator.rb
+++ b/logstash-core/lib/logstash/output_delegator.rb
@@ -15,12 +15,12 @@ module LogStash class OutputDelegator
     @strategy_registry = strategy_registry
     raise ArgumentError, "No strategy registry specified" unless strategy_registry
     raise ArgumentError, "No ID specified! Got args #{plugin_args}" unless id
-    
+
     build_strategy!
 
     @namespaced_metric = metric.namespace(id.to_sym)
+    @namespaced_metric.gauge(:name, config_name)
     @metric_events = @namespaced_metric.namespace(:events)
-    @namespaced_metric.gauge(:name, id)
   end
 
   def config_name

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -641,6 +641,18 @@ describe LogStash::Pipeline do
         plugin_name = dummy_output_id.to_sym
         expect(collected_metric[:stats][:pipelines][:main][:plugins][:outputs][plugin_name][:events][:out].value).to eq(number_of_events)
       end
+
+      it "populates the name of the output plugin" do
+        plugin_name = dummy_output_id.to_sym
+        expect(collected_metric[:stats][:pipelines][:main][:plugins][:outputs][plugin_name][:name].value).to eq(DummyOutput.config_name)
+      end
+
+      it "populates the name of the filter plugin" do
+        [multiline_id, multiline_id_other].map(&:to_sym).each do |id|
+          plugin_name = "multiline_#{id}".to_sym
+          expect(collected_metric[:stats][:pipelines][:main][:plugins][:filters][plugin_name][:name].value).to eq(LogStash::Filters::Multiline.config_name)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Fixes: #5799