### PR TITLE
-e and -f should merge even without valid conf file

### DIFF
--- a/logstash-core/lib/logstash/config/loader.rb
+++ b/logstash-core/lib/logstash/config/loader.rb
@@ -12,7 +12,18 @@ module LogStash; module Config; class Loader
       # Append the config string.
       # This allows users to provide both -f and -e flags. The combination
       # is rare, but useful for debugging.
-      config_string = config_string + load_config(config_path)
+      loaded_config = load_config(config_path)
+      if loaded_config.empty? && config_string.empty?
+        # If loaded config from `-f` is empty *and* if config string is empty we raise an error
+        fail(I18n.t("logstash.runner.configuration.file-not-found", :path => config_path))
+      end
+
+      # tell the user we are merging, otherwise it is very confusing
+      if !loaded_config.empty? && !config_string.empty?
+        @logger.info("Created final config by merging config string and config path", :path => config_path)
+      end
+
+      config_string = config_string + loaded_config
     else
       # include a default stdin input if no inputs given
       if config_string !~ /input *{/
@@ -52,11 +63,12 @@ module LogStash; module Config; class Loader
     path = ::File.expand_path(path)
     path = ::File.join(path, "*") if ::File.directory?(path)
 
+    config = ""
     if Dir.glob(path).length == 0
-      fail(I18n.t("logstash.runner.configuration.file-not-found", :path => path))
+      @logger.info("No config files found in path", :path => path)
+      return config
     end
 
-    config = ""
     encoding_issue_files = []
     Dir.glob(path).sort.each do |file|
       next unless ::File.file?(file)

--- a/qa/integration/specs/01_logstash_bin_smoke_spec.rb
+++ b/qa/integration/specs/01_logstash_bin_smoke_spec.rb
@@ -25,6 +25,9 @@ describe "Test Logstash instance" do
   let(:num_retries) { 10 }
   let(:config1) { config_to_temp_file(@fixture.config("root", { :port => random_port })) }
   let(:config2) { config_to_temp_file(@fixture.config("root", { :port => random_port })) }
+  let(:port1) { random_port }
+  let(:port2) { random_port }
+  let(:config3) { config_to_temp_file(@fixture.config("root", { :port => port2 })) }
 
   it "can start the embedded http server on default port 9600" do
     @ls1.start_with_stdin
@@ -54,4 +57,34 @@ describe "Test Logstash instance" do
     expected = YAML.load_file(LogstashService::LS_VERSION_FILE)
     expect(@ls1.get_version.strip).to eq("logstash #{expected['logstash']}")
   end
-end    
+  
+  it "should still merge when -e is specified and -f has no valid config files" do
+    config_string = "input { tcp { port => #{port1} } }"
+    @ls1.spawn_logstash("-e", config_string, "-f" "/tmp/foobartest")
+    @ls1.wait_for_logstash
+
+    try(20) do
+      expect(is_port_open?(port1)).to be true
+    end
+  end
+  
+  it "should not start when -e is not specified and -f has no valid config files" do
+    @ls1.spawn_logstash("-e", "", "-f" "/tmp/foobartest")
+    expect(is_port_open?(9600)).to be false
+  end
+  
+  it "should merge config_string when both -f and -e is specified" do
+    config_string = "input { tcp { port => #{port1} } }"
+    @ls1.spawn_logstash("-e", config_string, "-f", config3)
+    @ls1.wait_for_logstash
+
+    # Both ports should be reachable
+    try(20) do
+      expect(is_port_open?(port1)).to be true
+    end
+    
+    try(20) do
+      expect(is_port_open?(port2)).to be true
+    end
+  end
+end


### PR DESCRIPTION
Previously if both -e and -f was specified, LS required that
-f still have valid config file(s) before merging. This fixes it
to either have one of -f or -e provided

Fixes #6164