### PR TITLE
Fix version info

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -3,8 +3,8 @@
 
 :branch:                5.x
 :major-version:         5.x
-:logstash_version:      5.1.0
-:elasticsearch_version: 5.1.0
+:logstash_version:      5.x.0
+:elasticsearch_version: 5.x.0
 :docker-image:          docker.elastic.co/logstash/logstash:{logstash_version}
 
 //////////


### PR DESCRIPTION
Changed versions to 5.x.0 so that we don't end up with misleading statements like "version 5.1.0 of Logstash has not yet been released, so no Docker image is currently available for this version." 

Even tho the doc is clearly flagged a prerelease, we don't want it to contain info that is blatantly wrong.