### PR TITLE
MINOR: Cleanup imports on compiler.rb and pipeline.rb

### DIFF
--- a/logstash-core/lib/logstash/compiler.rb
+++ b/logstash-core/lib/logstash/compiler.rb
@@ -2,8 +2,7 @@ require 'logstash/util/loggable'
 require 'logstash/compiler/lscl/lscl_grammar'
 
 java_import org.logstash.config.ir.PipelineIR
-java_import org.logstash.config.ir.graph.Graph;
-java_import org.logstash.config.ir.graph.PluginVertex;
+java_import org.logstash.config.ir.graph.Graph
 
 module LogStash; class Compiler
   include ::LogStash::Util::Loggable
@@ -13,8 +12,8 @@ module LogStash; class Compiler
       self.compile_graph(swm)
     end
 
-    input_graph = org.logstash.config.ir.graph.Graph.combine(*graph_sections.map {|s| s[:input] }).graph
-    output_graph = org.logstash.config.ir.graph.Graph.combine(*graph_sections.map {|s| s[:output] }).graph
+    input_graph = Graph.combine(*graph_sections.map {|s| s[:input] }).graph
+    output_graph = Graph.combine(*graph_sections.map {|s| s[:output] }).graph
 
     filter_graph = graph_sections.reduce(nil) do |acc, s| 
       filter_section = s[:filter]
@@ -28,7 +27,7 @@ module LogStash; class Compiler
 
     original_source = sources_with_metadata.map(&:text).join("\n")
 
-    org.logstash.config.ir.PipelineIR.new(input_graph, filter_graph, output_graph, original_source)
+    PipelineIR.new(input_graph, filter_graph, output_graph, original_source)
   end
 
   def self.compile_ast(source_with_metadata)

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -26,6 +26,7 @@ require "logstash/compiler"
 require "logstash/execution_context"
 
 java_import org.logstash.common.DeadLetterQueueFactory
+java_import org.logstash.common.SourceWithMetadata
 java_import org.logstash.common.io.DeadLetterQueueWriter
 
 module LogStash; class BasePipeline
@@ -85,7 +86,7 @@ module LogStash; class BasePipeline
   end
 
   def compile_lir
-    source_with_metadata = org.logstash.common.SourceWithMetadata.new("str", "pipeline", self.config_str)
+    source_with_metadata = SourceWithMetadata.new("str", "pipeline", self.config_str)
     LogStash::Compiler.compile_sources(source_with_metadata)
   end
 


### PR DESCRIPTION
Should keep the `java_import`s clean to have an easy picture of the RB/Java boundary imo :)

* Removed package name from imported Java classes
* Added missing Java imports
* Removed unused Java import