### PR TITLE
small code changes to reduce warnings

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/BufferedChecksum.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/BufferedChecksum.java
@@ -13,12 +13,21 @@ public class BufferedChecksum implements Checksum {
     /** Default buffer size: 256 */
     public static final int DEFAULT_BUFFERSIZE = 256;
 
-    /** Create a new BufferedChecksum with {@link #DEFAULT_BUFFERSIZE} */
+    /**
+     * Create a new BufferedChecksum with {@link #DEFAULT_BUFFERSIZE}
+     *
+     * @param in The checksum
+     */
     public BufferedChecksum(Checksum in) {
         this(in, DEFAULT_BUFFERSIZE);
     }
 
-    /** Create a new BufferedChecksum with the specified bufferSize */
+    /**
+     * Create a new BufferedChecksum with the specified buffer size
+     *
+     * @param in The checksum
+     * @param bufferSize The buffer size in bytes
+     */
     public BufferedChecksum(Checksum in, int bufferSize) {
         this.in = in;
         this.buffer = new byte[bufferSize];

--- a/logstash-core/src/main/java/org/logstash/common/io/ByteBufferPageIO.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/ByteBufferPageIO.java
@@ -1,15 +1,7 @@
 package org.logstash.common.io;
 
-import org.logstash.ackedqueue.Queueable;
-import org.logstash.ackedqueue.SequencedList;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.zip.CRC32;
-import java.util.zip.Checksum;
 
 public class ByteBufferPageIO extends AbstractByteBufferPageIO {
 

--- a/logstash-core/src/main/java/org/logstash/common/io/FileCheckpointIO.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/FileCheckpointIO.java
@@ -1,7 +1,6 @@
 package org.logstash.common.io;
 
 import org.logstash.ackedqueue.Checkpoint;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -72,7 +71,7 @@ public class FileCheckpointIO  implements CheckpointIO {
     @Override
     public void purge() throws IOException {
         // TODO: dir traversal and delete all checkpoints?
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException("purge() is not supported");
     }
 
     // @return the head page checkpoint file name

--- a/logstash-core/src/main/java/org/logstash/common/io/MemoryCheckpointIO.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/MemoryCheckpointIO.java
@@ -1,12 +1,9 @@
 package org.logstash.common.io;
 
 import org.logstash.ackedqueue.Checkpoint;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/logstash-core/src/main/java/org/logstash/common/io/MmapPageIO.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/MmapPageIO.java
@@ -13,9 +13,11 @@ import java.nio.file.Paths;
 
 // TODO: this essentially a copy of ByteBufferPageIO and should be DRY'ed - temp impl to test file based stress test
 
+@SuppressWarnings("sunapi")
 public class MmapPageIO extends AbstractByteBufferPageIO {
 
     private File file;
+
     private FileChannel channel;
     protected MappedByteBuffer buffer;
 

--- a/logstash-core/src/main/java/org/logstash/common/io/PageIO.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/PageIO.java
@@ -1,11 +1,9 @@
 package org.logstash.common.io;
 
-import org.logstash.ackedqueue.Queueable;
 import org.logstash.ackedqueue.SequencedList;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.List;
 
 public interface PageIO extends Closeable {
 

--- a/logstash-core/src/main/java/org/logstash/common/io/StreamInput.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/StreamInput.java
@@ -6,6 +6,8 @@ import java.io.InputStream;
 public abstract class StreamInput extends InputStream {
     /**
      * Reads and returns a single byte.
+     * @return byte from stream
+     * @throws IOException if error occurs while reading content
      */
     public abstract byte readByte() throws IOException;
 
@@ -15,11 +17,15 @@ public abstract class StreamInput extends InputStream {
      * @param b      the array to read bytes into
      * @param offset the offset in the array to start storing bytes
      * @param len    the number of bytes to read
+     * @throws IOException if an error occurs while reading content
      */
     public abstract void readBytes(byte[] b, int offset, int len) throws IOException;
 
     /**
      * Reads four bytes and returns an int.
+     *
+     * @return four-byte integer value from bytes
+     * @throws IOException if an error occurs while reading content
      */
     public int readInt() throws IOException {
         return ((readByte() & 0xFF) << 24) | ((readByte() & 0xFF) << 16)
@@ -31,6 +37,9 @@ public abstract class StreamInput extends InputStream {
      * five bytes.  Smaller values take fewer bytes.  Negative numbers
      * will always use all 5 bytes and are therefore better serialized
      * using {@link #readInt}
+     *
+     * @return integer value from var-int formatted bytes
+     * @throws IOException if an error occurs while reading content
      */
     public int readVInt() throws IOException {
         byte b = readByte();
@@ -60,6 +69,9 @@ public abstract class StreamInput extends InputStream {
 
     /**
      * Reads two bytes and returns a short.
+     *
+     * @return short value from bytes
+     * @throws IOException if an error occurs while reading content
      */
     public short readShort() throws IOException {
         int i = ((readByte() & 0xFF) <<  8);
@@ -69,6 +81,9 @@ public abstract class StreamInput extends InputStream {
 
     /**
      * Reads eight bytes and returns a long.
+     *
+     * @return long value from bytes
+     * @throws IOException if an error occurs while reading content
      */
     public long readLong() throws IOException {
         return (((long) readInt()) << 32) | (readInt() & 0xFFFFFFFFL);

--- a/logstash-core/src/main/java/org/logstash/common/io/StreamOutput.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/StreamOutput.java
@@ -20,6 +20,9 @@ public abstract class StreamOutput extends OutputStream {
      * five bytes.  Smaller values take fewer bytes.  Negative numbers
      * will always use all 5 bytes and are therefore better serialized
      * using {@link #writeInt}
+     *
+     * @param i The integer to write
+     * @throws IOException if an error occurs while writing content
      */
     public void writeVInt(int i) throws IOException {
         while ((i & ~0x7F) != 0) {
@@ -31,6 +34,9 @@ public abstract class StreamOutput extends OutputStream {
 
     /**
      * Writes a short as two bytes.
+     *
+     * @param i The short to write
+     * @throws IOException if an error occurs while writing content
      */
     public void writeShort(short i) throws IOException {
         writeByte((byte)(i >>  8));
@@ -39,6 +45,9 @@ public abstract class StreamOutput extends OutputStream {
 
     /**
      * Writes an int as four bytes.
+     *
+     * @param i The int to write
+     * @throws IOException if an error occurs while writing content
      */
     public void writeInt(int i) throws IOException {
         writeByte((byte) (i >> 24));
@@ -56,6 +65,9 @@ public abstract class StreamOutput extends OutputStream {
 
     /**
      * Writes a long as eight bytes.
+     *
+     * @param i the long to write
+     * @throws IOException if an error occurs while writing content
      */
     public void writeLong(long i) throws IOException {
         writeInt((int) (i >> 32));
@@ -66,6 +78,7 @@ public abstract class StreamOutput extends OutputStream {
      * Writes an array of bytes.
      *
      * @param b the bytes to write
+     * @throws IOException if an error occurs while writing content
      */
     public void writeByteArray(byte[] b) throws IOException {
         writeInt(b.length);

--- a/logstash-core/src/main/java/org/logstash/common/io/wip/MemoryPageIOStream.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/wip/MemoryPageIOStream.java
@@ -1,14 +1,12 @@
 package org.logstash.common.io.wip;
 
 import org.logstash.ackedqueue.Checkpoint;
-import org.logstash.ackedqueue.Queueable;
 import org.logstash.ackedqueue.SequencedList;
 import org.logstash.common.io.BufferedChecksumStreamInput;
 import org.logstash.common.io.BufferedChecksumStreamOutput;
 import org.logstash.common.io.ByteArrayStreamOutput;
 import org.logstash.common.io.ByteBufferStreamInput;
 import org.logstash.common.io.PageIO;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -72,7 +70,7 @@ public class MemoryPageIOStream implements PageIO {
 
     @Override
     public void recover() throws IOException {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException("recover() is not supported");
     }
 
     @Override


### PR DESCRIPTION
Here are the warnings that remain:

```
:logstash-core:compileJava
/Users/tal/Code/es/talevy-logstash/logstash-core/src/main/java/org/logstash/common/io/MmapPageIO.java:3: warning: Cleaner is internal proprietary API and may be removed in a future release
import sun.misc.Cleaner;
               ^
/Users/tal/Code/es/talevy-logstash/logstash-core/src/main/java/org/logstash/common/io/MmapPageIO.java:4: warning: DirectBuffer is internal proprietary API and may be removed in a future release
import sun.nio.ch.DirectBuffer;
                 ^
/Users/tal/Code/es/talevy-logstash/logstash-core/src/main/java/org/logstash/common/io/MmapPageIO.java:3: warning: Cleaner is internal proprietary API and may be removed in a future release
import sun.misc.Cleaner;
               ^
/Users/tal/Code/es/talevy-logstash/logstash-core/src/main/java/org/logstash/common/io/MmapPageIO.java:4: warning: DirectBuffer is internal proprietary API and may be removed in a future release
import sun.nio.ch.DirectBuffer;
                 ^
/Users/tal/Code/es/talevy-logstash/logstash-core/src/main/java/org/logstash/common/io/MmapPageIO.java:3: warning: Cleaner is internal proprietary API and may be removed in a future release
import sun.misc.Cleaner;
               ^
/Users/tal/Code/es/talevy-logstash/logstash-core/src/main/java/org/logstash/common/io/MmapPageIO.java:4: warning: DirectBuffer is internal proprietary API and may be removed in a future release
import sun.nio.ch.DirectBuffer;
                 ^
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
6 warnings
```

These can be fixed with a follow-up PR that borrows java-9 compatible code for managing the Cleaner and DirectBuffers from Lucene