### PR TITLE
Bump concurrent gem dep to allow for more recent version

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "clamp", "~> 0.6.5" #(MIT license) for command line args/flags
   gem.add_runtime_dependency "filesize", "0.0.4" #(MIT license) for :bytes config validator
   gem.add_runtime_dependency "gems", "~> 0.8.3"  #(MIT license)
-  gem.add_runtime_dependency "concurrent-ruby", "1.0.0"
+  gem.add_runtime_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.5"
 
   # Later versions are ruby 2.0 only. We should remove the rack dep once we support 9k
   gem.add_runtime_dependency "rack", '1.6.6'


### PR DESCRIPTION
The old version (1.0.0) had a broken version of Concurrent::Timer that
did not work on all machines for reasons that are still unclear, but may
be related to the Java version