### PR TITLE
Bug Fix: Fix ability to change log level via the API

### DIFF
--- a/qa/integration/services/monitoring_api.rb
+++ b/qa/integration/services/monitoring_api.rb
@@ -38,8 +38,8 @@ class MonitoringAPI
     JSON.parse(resp)
   end
 
-  def logging_put(json_body)
-    resp = Manticore.put("http://localhost:9600/_node/logging", {headers: {"Content-Type" => "application/json"}, body: json_body }).body
+  def logging_put(body)
+    resp = Manticore.put("http://localhost:9600/_node/logging", {headers: {"Content-Type" => "application/json"}, body: body.to_json }).body
     JSON.parse(resp)
   end
 end

--- a/qa/integration/services/monitoring_api.rb
+++ b/qa/integration/services/monitoring_api.rb
@@ -33,4 +33,13 @@ class MonitoringAPI
     JSON.parse(resp)
   end
 
+  def logging_get
+    resp = Manticore.get("http://localhost:9600/_node/logging").body
+    JSON.parse(resp)
+  end
+
+  def logging_put(json_body)
+    resp = Manticore.put("http://localhost:9600/_node/logging", {headers: {"Content-Type" => "application/json"}, body: json_body }).body
+    JSON.parse(resp)
+  end
 end

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -92,20 +92,20 @@ describe "Test Monitoring API" do
       logging_get_assert logstash_service, "INFO", "TRACE"
 
       #root logger - does not apply to logger.slowlog
-      logging_put_assert logstash_service.monitoring_api.logging_put({"logger." => "WARN"}.to_json)
+      logging_put_assert logstash_service.monitoring_api.logging_put({"logger." => "WARN"})
       logging_get_assert logstash_service, "WARN", "TRACE"
-      logging_put_assert logstash_service.monitoring_api.logging_put({"logger." => "INFO"}.to_json)
+      logging_put_assert logstash_service.monitoring_api.logging_put({"logger." => "INFO"})
       logging_get_assert logstash_service, "INFO", "TRACE"
 
       #package logger 
-      logging_put_assert logstash_service.monitoring_api.logging_put({"logger.logstash.agent" => "DEBUG"}.to_json)
+      logging_put_assert logstash_service.monitoring_api.logging_put({"logger.logstash.agent" => "DEBUG"})
       expect(logstash_service.monitoring_api.logging_get["loggers"]["logstash.agent"]).to eq ("DEBUG")
-      logging_put_assert logstash_service.monitoring_api.logging_put({"logger.logstash.agent" => "INFO"}.to_json)
+      logging_put_assert logstash_service.monitoring_api.logging_put({"logger.logstash.agent" => "INFO"})
       logging_get_assert logstash_service, "INFO", "TRACE"
 
       #parent package loggers
-      logging_put_assert logstash_service.monitoring_api.logging_put({"logger.logstash" => "ERROR"}.to_json)
-      logging_put_assert logstash_service.monitoring_api.logging_put({"logger.slowlog" => "ERROR"}.to_json)
+      logging_put_assert logstash_service.monitoring_api.logging_put({"logger.logstash" => "ERROR"})
+      logging_put_assert logstash_service.monitoring_api.logging_put({"logger.slowlog" => "ERROR"})
 
       result = logstash_service.monitoring_api.logging_get
       result["loggers"].each do | k, v |


### PR DESCRIPTION
The ability to change the log level as described at https://www.elastic.co/guide/en/logstash/current/logging.html#_logging_apis appears to no longer work. The root cause of this issue is that log4j2 context we initialize is different from the log4j2 context that we are setting via the API. The fix here is to mirror the functionality of org.apache.logging.log4j.core.config.Configurator.setLevel Java method, but instead use the logging_context initialized in our code via JRuby.

Fixes #7277