### PR TITLE
Minor: Avoid redundant Java to Ruby conversions

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -56,10 +56,23 @@ public class Event implements Cloneable, Serializable, Queueable {
         this.metadata_accessors = new Accessors(this.metadata);
     }
 
-    public Event(Map data)
-    {
-        this.data = (Map<String, Object>)Valuefier.convert(data);
+    /**
+     * Constructor from a map that will be copied and the copy will have its contents converted to
+     * Java objects.
+     * @param data Map that is assumed to have either {@link String} or {@link org.jruby.RubyString}
+     * keys and may contain Java and Ruby objects.
+     */
+    public Event(Map data) {
+        this(ConvertedMap.newFromMap(data));
+    }
 
+    /**
+     * Constructor wrapping a {@link ConvertedMap} without copying it. Any changes this instance
+     * makes to its underlying data will be propagated to it.
+     * @param data Converted Map
+     */
+    public Event(ConvertedMap<String, Object> data) {
+        this.data = data;
         if (!this.data.containsKey(VERSION)) {
             this.data.put(VERSION, VERSION_ONE);
         }


### PR DESCRIPTION
This cleans up one redundant set of Ruby to Java conversions, which shows with a visible performance gain on my test machine (~5-10% for me).
The more complex your events, the larger the gain most likely.

The reason being that we are setting up events with this code:

```java
            } else if (data instanceof RubyHash) {
                this.event = new Event(ConvertedMap.newFromRubyHash((RubyHash) data));
            } else if (data instanceof MapJavaProxy) {
                this.event = new Event(ConvertedMap.newFromMap(
                    (Map)((MapJavaProxy)data).getObject())
                );
            } else {
```

This already creates a `ConvertedMap` that is a copy of the input data. In the current code we run these maps that we know to be converted already through the converter again, creating a new copy of it needlessly.
Also it can't hurt to directly call `ConvertedMap.newFromMap(data)` when we know it's a `Map` instead of taking the detour of the `Valuefier` which has no typed interface.