### PR TITLE
use a temporary path instead of a temporary file

### DIFF
--- a/qa/integration/specs/beats_input_spec.rb
+++ b/qa/integration/specs/beats_input_spec.rb
@@ -16,8 +16,12 @@ describe "Beat Input" do
     filebeat_service.stop
   end
 
+  before :each do
+    FileUtils.mkdir_p(File.dirname(registry_file))
+  end
+
   let(:max_retry) { 120 }
-  let(:registry_file) { Stud::Temporary.file.path }
+  let(:registry_file) { File.join(Stud::Temporary.pathname, "registry") }
   let(:logstash_service) { @fixture.get_service("logstash") }
   let(:filebeat_service) { @fixture.get_service("filebeat") }
   let(:log_path) do


### PR DESCRIPTION
Using an empty file for the registry make FB quits with a EOF error.

Fixes: #6285