### PR TITLE
Use docker-ce instead of docker engine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ env:
   - INTEGRATION=false FEATURE_FLAG=persistent_queues SPEC_OPTS="--order rand --format documentation"
   - INTEGRATION=true FEATURE_FLAG=persistent_queues SPEC_OPTS="--order rand --format documentation"
 before_install:
-  - sudo apt-get remove -y docker-engine
-  - sudo apt-get install -y docker-engine
+  - sudo apt-get remove -y docker-ce
+  - sudo apt-get install -y docker-ce
   - sudo service docker stop
   - sudo dockerd --disable-legacy-registry &>/dev/null &
   # Force bundler 1.12.5 because version 1.13 has issues, see https://github.com/fastlane/fastlane/issues/6065#issuecomment-246044617


### PR DESCRIPTION
docker engine seems to be not available anymore and is replaced by
docker-ce.

backport of #7517