### PR TITLE
rephrase pipeline creation error message

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -261,9 +261,9 @@ class LogStash::Agent
       n.gauge(:last_failure_timestamp, LogStash::Timestamp.now)
     end
     if @logger.debug?
-      @logger.error("Cannot load an invalid configuration", :reason => message, :backtrace => backtrace)
+      @logger.error("Cannot create pipeline", :reason => message, :backtrace => backtrace)
     else
-      @logger.error("Cannot load an invalid configuration", :reason => message)
+      @logger.error("Cannot create pipeline", :reason => message)
     end
   end
 


### PR DESCRIPTION
Fixes #6575 

All `Pipeline.new` exceptions are reported by the `Agent` as 
```
[logstash.agent           ] Cannot load an invalid configuration
```
but Pipeline instantiation exceptions are not only configuration errors. 

Since this is now fixed in master for 6.0 with the `Agent` refactor in #6632, In 5.x I do not think we should yak shave the `Pipeline.new` exception handling and simply print a more generic message instead of `Cannot load an invalid configuration`. 

This PR simply rephrase the exception message to `Cannot create pipeline`. 

In the case of a Queue exception the output will look like this:
```
[2017-04-25T16:29:27,878][ERROR][logstash.pipeline        ] Logstash failed to create queue {"exception"=>"SOME QUEUE ERROR", "backtrace"=>["/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/pipeline.rb:148:in `initialize'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:277:in `create_pipeline'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:95:in `register_pipeline'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/runner.rb:274:in `execute'", "/Users/colin/dev/src/elasticsearch/logstash/vendor/bundle/jruby/1.9/gems/clamp-0.6.5/lib/clamp/command.rb:67:in `run'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/runner.rb:185:in `run'", "/Users/colin/dev/src/elasticsearch/logstash/vendor/bundle/jruby/1.9/gems/clamp-0.6.5/lib/clamp/command.rb:132:in `run'", "/Users/colin/dev/src/elasticsearch/logstash/lib/bootstrap/environment.rb:71:in `(root)'"]}
[2017-04-25T16:29:27,887][ERROR][logstash.agent           ] Cannot create pipeline {:reason=>"SOME QUEUE ERROR"}
```

and for an actual configuration syntax error it will look like this:

```
[2017-04-25T16:30:22,180][ERROR][logstash.agent           ] Cannot create pipeline {:reason=>"Expected one of #, input, filter, output at line 1, column 1 (byte 1) after "}
```

I believe this is sufficient to avoid confusion with the "configuration error". 