### PR TITLE
RFC: Test commit to split travis jobs up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,11 @@ jdk:
   - oraclejdk8
 env:
   - INTEGRATION=false SPEC_OPTS="--order rand --format documentation" JRUBY_OPTS='-Xcompile.invokedynamic=false'
-  - INTEGRATION=true SPEC_OPTS="--order rand --format documentation" JRUBY_OPTS='-Xcompile.invokedynamic=false'
+  - INTEGRATION=true ONLINE=false SPEC_OPTS="--order rand --format documentation" JRUBY_OPTS='-Xcompile.invokedynamic=false'
+  - INTEGRATION=true ONLINE=true SPEC_OPTS="--order rand --format documentation" JRUBY_OPTS='-Xcompile.invokedynamic=false'
   - INTEGRATION=false FEATURE_FLAG=persistent_queues SPEC_OPTS="--order rand --format documentation" JRUBY_OPTS='-Xcompile.invokedynamic=false'
-  - INTEGRATION=true FEATURE_FLAG=persistent_queues SPEC_OPTS="--order rand --format documentation" JRUBY_OPTS='-Xcompile.invokedynamic=false'
+  - INTEGRATION=true ONLINE=true FEATURE_FLAG=persistent_queues SPEC_OPTS="--order rand --format documentation" JRUBY_OPTS='-Xcompile.invokedynamic=false'
+  - INTEGRATION=true ONLINE=false FEATURE_FLAG=persistent_queues SPEC_OPTS="--order rand --format documentation" JRUBY_OPTS='-Xcompile.invokedynamic=false'
 before_install:
   - sudo apt-get update && sudo apt-get install -y docker-ce
   - sudo service docker stop
@@ -29,7 +31,11 @@ script:
   - |+
       if [ "$INTEGRATION" == "true" ]; then
         ci/travis_integration_install.sh
-        ci/travis_integration_run.sh;
+        if [ "$ONLINE" == "true" ]; then
+          ci/travis_integration_run_online.sh
+        else
+          ci/travis_integration_run_offline.sh
+        fi
       else
         rake test:core
       fi

--- a/ci/travis_integration_run_offline.sh
+++ b/ci/travis_integration_run_offline.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+if [[ "$INTEGRATION" != "true" ]]; then
+    exit
+fi
+
+echo "Running integration tests from qa/integration directory"
+cd qa/integration
+
+rspec --tag offline --profile

--- a/ci/travis_integration_run_online.sh
+++ b/ci/travis_integration_run_online.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+if [[ "$INTEGRATION" != "true" ]]; then
+    exit
+fi
+
+echo "Running integration tests from qa/integration directory"
+cd qa/integration
+
+rspec --tag ~offline --profile


### PR DESCRIPTION
Splits the Travis commit into online and offline spec to reduce the number of time out build failures.