### PR TITLE
Backport to 5.x (5.6): Feature flag for string escape sequences

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -85,6 +85,11 @@
 #
 # config.debug: false
 #
+# When enabled, process escaped characters such as \n and \" in strings in the
+# pipeline configuration files.
+#
+# config.support_escapes: false
+#
 # ------------ Module Settings ---------------
 # Define modules here.  Modules definitions must be defined as an array.
 # The simple way to see this is to prepend each `name` with a `-`, and keep

--- a/docs/static/configuration.asciidoc
+++ b/docs/static/configuration.asciidoc
@@ -249,10 +249,24 @@ Example:
 ==== String
 
 A string must be a single character sequence. Note that string values are
-enclosed in quotes, either double or single. Literal quotes in the string
-need to be escaped with a backslash if they are of the same kind as the string
-delimiter, i.e. single quotes within a single-quoted string need to be escaped
-as well as double quotes within a double-quoted string.
+enclosed in quotes, either double or single. 
+
+===== Escape Sequences
+
+By default, escape sequences are not enabled. If you wish to use escape
+sequences in quoted strings, you will need to set
+`config.support_escapes: true` in your `logstash.yml`. When `true`, quoted
+strings (double and single) will have this transformation:
+
+|===========================
+| Text | Result
+| \r   | carriage return (ASCII 13)
+| \n   | new line (ASCII 10)
+| \t   | tab (ASCII 9)
+| \\   | backslash (ASCII 92)
+| \"   | double quote (ASCII 34)
+| \'   | single quote (ASCII 39)
+|===========================
 
 Example:
 

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -120,6 +120,11 @@ The `logstash.yml` file includes the following settings:
   in plaintext passwords appearing in your logs!
 | `false`
 
+| `config.support_escapes`
+| When set to `true`, quoted strings will process the following escape sequences: `\n` becomes a literal newline (ASCII 10). `\r` becomes a literal carriage return (ASCII 13). `\t` becomes a literal tab (ASCII 9). `\\` becomes a literal backslash `\`. `\"` becomes a literal double quotation mark. `\'` becomes a literal quotation mark.
+| `false`
++
+
 | `queue.type`
 | The internal queuing model to use for event buffering. Specify `memory` for legacy in-memory based queuing, or `persisted` for disk-based ACKed queueing (<<persistent-queues,persistent queues>>).
 | `memory`

--- a/logstash-core/lib/logstash/config/config_ast.rb
+++ b/logstash-core/lib/logstash/config/config_ast.rb
@@ -9,6 +9,18 @@ class Treetop::Runtime::SyntaxNode
     return elements.collect(&:compile).reject(&:empty?).join("")
   end
 
+  def get_meta(key)
+    @ast_metadata ||= {}
+    return @ast_metadata[key] if @ast_metadata[key]
+    return self.parent.get_meta(key) if self.parent
+    nil
+  end
+
+  def set_meta(key, value)
+    @ast_metadata ||= {}
+    @ast_metadata[key] = value
+  end
+
   # Traverse the syntax tree recursively.
   # The order should respect the order of the configuration file as it is read
   # and written by humans (and the order in which it is parsed).

--- a/logstash-core/lib/logstash/config/string_escape.rb
+++ b/logstash-core/lib/logstash/config/string_escape.rb
@@ -1,0 +1,27 @@
+
+
+module LogStash; module Config; module StringEscape
+  class << self
+    def process_escapes(input)
+      input.gsub(/\\./) do |value|
+        process(value)
+      end
+    end
+
+    private
+    def process(value)
+      case value[1]
+      when '"', "'", "\\"
+        value[1]
+      when "n"
+        "\n"
+      when "r"
+        "\r"
+      when "t"
+        "\t"
+      else
+        value
+      end
+    end
+  end
+end end end

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -24,6 +24,7 @@ module LogStash
                     Setting.new("modules", Array, []),
            Setting::Boolean.new("config.test_and_exit", false),
            Setting::Boolean.new("config.reload.automatic", false),
+           Setting::Boolean.new("config.support_escapes", false),
            Setting::Numeric.new("config.reload.interval", 3), # in seconds
            Setting::Boolean.new("metric.collect", true),
             Setting::String.new("pipeline.id", "main"),

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -58,6 +58,8 @@ module LogStash; class BasePipeline
     parsed_config = grammar.parse(config_str)
     raise(ConfigurationError, grammar.failure_reason) if parsed_config.nil?
 
+    parsed_config.process_escape_sequences = settings.get_value("config.support_escapes")
+
     config_code = parsed_config.compile
 
     # config_code = BasePipeline.compileConfig(config_str)

--- a/logstash-core/spec/logstash/config/config_ast_spec.rb
+++ b/logstash-core/spec/logstash/config/config_ast_spec.rb
@@ -6,6 +6,8 @@ require "logstash/config/grammar"
 require "logstash/config/config_ast"
 
 describe LogStashConfigParser do
+  let(:settings) { mock_settings({}) }
+
   context '#parse' do
     context "valid configuration" do
       it "should permit single-quoted attribute names" do
@@ -77,7 +79,7 @@ describe LogStashConfigParser do
         }
       CONFIG
       subject { LogStashConfigParser.new }
-         
+
       it "should compile successfully" do
         result = subject.parse(config)
         expect(result).not_to(be_nil)
@@ -142,12 +144,50 @@ describe LogStashConfigParser do
         expect(config).to be_nil
       end
     end
+
+    context "when config.support_escapes" do
+      let(:parser) { LogStashConfigParser.new }
+
+      let(:processed_value)  { 'The computer says, "No"' }
+
+      let(:config) {
+        parser.parse(%q(
+          input {
+            foo {
+              bar => "The computer says, \"No\""
+            }
+          }
+        ))
+      }
+
+      let(:compiled_string) { eval(config.recursive_select(LogStash::Config::AST::String).first.compile) }
+
+      before do
+        config.process_escape_sequences = escapes
+      end
+
+      context "is enabled" do
+        let(:escapes) { true }
+
+        it "should process escape sequences" do
+          expect(compiled_string).to be == processed_value
+        end
+      end
+
+      context "is false" do
+        let(:escapes) { false }
+
+        it "should not process escape sequences" do
+          expect(compiled_string).not_to be == processed_value
+        end
+      end
+    end
   end
 
   context "when using two plugin sections of the same type" do
     let(:pipeline_klass) do
       Class.new do
-        def initialize(config)
+        def initialize(config, settings)
           grammar = LogStashConfigParser.new
           @config = grammar.parse(config)
           @code = @config.compile
@@ -166,7 +206,7 @@ describe LogStashConfigParser do
 
 
       it "should create a pipeline with both sections" do
-        generated_objects = pipeline_klass.new(config_string).instance_variable_get("@generated_objects")
+        generated_objects = pipeline_klass.new(config_string, settings).instance_variable_get("@generated_objects")
         filters = generated_objects.keys.map(&:to_s).select {|obj_name| obj_name.match(/^filter.+?_\d+$/) }
         expect(filters.size).to eq(2)
       end
@@ -181,14 +221,13 @@ describe LogStashConfigParser do
 
 
       it "should create a pipeline with both sections" do
-        generated_objects = pipeline_klass.new(config_string).instance_variable_get("@generated_objects")
+        generated_objects = pipeline_klass.new(config_string, settings).instance_variable_get("@generated_objects")
         outputs = generated_objects.keys.map(&:to_s).select {|obj_name| obj_name.match(/^output.+?_\d+$/) }
         expect(outputs.size).to eq(2)
       end
     end
   end
   context "when creating two instances of the same configuration" do
-
     let(:config_string) {
       "input { generator { } }
        filter {
@@ -201,7 +240,7 @@ describe LogStashConfigParser do
 
     let(:pipeline_klass) do
       Class.new do
-        def initialize(config)
+        def initialize(config, settings)
           grammar = LogStashConfigParser.new
           @config = grammar.parse(config)
           @code = @config.compile
@@ -213,8 +252,8 @@ describe LogStashConfigParser do
 
     describe "generated conditional functionals" do
       it "should be created per instance" do
-        instance_1 = pipeline_klass.new(config_string)
-        instance_2 = pipeline_klass.new(config_string)
+        instance_1 = pipeline_klass.new(config_string, settings)
+        instance_2 = pipeline_klass.new(config_string, settings)
         generated_method_1 = instance_1.instance_variable_get("@generated_objects")[:cond_func_1]
         generated_method_2 = instance_2.instance_variable_get("@generated_objects")[:cond_func_1]
         expect(generated_method_1).to_not be(generated_method_2)

--- a/logstash-core/spec/logstash/config/string_escape_spec.rb
+++ b/logstash-core/spec/logstash/config/string_escape_spec.rb
@@ -1,0 +1,24 @@
+
+require "logstash/config/string_escape"
+
+describe LogStash::Config::StringEscape do
+  let(:result) { described_class.process_escapes(text) }
+
+  table = {
+    '\\"' => '"',
+    "\\'" => "'",
+    "\\n" => "\n",
+    "\\r" => "\r",
+    "\\t" => "\t",
+    "\\\\" => "\\",
+  }
+
+  table.each do |input, expected|
+    context "when processing #{input.inspect}" do
+      let(:text) { input }
+      it "should produce #{expected.inspect}" do
+        expect(result).to be == expected
+      end
+    end
+  end
+end


### PR DESCRIPTION
(This is a backport from master to 5.x branch of https://github.com/elastic/logstash/pull/7442)

New boolean setting `config.support_escapes` which defaults to false
(the historical behavior). When set to true, the following escapes are
handled:

* backslash doublequote -> doublequote
* backslash quote -> quote
* backslash n -> newline (ascii 10)
* backslash r -> carriage return (ascii 13)
* backslash backslash -> backslash
* backslash t -> tab (ascii 9)

This will solve #1645.
