### PR TITLE
Update pleaserun and system-install

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem "rack-test", :require => "rack/test", :group => :development
 gem "flores", "~> 0.0.6", :group => :development
 gem "term-ansicolor", "~> 1.3.2", :group => :development
 gem "docker-api", "1.31.0", :group => :development
-gem "pleaserun", "~>0.0.27"
+gem "pleaserun", "~>0.0.28"
 gem "logstash-input-heartbeat"
 gem "logstash-codec-collectd"
 gem "logstash-output-xmpp"

--- a/bin/system-install
+++ b/bin/system-install
@@ -5,8 +5,11 @@ unset CDPATH
 setup
 
 if [ -z "$1" ]; then
-  [ -r ${LOGSTASH_HOME}/config/startup.options ] && . ${LOGSTASH_HOME}/config/startup.options
-  [ -r /etc/logstash/startup.options ] && . /etc/logstash/startup.options
+  if [ -r /etc/logstash/startup.options ]; then
+    OPTIONS_PATH=/etc/logstash/startup.options
+  elif [ -r ${LOGSTASH_HOME}/config/startup.options ]; then
+    OPTIONS_PATH=${LOGSTASH_HOME}/config/startup.options
+  fi
 elif [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
   echo "Usage: system-install [OPTIONSFILE] [STARTUPTYPE] [VERSION]"
   echo
@@ -29,7 +32,7 @@ elif [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
 else
   if [ -r $1 ]; then
     echo "Using provided startup.options file: ${1}"
-    . $1
+    OPTIONS_PATH=$1
   else
     echo "$1 is not a file path"
     echo "To manually specify a startup style, put the path to startup.options as the "
@@ -37,6 +40,24 @@ else
     exit 1
   fi
 fi
+
+# Read in the env vars in the selected startup.options file...
+. ${OPTIONS_PATH}
+
+old_IFS=$IFS
+IFS=$'\n'
+lines=($(grep -v ^# ${OPTIONS_PATH} | tr -d '"' | grep -v '^LS_OPTS=' | grep \= | grep -v '\=$' | grep -v '\=\"\"$'))
+IFS=$old_IFS
+
+ENV_VAR_ARGS=()
+
+for line in ${lines[@]}; do
+  var=$(echo $line | awk -F\= '{print $1}')
+  if [ "x${!var}" != "x" ]; then
+    ENV_VAR_ARGS+=('--environment-variables')
+    ENV_VAR_ARGS+=("${var}=${!var}")
+  fi
+done
 
 # bin/logstash-plugin is a short lived ruby script thus we can use aggressive "faster starting JRuby options"
 # see https://github.com/jruby/jruby/wiki/Improving-startup-time
@@ -61,9 +82,10 @@ if [[ $3 ]]; then
   opts+=($3)
 fi
 
+allopts=("${ENV_VAR_ARGS[@]}" "${opts[@]}")
 program="$(cd `dirname $0`/..; pwd)/bin/logstash"
 
-$(ruby_exec "${LOGSTASH_HOME}/lib/systeminstall/pleasewrap.rb" "${opts[@]}" ${program} ${LS_OPTS})
+$(ruby_exec "${LOGSTASH_HOME}/lib/systeminstall/pleasewrap.rb" "${allopts[@]}" ${program} ${LS_OPTS})
 exit_code=$?
 
 if [ $exit_code -ne 0 ]; then


### PR DESCRIPTION
This will now put ENV variables from the `startup.options` file into `/etc/default/logstash` or `/etc/sysconfig/logstash` (or whatever service name you chose), and use the updated pleaserun to ensure these are honored at start time for whichever init system you use (systemd, upstart, SysV).

fixes #6482