### PR TITLE
prevent exception if logstash is interrupted during startup

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -202,6 +202,8 @@ class LogStash::Agent < Clamp::Command
                           :allow_env => allow_env?
                           }))
 
+    @thread = Thread.current # this var is implicilty used by Stud.stop?
+
     sigint_id = trap_sigint()
     sigterm_id = trap_sigterm()
     sighup_id = trap_sighup()
@@ -213,8 +215,6 @@ class LogStash::Agent < Clamp::Command
     start_pipelines
 
     return 1 if clean_state?
-
-    @thread = Thread.current # this var is implicilty used by Stud.stop?
 
     Stud.stoppable_sleep(reload_interval) # sleep before looping
 


### PR DESCRIPTION
during startup signal trapping is set up to gracefully shutdown logstash
this signal handling relies on Stud.stop? which depends on @thread being set

Currently we set that variable after setting up the trapping, which
creates a window where an interruption will trigger Stud.stop and find
@thread to be nil.

This patch moves the setting of @thread to be done before trapping, this
fixing the issue.

fixes https://github.com/elastic/logstash/issues/5604