### PR TITLE
Make the relative path more obvious

### DIFF
--- a/logstash-core/spec/logstash/config/source/local_spec.rb
+++ b/logstash-core/spec/logstash/config/source/local_spec.rb
@@ -57,10 +57,12 @@ describe LogStash::Config::Source::Local::ConfigPathLoader do
       let(:directory) { Stud::Temporary.pathname }
 
       before do
-        files.keys.shuffle.each do |file|
-          content = files[file]
+        files.each do |file, content|
           temporary_file(content, file, directory)
         end
+
+        expect(files.size).to be >= 1
+        expect(Dir.glob(::File.join(directory, "*")).size).to eq(files.size)
       end
 
       it "returns a `config_parts` per file" do
@@ -208,14 +210,14 @@ describe LogStash::Config::Source::Local::ConfigPathLoader do
 
     context "relative path" do
       let(:reader_config) do
-        current = Pathname.new(::File.dirname(__FILE__))
-        target = Pathname.new(::File.join(directory, files.keys.first))
-        target.relative_path_from(current).to_s
+        FileUtils.mkdir_p(::File.join(directory, "inside"))
+        ::File.join(directory, "inside", "../")
       end
 
       let(:files) {
         {
-          "config1.conf" => "input1",
+          "config2.conf" => "input1",
+          "config1.conf" => "input2",
         }
       }
 


### PR DESCRIPTION
I've changed the relative path used in the test, I am using a relative
path that I can more easily control and doesn't have 10 level of nested
directories, I think it was confusing when ran in on our linux ci.

I also added an assert in the `before` to make sure we generate the
right number of configuration in the example.

Ref: #6935