### PR TITLE
Deprecate uninstall for Plugin Manager

### DIFF
--- a/docs/static/glossary.asciidoc
+++ b/docs/static/glossary.asciidoc
@@ -68,7 +68,7 @@
  
 [[glossary-plugin-manager]]plugin manager::
   Accessed via the `bin/logstash-plugin` script, the plugin manager enables you to manage the lifecycle of
-  <<glossary-plugin,plugins>> in your Logstash deployment. You can install, uninstall, and upgrade plugins by using the
+  <<glossary-plugin,plugins>> in your Logstash deployment. You can install, remove, and upgrade plugins by using the
   plugin manager Command Line Interface (CLI).
 
 [[shipper]]shipper::

--- a/docs/static/plugin-manager.asciidoc
+++ b/docs/static/plugin-manager.asciidoc
@@ -3,7 +3,7 @@
 
 Logstash has a rich collection of input, filter, codec and output plugins. Plugins are available as self-contained
 packages called gems and hosted on RubyGems.org. The plugin manager accessed via `bin/logstash-plugin` script is used to manage the
-lifecycle of plugins in your Logstash deployment. You can install, uninstall and upgrade plugins using the Command Line
+lifecycle of plugins in your Logstash deployment. You can install, remove and upgrade plugins using the Command Line
 Interface (CLI) invocations described below.
 
 [float]
@@ -94,7 +94,7 @@ If you need to remove plugins from your Logstash installation:
 
 [source,shell]
 ----------------------------------
-bin/logstash-plugin uninstall logstash-output-kafka
+bin/logstash-plugin remove logstash-output-kafka
 ----------------------------------
 
 [[proxy-plugins]]

--- a/lib/pluginmanager/main.rb
+++ b/lib/pluginmanager/main.rb
@@ -16,6 +16,7 @@ require "pluginmanager/util"
 require "pluginmanager/gemfile"
 require "pluginmanager/install"
 require "pluginmanager/uninstall"
+require "pluginmanager/remove"
 require "pluginmanager/list"
 require "pluginmanager/update"
 require "pluginmanager/pack"
@@ -27,13 +28,15 @@ module LogStash
     class Error < StandardError; end
 
     class Main < Clamp::Command
-      subcommand "install", "Install a plugin", LogStash::PluginManager::Install
-      subcommand "uninstall", "Uninstall a plugin", LogStash::PluginManager::Uninstall
+      subcommand "list", "List all installed Logstash plugins", LogStash::PluginManager::List
+      subcommand "install", "Install a Logstash plugin", LogStash::PluginManager::Install
+      subcommand "remove", "Remove a Logstash plugin", LogStash::PluginManager::Remove
       subcommand "update", "Update a plugin", LogStash::PluginManager::Update
       subcommand "pack", "Package currently installed plugins", LogStash::PluginManager::Pack
       subcommand "unpack", "Unpack packaged plugins", LogStash::PluginManager::Unpack
       subcommand "list", "List all installed plugins", LogStash::PluginManager::List
       subcommand "generate", "Create the foundation for a new plugin", LogStash::PluginManager::Generate
+      subcommand "uninstall", "Uninstall a plugin. Deprecated: Please use remove instead", LogStash::PluginManager::Uninstall
     end
   end
 end

--- a/lib/pluginmanager/remove.rb
+++ b/lib/pluginmanager/remove.rb
@@ -1,16 +1,13 @@
 # encoding: utf-8
 require "pluginmanager/command"
 
-# TODO: SR: Delete this file in 6.0, as we deprecated uninstall in favar of remove to be consistent with the stack
-
-class LogStash::PluginManager::Uninstall < LogStash::PluginManager::Command
+class LogStash::PluginManager::Remove < LogStash::PluginManager::Command
 
   parameter "PLUGIN", "plugin name"
 
   def execute
-    puts "uninstall subcommand is deprecated and will be removed in the next major version. Please use logstash-plugin remove instead."
-
     signal_error("File #{LogStash::Environment::GEMFILE_PATH} does not exist or is not writable, aborting") unless File.writable?(LogStash::Environment::GEMFILE_PATH)
+
     ##
     # Need to setup the bundler status to enable uninstall of plugins
     # installed as local_gems, otherwise gem:specification is not
@@ -27,7 +24,7 @@ class LogStash::PluginManager::Uninstall < LogStash::PluginManager::Command
     if gemfile.remove(plugin)
       gemfile.save
 
-      puts("Uninstalling #{plugin}")
+      puts("Removing #{plugin}")
 
       # any errors will be logged to $stderr by invoke!
       # output, exception = LogStash::Bundler.invoke!(:install => true, :clean => true)
@@ -37,7 +34,7 @@ class LogStash::PluginManager::Uninstall < LogStash::PluginManager::Command
     end
   rescue => exception
     gemfile.restore!
-    report_exception("Uninstall Aborted", exception)
+    report_exception("Remove Aborted", exception)
   ensure
     display_bundler_output(output)
   end

--- a/qa/acceptance/spec/lib/cli_operation_spec.rb
+++ b/qa/acceptance/spec/lib/cli_operation_spec.rb
@@ -4,6 +4,7 @@ require_relative "../shared_examples/cli/logstash/version"
 require_relative "../shared_examples/cli/logstash-plugin/install"
 require_relative "../shared_examples/cli/logstash-plugin/list"
 require_relative "../shared_examples/cli/logstash-plugin/uninstall"
+require_relative "../shared_examples/cli/logstash-plugin/remove"
 require_relative "../shared_examples/cli/logstash-plugin/update"
 
 # This is the collection of test for the CLI interface, this include the plugin manager behaviour, 
@@ -16,6 +17,7 @@ describe "CLI operation" do
     it_behaves_like "logstash install", logstash
     it_behaves_like "logstash list", logstash
     it_behaves_like "logstash uninstall", logstash
+    it_behaves_like "logstash remove", logstash
     it_behaves_like "logstash update", logstash
   end
 end

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/remove.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/remove.rb
@@ -1,0 +1,35 @@
+# encoding: utf-8
+require_relative "../../../spec_helper"
+require "logstash/version"
+require "fileutils"
+
+shared_examples "logstash uninstall" do |logstash|
+  describe "logstash uninstall on #{logstash.hostname}" do
+    before :each do
+      logstash.install({:version => LOGSTASH_VERSION})
+    end
+
+    after :each do
+      logstash.uninstall
+    end
+
+    context "when the plugin isn't installed" do
+      it "fails to remove it" do
+        result = logstash.run_command_in_path("bin/logstash-plugin remove logstash-filter-qatest")
+        expect(result.stderr).to match(/ERROR: Remove Aborted, message: This plugin has not been previously installed, aborting/)
+      end
+    end
+
+    # Disabled because of this bug https://github.com/elastic/logstash/issues/5286
+    xcontext "when the plugin is installed" do
+      it "succesfully removes it" do
+        result = logstash.run_command_in_path("bin/logstash-plugin install logstash-filter-qatest")
+        expect(logstash).to have_installed?("logstash-filter-qatest")
+
+        result = logstash.run_command_in_path("bin/logstash-plugin remove logstash-filter-qatest")
+        expect(result.stdout).to match(/^Removing logstash-filter-qatest/)
+        expect(logstash).not_to have_installed?("logstash-filter-qatest")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds remove and deprecates uninstall to be consistent with rest of Elastic stack

Fixes #6041