### PR TITLE
Fix SafeURI to maintain pre-5.5.0 escaping behavior

### DIFF
--- a/logstash-core/lib/logstash/util/safe_uri.rb
+++ b/logstash-core/lib/logstash/util/safe_uri.rb
@@ -92,8 +92,8 @@ class LogStash::Util::SafeURI
   end
 
   def user
-    if @uri.userInfo
-      @uri.userInfo.split(":")[0]
+    if userinfo
+      userinfo.split(":")[0]
     end
   end
 
@@ -102,8 +102,8 @@ class LogStash::Util::SafeURI
   end
 
   def password
-    if @uri.userInfo
-      @uri.userInfo.split(":")[1]
+    if userinfo
+      userinfo.split(":")[1]
     end
   end
 
@@ -160,7 +160,23 @@ class LogStash::Util::SafeURI
     d
   end
 
-  def_delegators :@uri, :absolute?, :scheme, :host, :path, :query, :fragment, :userinfo
+  def path
+    @uri.raw_path
+  end
+
+  def query
+    @uri.raw_query
+  end
+
+  def fragment
+    @uri.raw_fragment
+  end
+
+  def userinfo
+    @uri.raw_user_info
+  end
+
+  def_delegators :@uri, :absolute?, :scheme, :host
 
   private
 

--- a/logstash-core/spec/logstash/util/safe_uri_spec.rb
+++ b/logstash-core/spec/logstash/util/safe_uri_spec.rb
@@ -16,5 +16,21 @@ module LogStash module Util
         expect(cloned_safe_uri.query).to eq("a=b")
       end
     end
+
+    describe "handling escapable fields" do
+      let(:user) { "u%20" }
+      let(:password) { "p%20ss" }
+      let(:path) { "/a%20/path" }
+      let(:query) { "a%20query&another=es%3dq" }
+      let(:fragment) { "spacey%20fragment" }
+      subject { LogStash::Util::SafeURI.new("http://#{user}:#{password}@example.net#{path}?#{query}\##{fragment}") }
+
+      [:user, :password, :path, :query, :fragment].each do |field|
+        it "should not escape the #{field} field" do
+          expected = self.send(field)
+          expect(subject.send(field)).to eq(expected)
+        end
+      end
+    end
   end
 end end


### PR DESCRIPTION
Prior to Logstash 5.5.0 the ::LogStash::Util::SafeURI class returned escaped values where applicable. As part of the refactor in https://github.com/elastic/logstash/pull/7236 this behavior was accidentally changed, breaking the ES output and resulting in bugs like: https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/618 .

This PR maintains the java.net.URI refactor but fixes the behavior to align with pre-5.5.0 logstashes by correctly returning escaped values.