### PR TITLE
add queue_size_on_disk stat to persisted queue node stats

### DIFF
--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -71,7 +71,7 @@ module LogStash; class BasePipeline
       raise e
     end
   end
-  
+
   def compile_lir
     LogStash::Compiler.compile_pipeline(self.config_str)
   end
@@ -190,8 +190,8 @@ module LogStash; class Pipeline < BasePipeline
     @flushing = Concurrent::AtomicReference.new(false)
     @force_shutdown = Concurrent::AtomicBoolean.new(false)
   end # def initialize
-  
-  
+
+
 
   def ready?
     @ready.value
@@ -691,6 +691,7 @@ module LogStash; class Pipeline < BasePipeline
         n.gauge(:page_capacity_in_bytes, queue.page_capacity)
         n.gauge(:max_queue_size_in_bytes, queue.max_size_in_bytes)
         n.gauge(:max_unread_events, queue.max_unread_events)
+        n.gauge(:queue_size_in_bytes, queue.persisted_size_in_bytes)
       end
       pipeline_metric.namespace([:data]).tap do |n|
         n.gauge(:free_space_in_bytes, file_store.get_unallocated_space)

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -139,6 +139,10 @@ public class Queue implements Closeable {
         return this.currentByteSize;
     }
 
+    public long getPersistedByteSize() {
+        return headPage.getPageIO().getHead() + tailPages.stream().mapToLong((p) -> p.getPageIO().getHead()).sum();
+    }
+
     public int getPageCapacity() {
         return this.pageCapacity;
     }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java
@@ -112,6 +112,11 @@ public class JrubyAckedQueueExtLibrary implements Library {
             return context.runtime.newFixnum(queue.getCurrentByteSize());
         }
 
+        @JRubyMethod(name = "persisted_size_in_bytes")
+        public IRubyObject ruby_persisted_size_in_bytes(ThreadContext context) {
+            return context.runtime.newFixnum(queue.getPersistedByteSize());
+        }
+
         @JRubyMethod(name = "acked_count")
         public IRubyObject ruby_acked_count(ThreadContext context) {
             return context.runtime.newFixnum(queue.getAckedCount());

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueMemoryExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueMemoryExtLibrary.java
@@ -107,6 +107,11 @@ public class JrubyAckedQueueMemoryExtLibrary implements Library {
             return context.runtime.newFixnum(queue.getCurrentByteSize());
         }
 
+        @JRubyMethod(name = "persisted_size_in_bytes")
+        public IRubyObject ruby_persisted_size_in_bytes(ThreadContext context) {
+            return context.runtime.newFixnum(queue.getPersistedByteSize());
+        }
+
         @JRubyMethod(name = "acked_count")
         public IRubyObject ruby_acked_count(ThreadContext context) {
             return context.runtime.newFixnum(queue.getAckedCount());

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/AbstractByteBufferPageIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/AbstractByteBufferPageIO.java
@@ -271,6 +271,11 @@ public abstract class AbstractByteBufferPageIO implements PageIO {
         return SEQNUM_SIZE + LENGTH_SIZE + byteCount + CHECKSUM_SIZE;
     }
 
+    @Override
+    public int getHead() {
+        return this.head;
+    }
+
     protected int checksum(byte[] bytes) {
         checkSummer.reset();
         checkSummer.update(bytes, 0, bytes.length);

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/PageIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/PageIO.java
@@ -37,6 +37,9 @@ public interface PageIO extends Closeable {
     // @return the data container total capacity in bytes
     int getCapacity();
 
+    // @return the current head offset within the page
+    int getHead();
+
     // @return the actual persisted byte count (with overhead) for the given data bytes
     int persistedByteCount(int bytes);
 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/wip/MemoryPageIOStream.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/wip/MemoryPageIOStream.java
@@ -154,6 +154,11 @@ public class MemoryPageIOStream implements PageIO {
     }
 
     @Override
+    public int getHead() {
+        return writePosition;
+    }
+
+    @Override
     public void deactivate() {
         // do nothing
     }


### PR DESCRIPTION
This is a clean rebase of #6518 (no changes were necessary to the original commit in that PR just needed a `cherry-pick`).