### PR TITLE
7039 JMH Benchmarks to Illustrate PQ High-Throughput Behaviour

### DIFF
--- a/logstash-core/benchmarks/Readme.md
+++ b/logstash-core/benchmarks/Readme.md
@@ -1,0 +1,56 @@
+# Logstash Microbenchmark Suite
+
+This directory contains the microbenchmark suite of Logstash. It relies on [JMH](http://openjdk.java.net/projects/code-tools/jmh/).
+
+## Getting Started
+
+Just run `./gradlew jmh` from the project root directory. It will build all microbenchmarks, execute them and print the result.
+
+#### Example Output
+
+```bash
+➜  logstash: ./gradlew jmh
+# JMH 1.18 (released 66 days ago)
+# VM version: JDK 1.8.0_121, VM 25.121-b13
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_121.jdk/Contents/Home/jre/bin/java
+# VM options: -Dfile.encoding=US-ASCII -Duser.country=US -Duser.language=en -Duser.variant
+# Warmup: 3 iterations, 100 ms each
+# Measurement: 10 iterations, 100 ms each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: org.logstash.benchmark.QueueBenchmark.pushToPersistedQueue
+
+# Run progress: 0.00% complete, ETA 00:00:01
+# Fork: 1 of 1
+# Warmup Iteration   1: 249.325 ops/ms
+# Warmup Iteration   2: 290.150 ops/ms
+# Warmup Iteration   3: 293.669 ops/ms
+Iteration   1: 315.075 ops/ms
+Iteration   2: 282.020 ops/ms
+Iteration   3: 317.281 ops/ms
+Iteration   4: 296.559 ops/ms
+Iteration   5: 302.803 ops/ms
+Iteration   6: 305.187 ops/ms
+Iteration   7: 320.959 ops/ms
+Iteration   8: 304.073 ops/ms
+Iteration   9: 297.499 ops/ms
+Iteration  10: 301.889 ops/ms
+
+
+Result "org.logstash.benchmark.QueueBenchmark.pushToPersistedQueue":
+  304.334 ?(99.9%) 17.264 ops/ms [Average]
+  (min, avg, max) = (282.020, 304.334, 320.959), stdev = 11.419
+  CI (99.9%): [287.070, 321.599] (assumes normal distribution)
+
+
+# Run complete. Total time: 00:00:22
+
+Benchmark                             Mode  Cnt    Score    Error   Units
+QueueBenchmark.pushToPersistedQueue  thrpt   10  304.334 ? 17.264  ops/ms
+
+```
+
+## More
+
+Additional information on JMH can be found in the Elasticsearch project's [benchmark documentation](https://github.com/elastic/elasticsearch/blob/master/benchmarks/README.md).

--- a/logstash-core/benchmarks/build.gradle
+++ b/logstash-core/benchmarks/build.gradle
@@ -1,0 +1,78 @@
+import org.yaml.snakeyaml.Yaml
+
+apply plugin: 'java'
+apply plugin: 'idea'
+
+// fetch version from Logstash's master versions.yml file
+def versionMap = (Map) (new Yaml()).load(new File("$projectDir/../../versions.yml").text)
+
+group = 'org.logstash'
+description = """Logstash Core Java Benchmarks"""
+version = versionMap['logstash-core']
+
+project.sourceCompatibility = JavaVersion.VERSION_1_8
+project.targetCompatibility = JavaVersion.VERSION_1_8
+
+repositories {
+  mavenCentral()
+  jcenter()
+}
+
+buildscript {
+  repositories {
+    mavenCentral()
+    jcenter()
+  }
+  dependencies {
+    classpath 'org.yaml:snakeyaml:1.17'
+    classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
+  }
+}
+
+test.enabled = false
+
+jar {
+  manifest {
+    attributes "Main-Class": "org.openjdk.jmh.Main"
+  }
+}
+
+ext {
+  jmh = 1.18 
+}
+
+dependencies {
+  compile project(':logstash-core')
+  compile "org.openjdk.jmh:jmh-core:$jmh"
+  compile "org.openjdk.jmh:jmh-generator-annprocess:$jmh"
+  compile "org.openjdk.jmh:jmh-core-benchmarks:$jmh"
+  compile 'net.sf.jopt-simple:jopt-simple:5.0.3'
+  compile 'com.google.guava:guava:21.0'
+  compile 'commons-io:commons-io:2.5'
+  runtime 'joda-time:joda-time:2.8.2'
+  runtime 'org.jruby:jruby-core:1.7.26'
+}
+
+javadoc {
+  enabled = false
+}
+
+apply plugin: 'com.github.johnrengelman.shadow'
+
+shadowJar {
+  baseName = 'logstash-core-benchmarks-all'
+  classifier = null
+  version = null
+}
+
+task jmh(type: JavaExec, dependsOn: [':logstash-core-benchmarks:clean', ':logstash-core-benchmarks:shadowJar']) {
+
+  main="-jar"
+
+  doFirst {
+    if (System.getProperty("jmhArgs")) {
+      args System.getProperty("jmhArgs").split(',')
+    }
+    args = [shadowJar.archivePath, *args]
+  }
+}

--- a/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/QueueBenchmark.java
+++ b/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/QueueBenchmark.java
@@ -1,0 +1,96 @@
+package org.logstash.benchmark;
+
+import com.google.common.io.Files;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.logstash.Event;
+import org.logstash.Timestamp;
+import org.logstash.ackedqueue.FileSettings;
+import org.logstash.ackedqueue.Queue;
+import org.logstash.ackedqueue.Settings;
+import org.logstash.ackedqueue.io.FileCheckpointIO;
+import org.logstash.ackedqueue.io.MmapPageIO;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@Warmup(iterations = 3, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+public class QueueBenchmark {
+
+    private static final int EVENTS_PER_INVOCATION = 500_000;
+
+    private static final Event EVENT = new Event();
+
+    private Queue queue;
+
+    private String path;
+
+    @Setup
+    public void setUp() throws IOException {
+        final Settings settings = settings();
+        EVENT.setField("Foo", "Bar");
+        EVENT.setField("Foo1", "Bar1");
+        EVENT.setField("Foo2", "Bar2");
+        EVENT.setField("Foo3", "Bar3");
+        EVENT.setField("Foo4", "Bar4");
+        path = settings.getDirPath();
+        queue = new Queue(settings);
+        queue.open();
+    }
+
+    @TearDown
+    public void tearDown() throws IOException {
+        queue.close();
+        FileUtils.deleteDirectory(new File(path));
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(EVENTS_PER_INVOCATION)
+    public final void pushToPersistedQueue() throws Exception {
+        for (int i = 0; i < EVENTS_PER_INVOCATION; ++i) {
+            final Event evnt = EVENT.clone();
+            evnt.setTimestamp(Timestamp.now());
+            queue.write(evnt);
+        }
+    }
+
+    public static void main(final String... args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+            .include(QueueBenchmark.class.getSimpleName())
+            .forks(2)
+            .build();
+        new Runner(opt).run();
+    }
+
+    private static Settings settings() {
+        Settings s = new FileSettings(Files.createTempDir().getPath());
+        s.setCapacity(256 * 1024 * 1024);
+        s.setQueueMaxBytes(Long.MAX_VALUE);
+        s.setElementIOFactory(MmapPageIO::new);
+        s.setCheckpointMaxWrites(50_000);
+        s.setCheckpointMaxAcks(50_000);
+        s.setCheckpointIOFactory(FileCheckpointIO::new);
+        s.setElementClass(Event.class);
+        return s;
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
-include ':logstash-core'
+include ':logstash-core', 'logstash-core-benchmarks'
 project(':logstash-core').projectDir = new File('./logstash-core')
+project(':logstash-core-benchmarks').projectDir = new File('./logstash-core/benchmarks')


### PR DESCRIPTION
@colinsurprenant @suyograo @jordansissel this is the output of the JMH I was talking about earlier today (well and the JMH code itself :)).

The leaky behaviour only shows up at very high throughput (achieved by 50k ack intervalls):

<img width="1676" alt="screen shot 2017-05-16 at 02 10 59" src="https://cloud.githubusercontent.com/assets/6490959/26085639/9c977588-39dd-11e7-8dee-2ce2cd050759.png">

As compared to GC keeping up just fine with the much more I/O bound behaviour at 100 event ack intervals:

<img width="857" alt="screen shot 2017-05-16 at 02 06 20" src="https://cloud.githubusercontent.com/assets/6490959/26085651/aff4ccc0-39dd-11e7-8050-a39c6b95f49b.png">

Not necessarily saying we shouldn't pursue #7039 , but it may not be worth doing this for now since the effects are likely overshadowed by GC from the JRuby code as well as plugins in general.

Still maybe we should add this kind of for posterity to use when optimizing? :)
The more interesting effect to examine here may be the extreme slowdown that acking comes with. I think it should be possible to find a more performant approach here, Kafka for example acks in very small intervals too without the throughput to disk going down to `< 10 MB/s`

Benchmark can be executed by simply running `./gradlew jmh` from the project root btw :)