### PR TITLE
add queue_size_on_disk stat to persisted queue node stats

### DIFF
--- a/logstash-core-queue-jruby/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java
+++ b/logstash-core-queue-jruby/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java
@@ -112,6 +112,11 @@ public class JrubyAckedQueueExtLibrary implements Library {
             return context.runtime.newFixnum(queue.getCurrentByteSize());
         }
 
+        @JRubyMethod(name = "current_persisted_bytes")
+        public IRubyObject ruby_current_persisted_bytes(ThreadContext context) {
+            return context.runtime.newFixnum(queue.getCurrentPhysicallyPersistedByteSize());
+        }
+
         @JRubyMethod(name = "acked_count")
         public IRubyObject ruby_acked_count(ThreadContext context) {
             return context.runtime.newFixnum(queue.getAckedCount());

--- a/logstash-core-queue-jruby/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueMemoryExtLibrary.java
+++ b/logstash-core-queue-jruby/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueMemoryExtLibrary.java
@@ -106,6 +106,11 @@ public class JrubyAckedQueueMemoryExtLibrary implements Library {
             return context.runtime.newFixnum(queue.getCurrentByteSize());
         }
 
+        @JRubyMethod(name = "current_persisted_bytes")
+        public IRubyObject ruby_current_persisted_bytes(ThreadContext context) {
+            return context.runtime.newFixnum(queue.getCurrentPhysicallyPersistedByteSize());
+        }
+
         @JRubyMethod(name = "acked_count")
         public IRubyObject ruby_acked_count(ThreadContext context) {
             return context.runtime.newFixnum(queue.getAckedCount());

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -539,6 +539,7 @@ module LogStash; class Pipeline
         n.gauge(:page_capacity_in_bytes, queue.page_capacity)
         n.gauge(:max_queue_size_in_bytes, queue.max_size_in_bytes)
         n.gauge(:max_unread_events, queue.max_unread_events)
+        n.gauge(:queue_size_on_disk, queue.current_persisted_bytes)
       end
       pipeline_metric.namespace([:data]).tap do |n|
         n.gauge(:free_space_in_bytes, file_store.get_unallocated_space)

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -126,6 +126,10 @@ public class Queue implements Closeable {
         return this.currentByteSize;
     }
 
+    public long getCurrentPhysicallyPersistedByteSize() {
+        return headPage.getPageIO().getHead() + tailPages.stream().mapToLong((p) -> p.getPageIO().getHead()).sum();
+    }
+
     public int getPageCapacity() {
         return this.pageCapacity;
     }

--- a/logstash-core/src/main/java/org/logstash/common/io/AbstractByteBufferPageIO.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/AbstractByteBufferPageIO.java
@@ -265,6 +265,11 @@ public abstract class AbstractByteBufferPageIO implements PageIO {
         return SEQNUM_SIZE + LENGTH_SIZE + byteCount + CHECKSUM_SIZE;
     }
 
+    @Override
+    public int getHead() {
+        return this.head;
+    }
+
     protected int checksum(byte[] bytes) {
         checkSummer.reset();
         checkSummer.update(bytes, 0, bytes.length);

--- a/logstash-core/src/main/java/org/logstash/common/io/PageIO.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/PageIO.java
@@ -39,6 +39,9 @@ public interface PageIO extends Closeable {
     // @return the data container total capacity in bytes
     int getCapacity();
 
+    // @return the current head offset within the page
+    int getHead();
+
     // @return the actual persisted byte count (with overhead) for the given data bytes
     int persistedByteCount(int bytes);
 

--- a/logstash-core/src/main/java/org/logstash/common/io/wip/MemoryPageIOStream.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/wip/MemoryPageIOStream.java
@@ -156,6 +156,11 @@ public class MemoryPageIOStream implements PageIO {
     }
 
     @Override
+    public int getHead() {
+        return writePosition;
+    }
+
+    @Override
     public void deactivate() {
         // do nothing
     }


### PR DESCRIPTION
This uses the Queue's offset state management as a metric for measuring
bytes usage of the queue on the physical disk.

re #6508.