### PR TITLE
Add at_least(:once) to work around intermittent test failures

### DIFF
--- a/logstash-core/spec/logstash/instrument/periodic_poller/jvm_spec.rb
+++ b/logstash-core/spec/logstash/instrument/periodic_poller/jvm_spec.rb
@@ -44,7 +44,7 @@ describe LogStash::Instrument::PeriodicPoller::JVM do
         before do
           expect(LogStash::Environment).to receive(:windows?).and_return(false)
           expect(LogStash::Environment).to receive(:linux?).and_return(true)
-          expect(::File).to receive(:read).with("/proc/loadavg").and_raise("Didnt work out so well")
+          expect(::File).to receive(:read).with("/proc/loadavg").at_least(:once).and_raise("Didnt work out so well")
         end
 
         it "doesn't raise an exception" do


### PR DESCRIPTION
The test that calls out to /proc/loadavg has been intermittently
 failing, because /proc/loadavg is being read from more than once
This should be benign, so this commit allows it to happen

Fixes #6867