### PR TITLE
add webserver address metric to metric store

### DIFF
--- a/logstash-core/lib/logstash/api/commands/default_metadata.rb
+++ b/logstash-core/lib/logstash/api/commands/default_metadata.rb
@@ -20,7 +20,9 @@ module LogStash
         end
 
         def http_address
-          service.agent.webserver.address
+          @http_address ||= service.get_shallow(:http_address).value
+        rescue ::LogStash::Instrument::MetricStore::MetricNotFound, NoMethodError => e
+          nil
         end
       end
     end

--- a/logstash-core/lib/logstash/webserver.rb
+++ b/logstash-core/lib/logstash/webserver.rb
@@ -87,9 +87,17 @@ module LogStash
       @server = ::Puma::Server.new(app, events)
       @server.add_tcp_listener(http_host, port)
 
-      logger.info("Successfully started Logstash API endpoint", :port => @port)
+      logger.info("Successfully started Logstash API endpoint", :port => port)
+
+      set_http_address_metric("#{http_host}:#{port}")
 
       @server.run.join
+    end
+
+    private
+    def set_http_address_metric(value)
+      return unless @agent.metric
+      @agent.metric.gauge([], :http_address, value)
     end
   end
 end

--- a/logstash-core/spec/api/spec_helper.rb
+++ b/logstash-core/spec/api/spec_helper.rb
@@ -20,7 +20,9 @@ end
 module LogStash
   class DummyAgent < Agent
     def start_webserver
-      @webserver = Struct.new(:address).new("#{Socket.gethostname}:#{::LogStash::WebServer::DEFAULT_PORTS.first}")
+      http_address = "#{Socket.gethostname}:#{::LogStash::WebServer::DEFAULT_PORTS.first}"
+      @webserver = Struct.new(:address).new(http_address)
+      self.metric.gauge([], :http_address, http_address)
     end
     def stop_webserver; end
   end


### PR DESCRIPTION
since the port used by the webserver is decided at runtime during agent.run, we need to make the webserver write the finally chosen port as metric to the metric store.

This PR adds a new metric called http_address at the root of the metric store which represents the final "host:port" address of the webserver api.