### PR TITLE
PERFORMANCE: Intern String Keys from FieldReference

### DIFF
--- a/logstash-core/src/main/java/org/logstash/FieldReference.java
+++ b/logstash-core/src/main/java/org/logstash/FieldReference.java
@@ -67,10 +67,10 @@ public final class FieldReference {
         final List<String> path = new ArrayList<>(parts.length);
         for (final String part : parts) {
             if (!part.isEmpty()) {
-                path.add(part);
+                path.add(part.intern());
             }
         }
-        final String key = path.remove(path.size() - 1);
+        final String key = path.remove(path.size() - 1).intern();
         final boolean empty = path.isEmpty();
         if (empty && key.equals(Event.METADATA)) {
             return METADATA_PARENT_REFERENCE;


### PR DESCRIPTION
This is a fun/trivial but effective one :)

We are using the `String` keys from `FieldReference` instances in every `HashMap` we create from `set` operations on an event + obviously, we have a ton of duplication between `FieldReference` instances themselves.
This reduces the used old gen size from `212MB` to `200MB` for me and comes with a small but measurable speed-up (likely from a much better CPU cache hit rate).