### PR TITLE
Fix messed up links in 5.x branch

### DIFF
--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -16,7 +16,7 @@ consistent with other Elastic products. Full directory layout is described in <<
 (in core and plugins) were too noisy at INFO level, so we had to audit log messages and switch some of them to DEBUG
 level.
 
-**Index Template:** The index template for 5.0 has been changed to reflect {ref}/breaking_50_mapping_changes.html[Elasticsearch's mapping changes]. Most
+**Index Template:** The index template for 5.0 has been changed to reflect {ref}breaking_50_mapping_changes.html[Elasticsearch's mapping changes]. Most
 importantly, the subfield for string multi-fields has changed from `.raw` to `.keyword` to match Elasticsearch's default
 behavior. The impact of this change to various user groups is detailed below:
 

--- a/docs/static/deploying.asciidoc
+++ b/docs/static/deploying.asciidoc
@@ -63,7 +63,7 @@ nodes. By default, Logstash uses the HTTP protocol to move data into the cluster
 You can use the Elasticsearch HTTP REST APIs to index data into the Elasticsearch cluster. These APIs represent the
 indexed data in JSON. Using the REST APIs does not require the Java client classes or any additional JAR
 files and has no performance disadvantages compared to the transport or node protocols. You can secure communications
-that use the HTTP REST APIs by using {xpack}/xpack-security.html[{security}], which supports SSL and HTTP basic authentication.
+that use the HTTP REST APIs by using {xpack}xpack-security.html[{security}], which supports SSL and HTTP basic authentication.
 
 When you use the HTTP protocol, you can configure the Logstash Elasticsearch output plugin to automatically
 load-balance indexing requests across a


### PR DESCRIPTION
These changes have already been pushed to 5.x in logstash-docs.