### PR TITLE
Remove closed DeadLetterQueueWriters from 'Factory'

### DIFF
--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -93,6 +93,13 @@ module LogStash; class BasePipeline
     end
   end
 
+  def close_dlq_writer
+    @dlq_writer.close
+    if settings.get_value("dead_letter_queue.enable")
+      DeadLetterQueueFactory.release(pipeline_id)
+    end
+  end
+
   def compile_lir
     sources_with_metadata = [
       SourceWithMetadata.new("str", "pipeline", 0, 0, self.config_str)
@@ -340,7 +347,7 @@ module LogStash; class Pipeline < BasePipeline
   def close
     @filter_queue_client.close
     @queue.close
-    @dlq_writer.close
+    close_dlq_writer
   end
 
   def transition_to_running

--- a/logstash-core/src/main/java/org/logstash/common/DeadLetterQueueFactory.java
+++ b/logstash-core/src/main/java/org/logstash/common/DeadLetterQueueFactory.java
@@ -56,13 +56,19 @@ public class DeadLetterQueueFactory {
      * @return The write manager for the specific id's dead-letter-queue context
      */
     public static DeadLetterQueueWriter getWriter(String id, String dlqPath, long maxQueueSize) {
-        return REGISTRY.computeIfAbsent(id, k -> {
-            try {
-                return new DeadLetterQueueWriter(Paths.get(dlqPath, k), MAX_SEGMENT_SIZE_BYTES, maxQueueSize);
-            } catch (IOException e) {
-                logger.error("unable to create dead letter queue writer", e);
-            }
-            return null;
-        });
+        return REGISTRY.computeIfAbsent(id, key -> newWriter(key, dlqPath, maxQueueSize));
+    }
+
+    public static DeadLetterQueueWriter release(String id) {
+        return REGISTRY.remove(id);
+    }
+
+    private static DeadLetterQueueWriter newWriter(final String id, final String dlqPath, final long maxQueueSize) {
+        try {
+            return new DeadLetterQueueWriter(Paths.get(dlqPath, id), MAX_SEGMENT_SIZE_BYTES, maxQueueSize);
+        } catch (IOException e) {
+            logger.error("unable to create dead letter queue writer", e);
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Fix bug where reloading a pipeline would close the DLQWriter, but
leave the closed version cached in the factory object, stopping
the reloaded pipeline from being able to write to the dead letter
queue.