### PR TITLE
fix bad head positioning on recovery & tests

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -160,6 +160,8 @@ public class Queue implements Closeable {
             } catch (NoSuchFileException e) {
                 // if there is no head checkpoint, create a new headpage and checkpoint it and exit method
 
+                logger.debug("No head checkpoint found at: {}, creating new head page", checkpointIO.headFileName());
+
                 this.seqNum = 0;
                 headPageNum = 0;
 
@@ -177,6 +179,8 @@ public class Queue implements Closeable {
                 // all tail checkpoints in the sequence should exist, if not abort mission with a NoSuchFileException
                 Checkpoint cp = this.checkpointIO.read(this.checkpointIO.tailFileName(pageNum));
 
+                logger.debug("opening tail page: {}, in: {}, with checkpoint: {}", pageNum, this.dirPath, cp.toString());
+
                 PageIO pageIO = this.pageIOFactory.build(pageNum, this.pageCapacity, this.dirPath);
                 pageIO.open(cp.getMinSeqNum(), cp.getElementCount());
 
@@ -185,6 +189,8 @@ public class Queue implements Closeable {
 
             // transform the head page into a tail page only if the headpage is non-empty
             // in both cases it will be checkpointed to track any changes in the firstUnackedPageNum when reconstructing the tail pages
+
+            logger.debug("opening head page: {}, in: {}, with checkpoint: {}", headCheckpoint.getPageNum(), this.dirPath, headCheckpoint.toString());
 
             PageIO pageIO = this.pageIOFactory.build(headCheckpoint.getPageNum(), this.pageCapacity, this.dirPath);
             pageIO.recover(); // optimistically recovers the head page data file and set minSeqNum and elementCount to the actual read/recovered data

--- a/logstash-core/src/main/java/org/logstash/common/io/MmapPageIO.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/MmapPageIO.java
@@ -101,6 +101,9 @@ public class MmapPageIO extends AbstractByteBufferPageIO {
 
     @Override
     public void close() throws IOException {
+        if (this.buffer != null) {
+            this.buffer.force();
+        }
         if (this.channel != null && this.channel.isOpen()) {
             this.channel.close();
         }

--- a/logstash-core/src/test/java/org/logstash/common/io/ByteBufferPageIOTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/ByteBufferPageIOTest.java
@@ -134,6 +134,46 @@ public class ByteBufferPageIOTest {
         assertThat(io.getMinSeqNum(), is(equalTo(seqNum)));
     }
 
+    @Test
+    public void recoverEmptyWriteRecover() throws IOException {
+        Queueable element = new StringElement("foobarbaz");
+        long seqNum = 42L;
+        ByteBufferPageIO io = newEmptyPageIO();
+        byte[] inititalState = io.dump();
+
+        io = newPageIO(inititalState.length, inititalState);
+        io.recover();
+        assertThat(io.getElementCount(), is(equalTo(0)));
+
+        io.write(element.serialize(), seqNum);
+        inititalState = io.dump();
+
+        io = newPageIO(inititalState.length, inititalState);
+        io.recover();
+        assertThat(io.getElementCount(), is(equalTo(1)));
+        assertThat(io.getMinSeqNum(), is(equalTo(seqNum)));
+    }
+
+    @Test
+    public void recoverNonEmptyWriteRecover() throws IOException {
+        Queueable element = new StringElement("foobarbaz");
+
+        ByteBufferPageIO io = newEmptyPageIO();
+        io.write(element.serialize(), 1L);
+        byte[] inititalState = io.dump();
+
+        io = newPageIO(inititalState.length, inititalState);
+        io.recover();
+        assertThat(io.getElementCount(), is(equalTo(1)));
+
+        io.write(element.serialize(), 2L);
+        inititalState = io.dump();
+
+        io = newPageIO(inititalState.length, inititalState);
+        io.recover();
+        assertThat(io.getElementCount(), is(equalTo(2)));
+    }
+
     @Test(expected = IOException.class)
     public void openUnexpectedSeqNum() throws IOException {
         Queueable element = new StringElement("foobarbaz");


### PR DESCRIPTION
This fixes a problem found while testing #6691 where recovery would fail with 
```
[2017-02-13T10:37:56,505][WARN ][org.logstash.ackedqueue.Queue] recovered head data page 1 is different than checkpoint, using recovered page information.
```
- The problem is in the head page positioning after recovery. The head needs to be update only after a fully valid recovered element. 
- Added tests for this case. Tests are failing without fix and passing with fix.
- I also left some debug traces used to diagnose the problem. 
- I also added an explicit fsync on close. 