### PR TITLE
#7704 backport to 5.x

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/TailPage.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/TailPage.java
@@ -15,7 +15,7 @@ public class TailPage extends Page {
 
     // create a new TailPage object for an exiting Checkpoint and data file
     // @param pageIO the PageIO object is expected to be open/recover/create
-    public TailPage(Checkpoint checkpoint, Queue queue, PageIO pageIO) throws IOException {
+    public TailPage(Checkpoint checkpoint, Queue queue, PageIO pageIO) {
         super(checkpoint.getPageNum(), queue, checkpoint.getMinSeqNum(), checkpoint.getElementCount(), checkpoint.getFirstUnackedSeqNum(), new BitSet(), pageIO);
 
         // this page ackedSeqNums bitset is a new empty bitset, if we have some acked elements, set them in the bitset

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/wip/MemoryPageIOStream.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/wip/MemoryPageIOStream.java
@@ -276,7 +276,7 @@ public class MemoryPageIOStream implements PageIO {
         return streamedInput.readByteArray();
     }
 
-    private void skipChecksum() throws IOException {
+    private void skipChecksum() {
         streamedInput.skip(CHECKSUM_SIZE);
     }
 

--- a/logstash-core/src/main/java/org/logstash/common/io/ByteBufferStreamInput.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/ByteBufferStreamInput.java
@@ -40,7 +40,7 @@ public class ByteBufferStreamInput extends StreamInput {
     }
 
     @Override
-    public long skip(long n) throws IOException {
+    public long skip(long n) {
         if (n > buffer.remaining()) {
             int ret = buffer.position();
             buffer.position(buffer.limit());
@@ -67,7 +67,7 @@ public class ByteBufferStreamInput extends StreamInput {
         buffer.position(position);
     }
 
-    public void rewind() throws IOException {
+    public void rewind() {
         buffer.rewind();
     }
 

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReader.java
@@ -138,7 +138,7 @@ public class DeadLetterQueueReader {
         return currentReader.getPath();
     }
 
-    public long getCurrentPosition() throws IOException {
+    public long getCurrentPosition() {
         return currentReader.getChannelPosition();
     }
 

--- a/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
@@ -121,7 +121,7 @@ public class RecordIOReader {
         return event;
     }
 
-    public long getChannelPosition() throws IOException {
+    public long getChannelPosition() {
         return channelPosition;
     }
 
@@ -150,7 +150,7 @@ public class RecordIOReader {
     /**
      *
      */
-     int seekToStartOfEventInBlock() throws IOException {
+     int seekToStartOfEventInBlock() {
          while (true) {
              RecordType type = RecordType.fromByte(currentBlock.array()[currentBlock.arrayOffset() + currentBlock.position()]);
              if (RecordType.COMPLETE.equals(type) || RecordType.START.equals(type)) {
@@ -192,7 +192,7 @@ public class RecordIOReader {
         }
     }
 
-    private void getRecord(ByteBuffer buffer, RecordHeader header) throws IOException {
+    private void getRecord(ByteBuffer buffer, RecordHeader header) {
         Checksum computedChecksum = new CRC32();
         computedChecksum.update(currentBlock.array(), currentBlock.position(), header.getSize());
 

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -196,7 +196,7 @@ public class JrubyEventExtLibrary implements Library {
         }
 
         @JRubyMethod(name = "sprintf", required = 1)
-        public IRubyObject ruby_sprintf(ThreadContext context, IRubyObject format) throws IOException {
+        public IRubyObject ruby_sprintf(ThreadContext context, IRubyObject format) {
             try {
                 return RubyString.newString(context.runtime, event.sprintf(format.toString()));
             } catch (IOException e) {
@@ -211,14 +211,12 @@ public class JrubyEventExtLibrary implements Library {
         }
 
         @JRubyMethod(name = "to_hash")
-        public IRubyObject ruby_to_hash(ThreadContext context) throws IOException
-        {
+        public IRubyObject ruby_to_hash(ThreadContext context) {
             return Rubyfier.deep(context.runtime, this.event.getData());
         }
 
         @JRubyMethod(name = "to_hash_with_metadata")
-        public IRubyObject ruby_to_hash_with_metadata(ThreadContext context) throws IOException
-        {
+        public IRubyObject ruby_to_hash_with_metadata(ThreadContext context) {
             Map data = this.event.toMap();
             Map metadata = this.event.getMetadata();
 


### PR DESCRIPTION
Backport of the subsection of #7704 that applies to `5.x`. We don't have the LIR logic in `5.x` so only the fixes to the Queue and Event logic apply.