### PR TITLE
fix tests and bring back configure logging in runner

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -188,6 +188,8 @@ class LogStash::Runner < Clamp::StrictCommand
       log4j_config_location = ::File.join(setting("path.settings"), "log4j2.properties")
       LogStash::Logging::Logger::initialize(log4j_config_location)
     end
+    # override log level that may have been introduced from a custom log4j config file
+    LogStash::Logging::Logger::configure_logging(setting("log.level"))
 
     if setting("config.debug") && logger.debug?
       logger.warn("--config.debug was specified, but log.level was not set to \'debug\'! No config info will be logged.")


### PR DESCRIPTION
meant to override any custom log4j2.properties file that is introduced