### PR TITLE
Fix bug where old-style plugin libraries were not being loaded

### DIFF
--- a/logstash-core/lib/logstash/plugins/registry.rb
+++ b/logstash-core/lib/logstash/plugins/registry.rb
@@ -65,6 +65,8 @@ module LogStash
       else
         # The plugin was defined directly in the code, so there is no need to use the
         # require way of loading classes
+        @logger.info("Plugin doesn't appear to be installed with the plugin manager. I will try to load it the old and deprecated way.", :path => plugin.path, :type => type, :name => plugin_name)
+        require plugin.path
         return @registry[plugin.path] if registered?(plugin.path)
         raise LoadError
       end


### PR DESCRIPTION
This fixes a bug found in 5.0.0rc1 where plugins in `path.plugins` (old-style, deprecated, should not be used anymore, please stop writing plugins like this!) sourced plugins would not be loaded.

I am on the fence about merging this, and would rather just this feature and require folks to write plugins as gems. The ruby filter can continue to exist to support users who want single-file plugins..
