### PR TITLE
Logging: Add log4j-slf4j-impl to classpath to allow logging via SLF4J.

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -107,6 +107,7 @@ idea {
 dependencies {
     compile 'org.apache.logging.log4j:log4j-api:2.6.2'
     compile 'org.apache.logging.log4j:log4j-core:2.6.2'
+    runtime 'org.apache.logging.log4j:log4j-slf4j-impl:2.6.2'
     compile 'com.fasterxml.jackson.core:jackson-core:2.7.4'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.7.4'
     compile 'com.fasterxml.jackson.module:jackson-module-afterburner:2.7.4'


### PR DESCRIPTION
Fixes #7242