### PR TITLE
Fix reverseDepthFirst(Vertex) to search backward, not forward

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/algorithms/DepthFirst.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/algorithms/DepthFirst.java
@@ -24,7 +24,7 @@ public class DepthFirst {
     }
 
     public static Stream<Vertex> reverseDepthFirst(Vertex v) {
-        return depthFirst(Collections.singleton(v));
+        return reverseDepthFirst(Collections.singleton(v));
     }
 
     public static Stream<Vertex> depthFirst(Collection<Vertex> v) {

--- a/logstash-core/src/test/java/org/logstash/config/ir/graph/algorithms/DepthFirstTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/graph/algorithms/DepthFirstTest.java
@@ -1,5 +1,6 @@
 package org.logstash.config.ir.graph.algorithms;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.logstash.config.ir.IRHelpers;
 import org.logstash.config.ir.InvalidIRException;
@@ -16,13 +17,40 @@ import static junit.framework.TestCase.assertEquals;
  * Created by andrewvc on 1/5/17.
  */
 public class DepthFirstTest {
+    Graph g = Graph.empty();
+    final AtomicInteger visitCount = new AtomicInteger();
+    final List<Vertex> visited = new ArrayList<>();
+
+    @Before
+    public void setup() throws InvalidIRException {
+        g.chainVertices(
+                IRHelpers.createTestVertex(),
+                IRHelpers.createTestVertex(),
+                IRHelpers.createTestVertex()
+        );
+    }
+
     @Test
-    public void testDFSBasic() throws InvalidIRException {
-        Graph g = Graph.empty();
-        g.chainVertices(IRHelpers.createTestVertex(), IRHelpers.createTestVertex(), IRHelpers.createTestVertex());
-        final AtomicInteger visitCount = new AtomicInteger();
-        final List<Vertex> visited = new ArrayList<>();
+    public void testDFSBasic() {
         DepthFirst.depthFirst(g).forEach(v -> visitCount.incrementAndGet());
+        assertEquals("It should visit each node once", visitCount.get(), 3);
+    }
+
+    @Test
+    public void testDFSReverse() {
+        DepthFirst.reverseDepthFirst(g).forEach(v -> visitCount.incrementAndGet());
+        assertEquals("It should visit each node once", visitCount.get(), 3);
+    }
+
+    @Test
+    public void testDFSVertex() {
+        DepthFirst.depthFirst(g.getRoots()).forEach(v -> visitCount.incrementAndGet());
+        assertEquals("It should visit each node once", visitCount.get(), 3);
+    }
+
+    @Test
+    public void testReverseDFSVertex() {
+        DepthFirst.reverseDepthFirst(g.getLeaves()).forEach(v -> visitCount.incrementAndGet());
         assertEquals("It should visit each node once", visitCount.get(), 3);
     }
 }


### PR DESCRIPTION
This was an untested portion of code, and it accidentally invoked a forward depth-first search instead of a reverse one.