### PR TITLE
PERFORMANCE: Move null guard out of Javafier.deep

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -136,7 +136,8 @@ public final class Event implements Cloneable, Queueable {
     }
 
     public Object getField(String reference) {
-        return Javafier.deep(getUnconvertedField(reference));
+        final Object unconverted = getUnconvertedField(reference);
+        return unconverted == null ? null : Javafier.deep(unconverted);
     }
 
     public Object getUnconvertedField(String reference) {
@@ -330,18 +331,18 @@ public final class Event implements Cloneable, Queueable {
     }
 
     public void tag(final String tag) {
-        final Object tags = Javafier.deep(accessors.get("tags"));
+        final Object tags = accessors.get("tags");
         // short circuit the null case where we know we won't need deduplication step below at the end
         if (tags == null) {
             initTag(tag);
         } else {
-            existingTag(tags, tag);
+            existingTag(Javafier.deep(tags), tag);
         }
     }
 
     /**
      * Branch of {@link Event#tag(String)} that handles adding the first tag to this event.
-     * @param tag
+     * @param tag Tag to add
      */
     private void initTag(final String tag) {
         final ConvertedList list = new ConvertedList(1);

--- a/logstash-core/src/main/java/org/logstash/Javafier.java
+++ b/logstash-core/src/main/java/org/logstash/Javafier.java
@@ -15,9 +15,6 @@ public class Javafier {
     private Javafier(){}
 
     public static Object deep(Object o) {
-        if(o == null) {
-            return null;
-        }
         if (o instanceof BiValue) {
             return ((BiValue)o).javaValue();
         } else if(o instanceof ConvertedMap) {
@@ -25,12 +22,24 @@ public class Javafier {
         }  else if(o instanceof ConvertedList) {
             return ((ConvertedList) o).unconvert();
         } else {
-            try {
-                return BiValues.newBiValue(o).javaValue();
-            } catch (IllegalArgumentException e) {
-                Class cls = o.getClass();
-                throw new IllegalArgumentException(String.format(ERR_TEMPLATE, cls.getName(), cls.getSimpleName()));
-            }
+            return fallback(o);
+        }
+    }
+
+    /**
+     * Cold path of {@link Javafier#deep(Object)}.
+     * We assume that we never get an input that is neither {@link ConvertedMap}, {@link ConvertedList}
+     * nor {@link BiValue}, but fallback to attempting to create a {@link BiValue} from the input
+     * before converting to a Java type.
+     * @param o Know to not be an expected type in {@link Javafier#deep(Object)}.
+     * @return Input converted to Java type
+     */
+    private static Object fallback(final Object o) {
+        try {
+            return BiValues.newBiValue(o).javaValue();
+        } catch (IllegalArgumentException e) {
+            Class cls = o.getClass();
+            throw new IllegalArgumentException(String.format(ERR_TEMPLATE, cls.getName(), cls.getSimpleName()));
         }
     }
 }


### PR DESCRIPTION
We can actually factor the `null` guard out here since this method is only called in 4 production code places, the two handled here + two in `ConvertedList` and `ConvertedMap`.

In `ConvertedList` and `ConvertedMap` we know we won't have `null` entries pretty much ever (and if we do `BiValues.newBiValue` is able to deal with it), but in all other cases we can simply skip this huge (byte code wise) function that is pretty likely (50% in the Apach dataset according to JIT watch + more than that (pretty much `100%` then) if you only add a single tag to an `Event`.)
=> much better inlining outright.

Also to make it even better I extracted the cold path from this method and commented on the why of that in the code.