### PR TITLE
Fix generated jar dependencies for ls-event-java

### DIFF
--- a/logstash-core-event-java/lib/logstash-core-event-java_jars.rb
+++ b/logstash-core-event-java/lib/logstash-core-event-java_jars.rb
@@ -3,12 +3,12 @@ begin
   require 'jar_dependencies'
 rescue LoadError
   require 'com/fasterxml/jackson/core/jackson-databind/2.7.3/jackson-databind-2.7.3.jar'
-  require 'com/fasterxml/jackson/core/jackson-annotations/2.7.3/jackson-annotations-2.7.3.jar'
+  require 'com/fasterxml/jackson/core/jackson-annotations/2.7.0/jackson-annotations-2.7.0.jar'
   require 'com/fasterxml/jackson/core/jackson-core/2.7.3/jackson-core-2.7.3.jar'
 end
 
 if defined? Jars
   require_jar( 'com.fasterxml.jackson.core', 'jackson-databind', '2.7.3' )
-  require_jar( 'com.fasterxml.jackson.core', 'jackson-annotations', '2.7.3' )
+  require_jar( 'com.fasterxml.jackson.core', 'jackson-annotations', '2.7.0' )
   require_jar( 'com.fasterxml.jackson.core', 'jackson-core', '2.7.3' )
 end


### PR DESCRIPTION
This file was incorrectly checked-in with a jackson-annotations
dependency of `2.7.3`. jackson-databind depends on `2.7.0` of the
annotations library.