### PR TITLE
PERFORMANCE: Much Faster ConvertedMap

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Accessors.java
+++ b/logstash-core/src/main/java/org/logstash/Accessors.java
@@ -103,7 +103,7 @@ public final class Accessors {
 
     private static Object setChild(final Object target, final String key, final Object value) {
         if (target instanceof Map) {
-            ((ConvertedMap) target).put(key, value);
+            ((ConvertedMap) target).putInterned(key, value);
             return value;
         } else {
             return setOnList(key, value, (ConvertedList) target);
@@ -112,7 +112,7 @@ public final class Accessors {
 
     private static Object createChild(final ConvertedMap target, final String key) {
         final Object result = new ConvertedMap(1);
-        target.put(key, result);
+        target.putInterned(key, result);
         return result;
     }
 

--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -44,10 +44,10 @@ public final class Event implements Cloneable, Queueable {
     {
         this.metadata = new ConvertedMap(10);
         this.data = new ConvertedMap(10);
-        this.data.put(VERSION, VERSION_ONE);
+        this.data.putInterned(VERSION, VERSION_ONE);
         this.cancelled = false;
         this.timestamp = new Timestamp();
-        this.data.put(TIMESTAMP, this.timestamp);
+        this.data.putInterned(TIMESTAMP, this.timestamp);
     }
 
     /**
@@ -68,7 +68,7 @@ public final class Event implements Cloneable, Queueable {
     public Event(ConvertedMap data) {
         this.data = data;
         if (!this.data.containsKey(VERSION)) {
-            this.data.put(VERSION, VERSION_ONE);
+            this.data.putInterned(VERSION, VERSION_ONE);
         }
 
         if (this.data.containsKey(METADATA)) {
@@ -120,7 +120,7 @@ public final class Event implements Cloneable, Queueable {
 
     public void setTimestamp(Timestamp t) {
         this.timestamp = t;
-        this.data.put(TIMESTAMP, this.timestamp);
+        this.data.putInterned(TIMESTAMP, this.timestamp);
     }
 
     public Object getField(final String reference) {


### PR DESCRIPTION
* Use IdentityHashMap since we intern all possible keys anyways and can look them up more efficiently than `String.intern()` from our PathCache (which only holds interned `String`s in its cached `FieldReference`s )
* Use the PathCache to never have to instantiate new `String` when converting a RubyHash