### PR TITLE
add metrics regarding pipeline reloading

### DIFF
--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -91,7 +91,8 @@ module LogStash
                 :inputs => plugin_stats(stats, :inputs),
                 :filters => plugin_stats(stats, :filters),
                 :outputs => plugin_stats(stats, :outputs)
-              }
+              },
+              :reloads => stats[:reloads],
             }
           end
         end # module PluginsStats

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -440,7 +440,7 @@ describe LogStash::Agent do
       it "sets the success reload timestamp" do
         snapshot = subject.metric.collector.snapshot_metric
         value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:last_success_timestamp].value
-        expect(value).to_not be(nil)
+        expect(value).to be_a(LogStash::Timestamp)
       end
 
       it "does not set the last reload error" do
@@ -488,13 +488,14 @@ describe LogStash::Agent do
       it "sets the failure reload timestamp" do
         snapshot = subject.metric.collector.snapshot_metric
         value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:last_failure_timestamp].value
-        expect(value).to_not be(nil)
+        expect(value).to be_a(LogStash::Timestamp)
       end
 
       it "sets the last reload error" do
         snapshot = subject.metric.collector.snapshot_metric
         value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:last_error].value
-        expect(value).to_not be(nil)
+        expect(value).to be_a(Hash)
+        expect(value).to include(:message, :backtrace)
       end
 
       it "increases the failed reload count" do


### PR DESCRIPTION
This is a ~~WIP~~ PR to add pipeline reload metrics to logstash.

targets https://github.com/elastic/logstash/issues/5680

example output:

```
% curl localhost:9600/_node/stats/pipeline?pretty
{
  "host" : "Joaos-MBP",
  "version" : "5.0.0-alpha6",
  "http_address" : "127.0.0.1:9600",
  "pipeline" : {
    "events" : {
      "duration_in_millis" : 35775,
      "in" : 3500,
      "filtered" : 3000,
      "out" : 3000
    },
    "plugins" : {
      "inputs" : [ ],
      "filters" : [ {
        "id" : "sleep_fd1abb9cb9a7857c354a6579fd0dfbc050304f10-2",
        "events" : {
          "duration_in_millis" : 37114,
          "in" : 3160,
          "out" : 3156
        }
      } ],
      "outputs" : [ ]
    },
    "reloads" : {
      "last_error" : {
        "message" : "Expected one of #, => at line 3, column 8 (byte 60) after filter { sleep { time => 0.\noutput ",
        "backtrace" : [ "/Users/joaoduarte/projects/logstash/logstash-core/lib/logstash/pipeline.rb:74:in `initialize'", "/Users/joaoduarte/projects/logstash/logstash-core/lib/logstash/agent.rb:191:in `create_pipeline'", "/Users/joaoduarte/projects/logstash/logstash-core/lib/logstash/agent.rb:221:in `reload_pipeline!'", "/Users/joaoduarte/projects/logstash/logstash-core/lib/logstash/agent.rb:102:in `reload_state!'", "org/jruby/RubyHash.java:1342:in `each'", "/Users/joaoduarte/projects/logstash/logstash-core/lib/logstash/agent.rb:100:in `reload_state!'", "org/jruby/ext/thread/Mutex.java:149:in `synchronize'", "/Users/joaoduarte/projects/logstash/logstash-core/lib/logstash/agent.rb:99:in `reload_state!'", "/Users/joaoduarte/projects/logstash/logstash-core/lib/logstash/agent.rb:67:in `execute'", "org/jruby/RubyProc.java:281:in `call'", "/Users/joaoduarte/projects/logstash/vendor/bundle/jruby/1.9/gems/stud-0.0.22/lib/stud/interval.rb:20:in `interval'", "/Users/joaoduarte/projects/logstash/logstash-core/lib/logstash/agent.rb:67:in `execute'", "/Users/joaoduarte/projects/logstash/logstash-core/lib/logstash/runner.rb:252:in `execute'", "org/jruby/RubyProc.java:281:in `call'", "/Users/joaoduarte/projects/logstash/vendor/bundle/jruby/1.9/gems/stud-0.0.22/lib/stud/task.rb:24:in `initialize'" ]
      },
      "successes" : 3,
      "last_success_timestamp" : "2016-08-31T11:11:57.047Z",
      "last_failure_timestamp" : "2016-08-31T11:11:26.917Z",
      "failures" : 3
    }
  }
}               
```