### PR TITLE
PERFORMANCE: Generate more optimal filter_func

### DIFF
--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -68,7 +68,7 @@ module LogStash; class BasePipeline
     raise(ConfigurationError, grammar.failure_reason) if parsed_config.nil?
 
     parsed_config.process_escape_sequences = settings.get_value("config.support_escapes")
-    config_code = parsed_config.compile
+    config_code = parsed_config.compile(@logger.debug?)
 
     # config_code = BasePipeline.compileConfig(config_str)
 

--- a/logstash-core/spec/logstash/config/config_ast_spec.rb
+++ b/logstash-core/spec/logstash/config/config_ast_spec.rb
@@ -64,7 +64,7 @@ describe LogStashConfigParser do
       it "should compile successfully" do
         result = subject.parse(config)
         expect(result).not_to(be_nil)
-        expect { eval(result.compile) }.not_to(raise_error)
+        expect { eval(result.compile(false)) }.not_to(raise_error)
       end
     end
 
@@ -83,7 +83,7 @@ describe LogStashConfigParser do
       it "should compile successfully" do
         result = subject.parse(config)
         expect(result).not_to(be_nil)
-        expect { eval(result.compile) }.not_to(raise_error)
+        expect { eval(result.compile(false)) }.not_to(raise_error)
       end
     end
 
@@ -103,7 +103,7 @@ describe LogStashConfigParser do
           }
         ))
 
-        expect { config.compile }.to raise_error(LogStash::ConfigurationError, /Duplicate keys found in your configuration: \["message"\]/)
+        expect { config.compile(false) }.to raise_error(LogStash::ConfigurationError, /Duplicate keys found in your configuration: \["message"\]/)
       end
 
       it "rejects duplicate keys in nested hash" do
@@ -122,7 +122,7 @@ describe LogStashConfigParser do
           }
         ))
 
-        expect { config.compile }.to raise_error(LogStash::ConfigurationError, /Duplicate keys found in your configuration: \["cool"\]/)
+        expect { config.compile(false) }.to raise_error(LogStash::ConfigurationError, /Duplicate keys found in your configuration: \["cool"\]/)
       end
 
       it "rejects a key with multiple double quotes" do
@@ -190,7 +190,7 @@ describe LogStashConfigParser do
         def initialize(config, settings)
           grammar = LogStashConfigParser.new
           @config = grammar.parse(config)
-          @code = @config.compile
+          @code = @config.compile(false)
           eval(@code)
         end
         def plugin(*args);end
@@ -243,7 +243,7 @@ describe LogStashConfigParser do
         def initialize(config, settings)
           grammar = LogStashConfigParser.new
           @config = grammar.parse(config)
-          @code = @config.compile
+          @code = @config.compile(false)
           eval(@code)
         end
         def plugin(*args);end


### PR DESCRIPTION
Baseline performance 250k/s -> 270k/s (had a better number here, but had to remove one step of the optimization for JRuby issues.)
Basically what this does is just not add the debug logging lines to the generated methods when debug logging is disabled, this has a pretty measurable effect on performance since that call (`.debug?`) is somewhat expensive + blows up method size needlessly since the dead code removal doesn't work all that well in JRuby code it seems. 