### PR TITLE
remove question only todo

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Timestamp.java
+++ b/logstash-core/src/main/java/org/logstash/Timestamp.java
@@ -18,7 +18,6 @@ public class Timestamp implements Cloneable, Comparable, Queueable {
     // all methods setting the time object must set it in the UTC timezone
     private DateTime time;
 
-    // TODO: is this DateTimeFormatter thread safe?
     private static DateTimeFormatter iso8601Formatter = ISODateTimeFormat.dateTime();
 
     private static final LocalDateTime JAN_1_1970 = new LocalDateTime(1970, 1, 1, 0, 0);


### PR DESCRIPTION
Yes it is threadsafe:

```java
 * ISODateTimeFormat is thread-safe and immutable, and the formatters it
 * returns are as well.
 *
 * @author Brian S O'Neill
 * @since 1.0
 * @see DateTimeFormat
 * @see DateTimeFormatterBuilder
 */
public class ISODateTimeFormat {

```