### PR TITLE
MINOR: Much Faster String Java to Ruby Conversion in ConvertedMap + Corrected Types

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ConvertedMap.java
+++ b/logstash-core/src/main/java/org/logstash/ConvertedMap.java
@@ -1,9 +1,6 @@
 package org.logstash;
 
-import org.logstash.bivalues.BiValues;
-import org.jruby.RubyHash;
-import org.jruby.runtime.builtin.IRubyObject;
-
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -11,6 +8,8 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import org.jruby.RubyHash;
+import org.jruby.runtime.builtin.IRubyObject;
 
 public class ConvertedMap<K, V> implements Map<K, V> {
 
@@ -20,11 +19,10 @@ public class ConvertedMap<K, V> implements Map<K, V> {
         this.delegate = new HashMap<>(size);
     }
 
-    public static ConvertedMap<String, Object> newFromMap(Map<String, Object> o) {
+    public static ConvertedMap<String, Object> newFromMap(Map<Serializable, Object> o) {
         ConvertedMap<String, Object> cm = new ConvertedMap<>(o.size());
-        for (Map.Entry<String, Object> entry : o.entrySet()) {
-            String k = String.valueOf(BiValues.newBiValue(entry.getKey()).javaValue());
-            cm.put(k, Valuefier.convert(entry.getValue()));
+        for (final Map.Entry<Serializable, Object> entry : o.entrySet()) {
+            cm.put(entry.getKey().toString(), Valuefier.convert(entry.getValue()));
         }
         return cm;
     }
@@ -35,8 +33,7 @@ public class ConvertedMap<K, V> implements Map<K, V> {
         o.visitAll(o.getRuntime().getCurrentContext(), new RubyHash.Visitor() {
             @Override
             public void visit(IRubyObject key, IRubyObject value) {
-                String k = String.valueOf(BiValues.newBiValue(key).javaValue()) ;
-                result.put(k, Valuefier.convert(value));
+                result.put(key.toString(), Valuefier.convert(value));
             }
         }, null);
         return result;

--- a/logstash-core/src/main/java/org/logstash/Valuefier.java
+++ b/logstash-core/src/main/java/org/logstash/Valuefier.java
@@ -1,5 +1,6 @@
 package org.logstash;
 
+import java.io.Serializable;
 import org.logstash.bivalues.BiValue;
 import org.logstash.bivalues.BiValues;
 import org.logstash.ext.JrubyTimestampExtLibrary;
@@ -67,7 +68,7 @@ public class Valuefier {
             return ConvertedList.newFromRubyArray((RubyArray) o);
         }
         if (o instanceof Map) {
-            return ConvertedMap.newFromMap((Map<String, Object>) o);
+            return ConvertedMap.newFromMap((Map<Serializable, Object>) o);
         }
         if (o instanceof List) {
             return ConvertedList.newFromList((List<Object>) o);

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -98,8 +98,9 @@ public class JrubyEventExtLibrary implements Library {
             } else if (data instanceof RubyHash) {
                 this.event = new Event(ConvertedMap.newFromRubyHash((RubyHash) data));
             } else if (data instanceof MapJavaProxy) {
-                Map<String, Object> m = (Map)((MapJavaProxy)data).getObject();
-                this.event = new Event(ConvertedMap.newFromMap(m));
+                this.event = new Event(ConvertedMap.newFromMap(
+                    (Map)((MapJavaProxy)data).getObject())
+                );
             } else {
                 throw context.runtime.newTypeError("wrong argument type " + data.getMetaClass() + " (expected Hash)");
             }


### PR DESCRIPTION
This actually shows up with a visible performance gain for me (~5-10% on the Apache dataset).

Two problems here:

```java
String.valueOf(BiValues.newBiValue(entry.getKey()).javaValue());
```

is not necessary. Both the Ruby and the Java strings are serializable, Java String just returns identity for the `toString`, `RubyString` returns Java string for it.
=> Saving at least one Object for each key here.

Also, the type `Map<String,Object>` was actually not correct here in the first place.
We were simply casting a `org.jruby.java.proxies.JavaProxy#getObject` here and it, in fact, contained `RubyString` as key type in practice (remember, casting generics like this isn't a safe operation).