### PR TITLE
Allow to run the bin/logstash-plugin install <pack> outside of the logstash directory

### DIFF
--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -238,7 +238,7 @@ class LogstashService < Service
       run("install #{plugin_name}")
     end
 
-    def run_raw(cmd_parameters)
+    def run_raw(cmd_parameters, change_dir = true)
       out = Tempfile.new("content")
       out.sync = true
 
@@ -248,8 +248,12 @@ class LogstashService < Service
       process = ChildProcess.build(cmd, *parts)
       process.io.stdout = process.io.stderr = out
 
-      Dir.chdir(@logstash_home) do
-        Bundler.with_clean_env do
+      Bundler.with_clean_env do
+        if change_dir
+          Dir.chdir(@logstash_home) do
+            process.start
+          end
+        else
           process.start
         end
       end

--- a/qa/integration/specs/cli/install_spec.rb
+++ b/qa/integration/specs/cli/install_spec.rb
@@ -4,6 +4,8 @@ require_relative "../../framework/settings"
 require_relative "../../services/logstash_service"
 require_relative "../../framework/helpers"
 require "logstash/devutils/rspec/spec_helper"
+require "stud/temporary"
+require "fileutils"
 
 def gem_in_lock_file?(pattern, lock_file)
   content =  File.read(lock_file)
@@ -19,8 +21,10 @@ describe "CLI > logstash-plugin install" do
     @pack_directory =  File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "fixtures", "logstash-dummy-pack"))
   end
 
-  context "pack" do
+  shared_examples "install from a pack" do
     let(:pack) { "file://#{File.join(@pack_directory, "logstash-dummy-pack.zip")}" }
+    let(:install_command) { "bin/logstash-plugin install" }
+    let(:change_dir) { true }
 
     # When you are on anything by linux we wont disable the internet with seccomp
     if RbConfig::CONFIG["host_os"] == "linux"
@@ -38,7 +42,7 @@ describe "CLI > logstash-plugin install" do
         let(:offline_wrapper_cmd) { File.join(offline_wrapper_path, "offline") }
 
         it "successfully install the pack" do
-          execute = @logstash_plugin.run_raw("#{offline_wrapper_cmd} bin/logstash-plugin install #{pack}")
+          execute = @logstash_plugin.run_raw("#{offline_wrapper_cmd} #{install_command} #{pack}", change_dir)
 
           expect(execute.stderr_and_stdout).to match(/Install successful/)
           expect(execute.exit_code).to eq(0)
@@ -50,9 +54,10 @@ describe "CLI > logstash-plugin install" do
         end
       end
     else
+
       context "with internet connection" do
         it "successfully install the pack" do
-          execute = @logstash_plugin.install(pack)
+          execute = @logstash_plugin.run_raw("#{install_command} #{pack}", change_dir)
 
           expect(execute.stderr_and_stdout).to match(/Install successful/)
           expect(execute.exit_code).to eq(0)
@@ -61,6 +66,30 @@ describe "CLI > logstash-plugin install" do
           expect(installed.stderr_and_stdout).to match(/logstash-output-secret/)
 
           expect(gem_in_lock_file?(/gemoji/, @logstash.lock_file)).to be_truthy
+        end
+      end
+    end
+  end
+
+  context "pack" do
+    context "when the command is run in the `$LOGSTASH_HOME`" do
+      include_examples "install from a pack"
+    end
+
+    context "when the command is run outside of the `$LOGSTASH_HOME`" do
+      include_examples "install from a pack" do
+        let(:change_dir) { false }
+        let(:install_command) { "#{@logstash.logstash_home}/bin/logstash-plugin install" }
+
+        before :all do
+          @current = Dir.pwd
+          tmp = Stud::Temporary.pathname
+          FileUtils.mkdir_p(tmp)
+          Dir.chdir(tmp)
+        end
+
+        after :all do
+          Dir.chdir(@current)
         end
       end
     end


### PR DESCRIPTION
Allow to run the bin/logstash-plugin install <pack> outside of the logstash directory
Fixes: #6599