### PR TITLE
Refactor ByteBufferPageIO._persistedByteCount() #6594

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -120,6 +120,7 @@ dependencies {
     testCompile 'org.apache.logging.log4j:log4j-api:2.6.2:tests'
     testCompile 'junit:junit:4.12'
     testCompile 'net.javacrumbs.json-unit:json-unit:1.9.0'
+    testCompile 'org.elasticsearch:securemock:1.2'
     provided 'org.jruby:jruby-core:1.7.25'
 }
 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/AbstractByteBufferPageIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/AbstractByteBufferPageIO.java
@@ -27,6 +27,9 @@ public abstract class AbstractByteBufferPageIO implements PageIO {
     public static final int HEADER_SIZE = 1;     // version byte
     public static final int MIN_CAPACITY = VERSION_SIZE + SEQNUM_SIZE + LENGTH_SIZE + 1 + CHECKSUM_SIZE; // header overhead plus elements overhead to hold a single 1 byte element
 
+    // Size of: Header + Sequence Number + Length + Checksum
+    public static final int WRAPPER_SIZE = HEADER_SIZE + SEQNUM_SIZE + LENGTH_SIZE + CHECKSUM_SIZE;
+
     public static final boolean VERIFY_CHECKSUM = true;
     public static final boolean STRICT_CAPACITY = true;
 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/ByteBufferPageIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/ByteBufferPageIO.java
@@ -47,9 +47,6 @@ public class ByteBufferPageIO extends AbstractByteBufferPageIO {
 
     // below public methods only used by tests
 
-    // TODO: static method for tests - should refactor
-    public static int _persistedByteCount(int byteCount) { return SEQNUM_SIZE + LENGTH_SIZE + byteCount + CHECKSUM_SIZE; }
-
     public int getWritePosition() { return this.head; }
 
     public byte[] dump() { return this.buffer.array(); }

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/HeadPageTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/HeadPageTest.java
@@ -1,7 +1,6 @@
 package org.logstash.ackedqueue;
 
 import org.junit.Test;
-import org.logstash.ackedqueue.io.ByteBufferPageIO;
 import org.logstash.ackedqueue.io.PageIO;
 
 import java.io.IOException;
@@ -9,96 +8,92 @@ import java.io.IOException;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.logstash.ackedqueue.QueueTestHelpers.singleElementCapacityForByteBufferPageIO;
+import static org.mockito.Mockito.mock;
 
 public class HeadPageTest {
 
     @Test
     public void newHeadPage() throws IOException {
         Settings s = TestSettings.volatileQueueSettings(100);
-        Queue q = new Queue(s);
+        // Close method on HeadPage requires an instance of Queue that has already been opened.
+        Queue q = mock(Queue.class);
         PageIO pageIO = s.getPageIOFactory().build(0, 100, "dummy");
         pageIO.create();
-        HeadPage p = new HeadPage(0, q, pageIO);
-
-        assertThat(p.getPageNum(), is(equalTo(0)));
-        assertThat(p.isFullyRead(), is(true));
-        assertThat(p.isFullyAcked(), is(false));
-        assertThat(p.hasSpace(10), is(true));
-        assertThat(p.hasSpace(100), is(false));
-
-        q.close();
+        try(final HeadPage p = new HeadPage(0, q, pageIO)) {
+            assertThat(p.getPageNum(), is(equalTo(0)));
+            assertThat(p.isFullyRead(), is(true));
+            assertThat(p.isFullyAcked(), is(false));
+            assertThat(p.hasSpace(10), is(true));
+            assertThat(p.hasSpace(100), is(false));
+        }
     }
 
     @Test
     public void pageWrite() throws IOException {
         Queueable element = new StringElement("foobarbaz");
-        int singleElementCapacity = ByteBufferPageIO.HEADER_SIZE + ByteBufferPageIO._persistedByteCount(element.serialize().length);
 
-        Settings s = TestSettings.volatileQueueSettings(singleElementCapacity);
-        Queue q = new Queue(s);
-        q.open();
-        HeadPage p = q.headPage;
+        Settings s = TestSettings.volatileQueueSettings(singleElementCapacityForByteBufferPageIO(element));
+        try(Queue q = new Queue(s)) {
+            q.open();
+            HeadPage p = q.headPage;
 
-        assertThat(p.hasSpace(element.serialize().length), is(true));
-        p.write(element.serialize(), 0, 1);
+            assertThat(p.hasSpace(element.serialize().length), is(true));
+            p.write(element.serialize(), 0, 1);
 
-        assertThat(p.hasSpace(element.serialize().length), is(false));
-        assertThat(p.isFullyRead(), is(false));
-        assertThat(p.isFullyAcked(), is(false));
-
-        q.close();
+            assertThat(p.hasSpace(element.serialize().length), is(false));
+            assertThat(p.isFullyRead(), is(false));
+            assertThat(p.isFullyAcked(), is(false));
+        }
     }
 
     @Test
     public void pageWriteAndReadSingle() throws IOException {
         long seqNum = 1L;
         Queueable element = new StringElement("foobarbaz");
-        int singleElementCapacity = ByteBufferPageIO.HEADER_SIZE + ByteBufferPageIO._persistedByteCount(element.serialize().length);
+        int singleElementCapacity = singleElementCapacityForByteBufferPageIO(element);
 
         Settings s = TestSettings.volatileQueueSettings(singleElementCapacity);
-        Queue q = new Queue(s);
-        q.open();
-        HeadPage p = q.headPage;
+        try(Queue q = new Queue(s)) {
+            q.open();
+            HeadPage p = q.headPage;
 
-        assertThat(p.hasSpace(element.serialize().length), is(true));
-        p.write(element.serialize(), seqNum, 1);
+            assertThat(p.hasSpace(element.serialize().length), is(true));
+            p.write(element.serialize(), seqNum, 1);
 
-        Batch b = p.readBatch(1);
+            Batch b = p.readBatch(1);
 
-        assertThat(b.getElements().size(), is(equalTo(1)));
-        assertThat(b.getElements().get(0).toString(), is(equalTo(element.toString())));
+            assertThat(b.getElements().size(), is(equalTo(1)));
+            assertThat(b.getElements().get(0).toString(), is(equalTo(element.toString())));
 
-        assertThat(p.hasSpace(element.serialize().length), is(false));
-        assertThat(p.isFullyRead(), is(true));
-        assertThat(p.isFullyAcked(), is(false));
-
-        q.close();
+            assertThat(p.hasSpace(element.serialize().length), is(false));
+            assertThat(p.isFullyRead(), is(true));
+            assertThat(p.isFullyAcked(), is(false));
+        }
     }
 
     @Test
     public void pageWriteAndReadMulti() throws IOException {
         long seqNum = 1L;
         Queueable element = new StringElement("foobarbaz");
-        int singleElementCapacity = ByteBufferPageIO.HEADER_SIZE + ByteBufferPageIO._persistedByteCount(element.serialize().length);
 
-        Settings s = TestSettings.volatileQueueSettings(singleElementCapacity);
-        Queue q = new Queue(s);
-        q.open();
-        HeadPage p = q.headPage;
+        Settings s = TestSettings.volatileQueueSettings(singleElementCapacityForByteBufferPageIO(element));
+        try(Queue q = new Queue(s)) {
+            q.open();
+            HeadPage p = q.headPage;
 
-        assertThat(p.hasSpace(element.serialize().length), is(true));
-        p.write(element.serialize(), seqNum, 1);
+            assertThat(p.hasSpace(element.serialize().length), is(true));
+            p.write(element.serialize(), seqNum, 1);
 
-        Batch b = p.readBatch(10);
+            Batch b = p.readBatch(10);
 
-        assertThat(b.getElements().size(), is(equalTo(1)));
-        assertThat(b.getElements().get(0).toString(), is(equalTo(element.toString())));
+            assertThat(b.getElements().size(), is(equalTo(1)));
+            assertThat(b.getElements().get(0).toString(), is(equalTo(element.toString())));
 
-        assertThat(p.hasSpace(element.serialize().length), is(false));
-        assertThat(p.isFullyRead(), is(true));
-        assertThat(p.isFullyAcked(), is(false));
-
-        q.close();
+            assertThat(p.hasSpace(element.serialize().length), is(false));
+            assertThat(p.isFullyRead(), is(true));
+            assertThat(p.isFullyAcked(), is(false));
+        }
     }
 
     // disabled test until we figure what to do in this condition
@@ -107,7 +102,7 @@ public class HeadPageTest {
 //        URL url = FileCheckpointIOTest.class.getResource("checkpoint.head");
 //        String dirPath = Paths.get(url.toURI()).getParent().toString();
 //        Queueable element = new StringElement("foobarbaz");
-//        int singleElementCapacity = ByteBufferPageIO.HEADER_SIZE + ByteBufferPageIO._persistedByteCount(element.serialize().length);
+//        int singleElementCapacity = singleElementCapacityForByteBufferPageIO(element);
 //        Settings s = TestSettings.persistedQueueSettings(singleElementCapacity, dirPath);
 //        TestQueue q = new TestQueue(s);
 //        try {

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTestHelpers.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTestHelpers.java
@@ -1,0 +1,27 @@
+package org.logstash.ackedqueue;
+
+import org.logstash.ackedqueue.io.ByteBufferPageIO;
+
+import java.io.IOException;
+
+/**
+ * Class containing common methods to help DRY up acked queue tests.
+ */
+public class QueueTestHelpers {
+
+    /**
+     * Returns the minimum capacity required for {@link ByteBufferPageIO}
+     * @return int - minimum capacity required
+     */
+    public static final int BYTE_BUF_PAGEIO_MIN_CAPACITY = ByteBufferPageIO.WRAPPER_SIZE;
+
+    /**
+     * Returns the {@link ByteBufferPageIO} capacity required for the supplied element
+     * @param element
+     * @return int - capacity required for the supplied element
+     * @throws IOException Throws if a serialization error occurs
+     */
+    public static int singleElementCapacityForByteBufferPageIO(final Queueable element) throws IOException {
+        return ByteBufferPageIO.WRAPPER_SIZE + element.serialize().length;
+    }
+}


### PR DESCRIPTION
Remove static method in ByteBufferPageIO, replacing with static test helper method to move
the required functionality to a single place.

Also, cleans up HeadPageTest, using try... with resources in place of explicit, and
potentially missed, close() calls.

Resolves #6594