### PR TITLE
pass http_options to can_connect in kibana_client

### DIFF
--- a/logstash-core/lib/logstash/modules/kibana_client.rb
+++ b/logstash-core/lib/logstash/modules/kibana_client.rb
@@ -96,7 +96,7 @@ module LogStash module Modules class KibanaClient
   end
 
   def head(relative_path)
-    safely(:head, relative_path)
+    safely(:head, relative_path, @http_options)
   end
 
   def can_connect?


### PR DESCRIPTION
the can_connect? method performs a HEAD request to /api/status but doesn't use the `@http_options`, which causes requests to fail if authorization credentials are required.

This PR ensures the `@http_options` are used.