### PR TITLE
Metrics: Witness data model

### DIFF
--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/counter/LongCounter.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/counter/LongCounter.java
@@ -72,4 +72,13 @@ public class LongCounter extends AbstractMetric<Long> implements CounterMetric<L
         dirty = true;
     }
 
+    /**
+     * Resets the counter back to it's initial state.
+     */
+    public void reset(){
+        //replacing since LongAdder#reset "is only effective if there are no concurrent updates", we can not make that guarantee
+        longAdder = new LongAdder();
+        dirty = false;
+    }
+
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/ConfigWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/ConfigWitness.java
@@ -1,0 +1,156 @@
+package org.logstash.instrument.witness;
+
+import org.logstash.instrument.metrics.gauge.BooleanGauge;
+import org.logstash.instrument.metrics.gauge.LongGauge;
+
+/**
+ * The witness for configuration.
+ */
+final public class ConfigWitness {
+
+    private final BooleanGauge deadLetterQueueEnabled;
+    private final BooleanGauge configReloadAutomatic;
+    private final LongGauge batchSize;
+    private final LongGauge workers;
+    private final LongGauge batchDelay;
+    private final LongGauge configReloadInterval;
+    private final Snitch snitch;
+
+    /**
+     * Constructor.
+     */
+    public ConfigWitness() {
+        deadLetterQueueEnabled = new BooleanGauge("dead_letter_queue_enabled");
+        configReloadAutomatic = new BooleanGauge("config_reload_automatic");
+        batchSize = new LongGauge("batch_size");
+        workers = new LongGauge("workers");
+        batchDelay = new LongGauge("batch_delay");
+        configReloadInterval = new LongGauge("config_reload_interval");
+        snitch = new Snitch(this);
+    }
+
+    /**
+     * Sets the configured batch delay
+     *
+     * @param delay the configured batch delay
+     */
+    public void batchDelay(long delay) {
+        batchDelay.set(delay);
+    }
+
+    /**
+     * Sets the configured batch size
+     *
+     * @param size the configured batch size
+     */
+    public void batchSize(long size) {
+        batchSize.set(size);
+    }
+
+    /**
+     * Flag to determine if the configuration is configured for auto reload
+     *
+     * @param isAuto true if the config is set reload, false otherwise
+     */
+    public void configReloadAutomatic(boolean isAuto) {
+        configReloadAutomatic.set(isAuto);
+    }
+
+    /**
+     * The configured reload interval
+     *
+     * @param interval the interval between reloads
+     */
+    public void configReloadInterval(long interval) {
+        configReloadInterval.set(interval);
+    }
+
+    /**
+     * Flag to determine if the dead letter queue is configured to be enabled.
+     *
+     * @param enabled true if enabled, false otherwise
+     */
+    public void deadLetterQueueEnabled(boolean enabled) {
+        deadLetterQueueEnabled.set(enabled);
+    }
+
+    /**
+     * The number of configured workers
+     *
+     * @param workers the number of configured workers
+     */
+    public void workers(long workers) {
+        this.workers.set(workers);
+    }
+
+    /**
+     * Get a reference to associated snitch to get discrete metric values.
+     *
+     * @return the associate {@link Snitch}
+     */
+    public Snitch snitch() {
+        return this.snitch;
+    }
+
+    /**
+     * The snitch for the errors. Used to retrieve discrete metric values.
+     */
+    public static class Snitch {
+        private final ConfigWitness witness;
+
+        Snitch(ConfigWitness witness) {
+            this.witness = witness;
+        }
+
+
+        /**
+         * Gets the configured batch delay
+         * @return the batch delay
+         */
+        public long batchDelay() {
+            return witness.batchDelay.getValue();
+        }
+
+
+        /**
+         * Gets the configured batch size
+         * @return the batch size
+         */
+        public long batchSize() {
+            return witness.batchSize.getValue();
+        }
+
+        /**
+         * Gets if the reload automatic is configured
+         * @return true if configured for automatic, false otherwise
+         */
+        public boolean configReloadAutomatic() {
+            return witness.configReloadAutomatic.getValue();
+        }
+
+        /**
+         * Gets the configured reload interval
+         * @return the configured reload interval
+         */
+        public long configReloadInterval() {
+            return witness.configReloadInterval.getValue();
+        }
+
+        /**
+         * Gets if the dead letter queue is configured to be enabled
+          * @return true if the dead letter queue is configured to be enabled, false otherwise
+         */
+        public boolean deadLetterQueueEnabled() {
+            return witness.deadLetterQueueEnabled.getValue();
+        }
+
+        /**
+         * Gets the number of configured workers
+         * @return the configured number of workers.
+         */
+        public long workers() {
+            return witness.workers.getValue();
+        }
+
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/ErrorWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/ErrorWitness.java
@@ -1,0 +1,100 @@
+package org.logstash.instrument.witness;
+
+import org.logstash.instrument.metrics.gauge.TextGauge;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Witness for errors.
+ */
+public class ErrorWitness {
+
+    private final TextGauge message;
+    private final TextGauge backtrace;
+    private final Snitch snitch;
+
+    public ErrorWitness() {
+        message = new TextGauge("message");
+        backtrace = new TextGauge("backtrace");
+        snitch = new Snitch(this);
+    }
+
+    /**
+     * Stacktrace as a {@link String}
+     *
+     * @param stackTrace The stack trace already formatted for output.
+     */
+    public void backtrace(String stackTrace) {
+        this.backtrace.set(stackTrace);
+    }
+
+    /**
+     * The message of the error.
+     *
+     * @param message human readable error message.
+     */
+    public void message(String message) {
+        this.message.set(message);
+    }
+
+    /**
+     * Get a reference to associated snitch to get discrete metric values.
+     *
+     * @return the associate {@link Snitch}
+     */
+    public Snitch snitch() {
+        return this.snitch;
+    }
+
+    /**
+     * Stacktrace for Java.
+     *
+     * @param throwable The Java {@link Throwable} that contains the stacktrace to output
+     */
+    public void backtrace(Throwable throwable) {
+
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+             PrintStream printStream = new PrintStream(byteArrayOutputStream)) {
+
+            throwable.printStackTrace(printStream);
+            String backtrace = byteArrayOutputStream.toString("UTF-8");
+            this.backtrace.set(backtrace);
+
+        } catch (IOException e) {
+            //A checked exception due to a the close on a ByteArrayOutputStream is simply annoying since it is an empty method.  This will never be called.
+            throw new IllegalStateException("Unknown error", e);
+        }
+    }
+
+    /**
+     * The snitch for the errors. Used to retrieve discrete metric values.
+     */
+    public static class Snitch {
+        private final ErrorWitness witness;
+
+        Snitch(ErrorWitness witness) {
+            this.witness = witness;
+        }
+
+        /**
+         * Gets the error message
+         *
+         * @return the error message
+         */
+        public String message() {
+            return witness.message.getValue();
+        }
+
+        /**
+         * Gets the error stack/back trace
+         *
+         * @return the backtrace as a String
+         */
+        public String backtrace() {
+            return witness.backtrace.getValue();
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/EventsWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/EventsWitness.java
@@ -1,0 +1,184 @@
+package org.logstash.instrument.witness;
+
+import org.logstash.instrument.metrics.counter.LongCounter;
+
+/**
+ * Witness for events.
+ */
+final public class EventsWitness{
+
+    private LongCounter filtered;
+    private LongCounter out;
+    private LongCounter in;
+    private LongCounter duration;
+    private LongCounter queuePushDuration;
+    private final Snitch snitch;
+    private boolean dirty; //here for passivity with legacy Ruby implementation
+
+    /**
+     * Constructor.
+     */
+    public EventsWitness() {
+        filtered = new LongCounter("filtered");
+        out = new LongCounter("out");
+        in = new LongCounter("in");
+        duration = new LongCounter("duration_in_millis");
+        queuePushDuration = new LongCounter("queue_push_duration_in_millis");
+        snitch = new Snitch(this);
+        dirty = false;
+    }
+
+    /**
+     * Add to the existing duration
+     *
+     * @param durationToAdd the amount to add to the existing duration.
+     */
+    public void duration(long durationToAdd) {
+        duration.increment(durationToAdd);
+        dirty = true;
+    }
+
+    /**
+     * increment the filtered count by 1
+     */
+    public void filtered() {
+        filtered.increment();
+        dirty = true;
+    }
+
+    /**
+     * increment the filtered count
+     *
+     * @param count the count to increment by
+     */
+    public void filtered(long count) {
+        filtered.increment(count);
+        dirty = true;
+    }
+
+    /**
+     * Forgets all information related to this witness.
+     */
+    public void forgetAll() {
+        filtered.reset();
+        out.reset();
+        in.reset();
+        duration.reset();
+        queuePushDuration.reset();
+        dirty = false;
+    }
+
+
+    /**
+     * increment the in count by 1
+     */
+    public void in() {
+        in.increment();
+        dirty = true;
+    }
+
+    /**
+     * increment the in count
+     *
+     * @param count the number to increment by
+     */
+    public void in(long count) {
+        in.increment(count);
+        dirty = true;
+    }
+
+    /**
+     * increment the out count by 1
+     */
+    public void out() {
+        out.increment();
+        dirty = true;
+    }
+
+    /**
+     * increment the count
+     *
+     * @param count the number by which to increment by
+     */
+    public void out(long count) {
+        out.increment(count);
+        dirty = true;
+    }
+
+    /**
+     * Get a reference to associated snitch to get discrete metric values.
+     *
+     * @return the associate {@link Snitch}
+     */
+    public Snitch snitch() {
+        return snitch;
+    }
+
+    /**
+     * Add to the existing queue push duration
+     *
+     * @param durationToAdd the duration to add
+     */
+    public void queuePushDuration(long durationToAdd) {
+        queuePushDuration.increment(durationToAdd);
+        dirty = true;
+    }
+
+    /**
+     * The snitch for the {@link EventsWitness}. Allows to read discrete metrics values.
+     */
+    public static class Snitch {
+
+        private final EventsWitness witness;
+
+        Snitch(EventsWitness witness) {
+            this.witness = witness;
+        }
+
+        /**
+         * Gets the duration of the events.
+         *
+         * @return the events duration.
+         */
+        public long duration() {
+            return witness.duration.getValue();
+        }
+
+        /**
+         * Gets the filtered events count.
+         *
+         * @return the count of the filtered events.
+         */
+        public long filtered() {
+            return witness.filtered.getValue();
+
+        }
+
+        /**
+         * Gets the in events count.
+         *
+         * @return the count of the events in.
+         */
+        public long in() {
+            return witness.in.getValue();
+        }
+
+        /**
+         * Gets the out events count.
+         *
+         * @return the count of the events out.
+         */
+        public long out() {
+            return witness.out.getValue();
+        }
+
+        /**
+         * Gets the duration of the queue push
+         * @return the queue push duration.
+         */
+        public long queuePushDuration() {
+            return witness.queuePushDuration.getValue();
+        }
+
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/PipelineWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/PipelineWitness.java
@@ -1,0 +1,113 @@
+package org.logstash.instrument.witness;
+
+/**
+ * A single pipeline witness.
+ */
+final public class PipelineWitness {
+
+    private final ReloadWitness reloadWitness;
+    private final EventsWitness eventsWitness;
+    private final ConfigWitness configWitness;
+    private final PluginsWitness pluginsWitness;
+    private final QueueWitness queueWitness;
+
+    /**
+     * Constructor.
+     *
+     * @param pipelineName The uniquely identifying name of the pipeline.
+     */
+    public PipelineWitness(String pipelineName) {  //NOTE - pipeline name is used as part of the serialization
+        this.reloadWitness = new ReloadWitness();
+        this.eventsWitness = new EventsWitness();
+        this.configWitness = new ConfigWitness();
+        this.pluginsWitness = new PluginsWitness();
+        this.queueWitness = new QueueWitness();
+    }
+
+    /**
+     * Get a reference to associated config witness
+     *
+     * @return the associated {@link ConfigWitness}
+     */
+    public ConfigWitness config() {
+        return configWitness;
+    }
+
+    /**
+     * Get a reference to associated events witness
+     *
+     * @return the associated {@link EventsWitness}
+     */
+    public EventsWitness events() {
+        return eventsWitness;
+    }
+
+    /**
+     * Gets the {@link PluginWitness} for the given id, creates the associated {@link PluginWitness} if needed
+     * @param id the id of the filter
+     * @return the associated {@link PluginWitness} (for method chaining)
+     */
+    public PluginWitness filters(String id) {
+        return pluginsWitness.filters(id);
+    }
+
+    /**
+     * Forgets all events for this witness.
+     */
+    public void forgetEvents() {
+        events().forgetAll();
+    }
+
+    /**
+     * Forgets all plugins for this witness.
+     */
+    public void forgetPlugins() {
+        plugins().forgetAll();
+    }
+
+    /**
+     * Gets the {@link PluginWitness} for the given id, creates the associated {@link PluginWitness} if needed
+     * @param id the id of the input
+     * @return the associated {@link PluginWitness} (for method chaining)
+     */
+    public PluginWitness inputs(String id) {
+        return pluginsWitness.inputs(id);
+    }
+
+    /**
+     * Gets the {@link PluginWitness} for the given id, creates the associated {@link PluginWitness} if needed
+     * @param id the id of the output
+     * @return the associated {@link PluginWitness} (for method chaining)
+     */
+    public PluginWitness outputs(String id) {
+        return pluginsWitness.outputs(id);
+    }
+
+    /**
+     * Get a reference to associated plugins witness
+     *
+     * @return the associated {@link PluginsWitness}
+     */
+    public PluginsWitness plugins() {
+        return pluginsWitness;
+    }
+
+    /**
+     * Get a reference to associated reload witness
+     *
+     * @return the associated {@link ReloadWitness}
+     */
+    public ReloadWitness reloads() {
+        return reloadWitness;
+    }
+
+    /**
+     * Get a reference to associated queue witness
+     *
+     * @return the associated {@link QueueWitness}
+     */
+    public QueueWitness queue() {
+        return queueWitness;
+    }
+}
+

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/PipelinesWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/PipelinesWitness.java
@@ -1,0 +1,30 @@
+package org.logstash.instrument.witness;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Witness for the set of pipelines.
+ */
+final public class PipelinesWitness {
+
+    private final Map<String, PipelineWitness> pipelines;
+
+    /**
+     * Constructor.
+     */
+    public PipelinesWitness() {
+        this.pipelines = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Get a uniquely named pipeline witness. If one does not exist, it will be created.
+     *
+     * @param name The name of the pipeline.
+     * @return the {@link PipelineWitness} identified by the given name.
+     */
+    public PipelineWitness pipeline(String name) {
+        return pipelines.computeIfAbsent(name, k -> new PipelineWitness(k));
+    }
+
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/PluginWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/PluginWitness.java
@@ -1,0 +1,87 @@
+package org.logstash.instrument.witness;
+
+import org.logstash.instrument.metrics.gauge.TextGauge;
+
+/**
+ * Witness for a single plugin.
+ */
+public class PluginWitness {
+
+    private final EventsWitness eventsWitness;
+    private final TextGauge id;
+    private final TextGauge name;
+    private final Snitch snitch;
+
+    /**
+     * Constructor.
+     *
+     * @param id The unique identifier for this plugin.
+     */
+    public PluginWitness(String id) {
+        eventsWitness = new EventsWitness();
+        this.id = new TextGauge("id", id);
+        this.name = new TextGauge("name");
+        this.snitch = new Snitch(this);
+    }
+
+    /**
+     * Get a reference to the associated events witness.
+     *
+     * @return the associated {@link EventsWitness}
+     */
+    public EventsWitness events() {
+        return eventsWitness;
+    }
+
+    /**
+     * Sets the name of this plugin.
+     *
+     * @param name the name of this plugin.
+     * @return an instance of this witness (to allow method chaining)
+     */
+    public PluginWitness name(String name) {
+        this.name.set(name);
+        return this;
+    }
+
+    /**
+     * Get a reference to associated snitch to get discrete metric values.
+     *
+     * @return the associate {@link Snitch}
+     */
+    public Snitch snitch() {
+        return snitch;
+    }
+
+
+    /**
+     * Snitch for a plugin. Provides discrete metric values.
+     */
+    public static class Snitch {
+
+        private final PluginWitness witness;
+
+        Snitch(PluginWitness witness) {
+            this.witness = witness;
+        }
+
+        /**
+         * Gets the id for this plugin.
+         *
+         * @return the id
+         */
+        public String id() {
+            return witness.id.getValue();
+        }
+
+        /**
+         * Gets the name of this plugin
+         *
+         * @return the name
+         */
+        public String name() {
+            return witness.name.getValue();
+        }
+
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/PluginsWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/PluginsWitness.java
@@ -1,0 +1,73 @@
+package org.logstash.instrument.witness;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A Witness for the set of plugins.
+ */
+public class PluginsWitness{
+
+    private final Map<String, PluginWitness> inputs;
+    private final Map<String, PluginWitness> outputs;
+    private final Map<String, PluginWitness> filters;
+
+    /**
+     * Constructor.
+     */
+    public PluginsWitness() {
+
+        this.inputs = new ConcurrentHashMap<>();
+        this.outputs = new ConcurrentHashMap<>();
+        this.filters = new ConcurrentHashMap<>();
+     }
+
+    /**
+     * Gets the {@link PluginWitness} for the given id, creates the associated {@link PluginWitness} if needed
+     * @param id the id of the input
+     * @return the associated {@link PluginWitness} (for method chaining)
+     */
+    public PluginWitness inputs(String id) {
+        return getPlugin(inputs, id);
+    }
+
+    /**
+     * Gets the {@link PluginWitness} for the given id, creates the associated {@link PluginWitness} if needed
+     * @param id the id of the output
+     * @return the associated {@link PluginWitness} (for method chaining)
+     */
+    public PluginWitness outputs(String id) {
+        return getPlugin(outputs, id);
+    }
+
+    /**
+     * Gets the {@link PluginWitness} for the given id, creates the associated {@link PluginWitness} if needed
+     * @param id the id of the filter
+     * @return the associated {@link PluginWitness} (for method chaining)
+     */
+    public PluginWitness filters(String id) {
+        return getPlugin(filters, id);
+    }
+
+    /**
+     * Forgets all information related to the the plugins.
+     */
+    public void forgetAll() {
+        inputs.clear();
+        outputs.clear();
+        filters.clear();
+    }
+
+    /**
+     * Gets or creates the {@link PluginWitness}
+     *
+     * @param plugin the map of the plugin type.
+     * @param id     the id of the plugin
+     * @return existing or new {@link PluginWitness}
+     */
+    private PluginWitness getPlugin(Map<String, PluginWitness> plugin, String id) {
+        return plugin.computeIfAbsent(id, k -> new PluginWitness(k) );
+    }
+
+}
+

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/QueueWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/QueueWitness.java
@@ -1,0 +1,60 @@
+package org.logstash.instrument.witness;
+
+import org.logstash.instrument.metrics.gauge.TextGauge;
+
+/**
+ * Witness for the queue.
+ */
+final public class QueueWitness {
+
+    private final TextGauge type;
+    private final Snitch snitch;
+
+    /**
+     * Constructor.
+     */
+    public QueueWitness() {
+        type = new TextGauge("type");
+        snitch = new Snitch(this);
+    }
+
+    /**
+     * Get a reference to associated snitch to get discrete metric values.
+     *
+     * @return the associate {@link Snitch}
+     */
+    public Snitch snitch() {
+        return snitch;
+    }
+
+    /**
+     * Sets the type of the queue.
+     *
+     * @param type The type of the queue.
+     */
+    public void type(String type) {
+        this.type.set(type);
+    }
+
+    /**
+     * Snitch for queue. Provides discrete metric values.
+     */
+    public static class Snitch {
+
+        private final QueueWitness witness;
+
+        Snitch(QueueWitness witness) {
+            this.witness = witness;
+        }
+
+        /**
+         * Gets the type of queue
+         *
+         * @return the queue type.
+         */
+        public String type() {
+            return witness.type.getValue();
+        }
+
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/ReloadWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/ReloadWitness.java
@@ -1,0 +1,152 @@
+package org.logstash.instrument.witness;
+
+import org.logstash.Timestamp;
+import org.logstash.ext.JrubyTimestampExtLibrary;
+import org.logstash.instrument.metrics.counter.LongCounter;
+import org.logstash.instrument.metrics.gauge.RubyTimeStampGauge;
+
+/**
+ * A witness to record reloads.
+ */
+final public class ReloadWitness {
+
+    private final LongCounter success;
+    private final LongCounter failure;
+    private final ErrorWitness lastError;
+    private final RubyTimeStampGauge lastSuccessTimestamp;
+    private final RubyTimeStampGauge lastFailureTimestamp;
+    private final Snitch snitch;
+
+    /**
+     * Constructor.
+     */
+    public ReloadWitness() {
+        success = new LongCounter("successes");
+        failure = new LongCounter("failures");
+        lastError = new ErrorWitness();
+        lastSuccessTimestamp = new RubyTimeStampGauge("last_success_timestamp");
+        lastFailureTimestamp = new RubyTimeStampGauge("last_failure_timestamp");
+        snitch = new Snitch(this);
+    }
+
+    /**
+     * Obtain a reference to the associated error witness.
+     *
+     * @return the associated {@link ErrorWitness}
+     */
+    public ErrorWitness error() {
+        return lastError;
+    }
+
+    /**
+     * Record a single failure
+     */
+    public void failure() {
+        failure.increment();
+    }
+
+    /**
+     * Record a failure
+     *
+     * @param count the number of failures
+     */
+    public void failures(long count) {
+        failure.increment(count);
+    }
+
+    /**
+     * Record a single success
+     */
+    public void success() {
+        success.increment();
+    }
+
+    /**
+     * Record a success
+     *
+     * @param count the number of successes
+     */
+    public void successes(long count) {
+        success.increment(count);
+    }
+
+    /**
+     * Get a reference to associated snitch to get discrete metric values.
+     *
+     * @return the associate {@link Snitch}
+     */
+    public Snitch snitch() {
+        return snitch;
+    }
+
+    /**
+     * Set the last success timestamp.
+     *
+     * @param timestamp the {@link JrubyTimestampExtLibrary.RubyTimestamp} to set
+     * @deprecated
+     */
+    public void lastSuccessTimestamp(JrubyTimestampExtLibrary.RubyTimestamp timestamp) {
+        lastSuccessTimestamp.set(timestamp);
+    }
+
+    /**
+     * Set the last failure timestamp.
+     *
+     * @param timestamp the {@link JrubyTimestampExtLibrary.RubyTimestamp} to set
+     * @deprecated
+     */
+    public void lastFailureTimestamp(JrubyTimestampExtLibrary.RubyTimestamp timestamp) {
+        lastFailureTimestamp.set(timestamp);
+    }
+
+    /**
+     * The Reload snitch. Provides a means to get discrete metric values.
+     */
+    public static class Snitch {
+
+        private final ReloadWitness witness;
+
+        Snitch(ReloadWitness witness) {
+            this.witness = witness;
+        }
+
+        /**
+         * Get the number of successful reloads
+         *
+         * @return the count of successful reloads
+         */
+        public long successes() {
+            return witness.success.getValue();
+        }
+
+        /**
+         * Get the number of failed reloads
+         *
+         * @return the count of failed reloads
+         */
+        public long failures() {
+            return witness.failure.getValue();
+        }
+
+        /**
+         * Gets the timestamp for the last success reload
+         *
+         * @return {@link Timestamp} of the last successful reload
+         * @deprecated
+         */
+        public Timestamp lastSuccessTimestamp() {
+            return witness.lastSuccessTimestamp.getValue();
+        }
+
+        /**
+         * Gets the timestamp for the last failed reload
+         *
+         * @return {@link Timestamp} of the last failed reload
+         * @deprecated
+         */
+        public Timestamp lastFailureTimestamp() {
+            return witness.lastFailureTimestamp.getValue();
+        }
+
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/Witness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/Witness.java
@@ -1,0 +1,89 @@
+package org.logstash.instrument.witness;
+
+import java.util.Arrays;
+
+/**
+ * <p>Primary entry point for the Witness subsystem. The Witness subsystem is an abstraction for the {@link org.logstash.instrument.metrics.Metric}'s that watches/witnesses what
+ * is happening inside Logstash. </p>
+ * <p>Usage example to increment the events counter for the foo input in the main pipeline:
+ * {@code Witness.instance().pipeline("main").inputs("foo").events().in(1);}
+ * </p>
+ * <p>A Witness may be forgetful. Which means that those witnesses may expose a {@code forget()} method to reset underlying metrics back to it's initial state. </p>
+ * <p>A Witness may also be a snitch. Which means that those witnesses may expose a {@code snitch()} method to retrieve the underlying metric values without JSON serialization.</p>
+ * <p>All Witnesses are capable of serializing their underlying metrics as JSON.</p>
+ */
+final public class Witness {
+
+    private final ReloadWitness reloadWitness;
+    private final EventsWitness eventsWitness;
+    private final PipelinesWitness pipelinesWitness;
+
+    private static Witness _instance;
+
+    /**
+     * Constructor. Consumers should use {@link #instance()} method to obtain an instance of this class.
+     * <p>THIS IS ONLY TO BE USED BY THE RUBY AGENT</p>
+     */
+    public Witness() {
+        this.reloadWitness = new ReloadWitness();
+        this.eventsWitness = new EventsWitness();
+        this.pipelinesWitness = new PipelinesWitness();
+    }
+
+    /**
+     * This is a dirty hack since the {@link Witness} needs to mirror the Ruby agent's lifecycle which, at least for testing, can mean more then 1 instance per JVM, but only 1
+     * active instance at any time.  Exposing this allows Ruby to create the instance for use in it's agent constructor, then set it here for all to use as a singleton.
+     * <p>THIS IS ONLY TO BE USED BY THE RUBY AGENT</p>
+     *
+     * @param __instance The instance of the {@link Witness} to use as the singleton instance that mirror's the agent's lifecycle.
+     */
+    public static void setInstance(Witness __instance) {
+        _instance = __instance;
+    }
+
+    /**
+     * Obtain the singleton instance of the {@link Witness}
+     *
+     * @return the singleton instance of the {@link Witness}
+     * @throws IllegalStateException if attempted to be used before being set.
+     */
+    public static Witness instance() {
+        if (_instance == null) {
+            throw new IllegalStateException("The stats witness instance must be set before it used. Called from: " + Arrays.toString(new Throwable().getStackTrace()));
+        }
+        return _instance;
+    }
+
+    public EventsWitness events() {
+        return eventsWitness;
+    }
+
+    /**
+     * Obtain a reference to the associated reload witness.
+     *
+     * @return The associated {@link ReloadWitness}
+     */
+    public ReloadWitness reloads() {
+        return reloadWitness;
+    }
+
+    /**
+     * Obtain a reference to the associated pipelines witness. Consumers may use {@link #pipeline(String)} as a shortcut to this method.
+     *
+     * @return The associated {@link PipelinesWitness}
+     */
+    public PipelinesWitness pipelines() {
+        return pipelinesWitness;
+    }
+
+    /**
+     * Shortcut method for {@link PipelinesWitness#pipeline(String)}
+     *
+     * @param name The name of the pipeline witness to retrieve.
+     * @return the associated {@link PipelineWitness} for the given name
+     */
+    public PipelineWitness pipeline(String name) {
+        return pipelinesWitness.pipeline(name);
+    }
+
+}

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/ConfigWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/ConfigWitnessTest.java
@@ -1,0 +1,61 @@
+package org.logstash.instrument.witness;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+/**
+ * Unit tests for {@link ConfigWitness}
+ */
+public class ConfigWitnessTest {
+
+    private ConfigWitness witness;
+
+    @Before
+    public void setup() {
+        witness = new ConfigWitness();
+    }
+
+    @Test
+    public void testBatchDelay() {
+        witness.batchDelay(99);
+        assertThat(witness.snitch().batchDelay()).isEqualTo(99);
+    }
+
+    @Test
+    public void testBatchSize() {
+        witness.batchSize(98);
+        assertThat(witness.snitch().batchSize()).isEqualTo(98);
+    }
+
+    @Test
+    public void testConfigReloadAutomatic() {
+        witness.configReloadAutomatic(true);
+        assertThat(witness.snitch().configReloadAutomatic()).isTrue();
+        witness.configReloadAutomatic(false);
+        assertThat(witness.snitch().configReloadAutomatic()).isFalse();
+    }
+
+    @Test
+    public void testConfigReloadInterval() {
+        witness.configReloadInterval(97);
+        assertThat(witness.snitch().configReloadInterval()).isEqualTo(97);
+    }
+
+    @Test
+    public void testDeadLetterQueueEnabled() {
+        witness.deadLetterQueueEnabled(true);
+        assertThat(witness.snitch().deadLetterQueueEnabled()).isTrue();
+        witness.deadLetterQueueEnabled(false);
+        assertThat(witness.snitch().deadLetterQueueEnabled()).isFalse();
+    }
+
+    @Test
+    public void testWorkers() {
+        witness.workers(96);
+        assertThat(witness.snitch().workers()).isEqualTo(96);
+    }
+
+}

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/ErrorWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/ErrorWitnessTest.java
@@ -1,0 +1,39 @@
+package org.logstash.instrument.witness;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link ErrorWitness}
+ */
+public class ErrorWitnessTest {
+
+    private ErrorWitness witness;
+
+    @Before
+    public void setup() {
+        witness = new ErrorWitness();
+    }
+
+    @Test
+    public void backtrace() {
+        //as String
+        witness.backtrace("foo");
+        assertThat(witness.snitch().backtrace()).isEqualTo("foo");
+
+        //as Exception
+        RuntimeException exception = new RuntimeException("foobar");
+        witness.backtrace(exception);
+        for(StackTraceElement element : exception.getStackTrace()){
+            assertThat(witness.snitch().backtrace()).contains(element.toString());
+        }
+    }
+
+    @Test
+    public void message() {
+        witness.message("baz");
+        assertThat(witness.snitch().message()).isEqualTo("baz");
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/EventsWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/EventsWitnessTest.java
@@ -1,0 +1,81 @@
+package org.logstash.instrument.witness;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link EventsWitness}
+ */
+public class EventsWitnessTest {
+
+    private EventsWitness witness;
+
+    @Before
+    public void setup() {
+        witness = new EventsWitness();
+    }
+
+    @Test
+    public void testDuration() {
+        witness.duration(99);
+        assertThat(witness.snitch().duration()).isEqualTo(99);
+        witness.duration(1);
+        assertThat(witness.snitch().duration()).isEqualTo(100);
+    }
+
+    @Test
+    public void testFiltered() {
+        witness.filtered(88);
+        assertThat(witness.snitch().filtered()).isEqualTo(88);
+        witness.filtered();
+        assertThat(witness.snitch().filtered()).isEqualTo(89);
+    }
+
+    @Test
+    public void testForget() {
+        witness.duration(99);
+        witness.filtered(88);
+        witness.in(66);
+        witness.out(55);
+        witness.queuePushDuration(44);
+
+        assertThat(witness.snitch().duration()).isEqualTo(99);
+        assertThat(witness.snitch().in()).isEqualTo(66);
+        assertThat(witness.snitch().out()).isEqualTo(55);
+        assertThat(witness.snitch().queuePushDuration()).isEqualTo(44);
+
+        witness.forgetAll();
+
+        assertThat(witness.snitch().duration()).isEqualTo(0);
+        assertThat(witness.snitch().in()).isEqualTo(0);
+        assertThat(witness.snitch().out()).isEqualTo(0);
+        assertThat(witness.snitch().queuePushDuration()).isEqualTo(0);
+    }
+
+    @Test
+    public void testIn() {
+        witness.in(66);
+        assertThat(witness.snitch().in()).isEqualTo(66);
+        witness.in();
+        assertThat(witness.snitch().in()).isEqualTo(67);
+    }
+
+    @Test
+    public void testOut() {
+        witness.out(55);
+        assertThat(witness.snitch().out()).isEqualTo(55);
+        witness.out();
+        assertThat(witness.snitch().out()).isEqualTo(56);
+    }
+
+    @Test
+    public void testQueuePushDuration() {
+        witness.queuePushDuration(44);
+        assertThat(witness.snitch().queuePushDuration()).isEqualTo(44);
+        witness.queuePushDuration(1);
+        assertThat(witness.snitch().queuePushDuration()).isEqualTo(45);
+    }
+
+}

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/PipelineWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/PipelineWitnessTest.java
@@ -1,0 +1,65 @@
+package org.logstash.instrument.witness;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link PipelineWitness}
+ */
+public class PipelineWitnessTest {
+
+    private PipelineWitness witness;
+
+    @Before
+    public void setup(){
+        witness = new PipelineWitness("default");
+    }
+
+
+    @Test
+    public void testNotNull(){
+        assertThat(witness.inputs("123")).isNotNull();
+        assertThat(witness.filters("456")).isNotNull();
+        assertThat(witness.outputs("789")).isNotNull();
+        assertThat(witness.events()).isNotNull();
+        assertThat(witness.plugins()).isNotNull();
+        assertThat(witness.queue()).isNotNull();
+        assertThat(witness.config()).isNotNull();
+        assertThat(witness.reloads()).isNotNull();
+    }
+
+    @Test
+    public void testForget(){
+        witness.inputs("123").events().in(99);
+        witness.filters("456").events().in(98);
+        witness.outputs("789").events().in(97);
+        assertThat(witness.inputs("123").events().snitch().in()).isEqualTo(99);
+        assertThat(witness.filters("456").events().snitch().in()).isEqualTo(98);
+        assertThat(witness.outputs("789").events().snitch().in()).isEqualTo(97);
+
+        witness.events().in(99);
+        witness.events().filtered(98);
+        witness.events().out(97);
+        assertThat(witness.events().snitch().in()).isEqualTo(99);
+        assertThat(witness.events().snitch().filtered()).isEqualTo(98);
+        assertThat(witness.events().snitch().out()).isEqualTo(97);
+
+        witness.queue().type("memory");
+
+        witness.forgetPlugins();
+        witness.forgetEvents();
+
+        assertThat(witness.inputs("123").events().snitch().in())
+                .isEqualTo(witness.filters("456").events().snitch().in())
+                .isEqualTo(witness.outputs("789").events().snitch().in())
+                .isEqualTo(witness.events().snitch().in())
+                .isEqualTo(witness.events().snitch().filtered())
+                .isEqualTo(witness.events().snitch().out())
+                .isEqualTo(0);
+
+        assertThat(witness.queue().snitch().type()).isEqualTo("memory");
+    }
+
+}

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/PipelinesWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/PipelinesWitnessTest.java
@@ -1,0 +1,29 @@
+package org.logstash.instrument.witness;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+/**
+ * Unit tests for {@link PipelinesWitness}
+ */
+public class PipelinesWitnessTest {
+
+    private PipelinesWitness witness;
+
+    @Before
+    public void setup() {
+        witness = new PipelinesWitness();
+    }
+
+    @Test
+    public void testPipeline() {
+        //once to create
+        assertThat(witness.pipeline("default")).isNotNull();
+        //again to assert it can pull from the map
+        assertThat(witness.pipeline("default")).isNotNull();
+    }
+
+}

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/PluginWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/PluginWitnessTest.java
@@ -1,0 +1,32 @@
+package org.logstash.instrument.witness;
+
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link PluginWitness}
+ */
+public class PluginWitnessTest {
+
+    private PluginWitness witness;
+
+    @Before
+    public void setup(){
+        witness = new PluginWitness("123");
+        assertThat(witness.snitch().id()).isEqualTo("123");
+    }
+
+    @Test
+    public void testName(){
+        assertThat(witness.name("abc")).isEqualTo(witness);
+        assertThat(witness.snitch().name()).isEqualTo("abc");
+    }
+
+    @Test
+    public void testEvents(){
+        assertThat(witness.events()).isNotNull();
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/PluginsWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/PluginsWitnessTest.java
@@ -1,0 +1,36 @@
+package org.logstash.instrument.witness;
+
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link PluginsWitness}
+ */
+public class PluginsWitnessTest {
+
+    private PluginsWitness witness;
+
+    @Before
+    public void setup(){
+        witness = new PluginsWitness();
+    }
+
+    @Test
+    public void testForget(){
+        witness.inputs("1").events().in(99);
+        assertThat(witness.inputs("1").events().snitch().in()).isEqualTo(99);
+        witness.filters("1").events().in(98);
+        assertThat(witness.filters("1").events().snitch().in()).isEqualTo(98);
+        witness.outputs("1").events().in(97);
+        assertThat(witness.outputs("1").events().snitch().in()).isEqualTo(97);
+
+        witness.forgetAll();
+
+        assertThat(witness.inputs("1").events().snitch().in()).isEqualTo(0);
+        assertThat(witness.filters("1").events().snitch().filtered()).isEqualTo(0);
+        assertThat(witness.outputs("1").events().snitch().in()).isEqualTo(0);
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/QueueWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/QueueWitnessTest.java
@@ -1,0 +1,26 @@
+package org.logstash.instrument.witness;
+
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link QueueWitness}
+ */
+public class QueueWitnessTest {
+
+    private QueueWitness witness;
+
+    @Before
+    public void setup(){
+        witness = new QueueWitness();
+    }
+    @Test
+    public void testType(){
+        witness.type("memory");
+        assertThat(witness.snitch().type()).isEqualTo("memory");
+    }
+
+}

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/ReloadWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/ReloadWitnessTest.java
@@ -1,0 +1,57 @@
+package org.logstash.instrument.witness;
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.logstash.Timestamp;
+import org.logstash.ext.JrubyTimestampExtLibrary;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ReloadWitness}
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ReloadWitnessTest {
+
+    private ReloadWitness witness;
+    private Timestamp timestamp = new Timestamp();
+    @Mock
+    JrubyTimestampExtLibrary.RubyTimestamp rubyTimestamp;
+
+    @Before
+    public void setup(){
+        witness = new ReloadWitness();
+        when(rubyTimestamp.getTimestamp()).thenReturn(timestamp);
+    }
+
+    @Test
+    public void testSuccess(){
+        witness.success();
+        witness.lastSuccessTimestamp(rubyTimestamp);
+        assertThat(witness.snitch().successes()).isEqualTo(1);
+        assertThat(witness.snitch().lastSuccessTimestamp()).isEqualTo(timestamp);
+        witness.successes(99);
+        assertThat(witness.snitch().successes()).isEqualTo(100);
+    }
+
+    @Test
+    public void testFailure(){
+        witness.failure();
+        witness.lastFailureTimestamp(rubyTimestamp);
+        assertThat(witness.snitch().failures()).isEqualTo(1);
+        assertThat(witness.snitch().lastFailureTimestamp()).isEqualTo(timestamp);
+        witness.failures(99);
+        assertThat(witness.snitch().failures()).isEqualTo(100);
+    }
+
+    @Test
+    public void testError(){
+        witness.error().message("foo");
+        assertThat(witness.error().snitch().message()).isEqualTo("foo");
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/WitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/WitnessTest.java
@@ -1,0 +1,40 @@
+package org.logstash.instrument.witness;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link Witness}
+ */
+public class WitnessTest {
+    private Witness witness;
+
+    @Before
+    public void setup(){
+        Witness.setInstance(null);
+    }
+
+    @Test
+    public void testInstance(){
+        witness = new Witness();
+        Witness.setInstance(witness);
+        assertThat(Witness.instance()).isEqualTo(witness);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testNoInstanceError(){
+        Witness.instance();
+    }
+
+    @Test
+    public void testNotNull() {
+        witness = new Witness();
+        Witness.setInstance(witness);
+        assertThat(witness.events()).isNotNull();
+        assertThat(witness.reloads()).isNotNull();
+        assertThat(witness.pipelines()).isNotNull();
+        assertThat(witness.pipeline("foo")).isNotNull();
+    }
+}


### PR DESCRIPTION
Note to reviewer(s): I pulled the serialization code out of this commit to try to keep the review smaller. There may be a few very minor things still in here that is only used by the serialization logic (which is not part of this PR). 

The code here is basically just setters and getters. Not much (if any) business logic. 

-----------

The role of Witness is to provide an API record state of what is happening inside of Logstash, and provide means to serialize the data for consumption (not included in the commit). The Witness is implemented by chaining methods with a singleton root. For example:

`Witness.instance().pipeline("main").inputs("foo").events().in(1)`

Can be used to express that for the foo input in the main pipeline, 1 new event has been seen.

Witnesses may also have a snitch method, which allows the witness to snitch (tell others) the discrete values of the metrics. A snitch method is basically the getter. For example:

`Witness.instance().pipeline("main").inputs("foo").events().snitch().in()`

Tells you you how many events have been witnessed for the foo input in the main pipeline. In practice this the snitch is really only used for testing, but may be useful as just a standard set/get type operations. Serialization to JSON (not included in this commit) is the primary means to get data out of a Witness.

Some workflows require that a Witness forgets what it saw, for example during a pipeline reload. In these cases the Witness may completely or partially forget the data they have seen. This is implemented with a forget method. For example:

`Witness.instance().pipeline("main").inputs("foo").events().forget().all();`

Part of #7788 