### PR TITLE
Add `ephemeral_id` on the Logstash instance and for the pipelines.

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -25,7 +25,7 @@ class LogStash::Agent
   include LogStash::Util::Loggable
   STARTED_AT = Time.now.freeze
 
-  attr_reader :metric, :name, :settings, :webserver, :dispatcher
+  attr_reader :metric, :name, :settings, :webserver, :dispatcher, :ephemeral_id
   attr_accessor :logger
 
   # initialize method for LogStash::Agent
@@ -37,6 +37,7 @@ class LogStash::Agent
     @logger = self.class.logger
     @settings = settings
     @auto_reload = setting("config.reload.automatic")
+    @ephemeral_id = SecureRandom.uuid
 
     # Do not use @pipelines directly. Use #with_pipelines which does locking
     @pipelines = {}

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -24,6 +24,7 @@ require "logstash/filter_delegator"
 require "logstash/queue_factory"
 require "logstash/compiler"
 require "logstash/execution_context"
+require "securerandom"
 
 java_import org.logstash.common.DeadLetterQueueFactory
 java_import org.logstash.common.SourceWithMetadata
@@ -32,11 +33,13 @@ java_import org.logstash.common.io.DeadLetterQueueWriter
 module LogStash; class BasePipeline
   include LogStash::Util::Loggable
 
-  attr_reader :settings, :config_str, :config_hash, :inputs, :filters, :outputs, :pipeline_id, :lir, :execution_context
+  attr_reader :settings, :config_str, :config_hash, :inputs, :filters, :outputs, :pipeline_id, :lir, :execution_context, :ephemeral_id
   attr_reader :pipeline_config
 
   def initialize(pipeline_config, namespaced_metric = nil, agent = nil)
     @logger = self.logger
+
+    @ephemeral_id = SecureRandom.uuid
 
     @pipeline_config = pipeline_config
     @config_str = pipeline_config.config_string
@@ -177,6 +180,7 @@ module LogStash; class Pipeline < BasePipeline
       Instrument::NullMetric.new
     end
 
+    @ephemeral_id = SecureRandom.uuid
     @settings = settings
     @reporter = PipelineReporter.new(@logger, self)
     @worker_threads = []

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -81,6 +81,12 @@ describe LogStash::Agent do
     end
   end
 
+  describe "ephemeral_id" do
+    it "create a ephemeral id at creation time" do
+      expect(subject.ephemeral_id).to_not be_nil
+    end
+  end
+
   describe "#execute" do
     let(:config_string) { "input { generator { id => 'old'} } output { }" }
     let(:mock_config_pipeline) { mock_pipeline_config(:main, config_string, pipeline_settings) }

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -124,6 +124,18 @@ describe LogStash::Pipeline do
     pipeline_settings_obj.reset
   end
 
+  describe "#ephemeral_id" do
+    it "creates an ephemeral_id at creation time" do
+      pipeline = mock_pipeline_from_string("input { generator { count =>  1 } } output { null {} }")
+      expect(pipeline.ephemeral_id).to_not be_nil
+      pipeline.close
+
+      second_pipeline = mock_pipeline_from_string("input { generator { count => 1 } } output { null {} }")
+      expect(second_pipeline.ephemeral_id).not_to eq(pipeline.ephemeral_id)
+      second_pipeline.close
+    end
+  end
+
 
   describe "event cancellation" do
     # test harness for https://github.com/elastic/logstash/issues/6055


### PR DESCRIPTION
Theses id wont be persisted between restart of logstash or between
creation of pipeline. When we reload pipelines the ephemeral_id will be
generated again.

Fixes: #7407