### PR TITLE
remove commented value for path.logs in default settings file

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -107,7 +107,7 @@
 #   * trace
 #
 # log.level: info
-# path.logs: LOGSTASH_HOME/logs
+# path.logs:
 #
 # ------------ Other Settings --------------
 #


### PR DESCRIPTION
the build scripts rely on the value not being present to update with
appropriate value for the package