### PR TITLE
Add more options for the modules templates

### DIFF
--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -537,8 +537,27 @@ module LogStash
         end
       end
     end
-  end
 
+    class SplittableStringArray < ArrayCoercible
+      DEFAULT_TOKEN = ","
+
+      def initialize(name, klass, default, strict=true, tokenizer = DEFAULT_TOKEN, &validator_proc)
+        @element_class = klass
+        @token = tokenizer
+        super(name, klass, default, strict, &validator_proc)
+      end
+
+      def coerce(value)
+        if value.is_a?(Array)
+          value
+        elsif value.nil?
+          []
+        else
+          value.split(@token).map(&:strip)
+        end
+      end
+    end
+  end
 
   SETTINGS = Settings.new
 end

--- a/logstash-core/spec/logstash/modules/logstash_config_spec.rb
+++ b/logstash-core/spec/logstash/modules/logstash_config_spec.rb
@@ -1,0 +1,56 @@
+# encoding: utf-8
+require "logstash/modules/logstash_config"
+
+describe LogStash::Modules::LogStashConfig do
+  let(:mod) { instance_double("module", :directory => Stud::Temporary.directory, :module_name => "testing") }
+  let(:settings) { {"var.logstash.testing.pants" => "fancy" }}
+  subject { described_class.new(mod, settings) }
+
+  describe "configured inputs" do
+    context "when no inputs is send" do
+      it "returns the default" do
+        expect(subject.configured_inputs(["kafka"])).to include("kafka")
+      end
+    end
+
+    context "when inputs are send" do
+      let(:settings) { { "var.inputs" => "tcp" } }
+
+      it "returns the configured inputs" do
+        expect(subject.configured_inputs(["kafka"])).to include("tcp")
+      end
+
+      context "when alias is specified" do
+        let(:settings) { { "var.inputs" => "smartconnector" } }
+
+        it "returns the configured inputs" do
+          expect(subject.configured_inputs(["kafka"], { "smartconnector" => "tcp"  })).to include("tcp", "smartconnector")
+        end
+      end
+    end
+  end
+
+  describe "array to logstash array string" do
+    it "return an escaped string" do
+      expect(subject.array_to_string(["hello", "ninja"])).to eq("['hello', 'ninja']")
+    end
+  end
+
+  describe "alias modules options" do
+    let(:alias_table) do
+      { "var.logstash.testing" => "var.logstash.better" }
+    end
+
+    before do
+      subject.alias_settings_keys!(alias_table)
+    end
+
+    it "allow to retrieve settings" do
+      expect(subject.setting("var.logstash.better.pants", "dont-exist")).to eq("fancy")
+    end
+
+    it "allow to retrieve settings with the original name" do
+      expect(subject.setting("var.logstash.testing.pants", "dont-exist")).to eq("fancy")
+    end
+  end
+end

--- a/logstash-core/spec/logstash/modules/scaffold_spec.rb
+++ b/logstash-core/spec/logstash/modules/scaffold_spec.rb
@@ -80,7 +80,7 @@ ERB
       expect(test_module.logstash_configuration).not_to be_nil
       config_string = test_module.config_string
       expect(config_string).to include("port => 5606")
-      expect(config_string).to include('hosts => ["es.mycloud.com:9200"]')
+      expect(config_string).to include("hosts => ['es.mycloud.com:9200']")
     end
   end
 

--- a/logstash-core/spec/logstash/settings/splittable_string_array_spec.rb
+++ b/logstash-core/spec/logstash/settings/splittable_string_array_spec.rb
@@ -1,0 +1,51 @@
+# encoding: utf-8
+require "spec_helper"
+require "logstash/settings"
+
+describe LogStash::Setting::SplittableStringArray do
+  let(:element_class) { String }
+  let(:default_value) { [] }
+
+  subject { described_class.new("testing", element_class, default_value) }
+
+  before do
+    subject.set(candidate)
+  end
+
+  context "when giving an array" do
+    let(:candidate) { ["hello,", "ninja"] }
+
+    it "returns the same elements" do
+      expect(subject.value).to match(candidate)
+    end
+  end
+
+  context "when given a string" do
+    context "with 1 element" do
+      let(:candidate) { "hello" }
+
+      it "returns 1 element" do
+        expect(subject.value).to match(["hello"])
+      end
+    end
+
+    context "with multiple element" do
+      let(:candidate) { "hello,ninja" }
+
+      it "returns an array of string" do
+        expect(subject.value).to match(["hello", "ninja"])
+      end
+    end
+  end
+
+  context "when defining a custom tokenizer" do
+    subject { described_class.new("testing", element_class, default_value, strict=true, ";") }
+
+    let(:candidate) { "hello;ninja" }
+
+    it "returns an array of string" do
+      expect(subject.value).to match(["hello", "ninja"])
+    end
+  end
+end
+


### PR DESCRIPTION
This commits add the following new features:

Allow users to use the internal settings classes to have better handling
over the primitives values that a user can use in the modules templates,
by default we are using a `NullableString` which is the more flexible
type.

This change open the way to have more strict validation on the module
templates and will allow us to preprocess configuration to retrieve the
list of the settings and their settings types.

We also add a new type of settings called `SplittableStringArray`, this
class is a subclass or `ArrayCoercible` but target module CLI
configuration. It will take the following form `-M
"arcsight.var.input.hosts=127.0.0.1:3333,192.168.1.23:9999"` and
transform it into a ruby array of string.

We can also add alias of settings values in the configuration by using the
`alias_settings_keys!()`, this is usefull when the language domain is
different from the logstash domain.