### PR TITLE
 #6696 validate evaluation result

### DIFF
--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -143,6 +143,9 @@ module LogStash::Config::Mixin
   end # def config_init
 
   module DSL
+
+    include LogStash::Util::EnvironmentVariables
+
     attr_accessor :flags
 
     # If name is given, set the name and return it.
@@ -387,6 +390,8 @@ module LogStash::Config::Mixin
       #   config :mykey => lambda do |value| ... end
       # (see LogStash::Inputs::File for example)
       result = nil
+
+      value = deep_replace(value)
 
       if validator.nil?
         return true, value

--- a/logstash-core/spec/logstash/config/mixin_spec.rb
+++ b/logstash-core/spec/logstash/config/mixin_spec.rb
@@ -369,11 +369,13 @@ describe LogStash::Config::Mixin do
       before do
         ENV["FunString"] = "fancy"
         ENV["FunBool"] = "true"
+        ENV["SERVER_LS_TEST_ADDRESS"] = "some.host.address.tld"
       end
 
       after do
         ENV.delete("FunString")
         ENV.delete("FunBool")
+        ENV.delete("SERVER_LS_TEST_ADDRESS")
       end
 
       subject do
@@ -396,6 +398,16 @@ describe LogStash::Config::Mixin do
         expect(subject.nestedHash).to(be == { "level1" => { "key1" => "http://fancy:8080/blah.txt" } })
         expect(subject.nestedArray).to(be == { "level1" => [{ "key1" => "http://fancy:8080/blah.txt" }, { "key2" => "http://fancy:8080/foo.txt" }] })
         expect(subject.deepHash).to(be == { "level1" => { "level2" => { "level3" => { "key1" => "http://fancy:8080/blah.txt" } } } })
+      end
+
+      it "should validate settings after interpolating ENV variables" do
+        expect {
+          Class.new(LogStash::Filters::Base) do
+            include LogStash::Config::Mixin
+            config_name "test"
+            config :server_address, :validate => :uri
+          end.new({"server_address" => "${SERVER_LS_TEST_ADDRESS}"})
+        }.not_to raise_error
       end
     end
 


### PR DESCRIPTION
For #6696 

The interpolation for the ES hosts breaks because we are running validation against the original, not interpolated values. So `${ES_HOST}` is rejected as value for a `:uri` field obviously.

Running validation against the interpolated values fixes the issue. Is there anything wrong with this approach? If not, happy to add a spec for this :)