### PR TITLE
Clarify -f description and add info about supported glob patterns

### DIFF
--- a/docs/static/command-line-flags.asciidoc
+++ b/docs/static/command-line-flags.asciidoc
@@ -16,10 +16,23 @@ Any flags that you set at the command line override the corresponding settings i
   hostname.
 
 *`-f, --path.config CONFIG_PATH`*::
-  Load the Logstash config from a specific file or directory. If a directory is given, all
-  files in that directory will be concatenated in lexicographical order and then parsed as a
-  single config file. You can also specify wildcards (globs) and any matched files will
-  be loaded in the order described above.
+Load the Logstash config from a specific file or directory. If a directory is given, all
+files in that directory will be concatenated in lexicographical order and then parsed as a
+single config file. Specifying this flag multiple times is not supported. If you specify
+this flag multiple times, Logstash uses the last occurrence (for example, `-f foo -f bar`
+is the same as `-f bar`).
++
+You can specify wildcards (<<glob-support,globs>>) and any matched files will
+be loaded in the order described above. For example, you can use the wildcard feature to
+load specific files by name: 
++
+[source,shell]
+---------------------------------------------
+bin/logstash --debug -f '/tmp/{one,two,three}'
+---------------------------------------------
++
+With this command, Logstash concatenates three config files, `/tmp/one`, `/tmp/two`, and
+`/tmp/three`, and parses them into a single config.
 
 *`-e, --config.string CONFIG_STRING`*::
   Use the given string as the configuration data. Same syntax as the config file. If no

--- a/docs/static/command-line-flags.asciidoc
+++ b/docs/static/command-line-flags.asciidoc
@@ -77,7 +77,7 @@ With this command, Logstash concatenates three config files, `/tmp/one`, `/tmp/t
   and `NAME` is the name of the plugin.
 
 *`-l, --path.logs PATH`*::
-  Directory to Write Logstash internal logs to.
+  Directory to write Logstash internal logs to.
 
 *`--log.level LEVEL`*::
  Set the log level for Logstash. Possible values are:

--- a/docs/static/glob-support.asciidoc
+++ b/docs/static/glob-support.asciidoc
@@ -35,16 +35,16 @@ as part of a glob. The pattern `c:\foo*` will not work, so use `foo*` instead.
 
 Here are some common examples of glob patterns: 
 
-*`"/path/to/*.conf"`*::
+`"/path/to/*.conf"`::
 Matches config files ending in `.conf` in the specified path.
 
-*`"/var/log/*.log"`*::
+`"/var/log/*.log"`::
 Matches log files ending in `.log` in the specified path.
 
-*`"/var/log/**/*.log`*::
+`"/var/log/**/*.log`::
 Matches log files ending in `.log` in subdirectories under the specified path.
 
-*`"/path/to/logs/{app1,app2,app3}/data.log"`*::
+`"/path/to/logs/{app1,app2,app3}/data.log"`::
 Matches app log files in the `app1`, `app2`, and `app3` subdirectories under the
 specified path.
 

--- a/docs/static/glob-support.asciidoc
+++ b/docs/static/glob-support.asciidoc
@@ -28,3 +28,23 @@ to using alternation with the vertical bar in regular expressions (`foo|bar`).
 *`\`*::
 Escape the next metacharacter. This means that you cannot use a backslash in Windows
 as part of a glob. The pattern `c:\foo*` will not work, so use `foo*` instead.
+
+[float]
+[[example-glob-patterns]]
+==== Example Patterns
+
+Here are some common examples of glob patterns: 
+
+*`"/path/to/*.conf"`*::
+Matches config files ending in `.conf` in the specified path.
+
+*`"/var/log/*.log"`*::
+Matches log files ending in `.log` in the specified path.
+
+*`"/var/log/**/*.log`*::
+Matches log files ending in `.log` in subdirectories under the specified path.
+
+*`"/path/to/logs/{app1,app2,app3}/data.log"`*::
+Matches app log files in the `app1`, `app2`, and `app3` subdirectories under the
+specified path.
+

--- a/docs/static/glob-support.asciidoc
+++ b/docs/static/glob-support.asciidoc
@@ -1,0 +1,30 @@
+[[glob-support]]
+=== Glob Pattern Support
+
+Logstash supports the following patterns wherever glob patters are allowed:
+
+*`*`*::
+Match any file. You can also use an `*` to restrict other values in the glob.
+For example, `*conf` matches all files that end in `conf`. `*apache*` matches
+any files with `apache` in the name. This pattern does not match hidden files
+(dot files) on Unix-like operating systems. To match dot files, use a pattern
+like `{*,.*}`.
+
+*`**`*::
+Match directories recursively.
+
+*`?`*::
+Match any one character.
+
+*`[set]`*::
+Match any one character in a set. For example, `[a-z]`. Also supports set negation
+(`[^a-z]`).
+
+*`{p,q}`*::
+Match either literal `p` or literal `q`. The matching literal can be more than one
+character, and you can specify more than two literals. This pattern is the equivalent
+to using alternation with the vertical bar in regular expressions (`foo|bar`).
+
+*`\`*::
+Escape the next metacharacter. This means that you cannot use a backslash in Windows
+as part of a glob. The pattern `c:\foo*` will not work, so use `foo*` instead.


### PR DESCRIPTION
Fixes issue https://github.com/elastic/logstash/issues/3920.

Also added a topic about supported glob patterns (might help users understand that they can use pattern matching for more control over specifying config files). 