### PR TITLE
Backport of Outputs#base.concurrency to 2.4 branch

### DIFF
--- a/logstash-core/lib/logstash/outputs/base.rb
+++ b/logstash-core/lib/logstash/outputs/base.rb
@@ -27,6 +27,22 @@ class LogStash::Outputs::Base < LogStash::Plugin
 
   attr_reader :worker_plugins, :available_workers, :workers, :worker_plugins, :workers_not_supported
 
+    # Set or return concurrency type
+  def self.concurrency(type=nil)
+    if type
+      @concurrency = type
+      
+      if type == :shared
+        declare_threadsafe!
+      elsif type == :single
+        declare_workers_not_supported!("This plugin only supports one worker!")
+      end
+      
+    else
+      @concurrency || :legacy # default is :legacyo
+    end
+  end
+
   def self.declare_threadsafe!
     declare_workers_not_supported!
     @threadsafe = true
@@ -76,6 +92,11 @@ class LogStash::Outputs::Base < LogStash::Plugin
   def receive(event)
     raise "#{self.class}#receive must be overidden"
   end # def receive
+
+  public
+  def concurrency
+    self.class.concurrency
+  end
 
   public
   # To be overriden in implementations


### PR DESCRIPTION
This is the 2.4 version of https://github.com/elastic/logstash/pull/5795 which targeted 2.x

This is a backport of https://github.com/elastic/logstash/pull/5752 to
the 2.x branch targetting the 2.4 release.

The changes here are more minimal since the pipeline code is simpler and we need to support
some other legacy constructs such as the instance level version of Outputs::Base#workers_not_supported.