### PR TITLE
DON'T MERGE Sequential persistent queue experiment (or persisting 43% faster than current)

### DIFF
--- a/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
@@ -66,6 +66,14 @@ module LogStash; module Util
         @inflight_clocks = {}
         @batch_size = batch_size
         @wait_for = wait_for
+
+        # This should really be the number of workers, but I just set it here to a high number
+        # out of laziness
+        num_files = 20 
+        @file_pool = java.util.concurrent.ArrayBlockingQueue.new(num_files)
+        num_files.times do |t|
+          @file_pool.put(::File.open("/tmp/lsq/#{t}.batch", "ab"))
+        end
       end
 
       def close
@@ -113,7 +121,8 @@ module LogStash; module Util
       # create a new empty batch
       # @return [ReadBatch] a new empty read batch
       def new_batch
-        ReadBatch.new(@queue, @batch_size, @wait_for)
+        file = @file_pool.take()
+        ReadBatch.new(@queue, @batch_size, @wait_for, file)
       end
 
       def read_batch
@@ -144,6 +153,10 @@ module LogStash; module Util
       end
 
       def close_batch(batch)
+        file = batch.file
+        file.truncate(0)
+        @file_pool.put(file)
+
         @mutex.lock
         begin
           # there seems to be concurrency issues with metrics, keep it in the mutex
@@ -185,10 +198,13 @@ module LogStash; module Util
     end
 
     class ReadBatch
-      def initialize(queue, size, wait)
+      attr_reader :file
+
+      def initialize(queue, size, wait, file)
         @queue = queue
         @size = size
         @wait = wait
+        @file = file
 
         @originals = Hash.new
 
@@ -201,13 +217,20 @@ module LogStash; module Util
         @acked_batch = nil
       end
 
+      NEWLINE = "\n"
       def read_next
+
         @size.times do |t|
           event = @queue.poll(@wait)
           return if event.nil? # queue poll timed out
 
+          @file << event.to_json
+          @file << NEWLINE
+
           @originals[event] = true
         end
+
+        @file.fsync
       end
 
       def merge(event)


### PR DESCRIPTION
Hi all,

NOTE: This implementation is very fast, but makes some weird tradeoffs. Please read https://github.com/elastic/logstash/pull/7428#issuecomment-308018679 where I discuss a 'stealing' queue design that does full serialization/deserialization for a modest penalty that still yields a large improvement.

Reading through @original-brownbear excellent research in issues like: https://github.com/elastic/logstash/issues/7317 inspired me to think of what the minimal version of sequential persistence would look like. This isn't a real patch, just an experiment, but I think its telling that its performance is dramatically faster than the current persistent queue.  See the benchmarks below. Note that the `memory` queue is now persistent, I patched the class to actually safely store data to disk. The benchmarks show that the new queue uses 26% less Userspace CPU time than the current persistent queue and 43% less system time for a combined improvement of 28%. Initial runs showed an even more pronounced difference, but now I can't repro it.

```
~/p/logstash (sequential-queue) $ head  config/logstash.yml
queue.type: memory

#queue.type: persisted
#queue.checkpoint.writes: 1024

~/p/logstash (sequential-queue) $
time bin/logstash -b 512 -w 2 -e 'input { generator { count => 1000000 } } output { stdout {} }' | pv -l | wc -l
ERROR StatusLogger No log4j2 configuration file found. Using default configuration: logging only errors to the console.
       47.66 real       107.01 user         8.92 sys       <=>           ]
   1M 0:00:47 [  21k/s] [                                   <=>          ]
 1000007
~/p/logstash (sequential-queue) $ git status^C
~/p/logstash (sequential-queue) $ cat config/log^C
~/p/logstash (sequential-queue) $ head  config/logstash.yml
#queue.type: memory

queue.type: persisted
queue.checkpoint.writes: 1024

time bin/logstash -b 512 -w 1 -e 'input { generator { count => 1000000 } } output { stdout {} }'  | pv -l | wc -l
ERROR StatusLogger No log4j2 configuration file found. Using default configuration: logging only errors to the console.
       67.20 real       144.56 user        14.47 sys                      <=>          ]
   1M 0:01:07 [14.9k/s] [                                                <=>           ]
 1000007
```


One key difference in this minimal implementation is that we don't allow for queues larger than BATCH_SIZE * NUM_WORKERS. It's pretty clear though that with extra work we could add that facility, along with other things.

This implementation looks to me to have the same consistency guarantees as the current queue when operating with checkpoint_writes > 1. To implement the same behavior as checkpoint_writes=1 would require a different code path, but not one with more complexity.

Obviously this code does not include any recovery mechanisms, but that's trivial to write given the approach. Just slurp up all files and replay them.

At any rate, I hope this code proves useful to the ongoing discussion, and lets us think about how we build future components in this area.