### PR TITLE
DLQ:Fix handling of last event in block

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
@@ -144,7 +144,7 @@ public class RecordIOReader {
      */
      int seekToStartOfEventInBlock() {
          // Already consumed all the bytes in this block.
-        if (currentBlock.position() == currentBlockSizeReadFromChannel){
+        if (currentBlock.position() >= currentBlockSizeReadFromChannel){
              return -1;
          }
          while (true) {

--- a/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
@@ -28,7 +28,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Comparator;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.zip.CRC32;
 import java.util.zip.Checksum;
 
@@ -114,7 +113,7 @@ public class RecordIOReader {
         return event;
     }
 
-    public long getChannelPosition() throws IOException {
+    public long getChannelPosition() {
         return channelPosition;
     }
 
@@ -143,7 +142,11 @@ public class RecordIOReader {
     /**
      *
      */
-     int seekToStartOfEventInBlock() throws IOException {
+     int seekToStartOfEventInBlock() {
+         // Already consumed all the bytes in this block.
+        if (currentBlock.position() == currentBlockSizeReadFromChannel){
+             return -1;
+         }
          while (true) {
              RecordType type = RecordType.fromByte(currentBlock.array()[currentBlock.arrayOffset() + currentBlock.position()]);
              if (RecordType.COMPLETE.equals(type) || RecordType.START.equals(type)) {
@@ -185,7 +188,7 @@ public class RecordIOReader {
         }
     }
 
-    private void getRecord(ByteBuffer buffer, RecordHeader header) throws IOException {
+    private void getRecord(ByteBuffer buffer, RecordHeader header) {
         Checksum computedChecksum = new CRC32();
         computedChecksum.update(currentBlock.array(), currentBlock.position(), header.getSize());
 


### PR DESCRIPTION
The last event in a block was being incorrectly handled in such a way that caused unexpected
behavior depending on the contents of the final event, it could cause plugins to fail, or
Logstash to fail with an OutOfMemoryError

Backport to 5.5 of #7871