### PR TITLE
add ci_test.bat file so windows can run tests like other OS do

### DIFF
--- a/ci/ci_test.bat
+++ b/ci/ci_test.bat
@@ -1,0 +1,41 @@
+@echo off
+
+setlocal
+
+REM Since we are using the system jruby, we need to make sure our jvm process
+REM uses at least 1g of memory, If we don't do this we can get OOM issues when
+REM installing gems. See https://github.com/elastic/logstash/issues/5179
+
+SET JRUBY_OPTS="-J-Xmx1g"
+SET SELECTEDTESTSUITE=%1
+SET /p JRUBYVERSION=<.ruby-version
+
+IF NOT EXIST %JRUBYSRCDIR% (
+  echo "Variable JRUBYSRCDIR must be declared with a valid directory. Aborting.."
+  exit /B 1
+)
+
+SET JRUBYPATH=%JRUBYSRCDIR%\%JRUBYVERSION%
+
+IF NOT EXIST %JRUBYPATH% (
+  echo "Could not find JRuby in %JRUBYPATH%. Aborting.."
+  exit /B 1
+)
+
+SET RAKEPATH=%JRUBYPATH%\bin\rake
+
+IF "%SELECTEDTESTSUITE%"=="core-fail-fast" (
+  echo "Running core-fail-fast tests"
+  %RAKEPATH% test:install-core
+  %RAKEPATH% test:core-fail-fast
+) ELSE (
+  IF "%SELECTEDTESTSUITE%"=="all" (
+    echo "Running all plugins tests"
+    %RAKEPATH% test:install-all
+    %RAKEPATH% test:plugins
+  ) ELSE (
+    echo "Running core tests"
+    %RAKEPATH% test:install-core
+    %RAKEPATH% test:core
+  )
+)


### PR DESCRIPTION
this requires jruby to be unpacked into ~~`C:\Program Files\jruby\src\jruby-<version>`~~ %JRUBYSRCDIR%
The actual version will be read from the `.ruby-version` file.

fixes #7553 

REMINDER: for backporting this to 5.x it's necessary to include the .ruby-version file in the PR too, since the 5.x and 5.6.0 branches do not contain this file