### PR TITLE
Correct ES_client to only split strings + add csv_string(array) method

### DIFF
--- a/logstash-core/lib/logstash/elasticsearch_client.rb
+++ b/logstash-core/lib/logstash/elasticsearch_client.rb
@@ -108,7 +108,11 @@ module LogStash class ElasticsearchClient
     end
 
     def unpack_hosts
-      @settings.fetch("var.elasticsearch.hosts", "localhost:9200").split(',').map(&:strip)
+      setting = @settings.fetch("var.elasticsearch.hosts", "localhost:9200")
+      if setting.is_a?(String)
+        return setting.split(',').map(&:strip)
+      end
+      setting
     end
   end
 

--- a/logstash-core/lib/logstash/modules/logstash_config.rb
+++ b/logstash-core/lib/logstash/modules/logstash_config.rb
@@ -33,6 +33,10 @@ module LogStash module Modules class LogStashConfig
     "[#{array.collect { |i| "'#{i}'" }.join(", ")}]"
   end
 
+  def csv_string(array)
+    "'#{array.join(',')}'"
+  end
+
   def get_setting(setting_class)
     raw_value = @settings[setting_class.name]
     # If we dont check for NIL, the Settings class will try to coerce the value


### PR DESCRIPTION
an x-pack-logstash PR will be reliant on the csv_string method.