### PR TITLE
Pin webmock to 2.2.0

### DIFF
--- a/tools/logstash-docgen/logstash-docgen.gemspec
+++ b/tools/logstash-docgen/logstash-docgen.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
 
   # Used for the dependency lookup code
   spec.add_development_dependency "vcr"
-  spec.add_development_dependency "webmock"
+  spec.add_development_dependency "webmock", "2.2.0"
 end


### PR DESCRIPTION
The latest version of webmock (2.3.1) requires Ruby 2.0 or newer.