### PR TITLE
remove current_size_in_bytes and acked info from node stats

### DIFF
--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -570,16 +570,11 @@ module LogStash; class Pipeline
       end
       pipeline_metric.namespace([:data]).tap do |n|
         n.gauge(:free_space_in_bytes, file_store.get_unallocated_space)
-        n.gauge(:current_size_in_bytes, queue.current_byte_size)
         n.gauge(:storage_type, file_store.type)
         n.gauge(:path, dir_path)
       end
 
-      pipeline_metric.namespace([:events]).tap do |n|
-        n.gauge(:acked_count, queue.acked_count)
-        n.gauge(:unacked_count, queue.unacked_count)
-        n.gauge(:unread_count, queue.unread_count)
-      end
+      pipeline_metric.gauge(:events, queue.unread_count)
     end
   end
 

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -58,12 +58,9 @@ describe "Test Monitoring API" do
       if logstash_service.settings.feature_flag == "persistent_queues"
         expect(result["pipeline"]["queue"]["type"]).to eq "persisted"
         expect(result["pipeline"]["queue"]["data"]["free_space_in_bytes"]).not_to be_nil
-        expect(result["pipeline"]["queue"]["data"]["current_size_in_bytes"]).not_to be_nil
         expect(result["pipeline"]["queue"]["data"]["storage_type"]).not_to be_nil
         expect(result["pipeline"]["queue"]["data"]["path"]).not_to be_nil
-        expect(result["pipeline"]["queue"]["events"]["acked_count"]).not_to be_nil
-        expect(result["pipeline"]["queue"]["events"]["unread_count"]).not_to be_nil
-        expect(result["pipeline"]["queue"]["events"]["unacked_count"]).not_to be_nil
+        expect(result["pipeline"]["queue"]["events"]).not_to be_nil
         expect(result["pipeline"]["queue"]["capacity"]["page_capacity_in_bytes"]).not_to be_nil
         expect(result["pipeline"]["queue"]["capacity"]["max_queue_size_in_bytes"]).not_to be_nil
         expect(result["pipeline"]["queue"]["capacity"]["max_unread_events"]).not_to be_nil


### PR DESCRIPTION
re #6508.

- removed `acked_count`, `unacked_count`, and migrated `unread_count` to
top-level `events` field.
- removed `current_size_in_bytes` info from queue node stats