### PR TITLE
Set default log.level to INFO

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -101,12 +101,12 @@
 # Options for log.level:
 #   * fatal
 #   * error
-#   * warn (default)
-#   * info
+#   * warn
+#   * info (default)
 #   * debug
 #   * trace
 #
-# log.level: warn
+# log.level: info
 # path.logs: LOGSTASH_HOME/logs
 #
 # ------------ Other Settings --------------

--- a/docs/static/command-line-flags.asciidoc
+++ b/docs/static/command-line-flags.asciidoc
@@ -72,8 +72,8 @@ added[5.0.0-alpha3, Command-line flags have dots instead of dashes in their name
  Set the log level for Logstash. Possible values are:
 * `fatal`: log very severe error messages that will usually be followed by the application aborting
 * `error`: log errors
-* `warn`: log warnings (this is the default)
-* `info`: log verbose info (for users)
+* `warn`: log warnings
+* `info`: log verbose info (this is the default)
 * `debug`: log debugging info (for developers)
 * `trace`: log finer-grained messages beyond debugging info
 

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -54,7 +54,7 @@ class LogStash::Agent
 
   def execute
     @thread = Thread.current # this var is implicilty used by Stud.stop?
-    @logger.info("starting agent")
+    @logger.debug("starting agent")
 
     start_pipelines
     start_webserver
@@ -243,7 +243,7 @@ class LogStash::Agent
     pipeline = @pipelines[id]
     return unless pipeline.is_a?(LogStash::Pipeline)
     return if pipeline.ready?
-    @logger.info("starting pipeline", :id => id)
+    @logger.debug("starting pipeline", :id => id)
     Thread.new do
       LogStash::Util.set_thread_name("pipeline.#{id}")
       begin

--- a/logstash-core/lib/logstash/api/rack_app.rb
+++ b/logstash-core/lib/logstash/api/rack_app.rb
@@ -32,9 +32,9 @@ module LogStash
           status, headers, body = res
 
           if fatal_error?(status)
-            @logger.warn? && @logger.warn(LOG_MESSAGE, RackApp.log_metadata(status, env))
+            @logger.error? && @logger.error(LOG_MESSAGE, RackApp.log_metadata(status, env))
           else
-            @logger.info? && @logger.info(LOG_MESSAGE, RackApp.log_metadata(status, env))
+            @logger.debug? && @logger.debug(LOG_MESSAGE, RackApp.log_metadata(status, env))
           end
 
           res

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -33,7 +33,7 @@ module LogStash
                     Setting.new("path.plugins", Array, []),
             Setting::String.new("interactive", nil, false),
            Setting::Boolean.new("config.debug", false),
-            Setting::String.new("log.level", "warn", true, ["fatal", "error", "warn", "debug", "info", "trace"]),
+            Setting::String.new("log.level", "info", true, ["fatal", "error", "warn", "debug", "info", "trace"]),
            Setting::Boolean.new("version", false),
            Setting::Boolean.new("help", false),
             Setting::String.new("log.format", "plain", true, ["json", "plain"]),

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -162,12 +162,12 @@ module LogStash; class Pipeline
     wait_inputs
     transition_to_stopped
 
-    @logger.info("Input plugins stopped! Will shutdown filter/output workers.")
+    @logger.debug("Input plugins stopped! Will shutdown filter/output workers.")
 
     shutdown_flusher
     shutdown_workers
 
-    @logger.info("Pipeline #{@pipeline_id} has been shutdown")
+    @logger.debug("Pipeline #{@pipeline_id} has been shutdown")
 
     # exit code
     return 0
@@ -375,9 +375,9 @@ module LogStash; class Pipeline
 
     before_stop.call if block_given?
 
-    @logger.info "Closing inputs"
+    @logger.debug "Closing inputs"
     @inputs.each(&:do_stop)
-    @logger.info "Closed inputs"
+    @logger.debug "Closed inputs"
   end # def shutdown
 
   # After `shutdown` is called from an external thread this is called from the main thread to

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -219,7 +219,7 @@ class LogStash::Runner < Clamp::StrictCommand
 
     return start_shell(setting("interactive"), binding) if setting("interactive")
 
-    @settings.format_settings.each {|line| logger.info(line) }
+    @settings.format_settings.each {|line| logger.debug(line) }
 
     if setting("config.string").nil? && setting("path.config").nil?
       fail(I18n.t("logstash.runner.missing-configuration"))

--- a/logstash-core/lib/logstash/webserver.rb
+++ b/logstash-core/lib/logstash/webserver.rb
@@ -104,7 +104,7 @@ module LogStash
       @server = ::Puma::Server.new(app, events)
       @server.add_tcp_listener(http_host, port)
 
-      logger.info("Succesfully started Logstash API", :port => @port)
+      logger.info("Successfully started Logstash API endpoint", :port => @port)
 
       @server.run.join
     end

--- a/logstash-core/spec/api/lib/rack_app_spec.rb
+++ b/logstash-core/spec/api/lib/rack_app_spec.rb
@@ -76,14 +76,14 @@ describe LogStash::Api::RackApp do
     end
 
     it "should log good requests as info" do
-      expect(logger).to receive(:info?).and_return(true)
-      expect(logger).to receive(:info).with(LogStash::Api::RackApp::ApiLogger::LOG_MESSAGE, anything).once
+      expect(logger).to receive(:debug?).and_return(true)
+      expect(logger).to receive(:debug).with(LogStash::Api::RackApp::ApiLogger::LOG_MESSAGE, anything).once
       get "/good-page"
     end
 
     it "should log 5xx requests as warnings" do
-      expect(logger).to receive(:warn?).and_return(true)
-      expect(logger).to receive(:warn).with(LogStash::Api::RackApp::ApiLogger::LOG_MESSAGE, anything).once
+      expect(logger).to receive(:error?).and_return(true)
+      expect(logger).to receive(:error).with(LogStash::Api::RackApp::ApiLogger::LOG_MESSAGE, anything).once
       get "/service-unavailable"
     end
   end

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -21,6 +21,7 @@ describe LogStash::Runner do
     allow(LogStash::Runner).to receive(:logger).and_return(logger)
     allow(logger).to receive(:debug?).and_return(true)
     allow(logger).to receive(:subscribe).with(any_args)
+    allow(logger).to receive(:debug) {}
     allow(logger).to receive(:log) {}
     allow(logger).to receive(:info) {}
     allow(logger).to receive(:fatal) {}
@@ -279,7 +280,7 @@ describe LogStash::Runner do
       it "should set log level to warn" do
         args = ["--version"]
         subject.run("bin/logstash", args)
-        expect(logger.level).to eq(:warn)
+        expect(logger.level).to eq(:info)
       end
     end
     context "when setting to debug" do


### PR DESCRIPTION
sets default to INFO and updates some verbose logging to
more appropriate, less verbose log levels where it makes sense.

Closes #5735.
Closes #5893.