### PR TITLE
MINOR: Cleanup multiple ObjectMappers being used

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ObjectMappers.java
+++ b/logstash-core/src/main/java/org/logstash/ObjectMappers.java
@@ -5,15 +5,15 @@ import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
 import com.fasterxml.jackson.dataformat.cbor.CBORGenerator;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 
-public class ObjectMappers {
-    public static final ObjectMapper JSON_MAPPER = new ObjectMapper();
-    public static final ObjectMapper CBOR_MAPPER = new ObjectMapper(new CBORFactory());
+public final class ObjectMappers {
 
-    static {
-        JSON_MAPPER.registerModule(new AfterburnerModule());
+    public static final ObjectMapper JSON_MAPPER = new ObjectMapper()
+        .registerModule(new AfterburnerModule());
 
-        CBORFactory cborf = (CBORFactory) CBOR_MAPPER.getFactory();
-        cborf.configure(CBORGenerator.Feature.WRITE_MINIMAL_INTS, false);
-        CBOR_MAPPER.registerModule(new AfterburnerModule());
+    public static final ObjectMapper CBOR_MAPPER = new ObjectMapper(
+        new CBORFactory().configure(CBORGenerator.Feature.WRITE_MINIMAL_INTS, false)
+    ).registerModule(new AfterburnerModule());
+
+    private ObjectMappers() {
     }
 }

--- a/logstash-core/src/main/java/org/logstash/StringInterpolation.java
+++ b/logstash-core/src/main/java/org/logstash/StringInterpolation.java
@@ -1,6 +1,5 @@
 package org.logstash;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -8,8 +7,6 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 
 public final class StringInterpolation {
-    
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private static final ThreadLocal<StringBuilder> STRING_BUILDER =
         new ThreadLocal<StringBuilder>() {
@@ -58,7 +55,7 @@ public final class StringInterpolation {
                     if (value instanceof List) {
                         builder.append(KeyNode.join((List) value, ","));
                     } else if (value instanceof Map) {
-                        builder.append(OBJECT_MAPPER.writeValueAsString(value));
+                        builder.append(ObjectMappers.JSON_MAPPER.writeValueAsString(value));
                     } else {
                         builder.append(value.toString());
                     }

--- a/logstash-core/src/main/java/org/logstash/Util.java
+++ b/logstash-core/src/main/java/org/logstash/Util.java
@@ -1,6 +1,5 @@
 package org.logstash;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -21,9 +20,7 @@ public class Util {
         json.append("\"float\": 42.42, ");
         json.append("\"array\": [\"bar\",\"baz\"], ");
         json.append("\"hash\": {\"string\":\"quux\"} }");
-
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(json.toString(), Object.class);
+        return ObjectMappers.JSON_MAPPER.readValue(json.toString(), Object.class);
     }
 
     public static Map<String, Object> getMapFixtureHandcrafted() {

--- a/logstash-core/src/main/java/org/logstash/config/ir/PluginDefinition.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/PluginDefinition.java
@@ -1,24 +1,23 @@
 package org.logstash.config.ir;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.logstash.common.SourceWithMetadata;
-
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import org.logstash.ObjectMappers;
+import org.logstash.common.SourceWithMetadata;
 
 /**
  * Created by andrewvc on 9/20/16.
  */
 public class PluginDefinition implements SourceComponent, HashableWithSource {
-    private static ObjectMapper om = new ObjectMapper();
 
     @Override
     public String hashSource() {
         try {
-            String serializedArgs = om.writeValueAsString(this.getArguments());
+            String serializedArgs =
+                ObjectMappers.JSON_MAPPER.writeValueAsString(this.getArguments());
             return this.getClass().getCanonicalName() + "|" +
                     this.getType().toString() + "|" +
                     this.getName() + "|" +

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/PluginVertex.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/PluginVertex.java
@@ -1,13 +1,11 @@
 package org.logstash.config.ir.graph;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.logstash.common.Util;
-import org.logstash.config.ir.SourceComponent;
-import org.logstash.config.ir.PluginDefinition;
+import org.logstash.ObjectMappers;
 import org.logstash.common.SourceWithMetadata;
-
-import java.util.UUID;
+import org.logstash.common.Util;
+import org.logstash.config.ir.PluginDefinition;
+import org.logstash.config.ir.SourceComponent;
 
 /**
  * Created by andrewvc on 9/15/16.
@@ -38,13 +36,13 @@ public class PluginVertex extends Vertex {
 
     @Override
     public String calculateIndividualHashSource() {
-        ObjectMapper objectMapper = new ObjectMapper();
         try {
             return Util.digest(this.getClass().getCanonicalName() + "|" +
                     (this.getExplicitId() != null ? this.getExplicitId() : "NOID") + "|" +
                     this.pluginDefinition.getName() + "|" +
                     this.pluginDefinition.getType().toString() + "|" +
-                    objectMapper.writeValueAsString(this.pluginDefinition.getArguments()));
+                    ObjectMappers.JSON_MAPPER
+                        .writeValueAsString(this.pluginDefinition.getArguments()));
         } catch (JsonProcessingException e) {
             // This is basically impossible given the constrained values in the plugin definition
             throw new RuntimeException(e);

--- a/logstash-core/src/test/java/org/logstash/log/CustomLogEventTests.java
+++ b/logstash-core/src/test/java/org/logstash/log/CustomLogEventTests.java
@@ -19,24 +19,22 @@
 
 package org.logstash.log;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.junit.LoggerContextRule;
 import org.apache.logging.log4j.test.appender.ListAppender;
 import org.junit.ClassRule;
 import org.junit.Test;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import org.logstash.ObjectMappers;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
 
 public class CustomLogEventTests {
-    private static final ObjectMapper mapper = new ObjectMapper();
     private static final String CONFIG = "log4j2-test1.xml";
     private ListAppender appender;
 
@@ -74,7 +72,8 @@ public class CustomLogEventTests {
 
         List<String> messages = appender.getMessages();
 
-        Map<String, Object> firstMessage = mapper.readValue(messages.get(0), Map.class);
+        Map<String, Object> firstMessage =
+            ObjectMappers.JSON_MAPPER.readValue(messages.get(0), Map.class);
 
         assertEquals(5, firstMessage.size());
         assertEquals("INFO", firstMessage.get("level"));
@@ -82,7 +81,8 @@ public class CustomLogEventTests {
         assertNotNull(firstMessage.get("thread"));
         assertEquals(Collections.singletonMap("message", "simple message"), firstMessage.get("logEvent"));
 
-        Map<String, Object> secondMessage = mapper.readValue(messages.get(1), Map.class);
+        Map<String, Object> secondMessage =
+            ObjectMappers.JSON_MAPPER.readValue(messages.get(1), Map.class);
 
         assertEquals(5, secondMessage.size());
         assertEquals("WARN", secondMessage.get("level"));
@@ -93,19 +93,22 @@ public class CustomLogEventTests {
         logEvent.put("foo", "bar");
         assertEquals(logEvent, secondMessage.get("logEvent"));
 
-        Map<String, Object> thirdMessage = mapper.readValue(messages.get(2), Map.class);
+        Map<String, Object> thirdMessage =
+            ObjectMappers.JSON_MAPPER.readValue(messages.get(2), Map.class);
         assertEquals(5, thirdMessage.size());
         logEvent = Collections.singletonMap("message", "my name is: foo");
         assertEquals(logEvent, thirdMessage.get("logEvent"));
 
-        Map<String, Object> fourthMessage = mapper.readValue(messages.get(3), Map.class);
+        Map<String, Object> fourthMessage =
+            ObjectMappers.JSON_MAPPER.readValue(messages.get(3), Map.class);
         assertEquals(5, fourthMessage.size());
         logEvent = new HashMap<>();
         logEvent.put("message", "here is a map: {}");
         logEvent.put("2", 5);
         assertEquals(logEvent, fourthMessage.get("logEvent"));
 
-        Map<String, Object> fifthMessage = mapper.readValue(messages.get(4), Map.class);
+        Map<String, Object> fifthMessage =
+            ObjectMappers.JSON_MAPPER.readValue(messages.get(4), Map.class);
         assertEquals(5, fifthMessage.size());
         logEvent = Collections.singletonMap("message", "ignored params 4");
         assertEquals(logEvent, fifthMessage.get("logEvent"));


### PR DESCRIPTION
Motivated by finding inline `ObjectMapper` instantiation in the LIR code :)

* Removed all redundant `ObjectMapper` instances, much better to only have one global one from the caching perspective
   * Also no reason not to have `AfterBurner` active for all JSON spots :)
* Also cleaned up the instantiation of the mappers a little
   * Much cleaner to read/maintain if you don't have to jump to the `static` block