### PR TITLE
add config_name to input plugin metrics

### DIFF
--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -96,7 +96,9 @@ module LogStash; class BasePipeline
       FilterDelegator.new(@logger, klass, type_scoped_metric, @execution_context, args)
     else # input
       input_plugin = klass.new(args)
-      input_plugin.metric = type_scoped_metric.namespace(id)
+      scoped_metric = type_scoped_metric.namespace(id.to_sym)
+      scoped_metric.gauge(:name, input_plugin.config_name)
+      input_plugin.metric = scoped_metric
       input_plugin.execution_context = @execution_context
       input_plugin
     end


### PR DESCRIPTION
replaces https://github.com/elastic/logstash/pull/6915 since the problem is fixed in master.
This PR targets the 5.x line.