### PR TITLE
Fix path for local development (attempt 2)

### DIFF
--- a/logstash-core/lib/logstash-core/logstash-core.rb
+++ b/logstash-core/lib/logstash-core/logstash-core.rb
@@ -8,8 +8,16 @@ end
 require "logstash-core_jars"
 
 # local dev setup
-classes_dir = File.expand_path("../../../build/classes/java/main", __FILE__)
-resources_dir = File.expand_path("../../../build/resources/main", __FILE__)
+alt_classdir = File.expand_path("../../../out/production/classes", __FILE__) #IntelliJ's gradle output as of 2017.02 https://youtrack.jetbrains.com/issue/IDEA-175172
+if File.directory?(alt_classdir)
+  classes_dir = alt_classdir
+  resources_dir = File.expand_path("../../../out/production/resources", __FILE__)
+else
+  classes_dir = File.expand_path("../../../build/classes/java/main", __FILE__)
+  resources_dir = File.expand_path("../../../build/resources/main", __FILE__)
+end
+
+
 
 if File.directory?(classes_dir) && File.directory?(resources_dir)
   # if in local dev setup, add target to classpath


### PR DESCRIPTION
With IntelliJ 2017.02 the gradle output changed from 'build/classes' to 'out/production/classes'. See https://youtrack.jetbrains.com/issue/IDEA-175172 for additional information.

This PR changes the local developement behavior to prefer the classes build with IntelliJ (if they exist) over the classes built directly with gradle.