### PR TITLE
Queue: fix unlock mutex on close()

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -644,8 +644,9 @@ public class Queue implements Closeable {
                 } catch (IOException e) {
                     // log error and ignore
                     logger.error("Queue close releaseLock failed, error={}", e.getMessage());
+                } finally {
+                    lock.unlock();
                 }
-                lock.unlock();
             }
         }
     }


### PR DESCRIPTION
On o.l.ackedqueue.Queue#close() method the
lock.unlock() call might not execute, leaving
a mutex locked.

This change ensure that lock.unlock() is always
execute by moving its call to the sibling
try/catch's finally block.