### PR TITLE
improve user facing error when yaml is incorrect

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -170,7 +170,12 @@ class LogStash::Runner < Clamp::StrictCommand
     rescue => e
       # abort unless we're just looking for the help
       unless cli_help?(args)
-        $stderr.puts "ERROR: Failed to load settings file from \"path.settings\". Aborting... path.setting=#{LogStash::SETTINGS.get("path.settings")}, exception=#{e.class}, message=>#{e.message}"
+        if e.kind_of?(Psych::Exception)
+          yaml_file_path = ::File.join(LogStash::SETTINGS.get("path.settings"), "logstash.yml")
+          $stderr.puts "ERROR: Failed to parse YAML file \"#{yaml_file_path}\". Please confirm if the YAML structure is valid (e.g. look for incorrect usage of whitespace or indentation). Aborting... parser_error=>#{e.message}"
+        else
+          $stderr.puts "ERROR: Failed to load settings file from \"path.settings\". Aborting... path.setting=#{LogStash::SETTINGS.get("path.settings")}, exception=#{e.class}, message=>#{e.message}"
+        end
         return 1
       end
     end


### PR DESCRIPTION
fixes https://github.com/elastic/logstash/issues/6509

before:

```
% bin/logstash -e ""
ERROR: Failed to load settings file from "path.settings". Aborting... path.setting=/tmp/logstash/config, exception=Psych::SyntaxError, message=>(<unknown>): found character      '\t(TAB)' that cannot start any token. (Do not use \t(TAB) for indentation) while scanning for the next token at line 138 column 1
```

after

```
% bin/logstash -e ""
ERROR: Failed to parse YAML file "/tmp/logstash/config/logstash.yml". Please confirm if the YAML structure is valid (e.g. look for incorrect usage of whitespace or indentation). Aborting... parser_error=>(<unknown>): found character      '\t(TAB)' that cannot start any token. (Do not use \t(TAB) for indentation) while scanning for the next token at line 138 column 1
```