### PR TITLE
MINOR: Removed dead casts and interface declarations

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ConvertedList.java
+++ b/logstash-core/src/main/java/org/logstash/ConvertedList.java
@@ -17,7 +17,7 @@ import java.util.stream.Stream;
 
 import static org.logstash.Valuefier.convert;
 
-public class ConvertedList<T> implements List<T>, Collection<T>, Iterable<T> {
+public class ConvertedList<T> implements List<T> {
     private final List<T> delegate;
 
     public ConvertedList(final int size) {

--- a/logstash-core/src/main/java/org/logstash/KeyNode.java
+++ b/logstash-core/src/main/java/org/logstash/KeyNode.java
@@ -30,7 +30,7 @@ public class KeyNode implements TemplateNode {
                 return join((List)value, ",");
             } else if (value instanceof Map) {
                 ObjectMapper mapper = new ObjectMapper();
-                return mapper.writeValueAsString((Map<String, Object>)value);
+                return mapper.writeValueAsString(value);
             } else {
                 return event.getField(this.key).toString();
             }
@@ -60,7 +60,7 @@ public class KeyNode implements TemplateNode {
         if (value == null) return "";
         if (value instanceof List) return join((List)value, delim);
         if (value instanceof BiValue) {
-            return ((BiValue) value).toString();
+            return value.toString();
         }
         return value.toString();
     }


### PR DESCRIPTION
Just 3 small spots I found researching something:

* `List` implies `Collection` and `Iterable`
* Removed two redundant casts