### PR TITLE
Rename Pipeline -> PipelineIR + Fix PipelineIR concatenation

### DIFF
--- a/logstash-core/lib/logstash/compiler.rb
+++ b/logstash-core/lib/logstash/compiler.rb
@@ -1,7 +1,7 @@
 require 'logstash/util/loggable'
 require 'logstash/compiler/lscl/lscl_grammar'
 
-java_import org.logstash.config.ir.Pipeline
+java_import org.logstash.config.ir.PipelineIR
 java_import org.logstash.config.ir.graph.Graph;
 java_import org.logstash.config.ir.graph.PluginVertex;
 
@@ -26,9 +26,9 @@ module LogStash; class Compiler
       end
     end
 
-    original_source = sources_with_metadata.join("\n")
+    original_source = sources_with_metadata.map(&:text).join("\n")
 
-    org.logstash.config.ir.Pipeline.new(input_graph, filter_graph, output_graph, original_source)
+    org.logstash.config.ir.PipelineIR.new(input_graph, filter_graph, output_graph, original_source)
   end
 
   def self.compile_ast(source_with_metadata)

--- a/logstash-core/spec/logstash/compiler/compiler_spec.rb
+++ b/logstash-core/spec/logstash/compiler/compiler_spec.rb
@@ -47,7 +47,11 @@ describe LogStash::Compiler do
       subject(:pipeline) { described_class.compile_sources(*sources_with_metadata) }
 
       it "should compile cleanly" do
-        expect(pipeline).to be_a(org.logstash.config.ir.Pipeline)
+        expect(pipeline).to be_a(org.logstash.config.ir.PipelineIR)
+      end
+
+      it "should provide the original source" do
+        expect(pipeline.original_source).to eq(sources.join("\n"))
       end
 
       describe "applying protocol and id metadata" do

--- a/logstash-core/src/main/java/org/logstash/config/ir/PipelineIR.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/PipelineIR.java
@@ -13,7 +13,7 @@ import java.util.stream.Stream;
 /**
  * Created by andrewvc on 9/20/16.
  */
-public class Pipeline implements Hashable {
+public class PipelineIR implements Hashable {
     public Graph getGraph() {
         return graph;
     }
@@ -28,10 +28,14 @@ public class Pipeline implements Hashable {
     // Then we will no longer need this property here
     private final String originalSource;
 
-    public Pipeline(Graph inputSection, Graph filterSection, Graph outputSection, String originalSource) throws InvalidIRException {
+    public PipelineIR(Graph inputSection, Graph filterSection, Graph outputSection) throws InvalidIRException {
+        this(inputSection, filterSection, outputSection, null);
+    }
+
+    public PipelineIR(Graph inputSection, Graph filterSection, Graph outputSection, String originalSource) throws InvalidIRException {
         this.originalSource = originalSource;
 
-        // Validate all incoming graphs, we can't turn an invalid graph into a Pipeline!
+        // Validate all incoming graphs, we can't turn an invalid graph into a PipelineIR!
         inputSection.validate();
         filterSection.validate();
         outputSection.validate();

--- a/logstash-core/src/test/java/org/logstash/config/ir/IRHelpers.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/IRHelpers.java
@@ -124,7 +124,7 @@ public class IRHelpers {
         return new PluginDefinition(PluginDefinition.Type.FILTER, "testDefinition", new HashMap<String, Object>());
     }
 
-    public static Pipeline samplePipeline() throws InvalidIRException {
+    public static PipelineIR samplePipeline() throws InvalidIRException {
         Graph inputSection = iComposeParallel(iPlugin(INPUT, "generator"), iPlugin(INPUT, "stdin")).toGraph();
         Graph filterSection = iIf(eEq(eEventValue("[foo]"), eEventValue("[bar]")),
                                     iPlugin(FILTER, "grok"),
@@ -135,6 +135,6 @@ public class IRHelpers {
                                             iPlugin(OUTPUT, "elasticsearch")),
                                     iPlugin(OUTPUT, "stdout")).toGraph();
 
-        return new Pipeline(inputSection, filterSection, outputSection);
+        return new PipelineIR(inputSection, filterSection, outputSection);
     }
 }

--- a/logstash-core/src/test/java/org/logstash/config/ir/PipelineIRTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/PipelineIRTest.java
@@ -11,7 +11,7 @@ import static org.logstash.config.ir.PluginDefinition.Type.*;
 /**
  * Created by andrewvc on 9/20/16.
  */
-public class PipelineTest {
+public class PipelineIRTest {
     @Test
     public void testPipelineCreation() throws InvalidIRException {
         Graph inputSection = iComposeParallel(iPlugin(INPUT, "generator"), iPlugin(INPUT, "stdin")).toGraph();
@@ -24,9 +24,9 @@ public class PipelineTest {
                                             iPlugin(OUTPUT, "elasticsearch")),
                                     iPlugin(OUTPUT, "stdout")).toGraph();
 
-        Pipeline pipeline = new Pipeline(inputSection, filterSection, outputSection);
-        assertEquals(2, pipeline.getInputPluginVertices().size());
-        assertEquals(2, pipeline.getFilterPluginVertices().size());
-        assertEquals(3, pipeline.getOutputPluginVertices().size());
+        PipelineIR pipelineIR = new PipelineIR(inputSection, filterSection, outputSection);
+        assertEquals(2, pipelineIR.getInputPluginVertices().size());
+        assertEquals(2, pipelineIR.getFilterPluginVertices().size());
+        assertEquals(3, pipelineIR.getOutputPluginVertices().size());
     }
 }


### PR DESCRIPTION
This PR helps enable https://github.com/elastic/logstash/issues/7076

This also fixes a bug where when concatenating pipelines for PipelineIR
the to_s versions of the SourceWithMetadata objects were conjoined
instead of just the `text`.