### PR TITLE
Add Metrics for dead letter queue (merge #7338 into 5.x)

### DIFF
--- a/logstash-core/lib/logstash/api/commands/node.rb
+++ b/logstash-core/lib/logstash/api/commands/node.rb
@@ -20,8 +20,8 @@ module LogStash
         def pipeline(pipeline_id = LogStash::SETTINGS.get("pipeline.id").to_sym)
           stats = extract_metrics(
             [:stats, :pipelines, pipeline_id, :config],
-            :workers, :batch_size, :batch_delay, :config_reload_automatic, :config_reload_interval
-          )
+            :workers, :batch_size, :batch_delay, :config_reload_automatic, :config_reload_interval, :dead_letter_queue_enabled, :dead_letter_queue_path
+          ).reject{|_, v|v.nil?}
           stats.merge(:id => pipeline_id)
         end
 

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -107,8 +107,8 @@ module LogStash
               },
               :reloads => stats[:reloads],
               :queue => stats[:queue]
-            }
-          end
+            }.merge(stats[:dlq] ? {:dead_letter_queue => stats[:dlq]} : {})
+            end
         end # module PluginsStats
       end
     end

--- a/logstash-core/lib/logstash/instrument/periodic_poller/dlq.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/dlq.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+require 'logstash/instrument/periodic_poller/base'
+
+module LogStash module Instrument module PeriodicPoller
+  class DeadLetterQueue < Base
+    def initialize(metric, agent, options = {})
+      super(metric, options)
+      @metric = metric
+      @agent = agent
+    end
+
+    def collect
+      _, pipeline = @agent.running_pipelines.first
+      unless pipeline.nil?
+        pipeline.collect_dlq_stats
+      end
+    end
+  end
+end end end

--- a/logstash-core/lib/logstash/instrument/periodic_pollers.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_pollers.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require "logstash/instrument/periodic_poller/dlq"
 require "logstash/instrument/periodic_poller/os"
 require "logstash/instrument/periodic_poller/jvm"
 require "logstash/instrument/periodic_poller/pq"
@@ -14,7 +15,8 @@ module LogStash module Instrument
       @metric = metric
       @periodic_pollers = [PeriodicPoller::Os.new(metric),
                            PeriodicPoller::JVM.new(metric),
-                           PeriodicPoller::PersistentQueue.new(metric, queue_type, pipelines)]
+                           PeriodicPoller::PersistentQueue.new(metric, queue_type, pipelines),
+                           PeriodicPoller::DeadLetterQueue.new(metric, pipelines)]
     end
 
     def start

--- a/logstash-core/spec/logstash/api/modules/node_spec.rb
+++ b/logstash-core/spec/logstash/api/modules/node_spec.rb
@@ -114,7 +114,8 @@ describe LogStash::Api::Modules::Node do
           "batch_size" => Numeric,
           "batch_delay" => Numeric,
           "config_reload_automatic" => Boolean,
-          "config_reload_interval" => Numeric
+          "config_reload_interval" => Numeric,
+          "dead_letter_queue_enabled" => Boolean
         },
         "os" => {
           "name" => String,

--- a/logstash-core/spec/logstash/instrument/periodic_poller/dlq_spec.rb
+++ b/logstash-core/spec/logstash/instrument/periodic_poller/dlq_spec.rb
@@ -1,0 +1,17 @@
+# encoding: utf-8
+require "spec_helper"
+require "logstash/instrument/periodic_poller/dlq"
+require "logstash/instrument/collector"
+
+describe LogStash::Instrument::PeriodicPoller::DeadLetterQueue do
+  subject { LogStash::Instrument::PeriodicPoller::DeadLetterQueue }
+
+  let(:metric) { LogStash::Instrument::Metric.new(LogStash::Instrument::Collector.new) }
+  let(:agent) { double("agent")}
+  let(:options) { {} }
+  subject(:dlq) { described_class.new(metric, agent, options) }
+
+  it "should initialize cleanly" do
+    expect { dlq }.not_to raise_error
+  end
+end

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -48,6 +48,25 @@ describe "Test Monitoring API" do
     end
   end
 
+  it 'can retrieve dlq stats' do
+    logstash_service = @fixture.get_service("logstash")
+    logstash_service.start_with_stdin
+    logstash_service.wait_for_logstash
+    Stud.try(max_retry.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
+      # node_stats can fail if the stats subsystem isn't ready
+      result = logstash_service.monitoring_api.node_stats rescue nil
+      expect(result).not_to be_nil
+      # we use fetch here since we want failed fetches to raise an exception
+      # and trigger the retry block
+      queue_stats = result.fetch('pipeline')['dead_letter_queue']
+      if logstash_service.settings.get("dead_letter_queue.enable")
+        expect(queue_stats['queue_size_in_bytes']).not_to be_nil
+      else
+        expect(queue_stats).to be nil
+      end
+    end
+  end
+
   it "can retrieve queue stats" do
     logstash_service = @fixture.get_service("logstash")
     logstash_service.start_with_stdin


### PR DESCRIPTION
Add an initial set of metrics for the dead letter queue.

Metrics are supplied under the pipeline in the following format:

"dead_letter_queue": {
        "queue_size_in_bytes": ...,
      }

Metrics are populated via a PeriodicPoller

Also fixed up calculation of currentQueueSize to take account
of version headers, which was previously being skipped.

Additionally, whether the dlq is enabled, and if so, the path
of the dlq is supplied under the pipelines API endpoint

Resolves #7287

Fixes #7338