### PR TITLE
Release notes and breaking changes for 5.3

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -154,3 +154,7 @@ include::static/submitting-a-plugin.asciidoc[]
 
 include::static/glossary.asciidoc[]
 
+
+// Release Notes
+
+include::static/releasenotes.asciidoc[]

--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -11,12 +11,13 @@ This section summarizes the breaking changes in the following releases:
 [[logstash-breaking-changes-5-3]]
 === Logstash 5.3.0 Breaking Changes
 
+This section discusses the changes that you need to be aware of when migrating your application 
+from Logstash 5.2 to 5.3.
+
 [float]
 ==== Changes in Logstash Core
 
 ==== Persistent queue
-
-If you are using the persistent queue feature and upgrading from 5.2.0, please see the below section:
 
 The default location on disk where the queue data is stored has been changed from `<path.data>/queue` to 
 `<path.data>/queue/main`. The directory hierarchy now includes the pipeline ID which defaults to `main`. 
@@ -24,20 +25,20 @@ This change was made to accommodate an upcoming feature where multiple, isolated
 the same Logstash instance. In this future situation, each pipeline will have its own queue; hence the new directory 
 structure.
 
-**Upgrading from 5.3.0**
+**Upgrading to 5.3**
 
-The following options are available if you intend to upgrade to 5.3.0 with the persistent queue enabled:
+If you are using the persistent queue feature and intend to upgrade to 5.3:
 
-* Ensure you completely drain the queue data in 5.2.0 by stopping the incoming data and processing all of the 
+* Ensure you completely drain the queue data in 5.2 by stopping the incoming data and processing all of the 
   in-flight events.
-* Stop Logstash and manually move the files under `<path.data>/queue/`` to `<path.data>/queue/main` before upgrading to 5.3.
-* If you do not intend to process the data currently buffered in the queue in 5.2.0, you can manually delete 
-  the `path.data/queue` directory before upgrading to 5.3.0.
+* Stop Logstash and manually move the files under `<path.data>/queue/` to `<path.data>/queue/main` before upgrading to 5.3.
+* If you do not intend to process the data currently buffered in the queue in 5.2, you can manually delete 
+  the `path.data/queue` directory before upgrading to 5.3.
 
 [float]
 ==== Breaking Changes in Plugins
 
-*`KV`*: `trim` and `trimkey` options are renamed to `trim_value` and `trim_key` respectively. Their behavior has been 
+*`KV filter`*: `trim` and `trimkey` options are renamed to `trim_value` and `trim_key` respectively. Their behavior has been 
 changed as well to _trim_ the characters at the beginning or end of the values.
 
 [[logstash-breaking-changes-5-2]]

--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -1,10 +1,62 @@
 [[breaking-changes]]
 == Breaking changes
 
+This section summarizes the breaking changes in the following releases:
+
+* <<logstash-breaking-changes-5-3,Logstash 5.3.0>>
+* <<logstash-breaking-changes-5-2,Logstash 5.2.0>>
+* <<logstash-breaking-changes-5-1,Logstash 5.1.0>>
+* <<logstash-breaking-changes-5-0,Logstash 5.0.0>>
+
+[[logstash-breaking-changes-5-3]]
+=== Logstash 5.3.0 Breaking Changes
+
+[float]
+==== Changes in Logstash Core
+
+==== Persistent queue
+
+If you are using the persistent queue feature and upgrading from 5.2.0, please see the below section:
+
+The default location on disk where the queue data is stored has been changed from `<path.data>/queue` to 
+`<path.data>/queue/main`. The directory hierarchy now includes the pipeline ID which defaults to `main`. 
+This change was made to accommodate an upcoming feature where multiple, isolated pipelines can be run on 
+the same Logstash instance. In this future situation, each pipeline will have its own queue; hence the new directory 
+structure.
+
+**Upgrading from 5.3.0**
+
+The following options are available if you intend to upgrade to 5.3.0 with the persistent queue enabled:
+
+* Ensure you completely drain the queue data in 5.2.0 by stopping the incoming data and processing all of the 
+  in-flight events.
+* Stop Logstash and manually move the files under `<path.data>/queue/`` to `<path.data>/queue/main` before upgrading to 5.3.
+* If you do not intend to process the data currently buffered in the queue in 5.2.0, you can manually delete 
+  the `path.data/queue` directory before upgrading to 5.3.0.
+
+[float]
+==== Breaking Changes in Plugins
+
+*`KV`*: `trim` and `trimkey` options are renamed to `trim_value` and `trim_key` respectively. Their behavior has been 
+changed as well to _trim_ the characters at the beginning or end of the values.
+
+[[logstash-breaking-changes-5-2]]
+=== Logstash 5.2.0 Breaking Changes
+
+There are no breaking changes in this particular release.
+
+[[logstash-breaking-changes-5-1]]
+=== Logstash 5.1.0 Breaking Changes
+
+There are no breaking changes in this particular release.
+
+[[logstash-breaking-changes-5-0]]
+=== Logstash 5.0.0 Breaking Changes
+
 This section discusses the changes that you need to be aware of when migrating your application to Logstash 5.0 from the previous major release of Logstash (2.x).
 
 [float]
-=== Changes in Logstash Core
+==== Changes in Logstash Core
 
 These changes can impact any instance of Logstash and are plugin agnostic, but only if you are using the features that are impacted.
 
@@ -153,7 +205,7 @@ were familiar with the RSpec framework, which is a Ruby testing framework.
 
 
 [float]
-=== Breaking Changes in Plugins
+==== Breaking Changes in Plugins
 
 [float]
 ==== Elasticsearch Output `workers` Setting Removed

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -10,9 +10,9 @@ This section summarizes the changes in the following releases:
 
 
 * Persistent queues:
-    ** Changed the default queue location on disk to include the pipeline's ID as it's parent directory.
-       By default, the queue now gets created under path.data/queue/main. This breaking change was made in
-       anticipation of an upcoming feature where multiple, isolated pipelines could be run on the same Logstash
+    ** Changed the default queue location on disk to include the pipeline's ID in the path hierarchy.
+       By default, the queue is now created under <path.data>/queue/main. This breaking change was made to
+       accommodate an upcoming feature where multiple, isolated pipelines could be run on the same Logstash
        instance.
     ** Added a _recovery_ process that runs when Logstash starts up to recover data written to the persistent
        queue, but not yet checkpoint'd. This is useful in a situation when the input had written data to the queue,
@@ -44,11 +44,11 @@ This section summarizes the changes in the following releases:
 
 *`KV`*:
 
-* Breaking: `trim` and `trimkey` options are renamed to `trim_value` and `trim_key`.
+* Breaking: `trim` and `trimkey` options are renamed to `trim_value` and `trim_key` respectively (https://github.com/logstash-plugins/logstash-filter-kv/issues/10[Issue 10]).
 * `trim_value` only removes the specified leading and trailing characters from the value. Similarly, `trim_key`
   only removes the specified leading and trailing characters from the key (https://github.com/logstash-plugins/logstash-filter-kv/issues/10[Issue 10]).
 * Added new options `remove_char_value` and `remove_char_key` to remove the specified characters from keys
-  (or values) regardless of where these characters are found.
+  (or values) regardless of where these characters are found (https://github.com/logstash-plugins/logstash-filter-kv/issues/10[Issue 10]).
 
 *`Grok`*:
 

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -11,18 +11,18 @@ This section summarizes the changes in the following releases:
 
 * Persistent queues:
     ** Changed the default queue location on disk to include the pipeline's ID in the path hierarchy.
-       By default, the queue is now created under <path.data>/queue/main. This breaking change was made to
+       By default, the queue is now created under `<path.data>/queue/main`. This breaking change was made to
        accommodate an upcoming feature where multiple, isolated pipelines could be run on the same Logstash
        instance.
-    ** Added a _recovery_ process that runs when Logstash starts up to recover data written to the persistent
-       queue, but not yet checkpoint'd. This is useful in a situation when the input had written data to the queue,
-       but Logstash crashed before writing to the checkpoint file.
-    ** Added exclusive access to the persistent queue on disk, as defined by the path.queue setting. Using a file
-       lock we ensure that only a single Logstash instance has access to write to the queue on the same path, to
-       guard against corruption ({lsissue}6604[Issue 6604]).
-    ** You can now safely reload the pipeline config when using persistent queues. Previously, the reloading of
-       config could result in data corruption.  In 5.3, the reload sequence has been changed to reliably shutdown the
-       first pipeline before a new one is started with same settings.
+    ** Added a recovery process that runs during Logstash startup to recover data that has been written to the 
+       persistent queue, but not yet checkpointed. This is useful in situations where the input has written data to 
+       the queue, but Logstash crashed before writing to the checkpoint file.
+    ** Added exclusive access to the persistent queue on disk, as defined by the `path.queue` setting. Using a file 
+       lock guards against corruption by ensuring that only a single Logstash instance has access to write to the 
+       queue on the same path. ({lsissue}6604[Issue 6604]).
+    ** You can now safely reload the pipeline config when using persistent queues. Previously, reloading the 
+       config could result in data corruption. In 5.3, the reload sequence has been changed to reliably shut down the
+       first pipeline before a new one is started with the same settings.
     ** Fixed an issue where Logstash would stop accepting new events when queue capacity is reached even though events
        were successfully acknowledged ({lsissue}6626[Issue 6626]).
 
@@ -38,13 +38,13 @@ This section summarizes the changes in the following releases:
 
 *`Unix`*:
 
-* Do not overwrite `host` and `path` fields if they are already provided by `add_field` config.
+* The `host` and `path` fields are no longer overwritten if they are already provided by `add_field` config.
 
 ==== Filter Plugins
 
 *`KV`*:
 
-* Breaking: `trim` and `trimkey` options are renamed to `trim_value` and `trim_key` respectively (https://github.com/logstash-plugins/logstash-filter-kv/issues/10[Issue 10]).
+* Breaking: The `trim` and `trimkey` options are renamed to `trim_value` and `trim_key` respectively (https://github.com/logstash-plugins/logstash-filter-kv/issues/10[Issue 10]).
 * `trim_value` only removes the specified leading and trailing characters from the value. Similarly, `trim_key`
   only removes the specified leading and trailing characters from the key (https://github.com/logstash-plugins/logstash-filter-kv/issues/10[Issue 10]).
 * Added new options `remove_char_value` and `remove_char_key` to remove the specified characters from keys
@@ -63,4 +63,4 @@ This section summarizes the changes in the following releases:
 
 *`CSV`*:
 
-* Updated to work with 5.0 event API and threading contracts (https://github.com/logstash-plugins/logstash-output-csv/issues/10[Issue 10]).
+* Updated to work with the 5.0 event API and threading contracts (https://github.com/logstash-plugins/logstash-output-csv/issues/10[Issue 10]).

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -1,0 +1,66 @@
+[[releasenotes]]
+== Release Notes
+
+This section summarizes the changes in the following releases:
+
+* <<logstash-5-3-0,Logstash 5.3.0>>
+
+[[logstash-5-3-0]]
+=== Logstash 5.3.0 Release Notes
+
+
+* Persistent queues:
+    ** Changed the default queue location on disk to include the pipeline's ID as it's parent directory.
+       By default, the queue now gets created under path.data/queue/main. This breaking change was made in
+       anticipation of an upcoming feature where multiple, isolated pipelines could be run on the same Logstash
+       instance.
+    ** Added a _recovery_ process that runs when Logstash starts up to recover data written to the persistent
+       queue, but not yet checkpoint'd. This is useful in a situation when the input had written data to the queue,
+       but Logstash crashed before writing to the checkpoint file.
+    ** Added exclusive access to the persistent queue on disk, as defined by the path.queue setting. Using a file
+       lock we ensure that only a single Logstash instance has access to write to the queue on the same path, to
+       guard against corruption ({lsissue}6604[Issue 6604]).
+    ** You can now safely reload the pipeline config when using persistent queues. Previously, the reloading of
+       config could result in data corruption.  In 5.3, the reload sequence has been changed to reliably shutdown the
+       first pipeline before a new one is started with same settings.
+    ** Fixed an issue where Logstash would stop accepting new events when queue capacity is reached even though events
+       were successfully acknowledged ({lsissue}6626[Issue 6626]).
+
+* Fixed a warning message when --config.debug is used with --log.level=debug  ({lsissue}6256[Issue 6256]).
+
+
+[float]
+==== Input Plugins
+
+*`S3`*:
+
+* We now include the S3 key information in the metadata (https://github.com/logstash-plugins/logstash-input-s3/issues/105[Issue 105]).
+
+*`Unix`*:
+
+* Do not overwrite `host` and `path` fields if they are already provided by `add_field` config.
+
+==== Filter Plugins
+
+*`KV`*:
+
+* Breaking: `trim` and `trimkey` options are renamed to `trim_value` and `trim_key`.
+* `trim_value` only removes the specified leading and trailing characters from the value. Similarly, `trim_key`
+  only removes the specified leading and trailing characters from the key (https://github.com/logstash-plugins/logstash-filter-kv/issues/10[Issue 10]).
+* Added new options `remove_char_value` and `remove_char_key` to remove the specified characters from keys
+  (or values) regardless of where these characters are found.
+
+*`Grok`*:
+
+* Added an option to define custom patterns using `pattern_definitions` configuration.
+
+==== Output Plugins
+
+*`S3`*:
+
+* Fixed to use the correct `signature_version` for the SDK v2 library (https://github.com/logstash-plugins/logstash-output-csv/issues/129[Issue 129]).
+* Fixed an issue which resulted in uploading empty files to S3 when using gzip compression (https://github.com/logstash-plugins/logstash-output-s3/issues/95[Issue 95]).
+
+*`CSV`*:
+
+* Updated to work with 5.0 event API and threading contracts (https://github.com/logstash-plugins/logstash-output-csv/issues/10[Issue 10]).


### PR DESCRIPTION
We usually avoid breaking changes in point releases, but unfortunately, there is one in PQ -- which is a beta feature, so breaking change is OK. Second, there is a breaking change in a plugin (again, this is something we avoid at best). Hence, I added breaking changes section per release.