### PR TITLE
Require 'forwardable' in SafeURI

### DIFF
--- a/logstash-core/lib/logstash/util/safe_uri.rb
+++ b/logstash-core/lib/logstash/util/safe_uri.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/namespace"
 require "logstash/util"
+require "forwardable"
 
 # This class exists to quietly wrap a password string so that, when printed or
 # logged, you don't accidentally print the password itself.


### PR DESCRIPTION
SafeURI requires forwardable, which is included elsewhere in logstash. Plugin tests using this validation don't load logstash in the right order for this to work, so we need an explicit require here.