### PR TITLE
Deprecate path.plugins

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -154,8 +154,3 @@
 #
 # log.level: info
 # path.logs:
-#
-# ------------ Other Settings --------------
-#
-# Where to find custom plugins
-# path.plugins: []

--- a/docs/static/plugin-manager.asciidoc
+++ b/docs/static/plugin-manager.asciidoc
@@ -55,21 +55,6 @@ provides you the option to install a locally built plugin which is packaged as a
 bin/logstash-plugin install /path/to/logstash-output-kafka-1.0.0.gem
 ----------------------------------
 
-[[installing-local-plugins-path]]
-[float]
-==== Advanced: Using `--path.plugins`
-
-Using the Logstash `--path.plugins` flag, you can load a plugin source code located on your file system. Typically this is used by
-developers who are iterating on a custom plugin and want to test it before creating a ruby gem.
-
-The path needs to be in a  specific directory hierarchy: `PATH/logstash/TYPE/NAME.rb`, where TYPE is 'inputs' 'filters', 'outputs' or 'codecs' and NAME is the name of the plugin.
-
-[source,shell]
-----------------------------------
-# supposing the code is in /opt/shared/lib/logstash/inputs/my-custom-plugin-code.rb
-bin/logstash --path.plugins /opt/shared/lib
-----------------------------------
-
 [[updating-plugins]]
 [float]
 === Updating plugins

--- a/docs/static/setting-up-logstash.asciidoc
+++ b/docs/static/setting-up-logstash.asciidoc
@@ -56,11 +56,6 @@ config and the logs directories so that you do not delete important data later o
   | `{extract.path}/logs`
   | `path.logs`
 
-| plugins
-  | Local, non Ruby-Gem plugin files. Each plugin is contained in a subdirectory. Recommended for development only.
-  | `{extract.path}/plugins`
-  | `path.plugins`
-
 |=======================================================================
 
 [[deb-layout]]

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -164,7 +164,7 @@ The log level. Valid options are:
 | `LOGSTASH_HOME/logs
 
 | `path.plugins`
-| Where to find custom plugins. You can specify this setting multiple times to include
+| DEPRECATED: Where to find old-style plugins. You can specify this setting multiple times to include
   multiple paths. Plugins are expected to be in a specific directory hierarchy:
   `PATH/logstash/TYPE/NAME.rb` where `TYPE` is `inputs`, `filters`, `outputs`, or `codecs`,
   and `NAME` is the name of the plugin.

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -331,6 +331,7 @@ class LogStash::Runner < Clamp::StrictCommand
   # add the given paths for ungemified/bare plugins lookups
   # @param paths [String, Array<String>] plugins path string or list of path strings to add
   def configure_plugin_paths(paths)
+    logger.warn("The path.plugins setting is deprecated. It will be removed in the future.") if paths.any?
     Array(paths).each do |path|
       fail(I18n.t("logstash.runner.configuration.plugin_path_missing", :path => path)) unless File.directory?(path)
       LogStash::Environment.add_plugin_path(path)


### PR DESCRIPTION
I've intended to deprecate old-style plugin (older flag --pluginpath, --path.plugin) for years. Let's do it now :)

Details and discussion are in #6200 

My intent primarily is to deprecate this feature, not remove it entirely, by doing the following:

* Remove references in documentation
* Warn on usage