### PR TITLE
MINOR: Remove needless singleton use in pathcache

### DIFF
--- a/logstash-core/src/main/java/org/logstash/PathCache.java
+++ b/logstash-core/src/main/java/org/logstash/PathCache.java
@@ -2,30 +2,21 @@ package org.logstash;
 
 import java.util.concurrent.ConcurrentHashMap;
 
-public class PathCache {
+public final class PathCache {
 
-    private static PathCache instance = null;
-    private static ConcurrentHashMap<String, FieldReference> cache = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, FieldReference> cache = new ConcurrentHashMap<>();
 
-    private FieldReference timestamp;
+    private static final FieldReference timestamp = cache(Event.TIMESTAMP);
 
     private static final String BRACKETS_TIMESTAMP = "[" + Event.TIMESTAMP + "]";
 
-    protected PathCache() {
+    static {
         // inject @timestamp
-        this.timestamp = cache(Event.TIMESTAMP);
-        cache(BRACKETS_TIMESTAMP, this.timestamp);
+        cache(BRACKETS_TIMESTAMP, timestamp);
     }
 
-    public static PathCache getInstance() {
-        if (instance == null) {
-            instance = new PathCache();
-        }
-        return instance;
-    }
-
-    public boolean isTimestamp(String reference) {
-        return (cache(reference) == this.timestamp);
+    public static boolean isTimestamp(String reference) {
+        return cache(reference) == timestamp;
     }
 
     public static FieldReference cache(String reference) {

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -120,7 +120,7 @@ public class JrubyEventExtLibrary implements Library {
         {
             String r = reference.asJavaString();
 
-            if (PathCache.getInstance().isTimestamp(r)) {
+            if (PathCache.isTimestamp(r)) {
                 if (!(value instanceof JrubyTimestampExtLibrary.RubyTimestamp)) {
                     throw context.runtime.newTypeError("wrong argument type " + value.getMetaClass() + " (expected LogStash::Timestamp)");
                 }


### PR DESCRIPTION
Just doesn't make sense to have a singleton with lazy initialization here when this thing is used on ever set to an `Event`. Saves some lines of code and a few function calls per `set`.