### PR TITLE
Update old references to verbose or debug modes

### DIFF
--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -215,7 +215,7 @@ en:
           Specifying once will show 'informational'
           logs. Specifying twice will show 'debug'
           logs. This flag is deprecated. You should use
-          --verbose or --debug instead.
+          --log-level=info or --log-level=debug instead.
         version: |+
           Emit the version of logstash and its friends,
           then exit.
@@ -253,7 +253,7 @@ en:
         agent: |+
           Specify an alternate agent plugin name.
         config_debug: |+
-          Print the compiled config ruby code out as a debug log (you must also have --debug enabled).
+          Print the compiled config ruby code out as a debug log (you must also have --log.level=debug enabled).
           WARNING: This will include any 'password' options passed to plugin configs as plaintext, and may result
           in plaintext passwords appearing in your logs!
         log_format: |+
@@ -264,7 +264,7 @@ en:
           DEPRECATED: use --log.level=debug instead.
         verbose: |+
           Set the log level to info.
-          DEPRECATED: use --log.level=verbose instead.
+          DEPRECATED: use --log.level=info instead.
         quiet: |+
           Set the log level to info.
           DEPRECATED: use --log.level=quiet instead.


### PR DESCRIPTION
Replace with --log-level=verbose and --log-level=debug

Fixes #6095