### PR TITLE
Add Metrics for dead letter queue

### DIFF
--- a/logstash-core/lib/logstash/api/commands/node.rb
+++ b/logstash-core/lib/logstash/api/commands/node.rb
@@ -27,8 +27,8 @@ module LogStash
         def pipeline(pipeline_id)
           extract_metrics(
             [:stats, :pipelines, pipeline_id.to_sym, :config],
-            :workers, :batch_size, :batch_delay, :config_reload_automatic, :config_reload_interval
-          )
+            :workers, :batch_size, :batch_delay, :config_reload_automatic, :config_reload_interval, :dead_letter_queue_enabled, :dead_letter_queue_path
+          ).reject{|_, v|v.nil?}
         rescue
           {}
         end

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -120,8 +120,8 @@ module LogStash
               },
               :reloads => stats[:reloads],
               :queue => stats[:queue]
-            }
-          end
+            }.merge(stats[:dlq] ? {:dead_letter_queue => stats[:dlq]} : {})
+            end
         end # module PluginsStats
       end
     end

--- a/logstash-core/lib/logstash/instrument/periodic_poller/dlq.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/dlq.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+require 'logstash/instrument/periodic_poller/base'
+
+module LogStash module Instrument module PeriodicPoller
+  class DeadLetterQueue < Base
+    def initialize(metric, agent, options = {})
+      super(metric, options)
+      @metric = metric
+      @agent = agent
+    end
+
+    def collect
+      _, pipeline = @agent.with_running_pipelines { |pipelines| pipelines.first }
+      unless pipeline.nil?
+        pipeline.collect_dlq_stats
+      end
+    end
+  end
+end end end

--- a/logstash-core/lib/logstash/instrument/periodic_pollers.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_pollers.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require "logstash/instrument/periodic_poller/dlq"
 require "logstash/instrument/periodic_poller/os"
 require "logstash/instrument/periodic_poller/jvm"
 require "logstash/instrument/periodic_poller/pq"
@@ -14,7 +15,8 @@ module LogStash module Instrument
       @metric = metric
       @periodic_pollers = [PeriodicPoller::Os.new(metric),
                            PeriodicPoller::JVM.new(metric),
-                           PeriodicPoller::PersistentQueue.new(metric, queue_type, pipelines)]
+                           PeriodicPoller::PersistentQueue.new(metric, queue_type, pipelines),
+                           PeriodicPoller::DeadLetterQueue.new(metric, pipelines)]
     end
 
     def start

--- a/logstash-core/spec/logstash/api/modules/node_spec.rb
+++ b/logstash-core/spec/logstash/api/modules/node_spec.rb
@@ -115,7 +115,8 @@ describe LogStash::Api::Modules::Node do
             "batch_size" => Numeric,
             "batch_delay" => Numeric,
             "config_reload_automatic" => Boolean,
-            "config_reload_interval" => Numeric
+            "config_reload_interval" => Numeric,
+            "dead_letter_queue_enabled" => Boolean
           }
         },
         "os" => {

--- a/logstash-core/spec/logstash/instrument/periodic_poller/dlq_spec.rb
+++ b/logstash-core/spec/logstash/instrument/periodic_poller/dlq_spec.rb
@@ -1,0 +1,17 @@
+# encoding: utf-8
+require "spec_helper"
+require "logstash/instrument/periodic_poller/dlq"
+require "logstash/instrument/collector"
+
+describe LogStash::Instrument::PeriodicPoller::DeadLetterQueue do
+  subject { LogStash::Instrument::PeriodicPoller::DeadLetterQueue }
+
+  let(:metric) { LogStash::Instrument::Metric.new(LogStash::Instrument::Collector.new) }
+  let(:agent) { double("agent")}
+  let(:options) { {} }
+  subject(:dlq) { described_class.new(metric, agent, options) }
+
+  it "should initialize cleanly" do
+    expect { dlq }.not_to raise_error
+  end
+end

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -104,12 +104,19 @@ describe LogStash::Pipeline do
   let(:worker_thread_count)     { 5 }
   let(:safe_thread_count)       { 1 }
   let(:override_thread_count)   { 42 }
+  let(:dead_letter_queue_enabled) { false }
+  let(:dead_letter_queue_path) { }
   let(:pipeline_settings_obj) { LogStash::SETTINGS }
   let(:pipeline_settings) { {} }
 
   before :each do
     pipeline_workers_setting = LogStash::SETTINGS.get_setting("pipeline.workers")
     allow(pipeline_workers_setting).to receive(:default).and_return(worker_thread_count)
+    dlq_enabled_setting = LogStash::SETTINGS.get_setting("dead_letter_queue.enable")
+    allow(dlq_enabled_setting).to receive(:value).and_return(dead_letter_queue_enabled)
+    dlq_path_setting = LogStash::SETTINGS.get_setting("path.dead_letter_queue")
+    allow(dlq_path_setting).to receive(:value).and_return(dead_letter_queue_path)
+
     pipeline_settings.each {|k, v| pipeline_settings_obj.set(k, v) }
   end
 
@@ -838,6 +845,33 @@ describe LogStash::Pipeline do
         [multiline_id, multiline_id_other].map(&:to_sym).each do |id|
           plugin_name = id.to_sym
           expect(collected_metric[:stats][:pipelines][:main][:plugins][:filters][plugin_name][:name].value).to eq(LogStash::Filters::Multiline.config_name)
+        end
+      end
+
+      context 'when dlq is disabled' do
+        let (:collect_stats) { subject.collect_dlq_stats}
+        let (:collected_stats) { collected_metric[:stats][:pipelines][:main][:dlq]}
+        let (:available_stats) {[:path, :queue_size_in_bytes]}
+
+        it 'should show not show any dlq stats' do
+          collect_stats
+          expect(collected_stats).to be_nil
+        end
+
+      end
+
+      context 'when dlq is enabled' do
+        let (:dead_letter_queue_enabled) { true }
+        let (:dead_letter_queue_path) { Stud::Temporary.directory }
+        let (:pipeline_dlq_path) { "#{dead_letter_queue_path}/#{pipeline_id}"}
+
+        let (:collect_stats) { subject.collect_dlq_stats }
+        let (:collected_stats) { collected_metric[:stats][:pipelines][:main][:dlq]}
+
+        it 'should show dlq stats' do
+          collect_stats
+          # A newly created dead letter queue with no entries will have a size of 1 (the version 'header')
+          expect(collected_stats[:queue_size_in_bytes].value).to eq(1)
         end
       end
     end


### PR DESCRIPTION
Add an initial set of metrics for the dead letter queue.

Metrics are supplied under the pipeline in the following format:

"dead_letter_queue": {
        "path": ...,
        "enabled": ...,
        "current_queue_size_in_bytes": ...,
        "segment_count": ...,
        "max_segment_size_in_bytes": ...
      }

Note that if the dead letter queue is not enabled, then only the
enabled property will be displayed, with a value of false.

Metrics are populated via a PeriodicPoller

Resolves #7287 