### PR TITLE
Fix NoMethodError when Stack Trace is empty #7174

### DIFF
--- a/logstash-core/lib/logstash/api/commands/hot_threads_reporter.rb
+++ b/logstash-core/lib/logstash/api/commands/hot_threads_reporter.rb
@@ -42,7 +42,7 @@ class HotThreadsReport
       _hash["thread.stacktrace"].each do |trace|
         traces << trace
       end
-      thread[:traces] = traces unless traces.empty?
+      thread[:traces] = traces
       hash[:threads] << thread
     end
     { :hot_threads => hash }


### PR DESCRIPTION
Adds :traces to hash even if traces are empty.

Fixes #7174