### PR TITLE
fix warning message when set USE_DRIP=1 and no JAVA_OPTS set in system

### DIFF
--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -107,7 +107,11 @@ setup_drip() {
   if [ "$USE_RUBY" = "1" ] ; then
     export JRUBY_OPTS="$JRUBY_OPTS -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify"
   else
-    JAVA_OPTS="$JAVA_OPTS -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify"
+    if [ -z "$JAVA_OPTS" ] ; then
+      LS_JAVA_OPTS="$LS_JAVA_OPTS -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify"
+    else
+      JAVA_OPTS="$JAVA_OPTS -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify"
+    fi
   fi
   export JAVACMD
   export DRIP_INIT_CLASS="org.jruby.main.DripMain"


### PR DESCRIPTION
When launching logstash with option `USE_DRIP=1` like 
    
    USE_DRIP=1 ./bin/logstash

in function `setup_drip`, it would set `$JAVA_OPTS`; then in follwing function `setup_java`, it would output warning message that default $JAVA_OPTS would be overwritten. But actually user did not set "default $JAVA_OPTS".

This fix would not output such warning message if user did not set $JAVA_OPTS