### PR TITLE
Minor code cleanup and reorg of TopologicalSort

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/InvalidIRException.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/InvalidIRException.java
@@ -1,10 +1,16 @@
 package org.logstash.config.ir;
 
+import org.logstash.config.ir.graph.algorithms.TopologicalSort;
+
 /**
  * Created by andrewvc on 9/6/16.
  */
 public class InvalidIRException extends Exception {
     public InvalidIRException(String s) {
         super(s);
+    }
+
+    public InvalidIRException(String s, Exception e) {
+        super(s,e);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/algorithms/TopologicalSort.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/algorithms/TopologicalSort.java
@@ -1,0 +1,51 @@
+package org.logstash.config.ir.graph.algorithms;
+
+import org.logstash.config.ir.graph.Edge;
+import org.logstash.config.ir.graph.Graph;
+import org.logstash.config.ir.graph.Vertex;
+
+import java.util.*;
+
+/**
+ * Created by andrewvc on 1/7/17.
+ */
+public class TopologicalSort {
+    public static class UnexpectedGraphCycleError extends Exception {
+        UnexpectedGraphCycleError(Graph g) {
+            super("Graph has cycles, is not a DAG! " + g);
+        }
+    }
+
+    // Uses Kahn's algorithm to do a topological sort and detect cycles
+    public static List<Vertex> sortVertices(Graph g) throws UnexpectedGraphCycleError {
+        if (g.getEdges().size() == 0) return new ArrayList<>(g.getVertices());
+
+        List<Vertex> sorted = new ArrayList<>(g.getVertices().size());
+
+        Deque<Vertex> pending = new LinkedList<>();
+        pending.addAll(g.getRoots());
+
+        Set<Edge> traversedEdges = new HashSet<>();
+
+        while (!pending.isEmpty()) {
+            Vertex currentVertex = pending.removeFirst();
+            sorted.add(currentVertex);
+
+            currentVertex.getOutgoingEdges().forEach(edge -> {
+                traversedEdges.add(edge);
+                Vertex toVertex = edge.getTo();
+                if (toVertex.getIncomingEdges().stream().allMatch(traversedEdges::contains)) {
+                    pending.add(toVertex);
+                }
+            });
+        }
+
+        // Check for cycles
+        if (g.edges().noneMatch(traversedEdges::contains)) {
+            throw new UnexpectedGraphCycleError(g);
+        }
+
+        return sorted;
+    }
+
+}

--- a/logstash-core/src/test/java/org/logstash/config/ir/graph/algorithms/TopologicalSortTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/graph/algorithms/TopologicalSortTest.java
@@ -1,0 +1,46 @@
+package org.logstash.config.ir.graph.algorithms;
+
+import org.junit.Test;
+import org.logstash.config.ir.InvalidIRException;
+import org.logstash.config.ir.graph.Graph;
+import org.logstash.config.ir.graph.Vertex;
+
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.AnyOf.anyOf;
+import static org.hamcrest.core.Is.is;
+import static org.logstash.config.ir.IRHelpers.testVertex;
+
+/**
+ * Created by andrewvc on 1/7/17.
+ */
+public class TopologicalSortTest {
+    @Test(expected = InvalidIRException.class)
+    public void testGraphCycleDetection() throws InvalidIRException {
+        Graph g = Graph.empty();
+        Vertex v1 = testVertex();
+        Vertex v2 = testVertex();
+        Vertex v3 = testVertex();
+        g.threadVertices(v1, v2);
+        g.threadVertices(v2, v3);
+        g.threadVertices(v2, v1);
+    }
+
+    @Test
+    public void testSortOrder() throws InvalidIRException, TopologicalSort.UnexpectedGraphCycleError {
+        Graph g = Graph.empty();
+        Vertex v1 = testVertex();
+        Vertex v2 = testVertex();
+        Vertex v3 = testVertex();
+        Vertex v4 = testVertex();
+        g.threadVertices(v3, v1, v2);
+        g.threadVertices(v4, v1, v2);
+        assertThat(TopologicalSort.sortVertices(g),
+                anyOf(
+                        is(Arrays.asList(v3,v4,v1,v2)),
+                        is(Arrays.asList(v4,v3,v1,v2))
+                ));
+    }
+
+}


### PR DESCRIPTION
This moves the TopologicalSort algorithm class to the proper
graph.algorithms package. It also cleans up a few little syntax things