### PR TITLE
Add at least once delivery to persistent queue docs

### DIFF
--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -21,19 +21,19 @@ persistent queues to buffer events on disk and remove the message broker.
 
 In summary, the benefits of enabling persistent queues are as follows:
 
-* Provides protection from in-flight message loss when the Logstash process is abnormally terminated.
-* Absorbs bursts of events without needing an external buffering mechanism like Redis or Apache Kafka.
-* Provides an at-least-once message delivery guarantee. If Logstash is restarted while events are
-in-flight, Logstash will attempt to deliver messages stored in the persistent queue until delivery
-succeeds at least once. In other words, messages stored in the persistent queue may be duplicated, but
-not lost.
+* Absorbs bursts of events without needing an external buffering mechanism like
+Redis or Apache Kafka.
+* Provides an at-least-once delivery guarantee against message loss during
+a normal shutdown as well as when Logstash is terminated abnormally. If Logstash
+is restarted while events are in-flight, Logstash will attempt to deliver
+messages stored in the persistent queue until delivery succeeds at least once.
 
 [[persistent-queues-limitations]]
 ==== Limitations of Persistent Queues
 
 The following are problems not solved by the persistent queue feature:
 
-* Input plugins that do not use a request-response protocol cannot be protected from data loss. For example: tcp, udp, zeromq push+pull, and many other inputs do not have a mechanism to acknowledge receipt to the sender. Plugins such as beats and http, which *do* have a acknowledgement capability, are well protected by this queue.
+* Input plugins that do not use a request-response protocol cannot be protected from data loss. For example: tcp, udp, zeromq push+pull, and many other inputs do not have a mechanism to acknowledge receipt to the sender. Plugins such as beats and http, which *do* have an acknowledgement capability, are well protected by this queue.
 * It does not handle permanent machine failures such as disk corruption, disk failure, and machine loss. The data persisted to disk is not replicated.
 
 [[persistent-queues-architecture]]

--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -19,10 +19,14 @@ Instead of deploying and managing a message broker, such as Redis, RabbitMQ, or
 Apache Kafka, to facilitate a buffered publish-subscriber model, you can enable
 persistent queues to buffer events on disk and remove the message broker.
 
-In summary, the two benefits of enabling persistent queues are as follows:
+In summary, the benefits of enabling persistent queues are as follows:
 
 * Provides protection from in-flight message loss when the Logstash process is abnormally terminated.
 * Absorbs bursts of events without needing an external buffering mechanism like Redis or Apache Kafka.
+* Provides an at-least-once message delivery guarantee. If Logstash is restarted while events are
+in-flight, Logstash will attempt to deliver messages stored in the persistent queue until delivery
+succeeds at least once. In other words, messages stored in the persistent queue may be duplicated, but
+not lost.
 
 [[persistent-queues-limitations]]
 ==== Limitations of Persistent Queues


### PR DESCRIPTION
@acchen97  I've added the "at least once" delivery guarantee back into the PQ docs, as you requested. I've used the language that we removed before.

@jordansissel Can you confirm that this language is accurate for 5.3? Asking you because you did so much work to improve the accuracy of the PQ docs during the last round of updates. Can you let me know if there's any content that is no longer true given the changes added in 5.3.

This PR addresses one of the items tracked in https://github.com/elastic/logstash/issues/6724