### PR TITLE
prevent force shutdown to be blocked by with_pipelines

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -190,13 +190,6 @@ class LogStash::Agent
     converge_result
   end
 
-  def force_shutdown!
-    stop_collecting_metrics
-    stop_webserver
-    transition_to_stopped
-    force_shutdown_pipelines!
-  end
-
   def id
     return @id if @id
 
@@ -425,13 +418,6 @@ class LogStash::Agent
 
   def collect_metrics?
     @collect_metric
-  end
-
-  def force_shutdown_pipelines!
-    @pipelines.each do |_, pipeline|
-      # TODO(ph): should it be his own action?
-      pipeline.force_shutdown!
-    end
   end
 
   def shutdown_pipelines

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -428,11 +428,9 @@ class LogStash::Agent
   end
 
   def force_shutdown_pipelines!
-    with_pipelines do |pipelines|
-      pipelines.each do |_, pipeline|
-        # TODO(ph): should it be his own action?
-        pipeline.force_shutdown!
-      end
+    @pipelines.each do |_, pipeline|
+      # TODO(ph): should it be his own action?
+      pipeline.force_shutdown!
     end
   end
 

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -468,8 +468,7 @@ class LogStash::Runner < Clamp::StrictCommand
     Stud::trap("INT") do
       if @interrupted_once
         logger.fatal(I18n.t("logstash.agent.forced_sigint"))
-        @agent.force_shutdown!
-        exit
+        exit(1)
       else
         logger.warn(I18n.t("logstash.agent.sigint"))
         Thread.new(logger) {|lg| sleep 5; lg.warn(I18n.t("logstash.agent.slow_shutdown")) }


### PR DESCRIPTION
if force shutdown uses `with_pipelines` then it will never acquire the
`@pipelines_lock` from `shutdown_pipelines` until it terminates.

This PR makes force shutdown use `@pipelines` directly, fixing it.

fixes https://github.com/elastic/logstash/issues/7913