### PR TITLE
Close channel associated with lock in DLQ

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -146,7 +146,12 @@ public final class DeadLetterQueueWriter implements Closeable {
 
     @Override
     public synchronized void close() throws IOException {
-        this.lock.release();
+        if (this.lock != null){
+            this.lock.release();
+            if (this.lock.channel() != null && this.lock.channel().isOpen()) {
+                this.lock.channel().close();
+            }
+        }
         if (currentWriter != null) {
             currentWriter.close();
         }


### PR DESCRIPTION
Fix Windows build issue where .lock file cannot be deleted due to
underling channel associated with lock not being closed. This
will stop the file from being deleted until the JVM exits, despite
reporting through Java that the file *has* been deleted and does not
exist. It also blocks new files from being created with the same
filename, which caused the test failure here.