### PR TITLE
revert default logging to `warn`

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -101,12 +101,12 @@
 # Options for log.level:
 #   * fatal
 #   * error
-#   * warn
-#   * info (default)
+#   * warn (default)
+#   * info
 #   * debug
 #   * trace
 #
-# log.level: info
+# log.level: warn
 # path.logs:
 #
 # ------------ Other Settings --------------

--- a/docs/static/command-line-flags.asciidoc
+++ b/docs/static/command-line-flags.asciidoc
@@ -72,8 +72,8 @@ added[5.0.0-alpha3, Command-line flags have dots instead of dashes in their name
  Set the log level for Logstash. Possible values are:
 * `fatal`: log very severe error messages that will usually be followed by the application aborting
 * `error`: log errors
-* `warn`: log warnings
-* `info`: log verbose info (this is the default)
+* `warn`: log warnings (this is the default)
+* `info`: log verbose info
 * `debug`: log debugging info (for developers)
 * `trace`: log finer-grained messages beyond debugging info
 

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -116,12 +116,12 @@ The `logstash.yml` file includes the following settings:
 a|
 The log level. Valid options are:
 
+* `info`: log info messages
 * `warn`: log warnings
 * `quiet`: log errors
-* `verbose`: log verbose info (for users)
 * `debug`: log debugging info (for developers)
-
-| `warn`
+* `trace`: log trace info (for developers)
+* `fatal`: log fatal messages
  
 | `log.format`
 | The log format. Set to `json` to log in JSON format, or `plain` to use `Object#.inspect`.

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -33,7 +33,7 @@ module LogStash
                     Setting.new("path.plugins", Array, []),
             Setting::String.new("interactive", nil, false),
            Setting::Boolean.new("config.debug", false),
-            Setting::String.new("log.level", "info", true, ["fatal", "error", "warn", "debug", "info", "trace"]),
+            Setting::String.new("log.level", "warn", true, ["fatal", "error", "warn", "debug", "info", "trace"]),
            Setting::Boolean.new("version", false),
            Setting::Boolean.new("help", false),
             Setting::String.new("log.format", "plain", true, ["json", "plain"]),

--- a/logstash-core/lib/logstash/logging/logger.rb
+++ b/logstash-core/lib/logstash/logging/logger.rb
@@ -61,6 +61,10 @@ module LogStash
         @logger.trace(message, data)
       end
 
+      def log(level, message, data = {})
+        @logger.log(level, message, data)
+      end
+
       def self.configure_logging(level, path = LogManager::ROOT_LOGGER_NAME)
         @@config_mutex.synchronize { Configurator.setLevel(path, Level.valueOf(level)) }
       rescue Exception => e

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -152,7 +152,7 @@ module LogStash; class Pipeline
 
     start_workers
 
-    @logger.info("Pipeline #{@pipeline_id} started")
+    @logger.log(org.apache.logging.log4j.Level.forName("DIAG", 250), "Pipeline #{@pipeline_id} started")
 
     # Block until all inputs have stopped
     # Generally this happens if SIGINT is sent and `shutdown` is called from an external thread

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -280,7 +280,7 @@ describe LogStash::Runner do
       it "should set log level to warn" do
         args = ["--version"]
         subject.run("bin/logstash", args)
-        expect(logger.level).to eq(:info)
+        expect(logger.level).to eq(:warn)
       end
     end
     context "when setting to debug" do


### PR DESCRIPTION
this also introduces a DIAG level that is between ERROR and WARN so that
the "Pipeline started" message is still exposed


Note: The only reason this PR exists is due to the verbosity of many plugins mentioned here: https://github.com/elastic/logstash/issues/5930.