### PR TITLE
[fix-bug] respect log.format and path.logs from cli

### DIFF
--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -2,26 +2,39 @@ status = error
 name = LogstashPropertiesConfig
 
 appender.console.type = Console
-appender.console.name = console
+appender.console.name = plain_console
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %m%n
-# JSON Logging
-# appender.console.layout.type = JSONLayout
-# appender.console.layout.compact = true
-# appender.console.layout.eventEol = true
+
+appender.json_console.type = Console
+appender.json_console.name = json_console
+appender.json_console.layout.type = JSONLayout
+appender.json_console.layout.compact = true
+appender.json_console.layout.eventEol = true
 
 appender.rolling.type = RollingFile
-appender.rolling.name = rolling
+appender.rolling.name = plain_rolling
 appender.rolling.fileName = ${sys:ls.logs}/logstash.log
-appender.rolling.layout.type = PatternLayout
-appender.rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %.10000m%n
 appender.rolling.filePattern = ${sys:ls.logs}/logstash-%d{yyyy-MM-dd}.log
 appender.rolling.policies.type = Policies
 appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
 appender.rolling.policies.time.interval = 1
 appender.rolling.policies.time.modulate = true
+appender.rolling.layout.type = PatternLayout
+appender.rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %.10000m%n
 
-rootLogger.level = error
-rootLogger.appenderRef.console.ref = console
-rootLogger.appenderRef.rolling.ref = rolling
+appender.json_rolling.type = RollingFile
+appender.json_rolling.name = json_rolling
+appender.json_rolling.fileName = ${sys:ls.logs}/logstash.log
+appender.json_rolling.filePattern = ${sys:ls.logs}/logstash-%d{yyyy-MM-dd}.log
+appender.json_rolling.policies.type = Policies
+appender.json_rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.json_rolling.policies.time.interval = 1
+appender.json_rolling.policies.time.modulate = true
+appender.json_rolling.layout.type = JSONLayout
+appender.json_rolling.layout.compact = true
+appender.json_rolling.layout.eventEol = true
 
+rootLogger.level = ${sys:ls.log.level}
+rootLogger.appenderRef.console.ref = ${sys:ls.log.format}_console
+rootLogger.appenderRef.rolling.ref = ${sys:ls.log.format}_rolling

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -171,15 +171,6 @@ class LogStash::Runner < Clamp::StrictCommand
       end
     end
 
-    # Configure Logstash logging facility, this need to be done before everything else to
-    # make sure the logger has the correct settings and the log level is correctly defined.
-    # TODO(talevy): cleanly support `path.logs` setting in log4j
-    java.lang.System.setProperty("ls.logs", setting("path.logs"))
-    unless java.lang.System.getProperty("log4j.configurationFile")
-      log4j_config_location = ::File.join(setting("path.settings"), "log4j2.properties")
-      LogStash::Logging::Logger::initialize(log4j_config_location)
-    end
-
     super(*[args])
   end
 
@@ -188,7 +179,15 @@ class LogStash::Runner < Clamp::StrictCommand
     require "logstash/util/java_version"
     require "stud/task"
 
-    LogStash::Logging::Logger::configure_logging(setting("log.level"))
+    # Configure Logstash logging facility, this need to be done before everything else to
+    # make sure the logger has the correct settings and the log level is correctly defined.
+    java.lang.System.setProperty("ls.logs", setting("path.logs"))
+    java.lang.System.setProperty("ls.log.format", setting("log.format"))
+    java.lang.System.setProperty("ls.log.level", setting("log.level"))
+    unless java.lang.System.getProperty("log4j.configurationFile")
+      log4j_config_location = ::File.join(setting("path.settings"), "log4j2.properties")
+      LogStash::Logging::Logger::initialize(log4j_config_location)
+    end
 
     if setting("config.debug") && logger.debug?
       logger.warn("--config.debug was specified, but log.level was not set to \'debug\'! No config info will be logged.")


### PR DESCRIPTION
also change how `log.level` is configured at startup time to be set
as a property directly in the log4j2.properties file

Closes #5895