### PR TITLE
 #7851 allow UTF-8 in config file

### DIFF
--- a/logstash-core/lib/logstash/config/source/local.rb
+++ b/logstash-core/lib/logstash/config/source/local.rb
@@ -53,7 +53,7 @@ module LogStash module Config module Source
 
           config_string = ::File.read(file)
 
-          if valid_encoding?(config_string)
+          if config_string.valid_encoding?
             part = org.logstash.common.SourceWithMetadata.new("file", file, 0, 0, config_string)
             config_parts << part
           else
@@ -99,10 +99,6 @@ module LogStash module Config module Source
         t = ::File.split(@path)
         all_files = Dir.glob(::File.join(t.first, "*")).sort
         all_files - get_matched_files
-      end
-
-      def valid_encoding?(content)
-        content.ascii_only? && content.valid_encoding?
       end
 
       def temporary_file?(filepath)


### PR DESCRIPTION
Seems more logical to me this way, see my comment https://github.com/elastic/logstash/issues/7851#issuecomment-318997183

"Either your file content is just ascii or it has an otherwise valid encoding" ... is what this check should be imo

Also this works fine:

```sh
➜  logstash git:(7851) ✗ bin/logstash -f ~/tmp/heart.cfg                                                                                
WARNING: Default JAVA_OPTS will be overridden by the JAVA_OPTS defined in the environment. Environment JAVA_OPTS are -Xms4g -Xmx4g -Djava.net.preferIPv4Stack=true
Sending Logstash's logs to /Users/brownbear/src/logstash/logs which is now configured via log4j2.properties
[2017-07-31T10:18:32,532][INFO ][logstash.setting.writabledirectory] Creating directory {:setting=>"path.dead_letter_queue", :path=>"/Users/brownbear/src/logstash/data/dead_letter_queue"}
[2017-07-31T10:18:32,603][WARN ][logstash.config.source.multilocal] Ignoring the 'pipelines.yml' file because modules or command line options are specified
[2017-07-31T10:18:33,249][INFO ][logstash.agent           ] Successfully started Logstash API endpoint {:port=>9600}
[2017-07-31T10:18:33,944][INFO ][logstash.pipeline        ] Starting pipeline {:pipeline_id=>"main", "pipeline.workers"=>8, "pipeline.batch.size"=>125, "pipeline.batch.delay"=>5, "pipeline.max_inflight"=>1000, :thread=>"#<Thread:0x243b2e3 run>"}
[2017-07-31T10:18:33,980][INFO ][logstash.pipeline        ] Pipeline started {"pipeline.id"=>"main"}
[2017-07-31T10:18:34,037][INFO ][logstash.agent           ] Pipelines running {:count=>1, :pipelines=>["main"]}
2017-07-31T08:18:34.035Z localhost Hello from Logstash 💓
2017-07-31T08:18:39.024Z localhost Hello from Logstash 💓
^C[2017-07-31T10:18:40,236][WARN ][logstash.runner          ] SIGINT received. Shutting down the agent.
[2017-07-31T10:18:40,400][INFO ][logstash.pipeline        ] Pipeline terminated {"pipeline.id"=>"main"}

```