### PR TITLE
Rename Event Dependent Configuration chapter

### DIFF
--- a/docs/static/configuration.asciidoc
+++ b/docs/static/configuration.asciidoc
@@ -278,7 +278,7 @@ input { # comments can appear at the end of a line, too
 ----------------------------------
 
 [[event-dependent-configuration]]
-=== Event Dependent Configuration
+=== Accessing Event Data and Fields in the Configuration
 
 The logstash agent is a processing pipeline with 3 stages: inputs -> filters ->
 outputs. Inputs generate events, filters modify them, outputs ship them


### PR DESCRIPTION
Renaming to a more intuitive name as discussed originally in PR #5696.