### PR TITLE
MINOR: Exclude JAVA_OPT* line from matching in prepare_offline_pack_spec

### DIFF
--- a/qa/integration/specs/cli/prepare_offline_pack_spec.rb
+++ b/qa/integration/specs/cli/prepare_offline_pack_spec.rb
@@ -54,7 +54,7 @@ describe "CLI > logstash-plugin prepare-offline-pack", :offline => true do
 
       unpacked = unpack(temporary_zip_file)
 
-      filters = @logstash_plugin.list(plugins_to_pack.first).stderr_and_stdout.split("\n").delete_if { |f| f =~ /cext/ }
+      filters = @logstash_plugin.list(plugins_to_pack.first).stderr_and_stdout.split("\n").delete_if { |f| f =~ /cext/ || f =~ /JAVA_OPT/ }
 
       expect(unpacked.plugins.collect(&:name)).to include(*filters)
       expect(unpacked.plugins.size).to eq(filters.size)


### PR DESCRIPTION
Currently `Picked up _JAVA_OPTIONS: -Xmx2048m -Xms512m` or `WARNING: Default JAVA_OPTS will be overridden by the JAVA_OPTS defined in the environment. Environment JAVA_OPTS are  -Djava.net.preferIPv4Stack=true -Xmx4g -Xms4g -Xss2048k
` (or similar lines as a result of set environment variables) in the output of LS break the IT `qa/integration/specs/cli/prepare_offline_pack_spec.rb`.
This excludes those lines from the stdout matching and fixes failures like:

```sh
  create a pack from a wildcard
    successfully create a pack (FAILED - 1)
Failures:
  1) CLI > logstash-plugin prepare-offline-pack create a pack from a wildcard successfully create a pack
     Failure/Error: expect(unpacked.plugins.collect(&:name)).to include(*filters)
       expected ["logstash-filter-throttle", "logstash-filter-dissect", "logstash-filter-drop", "logstash-filter-date...logstash-filter-json", "logstash-filter-mutate", "logstash-filter-metrics", "logstash-filter-geoip"] to include "Picked up _JAVA_OPTIONS: -Xmx2048m -Xms512m"
     # ./specs/cli/prepare_offline_pack_spec.rb:59:in `block in (root)'
     # /home/travis/.rvm/gems/jruby-9.1.10.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block in (root)'
Finished in 2 minutes 25 seconds (files took 10.06 seconds to load)
3 examples, 1 failure
```