### PR TITLE
[WIP] Making the integration test suite a bit more robust to run on travis

### DIFF
--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -1,12 +1,15 @@
 require_relative "monitoring_api"
-
 require "childprocess"
 require "bundler"
 require "tempfile"
-require 'yaml'
+require "yaml"
+require "json"
+require "net/http"
+require "uri"
 
 # A locally started Logstash service
 class LogstashService < Service
+  API_URL = "http://localhost:9600/"
 
   LS_ROOT_DIR = File.join("..", "..", "..", "..")
   LS_VERSION_FILE = File.expand_path(File.join(LS_ROOT_DIR, "versions.yml"), __FILE__)
@@ -16,10 +19,10 @@ class LogstashService < Service
   SETTINGS_CLI_FLAG = "--path.settings"
 
   STDIN_CONFIG = "input {stdin {}} output { }"
-  RETRY_ATTEMPTS = 10
+  MAXIMUM_WAIT_TIME = 15 * 60
 
   @process = nil
-  
+
   attr_reader :logstash_home
   attr_reader :default_settings_file
   attr_writer :env_variables
@@ -42,7 +45,7 @@ class LogstashService < Service
       @logstash_bin = File.join("#{@logstash_home}", LS_BIN)
       raise "Logstash binary not found in path #{@logstash_home}" unless File.file? @logstash_bin
     end
-    
+
     @default_settings_file = File.join(@logstash_home, LS_CONFIG_FILE)
     @monitoring_api = MonitoringAPI.new
   end
@@ -54,14 +57,14 @@ class LogstashService < Service
       @process.alive?
     end
   end
-  
+
   def exited?
     @process.exited?
   end
-  
+
   def exit_code
     @process.exit_code
-  end  
+  end
 
   # Starts a LS process in background with a given config file
   # and shuts it down after input is completely processed
@@ -154,34 +157,56 @@ class LogstashService < Service
     @monitoring_api
   end
 
-  # Wait until LS is started by repeatedly doing a socket connection to HTTP port
+  # Wait until logstash is started and the tcp server answer a real HTTP response
   def wait_for_logstash
-    tries = RETRY_ATTEMPTS
-    while tries > 0
-      if is_port_open?
-        break
-      else
-        sleep 1
+    started_at = Time.now
+
+    uri = URI(API_URL)
+    successful = false
+
+    while Time.now - started_at < MAXIMUM_WAIT_TIME
+      begin
+        response = Net::HTTP.get_response(uri)
+
+        if response.code.to_i == 200
+          data = JSON.parse(response.body)
+          if !data["host"].nil? && !data["version"].nil?
+            successful = true
+            break
+          else
+            puts "Received wrong response from the Logstash's API: #{data}"
+          end
+        else
+          puts "Received wrong code, expected 200 received #{response.code}"
+        end
+
+        sleep(1)
+      rescue => e
+        puts "Retrying to reach Logstash's API, but got an error: #{e}"
+        sleep(1)
       end
-      tries -= 1
+    end
+
+    if !successful
+      raise "Logstash's API didn't answer corrrectly within the specified maximum time of #{MAXIMUM_WAIT_TIME}"
     end
   end
-  
+
   # this method only overwrites existing config with new config
-  # it does not assume that LS pipeline is fully reloaded after a 
+  # it does not assume that LS pipeline is fully reloaded after a
   # config change. It is up to the caller to validate that.
   def reload_config(initial_config_file, reload_config_file)
     FileUtils.cp(reload_config_file, initial_config_file)
-  end  
-  
+  end
+
   def get_version
     `#{@logstash_bin} --version`
   end
-  
+
   def get_version_yml
     LS_VERSION_FILE
-  end   
-  
+  end
+
   def process_id
     @process.pid
   end

--- a/qa/integration/services/monitoring_api.rb
+++ b/qa/integration/services/monitoring_api.rb
@@ -23,13 +23,13 @@ class MonitoringAPI
   end
   
   def node_info
-    resp = Manticore.get("http://localhost:9600/_node").body
-    JSON.parse(resp)
+    resp = Manticore.get("http://localhost:9600/_node")
+    JSON.parse(resp.body)
   end
 
   def node_stats
-    resp = Manticore.get("http://localhost:9600/_node/stats").body
-    JSON.parse(resp)
+    resp = Manticore.get("http://localhost:9600/_node/stats")
+    JSON.parse(resp.body)
   end
 
 end

--- a/qa/integration/specs/01_logstash_bin_smoke_spec.rb
+++ b/qa/integration/specs/01_logstash_bin_smoke_spec.rb
@@ -55,7 +55,7 @@ describe "Test Logstash instance" do
       sleep(0.1) until File.exist?(file_config1) && File.size(file_config1) > 0 # Everything is started successfully at this point
       expect(is_port_open?(9600)).to be true
 
-      @ls2.spawn_logstash("-f", config2, "--path.data", tmp_data_path)
+      @ls2.spawn_logstash("-f", config2, "--path.data", tmp_data_path, :dont_wait_for_pipelines)
       try(20) do
         expect(@ls2.exited?).to be(true)
       end
@@ -139,7 +139,7 @@ describe "Test Logstash instance" do
   end
 
   it "should not start when -e is not specified and -f has no valid config files" do
-    @ls2.spawn_logstash("-e", "", "-f" "/tmp/foobartest")
+    @ls2.spawn_logstash("-e", "", "-f" "/tmp/foobartest", :dont_wait_for_pipelines)
     try(num_retries) do
       expect(is_port_open?(9600)).to be_falsey
     end

--- a/qa/integration/specs/es_output_how_spec.rb
+++ b/qa/integration/specs/es_output_how_spec.rb
@@ -21,20 +21,22 @@ describe "Test Elasticsearch output" do
     es_client = es_service.get_client
     # now we test if all data was indexed by ES, but first refresh manually
     es_client.indices.refresh
-    result = es_client.search(index: 'logstash-*', size: 0, q: '*')
-    expect(result["hits"]["total"]).to eq(37)
-    
-    # randomly checked for results and structured fields
-    result = es_client.search(index: 'logstash-*', size: 1, q: 'dynamic')
-    expect(result["hits"]["total"]).to eq(1)
-    s = result["hits"]["hits"][0]["_source"]
-    expect(s["bytes"]).to eq(18848)
-    expect(s["response"]).to eq(200)
-    expect(s["clientip"]).to eq("213.113.233.227")
-    expect(s["geoip"]["longitude"]).to eq(12.9443)
-    expect(s["geoip"]["latitude"]).to eq(56.1357)
-    expect(s["verb"]).to eq("GET")
-    expect(s["useragent"]["os"]).to eq("Windows 7")
-  end
 
+    try do
+      result = es_client.search(index: 'logstash-*', size: 0, q: '*')
+      expect(result["hits"]["total"]).to eq(37)
+
+      # randomly checked for results and structured fields
+      result = es_client.search(index: 'logstash-*', size: 1, q: 'dynamic')
+      expect(result["hits"]["total"]).to eq(1)
+      s = result["hits"]["hits"][0]["_source"]
+      expect(s["bytes"]).to eq(18848)
+      expect(s["response"]).to eq(200)
+      expect(s["clientip"]).to eq("213.113.233.227")
+      expect(s["geoip"]["longitude"]).to eq(12.9443)
+      expect(s["geoip"]["latitude"]).to eq(56.1357)
+      expect(s["verb"]).to eq("GET")
+      expect(s["useragent"]["os"]).to eq("Windows 7")
+    end
+  end
 end

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -39,7 +39,6 @@ describe "Test Monitoring API" do
   it "can retrieve JVM stats" do
     logstash_service = @fixture.get_service("logstash")
     logstash_service.start_with_stdin
-    logstash_service.wait_for_logstash
 
     Stud.try(max_retry.times, RSpec::Expectations::ExpectationNotMetError) do
        result = logstash_service.monitoring_api.node_stats
@@ -50,7 +49,6 @@ describe "Test Monitoring API" do
   it "can retrieve queue stats" do
     logstash_service = @fixture.get_service("logstash")
     logstash_service.start_with_stdin
-    logstash_service.wait_for_logstash
 
     Stud.try(max_retry.times, RSpec::Expectations::ExpectationNotMetError) do
       result = logstash_service.monitoring_api.node_stats

--- a/qa/integration/specs/settings_spec.rb
+++ b/qa/integration/specs/settings_spec.rb
@@ -83,7 +83,7 @@ describe "Test Logstash instance whose default settings are overridden" do
     test_config_path = File.join(temp_dir, "test.config")
     IO.write(test_config_path, "#{tcp_config}")
     expect(File.exists?(test_config_path)).to be true
-    @logstash_service.spawn_logstash
+    @logstash_service.spawn_logstash(:dont_wait_for_pipelines)
     try(num_retries) do
       expect(@logstash_service.exited?).to be true
     end
@@ -92,7 +92,7 @@ describe "Test Logstash instance whose default settings are overridden" do
     # now with bad config
     IO.write(test_config_path, "#{tcp_config} filters {} ")
     expect(File.exists?(test_config_path)).to be true
-    @logstash_service.spawn_logstash
+    @logstash_service.spawn_logstash(:dont_wait_for_pipelines)
     try(num_retries) do
       expect(@logstash_service.exited?).to be true
     end


### PR DESCRIPTION

This is an experiment and its not ready for review, the api is subject
to changes but I wanted to test it out as fast as possible.

Instead of checking on the TCP port open (which we can still do), I
inspect the stdout and check if the pipeline are started at this point.
I am aware that it couple this code to the output of the log but, I
think it will be more resilient in the short term.

Also instead of using a fix amount of retries I use a time limit
instead and when we run out of time I will print the content of the
stdout.
