### PR TITLE
Fix Suse Enterprise Linux 12 box setup and configuration

### DIFF
--- a/qa/rspec/commands/suse.rb
+++ b/qa/rspec/commands/suse.rb
@@ -49,7 +49,7 @@ module ServiceTester
         cmd = sudo_exec!("service #{package} status")
         stdout = cmd.stdout
       end
-      stdout.match(/#{package} started.$/)
+      stdout.match(/Active: active \(running\)/)
     end
 
     def service_manager(service, action, host=nil)

--- a/qa/sys/suse/sles-12/bootstrap.sh
+++ b/qa/sys/suse/sles-12/bootstrap.sh
@@ -6,4 +6,6 @@ zypper addrepo -t yast2 http://demeter.uni-regensburg.de/SLES12-x64/DVD2/ dvd2 |
 zypper addrepo http://download.opensuse.org/repositories/Java:Factory/SLE_12/Java:Factory.repo || true
 zypper --no-gpg-checks --non-interactive refresh
 zypper --non-interactive list-updates
-zypper --non-interactive --no-gpg-checks --quiet install --no-recommends java-1_8_0-openjdk-devel
+ln -s /usr/sbin/update-alternatives /usr/sbin/alternatives
+curl -L 'https://edelivery.oracle.com/otn-pub/java/jdk/8u77-b03/jdk-8u77-linux-x64.rpm' -H 'Accept-Encoding: gzip, deflate, sdch' -H 'Accept-Language: en-US,en;q=0.8' -H 'Upgrade-Insecure-Requests: 1' -H 'User-Agent: Mozilla/5.0' -H 'Cookie: oraclelicense=accept-securebackup-cookie;' -H 'Connection: keep-alive' --compressed -o oracle_jdk_1.8.rpm
+zypper -q -n --non-interactive install oracle_jdk_1.8.rpm


### PR DESCRIPTION
This PR fixes the SLES-12 box setup and configuration making:

* The bootstrap, basically installation of openjdk 8.
* The expected way command behave.

@untergeek this should fix the problem you have been facing with bootstrapping suse's