### PR TITLE
Slowlog For Filters in Logstash

### DIFF
--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -35,6 +35,49 @@ appender.json_rolling.layout.type = JSONLayout
 appender.json_rolling.layout.compact = true
 appender.json_rolling.layout.eventEol = true
 
+
 rootLogger.level = ${sys:ls.log.level}
 rootLogger.appenderRef.console.ref = ${sys:ls.log.format}_console
 rootLogger.appenderRef.rolling.ref = ${sys:ls.log.format}_rolling
+
+# Slowlog
+
+appender.console_slowlog.type = Console
+appender.console_slowlog.name = plain_console_slowlog
+appender.console_slowlog.layout.type = PatternLayout
+appender.console_slowlog.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %m%n
+
+appender.json_console_slowlog.type = Console
+appender.json_console_slowlog.name = json_console_slowlog
+appender.json_console_slowlog.layout.type = JSONLayout
+appender.json_console_slowlog.layout.compact = true
+appender.json_console_slowlog.layout.eventEol = true
+
+appender.rolling_slowlog.type = RollingFile
+appender.rolling_slowlog.name = plain_rolling_slowlog
+appender.rolling_slowlog.fileName = ${sys:ls.logs}/logstash-slowlog-${sys:ls.log.format}.log
+appender.rolling_slowlog.filePattern = ${sys:ls.logs}/logstash-slowlog-${sys:ls.log.format}-%d{yyyy-MM-dd}.log
+appender.rolling_slowlog.policies.type = Policies
+appender.rolling_slowlog.policies.time.type = TimeBasedTriggeringPolicy
+appender.rolling_slowlog.policies.time.interval = 1
+appender.rolling_slowlog.policies.time.modulate = true
+appender.rolling_slowlog.layout.type = PatternLayout
+appender.rolling_slowlog.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %.10000m%n
+
+appender.json_rolling_slowlog.type = RollingFile
+appender.json_rolling_slowlog.name = json_rolling_slowlog
+appender.json_rolling_slowlog.fileName = ${sys:ls.logs}/logstash-slowlog-${sys:ls.log.format}.log
+appender.json_rolling_slowlog.filePattern = ${sys:ls.logs}/logstash-slowlog-${sys:ls.log.format}-%d{yyyy-MM-dd}.log
+appender.json_rolling_slowlog.policies.type = Policies
+appender.json_rolling_slowlog.policies.time.type = TimeBasedTriggeringPolicy
+appender.json_rolling_slowlog.policies.time.interval = 1
+appender.json_rolling_slowlog.policies.time.modulate = true
+appender.json_rolling_slowlog.layout.type = JSONLayout
+appender.json_rolling_slowlog.layout.compact = true
+appender.json_rolling_slowlog.layout.eventEol = true
+
+logger.slowlog.name = slowlog
+logger.slowlog.level = trace
+logger.slowlog.appenderRef.console_slowlog.ref = ${sys:ls.log.format}_console_slowlog
+logger.slowlog.appenderRef.rolling_slowlog.ref = ${sys:ls.log.format}_rolling_slowlog
+logger.slowlog.additivity = false

--- a/docs/static/logging.asciidoc
+++ b/docs/static/logging.asciidoc
@@ -21,6 +21,38 @@ Logstash ships with a `log4j2.properties` file with out-of-the-box settings. You
 rotation policy, type, and other https://logging.apache.org/log4j/2.x/manual/configuration.html#Loggers[log4j2 configuration]. 
 You must restart Lostash to apply any changes that you make to this file.
 
+==== Slowlog
+
+Slow-log for Logstash adds the ability to log when a specific event takes an abnormal amount of time to make its way
+through the pipeline. Just like the normal application log, you can find slow-logs in your `--path.logs` directory.
+Slowlog is configured in the `logstash.yml` settings file with the following options:
+
+------------------------------
+[source]
+slowlog.threshold.warn (default: -1)
+slowlog.threshold.info (default: -1)
+slowlog.threshold.debug (default: -1)
+slowlog.threshold.trace (default: -1)
+------------------------------
+
+By default, these values are set to `-1nanos` to represent an infinite threshold where no slowlog will be invoked. These `slowlog.threshold`
+fields are configured using a time-value format which enables a wide range of trigger intervals. The positive numeric ranges
+can be specified using the following time units: `nanos` (nanoseconds), `micros` (microseconds), `ms` (milliseconds), `s` (second), `m` (minute),
+`h` (hour), `d` (day).
+
+Here is an example:
+
+------------------------------
+[source]
+slowlog.threshold.warn: 2s
+slowlog.threshold.info 1s
+slowlog.threshold.debug 500ms
+slowlog.threshold.trace 100ms
+------------------------------
+
+In the above configuration, events that take longer than two seconds to be processed within a filter will be logged.
+The logs will include the full event and filter configuration that are responsible for the slowness.
+
 ==== Logging APIs
 
 You could modify the `log4j2.properties` file and restart your Logstash, but that is both tedious and leads to unnecessary 

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -43,6 +43,10 @@ module LogStash
             Setting::String.new("queue.type", "memory", true, ["persisted", "memory", "memory_acked"]),
             Setting::Bytes.new("queue.page_capacity", "250mb"),
             Setting::Numeric.new("queue.max_events", 0), # 0 is unlimited
+            Setting::TimeValue.new("slowlog.threshold.warn", "-1"),
+            Setting::TimeValue.new("slowlog.threshold.info", "-1"),
+            Setting::TimeValue.new("slowlog.threshold.debug", "-1"),
+            Setting::TimeValue.new("slowlog.threshold.trace", "-1")
   ].each {|setting| SETTINGS.register(setting) }
 
   # Compute the default queue path based on `path.data`

--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -46,6 +46,12 @@ class LogStash::Plugin
 
   def initialize(params=nil)
     @logger = self.logger
+    # need to access settings statically because plugins are initialized in config_ast with no context.
+    settings = LogStash::SETTINGS
+    @slow_logger = self.slow_logger(settings.get("slowlog.threshold.warn"),
+                                    settings.get("slowlog.threshold.info"),
+                                    settings.get("slowlog.threshold.debug"),
+                                    settings.get("slowlog.threshold.trace"))
     @params = LogStash::Util.deep_clone(params)
     # The id should always be defined normally, but in tests that might not be the case
     # In the future we may make this more strict in the Plugin API

--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -2,6 +2,7 @@
 require "logstash/util/loggable"
 require "fileutils"
 require "logstash/util/byte_value"
+require "logstash/util/time_value"
 
 module LogStash
   class Settings
@@ -463,7 +464,19 @@ module LogStash
         end
       end
     end
+
+    class TimeValue < Coercible
+      def initialize(name, default, strict=true, &validator_proc)
+        super(name, ::Fixnum, default, strict, &validator_proc)
+      end
+
+      def coerce(value)
+        return value if value.is_a?(::Fixnum)
+        Util::TimeValue.from_value(value).to_nanos
+      end
+    end
   end
+
 
   SETTINGS = Settings.new
 end

--- a/logstash-core/lib/logstash/util/loggable.rb
+++ b/logstash-core/lib/logstash/util/loggable.rb
@@ -5,14 +5,26 @@ require "logstash/namespace"
 module LogStash module Util
   module Loggable
     def self.included(klass)
-      def klass.logger
+
+      def klass.log4j_name
         ruby_name = self.name || self.class.name || self.class.to_s
-        log4j_name = ruby_name.gsub('::', '.').downcase
+        ruby_name.gsub('::', '.').downcase
+      end
+
+      def klass.logger
         @logger ||= LogStash::Logging::Logger.new(log4j_name)
+      end
+
+      def klass.slow_logger(warn_threshold, info_threshold, debug_threshold, trace_threshold)
+        @slow_logger ||= LogStash::Logging::SlowLogger.new(log4j_name, warn_threshold, info_threshold, debug_threshold, trace_threshold)
       end
 
       def logger
         self.class.logger
+      end
+
+      def slow_logger(warn_threshold, info_threshold, debug_threshold, trace_threshold)
+        self.class.slow_logger(warn_threshold, info_threshold, debug_threshold, trace_threshold)
       end
     end
   end

--- a/logstash-core/lib/logstash/util/time_value.rb
+++ b/logstash-core/lib/logstash/util/time_value.rb
@@ -1,0 +1,70 @@
+module LogStash
+  module Util
+    class TimeValue
+      def initialize(duration, time_unit)
+        @duration = duration
+        @time_unit = time_unit
+      end
+
+      def self.from_value(value)
+        if value.is_a?(TimeValue)
+          TimeValue.new(value.duration, value.time_unit)
+        elsif value.is_a?(::String)
+          normalized = value.downcase.strip
+          if normalized.end_with?("nanos")
+            TimeValue.new(parse(normalized, 5), :nanosecond)
+          elsif normalized.end_with?("micros")
+            TimeValue.new(parse(normalized, 6), :microsecond)
+          elsif normalized.end_with?("ms")
+            TimeValue.new(parse(normalized, 2), :millisecond)
+          elsif normalized.end_with?("s")
+            TimeValue.new(parse(normalized, 1), :second)
+          elsif normalized.end_with?("m")
+            TimeValue.new(parse(normalized, 1), :minute)
+          elsif normalized.end_with?("h")
+            TimeValue.new(parse(normalized, 1), :hour)
+          elsif normalized.end_with?("d")
+            TimeValue.new(parse(normalized, 1), :day)
+          elsif normalized =~ /^-0*1/
+            TimeValue.new(-1, :nanosecond)
+          else
+            raise ArgumentError.new("invalid time unit: \"#{value}\"")
+          end
+        else
+          raise ArgumentError.new("value is not a string: #{value} [#{value.class}]")
+        end
+      end
+
+      def to_nanos
+        case @time_unit
+        when :day
+          86400000000000 * @duration
+        when :hour
+          3600000000000 * @duration
+        when :minute
+          60000000000 * @duration
+        when :second
+          1000000000 * @duration
+        when :millisecond
+          1000000 * @duration
+        when :microsecond
+          1000 * @duration
+        when :nanosecond
+          @duration
+        end
+      end
+
+      def ==(other)
+        self.duration == other.duration and self.time_unit == other.time_unit
+      end
+
+      def self.parse(value, suffix)
+        Integer(value[0..(value.size - suffix - 1)].strip)
+      end
+
+      private_class_method :parse
+      attr_reader :duration
+      attr_reader :time_unit
+    end
+  end
+end

--- a/logstash-core/spec/logstash/settings/time_value_spec.rb
+++ b/logstash-core/spec/logstash/settings/time_value_spec.rb
@@ -1,0 +1,31 @@
+# encoding: utf-8
+require "spec_helper"
+require "logstash/settings"
+
+describe LogStash::Setting::TimeValue do
+  subject { described_class.new("option", "-1") }
+  describe "#set" do
+    it "should coerce the default correctly" do
+      expect(subject.value).to eq(LogStash::Util::TimeValue.new(-1, :nanosecond).to_nanos)
+    end
+
+    context "when a value is given outside of possible_values" do
+      it "should raise an ArgumentError" do
+        expect { subject.set("invalid") }.to raise_error(ArgumentError)
+      end
+    end
+    context "when a value is given as a time value" do
+      it "should set the value" do
+        subject.set("18m")
+        expect(subject.value).to eq(LogStash::Util::TimeValue.new(18, :minute).to_nanos)
+      end
+    end
+
+    context "when a value is given as a nanosecond" do
+      it "should set the value" do
+        subject.set(5)
+        expect(subject.value).to eq(LogStash::Util::TimeValue.new(5, :nanosecond).to_nanos)
+      end
+    end
+  end
+end

--- a/logstash-core/spec/logstash/util/time_value_spec.rb
+++ b/logstash-core/spec/logstash/util/time_value_spec.rb
@@ -1,0 +1,59 @@
+# encoding: utf-8
+require "logstash/util/time_value"
+require "spec_helper"
+
+RSpec.shared_examples "coercion example" do |value, expected|
+  let(:value) { value }
+  let(:expected) { expected }
+  it 'coerces correctly' do
+    expect(LogStash::Util::TimeValue.from_value(value)).to eq(expected)
+  end
+end
+
+
+module LogStash module Util
+describe TimeValue do
+    it_behaves_like "coercion example", TimeValue.new(100, :hour), TimeValue.new(100, :hour)
+    it_behaves_like "coercion example", "18nanos", TimeValue.new(18, :nanosecond)
+    it_behaves_like "coercion example", "18micros", TimeValue.new(18, :microsecond)
+    it_behaves_like "coercion example", "18ms", TimeValue.new(18, :millisecond)
+    it_behaves_like "coercion example", "18s", TimeValue.new(18, :second)
+    it_behaves_like "coercion example", "18m", TimeValue.new(18, :minute)
+    it_behaves_like "coercion example", "18h", TimeValue.new(18, :hour)
+    it_behaves_like "coercion example", "18d", TimeValue.new(18, :day)
+
+    it "coerces with a space between the duration and the unit" do
+      expected = TimeValue.new(18, :hour)
+      actual = TimeValue.from_value("18      h")
+      expect(actual).to eq(expected)
+    end
+
+    it "fails to coerce non-ints" do
+      begin
+        a = TimeValue.from_value("f18 nanos")
+        fail "should not parse"
+      rescue ArgumentError => e
+        expect(e.message).to eq("invalid value for Integer(): \"f18\"")
+      end
+    end
+
+    it "fails to coerce invalid units" do
+      begin
+        a = TimeValue.from_value("18xyz")
+        fail "should not parse"
+      rescue ArgumentError => e
+        expect(e.message).to eq("invalid time unit: \"18xyz\"")
+      end
+    end
+
+    it "fails to coerce invalid value types" do
+      begin
+        a = TimeValue.from_value(32)
+        fail "should not parse"
+      rescue ArgumentError => e
+        expect(e.message).to eq("value is not a string: 32 [Fixnum]")
+      end
+    end
+end
+end
+end

--- a/qa/integration/fixtures/slowlog_spec.yml
+++ b/qa/integration/fixtures/slowlog_spec.yml
@@ -1,0 +1,15 @@
+---
+services:
+  - logstash
+config: |-
+ input {
+    generator {
+      count => 4
+    }
+ }
+ filter {
+   sleep { time => 1 every => 2 }
+ }
+ output {
+   null {}
+ }

--- a/qa/integration/specs/slowlog_spec.rb
+++ b/qa/integration/specs/slowlog_spec.rb
@@ -1,0 +1,46 @@
+require_relative '../framework/fixture'
+require_relative '../framework/settings'
+require_relative '../services/logstash_service'
+require_relative '../framework/helpers'
+require "logstash/devutils/rspec/spec_helper"
+require "yaml"
+
+describe "Test Logstash Slowlog" do
+  before(:all) {
+    @fixture = Fixture.new(__FILE__)
+    # used in multiple LS tests
+    @ls = @fixture.get_service("logstash")
+  }
+
+  after(:all) {
+    @fixture.teardown
+  }
+
+  before(:each) {
+    # backup the application settings file -- logstash.yml
+    FileUtils.cp(@ls.application_settings_file, "#{@ls.application_settings_file}.original")
+  }
+
+  after(:each) {
+    @ls.teardown
+    # restore the application settings file -- logstash.yml
+    FileUtils.mv("#{@ls.application_settings_file}.original", @ls.application_settings_file)
+  }
+
+  let(:temp_dir) { Stud::Temporary.directory("logstash-slowlog-test") }
+  let(:config) { @fixture.config("root") }
+
+  it "should write logs to a new dir" do
+    settings = {
+      "path.logs" => temp_dir,
+      "slowlog.threshold.warn" => "500ms"
+    }
+    IO.write(@ls.application_settings_file, settings.to_yaml)
+    @ls.spawn_logstash("-e", config)
+    @ls.wait_for_logstash
+    sleep 1 until @ls.exited?
+    slowlog_file = "#{temp_dir}/logstash-slowlog-plain.log"
+    expect(File.exists?(slowlog_file)).to be true
+    expect(IO.read(slowlog_file).split("\n").size).to eq(2)
+  end
+end


### PR DESCRIPTION
Ever wish you can find out what is taking a long time in your Logstash Pipeline?

With the new addition of the [Monitoring API](https://www.elastic.co/guide/en/logstash/5.0/monitoring.html), you can introspect Logstash at the thread level, but there is no easy way to see what actions are taking long. Slowlog in Logstash is the first step in catching some important plugin actions that are slowing the pipeline down.

For demonstration, here is a sample pipeline with a test filter that will `sleep` for varying durations that, at times, will trigger a slowlog event to be logged.

```
input {
  generator { count => 1 }
}

filter {
  sleep {
    time => "2"
  }
}
output {
  null {}
}
```

Now you can configure a slowlog to log to `/path/to/logs/logstash-slowlog-plain-YYYY-MM-dd.log`

Slowlog is currently only configured on filters. If any filter action on an event exceeds a pre-defined threshold, the instance will be logged.
The thresholds are configured in `logstash.yml` as the following configuration keys:

```
slowlog.threshold.warn (default: -1)
slowlog.threshold.info (default: -1)
slowlog.threshold.debug (default: -1)
slowlog.threshold.trace (default: -1)
```

These options take in a time value similar to [Elasticsearch's Slowlog](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-slowlog.html).  By default, these values are set to `-1` to represent an infinite threshold where no slowlog will be invoked.

Here is a sample:

```
slowlog.threshold.warn: 2s
slowlog.threshold.info 1s
slowlog.threshold.debug 500ms
slowlog.threshold.trace 100ms
```
### Contents of Slowlog

Assuming the above pipeline and the example configuration were run in tandem, we may find our slowlog filled with the following content in the case of a filter taking a little over 2 seconds. The log line will include the offending event and the time it took to process within the filter

```
...
[2016-10-27T13:48:19,308][WARN ][slowlog.logstash.filters.sleep] event processing time {:took_in_nanos=>1000614130, :event=>"{\"sequence\":1,\"@timestamp\":\"2016-10-27T20:48:18.150Z\",\"@version\":\"1\",\"host\":\"elasticbox-2.local\",\"mes
sage\":\"Hello world!\"}"}
```
### Old efforts forgotten?

There were some previous efforts to introduce this feature to Logstash. This is picking up that torch and moving forward with the task.

for reference to older discussions, please reference:

| Feature Issue | https://github.com/elastic/logstash/issues/5733 |
| --- | --- |
| The PR | https://github.com/elastic/logstash/pull/5886 |

I hope that many of the discussion from there will continue here. One major difference between
that PR and this is that this only sets up the slowlog functionality itself with no consideration of the API for tracking "top-K" style metrics of slow operations. That can continue in follow-up commits.
