### PR TITLE
Test Stability: Fix Global Ruby Runtime Setup

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -13,7 +13,6 @@ import org.joda.time.DateTime;
 import org.jruby.RubyString;
 import org.jruby.RubySymbol;
 import org.logstash.ackedqueue.Queueable;
-import org.logstash.bivalues.BiValues;
 import org.logstash.bivalues.NullBiValue;
 import org.logstash.ext.JrubyTimestampExtLibrary;
 
@@ -335,7 +334,7 @@ public final class Event implements Cloneable, Queueable {
      */
     private void initTag(final String tag) {
         final ConvertedList list = new ConvertedList(1);
-        list.add(BiValues.RUBY.newString(tag));
+        list.add(RubyUtil.RUBY.newString(tag));
         Accessors.set(data, TAGS_FIELD, list);
     }
 

--- a/logstash-core/src/main/java/org/logstash/RubyUtil.java
+++ b/logstash-core/src/main/java/org/logstash/RubyUtil.java
@@ -1,0 +1,28 @@
+package org.logstash;
+
+import org.jruby.Ruby;
+
+/**
+ * Utilities around interaction with the {@link Ruby} runtime.
+ */
+public final class RubyUtil {
+
+    /**
+     * Reference to the global {@link Ruby} runtime.
+     */
+    public static final Ruby RUBY = setupRuby();
+
+    private RubyUtil() {
+    }
+
+    /**
+     * Sets up the global {@link Ruby} runtime and ensures the creation of the "LogStash" module
+     * on it.
+     * @return Global {@link Ruby} Runtime
+     */
+    private static Ruby setupRuby() {
+        final Ruby ruby = Ruby.getGlobalRuntime();
+        ruby.getOrCreateModule("LogStash");
+        return ruby;
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/Rubyfier.java
+++ b/logstash-core/src/main/java/org/logstash/Rubyfier.java
@@ -32,13 +32,13 @@ public final class Rubyfier {
             || input instanceof JrubyTimestampExtLibrary.RubyTimestamp) {
             return (IRubyObject) input;
         }
-        if (input instanceof String) return BiValues.RUBY.newString((String) input);
+        if (input instanceof String) return RubyUtil.RUBY.newString((String) input);
         if (input instanceof Double || input instanceof Float) {
-            return BiValues.RUBY.newFloat(((Number) input).doubleValue());
+            return RubyUtil.RUBY.newFloat(((Number) input).doubleValue());
         }
         if (input instanceof Timestamp) {
             return JrubyTimestampExtLibrary.RubyTimestamp.newRubyTimestamp(
-                BiValues.RUBY, (Timestamp) input
+                RubyUtil.RUBY, (Timestamp) input
             );
         }
         if (input instanceof BiValue) return ((BiValue) input).rubyValue(runtime);

--- a/logstash-core/src/main/java/org/logstash/Valuefier.java
+++ b/logstash-core/src/main/java/org/logstash/Valuefier.java
@@ -59,24 +59,24 @@ public final class Valuefier {
             return o;
         }
         if (o instanceof String) {
-            return BiValues.RUBY.newString((String) o);
+            return RubyUtil.RUBY.newString((String) o);
         }
         if (o instanceof Float || o instanceof Double) {
-            return BiValues.RUBY.newFloat(((Number) o).doubleValue());
+            return RubyUtil.RUBY.newFloat(((Number) o).doubleValue());
         }
         if (o instanceof Timestamp) {
             return JrubyTimestampExtLibrary.RubyTimestamp.newRubyTimestamp(
-                BiValues.RUBY, (Timestamp) o
+                RubyUtil.RUBY, (Timestamp) o
             );
         }
         if (o instanceof RubyTime) {
             return JrubyTimestampExtLibrary.RubyTimestamp.newRubyTimestamp(
-                BiValues.RUBY, new Timestamp(((RubyTime) o).getDateTime())
+                RubyUtil.RUBY, new Timestamp(((RubyTime) o).getDateTime())
             );
         }
         if (o instanceof DateTime) {
             return JrubyTimestampExtLibrary.RubyTimestamp.newRubyTimestamp(
-                BiValues.RUBY, new Timestamp((DateTime) o)
+                RubyUtil.RUBY, new Timestamp((DateTime) o)
             );
         }
         if (o instanceof RubyHash) {

--- a/logstash-core/src/main/java/org/logstash/bivalues/BiValues.java
+++ b/logstash-core/src/main/java/org/logstash/bivalues/BiValues.java
@@ -3,7 +3,6 @@ package org.logstash.bivalues;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.HashMap;
-import org.jruby.Ruby;
 import org.jruby.RubyBignum;
 import org.jruby.RubyBoolean;
 import org.jruby.RubyInteger;
@@ -49,8 +48,6 @@ public enum BiValues {
         hm.put("org.jruby.java.proxies.ConcreteJavaProxy", "ORG_JRUBY_JAVA_PROXIES_CONCRETEJAVAPROXY");
         return hm;
     }
-
-    public static final Ruby RUBY = Ruby.getGlobalRuntime();
 
     public static final NullBiValue NULL_BI_VALUE = NullBiValue.newNullBiValue();
 

--- a/logstash-core/src/test/java/org/logstash/AccessorsTest.java
+++ b/logstash-core/src/test/java/org/logstash/AccessorsTest.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.Test;
-import org.logstash.bivalues.BiValues;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -21,7 +20,7 @@ public class AccessorsTest {
         data.put("foo", "bar");
         String reference = "foo";
         assertEquals(
-            BiValues.RUBY.newString("bar"), get(ConvertedMap.newFromMap(data), reference)
+            RubyUtil.RUBY.newString("bar"), get(ConvertedMap.newFromMap(data), reference)
         );
     }
 
@@ -39,7 +38,7 @@ public class AccessorsTest {
         data.put("foo", "bar");
         String reference = "[foo]";
         assertEquals(
-            BiValues.RUBY.newString("bar"), get(ConvertedMap.newFromMap(data), reference)
+            RubyUtil.RUBY.newString("bar"), get(ConvertedMap.newFromMap(data), reference)
         );
     }
 
@@ -51,7 +50,7 @@ public class AccessorsTest {
         inner.put("bar", "baz");
         String reference = "[foo][bar]";
         assertEquals(
-            BiValues.RUBY.newString("baz"), get(ConvertedMap.newFromMap(data), reference)
+            RubyUtil.RUBY.newString("baz"), get(ConvertedMap.newFromMap(data), reference)
         );
     }
 
@@ -73,7 +72,7 @@ public class AccessorsTest {
         inner.add("bar");
         String reference = "[foo][0]";
         assertEquals(
-            BiValues.RUBY.newString("bar"), get(ConvertedMap.newFromMap(data), reference)
+            RubyUtil.RUBY.newString("bar"), get(ConvertedMap.newFromMap(data), reference)
         );
     }
 

--- a/logstash-core/src/test/java/org/logstash/EventTest.java
+++ b/logstash-core/src/test/java/org/logstash/EventTest.java
@@ -6,24 +6,13 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import org.logstash.bivalues.BiValues;
 
 import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 public final class EventTest {
-
-    /**
-     * Some of these tests require a fully initialized global {@link org.jruby.Ruby} instance
-     * so we force the creation of the "LogStash" module here.
-     */
-    @BeforeClass
-    public static void before() {
-        BiValues.RUBY.getOrCreateModule("LogStash");
-    }
 
     @Test
     public void queueableInterfaceRoundTrip() throws Exception {


### PR DESCRIPTION
Fixes test issues from the "LogStash" `Ruby` module not being set up before a test due to the class load order.
In production code, we're guaranteed to have the global `Ruby` all setup, but in tests, no such guarantee exists.

Fixes https://logstash-ci.elastic.co/job/elastic+logstash+pull-request+multijob-linux-intake/423/console