### PR TITLE
bump kafka setup for integration tests to 0.10.1.0

### DIFF
--- a/qa/integration/services/kafka_setup.sh
+++ b/qa/integration/services/kafka_setup.sh
@@ -8,7 +8,7 @@ if [ -n "${KAFKA_VERSION+1}" ]; then
     echo "KAFKA_VERSION is $KAFKA_VERSION"
     version=$KAFKA_VERSION
 else
-    version=0.10.0.1
+    version=0.10.1.0
 fi
 
 KAFKA_HOME=$INSTALL_DIR/kafka


### PR DESCRIPTION
in master (6.0.0-alpha1), the kafka plugins are targeted towards Kafka `0.10.1.0`, integration tests need to be updated to reflect this.