### PR TITLE
Optimize LIR pipeline hashing

### DIFF
--- a/logstash-core/lib/logstash/compiler/lscl.rb
+++ b/logstash-core/lib/logstash/compiler/lscl.rb
@@ -46,10 +46,6 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
       [self.input.line_of(start), self.input.column_of(start)]
     end
 
-    def empty_source_meta()
-      org.logstash.common.SourceWithMetadata.new(base_protocol, base_id, nil)
-    end
-
     def jdsl
       org.logstash.config.ir.DSL
     end
@@ -99,11 +95,12 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
         end
       end
 
+      compiled_section_map = {}
       section_map.keys.each do |key|
-        section_map[key] = compose_for(key).call(empty_source_meta, *section_map[key])
+        compiled_section_map[key] = compose_for(key).call(*section_map[key])
       end
 
-      section_map
+      compiled_section_map
     end
   end
 

--- a/logstash-core/lib/logstash/config/source/local.rb
+++ b/logstash-core/lib/logstash/config/source/local.rb
@@ -19,7 +19,7 @@ module LogStash module Config module Source
   class Local < Base
     class ConfigStringLoader
       def self.read(config_string)
-        [org.logstash.common.SourceWithMetadata.new("string", "config_string", config_string)]
+        [org.logstash.common.SourceWithMetadata.new("string", "config_string", 0, 0, config_string)]
       end
     end
 
@@ -54,7 +54,7 @@ module LogStash module Config module Source
           config_string = ::File.read(file)
 
           if valid_encoding?(config_string)
-            part = org.logstash.common.SourceWithMetadata.new("file", file, config_string)
+            part = org.logstash.common.SourceWithMetadata.new("file", file, 0, 0, config_string)
             config_parts << part
           else
             encoding_issue_files << file
@@ -121,7 +121,7 @@ module LogStash module Config module Source
           # since we have fetching config we wont follow any redirection.
           case response.code.to_i
           when 200
-            [org.logstash.common.SourceWithMetadata.new(uri.scheme, uri.to_s, response.body)]
+            [org.logstash.common.SourceWithMetadata.new(uri.scheme, uri.to_s, 0, 0, response.body)]
           when 302
             raise LogStash::ConfigLoadingError, I18n.t("logstash.runner.configuration.fetch-failed", :path => uri.to_s, :message => "We don't follow redirection for remote configuration")
           when 404
@@ -177,12 +177,12 @@ module LogStash module Config module Source
     # this is for backward compatibility reason
     def add_missing_default_inputs_or_outputs(config_parts)
       if !config_parts.any? { |part| INPUT_BLOCK_RE.match(part.text) }
-        config_parts << org.logstash.common.SourceWithMetadata.new(self.class.name, "default input", LogStash::Config::Defaults.input)
+        config_parts << org.logstash.common.SourceWithMetadata.new(self.class.name, "default input", 0, 0, LogStash::Config::Defaults.input)
       end
 
       # include a default stdout output if no outputs given
       if !config_parts.any? { |part| OUTPUT_BLOCK_RE.match(part.text) }
-        config_parts << org.logstash.common.SourceWithMetadata.new(self.class.name, "default output", LogStash::Config::Defaults.output)
+        config_parts << org.logstash.common.SourceWithMetadata.new(self.class.name, "default output", 0, 0, LogStash::Config::Defaults.output)
       end
     end
 

--- a/logstash-core/lib/logstash/config/source/modules.rb
+++ b/logstash-core/lib/logstash/config/source/modules.rb
@@ -14,7 +14,7 @@ module LogStash module Config module Source
       pipelines = LogStash::Config::ModulesCommon.pipeline_configs(@settings)
       pipelines.map do |hash|
         PipelineConfig.new(self, hash["pipeline_id"].to_sym,
-          org.logstash.common.SourceWithMetadata.new("module", hash["alt_name"], hash["config_string"]),
+          org.logstash.common.SourceWithMetadata.new("module", hash["alt_name"], 0, 0, hash["config_string"]),
           hash["settings"])
       end
     end

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -90,7 +90,7 @@ module LogStash; class BasePipeline
   end
 
   def compile_lir
-    source_with_metadata = SourceWithMetadata.new("str", "pipeline", self.config_str)
+    source_with_metadata = SourceWithMetadata.new("str", "pipeline", 0, 0, self.config_str)
     LogStash::Compiler.compile_sources(source_with_metadata)
   end
 

--- a/logstash-core/spec/logstash/compiler/compiler_spec.rb
+++ b/logstash-core/spec/logstash/compiler/compiler_spec.rb
@@ -28,8 +28,8 @@ describe LogStash::Compiler do
 
   describe "compiling to Pipeline" do
     subject(:source_id) { "fake_sourcefile" }
-    let(:source_with_metadata) { org.logstash.common.SourceWithMetadata.new(source_protocol, source_id, source) }
-    subject(:compiled) { described_class.compile_pipeline(source_with_metadata) }
+    let(:source_with_metadata) { org.logstash.common.SourceWithMetadata.new(source_protocol, source_id, 0, 0, source) }
+    subject(:compiled) { puts "PCOMP"; described_class.compile_pipeline(source_with_metadata) }
 
     describe "compiling multiple sources" do
       let(:sources) do
@@ -40,7 +40,7 @@ describe LogStash::Compiler do
       end
       let(:sources_with_metadata) do
         sources.map.with_index do |source, idx|
-          org.logstash.common.SourceWithMetadata.new("#{source_protocol}_#{idx}", "#{source_id}_#{idx}", source)
+          org.logstash.common.SourceWithMetadata.new("#{source_protocol}_#{idx}", "#{source_id}_#{idx}", 0, 0, source)
         end
       end
 
@@ -92,7 +92,7 @@ describe LogStash::Compiler do
 
   describe "compiling imperative" do
     let(:source_id) { "fake_sourcefile" }
-    let(:source_with_metadata) { org.logstash.common.SourceWithMetadata.new(source_protocol, source_id, source) }
+    let(:source_with_metadata) { org.logstash.common.SourceWithMetadata.new(source_protocol, source_id, 0, 0, source) }
     subject(:compiled) { described_class.compile_imperative(source_with_metadata) }
 
     describe "an empty file" do

--- a/logstash-core/spec/logstash/config/pipeline_config_spec.rb
+++ b/logstash-core/spec/logstash/config/pipeline_config_spec.rb
@@ -7,13 +7,13 @@ describe LogStash::Config::PipelineConfig do
   let(:pipeline_id) { :main }
   let(:ordered_config_parts) do
     [
-      org.logstash.common.SourceWithMetadata.new("file", "/tmp/1", "input { generator1 }"),
-      org.logstash.common.SourceWithMetadata.new("file", "/tmp/2", "input { generator2 }"),
-      org.logstash.common.SourceWithMetadata.new("file", "/tmp/3", "input { generator3 }"),
-      org.logstash.common.SourceWithMetadata.new("file", "/tmp/4", "input { generator4 }"),
-      org.logstash.common.SourceWithMetadata.new("file", "/tmp/5", "input { generator5 }"),
-      org.logstash.common.SourceWithMetadata.new("file", "/tmp/6", "input { generator6 }"),
-      org.logstash.common.SourceWithMetadata.new("string", "config_string", "input { generator1 }"),
+      org.logstash.common.SourceWithMetadata.new("file", "/tmp/1", 0, 0, "input { generator1 }"),
+      org.logstash.common.SourceWithMetadata.new("file", "/tmp/2", 0, 0,  "input { generator2 }"),
+      org.logstash.common.SourceWithMetadata.new("file", "/tmp/3", 0, 0, "input { generator3 }"),
+      org.logstash.common.SourceWithMetadata.new("file", "/tmp/4", 0, 0, "input { generator4 }"),
+      org.logstash.common.SourceWithMetadata.new("file", "/tmp/5", 0, 0, "input { generator5 }"),
+      org.logstash.common.SourceWithMetadata.new("file", "/tmp/6", 0, 0, "input { generator6 }"),
+      org.logstash.common.SourceWithMetadata.new("string", "config_string", 0, 0, "input { generator1 }"),
     ]
   end
 

--- a/logstash-core/spec/logstash/config/source/local_spec.rb
+++ b/logstash-core/spec/logstash/config/source/local_spec.rb
@@ -367,6 +367,7 @@ describe LogStash::Config::Source::Local do
         file = Stud::Temporary.file
         path = file.path
         file.write(config_string)
+        file.close # we need to flush the write
         path
       end
       let(:settings) { mock_settings( "path.config" => config_path) }

--- a/logstash-core/spec/logstash/config/source/multi_local_spec.rb
+++ b/logstash-core/spec/logstash/config/source/multi_local_spec.rb
@@ -29,7 +29,7 @@ describe LogStash::Config::Source::MultiLocal do
     end
 
     context "when `config.path` are set`" do
-      let(:config_file) { temporary_file("") }
+      let(:config_file) { temporary_file("input {} output {}") }
 
       let(:settings) do
         mock_settings("path.config" => config_file)
@@ -85,8 +85,8 @@ describe LogStash::Config::Source::MultiLocal do
   describe "#pipeline_configs" do
     let(:retrieved_pipelines) do
       [
-        { "pipeline.id" => "main", "config.string" => "" },
-        { "pipeline.id" => "backup", "config.string" => "" }
+        { "pipeline.id" => "main", "config.string" => "input {} output {}" },
+        { "pipeline.id" => "backup", "config.string" => "input {} output {}" }
       ]
     end
     before(:each) do

--- a/logstash-core/spec/logstash/config/source_loader_spec.rb
+++ b/logstash-core/spec/logstash/config/source_loader_spec.rb
@@ -4,7 +4,7 @@ require "logstash/config/source/base"
 require_relative "../../support/helpers"
 
 def temporary_pipeline_config(id, source, reader = "random_reader")
-  config_part = org.logstash.common.SourceWithMetadata.new("local", "...", "input {} output {}")
+  config_part = org.logstash.common.SourceWithMetadata.new("local", "...", 0, 0, "input {} output {}")
   LogStash::Config::PipelineConfig.new(source, id, [config_part], LogStash::SETTINGS)
 end
 

--- a/logstash-core/spec/support/helpers.rb
+++ b/logstash-core/spec/support/helpers.rb
@@ -63,7 +63,7 @@ def mock_pipeline_config(pipeline_id, config_string = nil, settings = {})
     settings = mock_settings(settings)
   end
 
-  config_part = org.logstash.common.SourceWithMetadata.new("config_string", "config_string", config_string)
+  config_part = org.logstash.common.SourceWithMetadata.new("config_string", "config_string", 0, 0, config_string)
 
   LogStash::Config::PipelineConfig.new(LogStash::Config::Source::Local, pipeline_id, config_part, settings)
 end

--- a/logstash-core/src/main/java/org/logstash/common/IncompleteSourceWithMetadataException.java
+++ b/logstash-core/src/main/java/org/logstash/common/IncompleteSourceWithMetadataException.java
@@ -1,0 +1,12 @@
+package org.logstash.common;
+
+import org.logstash.config.ir.InvalidIRException;
+
+/**
+ * Created by andrewvc on 6/12/17.
+ */
+public class IncompleteSourceWithMetadataException extends InvalidIRException {
+    public IncompleteSourceWithMetadataException(String message) {
+        super(message);
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/config/ir/DSL.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/DSL.java
@@ -23,7 +23,7 @@ public class DSL {
     }
 
     public static EventValueExpression eEventValue(String fieldName) {
-        return eEventValue(new SourceWithMetadata(), fieldName);
+        return eEventValue(null, fieldName);
     }
 
     public static ValueExpression eValue(SourceWithMetadata meta, Object value) throws InvalidIRException {
@@ -31,7 +31,7 @@ public class DSL {
     }
 
     public static ValueExpression eValue(Object value) throws InvalidIRException {
-        return eValue(new SourceWithMetadata(), value);
+        return eValue(null, value);
     }
 
     public static ValueExpression eRegex(SourceWithMetadata meta, String pattern) throws InvalidIRException {
@@ -39,12 +39,12 @@ public class DSL {
     }
 
     public static ValueExpression eRegex(String pattern) throws InvalidIRException {
-        return eRegex(new SourceWithMetadata(), pattern);
+        return eRegex(null, pattern);
     }
 
     public static ValueExpression eValue(long value) {
         try {
-            return eValue(new SourceWithMetadata(), value);
+            return eValue(null, value);
         } catch (InvalidIRException e) {
             e.printStackTrace(); // Can't happen with an int
             return null;
@@ -53,7 +53,7 @@ public class DSL {
 
     public static ValueExpression eValue(double value) {
         try {
-            return eValue(new SourceWithMetadata(), value);
+            return eValue(null, value);
         } catch (InvalidIRException e) {
             e.printStackTrace(); // Can't happen with an int
             return null;
@@ -195,7 +195,7 @@ public class DSL {
     }
 
     public static NoopStatement noop() {
-        return new NoopStatement(new SourceWithMetadata());
+        return new NoopStatement(null);
     }
 
     public static PluginStatement iPlugin(SourceWithMetadata meta, PluginDefinition.Type pluginType, String pluginName, Map<String, Object> pluginArguments) {
@@ -203,7 +203,7 @@ public class DSL {
     }
 
     public static PluginStatement iPlugin(PluginDefinition.Type type, String pluginName, Map<String, Object> pluginArguments) {
-        return iPlugin(new SourceWithMetadata(), type, pluginName, pluginArguments);
+        return iPlugin(null, type, pluginName, pluginArguments);
     }
 
     public static PluginStatement iPlugin(PluginDefinition.Type type, String pluginName, MapBuilder<String, Object> argBuilder) {
@@ -229,12 +229,12 @@ public class DSL {
     public static IfStatement iIf(Expression condition,
                                   Statement ifTrue,
                                   Statement ifFalse) throws InvalidIRException {
-        return iIf(new SourceWithMetadata(), condition, ifTrue, ifFalse);
+        return iIf(null, condition, ifTrue, ifFalse);
     }
 
     public static IfStatement iIf(Expression condition,
                                   Statement ifTrue) throws InvalidIRException {
-        return iIf(new SourceWithMetadata(), condition, ifTrue, noop());
+        return iIf(null, condition, ifTrue, noop());
     }
 
     public static class MapBuilder<K,V> {
@@ -275,7 +275,7 @@ public class DSL {
     }
 
     public static PluginVertex gPlugin(PluginDefinition.Type type, String pluginName, Map<String, Object> pluginArgs) {
-        return gPlugin(new SourceWithMetadata(), type, pluginName, pluginArgs);
+        return gPlugin(null, type, pluginName, pluginArgs);
     }
 
     public static PluginVertex gPlugin(PluginDefinition.Type type, String pluginName, String id) {
@@ -283,7 +283,7 @@ public class DSL {
     }
 
     public static PluginVertex gPlugin(PluginDefinition.Type type, String pluginName) {
-        return gPlugin(new SourceWithMetadata(), type, pluginName, new HashMap<>());
+        return gPlugin(null, type, pluginName, new HashMap<>());
     }
 
 
@@ -292,6 +292,6 @@ public class DSL {
     }
 
     public static IfVertex gIf(BooleanExpression expression) {
-       return new IfVertex(new SourceWithMetadata(), expression);
+       return new IfVertex(null, expression);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/Hashable.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/Hashable.java
@@ -6,9 +6,5 @@ import org.logstash.common.Util;
  * Created by andrewvc on 12/23/16.
  */
 public interface Hashable {
-    String hashSource();
-
-    default String uniqueHash() {
-        return Util.digest(this.hashSource());
-    }
+    String uniqueHash();
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/HashableWithSource.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/HashableWithSource.java
@@ -1,0 +1,15 @@
+package org.logstash.config.ir;
+
+import org.logstash.common.Util;
+import org.logstash.config.ir.Hashable;
+
+/**
+ * Created by andrewvc on 6/12/17.
+ */
+public interface HashableWithSource extends Hashable {
+    @Override
+    default String uniqueHash() {
+        return Util.digest(hashSource());
+    }
+    String hashSource();
+}

--- a/logstash-core/src/main/java/org/logstash/config/ir/PipelineIR.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/PipelineIR.java
@@ -13,6 +13,8 @@ import java.util.stream.Stream;
  * Created by andrewvc on 9/20/16.
  */
 public class PipelineIR implements Hashable {
+    private String uniqueHash;
+
     public Graph getGraph() {
         return graph;
     }
@@ -47,6 +49,10 @@ public class PipelineIR implements Hashable {
         this.graph = tempGraph.chain(outputSection);
 
         this.graph.validate();
+
+        if (this.getOriginalSource() != null && this.getOriginalSource().matches("^\\S+$")) {
+            uniqueHash = this.graph.uniqueHash();
+        }
     }
 
     public String getOriginalSource() {
@@ -101,7 +107,7 @@ public class PipelineIR implements Hashable {
     }
 
     @Override
-    public String hashSource() {
-        return this.graph.uniqueHash();
+    public String uniqueHash() {
+        return this.uniqueHash;
     }
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/PipelineIR.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/PipelineIR.java
@@ -34,11 +34,6 @@ public class PipelineIR implements Hashable {
     public PipelineIR(Graph inputSection, Graph filterSection, Graph outputSection, String originalSource) throws InvalidIRException {
         this.originalSource = originalSource;
 
-        // Validate all incoming graphs, we can't turn an invalid graph into a PipelineIR!
-        inputSection.validate();
-        filterSection.validate();
-        outputSection.validate();
-
         Graph tempGraph = inputSection.copy(); // The input section are our roots, so we can import that wholesale
 
         // Connect all the input vertices out to the queue
@@ -50,6 +45,8 @@ public class PipelineIR implements Hashable {
 
         // Finally, connect the filter out node to all the outputs
         this.graph = tempGraph.chain(outputSection);
+
+        this.graph.validate();
     }
 
     public String getOriginalSource() {

--- a/logstash-core/src/main/java/org/logstash/config/ir/PluginDefinition.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/PluginDefinition.java
@@ -12,7 +12,7 @@ import java.util.Set;
 /**
  * Created by andrewvc on 9/20/16.
  */
-public class PluginDefinition implements SourceComponent, Hashable {
+public class PluginDefinition implements SourceComponent, HashableWithSource {
     private static ObjectMapper om = new ObjectMapper();
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/config/ir/expression/BinaryBooleanExpression.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/expression/BinaryBooleanExpression.java
@@ -1,5 +1,6 @@
 package org.logstash.config.ir.expression;
 
+import org.logstash.common.Util;
 import org.logstash.config.ir.SourceComponent;
 import org.logstash.config.ir.InvalidIRException;
 import org.logstash.common.SourceWithMetadata;
@@ -46,8 +47,7 @@ public abstract class BinaryBooleanExpression extends BooleanExpression {
         return "(" + getLeft().toRubyString() + rubyOperator() + getRight().toRubyString() + ")";
     }
 
-    @Override
-    public String hashSource() {
-        return this.getClass().getCanonicalName() + "[" + getLeft().hashSource() + "|" + getRight().hashSource() + "]";
+    public String uniqueHash() {
+        return Util.digest(this.getClass().getCanonicalName() + "[" + getLeft().hashSource() + "|" + getRight().hashSource() + "]");
     }
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/expression/Expression.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/expression/Expression.java
@@ -6,6 +6,7 @@ import org.jruby.embed.ScriptingContainer;
 import org.logstash.config.ir.Hashable;
 import org.logstash.config.ir.BaseSourceComponent;
 import org.logstash.common.SourceWithMetadata;
+import org.logstash.config.ir.HashableWithSource;
 
 /*
  * [foo] == "foostr" eAnd [bar] > 10
@@ -15,7 +16,7 @@ import org.logstash.common.SourceWithMetadata;
  * notnull(eEventValue("foo"))
  * Created by andrewvc on 9/6/16.
  */
-public abstract class Expression extends BaseSourceComponent implements Hashable {
+public abstract class Expression extends BaseSourceComponent implements HashableWithSource {
     private ScriptingContainer container;
 
     public Expression(SourceWithMetadata meta) {
@@ -40,4 +41,8 @@ public abstract class Expression extends BaseSourceComponent implements Hashable
     }
 
     public abstract String toRubyString();
+
+    public String hashSource() {
+        return toRubyString();
+    }
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/Graph.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/Graph.java
@@ -268,10 +268,6 @@ public class Graph implements SourceComponent, Hashable {
         return rank;
     }
 
-    public Map<String, List<Vertex>> verticesByHash() {
-        return this.vertices().parallel().collect(Collectors.groupingBy(Vertex::uniqueHash));
-    }
-
     public void validate() throws InvalidIRException {
         if (this.isEmpty()) return;
 
@@ -426,8 +422,7 @@ public class Graph implements SourceComponent, Hashable {
         return this.edges.stream();
     }
 
-    @Override
-    public String hashSource() {
+    public String uniqueHash() {
         MessageDigest lineageDigest = Util.defaultMessageDigest();
 
         // We only need to calculate the hashes of the leaves since those hashes are sensitive to changes

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/IfVertex.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/IfVertex.java
@@ -13,6 +13,8 @@ import java.util.stream.Collectors;
  * Created by andrewvc on 9/15/16.
  */
 public class IfVertex extends Vertex {
+    private volatile String generatedId;
+
     public BooleanExpression getBooleanExpression() {
         return booleanExpression;
     }
@@ -64,11 +66,6 @@ public class IfVertex extends Vertex {
 
     public boolean acceptsOutgoingEdge(Edge e) {
         return (e instanceof BooleanEdge);
-    }
-
-    @Override
-    public String getId() {
-        return this.uniqueHash();
     }
 
     public Collection<BooleanEdge> getOutgoingBooleanEdges() {

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/IfVertex.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/IfVertex.java
@@ -97,7 +97,7 @@ public class IfVertex extends Vertex {
     }
 
     @Override
-    public String individualHashSource() {
+    public String calculateIndividualHashSource() {
         return this.getClass().getCanonicalName() + "{" + this.booleanExpression.hashSource() + "}";
     }
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/PluginVertex.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/PluginVertex.java
@@ -47,7 +47,7 @@ public class PluginVertex extends Vertex {
     }
 
     @Override
-    public String individualHashSource() {
+    public String calculateIndividualHashSource() {
         ObjectMapper objectMapper = new ObjectMapper();
         try {
             return Util.digest(this.getClass().getCanonicalName() + "|" +
@@ -59,10 +59,6 @@ public class PluginVertex extends Vertex {
             // This is basically impossible given the constrained values in the plugin definition
             throw new RuntimeException(e);
         }
-    }
-
-    public String individualHash() {
-        return Util.digest(individualHashSource());
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/QueueVertex.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/QueueVertex.java
@@ -17,7 +17,7 @@ public class QueueVertex extends Vertex {
     }
 
     @Override
-    public String individualHashSource() {
+    public String calculateIndividualHashSource() {
         return this.getClass().getCanonicalName();
     }
 

--- a/logstash-core/src/test/java/org/logstash/common/SourceWithMetadataTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/SourceWithMetadataTest.java
@@ -1,0 +1,64 @@
+package org.logstash.common;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Created by andrewvc on 6/12/17.
+ */
+@RunWith(Parameterized.class)
+public class SourceWithMetadataTest {
+    private final ParameterGroup parameterGroup;
+
+    public static class ParameterGroup {
+        public final String protocol;
+        public final String path;
+        public final Integer line;
+        public final Integer column;
+        public final String text;
+
+        public ParameterGroup(String protocol, String path, Integer line, Integer column, String text) {
+            this.protocol = protocol;
+            this.path = path;
+            this.line = line;
+            this.column = column;
+            this.text = text;
+        }
+    }
+
+    @Parameterized.Parameters
+    public static Iterable<ParameterGroup> data() {
+        return Arrays.asList(
+            new ParameterGroup(null, "path", 1, 1, "foo"),
+            new ParameterGroup("proto", null, 1, 1, "foo"),
+            new ParameterGroup("proto", "path", null, 1, "foo"),
+            new ParameterGroup("proto", "path", 1, null, "foo"),
+            new ParameterGroup("proto", "path", 1, 1, null),
+            new ParameterGroup("", "path", 1, 1, "foo"),
+            new ParameterGroup("proto", "", 1, 1, "foo"),
+            new ParameterGroup("proto", "path", 1, 1, ""),
+            new ParameterGroup(" ", "path", 1, 1, "foo"),
+            new ParameterGroup("proto", "  ", 1, 1, "foo"),
+            new ParameterGroup("proto", "path", 1, 1, "   ")
+        );
+    }
+
+    public SourceWithMetadataTest(ParameterGroup parameterGroup) {
+        this.parameterGroup = parameterGroup;
+    }
+
+    // So, this really isn't parameterized, but it isn't worth making a separate class for this
+    @Test
+    public void itShouldInstantiateCleanlyWhenParamsAreGood() throws IncompleteSourceWithMetadataException {
+        new SourceWithMetadata("proto", "path", 1, 1, "text");
+    }
+
+    @Test(expected = IncompleteSourceWithMetadataException.class)
+    public void itShouldThrowWhenMissingAField() throws IncompleteSourceWithMetadataException {
+        new SourceWithMetadata(parameterGroup.protocol, parameterGroup.path, parameterGroup.line, parameterGroup.column, parameterGroup.text);
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/config/ir/IRHelpers.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/IRHelpers.java
@@ -1,6 +1,7 @@
 package org.logstash.config.ir;
 
 import org.hamcrest.MatcherAssert;
+import org.logstash.common.IncompleteSourceWithMetadataException;
 import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.expression.BooleanExpression;
 import org.logstash.config.ir.expression.ValueExpression;
@@ -116,8 +117,8 @@ public class IRHelpers {
         return new Truthy(null, new ValueExpression(null, 1));
     }
 
-    public static SourceWithMetadata testMetadata() {
-        return new SourceWithMetadata("/fake/file", 1, 2, "<fakesource>");
+    public static SourceWithMetadata testMetadata() throws IncompleteSourceWithMetadataException {
+        return new SourceWithMetadata("file", "/fake/file", 1, 2, "<fakesource>");
     }
 
     public static PluginDefinition testPluginDefinition() {

--- a/logstash-core/src/test/java/org/logstash/config/ir/IRHelpers.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/IRHelpers.java
@@ -52,7 +52,7 @@ public class IRHelpers {
         }
 
         @Override
-        public String individualHashSource() {
+        public String calculateIndividualHashSource() {
             return "TVertex" + "|" + id;
         }
 

--- a/logstash-core/src/test/java/org/logstash/config/ir/graph/GraphTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/graph/GraphTest.java
@@ -9,6 +9,7 @@ import org.logstash.config.ir.imperative.IfStatement;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;

--- a/logstash-core/src/test/java/org/logstash/config/ir/graph/PluginVertexTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/graph/PluginVertexTest.java
@@ -1,6 +1,8 @@
 package org.logstash.config.ir.graph;
 
 import org.junit.Test;
+import org.logstash.common.IncompleteSourceWithMetadataException;
+import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.InvalidIRException;
 import org.logstash.config.ir.PluginDefinition;
 
@@ -25,7 +27,7 @@ public class PluginVertexTest {
     }
 
     @Test
-    public void testConstructionIdHandlingWhenExplicitId() {
+    public void testConstructionIdHandlingWhenExplicitId() throws IncompleteSourceWithMetadataException {
         String customId = "mycustomid";
         Map<String, Object> pluginArguments = new HashMap<>();
         pluginArguments.put("id", customId);


### PR DESCRIPTION
Fixes #7379

Prior to this patch large configuration files would take a long time to load, sometimes, so long that any sane user would just give up. This patch improves the graph hashing algorithm in the following ways:

1. Caches expensive to compute paths
2. Use parallel computation where possible to speed calculations
3. Removes unnecessary validation on Graph#chainVertices
4. Validates the entire graph in PipelineIR which allows the cache to be used for both validation and hashing
5. Validation now only checks for duplicate IDs, not duplicate hashes. If the user supplies their own IDs this check will be sped up.
6. Hashing only consists of calculating the unique hash for the leaf nodes. Since hashing is sensitive to the full ancestry of a given node this is sufficient vs. previously where each vertex's hash was combined. We will still calculate the hash for each vertex if no ID is specified however.

Benchmark results on the new branch look good. Configs used were [bigconfig.config](https://gist.githubusercontent.com/andrewvc/6251a238ecba54510d34ec348168dde8/raw/dbfd148a3a2711f96cd9db9109bd3345b9a63644/bigconfig.config) and [smallconfig.config](https://gist.githubusercontent.com/andrewvc/6251a238ecba54510d34ec348168dde8/raw/dbfd148a3a2711f96cd9db9109bd3345b9a63644/smallconfig.config). Results posted below:

```
~/p/logstash (optimize-pipeline-hashing) $ time bin/logstash -f smallconfig.config
ERROR StatusLogger No log4j2 configuration file found. Using default configuration: logging only errors to the console.
Sending Logstash's logs to /Users/andrewvc/projects/logstash/logs which is now configured via log4j2.properties
[2017-06-09T16:37:34,951][WARN ][logstash.config.source.multilocal] Ignoring the 'pipelines.yml' file because 'path.config' (-f) is being used.
[2017-06-09T16:37:34,993][INFO ][logstash.agent           ] Successfully started Logstash API endpoint {:port=>9600}
[2017-06-09T16:37:35,354][INFO ][logstash.pipeline        ] Starting pipeline {:pipeline_id=>"main", :thread=>"#<Thread:0x194f3bde run>", "pipeline.workers"=>8, "pipeline.batch.size"=>125, "pipeline.batch.delay"=>5, "pipeline.max_inflight"=>1000}
[2017-06-09T16:37:35,358][INFO ][logstash.pipeline        ] Pipeline started {"pipeline.id"=>"main"}
[2017-06-09T16:37:35,364][INFO ][logstash.agent           ] Pipelines running {:count=>1, :pipelines=>["main"]}
2017-06-09T21:37:35.368Z andrewvc-elastic Hello world!
[2017-06-09T16:37:35,878][INFO ][logstash.pipeline        ] Pipeline terminated {"pipeline.id"=>"main"}
        8.52 real        30.56 user         1.15 sys
~/p/logstash (optimize-pipeline-hashing) $ time bin/logstash -f bigconfig.config
ERROR StatusLogger No log4j2 configuration file found. Using default configuration: logging only errors to the console.
Sending Logstash's logs to /Users/andrewvc/projects/logstash/logs which is now configured via log4j2.properties
[2017-06-09T16:37:49,420][WARN ][logstash.config.source.multilocal] Ignoring the 'pipelines.yml' file because 'path.config' (-f) is being used.
[2017-06-09T16:37:49,467][INFO ][logstash.agent           ] Successfully started Logstash API endpoint {:port=>9600}
[2017-06-09T16:37:58,455][INFO ][logstash.pipeline        ] Starting pipeline {:pipeline_id=>"main", :thread=>"#<Thread:0x5d006478 run>", "pipeline.workers"=>8, "pipeline.batch.size"=>125, "pipeline.batch.delay"=>5, "pipeline.max_inflight"=>1000}
[2017-06-09T16:37:58,533][INFO ][logstash.pipeline        ] Pipeline started {"pipeline.id"=>"main"}
[2017-06-09T16:37:58,547][INFO ][logstash.agent           ] Pipelines running {:count=>1, :pipelines=>["main"]}
2017-06-09T21:37:58.546Z andrewvc-elastic Hello world!
[2017-06-09T16:37:59,060][INFO ][logstash.pipeline        ] Pipeline terminated {"pipeline.id"=>"main"}
       16.84 real        71.79 user         1.56 sys
```

compared to before this commit:

```
~/p/logstash (master) $ time bin/logstash -f smallconfig.config
ERROR StatusLogger No log4j2 configuration file found. Using default configuration: logging only errors to the console.
Sending Logstash's logs to /Users/andrewvc/projects/logstash/logs which is now configured via log4j2.properties
[2017-06-09T16:48:20,142][WARN ][logstash.config.source.multilocal] Ignoring the 'pipelines.yml' file because 'path.config' (-f) is being used.
[2017-06-09T16:48:20,187][INFO ][logstash.agent           ] Successfully started Logstash API endpoint {:port=>9600}
[2017-06-09T16:48:24,581][INFO ][logstash.pipeline        ] Starting pipeline {:pipeline_id=>"main", :thread=>"#<Thread:0x7866ed16 run>", "pipeline.workers"=>8, "pipeline.batch.size"=>125, "pipeline.batch.delay"=>5, "pipeline.max_inflight"=>1000}
[2017-06-09T16:48:24,586][INFO ][logstash.pipeline        ] Pipeline started {"pipeline.id"=>"main"}
[2017-06-09T16:48:24,598][INFO ][logstash.agent           ] Pipelines running {:count=>1, :pipelines=>["main"]}
2017-06-09T21:48:24.607Z andrewvc-elastic Hello world!
[2017-06-09T16:48:25,116][INFO ][logstash.pipeline        ] Pipeline terminated {"pipeline.id"=>"main"}
       13.38 real        43.93 user         1.42 sys

# I Had to terminate execution here after 10m because it was still running!
~/p/logstash (master) $ time bin/logstash -f bigconfig.config
ERROR StatusLogger No log4j2 configuration file found. Using default configuration: logging only errors to the console.
Sending Logstash's logs to /Users/andrewvc/projects/logstash/logs which is now configured via log4j2.properties
[2017-06-09T16:39:27,507][WARN ][logstash.config.source.multilocal] Ignoring the 'pipelines.yml' file because 'path.config' (-f) is being used.
[2017-06-09T16:39:27,559][INFO ][logstash.agent           ] Successfully started Logstash API endpoint {:port=>9600}
[2017-06-09T16:47:21,963][WARN ][logstash.runner          ] SIGTERM received. Shutting down the agent.
Command terminated abnormally.
      485.85 real       571.93 user         5.31 sys
```