### PR TITLE
Use the headless JRE for the kafka docker image

### DIFF
--- a/qa/integration/services/kafka_dockerized/Dockerfile
+++ b/qa/integration/services/kafka_dockerized/Dockerfile
@@ -6,7 +6,7 @@ ENV KAFKA_VERSION 0.10.2.1
 ENV _JAVA_OPTIONS "-Djava.net.preferIPv4Stack=true"
 ENV TERM=linux
 
-RUN apt-get update && apt-get install -y curl openjdk-8-jdk netcat
+RUN apt-get update && apt-get install -y curl openjdk-8-jre-headless netcat
 
 RUN mkdir -p ${KAFKA_LOGS_DIR} && mkdir -p ${KAFKA_HOME} && curl -s -o $INSTALL_DIR/kafka.tgz \
     "http://ftp.wayne.edu/apache/kafka/${KAFKA_VERSION}/kafka_2.11-${KAFKA_VERSION}.tgz" && \


### PR DESCRIPTION
This should help the image build a bit faster since it won't have to pull all of X11 in.