### PR TITLE
Improve docs for linux service managers

### DIFF
--- a/docs/static/getting-started-with-logstash.asciidoc
+++ b/docs/static/getting-started-with-logstash.asciidoc
@@ -105,21 +105,7 @@ it with:
 sudo apt-get update && sudo apt-get install logstash
 --------------------------------------------------
 
-Configure Logstash to automatically start during bootup. If your
-distribution is using SysV init, then you will need to run:
-
-[source,sh]
---------------------------------------------------
-sudo update-rc.d logstash defaults 95 10
---------------------------------------------------
-
-Otherwise if your distribution is using systemd:
-
-[source,sh]
---------------------------------------------------
-sudo /bin/systemctl daemon-reload
-sudo /bin/systemctl enable logstash.service
---------------------------------------------------
+See the <<running-logstash,Running Logstash>> document for managing Logstash as a system service.
 
 [float]
 ==== YUM
@@ -153,24 +139,10 @@ And your repository is ready for use. You can install it with:
 sudo yum install logstash
 --------------------------------------------------
 
-Configure Logstash to automatically start during bootup. If your
-distribution is using SysV `init` (check with `ps -p 1`), then you will need to run:
-
 WARNING: The repositories do not work with older rpm based distributions
          that still use RPM v3, like CentOS5.
 
-[source,sh]
---------------------------------------------------
-chkconfig --add logstash
---------------------------------------------------
-
-Otherwise if your distribution is using `systemd`:
-
-[source,sh]
---------------------------------------------------
-sudo /bin/systemctl daemon-reload
-sudo /bin/systemctl enable logstash.service
---------------------------------------------------
+See the <<running-logstash,Running Logstash>> document for managing Logstash as a system service.
 
 [[first-event]]
 === Stashing Your First Event

--- a/docs/static/setting-up-logstash.asciidoc
+++ b/docs/static/setting-up-logstash.asciidoc
@@ -134,6 +134,19 @@ The settings files are already defined in the Logstash installation. Logstash in
 Logstash is not started automatically after installation. How to start and stop Logstash depends on whether your system
 uses systemd, upstart, or SysV.
 
+Here are some common operating systems and versions, and the corresponding
+startup styles they use.  This list is intended to be informative, not exhaustive.
+
+|=======================================================================
+| Distribution | Service System |
+| Ubuntu 16.04 and newer | <<running-logstash-systemd,systemd>> |
+| Ubuntu 12.04 through 15.10 | <<running-logstash-upstart,upstart>> |
+| Debian 8 "jessie" and newer | <<running-logstash-systemd,systemd>> |
+| Debian 7 "wheezy" and older | <<running-logstash-sysv,sysv>> |
+| CentOS (and RHEL) 7 and newer | <<running-logstash-systemd,systemd>> |
+| CentOS (and RHEL) 6 | <<running-logstash-upstart,upstart>> |
+|=======================================================================
+
 [[running-logstash-systemd]]
 ==== Running Logstash by Using Systemd
 
@@ -168,8 +181,3 @@ sudo /etc/init.d/logstash start
 -------------------------------------------
 
 The auto-generated configuration file for SysV systems is `/etc/init.d/logstash`.
-
-
-
-
-


### PR DESCRIPTION
* Add a table of Linux distributions and corresponding service systems.
* Replace redundant service docs with links to the running-logstash.

Hopefully fixes #6148