### PR TITLE
Minor: Stop allocating byte[] to compute CRC32

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/AbstractByteBufferPageIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/AbstractByteBufferPageIO.java
@@ -1,15 +1,13 @@
 package org.logstash.ackedqueue.io;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.logstash.ackedqueue.SequencedList;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.CRC32;
-import java.util.zip.Checksum;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.logstash.ackedqueue.SequencedList;
 
 public abstract class AbstractByteBufferPageIO implements PageIO {
 
@@ -44,7 +42,7 @@ public abstract class AbstractByteBufferPageIO implements PageIO {
     protected int elementCount;
     protected int head; // head is the write position and is an int per ByteBuffer class position
     protected byte version;
-    protected Checksum checkSummer;
+    private CRC32 checkSummer;
 
     public AbstractByteBufferPageIO(int pageNum, int capacity) {
         this.minSeqNum = 0;
@@ -155,10 +153,13 @@ public abstract class AbstractByteBufferPageIO implements PageIO {
 
         if (verifyChecksum) {
             // read data and compute checksum;
-            byte[] readBytes = new byte[length];
-            buffer.get(readBytes);
+            this.checkSummer.reset();
+            final int prevLimit = buffer.limit();
+            buffer.limit(buffer.position() + length);
+            this.checkSummer.update(buffer);
+            buffer.limit(prevLimit);
             int checksum = buffer.getInt();
-            int computedChecksum = checksum(readBytes);
+            int computedChecksum = (int) this.checkSummer.getValue();
             if (computedChecksum != checksum) { throw new PageIOInvalidElementException("Element invalid checksum"); }
         }
 


### PR DESCRIPTION
Found this today while working on #6998, freebie performance improvement for `open()` imo :)

The `CRC32` can pass a `DirectByteBuffer` (which we have) straight to the underlying `native` call for the crc32 calculation which should be faster right away.
+ Saves us a ton of `byte[]` GC.

Also made the `CRC32` `private` since no child class was using it (and it's mutable and not threadsafe)