### PR TITLE
Cleanup some RecordIO cases

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriteManager.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriteManager.java
@@ -37,7 +37,7 @@ public class DeadLetterQueueWriteManager {
 
     private static final Logger logger = LogManager.getLogger(DeadLetterQueueWriteManager.class);
 
-    static final String SEGMENT_FILE_PATTERN = "%020d.log";
+    static final String SEGMENT_FILE_PATTERN = "%d.log";
     static final String LOCK_FILE = ".lock";
     private final long maxSegmentSize;
     private final long maxQueueSize;

--- a/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
@@ -109,6 +109,9 @@ public class RecordIOReader {
         while (compare < 0) {
             currentPosition = currentBlock.position();
             event = readEvent();
+            if (event == null) {
+                return null;
+            }
             compare = keyComparator.compare(keyExtractor.apply(event), target);
         }
         currentBlock.position(currentPosition);

--- a/logstash-core/src/test/java/org/logstash/common/io/RecordIOWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/RecordIOWriterTest.java
@@ -19,7 +19,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.logstash.common.io.RecordIOWriter.BLOCK_SIZE;
 
-public class RecordHeaderIOWriterTest {
+public class RecordIOWriterTest {
     private Path file;
 
     @Rule


### PR DESCRIPTION
- rename segment files to `%d.log` instead of having a length of 20 characters
- rename test file
- check for `null` events when seeking by timestamp, meaning there was no data found and we reached the end of the block that was supposed to have the event according to some timestamp comparison.