### PR TITLE
fix return value of start_pipeline when start_workers fails

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -313,7 +313,7 @@ class LogStash::Agent
     while true do
       if !t.alive?
         return false
-      elsif pipeline.ready?
+      elsif pipeline.running?
         return true
       else
         sleep 0.01


### PR DESCRIPTION
during Agent#start_pipeline a new thread is launched that executes
a pipeline.run and a rescue block which increments the failed reload counter

After launching the thread, the parent thread will wait for the pipeline
to start, or detect that the pipeline aborted, or sleep and check again.

There is a bug that, if the pipeline.run aborts during start_workers,
the pipeline is still be marked as `ready`, and the thread will continue
running for a very short period of time, while incrementing the failed reload
metric.

During this period of `pipeline.ready? == true` and `thread.alive? == true`,
the parent check code will observe all the necessary conditions to
consider the pipeline.run to be successful and thus increment the success
counter too. This failed reload can then result in both the success and
failure reload count being incremented.

This commit changes the parent thread check to use `pipeline.running?`
instead of `pipeline.ready?` which is the next logical state transition,
and ensures it is only true if `start_workers` runs successfully.

fixes https://github.com/elastic/logstash/issues/6565