### PR TITLE
Enable back the WritableDirectory spec

### DIFF
--- a/logstash-core/spec/logstash/settings/writable_directory_spec.rb
+++ b/logstash-core/spec/logstash/settings/writable_directory_spec.rb
@@ -79,9 +79,7 @@ describe LogStash::Setting::WritableDirectory do
         it_behaves_like "failure"
       end
 
-      # Skip this test due to a testing bug on OSX.
-      # `path` is rejected on OSX because it is too long (but passes on Linux)
-      xcontext "but is a socket" do
+      context "but is a socket" do
         let(:socket) { UNIXServer.new(path) }
         before { socket } # realize `socket` value
         after { socket.close }


### PR DESCRIPTION
A few days ago I've created this PR[1] to to enable the writable directory
spec to pass on macos X. When the PQ got merged in the master branch the
test was disabled again[2], I presume this was a small error in the merge.

[1] http://github.com/elastic/logstash/pull/6110
[2] https://github.com/elastic/logstash/commit/761f9f1bc90b80f3dfc6c08294585b7f2991c7a7