### PR TITLE
MINOR: Fix a few more compiler warnings

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Accessors.java
+++ b/logstash-core/src/main/java/org/logstash/Accessors.java
@@ -1,7 +1,5 @@
 package org.logstash;
 
-import java.util.Map;
-
 public final class Accessors {
 
     private Accessors() {
@@ -102,7 +100,7 @@ public final class Accessors {
     }
 
     private static Object setChild(final Object target, final String key, final Object value) {
-        if (target instanceof Map) {
+        if (target instanceof ConvertedMap) {
             ((ConvertedMap) target).putInterned(key, value);
             return value;
         } else {

--- a/logstash-core/src/main/java/org/logstash/Cloner.java
+++ b/logstash-core/src/main/java/org/logstash/Cloner.java
@@ -1,6 +1,13 @@
 package org.logstash;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 public final class Cloner {
 
@@ -23,8 +30,6 @@ public final class Cloner {
         if (list instanceof LinkedList<?>) {
             clone = new LinkedList<>();
         } else if (list instanceof ArrayList<?>) {
-            clone = new ArrayList<>();
-        } else if (list instanceof ConvertedList) {
             clone = new ArrayList<>();
         } else {
             throw new ClassCastException("unexpected List type " + list.getClass());

--- a/logstash-core/src/main/java/org/logstash/ConvertedMap.java
+++ b/logstash-core/src/main/java/org/logstash/ConvertedMap.java
@@ -42,9 +42,9 @@ public final class ConvertedMap extends IdentityHashMap<String, Object> {
         super(size);
     }
 
-    public static ConvertedMap newFromMap(Map<Serializable, Object> o) {
+    public static ConvertedMap newFromMap(Map<? extends Serializable, Object> o) {
         ConvertedMap cm = new ConvertedMap(o.size());
-        for (final Map.Entry<Serializable, Object> entry : o.entrySet()) {
+        for (final Map.Entry<? extends Serializable, Object> entry : o.entrySet()) {
             final Serializable found = entry.getKey();
             if (found instanceof String) {
                 cm.put((String) found, Valuefier.convert(entry.getValue()));

--- a/logstash-core/src/main/java/org/logstash/Javafier.java
+++ b/logstash-core/src/main/java/org/logstash/Javafier.java
@@ -58,7 +58,7 @@ public class Javafier {
         try {
             return BiValues.newBiValue(o).javaValue();
         } catch (IllegalArgumentException e) {
-            Class cls = o.getClass();
+            final Class<?> cls = o.getClass();
             throw new IllegalArgumentException(String.format(ERR_TEMPLATE, cls.getName(), cls.getSimpleName()));
         }
     }

--- a/logstash-core/src/main/java/org/logstash/Valuefier.java
+++ b/logstash-core/src/main/java/org/logstash/Valuefier.java
@@ -122,13 +122,15 @@ public final class Valuefier {
             )
         );
         converters.put(RubyHash.class, input -> ConvertedMap.newFromRubyHash((RubyHash) input));
-        converters.put(Map.class, input -> ConvertedMap.newFromMap((Map) input));
+        converters.put(Map.class, input -> ConvertedMap.newFromMap((Map<String, Object>) input));
         converters.put(List.class, input -> ConvertedList.newFromList((List) input));
         converters.put(ArrayJavaProxy.class, JAVAPROXY_CONVERTER);
         converters.put(ConcreteJavaProxy.class, JAVAPROXY_CONVERTER);
         converters.put(
             MapJavaProxy.class,
-            input -> ConvertedMap.newFromMap((Map) ((MapJavaProxy) input).getObject())
+            input -> ConvertedMap.newFromMap(
+                (Map<String, Object>) ((MapJavaProxy) input).getObject()
+            )
         );
         converters.put(
             RubyArray.class, input -> ConvertedList.newFromRubyArray((RubyArray) input)

--- a/logstash-core/src/main/java/org/logstash/bivalues/BiValue.java
+++ b/logstash-core/src/main/java/org/logstash/bivalues/BiValue.java
@@ -88,7 +88,7 @@ public abstract class BiValue<R extends IRubyObject, J> implements Serializable 
         return String.valueOf(javaValue);
     }
 
-    protected static Object newProxy(BiValue instance) {
+    protected static Object newProxy(BiValue<?, ?> instance) {
         return new SerializationProxy(instance);
     }
 

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -159,12 +159,12 @@ public final class DeadLetterQueueWriter implements Closeable {
      * @param event Logstash Event
      * @return boolean indicating whether the event is eligible to be added to the DLQ
      */
-    private boolean alreadyProcessed(final Event event) {
+    private static boolean alreadyProcessed(final Event event) {
         return event.getMetadata() != null && event.getMetadata().containsKey(DEAD_LETTER_QUEUE_METADATA_KEY);
     }
 
     @Override
-    public synchronized void close() throws IOException {
+    public synchronized void close() {
         if (currentWriter != null) {
             try {
                 currentWriter.close();

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/algorithms/GraphDiff.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/algorithms/GraphDiff.java
@@ -1,13 +1,13 @@
 package org.logstash.config.ir.graph.algorithms;
 
-import org.logstash.config.ir.graph.Edge;
-import org.logstash.config.ir.graph.Graph;
-import org.logstash.config.ir.graph.Vertex;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.logstash.config.ir.SourceComponent;
+import org.logstash.config.ir.graph.Edge;
+import org.logstash.config.ir.graph.Graph;
+import org.logstash.config.ir.graph.Vertex;
 
 /**
  * Created by andrewvc on 1/5/17.
@@ -86,14 +86,15 @@ public class GraphDiff {
             return output.toString();
         }
 
-        private static String detailedDiffFor(String name, Collection removed, Collection added) {
-            return (name + " GraphDiff: " + "\n") +
-                    "--------------------------\n" +
-                    Stream.concat(removed.stream().map(c -> "-" + c.toString()),
-                            added.stream().map(c -> "+" + c.toString())).
-                            map(Object::toString).
-                            collect(Collectors.joining("\n")) +
-                    "\n--------------------------";
+        private static String detailedDiffFor(final String name,
+            final Collection<? extends SourceComponent> removed,
+            final Collection<? extends SourceComponent> added) {
+            return name + " GraphDiff: \n--------------------------\n" +
+                Stream.concat(
+                    removed.stream().map(c -> '-' + c.toString()),
+                    added.stream().map(c -> '+' + c.toString())
+                ).map(Object::toString).collect(Collectors.joining("\n")) +
+                "\n--------------------------";
         }
     }
 }

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -219,8 +219,8 @@ public class JrubyEventExtLibrary implements Library {
 
         @JRubyMethod(name = "to_hash_with_metadata")
         public IRubyObject ruby_to_hash_with_metadata(ThreadContext context) {
-            Map data = this.event.toMap();
-            Map metadata = this.event.getMetadata();
+            Map<String, Object> data = this.event.toMap();
+            Map<String, Object> metadata = this.event.getMetadata();
 
             if (!metadata.isEmpty()) {
                 data.put(Event.METADATA, metadata);
@@ -323,7 +323,7 @@ public class JrubyEventExtLibrary implements Library {
                 this.event = new Event();
             } else if (data instanceof MapJavaProxy) {
                 this.event = new Event(ConvertedMap.newFromMap(
-                    (Map)((MapJavaProxy)data).getObject())
+                    (Map<String, Object>)((MapJavaProxy)data).getObject())
                 );
             } else {
                 throw context.runtime.newTypeError("wrong argument type " + data.getMetaClass() + " (expected Hash)");

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/Metric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/Metric.java
@@ -21,6 +21,7 @@ public interface Metric<T> {
      * @return This metric value
      * @deprecated
      */
+    @Deprecated
     default T get() {
         return getValue();
     }
@@ -45,6 +46,7 @@ public interface Metric<T> {
      * @return A description of this Metric that can be used for logging.
      * @deprecated
      */
+    @Deprecated
     default String inspect() {
         return toString();
     }
@@ -55,6 +57,7 @@ public interface Metric<T> {
      * @return The {@link String} version of the {@link MetricType}
      * @deprecated
      */
+    @Deprecated
     default String type() {
         return getType().asString();
     }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGauge.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGauge.java
@@ -91,7 +91,7 @@ public class LazyDelegatingGauge extends AbstractMetric<Object> implements Gauge
             } else if (value instanceof RubyHash) {
                 lazyMetric = new RubyHashGauge(key, (RubyHash) value);
             } else if (value instanceof RubyTimestamp) {
-                lazyMetric = new RubyTimeStampGauge(key, ((RubyTimestamp) value));
+                lazyMetric = new RubyTimeStampGauge(key, (RubyTimestamp) value);
             } else {
                 LOGGER.warn("A gauge metric of an unknown type ({}) has been create for key: {}. This may result in invalid serialization.  It is recommended to " +
                         "log an issue to the responsible developer/development team.", value.getClass().getCanonicalName(), key);

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/DeadLetterQueueWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/DeadLetterQueueWitness.java
@@ -94,7 +94,7 @@ public class DeadLetterQueueWitness implements SerializableWitness {
     /**
      * The snitch for the dead letter queue. Used to retrieve discrete metric values.
      */
-    public class Snitch {
+    public static class Snitch {
         private final DeadLetterQueueWitness witness;
 
         private Snitch(DeadLetterQueueWitness witness) {

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/PluginsWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/PluginsWitness.java
@@ -89,8 +89,8 @@ public class PluginsWitness implements SerializableWitness {
      * @param id     the id of the plugin
      * @return existing or new {@link PluginWitness}
      */
-    private PluginWitness getPlugin(Map<String, PluginWitness> plugin, String id) {
-        return plugin.computeIfAbsent(id, k -> new PluginWitness(k));
+    private static PluginWitness getPlugin(Map<String, PluginWitness> plugin, String id) {
+        return plugin.computeIfAbsent(id, PluginWitness::new);
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/QueueWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/QueueWitness.java
@@ -84,13 +84,13 @@ public final class QueueWitness implements SerializableWitness {
 
     @Override
     public void genJson(JsonGenerator gen, SerializerProvider provider) throws IOException {
-        SERIALIZER.innerSerialize(this, gen);
+        Serializer.innerSerialize(this, gen);
     }
 
     /**
      * Inner witness for the queue capacity
      */
-    public class CapacityWitness {
+    public static class CapacityWitness {
 
         private final NumberGauge queueSizeInBytes;
         private final NumberGauge pageCapacityInBytes;
@@ -156,7 +156,7 @@ public final class QueueWitness implements SerializableWitness {
         /**
          * Snitch for queue capacity. Provides discrete metric values.
          */
-        public class Snitch {
+        public static class Snitch {
 
             private final CapacityWitness witness;
 
@@ -206,7 +206,7 @@ public final class QueueWitness implements SerializableWitness {
     /**
      * Inner witness for the queue data
      */
-    public class DataWitness {
+    public static class DataWitness {
 
         private final TextGauge path;
         private final NumberGauge freeSpaceInBytes;
@@ -261,7 +261,7 @@ public final class QueueWitness implements SerializableWitness {
         /**
          * Snitch for queue capacity. Provides discrete metric values.
          */
-        public class Snitch {
+        public static class Snitch {
 
             private final DataWitness witness;
 
@@ -329,7 +329,7 @@ public final class QueueWitness implements SerializableWitness {
             gen.writeEndObject();
         }
 
-        void innerSerialize(QueueWitness witness, JsonGenerator gen) throws IOException {
+        static void innerSerialize(QueueWitness witness, JsonGenerator gen) throws IOException {
             gen.writeObjectFieldStart(KEY);
             MetricSerializer<Metric<Number>> numberSerializer = MetricSerializer.Get.numberSerializer(gen);
             MetricSerializer<Metric<String>> stringSerializer = MetricSerializer.Get.stringSerializer(gen);

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/ReloadWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/ReloadWitness.java
@@ -116,7 +116,7 @@ public final class ReloadWitness implements SerializableWitness {
 
     @Override
     public void genJson(JsonGenerator gen, SerializerProvider provider) throws IOException {
-        SERIALIZER.innerSerialize(this, gen, provider);
+        Serializer.innerSerialize(this, gen, provider);
     }
 
     /**
@@ -149,7 +149,8 @@ public final class ReloadWitness implements SerializableWitness {
             gen.writeEndObject();
         }
 
-        void innerSerialize(ReloadWitness witness, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        static void innerSerialize(ReloadWitness witness, JsonGenerator gen,
+            SerializerProvider provider) throws IOException {
             gen.writeObjectFieldStart(ReloadWitness.KEY);
             witness.lastError.genJson(gen, provider);
             MetricSerializer<Metric<Long>> longSerializer = MetricSerializer.Get.longSerializer(gen);

--- a/logstash-core/src/test/java/org/logstash/EventTest.java
+++ b/logstash-core/src/test/java/org/logstash/EventTest.java
@@ -275,17 +275,17 @@ public final class EventTest {
         Event.fromJson("gabeutch");
     }
 
-    @Test(expected=IOException.class)
+    @Test(expected=ClassCastException.class)
     public void testFromJsonWithInvalidJsonArray1() throws Exception {
         Event.fromJson("[1,2]");
     }
 
-    @Test(expected=IOException.class)
+    @Test(expected=ClassCastException.class)
     public void testFromJsonWithInvalidJsonArray2() throws Exception {
         Event.fromJson("[\"gabeutch\"]");
     }
 
-    @Test(expected=IOException.class)
+    @Test(expected=ClassCastException.class)
     public void testFromJsonWithPartialInvalidJsonArray() throws Exception {
         Event.fromJson("[{\"foo\":\"bar\"}, 1]");
     }


### PR DESCRIPTION
Just stuff the compiler warns us about should be self explainatory with the exception of this part:

```diff
-        } else if (list instanceof ConvertedList) {		
-            clone = new ArrayList<>();		
         } else {		
```

This is simply never hit because `ConvertedList` is a child of `ArrayList` which is caught by the `instanceof ArrayList` check above => removed the dead code :)

and the change to `public static Event[] fromJson(String json)`:

* We should really use hard types here instead of `instanceof` checks for 2 reasons:
   * more compile time safety
   * `ClasscastException` with a proper is a lot easier to interpret that our homebrew `IOException`

Fixed about 30 warnings for #7701 :)