### PR TITLE
Run offline specs separately from online ones.

### DIFF
--- a/ci/travis_integration_run.sh
+++ b/ci/travis_integration_run.sh
@@ -7,4 +7,10 @@ fi
 
 echo "Running integration tests from qa/integration directory"
 cd qa/integration
-rspec
+
+# The offline specs can break the online ones
+# due to some sideeffects of the seccomp policy interfering with
+# the docker daemon
+# See prepare_offline_pack_spec.rb for details
+rspec --tag ~offline
+rspec --tag offline

--- a/qa/integration/specs/cli/prepare_offline_pack_spec.rb
+++ b/qa/integration/specs/cli/prepare_offline_pack_spec.rb
@@ -5,7 +5,13 @@ require_relative "../../services/logstash_service"
 require_relative "../../framework/helpers"
 require "logstash/devutils/rspec/spec_helper"
 
-describe "CLI > logstash-plugin prepare-offline-pack" do
+
+# These are segmented into a separate tag that MUST be run separately from any docker tests
+# The reason they break the Docker API and that in turn even breaks tests not using Docker 
+# is that the Docker API has a global singleton Docker container set up as soon as it's 
+# required that acts in the background and will err out if the internet is down
+# See https://github.com/elastic/logstash/issues/7160#issue-229902725
+describe "CLI > logstash-plugin prepare-offline-pack", :offline => true do
   before(:all) do
     @fixture = Fixture.new(__FILE__)
     @logstash_plugin = @fixture.get_service("logstash").plugin_cli


### PR DESCRIPTION
The internet disabling C hack can break other tests, so, we now run those tests separately.

Fixes https://github.com/elastic/logstash/issues/7178

/cc @original-brownbear this isn't as nice as using docker, but its the same effect for a lot less work right now. I think we can triage that work ATM.