### PR TITLE
New Settings API endpoint that only supports Logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,8 @@ qa/.vm_ssh_config
 qa/.vagrant
 qa/acceptance/.vagrant
 qa/Gemfile.lock
-
+*.ipr
+*.iws
+*.iml
+.gradle
+.idea

--- a/logstash-core/lib/logstash/api/modules/logging.rb
+++ b/logstash-core/lib/logstash/api/modules/logging.rb
@@ -1,0 +1,52 @@
+# encoding: utf-8
+#
+java_import org.apache.logging.log4j.core.LoggerContext
+
+module LogStash
+  module Api
+    module Modules
+      class Logging < ::LogStash::Api::Modules::Base
+        # retrieve logging specific parameters from the provided settings
+        #
+        # return any unused configurations
+        def handle_logging(settings)
+          Hash[settings.map do |key, level|
+            if key.start_with?("logger.")
+              _, path = key.split("logger.")
+              LogStash::Logging::Logger::configure_logging(level, path)
+              nil
+            else
+              [key, level]
+            end
+          end]
+        end
+
+        put "/" do
+          begin
+            request.body.rewind
+            req_body = LogStash::Json.load(request.body.read)
+            remaining = handle_logging(req_body)
+            unless remaining.empty?
+              raise ArgumentError, I18n.t("logstash.web_api.logging.unrecognized_option", :option => remaining.keys.first)
+            end
+            respond_with({"acknowledged" => true})
+          rescue ArgumentError => e
+            status 400
+            respond_with({"error" => e.message})
+          end
+        end
+
+        get "/" do
+          context = LogStash::Logging::Logger::get_logging_context
+          if context.nil?
+            status 500
+            respond_with({"error" => "Logstash loggers were not initialized properly"})
+          else
+            loggers = context.getLoggers.map { |lgr| [lgr.getName, lgr.getLevel.name] }.sort
+            respond_with({"loggers" => Hash[loggers]})
+          end
+        end
+      end
+    end
+  end
+end

--- a/logstash-core/lib/logstash/api/rack_app.rb
+++ b/logstash-core/lib/logstash/api/rack_app.rb
@@ -5,6 +5,7 @@ require "logstash/api/modules/node"
 require "logstash/api/modules/node_stats"
 require "logstash/api/modules/plugins"
 require "logstash/api/modules/root"
+require "logstash/api/modules/logging"
 require "logstash/api/modules/stats"
 
 module LogStash
@@ -103,7 +104,8 @@ module LogStash
           "/_node" => LogStash::Api::Modules::Node,
           "/_stats" => LogStash::Api::Modules::Stats,
           "/_node/stats" => LogStash::Api::Modules::NodeStats,
-          "/_node/plugins" => LogStash::Api::Modules::Plugins
+          "/_node/plugins" => LogStash::Api::Modules::Plugins,
+          "/_node/logging" => LogStash::Api::Modules::Logging
         }
       end
     end

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -83,6 +83,9 @@ en:
           Hot threads at %{time}, busiestThreads=%{top_count}:
         thread_title: |-
           %{percent_of_cpu_time} % of cpu usage, state: %{thread_state}, thread name: '%{thread_name}'
+      logging:
+        unrecognized_option: |-
+          unrecognized option [%{option}]
     runner:
       short-help: |-
         usage:

--- a/logstash-core/spec/api/lib/api/logging_spec.rb
+++ b/logstash-core/spec/api/lib/api/logging_spec.rb
@@ -1,0 +1,41 @@
+# encoding: utf-8
+require_relative "../../spec_helper"
+require "sinatra"
+require "logstash/api/modules/logging"
+require "logstash/json"
+
+describe LogStash::Api::Modules::Logging do
+  include_context "api setup"
+
+  describe "#logging" do
+
+    context "when setting a logger's log level" do
+      before(:all) do
+        @runner = LogStashRunner.new
+        @runner.start
+      end
+
+      after(:all) do
+        @runner.stop
+      end
+
+      it "should return a positive acknowledgement on success" do
+        put '/', '{"logger.logstash": "ERROR"}'
+        payload = LogStash::Json.load(last_response.body)
+        expect(payload['acknowledged']).to eq(true)
+      end
+
+      it "should throw error when level is invalid" do
+        put '/', '{"logger.logstash": "invalid"}'
+        payload = LogStash::Json.load(last_response.body)
+        expect(payload['error']).to eq("invalid level[invalid] for logger[logstash]")
+      end
+
+      it "should throw error when key logger is invalid" do
+        put '/', '{"invalid" : "ERROR"}'
+        payload = LogStash::Json.load(last_response.body)
+        expect(payload['error']).to eq("unrecognized option [invalid]")
+      end
+    end
+  end
+end


### PR DESCRIPTION
All settings changes are implicitly transient.

# PUT API

```
PUT _node/settings
{"logger.logstash" : "error"}
```

with response:

```
{"host":"elasticbox","version":"5.0.0alpha6","http_address":"127.0.0.1:9600","acknowledged":true}
```

Or if there is something that goes wrong... you get an http status code of `400`

```
PUT _node/settings
{"logger.logstash" : "notalevel"}
```

with response:

```
{"host":"elasticbox","version":"5.0.0-alpha6","http_address":"127.0.0.1:9600","error":"invalid level[notalevel] for logger[logstash]"}
```

# Get API

```
curl -XGET "http://localhost:9600/_node/logging?pretty"
{
  "host" : "elasticbox-2.local",
  "version" : "6.0.0-alpha1",
  "http_address" : "127.0.0.1:9600",
  "loggers" : {
    "logstash.registry" : "WARN",
    "logstash.instrument.periodicpoller.os" : "WARN",
    "logstash.instrument.collector" : "WARN",
    "logstash.runner" : "WARN",
    "logstash.inputs.stdin" : "WARN",
    "logstash.outputs.stdout" : "WARN",
    "logstash.agent" : "WARN",
    "logstash.api.service" : "WARN",
    "logstash.instrument.periodicpoller.jvm" : "WARN",
    "logstash.pipeline" : "WARN",
    "logstash.codecs.line" : "WARN"
  }
```