### PR TITLE
Filter invocation improvements

### DIFF
--- a/logstash-core/lib/logstash/filter_delegator.rb
+++ b/logstash-core/lib/logstash/filter_delegator.rb
@@ -44,12 +44,11 @@ module LogStash
       clock.stop
 
       # There is no guarantee in the context of filter
-      # that EVENTS_INT == EVENTS_OUT, see the aggregates and
+      # that EVENTS_IN == EVENTS_OUT, see the aggregates and
       # the split filter
       c = new_events.count { |event| !event.cancelled? }
       @metric_events.increment(:out, c) if c > 0
-
-      return new_events
+      new_events
     end
 
     private


### PR DESCRIPTION
We are doing quite a few operations on the `RubyEvent` that benefit from a proper hashcode and equals method.
The ones we get from `RubyObject` aren't very efficient for our purposes (since the `RubyEvent` holds no state, all we care about is reference equality anyway).

*  Overrode `equals` to only check reference equality
* Implemented a much faster `hashCode`
* Also removed one explicit `return` from the hot loop (no effect really, but I came across https://github.com/jruby/jruby/issues/3715 the other day :D)

Overall this seems to speed up larger batches slightly.