### PR TITLE
Fix incorrect command syntax

### DIFF
--- a/docs/static/plugin-manager.asciidoc
+++ b/docs/static/plugin-manager.asciidoc
@@ -16,7 +16,7 @@ available in your deployment:
 [source,shell]
 ----------------------------------
 bin/logstash-plugin list <1>
-bin/logstash-plugin list --info <2>
+bin/logstash-plugin list --verbose <2>
 bin/logstash-plugin list '*namefragment*' <3>
 bin/logstash-plugin list --group output <4>
 ----------------------------------


### PR DESCRIPTION
Fixing this in 5.0 (we've already fixed this in the other 5.x branches, so it doesn't require a review). 

We can close PR #6267 because this fixes the problem.