### PR TITLE
Add SSLError to the list of retryable exception

### DIFF
--- a/spec/unit/plugin_manager/offline_plugin_packager_spec.rb
+++ b/spec/unit/plugin_manager/offline_plugin_packager_spec.rb
@@ -6,6 +6,7 @@ require "bootstrap/util/compress"
 require "fileutils"
 require "spec_helper"
 require "webmock"
+require "openssl"
 
 def retrieve_packaged_plugins(path)
   Dir.glob(::File.join(path, "logstash", "*.gem"))
@@ -42,7 +43,7 @@ describe LogStash::PluginManager::OfflinePluginPackager do
   let(:target) { ::File.join(temporary_dir, "my-pack.zip")}
   let(:extract_to) { Stud::Temporary.pathname }
   let(:retries_count) { 50 }
-  let(:retries_exceptions) { [IOError] }
+  let(:retries_exceptions) { [IOError, OpenSSL::SSL::SSLError] }
 
   context "when the plugins doesn't" do
     let(:plugins_args) { "idotnotexist" }


### PR DESCRIPTION
When building an offline pack we do a real network call to rubygems to
test the structure of the created package, something the network can be
a bit unreliable and SSLError can be raised, when theses errors happen
we will retry them.

Fix: #7251