### PR TITLE
create source_loader after logging setup

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -190,12 +190,6 @@ class LogStash::Runner < Clamp::StrictCommand
     @settings = LogStash::SETTINGS
     @bootstrap_checks = DEFAULT_BOOTSTRAP_CHECKS.dup
 
-    # Default we check local sources: `-e`, `-f` and the logstash.yml options.
-    @source_loader = LogStash::Config::SourceLoader.new(@settings)
-    @source_loader.add_source(LogStash::Config::Source::Local.new(@settings))
-    @source_loader.add_source(LogStash::Config::Source::Modules.new(@settings))
-    @source_loader.add_source(LogStash::Config::Source::MultiLocal.new(@settings))
-
     super(*args)
   end
 
@@ -255,6 +249,12 @@ class LogStash::Runner < Clamp::StrictCommand
       show_version
       return 0
     end
+
+    # Default we check local sources: `-e`, `-f` and the logstash.yml options.
+    @source_loader = LogStash::Config::SourceLoader.new(@settings)
+    @source_loader.add_source(LogStash::Config::Source::Local.new(@settings))
+    @source_loader.add_source(LogStash::Config::Source::Modules.new(@settings))
+    @source_loader.add_source(LogStash::Config::Source::MultiLocal.new(@settings))
 
     # Add local modules to the registry before everything else
     LogStash::Modules::Util.register_local_modules(LogStash::Environment::LOGSTASH_HOME)


### PR DESCRIPTION
Without this PR:

```
% bin/logstash -f "logstash_configs/*"
[2017-08-10T12:48:01,463][WARN ][logstash.config.source.multilocal] Ignoring the 'pipelines.yml' file because modules or command line options are specified
[2017-08-10T12:48:02,760][INFO ][logstash.config.source.local.configpathloader] No config files found in path {:path=>"/Users/joaoduarte/projects/elastic/logstash/logstash_configs/*"}
[ERROR] 2017-08-10 12:48:02.781 [Ruby-0-Thread-1: /Users/joaoduarte/projects/elastic/logstash/lib/bootstrap/environment.rb:6] sourceloader - No configuration found in the configured sources.
```

With this PR:

```
% bin/logstash -f "logstash_configs/*"
[2017-08-10T12:48:55,008][WARN ][logstash.config.source.multilocal] Ignoring the 'pipelines.yml' file because modules or command line options are specified
[2017-08-10T12:48:55,981][INFO ][logstash.config.source.local.configpathloader] No config files found in path {:path=>"/Users/joaoduarte/projects/elastic/logstash/logstash_configs/*"}
[2017-08-10T12:48:56,002][ERROR][logstash.config.sourceloader] No configuration found in the configured sources.
```