### PR TITLE
Make sure we scope the installed gems for the logstash-docgen tool

### DIFF
--- a/ci/ci_docs_master.sh
+++ b/ci/ci_docs_master.sh
@@ -11,5 +11,7 @@ rm -rf build/docs/*
 rm -rf tools/logstash-docgen/source
 
 cd tools/logstash-docgen
-bundle install
+# Make sure we scope the gem in the project directory
+# so we don't run into weird issues about rake.
+bundle install --path vendor
 bin/logstash-docgen --all --target ../../build/docs


### PR DESCRIPTION
Instead of installing the gems globally in your current environment we
use the `--path` option of bundler to scope the gem into a vendor
directory.