### PR TITLE
prevent tests from changing config.debug flag

### DIFF
--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -118,7 +118,7 @@ describe LogStash::Pipeline do
   let(:override_thread_count)   { 42 }
   let(:dead_letter_queue_enabled) { false }
   let(:dead_letter_queue_path) { }
-  let(:pipeline_settings_obj) { LogStash::SETTINGS }
+  let(:pipeline_settings_obj) { LogStash::SETTINGS.clone }
   let(:pipeline_settings) { {} }
   let(:max_retry) {10} #times
   let(:timeout) {120} #seconds
@@ -132,10 +132,6 @@ describe LogStash::Pipeline do
     allow(dlq_path_setting).to receive(:value).and_return(dead_letter_queue_path)
 
     pipeline_settings.each {|k, v| pipeline_settings_obj.set(k, v) }
-  end
-
-  after :each do
-    pipeline_settings_obj.reset
   end
 
   describe "#ephemeral_id" do

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -294,6 +294,9 @@ describe LogStash::Runner do
     end
 
     describe "config.debug" do
+      after(:each) do
+        LogStash::SETTINGS.set("config.debug", false)
+      end
       it "should set 'config.debug' to false by default" do
         expect(LogStash::Agent).to receive(:new) do |settings|
           expect(settings.get("config.debug")).to eq(false)


### PR DESCRIPTION
a few tests can globally enable debug causing builds to have 53mb of raw logs like https://logstash-ci.elastic.co/job/elastic+logstash+pull-request+multijob-linux-intake/430/