### PR TITLE
#7184 avoid broken format being used in test

### DIFF
--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
@@ -297,7 +297,9 @@ public class QueueTest {
         // 10 tests of random queue sizes
         for (int loop = 0; loop < 10; loop++) {
             int page_count = random.nextInt(10000) + 1;
-            int digits = new Double(Math.ceil(Math.log10(page_count))).intValue();
+
+            // String format call below needs to at least print one digit
+            final int digits = Math.max((int) Math.ceil(Math.log10(page_count)), 1);
 
             // create a queue with a single element per page
             List<Queueable> elements = new ArrayList<>();


### PR DESCRIPTION
Fixes #7184 

digits can't be `0`, otherwise this line is running into an invalid format string:

```java
                elements.add(new StringElement(String.format("%0" + digits + "d", i)));
```

Made it always at least `1` and made the cast to `int` more visible (`Double.intValue()` is just a cast , no need for that instance)