### PR TITLE
Refactor `non_reloadable_plugin`

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -94,7 +94,7 @@ class LogStash::Agent
 
     pipeline = create_pipeline(pipeline_settings)
     return unless pipeline.is_a?(LogStash::Pipeline)
-    if @auto_reload && pipeline.non_reloadable_plugins.any?
+    if @auto_reload && !pipeline.reloadable?
       @logger.error(I18n.t("logstash.agent.non_reloadable_config_register"),
                     :pipeline_id => pipeline_id,
                     :plugins => pipeline.non_reloadable_plugins.map(&:class))
@@ -279,7 +279,7 @@ class LogStash::Agent
 
     return if new_pipeline.nil?
 
-    if new_pipeline.non_reloadable_plugins.any?
+    if !new_pipeline.reloadable?
       @logger.error(I18n.t("logstash.agent.non_reloadable_config_reload"),
                     :pipeline_id => id,
                     :plugins => new_pipeline.non_reloadable_plugins.map(&:class))

--- a/logstash-core/lib/logstash/filter_delegator.rb
+++ b/logstash-core/lib/logstash/filter_delegator.rb
@@ -9,7 +9,8 @@ module LogStash
       :threadsafe?,
       :do_close,
       :do_stop,
-      :periodic_flush
+      :periodic_flush,
+      :reloadable?
     ]
     def_delegators :@filter, *DELEGATED_METHODS
 

--- a/logstash-core/lib/logstash/output_delegator.rb
+++ b/logstash-core/lib/logstash/output_delegator.rb
@@ -29,6 +29,10 @@ module LogStash class OutputDelegator
     @output_class.config_name
   end
 
+  def reloadable?
+    @output_class.reloadable?
+  end
+
   def concurrency
     @output_class.concurrency
   end

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -45,10 +45,6 @@ module LogStash; class Pipeline
 
   MAX_INFLIGHT_WARN_THRESHOLD = 10_000
 
-  RELOAD_INCOMPATIBLE_PLUGINS = [
-    "LogStash::Inputs::Stdin"
-  ]
-
   def initialize(config_str, settings = SETTINGS, namespaced_metric = nil)
     @logger = self.logger
     @config_str = config_str
@@ -548,10 +544,12 @@ module LogStash; class Pipeline
       .each {|t| t.delete("status") }
   end
 
+  def reloadable?
+    non_reloadable_plugins.empty?
+  end
+
   def non_reloadable_plugins
-    (inputs + filters + outputs).select do |plugin|
-      RELOAD_INCOMPATIBLE_PLUGINS.include?(plugin.class.name)
-    end
+    (inputs + filters + outputs).select { |plugin| !plugin.reloadable? }
   end
 
   def collect_stats
@@ -595,5 +593,4 @@ module LogStash; class Pipeline
       :flushing => @flushing
     }
   end
-
 end end

--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -94,6 +94,14 @@ class LogStash::Plugin
     end
   end
 
+  def reloadable?
+    self.class.reloadable?
+  end
+
+  def self.reloadable?
+    true
+  end
+
   def debug_info
     [self.class.to_s, original_params]
   end

--- a/logstash-core/spec/logstash/plugin_spec.rb
+++ b/logstash-core/spec/logstash/plugin_spec.rb
@@ -7,6 +7,41 @@ require "logstash/inputs/base"
 require "logstash/filters/base"
 
 describe LogStash::Plugin do
+  context "reloadable" do
+    context "by default" do
+      subject do
+        Class.new(LogStash::Plugin) do
+        end
+      end
+
+      it "makes .reloadable? return true" do
+        expect(subject.reloadable?).to be_truthy
+      end
+
+      it "makes #reloadable? return true" do
+        expect(subject.new({}).reloadable?).to be_truthy
+      end
+    end
+
+    context "user can overrides" do
+      subject do
+        Class.new(LogStash::Plugin) do
+          def self.reloadable?
+            false
+          end
+        end
+      end
+
+      it "makes .reloadable? return true" do
+        expect(subject.reloadable?).to be_falsey
+      end
+
+      it "makes #reloadable? return true" do
+        expect(subject.new({}).reloadable?).to be_falsey
+      end
+    end
+  end
+
   it "should fail lookup on inexisting type" do
     #expect_any_instance_of(Cabin::Channel).to receive(:debug).once
     expect { LogStash::Plugin.lookup("badbadtype", "badname") }.to raise_error(LogStash::PluginLoadingError)


### PR DESCRIPTION
Instead of using a list of non reloadable plugin we add a new class
method on the base plugin class that the plugin will override.

By default we assume that all plugins are reloadable, only the stdin
shouldn't be reloadable.