### PR TITLE
#7904 Faster Metrics by Caching Counters

### DIFF
--- a/logstash-core/lib/logstash/filter_delegator.rb
+++ b/logstash-core/lib/logstash/filter_delegator.rb
@@ -26,6 +26,8 @@ module LogStash
       @filter.execution_context = execution_context
 
       @metric_events = namespaced_metric.namespace(:events)
+      @metric_events_in = @metric_events.counter(:in)
+      @metric_events_out = @metric_events.counter(:out)
       namespaced_metric.gauge(:name, config_name)
 
       # Not all the filters will do bufferings
@@ -37,7 +39,7 @@ module LogStash
     end
 
     def multi_filter(events)
-      @metric_events.increment(:in, events.size)
+      @metric_events_in.increment(events.size)
 
       clock = @metric_events.time(:duration_in_millis)
       new_events = @filter.multi_filter(events)
@@ -47,7 +49,7 @@ module LogStash
       # that EVENTS_IN == EVENTS_OUT, see the aggregates and
       # the split filter
       c = new_events.count { |event| !event.cancelled? }
-      @metric_events.increment(:out, c) if c > 0
+      @metric_events_out.increment(:out) if c > 0
       new_events
     end
 

--- a/logstash-core/lib/logstash/filter_delegator.rb
+++ b/logstash-core/lib/logstash/filter_delegator.rb
@@ -41,9 +41,11 @@ module LogStash
     def multi_filter(events)
       @metric_events_in.increment(events.size)
 
-      clock = @metric_events.time(:duration_in_millis)
+      start_time = java.lang.System.current_time_millis
       new_events = @filter.multi_filter(events)
-      clock.stop
+      @metric_events.report_time(
+        :duration_in_millis, java.lang.System.current_time_millis - start_time
+      )
 
       # There is no guarantee in the context of filter
       # that EVENTS_IN == EVENTS_OUT, see the aggregates and

--- a/logstash-core/lib/logstash/instrument/collector.rb
+++ b/logstash-core/lib/logstash/instrument/collector.rb
@@ -33,11 +33,7 @@ module LogStash module Instrument
     #
     def push(namespaces_path, key, type, *metric_type_params)
       begin
-        metric = @metric_store.fetch_or_store(namespaces_path, key) do
-          LogStash::Instrument::MetricType.create(type, namespaces_path, key)
-        end
-
-        metric.execute(*metric_type_params)
+        get(namespaces_path, key, type).execute(*metric_type_params)
       rescue MetricStore::NamespacesExpectedError => e
         logger.error("Collector: Cannot record metric", :exception => e)
       rescue NameError => e
@@ -48,6 +44,12 @@ module LogStash module Instrument
                      :metrics_params => metric_type_params,
                      :exception => e,
                      :stacktrace => e.backtrace)
+      end
+    end
+
+    def get(namespaces_path, key, type)
+      @metric_store.fetch_or_store(namespaces_path, key) do
+        LogStash::Instrument::MetricType.create(type, namespaces_path, key)
       end
     end
 

--- a/logstash-core/lib/logstash/instrument/namespaced_metric.rb
+++ b/logstash-core/lib/logstash/instrument/namespaced_metric.rb
@@ -43,6 +43,10 @@ module LogStash module Instrument
     def collector
       @metric.collector
     end
+    
+    def counter(key)
+      collector.get(@namespace_name, key, :counter)
+    end
 
     def namespace(name)
       NamespacedMetric.new(metric, namespace_name + Array(name))

--- a/logstash-core/lib/logstash/instrument/namespaced_null_metric.rb
+++ b/logstash-core/lib/logstash/instrument/namespaced_null_metric.rb
@@ -44,6 +44,10 @@ module LogStash module Instrument
       @metric.collector
     end
 
+    def counter(_)
+      ::LogStash::Instrument::NullMetric::NullGauge
+    end
+
     def namespace(name)
       NamespacedNullMetric.new(metric, namespace_name + Array(name))
     end

--- a/logstash-core/lib/logstash/instrument/null_metric.rb
+++ b/logstash-core/lib/logstash/instrument/null_metric.rb
@@ -39,6 +39,10 @@ module LogStash module Instrument
       end
     end
 
+    def counter(_)
+      NullGauge
+    end
+
     def namespace(name)
       raise MetricNoNamespaceProvided if name.nil? || name.empty?
       NamespacedNullMetric.new(self, name)
@@ -49,6 +53,12 @@ module LogStash module Instrument
     end
 
     private
+
+    class NullGauge
+      def self.increment(_)
+      end
+    end
+
     # Null implementation of the internal timer class
     #
     # @see LogStash::Instrument::TimedExecution`

--- a/logstash-core/lib/logstash/instrument/wrapped_write_client.rb
+++ b/logstash-core/lib/logstash/instrument/wrapped_write_client.rb
@@ -10,7 +10,9 @@ module LogStash module Instrument
       @events_metrics = metric.namespace([:stats, :events])
       @pipeline_metrics = metric.namespace([:stats, :pipelines, pipeline_id, :events])
       @plugin_events_metrics = metric.namespace([:stats, :pipelines, pipeline_id, :plugins, plugin_type, plugin.id.to_sym, :events])
-
+      @events_metrics_counter = @events_metrics.counter(:in)
+      @pipeline_metrics_counter = @pipeline_metrics.counter(:in)
+      @plugin_events_metrics_counter = @plugin_events_metrics.counter(:out)
       define_initial_metrics_values
     end
 
@@ -29,9 +31,9 @@ module LogStash module Instrument
 
     private
     def record_metric(size = 1)
-      @events_metrics.increment(:in, size)
-      @pipeline_metrics.increment(:in, size)
-      @plugin_events_metrics.increment(:out, size)
+      @events_metrics_counter.increment(size)
+      @pipeline_metrics_counter.increment(size)
+      @plugin_events_metrics_counter.increment(size)
 
       clock = @events_metrics.time(:queue_push_duration_in_millis)
 
@@ -47,9 +49,9 @@ module LogStash module Instrument
     end
 
     def define_initial_metrics_values
-      @events_metrics.increment(:in, 0)
-      @pipeline_metrics.increment(:in, 0)
-      @plugin_events_metrics.increment(:out, 0)
+      @events_metrics_counter.increment(0)
+      @pipeline_metrics_counter.increment(0)
+      @plugin_events_metrics_counter.increment(0)
 
       @events_metrics.report_time(:queue_push_duration_in_millis, 0)
       @pipeline_metrics.report_time(:queue_push_duration_in_millis, 0)

--- a/logstash-core/lib/logstash/output_delegator.rb
+++ b/logstash-core/lib/logstash/output_delegator.rb
@@ -21,6 +21,7 @@ module LogStash class OutputDelegator
     @metric_events = @namespaced_metric.namespace(:events)
     @in_counter = @metric_events.counter(:in)
     @out_counter = @metric_events.counter(:out)
+    @time_metric = @metric_events.counter(:duration_in_millis)
     @strategy = strategy_registry.
                   class_for(self.concurrency).
                   new(@logger, @output_class, @namespaced_metric, execution_context, plugin_args)
@@ -46,9 +47,7 @@ module LogStash class OutputDelegator
     @in_counter.increment(events.length)
     start_time = java.lang.System.current_time_millis
     @strategy.multi_receive(events)
-    @metric_events.report_time(
-      :duration_in_millis, java.lang.System.current_time_millis - start_time
-    )
+    @time_metric.increment(java.lang.System.current_time_millis - start_time)
     @out_counter.increment(events.length)
   end
 

--- a/logstash-core/lib/logstash/output_delegator.rb
+++ b/logstash-core/lib/logstash/output_delegator.rb
@@ -44,9 +44,11 @@ module LogStash class OutputDelegator
 
   def multi_receive(events)
     @in_counter.increment(events.length)
-    clock = @metric_events.time(:duration_in_millis)
+    start_time = java.lang.System.current_time_millis
     @strategy.multi_receive(events)
-    clock.stop
+    @metric_events.report_time(
+      :duration_in_millis, java.lang.System.current_time_millis - start_time
+    )
     @out_counter.increment(events.length)
   end
 

--- a/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
@@ -205,19 +205,18 @@ module LogStash; module Util
       end
 
       def start_clock
-        @inflight_clocks[Thread.current] = [
-          @event_metric.time(:duration_in_millis),
-          @pipeline_metric.time(:duration_in_millis)
-        ]
+        @inflight_clocks[Thread.current] = java.lang.System.current_time_millis
       end
 
       def stop_clock(batch)
         unless @inflight_clocks[Thread.current].nil?
           if batch.size > 0
-            # onl/y stop (which also records) the metrics if the batch is non-empty.
+            # only stop (which also records) the metrics if the batch is non-empty.
             # start_clock is now called at empty batch creation and an empty batch could
             # stay empty all the way down to the close_batch call.
-            @inflight_clocks[Thread.current].each(&:stop)
+            time_taken = java.lang.System.current_time_millis - @inflight_clocks[Thread.current]
+            @event_metric.report_time(:duration_in_millis, time_taken)
+            @pipeline_metric.report_time(:duration_in_millis, time_taken)
           end
           @inflight_clocks.delete(Thread.current)
         end

--- a/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
@@ -71,11 +71,15 @@ module LogStash; module Util
 
       def set_events_metric(metric)
         @event_metric = metric
+        @event_metric_out = @event_metric.counter(:out)
+        @event_metric_filtered = @event_metric.counter(:filtered)
         define_initial_metrics_values(@event_metric)
       end
 
       def set_pipeline_metric(metric)
         @pipeline_metric = metric
+        @pipeline_metric_out = @pipeline_metric.counter(:out)
+        @pipeline_metric_filtered = @pipeline_metric.counter(:filtered)
         define_initial_metrics_values(@pipeline_metric)
       end
 
@@ -157,13 +161,13 @@ module LogStash; module Util
       end
 
       def add_filtered_metrics(batch)
-        @event_metric.increment(:filtered, batch.filtered_size)
-        @pipeline_metric.increment(:filtered, batch.filtered_size)
+        @event_metric_filtered.increment(batch.filtered_size)
+        @pipeline_metric_filtered.increment(batch.filtered_size)
       end
 
       def add_output_metrics(batch)
-        @event_metric.increment(:out, batch.filtered_size)
-        @pipeline_metric.increment(:out, batch.filtered_size)
+        @event_metric_out.increment(batch.filtered_size)
+        @pipeline_metric_out.increment(batch.filtered_size)
       end
     end
 

--- a/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
@@ -73,6 +73,7 @@ module LogStash; module Util
         @event_metric = metric
         @event_metric_out = @event_metric.counter(:out)
         @event_metric_filtered = @event_metric.counter(:filtered)
+        @event_metric_time = @event_metric.counter(:duration_in_millis)
         define_initial_metrics_values(@event_metric)
       end
 
@@ -80,6 +81,7 @@ module LogStash; module Util
         @pipeline_metric = metric
         @pipeline_metric_out = @pipeline_metric.counter(:out)
         @pipeline_metric_filtered = @pipeline_metric.counter(:filtered)
+        @pipeline_metric_time = @pipeline_metric.counter(:duration_in_millis)
         define_initial_metrics_values(@pipeline_metric)
       end
 
@@ -152,8 +154,8 @@ module LogStash; module Util
             # start_clock is now called at empty batch creation and an empty batch could
             # stay empty all the way down to the close_batch call.
             time_taken = java.lang.System.current_time_millis - @inflight_clocks[Thread.current]
-            @event_metric.report_time(:duration_in_millis, time_taken)
-            @pipeline_metric.report_time(:duration_in_millis, time_taken)
+            @event_metric_time.increment(time_taken)
+            @pipeline_metric_time.increment(time_taken)
           end
           @inflight_clocks.delete(Thread.current)
         end

--- a/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
@@ -142,10 +142,7 @@ module LogStash; module Util
       end
 
       def start_clock
-        @inflight_clocks[Thread.current] = [
-          @event_metric.time(:duration_in_millis),
-          @pipeline_metric.time(:duration_in_millis)
-        ]
+        @inflight_clocks[Thread.current] = java.lang.System.current_time_millis
       end
 
       def stop_clock(batch)
@@ -154,7 +151,9 @@ module LogStash; module Util
             # only stop (which also records) the metrics if the batch is non-empty.
             # start_clock is now called at empty batch creation and an empty batch could
             # stay empty all the way down to the close_batch call.
-            @inflight_clocks[Thread.current].each(&:stop)
+            time_taken = java.lang.System.current_time_millis - @inflight_clocks[Thread.current]
+            @event_metric.report_time(:duration_in_millis, time_taken)
+            @pipeline_metric.report_time(:duration_in_millis, time_taken)
           end
           @inflight_clocks.delete(Thread.current)
         end

--- a/logstash-core/spec/logstash/filter_delegator_spec.rb
+++ b/logstash-core/spec/logstash/filter_delegator_spec.rb
@@ -7,6 +7,12 @@ require "logstash/execution_context"
 require "support/shared_contexts"
 
 describe LogStash::FilterDelegator do
+
+  class MockGauge
+    def increment(_)
+    end
+  end
+
   include_context "execution_context"
   
   let(:logger) { double(:logger) }
@@ -15,12 +21,18 @@ describe LogStash::FilterDelegator do
     { "host" => "127.0.0.1", "id" => filter_id }
   end
   let(:collector) { [] }
+  let(:counter_in) { MockGauge.new }
+  let(:counter_out) { MockGauge.new }
+  let(:counter_time) { MockGauge.new }
   let(:metric) { LogStash::Instrument::NamespacedNullMetric.new(collector, :null) }
   let(:events) { [LogStash::Event.new, LogStash::Event.new] }
 
   before :each do
     allow(pipeline).to receive(:id).and_return(pipeline_id)
     allow(metric).to receive(:namespace).with(anything).and_return(metric)
+    allow(metric).to receive(:counter).with(:in).and_return(counter_in)
+    allow(metric).to receive(:counter).with(:out).and_return(counter_out)
+    allow(metric).to receive(:counter).with(:duration_in_millis).and_return(counter_time)
   end
 
   let(:plugin_klass) do
@@ -60,7 +72,7 @@ describe LogStash::FilterDelegator do
     context "when the flush return events" do
       it "increments the out" do
         subject.multi_filter([LogStash::Event.new])
-        expect(metric).to receive(:increment).with(:out, 1)
+        expect(counter_out).to receive(:increment).with(1)
         subject.flush({})
       end
     end
@@ -78,12 +90,12 @@ describe LogStash::FilterDelegator do
       end
 
       it "has incremented :in" do
-        expect(metric).to receive(:increment).with(:in, events.size)
+        expect(counter_in).to receive(:increment).with(events.size)
         subject.multi_filter(events)
       end
 
       it "has not incremented :out" do
-        expect(metric).not_to receive(:increment).with(:out, anything)
+        expect(counter_out).not_to receive(:increment).with(anything)
         subject.multi_filter(events)
       end
     end
@@ -109,8 +121,8 @@ describe LogStash::FilterDelegator do
       end
 
       it "increments the in/out of the metric" do
-        expect(metric).to receive(:increment).with(:in, events.size)
-        expect(metric).to receive(:increment).with(:out, events.size * 2)
+        expect(counter_in).to receive(:increment).with(events.size)
+        expect(counter_out).to receive(:increment).with(events.size * 2)
 
         subject.multi_filter(events)
       end
@@ -138,8 +150,8 @@ describe LogStash::FilterDelegator do
     end
 
     it "increments the in/out of the metric" do
-      expect(metric).to receive(:increment).with(:in, events.size)
-      expect(metric).to receive(:increment).with(:out, events.size)
+      expect(counter_in).to receive(:increment).with(events.size)
+      expect(counter_out).to receive(:increment).with(events.size)
 
       subject.multi_filter(events)
     end

--- a/logstash-core/spec/logstash/output_delegator_spec.rb
+++ b/logstash-core/spec/logstash/output_delegator_spec.rb
@@ -64,9 +64,7 @@ describe LogStash::OutputDelegator do
       end
 
       it "should record the `duration_in_millis`" do
-        clock = spy("clock")
-        expect(subject.metric_events).to receive(:time).with(:duration_in_millis).and_return(clock)
-        expect(clock).to receive(:stop)
+        expect(subject.metric_events).to receive(:report_time).with(:duration_in_millis, Integer)
         subject.multi_receive(events)
       end
     end


### PR DESCRIPTION
For #7904 also incorporates #7907 

First things first, we're almost twice as fast with this, as the fastest version (`5.3.0`) I could find in the baseline benchmark.

```bash
Logstash Benchmark
------------------------------------------
Benchmarking Version: /Users/brownbear/src/logstash
Running Test Case: baseline (x3)
------------------------------------------
Start Time: Sat 8 5 20:20:46 2017 CEST
Statistical Summary:

Elapsed Time: 34s
Num Events: 2982064
Throughput Min: 250.00
Throughput Max: 310750.00
Throughput Mean: 248505.33
Throughput StdDev: 107847.10
Throughput Variance: 11630996629.52
Mean CPU Usage: 30.75%

➜  logstash git:(faster-metrics) bin/benchmark.sh --distribution-version=5.3.0 -repeat-data=3
Logstash Benchmark
------------------------------------------
Benchmarking Version: 5.3.0
Running Test Case: baseline (x3)
------------------------------------------
Using Logstash 5.3.0 from cache.
Start Time: Sat 8 5 12:55:27 2017 CEST
Statistical Summary:

Elapsed Time: 31s
Num Events: 2999888
Throughput Min: 1633.00
Throughput Max: 142875.00
Throughput Mean: 124995.33
Throughput StdDev: 30999.54
Throughput Variance: 960971473.71
Mean CPU Usage: 29.04%
```

By comparison `master` is ~3x slower in the baseline:

```sh
➜  logstash git:(master) bin/benchmark.sh --local-path=${PWD} -repeat-data=3                                                                          
Logstash Benchmark
------------------------------------------
Benchmarking Version: /Users/brownbear/src/logstash
Running Test Case: baseline (x3)
------------------------------------------
Start Time: Sat 8 5 13:00:45 2017 CEST
Statistical Summary:

Elapsed Time: 66s
Num Events: 2978307
Throughput Min: 0.00
Throughput Max: 79875.00
Throughput Mean: 72641.63
Throughput StdDev: 17982.31
Throughput Variance: 323363589.59
Mean CPU Usage: 25.02%
```

(As a side note: It's kind of interesting to see how much time we were losing bc of lock contention before judging from the CPU usage `%`, worker threads all went from `80%` hot time to `90%+`)

For the Apache dataset, I see a throughput improvement of about a third (1.33x faster) over `master`. Haven't had time for large sample sizes here, though so I'd say I'm confident to have at least a `25%` speed-up on my i7 (the whole thing is CPU bound anyway).

Fixed by:
* Caching `:counter` type `Gauge`s
   * Reload is not a problem since the `FilterDelegator`, `OutputDelegator` and `WrappedWriteClient` client that cache these are instantiated fresh anyways (**please double check this as I could be missing some piece of this puzzle, 95% confident in this though**)
* Had to adjust some specs, but I think the changes are somewhat self-explanatory and rather improve than worsen the strength of the tests (imo)


PS: This makes the metric overhead almost non-existent even in the baseline benchmark. It seems to be `< 10%`  easily for `baseline` and is almost invisible in the `apache` version (obv gotta compare `| pv | wc -c` to see that).