### PR TITLE
Add missing dependency on manticore

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -54,6 +54,7 @@ Gem::Specification.new do |gem|
   # which does not have this problem.
   gem.add_runtime_dependency "ruby-maven", "~> 3.3.9"
   gem.add_runtime_dependency "elasticsearch", "~> 5.0", ">= 5.0.4" # Ruby client for ES (Apache 2.0 license)
+  gem.add_runtime_dependency "manticore", '>= 0.5.4', '< 1.0.0'
 
   eval(File.read(File.expand_path("../gemspec_jars.rb", __FILE__)))
 end


### PR DESCRIPTION
With the merge of https://github.com/elastic/logstash/pull/7284, Logstash
now depends on elasticsearch client to setup modules.

To be usable under jruby we also need to depends on manticore, this
problem is only show when try to use the logstash-core gem directly and
not in the Logstash project since it bundle the elasticsearch output
with the manticore dependency.