### PR TITLE
 #7784 Cleanup Metric Collection in Benchmarks

### DIFF
--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/cases/ApacheLogsComplex.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/cases/ApacheLogsComplex.java
@@ -9,10 +9,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.EnumMap;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.commons.io.IOUtils;
 import org.logstash.benchmark.cli.LogstashInstallation;
@@ -45,10 +41,8 @@ public final class ApacheLogsComplex implements Case {
 
     @Override
     public EnumMap<LsMetricStats, ListStatistics> run() {
-        final LsMetricsMonitor monitor = new LsMetricsMonitor(logstash.metrics());
-        final ExecutorService exec = Executors.newSingleThreadExecutor();
-        final Future<EnumMap<LsMetricStats, ListStatistics>> future = exec.submit(monitor);
-        try {
+        try (final LsMetricsMonitor.MonitorExecution monitor =
+                 new LsMetricsMonitor.MonitorExecution(logstash.metrics())) {
             final String config;
             try (final InputStream cfg = ApacheLogsComplex.class
                 .getResourceAsStream("apache.cfg")) {
@@ -57,12 +51,9 @@ public final class ApacheLogsComplex implements Case {
                 config = baos.toString();
             }
             logstash.execute(config, data);
-            monitor.stop();
-            return future.get(20L, TimeUnit.SECONDS);
+            return monitor.stopAndGet();
         } catch (final IOException | InterruptedException | ExecutionException | TimeoutException ex) {
             throw new IllegalStateException(ex);
-        } finally {
-            exec.shutdownNow();
         }
     }
 


### PR DESCRIPTION
Just some cleanup of compiler warnings and duplication to prepare for introducing optional ES output in #7784.