### PR TITLE
Remove coveralls dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem "logstash-core-plugin-api", :path => "./logstash-core-plugin-api"
 gem "file-dependencies", "0.1.6"
 gem "ci_reporter_rspec", "1.0.0", :group => :development
 gem "simplecov", :group => :development
-gem "coveralls", :group => :development
 gem "tins", "1.6", :group => :development
 gem "rspec", "~> 3.1.0", :group => :development
 gem "logstash-devutils", "~> 1.1", :group => :development

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "pry", "~> 0.10.1"  #(Ruby license)
   gem.add_runtime_dependency "stud", "~> 0.0.19" #(Apache 2.0 license)
   gem.add_runtime_dependency "clamp", "~> 0.6.5" #(MIT license) for command line args/flags
-  gem.add_runtime_dependency "term-ansicolor", "~> 1.3.2" # 1.4.0 uses ruby 2.0
   gem.add_runtime_dependency "filesize", "0.0.4" #(MIT license) for :bytes config validator
   gem.add_runtime_dependency "gems", "~> 0.8.3"  #(MIT license)
   gem.add_runtime_dependency "concurrent-ruby", "1.0.0"


### PR DESCRIPTION
1) I don't think we use coveralls to record coverage info
2) It depends terms-ansicolor which is GPL-2 which we cannot use.

Not sure how the license tests were passing before this.