### PR TITLE
Properly catch connection refused error when installing plugin

### DIFF
--- a/lib/pluginmanager/pack_fetch_strategy/repository.rb
+++ b/lib/pluginmanager/pack_fetch_strategy/repository.rb
@@ -36,10 +36,10 @@ module LogStash module PluginManager module PackFetchStrategy
           PluginManager.ui.debug("Package not found at: #{uri}")
           return nil
         end
-      rescue SocketError => e
+      rescue SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH => e
         # This probably means there is a firewall in place of the proxy is not correctly configured.
         # So lets skip this strategy but log a meaningful errors.
-        PluginManager.ui.debug("SocketError, skipping Elastic pack, exception: #{e}")
+        PluginManager.ui.debug("Network error, skipping Elastic pack, exception: #{e}")
 
         return nil
       end


### PR DESCRIPTION
When artifacts.elastic.co is unreachable (e.g. because of a firewall), `logstash-plugin` will not fall back to a source specified in the `Gemfile`.

Simulating it by setting a bogus IP for it in /etc/hosts gives me:
```
% DEBUG=true bin/logstash-plugin install logstash-input-intercom
DEBUG: exec /Users/cwurm/Products/Logstash/logstash-5.3.0/vendor/jruby/bin/jruby /Users/cwurm/Products/Logstash/logstash-5.3.0/lib/pluginmanager/main.rb install logstash-input-intercom
Looking if package named: logstash-input-intercom exists at https://artifacts.elastic.co/downloads/logstash-plugins/logstash-input-intercom/logstash-input-intercom-5.3.0.zip
Errno::ECONNREFUSED: Connection refused - Connection refused
          initialize at org/jruby/ext/socket/RubyTCPSocket.java:126
                open at org/jruby/RubyIO.java:1197
             connect at /Users/cwurm/Products/Logstash/logstash-5.3.0/vendor/jruby/lib/ruby/1.9/net/http.rb:763
             timeout at org/jruby/ext/timeout/Timeout.java:98
             connect at /Users/cwurm/Products/Logstash/logstash-5.3.0/vendor/jruby/lib/ruby/1.9/net/http.rb:763
            do_start at /Users/cwurm/Products/Logstash/logstash-5.3.0/vendor/jruby/lib/ruby/1.9/net/http.rb:756
               start at /Users/cwurm/Products/Logstash/logstash-5.3.0/vendor/jruby/lib/ruby/1.9/net/http.rb:745
               start at /Users/cwurm/Products/Logstash/logstash-5.3.0/vendor/jruby/lib/ruby/1.9/net/http.rb:557
               start at /Users/cwurm/Products/Logstash/logstash-5.3.0/lib/pluginmanager/utils/http_client.rb:13
  remote_file_exist? at /Users/cwurm/Products/Logstash/logstash-5.3.0/lib/pluginmanager/utils/http_client.rb:23
   get_installer_for at /Users/cwurm/Products/Logstash/logstash-5.3.0/lib/pluginmanager/pack_fetch_strategy/repository.rb:32
              create at /Users/cwurm/Products/Logstash/logstash-5.3.0/lib/pluginmanager/install_strategy_factory.rb:15
                each at org/jruby/RubyArray.java:1613
              create at /Users/cwurm/Products/Logstash/logstash-5.3.0/lib/pluginmanager/install_strategy_factory.rb:14
             execute at /Users/cwurm/Products/Logstash/logstash-5.3.0/lib/pluginmanager/install.rb:30
                 run at /Users/cwurm/Products/Logstash/logstash-5.3.0/vendor/bundle/jruby/1.9/gems/clamp-0.6.5/lib/clamp/command.rb:67
             execute at /Users/cwurm/Products/Logstash/logstash-5.3.0/vendor/bundle/jruby/1.9/gems/clamp-0.6.5/lib/clamp/subcommand/execution.rb:11
                 run at /Users/cwurm/Products/Logstash/logstash-5.3.0/vendor/bundle/jruby/1.9/gems/clamp-0.6.5/lib/clamp/command.rb:67
                 run at /Users/cwurm/Products/Logstash/logstash-5.3.0/vendor/bundle/jruby/1.9/gems/clamp-0.6.5/lib/clamp/command.rb:132
              (root) at /Users/cwurm/Products/Logstash/logstash-5.3.0/lib/pluginmanager/main.rb:46
```

Another example of this is https://github.com/elastic/logstash/issues/6529.