### PR TITLE
Quick fix for OS's that don't support CGroup calls that logstash makes.

### DIFF
--- a/logstash-core/lib/logstash/instrument/periodic_poller/cgroup.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/cgroup.rb
@@ -125,8 +125,9 @@ module LogStash module Instrument module PeriodicPoller
 
        cgroups_stats
       rescue => e
-        logger.debug("Error, cannot retrieve cgroups information", :exception => e.class.name, :message => e.message) if logger.debug?
-        nil
+        logger.debug("Error, cannot retrieve cgroups information, returning empty data: ", :exception => e.class.name, :message => e.message) if logger.debug?
+        # return empty information rather then nil.
+        { :cpuacct => {}, :cpu => {} }
       end
 
       def get


### PR DESCRIPTION
Is this quick fix reasonable as a temporary workaround to  #6824 , so that logstash doesn't blow up when cgroups information fails?   Just a thought to get some momentum towards a fix.