### PR TITLE
Fix test for LogStash::Setting::WritableDirectory#set

### DIFF
--- a/logstash-core/spec/logstash/settings/writable_directory_spec.rb
+++ b/logstash-core/spec/logstash/settings/writable_directory_spec.rb
@@ -1,12 +1,17 @@
 # encoding: utf-8
 require "spec_helper"
 require "logstash/settings"
-require "stud/temporary"
+require "tmpdir"
 require "socket" # for UNIXSocket
+
+
+
 
 describe LogStash::Setting::WritableDirectory do
   let(:mode_rx) { 0555 }
-  let(:parent) { Stud::Temporary.pathname }
+  # linux is 108, Macos is 104, so use a safe value
+  # Stud::Temporary.pathname, will exceed that size without adding anything
+  let(:parent) { File.join(Dir.tmpdir, Time.now.to_f.to_s) }
   let(:path) { File.join(parent, "fancy") }
 
   before { Dir.mkdir(parent) }

--- a/logstash-core/spec/logstash/settings/writable_directory_spec.rb
+++ b/logstash-core/spec/logstash/settings/writable_directory_spec.rb
@@ -4,9 +4,6 @@ require "logstash/settings"
 require "tmpdir"
 require "socket" # for UNIXSocket
 
-
-
-
 describe LogStash::Setting::WritableDirectory do
   let(:mode_rx) { 0555 }
   # linux is 108, Macos is 104, so use a safe value


### PR DESCRIPTION
path for unix domain socket have a hard limit of 104 chars on macos and 108 on
linux, using `Stud::Temporary.pathname` to generate the path will exceed
that limit. So we will use a custom generation of using the tmpdir +
Time.now.to_f which should be good enough for this test.

Fixes: #6108