### PR TITLE
MINOR: Cleanup some inefficient List usage

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/wip/MemoryPageIOStream.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/wip/MemoryPageIOStream.java
@@ -1,5 +1,6 @@
 package org.logstash.ackedqueue.io.wip;
 
+import java.util.Collections;
 import org.logstash.ackedqueue.Checkpoint;
 import org.logstash.ackedqueue.SequencedList;
 import org.logstash.common.io.BufferedChecksumStreamInput;
@@ -142,7 +143,7 @@ public class MemoryPageIOStream implements PageIO {
     @Override
     public SequencedList<byte[]> read(long seqNum, int limit) throws IOException {
         if (elementCount == 0) {
-            return new SequencedList<>(new ArrayList<>(), new ArrayList<>());
+            return new SequencedList<>(Collections.emptyList(), Collections.emptyList());
         }
         setReadPoint(seqNum);
         return read(limit);
@@ -215,7 +216,7 @@ public class MemoryPageIOStream implements PageIO {
         return details;
     }
 
-    private void setReadPoint(long seqNum) throws IOException {
+    private void setReadPoint(long seqNum) {
         int readPosition = offsetMap.get(calcRelativeSeqNum(seqNum));
         streamedInput.movePosition(readPosition);
     }
@@ -254,10 +255,9 @@ public class MemoryPageIOStream implements PageIO {
     }
 
     private SequencedList<byte[]> read(int limit) throws IOException {
-        List<byte[]> elements = new ArrayList<>();
-        List<Long> seqNums = new ArrayList<>();
-
         int upto = available(limit);
+        List<byte[]> elements = new ArrayList<>(upto);
+        List<Long> seqNums = new ArrayList<>(upto);
         for (int i = 0; i < upto; i++) {
             long seqNum = readSeqNum();
             byte[] data = readData();


### PR DESCRIPTION
Just some minor cleanups of `List` performance cases in the critical path.

* `stream`, `map` then `collect` is very slow relative to just iterating over a list due to all the overhead allocations of intermediate `Collection`s
* `new ArrayList()` as an empty list constant is a waste of allocations + has some potential for introducing bugs since it's mutable, better to use the constant
* if we know the size an `ArrayList()` is going to be we should pre-allocate the size

Two very minors:
* IOException is not thrown, removed from the signature 
* `Batch` is a `Closeable` and as such should not by assigned to a local variable in a non-resource-safe manner (doesn't matter here but nice for consistency)