### PR TITLE
Allow 'Elastic' license in the spec

### DIFF
--- a/spec/unit/license_spec.rb
+++ b/spec/unit/license_spec.rb
@@ -15,7 +15,9 @@ describe "Project licenses" do
                    /artistic 2.*/,
                    /ruby/,
                    /lgpl/,
-                   /epl/])
+                   /epl/,
+                   /elastic/i
+  ])
   }
 
   ##


### PR DESCRIPTION
Allow plugin like the x-pack to use the elastic license