### PR TITLE
reference correct class path

### DIFF
--- a/bin/cpdump
+++ b/bin/cpdump
@@ -6,6 +6,6 @@ require "logstash-core"
 require "logstash/environment"
 require "logstash/settings"
 
-io = Java::OrgLogstashCommonIo::FileCheckpointIO.new(LogStash::SETTINGS.get_value("path.queue"))
+io = Java::OrgLogstashAckedqueueIo::FileCheckpointIO.new(LogStash::SETTINGS.get_value("path.queue"))
 cp = io.read(ARGV[0])
 puts("checkpoint #{cp.toString}")


### PR DESCRIPTION
fixes #7695

At some point the queue classes namespace was changed but `cpdump` was not updated. 

Manually tested locally using (after running logstash with PQ enabled)

```sh
bin/cpdump main/checkpoint.head
```
