### PR TITLE
PERFORMANCE: Extracted Cold paths in BiValues and Accessors

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Accessors.java
+++ b/logstash-core/src/main/java/org/logstash/Accessors.java
@@ -91,22 +91,19 @@ public class Accessors {
     }
 
     private Object findTarget(FieldReference field) {
-        Object target;
+        final Object target = this.lut.get(field.getReference());
+        return target != null ? target : cacheTarget(field);
+    }
 
-        if ((target = this.lut.get(field.getReference())) != null) {
-            return target;
-        }
-
-        target = this.data;
-        for (String key : field.getPath()) {
+    private Object cacheTarget(final FieldReference field) {
+        Object target = this.data;
+        for (final String key : field.getPath()) {
             target = fetch(target, key);
-            if (! isCollection(target)) {
+            if (!isCollection(target)) {
                 return null;
             }
         }
-
         this.lut.put(field.getReference(), target);
-
         return target;
     }
 

--- a/logstash-core/src/main/java/org/logstash/Javafier.java
+++ b/logstash-core/src/main/java/org/logstash/Javafier.java
@@ -15,6 +15,9 @@ public class Javafier {
     private Javafier(){}
 
     public static Object deep(Object o) {
+        if(o == null) {
+            return null;
+        }
         if (o instanceof BiValue) {
             return ((BiValue)o).javaValue();
         } else if(o instanceof ConvertedMap) {

--- a/logstash-core/src/main/java/org/logstash/PathCache.java
+++ b/logstash-core/src/main/java/org/logstash/PathCache.java
@@ -12,7 +12,7 @@ public final class PathCache {
 
     static {
         // inject @timestamp
-        cache(BRACKETS_TIMESTAMP, timestamp);
+        cache.put(BRACKETS_TIMESTAMP, timestamp);
     }
 
     public static boolean isTimestamp(String reference) {
@@ -21,16 +21,16 @@ public final class PathCache {
 
     public static FieldReference cache(String reference) {
         // atomicity between the get and put is not important
-        FieldReference result = cache.get(reference);
-        if (result == null) {
-            result = FieldReference.parse(reference);
-            cache.put(reference, result);
+        final FieldReference result = cache.get(reference);
+        if (result != null) {
+            return result;
         }
-        return result;
+        return parseToCache(reference);
     }
-
-    public static FieldReference cache(String reference, FieldReference field) {
-        cache.put(reference, field);
-        return field;
+    
+    private static FieldReference parseToCache(final String reference) {
+        final FieldReference result = FieldReference.parse(reference);
+        cache.put(reference, result);
+        return result;
     }
 }

--- a/logstash-core/src/main/java/org/logstash/Valuefier.java
+++ b/logstash-core/src/main/java/org/logstash/Valuefier.java
@@ -25,6 +25,9 @@ public class Valuefier {
     private Valuefier(){}
 
     private static Object convertJavaProxy(JavaProxy jp) {
+        if(jp == null) {
+            return BiValues.NULL_BI_VALUE;
+        }
         Object obj = JavaUtil.unwrapJavaObject(jp);
         if (obj instanceof IRubyObject[]) {
             return ConvertedList.newFromRubyArray((IRubyObject[]) obj);
@@ -42,7 +45,7 @@ public class Valuefier {
 
     public static Object convertNonCollection(Object o) {
         try {
-            return BiValues.newBiValue(o);
+            return o == null ? BiValues.NULL_BI_VALUE : BiValues.newBiValue(o);
         } catch (IllegalArgumentException e) {
             final Class<?> cls = o.getClass();
             throw new IllegalArgumentException(String.format(ERR_TEMPLATE, cls.getName(), cls.getSimpleName()), e);

--- a/logstash-core/src/main/java/org/logstash/bivalues/BiValues.java
+++ b/logstash-core/src/main/java/org/logstash/bivalues/BiValues.java
@@ -67,7 +67,7 @@ public enum BiValues {
         return hm;
     }
 
-    private static final NullBiValue NULL_BI_VALUE = NullBiValue.newNullBiValue();
+    public static final NullBiValue NULL_BI_VALUE = NullBiValue.newNullBiValue();
 
     private final BiValueType biValueType;
 
@@ -75,7 +75,7 @@ public enum BiValues {
         this.biValueType = biValueType;
     }
 
-    private static final HashMap<String, String> nameCache = initCache();
+    private static final HashMap<String, String> NAME_CACHE = initCache();
 
     private BiValue build(Object value) {
         return biValueType.build(value);
@@ -85,18 +85,22 @@ public enum BiValues {
         if (o == null) {
             return NULL_BI_VALUE;
         }
-        BiValues bvs = valueOf(fetchName(o));
-        return bvs.build(o);
+        return valueOf(fetchName(o)).build(o);
     }
 
     private static String fetchName(Object o) {
-        String cls = o.getClass().getName();
-        if (nameCache.containsKey(cls)) {
-            return nameCache.get(cls);
+        final String cls = o.getClass().getName();
+        final String name = NAME_CACHE.get(cls);
+        if (name != null) {
+            return name;
         }
-        String toCache = cls.toUpperCase().replace('.', '_');
+        return cacheName(cls);
+    }
+    
+    private static String cacheName(final String cls) {
+        final String toCache = cls.toUpperCase().replace('.', '_');
         // TODO[Guy] log warn that we are seeing a uncached value
-        nameCache.put(cls, toCache);
+        NAME_CACHE.put(cls, toCache);
         return toCache;
     }
 


### PR DESCRIPTION
Standard improvements:

* Extract cold cache branches to separate methods where possible (then the JIT can inline the much more likely hot cache path in more instances than when it has to also inline the cold path to where it's never used)
* Move `null` checks up the stack in `Valuefier` etc. The `null` path showed with a likelihood of about `50%` across multiple config examples I tested and the redundant `null` check introduced in the other half of cases is way cheaper than a few `instanceof` and a subsequent method call now saved in the `null` case

Also:

* corrected naming of `NAME_CACHE` since it's a constant
* Removed redundant `public static FieldReference cache(String reference, FieldReference field)` because the return value was never used and hence it was simply a wrapper for `.put()` making JIT logs harder to read with the other overload of `cache` being super hot

... that's it for the obvious things that could be found using JitWatch I think :)