### PR TITLE
Make sure we have we configure the `ssl_certificate_authorities`

### DIFF
--- a/qa/integration/fixtures/beats_input_spec.yml
+++ b/qa/integration/fixtures/beats_input_spec.yml
@@ -27,7 +27,8 @@ config:
         port => 5044
         ssl_certificate => '<%=options[:ssl_certificate]%>'
         ssl_key => '<%=options[:ssl_key]%>'
-        ssl_verify_mode => "peer"
+        ssl_verify_mode => "force_peer"
+        ssl_certificate_authorities => '<%=options[:ssl_certificate]%>'
       }
     }
     output {}


### PR DESCRIPTION
Make sure we have we configure the `ssl_certificate_authorities` and set the verify mode to force_peer to make sure the input uses it.

Fixes #6185