### PR TITLE
#7712 Simplify BiValue Serialization

### DIFF
--- a/logstash-core/src/main/java/org/logstash/bivalues/BigDecimalBiValue.java
+++ b/logstash-core/src/main/java/org/logstash/bivalues/BigDecimalBiValue.java
@@ -1,12 +1,13 @@
 package org.logstash.bivalues;
 
+import java.math.BigDecimal;
 import org.jruby.Ruby;
 import org.jruby.ext.bigdecimal.RubyBigDecimal;
 
-import java.io.ObjectStreamException;
-import java.math.BigDecimal;
+public final class BigDecimalBiValue extends BiValueCommon<RubyBigDecimal, BigDecimal> 
+    implements BiValue<RubyBigDecimal, BigDecimal> {
 
-public class BigDecimalBiValue extends BiValueCommon<RubyBigDecimal, BigDecimal> implements BiValue<RubyBigDecimal, BigDecimal> {
+    private static final long serialVersionUID = -3408830056779123333L;
 
     public BigDecimalBiValue(RubyBigDecimal rubyValue) {
         this.rubyValue = rubyValue;
@@ -18,19 +19,11 @@ public class BigDecimalBiValue extends BiValueCommon<RubyBigDecimal, BigDecimal>
         rubyValue = null;
     }
 
-    private BigDecimalBiValue() {
-    }
-
     protected void addRuby(Ruby runtime) {
         rubyValue = new RubyBigDecimal(runtime, runtime.getClass("BigDecimal"), javaValue);
     }
 
     protected void addJava() {
         javaValue = rubyValue.getBigDecimalValue();
-    }
-
-    // Called when object is to be serialized on a stream to allow the object to substitute a proxy for itself.
-    private Object writeReplace() throws ObjectStreamException {
-        return newProxy(this);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/bivalues/BigIntegerBiValue.java
+++ b/logstash-core/src/main/java/org/logstash/bivalues/BigIntegerBiValue.java
@@ -1,12 +1,13 @@
 package org.logstash.bivalues;
 
+import java.math.BigInteger;
 import org.jruby.Ruby;
 import org.jruby.RubyBignum;
 
-import java.io.ObjectStreamException;
-import java.math.BigInteger;
+public final class BigIntegerBiValue extends BiValueCommon<RubyBignum, BigInteger> 
+    implements BiValue<RubyBignum, BigInteger> {
 
-public class BigIntegerBiValue extends BiValueCommon<RubyBignum, BigInteger> implements BiValue<RubyBignum, BigInteger> {
+    private static final long serialVersionUID = -6779003043647264917L;
 
     public BigIntegerBiValue(RubyBignum rubyValue) {
         this.rubyValue = rubyValue;
@@ -18,19 +19,11 @@ public class BigIntegerBiValue extends BiValueCommon<RubyBignum, BigInteger> imp
         rubyValue = null;
     }
 
-    private BigIntegerBiValue() {
-    }
-
     protected void addRuby(Ruby runtime) {
         rubyValue = new RubyBignum(runtime, javaValue);
     }
 
     protected void addJava() {
         javaValue = rubyValue.getValue();
-    }
-
-    // Called when object is to be serialized on a stream to allow the object to substitute a proxy for itself.
-    private Object writeReplace() throws ObjectStreamException {
-        return newProxy(this);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/bivalues/BooleanBiValue.java
+++ b/logstash-core/src/main/java/org/logstash/bivalues/BooleanBiValue.java
@@ -3,10 +3,10 @@ package org.logstash.bivalues;
 import org.jruby.Ruby;
 import org.jruby.RubyBoolean;
 
-import java.io.ObjectStreamException;
+public final class BooleanBiValue extends BiValueCommon<RubyBoolean, Boolean> 
+    implements BiValue<RubyBoolean, Boolean> {
 
-
-public class BooleanBiValue extends BiValueCommon<RubyBoolean, Boolean> implements BiValue<RubyBoolean, Boolean> {
+    private static final long serialVersionUID = 126658646136243974L;
 
     public BooleanBiValue(RubyBoolean rubyValue) {
         this.rubyValue = rubyValue;
@@ -18,19 +18,11 @@ public class BooleanBiValue extends BiValueCommon<RubyBoolean, Boolean> implemen
         rubyValue = null;
     }
 
-    private BooleanBiValue() {
-    }
-
     protected void addRuby(Ruby runtime) {
         rubyValue = RubyBoolean.newBoolean(runtime, javaValue);
     }
 
     protected void addJava() {
         javaValue = rubyValue.isTrue();
-    }
-
-    // Called when object is to be serialized on a stream to allow the object to substitute a proxy for itself.
-    private Object writeReplace() throws ObjectStreamException {
-        return newProxy(this);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/bivalues/DoubleBiValue.java
+++ b/logstash-core/src/main/java/org/logstash/bivalues/DoubleBiValue.java
@@ -3,10 +3,10 @@ package org.logstash.bivalues;
 import org.jruby.Ruby;
 import org.jruby.RubyFloat;
 
-import java.io.ObjectStreamException;
+public final class DoubleBiValue extends BiValueCommon<RubyFloat, Double> 
+    implements BiValue<RubyFloat, Double> {
 
-
-public class DoubleBiValue extends BiValueCommon<RubyFloat, Double> implements BiValue<RubyFloat, Double> {
+    private static final long serialVersionUID = 3434273761801429821L;
 
     public DoubleBiValue(RubyFloat rubyValue) {
         this.rubyValue = rubyValue;
@@ -18,19 +18,11 @@ public class DoubleBiValue extends BiValueCommon<RubyFloat, Double> implements B
         rubyValue = null;
     }
 
-    private DoubleBiValue() {
-    }
-
     protected void addRuby(Ruby runtime) {
         rubyValue = RubyFloat.newFloat(runtime, javaValue);
     }
 
     protected void addJava() {
         javaValue = rubyValue.getDoubleValue();
-    }
-
-    // Called when object is to be serialized on a stream to allow the object to substitute a proxy for itself.
-    private Object writeReplace() throws ObjectStreamException {
-        return newProxy(this);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/bivalues/FloatBiValue.java
+++ b/logstash-core/src/main/java/org/logstash/bivalues/FloatBiValue.java
@@ -3,10 +3,10 @@ package org.logstash.bivalues;
 import org.jruby.Ruby;
 import org.jruby.RubyFloat;
 
-import java.io.ObjectStreamException;
+public final class FloatBiValue extends BiValueCommon<RubyFloat, Float> 
+    implements BiValue<RubyFloat, Float> {
 
-
-public class FloatBiValue extends BiValueCommon<RubyFloat, Float> implements BiValue<RubyFloat, Float> {
+    private static final long serialVersionUID = 3076337527056049715L;
 
     public FloatBiValue(RubyFloat rubyValue) {
         this.rubyValue = rubyValue;
@@ -16,9 +16,6 @@ public class FloatBiValue extends BiValueCommon<RubyFloat, Float> implements BiV
     public FloatBiValue(Float javaValue) {
         this.javaValue = javaValue;
         rubyValue = null;
-    }
-
-    private FloatBiValue() {
     }
 
     protected void addRuby(Ruby runtime) {
@@ -31,10 +28,5 @@ public class FloatBiValue extends BiValueCommon<RubyFloat, Float> implements BiV
             throw new ArithmeticException("Float overflow - Incorrect FloatBiValue usage: BiValues should pick DoubleBiValue for RubyFloat");
         }
         javaValue = (float) value;
-    }
-
-    // Called when object is to be serialized on a stream to allow the object to substitute a proxy for itself.
-    private Object writeReplace() throws ObjectStreamException {
-        return newProxy(this);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/bivalues/IntegerBiValue.java
+++ b/logstash-core/src/main/java/org/logstash/bivalues/IntegerBiValue.java
@@ -4,9 +4,10 @@ import org.jruby.Ruby;
 import org.jruby.RubyInteger;
 import org.jruby.javasupport.JavaUtil;
 
-import java.io.ObjectStreamException;
+public final class IntegerBiValue extends BiValueCommon<RubyInteger, Integer> 
+    implements BiValue<RubyInteger, Integer> {
 
-public class IntegerBiValue extends BiValueCommon<RubyInteger, Integer> implements BiValue<RubyInteger, Integer> {
+    private static final long serialVersionUID = -3220011682769931400L;
 
     public IntegerBiValue(RubyInteger rubyValue) {
         this.rubyValue = rubyValue;
@@ -16,9 +17,6 @@ public class IntegerBiValue extends BiValueCommon<RubyInteger, Integer> implemen
     public IntegerBiValue(int javaValue) {
         this.javaValue = javaValue;
         rubyValue = null;
-    }
-
-    private IntegerBiValue() {
     }
 
     protected void addRuby(Ruby runtime) {
@@ -31,10 +29,5 @@ public class IntegerBiValue extends BiValueCommon<RubyInteger, Integer> implemen
             throw new ArithmeticException("Integer overflow - Incorrect IntegerBiValue usage: BiValues should pick LongBiValue for RubyInteger");
         }
         javaValue = (int) value;
-    }
-
-    // Called when object is to be serialized on a stream to allow the object to substitute a proxy for itself.
-    private Object writeReplace() throws ObjectStreamException {
-        return newProxy(this);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/bivalues/JavaProxyBiValue.java
+++ b/logstash-core/src/main/java/org/logstash/bivalues/JavaProxyBiValue.java
@@ -4,9 +4,10 @@ import org.jruby.Ruby;
 import org.jruby.java.proxies.JavaProxy;
 import org.jruby.javasupport.JavaUtil;
 
-import java.io.ObjectStreamException;
+public final class JavaProxyBiValue extends BiValueCommon<JavaProxy, Object> 
+    implements BiValue<JavaProxy, Object> {
 
-public class JavaProxyBiValue extends BiValueCommon<JavaProxy, Object> implements BiValue<JavaProxy, Object> {
+    private static final long serialVersionUID = 9127622347449815350L;
 
     public JavaProxyBiValue(JavaProxy rubyValue) {
         this.rubyValue = rubyValue;
@@ -18,19 +19,11 @@ public class JavaProxyBiValue extends BiValueCommon<JavaProxy, Object> implement
         rubyValue = null;
     }
 
-    private JavaProxyBiValue() {
-    }
-
     protected void addRuby(Ruby runtime) {
         rubyValue = (JavaProxy) JavaUtil.convertJavaToUsableRubyObject(runtime, javaValue);
     }
 
     protected void addJava() {
         javaValue = rubyValue.getObject();
-    }
-
-    // Called when object is to be serialized on a stream to allow the object to substitute a proxy for itself.
-    private Object writeReplace() throws ObjectStreamException {
-        return newProxy(this);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/bivalues/LongBiValue.java
+++ b/logstash-core/src/main/java/org/logstash/bivalues/LongBiValue.java
@@ -4,9 +4,10 @@ import org.jruby.Ruby;
 import org.jruby.RubyInteger;
 import org.jruby.javasupport.JavaUtil;
 
-import java.io.ObjectStreamException;
+public final class LongBiValue extends BiValueCommon<RubyInteger, Long>
+    implements BiValue<RubyInteger, Long> {
 
-public class LongBiValue extends BiValueCommon<RubyInteger, Long> implements BiValue<RubyInteger, Long> {
+    private static final long serialVersionUID = -6119062523375669671L;
 
     public LongBiValue(RubyInteger rubyValue) {
         this.rubyValue = rubyValue;
@@ -18,19 +19,11 @@ public class LongBiValue extends BiValueCommon<RubyInteger, Long> implements BiV
         rubyValue = null;
     }
 
-    private LongBiValue() {
-    }
-
     protected void addRuby(Ruby runtime) {
         rubyValue = (RubyInteger) JavaUtil.convertJavaToUsableRubyObject(runtime, javaValue);
     }
 
     protected void addJava() {
         javaValue = rubyValue.getLongValue();
-    }
-
-    // Called when object is to be serialized on a stream to allow the object to substitute a proxy for itself.
-    private Object writeReplace() throws ObjectStreamException {
-        return newProxy(this);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/bivalues/NullBiValue.java
+++ b/logstash-core/src/main/java/org/logstash/bivalues/NullBiValue.java
@@ -1,7 +1,6 @@
 package org.logstash.bivalues;
 
 import com.fasterxml.jackson.annotation.JsonValue;
-import java.io.ObjectStreamException;
 import org.jruby.Ruby;
 import org.jruby.RubyNil;
 
@@ -11,7 +10,7 @@ public final class NullBiValue extends BiValueCommon<RubyNil, Object>
     private static final NullBiValue INSTANCE =
         new NullBiValue((RubyNil) Ruby.getGlobalRuntime().getNil());
 
-    private static final Object WRITE_PROXY = newProxy(INSTANCE);
+    private static final long serialVersionUID = 3324022424426763767L;
 
     public static NullBiValue newNullBiValue() {
         return INSTANCE;
@@ -43,9 +42,4 @@ public final class NullBiValue extends BiValueCommon<RubyNil, Object>
 
     @Override
     protected void addJava() {}
-
-    // Called when object is to be serialized on a stream to allow the object to substitute a proxy for itself.
-    private Object writeReplace() throws ObjectStreamException {
-        return WRITE_PROXY;
-    }
 }

--- a/logstash-core/src/main/java/org/logstash/bivalues/StringBiValue.java
+++ b/logstash-core/src/main/java/org/logstash/bivalues/StringBiValue.java
@@ -1,12 +1,13 @@
 package org.logstash.bivalues;
 
 import com.fasterxml.jackson.annotation.JsonValue;
-import java.io.ObjectStreamException;
 import org.jruby.Ruby;
 import org.jruby.RubyString;
 
 public final class StringBiValue extends BiValueCommon<RubyString, String>
     implements BiValue<RubyString, String> {
+
+    private static final long serialVersionUID = -1059663228107569565L;
 
     public StringBiValue(RubyString rubyValue) {
         this.rubyValue = rubyValue;
@@ -15,9 +16,6 @@ public final class StringBiValue extends BiValueCommon<RubyString, String>
     public StringBiValue(String javaValue) {
         this.javaValue = javaValue;
         rubyValue = null;
-    }
-
-    private StringBiValue() {
     }
 
     @Override
@@ -49,10 +47,5 @@ public final class StringBiValue extends BiValueCommon<RubyString, String>
     @Override
     public boolean hasJavaValue() {
         return true;
-    }
-
-    // Called when object is to be serialized on a stream to allow the object to substitute a proxy for itself.
-    private Object writeReplace() throws ObjectStreamException {
-        return newProxy(this);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/bivalues/SymbolBiValue.java
+++ b/logstash-core/src/main/java/org/logstash/bivalues/SymbolBiValue.java
@@ -3,9 +3,10 @@ package org.logstash.bivalues;
 import org.jruby.Ruby;
 import org.jruby.RubySymbol;
 
-import java.io.ObjectStreamException;
+public final class SymbolBiValue extends BiValueCommon<RubySymbol, String> 
+    implements BiValue<RubySymbol, String> {
 
-public class SymbolBiValue extends BiValueCommon<RubySymbol, String> implements BiValue<RubySymbol, String> {
+    private static final long serialVersionUID = -2010627976505908822L;
 
     public SymbolBiValue(RubySymbol rubyValue) {
         this.rubyValue = rubyValue;
@@ -17,19 +18,11 @@ public class SymbolBiValue extends BiValueCommon<RubySymbol, String> implements 
         rubyValue = null;
     }
 
-    private SymbolBiValue() {
-    }
-
     protected void addRuby(Ruby runtime) {
         rubyValue = RubySymbol.newSymbol(runtime, javaValue);
     }
 
     protected void addJava() {
         javaValue = rubyValue.asJavaString();
-    }
-
-    // Called when object is to be serialized on a stream to allow the object to substitute a proxy for itself.
-    private Object writeReplace() throws ObjectStreamException {
-        return newProxy(this);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/bivalues/TimeBiValue.java
+++ b/logstash-core/src/main/java/org/logstash/bivalues/TimeBiValue.java
@@ -4,10 +4,10 @@ import org.joda.time.DateTime;
 import org.jruby.Ruby;
 import org.jruby.RubyTime;
 
-import java.io.ObjectStreamException;
+public final class TimeBiValue extends BiValueCommon<RubyTime, DateTime> 
+    implements BiValue<RubyTime, DateTime> {
 
-
-public class TimeBiValue extends BiValueCommon<RubyTime, DateTime> implements BiValue<RubyTime, DateTime> {
+    private static final long serialVersionUID = -8792359519343205099L;
 
     public TimeBiValue(RubyTime rubyValue) {
         this.rubyValue = rubyValue;
@@ -19,19 +19,11 @@ public class TimeBiValue extends BiValueCommon<RubyTime, DateTime> implements Bi
         rubyValue = null;
     }
 
-    private TimeBiValue() {
-    }
-
     protected void addRuby(Ruby runtime) {
         rubyValue = RubyTime.newTime(runtime, javaValue);
     }
 
     protected void addJava() {
         javaValue = rubyValue.getDateTime();
-    }
-
-    // Called when object is to be serialized on a stream to allow the object to substitute a proxy for itself.
-    private Object writeReplace() throws ObjectStreamException {
-        return newProxy(this);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/bivalues/TimestampBiValue.java
+++ b/logstash-core/src/main/java/org/logstash/bivalues/TimestampBiValue.java
@@ -1,12 +1,13 @@
 package org.logstash.bivalues;
 
+import org.jruby.Ruby;
 import org.logstash.Timestamp;
 import org.logstash.ext.JrubyTimestampExtLibrary.RubyTimestamp;
-import org.jruby.Ruby;
 
-import java.io.ObjectStreamException;
+public final class TimestampBiValue extends BiValueCommon<RubyTimestamp, Timestamp> 
+    implements BiValue<RubyTimestamp, Timestamp> {
 
-public class TimestampBiValue extends BiValueCommon<RubyTimestamp, Timestamp> implements BiValue<RubyTimestamp, Timestamp> {
+    private static final long serialVersionUID = -4868460704798452962L;
 
     public TimestampBiValue(RubyTimestamp rubyValue) {
         this.rubyValue = rubyValue;
@@ -18,19 +19,11 @@ public class TimestampBiValue extends BiValueCommon<RubyTimestamp, Timestamp> im
         rubyValue = null;
     }
 
-    private TimestampBiValue() {
-    }
-
     protected void addRuby(Ruby runtime) {
         rubyValue = RubyTimestamp.newRubyTimestamp(runtime, javaValue);
     }
 
     protected void addJava() {
         javaValue = rubyValue.getTimestamp();
-    }
-
-    // Called when object is to be serialized on a stream to allow the object to substitute a proxy for itself.
-    private Object writeReplace() throws ObjectStreamException {
-        return newProxy(this);
     }
 }


### PR DESCRIPTION
This looks like a reasonable step/simplification on the road to removing the `BiValue` overhead for #7712 

* Stop using `SerializationProxy`, it's just overhead since we don't have any `final` fields
   * Should make PQ faster in some spots + saves a ton of memory in all situations
   * Made all fields `transient` to prevent random mistakes in the implementation
   * Saves a lot of code since we can inherit the serialization overrides from the abstract base class
* Add a serialization UID to each type to remove the `javac` warning
* Make each of these `final` to et some clarity, it's bad enough we inherit the serialization approach in the first place :)
* No need for the dead private constructors now => removed