### PR TITLE
Add test for logstash-plugin generate command.

### DIFF
--- a/qa/acceptance/spec/lib/cli_operation_spec.rb
+++ b/qa/acceptance/spec/lib/cli_operation_spec.rb
@@ -6,6 +6,7 @@ require_relative "../shared_examples/cli/logstash-plugin/list"
 require_relative "../shared_examples/cli/logstash-plugin/uninstall"
 require_relative "../shared_examples/cli/logstash-plugin/remove"
 require_relative "../shared_examples/cli/logstash-plugin/update"
+require_relative "../shared_examples/cli/logstash-plugin/generate"
 
 # This is the collection of test for the CLI interface, this include the plugin manager behaviour, 
 # it also include the checks for other CLI options.
@@ -19,5 +20,6 @@ describe "CLI operation" do
     it_behaves_like "logstash uninstall", logstash
     it_behaves_like "logstash remove", logstash
     it_behaves_like "logstash update", logstash
+    it_behaves_like "logstash generate", logstash
   end
 end

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/generate.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/generate.rb
@@ -1,0 +1,32 @@
+# encoding: utf-8
+require_relative "../../../spec_helper"
+require "logstash/version"
+require "fileutils"
+
+shared_examples "logstash generate" do |logstash|
+  before(:each) do
+    logstash.install({:version => LOGSTASH_VERSION})
+  end
+
+  after(:each) do
+    logstash.uninstall
+  end
+
+  describe "on #{logstash.hostname}" do
+
+    GENERATE_TYPES = ["input", "filter", "codec", "output"]
+    GENERATE_TYPES.each |type| do
+      context "with type #{type}" do
+        it "successfully generate the plugin skeleton" do
+          command = logstash.run_command_in_path("bin/logstash-plugin generate --type #{type} --name qatest-generated")
+          expect(logstash).to File.directory?("logstash-#{type}-qatest-generated")
+        end
+        it "successfully install the plugin" do
+            command = logstash.run_command_in_path("bin/logstash-plugin install logstash-#{type}-qatest-generated")
+            expect(command).to install_successfully
+            expect(logstash).to have_installed?("logstash-#{type}-qatest-generated")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change adds an acceptance test that creates a plugin template
for each type with logstash-plugin generate command,
then proceed to check they can be installed.

Fixes #6183.