### PR TITLE
PERFORMANCE: Flatten logic for write batch instantiation

### DIFF
--- a/logstash-core/lib/logstash/instrument/wrapped_write_client.rb
+++ b/logstash-core/lib/logstash/instrument/wrapped_write_client.rb
@@ -20,7 +20,7 @@ module LogStash module Instrument
     end
 
     def get_new_batch
-      @write_client.get_new_batch
+      []
     end
 
     def push(event)

--- a/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
@@ -342,10 +342,6 @@ module LogStash; module Util
         @queue = queue
       end
 
-      def get_new_batch
-        []
-      end
-
       def push(event)
         if @queue.closed?
           raise QueueClosedError.new("Attempted to write an event to a closed AckedQueue")

--- a/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
@@ -246,10 +246,6 @@ module LogStash; module Util
         @queue = queue.queue
       end
 
-      def get_new_batch
-        []
-      end
-
       def push(event)
         @queue.put(event)
       end

--- a/logstash-core/spec/logstash/instrument/wrapped_write_client_spec.rb
+++ b/logstash-core/spec/logstash/instrument/wrapped_write_client_spec.rb
@@ -47,7 +47,7 @@ describe LogStash::Instrument::WrappedWriteClient do
     end
 
     it "pushes batch to the `WriteClient`" do
-      batch = write_client.get_new_batch
+      batch = []
       batch << event
 
       pusher_thread = Thread.new(subject, batch) do |_subject, _batch|

--- a/logstash-core/spec/logstash/util/wrapped_synchronous_queue_spec.rb
+++ b/logstash-core/spec/logstash/util/wrapped_synchronous_queue_spec.rb
@@ -60,7 +60,7 @@ describe LogStash::Util::WrappedSynchronousQueue do
 
         context "when we have item in the queue" do
           it "records the `duration_in_millis`" do
-            batch = write_client.get_new_batch
+            batch = []
             5.times {|i| batch.push(LogStash::Event.new({"message" => "value-#{i}"}))}
             write_client.push_batch(batch)
 
@@ -90,7 +90,7 @@ describe LogStash::Util::WrappedSynchronousQueue do
         end
 
         it "appends batches to the queue" do
-          batch = write_client.get_new_batch
+          batch = []
           messages = []
           5.times do |i|
             message = "value-#{i}"


### PR DESCRIPTION
Follow up to #8155:

The `get_new_batch` methods on the memory and the acked queue are both internal APIs and completely redundant since plugins only see `WrappedWriteClient`.
=> flattened this out

Also ... this actually comes with a measurable, statistically significant gain of `~3%` on the baseline (likely removing one step of stack depth got us over the barrier to not be affected by https://github.com/jruby/jruby/issues/4763 for `RubyArray` here).
