### PR TITLE
Metrics: Add Jackson serialization to the Witness classes.

### DIFF
--- a/logstash-core/src/main/java/org/logstash/instrument/witness/MetricSerializer.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/MetricSerializer.java
@@ -1,0 +1,87 @@
+package org.logstash.instrument.witness;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.logstash.instrument.metrics.Metric;
+import org.logstash.instrument.metrics.gauge.GaugeMetric;
+import org.logstash.instrument.metrics.gauge.RubyTimeStampGauge;
+
+import java.io.IOException;
+
+/**
+ * Similar to the {@link java.util.function.Consumer} functional interface this is expected to operate via side effects. Differs from {@link java.util.function.Consumer} in that
+ * this is stricter typed, and allows for a checked {@link IOException}.
+ *
+ * @param <T> The type of {@link GaugeMetric} to serialize
+ */
+@FunctionalInterface
+public interface MetricSerializer<T extends Metric<?>> {
+
+    /**
+     * Performs this operation on the given argument.
+     *
+     * @param t the input argument
+     */
+    void serialize(T t) throws IOException;
+
+    /**
+     * Helper class to create a functional fluent api.
+     * Usage example: {@code MetricSerializer.Get.longSerializer(gen).serialize(99);}
+     */
+    class Get {
+        /**
+         * Proper way to serialize a {@link Long} type metric to JSON
+         *
+         * @param gen The {@link JsonGenerator} used to generate JSON
+         * @return the {@link MetricSerializer} which is the function used to serialize the metric
+         */
+        static MetricSerializer<Metric<Long>> longSerializer(JsonGenerator gen) {
+            return m -> {
+                if (m != null && m.isDirty() && m.getValue() != null) {
+                    gen.writeNumberField(m.getName(), m.getValue());
+                }
+            };
+        }
+
+        /**
+         * Proper way to serialize a {@link Boolean} type metric to JSON
+         *
+         * @param gen The {@link JsonGenerator} used to generate JSON
+         * @return the {@link MetricSerializer} which is the function used to serialize the metric
+         */
+        static MetricSerializer<Metric<Boolean>> booleanSerializer(JsonGenerator gen) {
+            return m -> {
+                if (m != null && m.isDirty() && m.getValue() != null) {
+                    gen.writeBooleanField(m.getName(), m.getValue());
+                }
+            };
+        }
+
+        /**
+         * Proper way to serialize a {@link String} type metric to JSON
+         *
+         * @param gen The {@link JsonGenerator} used to generate JSON
+         * @return the {@link MetricSerializer} which is the function used to serialize the metric
+         */
+        static MetricSerializer<Metric<String>> stringSerializer(JsonGenerator gen) {
+            return m -> {
+                if (m != null && m.isDirty() && m.getValue() != null) {
+                    gen.writeStringField(m.getName(), m.getValue());
+                }
+            };
+        }
+
+        /**
+         * Proper way to serialize a {@link RubyTimeStampGauge} type metric to JSON that should emit a {@code null} JSON value if missing
+         *
+         * @param gen The {@link JsonGenerator} used to generate JSON
+         * @return the {@link MetricSerializer} which is the function used to serialize the metric
+         */
+        static MetricSerializer<RubyTimeStampGauge> timestampSerializer(JsonGenerator gen) {
+            return m -> {
+                if (m != null) {
+                    gen.writeStringField(m.getName(), m.getValue() != null ? m.getValue().toString() : null);
+                }
+            };
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/PipelinesWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/PipelinesWitness.java
@@ -1,14 +1,24 @@
 package org.logstash.instrument.witness;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Witness for the set of pipelines.
  */
-final public class PipelinesWitness {
+@JsonSerialize(using = PipelinesWitness.Serializer.class)
+final public class PipelinesWitness implements SerializableWitness {
 
     private final Map<String, PipelineWitness> pipelines;
+
+    private final static String KEY = "pipelines";
+    private static final Serializer SERIALIZER = new Serializer();
 
     /**
      * Constructor.
@@ -25,6 +35,48 @@ final public class PipelinesWitness {
      */
     public PipelineWitness pipeline(String name) {
         return pipelines.computeIfAbsent(name, k -> new PipelineWitness(k));
+    }
+
+    @Override
+    public void genJson(JsonGenerator gen, SerializerProvider provider) throws IOException {
+        SERIALIZER.innerSerialize(this, gen, provider);
+    }
+
+    /**
+     * The Jackson serializer.
+     */
+    public static class Serializer extends StdSerializer<PipelinesWitness> {
+
+        /**
+         * Default constructor - required for Jackson
+         */
+        public Serializer() {
+            this(PipelinesWitness.class);
+        }
+
+        /**
+         * Constructor
+         *
+         * @param t the type to serialize
+         */
+        protected Serializer(Class<PipelinesWitness> t) {
+            super(t);
+        }
+
+        @Override
+        public void serialize(PipelinesWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            gen.writeStartObject();
+            innerSerialize(witness, gen, provider);
+            gen.writeEndObject();
+        }
+
+        void innerSerialize(PipelinesWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            gen.writeObjectFieldStart(KEY);
+            for (Map.Entry<String, PipelineWitness> entry : witness.pipelines.entrySet()) {
+                entry.getValue().genJson(gen, provider);
+            }
+            gen.writeEndObject();
+        }
     }
 
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/PluginWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/PluginWitness.java
@@ -1,16 +1,25 @@
 package org.logstash.instrument.witness;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.logstash.instrument.metrics.Metric;
 import org.logstash.instrument.metrics.gauge.TextGauge;
+
+import java.io.IOException;
 
 /**
  * Witness for a single plugin.
  */
-public class PluginWitness {
+@JsonSerialize(using = PluginWitness.Serializer.class)
+public class PluginWitness implements SerializableWitness {
 
     private final EventsWitness eventsWitness;
     private final TextGauge id;
     private final TextGauge name;
     private final Snitch snitch;
+    private static final Serializer SERIALIZER = new Serializer();
 
     /**
      * Constructor.
@@ -53,6 +62,46 @@ public class PluginWitness {
         return snitch;
     }
 
+    @Override
+    public void genJson(JsonGenerator gen, SerializerProvider provider) throws IOException {
+        SERIALIZER.innerSerialize(this, gen, provider);
+    }
+
+    /**
+     * The Jackson JSON serializer.
+     */
+    public static class Serializer extends StdSerializer<PluginWitness> {
+
+        /**
+         * Default constructor - required for Jackson
+         */
+        public Serializer() {
+            this(PluginWitness.class);
+        }
+
+        /**
+         * Constructor
+         *
+         * @param t the type to serialize
+         */
+        protected Serializer(Class<PluginWitness> t) {
+            super(t);
+        }
+
+        @Override
+        public void serialize(PluginWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            gen.writeStartObject();
+            innerSerialize(witness, gen, provider);
+            gen.writeEndObject();
+        }
+
+        void innerSerialize(PluginWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            MetricSerializer<Metric<String>> stringSerializer = MetricSerializer.Get.stringSerializer(gen);
+            stringSerializer.serialize(witness.id);
+            witness.events().genJson(gen, provider);
+            stringSerializer.serialize(witness.name);
+        }
+    }
 
     /**
      * Snitch for a plugin. Provides discrete metric values.

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/PluginsWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/PluginsWitness.java
@@ -1,16 +1,27 @@
 package org.logstash.instrument.witness;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A Witness for the set of plugins.
  */
-public class PluginsWitness{
+@JsonSerialize(using = PluginsWitness.Serializer.class)
+public class PluginsWitness implements SerializableWitness {
 
     private final Map<String, PluginWitness> inputs;
     private final Map<String, PluginWitness> outputs;
     private final Map<String, PluginWitness> filters;
+    private final Map<String, PluginWitness> codecs;
+    private final static String KEY = "plugins";
+    private static final Serializer SERIALIZER = new Serializer();
 
     /**
      * Constructor.
@@ -20,10 +31,12 @@ public class PluginsWitness{
         this.inputs = new ConcurrentHashMap<>();
         this.outputs = new ConcurrentHashMap<>();
         this.filters = new ConcurrentHashMap<>();
-     }
+        this.codecs = new ConcurrentHashMap<>();
+    }
 
     /**
      * Gets the {@link PluginWitness} for the given id, creates the associated {@link PluginWitness} if needed
+     *
      * @param id the id of the input
      * @return the associated {@link PluginWitness} (for method chaining)
      */
@@ -33,6 +46,7 @@ public class PluginsWitness{
 
     /**
      * Gets the {@link PluginWitness} for the given id, creates the associated {@link PluginWitness} if needed
+     *
      * @param id the id of the output
      * @return the associated {@link PluginWitness} (for method chaining)
      */
@@ -42,11 +56,22 @@ public class PluginsWitness{
 
     /**
      * Gets the {@link PluginWitness} for the given id, creates the associated {@link PluginWitness} if needed
+     *
      * @param id the id of the filter
      * @return the associated {@link PluginWitness} (for method chaining)
      */
     public PluginWitness filters(String id) {
         return getPlugin(filters, id);
+    }
+
+    /**
+     * Gets the {@link PluginWitness} for the given id, creates the associated {@link PluginWitness} if needed
+     *
+     * @param id the id of the codec
+     * @return the associated {@link PluginWitness} (for method chaining)
+     */
+    public PluginWitness codecs(String id) {
+        return getPlugin(codecs, id);
     }
 
     /**
@@ -56,6 +81,7 @@ public class PluginsWitness{
         inputs.clear();
         outputs.clear();
         filters.clear();
+        codecs.clear();
     }
 
     /**
@@ -66,8 +92,62 @@ public class PluginsWitness{
      * @return existing or new {@link PluginWitness}
      */
     private PluginWitness getPlugin(Map<String, PluginWitness> plugin, String id) {
-        return plugin.computeIfAbsent(id, k -> new PluginWitness(k) );
+        return plugin.computeIfAbsent(id, k -> new PluginWitness(k));
     }
 
-}
+    @Override
+    public void genJson(JsonGenerator gen, SerializerProvider provider) throws IOException {
+        SERIALIZER.innerSerialize(this, gen, provider);
+    }
 
+    /**
+     * The Jackson serializer.
+     */
+    public static class Serializer extends StdSerializer<PluginsWitness> {
+
+        /**
+         * Default constructor - required for Jackson
+         */
+        public Serializer() {
+            this(PluginsWitness.class);
+        }
+
+        /**
+         * Constructor
+         *
+         * @param t the type to serialize
+         */
+        protected Serializer(Class<PluginsWitness> t) {
+            super(t);
+        }
+
+        @Override
+        public void serialize(PluginsWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            gen.writeStartObject();
+            innerSerialize(witness, gen, provider);
+            gen.writeEndObject();
+        }
+
+        void innerSerialize(PluginsWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            gen.writeObjectFieldStart(KEY);
+
+            serializePlugins("inputs", witness.inputs, gen, provider);
+            serializePlugins("filters", witness.filters, gen, provider);
+            serializePlugins("outputs", witness.outputs, gen, provider);
+            //codec is not serialized
+
+            gen.writeEndObject();
+        }
+
+        private void serializePlugins(String key, Map<String, PluginWitness> plugin, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            gen.writeArrayFieldStart(key);
+            for (Map.Entry<String, PluginWitness> entry : plugin.entrySet()) {
+                gen.writeStartObject();
+                entry.getValue().genJson(gen, provider);
+                gen.writeEndObject();
+            }
+            gen.writeEndArray();
+
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/QueueWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/QueueWitness.java
@@ -1,14 +1,23 @@
 package org.logstash.instrument.witness;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import org.logstash.instrument.metrics.gauge.TextGauge;
+
+import java.io.IOException;
 
 /**
  * Witness for the queue.
  */
-final public class QueueWitness {
+@JsonSerialize(using = QueueWitness.Serializer.class)
+final public class QueueWitness implements SerializableWitness {
 
     private final TextGauge type;
     private final Snitch snitch;
+    private final static String KEY = "queue";
+    private static final Serializer SERIALIZER = new Serializer();
 
     /**
      * Constructor.
@@ -34,6 +43,45 @@ final public class QueueWitness {
      */
     public void type(String type) {
         this.type.set(type);
+    }
+
+    @Override
+    public void genJson(JsonGenerator gen, SerializerProvider provider) throws IOException {
+        SERIALIZER.innerSerialize(this, gen, provider);
+    }
+
+    /**
+     * The Jackson serializer.
+     */
+    public static class Serializer extends StdSerializer<QueueWitness> {
+        /**
+         * Default constructor - required for Jackson
+         */
+        public Serializer() {
+            this(QueueWitness.class);
+        }
+
+        /**
+         * Constructor
+         *
+         * @param t the type to serialize
+         */
+        protected Serializer(Class<QueueWitness> t) {
+            super(t);
+        }
+
+        @Override
+        public void serialize(QueueWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            gen.writeStartObject();
+            innerSerialize(witness, gen, provider);
+            gen.writeEndObject();
+        }
+
+        void innerSerialize(QueueWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            gen.writeObjectFieldStart(KEY);
+            MetricSerializer.Get.stringSerializer(gen).serialize(witness.type);
+            gen.writeEndObject();
+        }
     }
 
     /**

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/ReloadWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/ReloadWitness.java
@@ -1,14 +1,22 @@
 package org.logstash.instrument.witness;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import org.logstash.Timestamp;
 import org.logstash.ext.JrubyTimestampExtLibrary;
+import org.logstash.instrument.metrics.Metric;
 import org.logstash.instrument.metrics.counter.LongCounter;
 import org.logstash.instrument.metrics.gauge.RubyTimeStampGauge;
+
+import java.io.IOException;
 
 /**
  * A witness to record reloads.
  */
-final public class ReloadWitness {
+@JsonSerialize(using = ReloadWitness.Serializer.class)
+final public class ReloadWitness implements SerializableWitness {
 
     private final LongCounter success;
     private final LongCounter failure;
@@ -16,6 +24,9 @@ final public class ReloadWitness {
     private final RubyTimeStampGauge lastSuccessTimestamp;
     private final RubyTimeStampGauge lastFailureTimestamp;
     private final Snitch snitch;
+    private static final Serializer SERIALIZER = new Serializer();
+
+    private final static String KEY = "reloads";
 
     /**
      * Constructor.
@@ -26,6 +37,11 @@ final public class ReloadWitness {
         lastError = new ErrorWitness();
         lastSuccessTimestamp = new RubyTimeStampGauge("last_success_timestamp");
         lastFailureTimestamp = new RubyTimeStampGauge("last_failure_timestamp");
+        //Legacy Ruby API initializes all of these to zero, resulting in the dirty flag
+        success.setDirty(true);
+        failure.setDirty(true);
+        lastFailureTimestamp.setDirty(true);
+        lastFailureTimestamp.setDirty(true);
         snitch = new Snitch(this);
     }
 
@@ -97,6 +113,52 @@ final public class ReloadWitness {
      */
     public void lastFailureTimestamp(JrubyTimestampExtLibrary.RubyTimestamp timestamp) {
         lastFailureTimestamp.set(timestamp);
+    }
+
+    @Override
+    public void genJson(JsonGenerator gen, SerializerProvider provider) throws IOException {
+        SERIALIZER.innerSerialize(this, gen, provider);
+    }
+
+    /**
+     * The Jackson serializer.
+     */
+    public static class Serializer extends StdSerializer<ReloadWitness> {
+
+        /**
+         * Default constructor - required for Jackson
+         */
+        public Serializer() {
+            this(ReloadWitness.class);
+        }
+
+        /**
+         * Constructor
+         *
+         * @param t the type to serialize
+         */
+        protected Serializer(Class<ReloadWitness> t) {
+            super(t);
+        }
+
+        @Override
+        public void serialize(ReloadWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            gen.writeStartObject();
+            innerSerialize(witness, gen, provider);
+            gen.writeEndObject();
+        }
+
+        void innerSerialize(ReloadWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            gen.writeObjectFieldStart(ReloadWitness.KEY);
+            witness.lastError.genJson(gen, provider);
+            MetricSerializer<Metric<Long>> longSerializer = MetricSerializer.Get.longSerializer(gen);
+            MetricSerializer<RubyTimeStampGauge> timestampSerializer = MetricSerializer.Get.timestampSerializer(gen);
+            longSerializer.serialize(witness.success);
+            timestampSerializer.serialize(witness.lastSuccessTimestamp);
+            timestampSerializer.serialize(witness.lastFailureTimestamp);
+            longSerializer.serialize(witness.failure);
+            gen.writeEndObject();
+        }
     }
 
     /**

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/SerializableWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/SerializableWitness.java
@@ -1,0 +1,45 @@
+package org.logstash.instrument.witness;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+/**
+ * A Witness that can be serialized as JSON. A Witness is an abstraction to the {@link org.logstash.instrument.metrics.Metric}'s that watches/witnesses what is happening inside
+ * of Logstash.
+ */
+public interface SerializableWitness {
+
+    /**
+     * Generates the corresponding JSON for the witness.
+     *
+     * @param gen      The {@link JsonGenerator} used to generate the JSON
+     * @param provider The {@link SerializerProvider} that may be used to assist with the JSON generation.
+     * @throws IOException if any errors occur in JSON generation
+     */
+    void genJson(final JsonGenerator gen, SerializerProvider provider) throws IOException;
+
+    /**
+     * Helper method to return the Witness as a JSON string.
+     *
+     * @return A {@link String} whose content is the JSON representation for the witness.
+     * @throws IOException if any errors occur in JSON generation
+     */
+    default String asJson() throws IOException {
+        JsonFactory jsonFactory = new JsonFactory();
+        try (StringWriter sw = new StringWriter();
+             JsonGenerator gen = jsonFactory.createGenerator(sw)) {
+            ObjectMapper mapper = new ObjectMapper(jsonFactory);
+            gen.writeStartObject();
+            genJson(gen, mapper.getSerializerProvider());
+            gen.writeEndObject();
+            gen.flush();
+            sw.flush();
+            return sw.toString();
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/Witness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/Witness.java
@@ -1,9 +1,15 @@
 package org.logstash.instrument.witness;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
 import java.util.Arrays;
 
 /**
- * <p>Primary entry point for the Witness subsystem. The Witness subsystem is an abstraction for the {@link org.logstash.instrument.metrics.Metric}'s that watches/witnesses what
+ * <p>Primary entry point for the Witness subsystem. The Witness subsystem is an abstraction for the {@link org.logstash.instrument.metrics.Metric}'s  that watches/witnesses what
  * is happening inside Logstash. </p>
  * <p>Usage example to increment the events counter for the foo input in the main pipeline:
  * {@code Witness.instance().pipeline("main").inputs("foo").events().in(1);}
@@ -12,13 +18,15 @@ import java.util.Arrays;
  * <p>A Witness may also be a snitch. Which means that those witnesses may expose a {@code snitch()} method to retrieve the underlying metric values without JSON serialization.</p>
  * <p>All Witnesses are capable of serializing their underlying metrics as JSON.</p>
  */
-final public class Witness {
+@JsonSerialize(using = Witness.Serializer.class)
+final public class Witness implements SerializableWitness {
 
     private final ReloadWitness reloadWitness;
     private final EventsWitness eventsWitness;
     private final PipelinesWitness pipelinesWitness;
 
     private static Witness _instance;
+    private static final Serializer SERIALIZER = new Serializer();
 
     /**
      * Constructor. Consumers should use {@link #instance()} method to obtain an instance of this class.
@@ -86,4 +94,43 @@ final public class Witness {
         return pipelinesWitness.pipeline(name);
     }
 
+    @Override
+    public void genJson(JsonGenerator gen, SerializerProvider provider) throws IOException {
+        SERIALIZER.innerSerialize(this, gen, provider);
+    }
+
+    /**
+     * The Jackson serializer.
+     */
+    static class Serializer extends StdSerializer<Witness> {
+
+        /**
+         * Default constructor - required for Jackson
+         */
+        public Serializer() {
+            this(Witness.class);
+        }
+
+        /**
+         * Constructor
+         *
+         * @param t the type to serialize
+         */
+        protected Serializer(Class<Witness> t) {
+            super(t);
+        }
+
+        @Override
+        public void serialize(Witness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            gen.writeStartObject();
+            innerSerialize(witness, gen, provider);
+            gen.writeEndObject();
+        }
+
+        void innerSerialize(Witness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            witness.events().genJson(gen, provider);
+            witness.reloads().genJson(gen, provider);
+            witness.pipelinesWitness.genJson(gen, provider);
+        }
+    }
 }

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/ConfigWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/ConfigWitnessTest.java
@@ -1,5 +1,6 @@
 package org.logstash.instrument.witness;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -56,6 +57,60 @@ public class ConfigWitnessTest {
     public void testWorkers() {
         witness.workers(96);
         assertThat(witness.snitch().workers()).isEqualTo(96);
+    }
+
+    @Test
+    public void testAsJson() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        assertThat(mapper.writeValueAsString(witness)).isEqualTo(witness.asJson()).contains("config");
+    }
+
+    @Test
+    public void testSerializeEmpty() throws Exception {
+        String json = witness.asJson();
+        assertThat(json).isEqualTo("{\"config\":{}}");
+    }
+
+    @Test
+    public void testSerializeBatchSize() throws Exception {
+        witness.batchSize(999);
+        String json = witness.asJson();
+        assertThat(json).contains("999");
+    }
+
+    @Test
+    public void testSerializeWorkersSize() throws Exception {
+        witness.workers(888);
+        String json = witness.asJson();
+        assertThat(json).isEqualTo("{\"config\":{\"workers\":888}}");
+    }
+
+    @Test
+    public void testSerializeBatchDelay() throws Exception {
+        witness.batchDelay(777);
+        String json = witness.asJson();
+        assertThat(json).isEqualTo("{\"config\":{\"batch_delay\":777}}");
+    }
+
+    @Test
+    public void testSerializeAutoConfigReload() throws Exception {
+        witness.configReloadAutomatic(true);
+        String json = witness.asJson();
+        assertThat(json).isEqualTo("{\"config\":{\"config_reload_automatic\":true}}");
+    }
+
+    @Test
+    public void testSerializeReloadInterval() throws Exception {
+        witness.configReloadInterval(666);
+        String json = witness.asJson();
+        assertThat(json).isEqualTo("{\"config\":{\"config_reload_interval\":666}}");
+    }
+
+    @Test
+    public void testSerializeEnableDeadLetterQueue() throws Exception {
+        witness.deadLetterQueueEnabled(true);
+        String json = witness.asJson();
+        assertThat(json).isEqualTo("{\"config\":{\"dead_letter_queue_enabled\":true}}");
     }
 
 }

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/ErrorWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/ErrorWitnessTest.java
@@ -1,5 +1,6 @@
 package org.logstash.instrument.witness;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -26,7 +27,7 @@ public class ErrorWitnessTest {
         //as Exception
         RuntimeException exception = new RuntimeException("foobar");
         witness.backtrace(exception);
-        for(StackTraceElement element : exception.getStackTrace()){
+        for (StackTraceElement element : exception.getStackTrace()) {
             assertThat(witness.snitch().backtrace()).contains(element.toString());
         }
     }
@@ -35,5 +36,35 @@ public class ErrorWitnessTest {
     public void message() {
         witness.message("baz");
         assertThat(witness.snitch().message()).isEqualTo("baz");
+    }
+
+    @Test
+    public void testAsJson() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        assertThat(mapper.writeValueAsString(witness)).isEqualTo(witness.asJson()).contains("last_error");
+    }
+
+    @Test
+    public void testSerializeEmpty() throws Exception {
+        String json = witness.asJson();
+        assertThat(json).isEqualTo("{\"last_error\":null}");
+    }
+
+    @Test
+    public void testSerializeMessage() throws Exception {
+        witness.message("whoops");
+        String json = witness.asJson();
+        assertThat(json).isEqualTo("{\"last_error\":{\"message\":\"whoops\"}}");
+    }
+
+    @Test
+    public void testSerializeBackTrace() throws Exception {
+        witness.backtrace("ruby, backtrace");
+        String json = witness.asJson();
+        assertThat(json).contains("ruby").contains("backtrace");
+
+        witness.backtrace(new RuntimeException("Uh oh!"));
+        json = witness.asJson();
+        assertThat(json).contains("Uh oh!").contains("ErrorWitnessTest");
     }
 }

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/EventsWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/EventsWitnessTest.java
@@ -1,5 +1,6 @@
 package org.logstash.instrument.witness;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -76,6 +77,72 @@ public class EventsWitnessTest {
         assertThat(witness.snitch().queuePushDuration()).isEqualTo(44);
         witness.queuePushDuration(1);
         assertThat(witness.snitch().queuePushDuration()).isEqualTo(45);
+    }
+
+    @Test
+    public void testAsJson() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        //empty
+        assertThat(mapper.writeValueAsString(witness)).isEqualTo(witness.asJson()).isEmpty();
+        //dirty
+        witness.in(1);
+        assertThat(mapper.writeValueAsString(witness)).isEqualTo(witness.asJson()).contains("events");
+    }
+
+    @Test
+    public void testSerializeEmpty() throws Exception {
+        //Due to legacy requirements if empty, the events should not serialize at all.
+        assertThat(witness.asJson()).isEmpty();
+    }
+
+    @Test
+    public void testSerializeDuration() throws Exception {
+        witness.duration(999);
+        String json = witness.asJson();
+        assertThat(json).contains("999");
+        witness.forgetAll();
+        json = witness.asJson();
+        assertThat(json).doesNotContain("999");
+    }
+
+    @Test
+    public void testSerializeIn() throws Exception {
+        witness.in(888);
+        String json = witness.asJson();
+        assertThat(json).contains("888");
+        witness.forgetAll();
+        json = witness.asJson();
+        assertThat(json).doesNotContain("888");
+    }
+
+    @Test
+    public void testSerializeFiltered() throws Exception {
+        witness.filtered(777);
+        String json = witness.asJson();
+        assertThat(json).contains("777");
+        witness.forgetAll();
+        json = witness.asJson();
+        assertThat(json).doesNotContain("777");
+    }
+
+    @Test
+    public void testSerializeOut() throws Exception {
+        witness.out(666);
+        String json = witness.asJson();
+        assertThat(json).contains("666");
+        witness.forgetAll();
+        json = witness.asJson();
+        assertThat(json).doesNotContain("666");
+    }
+
+    @Test
+    public void testSerializeQueueDuration() throws Exception {
+        witness.queuePushDuration(555);
+        String json = witness.asJson();
+        assertThat(json).contains("555");
+        witness.forgetAll();
+        json = witness.asJson();
+        assertThat(json).doesNotContain("555");
     }
 
 }

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/PipelinesWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/PipelinesWitnessTest.java
@@ -1,5 +1,6 @@
 package org.logstash.instrument.witness;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -24,6 +25,27 @@ public class PipelinesWitnessTest {
         assertThat(witness.pipeline("default")).isNotNull();
         //again to assert it can pull from the map
         assertThat(witness.pipeline("default")).isNotNull();
+    }
+
+    @Test
+    public void testAsJson() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        assertThat(mapper.writeValueAsString(witness)).isEqualTo(witness.asJson()).contains("pipelines");
+    }
+
+    @Test
+    public void testSerializeEmpty() throws Exception {
+        String json = witness.asJson();
+        assertThat(json).isEqualTo("{\"pipelines\":{}}");
+    }
+
+    @Test
+    public void testSerializePipelines() throws Exception {
+        witness.pipeline("aaa");
+        witness.pipeline("bbb");
+        witness.pipeline("ccc");
+        String json = witness.asJson();
+        assertThat(json).contains("aaa").contains("bbb").contains("ccc");
     }
 
 }

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/PluginWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/PluginWitnessTest.java
@@ -1,6 +1,7 @@
 package org.logstash.instrument.witness;
 
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -28,5 +29,31 @@ public class PluginWitnessTest {
     @Test
     public void testEvents(){
         assertThat(witness.events()).isNotNull();
+    }
+
+    @Test
+    public void testAsJson() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        assertThat(mapper.writeValueAsString(witness)).isEqualTo(witness.asJson());
+    }
+
+    @Test
+    public void testSerializationEmpty() throws Exception {
+        String json = witness.asJson();
+        assertThat(json).isEqualTo("{\"id\":\"123\"}");
+    }
+
+    @Test
+    public void testSerializationName() throws Exception {
+        witness.name("abc");
+        String json = witness.asJson();
+        assertThat(json).isEqualTo("{\"id\":\"123\",\"name\":\"abc\"}");
+    }
+
+    @Test
+    public void testSerializationEvents() throws Exception {
+        witness.events().in();
+        String json = witness.asJson();
+        assertThat(json).isEqualTo("{\"id\":\"123\",\"events\":{\"in\":1}}");
     }
 }

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/PluginsWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/PluginsWitnessTest.java
@@ -1,6 +1,7 @@
 package org.logstash.instrument.witness;
 
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -26,11 +27,67 @@ public class PluginsWitnessTest {
         assertThat(witness.filters("1").events().snitch().in()).isEqualTo(98);
         witness.outputs("1").events().in(97);
         assertThat(witness.outputs("1").events().snitch().in()).isEqualTo(97);
+        witness.codecs("1").events().in(96);
+        assertThat(witness.codecs("1").events().snitch().in()).isEqualTo(96);
 
         witness.forgetAll();
 
         assertThat(witness.inputs("1").events().snitch().in()).isEqualTo(0);
         assertThat(witness.filters("1").events().snitch().filtered()).isEqualTo(0);
         assertThat(witness.outputs("1").events().snitch().in()).isEqualTo(0);
+        assertThat(witness.codecs("1").events().snitch().in()).isEqualTo(0);
+    }
+
+    @Test
+    public void testAsJson() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        assertThat(mapper.writeValueAsString(witness)).isEqualTo(witness.asJson());
+    }
+
+    @Test
+    public void testSerializeEmpty() throws Exception{
+        String json = witness.asJson();
+        assertThat(json).isEqualTo("{\"plugins\":{\"inputs\":[],\"filters\":[],\"outputs\":[]}}");
+    }
+
+    @Test
+    public void testSerializeInput() throws Exception{
+        witness.inputs("foo");
+        String json = witness.asJson();
+        assertThat(json).isEqualTo("{\"plugins\":{\"inputs\":[{\"id\":\"foo\"}],\"filters\":[],\"outputs\":[]}}");
+        witness.forgetAll();
+        json = witness.asJson();
+        assertThat(json).isEqualTo("{\"plugins\":{\"inputs\":[],\"filters\":[],\"outputs\":[]}}");
+    }
+
+    @Test
+    public void testSerializeFilters() throws Exception{
+        witness.filters("foo");
+        String json = witness.asJson();
+        assertThat(json).isEqualTo("{\"plugins\":{\"inputs\":[],\"filters\":[{\"id\":\"foo\"}],\"outputs\":[]}}");
+        witness.forgetAll();
+        json = witness.asJson();
+        assertThat(json).isEqualTo("{\"plugins\":{\"inputs\":[],\"filters\":[],\"outputs\":[]}}");
+    }
+
+    @Test
+    public void testSerializeOutputs() throws Exception{
+        witness.outputs("foo");
+        String json = witness.asJson();
+        assertThat(json).isEqualTo("{\"plugins\":{\"inputs\":[],\"filters\":[],\"outputs\":[{\"id\":\"foo\"}]}}");
+        witness.forgetAll();
+        json = witness.asJson();
+        assertThat(json).isEqualTo("{\"plugins\":{\"inputs\":[],\"filters\":[],\"outputs\":[]}}");
+    }
+
+    @Test
+    public void testSerializeCodecs() throws Exception{
+        witness.codecs("foo");
+        String json = witness.asJson();
+        //codecs are not currently serialized.
+        assertThat(json).isEqualTo("{\"plugins\":{\"inputs\":[],\"filters\":[],\"outputs\":[]}}");
+        witness.forgetAll();
+        json = witness.asJson();
+        assertThat(json).isEqualTo("{\"plugins\":{\"inputs\":[],\"filters\":[],\"outputs\":[]}}");
     }
 }

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/QueueWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/QueueWitnessTest.java
@@ -1,6 +1,7 @@
 package org.logstash.instrument.witness;
 
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -21,6 +22,25 @@ public class QueueWitnessTest {
     public void testType(){
         witness.type("memory");
         assertThat(witness.snitch().type()).isEqualTo("memory");
+    }
+
+    @Test
+    public void testAsJson() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        assertThat(mapper.writeValueAsString(witness)).isEqualTo(witness.asJson());
+    }
+
+    @Test
+    public void testSerializeEmpty() throws Exception{
+        String json = witness.asJson();
+        assertThat(json).isEqualTo("{\"queue\":{}}");
+    }
+
+    @Test
+    public void testSerializeType() throws Exception{
+        witness.type("memory");
+        String json = witness.asJson();
+        assertThat(json).isEqualTo("{\"queue\":{\"type\":\"memory\"}}");
     }
 
 }

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/WitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/WitnessTest.java
@@ -1,5 +1,6 @@
 package org.logstash.instrument.witness;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -12,19 +13,19 @@ public class WitnessTest {
     private Witness witness;
 
     @Before
-    public void setup(){
+    public void setup() {
         Witness.setInstance(null);
     }
 
     @Test
-    public void testInstance(){
+    public void testInstance() {
         witness = new Witness();
         Witness.setInstance(witness);
         assertThat(Witness.instance()).isEqualTo(witness);
     }
 
     @Test(expected = IllegalStateException.class)
-    public void testNoInstanceError(){
+    public void testNoInstanceError() {
         Witness.instance();
     }
 
@@ -36,5 +37,58 @@ public class WitnessTest {
         assertThat(witness.reloads()).isNotNull();
         assertThat(witness.pipelines()).isNotNull();
         assertThat(witness.pipeline("foo")).isNotNull();
+    }
+
+    @Test
+    public void testAsJson() throws Exception {
+        witness = new Witness();
+        ObjectMapper mapper = new ObjectMapper();
+        assertThat(mapper.writeValueAsString(witness)).isEqualTo(witness.asJson());
+    }
+
+    @Test
+    public void testSerializeEmpty() throws Exception {
+        witness = new Witness();
+        String json = witness.asJson();
+        //empty pipelines
+        assertThat(json).contains("\"pipelines\":{}");
+        //non-empty reloads
+        assertThat(json).contains("{\"reloads\":{\"");
+        //no events
+        assertThat(json).doesNotContain("events");
+    }
+
+    @Test
+    public void testSerializeEvents() throws Exception {
+        witness = new Witness();
+        witness.events().in(99);
+        String json = witness.asJson();
+        assertThat(json).contains("{\"events\":{\"in\":99}");
+        witness.events().forgetAll();
+        json = witness.asJson();
+        assertThat(json).doesNotContain("events");
+    }
+
+    @Test
+    public void testSerializePipelines() throws Exception {
+        witness = new Witness();
+        witness.pipeline("foo").events().in(98);
+        witness.pipeline("foo").inputs("bar").events().in(99);
+        String json = witness.asJson();
+        assertThat(json).contains("\"pipelines\":{\"foo\"");
+        //pipeline events
+        assertThat(json).contains("\"foo\":{\"events\":{\"in\":98");
+        //plugin events
+        assertThat(json).contains("plugins\":{\"inputs\":[{\"id\":\"bar\",\"events\":{\"in\":99");
+        //forget events
+        witness.pipeline("foo").forgetEvents();
+        json = witness.asJson();
+        assertThat(json).doesNotContain("98");
+        //forget plugins
+        witness.pipeline("foo").forgetPlugins();
+        json = witness.asJson();
+        assertThat(json).doesNotContain("99");
+        //pipelines still there
+        assertThat(json).contains("\"pipelines\":{\"foo\"");
     }
 }


### PR DESCRIPTION
This PR builds on  https://github.com/elastic/logstash/pull/7947 by adding in the Jackson Serialization to the `Witness` objects.  

The `dirty` flag and/or other oddities (like explicity pushing a `null` string to JSON) are there for passivity w/r/t the JSON output. I am striving for identical output from the API for 6.x. 

Eventually, for 7.x, we will adopt https://github.com/elastic/logstash/issues/7885 and remove some of the custom rules here. 

Note - matching the JSON output to the Ruby serialization is an ongoing effort, and expect to see some tweaking to this in the reviews to come...but at least for the simplest cases this JSON is identical to the Ruby implementation.  

Part of #7788