### PR TITLE
Pipeline register hooks + hash fix

### DIFF
--- a/logstash-core/lib/logstash-core_jars.rb
+++ b/logstash-core/lib/logstash-core_jars.rb
@@ -1,8 +1,18 @@
 # this is a generated file, to avoid over-writing it just delete this comment
-require 'jar_dependencies'
+begin
+  require 'jar_dependencies'
+rescue LoadError
+  require 'org/apache/logging/log4j/log4j-core/2.6.2/log4j-core-2.6.2.jar'
+  require 'org/apache/logging/log4j/log4j-api/2.6.2/log4j-api-2.6.2.jar'
+  require 'com/fasterxml/jackson/core/jackson-core/2.7.4/jackson-core-2.7.4.jar'
+  require 'com/fasterxml/jackson/core/jackson-annotations/2.7.0/jackson-annotations-2.7.0.jar'
+  require 'com/fasterxml/jackson/core/jackson-databind/2.7.4/jackson-databind-2.7.4.jar'
+end
 
-require_jar( 'org.apache.logging.log4j', 'log4j-core', '2.6.2' )
-require_jar( 'com.fasterxml.jackson.core', 'jackson-annotations', '2.7.0' )
-require_jar( 'com.fasterxml.jackson.core', 'jackson-databind', '2.7.4' )
-require_jar( 'org.apache.logging.log4j', 'log4j-api', '2.6.2' )
-require_jar( 'com.fasterxml.jackson.core', 'jackson-core', '2.7.4' )
+if defined? Jars
+  require_jar( 'org.apache.logging.log4j', 'log4j-core', '2.6.2' )
+  require_jar( 'org.apache.logging.log4j', 'log4j-api', '2.6.2' )
+  require_jar( 'com.fasterxml.jackson.core', 'jackson-core', '2.7.4' )
+  require_jar( 'com.fasterxml.jackson.core', 'jackson-annotations', '2.7.0' )
+  require_jar( 'com.fasterxml.jackson.core', 'jackson-databind', '2.7.4' )
+end

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -403,6 +403,7 @@ class LogStash::Agent
       if !t.alive?
         return false
       elsif pipeline.running?
+        dispatcher.fire(:pipeline_started, pipeline)
         return true
       else
         sleep 0.01
@@ -416,6 +417,7 @@ class LogStash::Agent
     @logger.warn("stopping pipeline", :id => id)
     pipeline.shutdown { LogStash::ShutdownWatcher.start(pipeline) }
     @pipelines[id].thread.join
+    dispatcher.fire(:pipeline_stopped, pipeline)
   end
 
   def start_pipelines

--- a/logstash-core/lib/logstash/instrument/metric_store.rb
+++ b/logstash-core/lib/logstash/instrument/metric_store.rb
@@ -218,7 +218,7 @@ module LogStash module Instrument
       key_candidates = extract_filter_keys(key_paths.shift)
 
       key_candidates.each do |key_candidate|
-        raise MetricNotFound, "For path: #{key_candidate}" if map[key_candidate].nil?
+        raise MetricNotFound, "For path: #{key_candidate}. Map keys: #{map.keys}" if map[key_candidate].nil?
 
         if key_paths.empty? # End of the user requested path
           if map[key_candidate].is_a?(Concurrent::Map)

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -20,16 +20,20 @@ require "logstash/instrument/collector"
 require "logstash/output_delegator"
 require "logstash/filter_delegator"
 require "logstash/queue_factory"
+require 'logstash/compiler'
 
 module LogStash; class BasePipeline
   include LogStash::Util::Loggable
 
-  attr_reader :config_str, :config_hash, :inputs, :filters, :outputs, :pipeline_id
-
+  attr_reader :config_str, :config_hash, :inputs, :filters, :outputs, :pipeline_id, :lir
+  
   def initialize(config_str, settings = SETTINGS)
     @logger = self.logger
     @config_str = config_str
     @config_hash = Digest::SHA1.hexdigest(@config_str)
+    
+    @lir = compile_lir
+    
     # Every time #plugin is invoked this is incremented to give each plugin
     # a unique id when auto-generating plugin ids
     @plugin_counter ||= 0
@@ -61,6 +65,10 @@ module LogStash; class BasePipeline
     rescue => e
       raise e
     end
+  end
+  
+  def compile_lir
+    LogStash::Compiler.compile_pipeline(self.config_str)
   end
 
   def plugin(plugin_type, name, *args)
@@ -164,6 +172,8 @@ module LogStash; class Pipeline < BasePipeline
     @running = Concurrent::AtomicBoolean.new(false)
     @flushing = Concurrent::AtomicReference.new(false)
   end # def initialize
+  
+  
 
   def ready?
     @ready.value
@@ -498,7 +508,6 @@ module LogStash; class Pipeline < BasePipeline
       @signal_queue.push(FLUSH)
     end
   end
-
 
   # Calculate the uptime in milliseconds
   #

--- a/logstash-core/spec/logstash/compiler/compiler_spec.rb
+++ b/logstash-core/spec/logstash/compiler/compiler_spec.rb
@@ -392,6 +392,15 @@ describe LogStash::Compiler do
               it "should compile correctly" do
                 expect(c_expression).to ir_eql(j.eRegexEq(j.eEventValue("[foo]"), j.eRegex('^abc$')))
               end
+              
+              # Believe it or not, "\.\." is a valid regexp!
+              describe "when given a quoted regexp" do
+                let(:expression) { '[foo] =~ "\\.\\."' }
+              
+                it "should compile correctly" do
+                  expect(c_expression).to ir_eql(j.eRegexEq(j.eEventValue("[foo]"), j.eRegex('\\.\\.')))
+                end
+              end
             end
 
             describe "'!~'" do

--- a/logstash-core/src/main/java/org/logstash/common/Util.java
+++ b/logstash-core/src/main/java/org/logstash/common/Util.java
@@ -9,14 +9,19 @@ import java.security.NoSuchAlgorithmException;
  */
 public class Util {
     // Modified from http://stackoverflow.com/a/11009612/11105
-    public static String sha256(String base) {
+
+    public static MessageDigest defaultMessageDigest() {
         try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(base.getBytes(StandardCharsets.UTF_8));
-            return bytesToHexString(hash);
+            return MessageDigest.getInstance("SHA-256");
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("Your system is (somehow) missing the SHA-256 algorithm!", e);
+            throw new RuntimeException(e);
         }
+    }
+
+    public static String digest(String base) {
+        MessageDigest digest = defaultMessageDigest();
+        byte[] hash = digest.digest(base.getBytes(StandardCharsets.UTF_8));
+        return bytesToHexString(hash);
     }
 
     public static String bytesToHexString(byte[] bytes) {

--- a/logstash-core/src/main/java/org/logstash/config/ir/IHashable.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/IHashable.java
@@ -9,6 +9,6 @@ public interface IHashable {
     String hashSource();
 
     default String uniqueHash() {
-        return Util.sha256(this.hashSource());
+        return Util.digest(this.hashSource());
     }
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/Pipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/Pipeline.java
@@ -30,6 +30,11 @@ public class Pipeline implements IHashable {
     private final SpecialVertex filterOut;
 
     public Pipeline(Graph inputSection, Graph filterSection, Graph outputSection) throws InvalidIRException {
+        // Validate all incoming graphs, we can't turn an invalid graph into a Pipeline!
+        inputSection.validate();
+        filterSection.validate();
+        outputSection.validate();
+
         Graph tempGraph = inputSection.copy(); // The input section are our roots, so we can import that wholesale
 
         // Connect all the input vertices out to the queue

--- a/logstash-core/src/main/java/org/logstash/config/ir/expression/BinaryBooleanExpression.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/expression/BinaryBooleanExpression.java
@@ -48,6 +48,6 @@ public abstract class BinaryBooleanExpression extends BooleanExpression {
 
     @Override
     public String hashSource() {
-        return getLeft().hashSource() + this.getClass().getCanonicalName() + getRight().hashSource();
+        return this.getClass().getCanonicalName() + "[" + getLeft().hashSource() + "|" + getRight().hashSource() + "]";
     }
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/expression/Expression.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/expression/Expression.java
@@ -7,7 +7,7 @@ import org.logstash.config.ir.IHashable;
 import org.logstash.config.ir.SourceComponent;
 import org.logstash.config.ir.SourceMetadata;
 
-/**
+/*
  * [foo] == "foostr" eAnd [bar] > 10
  * eAnd(eEq(eventValueExpr("foo"), value("foostr")), eEq(eEventValue("bar"), value(10)))
  *

--- a/logstash-core/src/main/java/org/logstash/config/ir/expression/UnaryBooleanExpression.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/expression/UnaryBooleanExpression.java
@@ -22,6 +22,6 @@ public abstract class UnaryBooleanExpression extends BooleanExpression {
 
     @Override
     public String hashSource() {
-        return this.getClass().getCanonicalName() + this.expression.hashSource();
+        return this.getClass().getCanonicalName() + "[" + this.expression.hashSource() + "]";
     }
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/BooleanEdge.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/BooleanEdge.java
@@ -1,5 +1,6 @@
 package org.logstash.config.ir.graph;
 
+import org.logstash.common.Util;
 import org.logstash.config.ir.ISourceComponent;
 import org.logstash.config.ir.InvalidIRException;
 
@@ -50,7 +51,12 @@ public class BooleanEdge extends Edge {
 
     @Override
     public String individualHashSource() {
-        return this.getClass().getCanonicalName() + "|" + this.getEdgeType();
+        return this.getClass().getCanonicalName() + "|" + this.getEdgeType() + "|";
+    }
+
+    @Override
+    public String getId() {
+        return Util.digest(this.getFrom().getId() + "[" + this.getEdgeType() + "]->" + this.getTo().getId());
     }
 
     public String toString() {

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/Edge.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/Edge.java
@@ -89,6 +89,9 @@ public abstract class Edge implements ISourceComponent {
 
     public abstract String individualHashSource();
 
+
+    public abstract String getId();
+
     @Override
     public SourceMetadata getMeta() {
         return null;

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/IfVertex.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/IfVertex.java
@@ -93,6 +93,6 @@ public class IfVertex extends Vertex {
 
     @Override
     public String individualHashSource() {
-        return this.getClass().getCanonicalName() + "|" + this.booleanExpression.hashSource();
+        return this.getClass().getCanonicalName() + "{" + this.booleanExpression.hashSource() + "}";
     }
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/PlainEdge.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/PlainEdge.java
@@ -1,5 +1,6 @@
 package org.logstash.config.ir.graph;
 
+import org.logstash.common.Util;
 import org.logstash.config.ir.InvalidIRException;
 
 /**
@@ -18,6 +19,11 @@ public class PlainEdge extends Edge {
     @Override
     public String individualHashSource() {
         return this.getClass().getCanonicalName();
+    }
+
+    @Override
+    public String getId() {
+        return Util.digest(this.getFrom().getId() + "->" + this.getTo().getId());
     }
 
     public PlainEdge(Vertex from, Vertex to) throws InvalidIRException {

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/PluginVertex.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/PluginVertex.java
@@ -41,18 +41,19 @@ public class PluginVertex extends Vertex {
     }
 
     public String toString() {
-        return "P[" + pluginDefinition + "]";
+        return "P[" + pluginDefinition + "|" + this.getMeta() + "]";
     }
 
     @Override
     public String individualHashSource() {
-        return Util.sha256(this.getClass().getCanonicalName() + "|" +
+        return Util.digest(this.getClass().getCanonicalName() + "|" +
                 (this.id != null ? this.id : "NOID") + "|" +
+                //this.getMeta().getSourceLine() + "|" + this.getMeta().getSourceColumn() + "|" + // Temp hack REMOVE BEFORE RELEASE
                 this.getPluginDefinition().hashSource());
     }
 
     public String individualHash() {
-        return Util.sha256(individualHashSource());
+        return Util.digest(individualHashSource());
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/config/ir/imperative/IfStatement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/imperative/IfStatement.java
@@ -93,11 +93,11 @@ public class IfStatement extends Statement {
         newGraph.addVertex(ifVertex);
 
         for (Vertex v : trueRoots) {
-            newGraph.threadVertices(BooleanEdge.trueFactory, ifVertex, v);
+            newGraph.threadVerticesUnsafe(BooleanEdge.trueFactory, ifVertex, v);
         }
 
         for (Vertex v : falseRoots) {
-            newGraph.threadVertices(BooleanEdge.falseFactory, ifVertex, v);
+            newGraph.threadVerticesUnsafe(BooleanEdge.falseFactory, ifVertex, v);
         }
 
         return newGraph;

--- a/logstash-core/src/test/java/org/logstash/config/ir/IRHelpers.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/IRHelpers.java
@@ -99,6 +99,11 @@ public class IRHelpers {
         public String individualHashSource() {
             return "TEdge";
         }
+
+        @Override
+        public String getId() {
+            return individualHashSource();
+        }
     }
 
     public static BooleanExpression testExpression() throws InvalidIRException {

--- a/logstash-core/src/test/java/org/logstash/config/ir/imperative/ImperativeToGraphtest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/imperative/ImperativeToGraphtest.java
@@ -19,6 +19,8 @@ public class ImperativeToGraphtest {
     @Test
     public void convertSimpleExpression() throws InvalidIRException {
         Graph imperative =  iComposeSequence(iPlugin(FILTER, "json"), iPlugin(FILTER, "stuff")).toGraph();
+        imperative.validate(); // Verify this is a valid graph
+
         Graph regular = Graph.empty();
         regular.threadVertices(gPlugin(FILTER, "json"), gPlugin(FILTER, "stuff"));
 
@@ -28,6 +30,8 @@ public class ImperativeToGraphtest {
     @Test
     public void testIdsDontAffectSourceComponentEquality() throws InvalidIRException {
         Graph imperative =  iComposeSequence(iPlugin(FILTER, "json", "oneid"), iPlugin(FILTER, "stuff", "anotherid")).toGraph();
+        imperative.validate(); // Verify this is a valid graph
+
         Graph regular = Graph.empty();
         regular.threadVertices(gPlugin(FILTER, "json", "someotherid"), gPlugin(FILTER, "stuff", "graphid"));
 
@@ -36,7 +40,7 @@ public class ImperativeToGraphtest {
 
     @Test
     public void convertComplexExpression() throws InvalidIRException {
-        Graph generated = iComposeSequence(
+        Graph imperative = iComposeSequence(
                 iPlugin(FILTER, "p1"),
                 iPlugin(FILTER, "p2"),
                 iIf(eAnd(eTruthy(eValue(5l)), eTruthy(eValue(null))),
@@ -44,6 +48,7 @@ public class ImperativeToGraphtest {
                         iComposeSequence(iPlugin(FILTER, "p4"), iPlugin(FILTER, "p5"))
                 )
         ).toGraph();
+        imperative.validate(); // Verify this is a valid graph
 
         PluginVertex p1 = gPlugin(FILTER, "p1");
         PluginVertex p2 = gPlugin(FILTER, "p2");
@@ -58,14 +63,14 @@ public class ImperativeToGraphtest {
         expected.threadVertices(false, testIf, p4);
         expected.threadVertices(p4, p5);
 
-        assertGraphEquals(expected, generated);
+        assertGraphEquals(expected, imperative);
     }
 
     // This test has an imperative grammar with nested ifs and dangling
     // partial leaves. This makes sure they all wire-up right
     @Test
     public void deepDanglingPartialLeaves() throws InvalidIRException {
-         Graph generated = iComposeSequence(
+         Graph imperative = iComposeSequence(
                  iPlugin(FILTER, "p0"),
                  iIf(eTruthy(eValue(1)),
                          iPlugin(FILTER, "p1"),
@@ -79,6 +84,7 @@ public class ImperativeToGraphtest {
                  iPlugin(FILTER, "pLast")
 
          ).toGraph();
+        imperative.validate(); // Verify this is a valid graph
 
         IfVertex if1 = gIf(eTruthy(eValue(1)));
         IfVertex if2 = gIf(eTruthy(eValue(2)));
@@ -104,7 +110,7 @@ public class ImperativeToGraphtest {
         expected.threadVertices(p3, pLast);
         expected.threadVertices(p4,pLast);
 
-        assertGraphEquals(generated, expected);
+        assertGraphEquals(imperative, expected);
     }
 
     // This is a good test for what the filter block will do, where there
@@ -112,7 +118,7 @@ public class ImperativeToGraphtest {
     // single node
     @Test
     public void convertComplexExpressionWithTerminal() throws InvalidIRException {
-        Graph generated = iComposeSequence(
+        Graph imperative = iComposeSequence(
             iPlugin(FILTER, "p1"),
             iIf(eTruthy(eValue(1)),
                 iComposeSequence(
@@ -126,6 +132,7 @@ public class ImperativeToGraphtest {
             ),
             iPlugin(FILTER, "terminal")
         ).toGraph();
+        imperative.validate(); // Verify this is a valid graph
 
         PluginVertex p1 = gPlugin(FILTER,"p1");
         PluginVertex p2 = gPlugin(FILTER, "p2");
@@ -154,7 +161,7 @@ public class ImperativeToGraphtest {
         expected.threadVertices(p4, p5);
         expected.threadVertices(p5, terminal);
 
-        assertGraphEquals(generated, expected);
+        assertGraphEquals(imperative, expected);
 
     }
 }

--- a/rakelib/compile.rake
+++ b/rakelib/compile.rake
@@ -10,20 +10,27 @@ namespace "compile" do
   desc "Compile the config grammar"
 
   task "grammar" => "logstash-core/lib/logstash/config/grammar.rb"
+  
+  def safe_system(*args)
+    if !system(*args)
+      status = $?
+      raise "Got exit status #{status.exitstatus} attempting to execute #{args.inspect}!"
+    end
+  end
 
   task "logstash-core-java" do
     puts("Building logstash-core using gradle")
-    system("./gradlew", "jar", "-p", "./logstash-core")
+    safe_system("./gradlew", "jar", "-p", "./logstash-core")
   end
 
   task "logstash-core-event-java" do
     puts("Building logstash-core-event-java using gradle")
-    system("./gradlew", "jar", "-p", "./logstash-core-event-java")
+    safe_system("./gradlew", "jar", "-p", "./logstash-core-event-java")
   end
 
   task "logstash-core-queue-jruby" do
     puts("Building logstash-core-queue-jruby using gradle")
-    system("./gradlew", "jar", "-p", "./logstash-core-queue-jruby")
+    safe_system("./gradlew", "jar", "-p", "./logstash-core-queue-jruby")
   end
 
   desc "Build everything"


### PR DESCRIPTION
This PR does three things:

1. It adds hooks for pipeline lifecycle events (and adds an LIR object to all pipeline objects)
2. It fixes a bug where sometimes if statements would create invalid graph objects during their construction.
3. It also fixes a bug where configs using strings as regex rvalues would break. Ex: `[foo] =~ "bar"`