### PR TITLE
Pin rack version to avoid ruby2.0 only features

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -25,6 +25,10 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "filesize", "0.0.4" #(MIT license) for :bytes config validator
   gem.add_runtime_dependency "gems", "~> 0.8.3"  #(MIT license)
   gem.add_runtime_dependency "concurrent-ruby", "1.0.0"
+
+  # Later versions are ruby 2.0 only. We should remove the rack dep once we support 9k
+  gem.add_runtime_dependency "rack", '1.6.6'
+  
   gem.add_runtime_dependency "sinatra", '~> 1.4', '>= 1.4.6'
   gem.add_runtime_dependency 'puma', '~> 2.16'
   gem.add_runtime_dependency "jruby-openssl", "0.9.16" # >= 0.9.13 Required to support TLSv1.2

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -34,7 +34,7 @@ namespace "test" do
   end
 
   def core_specs
-    exit(1) unless system './gradlew clean test'
+    exit(1) unless system './gradlew clean test --info'
     
     specs = ["spec/unit/**/*_spec.rb", "logstash-core/spec/**/*_spec.rb"]
 


### PR DESCRIPTION
We can't run the latest rack without JRuby 9k unfortunately. This fixes #7109 