### PR TITLE
Always log backtrace for converge / pipeline exceptions

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -337,12 +337,13 @@ class LogStash::Agent
 
           unless action_result.successful?
             logger.error("Failed to execute action", :id => action.pipeline_id,
-                        :action_type => action_result.class, :message => action_result.message)
+                        :action_type => action_result.class, :message => action_result.message,
+                        :backtrace => action_result.backtrace)
           end
         rescue SystemExit => e
           converge_result.add(action, e)
         rescue Exception => e
-          logger.error("Failed to execute action", :action => action, :exception => e.class.name, :message => e.message)
+          logger.error("Failed to execute action", :action => action, :exception => e.class.name, :message => e.message, :backtrace => e.backtrace)
           converge_result.add(action, e)
         end
       end

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -578,17 +578,12 @@ module LogStash; class Pipeline < BasePipeline
       end
 
       # otherwise, report error and restart
-      if @logger.debug?
-        @logger.error(I18n.t("logstash.pipeline.worker-error-debug",
-                             default_logging_keys(
-                               :plugin => plugin.inspect,
-                               :error => e.message,
-                               :exception => e.class,
-                               :stacktrace => e.backtrace.join("\n"))))
-      else
-        @logger.error(I18n.t("logstash.pipeline.worker-error",
-                             default_logging_keys(:plugin => plugin.inspect, :error => e.message)))
-      end
+      @logger.error(I18n.t("logstash.pipeline.worker-error-debug",
+                            default_logging_keys(
+                              :plugin => plugin.inspect,
+                              :error => e.message,
+                              :exception => e.class,
+                              :stacktrace => e.backtrace.join("\n"))))
 
       # Assuming the failure that caused this exception is transient,
       # let's sleep for a bit and execute #run again


### PR DESCRIPTION
Previously users had to enable --log.level=debug to see backtraces. These errors catch everything which can make debugging based on user reports difficult if not impossible.

Enabling --log.level=debug to solve these issues is not useful because users cannot enable it in production for rare errors.

I've labeled this a bug since I believe this should make it into the 6.0 GA due to the possibility that this behavior was never really intended, and could make debugging other 6.0 problems impossible. I think there's some gray area here, but I do believe that not logging full stacktraces here is a bug.