### PR TITLE
MINOR: Make Docker upgrade more stable in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ env:
   - INTEGRATION=false FEATURE_FLAG=persistent_queues SPEC_OPTS="--order rand --format documentation" JRUBY_OPTS='-Xcompile.invokedynamic=false'
   - INTEGRATION=true FEATURE_FLAG=persistent_queues SPEC_OPTS="--order rand --format documentation" JRUBY_OPTS='-Xcompile.invokedynamic=false'
 before_install:
-  - sudo apt-get remove -y docker-ce
-  - sudo apt-get install -y docker-ce
+  - sudo apt-get update && sudo apt-get install -y docker-ce
   - sudo service docker stop
   - sudo dockerd --disable-legacy-registry &>/dev/null &
   - export JRUBY_OPTS=""


### PR DESCRIPTION
This should fix instances of this one https://travis-ci.org/elastic/logstash/jobs/252548207 (Travis failing to upgrade Docker).

Without a prior `apt-get update` we're at the mercy of whatever Travis `apt` has cached at the moment the test is run, this can't be stable and isn't in practice :)
Also, there is no need to remove the package before installing it again to upgrade, just running install will upgrade the package as well.