### PR TITLE
#7239 fix timeunit on cpu time metric

### DIFF
--- a/logstash-core/src/main/java/org/logstash/instrument/monitors/ProcessMonitor.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/monitors/ProcessMonitor.java
@@ -1,13 +1,12 @@
 package org.logstash.instrument.monitors;
 
 import com.sun.management.UnixOperatingSystemMXBean;
-
-import javax.management.MBeanServer;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import javax.management.MBeanServer;
 
 /**
  * Created by andrewvc on 5/12/16.
@@ -35,8 +34,9 @@ public class ProcessMonitor {
 
                 this.openFds = unixOsBean.getOpenFileDescriptorCount();
                 this.maxFds =  unixOsBean.getMaxFileDescriptorCount();
-
-                this.cpuMillisTotal = unixOsBean.getProcessCpuTime();
+                this.cpuMillisTotal = TimeUnit.MILLISECONDS.convert(
+                    unixOsBean.getProcessCpuTime(), TimeUnit.NANOSECONDS
+                );
                 this.cpuProcessPercent = scaleLoadToPercent(unixOsBean.getProcessCpuLoad());
                 this.cpuSystemPercent = scaleLoadToPercent(unixOsBean.getSystemCpuLoad());
 


### PR DESCRIPTION
Trivial time unit issue, fixes #7239.

Lame excuse for no test: I saw there was some instability in the metrics tests and adjustments being done. Since this is a prime candidate for an unstable test I didn't want to pile on for a trivial thing like this.