### PR TITLE
 #8148 properly join threads in webserver_spec

### DIFF
--- a/logstash-core/spec/logstash/webserver_spec.rb
+++ b/logstash-core/spec/logstash/webserver_spec.rb
@@ -13,16 +13,12 @@ def block_ports(range)
   range.each do |port|
     begin
       server = TCPServer.new("localhost", port)
-      Thread.new do
-        client = server.accept rescue nil
-      end
       servers << server
     rescue => e
       # The port can already be taken
     end
   end
 
-  sleep(1)
   servers
 end
 
@@ -78,7 +74,8 @@ describe LogStash::WebServer do
       sleep(1)
 
       # We cannot use stop here, since the code is stuck in an infinite loop
-      t.kill rescue nil
+      t.kill
+      t.join
 
       silence_warnings do
         STDERR = backup_stderr
@@ -107,7 +104,7 @@ describe LogStash::WebServer do
         expect(subject.address).to eq("localhost:10006")
 
         subject.stop
-        t.kill rescue nil
+        t.join
       end
     end
 


### PR DESCRIPTION
Fixes #8148 by preventing threads from leaking between specs.

background:

`kill` on a Ruby thread simply invokes this:

```java
    private IRubyObject genericKill(Ruby runtime, RubyThread currentThread) {
        // If the killee thread is the same as the killer thread, just die
        if (currentThread == this) throwThreadKill();

        pendingInterruptEnqueue(RubyFixnum.zero(runtime));
        interrupt();

        return this;
    }
```

=> it's just an interrupt and no guarantee that the thread will immediately return => still have to `join` it (and shouldn't suppress any exceptions while during so, otherwise you'll leak the thread and it becomes so much harder to track this kind of thing down).
=> don't use `interrupt` in place of a `clean` stop on the web server, better make sure it actually `join`s after calling its own `stop`

Moreover, the constructor of `RubyTCPServer` i.e. `TCPServer` actually does call `bind` on the underlying `ServerSocketChannel` so there is no need to actually loop on `accept` to block a port => removed the `Thread` + `accept` combo => can't leak any threads there anymore either + you save 1 second per run, because `bind` will synchronously block instead of waiting for the `Thread` to start `accept`ing :).