### PR TITLE
Fix user feedback message for package install

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -162,10 +162,14 @@ class LogStash::Runner < Clamp::StrictCommand
 
     begin
       LogStash::SETTINGS.from_yaml(LogStash::SETTINGS.get("path.settings"))
+    rescue Errno::ENOENT 
+      unless cli_help?(args)
+        $stderr.puts "ERROR: Logstash requires a setting file which is typically located in $LS_HOME/config or /etc/logstash. If you installed Logstash through a package and are starting it manually, please specify the location to this settings file by passing --path.settings /etc/logstash"
+        return 1
+      end   
     rescue => e
       # abort unless we're just looking for the help
-      if (["--help", "-h"] & args).empty?
-        $stderr.puts "INFO: Logstash requires a setting file which is typically located in $LS_HOME/config or /etc/logstash. If you installed Logstash through a package and are starting it manually please specify the location to this settings file by passing in \"--path.settings=/path/..\""
+      unless cli_help?(args)
         $stderr.puts "ERROR: Failed to load settings file from \"path.settings\". Aborting... path.setting=#{LogStash::SETTINGS.get("path.settings")}, exception=#{e.class}, message=>#{e.message}"
         return 1
       end
@@ -410,5 +414,11 @@ class LogStash::Runner < Clamp::StrictCommand
       nil
     end
   end
+  
+  # is the user asking for CLI help subcommand?
+  def cli_help?(args)
+    # I know, double negative
+    !(["--help", "-h"] & args).empty?
+  end  
 
 end

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -112,8 +112,7 @@ en:
           longer available. %{extra} If you have any questions about this, you
           are invited to visit https://discuss.elastic.co/c/logstash and ask.
         file-not-found: |-
-          No config files found: %{path}
-          Can you make sure this path is a logstash config file?
+          No config files found: %{path}. Can you make sure this path is a logstash config file?
         scheme-not-supported: |-
           URI scheme not supported: %{path}
           Either pass a local file path or "file|http://" URI


### PR DESCRIPTION
We were showing both INFO and ERROR for all cases which is confusing

```
sudo -u logstash bin/logstash -e 'input { stdin { } } output { stdout {} }'
INFO: Logstash has a new settings file which defines start up time settings. This file is typically located in $LS_HOME/config or /etc/logstash. If you installed Logstash through a package and are starting it manually please specify the location to this settings file by passing in "--path.settings=/path/.." in the command line options
ERROR: Failed to load settings file from "path.settings". Aborting... path.setting=/usr/share/logstash/config, exception=Errno::ENOENT, message=>No such file or directory - /usr/share/logstash/config/logstash.yml
```

now:

```
ubuntu@ip-10-0-2-201:/usr/share/logstash$ sudo -u logstash bin/logstash -e 'input { stdin { } } output { stdout {} }'
ERROR: Logstash requires a setting file which is typically located in $LS_HOME/config or /etc/logstash. If you installed Logstash through a packa....
```
