### PR TITLE
Benchmark: Some Improvements

### DIFF
--- a/bin/benchmark.sh
+++ b/bin/benchmark.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+java -cp "$(cd `dirname $0`/..; pwd)"'/tools/benchmark-cli/build/libs/benchmark-cli.jar:*' \
+ org.logstash.benchmark.cli.Main "$@"

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/DataStore.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/DataStore.java
@@ -59,7 +59,7 @@ public interface DataStore extends Closeable {
         ElasticSearch(final String host, final int port, final String schema,
             final Map<String, Object> meta) {
             client = RestClient.builder(new HttpHost(host, port, schema)).build();
-            this.meta = meta;
+            this.meta = Collections.unmodifiableMap(meta);
         }
 
         @Override

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/JRubyInstallation.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/JRubyInstallation.java
@@ -41,8 +41,7 @@ public final class JRubyInstallation {
             String.format(
                 "http://jruby.org.s3.amazonaws.com/downloads/%s/jruby-bin-%s.tar.gz",
                 JRUBY_DEFAULT_VERSION, JRUBY_DEFAULT_VERSION
-            ),
-            false
+            )
         );
         return new JRubyInstallation(
             pwd.resolve("jruby").resolve(String.format("jruby-%s", JRUBY_DEFAULT_VERSION))

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/LogstashInstallation.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/LogstashInstallation.java
@@ -55,6 +55,7 @@ public interface LogstashInstallation {
                 } else {
                     output.blue(String.format("Downloading Logstash %s.", version));
                     LogstashInstallation.FromRelease.download(pwd, version);
+                    output.blue("Finished downloading Logstash.");
                 }
                 this.base = LogstashInstallation.FromRelease.setup(basedir);
             } catch (IOException | NoSuchAlgorithmException ex) {
@@ -83,9 +84,8 @@ public interface LogstashInstallation {
             LsBenchDownloader.downloadDecompress(
                 pwd,
                 String.format(
-                    "https://artifacts.elastic.co/downloads/logstash/logstash-%s.zip",
-                    version
-                ), true
+                    "https://artifacts.elastic.co/downloads/logstash/logstash-%s.zip", version
+                )
             );
         }
 
@@ -212,8 +212,7 @@ public interface LogstashInstallation {
         private static void download(final File pwd, final String user, final String hash)
             throws IOException, NoSuchAlgorithmException {
             LsBenchDownloader.downloadDecompress(
-                pwd, String.format("https://github.com/%s/logstash/archive/%s.zip", user, hash),
-                true
+                pwd, String.format("https://github.com/%s/logstash/archive/%s.zip", user, hash)
             );
         }
 

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/LogstashInstallation.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/LogstashInstallation.java
@@ -13,6 +13,7 @@ import java.nio.file.StandardOpenOption;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 import org.apache.commons.io.IOUtils;
+import org.logstash.benchmark.cli.ui.UserOutput;
 import org.logstash.benchmark.cli.util.LsBenchDownloader;
 import org.logstash.benchmark.cli.util.LsBenchFileUtil;
 
@@ -46,12 +47,16 @@ public interface LogstashInstallation {
 
         private final LogstashInstallation base;
 
-        public FromRelease(final File pwd, final String version) {
+        public FromRelease(final File pwd, final String version, final UserOutput output) {
             try {
-                LogstashInstallation.FromRelease.download(pwd, version);
-                this.base = LogstashInstallation.FromRelease.setup(
-                    pwd.toPath().resolve(String.format("logstash-%s", version))
-                );
+                final Path basedir = pwd.toPath().resolve(String.format("logstash-%s", version));
+                if (basedir.toFile().exists()) {
+                    output.blue(String.format("Using Logstash %s from cache.", version));
+                } else {
+                    output.blue(String.format("Downloading Logstash %s.", version));
+                    LogstashInstallation.FromRelease.download(pwd, version);
+                }
+                this.base = LogstashInstallation.FromRelease.setup(basedir);
             } catch (IOException | NoSuchAlgorithmException ex) {
                 throw new IllegalStateException(ex);
             }

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/LsMetricsMonitor.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/LsMetricsMonitor.java
@@ -106,10 +106,11 @@ public final class LsMetricsMonitor implements Callable<EnumMap<LsMetricStats, L
         }
     }
 
+    @SuppressWarnings("unchecked")
     private static long readNestedLong(final Map<String, Object> map, final String ... path) {
         Map<String, Object> nested = map;
         for (int i = 0; i < path.length - 1; ++i) {
-            nested = (Map<String, Object>) (nested).get(path[i]);
+            nested = (Map<String, Object>) nested.get(path[i]);
         }
         return ((Number) nested.get(path[path.length - 1])).longValue();
     }

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/Main.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/Main.java
@@ -147,7 +147,7 @@ public final class Main {
                 LsBenchLsSetup.setupLS(cwd.toAbsolutePath().toString(), version, type, output);
         }
         try (final DataStore store = setupDataStore(esout, test, version, type)) {
-            final Case testcase = setupTestCase(store, logstash, cwd, settings, test);
+            final Case testcase = setupTestCase(store, logstash, cwd, settings, test, output);
             output.printStartTime();
             final long start = System.currentTimeMillis();
             final AbstractMap<LsMetricStats, ListStatistics> stats = testcase.run();
@@ -163,13 +163,13 @@ public final class Main {
     }
 
     private static Case setupTestCase(final DataStore store, final LogstashInstallation logstash,
-        final Path cwd, final Properties settings, final String test)
+        final Path cwd, final Properties settings, final String test, final UserOutput output)
         throws IOException, NoSuchAlgorithmException {
         final Case testcase;
         if (GeneratorToStdout.IDENTIFIER.equalsIgnoreCase(test)) {
             testcase = new GeneratorToStdout(store, logstash, settings);
         } else if (ApacheLogsComplex.IDENTIFIER.equalsIgnoreCase(test)) {
-            testcase = new ApacheLogsComplex(store, logstash, cwd, settings);
+            testcase = new ApacheLogsComplex(store, logstash, cwd, settings, output);
         } else {
             throw new IllegalArgumentException(String.format("Unknown test case %s", test));
         }

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/Main.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/Main.java
@@ -143,7 +143,8 @@ public final class Main {
                 cwd.toAbsolutePath().toString(), version, JRubyInstallation.bootstrapJruby(cwd)
             );
         } else {
-            logstash = LsBenchLsSetup.setupLS(cwd.toAbsolutePath().toString(), version, type);
+            logstash =
+                LsBenchLsSetup.setupLS(cwd.toAbsolutePath().toString(), version, type, output);
         }
         try (final DataStore store = setupDataStore(esout, test, version, type)) {
             final Case testcase = setupTestCase(store, logstash, cwd, settings, test);

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/ui/UserOutput.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/ui/UserOutput.java
@@ -16,6 +16,11 @@ public final class UserOutput {
     private static final String GREEN_ANSI_OPEN = SystemUtils.IS_OS_UNIX ? "\u001B[32m" : "";
 
     /**
+     * ANSI colorized blue section open sequence(On Unix platform only).
+     */
+    private static final String BLUE_ANSI_OPEN = SystemUtils.IS_OS_UNIX ? "\u001B[34m" : "";
+
+    /**
      * ANSI colorized section close sequence(On Unix platform only).
      */
     private static final String ANSI_CLOSE = SystemUtils.IS_OS_UNIX ? "\u001B[0m" : "";
@@ -54,6 +59,10 @@ public final class UserOutput {
 
     public void green(final String line) {
         target.println(colorize(line, GREEN_ANSI_OPEN));
+    }
+
+    public void blue(final String line) {
+        target.println(colorize(line, BLUE_ANSI_OPEN));
     }
 
     public void printStatistics(final Map<LsMetricStats, ListStatistics> stats) {

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/util/LsBenchDownloader.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/util/LsBenchDownloader.java
@@ -15,9 +15,9 @@ import org.apache.http.impl.client.HttpClientBuilder;
 
 public final class LsBenchDownloader {
     
-    public static void downloadDecompress(final File file, final String url, final boolean force)
+    public static void downloadDecompress(final File file, final String url)
         throws IOException, NoSuchAlgorithmException {
-        if (force && file.exists()) {
+        if (file.exists()) {
             LsBenchFileUtil.ensureDeleted(file);
         }
         if (!file.exists()) {

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/util/LsBenchLsSetup.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/util/LsBenchLsSetup.java
@@ -5,6 +5,7 @@ import java.nio.file.Paths;
 import org.logstash.benchmark.cli.JRubyInstallation;
 import org.logstash.benchmark.cli.LogstashInstallation;
 import org.logstash.benchmark.cli.ui.LsVersionType;
+import org.logstash.benchmark.cli.ui.UserOutput;
 
 public final class LsBenchLsSetup {
 
@@ -25,13 +26,13 @@ public final class LsBenchLsSetup {
     }
 
     public static LogstashInstallation setupLS(final String pwd, final String version,
-        final LsVersionType type) {
+        final LsVersionType type, final UserOutput output) {
         final LogstashInstallation logstash;
         if (type == LsVersionType.LOCAL) {
             logstash = new LogstashInstallation.FromLocalPath(version);
         } else {
             logstash = new LogstashInstallation.FromRelease(
-                Paths.get(pwd, String.format("ls-release-%s", version)).toFile(), version
+                Paths.get(pwd, String.format("ls-release-%s", version)).toFile(), version, output
             );
         }
         return logstash;


### PR DESCRIPTION
Some improvements to the benchmark tool:

* Bash script to run it comfortably
* Fix/suppress all compiler warning
* Fix download cache by moving it upstream (gnarf it was just overwriting every time) and add visual feedback for cache hits and before + after downloading
* Trivial cleanup in redundant code for piping around in `ApacheLogsComplex`