### PR TITLE
broken Event.toString() when missing @timestamp

### DIFF
--- a/logstash-core/spec/logstash/legacy_ruby_event_spec.rb
+++ b/logstash-core/spec/logstash/legacy_ruby_event_spec.rb
@@ -590,15 +590,6 @@ describe LogStash::Event do
   describe "#to_s" do
     let(:timestamp) { LogStash::Timestamp.new }
     let(:event1) { LogStash::Event.new({ "@timestamp" => timestamp, "host" => "foo", "message" => "bar"}) }
-    let(:event2) { LogStash::Event.new({ "host" => "bar", "message" => "foo"}) }
-
-    it "should cache only one template" do
-      Java::OrgLogstash::StringInterpolation.clear_cache
-      expect {
-        event1.to_s
-        event2.to_s
-      }.to change { Java::OrgLogstash::StringInterpolation.cache_size }.by(1)
-    end
 
     it "return the string containing the timestamp, the host and the message" do
       expect(event1.to_s).to eq("#{timestamp.to_iso8601} #{event1.get("host")} #{event1.get("message")}")

--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -264,17 +264,15 @@ public class Event implements Cloneable, Serializable, Queueable {
     }
 
     public String toString() {
-        // TODO: (colin) clean this IOException handling, not sure why we bubble IOException here
+        Object hostField = this.getField("host");
+        Object messageField = this.getField("message");
+        String hostMessageString = (hostField != null ? hostField.toString() : "%{host}") + " " + (messageField != null ? messageField.toString() : "%{message}");
+
         try {
-            return (getTimestamp().toIso8601() + " " + this.sprintf("%{host} %{message}"));
+            // getTimestamp throws an IOException if there is no @timestamp field, see #7613
+            return getTimestamp().toIso8601() + " " + hostMessageString;
         } catch (IOException e) {
-            String host = (String)this.data.get("host");
-            host = (host != null ? host : "%{host}");
-
-            String message = (String)this.data.get("message");
-            message = (message != null ? message : "%{message}");
-
-            return (host + " " + message);
+            return hostMessageString;
         }
     }
 

--- a/logstash-core/src/test/java/org/logstash/EventTest.java
+++ b/logstash-core/src/test/java/org/logstash/EventTest.java
@@ -285,6 +285,28 @@ public class EventTest {
         assertEquals(tags.size(), 2);
         assertEquals(tags.get(0), "foo");
         assertEquals(tags.get(1), "bar");
-      }
+    }
 
+    @Test
+    public void toStringwithTimestamp() throws Exception {
+        Map data = new HashMap();
+        data.put("host", "foo");
+        data.put("message", "bar");
+        Event e = new Event(data);
+        assertEquals(e.toString(), e.getTimestamp().toIso8601() + " foo bar");
+    }
+
+    @Test
+    public void toStringwithoutTimestamp() throws Exception {
+        Map data = new HashMap();
+        data.put("host", "foo");
+        data.put("message", "bar");
+        Event e = new Event(data);
+        e.remove("@timestamp");
+        assertEquals(e.toString(), "foo bar");
+
+        e = new Event();
+        e.remove("@timestamp");
+        assertEquals(e.toString(), "%{host} %{message}");
+    }
 }


### PR DESCRIPTION
Fixes #6756 

The problem is the missing `@timestamp` handling which produces this exception when `Event.toString()` is called.

```
org.logstash.bivalues.StringBiValue cannot be cast to java.lang.String
```

Will also followup with an issue to review the `Event.getTimestamp()` behaviour in #7613

To manually repro this bug
```sh
bin/logstash -e 'filter{mutate{rename => {"@timestamp" => "foo"}}} output{stdout{}}'
```