### PR TITLE
Fix a few issues when using the logstash-docgen tools

### DIFF
--- a/tools/logstash-docgen/lib/logstash/docgen/github_generator.rb
+++ b/tools/logstash-docgen/lib/logstash/docgen/github_generator.rb
@@ -26,12 +26,16 @@ module LogStash module Docgen
     BUNDLER_CMD = "bundler install --jobs 8 --quiet --path /tmp/vendor"
     RAKE_VENDOR_CMD = "bundle exec rake vendor"
     RAKE_DOC_ASCIIDOC = "bundle exec rake doc:asciidoc"
+    DOCUMENT_SEPARATOR = "~~~ASCIIDOC_DOCUMENT~~~\n"
 
     # Content needed to inject to make the generator work
     GEMFILE_CHANGES = "gem 'logstash-docgen', :path => \"#{File.expand_path(File.join(File.dirname(__FILE__), "..", "..", ".."))}\""
 
     # require devutils to fix an issue when the logger is not found
-    RAKEFILE_CHANGES = "require 'logstash/devutils/rspec/spec_helper'; require 'logstash/docgen/plugin_doc'"
+    RAKEFILE_CHANGES = "
+    require 'logstash/devutils/rspec/spec_helper'
+    puts '#{DOCUMENT_SEPARATOR}'
+    require 'logstash/docgen/plugin_doc'"
 
     attr_reader :path, :full_name
 
@@ -89,7 +93,8 @@ module LogStash module Docgen
       output = run_in_directory(RAKE_DOC_ASCIIDOC)
       destination = File.join(destination, "#{type}s")
       FileUtils.mkdir_p(destination)
-      IO.write(File.join(destination, "#{name}.asciidoc"), output.read)
+      content = output.read.split(DOCUMENT_SEPARATOR).last
+      IO.write(File.join(destination, "#{name}.asciidoc"), content)
     end
 
     def bundle_install

--- a/tools/logstash-docgen/lib/logstash/docgen/github_generator.rb
+++ b/tools/logstash-docgen/lib/logstash/docgen/github_generator.rb
@@ -29,7 +29,9 @@ module LogStash module Docgen
 
     # Content needed to inject to make the generator work
     GEMFILE_CHANGES = "gem 'logstash-docgen', :path => \"#{File.expand_path(File.join(File.dirname(__FILE__), "..", "..", ".."))}\""
-    RAKEFILE_CHANGES = "require 'logstash/docgen/plugin_doc'"
+
+    # require devutils to fix an issue when the logger is not found
+    RAKEFILE_CHANGES = "require 'logstash/devutils/rspec/spec_helper'; require 'logstash/docgen/plugin_doc'"
 
     attr_reader :path, :full_name
 

--- a/tools/logstash-docgen/lib/logstash/docgen/static_parser.rb
+++ b/tools/logstash-docgen/lib/logstash/docgen/static_parser.rb
@@ -18,6 +18,7 @@ module LogStash::Docgen
     NEW_CLASS_DEFINITION_RE_ML = /^\s*class\s(.*) < *(::)?LogStash::(Outputs|Filters|Inputs|Codecs)::(\w+)/
     CONFIG_OPTION_RE = /^\s*((mod|base).)?config +[^=].*/
     CONFIG_NAME_RE = /^ *config_name .*/
+    RESET_BUFFER_RE = /^require\s("|')\w+("|')/
 
     def initialize(context)
       @rules =  [
@@ -26,6 +27,7 @@ module LogStash::Docgen
         [ NEW_CLASS_DEFINITION_RE_ML, :parse_new_class_description ],
         [ CONFIG_OPTION_RE, :parse_config ],
         [ CONFIG_NAME_RE, :parse_config_name ],
+        [ RESET_BUFFER_RE, :reset_buffer ]
       ]
 
       @context = context


### PR DESCRIPTION
Fixes the following issues:

- Make multiline plugin definition correctly take the description See
rabbit mq input or output
- Use a regexp to ignore encoding comment
- Use `TODO` The doc gen will now ignore some TODOs.
- rules are now executed in the correct order,
- make sure to ignore comment not associated with a description of an
attribute

Ref: #6692
