### PR TITLE
BUG: Accessors were quietly swallowing broken syntax

### DIFF
--- a/logstash-core/src/test/java/org/logstash/AccessorsTest.java
+++ b/logstash-core/src/test/java/org/logstash/AccessorsTest.java
@@ -13,7 +13,6 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -124,30 +123,6 @@ public class AccessorsTest {
         assertNull(accessors.lutGet(reference));
         assertNull(accessors.get(reference));
         assertEquals(inner, accessors.lutGet(reference));
-    }
-    /*
-     * Check if accessors are able to recovery from
-     * failure to convert the key (string) to integer,
-     * when it is a non-numeric value, which is not
-     * expected.
-     */
-    @Test
-    public void testInvalidIdList() throws Exception {
-        Map<String, Object> data = new HashMap<>();
-        List inner = new ArrayList();
-        data.put("map1", inner);
-        inner.add("obj1");
-        inner.add("obj2");
-
-        String reference = "[map1][IdNonNumeric]";
-
-        TestableAccessors accessors = new TestableAccessors(data);
-        assertNull(accessors.lutGet(reference));
-        assertNull(accessors.get(reference));
-        assertNull(accessors.set(reference, "obj3"));
-        assertEquals(inner, accessors.lutGet(reference));
-        assertFalse(accessors.includes(reference));
-        assertNull(accessors.del(reference));
     }
 
     @Test
@@ -262,8 +237,7 @@ public class AccessorsTest {
 
       @Theory
       public void testListIndexOutOfBounds(int i) {
-        exception.expect(IndexOutOfBoundsException.class);
-        Accessors.listIndex(i, size);
+        assertEquals(-1, Accessors.listIndex(i, size));
       }
     }
 


### PR DESCRIPTION
Two things here (sorry for putting them into one PR, but they were really close logically and it seems like it would lead to a clearer git history to not have two back-to-back commits on the relevant lines here), so one important thing and one is just cleanup:

### Easy clean-up first:

Throwing `IndexOutOfBoundsException` in `listIndex ` only to catch it every time and interpret as wrong input makes no sense, that method only returns valid values `>=0` -> just return `-1` to signal an issue => fix exceptions as flow control anti-pattern + is much easier on the JIT in the very hot path here.

### Bug

We were quietly swallowing what the deleted test shows, the following did not even log a warning:

1. Put a list to `[a][b]`
2. Store something to or get something from `[a][b][c]` (c being not numeric) would simply be indistinguishable from any other `set` valid call and just return `null` for `get` without being distinguishable from any other call to an empty/non-existing field. (note: the `null` return on the `set` calls or any return from it, is simply ignored in `Event`)

I don't think this should be something we catch at any level. This seems equivalent to a syntax error in a plugin and should outright die to prevent data-loss and creating bugs that are almost impossible to debug.