### PR TITLE
[DOCS] Use shared versions file for doc builds

### DIFF
--- a/docs/index-shared1.asciidoc
+++ b/docs/index-shared1.asciidoc
@@ -1,14 +1,5 @@
-:branch:                5.5
-:major-version:         5.x
-:logstash_version:      5.5.1
-:elasticsearch_version: 5.5.1
-:kibana_version:        5.5.1
-:docker-image:          docker.elastic.co/logstash/logstash:{logstash_version}
 
-//////////
-release-state can be: released | prerelease | unreleased
-//////////
-:release-state:  released
+:docker-image:          docker.elastic.co/logstash/logstash:{logstash_version}
 
 :jdk:                   1.8.0
 :guide:                 https://www.elastic.co/guide/en/elasticsearch/guide/current/
@@ -17,6 +8,7 @@ release-state can be: released | prerelease | unreleased
 :metricbeat:            https://www.elastic.co/guide/en/beats/metricbeat/{branch}/
 :lsissue:               https://github.com/elastic/logstash/issues/
 
+include::{asciidoc-dir}/../../shared/versions55.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 [[introduction]]


### PR DESCRIPTION
This pull request changes the Logstash Reference documentation build so that it pulls version information from a shared file in elastic/docs/shared repository. This allows versioning information to be updated more uniformly and quickly across many books.

The X-Pack Reference already uses those shared files successfully and other books will be migrated to use them as well. See elastic/elasticsearch#26004 and https://github.com/elastic/kibana/pull/13277