### PR TITLE
Default URL if $LOGSTASH_PACK_URL is empty string

### DIFF
--- a/lib/pluginmanager/pack_fetch_strategy/repository.rb
+++ b/lib/pluginmanager/pack_fetch_strategy/repository.rb
@@ -10,7 +10,12 @@ require "uri"
 
 module LogStash module PluginManager module PackFetchStrategy
   class Repository
-    ELASTIC_PACK_BASE_URI = ENV["LOGSTASH_PACK_URL"] || "https://artifacts.elastic.co/downloads/logstash-plugins"
+    if ENV["LOGSTASH_PACK_URL"].nil? || ENV["LOGSTASH_PACK_URL"].empty?
+      ELASTIC_PACK_BASE_URI = "https://artifacts.elastic.co/downloads/logstash-plugins"
+    else
+      ELASTIC_PACK_BASE_URI = ENV["LOGSTASH_PACK_URL"]
+    end
+
     PACK_EXTENSION = "zip"
 
     class << self


### PR DESCRIPTION
When the environment variable $LOGSTASH_PACK_URL is either undefined
or a zero-length string, use the default URL to download the X-Pack
plugin.

You may have already done this, @ph. Please disregard if so.

Thanks.