### PR TITLE
MINOR: Gitignore out paths coming from Gradle 4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ pkg/*.rpm
 *.jar
 .bundle
 build
+out
 local
 test/setup/elasticsearch/elasticsearch-*
 vendor


### PR DESCRIPTION
The newer Gradle version (4.0) seems to add the `out` path alongside the `build` path for its caching during builds => gitignore it :)