### PR TITLE
#7317 Queue RW Benchmark

### DIFF
--- a/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/QueueWriteBenchmark.java
+++ b/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/QueueWriteBenchmark.java
@@ -1,0 +1,95 @@
+package org.logstash.benchmark;
+
+import com.google.common.io.Files;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.logstash.Event;
+import org.logstash.Timestamp;
+import org.logstash.ackedqueue.Queue;
+import org.logstash.ackedqueue.Settings;
+import org.logstash.ackedqueue.SettingsImpl;
+import org.logstash.ackedqueue.io.FileCheckpointIO;
+import org.logstash.ackedqueue.io.MmapPageIO;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@Warmup(iterations = 3, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+public class QueueWriteBenchmark {
+
+    private static final int EVENTS_PER_INVOCATION = 500_000;
+
+    private static final Event EVENT = new Event();
+
+    private Queue queue;
+
+    private String path;
+
+    @Setup
+    public void setUp() throws IOException {
+        final Settings settings = settings();
+        EVENT.setField("Foo", "Bar");
+        EVENT.setField("Foo1", "Bar1");
+        EVENT.setField("Foo2", "Bar2");
+        EVENT.setField("Foo3", "Bar3");
+        EVENT.setField("Foo4", "Bar4");
+        path = settings.getDirPath();
+        queue = new Queue(settings);
+        queue.open();
+    }
+
+    @TearDown
+    public void tearDown() throws IOException {
+        queue.close();
+        FileUtils.deleteDirectory(new File(path));
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(EVENTS_PER_INVOCATION)
+    public final void pushToPersistedQueue() throws Exception {
+        for (int i = 0; i < EVENTS_PER_INVOCATION; ++i) {
+            final Event evnt = EVENT.clone();
+            evnt.setTimestamp(Timestamp.now());
+            queue.write(evnt);
+        }
+    }
+
+    public static void main(final String... args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+            .include(QueueWriteBenchmark.class.getSimpleName())
+            .forks(2)
+            .build();
+        new Runner(opt).run();
+    }
+
+    private static Settings settings() {
+        return SettingsImpl.fileSettingsBuilder(Files.createTempDir().getPath())
+            .capacity(256 * 1024 * 1024)
+            .queueMaxBytes(Long.MAX_VALUE)
+            .elementIOFactory(MmapPageIO::new)
+            .checkpointMaxWrites(1024)
+            .checkpointMaxAcks(1024)
+            .checkpointIOFactory(FileCheckpointIO::new)
+            .elementClass(Event.class).build();
+    }
+}


### PR DESCRIPTION
Trivial RW benchmark for #7317, running one producer and one consumer.


Results are:

```sh
# Run progress: 0.00% complete, ETA 00:00:01
# Fork: 1 of 1
# Warmup Iteration   1: ERROR StatusLogger No log4j2 configuration file found. Using default configuration: logging only errors to the console.
107.895 ops/ms
# Warmup Iteration   2: 58.913 ops/ms
# Warmup Iteration   3: 48.597 ops/ms
Iteration   1: 44.174 ops/ms
Iteration   2: 75.928 ops/ms
Iteration   3: 77.686 ops/ms
Iteration   4: 59.150 ops/ms
Iteration   5: 49.295 ops/ms
Iteration   6: 67.341 ops/ms
Iteration   7: 78.900 ops/ms
Iteration   8: 59.567 ops/ms
Iteration   9: 49.540 ops/ms
Iteration  10: 52.455 ops/ms


Result "org.logstash.benchmark.QueueRWBenchmark.readFromPersistedQueue":
  61.404 ±(99.9%) 19.454 ops/ms [Average]
  (min, avg, max) = (44.174, 61.404, 78.900), stdev = 12.868
  CI (99.9%): [41.949, 80.858] (assumes normal distribution)


# Run complete. Total time: 00:01:49

Benchmark                                 Mode  Cnt   Score    Error   Units
QueueRWBenchmark.readFromPersistedQueue  thrpt   10  61.404 ± 19.454  ops/ms

Process finished with exit code 0
```

Which is within the error of measurement of what I get for the write throughput on my box.

```sh
Benchmark                                  Mode  Cnt   Score    Error   Units
QueueRWBenchmark.readFromPersistedQueue   thrpt   10  53.316 ± 17.471  ops/ms
QueueWriteBenchmark.pushToPersistedQueue  thrpt   10  65.128 ± 27.014  ops/ms
```