### PR TITLE
Metrics: Introduce the Scheduled Witness and Scheduler

### DIFF
--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGauge.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGauge.java
@@ -11,9 +11,7 @@ import org.logstash.instrument.metrics.MetricType;
  * A lazy proxy to a more specific typed {@link GaugeMetric}. The metric will only be initialized if the initial value is set, or once the {@code set} operation is called.
  * <p><strong>Intended only for use with Ruby's duck typing, Java consumers should use the specific typed {@link GaugeMetric}</strong></p>
  *
- * @deprecated - there are no plans to replace this.
  */
-@Deprecated
 public class LazyDelegatingGauge extends AbstractMetric<Object> implements GaugeMetric<Object, Object> {
 
     private static final Logger LOGGER = LogManager.getLogger(LazyDelegatingGauge.class);
@@ -26,9 +24,8 @@ public class LazyDelegatingGauge extends AbstractMetric<Object> implements Gauge
      * Constructor - null initial value
      *
      * @param key The key <i>(with in the namespace)</i> for this metric
-     * @deprecated - there are no plans to replace this
      */
-    @Deprecated
+    
     public LazyDelegatingGauge(final String key) {
         this(key, null);
     }
@@ -38,10 +35,8 @@ public class LazyDelegatingGauge extends AbstractMetric<Object> implements Gauge
      *
      * @param key          The key for this metric
      * @param initialValue The initial value for this {@link GaugeMetric}, may be null
-     * @deprecated - there are no plans to replace this
      */
-    @Deprecated
-    public LazyDelegatingGauge(String key, Object initialValue) {
+     public LazyDelegatingGauge(String key, Object initialValue) {
         super(key);
         this.key = key;
         if (initialValue != null) {

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/process/ProcessWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/process/ProcessWitness.java
@@ -1,0 +1,242 @@
+package org.logstash.instrument.witness.process;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.sun.management.UnixOperatingSystemMXBean;
+import org.logstash.instrument.metrics.Metric;
+import org.logstash.instrument.metrics.gauge.NumberGauge;
+import org.logstash.instrument.witness.MetricSerializer;
+import org.logstash.instrument.witness.SerializableWitness;
+import org.logstash.instrument.witness.schedule.ScheduledWitness;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A scheduled witness for process metrics
+ */
+@JsonSerialize(using = ProcessWitness.Serializer.class)
+public class ProcessWitness implements SerializableWitness, ScheduledWitness {
+
+    private static final OperatingSystemMXBean osMxBean;
+    private static final String KEY = "process";
+    public  static final boolean isUnix;
+    private static final UnixOperatingSystemMXBean unixOsBean;
+    private final NumberGauge openFileDescriptors;
+    private final NumberGauge peakOpenFileDescriptors;
+    private final NumberGauge maxFileDescriptors;
+    private final Cpu cpu;
+    private final Memory memory;
+    private final Snitch snitch;
+
+    static {
+        osMxBean = ManagementFactory.getOperatingSystemMXBean();
+        isUnix = osMxBean instanceof UnixOperatingSystemMXBean;
+        unixOsBean = isUnix ? (UnixOperatingSystemMXBean) osMxBean : null;
+    }
+
+    /**
+     * Constructor
+     */
+    public ProcessWitness() {
+        this.openFileDescriptors = new NumberGauge("open_file_descriptors", -1);
+        this.maxFileDescriptors = new NumberGauge("max_file_descriptors", -1);
+        this.peakOpenFileDescriptors = new NumberGauge("peak_open_file_descriptors", -1);
+        this.cpu = new Cpu();
+        this.memory = new Memory();
+        this.snitch = new Snitch(this);
+    }
+
+    @Override
+    public void refresh() {
+        if (isUnix) {
+            long currentOpen = unixOsBean.getOpenFileDescriptorCount();
+            openFileDescriptors.set(currentOpen);
+            if (maxFileDescriptors.getValue() == null || peakOpenFileDescriptors.getValue().longValue() < currentOpen) {
+                peakOpenFileDescriptors.set(currentOpen);
+            }
+            maxFileDescriptors.set(unixOsBean.getMaxFileDescriptorCount());
+        }
+        cpu.refresh();
+        memory.refresh();
+    }
+
+    /**
+     * Get a reference to associated snitch to get discrete metric values.
+     *
+     * @return the associate {@link Snitch}
+     */
+    public Snitch snitch() {
+        return snitch;
+    }
+
+    /**
+     * An inner witness for the process / cpu metrics
+     */
+    public class Cpu implements ScheduledWitness {
+        private static final String KEY = "cpu";
+        private final NumberGauge cpuProcessPercent;
+        private final NumberGauge cpuTotalInMillis;
+
+        private Cpu() {
+            this.cpuProcessPercent = new NumberGauge("percent", -1);
+            this.cpuTotalInMillis = new NumberGauge("total_in_millis", -1);
+        }
+
+        @Override
+        public void refresh() {
+            cpuProcessPercent.set(scaleLoadToPercent(unixOsBean.getProcessCpuLoad()));
+            cpuTotalInMillis.set(TimeUnit.MILLISECONDS.convert(unixOsBean.getProcessCpuTime(), TimeUnit.NANOSECONDS));
+        }
+    }
+
+    /**
+     * An inner witness for the the process / memory metrics
+     */
+    public class Memory implements ScheduledWitness {
+        private static final String KEY = "mem";
+        private final NumberGauge memTotalVirtualInBytes;
+
+        private Memory() {
+            memTotalVirtualInBytes = new NumberGauge("total_virtual_in_bytes", -1);
+        }
+
+        @Override
+        public void refresh() {
+            memTotalVirtualInBytes.set(unixOsBean.getCommittedVirtualMemorySize());
+        }
+    }
+
+    @Override
+    public void genJson(JsonGenerator gen, SerializerProvider provider) throws IOException {
+        Serializer.innerSerialize(this, gen);
+    }
+
+    /**
+     * The Jackson serializer.
+     */
+    public static final class Serializer extends StdSerializer<ProcessWitness> {
+        /**
+         * Default constructor - required for Jackson
+         */
+        public Serializer() {
+            this(ProcessWitness.class);
+        }
+
+        /**
+         * Constructor
+         *
+         * @param t the type to serialize
+         */
+        protected Serializer(Class<ProcessWitness> t) {
+            super(t);
+        }
+
+        @Override
+        public void serialize(ProcessWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            gen.writeStartObject();
+            innerSerialize(witness, gen);
+            gen.writeEndObject();
+        }
+
+        static void innerSerialize(ProcessWitness witness, JsonGenerator gen) throws IOException {
+            MetricSerializer<Metric<Number>> numberSerializer = MetricSerializer.Get.numberSerializer(gen);
+            gen.writeObjectFieldStart(KEY);
+            numberSerializer.serialize(witness.openFileDescriptors);
+            numberSerializer.serialize(witness.peakOpenFileDescriptors);
+            numberSerializer.serialize(witness.maxFileDescriptors);
+            //memory
+            gen.writeObjectFieldStart(Memory.KEY);
+            numberSerializer.serialize(witness.memory.memTotalVirtualInBytes);
+            gen.writeEndObject();
+            //cpu
+            gen.writeObjectFieldStart(Cpu.KEY);
+            numberSerializer.serialize(witness.cpu.cpuTotalInMillis);
+            numberSerializer.serialize(witness.cpu.cpuProcessPercent);
+
+            //TODO: jake load average
+
+            gen.writeEndObject();
+            gen.writeEndObject();
+        }
+    }
+
+    /**
+     * The Process snitch. Provides a means to get discrete metric values.
+     */
+    public static final class Snitch {
+
+        private final ProcessWitness witness;
+
+        private Snitch(ProcessWitness witness) {
+            this.witness = witness;
+        }
+
+        /**
+         * Get the number of open file descriptors for this process
+         *
+         * @return the open file descriptors
+         */
+        public long openFileDescriptors() {
+            return witness.openFileDescriptors.getValue().longValue();
+        }
+
+        /**
+         * Get the max file descriptors for this process
+         *
+         * @return the max file descriptors
+         */
+        public long maxFileDescriptors() {
+            return witness.maxFileDescriptors.getValue().longValue();
+        }
+
+        /**
+         * Get the high water number of open file descriptors for this process
+         *
+         * @return the high water/ peak of the seen open file descriptors
+         */
+        public long peakOpenFileDescriptors() {
+            return witness.peakOpenFileDescriptors.getValue().longValue();
+        }
+
+        /**
+         * Get the cpu percent for this process
+         *
+         * @return the cpu percent
+         */
+        public short cpuProcessPercent() {
+            return witness.cpu.cpuProcessPercent.getValue().shortValue();
+        }
+
+        /**
+         * Get the total time of the cpu in milliseconds for this process
+         *
+         * @return the cpu total in milliseconds
+         */
+        public long cpuTotalInMillis() {
+            return witness.cpu.cpuTotalInMillis.getValue().longValue();
+        }
+
+        /**
+         * Get the committed (virtual) memory for this process
+         *
+         * @return the committed memory
+         */
+        public long memTotalVirtualInBytes() {
+            return witness.memory.memTotalVirtualInBytes.getValue().longValue();
+        }
+
+    }
+
+    private short scaleLoadToPercent(double load) {
+        if (isUnix && load >= 0) {
+            return Double.valueOf(Math.floor(load * 100)).shortValue();
+        } else {
+            return (short) -1;
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/schedule/ScheduledWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/schedule/ScheduledWitness.java
@@ -1,0 +1,34 @@
+package org.logstash.instrument.witness.schedule;
+
+import java.time.Duration;
+
+/**
+ * A witness that is self-populating on a given schedule.
+ */
+public interface ScheduledWitness {
+
+    /**
+     * The duration between updates for this witness
+     *
+     * @return the {@link Duration} between scheduled updates. For example {@link Duration#ofMinutes(long)} with a value of 5 would schedule this implemenation to
+     * self-populate every 5 minute. Defaults to every 60 seconds. - Note, implementations may not allow schedules faster then every 1 second.
+     */
+    default Duration every() {
+        //note - the system property is an only an escape hatch if this proves to cause performance issues. Do not document this system property, it is not part of the contract.
+        return Duration.ofSeconds(Long.parseLong(System.getProperty("witness.scheduled.duration.in.seconds", "10")));
+    }
+
+    /**
+     * Get the name to set for the thread on which this is scheduled. This is useful for debugging purposes. Defaults to the class name + -thread.
+     *
+     * @return The name for the scheduled thread.
+     */
+    default String threadName() {
+        return getClass().getSimpleName() + "-thread";
+    }
+
+    /**
+     * Updates the underlying metrics on the given schedule.
+     */
+    void refresh();
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/schedule/WitnessScheduler.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/schedule/WitnessScheduler.java
@@ -1,0 +1,80 @@
+package org.logstash.instrument.witness.schedule;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Schedules {@link ScheduledWitness} to refresh themselves on an interval.
+ */
+public class WitnessScheduler {
+
+    private final ScheduledWitness witness;
+    private final ScheduledExecutorService executorService;
+    private static final Logger LOGGER = LogManager.getLogger(WitnessScheduler.class);
+
+    /**
+     * Constructor
+     *
+     * @param witness the {@link ScheduledWitness} to schedule
+     */
+    public WitnessScheduler(ScheduledWitness witness) {
+        this.witness = witness;
+
+        this.executorService = Executors.newScheduledThreadPool(1, ((Runnable r) -> {
+            Thread t = new Thread(r);
+            //Allow this thread to simply die when the JVM dies
+            t.setDaemon(true);
+            //Set the name
+            t.setName(witness.threadName());
+            return t;
+        }));
+    }
+
+    /**
+     * Schedules the witness to refresh on provided schedule. Note - this implementation does not allow refreshes faster then every 1 second.
+     */
+    public void schedule() {
+        executorService.scheduleAtFixedRate(new RefreshRunnable(), 0, witness.every().getSeconds(), TimeUnit.SECONDS);
+    }
+
+    /**
+     * Shuts down the underlying executor service. Since these are daemon threads, this is not absolutely necessary.
+     */
+    public void shutdown(){
+        executorService.shutdown();
+        try {
+            if(!executorService.awaitTermination(5, TimeUnit.SECONDS)){
+                executorService.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            throw new IllegalStateException("Witness should be scheduled from the main thread, and the main thread does not expect to be interrupted", e);
+        }
+    }
+
+    /**
+     * Runnable that will won't cancel the scheduled tasks on refresh if an exception is thrown, and throttles the log message.
+     */
+    class RefreshRunnable implements Runnable {
+
+       long lastLogged = 0;
+
+        @Override
+        public void run() {
+            try {
+                witness.refresh();
+            } catch (Exception e) {
+                long now = System.currentTimeMillis();
+                //throttle to only log the warning if it hasn't been logged in the past 120 seconds, this will ensure at least 1 log message, and logging for intermittent issues,
+                // but keep from flooding the log file on a repeating error on every schedule
+                if (lastLogged == 0 || now - lastLogged > 120_000) {
+                    LOGGER.warn("Can not fully refresh the metrics for the " + witness.getClass().getSimpleName(), e);
+                }
+                lastLogged = now;
+            }
+        }
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/counter/LongCounterTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/counter/LongCounterTest.java
@@ -35,6 +35,11 @@ public class LongCounterTest {
         longCounter.increment(-100l);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void incrementByNegativeLongValue() {
+        longCounter.increment(Long.valueOf(-100));
+    }
+
     @Test
     public void incrementByValue() {
         longCounter.increment(100l);

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGaugeTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGaugeTest.java
@@ -70,6 +70,8 @@ public class LazyDelegatingGaugeTest {
         assertThat(gauge.getValue()).isNull();
         assertThat(gauge.get()).isNull();
         assertThat(gauge.getType()).isNull();
+
+        assertThat(gauge.getName()).isNotEmpty();
     }
 
     @Test

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/WitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/WitnessTest.java
@@ -51,9 +51,10 @@ public class WitnessTest {
         witness = new Witness();
         String json = witness.asJson();
         //empty pipelines
-        assertThat(json).isEqualTo("{\"events\":{\"duration_in_millis\":0,\"in\":0,\"out\":0,\"filtered\":0,\"queue_push_duration_in_millis\":0}," +
-                "\"reloads\":{\"last_error\":{\"message\":null,\"backtrace\":null},\"successes\":0,\"last_success_timestamp\":null,\"last_failure_timestamp\":null," +
-                "\"failures\":0},\"pipelines\":{}}");
+        assertThat(json).isEqualTo("{\"process\":{\"open_file_descriptors\":-1,\"peak_open_file_descriptors\":-1,\"max_file_descriptors\":-1," +
+                "\"mem\":{\"total_virtual_in_bytes\":-1},\"cpu\":{\"total_in_millis\":-1,\"percent\":-1}},\"events\":{\"duration_in_millis\":0,\"in\":0,\"out\":0,\"filtered\":0," +
+                "\"queue_push_duration_in_millis\":0},\"reloads\":{\"last_error\":{\"message\":null,\"backtrace\":null},\"successes\":0,\"last_success_timestamp\":null," +
+                "\"last_failure_timestamp\":null,\"failures\":0},\"pipelines\":{}}");
     }
 
     @Test

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/process/ProcessWitnessTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/process/ProcessWitnessTest.java
@@ -1,0 +1,111 @@
+package org.logstash.instrument.witness.process;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.security.MessageDigest;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Unit tests for {@link ProcessWitness}
+ */
+public class ProcessWitnessTest {
+
+    private ProcessWitness witness;
+
+    @Before
+    public void setup(){
+        witness = new ProcessWitness();
+    }
+
+    @Test
+    public void testInitialState(){
+        ProcessWitness.Snitch snitch = witness.snitch();
+        assertThat(snitch.cpuProcessPercent()).isEqualTo((short) -1);
+        assertThat(snitch.cpuTotalInMillis()).isEqualTo(-1);
+        assertThat(snitch.maxFileDescriptors()).isEqualTo(-1);
+        assertThat(snitch.memTotalVirtualInBytes()).isEqualTo(-1);
+        assertThat(snitch.openFileDescriptors()).isEqualTo(-1);
+        assertThat(snitch.peakOpenFileDescriptors()).isEqualTo(-1);
+    }
+
+    @Test
+    public void testRefresh(){
+        ProcessWitness.Snitch snitch = witness.snitch();
+        assumeTrue(ProcessWitness.isUnix);
+        witness.refresh();
+        assertThat(snitch.cpuProcessPercent()).isGreaterThanOrEqualTo((short) 0);
+        assertThat(snitch.cpuTotalInMillis()).isGreaterThan(0);
+        assertThat(snitch.maxFileDescriptors()).isGreaterThan(0);
+        assertThat(snitch.memTotalVirtualInBytes()).isGreaterThan(0);
+        assertThat(snitch.openFileDescriptors()).isGreaterThan(0);
+        assertThat(snitch.peakOpenFileDescriptors()).isGreaterThan(0);
+    }
+
+    @Test
+    public void testRefreshChanges() throws InterruptedException {
+        ProcessWitness.Snitch snitch = witness.snitch();
+        assumeTrue(ProcessWitness.isUnix);
+        witness.refresh();
+        long before = snitch.cpuProcessPercent();
+
+        ScheduledExecutorService refresh = Executors.newSingleThreadScheduledExecutor();
+        refresh.scheduleAtFixedRate(() -> witness.refresh(), 0 , 100, TimeUnit.MILLISECONDS);
+
+        //Add some arbitrary CPU load
+        ExecutorService cpuLoad = Executors.newSingleThreadExecutor();
+        cpuLoad.execute(() -> {
+            while(true){
+                try {
+                    MessageDigest md = MessageDigest.getInstance("SHA-1");
+                    md.update(UUID.randomUUID().toString().getBytes());
+                    md.digest();
+                    if(Thread.currentThread().isInterrupted()){
+                        break;
+                    }
+                } catch (Exception e) {
+                    //do nothing
+                }
+            }
+        });
+        //give the threads some time up add measurable load
+        Thread.sleep(3000);
+        long after = snitch.cpuProcessPercent();
+        //There is a slim chance that the stars align and the before and after are indeed equal, but should be very rare.
+        assertThat(before).isNotEqualTo(after);
+
+        refresh.shutdownNow();
+        cpuLoad.shutdownNow();
+    }
+
+    @Test
+    public void testAsJson() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        assertThat(mapper.writeValueAsString(witness)).isEqualTo(witness.asJson());
+    }
+
+    @Test
+    public void testSerializeEmpty() throws Exception {
+        String json = witness.asJson();
+        assertThat(json).isEqualTo("{\"process\":{\"open_file_descriptors\":-1,\"peak_open_file_descriptors\":-1,\"max_file_descriptors\":-1," +
+                "\"mem\":{\"total_virtual_in_bytes\":-1},\"cpu\":{\"total_in_millis\":-1,\"percent\":-1}}}");
+    }
+
+    @Test
+    public void testSerializePopulated() throws Exception {
+        assumeTrue(ProcessWitness.isUnix);
+        String emptyJson = witness.asJson();
+        witness.refresh();
+        String populatedJson = witness.asJson();
+        assertThat(emptyJson).isNotEqualTo(populatedJson);
+        assertThat(populatedJson).doesNotContain("-1");
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/instrument/witness/schedule/WitnessSchedulerTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/witness/schedule/WitnessSchedulerTest.java
@@ -1,0 +1,138 @@
+package org.logstash.instrument.witness.schedule;
+
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.ErrorHandler;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.time.Duration;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link WitnessScheduler}
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class WitnessSchedulerTest {
+
+    private Witness1 witness1;
+    private Witness2 witness2;
+    private Witness3 witness3;
+
+    @Mock
+    Appender appender;
+
+    @Mock
+    ErrorHandler errorHandler;
+
+    @Before
+    public void setup() {
+        witness1 = new Witness1();
+        witness2 = new Witness2();
+        witness3 = new Witness3();
+        when(appender.getName()).thenReturn("junit");
+        when(appender.getHandler()).thenReturn(errorHandler);
+        when(appender.isStarted()).thenReturn(true);
+        LoggerContext.getContext(false).getLogger(WitnessScheduler.class.getName()).addAppender(appender);
+        LoggerContext.getContext(false).getLogger(WitnessScheduler.class.getName()).setLevel(Level.WARN);
+    }
+
+    @After
+    public void tearDown() {
+        LoggerContext.getContext(false).getLogger(WitnessScheduler.class.getName()).removeAppender(appender);
+    }
+
+    @Test
+    public void testSchedule() throws InterruptedException {
+        WitnessScheduler witness1Scheduler = new WitnessScheduler(witness1);
+        witness1Scheduler.schedule();
+        new WitnessScheduler(witness2).schedule();
+        new WitnessScheduler(witness3).schedule();
+        //Give some time fo the schedules to run.
+        Thread.sleep(15000);
+        assertThat(witness1.counter).isBetween(15, 60);
+        assertThat(witness2.counter).isBetween(3, 10);
+        //this tests that an exception thrown does not kill the scheduler
+        assertThat(witness3.counter).isBetween(15, 60);
+
+        assertThat(Thread.getAllStackTraces().keySet().stream().map(t -> t.getName()).collect(Collectors.toSet())).contains("Witness1-thread").contains("Witness2-thread")
+                .contains("Witness3-thread");
+
+        ArgumentCaptor<LogEvent> argument = ArgumentCaptor.forClass(LogEvent.class);
+        //tests that Witness3 is the only error and that it only gets logged once
+        verify(appender).append(argument.capture());
+        assertThat(argument.getAllValues().stream().filter(a -> a.getMessage().toString().equals("Can not fully refresh the metrics for the Witness3")).count()).isEqualTo(1);
+
+        //shutdown 1 of the schedulers
+        witness1Scheduler.shutdown();
+        int count1 = witness1.counter;
+        int count2 = witness2.counter;
+        int count3 = witness3.counter;
+
+        Thread.sleep(10000);
+        //witness 1 has been stopped but the others keep on truckin
+        assertThat(count1).isEqualTo(witness1.counter);
+        assertThat(count2).isLessThan(witness2.counter);
+        assertThat(count3).isLessThan(witness3.counter);
+
+        assertThat(Thread.getAllStackTraces().keySet().stream().map(t -> t.getName()).collect(Collectors.toSet())).doesNotContain("Witness1-thread");
+    }
+
+
+    class Witness1 implements ScheduledWitness {
+
+        int counter = 0;
+
+        @Override
+        public void refresh() {
+            counter++;
+        }
+
+        @Override
+        public Duration every() {
+            return Duration.ofSeconds(1);
+        }
+    }
+
+    class Witness2 implements ScheduledWitness {
+
+        int counter = 0;
+
+        @Override
+        public void refresh() {
+            counter++;
+        }
+
+        @Override
+        public Duration every() {
+            return Duration.ofSeconds(5);
+        }
+    }
+
+    class Witness3 implements ScheduledWitness {
+
+        int counter = 0;
+
+        @Override
+        public void refresh() {
+            counter++;
+            throw new RuntimeException();
+        }
+
+        @Override
+        public Duration every() {
+            return Duration.ofSeconds(1);
+        }
+    }
+}


### PR DESCRIPTION
Introduce the Scheduled Witness and Scheduler
- A Witness that is self populated on a schedule
- load average will come in future commit

Change default scheduled interval from 5 to 10 seconds.

Un-deprecate LazyDelegatingGaguge
 - It is the strategy for Ruby based plugins that allows them to continue to duck type.

 Minor test coverage fixes.

Note - this is dead code until the Witness API is wired in via Ruby

Part of #7788