### PR TITLE
MINOR: Cleanup dead IO code

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/BufferedChecksumStreamInput.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/BufferedChecksumStreamInput.java
@@ -19,17 +19,6 @@ public final class BufferedChecksumStreamInput extends StreamInput {
         this.digest = new BufferedChecksum(new CRC32());
     }
 
-    public BufferedChecksumStreamInput(StreamInput in, BufferedChecksumStreamInput reuse) {
-        this.in = in;
-        if (reuse == null ) {
-            this.digest = new BufferedChecksum(new CRC32());
-        } else {
-            this.digest = reuse.digest;
-            digest.reset();
-            this.skipBuffer = reuse.skipBuffer;
-        }
-    }
-
     public long getChecksum() {
         return this.digest.getValue();
     }

--- a/logstash-core/src/main/java/org/logstash/common/io/ByteArrayStreamOutput.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/ByteArrayStreamOutput.java
@@ -1,7 +1,5 @@
 package org.logstash.common.io;
 
-import java.nio.ByteBuffer;
-
 public class ByteArrayStreamOutput extends StreamOutput {
     private byte[] bytes;
 
@@ -10,18 +8,6 @@ public class ByteArrayStreamOutput extends StreamOutput {
 
     public ByteArrayStreamOutput(byte[] bytes) {
         reset(bytes);
-    }
-
-    public ByteArrayStreamOutput(ByteBuffer bytebuffer) {
-        reset(bytebuffer.array());
-    }
-
-    public ByteArrayStreamOutput(ByteBuffer bytebuffer, int offset, int len) {
-        reset(bytebuffer.array(), offset, len);
-    }
-
-    public ByteArrayStreamOutput(byte[] bytes, int offset, int len) {
-        reset(bytes, offset, len);
     }
 
     public void reset(byte[] bytes) {

--- a/logstash-core/src/main/java/org/logstash/common/io/ByteBufferStreamInput.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/ByteBufferStreamInput.java
@@ -67,10 +67,6 @@ public class ByteBufferStreamInput extends StreamInput {
         buffer.position(position);
     }
 
-    public void rewind() {
-        buffer.rewind();
-    }
-
     @Override
     public int available() throws IOException {
         return buffer.remaining();

--- a/logstash-core/src/main/java/org/logstash/common/io/StreamInput.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/StreamInput.java
@@ -31,41 +31,6 @@ public abstract class StreamInput extends InputStream {
         return ((readByte() & 0xFF) << 24) | ((readByte() & 0xFF) << 16)
                 | ((readByte() & 0xFF) << 8) | (readByte() & 0xFF);
     }
-    
-    /**
-     * Reads an int stored in variable-length format.  Reads between one and
-     * five bytes.  Smaller values take fewer bytes.  Negative numbers
-     * will always use all 5 bytes and are therefore better serialized
-     * using {@link #readInt}
-     *
-     * @return integer value from var-int formatted bytes
-     * @throws IOException if an error occurs while reading content
-     */
-    public int readVInt() throws IOException {
-        byte b = readByte();
-        int i = b & 0x7F;
-        if ((b & 0x80) == 0) {
-            return i;
-        }
-        b = readByte();
-        i |= (b & 0x7F) << 7;
-        if ((b & 0x80) == 0) {
-            return i;
-        }
-        b = readByte();
-        i |= (b & 0x7F) << 14;
-        if ((b & 0x80) == 0) {
-            return i;
-        }
-        b = readByte();
-        i |= (b & 0x7F) << 21;
-        if ((b & 0x80) == 0) {
-            return i;
-        }
-        b = readByte();
-        assert (b & 0x80) == 0;
-        return i | ((b & 0x7F) << 28);
-    }
 
     /**
      * Reads two bytes and returns a short.

--- a/logstash-core/src/main/java/org/logstash/common/io/StreamOutput.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/StreamOutput.java
@@ -16,34 +16,6 @@ public abstract class StreamOutput extends OutputStream {
     public abstract void reset() throws IOException;
 
     /**
-     * Writes an int in a variable-length format.  Writes between one and
-     * five bytes.  Smaller values take fewer bytes.  Negative numbers
-     * will always use all 5 bytes and are therefore better serialized
-     * using {@link #writeInt}
-     *
-     * @param i The integer to write
-     * @throws IOException if an error occurs while writing content
-     */
-    public void writeVInt(int i) throws IOException {
-        while ((i & ~0x7F) != 0) {
-            writeByte((byte) ((i & 0x7f) | 0x80));
-            i >>>= 7;
-        }
-        writeByte((byte) i);
-    }
-
-    /**
-     * Writes a short as two bytes.
-     *
-     * @param i The short to write
-     * @throws IOException if an error occurs while writing content
-     */
-    public void writeShort(short i) throws IOException {
-        writeByte((byte)(i >>  8));
-        writeByte((byte) i);
-    }
-
-    /**
      * Writes an int as four bytes.
      *
      * @param i The int to write
@@ -54,13 +26,6 @@ public abstract class StreamOutput extends OutputStream {
         writeByte((byte) (i >> 16));
         writeByte((byte) (i >> 8));
         writeByte((byte) i);
-    }
-
-    public void writeIntArray(int[] values) throws IOException {
-        writeVInt(values.length);
-        for (int value : values) {
-            writeInt(value);
-        }
     }
 
     /**


### PR DESCRIPTION
Trivial cleanup, these are shown as dead code in Idea + removing them doesn't break tests.
=> No need to keep 100 lines of dead code around

PS: I think this is just code that was copied from ES and not cleaned up and this was never used.