### PR TITLE
Fix versions and release state

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -20,7 +20,7 @@ release-state can be: released | prerelease | unreleased
 :filebeat:              https://www.elastic.co/guide/en/beats/filebeat/5.1/
 :lsissue:               https://github.com/elastic/logstash/issues/
 :security:              X-Pack Security
-:stack:                 https://www.elastic.co/guide/en/elastic-stack/current/
+:stack:                 https://www.elastic.co/guide/en/elastic-stack/5.1/
 
 [[introduction]]
 == Logstash Introduction

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,23 +1,23 @@
 [[logstash-reference]]
 = Logstash Reference
 
-:branch:                5.x
+:branch:                5.1
 :major-version:         5.x
-:logstash_version:      5.1.1
-:elasticsearch_version: 5.1.1
+:logstash_version:      5.1.2
+:elasticsearch_version: 5.1.2
 :docker-image:          docker.elastic.co/logstash/logstash:{logstash_version}
 
 //////////
 release-state can be: released | prerelease | unreleased
 //////////
-:release-state:  unreleased
+:release-state:  released
 
 :jdk:                   1.8.0
 :guide:                 https://www.elastic.co/guide/en/elasticsearch/guide/current/
-:ref:                   https://www.elastic.co/guide/en/elasticsearch/reference/5.x/
+:ref:                   https://www.elastic.co/guide/en/elasticsearch/reference/5.1/
 :xpack:                 https://www.elastic.co/guide/en/x-pack/current/
-:logstash:              https://www.elastic.co/guide/en/logstash/5.x/
-:filebeat:              https://www.elastic.co/guide/en/beats/filebeat/5.x/
+:logstash:              https://www.elastic.co/guide/en/logstash/5.1/
+:filebeat:              https://www.elastic.co/guide/en/beats/filebeat/5.1/
 :lsissue:               https://github.com/elastic/logstash/issues/
 :security:              X-Pack Security
 :stack:                 https://www.elastic.co/guide/en/elastic-stack/current/


### PR DESCRIPTION
At some point the correct values for the release got overwritten. 

@suyograo Can you confirm that these are the correct values to use for 5.1? I'm not completely sure about the value of `{branch}`. It's used in https://github.com/elastic/logstash/blob/5.1/docs/static/include/pluginbody.asciidoc. 

This PR fixes https://github.com/elastic/logstash/issues/6487