### PR TITLE
Metrics / Bug Fix: Protect against race condition in metrics reporting with multiple inputs.

### DIFF
--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -38,7 +38,7 @@ module LogStash; class BasePipeline
 
   def initialize(pipeline_config, namespaced_metric = nil, agent = nil)
     @logger = self.logger
-
+    @mutex = Mutex.new
     @ephemeral_id = SecureRandom.uuid
 
     @pipeline_config = pipeline_config
@@ -809,6 +809,9 @@ module LogStash; class Pipeline < BasePipeline
   end
 
   def wrapped_write_client(plugin)
-    LogStash::Instrument::WrappedWriteClient.new(@input_queue_client, self, metric, plugin)
+    #need to ensure that metrics are initialized one plugin at a time, else a race condition can exist.
+    @mutex.synchronize do
+      LogStash::Instrument::WrappedWriteClient.new(@input_queue_client, self, metric, plugin)
+    end
   end
 end; end


### PR DESCRIPTION
Protect initialization of metrics obejcts with  mutex to prevent race condition. See https://github.com/elastic/logstash/issues/8011 for additional information.

Fixes #8011

Forward port of #8027