### PR TITLE
Update the configuration to make it work with the latest libbeat

### DIFF
--- a/qa/integration/services/filebeat_setup.sh
+++ b/qa/integration/services/filebeat_setup.sh
@@ -6,7 +6,7 @@ if [ -n "${FILEBEAT_VERSION}" ]; then
   echo "Filebeat version is $FILEBEAT_VERSION"
   version=$FILEBEAT_VERSION
 else
-   version=5.0.0-alpha5
+   version=5.0.0-alpha6
 fi
 
 setup_fb() {

--- a/qa/integration/specs/beats_input_spec.rb
+++ b/qa/integration/specs/beats_input_spec.rb
@@ -97,6 +97,9 @@ describe "Beat Input", :integration => true do
               "hosts" => ["localhost:5044"],
               "tls" => {
                 "certificate_authorities" => certificate_authorities
+              },
+              "ssl" => {
+                "certificate_authorities" => certificate_authorities
               }
             },
             "logging" => { "level" => "debug" }
@@ -123,6 +126,11 @@ describe "Beat Input", :integration => true do
                 "certificate_authorities" => certificate_authorities,
                 "certificate" => certificate,
                 "certificate_key" => ssl_key
+              },
+              "ssl" => {
+                "certificate_authorities" => certificate_authorities,
+                "certificate" => certificate,
+                "key" => ssl_key
               }
             },
             "logging" => { "level" => "debug" }


### PR DESCRIPTION
changes.

In beta1, some options changes occurred in filebeat with the name of the
ssl options.

Like theses:

tls=>ssl
certificate_key => key