### PR TITLE
Windows build fixes

### DIFF
--- a/lib/pluginmanager/utils/downloader.rb
+++ b/lib/pluginmanager/utils/downloader.rb
@@ -68,7 +68,7 @@ module LogStash module PluginManager module Utils
           downloaded_file.path
         end
       rescue => e
-        downloaded_file.close rescue nil
+        downloaded_file.close unless downloaded_file.closed?
         FileUtils.rm_rf(download_to)
         raise e
       end

--- a/logstash-core/lib/logstash/config/source/local.rb
+++ b/logstash-core/lib/logstash/config/source/local.rb
@@ -71,7 +71,8 @@ module LogStash module Config module Source
           end
 
           config_string = ::File.read(file)
-
+          config_string.force_encoding("UTF-8")
+          
           if config_string.valid_encoding?
             part = org.logstash.common.SourceWithMetadata.new("file", file, 0, 0, config_string)
             config_parts << part

--- a/logstash-core/lib/logstash/pipeline_action/stop.rb
+++ b/logstash-core/lib/logstash/pipeline_action/stop.rb
@@ -14,6 +14,7 @@ module LogStash module PipelineAction
     def execute(agent, pipelines)
       pipeline = pipelines[pipeline_id]
       pipeline.shutdown { LogStash::ShutdownWatcher.start(pipeline) }
+      pipeline.thread.join
       pipelines.delete(pipeline_id)
       # If we reach this part of the code we have succeeded because
       # the shutdown call will block.

--- a/logstash-core/spec/logstash/api/modules/node_stats_spec.rb
+++ b/logstash-core/spec/logstash/api/modules/node_stats_spec.rb
@@ -69,7 +69,7 @@ describe LogStash::Api::Modules::NodeStats do
       "cpu"=>{
         "total_in_millis"=>Numeric,
         "percent"=>Numeric,
-        "load_average" => { "1m" => Numeric }
+        # load_average is not supported on Windows, set it below
       }
     },
    "pipelines" => {
@@ -88,6 +88,10 @@ describe LogStash::Api::Modules::NodeStats do
      "failures" => Numeric
    }
   }
+
+  unless LogStash::Environment.windows?
+    root_structure["process"]["cpu"]["load_average"] = { "1m" => Numeric }
+  end
 
   test_api_and_resources(root_structure)
 end

--- a/logstash-core/spec/logstash/config/source/local_spec.rb
+++ b/logstash-core/spec/logstash/config/source/local_spec.rb
@@ -79,7 +79,7 @@ describe LogStash::Config::Source::Local::ConfigPathLoader do
 
         parts.each do |part|
           basename = ::File.basename(part.id)
-          file_path = ::File.join(directory, basename)
+          file_path = ::File.expand_path(::File.join(directory, basename))
           content = files[basename]
           expect(part).to be_a_source_with_metadata("file", file_path, content)
         end
@@ -99,7 +99,8 @@ describe LogStash::Config::Source::Local::ConfigPathLoader do
       end
 
       it "raises an exception" do
-        expect { subject.read(file_path) }.to raise_error LogStash::ConfigLoadingError, /#{file_path}/
+        # check against base name because on Windows long paths are shrinked in the exception message
+        expect { subject.read(file_path) }.to raise_error LogStash::ConfigLoadingError, /.+#{::File.basename(file_path)}/
       end
     end
 

--- a/logstash-core/spec/logstash/pipeline_action/create_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_action/create_spec.rb
@@ -19,7 +19,10 @@ describe LogStash::PipelineAction::Create do
   subject { described_class.new(pipeline_config, metric) }
 
   after do
-    pipelines.each { |_, pipeline| pipeline.shutdown }
+    pipelines.each do |_, pipeline| 
+      pipeline.shutdown 
+      pipeline.thread.join
+    end
   end
 
   it "returns the pipeline_id" do

--- a/logstash-core/spec/logstash/pipeline_action/reload_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_action/reload_spec.rb
@@ -22,7 +22,10 @@ describe LogStash::PipelineAction::Reload do
   end
 
   after do
-    pipelines.each { |_, pipeline| pipeline.shutdown }
+    pipelines.each do |_, pipeline| 
+      pipeline.shutdown
+      pipeline.thread.join
+    end
   end
 
   it "returns the pipeline_id" do

--- a/logstash-core/spec/logstash/pipeline_dlq_commit_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_dlq_commit_spec.rb
@@ -67,7 +67,7 @@ describe LogStash::Pipeline do
   end
 
   after(:each) do
-    FileUtils.remove_entry pipeline_settings["path.dead_letter_queue"]
+    FileUtils.rm_rf(pipeline_settings["path.dead_letter_queue"])
   end
 
   context "dlq is enabled" do
@@ -85,6 +85,7 @@ describe LogStash::Pipeline do
       entry = dlq_reader.pollEntry(40)
       expect(entry).to_not be_nil
       expect(entry.reason).to eq("my reason")
+      subject.shutdown
     end
   end
 
@@ -101,6 +102,7 @@ describe LogStash::Pipeline do
       subject.run
       dlq_path = java.nio.file.Paths.get(pipeline_settings_obj.get("path.dead_letter_queue"), pipeline_id)
       expect(java.nio.file.Files.exists(dlq_path)).to eq(false)
+      subject.shutdown
     end
   end
 

--- a/logstash-core/spec/logstash/settings/writable_directory_spec.rb
+++ b/logstash-core/spec/logstash/settings/writable_directory_spec.rb
@@ -3,17 +3,17 @@ require "spec_helper"
 require "logstash/settings"
 require "tmpdir"
 require "socket" # for UNIXSocket
+require "fileutils"
 
 describe LogStash::Setting::WritableDirectory do
-  let(:mode_rx) { 0555 }
   # linux is 108, Macos is 104, so use a safe value
   # Stud::Temporary.pathname, will exceed that size without adding anything
   let(:parent) { File.join(Dir.tmpdir, Time.now.to_f.to_s) }
   let(:path) { File.join(parent, "fancy") }
 
   before { Dir.mkdir(parent) }
-  after { Dir.exist?(path) && Dir.unlink(path) rescue nil }
-  after { Dir.unlink(parent) }
+  after { Dir.exist?(path) && FileUtils.rm_rf(path)}
+  after { FileUtils.rm_rf(parent) }
 
   shared_examples "failure" do
     before { subject.set(path) }
@@ -44,8 +44,9 @@ describe LogStash::Setting::WritableDirectory do
       end
 
       context "and the directory cannot be created" do
-        before { File.chmod(mode_rx, parent) }
         it "should fail" do
+          # using chmod does not work on Windows better mock and_raise("message")
+          expect(FileUtils).to receive(:mkdir_p).and_raise("foobar")
           expect { subject.value }.to raise_error
         end
       end
@@ -66,7 +67,8 @@ describe LogStash::Setting::WritableDirectory do
       end
 
       context "but is not writable" do
-        before { File.chmod(0, path) }
+        # chmod does not work on Windows, mock writable? instead
+        before { expect(File).to receive(:writable?).and_return(false) }
         it_behaves_like "failure"
       end
     end
@@ -84,12 +86,13 @@ describe LogStash::Setting::WritableDirectory do
         before { socket } # realize `socket` value
         after { socket.close }
         it_behaves_like "failure"
-      end
+      end unless LogStash::Environment.windows?
 
+      
       context "but is a symlink" do
-        before { File::symlink("whatever", path) }
+        before { FileUtils.symlink("whatever", path) }
         it_behaves_like "failure"
-      end
+      end unless LogStash::Environment.windows?
     end
 
     context "when the directory is missing" do
@@ -114,8 +117,8 @@ describe LogStash::Setting::WritableDirectory do
 
       context "and cannot be created" do
         before do
-          # Remove write permission on the parent
-          File.chmod(mode_rx, parent)
+          # chmod does not work on Windows, mock writable? instead
+          expect(File).to receive(:writable?).and_return(false)
         end
 
         it_behaves_like "failure"

--- a/spec/unit/plugin_manager/pack_fetch_strategy/uri_spec.rb
+++ b/spec/unit/plugin_manager/pack_fetch_strategy/uri_spec.rb
@@ -32,10 +32,12 @@ describe LogStash::PluginManager::PackFetchStrategy::Uri do
     let(:temporary_file) do
       f = Stud::Temporary.file
       f.write("hola")
+      f.close
       f.path
     end
 
-    let(:plugin_path) { "file://#{temporary_file}" }
+    # Windows safe way to produce a file: URI.
+    let(:plugin_path) { URI.join("file:///" + File.absolute_path(temporary_file)).to_s }
 
     it "returns a `LocalInstaller`" do
       expect(subject.get_installer_for(plugin_path)).to be_kind_of(LogStash::PluginManager::PackInstaller::Local)

--- a/spec/unit/plugin_manager/prepare_offline_pack_spec.rb
+++ b/spec/unit/plugin_manager/prepare_offline_pack_spec.rb
@@ -79,6 +79,10 @@ describe LogStash::PluginManager::PrepareOfflinePack do
         expect(LogStash::PluginManager::OfflinePluginPackager).not_to receive(:package).with(anything)
       end
 
+      after do
+        FileUtils.rm_rf(tmp_zip_file)
+      end
+
       it "fails to do any action" do
         expect { subject.run(cmd_args) }.to raise_error Clamp::ExecutionError, /you must specify a filename/
       end
@@ -101,13 +105,18 @@ describe LogStash::PluginManager::PrepareOfflinePack do
         FileUtils.touch(tmp_zip_file)
       end
 
+      after do
+        FileUtils.rm_f(tmp_zip_file)
+      end
+
       context "without `--overwrite`" do
         before do
           expect(LogStash::PluginManager::OfflinePluginPackager).not_to receive(:package).with(anything)
         end
 
         it "should fails" do
-          expect { subject.run(cmd_args) }.to raise_error Clamp::ExecutionError, /output file destination #{tmp_zip_file} already exist/
+          # ignore the first path part of tmp_zip_file because on Windows the long path is shrinked in the exception message 
+          expect { subject.run(cmd_args) }.to raise_error Clamp::ExecutionError, /output file destination .+#{::File.basename(tmp_zip_file)} already exist/
         end
       end
 

--- a/spec/unit/plugin_manager/utils/downloader_spec.rb
+++ b/spec/unit/plugin_manager/utils/downloader_spec.rb
@@ -56,7 +56,7 @@ describe LogStash::PluginManager::Utils::Downloader do
       let(:temporary_path) { Stud::Temporary.pathname }
 
       before do
-        expect_any_instance_of(::File).to receive(:close).at_least(:twice).and_raise("Didn't work")
+        expect(Net::HTTP::Get).to receive(:new).once.and_raise("Didn't work")
         expect(Stud::Temporary).to receive(:pathname).and_return(temporary_path)
       end
 


### PR DESCRIPTION
Modifications to have a green build on Windows.

Tested for successful `rake test:core` locally on Windows Server 2012 and on OSX. 

These are mostly spec fixes. 

The only non-spec significant change which should prevent potential problems on all platforms is in `logstash-core/lib/logstash/pipeline_action/stop.rb` where after issuing a pipeline shutdown, we were not waiting on the pipeline thread to complete.  