### PR TITLE
Update default license

### DIFF
--- a/lib/pluginmanager/templates/codec-plugin/logstash-codec-example.gemspec.erb
+++ b/lib/pluginmanager/templates/codec-plugin/logstash-codec-example.gemspec.erb
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-codec-<%= plugin_name %>'
   s.version       = '0.1.0'
-  s.licenses      = ['Apache License (2.0)']
+  s.licenses      = ['Apache-2.0']
   s.summary       = 'TODO: Write a short summary, because Rubygems requires one.'
   s.description   = 'TODO: Write a longer description or delete this line.'
   s.homepage      = 'TODO: Put your plugin''s website or public repo URL here.'

--- a/lib/pluginmanager/templates/filter-plugin/logstash-filter-example.gemspec.erb
+++ b/lib/pluginmanager/templates/filter-plugin/logstash-filter-example.gemspec.erb
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-filter-<%= plugin_name %>'
   s.version       = '0.1.0'
-  s.licenses      = ['Apache License (2.0)']
+  s.licenses      = ['Apache-2.0']
   s.summary       = 'TODO: Write a short summary, because Rubygems requires one.'
   s.description   = 'TODO: Write a longer description or delete this line.'
   s.homepage      = 'TODO: Put your plugin''s website or public repo URL here.'

--- a/lib/pluginmanager/templates/input-plugin/logstash-input-example.gemspec.erb
+++ b/lib/pluginmanager/templates/input-plugin/logstash-input-example.gemspec.erb
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-<%= plugin_name %>'
   s.version       = '0.1.0'
-  s.licenses      = ['Apache License (2.0)']
+  s.licenses      = ['Apache-2.0']
   s.summary       = 'TODO: Write a short summary, because Rubygems requires one.'
   s.description   = '{TODO: Write a longer description or delete this line.'
   s.homepage      = 'TODO: Put your plugin''s website or public repo URL here.'

--- a/lib/pluginmanager/templates/output-plugin/logstash-output-example.gemspec.erb
+++ b/lib/pluginmanager/templates/output-plugin/logstash-output-example.gemspec.erb
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-output-<%= plugin_name %>'
   s.version       = '0.1.0'
-  s.licenses      = ['Apache License (2.0)']
+  s.licenses      = ['Apache-2.0']
   s.summary       = 'TODO: Write a short summary, because Rubygems requires one.'
   s.description   = 'TODO: Write a longer description or delete this line.'
   s.homepage      = 'TODO: Put your plugin''s website or public repo URL here.'


### PR DESCRIPTION
The current value issues a warning when building: 

```
WARNING:  license value 'Apache License (2.0)' is invalid.  Use a license identifier from
http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
Did you mean 'Apache-2.0'?
```