### PR TITLE
fix a few issues with pipeline source loading

### DIFF
--- a/logstash-core/lib/logstash/config/source/base.rb
+++ b/logstash-core/lib/logstash/config/source/base.rb
@@ -41,7 +41,7 @@ module LogStash module Config module Source
     end
 
     def config_string?
-      !(config_string.nil? || config_string.empty?)
+      !config_string.nil?
     end
 
     def config_path_setting

--- a/logstash-core/lib/logstash/config/source/multi_local.rb
+++ b/logstash-core/lib/logstash/config/source/multi_local.rb
@@ -19,13 +19,15 @@ module LogStash module Config module Source
         ::LogStash::PipelineSettings.from_settings(@original_settings.clone).merge(pipeline_settings)
       end
       detect_duplicate_pipelines(pipelines_settings)
-      pipelines_settings.map do |pipeline_settings|
+      pipeline_configs = pipelines_settings.map do |pipeline_settings|
         @settings = pipeline_settings
         # this relies on instance variable @settings and the parent class' pipeline_configs
         # method. The alternative is to refactor most of the Local source methods to accept
         # a settings object instead of relying on @settings.
         local_pipeline_configs # create a PipelineConfig object based on @settings
       end.flatten
+      @settings = @original_settings
+      pipeline_configs
     end
 
     def match?

--- a/logstash-core/src/main/java/org/logstash/common/SourceWithMetadata.java
+++ b/logstash-core/src/main/java/org/logstash/common/SourceWithMetadata.java
@@ -60,6 +60,10 @@ public class SourceWithMetadata implements HashableWithSource {
             return false;
         }).collect(Collectors.toList());
 
+        if (!(this.getText() instanceof String)) {
+          badAttributes.add(this.getText());
+        }
+
         if (!badAttributes.isEmpty()){
             String message = "Missing attributes in SourceWithMetadata: (" + badAttributes + ") "
                     + this.toString();
@@ -72,7 +76,7 @@ public class SourceWithMetadata implements HashableWithSource {
     }
 
     public int hashCode() {
-        return Objects.hash(attributes().toArray());
+        return Objects.hash(hashableAttributes().toArray());
     }
 
     public String toString() {
@@ -81,11 +85,16 @@ public class SourceWithMetadata implements HashableWithSource {
 
     @Override
     public String hashSource() {
-        return attributes().stream().map(Object::toString).collect(Collectors.joining("|"));
+        return hashableAttributes().stream().map(Object::toString).collect(Collectors.joining("|"));
+    }
+
+    // Fields checked for being not null and non empty String
+    private Collection<Object> attributes() {
+        return Arrays.asList(this.getId(), this.getProtocol(), this.getLine(), this.getColumn());
     }
 
     // Fields used in the hashSource and hashCode methods to ensure uniqueness
-    private Collection<Object> attributes() {
+    private Collection<Object> hashableAttributes() {
         return Arrays.asList(this.getId(), this.getProtocol(), this.getLine(), this.getColumn(), this.getText());
     }
 }

--- a/logstash-core/src/test/java/org/logstash/common/SourceWithMetadataTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/SourceWithMetadataTest.java
@@ -40,10 +40,8 @@ public class SourceWithMetadataTest {
             new ParameterGroup("proto", "path", 1, 1, null),
             new ParameterGroup("", "path", 1, 1, "foo"),
             new ParameterGroup("proto", "", 1, 1, "foo"),
-            new ParameterGroup("proto", "path", 1, 1, ""),
             new ParameterGroup(" ", "path", 1, 1, "foo"),
-            new ParameterGroup("proto", "  ", 1, 1, "foo"),
-            new ParameterGroup("proto", "path", 1, 1, "   ")
+            new ParameterGroup("proto", "  ", 1, 1, "foo")
         );
     }
 


### PR DESCRIPTION
- allow empty config.string
- move all config autocompletion logic to the ConfigStringLoader
- gracefully handle absence of files in path.config
- ensure original_settings are restored in multi_local source after PipelineConfig creation

fixes #7865
fixes #7749