### PR TITLE
Move input metrics to be nested under 'events' for consistency

### DIFF
--- a/logstash-core/lib/logstash/instrument/wrapped_write_client.rb
+++ b/logstash-core/lib/logstash/instrument/wrapped_write_client.rb
@@ -9,7 +9,7 @@ module LogStash module Instrument
 
       @events_metrics = metric.namespace([:stats, :events])
       @pipeline_metrics = metric.namespace([:stats, :pipelines, pipeline_id, :events])
-      @plugin_metrics = metric.namespace([:stats, :pipelines, pipeline_id, :plugins, plugin_type, plugin.id.to_sym])
+      @plugin_events_metrics = metric.namespace([:stats, :pipelines, pipeline_id, :plugins, plugin_type, plugin.id.to_sym, :events])
 
       define_initial_metrics_values
     end
@@ -31,7 +31,7 @@ module LogStash module Instrument
     def record_metric(size = 1)
       @events_metrics.increment(:in, size)
       @pipeline_metrics.increment(:in, size)
-      @plugin_metrics.increment(:out, size)
+      @plugin_events_metrics.increment(:out, size)
 
       clock = @events_metrics.time(:queue_push_duration_in_millis)
 
@@ -41,7 +41,7 @@ module LogStash module Instrument
       execution_time = clock.stop
 
       @pipeline_metrics.report_time(:queue_push_duration_in_millis, execution_time)
-      @plugin_metrics.report_time(:queue_push_duration_in_millis, execution_time)
+      @plugin_events_metrics.report_time(:queue_push_duration_in_millis, execution_time)
 
       result
     end
@@ -49,11 +49,11 @@ module LogStash module Instrument
     def define_initial_metrics_values
       @events_metrics.increment(:in, 0)
       @pipeline_metrics.increment(:in, 0)
-      @plugin_metrics.increment(:out, 0)
+      @plugin_events_metrics.increment(:out, 0)
 
       @events_metrics.report_time(:queue_push_duration_in_millis, 0)
       @pipeline_metrics.report_time(:queue_push_duration_in_millis, 0)
-      @plugin_metrics.report_time(:queue_push_duration_in_millis, 0)
+      @plugin_events_metrics.report_time(:queue_push_duration_in_millis, 0)
     end
   end
 end end

--- a/logstash-core/spec/logstash/instrument/wrapped_write_client_spec.rb
+++ b/logstash-core/spec/logstash/instrument/wrapped_write_client_spec.rb
@@ -66,7 +66,7 @@ describe LogStash::Instrument::WrappedWriteClient do
       end
 
       it "record input `out`" do
-        expect(snapshot_metric[:pipelines][:main][:plugins][:inputs][myid.to_sym][:out].value).to eq(1)
+        expect(snapshot_metric[:pipelines][:main][:plugins][:inputs][myid.to_sym][:events][:out].value).to eq(1)
       end
 
       context "recording of the duration of pushing to the queue" do
@@ -79,7 +79,7 @@ describe LogStash::Instrument::WrappedWriteClient do
         end
 
         it "records at the `plugin level" do
-          expect(snapshot_metric[:pipelines][:main][:plugins][:inputs][myid.to_sym][:queue_push_duration_in_millis].value).to be_kind_of(Integer)
+          expect(snapshot_metric[:pipelines][:main][:plugins][:inputs][myid.to_sym][:events][:queue_push_duration_in_millis].value).to be_kind_of(Integer)
         end
       end
     end


### PR DESCRIPTION
Filters/outputs nest their 'out' metric under 'events'. Inputs should not be different.