### PR TITLE
Fix building the doc for the codec multiline and the redis input

### DIFF
--- a/tools/logstash-docgen/lib/logstash/docgen/parser.rb
+++ b/tools/logstash-docgen/lib/logstash/docgen/parser.rb
@@ -83,8 +83,8 @@ module LogStash module Docgen
 
     def release_date(format = "%B %-d, %Y")
       @release_date ||= begin
-
-                          response = open("https://rubygems.org/api/v1/versions/#{canonical_name}.json").read
+                          url ="https://rubygems.org/api/v1/versions/#{canonical_name}.json"
+                          response = open(url).read
                           # HACK: One of out default plugins, the webhdfs, has a bad encoding in the gemspec
                           # which make our parser trip with this error:
                           #

--- a/tools/logstash-docgen/lib/logstash/docgen/static_parser.rb
+++ b/tools/logstash-docgen/lib/logstash/docgen/static_parser.rb
@@ -6,7 +6,7 @@ module LogStash::Docgen
   class StaticParser
     COMMENTS_IGNORE = Regexp.union(
       Regexp.new(/encoding: utf-8/i),
-      Regexp.new(/TODO:/)
+      Regexp.new(/TODO:?/)
     )
 
     VALID_CLASS_NAME = /^LogStash::(Codecs|Inputs|Filters|Outputs)::(\w+)/

--- a/tools/logstash-docgen/lib/logstash/docgen/static_parser.rb
+++ b/tools/logstash-docgen/lib/logstash/docgen/static_parser.rb
@@ -13,9 +13,9 @@ module LogStash::Docgen
     COMMENT_RE = /^ *#(?: (.*)| *$)/
     MULTILINE_RE = /(, *$)|(\\$)|(\[ *$)/
     ENDLINES_RE = /\r\n|\n/
-    CLASS_DEFINITION_RE = /^ *class\s(.*) < *(::)?LogStash::(Outputs|Filters|Inputs|Codecs)::(\w)/ 
-    NEW_CLASS_DEFINITION_RE = /^module (\w+) module (\w+) class\s(.*) < *(::)?LogStash::(Outputs|Filters|Inputs|Codecs)::(\w)/
-    NEW_CLASS_DEFINITION_RE_ML = /^\s*class\s(.*) < *(::)?LogStash::(Outputs|Filters|Inputs|Codecs)::(\w+)/
+    CLASS_DEFINITION_RE = /^ *class\s(.*) < *(::)?LogStash::(Outputs|Filters|Inputs|Codecs)::(\w+)/
+    NEW_CLASS_DEFINITION_RE = /module (\w+) module (\w+) class\s(.*) < *(::)?LogStash::(Outputs|Filters|Inputs|Codecs)::(\w+)/
+    NEW_CLASS_DEFINITION_RE_ML = /\s*class\s(.*) < *(::)?LogStash::(Outputs|Filters|Inputs|Codecs)::(\w+)/
     CONFIG_OPTION_RE = /^\s*((mod|base).)?config +[^=].*/
     CONFIG_NAME_RE = /^ *config_name .*/
     RESET_BUFFER_RE = /^require\s("|')\w+("|')/


### PR DESCRIPTION
Fix an issue with handling the plugin type with new style declaration
Correctly extract the plugin type when the plugin is defined with

```
module LogStash module Inputs class XXX < ...
```

Also adjust the regular expression to skip `TODO` statement to ignore `:`