### PR TITLE
MINOR: Remove unused function from Page

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Page.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Page.java
@@ -154,7 +154,4 @@ public abstract class Page implements Closeable {
         return this.ackedSeqNums.nextClearBit(0) + this.minSeqNum;
     }
 
-    protected int firstUnackedPageNumFromQueue() {
-        return queue.firstUnackedPageNum();
-    }
 }


### PR DESCRIPTION
This one is not used anywhere -> no need to keep it around.