### PR TITLE
fix for cancelled events issue #6055

### DIFF
--- a/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
@@ -148,7 +148,10 @@ module LogStash; module Util
         @shutdown_signal_received = false
         @flush_signal_received = false
         @originals = Hash.new
-        @cancelled = Hash.new
+
+        # TODO: disabled for https://github.com/elastic/logstash/issues/6055 - will have to properly refactor
+        # @cancelled = Hash.new
+
         @generated = Hash.new
         @iterating_temp = Hash.new
         @iterating = false # Atomic Boolean maybe? Although batches are not shared across threads
@@ -168,17 +171,22 @@ module LogStash; module Util
       end
 
       def cancel(event)
-        @cancelled[event] = true
+        # TODO: disabled for https://github.com/elastic/logstash/issues/6055 - will have to properly refactor
+        raise("cancel is unsupported")
+        # @cancelled[event] = true
       end
 
       def each(&blk)
         # take care not to cause @originals or @generated to change during iteration
         @iterating = true
+
+        # below the checks for @cancelled.include?(e) have been replaced by e.cancelled?
+        # TODO: for https://github.com/elastic/logstash/issues/6055 = will have to properly refactor
         @originals.each do |e, _|
-          blk.call(e) unless @cancelled.include?(e)
+          blk.call(e) unless e.cancelled?
         end
         @generated.each do |e, _|
-          blk.call(e) unless @cancelled.include?(e)
+          blk.call(e) unless e.cancelled?
         end
         @iterating = false
         update_generated
@@ -197,7 +205,9 @@ module LogStash; module Util
       end
 
       def cancelled_size
-        @cancelled.size
+      # TODO: disabled for https://github.com/elastic/logstash/issues/6055 = will have to properly refactor
+      raise("cancelled_size is unsupported ")
+        # @cancelled.size
       end
 
       def shutdown_signal_received?

--- a/logstash-core/spec/support/mocks_classes.rb
+++ b/logstash-core/spec/support/mocks_classes.rb
@@ -25,3 +25,25 @@ class DummyOutput < LogStash::Outputs::Base
     @num_closes = 1
   end
 end
+
+class DummyOutputWithEventsArray < LogStash::Outputs::Base
+  config_name "dummyoutput2"
+  milestone 2
+
+  attr_reader :events
+
+  def initialize(params={})
+    super
+    @events = []
+  end
+
+  def register
+  end
+
+  def receive(event)
+    @events << event
+  end
+
+  def close
+  end
+end


### PR DESCRIPTION
Solves the bug described in issue #6055 where dropped events are still being output.

The problem is that Event cancellation is done by mutating the Event itself by calling Event#cancel and thus the Batch object is not informed of this change and cannot keep an internal state of the cancelled events as the events are processed through the `filter_func`. 

Ultimately the proper fix will be to surface the Batch object as the main container for keeping tabs on the Events lifecycle (originals, generated, cancelled, etc). 