### PR TITLE
Explicitely require LogStash::Bundler.setup! make the plugin install process to require internet access

### DIFF
--- a/lib/pluginmanager/main.rb
+++ b/lib/pluginmanager/main.rb
@@ -6,8 +6,6 @@ require "bootstrap/environment"
 ENV["GEM_HOME"] = ENV["GEM_PATH"] = LogStash::Environment.logstash_gem_home
 Gem.use_paths(LogStash::Environment.logstash_gem_home)
 
-LogStash::Bundler.setup!({:without => [:build, :development]})
-
 module LogStash
   module PluginManager
   end


### PR DESCRIPTION

Fixes: #6386