### PR TITLE
MINOR: Cleanup Event by making it final and removing the incorrect serializable interface

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -1,7 +1,6 @@
 package org.logstash;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -22,8 +21,7 @@ import org.logstash.ext.JrubyTimestampExtLibrary;
 import static org.logstash.ObjectMappers.CBOR_MAPPER;
 import static org.logstash.ObjectMappers.JSON_MAPPER;
 
-
-public class Event implements Cloneable, Serializable, Queueable {
+public final class Event implements Cloneable, Queueable {
 
     private boolean cancelled;
     private Map<String, Object> data;
@@ -272,8 +270,8 @@ public class Event implements Cloneable, Serializable, Queueable {
     }
 
     @Override
-    public Event clone() throws CloneNotSupportedException {
-        return new Event(Cloner.deep(getData()));
+    public Event clone() {
+        return new Event(Cloner.deep(this.data));
     }
 
     public String toString() {

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -166,11 +166,7 @@ public class JrubyEventExtLibrary implements Library {
         @JRubyMethod(name = "clone")
         public IRubyObject ruby_clone(ThreadContext context)
         {
-            try {
-                return RubyEvent.newRubyEvent(context.runtime, this.event.clone());
-            } catch (CloneNotSupportedException e) {
-                throw context.runtime.newRuntimeError(e.getMessage());
-            }
+            return RubyEvent.newRubyEvent(context.runtime, this.event.clone());
         }
 
         @JRubyMethod(name = "overwrite", required = 1)


### PR DESCRIPTION
* We don't extend `Event` anywhere
   * We can save the JIT some trouble here by making it `final`, also saves us some random code around the `clone()` method which now won't throw
* `Event` is not `Serializable` in the sense of that interface, dropped the interface to save us a compiler warning for the missing serialization version UID