### PR TITLE
Set release-state to released

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -10,7 +10,7 @@
 //////////
 release-state can be: released | prerelease | unreleased
 //////////
-:release-state:  unreleased
+:release-state:  released
 
 :jdk:                   1.8.0
 :guide:                 https://www.elastic.co/guide/en/elasticsearch/guide/current/


### PR DESCRIPTION
Changes the release state to "released" for 5.4 (required for the installation instructions to show in the docs).