### PR TITLE
Make logstash.yml optional

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -281,7 +281,7 @@ class LogStash::Runner < Clamp::StrictCommand
   rescue => e
     # if logger itself is not initialized
     if LogStash::Logging::Logger.get_logging_context.nil?
-      puts e
+      $stderr.puts "#{I18n.t("oops")} :error => #{e}, :backtrace => #{e.backtrace}"
     else
       logger.fatal(I18n.t("oops"), :error => e, :backtrace => e.backtrace)
     end

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -353,8 +353,8 @@ describe LogStash::Runner do
     context "if does not exist" do
       let(:args) { ["--path.settings", "/tmp/a/a/a/a", "-e", "input {} output {}"] }
 
-      it "should terminate logstash" do
-        expect(subject.run(args)).to eq(1)
+      it "should not terminate logstash" do
+        expect(subject.run(args)).to eq(nil)
       end
 
       context "but if --help is passed" do


### PR DESCRIPTION
5.0.0 required Logstash to have a valid logstash.yml before it could start successfully. This
was mostly fine for users who installed Logstash via tar.gz, but many many folks who install
it via packages still start Logstash manually. Also, our documentation uses -e flag for
getting started on Logstash and sending their first event.logstash.yml has only defaults defined,
and there is no required parameter to start Logstash. We should be able to use the defaults if no
logstash.yml. Obviously, this is not ideal from a user point of view, so we should log a warning but
continue to bootstrap.

Fixes #6170