### PR TITLE
fix name of the all plugin rpm and debian packages

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -227,7 +227,7 @@ namespace "artifact" do
     case platform
       when "redhat", "centos"
         # produce: logstash-5.0.0-alpha1.noarch.rpm
-        package_filename = "logstash-#{LOGSTASH_VERSION}.ARCH.TYPE"
+        package_filename = "#{package_name}-#{LOGSTASH_VERSION}.ARCH.TYPE"
 
         File.join(basedir, "pkg", "logrotate.conf").tap do |path|
           dir.input("#{path}=/etc/logrotate.d/logstash")
@@ -250,7 +250,7 @@ namespace "artifact" do
         out.config_files << "/etc/init.d/logstash"
       when "debian", "ubuntu"
         # produce: logstash-5.0.0-alpha1_all.deb"
-        package_filename = "logstash-#{LOGSTASH_VERSION}_ARCH.TYPE"
+        package_filename = "#{package_name}-#{LOGSTASH_VERSION}_ARCH.TYPE"
 
         File.join(basedir, "pkg", "logstash.default").tap do |path|
           dir.input("#{path}=/etc/default/logstash")


### PR DESCRIPTION
in https://github.com/elastic/logstash/commit/4347cf8aecd54bf349da56c371de13fce34898de two rake tasks were added to generate the "all-plugins" rpm and debian packages.

However, currently the packages will be created with the names `logstash-2.4.0_all.deb` and `logstash-2.4.0.noarch.rpm`, instead of having "all-plugins" in the name.

This PR ensure the names of generated packages will be `logstash-all-plugins-2.4.0.noarch.rpm` and `logstash-all-plugins-2.4.0_all.deb`