### PR TITLE
MINOR: Factor out cold-path from org.logstash.Event#initTimestamp

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -290,11 +290,22 @@ public class Event implements Cloneable, Serializable, Queueable {
     }
 
     private static Timestamp initTimestamp(Object o) {
+        if (o == null || o instanceof NullBiValue) {
+            // most frequent
+            return new Timestamp();
+        } else {
+            return parseTimestamp(o);
+        }
+    }
+
+    /**
+     * Cold path of {@link Event#initTimestamp(Object)}.
+     * @param o Object to parse Timestamp out of
+     * @return Parsed {@link Timestamp} or {@code null} on failure
+     */
+    private static Timestamp parseTimestamp(final Object o) {
         try {
-            if (o == null || o instanceof NullBiValue) {
-                // most frequent
-                return new Timestamp();
-            } else if (o instanceof String) {
+            if (o instanceof String) {
                 // second most frequent
                 return new Timestamp((String) o);
             } else if (o instanceof StringBiValue) {
@@ -319,7 +330,6 @@ public class Event implements Cloneable, Serializable, Queueable {
         } catch (IllegalArgumentException e) {
             logger.warn("Error parsing " + TIMESTAMP + " string value=" + o.toString());
         }
-
         return null;
     }
 


### PR DESCRIPTION
This is a pretty visible offender when looking at the compile logs.
The hot path (as commented) is def the breakout `if (o == null || o instanceof NullBiValue) {` but the method isn't inlined because of the huge conditional that follows and is super cold.

=> factored it out and now `initTimestamp` gets inlined into the constructor of `Event`.