### PR TITLE
Allow Finite pipeline to shutdown internal pipelines and make internal pipeline start first

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -104,9 +104,12 @@ class LogStash::Agent
       return 1 if clean_state?
 
       while !Stud.stop?
-        if clean_state? || running_pipelines?
-          sleep 0.5
-        else
+        if running_user_defined_pipelines?
+          sleep(0.5)
+        elsif running_pipelines?
+          logger.debug("Shutting down system pipelines")
+          shutdown_pipelines
+        elsif clean_state? || !running_pipelines?
           break
         end
       end
@@ -240,6 +243,15 @@ class LogStash::Agent
   def running_pipelines?
     @pipelines_mutex.synchronize do
       @pipelines.select {|pipeline_id, _| running_pipeline?(pipeline_id) }.any?
+    end
+  end
+
+  def running_user_defined_pipelines?
+    @pipelines_mutex.synchronize do
+      @pipelines.select do |pipeline_id, _|
+        pipeline = @pipelines[pipeline_id]
+        pipeline.running? && !pipeline.system?
+      end.any?
     end
   end
 

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -244,11 +244,15 @@ class LogStash::Agent
   end
 
   def running_user_defined_pipelines?
+    user_defined_pipelines.any?
+  end
+
+  def user_defined_pipelines
     @pipelines_mutex.synchronize do
       @pipelines.select do |pipeline_id, _|
         pipeline = @pipelines[pipeline_id]
         pipeline.running? && !pipeline.system?
-      end.any?
+      end
     end
   end
 

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -104,12 +104,9 @@ class LogStash::Agent
       return 1 if clean_state?
 
       while !Stud.stop?
-        if running_user_defined_pipelines?
+        if clean_state? || running_user_defined_pipelines?
           sleep(0.5)
-        elsif running_pipelines?
-          logger.debug("Shutting down system pipelines")
-          shutdown_pipelines
-        elsif clean_state? || !running_pipelines?
+        else
           break
         end
       end

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -244,13 +244,12 @@ class LogStash::Agent
   end
 
   def running_user_defined_pipelines?
-    user_defined_pipelines.any?
+    running_user_defined_pipelines.any?
   end
 
-  def user_defined_pipelines
+  def running_user_defined_pipelines
     @pipelines_mutex.synchronize do
-      @pipelines.select do |pipeline_id, _|
-        pipeline = @pipelines[pipeline_id]
+      @pipelines.select do |_, pipeline|
         pipeline.running? && !pipeline.system?
       end
     end

--- a/logstash-core/lib/logstash/config/pipeline_config.rb
+++ b/logstash-core/lib/logstash/config/pipeline_config.rb
@@ -23,6 +23,10 @@ module LogStash module Config
       @config_string = config_parts.collect(&:config_string).join("\n")
     end
 
+    def system?
+      @settings.get("pipeline.system")
+    end
+
     def ==(other)
       config_hash == other.config_hash && pipeline_id == other.pipeline_id
     end

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -25,7 +25,7 @@ module LogStash
            Setting::Numeric.new("config.reload.interval", 3), # in seconds
            Setting::Boolean.new("metric.collect", true),
             Setting::String.new("pipeline.id", "main"),
-            Setting::Boolean.new("pipeline.system", false),
+           Setting::Boolean.new("pipeline.system", false),
    Setting::PositiveInteger.new("pipeline.workers", LogStash::Config::CpuCoreStrategy.maximum),
    Setting::PositiveInteger.new("pipeline.output.workers", 1),
    Setting::PositiveInteger.new("pipeline.batch.size", 125),

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -25,6 +25,7 @@ module LogStash
            Setting::Numeric.new("config.reload.interval", 3), # in seconds
            Setting::Boolean.new("metric.collect", true),
             Setting::String.new("pipeline.id", "main"),
+            Setting::Boolean.new("pipeline.system", false),
    Setting::PositiveInteger.new("pipeline.workers", LogStash::Config::CpuCoreStrategy.maximum),
    Setting::PositiveInteger.new("pipeline.output.workers", 1),
    Setting::PositiveInteger.new("pipeline.batch.size", 125),

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -323,6 +323,10 @@ module LogStash; class Pipeline < BasePipeline
     @running.false?
   end
 
+  def system?
+    settings.get_value("pipeline.system")
+  end
+
   # register_plugin simply calls the plugin #register method and catches & logs any error
   # @param plugin [Plugin] the plugin to register
   # @return [Plugin] the registered plugin

--- a/logstash-core/lib/logstash/pipeline_action.rb
+++ b/logstash-core/lib/logstash/pipeline_action.rb
@@ -5,9 +5,9 @@ require "logstash/pipeline_action/stop"
 require "logstash/pipeline_action/reload"
 
 module LogStash module PipelineAction
-  ORDERING = [
-    LogStash::PipelineAction::Create,
-    LogStash::PipelineAction::Reload,
-    LogStash::PipelineAction::Stop
-  ]
+  ORDERING = {
+    LogStash::PipelineAction::Create => 100,
+    LogStash::PipelineAction::Reload => 200,
+    LogStash::PipelineAction::Stop => 300
+  }
 end end

--- a/logstash-core/lib/logstash/pipeline_action/base.rb
+++ b/logstash-core/lib/logstash/pipeline_action/base.rb
@@ -6,7 +6,6 @@
 # Some actions could be retryable, or have a delay or timeout.
 module LogStash module PipelineAction
   class Base
-
     # Only used for debugging purpose and in the logger statement.
     def inspect
       "#{self.class.name}/pipeline_id:#{pipeline_id}"
@@ -17,8 +16,13 @@ module LogStash module PipelineAction
       raise "`#execute` Not implemented!"
     end
 
+    # See the definition in `logstash/pipeline_action.rb` for the default ordering
+    def execution_priority
+      ORDERING.fetch(self.class)
+    end
+
     def <=>(other)
-      order = ORDERING.index(self.class) <=> ORDERING.index(other.class)
+      order = self.execution_priority <=> other.execution_priority
       order.nonzero? ? order : self.pipeline_id <=> other.pipeline_id
     end
   end

--- a/logstash-core/lib/logstash/pipeline_action/create.rb
+++ b/logstash-core/lib/logstash/pipeline_action/create.rb
@@ -21,6 +21,14 @@ module LogStash module PipelineAction
       @pipeline_config.pipeline_id
     end
 
+    # Make sure we execution system pipeline like the monitoring
+    # before any user defined pipelines, system pipeline register hooks into the system that will be
+    # triggered by the user defined pipeline.
+    def execution_priority
+      default_priority = super
+      @pipeline_config.system? ? default_priority * -1 : default_priority
+    end
+
     # The execute assume that the thread safety access of the pipeline
     # is managed by the caller.
     def execute(agent, pipelines)

--- a/logstash-core/spec/logstash/agent/converge_spec.rb
+++ b/logstash-core/spec/logstash/agent/converge_spec.rb
@@ -73,11 +73,11 @@ describe LogStash::Agent do
         end
       end
 
-      describe "#user_defined_pipelines" do
+      describe "#running_user_defined_pipelines" do
         it "returns the user defined pipelines" do
           agent_task = start_agent(subject)
-          expect(subject.user_defined_pipelines.keys).to include(:main)
-          expect(subject.user_defined_pipelines.keys).not_to include(:system_pipeline)
+          expect(subject.running_user_defined_pipelines.keys).to include(:main)
+          expect(subject.running_user_defined_pipelines.keys).not_to include(:system_pipeline)
           subject.shutdown
         end
       end

--- a/logstash-core/spec/logstash/agent/converge_spec.rb
+++ b/logstash-core/spec/logstash/agent/converge_spec.rb
@@ -73,7 +73,16 @@ describe LogStash::Agent do
         end
       end
 
-      context "#running_user_defined_pipelines?" do
+      describe "#user_defined_pipelines" do
+        it "returns the user defined pipelines" do
+          agent_task = start_agent(subject)
+          expect(subject.user_defined_pipelines.keys).to include(:main)
+          expect(subject.user_defined_pipelines.keys).not_to include(:system_pipeline)
+          subject.shutdown
+        end
+      end
+
+      describe "#running_user_defined_pipelines?" do
         it "returns true" do
           agent_task = start_agent(subject)
           expect(subject.running_user_defined_pipelines?).to be_truthy

--- a/logstash-core/spec/logstash/agent/converge_spec.rb
+++ b/logstash-core/spec/logstash/agent/converge_spec.rb
@@ -59,16 +59,6 @@ describe LogStash::Agent do
       end
     end
 
-    context "#running_user_defined_pipelines?" do
-      let(:finite_pipeline_config) { mock_pipeline_config(:main, "input { generator { count => 1 } } output { null {} }") }
-
-      it "returns false" do
-        agent_task = start_agent(subject)
-        expect(subject.running_user_defined_pipelines?).to be_falsey
-        subject.shutdown
-      end
-    end
-
     context "system pipeline" do
       let(:finite_pipeline_config) { mock_pipeline_config(:main, "input { generator { count => 1000 } } output { null {} }") }
       let(:system_pipeline_config) { mock_pipeline_config(:system_pipeline, "input { generator { } } output { null {} }", { "pipeline.system" => true }) }

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -111,7 +111,7 @@ describe LogStash::Agent do
 
       context "if state is clean" do
         before :each do
-          allow(subject).to receive(:running_pipelines?).and_return(true)
+          allow(subject).to receive(:running_user_defined_pipelines?).and_return(true)
           allow(subject).to receive(:clean_state?).and_return(false)
         end
 

--- a/logstash-core/spec/logstash/config/pipeline_config_spec.rb
+++ b/logstash-core/spec/logstash/config/pipeline_config_spec.rb
@@ -57,4 +57,20 @@ describe LogStash::Config::PipelineConfig do
     not_same_pipeline_id = described_class.new(source, :another_pipeline, unordered_config_parts, settings)
     expect(subject).not_to eq(not_same_pipeline_id)
   end
+
+  describe "#system?" do
+    context "when the pipeline is a system pipeline" do
+      let(:settings) { mock_settings({ "pipeline.system" => true })}
+
+      it "returns true if the pipeline is a system pipeline" do
+        expect(subject.system?).to be_truthy
+      end
+    end
+
+    context "when is not a system pipeline" do
+      it "returns false if the pipeline is not a system pipeline" do
+        expect(subject.system?).to be_falsey
+      end
+    end
+  end
 end

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -855,6 +855,26 @@ describe LogStash::Pipeline do
     end
   end
 
+  context "#system" do
+    after do
+      pipeline.close # close the queue
+    end
+
+    context "when the pipeline is a system pipeline" do
+      let(:pipeline) { LogStash::Pipeline.new("input { generator {} } output { null {} }", mock_settings("pipeline.system" => true)) }
+      it "returns true" do
+        expect(pipeline.system?).to be_truthy
+      end
+    end
+
+    context "when the pipeline is not a system pipeline" do
+      let(:pipeline) { LogStash::Pipeline.new("input { generator {} } output { null {} }", mock_settings("pipeline.system" => false)) }
+      it "returns true" do
+        expect(pipeline.system?).to be_falsey
+      end
+    end
+  end
+
   context "#reloadable?" do
     after do
       pipeline.close # close the queue


### PR DESCRIPTION
With the creation of the x-pack we have added our first internal
pipeline, but if you were running the monitoring pipeline with a
*finite* pipeline (LIKE generator count => X) when the finite has
completed processing all the events logstash would refuse to stop.

This PR fixes the problem by adding a new pipeline settings called
`system` in the shutdown loop we will check if all the user defined
pipeline are completed if its the case we will shutdown any internal
pipeline and logtash will stop gracefully.