### PR TITLE
#7690 Fix needless waiting

### DIFF
--- a/logstash-core/lib/logstash/queue_factory.rb
+++ b/logstash-core/lib/logstash/queue_factory.rb
@@ -29,7 +29,9 @@ module LogStash
         LogStash::Util::WrappedAckedQueue.create_file_based(queue_path, queue_page_capacity, queue_max_events, checkpoint_max_writes, checkpoint_max_acks, checkpoint_max_interval, queue_max_bytes)
       when "memory"
         # memory is the legacy and default setting
-        LogStash::Util::WrappedSynchronousQueue.new
+        LogStash::Util::WrappedSynchronousQueue.new(
+          settings.get("pipeline.batch.size") * settings.get("pipeline.workers") * 2
+        )
       else
         raise ConfigurationError, "Invalid setting `#{queue_type}` for `queue.type`, supported types are: 'memory_acked', 'memory', 'persisted'"
       end

--- a/logstash-core/spec/logstash/instrument/wrapped_write_client_spec.rb
+++ b/logstash-core/spec/logstash/instrument/wrapped_write_client_spec.rb
@@ -101,7 +101,7 @@ describe LogStash::Instrument::WrappedWriteClient do
   end
 
   context "WrappedSynchronousQueue" do
-    let(:queue) { LogStash::Util::WrappedSynchronousQueue.new }
+    let(:queue) { LogStash::Util::WrappedSynchronousQueue.new(1024) }
 
     before do
       read_client.set_events_metric(metric.namespace([:stats, :events]))

--- a/logstash-core/spec/logstash/queue_factory_spec.rb
+++ b/logstash-core/spec/logstash/queue_factory_spec.rb
@@ -15,7 +15,9 @@ describe LogStash::QueueFactory do
       LogStash::Setting::Numeric.new("queue.checkpoint.acks", 1024),
       LogStash::Setting::Numeric.new("queue.checkpoint.writes", 1024),
       LogStash::Setting::Numeric.new("queue.checkpoint.interval", 1000),
-      LogStash::Setting::String.new("pipeline.id", pipeline_id)
+      LogStash::Setting::String.new("pipeline.id", pipeline_id),
+      LogStash::Setting::PositiveInteger.new("pipeline.batch.size", 125),
+      LogStash::Setting::PositiveInteger.new("pipeline.workers", LogStash::Config::CpuCoreStrategy.maximum)
     ]
   end
 
@@ -72,9 +74,10 @@ describe LogStash::QueueFactory do
   context "when `queue.type` is `memory`" do
     before do
       settings.set("queue.type", "memory")
+      settings.set("pipeline.batch.size", 1024)
     end
 
-    it "returns a `WrappedAckedQueue`" do
+    it "returns a `WrappedSynchronousQueue`" do
       queue =  subject.create(settings)
       expect(queue).to be_kind_of(LogStash::Util::WrappedSynchronousQueue)
       queue.close


### PR DESCRIPTION
For #7690:

* This also contains #7623 
* Instead of the synchronous queue, use an array blocking queue of `2 * batch_size * worker_count` size to avoid needless sleeping
* Use `drainTo` to require far less locking
* Use a `HashSet` with appropriate sizing and load parameter to back the batch
* Note how I didn't yet fix 4 specs that use some "DummyQueue" which are broken now, functionally this thing is 100% fine though as far as I can tell

## Numbers:

Apache Dataset, command: `time cat ~/Downloads/apache_access_logs | bin/logstash -b 1024 -w 2 -f ~/tmp/logstash.cfg  | pv  | wc -c`

### Master

```sh
➜  logstash git:(master) time cat ~/Downloads/apache_access_logs | bin/logstash -b 1024 -w 2 -f ~/tmp/logstash.cfg  | pv  | wc -c
6.58MiB 0:10:17 [10.9KiB/s] [                     <=>                                                                                                                                   ]
 6901231
cat ~/Downloads/apache_access_logs  0.06s user 1.01s system 0% cpu 10:17.43 total
bin/logstash -b 1024 -w 2 -f ~/tmp/logstash.cfg  1792.97s user 41.74s system 297% cpu 10:17.69 total
pv  0.98s user 6.64s system 1% cpu 10:17.69 total
wc -c  0.09s user 0.60s system 0% cpu 10:17.69 total
```

** (2.97 * 10.3 ~ 31 min) **

### This Branch

```sh
➜  logstash git:(fix-needless-waiting) time cat ~/Downloads/apache_access_logs | bin/logstash -b 1024 -w 2 -f ~/tmp/logstash.cfg  | pv  | wc -c
6.58MiB 0:09:49 [11.4KiB/s] [                                                               <=>                                                                                         ]
 6900962
cat ~/Downloads/apache_access_logs  0.08s user 1.63s system 0% cpu 9:48.80 total
bin/logstash -b 1024 -w 2 -f ~/tmp/logstash.cfg  1899.15s user 16.16s system 324% cpu 9:49.37 total
pv  1.10s user 6.99s system 1% cpu 9:49.37 total
wc -c  0.11s user 0.85s system 0% cpu 9:49.37 total
```

** (3.24 * 9.8 ~ 31min) **

=> Master takes `6%` more wall clock time and the same amount of CPU time overall.

Also visible when looking at the profiler timelines for the threads, lots more yellow for master's workers:

<img width="1152" alt="screen shot 2017-07-14 at 10 03 04" src="https://user-images.githubusercontent.com/6490959/28204896-16158636-6880-11e7-8130-9333ce76d313.png">

when compared to this branch:

<img width="1289" alt="screen shot 2017-07-14 at 09 47 42" src="https://user-images.githubusercontent.com/6490959/28204905-1cef60b2-6880-11e7-8ffa-7c83ef985183.png">

