### PR TITLE
Metrics: Cache the hostname in class variable

### DIFF
--- a/logstash-core/lib/logstash/api/commands/default_metadata.rb
+++ b/logstash-core/lib/logstash/api/commands/default_metadata.rb
@@ -12,7 +12,7 @@ module LogStash
         end
 
         def host
-          Socket.gethostname
+          @@host ||= Socket.gethostname
         end
 
         def version


### PR DESCRIPTION
Fixes: #7857 

@jordansissel - can you please review ?


Over [here](https://github.com/elastic/logstash/issues/6520#issuecomment-271753343) you mention:
>Just a note, Socket.gethostname is something we should expect to be a nonstable value during the life of Logstash - a server's hostname can change. 

While I agree, I believe that changing the host name with out restarting to be a fairly rare. 

A 5 second delay and extra IO is obviously not good, and with X-pack is happening with high frequence. The solution proposed over at #6520 is likely the best fix (though hostname is [surprising difficult](https://github.com/elastic/support-dev-help/issues/2118#issuecomment-315542137)).  

In the spirit of `don't let the perfect be the enemy of good`, I would advocate this very simple change.
