### PR TITLE
PQ exclusive locking backport in 5.2

### DIFF
--- a/bin/lock
+++ b/bin/lock
@@ -1,0 +1,9 @@
+#!/usr/bin/env bin/ruby
+
+require_relative "../lib/bootstrap/environment"
+LogStash::Bundler.setup!({:without => [:build, :development]})
+require "logstash-core"
+
+lock = Java::OrgLogstash::FileLockFactory.getDefault.obtainLock(ARGV[0], ".lock")
+puts("locking " + File.join(ARGV[0], ".lock"))
+sleep

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -249,7 +249,7 @@ class LogStash::Runner < Clamp::StrictCommand
       config_loader = LogStash::Config::Loader.new(logger)
       config_str = config_loader.format_config(setting("path.config"), setting("config.string"))
       begin
-        LogStash::Pipeline.new(config_str)
+        LogStash::BasePipeline.new(config_str)
         puts "Configuration OK"
         logger.info "Using config.test_and_exit mode. Config Validation Result: OK. Exiting Logstash"
         return 0

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -138,7 +138,7 @@ describe LogStash::Pipeline do
       Thread.abort_on_exception = true
 
       pipeline = LogStash::Pipeline.new(config, pipeline_settings_obj)
-      Thread.new { pipeline.run }
+      t = Thread.new { pipeline.run }
       sleep 0.1 while !pipeline.ready?
       wait(3).for do
         # give us a bit of time to flush the events
@@ -149,6 +149,7 @@ describe LogStash::Pipeline do
       expect(output.events[0].get("tags")).to eq(["notdropped"])
       expect(output.events[1].get("tags")).to eq(["notdropped"])
       pipeline.shutdown
+      t.join
 
       Thread.abort_on_exception = abort_on_exception_state
     end
@@ -192,12 +193,14 @@ describe LogStash::Pipeline do
           pipeline_settings_obj.set("config.debug", false)
           expect(logger).not_to receive(:debug).with(/Compiled pipeline/, anything)
           pipeline = TestPipeline.new(test_config_with_filters)
+          pipeline.close
         end
 
         it "should print the compiled code if config.debug is set to true" do
           pipeline_settings_obj.set("config.debug", true)
           expect(logger).to receive(:debug).with(/Compiled pipeline/, anything)
           pipeline = TestPipeline.new(test_config_with_filters, pipeline_settings_obj)
+          pipeline.close
         end
       end
 
@@ -385,9 +388,12 @@ describe LogStash::Pipeline do
       allow(LogStash::Plugin).to receive(:lookup).with("codec", "plain").and_return(DummyCodec)
       allow(LogStash::Plugin).to receive(:lookup).with("output", "dummyoutput").and_return(::LogStash::Outputs::DummyOutput)
       allow(logger).to receive(:warn)
-      thread = Thread.new { pipeline.run }
+      # pipeline must be first called outside the thread context because it lazyly initialize
+      p = pipeline
+      t = Thread.new { p.run }
+      sleep(0.1) until pipeline.ready?
       pipeline.shutdown
-      thread.join
+      t.join
     end
 
     it "should not raise a max inflight warning if the max_inflight count isn't exceeded" do
@@ -439,6 +445,10 @@ describe LogStash::Pipeline do
 
     let(:settings) { LogStash::SETTINGS.clone }
     subject { LogStash::Pipeline.new(config, settings, metric) }
+
+    after :each do
+      subject.close
+    end
 
     context "when metric.collect is disabled" do
       before :each do
@@ -528,8 +538,20 @@ describe LogStash::Pipeline do
       allow(LogStash::Plugin).to receive(:lookup).with("output", "dummyoutputmore").and_return(DummyOutputMore)
     end
 
+    # multiple pipelines cannot be instantiated using the same PQ settings, force memory queue
+    before :each do
+      pipeline_workers_setting = LogStash::SETTINGS.get_setting("queue.type")
+      allow(pipeline_workers_setting).to receive(:value).and_return("memory")
+      pipeline_settings.each {|k, v| pipeline_settings_obj.set(k, v) }
+    end
+
     let(:pipeline1) { LogStash::Pipeline.new("input { dummyinputgenerator {} } filter { dummyfilter {} } output { dummyoutput {}}") }
     let(:pipeline2) { LogStash::Pipeline.new("input { dummyinputgenerator {} } filter { dummyfilter {} } output { dummyoutputmore {}}") }
+
+    after  do
+      pipeline1.close
+      pipeline2.close
+    end
 
     it "should handle evaluating different config" do
       expect(pipeline1.output_func(LogStash::Event.new)).not_to include(nil)
@@ -573,7 +595,7 @@ describe LogStash::Pipeline do
     it "flushes the buffered contents of the filter" do
       Thread.abort_on_exception = true
       pipeline = LogStash::Pipeline.new(config, pipeline_settings_obj)
-      Thread.new { pipeline.run }
+      t = Thread.new { pipeline.run }
       sleep 0.1 while !pipeline.ready?
       wait(3).for do
         # give us a bit of time to flush the events
@@ -582,6 +604,7 @@ describe LogStash::Pipeline do
       event = output.events.pop
       expect(event.get("message").count("\n")).to eq(99)
       pipeline.shutdown
+      t.join
     end
   end
 
@@ -595,6 +618,13 @@ describe LogStash::Pipeline do
 
     let(:pipeline1) { LogStash::Pipeline.new("input { generator {} } filter { dummyfilter {} } output { dummyoutput {}}") }
     let(:pipeline2) { LogStash::Pipeline.new("input { generator {} } filter { dummyfilter {} } output { dummyoutput {}}") }
+
+    # multiple pipelines cannot be instantiated using the same PQ settings, force memory queue
+    before :each do
+      pipeline_workers_setting = LogStash::SETTINGS.get_setting("queue.type")
+      allow(pipeline_workers_setting).to receive(:value).and_return("memory")
+      pipeline_settings.each {|k, v| pipeline_settings_obj.set(k, v) }
+    end
 
     it "should handle evaluating different config" do
       # When the functions are compiled from the AST it will generate instance
@@ -626,8 +656,14 @@ describe LogStash::Pipeline do
 
     subject { described_class.new(config) }
 
-    it "returns nil when the pipeline isnt started" do
-      expect(subject.started_at).to be_nil
+    context "when the pipeline is not started" do
+      after :each do
+        subject.close
+      end
+
+      it "returns nil when the pipeline isnt started" do
+        expect(subject.started_at).to be_nil
+      end
     end
 
     it "return when the pipeline started working" do
@@ -648,6 +684,10 @@ describe LogStash::Pipeline do
     subject { described_class.new(config) }
 
     context "when the pipeline is not started" do
+      after :each do
+        subject.close
+      end
+
       it "returns 0" do
         expect(subject.uptime).to eq(0)
       end
@@ -655,10 +695,14 @@ describe LogStash::Pipeline do
 
     context "when the pipeline is started" do
       it "return the duration in milliseconds" do
-        t = Thread.new { subject.run }
+        # subject must be first call outside the thread context because of lazy initialization
+        s = subject
+        t = Thread.new { s.run }
+        sleep(0.1) until subject.ready?
         sleep(0.1)
         expect(subject.uptime).to be > 0
         subject.shutdown
+        t.join
       end
     end
   end
@@ -704,6 +748,12 @@ describe LogStash::Pipeline do
     end
     let(:dummyoutput) { ::LogStash::Outputs::DummyOutput.new({ "id" => dummy_output_id }) }
     let(:metric_store) { subject.metric.collector.snapshot_metric.metric_store }
+    let(:pipeline_thread) do
+      # subject has to be called for the first time outside the thread because it will create a race condition
+      # with the subject.ready? call since subject is lazily initialized
+      s = subject
+      Thread.new { s.run }
+    end
 
     before :each do
       allow(::LogStash::Outputs::DummyOutput).to receive(:new).with(any_args).and_return(dummyoutput)
@@ -712,7 +762,9 @@ describe LogStash::Pipeline do
       allow(LogStash::Plugin).to receive(:lookup).with("filter", "multiline").and_return(LogStash::Filters::Multiline)
       allow(LogStash::Plugin).to receive(:lookup).with("output", "dummyoutput").and_return(::LogStash::Outputs::DummyOutput)
 
-      Thread.new { subject.run }
+      pipeline_thread
+      sleep(0.1) until subject.ready?
+
       # make sure we have received all the generated events
       wait(3).for do
         # give us a bit of time to flush the events
@@ -722,6 +774,7 @@ describe LogStash::Pipeline do
 
     after :each do
       subject.shutdown
+      pipeline_thread.join
     end
 
     context "global metric" do
@@ -786,6 +839,13 @@ describe LogStash::Pipeline do
 
     let(:pipeline1) { LogStash::Pipeline.new("input { generator {} } filter { dummyfilter {} } output { dummyoutput {}}") }
     let(:pipeline2) { LogStash::Pipeline.new("input { generator {} } filter { dummyfilter {} } output { dummyoutput {}}") }
+
+    # multiple pipelines cannot be instantiated using the same PQ settings, force memory queue
+    before :each do
+      pipeline_workers_setting = LogStash::SETTINGS.get_setting("queue.type")
+      allow(pipeline_workers_setting).to receive(:value).and_return("memory")
+      pipeline_settings.each {|k, v| pipeline_settings_obj.set(k, v) }
+    end
 
     it "should not add ivars" do
        expect(pipeline1.instance_variables).to eq(pipeline2.instance_variables)

--- a/logstash-core/src/main/java/org/logstash/FileLockFactory.java
+++ b/logstash-core/src/main/java/org/logstash/FileLockFactory.java
@@ -1,0 +1,121 @@
+// this class is largely inspired by Lucene FSLockFactory and friends, below is the Lucene original Apache 2.0 license:
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.logstash;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * FileLockFactory provides a way to obtain an exclusive file lock for a given dir path and lock name.
+ * The obtainLock() method will return a Filelock object which should be released using the releaseLock()
+ * method. Normally the returned FileLock object should not be manipulated directly. Only the obtainLock()
+ * and releaseLock() methods should be use to gain and release exclusive access.
+ * This is threadsafe and will work across threads on the same JVM and will also work across processes/JVM.
+ *
+ * TODO: because of the releaseLock() method, strictly speaking this class is not only a factory anymore,
+ * maybe we should rename it FileLockManager?
+ */
+public class FileLockFactory {
+
+    /**
+     * Singleton instance
+     */
+    public static final FileLockFactory INSTANCE = new FileLockFactory();
+
+    private FileLockFactory() {}
+
+    private static final Set<String> LOCK_HELD = Collections.synchronizedSet(new HashSet<>());
+    private static final Map<FileLock, String> LOCK_MAP =  Collections.synchronizedMap(new HashMap<>());
+
+    public static final FileLockFactory getDefault() {
+        return FileLockFactory.INSTANCE;
+    }
+
+    public FileLock obtainLock(String lockDir, String lockName) throws IOException {
+        Path dirPath = FileSystems.getDefault().getPath(lockDir);
+
+        // Ensure that lockDir exists and is a directory.
+        // note: this will fail if lockDir is a symlink
+        Files.createDirectories(dirPath);
+
+        Path lockPath = dirPath.resolve(lockName);
+
+        try {
+            Files.createFile(lockPath);
+        } catch (IOException ignore) {
+            // we must create the file to have a truly canonical path.
+            // if it's already created, we don't care. if it cant be created, it will fail below.
+        }
+
+        // fails if the lock file does not exist
+        final Path realLockPath = lockPath.toRealPath();
+
+        if (LOCK_HELD.add(realLockPath.toString())) {
+            FileChannel channel = null;
+            FileLock lock = null;
+            try {
+                channel = FileChannel.open(realLockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                lock = channel.tryLock();
+                if (lock != null) {
+                    LOCK_MAP.put(lock, realLockPath.toString());
+                    return lock;
+                } else {
+                    throw new LockException("Lock held by another program on lock path: " + realLockPath);
+                }
+            } finally {
+                if (lock == null) { // not successful - clear up and move out
+                    try {
+                        if (channel != null) {
+                            channel.close();
+                        }
+                    } catch (Throwable t) {
+                        // suppress any channel close exceptions
+                    }
+
+                    boolean removed = LOCK_HELD.remove(realLockPath.toString());
+                    if (removed == false) {
+                        throw new LockException("Lock path was cleared but never marked as held: " + realLockPath);
+                    }
+                }
+            }
+        } else {
+            throw new LockException("Lock held by this virtual machine on lock path: " + realLockPath);
+        }
+    }
+
+    public void releaseLock(FileLock lock) throws IOException {
+        String lockPath = LOCK_MAP.remove(lock);
+        if (lockPath == null) { throw new LockException("Cannot release unobtained lock"); }
+        lock.release();
+        Boolean removed = LOCK_HELD.remove(lockPath);
+        if (removed == false) { throw new LockException("Lock path was not marked as held: " + lockPath); }
+    }
+
+}

--- a/logstash-core/src/main/java/org/logstash/LockException.java
+++ b/logstash-core/src/main/java/org/logstash/LockException.java
@@ -1,0 +1,13 @@
+package org.logstash;
+
+import java.io.IOException;
+
+public class LockException extends IOException {
+    public LockException(String message) {
+        super(message);
+    }
+
+    public LockException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/FileLockFactoryTest.java
+++ b/logstash-core/src/test/java/org/logstash/FileLockFactoryTest.java
@@ -1,0 +1,91 @@
+package org.logstash;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.nio.channels.FileLock;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+public class FileLockFactoryTest {
+    @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    private String lockDir;
+    private final String LOCK_FILE = ".test";
+
+    private FileLock lock;
+
+    @Before
+    public void setUp() throws Exception {
+        lockDir = temporaryFolder.newFolder("lock").getPath();
+    }
+
+    @Before
+    public void lockFirst() throws Exception {
+        lock = FileLockFactory.getDefault().obtainLock(lockDir, LOCK_FILE);
+        assertThat(lock.isValid(), is(equalTo(true)));
+        assertThat(lock.isShared(), is(equalTo(false)));
+    }
+
+    @Test
+    public void ObtainLockOnNonLocked() throws IOException {
+        // empty to just test the lone @Before lockFirst() test
+    }
+
+    @Test(expected = LockException.class)
+    public void ObtainLockOnLocked() throws IOException {
+        FileLockFactory.getDefault().obtainLock(lockDir, LOCK_FILE);
+    }
+
+    @Test
+    public void ObtainLockOnOtherLocked() throws IOException {
+        FileLock lock2 = FileLockFactory.getDefault().obtainLock(lockDir, ".test2");
+        assertThat(lock2.isValid(), is(equalTo(true)));
+        assertThat(lock2.isShared(), is(equalTo(false)));
+    }
+
+    @Test
+    public void LockReleaseLock() throws IOException {
+        FileLockFactory.getDefault().releaseLock(lock);
+    }
+
+    @Test
+    public void LockReleaseLockObtainLock() throws IOException {
+        FileLockFactory.getDefault().releaseLock(lock);
+
+        FileLock lock2 = FileLockFactory.getDefault().obtainLock(lockDir, LOCK_FILE);
+        assertThat(lock2.isValid(), is(equalTo(true)));
+        assertThat(lock2.isShared(), is(equalTo(false)));
+    }
+
+    @Test
+    public void LockReleaseLockObtainLockRelease() throws IOException {
+        FileLockFactory.getDefault().releaseLock(lock);
+
+        FileLock lock2 = FileLockFactory.getDefault().obtainLock(lockDir, LOCK_FILE);
+        assertThat(lock2.isValid(), is(equalTo(true)));
+        assertThat(lock2.isShared(), is(equalTo(false)));
+
+        FileLockFactory.getDefault().releaseLock(lock2);
+    }
+
+    @Test(expected = LockException.class)
+    public void ReleaseNullLock() throws IOException {
+        FileLockFactory.getDefault().releaseLock(null);
+     }
+
+    @Test(expected = LockException.class)
+    public void ReleaseUnobtainedLock() throws IOException {
+        FileLockFactory.getDefault().releaseLock(lock);
+        FileLockFactory.getDefault().releaseLock(lock);
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/HeadPageTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/HeadPageTest.java
@@ -29,6 +29,8 @@ public class HeadPageTest {
         assertThat(p.isFullyAcked(), is(false));
         assertThat(p.hasSpace(10), is(true));
         assertThat(p.hasSpace(100), is(false));
+
+        q.close();
     }
 
     @Test
@@ -47,6 +49,8 @@ public class HeadPageTest {
         assertThat(p.hasSpace(element.serialize().length), is(false));
         assertThat(p.isFullyRead(), is(false));
         assertThat(p.isFullyAcked(), is(false));
+
+        q.close();
     }
 
     @Test
@@ -71,6 +75,8 @@ public class HeadPageTest {
         assertThat(p.hasSpace(element.serialize().length), is(false));
         assertThat(p.isFullyRead(), is(true));
         assertThat(p.isFullyAcked(), is(false));
+
+        q.close();
     }
 
     @Test
@@ -95,6 +101,8 @@ public class HeadPageTest {
         assertThat(p.hasSpace(element.serialize().length), is(false));
         assertThat(p.isFullyRead(), is(true));
         assertThat(p.isFullyAcked(), is(false));
+
+        q.close();
     }
 
     // disabled test until we figure what to do in this condition

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
@@ -40,6 +40,8 @@ public class QueueTest {
         q.open();
 
         assertThat(q.nonBlockReadBatch(1), is(equalTo(null)));
+
+        q.close();
     }
 
     @Test
@@ -55,6 +57,8 @@ public class QueueTest {
         assertThat(b.getElements().size(), is(equalTo(1)));
         assertThat(b.getElements().get(0).toString(), is(equalTo(element.toString())));
         assertThat(q.nonBlockReadBatch(1), is(equalTo(null)));
+
+        q.close();
     }
 
     @Test
@@ -70,6 +74,8 @@ public class QueueTest {
         assertThat(b.getElements().size(), is(equalTo(1)));
         assertThat(b.getElements().get(0).toString(), is(equalTo(element.toString())));
         assertThat(q.nonBlockReadBatch(2), is(equalTo(null)));
+
+        q.close();
     }
 
     @Test
@@ -93,6 +99,8 @@ public class QueueTest {
 
         assertThat(b.getElements().size(), is(equalTo(1)));
         assertThat(b.getElements().get(0).toString(), is(equalTo(elements.get(2).toString())));
+
+        q.close();
     }
 
     @Test
@@ -135,6 +143,8 @@ public class QueueTest {
 
         b = q.nonBlockReadBatch(10);
         assertThat(b, is(equalTo(null)));
+
+        q.close();
     }
 
 
@@ -176,6 +186,8 @@ public class QueueTest {
         b.close();
 
         assertThat(q.getHeadPage().isFullyAcked(), is(equalTo(true)));
+
+        q.close();
     }
 
     @Test
@@ -256,6 +268,8 @@ public class QueueTest {
         assertThat(c.getMinSeqNum(), is(equalTo(3L)));
         assertThat(c.getFirstUnackedSeqNum(), is(equalTo(5L)));
         assertThat(c.getFirstUnackedPageNum(), is(equalTo(1)));
+
+        q.close();
     }
 
     @Test
@@ -297,6 +311,8 @@ public class QueueTest {
             }
 
             assertThat(q.getTailPages().size(), is(equalTo(0)));
+
+            q.close();
         }
     }
 
@@ -346,6 +362,8 @@ public class QueueTest {
 
         // since we did not ack and pages hold a single item
         assertThat(q.getTailPages().size(), is(equalTo(ELEMENT_COUNT)));
+
+        q.close();
     }
 
     @Test
@@ -399,6 +417,8 @@ public class QueueTest {
         assertThat(q.getHeadPage().getElementCount() > 0L, is(true));
         assertThat(q.getHeadPage().unreadCount(), is(equalTo(1L)));
         assertThat(q.unreadCount, is(equalTo(1L)));
+
+        q.close();
     }
 
     @Test(timeout = 5000)
@@ -433,6 +453,8 @@ public class QueueTest {
         assertThat(q.isFull(), is(true));
 
         executor.shutdown();
+
+        q.close();
     }
 
     @Test(timeout = 5000)
@@ -476,6 +498,8 @@ public class QueueTest {
         assertThat(q.isFull(), is(false));
 
         executor.shutdown();
+
+        q.close();
     }
 
     @Test(timeout = 5000)
@@ -516,6 +540,8 @@ public class QueueTest {
         assertThat(q.isFull(), is(true)); // queue should still be full
 
         executor.shutdown();
+
+        q.close();
     }
 
     @Test

--- a/logstash-core/src/test/java/org/logstash/stress/Concurent.java
+++ b/logstash-core/src/test/java/org/logstash/stress/Concurent.java
@@ -162,6 +162,8 @@ public class Concurent {
         } else {
             System.out.println("SUCCESS, result size=" + output.size() + ", elapsed=" + Duration.between(start, end) + ", rate=" + (new Float(ELEMENT_COUNT) / Duration.between(start, end).toMillis()) * 1000);
         }
+
+        q.close();
     }
 
 

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -60,6 +60,7 @@ namespace "artifact" do
     @exclude_paths << "bin/bundle"
     @exclude_paths << "bin/rspec"
     @exclude_paths << "bin/rspec.bat"
+    @exclude_paths << "bin/lock"
 
     @exclude_paths
   end


### PR DESCRIPTION
This backports the 5.3 PQ exclusive locking into 5.2, which also required backporting:
- pipeline reloading fixes to avoid double opened pipelines
- pipeline workers start to properly clean state upon errors
- all related specs 