### PR TITLE
MODULES: Fix broken multiple pipelines introduced by the modules implementation

### DIFF
--- a/logstash-core/lib/logstash/bootstrap_check/default_config.rb
+++ b/logstash-core/lib/logstash/bootstrap_check/default_config.rb
@@ -4,84 +4,9 @@ require "logstash/logging"
 
 module LogStash module BootstrapCheck
   class DefaultConfig
-    include LogStash::Util::Loggable
-
-    def initialize(settings)
-      @settings = settings
-    end
-
-    def config_reload?
-      @settings.get("config.reload.automatic")
-    end
-
-    def config_string?
-      @settings.get("config.string")
-    end
-
-    def path_config?
-      @settings.get("path.config")
-    end
-
-    def config_modules?
-      # We want it to report true if not empty
-      !@settings.get("modules").empty?
-    end
-
-    def cli_modules?
-      # We want it to report true if not empty
-      !@settings.get("modules.cli").empty?
-    end
-
-    def both_config_flags?
-      config_string? && path_config?
-    end
-
-    def both_module_configs?
-      cli_modules? && config_modules?
-    end
-
-    def config_defined?
-      config_string? || path_config?
-    end
-
-    def modules_defined?
-      cli_modules? || config_modules?
-    end
-
-    def any_config?
-      config_defined? || modules_defined?
-    end
-
-    def check
-      # Check if both -f and -e are present
-      if both_config_flags?
-        raise LogStash::BootstrapCheckError, I18n.t("logstash.runner.config-string-path-exclusive")
-      end
-
-      # Make note that if modules are configured in both cli and logstash.yml that cli module  
-      # settings will be used, and logstash.yml modules settings ignored
-      if both_module_configs?
-        logger.info(I18n.t("logstash.runner.cli-module-override"))
-      end
-
-      # Check if both config (-f or -e) and modules are configured
-      if config_defined? && modules_defined?
-        raise LogStash::BootstrapCheckError, I18n.t("logstash.runner.config-module-exclusive")
-      end
-
-      # Check for absence of any configuration
-      if !any_config?
-        raise LogStash::BootstrapCheckError, I18n.t("logstash.runner.missing-configuration")
-      end
-
-      # Check to ensure that if configuration auto-reload is used that -f is specified
-      if config_reload? && !path_config?
-        raise LogStash::BootstrapCheckError, I18n.t("logstash.runner.reload-without-config-path")
-      end
-    end
-
     def self.check(settings)
-      DefaultConfig.new(settings).check
+      # currently none of the checks applies if there are multiple pipelines
+      # See LogStash::Config::Source::Base for any further settings conflict checks
     end
   end
 end end

--- a/logstash-core/lib/logstash/config/source/base.rb
+++ b/logstash-core/lib/logstash/config/source/base.rb
@@ -1,8 +1,11 @@
 # encoding: utf-8
 module LogStash module Config module Source
   class Base
+    attr_reader :conflict_messages
+
     def initialize(settings)
       @settings = settings
+      @conflict_messages = []
     end
 
     def pipeline_configs
@@ -11,6 +14,78 @@ module LogStash module Config module Source
 
     def match?
       raise NotImplementedError, "`match?` must be implemented!"
+    end
+
+    def config_conflict?
+      raise NotImplementedError, "`config_conflict?` must be implemented!"
+    end
+
+    def config_reload_automatic_setting
+      @settings.get_setting("config.reload.automatic")
+    end
+
+    def config_reload_automatic
+      config_reload_automatic_setting.value
+    end
+
+    def config_reload_automatic?
+      config_reload_automatic_setting.set?
+    end
+
+    def config_string_setting
+      @settings.get_setting("config.string")
+    end
+
+    def config_string
+      config_string_setting.value
+    end
+
+    def config_string?
+      !(config_string.nil? || config_string.empty?)
+    end
+
+    def config_path_setting
+      @settings.get_setting("path.config")
+    end
+
+    def config_path
+      config_path_setting.value
+    end
+
+    def config_path?
+      !(config_path.nil? || config_path.empty?)
+    end
+
+    def modules_cli_setting
+      @settings.get_setting("modules.cli")
+    end
+
+    def modules_cli
+      modules_cli_setting.value
+    end
+
+    def modules_cli?
+      !(modules_cli.nil? || modules_cli.empty?)
+    end
+
+    def modules_setting
+      @settings.get_setting("modules")
+    end
+
+    def modules
+      modules_setting.value
+    end
+
+    def modules?
+      !(modules.nil? || modules.empty?)
+    end
+
+    def both_module_configs?
+      modules_cli? && modules?
+    end
+
+    def modules_defined?
+      modules_cli? || modules?
     end
   end
 end end end

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -124,10 +124,18 @@ en:
       config-module-exclusive: >-
         Settings 'path.config' (-f) or 'config.string' (-e) can't be used in conjunction with
         (--modules) or the "modules:" block in the logstash.yml file.
+      reload-with-modules: >-
+        Configuration reloading can't be used with command-line or logstash.yml specified modules.
       cli-module-override: >-
         Both command-line and logstash.yml modules configurations detected.
         Using command-line module configuration and ignoring logstash.yml module
         configuration.
+      config-pipelines-failed-read: >-
+        Failed to read pipelines yaml file. Location: %{path}
+      config-pipelines-empty: >-
+        Pipelines YAML file is empty. Location: %{path}
+      config-pipelines-invalid: >-
+        Pipelines YAML file must contain an array of pipeline configs. Found "%{invalid_class}" in %{path}
       reload-without-config-path: >-
         Configuration reloading also requires passing a configuration path with '-f yourlogstash.conf'
       reload-with-config-string: >-

--- a/logstash-core/spec/logstash/config/source/local_spec.rb
+++ b/logstash-core/spec/logstash/config/source/local_spec.rb
@@ -288,13 +288,15 @@ describe LogStash::Config::Source::Local do
     let(:settings) do
       mock_settings(
         "config.string" => "#{filter_block} #{output_block}",
-        "path.config" => config_file
+        "path.config" => config_file,
+        "modules.cli" => [],
+        "modules" => []
       )
     end
 
     # this should be impossible as the bootstrap checks should catch this
     it "raises an exception" do
-      expect { subject.pipeline_configs }.to raise_error
+      expect { subject.pipeline_configs }.to raise_error(LogStash::ConfigurationError)
     end
   end
 

--- a/logstash-core/spec/logstash/config/source/multi_local_spec.rb
+++ b/logstash-core/spec/logstash/config/source/multi_local_spec.rb
@@ -18,10 +18,52 @@ describe LogStash::Config::Source::MultiLocal do
     allow(subject).to receive(:pipelines_yaml_location).and_return(pipelines_yaml_location)
   end
 
+  describe "#config_conflict?" do
+    context "when `config.string` is set" do
+      let(:settings) do
+        mock_settings("config.string" => "input {} output {}")
+      end
+      it "returns false" do
+        expect(subject.config_conflict?).to be_falsey
+        expect(subject.conflict_messages).to be_empty
+      end
+    end
+
+    context "when `config.path` is set" do
+      let(:config_file) { temporary_file("") }
+
+      let(:settings) do
+        mock_settings("path.config" => config_file)
+      end
+      it "returns false" do
+        expect(subject.config_conflict?).to be_falsey
+        expect(subject.conflict_messages).to be_empty
+      end
+    end
+
+    context "when `pipelines.yml` is not set" do
+      let(:pipelines_yaml_location) { ::File.join(Stud::Temporary.pathname, "pipelines.yml") }
+      it "returns true with messages" do
+        expect(subject.config_conflict?).to be_truthy
+        expect(subject.conflict_messages).to include(/Failed to read pipelines yaml file. Location:/)
+      end
+    end
+
+    context "when `pipelines.yml` is only comments" do
+      before(:each) do
+        allow(subject).to receive(:read_pipelines_from_yaml).and_return(::YAML.load("# blah\n# blah\n# blah\n"))
+      end
+      it "returns true with messages" do
+        expect(subject.config_conflict?).to be_truthy
+        expect(subject.conflict_messages).to include(/Pipelines YAML file is empty. Location:/)
+      end
+    end
+  end
+
   describe "#match?" do
     context "when `config.string` is set" do
       let(:settings) do
-        mock_settings("config.string" => "")
+        mock_settings("config.string" => "input {} output {}")
       end
       it "returns false" do
         expect(subject.match?).to be_falsey
@@ -42,27 +84,31 @@ describe LogStash::Config::Source::MultiLocal do
 
     context "when both `config.string` and `path.config` are set" do
       let(:settings) do
-        mock_settings("config.string" => "", "path.config" => temporary_file(""))
+        mock_settings("config.string" => "input {} output {}", "path.config" => temporary_file("input {} output {}"))
       end
       it "returns false" do
         expect(subject.match?).to be_falsey
       end
     end
 
-    context "when neither `config.path` nor `path.config` are set`" do
+    context "when neither `config.path` nor `path.config` are set` and pipelines.yml has configs" do
+      before do
+        allow(subject).to receive(:invalid_pipelines_detected?).and_return(false)
+      end
       it "returns true" do
         expect(subject.match?).to be_truthy
       end
     end
   end
+
   describe "#detect_duplicate_pipelines" do
     let(:retrieved_pipelines) { [{}] }
     let(:retrieved_pipelines_configs) { retrieved_pipelines.map {|h| mock_settings(h) } }
     context "when there are duplicate pipeline ids" do
       let(:retrieved_pipelines) do
         [
-          {"pipeline.id" => "main", "config.string" => ""},
-          {"pipeline.id" => "main", "config.string" => ""},
+          {"pipeline.id" => "main", "config.string" => "input {} output {}"},
+          {"pipeline.id" => "main", "config.string" => "input {} output {}"},
         ]
       end
       it "should raise a ConfigurationError" do
@@ -72,8 +118,8 @@ describe LogStash::Config::Source::MultiLocal do
     context "when there are no duplicate pipeline ids" do
       let(:retrieved_pipelines) do
         [
-          {"pipeline.id" => "main", "config.string" => ""},
-          {"pipeline.id" => "backup", "config.string" => ""},
+          {"pipeline.id" => "main", "config.string" => "input {} output {}"},
+          {"pipeline.id" => "backup", "config.string" => "input {} output {}"},
         ]
       end
       it "should not raise an error" do


### PR DESCRIPTION
If you define your pipeline in the pipelines.yml and your start Logstash you will get:
```
ERROR: No configuration file was specified. Perhaps you forgot to provide the '-f yourlogstash.conf' flag?
```
Fixes #7369 