### PR TITLE
Replace the class declaration with let statements

### DIFF
--- a/logstash-core/spec/logstash/plugins/registry_spec.rb
+++ b/logstash-core/spec/logstash/plugins/registry_spec.rb
@@ -53,13 +53,12 @@ describe LogStash::Plugins::Registry do
   end
 
   context "when loading plugin manually configured" do
-    it "should return the plugin" do
-      class SimplePlugin
-      end
+    let(:simple_plugin) { Class.new }
 
+    it "should return the plugin" do
       expect { registry.lookup("filter", "simple_plugin") }.to raise_error(LoadError)
-      registry.add(:filter, "simple_plugin", SimplePlugin)
-      expect(registry.lookup("filter", "simple_plugin")).to eq(SimplePlugin)
+      registry.add(:filter, "simple_plugin", simple_plugin)
+      expect(registry.lookup("filter", "simple_plugin")).to eq(simple_plugin)
     end
 
     it "doesn't add multiple time the same plugin" do
@@ -74,9 +73,9 @@ describe LogStash::Plugins::Registry do
     end
 
     it "allow you find plugin by type" do
-      registry.add(:filter, "simple_plugin", SimplePlugin)
+      registry.add(:filter, "simple_plugin", simple_plugin)
 
-      expect(registry.plugins_with_type(:filter)).to include(SimplePlugin)
+      expect(registry.plugins_with_type(:filter)).to include(simple_plugin)
       expect(registry.plugins_with_type(:modules)).to match([])
     end
   end


### PR DESCRIPTION
Instead of using a concrete class use let statement instead, this make
sure they are reset between run and make the variable available at the
context level.

This issue was found in https://github.com/elastic/logstash/pull/7008 and was generating the following errors. Depending of the ordering of the test, the class could be available or not.


```
  1) LogStash::Plugins::Registry when loading plugin manually configured allow you find plugin by type
     Failure/Error: registry.add(:filter, "simple_plugin", SimplePlugin)
     NameError:
       uninitialized constant SimplePlugin
     # ./logstash-core/spec/logstash/plugins/registry_spec.rb:77:in `(root)'
     # ./vendor/bundle/jruby/1.9/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `(root)'
     # ./rakelib/test.rake:47:in `(root)'
```
