### PR TITLE
Metrics: Consistent serialization

### DIFF
--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractMetric.java
@@ -3,9 +3,6 @@ package org.logstash.instrument.metrics;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import java.util.Arrays;
-import java.util.List;
-
 /**
  * Abstract implementation of a {@link Metric}. All metrics should subclass this.
  *

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/Metric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/Metric.java
@@ -59,18 +59,4 @@ public interface Metric<T> {
         return getType().asString();
     }
 
-    /**
-     * Determine if this metric has a value explicitly set.
-     * @return true if this metric has been set to a specific value, false if it is the default state
-     * @deprecated - This will be removed in the next release.
-     */
-    boolean isDirty();
-
-    /**
-     * Sets the dirty state of this metric. A metric is dirty if it is anything other then it's default state.
-     *
-     * @param dirty the dirty state
-     * @deprecated - This will be removed in the next release.
-     */
-    void setDirty(boolean dirty);
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/counter/LongCounter.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/counter/LongCounter.java
@@ -14,7 +14,6 @@ public class LongCounter extends AbstractMetric<Long> implements CounterMetric<L
 
     private static final IllegalArgumentException NEGATIVE_COUNT_EXCEPTION = new IllegalArgumentException("Counters can not be incremented by negative values");
     private LongAdder longAdder;
-    private boolean dirty;
 
     /**
      * Constructor
@@ -37,16 +36,6 @@ public class LongCounter extends AbstractMetric<Long> implements CounterMetric<L
     }
 
     @Override
-    public boolean isDirty() {
-        return dirty;
-    }
-
-    @Override
-    public void setDirty(boolean dirty){
-        this.dirty = dirty;
-    }
-
-    @Override
     public void increment() {
         increment(1l);
     }
@@ -57,7 +46,6 @@ public class LongCounter extends AbstractMetric<Long> implements CounterMetric<L
             throw NEGATIVE_COUNT_EXCEPTION;
         }
         longAdder.add(by);
-        dirty = true;
     }
 
     /**
@@ -69,7 +57,6 @@ public class LongCounter extends AbstractMetric<Long> implements CounterMetric<L
             throw NEGATIVE_COUNT_EXCEPTION;
         }
         longAdder.add(by);
-        dirty = true;
     }
 
     /**
@@ -78,7 +65,6 @@ public class LongCounter extends AbstractMetric<Long> implements CounterMetric<L
     public void reset(){
         //replacing since LongAdder#reset "is only effective if there are no concurrent updates", we can not make that guarantee
         longAdder = new LongAdder();
-        dirty = false;
     }
 
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/AbstractGaugeMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/AbstractGaugeMetric.java
@@ -8,8 +8,6 @@ import org.logstash.instrument.metrics.AbstractMetric;
  */
 public abstract class AbstractGaugeMetric<T> extends AbstractMetric<T> implements GaugeMetric<T,T>{
 
-    private boolean dirty;
-
     private volatile T value;
 
     /**
@@ -30,19 +28,8 @@ public abstract class AbstractGaugeMetric<T> extends AbstractMetric<T> implement
     public AbstractGaugeMetric(String name, T initialValue) {
         super(name);
         this.value = initialValue;
-        setDirty(true);
-
     }
 
-    @Override
-    public boolean isDirty() {
-        return dirty;
-    }
-
-    @Override
-    public void setDirty(boolean dirty){
-        this.dirty = dirty;
-    }
 
     @Override
     public T getValue() {
@@ -53,7 +40,6 @@ public abstract class AbstractGaugeMetric<T> extends AbstractMetric<T> implement
     @Override
     public void set(T value) {
         this.value = value;
-        setDirty(true);
     }
 
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGauge.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGauge.java
@@ -3,7 +3,6 @@ package org.logstash.instrument.metrics.gauge;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jruby.RubyHash;
-import org.logstash.Timestamp;
 import org.logstash.ext.JrubyTimestampExtLibrary.RubyTimestamp;
 import org.logstash.instrument.metrics.AbstractMetric;
 import org.logstash.instrument.metrics.MetricType;
@@ -69,22 +68,12 @@ public class LazyDelegatingGauge extends AbstractMetric<Object> implements Gauge
     }
 
     @Override
-    public boolean isDirty() {
-        return lazyMetric == null ? false : lazyMetric.isDirty();
-    }
-
-    @Override
     public void set(Object value) {
         if (lazyMetric == null) {
             wakeMetric(value);
         } else {
             lazyMetric.set(value);
         }
-    }
-
-    @Override
-    public void setDirty(boolean dirty) {
-        lazyMetric.setDirty(dirty);
     }
 
     /**
@@ -112,7 +101,6 @@ public class LazyDelegatingGauge extends AbstractMetric<Object> implements Gauge
                         "log an issue to the responsible developer/development team.", value.getClass().getCanonicalName(), key, nameSpaces);
                 lazyMetric = new UnknownGauge(key, value);
             }
-            lazyMetric.setDirty(true);
         }
     }
 

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/RubyHashGauge.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/RubyHashGauge.java
@@ -1,11 +1,7 @@
 package org.logstash.instrument.metrics.gauge;
 
 import org.jruby.RubyHash;
-import org.logstash.instrument.metrics.AbstractMetric;
 import org.logstash.instrument.metrics.MetricType;
-
-
-import java.util.List;
 
 /**
  * A {@link GaugeMetric} that is backed by a {@link RubyHash}.  Note - This should not be used directly from Java code and exists for passivity with legacy Ruby code. Depending

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/RubyTimeStampGauge.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/RubyTimeStampGauge.java
@@ -1,12 +1,9 @@
 package org.logstash.instrument.metrics.gauge;
 
 import org.logstash.Timestamp;
-import org.logstash.bivalues.BiValues;
 import org.logstash.ext.JrubyTimestampExtLibrary.RubyTimestamp;
 import org.logstash.instrument.metrics.AbstractMetric;
 import org.logstash.instrument.metrics.MetricType;
-
-import java.util.List;
 
 /**
  * A {@link GaugeMetric} that is set by a {@link RubyTimestamp}, and retrieved/serialized as a {@link Timestamp}.  Note - This should not be used directly from Java code and
@@ -16,8 +13,6 @@ import java.util.List;
 public class RubyTimeStampGauge extends AbstractMetric<Timestamp> implements GaugeMetric<Timestamp, RubyTimestamp> {
 
     private volatile Timestamp value;
-
-    private volatile boolean dirty;
 
     /**
      * Constructor
@@ -39,7 +34,6 @@ public class RubyTimeStampGauge extends AbstractMetric<Timestamp> implements Gau
     protected RubyTimeStampGauge(String key, RubyTimestamp initialValue) {
         super(key);
         this.value = initialValue == null ? null : initialValue.getTimestamp();
-        setDirty(true);
     }
 
     @Override
@@ -53,18 +47,7 @@ public class RubyTimeStampGauge extends AbstractMetric<Timestamp> implements Gau
     }
 
     @Override
-    public boolean isDirty() {
-        return dirty;
-    }
-
-    @Override
-    public void setDirty(boolean dirty) {
-        this.dirty = dirty;
-    }
-
-    @Override
     public void set(RubyTimestamp value) {
         this.value = value == null ? null : value.getTimestamp();
-        setDirty(true);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/ErrorWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/ErrorWitness.java
@@ -24,8 +24,6 @@ public class ErrorWitness implements SerializableWitness {
     private final static String KEY = "last_error";
     private static final Serializer SERIALIZER = new Serializer();
 
-    private boolean dirty; //here for passivity with legacy Ruby implementation
-
     public ErrorWitness() {
         message = new TextGauge("message");
         backtrace = new TextGauge("backtrace");
@@ -39,7 +37,6 @@ public class ErrorWitness implements SerializableWitness {
      */
     public void backtrace(String stackTrace) {
         this.backtrace.set(stackTrace);
-        dirty = true;
     }
 
     /**
@@ -49,7 +46,6 @@ public class ErrorWitness implements SerializableWitness {
      */
     public void message(String message) {
         this.message.set(message);
-        dirty = true;
     }
 
     /**
@@ -115,15 +111,11 @@ public class ErrorWitness implements SerializableWitness {
         }
 
         void innerSerialize(ErrorWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
-            if (witness.dirty) {
-                gen.writeObjectFieldStart(KEY);
-                MetricSerializer<Metric<String>> stringSerializer = MetricSerializer.Get.stringSerializer(gen);
-                stringSerializer.serialize(witness.message);
-                stringSerializer.serialize(witness.backtrace);
-                gen.writeEndObject();
-            } else {
-                gen.writeStringField(KEY, null);
-            }
+            gen.writeObjectFieldStart(KEY);
+            MetricSerializer<Metric<String>> stringSerializer = MetricSerializer.Get.stringSerializer(gen);
+            stringSerializer.serialize(witness.message);
+            stringSerializer.serialize(witness.backtrace);
+            gen.writeEndObject();
         }
     }
 

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/MetricSerializer.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/MetricSerializer.java
@@ -36,7 +36,7 @@ public interface MetricSerializer<T extends Metric<?>> {
          */
         static MetricSerializer<Metric<Long>> longSerializer(JsonGenerator gen) {
             return m -> {
-                if (m != null && m.isDirty() && m.getValue() != null) {
+                if (m != null && m.getValue() != null) {
                     gen.writeNumberField(m.getName(), m.getValue());
                 }
             };
@@ -50,7 +50,7 @@ public interface MetricSerializer<T extends Metric<?>> {
          */
         static MetricSerializer<Metric<Boolean>> booleanSerializer(JsonGenerator gen) {
             return m -> {
-                if (m != null && m.isDirty() && m.getValue() != null) {
+                if (m != null && m.getValue() != null) {
                     gen.writeBooleanField(m.getName(), m.getValue());
                 }
             };
@@ -64,7 +64,7 @@ public interface MetricSerializer<T extends Metric<?>> {
          */
         static MetricSerializer<Metric<String>> stringSerializer(JsonGenerator gen) {
             return m -> {
-                if (m != null && m.isDirty() && m.getValue() != null) {
+                if (m != null && m.getValue() != null) {
                     gen.writeStringField(m.getName(), m.getValue());
                 }
             };

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/ReloadWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/ReloadWitness.java
@@ -37,11 +37,6 @@ final public class ReloadWitness implements SerializableWitness {
         lastError = new ErrorWitness();
         lastSuccessTimestamp = new RubyTimeStampGauge("last_success_timestamp");
         lastFailureTimestamp = new RubyTimeStampGauge("last_failure_timestamp");
-        //Legacy Ruby API initializes all of these to zero, resulting in the dirty flag
-        success.setDirty(true);
-        failure.setDirty(true);
-        lastFailureTimestamp.setDirty(true);
-        lastFailureTimestamp.setDirty(true);
         snitch = new Snitch(this);
     }
 

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/counter/LongCounterTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/counter/LongCounterTest.java
@@ -49,12 +49,8 @@ public class LongCounterTest {
     @Test
     public void noInitialValue() {
         LongCounter counter = new LongCounter("bar");
-        assertThat(counter.isDirty()).isFalse();
         counter.increment();
-        assertThat(counter.isDirty()).isTrue();
         assertThat(counter.getValue()).isEqualTo(1l);
-        counter.setDirty(false);
-        assertThat(counter.isDirty()).isFalse();
     }
 
     @Test

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/BooleanGaugeTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/BooleanGaugeTest.java
@@ -14,7 +14,6 @@ public class BooleanGaugeTest {
     @Test
     public void getValue() {
         BooleanGauge gauge = new BooleanGauge("bar", true);
-        assertThat(gauge.isDirty()).isTrue();
         assertThat(gauge.getValue()).isTrue();
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_BOOLEAN);
 
@@ -28,14 +27,11 @@ public class BooleanGaugeTest {
     public void set() {
         BooleanGauge gauge = new BooleanGauge("bar");
         assertThat(gauge.getValue()).isNull();
-        assertThat(gauge.isDirty()).isFalse();
         gauge.set(true);
         assertThat(gauge.getValue()).isTrue();
         gauge.set(false);
         assertThat(gauge.getValue()).isFalse();
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_BOOLEAN);
-        assertThat(gauge.isDirty()).isTrue();
-        gauge.setDirty(false);
         assertThat(gauge.getValue()).isFalse();
     }
 }

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/DoubleGaugeTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/DoubleGaugeTest.java
@@ -13,7 +13,6 @@ public class DoubleGaugeTest {
     @Test
     public void getValue() {
         DoubleGauge gauge = new DoubleGauge("bar", 123.0);
-        assertThat(gauge.isDirty()).isTrue();
         assertThat(gauge.getValue()).isEqualTo(123.0);
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_DOUBLE);
 
@@ -27,13 +26,8 @@ public class DoubleGaugeTest {
     public void set() {
         DoubleGauge gauge = new DoubleGauge("bar");
         assertThat(gauge.getValue()).isNull();
-        assertThat(gauge.isDirty()).isFalse();
         gauge.set(123.0);
         assertThat(gauge.getValue()).isEqualTo(123.0);
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_DOUBLE);
-        assertThat(gauge.isDirty()).isTrue();
-        gauge.setDirty(false);
-        assertThat(gauge.isDirty()).isFalse();
-
     }
 }

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGaugeTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGaugeTest.java
@@ -43,7 +43,6 @@ public class LazyDelegatingGaugeTest {
     public void getValue() {
         //Long
         LazyDelegatingGauge gauge = new LazyDelegatingGauge(Collections.singletonList("foo"), "bar", 99l);
-        assertThat(gauge.isDirty()).isTrue();
         assertThat(gauge.getValue()).isEqualTo(99l);
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_LONG);
 
@@ -89,9 +88,7 @@ public class LazyDelegatingGaugeTest {
     public void set() {
         //Long
         LazyDelegatingGauge gauge = new LazyDelegatingGauge(Collections.singletonList("foo"), "bar");
-        assertThat(gauge.isDirty()).isFalse();
         gauge.set(99l);
-        assertThat(gauge.isDirty()).isTrue();
         assertThat(gauge.getValue()).isEqualTo(99l);
         gauge.set(199l);
         assertThat(gauge.getValue()).isEqualTo(199l);
@@ -154,9 +151,6 @@ public class LazyDelegatingGaugeTest {
         gauge.set(null);
         assertThat(gauge.getValue()).isNull();
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_TEXT);
-        assertThat(gauge.isDirty()).isTrue();
-        gauge.setDirty(false);
-        assertThat(gauge.isDirty()).isFalse();
     }
 
 }

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/LongGaugeTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/LongGaugeTest.java
@@ -14,7 +14,6 @@ public class LongGaugeTest {
     @Test
     public void getValue() {
         LongGauge gauge = new LongGauge("bar", 99l);
-        assertThat(gauge.isDirty()).isTrue();
         assertThat(gauge.getValue()).isEqualTo(99);
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_LONG);
 
@@ -27,13 +26,9 @@ public class LongGaugeTest {
     @Test
     public void set() {
         LongGauge gauge = new LongGauge("bar");
-        assertThat(gauge.isDirty()).isFalse();
         assertThat(gauge.getValue()).isNull();
         gauge.set(123l);
         assertThat(gauge.getValue()).isEqualTo(123);
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_LONG);
-        assertThat(gauge.isDirty()).isTrue();
-        gauge.setDirty(false);
-        assertThat(gauge.isDirty()).isFalse();
     }
 }

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/RubyHashGaugeTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/RubyHashGaugeTest.java
@@ -34,7 +34,6 @@ public class RubyHashGaugeTest {
     @Test
     public void getValue() {
         RubyHashGauge gauge = new RubyHashGauge("bar", rubyHash);
-        assertThat(gauge.isDirty()).isTrue();
         assertThat(gauge.getValue().toString()).isEqualTo(RUBY_HASH_AS_STRING);
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_RUBYHASH);
 
@@ -50,13 +49,9 @@ public class RubyHashGaugeTest {
     @Test
     public void set() {
         RubyHashGauge gauge = new RubyHashGauge("bar");
-        assertThat(gauge.isDirty()).isFalse();
         gauge.set(rubyHash);
         assertThat(gauge.getValue().toString()).isEqualTo(RUBY_HASH_AS_STRING);
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_RUBYHASH);
-        assertThat(gauge.isDirty()).isTrue();
-        gauge.setDirty(false);
-        assertThat(gauge.isDirty()).isFalse();
     }
 
 }

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/RubyTimeStampGaugeTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/RubyTimeStampGaugeTest.java
@@ -34,7 +34,6 @@ public class RubyTimeStampGaugeTest {
     @Test
     public void getValue() {
         RubyTimeStampGauge gauge = new RubyTimeStampGauge("bar", rubyTimestamp);
-        assertThat(gauge.isDirty()).isTrue();
         assertThat(gauge.getValue()).isEqualTo(rubyTimestamp.getTimestamp());
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_RUBYTIMESTAMP);
 
@@ -47,12 +46,8 @@ public class RubyTimeStampGaugeTest {
     @Test
     public void set() {
         RubyTimeStampGauge gauge = new RubyTimeStampGauge("bar");
-        assertThat(gauge.isDirty()).isFalse();
         gauge.set(rubyTimestamp);
         assertThat(gauge.getValue()).isEqualTo(rubyTimestamp.getTimestamp());
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_RUBYTIMESTAMP);
-        assertThat(gauge.isDirty()).isTrue();
-        gauge.setDirty(false);
-        assertThat(gauge.isDirty()).isFalse();
     }
 }

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/TextGaugeTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/TextGaugeTest.java
@@ -14,7 +14,6 @@ public class TextGaugeTest {
     @Test
     public void getValue() {
         TextGauge gauge = new TextGauge("bar", "baz");
-        assertThat(gauge.isDirty()).isTrue();
         assertThat(gauge.getValue()).isEqualTo("baz");
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_TEXT);
 
@@ -27,12 +26,8 @@ public class TextGaugeTest {
     @Test
     public void set() {
         TextGauge gauge = new TextGauge("bar");
-        assertThat(gauge.isDirty()).isFalse();
         gauge.set("baz");
         assertThat(gauge.getValue()).isEqualTo("baz");
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_TEXT);
-        assertThat(gauge.isDirty()).isTrue();
-        gauge.setDirty(false);
-        assertThat(gauge.isDirty()).isFalse();
     }
 }

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/UnknownGaugeTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/UnknownGaugeTest.java
@@ -16,7 +16,6 @@ public class UnknownGaugeTest {
     @Test
     public void getValue() {
         UnknownGauge gauge = new UnknownGauge("bar", URI.create("baz"));
-        assertThat(gauge.isDirty()).isTrue();
         assertThat(gauge.getValue()).isEqualTo(URI.create("baz"));
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_UNKNOWN);
 
@@ -29,14 +28,10 @@ public class UnknownGaugeTest {
     @Test
     public void set() {
         UnknownGauge gauge = new UnknownGauge("bar");
-        assertThat(gauge.isDirty()).isFalse();
         gauge.set(URI.create("baz"));
         assertThat(gauge.getValue()).isEqualTo(URI.create("baz"));
         gauge.set(URI.create("fizzbuzz"));
         assertThat(gauge.getValue()).isEqualTo(URI.create("fizzbuzz"));
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_UNKNOWN);
-        assertThat(gauge.isDirty()).isTrue();
-        gauge.setDirty(false);
-        assertThat(gauge.isDirty()).isFalse();
     }
 }

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/ErrorWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/ErrorWitnessTest.java
@@ -47,7 +47,7 @@ public class ErrorWitnessTest {
     @Test
     public void testSerializeEmpty() throws Exception {
         String json = witness.asJson();
-        assertThat(json).isEqualTo("{\"last_error\":null}");
+        assertThat(json).isEqualTo("{\"last_error\":{}}");
     }
 
     @Test

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/EventsWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/EventsWitnessTest.java
@@ -83,7 +83,7 @@ public class EventsWitnessTest {
     public void testAsJson() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         //empty
-        assertThat(mapper.writeValueAsString(witness)).isEqualTo(witness.asJson()).isEmpty();
+        assertThat(mapper.writeValueAsString(witness)).isEqualTo(witness.asJson());
         //dirty
         witness.in(1);
         assertThat(mapper.writeValueAsString(witness)).isEqualTo(witness.asJson()).contains("events");
@@ -91,8 +91,7 @@ public class EventsWitnessTest {
 
     @Test
     public void testSerializeEmpty() throws Exception {
-        //Due to legacy requirements if empty, the events should not serialize at all.
-        assertThat(witness.asJson()).isEmpty();
+        assertThat(witness.asJson()).isNotEmpty();
     }
 
     @Test

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/PipelineWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/PipelineWitnessTest.java
@@ -73,8 +73,9 @@ public class PipelineWitnessTest {
     @Test
     public void testSerializeEmpty() throws Exception {
         String json = witness.asJson();
-        assertThat(json).isEqualTo("{\"default\":{\"plugins\":{\"inputs\":[],\"filters\":[],\"outputs\":[]},\"reloads\":{\"last_error\":null,\"successes\":0," +
-                "\"last_success_timestamp\":null,\"last_failure_timestamp\":null,\"failures\":0},\"queue\":{}}}");
+        assertThat(json).isEqualTo("{\"default\":{\"events\":{\"duration_in_millis\":0,\"in\":0,\"out\":0,\"filtered\":0,\"queue_push_duration_in_millis\":0}," +
+                "\"plugins\":{\"inputs\":[],\"filters\":[],\"outputs\":[]},\"reloads\":{\"last_error\":{},\"successes\":0,\"last_success_timestamp\":null," +
+                "\"last_failure_timestamp\":null,\"failures\":0},\"queue\":{}}}");
     }
 
     @Test

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/PluginWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/PluginWitnessTest.java
@@ -40,20 +40,20 @@ public class PluginWitnessTest {
     @Test
     public void testSerializationEmpty() throws Exception {
         String json = witness.asJson();
-        assertThat(json).isEqualTo("{\"id\":\"123\"}");
+        assertThat(json).isEqualTo("{\"id\":\"123\",\"events\":{\"duration_in_millis\":0,\"in\":0,\"out\":0,\"filtered\":0,\"queue_push_duration_in_millis\":0}}");
     }
 
     @Test
     public void testSerializationName() throws Exception {
         witness.name("abc");
         String json = witness.asJson();
-        assertThat(json).isEqualTo("{\"id\":\"123\",\"name\":\"abc\"}");
+        assertThat(json).isEqualTo("{\"id\":\"123\",\"events\":{\"duration_in_millis\":0,\"in\":0,\"out\":0,\"filtered\":0,\"queue_push_duration_in_millis\":0},\"name\":\"abc\"}");
     }
 
     @Test
     public void testSerializationEvents() throws Exception {
         witness.events().in();
         String json = witness.asJson();
-        assertThat(json).isEqualTo("{\"id\":\"123\",\"events\":{\"in\":1}}");
+        assertThat(json).isEqualTo("{\"id\":\"123\",\"events\":{\"duration_in_millis\":0,\"in\":1,\"out\":0,\"filtered\":0,\"queue_push_duration_in_millis\":0}}");
     }
 }

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/PluginsWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/PluginsWitnessTest.java
@@ -54,7 +54,8 @@ public class PluginsWitnessTest {
     public void testSerializeInput() throws Exception{
         witness.inputs("foo");
         String json = witness.asJson();
-        assertThat(json).isEqualTo("{\"plugins\":{\"inputs\":[{\"id\":\"foo\"}],\"filters\":[],\"outputs\":[]}}");
+        assertThat(json).isEqualTo("{\"plugins\":{\"inputs\":[{\"id\":\"foo\",\"events\":{\"duration_in_millis\":0,\"in\":0,\"out\":0,\"filtered\":0," +
+                "\"queue_push_duration_in_millis\":0}}],\"filters\":[],\"outputs\":[]}}");
         witness.forgetAll();
         json = witness.asJson();
         assertThat(json).isEqualTo("{\"plugins\":{\"inputs\":[],\"filters\":[],\"outputs\":[]}}");
@@ -64,7 +65,8 @@ public class PluginsWitnessTest {
     public void testSerializeFilters() throws Exception{
         witness.filters("foo");
         String json = witness.asJson();
-        assertThat(json).isEqualTo("{\"plugins\":{\"inputs\":[],\"filters\":[{\"id\":\"foo\"}],\"outputs\":[]}}");
+        assertThat(json).isEqualTo("{\"plugins\":{\"inputs\":[],\"filters\":[{\"id\":\"foo\",\"events\":{\"duration_in_millis\":0,\"in\":0,\"out\":0,\"filtered\":0," +
+                "\"queue_push_duration_in_millis\":0}}],\"outputs\":[]}}");
         witness.forgetAll();
         json = witness.asJson();
         assertThat(json).isEqualTo("{\"plugins\":{\"inputs\":[],\"filters\":[],\"outputs\":[]}}");
@@ -74,7 +76,8 @@ public class PluginsWitnessTest {
     public void testSerializeOutputs() throws Exception{
         witness.outputs("foo");
         String json = witness.asJson();
-        assertThat(json).isEqualTo("{\"plugins\":{\"inputs\":[],\"filters\":[],\"outputs\":[{\"id\":\"foo\"}]}}");
+        assertThat(json).isEqualTo("{\"plugins\":{\"inputs\":[],\"filters\":[],\"outputs\":[{\"id\":\"foo\",\"events\":{\"duration_in_millis\":0,\"in\":0,\"out\":0," +
+                "\"filtered\":0,\"queue_push_duration_in_millis\":0}}]}}");
         witness.forgetAll();
         json = witness.asJson();
         assertThat(json).isEqualTo("{\"plugins\":{\"inputs\":[],\"filters\":[],\"outputs\":[]}}");

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/ReloadWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/ReloadWitnessTest.java
@@ -65,7 +65,7 @@ public class ReloadWitnessTest {
     @Test
     public void testSerializeEmpty() throws Exception {
         String json = witness.asJson();
-        assertThat(json).isEqualTo("{\"reloads\":{\"last_error\":null,\"successes\":0,\"last_success_timestamp\":null,\"last_failure_timestamp\":null,\"failures\":0}}");
+        assertThat(json).isEqualTo("{\"reloads\":{\"last_error\":{},\"successes\":0,\"last_success_timestamp\":null,\"last_failure_timestamp\":null,\"failures\":0}}");
     }
 
     @Test
@@ -73,7 +73,7 @@ public class ReloadWitnessTest {
         witness.success();
         witness.lastSuccessTimestamp(rubyTimestamp);
         String json = witness.asJson();
-        assertThat(json).isEqualTo("{\"reloads\":{\"last_error\":null,\"successes\":1,\"last_success_timestamp\":\"" + timestamp.toIso8601() +
+        assertThat(json).isEqualTo("{\"reloads\":{\"last_error\":{},\"successes\":1,\"last_success_timestamp\":\"" + timestamp.toIso8601() +
                 "\",\"last_failure_timestamp\":null,\"failures\":0}}");
     }
 
@@ -82,7 +82,7 @@ public class ReloadWitnessTest {
         witness.failure();
         witness.lastFailureTimestamp(rubyTimestamp);
         String json = witness.asJson();
-        assertThat(json).isEqualTo("{\"reloads\":{\"last_error\":null,\"successes\":0,\"last_success_timestamp\":null,\"last_failure_timestamp\":\""
+        assertThat(json).isEqualTo("{\"reloads\":{\"last_error\":{},\"successes\":0,\"last_success_timestamp\":null,\"last_failure_timestamp\":\""
                 + timestamp.toIso8601() + "\",\"failures\":1}}");
     }
 

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/WitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/WitnessTest.java
@@ -51,11 +51,8 @@ public class WitnessTest {
         witness = new Witness();
         String json = witness.asJson();
         //empty pipelines
-        assertThat(json).contains("\"pipelines\":{}");
-        //non-empty reloads
-        assertThat(json).contains("{\"reloads\":{\"");
-        //no events
-        assertThat(json).doesNotContain("events");
+        assertThat(json).contains("{\"events\":{\"duration_in_millis\":0,\"in\":0,\"out\":0,\"filtered\":0,\"queue_push_duration_in_millis\":0},\"reloads\":{\"last_error\":{}," +
+                "\"successes\":0,\"last_success_timestamp\":null,\"last_failure_timestamp\":null,\"failures\":0},\"pipelines\":{}}");
     }
 
     @Test
@@ -63,10 +60,10 @@ public class WitnessTest {
         witness = new Witness();
         witness.events().in(99);
         String json = witness.asJson();
-        assertThat(json).contains("{\"events\":{\"in\":99}");
+        assertThat(json).contains("\"in\":99");
         witness.events().forgetAll();
         json = witness.asJson();
-        assertThat(json).doesNotContain("events");
+        assertThat(json).doesNotContain("99");
     }
 
     @Test
@@ -77,9 +74,9 @@ public class WitnessTest {
         String json = witness.asJson();
         assertThat(json).contains("\"pipelines\":{\"foo\"");
         //pipeline events
-        assertThat(json).contains("\"foo\":{\"events\":{\"in\":98");
+        assertThat(json).contains("foo").contains("in").contains(":98");
         //plugin events
-        assertThat(json).contains("plugins\":{\"inputs\":[{\"id\":\"bar\",\"events\":{\"in\":99");
+        assertThat(json).contains("\"in\":99");
         //forget events
         witness.pipeline("foo").forgetEvents();
         json = witness.asJson();


### PR DESCRIPTION
This change allows for the serialized output of the metrics to be consistent w/r/t the un-initialized values. Note - the code presented here is not the current code in use, rather it is the code staged, but unused to replace the metrics store / namespace implementation.

Fixes #7885 (for a future release)