### PR TITLE
Fix warning about eval being aliased in lscl.rb

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/expression/Expression.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/expression/Expression.java
@@ -22,10 +22,6 @@ public abstract class Expression extends BaseSourceComponent implements Hashable
         super(meta);
     }
 
-    public boolean eval() {
-        return true;
-    }
-
     public void compile() {
         container = new ScriptingContainer();
         container.setCompileMode(RubyInstanceConfig.CompileMode.JIT);


### PR DESCRIPTION
This warning was generated due to a java class being used that had its own `eval` method which wasn't even being used.