### PR TITLE
PQ exclusive access to path.queue using file locking

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -249,7 +249,7 @@ class LogStash::Runner < Clamp::StrictCommand
       config_loader = LogStash::Config::Loader.new(logger)
       config_str = config_loader.format_config(setting("path.config"), setting("config.string"))
       begin
-        LogStash::Pipeline.new(config_str)
+        LogStash::BasePipeline.new(config_str)
         puts "Configuration OK"
         logger.info "Using config.test_and_exit mode. Config Validation Result: OK. Exiting Logstash"
         return 0

--- a/logstash-core/spec/conditionals_spec.rb
+++ b/logstash-core/spec/conditionals_spec.rb
@@ -287,7 +287,7 @@ describe "conditionals in filter" do
     conditional "!([message] <= 'sample')" do
       sample("apple") { expect(subject.get("tags")).not_to include("success") }
       sample("zebra") { expect(subject.get("tags")).not_to include("failure") }
-      sample("sample") { expect(subject.get("tags")).not_to include("success") }
+      sample("sample") { expect(subject.get("tags")).not_to include("success")}
     end
 
     conditional "!([message] >= 'sample')" do

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -16,7 +16,7 @@ describe LogStash::Agent do
   let(:config_file) { Stud::Temporary.pathname }
   let(:config_file_txt) { "input { generator { count => 100000 } } output { }" }
 
-    subject { LogStash::Agent.new(agent_settings) }
+  subject { LogStash::Agent.new(agent_settings) }
 
   before :each do
     # This MUST run first, before `subject` is invoked to ensure clean state
@@ -52,6 +52,10 @@ describe LogStash::Agent do
       }
     end
 
+    after(:each) do
+      subject.close_pipelines
+    end
+
     it "should delegate settings to new pipeline" do
       expect(LogStash::Pipeline).to receive(:new) do |arg1, arg2|
         expect(arg1).to eq(config_string)
@@ -75,7 +79,7 @@ describe LogStash::Agent do
     end
   end
 
-    describe "#execute" do
+  describe "#execute" do
     let(:config_file_txt) { "input { generator { count => 100000 } } output { }" }
 
     before :each do
@@ -105,7 +109,10 @@ describe LogStash::Agent do
         it "should not reload_state!" do
           expect(subject).to_not receive(:reload_state!)
           t = Thread.new { subject.execute }
-          sleep 0.1
+
+          # TODO: refactor this. forcing an arbitrary fixed delay for thread concurrency issues is an indication of
+          # a bad test design or missing class functionality.
+          sleep(0.1)
           Stud.stop!(t)
           t.join
           subject.shutdown
@@ -118,11 +125,14 @@ describe LogStash::Agent do
 
           it "does not upgrade the new config" do
             t = Thread.new { subject.execute }
-            sleep 0.01 until subject.running_pipelines? && subject.pipelines.values.first.ready?
+            sleep(0.1) until subject.running_pipelines? && subject.pipelines.values.first.ready?
             expect(subject).to_not receive(:upgrade_pipeline)
             File.open(config_file, "w") { |f| f.puts second_pipeline_config }
             subject.send(:"reload_pipeline!", "main")
-            sleep 0.1
+
+            # TODO: refactor this. forcing an arbitrary fixed delay for thread concurrency issues is an indication of
+            # a bad test design or missing class functionality.
+            sleep(0.1)
             Stud.stop!(t)
             t.join
             subject.shutdown
@@ -134,14 +144,16 @@ describe LogStash::Agent do
 
           it "does upgrade the new config" do
             t = Thread.new { subject.execute }
-            sleep 0.01 until subject.running_pipelines? && subject.pipelines.values.first.ready?
+            sleep(0.1) until subject.running_pipelines? && subject.pipelines.values.first.ready?
             expect(subject).to receive(:upgrade_pipeline).once.and_call_original
             File.open(config_file, "w") { |f| f.puts second_pipeline_config }
             subject.send(:"reload_pipeline!", "main")
-            sleep 0.1
+
+            # TODO: refactor this. forcing an arbitrary fixed delay for thread concurrency issues is an indication of
+            # a bad test design or missing class functionality.
+            sleep(0.1)
             Stud.stop!(t)
             t.join
-
             subject.shutdown
           end
         end
@@ -154,14 +166,16 @@ describe LogStash::Agent do
 
           it "does not try to reload the pipeline" do
             t = Thread.new { subject.execute }
-            sleep 0.01 until subject.running_pipelines? && subject.pipelines.values.first.running?
+            sleep(0.01) until subject.running_pipelines? && subject.pipelines.values.first.running?
             expect(subject).to_not receive(:reload_pipeline!)
             File.open(config_file, "w") { |f| f.puts second_pipeline_config }
             subject.reload_state!
-            sleep 0.1
+
+            # TODO: refactor this. forcing an arbitrary fixed delay for thread concurrency issues is an indication of
+            # a bad test design or missing class functionality.
+            sleep(0.1)
             Stud.stop!(t)
             t.join
-
             subject.shutdown
           end
         end
@@ -172,14 +186,16 @@ describe LogStash::Agent do
 
           it "tries to reload the pipeline" do
             t = Thread.new { subject.execute }
-            sleep 0.01 until subject.running_pipelines? && subject.pipelines.values.first.running?
+            sleep(0.01) until subject.running_pipelines? && subject.pipelines.values.first.running?
             expect(subject).to receive(:reload_pipeline!).once.and_call_original
             File.open(config_file, "w") { |f| f.puts second_pipeline_config }
             subject.reload_state!
-            sleep 0.1
+
+            # TODO: refactor this. forcing an arbitrary fixed delay for thread concurrency issues is an indication of
+            # a bad test design or missing class functionality.
+            sleep(0.1)
             Stud.stop!(t)
             t.join
-
             subject.shutdown
           end
         end
@@ -203,9 +219,12 @@ describe LogStash::Agent do
         it "should periodically reload_state" do
           allow(subject).to receive(:clean_state?).and_return(false)
           t = Thread.new { subject.execute }
-          sleep 0.01 until subject.running_pipelines? && subject.pipelines.values.first.running?
+          sleep(0.01) until subject.running_pipelines? && subject.pipelines.values.first.running?
           expect(subject).to receive(:reload_state!).at_least(2).times
-          sleep 0.1
+
+          # TODO: refactor this. forcing an arbitrary fixed delay for thread concurrency issues is an indication of
+          # a bad test design or missing class functionality.
+          sleep(0.1)
           Stud.stop!(t)
           t.join
           subject.shutdown
@@ -218,10 +237,13 @@ describe LogStash::Agent do
 
           it "does not upgrade the new config" do
             t = Thread.new { subject.execute }
-            sleep 0.01 until subject.running_pipelines? && subject.pipelines.values.first.running?
+            sleep(0.01) until subject.running_pipelines? && subject.pipelines.values.first.running?
             expect(subject).to_not receive(:upgrade_pipeline)
             File.open(config_file, "w") { |f| f.puts second_pipeline_config }
-            sleep 0.1
+
+            # TODO: refactor this. forcing an arbitrary fixed delay for thread concurrency issues is an indication of
+            # a bad test design or missing class functionality.
+            sleep(0.1)
             Stud.stop!(t)
             t.join
             subject.shutdown
@@ -233,10 +255,13 @@ describe LogStash::Agent do
 
           it "does upgrade the new config" do
             t = Thread.new { subject.execute }
-            sleep 0.01 until subject.running_pipelines? && subject.pipelines.values.first.running?
+            sleep(0.01) until subject.running_pipelines? && subject.pipelines.values.first.running?
             expect(subject).to receive(:upgrade_pipeline).once.and_call_original
             File.open(config_file, "w") { |f| f.puts second_pipeline_config }
-            sleep 0.1
+
+            # TODO: refactor this. forcing an arbitrary fixed delay for thread concurrency issues is an indication of
+            # a bad test design or missing class functionality.
+            sleep(0.1)
             Stud.stop!(t)
             t.join
             subject.shutdown
@@ -257,6 +282,10 @@ describe LogStash::Agent do
 
     before(:each) do
       subject.register_pipeline(pipeline_settings)
+    end
+
+    after(:each) do
+      subject.close_pipelines
     end
 
     context "when fetching a new state" do
@@ -291,6 +320,7 @@ describe LogStash::Agent do
 
       after :each do
         ENV["FOO"] = @foo_content
+        subject.close_pipelines
       end
 
       it "doesn't upgrade the state" do
@@ -314,14 +344,20 @@ describe LogStash::Agent do
     end
 
     after(:each) do
-      subject.shutdown
+      # new pipelines will be created part of the upgrade process so we need
+      # to close any initialized pipelines
+      subject.close_pipelines
     end
 
     context "when the upgrade fails" do
       before :each do
         allow(subject).to receive(:fetch_config).and_return(new_pipeline_config)
         allow(subject).to receive(:create_pipeline).and_return(nil)
-        allow(subject).to receive(:stop_pipeline)
+        allow(subject).to receive(:stop_pipeline) do |id|
+          # we register_pipeline but we never execute them so we have to mock #stop_pipeline to
+          # not call Pipeline#shutdown but Pipeline#close
+          subject.close_pipeline(id)
+        end
       end
 
       it "leaves the state untouched" do
@@ -339,18 +375,29 @@ describe LogStash::Agent do
 
     context "when the upgrade succeeds" do
       let(:new_config) { "input { generator { count => 1 } } output { }" }
+
       before :each do
         allow(subject).to receive(:fetch_config).and_return(new_config)
-        allow(subject).to receive(:stop_pipeline)
-        allow(subject).to receive(:start_pipeline)
+        allow(subject).to receive(:start_pipeline).and_return(true)
+        allow(subject).to receive(:stop_pipeline) do |id|
+          # we register_pipeline but we never execute them so we have to mock #stop_pipeline to
+          # not call Pipeline#shutdown but Pipeline#close
+          subject.close_pipeline(id)
+        end
       end
+
       it "updates the state" do
         subject.send(:"reload_pipeline!", default_pipeline_id)
         expect(subject.pipelines[default_pipeline_id].config_str).to eq(new_config)
       end
+
       it "starts the pipeline" do
-        expect(subject).to receive(:stop_pipeline)
-        expect(subject).to receive(:start_pipeline)
+        expect(subject).to receive(:start_pipeline).and_return(true)
+        expect(subject).to receive(:stop_pipeline) do |id|
+          # we register_pipeline but we never execute them so we have to mock #stop_pipeline to
+          # not call Pipeline#shutdown but Pipeline#close
+          subject.close_pipeline(id)
+        end
         subject.send(:"reload_pipeline!", default_pipeline_id)
       end
     end
@@ -378,9 +425,9 @@ describe LogStash::Agent do
     end
   end
 
-
   context "metrics after config reloading" do
     let!(:config) { "input { generator { } } output { dummyoutput { } }" }
+
     let!(:config_path) do
       f = Stud::Temporary.file
       f.write(config)
@@ -388,6 +435,7 @@ describe LogStash::Agent do
       f.close
       f.path
     end
+
     let(:pipeline_args) do
       {
         "pipeline.workers" => 2,
@@ -411,6 +459,13 @@ describe LogStash::Agent do
     let!(:dummy_output) { LogStash::Outputs::DroppingDummyOutput.new }
     let!(:dummy_output2) { DummyOutput2.new }
     let(:initial_generator_threshold) { 1000 }
+    let(:pipeline_thread) do
+      Thread.new do
+        subject.register_pipeline(pipeline_settings)
+        subject.execute
+      end
+    end
+
 
     before :each do
       allow(LogStash::Outputs::DroppingDummyOutput).to receive(:new).at_least(:once).with(anything).and_return(dummy_output)
@@ -424,20 +479,17 @@ describe LogStash::Agent do
       @abort_on_exception = Thread.abort_on_exception
       Thread.abort_on_exception = true
 
-      @t = Thread.new do
-        subject.register_pipeline(pipeline_settings)
-        subject.execute
-      end
+      pipeline_thread
 
       # wait for some events to reach the dummy_output
-      sleep(0.01) until dummy_output.events_received > initial_generator_threshold
+      sleep(0.1) until dummy_output.events_received > initial_generator_threshold
     end
 
     after :each do
       begin
         subject.shutdown
-        Stud.stop!(@t)
-        @t.join
+        Stud.stop!(pipeline_thread)
+        pipeline_thread.join
       ensure
         Thread.abort_on_exception = @abort_on_exception
       end
@@ -446,8 +498,8 @@ describe LogStash::Agent do
     context "when reloading a good config" do
       let(:new_config_generator_counter) { 500 }
       let(:new_config) { "input { generator { count => #{new_config_generator_counter} } } output { dummyoutput2 {} }" }
-      before :each do
 
+      before :each do
         File.open(config_path, "w") do |f|
           f.write(new_config)
           f.fsync
@@ -496,12 +548,10 @@ describe LogStash::Agent do
         value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:last_error].value
         expect(value).to be(nil)
       end
-
     end
 
     context "when reloading a bad config" do
       let(:new_config) { "input { generator { count => " }
-      let(:new_config_generator_counter) { 500 }
       before :each do
 
         File.open(config_path, "w") do |f|
@@ -546,7 +596,6 @@ describe LogStash::Agent do
 
     context "when reloading a config that raises exception on pipeline.run" do
       let(:new_config) { "input { generator { count => 10000 } }" }
-      let(:new_config_generator_counter) { 500 }
 
       class BrokenGenerator < LogStash::Inputs::Generator
         def register
@@ -555,14 +604,12 @@ describe LogStash::Agent do
       end
 
       before :each do
-
         allow(LogStash::Plugin).to receive(:lookup).with("input", "generator").and_return(BrokenGenerator)
 
         File.open(config_path, "w") do |f|
           f.write(new_config)
           f.fsync
         end
-
       end
 
       it "does not increase the successful reload count" do
@@ -573,7 +620,7 @@ describe LogStash::Agent do
         }
       end
 
-      it "increases the failured reload count" do
+      it "increases the failures reload count" do
         expect { subject.send(:"reload_pipeline!", "main") }.to change {
           snapshot = subject.metric.collector.snapshot_metric
           reload_metrics = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads]

--- a/logstash-core/spec/logstash/queue_factory_spec.rb
+++ b/logstash-core/spec/logstash/queue_factory_spec.rb
@@ -36,7 +36,9 @@ describe LogStash::QueueFactory do
     end
 
     it "returns a `WrappedAckedQueue`" do
-      expect(subject.create(settings)).to be_kind_of(LogStash::Util::WrappedAckedQueue)
+      queue =  subject.create(settings)
+      expect(queue).to be_kind_of(LogStash::Util::WrappedAckedQueue)
+      queue.close
     end
 
     describe "per pipeline id subdirectory creation" do
@@ -50,6 +52,7 @@ describe LogStash::QueueFactory do
         expect(Dir.exist?(queue_path)).to be_falsey
         queue = subject.create(settings)
         expect(Dir.exist?(queue_path)).to be_truthy
+        queue.close
       end
     end
   end
@@ -60,7 +63,9 @@ describe LogStash::QueueFactory do
     end
 
     it "returns a `WrappedAckedQueue`" do
-      expect(subject.create(settings)).to be_kind_of(LogStash::Util::WrappedAckedQueue)
+      queue =  subject.create(settings)
+      expect(queue).to be_kind_of(LogStash::Util::WrappedAckedQueue)
+      queue.close
     end
   end
 
@@ -70,7 +75,9 @@ describe LogStash::QueueFactory do
     end
 
     it "returns a `WrappedAckedQueue`" do
-      expect(subject.create(settings)).to be_kind_of(LogStash::Util::WrappedSynchronousQueue)
+      queue =  subject.create(settings)
+      expect(queue).to be_kind_of(LogStash::Util::WrappedSynchronousQueue)
+      queue.close
     end
   end
 end

--- a/logstash-core/src/main/java/org/logstash/FileLockFactory.java
+++ b/logstash-core/src/main/java/org/logstash/FileLockFactory.java
@@ -87,7 +87,7 @@ public class FileLockFactory {
                     LOCK_MAP.put(lock, realLockPath.toString());
                     return lock;
                 } else {
-                    throw new LockException("Lock held by another program: " + realLockPath);
+                    throw new LockException("Lock held by another program on lock path: " + realLockPath);
                 }
             } finally {
                 if (lock == null) { // not successful - clear up and move out
@@ -106,7 +106,7 @@ public class FileLockFactory {
                 }
             }
         } else {
-            throw new LockException("Lock held by this virtual machine: " + realLockPath);
+            throw new LockException("Lock held by this virtual machine on lock path: " + realLockPath);
         }
     }
 

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/HeadPageTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/HeadPageTest.java
@@ -25,6 +25,8 @@ public class HeadPageTest {
         assertThat(p.isFullyAcked(), is(false));
         assertThat(p.hasSpace(10), is(true));
         assertThat(p.hasSpace(100), is(false));
+
+        q.close();
     }
 
     @Test
@@ -43,6 +45,8 @@ public class HeadPageTest {
         assertThat(p.hasSpace(element.serialize().length), is(false));
         assertThat(p.isFullyRead(), is(false));
         assertThat(p.isFullyAcked(), is(false));
+
+        q.close();
     }
 
     @Test
@@ -67,6 +71,8 @@ public class HeadPageTest {
         assertThat(p.hasSpace(element.serialize().length), is(false));
         assertThat(p.isFullyRead(), is(true));
         assertThat(p.isFullyAcked(), is(false));
+
+        q.close();
     }
 
     @Test
@@ -91,6 +97,8 @@ public class HeadPageTest {
         assertThat(p.hasSpace(element.serialize().length), is(false));
         assertThat(p.isFullyRead(), is(true));
         assertThat(p.isFullyAcked(), is(false));
+
+        q.close();
     }
 
     // disabled test until we figure what to do in this condition

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
@@ -42,6 +42,8 @@ public class QueueTest {
         q.open();
 
         assertThat(q.nonBlockReadBatch(1), is(equalTo(null)));
+
+        q.close();
     }
 
     @Test
@@ -57,6 +59,8 @@ public class QueueTest {
         assertThat(b.getElements().size(), is(equalTo(1)));
         assertThat(b.getElements().get(0).toString(), is(equalTo(element.toString())));
         assertThat(q.nonBlockReadBatch(1), is(equalTo(null)));
+
+        q.close();
     }
 
     @Test
@@ -72,6 +76,8 @@ public class QueueTest {
         assertThat(b.getElements().size(), is(equalTo(1)));
         assertThat(b.getElements().get(0).toString(), is(equalTo(element.toString())));
         assertThat(q.nonBlockReadBatch(2), is(equalTo(null)));
+
+        q.close();
     }
 
     @Test
@@ -95,6 +101,8 @@ public class QueueTest {
 
         assertThat(b.getElements().size(), is(equalTo(1)));
         assertThat(b.getElements().get(0).toString(), is(equalTo(elements.get(2).toString())));
+
+        q.close();
     }
 
     @Test
@@ -137,6 +145,8 @@ public class QueueTest {
 
         b = q.nonBlockReadBatch(10);
         assertThat(b, is(equalTo(null)));
+
+        q.close();
     }
 
 
@@ -178,6 +188,8 @@ public class QueueTest {
         b.close();
 
         assertThat(q.getHeadPage().isFullyAcked(), is(equalTo(true)));
+
+        q.close();
     }
 
     @Test
@@ -263,6 +275,8 @@ public class QueueTest {
         assertThat(c.getMinSeqNum(), is(equalTo(3L)));
         assertThat(c.getFirstUnackedSeqNum(), is(equalTo(5L)));
         assertThat(c.getFirstUnackedPageNum(), is(equalTo(1)));
+
+        q.close();
     }
 
     @Test
@@ -304,6 +318,8 @@ public class QueueTest {
             }
 
             assertThat(q.getTailPages().size(), is(equalTo(0)));
+
+            q.close();
         }
     }
 
@@ -353,6 +369,8 @@ public class QueueTest {
 
         // since we did not ack and pages hold a single item
         assertThat(q.getTailPages().size(), is(equalTo(ELEMENT_COUNT)));
+
+        q.close();
     }
 
     @Test
@@ -406,6 +424,8 @@ public class QueueTest {
         assertThat(q.getHeadPage().getElementCount() > 0L, is(true));
         assertThat(q.getHeadPage().unreadCount(), is(equalTo(1L)));
         assertThat(q.unreadCount, is(equalTo(1L)));
+
+        q.close();
     }
 
     @Test(timeout = 5000)
@@ -440,6 +460,7 @@ public class QueueTest {
         assertThat(q.isFull(), is(true));
 
         executor.shutdown();
+        q.close();
     }
 
     @Test(timeout = 5000)
@@ -483,6 +504,7 @@ public class QueueTest {
         assertThat(q.isFull(), is(false));
 
         executor.shutdown();
+        q.close();
     }
 
     @Test(timeout = 5000)
@@ -523,6 +545,7 @@ public class QueueTest {
         assertThat(q.isFull(), is(true)); // queue should still be full
 
         executor.shutdown();
+        q.close();
     }
 
     @Test

--- a/logstash-core/src/test/java/org/logstash/stress/Concurent.java
+++ b/logstash-core/src/test/java/org/logstash/stress/Concurent.java
@@ -151,6 +151,7 @@ public class Concurent {
 
         // gotta hate exception handling in lambdas
         consumers.forEach(c -> {try{c.join();} catch(InterruptedException e) {throw new RuntimeException(e);}});
+        q.close();
 
         Instant end = Instant.now();
 


### PR DESCRIPTION
This fixes #6604 by implementing exclusive access to the queue at Pipeline initialization. 

The `sample` spec helper in **devutils** `logstash_helpers.rb`does not close the pipeline after instantiating it. I decided to explicitly close the pipelines in all tests using `sample` instead of modifying **devutils** because I am afraid of potential dependency conflicts if we update **devutils** at this point also knowing that it will be refactored into the main source tree soon.

I am not sure if this is the best idea, I am open to suggestions.

#### TODO
- [x] fix the pipeline commented out specs for the multi pipelines cases.