### PR TITLE
MINOR: default to -Djruby.compile.invokedynamic=true

### DIFF
--- a/config/jvm.options
+++ b/config/jvm.options
@@ -51,6 +51,9 @@
 # use our provided JNA always versus the system one
 #-Djna.nosys=true
 
+# Turn on JRuby invokedynamic
+-Djruby.compile.invokedynamic=true
+
 ## heap dumps
 
 # generate a heap dump when an allocation from the Java heap fails


### PR DESCRIPTION
Any reason we shouldn't set `-Djruby.compile.invokedynamic=true` as a default?

I just tested this and it gives us a **15-20%** gain when running the Apache test set. I don't see why this shouldn't be on by default for a long running process like Logstash?