### PR TITLE
Fix bad callout formatting in doc

### DIFF
--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -129,8 +129,8 @@ before-and-after examples. In Logstash 2.x, you may have run something:
 bin/logstash --config my.conf --pipeline-workers 8 <1>
 bin/logstash -f my.conf -w 8 <2>
 ----------------------------------
-1. Long form options `config` and `pipeline-workers` are used here.
-2. Short form options `f` and `w` (aliases for the former` are used here.
+<1> Long form options `config` and `pipeline-workers` are used here.
+<2> Short form options `f` and `w` (aliases for the former` are used here.
 
 But, in Logstash 5.0, this becomes:
 
@@ -139,8 +139,8 @@ But, in Logstash 5.0, this becomes:
 bin/logstash --path.config my.conf --pipeline.workers 8 <1>
 bin/logstash -f my.conf -w 8 <2>
 ----------------------------------
-1. Long form options are changed to reflect the new options.
-2. Short form options are unchanged.
+<1> Long form options are changed to reflect the new options.
+<2> Short form options are unchanged.
 
 NOTE: None of the short form options have changed!
 


### PR DESCRIPTION
Fixes https://github.com/elastic/website-www.elastic.co/issues/1370 (the incorrectly formatted callouts were resulting in additional numbers added to the next topic that contained callouts).