### PR TITLE
Replace the internal list of listeners with a set

### DIFF
--- a/logstash-core/lib/logstash/event_dispatcher.rb
+++ b/logstash-core/lib/logstash/event_dispatcher.rb
@@ -1,13 +1,13 @@
 # encoding: utf-8
 module LogStash
   class EventDispatcher
-    java_import "java.util.concurrent.CopyOnWriteArrayList"
+    java_import "java.util.concurrent.CopyOnWriteArraySet"
 
     attr_reader :emitter
 
     def initialize(emitter)
       @emitter = emitter
-      @listeners = CopyOnWriteArrayList.new
+      @listeners = CopyOnWriteArraySet.new
     end
 
     # This operation is slow because we use a CopyOnWriteArrayList

--- a/logstash-core/spec/logstash/event_dispatcher_spec.rb
+++ b/logstash-core/spec/logstash/event_dispatcher_spec.rb
@@ -34,6 +34,13 @@ describe LogStash::EventDispatcher do
   let(:listener) { CustomSpy }
   subject(:emitter) { DummyEmitter.new }
 
+  it "ignores duplicate listener" do
+    emitter.dispatcher.add_listener(listener)
+    emitter.dispatcher.add_listener(listener)
+    expect(listener).to receive(:method_exists).with(emitter).once
+    emitter.method_exists
+  end
+
   describe "Emits events" do
     before do
       emitter.dispatcher.add_listener(listener)


### PR DESCRIPTION
Because we sync listeners with emitters when adding or creating hook
this could lead to duplicates of listeners, this PR fixes the problem by using a set
instead of a list. Making sure we can only have one instance of a specific
listener at any time.

**More details**

We have to sync the emitters and the listeners on multiples configuration call on the hook registry because plugins can register hooks for classes that don't have a concrete instance created yet.

This problem was found when moving the x-pack to use the new #6632 PR, it was creating multiple `SourceLoader` that were returning the same configuration.