### PR TITLE
Check if the file exist before deleting them

### DIFF
--- a/ci/ci_acceptance.sh
+++ b/ci/ci_acceptance.sh
@@ -12,8 +12,8 @@ SELECTED_TEST_SUITE=$1
 # this mean the lock of the Gemfile can be sticky from a previous run, before generating any package
 # we will clear them out to make sure we use the latest version of theses files
 # If we don't do this we will run into gem Conflict error.
-rm *.lock
-rm Gemfile
+[ -f Gemfile ] && rm Gemfile
+[ -f Gemfile.jruby-2.3.lock ] && rm Gemfile.jruby-2.3.lock
 
 if [[ $SELECTED_TEST_SUITE == $"redhat" ]]; then
   echo "Generating the RPM, make sure you start with a clean environment before generating other packages."


### PR DESCRIPTION
When running the `ci_acceptance` test we need to make sure we don't have
any Gemfile or *.lock laying around. Deleting a non existant file would
make the test fails.