### PR TITLE
several improvements to starting and stopping logging messaging

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -81,7 +81,7 @@ class LogStash::Agent
 
   def execute
     @thread = Thread.current # this var is implicitly used by Stud.stop?
-    logger.debug("starting agent")
+    logger.debug("Starting agent")
 
     start_webserver
 
@@ -272,24 +272,6 @@ class LogStash::Agent
     end
   end
 
-  def close_pipeline(id)
-    with_pipelines do |pipelines|
-      pipeline = pipelines[id]
-      if pipeline
-        @logger.warn("closing pipeline", :id => id)
-        pipeline.close
-      end
-    end
-  end
-
-  def close_pipelines
-    with_pipelines do |pipelines|
-      pipelines.each  do |id, _|
-        close_pipeline(id)
-      end
-    end
-  end
-
   private
   def transition_to_stopped
     @running.make_false
@@ -310,11 +292,9 @@ class LogStash::Agent
   # for other tasks.
   #
   def converge_state(pipeline_actions)
-    logger.debug("Converging pipelines")
+    logger.debug("Converging pipelines state", :actions_count => pipeline_actions.size)
 
     converge_result = LogStash::ConvergeResult.new(pipeline_actions.size)
-
-    logger.debug("Needed actions to converge", :actions_count => pipeline_actions.size) unless pipeline_actions.empty?
 
     pipeline_actions.each do |action|
       # We execute every task we need to converge the current state of pipelines
@@ -409,7 +389,7 @@ class LogStash::Agent
     @collector = LogStash::Instrument::Collector.new
 
     @metric = if collect_metrics?
-      @logger.debug("Agent: Configuring metric collection")
+      @logger.debug("Setting up metric collection")
       LogStash::Instrument::Metric.new(@collector)
     else
       LogStash::Instrument::NullMetric.new(@collector)

--- a/logstash-core/lib/logstash/config/source/multi_local.rb
+++ b/logstash-core/lib/logstash/config/source/multi_local.rb
@@ -31,9 +31,11 @@ module LogStash module Config module Source
     end
 
     def match?
+      if modules_cli? || modules? || config_string? || config_path?
+        return false
+      end
       detect_pipelines if !@detect_pipelines_called
-      # see basic settings predicates and getters defined in the base class
-      return !(invalid_pipelines_detected? || modules_cli? || modules? || config_string? || config_path?)
+      return !(invalid_pipelines_detected?)
     end
 
     def invalid_pipelines_detected?
@@ -41,10 +43,10 @@ module LogStash module Config module Source
     end
 
     def config_conflict?
-      detect_pipelines if !@detect_pipelines_called
       @conflict_messages.clear
       # are there any auto-reload conflicts?
       if !(modules_cli? || modules? || config_string? || config_path?)
+        detect_pipelines if !@detect_pipelines_called
         if @detected_marker.nil?
           @conflict_messages << I18n.t("logstash.runner.config-pipelines-failed-read", :path => pipelines_yaml_location)
         elsif @detected_marker == false

--- a/logstash-core/lib/logstash/inputs/base.rb
+++ b/logstash-core/lib/logstash/inputs/base.rb
@@ -84,7 +84,7 @@ class LogStash::Inputs::Base < LogStash::Plugin
 
   public
   def do_stop
-    @logger.debug("stopping", :plugin => self.class.name)
+    @logger.debug("Stopping", :plugin => self.class.name)
     @stop_called.make_true
     stop
   end

--- a/logstash-core/lib/logstash/instrument/periodic_poller/base.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/base.rb
@@ -27,7 +27,7 @@ module LogStash module Instrument module PeriodicPoller
       if exception.is_a?(Concurrent::TimeoutError)
         # On a busy system this can happen, we just log it as a debug
         # event instead of an error, Some of the JVM calls can take a long time or block.
-        logger.debug("PeriodicPoller: Timeout exception",
+        logger.debug("Timeout exception",
                 :poller => self,
                 :result => result,
                 :polling_timeout => @options[:polling_timeout],
@@ -35,7 +35,7 @@ module LogStash module Instrument module PeriodicPoller
                 :exception => exception.class,
                 :executed_at => time)
       else
-        logger.error("PeriodicPoller: exception",
+        logger.error("Exception",
                 :poller => self,
                 :result => result,
                 :exception => exception.class,
@@ -50,7 +50,7 @@ module LogStash module Instrument module PeriodicPoller
     end
 
     def start
-      logger.debug("PeriodicPoller: Starting",
+      logger.debug("Starting",
                    :polling_interval => @options[:polling_interval],
                    :polling_timeout => @options[:polling_timeout]) if logger.debug?
 
@@ -59,7 +59,7 @@ module LogStash module Instrument module PeriodicPoller
     end
 
     def stop
-      logger.debug("PeriodicPoller: Stopping")
+      logger.debug("Stopping")
       @task.shutdown
     end
 

--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -73,7 +73,7 @@ class LogStash::Plugin
   # close is called during shutdown, after the plugin worker
   # main task terminates
   def do_close
-    @logger.debug("closing", :plugin => self.class.name)
+    @logger.debug("Closing", :plugin => self.class.name)
     close
   end
 

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -58,9 +58,9 @@ en:
       sighup: >-
         SIGHUP received.
       sigint: >-
-        SIGINT received. Shutting down the agent.
+        SIGINT received. Shutting down.
       sigterm: >-
-        SIGTERM received. Shutting down the agent.
+        SIGTERM received. Shutting down.
       slow_shutdown: |-
         Received shutdown signal, but pipeline is still waiting for in-flight events
         to be processed. Sending another ^C will force quit Logstash, but this may cause
@@ -327,8 +327,6 @@ en:
         name: |+
           Specify the name of this logstash instance, if no value is given
           it will default to the current hostname.
-        agent: |+
-          Specify an alternate agent plugin name.
         config_debug: |+
           Print the compiled config ruby code out as a debug log (you must also have --log.level=debug enabled).
           WARNING: This will include any 'password' options passed to plugin configs as plaintext, and may result


### PR DESCRIPTION
This PRs ensures the text of the logging messages makes sense for an ordering perspective, makes log message formats a bit more consistent and adjusts some logging levels.
Below you can see a comparison between the two, look specially at the shutdown sequence messages.

Before:

```
/tmp/logstash (git)-[master] % bin/logstash -e "input { generator { count => 1 } }" --log.level=debug
/tmp/logstash/vendor/bundle/jruby/2.3.0/gems/manticore-0.6.1-java/lib/manticore/client.rb:108: warning: already initialized constant DEFAULT_MAX_POOL_SIZE
/tmp/logstash/vendor/bundle/jruby/2.3.0/gems/manticore-0.6.1-java/lib/manticore/client.rb:110: warning: already initialized constant DEFAULT_REQUEST_TIMEOUT
/tmp/logstash/vendor/bundle/jruby/2.3.0/gems/manticore-0.6.1-java/lib/manticore/client.rb:111: warning: already initialized constant DEFAULT_SOCKET_TIMEOUT
/tmp/logstash/vendor/bundle/jruby/2.3.0/gems/manticore-0.6.1-java/lib/manticore/client.rb:112: warning: already initialized constant DEFAULT_CONNECT_TIMEOUT
/tmp/logstash/vendor/bundle/jruby/2.3.0/gems/manticore-0.6.1-java/lib/manticore/client.rb:113: warning: already initialized constant DEFAULT_MAX_REDIRECTS
/tmp/logstash/vendor/bundle/jruby/2.3.0/gems/manticore-0.6.1-java/lib/manticore/client.rb:114: warning: already initialized constant DEFAULT_EXPECT_CONTINUE
/tmp/logstash/vendor/bundle/jruby/2.3.0/gems/manticore-0.6.1-java/lib/manticore/client.rb:115: warning: already initialized constant DEFAULT_STALE_CHECK
/tmp/logstash/vendor/bundle/jruby/2.3.0/gems/manticore-0.6.1-java/lib/manticore/client.rb:590: warning: already initialized constant ISO_8859_1
/tmp/logstash/vendor/bundle/jruby/2.3.0/gems/manticore-0.6.1-java/lib/manticore/client.rb:641: warning: already initialized constant KEY_EXTRACTION_REGEXP
Sending Logstash's logs to /tmp/logstash/logs which is now configured via log4j2.properties
[2017-08-09T14:20:06,531][DEBUG][logstash.plugins.registry] Adding plugin to the registry {:name=>"fb_apache", :type=>:modules, :class=>#<LogStash::Modules::Scaffold:0x58390e40 @module_name="fb_apache", @directory="/tmp/logstash/modules/fb_apache/configuration", @kibana_version_parts=["6", "0", "0"]>}
[2017-08-09T14:20:06,551][DEBUG][logstash.plugins.registry] Adding plugin to the registry {:name=>"netflow", :type=>:modules, :class=>#<LogStash::Modules::Scaffold:0x3d04e5de @module_name="netflow", @directory="/tmp/logstash/modules/netflow/configuration", @kibana_version_parts=["6", "0", "0"]>}
[2017-08-09T14:20:06,698][INFO ][logstash.setting.writabledirectory] Creating directory {:setting=>"path.dead_letter_queue", :path=>"/tmp/logstash/data/dead_letter_queue"}
[2017-08-09T14:20:06,811][DEBUG][logstash.runner          ] -------- Logstash Settings (* means modified) ---------
[2017-08-09T14:20:06,811][DEBUG][logstash.runner          ] node.name: "Joaos-MBP-5.lan"
[2017-08-09T14:20:06,811][DEBUG][logstash.runner          ] path.data: "/tmp/logstash/data"
[2017-08-09T14:20:06,811][DEBUG][logstash.runner          ] *config.string: "input { generator { count => 1 } }"
[2017-08-09T14:20:06,812][DEBUG][logstash.runner          ] modules.cli: []
[2017-08-09T14:20:06,812][DEBUG][logstash.runner          ] modules: []
[2017-08-09T14:20:06,812][DEBUG][logstash.runner          ] config.test_and_exit: false
[2017-08-09T14:20:06,812][DEBUG][logstash.runner          ] config.reload.automatic: false
[2017-08-09T14:20:06,812][DEBUG][logstash.runner          ] config.reload.interval: 3000000000
[2017-08-09T14:20:06,812][DEBUG][logstash.runner          ] config.support_escapes: false
[2017-08-09T14:20:06,813][DEBUG][logstash.runner          ] metric.collect: true
[2017-08-09T14:20:06,813][DEBUG][logstash.runner          ] pipeline.id: "main"
[2017-08-09T14:20:06,814][DEBUG][logstash.runner          ] pipeline.system: false
[2017-08-09T14:20:06,814][DEBUG][logstash.runner          ] pipeline.workers: 4
[2017-08-09T14:20:06,814][DEBUG][logstash.runner          ] pipeline.output.workers: 1
[2017-08-09T14:20:06,814][DEBUG][logstash.runner          ] pipeline.batch.size: 125
[2017-08-09T14:20:06,815][DEBUG][logstash.runner          ] pipeline.batch.delay: 5
[2017-08-09T14:20:06,815][DEBUG][logstash.runner          ] pipeline.unsafe_shutdown: false
[2017-08-09T14:20:06,815][DEBUG][logstash.runner          ] pipeline.reloadable: true
[2017-08-09T14:20:06,815][DEBUG][logstash.runner          ] path.plugins: []
[2017-08-09T14:20:06,815][DEBUG][logstash.runner          ] config.debug: false
[2017-08-09T14:20:06,816][DEBUG][logstash.runner          ] *log.level: "debug" (default: "info")
[2017-08-09T14:20:06,816][DEBUG][logstash.runner          ] version: false
[2017-08-09T14:20:06,816][DEBUG][logstash.runner          ] help: false
[2017-08-09T14:20:06,816][DEBUG][logstash.runner          ] log.format: "plain"
[2017-08-09T14:20:06,817][DEBUG][logstash.runner          ] http.host: "127.0.0.1"
[2017-08-09T14:20:06,817][DEBUG][logstash.runner          ] http.port: 9600..9700
[2017-08-09T14:20:06,817][DEBUG][logstash.runner          ] http.environment: "production"
[2017-08-09T14:20:06,817][DEBUG][logstash.runner          ] queue.type: "memory"
[2017-08-09T14:20:06,818][DEBUG][logstash.runner          ] queue.drain: false
[2017-08-09T14:20:06,818][DEBUG][logstash.runner          ] queue.page_capacity: 262144000
[2017-08-09T14:20:06,818][DEBUG][logstash.runner          ] queue.max_bytes: 1073741824
[2017-08-09T14:20:06,818][DEBUG][logstash.runner          ] queue.max_events: 0
[2017-08-09T14:20:06,818][DEBUG][logstash.runner          ] queue.checkpoint.acks: 1024
[2017-08-09T14:20:06,819][DEBUG][logstash.runner          ] queue.checkpoint.writes: 1024
[2017-08-09T14:20:06,819][DEBUG][logstash.runner          ] queue.checkpoint.interval: 1000
[2017-08-09T14:20:06,819][DEBUG][logstash.runner          ] dead_letter_queue.enable: false
[2017-08-09T14:20:06,819][DEBUG][logstash.runner          ] dead_letter_queue.max_bytes: 1073741824
[2017-08-09T14:20:06,820][DEBUG][logstash.runner          ] slowlog.threshold.warn: -1
[2017-08-09T14:20:06,820][DEBUG][logstash.runner          ] slowlog.threshold.info: -1
[2017-08-09T14:20:06,821][DEBUG][logstash.runner          ] slowlog.threshold.debug: -1
[2017-08-09T14:20:06,821][DEBUG][logstash.runner          ] slowlog.threshold.trace: -1
[2017-08-09T14:20:06,822][DEBUG][logstash.runner          ] path.queue: "/tmp/logstash/data/queue"
[2017-08-09T14:20:06,822][DEBUG][logstash.runner          ] path.dead_letter_queue: "/tmp/logstash/data/dead_letter_queue"
[2017-08-09T14:20:06,822][DEBUG][logstash.runner          ] path.settings: "/tmp/logstash/config"
[2017-08-09T14:20:06,822][DEBUG][logstash.runner          ] path.logs: "/tmp/logstash/logs"
[2017-08-09T14:20:06,822][DEBUG][logstash.runner          ] --------------- Logstash Settings -------------------
[2017-08-09T14:20:06,998][DEBUG][logstash.config.source.multilocal] Reading pipeline configurations from YAML {:location=>"/tmp/logstash/config/pipelines.yml"}
[2017-08-09T14:20:07,022][WARN ][logstash.config.source.multilocal] Ignoring the 'pipelines.yml' file because modules or command line options are specified
[2017-08-09T14:20:07,085][INFO ][logstash.agent           ] No persistent UUID file found. Generating new UUID {:uuid=>"5dec9d7b-2aab-41df-a5f9-0e0ea91c7887", :path=>"/tmp/logstash/data/uuid"}
[2017-08-09T14:20:07,126][DEBUG][logstash.agent           ] Agent: Configuring metric collection
[2017-08-09T14:20:07,253][DEBUG][logstash.instrument.periodicpoller.os] PeriodicPoller: Starting {:polling_interval=>5, :polling_timeout=>120}
[2017-08-09T14:20:07,580][DEBUG][logstash.instrument.periodicpoller.jvm] PeriodicPoller: Starting {:polling_interval=>5, :polling_timeout=>120}
[2017-08-09T14:20:07,918][DEBUG][logstash.instrument.periodicpoller.persistentqueue] PeriodicPoller: Starting {:polling_interval=>5, :polling_timeout=>120}
[2017-08-09T14:20:07,938][DEBUG][logstash.instrument.periodicpoller.deadletterqueue] PeriodicPoller: Starting {:polling_interval=>5, :polling_timeout=>120}
[2017-08-09T14:20:08,059][DEBUG][logstash.agent           ] starting agent
[2017-08-09T14:20:08,087][DEBUG][logstash.agent           ] Starting puma
[2017-08-09T14:20:08,104][DEBUG][logstash.agent           ] Trying to start WebServer {:port=>9600}
[2017-08-09T14:20:08,209][DEBUG][logstash.api.service     ] [api-service] start
[2017-08-09T14:20:08,299][DEBUG][logstash.agent           ] Converging pipelines
[2017-08-09T14:20:08,312][DEBUG][logstash.agent           ] Needed actions to converge {:actions_count=>1}
[2017-08-09T14:20:08,319][DEBUG][logstash.agent           ] Executing action {:action=>LogStash::PipelineAction::Create/pipeline_id:main}
[2017-08-09T14:20:08,604][INFO ][logstash.agent           ] Successfully started Logstash API endpoint {:port=>9600}
[2017-08-09T14:20:10,366][DEBUG][logstash.plugins.registry] On demand adding plugin to the registry {:name=>"stdout", :type=>"output", :class=>LogStash::Outputs::Stdout}
[2017-08-09T14:20:10,893][DEBUG][logstash.plugins.registry] On demand adding plugin to the registry {:name=>"rubydebug", :type=>"codec", :class=>LogStash::Codecs::RubyDebug}
[2017-08-09T14:20:10,934][DEBUG][logstash.codecs.rubydebug] config LogStash::Codecs::RubyDebug/@id = "rubydebug_b4e4dec7-375b-44d7-849d-82688a319c61"
[2017-08-09T14:20:10,936][DEBUG][logstash.codecs.rubydebug] config LogStash::Codecs::RubyDebug/@enable_metric = true
[2017-08-09T14:20:10,936][DEBUG][logstash.codecs.rubydebug] config LogStash::Codecs::RubyDebug/@metadata = false
[2017-08-09T14:20:12,215][DEBUG][logstash.outputs.stdout  ] config LogStash::Outputs::Stdout/@codec = <LogStash::Codecs::RubyDebug id=>"rubydebug_b4e4dec7-375b-44d7-849d-82688a319c61", enable_metric=>true, metadata=>false>
[2017-08-09T14:20:12,216][DEBUG][logstash.outputs.stdout  ] config LogStash::Outputs::Stdout/@id = "8f0fed3fa56e1ade5293772f25691d085863d679-1"
[2017-08-09T14:20:12,217][DEBUG][logstash.outputs.stdout  ] config LogStash::Outputs::Stdout/@enable_metric = true
[2017-08-09T14:20:12,218][DEBUG][logstash.outputs.stdout  ] config LogStash::Outputs::Stdout/@workers = 1
[2017-08-09T14:20:12,250][DEBUG][logstash.plugins.registry] On demand adding plugin to the registry {:name=>"generator", :type=>"input", :class=>LogStash::Inputs::Generator}
[2017-08-09T14:20:12,320][DEBUG][logstash.plugins.registry] On demand adding plugin to the registry {:name=>"plain", :type=>"codec", :class=>LogStash::Codecs::Plain}
[2017-08-09T14:20:12,337][DEBUG][logstash.codecs.plain    ] config LogStash::Codecs::Plain/@id = "plain_99f7df93-7f14-40da-9dfe-732b447e7726"
[2017-08-09T14:20:12,338][DEBUG][logstash.codecs.plain    ] config LogStash::Codecs::Plain/@enable_metric = true
[2017-08-09T14:20:12,338][DEBUG][logstash.codecs.plain    ] config LogStash::Codecs::Plain/@charset = "UTF-8"
[2017-08-09T14:20:12,352][DEBUG][logstash.inputs.generator] config LogStash::Inputs::Generator/@count = 1
[2017-08-09T14:20:12,352][DEBUG][logstash.inputs.generator] config LogStash::Inputs::Generator/@id = "8f0fed3fa56e1ade5293772f25691d085863d679-2"
[2017-08-09T14:20:12,352][DEBUG][logstash.inputs.generator] config LogStash::Inputs::Generator/@enable_metric = true
[2017-08-09T14:20:12,354][DEBUG][logstash.inputs.generator] config LogStash::Inputs::Generator/@codec = <LogStash::Codecs::Plain id=>"plain_99f7df93-7f14-40da-9dfe-732b447e7726", enable_metric=>true, charset=>"UTF-8">
[2017-08-09T14:20:12,356][DEBUG][logstash.inputs.generator] config LogStash::Inputs::Generator/@add_field = {}
[2017-08-09T14:20:12,356][DEBUG][logstash.inputs.generator] config LogStash::Inputs::Generator/@threads = 1
[2017-08-09T14:20:12,356][DEBUG][logstash.inputs.generator] config LogStash::Inputs::Generator/@message = "Hello world!"
[2017-08-09T14:20:12,469][DEBUG][logstash.pipeline        ] Starting pipeline {:pipeline_id=>"main"}
[2017-08-09T14:20:12,560][INFO ][logstash.pipeline        ] Starting pipeline {:pipeline_id=>"main", "pipeline.workers"=>4, "pipeline.batch.size"=>125, "pipeline.batch.delay"=>5, "pipeline.max_inflight"=>500, :thread=>"#<Thread:0x58ae79bc run>"}
[2017-08-09T14:20:12,651][INFO ][logstash.pipeline        ] Pipeline started {"pipeline.id"=>"main"}
[2017-08-09T14:20:12,678][DEBUG][logstash.pipeline        ] Pipeline started successfully {:pipeline_id=>"main", :thread=>"#<Thread:0x58ae79bc run>"}
[2017-08-09T14:20:12,805][DEBUG][logstash.inputs.generator] closing {:plugin=>"LogStash::Inputs::Generator"}
[2017-08-09T14:20:12,813][INFO ][logstash.agent           ] Pipelines running {:count=>1, :pipelines=>["main"]}
[2017-08-09T14:20:12,816][DEBUG][logstash.pipeline        ] filter received {"event"=>{"@version"=>"1", "host"=>"Joaos-MBP-5.lan", "sequence"=>0, "@timestamp"=>2017-08-09T13:20:12.740Z, "message"=>"Hello world!"}}
[2017-08-09T14:20:12,817][DEBUG][logstash.pipeline        ] Input plugins stopped! Will shutdown filter/output workers. {:pipeline_id=>"main", :thread=>"#<Thread:0x58ae79bc run>"}
[2017-08-09T14:20:12,839][DEBUG][logstash.pipeline        ] output received {"event"=>{"@version"=>"1", "host"=>"Joaos-MBP-5.lan", "sequence"=>0, "@timestamp"=>2017-08-09T13:20:12.740Z, "message"=>"Hello world!"}}
[2017-08-09T14:20:12,876][DEBUG][logstash.instrument.periodicpoller.os] PeriodicPoller: Stopping
[2017-08-09T14:20:12,903][DEBUG][logstash.pipeline        ] Pushing flush onto pipeline {:pipeline_id=>"main", :thread=>"#<Thread:0x58ae79bc sleep>"}
[2017-08-09T14:20:12,920][DEBUG][logstash.instrument.periodicpoller.jvm] PeriodicPoller: Stopping
[2017-08-09T14:20:12,926][DEBUG][logstash.instrument.periodicpoller.persistentqueue] PeriodicPoller: Stopping
[2017-08-09T14:20:12,929][DEBUG][logstash.instrument.periodicpoller.deadletterqueue] PeriodicPoller: Stopping
[2017-08-09T14:20:12,933][DEBUG][logstash.pipeline        ] Pushing shutdown {:pipeline_id=>"main", :thread=>"#<Thread:0x58ae79bc run>"}
[2017-08-09T14:20:12,935][DEBUG][logstash.pipeline        ] Pushing shutdown {:pipeline_id=>"main", :thread=>"#<Thread:0x58ae79bc run>"}
[2017-08-09T14:20:12,935][DEBUG][logstash.pipeline        ] Pushing shutdown {:pipeline_id=>"main", :thread=>"#<Thread:0x58ae79bc run>"}
[2017-08-09T14:20:12,936][DEBUG][logstash.pipeline        ] Pushing shutdown {:pipeline_id=>"main", :thread=>"#<Thread:0x58ae79bc run>"}
[2017-08-09T14:20:12,940][DEBUG][logstash.pipeline        ] Shutdown waiting for worker thread {:pipeline_id=>"main", :thread=>"#<Thread:0x58ae79bc run>"}
[2017-08-09T14:20:12,971][DEBUG][logstash.pipeline        ] Shutdown waiting for worker thread {:pipeline_id=>"main", :thread=>"#<Thread:0x58ae79bc run>"}
[2017-08-09T14:20:13,232][DEBUG][logstash.agent           ] Shutting down all pipelines {:pipelines_count=>1}
[2017-08-09T14:20:13,241][DEBUG][logstash.agent           ] Converging pipelines
[2017-08-09T14:20:13,243][DEBUG][logstash.agent           ] Needed actions to converge {:actions_count=>1}
[2017-08-09T14:20:13,245][DEBUG][logstash.agent           ] Executing action {:action=>LogStash::PipelineAction::Stop/pipeline_id:main}
[2017-08-09T14:20:13,285][DEBUG][logstash.pipeline        ] Closing inputs {:pipeline_id=>"main", :thread=>"#<Thread:0x58ae79bc sleep>"}
[2017-08-09T14:20:13,290][DEBUG][logstash.inputs.generator] stopping {:plugin=>"LogStash::Inputs::Generator"}
[2017-08-09T14:20:13,294][DEBUG][logstash.pipeline        ] Closed inputs {:pipeline_id=>"main", :thread=>"#<Thread:0x58ae79bc sleep>"}
[2017-08-09T14:20:13,302][DEBUG][logstash.pipeline        ] Closing inputs {:pipeline_id=>"main", :thread=>"#<Thread:0x58ae79bc sleep>"}
{
      "@version" => "1",
          "host" => "Joaos-MBP-5.lan",
      "sequence" => 0,
    "@timestamp" => 2017-08-09T13:20:12.740Z,
       "message" => "Hello world!"
}
[2017-08-09T14:20:13,570][DEBUG][logstash.pipeline        ] Worker closed {:pipeline_id=>"main", :thread=>"#<Thread:0x58ae79bc sleep>"}
[2017-08-09T14:20:13,571][DEBUG][logstash.pipeline        ] Shutdown waiting for worker thread {:pipeline_id=>"main", :thread=>"#<Thread:0x58ae79bc run>"}
[2017-08-09T14:20:13,571][DEBUG][logstash.pipeline        ] Shutdown waiting for worker thread {:pipeline_id=>"main", :thread=>"#<Thread:0x58ae79bc run>"}
[2017-08-09T14:20:13,580][DEBUG][logstash.outputs.stdout  ] closing {:plugin=>"LogStash::Outputs::Stdout"}
[2017-08-09T14:20:13,599][DEBUG][logstash.pipeline        ] Pipeline has been shutdown {:pipeline_id=>"main", :thread=>"#<Thread:0x58ae79bc run>"}
[2017-08-09T14:20:13,624][INFO ][logstash.pipeline        ] Pipeline terminated {"pipeline.id"=>"main"}
```

after:

```
/tmp/logstash (git)-[logging_improvements] % bin/logstash -e "input { generator { count => 1 } }" --log.level=debug
Sending Logstash's logs to /tmp/logstash/logs which is now configured via log4j2.properties
[2017-08-09T14:22:38,503][DEBUG][logstash.plugins.registry] Adding plugin to the registry {:name=>"fb_apache", :type=>:modules, :class=>#<LogStash::Modules::Scaffold:0x77098877 @module_name="fb_apache", @directory="/tmp/logstash/modules/fb_apache/configuration", @kibana_version_parts=["6", "0", "0"]>}
[2017-08-09T14:22:38,550][DEBUG][logstash.plugins.registry] Adding plugin to the registry {:name=>"netflow", :type=>:modules, :class=>#<LogStash::Modules::Scaffold:0x65de895a @module_name="netflow", @directory="/tmp/logstash/modules/netflow/configuration", @kibana_version_parts=["6", "0", "0"]>}
[2017-08-09T14:22:38,837][DEBUG][logstash.runner          ] -------- Logstash Settings (* means modified) ---------
[2017-08-09T14:22:38,838][DEBUG][logstash.runner          ] node.name: "Joaos-MBP-5.lan"
[2017-08-09T14:22:38,838][DEBUG][logstash.runner          ] path.data: "/tmp/logstash/data"
[2017-08-09T14:22:38,838][DEBUG][logstash.runner          ] *config.string: "input { generator { count => 1 } }"
[2017-08-09T14:22:38,838][DEBUG][logstash.runner          ] modules.cli: []
[2017-08-09T14:22:38,838][DEBUG][logstash.runner          ] modules: []
[2017-08-09T14:22:38,838][DEBUG][logstash.runner          ] config.test_and_exit: false
[2017-08-09T14:22:38,839][DEBUG][logstash.runner          ] config.reload.automatic: false
[2017-08-09T14:22:38,839][DEBUG][logstash.runner          ] config.reload.interval: 3000000000
[2017-08-09T14:22:38,839][DEBUG][logstash.runner          ] config.support_escapes: false
[2017-08-09T14:22:38,840][DEBUG][logstash.runner          ] metric.collect: true
[2017-08-09T14:22:38,841][DEBUG][logstash.runner          ] pipeline.id: "main"
[2017-08-09T14:22:38,841][DEBUG][logstash.runner          ] pipeline.system: false
[2017-08-09T14:22:38,841][DEBUG][logstash.runner          ] pipeline.workers: 4
[2017-08-09T14:22:38,842][DEBUG][logstash.runner          ] pipeline.output.workers: 1
[2017-08-09T14:22:38,842][DEBUG][logstash.runner          ] pipeline.batch.size: 125
[2017-08-09T14:22:38,842][DEBUG][logstash.runner          ] pipeline.batch.delay: 5
[2017-08-09T14:22:38,842][DEBUG][logstash.runner          ] pipeline.unsafe_shutdown: false
[2017-08-09T14:22:38,842][DEBUG][logstash.runner          ] pipeline.reloadable: true
[2017-08-09T14:22:38,843][DEBUG][logstash.runner          ] path.plugins: []
[2017-08-09T14:22:38,843][DEBUG][logstash.runner          ] config.debug: false
[2017-08-09T14:22:38,843][DEBUG][logstash.runner          ] *log.level: "debug" (default: "info")
[2017-08-09T14:22:38,843][DEBUG][logstash.runner          ] version: false
[2017-08-09T14:22:38,843][DEBUG][logstash.runner          ] help: false
[2017-08-09T14:22:38,843][DEBUG][logstash.runner          ] log.format: "plain"
[2017-08-09T14:22:38,844][DEBUG][logstash.runner          ] http.host: "127.0.0.1"
[2017-08-09T14:22:38,844][DEBUG][logstash.runner          ] http.port: 9600..9700
[2017-08-09T14:22:38,844][DEBUG][logstash.runner          ] http.environment: "production"
[2017-08-09T14:22:38,844][DEBUG][logstash.runner          ] queue.type: "memory"
[2017-08-09T14:22:38,844][DEBUG][logstash.runner          ] queue.drain: false
[2017-08-09T14:22:38,844][DEBUG][logstash.runner          ] queue.page_capacity: 262144000
[2017-08-09T14:22:38,845][DEBUG][logstash.runner          ] queue.max_bytes: 1073741824
[2017-08-09T14:22:38,845][DEBUG][logstash.runner          ] queue.max_events: 0
[2017-08-09T14:22:38,845][DEBUG][logstash.runner          ] queue.checkpoint.acks: 1024
[2017-08-09T14:22:38,845][DEBUG][logstash.runner          ] queue.checkpoint.writes: 1024
[2017-08-09T14:22:38,845][DEBUG][logstash.runner          ] queue.checkpoint.interval: 1000
[2017-08-09T14:22:38,845][DEBUG][logstash.runner          ] dead_letter_queue.enable: false
[2017-08-09T14:22:38,846][DEBUG][logstash.runner          ] dead_letter_queue.max_bytes: 1073741824
[2017-08-09T14:22:38,846][DEBUG][logstash.runner          ] slowlog.threshold.warn: -1
[2017-08-09T14:22:38,846][DEBUG][logstash.runner          ] slowlog.threshold.info: -1
[2017-08-09T14:22:38,846][DEBUG][logstash.runner          ] slowlog.threshold.debug: -1
[2017-08-09T14:22:38,846][DEBUG][logstash.runner          ] slowlog.threshold.trace: -1
[2017-08-09T14:22:38,846][DEBUG][logstash.runner          ] path.queue: "/tmp/logstash/data/queue"
[2017-08-09T14:22:38,847][DEBUG][logstash.runner          ] path.dead_letter_queue: "/tmp/logstash/data/dead_letter_queue"
[2017-08-09T14:22:38,847][DEBUG][logstash.runner          ] path.settings: "/tmp/logstash/config"
[2017-08-09T14:22:38,847][DEBUG][logstash.runner          ] path.logs: "/tmp/logstash/logs"
[2017-08-09T14:22:38,847][DEBUG][logstash.runner          ] --------------- Logstash Settings -------------------
[2017-08-09T14:22:38,940][WARN ][logstash.config.source.multilocal] Ignoring the 'pipelines.yml' file because modules or command line options are specified
[2017-08-09T14:22:39,133][DEBUG][logstash.agent           ] Setting up metric collection
[2017-08-09T14:22:39,369][DEBUG][logstash.instrument.periodicpoller.os] Starting {:polling_interval=>5, :polling_timeout=>120}
[2017-08-09T14:22:39,815][DEBUG][logstash.instrument.periodicpoller.jvm] Starting {:polling_interval=>5, :polling_timeout=>120}
[2017-08-09T14:22:40,096][DEBUG][logstash.instrument.periodicpoller.persistentqueue] Starting {:polling_interval=>5, :polling_timeout=>120}
[2017-08-09T14:22:40,114][DEBUG][logstash.instrument.periodicpoller.deadletterqueue] Starting {:polling_interval=>5, :polling_timeout=>120}
[2017-08-09T14:22:40,210][DEBUG][logstash.agent           ] Starting agent
[2017-08-09T14:22:40,239][DEBUG][logstash.agent           ] Starting puma
[2017-08-09T14:22:40,254][DEBUG][logstash.agent           ] Trying to start WebServer {:port=>9600}
[2017-08-09T14:22:40,345][DEBUG][logstash.api.service     ] [api-service] start
[2017-08-09T14:22:40,369][DEBUG][logstash.agent           ] Converging pipelines state {:actions_count=>1}
[2017-08-09T14:22:40,399][DEBUG][logstash.agent           ] Executing action {:action=>LogStash::PipelineAction::Create/pipeline_id:main}
[2017-08-09T14:22:40,750][INFO ][logstash.agent           ] Successfully started Logstash API endpoint {:port=>9600}
[2017-08-09T14:22:42,417][DEBUG][logstash.plugins.registry] On demand adding plugin to the registry {:name=>"stdout", :type=>"output", :class=>LogStash::Outputs::Stdout}
[2017-08-09T14:22:43,330][DEBUG][logstash.plugins.registry] On demand adding plugin to the registry {:name=>"rubydebug", :type=>"codec", :class=>LogStash::Codecs::RubyDebug}
[2017-08-09T14:22:43,375][DEBUG][logstash.codecs.rubydebug] config LogStash::Codecs::RubyDebug/@id = "rubydebug_70295633-b872-4499-9fb1-2de9a52ebfff"
[2017-08-09T14:22:43,377][DEBUG][logstash.codecs.rubydebug] config LogStash::Codecs::RubyDebug/@enable_metric = true
[2017-08-09T14:22:43,378][DEBUG][logstash.codecs.rubydebug] config LogStash::Codecs::RubyDebug/@metadata = false
[2017-08-09T14:22:44,982][DEBUG][logstash.outputs.stdout  ] config LogStash::Outputs::Stdout/@codec = <LogStash::Codecs::RubyDebug id=>"rubydebug_70295633-b872-4499-9fb1-2de9a52ebfff", enable_metric=>true, metadata=>false>
[2017-08-09T14:22:44,983][DEBUG][logstash.outputs.stdout  ] config LogStash::Outputs::Stdout/@id = "8f0fed3fa56e1ade5293772f25691d085863d679-1"
[2017-08-09T14:22:44,984][DEBUG][logstash.outputs.stdout  ] config LogStash::Outputs::Stdout/@enable_metric = true
[2017-08-09T14:22:44,984][DEBUG][logstash.outputs.stdout  ] config LogStash::Outputs::Stdout/@workers = 1
[2017-08-09T14:22:45,020][DEBUG][logstash.plugins.registry] On demand adding plugin to the registry {:name=>"generator", :type=>"input", :class=>LogStash::Inputs::Generator}
[2017-08-09T14:22:45,192][DEBUG][logstash.plugins.registry] On demand adding plugin to the registry {:name=>"plain", :type=>"codec", :class=>LogStash::Codecs::Plain}
[2017-08-09T14:22:45,216][DEBUG][logstash.codecs.plain    ] config LogStash::Codecs::Plain/@id = "plain_164f3a12-1e41-4df7-952c-82fedfc852ce"
[2017-08-09T14:22:45,217][DEBUG][logstash.codecs.plain    ] config LogStash::Codecs::Plain/@enable_metric = true
[2017-08-09T14:22:45,217][DEBUG][logstash.codecs.plain    ] config LogStash::Codecs::Plain/@charset = "UTF-8"
[2017-08-09T14:22:45,232][DEBUG][logstash.inputs.generator] config LogStash::Inputs::Generator/@count = 1
[2017-08-09T14:22:45,233][DEBUG][logstash.inputs.generator] config LogStash::Inputs::Generator/@id = "8f0fed3fa56e1ade5293772f25691d085863d679-2"
[2017-08-09T14:22:45,233][DEBUG][logstash.inputs.generator] config LogStash::Inputs::Generator/@enable_metric = true
[2017-08-09T14:22:45,235][DEBUG][logstash.inputs.generator] config LogStash::Inputs::Generator/@codec = <LogStash::Codecs::Plain id=>"plain_164f3a12-1e41-4df7-952c-82fedfc852ce", enable_metric=>true, charset=>"UTF-8">
[2017-08-09T14:22:45,235][DEBUG][logstash.inputs.generator] config LogStash::Inputs::Generator/@add_field = {}
[2017-08-09T14:22:45,236][DEBUG][logstash.inputs.generator] config LogStash::Inputs::Generator/@threads = 1
[2017-08-09T14:22:45,237][DEBUG][logstash.inputs.generator] config LogStash::Inputs::Generator/@message = "Hello world!"
[2017-08-09T14:22:45,359][INFO ][logstash.pipeline        ] Starting pipeline {:pipeline_id=>"main", "pipeline.workers"=>4, "pipeline.batch.size"=>125, "pipeline.batch.delay"=>5}
[2017-08-09T14:22:45,524][INFO ][logstash.pipeline        ] Pipeline started succesfully {:pipeline_id=>"main", :thread=>"#<Thread:0x20f15b44 run>"}
[2017-08-09T14:22:45,672][DEBUG][logstash.pipeline        ] filter received {"event"=>{"@version"=>"1", "host"=>"Joaos-MBP-5.lan", "sequence"=>0, "@timestamp"=>2017-08-09T13:22:45.583Z, "message"=>"Hello world!"}}
[2017-08-09T14:22:45,677][DEBUG][logstash.inputs.generator] Closing {:plugin=>"LogStash::Inputs::Generator"}
[2017-08-09T14:22:45,679][INFO ][logstash.agent           ] Pipelines running {:count=>1, :pipelines=>["main"]}
[2017-08-09T14:22:45,704][DEBUG][logstash.pipeline        ] output received {"event"=>{"@version"=>"1", "host"=>"Joaos-MBP-5.lan", "sequence"=>0, "@timestamp"=>2017-08-09T13:22:45.583Z, "message"=>"Hello world!"}}
[2017-08-09T14:22:45,752][DEBUG][logstash.instrument.periodicpoller.os] Stopping
[2017-08-09T14:22:45,862][DEBUG][logstash.pipeline        ] Pushing flush onto pipeline {:pipeline_id=>"main", :thread=>"#<Thread:0x20f15b44 sleep>"}
[2017-08-09T14:22:45,984][DEBUG][logstash.pipeline        ] Shutting down filter/output workers {:pipeline_id=>"main", :thread=>"#<Thread:0x20f15b44 run>"}
[2017-08-09T14:22:45,988][DEBUG][logstash.instrument.periodicpoller.jvm] Stopping
[2017-08-09T14:22:45,993][DEBUG][logstash.instrument.periodicpoller.persistentqueue] Stopping
[2017-08-09T14:22:45,996][DEBUG][logstash.instrument.periodicpoller.deadletterqueue] Stopping
[2017-08-09T14:22:45,997][DEBUG][logstash.pipeline        ] Pushing shutdown {:pipeline_id=>"main", :thread=>"#<Thread:0x20f15b44 run>"}
[2017-08-09T14:22:46,002][DEBUG][logstash.pipeline        ] Pushing shutdown {:pipeline_id=>"main", :thread=>"#<Thread:0x20f15b44 run>"}
[2017-08-09T14:22:46,002][DEBUG][logstash.pipeline        ] Pushing shutdown {:pipeline_id=>"main", :thread=>"#<Thread:0x20f15b44 run>"}
[2017-08-09T14:22:46,006][DEBUG][logstash.pipeline        ] Pushing shutdown {:pipeline_id=>"main", :thread=>"#<Thread:0x20f15b44 run>"}
[2017-08-09T14:22:46,009][DEBUG][logstash.pipeline        ] Shutdown waiting for worker thread {:pipeline_id=>"main", :thread=>"#<Thread:0x20f15b44 run>"}
[2017-08-09T14:22:46,108][DEBUG][logstash.agent           ] Shutting down all pipelines {:pipelines_count=>1}
[2017-08-09T14:22:46,115][DEBUG][logstash.agent           ] Converging pipelines state {:actions_count=>1}
[2017-08-09T14:22:46,117][DEBUG][logstash.agent           ] Executing action {:action=>LogStash::PipelineAction::Stop/pipeline_id:main}
[2017-08-09T14:22:46,154][DEBUG][logstash.pipeline        ] Stopping inputs {:pipeline_id=>"main", :thread=>"#<Thread:0x20f15b44 sleep>"}
[2017-08-09T14:22:46,159][DEBUG][logstash.inputs.generator] Stopping {:plugin=>"LogStash::Inputs::Generator"}
[2017-08-09T14:22:46,163][DEBUG][logstash.pipeline        ] Stopped inputs {:pipeline_id=>"main", :thread=>"#<Thread:0x20f15b44 sleep>"}
{
      "@version" => "1",
          "host" => "Joaos-MBP-5.lan",
      "sequence" => 0,
    "@timestamp" => 2017-08-09T13:22:45.583Z,
       "message" => "Hello world!"
}
[2017-08-09T14:22:46,317][DEBUG][logstash.pipeline        ] Shutdown waiting for worker thread {:pipeline_id=>"main", :thread=>"#<Thread:0x20f15b44 run>"}
[2017-08-09T14:22:46,318][DEBUG][logstash.pipeline        ] Shutdown waiting for worker thread {:pipeline_id=>"main", :thread=>"#<Thread:0x20f15b44 run>"}
[2017-08-09T14:22:46,318][DEBUG][logstash.pipeline        ] Shutdown waiting for worker thread {:pipeline_id=>"main", :thread=>"#<Thread:0x20f15b44 run>"}
[2017-08-09T14:22:46,319][DEBUG][logstash.pipeline        ] Worker terminated {:pipeline_id=>"main", :thread=>"#<Thread:0x20f15b44 run>"}
[2017-08-09T14:22:46,320][DEBUG][logstash.pipeline        ] Worker terminated {:pipeline_id=>"main", :thread=>"#<Thread:0x20f15b44 run>"}
[2017-08-09T14:22:46,320][DEBUG][logstash.pipeline        ] Worker terminated {:pipeline_id=>"main", :thread=>"#<Thread:0x20f15b44 run>"}
[2017-08-09T14:22:46,320][DEBUG][logstash.pipeline        ] Worker terminated {:pipeline_id=>"main", :thread=>"#<Thread:0x20f15b44 run>"}
[2017-08-09T14:22:46,326][DEBUG][logstash.outputs.stdout  ] Closing {:plugin=>"LogStash::Outputs::Stdout"}
[2017-08-09T14:22:46,341][INFO ][logstash.pipeline        ] Pipeline has terminated {:pipeline_id=>"main", :thread=>"#<Thread:0x20f15b44 run>"}
```