### PR TITLE
rakelib: List log4j2.properties as a config file in RPM/Deb (#7688)

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -328,6 +328,7 @@ namespace "artifact" do
         out.attributes[:rpm_os] = "linux"
         out.config_files << "/etc/logstash/startup.options"
         out.config_files << "/etc/logstash/jvm.options"
+        out.config_files << "/etc/logstash/log4j2.properties"
         out.config_files << "/etc/logstash/logstash.yml"
       when "debian", "ubuntu"
         File.join(basedir, "pkg", "startup.options").tap do |path|
@@ -347,6 +348,7 @@ namespace "artifact" do
         out.attributes[:deb_suggests] = "java8-runtime-headless"
         out.config_files << "/etc/logstash/startup.options"
         out.config_files << "/etc/logstash/jvm.options"
+        out.config_files << "/etc/logstash/log4j2.properties"
         out.config_files << "/etc/logstash/logstash.yml"
     end
 


### PR DESCRIPTION
When a file is listed as a configuration file the package manager
will ask the user about what to do about local modifications when
the package is upgraded and the file has changed upstream. If not
listed as a configuration file any local modifications will silently
be lost.