### PR TITLE
Fix DLQ seek by Timestamp bugs

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
@@ -80,7 +80,7 @@ public class RecordIOReader {
         int matchingBlock;
         int lowBlock = 0;
         int highBlock = (int) (channel.size() - VERSION_SIZE) / BLOCK_SIZE;
-        
+
         while (lowBlock < highBlock) {
             int middle = (int) Math.ceil((highBlock + lowBlock) / 2.0);
             seekToBlock(middle);

--- a/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
@@ -80,11 +80,7 @@ public class RecordIOReader {
         int matchingBlock;
         int lowBlock = 0;
         int highBlock = (int) (channel.size() - VERSION_SIZE) / BLOCK_SIZE;
-
-        if (highBlock == 0) {
-            return null;
-        }
-
+        
         while (lowBlock < highBlock) {
             int middle = (int) Math.ceil((highBlock + lowBlock) / 2.0);
             seekToBlock(middle);


### PR DESCRIPTION
Fixes 2 seekByTimestamp failure scenarios that occur when a segment is closed with entries smaller than BLOCK_SIZE

If the next segment is > BLOCK_SIZE, then the seek will advance to the next segment. (Skipping past all events
in the closed segment)
If the next segment < BLOCK_SIZE, then the seek will advance to the start of the small segment. (Processing
entries prior to the timestamp)

Backport to 5.5 of #7789 