### PR TITLE
MINOR: Fix missing static identifiers and save some memory

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -288,7 +288,7 @@ class LogStash::Runner < Clamp::StrictCommand
     end
 
     # lock path.data before starting the agent
-    @data_path_lock = FileLockFactory.getDefault().obtainLock(setting("path.data"), ".lock");
+    @data_path_lock = FileLockFactory.obtainLock(setting("path.data"), ".lock");
 
     @dispatcher.fire(:before_agent)
     @agent = create_agent(@settings, @source_loader)
@@ -333,7 +333,7 @@ class LogStash::Runner < Clamp::StrictCommand
     Stud::untrap("INT", sigint_id) unless sigint_id.nil?
     Stud::untrap("TERM", sigterm_id) unless sigterm_id.nil?
     Stud::untrap("HUP", sighup_id) unless sighup_id.nil?
-    FileLockFactory.getDefault().releaseLock(@data_path_lock) if @data_path_lock
+    FileLockFactory.releaseLock(@data_path_lock) if @data_path_lock
     @log_fd.close if @log_fd
   end # def self.main
 

--- a/logstash-core/src/main/java/org/logstash/Accessors.java
+++ b/logstash-core/src/main/java/org/logstash/Accessors.java
@@ -15,19 +15,19 @@ public class Accessors {
     }
 
     public Object get(String reference) {
-        FieldReference field = PathCache.getInstance().cache(reference);
+        FieldReference field = PathCache.cache(reference);
         Object target = findTarget(field);
         return (target == null) ? null : fetch(target, field.getKey());
     }
 
     public Object set(String reference, Object value) {
-        FieldReference field = PathCache.getInstance().cache(reference);
+        FieldReference field = PathCache.cache(reference);
         Object target = findCreateTarget(field);
         return store(target, field.getKey(), value);
     }
 
     public Object del(String reference) {
-        FieldReference field = PathCache.getInstance().cache(reference);
+        FieldReference field = PathCache.cache(reference);
         Object target = findTarget(field);
         if (target != null) {
             if (target instanceof Map) {
@@ -48,7 +48,7 @@ public class Accessors {
     }
 
     public boolean includes(String reference) {
-        FieldReference field = PathCache.getInstance().cache(reference);
+        FieldReference field = PathCache.cache(reference);
         Object target = findTarget(field);
         if (target instanceof Map && foundInMap((Map<String, Object>) target, field.getKey())) {
             return true;
@@ -122,7 +122,7 @@ public class Accessors {
         return target;
     }
 
-    private boolean foundInList(List<Object> target, int index) {
+    private static boolean foundInList(List<Object> target, int index) {
         try {
             int offset = listIndex(index, target.size());
             return target.get(offset) != null;
@@ -132,11 +132,11 @@ public class Accessors {
 
     }
 
-    private boolean foundInMap(Map<String, Object> target, String key) {
+    private static boolean foundInMap(Map<String, Object> target, String key) {
         return target.containsKey(key);
     }
 
-    private Object fetch(Object target, String key) {
+    private static Object fetch(Object target, String key) {
         if (target instanceof Map) {
             Object result = ((Map<String, Object>) target).get(key);
             return result;
@@ -154,7 +154,7 @@ public class Accessors {
         }
     }
 
-    private Object store(Object target, String key, Object value) {
+    private static Object store(Object target, String key, Object value) {
         if (target instanceof Map) {
             ((Map<String, Object>) target).put(key, value);
         } else if (target instanceof List) {
@@ -184,14 +184,14 @@ public class Accessors {
         return value;
     }
 
-    private boolean isCollection(Object target) {
+    private static boolean isCollection(Object target) {
         if (target == null) {
             return false;
         }
         return (target instanceof Map || target instanceof List);
     }
 
-    private ClassCastException newCollectionException(Object target) {
+    private static ClassCastException newCollectionException(Object target) {
         return new ClassCastException("expecting List or Map, found "  + target.getClass());
     }
 

--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -1,16 +1,5 @@
 package org.logstash;
 
-import org.logstash.bivalues.NullBiValue;
-import org.logstash.bivalues.StringBiValue;
-import org.logstash.bivalues.TimeBiValue;
-import org.logstash.bivalues.TimestampBiValue;
-import org.logstash.ext.JrubyTimestampExtLibrary;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.joda.time.DateTime;
-import org.jruby.RubySymbol;
-import org.logstash.ackedqueue.Queueable;
-
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -19,6 +8,16 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.joda.time.DateTime;
+import org.jruby.RubySymbol;
+import org.logstash.ackedqueue.Queueable;
+import org.logstash.bivalues.NullBiValue;
+import org.logstash.bivalues.StringBiValue;
+import org.logstash.bivalues.TimeBiValue;
+import org.logstash.bivalues.TimestampBiValue;
+import org.logstash.ext.JrubyTimestampExtLibrary;
 
 import static org.logstash.ObjectMappers.CBOR_MAPPER;
 import static org.logstash.ObjectMappers.JSON_MAPPER;
@@ -192,7 +191,8 @@ public class Event implements Cloneable, Serializable, Queueable {
         return hashMap;
     }
 
-    private byte[] toBinaryFromMap(Map<String, Map<String, Object>> representation) throws IOException {
+    private static byte[] toBinaryFromMap(Map<String, Map<String, Object>> representation)
+        throws IOException {
         return CBOR_MAPPER.writeValueAsBytes(representation);
     }
 
@@ -315,7 +315,7 @@ public class Event implements Cloneable, Serializable, Queueable {
         }
     }
 
-    private Timestamp initTimestamp(Object o) {
+    private static Timestamp initTimestamp(Object o) {
         try {
             if (o == null || o instanceof NullBiValue) {
                 // most frequent

--- a/logstash-core/src/main/java/org/logstash/FileLockFactory.java
+++ b/logstash-core/src/main/java/org/logstash/FileLockFactory.java
@@ -44,21 +44,12 @@ import java.util.Set;
  */
 public class FileLockFactory {
 
-    /**
-     * Singleton instance
-     */
-    public static final FileLockFactory INSTANCE = new FileLockFactory();
-
     private FileLockFactory() {}
 
     private static final Set<String> LOCK_HELD = Collections.synchronizedSet(new HashSet<>());
     private static final Map<FileLock, String> LOCK_MAP =  Collections.synchronizedMap(new HashMap<>());
 
-    public static final FileLockFactory getDefault() {
-        return FileLockFactory.INSTANCE;
-    }
-
-    public FileLock obtainLock(String lockDir, String lockName) throws IOException {
+    public static FileLock obtainLock(String lockDir, String lockName) throws IOException {
         Path dirPath = FileSystems.getDefault().getPath(lockDir);
 
         // Ensure that lockDir exists and is a directory.
@@ -110,7 +101,7 @@ public class FileLockFactory {
         }
     }
 
-    public void releaseLock(FileLock lock) throws IOException {
+    public static void releaseLock(FileLock lock) throws IOException {
         String lockPath = LOCK_MAP.remove(lock);
         if (lockPath == null) { throw new LockException("Cannot release unobtained lock"); }
         lock.release();

--- a/logstash-core/src/main/java/org/logstash/PathCache.java
+++ b/logstash-core/src/main/java/org/logstash/PathCache.java
@@ -28,7 +28,7 @@ public class PathCache {
         return (cache(reference) == this.timestamp);
     }
 
-    public FieldReference cache(String reference) {
+    public static FieldReference cache(String reference) {
         // atomicity between the get and put is not important
         FieldReference result = cache.get(reference);
         if (result == null) {
@@ -38,7 +38,7 @@ public class PathCache {
         return result;
     }
 
-    public FieldReference cache(String reference, FieldReference field) {
+    public static FieldReference cache(String reference, FieldReference field) {
         cache.put(reference, field);
         return field;
     }

--- a/logstash-core/src/main/java/org/logstash/StringInterpolation.java
+++ b/logstash-core/src/main/java/org/logstash/StringInterpolation.java
@@ -47,7 +47,7 @@ public class StringInterpolation {
         return compiledTemplate.evaluate(event);
     }
 
-    public TemplateNode compile(String template) {
+    public static TemplateNode compile(String template) {
         Template compiledTemplate = new Template();
 
         if (template.indexOf('%') == -1) {
@@ -83,7 +83,7 @@ public class StringInterpolation {
         }
     }
 
-    public TemplateNode identifyTag(String tag) {
+    public static TemplateNode identifyTag(String tag) {
         if(tag.equals("+%s")) {
             return new EpochNode();
         } else if(tag.charAt(0) == '+') {

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -166,7 +166,7 @@ public class Queue implements Closeable {
         lock.lock();
         try {
             // verify exclusive access to the dirPath
-            this.dirLock = FileLockFactory.getDefault().obtainLock(this.dirPath, LOCK_NAME);
+            this.dirLock = FileLockFactory.obtainLock(this.dirPath, LOCK_NAME);
 
             Checkpoint headCheckpoint;
             try {
@@ -671,7 +671,7 @@ public class Queue implements Closeable {
 
             } finally {
                 try {
-                    FileLockFactory.getDefault().releaseLock(this.dirLock);
+                    FileLockFactory.releaseLock(this.dirLock);
                 } catch (IOException e) {
                     // log error and ignore
                     logger.error("Queue close releaseLock failed, error={}", e.getMessage());

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/AbstractByteBufferPageIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/AbstractByteBufferPageIO.java
@@ -11,11 +11,11 @@ import org.logstash.ackedqueue.SequencedList;
 
 public abstract class AbstractByteBufferPageIO implements PageIO {
 
-    public class PageIOInvalidElementException extends IOException {
+    public static class PageIOInvalidElementException extends IOException {
         public PageIOInvalidElementException(String message) { super(message); }
     }
 
-    public class PageIOInvalidVersionException extends IOException {
+    public static class PageIOInvalidVersionException extends IOException {
         public PageIOInvalidVersionException(String message) { super(message); }
     }
 
@@ -120,9 +120,10 @@ public abstract class AbstractByteBufferPageIO implements PageIO {
 
     // we don't have different versions yet so simply check if the version is VERSION_ONE for basic integrity check
     // and if an unexpected version byte is read throw PageIOInvalidVersionException
-    private void validateVersion(byte version) throws PageIOInvalidVersionException {
+    private static void validateVersion(byte version) throws PageIOInvalidVersionException {
         if (version != VERSION_ONE) {
-            throw new PageIOInvalidVersionException(String.format("Expected page version=%d but found version=%d", VERSION_ONE, version));
+            throw new PageIOInvalidVersionException(String
+                .format("Expected page version=%d but found version=%d", VERSION_ONE, version));
         }
     }
 
@@ -131,7 +132,8 @@ public abstract class AbstractByteBufferPageIO implements PageIO {
     private void readNextElement(long expectedSeqNum, boolean verifyChecksum) throws PageIOInvalidElementException {
         // if there is no room for the seqNum and length bytes stop here
         // TODO: I know this isn't a great exception message but at the time of writing I couldn't come up with anything better :P
-        if (this.head + SEQNUM_SIZE + LENGTH_SIZE > capacity) { throw new PageIOInvalidElementException("cannot read seqNum and length bytes past buffer capacity"); }
+        if (this.head + SEQNUM_SIZE + LENGTH_SIZE > capacity) { throw new PageIOInvalidElementException(
+            "cannot read seqNum and length bytes past buffer capacity"); }
 
         int elementOffset = this.head;
         int newHead = this.head;
@@ -140,7 +142,8 @@ public abstract class AbstractByteBufferPageIO implements PageIO {
         long seqNum = buffer.getLong();
         newHead += SEQNUM_SIZE;
 
-        if (seqNum != expectedSeqNum) { throw new PageIOInvalidElementException(String.format("Element seqNum %d is expected to be %d", seqNum, expectedSeqNum)); }
+        if (seqNum != expectedSeqNum) { throw new PageIOInvalidElementException(
+            String.format("Element seqNum %d is expected to be %d", seqNum, expectedSeqNum)); }
 
         int length = buffer.getInt();
         newHead += LENGTH_SIZE;
@@ -149,7 +152,8 @@ public abstract class AbstractByteBufferPageIO implements PageIO {
         if (length <= 0) { throw new PageIOInvalidElementException("Element invalid length"); }
 
         // if there is no room for the proposed data length and checksum just stop here
-        if (newHead + length + CHECKSUM_SIZE > capacity) { throw new PageIOInvalidElementException("cannot read element payload and checksum past buffer capacity"); }
+        if (newHead + length + CHECKSUM_SIZE > capacity) { throw new PageIOInvalidElementException(
+            "cannot read element payload and checksum past buffer capacity"); }
 
         if (verifyChecksum) {
             // read data and compute checksum;
@@ -160,7 +164,8 @@ public abstract class AbstractByteBufferPageIO implements PageIO {
             buffer.limit(prevLimit);
             int checksum = buffer.getInt();
             int computedChecksum = (int) this.checkSummer.getValue();
-            if (computedChecksum != checksum) { throw new PageIOInvalidElementException("Element invalid checksum"); }
+            if (computedChecksum != checksum) { throw new PageIOInvalidElementException(
+                "Element invalid checksum"); }
         }
 
         // at this point we recovered a valid element

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/FileCheckpointIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/FileCheckpointIO.java
@@ -100,7 +100,7 @@ public class FileCheckpointIO implements CheckpointIO {
         return TAIL_CHECKPOINT + pageNum;
     }
 
-    private Checkpoint read(BufferedChecksumStreamInput crcsi) throws IOException {
+    private static Checkpoint read(BufferedChecksumStreamInput crcsi) throws IOException {
         int version = (int) crcsi.readShort();
         // TODO - build reader for this version
         int pageNum = crcsi.readInt();

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/MemoryCheckpointIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/MemoryCheckpointIO.java
@@ -9,8 +9,8 @@ import java.util.Map;
 
 public class MemoryCheckpointIO implements CheckpointIO {
 
-    private final String HEAD_CHECKPOINT = "checkpoint.head";
-    private final String TAIL_CHECKPOINT = "checkpoint.";
+    private static final String HEAD_CHECKPOINT = "checkpoint.head";
+    private static final String TAIL_CHECKPOINT = "checkpoint.";
 
     private static final Map<String, Map<String, Checkpoint>> sources = new HashMap<>();
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/Edge.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/Edge.java
@@ -57,7 +57,7 @@ public abstract class Edge implements SourceComponent {
             throw new Vertex.InvalidEdgeTypeException(String.format("Invalid outgoing edge %s for edge %s", this.from, this));
         }
 
-        if (!this.to.acceptsIncomingEdge(this)) {
+        if (!Vertex.acceptsIncomingEdge(this)) {
             throw new Vertex.InvalidEdgeTypeException(String.format("Invalid incoming edge %s for edge %s", this.from, this));
         }
     }

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/Vertex.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/Vertex.java
@@ -189,7 +189,7 @@ public abstract class Vertex implements SourceComponent, Hashable {
        return getUnusedOutgoingEdgeFactories().size() > 0;
     }
 
-    public boolean acceptsIncomingEdge(Edge e) {
+    public static boolean acceptsIncomingEdge(Edge e) {
         return true;
     }
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/algorithms/GraphDiff.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/algorithms/GraphDiff.java
@@ -86,7 +86,7 @@ public class GraphDiff {
             return output.toString();
         }
 
-        private String detailedDiffFor(String name, Collection removed, Collection added) {
+        private static String detailedDiffFor(String name, Collection removed, Collection added) {
             return (name + " GraphDiff: " + "\n") +
                     "--------------------------\n" +
                     Stream.concat(removed.stream().map(c -> "-" + c.toString()),

--- a/logstash-core/src/main/java/org/logstash/config/ir/imperative/Statement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/imperative/Statement.java
@@ -21,7 +21,7 @@ public abstract class Statement extends BaseSourceComponent {
 
     public abstract String toString(int indent);
 
-    public String indentPadding(int length) {
+    public static String indentPadding(int length) {
         return String.format("%" + length + "s", "");
     }
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/monitors/HotThreadsMonitor.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/monitors/HotThreadsMonitor.java
@@ -53,7 +53,7 @@ public class HotThreadsMonitor {
             map.put(THREAD_STACKTRACE, stackTraceAsString(info.getStackTrace()));
         }
 
-        private List<String> stackTraceAsString(StackTraceElement [] elements) {
+        private static List<String> stackTraceAsString(StackTraceElement[] elements) {
             return Arrays.stream(elements)
                             .map(StackTraceElement::toString)
                             .collect(Collectors.toList());
@@ -164,12 +164,12 @@ public class HotThreadsMonitor {
         return sort(new ArrayList<>(reports.values()), type);
      }
 
-    private List<ThreadReport> sort(List<ThreadReport> reports, final String type) {
+    private static List<ThreadReport> sort(List<ThreadReport> reports, final String type) {
         reports.sort(comparatorForOrderType(type));
         return reports;
     }
 
-    private Comparator<ThreadReport> comparatorForOrderType(final String type){
+    private static Comparator<ThreadReport> comparatorForOrderType(final String type){
         if ("block".equals(type)){
             return Comparator.comparingLong(ThreadReport::getBlockedTime).reversed();
         } else if ("wait".equals(type)) {

--- a/logstash-core/src/main/java/org/logstash/instrument/monitors/MemoryMonitor.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/monitors/MemoryMonitor.java
@@ -48,14 +48,14 @@ public class MemoryMonitor {
             addPeak(beanMap, bean.getPeakUsage());
         }
 
-        private void addUsage(Map<String, Object> map, MemoryUsage usage){
+        private static void addUsage(Map<String, Object> map, MemoryUsage usage){
             map.put(USAGE_INIT, usage.getInit());
             map.put(USAGE_COMMITTED, usage.getCommitted());
             map.put(USAGE_USED, usage.getUsed());
             map.put(USAGE_MAX, usage.getMax());
         }
 
-        private void addPeak(Map<String, Object> map, MemoryUsage peak){
+        private static void addPeak(Map<String, Object> map, MemoryUsage peak){
             map.put(PEAK_INIT, peak.getInit());
             map.put(PEAK_COMMITTED, peak.getCommitted());
             map.put(PEAK_USED, peak.getUsed());
@@ -63,7 +63,7 @@ public class MemoryMonitor {
         }
      }
 
-     public Report detect(Type selectType){
+     public static Report detect(Type selectType){
         List<MemoryPoolMXBean> beans = ManagementFactory.getMemoryPoolMXBeans();
         Report report = new Report();
 
@@ -73,7 +73,7 @@ public class MemoryMonitor {
         return report;
     }
 
-    private boolean filterPool(MemoryType type, Type selectType) {
+    private static boolean filterPool(MemoryType type, Type selectType) {
        return ((selectType.equals(Type.NonHeap) && type.equals(MemoryType.HEAP))
                || (selectType.equals(Type.Heap) && type.equals(MemoryType.NON_HEAP)));
     }

--- a/logstash-core/src/main/java/org/logstash/instrument/monitors/ProcessMonitor.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/monitors/ProcessMonitor.java
@@ -62,7 +62,7 @@ public class ProcessMonitor {
             return map;
         }
 
-        private short scaleLoadToPercent(double load) {
+        private static short scaleLoadToPercent(double load) {
             if (osMxBean instanceof UnixOperatingSystemMXBean) {
                 if (load >= 0) {
                     return (short) (load * 100);
@@ -75,7 +75,7 @@ public class ProcessMonitor {
         }
     }
 
-    public Report detect() {
+    public static Report detect() {
         return new Report();
     }
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/monitors/SystemMonitor.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/monitors/SystemMonitor.java
@@ -33,7 +33,7 @@ public class SystemMonitor {
         }
     }
 
-    public Report detect() {
+    public static Report detect() {
         return new Report(ManagementFactory.getOperatingSystemMXBean());
     }
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/reports/ProcessReport.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/reports/ProcessReport.java
@@ -12,6 +12,6 @@ public class ProcessReport {
      * @return a Map with the current process report
      */
     public static Map<String, Object> generate() {
-        return new ProcessMonitor().detect().toMap();
+        return ProcessMonitor.detect().toMap();
     }
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/reports/SystemReport.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/reports/SystemReport.java
@@ -15,7 +15,7 @@ import java.util.Map;
      * @return a Map with the current system report
      */
     public static Map<String, Object> generate() {
-        return new SystemMonitor().detect().toMap();
+        return SystemMonitor.detect().toMap();
     }
 }
 

--- a/logstash-core/src/test/java/org/logstash/FileLockFactoryMain.java
+++ b/logstash-core/src/test/java/org/logstash/FileLockFactoryMain.java
@@ -9,7 +9,7 @@ public class FileLockFactoryMain {
 
     public static void main(String[] args) {
         try {
-            FileLockFactory.getDefault().obtainLock(args[0], args[1]);
+            FileLockFactory.obtainLock(args[0], args[1]);
             System.out.println("File locked");
             // Sleep enough time until this process is killed.
             Thread.sleep(Long.MAX_VALUE);

--- a/logstash-core/src/test/java/org/logstash/FileLockFactoryTest.java
+++ b/logstash-core/src/test/java/org/logstash/FileLockFactoryTest.java
@@ -12,8 +12,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.channels.FileLock;
-import java.nio.file.FileSystems;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
@@ -42,7 +40,7 @@ public class FileLockFactoryTest {
 
     @Before
     public void lockFirst() throws Exception {
-        lock = FileLockFactory.getDefault().obtainLock(lockDir, LOCK_FILE);
+        lock = FileLockFactory.obtainLock(lockDir, LOCK_FILE);
         assertThat(lock.isValid(), is(equalTo(true)));
         assertThat(lock.isShared(), is(equalTo(false)));
     }
@@ -62,50 +60,50 @@ public class FileLockFactoryTest {
 
     @Test(expected = LockException.class)
     public void ObtainLockOnLocked() throws IOException {
-        FileLockFactory.getDefault().obtainLock(lockDir, LOCK_FILE);
+        FileLockFactory.obtainLock(lockDir, LOCK_FILE);
     }
 
     @Test
     public void ObtainLockOnOtherLocked() throws IOException {
-        FileLock lock2 = FileLockFactory.getDefault().obtainLock(lockDir, ".test2");
+        FileLock lock2 = FileLockFactory.obtainLock(lockDir, ".test2");
         assertThat(lock2.isValid(), is(equalTo(true)));
         assertThat(lock2.isShared(), is(equalTo(false)));
     }
 
     @Test
     public void LockReleaseLock() throws IOException {
-        FileLockFactory.getDefault().releaseLock(lock);
+        FileLockFactory.releaseLock(lock);
     }
 
     @Test
     public void LockReleaseLockObtainLock() throws IOException {
-        FileLockFactory.getDefault().releaseLock(lock);
+        FileLockFactory.releaseLock(lock);
 
-        FileLock lock2 = FileLockFactory.getDefault().obtainLock(lockDir, LOCK_FILE);
+        FileLock lock2 = FileLockFactory.obtainLock(lockDir, LOCK_FILE);
         assertThat(lock2.isValid(), is(equalTo(true)));
         assertThat(lock2.isShared(), is(equalTo(false)));
     }
 
     @Test
     public void LockReleaseLockObtainLockRelease() throws IOException {
-        FileLockFactory.getDefault().releaseLock(lock);
+        FileLockFactory.releaseLock(lock);
 
-        FileLock lock2 = FileLockFactory.getDefault().obtainLock(lockDir, LOCK_FILE);
+        FileLock lock2 = FileLockFactory.obtainLock(lockDir, LOCK_FILE);
         assertThat(lock2.isValid(), is(equalTo(true)));
         assertThat(lock2.isShared(), is(equalTo(false)));
 
-        FileLockFactory.getDefault().releaseLock(lock2);
+        FileLockFactory.releaseLock(lock2);
     }
 
     @Test(expected = LockException.class)
     public void ReleaseNullLock() throws IOException {
-        FileLockFactory.getDefault().releaseLock(null);
+        FileLockFactory.releaseLock(null);
      }
 
     @Test(expected = LockException.class)
     public void ReleaseUnobtainedLock() throws IOException {
-        FileLockFactory.getDefault().releaseLock(lock);
-        FileLockFactory.getDefault().releaseLock(lock);
+        FileLockFactory.releaseLock(lock);
+        FileLockFactory.releaseLock(lock);
     }
 
     @Test
@@ -137,7 +135,7 @@ public class FileLockFactoryTest {
 
             try {
                 // Try to obtain the lock held by the children process.
-                FileLockFactory.getDefault().obtainLock(lockDir, lockFile);
+                FileLockFactory.obtainLock(lockDir, lockFile);
                 fail("Should have threw an exception");
             } catch (LockException e) {
                 // Expected exception as the file is already locked.

--- a/logstash-core/src/test/java/org/logstash/instruments/monitors/ProcessMonitorTest.java
+++ b/logstash-core/src/test/java/org/logstash/instruments/monitors/ProcessMonitorTest.java
@@ -14,14 +14,14 @@ public class ProcessMonitorTest {
 
     @Test
     public void testReportFDStats(){
-        Map<String, Object> processStats = new ProcessMonitor().detect().toMap();
+        Map<String, Object> processStats = ProcessMonitor.detect().toMap();
         assertThat("open_file_descriptors", (Long)processStats.get("open_file_descriptors") > 0L, is(true));
         assertThat("max_file_descriptors", (Long)processStats.get("max_file_descriptors") > 0L, is(true));
     }
 
     @Test
     public void testReportCpuStats(){
-        Map<String, Object> processStats = new ProcessMonitor().detect().toMap();
+        Map<String, Object> processStats = ProcessMonitor.detect().toMap();
         assertThat("cpu", processStats.get("cpu"), instanceOf(Map.class));
         Map cpuStats = ((Map)processStats.get("cpu"));
         assertThat("cpu.process_percent", (Short)cpuStats.get("process_percent") >= 0, is(true));
@@ -31,7 +31,7 @@ public class ProcessMonitorTest {
 
     @Test
     public void testReportMemStats() {
-        Map<String, Object> processStats = new ProcessMonitor().detect().toMap();
+        Map<String, Object> processStats = ProcessMonitor.detect().toMap();
         assertThat("mem", processStats.get("mem"), instanceOf(Map.class));
         Map memStats = ((Map)processStats.get("mem"));
         assertThat("mem.total_virtual_in_bytes", (Long)memStats.get("total_virtual_in_bytes") >= 0L, is(true));

--- a/logstash-core/src/test/java/org/logstash/instruments/monitors/SystemMonitorTest.java
+++ b/logstash-core/src/test/java/org/logstash/instruments/monitors/SystemMonitorTest.java
@@ -13,7 +13,7 @@ public class SystemMonitorTest {
 
     @Test
     public void systemMonitorTest(){
-        Map<String, Object> map = new SystemMonitor().detect().toMap();
+        Map<String, Object> map = SystemMonitor.detect().toMap();
         assertThat("system.load_average is missing", (Double)map.get("system.load_average") > 0, is(true));
         assertThat("system.available_processors is missing ", ((Integer)map.get("system.available_processors")) > 0, is(true));
         assertThat("os.version is missing", map.get("os.version"), allOf(notNullValue(), instanceOf(String.class)));


### PR DESCRIPTION
We had a few spots where `static` methods were not actually `static`, fixed here :)

Reviewing is really trivial, the fact that we only have additions of the modifier but the method body changes and it still compiles proves there were no instances references in the methods, to begin with.
=> Let's save some allocations and make the JITs life one step easier. 