### PR TITLE
VERSION BUMP: 6.0.0-alpha3 -> 6.0.0-beta1

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ For the daring, snapshot builds from `master` branch are available. These builds
 
 | artifact |
 | --- |
-| [tar](https://snapshots.elastic.co/downloads/logstash/logstash-6.0.0-alpha3-SNAPSHOT.tar.gz) |
-| [zip](https://snapshots.elastic.co/downloads/logstash/logstash-6.0.0-alpha3-SNAPSHOT.zip) |
-| [deb](https://snapshots.elastic.co/downloads/logstash/logstash-6.0.0-alpha3-SNAPSHOT.deb) |
-| [rpm](https://snapshots.elastic.co/downloads/logstash/logstash-6.0.0-alpha3-SNAPSHOT.rpm) |
+| [tar](https://snapshots.elastic.co/downloads/logstash/logstash-6.0.0-beta1-SNAPSHOT.tar.gz) |
+| [zip](https://snapshots.elastic.co/downloads/logstash/logstash-6.0.0-beta1-SNAPSHOT.zip) |
+| [deb](https://snapshots.elastic.co/downloads/logstash/logstash-6.0.0-beta1-SNAPSHOT.deb) |
+| [rpm](https://snapshots.elastic.co/downloads/logstash/logstash-6.0.0-beta1-SNAPSHOT.rpm) |
 
 ## Need Help?
 

--- a/docs/index-shared1.asciidoc
+++ b/docs/index-shared1.asciidoc
@@ -1,9 +1,9 @@
 
 :branch:                master
 :major-version:         6.x
-:logstash_version:      6.0.0-alpha3
-:elasticsearch_version: 6.0.0-alpha3
-:kibana_version:        6.0.0-alpha3
+:logstash_version:      6.0.0-beta1
+:elasticsearch_version: 6.0.0-beta1
+:kibana_version:        6.0.0-beta1
 :docker-image:          docker.elastic.co/logstash/logstash:{logstash_version}
 
 //////////

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -3,14 +3,14 @@
 
 This section summarizes the changes in the following releases:
 
-* <<logstash-6-0-0-alpha3,Logstash 6.0.0-alpha3>>
+* <<logstash-6-0-0-beta1,Logstash 6.0.0-beta1>>
 * <<logstash-6-0-0-alpha2,Logstash 6.0.0-alpha2>>
 * <<logstash-6-0-0-alpha1,Logstash 6.0.0-alpha1>>
 
-[[logstash-6-0-0-alpha3]]
-=== Logstash 6.0.0-alpha3 Release Notes
+[[logstash-6-0-0-beta1]]
+=== Logstash 6.0.0-beta1 Release Notes
 
-Placeholder for alpha3 release notes
+Placeholder for beta1 release notes
 
 * Added new `logstash.yml` setting: `config.support_escapes`. When
   enabled, Logstash will interpret escape sequences in strings in the pipeline

--- a/logstash-core-plugin-api/logstash-core-plugin-api.gemspec
+++ b/logstash-core-plugin-api/logstash-core-plugin-api.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = LOGSTASH_CORE_PLUGIN_API
 
-  gem.add_runtime_dependency "logstash-core", "6.0.0.alpha3"
+  gem.add_runtime_dependency "logstash-core", "6.0.0.beta1"
 
   # Make sure we dont build this gem from a non jruby
   # environment.

--- a/logstash-core/lib/logstash-core/version.rb
+++ b/logstash-core/lib/logstash-core/version.rb
@@ -5,4 +5,4 @@
 # Note to authors: this should not include dashes because 'gem' barfs if
 # you include a dash in the version string.
 
-LOGSTASH_CORE_VERSION = "6.0.0-alpha3"
+LOGSTASH_CORE_VERSION = "6.0.0-beta1"

--- a/logstash-core/lib/logstash/modules/kibana_client.rb
+++ b/logstash-core/lib/logstash/modules/kibana_client.rb
@@ -39,7 +39,7 @@ module LogStash module Modules class KibanaClient
       @http_options[:headers]['Authorization'] = 'Basic ' + Base64.encode64( "#{username}:#{password}" ).chomp
     end
 
-    # e.g. {"name":"Elastics-MacBook-Pro.local","version":{"number":"6.0.0-alpha3","build_hash":"41e69","build_number":15613,"build_snapshot":true}..}
+    # e.g. {"name":"Elastics-MacBook-Pro.local","version":{"number":"6.0.0-beta1","build_hash":"41e69","build_number":15613,"build_snapshot":true}..}
     @version = "0.0.0"
     response = get("api/status")
     if response.succeeded?

--- a/logstash-core/lib/logstash/modules/kibana_settings.rb
+++ b/logstash-core/lib/logstash/modules/kibana_settings.rb
@@ -22,7 +22,7 @@ module LogStash module Modules class KibanaSettings < KibanaBase
 
   def import(client)
     # e.g. curl "http://localhost:5601/api/kibana/settings"
-    # 6.0.0-alpha3 -> {"settings":{"buildNum":{"userValue":15613},"defaultIndex":{"userValue":"arcsight-*"}}}
+    # 6.0.0-beta1 -> {"settings":{"buildNum":{"userValue":15613},"defaultIndex":{"userValue":"arcsight-*"}}}
     # 5.4 -> {"settings":{"defaultIndex":{"userValue":"cef-*"},"metrics:max_buckets":{"userValue":"600000"}}}
     # array of Setting objects
     # The POST api body { "changes": { "defaultIndex": "arcsight-*", "metrics:max_buckets": "400" } }

--- a/logstash-core/lib/logstash/version.rb
+++ b/logstash-core/lib/logstash/version.rb
@@ -11,4 +11,4 @@
 #       eventually this file should be in the root logstash lib fir and dependencies in logstash-core should be
 #       fixed.
 
-LOGSTASH_VERSION = "6.0.0-alpha3"
+LOGSTASH_VERSION = "6.0.0-beta1"

--- a/versions.yml
+++ b/versions.yml
@@ -1,6 +1,6 @@
 ---
-logstash: 6.0.0-alpha3
-logstash-core: 6.0.0-alpha3
+logstash: 6.0.0-beta1
+logstash-core: 6.0.0-beta1
 logstash-core-plugin-api: 2.1.16
 jruby:
   version: 9.1.12.0


### PR DESCRIPTION
Following ES's lead : https://github.com/elastic/elasticsearch/commit/c084542731c49734dad373bca2d23e62cd0158b5

Find/replace for all instances of alpha3 to beta1 (since alpha3 was never released). 