### PR TITLE
Fixed typo for logstash cli help in logstash shell script

### DIFF
--- a/bin/logstash
+++ b/bin/logstash
@@ -6,7 +6,7 @@
 # Usage:
 #   bin/logstash <command> [arguments]
 #
-# See 'bin/logstash help' for a list of commands.
+# See 'bin/logstash --help' for a list of commands.
 #
 # Supported environment variables:
 #   LS_JVM_OPTS="xxx" path to file with JVM options


### PR DESCRIPTION
The original shell script throws a error when calling it with "bin/logstash help"
```
# ./logstash help
ERROR: Unknown command 'help'

See: 'bin/logstash --help'
```
./logstash --help is the correct syntax