### PR TITLE
#7998 Event Serialization Benchmark and Afterburner Removal

### DIFF
--- a/logstash-core/benchmarks/build.gradle
+++ b/logstash-core/benchmarks/build.gradle
@@ -44,7 +44,7 @@ dependencies {
   compile 'com.google.guava:guava:21.0'
   compile 'commons-io:commons-io:2.5'
   runtime 'joda-time:joda-time:2.8.2'
-  runtime "org.jruby:jruby-core:$jrubyVersion"
+  compile "org.jruby:jruby-core:$jrubyVersion"
 }
 
 javadoc {

--- a/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/EventSerializationBenchmark.java
+++ b/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/EventSerializationBenchmark.java
@@ -1,0 +1,79 @@
+package org.logstash.benchmark;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.logstash.Event;
+import org.logstash.Timestamp;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.util.NullOutputStream;
+
+@Warmup(iterations = 3, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+public class EventSerializationBenchmark {
+
+    private static final int EVENTS_PER_INVOCATION = 10_000;
+
+    private static final DataOutputStream SINK = new DataOutputStream(new NullOutputStream());
+
+    private static final Event EVENT = new Event();
+
+    @Setup
+    public void setUp() throws IOException {
+        EVENT.setField("Foo", "Bar");
+        EVENT.setField("Foo1", "Bar1");
+        EVENT.setField("Foo2", "Bar2");
+        EVENT.setField("Foo3", "Bar3");
+        EVENT.setField("Foo4", "Bar4");
+        EVENT.setField("Foo5", new Timestamp(System.currentTimeMillis()));
+        final Map<String, Object> nested = new HashMap<>(5);
+        nested.put("foooo", "baaaaaar");
+        nested.put("fooooish", "baaaaaar234");
+        EVENT.setField("sdfsfsdf", nested);
+        EVENT.setTimestamp(Timestamp.now());
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(EVENTS_PER_INVOCATION)
+    public final void serializeCbor() throws Exception {
+        for (int i = 0; i < EVENTS_PER_INVOCATION; ++i) {
+            SINK.write(EVENT.serialize());
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(EVENTS_PER_INVOCATION)
+    public final void serializeJson() throws Exception {
+        for (int i = 0; i < EVENTS_PER_INVOCATION; ++i) {
+            SINK.writeBytes(EVENT.toJson());
+        }
+    }
+
+    public static void main(final String... args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+            .include(EventSerializationBenchmark.class.getSimpleName())
+            .forks(2)
+            .build();
+        new Runner(opt).run();
+    }
+}

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -105,7 +105,6 @@ dependencies {
     compile 'com.fasterxml.jackson.core:jackson-core:2.7.3'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.7.3'
     compile 'com.fasterxml.jackson.core:jackson-annotations:2.7.3'
-    compile 'com.fasterxml.jackson.module:jackson-module-afterburner:2.7.3'
     compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.7.3'
     testCompile 'org.apache.logging.log4j:log4j-core:2.6.2:tests'
     testCompile 'org.apache.logging.log4j:log4j-api:2.6.2:tests'

--- a/logstash-core/src/main/java/org/logstash/ObjectMappers.java
+++ b/logstash-core/src/main/java/org/logstash/ObjectMappers.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.NonTypedScalarSerializerBase;
 import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
 import com.fasterxml.jackson.dataformat.cbor.CBORGenerator;
-import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import java.io.IOException;
 import java.util.HashMap;
 import org.jruby.RubyFloat;
@@ -21,12 +20,12 @@ public final class ObjectMappers {
             .addSerializer(RubyString.class, new RubyStringSerializer())
             .addSerializer(RubyFloat.class, new RubyFloatSerializer());
 
-    public static final ObjectMapper JSON_MAPPER = new ObjectMapper()
-        .registerModule(new AfterburnerModule()).registerModule(RUBY_SERIALIZERS);
+    public static final ObjectMapper JSON_MAPPER = 
+        new ObjectMapper().registerModule(RUBY_SERIALIZERS);
 
     public static final ObjectMapper CBOR_MAPPER = new ObjectMapper(
         new CBORFactory().configure(CBORGenerator.Feature.WRITE_MINIMAL_INTS, false)
-    ).registerModule(new AfterburnerModule()).registerModule(RUBY_SERIALIZERS);
+    ).registerModule(RUBY_SERIALIZERS);
 
     /**
      * {@link JavaType} for the {@link HashMap} that {@link Event} is serialized as.


### PR DESCRIPTION
As discussed in #7998 

* `Afterburner` seems to not add anything performance wise + Afterburner adds potential instabilities + forces us to use a mix of annotations and explicit serializer registering => removing it is a reasonable cleanup
* Had to compile JRuby into the benchmark now to get the dependencies for setting a timestamp on the `Event`