### PR TITLE
Centralize the JRuby version

### DIFF
--- a/logstash-core/benchmarks/build.gradle
+++ b/logstash-core/benchmarks/build.gradle
@@ -5,6 +5,7 @@ def versionMap = (Map) (new Yaml()).load(new File("$projectDir/../../versions.ym
 
 description = """Logstash Core Java Benchmarks"""
 version = versionMap['logstash-core']
+String jrubyVersion = versionMap['jruby']['version']
 
 repositories {
   mavenCentral()
@@ -43,7 +44,7 @@ dependencies {
   compile 'com.google.guava:guava:21.0'
   compile 'commons-io:commons-io:2.5'
   runtime 'joda-time:joda-time:2.8.2'
-  runtime 'org.jruby:jruby-core:9.1.10.0'
+  runtime "org.jruby:jruby-core:$jrubyVersion"
 }
 
 javadoc {

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -5,6 +5,7 @@ def versionMap = (Map) (new Yaml()).load(new File("$projectDir/../versions.yml")
 
 description = """Logstash Core Java"""
 version = versionMap['logstash-core']
+String jrubyVersion = versionMap['jruby']['version']
 
 repositories {
     mavenCentral()
@@ -115,5 +116,5 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'net.javacrumbs.json-unit:json-unit:1.9.0'
     testCompile 'org.elasticsearch:securemock:1.2'
-    provided 'org.jruby:jruby-core:9.1.10.0'
+    provided "org.jruby:jruby-core:$jrubyVersion"
 }

--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -1,7 +1,6 @@
 namespace "vendor" do
-  VERSIONS = {
-    "jruby" => { "version" => "9.1.10.0", "sha1" => "ced42e80db30fa0d0ea3bb97c5da860c34d98e3e" },
-  }
+  require "yaml"
+  VERSIONS = YAML.load(File.read(File.join(File.dirname(__FILE__), "..", "versions.yml")))
 
   def vendor(*args)
     return File.join("vendor", *args)

--- a/rakelib/version.rake
+++ b/rakelib/version.rake
@@ -1,7 +1,9 @@
 require 'yaml'
 
+VERSION_FILE = "versions.yml"
+
 def get_versions
-  yaml_versions = YAML.safe_load(IO.read("versions.yml"))
+  yaml_versions = YAML.safe_load(IO.read(VERSION_FILE))
   {
     "logstash" => {
       "location" => File.join("logstash-core", "lib", "logstash", "version.rb"),
@@ -19,6 +21,12 @@ def get_versions
       "current_version" => get_version(File.join("logstash-core-plugin-api", "lib", "logstash-core-plugin-api", "version.rb")),
     }
   }
+end
+
+def update_version_file(hash)
+  existing_content = YAML.safe_load(File.read(VERSION_FILE))
+  existing_content.merge!(hash)
+  IO.write(VERSION_FILE, existing_content.to_yaml)
 end
 
 def get_version(file)
@@ -83,7 +91,7 @@ namespace :version do
         hash[component] = args[:version]
       end
     end
-    IO.write("versions.yml", hash.to_yaml)
+    update_version_file(hash)
     Rake::Task["version:sync"].invoke; Rake::Task["version:sync"].reenable
   end
 
@@ -97,7 +105,7 @@ namespace :version do
         hash[component] = metadata["yaml_version"]
       end
     end
-    IO.write("versions.yml", hash.to_yaml)
+    update_version_file(hash)
     Rake::Task["version:sync"].invoke; Rake::Task["version:sync"].reenable
   end
 

--- a/versions.yml
+++ b/versions.yml
@@ -2,3 +2,6 @@
 logstash: 6.0.0-alpha3
 logstash-core: 6.0.0-alpha3
 logstash-core-plugin-api: 2.1.16
+jruby:
+  version: 9.1.10.0
+  sha1: ced42e80db30fa0d0ea3bb97c5da860c34d98e3e


### PR DESCRIPTION
We have multiple places to declare the jruby version, this commit
centralize everything into the `versions.yml` file. This is now used by
the ruby part and the gradle build file to correctly fetch the jruby
library.