### PR TITLE
Hash source code when spaces are present

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/PipelineIR.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/PipelineIR.java
@@ -51,7 +51,7 @@ public class PipelineIR implements Hashable {
 
         this.graph.validate();
 
-        if (this.getOriginalSource() != null && this.getOriginalSource().matches("^\\S+$")) {
+        if (this.getOriginalSource() != null && !this.getOriginalSource().matches("^\\s+$")) {
             uniqueHash = Util.digest(this.getOriginalSource());
         } else {
             uniqueHash = this.graph.uniqueHash();

--- a/logstash-core/src/test/java/org/logstash/config/ir/PipelineIRTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/PipelineIRTest.java
@@ -50,7 +50,7 @@ public class PipelineIRTest {
 
     @Test
     public void hashingWithOriginalSource() throws InvalidIRException {
-        String source = "mysource";
+        String source = "input { stdin {} } output { stdout {} }";
         PipelineIR pipelineIR = new PipelineIR(makeInputSection(), makeFilterSection(), makeOutputSection(), source);
         assertEquals(pipelineIR.uniqueHash(), Util.digest(source));
     }


### PR DESCRIPTION
We were falling back to the graph hash (slow) algorithm anytime spaces were present in source code due to a mixed-up regexp. This clears up that issue.

The test, sadly, had a non-realistic string which didn't catch this error!