### PR TITLE
Add '.gradle' to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ qa/Gemfile.lock
 .idea
 logs
 qa/integration/services/installed/
+.gradle


### PR DESCRIPTION
It's annoying that `git add logstash-core` sweeps in the whole `logstash-core/.gradle` dir.