### PR TITLE
#6785 Interpolate ENV into settings read from logstash.yml

### DIFF
--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -33,37 +33,21 @@ LogStash::Environment.load_locale!
 # }
 #
 module LogStash::Config::Mixin
+  
+  include LogStash::Util::EnvironmentVariables
+  
   attr_accessor :config
   attr_accessor :original_params
 
   PLUGIN_VERSION_1_0_0 = LogStash::Util::PluginVersion.new(1, 0, 0)
   PLUGIN_VERSION_0_9_0 = LogStash::Util::PluginVersion.new(0, 9, 0)
-
-  ENV_PLACEHOLDER_REGEX = /\$\{(?<name>\w+)(\:(?<default>[^}]*))?\}/
-
+  
   # This method is called when someone does 'include LogStash::Config'
   def self.included(base)
     # Add the DSL methods to the 'base' given.
     base.extend(LogStash::Config::Mixin::DSL)
   end
-
-  # Recursive method to replace environment variable references in parameters
-  def deep_replace(value)
-    if (value.is_a?(Hash))
-      value.each do |valueHashKey, valueHashValue|
-        value[valueHashKey.to_s] = deep_replace(valueHashValue)
-      end
-    else
-      if (value.is_a?(Array))
-        value.each_index do | valueArrayIndex|
-          value[valueArrayIndex] = deep_replace(value[valueArrayIndex])
-        end
-      else
-        return replace_env_placeholders(value)
-      end
-    end
-  end
-
+  
   def config_init(params)
     # Validation will modify the values inside params if necessary.
     # For example: converting a string to a number, etc.
@@ -157,27 +141,6 @@ module LogStash::Config::Mixin
 
     @config = params
   end # def config_init
-
-  # Replace all environment variable references in 'value' param by environment variable value and return updated value
-  # Process following patterns : $VAR, ${VAR}, ${VAR:defaultValue}
-  def replace_env_placeholders(value)
-    return value unless value.is_a?(String)
-
-    value.gsub(ENV_PLACEHOLDER_REGEX) do |placeholder|
-      # Note: Ruby docs claim[1] Regexp.last_match is thread-local and scoped to
-      # the call, so this should be thread-safe.
-      #
-      # [1] http://ruby-doc.org/core-2.1.1/Regexp.html#method-c-last_match
-      name = Regexp.last_match(:name)
-      default = Regexp.last_match(:default)
-
-      replacement = ENV.fetch(name, default)
-      if replacement.nil?
-        raise LogStash::ConfigurationError, "Cannot evaluate `#{placeholder}`. Environment variable `#{name}` is not set and there is no default value given."
-      end
-      replacement
-    end
-  end # def replace_env_placeholders
 
   module DSL
     attr_accessor :flags

--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -2,11 +2,14 @@
 require "logstash/util/loggable"
 require "fileutils"
 require "logstash/util/byte_value"
+require "logstash/util/environment_variables"
 require "logstash/util/time_value"
 
 module LogStash
   class Settings
 
+    include LogStash::Util::EnvironmentVariables
+    
     def initialize
       @settings = {}
       # Theses settings were loaded from the yaml file
@@ -108,8 +111,10 @@ module LogStash
 
     def from_yaml(yaml_path)
       settings = read_yaml(::File.join(yaml_path, "logstash.yml"))
-      substitute_env(settings)
-      self.merge(flatten_hash(settings), true)
+      self.merge(
+        deep_replace(flatten_hash(settings)),
+        true
+      )
       self
     end
     
@@ -148,15 +153,6 @@ module LogStash
         h.each { |k,r| flatten_hash(r,"#{f}.#{k}",g) }
       end
       g
-    end
-
-    # Substitutes environment variables into setting values of string type.
-    def substitute_env(settings)
-      settings.each do |_, setting|
-        if setting.is_a? String
-          setting.gsub!(/\$([a-zA-Z_.][a-zA-Z0-9_.]*)|\${\g<1>}|%\g<1>%/) {ENV[$1]}
-        end
-      end
     end
   end
 

--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -108,6 +108,7 @@ module LogStash
 
     def from_yaml(yaml_path)
       settings = read_yaml(::File.join(yaml_path, "logstash.yml"))
+      substitute_env(settings)
       self.merge(flatten_hash(settings), true)
       self
     end
@@ -147,6 +148,15 @@ module LogStash
         h.each { |k,r| flatten_hash(r,"#{f}.#{k}",g) }
       end
       g
+    end
+
+    # Substitutes environment variables into setting values of string type.
+    def substitute_env(settings)
+      settings.each do |_, setting|
+        if setting.is_a? String
+          setting.gsub!(/\$([a-zA-Z_.][a-zA-Z0-9_.]*)|\${\g<1>}|%\g<1>%/) {ENV[$1]}
+        end
+      end
     end
   end
 

--- a/logstash-core/lib/logstash/util/environment_variables.rb
+++ b/logstash-core/lib/logstash/util/environment_variables.rb
@@ -1,0 +1,43 @@
+# encoding: utf-8
+module ::LogStash::Util::EnvironmentVariables
+
+  ENV_PLACEHOLDER_REGEX = /\${(?<name>[a-zA-Z_.][a-zA-Z0-9_.]*)(:(?<default>[^}]*))?}/
+
+  # Recursive method to replace environment variable references in parameters
+  def deep_replace(value)
+    if value.is_a?(Hash)
+      value.each do |valueHashKey, valueHashValue|
+        value[valueHashKey.to_s] = deep_replace(valueHashValue)
+      end
+    else
+      if value.is_a?(Array)
+        value.each_index do | valueArrayIndex|
+          value[valueArrayIndex] = deep_replace(value[valueArrayIndex])
+        end
+      else
+        return replace_env_placeholders(value)
+      end
+    end
+  end
+
+  # Replace all environment variable references in 'value' param by environment variable value and return updated value
+  # Process following patterns : $VAR, ${VAR}, ${VAR:defaultValue}
+  def replace_env_placeholders(value)
+    return value unless value.is_a?(String)
+
+    value.gsub(ENV_PLACEHOLDER_REGEX) do |placeholder|
+      # Note: Ruby docs claim[1] Regexp.last_match is thread-local and scoped to
+      # the call, so this should be thread-safe.
+      #
+      # [1] http://ruby-doc.org/core-2.1.1/Regexp.html#method-c-last_match
+      name = Regexp.last_match(:name)
+      default = Regexp.last_match(:default)
+
+      replacement = ENV.fetch(name, default)
+      if replacement.nil?
+        raise LogStash::ConfigurationError, "Cannot evaluate `#{placeholder}`. Environment variable `#{name}` is not set and there is no default value given."
+      end
+      replacement
+    end
+  end # def replace_env_placeholders
+end

--- a/logstash-core/spec/logstash/settings_spec.rb
+++ b/logstash-core/spec/logstash/settings_spec.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require "spec_helper"
+require "logstash/util/environment_variables"
 require "logstash/settings"
 require "fileutils"
 
@@ -160,14 +161,12 @@ describe LogStash::Settings do
         settings = described_class.new
         settings.register(LogStash::Setting::String.new("interpolated", "missing"))
         settings.register(LogStash::Setting::String.new("with_dot", "missing"))
-        settings.register(LogStash::Setting::String.new("windows_notation", "missing"))
         settings
       end
 
       let(:values) {{
         "interpolated" => "${SOME_LOGSTASH_SPEC_ENV_VAR}",
-        "with_dot" => "${some.logstash.spec.env.var}",
-        "windows_notation" => "%SOME_LOGSTASH_SPEC_ENV_VAR%",
+        "with_dot" => "${some.logstash.spec.env.var}"
       }}
       let(:yaml_path) do
         p = Stud::Temporary.pathname
@@ -182,13 +181,11 @@ describe LogStash::Settings do
       it "can interpolate environment into settings" do
         expect(subject.get('interpolated')).to eq("missing")
         expect(subject.get('with_dot')).to eq("missing")
-        expect(subject.get('windows_notation')).to eq("missing")
         ENV['SOME_LOGSTASH_SPEC_ENV_VAR'] = "correct_setting"
         ENV['some.logstash.spec.env.var'] = "correct_setting_for_dotted"
         subject.from_yaml(yaml_path)
         expect(subject.get('interpolated')).to eq("correct_setting")
         expect(subject.get('with_dot')).to eq("correct_setting_for_dotted")
-        expect(subject.get('windows_notation')).to eq("correct_setting")
       end
     end
   end

--- a/logstash-core/spec/logstash/settings_spec.rb
+++ b/logstash-core/spec/logstash/settings_spec.rb
@@ -160,12 +160,14 @@ describe LogStash::Settings do
         settings = described_class.new
         settings.register(LogStash::Setting::String.new("interpolated", "missing"))
         settings.register(LogStash::Setting::String.new("with_dot", "missing"))
+        settings.register(LogStash::Setting::String.new("windows_notation", "missing"))
         settings
       end
 
       let(:values) {{
         "interpolated" => "${SOME_LOGSTASH_SPEC_ENV_VAR}",
-        "with_dot" => "${some.logstash.spec.env.var}"
+        "with_dot" => "${some.logstash.spec.env.var}",
+        "windows_notation" => "%SOME_LOGSTASH_SPEC_ENV_VAR%",
       }}
       let(:yaml_path) do
         p = Stud::Temporary.pathname
@@ -180,11 +182,13 @@ describe LogStash::Settings do
       it "can interpolate environment into settings" do
         expect(subject.get('interpolated')).to eq("missing")
         expect(subject.get('with_dot')).to eq("missing")
+        expect(subject.get('windows_notation')).to eq("missing")
         ENV['SOME_LOGSTASH_SPEC_ENV_VAR'] = "correct_setting"
         ENV['some.logstash.spec.env.var'] = "correct_setting_for_dotted"
         subject.from_yaml(yaml_path)
         expect(subject.get('interpolated')).to eq("correct_setting")
         expect(subject.get('with_dot')).to eq("correct_setting_for_dotted")
+        expect(subject.get('windows_notation')).to eq("correct_setting")
       end
     end
   end


### PR DESCRIPTION
closes #6785 

Added interpolation for env variables into settings:
* spec will only work on *nix, substitution should work on Windows as well
* ENV vars containing a dot work as shown by the spec