### PR TITLE
Normalize the Alpha version of Logstash

### DIFF
--- a/logstash-core-plugin-api/logstash-core-plugin-api.gemspec
+++ b/logstash-core-plugin-api/logstash-core-plugin-api.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = LOGSTASH_CORE_PLUGIN_API
 
-  gem.add_runtime_dependency "logstash-core", "6.0.0-alpha1"
+  gem.add_runtime_dependency "logstash-core", "6.0.0.alpha1"
 
   # Make sure we dont build this gem from a non jruby
   # environment.

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "logstash-core"
   gem.require_paths = ["lib"]
-  gem.version       = LOGSTASH_CORE_VERSION
+  gem.version       = LOGSTASH_CORE_VERSION.gsub("-", ".")
 
   gem.platform = "java"
 

--- a/rakelib/version.rake
+++ b/rakelib/version.rake
@@ -59,7 +59,7 @@ namespace :version do
     text = IO.read(logstash_core_plugin_api_gemspec)
     IO.write(logstash_core_plugin_api_gemspec, text.sub(
       /  gem.add_runtime_dependency \"logstash-core\", \".+?\"/,
-      "  gem.add_runtime_dependency \"logstash-core\", \"#{logstash_core_version}\""))
+      "  gem.add_runtime_dependency \"logstash-core\", \"#{logstash_core_version.gsub("-", ".")}\""))
   end
 
   desc "show version of core components"


### PR DESCRIPTION
If you use 6.0.0-alpha1, rubygems will change it to 6.0.0.pre.alpha1,
this commit changes the behavior to normalize the version before saving
it to disk.