### PR TITLE
 #7241 Handling Pattern Definitions in JSON -> Grok Conversion Tool

### DIFF
--- a/tools/ingest-converter/src/test/java/org/logstash/ingest/GrokTest.java
+++ b/tools/ingest-converter/src/test/java/org/logstash/ingest/GrokTest.java
@@ -1,6 +1,5 @@
 package org.logstash.ingest;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -18,12 +17,20 @@ public final class GrokTest {
     public final TemporaryFolder temp = new TemporaryFolder();
 
     @Test
-    public void convertsCorrectly() throws Exception {
-        final File testdir = temp.newFolder();
-        final String grok = testdir.toPath().resolve("converted.grok").toString();
+    public void convertsFieldPatternsCorrectly() throws Exception {
+        final String grok = temp.newFolder().toPath().resolve("converted.grok").toString();
         Grok.main(resourcePath("ingestTestConfig.json"), grok);
         assertThat(
             utf8File(grok), is(utf8File(resourcePath("ingestTestConfig.grok")))
+        );
+    }
+
+    @Test
+    public void convertsFieldDefinitionsCorrectly() throws Exception {
+        final String grok = temp.newFolder().toPath().resolve("converted.grok").toString();
+        Grok.main(resourcePath("ingestTestPatternDefinition.json"), grok);
+        assertThat(
+            utf8File(grok), is(utf8File(resourcePath("ingestTestPatternDefinition.grok")))
         );
     }
 

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/ingestTestPatternDefinition.grok
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/ingestTestPatternDefinition.grok
@@ -1,0 +1,13 @@
+filter {
+   grok {
+      match => {
+         "message" => [
+            "%{SYSLOGTIMESTAMP:[system][syslog][timestamp]} %{SYSLOGHOST:[system][syslog][hostname]} %{DATA:[system][syslog][program]}(?:\[%{POSINT:[system][syslog][pid]}\])?: %{GREEDYMULTILINE:[system][syslog][message]}",
+            "%{SYSLOGTIMESTAMP:[system][syslog][timestamp]} %{GREEDYMULTILINE:[system][syslog][message]}"
+         ]
+      }
+      pattern_definitions => {
+         "GREEDYMULTILINE" => "(.|\n)*"
+      }
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/ingestTestPatternDefinition.json
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/ingestTestPatternDefinition.json
@@ -1,0 +1,18 @@
+{
+  "description":"Syslog",
+  "processors":[
+    {
+      "grok":{
+        "field":"message",
+        "patterns":[
+          "%{SYSLOGTIMESTAMP:system.syslog.timestamp} %{SYSLOGHOST:system.syslog.hostname} %{DATA:system.syslog.program}(?:\\[%{POSINT:system.syslog.pid}\\])?: %{GREEDYMULTILINE:system.syslog.message}",
+          "%{SYSLOGTIMESTAMP:system.syslog.timestamp} %{GREEDYMULTILINE:system.syslog.message}"
+        ],
+        "pattern_definitions":{
+          "GREEDYMULTILINE":"(.|\\n)*"
+        },
+        "ignore_missing":true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
closes #7241 

* New test for pattern definition
* Handling pattern definition field correctly
* Making indent handling stricter to allow for multiline string literals

... generally tried to keep things a little verbose in terms of function use with stuff like `join_hash_fields` to keep things readable, hope it helps.
