### PR TITLE
Add edit URLs back into index.asciidoc

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -15,7 +15,7 @@ release-state can be: released | prerelease | unreleased
 :jdk:                   1.8.0
 :guide:                 https://www.elastic.co/guide/en/elasticsearch/guide/current/
 :ref:                   https://www.elastic.co/guide/en/elasticsearch/reference/current/
-:xpack:                https://www.elastic.co/guide/en/x-pack/current
+:xpack:                 https://www.elastic.co/guide/en/x-pack/current
 :logstash:              https://www.elastic.co/guide/en/logstash/current/
 :libbeat:               https://www.elastic.co/guide/en/beats/libbeat/current/
 :filebeat:              https://www.elastic.co/guide/en/beats/filebeat/current/
@@ -40,90 +40,105 @@ volume and variety of data.
 
 // Introduction
 
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/introduction.asciidoc
 include::static/introduction.asciidoc[]
 
 // Glossary and core concepts go here
 
 // Getting Started with Logstash
 
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/getting-started-with-logstash.asciidoc
 include::static/getting-started-with-logstash.asciidoc[]
 
 // Advanced LS Pipelines
 
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/advanced-pipeline.asciidoc
 include::static/advanced-pipeline.asciidoc[]
 
 // Processing Pipeline
 
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/life-of-an-event.asciidoc
 include::static/life-of-an-event.asciidoc[]
 
 // Lostash setup
 
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/setting-up-logstash.asciidoc
 include::static/setting-up-logstash.asciidoc[]
 
-
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/settings-file.asciidoc
 include::static/settings-file.asciidoc[]
 
-
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/running-logstash-command-line.asciidoc
 include::static/running-logstash-command-line.asciidoc[]
 
-
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/running-logstash.asciidoc
 include::static/running-logstash.asciidoc[]
 
-
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/docker.asciidoc
 include::static/docker.asciidoc[]
 
-
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/logging.asciidoc
 include::static/logging.asciidoc[]
 
-
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/persistent-queues.asciidoc
 include::static/persistent-queues.asciidoc[]
 
 
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/staticinclude::static/shutdown.asciidoc[]
 include::static/shutdown.asciidoc[]
 
 // Breaking Changes
 
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/breaking-changes.asciidoc
 include::static/breaking-changes.asciidoc[]
 
 // Upgrading Logstash
 
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/upgrading.asciidoc
 include::static/upgrading.asciidoc[]
 
 // Configuring Logstash
 
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/configuration.asciidoc
 include::static/configuration.asciidoc[]
 
-
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/reloading-config.asciidoc
 include::static/reloading-config.asciidoc[]
 
-
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/managing-multiline-events.asciidoc
 include::static/managing-multiline-events.asciidoc[]
 
-
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/glob-support.asciidoc
 include::static/glob-support.asciidoc[]
 
 // Working with Filebeat Modules
 
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/filebeat-modules.asciidoc
 include::static/filebeat-modules.asciidoc[]
 
 // Transforming Data
 
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/transforming-data.asciidoc
 include::static/transforming-data.asciidoc[]
 
 // Deploying & Scaling
 
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/deploying.asciidoc
 include::static/deploying.asciidoc[]
 
 // Troubleshooting performance
 
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/performance-checklist.asciidoc
 include::static/performance-checklist.asciidoc[]
 
 // Monitoring APIs
 
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/monitoring-apis.asciidoc
 include::static/monitoring-apis.asciidoc[]
 
 // Working with Plugins
 
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/plugin-manager.asciidoc
 include::static/plugin-manager.asciidoc[]
 
 // These files do their own pass blocks
@@ -146,10 +161,12 @@ include::static/output.asciidoc[]
 
 // Contributing a Patch to a Logstash Plugin
 
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/contributing-patch.asciidoc
 include::static/contributing-patch.asciidoc[]
 
 // Logstash Community Maintainer Guide
 
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/maintainer-guide.asciidoc
 include::static/maintainer-guide.asciidoc[]
 
 // A space is necessary here ^^^
@@ -157,10 +174,12 @@ include::static/maintainer-guide.asciidoc[]
 
 // Submitting a Plugin
 
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/submitting-a-plugin.asciidoc
 include::static/submitting-a-plugin.asciidoc[]
 
 // Glossary of Terms
 
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/glossary.asciidoc
 include::static/glossary.asciidoc[]
 
 // This is in the pluginbody.asciidoc itself
@@ -168,5 +187,6 @@ include::static/glossary.asciidoc[]
 
 // Release Notes
 
+:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/releasenotes.asciidoc
 include::static/releasenotes.asciidoc[]
 


### PR DESCRIPTION
@clintongormley Not sure if there is a better way to do this, but we need to point the Edit links to the `logstash` repo because `logstash-docs` is meant to be a read-only repo. 

At the moment, the Edit links are all broken in the 5.0+ docs because the Edit URL is weird. For example: https://github.com/elastic/logstash/edit/logstash-docs/docs/static/life-of-an-event.asciidoc

I'm all for fixing this in one place if that's possible. Just not sure how.