### PR TITLE
Refactor SourceLoader to no longer be a singleton.

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -48,7 +48,7 @@ class LogStash::Agent
 
     # This is for backward compatibility in the tests
     if source_loader.nil?
-      @source_loader = LogStash::Config::SOURCE_LOADER
+      @source_loader = LogStash::Config::SourceLoader.new
       @source_loader.add_source(LogStash::Config::Source::Local.new(@settings))
     else
       @source_loader = source_loader

--- a/logstash-core/lib/logstash/config/source_loader.rb
+++ b/logstash-core/lib/logstash/config/source_loader.rb
@@ -120,6 +120,4 @@ module LogStash module Config
         .select { |group, pipeline_configs| pipeline_configs.size > 1 }
     end
   end
-
-  SOURCE_LOADER = SourceLoader.new
 end end

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -143,10 +143,6 @@ describe LogStash::Runner do
   end
 
   describe "--config.test_and_exit" do
-    before do
-      # Reset the source in a clean state before any asserts
-      LogStash::Config::SOURCE_LOADER.configure_sources([])
-    end
     subject { LogStash::Runner.new("") }
     let(:args) { ["-t", "-e", pipeline_string] }
 


### PR DESCRIPTION
This cleans up the code from a design patterns standpoint and makes testing plugins easier since you can just create/destroy agents at will.

Without this change the SOURCE_LOADER singleton's state will become dirty as agents are created/destroyed and be problematic.