### PR TITLE
PERFORMANCE: Correctly Size PathCache's Backing Map

### DIFF
--- a/logstash-core/src/main/java/org/logstash/PathCache.java
+++ b/logstash-core/src/main/java/org/logstash/PathCache.java
@@ -1,10 +1,12 @@
 package org.logstash;
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public final class PathCache {
 
-    private static final ConcurrentHashMap<String, FieldReference> cache = new ConcurrentHashMap<>();
+    private static final Map<String, FieldReference> cache =
+        new ConcurrentHashMap<>(64, 0.2F, 1);
 
     private static final FieldReference timestamp = cache(Event.TIMESTAMP);
 


### PR DESCRIPTION
Kind of a trivial improvement extracted from #7847.

This map is basically never updated after a certain point. The default concurrency level of `16` only wastes memory and increases the number of cache misses (CPU cache) relative to a smaller number.

=> Concurrency level 1 makes a lot more sense here
=> Use some of the memory savings to turn down the load factor 
=> Set a default initial size that is more reasonable, `10` is guaranteed too small just from the default fields we have at load factor `0.2`

... in `master` this isn't causing a visible throughput increase, in #7847 (much faster lookup implementation) it seems visible though, but probably easier to understand the change in isolation.