### PR TITLE
Do not show the configuration content anymore. 

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -237,9 +237,9 @@ class LogStash::Agent
       n.gauge(:last_failure_timestamp, LogStash::Timestamp.now)
     end
     if @logger.debug?
-      @logger.error("fetched an invalid config", :config => config, :reason => exception.message, :backtrace => exception.backtrace)
+      @logger.error("Cannot load an invalid configuration.", :reason => exception.message, :backtrace => exception.backtrace)
     else
-      @logger.error("fetched an invalid config", :config => config, :reason => exception.message)
+      @logger.error("Cannot load an invalid configuration.", :reason => exception.message)
     end
   end
 


### PR DESCRIPTION
Plugin validation errors and other config problems are more specifically logged before we get to this point, and showing the full config can too easily obscure a more actionable messages.