### PR TITLE
make wait time on stop configurable

### DIFF
--- a/pkg/logstash.default
+++ b/pkg/logstash.default
@@ -36,6 +36,9 @@
 #LS_NICE=19
 
 # If this is set to 1, then when `stop` is called, if the process has
-# not exited within a reasonable time, SIGKILL will be sent next.
+# not exited within STOP_WAIT_TIME, SIGKILL will be sent next.
 # The default behavior is to simply log a message "program stop failed; still running"
 KILL_ON_STOP_TIMEOUT=0
+
+# Time to wait for graceful exit on stop
+STOP_WAIT_TIME=10

--- a/pkg/logstash.sysv
+++ b/pkg/logstash.sysv
@@ -36,6 +36,7 @@ LS_CONF_DIR=/etc/logstash/conf.d
 LS_OPEN_FILES=16384
 LS_NICE=19
 KILL_ON_STOP_TIMEOUT=${KILL_ON_STOP_TIMEOUT-0} #default value is zero to this variable but could be updated by user request
+STOP_WAIT_TIME=10
 LS_OPTS=""
 
 
@@ -91,7 +92,7 @@ stop() {
     echo "Killing $name (pid $pid) with SIGTERM"
     kill -TERM $pid
     # Wait for it to exit.
-    for i in 1 2 3 4 5 6 7 8 9 ; do
+    for i in $(seq 1 $STOP_WAIT_TIME); do
       echo "Waiting $name (pid $pid) to die..."
       status || break
       sleep 1


### PR DESCRIPTION
When doing heaving lifting the current 10 seconds may not be sufficient to gracefully stop LS. Make the check period configurable, with 10 being the default (no change to current behaviour).