### PR TITLE
Remove *.lock and Gemfile before running any acceptance test

### DIFF
--- a/ci/ci_acceptance.sh
+++ b/ci/ci_acceptance.sh
@@ -8,6 +8,13 @@ export JRUBY_OPTS="-J-Xmx1g"
 
 SELECTED_TEST_SUITE=$1
 
+# The acceptance test in our CI infrastructure doesn't clear the workspace between run
+# this mean the lock of the Gemfile can be sticky from a previous run, before generating any package
+# we will clear them out to make sure we use the latest version of theses files
+# If we don't do this we will run into gem Conflict error.
+rm *.lock
+rm Gemfile
+
 if [[ $SELECTED_TEST_SUITE == $"redhat" ]]; then
   echo "Generating the RPM, make sure you start with a clean environment before generating other packages."
   rake artifact:rpm


### PR DESCRIPTION
The acceptance test in our CI infrastructure doesn't clear the workspace between run
this mean the lock of the Gemfile can be sticky from a previous run, before generating any package
we will clear them out to make sure we use the latest version of theses files from the template.
If we don't do this we will run into gem Conflict error.


See this job: https://logstash-ci.elastic.co/job/elastic+logstash+master+multijob-acceptance/label=metal,suite=debian/lastBuild/console

```
Bundler::Molinillo::VersionConflict: Bundler could not find compatible versions for gem "rubyzip":
  In Gemfile:
    logstash-core (>= 0) java depends on
      rubyzip (~> 1.2.1) java

    rubyzip (~> 1.1.7) java
/var/lib/jenkins/workspace/elastic
```