### PR TITLE
[wip] first step in refactoring Pipeline.new signature

### DIFF
--- a/logstash-core/lib/logstash/pipeline_action/create.rb
+++ b/logstash-core/lib/logstash/pipeline_action/create.rb
@@ -32,8 +32,8 @@ module LogStash module PipelineAction
     # The execute assume that the thread safety access of the pipeline
     # is managed by the caller.
     def execute(agent, pipelines)
-      pipeline = LogStash::Pipeline.new(@pipeline_config.config_string, @pipeline_config.settings, @metric, agent)
-      
+      pipeline = LogStash::Pipeline.new(@pipeline_config, @metric, agent)
+
       status = pipeline.start # block until the pipeline is correctly started or crashed
 
       if status

--- a/logstash-core/lib/logstash/pipeline_action/reload.rb
+++ b/logstash-core/lib/logstash/pipeline_action/reload.rb
@@ -27,7 +27,7 @@ module LogStash module PipelineAction
       end
 
       begin
-        pipeline_validator = LogStash::BasePipeline.new(@pipeline_config.config_string, @pipeline_config.settings)
+        pipeline_validator = LogStash::BasePipeline.new(@pipeline_config)
       rescue => e
         return LogStash::ConvergeResult::FailedAction.from_exception(e)
       end

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -272,7 +272,7 @@ class LogStash::Runner < Clamp::StrictCommand
         # TODO(ph): make it better for multiple pipeline
         if results.success?
           results.response.each do |pipeline_config|
-            LogStash::BasePipeline.new(pipeline_config.config_string)
+            LogStash::BasePipeline.new(pipeline_config)
           end
           puts "Configuration OK"
           logger.info "Using config.test_and_exit mode. Config Validation Result: OK. Exiting Logstash"

--- a/logstash-core/spec/logstash/pipeline_reporter_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_reporter_spec.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "spec_helper"
 require "logstash/pipeline"
+require "logstash/config/source/local"
 require "logstash/pipeline_reporter"
 require_relative "../support/mocks_classes"
 
@@ -11,7 +12,12 @@ describe LogStash::PipelineReporter do
   let(:config) do
     "input { generator { count => #{generator_count} } } output { dummyoutput {} } "
   end
-  let(:pipeline) { LogStash::Pipeline.new(config)}
+  let(:metric) { nil }
+  let(:pipeline_id) { :main }
+  let(:settings) { LogStash::SETTINGS }
+  let(:config_parts) { ::LogStash::Config::Source::Local::ConfigStringLoader.read(config) }
+  let(:pipeline_config) { ::LogStash::Config::PipelineConfig.new(nil, pipeline_id, config_parts, settings) }
+  let(:pipeline) { LogStash::Pipeline.new(pipeline_config, metric) }
   let(:reporter) { pipeline.reporter }
 
   before do

--- a/logstash-core/spec/support/helpers.rb
+++ b/logstash-core/spec/support/helpers.rb
@@ -55,6 +55,11 @@ def mock_pipeline_config(pipeline_id, config_string = nil, settings = {})
   LogStash::Config::PipelineConfig.new(LogStash::Config::Source::Local, pipeline_id, config_part, settings)
 end
 
+def mock_pipeline_from_string(config_string)
+  pipeline_config = mock_pipeline_config(:main, config_string)
+  LogStash::Pipeline.new(pipeline_config)
+end
+
 def start_agent(agent)
   agent_task = Stud::Task.new do
     begin


### PR DESCRIPTION
this PR changes the Pipeline constructor signature to accept a PipelineConfig object instead of a config_string + settings object.

the next step is to make it receive a LIRPipeline + settings object, as described in https://github.com/elastic/logstash/issues/7054#issuecomment-300195197

TODO: changes in the pipeline constructor signature require a change in logstash-devutils due to the `sample` helpers