### PR TITLE
Run integration tests separately

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ rvm:
 jdk:
   - oraclejdk8
 env:
+  - INTEGRATION=false
   - INTEGRATION=true
+  - INTEGRATION=false FEATURE_FLAG=persistent_queues
   - INTEGRATION=true FEATURE_FLAG=persistent_queues
 before_install:
   # Force bundler 1.12.5 because version 1.13 has issues, see https://github.com/fastlane/fastlane/issues/6065#issuecomment-246044617
@@ -17,9 +19,13 @@ before_install:
   - gem install bundler -v 1.12.5 --no-rdoc --no-ri --no-document --quiet   
 install:
   - rake test:install-core
-  - ci/travis_integration_install.sh
 before_script:
   - echo "--order rand" > .rspec
 script:
-  - rake test:core
-  - ci/travis_integration_run.sh
+  - |+
+      if [ "$INTEGRATION" == "true" ]; then
+        ci/travis_integration_install.sh
+        ci/travis_integration_run.sh;
+      else
+        rake test:core
+      fi      


### PR DESCRIPTION
This will clarify our travis results and make test suites run a bit faster by taking advantage of some parallelism.