### PR TITLE
update path.log to path.logs directory, and respect it in log4j2

### DIFF
--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -2,37 +2,26 @@ status = error
 name = LogstashPropertiesConfig
 
 appender.console.type = Console
-appender.console.name = STDOUT
-
-# Pattern Logging
-#
+appender.console.name = console
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %m%n
-
 # JSON Logging
-#
 # appender.console.layout.type = JSONLayout
 # appender.console.layout.compact = true
 # appender.console.layout.eventEol = true
 
-# Rolling File Appender
-#
-#property.filename = /tmp/logstash/logstash.log
-#
-# appender.rolling.type = RollingFile
-# appender.rolling.name = RollingFile
-# appender.rolling.fileName = ${filename}
-# appender.rolling.filePattern = /tmp/logstash/logstash-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz
-# appender.rolling.policies.type = Policies
-# appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
-# appender.rolling.policies.time.interval = 2
-# appender.rolling.policies.time.modulate = true
-# appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
-# appender.rolling.policies.size.size=100MB
-# appender.rolling.strategy.type = DefaultRolloverStrategy
-# appender.rolling.strategy.max = 5
-# appender.rolling.layout.type = PatternLayout
-# appender.rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %m%n
+appender.rolling.type = RollingFile
+appender.rolling.name = rolling
+appender.rolling.fileName = ${sys:ls.logs}/logstash.log
+appender.rolling.layout.type = PatternLayout
+appender.rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %.10000m%n
+appender.rolling.filePattern = ${sys:ls.logs}/logstash-%d{yyyy-MM-dd}.log
+appender.rolling.policies.type = Policies
+appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.rolling.policies.time.interval = 1
+appender.rolling.policies.time.modulate = true
 
 rootLogger.level = error
-rootLogger.appenderRef.stdout.ref = STDOUT
+rootLogger.appenderRef.console.ref = console
+rootLogger.appenderRef.rolling.ref = rolling
+

--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -107,7 +107,7 @@
 #   * trace
 #
 # log.level: warn
-# path.log:
+# path.logs: LOGSTASH_HOME/logs
 #
 # ------------ Other Settings --------------
 #

--- a/docs/static/command-line-flags.asciidoc
+++ b/docs/static/command-line-flags.asciidoc
@@ -65,8 +65,8 @@ added[5.0.0-alpha3, Command-line flags have dots instead of dashes in their name
   `PATH/logstash/TYPE/NAME.rb` where `TYPE` is `inputs`, `filters`, `outputs`, or `codecs`,
   and `NAME` is the name of the plugin.
 
-*`-l, --path.log FILE`*::
-  Write Logstash internal logs to the given file. Without this flag, Logstash will emit logs to standard output.
+*`-l, --path.logs PATH`*::
+  Directory to Write Logstash internal logs to.
 
 *`--log.level LEVEL`*::
  Set the log level for Logstash. Possible values are:

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -36,7 +36,6 @@ module LogStash
             Setting::String.new("log.level", "warn", true, ["fatal", "error", "warn", "debug", "info", "trace"]),
            Setting::Boolean.new("version", false),
            Setting::Boolean.new("help", false),
-            Setting::String.new("path.log", nil, false),
             Setting::String.new("log.format", "plain", true, ["json", "plain"]),
             Setting::String.new("http.host", "127.0.0.1"),
             Setting::PortRange.new("http.port", 9600..9700),

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -194,6 +194,8 @@ en:
         path_settings: |+
           Directory containing logstash.yml file. This can also be
           set through the LS_SETTINGS_DIR environment variable.
+        path_logs: |+
+            Directory to Write Logstash internal logs to.
         auto_reload: |+
           Monitor configuration changes and reload
           whenever it is changed.

--- a/pkg/centos/after-install.sh
+++ b/pkg/centos/after-install.sh
@@ -4,7 +4,7 @@ chown logstash:logstash /var/lib/logstash
 chmod 0644 /etc/logrotate.d/logstash
 sed -i \
   -e 's|# path.config:|path.config: /etc/logstash/conf.d|' \
-  -e 's|# path.log:|path.log: /var/log/logstash/logstash.log|' \
+  -e 's|# path.logs:|path.logs: /var/log/logstash|' \
   -e 's|# path.data:|path.data: /var/lib/logstash|' \
   /etc/logstash/logstash.yml
 /usr/share/logstash/bin/system-install /etc/logstash/startup.options

--- a/pkg/debian/after-install.sh
+++ b/pkg/debian/after-install.sh
@@ -7,7 +7,7 @@ chmod 755 /etc/logstash
 chmod 0644 /etc/logrotate.d/logstash
 sed -i \
   -e 's|# path.config:|path.config: /etc/logstash/conf.d|' \
-  -e 's|# path.log:|path.log: /var/log/logstash/logstash.log|' \
+  -e 's|# path.logs:|path.logs: /var/log/logstash|' \
   -e 's|# path.data:|path.data: /var/lib/logstash|' \
   /etc/logstash/logstash.yml
 /usr/share/logstash/bin/system-install /etc/logstash/startup.options

--- a/pkg/ubuntu/after-install.sh
+++ b/pkg/ubuntu/after-install.sh
@@ -6,7 +6,7 @@ chown logstash:logstash /var/lib/logstash
 chmod 0644 /etc/logrotate.d/logstash
 sed -i \
   -e 's|# path.config:|path.config: /etc/logstash/conf.d|' \
-  -e 's|# path.log:|path.log: /var/log/logstash/logstash.log|' \
+  -e 's|# path.logs:|path.logs: /var/log/logstash|' \
   -e 's|# path.data:|path.data: /var/lib/logstash|' \
   /etc/logstash/logstash.yml
 /usr/share/logstash/bin/system-install /etc/logstash/startup.options


### PR DESCRIPTION
With this PR, logs are emitted to both stdout and a rolling file called `logstash.log` in the `path.logs` directory