### PR TITLE
make e and f flags mutually exclusive

### DIFF
--- a/logstash-core/lib/logstash/bootstrap_check/default_config.rb
+++ b/logstash-core/lib/logstash/bootstrap_check/default_config.rb
@@ -8,6 +8,10 @@ module LogStash module BootstrapCheck
         raise LogStash::BootstrapCheckError, I18n.t("logstash.runner.missing-configuration")
       end
 
+      if settings.get("config.string") && settings.get("path.config")
+        raise LogStash::BootstrapCheckError, I18n.t("logstash.runner.config-string-path-exclusive")
+      end
+
       if settings.get("config.reload.automatic") && settings.get("path.config").nil?
         # there's nothing to reload
         raise LogStash::BootstrapCheckError, I18n.t("logstash.runner.reload-without-config-path")

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -98,6 +98,8 @@ en:
       missing-configuration: >-
         No configuration file was specified. Perhaps you forgot to provide
         the '-f yourlogstash.conf' flag?
+      config-string-path-exclusive:
+        Settings 'path.config' (-f) and 'config.string' (-e) can't be used simultaneously.
       reload-without-config-path: >-
         Configuration reloading also requires passing a configuration path with '-f yourlogstash.conf'
       locked-data-path: >-

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -396,7 +396,8 @@ describe LogStash::Agent do
 
   context "metrics after config reloading" do
     let(:agent_settings) { mock_settings({}) }
-    let!(:config) { "input { generator { } } output { dummyoutput { } }" }
+    let(:temporary_file) { Stud::Temporary.file.path }
+    let(:config) { "input { generator { count => #{initial_generator_threshold*2} } } output { file { path => '#{temporary_file}'} }" }
 
     let(:config_path) do
       f = Stud::Temporary.file
@@ -449,8 +450,8 @@ describe LogStash::Agent do
 
     context "when reloading a good config" do
       let(:new_config_generator_counter) { 500 }
-      let(:output_file) { Stud::Temporary.file.path }
-      let(:new_config) { "input { generator { count => #{new_config_generator_counter} } } output { file { path => '#{output_file}'} }" }
+      let(:new_file) { Stud::Temporary.file.path }
+      let(:new_config) { "input { generator { count => #{new_config_generator_counter} } } output { file { path => '#{new_file}'} }" }
 
       before :each do
         File.open(config_path, "w") do |f|
@@ -459,7 +460,7 @@ describe LogStash::Agent do
         end
 
         # wait until pipeline restarts
-        sleep(1) if ::File.read(output_file).empty?
+        sleep(1) if ::File.read(new_file).empty?
       end
 
       it "resets the pipeline metric collector" do

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -100,13 +100,8 @@ describe LogStash::Agent do
     end
 
     context "when auto_reload is false" do
-      let(:agent_args) do
-        {
-          "config.reload.automatic" => false,
-          "path.config" => config_file
-        }
-      end
-
+      let(:agent_settings) { mock_settings("config.reload.automatic" => false) }
+      let(:agent_args) { { "path.config" => config_file } }
 
       context "if state is clean" do
         before :each do
@@ -222,16 +217,10 @@ describe LogStash::Agent do
     end
 
     context "when auto_reload is true" do
+      let(:agent_settings) { mock_settings("config.reload.automatic" => true, "config.reload.interval" => 0.01) }
       subject { described_class.new(agent_settings, default_source_loader) }
 
-      let(:agent_args) do
-        {
-          "config.string" => "",
-          "config.reload.automatic" => true,
-          "config.reload.interval" => 0.01,
-          "path.config" => config_file
-        }
-      end
+      let(:agent_args) { { "path.config" => config_file } }
 
       context "if state is clean" do
         it "should periodically reload_state" do
@@ -406,8 +395,8 @@ describe LogStash::Agent do
   end
 
   context "metrics after config reloading" do
-    let(:temporary_file) { Stud::Temporary.file.path }
-    let(:config) { "input { generator { } } output { file { path => '#{temporary_file}' } }" }
+    let(:agent_settings) { mock_settings({}) }
+    let!(:config) { "input { generator { } } output { dummyoutput { } }" }
 
     let(:config_path) do
       f = Stud::Temporary.file

--- a/logstash-core/spec/logstash/config/source/local_spec.rb
+++ b/logstash-core/spec/logstash/config/source/local_spec.rb
@@ -292,8 +292,9 @@ describe LogStash::Config::Source::Local do
       )
     end
 
-    it "returns a merged config" do
-      expect(subject.pipeline_configs.first.config_string).to include(input_block, output_block, filter_block)
+    # this should be impossible as the bootstrap checks should catch this
+    it "raises an exception" do
+      expect { subject.pipeline_configs }.to raise_error
     end
   end
 
@@ -353,8 +354,8 @@ describe LogStash::Config::Source::Local do
         )
       end
 
-      it "returns a merged config" do
-        expect(subject.pipeline_configs.first.config_string).to include(input_block, filter_block)
+      it "raises an exception" do
+        expect { subject.pipeline_configs }.to raise_error
       end
     end
   end


### PR DESCRIPTION
makes -e and -f mutually exclusive, which also eliminates concatenation between the two

this is part of the changes described in https://github.com/elastic/logstash/issues/6926