### PR TITLE
MINOR: Fix static logic not declared static

### DIFF
--- a/logstash-core/lib/logstash/string_interpolation.rb
+++ b/logstash-core/lib/logstash/string_interpolation.rb
@@ -6,12 +6,12 @@ module LogStash
 
     # clear the global compiled templates cache
     def clear_cache
-      Java::OrgLogstash::StringInterpolation.get_instance.clear_cache;
+      Java::OrgLogstash::StringInterpolation.clear_cache;
     end
 
     # @return [Fixnum] the compiled templates cache size
     def cache_size
-      Java::OrgLogstash::StringInterpolation.get_instance.cache_size;
+      Java::OrgLogstash::StringInterpolation.cache_size;
     end
   end
 end

--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -255,7 +255,7 @@ public class Event implements Cloneable, Serializable, Queueable {
     }
 
     public String sprintf(String s) throws IOException {
-        return StringInterpolation.getInstance().evaluate(this, s);
+        return StringInterpolation.evaluate(this, s);
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/Timestamp.java
+++ b/logstash-core/src/main/java/org/logstash/Timestamp.java
@@ -64,7 +64,7 @@ public class Timestamp implements Cloneable, Comparable, Queueable {
     }
 
     public String toIso8601() {
-        return this.iso8601Formatter.print(this.time);
+        return iso8601Formatter.print(this.time);
     }
 
     public String toString() {

--- a/logstash-core/src/test/java/org/logstash/StringInterpolationTest.java
+++ b/logstash-core/src/test/java/org/logstash/StringInterpolationTest.java
@@ -18,87 +18,70 @@ public class StringInterpolationTest {
     public void testCompletelyStaticTemplate() throws IOException {
         Event event = getTestEvent();
         String path = "/full/path/awesome";
-        StringInterpolation si = StringInterpolation.getInstance();
-
-        assertEquals(path, si.evaluate(event, path));
+        assertEquals(path, StringInterpolation.evaluate(event, path));
     }
 
     @Test
     public void testOneLevelField() throws IOException {
         Event event = getTestEvent();
         String path = "/full/%{bar}/awesome";
-        StringInterpolation si = StringInterpolation.getInstance();
-
-        assertEquals("/full/foo/awesome", si.evaluate(event, path));
+        assertEquals("/full/foo/awesome", StringInterpolation.evaluate(event, path));
     }
 
     @Test
     public void testMultipleLevelField() throws IOException {
         Event event = getTestEvent();
         String path = "/full/%{bar}/%{awesome}";
-        StringInterpolation si = StringInterpolation.getInstance();
-
-        assertEquals("/full/foo/logstash", si.evaluate(event, path));
+        assertEquals("/full/foo/logstash", StringInterpolation.evaluate(event, path));
     }
 
     @Test
     public void testMissingKey() throws IOException {
         Event event = getTestEvent();
         String path = "/full/%{do-not-exist}";
-        StringInterpolation si = StringInterpolation.getInstance();
-
-        assertEquals("/full/%{do-not-exist}", si.evaluate(event, path));
+        assertEquals("/full/%{do-not-exist}", StringInterpolation.evaluate(event, path));
     }
 
     @Test
     public void testDateFormatter() throws IOException {
         Event event = getTestEvent();
         String path = "/full/%{+YYYY}";
-        StringInterpolation si = StringInterpolation.getInstance();
-
-        assertEquals("/full/2015", si.evaluate(event, path));
+        assertEquals("/full/2015", StringInterpolation.evaluate(event, path));
     }
 
     @Test
     public void TestMixDateAndFields() throws IOException {
         Event event = getTestEvent();
         String path = "/full/%{+YYYY}/weeee/%{bar}";
-        StringInterpolation si = StringInterpolation.getInstance();
-
-        assertEquals("/full/2015/weeee/foo", si.evaluate(event, path));
+        assertEquals("/full/2015/weeee/foo", StringInterpolation.evaluate(event, path));
     }
 
     @Test
     public void testUnclosedTag() throws IOException {
         Event event = getTestEvent();
         String path = "/full/%{+YYY/web";
-        StringInterpolation si = StringInterpolation.getInstance();
-
-        assertEquals("/full/%{+YYY/web", si.evaluate(event, path));
+        assertEquals("/full/%{+YYY/web", StringInterpolation.evaluate(event, path));
     }
 
     @Test
     public void TestStringIsOneDateTag() throws IOException {
         Event event = getTestEvent();
         String path = "%{+YYYY}";
-        StringInterpolation si = StringInterpolation.getInstance();
-        assertEquals("2015", si.evaluate(event, path));
+        assertEquals("2015", StringInterpolation.evaluate(event, path));
     }
 
     @Test
     public void TestFieldRef() throws IOException {
         Event event = getTestEvent();
         String path = "%{[j][k1]}";
-        StringInterpolation si = StringInterpolation.getInstance();
-        assertEquals("v", si.evaluate(event, path));
+        assertEquals("v", StringInterpolation.evaluate(event, path));
     }
 
     @Test
     public void TestEpoch() throws IOException {
         Event event = getTestEvent();
         String path = "%{+%s}";
-        StringInterpolation si = StringInterpolation.getInstance();
-        assertEquals("1443657600", si.evaluate(event, path));
+        assertEquals("1443657600", StringInterpolation.evaluate(event, path));
     }
 
     @Test
@@ -111,8 +94,7 @@ public class StringInterpolationTest {
         event.setField("message", l);
 
         String path = "%{message}";
-        StringInterpolation si = StringInterpolation.getInstance();
-        assertEquals("Hello,world", si.evaluate(event, path));
+        assertEquals("Hello,world", StringInterpolation.evaluate(event, path));
     }
 
     @Test
@@ -120,8 +102,7 @@ public class StringInterpolationTest {
         Event event = getTestEvent();
 
         String path = "%{j}";
-        StringInterpolation si = StringInterpolation.getInstance();
-        assertEquals("{\"k1\":\"v\"}", si.evaluate(event, path));
+        assertEquals("{\"k1\":\"v\"}", StringInterpolation.evaluate(event, path));
     }
 
     public Event getTestEvent() {


### PR DESCRIPTION
There were some syntactic mistakes here, accessing a `static` field with `this.` => removed those and it made it clear that we're still missing a few `static` here :)

=> Added missing type on cache map
=> Removed redundant non `static` access to eventually `static` field
=> Better correctness and better chance of inlining :)