### PR TITLE
Test stabilization: Ensure that logging is set back to 'info' after tests that may change it

### DIFF
--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -43,6 +43,10 @@ describe LogStash::Runner do
     allow(agent).to receive(:shutdown)
   end
 
+  after :each do
+    LogStash::Logging::Logger::configure_logging("info")
+  end
+
   describe "argument precedence" do
     let(:config) { "input {} output {}" }
     let(:cli_args) { ["-e", config, "-w", "20"] }


### PR DESCRIPTION
Fixes #7739