### PR TITLE
delete all pipeline metrics on pipeline removal

### DIFF
--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -603,7 +603,6 @@ module LogStash; class Pipeline < BasePipeline
     # We make this call blocking, so we know for sure when the method return the shtudown is
     # stopped
     wait_for_workers
-    clear_pipeline_metrics
     @logger.info("Pipeline terminated", "pipeline.id" => @pipeline_id)
   end # def shutdown
 
@@ -745,20 +744,6 @@ module LogStash; class Pipeline < BasePipeline
       end
 
       pipeline_metric.gauge(:events, queue.unread_count)
-    end
-  end
-
-  def clear_pipeline_metrics
-    # TODO(ph): I think the metric should also proxy that call correctly to the collector
-    # this will simplify everything since the null metric would simply just do a noop
-    collector = @metric.collector
-
-    unless collector.nil?
-      # selectively reset metrics we don't wish to keep after reloading
-      # these include metrics about the plugins and number of processed events
-      # we want to keep other metrics like reload counts and error messages
-      collector.clear("stats/pipelines/#{pipeline_id}/plugins")
-      collector.clear("stats/pipelines/#{pipeline_id}/events")
     end
   end
 

--- a/logstash-core/lib/logstash/pipeline_action/reload.rb
+++ b/logstash-core/lib/logstash/pipeline_action/reload.rb
@@ -37,7 +37,7 @@ module LogStash module PipelineAction
       end
 
       logger.info("Reloading pipeline", "pipeline.id" => pipeline_id)
-      status = Stop.new(pipeline_id).execute(agent, pipelines)
+      status = Stop.new(pipeline_id, :reload => true).execute(agent, pipelines)
 
       if status
         return Create.new(@pipeline_config, @metric).execute(agent, pipelines)

--- a/logstash-core/lib/logstash/pipeline_action/stop.rb
+++ b/logstash-core/lib/logstash/pipeline_action/stop.rb
@@ -7,14 +7,24 @@ module LogStash module PipelineAction
   class Stop < Base
     attr_reader :pipeline_id
 
-    def initialize(pipeline_id)
+    def initialize(pipeline_id, opts = {})
       @pipeline_id = pipeline_id
+      @is_reload = opts.fetch(:reload, false)
     end
 
     def execute(agent, pipelines)
       pipeline = pipelines[pipeline_id]
       pipeline.shutdown { LogStash::ShutdownWatcher.start(pipeline) }
       pipelines.delete(pipeline_id)
+        
+      if collector = agent.metric.collector
+        if @is_reload
+          collector.clear("stats/pipelines/#{pipeline_id}/plugins")
+          collector.clear("stats/pipelines/#{pipeline_id}/events")
+        else
+          collector.clear("stats/pipelines/#{pipeline_id}")
+        end
+      end
       # If we reach this part of the code we have succeeded because
       # the shutdown call will block.
       return LogStash::ConvergeResult::SuccessfulAction.new

--- a/logstash-core/lib/logstash/state_resolver.rb
+++ b/logstash-core/lib/logstash/state_resolver.rb
@@ -31,7 +31,7 @@ module LogStash
       # stop it.
       pipelines.keys
         .select { |pipeline_id| !running_pipelines.include?(pipeline_id) }
-        .each { |pipeline_id| actions << LogStash::PipelineAction::Stop.new(pipeline_id) }
+        .each { |pipeline_id| actions << LogStash::PipelineAction::Stop.new(pipeline_id, :reload => false) }
 
       actions.sort # See logstash/pipeline_action.rb
     end

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -381,42 +381,50 @@ describe LogStash::Agent do
 
       after(:each) { File.unlink(new_file) }
 
-      it "resets the pipeline metric collector" do
-        snapshot = subject.metric.collector.snapshot_metric
-        value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:events][:in].value
-        expect(value).to be <= new_config_generator_counter
+      context "for global metrics" do
+        it "does not reset the event count" do
+          snapshot = subject.metric.collector.snapshot_metric
+          value = snapshot.metric_store.get_with_path("/stats/events")[:stats][:events][:in].value
+          expect(value).to be > initial_generator_threshold
+        end
+
+        it "increases the successful reload count" do
+          snapshot = subject.metric.collector.snapshot_metric
+          instance_value = snapshot.metric_store.get_with_path("/stats")[:stats][:reloads][:successes].value
+          expect(instance_value).to eq(1)
+        end
       end
 
-      it "does not reset the global event count" do
-        snapshot = subject.metric.collector.snapshot_metric
-        value = snapshot.metric_store.get_with_path("/stats/events")[:stats][:events][:in].value
-        expect(value).to be > initial_generator_threshold
-      end
+      context "pipeline level metrics" do
+        it "resets the metric collector" do
+          snapshot = subject.metric.collector.snapshot_metric
+          value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:events][:in].value
+          expect(value).to be <= new_config_generator_counter
+        end
 
-      it "increases the successful reload count" do
-        snapshot = subject.metric.collector.snapshot_metric
-        value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:successes].value
-        expect(value).to eq(1)
-        instance_value = snapshot.metric_store.get_with_path("/stats")[:stats][:reloads][:successes].value
-        expect(instance_value).to eq(1)
-      end
+        it "increases the successful reload count" do
+          snapshot = subject.metric.collector.snapshot_metric
+          value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:successes].value
+          expect(value).to eq(1)
+        end
 
-      it "does not set the failure reload timestamp" do
-        snapshot = subject.metric.collector.snapshot_metric
-        value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:last_failure_timestamp].value
-        expect(value).to be(nil)
-      end
+        it "does not set the failure reload timestamp" do
+          snapshot = subject.metric.collector.snapshot_metric
+          value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:last_failure_timestamp].value
+          expect(value).to be(nil)
+        end
 
-      it "sets the success reload timestamp" do
-        snapshot = subject.metric.collector.snapshot_metric
-        value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:last_success_timestamp].value
-        expect(value).to be_a(Timestamp)
-      end
+        it "sets the success reload timestamp" do
+          snapshot = subject.metric.collector.snapshot_metric
+          value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:last_success_timestamp].value
+          expect(value).to be_a(Timestamp)
+        end
 
-      it "does not set the last reload error" do
-        snapshot = subject.metric.collector.snapshot_metric
-        value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:last_error].value
-        expect(value).to be(nil)
+        it "does not set the last reload error" do
+          snapshot = subject.metric.collector.snapshot_metric
+          value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:last_error].value
+          expect(value).to be(nil)
+        end
       end
     end
 
@@ -424,35 +432,51 @@ describe LogStash::Agent do
       let(:new_config) { "input { generator { count => " }
       before(:each) { subject.converge_state_and_update }
 
-      it "does not increase the successful reload count" do
-        snapshot = subject.metric.collector.snapshot_metric
-        value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:successes].value
-        expect(value).to eq(0)
+      context "global metrics" do
+        it "not increase the successful reload count" do
+          snapshot = subject.metric.collector.snapshot_metric
+          value = snapshot.metric_store.get_with_path("/stats")[:stats][:reloads][:successes].value
+          expect(value).to eq(0)
+        end
+
+        it "increases the failed reload count" do
+          snapshot = subject.metric.collector.snapshot_metric
+          value = snapshot.metric_store.get_with_path("/stats")[:stats][:reloads][:failures].value
+          expect(value).to be > 0
+        end
       end
 
-      it "does not set the successful reload timestamp" do
-        snapshot = subject.metric.collector.snapshot_metric
-        value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:last_success_timestamp].value
-        expect(value).to be(nil)
-      end
+      context "pipeline level metrics" do
+        it "does not increase the successful reload count" do
+          snapshot = subject.metric.collector.snapshot_metric
+          value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:successes].value
+          expect(value).to eq(0)
+        end
 
-      it "sets the failure reload timestamp" do
-        snapshot = subject.metric.collector.snapshot_metric
-        value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:last_failure_timestamp].value
-        expect(value).to be_a(Timestamp)
-      end
+        it "does not set the successful reload timestamp" do
+          snapshot = subject.metric.collector.snapshot_metric
+          value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:last_success_timestamp].value
+          expect(value).to be(nil)
+        end
 
-      it "sets the last reload error" do
-        snapshot = subject.metric.collector.snapshot_metric
-        value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:last_error].value
-        expect(value).to be_a(Hash)
-        expect(value).to include(:message, :backtrace)
-      end
+        it "sets the failure reload timestamp" do
+          snapshot = subject.metric.collector.snapshot_metric
+          value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:last_failure_timestamp].value
+          expect(value).to be_a(Timestamp)
+        end
 
-      it "increases the failed reload count" do
-        snapshot = subject.metric.collector.snapshot_metric
-        value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:failures].value
-        expect(value).to be > 0
+        it "sets the last reload error" do
+          snapshot = subject.metric.collector.snapshot_metric
+          value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:last_error].value
+          expect(value).to be_a(Hash)
+          expect(value).to include(:message, :backtrace)
+        end
+
+        it "increases the failed reload count" do
+          snapshot = subject.metric.collector.snapshot_metric
+          value = snapshot.metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines][:main][:reloads][:failures].value
+          expect(value).to be > 0
+        end
       end
     end
 

--- a/logstash-core/spec/logstash/pipeline_action/reload_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_action/reload_spec.rb
@@ -19,6 +19,7 @@ describe LogStash::PipelineAction::Reload do
   before do
     clear_data_dir
     pipeline.start
+    allow(agent).to receive(:metric).and_return(metric)
   end
 
   after do

--- a/logstash-core/spec/logstash/pipeline_action/stop_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_action/stop_spec.rb
@@ -11,12 +11,14 @@ describe LogStash::PipelineAction::Stop do
   let(:pipeline) { mock_pipeline_from_string(pipeline_config) }
   let(:pipelines) { { :main => pipeline } }
   let(:agent) { double("agent") }
+  let(:metric) { LogStash::Instrument::NullMetric.new(LogStash::Instrument::Collector.new) }
 
   subject { described_class.new(pipeline_id) }
 
   before do
     clear_data_dir
     pipeline.start
+    allow(agent).to receive(:metric).and_return(metric)
   end
 
   after do


### PR DESCRIPTION
this PR modifies the Stop action to distinguish between a reload and a complete stop.
In the former case, we can selectively clear only the metrics for event counts and plugins. In the latter case, we remove all metrics for that pipeline id.

I also added more tests for the global vs pipeline level metrics.

fixes https://github.com/elastic/logstash/issues/7926