### PR TITLE
Update the rake version:sync to ignore logstash-core-event

### DIFF
--- a/rakelib/version.rake
+++ b/rakelib/version.rake
@@ -13,11 +13,6 @@ def get_versions
       "yaml_version" => yaml_versions["logstash-core"],
       "current_version" => get_version(File.join("logstash-core", "lib", "logstash-core", "version.rb")),
     },
-    "logstash-core-event" => {
-      "location" => File.join("logstash-core-event", "lib", "logstash-core-event", "version.rb"),
-      "yaml_version" => yaml_versions["logstash-core-event"],
-      "current_version" => get_version(File.join("logstash-core-event", "lib", "logstash-core-event", "version.rb")),
-    },
     "logstash-core-plugin-api" => {
       "location" => File.join("logstash-core-plugin-api", "lib", "logstash-core-plugin-api", "version.rb"),
       "yaml_version" => yaml_versions["logstash-core-plugin-api"],


### PR DESCRIPTION
With the gem refactoring we don't build the logstash-core-event anymore