### PR TITLE
[2.x] Add new `Codec#encode_sync`, `Codec#multi_encode` and `Output#multi_r…

### DIFF
--- a/lib/pluginmanager/templates/codec-plugin/lib/logstash/codecs/example.rb.erb
+++ b/lib/pluginmanager/templates/codec-plugin/lib/logstash/codecs/example.rb.erb
@@ -37,8 +37,9 @@ class LogStash::Codecs::<%= classify(plugin_name) %> < LogStash::Codecs::Base
     end
   end # def decode
 
-  def encode(event)
-    @on_event.call(event, event.get("message").to_s + @append + NL)
-  end # def encode
+  # Encode a single event, this returns the raw data to be returned as a String
+  def encode_sync(event)
+    event.get("message").to_s + @append + NL
+  end # def encode_sync
 
 end # class LogStash::Codecs::<%= classify(plugin_name) %>

--- a/logstash-core/lib/logstash/codecs/base.rb
+++ b/logstash-core/lib/logstash/codecs/base.rb
@@ -13,6 +13,7 @@ module LogStash::Codecs; class Base < LogStash::Plugin
     super
     config_init(@params)
     register if respond_to?(:register)
+    setup_multi_encode!
   end
 
   public
@@ -23,9 +24,36 @@ module LogStash::Codecs; class Base < LogStash::Plugin
   alias_method :<<, :decode
 
   public
+  # DEPRECATED: Prefer defining encode_sync or multi_encode
   def encode(event)
-    raise "#{self.class}#encode must be overidden"
+    encoded = multi_encode([event])
+    encoded.each {|event,data| @on_event.call(event,data) }
   end # def encode
+
+  public
+  # Relies on the codec being synchronous (which they all are!)
+  # We need a better long term design here, but this is an improvement
+  # over the current API for shared plugins
+  # It is best if the codec implements this directly
+  def multi_encode(events)
+    if @has_encode_sync              
+      events.map {|event| [event, self.encode_sync(event)]}
+    else
+      batch = Thread.current[:logstash_output_codec_batch] ||= []
+      batch.clear
+      
+      events.each {|event| self.encode(event) }
+      batch
+    end
+  end
+
+  def setup_multi_encode!
+    @has_encode_sync = self.methods.include?(:encode_sync)
+
+    on_event do |event, data|
+      Thread.current[:logstash_output_codec_batch] << [event, data]
+    end
+  end
 
   public
   def close; end;

--- a/logstash-core/spec/logstash/codecs/base_spec.rb
+++ b/logstash-core/spec/logstash/codecs/base_spec.rb
@@ -1,0 +1,74 @@
+# encoding: utf-8
+require "spec_helper"
+
+DATA_DOUBLE = "data".freeze
+
+# use a dummy NOOP output to test Outputs::Base
+class LogStash::Codecs::NOOPAsync < LogStash::Codecs::Base
+  attr_reader :last_result
+  config_name "noop_async"
+
+  def encode(event)
+    @last_result = @on_event.call(event, DATA_DOUBLE)
+  end
+end
+
+class LogStash::Codecs::NOOPSync < LogStash::Codecs::Base
+  attr_reader :last_result
+  config_name "noop_sync"
+
+  def encode_sync(event)
+    DATA_DOUBLE
+  end
+end
+
+class LogStash::Codecs::NOOPMulti < LogStash::Codecs::Base
+  attr_reader :last_result
+  config_name "noop_multi"
+
+  def encode_sync(event)
+    DATA_DOUBLE
+  end
+end
+
+describe LogStash::Codecs::Base do
+  let(:params) { {} }
+  subject(:instance) { klass.new(params.dup) }
+  let(:event) { double("event") }
+  let(:encoded_data) { DATA_DOUBLE }
+  let(:encoded_tuple) { [event, encoded_data] }
+
+  describe "encoding" do
+    shared_examples "encoder types" do |codec_class|
+      let(:klass) { codec_class }
+      
+      describe "#{codec_class}" do
+        describe "multi_encode" do
+          it "should return an array of [event,data] tuples" do
+            expect(instance.multi_encode([event,event])).to eq([encoded_tuple, encoded_tuple])
+          end
+        end
+        
+        describe "#encode" do
+          before do
+            @result = nil
+            instance.on_event do |event, data|
+              @result = [event, data]
+            end
+            instance.encode(event)
+          end
+          
+          it "should yield the correct result" do
+            expect(@result).to eq(encoded_tuple)
+          end
+        end
+      end
+    end
+
+    include_examples("encoder types", LogStash::Codecs::NOOPAsync)
+    include_examples("encoder types", LogStash::Codecs::NOOPSync)
+    include_examples("encoder types", LogStash::Codecs::NOOPMulti)
+  end
+end
+
+                          


### PR DESCRIPTION
…eceive_encoded` methods.

These methods allow outputs to receive their events pre-encoded for them
by the pipeline. This is mostly useful in the context of `#shared` outputs, for whom
encoding a discrete batch in a threadsafe way is not necessarily straightforward.

It would be advised for codecs to prefer `#multi_encode` as the main way of operating
as the standard `#encode` method is not threadsafe.