### PR TITLE
Add queue.drain option to the docs

### DIFF
--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -84,6 +84,7 @@ Logstash <<logstash-settings-file,settings file>>:
 * `queue.type`: Specify `persisted` to enable persistent queues. By default, persistent queues are disabled (default: `queue.type: memory`).
 * `path.queue`: The directory path where the data files will be stored. By default, the files are stored in `path.data/queue`. 
 * `queue.page_capacity`: The maximum size of a queue page in bytes. The queue data consists of append-only files called "pages". The default size is 250mb. Changing this value is unlikely to have performance benefits.
+* `queue.drain`: Specify `true` if you want Logstash to wait until the persistent queue is drained before shutting down. The amount of time it takes to drain the queue depends on the number of events that have accumulated in the queue. Therefore, you should avoid using this setting unless the queue, even when full, is relatively small and can be drained quickly. 
 // Technically, I know, this isn't "maximum number of events" it's really maximum number of events not yet read by the pipeline worker. We only use this for testing and users generally shouldn't be setting this.
 * `queue.max_events`:  The maximum number of events that are allowed in the queue. The default is 0 (unlimited). This value is used internally for the Logstash test suite.
 * `queue.max_bytes`: The total capacity of the queue in number of bytes. The

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -178,6 +178,10 @@ The `logstash.yml` file includes the following settings:
 | The interval in milliseconds when a checkpoint is forced on the head page when persistent queues are enabled (`queue.type: persisted`). Specify `queue.checkpoint.interval: 0` for no periodic checkpoint.
 | 1000
 
+| `queue.drain`
+| When enabled, Logstash waits until the persistent queue is drained before shutting down.
+| false
+
 | `dead_letter_queue.enable`
 | Flag to instruct Logstash to enable the DLQ feature supported by plugins.
 | `false`


### PR DESCRIPTION
Fixes issue #6778 

@colinsurprenant Wasn't sure if you were planning to add this along with the changes you plan to make to the PQ docs, so I went ahead and added it. Would be good to get this reviewed/merged before the 5.5 release.