### PR TITLE
Fix existing examples and add autditd example

### DIFF
--- a/docs/static/filebeat-modules.asciidoc
+++ b/docs/static/filebeat-modules.asciidoc
@@ -113,6 +113,7 @@ Logstash pipelines that parse:
 * <<parsing-mysql>>
 * <<parsing-nginx>>
 * <<parsing-system>>
+* <<parsing-auditd>>
 
 Of course, the paths that you specify in the Filebeat config depend on the location
 of the logs you are harvesting. The examples show common default locations.
@@ -277,3 +278,24 @@ Example Logstash pipeline config:
 ----------------------------------------------------------------------------
 include::filebeat_modules/system/syslog/pipeline.conf[]
 ----------------------------------------------------------------------------
+
+[[parsing-auditd]]
+==== Auditd Logs
+
+Here are some configuration examples for shipping and parsing auditd logs.
+
+Filebeat config:
+
+[source,yml]
+----------------------------------------------------------------------
+include::filebeat_modules/auditd/log/filebeat.yml[]
+----------------------------------------------------------------------
+
+
+Example Logstash pipeline config:
+
+[source,json]
+----------------------------------------------------------------------------
+include::filebeat_modules/auditd/log/pipeline.conf[]
+----------------------------------------------------------------------------
+

--- a/docs/static/filebeat_modules/auditd/log/filebeat.yml
+++ b/docs/static/filebeat_modules/auditd/log/filebeat.yml
@@ -1,0 +1,7 @@
+filebeat.prospectors:
+- input_type: log
+  paths:
+    - /var/log/audit/audit.log*
+  exclude_files: [".gz$"]
+output.logstash:
+  hosts: ["localhost:5044"]

--- a/docs/static/filebeat_modules/auditd/log/pipeline.conf
+++ b/docs/static/filebeat_modules/auditd/log/pipeline.conf
@@ -1,0 +1,48 @@
+input {
+  beats {
+    # The port to listen on for filebeat connections.
+    port => 5044
+    # The IP address to listen for filebeat connections.
+    host => "0.0.0.0"
+  }
+}
+filter {
+   grok {
+      match => {
+         "message" => [
+            "%{AUDIT_PREFIX} %{AUDIT_KEY_VALUES:[auditd][log][kv]} old auid=%{NUMBER:[auditd][log][old_auid]} new auid=%{NUMBER:[auditd][log][new_auid]} old ses=%{NUMBER:[auditd][log][old_ses]} new ses=%{NUMBER:[auditd][log][new_ses]}",
+            "%{AUDIT_PREFIX} %{AUDIT_KEY_VALUES:[auditd][log][kv]} msg=['\"](%{DATA:[auditd][log][msg]}\s+)?%{AUDIT_KEY_VALUES:[auditd][log][sub_kv]}['\"]",
+            "%{AUDIT_PREFIX} %{AUDIT_KEY_VALUES:[auditd][log][kv]}",
+            "%{AUDIT_PREFIX}",
+            "%{AUDIT_TYPE} %{AUDIT_KEY_VALUES:[auditd][log][kv]}"
+         ]
+      }
+      pattern_definitions => {
+         "AUDIT_TYPE" => "^type=%{NOTSPACE:auditd.log.record_type}" "AUDIT_PREFIX" => "%{AUDIT_TYPE} msg=audit\(%{NUMBER:auditd.log.epoch}:%{NUMBER:auditd.log.sequence}\):(%{DATA})?" "AUDIT_KEY_VALUES" => "%{WORD}=%{GREEDYDATA}"
+      }
+   } 
+   date {
+      match => [
+         "[auditd][log][epoch]",
+         "UNIX"
+      ]
+      target => "@timestamp"
+   }   
+   mutate {
+      convert => {
+         "[auditd][log][sequence]" => "integer"
+      }
+   } 
+   geoip {
+      source => "[auditd][log][addr]"
+      target => "[auditd][log][geoip]"
+   }
+}
+output {
+  elasticsearch {
+    hosts => localhost
+    manage_template => false
+    index => "%{[@metadata][beat]}-%{+YYYY.MM.dd}"
+    document_type => "%{[@metadata][type]}"
+  }
+}

--- a/docs/static/filebeat_modules/nginx/access/pipeline.conf
+++ b/docs/static/filebeat_modules/nginx/access/pipeline.conf
@@ -12,8 +12,8 @@ filter {
       remove_field => "message"
    }
    mutate {
-      rename => { "@timestamp" => "read_timestamp" }
-   }
+         add_field => { "read_timestamp" => "@timestamp" }
+      }
    date {
       match => [ "[nginx][access][time]", "dd/MMM/YYYY:H:m:s Z" ]
       remove_field => "[nginx][access][time]"


### PR DESCRIPTION
To generate the auditd config, I used the ingest converter.  The original ingest pipeline had some painless defined in it...I'm assuming the converter + Logstash takes care of whatever the painless does because *most* of the visualizations rendered OK. There were a couple of visualizations that didn not show data, but I noticed that we're not even parsing those fields in the LS config. So....I will test the ingest pipelines and open a separate issue/PR if we need to update the content further.



