### PR TITLE
Use LIR to generate vertex plugin IDs

### DIFF
--- a/logstash-core/lib/logstash/compiler/lscl.rb
+++ b/logstash-core/lib/logstash/compiler/lscl.rb
@@ -2,6 +2,7 @@
 require 'logstash/errors'
 require "treetop"
 require "logstash/compiler/treetop_monkeypatches"
+require "logstash/compiler/lscl/helpers"
 require "logstash/config/string_escape"
 
 java_import org.logstash.config.ir.DSL
@@ -10,59 +11,7 @@ java_import org.logstash.common.SourceWithMetadata
 module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSCL; module AST
   PROCESS_ESCAPE_SEQUENCES = :process_escape_sequences
 
-  # Helpers for parsing LSCL files
-  module Helpers
-    def source_meta
-      line, column = line_and_column
-      org.logstash.common.SourceWithMetadata.new(base_protocol, base_id, line, column, self.text_value)
-    end
-
-    def base_source_with_metadata=(value)
-      set_meta(:base_source_with_metadata, value)
-    end
-    
-    def base_source_with_metadata
-      get_meta(:base_source_with_metadata)
-    end
-
-    def base_protocol
-      self.base_source_with_metadata.protocol
-    end
-
-    def base_id
-      self.base_source_with_metadata.id
-    end
-
-    def compose(*statements)
-      compose_for(section_type.to_sym).call(source_meta, *statements)
-    end
-
-    def compose_for(section_sym)
-      if section_sym == :filter
-        jdsl.method(:iComposeSequence)
-      else
-        jdsl.method(:iComposeParallel)
-      end
-    end
-
-    def line_and_column
-      start = self.interval.first
-      [self.input.line_of(start), self.input.column_of(start)]
-    end
-
-    def jdsl
-      org.logstash.config.ir.DSL
-    end
-
-    def self.jdsl
-      org.logstash.config.ir.DSL
-    end
-    
-    AND_METHOD = jdsl.method(:eAnd)
-    OR_METHOD = jdsl.method(:eOr)
-  end
-  
-  class Node < Treetop::Runtime::SyntaxNode
+    class Node < Treetop::Runtime::SyntaxNode
     include Helpers
     
     def section_type

--- a/logstash-core/lib/logstash/compiler/lscl/helpers.rb
+++ b/logstash-core/lib/logstash/compiler/lscl/helpers.rb
@@ -1,0 +1,55 @@
+# encoding: utf-8
+
+module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSCL; module AST
+  # Helpers for parsing LSCL files
+  module Helpers
+    def source_meta
+      line, column = line_and_column
+      org.logstash.common.SourceWithMetadata.new(base_protocol, base_id, line, column, self.text_value)
+    end
+
+    def base_source_with_metadata=(value)
+      set_meta(:base_source_with_metadata, value)
+    end
+    
+    def base_source_with_metadata
+      get_meta(:base_source_with_metadata)
+    end
+
+    def base_protocol
+      self.base_source_with_metadata ? self.base_source_with_metadata.protocol : 'config_ast'
+    end
+
+    def base_id
+      self.base_source_with_metadata ? self.base_source_with_metadata.id : 'config_ast'
+    end
+
+    def compose(*statements)
+      compose_for(section_type.to_sym).call(source_meta, *statements)
+    end
+
+    def compose_for(section_sym)
+      if section_sym == :filter
+        jdsl.method(:iComposeSequence)
+      else
+        jdsl.method(:iComposeParallel)
+      end
+    end
+
+    def line_and_column
+      start = self.interval.first
+      [self.input.line_of(start), self.input.column_of(start)]
+    end
+
+    def jdsl
+      org.logstash.config.ir.DSL
+    end
+
+    def self.jdsl
+      org.logstash.config.ir.DSL
+    end
+    
+    AND_METHOD = jdsl.method(:eAnd)
+    OR_METHOD = jdsl.method(:eOr)
+  end
+end; end; end; end; end

--- a/logstash-core/lib/logstash/filter_delegator.rb
+++ b/logstash-core/lib/logstash/filter_delegator.rb
@@ -14,6 +14,8 @@ module LogStash
     ]
     def_delegators :@filter, *DELEGATED_METHODS
 
+    attr_reader :id
+
     def initialize(logger, klass, metric, execution_context, plugin_args)
       @logger = logger
       @klass = klass

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -113,12 +113,16 @@ module LogStash; class BasePipeline
     # Collapse the array of arguments into a single merged hash
     args = args.reduce({}, &:merge)
 
-    # Pull the ID from LIR to keep IDs consistent between the two representations
-    id = lir.graph.vertices.filter do |v| 
-      v.source_with_metadata && 
-      v.source_with_metadata.line == line && 
-      v.source_with_metadata.column == column
-    end.findFirst.get.id
+    if plugin_type == "codec"
+      id = SecureRandom.uuid # codecs don't really use their IDs for metrics, so we can use anything here
+    else
+      # Pull the ID from LIR to keep IDs consistent between the two representations
+      id = lir.graph.vertices.filter do |v| 
+        v.source_with_metadata && 
+        v.source_with_metadata.line == line && 
+        v.source_with_metadata.column == column
+      end.findFirst.get.id
+    end
 
     args["id"] = id # some code pulls the id out of the args
 

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -41,6 +41,8 @@ class DummyCodec < LogStash::Codecs::Base
   config_name "dummycodec"
   milestone 2
 
+  config :format, :validate => :string
+
   def decode(data)
     data
   end
@@ -373,7 +375,7 @@ describe LogStash::Pipeline do
       allow(LogStash::Plugin).to receive(:lookup).with("output", "dummyoutput").and_return(::LogStash::Outputs::DummyOutput)
     end
 
-    let(:config) { "input { dummyinput {} } filter { dummyfilter {} } output { dummyoutput {} }"}
+    let(:config) { "input { dummyinput { codec => plain { format => 'something'  } } } filter { dummyfilter {} } output { dummyoutput {} }"}
     let(:pipeline) { mock_pipeline_from_string(config) }
 
     after do


### PR DESCRIPTION
In this patch we unify the IDs reported by LIR with those generated using config_ast.rb

This is a temporary fix until LIR execution is built. It relies on the fact that currently both LIR and config_ast.rb only operate on a single concatenated string of configurations. In the future LIR will compile different files separately, then merge their IRs. For now, however, this solution will hold.

This change also exposes the :id attribute of FilterDelegator to bring it to parity with OutputDelegator and InputDelegator which is required for testing purposes.