### PR TITLE
Enhance ingest convert to add input/output

### DIFF
--- a/tools/ingest-converter/src/main/java/org/logstash/ingest/JsUtil.java
+++ b/tools/ingest-converter/src/main/java/org/logstash/ingest/JsUtil.java
@@ -68,7 +68,7 @@ final class JsUtil {
         ).withRequiredArg().ofType(URI.class).required().forHelp();
         final OptionSpec<Void> appendStdio = parser.accepts(
             "append-stdio",
-            "Flag to append stdin and stdout as outputs instead of the ES default."
+            "Flag to append stdin and stdout as outputs instead of the default ES output."
         ).forHelp();
         try {
             final OptionSet options;

--- a/tools/ingest-converter/src/main/java/org/logstash/ingest/JsUtil.java
+++ b/tools/ingest-converter/src/main/java/org/logstash/ingest/JsUtil.java
@@ -66,6 +66,10 @@ final class JsUtil {
             "output",
             "Output Logstash DSL file location URI. Only supports 'file://' as URI schema."
         ).withRequiredArg().ofType(URI.class).required().forHelp();
+        final OptionSpec<Void> appendStdio = parser.accepts(
+            "append-stdio",
+            "Flag to append stdin and stdout as outputs instead of the ES default."
+        ).forHelp();
         try {
             final OptionSet options;
             try {
@@ -78,7 +82,7 @@ final class JsUtil {
             Files.write(
                 Paths.get(options.valueOf(output)),
                 ((String) ((Invocable) engine).invokeFunction(
-                    jsFunc, input(options.valueOf(input))
+                    jsFunc, input(options.valueOf(input)), options.has(appendStdio)
                 )).getBytes(StandardCharsets.UTF_8)
             );
         } catch (final IOException ex) {

--- a/tools/ingest-converter/src/main/resources/ingest-append.js
+++ b/tools/ingest-converter/src/main/resources/ingest-append.js
@@ -21,7 +21,7 @@ var IngestAppend = {
 /**
  * Converts Ingest Append JSON to LS mutate filter.
  */
-function ingest_append_to_logstash(json) {
+function ingest_append_to_logstash(json, append_stdio) {
 
     function map_processor(processor) {
 
@@ -32,5 +32,9 @@ function ingest_append_to_logstash(json) {
         );
     }
 
-    return IngestConverter.filters_to_file(JSON.parse(json)["processors"].map(map_processor));
+    var filters_pipeline = JSON.parse(json)["processors"].map(map_processor);
+    return IngestConverter.filters_to_file([
+        IngestConverter.append_io_plugins(filters_pipeline, append_stdio)
+        ]
+    );
 }

--- a/tools/ingest-converter/src/main/resources/ingest-convert.js
+++ b/tools/ingest-converter/src/main/resources/ingest-convert.js
@@ -15,7 +15,7 @@ var IngestConvert = {
 /**
  * Converts Ingest Convert JSON to LS Date filter.
  */
-function ingest_convert_to_logstash(json) {
+function ingest_convert_to_logstash(json, append_stdio) {
 
     function map_processor(processor) {
 
@@ -26,5 +26,9 @@ function ingest_convert_to_logstash(json) {
         );
     }
 
-    return IngestConverter.filters_to_file(JSON.parse(json)["processors"].map(map_processor));
+    var filters_pipeline = JSON.parse(json)["processors"].map(map_processor);
+    return IngestConverter.filters_to_file([
+        IngestConverter.append_io_plugins(filters_pipeline, append_stdio)
+        ]
+    );
 }

--- a/tools/ingest-converter/src/main/resources/ingest-date.js
+++ b/tools/ingest-converter/src/main/resources/ingest-date.js
@@ -41,7 +41,7 @@ var IngestDate = {
 /**
  * Converts Ingest Date JSON to LS Date filter.
  */
-function ingest_to_logstash_date(json) {
+function ingest_to_logstash_date(json, append_stdio) {
 
     function map_processor(processor) {
 
@@ -52,5 +52,9 @@ function ingest_to_logstash_date(json) {
         );
     }
 
-    return IngestConverter.filters_to_file(JSON.parse(json)["processors"].map(map_processor));
+    var filters_pipeline = JSON.parse(json)["processors"].map(map_processor);
+    return IngestConverter.filters_to_file([
+        IngestConverter.append_io_plugins(filters_pipeline, append_stdio)
+        ]
+    );
 }

--- a/tools/ingest-converter/src/main/resources/ingest-geoip.js
+++ b/tools/ingest-converter/src/main/resources/ingest-geoip.js
@@ -33,7 +33,7 @@ var IngestGeoIp = {
 /**
  * Converts Ingest JSON to LS Grok.
  */
-function ingest_to_logstash_geoip(json) {
+function ingest_to_logstash_geoip(json, append_stdio) {
 
     function map_processor(processor) {
 
@@ -42,5 +42,9 @@ function ingest_to_logstash_geoip(json) {
         )
     }
 
-    return IngestConverter.filters_to_file(JSON.parse(json)["processors"].map(map_processor));
+    var filters_pipeline = JSON.parse(json)["processors"].map(map_processor);
+    return IngestConverter.filters_to_file([
+        IngestConverter.append_io_plugins(filters_pipeline, append_stdio)
+        ]
+    );
 }

--- a/tools/ingest-converter/src/main/resources/ingest-grok.js
+++ b/tools/ingest-converter/src/main/resources/ingest-grok.js
@@ -48,7 +48,7 @@ var IngestGrok = {
 /**
  * Converts Ingest JSON to LS Grok.
  */
-function ingest_to_logstash_grok(json) {
+function ingest_to_logstash_grok(json, append_stdio) {
 
     function map_processor(processor) {
 
@@ -57,5 +57,9 @@ function ingest_to_logstash_grok(json) {
         )
     }
 
-    return IngestConverter.filters_to_file(JSON.parse(json)["processors"].map(map_processor));
+    var filters_pipeline = JSON.parse(json)["processors"].map(map_processor);
+    return IngestConverter.filters_to_file([
+        IngestConverter.append_io_plugins(filters_pipeline, append_stdio)
+        ]
+    );
 }

--- a/tools/ingest-converter/src/main/resources/ingest-gsub.js
+++ b/tools/ingest-converter/src/main/resources/ingest-gsub.js
@@ -16,7 +16,7 @@ var IngestGsub = {
 /**
  * Converts Ingest JSON to LS Grok.
  */
-function ingest_to_logstash_gsub(json) {
+function ingest_to_logstash_gsub(json, append_stdio) {
 
     function map_processor(processor) {
 
@@ -25,5 +25,9 @@ function ingest_to_logstash_gsub(json) {
         )
     }
 
-    return IngestConverter.filters_to_file(JSON.parse(json)["processors"].map(map_processor));
+    var filters_pipeline = JSON.parse(json)["processors"].map(map_processor);
+    return IngestConverter.filters_to_file([
+        IngestConverter.append_io_plugins(filters_pipeline, append_stdio)
+        ]
+    );
 }

--- a/tools/ingest-converter/src/main/resources/ingest-json.js
+++ b/tools/ingest-converter/src/main/resources/ingest-json.js
@@ -31,7 +31,7 @@ var IngestJson = {
 /**
  * Converts Ingest json processor to LS json filter.
  */
-function ingest_json_to_logstash(json) {
+function ingest_json_to_logstash(json, append_stdio) {
 
     function map_processor(processor) {
 
@@ -40,5 +40,9 @@ function ingest_json_to_logstash(json) {
         )
     }
 
-    return IngestConverter.filters_to_file(JSON.parse(json)["processors"].map(map_processor));
+    var filters_pipeline = JSON.parse(json)["processors"].map(map_processor);
+    return IngestConverter.filters_to_file([
+        IngestConverter.append_io_plugins(filters_pipeline, append_stdio)
+        ]
+    );
 }

--- a/tools/ingest-converter/src/main/resources/ingest-lowercase.js
+++ b/tools/ingest-converter/src/main/resources/ingest-lowercase.js
@@ -15,7 +15,7 @@ var IngestLowercase = {
 /**
  * Converts Ingest Lowercase JSON to LS mutate filter.
  */
-function ingest_lowercase_to_logstash(json) {
+function ingest_lowercase_to_logstash(json, append_stdio) {
 
     function map_processor(processor) {
 
@@ -26,5 +26,9 @@ function ingest_lowercase_to_logstash(json) {
         );
     }
 
-    return IngestConverter.filters_to_file(JSON.parse(json)["processors"].map(map_processor));
+    var filters_pipeline = JSON.parse(json)["processors"].map(map_processor);
+    return IngestConverter.filters_to_file([
+        IngestConverter.append_io_plugins(filters_pipeline, append_stdio)
+        ]
+    );
 }

--- a/tools/ingest-converter/src/main/resources/ingest-pipeline.js
+++ b/tools/ingest-converter/src/main/resources/ingest-pipeline.js
@@ -1,7 +1,7 @@
 /**
  * Converts Ingest JSON to LS Grok.
  */
-function ingest_pipeline_to_logstash(json) {
+function ingest_pipeline_to_logstash(json, append_stdio) {
 
     function handle_on_failure_pipeline(on_failure_json, tag_name) {
 
@@ -74,10 +74,11 @@ function ingest_pipeline_to_logstash(json) {
         return IngestConverter.join_hash_fields(filter_blocks);
     }
 
+    var logstash_pipeline = IngestConverter.filter_hash(
+        IngestConverter.join_hash_fields(JSON.parse(json)["processors"].map(map_processor))
+    );
     return IngestConverter.filters_to_file([
-            IngestConverter.filter_hash(
-                IngestConverter.join_hash_fields(JSON.parse(json)["processors"].map(map_processor))
-            )
+        IngestConverter.append_io_plugins(logstash_pipeline, append_stdio)
         ]
     );
 }

--- a/tools/ingest-converter/src/main/resources/ingest-rename.js
+++ b/tools/ingest-converter/src/main/resources/ingest-rename.js
@@ -15,7 +15,7 @@ var IngestRename = {
 /**
  * Converts Ingest Rename JSON to LS mutate filter.
  */
-function ingest_rename_to_logstash(json) {
+function ingest_rename_to_logstash(json, append_stdio) {
 
     function map_processor(processor) {
 
@@ -26,5 +26,9 @@ function ingest_rename_to_logstash(json) {
         );
     }
 
-    return IngestConverter.filters_to_file(JSON.parse(json)["processors"].map(map_processor));
+    var filters_pipeline = JSON.parse(json)["processors"].map(map_processor);
+    return IngestConverter.filters_to_file([
+        IngestConverter.append_io_plugins(filters_pipeline, append_stdio)
+        ]
+    );
 }

--- a/tools/ingest-converter/src/main/resources/ingest-set.js
+++ b/tools/ingest-converter/src/main/resources/ingest-set.js
@@ -21,7 +21,7 @@ var IngestSet = {
 /**
  * Converts Ingest Set JSON to LS mutate filter.
  */
-function ingest_set_to_logstash(json) {
+function ingest_set_to_logstash(json, append_stdio) {
 
     function map_processor(processor) {
 
@@ -32,5 +32,9 @@ function ingest_set_to_logstash(json) {
         );
     }
 
-    return IngestConverter.filters_to_file(JSON.parse(json)["processors"].map(map_processor));
+    var filters_pipeline = JSON.parse(json)["processors"].map(map_processor);
+    return IngestConverter.filters_to_file([
+        IngestConverter.append_io_plugins(filters_pipeline, append_stdio)
+        ]
+    );
 }

--- a/tools/ingest-converter/src/main/resources/ingest-shared.js
+++ b/tools/ingest-converter/src/main/resources/ingest-shared.js
@@ -167,19 +167,11 @@ var IngestConverter = {
             "}");
     },
 
-    get_newline: function () {
-        return "\n";
-    },
-
     append_io_plugins: function(filters_pipeline, append_stdio) {
         if (append_stdio === true) {
-            return IngestConverter.get_stdin_input() +
-                IngestConverter.get_newline() +
-                filters_pipeline +
-                IngestConverter.get_newline() +
-                IngestConverter.get_stdout_output();
+            return [IngestConverter.get_stdin_input(), filters_pipeline, IngestConverter.get_stdout_output()].join("\n");
         } else {
-            return filters_pipeline + IngestConverter.get_newline() + IngestConverter.get_elasticsearch_output();
+            return [filters_pipeline, IngestConverter.get_elasticsearch_output()].join("\n");
         }
     }
 };

--- a/tools/ingest-converter/src/main/resources/ingest-shared.js
+++ b/tools/ingest-converter/src/main/resources/ingest-shared.js
@@ -142,5 +142,44 @@ var IngestConverter = {
         return "if " + this.quote_string(tag) + " in [tags] {\n" +
                 on_failure_pipeline + "\n" +
                 "}";
+    },
+
+    get_elasticsearch_output: function () {
+        return this.fix_indent("output {\n" +
+            "elasticsearch {\n" +
+            "hosts => \"localhost\"\n" +
+            "}\n" +
+            "}");
+    },
+
+    get_stdin_input: function () {
+        return this.fix_indent("input {\n" +
+            "stdin {\n" +
+            "}\n" +
+            "}");
+    },
+
+    get_stdout_output: function () {
+        return this.fix_indent("output {\n" +
+            "stdout {\n" +
+            "codec => \"rubydebug\"\n" +
+            "}\n" +
+            "}");
+    },
+
+    get_newline: function () {
+        return "\n";
+    },
+
+    append_io_plugins: function(filters_pipeline, append_stdio) {
+        if (append_stdio === true) {
+            return IngestConverter.get_stdin_input() +
+                IngestConverter.get_newline() +
+                filters_pipeline +
+                IngestConverter.get_newline() +
+                IngestConverter.get_stdout_output();
+        } else {
+            return filters_pipeline + IngestConverter.get_newline() + IngestConverter.get_elasticsearch_output();
+        }
     }
 };

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashAppend.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashAppend.conf
@@ -8,3 +8,8 @@ filter {
       }
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashAppendScalar.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashAppendScalar.conf
@@ -5,3 +5,8 @@ filter {
       }
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashComplexCase1.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashComplexCase1.conf
@@ -39,3 +39,8 @@ filter {
       }
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashComplexCase2.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashComplexCase2.conf
@@ -26,3 +26,8 @@ filter {
       }
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashComplexCase3.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashComplexCase3.conf
@@ -24,3 +24,8 @@ filter {
       target => "geo"
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashComplexCase4.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashComplexCase4.conf
@@ -29,3 +29,8 @@ filter {
       target => "geo"
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashConvert.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashConvert.conf
@@ -5,3 +5,8 @@ filter {
       }
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashConvertBoolean.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashConvertBoolean.conf
@@ -5,3 +5,8 @@ filter {
       }
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashConvertString.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashConvertString.conf
@@ -5,3 +5,8 @@ filter {
       }
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashDate.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashDate.conf
@@ -8,3 +8,8 @@ filter {
       target => "timestamp"
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashDateExtraFields.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashDateExtraFields.conf
@@ -10,3 +10,8 @@ filter {
       locale => "en"
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashDotsInAppendField.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashDotsInAppendField.conf
@@ -8,3 +8,8 @@ filter {
       }
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashDotsInConvertField.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashDotsInConvertField.conf
@@ -5,3 +5,8 @@ filter {
       }
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashDotsInDateField.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashDotsInDateField.conf
@@ -10,3 +10,8 @@ filter {
       locale => "en"
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashDotsInGeoIpField.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashDotsInGeoIpField.conf
@@ -8,3 +8,8 @@ filter {
       ]
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashDotsInJsonField.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashDotsInJsonField.conf
@@ -4,3 +4,8 @@ filter {
       target => "[bar][json_target]"
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashDotsInRenameField.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashDotsInRenameField.conf
@@ -5,3 +5,8 @@ filter {
       }
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashDotsInSetField.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashDotsInSetField.conf
@@ -5,3 +5,8 @@ filter {
       }
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashGeoIpSimple.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashGeoIpSimple.conf
@@ -8,3 +8,8 @@ filter {
       ]
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashGrok.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashGrok.conf
@@ -8,3 +8,8 @@ filter {
       }
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashGrokPatternDefinition.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashGrokPatternDefinition.conf
@@ -11,3 +11,8 @@ filter {
       }
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashGsubSimple.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashGsubSimple.conf
@@ -5,3 +5,8 @@ filter {
       ]
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashJson.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashJson.conf
@@ -3,3 +3,8 @@ filter {
       source => "string_source"
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashJsonExtraFields.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashJsonExtraFields.conf
@@ -4,3 +4,8 @@ filter {
       target => "json_target"
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashLowercaseDots.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashLowercaseDots.conf
@@ -3,3 +3,8 @@ filter {
       lowercase => "[foo][bar]"
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashLowercaseSimple.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashLowercaseSimple.conf
@@ -3,3 +3,8 @@ filter {
       lowercase => "foo"
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashRename.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashRename.conf
@@ -5,3 +5,8 @@ filter {
       }
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashSet.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashSet.conf
@@ -5,3 +5,8 @@ filter {
       }
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashSetNumber.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashSetNumber.conf
@@ -5,3 +5,8 @@ filter {
       }
    }
 }
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}


### PR DESCRIPTION
Since ingest's implicit output is Elasticsearch, we should mirror that behavior by creating an ES output when converting a pipeline.

Also, added a flag to append `stdin` and `stdout` if a user chooses to. This makes manual testing easier.