### PR TITLE
Add support for Dead Letter Queue RecordIO library

### DIFF
--- a/logstash-core/src/main/java/org/logstash/DLQEntry.java
+++ b/logstash-core/src/main/java/org/logstash/DLQEntry.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.logstash;
+
+import org.logstash.ackedqueue.Queueable;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+
+
+public class DLQEntry implements Cloneable, Serializable, Queueable {
+
+    private final Event event;
+    private final String pluginType;
+    private final String pluginId;
+    private final String reason;
+    private final Timestamp entryTime;
+
+    public DLQEntry(Event event, String pluginType, String pluginId, String reason) {
+        this(event, pluginType, pluginId, reason, Timestamp.now());
+    }
+
+    public DLQEntry(Event event, String pluginType, String pluginId, String reason, Timestamp entryTime) {
+        this.event = event;
+        this.pluginType = pluginType;
+        this.pluginId = pluginId;
+        this.reason = reason;
+        this.entryTime = entryTime;
+    }
+
+    @Override
+    public byte[] serialize() throws IOException {
+        byte[] entryTimeInBytes = entryTime.serialize();
+        byte[] eventInBytes = this.event.serialize();
+        byte[] pluginTypeBytes = pluginType.getBytes();
+        byte[] pluginIdBytes = pluginId.getBytes();
+        byte[] reasonBytes = reason.getBytes();
+        ByteBuffer buffer = ByteBuffer.allocate(entryTimeInBytes.length
+                + eventInBytes.length
+                + pluginTypeBytes.length
+                + pluginIdBytes.length
+                + reasonBytes.length
+                + (Integer.BYTES * 5));
+        buffer.putInt(entryTimeInBytes.length);
+        buffer.put(entryTimeInBytes);
+        buffer.putInt(eventInBytes.length);
+        buffer.put(eventInBytes);
+        buffer.putInt(pluginTypeBytes.length);
+        buffer.put(pluginTypeBytes);
+        buffer.putInt(pluginIdBytes.length);
+        buffer.put(pluginIdBytes);
+        buffer.putInt(reasonBytes.length);
+        buffer.put(reasonBytes);
+        return buffer.array();
+    }
+
+    public static DLQEntry deserialize(byte[] bytes) throws IOException {
+        ByteBuffer buffer = ByteBuffer.allocate(bytes.length);
+        buffer.put(bytes);
+        buffer.position(0);
+
+        int entryTimeLength = buffer.getInt();
+        byte[] entryTimeBytes = new byte[entryTimeLength];
+        buffer.get(entryTimeBytes);
+        Timestamp entryTime = new Timestamp(new String(entryTimeBytes));
+
+        int eventLength = buffer.getInt();
+        byte[] eventBytes = new byte[eventLength];
+        buffer.get(eventBytes);
+        Event event = Event.deserialize(eventBytes);
+
+        int pluginTypeLength = buffer.getInt();
+        byte[] pluginTypeBytes = new byte[pluginTypeLength];
+        buffer.get(pluginTypeBytes);
+        String pluginType = new String(pluginTypeBytes);
+
+        int pluginIdLength = buffer.getInt();
+        byte[] pluginIdBytes = new byte[pluginIdLength];
+        buffer.get(pluginIdBytes);
+        String pluginId = new String(pluginIdBytes);
+
+        int reasonLength = buffer.getInt();
+        byte[] reasonBytes = new byte[reasonLength];
+        buffer.get(reasonBytes);
+        String reason = new String(reasonBytes);
+
+        return new DLQEntry(event, pluginType, pluginId, reason, entryTime);
+    }
+
+    public Event getEvent() {
+        return event;
+    }
+
+    public String getPluginType() {
+        return pluginType;
+    }
+
+    public String getPluginId() {
+        return pluginId;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public Timestamp getEntryTime() {
+        return entryTime;
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/Timestamp.java
+++ b/logstash-core/src/main/java/org/logstash/Timestamp.java
@@ -7,11 +7,13 @@ import org.joda.time.Duration;
 import org.joda.time.LocalDateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
+import org.logstash.ackedqueue.Queueable;
 
+import java.io.IOException;
 import java.util.Date;
 
 @JsonSerialize(using = org.logstash.json.TimestampSerializer.class)
-public class Timestamp implements Cloneable {
+public class Timestamp implements Cloneable, Queueable {
 
     // all methods setting the time object must set it in the UTC timezone
     private DateTime time;
@@ -80,5 +82,10 @@ public class Timestamp implements Cloneable {
         Timestamp clone = (Timestamp)super.clone();
         clone.setTime(this.getTime());
         return clone;
+    }
+
+    @Override
+    public byte[] serialize() throws IOException {
+        return toString().getBytes();
     }
 }

--- a/logstash-core/src/main/java/org/logstash/Timestamp.java
+++ b/logstash-core/src/main/java/org/logstash/Timestamp.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 import java.util.Date;
 
 @JsonSerialize(using = org.logstash.json.TimestampSerializer.class)
-public class Timestamp implements Cloneable, Queueable {
+public class Timestamp implements Cloneable, Comparable, Queueable {
 
     // all methods setting the time object must set it in the UTC timezone
     private DateTime time;
@@ -75,6 +75,11 @@ public class Timestamp implements Cloneable, Queueable {
         // JodaTime only supports milliseconds precision we can only return usec at millisec precision.
         // note that getMillis() return millis since epoch
         return (new Duration(JAN_1_1970.toDateTime(DateTimeZone.UTC), this.time).getMillis() % 1000) * 1000;
+    }
+
+    @Override
+    public int compareTo(Object other) {
+        return getTime().compareTo(((Timestamp) other).getTime());
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReadManager.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReadManager.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.logstash.common.io;
+
+import org.logstash.DLQEntry;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
+import static org.logstash.common.io.DeadLetterQueueWriteManager.getSegmentPaths;
+
+public class DeadLetterQueueReadManager {
+
+    private RecordIOReader currentReader;
+    private final Path queuePath;
+    private final ConcurrentSkipListSet<Path> segments;
+    private final WatchService watchService;
+
+    public DeadLetterQueueReadManager(Path queuePath) throws Exception {
+        this.queuePath = queuePath;
+        this.watchService = FileSystems.getDefault().newWatchService();
+        this.queuePath.register(watchService, ENTRY_CREATE, ENTRY_DELETE);
+        this.segments = new ConcurrentSkipListSet<>((p1, p2) -> {
+            Function<Path, Integer> id = (p) -> Integer.parseInt(p.getFileName().toString().split("\\.")[0]);
+            return id.apply(p1).compareTo(id.apply(p2));
+        });
+
+        segments.addAll(getSegmentPaths(queuePath).collect(Collectors.toList()));
+    }
+
+    private long pollNewSegments(long timeout) throws IOException, InterruptedException {
+        long startTime = System.currentTimeMillis();
+        WatchKey key = watchService.poll(timeout, TimeUnit.MILLISECONDS);
+        if (key != null) {
+            for (WatchEvent<?> watchEvent : key.pollEvents()) {
+                if (watchEvent.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
+                    segments.addAll(getSegmentPaths(queuePath).collect(Collectors.toList()));
+                }
+                key.reset();
+            }
+        }
+        return System.currentTimeMillis() - startTime;
+    }
+
+    public DLQEntry pollEntry(long timeout) throws IOException, InterruptedException {
+        return DLQEntry.deserialize(pollEntryBytes(timeout));
+    }
+
+    byte[] pollEntryBytes() throws IOException, InterruptedException {
+        return pollEntryBytes(100);
+    }
+
+    byte[] pollEntryBytes(long timeout) throws IOException, InterruptedException {
+        long timeoutRemaining = timeout;
+        if (currentReader == null) {
+            timeoutRemaining -= pollNewSegments(timeout);
+            currentReader = new RecordIOReader(segments.first());
+        }
+
+        byte[] event = currentReader.readEvent();
+        if (event == null && currentReader.isEndOfStream()) {
+            if (currentReader.getPath().equals(segments.last())) {
+                pollNewSegments(timeoutRemaining);
+            } else {
+                currentReader.close();
+                currentReader = new RecordIOReader(segments.higher(currentReader.getPath()));
+                return pollEntryBytes(timeoutRemaining);
+            }
+        }
+
+        return event;
+    }
+
+    public void close() throws IOException {
+        if (currentReader != null) {
+            currentReader.close();
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriteManager.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriteManager.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.logstash.common.io;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.logstash.DLQEntry;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.stream.Stream;
+
+import static org.logstash.common.io.RecordIOWriter.RECORD_HEADER_SIZE;
+
+public class DeadLetterQueueWriteManager {
+
+    private static final Logger logger = LogManager.getLogger(DeadLetterQueueWriteManager.class);
+
+    static final String SEGMENT_FILE_PATTERN = "%020d.log";
+    static final String LOCK_FILE = ".lock";
+    private final long maxSegmentSize;
+    private final long maxQueueSize;
+    private final Path queuePath;
+    private final FileLock lock;
+    private RecordIOWriter currentWriter;
+    private long currentQueueSize;
+    private int currentSegmentIndex;
+
+    /**
+     *
+     * @param queuePath
+     * @param maxSegmentSize
+     * @throws IOException
+     */
+    public DeadLetterQueueWriteManager(Path queuePath, long maxSegmentSize, long maxQueueSize) throws IOException {
+        // check that only one instance of the writer is open in this configured path
+        Path lockFilePath = queuePath.resolve(LOCK_FILE);
+        boolean isNewlyCreated = lockFilePath.toFile().createNewFile();
+        FileChannel channel = FileChannel.open(lockFilePath, StandardOpenOption.WRITE);
+        try {
+            this.lock = channel.lock();
+        } catch (OverlappingFileLockException e) {
+            if (isNewlyCreated) {
+                logger.warn("Previous Dead Letter Queue Writer was not closed safely.");
+            }
+            throw new RuntimeException("uh oh, someone else is writing to this dead-letter queue");
+        }
+
+        this.queuePath = queuePath;
+        this.maxSegmentSize = maxSegmentSize;
+        this.maxQueueSize = maxQueueSize;
+        this.currentQueueSize = getStartupQueueSize();
+
+        currentSegmentIndex = getSegmentPaths(queuePath)
+                .map(s -> s.getFileName().toString().split("\\.")[0])
+                .mapToInt(Integer::parseInt)
+                .max().orElse(0);
+        this.currentWriter = nextWriter();
+    }
+
+    private long getStartupQueueSize() throws IOException {
+        return getSegmentPaths(queuePath)
+                .mapToLong((p) -> {
+                    try {
+                        return Files.size(p);
+                    } catch (IOException e) {
+                        return 0L;
+                    }
+                } )
+                .sum();
+    }
+
+    private RecordIOWriter nextWriter() throws IOException {
+        return new RecordIOWriter(queuePath.resolve(String.format(SEGMENT_FILE_PATTERN, ++currentSegmentIndex)));
+    }
+
+    static Stream<Path> getSegmentPaths(Path path) throws IOException {
+        return Files.list(path).filter((p) -> p.toString().endsWith(".log"));
+    }
+
+    public void writeEntry(DLQEntry event) throws IOException {
+        byte[] record = event.serialize();
+        int eventPayloadSize = RECORD_HEADER_SIZE + record.length;
+        if (currentQueueSize + eventPayloadSize > maxQueueSize) {
+            logger.error("cannot write event to DLQ, no space available");
+            return;
+        } else if (currentWriter.getPosition() + eventPayloadSize > maxSegmentSize) {
+            currentWriter.close();
+            currentWriter = nextWriter();
+        }
+        currentQueueSize += currentWriter.writeEvent(record);
+    }
+
+    public void close() throws IOException {
+        this.lock.release();
+        if (currentWriter != null) {
+            currentWriter.close();
+        }
+        Files.deleteIfExists(queuePath.resolve(LOCK_FILE));
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriteManager.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriteManager.java
@@ -99,7 +99,7 @@ public class DeadLetterQueueWriteManager {
         return Files.list(path).filter((p) -> p.toString().endsWith(".log"));
     }
 
-    public void writeEntry(DLQEntry event) throws IOException {
+    public synchronized void writeEntry(DLQEntry event) throws IOException {
         byte[] record = event.serialize();
         int eventPayloadSize = RECORD_HEADER_SIZE + record.length;
         if (currentQueueSize + eventPayloadSize > maxQueueSize) {
@@ -112,7 +112,7 @@ public class DeadLetterQueueWriteManager {
         currentQueueSize += currentWriter.writeEvent(record);
     }
 
-    public void close() throws IOException {
+    public synchronized void close() throws IOException {
         this.lock.release();
         if (currentWriter != null) {
             currentWriter.close();

--- a/logstash-core/src/main/java/org/logstash/common/io/RecordHeader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/RecordHeader.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.logstash.common.io;
+
+import java.nio.ByteBuffer;
+import java.util.OptionalInt;
+
+public class RecordHeader {
+    private final RecordType type;
+    private final int size;
+    private final OptionalInt totalEventSize;
+    private final int checksum;
+
+    public RecordHeader(RecordType type, int size, OptionalInt totalEventSize, int checksum) {
+        this.type = type;
+        this.size = size;
+        this.totalEventSize = totalEventSize;
+        this.checksum = checksum;
+    }
+
+    public RecordType getType() {
+        return type;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public int getChecksum() {
+        return checksum;
+    }
+
+    public OptionalInt getTotalEventSize() {
+        return totalEventSize;
+    }
+
+    public static RecordHeader get(ByteBuffer currentBlock) {
+        RecordType type = RecordType.fromByte(currentBlock.get());
+
+        if (type == null) {
+            return null;
+        }
+
+        final int size = currentBlock.getInt();
+        final int totalSize = currentBlock.getInt();
+        final OptionalInt totalEventSize = (totalSize != -1) ? OptionalInt.of(totalSize) : OptionalInt.empty();
+        final int checksum = currentBlock.getInt();
+        return new RecordHeader(type, size, totalEventSize, checksum);
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.logstash.common.io;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.zip.CRC32;
+import java.util.zip.Checksum;
+
+import static org.logstash.common.io.RecordIOWriter.BLOCK_SIZE;
+import static org.logstash.common.io.RecordIOWriter.RECORD_HEADER_SIZE;
+import static org.logstash.common.io.RecordIOWriter.VERSION;
+import static org.logstash.common.io.RecordIOWriter.VERSION_SIZE;
+
+/**
+ */
+public class RecordIOReader {
+
+    private final FileChannel channel;
+    private final ByteBuffer currentBlock;
+    private int currentBlockSizeReadFromChannel;
+    private final Path path;
+
+    public RecordIOReader(Path path) throws IOException {
+        this.path = path;
+        this.channel = FileChannel.open(path, StandardOpenOption.READ);
+        this.currentBlock = ByteBuffer.allocate(BLOCK_SIZE);
+        this.currentBlockSizeReadFromChannel = 0;
+        ByteBuffer versionBuffer = ByteBuffer.allocate(1);
+        this.channel.read(versionBuffer);
+        versionBuffer.rewind();
+        if (versionBuffer.get() != VERSION) {
+            throw new RuntimeException("Invalid file. check version");
+        }
+    }
+
+    public Path getPath() {
+        return path;
+    }
+
+    public void seekToBlock(int bid) throws IOException {
+        currentBlock.rewind();
+        currentBlockSizeReadFromChannel = 0;
+        channel.position(bid * BLOCK_SIZE + VERSION_SIZE);
+    }
+
+    /**
+     *
+     * @param rewind
+     * @throws IOException
+     */
+    void consumeBlock(boolean rewind) throws IOException {
+        if (rewind) {
+            currentBlockSizeReadFromChannel = 0;
+            currentBlock.rewind();
+        } else if (currentBlockSizeReadFromChannel == BLOCK_SIZE) {
+            // already read enough, no need to read more
+            return;
+        }
+        int originalPosition = currentBlock.position();
+        int read = channel.read(currentBlock);
+        currentBlockSizeReadFromChannel += (read > 0) ? read : 0;
+        currentBlock.position(originalPosition);
+    }
+
+    /**
+     * basically, is last block
+     * @return
+     */
+    public boolean isEndOfStream() {
+        return currentBlockSizeReadFromChannel < BLOCK_SIZE;
+    }
+
+    /**
+     *
+     */
+     int seekToStartOfEventInBlock() throws IOException {
+         while (true) {
+             RecordType type = RecordType.fromByte(currentBlock.array()[currentBlock.arrayOffset() + currentBlock.position()]);
+             if (RecordType.COMPLETE.equals(type) || RecordType.START.equals(type)) {
+                 return currentBlock.position();
+             } else if (RecordType.END.equals(type)) {
+                 RecordHeader header = RecordHeader.get(currentBlock);
+                 currentBlock.position(currentBlock.position() + header.getSize());
+             } else {
+                 return -1;
+             }
+         }
+    }
+
+    /**
+     *
+     * @return true if ready to read event, false otherwise
+     * @throws IOException
+     */
+    boolean consumeToStartOfEvent() throws IOException {
+        // read and seek to start of event
+        consumeBlock(false);
+        while (true) {
+            int eventStartPosition = seekToStartOfEventInBlock();
+            if (eventStartPosition < 0) {
+                if (isEndOfStream()) {
+                    return false;
+                } else {
+                    consumeBlock(true);
+                }
+            } else {
+                return true;
+            }
+        }
+    }
+
+    private void maybeRollToNextBlock() throws IOException {
+        // check block position state
+        if (currentBlock.remaining() < RECORD_HEADER_SIZE + 1) {
+            consumeBlock(true);
+        }
+    }
+
+    private void getRecord(ByteBuffer buffer, RecordHeader header) throws IOException {
+        Checksum computedChecksum = new CRC32();
+        computedChecksum.update(currentBlock.array(), currentBlock.position(), header.getSize());
+
+        if ((int) computedChecksum.getValue() != header.getChecksum()) {
+            throw new RuntimeException("invalid checksum of record");
+        }
+
+        buffer.put(currentBlock.array(), currentBlock.position(), header.getSize());
+        currentBlock.position(currentBlock.position() + header.getSize());
+    }
+
+    /**
+     * @return
+     * @throws IOException
+     */
+    public byte[] readEvent() throws IOException {
+        if (consumeToStartOfEvent() == false) {
+            return null;
+        }
+        RecordHeader header = RecordHeader.get(currentBlock);
+        int cumReadSize = 0;
+        int bufferSize = header.getTotalEventSize().orElseGet(header::getSize);
+        ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
+        getRecord(buffer, header);
+        cumReadSize += header.getSize();
+        while (cumReadSize < bufferSize) {
+            maybeRollToNextBlock();
+            RecordHeader nextHeader = RecordHeader.get(currentBlock);
+            getRecord(buffer, nextHeader);
+            cumReadSize += nextHeader.getSize();
+        }
+        return buffer.array();
+    }
+
+    public void close() throws IOException {
+        channel.close();
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/common/io/RecordIOWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/RecordIOWriter.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.logstash.common.io;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.OptionalInt;
+import java.util.zip.CRC32;
+import java.util.zip.Checksum;
+
+import static org.logstash.common.io.RecordType.COMPLETE;
+import static org.logstash.common.io.RecordType.END;
+import static org.logstash.common.io.RecordType.MIDDLE;
+import static org.logstash.common.io.RecordType.START;
+
+/**
+ *
+ * File Format
+ * | — magic number (4bytes) --|
+ *
+ * [  32kbyte block....
+ *    --- 1 byte RecordHeader Type ---
+ *    --- 4 byte RecordHeader Size ---
+ *
+ * ]
+ * [ 32kbyte block...
+ *
+ *
+ *
+ * ]
+ */
+public class RecordIOWriter {
+
+    private final FileChannel channel;
+    private int posInBlock;
+    private int currentBlockIdx;
+
+    static final int BLOCK_SIZE = 32 * 1024; // package-private for tests
+    static final int RECORD_HEADER_SIZE = 13;
+    static final int VERSION_SIZE = 1;
+    static final char VERSION = '1';
+
+    public RecordIOWriter(Path recordsFile) throws IOException {
+        this.posInBlock = 0;
+        this.currentBlockIdx = 0;
+        recordsFile.toFile().createNewFile();
+        this.channel = FileChannel.open(recordsFile, StandardOpenOption.WRITE);
+        this.channel.write(ByteBuffer.wrap(new byte[] { VERSION }));
+    }
+
+    private int remainingInBlock() {
+        return BLOCK_SIZE - posInBlock;
+    }
+
+    int writeRecordHeader(RecordHeader header) throws IOException {
+        ByteBuffer buffer = ByteBuffer.allocate(RECORD_HEADER_SIZE);
+        buffer.put(header.getType().toByte());
+        buffer.putInt(header.getSize());
+        buffer.putInt(header.getTotalEventSize().orElse(-1));
+        buffer.putInt(header.getChecksum());
+        buffer.rewind();
+        return channel.write(buffer);
+    }
+
+    private RecordType getNextType(ByteBuffer buffer, RecordType previous) {
+        boolean fits = buffer.remaining() + RECORD_HEADER_SIZE < remainingInBlock();
+        if (previous == null) {
+            return (fits) ? COMPLETE : START;
+        }
+        if (previous == START || previous == MIDDLE) {
+            return (fits) ? END : MIDDLE;
+        }
+        return null;
+    }
+
+    public long getPosition() throws IOException {
+        return channel.position();
+    }
+
+    public long writeEvent(byte[] eventArray) throws IOException {
+        ByteBuffer eventBuffer = ByteBuffer.wrap(eventArray);
+        RecordType nextType = null;
+        ByteBuffer slice = eventBuffer.slice();
+        long startPosition = channel.position();
+        while (slice.hasRemaining()) {
+            if (posInBlock + RECORD_HEADER_SIZE + 1 > BLOCK_SIZE) {
+                channel.position((++currentBlockIdx) * BLOCK_SIZE + VERSION_SIZE);
+                posInBlock = 0;
+            }
+            nextType = getNextType(slice, nextType);
+            int originalLimit = slice.limit();
+            int nextRecordSize = Math.min(remainingInBlock() - RECORD_HEADER_SIZE, slice.remaining());
+            OptionalInt optTotalSize = (nextType == RecordType.START) ? OptionalInt.of(eventArray.length) : OptionalInt.empty();
+            slice.limit(nextRecordSize);
+
+            Checksum checksum = new CRC32();
+            checksum.update(slice.array(), slice.arrayOffset() + slice.position(), nextRecordSize);
+            posInBlock += writeRecordHeader(
+                    new RecordHeader(nextType, nextRecordSize, optTotalSize, (int) checksum.getValue()));
+            posInBlock += channel.write(slice);
+
+            slice.limit(originalLimit);
+            slice = slice.slice();
+        }
+        return channel.position() - startPosition;
+    }
+
+    public void close() throws IOException {
+        channel.close();
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/common/io/RecordType.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/RecordType.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.logstash.common.io;
+
+public enum RecordType {
+    COMPLETE,
+    START,
+    MIDDLE,
+    END;
+
+    public byte toByte() {
+        switch (this) {
+            case COMPLETE:
+                return 'c';
+            case START:
+                return 's';
+            case MIDDLE:
+                return 'm';
+            case END:
+                return 'e';
+            default:
+                throw new RuntimeException("wat?");
+        }
+    }
+
+    public static RecordType fromByte(byte b) {
+        switch (b) {
+            case 'c':
+                return COMPLETE;
+            case 's':
+                return START;
+            case 'm':
+                return MIDDLE;
+            case 'e':
+                return END;
+            default:
+                return null;
+        }
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/DLQEntryTest.java
+++ b/logstash-core/src/test/java/org/logstash/DLQEntryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.logstash;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertNotNull;
+
+public class DLQEntryTest {
+    @Test
+    public void testConstruct() throws Exception {
+        Event event = new Event(Collections.singletonMap("key", "value"));
+        DLQEntry entry = new DLQEntry(event, "type", "id", "reason");
+        assertThat(entry.getEvent(), equalTo(event));
+        assertNotNull(entry.getEntryTime());
+        assertThat(entry.getPluginType(), equalTo("type"));
+        assertThat(entry.getPluginId(), equalTo("id"));
+        assertThat(entry.getReason(), equalTo("reason"));
+    }
+
+    @Test
+    public void testSerDe() throws Exception {
+        Event event = new Event(Collections.singletonMap("key", "value"));
+        DLQEntry expected = new DLQEntry(event, "type", "id", "reason");
+        byte[] bytes = expected.serialize();
+        DLQEntry actual = DLQEntry.deserialize(bytes);
+        assertJsonEquals(actual.getEvent().toJson(), event.toJson());
+        assertThat(actual.getEntryTime().toIso8601(), equalTo(expected.getEntryTime().toIso8601()));
+        assertThat(actual.getPluginType(), equalTo("type"));
+        assertThat(actual.getPluginId(), equalTo("id"));
+        assertThat(actual.getReason(), equalTo("reason"));
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReadManagerTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReadManagerTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.logstash.common.io;
+
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.logstash.ackedqueue.StringElement;
+
+import java.nio.file.Path;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class DeadLetterQueueReadManagerTest {
+    private Path dir;
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Before
+    public void setUp() throws Exception {
+        dir = temporaryFolder.newFolder().toPath();
+    }
+
+    @Test
+    public void testReadFromTwoSegments() throws Exception {
+        RecordIOWriter writer = null;
+
+        for (int i = 0; i < 5; i++) {
+            Path segmentPath = dir.resolve(String.format(DeadLetterQueueWriteManager.SEGMENT_FILE_PATTERN, i));
+            writer = new RecordIOWriter(segmentPath);
+            for (int j = 0; j < 10; j++) {
+                writer.writeEvent((new StringElement("" + (i * 10 + j))).serialize());
+            }
+            if (i < 4) {
+                writer.close();
+            }
+        }
+
+        DeadLetterQueueReadManager manager = new DeadLetterQueueReadManager(dir);
+
+        for (int i = 0; i < 50; i++) {
+            String first = StringElement.deserialize(manager.pollEntryBytes()).toString();
+            assertThat(first, equalTo(String.valueOf(i)));
+        }
+
+        assertThat(manager.pollEntryBytes(), is(nullValue()));
+        assertThat(manager.pollEntryBytes(), is(nullValue()));
+        assertThat(manager.pollEntryBytes(), is(nullValue()));
+        assertThat(manager.pollEntryBytes(), is(nullValue()));
+
+        for (int j = 50; j < 60; j++) {
+            writer.writeEvent((new StringElement(String.valueOf(j))).serialize());
+        }
+
+        for (int i = 50; i < 60; i++) {
+            String first = StringElement.deserialize(manager.pollEntryBytes()).toString();
+            assertThat(first, equalTo(String.valueOf(i)));
+        }
+
+        writer.close();
+
+        Path segmentPath = dir.resolve(String.format(DeadLetterQueueWriteManager.SEGMENT_FILE_PATTERN, 5));
+        writer = new RecordIOWriter(segmentPath);
+
+        for (int j = 0; j < 10; j++) {
+            writer.writeEvent((new StringElement(String.valueOf(j))).serialize());
+        }
+
+
+        for (int i = 0; i < 10; i++) {
+            byte[] read = manager.pollEntryBytes();
+            while (read == null) {
+                read = manager.pollEntryBytes();
+            }
+            String first = StringElement.deserialize(read).toString();
+            assertThat(first, equalTo(String.valueOf(i)));
+        }
+
+
+        manager.close();
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriteManagerTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriteManagerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.logstash.common.io;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.logstash.DLQEntry;
+import org.logstash.Event;
+
+import java.nio.channels.FileChannel;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class DeadLetterQueueWriteManagerTest {
+    private Path dir;
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Before
+    public void setUp() throws Exception {
+        dir = temporaryFolder.newFolder().toPath();
+    }
+
+    @Test
+    public void testLockFileManagement() throws Exception {
+        Path lockFile = dir.resolve(".lock");
+        DeadLetterQueueWriteManager writer = new DeadLetterQueueWriteManager(dir, 1000, 1000000);
+        assertTrue(Files.exists(lockFile));
+        writer.close();
+        assertFalse(Files.exists(lockFile));
+    }
+
+    @Test
+    public void testFileLocking() throws Exception {
+        DeadLetterQueueWriteManager writer = new DeadLetterQueueWriteManager(dir, 1000, 1000000);
+        try {
+            new DeadLetterQueueWriteManager(dir, 1000, 100000);
+            fail();
+        } catch (RuntimeException e) {
+        } finally {
+            writer.close();
+        }
+    }
+
+    @Test
+    public void testUncleanCloseOfPreviousWriter() throws Exception {
+        Path lockFilePath = dir.resolve(".lock");
+        boolean created = lockFilePath.toFile().createNewFile();
+        DeadLetterQueueWriteManager writer = new DeadLetterQueueWriteManager(dir, 1000, 1000000);
+
+        FileChannel channel = FileChannel.open(lockFilePath, StandardOpenOption.WRITE);
+        try {
+            channel.lock();
+            fail();
+        } catch (OverlappingFileLockException e) {
+            assertTrue(created);
+        } finally {
+            writer.close();
+        }
+    }
+
+    @Test
+    public void testWrite() throws Exception {
+        DeadLetterQueueWriteManager writer = new DeadLetterQueueWriteManager(dir, 1000, 1000000);
+        DLQEntry entry = new DLQEntry(new Event(), "type", "id", "reason");
+        writer.writeEntry(entry);
+        writer.close();
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/common/io/RecordHeaderIOWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/RecordHeaderIOWriterTest.java
@@ -1,0 +1,169 @@
+package org.logstash.common.io;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.logstash.ackedqueue.StringElement;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.logstash.common.io.RecordIOWriter.BLOCK_SIZE;
+
+public class RecordHeaderIOWriterTest {
+    private Path file;
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Before
+    public void setUp() throws Exception {
+        file = temporaryFolder.newFile("test").toPath();
+    }
+
+    @Test
+    public void testReadEmptyBlock() throws Exception {
+        RecordIOWriter writer = new RecordIOWriter(file);
+        RecordIOReader reader = new RecordIOReader(file);
+        assertThat(reader.readEvent(), is(nullValue()));
+        writer.close();
+        reader.close();
+    }
+
+    @Test
+    public void testSingleComplete() throws Exception {
+        StringElement input = new StringElement("element");
+        RecordIOWriter writer = new RecordIOWriter(file);
+        writer.writeEvent(input.serialize());
+        RecordIOReader reader = new RecordIOReader(file);
+        assertThat(StringElement.deserialize(reader.readEvent()), is(equalTo(input)));
+
+        reader.close();
+        writer.close();
+    }
+
+    @Test
+    public void testSeekToStartFromEndWithoutNextRecord() throws Exception {
+        char[] tooBig = new char[BLOCK_SIZE + 1000];
+        Arrays.fill(tooBig, 'c');
+        StringElement input = new StringElement(new String(tooBig));
+        RecordIOWriter writer = new RecordIOWriter(file);
+        writer.writeEvent(input.serialize());
+
+        RecordIOReader reader = new RecordIOReader(file);
+        reader.seekToBlock(1);
+        reader.consumeBlock(true);
+        assertThat(reader.seekToStartOfEventInBlock(), equalTo(-1));
+
+        reader.close();
+        writer.close();
+    }
+
+    @Test
+    public void testSeekToStartFromEndWithNextRecordPresent() throws Exception {
+        char[] tooBig = new char[BLOCK_SIZE + 1000];
+        Arrays.fill(tooBig, 'c');
+        StringElement input = new StringElement(new String(tooBig));
+        RecordIOWriter writer = new RecordIOWriter(file);
+        writer.writeEvent(input.serialize());
+        writer.writeEvent(input.serialize());
+
+        RecordIOReader reader = new RecordIOReader(file);
+        reader.seekToBlock(1);
+        reader.consumeBlock(true);
+        assertThat(reader.seekToStartOfEventInBlock(), equalTo(1026));
+
+        reader.close();
+        writer.close();
+    }
+
+
+    @Test
+    public void testFitsInTwoBlocks() throws Exception {
+        char[] tooBig = new char[BLOCK_SIZE + 1000];
+        Arrays.fill(tooBig, 'c');
+        StringElement input = new StringElement(new String(tooBig));
+        RecordIOWriter writer = new RecordIOWriter(file);
+        writer.writeEvent(input.serialize());
+        writer.close();
+    }
+
+    @Test
+    public void testFitsInThreeBlocks() throws Exception {
+        char[] tooBig = new char[2 * BLOCK_SIZE + 1000];
+        Arrays.fill(tooBig, 'r');
+        StringElement input = new StringElement(new String(tooBig));
+        RecordIOWriter writer = new RecordIOWriter(file);
+        writer.writeEvent(input.serialize());
+        writer.close();
+
+        RecordIOReader reader = new RecordIOReader(file);
+        StringElement element = StringElement.deserialize(reader.readEvent());
+        assertThat(element.toString().length(), equalTo(input.toString().length()));
+        assertThat(element.toString(), equalTo(input.toString()));
+        assertThat(reader.readEvent(), is(nullValue()));
+        reader.close();
+    }
+
+    @Test
+    public void testReadWhileWrite() throws Exception {
+        char[] tooBig = new char[2 * BLOCK_SIZE + 1000];
+        Arrays.fill(tooBig, 'r');
+        StringElement input = new StringElement(new String(tooBig));
+        RecordIOWriter writer = new RecordIOWriter(file);
+        RecordIOReader reader = new RecordIOReader(file);
+        byte[] inputSerialized = input.serialize();
+
+        writer.writeEvent(inputSerialized);
+        assertThat(reader.readEvent(), equalTo(inputSerialized));
+        writer.writeEvent(inputSerialized);
+        assertThat(reader.readEvent(), equalTo(inputSerialized));
+        writer.writeEvent(inputSerialized);
+        assertThat(reader.readEvent(), equalTo(inputSerialized));
+        writer.writeEvent(inputSerialized);
+        assertThat(reader.readEvent(), equalTo(inputSerialized));
+        assertThat(reader.readEvent(), is(nullValue()));
+        assertThat(reader.readEvent(), is(nullValue()));
+        assertThat(reader.readEvent(), is(nullValue()));
+        writer.writeEvent(inputSerialized);
+        assertThat(reader.readEvent(), equalTo(inputSerialized));
+        writer.writeEvent(inputSerialized);
+        writer.writeEvent(inputSerialized);
+        writer.writeEvent(inputSerialized);
+        writer.writeEvent(inputSerialized);
+        assertThat(reader.readEvent(), equalTo(inputSerialized));
+        assertThat(reader.readEvent(), equalTo(inputSerialized));
+        assertThat(reader.readEvent(), equalTo(inputSerialized));
+        assertThat(reader.readEvent(), equalTo(inputSerialized));
+        assertThat(reader.readEvent(), is(nullValue()));
+
+        writer.close();
+        reader.close();
+    }
+
+    @Test
+    public void testReadMiddle() throws Exception {
+        char[] tooBig = new char[3 * BLOCK_SIZE + 1000];
+        Arrays.fill(tooBig, 'r');
+        StringElement input = new StringElement(new String(tooBig));
+        RecordIOWriter writer = new RecordIOWriter(file);
+        RecordIOReader reader = new RecordIOReader(file);
+        byte[] inputSerialized = input.serialize();
+
+        writer.writeEvent(inputSerialized);
+        reader.seekToBlock(1);
+        assertThat(reader.readEvent(), is(nullValue()));
+        writer.writeEvent(inputSerialized);
+        reader.seekToBlock(1);
+        assertThat(reader.readEvent(), is(not(nullValue())));
+
+        writer.close();
+        reader.close();
+    }
+}


### PR DESCRIPTION
This PR adds a few base components for the Dead Letter Queue

- RecordIO Library

This library writes and reads events into a file with a specific format. The format splits up the file into contiguous blocks of the same size. These blocks contain records, which are either complete or partial byte arrays making up the full event being written.

- DeadLetterQueue Manager

These read/write managers build on top of RecordIO to manage a sorted list of recordio files that, together, make up the DLQ