### PR TITLE
 #7754 ensure we actually test periodic flushing in specs + make flush work without data input data

### DIFF
--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -224,6 +224,7 @@ module LogStash; class Pipeline < BasePipeline
     @running = Concurrent::AtomicBoolean.new(false)
     @flushing = Concurrent::AtomicReference.new(false)
     @force_shutdown = Concurrent::AtomicBoolean.new(false)
+    @outputs_registered = Concurrent::AtomicBoolean.new(false)
   end # def initialize
 
   def ready?
@@ -385,9 +386,9 @@ module LogStash; class Pipeline < BasePipeline
 
   def start_workers
     @worker_threads.clear # In case we're restarting the pipeline
+    @outputs_registered.make_false
     begin
-      register_plugins(@outputs)
-      register_plugins(@filters)
+      maybe_setup_out_plugins
 
       pipeline_workers = safe_pipeline_worker_count
       batch_size = @settings.get("pipeline.batch.size")
@@ -454,16 +455,17 @@ module LogStash; class Pipeline < BasePipeline
       shutdown_requested |= signal.shutdown? # latch on shutdown signal
 
       batch = @filter_queue_client.read_batch # metrics are started in read_batch
-      if (batch.size > 0)
+      if batch.size > 0
         @events_consumed.increment(batch.size)
         filter_batch(batch)
-        flush_filters_to_batch(batch, :final => false) if signal.flush?
+      end
+      flush_filters_to_batch(batch, :final => false) if signal.flush?
+      if batch.size > 0
         output_batch(batch)
         unless @force_shutdown.true? # ack the current batch
           @filter_queue_client.close_batch(batch)
         end
       end
-
       # keep break at end of loop, after the read_batch operation, some pipeline specs rely on this "final read_batch" before shutdown.
       break if (shutdown_requested && !draining_queue?) || @force_shutdown.true?
     end
@@ -646,10 +648,10 @@ module LogStash; class Pipeline < BasePipeline
   # for backward compatibility in devutils for the rspec helpers, this method is not used
   # in the pipeline anymore.
   def filter(event, &block)
+    maybe_setup_out_plugins
     # filter_func returns all filtered events, including cancelled ones
-    filter_func(event).each { |e| block.call(e) }
+    filter_func(event).each {|e| block.call(e)}
   end
-
 
   # perform filters flush and yield flushed event to the passed block
   # @param options [Hash]
@@ -784,6 +786,13 @@ module LogStash; class Pipeline < BasePipeline
   end
 
   private
+
+  def maybe_setup_out_plugins
+    if @outputs_registered.make_true
+      register_plugins(@outputs)
+      register_plugins(@filters)
+    end
+  end
 
   def default_logging_keys(other_keys = {})
     keys = super


### PR DESCRIPTION
This is a bit of a tricky one I'm afraid, read carefully:

The initial problem is that we're running this line:

```rb
flush_filters_to_batch(batch, :final => false) if signal.flush?
```

when we actually have input events, means that periodic flushing only works if we have data coming in from the inputs. Otherwise, flushing will only occur on pipeline shutdown.
This is not correct I think and makes the tests unstable because the whole flushing logic is just executed when the pipeline shuts down, while the tests even in name assume "periodic" flushing.
This is causing issues like #7754.

Note that this is all about the legacy `filter(event, &block)` call in what follows and doesn't apply to production code and only seems to really hit specs using `logstash-dev-utils`:

The problem is, that calling `flush_filters_to_batch` without the `batch.size > 0` guard throws in some specs using `multiline` + calling ` def filter(event, &block)`.
Because now, the `multiline` filter didn't have it's `register` function called before `filter(...` is called and `@grok` is `nil` in:

```rb
  public
  def filter(event)
    match = event.get(@source).is_a?(Array) ? @grok.match(event.get(@source).first) : @grok.match(event.get(@source))
```

I fixed this by: 

* guarding the registering of output by the atomic boolean `@outputs_registered`.
* Added a clear for that guard to allow repeat `start` calls on pipeline reload via `@outputs_registered.make_false`
* Used this to allow for manually registering the filters and outputs in `filter(event, &block)`
   * I can't fix all the legacy specs + `logstash-dev-utils`, so this seemed like the appropriate alternative?
* Improved the specs to actually check that periodic flushing happened where applicable