### PR TITLE
add queue stats to node/stats api

### DIFF
--- a/logstash-core-queue-jruby/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java
+++ b/logstash-core-queue-jruby/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java
@@ -87,6 +87,46 @@ public class JrubyAckedQueueExtLibrary implements Library {
             return context.nil;
         }
 
+        @JRubyMethod(name = "max_unread_events")
+        public IRubyObject ruby_max_unread_events(ThreadContext context) {
+            return context.runtime.newFixnum(queue.getMaxUnread());
+        }
+
+        @JRubyMethod(name = "max_size_in_bytes")
+        public IRubyObject ruby_max_size_in_bytes(ThreadContext context) {
+            return context.runtime.newFixnum(queue.getMaxBytes());
+        }
+
+        @JRubyMethod(name = "page_capacity")
+        public IRubyObject ruby_page_capacity(ThreadContext context) {
+            return context.runtime.newFixnum(queue.getPageCapacity());
+        }
+
+        @JRubyMethod(name = "dir_path")
+        public IRubyObject ruby_dir_path(ThreadContext context) {
+            return context.runtime.newString(queue.getDirPath());
+        }
+
+        @JRubyMethod(name = "current_byte_size")
+        public IRubyObject ruby_current_byte_size(ThreadContext context) {
+            return context.runtime.newFixnum(queue.getCurrentByteSize());
+        }
+
+        @JRubyMethod(name = "acked_count")
+        public IRubyObject ruby_acked_count(ThreadContext context) {
+            return context.runtime.newFixnum(queue.getAckedCount());
+        }
+
+        @JRubyMethod(name = "unacked_count")
+        public IRubyObject ruby_unacked_count(ThreadContext context) {
+            return context.runtime.newFixnum(queue.getUnackedCount());
+        }
+
+        @JRubyMethod(name = "unread_count")
+        public IRubyObject ruby_unread_count(ThreadContext context) {
+            return context.runtime.newFixnum(queue.getUnreadCount());
+        }
+
         @JRubyMethod(name = "open")
         public IRubyObject ruby_open(ThreadContext context)
         {

--- a/logstash-core-queue-jruby/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueMemoryExtLibrary.java
+++ b/logstash-core-queue-jruby/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueMemoryExtLibrary.java
@@ -81,6 +81,46 @@ public class JrubyAckedQueueMemoryExtLibrary implements Library {
             return context.nil;
         }
 
+        @JRubyMethod(name = "max_unread_events")
+        public IRubyObject ruby_max_unread_events(ThreadContext context) {
+            return context.runtime.newFixnum(queue.getMaxUnread());
+        }
+
+        @JRubyMethod(name = "max_size_in_bytes")
+        public IRubyObject ruby_max_size_in_bytes(ThreadContext context) {
+            return context.runtime.newFixnum(queue.getMaxBytes());
+        }
+
+        @JRubyMethod(name = "page_capacity")
+        public IRubyObject ruby_page_capacity(ThreadContext context) {
+            return context.runtime.newFixnum(queue.getPageCapacity());
+        }
+
+        @JRubyMethod(name = "dir_path")
+        public IRubyObject ruby_dir_path(ThreadContext context) {
+            return context.runtime.newString(queue.getDirPath());
+        }
+
+        @JRubyMethod(name = "current_byte_size")
+        public IRubyObject ruby_current_byte_size(ThreadContext context) {
+            return context.runtime.newFixnum(queue.getCurrentByteSize());
+        }
+
+        @JRubyMethod(name = "acked_count")
+        public IRubyObject ruby_acked_count(ThreadContext context) {
+            return context.runtime.newFixnum(queue.getAckedCount());
+        }
+
+        @JRubyMethod(name = "unread_count")
+        public IRubyObject ruby_unread_count(ThreadContext context) {
+            return context.runtime.newFixnum(queue.getUnreadCount());
+        }
+
+        @JRubyMethod(name = "unacked_count")
+        public IRubyObject ruby_unacked_count(ThreadContext context) {
+            return context.runtime.newFixnum(queue.getUnackedCount());
+        }
+
         @JRubyMethod(name = "open")
         public IRubyObject ruby_open(ThreadContext context)
         {

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -215,7 +215,9 @@ class LogStash::Agent
               end
 
 
-    @periodic_pollers = LogStash::Instrument::PeriodicPollers.new(@metric)
+    @periodic_pollers = LogStash::Instrument::PeriodicPollers.new(@metric,
+                                                                  settings.get("queue.type"),
+                                                                  self)
     @periodic_pollers.start
   end
 
@@ -331,8 +333,9 @@ class LogStash::Agent
   def start_pipelines
     @instance_reload_metric.increment(:successes, 0)
     @instance_reload_metric.increment(:failures, 0)
-    @pipelines.each do |id, _|
+    @pipelines.each do |id, pipeline|
       start_pipeline(id)
+      pipeline.collect_stats
       # no reloads yet, initalize all the reload metrics
       init_pipeline_reload_metrics(id)
     end

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -178,6 +178,12 @@ class LogStash::Agent
     @id_path ||= ::File.join(settings.get("path.data"), "uuid")
   end
 
+  def running_pipelines
+    @upgrade_mutex.synchronize do
+      @pipelines.select {|pipeline_id, _| running_pipeline?(pipeline_id) }
+    end
+  end
+
   def running_pipelines?
     @upgrade_mutex.synchronize do
       @pipelines.select {|pipeline_id, _| running_pipeline?(pipeline_id) }.any?

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -22,10 +22,10 @@ module LogStash
             :uptime_in_millis => service.get_shallow(:jvm, :uptime_in_millis),
           }
         end
-        
+
         def reloads
           service.get_shallow(:stats, :reloads)
-        end  
+        end
 
         def process
           extract_metrics(
@@ -48,39 +48,6 @@ module LogStash
         def pipeline
           stats = service.get_shallow(:stats, :pipelines)
           PluginsStats.report(stats)
-        end
-
-        def queue
-          queue_type = service.agent.settings.get("queue.type")
-          pipeline = service.agent.pipelines { |id, _| service.agent.running_pipeline?(id) }.values.first
-          if pipeline.nil?
-            { :type => queue_type }
-          elsif pipeline.queue.is_a?(LogStash::Util::WrappedAckedQueue) && pipeline.queue.queue.is_a?(LogStash::AckedQueue)
-            queue = pipeline.queue.queue
-            dir_path = queue.dir_path
-            file_store = Files.get_file_store(Paths.get(dir_path))
-            {
-              :type => queue_type,
-              :capacity => {
-                :page_capacity_in_bytes => queue.page_capacity,
-                :max_queue_size_in_bytes => queue.max_size_in_bytes,
-                :max_unread_events => queue.max_unread_events,
-              },
-              :data => {
-                :free_space_in_bytes => file_store.get_unallocated_space,
-                :current_size_in_bytes => queue.current_byte_size,
-                :storage_type => file_store.type,
-                :path => dir_path
-              },
-              :events => {
-                :acked_count => queue.acked_count,
-                :unread_count => queue.unread_count,
-                :unacked_count => queue.unacked_count
-              }
-            }
-          else
-            { :type => queue_type }
-          end
         end
 
         def memory
@@ -134,6 +101,7 @@ module LogStash
                 :outputs => plugin_stats(stats, :outputs)
               },
               :reloads => stats[:reloads],
+              :queue => stats[:queue]
             }
           end
         end # module PluginsStats

--- a/logstash-core/lib/logstash/api/modules/node_stats.rb
+++ b/logstash-core/lib/logstash/api/modules/node_stats.rb
@@ -13,8 +13,7 @@ module LogStash
             :jvm => jvm_payload,
             :process => process_payload,
             :pipeline => pipeline_payload,
-            :reloads => reloads,
-            :queue => queue_payload
+            :reloads => reloads
           }
           respond_with(payload, {:filter => params["filter"]})
         end
@@ -43,10 +42,6 @@ module LogStash
 
         def pipeline_payload
           @stats.pipeline
-        end
-
-        def queue_payload
-          @stats.queue
         end
       end
     end

--- a/logstash-core/lib/logstash/api/modules/node_stats.rb
+++ b/logstash-core/lib/logstash/api/modules/node_stats.rb
@@ -13,7 +13,8 @@ module LogStash
             :jvm => jvm_payload,
             :process => process_payload,
             :pipeline => pipeline_payload,
-            :reloads => reloads
+            :reloads => reloads,
+            :queue => queue_payload
           }
           respond_with(payload, {:filter => params["filter"]})
         end
@@ -27,7 +28,7 @@ module LogStash
         def jvm_payload
           @stats.jvm
         end
-        
+
         def reloads
           @stats.reloads
         end
@@ -42,6 +43,10 @@ module LogStash
 
         def pipeline_payload
           @stats.pipeline
+        end
+
+        def queue_payload
+          @stats.queue
         end
       end
     end

--- a/logstash-core/lib/logstash/instrument/periodic_poller/pq.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/pq.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+require "logstash/instrument/periodic_poller/base"
+
+module LogStash module Instrument module PeriodicPoller
+  class PersistentQueue < Base
+    def initialize(metric, queue_type, agent, options = {})
+      super(metric, options)
+      @metric = metric
+      @queue_type = queue_type
+      @agent = agent
+    end
+
+    def collect
+      pipeline_id, pipeline = @agent.running_pipelines.first
+      unless pipeline.nil?
+        pipeline.collect_stats
+      end
+    end
+  end
+end; end; end

--- a/logstash-core/lib/logstash/instrument/periodic_pollers.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_pollers.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/instrument/periodic_poller/os"
 require "logstash/instrument/periodic_poller/jvm"
+require "logstash/instrument/periodic_poller/pq"
 
 module LogStash module Instrument
   # Each PeriodPoller manager his own thread to do the poller
@@ -9,10 +10,11 @@ module LogStash module Instrument
   class PeriodicPollers
     attr_reader :metric
 
-    def initialize(metric)
+    def initialize(metric, queue_type, pipelines)
       @metric = metric
       @periodic_pollers = [PeriodicPoller::Os.new(metric),
-                          PeriodicPoller::JVM.new(metric)]
+                           PeriodicPoller::JVM.new(metric),
+                           PeriodicPoller::PersistentQueue.new(metric, queue_type, pipelines)]
     end
 
     def start

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -550,6 +550,35 @@ module LogStash; class Pipeline
     end
   end
 
+  def collect_stats
+    pipeline_metric = @metric.namespace([:stats, :pipelines, pipeline_id.to_s.to_sym, :queue])
+    pipeline_metric.gauge(:type, settings.get("queue.type"))
+
+    if @queue.is_a?(LogStash::Util::WrappedAckedQueue) && @queue.queue.is_a?(LogStash::AckedQueue)
+      queue = @queue.queue
+      dir_path = queue.dir_path
+      file_store = Files.get_file_store(Paths.get(dir_path))
+
+      pipeline_metric.namespace([:capacity]).tap do |n|
+        n.gauge(:page_capacity_in_bytes, queue.page_capacity)
+        n.gauge(:max_queue_size_in_bytes, queue.max_size_in_bytes)
+        n.gauge(:max_unread_events, queue.max_unread_events)
+      end
+      pipeline_metric.namespace([:data]).tap do |n|
+        n.gauge(:free_space_in_bytes, file_store.get_unallocated_space)
+        n.gauge(:current_size_in_bytes, queue.current_byte_size)
+        n.gauge(:storage_type, file_store.type)
+        n.gauge(:path, dir_path)
+      end
+
+      pipeline_metric.namespace([:events]).tap do |n|
+        n.gauge(:acked_count, queue.acked_count)
+        n.gauge(:unacked_count, queue.unacked_count)
+        n.gauge(:unread_count, queue.unread_count)
+      end
+    end
+  end
+
   # Sometimes we log stuff that will dump the pipeline which may contain
   # sensitive information (like the raw syntax tree which can contain passwords)
   # We want to hide most of what's in here

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -40,7 +40,8 @@ module LogStash; class Pipeline
     :settings,
     :metric,
     :filter_queue_client,
-    :input_queue_client
+    :input_queue_client,
+    :queue
 
   MAX_INFLIGHT_WARN_THRESHOLD = 10_000
 

--- a/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
@@ -33,6 +33,8 @@ module LogStash; module Util
 
     private_class_method :new
 
+    attr_reader :queue
+
     def with_queue(queue)
       @queue = queue
       @queue.open

--- a/logstash-core/spec/api/lib/api/node_stats_spec.rb
+++ b/logstash-core/spec/api/lib/api/node_stats_spec.rb
@@ -84,9 +84,6 @@ describe LogStash::Api::Modules::NodeStats do
    "reloads" => {
      "successes" => Numeric,
      "failures" => Numeric
-   },
-   "queue" => {
-     "type" => String
    }
   }
 

--- a/logstash-core/spec/api/lib/api/node_stats_spec.rb
+++ b/logstash-core/spec/api/lib/api/node_stats_spec.rb
@@ -84,6 +84,9 @@ describe LogStash::Api::Modules::NodeStats do
    "reloads" => {
      "successes" => Numeric,
      "failures" => Numeric
+   },
+   "queue" => {
+     "type" => String
    }
   }
 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -106,6 +106,30 @@ public class Queue implements Closeable {
         }
     }
 
+    public String getDirPath() {
+        return this.dirPath;
+    }
+
+    public long getMaxBytes() {
+        return this.maxBytes;
+    }
+
+    public long getMaxUnread() {
+        return this.maxUnread;
+    }
+
+    public long getCurrentByteSize() {
+        return this.currentByteSize;
+    }
+
+    public int getPageCapacity() {
+        return this.pageCapacity;
+    }
+
+    public long getUnreadCount() {
+        return this.unreadCount;
+    }
+
     // moved queue opening logic in open() method until we have something in place to used in-memory checkpoints for testing
     // because for now we need to pass a Queue instance to the Page and we don't want to trigger a Queue recovery when
     // testing Page
@@ -583,6 +607,19 @@ public class Queue implements Closeable {
             return this.headPage.getPageNum();
         }
         return this.tailPages.get(0).getPageNum();
+    }
+
+    public long getAckedCount() {
+        return headPage.ackedSeqNums.cardinality() + tailPages.stream()
+                .mapToLong(page -> page.ackedSeqNums.cardinality())
+                .sum();
+    }
+
+    public long getUnackedCount() {
+        long headPageCount = (headPage.getElementCount() - headPage.ackedSeqNums.cardinality());
+        long tailPagesCount = tailPages.stream()
+                .mapToLong(page -> (page.getElementCount() - page.ackedSeqNums.cardinality())).sum();
+        return headPageCount + tailPagesCount;
     }
 
     protected long nextSeqNum() {

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/TestSettings.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/TestSettings.java
@@ -4,6 +4,7 @@ import org.logstash.common.io.ByteBufferPageIO;
 import org.logstash.common.io.CheckpointIOFactory;
 import org.logstash.common.io.FileCheckpointIO;
 import org.logstash.common.io.MemoryCheckpointIO;
+import org.logstash.common.io.MmapPageIO;
 import org.logstash.common.io.PageIOFactory;
 
 public class TestSettings {
@@ -35,10 +36,11 @@ public class TestSettings {
 
     public static Settings getSettingsCheckpointFilePageMemory(int capacity, String folder) {
         Settings s = new FileSettings(folder);
-        PageIOFactory pageIOFactory = (pageNum, size, path) -> new ByteBufferPageIO(pageNum, size, path);
+        PageIOFactory pageIOFactory = (pageNum, size, path) -> new MmapPageIO(pageNum, size, path);
         CheckpointIOFactory checkpointIOFactory = (source) -> new FileCheckpointIO(source);
         s.setCapacity(capacity);
         s.setElementIOFactory(pageIOFactory);
+        s.setCheckpointMaxWrites(1);
         s.setCheckpointIOFactory(checkpointIOFactory);
         s.setElementClass(StringElement.class);
         return s;

--- a/qa/integration/services/service.rb
+++ b/qa/integration/services/service.rb
@@ -1,6 +1,8 @@
 # Base class for a service like Kafka, ES, Logstash
 class Service
 
+  attr_reader :settings
+
   def initialize(name, settings)
     @name = name
     @settings = settings

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -47,4 +47,18 @@ describe "Test Monitoring API" do
     end
   end
 
+  it "can retrieve queue stats" do
+    logstash_service = @fixture.get_service("logstash")
+    logstash_service.start_with_stdin
+    logstash_service.wait_for_logstash
+
+    Stud.try(max_retry.times, RSpec::Expectations::ExpectationNotMetError) do
+      result = logstash_service.monitoring_api.node_stats
+      if logstash_service.settings.feature_flag == "persistent_queues"
+        expect(result["queue"]["type"]).to eq "persisted"
+      else
+        expect(result["queue"]["type"]).to eq "memory"
+      end
+    end
+  end
 end

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -54,10 +54,21 @@ describe "Test Monitoring API" do
 
     Stud.try(max_retry.times, RSpec::Expectations::ExpectationNotMetError) do
       result = logstash_service.monitoring_api.node_stats
+      expect(result["pipeline"]["queue"]).not_to be_nil
       if logstash_service.settings.feature_flag == "persistent_queues"
-        expect(result["queue"]["type"]).to eq "persisted"
+        expect(result["pipeline"]["queue"]["type"]).to eq "persisted"
+        expect(result["pipeline"]["queue"]["data"]["free_space_in_bytes"]).not_to be_nil
+        expect(result["pipeline"]["queue"]["data"]["current_size_in_bytes"]).not_to be_nil
+        expect(result["pipeline"]["queue"]["data"]["storage_type"]).not_to be_nil
+        expect(result["pipeline"]["queue"]["data"]["path"]).not_to be_nil
+        expect(result["pipeline"]["queue"]["events"]["acked_count"]).not_to be_nil
+        expect(result["pipeline"]["queue"]["events"]["unread_count"]).not_to be_nil
+        expect(result["pipeline"]["queue"]["events"]["unacked_count"]).not_to be_nil
+        expect(result["pipeline"]["queue"]["capacity"]["page_capacity_in_bytes"]).not_to be_nil
+        expect(result["pipeline"]["queue"]["capacity"]["max_queue_size_in_bytes"]).not_to be_nil
+        expect(result["pipeline"]["queue"]["capacity"]["max_unread_events"]).not_to be_nil
       else
-        expect(result["queue"]["type"]).to eq "memory"
+        expect(result["pipeline"]["queue"]["type"]).to eq "memory"
       end
     end
   end


### PR DESCRIPTION
example queue section:

```javascript
"queue" : {
    "type" : "persisted",
    "capacity" : {
      "page_capacity_in_bytes" : 262144000,
      "max_queue_size_in_bytes" : 1073741824,
      "max_unread_events" : 0
    },
    "data" : {
      "free_space_in_bytes" : 33851523072,
      "current_size_in_bytes" : 262144000,
      "storage_type" : "hfs",
      "path" : "/logstash/data/queue"
    },
    "events" : {
      "acked_count" : 0,
      "unread_count" : 0,
      "unacked_count" : 0
    }
}
```

When retrieving node stats for a logstash instance that is not running with `queue.type: persisted`, the output of this section will simply be:

```javascript
{ "type" : "memory_acked"}
or
{ "type" : "memory"}
```

as discussed in the comments below, this information will be per pipeline and under the `pipeline` section of the stats. All of these stats will be stored in the metrics store.

Closes #6182.