### PR TITLE
Fix buggy logstash --version flag pattern

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -284,7 +284,7 @@ class LogStash::Runner < Clamp::StrictCommand
   def show_version
     show_version_logstash
 
-    if logger.is_info_enabled
+    if logger.info?
       show_version_ruby
       show_version_java if LogStash::Environment.jruby?
       show_gems if logger.debug?


### PR DESCRIPTION
When using the --version flag like:

```bash
skywalker% ./bin/logstash  --path.settings=config --version
logstash 6.0.0-alpha1
[2016-09-15T15:31:17,741][FATAL][logstash.runner          ] An unexpected error occurred! {:error=>#<NoMethodError: undefined method `is_info_enabled' for #<LogStash::Logging::Logger:0x7671a060>>, :backtrace=>["/Users/purbon/work/logstash/logstash-core/lib/logstash/runner.rb:287:in `show_version'", "/Users/purbon/work/logstash/logstash-core/lib/logstash/runner.rb:217:in `execute'", "/Users/purbon/work/logstash/vendor/bundle/jruby/1.9/gems/clamp-0.6.5/lib/clamp/command.rb:67:in `run'", "/Users/purbon/work/logstash/logstash-core/lib/logstash/runner.rb:174:in `run'", "/Users/purbon/work/logstash/vendor/bundle/jruby/1.9/gems/clamp-0.6.5/lib/clamp/command.rb:132:in `run'", "/Users/purbon/work/logstash/lib/bootstrap/environment.rb:68:in `(root)'"]}
skywalker% echo $?
1
```
fails when accessing the logger instance, this PR provide a fix for this and bring back the expected output. Something like:

```bash
skywalker% ./bin/logstash  --path.settings=config --version 
logstash 6.0.0-alpha1
jruby 1.7.25 (1.9.3p551) 2016-04-13 867cb81 on Java HotSpot(TM) 64-Bit Server VM 1.8.0_91-b14 +jit [darwin-x86_64]
java 1.8.0_91 (Oracle Corporation)
jvm Java HotSpot(TM) 64-Bit Server VM / 25.91-b14
```

This is one of the reason why the acceptance test red at [logstash-ci](https://logstash-ci.elastic.co/job/elastic+logstash+master+multijob-acceptance/label=metal,suite=debian/123/console)

Fix #5924 