### PR TITLE
Silence PUMA errors when an exception occur in logstash core

### DIFF
--- a/logstash-core/lib/logstash/webserver.rb
+++ b/logstash-core/lib/logstash/webserver.rb
@@ -70,10 +70,38 @@ module LogStash
       @server.stop(true) if @server
     end
 
+    # Puma uses by default the STDERR an the STDOUT for all his error
+    # handling, the server class accept custom a events object that can accept custom io object,
+    # so I just wrap the logger into an IO like object.
+    class IOWrappedLogger
+      def initialize(logger)
+        @logger = logger
+      end
+
+      def sync=(v)
+      end
+
+      def puts(str)
+        # The logger only accept a str as the first argument
+        @logger.debug(str.to_s)
+      end
+      alias_method :write, :puts
+      alias_method :<<, :puts
+    end
+
     def start_webserver(port)
+      # wrap any output that puma could generate into a wrapped logger
+      # use the puma namespace to override STDERR, STDOUT in that scope.
+      io_wrapped_logger = IOWrappedLogger.new(@logger)
+
+      ::Puma.const_set("STDERR", io_wrapped_logger) unless ::Puma.const_defined?("STDERR")
+      ::Puma.const_set("STDOUT", io_wrapped_logger) unless ::Puma.const_defined?("STDOUT")
+
       app = LogStash::Api::RackApp.app(logger, agent, http_environment)
 
-      @server = ::Puma::Server.new(app)
+      events = ::Puma::Events.new(io_wrapped_logger, io_wrapped_logger)
+
+      @server = ::Puma::Server.new(app, events)
       @server.add_tcp_listener(http_host, port)
 
       logger.info("Succesfully started Logstash API", :port => @port)

--- a/logstash-core/spec/support/helpers.rb
+++ b/logstash-core/spec/support/helpers.rb
@@ -1,0 +1,8 @@
+# encoding: utf-8
+def silence_warnings
+  warn_level = $VERBOSE
+  $VERBOSE = nil
+  yield
+ensure
+  $VERBOSE = warn_level
+end


### PR DESCRIPTION
When Logstash encounter an exception Puma was getting really noisy about
the file descriptor it used. Its because Puma has an infinite loop into
his reactor and when logstash is dying from the exception the FD get
removed under the puma threads.

Puma is using the constants `STDERR` and `STDOUT` to give information
about the errors, there is no easy way to provide Puma with a custom IO.
This PR hacks the Puma name to redefine both constants and send the
information to the logger using the `debug` level.

Also when we start the server we can pass a custom Puma::Events instance
to record some of the errors happening in the internal threads, this PR
also make sure we send all theses message to the configured logger.

Fixes: #5822