### PR TITLE
Initialize the metric values in the batch to the correct type

### DIFF
--- a/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
@@ -141,7 +141,7 @@ module LogStash; module Util
       end
 
       def define_initial_metrics_values(namespaced_metric)
-        namespaced_metric.gauge(:duration_in_millis, 0)
+        namespaced_metric.report_time(:duration_in_millis, 0)
         namespaced_metric.increment(:filtered, 0)
         namespaced_metric.increment(:in, 0)
         namespaced_metric.increment(:out, 0)

--- a/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
@@ -88,7 +88,7 @@ module LogStash; module Util
       end
 
       def define_initial_metrics_values(namespaced_metric)
-        namespaced_metric.gauge(:duration_in_millis, 0)
+        namespaced_metric.report_time(:duration_in_millis, 0)
         namespaced_metric.increment(:filtered, 0)
         namespaced_metric.increment(:in, 0)
         namespaced_metric.increment(:out, 0)

--- a/logstash-core/spec/logstash/util/wrapped_synchronous_queue_spec.rb
+++ b/logstash-core/spec/logstash/util/wrapped_synchronous_queue_spec.rb
@@ -65,13 +65,28 @@ describe LogStash::Util::WrappedSynchronousQueue do
             store = collector.snapshot_metric.metric_store
 
             expect(store.get_shallow(:events, :in).value).to eq(0)
+            expect(store.get_shallow(:events, :in)).to be_kind_of(LogStash::Instrument::MetricType::Counter)
+
             expect(store.get_shallow(:events, :out).value).to eq(0)
+            expect(store.get_shallow(:events, :out)).to be_kind_of(LogStash::Instrument::MetricType::Counter)
+
             expect(store.get_shallow(:events, :filtered).value).to eq(0)
+            expect(store.get_shallow(:events, :filtered)).to be_kind_of(LogStash::Instrument::MetricType::Counter)
+
             expect(store.get_shallow(:events, :duration_in_millis).value).to eq(0)
+            expect(store.get_shallow(:events, :duration_in_millis)).to be_kind_of(LogStash::Instrument::MetricType::Counter)
+
             expect(store.get_shallow(:pipeline, :in).value).to eq(0)
+            expect(store.get_shallow(:pipeline, :in)).to be_kind_of(LogStash::Instrument::MetricType::Counter)
+
             expect(store.get_shallow(:pipeline, :duration_in_millis).value).to eq(0)
+            expect(store.get_shallow(:pipeline, :duration_in_millis)).to be_kind_of(LogStash::Instrument::MetricType::Counter)
+
             expect(store.get_shallow(:pipeline, :out).value).to eq(0)
+            expect(store.get_shallow(:pipeline, :out)).to be_kind_of(LogStash::Instrument::MetricType::Counter)
+
             expect(store.get_shallow(:pipeline, :filtered).value).to eq(0)
+            expect(store.get_shallow(:pipeline, :filtered)).to be_kind_of(LogStash::Instrument::MetricType::Counter)
           end
         end
 


### PR DESCRIPTION
When we were initilizing the `duration_in_millis` in the the batch we
were using a `Gauge` instead of a counter, since all the object have the
same signature when the were actually recording the time the value was
replaced instead of incremented.