### PR TITLE
Upgrade minitar to fix CVE-2016-10173

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "i18n", "= 0.6.9" #(MIT license)
 
   # filetools and rakelib
-  gem.add_runtime_dependency "minitar", "~> 0.5.4"
+  gem.add_runtime_dependency "minitar", "~> 0.6.1"
   gem.add_runtime_dependency "rubyzip", "~> 1.2.1"
   gem.add_runtime_dependency "thread_safe", "~> 0.3.5" #(Apache 2.0 license)
 

--- a/rakelib/dependency.rake
+++ b/rakelib/dependency.rake
@@ -9,7 +9,7 @@ namespace "dependency" do
   end # task rbx-stdlib
 
   task "archive-tar-minitar" do
-    Rake::Task["gem:require"].invoke("minitar", "0.5.4")
+    Rake::Task["gem:require"].invoke("minitar", "0.6.1")
   end # task archive-minitar
 
   task "stud" do


### PR DESCRIPTION
Noticed `rubyzip` was bumped to take care of a similar CVE, but `minitar` is still pinned to the old version.

PR which fixed the issue: https://github.com/halostatue/minitar/issues/16

Shipping a new version of `logstash-core` and `logstash-core-plugin-api` would be super helpful as well.