### PR TITLE
	Handle Elasticsearch errors better during DLQ integration tests

### DIFF
--- a/qa/integration/specs/dlq_spec.rb
+++ b/qa/integration/specs/dlq_spec.rb
@@ -42,8 +42,6 @@ describe "Test Dead Letter Queue" do
     it 'should index all documents' do
       es_service = @fixture.get_service("elasticsearch")
       es_client = es_service.get_client
-      # Wait for es client to come up
-      sleep(20)
       # test if all data was indexed by ES, but first refresh manually
       es_client.indices.refresh
 

--- a/qa/integration/specs/dlq_spec.rb
+++ b/qa/integration/specs/dlq_spec.rb
@@ -43,14 +43,20 @@ describe "Test Dead Letter Queue" do
       es_service = @fixture.get_service("elasticsearch")
       es_client = es_service.get_client
       # Wait for es client to come up
-      sleep(15)
+      sleep(20)
       # test if all data was indexed by ES, but first refresh manually
       es_client.indices.refresh
 
       logstash_service.wait_for_logstash
-      try(75) do
-        result = es_client.search(index: 'logstash-*', size: 0, q: '*')
-        expect(result["hits"]["total"]).to eq(1000)
+      try(60) do
+        begin
+          result = es_client.search(index: 'logstash-*', size: 0, q: '*')
+          hits = result["hits"]["total"]
+        rescue Elasticsearch::Transport::Transport::Errors::ServiceUnavailable => e
+          puts "Elasticsearch unavailable #{e.inspect}"
+          hits = 0
+        end
+        expect(hits).to eq(1000)
       end
 
       result = es_client.search(index: 'logstash-*', size: 1, q: '*')


### PR DESCRIPTION
Give more time for Elasticsearch to start up, and retry after 503 responses
