### PR TITLE
Support for multiple pipelines in the same logstash instance [wip]

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -159,3 +159,4 @@
 #
 # Where to find custom plugins
 # path.plugins: []
+config.multi_pipeline: true

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -21,6 +21,7 @@ module LogStash
  Setting::WritableDirectory.new("path.data", ::File.join(LogStash::Environment::LOGSTASH_HOME, "data")),
     Setting::NullableString.new("config.string", nil, false),
            Setting::Boolean.new("config.test_and_exit", false),
+           Setting::Boolean.new("config.multi_pipeline", false),
            Setting::Boolean.new("config.reload.automatic", false),
            Setting::Numeric.new("config.reload.interval", 3), # in seconds
            Setting::Boolean.new("metric.collect", true),

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -22,6 +22,7 @@ module LogStash
     Setting::NullableString.new("config.string", nil, false),
            Setting::Boolean.new("config.test_and_exit", false),
            Setting::Boolean.new("config.multi_pipeline", false),
+                    Setting.new("pipelines", Array, []),
            Setting::Boolean.new("config.reload.automatic", false),
            Setting::Numeric.new("config.reload.interval", 3), # in seconds
            Setting::Boolean.new("metric.collect", true),

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -100,6 +100,8 @@ en:
         Configuration reloading also requires passing a configuration path with '-f yourlogstash.conf'
       invalid-shell: >-
         Invalid option for interactive Ruby shell. Use either "irb" or "pry"
+      multi-pipeline-with-config-flags: >-
+        Cannot use config.multi_pipeline with path.config (-f) or config.string (-w)
       configtest-flag-information: |-
         You may be interested in the '--configtest' flag which you can use to validate
         logstash's configuration before you choose to restart a running system.

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -366,4 +366,29 @@ describe LogStash::Runner do
       end
     end
   end
+
+  describe "setting config.multi_pipeline" do
+    subject { LogStash::Runner.new("") }
+    context "when enabled" do
+      before :each do
+        LogStash::SETTINGS.set("config.multi_pipeline", true)
+      end
+      context "and -f is enabled too" do
+        let(:args) { ["-f", Stud::Temporary.pathname] }
+
+        it "terminates runner and shows help" do
+          expect(subject).to receive(:signal_usage_error)
+          expect(subject.run(args)).to eq(1)
+        end
+      end
+      context "and -e is enabled too" do
+        let(:args) { ["-e", ""] }
+
+        it "terminates runner and shows help" do
+          expect(subject).to receive(:signal_usage_error)
+          expect(subject.run(args)).to eq(1)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Solves #6521 

This PR adds a new setting flag called `config.multi_pipeline` which will read the `pipelines` array property of the logstash.yml and load each as a new pipeline.

Example:

```yml
config.multi_pipeline: true
pipelines:
  - pipeline.id: line
    config.string: "input { generator {} } filter { sleep { time => 1 } } output { stdout { codec => line } }"
    pipeline.workers: 1
  - pipeline.id: dots
    config.string: "input { generator {} } filter { sleep { time => 0.25 } } output { stdout { codec => dots } }"
    pipeline.workers: 2
```

This is a work in progress PR as there are still some challenges to overcome:
- [ ] make metrics api work with multiple pipelines
- [ ] define which metrics should be configurable per pipeline. see https://github.com/elastic/logstash/issues/6492
