### PR TITLE
Remove the default column in the plugin doc page to give space to the sidebar

### DIFF
--- a/tools/logstash-docgen/templates/plugin-doc.asciidoc.erb
+++ b/tools/logstash-docgen/templates/plugin-doc.asciidoc.erb
@@ -44,7 +44,7 @@ Complete configuration example:
 
 Available configuration options:
 
-[cols="<,<,<,<m",options="header",]
+[cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
 <% sorted_attributes.each do |name, config|

--- a/tools/logstash-docgen/templates/plugin-doc.asciidoc.erb
+++ b/tools/logstash-docgen/templates/plugin-doc.asciidoc.erb
@@ -46,7 +46,7 @@ Available configuration options:
 
 [cols="<,<,<,<m",options="header",]
 |=======================================================================
-|Setting |Input type|Required|Default value
+|Setting |Input type|Required
 <% sorted_attributes.each do |name, config|
    next if config[:obsolete]
    next if config[:deprecated]
@@ -65,11 +65,6 @@ Available configuration options:
      annotation += "|Yes"
    else
      annotation += "|No"
-   end
-   if config.include?(:default)
-     annotation += "|`#{config[:default].inspect}`"
-   else
-     annotation += "|"
    end
 -%>
 | <<plugins-<%= section %>s-<%=config_name%>-<%=name%>>> <%= annotation %>


### PR DESCRIPTION

Fix: #6515