### PR TITLE
force UTF-8 encoding for gem file reading

### DIFF
--- a/lib/pluginmanager/gemfile.rb
+++ b/lib/pluginmanager/gemfile.rb
@@ -16,6 +16,9 @@ module LogStash
     end
 
     def load(with_backup = true)
+      # encoding must be set to UTF-8 here to avoid ending up with Windows-1252 encoding on Windows
+      # which will break the DSL instance_eval of that string
+      @io.set_encoding(Encoding::UTF_8)
       @gemset ||= DSL.parse(@io.read)
       backup if with_backup
       self


### PR DESCRIPTION
fixes #7768

Under Windows, the read string encoding was set to `Windows-1252` which was breaking the `DSL` `instance_eval` on that string.

It is probably worth exploring if that encoding problem is actually a JRuby specific bug and report it if it is.  The fact that there is no exception when doing the`instance_eval` but instead the object becomes invalid is certainly a bug worth digging and reporting. 

tested on OSX for regression and Windows where previously the plugins installation would fail and now correctly works.