### PR TITLE
Shorten Vertex generated IDs

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/Vertex.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/Vertex.java
@@ -243,7 +243,7 @@ public abstract class Vertex implements SourceComponent, HashableWithSource {
         // they have no source metadata. This might also be used in the future by alternate config languages which are
         // willing to take the hit.
         if (this.getSourceWithMetadata() != null) {
-            generatedId = this.getGraph().uniqueHash() + "|" + this.getSourceWithMetadata().uniqueHash();
+            generatedId = Util.digest(this.getGraph().uniqueHash() + "|" + this.getSourceWithMetadata().uniqueHash());
         } else {
             generatedId = this.uniqueHash();
         }


### PR DESCRIPTION
Currently generated Vertex IDs are unwieldy concatenations of two sha256 hashes. This is just a pain to deal with.

This patch hashes that concatenation instead, yielding something far easier to deal with.