### PR TITLE
6.0 & 6.x - Test Fix: Update test to properly reflect the Java Timestamp object.

### DIFF
--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -9,6 +9,8 @@ require "fileutils"
 require_relative "../support/helpers"
 require_relative "../support/matchers"
 
+java_import org.logstash.Timestamp
+
 describe LogStash::Agent do
   let(:agent_settings) { mock_settings({}) }
   let(:agent_args) { {} }
@@ -392,7 +394,7 @@ describe LogStash::Agent do
       it "sets the success reload timestamp" do
         snapshot = subject.metric.collector.snapshot_metric
         value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:last_success_timestamp].value
-        expect(value).to be_a(LogStash::Timestamp)
+        expect(value).to be_a(Timestamp)
       end
 
       it "does not set the last reload error" do
@@ -421,7 +423,7 @@ describe LogStash::Agent do
       it "sets the failure reload timestamp" do
         snapshot = subject.metric.collector.snapshot_metric
         value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:last_failure_timestamp].value
-        expect(value).to be_a(LogStash::Timestamp)
+        expect(value).to be_a(Timestamp)
       end
 
       it "sets the last reload error" do


### PR DESCRIPTION
Fixes #7843 
This needs to be merged to 6.0 and 6.x, a fix for master will come on a different PR.