### PR TITLE
#7784 Benchmark ES Output

### DIFF
--- a/tools/benchmark-cli/README.md
+++ b/tools/benchmark-cli/README.md
@@ -18,6 +18,8 @@ Option                           Description
 ------                           -----------                                    
 --distribution-version <String>  The version of a Logstash build to download    
                                    from elastic.co.                             
+--elasticsearch-export <String>  Optional Elasticsearch host URL to store       
+                                   detailed results at. (default: )                       
 --git-hash <String>              Either a git tree (tag/branch or commit hash), 
                                    optionally prefixed by a Github username,    
                                  if ran against forks.                          

--- a/tools/benchmark-cli/build.gradle
+++ b/tools/benchmark-cli/build.gradle
@@ -23,7 +23,8 @@ buildscript {
 }
 
 ext {
-  jmh = 1.18
+  jmh = '1.18'
+  elasticsearch = '5.5.0'
 }
 
 dependencies {
@@ -34,6 +35,7 @@ dependencies {
   compile group: 'commons-io', name: 'commons-io', version: '2.5'
   compile 'com.fasterxml.jackson.core:jackson-core:2.7.4'
   compile 'com.fasterxml.jackson.core:jackson-databind:2.7.4'
+  compile group: 'org.elasticsearch.client', name: 'rest', version: elasticsearch
   compile "org.openjdk.jmh:jmh-core:$jmh"
   testCompile group: 'com.github.tomakehurst', name: 'wiremock-standalone', version: '2.6.0'
   testCompile "junit:junit:4.12"
@@ -45,6 +47,7 @@ javadoc {
 
 test {
   exclude '**/org/logstash/benchmark/cli/MainTest*'
+  exclude '**/org/logstash/benchmark/cli/MainEsStorageTest*'
 }
 
 apply plugin: 'com.github.johnrengelman.shadow'

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/DataStore.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/DataStore.java
@@ -1,0 +1,84 @@
+package org.logstash.benchmark.cli;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpStatus;
+import org.apache.http.entity.ContentType;
+import org.apache.http.nio.entity.NStringEntity;
+import org.elasticsearch.client.RestClient;
+import org.logstash.benchmark.cli.ui.LsMetricStats;
+import org.logstash.benchmark.cli.util.LsBenchJsonUtil;
+import org.openjdk.jmh.util.ListStatistics;
+
+public interface DataStore extends Closeable {
+
+    /**
+     * Dummy {@link DataStore} that does nothing.
+     */
+    DataStore NONE = new DataStore() {
+        @Override
+        public void store(final Map<LsMetricStats, ListStatistics> data) {
+        }
+
+        @Override
+        public void close() {
+        }
+    };
+
+    /**
+     * @param data Measured Data
+     * @throws IOException On Failure
+     */
+    void store(Map<LsMetricStats, ListStatistics> data) throws IOException;
+
+    /**
+     * Datastore backed by Elasticsearch.
+     */
+    final class ElasticSearch implements DataStore {
+
+        /**
+         * Low Level Elasticsearch {@link RestClient}.
+         */
+        private final RestClient client;
+
+        /**
+         * Metadata for the current benchmark run.
+         */
+        private final Map<String, Object> meta;
+
+        /**
+         * Ctor.
+         * @param host Elasticsearch Hostname
+         * @param port Elasticsearch Port
+         * @param schema {@code "http"} or {@code "https"} 
+         * @param meta Metadata
+         */
+        ElasticSearch(final String host, final int port, final String schema,
+            final Map<String, Object> meta) {
+            client = RestClient.builder(new HttpHost(host, port, schema)).build();
+            this.meta = meta;
+        }
+
+        @Override
+        public void store(final Map<LsMetricStats, ListStatistics> data) throws IOException {
+            if (client.performRequest(
+                "POST", "/logstash-benchmarks/measurement/",
+                Collections.emptyMap(),
+                new NStringEntity(
+                    LsBenchJsonUtil.serializeEsResult(data, meta), ContentType.APPLICATION_JSON
+                )
+            ).getStatusLine().getStatusCode() != HttpStatus.SC_CREATED) {
+                throw new IllegalStateException(
+                    "Failed to save measurement to Elasticsearch.");
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            client.close();
+        }
+    }
+}

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/cases/ApacheLogsComplex.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/cases/ApacheLogsComplex.java
@@ -11,6 +11,7 @@ import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import org.apache.commons.io.IOUtils;
+import org.logstash.benchmark.cli.DataStore;
 import org.logstash.benchmark.cli.LogstashInstallation;
 import org.logstash.benchmark.cli.LsMetricsMonitor;
 import org.logstash.benchmark.cli.ui.LsMetricStats;
@@ -32,17 +33,21 @@ public final class ApacheLogsComplex implements Case {
 
     private final File data;
 
-    public ApacheLogsComplex(final LogstashInstallation logstash, final Path cwd,
+    private final DataStore store;
+
+    public ApacheLogsComplex(final DataStore store, final LogstashInstallation logstash,
+        final Path cwd,
         final Properties settings) throws IOException, NoSuchAlgorithmException {
         this.data = cwd.resolve("data_apache").resolve("apache_access_logs").toFile();
         ensureDatafile(data.toPath().getParent().toFile(), settings);
         this.logstash = logstash;
+        this.store = store;
     }
 
     @Override
     public EnumMap<LsMetricStats, ListStatistics> run() {
         try (final LsMetricsMonitor.MonitorExecution monitor =
-                 new LsMetricsMonitor.MonitorExecution(logstash.metrics())) {
+                 new LsMetricsMonitor.MonitorExecution(logstash.metrics(), store)) {
             final String config;
             try (final InputStream cfg = ApacheLogsComplex.class
                 .getResourceAsStream("apache.cfg")) {

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/cases/GeneratorToStdout.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/cases/GeneratorToStdout.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.EnumMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import org.logstash.benchmark.cli.DataStore;
 import org.logstash.benchmark.cli.LogstashInstallation;
 import org.logstash.benchmark.cli.LsMetricsMonitor;
 import org.logstash.benchmark.cli.ui.LsMetricStats;
@@ -24,14 +25,18 @@ public final class GeneratorToStdout implements Case {
 
     private final LogstashInstallation logstash;
 
-    public GeneratorToStdout(final LogstashInstallation logstash) {
+    private final DataStore store;
+
+    public GeneratorToStdout(final DataStore store, final LogstashInstallation logstash) {
         this.logstash = logstash;
+        this.store = store;
+
     }
 
     @Override
     public EnumMap<LsMetricStats, ListStatistics> run() {
         try (final LsMetricsMonitor.MonitorExecution monitor =
-                 new LsMetricsMonitor.MonitorExecution(logstash.metrics())) {
+                 new LsMetricsMonitor.MonitorExecution(logstash.metrics(), store)) {
             logstash.execute(GeneratorToStdout.CONFIGURATION);
             return monitor.stopAndGet();
         } catch (final IOException | InterruptedException | ExecutionException | TimeoutException ex) {

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/ui/UserInput.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/ui/UserInput.java
@@ -8,6 +8,12 @@ import java.nio.file.Paths;
  */
 public final class UserInput {
 
+    public static final String ES_OUTPUT_PARAM = "elasticsearch-export";
+
+    public static final String ES_OUTPUT_HELP = "Optional Elasticsearch host URL to store detailed results at.";
+
+    public static final String ES_OUTPUT_DEFAULT = "";
+
     /**
      * The Default Cache/Working-Directory.
      */

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/ui/UserOutput.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/ui/UserOutput.java
@@ -4,7 +4,9 @@ import java.io.PrintStream;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.util.Map;
 import org.apache.commons.lang3.SystemUtils;
+import org.openjdk.jmh.util.ListStatistics;
 
 public final class UserOutput {
 
@@ -54,6 +56,23 @@ public final class UserOutput {
         target.println(colorize(line, GREEN_ANSI_OPEN));
     }
 
+    public void printStatistics(final Map<LsMetricStats, ListStatistics> stats) {
+        green(
+            String.format("Num Events: %d", (long) stats.get(LsMetricStats.COUNT).getMax())
+        );
+        final ListStatistics throughput = stats.get(LsMetricStats.THROUGHPUT);
+        green(String.format("Throughput Min: %.2f", throughput.getMin()));
+        green(String.format("Throughput Max: %.2f", throughput.getMax()));
+        green(String.format("Throughput Mean: %.2f", throughput.getMean()));
+        green(String.format("Throughput StdDev: %.2f", throughput.getStandardDeviation()));
+        green(String.format("Throughput Variance: %.2f", throughput.getVariance()));
+        green(
+            String.format(
+                "Mean CPU Usage: %.2f%%", stats.get(LsMetricStats.CPU_USAGE).getMean()
+            )
+        );
+    }
+    
     private static String colorize(final String line, final String prefix) {
         final String reset = ANSI_CLOSE;
         return new StringBuilder(line.length() + 2 * reset.length())

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/util/LsBenchJsonUtil.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/util/LsBenchJsonUtil.java
@@ -1,0 +1,57 @@
+package org.logstash.benchmark.cli.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.logstash.benchmark.cli.ui.LsMetricStats;
+import org.openjdk.jmh.util.ListStatistics;
+
+/**
+ * Json Utilities.
+ */
+public final class LsBenchJsonUtil {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final JavaType LS_METRIC_TYPE =
+        OBJECT_MAPPER.getTypeFactory().constructMapType(HashMap.class, String.class, Object.class);
+
+    private LsBenchJsonUtil() {
+        // Utility Class
+    }
+
+    /**
+     * Deserializes metrics read from LS HTTP Api.
+     * @param data raw bytes read from HTTP API
+     * @return Deserialized JSON Map of Metrics
+     * @throws IOException On Deserialization Failure
+     */
+    public static Map<String, Object> deserializeMetrics(final byte[] data) throws IOException {
+        return LsBenchJsonUtil.OBJECT_MAPPER.readValue(data, LsBenchJsonUtil.LS_METRIC_TYPE);
+    }
+
+    /**
+     * Serializes result for storage in Elasticsearch.
+     * @param data Measurement Data
+     * @param meta Metadata
+     * @return JSON String
+     * @throws JsonProcessingException On Failure to Serialize
+     */
+    public static String serializeEsResult(final Map<LsMetricStats, ListStatistics> data,
+        final Map<String, Object> meta) throws JsonProcessingException {
+        final Map<String, Object> measurement = new HashMap<>(4);
+        measurement.put("@timestamp", System.currentTimeMillis());
+        final ListStatistics throughput = data.get(LsMetricStats.THROUGHPUT);
+        measurement.put("throughput_min", throughput.getMin());
+        measurement.put("throughput_max", throughput.getMax());
+        measurement.put("throughput_mean", Math.round(throughput.getMean()));
+        measurement.put(
+            "cpu_usage_mean_percent", Math.round(data.get(LsMetricStats.CPU_USAGE).getMean())
+        );
+        measurement.put("meta", meta);
+        return OBJECT_MAPPER.writeValueAsString(measurement);
+    }
+}

--- a/tools/benchmark-cli/src/test/java/org/logstash/benchmark/cli/LsMetricsMonitorTest.java
+++ b/tools/benchmark-cli/src/test/java/org/logstash/benchmark/cli/LsMetricsMonitorTest.java
@@ -6,10 +6,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.EnumMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.CoreMatchers;
@@ -17,7 +13,6 @@ import org.hamcrest.MatcherAssert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.logstash.benchmark.cli.ui.LsMetricStats;
-import org.openjdk.jmh.util.ListStatistics;
 import org.openjdk.jmh.util.Statistics;
 
 /**
@@ -34,17 +29,15 @@ public final class LsMetricsMonitorTest {
         http.stubFor(WireMock.get(WireMock.urlEqualTo(path)).willReturn(WireMock.okJson(
             metricsFixture()
         )));
-        final ExecutorService executor = Executors.newSingleThreadExecutor();
-        try {
-            final LsMetricsMonitor monitor =
-                new LsMetricsMonitor(String.format("http://127.0.0.1:%d/%s", http.port(), path));
-            final Future<EnumMap<LsMetricStats, ListStatistics>> future = executor.submit(monitor);
+        try (final LsMetricsMonitor.MonitorExecution monitor =
+                 new LsMetricsMonitor.MonitorExecution(
+                     String.format("http://127.0.0.1:%d/%s", http.port(), path),
+                     DataStore.NONE
+                 )
+        ) {
             TimeUnit.SECONDS.sleep(5L);
-            monitor.stop();
-            final Statistics stats = future.get().get(LsMetricStats.THROUGHPUT);
+            final Statistics stats = monitor.stopAndGet().get(LsMetricStats.THROUGHPUT);
             MatcherAssert.assertThat(stats.getMax(), CoreMatchers.is(21052.0D));
-        } finally {
-            executor.shutdownNow();
         }
     }
 
@@ -54,17 +47,15 @@ public final class LsMetricsMonitorTest {
         http.stubFor(WireMock.get(WireMock.urlEqualTo(path)).willReturn(WireMock.okJson(
             metricsFixture()
         )));
-        final ExecutorService executor = Executors.newSingleThreadExecutor();
-        try {
-            final LsMetricsMonitor monitor =
-                new LsMetricsMonitor(String.format("http://127.0.0.1:%d/%s", http.port(), path));
-            final Future<EnumMap<LsMetricStats, ListStatistics>> future = executor.submit(monitor);
+        try (final LsMetricsMonitor.MonitorExecution monitor =
+                 new LsMetricsMonitor.MonitorExecution(
+                     String.format("http://127.0.0.1:%d/%s", http.port(), path),
+                     DataStore.NONE
+                 )
+        ) {
             TimeUnit.SECONDS.sleep(5L);
-            monitor.stop();
-            final Statistics stats = future.get().get(LsMetricStats.CPU_USAGE);
+            final Statistics stats = monitor.stopAndGet().get(LsMetricStats.CPU_USAGE);
             MatcherAssert.assertThat(stats.getMax(), CoreMatchers.is(63.0D));
-        } finally {
-            executor.shutdownNow();
         }
     }
 

--- a/tools/benchmark-cli/src/test/java/org/logstash/benchmark/cli/MainEsStorageTest.java
+++ b/tools/benchmark-cli/src/test/java/org/logstash/benchmark/cli/MainEsStorageTest.java
@@ -1,0 +1,29 @@
+package org.logstash.benchmark.cli;
+
+import java.io.File;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.logstash.benchmark.cli.ui.UserInput;
+
+/**
+ * Tests for {@link Main}.
+ */
+public final class MainEsStorageTest {
+
+    @Rule
+    public final TemporaryFolder temp = new TemporaryFolder();
+    
+    /**
+     * @throws Exception On Failure
+     */
+    @Test
+    public void runsAgainstRelease() throws Exception {
+        final File pwd = temp.newFolder();
+        Main.main(
+            String.format("--%s=5.5.0", UserInput.DISTRIBUTION_VERSION_PARAM),
+            String.format("--workdir=%s", pwd.getAbsolutePath()),
+            String.format("--%s=%s", UserInput.ES_OUTPUT_PARAM, "http://127.0.0.1:9200/")
+        );
+    }
+}


### PR DESCRIPTION
For #7784 

Example measurement:


```json
      {
        "_index": "benchmarks",
        "_type": "measurement",
        "_id": "AV2F_J12UU4CBrYGZnqC",
        "_score": 1,
        "_source": {
          "@timestamp": 1501191511344,
          "throughput_mean": 39563,
          "throughput_max": 46750,
          "cpu_usage_mean_percent": 22,
          "throughput_min": 5829,
          "meta": {
            "version_type": "DISTRIBUTION",
            "os_version": "10.12.5",
            "os_name": "Mac OS X",
            "cpu_cores": 8,
            "test_name": "baseline",
            "version": "5.5.0",
            "host_name": "bb-elastic-mac.dev"
          }
      }
```