### PR TITLE
MINOR: Cleanup LongCounter Javadoc warning + duplication

### DIFF
--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/counter/LongCounter.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/counter/LongCounter.java
@@ -1,16 +1,17 @@
 package org.logstash.instrument.metrics.counter;
 
-
-import org.logstash.instrument.metrics.AbstractMetric;
-import org.logstash.instrument.metrics.MetricType;
-
 import java.util.List;
 import java.util.concurrent.atomic.LongAdder;
+import org.logstash.instrument.metrics.AbstractMetric;
+import org.logstash.instrument.metrics.MetricType;
 
 /**
  * A {@link CounterMetric} that is backed by a {@link Long} type.
  */
 public class LongCounter extends AbstractMetric<Long> implements CounterMetric<Long> {
+
+    private static final IllegalArgumentException NEG_COUNT_EX =
+        new IllegalArgumentException("Counters can not be incremented by negative values");
 
     private final LongAdder longAdder;
 
@@ -40,25 +41,21 @@ public class LongCounter extends AbstractMetric<Long> implements CounterMetric<L
         increment(1l);
     }
 
-    /**
-     * {@inheritDoc}
-     * throws {@link UnsupportedOperationException} if attempt is made to increment by a negative value
-     */
     @Override
     public void increment(Long by) {
         if (by < 0) {
-            throw new UnsupportedOperationException("Counters can not be incremented by negative values");
+            throw NEG_COUNT_EX;
         }
         longAdder.add(by);
     }
 
     /**
      * Optimized version of {@link #increment(Long)} to avoid auto-boxing.
-     * throws {@link UnsupportedOperationException} if attempt is made to increment by a negative value
+     * @param by Count to add
      */
     public void increment(long by) {
         if (by < 0) {
-            throw new UnsupportedOperationException("Counters can not be incremented by negative values");
+            throw NEG_COUNT_EX;
         }
         longAdder.add(by);
     }

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/counter/LongCounterTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/counter/LongCounterTest.java
@@ -34,7 +34,7 @@ public class LongCounterTest {
         assertThat(longCounter.getValue()).isEqualTo(INITIAL_VALUE + 1);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void incrementByNegativeValue() {
         longCounter.increment(-100l);
     }


### PR DESCRIPTION
Cleans up warnings from broken Javadoc for #7701 

* Don't add `throws` for `RuntimeException`
* Missing `param` added

Also:

* removed duplicate `throws` in code (mainly to not get the JIT warning from not being able to inline throwable constructor, but it's cleaner in general too :))