### PR TITLE
MINOR: Remove unused take and timed offer from queue wrappers

### DIFF
--- a/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
@@ -57,24 +57,6 @@ module LogStash; module Util
     end
     alias_method(:<<, :push)
 
-    # TODO - fix doc for this noop method
-    # Offer an object to the queue, wait for the specified amount of time.
-    # If adding to the queue was successful it will return true, false otherwise.
-    #
-    # @param [Object] Object to add to the queue
-    # @param [Integer] Time in milliseconds to wait before giving up
-    # @return [Boolean] True if adding was successful if not it return false
-    def offer(obj, timeout_ms)
-      raise NotImplementedError.new("The offer method is not implemented. There is no non blocking write operation yet.")
-    end
-
-    # Blocking
-    def take
-      check_closed("read a batch")
-      # TODO - determine better arbitrary timeout millis
-      @queue.read_batch(1, 200).get_elements.first
-    end
-
     # Block for X millis
     def poll(millis)
       check_closed("read")

--- a/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
@@ -18,21 +18,6 @@ module LogStash; module Util
     end
     alias_method(:<<, :push)
 
-    # Offer an object to the queue, wait for the specified amount of time.
-    # If adding to the queue was successful it wil return true, false otherwise.
-    #
-    # @param [Object] Object to add to the queue
-    # @param [Integer] Time in milliseconds to wait before giving up
-    # @return [Boolean] True if adding was successful if not it return false
-    def offer(obj, timeout_ms)
-      @queue.offer(obj, timeout_ms, TimeUnit::MILLISECONDS)
-    end
-
-    # Blocking
-    def take
-      @queue.take
-    end
-
     # Block for X millis
     def poll(millis)
       @queue.poll(millis, TimeUnit::MILLISECONDS)

--- a/logstash-core/spec/logstash/util/wrapped_synchronous_queue_spec.rb
+++ b/logstash-core/spec/logstash/util/wrapped_synchronous_queue_spec.rb
@@ -4,28 +4,6 @@ require "logstash/util/wrapped_synchronous_queue"
 require "logstash/instrument/collector"
 
 describe LogStash::Util::WrappedSynchronousQueue do
-  context "#offer" do
-    context "queue is blocked" do
-      it "fails and give feedback" do
-        expect(subject.offer("Bonjour", 2)).to be_falsey
-      end
-    end
-
-    context "queue is not blocked" do
-      before do
-        @consumer = Thread.new { loop { subject.take } }
-        sleep(0.1)
-      end
-
-      after do
-        @consumer.kill
-      end
-
-      it "inserts successfully" do
-        expect(subject.offer("Bonjour", 20)).to be_truthy
-      end
-    end
-  end
 
   describe "queue clients" do
     context "when requesting a write client" do


### PR DESCRIPTION
`offer` and `take` aren't used anywhere => remove the dead code.