### PR TITLE
Log4j1.x and SLF4j compatibility jars in classpath need to be included (#5781)

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -29,14 +29,19 @@ repositories {
 }
 
 dependencies {
-  runtime 'org.apache.logging.log4j:log4j-1.2-api:2.6.2'
-  compile 'org.apache.logging.log4j:log4j-api:2.6.2'
-  compile 'org.apache.logging.log4j:log4j-core:2.6.2'
   compile 'com.fasterxml.jackson.core:jackson-core:2.7.4'
   compile 'com.fasterxml.jackson.core:jackson-databind:2.7.4'
+  compile 'org.apache.logging.log4j:log4j-api:2.6.2'
+  compile 'org.apache.logging.log4j:log4j-core:2.6.2'
+
+  runtime 'org.apache.logging.log4j:log4j-slf4j-impl:2.6.2'
+  runtime 'org.apache.logging.log4j:log4j-jcl:2.6.2'
+  runtime 'org.apache.logging.log4j:log4j-1.2-api:2.6.2'
+    
   testCompile 'org.apache.logging.log4j:log4j-core:2.6.2:tests'
   testCompile 'org.apache.logging.log4j:log4j-api:2.6.2:tests'
   testCompile 'junit:junit:4.12'
+
   provided 'org.jruby:jruby-core:1.7.25'
 }
 


### PR DESCRIPTION
add log4j2 implementations for slf4j and jcl in dependencies (`build.gradle`), to fix issue #5781
