### PR TITLE
Add links to grok debugger

### DIFF
--- a/docs/index-shared1.asciidoc
+++ b/docs/index-shared1.asciidoc
@@ -13,16 +13,16 @@ release-state can be: released | prerelease | unreleased
 
 :jdk:                   1.8.0
 :guide:                 https://www.elastic.co/guide/en/elasticsearch/guide/current/
-:ref:                   https://www.elastic.co/guide/en/elasticsearch/reference/current/
-:xpack-ref:             https://www.elastic.co/guide/en/x-pack/current/
-:kibana-ref:            https://www.elastic.co/guide/en/kibana/current/
-:logstash:              https://www.elastic.co/guide/en/logstash/current/
-:libbeat:               https://www.elastic.co/guide/en/beats/libbeat/current/
-:filebeat:              https://www.elastic.co/guide/en/beats/filebeat/current/
-:metricbeat:            https://www.elastic.co/guide/en/beats/metricbeat/current/
+:ref:                   https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/
+:xpack-ref:             https://www.elastic.co/guide/en/x-pack/{branch}/
+:kibana-ref:            https://www.elastic.co/guide/en/kibana/{branch}/
+:logstash:              https://www.elastic.co/guide/en/logstash/{branch}/
+:libbeat:               https://www.elastic.co/guide/en/beats/libbeat/{branch}/
+:filebeat:              https://www.elastic.co/guide/en/beats/filebeat/{branch}/
+:metricbeat:            https://www.elastic.co/guide/en/beats/metricbeat/{branch}/
 :lsissue:               https://github.com/elastic/logstash/issues/
 :security:              X-Pack security
-:stack:                 https://www.elastic.co/guide/en/elastic-stack/current/
+:stack:                 https://www.elastic.co/guide/en/elastic-stack/{branch}/
 
 :xpack:                 X-Pack
 :es:                    Elasticsearch

--- a/docs/static/advanced-pipeline.asciidoc
+++ b/docs/static/advanced-pipeline.asciidoc
@@ -223,6 +223,10 @@ Bytes served:: `bytes`
 Referrer URL:: `referrer`
 User agent:: `agent`
 
+TIP: If you need help building grok patterns, try out the
+{kibana-ref}xpack-grokdebugger.html[Grok Debugger]. The Grok Debugger is an
+{xpack} feature under the Basic License and is therefore *free to use*. 
+
 Edit the `first-pipeline.conf` file and replace the entire `filter` section with the following text:
 
 [source,json]
@@ -311,7 +315,6 @@ After Logstash applies the grok pattern, the events will have the following JSON
 --------------------------------------------------------------------------------
 
 Notice that the event includes the original message, but the log message is also broken down into specific fields.
-
 
 [float]
 [[configuring-geoip-plugin]]

--- a/docs/static/configuration.asciidoc
+++ b/docs/static/configuration.asciidoc
@@ -796,6 +796,10 @@ filter {
 === Logstash Configuration Examples
 The following examples illustrate how you can configure Logstash to filter events, process Apache logs and syslog messages, and use conditionals to control what events are processed by a filter or output.
 
+TIP: If you need help building grok patterns, try out the
+{kibana-ref}xpack-grokdebugger.html[Grok Debugger]. The Grok Debugger is an
+{xpack} feature under the Basic License and is therefore *free to use*.
+
 [float]
 [[filter-example]]
 ==== Configuring Filters

--- a/docs/static/transforming-data.asciidoc
+++ b/docs/static/transforming-data.asciidoc
@@ -352,6 +352,10 @@ After the filter is applied, the event in the example will have these fields:
 * `bytes: 15824`
 * `duration: 0.043`
 
+TIP: If you need help building grok patterns, try out the
+{kibana-ref}xpack-grokdebugger.html[Grok Debugger]. The Grok Debugger is an
+{xpack} feature under the Basic License and is therefore *free to use*. 
+
 [[lookup-enrichment]]
 === Enriching Data with Lookups
 


### PR DESCRIPTION
Adds some links that point to the grok debugger so users will know that the tool exists.

Not sure why we were pointing to current in the index, but I think it's better to point to the branch (we actually can't point to current because grok debugger docs won't exist in current until the code is released).
