### PR TITLE
MINOR: Set JVM's Xms == Xmx as a default

### DIFF
--- a/config/jvm.options
+++ b/config/jvm.options
@@ -3,7 +3,7 @@
 # Xms represents the initial size of total heap space
 # Xmx represents the maximum size of total heap space
 
--Xms256m
+-Xms1g
 -Xmx1g
 
 ################################################################

--- a/docs/static/performance-checklist.asciidoc
+++ b/docs/static/performance-checklist.asciidoc
@@ -43,6 +43,7 @@ You may be tempted to jump ahead and change settings like `pipeline.workers` (`-
 * Often times CPU utilization can go through the roof if the heap size is too low, resulting in the JVM constantly garbage collecting.
 * A quick way to check for this issue is to double the heap size and see if performance improves. Do not increase the heap size past the amount of physical memory. Leave at least 1GB free for the OS and other processes.
 * You can make more accurate measurements of the JVM heap by using either the `jmap` command line utility distributed with Java or by using VisualVM. For more info, see <<profiling-the-heap>>.
+* Always make sure to set the minimum (Xms) and maximum (Xmx) heap allocation size to the same value to prevent the heap from resizing at runtime, which is a very costly process.
 
 . *Tune Logstash worker settings:*
 +


### PR DESCRIPTION
This is a really trivial gain with the default settings:

### Before:

<img width="1360" alt="screen shot 2017-07-18 at 16 37 17" src="https://user-images.githubusercontent.com/6490959/28322862-8299b8cc-6bd7-11e7-95d6-962f87029259.png">

### After:

<img width="1351" alt="screen shot 2017-07-18 at 16 35 17" src="https://user-images.githubusercontent.com/6490959/28322877-8da19640-6bd7-11e7-9b6b-35dae0e7af61.png">

less than half the number of GCs and each individual one is ~5x as fast as before (obviously, since we're not resizing the Heap all the time).
~25% speedup with 2 threads on the Apache dataset.