### PR TITLE
BUG: Fix deadlock on Queue not full wait

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -382,6 +382,7 @@ public class Queue implements Closeable {
                     // not trigger a checkpoint creation in itself
                     TailPage tailPage = new TailPage(this.headPage);
                     tailPage.purge();
+                    currentByteSize -= tailPage.getPageIO().getCapacity();
                 } else {
                     // beheading includes checkpoint+fsync if required
                     TailPage tailPage = this.headPage.behead();

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.logstash.ackedqueue.io.AbstractByteBufferPageIO;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -76,6 +77,31 @@ public class QueueTest {
 
             assertThat(b.getElements().size(), is(1));
             assertThat(b.getElements().get(0).toString(), is(element.toString()));
+            assertThat(q.nonBlockReadBatch(1), nullValue());
+        }
+    }
+
+    /**
+     * This test guards against issue https://github.com/elastic/logstash/pull/8186 by ensuring
+     * that repeated writes to an already fully acknowledged headpage do not corrupt the queue's
+     * internal bytesize counter.
+     * @throws IOException On Failure
+     */
+    @Test(timeout = 5000)
+    public void writeToFullyAckedHeadpage() throws IOException {
+        final Queueable element = new StringElement("foobarbaz");
+        final int page = element.serialize().length * 2 + AbstractByteBufferPageIO.MIN_CAPACITY;
+        // Queue that can only hold one element per page.
+        try (Queue q = new TestQueue(
+            TestSettings.volatileQueueSettings(page, page * 2 - 1))) {
+            q.open();
+            for (int i = 0; i < 5; ++i) {
+                q.write(element);
+                try (Batch b = q.readBatch(1, 500L)) {
+                    assertThat(b.getElements().size(), is(1));
+                    assertThat(b.getElements().get(0).toString(), is(element.toString()));
+                }
+            }
             assertThat(q.nonBlockReadBatch(1), nullValue());
         }
     }


### PR DESCRIPTION
We cannot lock the Ruby side here, otherwise, we can get into the situation of a **full read** but **full queue** that doesn't get acks through.

Why?

* Readers read many events per lock acquire
* Writers just write on

=> Readers can read everything => get stuck on `notEmpty.await();` in `Queue` and hold on to this mutex:

```rb
      def read_batch
        if @queue.closed?
          raise QueueClosedError.new("Attempt to take a batch from a closed AckedQueue")
        end

        batch = new_batch
        @mutex.lock
        begin
          batch.read_next
        ensure
          @mutex.unlock
```

now acks can't happen because they need the same mutex:

```rb
      def close_batch(batch)
        @mutex.lock
        begin
          batch.close
          # there seems to be concurrency issues with metrics, keep it in the mutex
          @inflight_batches.delete(Thread.current)
          stop_clock(batch)
        ensure
          @mutex.unlock
        end
      end
```

-> deadlocked like in the linked issue.

-> We can simply remove the read mutex in Ruby here because we have a lock on the Java side anyways and fix this issue.