### PR TITLE
#7178 try newest Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ env:
   - INTEGRATION=false FEATURE_FLAG=persistent_queues SPEC_OPTS="--order rand --format documentation"
   - INTEGRATION=true FEATURE_FLAG=persistent_queues SPEC_OPTS="--order rand --format documentation"
 before_install:
-  - sudo apt-get remove -y docker docker-engine
-  - sudo apt-get install -y docker-ce
+  - sudo apt-get remove -y docker-engine
+  - sudo apt-get install -y docker-engine
   # Force bundler 1.12.5 because version 1.13 has issues, see https://github.com/fastlane/fastlane/issues/6065#issuecomment-246044617
   - yes | gem uninstall -q -i /home/travis/.rvm/gems/jruby-1.7.25@global bundler
   - gem install bundler -v 1.12.5 --no-rdoc --no-ri --no-document --quiet

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ env:
   - INTEGRATION=false FEATURE_FLAG=persistent_queues SPEC_OPTS="--order rand --format documentation"
   - INTEGRATION=true FEATURE_FLAG=persistent_queues SPEC_OPTS="--order rand --format documentation"
 before_install:
+  - sudo apt-get remove -y docker docker-engine
+  - sudo apt-get install -y docker-ce
   # Force bundler 1.12.5 because version 1.13 has issues, see https://github.com/fastlane/fastlane/issues/6065#issuecomment-246044617
   - yes | gem uninstall -q -i /home/travis/.rvm/gems/jruby-1.7.25@global bundler
   - gem install bundler -v 1.12.5 --no-rdoc --no-ri --no-document --quiet


### PR DESCRIPTION
for #7178, let's try running recent Docker maybe it's just a known Docker bug in the old default version, there's quite a few in the changelog (`1.12.3` is the current Travis default ) that could be applicable.