### PR TITLE
#4324 streamline behaviour of Timestamp.== and Timestamp.eql?

### DIFF
--- a/logstash-core/lib/logstash/timestamp.rb
+++ b/logstash-core/lib/logstash/timestamp.rb
@@ -13,6 +13,10 @@ module LogStash
       self.time <=> other.time
     end
 
+    def eql?(other)
+      self.== other
+    end
+
     # TODO (colin) implement in Java
     def +(other)
       self.time + other

--- a/logstash-core/spec/logstash/timestamp_spec.rb
+++ b/logstash-core/spec/logstash/timestamp_spec.rb
@@ -20,6 +20,12 @@ describe LogStash::Timestamp do
       expect(t.time.to_i).to eq(now.to_i)
     end
 
+    it "should have consistent behaviour across == and .eql?" do
+      its_xmas = Time.utc(2015, 12, 25, 0, 0, 0)
+      expect(LogStash::Timestamp.new(its_xmas)).to eql(LogStash::Timestamp.new(its_xmas))
+      expect(LogStash::Timestamp.new(its_xmas)).to be ==(LogStash::Timestamp.new(its_xmas))
+    end
+
     it "should raise exception on invalid format" do
       expect{LogStash::Timestamp.new("foobar")}.to raise_error
     end


### PR DESCRIPTION
For #4324:

* `Timestamp.eql?` and `Timestamp.==` should be aliases of one another