### PR TITLE
Quote shell script variables handling paths.

### DIFF
--- a/bin/logstash
+++ b/bin/logstash
@@ -21,16 +21,16 @@
 unset CDPATH
 # This unwieldy bit of scripting is to try to catch instances where Logstash
 # was launched from a symlink, rather than a full path to the Logstash binary
-if [ -L $0 ]; then
+if [ -L "$0" ]; then
   # Launched from a symlink
   # --Test for the readlink binary
-  RL=$(which readlink)
+  RL="$(which readlink)"
   if [ $? -eq 0 ]; then
     # readlink exists
-    SOURCEPATH=$($RL $0)
+    SOURCEPATH="$($RL $0)"
   else
     # readlink not found, attempt to parse the output of stat
-    SOURCEPATH=$(stat -c %N $0 | awk '{print $3}' | sed -e 's/\‘//' -e 's/\’//')
+    SOURCEPATH="$(stat -c %N $0 | awk '{print $3}' | sed -e 's/\‘//' -e 's/\’//')"
     if [ $? -ne 0 ]; then
       # Failed to execute or parse stat
       echo "Failed to find source library at path $(cd `dirname $0`/..; pwd)/bin/logstash.lib.sh"
@@ -40,7 +40,7 @@ if [ -L $0 ]; then
   fi
 else
   # Not a symlink
-  SOURCEPATH=$0
+  SOURCEPATH="$0"
 fi
 
 . "$(cd `dirname $SOURCEPATH`/..; pwd)/bin/logstash.lib.sh"

--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -1,16 +1,16 @@
 unset CDPATH
 # This unwieldy bit of scripting is to try to catch instances where Logstash
 # was launched from a symlink, rather than a full path to the Logstash binary
-if [ -L $0 ]; then
+if [ -L "$0" ]; then
   # Launched from a symlink
   # --Test for the readlink binary
-  RL=$(which readlink)
+  RL="$(which readlink)"
   if [ $? -eq 0 ]; then
     # readlink exists
-    SOURCEPATH=$($RL $0)
+    SOURCEPATH="$($RL $0)"
   else
     # readlink not found, attempt to parse the output of stat
-    SOURCEPATH=$(stat -c %N $0 | awk '{print $3}' | sed -e 's/\‘//' -e 's/\’//')
+    SOURCEPATH="$(stat -c %N $0 | awk '{print $3}' | sed -e 's/\‘//' -e 's/\’//')"
     if [ $? -ne 0 ]; then
       # Failed to execute or parse stat
       echo "Failed to set LOGSTASH_HOME from $(cd `dirname $0`/..; pwd)/bin/logstash.lib.sh"
@@ -20,12 +20,12 @@ if [ -L $0 ]; then
   fi
 else
   # Not a symlink
-  SOURCEPATH=$0
+  SOURCEPATH="$0"
 fi
 
-LOGSTASH_HOME=$(cd `dirname $SOURCEPATH`/..; pwd)
+LOGSTASH_HOME="$(cd `dirname $SOURCEPATH`/..; pwd)"
 export LOGSTASH_HOME
-SINCEDB_DIR=${LOGSTASH_HOME}
+SINCEDB_DIR="${LOGSTASH_HOME}"
 export SINCEDB_DIR
 
 # This block will iterate over the command-line args Logstash was started with
@@ -65,7 +65,7 @@ setup_java() {
 
   # Resolve full path to the java command.
   if [ ! -f "$JAVACMD" ] ; then
-    JAVACMD=$(which $JAVACMD 2>/dev/null)
+    JAVACMD="$(which $JAVACMD 2>/dev/null)"
   fi
 
   if [ ! -x "$JAVACMD" ] ; then
@@ -114,7 +114,7 @@ setup_drip() {
 
   # resolve full path to the drip command.
   if [ ! -f "$JAVACMD" ] ; then
-    JAVACMD=$(which $JAVACMD 2>/dev/null)
+    JAVACMD="$(which $JAVACMD 2>/dev/null)"
   fi
 
   if [ ! -x "$JAVACMD" ] ; then

--- a/bin/system-install
+++ b/bin/system-install
@@ -7,8 +7,8 @@ setup
 if [ -z "$1" ]; then
   if [ -r /etc/logstash/startup.options ]; then
     OPTIONS_PATH=/etc/logstash/startup.options
-  elif [ -r ${LOGSTASH_HOME}/config/startup.options ]; then
-    OPTIONS_PATH=${LOGSTASH_HOME}/config/startup.options
+  elif [ -r "${LOGSTASH_HOME}"/config/startup.options ]; then
+    OPTIONS_PATH="${LOGSTASH_HOME}"/config/startup.options
   fi
 elif [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
   echo "Usage: system-install [OPTIONSFILE] [STARTUPTYPE] [VERSION]"
@@ -30,9 +30,9 @@ elif [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
   echo "For more information, see https://github.com/jordansissel/pleaserun"
   exit 0
 else
-  if [ -r $1 ]; then
+  if [ -r "$1" ]; then
     echo "Using provided startup.options file: ${1}"
-    OPTIONS_PATH=$1
+    OPTIONS_PATH="$1"
   else
     echo "$1 is not a file path"
     echo "To manually specify a startup style, put the path to startup.options as the "
@@ -42,7 +42,7 @@ else
 fi
 
 # Read in the env vars in the selected startup.options file...
-. ${OPTIONS_PATH}
+. "${OPTIONS_PATH}"
 
 old_IFS=$IFS
 IFS=$'\n'


### PR DESCRIPTION
Some variables that hold path in Linux shell scripts
are not properly quoted, thus undefined behaviors may
show up (e.g. a link path with space).

This change enclose variables with quotes in bin/logstash,
bin/logstash.lib.sh and, bin/system-install scripts.

Fixes #6596