### PR TITLE
Only include Logstash plugins in list of plugins

### DIFF
--- a/rakelib/plugins_docs_dependencies.rake
+++ b/rakelib/plugins_docs_dependencies.rake
@@ -135,7 +135,7 @@ class PluginVersionWorking
   end
 
   def extract_versions(definition, dependencies, from)
-    definition.specs.each do |spec|
+    definition.specs.select { |spec| spec.metadata && spec.metadata["logstash_plugin"] == "true" }.each do |spec|
       dependencies[spec.name] ||= []
       dependencies[spec.name] << VersionDependencies.new(spec.version, from)
     end


### PR DESCRIPTION
When generating list of compatible plugins for documentation, we
previously were accidentally include all gems, not just logstash
plugins.