### PR TITLE
Minor: Some cleanup in queue java code

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/HeadPage.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/HeadPage.java
@@ -9,13 +9,13 @@ import java.util.BitSet;
 public class HeadPage extends Page {
 
     // create a new HeadPage object and new page.{pageNum} empty valid data file
-    public HeadPage(int pageNum, Queue queue, PageIO pageIO) throws IOException {
+    public HeadPage(int pageNum, Queue queue, PageIO pageIO) {
         super(pageNum, queue, 0, 0, 0, new BitSet(), pageIO);
     }
 
     // create a new HeadPage object from an existing checkpoint and open page.{pageNum} empty valid data file
     // @param pageIO is expected to be open/recover/create
-    public HeadPage(Checkpoint checkpoint, Queue queue, PageIO pageIO) throws IOException {
+    public HeadPage(Checkpoint checkpoint, Queue queue, PageIO pageIO) {
         super(checkpoint.getPageNum(), queue, checkpoint.getMinSeqNum(), checkpoint.getElementCount(), checkpoint.getFirstUnackedSeqNum(), new BitSet(), pageIO);
 
         assert checkpoint.getMinSeqNum() == pageIO.getMinSeqNum() && checkpoint.getElementCount() == pageIO.getElementCount() :

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/AbstractByteBufferPageIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/AbstractByteBufferPageIO.java
@@ -248,7 +248,7 @@ public abstract class AbstractByteBufferPageIO implements PageIO {
             }
         }
 
-        return new SequencedList<byte[]>(elements, seqNums);
+        return new SequencedList<>(elements, seqNums);
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/FileCheckpointIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/FileCheckpointIO.java
@@ -35,10 +35,10 @@ public class FileCheckpointIO  implements CheckpointIO {
             + Integer.BYTES  // eventCount
             + Integer.BYTES;    // checksum
 
+    private static final String HEAD_CHECKPOINT = "checkpoint.head";
+    private static final String TAIL_CHECKPOINT = "checkpoint.";
+    private static final OpenOption[] WRITE_OPTIONS = { WRITE, CREATE, TRUNCATE_EXISTING, DSYNC };
     private final String dirPath;
-    private final String HEAD_CHECKPOINT = "checkpoint.head";
-    private final String TAIL_CHECKPOINT = "checkpoint.";
-    private final OpenOption[] WRITE_OPTIONS = new OpenOption[] { WRITE, CREATE, TRUNCATE_EXISTING, DSYNC };
 
     public FileCheckpointIO(String dirPath) {
         this.dirPath = dirPath;

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/MmapPageIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/MmapPageIO.java
@@ -21,7 +21,7 @@ public class MmapPageIO extends AbstractByteBufferPageIO {
     private FileChannel channel;
     protected MappedByteBuffer buffer;
 
-    public MmapPageIO(int pageNum, int capacity, String dirPath) throws IOException {
+    public MmapPageIO(int pageNum, int capacity, String dirPath) {
         super(pageNum, capacity);
 
         this.file = Paths.get(dirPath, "page." + pageNum).toFile();


### PR DESCRIPTION
Just some (very) minor points I found when looking over the PQ code:

* Removed some wrong/redundant exception declarations
* Made actual constants `static`
* Used diamond for one redundant type annotation