### PR TITLE
Previous commit incorrectly added a dependency on gradle building gemspec_jars.rb 

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -50,6 +50,4 @@ Gem::Specification.new do |gem|
   # has an rdoc problem that causes a bundler exception. 3.3.9 is the current latest version
   # which does not have this problem.
   gem.add_runtime_dependency "ruby-maven", "~> 3.3.9"
-
-  eval(File.read(File.expand_path("../gemspec_jars.rb", __FILE__)))
 end


### PR DESCRIPTION
There was a Errno::ENOENT while loading logstash-core.gemspec: 
No such file or directory - /var/lib/jenkins/workspace/elastic+logstash+2.x+multijob-intake/logstash-core/gemspec_jars.rb

Fixes #7506