### PR TITLE
gitignore .lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,6 @@ Gemfile
 *.iml
 .idea
 logs
+.lock
 qa/integration/services/installed/
 .gradle


### PR DESCRIPTION
This file is left after clean builds still (100% of the time for me).