### PR TITLE
 #7178 disable docker legacy registry use on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ env:
 before_install:
   - sudo apt-get remove -y docker-engine
   - sudo apt-get install -y docker-engine
+  - sudo service docker stop
+  - sudo dockerd --disable-legacy-registry &>/dev/null &
   # Force bundler 1.12.5 because version 1.13 has issues, see https://github.com/fastlane/fastlane/issues/6065#issuecomment-246044617
   - yes | gem uninstall -q -i /home/travis/.rvm/gems/jruby-1.7.25@global bundler
   - gem install bundler -v 1.12.5 --no-rdoc --no-ri --no-document --quiet


### PR DESCRIPTION
closes #7178 

The problem is Docker randomly trying to use the legacy `V1` registry API which throws an error.
I used the workaround proposed in https://github.com/moby/moby/issues/15759#issuecomment-222906432 here.

Documented in https://github.com/moby/moby/issues/15759 and https://github.com/swipely/docker-api/issues/455