### PR TITLE
MINOR: Size HashMaps more Efficiently in ConvertedMap

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ConvertedMap.java
+++ b/logstash-core/src/main/java/org/logstash/ConvertedMap.java
@@ -8,8 +8,8 @@ import org.jruby.runtime.builtin.IRubyObject;
 
 public final class ConvertedMap extends HashMap<String, Object> {
 
-    public ConvertedMap(final int size) {
-        super(size);
+    private ConvertedMap(final int size) {
+        super((size << 2) / 3 + 2);
     }
     
     public static ConvertedMap newFromMap(Map<Serializable, Object> o) {


### PR DESCRIPTION
Trivial, but visible in the number of `HashMap$Node` that need to be GCed.
We should set a size here that takes the load factor into account to prevent rehashing on instantiation of the `ConvertedMap`.
Also for some reason, the constructor here become `public` which it really shouldn't be since we're using this class to ensure the correct types of the values, made it `private` again.