### PR TITLE
Missing require 'execution_context' in the backport

### DIFF
--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -21,6 +21,7 @@ require "logstash/instrument/wrapped_write_client"
 require "logstash/output_delegator"
 require "logstash/filter_delegator"
 require "logstash/queue_factory"
+require "logstash/execution_context"
 
 module LogStash; class BasePipeline
   include LogStash::Util::Loggable


### PR DESCRIPTION
Missing require in https://github.com/elastic/logstash/commit/2dd135a1623f07bab1b3d6a84fdb6bce825dec85

Fixes: https://github.com/elastic/logstash/issues/6896