### PR TITLE
Collecting the ThreadCount and the PeakThreadCount should not trigger a threaddump

### DIFF
--- a/logstash-core/lib/logstash/instrument/periodic_poller/jvm.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/jvm.rb
@@ -44,7 +44,7 @@ module LogStash module Instrument module PeriodicPoller
 
     def collect
       raw = JRMonitor.memory.generate
-      collect_jvm_metrics(raw)      
+      collect_jvm_metrics(raw)
       collect_pools_metrics(raw)
       collect_threads_metrics
       collect_process_metrics
@@ -69,15 +69,10 @@ module LogStash module Instrument module PeriodicPoller
     end
 
     def collect_threads_metrics
-      threads = JRMonitor.threads.generate
+      threads_mx = ManagementFactory.getThreadMXBean()
 
-      current = threads.count
-      if @peak_threads.nil? || @peak_threads < current
-        @peak_threads = current
-      end
-
-      metric.gauge([:jvm, :threads], :count, threads.count)
-      metric.gauge([:jvm, :threads], :peak_count, @peak_threads)
+      metric.gauge([:jvm, :threads], :count, threads_mx.getThreadCount())
+      metric.gauge([:jvm, :threads], :peak_count, threads_mx.getPeakThreadCount())
     end
 
     def collect_process_metrics


### PR DESCRIPTION
When we use the JRMonitor library to get information about the running
threads it will trigger a thread dump to get the stacktrace information this OK when
we do a direct call to the `hot_threads` API but in the context of the
periodic poller this would mean that the threads need to be stopped to
generate their current stacktrace. 

Which could significantly slow down logstash. This PR use the **ThreadMXBean** but only use the `#getThreadCount` and the `#getPeakThreadCount`. Theses two calls won't generate a hreaddump and won't block the currents
threads.

**To test** add the following option to your `config/jvm.options` and let logstash run for a few minutes to trigger a few periodic poller iteration and stop logstash you will see the report.

```
-XX:+PrintSafepointStatistics
-XX:PrintSafepointStatisticsCount=1
```


Fixes: #6603 