### PR TITLE
Do not clean unused gems after updating gems

### DIFF
--- a/lib/pluginmanager/update.rb
+++ b/lib/pluginmanager/update.rb
@@ -62,7 +62,9 @@ class LogStash::PluginManager::Update < LogStash::PluginManager::Command
     options = {:update => plugins, :rubygems_source => gemfile.gemset.sources}
     options[:local] = true if local?
     output = LogStash::Bundler.invoke!(options)
-    output = LogStash::Bundler.invoke!(:clean => true)
+    # We currently dont removed unused gems from the logstash installation
+    # see: https://github.com/elastic/logstash/issues/6339
+    # output = LogStash::Bundler.invoke!(:clean => true)
     display_updated_plugins(previous_gem_specs_map)
   rescue => exception
     gemfile.restore!

--- a/spec/unit/plugin_manager/update_spec.rb
+++ b/spec/unit/plugin_manager/update_spec.rb
@@ -10,7 +10,6 @@ describe LogStash::PluginManager::Update do
     expect(cmd).to receive(:find_latest_gem_specs).and_return({})
     allow(cmd).to receive(:warn_local_gems).and_return(nil)
     expect(cmd).to receive(:display_updated_plugins).and_return(nil)
-    expect_any_instance_of(LogStash::Bundler).to receive(:invoke!).with(:clean => true)
   end
 
   it "pass all gem sources to the bundle update command" do


### PR DESCRIPTION
The are a difference between the gems installed and the available spec
loaded in memory making bundler remove the gem that we have just
updated.

Fixes: #6339