### PR TITLE
only auto complete config.string

### DIFF
--- a/logstash-core/lib/logstash/config/source/local.rb
+++ b/logstash-core/lib/logstash/config/source/local.rb
@@ -148,9 +148,8 @@ module LogStash module Config module Source
       end
 
       return if config_parts.empty?
-      return if config_string? && config_string.strip.empty?
 
-      add_missing_default_inputs_or_outputs(config_parts)
+      add_missing_default_inputs_or_outputs(config_parts) if config_string?
 
       [PipelineConfig.new(self.class, PIPELINE_ID, config_parts, @settings)]
     end

--- a/logstash-core/spec/logstash/config/source/local_spec.rb
+++ b/logstash-core/spec/logstash/config/source/local_spec.rb
@@ -361,6 +361,21 @@ describe LogStash::Config::Source::Local do
   end
 
   context "incomplete configuration" do
+    context "when using path.config" do
+      let(:config_string) { filter_block }
+      let(:config_path) do
+        file = Stud::Temporary.file
+        path = file.path
+        file.write(config_string)
+        path
+      end
+      let(:settings) { mock_settings( "path.config" => config_path) }
+
+      it "doesn't add anything" do
+        expect(subject.pipeline_configs.config_string).not_to include(LogStash::Config::Defaults.output, LogStash::Config::Defaults.input)
+      end
+    end
+
     context "when the input block is missing" do
       let(:settings) { mock_settings( "config.string" => "#{filter_block} #{output_block}") }
 

--- a/logstash-core/spec/logstash/config/source/local_spec.rb
+++ b/logstash-core/spec/logstash/config/source/local_spec.rb
@@ -372,7 +372,7 @@ describe LogStash::Config::Source::Local do
       let(:settings) { mock_settings( "path.config" => config_path) }
 
       it "doesn't add anything" do
-        expect(subject.pipeline_configs.config_string).not_to include(LogStash::Config::Defaults.output, LogStash::Config::Defaults.input)
+        expect(subject.pipeline_configs.first.config_string).not_to include(LogStash::Config::Defaults.output, LogStash::Config::Defaults.input)
       end
     end
 


### PR DESCRIPTION
this was the behaviour in 1.x and 2.x and 5.x introduced auto completion of path.config
this PR goes back to 1.x and 2.x behaviour.

This is part of a list of changes described in https://github.com/elastic/logstash/issues/6926