### PR TITLE
MINOR: Optimized map merge in org.logstash.Util#mapMerge

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Util.java
+++ b/logstash-core/src/main/java/org/logstash/Util.java
@@ -1,7 +1,6 @@
 package org.logstash;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,42 +38,65 @@ public class Util {
         return map;
     }
 
-    public static void mapMerge(Map<String, Object> target, Map<String, Object> add) {
-        for (Map.Entry<String, Object> e : add.entrySet()) {
-            if (target.containsKey(e.getKey())) {
-                if (target.get(e.getKey()) instanceof Map && e.getValue() instanceof Map) {
-                    mapMerge((Map<String, Object>) target.get(e.getKey()), (Map<String, Object>) e.getValue());
-                } else if (e.getValue() instanceof List) {
-                    if (target.get(e.getKey()) instanceof List) {
-                        // needs optimizing
-                        List targetList = (List) target.get(e.getKey());
-                        targetList.addAll((List) e.getValue());
-                        target.put(e.getKey(), new ArrayList<Object>(new LinkedHashSet<Object>(targetList)));
+    public static void mapMerge(final Map<String, Object> target, final Map<String, Object> add) {
+        LinkedHashSet<Object> buffer = null;
+        for (final Map.Entry<String, Object> entry : add.entrySet()) {
+            final String entryKey = entry.getKey();
+            final Object entryValue = entry.getValue();
+            final Object targetValue = target.get(entryKey);
+            if (targetValue == null) {
+                target.put(entryKey, entryValue);
+            } else {
+                if (targetValue instanceof Map && entryValue instanceof Map) {
+                    mapMerge((Map<String, Object>) targetValue, (Map<String, Object>) entryValue);
+                } else if (entryValue instanceof List) {
+                    final List<Object> entryValueList = (List<Object>) entryValue;
+                    if (targetValue instanceof List) {
+                        if (buffer == null) {
+                            buffer = new LinkedHashSet<>();
+                        } else {
+                            buffer.clear();
+                        }
+                        mergeLists((List<Object>) targetValue, (List<Object>) entryValue, buffer);
                     } else {
-                        Object targetValue = target.get(e.getKey());
-                        List targetValueList = new ArrayList();
+                        final List<Object> targetValueList =
+                            new ArrayList<>(entryValueList.size() + 1);
                         targetValueList.add(targetValue);
-                        for (Object o : (List) e.getValue()) {
+                        for (final Object o : entryValueList) {
                             if (!targetValue.equals(o)) {
                                 targetValueList.add(o);
                             }
                         }
-                        target.put(e.getKey(), targetValueList);
+                        target.put(entryKey, targetValueList);
                     }
-                } else if (target.get(e.getKey()) instanceof List) {
-                    List t = ((List) target.get(e.getKey()));
-                    if (!t.contains(e.getValue())) {
-                        t.add(e.getValue());
+                } else if (targetValue instanceof List) {
+                    final List<Object> targetValueList = (List<Object>) targetValue;
+                    if (!targetValueList.contains(entryValue)) {
+                        targetValueList.add(entryValue);
                     }
-                } else if (!target.get(e.getKey()).equals(e.getValue())) {
-                    List targetValue = new ArrayList();
-                    targetValue.add(target.get(e.getKey()));
-                    ((List) targetValue).add(e.getValue());
-                    target.put(e.getKey(), targetValue);
+                } else if (!targetValue.equals(entryValue)) {
+                    final List<Object> targetValueList = new ArrayList<>(2);
+                    targetValueList.add(targetValue);
+                    targetValueList.add(entryValue);
+                    target.put(entryKey, targetValueList);
                 }
-            } else {
-                target.put(e.getKey(), e.getValue());
             }
         }
+    }
+
+    /**
+     * Merges elements in the source list into the target list, adding only those in the source
+     * list that are not yet contained in the target list while keeping the target list ordered
+     * according to last added.
+     * @param target Target List
+     * @param source Source List
+     * @param buffer {@link LinkedHashSet} used as sort buffer
+     */
+    private static void mergeLists(final List<Object> target, final List<Object> source,
+        final LinkedHashSet<Object> buffer) {
+        buffer.addAll(target);
+        buffer.addAll(source);
+        target.clear();
+        target.addAll(buffer);
     }
 }

--- a/logstash-core/src/test/java/org/logstash/EventTest.java
+++ b/logstash-core/src/test/java/org/logstash/EventTest.java
@@ -1,14 +1,12 @@
 package org.logstash;
 
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.junit.Test;
 
 import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
 import static org.junit.Assert.assertEquals;
@@ -198,6 +196,25 @@ public class EventTest {
         assertEquals(2, ((List) e.getField("[field1]")).size());
         assertEquals("original1", e.getField("[field1][0]"));
         assertEquals("original2", e.getField("[field1][1]"));
+    }
+
+    @Test
+    public void testAppendLists() throws Exception {
+        Map data1 = new HashMap();
+        data1.put("field1", Arrays.asList("original1", "original2"));
+
+        Map data2 = new HashMap();
+        data2.put("field1", Arrays.asList("original3", "original4"));
+
+        Event e = new Event(data1);
+        Event e2 = new Event(data2);
+        e.append(e2);
+
+        assertEquals(4, ((List) e.getField("[field1]")).size());
+        assertEquals("original1", e.getField("[field1][0]"));
+        assertEquals("original2", e.getField("[field1][1]"));
+        assertEquals("original3", e.getField("[field1][2]"));
+        assertEquals("original4", e.getField("[field1][3]"));
     }
 
     @Test


### PR DESCRIPTION
Saw the todo and took care of it as best as possible without larger changes:

* removed todo :P
* reusing sort buffer (saves creating a new `ArrayList<>` on the target also)
* avoid redundant map lookups
* size lists correctly when instantiating
* fixes JRuby error that shows with the newly added test, it fails with the following in `master`
```java
java.lang.IllegalArgumentException: Missing Ruby class handling for full class name=java.util.ArrayList, simple name=ArrayList

|tat org.logstash.Javafier.deep(Javafier.java:29)
|tat org.logstash.Event.getField(Event.java:147)
|tat org.logstash.EventTest.testAppendLists(EventTest.java:213)
|tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
|tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
|tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
|tat java.lang.reflect.Method.invoke(Method.java:498)
|tat org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
|tat org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
|tat org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
|tat org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
|tat org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
|tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
|tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
|tat org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
|tat org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
|tat org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
|tat org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
|tat org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
|tat org.junit.runners.ParentRunner.run(ParentRunner.java:363)
|tat org.junit.runner.JUnitCore.run(JUnitCore.java:137)
|tat com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
|tat com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
|tat com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
|tat com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
```