### PR TITLE
add option for different jruby runtime version

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "sinatra", '~> 1.4', '>= 1.4.6'
   gem.add_runtime_dependency 'puma', '~> 2.16'
-  gem.add_runtime_dependency "jruby-openssl", "0.9.20" # >= 0.9.13 Required to support TLSv1.2
+  gem.add_runtime_dependency "jruby-openssl", ">= 0.9.20" # >= 0.9.13 Required to support TLSv1.2
   gem.add_runtime_dependency "chronic_duration", "0.10.6"
 
   # TODO(sissel): Treetop 1.5.x doesn't seem to work well, but I haven't

--- a/rakelib/fetch.rake
+++ b/rakelib/fetch.rake
@@ -10,7 +10,7 @@ def fetch(url, sha1, output)
   puts "Downloading #{url}"
   actual_sha1 = download(url, output)
 
-  if actual_sha1 != sha1
+  if sha1 != "IGNORE" && actual_sha1 != sha1
     fail "SHA1 does not match (expected '#{sha1}' but got '#{actual_sha1}')"
   end
 end # def fetch
@@ -21,7 +21,7 @@ def file_fetch(url, sha1)
   task output => [ "vendor/_" ] do
     begin
       actual_sha1 = file_sha1(output)
-      if actual_sha1 != sha1
+      if sha1 != "IGNORE" && actual_sha1 != sha1
         fetch(url, sha1, output)
       end
     rescue Errno::ENOENT

--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -60,9 +60,12 @@ namespace "vendor" do
   end # def untar
 
   task "jruby" do |task, args|
-    name = task.name.split(":")[1]
-    info = VERSIONS[name]
+    JRUBY = "jruby"
+    JRUBY_RUNTIME = "jruby-runtime-override"
+
+    info = VERSIONS[JRUBY_RUNTIME] || VERSIONS[JRUBY]
     version = info["version"]
+    url = info["url"] || "http://jruby.org.s3.amazonaws.com/downloads/#{version}/jruby-bin-#{version}.tar.gz"
 
     discard_patterns = Regexp.union([
       /^samples/,
@@ -72,10 +75,9 @@ namespace "vendor" do
       /lib\/ruby\/shared\/rdoc/,
     ])
 
-    url = "http://jruby.org.s3.amazonaws.com/downloads/#{version}/jruby-bin-#{version}.tar.gz"
     download = file_fetch(url, info["sha1"])
 
-    parent = vendor(name).gsub(/\/$/, "")
+    parent = vendor(JRUBY).gsub(/\/$/, "")
     directory parent => "vendor" do
       next if parent =~ discard_patterns
       FileUtils.mkdir(parent)
@@ -85,7 +87,7 @@ namespace "vendor" do
     untar(download) do |entry|
       out = entry.full_name.gsub(prefix_re, "")
       next if out =~ discard_patterns
-      vendor(name, out)
+      vendor(JRUBY, out)
     end # untar
   end # jruby
 

--- a/versions.yml
+++ b/versions.yml
@@ -2,6 +2,17 @@
 logstash: 7.0.0-alpha1
 logstash-core: 7.0.0-alpha1
 logstash-core-plugin-api: 2.1.16
+
+# jruby must reference a *released* version of jruby which can be downloaded from the official download url
+# *and* for which jars artifacts are published for compile-time
 jruby:
-  version: 9.1.12.0
-  sha1: 9b6c15d42eb11db7215d94dd9842ee5184a41fea
+  version: 9.1.13.0
+  sha1: 815bac27d5daa1459a4477d6d80584f007ce6a68
+
+# jruby-runtime-override, if specified, will override the jruby version installed in vendor/jruby for logstash runtime only,
+# not for the compile-time jars
+#
+#jruby-runtime-override:
+#  url: http://ci.jruby.org/snapshots/previous/jruby-bin-9.1.13.0-SNAPSHOT.tar.gz
+#  version: 9.1.13.0-SNAPSHOT
+#  sha1: IGNORE


### PR DESCRIPTION
Add support for an optional `jruby-runtime:` key in `versions.yml`. 

If `jruby-runtime:` is specified it will override the **runtime** JRuby version installed in `vendor/jruby`. 

Note that the `jruby:` key will still be used to reference the compile-time *provided* jars in `build.gradle`. 

This is useful to be able to use a JRuby pre-relase/snapshot version for the builds & specs or measure performance. 

This PR also sets the `jruby-runtime:` to  9.1.13.0-SNAPSHOT so we can start testing against the fix  for the JRuby JIT problem #8006