### PR TITLE
Performance: Lock More Efficiently

### DIFF
--- a/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
@@ -57,7 +57,7 @@ module LogStash; module Util
 
       def initialize(queue, batch_size = 125, wait_for = 250)
         @queue = queue
-        @mutex = java.util.concurrent.locks.ReentrantLock.new
+        @mutex = Mutex.new
         # Note that @inflight_batches as a central mechanism for tracking inflight
         # batches will fail if we have multiple read clients in the pipeline.
         @inflight_batches = {}


### PR DESCRIPTION
Did some profiling on for various thread counts `x` and figured that the `Mutex` in `wrapped_synchronous_queue.rb` is a significant contributor to the overall runtime.

```sh
bin/logstash -e 'input { generator { threads => x }  } output { stdout { } }'
```

=> Saw that the `Mutex.synchronize` call takes a long time.
=> Moved to standard Java lock approach (retaining the `Mutex` which is then just a Jitted `ReentrantLock`) usage and saw improvement (though it becomes less relevant with larger `x`)

* For `x == 1` I got about a 6% speedup (measured using events/ms via the metrics endpoint).
* `x == 4` still comes with a 3% gain.

=> I think this is a valid improvement, not only for the direct gain (which is basically just due to the reduction in function calls made I think), but also for moving to a more "Java native" locking approach that is easier to reason about. I don't think the few extra lines really hurt here, given that this is on the way critical path.

**EDIT:**
~~looks like this breaks some IT ... don't merge :) Will look into this soon.~~
Look like this is not a problem with this change, but rather the ES output ...

**that said ... locking in the single threaded case comes with one order of magnitude of slowdown here for the single threaded case!**