### PR TITLE
#7154 delete queue path in logstash integration tests to improve test isolation

### DIFF
--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -40,8 +40,7 @@ class LogstashService < Service
       @logstash_home += "-SNAPSHOT" unless Dir.exists?(@logstash_home)
       
       @logstash_queue_path = File.join("#{@logstash_home}", "data/queue")
-      FileUtils.remove_dir(@logstash_queue_path, true)
-      FileUtils.mkdir(@logstash_queue_path)
+      clear_pq_data
       
       puts "Using #{@logstash_home} as LS_HOME"
       @logstash_bin = File.join("#{@logstash_home}", LS_BIN)
@@ -140,8 +139,7 @@ class LogstashService < Service
       @process.io.stdin.close rescue nil
       @process.stop
       @process = nil
-      FileUtils.remove_dir(@logstash_queue_path, true)
-      FileUtils.mkdir(@logstash_queue_path)
+      clear_pq_data
     end
   end
 
@@ -208,6 +206,13 @@ class LogstashService < Service
 
   def lock_file
     File.join(@logstash_home, "Gemfile.jruby-1.9.lock")
+  end
+  
+  private
+  
+  def clear_pq_data
+    FileUtils.remove_dir(@logstash_queue_path, true)
+    FileUtils.mkdir(@logstash_queue_path)
   end
 
   class PluginCli

--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -38,7 +38,10 @@ class LogstashService < Service
       # First try without the snapshot if it's there
       @logstash_home = File.expand_path(File.join(LS_BUILD_DIR, ls_file), __FILE__)
       @logstash_home += "-SNAPSHOT" unless Dir.exists?(@logstash_home)
-
+      
+      @logstash_queue_path = File.join("#{@logstash_home}", "data")
+      FileUtils.remove_dir(@logstash_queue_path, true)
+      
       puts "Using #{@logstash_home} as LS_HOME"
       @logstash_bin = File.join("#{@logstash_home}", LS_BIN)
       raise "Logstash binary not found in path #{@logstash_home}" unless File.file? @logstash_bin
@@ -136,6 +139,7 @@ class LogstashService < Service
       @process.io.stdin.close rescue nil
       @process.stop
       @process = nil
+      FileUtils.remove_dir(@logstash_queue_path, true)
     end
   end
 

--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -41,6 +41,7 @@ class LogstashService < Service
       
       @logstash_queue_path = File.join("#{@logstash_home}", "data/queue")
       FileUtils.remove_dir(@logstash_queue_path, true)
+      FileUtils.mkdir(@logstash_queue_path)
       
       puts "Using #{@logstash_home} as LS_HOME"
       @logstash_bin = File.join("#{@logstash_home}", LS_BIN)
@@ -53,7 +54,7 @@ class LogstashService < Service
 
   def alive?
     if @process.nil? || @process.exited?
-      raise "Logstash process is not up because of an errot, or it stopped"
+      raise "Logstash process is not up because of an error, or it stopped"
     else
       @process.alive?
     end
@@ -140,6 +141,7 @@ class LogstashService < Service
       @process.stop
       @process = nil
       FileUtils.remove_dir(@logstash_queue_path, true)
+      FileUtils.mkdir(@logstash_queue_path)
     end
   end
 

--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -39,7 +39,7 @@ class LogstashService < Service
       @logstash_home = File.expand_path(File.join(LS_BUILD_DIR, ls_file), __FILE__)
       @logstash_home += "-SNAPSHOT" unless Dir.exists?(@logstash_home)
       
-      @logstash_queue_path = File.join("#{@logstash_home}", "data")
+      @logstash_queue_path = File.join("#{@logstash_home}", "data/queue")
       FileUtils.remove_dir(@logstash_queue_path, true)
       
       puts "Using #{@logstash_home} as LS_HOME"


### PR DESCRIPTION
This is the best I could find here, I wasn't able to reproduce this *but* the fact that we keep reusing the same persisted queue path over and over slows the whole thing way down (by that I mean the time until `logstash-core/lib/logstash/pipeline.rb:694` (`collect_stats`) works out the first time, evidently the other parts of the metrics hash are populated).

=> I'd start by fixing test isolation here and ensuring that the queue path is removed before any tests are ran (hence adding it to `initialize` too, to avoid interference from unclean shutdowns).

With reuse of the path I can see runs take 20s at times for this test, without it's 10s every time. I get that we should also look into improving the queue performance (probably some locking timing issue thing), but test isolation is a valid step one here imo.
