### PR TITLE
MINOR: Cleanup of org.logstash.FieldReference

### DIFF
--- a/logstash-core/src/main/java/org/logstash/FieldReference.java
+++ b/logstash-core/src/main/java/org/logstash/FieldReference.java
@@ -1,17 +1,17 @@
 package org.logstash;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-
+import java.util.regex.Pattern;
 // TODO: implement thread-safe path cache singleton to avoid parsing
 
 public class FieldReference {
 
+    private static final Pattern SPLIT_PATTERN = Pattern.compile("[\\[\\]]");
+
     private List<String> path;
     private String key;
     private String reference;
-    private static List<String> EMPTY_STRINGS = Arrays.asList("");
 
     public FieldReference(List<String> path, String key, String reference) {
         this.path = path;
@@ -32,8 +32,13 @@ public class FieldReference {
     }
 
     public static FieldReference parse(String reference) {
-        List<String> path = new ArrayList(Arrays.asList(reference.split("[\\[\\]]")));
-        path.removeAll(EMPTY_STRINGS);
+        final String[] parts = SPLIT_PATTERN.split(reference);
+        List<String> path = new ArrayList<>(parts.length);
+        for (final String part : parts) {
+            if (!part.isEmpty()) {
+                path.add(part);
+            }
+        }
         String key = path.remove(path.size() - 1);
         return new FieldReference(path, key, reference);
     }


### PR DESCRIPTION
Few obvious ones in this class:

* Regex should use compiled pattern
* `EMPTY_STRINGS` was a very inefficient approach to filtering empty strings, let's just not copy them to the list in the first place and avoid that extra loop
* Avoid creating redundant `ArrayList` in `new ArrayList(Arrays.asList(reference.split("[\\[\\]]")));`, just copy straight to the array