### PR TITLE
Reduce the visibility of the Pipeline

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -293,11 +293,10 @@ class LogStash::Agent
 
   def start_pipeline(id)
     pipeline = @pipelines[id]
-    return unless pipeline.is_a?(LogStash::Pipeline)
     return if pipeline.ready?
     @logger.debug("starting pipeline", :id => id)
     t = Thread.new do
-      LogStash::Util.set_thread_name("pipeline.#{id}")
+      LogStash::Util.set_thread_name("[#{id}]-pipeline-manager")
       begin
         pipeline.run
       rescue => e

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -325,7 +325,6 @@ class LogStash::Agent
     return unless pipeline
     @logger.warn("stopping pipeline", :id => id)
     pipeline.shutdown { LogStash::ShutdownWatcher.start(pipeline) }
-    @pipelines[id].thread.join
   end
 
   def start_pipelines
@@ -344,8 +343,7 @@ class LogStash::Agent
   end
 
   def running_pipeline?(pipeline_id)
-    thread = @pipelines[pipeline_id].thread
-    thread.is_a?(Thread) && thread.alive?
+    @pipelines[pipeline_id].running?
   end
 
   def upgrade_pipeline(pipeline_id, new_pipeline)

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -204,6 +204,11 @@ module LogStash; class Pipeline
 
     # exit code
     return 0
+  rescue Exception => e
+    # The pipeline doesn't have a `failed` test but we use the `#running?` predicate to see if a pipeline is running
+    # so on exception we mark this pipeline as not running and reraise the exception to be handled higher.
+    transition_to_stopped
+    raise e
   end # def run
 
   def transition_to_running
@@ -529,6 +534,7 @@ module LogStash; class Pipeline
 
     @flushing.set(false)
   end # flush_filters_to_batch
+  private :flush_filters_to_batch
 
   def plugin_threads_info
     input_threads = @input_threads.select {|t| t.alive? }

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -34,7 +34,6 @@ module LogStash; class Pipeline
     :reporter,
     :pipeline_id,
     :started_at,
-    :thread,
     :config_str,
     :config_hash,
     :settings,
@@ -406,8 +405,9 @@ module LogStash; class Pipeline
     before_stop.call if block_given?
 
     @logger.debug "Closing inputs"
-    @inputs.each(&:do_stop)
+    stop_inputs
     @logger.debug "Closed inputs"
+    wait_workers
   end # def shutdown
 
   # After `shutdown` is called from an external thread this is called from the main thread to
@@ -590,5 +590,14 @@ module LogStash; class Pipeline
       :running => @running,
       :flushing => @flushing
     }
+  end
+
+  private
+  def stop_inputs
+    @inputs.each(&:do_stop)
+  end
+
+  def wait_workers
+    @worker_threads.each(&:join)
   end
 end end

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -31,16 +31,16 @@ module LogStash; class Pipeline
     :worker_threads,
     :events_consumed,
     :events_filtered,
+    :filter_queue_client,
+    :queue,
+    :input_queue_client,
     :reporter,
     :pipeline_id,
     :started_at,
     :config_str,
     :config_hash,
-    :settings,
     :metric,
-    :filter_queue_client,
-    :input_queue_client,
-    :queue
+    :settings
 
   MAX_INFLIGHT_WARN_THRESHOLD = 10_000
 

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -31,16 +31,17 @@ module LogStash; class Pipeline
     :worker_threads,
     :events_consumed,
     :events_filtered,
-    :filter_queue_client,
-    :queue,
-    :input_queue_client,
     :reporter,
     :pipeline_id,
     :started_at,
+    :thread,
     :config_str,
     :config_hash,
+    :settings,
     :metric,
-    :settings
+    :filter_queue_client,
+    :input_queue_client,
+    :queue
 
   MAX_INFLIGHT_WARN_THRESHOLD = 10_000
 

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -179,13 +179,6 @@ module LogStash; class Pipeline
     return @filters.any?
   end
 
-  def start
-    @thread = Thread.new do
-      Util.set_thread_name("[#{pipeline_id}]-pipeline-manager")
-      run
-    end
-  end
-
   def run
     @started_at = Time.now
     start_workers

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -179,12 +179,15 @@ module LogStash; class Pipeline
     return @filters.any?
   end
 
+  def start
+    @thread = Thread.new do
+      Util.set_thread_name("[#{pipeline_id}]-pipeline-manager")
+      run
+    end
+  end
+
   def run
     @started_at = Time.now
-
-    @thread = Thread.current
-    Util.set_thread_name("[#{pipeline_id}]-pipeline-manager")
-
     start_workers
 
     @logger.info("Pipeline #{@pipeline_id} started")
@@ -595,5 +598,4 @@ module LogStash; class Pipeline
       :flushing => @flushing
     }
   end
-
 end end

--- a/logstash-core/lib/logstash/pipeline_reporter.rb
+++ b/logstash-core/lib/logstash/pipeline_reporter.rb
@@ -1,6 +1,4 @@
 # encoding: utf-8
-require 'ostruct'
-
 module LogStash; class PipelineReporter
   attr_reader :logger, :pipeline
 

--- a/logstash-core/lib/logstash/shutdown_watcher.rb
+++ b/logstash-core/lib/logstash/shutdown_watcher.rb
@@ -40,7 +40,7 @@ module LogStash
       cycle_number = 0
       stalled_count = 0
       Stud.interval(@cycle_period) do
-        break unless @pipeline.thread.alive?
+        break unless @pipeline.running?
         @reports << pipeline_report_snapshot
         @reports.delete_at(0) if @reports.size > @report_every # expire old report
         if cycle_number == (@report_every - 1) # it's report time!

--- a/logstash-core/spec/logstash/pipeline_reporter_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_reporter_spec.rb
@@ -20,7 +20,6 @@ describe LogStash::PipelineReporter do
     allow(LogStash::Plugin).to receive(:lookup).with("codec", "plain").and_call_original
 
     @pre_snapshot = reporter.snapshot
-    
     pipeline.run
     @post_snapshot = reporter.snapshot
   end

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -154,6 +154,24 @@ describe LogStash::Pipeline do
     end
   end
 
+  describe "when an exception occur in a running pipeline" do
+    let(:config) {
+      <<-eos
+      input { generator {} }
+      output { null {} }
+      eos
+    }
+
+    subject { TestPipeline.new(config, pipeline_settings_obj) }
+
+    it "transition to stopped" do
+      expect(subject.running?).to be_falsey
+      expect(subject).to receive(:start_workers).and_raise { "it crashed" }
+      expect { subject.run }.to raise_error
+      expect(subject.running?).to be_falsey
+    end
+  end
+
   describe "defaulting the pipeline workers based on thread safety" do
     before(:each) do
       allow(LogStash::Plugin).to receive(:lookup).with("input", "dummyinput").and_return(DummyInput)

--- a/logstash-core/spec/logstash/shutdown_watcher_spec.rb
+++ b/logstash-core/spec/logstash/shutdown_watcher_spec.rb
@@ -6,14 +6,13 @@ describe LogStash::ShutdownWatcher do
   let(:check_every) { 0.01 }
   let(:check_threshold) { 100 }
   subject { LogStash::ShutdownWatcher.new(pipeline, check_every) }
-  let(:pipeline) { double("pipeline") }
+  let(:pipeline) { double("pipeline", :running? => true) }
   let(:reporter) { double("reporter") }
   let(:reporter_snapshot) { double("reporter snapshot") }
   report_count = 0
 
   before :each do
     allow(pipeline).to receive(:reporter).and_return(reporter)
-    allow(pipeline).to receive(:thread).and_return(Thread.current)
     allow(reporter).to receive(:snapshot).and_return(reporter_snapshot)
     allow(reporter_snapshot).to receive(:o_simple_hash).and_return({})
 


### PR DESCRIPTION
With the upcoming changes of the #6281 I want to reduce the visibility of the pipeline as much as possible to the outside world.

- Make sure we don't use any reference to the thread to check if a pipeline is running or not and only rely on the `#running?` method.
- use the private method to mark as much as possible the method that doesn't need to be exposed, this is a start I would also like to hide some of the `attr_reader` methods but this would require more refactoring.
- Set the name of the pipeline thread only once in the agent instead of the `Pipeline#run`.
- Remove the type check on pipeline and instead rely on duck typing.

The tests require https://github.com/elastic/logstash-devutils/pull/65 to make the `#sample` method work.

Ref: #6493