### PR TITLE
Fix filter 'id' naming to be consistent with inputs / outputs

### DIFF
--- a/logstash-core/lib/logstash/filter_delegator.rb
+++ b/logstash-core/lib/logstash/filter_delegator.rb
@@ -20,7 +20,7 @@ module LogStash
       @filter = klass.new(plugin_args)
 
       # Scope the metrics to the plugin
-      namespaced_metric = metric.namespace("#{@klass.config_name}_#{@id}".to_sym)
+      namespaced_metric = metric.namespace(@id.to_sym)
       @filter.metric = namespaced_metric
 
       @metric_events = namespaced_metric.namespace(:events)

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -685,7 +685,7 @@ describe LogStash::Pipeline do
       it "populates the filter metrics" do
         [multiline_id, multiline_id_other].map(&:to_sym).each do |id|
           [:in, :out].each do |metric_key|
-            plugin_name = "multiline_#{id}".to_sym
+            plugin_name = id.to_sym
             expect(collected_metric[:stats][:pipelines][:main][:plugins][:filters][plugin_name][:events][metric_key].value).to eq(number_of_events)
           end
         end
@@ -703,7 +703,7 @@ describe LogStash::Pipeline do
 
       it "populates the name of the filter plugin" do
         [multiline_id, multiline_id_other].map(&:to_sym).each do |id|
-          plugin_name = "multiline_#{id}".to_sym
+          plugin_name = id.to_sym
           expect(collected_metric[:stats][:pipelines][:main][:plugins][:filters][plugin_name][:name].value).to eq(LogStash::Filters::Multiline.config_name)
         end
       end


### PR DESCRIPTION
The filters were the only category prefixing IDs with their plugin names