### PR TITLE
Deprecate `mean` metric instrument

### DIFF
--- a/Gemfile.jruby-1.9.lock.release
+++ b/Gemfile.jruby-1.9.lock.release
@@ -15,6 +15,7 @@ PATH
       minitar (~> 0.5.4)
       pry (~> 0.10.1)
       puma (~> 2.16)
+      rack (= 1.6.6)
       ruby-maven (~> 3.3.9)
       rubyzip (~> 1.1.7)
       sinatra (~> 1.4, >= 1.4.6)
@@ -44,16 +45,16 @@ GEM
       jmespath (~> 1.0)
     aws-sdk-resources (2.3.22)
       aws-sdk-core (= 2.3.22)
-    aws-sdk-v1 (1.66.0)
+    aws-sdk-v1 (1.67.0)
       json (~> 1.4)
-      nokogiri (>= 1.4.4)
-    backports (3.6.8)
+      nokogiri (~> 1)
+    backports (3.8.0)
     benchmark-ips (2.7.2)
-    bindata (2.3.5)
+    bindata (2.4.0)
     buftok (0.2.0)
     builder (3.2.3)
     cabin (0.9.0)
-    childprocess (0.6.1)
+    childprocess (0.7.0)
       ffi (~> 1.0, >= 1.0.11)
     chronic_duration (0.10.6)
       numerizer (~> 0.1.1)
@@ -66,33 +67,35 @@ GEM
     clamp (0.6.5)
     coderay (1.1.1)
     concurrent-ruby (1.0.0-java)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     docile (1.1.5)
     docker-api (1.31.0)
       excon (>= 0.38.0)
       json
-    domain_name (0.5.20161129)
+    domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.2.0)
+    dotenv (2.2.1)
     edn (1.1.1)
-    elasticsearch (5.0.3)
-      elasticsearch-api (= 5.0.3)
-      elasticsearch-transport (= 5.0.3)
-    elasticsearch-api (5.0.3)
+    elasticsearch (5.0.4)
+      elasticsearch-api (= 5.0.4)
+      elasticsearch-transport (= 5.0.4)
+    elasticsearch-api (5.0.4)
       multi_json
-    elasticsearch-transport (5.0.3)
+    elasticsearch-transport (5.0.4)
       faraday
       multi_json
     equalizer (0.0.10)
     excon (0.55.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.17-java)
+    ffi (1.9.18-java)
     file-dependencies (0.1.6)
       minitar
     filesize (0.0.4)
     filewatch (0.9.0)
-    fivemat (1.3.2)
+    fivemat (1.3.3)
     flores (0.0.7)
     fpm (1.3.3)
       arr-pm (~> 0.0.9)
@@ -102,9 +105,18 @@ GEM
       clamp (~> 0.6)
       ffi
       json (>= 1.7.7)
+    ftw (0.0.45)
+      addressable (~> 2.2)
+      backports (>= 2.6.2)
+      cabin (> 0)
+      http_parser.rb (~> 0.6)
+    gelf (1.3.2)
+      json
     gelfd (0.2.0)
     gem_publisher (1.5.0)
     gems (0.8.3)
+    gmetric (0.1.3)
+    gzip (1.0)
     hitimes (1.2.4-java)
     http (0.9.9)
       addressable (~> 2.3)
@@ -118,6 +130,7 @@ GEM
     i18n (0.6.9)
     insist (1.0.0)
     jar-dependencies (0.3.11)
+    jdbc-derby (10.12.1.1)
     jls-grok (0.11.4)
       cabin (>= 0.6.0)
     jls-lumberjack (0.0.26)
@@ -145,7 +158,7 @@ GEM
     logstash-codec-es_bulk (3.0.3)
       logstash-codec-line
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-codec-fluent (3.0.2-java)
+    logstash-codec-fluent (3.1.1-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       msgpack-jruby
     logstash-codec-graphite (3.0.2)
@@ -165,7 +178,7 @@ GEM
       jls-grok (~> 0.11.1)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-patterns-core
-    logstash-codec-netflow (3.3.0)
+    logstash-codec-netflow (3.4.0)
       bindata (>= 1.5.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-codec-plain (3.0.2)
@@ -188,7 +201,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-csv (3.0.2)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-date (3.1.3)
+    logstash-filter-date (3.1.5)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-dissect (1.0.8)
       jar-dependencies
@@ -198,15 +211,16 @@ GEM
       lru_redux (~> 1.1.0)
     logstash-filter-drop (3.0.2)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-fingerprint (3.0.2)
+    logstash-filter-fingerprint (3.0.3)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       murmurhash3
-    logstash-filter-geoip (4.0.4-java)
+    logstash-filter-geoip (4.1.1-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-grok (3.3.1)
+    logstash-filter-grok (3.4.1)
       jls-grok (~> 0.11.3)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-patterns-core
+      stud (~> 0.0.22)
     logstash-filter-json (3.0.2)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-kv (4.0.0)
@@ -215,6 +229,10 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       metriks
       thread_safe
+    logstash-filter-multiline (3.0.2)
+      jls-grok (~> 0.11.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-patterns-core
     logstash-filter-mutate (3.1.3)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-ruby (3.0.2)
@@ -230,31 +248,29 @@ GEM
       atomic
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       thread_safe
-    logstash-filter-urldecode (3.0.2)
+    logstash-filter-urldecode (3.0.3)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-useragent (3.0.3)
+    logstash-filter-useragent (3.1.1-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-      lru_redux (~> 1.1.0)
-      user_agent_parser (>= 2.0.0)
     logstash-filter-uuid (3.0.2)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-xml (4.0.2)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       nokogiri
       xml-simple
-    logstash-input-beats (3.1.12-java)
+    logstash-input-beats (3.1.15-java)
       concurrent-ruby (>= 0.9.2, <= 1.0.0)
       jar-dependencies (~> 0.3.4)
       logstash-codec-multiline (>= 2.0.5)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       thread_safe (~> 0.3.5)
-    logstash-input-couchdb_changes (3.1.0)
+    logstash-input-couchdb_changes (3.1.1)
       json
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       stud (>= 0.0.22)
-    logstash-input-elasticsearch (4.0.2)
+    logstash-input-elasticsearch (4.0.3)
       elasticsearch (>= 5.0.3, < 6.0.0)
       logstash-codec-json
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -287,16 +303,16 @@ GEM
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       stud
-    logstash-input-http (3.0.3)
+    logstash-input-http (3.0.4)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       puma (~> 2.16, >= 2.16.0)
       rack (~> 1)
       stud
-    logstash-input-http_poller (3.1.1)
+    logstash-input-http_poller (3.3.0)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-      logstash-mixin-http_client (>= 2.2.4, < 5.0.0)
+      logstash-mixin-http_client (>= 5.0.0, < 6.0.0)
       rufus-scheduler (~> 3.0.9)
       stud (~> 0.0.22)
     logstash-input-imap (3.0.2)
@@ -310,19 +326,19 @@ GEM
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       stud (~> 0.0.22)
-    logstash-input-jdbc (4.1.3)
+    logstash-input-jdbc (4.2.0)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       rufus-scheduler
       sequel
       tzinfo
       tzinfo-data
-    logstash-input-kafka (5.1.6)
+    logstash-input-kafka (6.3.0)
       logstash-codec-json
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       stud (>= 0.0.22, < 0.1.0)
-    logstash-input-log4j (3.0.3-java)
+    logstash-input-log4j (3.0.5-java)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-input-lumberjack (3.1.1)
@@ -335,7 +351,7 @@ GEM
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       stud (~> 0.0.22)
-    logstash-input-rabbitmq (5.2.2)
+    logstash-input-rabbitmq (5.2.3)
       logstash-codec-json
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-rabbitmq_connection (>= 4.2.2, < 5.0.0)
@@ -343,7 +359,7 @@ GEM
       logstash-codec-json
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       redis
-    logstash-input-s3 (3.1.2)
+    logstash-input-s3 (3.1.4)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-aws
       stud (~> 0.0.18)
@@ -351,7 +367,7 @@ GEM
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       snmp
-    logstash-input-sqs (3.0.2)
+    logstash-input-sqs (3.0.3)
       logstash-codec-json
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-aws (>= 1.0.0)
@@ -374,43 +390,45 @@ GEM
       logstash-codec-line
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-input-twitter (3.0.3)
+    logstash-input-twitter (3.0.4)
+      http-form_data (<= 1.0.1)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
+      public_suffix (<= 1.4.6)
       stud (>= 0.0.22, < 0.1)
       twitter (= 5.15.0)
     logstash-input-udp (3.1.0)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       stud (~> 0.0.22)
-    logstash-input-unix (3.0.2)
+    logstash-input-unix (3.0.3)
       logstash-codec-line
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-input-xmpp (3.1.2)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       xmpp4r (= 0.5)
-    logstash-mixin-aws (4.2.0)
+    logstash-mixin-aws (4.2.1)
       aws-sdk (~> 2.3.0)
       aws-sdk-v1 (>= 1.61.0)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-mixin-http_client (4.0.3)
+    logstash-mixin-http_client (5.2.0)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       manticore (>= 0.5.2, < 1.0.0)
-    logstash-mixin-rabbitmq_connection (4.2.2-java)
-      march_hare (~> 2.22.0)
+    logstash-mixin-rabbitmq_connection (4.3.0-java)
+      march_hare (~> 3.0.0)
       stud (~> 0.0.22)
     logstash-output-cloudwatch (3.0.4)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-aws (>= 1.0.0)
       rufus-scheduler (~> 3.0.9)
-    logstash-output-csv (3.0.2)
+    logstash-output-csv (3.0.3)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-filter-json
       logstash-input-generator
       logstash-output-file
-    logstash-output-elasticsearch (6.3.0-java)
+    logstash-output-elasticsearch (7.3.1-java)
       cabin (~> 0.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       manticore (>= 0.5.4, < 1.0.0)
@@ -421,14 +439,14 @@ GEM
       logstash-core-plugin-api (>= 2.0.0, < 2.99)
     logstash-output-graphite (3.1.1)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-output-http (4.1.0)
+    logstash-output-http (4.3.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-      logstash-mixin-http_client (>= 2.2.1, < 5.0.0)
+      logstash-mixin-http_client (>= 5.1.0, < 6.0.0)
     logstash-output-irc (3.0.2)
       cinch
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-output-kafka (5.1.5)
+    logstash-output-kafka (6.2.0)
       logstash-codec-json
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -444,19 +462,19 @@ GEM
     logstash-output-pipe (3.0.2)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-output-rabbitmq (4.0.6-java)
+    logstash-output-rabbitmq (4.0.7-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-      logstash-mixin-rabbitmq_connection (>= 4.2.2, < 5.0.0)
+      logstash-mixin-rabbitmq_connection (>= 4.3.0, < 5.0.0)
     logstash-output-redis (3.0.3)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       redis
       stud
-    logstash-output-s3 (4.0.5)
+    logstash-output-s3 (4.0.7)
       concurrent-ruby
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-aws
       stud (~> 0.0.22)
-    logstash-output-sns (4.0.2)
+    logstash-output-sns (4.0.3)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-aws (>= 1.0.0)
     logstash-output-sqs (4.0.1)
@@ -483,17 +501,17 @@ GEM
     logstash-output-xmpp (3.0.2)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       xmpp4r (= 0.5)
-    logstash-patterns-core (4.0.2)
+    logstash-patterns-core (4.1.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     lru_redux (1.1.0)
-    mail (2.6.4)
+    mail (2.6.5)
       mime-types (>= 1.16, < 4)
     manticore (0.6.1-java)
-    march_hare (2.22.0-java)
+    march_hare (3.0.0-java)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     method_source (0.8.2)
-    metriks (0.9.9.7)
+    metriks (0.9.9.8)
       atomic (~> 1.0)
       avl_tree (~> 1.2.0)
       hitimes (~> 1.1)
@@ -505,13 +523,12 @@ GEM
     murmurhash3 (0.1.6-java)
     mustache (0.99.8)
     naught (1.1.0)
-    netrc (0.11.0)
-    nokogiri (1.7.0.1-java)
+    nokogiri (1.7.2-java)
     numerizer (0.1.1)
     octokit (3.8.0)
       sawyer (~> 0.6.0, >= 0.5.3)
-    paquet (0.2.0)
-    pleaserun (0.0.28)
+    paquet (0.2.1)
+    pleaserun (0.0.29)
       cabin (> 0)
       clamp
       dotenv
@@ -519,23 +536,21 @@ GEM
       mustache (= 0.99.8)
       stud
     polyglot (0.3.5)
+    poseidon (0.0.5)
     pry (0.10.4-java)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
       spoon (~> 0.0)
+    public_suffix (1.4.6)
     puma (2.16.0-java)
-    rack (1.6.5)
+    rack (1.6.6)
     rack-protection (1.5.3)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rake (12.0.0)
     redis (3.3.3)
-    rest-client (1.8.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)
@@ -547,6 +562,9 @@ GEM
       rspec-support (~> 3.1.0)
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
+    rspec-sequencing (0.1.0)
+      concurrent-ruby
+      rspec (>= 3.0.0)
     rspec-support (3.1.2)
     rspec-wait (0.0.9)
       rspec (>= 3, < 4)
@@ -557,12 +575,13 @@ GEM
     rubyzip (1.1.7)
     rufus-scheduler (3.0.9)
       tzinfo
+    safe_yaml (1.0.4)
     sawyer (0.6.0)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
-    sequel (4.43.0)
+    sequel (4.46.0)
     simple_oauth (0.3.1)
-    simplecov (0.13.0)
+    simplecov (0.14.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
@@ -582,8 +601,9 @@ GEM
     stud (0.0.22)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
-    thread_safe (0.3.5-java)
+    thread_safe (0.3.6-java)
     tilt (2.0.7)
+    timecop (0.8.1)
     tins (1.6.0)
     treetop (1.4.15)
       polyglot
@@ -599,14 +619,17 @@ GEM
       memoizable (~> 0.4.0)
       naught (~> 1.0)
       simple_oauth (~> 0.3.0)
-    tzinfo (1.2.2)
+    tzinfo (1.2.3)
       thread_safe (~> 0.1)
-    tzinfo-data (1.2016.10)
+    tzinfo-data (1.2017.2)
       tzinfo (>= 1.0.0)
     unf (0.1.4-java)
-    user_agent_parser (2.3.0)
     webhdfs (0.8.0)
       addressable
+    webmock (1.21.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+    webrick (1.3.1)
     xml-simple (1.1.5)
     xmpp4r (0.5)
 
@@ -614,14 +637,24 @@ PLATFORMS
   java
 
 DEPENDENCIES
+  addressable (~> 2.3.0)
   benchmark-ips
   builder (~> 3.2.2)
+  childprocess
   ci_reporter_rspec (= 1.0.0)
   docker-api (= 1.31.0)
+  elasticsearch
   file-dependencies (= 0.1.6)
   flores (~> 0.0.6)
   fpm (~> 1.3.3)
+  ftw (~> 0.0.42)
+  gelf (= 1.3.2)
   gems (~> 0.8.3)
+  gmetric
+  gzip
+  jar-dependencies
+  jdbc-derby
+  json
   logstash-codec-cef
   logstash-codec-collectd
   logstash-codec-dots
@@ -653,6 +686,7 @@ DEPENDENCIES
   logstash-filter-json
   logstash-filter-kv
   logstash-filter-metrics
+  logstash-filter-multiline
   logstash-filter-mutate
   logstash-filter-ruby
   logstash-filter-sleep
@@ -678,7 +712,7 @@ DEPENDENCIES
   logstash-input-imap
   logstash-input-irc
   logstash-input-jdbc
-  logstash-input-kafka (~> 5)
+  logstash-input-kafka
   logstash-input-log4j
   logstash-input-lumberjack
   logstash-input-pipe
@@ -701,7 +735,7 @@ DEPENDENCIES
   logstash-output-graphite
   logstash-output-http
   logstash-output-irc
-  logstash-output-kafka (~> 5)
+  logstash-output-kafka
   logstash-output-nagios
   logstash-output-null
   logstash-output-pagerduty
@@ -717,15 +751,25 @@ DEPENDENCIES
   logstash-output-udp
   logstash-output-webhdfs
   logstash-output-xmpp
+  logstash-patterns-core
   octokit (= 3.8.0)
   paquet (~> 0.2.0)
   pleaserun (~> 0.0.28)
+  poseidon
+  pry
   rack-test
-  rest-client (= 1.8.0)
   rspec (~> 3.1.0)
+  rspec-sequencing
+  rspec-wait
+  ruby-maven (~> 3.3)
   ruby-progressbar (~> 1.8.1)
   rubyzip (~> 1.1.7)
   simplecov
+  sinatra
+  snappy
   stud (~> 0.0.22)
   term-ansicolor (~> 1.3.2)
+  timecop
   tins (= 1.6)
+  webmock (~> 1.21.0)
+  webrick

--- a/Gemfile.template
+++ b/Gemfile.template
@@ -19,6 +19,8 @@ gem "stud", "~> 0.0.22", :group => :build
 gem "fpm", "~> 1.3.3", :group => :build
 gem "rubyzip", "~> 1.1.7", :group => :build
 gem "gems", "~> 0.8.3", :group => :build
+# Pinned till we have Jruby 9k with ruby 2.0 support
+gem "rack", "1.6.6"
 gem "rack-test", :require => "rack/test", :group => :development
 gem "flores", "~> 0.0.6", :group => :development
 gem "term-ansicolor", "~> 1.3.2", :group => :development

--- a/NOTICE.TXT
+++ b/NOTICE.TXT
@@ -57,29 +57,6 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================================================
-RubyGem: jar-dependencies Version: 0.3.10
-Copyright (c) 2014 Christian Meier
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-==========================================================================
 RubyGem: lru_redux Version: 1.1.0
 Copyright (c) 2013 Sam Saffron
 
@@ -127,7 +104,7 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ==========================================================================
-RubyGem: elasticsearch Version: 1.1.2
+RubyGem: elasticsearch Version: 5.0.4
    Copyright 2013 Elasticsearch
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -372,8 +349,8 @@ THE SOFTWARE.
 
 
 ==========================================================================
-RubyGem: mail Version: 2.6.4
-Copyright (c) 2009-2016 Mikel Lindsaar
+RubyGem: mail Version: 2.6.5
+Copyright (c) 2009-2017 Mikel Lindsaar
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -419,7 +396,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================================================
-RubyGem: sequel Version: 4.43.0
+RubyGem: sequel Version: 4.46.0
 Copyright (c) 2007-2008 Sharon Rosner
 Copyright (c) 2008-2017 Jeremy Evans
 
@@ -441,8 +418,8 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================================================
-RubyGem: tzinfo Version: 1.2.2
-Copyright (c) 2005-2014 Philip Ross
+RubyGem: tzinfo Version: 1.2.3
+Copyright (c) 2005-2017 Philip Ross
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 
@@ -463,8 +440,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==========================================================================
-RubyGem: tzinfo-data Version: 1.2016.10
-Copyright (c) 2005-2016 Philip Ross
+RubyGem: tzinfo-data Version: 1.2017.2
+Copyright (c) 2005-2017 Philip Ross
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/logstash-core/lib/logstash/instrument/metric_type/mean.rb
+++ b/logstash-core/lib/logstash/instrument/metric_type/mean.rb
@@ -4,7 +4,12 @@ require "concurrent"
 
 module LogStash module Instrument module MetricType
   class Mean < Base
+    include ::LogStash::Util::Loggable
+
     def initialize(namespaces, key)
+      logger.warn("Deprecated 'mean' metric type used! This will be removed in Logstash 6.0!",
+                   :namespaces => namespaces,
+                   :key => key)
       super(namespaces, key)
 
       @counter = Concurrent::AtomicFixnum.new


### PR DESCRIPTION
This feature is removed in #7105 for 6.0+

Fixes #7094