### PR TITLE
avoid logging exception objects in agent.rb

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -245,7 +245,7 @@ class LogStash::Agent < Clamp::Command
       @logger.terminal(e.message)
       @logger.unsubscribe(stdout_logs)
     end
-    @logger.warn(I18n.t("oops"), :error => e, :class => e.class.name, :backtrace => e.backtrace)
+    @logger.warn(I18n.t("oops"), :error => e.message, :class => e.class.name, :backtrace => e.backtrace)
     return 1
   ensure
     @log_fd.close if @log_fd
@@ -490,7 +490,7 @@ class LogStash::Agent < Clamp::Command
       begin
         pipeline.run
       rescue => e
-        @logger.error("Pipeline aborted due to error", :exception => e.class.name, :backtrace => e.backtrace)
+        @logger.error("Pipeline aborted due to error", :exception => e.class.name, :error => e.message, :backtrace => e.backtrace)
       end
     end
     sleep 0.01 until pipeline.ready?


### PR DESCRIPTION
also provide proper information about the error message instead of just the class name + backtrace.

This needs to be merged into 2.x and 2.4

fixes https://github.com/elastic/logstash/issues/5969