### PR TITLE
Check Available Disk Space for Persisted Queues, fixes #6552 

### DIFF
--- a/logstash-core/lib/logstash/bootstrap_check/persisted_queue_config.rb
+++ b/logstash-core/lib/logstash/bootstrap_check/persisted_queue_config.rb
@@ -1,0 +1,14 @@
+# encoding: utf-8
+require 'logstash/errors'
+
+module LogStash module BootstrapCheck
+    class PersistedQueueConfig
+      def self.check(settings)
+        return unless settings.get('queue.type') == 'persisted'
+        if settings.get('queue.page_capacity') > settings.get('queue.max_bytes')
+          raise LogStash::BootstrapCheckError,
+                'Invalid configuration, `queue.page_capacity` must be smaller or equal to `queue.max_bytes`'
+        end
+      end
+    end
+end end

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -20,9 +20,10 @@ require "logstash/patches/clamp"
 require "logstash/settings"
 require "logstash/version"
 require "logstash/plugins/registry"
-require "logstash/bootstrap_check/default_config"
 require "logstash/bootstrap_check/bad_java"
 require "logstash/bootstrap_check/bad_ruby"
+require "logstash/bootstrap_check/default_config"
+require "logstash/bootstrap_check/persisted_queue_config"
 require "set"
 
 java_import 'org.logstash.FileLockFactory'
@@ -52,7 +53,8 @@ class LogStash::Runner < Clamp::StrictCommand
   DEFAULT_BOOTSTRAP_CHECKS = [
       LogStash::BootstrapCheck::BadRuby,
       LogStash::BootstrapCheck::BadJava,
-      LogStash::BootstrapCheck::DefaultConfig
+      LogStash::BootstrapCheck::DefaultConfig,
+      LogStash::BootstrapCheck::PersistedQueueConfig
   ]
 
   # Node Settings

--- a/logstash-core/spec/logstash/bootstrap_check/persisted_queue_config_spec.rb
+++ b/logstash-core/spec/logstash/bootstrap_check/persisted_queue_config_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+require "tmpdir"
+require "logstash/bootstrap_check/persisted_queue_config"
+
+describe LogStash::BootstrapCheck::PersistedQueueConfig do
+
+  context("when persisted queues are enabled") do
+    let(:settings) do
+      settings = LogStash::SETTINGS.dup
+      settings.set_value("queue.type", "persisted")
+      settings.set_value("queue.page_capacity", 1024)
+      settings.set_value("path.queue", ::File.join(Dir.tmpdir, "some/path"))
+      settings
+    end
+
+    context("and 'queue.max_bytes' is set to a value less than the value of 'queue.page_capacity'") do
+      it "should throw" do
+        settings.set_value("queue.max_bytes", 512)
+        expect { LogStash::BootstrapCheck::PersistedQueueConfig.check(settings) }.to raise_error
+      end
+    end
+  end
+end

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/FsUtil.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/FsUtil.java
@@ -1,0 +1,47 @@
+package org.logstash.ackedqueue;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * File System Utility Methods.
+ */
+public final class FsUtil {
+
+    private FsUtil() {
+    }
+
+    /**
+     * Checks if the request number of bytes of free disk space are available under the given
+     * path.
+     * @param path Directory to check
+     * @param size Bytes of free space requested
+     * @return True iff the
+     * @throws IOException on failure to determine free space for given path's partition
+     */
+    public static boolean hasFreeSpace(final String path, final long size) throws IOException {
+        final File[] partitions = File.listRoots();
+        File location = new File(path).getCanonicalFile();
+        boolean found = false;
+        while (!found) {
+            for (final File partition : partitions) {
+                if (partition.equals(location)) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                location = location.getParentFile();
+                if (location == null) {
+                    throw new IllegalStateException(
+                        String.format(
+                            "Unable to determine the partition that contains '%s'.", path
+                        )
+                    );
+                }
+            }
+        }
+        return location.getFreeSpace() >= size;
+    }
+
+}

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/AbstractByteBufferPageIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/AbstractByteBufferPageIO.java
@@ -44,6 +44,15 @@ public abstract class AbstractByteBufferPageIO implements PageIO {
     private CRC32 checkSummer;
     private final List<Integer> offsetMap; // has to be extendable
 
+    // we don't have different versions yet so simply check if the version is VERSION_ONE for basic integrity check
+    // and if an unexpected version byte is read throw PageIOInvalidVersionException
+    public static void validateVersion(byte version) throws PageIOInvalidVersionException {
+        if (version != VERSION_ONE) {
+            throw new PageIOInvalidVersionException(String
+                .format("Expected page version=%d but found version=%d", VERSION_ONE, version));
+        }
+    }
+
     public AbstractByteBufferPageIO(int pageNum, int capacity) {
         this.minSeqNum = 0;
         this.elementCount = 0;
@@ -115,15 +124,6 @@ public abstract class AbstractByteBufferPageIO implements PageIO {
         // if we were not able to read any element just reset minSeqNum to zero
         if (this.elementCount <= 0) {
             this.minSeqNum = 0;
-        }
-    }
-
-    // we don't have different versions yet so simply check if the version is VERSION_ONE for basic integrity check
-    // and if an unexpected version byte is read throw PageIOInvalidVersionException
-    private static void validateVersion(byte version) throws PageIOInvalidVersionException {
-        if (version != VERSION_ONE) {
-            throw new PageIOInvalidVersionException(String
-                .format("Expected page version=%d but found version=%d", VERSION_ONE, version));
         }
     }
 

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/FsUtilTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/FsUtilTest.java
@@ -1,0 +1,40 @@
+package org.logstash.ackedqueue;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests for {@link FsUtil}.
+ */
+public final class FsUtilTest {
+
+    @Rule
+    public final TemporaryFolder temp = new TemporaryFolder();
+
+    /**
+     * {@link FsUtil#hasFreeSpace(String, long)} should return true when asked for 1kb of free
+     * space in a subfolder of the system's TEMP location.
+     */
+    @Test
+    public void trueIfEnoughSpace() throws Exception {
+        MatcherAssert.assertThat(
+            FsUtil.hasFreeSpace(temp.newFolder().getAbsolutePath(), 1024L),
+            CoreMatchers.is(true)
+        );
+    }
+
+    /**
+     * {@link FsUtil#hasFreeSpace(String, long)} should return false when asked for
+     * {@link Long#MAX_VALUE} of free space in a subfolder of the system's TEMP location.
+     */
+    @Test
+    public void falseIfNotEnoughSpace() throws Exception {
+        MatcherAssert.assertThat(
+            FsUtil.hasFreeSpace(temp.newFolder().getAbsolutePath(), Long.MAX_VALUE),
+            CoreMatchers.is(false)
+        );
+    }
+}


### PR DESCRIPTION
For #6552:

* Implemented free disk space check in Java since Ruby doesn't have this out of the box apparently
* Added JUnit test for the Java file system logic
* Added new bootstrap check
  * checks against the max of (`queue.max_bytes` and `queue.page_capacity`)