### PR TITLE
windows launch scripts

### DIFF
--- a/bin/logstash.bat
+++ b/bin/logstash.bat
@@ -1,26 +1,51 @@
 @echo off
+setlocal enabledelayedexpansion
+set params='%*'
 
-SETLOCAL
-
-set SCRIPT_DIR=%~dp0
-CALL "%SCRIPT_DIR%\setup.bat"
-
-:EXEC
-REM is the first argument a flag? If so, assume 'agent'
-set first_arg=%1
-setlocal EnableDelayedExpansion
-if "!first_arg:~0,1!" equ "-" (
-  if "%VENDORED_JRUBY%" == "" (
-    %RUBYCMD% "%LS_HOME%\lib\bootstrap\environment.rb" "logstash\runner.rb" %*
-  ) else (
-    %JRUBY_BIN% %jruby_opts% "%LS_HOME%\lib\bootstrap\environment.rb" "logstash\runner.rb" %*
-  )
-) else (
-  if "%VENDORED_JRUBY%" == "" (
-    %RUBYCMD% "%LS_HOME%\lib\bootstrap\environment.rb" "logstash\runner.rb" %*
-  ) else (
-    %JRUBY_BIN% %jruby_opts% "%LS_HOME%\lib\bootstrap\environment.rb" "logstash\runner.rb" %*
-  )
+call "%~dp0setup.bat" || exit /b 1
+if errorlevel 1 (
+	if not defined nopauseonerror (
+		pause
+	)
+	exit /B %ERRORLEVEL%
 )
 
-ENDLOCAL
+rem iterate over the command line args and look for the argument
+rem after --path.settings to see if the jvm.options file is in
+rem that path and set LS_JVM_OPTIONS_CONFIG accordingly
+:loop
+for /F "usebackq tokens=1-2* delims= " %%A in (!params!) do (
+    set current=%%A
+    set next=%%B
+    set params='%%B %%C'
+
+    if "!current!" == "--path.settings" (
+    	if exist !next!\jvm.options (
+    	  set "LS_JVM_OPTIONS_CONFIG=!next!\jvm.options"
+    	)
+    )
+
+    if not "x!params!" == "x" (
+		goto loop
+	)
+)
+
+rem if explicit jvm.options is not found use default location
+if "%LS_JVM_OPTIONS_CONFIG%" == "" (
+  set LS_JVM_OPTIONS_CONFIG=%LS_HOME%\config\jvm.options
+)
+
+rem extract the options from the JVM options file %LS_JVM_OPTIONS_CONFIG%
+rem such options are the lines beginning with '-', thus "findstr /b"
+if exist %LS_JVM_OPTIONS_CONFIG% (
+  for /F "usebackq delims=" %%a in (`findstr /b \- %LS_JVM_OPTIONS_CONFIG%`) do set options=!options! %%a
+  set "LS_JAVA_OPTS=!options! %LS_JAVA_OPTS%"
+) else (
+  echo "warning: no jvm.options file found"
+)
+set JAVA_OPTS=%LS_JAVA_OPTS%
+
+rem jruby launcher will pickup JAVA_OPTS set above to set the JVM options before launching jruby
+%JRUBY_BIN% "%LS_HOME%\lib\bootstrap\environment.rb" "logstash\runner.rb" %*
+
+endlocal

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -1,92 +1,55 @@
 @echo off
 
-for %%I in ("%SCRIPT_DIR%..") do set LS_HOME=%%~dpfI
+set SCRIPT=%0
 
-if "%USE_RUBY%" == "1" (
-goto setup_ruby
+rem ### 1: determine logstash home
+
+rem  to do this, we strip from the path until we
+rem find bin, and then strip bin (there is an assumption here that there is no
+rem nested directory under bin also named bin)
+
+for %%I in (%SCRIPT%) do set LS_HOME=%%~dpI
+
+:ls_home_loop
+for %%I in ("%LS_HOME:~1,-1%") do set DIRNAME=%%~nxI
+if not "%DIRNAME%" == "bin" (
+  for %%I in ("%LS_HOME%..") do set LS_HOME=%%~dpfI
+  goto ls_home_loop
+)
+for %%I in ("%LS_HOME%..") do set LS_HOME=%%~dpfI
+
+rem ### 2: set java
+
+if defined JAVA_HOME (
+  set JAVA="%JAVA_HOME%\bin\java.exe"
 ) else (
-goto setup_jruby
+  for %%I in (java.exe) do set JAVA="%%~$PATH:I"
 )
 
-:setup_ruby
-set RUBYCMD=ruby
-set VENDORED_JRUBY=
-goto finally
-
-:setup_jruby
-REM setup_java()
-IF NOT DEFINED JAVA_HOME (
-  FOR %%I IN (java.exe) DO set JAVA_EXE=%%~$PATH:I
-)
-if defined JAVA_EXE set JAVA_HOME=%JAVA_EXE:\bin\java.exe=%
-if defined JAVA_EXE echo Using JAVA_HOME=%JAVA_HOME% retrieved from PATH
-
-if not defined JAVA_HOME goto missing_java_home
-REM ***** JAVA options *****
-
-if "%LS_HEAP_SIZE%" == "" (
-    set LS_HEAP_SIZE=1g
+if not exist %JAVA% (
+  echo could not find java; set JAVA_HOME or ensure java is in PATH 1>&2
+  exit /b 1
 )
 
-IF NOT "%JAVA_OPTS%" == "" (
-    ECHO JAVA_OPTS was set to [%JAVA_OPTS%]. Logstash will trust these options, and not set any defaults that it might usually set
-    goto opts_defined
+rem do not let JAVA_TOOL_OPTIONS slip in (as the JVM does by default)
+if not "%JAVA_TOOL_OPTIONS%" == "" (
+  echo "warning: ignoring JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+  set JAVA_TOOL_OPTIONS=
 )
 
-    SET JAVA_OPTS=%JAVA_OPTS% -Xmx%LS_HEAP_SIZE%
-
-    REM Enable aggressive optimizations in the JVM
-    REM    - Disabled by default as it might cause the JVM to crash
-    REM set JAVA_OPTS=%JAVA_OPTS% -XX:+AggressiveOpts
-
-    SET JAVA_OPTS=%JAVA_OPTS% -XX:+UseParNewGC
-    SET JAVA_OPTS=%JAVA_OPTS% -XX:+UseConcMarkSweepGC
-    SET JAVA_OPTS=%JAVA_OPTS% -XX:+CMSParallelRemarkEnabled
-    SET JAVA_OPTS=%JAVA_OPTS% -XX:SurvivorRatio=8
-    SET JAVA_OPTS=%JAVA_OPTS% -XX:MaxTenuringThreshold=1
-    SET JAVA_OPTS=%JAVA_OPTS% -XX:CMSInitiatingOccupancyFraction=75
-    SET JAVA_OPTS=%JAVA_OPTS% -XX:+UseCMSInitiatingOccupancyOnly
-
-    REM GC logging options -- uncomment to enable
-    REM JAVA_OPTS=%JAVA_OPTS% -XX:+PrintGCDetails
-    REM JAVA_OPTS=%JAVA_OPTS% -XX:+PrintGCTimeStamps
-    REM JAVA_OPTS=%JAVA_OPTS% -XX:+PrintClassHistogram
-    REM JAVA_OPTS=%JAVA_OPTS% -XX:+PrintTenuringDistribution
-    REM JAVA_OPTS=%JAVA_OPTS% -XX:+PrintGCApplicationStoppedTime
-    REM JAVA_OPTS=%JAVA_OPTS% -Xloggc:/var/log/logstash/gc.log
-
-    REM Causes the JVM to dump its heap on OutOfMemory.
-    SET JAVA_OPTS=%JAVA_OPTS% -XX:+HeapDumpOnOutOfMemoryError
-    REM The path to the heap dump location, note directory must exists and have enough
-    REM space for a full heap dump.
-    SET JAVA_OPTS=%JAVA_OPTS% -XX:HeapDumpPath="%LS_HOME%/heapdump.hprof"
-:opts_defined
-
-
-IF NOT "%LS_JAVA_OPTS%" == "" (
-    ECHO LS_JAVA_OPTS was set to [%LS_JAVA_OPTS%]. This will be appended to the JAVA_OPTS [%JAVA_OPTS%]
-    SET JAVA_OPTS=%JAVA_OPTS% %LS_JAVA_OPTS%
+rem JAVA_OPTS is not a built-in JVM mechanism but some people think it is so we
+rem warn them that we are not observing the value of %JAVA_OPTS%
+if not "%JAVA_OPTS%" == "" (
+  echo|set /p="warning: ignoring JAVA_OPTS=%JAVA_OPTS%; "
+  echo pass JVM parameters via LS_JAVA_OPTS
 )
 
-REM setup_vendored_jruby()
+rem ### 3: set jruby
+
 set JRUBY_BIN="%LS_HOME%\vendor\jruby\bin\jruby"
-if exist "%JRUBY_BIN%" (
-  set VENDORED_JRUBY=1
-  goto finally
-) else (
-  goto missing_jruby
+if not exist "%JRUBY_BIN%" (
+  echo "could not find jruby in %LS_HOME%\vendor\jruby" 1>&2
+  exit /b 1
 )
-
-:missing_java_home
-echo JAVA_HOME environment variable must be set!
-exit /b
-
-:missing_jruby
-echo Unable to find JRuby.
-echo If you are a user, this is a bug.
-echo If you are a developer, please run 'rake bootstrap'. Running 'rake' requires the 'ruby' program be available.
-exit /b
-
-:finally
 
 set RUBYLIB=%LS_HOME%\lib

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -249,7 +249,9 @@ class LogStash::Runner < Clamp::StrictCommand
     java.lang.System.setProperty("ls.log.level", setting("log.level"))
     unless java.lang.System.getProperty("log4j.configurationFile")
       log4j_config_location = ::File.join(setting("path.settings"), "log4j2.properties")
-      LogStash::Logging::Logger::reconfigure("file:///" + log4j_config_location)
+
+      # Windows safe way to produce a file: URI.
+      LogStash::Logging::Logger::reconfigure(URI.join("file:///" + File.absolute_path(log4j_config_location)).to_s)
     end
     # override log level that may have been introduced from a custom log4j config file
     LogStash::Logging::Logger::configure_logging(setting("log.level"))


### PR DESCRIPTION
fixes #8126 

This is mostly a rewrite of the windows launching batch files, inspired by the ES windows launch batch files.

The initial goal was to add support for the `config/jvm.options` in its default location or in `--path.settings` if specified on the command line. 

Here are the differences from the linux launching logic:
- existing `JAVA_OPTS` env var is now ignored, [ES is also doing this](https://github.com/elastic/elasticsearch/blob/33faf5ec70a29177eb50eccded4e2f103f938fc8/distribution/src/main/resources/bin/elasticsearch-env.bat#L37-L42)
- `JAVA_TOOL_OPTIONS` env var is cleared,  [ES is also doing this](https://github.com/elastic/elasticsearch/blob/33faf5ec70a29177eb50eccded4e2f103f938fc8/distribution/src/main/resources/bin/elasticsearch-env.bat#L31-L35)
- now only `LS_JAVA_OPTS` env var is supported to append options to parsed options in the `jvm.options` file.
- to simplify the rewrite I dropped the support of the `USE_RUBY` and `USE_DRIP` env vars. These were meant for development purposes and are not used anymore I believe. 

This also includes a fix in `runner.rb` which was creating an invalid URI for the path specified for `--path.settings` command line option. 

