### PR TITLE
unify gradle projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ qa/Gemfile.lock
 *.ipr
 *.iws
 *.iml
-.gradle
 .idea
 logs
 qa/integration/services/installed/

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,1 @@
+apply plugin: 'idea'

--- a/logstash-core-event-java/build.gradle
+++ b/logstash-core-event-java/build.gradle
@@ -106,7 +106,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'net.javacrumbs.json-unit:json-unit:1.9.0'
     provided 'org.jruby:jruby-core:1.7.25'
-    provided files('../logstash-core/lib/logstash-core/logstash-core.jar')
+    provided project(':logstash-core')
 }
 
 // See http://www.gradle.org/docs/current/userguide/gradle_wrapper.html

--- a/logstash-core-event-java/settings.gradle
+++ b/logstash-core-event-java/settings.gradle
@@ -1,2 +1,4 @@
 rootProject.name = 'logstash-core-event-java'
 
+include ':logstash-core'
+project(':logstash-core').projectDir = new File('../logstash-core')

--- a/logstash-core-queue-jruby/build.gradle
+++ b/logstash-core-queue-jruby/build.gradle
@@ -112,8 +112,8 @@ idea {
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     provided group: 'org.jruby', name: 'jruby-core', version: '1.7.25'
-    provided files('../logstash-core-event-java/lib/logstash-core-event-java/logstash-core-event-java.jar')
-    provided files('../logstash-core/lib/logstash-core/logstash-core.jar')
+    provided project(':logstash-core-event-java')
+    provided project(':logstash-core')
 }
 
 // See http://www.gradle.org/docs/current/userguide/gradle_wrapper.html

--- a/logstash-core-queue-jruby/settings.gradle
+++ b/logstash-core-queue-jruby/settings.gradle
@@ -1,1 +1,6 @@
 rootProject.name = 'logstash-core-queue-jruby'
+
+include ':logstash-core'
+include ':logstash-core-event-java'
+project(':logstash-core').projectDir = new File('../logstash-core')
+project(':logstash-core-event-java').projectDir = new File('../logstash-core-event-java')

--- a/rakelib/compile.rake
+++ b/rakelib/compile.rake
@@ -13,19 +13,9 @@ namespace "compile" do
 
   task "logstash-core-java" do
     puts("Building logstash-core using gradle")
-    system("./gradlew", "jar", "-p", "./logstash-core")
-  end
-
-  task "logstash-core-event-java" do
-    puts("Building logstash-core-event-java using gradle")
-    system("./gradlew", "jar", "-p", "./logstash-core-event-java")
-  end
-
-  task "logstash-core-queue-jruby" do
-    puts("Building logstash-core-queue-jruby using gradle")
-    system("./gradlew", "jar", "-p", "./logstash-core-queue-jruby")
+    system("./gradlew", "jar")
   end
 
   desc "Build everything"
-  task "all" => ["grammar", "logstash-core-java", "logstash-core-event-java", "logstash-core-queue-jruby"]
+  task "all" => ["grammar", "logstash-core-java"]
 end

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,6 @@
+include ':logstash-core'
+include ':logstash-core-event-java'
+include ':logstash-core-queue-jruby'
+project(':logstash-core').projectDir = new File('./logstash-core')
+project(':logstash-core-event-java').projectDir = new File('./logstash-core-event-java')
+project(':logstash-core-queue-jruby').projectDir = new File('./logstash-core-queue-jruby')


### PR DESCRIPTION
Currently, there are three separate gradle projects in this repository.

These gradle files unify them so that one can call `gradle build` from the parent `logstash` directory and build all of the projects together. This also allows one to run `gradle idea` to generate an intellij `.ipr` project for more seamless development between the three projects.