### PR TITLE
 #7611 Fix missing `static` in `5.x`

### DIFF
--- a/logstash-core/src/main/java/org/logstash/instrument/monitors/HotThreadsMonitor.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/monitors/HotThreadsMonitor.java
@@ -159,12 +159,12 @@ public final class HotThreadsMonitor {
         return sort(new ArrayList<>(reports.values()), type);
      }
 
-    private List<ThreadReport> sort(List<ThreadReport> reports, final String type) {
+    private static List<ThreadReport> sort(List<ThreadReport> reports, final String type) {
         reports.sort(comparatorForOrderType(type));
         return reports;
     }
 
-    private Comparator<ThreadReport> comparatorForOrderType(final String type){
+    private static Comparator<ThreadReport> comparatorForOrderType(final String type){
         if ("block".equals(type)){
             return Comparator.comparingLong(ThreadReport::getBlockedTime).reversed();
         } else if ("wait".equals(type)) {


### PR DESCRIPTION
fixes #7611 

Trivial, just missing a `static`.