### PR TITLE
Search java executable in %PATH%

### DIFF
--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -15,11 +15,11 @@ goto finally
 
 :setup_jruby
 REM setup_java()
-if not defined JAVA_HOME IF EXIST %ProgramData%\Oracle\java\javapath\java.exe (
-    for /f "tokens=2 delims=[]" %%a in ('dir %ProgramData%\Oracle\java\javapath\java.exe') do @set JAVA_EXE=%%a
+IF NOT DEFINED JAVA_HOME (
+  FOR %%I IN (java.exe) DO set JAVA_EXE=%%~$PATH:I
 )
 if defined JAVA_EXE set JAVA_HOME=%JAVA_EXE:\bin\java.exe=%
-if defined JAVA_EXE echo Using JAVA_HOME=%JAVA_HOME% retrieved from %ProgramData%\Oracle\java\javapath\java.exe
+if defined JAVA_EXE echo Using JAVA_HOME=%JAVA_HOME% retrieved from PATH
 
 if not defined JAVA_HOME goto missing_java_home
 REM ***** JAVA options *****


### PR DESCRIPTION
In their latest JDK 8u121 (maybe earlier, i didn't checked that) Oracle changed the java installation on windows a bit. Searching the java executable via the link `%ProgramData%\Oracle\java\javapath\java.exe` unfortunately doesn't work any more. I replaced that by searching the java executable in the PATH as it is already done in the elasticsearch start scripts.