### PR TITLE
adds key and namespace getters to Java Metric classes

### DIFF
--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractMetric.java
@@ -38,4 +38,14 @@ public abstract class AbstractMetric<T> implements Metric<T> {
                 getValue().toString());
     }
 
+    @Override
+    public List<String> getNameSpaces() {
+        return this.nameSpace;
+    }
+
+    @Override
+    public String getKey() {
+        return this.key;
+    }
+
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/Metric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/Metric.java
@@ -1,5 +1,7 @@
 package org.logstash.instrument.metrics;
 
+import java.util.List;
+
 /**
  * Top level contract for metrics within Logstash.
  *
@@ -7,6 +9,40 @@ package org.logstash.instrument.metrics;
  * @since 6.0
  */
 public interface Metric<T> {
+
+    /**
+     * The list of namespaces this metric belongs to, for compatibility with Ruby code. Java consumers should use #getNameSpaces()
+     *
+     * @return List of namespaces
+     * @deprecated
+     */
+    default List<String> namespaces() {
+        return getNameSpaces();
+    }
+
+    /**
+     * The list of namespaces this metric belongs to.
+     *
+     * @return List of namespaces
+     */
+    List<String> getNameSpaces();
+
+    /**
+     * This metric's key (or name), exists for access through Ruby code. Java consumers should use #getKey()
+     *
+     * @return This metric's key
+     * @deprecated
+     */
+    default String key() {
+        return getKey();
+    }
+
+    /**
+     * This metric's key (or name)
+     *
+     * @return List of namespaces
+     */
+    String getKey();
 
     /**
      * This should be equal to #getValue, exists for passivity with legacy Ruby code. Java consumers should use #getValue().


### PR DESCRIPTION
Outside code should be able to access these properties of metrics, namely in x-pack.