### PR TITLE
implement ssl in modules

### DIFF
--- a/logstash-core/lib/logstash/elasticsearch_client.rb
+++ b/logstash-core/lib/logstash/elasticsearch_client.rb
@@ -27,7 +27,18 @@ module LogStash class ElasticsearchClient
       @logger = logger
       @client_args = client_args
 
-      username = @settings["var.output.elasticsearch.user"]
+      ssl_options = {}
+
+      if @settings["var.ssl.enabled"] == "true"
+        ssl_options[:verify] = @settings.fetch("var.ssl.verification_mode", true)
+        ssl_options[:ca_file] = @settings.fetch("var.ssl.certificate_authority", nil)
+        ssl_options[:client_cert] = @settings.fetch("var.ssl.certificate", nil)
+        ssl_options[:client_key] = @settings.fetch("var.ssl.key", nil)
+      end
+
+      @client_args[:ssl] = ssl_options
+
+      username = @settings["var.output.elasticsearch.username"]
       password = @settings["var.output.elasticsearch.password"]
       if username
         @client_args[:transport_options] = { :headers => { "Authorization" => 'Basic ' + Base64.encode64( "#{username}:#{password}" ).chomp } }

--- a/logstash-core/lib/logstash/elasticsearch_client.rb
+++ b/logstash-core/lib/logstash/elasticsearch_client.rb
@@ -29,17 +29,17 @@ module LogStash class ElasticsearchClient
 
       ssl_options = {}
 
-      if @settings["var.ssl.enabled"] == "true"
-        ssl_options[:verify] = @settings.fetch("var.ssl.verification_mode", true)
-        ssl_options[:ca_file] = @settings.fetch("var.ssl.certificate_authority", nil)
-        ssl_options[:client_cert] = @settings.fetch("var.ssl.certificate", nil)
-        ssl_options[:client_key] = @settings.fetch("var.ssl.key", nil)
+      if @settings["var.elasticsearch.ssl.enabled"] == "true"
+        ssl_options[:verify] = @settings.fetch("var.elasticsearch.ssl.verification_mode", true)
+        ssl_options[:ca_file] = @settings.fetch("var.elasticsearch.ssl.certificate_authority", nil)
+        ssl_options[:client_cert] = @settings.fetch("var.elasticsearch.ssl.certificate", nil)
+        ssl_options[:client_key] = @settings.fetch("var.elasticsearch.ssl.key", nil)
       end
 
       @client_args[:ssl] = ssl_options
 
-      username = @settings["var.output.elasticsearch.username"]
-      password = @settings["var.output.elasticsearch.password"]
+      username = @settings["var.elasticsearch.username"]
+      password = @settings["var.elasticsearch.password"]
       if username
         @client_args[:transport_options] = { :headers => { "Authorization" => 'Basic ' + Base64.encode64( "#{username}:#{password}" ).chomp } }
       end
@@ -108,7 +108,7 @@ module LogStash class ElasticsearchClient
     end
 
     def unpack_hosts
-      @settings.fetch("var.output.elasticsearch.hosts", "localhost:9200").split(',').map(&:strip)
+      @settings.fetch("var.elasticsearch.hosts", "localhost:9200").split(',').map(&:strip)
     end
   end
 

--- a/logstash-core/lib/logstash/modules/kibana_client.rb
+++ b/logstash-core/lib/logstash/modules/kibana_client.rb
@@ -39,13 +39,11 @@ module LogStash module Modules class KibanaClient
 
     ssl_options = {}
 
-    if @settings["var.ssl.enabled"] == "true"
-      #ssl_options[:protocols] = @settings.fetch("ssl.supported_protocols", nil)
-      #ssl_options[:cipher_suites] = @settings.fetch("ssl.cipher_suites", nil)
-      ssl_options[:verify] = @settings.fetch("var.ssl.verification_mode", "strict").to_sym
-      ssl_options[:ca_file] = @settings.fetch("var.ssl.certificate_authority", nil)
-      ssl_options[:client_cert] = @settings.fetch("var.ssl.certificate", nil)
-      ssl_options[:client_key] = @settings.fetch("var.ssl.key", nil)
+    if @settings["var.kibana.ssl.enabled"] == "true"
+      ssl_options[:verify] = @settings.fetch("var.kibana.ssl.verification_mode", "strict").to_sym
+      ssl_options[:ca_file] = @settings.fetch("var.kibana.ssl.certificate_authority", nil)
+      ssl_options[:client_cert] = @settings.fetch("var.kibana.ssl.certificate", nil)
+      ssl_options[:client_key] = @settings.fetch("var.kibana.ssl.key", nil)
     end
 
     client_options[:ssl] = ssl_options

--- a/logstash-core/lib/logstash/modules/kibana_client.rb
+++ b/logstash-core/lib/logstash/modules/kibana_client.rb
@@ -28,7 +28,29 @@ module LogStash module Modules class KibanaClient
 
   def initialize(settings)
     @settings = settings
-    @client = Manticore::Client.new(request_timeout: 5, connect_timeout: 5, socket_timeout: 5, pool_max: 10, pool_max_per_route: 2)
+
+    client_options = {
+      request_timeout: 5,
+      connect_timeout: 5,
+      socket_timeout: 5,
+      pool_max: 10,
+      pool_max_per_route: 2
+    }
+
+    ssl_options = {}
+
+    if @settings["var.ssl.enabled"] == "true"
+      #ssl_options[:protocols] = @settings.fetch("ssl.supported_protocols", nil)
+      #ssl_options[:cipher_suites] = @settings.fetch("ssl.cipher_suites", nil)
+      ssl_options[:verify] = @settings.fetch("var.ssl.verification_mode", "strict").to_sym
+      ssl_options[:ca_file] = @settings.fetch("var.ssl.certificate_authority", nil)
+      ssl_options[:client_cert] = @settings.fetch("var.ssl.certificate", nil)
+      ssl_options[:client_key] = @settings.fetch("var.ssl.key", nil)
+    end
+
+    client_options[:ssl] = ssl_options
+
+    @client = Manticore::Client.new(client_options)
     @host = @settings.fetch("var.kibana.host", "localhost:5601")
     username = @settings["var.kibana.username"]
     password = @settings["var.kibana.password"]

--- a/logstash-core/lib/logstash/modules/logstash_config.rb
+++ b/logstash-core/lib/logstash/modules/logstash_config.rb
@@ -59,16 +59,16 @@ module LogStash module Modules class LogStashConfig
   end
 
   def elasticsearch_output_config(type_string = nil)
-    hosts = array_to_string(get_setting(LogStash::Setting::SplittableStringArray.new("var.output.elasticsearch.hosts", String, ["localhost:9200"])))
-    index = "#{@name}-#{setting("var.output.elasticsearch.index_suffix", "%{+YYYY.MM.dd}")}"
-    user = @settings["var.output.elasticsearch.username"]
-    password = @settings["var.output.elasticsearch.password"]
+    hosts = array_to_string(get_setting(LogStash::Setting::SplittableStringArray.new("var.elasticsearch.hosts", String, ["localhost:9200"])))
+    index = "#{@name}-#{setting("var.elasticsearch.index_suffix", "%{+YYYY.MM.dd}")}"
+    user = @settings["var.elasticsearch.username"]
+    password = @settings["var.elasticsearch.password"]
     lines = ["hosts => #{hosts}", "index => \"#{index}\""]
     lines.push(user ? "user => \"#{user}\"" : nil)
     lines.push(password ? "password => \"#{password}\"" : nil)
     lines.push(type_string ? "document_type => #{type_string}" : nil)
-    lines.push("ssl => #{@settings.fetch('var.ssl.enabled', false)}")
-    if cacert = @settings["var.ssl.certificate_authority"]
+    lines.push("ssl => #{@settings.fetch('var.elasticsearch.ssl.enabled', false)}")
+    if cacert = @settings["var.elasticsearch.ssl.certificate_authority"]
       lines.push("cacert => \"#{cacert}\"") if cacert
     end
     # NOTE: the first line should be indented in the conf.erb

--- a/logstash-core/lib/logstash/modules/logstash_config.rb
+++ b/logstash-core/lib/logstash/modules/logstash_config.rb
@@ -61,12 +61,16 @@ module LogStash module Modules class LogStashConfig
   def elasticsearch_output_config(type_string = nil)
     hosts = array_to_string(get_setting(LogStash::Setting::SplittableStringArray.new("var.output.elasticsearch.hosts", String, ["localhost:9200"])))
     index = "#{@name}-#{setting("var.output.elasticsearch.index_suffix", "%{+YYYY.MM.dd}")}"
-    user = @settings["var.output.elasticsearch.user"]
+    user = @settings["var.output.elasticsearch.username"]
     password = @settings["var.output.elasticsearch.password"]
     lines = ["hosts => #{hosts}", "index => \"#{index}\""]
     lines.push(user ? "user => \"#{user}\"" : nil)
     lines.push(password ? "password => \"#{password}\"" : nil)
     lines.push(type_string ? "document_type => #{type_string}" : nil)
+    lines.push("ssl => #{@settings.fetch('var.ssl.enabled', false)}")
+    if cacert = @settings["var.ssl.certificate_authority"]
+      lines.push("cacert => \"#{cacert}\"") if cacert
+    end
     # NOTE: the first line should be indented in the conf.erb
     <<-CONF
 elasticsearch {

--- a/logstash-core/spec/logstash/modules/scaffold_spec.rb
+++ b/logstash-core/spec/logstash/modules/scaffold_spec.rb
@@ -226,7 +226,6 @@ ERB
         "var.elasticsearch.user" => "foo",
         "var.elasticsearch.password" => "password",
         "var.input.tcp.port" => 5606,
-        "dashboards.kibana_index" => ".kibana"
       }
     end
     it "puts stuff in ES" do

--- a/logstash-core/spec/logstash/modules/scaffold_spec.rb
+++ b/logstash-core/spec/logstash/modules/scaffold_spec.rb
@@ -16,9 +16,9 @@ describe LogStash::Modules::Scaffold do
   subject(:test_module) { described_class.new(mname, base_dir) }
   let(:module_settings) do
     {
-      "var.output.elasticsearch.hosts" => "es.mycloud.com:9200",
-      "var.output.elasticsearch.user" => "foo",
-      "var.output.elasticsearch.password" => "password",
+      "var.elasticsearch.hosts" => "es.mycloud.com:9200",
+      "var.elasticsearch.user" => "foo",
+      "var.elasticsearch.password" => "password",
       "var.input.tcp.port" => 5606,
     }
   end
@@ -222,9 +222,9 @@ ERB
     let(:base_dir) { File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "modules_test_files", "#{mname}")) }
     let(:module_settings) do
       {
-        "var.output.elasticsearch.hosts" => "localhost:9200",
-        "var.output.elasticsearch.user" => "foo",
-        "var.output.elasticsearch.password" => "password",
+        "var.elasticsearch.hosts" => "localhost:9200",
+        "var.elasticsearch.user" => "foo",
+        "var.elasticsearch.password" => "password",
         "var.input.tcp.port" => 5606,
         "dashboards.kibana_index" => ".kibana"
       }


### PR DESCRIPTION
This allows modules to connect to kibana and elasticsearch through SSL.

NOTE: this PR also changes the setting `var.output.elasticsearch.user` to `var.output.elasticsearch.username` so both username settings are consistent (and also consistent with monitoring/management username settings)