### PR TITLE
Ignore java build files in logstash-core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ logs
 .lock
 qa/integration/services/installed/
 .gradle
+**/.settings
+**/.classpath
+logstash-core/bin


### PR DESCRIPTION
These files came in some recent master commit and are safe to ignore byproducts of the compile task.