### PR TITLE
Really fix verbose logging in tests

### DIFF
--- a/logstash-core/lib/logstash/logging/logger.rb
+++ b/logstash-core/lib/logstash/logging/logger.rb
@@ -92,6 +92,9 @@ module LogStash
         end
       end
 
+      # until dev_utils/rspec/spec_helper is changed, we need to have both methods
+      singleton_class.send(:alias_method, :initialize, :reconfigure)
+
       def self.get_logging_context
         return  LoggerContext.getContext(false)
       end

--- a/logstash-core/lib/logstash/logging/logger.rb
+++ b/logstash-core/lib/logstash/logging/logger.rb
@@ -73,7 +73,7 @@ module LogStash
         raise ArgumentError, "invalid level[#{level}] for logger[#{path}]"
       end
 
-      def self.initialize(config_location)
+      def self.reconfigure(config_location)
         @@config_mutex.synchronize do
           config_location_uri = URI.create(config_location)
           file_path = config_location_uri.path

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -249,7 +249,7 @@ class LogStash::Runner < Clamp::StrictCommand
     java.lang.System.setProperty("ls.log.level", setting("log.level"))
     unless java.lang.System.getProperty("log4j.configurationFile")
       log4j_config_location = ::File.join(setting("path.settings"), "log4j2.properties")
-      LogStash::Logging::Logger::initialize("file:///" + log4j_config_location)
+      LogStash::Logging::Logger::reconfigure("file:///" + log4j_config_location)
     end
     # override log level that may have been introduced from a custom log4j config file
     LogStash::Logging::Logger::configure_logging(setting("log.level"))

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -35,16 +35,12 @@ describe LogStash::Runner do
     allow(LogStash::Logging::Logger).to receive(:configure_logging) do |level, path|
       allow(logger).to receive(:level).and_return(level.to_sym)
     end
-
+    allow(LogStash::Logging::Logger).to receive(:reconfigure).with(any_args)
     # Make sure we don't start a real pipeline here.
     # because we cannot easily close the pipeline
     allow(LogStash::Agent).to receive(:new).with(any_args).and_return(agent)
     allow(agent).to receive(:execute)
     allow(agent).to receive(:shutdown)
-  end
-
-  after :each do
-    LogStash::Logging::Logger::configure_logging("info")
   end
 
   describe "argument precedence" do


### PR DESCRIPTION
In dev_utils spec_helper we set the logging to "OFF". However in runner we call initialize and turn it back on. We need to stub this method too.

in `logstash-core/lib/logstash/logging/logger.rb`, rename `initialize` class method to `reconfigure` because rspec really complains when you stub a method called `initialize`
in `logstash-core/lib/logstash/runner.rb`, use the new name `reconfigure`
in `logstash-core/spec/logstash/runner_spec.rb`, stub `reconfigure`, remove after block
