### PR TITLE
PERFORMANCE: Constant RubyHash Visitor

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -87,7 +87,9 @@ public class JrubyEventExtLibrary implements Library {
         public IRubyObject ruby_initialize(ThreadContext context, IRubyObject[] args) {
             final IRubyObject data = args.length > 0 ? args[0] : null;
             if (data instanceof RubyHash) {
-                this.event = new Event(ConvertedMap.newFromRubyHash((RubyHash) data));
+                this.event = new Event(
+                    ConvertedMap.newFromRubyHash(context, (RubyHash) data)
+                );
             } else {
                 initializeFallback(context, data);
             }


### PR DESCRIPTION
Unlike its name suggests `RubyHash.VisitorWithState` has no internal state => no need to set it up again and again for each conversion.

Original JRuby code for this:

```java
    public static abstract class VisitorWithState<T> {
        public abstract void visit(ThreadContext context, RubyHash self, IRubyObject key, IRubyObject value, int index, T state);
    }

    public static abstract class Visitor extends VisitorWithState {
        public void visit(ThreadContext context, RubyHash self, IRubyObject key, IRubyObject value, int index, Object state) {
            visit(key, value);
        }
        public abstract void visit(IRubyObject key, IRubyObject value);
    }
```

Also, we shouldn't get the thread-local context for the case of the `RubyEvent` construction where we clearly have it in the parameter.