### PR TITLE
Fix the heap collecting values

### DIFF
--- a/logstash-core/lib/logstash/instrument/periodic_poller/jvm.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/jvm.rb
@@ -161,14 +161,21 @@ module LogStash module Instrument module PeriodicPoller
     end
 
     def aggregate_information_for(collection)
+      transpose_map = {
+        "usage.used" => :used_in_bytes,
+        "usage.committed" => :committed_in_bytes,
+        "usage.max" => :max_in_bytes,
+        "peak.max" => :peak_max_in_bytes,
+        "peak.used" => :peak_used_in_bytes
+
+      }
       collection.reduce(default_information_accumulator) do |m,e|
         e = { e[0] => e[1] } if e.is_a?(Array)
         e.each_pair do |k,v|
-          m[:used_in_bytes] += v       if k.include?("used")
-          m[:committed_in_bytes] += v  if k.include?("committed")
-          m[:max_in_bytes] += v        if k.include?("max")
-          m[:peak_max_in_bytes] += v   if k.include?("peak.max")
-          m[:peak_used_in_bytes] += v  if k.include?("peak.used")
+          if transpose_map.include?(k)
+            transpose_key = transpose_map[k]
+            m[transpose_key] += v
+          end
         end
         m
       end

--- a/logstash-core/spec/logstash/instrument/periodic_poller/jvm_spec.rb
+++ b/logstash-core/spec/logstash/instrument/periodic_poller/jvm_spec.rb
@@ -54,6 +54,41 @@ describe LogStash::Instrument::PeriodicPoller::JVM do
     end
   end
 
+  describe "aggregate heap information" do
+    shared_examples "heap_information" do
+      let(:data_set) do
+        {
+          "usage.used" => 5,
+          "usage.committed" => 11,
+          "usage.max" => 21,
+          "peak.max" => 51,
+          "peak.used" => 61
+        }
+      end
+      let(:collection) { [data_set] }
+
+      it "return the right values" do
+        expect(subject.aggregate_information_for(collection)).to match({
+          :used_in_bytes => 5 * collection.size,
+          :committed_in_bytes => 11 * collection.size,
+          :max_in_bytes => 21 * collection.size,
+          :peak_max_in_bytes => 51 * collection.size,
+          :peak_used_in_bytes => 61 * collection.size
+        })
+      end
+    end
+
+    context "with only one data set in a collection" do
+      include_examples "heap_information"
+    end
+
+    context "with multiples data set in a collection" do
+      include_examples "heap_information" do
+        let(:collection) { ar = []; ar << data_set; ar << data_set; ar }
+      end
+    end
+  end
+
   describe "collections" do
     subject(:collection) { jvm.collect }
     it "should run cleanly" do


### PR DESCRIPTION
This PR fixes an issue where the max heap size was reported as the double of
the actual value because it was merging the values of the usage.max and
peak.max into a single value.

Fixes: #6608