### PR TITLE
[WIP] queue drain option support

### DIFF
--- a/logstash-core-queue-jruby/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java
+++ b/logstash-core-queue-jruby/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java
@@ -7,6 +7,7 @@ import org.jruby.RubyClass;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyModule;
 import org.jruby.RubyObject;
+import org.jruby.RubyBoolean;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.Arity;
@@ -42,7 +43,6 @@ public class JrubyAckedQueueExtLibrary implements Library {
     // TODO:
     // as a simplified first prototyping implementation, the Settings class is not exposed and the queue elements
     // are assumed to be logstash Event.
-
 
     @JRubyClass(name = "AckedQueue", parent = "Object")
     public static class RubyAckedQueue extends RubyObject {
@@ -171,6 +171,11 @@ public class JrubyAckedQueueExtLibrary implements Library {
             return (b == null) ? context.nil : new JrubyAckedBatchExtLibrary.RubyAckedBatch(context.runtime, b);
         }
 
+        @JRubyMethod(name = "is_fully_acked?")
+        public IRubyObject ruby_is_fully_acked(ThreadContext context)
+        {
+            return RubyBoolean.newBoolean(context.runtime, this.queue.isFullyAcked());
+        }
 
         @JRubyMethod(name = "close")
         public IRubyObject ruby_close(ThreadContext context)
@@ -183,6 +188,5 @@ public class JrubyAckedQueueExtLibrary implements Library {
 
             return context.nil;
         }
-
     }
 }

--- a/logstash-core-queue-jruby/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueMemoryExtLibrary.java
+++ b/logstash-core-queue-jruby/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueMemoryExtLibrary.java
@@ -7,6 +7,7 @@ import org.jruby.RubyClass;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyModule;
 import org.jruby.RubyObject;
+import org.jruby.RubyBoolean;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.Arity;
@@ -166,6 +167,11 @@ public class JrubyAckedQueueMemoryExtLibrary implements Library {
             return (b == null) ? context.nil : new JrubyAckedBatchExtLibrary.RubyAckedBatch(context.runtime, b);
         }
 
+        @JRubyMethod(name = "is_fully_acked?")
+        public IRubyObject ruby_is_fully_acked(ThreadContext context)
+        {
+            return RubyBoolean.newBoolean(context.runtime, this.queue.isFullyAcked());
+        }
 
         @JRubyMethod(name = "close")
         public IRubyObject ruby_close(ThreadContext context)

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -41,6 +41,7 @@ module LogStash
             Setting::PortRange.new("http.port", 9600..9700),
             Setting::String.new("http.environment", "production"),
             Setting::String.new("queue.type", "memory", true, ["persisted", "memory", "memory_acked"]),
+            Setting::Boolean.new("queue.drain", false),
             Setting::Bytes.new("queue.page_capacity", "250mb"),
             Setting::Bytes.new("queue.max_bytes", "1024mb"),
             Setting::Numeric.new("queue.max_events", 0), # 0 is unlimited

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 require "logstash/inputs/generator"
 require "logstash/filters/multiline"
 require_relative "../support/mocks_classes"
+require_relative "../logstash/pipeline_reporter_spec" # for DummyOutput class
 
 class DummyInput < LogStash::Inputs::Base
   config_name "dummyinput"

--- a/logstash-core/spec/logstash/util/wrapped_synchronous_queue_spec.rb
+++ b/logstash-core/spec/logstash/util/wrapped_synchronous_queue_spec.rb
@@ -60,7 +60,7 @@ describe LogStash::Util::WrappedSynchronousQueue do
 
         context "when the queue is empty" do
           it "doesnt record the `duration_in_millis`" do
-            batch = read_client.take_batch
+            batch = read_client.read_batch
             read_client.close_batch(batch)
             store = collector.snapshot_metric.metric_store
 
@@ -95,7 +95,8 @@ describe LogStash::Util::WrappedSynchronousQueue do
             batch = write_client.get_new_batch
             5.times {|i| batch.push("value-#{i}")}
             write_client.push_batch(batch)
-            read_batch = read_client.take_batch
+
+            read_batch = read_client.read_batch
             sleep(0.1) # simulate some work for the `duration_in_millis`
             # TODO: this interaction should be cleaned in an upcoming PR,
             # This is what the current pipeline does.
@@ -126,7 +127,7 @@ describe LogStash::Util::WrappedSynchronousQueue do
           batch = write_client.get_new_batch
           5.times {|i| batch.push(LogStash::Event.new({"message" => "value-#{i}"}))}
           write_client.push_batch(batch)
-          read_batch = read_client.take_batch
+          read_batch = read_client.read_batch
           expect(read_batch.size).to eq(5)
           i = 0
           read_batch.each do |data|

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -371,6 +371,16 @@ public class Queue implements Closeable {
         }
     }
 
+    // @return true if the queue is fully acked, which implies that it is fully read which works as an "empty" state.
+    public boolean isFullyAcked() {
+        lock.lock();
+        try {
+            return this.tailPages.isEmpty() ? this.headPage.isFullyAcked() : false;
+        } finally {
+            lock.unlock();
+        }
+    }
+
     // @param seqNum the element sequence number upper bound for which persistence should be garanteed (by fsync'ing)
     public void ensurePersistedUpto(long seqNum) throws IOException{
         lock.lock();


### PR DESCRIPTION
This is in [WIP] state because the metrics on empty batch/queue need to be assessed - The creation of an empty final batch to handle the final flush upon shutdown which did not contain metrics yielded some errors so I added metrics to empty batches. There was originally a check for empty batches read to not start metrics but I believe this was bug because if this empty batch got used in a flush signal (slim chance) it would have crashed because of unstarted metrics for that batch. 

Core tests/specs are passing locally.

This PR adds support for a queue drain option. It relates to issue #6085 and it is necessary for the upcoming BatchedQueue implementation. The goal is to be able to signal logstash to drain the queue before exiting on a normal shutdown.  It is necessary for in-memory queueing support where events can be buffered. 

- It refactors the Wrapped xxx Queue  ReadClient classes to not read the next batch directly in the constructor but instead expose a `read_batch` method so it is now possible to create a new empty batch. 

- The pipeline worker loop becomes a bit clearer to understand with regard to signal handling (shutdown & flush) and shutdown handling for final flush in particular. 

- By default this option is currently turned off and can be turned on in the config using `queue.drain: true`. 

TODO
- [ ] add tests/specs for the drain support.
- [ ] clarify the empty batch/queue metrics situation