### PR TITLE
pin minitar dep to 0.5.4

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "i18n", "= 0.6.9" #(MIT license)
 
   # filetools and rakelib
-  gem.add_runtime_dependency "minitar", "~> 0.5.4"
+  gem.add_runtime_dependency "minitar", "0.5.4"
   gem.add_runtime_dependency "rubyzip", "~> 1.1.7"
   gem.add_runtime_dependency "thread_safe", "~> 0.3.5" #(Apache 2.0 license)
 

--- a/rakelib/dependency.rake
+++ b/rakelib/dependency.rake
@@ -9,7 +9,7 @@ namespace "dependency" do
   end # task rbx-stdlib
 
   task "archive-tar-minitar" do
-    Rake::Task["gem:require"].invoke("minitar", ">= 0")
+    Rake::Task["gem:require"].invoke("minitar", "0.5.4")
   end # task archive-minitar
 
   task "stud" do


### PR DESCRIPTION
a new Minitar release was made: https://rubygems.org/gems/minitar/versions/0.6

It is breaking the build:

```
[bootstrap] Fetching and installing gem: minitar (>= 0)
The `minitar` executable is no longer bundled with `minitar`. If you are
expecting this executable, make sure you also install `minitar-cli`.
Successfully installed minitar-0.6
rake aborted!
IOError: closed stream
org/jruby/RubyIO.java:1826:in `seek'
org/jruby/ext/zlib/JZlibRubyGzipReader.java:205:in `rewind'
/home/travis/build/elastic/logstash/vendor/bundle/jruby/1.9/gems/minitar-0.6/lib/archive/tar/minitar/reader.rb:182:in `rewind'
/home/travis/build/elastic/logstash/vendor/bundle/jruby/1.9/gems/minitar-0.6/lib/archive/tar/minitar/input.rb:89:in `each_entry'
/home/travis/build/elastic/logstash/rakelib/vendor.rake:20:in `untar'
/home/travis/build/elastic/logstash/rakelib/vendor.rake:86:in `(root)'
org/jruby/RubyProc.java:281:in `call'
org/jruby/RubyArray.java:1613:in `each'
/home/travis/build/elastic/logstash/rakelib/z_rubycheck.rake:28:in `(root)'
org/jruby/RubyKernel.java:1059:in `load'
org/jruby/RubyKernel.java:1059:in `load'
org/jruby/RubyKernel.java:1079:in `eval'
/home/travis/.rvm/gems/jruby-1.7.25/bin/jruby_executable_hooks:15:in `(root)'
Tasks: TOP => vendor:jruby
(See full trace by running task with --trace)
```