### PR TITLE
#7160 don't run Kafka setup for every IT

### DIFF
--- a/qa/integration/services/kafka_service.rb
+++ b/qa/integration/services/kafka_service.rb
@@ -3,14 +3,14 @@ require "docker"
 
 class KafkaService < Service
   def initialize(settings)
-    @kafka_image = Docker::Image.build_from_dir(File.expand_path("../kafka_dockerized", __FILE__))
-                     .insert_local(
-                       'localPath' => File.join(TestSettings::FIXTURES_DIR, "how_sample.input"),
-                       'outputPath' => '/')
     super("kafka", settings)
   end
 
   def setup
+    @kafka_image = Docker::Image.build_from_dir(File.expand_path("../kafka_dockerized", __FILE__))
+                     .insert_local(
+                       'localPath' => File.join(TestSettings::FIXTURES_DIR, "how_sample.input"),
+                       'outputPath' => '/')
     @kafka_container = Docker::Container.create(:Image => @kafka_image.id,
                                                 :HostConfig => {
                                                   :PortBindings => {


### PR DESCRIPTION
Fixes #7160 by only interacting with Docker when necessary to set up Kafka.
We  are calling initialize even for services not actively used in a spec, so it was just a mistake on my end to put the Kafka setup into the initialize.

PS: This should also speed up the test suit overall :P 