### PR TITLE
Update version info shown in doc for building LS plugins

### DIFF
--- a/docs/static/contributing-to-logstash.asciidoc
+++ b/docs/static/contributing-to-logstash.asciidoc
@@ -24,9 +24,9 @@ deploying your own plugins:
 * <<submitting-plugin,Submitting a Plugin>>
 
 [float]
-==== Plugin API Changes
+==== Plugin Shutdown APIs
 
-The 2.0 release of Logstash changes how input plugins shut down to increase shutdown reliability. There are three methods
+Starting in Logstash 2.0, we changed how input plugins shut down to increase shutdown reliability. There are three methods
 for plugin shutdown: `stop`, `stop?`, and `close`.
 
 * Call the `stop` method from outside the plugin thread. This method signals the plugin to stop.
@@ -37,7 +37,7 @@ exit. The `close` method is a a new name for the method known as `teardown` in p
 The `shutdown`, `finished`, `finished?`, `running?`, and `terminating?` methods are redundant and no longer present in the
 Plugin Base class.
 
-Sample code for the new plugin shutdown APIs is https://github.com/logstash-plugins/logstash-input-example/blob/master/lib/logstash/inputs/example.rb[available].
+Sample code for the plugin shutdown APIs is https://github.com/logstash-plugins/logstash-input-example/blob/master/lib/logstash/inputs/example.rb[available].
 
 [float]
 === Extending Logstash core

--- a/docs/static/include/pluginbody.asciidoc
+++ b/docs/static/include/pluginbody.asciidoc
@@ -852,7 +852,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "{plugintype}" }
 
   # Gem dependencies
-  s.add_runtime_dependency 'logstash-core', '>= 5.0.0', '< 6.0.0'
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_development_dependency 'logstash-devutils'
 end
 ----------------------------------
@@ -910,16 +910,15 @@ Logstash plugins:
 [subs="attributes"]
 ----------------------------------
   # Gem dependencies
-  s.add_runtime_dependency 'logstash-core', '>= 5.0.0', '< 6.0.0'
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_development_dependency 'logstash-devutils'
 ----------------------------------
-This gemspec has a runtime dependency on the core Logstash gem and requires that
-it have a version number greater than or equal to version 5.0.0 `'>= 5.0.0'`,
-and less than version 6.0 `'< 6.0.0'`.
+This gemspec has a runtime dependency on the logstash-core-plugin-api and requires that
+it have a version number greater than or equal to version 1.60 and less than or equal to version 2.99.
 =========================
 
 
-IMPORTANT: All plugins have a runtime dependency on the `logstash` core gem, and
+IMPORTANT: All plugins have a runtime dependency on the `logstash-core-plugin-api` gem, and
 a development dependency on `logstash-devutils`.
 
 ==== Jar dependencies

--- a/docs/static/include/pluginbody.asciidoc
+++ b/docs/static/include/pluginbody.asciidoc
@@ -852,7 +852,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "{plugintype}" }
 
   # Gem dependencies
-  s.add_runtime_dependency 'logstash-core', '>= 1.4.0', '< 2.0.0'
+  s.add_runtime_dependency 'logstash-core', '>= 5.0.0', '< 6.0.0'
   s.add_development_dependency 'logstash-devutils'
 end
 ----------------------------------
@@ -910,12 +910,12 @@ Logstash plugins:
 [subs="attributes"]
 ----------------------------------
   # Gem dependencies
-  s.add_runtime_dependency 'logstash-core', '>= 1.4.0', '< 2.0.0'
+  s.add_runtime_dependency 'logstash-core', '>= 5.0.0', '< 6.0.0'
   s.add_development_dependency 'logstash-devutils'
 ----------------------------------
 This gemspec has a runtime dependency on the core Logstash gem and requires that
-it have a version number greater than or equal to version 1.4.0 `'>= 1.4.0'`,
-and less than version 2.0 `'< 2.0.0'`.
+it have a version number greater than or equal to version 5.0.0 `'>= 5.0.0'`,
+and less than version 6.0 `'< 6.0.0'`.
 =========================
 
 
@@ -933,7 +933,7 @@ added in the gemspec file in this manner:
 [subs="attributes"]
 ----------------------------------
   # Jar dependencies
-  s.requirements << "jar 'org.elasticsearch:elasticsearch', '1.4.0'"
+  s.requirements << "jar 'org.elasticsearch:elasticsearch', '5.0.0'"
   s.add_runtime_dependency 'jar-dependencies'
 ----------------------------------
 


### PR DESCRIPTION
This fixes examples in issue #6124 

Also tweaked the language in the introduction so it doesn't seem like 2.0 is the new release.

