### PR TITLE
Relax the acceptance test expectation to match only the exception

### DIFF
--- a/lib/pluginmanager/remove.rb
+++ b/lib/pluginmanager/remove.rb
@@ -17,7 +17,7 @@ class LogStash::PluginManager::Remove < LogStash::PluginManager::Command
 
     # make sure this is an installed plugin and present in Gemfile.
     # it is not possible to uninstall a dependency not listed in the Gemfile, for example a dependent codec
-    signal_error("This plugin has not been previously installed, aborting") unless LogStash::PluginManager.installed_plugin?(plugin, gemfile)
+    signal_error("This plugin has not been previously installed") unless LogStash::PluginManager.installed_plugin?(plugin, gemfile)
 
     exit(1) unless ::Bundler::LogstashUninstall.uninstall!(plugin)
 

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/remove.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/remove.rb
@@ -16,7 +16,7 @@ shared_examples "logstash remove" do |logstash|
     context "when the plugin isn't installed" do
       it "fails to remove it" do
         result = logstash.run_command_in_path("bin/logstash-plugin remove logstash-filter-qatest")
-        expect(result.stderr).to match(/ERROR: Remove Aborted, message: This plugin has not been previously installed, aborting/)
+        expect(result.stderr).to match(/This plugin has not been previously installed/)
       end
     end
 

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/uninstall.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/uninstall.rb
@@ -16,7 +16,7 @@ shared_examples "logstash uninstall" do |logstash|
     context "when the plugin isn't installed" do
       it "fails to uninstall it" do
         result = logstash.run_command_in_path("bin/logstash-plugin uninstall logstash-filter-qatest")
-        expect(result.stderr).to match(/ERROR: Uninstall Aborted, message: This plugin has not been previously installed, aborting/)
+        expect(result.stderr).to match(/This plugin has not been previously installed/)
       end
     end
 


### PR DESCRIPTION
Relax the acceptance test expectation to match only the exception

Fixes: #6310