### PR TITLE
[WIP] Change the `#wait_for_logstash` assert

### DIFF
--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -1,12 +1,15 @@
 require_relative "monitoring_api"
-
 require "childprocess"
 require "bundler"
 require "tempfile"
-require 'yaml'
+require "yaml"
+require "json"
+require "net/http"
+require "uri"
 
 # A locally started Logstash service
 class LogstashService < Service
+  API_URL = "http://localhost:9600/"
 
   LS_ROOT_DIR = File.join("..", "..", "..", "..")
   LS_VERSION_FILE = File.expand_path(File.join(LS_ROOT_DIR, "versions.yml"), __FILE__)
@@ -16,10 +19,10 @@ class LogstashService < Service
   SETTINGS_CLI_FLAG = "--path.settings"
 
   STDIN_CONFIG = "input {stdin {}} output { }"
-  RETRY_ATTEMPTS = 10
+  MAXIMUM_WAIT_TIME = 15 * 60
 
   @process = nil
-  
+
   attr_reader :logstash_home
   attr_reader :default_settings_file
   attr_writer :env_variables
@@ -42,7 +45,7 @@ class LogstashService < Service
       @logstash_bin = File.join("#{@logstash_home}", LS_BIN)
       raise "Logstash binary not found in path #{@logstash_home}" unless File.file? @logstash_bin
     end
-    
+
     @default_settings_file = File.join(@logstash_home, LS_CONFIG_FILE)
     @monitoring_api = MonitoringAPI.new
   end
@@ -54,14 +57,14 @@ class LogstashService < Service
       @process.alive?
     end
   end
-  
+
   def exited?
     @process.exited?
   end
-  
+
   def exit_code
     @process.exit_code
-  end  
+  end
 
   # Starts a LS process in background with a given config file
   # and shuts it down after input is completely processed
@@ -154,34 +157,56 @@ class LogstashService < Service
     @monitoring_api
   end
 
-  # Wait until LS is started by repeatedly doing a socket connection to HTTP port
+  # Wait until logstash is started and the tcp server answer a real HTTP response
   def wait_for_logstash
-    tries = RETRY_ATTEMPTS
-    while tries > 0
-      if is_port_open?
-        break
-      else
-        sleep 1
+    started_at = Time.now
+
+    uri = URI(API_URL)
+    successful = false
+
+    while Time.now - started_at < MAXIMUM_WAIT_TIME
+      begin
+        response = Net::HTTP.get_response(uri)
+
+        if response.code.to_i == 200
+          data = JSON.parse(response.body)
+          if !data["host"].nil? && !data["version"].nil?
+            successful = true
+            break
+          else
+            puts "Received wrong response from the Logstash's API: #{data}"
+          end
+        else
+          puts "Received wrong code, expected 200 received #{response.code}"
+        end
+
+        sleep(1)
+      rescue => e
+        puts "Retrying to reach Logstash's API, but got an error: #{e}"
+        sleep(1)
       end
-      tries -= 1
+    end
+
+    if !successful
+      raise "Logstash's API didn't answer corrrectly within the specified maximum time of #{MAXIMUM_WAIT_TIME}"
     end
   end
-  
+
   # this method only overwrites existing config with new config
-  # it does not assume that LS pipeline is fully reloaded after a 
+  # it does not assume that LS pipeline is fully reloaded after a
   # config change. It is up to the caller to validate that.
   def reload_config(initial_config_file, reload_config_file)
     FileUtils.cp(reload_config_file, initial_config_file)
-  end  
-  
+  end
+
   def get_version
     `#{@logstash_bin} --version`
   end
-  
+
   def get_version_yml
     LS_VERSION_FILE
-  end   
-  
+  end
+
   def process_id
     @process.pid
   end

--- a/qa/integration/services/monitoring_api.rb
+++ b/qa/integration/services/monitoring_api.rb
@@ -23,13 +23,13 @@ class MonitoringAPI
   end
   
   def node_info
-    resp = Manticore.get("http://localhost:9600/_node").body
-    JSON.parse(resp)
+    resp = Manticore.get("http://localhost:9600/_node")
+    JSON.parse(resp.body)
   end
 
   def node_stats
-    resp = Manticore.get("http://localhost:9600/_node/stats").body
-    JSON.parse(resp)
+    resp = Manticore.get("http://localhost:9600/_node/stats")
+    JSON.parse(resp.body)
   end
 
 end

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -39,7 +39,6 @@ describe "Test Monitoring API" do
   it "can retrieve JVM stats" do
     logstash_service = @fixture.get_service("logstash")
     logstash_service.start_with_stdin
-    logstash_service.wait_for_logstash
 
     Stud.try(max_retry.times, RSpec::Expectations::ExpectationNotMetError) do
        result = logstash_service.monitoring_api.node_stats
@@ -50,7 +49,6 @@ describe "Test Monitoring API" do
   it "can retrieve queue stats" do
     logstash_service = @fixture.get_service("logstash")
     logstash_service.start_with_stdin
-    logstash_service.wait_for_logstash
 
     Stud.try(max_retry.times, RSpec::Expectations::ExpectationNotMetError) do
       result = logstash_service.monitoring_api.node_stats


### PR DESCRIPTION
Instead of relying on checking if the port is open we make sure that the
root API return a concrete json response, also intead of using a retry limit we used a time limit which
should give more reliability on travis.

Fix: #6949