### PR TITLE
Revert "Fix path for local development"

### DIFF
--- a/logstash-core/lib/logstash-core/logstash-core.rb
+++ b/logstash-core/lib/logstash-core/logstash-core.rb
@@ -8,8 +8,8 @@ end
 require "logstash-core_jars"
 
 # local dev setup
-classes_dir = File.expand_path("../../../out/production/classes", __FILE__)
-resources_dir = File.expand_path("../../../out/production/resources", __FILE__)
+classes_dir = File.expand_path("../../../build/classes/java/main", __FILE__)
+resources_dir = File.expand_path("../../../build/resources/main", __FILE__)
 
 if File.directory?(classes_dir) && File.directory?(resources_dir)
   # if in local dev setup, add target to classpath


### PR DESCRIPTION
This reverts commit ae21bf374c3f4c605018af0280faa2ca26e11a6d.

This change was only applicable to IntelliJ, see https://youtrack.jetbrains.com/issue/IDEA-175172

The latest version of IntelliJ uses ```out/production``` , not ```build/classes``` this causes a mismatch between between running ./gradlew and using IntelliJ.

This change reverts back to preferring ./gradlew 's class path. 