### PR TITLE
MINOR: Fix a lot of new compiler warnings in Metrics code

### DIFF
--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGauge.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGauge.java
@@ -13,9 +13,10 @@ import org.logstash.instrument.metrics.MetricType;
  *
  * @deprecated - there are no plans to replace this.
  */
+@Deprecated
 public class LazyDelegatingGauge extends AbstractMetric<Object> implements GaugeMetric<Object, Object> {
 
-    private final static Logger LOGGER = LogManager.getLogger(LazyDelegatingGauge.class);
+    private static final Logger LOGGER = LogManager.getLogger(LazyDelegatingGauge.class);
 
     protected final String key;
 
@@ -27,6 +28,7 @@ public class LazyDelegatingGauge extends AbstractMetric<Object> implements Gauge
      * @param key The key <i>(with in the namespace)</i> for this metric
      * @deprecated - there are no plans to replace this
      */
+    @Deprecated
     public LazyDelegatingGauge(final String key) {
         this(key, null);
     }
@@ -38,6 +40,7 @@ public class LazyDelegatingGauge extends AbstractMetric<Object> implements Gauge
      * @param initialValue The initial value for this {@link GaugeMetric}, may be null
      * @deprecated - there are no plans to replace this
      */
+    @Deprecated
     public LazyDelegatingGauge(String key, Object initialValue) {
         super(key);
         this.key = key;

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/RubyHashGauge.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/RubyHashGauge.java
@@ -8,6 +8,7 @@ import org.logstash.instrument.metrics.MetricType;
  * on the types in in the {@link RubyHash} there are no guarantees serializing properly.
  * @deprecated - There are no plans to replace this.
  */
+@Deprecated
 public class RubyHashGauge extends AbstractGaugeMetric<RubyHash> {
 
     /**
@@ -16,6 +17,7 @@ public class RubyHashGauge extends AbstractGaugeMetric<RubyHash> {
      * @param name The name of this metric. This value may be used for display purposes.
      * @deprecated - There are no plans to replace this.
      */
+    @Deprecated
     protected RubyHashGauge(String name) {
         super(name);
     }
@@ -27,6 +29,7 @@ public class RubyHashGauge extends AbstractGaugeMetric<RubyHash> {
      * @param initialValue The initial value for this {@link GaugeMetric}, may be null
      * @deprecated - There are no plans to replace this.
      */
+    @Deprecated
     protected RubyHashGauge(String name, RubyHash initialValue) {
         super(name, initialValue);
     }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/RubyTimeStampGauge.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/RubyTimeStampGauge.java
@@ -10,6 +10,7 @@ import org.logstash.instrument.metrics.MetricType;
  * exists for passivity with legacy Ruby code.
  * @deprecated - There are no plans to replace this.
  */
+@Deprecated
 public class RubyTimeStampGauge extends AbstractMetric<Timestamp> implements GaugeMetric<Timestamp, RubyTimestamp> {
 
     private volatile Timestamp value;
@@ -20,6 +21,7 @@ public class RubyTimeStampGauge extends AbstractMetric<Timestamp> implements Gau
      * @param key       The key <i>(with in the namespace)</i> for this metric
      * @deprecated - There are no plans to replace this.
      */
+    @Deprecated
     public RubyTimeStampGauge(String key) {
         super(key);
     }
@@ -31,6 +33,7 @@ public class RubyTimeStampGauge extends AbstractMetric<Timestamp> implements Gau
      * @param initialValue The initial value for this {@link GaugeMetric}, may be null
      * @deprecated - There are no plans to replace this.
      */
+    @Deprecated
     protected RubyTimeStampGauge(String key, RubyTimestamp initialValue) {
         super(key);
         this.value = initialValue == null ? null : initialValue.getTimestamp();

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/UnknownGauge.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/UnknownGauge.java
@@ -6,6 +6,7 @@ import org.logstash.instrument.metrics.MetricType;
  * A {@link GaugeMetric} that is backed by a {@link Object}.  Note - A stronger typed {@link GaugeMetric} should be used since this makes no guarantees of serializing properly.
  * @deprecated - There are no plans to replace this.
  */
+@Deprecated
 public class UnknownGauge extends AbstractGaugeMetric<Object> {
 
     /**
@@ -14,6 +15,7 @@ public class UnknownGauge extends AbstractGaugeMetric<Object> {
      * @param name The name of this metric. This value may be used for display purposes.
      * @deprecated - There are no plans to replace this.
      */
+    @Deprecated
     public UnknownGauge(String name) {
         super(name);
     }
@@ -25,6 +27,7 @@ public class UnknownGauge extends AbstractGaugeMetric<Object> {
      * @param initialValue The initial value for this {@link GaugeMetric}, may be null
      * @deprecated - There are no plans to replace this.
      */
+    @Deprecated
     public UnknownGauge(String name, Object initialValue) {
         super(name, initialValue);
     }

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/MetricSerializer.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/MetricSerializer.java
@@ -20,6 +20,7 @@ public interface MetricSerializer<T extends Metric<?>> {
      * Performs this operation on the given argument.
      *
      * @param t the input argument
+     * @throws IOException On failure to serialize
      */
     void serialize(T t) throws IOException;
 

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/Witness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/Witness.java
@@ -23,14 +23,13 @@ import java.util.Arrays;
  * <p>All Witnesses are capable of serializing their underlying metrics as JSON.</p>
  */
 @JsonSerialize(using = Witness.Serializer.class)
-final public class Witness implements SerializableWitness {
+public final class Witness implements SerializableWitness {
 
     private final ReloadWitness reloadWitness;
     private final EventsWitness eventsWitness;
     private final PipelinesWitness pipelinesWitness;
 
     private static Witness _instance;
-    private static final Serializer SERIALIZER = new Serializer();
 
     /**
      * Constructor. Consumers should use {@link #instance()} method to obtain an instance of this class.
@@ -100,13 +99,15 @@ final public class Witness implements SerializableWitness {
 
     @Override
     public void genJson(JsonGenerator gen, SerializerProvider provider) throws IOException {
-        SERIALIZER.innerSerialize(this, gen, provider);
+        Serializer.innerSerialize(this, gen, provider);
     }
 
     /**
      * The Jackson serializer.
      */
-    static class Serializer extends StdSerializer<Witness> {
+    public static final class Serializer extends StdSerializer<Witness> {
+
+        private static final long serialVersionUID = 1L;
 
         /**
          * Default constructor - required for Jackson
@@ -120,7 +121,7 @@ final public class Witness implements SerializableWitness {
          *
          * @param t the type to serialize
          */
-        protected Serializer(Class<Witness> t) {
+        private Serializer(Class<Witness> t) {
             super(t);
         }
 
@@ -131,7 +132,7 @@ final public class Witness implements SerializableWitness {
             gen.writeEndObject();
         }
 
-        void innerSerialize(Witness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        static void innerSerialize(Witness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
             witness.events().genJson(gen, provider);
             witness.reloads().genJson(gen, provider);
             witness.pipelinesWitness.genJson(gen, provider);

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/configuration/ConfigWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/configuration/ConfigWitness.java
@@ -17,7 +17,7 @@ import java.io.IOException;
  * The witness for configuration.
  */
 @JsonSerialize(using = ConfigWitness.Serializer.class)
-final public class ConfigWitness implements SerializableWitness {
+public final class ConfigWitness implements SerializableWitness {
 
     private final BooleanGauge deadLetterQueueEnabled;
     private final BooleanGauge configReloadAutomatic;
@@ -27,9 +27,7 @@ final public class ConfigWitness implements SerializableWitness {
     private final NumberGauge configReloadInterval;
     private final TextGauge deadLetterQueuePath;
     private final Snitch snitch;
-    private final static String KEY = "config";
-    private static final Serializer SERIALIZER = new Serializer();
-
+    private static final String KEY = "config";
 
     /**
      * Constructor.
@@ -119,13 +117,15 @@ final public class ConfigWitness implements SerializableWitness {
 
     @Override
     public void genJson(JsonGenerator gen, SerializerProvider provider) throws IOException {
-        SERIALIZER.innerSerialize(this, gen, provider);
+        Serializer.innerSerialize(this, gen);
     }
 
     /**
      * The Jackson serializer.
      */
-    static class Serializer extends StdSerializer<ConfigWitness> {
+    public static final class Serializer extends StdSerializer<ConfigWitness> {
+
+        private static final long serialVersionUID = 1L;
 
         /**
          * Default constructor - required for Jackson
@@ -139,18 +139,18 @@ final public class ConfigWitness implements SerializableWitness {
          *
          * @param t the type to serialize
          */
-        protected Serializer(Class<ConfigWitness> t) {
+        private Serializer(Class<ConfigWitness> t) {
             super(t);
         }
 
         @Override
         public void serialize(ConfigWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
             gen.writeStartObject();
-            innerSerialize(witness, gen, provider);
+            innerSerialize(witness, gen);
             gen.writeEndObject();
         }
 
-        void innerSerialize(ConfigWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        static void innerSerialize(ConfigWitness witness, JsonGenerator gen) throws IOException {
             gen.writeObjectFieldStart(KEY);
 
             MetricSerializer<Metric<Number>> numberSerializer = MetricSerializer.Get.numberSerializer(gen);
@@ -171,7 +171,7 @@ final public class ConfigWitness implements SerializableWitness {
     /**
      * The snitch for the errors. Used to retrieve discrete metric values.
      */
-    public class Snitch {
+    public static final class Snitch {
         private final ConfigWitness witness;
 
         private Snitch(ConfigWitness witness) {

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/DeadLetterQueueWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/DeadLetterQueueWitness.java
@@ -17,8 +17,7 @@ import java.io.IOException;
 @JsonSerialize(using = DeadLetterQueueWitness.Serializer.class)
 public class DeadLetterQueueWitness implements SerializableWitness {
 
-    private static String KEY = "dead_letter_queue";
-    private static final Serializer SERIALIZER = new Serializer();
+    private static final String KEY = "dead_letter_queue";
     private final Snitch snitch;
     private final NumberGauge queueSizeInBytes;
 
@@ -51,13 +50,15 @@ public class DeadLetterQueueWitness implements SerializableWitness {
 
     @Override
     public void genJson(JsonGenerator gen, SerializerProvider provider) throws IOException {
-        SERIALIZER.innerSerialize(this, gen, provider);
+        Serializer.innerSerialize(this, gen);
     }
 
     /**
      * The Jackson serializer.
      */
-    static class Serializer extends StdSerializer<DeadLetterQueueWitness> {
+    public static final class Serializer extends StdSerializer<DeadLetterQueueWitness> {
+
+        private static final long serialVersionUID = 1L;
 
         /**
          * Default constructor - required for Jackson
@@ -78,11 +79,11 @@ public class DeadLetterQueueWitness implements SerializableWitness {
         @Override
         public void serialize(DeadLetterQueueWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
             gen.writeStartObject();
-            innerSerialize(witness, gen, provider);
+            innerSerialize(witness, gen);
             gen.writeEndObject();
         }
 
-        void innerSerialize(DeadLetterQueueWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        static void innerSerialize(DeadLetterQueueWitness witness, JsonGenerator gen) throws IOException {
             gen.writeObjectFieldStart(KEY);
             MetricSerializer<Metric<Number>> numberSerializer = MetricSerializer.Get.numberSerializer(gen);
             numberSerializer.serialize(witness.queueSizeInBytes);

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/ErrorWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/ErrorWitness.java
@@ -22,8 +22,7 @@ public class ErrorWitness implements SerializableWitness {
     private final TextGauge message;
     private final TextGauge backtrace;
     private final Snitch snitch;
-    private final static String KEY = "last_error";
-    private static final Serializer SERIALIZER = new Serializer();
+    private static final String KEY = "last_error";
 
     public ErrorWitness() {
         message = new TextGauge("message");
@@ -80,13 +79,15 @@ public class ErrorWitness implements SerializableWitness {
 
     @Override
     public void genJson(JsonGenerator gen, SerializerProvider provider) throws IOException {
-        SERIALIZER.innerSerialize(this, gen, provider);
+        Serializer.innerSerialize(this, gen);
     }
 
     /**
      * The Jackson serializer.
      */
-    static class Serializer extends StdSerializer<ErrorWitness> {
+    public static final class Serializer extends StdSerializer<ErrorWitness> {
+
+        private static final long serialVersionUID = 1L;
 
         /**
          * Default constructor - required for Jackson
@@ -107,11 +108,11 @@ public class ErrorWitness implements SerializableWitness {
         @Override
         public void serialize(ErrorWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
             gen.writeStartObject();
-            innerSerialize(witness, gen, provider);
+            innerSerialize(witness, gen);
             gen.writeEndObject();
         }
 
-        void innerSerialize(ErrorWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        static void innerSerialize(ErrorWitness witness, JsonGenerator gen) throws IOException {
             gen.writeObjectFieldStart(KEY);
             MetricSerializer<Metric<String>> stringSerializer = MetricSerializer.Get.stringSerializer(gen);
             stringSerializer.serialize(witness.message);
@@ -123,7 +124,7 @@ public class ErrorWitness implements SerializableWitness {
     /**
      * The snitch for the errors. Used to retrieve discrete metric values.
      */
-    public class Snitch {
+    public static final class Snitch {
         private final ErrorWitness witness;
 
         private Snitch(ErrorWitness witness) {

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/EventsWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/EventsWitness.java
@@ -15,15 +15,14 @@ import java.io.IOException;
  * Witness for events.
  */
 @JsonSerialize(using = EventsWitness.Serializer.class)
-final public class EventsWitness implements SerializableWitness {
+public final class EventsWitness implements SerializableWitness {
 
     private LongCounter filtered;
     private LongCounter out;
     private LongCounter in;
     private LongCounter duration;
     private LongCounter queuePushDuration;
-    private final static String KEY = "events";
-    private static final Serializer SERIALIZER = new Serializer();
+    private static final String KEY = "events";
     private final Snitch snitch;
 
     /**
@@ -127,13 +126,15 @@ final public class EventsWitness implements SerializableWitness {
 
     @Override
     public void genJson(final JsonGenerator gen, SerializerProvider provider) throws IOException {
-        SERIALIZER.innerSerialize(this, gen, provider);
+        Serializer.innerSerialize(this, gen);
     }
 
     /**
      * The Jackson serializer.
      */
-    static class Serializer extends StdSerializer<EventsWitness> {
+    public static final class Serializer extends StdSerializer<EventsWitness> {
+
+        private static final long serialVersionUID = 1L;
 
         /**
          * Default constructor - required for Jackson
@@ -147,18 +148,18 @@ final public class EventsWitness implements SerializableWitness {
          *
          * @param t the type to serialize
          */
-        protected Serializer(Class<EventsWitness> t) {
+        private Serializer(Class<EventsWitness> t) {
             super(t);
         }
 
         @Override
         public void serialize(EventsWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
             gen.writeStartObject();
-            innerSerialize(witness, gen, provider);
+            innerSerialize(witness, gen);
             gen.writeEndObject();
         }
 
-        void innerSerialize(EventsWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        static void innerSerialize(EventsWitness witness, JsonGenerator gen) throws IOException {
             gen.writeObjectFieldStart(KEY);
             MetricSerializer<Metric<Long>> longSerializer = MetricSerializer.Get.longSerializer(gen);
             longSerializer.serialize(witness.duration);
@@ -173,7 +174,7 @@ final public class EventsWitness implements SerializableWitness {
     /**
      * The snitch for the {@link EventsWitness}. Allows to read discrete metrics values.
      */
-    public class Snitch {
+    public static final class Snitch {
 
         private final EventsWitness witness;
 

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/PipelineWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/PipelineWitness.java
@@ -13,7 +13,7 @@ import java.io.IOException;
  * A single pipeline witness.
  */
 @JsonSerialize(using = PipelineWitness.Serializer.class)
-final public class PipelineWitness implements SerializableWitness {
+public final class PipelineWitness implements SerializableWitness {
 
     private final ReloadWitness reloadWitness;
     private final EventsWitness eventsWitness;
@@ -22,7 +22,6 @@ final public class PipelineWitness implements SerializableWitness {
     private final QueueWitness queueWitness;
     private final DeadLetterQueueWitness deadLetterQueueWitness;
     private final String KEY;
-    private static final Serializer SERIALIZER = new Serializer();
 
     /**
      * Constructor.
@@ -138,13 +137,15 @@ final public class PipelineWitness implements SerializableWitness {
 
     @Override
     public void genJson(JsonGenerator gen, SerializerProvider provider) throws IOException {
-        SERIALIZER.innerSerialize(this, gen, provider);
+        Serializer.innerSerialize(this, gen, provider);
     }
 
     /**
      * The Jackson serializer.
      */
-    static class Serializer extends StdSerializer<PipelineWitness> {
+    public static final class Serializer extends StdSerializer<PipelineWitness> {
+
+        private static final long serialVersionUID = 1L;
 
         /**
          * Default constructor - required for Jackson
@@ -158,7 +159,7 @@ final public class PipelineWitness implements SerializableWitness {
          *
          * @param t the type to serialize
          */
-        protected Serializer(Class<PipelineWitness> t) {
+        private Serializer(Class<PipelineWitness> t) {
             super(t);
         }
 
@@ -169,7 +170,8 @@ final public class PipelineWitness implements SerializableWitness {
             gen.writeEndObject();
         }
 
-        void innerSerialize(PipelineWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        static void innerSerialize(PipelineWitness witness, JsonGenerator gen,
+            SerializerProvider provider) throws IOException {
             gen.writeObjectFieldStart(witness.KEY);
             witness.events().genJson(gen, provider);
             witness.plugins().genJson(gen, provider);

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/PipelinesWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/PipelinesWitness.java
@@ -14,12 +14,11 @@ import java.util.concurrent.ConcurrentHashMap;
  * Witness for the set of pipelines.
  */
 @JsonSerialize(using = PipelinesWitness.Serializer.class)
-final public class PipelinesWitness implements SerializableWitness {
+public final class PipelinesWitness implements SerializableWitness {
 
     private final Map<String, PipelineWitness> pipelines;
 
-    private final static String KEY = "pipelines";
-    private static final Serializer SERIALIZER = new Serializer();
+    private static final String KEY = "pipelines";
 
     /**
      * Constructor.
@@ -40,13 +39,15 @@ final public class PipelinesWitness implements SerializableWitness {
 
     @Override
     public void genJson(JsonGenerator gen, SerializerProvider provider) throws IOException {
-        SERIALIZER.innerSerialize(this, gen, provider);
+        Serializer.innerSerialize(this, gen, provider);
     }
 
     /**
      * The Jackson serializer.
      */
-    static class Serializer extends StdSerializer<PipelinesWitness> {
+    public static final class Serializer extends StdSerializer<PipelinesWitness> {
+
+        private static final long serialVersionUID = 1L;
 
         /**
          * Default constructor - required for Jackson
@@ -71,7 +72,8 @@ final public class PipelinesWitness implements SerializableWitness {
             gen.writeEndObject();
         }
 
-        void innerSerialize(PipelinesWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        static void innerSerialize(PipelinesWitness witness, JsonGenerator gen,
+            SerializerProvider provider) throws IOException {
             gen.writeObjectFieldStart(KEY);
             for (Map.Entry<String, PipelineWitness> entry : witness.pipelines.entrySet()) {
                 entry.getValue().genJson(gen, provider);

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/PluginWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/PluginWitness.java
@@ -26,13 +26,10 @@ import java.util.concurrent.ConcurrentHashMap;
 public class PluginWitness implements SerializableWitness {
 
     private final EventsWitness eventsWitness;
-    private final CustomWitness customWitness;
+    private final PluginWitness.CustomWitness customWitness;
     private final TextGauge id;
     private final TextGauge name;
     private final Snitch snitch;
-
-
-    private static final Serializer SERIALIZER = new Serializer();
 
     /**
      * Constructor.
@@ -41,7 +38,7 @@ public class PluginWitness implements SerializableWitness {
      */
     public PluginWitness(String id) {
         eventsWitness = new EventsWitness();
-        customWitness = new CustomWitness();
+        customWitness = new PluginWitness.CustomWitness();
         this.id = new TextGauge("id", id);
         this.name = new TextGauge("name");
         this.snitch = new Snitch(this);
@@ -70,9 +67,9 @@ public class PluginWitness implements SerializableWitness {
     /**
      * Get a reference to the associated custom witness
      *
-     * @return the {@link CustomWitness}
+     * @return the {@link PluginWitness.CustomWitness}
      */
-    public CustomWitness custom() {
+    public PluginWitness.CustomWitness custom() {
         return this.customWitness;
     }
 
@@ -87,13 +84,15 @@ public class PluginWitness implements SerializableWitness {
 
     @Override
     public void genJson(JsonGenerator gen, SerializerProvider provider) throws IOException {
-        SERIALIZER.innerSerialize(this, gen, provider);
+        Serializer.innerSerialize(this, gen, provider);
     }
 
     /**
      * The Jackson JSON serializer.
      */
-    static class Serializer extends StdSerializer<PluginWitness> {
+    public static final class Serializer extends StdSerializer<PluginWitness> {
+
+        private static final long serialVersionUID = 1L;
 
         /**
          * Default constructor - required for Jackson
@@ -118,7 +117,8 @@ public class PluginWitness implements SerializableWitness {
             gen.writeEndObject();
         }
 
-        void innerSerialize(PluginWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        static void innerSerialize(PluginWitness witness, JsonGenerator gen,
+            SerializerProvider provider) throws IOException {
             MetricSerializer<Metric<String>> stringSerializer = MetricSerializer.Get.stringSerializer(gen);
             MetricSerializer<Metric<Long>> longSerializer = MetricSerializer.Get.longSerializer(gen);
             stringSerializer.serialize(witness.id);
@@ -136,7 +136,7 @@ public class PluginWitness implements SerializableWitness {
     /**
      * A custom witness that we can hand off to plugin's to contribute to the metrics
      */
-    public class CustomWitness {
+    public static final class CustomWitness {
 
         private final Snitch snitch;
 
@@ -233,16 +233,16 @@ public class PluginWitness implements SerializableWitness {
         /**
          * Snitch for a plugin. Provides discrete metric values.
          */
-        public class Snitch {
+        public static final class Snitch {
 
-            private final CustomWitness witness;
+            private final PluginWitness.CustomWitness witness;
 
             /**
              * Construtor
              *
              * @param witness the witness
              */
-            private Snitch(CustomWitness witness) {
+            private Snitch(PluginWitness.CustomWitness witness) {
                 this.witness = witness;
             }
 
@@ -289,7 +289,7 @@ public class PluginWitness implements SerializableWitness {
     /**
      * Snitch for a plugin. Provides discrete metric values.
      */
-    public class Snitch {
+    public static final class Snitch {
 
         private final PluginWitness witness;
 

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/PluginsWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/PluginsWitness.java
@@ -20,8 +20,7 @@ public class PluginsWitness implements SerializableWitness {
     private final Map<String, PluginWitness> outputs;
     private final Map<String, PluginWitness> filters;
     private final Map<String, PluginWitness> codecs;
-    private final static String KEY = "plugins";
-    private static final Serializer SERIALIZER = new Serializer();
+    private static final String KEY = "plugins";
 
     /**
      * Constructor.
@@ -96,13 +95,15 @@ public class PluginsWitness implements SerializableWitness {
 
     @Override
     public void genJson(JsonGenerator gen, SerializerProvider provider) throws IOException {
-        SERIALIZER.innerSerialize(this, gen, provider);
+        PluginsWitness.Serializer.innerSerialize(this, gen, provider);
     }
 
     /**
      * The Jackson serializer.
      */
-    static class Serializer extends StdSerializer<PluginsWitness> {
+    public static final class Serializer extends StdSerializer<PluginsWitness> {
+
+        private static final long serialVersionUID = 1L;
 
         /**
          * Default constructor - required for Jackson
@@ -116,7 +117,7 @@ public class PluginsWitness implements SerializableWitness {
          *
          * @param t the type to serialize
          */
-        protected Serializer(Class<PluginsWitness> t) {
+        private Serializer(Class<PluginsWitness> t) {
             super(t);
         }
 
@@ -127,7 +128,8 @@ public class PluginsWitness implements SerializableWitness {
             gen.writeEndObject();
         }
 
-        void innerSerialize(PluginsWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        static void innerSerialize(PluginsWitness witness, JsonGenerator gen,
+            SerializerProvider provider) throws IOException {
             gen.writeObjectFieldStart(KEY);
 
             serializePlugins("inputs", witness.inputs, gen, provider);
@@ -138,7 +140,8 @@ public class PluginsWitness implements SerializableWitness {
             gen.writeEndObject();
         }
 
-        private void serializePlugins(String key, Map<String, PluginWitness> plugin, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        private static void serializePlugins(String key, Map<String, PluginWitness> plugin,
+            JsonGenerator gen, SerializerProvider provider) throws IOException {
             gen.writeArrayFieldStart(key);
             for (Map.Entry<String, PluginWitness> entry : plugin.entrySet()) {
                 gen.writeStartObject();

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/QueueWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/QueueWitness.java
@@ -16,14 +16,14 @@ import java.io.IOException;
  * Witness for the queue.
  */
 @JsonSerialize(using = QueueWitness.Serializer.class)
-final public class QueueWitness implements SerializableWitness {
+public final class QueueWitness implements SerializableWitness {
 
     private final TextGauge type;
     private final NumberGauge events; // note this is NOT an EventsWitness
     private final Snitch snitch;
     private final CapacityWitness capacity;
     private final DataWitness data;
-    private final static String KEY = "queue";
+    private static final String KEY = "queue";
     private static final Serializer SERIALIZER = new Serializer();
 
     /**
@@ -84,7 +84,7 @@ final public class QueueWitness implements SerializableWitness {
 
     @Override
     public void genJson(JsonGenerator gen, SerializerProvider provider) throws IOException {
-        SERIALIZER.innerSerialize(this, gen, provider);
+        SERIALIZER.innerSerialize(this, gen);
     }
 
     /**
@@ -302,7 +302,10 @@ final public class QueueWitness implements SerializableWitness {
     /**
      * The Jackson serializer.
      */
-    static class Serializer extends StdSerializer<QueueWitness> {
+    public static final class Serializer extends StdSerializer<QueueWitness> {
+
+        private static final long serialVersionUID = 1L;
+
         /**
          * Default constructor - required for Jackson
          */
@@ -322,11 +325,11 @@ final public class QueueWitness implements SerializableWitness {
         @Override
         public void serialize(QueueWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
             gen.writeStartObject();
-            innerSerialize(witness, gen, provider);
+            innerSerialize(witness, gen);
             gen.writeEndObject();
         }
 
-        void innerSerialize(QueueWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        void innerSerialize(QueueWitness witness, JsonGenerator gen) throws IOException {
             gen.writeObjectFieldStart(KEY);
             MetricSerializer<Metric<Number>> numberSerializer = MetricSerializer.Get.numberSerializer(gen);
             MetricSerializer<Metric<String>> stringSerializer = MetricSerializer.Get.stringSerializer(gen);
@@ -354,7 +357,7 @@ final public class QueueWitness implements SerializableWitness {
     /**
      * Snitch for queue. Provides discrete metric values.
      */
-    public class Snitch {
+    public static final class Snitch {
 
         private final QueueWitness witness;
 

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/ReloadWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/ReloadWitness.java
@@ -18,7 +18,7 @@ import java.io.IOException;
  * A witness to record reloads.
  */
 @JsonSerialize(using = ReloadWitness.Serializer.class)
-final public class ReloadWitness implements SerializableWitness {
+public final class ReloadWitness implements SerializableWitness {
 
     private final LongCounter success;
     private final LongCounter failure;
@@ -28,7 +28,7 @@ final public class ReloadWitness implements SerializableWitness {
     private final Snitch snitch;
     private static final Serializer SERIALIZER = new Serializer();
 
-    private final static String KEY = "reloads";
+    private static final String KEY = "reloads";
 
     /**
      * Constructor.
@@ -98,6 +98,7 @@ final public class ReloadWitness implements SerializableWitness {
      * @param timestamp the {@link JrubyTimestampExtLibrary.RubyTimestamp} to set
      * @deprecated
      */
+    @Deprecated
     public void lastSuccessTimestamp(JrubyTimestampExtLibrary.RubyTimestamp timestamp) {
         lastSuccessTimestamp.set(timestamp);
     }
@@ -108,6 +109,7 @@ final public class ReloadWitness implements SerializableWitness {
      * @param timestamp the {@link JrubyTimestampExtLibrary.RubyTimestamp} to set
      * @deprecated
      */
+    @Deprecated
     public void lastFailureTimestamp(JrubyTimestampExtLibrary.RubyTimestamp timestamp) {
         lastFailureTimestamp.set(timestamp);
     }
@@ -120,7 +122,9 @@ final public class ReloadWitness implements SerializableWitness {
     /**
      * The Jackson serializer.
      */
-    static class Serializer extends StdSerializer<ReloadWitness> {
+    public static final class Serializer extends StdSerializer<ReloadWitness> {
+
+        private static final long serialVersionUID = 1L;
 
         /**
          * Default constructor - required for Jackson
@@ -193,6 +197,7 @@ final public class ReloadWitness implements SerializableWitness {
          * @return {@link Timestamp} of the last successful reload
          * @deprecated
          */
+        @Deprecated
         public Timestamp lastSuccessTimestamp() {
             return witness.lastSuccessTimestamp.getValue();
         }
@@ -203,6 +208,7 @@ final public class ReloadWitness implements SerializableWitness {
          * @return {@link Timestamp} of the last failed reload
          * @deprecated
          */
+        @Deprecated
         public Timestamp lastFailureTimestamp() {
             return witness.lastFailureTimestamp.getValue();
         }


### PR DESCRIPTION
Putting this to the general review queue since it's not in any way affecting functionality, just passive cleanup to get rid of about 20 compiler warnings.

* Added missing `@Deprecated` annotations
* Added missing `serialVersionUID`
* Made methods `static` that don't reference `this`
   * This also allowed for removing some `Serializer` fields
* Fixed missorted modifiers
* Removed dead parameters, those are fine when implementing an interface obviously but should not be passed down to `private` methods :)