### PR TITLE
PERFORMANCE: Remove needless locking on batch reads

### DIFF
--- a/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
@@ -6,7 +6,7 @@ module LogStash; module Util
     java_import java.util.concurrent.TimeUnit
 
     def initialize
-      @queue = java.util.concurrent.SynchronousQueue.new
+      @queue = SynchronousQueue.new
     end
 
     # Push an object to the queue if the queue is full
@@ -118,12 +118,7 @@ module LogStash; module Util
 
       def read_batch
         batch = new_batch
-        @mutex.lock
-        begin
-          batch.read_next
-        ensure
-          @mutex.unlock
-        end
+        batch.read_next
         start_metrics(batch)
         batch
       end


### PR DESCRIPTION
The locking on `read_next` serves no purpose as far as I can tell.
It only guards this block:

```rb
      def read_next
        @size.times do |t|
          event = @queue.poll(@wait)
          return if event.nil? # queue poll timed out

          @originals[event] = true
        end
      end
```

The instance variables here are not shared with other instances since the batch object is created in the same thread as the `read_next` is called in (except for `@queue` which is thread-safe anyways).

=> ~10% speedup in the Apache logs case.

* also removed the needless package qualifier on the `SynchronousQueue` (it's imported via `java_import` anyways).