### PR TITLE
Check for empty string when configuring proxies

### DIFF
--- a/lib/pluginmanager/proxy_support.rb
+++ b/lib/pluginmanager/proxy_support.rb
@@ -56,14 +56,16 @@ end
 
 def configure_proxy
   proxies = []
-  if proxy = (ENV["http_proxy"] || ENV["HTTP_PROXY"])
+  proxy = (ENV["http_proxy"] || ENV["HTTP_PROXY"])
+  if !proxy.nil? && !proxy.strip.empty?
     proxy_settings = extract_proxy_values_from_uri(proxy)
     proxy_settings[:protocol] = "http"
     apply_env_proxy_settings(proxy_settings)
     proxies << proxy_settings
   end
 
-  if proxy = (ENV["https_proxy"] || ENV["HTTPS_PROXY"])
+  proxy = (ENV["https_proxy"] || ENV["HTTPS_PROXY"])
+  if !proxy.nil? && !proxy.strip.empty?
     proxy_settings = extract_proxy_values_from_uri(proxy)
     proxy_settings[:protocol] = "https"
     apply_env_proxy_settings(proxy_settings)

--- a/lib/pluginmanager/proxy_support.rb
+++ b/lib/pluginmanager/proxy_support.rb
@@ -54,18 +54,26 @@ def extract_proxy_values_from_uri(proxy_uri)
   }
 end
 
+def get_proxy(key)
+  ENV[key.downcase] || ENV[key.upcase]
+end
+
+def valid_proxy?(proxy)
+  !proxy.nil? && !proxy.strip.empty?
+end
+
 def configure_proxy
   proxies = []
-  proxy = (ENV["http_proxy"] || ENV["HTTP_PROXY"])
-  if !proxy.nil? && !proxy.strip.empty?
+  proxy = get_proxy("http_proxy")
+  if valid_proxy?(proxy)
     proxy_settings = extract_proxy_values_from_uri(proxy)
     proxy_settings[:protocol] = "http"
     apply_env_proxy_settings(proxy_settings)
     proxies << proxy_settings
   end
 
-  proxy = (ENV["https_proxy"] || ENV["HTTPS_PROXY"])
-  if !proxy.nil? && !proxy.strip.empty?
+  proxy = get_proxy("https_proxy")
+  if valid_proxy?(proxy)
     proxy_settings = extract_proxy_values_from_uri(proxy)
     proxy_settings[:protocol] = "https"
     apply_env_proxy_settings(proxy_settings)

--- a/spec/unit/plugin_manager/proxy_support_spec.rb
+++ b/spec/unit/plugin_manager/proxy_support_spec.rb
@@ -112,4 +112,21 @@ describe "Proxy support" do
       }
     end
   end
+
+  context "when proxies are set with an empty string" do
+    let(:environments) {
+      {
+        "http_proxy" => "",
+        "https_proxy" => ""
+      }
+    }
+
+    before do
+      environments.each { |key, value| ENV[key] = value }
+    end
+
+    it "doesn't raise an exception" do
+      expect { configure_proxy }.not_to raise_exception
+    end
+  end
 end


### PR DESCRIPTION
On some Linux system like debian, the `HTTP_PROXY` are set to an empty
string and was causing the plugin manager to raise an exception. We now
strip the string and check if it is empty before trying to configure the
proxies.

Fixes: #7045