### PR TITLE
signal notfull on page purge

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -330,7 +330,9 @@ public class Queue implements Closeable {
             this.unreadCount++;
 
             // if the queue was empty before write, signal non emptiness
-            if (wasEmpty) { notEmpty.signalAll(); }
+            // a simple signal and not signalAll is necessary here since writing a single element
+            // can only really enable a single thread to read a batch
+            if (wasEmpty) { notEmpty.signal(); }
 
             // now check if we reached a queue full state and block here until it is not full
             // for the next write or the queue was closed.


### PR DESCRIPTION
Fixes #6626

Nasty bug where acking a batch and purging a page did not signal a notFull condition. 

I also changed all signal() for signalAll() because otherwise only 1 worker/thread would resume if many workers where waiting on a condition. All workers/thread should be given a chance to resume.