### PR TITLE
when a reload fails there should be at least one failure count

### DIFF
--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -501,7 +501,7 @@ describe LogStash::Agent do
       it "increases the failed reload count" do
         snapshot = subject.metric.collector.snapshot_metric
         value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:failures].value
-        expect(value).to be > 1
+        expect(value).to be > 0
       end
     end
   end


### PR DESCRIPTION
partial fix for https://github.com/elastic/logstash/issues/5914

addresses build failures such as https://logstash-ci.elastic.co/job/elastic+logstash+5.0+multijob-os-compatibility/140/os=debian/console
and 
https://logstash-ci.elastic.co/job/elastic+logstash+5.0+multijob-os-compatibility/137/os=oraclelinux/console