### PR TITLE
Properly hash when no original source is present.

### DIFF
--- a/logstash-core/spec/logstash/compiler/compiler_spec.rb
+++ b/logstash-core/spec/logstash/compiler/compiler_spec.rb
@@ -46,6 +46,10 @@ describe LogStash::Compiler do
 
       subject(:pipeline) { described_class.compile_sources(*sources_with_metadata) }
 
+      it "should generate a hash" do
+        expect(pipeline.unique_hash).to be_a(String)
+      end
+
       it "should compile cleanly" do
         expect(pipeline).to be_a(org.logstash.config.ir.PipelineIR)
       end

--- a/logstash-core/src/main/java/org/logstash/config/ir/PipelineIR.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/PipelineIR.java
@@ -1,5 +1,6 @@
 package org.logstash.config.ir;
 
+import org.logstash.common.Util;
 import org.logstash.config.ir.graph.Graph;
 import org.logstash.config.ir.graph.PluginVertex;
 import org.logstash.config.ir.graph.QueueVertex;
@@ -51,6 +52,8 @@ public class PipelineIR implements Hashable {
         this.graph.validate();
 
         if (this.getOriginalSource() != null && this.getOriginalSource().matches("^\\S+$")) {
+            uniqueHash = Util.digest(this.getOriginalSource());
+        } else {
             uniqueHash = this.graph.uniqueHash();
         }
     }

--- a/logstash-core/src/test/java/org/logstash/config/ir/PipelineIRTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/PipelineIRTest.java
@@ -1,9 +1,13 @@
 package org.logstash.config.ir;
 
 import org.junit.Test;
+import org.logstash.common.Util;
 import org.logstash.config.ir.graph.Graph;
 
+import java.nio.channels.Pipe;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.logstash.config.ir.DSL.*;
 import static org.logstash.config.ir.PluginDefinition.Type.*;
@@ -12,21 +16,42 @@ import static org.logstash.config.ir.PluginDefinition.Type.*;
  * Created by andrewvc on 9/20/16.
  */
 public class PipelineIRTest {
-    @Test
-    public void testPipelineCreation() throws InvalidIRException {
-        Graph inputSection = iComposeParallel(iPlugin(INPUT, "generator"), iPlugin(INPUT, "stdin")).toGraph();
-        Graph filterSection = iIf(eEq(eEventValue("[foo]"), eEventValue("[bar]")),
+    public Graph makeInputSection() throws InvalidIRException {
+        return iComposeParallel(iPlugin(INPUT, "generator"), iPlugin(INPUT, "stdin")).toGraph();
+    }
+
+    public Graph makeFilterSection() throws InvalidIRException {
+        return iIf(eEq(eEventValue("[foo]"), eEventValue("[bar]")),
                                     iPlugin(FILTER, "grok"),
                                     iPlugin(FILTER, "kv")).toGraph();
-        Graph outputSection = iIf(eGt(eEventValue("[baz]"), eValue(1000)),
+    }
+
+    public Graph makeOutputSection() throws InvalidIRException {
+        return iIf(eGt(eEventValue("[baz]"), eValue(1000)),
                                     iComposeParallel(
                                             iPlugin(OUTPUT, "s3"),
                                             iPlugin(OUTPUT, "elasticsearch")),
                                     iPlugin(OUTPUT, "stdout")).toGraph();
+    }
 
-        PipelineIR pipelineIR = new PipelineIR(inputSection, filterSection, outputSection);
+    @Test
+    public void testPipelineCreation() throws InvalidIRException {
+        PipelineIR pipelineIR = new PipelineIR(makeInputSection(), makeFilterSection(), makeOutputSection());
         assertEquals(2, pipelineIR.getInputPluginVertices().size());
         assertEquals(2, pipelineIR.getFilterPluginVertices().size());
         assertEquals(3, pipelineIR.getOutputPluginVertices().size());
+    }
+
+    @Test
+    public void hashingWithoutOriginalSource() throws InvalidIRException {
+        PipelineIR pipelineIR = new PipelineIR(makeInputSection(), makeFilterSection(), makeOutputSection());
+        assertEquals(pipelineIR.uniqueHash(), pipelineIR.getGraph().uniqueHash());
+    }
+
+    @Test
+    public void hashingWithOriginalSource() throws InvalidIRException {
+        String source = "mysource";
+        PipelineIR pipelineIR = new PipelineIR(makeInputSection(), makeFilterSection(), makeOutputSection(), source);
+        assertEquals(pipelineIR.uniqueHash(), Util.digest(source));
     }
 }


### PR DESCRIPTION
This corrects a mistake where the digest of the string source should be used when present, and the hash of the graph should be used when not.