### PR TITLE
 #7799 fix Windows incompatible Resource use + Windows incompatible use of /dev/null

### DIFF
--- a/tools/benchmark-cli/build.gradle
+++ b/tools/benchmark-cli/build.gradle
@@ -30,6 +30,7 @@ dependencies {
   compile 'net.sf.jopt-simple:jopt-simple:5.0.3'
   compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'
   compile group: 'org.apache.commons', name: 'commons-compress', version: '1.14'
+  compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.6'
   compile group: 'commons-io', name: 'commons-io', version: '2.5'
   compile 'com.fasterxml.jackson.core:jackson-core:2.7.4'
   compile 'com.fasterxml.jackson.core:jackson-databind:2.7.4'

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/LogstashInstallation.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/LogstashInstallation.java
@@ -127,8 +127,9 @@ public interface LogstashInstallation {
             );
             final Path lsbin = location.resolve("bin").resolve("logstash");
             LsBenchFileUtil.ensureExecutable(lsbin.toFile());
+            final File output = Files.createTempFile(null, null).toFile();
             final Process process = pbuilder.command(lsbin.toString(), "-w", "2", "-f", cfg.toString()).redirectOutput(
-                ProcessBuilder.Redirect.to(new File("/dev/null"))
+                ProcessBuilder.Redirect.to(output)
             ).start();
             if (data != null) {
                 try (final InputStream file = new FileInputStream(data);
@@ -140,6 +141,7 @@ public interface LogstashInstallation {
                 throw new IllegalStateException("Logstash failed to start!");
             }
             LsBenchFileUtil.ensureDeleted(cfg.toFile());
+            LsBenchFileUtil.ensureDeleted(output);
         }
 
         @Override

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/ui/UserOutput.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/ui/UserOutput.java
@@ -4,8 +4,21 @@ import java.io.PrintStream;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import org.apache.commons.lang3.SystemUtils;
 
 public final class UserOutput {
+
+    /**
+     * ANSI colorized green section open sequence(On Unix platform only).
+     */
+    private static final String GREEN_ANSI_OPEN = SystemUtils.IS_OS_UNIX ? "\u001B[32m" : "";
+
+    /**
+     * ANSI colorized section close sequence(On Unix platform only).
+     */
+    private static final String ANSI_CLOSE = SystemUtils.IS_OS_UNIX ? "\u001B[0m" : "";
+
+    private static final String BANNER = "Logstash Benchmark";
 
     private static final DateTimeFormatter DATE_TIME_FORMATTER = new DateTimeFormatterBuilder()
         .append(DateTimeFormatter.ofPattern("E")).appendLiteral(' ')
@@ -14,7 +27,7 @@ public final class UserOutput {
         .append(DateTimeFormatter.ISO_LOCAL_TIME).appendLiteral(' ')
         .append(DateTimeFormatter.ofPattern("yyyy")).appendLiteral(' ')
         .append(DateTimeFormatter.ofPattern("z")).toFormatter();
-    
+
     private final PrintStream target;
 
     public UserOutput(final PrintStream target) {
@@ -34,29 +47,15 @@ public final class UserOutput {
     }
 
     public void printBanner() {
-        green(
-            "██╗      ██████╗  ██████╗ ███████╗████████╗ █████╗ ███████╗██╗  ██╗          \n" +
-                "██║     ██╔═══██╗██╔════╝ ██╔════╝╚══██╔══╝██╔══██╗██╔════╝██║  ██║          \n" +
-                "██║     ██║   ██║██║  ███╗███████╗   ██║   ███████║███████╗███████║          \n" +
-                "██║     ██║   ██║██║   ██║╚════██║   ██║   ██╔══██║╚════██║██╔══██║          \n" +
-                "███████╗╚██████╔╝╚██████╔╝███████║   ██║   ██║  ██║███████║██║  ██║          \n" +
-                "╚══════╝ ╚═════╝  ╚═════╝ ╚══════╝   ╚═╝   ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝          \n" +
-                "                                                                             \n" +
-                "██████╗ ███████╗███╗   ██╗ ██████╗██╗  ██╗███╗   ███╗ █████╗ ██████╗ ██╗  ██╗\n" +
-                "██╔══██╗██╔════╝████╗  ██║██╔════╝██║  ██║████╗ ████║██╔══██╗██╔══██╗██║ ██╔╝\n" +
-                "██████╔╝█████╗  ██╔██╗ ██║██║     ███████║██╔████╔██║███████║██████╔╝█████╔╝ \n" +
-                "██╔══██╗██╔══╝  ██║╚██╗██║██║     ██╔══██║██║╚██╔╝██║██╔══██║██╔══██╗██╔═██╗ \n" +
-                "██████╔╝███████╗██║ ╚████║╚██████╗██║  ██║██║ ╚═╝ ██║██║  ██║██║  ██║██║  ██╗\n" +
-                "╚═════╝ ╚══════╝╚═╝  ╚═══╝ ╚═════╝╚═╝  ╚═╝╚═╝     ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝\n" +
-                "                                                                             ");
+        green(BANNER);
     }
 
     public void green(final String line) {
-        target.println(colorize(line, "\u001B[32m"));
+        target.println(colorize(line, GREEN_ANSI_OPEN));
     }
 
     private static String colorize(final String line, final String prefix) {
-        final String reset = "\u001B[0m";
+        final String reset = ANSI_CLOSE;
         return new StringBuilder(line.length() + 2 * reset.length())
             .append(prefix).append(line).append(reset).toString();
     }

--- a/tools/benchmark-cli/src/test/java/org/logstash/benchmark/cli/LsMetricsMonitorTest.java
+++ b/tools/benchmark-cli/src/test/java/org/logstash/benchmark/cli/LsMetricsMonitorTest.java
@@ -2,14 +2,16 @@ package org.logstash.benchmark.cli;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.EnumMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.IOUtils;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Rule;
@@ -30,11 +32,7 @@ public final class LsMetricsMonitorTest {
     public void parsesFilteredCount() throws Exception {
         final String path = "/_node/stats/?pretty";
         http.stubFor(WireMock.get(WireMock.urlEqualTo(path)).willReturn(WireMock.okJson(
-            new String(
-                Files.readAllBytes(
-                    Paths.get(LsMetricsMonitorTest.class.getResource("metrics.json").getPath()
-                    ))
-                , StandardCharsets.UTF_8)
+            metricsFixture()
         )));
         final ExecutorService executor = Executors.newSingleThreadExecutor();
         try {
@@ -54,11 +52,7 @@ public final class LsMetricsMonitorTest {
     public void parsesCpuUsage() throws Exception {
         final String path = "/_node/stats/?pretty";
         http.stubFor(WireMock.get(WireMock.urlEqualTo(path)).willReturn(WireMock.okJson(
-            new String(
-                Files.readAllBytes(
-                    Paths.get(LsMetricsMonitorTest.class.getResource("metrics.json").getPath()
-                    ))
-                , StandardCharsets.UTF_8)
+            metricsFixture()
         )));
         final ExecutorService executor = Executors.newSingleThreadExecutor();
         try {
@@ -72,5 +66,14 @@ public final class LsMetricsMonitorTest {
         } finally {
             executor.shutdownNow();
         }
+    }
+
+    private static String metricsFixture() throws IOException {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (final InputStream input = LsMetricsMonitorTest.class
+            .getResourceAsStream("metrics.json")) {
+            IOUtils.copy(input, baos);
+        }
+        return baos.toString(StandardCharsets.UTF_8.name());
     }
 }


### PR DESCRIPTION
Obvious fixes:

* `/dev/null` won't work on Windows, used random temp file instead (output size is small enough for this to be fine + Java doesn't really offer us much better than redirecting to a `File` when it comes to Windows anyway as far as I can tell)
* Adjusted the resources read to not work from a `URL` but just read the stream directly
* Banner didn't work on Windows for encoding reasons, removed for now, we can add a portable one at some later date I guess :D 

### Note to the Reviewer

The Windows build still fails :(, but the issue in #7799 is fixed here since the benchmark build passes