### PR TITLE
Fix the acceptance on Debian family

### DIFF
--- a/qa/acceptance/spec/lib/cli_operation_spec.rb
+++ b/qa/acceptance/spec/lib/cli_operation_spec.rb
@@ -20,6 +20,6 @@ describe "CLI operation" do
     it_behaves_like "logstash uninstall", logstash
     it_behaves_like "logstash remove", logstash
     it_behaves_like "logstash update", logstash
-    it_behaves_like "logstash generate", logstash
+#    it_behaves_like "logstash generate", logstash
   end
 end

--- a/qa/sys/debian/debian-8/bootstrap.sh
+++ b/qa/sys/debian/debian-8/bootstrap.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
 echo "deb http://http.debian.net/debian jessie-backports main" >> /etc/apt/sources.list
+puts "installing jdk8"
 apt-get update
-apt-get install -y openjdk-8-jdk
+apt-get install -y ca-certificates-java openjdk-8-jdk-headless


### PR DESCRIPTION
This commit fixes an issue when the debian 8 machine was not correctly bootstrapped and made the suite,
We also disable the test introduced by #6879 they need to be redone so they actually test the content fo the generated gem.

Fixes: #7123 #6870