### PR TITLE
Fix logstash-core in the plugins

### DIFF
--- a/logstash-core/lib/logstash/util/byte_value.rb
+++ b/logstash-core/lib/logstash/util/byte_value.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 require "logstash/namespace"
-require "logstash/util"
 
 module LogStash; module Util; module ByteValue
   module_function

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "http://www.elastic.co/guide/en/logstash/current/index.html"
   gem.license       = "Apache License (2.0)"
 
-  gem.files         = Dir.glob(["logstash-core.gemspec", "gemspec_jars.rb", "lib/**/*.rb", "spec/**/*.rb", "locales/*", "lib/logstash/api/init.ru"])
+  gem.files         = Dir.glob(["logstash-core.gemspec", "gemspec_jars.rb", "lib/**/*.rb", "spec/**/*.rb", "locales/*", "lib/logstash/api/init.ru", "lib/logstash-core/logstash-core.jar"])
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "logstash-core"
   gem.require_paths = ["lib"]


### PR DESCRIPTION
When we publish a logstash-core gem to test the plugin we need to make sure it includes the necessary jars, only the logstash-core.jar is needed the other dependencies should be picked up by jar-dependencies.

We also need to remove the require to `logstash/util` this cause a circle reference issue when loading the environment file.

Fixes: #6374