### PR TITLE
Revert "create source_loader after logging setup"

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -190,6 +190,12 @@ class LogStash::Runner < Clamp::StrictCommand
     @settings = LogStash::SETTINGS
     @bootstrap_checks = DEFAULT_BOOTSTRAP_CHECKS.dup
 
+    # Default we check local sources: `-e`, `-f` and the logstash.yml options.
+    @source_loader = LogStash::Config::SourceLoader.new(@settings)
+    @source_loader.add_source(LogStash::Config::Source::Local.new(@settings))
+    @source_loader.add_source(LogStash::Config::Source::Modules.new(@settings))
+    @source_loader.add_source(LogStash::Config::Source::MultiLocal.new(@settings))
+
     super(*args)
   end
 
@@ -249,12 +255,6 @@ class LogStash::Runner < Clamp::StrictCommand
       show_version
       return 0
     end
-
-    # Default we check local sources: `-e`, `-f` and the logstash.yml options.
-    @source_loader = LogStash::Config::SourceLoader.new(@settings)
-    @source_loader.add_source(LogStash::Config::Source::Local.new(@settings))
-    @source_loader.add_source(LogStash::Config::Source::Modules.new(@settings))
-    @source_loader.add_source(LogStash::Config::Source::MultiLocal.new(@settings))
 
     # Add local modules to the registry before everything else
     LogStash::Modules::Util.register_local_modules(LogStash::Environment::LOGSTASH_HOME)


### PR DESCRIPTION
This commit broke the plugin contract with plugins like xpack and caused many issues there. Reverted until it can be better handled. There was never a corresponding issue for what this fixed for me to link to, but the original PR was: https://github.com/elastic/logstash/pull/7970

This reverts commit 92cdbe2dbdf3d01e39540522508b679066f6dd93.