### PR TITLE
Allow negative array offsets in field references

### DIFF
--- a/logstash-core-event-java/spec/event_spec.rb
+++ b/logstash-core-event-java/spec/event_spec.rb
@@ -61,6 +61,16 @@ describe LogStash::Event do
       expect(e.get("[foo][2]")).to eq(1.0)
       expect(e.get("[foo][3]")).to be_nil
     end
+
+    context "negative array values" do
+      it "should index from the end of the array" do
+        list = ["bar", 1, 1.0]
+        e = LogStash::Event.new({"foo" => list})
+        expect(e.get("[foo][-3]")).to eq(list[-3])
+        expect(e.get("[foo][-2]")).to eq(list[-2])
+        expect(e.get("[foo][-1]")).to eq(list[-1])
+      end
+    end
   end
 
   context "#set" do

--- a/logstash-core-event-java/src/main/java/org/logstash/Accessors.java
+++ b/logstash-core-event-java/src/main/java/org/logstash/Accessors.java
@@ -188,7 +188,7 @@ public class Accessors {
      * @param size the size of the list.
      * @return the positive integer offset for the list given by index i.
      */
-    private static int listIndex(int i, int size) {
+    public static int listIndex(int i, int size) {
         if (i >= size || i < -size) {
             throw new IndexOutOfBoundsException("Index " + i + " is out of bounds for a list with size " + size);
         }

--- a/logstash-core-event-java/src/main/java/org/logstash/Accessors.java
+++ b/logstash-core-event-java/src/main/java/org/logstash/Accessors.java
@@ -35,7 +35,7 @@ public class Accessors {
             } else if (target instanceof List) {
                 int i = Integer.parseInt(field.getKey());
                 try {
-                    int offset = listIndex(i, (List) target);
+                    int offset = listIndex(i, ((List) target).size());
                     return ((List)target).remove(offset);
                 } catch (IndexOutOfBoundsException e) {
                     return null;
@@ -115,7 +115,7 @@ public class Accessors {
 
     private boolean foundInList(List<Object> target, int index) {
         try {
-            int offset = listIndex(index, target);
+            int offset = listIndex(index, target.size());
             return target.get(offset) != null;
         } catch (IndexOutOfBoundsException e) {
             return false;
@@ -133,7 +133,7 @@ public class Accessors {
             return result;
         } else if (target instanceof List) {
             try {
-                int offset = listIndex(Integer.parseInt(key), (List) target);
+                int offset = listIndex(Integer.parseInt(key), ((List) target).size());
                 return ((List<Object>) target).get(offset);
             } catch (IndexOutOfBoundsException e) {
                 return null;
@@ -161,7 +161,7 @@ public class Accessors {
                 }
                 ((List<Object>) target).add(value);
             } else {
-                int offset = listIndex(i, (List) target);
+                int offset = listIndex(i, ((List) target).size());
                 ((List<Object>) target).set(offset, value);
             }
         } else {
@@ -181,9 +181,14 @@ public class Accessors {
         return new ClassCastException("expecting List or Map, found "  + target.getClass());
     }
 
-    private static int listIndex(int i, List list) {
-        int size = list.size();
-
+    /* 
+     * Returns a positive integer offset for a list of known size.
+     *
+     * @param i if positive, and offset from the start of the list. If negative, the offset from the end of the list, where -1 means the last element.
+     * @param size the size of the list.
+     * @return the positive integer offset for the list given by index i.
+     */
+    private static int listIndex(int i, int size) {
         if (i >= size || i < -size) {
             throw new IndexOutOfBoundsException("Index " + i + " is out of bounds for a list with size " + size);
         }

--- a/logstash-core-event-java/src/main/java/org/logstash/Accessors.java
+++ b/logstash-core-event-java/src/main/java/org/logstash/Accessors.java
@@ -34,10 +34,15 @@ public class Accessors {
                 return ((Map<String, Object>) target).remove(field.getKey());
             } else if (target instanceof List) {
                 int i = Integer.parseInt(field.getKey());
-                if (i < 0 || i >= ((List) target).size()) {
-                    return null;
+                int size = ((List) target).size();
+                if (i >= size || i < -size) {
+                  return null;
+                } else if (i < 0) {
+                  // Offset from the end of the array.
+                  return ((List<Object>) target).remove(size + i);
+                } else {
+                  return ((List<Object>) target).remove(i);
                 }
-                return ((List<Object>) target).remove(i);
             } else {
                 throw newCollectionException(target);
             }
@@ -112,9 +117,15 @@ public class Accessors {
     }
 
     private boolean foundInList(List<Object> target, int index) {
-        if (index < 0 || index >= target.size()) {
+        int size = ((List) target).size();
+        if (index >= size || index < -size) {
             return false;
         }
+
+        if (index < 0) {
+            index = size + index;
+        }
+
         return target.get(index) != null;
     }
 
@@ -128,11 +139,15 @@ public class Accessors {
             return result;
         } else if (target instanceof List) {
             int i = Integer.parseInt(key);
-            if (i < 0 || i >= ((List) target).size()) {
+            int size = ((List) target).size();
+            if (i >= size || i < -size) {
                 return null;
+            } else if (i < 0) {
+                // Offset from the end of the array.
+                return ((List<Object>) target).get(size + i);
+            } else {
+                return ((List<Object>) target).get(i);
             }
-            Object result = ((List<Object>) target).get(i);
-            return result;
         } else if (target == null) {
             return null;
         } else {

--- a/logstash-core-event-java/src/test/java/org/logstash/AccessorsTest.java
+++ b/logstash-core-event-java/src/test/java/org/logstash/AccessorsTest.java
@@ -1,5 +1,11 @@
 package org.logstash;
 
+import org.junit.experimental.theories.DataPoint;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -206,5 +212,39 @@ public class AccessorsTest {
         assertEquals(accessors.set("[foo]", "boom"), "boom");
         assertEquals(accessors.get("[foo][bar]"), null);
         assertEquals(accessors.get("[foo]"), "boom");
+    }
+
+    @RunWith(Theories.class)
+    public static class TestListIndexFailureCases {
+      private static final int size = 10;
+
+      @DataPoint
+      public static final int tooLarge = size;
+
+      @DataPoint
+      public static final int tooLarge1 = size+1;
+
+      @DataPoint
+      public static final int tooLargeNegative = -size - 1;
+
+      @Rule
+      public ExpectedException exception = ExpectedException.none();
+
+      @Theory
+      public void testListIndexOutOfBounds(int i) {
+        exception.expect(IndexOutOfBoundsException.class);
+        Accessors.listIndex(i, size);
+      }
+    }
+
+    public static class TestListIndex {
+      public void testListIndexOutOfBounds() {
+        assertEquals(Accessors.listIndex(0, 10), 0);
+        assertEquals(Accessors.listIndex(1, 10), 1);
+        assertEquals(Accessors.listIndex(9, 10), 9);
+        assertEquals(Accessors.listIndex(-1, 10), 9);
+        assertEquals(Accessors.listIndex(-9, 10), 1);
+        assertEquals(Accessors.listIndex(-10, 10), 0);
+      }
     }
 }


### PR DESCRIPTION
This allows references of `[-1]` and similar negative numbers to mean an offset from the end of the list.