### PR TITLE
Add check to stop messages looping through DLQ

### DIFF
--- a/docs/static/dead-letter-queues.asciidoc
+++ b/docs/static/dead-letter-queues.asciidoc
@@ -113,6 +113,9 @@ queue, it will continue to run and process new events as they stream into the
 queue. This means that you do not need to stop your production system to handle
 events in the dead letter queue. 
 
+NOTE: Events emitted from the dead letter queue input plugin will not be resubmitted to the
+dead letter queue if they cannot be processed correctly
+
 [[dlq-timestamp]]
 ==== Reading From a Timestamp
 

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
@@ -32,11 +32,11 @@ import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.Collections;
 
 import static junit.framework.TestCase.assertFalse;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.logstash.common.io.RecordIOWriter.RECORD_HEADER_SIZE;
@@ -52,6 +52,8 @@ public class DeadLetterQueueWriterTest {
     public void setUp() throws Exception {
         dir = temporaryFolder.newFolder().toPath();
     }
+
+    private static long EMPTY_DLQ = VERSION_SIZE; // Only the version field has been written
 
     @Test
     public void testLockFileManagement() throws Exception {
@@ -100,37 +102,50 @@ public class DeadLetterQueueWriterTest {
     }
 
     @Test
+    public void testDoesNotWriteMessagesAlreadyRoutedThroughDLQ() throws Exception {
+        Event dlqEvent = new Event();
+        dlqEvent.setField("[@metadata][dead_letter_queue][plugin_type]", "dead_letter_queue");
+        DLQEntry entry = new DLQEntry(new Event(), "type", "id", "reason");
+        DLQEntry dlqEntry = new DLQEntry(dlqEvent, "type", "id", "reason");
+
+        try (DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 1000000);) {
+            writer.writeEntry(entry);
+            long dlqLengthAfterEvent  = dlqLength();
+
+            assertThat(dlqLengthAfterEvent, is(not(EMPTY_DLQ)));
+            writer.writeEntry(dlqEntry);
+            assertThat(dlqLength(), is(dlqLengthAfterEvent));
+        }
+    }
+
+    @Test
     public void testDoesNotWriteBeyondLimit() throws Exception {
         DLQEntry entry = new DLQEntry(new Event(), "type", "id", "reason");
 
         int payloadLength = RECORD_HEADER_SIZE + VERSION_SIZE + entry.serialize().length;
         final int MESSAGE_COUNT= 5;
-        long queueLength = payloadLength * MESSAGE_COUNT;
+        long MAX_QUEUE_LENGTH = payloadLength * MESSAGE_COUNT;
         DeadLetterQueueWriter writer = null;
 
         try{
-            writer = new DeadLetterQueueWriter(dir, payloadLength, queueLength);
+            writer = new DeadLetterQueueWriter(dir, payloadLength, MAX_QUEUE_LENGTH);
             for (int i = 0; i < MESSAGE_COUNT; i++)
                 writer.writeEntry(entry);
 
-            long size = Files.list(dir)
-                    .filter(p -> p.toString().endsWith(".log"))
-                    .mapToLong(p -> p.toFile().length())
-                    .sum();
-
-            assertThat(size, is(queueLength));
-
+            assertThat(dlqLength(), is(MAX_QUEUE_LENGTH));
             writer.writeEntry(entry);
-            size = Files.list(dir)
-                    .filter(p -> p.toString().endsWith(".log"))
-                    .mapToLong(p -> p.toFile().length())
-                    .sum();
-            assertThat(size, is(queueLength));
+            assertThat(dlqLength(), is(MAX_QUEUE_LENGTH));
         } finally {
             if (writer != null) {
                 writer.close();
             }
         }
+    }
 
+    private long dlqLength() throws IOException {
+        return Files.list(dir)
+                .filter(p -> p.toString().endsWith(".log"))
+                .mapToLong(p -> p.toFile().length())
+                .sum();
     }
 }


### PR DESCRIPTION
Add check to stop events from being written to the DLQ that have previously been written to the DLQ

Backport to 5.6 of #7838, #7879