### PR TITLE
Small typo in the pipelines.yml

### DIFF
--- a/config/pipelines.yml
+++ b/config/pipelines.yml
@@ -9,7 +9,7 @@
 # - pipeline.id: test
 #   pipeline.workers: 1
 #   pipeline.batch.size: 1
-#   config.string: "input { generator {} } filter { sleep { time => 1 } } output { stdout { codec => dots } }
+#   config.string: "input { generator {} } filter { sleep { time => 1 } } output { stdout { codec => dots } }"
 # - pipeline.id: another_test
 #   queue.type: persisted
 #   path.config: "/tmp/logstash/*.config"


### PR DESCRIPTION
The `config.string` option was not correctly closed with a double quote