### PR TITLE
make rspec use the format documentation when running any suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,18 +11,16 @@ rvm:
 jdk:
   - oraclejdk8
 env:
-  - INTEGRATION=false
-  - INTEGRATION=true
-  - INTEGRATION=false FEATURE_FLAG=persistent_queues
-  - INTEGRATION=true FEATURE_FLAG=persistent_queues
+  - INTEGRATION=false SPEC_OPTS="--order rand --format documentation"
+  - INTEGRATION=true SPEC_OPTS="--order rand --format documentation"
+  - INTEGRATION=false FEATURE_FLAG=persistent_queues SPEC_OPTS="--order rand --format documentation"
+  - INTEGRATION=true FEATURE_FLAG=persistent_queues SPEC_OPTS="--order rand --format documentation"
 before_install:
   # Force bundler 1.12.5 because version 1.13 has issues, see https://github.com/fastlane/fastlane/issues/6065#issuecomment-246044617
   - yes | gem uninstall -q -i /home/travis/.rvm/gems/jruby-1.7.25@global bundler
   - gem install bundler -v 1.12.5 --no-rdoc --no-ri --no-document --quiet
 install:
   - rake test:install-core
-before_script:
-  - echo "--order rand" > .rspec
 script:
   - |+
       if [ "$INTEGRATION" == "true" ]; then


### PR DESCRIPTION
We suite from the default dot formatter to the documentation format,
this will help localize some error in the build