### PR TITLE
Make the `load_average` test more robust by allowing to inject the content of the `load_average` file

### DIFF
--- a/logstash-core/lib/logstash/instrument/periodic_poller/load_average.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/load_average.rb
@@ -1,4 +1,6 @@
 # encoding: utf-8
+java_import "java.lang.management.ManagementFactory"
+
 module LogStash module Instrument module PeriodicPoller
   class LoadAverage
     class Windows
@@ -11,8 +13,8 @@ module LogStash module Instrument module PeriodicPoller
       LOAD_AVG_FILE = "/proc/loadavg"
       TOKEN_SEPARATOR = " "
 
-      def self.get
-        load_average = ::File.read(LOAD_AVG_FILE).chomp.split(TOKEN_SEPARATOR)
+      def self.get(content = ::File.read(LOAD_AVG_FILE))
+        load_average = content.chomp.split(TOKEN_SEPARATOR)
 
         {
           :"1m" => load_average[0].to_f,

--- a/logstash-core/spec/logstash/instrument/periodic_poller/load_average_spec.rb
+++ b/logstash-core/spec/logstash/instrument/periodic_poller/load_average_spec.rb
@@ -13,14 +13,10 @@ describe LogStash::Instrument::PeriodicPoller::LoadAverage do
       context "when it can read the file" do
         let(:proc_loadavg) { "0.00 0.01 0.05 3/180 29727" }
 
-        before do
-          expect(::File).to receive(:read).with("/proc/loadavg").and_return(proc_loadavg)
-        end
-
         it "return the 3 load average from `/proc/loadavg`" do
           avg_1m, avg_5m, avg_15m = proc_loadavg.chomp.split(" ")
 
-          expect(subject.get).to include(:"1m" => avg_1m.to_f, :"5m" => avg_5m.to_f, :"15m" => avg_15m.to_f)
+          expect(subject.get(proc_loadavg)).to include(:"1m" => avg_1m.to_f, :"5m" => avg_5m.to_f, :"15m" => avg_15m.to_f)
         end
       end
     end


### PR DESCRIPTION

Fixes: #6867