### PR TITLE
Make sure prepare_offline_pack command only accept a filename

### DIFF
--- a/docs/static/offline-plugins.asciidoc
+++ b/docs/static/offline-plugins.asciidoc
@@ -28,14 +28,15 @@ access the Internet.
 +
 [source, shell]
 -------------------------------------------------------------------------------
-bin/logstash-plugin prepare-offline-pack --output OUTPUT [PLUGINS]
+bin/logstash-plugin prepare-offline-pack --output OUTPUT [PLUGINS] --overwrite
 -------------------------------------------------------------------------------
 +
 where:
 +
-* `OUTPUT` specifies the location where the compressed plugin pack will be written. The default location is
-+/LOGSTASH_HOME/logstash-offline-plugins-{logstash_version}.zip+.
+* `OUTPUT` specifies the zip file where the compressed plugin pack will be written. The default file is
++/LOGSTASH_HOME/logstash-offline-plugins-{logstash_version}.zip+. If you are using 5.2.x and 5.3.0, this location should be a zip file whose contents will be overwritten.
 * `[PLUGINS]` specifies one or more plugins that you want to include in the pack.
+* `--overwrite` specifies if you want to override an existing file at the location
 
 Examples:
 


### PR DESCRIPTION
This PR changes the behavior of the command when you were specify a directory
instead of a filename, if the directory exists it would have deleted the
directory and the files in it.

The new flow and validation is now safer, if you specify a directory
Logstash will tell you to specify a complete filename.

If the ZIP extension is missing, the command line will ask you to make
sure you target a right filename.

If the output file already exist it will *not* delete it but instead
will return a warning message, you can force a delete by using the
`--overwrite` option.