### PR TITLE
Input#clone should also clone that input's codec

### DIFF
--- a/logstash-core/lib/logstash/inputs/base.rb
+++ b/logstash-core/lib/logstash/inputs/base.rb
@@ -94,6 +94,12 @@ class LogStash::Inputs::Base < LogStash::Plugin
   def stop?
     @stop_called.value
   end
+  
+  def clone
+    cloned = super
+    cloned.codec = @codec.clone if @codec
+    cloned
+  end
 
   protected
   def decorate(event)

--- a/logstash-core/spec/logstash/inputs/base_spec.rb
+++ b/logstash-core/spec/logstash/inputs/base_spec.rb
@@ -60,6 +60,24 @@ describe "LogStash::Inputs::Base#decorate" do
     expect(evt.get("field")).to eq(["value1","value2"])
     expect(evt.get("field2")).to eq("value")
   end
+  
+  describe "cloning" do
+    let(:input) do
+      LogStash::Inputs::NOOP.new("add_field" => {"field" => ["value1", "value2"], "field2" => "value"})
+    end
+    
+    let(:cloned) do
+      input.clone
+    end
+    
+    it "should clone the codec when cloned" do
+      expect(input.codec).not_to eq(cloned.codec)
+    end  
+    
+    it "should preserve codec params" do
+      expect(input.codec.params).to eq(cloned.codec.params)
+    end
+  end
 end
 
 describe "LogStash::Inputs::Base#fix_streaming_codecs" do


### PR DESCRIPTION
Some codecs are context-specific and not threadsafe. If, for instance,
you want to use `generator { threads => 3 }` you will run into buggy
behavior with the line and multiline codecs which are not threadsafe.

This patch is a quick workaround for this behavior. This does not fix
this issue for inputs that do their own multithreading. Those inputs
should handle codec cloning / lifecycle internally according to their
specific requirements.