### PR TITLE
 PERFORMANCE: Cleanup Redundant Timestamp Instantiations

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -314,11 +314,11 @@ public final class Event implements Cloneable, Queueable {
             } else if (o instanceof TimeBiValue) {
                 return new Timestamp(((TimeBiValue) o).javaValue());
             } else if (o instanceof JrubyTimestampExtLibrary.RubyTimestamp) {
-                return new Timestamp(((JrubyTimestampExtLibrary.RubyTimestamp) o).getTimestamp());
+                return ((JrubyTimestampExtLibrary.RubyTimestamp) o).getTimestamp();
             } else if (o instanceof Timestamp) {
-                return new Timestamp((Timestamp) o);
+                return (Timestamp) o;
             } else if (o instanceof TimestampBiValue) {
-                return new Timestamp(((TimestampBiValue) o).javaValue());
+                return ((TimestampBiValue) o).javaValue();
             } else if (o instanceof DateTime) {
                 return new Timestamp((DateTime) o);
             } else if (o instanceof Date) {

--- a/logstash-core/src/main/java/org/logstash/Timestamp.java
+++ b/logstash-core/src/main/java/org/logstash/Timestamp.java
@@ -11,11 +11,16 @@ import org.joda.time.format.ISODateTimeFormat;
 import org.logstash.ackedqueue.Queueable;
 import org.logstash.json.TimestampSerializer;
 
+/**
+ * Wrapper around a {@link DateTime} with Logstash specific serialization behaviour.
+ * This class is immutable and thread-safe since its only state is held in a final {@link DateTime}
+ * reference and {@link DateTime} which itself is immutable and thread-safe.
+ */
 @JsonSerialize(using = TimestampSerializer.class)
-public final class Timestamp implements Cloneable, Comparable<Timestamp>, Queueable {
+public final class Timestamp implements Comparable<Timestamp>, Queueable {
 
     // all methods setting the time object must set it in the UTC timezone
-    private DateTime time;
+    private final DateTime time;
 
     private static final DateTimeFormatter iso8601Formatter = ISODateTimeFormat.dateTime();
 
@@ -29,15 +34,7 @@ public final class Timestamp implements Cloneable, Comparable<Timestamp>, Queuea
         this.time = ISODateTimeFormat.dateTimeParser().parseDateTime(iso8601).toDateTime(DateTimeZone.UTC);
     }
 
-    public Timestamp(Timestamp t) {
-        this.time = t.getTime();
-    }
-
     public Timestamp(long epoch_milliseconds) {
-        this.time = new DateTime(epoch_milliseconds, DateTimeZone.UTC);
-    }
-
-    public Timestamp(Long epoch_milliseconds) {
         this.time = new DateTime(epoch_milliseconds, DateTimeZone.UTC);
     }
 
@@ -51,10 +48,6 @@ public final class Timestamp implements Cloneable, Comparable<Timestamp>, Queuea
 
     public DateTime getTime() {
         return time;
-    }
-
-    public void setTime(DateTime time) {
-        this.time = time.toDateTime(DateTimeZone.UTC);
     }
 
     public static Timestamp now() {
@@ -77,14 +70,7 @@ public final class Timestamp implements Cloneable, Comparable<Timestamp>, Queuea
 
     @Override
     public int compareTo(Timestamp other) {
-        return getTime().compareTo(other.getTime());
-    }
-
-    @Override
-    public Timestamp clone() throws CloneNotSupportedException {
-        Timestamp clone = (Timestamp)super.clone();
-        clone.setTime(this.getTime());
-        return clone;
+        return time.compareTo(other.time);
     }
 
     @Override

--- a/logstash-core/src/test/java/org/logstash/TimestampTest.java
+++ b/logstash-core/src/test/java/org/logstash/TimestampTest.java
@@ -36,9 +36,6 @@ public class TimestampTest {
         t = new Timestamp("2014-09-23T08:00:00.000Z");
         assertEquals(DateTimeZone.UTC, t.getTime().getZone());
 
-        t = new Timestamp(new Timestamp());
-        assertEquals(DateTimeZone.UTC, t.getTime().getZone());
-
         long ms = DateTime.now(DateTimeZone.forID("EST")).getMillis();
         t = new Timestamp(ms);
         assertEquals(DateTimeZone.UTC, t.getTime().getZone());

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
@@ -307,7 +307,7 @@ public class DeadLetterQueueReaderTest {
 
     private void seekReadAndVerify(final Timestamp seekTarget, final String expectedValue) throws Exception {
         try(DeadLetterQueueReader readManager = new DeadLetterQueueReader(dir)) {
-            readManager.seekToNextEvent(new Timestamp(seekTarget));
+            readManager.seekToNextEvent(seekTarget);
             DLQEntry readEntry = readManager.pollEntry(100);
             assertThat(readEntry.getReason(), equalTo(expectedValue));
             assertThat(readEntry.getEntryTime().toIso8601(), equalTo(seekTarget.toIso8601()));


### PR DESCRIPTION
Cleaned the use of `Timestamp` up a little to improve code quality and illustrate its redundant nature better for #7897.

Cleanups:

* No reason for this thing to be `Cloneable`, we never clone it and the `clone` implementation makes no sense on an immutable `Object` (`DateTime` is immutable and the only reason it wasn't `final` was that `clone` method calling the redundant `setTime`) => made the thing immutable
  * In the same spirit, removed the redundant copy constructor `public Timestamp(Timestamp t)`, it just makes no sense and only adds GC + complication
   * E.g. this pointless copy `readManager.seekToNextEvent(new Timestamp(seekTarget))` now simply being `readManager.seekToNextEvent(seekTarget)`
* Also removed `public Timestamp(Long epoch_milliseconds)`, this is redundant if you have `public Timestamp(long epoch_milliseconds)`, the JVM figures this out by itself if you pass a `Long` to `long`
* Cleaned up the logic of `public static IRubyObject ruby_coerce` by removing `public static Timestamp newTimestamp(IRubyObject time)`
   * `public static Timestamp newTimestamp(IRubyObject time)` was used here and in `public static IRubyObject ruby_parse_iso8601`. In `public static IRubyObject ruby_parse_iso8601` we don't need that weird type handling because we already know and checked that we're handling a `RubyString`. In the other case we can deal with logic much cleaner too. Especially now avoid going through:
```rb
else if (time instanceof RubyTimestamp) {		
                return new Timestamp(((RubyTimestamp) time).timestamp);
```
only to then turn the `Timestamp` into a `RubyTimestamp` again in the next method call.

=> same logic with less code + it's much clearer now which conversions are actually occuring
=> affected paths produce less GC now