### PR TITLE
fix shutdown watcher reports in 5.x

### DIFF
--- a/logstash-core/lib/logstash/shutdown_watcher.rb
+++ b/logstash-core/lib/logstash/shutdown_watcher.rb
@@ -44,7 +44,7 @@ module LogStash
         @reports << pipeline_report_snapshot
         @reports.delete_at(0) if @reports.size > @report_every # expire old report
         if cycle_number == (@report_every - 1) # it's report time!
-          logger.warn(@reports.last)
+          logger.warn(@reports.last.to_s)
 
           if shutdown_stalled?
             logger.error("The shutdown process appears to be stalled due to busy or blocked plugins. Check the logs for more information.") if stalled_count == 0


### PR DESCRIPTION
since 5.x introduced log4j2 as the main logging mechanism, it's
necessary to be more explicit when logging complex objects.

In this case we tell the logger to use the .to_s version of the Snapshot
report generated by the Watcher.
The Snapshot#to_s calls .to_simple_hash.to_s

fixes https://github.com/elastic/logstash/issues/6507

This should go to all 5.x branches (master, 5.x, 5.3, 5.2)

Before:

```
% bin/logstash -e "input { generator {} } filter {sleep { time => 100 } }" -w 1 -b 1
[2017-02-02T12:01:46,392][INFO ][logstash.pipeline        ] Pipeline main started
^C[2017-02-02T12:01:47,967][WARN ][logstash.runner          ] SIGINT received. Shutting down the agent.
[2017-02-02T12:01:47,974][WARN ][logstash.agent           ] stopping pipeline {:id=>"main"}
[2017-02-02T12:01:52,975][WARN ][logstash.runner          ] Received shutdown signal, but pipeline is still waiting for in-flight events
to be processed. Sending another ^C will force quit Logstash, but this may cause
data loss.
[2017-02-02T12:01:52,993][WARN ][logstash.shutdownwatcher ] {}
```

Now:

```
% bin/logstash -e "input { generator {} } filter {sleep { time => 100 } }" -w 1 -b 1
[2017-02-02T12:09:15,741][INFO ][logstash.pipeline        ] Pipeline main started
^C[2017-02-02T12:09:17,618][WARN ][logstash.runner          ] SIGINT received. Shutting down the agent.
[2017-02-02T12:09:17,634][WARN ][logstash.agent           ] stopping pipeline {:id=>"main"}
[2017-02-02T12:09:22,627][WARN ][logstash.runner          ] Received shutdown signal, but pipeline is still waiting for in-flight events
to be processed. Sending another ^C will force quit Logstash, but this may cause
data loss.
[2017-02-02T12:09:22,648][WARN ][logstash.shutdownwatcher ] {"inflight_count"=>1, "stalling_thread_info"=>{["LogStash::Filters::Sleep", {"time"=>100, "id"=>"b89a6c6217fecb6d8569f125cd636bbb64cc3006-2"}]=>[{"thread_id"=>19, "name"=>"[main]>worker0", "current_call"=>"[...]/vendor/bundle/jruby/1.9/gems/logstash-filter-sleep-3.0.3/lib/logstash/filters/sleep.rb:105:in `sleep'"}]}}
```