### PR TITLE
MINOR: Remove redundant wrapping and generics

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Cloner.java
+++ b/logstash-core/src/main/java/org/logstash/Cloner.java
@@ -24,7 +24,7 @@ public final class Cloner {
             clone = new LinkedList<>();
         } else if (list instanceof ArrayList<?>) {
             clone = new ArrayList<>();
-        } else if (list instanceof ConvertedList<?>) {
+        } else if (list instanceof ConvertedList) {
             clone = new ArrayList<>();
         } else {
             throw new ClassCastException("unexpected List type " + list.getClass());
@@ -45,7 +45,7 @@ public final class Cloner {
             clone = new TreeMap<>();
         } else if (map instanceof HashMap<?, ?>) {
             clone = new HashMap<>();
-        } else if (map instanceof ConvertedMap<?, ?>) {
+        } else if (map instanceof ConvertedMap) {
             clone = new HashMap<>();
         } else {
             throw new ClassCastException("unexpected Map type " + map.getClass());

--- a/logstash-core/src/main/java/org/logstash/ConvertedList.java
+++ b/logstash-core/src/main/java/org/logstash/ConvertedList.java
@@ -1,31 +1,20 @@
 package org.logstash;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.jruby.RubyArray;
 import org.jruby.runtime.builtin.IRubyObject;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Spliterator;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
-import java.util.stream.Stream;
-
 import static org.logstash.Valuefier.convert;
 
-public class ConvertedList<T> implements List<T> {
-    private final List<T> delegate;
+public final class ConvertedList extends ArrayList<Object> {
 
-    public ConvertedList(final int size) {
-        this.delegate = new ArrayList<>(size);
+    private ConvertedList(final int size) {
+        super(size);
     }
 
-    public static ConvertedList<Object> newFromList(List<Object> list) {
-        ConvertedList<Object> array = new ConvertedList<>(list.size());
+    public static ConvertedList newFromList(List<Object> list) {
+        ConvertedList array = new ConvertedList(list.size());
 
         for (Object item : list) {
             array.add(convert(item));
@@ -33,8 +22,16 @@ public class ConvertedList<T> implements List<T> {
         return array;
     }
 
-    public static ConvertedList<Object> newFromRubyArray(RubyArray a) {
-        final ConvertedList<Object> result = new ConvertedList<>(a.size());
+    public static ConvertedList newFromRubyArray(final IRubyObject[] a) {
+        final ConvertedList result = new ConvertedList(a.length);
+        for (IRubyObject o : a) {
+            result.add(convert(o));
+        }
+        return result;
+    }
+
+    public static ConvertedList newFromRubyArray(RubyArray a) {
+        final ConvertedList result = new ConvertedList(a.size());
 
         for (IRubyObject o : a.toJavaArray()) {
             result.add(convert(o));
@@ -42,180 +39,19 @@ public class ConvertedList<T> implements List<T> {
         return result;
     }
 
-    public Object unconvert() {
+    public List<Object> unconvert() {
         final ArrayList<Object> result = new ArrayList<>(size());
-        for (Object obj : delegate) {
+        for (Object obj : this) {
             result.add(Javafier.deep(obj));
         }
         return result;
     }
 
-    // delegate methods
-    @Override
-    public int size() {
-        return delegate.size();
-    }
-
-    @Override
-    public boolean isEmpty() {
-        return delegate.isEmpty();
-    }
-
-    @Override
-    public boolean contains(Object o) {
-        return delegate.contains(o);
-    }
-
-    @Override
-    public Iterator<T> iterator() {
-        return delegate.iterator();
-    }
-
-    @Override
-    public Object[] toArray() {
-        return delegate.toArray();
-    }
-
-    @Override
-    public <T1> T1[] toArray(T1[] a) {
-        return delegate.toArray(a);
-    }
-
-    @Override
-    public boolean add(T t) {
-        return delegate.add(t);
-    }
-
-    @Override
-    public boolean remove(Object o) {
-        return delegate.remove(o);
-    }
-
-    @Override
-    public boolean containsAll(Collection<?> c) {
-        return delegate.containsAll(c);
-    }
-
-    @Override
-    public boolean addAll(Collection<? extends T> c) {
-        return delegate.addAll(c);
-    }
-
-    @Override
-    public boolean addAll(int index, Collection<? extends T> c) {
-        return delegate.addAll(index, c);
-    }
-
-    @Override
-    public boolean removeAll(Collection<?> c) {
-        return delegate.removeAll(c);
-    }
-
-    @Override
-    public boolean retainAll(Collection<?> c) {
-        return delegate.retainAll(c);
-    }
-
-    @Override
-    public void replaceAll(UnaryOperator<T> operator) {
-        delegate.replaceAll(operator);
-    }
-
-    @Override
-    public void sort(Comparator<? super T> c) {
-        delegate.sort(c);
-    }
-
-    @Override
-    public void clear() {
-        delegate.clear();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        return delegate.equals(o);
-    }
-
-    @Override
-    public int hashCode() {
-        return delegate.hashCode();
-    }
-
-    @Override
-    public T get(int index) {
-        return delegate.get(index);
-    }
-
-    @Override
-    public T set(int index, T element) {
-        return delegate.set(index, element);
-    }
-
-    @Override
-    public void add(int index, T element) {
-        delegate.add(index, element);
-    }
-
-    @Override
-    public T remove(int index) {
-        return delegate.remove(index);
-    }
-
-    @Override
-    public int indexOf(Object o) {
-        return delegate.indexOf(o);
-    }
-
-    @Override
-    public int lastIndexOf(Object o) {
-        return delegate.lastIndexOf(o);
-    }
-
-    @Override
-    public ListIterator<T> listIterator() {
-        return delegate.listIterator();
-    }
-
-    @Override
-    public ListIterator<T> listIterator(int index) {
-        return delegate.listIterator(index);
-    }
-
-    @Override
-    public List<T> subList(int fromIndex, int toIndex) {
-        return delegate.subList(fromIndex, toIndex);
-    }
-
-    @Override
-    public Spliterator<T> spliterator() {
-        return delegate.spliterator();
-    }
-
     @Override
     public String toString() {
         final StringBuffer sb = new StringBuffer("ConvertedList{");
-        sb.append("delegate=").append(delegate.toString());
+        sb.append("delegate=").append(super.toString());
         sb.append('}');
         return sb.toString();
-    }
-
-    @Override
-    public boolean removeIf(Predicate<? super T> filter) {
-        return delegate.removeIf(filter);
-    }
-
-    @Override
-    public Stream<T> stream() {
-        return delegate.stream();
-    }
-
-    @Override
-    public Stream<T> parallelStream() {
-        return delegate.parallelStream();
-    }
-
-    @Override
-    public void forEach(Consumer<? super T> action) {
-        delegate.forEach(action);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/ConvertedMap.java
+++ b/logstash-core/src/main/java/org/logstash/ConvertedMap.java
@@ -1,34 +1,27 @@
 package org.logstash;
 
 import java.io.Serializable;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 import org.jruby.RubyHash;
 import org.jruby.runtime.builtin.IRubyObject;
 
-public class ConvertedMap<K, V> implements Map<K, V> {
+public final class ConvertedMap extends HashMap<String, Object> {
 
-    private final Map<K, V> delegate;
-
-    private ConvertedMap(final int size) {
-        this.delegate = new HashMap<>(size);
+    public ConvertedMap(final int size) {
+        super(size);
     }
-
-    public static ConvertedMap<String, Object> newFromMap(Map<Serializable, Object> o) {
-        ConvertedMap<String, Object> cm = new ConvertedMap<>(o.size());
+    
+    public static ConvertedMap newFromMap(Map<Serializable, Object> o) {
+        ConvertedMap cm = new ConvertedMap(o.size());
         for (final Map.Entry<Serializable, Object> entry : o.entrySet()) {
             cm.put(entry.getKey().toString(), Valuefier.convert(entry.getValue()));
         }
         return cm;
     }
 
-    public static ConvertedMap<String, Object> newFromRubyHash(RubyHash o) {
-        final ConvertedMap<String, Object> result = new ConvertedMap<>(o.size());
+    public static ConvertedMap newFromRubyHash(RubyHash o) {
+        final ConvertedMap result = new ConvertedMap(o.size());
 
         o.visitAll(o.getRuntime().getCurrentContext(), new RubyHash.Visitor() {
             @Override
@@ -40,136 +33,10 @@ public class ConvertedMap<K, V> implements Map<K, V> {
     }
 
     public Object unconvert() {
-        final HashMap<K, V> result = new HashMap<>(size());
-        for (final Map.Entry<K, V> entry : entrySet()) {
-            result.put(entry.getKey(), (V) Javafier.deep(entry.getValue()));
+        final HashMap<String, Object> result = new HashMap<>(size());
+        for (final Map.Entry<String, Object> entry : entrySet()) {
+            result.put(entry.getKey(), Javafier.deep(entry.getValue()));
         }
         return result;
-    }
-
-    // Delegate methods
-    @Override
-    public int size() {
-        return delegate.size();
-    }
-
-    @Override
-    public boolean isEmpty() {
-        return delegate.isEmpty();
-    }
-
-    @Override
-    public boolean containsKey(Object key) {
-        return delegate.containsKey(key);
-    }
-
-    @Override
-    public boolean containsValue(Object value) {
-        return delegate.containsValue(value);
-    }
-
-    @Override
-    public V get(Object key) {
-        return delegate.get(key);
-    }
-
-    @Override
-    public V put(K key, V value) {
-        return delegate.put(key, value);
-    }
-
-    @Override
-    public V remove(Object key) {
-        return delegate.remove(key);
-    }
-
-    @Override
-    public void putAll(Map<? extends K, ? extends V> m) {
-        delegate.putAll(m);
-    }
-
-    @Override
-    public void clear() {
-        delegate.clear();
-    }
-
-    @Override
-    public Set<K> keySet() {
-        return delegate.keySet();
-    }
-
-    @Override
-    public Collection<V> values() {
-        return delegate.values();
-    }
-
-    @Override
-    public Set<Entry<K, V>> entrySet() {
-        return delegate.entrySet();
-    }
-
-    @Override
-    public V getOrDefault(Object key, V defaultValue) {
-        return delegate.getOrDefault(key, defaultValue);
-    }
-
-    @Override
-    public void forEach(BiConsumer<? super K, ? super V> action) {
-        delegate.forEach(action);
-    }
-
-    @Override
-    public void replaceAll(BiFunction<? super K, ? super V, ? extends V> function) {
-        delegate.replaceAll(function);
-    }
-
-    @Override
-    public V putIfAbsent(K key, V value) {
-        return delegate.putIfAbsent(key, value);
-    }
-
-    @Override
-    public boolean remove(Object key, Object value) {
-        return delegate.remove(key, value);
-    }
-
-    @Override
-    public boolean replace(K key, V oldValue, V newValue) {
-        return delegate.replace(key, oldValue, newValue);
-    }
-
-    @Override
-    public V replace(K key, V value) {
-        return delegate.replace(key, value);
-    }
-
-    @Override
-    public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
-        return delegate.computeIfAbsent(key, mappingFunction);
-    }
-
-    @Override
-    public V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
-        return delegate.computeIfPresent(key, remappingFunction);
-    }
-
-    @Override
-    public V compute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
-        return delegate.compute(key, remappingFunction);
-    }
-
-    @Override
-    public V merge(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
-        return delegate.merge(key, value, remappingFunction);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        return delegate.equals(o);
-    }
-
-    @Override
-    public int hashCode() {
-        return delegate.hashCode();
     }
 }

--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -71,7 +71,7 @@ public class Event implements Cloneable, Serializable, Queueable {
      * makes to its underlying data will be propagated to it.
      * @param data Converted Map
      */
-    public Event(ConvertedMap<String, Object> data) {
+    public Event(ConvertedMap data) {
         this.data = data;
         if (!this.data.containsKey(VERSION)) {
             this.data.put(VERSION, VERSION_ONE);

--- a/logstash-core/src/main/java/org/logstash/Valuefier.java
+++ b/logstash-core/src/main/java/org/logstash/Valuefier.java
@@ -27,12 +27,7 @@ public class Valuefier {
     private static Object convertJavaProxy(JavaProxy jp) {
         Object obj = JavaUtil.unwrapJavaObject(jp);
         if (obj instanceof IRubyObject[]) {
-            final IRubyObject[] arr = (IRubyObject[]) obj;
-            ConvertedList<Object> list = new ConvertedList<>(arr.length);
-            for (IRubyObject ro : arr) {
-                list.add(convert(ro));
-            }
-            return list;
+            return ConvertedList.newFromRubyArray((IRubyObject[]) obj);
         }
         if (obj instanceof List) {
             return ConvertedList.newFromList((List<Object>) obj);

--- a/logstash-core/src/test/java/org/logstash/ValuefierTest.java
+++ b/logstash-core/src/test/java/org/logstash/ValuefierTest.java
@@ -36,7 +36,7 @@ public class ValuefierTest extends TestBase {
 
         Object result = Valuefier.convert(mjp);
         assertEquals(ConvertedMap.class, result.getClass());
-        ConvertedMap<String, Object> m = (ConvertedMap) result;
+        ConvertedMap m = (ConvertedMap) result;
         BiValue bv = BiValues.newBiValue("bar");
         assertEquals(bv.javaValue(), ((BiValue) m.get("foo")).javaValue());
     }


### PR DESCRIPTION
Pretty trivial cleanup if you think it about it:

* Our wrapping of `Hashmap` is only used to identify `Hashmap` that hold values that we ran through the `Valuefier`.
  * We can save at least one object (and level of indirection) for every one of these maps and lists by not wrapping but extending
  * We don't need these to be generic, we always just use `<Object>` or `<String, Object>` respectively anyways => much safer to enforce this type without generics

=> slight performance gain and memory saving (YK shows avg. GC pause going from 42ms to 36ms with this change, running the Apache dataset)
=> 300 lines of redundant code saved