### PR TITLE
MINOR: Remove dead and duplicate code from Event and EventTest

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -96,24 +96,8 @@ public class Event implements Cloneable, Serializable, Queueable {
         return this.metadata;
     }
 
-    public void setData(Map<String, Object> data) {
-        this.data = ConvertedMap.newFromMap(data);
-    }
-
-    public Accessors getAccessors() {
+    private Accessors getAccessors() {
         return this.accessors;
-    }
-
-    public Accessors getMetadataAccessors() {
-        return this.metadata_accessors;
-    }
-
-    public void setAccessors(Accessors accessors) {
-        this.accessors = accessors;
-    }
-
-    public void setMetadataAccessors(Accessors accessors) {
-        this.metadata_accessors = accessors;
     }
 
     public void cancel() {
@@ -180,20 +164,11 @@ public class Event implements Cloneable, Serializable, Queueable {
         }
     }
 
-    public byte[] toBinary() throws IOException {
-        return toBinaryFromMap(toSerializableMap());
-    }
-
     private Map<String, Map<String, Object>> toSerializableMap() {
         HashMap<String, Map<String, Object>> hashMap = new HashMap<>();
         hashMap.put(DATA_MAP_KEY, this.data);
         hashMap.put(META_MAP_KEY, this.metadata);
         return hashMap;
-    }
-
-    private static byte[] toBinaryFromMap(Map<String, Map<String, Object>> representation)
-        throws IOException {
-        return CBOR_MAPPER.writeValueAsBytes(representation);
     }
 
     private static Event fromSerializableMap(Map<String, Map<String, Object>> representation) throws IOException{
@@ -206,13 +181,6 @@ public class Event implements Cloneable, Serializable, Queueable {
         Map<String, Object> dataMap = representation.get(DATA_MAP_KEY);
         dataMap.put(METADATA, representation.get(META_MAP_KEY));
         return new Event(dataMap);
-    }
-
-    public static Event fromBinary(byte[] source) throws IOException {
-        if (source == null || source.length == 0) {
-            return new Event();
-        }
-        return fromSerializableMap(fromBinaryToMap(source));
     }
 
     private static Map<String, Map<String, Object>> fromBinaryToMap(byte[] source) throws IOException {
@@ -290,14 +258,9 @@ public class Event implements Cloneable, Serializable, Queueable {
         return StringInterpolation.getInstance().evaluate(this, s);
     }
 
-    public Event clone()
-            throws CloneNotSupportedException
-    {
-//        Event clone = (Event)super.clone();
-//        clone.setAccessors(new Accessors(clone.getData()));
-
-        Event clone = new Event(Cloner.deep(getData()));
-        return clone;
+    @Override
+    public Event clone() throws CloneNotSupportedException {
+        return new Event(Cloner.deep(getData()));
     }
 
     public String toString() {
@@ -378,20 +341,15 @@ public class Event implements Cloneable, Serializable, Queueable {
         this.setField("tags", tags);
     }
 
+    @Override
     public byte[] serialize() throws IOException {
-        Map<String, Map<String, Object>> dataMap = toSerializableMap();
-        return toBinaryFromMap(dataMap);
-    }
-
-    public byte[] serializeWithoutSeqNum() throws IOException {
-        return toBinary();
+        return CBOR_MAPPER.writeValueAsBytes(toSerializableMap());
     }
 
     public static Event deserialize(byte[] data) throws IOException {
         if (data == null || data.length == 0) {
             return new Event();
         }
-        Map<String, Map<String, Object>> dataMap = fromBinaryToMap(data);
-        return fromSerializableMap(dataMap);
+        return fromSerializableMap(fromBinaryToMap(data));
     }
 }

--- a/logstash-core/src/test/java/org/logstash/EventTest.java
+++ b/logstash-core/src/test/java/org/logstash/EventTest.java
@@ -13,26 +13,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 public class EventTest {
-    @Test
-    public void queueableInterfaceWithoutSeqNumRoundTrip() throws Exception {
-        Event e = new Event();
-        e.setField("foo", 42L);
-        e.setField("bar", 42);
-        HashMap inner = new HashMap(2);
-        inner.put("innerFoo", 42L);
-        inner.put("innerQuux", 42.42);
-        e.setField("baz", inner);
-        e.setField("[@metadata][foo]", 42L);
-        byte[] binary = e.serializeWithoutSeqNum();
-        Event er = Event.deserialize(binary);
-        assertEquals(42L, er.getField("foo"));
-        assertEquals(42, er.getField("bar"));
-        assertEquals(42L, er.getField("[baz][innerFoo]"));
-        assertEquals(42.42, er.getField("[baz][innerQuux]"));
-        assertEquals(42L, er.getField("[@metadata][foo]"));
-
-        assertEquals(e.getTimestamp().toIso8601(), er.getTimestamp().toIso8601());
-    }
 
     @Test
     public void queueableInterfaceRoundTrip() throws Exception {
@@ -65,8 +45,7 @@ public class EventTest {
         inner.put("innerQuux", 42.42);
         e.setField("baz", inner);
         e.setField("[@metadata][foo]", 42L);
-        byte[] binary = e.toBinary();
-        Event er = Event.fromBinary(binary);
+        Event er = Event.deserialize(e.serialize());
         assertEquals(42L, er.getField("foo"));
         assertEquals(42, er.getField("bar"));
         assertEquals(42L, er.getField("[baz][innerFoo]"));


### PR DESCRIPTION
Just some minor housekeeping :) Found these when looking over how to best approach #7039 

* Remove unused methods (all of them had no reference in the code when grepping except for in some old comment from 2015 -> removed that comment too)
* Removed duplicate methods, `toBinary`  `serialize` and `serializeWithoutSeqNum` were exactly the same!
   * removed test `queueableInterfaceWithoutSeqNumRoundTrip` since it was logically 100% equivalent to `queueableInterfaceRoundTrip` because of the above