### PR TITLE
Implements #has_metric?(*path)

### DIFF
--- a/logstash-core/spec/logstash/instrument/metric_store_spec.rb
+++ b/logstash-core/spec/logstash/instrument/metric_store_spec.rb
@@ -53,6 +53,20 @@ describe LogStash::Instrument::MetricStore do
       end
     end
 
+    context "#has_metric?" do
+      context "when the path exist" do
+        it "returns true" do
+          expect(subject.has_metric?(:node, :sashimi, :pipelines, :pipeline01, :plugins, :"logstash-output-elasticsearch", :event_in)).to be_truthy
+        end
+      end
+
+      context "when the path doesn't exist" do
+        it "returns false" do
+          expect(subject.has_metric?(:node, :sashimi, :pipelines, :pipeline01, :plugins, :"logstash-input-nothing")).to be_falsey
+        end
+      end
+    end
+
     describe "#get" do
       context "when the path exist" do
         it "retrieves end of of a branch" do


### PR DESCRIPTION
Add a new method that uses the `fast_lookup` has to find if a specific
metric exist instead of relying on exceptions.

Usage:

```ruby
metric_store.has_metric?(:node, :sashimi, :pipelines, :pipeline01, :plugins, :"logstash-output-elasticsearch", :event_in) # true
metric_store.has_metric?(:node, :sashimi, :pipelines, :pipeline01, :plugins, :"logstash-output-elasticsearch", :do_not_exist) # false
```
Fixes: #6533