### PR TITLE
Make ci_integration.sh use bash.

### DIFF
--- a/ci/ci_integration.sh
+++ b/ci/ci_integration.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 # Since we are using the system jruby, we need to make sure our jvm process


### PR DESCRIPTION
The ci_integration.sh script uses double brackets ('[[') test
which is not portable. For instance, running it with dash you
get the error:

./ci/ci_integration.sh: 10: ./ci/ci_integration.sh: [[: not found

This change makes the script use bash, that supports this kind
of test.