### PR TITLE
[DOCS] Update link to Logstash security

### DIFF
--- a/docs/static/deploying.asciidoc
+++ b/docs/static/deploying.asciidoc
@@ -120,7 +120,7 @@ Enterprise-grade security is available across the entire delivery chain.
 
 * Wire encryption is recommended for both the transport from
 {filebeat}configuring-ssl-logstash.html[Beats to Logstash] and from
-{xpack-ref}/logstash.html[Logstash to Elasticsearch].
+{logstash-ref}/ls-security.html[Logstash to Elasticsearch].
 * There’s a wealth of security options when communicating with Elasticsearch
 including basic authentication, TLS, PKI, LDAP, AD, and other custom realms.
 To enable Elasticsearch security, consult the


### PR DESCRIPTION
A separate pull request moved the "Logstash and Security" content from the X-Pack Reference (https://www.elastic.co/guide/en/x-pack/master/logstash.html) to the Logstash Reference.

This pull request updates a link to that content 
