### PR TITLE
Add the plugin titleabbrev

### DIFF
--- a/docs/include/plugin_header.asciidoc
+++ b/docs/include/plugin_header.asciidoc
@@ -1,3 +1,7 @@
+++++
+<titleabbrev>{plugin}</titleabbrev>
+++++
+
 * Plugin version: {version}
 * Released on: {release_date}
 * {changelog_url}[Changelog]


### PR DESCRIPTION
To have better search result we now use the full title in the plugin
main doc, but we also need an abbreviation.

Ref: #7439