### PR TITLE
Just for illustrative purposes: Use Charsequence Keys in Lookups

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Accessors.java
+++ b/logstash-core/src/main/java/org/logstash/Accessors.java
@@ -4,202 +4,157 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class Accessors {
+public final class Accessors {
 
-    private Map<String, Object> data;
-    protected Map<String, Object> lut;
-
-    public Accessors(Map<String, Object> data) {
-        this.data = data;
-        this.lut = new HashMap<>(); // reference -> target LUT
+    private Accessors() {
+        //Utility Class
     }
 
-    public Object get(String reference) {
-        FieldReference field = PathCache.cache(reference);
-        Object target = findTarget(field);
-        return (target == null) ? null : fetch(target, field.getKey());
-    }
-
-    public Object set(String reference, Object value) {
+    public static Object get(final Map<String, Object> data, final String reference) {
         final FieldReference field = PathCache.cache(reference);
-        final Object target = findCreateTarget(field);
-        final String key = field.getKey();
+        final Object target = findParent(data, field);
+        return target == null ? null : fetch(target, field.getKey());
+    }
+
+    public static Object set(final Map<String, Object> data, final String reference,
+        final Object value) {
+        final FieldReference field = PathCache.cache(reference);
+        return setChild(findCreateTarget(data, field), field.getKey(), value);
+    }
+
+    public static Object del(final Map<String, Object> data, final String reference) {
+        final FieldReference field = PathCache.cache(reference);
+        final Object target = findParent(data, field);
         if (target instanceof Map) {
-            ((Map<String, Object>) target).put(key, value);
-        } else if (target instanceof List) {
-            int i;
-            try {
-                i = Integer.parseInt(key);
-            } catch (NumberFormatException e) {
-                return null;
-            }
-            int size = ((List<Object>) target).size();
-            if (i >= size) {
-                // grow array by adding trailing null items
-                // this strategy reflects legacy Ruby impl behaviour and is backed by specs
-                // TODO: (colin) this is potentially dangerous, and could produce OOM using arbitrary big numbers
-                // TODO: (colin) should be guard against this?
-                for (int j = size; j < i; j++) {
-                    ((List<Object>) target).add(null);
-                }
-                ((List<Object>) target).add(value);
-            } else {
-                int offset = listIndex(i, ((List) target).size());
-                ((List<Object>) target).set(offset, value);
-            }
+            return ((Map<String, Object>) target).remove(field.getKey());
         } else {
-            throw newCollectionException(target);
+            return target == null ? null : delFromList((List<Object>) target, field.getKey());
         }
-        return value;
     }
 
-    public Object del(String reference) {
-        FieldReference field = PathCache.cache(reference);
-        Object target = findTarget(field);
-        if (target != null) {
-            if (target instanceof Map) {
-                return ((Map<String, Object>) target).remove(field.getKey());
-            } else if (target instanceof List) {
-                try {
-                    int i = Integer.parseInt(field.getKey());
-                    int offset = listIndex(i, ((List) target).size());
-                    return ((List)target).remove(offset);
-                } catch (IndexOutOfBoundsException|NumberFormatException e) {
-                    return null;
-                }
-            } else {
-                throw newCollectionException(target);
-            }
-        }
-        return null;
-    }
-
-    public boolean includes(String reference) {
+    public static boolean includes(final Map<String, Object> data, final String reference) {
         final FieldReference field = PathCache.cache(reference);
-        final Object target = findTarget(field);
+        final Object target = findParent(data, field);
         final String key = field.getKey();
         return target instanceof Map && ((Map<String, Object>) target).containsKey(key) ||
             target instanceof List && foundInList(key, (List<Object>) target);
     }
 
-    private static boolean foundInList(final String key, final List<Object> target) {
+    private static Object delFromList(final List<Object> list, final String key) {
         try {
-            return foundInList(target, Integer.parseInt(key));
-        } catch (NumberFormatException e) {
-            return false;
+            return list.remove(listIndex(key, list.size()));
+        } catch (IndexOutOfBoundsException | NumberFormatException e) {
+            return null;
         }
     }
 
-    private Object findTarget(FieldReference field) {
-        final Object target = this.lut.get(field.getReference());
-        return target != null ? target : cacheTarget(field);
+    private static Object setOnList(final String key, final Object value, final List<Object> list) {
+        final int index;
+        try {
+            index = Integer.parseInt(key);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+        final int size = list.size();
+        if (index >= size) {
+            appendAtIndex(list, value, index, size);
+        } else {
+            list.set(listIndex(index, size), value);
+        }
+        return value;
     }
 
-    private Object cacheTarget(final FieldReference field) {
-        Object target = this.data;
+    private static void appendAtIndex(final List<Object> list, final Object value, final int index,
+        final int size) {
+        // grow array by adding trailing null items
+        // this strategy reflects legacy Ruby impl behaviour and is backed by specs
+        // TODO: (colin) this is potentially dangerous, and could produce OOM using arbitrary big numbers
+        // TODO: (colin) should be guard against this?
+        for (int i = size; i < index; i++) {
+            list.add(null);
+        }
+        list.add(value);
+    }
+
+    private static Object findParent(final Map<String, Object> data, final FieldReference field) {
+        Object target = data;
         for (final String key : field.getPath()) {
             target = fetch(target, key);
-            if (!isCollection(target)) {
+            if (!(target instanceof Map || target instanceof List)) {
                 return null;
             }
         }
-        this.lut.put(field.getReference(), target);
         return target;
     }
 
-    private Object findCreateTarget(FieldReference field) {
-        Object target;
-
-        // flush the @lut to prevent stale cached fieldref which may point to an old target
-        // which was overwritten with a new value. for example, if "[a][b]" is cached and we
-        // set a new value for "[a]" then reading again "[a][b]" would point in a stale target.
-        // flushing the complete @lut is suboptimal, but a hierarchical lut would be required
-        // to be able to invalidate fieldrefs from a common root.
-        // see https://github.com/elastic/logstash/pull/5132
-        this.lut.clear();
-
-        target = this.data;
-        for (String key : field.getPath()) {
-            Object result = fetch(target, key);
-            if (result == null) {
-                result = new HashMap<String, Object>();
-                if (target instanceof Map) {
-                    ((Map<String, Object>)target).put(key, result);
-                } else if (target instanceof List) {
-                    try {
-                        int i = Integer.parseInt(key);
-                        // TODO: what about index out of bound?
-                        ((List<Object>)target).set(i, result);
-                    } catch (NumberFormatException e) {
-                        continue;
-                    }
-                } else if (target != null) {
-                    throw newCollectionException(target);
+    private static Object findCreateTarget(final Map<String, Object> data,
+        final FieldReference field) {
+        Object target = data;
+        boolean create = false;
+        for (final String key : field.getPath()) {
+            Object result;
+            if (create) {
+                result = createChild((Map<String, Object>) target, key);
+            } else {
+                result = fetch(target, key);
+                create = result == null;
+                if (create) {
+                    result = new HashMap<String, Object>();
+                    setChild(target, key, result);
                 }
             }
             target = result;
         }
-
-        this.lut.put(field.getReference(), target);
-
         return target;
     }
 
-    private static boolean foundInList(List<Object> target, int index) {
-        try {
-            int offset = listIndex(index, target.size());
-            return target.get(offset) != null;
-        } catch (IndexOutOfBoundsException e) {
-            return false;
+    private static Object setChild(final Object target, final String key, final Object value) {
+        if (target instanceof Map) {
+            ((Map<String, Object>) target).put(key, value);
+            return value;
+        } else {
+            return setOnList(key, value, (List<Object>) target);
         }
+    }
 
+    private static Object createChild(final Map<String, Object> target, final String key) {
+        final Object result = new HashMap<String, Object>();
+        target.put(key, result);
+        return result;
     }
 
     private static Object fetch(Object target, String key) {
-        if (target instanceof Map) {
-            Object result = ((Map<String, Object>) target).get(key);
-            return result;
-        } else if (target instanceof List) {
-            try {
-                int offset = listIndex(Integer.parseInt(key), ((List) target).size());
-                return ((List<Object>) target).get(offset);
-            } catch (IndexOutOfBoundsException|NumberFormatException e) {
-                return null;
-            }
-        } else if (target == null) {
+        return target instanceof Map 
+            ? ((Map<String, Object>) target).get(key) : fetchFromList((List<Object>) target, key);
+    }
+
+    private static Object fetchFromList(final List<Object> list, final String key) {
+        try {
+            return list.get(listIndex(key, list.size()));
+        } catch (IndexOutOfBoundsException | NumberFormatException e) {
             return null;
-        } else {
-            throw newCollectionException(target);
         }
     }
 
-    private static boolean isCollection(Object target) {
-        if (target == null) {
-            return false;
-        }
-        return (target instanceof Map || target instanceof List);
+    private static boolean foundInList(final String key, final List<Object> target) {
+        return fetchFromList(target, key) != null;
     }
 
-    private static ClassCastException newCollectionException(Object target) {
-        return new ClassCastException("expecting List or Map, found "  + target.getClass());
-    }
-
-    /* 
+    /**
      * Returns a positive integer offset for a list of known size.
-     *
-     * @param i if positive, and offset from the start of the list. If negative, the offset from the end of the list, where -1 means the last element.
      * @param size the size of the list.
      * @return the positive integer offset for the list given by index i.
      */
     public static int listIndex(int i, int size) {
-        if (i >= size || i < -size) {
-            throw new IndexOutOfBoundsException("Index " + i + " is out of bounds for a list with size " + size);
-        }
+        return i < 0 ? size + i : i;
+    }
 
-        if (i < 0) { // Offset from the end of the array.
-            return size + i;
-        } else {
-            return i;
-        }
+    /**
+     * Returns a positive integer offset for a list of known size.
+     * @param size the size of the list.
+     * @return the positive integer offset for the list given by index i.
+     */
+    private static int listIndex(final String key, final int size) {
+        return listIndex(Integer.parseInt(key), size);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/Accessors.java
+++ b/logstash-core/src/main/java/org/logstash/Accessors.java
@@ -10,19 +10,19 @@ public final class Accessors {
         //Utility Class
     }
 
-    public static Object get(final Map<String, Object> data, final String reference) {
+    public static Object get(final Map<String, Object> data, final CharSequence reference) {
         final FieldReference field = PathCache.cache(reference);
         final Object target = findParent(data, field);
         return target == null ? null : fetch(target, field.getKey());
     }
 
-    public static Object set(final Map<String, Object> data, final String reference,
+    public static Object set(final Map<String, Object> data, final CharSequence reference,
         final Object value) {
         final FieldReference field = PathCache.cache(reference);
         return setChild(findCreateTarget(data, field), field.getKey(), value);
     }
 
-    public static Object del(final Map<String, Object> data, final String reference) {
+    public static Object del(final Map<String, Object> data, final CharSequence reference) {
         final FieldReference field = PathCache.cache(reference);
         final Object target = findParent(data, field);
         if (target instanceof Map) {
@@ -32,7 +32,7 @@ public final class Accessors {
         }
     }
 
-    public static boolean includes(final Map<String, Object> data, final String reference) {
+    public static boolean includes(final Map<String, Object> data, final CharSequence reference) {
         final FieldReference field = PathCache.cache(reference);
         final Object target = findParent(data, field);
         final String key = field.getKey();

--- a/logstash-core/src/main/java/org/logstash/FieldReference.java
+++ b/logstash-core/src/main/java/org/logstash/FieldReference.java
@@ -3,23 +3,21 @@ package org.logstash;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
-// TODO: implement thread-safe path cache singleton to avoid parsing
 
-public class FieldReference {
+public final class FieldReference {
 
     private static final Pattern SPLIT_PATTERN = Pattern.compile("[\\[\\]]");
+    private static final String[] EMPTY_STRING_ARRAY = new String[0];
 
-    private List<String> path;
-    private String key;
-    private String reference;
+    private final String[] path;
+    private final String key;
 
-    public FieldReference(List<String> path, String key, String reference) {
-        this.path = path;
+    private FieldReference(final List<String> path, final String key) {
+        this.path = path.toArray(EMPTY_STRING_ARRAY);
         this.key = key;
-        this.reference = reference;
     }
 
-    public List<String> getPath() {
+    public String[] getPath() {
         return path;
     }
 
@@ -27,19 +25,14 @@ public class FieldReference {
         return key;
     }
 
-    public String getReference() {
-        return reference;
-    }
-
-    public static FieldReference parse(String reference) {
+    public static FieldReference parse(final CharSequence reference) {
         final String[] parts = SPLIT_PATTERN.split(reference);
-        List<String> path = new ArrayList<>(parts.length);
+        final List<String> path = new ArrayList<>(parts.length);
         for (final String part : parts) {
             if (!part.isEmpty()) {
                 path.add(part);
             }
         }
-        String key = path.remove(path.size() - 1);
-        return new FieldReference(path, key, reference);
+        return new FieldReference(path, path.remove(path.size() - 1));
     }
 }

--- a/logstash-core/src/main/java/org/logstash/PathCache.java
+++ b/logstash-core/src/main/java/org/logstash/PathCache.java
@@ -1,25 +1,31 @@
 package org.logstash;
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public final class PathCache {
 
-    private static final ConcurrentHashMap<String, FieldReference> cache = new ConcurrentHashMap<>();
+    private static final Map<CharSequence, FieldReference> cache =
+        new ConcurrentHashMap<>(10, 0.2F, 1);
 
     private static final FieldReference timestamp = cache(Event.TIMESTAMP);
 
-    private static final String BRACKETS_TIMESTAMP = "[" + Event.TIMESTAMP + "]";
+    private static final CharSequence BRACKETS_TIMESTAMP =
+        new StringBuilder().append('[').append(Event.TIMESTAMP).append(']').toString();
 
     static {
         // inject @timestamp
         cache.put(BRACKETS_TIMESTAMP, timestamp);
     }
 
-    public static boolean isTimestamp(String reference) {
-        return cache(reference) == timestamp;
+    private PathCache() {
     }
 
-    public static FieldReference cache(String reference) {
+    public static boolean isTimestamp(final CharSequence reference) {
+        return Event.compareString(Event.TIMESTAMP, reference);
+    }
+
+    public static FieldReference cache(final CharSequence reference) {
         // atomicity between the get and put is not important
         final FieldReference result = cache.get(reference);
         if (result != null) {
@@ -28,7 +34,7 @@ public final class PathCache {
         return parseToCache(reference);
     }
     
-    private static FieldReference parseToCache(final String reference) {
+    private static FieldReference parseToCache(final CharSequence reference) {
         final FieldReference result = FieldReference.parse(reference);
         cache.put(reference, result);
         return result;

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -96,15 +96,14 @@ public class JrubyEventExtLibrary implements Library {
         @JRubyMethod(name = "get", required = 1)
         public IRubyObject ruby_get_field(ThreadContext context, RubyString reference)
         {
-            Object value = this.event.getUnconvertedField(reference.asJavaString());
+            Object value = this.event.getUnconvertedField(reference.getByteList());
             return Rubyfier.deep(context.runtime, value);
         }
 
         @JRubyMethod(name = "set", required = 2)
         public IRubyObject ruby_set_field(ThreadContext context, RubyString reference, IRubyObject value)
         {
-            String r = reference.asJavaString();
-
+            final CharSequence r = reference.getByteList();
             if (PathCache.isTimestamp(r)) {
                 if (!(value instanceof JrubyTimestampExtLibrary.RubyTimestamp)) {
                     throw context.runtime.newTypeError("wrong argument type " + value.getMetaClass() + " (expected LogStash::Timestamp)");
@@ -139,13 +138,13 @@ public class JrubyEventExtLibrary implements Library {
         @JRubyMethod(name = "include?", required = 1)
         public IRubyObject ruby_includes(ThreadContext context, RubyString reference)
         {
-            return RubyBoolean.newBoolean(context.runtime, this.event.includes(reference.asJavaString()));
+            return RubyBoolean.newBoolean(context.runtime, this.event.includes(reference.getByteList()));
         }
 
         @JRubyMethod(name = "remove", required = 1)
         public IRubyObject ruby_remove(ThreadContext context, RubyString reference)
         {
-            return Rubyfier.deep(context.runtime, this.event.remove(reference.asJavaString()));
+            return Rubyfier.deep(context.runtime, this.event.remove(reference.getByteList()));
         }
 
         @JRubyMethod(name = "clone")

--- a/logstash-core/src/test/java/org/logstash/AccessorsTest.java
+++ b/logstash-core/src/test/java/org/logstash/AccessorsTest.java
@@ -4,13 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.theories.DataPoint;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -19,27 +13,12 @@ import static org.junit.Assert.assertTrue;
 
 public class AccessorsTest {
 
-    public class TestableAccessors extends Accessors {
-
-        public TestableAccessors(Map<String, Object> data) {
-            super(data);
-        }
-
-        public Object lutGet(String reference) {
-            return this.lut.get(reference);
-        }
-    }
-
     @Test
     public void testBareGet() throws Exception {
         Map<String, Object> data = new HashMap<>();
         data.put("foo", "bar");
         String reference = "foo";
-
-        TestableAccessors accessors = new TestableAccessors(data);
-        assertNull(accessors.lutGet(reference));
-        assertEquals("bar", accessors.get(reference));
-        assertEquals(data, accessors.lutGet(reference));
+        assertEquals("bar", Accessors.get(data, reference));
     }
 
     @Test
@@ -47,11 +26,7 @@ public class AccessorsTest {
         Map<String, Object> data = new HashMap<>();
         data.put("foo", "bar");
         String reference = "baz";
-
-        TestableAccessors accessors = new TestableAccessors(data);
-        assertNull(accessors.lutGet(reference));
-        assertNull(accessors.get(reference));
-        assertEquals(data, accessors.lutGet(reference));
+        assertNull(Accessors.get(data, reference));
     }
 
     @Test
@@ -60,10 +35,8 @@ public class AccessorsTest {
         data.put("foo", "bar");
         String reference = "[foo]";
 
-        TestableAccessors accessors = new TestableAccessors(data);
-        assertNull(accessors.lutGet(reference));
-        assertEquals("bar", accessors.get(reference));
-        assertEquals(data, accessors.lutGet(reference));
+        
+        assertEquals("bar", Accessors.get(data, reference));
     }
 
     @Test
@@ -74,11 +47,7 @@ public class AccessorsTest {
         inner.put("bar", "baz");
 
         String reference = "[foo][bar]";
-
-        TestableAccessors accessors = new TestableAccessors(data);
-        assertNull(accessors.lutGet(reference));
-        assertEquals("baz", accessors.get(reference));
-        assertEquals(inner, accessors.lutGet(reference));
+        assertEquals("baz", Accessors.get(data, reference));
     }
 
     @Test
@@ -89,11 +58,7 @@ public class AccessorsTest {
         inner.put("bar", "baz");
 
         String reference = "[foo][foo]";
-
-        TestableAccessors accessors = new TestableAccessors(data);
-        assertNull(accessors.lutGet(reference));
-        assertNull(accessors.get(reference));
-        assertEquals(inner, accessors.lutGet(reference));
+        assertNull(Accessors.get(data, reference));
     }
 
     @Test
@@ -105,10 +70,7 @@ public class AccessorsTest {
 
         String reference = "[foo][0]";
 
-        TestableAccessors accessors = new TestableAccessors(data);
-        assertNull(accessors.lutGet(reference));
-        assertEquals("bar", accessors.get(reference));
-        assertEquals(inner, accessors.lutGet(reference));
+        assertEquals("bar", Accessors.get(data, reference));
     }
 
     @Test
@@ -120,10 +82,7 @@ public class AccessorsTest {
 
         String reference = "[foo][1]";
 
-        TestableAccessors accessors = new TestableAccessors(data);
-        assertNull(accessors.lutGet(reference));
-        assertNull(accessors.get(reference));
-        assertEquals(inner, accessors.lutGet(reference));
+        assertNull(Accessors.get(data, reference));
     }
     /*
      * Check if accessors are able to recovery from
@@ -141,25 +100,18 @@ public class AccessorsTest {
 
         String reference = "[map1][IdNonNumeric]";
 
-        TestableAccessors accessors = new TestableAccessors(data);
-        assertNull(accessors.lutGet(reference));
-        assertNull(accessors.get(reference));
-        assertNull(accessors.set(reference, "obj3"));
-        assertEquals(inner, accessors.lutGet(reference));
-        assertFalse(accessors.includes(reference));
-        assertNull(accessors.del(reference));
+        assertNull(Accessors.get(data, reference));
+        assertNull(Accessors.set(data, reference, "obj3"));
+        assertFalse(Accessors.includes(data, reference));
+        assertNull(Accessors.del(data, reference));
     }
 
     @Test
     public void testBarePut() throws Exception {
         Map<String, Object> data = new HashMap<>();
         String reference = "foo";
-
-        TestableAccessors accessors = new TestableAccessors(data);
-        assertNull(accessors.lutGet(reference));
-        assertEquals("bar", accessors.set(reference, "bar"));
-        assertEquals(data, accessors.lutGet(reference));
-        assertEquals("bar", accessors.get(reference));
+        assertEquals("bar", Accessors.set(data, reference, "bar"));
+        assertEquals("bar", Accessors.get(data, reference));
     }
 
     @Test
@@ -167,11 +119,8 @@ public class AccessorsTest {
         Map<String, Object> data = new HashMap<>();
         String reference = "[foo]";
 
-        TestableAccessors accessors = new TestableAccessors(data);
-        assertNull(accessors.lutGet(reference));
-        assertEquals("bar", accessors.set(reference, "bar"));
-        assertEquals(data, accessors.lutGet(reference));
-        assertEquals("bar", accessors.get(reference));
+        assertEquals("bar", Accessors.set(data, reference, "bar"));
+        assertEquals("bar", Accessors.get(data, reference));
     }
 
     @Test
@@ -180,11 +129,8 @@ public class AccessorsTest {
 
         String reference = "[foo][bar]";
 
-        TestableAccessors accessors = new TestableAccessors(data);
-        assertNull(accessors.lutGet(reference));
-        assertEquals("baz", accessors.set(reference, "baz"));
-        assertEquals(accessors.lutGet(reference), data.get("foo"));
-        assertEquals("baz", accessors.get(reference));
+        assertEquals("baz", Accessors.set(data, reference, "baz"));
+        assertEquals("baz", Accessors.get(data, reference));
     }
 
     @Test
@@ -194,44 +140,40 @@ public class AccessorsTest {
         data.put("foo", inner);
         inner.add("bar");
         data.put("bar", "baz");
-        TestableAccessors accessors = new TestableAccessors(data);
 
-        assertEquals("bar", accessors.del("[foo][0]"));
-        assertNull(accessors.del("[foo][0]"));
-        assertEquals(new ArrayList<>(), accessors.get("[foo]"));
-        assertEquals("baz", accessors.del("[bar]"));
-        assertNull(accessors.get("[bar]"));
+        assertEquals("bar", Accessors.del(data, "[foo][0]"));
+        assertNull(Accessors.del(data, "[foo][0]"));
+        assertEquals(new ArrayList<>(), Accessors.get(data,"[foo]"));
+        assertEquals("baz", Accessors.del(data, "[bar]"));
+        assertNull(Accessors.get(data, "[bar]"));
     }
 
     @Test
     public void testNilInclude() throws Exception {
         Map<String, Object> data = new HashMap<>();
         data.put("nilfield", null);
-        TestableAccessors accessors = new TestableAccessors(data);
-        assertTrue(accessors.includes("nilfield"));
+        assertTrue(Accessors.includes(data, "nilfield"));
     }
 
     @Test
     public void testInvalidPath() throws Exception {
         Map<String, Object> data = new HashMap<>();
-        Accessors accessors = new Accessors(data);
 
-        assertEquals(1, accessors.set("[foo]", 1));
-        assertNull(accessors.get("[foo][bar]"));
+        assertEquals(1, Accessors.set(data, "[foo]", 1));
+        assertNull(Accessors.get(data, "[foo][bar]"));
     }
 
     @Test
     public void testStaleTargetCache() throws Exception {
         Map<String, Object> data = new HashMap<>();
 
-        Accessors accessors = new Accessors(data);
-        assertNull(accessors.get("[foo][bar]"));
-        assertEquals("baz", accessors.set("[foo][bar]", "baz"));
-        assertEquals("baz", accessors.get("[foo][bar]"));
+        assertNull(Accessors.get(data,"[foo][bar]"));
+        assertEquals("baz", Accessors.set(data,"[foo][bar]", "baz"));
+        assertEquals("baz", Accessors.get(data, "[foo][bar]"));
 
-        assertEquals("boom", accessors.set("[foo]", "boom"));
-        assertNull(accessors.get("[foo][bar]"));
-        assertEquals("boom", accessors.get("[foo]"));
+        assertEquals("boom", Accessors.set(data, "[foo]", "boom"));
+        assertNull(Accessors.get(data, "[foo][bar]"));
+        assertEquals("boom", Accessors.get(data,"[foo]"));
     }
 
     @Test
@@ -243,28 +185,4 @@ public class AccessorsTest {
         assertEquals(1, Accessors.listIndex(-9, 10));
         assertEquals(0, Accessors.listIndex(-10, 10));
     }
-
-    @RunWith(Theories.class)
-    public static class TestListIndexFailureCases {
-      private static final int size = 10;
-
-      @DataPoint
-      public static final int tooLarge = size;
-
-      @DataPoint
-      public static final int tooLarge1 = size+1;
-
-      @DataPoint
-      public static final int tooLargeNegative = -size - 1;
-
-      @Rule
-      public ExpectedException exception = ExpectedException.none();
-
-      @Theory
-      public void testListIndexOutOfBounds(int i) {
-        exception.expect(IndexOutOfBoundsException.class);
-        Accessors.listIndex(i, size);
-      }
-    }
-
 }

--- a/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
+++ b/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
@@ -9,28 +9,28 @@ public class FieldReferenceTest {
     @Test
     public void testParseSingleBareField() throws Exception {
         FieldReference f = FieldReference.parse("foo");
-        assertTrue(f.getPath().isEmpty());
+        assertEquals(0, f.getPath().length);
         assertEquals(f.getKey(), "foo");
     }
 
     @Test
     public void testParseSingleFieldPath() throws Exception {
         FieldReference f = FieldReference.parse("[foo]");
-        assertTrue(f.getPath().isEmpty());
+        assertEquals(0, f.getPath().length);
         assertEquals(f.getKey(), "foo");
     }
 
     @Test
     public void testParse2FieldsPath() throws Exception {
         FieldReference f = FieldReference.parse("[foo][bar]");
-        assertArrayEquals(f.getPath().toArray(), new String[]{"foo"});
+        assertArrayEquals(f.getPath(), new String[]{"foo"});
         assertEquals(f.getKey(), "bar");
     }
 
     @Test
     public void testParse3FieldsPath() throws Exception {
         FieldReference f = FieldReference.parse("[foo][bar]]baz]");
-        assertArrayEquals(f.getPath().toArray(), new String[]{"foo", "bar"});
+        assertArrayEquals(f.getPath(), new String[]{"foo", "bar"});
         assertEquals(f.getKey(), "baz");
     }
 }


### PR DESCRIPTION
Leveraging #7839 to get 0 GC lookups on `Event` fields

Not really work in progress code wise, it passes all tests just fine.