### PR TITLE
add config name metric to input plugins

### DIFF
--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -105,6 +105,7 @@ module LogStash; class BasePipeline
     else # input
       input_plugin = klass.new(args)
       input_plugin.metric = type_scoped_metric.namespace(id)
+      input_plugin.metric.gauge(:type, input_plugin.config_name)
       input_plugin.execution_context = @execution_context
       input_plugin
     end


### PR DESCRIPTION
currently input plugins don't set their own config_name metric value, resulting in metric documents like below:

```
% curl -s localhost:9600/_node/stats | jq ".pipeline.plugins.inputs"
[
  {
    "id": "88fd96b845d7b241ee7308afcf9999a32e1ddf0f-1",
    "current_connections": 0,
    "peak_connections": 3
  }
]
```

With this PR the config_name of the plugin is set as a gauge, thus resulting in:

```
% curl -s localhost:9600/_node/stats | jq ".pipeline.plugins.inputs"
[
  {
    "id": "88fd96b845d7b241ee7308afcf9999a32e1ddf0f-1",
    "type": "beats",
    "current_connections": 0,
    "peak_connections": 3
  }
]
```

see more about this in https://github.com/logstash-plugins/logstash-input-beats/pull/200#issuecomment-293894038