### PR TITLE
Do not log a warning if a plugin is not from in `#print_notice_version`

### DIFF
--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -268,6 +268,7 @@ module LogStash::Config::Mixin
       return is_valid
     end # def validate
 
+    # TODO: Remove in 6.0
     def print_version_notice
       return if @@version_notice_given
 
@@ -288,14 +289,10 @@ module LogStash::Config::Mixin
           end
         end
       rescue LogStash::PluginNoVersionError
-        # If we cannot find a version in the currently installed gems we
-        # will display this message. This could happen in the test, if you 
-        # create an anonymous class to test a plugin.
-        self.logger.warn(I18n.t("logstash.plugin.no_version",
-                                :type => @plugin_type,
-                                :name => @config_name,
-                                :LOGSTASH_VERSION => LOGSTASH_VERSION))
-      ensure 
+        # This can happen because of one of the following:
+        # - The plugin is loaded from the plugins.path and contains no gemspec.
+        # - The plugin is defined in a universal plugin, so the loaded plugin doesn't correspond to an actual gemspec.
+      ensure
         @@version_notice_given = true
       end
     end

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -44,9 +44,6 @@ en:
         %{plugin} plugin is using the 'milestone' method to declare the version
         of the plugin this method is deprecated in favor of declaring the
         version inside the gemspec.
-      no_version: >-
-        %{name} plugin doesn't have a version. This plugin isn't well
-         supported by the community and likely has no maintainer.
       version:
         0-9-x:
          Using version 0.9.x %{type} plugin '%{name}'. This plugin should work but

--- a/logstash-core/spec/logstash/plugin_spec.rb
+++ b/logstash-core/spec/logstash/plugin_spec.rb
@@ -106,12 +106,8 @@ describe LogStash::Plugin do
       one_notice.validate({})
     end
 
-    it "warns the user if we can't find a defined version" do
-      expect_any_instance_of(LogStash::Logging::Logger).to receive(:warn)
-        .once
-        .with(/plugin doesn't have a version/)
-
-      subject.validate({})
+    it "doesn't raise an exception if no version is found" do
+      expect { subject.validate({}) }.not_to raise_error
     end
 
 


### PR DESCRIPTION
When a plugin is loaded using the `plugins.path` option or is from a
universal plugin there no gemspec can be found for the specific plugin.

We should not print any warning on that case.

Fixes: #6444