### PR TITLE
Mention default log location for rpm/deb packages

### DIFF
--- a/docs/static/logging.asciidoc
+++ b/docs/static/logging.asciidoc
@@ -1,9 +1,9 @@
 [[logging]]
 === Logging
 
-Logstash emits internal logs during its operation, which are placed in `LS_HOME/logs`. The default logging level is `INFO`. 
-Logstash's logging framework is based on http://logging.apache.org/log4j/2.x/[Log4j2 framework], and much of its functionality 
-is exposed directly to users.
+Logstash emits internal logs during its operation, which are placed in `LS_HOME/logs` (or `/var/log/logstash` for
+DEB/RPM). The default logging level is `INFO`. Logstash's logging framework is based on
+http://logging.apache.org/log4j/2.x/[Log4j2 framework], and much of its functionality is exposed directly to users.
 
 When debugging problems, particularly problems with plugins, it can be helpful to increase the logging level to `DEBUG` 
 to emit more verbose messages. Previously, you could only set a log level that applied to the entire Logstash product. 

--- a/docs/static/setting-up-logstash.asciidoc
+++ b/docs/static/setting-up-logstash.asciidoc
@@ -45,6 +45,11 @@ config and the logs directories so that you do not delete important data later o
   | Configuration files, including `logstash.yml` and `jvm.options`
   | `{extract.path}/config`
   | `path.settings`
+  
+| logs
+  | Log files
+  | `{extract.path}/logs`
+  | `path.logs`
 
 | plugins
   | Local, non Ruby-Gem plugin files. Each plugin is contained in a subdirectory. Recommended for development only.


### PR DESCRIPTION
Resolves issue https://github.com/elastic/logstash/issues/3346. Also fixes inconsistent coverage of log file location for zip/tar installs.