### PR TITLE
make sure sed replacement is posix compliant

### DIFF
--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/update.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/update.rb
@@ -18,7 +18,7 @@ shared_examples "logstash update" do |logstash|
     before do
       logstash.run_command_in_path("bin/logstash-plugin install --no-verify --version #{previous_version} #{plugin_name}")
       # Logstash wont update when we have a pinned versionin the gemfile so we remove them
-      logstash.replace_in_gemfile(',\s"0.1.0"', "")
+      logstash.replace_in_gemfile(',[[:space:]]"0.1.0"', "")
       expect(logstash).to have_installed?(plugin_name, previous_version)
     end
 


### PR DESCRIPTION
the integration specs that target the update command sometimes use `sed` for setup actions before the actual specs are run.

One of these sed substitutions uses \s to match a whitespace, which in some systems might not work since it's not posix compliant,  [[:space]] should be used instead

aims to fix https://logstash-ci.elastic.co/job/elastic+logstash+master+multijob-acceptance/98/