### PR TITLE
Remove mem type from node stats API docs

### DIFF
--- a/docs/static/monitoring-apis.asciidoc
+++ b/docs/static/monitoring-apis.asciidoc
@@ -234,8 +234,6 @@ By default, all stats are returned. You can limit the info that's returned by co
 Gets JVM stats, including stats about threads, memory usage, and garbage collectors.
 `process`::
 Gets process stats, including stats about file descriptors, memory consumption, and CPU usage.
-`mem`::
-Gets memory usage stats.
 `pipeline`::
 Gets runtime stats about the Logstash pipeline.
 


### PR DESCRIPTION
Cleanup to resolve https://github.com/elastic/logstash/issues/6511 in 5.0 and 5.1 docs. The issue is already fixed in 5.2 and later.