### PR TITLE
Backport to 5.x - Bug Fix: Log messages from Java code base

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -115,5 +115,6 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'net.javacrumbs.json-unit:json-unit:1.9.0'
     testCompile 'org.elasticsearch:securemock:1.2'
+    testCompile 'org.assertj:assertj-core:3.8.0'
     provided 'org.jruby:jruby-core:1.7.25'
 }

--- a/logstash-core/src/main/java/org/logstash/log/LogstashLoggerContextFactory.java
+++ b/logstash-core/src/main/java/org/logstash/log/LogstashLoggerContextFactory.java
@@ -1,0 +1,41 @@
+package org.logstash.log;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.spi.LoggerContext;
+import org.apache.logging.log4j.spi.LoggerContextFactory;
+
+import java.net.URI;
+
+/**
+ * Log4j context factory to enable injection of a pre-established context. This may be used in conjunction with
+ * {@link LogManager#setFactory(LoggerContextFactory)} to ensure that the injected pre-established context is used by the {@link LogManager}
+ */
+public class LogstashLoggerContextFactory implements LoggerContextFactory {
+
+    private final LoggerContext context;
+
+    /**
+     * Constructor
+     *
+     * @param context The {@link LoggerContext} that this factory will ALWAYS return.
+     */
+    public LogstashLoggerContextFactory(LoggerContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public LoggerContext getContext(String fqcn, ClassLoader loader, Object externalContext, boolean currentContext) {
+        return context;
+    }
+
+    @Override
+    public LoggerContext getContext(String fqcn, ClassLoader loader, Object externalContext, boolean currentContext,
+                                    URI configLocation, String name) {
+        return context;
+    }
+
+    @Override
+    public void removeContext(LoggerContext context) {
+        //do nothing
+    }
+}

--- a/logstash-core/src/main/resources/log4j2.properties
+++ b/logstash-core/src/main/resources/log4j2.properties
@@ -1,0 +1,11 @@
+name=default
+appenders = console
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n
+
+rootLogger.level = error
+rootLogger.appenderRefs = stdout
+rootLogger.appenderRef.stdout.ref = STDOUT

--- a/logstash-core/src/test/java/org/logstash/log/LogstashLoggerContextFactoryTest.java
+++ b/logstash-core/src/test/java/org/logstash/log/LogstashLoggerContextFactoryTest.java
@@ -1,0 +1,43 @@
+package org.logstash.log;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.spi.LoggerContext;
+import org.apache.logging.log4j.spi.LoggerContextFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verify;
+
+import java.net.URI;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit test for {@link LogstashLoggerContextFactory}
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class LogstashLoggerContextFactoryTest {
+
+    @Mock
+    private LoggerContext preEstablishedContext;
+
+    private LogstashLoggerContextFactory contextFactory;
+
+    @Before
+    public void setup() {
+        contextFactory = new LogstashLoggerContextFactory(preEstablishedContext);
+    }
+
+    @Test
+    public void testGetContextAlwaysReturnsTheSameObject() {
+        assertThat(contextFactory.getContext("", ClassLoader.getSystemClassLoader(), null, false))
+                .isEqualTo(contextFactory.getContext("someRandomValue", null, null, false))
+                .isEqualTo(contextFactory.getContext("someOtherRandomValue", ClassLoader.getSystemClassLoader(), null, false, URI.create("foo"), "name"));
+    }
+}

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -128,8 +128,8 @@ describe "Test Monitoring API" do
 
       result = logstash_service.monitoring_api.logging_get
       result["loggers"].each do | k, v |
-        #since we explicitly set the logstash.agent logger above, the parent logger will not take precedence
-        if k.eql? "logstash.agent"
+        #since we explicitly set the logstash.agent logger above, the logger.logstash parent logger will not take precedence
+        if k.eql?("logstash.agent") || k.start_with?("org.logstash")
           expect(v).to eq("INFO")
         else
           expect(v).to eq("ERROR")
@@ -143,7 +143,7 @@ describe "Test Monitoring API" do
   def logging_get_assert(logstash_service, logstash_level, slowlog_level)
     result = logstash_service.monitoring_api.logging_get
     result["loggers"].each do | k, v |
-      if k.start_with? "logstash"
+      if k.start_with? "logstash", "org.logstash" #logstash is the ruby namespace, and org.logstash for java
         expect(v).to eq(logstash_level)
       elsif k.start_with? "slowlog"
         expect(v).to eq(slowlog_level)


### PR DESCRIPTION
Backport of https://github.com/elastic/logstash/pull/7528 to 5.x . Cherry-picked from https://github.com/elastic/logstash/commit/3a6902c2f3d029eea02dd920dd3d7c0730c69dfc and resolved minor merge conflict in logstash-core/build.gradle

-----------
This change re-configures default instead of creating a new context.

Fixes #7526