### PR TITLE
propapate pipeline.id to api resources

### DIFF
--- a/logstash-core/lib/logstash/api/commands/node.rb
+++ b/logstash-core/lib/logstash/api/commands/node.rb
@@ -18,10 +18,12 @@ module LogStash
         end
 
         def pipeline
-          extract_metrics(
-            [:stats, :pipelines, :main, :config],
+          pipeline_id = LogStash::SETTINGS.get("pipeline.id").to_sym
+          stats = extract_metrics(
+            [:stats, :pipelines, pipeline_id, :config],
             :workers, :batch_size, :batch_delay, :config_reload_automatic, :config_reload_interval
           )
+          stats.merge(:id => pipeline_id)
         end
 
         def os

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -46,8 +46,10 @@ module LogStash
         end
 
         def pipeline
-          stats = service.get_shallow(:stats, :pipelines)
-          PluginsStats.report(stats)
+          pipeline_id = LogStash::SETTINGS.get("pipeline.id").to_sym
+          stats = service.get_shallow(:stats, :pipelines, pipeline_id)
+          stats = PluginsStats.report(stats)
+          stats.merge(:id => pipeline_id)
         end
 
         def memory
@@ -98,9 +100,6 @@ module LogStash
           end
 
           def report(stats)
-            # Only one pipeline right now.
-            stats = stats[:main]
-
             {
               :events => stats[:events],
               :plugins => {


### PR DESCRIPTION
currently if the pipeline.id changes, the api calls to `/_node/pipeline`, `/_node/stats` and `/_node/stats/pipeline` raise an exception on logstash and return a 503

This PR fixes that and also includes the pipeline id into the documents

for example:

```
% curl -s localhost:9600/_node/pipeline | jq
{
  "host": "Joaos-MacBook-Pro-5.local",
  "version": "6.0.0-alpha1",
  "http_address": "127.0.0.1:9600",
  "id": "64783f42-7541-4db8-b663-eb4ffb748075",
  "name": "Joaos-MacBook-Pro-5.local",
  "pipeline": {
    "workers": 4,
    "batch_size": 125,
    "batch_delay": 5,
    "config_reload_automatic": false,
    "config_reload_interval": 3,
    "id": "test"
  }
}
```