### PR TITLE
handle fully acked zero byte page at queue open

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Batch.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Batch.java
@@ -38,6 +38,8 @@ public class Batch implements Closeable {
         return elements;
     }
 
+    public List<Long> getSeqNums() { return this.seqNums; }
+
     public Queue getQueue() {
         return queue;
     }


### PR DESCRIPTION
fixes #7809 

This fixes the condition upon opening the queue, a page file of zero byte with a fully acked checkpoint would generate this exception:

```
Logstash failed to create queue {"exception"=>"Page file size 0 different to configured page capacity xxx
```

I also added a test to reproduce that problem. Without this fix the test fails with the above exception and passes with this PR.

This condition should not prevent LS from starting since fully acked page are simply purged in the open process. Here we just do the purge before checking on the file size. 

Now, the condition which leads to having a zero byte page file is still unknown. 

followup issue #7811 to DRY the code. This seems to be an acceptable fix for now. 