### PR TITLE
MINOR: Clean up HotThreadsMonitor

### DIFF
--- a/logstash-core/src/main/java/org/logstash/instrument/monitors/HotThreadsMonitor.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/monitors/HotThreadsMonitor.java
@@ -1,30 +1,34 @@
 package org.logstash.instrument.monitors;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
-
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Hot threads monitoring class. This class pulls information out of the JVM #
  * provided beans and lest the different consumers query it.
  * Created by purbon on 12/12/15.
  */
-public class HotThreadsMonitor {
+public final class HotThreadsMonitor {
 
     private static final String ORDERED_BY = "ordered_by";
     private static final String STACKTRACE_SIZE = "stacktrace_size";
-    private final Logger logger = LogManager.getLogger(HotThreadsMonitor.class);
+    private static final Logger logger = LogManager.getLogger(HotThreadsMonitor.class);
+
+    private HotThreadsMonitor() {
+        //Utility Class
+    }
 
     /**
      * Placeholder for a given thread report
@@ -63,10 +67,6 @@ public class HotThreadsMonitor {
             return map;
         }
 
-        public String getThreadState() {
-            return (String) map.get(THREAD_STATE);
-        }
-
         public String getThreadName() {
             return (String) map.get(THREAD_NAME);
         }
@@ -98,21 +98,16 @@ public class HotThreadsMonitor {
         }
     }
 
-    private List<String> VALID_ORDER_BY = new ArrayList<>();
-
-    public HotThreadsMonitor() {
-        VALID_ORDER_BY.add("cpu");
-        VALID_ORDER_BY.add("wait");
-        VALID_ORDER_BY.add("block");
-    }
+    private static final Collection<String>
+        VALID_ORDER_BY = new HashSet<>(Arrays.asList("cpu", "wait", "block"));
 
     /**
      * Return the current hot threads information as provided by the JVM
      *
      * @return A list of ThreadReport including all selected threads
      */
-    public List<ThreadReport> detect() {
-        Map<String, String> options = new HashMap<String, String>();
+    public static List<ThreadReport> detect() {
+        Map<String, String> options = new HashMap<>();
         options.put(ORDERED_BY, "cpu");
         return detect(options);
     }
@@ -125,7 +120,7 @@ public class HotThreadsMonitor {
      *                      stacktrace_size - max depth of stack trace
      * @return A list of ThreadReport including all selected threads
      */
-    public List<ThreadReport> detect(Map<String, String> options) {
+    public static List<ThreadReport> detect(Map<String, String> options) {
         String type = "cpu";
         if (options.containsKey(ORDERED_BY)) {
             type = options.get(ORDERED_BY);
@@ -179,12 +174,11 @@ public class HotThreadsMonitor {
         }
     }
 
-    private boolean isValidSortOrder(String type) {
-        return VALID_ORDER_BY.indexOf(type.toLowerCase()) != -1;
+    private static boolean isValidSortOrder(String type) {
+        return VALID_ORDER_BY.contains(type.toLowerCase());
     }
 
-
-    private void enableCpuTime(ThreadMXBean threadMXBean) {
+    private static void enableCpuTime(ThreadMXBean threadMXBean) {
         try {
             if (threadMXBean.isThreadCpuTimeSupported()) {
                 if (!threadMXBean.isThreadCpuTimeEnabled()) {

--- a/logstash-core/src/main/java/org/logstash/instrument/reports/ThreadsReport.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/reports/ThreadsReport.java
@@ -22,8 +22,7 @@ public class ThreadsReport {
      * @return A Map containing hot threads information
      */
     public static Map<String, Object> generate(Map<String, String> options) {
-        HotThreadsMonitor reporter = new HotThreadsMonitor();
-        List<HotThreadsMonitor.ThreadReport> reports = reporter.detect(options);
+        List<HotThreadsMonitor.ThreadReport> reports = HotThreadsMonitor.detect(options);
         return reports
                 .stream()
                 .collect(Collectors

--- a/logstash-core/src/test/java/org/logstash/instruments/monitors/HotThreadMonitorTest.java
+++ b/logstash-core/src/test/java/org/logstash/instruments/monitors/HotThreadMonitorTest.java
@@ -16,32 +16,32 @@ public class HotThreadMonitorTest {
 
     @Test
     public void testThreadsReportsGenerated(){
-        assertThat(new HotThreadsMonitor().detect().size() > 0, is(true));
+        assertThat(HotThreadsMonitor.detect().size() > 0, is(true));
     }
 
     @Test
     public void testAllThreadsHaveCpuTime(){
-        new HotThreadsMonitor().detect().forEach(x -> assertThat(x.toMap().keySet(), hasItem("cpu.time")));
+        HotThreadsMonitor.detect().forEach(x -> assertThat(x.toMap().keySet(), hasItem("cpu.time")));
     }
 
     @Test
     public void testAllThreadsHaveThreadState(){
-        new HotThreadsMonitor().detect().forEach(x -> assertThat(x.toMap().keySet(), hasItem("thread.state")));
+        HotThreadsMonitor.detect().forEach(x -> assertThat(x.toMap().keySet(), hasItem("thread.state")));
     }
 
     @Test
     public void testAllThreadsHaveBlockedInformation(){
-        new HotThreadsMonitor().detect().forEach(x -> assertThat(x.toMap().keySet(), hasItems("blocked.count", "blocked.time")));
+        HotThreadsMonitor.detect().forEach(x -> assertThat(x.toMap().keySet(), hasItems("blocked.count", "blocked.time")));
     }
 
     @Test
     public void testAllThreadsHaveWaitedInformation(){
-        new HotThreadsMonitor().detect().forEach(x -> assertThat(x.toMap().keySet(), hasItems("waited.count", "waited.time")));
+        HotThreadsMonitor.detect().forEach(x -> assertThat(x.toMap().keySet(), hasItems("waited.count", "waited.time")));
     }
 
     @Test
     public void testAllThreadsHaveStackTraces(){
-        new HotThreadsMonitor().detect().forEach(tr -> assertThat(tr.toMap().keySet(), hasItem("thread.stacktrace")));
+        HotThreadsMonitor.detect().forEach(tr -> assertThat(tr.toMap().keySet(), hasItem("thread.stacktrace")));
     }
 
     @Test
@@ -49,7 +49,7 @@ public class HotThreadMonitorTest {
         final String testStackSize = "4";
         Map<String, String> options = new HashMap<>();
         options.put("stacktrace_size", testStackSize);
-        new HotThreadsMonitor().detect(options).stream().filter(tr -> !tr.getThreadName().equals("Signal Dispatcher") &&
+        HotThreadsMonitor.detect(options).stream().filter(tr -> !tr.getThreadName().equals("Signal Dispatcher") &&
                                                                       !tr.getThreadName().equals("Reference Handler"))
                                                         .forEach(tr -> {
             List stackTrace = (List)tr.toMap().get("thread.stacktrace");
@@ -63,7 +63,7 @@ public class HotThreadMonitorTest {
         options.put("ordered_by", "cpu");
         // Using single element array to circumvent lambda expectation of 'effective final'
         final long[] lastCpuTime = {Long.MAX_VALUE};
-        new HotThreadsMonitor().detect(options).forEach(tr -> {
+        HotThreadsMonitor.detect(options).forEach(tr -> {
             Long cpuTime = (Long)tr.toMap().get("cpu.time");
             assertThat(lastCpuTime[0] >= cpuTime, is(true));
             lastCpuTime[0] = cpuTime;
@@ -76,7 +76,7 @@ public class HotThreadMonitorTest {
         options.put("ordered_by", "wait");
         // Using single element array to circumvent lambda expectation of 'effectively final'
         final long[] lastWaitTime = {Long.MAX_VALUE};
-        new HotThreadsMonitor().detect(options).forEach(tr -> {
+        HotThreadsMonitor.detect(options).forEach(tr -> {
             Long waitTime = (Long)tr.toMap().get("waited.time");
             assertThat(lastWaitTime[0] >= waitTime, is(true));
             lastWaitTime[0] = waitTime;
@@ -89,7 +89,7 @@ public class HotThreadMonitorTest {
         options.put("ordered_by", "block");
         // Using single element array to circumvent lambda expectation of 'effectively final'
         final long[] lastBlockedTime = {Long.MAX_VALUE};
-        new HotThreadsMonitor().detect(options).forEach(tr -> {
+        HotThreadsMonitor.detect(options).forEach(tr -> {
             Long blockedTime = (Long)tr.toMap().get("blocked.time");
             assertThat(lastBlockedTime[0] >= blockedTime, is(true));
             lastBlockedTime[0] = blockedTime;


### PR DESCRIPTION
Trivial cleanup:

* Made Logger `static`
* Made constant `Collection` of valid order keys `static final` (and used a set to make the lookup faster)
* Made everything that was `static` as a result explicitly `static`