### PR TITLE
 #8177 break cyclic dependency on old Logstash core in ITs and properly load it before service setup

### DIFF
--- a/ci/travis_integration_run.sh
+++ b/ci/travis_integration_run.sh
@@ -12,5 +12,5 @@ cd qa/integration
 # due to some sideeffects of the seccomp policy interfering with
 # the docker daemon
 # See prepare_offline_pack_spec.rb for details
-rspec --tag ~offline
-rspec --tag offline
+bundle exec rspec --tag ~offline
+bundle exec rspec --tag offline

--- a/qa/integration/Gemfile
+++ b/qa/integration/Gemfile
@@ -1,2 +1,4 @@
 source "https://rubygems.org"
+gem "logstash-core", :path => "../../logstash-core"
+gem "logstash-core-plugin-api", :path => "../../logstash-core-plugin-api"
 gemspec

--- a/qa/integration/integration_tests.gemspec
+++ b/qa/integration/integration_tests.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'manticore'
   s.add_development_dependency 'stud'
   s.add_development_dependency 'pry'
-  s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'logstash-devutils', '= 1.3.3'
   s.add_development_dependency 'flores'
   s.add_development_dependency 'rubyzip'
 end

--- a/qa/integration/services/service.rb
+++ b/qa/integration/services/service.rb
@@ -1,3 +1,5 @@
+require_relative '../../../logstash-core/lib/logstash-core.rb'
+
 # Base class for a service like Kafka, ES, Logstash
 class Service
 


### PR DESCRIPTION
Fixes #8177 (manually confirmed that :))

Best we can do here I fear, as @jakelandis points out manually requiring `logstash-core` before we use the logger fixes things, so I did that in `service.rb` because all downstream use of the logger starts from that script.
Also forced the use of the logstash core from the current code and not that from dev utils, to break the cyclic dependency on old LS.