### PR TITLE
Javaify individual metrics types

### DIFF
--- a/logstash-core/lib/logstash/instrument/metric_type/base.rb
+++ b/logstash-core/lib/logstash/instrument/metric_type/base.rb
@@ -2,30 +2,8 @@
 require "logstash/util"
 
 module LogStash module Instrument module MetricType
-  class Base
-    attr_reader :namespaces, :key
-
-    def initialize(namespaces, key)
-      @namespaces = namespaces
-      @key = key
-    end
-
-    def inspect
-      "#{self.class.name} - namespaces: #{namespaces} key: #{key} value: #{value}"
-    end
-
-    def to_hash
-      {
-        key => value
-      }
-    end
-
-    def to_json_data
-      value
-    end
-
-    def type
-      @type ||= LogStash::Util.class_name(self).downcase
-    end
-  end
+  # This is here for backwards compatibility.
+  # Some tests and perhaps even user code check for class identity
+  # We should remove this in master/6.0
+  Base = org.logstash.instrument.metrics.AbstractMetric
 end; end; end

--- a/logstash-core/lib/logstash/instrument/metric_type/counter.rb
+++ b/logstash-core/lib/logstash/instrument/metric_type/counter.rb
@@ -3,27 +3,14 @@ require "logstash/instrument/metric_type/base"
 require "concurrent"
 
 module LogStash module Instrument module MetricType
-  class Counter < Base
-    def initialize(namespaces, key, value = 0)
-      super(namespaces, key)
-
-      @counter = Concurrent::AtomicFixnum.new(value)
-    end
-
-    def increment(value = 1)
-      @counter.increment(value)
-    end
-
-    def decrement(value = 1)
-      @counter.decrement(value)
-    end
-
+  class Counter < org.logstash.instrument.metrics.Counter
     def execute(action, value = 1)
-      @counter.send(action, value)
+      self.send(action, value)
     end
 
+    # We don't want this ruby style method in java-land
     def value
-      @counter.value
+      self.getValue()
     end
   end
 end; end; end

--- a/logstash-core/lib/logstash/instrument/metric_type/gauge.rb
+++ b/logstash-core/lib/logstash/instrument/metric_type/gauge.rb
@@ -4,19 +4,18 @@ require "concurrent/atomic_reference/mutex_atomic"
 require "logstash/json"
 
 module LogStash module Instrument module MetricType
-  class Gauge < Base
-    def initialize(namespaces, key)
-      super(namespaces, key)
-
-      @gauge = Concurrent::MutexAtomicReference.new()
-    end
-
+  class Gauge < org.logstash.instrument.metrics.Gauge
     def execute(action, value = nil)
-      @gauge.set(value)
+      self.set(value)
     end
 
-    def value
-      @gauge.get
+    # We don't want these ruby style methods in java-land
+    def get
+      self.getValue()
+    end
+
+    def set(value)
+      self.setValue(value)
     end
   end
 end; end; end

--- a/logstash-core/spec/logstash/instrument/metric_store_spec.rb
+++ b/logstash-core/spec/logstash/instrument/metric_store_spec.rb
@@ -159,7 +159,7 @@ describe LogStash::Instrument::MetricStore do
     describe "get_shallow" do
       it "should retrieve a path as a single value" do
         r = subject.get_shallow(:node, :sashimi, :pipelines, :pipeline01, :processed_events_in)
-        expect(r.value).to eql(1)
+        expect(r.value).to eql(1.0)
       end
     end
 
@@ -170,8 +170,8 @@ describe LogStash::Instrument::MetricStore do
           :processed_events_in,
           :processed_events_out,
         )
-        expect(r[:processed_events_in]).to eql(1)
-        expect(r[:processed_events_out]).to eql(1)
+        expect(r[:processed_events_in]).to eql(1.0)
+        expect(r[:processed_events_out]).to eql(1.0)
       end
 
       it "should retrieve nested values correctly alongside non-nested ones" do
@@ -180,8 +180,8 @@ describe LogStash::Instrument::MetricStore do
           :processed_events_in,
           [:plugins, :"logstash-output-elasticsearch", :event_in]
         )
-       expect(r[:processed_events_in]).to eql(1)
-        expect(r[:plugins][:"logstash-output-elasticsearch"][:event_in]).to eql(1)
+       expect(r[:processed_events_in]).to eql(1.0)
+        expect(r[:plugins][:"logstash-output-elasticsearch"][:event_in]).to eql(1.0)
       end
 
       it "should retrieve multiple nested keys at a given location" do
@@ -190,8 +190,8 @@ describe LogStash::Instrument::MetricStore do
           [:pipeline01, [:processed_events_in, :processed_events_out]]
         )
 
-        expect(r[:pipeline01][:processed_events_in]).to eql(1)
-        expect(r[:pipeline01][:processed_events_out]).to eql(1)
+        expect(r[:pipeline01][:processed_events_in]).to eql(1.0)
+        expect(r[:pipeline01][:processed_events_out]).to eql(1.0)
       end
 
       it "should retrieve a single key nested in multiple places" do
@@ -200,8 +200,8 @@ describe LogStash::Instrument::MetricStore do
           [[:pipeline01, :pipeline02], :processed_events_out]
         )
 
-        expect(r[:pipeline01][:processed_events_out]).to eql(1)
-        expect(r[:pipeline02][:processed_events_out]).to eql(1)
+        expect(r[:pipeline01][:processed_events_out]).to eql(1.0)
+        expect(r[:pipeline02][:processed_events_out]).to eql(1.0)
       end
 
       it "handle overlaps of paths" do
@@ -211,9 +211,9 @@ describe LogStash::Instrument::MetricStore do
           [[:pipeline01, :pipeline02], :processed_events_out]
         )
 
-        expect(r[:pipeline01][:processed_events_in]).to eql(1)
-        expect(r[:pipeline01][:processed_events_out]).to eql(1)
-        expect(r[:pipeline02][:processed_events_out]).to eql(1)
+        expect(r[:pipeline01][:processed_events_in]).to eql(1.0)
+        expect(r[:pipeline01][:processed_events_out]).to eql(1.0)
+        expect(r[:pipeline02][:processed_events_out]).to eql(1.0)
       end
     end
 

--- a/logstash-core/spec/logstash/instrument/metric_type/counter_spec.rb
+++ b/logstash-core/spec/logstash/instrument/metric_type/counter_spec.rb
@@ -22,7 +22,7 @@ describe LogStash::Instrument::MetricType::Counter do
 
   context "When serializing to JSON" do
     it "serializes the value" do
-      expect(LogStash::Json.dump(subject)).to eq("0")
+      expect(LogStash::Json.dump(subject)).to eq("0.0")
     end
   end
 

--- a/logstash-core/spec/logstash/instrument/wrapped_write_client_spec.rb
+++ b/logstash-core/spec/logstash/instrument/wrapped_write_client_spec.rb
@@ -86,15 +86,15 @@ describe LogStash::Instrument::WrappedWriteClient do
 
       context "recording of the duration of pushing to the queue" do
         it "records at the `global events` level" do
-          expect(snapshot_metric[:events][:queue_push_duration_in_millis].value).to be_kind_of(Integer)
+          expect(snapshot_metric[:events][:queue_push_duration_in_millis].value).to be_kind_of(Float)
         end
 
         it "records at the `pipeline` level" do
-          expect(snapshot_metric[:pipelines][:main][:events][:queue_push_duration_in_millis].value).to be_kind_of(Integer)
+          expect(snapshot_metric[:pipelines][:main][:events][:queue_push_duration_in_millis].value).to be_kind_of(Float)
         end
 
         it "records at the `plugin level" do
-          expect(snapshot_metric[:pipelines][:main][:plugins][:inputs][myid.to_sym][:events][:queue_push_duration_in_millis].value).to be_kind_of(Integer)
+          expect(snapshot_metric[:pipelines][:main][:plugins][:inputs][myid.to_sym][:events][:queue_push_duration_in_millis].value).to be_kind_of(Float)
         end
       end
     end

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractMetric.java
@@ -1,0 +1,56 @@
+package org.logstash.instrument.metrics;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Created by andrewvc on 5/25/17.
+ */
+@JsonSerialize(using = AbstractMetricSerializer.class)
+public abstract class AbstractMetric {
+    // The use of Object here is to deal with the fact that the namespace can
+    // also be a String or a Keyword in ruby.
+    // At some point we should refactor these to be String, not Object
+    private final List<Object> namespaces;
+    private final Object key;
+    private final String type = this.getClass().getName().toLowerCase();
+
+    public AbstractMetric(List<Object> namespaces, Object key) {
+        this.namespaces = namespaces;
+        this.key = key;
+    }
+
+    public List<Object> getNamespaces() {
+        return namespaces;
+    }
+
+    public Object getKey() {
+        return key;
+    }
+
+    public String toString() {
+        return this.getClass().getName() + " - " +
+                "namespaces: " + getNamespaces().stream().
+                    map(Object::toString).
+                    collect(Collectors.joining("->")) +
+                "key: " + getKey() +
+                "value: " + getValue();
+    }
+
+    public Map<Object,Object> toHash() {
+        HashMap<Object, Object> map = new HashMap<>();
+        map.put(getKey(), getValue());
+        return map;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public abstract Object getValue();
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractMetricSerializer.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractMetricSerializer.java
@@ -1,0 +1,36 @@
+package org.logstash.instrument.metrics;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+/**
+ * Created by andrewvc on 5/25/17.
+ */
+public class AbstractMetricSerializer extends JsonSerializer<AbstractMetric> {
+    @Override
+    public void serialize(AbstractMetric metric, JsonGenerator gen, SerializerProvider serializers) throws IOException, JsonProcessingException {
+        Object value = metric.getValue();
+        if (value == null) {
+            gen.writeNull();
+        }
+        else if (value instanceof String) {
+            gen.writeString((String) value);
+        } else if (value instanceof Double) {
+            gen.writeNumber((Double) value);
+        } else if (value instanceof Float) {
+            gen.writeNumber((Float) value);
+        } else if (value instanceof Long) {
+            gen.writeNumber((Long) value);
+        } else if (value instanceof Integer) {
+            gen.writeNumber((Integer) value);
+        } else if (value instanceof Boolean) {
+            gen.writeBoolean((Boolean) value);
+        } else {
+            gen.writeString(value.toString());
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/Counter.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/Counter.java
@@ -1,0 +1,43 @@
+package org.logstash.instrument.metrics;
+
+import java.util.List;
+import java.util.concurrent.atomic.DoubleAdder;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Created by andrewvc on 5/25/17.
+ */
+public class Counter extends AbstractMetric {
+    private final DoubleAdder value = new DoubleAdder();
+
+    public Counter(List<Object> namespaces, Object key) {
+        this(namespaces, key, 0);
+    }
+
+    public Counter(List<Object> namespaces, Object key, double value) {
+        super(namespaces, key);
+        this.value.reset();
+        this.value.add(value);
+    }
+
+    public void increment(double incValue) {
+        value.add(incValue);
+    }
+
+    public void increment() {
+        value.add(1);
+    }
+
+    public void decrement(double decValue) {
+        value.add(-decValue);
+    }
+
+    public void decrement() {
+        value.add(-1);
+    }
+
+    @Override
+    public Object getValue() {
+        return value.doubleValue();
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/Gauge.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/Gauge.java
@@ -1,0 +1,23 @@
+package org.logstash.instrument.metrics;
+
+import java.util.List;
+
+/**
+ * Created by andrewvc on 5/25/17.
+ */
+public class Gauge extends AbstractMetric {
+    private volatile Object value = null;
+
+    public Gauge(List<Object> namespaces, Object key) {
+        super(namespaces, key);
+    }
+
+    @Override
+    public Object getValue() {
+        return value;
+    }
+
+    public void setValue(Object value) {
+        this.value = value;
+    }
+}


### PR DESCRIPTION
This is in preparation for https://github.com/elastic/logstash/issues/7155

We will want to make those objects for GlobalStats etc. Java objects, so we'll need to javaify these classes first. We're breaking up this workinto multiple stand-alone commits to make this easier.

I initially thought we'd need to move `TimedExecution` to this, but I don't think that makes sense anymore. I think it makes sense to do that in the next phase, and see how that plays out with the larger java 

This moves all metrics from ruby Numeric to java Double. This is more appropriate for a number of reasons, but primarily it makes dealing with numbers externally a lot easier. You can know that metrics are either strings or (double) numbers.