### PR TITLE
MINOR: Remove dead if branch from Vertex class

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/Edge.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/Edge.java
@@ -56,10 +56,6 @@ public abstract class Edge implements SourceComponent {
         if (!this.from.acceptsOutgoingEdge(this)) {
             throw new Vertex.InvalidEdgeTypeException(String.format("Invalid outgoing edge %s for edge %s", this.from, this));
         }
-
-        if (!Vertex.acceptsIncomingEdge(this)) {
-            throw new Vertex.InvalidEdgeTypeException(String.format("Invalid incoming edge %s for edge %s", this.from, this));
-        }
     }
 
     public Vertex getTo() {

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/Vertex.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/Vertex.java
@@ -218,10 +218,6 @@ public abstract class Vertex implements SourceComponent, HashableWithSource {
        return getUnusedOutgoingEdgeFactories().size() > 0;
     }
 
-    public static boolean acceptsIncomingEdge(Edge e) {
-        return true;
-    }
-
     public boolean acceptsOutgoingEdge(Edge e) {
         return true;
     }


### PR DESCRIPTION
This was probably a leftover from some automatic refactoring, the method simply always returns true => this `if` is dead code.