### PR TITLE
ci: provides TLS certificates in base docker image

### DIFF
--- a/qa/integration/services/dockerized/Dockerfile
+++ b/qa/integration/services/dockerized/Dockerfile
@@ -16,6 +16,11 @@ USER tester
 ENV WORKDIR /home/tester
 WORKDIR $WORKDIR
 
+# Generate TLS certificates that can be used by services.
+ENV CERTIFICATES_DIR $WORKDIR/certificates
+RUN mkdir -p $CERTIFICATES_DIR && \
+openssl req -subj '/CN=localhost/' -x509 -days $((100 * 365)) -batch -nodes -newkey rsa:2048 -keyout $CERTIFICATES_DIR/certificate.key -out $CERTIFICATES_DIR/certificate.crt
+
 # Script with routines that can be used in derived images.
 ADD helpers.sh .
 


### PR DESCRIPTION
Some test cases uses TLS certificates to check
the behavior with trusted communication among the
services.

This change generates the certificates in the base
docker image and add ServiceContainer#certificates
method so that the files can be copied to host.

An support method (ServiceContainer#envvar) is
also added. It gets an environment variable value
exported within the container.

In preparation to Fix #7098