### PR TITLE
Make the package install command mandatory to succeed

### DIFF
--- a/qa/rspec/commands/base.rb
+++ b/qa/rspec/commands/base.rb
@@ -4,6 +4,8 @@ require_relative "system_helpers"
 
 module ServiceTester
 
+  class InstallException < Exception; end
+
   class Base
     LOCATION="/logstash-build".freeze
     LOGSTASH_PATH="/usr/share/logstash/".freeze

--- a/qa/rspec/commands/debian.rb
+++ b/qa/rspec/commands/debian.rb
@@ -22,9 +22,14 @@ module ServiceTester
 
     def install(package, host=nil)
       hosts = (host.nil? ? servers : Array(host))
+      errors = []
       at(hosts, {in: :serial}) do |_|
-        sudo_exec!("dpkg -i --force-confnew #{package}")
+        cmd = sudo_exec!("dpkg -i --force-confnew #{package}")
+        if cmd.exit_status != 0
+          errors << cmd.stderr.to_s
+        end
       end
+      raise InstallException.new(errors.join("\n")) unless errors.empty?
     end
 
     def uninstall(package, host=nil)

--- a/qa/rspec/commands/redhat.rb
+++ b/qa/rspec/commands/redhat.rb
@@ -22,12 +22,12 @@ module ServiceTester
 
     def install(package, host=nil)
       hosts  = (host.nil? ? servers : Array(host))
-      errors = {}
+      errors = []
       at(hosts, {in: :serial}) do |_host|
         cmd = sudo_exec!("yum install -y  #{package}")
-        errors[_host] = cmd.stderr unless cmd.stderr.empty?
+        errors << cmd.stderr unless cmd.stderr.empty?
       end
-      errors
+      raise InstallException.new(errors.join("\n")) unless errors.empty?
     end
 
     def uninstall(package, host=nil)

--- a/qa/rspec/commands/suse.rb
+++ b/qa/rspec/commands/suse.rb
@@ -19,12 +19,12 @@ module ServiceTester
 
     def install(package, host=nil)
       hosts  = (host.nil? ? servers : Array(host))
-      errors = {}
+      errors = []
       at(hosts, {in: :serial}) do |_host|
         cmd = sudo_exec!("zypper --no-gpg-checks --non-interactive install  #{package}")
-        errors[_host] = cmd.stderr unless cmd.stderr.empty?
+        errors << cmd.stderr unless cmd.stderr.empty?
       end
-      errors
+      raise InstallException.new(errors.join("\n")) unless errors.empty?
     end
 
     def uninstall(package, host=nil)


### PR DESCRIPTION
Currently in our QA acceptance framework if the install command failed, it failed silently what is bad for feedback is something wrong happend.

With this changes the install command is mandatory to succeed, otherwise it will raise an exception and the test will brake.

One example failure, would be if we forget to build the current branch artifacts, see

```bash

Failures:

  1) artifacts operation behaves like installable is installed on ubuntu-1204
     Failure/Error: logstash.install({:version => LOGSTASH_VERSION})
     ServiceTester::InstallException:
       dpkg: error processing /logstash-build/logstash-5.0.0-alpha6-SNAPSHOT.deb (--install):
        cannot access archive: No such file or directory
       Errors were encountered while processing:
        /logstash-build/logstash-5.0.0-alpha6-SNAPSHOT.deb
     Shared Example Group: "installable" called from ./acceptance/spec/lib/artifact_operation_spec.rb:12
     # ./rspec/commands/debian.rb:32:in `install'
     # ./rspec/commands.rb:62:in `install'
     # ./acceptance/spec/shared_examples/installed.rb:8:in `(root)'

Finished in 0.638 seconds (files took 1.75 seconds to load)
3 examples, 1 failure, 2 pending
```
this error is explicit to report something wrong has happened when accessing the local snapshot file.

@untergeek this change will help the overall test experience with more clear error reporting, your thougts are very welcome.