### PR TITLE
MINOR: Cleanup Event serialization and fix related compiler warnings

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -1,5 +1,6 @@
 package org.logstash;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
@@ -176,35 +177,25 @@ public final class Event implements Cloneable, Queueable {
         }
     }
 
-    private Map<String, Map<String, Object>> toSerializableMap() {
-        HashMap<String, Map<String, Object>> hashMap = new HashMap<>();
-        hashMap.put(DATA_MAP_KEY, this.data);
-        hashMap.put(META_MAP_KEY, this.metadata);
-        return hashMap;
-    }
-
-    private static Event fromSerializableMap(Map<String, Map<String, Object>> representation) throws IOException{
-        if (!representation.containsKey(DATA_MAP_KEY)) {
+    private static Event fromSerializableMap(final byte[] source) throws IOException {
+        final Map<String, Map<String, Object>> representation =
+            CBOR_MAPPER.readValue(source, ObjectMappers.EVENT_MAP_TYPE);
+        if (representation == null) {
+            throw new IOException("incompatible from binary object type only HashMap is supported");
+        }
+        final Map<String, Object> dataMap = representation.get(DATA_MAP_KEY);
+        if (dataMap == null) {
             throw new IOException("The deserialized Map must contain the \"DATA\" key");
         }
-        if (!representation.containsKey(META_MAP_KEY)) {
+        final Map<String, Object> metaMap = representation.get(META_MAP_KEY);
+        if (metaMap == null) {
             throw new IOException("The deserialized Map must contain the \"META\" key");
         }
-        Map<String, Object> dataMap = representation.get(DATA_MAP_KEY);
-        dataMap.put(METADATA, representation.get(META_MAP_KEY));
+        dataMap.put(METADATA, metaMap);
         return new Event(dataMap);
     }
 
-    private static Map<String, Map<String, Object>> fromBinaryToMap(byte[] source) throws IOException {
-        Object o = CBOR_MAPPER.readValue(source, HashMap.class);
-        if (o == null) {
-            throw new IOException("incompatible from binary object type only HashMap is supported");
-        } else {
-            return (Map<String, Map<String, Object>>) o;
-        }
-    }
-
-    public String toJson() throws IOException {
+    public String toJson() throws JsonProcessingException {
         return JSON_MAPPER.writeValueAsString(this.data);
     }
 
@@ -391,14 +382,17 @@ public final class Event implements Cloneable, Queueable {
     }
 
     @Override
-    public byte[] serialize() throws IOException {
-        return CBOR_MAPPER.writeValueAsBytes(toSerializableMap());
+    public byte[] serialize() throws JsonProcessingException {
+        final Map<String, Map<String, Object>> map = new HashMap<>(2, 1.0F);
+        map.put(DATA_MAP_KEY, this.data);
+        map.put(META_MAP_KEY, this.metadata);
+        return CBOR_MAPPER.writeValueAsBytes(map);
     }
 
     public static Event deserialize(byte[] data) throws IOException {
         if (data == null || data.length == 0) {
             return new Event();
         }
-        return fromSerializableMap(fromBinaryToMap(data));
+        return fromSerializableMap(data);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/ObjectMappers.java
+++ b/logstash-core/src/main/java/org/logstash/ObjectMappers.java
@@ -1,6 +1,7 @@
 package org.logstash;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -9,6 +10,7 @@ import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
 import com.fasterxml.jackson.dataformat.cbor.CBORGenerator;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import java.io.IOException;
+import java.util.HashMap;
 import org.jruby.RubyFloat;
 import org.jruby.RubyString;
 
@@ -25,6 +27,12 @@ public final class ObjectMappers {
     public static final ObjectMapper CBOR_MAPPER = new ObjectMapper(
         new CBORFactory().configure(CBORGenerator.Feature.WRITE_MINIMAL_INTS, false)
     ).registerModule(new AfterburnerModule()).registerModule(RUBY_SERIALIZERS);
+
+    /**
+     * {@link JavaType} for the {@link HashMap} that {@link Event} is serialized as.
+     */
+    public static final JavaType EVENT_MAP_TYPE =
+        CBOR_MAPPER.getTypeFactory().constructMapType(HashMap.class, String.class, Object.class);
 
     private ObjectMappers() {
     }


### PR DESCRIPTION
Just fixing this up a little:

* Use `EVENT_MAP_TYPE` to get (some) type safety when deserializing the generic `Map` for `Event`
   * At least this fixes 2 compiler warnings for #7701 

Also:

* Be a little more efficient when serializing and deserializing `Event`
  * `fromBinaryToMap` is redundant, it's only used in `fromSerializableMap` 
  * `containsKey` is redundant if you care about the actual value, just use `null` checks
  * `toSerializableMap` is redundant and only used in `serialize` => this hides the fact that we are only using the created `HashMap` for serialization purposes and can size it more appropriately (could even use an `EnumMap` here, but that might not be consistent with existing data in PQs => let's not do it yet)