### PR TITLE
Add a note about entropy level to start Logstash

### DIFF
--- a/docs/static/getting-started-with-logstash.asciidoc
+++ b/docs/static/getting-started-with-logstash.asciidoc
@@ -203,6 +203,8 @@ bin/logstash -e 'input { stdin { } } output { stdout {} }'
 NOTE: The location of the `bin` directory varies by platform. See <<dir-layout>>
 to find the location of `bin\logstash` on your system.
 
+NOTE: Logstash requires an adequate level for the random entropy pool to start. Please run `cat /proc/sys/kernel/random/entropy_avail` to check your entropy level: any value below 200 may not be enough. See on how to setup additional sources of entropy for your system.
+
 The `-e` flag enables you to specify a configuration directly from the command line. Specifying configurations at the
 command line lets you quickly test configurations without having to edit a file between iterations.
 The pipeline in the example takes input from the standard input, `stdin`, and moves that input to the standard output,


### PR DESCRIPTION
Logstash hangs at startup until it has enough entropy in the system pool. A note about it saves a lot of time of trying to understand why Logstash starts only after several minutes with no CPU, RAM or disk activity.