### PR TITLE
MINOR: Faster batch clocks

### DIFF
--- a/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
@@ -103,7 +103,7 @@ module LogStash; module Util
         # batches will fail if we have multiple read clients in the pipeline.
         @inflight_batches = {}
         # allow the worker thread to report the execution time of the filter + output
-        @inflight_clocks = {}
+        @inflight_clocks = Concurrent::Map.new
         @batch_size = batch_size
         @wait_for = wait_for
       end
@@ -180,12 +180,11 @@ module LogStash; module Util
       def start_metrics(batch)
         @mutex.lock
         begin
-          # there seems to be concurrency issues with metrics, keep it in the mutex
           set_current_thread_inflight_batch(batch)
-          start_clock
         ensure
           @mutex.unlock
         end
+        start_clock
       end
 
       def set_current_thread_inflight_batch(batch)
@@ -196,12 +195,11 @@ module LogStash; module Util
         @mutex.lock
         begin
           batch.close
-          # there seems to be concurrency issues with metrics, keep it in the mutex
           @inflight_batches.delete(Thread.current)
-          stop_clock(batch)
         ensure
           @mutex.unlock
         end
+        stop_clock(batch)
       end
 
       def start_clock
@@ -209,16 +207,16 @@ module LogStash; module Util
       end
 
       def stop_clock(batch)
-        unless @inflight_clocks[Thread.current].nil?
+        start_time = @inflight_clocks.get_and_set(Thread.current, nil)
+        unless start_time.nil?
           if batch.size > 0
             # only stop (which also records) the metrics if the batch is non-empty.
             # start_clock is now called at empty batch creation and an empty batch could
             # stay empty all the way down to the close_batch call.
-            time_taken = (java.lang.System.nano_time - @inflight_clocks[Thread.current]) / 1_000_000
+            time_taken = (java.lang.System.nano_time - start_time) / 1_000_000
             @event_metric.report_time(:duration_in_millis, time_taken)
             @pipeline_metric.report_time(:duration_in_millis, time_taken)
           end
-          @inflight_clocks.delete(Thread.current)
         end
       end
 


### PR DESCRIPTION
* No point in constantly rehashing the hash that holds the same `Thread` as hash-key over time
  * Just set `nil` as a "reset"
* No need to lock this operation across threads
  * Use a concurrent hash map instead of synchronizing on a normal `RubyHash`
=> Multithreaded baseline get a little better (can post benchmarks some other time, it's kind of obvious how this is faster and makes scaling to more threads better imo)