### PR TITLE
#7256 close channel underlying the queue's Filelock

### DIFF
--- a/logstash-core/src/main/java/org/logstash/FileLockFactory.java
+++ b/logstash-core/src/main/java/org/logstash/FileLockFactory.java
@@ -114,6 +114,7 @@ public class FileLockFactory {
         String lockPath = LOCK_MAP.remove(lock);
         if (lockPath == null) { throw new LockException("Cannot release unobtained lock"); }
         lock.release();
+        lock.channel().close();
         Boolean removed = LOCK_HELD.remove(lockPath);
         if (removed == false) { throw new LockException("Lock path was not marked as held: " + lockPath); }
     }


### PR DESCRIPTION
Very straightforward.

A Java `FileLock` is obtained from a `Channel` but the relationship is (for most platforms at least).

Close Channel => Release Lock (this isn't true for all platforms)
Release Lock => No effect on Channel

We were never closing the channel underlying the lock => leaking one FD per Queue.

Fixed by safely ensuring close of the underlying channel.

Works (more loops run through than my OSX allows me FDs :P):

<img width="902" alt="screen shot 2017-05-29 at 23 34 38" src="https://cloud.githubusercontent.com/assets/6490959/26562580/d31a9654-44c7-11e7-8d82-7cdc82349533.png">
