### PR TITLE
Unset JAVACMD by default

### DIFF
--- a/config/startup.options
+++ b/config/startup.options
@@ -9,7 +9,7 @@
 ################################################################################
 
 # Override Java location
-JAVACMD=/usr/bin/java
+#JAVACMD=/usr/bin/java
 
 # Set a home directory
 LS_HOME=/usr/share/logstash


### PR DESCRIPTION
In most cases, this will probably work out, but it will need some testing.

JRuby and `logstash.lib.sh` both check first for the presence of `JAVACMD`. If that isn't found, it tries `$JAVA_HOME/bin/java`. If that isn't found, it tries `java` in the system $PATH.

The previous behavior was to manually assign `JAVACMD=/usr/bin/java`.  This will still work for most users.  Special cases will still need manual configuration, but this will _probably_ work better for most cases in the long run.