### PR TITLE
#7022 unopened queue was throwing npe

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -140,7 +140,14 @@ public class Queue implements Closeable {
     }
 
     public long getPersistedByteSize() {
-        return headPage.getPageIO().getHead() + tailPages.stream().mapToLong((p) -> p.getPageIO().getHead()).sum();
+        final long size;
+        if (headPage == null) {
+            size = 0L;
+        } else {
+            size = headPage.getPageIO().getHead()
+                + tailPages.stream().mapToLong(p -> p.getPageIO().getHead()).sum();
+        }
+        return size;
     }
 
     public int getPageCapacity() {

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
@@ -725,4 +725,11 @@ public class QueueTest {
         q.close();
     }
 
+    @Test
+    public void getsPersistedByteSizeCorrectlyForUnopened() throws Exception {
+        Settings settings = TestSettings.persistedQueueSettings(100, dataPath);
+        try (Queue q = new Queue(settings)) {
+            assertThat(q.getPersistedByteSize(), is(equalTo(0L)));
+        }
+    }
 }


### PR DESCRIPTION
Handling #7022 

* Obvious NPE since the `headPage` isn't set until `open` is called on the `Queue`.