### PR TITLE
PERFORMANCE: Remove WriteBatch, it's 100% Redundant

### DIFF
--- a/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
@@ -343,7 +343,7 @@ module LogStash; module Util
       end
 
       def get_new_batch
-        WriteBatch.new
+        []
       end
 
       def push(event)
@@ -360,27 +360,6 @@ module LogStash; module Util
         end
         batch.each do |event|
           push(event)
-        end
-      end
-    end
-
-    class WriteBatch
-      def initialize
-        @events = []
-      end
-
-      def size
-        @events.size
-      end
-
-      def push(event)
-        @events.push(event)
-      end
-      alias_method(:<<, :push)
-
-      def each(&blk)
-        @events.each do |e|
-          blk.call(e)
         end
       end
     end

--- a/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
@@ -247,7 +247,7 @@ module LogStash; module Util
       end
 
       def get_new_batch
-        WriteBatch.new
+        []
       end
 
       def push(event)
@@ -256,30 +256,7 @@ module LogStash; module Util
       alias_method(:<<, :push)
 
       def push_batch(batch)
-        LsQueueUtils.addAll(@queue, batch.events)
-      end
-    end
-
-    class WriteBatch
-      attr_reader :events
-
-      def initialize
-        @events = []
-      end
-
-      def size
-        @events.size
-      end
-
-      def push(event)
-        @events.push(event)
-      end
-      alias_method(:<<, :push)
-
-      def each(&blk)
-        @events.each do |e|
-          blk.call(e)
-        end
+        LsQueueUtils.addAll(@queue, batch)
       end
     end
   end


### PR DESCRIPTION
`WriteBatch` (apart from from `events` field accessor that I added a few days ago and that never made it to production) exposes no API that `[]` doesn't also expose.
=> We can simply drop the pointless wrapper and use an array a write batch.