### PR TITLE
MINOR: Update docker-api gem to latest version to improve stability

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -22,7 +22,7 @@ gem "gems", "~> 0.8.3", :group => :build
 gem "rack-test", :require => "rack/test", :group => :development
 gem "flores", "~> 0.0.6", :group => :development
 gem "term-ansicolor", "~> 1.3.2", :group => :development
-gem "docker-api", "1.31.0", :group => :development
+gem "docker-api", "1.33.4", :group => :development
 gem "pleaserun", "~>0.0.28"
 gem "logstash-input-heartbeat"
 gem "logstash-codec-collectd"


### PR DESCRIPTION
Trivial change, but now that we have JRuby 9k I think we should upgrade this dependency in `master` to hopefully improve stability. 
I'm still seeing some random failures from the Docker ITs.