### PR TITLE
Fix typo in logstash core

### DIFF
--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -20,7 +20,7 @@ class LogStash::Plugin
   config :enable_metric, :validate => :boolean, :default => true
 
   # Add a unique `ID` to the plugin configuration. If no ID is specified, Logstash will generate one. 
-  # It is strongly recommended to set this ID in your configuration. This is particulary useful 
+  # It is strongly recommended to set this ID in your configuration. This is particularly useful 
   # when you have two or more plugins of the same type, for example, if you have 2 grok filters. 
   # Adding a named ID in this case will help in monitoring Logstash when using the monitoring APIs.
   #


### PR DESCRIPTION
This gets propagated into a bunch of files in the plugin docs. :-(

Let me know if I also need to bump the version in the gemspec. Wasn't sure if that would be required....