### PR TITLE
fix monitoring api integration race condition

### DIFF
--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -27,8 +27,9 @@ describe "Test Monitoring API" do
     number_of_events.times { logstash_service.write_to_stdin("Hello world") }
 
     Stud.try(max_retry.times, RSpec::Expectations::ExpectationNotMetError) do
-       result = logstash_service.monitoring_api.event_stats
-       expect(result["in"]).to eq(number_of_events)
+      # event_stats can fail if the stats subsystem isn't ready
+      result = logstash_service.monitoring_api.event_stats rescue {}
+      expect(result["in"]).to eq(number_of_events)
     end
   end
 
@@ -38,8 +39,11 @@ describe "Test Monitoring API" do
     logstash_service.wait_for_logstash
 
     Stud.try(max_retry.times, RSpec::Expectations::ExpectationNotMetError) do
-       result = logstash_service.monitoring_api.node_stats
-       expect(result["jvm"]["uptime_in_millis"]).to be > 100
+      # node_stats can fail if the stats subsystem isn't ready
+      result = logstash_service.monitoring_api.node_stats rescue nil
+      expect(result).not_to be_nil
+      expect(result["jvm"]).not_to be_nil
+      expect(result["jvm"]["uptime_in_millis"]).to be > 100
     end
   end
 
@@ -49,7 +53,10 @@ describe "Test Monitoring API" do
     logstash_service.wait_for_logstash
 
     Stud.try(max_retry.times, RSpec::Expectations::ExpectationNotMetError) do
-      result = logstash_service.monitoring_api.node_stats
+      # node_stats can fail if the stats subsystem isn't ready
+      result = logstash_service.monitoring_api.node_stats rescue nil
+      expect(result).not_to be_nil
+      expect(result["pipeline"]).not_to be_nil
       expect(result["pipeline"]["queue"]).not_to be_nil
       if logstash_service.settings.feature_flag == "persistent_queues"
         expect(result["pipeline"]["queue"]["type"]).to eq "persisted"


### PR DESCRIPTION
because the metric subsystem may not be ready yet when the tests ask for
the values, the test code may generate a NoMethodError accessing nested
hashes.

The NoMethodError exception aborts the try mechanism instead of retrying.

This PR rescues potential exceptions and adds more expectations to
protect the try block.

fixes https://github.com/elastic/logstash/issues/6949