### PR TITLE
[WIP] Initialize `tags` field

### DIFF
--- a/logstash-core-event-java/src/main/java/org/logstash/Event.java
+++ b/logstash-core-event-java/src/main/java/org/logstash/Event.java
@@ -36,6 +36,7 @@ public class Event implements Cloneable, Serializable, Queueable {
 
     public static final String METADATA = "@metadata";
     public static final String METADATA_BRACKETS = "[" + METADATA + "]";
+    public static final String TAGS = "tags";
     public static final String TIMESTAMP = "@timestamp";
     public static final String TIMESTAMP_FAILURE_TAG = "_timestampparsefailure";
     public static final String TIMESTAMP_FAILURE_FIELD = "_@timestamp";
@@ -55,6 +56,7 @@ public class Event implements Cloneable, Serializable, Queueable {
         this.data = new HashMap<String, Object>();
         this.data.put(VERSION, VERSION_ONE);
         this.cancelled = false;
+        this.data.put(TAGS, new ArrayList<>());
         this.timestamp = new Timestamp();
         this.data.put(TIMESTAMP, this.timestamp);
         this.accessors = new Accessors(this.data);
@@ -355,13 +357,7 @@ public class Event implements Cloneable, Serializable, Queueable {
 
     public void tag(String tag) {
         List<Object> tags;
-        Object _tags = this.getField("tags");
-
-        // short circuit the null case where we know we won't need deduplication step below at the end
-        if (_tags == null) {
-            setField("tags", Arrays.asList(tag));
-            return;
-        }
+        Object _tags = this.getTags();
 
         // assign to tags var the proper List of either the existing _tags List or a new List containing whatever non-List item was in the tags field
         if (_tags instanceof List) {
@@ -379,7 +375,11 @@ public class Event implements Cloneable, Serializable, Queueable {
         }
 
         // set that back as a proper BiValue
-        this.setField("tags", tags);
+        this.setField(TAGS, tags);
+    }
+
+    public List<Object> getTags() {
+        return this.getField(TAGS);
     }
 
     public byte[] serialize() throws IOException {

--- a/logstash-core-event-java/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core-event-java/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -35,6 +35,7 @@ public class JrubyEventExtLibrary implements Library {
 
         clazz.setConstant("METADATA", runtime.newString(Event.METADATA));
         clazz.setConstant("METADATA_BRACKETS", runtime.newString(Event.METADATA_BRACKETS));
+        clazz.setConstant("TAGS", runtime.newString(Event.TAGS));
         clazz.setConstant("TIMESTAMP", runtime.newString(Event.TIMESTAMP));
         clazz.setConstant("TIMESTAMP_FAILURE_TAG", runtime.newString(Event.TIMESTAMP_FAILURE_TAG));
         clazz.setConstant("TIMESTAMP_FAILURE_FIELD", runtime.newString(Event.TIMESTAMP_FAILURE_FIELD));
@@ -282,6 +283,11 @@ public class JrubyEventExtLibrary implements Library {
             //TODO(guy) should these tags be BiValues?
             this.event.tag(((RubyString) value).asJavaString());
             return context.nil;
+        }
+
+        @JRubyMethod(name = "tags")
+        public IRubyObject ruby_tags(ThreadContext context) {
+            return Rubyfier.deep(context.runtime, this.event.getTags());
         }
 
         @JRubyMethod(name = "timestamp")

--- a/logstash-core-event-java/src/test/java/org/logstash/EventTest.java
+++ b/logstash-core-event-java/src/test/java/org/logstash/EventTest.java
@@ -273,7 +273,7 @@ public class EventTest {
         Event e = new Event();
         e.tag("foo");
 
-        List<String> tags = (List<String>)e.getField("tags");
+        List<String> tags = (List<String>)e.getTags();
         assertEquals(tags.size(), 1);
         assertEquals(tags.get(0), "foo");
     }
@@ -285,7 +285,7 @@ public class EventTest {
         Event e = new Event(data);
         e.tag("bar");
 
-        List<String> tags = (List<String>)e.getField("tags");
+        List<String> tags = (List<String>)e.getTags();
         assertEquals(tags.size(), 2);
         assertEquals(tags.get(0), "foo");
         assertEquals(tags.get(1), "bar");

--- a/logstash-core-event/lib/logstash/event.rb
+++ b/logstash-core-event/lib/logstash/event.rb
@@ -87,6 +87,7 @@ class LogStash::Event
     @data[VERSION] ||= VERSION_ONE
     ts = @data[TIMESTAMP]
     @data[TIMESTAMP] = ts ? init_timestamp(ts) : LogStash::Timestamp.now
+    @data[TAGS] ||= []
 
     @metadata = @data.delete(METADATA) || {}
     @metadata_accessors = LogStash::Util::Accessors.new(@metadata)
@@ -117,6 +118,10 @@ class LogStash::Event
 
   def to_s
     "#{timestamp.to_iso8601} #{self.sprintf("%{host} %{message}")}"
+  end
+
+  def tags
+    @data[TAGS]
   end
 
   def timestamp
@@ -215,7 +220,7 @@ class LogStash::Event
 
   def tag(value)
     # Generalize this method for more usability
-    tags = @accessors.get(TAGS) || []
+    tags = @accessors.get(TAGS)
     tags << value unless tags.include?(value)
     @accessors.set(TAGS, tags)
   end

--- a/logstash-core-event/spec/logstash/event_spec.rb
+++ b/logstash-core-event/spec/logstash/event_spec.rb
@@ -431,6 +431,12 @@ describe LogStash::Event do
       end
     end
 
+    context "tags initialization" do
+      it "should default to empty array" do
+        expect(LogStash::Event.new({}).tags).to eq([])
+      end
+    end
+
     context "to_json" do
       it "should support to_json" do
         new_event = LogStash::Event.new(


### PR DESCRIPTION
Currently I am trying to do this:

```
expect(subject.get('tags')).not_to include('_grokparsefailure')
```

This doesn't work, however, because the `tags` field is not always initialized (it is only initialized if the `Event#tag` method is called. As such, I need to do this instead:

```
expect(subject.get('tags') || []).not_to include('_grokparsefailure')
```

This change initializes the `tags` field to `[]` and provides an `Event#tags` method to replace `subject.get('tags')`.