### PR TITLE
MINOR: Enable javac warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,4 +6,8 @@ allprojects {
   
   project.sourceCompatibility = JavaVersion.VERSION_1_8
   project.targetCompatibility = JavaVersion.VERSION_1_8
+
+  tasks.withType(JavaCompile).all {
+    options.compilerArgs.add("-Xlint:all")
+  }
 }

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -20,13 +20,6 @@ buildscript {
     }
 }
 
-gradle.projectsEvaluated {
-    tasks.withType(JavaCompile) {
-        options.compilerArgs << "-Xlint:deprecation"
-//        options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
-    }
-}
-
 task sourcesJar(type: org.gradle.api.tasks.bundling.Jar, dependsOn: classes) {
     from sourceSets.main.allSource
     classifier 'sources'


### PR DESCRIPTION
No point in not having them show globally.
We have quite a few issues with (generic-)type safety that we should track and clean up step by step, not hide from the output.