### PR TITLE
Update CLI topic with missing options

### DIFF
--- a/docs/static/command-line-flags.asciidoc
+++ b/docs/static/command-line-flags.asciidoc
@@ -13,91 +13,110 @@ Any flags that you set at the command line override the corresponding settings i
 
 added[5.0.0-alpha3, Command-line flags have dots instead of dashes in their names]
 
-*`-f, --path.config CONFIGFILE`*::
- Load the Logstash config from a specific file or directory. If
- you specify a directory or wildcard, config files are read from the directory in
- alphabetical order.
+*`--node.name NAME`*::
+  Specify the name of this Logstash instance. If no value is given it will default to the current
+  hostname.
+ 
+*`-f, --path.config CONFIG_PATH`*::
+  Load the Logstash config from a specific file or directory. If a directory is given, all
+  files in that directory will be concatenated in lexicographical order and then parsed as a
+  single config file. You can also specify wildcards (globs) and any matched files will
+  be loaded in the order described above.
 
-*`-e, --config.string CONFIGSTRING`*::
- Use the given string as the configuration data. Use the same syntax as the config file.
- If no input is specified, `stdin { type => stdin }` is used by default. If no output
- is specified, `stdout { codec => rubydebug }}` is used by default.
+*`-e, --config.string CONFIG_STRING`*::
+  Use the given string as the configuration data. Same syntax as the config file. If no
+  input is specified, then the following is used as the default input:
+  `input { stdin { type => stdin } }` and if no output is specified, then the
+  following is used as the default output: `output { stdout { codec => rubydebug } }`.
+  If you wish to use both defaults, please use the empty string for the `-e` flag.
+  The default is nil.
 
 *`-w, --pipeline.workers COUNT`*::
- Set the number of workers that will, in parallel, execute the filter and output stages of the pipeline.  
- This defaults to the number of the host's CPU cores. If you find that events are backing up, or that
- the CPU is not saturated, consider increasing this number to better utilize machine processing power.
+  Sets the number of pipeline workers to run. This option sets the number of workers that will,
+  in parallel, execute the filter and output stages of the pipeline. If you find that events are
+  backing up, or that  the CPU is not saturated, consider increasing this number to better utilize
+  machine processing power. The default is 8.
  
 *`-b, --pipeline.batch.size SIZE`*::
- Define the maximum number of events an individual worker thread will collect from inputs
- before attempting to execute its filters and outputs. The default is 125 events.
- Larger batch sizes are generally more efficient, but come at the cost of increased memory
- overhead. You may have to increase the JVM heap size by setting the `LS_HEAP_SIZE`
- variable to effectively use the option.
+  Size of batches the pipeline is to work in. This option defines the maximum number of events an
+  individual worker thread will collect from inputs before attempting to execute its filters and outputs.
+  The default is 125 events. Larger batch sizes are generally more efficient, but come at the cost of
+  increased memory overhead. You may have to increase the JVM heap size by setting the `LS_HEAP_SIZE`
+  variable to effectively use the option.
 
 *`-u, --pipeline.batch.delay DELAY_IN_MS`*::
- When creating pipeline event batches, how long in milliseconds to wait before dispatching an undersized
-  batch to filters and workers.
- The default is 5ms.
-
-*`-l, --path.log FILE`*::
- Log to a given file. The default is to log to stdout
-
-*`--log.level LEVEL`*::
- Valid levels are:
-* `fatal`: log very severe error messages that will usually be followed by the application aborting
-* `error`: log errors
-* `warn`: log warnings
-* `info`: log verbose info (for users)
-* `debug`: log debugging info (for developers)
-* `trace`: finer-grained messages beyond debug
-
-*`--path.settings SETTINGS_DIR`*::
- Set the directory containing the `logstash.yml` <<logstash-settings-file,settings file>> as well
- as the log4j logging configuration.
-
-*`--node.name NAME`*::
- Set a descriptive name for the node. If no value is specified, defaults to the machine's hostname. 
-
-*`--config.debug`*::
- Show the fully compiled configuration as a debug log message (you must also have `--log.level=debug` enabled).
- WARNING: The log message will include any 'password' options passed to plugin configs as plaintext, and may result
- in plaintext passwords appearing in your logs!
-
-*`-V, --version`*::
-  Display the version of Logstash.
-
-*`-p, --path.plugins`*::
-  Where to find custom plugins. This flag can be given multiple times to include
-  multiple paths. Plugins are expected to be in a specific directory hierarchy:
-  `PATH/logstash/TYPE/NAME.rb` where `TYPE` is `inputs`, `filters`, `outputs`, or `codecs`,
-  and `NAME` is the name of the plugin.
-
-*`-t, --config.test_and_exit`*::
-  Check configuration and then exit. Note that grok patterns are not checked for
-  correctness with this flag.
-  Logstash can read multiple config files from a directory. If you combine this
-  flag with `--log.level=debug`, Logstash will log the combined config file, annotating
-  each config block with the source file it came from.
+  When creating pipeline batches, how long to wait while polling for the next event. This option defines
+  how long in milliseconds to wait before dispatching an undersized batch to filters and workers.
+  The default is 5ms.
   
-*`-r, --config.reload.automatic`*::
-  Periodically check if the configuration has changed and reload the configuration whenever it is changed.
-
-*`--config.reload.interval RELOAD_INTERVAL`*::
-  Set how often in seconds Logstash checks the config files for changes. The default is every 3 seconds.
-
-*`--http.host HTTP_HOST`*::
-  The bind address for the metrics REST endpoint. The default is "127.0.0.1".
-
-*`--http.port HTTP_PORT`*::
-  The bind port for the metrics REST endpoint. The default is 9600-9700.
-  This setting accepts a range of the format 9600-9700. Logstash will pick up the first available port.
-
 *`--pipeline.unsafe_shutdown`*::
   Force Logstash to exit during shutdown even if there are still inflight events
   in memory. By default, Logstash will refuse to quit until all received events
   have been pushed to the outputs. Enabling this option can lead to data loss during shutdown.
 
+*`--path.data PATH`*::
+  This should point to a writable directory. Logstash will use this directory whenever it needs to store
+  data. Plugins will also have access to this path. The default is the `data` directory under
+  Logstash home. 
+  
+*`-p, --path.plugins PATH`*::
+  A path of where to find custom plugins. This flag can be given multiple times to include
+  multiple paths. Plugins are expected to be in a specific directory hierarchy:
+  `PATH/logstash/TYPE/NAME.rb` where `TYPE` is `inputs`, `filters`, `outputs`, or `codecs`,
+  and `NAME` is the name of the plugin.
+
+*`-l, --path.log FILE`*::
+  Write Logstash internal logs to the given file. Without this flag, Logstash will emit logs to standard output.
+
+*`--log.level LEVEL`*::
+ Set the log level for Logstash. Possible values are:
+* `fatal`: log very severe error messages that will usually be followed by the application aborting
+* `error`: log errors
+* `warn`: log warnings (this is the default)
+* `info`: log verbose info (for users)
+* `debug`: log debugging info (for developers)
+* `trace`: log finer-grained messages beyond debugging info
+
+*`--config.debug`*::
+  Show the fully compiled configuration as a debug log message (you must also have `--log.level=debug` enabled).
+  WARNING: The log message will include any 'password' options passed to plugin configs as plaintext, and may result
+  in plaintext passwords appearing in your logs!
+  
+*`-i, --interactive SHELL`*::
+  Drop to shell instead of running as normal. Valid shells are "irb" and "pry".
+
+*`-V, --version`*::
+  Emit the version of Logstash and its friends, then exit.
+
+*`-t, --config.test_and_exit`*::
+  Check configuration for valid syntax and then exit. Note that grok patterns are not checked for
+  correctness with this flag. Logstash can read multiple config files from a directory. If you combine this
+  flag with `--log.level=debug`, Logstash will log the combined config file, annotating
+  each config block with the source file it came from.
+  
+*`-r, --config.reload.automatic`*::
+  Monitor configuration changes and reload whenever the configuration is changed.
+  NOTE: Use SIGHUP to manually reload the config. The default is false.
+
+*`--config.reload.interval RELOAD_INTERVAL`*::
+  How frequently to poll the configuration location for changes, in seconds. The default is every 3 seconds.
+
+*`--http.host HTTP_HOST`*::
+  Web API binding host. This option specifies the bind address for the metrics REST endpoint. The default is "127.0.0.1".
+
+*`--http.port HTTP_PORT`*::
+  Web API http port. This option specifies the bind port for the metrics REST endpoint. The default is 9600-9700.
+  This setting accepts a range of the format 9600-9700. Logstash will pick up the first available port.
+  
+*`--log.format FORMAT`*::
+   Specify if Logstash should write its own logs in JSON form (one event per line) or in plain text
+   (using Ruby's Object#inspect). The default is "plain".
+
+*`--path.settings SETTINGS_DIR`*::
+  Set the directory containing the `logstash.yml` <<logstash-settings-file,settings file>> as well
+  as the log4j logging configuration. This can also be set through the LS_SETTINGS_DIR environment variable.
+  The default is the `config` directory under Logstash home. 
+                                   
 *`-h, --help`*::
   Print help
 


### PR DESCRIPTION
The list of options here now matches what I see when I run LS with the `-h` flag. If anything is missing or needs to be added, we'll need to add it to the `-h` output, too.  Please verify that the defaults are correct because I used what was listed in in the `-h` output. Not sure if I inadvertently used any calculated values.

Overview of changes:
* Reordered options to match `-h` output in the latest snapshot build in master.
* Fixed wording to better match output of `-h` (though the content in the doc does have slightly more info in places, which makes sense). I made the assumption that the `-h` output is more up-to-date than the docs, so please make sure that I haven't changed something in the doc that was actually correct.
* Added some options that were missing previously.



