### PR TITLE
handle specified dlq-dir with no segments

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReadManager.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReadManager.java
@@ -18,6 +18,8 @@
  */
 package org.logstash.common.io;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.logstash.DLQEntry;
 import org.logstash.Timestamp;
 
@@ -38,6 +40,7 @@ import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
 import static org.logstash.common.io.DeadLetterQueueWriteManager.getSegmentPaths;
 
 public class DeadLetterQueueReadManager {
+    private static final Logger logger = LogManager.getLogger(DeadLetterQueueReadManager.class);
 
     private RecordIOReader currentReader;
     private final Path queuePath;
@@ -104,6 +107,11 @@ public class DeadLetterQueueReadManager {
         long timeoutRemaining = timeout;
         if (currentReader == null) {
             timeoutRemaining -= pollNewSegments(timeout);
+            // If no new segments are found, exit
+            if (segments.isEmpty()) {
+                logger.debug("No entries found: no segment files found in dead-letter-queue directory");
+                return null;
+            }
             currentReader = new RecordIOReader(segments.first());
         }
 

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReadManagerTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReadManagerTest.java
@@ -29,7 +29,9 @@ import org.logstash.Event;
 import org.logstash.Timestamp;
 import org.logstash.ackedqueue.StringElement;
 
+import java.io.BufferedWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 
@@ -133,5 +135,11 @@ public class DeadLetterQueueReadManagerTest {
         DLQEntry entry = readManager.pollEntry(100);
         assertThat(entry.getEntryTime().toIso8601(), equalTo(target.toIso8601()));
         assertThat(entry.getReason(), equalTo("543"));
+    }
+
+    @Test
+    public void testInvalidDirectory()  throws Exception {
+        DeadLetterQueueReadManager readManager = new DeadLetterQueueReadManager(dir);
+        assertThat(readManager.pollEntry(100), is(nullValue()));
     }
 }


### PR DESCRIPTION
Before, the DeadLetterQueueReadManager would throw an exception
when it attempted to choose to read a segment from its segments
list and that list was empty. This fixes that.

this was the old exception

```
java.util.NoSuchElementException
	at java.util.concurrent.ConcurrentSkipListMap.firstKey(ConcurrentSkipListMap.java:2036)
	at java.util.concurrent.ConcurrentSkipListSet.first(ConcurrentSkipListSet.java:396)
	at org.logstash.common.io.DeadLetterQueueReadManager.pollEntryBytes(DeadLetterQueueReadManager.java:111)
...
```

now `null` is returned by `pollEntryBytes`, so that the user can re-run method to poll for any segments that may have been added since the previous poll