### PR TITLE
Log the exception if loading the plugin (via `require`) fails.

### DIFF
--- a/logstash-core/lib/logstash/plugins/registry.rb
+++ b/logstash-core/lib/logstash/plugins/registry.rb
@@ -9,6 +9,8 @@ module LogStash module Plugins
   class Registry
     include LogStash::Util::Loggable
 
+    class UnknownPlugin < NameError; end
+
     # Add a bit more sanity with when interacting with the rubygems'
     # specifications database, most of out code interact directly with really low level
     # components of bundler/rubygems we need to encapsulate that and this is a start.
@@ -152,14 +154,19 @@ module LogStash module Plugins
       begin
         path = "logstash/#{type}s/#{plugin_name}"
 
-        begin
-          require path
-        rescue LoadError
-          # Plugin might be already defined in the current scope
-          # This scenario often happen in test when we write an adhoc class
+        klass = begin
+          namespace_lookup(type, plugin_name)
+        rescue UnknownPlugin => e
+          # Plugin not registered. Try to load it.
+          begin
+            require path
+            namespace_lookup(type, plugin_name)
+          rescue LoadError => e
+            logger.error("Tried to load a plugin's code, but failed.", :exception => e, :path => path, :type => type, :name => plugin_name)
+            raise
+          end
         end
 
-        klass = namespace_lookup(type, plugin_name)
         plugin = lazy_add(type, plugin_name, klass)
       rescue => e
         logger.error("Problems loading a plugin with",
@@ -223,7 +230,7 @@ module LogStash module Plugins
       klass_sym = namespace.constants.find { |c| is_a_plugin?(namespace.const_get(c), name) }
       klass = klass_sym && namespace.const_get(klass_sym)
 
-      raise(NameError) unless klass
+      raise(UnknownPlugin) unless klass
       klass
     end
 


### PR DESCRIPTION

Fixes: https://github.com/elastic/logstash/issues/6834

This fix was slightly complex (more than just logging the exception) because many of our tests create plugins at runtime which would fail with LoadError when legacy_lookup failed to find the predicted file path.

Good errors now, I think, or at least, better than just "NameError"

```
% bin/logstash -e 'input { fancy { } }'

[2017-09-05T17:18:46,988][ERROR][logstash.plugins.registry] Tried to load a plugin's code, but failed. {:exception=>#<LoadError: no such file to load -- logstash/inputs/fancy>, :path=>"logstash/inputs/fancy", :type=>"input", :name=>"fancy"}
[2017-09-05T17:18:47,008][ERROR][logstash.agent           ] Failed to execute action {:action=>LogStash::PipelineAction::Create/pipeline_id:main, :exception=>"LogStash::PluginLoadingError", :message=>"Couldn't find any input plugin named 'fancy'. Are you sure this is correct? Trying to load the fancy input plugin resulted in this error: no such file to load -- logstash/inputs/fancy"}
```