### PR TITLE
Add --setup phase for modules

### DIFF
--- a/logstash-core/lib/logstash/config/modules_common.rb
+++ b/logstash-core/lib/logstash/config/modules_common.rb
@@ -66,7 +66,9 @@ module LogStash module Config
           module_settings.set("pipeline.id", pipeline_id)
           current_module.with_settings(module_hash)
           config_test = settings.get("config.test_and_exit")
-          if !config_test
+          modul_setup = settings.get("modules_setup")
+          # Only import data if it's not a config test and --setup is true
+          if !config_test && modul_setup
             esclient = LogStash::ElasticsearchClient.build(module_hash)
             kbnclient = LogStash::Modules::KibanaClient.new(module_hash)
             esconnected = esclient.can_connect?

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -22,6 +22,7 @@ module LogStash
     Setting::NullableString.new("config.string", nil, false),
                     Setting.new("modules.cli", Array, []),
                     Setting.new("modules", Array, []),
+           Setting::Boolean.new("modules_setup", false),
            Setting::Boolean.new("config.test_and_exit", false),
            Setting::Boolean.new("config.reload.automatic", false),
            Setting::TimeValue.new("config.reload.interval", "3s"), # in seconds

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -74,6 +74,11 @@ class LogStash::Runner < Clamp::StrictCommand
     :multivalued => true,
     :attribute_name => "modules_variable_list"
 
+  option ["--setup"], :flag,
+    I18n.t("logstash.runner.flag.modules_setup"),
+    :default => LogStash::SETTINGS.get_default("modules_setup"),
+    :attribute_name => "modules_setup"
+
   # Pipeline settings
   option ["-w", "--pipeline.workers"], "COUNT",
     I18n.t("logstash.runner.flag.pipeline-workers"),

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -242,6 +242,10 @@ en:
           '-M "MODULE_NAME.var.PLUGIN_TYPE.PLUGIN_NAME.VARIABLE_NAME=VALUE"'
           as in
           '-M "example.var.filter.mutate.fieldname=fieldvalue"'
+        modules_setup: |+
+          Load index template into Elasticsearch, and saved searches, 
+          index-pattern, visualizations, and dashboards into Kibana when
+          running modules.
         configtest: |+
           Check configuration for valid syntax and then exit.
         http_host: Web API binding host

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -340,7 +340,7 @@ describe LogStash::Runner do
     end
 
     describe "--modules" do
-      let(:args) { ["--modules", module_string] }
+      let(:args) { ["--modules", module_string, "--setup"] }
 
       context "with an available module specified but no connection to elasticsearch" do
         let(:module_string) { "tester" }


### PR DESCRIPTION
Without the `--setup` flag, the index template for elasticsearch, and the index-pattern, saved searches, visualizations, and dashboards for Kibana will not be published.

fixes #7959