### PR TITLE
Fix when settings set in the pipeline_pq_file_spec bleed into other examples

### DIFF
--- a/logstash-core/spec/logstash/pipeline_pq_file_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_pq_file_spec.rb
@@ -36,7 +36,7 @@ class PipelinePqFileOutput < LogStash::Outputs::Base
 end
 
 describe LogStash::Pipeline do
-  let(:pipeline_settings_obj) { LogStash::SETTINGS }
+  let(:pipeline_settings_obj) { LogStash::SETTINGS.clone }
   let(:pipeline_id) { "main" }
 
   let(:multiline_id) { "my-multiline" }


### PR DESCRIPTION
make sure we clone the LogStash::Settings before mutating it.

Fixes: #6868 and other related failures about the workers.