### PR TITLE
upgrade jruby to 1.7.27

### DIFF
--- a/Gemfile.jruby-1.9.lock.release
+++ b/Gemfile.jruby-1.9.lock.release
@@ -11,7 +11,7 @@ PATH
       i18n (= 0.6.9)
       jar-dependencies
       jrjackson (~> 0.4.0)
-      jruby-openssl (= 0.9.16)
+      jruby-openssl (= 0.9.19)
       manticore (>= 0.5.4, < 1.0.0)
       minitar (~> 0.5.4)
       pry (~> 0.10.1)
@@ -126,7 +126,7 @@ GEM
       concurrent-ruby
     jmespath (1.3.1)
     jrjackson (0.4.2-java)
-    jruby-openssl (0.9.16-java)
+    jruby-openssl (0.9.19-java)
     jruby-stdin-channel (0.2.0-java)
     json (1.8.6-java)
     kramdown (1.13.2)

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |gem|
   
   gem.add_runtime_dependency "sinatra", '~> 1.4', '>= 1.4.6'
   gem.add_runtime_dependency 'puma', '~> 2.16'
-  gem.add_runtime_dependency "jruby-openssl", "0.9.16" # >= 0.9.13 Required to support TLSv1.2
+  gem.add_runtime_dependency "jruby-openssl", "0.9.19" # >= 0.9.13 Required to support TLSv1.2
   gem.add_runtime_dependency "chronic_duration", "0.10.6"
 
   # TODO(sissel): Treetop 1.5.x doesn't seem to work well, but I haven't

--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -1,6 +1,6 @@
 namespace "vendor" do
   VERSIONS = {
-    "jruby" => { "version" => "1.7.25", "sha1" => "cd15aef419f97cff274491e53fcfb8b88ec36785" },
+    "jruby" => { "version" => "1.7.27", "sha1" => "4a24fe103d3735b23cc58668dec711857125a6f3" },
   }
 
   def vendor(*args)


### PR DESCRIPTION
this solves https://github.com/elastic/logstash/issues/7477

Also fixes https://github.com/elastic/logstash/issues/5507: from the jruby changelog "Backport securerandom" https://github.com/jruby/jruby/pull/4149"

This should be merged to 5.x 5.5 and 5.4