### PR TITLE
add explit fsync on checkpoint write

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/FileCheckpointIO.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/FileCheckpointIO.java
@@ -5,8 +5,13 @@ import org.logstash.ackedqueue.Checkpoint;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.WRITE;
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+import static java.nio.file.StandardOpenOption.DSYNC;
 
 public class FileCheckpointIO  implements CheckpointIO {
 //    Checkpoint file structure
@@ -50,10 +55,11 @@ public class FileCheckpointIO  implements CheckpointIO {
 
     @Override
     public void write(String fileName, Checkpoint checkpoint) throws IOException {
+        OpenOption[] options = new OpenOption[] { WRITE, CREATE, TRUNCATE_EXISTING, DSYNC };
         Path path = Paths.get(dirPath, fileName);
         final byte[] buffer = new byte[BUFFER_SIZE];
         write(checkpoint, buffer);
-        Files.write(path, buffer);
+        Files.write(path, buffer, options);
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/common/io/FileCheckpointIO.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/FileCheckpointIO.java
@@ -34,6 +34,7 @@ public class FileCheckpointIO  implements CheckpointIO {
     private final String dirPath;
     private final String HEAD_CHECKPOINT = "checkpoint.head";
     private final String TAIL_CHECKPOINT = "checkpoint.";
+    private final OpenOption[] WRITE_OPTIONS = new OpenOption[] { WRITE, CREATE, TRUNCATE_EXISTING, DSYNC };
 
     public FileCheckpointIO(String dirPath) {
         this.dirPath = dirPath;
@@ -55,11 +56,10 @@ public class FileCheckpointIO  implements CheckpointIO {
 
     @Override
     public void write(String fileName, Checkpoint checkpoint) throws IOException {
-        OpenOption[] options = new OpenOption[] { WRITE, CREATE, TRUNCATE_EXISTING, DSYNC };
         Path path = Paths.get(dirPath, fileName);
         final byte[] buffer = new byte[BUFFER_SIZE];
         write(checkpoint, buffer);
-        Files.write(path, buffer, options);
+        Files.write(path, buffer, WRITE_OPTIONS);
     }
 
     @Override


### PR DESCRIPTION
Add explit fsync on checkpoint write. We assumed that the `Files.write` open/write/close implied fsync'ing which it does not.