### PR TITLE
No longer supported 'remove'

### DIFF
--- a/docs/static/plugin-manager.asciidoc
+++ b/docs/static/plugin-manager.asciidoc
@@ -88,13 +88,13 @@ bin/logstash-plugin update logstash-output-kafka <2>
 
 [[removing-plugins]]
 [float]
-=== Removing plugins
+=== Uninstalling plugins
 
 If you need to remove plugins from your Logstash installation:
 
 [source,shell]
 ----------------------------------
-bin/logstash-plugin remove logstash-output-kafka
+bin/logstash-plugin uninstall logstash-output-kafka
 ----------------------------------
 
 [[proxy-plugins]]


### PR DESCRIPTION
remove is notsupported. should be used `uninstall` instead of remove

```
bin/logstash-plugin remove logstash-output-kafka
ERROR: No such sub-command 'remove'

See: 'bin/logstash-plugin --help'
```