### PR TITLE
Do not try to reach the artifact server when no plugins is given

### DIFF
--- a/lib/pluginmanager/install_strategy_factory.rb
+++ b/lib/pluginmanager/install_strategy_factory.rb
@@ -10,9 +10,12 @@ module LogStash module PluginManager
       LogStash::PluginManager::PackFetchStrategy::Repository
     ]
 
-    def self.create(plugins_arg)
+    def self.create(plugins_args)
+      plugin_name_or_uri = plugins_args.first
+      return false if plugin_name_or_uri.nil? || plugin_name_or_uri.strip.empty?
+
       AVAILABLES_STRATEGIES.each do |strategy|
-        if installer = strategy.get_installer_for(plugins_arg.first)
+        if installer = strategy.get_installer_for(plugin_name_or_uri)
           return installer
         end
       end

--- a/spec/unit/plugin_manager/install_spec.rb
+++ b/spec/unit/plugin_manager/install_spec.rb
@@ -7,17 +7,10 @@ describe LogStash::PluginManager::Install do
   let(:cmd) { LogStash::PluginManager::Install.new("install") }
 
   context "when validating plugins" do
-    before(:each) do
-      expect(cmd).to receive(:validate_cli_options!).and_return(nil)
-    end
-
-    before do
-      expect(LogStash::PluginManager::PackFetchStrategy::Repository).to receive(:get_installer_for).with(anything).and_return(nil)
-    end
-
     let(:sources) { ["https://rubygems.org", "http://localhost:9292"] }
 
     before(:each) do
+      expect(cmd).to receive(:validate_cli_options!).and_return(nil)
       expect(cmd).to receive(:plugins_gems).and_return([["dummy", nil]])
       expect(cmd).to receive(:install_gems_list!).and_return(nil)
       expect(cmd).to receive(:remove_unused_locally_installed_gems!).and_return(nil)

--- a/spec/unit/plugin_manager/install_strategy_factory_spec.rb
+++ b/spec/unit/plugin_manager/install_strategy_factory_spec.rb
@@ -3,25 +3,46 @@ require "pluginmanager/install_strategy_factory"
 
 describe LogStash::PluginManager::InstallStrategyFactory do
   subject { described_class }
-  let(:plugins_args) { [ "logstash-pack-mega" ] }
 
-  it "returns the first matched strategy" do
-    success = double("urifetch success")
+  context "when the plugins args is valid" do
+    let(:plugins_args) { [ "logstash-pack-mega" ] }
 
-    expect(LogStash::PluginManager::PackFetchStrategy::Uri).to receive(:get_installer_for).with(plugins_args.first).and_return(success)
-    expect(subject.create(plugins_args)).to eq(success)
+    it "returns the first matched strategy" do
+      success = double("urifetch success")
+
+      expect(LogStash::PluginManager::PackFetchStrategy::Uri).to receive(:get_installer_for).with(plugins_args.first).and_return(success)
+      expect(subject.create(plugins_args)).to eq(success)
+    end
+
+    it "returns the matched strategy" do
+      success = double("elastic xpack success")
+
+      expect(LogStash::PluginManager::PackFetchStrategy::Repository).to receive(:get_installer_for).with(plugins_args.first).and_return(success)
+      expect(subject.create(plugins_args)).to eq(success)
+    end
+
+    it "return nil when no strategy matches" do
+      expect(LogStash::PluginManager::PackFetchStrategy::Uri).to receive(:get_installer_for).with(plugins_args.first).and_return(nil)
+      expect(LogStash::PluginManager::PackFetchStrategy::Repository).to receive(:get_installer_for).with(plugins_args.first).and_return(nil)
+      expect(subject.create(plugins_args)).to be_falsey
+    end
   end
 
-  it "returns the matched strategy" do
-    success = double("elastic xpack success")
+  context "when the plugins args" do
+    context "is an empty string" do
+      let(:plugins_args) { [""] }
 
-    expect(LogStash::PluginManager::PackFetchStrategy::Repository).to receive(:get_installer_for).with(plugins_args.first).and_return(success)
-    expect(subject.create(plugins_args)).to eq(success)
-  end
+      it "returns no strategy matched" do
+        expect(subject.create(plugins_args)).to be_falsey
+      end
+    end
 
-  it "return nil when no strategy matches" do
-    expect(LogStash::PluginManager::PackFetchStrategy::Uri).to receive(:get_installer_for).with(plugins_args.first).and_return(nil)
-    expect(LogStash::PluginManager::PackFetchStrategy::Repository).to receive(:get_installer_for).with(plugins_args.first).and_return(nil)
-    expect(subject.create(plugins_args)).to be_falsey
+    context "is nil" do
+      let(:plugins_args) { [] }
+
+      it "returns no strategy matched" do
+        expect(subject.create(plugins_args)).to be_falsey
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR fix an annoyance when running the `bin/logstash-plugin install
--no-verify` without any plugins, the command was making an unnecessary
call to the artifacts web server.