### PR TITLE
ensure a failed sprintf returns null

### DIFF
--- a/logstash-core-event-java/src/main/java/org/logstash/KeyNode.java
+++ b/logstash-core-event-java/src/main/java/org/logstash/KeyNode.java
@@ -25,18 +25,15 @@ public class KeyNode implements TemplateNode {
     public String evaluate(Event event) throws IOException {
         Object value = event.getField(this.key);
 
-        if (value != null) {
-            if (value instanceof List) {
-                return join((List)value, ",");
-            } else if (value instanceof Map) {
-                ObjectMapper mapper = new ObjectMapper();
-                return mapper.writeValueAsString((Map<String, Object>)value);
-            } else {
-                return event.getField(this.key).toString();
-            }
+        if (value == null) { return null; }
 
+        if (value instanceof List) {
+            return join((List)value, ",");
+        } else if (value instanceof Map) {
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.writeValueAsString((Map<String, Object>)value);
         } else {
-            return "%{" + this.key + "}";
+            return event.getField(this.key).toString();
         }
     }
 

--- a/logstash-core-event-java/src/main/java/org/logstash/Template.java
+++ b/logstash-core-event-java/src/main/java/org/logstash/Template.java
@@ -22,10 +22,16 @@ public class Template implements TemplateNode {
 
     @Override
     public String evaluate(Event event) throws IOException {
+        String nodeResult;
         StringBuffer results = new StringBuffer();
 
         for (int i = 0; i < nodes.size(); i++) {
-            results.append(((TemplateNode) nodes.get(i)).evaluate(event));
+            nodeResult = ((TemplateNode) nodes.get(i)).evaluate(event);
+            if (nodeResult == null) {
+                return null; // if one node fails to evaluate, abort everything
+            } else {
+                results.append(nodeResult);
+            }
         }
         return results.toString();
     }

--- a/logstash-core-event-java/src/test/java/org/logstash/StringInterpolationTest.java
+++ b/logstash-core-event-java/src/test/java/org/logstash/StringInterpolationTest.java
@@ -47,7 +47,7 @@ public class StringInterpolationTest {
         String path = "/full/%{do-not-exist}";
         StringInterpolation si = StringInterpolation.getInstance();
 
-        assertEquals("/full/%{do-not-exist}", si.evaluate(event, path));
+        assertNull(si.evaluate(event, path));
     }
 
     @Test


### PR DESCRIPTION
work in progress, allowing event.sprintf to return null causes tons of repercussions on the existing code, as evident by the test failures with NPE

fixes #6363 