### PR TITLE
ci: fix run single specs

### DIFF
--- a/qa/integration/framework/helpers.rb
+++ b/qa/integration/framework/helpers.rb
@@ -3,6 +3,9 @@
 require "flores/random"
 require "fileutils"
 require "zip"
+require "stud/temporary"
+require "socket"
+require "ostruct"
 
 def wait_for_port(port, retry_attempts)
   tries = retry_attempts

--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -2,6 +2,7 @@ require_relative "monitoring_api"
 
 require "childprocess"
 require "bundler"
+require "socket"
 require "tempfile"
 require 'yaml'
 

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -2,6 +2,7 @@ require_relative '../framework/fixture'
 require_relative '../framework/settings'
 require_relative '../services/logstash_service'
 require "logstash/devutils/rspec/spec_helper"
+require"stud/try"
 
 describe "Test Monitoring API" do
   before(:all) {


### PR DESCRIPTION
Some integration spec tests fail to run
individually due missing require modules.

This fix it by ensuring all specs and helpers
require the needed modules.

Fixes #7037