### PR TITLE
fix wrong warning about log level debug + config.debug flags 

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -207,7 +207,7 @@ class LogStash::Runner < Clamp::StrictCommand
     # override log level that may have been introduced from a custom log4j config file
     LogStash::Logging::Logger::configure_logging(setting("log.level"))
 
-    if setting("config.debug") && logger.debug?
+    if setting("config.debug") && !logger.debug?
       logger.warn("--config.debug was specified, but log.level was not set to \'debug\'! No config info will be logged.")
     end
 


### PR DESCRIPTION
~~during a refactor a bug was introduced in the boolean logic that prevents the config from being shown even if the `--config.debug` flag is enabled:~~

during a refactor a bug was introduced in the boolean logic that shows an incorrect warning that debug was not enabled even though it is:

```ruby
if setting("config.debug") && logger.debug?
  logger.warn("--config.debug was specified, but log.level was not set to \'debug\'! No config info will be logged.")
end
```

this logic used to be:

```ruby
if setting("config.debug") && @logger.level != :debug
  @logger.warn("--config.debug was specified, but log.level was not set to \'debug\'! No config info will be logged.")
end
```

this pr re-establishes the correct behaviour

fixes https://github.com/elastic/logstash/issues/6256