### PR TITLE
MINOR: Optimized Map and List allocation

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ConvertedList.java
+++ b/logstash-core/src/main/java/org/logstash/ConvertedList.java
@@ -20,15 +20,12 @@ import static org.logstash.Valuefier.convert;
 public class ConvertedList<T> implements List<T>, Collection<T>, Iterable<T> {
     private final List<T> delegate;
 
-    public ConvertedList(List<T> delegate) {
-        this.delegate = delegate;
-    }
-    public ConvertedList() {
-        this.delegate = new ArrayList<>();
+    public ConvertedList(final int size) {
+        this.delegate = new ArrayList<>(size);
     }
 
     public static ConvertedList<Object> newFromList(List<Object> list) {
-        ConvertedList<Object> array = new ConvertedList<>();
+        ConvertedList<Object> array = new ConvertedList<>(list.size());
 
         for (Object item : list) {
             array.add(convert(item));
@@ -37,7 +34,7 @@ public class ConvertedList<T> implements List<T>, Collection<T>, Iterable<T> {
     }
 
     public static ConvertedList<Object> newFromRubyArray(RubyArray a) {
-        final ConvertedList<Object> result = new ConvertedList<>();
+        final ConvertedList<Object> result = new ConvertedList<>(a.size());
 
         for (IRubyObject o : a.toJavaArray()) {
             result.add(convert(o));
@@ -46,7 +43,7 @@ public class ConvertedList<T> implements List<T>, Collection<T>, Iterable<T> {
     }
 
     public Object unconvert() {
-        final ArrayList<Object> result = new ArrayList<>();
+        final ArrayList<Object> result = new ArrayList<>(size());
         for (Object obj : delegate) {
             result.add(Javafier.deep(obj));
         }

--- a/logstash-core/src/main/java/org/logstash/ConvertedMap.java
+++ b/logstash-core/src/main/java/org/logstash/ConvertedMap.java
@@ -16,16 +16,12 @@ public class ConvertedMap<K, V> implements Map<K, V> {
 
     private final Map<K, V> delegate;
 
-    public ConvertedMap(Map<K, V> delegate) {
-        this.delegate = delegate;
-    }
-
-    public ConvertedMap() {
-        this.delegate = new HashMap<>();
+    private ConvertedMap(final int size) {
+        this.delegate = new HashMap<>(size);
     }
 
     public static ConvertedMap<String, Object> newFromMap(Map<String, Object> o) {
-        ConvertedMap<String, Object> cm = new ConvertedMap<>();
+        ConvertedMap<String, Object> cm = new ConvertedMap<>(o.size());
         for (Map.Entry<String, Object> entry : o.entrySet()) {
             String k = String.valueOf(BiValues.newBiValue(entry.getKey()).javaValue());
             cm.put(k, Valuefier.convert(entry.getValue()));
@@ -34,7 +30,7 @@ public class ConvertedMap<K, V> implements Map<K, V> {
     }
 
     public static ConvertedMap<String, Object> newFromRubyHash(RubyHash o) {
-        final ConvertedMap<String, Object> result = new ConvertedMap<>();
+        final ConvertedMap<String, Object> result = new ConvertedMap<>(o.size());
 
         o.visitAll(o.getRuntime().getCurrentContext(), new RubyHash.Visitor() {
             @Override
@@ -47,8 +43,8 @@ public class ConvertedMap<K, V> implements Map<K, V> {
     }
 
     public Object unconvert() {
-        final HashMap<K, V> result = new HashMap<>();
-        for (Map.Entry<K, V> entry : entrySet()) {
+        final HashMap<K, V> result = new HashMap<>(size());
+        for (final Map.Entry<K, V> entry : entrySet()) {
             result.put(entry.getKey(), (V) Javafier.deep(entry.getValue()));
         }
         return result;

--- a/logstash-core/src/main/java/org/logstash/Valuefier.java
+++ b/logstash-core/src/main/java/org/logstash/Valuefier.java
@@ -26,8 +26,9 @@ public class Valuefier {
     private static Object convertJavaProxy(JavaProxy jp) {
         Object obj = JavaUtil.unwrapJavaObject(jp);
         if (obj instanceof IRubyObject[]) {
-            ConvertedList<Object> list = new ConvertedList<>();
-            for (IRubyObject ro : ((IRubyObject[]) obj)) {
+            final IRubyObject[] arr = (IRubyObject[]) obj;
+            ConvertedList<Object> list = new ConvertedList<>(arr.length);
+            for (IRubyObject ro : arr) {
                 list.add(convert(ro));
             }
             return list;


### PR DESCRIPTION
Profiling a test run on our apache logs dataset shows a lot of GC on `Object[]` and `HashMapNode`
This reduces the noise from that a little by removing some collection allocations without a size hint when the size is known to us.