### PR TITLE
ExecutionContext for the plugins

### DIFF
--- a/logstash-core/lib/logstash/execution_context.rb
+++ b/logstash-core/lib/logstash/execution_context.rb
@@ -1,0 +1,10 @@
+# encoding: utf-8
+module LogStash
+  class ExecutionContext
+    attr_reader :pipeline_id
+
+    def initialize(pipeline_id)
+      @pipeline_id = pipeline_id
+    end
+  end
+end

--- a/logstash-core/lib/logstash/filter_delegator.rb
+++ b/logstash-core/lib/logstash/filter_delegator.rb
@@ -14,7 +14,7 @@ module LogStash
     ]
     def_delegators :@filter, *DELEGATED_METHODS
 
-    def initialize(logger, klass, metric, plugin_args)
+    def initialize(logger, klass, metric, execution_context, plugin_args)
       @logger = logger
       @klass = klass
       @id = plugin_args["id"]
@@ -23,6 +23,7 @@ module LogStash
       # Scope the metrics to the plugin
       namespaced_metric = metric.namespace(@id.to_sym)
       @filter.metric = namespaced_metric
+      @filter.execution_context = execution_context
 
       @metric_events = namespaced_metric.namespace(:events)
       namespaced_metric.gauge(:name, config_name)

--- a/logstash-core/lib/logstash/inputs/base.rb
+++ b/logstash-core/lib/logstash/inputs/base.rb
@@ -101,6 +101,14 @@ class LogStash::Inputs::Base < LogStash::Plugin
     cloned
   end
 
+  def execution_context=(context)
+    super
+    # There is no easy way to propage an instance variable into the codec, because the codec
+    # are created at the class level
+    @codec.execution_context = context
+    context
+  end
+
   protected
   def decorate(event)
     # Only set 'type' if not already set. This is backwards-compatible behavior

--- a/logstash-core/lib/logstash/output_delegator.rb
+++ b/logstash-core/lib/logstash/output_delegator.rb
@@ -7,7 +7,7 @@ require "logstash/output_delegator_strategies/legacy"
 module LogStash class OutputDelegator
   attr_reader :metric, :metric_events, :strategy, :namespaced_metric, :metric_events, :id
 
-  def initialize(logger, output_class, metric, strategy_registry, plugin_args)
+  def initialize(logger, output_class, metric, execution_context, strategy_registry, plugin_args)
     @logger = logger
     @output_class = output_class
     @metric = metric
@@ -18,7 +18,7 @@ module LogStash class OutputDelegator
     
     @strategy = strategy_registry.
                   class_for(self.concurrency).
-                  new(@logger, @output_class, @metric, plugin_args)
+                  new(@logger, @output_class, @metric, execution_context, plugin_args)
     
     @namespaced_metric = metric.namespace(id.to_sym)
     @namespaced_metric.gauge(:name, config_name)

--- a/logstash-core/lib/logstash/output_delegator_strategies/legacy.rb
+++ b/logstash-core/lib/logstash/output_delegator_strategies/legacy.rb
@@ -2,10 +2,13 @@
 module LogStash module OutputDelegatorStrategies class Legacy
   attr_reader :worker_count, :workers
   
-  def initialize(logger, klass, metric, plugin_args)
+  def initialize(logger, klass, metric, execution_context, plugin_args)
     @worker_count = (plugin_args["workers"] || 1).to_i
     @workers = @worker_count.times.map { klass.new(plugin_args) }
-    @workers.each {|w| w.metric = metric }
+    @workers.each do |w|
+      w.metric = metric
+      w.execution_context = execution_context
+    end
     @worker_queue = SizedQueue.new(@worker_count)
     @workers.each {|w| @worker_queue << w}
   end

--- a/logstash-core/lib/logstash/output_delegator_strategies/shared.rb
+++ b/logstash-core/lib/logstash/output_delegator_strategies/shared.rb
@@ -1,7 +1,8 @@
 module LogStash module OutputDelegatorStrategies class Shared
-  def initialize(logger, klass, metric, plugin_args)
+  def initialize(logger, klass, metric, execution_context, plugin_args)
     @output = klass.new(plugin_args)
     @output.metric = metric
+    @output.execution_context = execution_context
   end
   
   def register

--- a/logstash-core/lib/logstash/output_delegator_strategies/single.rb
+++ b/logstash-core/lib/logstash/output_delegator_strategies/single.rb
@@ -1,7 +1,8 @@
 module LogStash module OutputDelegatorStrategies class Single
-  def initialize(logger, klass, metric, plugin_args)
+  def initialize(logger, klass, metric, execution_context, plugin_args)
     @output = klass.new(plugin_args)
     @output.metric = metric
+    @output.execution_context = execution_context
     @mutex = Mutex.new
   end
 

--- a/logstash-core/lib/logstash/outputs/base.rb
+++ b/logstash-core/lib/logstash/outputs/base.rb
@@ -105,6 +105,14 @@ class LogStash::Outputs::Base < LogStash::Plugin
     self.class.concurrency
   end
 
+  def execution_context=(context)
+    super
+    # There is no easy way to propage an instance variable into the codec, because the codec
+    # are created at the class level
+    @codec.execution_context = context
+    context
+  end
+
   private
   def output?(event)
     # TODO: noop for now, remove this once we delete this call from all plugins

--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -8,7 +8,8 @@ require "securerandom"
 
 class LogStash::Plugin
   include LogStash::Util::Loggable
-  attr_accessor :params
+
+  attr_accessor :params, :execution_context
 
   NL = "\n"
 
@@ -122,6 +123,7 @@ class LogStash::Plugin
                          LogStash::Instrument::NamespacedNullMetric.new(@metric, :null)
                        end
   end
+
   # return the configured name of this plugin
   # @return [String] The name of the plugin defined by `config_name`
   def config_name

--- a/logstash-core/spec/logstash/execution_context_spec.rb
+++ b/logstash-core/spec/logstash/execution_context_spec.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+require "spec_helper"
+require "logstash/execution_context"
+
+describe LogStash::ExecutionContext do
+  let(:pipeline_id) { :main }
+
+  subject { described_class.new(pipeline_id) }
+
+  it "returns the `pipeline_id`" do
+    expect(subject.pipeline_id).to eq(pipeline_id)
+  end
+end

--- a/logstash-core/spec/logstash/filter_delegator_spec.rb
+++ b/logstash-core/spec/logstash/filter_delegator_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 require "logstash/filter_delegator"
 require "logstash/instrument/null_metric"
 require "logstash/event"
+require "logstash/execution_context"
 
 describe LogStash::FilterDelegator do
   let(:logger) { double(:logger) }
@@ -13,6 +14,7 @@ describe LogStash::FilterDelegator do
   let(:collector) { [] }
   let(:metric) { LogStash::Instrument::NamespacedNullMetric.new(collector, :null) }
   let(:events) { [LogStash::Event.new, LogStash::Event.new] }
+  let(:default_execution_context) { LogStash::ExecutionContext.new(:main) }
 
   before :each do
     allow(metric).to receive(:namespace).with(anything).and_return(metric)
@@ -26,11 +28,11 @@ describe LogStash::FilterDelegator do
     end
   end
 
-  subject { described_class.new(logger, plugin_klass, metric, config) }
+  subject { described_class.new(logger, plugin_klass, metric, default_execution_context, config) }
 
   it "create a plugin with the passed options" do
     expect(plugin_klass).to receive(:new).with(config).and_return(plugin_klass.new(config))
-    described_class.new(logger, plugin_klass, metric, config)
+    described_class.new(logger, plugin_klass, metric, default_execution_context, config)
   end
 
   context "when the plugin support flush" do

--- a/logstash-core/spec/logstash/inputs/base_spec.rb
+++ b/logstash-core/spec/logstash/inputs/base_spec.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 require "spec_helper"
+require "logstash/execution_context"
+require "logstash/inputs/base"
 
 # use a dummy NOOP input to test Inputs::Base
 class LogStash::Inputs::NOOP < LogStash::Inputs::Base
@@ -60,7 +62,28 @@ describe "LogStash::Inputs::Base#decorate" do
     expect(evt.get("field")).to eq(["value1","value2"])
     expect(evt.get("field2")).to eq("value")
   end
-  
+
+  context "execution context" do
+    let(:default_execution_context) { LogStash::ExecutionContext.new(:main) }
+    let(:klass) { LogStash::Inputs::NOOP }
+
+    subject(:instance) { klass.new({}) }
+
+    it "allow to set the context" do
+      expect(instance.execution_context).to be_nil
+      instance.execution_context = default_execution_context
+
+      expect(instance.execution_context).to eq(default_execution_context)
+    end
+
+    it "propagate the context to the codec" do
+      expect(instance.codec.execution_context).to be_nil
+      instance.execution_context = default_execution_context
+
+      expect(instance.codec.execution_context).to eq(default_execution_context)
+    end
+  end
+
   describe "cloning" do
     let(:input) do
       LogStash::Inputs::NOOP.new("add_field" => {"field" => ["value1", "value2"], "field2" => "value"})

--- a/logstash-core/spec/logstash/output_delegator_spec.rb
+++ b/logstash-core/spec/logstash/output_delegator_spec.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/output_delegator"
-require 'spec_helper'
+require "logstash/execution_context"
+require "spec_helper"
 
 describe LogStash::OutputDelegator do
   let(:logger) { double("logger") }
@@ -8,8 +9,9 @@ describe LogStash::OutputDelegator do
   let(:plugin_args) { {"id" => "foo", "arg1" => "val1"} }
   let(:collector) { [] }
   let(:metric) { LogStash::Instrument::NamespacedNullMetric.new(collector, :null) }
+  let(:default_execution_context) { LogStash::ExecutionContext.new(:main) }
 
-  subject { described_class.new(logger, out_klass, metric, ::LogStash::OutputDelegatorStrategyRegistry.instance, plugin_args) }
+  subject { described_class.new(logger, out_klass, metric, default_execution_context, ::LogStash::OutputDelegatorStrategyRegistry.instance, plugin_args) }
 
   context "with a plain output plugin" do
     let(:out_klass) { double("output klass") }
@@ -27,6 +29,7 @@ describe LogStash::OutputDelegator do
       allow(out_inst).to receive(:register)
       allow(out_inst).to receive(:multi_receive)
       allow(out_inst).to receive(:metric=).with(any_args)
+      allow(out_inst).to receive(:execution_context=).with(default_execution_context)
       allow(out_inst).to receive(:id).and_return("a-simple-plugin")
 
       allow(subject.metric_events).to receive(:increment).with(any_args)
@@ -39,7 +42,7 @@ describe LogStash::OutputDelegator do
 
     it "should push the name of the plugin to the metric" do
       expect(metric).to receive(:gauge).with(:name, out_klass.config_name)
-      described_class.new(logger, out_klass, metric, ::LogStash::OutputDelegatorStrategyRegistry.instance, plugin_args)
+      described_class.new(logger, out_klass, metric, default_execution_context, ::LogStash::OutputDelegatorStrategyRegistry.instance, plugin_args)
     end
 
     context "after having received a batch of events" do

--- a/logstash-core/spec/logstash/outputs/base_spec.rb
+++ b/logstash-core/spec/logstash/outputs/base_spec.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 require "spec_helper"
+require "logstash/outputs/base"
+require "logstash/execution_context"
 
 # use a dummy NOOP output to test Outputs::Base
 class LogStash::Outputs::NOOPSingle < LogStash::Outputs::Base
@@ -74,6 +76,27 @@ describe "LogStash::Outputs::Base#new" do
 
     it "should default concurrency to :legacy" do
       expect(subject.concurrency).to eq(:legacy)
+    end
+  end
+
+  context "execution context" do
+    let(:default_execution_context) { LogStash::ExecutionContext.new(:main) }
+    let(:klass) { LogStash::Outputs::NOOPSingle }
+
+    subject(:instance) { klass.new(params.dup) }
+
+    it "allow to set the context" do
+      expect(instance.execution_context).to be_nil
+      instance.execution_context = default_execution_context
+
+      expect(instance.execution_context).to eq(default_execution_context)
+    end
+
+    it "propagate the context to the codec" do
+      expect(instance.codec.execution_context).to be_nil
+      instance.execution_context = default_execution_context
+
+      expect(instance.codec.execution_context).to eq(default_execution_context)
     end
   end
 

--- a/logstash-core/spec/logstash/plugin_spec.rb
+++ b/logstash-core/spec/logstash/plugin_spec.rb
@@ -5,6 +5,7 @@ require "logstash/outputs/base"
 require "logstash/codecs/base"
 require "logstash/inputs/base"
 require "logstash/filters/base"
+require "logstash/execution_context"
 
 describe LogStash::Plugin do
   context "reloadable" do
@@ -39,6 +40,17 @@ describe LogStash::Plugin do
       it "makes #reloadable? return true" do
         expect(subject.new({}).reloadable?).to be_falsey
       end
+    end
+  end
+
+  context "#execution_context" do
+    subject { Class.new(LogStash::Plugin).new({}) }
+
+    it "can be set and get" do
+      expect(subject.execution_context).to be_nil
+      execution_context = LogStash::ExecutionContext.new(:main)
+      subject.execution_context = execution_context
+      expect(subject.execution_context).to eq(execution_context)
     end
   end
 


### PR DESCRIPTION
This PR add the initial building block to pass some `ExecutionContext`
from the pipeline to the plugin, currently we only pass the `pipeline_id`.

We use the accessor `execution_context=` to set the context, in a future
refactor we will pass the object to the constructor.

The context is available in the inputs, filter, output and codecs.