### PR TITLE
MINOR: Cleanup redundant code in RubyEvent

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedBatchExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedBatchExtLibrary.java
@@ -71,7 +71,7 @@ public class JrubyAckedBatchExtLibrary implements Library {
         public IRubyObject ruby_get_elements(ThreadContext context)
         {
             RubyArray result = context.runtime.newArray();
-            this.batch.getElements().forEach(e -> result.add(new JrubyEventExtLibrary.RubyEvent(context.runtime, (Event)e)));
+            this.batch.getElements().forEach(e -> result.add(JrubyEventExtLibrary.RubyEvent.newRubyEvent(context.runtime, (Event)e)));
 
             return result;
         }

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
@@ -39,7 +39,7 @@ public class JrubyTimestampExtLibrary implements Library {
         return clazz;
     }
 
-    @JRubyClass(name = "Timestamp", parent = "Object")
+    @JRubyClass(name = "Timestamp")
     public static class RubyTimestamp extends RubyObject {
 
         private Timestamp timestamp;


### PR DESCRIPTION
Minor cleanups:

* Only have one constructor for `RubyEvent` and use a method reference as `ObjectAllocator` => inlines a little better (this isn't that important most of the time since we don't allocate `RubyEvent` in hot loops, but since (our) Ruby methods are fairly large it might have positive side effects on newer JVMs (and is much cleaner to read)
   * Only if there is one single constructor though
* Also made setter for event private since it was not used anywhere (actually this change towards the static wrapper for the construction of the `RubyEvent` is the only use of it now)
* Removed redundant default on `RubyTimestamp`'s annotation