### PR TITLE
Remove unnecessary log4j-1.2-api depedency.

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -110,7 +110,6 @@ idea {
 }
 
 dependencies {
-    runtime 'org.apache.logging.log4j:log4j-1.2-api:2.6.2'
     compile 'org.apache.logging.log4j:log4j-api:2.6.2'
     compile 'org.apache.logging.log4j:log4j-core:2.6.2'
     compile 'com.fasterxml.jackson.core:jackson-core:2.7.4'

--- a/logstash-core/gemspec_jars.rb
+++ b/logstash-core/gemspec_jars.rb
@@ -2,7 +2,6 @@
 # runtime dependencies to generate this gemspec dependencies file to be eval'ed by the gemspec
 # for the jar-dependencies requirements.
 
-gem.requirements << "jar org.apache.logging.log4j:log4j-1.2-api, 2.6.2"
 gem.requirements << "jar org.apache.logging.log4j:log4j-api, 2.6.2"
 gem.requirements << "jar org.apache.logging.log4j:log4j-core, 2.6.2"
 gem.requirements << "jar com.fasterxml.jackson.core:jackson-core, 2.7.4"

--- a/logstash-core/lib/logstash-core_jars.rb
+++ b/logstash-core/lib/logstash-core_jars.rb
@@ -5,7 +5,6 @@ rescue LoadError
   require 'org/apache/logging/log4j/log4j-core/2.6.2/log4j-core-2.6.2.jar'
   require 'org/apache/logging/log4j/log4j-api/2.6.2/log4j-api-2.6.2.jar'
   require 'com/fasterxml/jackson/core/jackson-core/2.7.4/jackson-core-2.7.4.jar'
-  require 'org/apache/logging/log4j/log4j-1.2-api/2.6.2/log4j-1.2-api-2.6.2.jar'
   require 'com/fasterxml/jackson/core/jackson-annotations/2.7.0/jackson-annotations-2.7.0.jar'
   require 'com/fasterxml/jackson/core/jackson-databind/2.7.4/jackson-databind-2.7.4.jar'
 end
@@ -14,7 +13,6 @@ if defined? Jars
   require_jar( 'org.apache.logging.log4j', 'log4j-core', '2.6.2' )
   require_jar( 'org.apache.logging.log4j', 'log4j-api', '2.6.2' )
   require_jar( 'com.fasterxml.jackson.core', 'jackson-core', '2.7.4' )
-  require_jar( 'org.apache.logging.log4j', 'log4j-1.2-api', '2.6.2' )
   require_jar( 'com.fasterxml.jackson.core', 'jackson-annotations', '2.7.0' )
   require_jar( 'com.fasterxml.jackson.core', 'jackson-databind', '2.7.4' )
 end


### PR DESCRIPTION
This log4j-1.2-api library provides a "log4j 1.2"-like API from the log4j2 library.

We don't seem to use this, and including it seems to be the cause of the
Logstash log4j input rejecting log4j 1.x's SocketAppender with this
message:

    org.apache.log4j.spi.LoggingEvent; class invalid for deserialization

The origin of this error is that log4j2's log4j-1.2-api defines
LoggingEvent without `implements Serializable`.

This commit also includes regenerated gemspec_jars.rb and
logstash-core_jars.rb.

Reference: https://github.com/logstash-plugins/logstash-input-log4j/issues/36