### PR TITLE
Close channel associated with lock

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -165,12 +165,33 @@ public final class DeadLetterQueueWriter implements Closeable {
 
     @Override
     public synchronized void close() throws IOException {
-        this.lock.release();
         if (currentWriter != null) {
-            currentWriter.close();
+            try {
+                currentWriter.close();
+                open = false;
+            }catch (Exception e){
+                logger.debug("Unable to close dlq writer", e);
+            }
         }
-        Files.deleteIfExists(queuePath.resolve(LOCK_FILE));
-        open = false;
+        releaseLock();
+    }
+
+    private void releaseLock() {
+        if (this.lock != null){
+            try {
+                this.lock.release();
+                if (this.lock.channel() != null && this.lock.channel().isOpen()) {
+                    this.lock.channel().close();
+                }
+            } catch (Exception e) {
+                logger.debug("Unable to close lock channel", e);
+            }
+            try {
+                Files.deleteIfExists(queuePath.resolve(LOCK_FILE));
+            } catch (IOException e){
+                logger.debug("Unable to delete lock file", e);
+            }
+        }
     }
 
     public boolean isOpen() {


### PR DESCRIPTION
   Close channel associated with lock
    
    Fix Windows build issue where .lock file cannot be deleted due to
    underling channel associated with lock not being closed. This
    will stop the file from being deleted until the JVM exits, despite
    reporting through Java that the file *has* been deleted and does not
    exist. It also blocks new files from being created with the same
    filename, which caused the test failure here.
    
    Backport of #7822