### PR TITLE
avoid resetting inexisting tags field back to empty array plus specs

### DIFF
--- a/logstash-core/lib/logstash/util/decorators.rb
+++ b/logstash-core/lib/logstash/util/decorators.rb
@@ -34,8 +34,9 @@ module LogStash::Util
 
     # tags is an array of string. sprintf syntax can be used.
     def add_tags(new_tags, event, pluginname)
-      tags = event.get("tags")
-      tags = tags.nil? ? [] : Array(tags)
+      return if new_tags.empty?
+
+      tags = Array(event.get("tags")) # note that Array(nil) => []
 
       new_tags.each do |new_tag|
         new_tag = event.sprintf(new_tag)

--- a/logstash-core/spec/logstash/filters/base_spec.rb
+++ b/logstash-core/spec/logstash/filters/base_spec.rb
@@ -248,7 +248,21 @@ describe LogStash::Filters::NOOP do
     end
   end
 
- describe "remove_field on deep objects" do
+  describe "remove_field on tags" do
+    config <<-CONFIG
+    filter {
+      noop {
+        remove_field => ["tags"]
+      }
+    }
+    CONFIG
+
+    sample("tags" => "foo") do
+      reject { subject }.include?("tags")
+    end
+  end
+
+  describe "remove_field on deep objects" do
     config <<-CONFIG
     filter {
       noop {


### PR DESCRIPTION
Fix regression introduced in #6177 where doing a `remove_field => ["tags"]` now result in having the `tags` field systematically reset to the empty array `[]`.  This regression was introduced by the `add_tags` method fix.

I added a spec for the specific edge case.

This new spec alone passes on v5.0.0 but fails on master which confirms the regression. 

Fixes #6384 #6429