### PR TITLE
MINOR: Fix all compiler warnings in AccessorsTest and EventTest

### DIFF
--- a/logstash-core/src/test/java/org/logstash/AccessorsTest.java
+++ b/logstash-core/src/test/java/org/logstash/AccessorsTest.java
@@ -14,12 +14,14 @@ import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class AccessorsTest {
 
     public class TestableAccessors extends Accessors {
 
-        public TestableAccessors(Map data) {
+        public TestableAccessors(Map<String, Object> data) {
             super(data);
         }
 
@@ -30,73 +32,73 @@ public class AccessorsTest {
 
     @Test
     public void testBareGet() throws Exception {
-        Map data = new HashMap();
+        Map<String, Object> data = new HashMap<>();
         data.put("foo", "bar");
         String reference = "foo";
 
         TestableAccessors accessors = new TestableAccessors(data);
-        assertEquals(accessors.lutGet(reference), null);
-        assertEquals(accessors.get(reference), "bar");
-        assertEquals(accessors.lutGet(reference), data);
+        assertNull(accessors.lutGet(reference));
+        assertEquals("bar", accessors.get(reference));
+        assertEquals(data, accessors.lutGet(reference));
     }
 
     @Test
     public void testAbsentBareGet() throws Exception {
-        Map data = new HashMap();
+        Map<String, Object> data = new HashMap<>();
         data.put("foo", "bar");
         String reference = "baz";
 
         TestableAccessors accessors = new TestableAccessors(data);
-        assertEquals(accessors.lutGet(reference), null);
-        assertEquals(accessors.get(reference), null);
-        assertEquals(accessors.lutGet(reference), data);
+        assertNull(accessors.lutGet(reference));
+        assertNull(accessors.get(reference));
+        assertEquals(data, accessors.lutGet(reference));
     }
 
     @Test
     public void testBareBracketsGet() throws Exception {
-        Map data = new HashMap();
+        Map<String, Object> data = new HashMap<>();
         data.put("foo", "bar");
         String reference = "[foo]";
 
         TestableAccessors accessors = new TestableAccessors(data);
-        assertEquals(accessors.lutGet(reference), null);
-        assertEquals(accessors.get(reference), "bar");
-        assertEquals(accessors.lutGet(reference), data);
+        assertNull(accessors.lutGet(reference));
+        assertEquals("bar", accessors.get(reference));
+        assertEquals(data, accessors.lutGet(reference));
     }
 
     @Test
     public void testDeepMapGet() throws Exception {
-        Map data = new HashMap();
-        Map inner = new HashMap();
+        Map<String, Object> data = new HashMap<>();
+        Map<String, Object> inner = new HashMap<>();
         data.put("foo", inner);
         inner.put("bar", "baz");
 
         String reference = "[foo][bar]";
 
         TestableAccessors accessors = new TestableAccessors(data);
-        assertEquals(accessors.lutGet(reference), null);
-        assertEquals(accessors.get(reference), "baz");
-        assertEquals(accessors.lutGet(reference), inner);
+        assertNull(accessors.lutGet(reference));
+        assertEquals("baz", accessors.get(reference));
+        assertEquals(inner, accessors.lutGet(reference));
     }
 
     @Test
     public void testAbsentDeepMapGet() throws Exception {
-        Map data = new HashMap();
-        Map inner = new HashMap();
+        Map<String, Object> data = new HashMap<>();
+        Map<String, Object> inner = new HashMap<>();
         data.put("foo", inner);
         inner.put("bar", "baz");
 
         String reference = "[foo][foo]";
 
         TestableAccessors accessors = new TestableAccessors(data);
-        assertEquals(accessors.lutGet(reference), null);
-        assertEquals(accessors.get(reference), null);
-        assertEquals(accessors.lutGet(reference), inner);
+        assertNull(accessors.lutGet(reference));
+        assertNull(accessors.get(reference));
+        assertEquals(inner, accessors.lutGet(reference));
     }
 
     @Test
     public void testDeepListGet() throws Exception {
-        Map data = new HashMap();
+        Map<String, Object> data = new HashMap<>();
         List inner = new ArrayList();
         data.put("foo", inner);
         inner.add("bar");
@@ -104,14 +106,14 @@ public class AccessorsTest {
         String reference = "[foo][0]";
 
         TestableAccessors accessors = new TestableAccessors(data);
-        assertEquals(accessors.lutGet(reference), null);
-        assertEquals(accessors.get(reference), "bar");
-        assertEquals(accessors.lutGet(reference), inner);
+        assertNull(accessors.lutGet(reference));
+        assertEquals("bar", accessors.get(reference));
+        assertEquals(inner, accessors.lutGet(reference));
     }
 
     @Test
     public void testAbsentDeepListGet() throws Exception {
-        Map data = new HashMap();
+        Map<String, Object> data = new HashMap<>();
         List inner = new ArrayList();
         data.put("foo", inner);
         inner.add("bar");
@@ -119,9 +121,9 @@ public class AccessorsTest {
         String reference = "[foo][1]";
 
         TestableAccessors accessors = new TestableAccessors(data);
-        assertEquals(accessors.lutGet(reference), null);
-        assertEquals(accessors.get(reference), null);
-        assertEquals(accessors.lutGet(reference), inner);
+        assertNull(accessors.lutGet(reference));
+        assertNull(accessors.get(reference));
+        assertEquals(inner, accessors.lutGet(reference));
     }
     /*
      * Check if accessors are able to recovery from
@@ -131,7 +133,7 @@ public class AccessorsTest {
      */
     @Test
     public void testInvalidIdList() throws Exception {
-        Map data = new HashMap();
+        Map<String, Object> data = new HashMap<>();
         List inner = new ArrayList();
         data.put("map1", inner);
         inner.add("obj1");
@@ -140,108 +142,106 @@ public class AccessorsTest {
         String reference = "[map1][IdNonNumeric]";
 
         TestableAccessors accessors = new TestableAccessors(data);
-        assertEquals(accessors.lutGet(reference), null);
-        assertEquals(accessors.get(reference), null);
-        assertEquals(accessors.set(reference, "obj3"), null);
-        assertEquals(accessors.lutGet(reference), inner);
+        assertNull(accessors.lutGet(reference));
+        assertNull(accessors.get(reference));
+        assertNull(accessors.set(reference, "obj3"));
+        assertEquals(inner, accessors.lutGet(reference));
         assertFalse(accessors.includes(reference));
-        assertEquals(accessors.del(reference), null);
+        assertNull(accessors.del(reference));
     }
 
     @Test
     public void testBarePut() throws Exception {
-        Map data = new HashMap();
+        Map<String, Object> data = new HashMap<>();
         String reference = "foo";
 
         TestableAccessors accessors = new TestableAccessors(data);
-        assertEquals(accessors.lutGet(reference), null);
-        assertEquals(accessors.set(reference, "bar"), "bar");
-        assertEquals(accessors.lutGet(reference), data);
-        assertEquals(accessors.get(reference), "bar");
+        assertNull(accessors.lutGet(reference));
+        assertEquals("bar", accessors.set(reference, "bar"));
+        assertEquals(data, accessors.lutGet(reference));
+        assertEquals("bar", accessors.get(reference));
     }
 
     @Test
     public void testBareBracketsPut() throws Exception {
-        Map data = new HashMap();
+        Map<String, Object> data = new HashMap<>();
         String reference = "[foo]";
 
         TestableAccessors accessors = new TestableAccessors(data);
-        assertEquals(accessors.lutGet(reference), null);
-        assertEquals(accessors.set(reference, "bar"), "bar");
-        assertEquals(accessors.lutGet(reference), data);
-        assertEquals(accessors.get(reference), "bar");
+        assertNull(accessors.lutGet(reference));
+        assertEquals("bar", accessors.set(reference, "bar"));
+        assertEquals(data, accessors.lutGet(reference));
+        assertEquals("bar", accessors.get(reference));
     }
 
     @Test
     public void testDeepMapSet() throws Exception {
-        Map data = new HashMap();
+        Map<String, Object> data = new HashMap<>();
 
         String reference = "[foo][bar]";
 
         TestableAccessors accessors = new TestableAccessors(data);
-        assertEquals(accessors.lutGet(reference), null);
-        assertEquals(accessors.set(reference, "baz"), "baz");
+        assertNull(accessors.lutGet(reference));
+        assertEquals("baz", accessors.set(reference, "baz"));
         assertEquals(accessors.lutGet(reference), data.get("foo"));
-        assertEquals(accessors.get(reference), "baz");
+        assertEquals("baz", accessors.get(reference));
     }
 
     @Test
     public void testDel() throws Exception {
-        Map data = new HashMap();
+        Map<String, Object> data = new HashMap<>();
         List inner = new ArrayList();
         data.put("foo", inner);
         inner.add("bar");
         data.put("bar", "baz");
         TestableAccessors accessors = new TestableAccessors(data);
 
-        assertEquals(accessors.del("[foo][0]"), "bar");
-        assertEquals(accessors.del("[foo][0]"), null);
-        assertEquals(accessors.get("[foo]"), new ArrayList<>());
-        assertEquals(accessors.del("[bar]"), "baz");
-        assertEquals(accessors.get("[bar]"), null);
+        assertEquals("bar", accessors.del("[foo][0]"));
+        assertNull(accessors.del("[foo][0]"));
+        assertEquals(new ArrayList<>(), accessors.get("[foo]"));
+        assertEquals("baz", accessors.del("[bar]"));
+        assertNull(accessors.get("[bar]"));
     }
 
     @Test
     public void testNilInclude() throws Exception {
-        Map data = new HashMap();
+        Map<String, Object> data = new HashMap<>();
         data.put("nilfield", null);
         TestableAccessors accessors = new TestableAccessors(data);
-
-        assertEquals(accessors.includes("nilfield"), true);
+        assertTrue(accessors.includes("nilfield"));
     }
 
     @Test
     public void testInvalidPath() throws Exception {
-        Map data = new HashMap();
+        Map<String, Object> data = new HashMap<>();
         Accessors accessors = new Accessors(data);
 
-        assertEquals(accessors.set("[foo]", 1), 1);
-        assertEquals(accessors.get("[foo][bar]"), null);
+        assertEquals(1, accessors.set("[foo]", 1));
+        assertNull(accessors.get("[foo][bar]"));
     }
 
     @Test
     public void testStaleTargetCache() throws Exception {
-        Map data = new HashMap();
+        Map<String, Object> data = new HashMap<>();
 
         Accessors accessors = new Accessors(data);
+        assertNull(accessors.get("[foo][bar]"));
+        assertEquals("baz", accessors.set("[foo][bar]", "baz"));
+        assertEquals("baz", accessors.get("[foo][bar]"));
 
-        assertEquals(accessors.get("[foo][bar]"), null);
-        assertEquals(accessors.set("[foo][bar]", "baz"), "baz");
-        assertEquals(accessors.get("[foo][bar]"), "baz");
-
-        assertEquals(accessors.set("[foo]", "boom"), "boom");
-        assertEquals(accessors.get("[foo][bar]"), null);
-        assertEquals(accessors.get("[foo]"), "boom");
+        assertEquals("boom", accessors.set("[foo]", "boom"));
+        assertNull(accessors.get("[foo][bar]"));
+        assertEquals("boom", accessors.get("[foo]"));
     }
 
     @Test
     public void testListIndexOutOfBounds() {
-        assertEquals(Accessors.listIndex(0, 10), 0);
-        assertEquals(Accessors.listIndex(1, 10), 1);
-        assertEquals(Accessors.listIndex(9, 10), 9);
-        assertEquals(Accessors.listIndex(-1, 10), 9);
-        assertEquals(Accessors.listIndex(-9, 10), 1);
-        assertEquals(Accessors.listIndex(-10, 10), 0);
+        assertEquals(0, Accessors.listIndex(0, 10));
+        assertEquals(1, Accessors.listIndex(1, 10));
+        assertEquals(9, Accessors.listIndex(9, 10));
+        assertEquals(9, Accessors.listIndex(-1, 10));
+        assertEquals(1, Accessors.listIndex(-9, 10));
+        assertEquals(0, Accessors.listIndex(-10, 10));
     }
 
     @RunWith(Theories.class)

--- a/logstash-core/src/test/java/org/logstash/EventTest.java
+++ b/logstash-core/src/test/java/org/logstash/EventTest.java
@@ -19,7 +19,7 @@ public class EventTest {
         Event e = new Event();
         e.setField("foo", 42L);
         e.setField("bar", 42);
-        HashMap inner = new HashMap(2);
+        Map<String, Object> inner = new HashMap<>(2);
         inner.put("innerFoo", 42L);
         inner.put("innerQuux", 42.42);
         e.setField("baz", inner);
@@ -40,7 +40,7 @@ public class EventTest {
         Event e = new Event();
         e.setField("foo", 42L);
         e.setField("bar", 42);
-        HashMap inner = new HashMap(2);
+        Map<String, Object> inner = new HashMap<>(2);
         inner.put("innerFoo", 42L);
         inner.put("innerQuux", 42.42);
         e.setField("baz", inner);
@@ -63,7 +63,7 @@ public class EventTest {
 
     @Test
     public void testSimpleStringFieldToJson() throws Exception {
-        Map data = new HashMap();
+        Map<String, Object> data = new HashMap<>();
         data.put("foo", "bar");
         Event e = new Event(data);
         assertJsonEquals("{\"@timestamp\":\"" + e.getTimestamp().toIso8601() + "\",\"foo\":\"bar\",\"@version\":\"1\"}", e.toJson());
@@ -71,7 +71,7 @@ public class EventTest {
 
     @Test
     public void testSimpleIntegerFieldToJson() throws Exception {
-        Map data = new HashMap();
+        Map<String, Object> data = new HashMap<>();
         data.put("foo", 1);
         Event e = new Event(data);
         assertJsonEquals("{\"@timestamp\":\"" + e.getTimestamp().toIso8601() + "\",\"foo\":1,\"@version\":\"1\"}", e.toJson());
@@ -79,7 +79,7 @@ public class EventTest {
 
     @Test
     public void testSimpleDecimalFieldToJson() throws Exception {
-        Map data = new HashMap();
+        Map<String, Object> data = new HashMap<>();
         data.put("foo", 1.0);
         Event e = new Event(data);
         assertJsonEquals("{\"@timestamp\":\"" + e.getTimestamp().toIso8601() + "\",\"foo\":1.0,\"@version\":\"1\"}", e.toJson());
@@ -87,7 +87,7 @@ public class EventTest {
 
     @Test
     public void testSimpleMultipleFieldToJson() throws Exception {
-        Map data = new HashMap();
+        Map<String, Object> data = new HashMap<>();
         data.put("foo", 1.0);
         data.put("bar", "bar");
         data.put("baz", 1);
@@ -108,8 +108,8 @@ public class EventTest {
 
     @Test
     public void testGetFieldList() throws Exception {
-        Map data = new HashMap();
-        List l = new ArrayList();
+        Map<String, Object> data = new HashMap<>();
+        List<Object> l = new ArrayList<>();
         data.put("foo", l);
         l.add(1);
         Event e = new Event(data);
@@ -118,10 +118,10 @@ public class EventTest {
 
     @Test
     public void testDeepGetField() throws Exception {
-        Map data = new HashMap();
-        List l = new ArrayList();
+        Map<String, Object> data = new HashMap<>();
+        List<Object> l = new ArrayList<>();
         data.put("foo", l);
-        Map m = new HashMap();
+        Map<String, Object> m = new HashMap<>();
         m.put("bar", "baz");
         l.add(m);
         Event e = new Event(data);
@@ -131,11 +131,11 @@ public class EventTest {
 
     @Test
     public void testClone() throws Exception {
-        Map data = new HashMap();
-        List l = new ArrayList();
+        Map<String, Object> data = new HashMap<>();
+        List<Object> l = new ArrayList<>();
         data.put("array", l);
 
-        Map m = new HashMap();
+        Map<String, Object> m = new HashMap<>();
         m.put("foo", "bar");
         l.add(m);
 
@@ -154,18 +154,18 @@ public class EventTest {
     @Test
     public void testToMap() throws Exception {
         Event e = new Event();
-        Map original = e.getData();
-        Map clone = e.toMap();
+        Map<String, Object> original = e.getData();
+        Map<String, Object> clone = e.toMap();
         assertFalse(original == clone);
         assertEquals(original, clone);
     }
 
     @Test
     public void testAppend() throws Exception {
-        Map data1 = new HashMap();
+        Map<String, Object> data1 = new HashMap<>();
         data1.put("field1", Arrays.asList("original1", "original2"));
 
-        Map data2 = new HashMap();
+        Map<String, Object> data2 = new HashMap<>();
         data2.put("field1", "original1");
 
         Event e = new Event(data1);
@@ -179,10 +179,10 @@ public class EventTest {
 
     @Test
     public void testAppendLists() throws Exception {
-        Map data1 = new HashMap();
+        Map<String, Object> data1 = new HashMap<>();
         data1.put("field1", Arrays.asList("original1", "original2"));
 
-        Map data2 = new HashMap();
+        Map<String, Object> data2 = new HashMap<>();
         data2.put("field1", Arrays.asList("original3", "original4"));
 
         Event e = new Event(data1);
@@ -276,7 +276,7 @@ public class EventTest {
 
     @Test
     public void testTagOnExistingTagsField() throws Exception {
-        Map data = new HashMap();
+        Map<String, Object> data = new HashMap<>();
         data.put("tags", "foo");
         Event e = new Event(data);
         e.tag("bar");
@@ -289,7 +289,7 @@ public class EventTest {
 
     @Test
     public void toStringwithTimestamp() throws Exception {
-        Map data = new HashMap();
+        Map<String, Object> data = new HashMap<>();
         data.put("host", "foo");
         data.put("message", "bar");
         Event e = new Event(data);
@@ -298,7 +298,7 @@ public class EventTest {
 
     @Test
     public void toStringwithoutTimestamp() throws Exception {
-        Map data = new HashMap();
+        Map<String, Object> data = new HashMap<>();
         data.put("host", "foo");
         data.put("message", "bar");
         Event e = new Event(data);


### PR DESCRIPTION
Completely trivial auto-fix for #7701 :

* All raw generic type use in `EventTest` and `AccessorsTest` fixed
* All misordered assertions in `AccessorsTest` flipped or replaced by their simplified version