### PR TITLE
MINOR: Cleanup redundant casts + fix bug resulting from one of them

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Cloner.java
+++ b/logstash-core/src/main/java/org/logstash/Cloner.java
@@ -21,11 +21,11 @@ public final class Cloner {
     private static <E> List<E> deepList(final List<E> list) {
         List<E> clone;
         if (list instanceof LinkedList<?>) {
-            clone = new LinkedList<E>();
+            clone = new LinkedList<>();
         } else if (list instanceof ArrayList<?>) {
-            clone = new ArrayList<E>();
+            clone = new ArrayList<>();
         } else if (list instanceof ConvertedList<?>) {
-            clone = new ArrayList<E>();
+            clone = new ArrayList<>();
         } else {
             throw new ClassCastException("unexpected List type " + list.getClass());
         }
@@ -40,13 +40,13 @@ public final class Cloner {
     private static <K, V> Map<K, V> deepMap(final Map<K, V> map) {
         Map<K, V> clone;
         if (map instanceof LinkedHashMap<?, ?>) {
-            clone = new LinkedHashMap<K, V>();
+            clone = new LinkedHashMap<>();
         } else if (map instanceof TreeMap<?, ?>) {
-            clone = new TreeMap<K, V>();
+            clone = new TreeMap<>();
         } else if (map instanceof HashMap<?, ?>) {
-            clone = new HashMap<K, V>();
+            clone = new HashMap<>();
         } else if (map instanceof ConvertedMap<?, ?>) {
-            clone = new HashMap<K, V>();
+            clone = new HashMap<>();
         } else {
             throw new ClassCastException("unexpected Map type " + map.getClass());
         }

--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -185,10 +185,10 @@ public class Event implements Cloneable, Serializable, Queueable {
 
     private static Map<String, Map<String, Object>> fromBinaryToMap(byte[] source) throws IOException {
         Object o = CBOR_MAPPER.readValue(source, HashMap.class);
-        if (o instanceof Map) {
-            return (HashMap<String, Map<String, Object>>) o;
+        if (o == null) {
+            throw new IOException("incompatible from binary object type only HashMap is supported");
         } else {
-            throw new IOException("incompatible from binary object type=" + o.getClass().getName() + " , only HashMap is supported");
+            return (Map<String, Map<String, Object>>) o;
         }
     }
 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedBatchExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedBatchExtLibrary.java
@@ -1,5 +1,6 @@
 package org.logstash.ackedqueue.ext;
 
+import java.util.List;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
@@ -13,6 +14,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.load.Library;
 import org.logstash.ackedqueue.Batch;
 import org.logstash.Event;
+import org.logstash.ackedqueue.Queueable;
 import org.logstash.ext.JrubyEventExtLibrary;
 
 import java.io.IOException;
@@ -59,7 +61,7 @@ public class JrubyAckedBatchExtLibrary implements Library {
                 context.runtime.newArgumentError("expected queue AckedQueue");
             }
 
-            this.batch = new Batch(((RubyArray)events), ((RubyArray)seqNums), ((JrubyAckedQueueExtLibrary.RubyAckedQueue)queue).getQueue());
+            this.batch = new Batch((List<Queueable>) events, (List<Long>) seqNums, ((JrubyAckedQueueExtLibrary.RubyAckedQueue)queue).getQueue());
 
             return context.nil;
         }

--- a/logstash-core/src/main/java/org/logstash/bivalues/TimestampBiValue.java
+++ b/logstash-core/src/main/java/org/logstash/bivalues/TimestampBiValue.java
@@ -22,7 +22,7 @@ public class TimestampBiValue extends BiValueCommon<RubyTimestamp, Timestamp> im
     }
 
     protected void addRuby(Ruby runtime) {
-        rubyValue = RubyTimestamp.newRubyTimestamp(runtime, (Timestamp) javaValue);
+        rubyValue = RubyTimestamp.newRubyTimestamp(runtime, javaValue);
     }
 
     protected void addJava() {

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -281,7 +281,7 @@ public class JrubyEventExtLibrary implements Library {
         public IRubyObject ruby_tag(ThreadContext context, RubyString value)
         {
             //TODO(guy) should these tags be BiValues?
-            this.event.tag(((RubyString) value).asJavaString());
+            this.event.tag(value.asJavaString());
             return context.nil;
         }
 

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
@@ -1,10 +1,17 @@
 package org.logstash.ext;
 
-import org.jruby.*;
+import java.io.IOException;
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.RubyFixnum;
+import org.jruby.RubyFloat;
+import org.jruby.RubyModule;
+import org.jruby.RubyObject;
+import org.jruby.RubyString;
+import org.jruby.RubyTime;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.RaiseException;
-import org.jruby.ext.bigdecimal.RubyBigDecimal;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.Arity;
 import org.jruby.runtime.ObjectAllocator;
@@ -12,8 +19,6 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.load.Library;
 import org.logstash.Timestamp;
-
-import java.io.IOException;
 
 public class JrubyTimestampExtLibrary implements Library {
 
@@ -90,7 +95,7 @@ public class JrubyTimestampExtLibrary implements Library {
                 this.timestamp = new Timestamp(((RubyTime)time).getDateTime());
             } else if (time instanceof RubyString) {
                 try {
-                    this.timestamp = new Timestamp(((RubyString) time).toString());
+                    this.timestamp = new Timestamp(time.toString());
                 } catch (IllegalArgumentException e) {
                     throw new RaiseException(
                             getRuntime(),
@@ -161,7 +166,7 @@ public class JrubyTimestampExtLibrary implements Library {
             } else if (time instanceof RubyTime) {
                 return new Timestamp(((RubyTime)time).getDateTime());
             } else if (time instanceof RubyString) {
-                return new Timestamp(((RubyString) time).toString());
+                return new Timestamp(time.toString());
             } else if (time instanceof RubyTimestamp) {
                 return new Timestamp(((RubyTimestamp) time).timestamp);
             } else {


### PR DESCRIPTION
With the exception of the change to `Event` just standard cleanup of either overly precise casting or completely redundant casting.

The change to `Event` fixes an actual bug though!
* The return of `CBOR_MAPPER.readValue(source, HashMap.class)` will always be a `Map` or `null` => the current implementation would throw `NPE` when running into the else block's `o.getClass().getName()`