### PR TITLE
Allow to ask the registry to get a list of plugin klass of a specific

### DIFF
--- a/logstash-core/lib/logstash/plugins/registry.rb
+++ b/logstash-core/lib/logstash/plugins/registry.rb
@@ -109,6 +109,10 @@ module LogStash module Plugins
         .each { |specification| specification.register(hooks, LogStash::SETTINGS) }
     end
 
+    def plugins_with_type(type)
+      @registry.values.select { |specification| specification.type.to_sym == type.to_sym }.collect(&:klass)
+    end
+
     def load_available_plugins
       GemRegistry.logstash_plugins.each do |plugin_context|
         # When a plugin has a HOOK_FILE defined, its the responsibility of the plugin

--- a/logstash-core/spec/logstash/plugins/registry_spec.rb
+++ b/logstash-core/spec/logstash/plugins/registry_spec.rb
@@ -61,5 +61,23 @@ describe LogStash::Plugins::Registry do
       registry.add(:filter, "simple_plugin", SimplePlugin)
       expect(registry.lookup("filter", "simple_plugin")).to eq(SimplePlugin)
     end
+
+    it "doesn't add multiple time the same plugin" do
+      plugin1 = Class.new
+      plugin2 = Class.new
+
+      registry.add(:filter, "simple_plugin", plugin1)
+      registry.add(:filter, "simple_plugin", plugin2)
+
+      expect(registry.plugins_with_type(:filter)).to include(plugin1)
+      expect(registry.plugins_with_type(:filter).size).to eq(1)
+    end
+
+    it "allow you find plugin by type" do
+      registry.add(:filter, "simple_plugin", SimplePlugin)
+
+      expect(registry.plugins_with_type(:filter)).to include(SimplePlugin)
+      expect(registry.plugins_with_type(:modules)).to match([])
+    end
   end
 end


### PR DESCRIPTION
type

This expose some of the internal of the registry to the outside world to
allow other part of the system to retrieves plugins.

This change was motivated by #6851 to retrieve the installed list of
modules.