### PR TITLE
propagate pipeline.id to api resources

### DIFF
--- a/logstash-core/lib/logstash/api/commands/node.rb
+++ b/logstash-core/lib/logstash/api/commands/node.rb
@@ -17,11 +17,12 @@ module LogStash
           payload
         end
 
-        def pipeline
-          extract_metrics(
-            [:stats, :pipelines, :main, :config],
+        def pipeline(pipeline_id = LogStash::SETTINGS.get("pipeline.id").to_sym)
+          stats = extract_metrics(
+            [:stats, :pipelines, pipeline_id, :config],
             :workers, :batch_size, :batch_delay, :config_reload_automatic, :config_reload_interval
           )
+          stats.merge(:id => pipeline_id)
         end
 
         def os

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -45,9 +45,10 @@ module LogStash
           )
         end
 
-        def pipeline
-          stats = service.get_shallow(:stats, :pipelines)
-          PluginsStats.report(stats)
+        def pipeline(pipeline_id = LogStash::SETTINGS.get("pipeline.id").to_sym)
+          stats = service.get_shallow(:stats, :pipelines, pipeline_id)
+          stats = PluginsStats.report(stats)
+          stats.merge(:id => pipeline_id)
         end
 
         def memory
@@ -98,9 +99,6 @@ module LogStash
           end
 
           def report(stats)
-            # Only one pipeline right now.
-            stats = stats[:main]
-
             {
               :events => stats[:events],
               :plugins => {


### PR DESCRIPTION
this removes explicit references to the "main" pipeline in the api code,
using instead the value of the `pipeline.id` from LogStash::SETTINGS