### PR TITLE
Properly set Output Metrics in Output Delegator Strategy.

### DIFF
--- a/logstash-core/lib/logstash/output_delegator_strategies/legacy.rb
+++ b/logstash-core/lib/logstash/output_delegator_strategies/legacy.rb
@@ -4,7 +4,8 @@ module LogStash module OutputDelegatorStrategies class Legacy
   
   def initialize(logger, klass, metric, plugin_args)
     @worker_count = (plugin_args["workers"] || 1).to_i
-    @workers = @worker_count.times.map {|t| klass.new(plugin_args)}
+    @workers = @worker_count.times.map { klass.new(plugin_args) }
+    @workers.each {|w| w.metric = metric }
     @worker_queue = SizedQueue.new(@worker_count)
     @workers.each {|w| @worker_queue << w}
   end

--- a/logstash-core/lib/logstash/output_delegator_strategies/shared.rb
+++ b/logstash-core/lib/logstash/output_delegator_strategies/shared.rb
@@ -1,6 +1,7 @@
 module LogStash module OutputDelegatorStrategies class Shared
   def initialize(logger, klass, metric, plugin_args)
     @output = klass.new(plugin_args)
+    @output.metric = metric
   end
   
   def register

--- a/logstash-core/lib/logstash/output_delegator_strategies/single.rb
+++ b/logstash-core/lib/logstash/output_delegator_strategies/single.rb
@@ -1,6 +1,7 @@
 module LogStash module OutputDelegatorStrategies class Single
   def initialize(logger, klass, metric, plugin_args)
     @output = klass.new(plugin_args)
+    @output.metric = metric
     @mutex = Mutex.new
   end
 

--- a/logstash-core/spec/logstash/output_delegator_spec.rb
+++ b/logstash-core/spec/logstash/output_delegator_spec.rb
@@ -97,6 +97,10 @@ describe LogStash::OutputDelegator do
             expect(out_klass).to have_received(:new).with(plugin_args)
           end
 
+          it "should set the metric on the instance" do
+            expect(out_inst).to have_received(:metric=).with(metric)
+          end
+
           [[:register], [:do_close], [:multi_receive, [[]] ] ].each do |method, args|
             context "strategy objects" do
               before do

--- a/logstash-core/spec/logstash/outputs/base_spec.rb
+++ b/logstash-core/spec/logstash/outputs/base_spec.rb
@@ -34,7 +34,6 @@ class LogStash::Outputs::NOOPMultiReceiveEncoded < ::LogStash::Outputs::Base
   end
 end
 
-
 describe "LogStash::Outputs::Base#new" do
   let(:params) { {} }  
   subject(:instance) { klass.new(params.dup) }


### PR DESCRIPTION
Fixes https://github.com/elastic/logstash/issues/5810

Without this Outputs never have their `metric` property set. This doesn't perform the full refactor mentioned in #5810 , that will require more work than is merited at the moment.