### PR TITLE
Add a breaking changes note concerning the private key format for the input beats.

### DIFF
--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -1,6 +1,14 @@
 [[breaking-changes]]
 == Breaking Changes
 
+**Changes in 2.4**
+=== Beats Output config change
+
+The Beats input has been reimplemented using Netty, an asynchronous IO framework for Java.
+This rewrite for performance brings it in line with Logstash Forwarder + LS combination.
+As part of the Beats refactor we now only supports private keys in the PKCS8, your existing key can be easily converted, refer to the
+https://www.openssl.org/docs/manmaster/apps/pkcs8.html[OpenSSL] documentation.
+
 **Breaking changes in 2.2**
 Although 2.2 is fully compatible with configurations from older versions, there are some architectural 
 changes to the pipeline that users need to take into consideration before deploying in production. 


### PR DESCRIPTION
The change of the private key format was a breaking change and should have been documented in the breaking change page.