### PR TITLE
Add info to docs about upgrading with persistent queues

### DIFF
--- a/docs/static/upgrading.asciidoc
+++ b/docs/static/upgrading.asciidoc
@@ -16,6 +16,7 @@ See the following topics for information about upgrading Logstash:
 
 * <<upgrading-using-package-managers>>
 * <<upgrading-using-direct-download>>
+* <<upgrading-logstash-pqs>>
 * <<upgrading-logstash-5.0>>
 
 [[upgrading-using-package-managers]]
@@ -42,6 +43,20 @@ This procedure downloads the relevant Logstash binaries directly from Elastic.
 4. Test your configuration file with the `logstash --config.test_and_exit -f <configuration-file>` command. Configuration options for
 some Logstash plugins have changed in the 5.x release.
 5. Restart your Logstash pipeline after updating your configuration file.
+
+[[upgrading-logstash-pqs]]
+=== Upgrading with Persistent Queues Enabled
+
+Upgrading Logstash with persistent queues enabled is supported. The persistent
+queue directory is self-contained and can be read by a new Logstash instance
+running the same pipeline. You can safely shut down the original Logstash
+instance, spin up a new instance, and set `path.queue` in the `logstash.yml`
+<<logstash-settings-file,settings file>> to point to the original queue directory.
+You can also use a mounted drive to make this workflow easier.
+
+Keep in mind that only one Logstash instance can write to `path.queue`. You
+cannot have the original instance and the new instance writing to the queue at
+the same time.
 
 [[upgrading-logstash-5.0]]
 === Upgrading Logstash to 5.0


### PR DESCRIPTION
@acchen97 @suyograo Please review. I decided to add a separate short section because this info was too long for a note. Plus it's more visible now. I mostly used Alvin's language from #7158, but I thought it would be nice to tell users how to point Lostash to the original queue. Please confirm that particular detail.

BTW, someone has tested this, right? I could set up a couple of instances to test this, but I'm not sure I would catch subtle issues.