### PR TITLE
Add workers not supported error message for legacy plugins.

### DIFF
--- a/logstash-core/lib/logstash/outputs/base.rb
+++ b/logstash-core/lib/logstash/outputs/base.rb
@@ -92,6 +92,10 @@ class LogStash::Outputs::Base < LogStash::Plugin
     end
   end
 
+  def workers_not_supported(message=nil)
+    raise "This plugin (#{self.class.name}) is using the obsolete '#workers_not_supported' method. If you installed this plugin specifically on this Logstash version, it is not compatible. If you are a plugin author, please see https://www.elastic.co/guide/en/logstash/current/_how_to_write_a_logstash_output_plugin.html for more info"
+  end
+
   def codec
     params["codec"]
   end


### PR DESCRIPTION
Fixes https://github.com/elastic/logstash/issues/5823