### PR TITLE
Amend redhat based package install acceptance tests

### DIFF
--- a/qa/acceptance/spec/shared_examples/installed.rb
+++ b/qa/acceptance/spec/shared_examples/installed.rb
@@ -5,6 +5,7 @@ require          'logstash/version'
 RSpec.shared_examples "installable" do |logstash|
 
   before(:each) do
+    logstash.uninstall
     logstash.install({:version => LOGSTASH_VERSION})
   end
 

--- a/qa/rspec/commands/redhat.rb
+++ b/qa/rspec/commands/redhat.rb
@@ -38,7 +38,6 @@ module ServiceTester
       hosts = (host.nil? ? servers : Array(host))
       at(hosts, {in: :serial}) do |_|
         sudo_exec!("yum remove -y #{package}")
-        sudo_exec!("rm -rf /etc/logstash")
       end
     end
 

--- a/qa/rspec/commands/redhat.rb
+++ b/qa/rspec/commands/redhat.rb
@@ -23,17 +23,22 @@ module ServiceTester
     def install(package, host=nil)
       hosts  = (host.nil? ? servers : Array(host))
       errors = []
+      exit_status = 0
       at(hosts, {in: :serial}) do |_host|
         cmd = sudo_exec!("yum install -y  #{package}")
+        exit_status += cmd.exit_status
         errors << cmd.stderr unless cmd.stderr.empty?
       end
-      raise InstallException.new(errors.join("\n")) unless errors.empty?
+      if exit_status > 0 
+        raise InstallException.new(errors.join("\n"))
+      end
     end
 
     def uninstall(package, host=nil)
       hosts = (host.nil? ? servers : Array(host))
       at(hosts, {in: :serial}) do |_|
         sudo_exec!("yum remove -y #{package}")
+        sudo_exec!("rm -rf /etc/logstash")
       end
     end
 


### PR DESCRIPTION
The artifact install acceptance test was installing every time a new logstash artifact, however and since the introduction of error checking for the installation, this has been broken because installing multiple times a package will return always exit code !=0.

This PR makes sure to fix this by:

* make redhat test uninstall a package after test are done.
* make sure install errors are raised only when an error code is != 0, not only when something is written at stderr.

This is a reason why acceptance test are read at [logstash-ci](https://logstash-ci.elastic.co/job/elastic+logstash+master+multijob-acceptance/label=metal,suite=redhat/125/console).

Fixes #5935 