### PR TITLE
 #7665 pattern definitions hash should be proper ruby hash without commas

### DIFF
--- a/tools/ingest-converter/src/main/resources/ingest-grok.js
+++ b/tools/ingest-converter/src/main/resources/ingest-grok.js
@@ -24,7 +24,10 @@ var IngestGrok = {
                     );
                 }
             }
-            return create_hash_field("pattern_definitions", content);
+            return create_hash_field(
+                "pattern_definitions", 
+                content.map(IngestConverter.dots_to_square_brackets).join("\n")
+            );
         }
 
         var grok_data = processor["grok"];

--- a/tools/ingest-converter/src/main/resources/ingest-shared.js
+++ b/tools/ingest-converter/src/main/resources/ingest-shared.js
@@ -9,10 +9,17 @@ var IngestConverter = {
     dots_to_square_brackets: function (string) {
 
         function token_dots_to_square_brackets(string) {
-            return string.replace(/(\w*)\.(\w*)/g, "$1][$2")
-                .replace(/\[(\w+)(}|$)/g, "[$1]$2")
-                .replace(/{(\w+):(\w+)]/g, "{$1:[$2]")
-                .replace(/^(\w+)]\[/g, "[$1][");
+            var adjusted;
+            //Break out if this is not a naming pattern we convert
+            if (string.match(/([\w_]+\.)+[\w_]+/)) {
+                adjusted = string.replace(/(\w*)\.(\w*)/g, "$1][$2")
+                    .replace(/\[(\w+)(}|$)/g, "[$1]$2")
+                    .replace(/{(\w+):(\w+)]/g, "{$1:[$2]")
+                    .replace(/^(\w+)]\[/g, "[$1][");
+            } else {
+                adjusted = string;
+            }
+            return adjusted;
         }
 
         var literals = string.match(/\(\?:%{.*\|-\)/);

--- a/tools/ingest-converter/src/test/java/org/logstash/ingest/GrokTest.java
+++ b/tools/ingest-converter/src/test/java/org/logstash/ingest/GrokTest.java
@@ -9,7 +9,7 @@ public final class GrokTest extends IngestTest {
 
     @Parameters
     public static Iterable<String> data() {
-        return Arrays.asList("Grok", "GrokPatternDefinition");
+        return Arrays.asList("Grok", "GrokPatternDefinition", "GrokMultiplePatternDefinitions");
     }
 
     @Test

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/ingestGrokMultiplePatternDefinitions.json
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/ingestGrokMultiplePatternDefinitions.json
@@ -1,0 +1,19 @@
+{
+  "description":"Syslog",
+  "processors":[
+    {
+      "grok":{
+        "field":"message",
+        "patterns":[
+          "%{SYSLOGTIMESTAMP:system.syslog.timestamp} %{SYSLOGHOST:system.syslog.hostname} %{DATA:system.syslog.program}(?:\\[%{POSINT:system.syslog.pid}\\])?: %{GREEDYMULTILINE:system.syslog.message}",
+          "%{SYSLOGTIMESTAMP:system.syslog.timestamp} %{GREEDYMULTILINE:system.syslog.message}"
+        ],
+        "pattern_definitions":{
+          "GREEDYMULTILINE":"(.|\\n)*",
+          "AUDIT_TYPE": "^type=%{NOTSPACE:auditd.log.record_type}"
+        },
+        "ignore_missing":true
+      }
+    }
+  ]
+}

--- a/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashGrokMultiplePatternDefinitions.conf
+++ b/tools/ingest-converter/src/test/resources/org/logstash/ingest/logstashGrokMultiplePatternDefinitions.conf
@@ -1,0 +1,19 @@
+filter {
+   grok {
+      match => {
+         "message" => [
+            "%{SYSLOGTIMESTAMP:[system][syslog][timestamp]} %{SYSLOGHOST:[system][syslog][hostname]} %{DATA:[system][syslog][program]}(?:\[%{POSINT:[system][syslog][pid]}\])?: %{GREEDYMULTILINE:[system][syslog][message]}",
+            "%{SYSLOGTIMESTAMP:[system][syslog][timestamp]} %{GREEDYMULTILINE:[system][syslog][message]}"
+         ]
+      }
+      pattern_definitions => {
+         "GREEDYMULTILINE" => "(.|\n)*"
+         "AUDIT_TYPE" => "^type=%{NOTSPACE:[auditd][log][record_type]}"
+      }
+   }
+}
+output {
+   elasticsearch {
+      hosts => "localhost"
+   }
+}


### PR DESCRIPTION
fixes #7665 

* Added test case for the reported issue (multiple patterns were not joined into a proper ruby hash)
* Also noticed we are not running the field names in the pattern definitions through the `dots_to_square_brackets` filter => added that
   * Noticed a bug in `dots_to_square_brackets`, it was messing up `"(.|\n)*` by turning it into `"(][|\n)*` => fixed that by breaking out if we don't at least have to words joined by a dot