### PR TITLE
#7081 fix portability issues with Kafka Broker IPV4 and log path creation

### DIFF
--- a/qa/integration/services/kafka_setup.sh
+++ b/qa/integration/services/kafka_setup.sh
@@ -2,6 +2,8 @@
 set -ex
 current_dir="$(dirname "$0")"
 
+export _JAVA_OPTIONS="-Djava.net.preferIPv4Stack=true"
+
 source "$current_dir/helpers.sh"
 
 if [ -n "${KAFKA_VERSION+1}" ]; then
@@ -31,7 +33,8 @@ start_kafka() {
     $KAFKA_HOME/bin/zookeeper-server-start.sh -daemon $KAFKA_HOME/config/zookeeper.properties
     wait_for_port 2181
     echo "Starting Kafka broker"
-    $KAFKA_HOME/bin/kafka-server-start.sh -daemon $KAFKA_HOME/config/server.properties --override delete.topic.enable=true --override log.dirs=$KAFKA_LOGS_DIR --override log.flush.interval.ms=200
+    mkdir -p ${KAFKA_LOGS_DIR}
+    $KAFKA_HOME/bin/kafka-server-start.sh -daemon $KAFKA_HOME/config/server.properties --override delete.topic.enable=true --override advertised.host.name=127.0.0.1 --override log.dir=${KAFKA_LOGS_DIR} --override log.flush.interval.ms=200
     wait_for_port 9092
 }
 


### PR DESCRIPTION
This we need for a dockerized version too anyhow :)

* Kafka needs to advertise on loopback (this should fix the error we see here: https://travis-ci.org/elastic/logstash/jobs/231200764#L1525 , we'll see the same issue if we use Docker)
* On my mac it failed to recursively create the Kafka log path itself, would be nice to have this fixed too for debugging Dockerized spots 