### PR TITLE
memory mapped buffer cleaner

### DIFF
--- a/logstash-core/src/test/java/org/logstash/common/io/FileCheckpointIOTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/FileCheckpointIOTest.java
@@ -46,7 +46,7 @@ public class FileCheckpointIOTest {
         Path fullFileName = Paths.get(checkpointFolder, "checkpoint.head");
         byte[] contents = Files.readAllBytes(fullFileName);
         URL url = this.getClass().getResource("checkpoint.head");
-        Path path = Paths.get(url.getPath());
+        Path path = Paths.get(url.toURI());
         byte[] compare = Files.readAllBytes(path);
         assertThat(contents, is(equalTo(compare)));
     }


### PR DESCRIPTION
Fixes #6646 

Under Windows, sometimes PQ throws and exception when trying to purge a page with something like:
```
java.nio.file.FileSystemException: page.0: The process cannot access the file
 because it is being used by another process.
        at sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:86)
        at sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:97)
        at sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:102)
        at sun.nio.fs.WindowsFileSystemProvider.implDelete(WindowsFileSystemProvider.java:269)
        at sun.nio.fs.AbstractFileSystemProvider.delete(AbstractFileSystemProvider.java:103)
        at java.nio.file.Files.delete(Files.java:1126)
        at org.logstash.common.io.MmapPageIO.purge(MmapPageIO.java:99)
        at org.logstash.ackedqueue.TailPage.purge(TailPage.java:38)
       ...
```
I was able to reproduce this problem in the Java tests.

After reviewing code I did not find where a page could be deleted without being fully closed. After some investigations I found out that a memory mapped buffer will only be released when the resource is freed by the GC. 

These 2 threads discusses this problem:
- http://stackoverflow.com/questions/2972986/how-to-unmap-a-file-from-memory-mapped-using-filechannel-in-java
- http://stackoverflow.com/questions/8462200/examples-of-forcing-freeing-of-native-memory-direct-bytebuffer-has-allocated-us

Also note that Lucene also does something similar in https://github.com/apache/lucene-solr/blob/e8f4746ec4ea345b522f51c349f4a2a3abff352e/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java

This fix solved the tests on Windows. 

This PR also include a small fix for a resource path problem in Windows which only broke a test but did not have consequence in the actual code.