### PR TITLE
MINOR: Gitignore compiled c code in ITs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ qa/integration/services/installed/
 logstash-core/bin
 plugins_version_docs.json
 tools/benchmark-cli/out/
+qa/integration/fixtures/offline_wrapper/offline
+qa/integration/fixtures/offline_wrapper/offline.o


### PR DESCRIPTION
These two get compiled if you run the full IT suite on Linux.
Since the IT suite is kind of in-flux right now, I wouldn't put more effort towards a nicer build (i.e. proper target folder for binary output) for that` C` code and just ignore those two files explicitly.