### PR TITLE
Fix gradle assemble

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/DeadLetterQueueFactory.java
+++ b/logstash-core/src/main/java/org/logstash/common/DeadLetterQueueFactory.java
@@ -44,13 +44,13 @@ public class DeadLetterQueueFactory {
     }
 
     /**
-     * Retrieves an existing {@link DeadLetterQueueWriter} associated with {@param id}, or
+     * Retrieves an existing {@link DeadLetterQueueWriter} associated with the given id, or
      * opens a new one to be returned. It is the retrievers responsibility to close these newly
      * created writers.
      *
      * @param id The identifier context for this dlq manager
      * @param dlqPath The path to use for the queue's backing data directory. contains sub-directories
-     *                for each {@param id}
+     *                for each id
      * @return The write manager for the specific id's dead-letter-queue context
      */
     public static DeadLetterQueueWriter getWriter(String id, String dlqPath) {

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -53,12 +53,6 @@ public class DeadLetterQueueWriter {
     private Timestamp lastEntryTimestamp;
     private boolean open;
 
-    /**
-     *
-     * @param queuePath
-     * @param maxSegmentSize
-     * @throws IOException
-     */
     public DeadLetterQueueWriter(Path queuePath, long maxSegmentSize, long maxQueueSize) throws IOException {
         // ensure path exists, create it otherwise.
         Files.createDirectories(queuePath);
@@ -93,7 +87,7 @@ public class DeadLetterQueueWriter {
      * Constructor for Writer that uses defaults
      *
      * @param queuePath the path to the dead letter queue segments directory
-     * @throws IOException
+     * @throws IOException if the size of the file cannot be determined
      */
     public DeadLetterQueueWriter(String queuePath) throws IOException {
         this(Paths.get(queuePath), MAX_SEGMENT_SIZE_BYTES, Long.MAX_VALUE);

--- a/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
@@ -122,12 +122,7 @@ public class RecordIOReader {
         return channelPosition;
     }
 
-    /**
-     *
-     * @param rewind
-     * @throws IOException
-     */
-    void consumeBlock(boolean rewind) throws IOException {
+   void consumeBlock(boolean rewind) throws IOException {
         if (rewind) {
             currentBlockSizeReadFromChannel = 0;
             currentBlock.rewind();
@@ -143,7 +138,7 @@ public class RecordIOReader {
 
     /**
      * basically, is last block
-     * @return
+     * @return true if this is the end of the stream
      */
     public boolean isEndOfStream() {
         return currentBlockSizeReadFromChannel < BLOCK_SIZE;
@@ -169,7 +164,6 @@ public class RecordIOReader {
     /**
      *
      * @return true if ready to read event, false otherwise
-     * @throws IOException
      */
     boolean consumeToStartOfEvent() throws IOException {
         // read and seek to start of event
@@ -207,10 +201,6 @@ public class RecordIOReader {
         currentBlock.position(currentBlock.position() + header.getSize());
     }
 
-    /**
-     * @return
-     * @throws IOException
-     */
     public byte[] readEvent() throws IOException {
         try {
             if (channel.isOpen() == false || consumeToStartOfEvent() == false) {

--- a/rakelib/compile.rake
+++ b/rakelib/compile.rake
@@ -20,7 +20,7 @@ namespace "compile" do
 
   task "logstash-core-java" do
     puts("Building logstash-core using gradle")
-    safe_system("./gradlew", "jar")
+    safe_system("./gradlew", "assemble")
   end
 
   desc "Build everything"


### PR DESCRIPTION
This makes sure that `gradle assemble` is run with `compile:all` which is part of the CI suite. This is important as it helps to catch javadoc failures. This task was broken as the `javadoc` task had some small issues that have also been resolved here.

https://github.com/elastic/logstash/issues/7089