### PR TITLE
Correctly calculate the time spend in the filter + output block

### DIFF
--- a/logstash-core/lib/logstash/instrument/metric_store.rb
+++ b/logstash-core/lib/logstash/instrument/metric_store.rb
@@ -188,6 +188,10 @@ module LogStash module Instrument
       end
     end
 
+    def size
+      @fast_lookup.size
+    end
+
     private
     def get_all
       @fast_lookup.values

--- a/logstash-core/spec/logstash/instrument/metric_store_spec.rb
+++ b/logstash-core/spec/logstash/instrument/metric_store_spec.rb
@@ -203,6 +203,12 @@ describe LogStash::Instrument::MetricStore do
       end
     end
 
+    describe "#size" do
+      it "returns the number of unique metrics" do
+        expect(subject.size).to eq(metric_events.size)
+      end
+    end
+
     describe "#each" do
       it "retrieves all the metric" do
         expect(subject.each.size).to eq(metric_events.size)


### PR DESCRIPTION
This PR fix an issue where the time was calculated but no work was done
on the event. This code make sure we have at least one event to start
recording the time spend.

This was causing the `events/duratin_in_millis` to not be in sync with
the time spend on the filtera, since `take_batch` was called in a tight
loop and could return an empty array this made the duration was way off.

Fixes: #5952