### PR TITLE
MINOR: Cleanup magic string for LS JRuby Module name

### DIFF
--- a/logstash-core/src/main/java/org/logstash/RubyUtil.java
+++ b/logstash-core/src/main/java/org/logstash/RubyUtil.java
@@ -8,6 +8,11 @@ import org.jruby.Ruby;
 public final class RubyUtil {
 
     /**
+     * Name of the Logstash JRuby module we register.
+     */
+    public static final String LS_MODULE_NAME = "LogStash";
+
+    /**
      * Reference to the global {@link Ruby} runtime.
      */
     public static final Ruby RUBY = setupRuby();
@@ -22,7 +27,7 @@ public final class RubyUtil {
      */
     private static Ruby setupRuby() {
         final Ruby ruby = Ruby.getGlobalRuntime();
-        ruby.getOrCreateModule("LogStash");
+        ruby.getOrCreateModule(LS_MODULE_NAME);
         return ruby;
     }
 }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedBatchExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedBatchExtLibrary.java
@@ -12,6 +12,7 @@ import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.load.Library;
+import org.logstash.RubyUtil;
 import org.logstash.ackedqueue.Batch;
 import org.logstash.Event;
 import org.logstash.ackedqueue.Queueable;
@@ -22,7 +23,7 @@ import java.io.IOException;
 public class JrubyAckedBatchExtLibrary implements Library {
 
     public void load(Ruby runtime, boolean wrap) throws IOException {
-        RubyModule module = runtime.defineModule("LogStash");
+        RubyModule module = runtime.defineModule(RubyUtil.LS_MODULE_NAME);
 
         RubyClass clazz = runtime.defineClassUnder("AckedBatch", runtime.getObject(), new ObjectAllocator() {
             public IRubyObject allocate(Ruby runtime, RubyClass rubyClass) {
@@ -44,7 +45,7 @@ public class JrubyAckedBatchExtLibrary implements Library {
         }
 
         public RubyAckedBatch(Ruby runtime, Batch batch) {
-            super(runtime, runtime.getModule("LogStash").getClass("AckedBatch"));
+            super(runtime, runtime.getModule(RubyUtil.LS_MODULE_NAME).getClass("AckedBatch"));
             this.batch = batch;
         }
 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java
@@ -15,6 +15,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.load.Library;
 import org.logstash.Event;
+import org.logstash.RubyUtil;
 import org.logstash.ackedqueue.Batch;
 import org.logstash.ackedqueue.Queue;
 import org.logstash.ackedqueue.SettingsImpl;
@@ -25,7 +26,7 @@ import org.logstash.ext.JrubyEventExtLibrary;
 public class JrubyAckedQueueExtLibrary implements Library {
 
     public void load(Ruby runtime, boolean wrap) throws IOException {
-        RubyModule module = runtime.defineModule("LogStash");
+        RubyModule module = runtime.defineModule(RubyUtil.LS_MODULE_NAME);
 
         RubyClass clazz = runtime.defineClassUnder("AckedQueue", runtime.getObject(), new ObjectAllocator() {
             public IRubyObject allocate(Ruby runtime, RubyClass rubyClass) {

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueMemoryExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueMemoryExtLibrary.java
@@ -15,6 +15,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.load.Library;
 import org.logstash.Event;
+import org.logstash.RubyUtil;
 import org.logstash.ackedqueue.Batch;
 import org.logstash.ackedqueue.Queue;
 import org.logstash.ackedqueue.SettingsImpl;
@@ -25,7 +26,7 @@ import org.logstash.ext.JrubyEventExtLibrary;
 public class JrubyAckedQueueMemoryExtLibrary implements Library {
 
     public void load(Ruby runtime, boolean wrap) throws IOException {
-        RubyModule module = runtime.defineModule("LogStash");
+        RubyModule module = runtime.defineModule(RubyUtil.LS_MODULE_NAME);
 
         RubyClass clazz = runtime.defineClassUnder("AckedMemoryQueue", runtime.getObject(), new ObjectAllocator() {
             public IRubyObject allocate(Ruby runtime, RubyClass rubyClass) {

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -23,6 +23,7 @@ import org.logstash.ConvertedMap;
 import org.logstash.Event;
 import org.logstash.FieldReference;
 import org.logstash.PathCache;
+import org.logstash.RubyUtil;
 import org.logstash.Rubyfier;
 import org.logstash.Valuefier;
 
@@ -34,7 +35,7 @@ public class JrubyEventExtLibrary implements Library {
 
     @Override
     public void load(Ruby runtime, boolean wrap) throws IOException {
-        RubyModule module = runtime.defineModule("LogStash");
+        final RubyModule module = runtime.defineModule(RubyUtil.LS_MODULE_NAME);
 
         RubyClass clazz = runtime.defineClassUnder(
             "Event", runtime.getObject(), RubyEvent::new, module
@@ -50,15 +51,15 @@ public class JrubyEventExtLibrary implements Library {
         clazz.defineAnnotatedMethods(RubyEvent.class);
         clazz.defineAnnotatedConstants(RubyEvent.class);
 
-        PARSER_ERROR = runtime.getModule("LogStash").defineOrGetModuleUnder("Json").getClass("ParserError");
+        PARSER_ERROR = module.defineOrGetModuleUnder("Json").getClass("ParserError");
         if (PARSER_ERROR == null) {
             throw new RaiseException(runtime, runtime.getClass("StandardError"), "Could not find LogStash::Json::ParserError class", true);
         }
-        GENERATOR_ERROR = runtime.getModule("LogStash").defineOrGetModuleUnder("Json").getClass("GeneratorError");
+        GENERATOR_ERROR = module.defineOrGetModuleUnder("Json").getClass("GeneratorError");
         if (GENERATOR_ERROR == null) {
             throw new RaiseException(runtime, runtime.getClass("StandardError"), "Could not find LogStash::Json::GeneratorError class", true);
         }
-        LOGSTASH_ERROR = runtime.getModule("LogStash").getClass("Error");
+        LOGSTASH_ERROR = module.getClass("Error");
         if (LOGSTASH_ERROR == null) {
             throw new RaiseException(runtime, runtime.getClass("StandardError"), "Could not find LogStash::Error class", true);
         }
@@ -86,7 +87,7 @@ public class JrubyEventExtLibrary implements Library {
 
         public static RubyEvent newRubyEvent(Ruby runtime, Event event) {
             final RubyEvent ruby =
-                new RubyEvent(runtime, runtime.getModule("LogStash").getClass("Event"));
+                new RubyEvent(runtime, runtime.getModule(RubyUtil.LS_MODULE_NAME).getClass("Event"));
             ruby.setEvent(event);
             return ruby;
         }

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
@@ -19,6 +19,7 @@ import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.load.Library;
+import org.logstash.RubyUtil;
 import org.logstash.Timestamp;
 import org.logstash.json.RubyTimestampSerializer;
 
@@ -35,7 +36,7 @@ public class JrubyTimestampExtLibrary implements Library {
     }
 
     public static RubyClass createTimestamp(Ruby runtime) {
-        RubyModule module = runtime.defineModule("LogStash");
+        RubyModule module = runtime.defineModule(RubyUtil.LS_MODULE_NAME);
         RubyClass clazz = runtime.defineClassUnder("Timestamp", runtime.getObject(), ALLOCATOR, module);
         clazz.defineAnnotatedMethods(RubyTimestamp.class);
         return clazz;
@@ -57,7 +58,7 @@ public class JrubyTimestampExtLibrary implements Library {
         }
 
         public RubyTimestamp(Ruby runtime, Timestamp timestamp) {
-            this(runtime, runtime.getModule("LogStash").getClass("Timestamp"), timestamp);
+            this(runtime, runtime.getModule(RubyUtil.LS_MODULE_NAME).getClass("Timestamp"), timestamp);
         }
 
         public RubyTimestamp(Ruby runtime) {
@@ -102,7 +103,7 @@ public class JrubyTimestampExtLibrary implements Library {
                 } catch (IllegalArgumentException e) {
                     throw new RaiseException(
                             getRuntime(),
-                            getRuntime().getModule("LogStash").getClass("TimestampParserError"),
+                            getRuntime().getModule(RubyUtil.LS_MODULE_NAME).getClass("TimestampParserError"),
                             "invalid timestamp string format " + time,
                             true
                     );
@@ -181,7 +182,7 @@ public class JrubyTimestampExtLibrary implements Library {
              } catch (IllegalArgumentException e) {
                 throw new RaiseException(
                         context.runtime,
-                        context.runtime.getModule("LogStash").getClass("TimestampParserError"),
+                        context.runtime.getModule(RubyUtil.LS_MODULE_NAME).getClass("TimestampParserError"),
                         "invalid timestamp format " + e.getMessage(),
                         true
                 );
@@ -198,7 +199,7 @@ public class JrubyTimestampExtLibrary implements Library {
                 } catch (IllegalArgumentException e) {
                     throw new RaiseException(
                             context.runtime,
-                            context.runtime.getModule("LogStash").getClass("TimestampParserError"),
+                            context.runtime.getModule(RubyUtil.LS_MODULE_NAME).getClass("TimestampParserError"),
                             "invalid timestamp format " + e.getMessage(),
                             true
                     );


### PR DESCRIPTION
* Cleaning up that magic `String`
  * Making it easier to debug load issues, since we can more easily find all the places that reference our JRuby module explicitly :)