### PR TITLE
MINOR: Remove locking around simple getter

### DIFF
--- a/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
@@ -98,12 +98,7 @@ module LogStash; module Util
       end
 
       def inflight_batches
-        @mutex.lock
-        begin
-          yield(@inflight_batches)
-        ensure
-          @mutex.unlock
-        end
+        @inflight_batches
       end
 
       def current_inflight_batch


### PR DESCRIPTION
Not sure why we're locking around a simple getter here, this doesn't seem to do anything -> removing it.