### PR TITLE
fix debug logging messages with thread values

### DIFF
--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -803,7 +803,7 @@ module LogStash; class Pipeline < BasePipeline
 
   def default_logging_keys(other_keys = {})
     keys = super
-    keys[:thread] = thread.inspect if thread
+    keys[:thread] ||= thread.inspect if thread
     keys
   end
 


### PR DESCRIPTION
Examples of current broken logging messages in debug due to `default_logging_keys` overwriting the `:thread` key:

```
-08-09T11:05:38,151][DEBUG][logstash.pipeline        ] Pushing shutdown {:pipeline_id=>"main", :thread=>"#<Thread:0x1b275012 run>"}
[2017-08-09T11:05:38,156][DEBUG][logstash.pipeline        ] Pushing shutdown {:pipeline_id=>"main", :thread=>"#<Thread:0x1b275012 run>"}
[2017-08-09T11:05:38,156][DEBUG][logstash.pipeline        ] Pushing shutdown {:pipeline_id=>"main", :thread=>"#<Thread:0x1b275012 run>"}
[2017-08-09T11:05:38,157][DEBUG][logstash.pipeline        ] Pushing shutdown {:pipeline_id=>"main", :thread=>"#<Thread:0x1b275012 run>"}
[2017-08-09T11:05:38,162][DEBUG][logstash.pipeline        ] Shutdown waiting for worker thread {:pipeline_id=>"main", :thread=>"#<Thread:0x1b275012 run>"}
[2017-08-09T11:05:38,202][DEBUG][logstash.pipeline        ] Shutdown waiting for worker thread {:pipeline_id=>"main", :thread=>"#<Thread:0x1b275012 run>"}
[2017-08-09T11:05:38,202][DEBUG][logstash.pipeline        ] Shutdown waiting for worker thread {:pipeline_id=>"main", :thread=>"#<Thread:0x1b275012 run>"}
[2017-08-09T11:05:38,203][DEBUG][logstash.pipeline        ] Worker closed {:pipeline_id=>"main", :thread=>"#<Thread:0x1b275012 run>"}
[2017-08-09T11:05:38,203][DEBUG][logstash.pipeline        ] Shutdown waiting for worker thread {:pipeline_id=>"main", :thread=>"#<Thread:0x1b275012 run>"}
```

With this fix:

```
[2017-08-09T11:23:02,006][DEBUG][logstash.pipeline        ] Pushing shutdown {:pipeline_id=>"main", :thread=>"#<Thread:0x3f8b5ed7@[main]>worker0 run>"}
[2017-08-09T11:23:02,008][DEBUG][logstash.pipeline        ] Pushing shutdown {:pipeline_id=>"main", :thread=>"#<Thread:0x3c04e663@[main]>worker1 run>"}
[2017-08-09T11:23:02,009][DEBUG][logstash.pipeline        ] Pushing shutdown {:pipeline_id=>"main", :thread=>"#<Thread:0x454b0aa9@[main]>worker2 run>"}
[2017-08-09T11:23:02,009][DEBUG][logstash.pipeline        ] Pushing shutdown {:pipeline_id=>"main", :thread=>"#<Thread:0x471a65bc@[main]>worker3 run>"}
[2017-08-09T11:23:02,014][DEBUG][logstash.pipeline        ] Shutdown waiting for worker thread {:pipeline_id=>"main", :thread=>"#<Thread:0x3f8b5ed7@[main]>worker0 run>"}
[2017-08-09T11:23:02,062][DEBUG][logstash.pipeline        ] Shutdown waiting for worker thread {:pipeline_id=>"main", :thread=>"#<Thread:0x3c04e663@[main]>worker1 dead>"}
[2017-08-09T11:23:02,063][DEBUG][logstash.pipeline        ] Shutdown waiting for worker thread {:pipeline_id=>"main", :thread=>"#<Thread:0x454b0aa9@[main]>worker2 dead>"}
[2017-08-09T11:23:02,064][DEBUG][logstash.pipeline        ] Shutdown waiting for worker thread {:pipeline_id=>"main", :thread=>"#<Thread:0x471a65bc@[main]>worker3 dead>"}
```