### PR TITLE
Compile multiple sources together into one LIR pipeline

### DIFF
--- a/logstash-core/lib/logstash/compiler.rb
+++ b/logstash-core/lib/logstash/compiler.rb
@@ -26,7 +26,9 @@ module LogStash; class Compiler
       end
     end
 
-    org.logstash.config.ir.Pipeline.new(input_graph, filter_graph, output_graph)
+    original_source = sources_with_metadata.join("\n")
+
+    org.logstash.config.ir.Pipeline.new(input_graph, filter_graph, output_graph, original_source)
   end
 
   def self.compile_ast(source_with_metadata)

--- a/logstash-core/lib/logstash/compiler/lscl.rb
+++ b/logstash-core/lib/logstash/compiler/lscl.rb
@@ -10,15 +10,23 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
   module Helpers
     def source_meta
       line, column = line_and_column
-      org.logstash.common.SourceWithMetadata.new(source_file, line, column, self.text_value)
+      org.logstash.common.SourceWithMetadata.new(base_protocol, base_id, line, column, self.text_value)
     end
 
-    def source_file=(value)
-      set_meta(:source_file, value)
+    def base_source_with_metadata=(value)
+      set_meta(:base_source_with_metadata, value)
     end
     
-    def source_file
-      get_meta(:source_file)
+    def base_source_with_metadata
+      get_meta(:base_source_with_metadata)
+    end
+
+    def base_protocol
+      self.base_source_with_metadata.protocol
+    end
+
+    def base_id
+      self.base_source_with_metadata.id
     end
 
     def compose(*statements)
@@ -39,7 +47,7 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
     end
 
     def empty_source_meta()
-      org.logstash.common.SourceWithMetadata.new()
+      org.logstash.common.SourceWithMetadata.new(base_protocol, base_id, nil)
     end
 
     def jdsl
@@ -70,9 +78,9 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
   class Config < Node
     include Helpers
     
-    def compile(source_file=nil)
+    def compile(base_source_with_metadata=nil)
       # There is no way to move vars across nodes in treetop :(
-      self.source_file = source_file
+      self.base_source_with_metadata = base_source_with_metadata
 
       sections = recursive_select(PluginSection)
 

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -73,7 +73,8 @@ module LogStash; class BasePipeline
   end
 
   def compile_lir
-    LogStash::Compiler.compile_pipeline(self.config_str)
+    source_with_metadata = org.logstash.common.SourceWithMetadata.new("str", "pipeline", self.config_str)
+    LogStash::Compiler.compile_sources(source_with_metadata)
   end
 
   def plugin(plugin_type, name, *args)

--- a/logstash-core/src/main/java/org/logstash/config/ir/BaseSourceComponent.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/BaseSourceComponent.java
@@ -16,7 +16,7 @@ public abstract class BaseSourceComponent implements SourceComponent {
         this.meta = meta;
     }
 
-    public SourceWithMetadata getMeta() {
+    public SourceWithMetadata getSourceWithMetadata() {
         return meta;
     }
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/Pipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/Pipeline.java
@@ -1,5 +1,6 @@
 package org.logstash.config.ir;
 
+import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.graph.Graph;
 import org.logstash.config.ir.graph.PluginVertex;
 import org.logstash.config.ir.graph.QueueVertex;

--- a/logstash-core/src/main/java/org/logstash/config/ir/Pipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/Pipeline.java
@@ -22,15 +22,15 @@ public class Pipeline implements Hashable {
         return queue;
     }
 
-    //public QueueVertex getFilterOut() {
-    //    return filterOut;
-    //}
-
     private final Graph graph;
     private final QueueVertex queue;
-    //private final QueueVertex filterOut;
+    // Temporary until we have LIR execution
+    // Then we will no longer need this property here
+    private final String originalSource;
 
-    public Pipeline(Graph inputSection, Graph filterSection, Graph outputSection) throws InvalidIRException {
+    public Pipeline(Graph inputSection, Graph filterSection, Graph outputSection, String originalSource) throws InvalidIRException {
+        this.originalSource = originalSource;
+
         // Validate all incoming graphs, we can't turn an invalid graph into a Pipeline!
         inputSection.validate();
         filterSection.validate();
@@ -47,6 +47,10 @@ public class Pipeline implements Hashable {
 
         // Finally, connect the filter out node to all the outputs
         this.graph = tempGraph.chain(outputSection);
+    }
+
+    public String getOriginalSource() {
+        return this.originalSource;
     }
 
     public List<Vertex> getPostQueue() throws InvalidIRException {

--- a/logstash-core/src/main/java/org/logstash/config/ir/PluginDefinition.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/PluginDefinition.java
@@ -97,7 +97,7 @@ public class PluginDefinition implements SourceComponent, Hashable {
     }
 
     @Override
-    public SourceWithMetadata getMeta() {
+    public SourceWithMetadata getSourceWithMetadata() {
         return null;
     }
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/SourceComponent.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/SourceComponent.java
@@ -7,5 +7,5 @@ import org.logstash.common.SourceWithMetadata;
  */
 public interface SourceComponent {
     boolean sourceComponentEquals(SourceComponent sourceComponent);
-    SourceWithMetadata getMeta();
+    SourceWithMetadata getSourceWithMetadata();
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/Edge.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/Edge.java
@@ -93,7 +93,7 @@ public abstract class Edge implements SourceComponent {
     public abstract String getId();
 
     @Override
-    public SourceWithMetadata getMeta() {
+    public SourceWithMetadata getSourceWithMetadata() {
         return null;
     }
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/Graph.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/Graph.java
@@ -403,7 +403,7 @@ public class Graph implements SourceComponent, Hashable {
     }
 
     @Override
-    public SourceWithMetadata getMeta() {
+    public SourceWithMetadata getSourceWithMetadata() {
         return null;
     }
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/IfVertex.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/IfVertex.java
@@ -43,7 +43,7 @@ public class IfVertex extends Vertex {
 
     // An IfVertex has no real metadata in and of itself, but its expression does!
     @Override
-    public SourceWithMetadata getMeta() {
+    public SourceWithMetadata getSourceWithMetadata() {
         return null;
     }
 
@@ -83,7 +83,7 @@ public class IfVertex extends Vertex {
     // The easiest readable version of this for a human.
     // If the original source is available we use that, otherwise we serialize the expression
     public String humanReadableExpression() {
-        String sourceText = this.booleanExpression.getMeta() != null ? this.booleanExpression.getMeta().getText() : null;
+        String sourceText = this.booleanExpression.getSourceWithMetadata() != null ? this.booleanExpression.getSourceWithMetadata().getText() : null;
         if (sourceText != null) {
             return sourceText;
         } else {
@@ -93,7 +93,7 @@ public class IfVertex extends Vertex {
 
     @Override
     public IfVertex copy() {
-        return new IfVertex(getMeta(),getBooleanExpression());
+        return new IfVertex(getSourceWithMetadata(),getBooleanExpression());
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/PluginVertex.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/PluginVertex.java
@@ -27,7 +27,7 @@ public class PluginVertex extends Vertex {
         return pluginDefinition;
     }
     @Override
-    public SourceWithMetadata getMeta() {
+    public SourceWithMetadata getSourceWithMetadata() {
         return meta;
     }
 
@@ -43,7 +43,7 @@ public class PluginVertex extends Vertex {
     }
 
     public String toString() {
-        return "P[" + pluginDefinition + "|" + this.getMeta() + "]";
+        return "P[" + pluginDefinition + "|" + this.getSourceWithMetadata() + "]";
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/QueueVertex.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/QueueVertex.java
@@ -38,7 +38,7 @@ public class QueueVertex extends Vertex {
 
     // Special vertices really have no metadata
     @Override
-    public SourceWithMetadata getMeta() {
+    public SourceWithMetadata getSourceWithMetadata() {
         return null;
     }
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/imperative/IfStatement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/imperative/IfStatement.java
@@ -89,7 +89,7 @@ public class IfStatement extends Statement {
         Collection<Vertex> trueRoots = trueGraph.roots().map(combination.oldToNewVertices::get).collect(Collectors.toList());
         Collection<Vertex> falseRoots = falseGraph.roots().map(combination.oldToNewVertices::get).collect(Collectors.toList());
 
-        IfVertex ifVertex = new IfVertex(this.getMeta(), this.booleanExpression);
+        IfVertex ifVertex = new IfVertex(this.getSourceWithMetadata(), this.booleanExpression);
         newGraph.addVertex(ifVertex);
 
         for (Vertex v : trueRoots) {

--- a/logstash-core/src/main/java/org/logstash/config/ir/imperative/PluginStatement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/imperative/PluginStatement.java
@@ -37,7 +37,7 @@ public class PluginStatement extends Statement {
 
     @Override
     public Graph toGraph() throws InvalidIRException {
-        Vertex pluginVertex = new PluginVertex(getMeta(), pluginDefinition);
+        Vertex pluginVertex = new PluginVertex(getSourceWithMetadata(), pluginDefinition);
         Graph g = Graph.empty();
         g.addVertex(pluginVertex);
         return g;

--- a/logstash-core/src/test/java/org/logstash/config/ir/IRHelpers.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/IRHelpers.java
@@ -75,7 +75,7 @@ public class IRHelpers {
         }
 
         @Override
-        public SourceWithMetadata getMeta() {
+        public SourceWithMetadata getSourceWithMetadata() {
             return null;
         }
     }


### PR DESCRIPTION
This adds methods to the compiler that allow it to take multiple `SourceWithMetadata` objects and compile them together into one LIR Pipeline object.

This also sets us up to correctly set the protocol / metadata fields for LIR
pipelines and work on the refactor mentioned in https://github.com/elastic/logstash/issues/7054