### PR TITLE
PERFORMANCE: Force JIT compilation, don't AOT compile

### DIFF
--- a/config/jvm.options
+++ b/config/jvm.options
@@ -54,7 +54,6 @@
 # Turn on JRuby invokedynamic
 -Djruby.compile.invokedynamic=true
 # Force Compilation
--Djruby.compile.mode=FORCE
 -Djruby.jit.threshold=0
 
 ## heap dumps


### PR DESCRIPTION
I'm reversing 50% of my position from #7783 (urgh, you should only try one change at a time ... obviously only one of the two changes there had a positive impact).

After some digging into how JRuby class loading works (trying to figure out why my LIR implementations suck by comparison ...) I think we shouldn't AOT compile. It doesn't seem to provide any benefit in theory (AOT compilation is no different from JIT) and practice but has two drawbacks:
1. startup times are way longer with AOT
2. Memory use is up a lot from it (and in theory the fact that it increases the code cache size and metaspace size should slow things down, because JRuby allocates the classes it dynamically creates on the heap).

Throughput takes a little longer to converge without AOT, but that's irrelevant imo relative to the memory savings (also might be that running an even longer benchmark will show a more favorable result here even for the non-AOT version).

### Before
<img width="1354" alt="screen shot 2017-08-07 at 12 07 40" src="https://user-images.githubusercontent.com/6490959/29022336-3c2dc418-7b69-11e7-866a-ae23118f3028.png">

### After
<img width="1359" alt="screen shot 2017-08-07 at 12 04 38" src="https://user-images.githubusercontent.com/6490959/29022205-a165f054-7b68-11e7-8f27-55acd4ceeea7.png">

=> 100M+ saved
=> Same amount of GCs happening, but a smaller fraction of them incurs a pause + pauses are slower => I expect better throughput in the steady-state