### PR TITLE
introduce settting to limit byte size of queue 

### DIFF
--- a/logstash-core-queue-jruby/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java
+++ b/logstash-core-queue-jruby/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java
@@ -67,14 +67,14 @@ public class JrubyAckedQueueExtLibrary implements Library {
             int checkpointMaxAcks = RubyFixnum.num2int(args[3]);
             int checkpointMaxWrites = RubyFixnum.num2int(args[4]);
             int checkpointMaxInterval = RubyFixnum.num2int(args[5]);
-            long queueMaxSizeInBytes = RubyFixnum.num2long(args[6]);
+            long queueMaxBytes = RubyFixnum.num2long(args[6]);
 
             Settings s = new FileSettings(args[0].asJavaString());
             PageIOFactory pageIOFactory = (pageNum, size, path) -> new MmapPageIO(pageNum, size, path);
             CheckpointIOFactory checkpointIOFactory = (source) -> new FileCheckpointIO(source);
             s.setCapacity(capacity);
             s.setMaxUnread(maxUnread);
-            s.setQueueMaxSizeInBytes(queueMaxSizeInBytes);
+            s.setQueueMaxBytes(queueMaxBytes);
             s.setCheckpointMaxAcks(checkpointMaxAcks);
             s.setCheckpointMaxWrites(checkpointMaxWrites);
             s.setCheckpointMaxInterval(checkpointMaxInterval);

--- a/logstash-core-queue-jruby/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java
+++ b/logstash-core-queue-jruby/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java
@@ -57,22 +57,24 @@ public class JrubyAckedQueueExtLibrary implements Library {
         }
 
         // def initialize
-        @JRubyMethod(name = "initialize", optional = 6)
+        @JRubyMethod(name = "initialize", optional = 7)
         public IRubyObject ruby_initialize(ThreadContext context, IRubyObject[] args)
         {
-            args = Arity.scanArgs(context.runtime, args, 6, 0);
+            args = Arity.scanArgs(context.runtime, args, 7, 0);
 
             int capacity = RubyFixnum.num2int(args[1]);
             int maxUnread = RubyFixnum.num2int(args[2]);
             int checkpointMaxAcks = RubyFixnum.num2int(args[3]);
             int checkpointMaxWrites = RubyFixnum.num2int(args[4]);
             int checkpointMaxInterval = RubyFixnum.num2int(args[5]);
+            long queueMaxSizeInBytes = RubyFixnum.num2long(args[6]);
 
             Settings s = new FileSettings(args[0].asJavaString());
             PageIOFactory pageIOFactory = (pageNum, size, path) -> new MmapPageIO(pageNum, size, path);
             CheckpointIOFactory checkpointIOFactory = (source) -> new FileCheckpointIO(source);
             s.setCapacity(capacity);
             s.setMaxUnread(maxUnread);
+            s.setQueueMaxSizeInBytes(queueMaxSizeInBytes);
             s.setCheckpointMaxAcks(checkpointMaxAcks);
             s.setCheckpointMaxWrites(checkpointMaxWrites);
             s.setCheckpointMaxInterval(checkpointMaxInterval);

--- a/logstash-core-queue-jruby/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueMemoryExtLibrary.java
+++ b/logstash-core-queue-jruby/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueMemoryExtLibrary.java
@@ -64,14 +64,14 @@ public class JrubyAckedQueueMemoryExtLibrary implements Library {
 
             int capacity = RubyFixnum.num2int(args[1]);
             int maxUnread = RubyFixnum.num2int(args[2]);
-            long queueMaxSizeInBytes = RubyFixnum.num2long(args[3]);
+            long queueMaxBytes = RubyFixnum.num2long(args[3]);
 
             Settings s = new MemorySettings(args[0].asJavaString());
             PageIOFactory pageIOFactory = (pageNum, size, path) -> new ByteBufferPageIO(pageNum, size, path);
             CheckpointIOFactory checkpointIOFactory = (source) -> new MemoryCheckpointIO(source);
             s.setCapacity(capacity);
             s.setMaxUnread(maxUnread);
-            s.setQueueMaxSizeInBytes(queueMaxSizeInBytes);
+            s.setQueueMaxBytes(queueMaxBytes);
             s.setElementIOFactory(pageIOFactory);
             s.setCheckpointIOFactory(checkpointIOFactory);
             s.setElementClass(Event.class);

--- a/logstash-core-queue-jruby/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueMemoryExtLibrary.java
+++ b/logstash-core-queue-jruby/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueMemoryExtLibrary.java
@@ -57,19 +57,21 @@ public class JrubyAckedQueueMemoryExtLibrary implements Library {
         }
 
         // def initialize
-        @JRubyMethod(name = "initialize", optional = 3)
+        @JRubyMethod(name = "initialize", optional = 4)
         public IRubyObject ruby_initialize(ThreadContext context, IRubyObject[] args)
         {
-            args = Arity.scanArgs(context.runtime, args, 3, 0);
+            args = Arity.scanArgs(context.runtime, args, 4, 0);
 
             int capacity = RubyFixnum.num2int(args[1]);
             int maxUnread = RubyFixnum.num2int(args[2]);
+            long queueMaxSizeInBytes = RubyFixnum.num2long(args[3]);
 
             Settings s = new MemorySettings(args[0].asJavaString());
             PageIOFactory pageIOFactory = (pageNum, size, path) -> new ByteBufferPageIO(pageNum, size, path);
             CheckpointIOFactory checkpointIOFactory = (source) -> new MemoryCheckpointIO(source);
             s.setCapacity(capacity);
             s.setMaxUnread(maxUnread);
+            s.setQueueMaxSizeInBytes(queueMaxSizeInBytes);
             s.setElementIOFactory(pageIOFactory);
             s.setCheckpointIOFactory(checkpointIOFactory);
             s.setElementClass(Event.class);

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -42,6 +42,7 @@ module LogStash
             Setting::String.new("http.environment", "production"),
             Setting::String.new("queue.type", "memory", true, ["persisted", "memory", "memory_acked"]),
             Setting::Bytes.new("queue.page_capacity", "250mb"),
+            Setting::Bytes.new("queue.max_size", "1024mb"),
             Setting::Numeric.new("queue.max_events", 0), # 0 is unlimited
             Setting::Numeric.new("queue.checkpoint.acks", 1024), # 0 is unlimited
             Setting::Numeric.new("queue.checkpoint.writes", 1024), # 0 is unlimited

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -42,7 +42,7 @@ module LogStash
             Setting::String.new("http.environment", "production"),
             Setting::String.new("queue.type", "memory", true, ["persisted", "memory", "memory_acked"]),
             Setting::Bytes.new("queue.page_capacity", "250mb"),
-            Setting::Bytes.new("queue.max_size", "1024mb"),
+            Setting::Bytes.new("queue.max_bytes", "1024mb"),
             Setting::Numeric.new("queue.max_events", 0), # 0 is unlimited
             Setting::Numeric.new("queue.checkpoint.acks", 1024), # 0 is unlimited
             Setting::Numeric.new("queue.checkpoint.writes", 1024), # 0 is unlimited

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -118,7 +118,7 @@ module LogStash; class Pipeline
   def build_queue_from_settings
     queue_type = settings.get("queue.type")
     queue_page_capacity = settings.get("queue.page_capacity")
-    queue_max_size = settings.get("queue.max_size")
+    queue_max_bytes = settings.get("queue.max_bytes")
     queue_max_events = settings.get("queue.max_events")
     checkpoint_max_acks = settings.get("queue.checkpoint.acks")
     checkpoint_max_writes = settings.get("queue.checkpoint.writes")
@@ -126,14 +126,14 @@ module LogStash; class Pipeline
 
     if queue_type == "memory_acked"
       # memory_acked is used in tests/specs
-      LogStash::Util::WrappedAckedQueue.create_memory_based("", queue_page_capacity, queue_max_events, queue_max_size)
+      LogStash::Util::WrappedAckedQueue.create_memory_based("", queue_page_capacity, queue_max_events, queue_max_bytes)
     elsif queue_type == "memory"
       # memory is the legacy and default setting
       LogStash::Util::WrappedSynchronousQueue.new()
     elsif queue_type == "persisted"
       # persisted is the disk based acked queue
       queue_path = settings.get("path.queue")
-      LogStash::Util::WrappedAckedQueue.create_file_based(queue_path, queue_page_capacity, queue_max_events, checkpoint_max_writes, checkpoint_max_acks, checkpoint_max_interval, queue_max_size)
+      LogStash::Util::WrappedAckedQueue.create_file_based(queue_path, queue_page_capacity, queue_max_events, checkpoint_max_writes, checkpoint_max_acks, checkpoint_max_interval, queue_max_bytes)
     else
       raise(ConfigurationError, "invalid queue.type setting")
     end

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -118,21 +118,22 @@ module LogStash; class Pipeline
   def build_queue_from_settings
     queue_type = settings.get("queue.type")
     queue_page_capacity = settings.get("queue.page_capacity")
-    max_events = settings.get("queue.max_events")
+    queue_max_size = settings.get("queue.max_size")
+    queue_max_events = settings.get("queue.max_events")
     checkpoint_max_acks = settings.get("queue.checkpoint.acks")
     checkpoint_max_writes = settings.get("queue.checkpoint.writes")
     checkpoint_max_interval = settings.get("queue.checkpoint.interval")
 
     if queue_type == "memory_acked"
       # memory_acked is used in tests/specs
-      LogStash::Util::WrappedAckedQueue.create_memory_based("", queue_page_capacity, max_events)
+      LogStash::Util::WrappedAckedQueue.create_memory_based("", queue_page_capacity, queue_max_events, queue_max_size)
     elsif queue_type == "memory"
       # memory is the legacy and default setting
       LogStash::Util::WrappedSynchronousQueue.new()
     elsif queue_type == "persisted"
       # persisted is the disk based acked queue
       queue_path = settings.get("path.queue")
-      LogStash::Util::WrappedAckedQueue.create_file_based(queue_path, queue_page_capacity, max_events, checkpoint_max_writes, checkpoint_max_acks, checkpoint_max_interval)
+      LogStash::Util::WrappedAckedQueue.create_file_based(queue_path, queue_page_capacity, queue_max_events, checkpoint_max_writes, checkpoint_max_acks, checkpoint_max_interval, queue_max_size)
     else
       raise(ConfigurationError, "invalid queue.type setting")
     end

--- a/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
@@ -19,15 +19,15 @@ module LogStash; module Util
     class QueueClosedError < ::StandardError; end
     class NotImplementedError < ::StandardError; end
 
-    def self.create_memory_based(path, capacity, size)
+    def self.create_memory_based(path, capacity, max_events, max_size)
       self.allocate.with_queue(
-        LogStash::AckedMemoryQueue.new(path, capacity, size)
+        LogStash::AckedMemoryQueue.new(path, capacity, max_events, max_size)
       )
     end
 
-    def self.create_file_based(path, capacity, size, checkpoint_max_writes, checkpoint_max_acks, checkpoint_max_interval)
+    def self.create_file_based(path, capacity, max_events, checkpoint_max_writes, checkpoint_max_acks, checkpoint_max_interval, max_size)
       self.allocate.with_queue(
-        LogStash::AckedQueue.new(path, capacity, size, checkpoint_max_writes, checkpoint_max_acks, checkpoint_max_interval)
+        LogStash::AckedQueue.new(path, capacity, max_events, checkpoint_max_writes, checkpoint_max_acks, checkpoint_max_interval, max_size)
       )
     end
 

--- a/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
@@ -19,15 +19,15 @@ module LogStash; module Util
     class QueueClosedError < ::StandardError; end
     class NotImplementedError < ::StandardError; end
 
-    def self.create_memory_based(path, capacity, max_events, max_size)
+    def self.create_memory_based(path, capacity, max_events, max_bytes)
       self.allocate.with_queue(
-        LogStash::AckedMemoryQueue.new(path, capacity, max_events, max_size)
+        LogStash::AckedMemoryQueue.new(path, capacity, max_events, max_bytes)
       )
     end
 
-    def self.create_file_based(path, capacity, max_events, checkpoint_max_writes, checkpoint_max_acks, checkpoint_max_interval, max_size)
+    def self.create_file_based(path, capacity, max_events, checkpoint_max_writes, checkpoint_max_acks, checkpoint_max_interval, max_bytes)
       self.allocate.with_queue(
-        LogStash::AckedQueue.new(path, capacity, max_events, checkpoint_max_writes, checkpoint_max_acks, checkpoint_max_interval, max_size)
+        LogStash::AckedQueue.new(path, capacity, max_events, checkpoint_max_writes, checkpoint_max_acks, checkpoint_max_interval, max_bytes)
       )
     end
 

--- a/logstash-core/spec/logstash/pipeline_pq_file_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_pq_file_spec.rb
@@ -78,7 +78,7 @@ describe LogStash::Pipeline do
   let(:worker_thread_count) { 8 } # 1 4 8
   let(:number_of_events) { 100_000 }
   let(:page_capacity) { 1 * 1024 * 512 } # 1 128
-  let(:max_size) { 1024 * 1024 * 1024 } # 1 gb
+  let(:max_bytes) { 1024 * 1024 * 1024 } # 1 gb
   let(:queue_type) { "persisted" } #  "memory" "memory_acked"
   let(:times) { [] }
 
@@ -96,7 +96,7 @@ describe LogStash::Pipeline do
     allow(pipeline_workers_setting).to receive(:default).and_return(worker_thread_count)
     pipeline_settings.each {|k, v| pipeline_settings_obj.set(k, v) }
     pipeline_settings_obj.set("queue.page_capacity", page_capacity)
-    pipeline_settings_obj.set("queue.max_size", max_size)
+    pipeline_settings_obj.set("queue.max_bytes", max_bytes)
     Thread.new do
       # make sure we have received all the generated events
       while counting_output.event_count < number_of_events do
@@ -123,7 +123,7 @@ describe LogStash::Pipeline do
     expect(_metric[:out].value).to eq(number_of_events)
     STDOUT.puts "  queue.type: #{pipeline_settings_obj.get("queue.type")}"
     STDOUT.puts "  queue.page_capacity: #{pipeline_settings_obj.get("queue.page_capacity") / 1024}KB"
-    STDOUT.puts "  queue.max_size: #{pipeline_settings_obj.get("queue.max_size") / 1024}KB"
+    STDOUT.puts "  queue.max_bytes: #{pipeline_settings_obj.get("queue.max_bytes") / 1024}KB"
     STDOUT.puts "  workers: #{worker_thread_count}"
     STDOUT.puts "  events: #{number_of_events}"
     STDOUT.puts "  took: #{times.first}s"

--- a/logstash-core/spec/logstash/pipeline_pq_file_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_pq_file_spec.rb
@@ -78,6 +78,7 @@ describe LogStash::Pipeline do
   let(:worker_thread_count) { 8 } # 1 4 8
   let(:number_of_events) { 100_000 }
   let(:page_capacity) { 1 * 1024 * 512 } # 1 128
+  let(:max_size) { 1024 * 1024 * 1024 } # 1 gb
   let(:queue_type) { "persisted" } #  "memory" "memory_acked"
   let(:times) { [] }
 
@@ -95,6 +96,7 @@ describe LogStash::Pipeline do
     allow(pipeline_workers_setting).to receive(:default).and_return(worker_thread_count)
     pipeline_settings.each {|k, v| pipeline_settings_obj.set(k, v) }
     pipeline_settings_obj.set("queue.page_capacity", page_capacity)
+    pipeline_settings_obj.set("queue.max_size", max_size)
     Thread.new do
       # make sure we have received all the generated events
       while counting_output.event_count < number_of_events do
@@ -121,6 +123,7 @@ describe LogStash::Pipeline do
     expect(_metric[:out].value).to eq(number_of_events)
     STDOUT.puts "  queue.type: #{pipeline_settings_obj.get("queue.type")}"
     STDOUT.puts "  queue.page_capacity: #{pipeline_settings_obj.get("queue.page_capacity") / 1024}KB"
+    STDOUT.puts "  queue.max_size: #{pipeline_settings_obj.get("queue.max_size") / 1024}KB"
     STDOUT.puts "  workers: #{worker_thread_count}"
     STDOUT.puts "  events: #{number_of_events}"
     STDOUT.puts "  took: #{times.first}s"

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -450,7 +450,7 @@ describe LogStash::Pipeline do
       allow(settings).to receive(:get).with("queue.type").and_return("memory")
       allow(settings).to receive(:get).with("queue.page_capacity").and_return(1024 * 1024)
       allow(settings).to receive(:get).with("queue.max_events").and_return(250)
-      allow(settings).to receive(:get).with("queue.max_size").and_return(1024 * 1024 * 1024)
+      allow(settings).to receive(:get).with("queue.max_bytes").and_return(1024 * 1024 * 1024)
       allow(settings).to receive(:get).with("queue.checkpoint.acks").and_return(1024)
       allow(settings).to receive(:get).with("queue.checkpoint.writes").and_return(1024)
       allow(settings).to receive(:get).with("queue.checkpoint.interval").and_return(1000)

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -450,6 +450,7 @@ describe LogStash::Pipeline do
       allow(settings).to receive(:get).with("queue.type").and_return("memory")
       allow(settings).to receive(:get).with("queue.page_capacity").and_return(1024 * 1024)
       allow(settings).to receive(:get).with("queue.max_events").and_return(250)
+      allow(settings).to receive(:get).with("queue.max_size").and_return(1024 * 1024 * 1024)
       allow(settings).to receive(:get).with("queue.checkpoint.acks").and_return(1024)
       allow(settings).to receive(:get).with("queue.checkpoint.writes").and_return(1024)
       allow(settings).to receive(:get).with("queue.checkpoint.interval").and_return(1000)

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/FileSettings.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/FileSettings.java
@@ -9,7 +9,7 @@ public class FileSettings implements Settings {
     private PageIOFactory pageIOFactory;
     private Class elementClass;
     private int capacity;
-    private long queueMaxSizeInBytes;
+    private long queueMaxBytes;
     private int maxUnread;
     private int checkpointMaxAcks;
     private int checkpointMaxWrites;
@@ -44,8 +44,8 @@ public class FileSettings implements Settings {
     }
 
     @Override
-    public Settings setQueueMaxSizeInBytes(long size) {
-        this.queueMaxSizeInBytes = size;
+    public Settings setQueueMaxBytes(long size) {
+        this.queueMaxBytes = size;
         return this;
     }
 
@@ -114,7 +114,7 @@ public class FileSettings implements Settings {
     }
 
     @Override
-    public long getQueueMaxSizeInBytes() { return queueMaxSizeInBytes; }
+    public long getQueueMaxBytes() { return queueMaxBytes; }
 
     @Override
     public int getCapacity() {

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/FileSettings.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/FileSettings.java
@@ -9,7 +9,7 @@ public class FileSettings implements Settings {
     private PageIOFactory pageIOFactory;
     private Class elementClass;
     private int capacity;
-    private int queueMaxSizeInBytes;
+    private long queueMaxSizeInBytes;
     private int maxUnread;
     private int checkpointMaxAcks;
     private int checkpointMaxWrites;
@@ -44,7 +44,7 @@ public class FileSettings implements Settings {
     }
 
     @Override
-    public Settings setQueueMaxSizeInBytes(int size) {
+    public Settings setQueueMaxSizeInBytes(long size) {
         this.queueMaxSizeInBytes = size;
         return this;
     }
@@ -114,7 +114,7 @@ public class FileSettings implements Settings {
     }
 
     @Override
-    public int getQueueMaxSizeInBytes() { return queueMaxSizeInBytes; }
+    public long getQueueMaxSizeInBytes() { return queueMaxSizeInBytes; }
 
     @Override
     public int getCapacity() {

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/FileSettings.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/FileSettings.java
@@ -114,7 +114,9 @@ public class FileSettings implements Settings {
     }
 
     @Override
-    public long getQueueMaxBytes() { return queueMaxBytes; }
+    public long getQueueMaxBytes() {
+        return queueMaxBytes;
+    }
 
     @Override
     public int getCapacity() {

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/FileSettings.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/FileSettings.java
@@ -9,6 +9,7 @@ public class FileSettings implements Settings {
     private PageIOFactory pageIOFactory;
     private Class elementClass;
     private int capacity;
+    private int queueMaxSizeInBytes;
     private int maxUnread;
     private int checkpointMaxAcks;
     private int checkpointMaxWrites;
@@ -39,6 +40,12 @@ public class FileSettings implements Settings {
     @Override
     public Settings setElementClass(Class elementClass) {
         this.elementClass = elementClass;
+        return this;
+    }
+
+    @Override
+    public Settings setQueueMaxSizeInBytes(int size) {
+        this.queueMaxSizeInBytes = size;
         return this;
     }
 
@@ -105,6 +112,9 @@ public class FileSettings implements Settings {
     public String getDirPath() {
         return dirForFiles;
     }
+
+    @Override
+    public int getQueueMaxSizeInBytes() { return queueMaxSizeInBytes; }
 
     @Override
     public int getCapacity() {

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/MemorySettings.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/MemorySettings.java
@@ -8,7 +8,7 @@ public class MemorySettings implements Settings {
     private PageIOFactory pageIOFactory;
     private Class elementClass;
     private int capacity;
-    private long queueMaxSizeInBytes;
+    private long queueMaxBytes;
     private final String dirPath;
     private int maxUnread;
     private int checkpointMaxAcks;
@@ -52,8 +52,8 @@ public class MemorySettings implements Settings {
     }
 
     @Override
-    public Settings setQueueMaxSizeInBytes(long size) {
-        this.queueMaxSizeInBytes = size;
+    public Settings setQueueMaxBytes(long size) {
+        this.queueMaxBytes = size;
         return this;
     }
 
@@ -115,7 +115,7 @@ public class MemorySettings implements Settings {
         return this.dirPath;
     }
 
-    public long getQueueMaxSizeInBytes() { return this.queueMaxSizeInBytes; }
+    public long getQueueMaxBytes() { return this.queueMaxBytes; }
 
     @Override
     public int getCapacity() {

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/MemorySettings.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/MemorySettings.java
@@ -8,6 +8,7 @@ public class MemorySettings implements Settings {
     private PageIOFactory pageIOFactory;
     private Class elementClass;
     private int capacity;
+    private int queueMaxSizeInBytes;
     private final String dirPath;
     private int maxUnread;
     private int checkpointMaxAcks;
@@ -47,6 +48,12 @@ public class MemorySettings implements Settings {
     @Override
     public Settings setCapacity(int capacity) {
         this.capacity = capacity;
+        return this;
+    }
+
+    @Override
+    public Settings setQueueMaxSizeInBytes(int size) {
+        this.queueMaxSizeInBytes = size;
         return this;
     }
 
@@ -107,6 +114,8 @@ public class MemorySettings implements Settings {
     public String getDirPath() {
         return this.dirPath;
     }
+
+    public int getQueueMaxSizeInBytes() { return this.queueMaxSizeInBytes; }
 
     @Override
     public int getCapacity() {

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/MemorySettings.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/MemorySettings.java
@@ -115,7 +115,10 @@ public class MemorySettings implements Settings {
         return this.dirPath;
     }
 
-    public long getQueueMaxBytes() { return this.queueMaxBytes; }
+    @Override
+    public long getQueueMaxBytes() {
+        return this.queueMaxBytes;
+    }
 
     @Override
     public int getCapacity() {

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/MemorySettings.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/MemorySettings.java
@@ -8,7 +8,7 @@ public class MemorySettings implements Settings {
     private PageIOFactory pageIOFactory;
     private Class elementClass;
     private int capacity;
-    private int queueMaxSizeInBytes;
+    private long queueMaxSizeInBytes;
     private final String dirPath;
     private int maxUnread;
     private int checkpointMaxAcks;
@@ -52,7 +52,7 @@ public class MemorySettings implements Settings {
     }
 
     @Override
-    public Settings setQueueMaxSizeInBytes(int size) {
+    public Settings setQueueMaxSizeInBytes(long size) {
         this.queueMaxSizeInBytes = size;
         return this;
     }
@@ -115,7 +115,7 @@ public class MemorySettings implements Settings {
         return this.dirPath;
     }
 
-    public int getQueueMaxSizeInBytes() { return this.queueMaxSizeInBytes; }
+    public long getQueueMaxSizeInBytes() { return this.queueMaxSizeInBytes; }
 
     @Override
     public int getCapacity() {

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Settings.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Settings.java
@@ -12,6 +12,8 @@ public interface Settings {
 
     Settings setCapacity(int capacity);
 
+    Settings setQueueMaxSizeInBytes(int size);
+
     Settings setMaxUnread(int maxUnread);
 
     Settings setCheckpointMaxAcks(int checkpointMaxAcks);
@@ -29,6 +31,8 @@ public interface Settings {
     String getDirPath();
 
     int getCapacity();
+
+    int getQueueMaxSizeInBytes();
 
     int getMaxUnread();
 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Settings.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Settings.java
@@ -12,7 +12,7 @@ public interface Settings {
 
     Settings setCapacity(int capacity);
 
-    Settings setQueueMaxSizeInBytes(int size);
+    Settings setQueueMaxSizeInBytes(long size);
 
     Settings setMaxUnread(int maxUnread);
 
@@ -32,7 +32,7 @@ public interface Settings {
 
     int getCapacity();
 
-    int getQueueMaxSizeInBytes();
+    long getQueueMaxSizeInBytes();
 
     int getMaxUnread();
 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Settings.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Settings.java
@@ -12,7 +12,7 @@ public interface Settings {
 
     Settings setCapacity(int capacity);
 
-    Settings setQueueMaxSizeInBytes(long size);
+    Settings setQueueMaxBytes(long size);
 
     Settings setMaxUnread(int maxUnread);
 
@@ -32,7 +32,7 @@ public interface Settings {
 
     int getCapacity();
 
-    long getQueueMaxSizeInBytes();
+    long getQueueMaxBytes();
 
     int getMaxUnread();
 

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
@@ -456,7 +456,7 @@ public class QueueTest {
 
         assertThat(q.isFull(), is(true));
 
-        Batch b = q.readBatch(9); // read 1 page (10 events)
+        Batch b = q.readBatch(10); // read 1 page (10 events)
         b.close();  // purge 1 page
 
         // spin wait until data is written and write blocks

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
@@ -390,4 +390,58 @@ public class QueueTest {
         assertThat(q.unreadCount, is(equalTo(1L)));
     }
 
+    @Test
+    public void reachMaxSizeTest() throws IOException, InterruptedException, ExecutionException {
+        Queueable element = new StringElement("0123456789"); // 10 bytes
+
+        Settings settings = TestSettings.getSettings(256, 1000); // allow 10 elements per page but only 1024 bytes in total
+
+        TestQueue q = new TestQueue(settings);
+        q.open();
+
+        int ELEMENT_COUNT = 99; // should be able to write 100 events before getting full
+        for (int i = 0; i < ELEMENT_COUNT; i++) {
+            long seqNum = q.write(element);
+        }
+
+        assertThat(q.isFull(), is(false));
+
+        // we expect this next write call to block so let's wrap it in a Future
+        Callable<Long> write = () -> {
+            return q.write(element);
+        };
+
+        ExecutorService executor = Executors.newFixedThreadPool(1);
+        Future<Long> future = executor.submit(write);
+
+        Thread.sleep(1);
+        assertThat(q.isFull(), is(true));
+        // spin wait until data is written and write blocks
+        //while (!q.isFull()) { Thread.sleep(1); }
+            /*
+
+
+            // read one element, which will unblock the last write
+            Batch b = q.nonBlockReadBatch(1);
+            assertThat(b, is(notNullValue()));
+            assertThat(b.getElements().size(), is(equalTo(1)));
+            b.close();
+
+            // future result is the blocked write seqNum for the second element
+            assertThat(future.get(), is(equalTo(2L + i)));
+            assertThat(q.isFull(), is(false));
+
+            executor.shutdown();
+        }
+
+        // all batches are acked, no tail pages should exist
+        assertThat(q.getTailPages().size(), is(equalTo(0)));
+
+        // the last read unblocked the last write so some elements (1 unread and maybe some acked) should be in the head page
+        assertThat(q.getHeadPage().getElementCount() > 0L, is(true));
+        assertThat(q.getHeadPage().unreadCount(), is(equalTo(1L)));
+        assertThat(q.unreadCount, is(equalTo(1L)));
+        */
+    }
+
 }

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
@@ -417,7 +417,7 @@ public class QueueTest {
         ExecutorService executor = Executors.newFixedThreadPool(1);
         Future<Long> future = executor.submit(write);
 
-        while (!q.isFull()) { Thread.sleep(1); }
+        while (!q.isFull()) { Thread.sleep(10); }
 
         assertThat(q.isFull(), is(true));
 
@@ -452,7 +452,7 @@ public class QueueTest {
         ExecutorService executor = Executors.newFixedThreadPool(1);
         Future<Long> future = executor.submit(write);
 
-        while (!q.isFull()) { Thread.sleep(1); }
+        while (!q.isFull()) { Thread.sleep(10); }
 
         assertThat(q.isFull(), is(true));
 
@@ -460,7 +460,7 @@ public class QueueTest {
         b.close();  // purge 1 page
 
         // spin wait until data is written and write blocks
-        while (q.isFull()) { Thread.sleep(1); }
+        while (q.isFull()) { Thread.sleep(10); }
 
         assertThat(q.isFull(), is(false));
 
@@ -495,7 +495,7 @@ public class QueueTest {
         ExecutorService executor = Executors.newFixedThreadPool(1);
         Future<Long> future = executor.submit(write);
 
-        while (!q.isFull()) { Thread.sleep(1); }
+        while (!q.isFull()) { Thread.sleep(10); }
 
         assertThat(q.isFull(), is(true));
 

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
@@ -399,7 +399,7 @@ public class QueueTest {
         TestQueue q = new TestQueue(settings);
         q.open();
 
-        int ELEMENT_COUNT = 99; // should be able to write 100 events before getting full
+        int ELEMENT_COUNT = 99; // should be able to write 99 events before getting full
         for (int i = 0; i < ELEMENT_COUNT; i++) {
             long seqNum = q.write(element);
         }
@@ -416,32 +416,8 @@ public class QueueTest {
 
         Thread.sleep(1);
         assertThat(q.isFull(), is(true));
-        // spin wait until data is written and write blocks
-        //while (!q.isFull()) { Thread.sleep(1); }
-            /*
 
-
-            // read one element, which will unblock the last write
-            Batch b = q.nonBlockReadBatch(1);
-            assertThat(b, is(notNullValue()));
-            assertThat(b.getElements().size(), is(equalTo(1)));
-            b.close();
-
-            // future result is the blocked write seqNum for the second element
-            assertThat(future.get(), is(equalTo(2L + i)));
-            assertThat(q.isFull(), is(false));
-
-            executor.shutdown();
-        }
-
-        // all batches are acked, no tail pages should exist
-        assertThat(q.getTailPages().size(), is(equalTo(0)));
-
-        // the last read unblocked the last write so some elements (1 unread and maybe some acked) should be in the head page
-        assertThat(q.getHeadPage().getElementCount() > 0L, is(true));
-        assertThat(q.getHeadPage().unreadCount(), is(equalTo(1L)));
-        assertThat(q.unreadCount, is(equalTo(1L)));
-        */
+        executor.shutdown();
     }
 
 }

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/TestSettings.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/TestSettings.java
@@ -20,6 +20,19 @@ public class TestSettings {
         return s;
     }
 
+    public static Settings getSettings(int capacity, int size) {
+        MemoryCheckpointIO.clearSources();
+        Settings s = new MemorySettings();
+        PageIOFactory pageIOFactory = (pageNum, pageSize, path) -> new ByteBufferPageIO(pageNum, pageSize, path);
+        CheckpointIOFactory checkpointIOFactory = (source) -> new MemoryCheckpointIO(source);
+        s.setCapacity(capacity);
+        s.setQueueMaxSizeInBytes(size);
+        s.setElementIOFactory(pageIOFactory);
+        s.setCheckpointIOFactory(checkpointIOFactory);
+        s.setElementClass(StringElement.class);
+        return s;
+    }
+
     public static Settings getSettingsCheckpointFilePageMemory(int capacity, String folder) {
         Settings s = new FileSettings(folder);
         PageIOFactory pageIOFactory = (pageNum, size, path) -> new ByteBufferPageIO(pageNum, size, path);

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/TestSettings.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/TestSettings.java
@@ -20,7 +20,7 @@ public class TestSettings {
         return s;
     }
 
-    public static Settings getSettings(int capacity, int size) {
+    public static Settings getSettings(int capacity, long size) {
         MemoryCheckpointIO.clearSources();
         Settings s = new MemorySettings();
         PageIOFactory pageIOFactory = (pageNum, pageSize, path) -> new ByteBufferPageIO(pageNum, pageSize, path);

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/TestSettings.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/TestSettings.java
@@ -26,7 +26,7 @@ public class TestSettings {
         PageIOFactory pageIOFactory = (pageNum, pageSize, path) -> new ByteBufferPageIO(pageNum, pageSize, path);
         CheckpointIOFactory checkpointIOFactory = (source) -> new MemoryCheckpointIO(source);
         s.setCapacity(capacity);
-        s.setQueueMaxSizeInBytes(size);
+        s.setQueueMaxBytes(size);
         s.setElementIOFactory(pageIOFactory);
         s.setCheckpointIOFactory(checkpointIOFactory);
         s.setElementClass(StringElement.class);


### PR DESCRIPTION
introduce a setting to define the maximum size of the Queue in bytes.

The current strategy involves keeping a counter of the queue size by:

* bootstrapping the counter during queue initialization by going through each tail page and add its capacity to the counter
* every new write adds the byte count to the counter
* `isFull()` has an extra boolean check that compares current and max size for the queue

TODO:

- [x] account for the purge of pages (decrementing currentSize)
- [x] add ruby code to expose the config setting
- [x] test the unblocking of writes once pages are purged
- [ ] add currentSize of queue as a logstash metric (? to be determined if done in this PR)