### PR TITLE
MINOR: Flatten Pipeline Worker Threads

### DIFF
--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -415,10 +415,11 @@ module LogStash; class Pipeline < BasePipeline
       end
 
       pipeline_workers.times do |t|
-        @worker_threads << Thread.new do
-          Util.set_thread_name("[#{pipeline_id}]>worker#{t}")
-          worker_loop(batch_size, batch_delay)
+        thread = Thread.new(batch_size, batch_delay, self) do |_b_size, _b_delay, _pipeline|
+          _pipeline.worker_loop(_b_size, _b_delay)
         end
+        thread.name="[#{pipeline_id}]>worker#{t}"
+        @worker_threads << thread
       end
 
       # inputs should be started last, after all workers


### PR DESCRIPTION
This makes the stack of a worker loop one level flatter and makes the pipeline worker thread naming actually work.

### Before

<img width="1536" alt="screen shot 2017-07-28 at 10 39 08" src="https://user-images.githubusercontent.com/6490959/28709586-31975338-7381-11e7-8aa5-91033e7ce0cd.png">

### After

<img width="1546" alt="screen shot 2017-07-28 at 10 40 04" src="https://user-images.githubusercontent.com/6490959/28709588-32a6b980-7381-11e7-8f79-aa93cfa92303.png">

