### PR TITLE
Make pipeline and agent available through execution context

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -298,7 +298,7 @@ class LogStash::Agent
       # that we currently have.
       begin
         logger.debug("Executing action", :action => action)
-        action_result = action.execute(@pipelines)
+        action_result = action.execute(self, @pipelines)
         converge_result.add(action, action_result)
 
         unless action_result.successful?

--- a/logstash-core/lib/logstash/compiler/lscl.rb
+++ b/logstash-core/lib/logstash/compiler/lscl.rb
@@ -171,7 +171,7 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
   
   class String < Value
     def expr
-      jdsl.eValue(source_meta, text_value[1...-1])
+      jdsl.e_value(source_meta, text_value[1...-1])
     end
   end
   

--- a/logstash-core/lib/logstash/execution_context.rb
+++ b/logstash-core/lib/logstash/execution_context.rb
@@ -1,10 +1,15 @@
 # encoding: utf-8
 module LogStash
   class ExecutionContext
-    attr_reader :pipeline_id
+    attr_reader :pipeline, :agent
 
-    def initialize(pipeline_id)
-      @pipeline_id = pipeline_id
+    def initialize(pipeline, agent)
+      @pipeline = pipeline
+      @agent = agent
+    end
+    
+    def pipeline_id
+      @pipeline.pipeline_id
     end
   end
 end

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -27,9 +27,9 @@ require "logstash/execution_context"
 module LogStash; class BasePipeline
   include LogStash::Util::Loggable
 
-  attr_reader :settings, :config_str, :config_hash, :inputs, :filters, :outputs, :pipeline_id, :lir
+  attr_reader :settings, :config_str, :config_hash, :inputs, :filters, :outputs, :pipeline_id, :lir, :execution_context
 
-  def initialize(config_str, settings = SETTINGS, namespaced_metric = nil)
+  def initialize(config_str, settings = SETTINGS, namespaced_metric = nil, agent = nil)
     @logger = self.logger
 
     @config_str = config_str
@@ -49,7 +49,7 @@ module LogStash; class BasePipeline
     @inputs = nil
     @filters = nil
     @outputs = nil
-    @execution_context = LogStash::ExecutionContext.new(@pipeline_id)
+    @execution_context = LogStash::ExecutionContext.new(self, agent)
 
     grammar = LogStashConfigParser.new
     parsed_config = grammar.parse(config_str)
@@ -147,7 +147,7 @@ module LogStash; class Pipeline < BasePipeline
 
   MAX_INFLIGHT_WARN_THRESHOLD = 10_000
 
-  def initialize(config_str, settings = SETTINGS, namespaced_metric = nil)
+  def initialize(config_str, settings = SETTINGS, namespaced_metric = nil, agent = nil)
     # This needs to be configured before we call super which will evaluate the code to make
     # sure the metric instance is correctly send to the plugins to make the namespace scoping work
     @metric = if namespaced_metric
@@ -160,7 +160,7 @@ module LogStash; class Pipeline < BasePipeline
     @reporter = PipelineReporter.new(@logger, self)
     @worker_threads = []
 
-    super(config_str, settings)
+    super
 
     begin
       @queue = LogStash::QueueFactory.create(settings)

--- a/logstash-core/lib/logstash/pipeline_action/base.rb
+++ b/logstash-core/lib/logstash/pipeline_action/base.rb
@@ -13,7 +13,7 @@ module LogStash module PipelineAction
     end
     alias_method :to_s, :inspect
 
-    def execute(pipelines)
+    def execute(agent, pipelines)
       raise "`#execute` Not implemented!"
     end
 

--- a/logstash-core/lib/logstash/pipeline_action/create.rb
+++ b/logstash-core/lib/logstash/pipeline_action/create.rb
@@ -23,9 +23,9 @@ module LogStash module PipelineAction
 
     # The execute assume that the thread safety access of the pipeline
     # is managed by the caller.
-    def execute(pipelines)
-      pipeline = create_pipeline
-
+    def execute(agent, pipelines)
+      pipeline = LogStash::Pipeline.new(@pipeline_config.config_string, @pipeline_config.settings, @metric, agent)
+      
       status = pipeline.start # block until the pipeline is correctly started or crashed
 
       if status
@@ -35,8 +35,5 @@ module LogStash module PipelineAction
       LogStash::ConvergeResult::ActionResult.create(self, status)
     end
 
-    def create_pipeline
-      LogStash::Pipeline.new(@pipeline_config.config_string, @pipeline_config.settings, @metric)
-    end
   end
 end end

--- a/logstash-core/lib/logstash/pipeline_action/reload.rb
+++ b/logstash-core/lib/logstash/pipeline_action/reload.rb
@@ -19,7 +19,7 @@ module LogStash module PipelineAction
       @pipeline_config.pipeline_id
     end
 
-    def execute(pipelines)
+    def execute(agent, pipelines)
       old_pipeline = pipelines[pipeline_id]
 
       if !old_pipeline.reloadable?
@@ -36,10 +36,10 @@ module LogStash module PipelineAction
         return LogStash::ConvergeResult::FailedAction.new("Cannot reload pipeline, because the new pipeline is not reloadable")
       end
 
-      status = Stop.new(pipeline_id).execute(pipelines)
+      status = Stop.new(pipeline_id).execute(agent, pipelines)
 
       if status
-        return Create.new(@pipeline_config, @metric).execute(pipelines)
+        return Create.new(@pipeline_config, @metric).execute(agent, pipelines)
       else
         return status
       end

--- a/logstash-core/lib/logstash/pipeline_action/stop.rb
+++ b/logstash-core/lib/logstash/pipeline_action/stop.rb
@@ -11,7 +11,7 @@ module LogStash module PipelineAction
       @pipeline_id = pipeline_id
     end
 
-    def execute(pipelines)
+    def execute(agent, pipelines)
       pipeline = pipelines[pipeline_id]
       pipeline.shutdown { LogStash::ShutdownWatcher.start(pipeline) }
       pipelines.delete(pipeline_id)

--- a/logstash-core/spec/logstash/agent/converge_spec.rb
+++ b/logstash-core/spec/logstash/agent/converge_spec.rb
@@ -26,6 +26,18 @@ describe LogStash::Agent do
     expect(converge_result).to be_a_successful_converge
   end
 
+
+  describe "passing the agent to the pipeline" do
+    let(:source_loader) { TestSourceLoader.new(pipeline_config) }
+    let(:pipeline_config) { mock_pipeline_config(:main, "input { generator { count => 10 } } output { null {} }") }
+      
+    before { subject.execute }
+
+    it "execute the pipeline and stop execution" do
+      expect(subject.get_pipeline(:main).execution_context.agent).to eq(subject)
+    end
+  end
+
   context "Agent execute options" do
     let(:source_loader) do
       TestSourceLoader.new(finite_pipeline_config)

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -279,7 +279,7 @@ describe LogStash::Agent do
             sleep(0.05) until subject.running_pipelines? && subject.pipelines.values.first.running?
 
             File.open(config_file, "w") { |f| f.puts second_pipeline_config }
-            sleep(0.2) # lets us catch the new file
+            sleep(5) # lets us catch the new file
 
             try do
               expect(subject.pipelines[default_pipeline_id.to_sym]).not_to be_nil

--- a/logstash-core/spec/logstash/execution_context_spec.rb
+++ b/logstash-core/spec/logstash/execution_context_spec.rb
@@ -3,11 +3,26 @@ require "spec_helper"
 require "logstash/execution_context"
 
 describe LogStash::ExecutionContext do
+  let(:pipeline) { double("pipeline") }
   let(:pipeline_id) { :main }
+  let(:agent) { double("agent") }
+  
+  before do
+    allow(pipeline).to receive(:agent).and_return(agent)
+    allow(pipeline).to receive(:pipeline_id).and_return(pipeline_id)
+  end
 
-  subject { described_class.new(pipeline_id) }
+  subject { described_class.new(pipeline, agent) }
 
   it "returns the `pipeline_id`" do
     expect(subject.pipeline_id).to eq(pipeline_id)
+  end
+  
+  it "returns the pipeline" do
+    expect(subject.pipeline).to eq(pipeline)
+  end
+  
+  it "returns the agent" do
+    expect(subject.agent).to eq(agent)
   end
 end

--- a/logstash-core/spec/logstash/filter_delegator_spec.rb
+++ b/logstash-core/spec/logstash/filter_delegator_spec.rb
@@ -4,8 +4,11 @@ require "logstash/filter_delegator"
 require "logstash/instrument/null_metric"
 require "logstash/event"
 require "logstash/execution_context"
+require "support/shared_contexts"
 
 describe LogStash::FilterDelegator do
+  include_context "execution_context"
+  
   let(:logger) { double(:logger) }
   let(:filter_id) { "my-filter" }
   let(:config) do
@@ -14,9 +17,9 @@ describe LogStash::FilterDelegator do
   let(:collector) { [] }
   let(:metric) { LogStash::Instrument::NamespacedNullMetric.new(collector, :null) }
   let(:events) { [LogStash::Event.new, LogStash::Event.new] }
-  let(:default_execution_context) { LogStash::ExecutionContext.new(:main) }
 
   before :each do
+    allow(pipeline).to receive(:id).and_return(pipeline_id)
     allow(metric).to receive(:namespace).with(anything).and_return(metric)
   end
 
@@ -28,11 +31,11 @@ describe LogStash::FilterDelegator do
     end
   end
 
-  subject { described_class.new(logger, plugin_klass, metric, default_execution_context, config) }
+  subject { described_class.new(logger, plugin_klass, metric, execution_context, config) }
 
   it "create a plugin with the passed options" do
     expect(plugin_klass).to receive(:new).with(config).and_return(plugin_klass.new(config))
-    described_class.new(logger, plugin_klass, metric, default_execution_context, config)
+    described_class.new(logger, plugin_klass, metric, execution_context, config)
   end
 
   context "when the plugin support flush" do

--- a/logstash-core/spec/logstash/inputs/base_spec.rb
+++ b/logstash-core/spec/logstash/inputs/base_spec.rb
@@ -2,6 +2,7 @@
 require "spec_helper"
 require "logstash/execution_context"
 require "logstash/inputs/base"
+require "support/shared_contexts"
 
 # use a dummy NOOP input to test Inputs::Base
 class LogStash::Inputs::NOOP < LogStash::Inputs::Base
@@ -64,23 +65,24 @@ describe "LogStash::Inputs::Base#decorate" do
   end
 
   context "execution context" do
-    let(:default_execution_context) { LogStash::ExecutionContext.new(:main) }
+    include_context "execution_context"
+    
     let(:klass) { LogStash::Inputs::NOOP }
 
     subject(:instance) { klass.new({}) }
 
     it "allow to set the context" do
       expect(instance.execution_context).to be_nil
-      instance.execution_context = default_execution_context
+      instance.execution_context = execution_context
 
-      expect(instance.execution_context).to eq(default_execution_context)
+      expect(instance.execution_context).to eq(execution_context)
     end
 
     it "propagate the context to the codec" do
       expect(instance.codec.execution_context).to be_nil
-      instance.execution_context = default_execution_context
+      instance.execution_context = execution_context
 
-      expect(instance.codec.execution_context).to eq(default_execution_context)
+      expect(instance.codec.execution_context).to eq(execution_context)
     end
   end
 

--- a/logstash-core/spec/logstash/outputs/base_spec.rb
+++ b/logstash-core/spec/logstash/outputs/base_spec.rb
@@ -2,6 +2,7 @@
 require "spec_helper"
 require "logstash/outputs/base"
 require "logstash/execution_context"
+require "support/shared_contexts"
 
 # use a dummy NOOP output to test Outputs::Base
 class LogStash::Outputs::NOOPSingle < LogStash::Outputs::Base
@@ -80,23 +81,24 @@ describe "LogStash::Outputs::Base#new" do
   end
 
   context "execution context" do
-    let(:default_execution_context) { LogStash::ExecutionContext.new(:main) }
+    include_context "execution_context"
+    
     let(:klass) { LogStash::Outputs::NOOPSingle }
 
     subject(:instance) { klass.new(params.dup) }
 
     it "allow to set the context" do
       expect(instance.execution_context).to be_nil
-      instance.execution_context = default_execution_context
+      instance.execution_context = execution_context
 
-      expect(instance.execution_context).to eq(default_execution_context)
+      expect(instance.execution_context).to eq(execution_context)
     end
 
     it "propagate the context to the codec" do
       expect(instance.codec.execution_context).to be_nil
-      instance.execution_context = default_execution_context
+      instance.execution_context = execution_context
 
-      expect(instance.codec.execution_context).to eq(default_execution_context)
+      expect(instance.codec.execution_context).to eq(execution_context)
     end
   end
 

--- a/logstash-core/spec/logstash/pipeline_action/create_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_action/create_spec.rb
@@ -9,6 +9,7 @@ describe LogStash::PipelineAction::Create do
   let(:metric) { LogStash::Instrument::NullMetric.new(LogStash::Instrument::Collector.new) }
   let(:pipeline_config) { mock_pipeline_config(:main, "input { generator { id => '123' } } output { null {} }") }
   let(:pipelines) {  Hash.new }
+  let(:agent) { double("agent") }
 
   before do
     clear_data_dir
@@ -29,22 +30,22 @@ describe LogStash::PipelineAction::Create do
     let(:pipeline_config) { mock_pipeline_config(:main, "input { generator { count => 1 } } output { null {} }") }
 
     it "returns a successful execution status" do
-      expect(subject.execute(pipelines)).to be_truthy
+      expect(subject.execute(agent, pipelines)).to be_truthy
     end
   end
 
   context "when the pipeline succesfully start" do
     it "adds the pipeline to the current pipelines" do
-      expect { subject.execute(pipelines) }.to change(pipelines, :size).by(1)
+      expect { subject.execute(agent, pipelines) }.to change(pipelines, :size).by(1)
     end
 
     it "starts the pipeline" do
-      subject.execute(pipelines)
+      subject.execute(agent, pipelines)
       expect(pipelines[:main].running?).to be_truthy
     end
 
     it "returns a successful execution status" do
-      expect(subject.execute(pipelines)).to be_truthy
+      expect(subject.execute(agent, pipelines)).to be_truthy
     end
   end
 
@@ -53,7 +54,7 @@ describe LogStash::PipelineAction::Create do
       let(:pipeline_config) { mock_pipeline_config(:main, "input { generator { id => '123' } } output { stdout ") } # bad syntax
 
       it "raises the exception upstream" do
-        expect { subject.execute(pipelines) }.to raise_error
+        expect { subject.execute(agent, pipelines) }.to raise_error
       end
     end
 
@@ -61,7 +62,7 @@ describe LogStash::PipelineAction::Create do
       let(:pipeline_config) { mock_pipeline_config(:main, "input { generator { id => '123' } } filter { ruby { init => '1/0' code => '1+2' } } output { null {} }") }
 
       it "returns false" do
-        expect(subject.execute(pipelines)).not_to be_a_successful_action
+        expect(subject.execute(agent, pipelines)).not_to be_a_successful_action
       end
     end
   end

--- a/logstash-core/spec/logstash/pipeline_action/reload_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_action/reload_spec.rb
@@ -12,6 +12,7 @@ describe LogStash::PipelineAction::Reload do
   let(:pipeline_config) { "input { generator {} } output { null {} }" }
   let(:pipeline) { LogStash::Pipeline.new(pipeline_config, mock_settings("pipeline.reloadable" => true)) }
   let(:pipelines) { { pipeline_id => pipeline } }
+  let(:agent) { double("agent") }
 
   subject { described_class.new(new_pipeline_config, metric) }
 
@@ -30,16 +31,16 @@ describe LogStash::PipelineAction::Reload do
 
   context "when existing pipeline and new pipeline are both reloadable" do
     it "stop the previous pipeline" do
-      expect { subject.execute(pipelines) }.to change(pipeline, :running?).from(true).to(false)
+      expect { subject.execute(agent, pipelines) }.to change(pipeline, :running?).from(true).to(false)
     end
 
     it "start the new pipeline" do
-      subject.execute(pipelines)
+      subject.execute(agent, pipelines)
       expect(pipelines[pipeline_id].running?).to be_truthy
     end
 
     it "run the new pipeline code" do
-      subject.execute(pipelines)
+      subject.execute(agent, pipelines)
       expect(pipelines[pipeline_id].config_hash).to eq(new_pipeline_config.config_hash)
     end
   end
@@ -50,7 +51,7 @@ describe LogStash::PipelineAction::Reload do
     end
 
     it "cannot successfully execute the action" do
-      expect(subject.execute(pipelines)).not_to be_a_successful_action
+      expect(subject.execute(agent, pipelines)).not_to be_a_successful_action
     end
   end
 
@@ -58,7 +59,7 @@ describe LogStash::PipelineAction::Reload do
     let(:new_pipeline_config) { mock_pipeline_config(pipeline_id, "input { generator { id => 'new' } } output { null {} }", { "pipeline.reloadable" => false}) }
 
     it "cannot successfully execute the action" do
-      expect(subject.execute(pipelines)).not_to be_a_successful_action
+      expect(subject.execute(agent, pipelines)).not_to be_a_successful_action
     end
   end
 
@@ -66,7 +67,7 @@ describe LogStash::PipelineAction::Reload do
     let(:new_pipeline_config) { mock_pipeline_config(pipeline_id, "input generator { id => 'new' } } output { null {} }", { "pipeline.reloadable" => false}) }
 
     it "cannot successfully execute the action" do
-      expect(subject.execute(pipelines)).not_to be_a_successful_action
+      expect(subject.execute(agent, pipelines)).not_to be_a_successful_action
     end
   end
 
@@ -76,7 +77,7 @@ describe LogStash::PipelineAction::Reload do
     end
 
     it "cannot successfully execute the action" do
-      expect(subject.execute(pipelines)).not_to be_a_successful_action
+      expect(subject.execute(agent, pipelines)).not_to be_a_successful_action
     end
   end
 end

--- a/logstash-core/spec/logstash/pipeline_action/stop_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_action/stop_spec.rb
@@ -10,6 +10,7 @@ describe LogStash::PipelineAction::Stop do
   let(:pipeline_id) { :main }
   let(:pipeline) { LogStash::Pipeline.new(pipeline_config) }
   let(:pipelines) { { :main => pipeline } }
+  let(:agent) { double("agent") }
 
   subject { described_class.new(pipeline_id) }
 
@@ -27,10 +28,10 @@ describe LogStash::PipelineAction::Stop do
   end
 
   it "shutdown the running pipeline" do
-    expect { subject.execute(pipelines) }.to change(pipeline, :running?).from(true).to(false)
+    expect { subject.execute(agent, pipelines) }.to change(pipeline, :running?).from(true).to(false)
   end
 
   it "removes the pipeline from the running pipelines" do
-    expect { subject.execute(pipelines) }.to change { pipelines.include?(pipeline_id) }.from(true).to(false)
+    expect { subject.execute(agent, pipelines) }.to change { pipelines.include?(pipeline_id) }.from(true).to(false)
   end
 end

--- a/logstash-core/spec/logstash/plugin_spec.rb
+++ b/logstash-core/spec/logstash/plugin_spec.rb
@@ -6,6 +6,7 @@ require "logstash/codecs/base"
 require "logstash/inputs/base"
 require "logstash/filters/base"
 require "logstash/execution_context"
+require "support/shared_contexts"
 
 describe LogStash::Plugin do
   context "reloadable" do
@@ -45,10 +46,10 @@ describe LogStash::Plugin do
 
   context "#execution_context" do
     subject { Class.new(LogStash::Plugin).new({}) }
+    include_context "execution_context"
 
     it "can be set and get" do
       expect(subject.execution_context).to be_nil
-      execution_context = LogStash::ExecutionContext.new(:main)
       subject.execution_context = execution_context
       expect(subject.execution_context).to eq(execution_context)
     end

--- a/logstash-core/spec/support/shared_contexts.rb
+++ b/logstash-core/spec/support/shared_contexts.rb
@@ -1,0 +1,13 @@
+shared_context "execution_context" do
+  let(:pipeline) { double("pipeline") }
+  let(:pipeline_id) { :main }
+  let(:agent) { double("agent") }
+  let(:execution_context) do
+    ::LogStash::ExecutionContext.new(pipeline, agent)
+  end
+  
+  before do
+    allow(pipeline).to receive(:pipeline_id).and_return(pipeline_id)
+    allow(pipeline).to receive(:agent).and_return(agent)
+  end
+end

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -2,6 +2,7 @@
 # most common CI systems can not know whats up with this tests.
 
 require "pluginmanager/util"
+require 'pathname'
 
 namespace "test" do
 
@@ -21,6 +22,12 @@ namespace "test" do
     LogStash::Bundler.setup!({:without => [:build]})
     require "logstash-core"
 
+    # Aligns behavior with bin/rspec command here
+    $LOAD_PATH << Pathname.new(File.join(File.dirname(__FILE__), "..", "logstash-core", "spec")).
+      cleanpath.
+      expand_path.
+      to_s
+    
     require "rspec/core/runner"
     require "rspec"
     require 'ci/reporter/rake/rspec_loader'


### PR DESCRIPTION
This will let plugins inquire about stuff to the agent directly without using singletons.