### PR TITLE
Fix a concurrency issue with the Webserver when overrideing Puma STDERR and STDOUT.

### DIFF
--- a/logstash-core/lib/logstash/patches/puma.rb
+++ b/logstash-core/lib/logstash/patches/puma.rb
@@ -1,0 +1,44 @@
+# encoding: utf-8
+#
+# Patch to replace the usage of STDERR and STDOUT
+# see: https://github.com/elastic/logstash/issues/5912
+module LogStash
+  class NullLogger
+    def self.debug(message)
+    end
+  end
+
+  # Puma uses by default the STDERR an the STDOUT for all his error
+  # handling, the server class accept custom a events object that can accept custom io object,
+  # so I just wrap the logger into an IO like object.
+  class IOWrappedLogger
+    def initialize(new_logger)
+      @logger_lock = Mutex.new
+      @logger = new_logger
+    end
+
+    def sync=(v)
+      # noop
+    end
+
+    def logger=(logger)
+      @logger_lock.synchronize { @logger = logger }
+    end
+
+    def puts(str)
+      # The logger only accept a str as the first argument
+      @logger_lock.synchronize { @logger.debug(str.to_s) }
+    end
+    alias_method :write, :puts
+    alias_method :<<, :puts
+  end
+
+end
+
+# Reopen the puma class to create a scoped STDERR and STDOUT
+# This operation is thread safe since its done at the class level
+# and force JRUBY to flush his classes cache.
+module Puma
+  STDERR = LogStash::IOWrappedLogger.new(LogStash::NullLogger)
+  STDOUT = LogStash::IOWrappedLogger.new(LogStash::NullLogger)
+end

--- a/logstash-core/spec/logstash/webserver_spec.rb
+++ b/logstash-core/spec/logstash/webserver_spec.rb
@@ -126,7 +126,7 @@ describe LogStash::WebServer do
   end
 end
 
-describe LogStash::WebServer::IOWrappedLogger do
+describe LogStash::IOWrappedLogger do
   let(:logger)  { spy("logger") }
   let(:message) { "foobar" }
 


### PR DESCRIPTION


This PR changes how we modify the STDOUT/STDERR in puma, instande of
using `const_set`, we override the constants using a module.
This operation should be thread safe and will make sure the STDERR are
correctly visible.

After when we receive the logger we can swap the null logger with the
real thing in a thread safe way.

Fixes: #5912