### PR TITLE
Handle ingest on_failure processor

### DIFF
--- a/tools/ingest-converter/src/main/java/org/logstash/ingest/JsUtil.java
+++ b/tools/ingest-converter/src/main/java/org/logstash/ingest/JsUtil.java
@@ -24,7 +24,7 @@ final class JsUtil {
 
     private static final String[] SCRIPTS = {
         "shared", "date", "grok", "geoip", "gsub", "pipeline", "convert", "append", "json",
-        "rename", "lowercase"
+        "rename", "lowercase", "set"
     };
 
     private JsUtil() {
@@ -90,7 +90,7 @@ final class JsUtil {
      * Retrieves the input Ingest JSON from a given {@link URI}.
      * @param uri {@link URI} of Ingest JSON
      * @return Json String
-     * @throws IOException On failure to load Ingest JSON 
+     * @throws IOException On failure to load Ingest JSON
      */
     private static String input(final URI uri) throws IOException {
         if ("file".equals(uri.getScheme())) {

--- a/tools/ingest-converter/src/main/java/org/logstash/ingest/Set.java
+++ b/tools/ingest-converter/src/main/java/org/logstash/ingest/Set.java
@@ -1,0 +1,16 @@
+package org.logstash.ingest;
+
+import javax.script.ScriptException;
+
+/**
+ * Ingest Set DSL to Logstash mutate Transpiler.
+ */
+public class Set {
+    private Set() {
+        // Utility Wrapper for JS Script.
+    }
+
+    public static void main(final String... args) throws ScriptException, NoSuchMethodException {
+        JsUtil.convert(args, "ingest_set_to_logstash");
+    }
+}

--- a/tools/ingest-converter/src/main/resources/ingest-grok.js
+++ b/tools/ingest-converter/src/main/resources/ingest-grok.js
@@ -1,6 +1,9 @@
 var IngestGrok = {
     has_grok: function (processor) {
-        return !!processor["grok"];
+        return !!processor[this.get_name()];
+    },
+    get_name: function () {
+        return "grok";
     },
     grok_hash: function (processor) {
 

--- a/tools/ingest-converter/src/main/resources/ingest-pipeline.js
+++ b/tools/ingest-converter/src/main/resources/ingest-pipeline.js
@@ -15,7 +15,7 @@ function ingest_pipeline_to_logstash(json) {
         var filter_blocks = [];
         if (IngestGrok.has_grok(processor)) {
             filter_blocks.push(
-                IngestConverter.create_hash("grok", IngestGrok.grok_hash(processor))
+                IngestConverter.create_hash(IngestGrok.get_name(), IngestGrok.grok_hash(processor))
             );
             if (IngestConverter.has_on_failure(processor, IngestGrok.get_name())) {
                 filter_blocks.push(

--- a/tools/ingest-converter/src/main/resources/ingest-pipeline.js
+++ b/tools/ingest-converter/src/main/resources/ingest-pipeline.js
@@ -3,9 +3,9 @@
  */
 function ingest_pipeline_to_logstash(json) {
 
-    function handle_on_failure_pipeline(on_failure_json) {
+    function handle_on_failure_pipeline(on_failure_json, tag_name) {
 
-        return IngestConverter.create_tag_conditional("_grokparsefailure",
+        return IngestConverter.create_tag_conditional(tag_name,
             IngestConverter.join_hash_fields(on_failure_json.map(map_processor))
         );
     }
@@ -19,7 +19,10 @@ function ingest_pipeline_to_logstash(json) {
             );
             if (IngestConverter.has_on_failure(processor, IngestGrok.get_name())) {
                 filter_blocks.push(
-                    handle_on_failure_pipeline(IngestConverter.get_on_failure(processor, IngestGrok.get_name()))
+                    handle_on_failure_pipeline(
+                        IngestConverter.get_on_failure(processor, IngestGrok.get_name()),
+                        "_grokparsefailure"
+                    )
                 );
             }
         }

--- a/tools/ingest-converter/src/main/resources/ingest-pipeline.js
+++ b/tools/ingest-converter/src/main/resources/ingest-pipeline.js
@@ -3,13 +3,25 @@
  */
 function ingest_pipeline_to_logstash(json) {
 
+    function handle_on_failure_pipeline(on_failure_json) {
+
+        return IngestConverter.create_tag_conditional("_grokparsefailure",
+            IngestConverter.join_hash_fields(on_failure_json.map(map_processor))
+        );
+    }
+
     function map_processor(processor) {
 
         var filter_blocks = [];
         if (IngestGrok.has_grok(processor)) {
             filter_blocks.push(
                 IngestConverter.create_hash("grok", IngestGrok.grok_hash(processor))
-            )
+            );
+            if (IngestConverter.has_on_failure(processor, IngestGrok.get_name())) {
+                filter_blocks.push(
+                    handle_on_failure_pipeline(IngestConverter.get_on_failure(processor, IngestGrok.get_name()))
+                );
+            }
         }
         if (IngestDate.has_date(processor)) {
             filter_blocks.push(
@@ -49,6 +61,11 @@ function ingest_pipeline_to_logstash(json) {
         if (IngestLowercase.has_lowercase(processor)) {
             filter_blocks.push(
                 IngestConverter.create_hash("mutate", IngestLowercase.lowercase_hash(processor))
+            );
+        }
+        if (IngestSet.has_set(processor)) {
+            filter_blocks.push(
+                IngestConverter.create_hash("mutate", IngestSet.set_hash(processor))
             );
         }
         return IngestConverter.join_hash_fields(filter_blocks);

--- a/tools/ingest-converter/src/main/resources/ingest-set.js
+++ b/tools/ingest-converter/src/main/resources/ingest-set.js
@@ -1,0 +1,36 @@
+var IngestSet = {
+    has_set: function (processor) {
+        return !!processor["set"];
+    },
+    set_hash: function (processor) {
+        var set_json = processor["set"];
+        var value_contents;
+        var value = set_json["value"];
+        if (typeof value === 'string' || value instanceof String) {
+            value_contents = IngestConverter.quote_string(value);
+        } else {
+            value_contents = value;
+        }
+        var mutate_contents = IngestConverter.create_field(
+            IngestConverter.quote_string(IngestConverter.dots_to_square_brackets(set_json["field"])),
+            value_contents);
+        return IngestConverter.create_field("add_field", IngestConverter.wrap_in_curly(mutate_contents));
+    }
+};
+
+/**
+ * Converts Ingest Set JSON to LS mutate filter.
+ */
+function ingest_set_to_logstash(json) {
+
+    function map_processor(processor) {
+
+        return IngestConverter.filter_hash(
+            IngestConverter.create_hash(
+                "mutate", IngestSet.set_hash(processor)
+            )
+        );
+    }
+
+    return IngestConverter.filters_to_file(JSON.parse(json)["processors"].map(map_processor));
+}

--- a/tools/ingest-converter/src/main/resources/ingest-shared.js
+++ b/tools/ingest-converter/src/main/resources/ingest-shared.js
@@ -86,8 +86,8 @@ var IngestConverter = {
      * @returns {string} Pattern array in LS formatting
      */
     create_pattern_array: function (patterns) {
-        return "[\n" 
-            + patterns.map(this.dots_to_square_brackets).map(this.quote_string).join(",\n") 
+        return "[\n"
+            + patterns.map(this.dots_to_square_brackets).map(this.quote_string).join(",\n")
             + "\n]";
     },
 
@@ -96,7 +96,7 @@ var IngestConverter = {
             + ingest_array.map(this.quote_string).join(",\n")
             + "\n]";
     },
-    
+
     /**
      * Converts Ingest/JSON style pattern array to LS pattern array or string if the given array
      * contains a single element only, performing necessary variable name and quote escaping
@@ -109,12 +109,38 @@ var IngestConverter = {
             ? this.quote_string(this.dots_to_square_brackets(patterns[0]))
             : this.create_pattern_array(patterns);
     },
-    
+
     filter_hash: function(contents) {
         return this.fix_indent(this.create_hash("filter", contents))
     },
-    
+
     filters_to_file: function(filters) {
         return filters.join("\n\n") + "\n";
+    },
+
+    has_on_failure: function (processor, name) {
+        return !!processor[name]["on_failure"];
+    },
+
+    get_on_failure: function (processor, name) {
+        return processor[name]["on_failure"];
+    },
+
+    create_tag_conditional: function (tag, on_failure_pipeline) {
+        return "if " + this.quote_string(tag) + " in [tags] {\n" +
+                "   " + on_failure_pipeline + "\n" +
+                "}";
+    },
+
+    get_stdin_input: function () {
+        return "input { \n" +
+            "   stdin {}\n" +
+            "}";
+    },
+
+    get_stdout_output: function () {
+        return "output { \n" +
+            "   stdout { codec => \"rubydebug\" }\n" +
+            "}"
     }
 };

--- a/tools/ingest-converter/src/main/resources/ingest-shared.js
+++ b/tools/ingest-converter/src/main/resources/ingest-shared.js
@@ -140,7 +140,7 @@ var IngestConverter = {
      */
     create_tag_conditional: function (tag, on_failure_pipeline) {
         return "if " + this.quote_string(tag) + " in [tags] {\n" +
-                "   " + on_failure_pipeline + "\n" +
+                on_failure_pipeline + "\n" +
                 "}";
     }
 };

--- a/tools/ingest-converter/src/main/resources/ingest-shared.js
+++ b/tools/ingest-converter/src/main/resources/ingest-shared.js
@@ -118,6 +118,12 @@ var IngestConverter = {
         return filters.join("\n\n") + "\n";
     },
 
+    /**
+     * Does it have an on_failure field?
+     * @param processor Json
+     * @param name Name of the processor
+     * @returns {boolean} True if has on failure
+     */
     has_on_failure: function (processor, name) {
         return !!processor[name]["on_failure"];
     },
@@ -126,21 +132,15 @@ var IngestConverter = {
         return processor[name]["on_failure"];
     },
 
+    /**
+     * Creates an if clause with the tag name
+     * @param tag String tag name to find in [tags] field
+     * @param on_failure_pipeline The on failure pipeline converted to LS to tack on in the conditional
+     * @returns {string} a string representing a conditional logic
+     */
     create_tag_conditional: function (tag, on_failure_pipeline) {
         return "if " + this.quote_string(tag) + " in [tags] {\n" +
                 "   " + on_failure_pipeline + "\n" +
                 "}";
-    },
-
-    get_stdin_input: function () {
-        return "input { \n" +
-            "   stdin {}\n" +
-            "}";
-    },
-
-    get_stdout_output: function () {
-        return "output { \n" +
-            "   stdout { codec => \"rubydebug\" }\n" +
-            "}"
     }
 };

--- a/tools/ingest-converter/src/test/java/org/logstash/ingest/PipelineTest.java
+++ b/tools/ingest-converter/src/test/java/org/logstash/ingest/PipelineTest.java
@@ -13,6 +13,8 @@ public final class PipelineTest extends IngestTest {
         final Collection<String> cases = new ArrayList<>();
         cases.add("ComplexCase1");
         cases.add("ComplexCase2");
+        cases.add("ComplexCase3");
+        cases.add("ComplexCase4");
         GeoIpTest.data().forEach(cases::add);
         DateTest.data().forEach(cases::add);
         GrokTest.data().forEach(cases::add);
@@ -22,6 +24,7 @@ public final class PipelineTest extends IngestTest {
         JsonTest.data().forEach(cases::add);
         RenameTest.data().forEach(cases::add);
         LowercaseTest.data().forEach(cases::add);
+        SetTest.data().forEach(cases::add);
         return cases;
     }
 

--- a/tools/ingest-converter/src/test/java/org/logstash/ingest/SetTest.java
+++ b/tools/ingest-converter/src/test/java/org/logstash/ingest/SetTest.java
@@ -1,0 +1,19 @@
+package org.logstash.ingest;
+
+import java.util.Arrays;
+import org.junit.Test;
+
+import static org.junit.runners.Parameterized.Parameters;
+
+public final class SetTest extends IngestTest {
+
+    @Parameters
+    public static Iterable<String> data() {
+        return Arrays.asList("Set", "DotsInSetField", "SetNumber");
+    }
+
+    @Test
+    public void convertsSetProcessorCorrectly() throws Exception {
+        assertCorrectConversion(Set.class);
+    }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/ingestComplexCase3.json
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/ingestComplexCase3.json
@@ -1,0 +1,35 @@
+{
+  "description": "Pipeline to parse Apache logs",
+  "processors": [
+    {
+      "grok": {
+        "field": "message",
+        "patterns": ["%{COMBINEDAPACHELOG}"],
+        "on_failure" : [
+          {
+            "set" : {
+              "field" : "error",
+              "value" : "field does not exist"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "date": {
+        "field": "timestamp",
+        "target_field": "@timestamp",
+        "formats": [
+          "dd/MMM/YYYY:HH:mm:ss Z"
+        ],
+        "locale": "en"
+      }
+    },
+    {
+      "geoip": {
+        "field": "clientip",
+        "target_field": "geo"
+      }
+    }
+  ]
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/ingestComplexCase4.json
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/ingestComplexCase4.json
@@ -1,0 +1,41 @@
+{
+  "description": "Pipeline to parse Apache logs",
+  "processors": [
+    {
+      "grok": {
+        "field": "message",
+        "patterns": ["%{COMBINEDAPACHELOG}"],
+        "on_failure" : [
+          {
+            "set" : {
+              "field" : "error",
+              "value" : "field does not exist"
+            }
+          },
+          {
+            "convert": {
+              "field" : "client.ip",
+              "type": "integer"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "date": {
+        "field": "timestamp",
+        "target_field": "@timestamp",
+        "formats": [
+          "dd/MMM/YYYY:HH:mm:ss Z"
+        ],
+        "locale": "en"
+      }
+    },
+    {
+      "geoip": {
+        "field": "clientip",
+        "target_field": "geo"
+      }
+    }
+  ]
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/ingestDotsInSetField.json
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/ingestDotsInSetField.json
@@ -1,0 +1,11 @@
+{
+  "description": "SetExample",
+  "processors": [
+    {
+      "set": {
+        "field": "foo.bar",
+        "value": "baz"
+      }
+    }
+  ]
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/ingestSet.json
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/ingestSet.json
@@ -1,0 +1,12 @@
+{
+  "description": "SetExample",
+  "processors": [
+    {
+      "set": {
+        "field": "field1",
+        "value": "bar"
+      }
+    }
+  ]
+}
+

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/ingestSetNumber.json
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/ingestSetNumber.json
@@ -1,0 +1,11 @@
+{
+  "description": "SetExample",
+  "processors": [
+    {
+      "set": {
+        "field": "field1",
+        "value": 5344.4
+      }
+    }
+  ]
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashComplexCase3.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashComplexCase3.conf
@@ -1,0 +1,26 @@
+filter {
+   grok {
+      match => {
+         "message" => "%{COMBINEDAPACHELOG}"
+      }
+   }
+   if "_grokparsefailure" in [tags] {
+         mutate {
+         add_field => {
+            "error" => "field does not exist"
+         }
+      }
+   }
+   date {
+      match => [
+         "timestamp",
+         "dd/MMM/YYYY:HH:mm:ss Z"
+      ]
+      target => "@timestamp"
+      locale => "en"
+   }
+   geoip {
+      source => "clientip"
+      target => "geo"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashComplexCase3.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashComplexCase3.conf
@@ -5,7 +5,7 @@ filter {
       }
    }
    if "_grokparsefailure" in [tags] {
-         mutate {
+      mutate {
          add_field => {
             "error" => "field does not exist"
          }

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashComplexCase4.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashComplexCase4.conf
@@ -5,7 +5,7 @@ filter {
       }
    }
    if "_grokparsefailure" in [tags] {
-         mutate {
+      mutate {
          add_field => {
             "error" => "field does not exist"
          }

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashComplexCase4.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashComplexCase4.conf
@@ -1,0 +1,31 @@
+filter {
+   grok {
+      match => {
+         "message" => "%{COMBINEDAPACHELOG}"
+      }
+   }
+   if "_grokparsefailure" in [tags] {
+         mutate {
+         add_field => {
+            "error" => "field does not exist"
+         }
+      }
+      mutate {
+         convert => {
+            "[client][ip]" => "integer"
+         }
+      }
+   }
+   date {
+      match => [
+         "timestamp",
+         "dd/MMM/YYYY:HH:mm:ss Z"
+      ]
+      target => "@timestamp"
+      locale => "en"
+   }
+   geoip {
+      source => "clientip"
+      target => "geo"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashDotsInSetField.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashDotsInSetField.conf
@@ -1,0 +1,7 @@
+filter {
+   mutate {
+      add_field => {
+         "[foo][bar]" => "baz"
+      }
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashSet.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashSet.conf
@@ -1,0 +1,7 @@
+filter {
+   mutate {
+      add_field => {
+         "field1" => "bar"
+      }
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashSetNumber.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashSetNumber.conf
@@ -1,0 +1,7 @@
+filter {
+   mutate {
+      add_field => {
+         "field1" => 5344.4
+      }
+   }
+}


### PR DESCRIPTION
Ingest `on_failure` processor allows to define a new sub-piplene when a failure
happens in the current processor. Logstash does not have an on_failure but this can
be emulated using the tag and conditional.

Also added a set processor converter which is typically used in `on_failure`.