### PR TITLE
bump to 6.0.0-beta2

### DIFF
--- a/logstash-core-plugin-api/logstash-core-plugin-api.gemspec
+++ b/logstash-core-plugin-api/logstash-core-plugin-api.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = LOGSTASH_CORE_PLUGIN_API
 
-  gem.add_runtime_dependency "logstash-core", "6.0.0.beta1"
+  gem.add_runtime_dependency "logstash-core", "6.0.0.beta2"
 
   # Make sure we dont build this gem from a non jruby
   # environment.

--- a/logstash-core/lib/logstash-core/version.rb
+++ b/logstash-core/lib/logstash-core/version.rb
@@ -5,4 +5,4 @@
 # Note to authors: this should not include dashes because 'gem' barfs if
 # you include a dash in the version string.
 
-LOGSTASH_CORE_VERSION = "6.0.0-beta1"
+LOGSTASH_CORE_VERSION = "6.0.0-beta2"

--- a/logstash-core/lib/logstash/version.rb
+++ b/logstash-core/lib/logstash/version.rb
@@ -11,4 +11,4 @@
 #       eventually this file should be in the root logstash lib fir and dependencies in logstash-core should be
 #       fixed.
 
-LOGSTASH_VERSION = "6.0.0-beta1"
+LOGSTASH_VERSION = "6.0.0-beta2"

--- a/versions.yml
+++ b/versions.yml
@@ -1,6 +1,6 @@
 ---
-logstash: 6.0.0-beta1
-logstash-core: 6.0.0-beta1
+logstash: 6.0.0-beta2
+logstash-core: 6.0.0-beta2
 logstash-core-plugin-api: 2.1.16
 jruby:
   version: 9.1.12.0


### PR DESCRIPTION
bump version to 6.0.0-beta2
this will also fix the currently failing x-pack build on 6.0 branch.

tested locally:
`rake test:core` on logstash
`clean check integTest` on x-pack
