### PR TITLE
Set default entropy source to /dev/urandom

### DIFF
--- a/config/jvm.options
+++ b/config/jvm.options
@@ -72,3 +72,6 @@
 # log GC status to a file with time stamps
 # ensure the directory exists
 #-Xloggc:${LS_GC_LOG_FILE}
+
+# Entropy source for randomness
+-Djava.security.egd=file:/dev/urandom


### PR DESCRIPTION
This changes the Java-wide from the default of /dev/random. The reason
for this chnage is that /dev/random can block if there is insufficient
entropy available, and this blocking can cause Logstash to stall on
startup for many many minutes.

Fixes #6117.

This scenario (no entropy) seems especially prone to occur on virtual
machines.

Related: https://github.com/jruby/jruby/wiki/Improving-startup-time#ensure-your-system-has-adequate-entropy

On Windows, I was not sure if this would work, but the JDK source tree
says this:

    On Windows systems, specifying the URLs "file:/dev/random" or
    "file:/dev/urandom" will enable the native Microsoft CryptoAPI seeding
    mechanism for SHA1PRNG.

So defaulting to /dev/urandom should still do the right thing on
Windows.

I also checked to see if other unix-likes had /dev/urandom, and
according to Wikipedia[1], Linux, FreeBSD, OpenBSD, OSX, Solaris,
NetBSD, and others all have urandom.

[1] https://en.wikipedia.org/wiki//dev/random