### PR TITLE
Create an offline pack on Windows generate corrupted pack

### DIFF
--- a/tools/paquet/CHANGELOG.md
+++ b/tools/paquet/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 0.2.1
+ - Making sure the gems are downloaded in binary format, without it, gems downloaded on windows will be corrupted.

--- a/tools/paquet/lib/paquet/utils.rb
+++ b/tools/paquet/lib/paquet/utils.rb
@@ -11,7 +11,7 @@ module Paquet
       raise "Too many redirection" if counter == 0
 
       begin
-        f = File.open(destination, "w")
+        f = File.open(destination, "wb")
 
         uri = URI.parse(source)
 

--- a/tools/paquet/lib/paquet/version.rb
+++ b/tools/paquet/lib/paquet/version.rb
@@ -1,3 +1,3 @@
 module Paquet
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/tools/paquet/spec/paquet/gem_spec.rb
+++ b/tools/paquet/spec/paquet/gem_spec.rb
@@ -25,7 +25,7 @@ describe Paquet::Gem do
 
   context "when not configuring cache" do
     it "use_cache? returns false" do
-      expect(subject.use_cache?).to be_truthy
+      expect(subject.use_cache?).to be_falsey
     end
   end
 


### PR DESCRIPTION
When generating a pack on windows, Paquet was downloading the gems in plain text instead of binary mode, this was making them corrupted and the rubygems class was not able to unpack them correctly. This PR change the File open mode to be **wb** instead of **w**.


## Todo

- [ ] Release a new version of paquet.
- [ ] Make sure Logstash uses that version in a future release.