### PR TITLE
Ignore NIL/EMPTY values for LOGSTASH_PACK_URL environment variable

### DIFF
--- a/lib/pluginmanager/pack_fetch_strategy/repository.rb
+++ b/lib/pluginmanager/pack_fetch_strategy/repository.rb
@@ -10,12 +10,17 @@ require "uri"
 
 module LogStash module PluginManager module PackFetchStrategy
   class Repository
-    ELASTIC_PACK_BASE_URI = ENV["LOGSTASH_PACK_URL"] || "https://artifacts.elastic.co/downloads/logstash-plugins"
+    DEFAULT_PACK_URL = "https://artifacts.elastic.co/downloads/logstash-plugins"
     PACK_EXTENSION = "zip"
 
     class << self
+      def elastic_pack_base_uri
+        env_url = ENV["LOGSTASH_PACK_URL"]
+        (env_url.nil? || env_url.empty?) ? DEFAULT_PACK_URL : env_url
+      end
+
       def pack_uri(plugin_name)
-        url = "#{ELASTIC_PACK_BASE_URI}/#{plugin_name}/#{plugin_name}-#{LOGSTASH_VERSION}.#{PACK_EXTENSION}"
+        url = "#{elastic_pack_base_uri}/#{plugin_name}/#{plugin_name}-#{LOGSTASH_VERSION}.#{PACK_EXTENSION}"
         URI.parse(url)
       end
 

--- a/spec/unit/plugin_manager/pack_fetch_strategy/repository_spec.rb
+++ b/spec/unit/plugin_manager/pack_fetch_strategy/repository_spec.rb
@@ -11,7 +11,7 @@ describe LogStash::PluginManager::PackFetchStrategy::Repository do
 
   context "#plugin_uri" do
     it "generate an url from a name" do
-      matched = URI.parse("#{subject::ELASTIC_PACK_BASE_URI}/#{plugin_name}/#{plugin_name}-#{LOGSTASH_VERSION}.#{subject::PACK_EXTENSION}")
+      matched = URI.parse("#{subject.elastic_pack_base_uri}/#{plugin_name}/#{plugin_name}-#{LOGSTASH_VERSION}.#{subject::PACK_EXTENSION}")
       expect(subject.pack_uri(plugin_name)).to eq(matched)
     end
   end
@@ -35,8 +35,43 @@ describe LogStash::PluginManager::PackFetchStrategy::Repository do
       # To make sure we really try to connect to a failling host we have to let it through webmock
       host ="#{Time.now.to_i.to_s}-do-not-exist.com"
       WebMock.disable_net_connect!(:allow => host)
-      stub_const("LogStash::PluginManager::PackFetchStrategy::Repository::ELASTIC_PACK_BASE_URI", "http://#{host}")
+      ENV["LOGSTASH_PACK_URL"] = "http://#{host}"
       expect(subject.get_installer_for(plugin_name)).to be_falsey
+      ENV["LOGSTASH_PACK_URL"] = nil
+    end
+  end
+
+  context "pack repository url" do
+    context "when `LOGSTASH_PACK_URL` is set in ENV" do
+      before do
+        ENV["LOGSTASH_PACK_URL"] = url
+      end
+
+      after do
+        ENV.delete("LOGSTASH_PACK_URL")
+      end
+
+      context "value is a string" do
+        let(:url) { "http://testing.dev" }
+
+        it "return the configured string" do
+          expect(subject.elastic_pack_base_uri).to eq(url)
+        end
+      end
+
+      context "value is an empty string" do
+        let(:url) { "" }
+
+        it "return the default" do
+          expect(subject.elastic_pack_base_uri).to eq(subject::DEFAULT_PACK_URL)
+        end
+      end
+    end
+
+    context "when `LOGSTASH_PACK_URL` is not set in ENV" do
+      it "return the default" do
+        expect(subject.elastic_pack_base_uri).to eq(subject::DEFAULT_PACK_URL)
+      end
     end
   end
 end


### PR DESCRIPTION
Fix the issue when the `LOGSTASH_PACK_URL` is nil or empty and test for that.

Since this variable is mostly used for us as a way to test staging packages, I don't see the need to have a flag to the `logstash-plugin install` cmd.