### PR TITLE
#7662 Make StringBiValue safe against mutations to the underlying RubyString

### DIFF
--- a/logstash-core/spec/logstash/event_spec.rb
+++ b/logstash-core/spec/logstash/event_spec.rb
@@ -84,6 +84,15 @@ describe LogStash::Event do
       expect(e.get("foo")).to eq("bar")
     end
 
+    it "should propagate changes to mutable strings to java APIs" do
+      e = LogStash::Event.new()
+      e.to_java.setField("foo", "bar")
+      expect(e.get("foo")).to eq("bar")
+      e.get("foo").gsub!(/bar/, 'pff')
+      expect(e.get("foo")).to eq("pff")
+      expect(e.to_java.getField("foo")).to eq("pff")
+    end
+
     it "should set deep hash values" do
       e = LogStash::Event.new()
       expect(e.set("[foo][bar]", "baz")).to eq("baz")

--- a/logstash-core/src/main/java/org/logstash/bivalues/StringBiValue.java
+++ b/logstash-core/src/main/java/org/logstash/bivalues/StringBiValue.java
@@ -1,15 +1,15 @@
 package org.logstash.bivalues;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.io.ObjectStreamException;
 import org.jruby.Ruby;
 import org.jruby.RubyString;
 
-import java.io.ObjectStreamException;
-
-public class StringBiValue extends BiValueCommon<RubyString, String> implements BiValue<RubyString, String> {
+public final class StringBiValue extends BiValueCommon<RubyString, String>
+    implements BiValue<RubyString, String> {
 
     public StringBiValue(RubyString rubyValue) {
         this.rubyValue = rubyValue;
-        javaValue = null;
     }
 
     public StringBiValue(String javaValue) {
@@ -20,12 +20,35 @@ public class StringBiValue extends BiValueCommon<RubyString, String> implements 
     private StringBiValue() {
     }
 
+    @Override
+    @JsonValue
+    public String javaValue() {
+        return rubyValue != null ? rubyValue.toString() : javaValue;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o instanceof BiValue) {
+            final BiValueCommon<?, ?> other = (BiValueCommon<?, ?>) o;
+            return other.hasRubyValue() && other.rubyValueUnconverted().equals(rubyValue) ||
+                (other.hasJavaValue() && other.javaValue().equals(this.javaValue()));
+        } else {
+            return String.class.isAssignableFrom(o.getClass()) && this.javaValue().equals(o);
+        }
+    }
+
     protected void addRuby(Ruby runtime) {
         rubyValue = RubyString.newUnicodeString(runtime, javaValue);
     }
 
+    @Override
     protected void addJava() {
-        javaValue = rubyValue.asJavaString();
+    }
+
+    @Override
+    public boolean hasJavaValue() {
+        return true;
     }
 
     // Called when object is to be serialized on a stream to allow the object to substitute a proxy for itself.

--- a/logstash-core/src/test/java/org/logstash/bivalues/BiValueTest.java
+++ b/logstash-core/src/test/java/org/logstash/bivalues/BiValueTest.java
@@ -29,7 +29,7 @@ public class BiValueTest extends TestBase {
         String s = "foo bar baz";
         StringBiValue subject = new StringBiValue(RubyString.newString(ruby, s));
         assertTrue(subject.hasRubyValue());
-        assertFalse(subject.hasJavaValue());
+        assertTrue(subject.hasJavaValue());
         assertEquals(s, subject.javaValue());
     }
 


### PR DESCRIPTION
Fixes #7662

Since `org.jruby.RubyString` is mutable we simply cannot cache its `String` representation, as much as this **seems to** hurts performance wise.
In actuality there is no performance gain anyways since we're forced to `.dup` strings whenever we have shared Java and Ruby logic like in the UA filter:

https://github.com/logstash-plugins/logstash-filter-useragent/blob/master/lib/logstash/filters/useragent.rb#L138

```rb
event.set(@prefixed_major, ua_version.major.dup.force_encoding(Encoding::UTF_8)) if ua_version.major
  | event.set(@prefixed_minor, ua_version.minor.dup.force_encoding(Encoding::UTF_8)) if ua_version.minor
  | event.set(@prefixed_patch, ua_version.patch.dup.force_encoding(Encoding::UTF_8)) if ua_version.patch
  | event.set(@prefixed_build, ua_version.patchMinor.dup.force_encoding(Encoding::UTF_8)) if ua_version.patchMinor
```

With this fix, we get consistency by simply computing the Java object on demand. The theoretical performance hit (in practice it seems this actually speeds up the Apache dataset, likely as a result of the `String` objects now living for a shorter time and hence being collected easier) we can completely alleviate in real life use cases, by removing the `.dup` calls from plugins like the above.