### PR TITLE
MINOR: Turn NullBiValue into a Singleton

### DIFF
--- a/logstash-core/src/main/java/org/logstash/bivalues/BiValues.java
+++ b/logstash-core/src/main/java/org/logstash/bivalues/BiValues.java
@@ -1,21 +1,19 @@
 package org.logstash.bivalues;
 
-import org.logstash.Timestamp;
-import org.logstash.ext.JrubyTimestampExtLibrary.RubyTimestamp;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.HashMap;
 import org.jruby.RubyBignum;
 import org.jruby.RubyBoolean;
 import org.jruby.RubyFloat;
 import org.jruby.RubyInteger;
-import org.jruby.RubyNil;
 import org.jruby.RubyString;
 import org.jruby.RubySymbol;
 import org.jruby.ext.bigdecimal.RubyBigDecimal;
 import org.jruby.java.proxies.JavaProxy;
 import org.jruby.runtime.builtin.IRubyObject;
-
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.HashMap;
+import org.logstash.Timestamp;
+import org.logstash.ext.JrubyTimestampExtLibrary.RubyTimestamp;
 
 public enum BiValues {
     ORG_LOGSTASH_EXT_JRUBYTIMESTAMPEXTLIBRARY$RUBYTIMESTAMP(BiValueType.TIMESTAMP),
@@ -69,6 +67,8 @@ public enum BiValues {
         return hm;
     }
 
+    private static final NullBiValue NULL_BI_VALUE = NullBiValue.newNullBiValue();
+
     private final BiValueType biValueType;
 
     BiValues(BiValueType biValueType) {
@@ -82,8 +82,8 @@ public enum BiValues {
     }
 
     public static BiValue newBiValue(Object o) {
-        if (o == null){
-            return NULL.build(null);
+        if (o == null) {
+            return NULL_BI_VALUE;
         }
         BiValues bvs = valueOf(fetchName(o));
         return bvs.build(o);
@@ -174,11 +174,8 @@ public enum BiValues {
             }
         },
         NULL {
-            BiValue build(Object value) {
-                if (value instanceof IRubyObject) {
-                    return new NullBiValue((RubyNil) value);
-                }
-                return NullBiValue.newNullBiValue();
+            NullBiValue build(Object value) {
+                return NULL_BI_VALUE;
             }
         },
         BIGINT {

--- a/logstash-core/src/main/java/org/logstash/bivalues/NullBiValue.java
+++ b/logstash-core/src/main/java/org/logstash/bivalues/NullBiValue.java
@@ -1,23 +1,24 @@
 package org.logstash.bivalues;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import java.io.ObjectStreamException;
 import org.jruby.Ruby;
 import org.jruby.RubyNil;
 
-import java.io.ObjectStreamException;
+public final class NullBiValue extends BiValueCommon<RubyNil, Object>
+    implements BiValue<RubyNil, Object> {
 
-public class NullBiValue extends BiValueCommon<RubyNil, Object> implements BiValue<RubyNil, Object> {
+    private static final NullBiValue INSTANCE =
+        new NullBiValue((RubyNil) Ruby.getGlobalRuntime().getNil());
+
+    private static final Object WRITE_PROXY = newProxy(INSTANCE);
+
     public static NullBiValue newNullBiValue() {
-        return new NullBiValue();
+        return INSTANCE;
     }
 
-    public NullBiValue(RubyNil rubyValue) {
+    private NullBiValue(final RubyNil rubyValue) {
         this.rubyValue = rubyValue;
-        javaValue = null;
-    }
-
-    private NullBiValue() {
-        rubyValue = null;
         javaValue = null;
     }
 
@@ -32,14 +33,19 @@ public class NullBiValue extends BiValueCommon<RubyNil, Object> implements BiVal
         return true;
     }
 
-    protected void addRuby(Ruby runtime) {
-        rubyValue = (RubyNil) runtime.getNil();
+    @Override
+    public boolean hasRubyValue() {
+        return true;
     }
 
+    @Override
+    protected void addRuby(Ruby runtime) {}
+
+    @Override
     protected void addJava() {}
 
     // Called when object is to be serialized on a stream to allow the object to substitute a proxy for itself.
     private Object writeReplace() throws ObjectStreamException {
-        return newProxy(this);
+        return WRITE_PROXY;
     }
 }

--- a/logstash-core/src/test/java/org/logstash/TestBase.java
+++ b/logstash-core/src/test/java/org/logstash/TestBase.java
@@ -1,22 +1,17 @@
 package org.logstash;
 
-import org.logstash.ext.JrubyTimestampExtLibrary;
-import org.jruby.CompatVersion;
 import org.jruby.Ruby;
-import org.jruby.RubyInstanceConfig;
 import org.jruby.ext.bigdecimal.RubyBigDecimal;
 import org.junit.Before;
+import org.logstash.ext.JrubyTimestampExtLibrary;
 
 public abstract class TestBase {
     private static boolean setupDone = false;
-    public static Ruby ruby;
+    public static final Ruby ruby = Ruby.getGlobalRuntime();
 
     @Before
     public void setUp() throws Exception {
         if (setupDone) return;
-
-        RubyInstanceConfig config = new RubyInstanceConfig();
-        ruby = Ruby.newInstance(config);
         RubyBigDecimal.createBigDecimal(ruby); // we need to do 'require "bigdecimal"'
         JrubyTimestampExtLibrary.createTimestamp(ruby);
         setupDone = true;

--- a/logstash-core/src/test/java/org/logstash/bivalues/BiValueTest.java
+++ b/logstash-core/src/test/java/org/logstash/bivalues/BiValueTest.java
@@ -1,25 +1,23 @@
 package org.logstash.bivalues;
 
-import org.logstash.TestBase;
-import org.joda.time.DateTime;
-import org.jruby.RubyBignum;
-import org.jruby.RubyBoolean;
-import org.jruby.RubyFixnum;
-import org.jruby.RubyFloat;
-import org.jruby.RubyInteger;
-import org.jruby.RubyNil;
-import org.jruby.RubyString;
-import org.jruby.RubySymbol;
-import org.jruby.RubyTime;
-import org.jruby.ext.bigdecimal.RubyBigDecimal;
-import org.junit.Test;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import org.joda.time.DateTime;
+import org.jruby.RubyBignum;
+import org.jruby.RubyBoolean;
+import org.jruby.RubyFixnum;
+import org.jruby.RubyFloat;
+import org.jruby.RubyInteger;
+import org.jruby.RubyString;
+import org.jruby.RubySymbol;
+import org.jruby.RubyTime;
+import org.jruby.ext.bigdecimal.RubyBigDecimal;
+import org.junit.Test;
+import org.logstash.TestBase;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -144,17 +142,9 @@ public class BiValueTest extends TestBase {
     }
 
     @Test
-    public void testNullBiValueFromRuby() {
-        NullBiValue subject = new NullBiValue((RubyNil) ruby.getNil());
-        assertTrue(subject.hasRubyValue());
-        assertTrue(subject.hasJavaValue());
-        assertEquals(null, subject.javaValue());
-    }
-
-    @Test
     public void testNullBiValueFromJava() {
         NullBiValue subject = NullBiValue.newNullBiValue();
-        assertFalse(subject.hasRubyValue());
+        assertTrue(subject.hasRubyValue());
         assertTrue(subject.hasJavaValue());
         assertEquals(ruby.getNil(), subject.rubyValue(ruby));
     }


### PR DESCRIPTION
The Ruby execution environment is a singleton in the way we use JRuby (calling Java from a Ruby application) => There is no reason to instantiate multiple instances of the `null` wrapper, they will all point to the same `RubyNil` instance anyway and have no further state stored.

* Saves us `~30k` of these when benchmarking the Apache dataset.
* Also fixed one more compiler warning from the raw return type on `org.logstash.bivalues.BiValues.BiValueType#build` :)
* Had to adjust `org.logstash.TestBase#ruby` to use the global `Ruby` instance as well, which is more accurately representing our environment anyways imo
