### PR TITLE
correct wrong command example

### DIFF
--- a/docs/static/offline-plugins.asciidoc
+++ b/docs/static/offline-plugins.asciidoc
@@ -66,7 +66,7 @@ the offline plugin pack.
 ["source","sh",subs="attributes"]
 .Windows example:
 -------------------------------------------------------------------------------
-bin/logstash-plugin install file:///c:/path/to/logstash-offline-plugins-{logstash_version}.zip
+logstash-{logstash_version}\bin> logstash-plugin install file:///c:/path/to/logstash-offline-plugins-{logstash_version}.zip
 -------------------------------------------------------------------------------
 +
 ["source","sh",subs="attributes"]


### PR DESCRIPTION
the original version was misleading because windows won't recognize `/` in paths. So `bin/logstash-plugin` will cause errors.