### PR TITLE
make integration specs a bit more resilient

### DIFF
--- a/qa/integration/specs/01_logstash_bin_smoke_spec.rb
+++ b/qa/integration/specs/01_logstash_bin_smoke_spec.rb
@@ -29,7 +29,7 @@ describe "Test Logstash instance" do
   let(:file_config2) { Stud::Temporary.file.path }
   let(:file_config3) { Stud::Temporary.file.path }
 
-  let(:num_retries) { 10 }
+  let(:num_retries) { 50 }
   let(:config1) { config_to_temp_file(@fixture.config("root", { :port => port1, :random_file => file_config1 })) }
   let(:config2) { config_to_temp_file(@fixture.config("root", { :port => port2 , :random_file => file_config2 })) }
   let(:config3) { config_to_temp_file(@fixture.config("root", { :port => port3, :random_file => file_config3 })) }
@@ -42,7 +42,7 @@ describe "Test Logstash instance" do
   it "can start the embedded http server on default port 9600" do
     @ls1.start_with_stdin
     try(num_retries) do
-      expect(is_port_open?(9600)).to be true
+      expect(is_port_open?(9600)).to be(true)
     end
   end
 
@@ -56,7 +56,7 @@ describe "Test Logstash instance" do
       expect(is_port_open?(9600)).to be true
 
       @ls2.spawn_logstash("-f", config2, "--path.data", tmp_data_path)
-      try(20) do
+      try(num_retries) do
         expect(@ls2.exited?).to be(true)
       end
       expect(@ls2.exit_code).to be(1)
@@ -131,7 +131,7 @@ describe "Test Logstash instance" do
   it "should abort if both -f and -e are specified" do
     config_string = "input { tcp { port => #{port1} } }"
     @ls1.spawn_logstash("-e", config_string, "-f", config2)
-    try(20) do
+    try(num_retries) do
       expect(@ls1.exited?).to be(true)
     end
     expect(@ls1.exit_code).to be(1)

--- a/qa/integration/specs/env_variables_config_spec.rb
+++ b/qa/integration/specs/env_variables_config_spec.rb
@@ -13,7 +13,7 @@ describe "Test Logstash configuration" do
     @fixture.teardown
   }
   
-  let(:num_retries) { 10 }
+  let(:num_retries) { 50 }
   let(:test_tcp_port) { random_port }
   let(:test_tag) { "environment_variables_are_evil" }
   let(:test_path) { Stud::Temporary.directory }

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -23,13 +23,8 @@ describe "Test Monitoring API" do
   it "can retrieve event stats" do
     logstash_service = @fixture.get_service("logstash")
     logstash_service.start_with_stdin
+    logstash_service.wait_for_logstash
     number_of_events.times { logstash_service.write_to_stdin("Hello world") }
-
-    begin
-      sleep(1) while (result = logstash_service.monitoring_api.event_stats).nil?
-    rescue
-      retry
-    end
 
     Stud.try(max_retry.times, RSpec::Expectations::ExpectationNotMetError) do
        result = logstash_service.monitoring_api.event_stats


### PR DESCRIPTION
increase the number of tries and rely more on `@logstash_service.wait_for_logstash`
