### PR TITLE
MINOR: Cleanup JAVAC warnings around our Jruby Extensions

### DIFF
--- a/logstash-core/src/main/java/JrubyAckedBatchExtService.java
+++ b/logstash-core/src/main/java/JrubyAckedBatchExtService.java
@@ -2,12 +2,9 @@ import org.jruby.Ruby;
 import org.jruby.runtime.load.BasicLibraryService;
 import org.logstash.ackedqueue.ext.JrubyAckedBatchExtLibrary;
 
-import java.io.IOException;
-
 public class JrubyAckedBatchExtService implements BasicLibraryService {
-    public boolean basicLoad(final Ruby runtime)
-            throws IOException
-    {
+    @Override
+    public boolean basicLoad(final Ruby runtime) {
         new JrubyAckedBatchExtLibrary().load(runtime, false);
         return true;
     }

--- a/logstash-core/src/main/java/JrubyAckedQueueExtService.java
+++ b/logstash-core/src/main/java/JrubyAckedQueueExtService.java
@@ -3,12 +3,9 @@ import org.jruby.runtime.load.BasicLibraryService;
 import org.logstash.ackedqueue.ext.JrubyAckedQueueExtLibrary;
 import org.logstash.ackedqueue.ext.JrubyAckedQueueMemoryExtLibrary;
 
-import java.io.IOException;
-
-public class JrubyAckedQueueExtService implements BasicLibraryService {
-    public boolean basicLoad(final Ruby runtime)
-            throws IOException
-    {
+public final class JrubyAckedQueueExtService implements BasicLibraryService {
+    @Override
+    public boolean basicLoad(final Ruby runtime) {
         new JrubyAckedQueueExtLibrary().load(runtime, false);
         new JrubyAckedQueueMemoryExtLibrary().load(runtime, false);
         return true;

--- a/logstash-core/src/main/java/JrubyEventExtService.java
+++ b/logstash-core/src/main/java/JrubyEventExtService.java
@@ -1,13 +1,10 @@
-import org.logstash.ext.JrubyEventExtLibrary;
 import org.jruby.Ruby;
 import org.jruby.runtime.load.BasicLibraryService;
+import org.logstash.ext.JrubyEventExtLibrary;
 
-import java.io.IOException;
-
-public class JrubyEventExtService implements BasicLibraryService {
-    public boolean basicLoad(final Ruby runtime)
-        throws IOException
-    {
+public final class JrubyEventExtService implements BasicLibraryService {
+    @Override
+    public boolean basicLoad(final Ruby runtime) {
         new JrubyEventExtLibrary().load(runtime, false);
         return true;
     }

--- a/logstash-core/src/main/java/JrubyTimestampExtService.java
+++ b/logstash-core/src/main/java/JrubyTimestampExtService.java
@@ -1,13 +1,10 @@
-import org.logstash.ext.JrubyTimestampExtLibrary;
 import org.jruby.Ruby;
 import org.jruby.runtime.load.BasicLibraryService;
+import org.logstash.ext.JrubyTimestampExtLibrary;
 
-import java.io.IOException;
-
-public class JrubyTimestampExtService implements BasicLibraryService {
-    public boolean basicLoad(final Ruby runtime)
-            throws IOException
-    {
+public final class JrubyTimestampExtService implements BasicLibraryService {
+    @Override
+    public boolean basicLoad(final Ruby runtime) {
         new JrubyTimestampExtLibrary().load(runtime, false);
         return true;
     }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedBatchExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedBatchExtLibrary.java
@@ -20,9 +20,10 @@ import org.logstash.ext.JrubyEventExtLibrary;
 
 import java.io.IOException;
 
-public class JrubyAckedBatchExtLibrary implements Library {
+public final class JrubyAckedBatchExtLibrary implements Library {
 
-    public void load(Ruby runtime, boolean wrap) throws IOException {
+    @Override
+    public void load(Ruby runtime, boolean wrap) {
         RubyModule module = runtime.defineModule(RubyUtil.LS_MODULE_NAME);
 
         RubyClass clazz = runtime.defineClassUnder("AckedBatch", runtime.getObject(), new ObjectAllocator() {
@@ -35,7 +36,7 @@ public class JrubyAckedBatchExtLibrary implements Library {
     }
 
     @JRubyClass(name = "AckedBatch")
-    public static class RubyAckedBatch extends RubyObject {
+    public static final class RubyAckedBatch extends RubyObject {
         private static final long serialVersionUID = -3118949118637372130L;
         private Batch batch;
 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java
@@ -5,12 +5,10 @@ import org.jruby.Ruby;
 import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyFixnum;
-import org.jruby.RubyModule;
 import org.jruby.RubyObject;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.Arity;
-import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.load.Library;
@@ -23,26 +21,25 @@ import org.logstash.ackedqueue.io.FileCheckpointIO;
 import org.logstash.ackedqueue.io.MmapPageIO;
 import org.logstash.ext.JrubyEventExtLibrary;
 
-public class JrubyAckedQueueExtLibrary implements Library {
+public final class JrubyAckedQueueExtLibrary implements Library {
 
-    public void load(Ruby runtime, boolean wrap) throws IOException {
-        RubyModule module = runtime.defineModule(RubyUtil.LS_MODULE_NAME);
-
-        RubyClass clazz = runtime.defineClassUnder("AckedQueue", runtime.getObject(), new ObjectAllocator() {
-            public IRubyObject allocate(Ruby runtime, RubyClass rubyClass) {
-                return new RubyAckedQueue(runtime, rubyClass);
-            }
-        }, module);
-
-        clazz.defineAnnotatedMethods(RubyAckedQueue.class);
+    @Override
+    public void load(Ruby runtime, boolean wrap) {
+        runtime.defineClassUnder(
+            "AckedQueue", runtime.getObject(), JrubyAckedQueueExtLibrary.RubyAckedQueue::new,
+            runtime.defineModule(RubyUtil.LS_MODULE_NAME)
+        ).defineAnnotatedMethods(JrubyAckedQueueExtLibrary.RubyAckedQueue.class);
     }
 
     // TODO:
     // as a simplified first prototyping implementation, the Settings class is not exposed and the queue elements
     // are assumed to be logstash Event.
 
-    @JRubyClass(name = "AckedQueue", parent = "Object")
-    public static class RubyAckedQueue extends RubyObject {
+    @JRubyClass(name = "AckedQueue")
+    public static final class RubyAckedQueue extends RubyObject {
+
+        private static final long serialVersionUID = 1L;
+
         private Queue queue;
 
         public RubyAckedQueue(Ruby runtime, RubyClass klass) {

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueMemoryExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueMemoryExtLibrary.java
@@ -5,12 +5,10 @@ import org.jruby.Ruby;
 import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyFixnum;
-import org.jruby.RubyModule;
 import org.jruby.RubyObject;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.Arity;
-import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.load.Library;
@@ -23,18 +21,15 @@ import org.logstash.ackedqueue.io.ByteBufferPageIO;
 import org.logstash.ackedqueue.io.MemoryCheckpointIO;
 import org.logstash.ext.JrubyEventExtLibrary;
 
-public class JrubyAckedQueueMemoryExtLibrary implements Library {
+public final class JrubyAckedQueueMemoryExtLibrary implements Library {
 
-    public void load(Ruby runtime, boolean wrap) throws IOException {
-        RubyModule module = runtime.defineModule(RubyUtil.LS_MODULE_NAME);
-
-        RubyClass clazz = runtime.defineClassUnder("AckedMemoryQueue", runtime.getObject(), new ObjectAllocator() {
-            public IRubyObject allocate(Ruby runtime, RubyClass rubyClass) {
-                return new RubyAckedMemoryQueue(runtime, rubyClass);
-            }
-        }, module);
-
-        clazz.defineAnnotatedMethods(RubyAckedMemoryQueue.class);
+    @Override
+    public void load(Ruby runtime, boolean wrap) {
+        runtime.defineClassUnder(
+            "AckedMemoryQueue", runtime.getObject(),
+            JrubyAckedQueueMemoryExtLibrary.RubyAckedMemoryQueue::new,
+            runtime.defineModule(RubyUtil.LS_MODULE_NAME)
+        ).defineAnnotatedMethods(JrubyAckedQueueMemoryExtLibrary.RubyAckedMemoryQueue.class);
     }
 
     // TODO:
@@ -42,8 +37,11 @@ public class JrubyAckedQueueMemoryExtLibrary implements Library {
     // are assumed to be logstash Event.
 
 
-    @JRubyClass(name = "AckedMemoryQueue", parent = "Object")
-    public static class RubyAckedMemoryQueue extends RubyObject {
+    @JRubyClass(name = "AckedMemoryQueue")
+    public static final class RubyAckedMemoryQueue extends RubyObject {
+
+        private static final long serialVersionUID = 1L;
+
         private Queue queue;
 
         public RubyAckedMemoryQueue(Ruby runtime, RubyClass klass) {

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -27,14 +27,14 @@ import org.logstash.RubyUtil;
 import org.logstash.Rubyfier;
 import org.logstash.Valuefier;
 
-public class JrubyEventExtLibrary implements Library {
+public final class JrubyEventExtLibrary implements Library {
 
     private static RubyClass PARSER_ERROR = null;
     private static RubyClass GENERATOR_ERROR = null;
     private static RubyClass LOGSTASH_ERROR = null;
 
     @Override
-    public void load(Ruby runtime, boolean wrap) throws IOException {
+    public void load(Ruby runtime, boolean wrap) {
         final RubyModule module = runtime.defineModule(RubyUtil.LS_MODULE_NAME);
 
         RubyClass clazz = runtime.defineClassUnder(
@@ -67,6 +67,8 @@ public class JrubyEventExtLibrary implements Library {
 
     @JRubyClass(name = "Event")
     public static final class RubyEvent extends RubyObject {
+
+        private static final long serialVersionUID = 1L;
 
         /**
          * Sequence number generator, for generating {@link RubyEvent#hash}.

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
@@ -1,7 +1,6 @@
 package org.logstash.ext;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import java.io.IOException;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyFixnum;
@@ -23,7 +22,7 @@ import org.logstash.ObjectMappers;
 import org.logstash.RubyUtil;
 import org.logstash.Timestamp;
 
-public class JrubyTimestampExtLibrary implements Library {
+public final class JrubyTimestampExtLibrary implements Library {
 
     private static final ObjectAllocator ALLOCATOR = new ObjectAllocator() {
         public RubyTimestamp allocate(Ruby runtime, RubyClass rubyClass) {
@@ -31,7 +30,8 @@ public class JrubyTimestampExtLibrary implements Library {
         }
     };
 
-    public void load(Ruby runtime, boolean wrap) throws IOException {
+    @Override
+    public void load(Ruby runtime, boolean wrap) {
         createTimestamp(runtime);
     }
 
@@ -44,7 +44,9 @@ public class JrubyTimestampExtLibrary implements Library {
 
     @JRubyClass(name = "Timestamp")
     @JsonSerialize(using = ObjectMappers.RubyTimestampSerializer.class)
-    public static class RubyTimestamp extends RubyObject {
+    public static final class RubyTimestamp extends RubyObject {
+
+        private static final long serialVersionUID = 1L;
 
         private Timestamp timestamp;
 
@@ -67,11 +69,6 @@ public class JrubyTimestampExtLibrary implements Library {
 
         public static RubyTimestamp newRubyTimestamp(Ruby runtime) {
             return new RubyTimestamp(runtime);
-        }
-
-        public static RubyTimestamp newRubyTimestamp(Ruby runtime, long epoch) {
-            // Ruby epoch is in seconds, Java in milliseconds
-            return new RubyTimestamp(runtime, new Timestamp(epoch * 1000));
         }
 
         public static RubyTimestamp newRubyTimestamp(Ruby runtime, Timestamp timestamp) {

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGaugeTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGaugeTest.java
@@ -1,43 +1,31 @@
 package org.logstash.instrument.metrics.gauge;
 
+import java.net.URI;
+import java.util.Collections;
 import org.jruby.RubyHash;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.logstash.RubyUtil;
 import org.logstash.Timestamp;
 import org.logstash.ext.JrubyTimestampExtLibrary;
 import org.logstash.instrument.metrics.MetricType;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
-import java.net.URI;
-import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link LazyDelegatingGauge}
  */
-@RunWith(MockitoJUnitRunner.class)
 public class LazyDelegatingGaugeTest {
 
-    @Mock
-    RubyHash rubyHash;
+    private static final RubyHash RUBY_HASH = RubyHash.newHash(RubyUtil.RUBY);
 
-    @Mock
-    private JrubyTimestampExtLibrary.RubyTimestamp rubyTimestamp;
+    private static final Timestamp TIMESTAMP = new Timestamp();
 
-    private final Timestamp timestamp = new Timestamp();
+    private static final JrubyTimestampExtLibrary.RubyTimestamp RUBY_TIMESTAMP =
+        JrubyTimestampExtLibrary.RubyTimestamp.newRubyTimestamp(
+            RubyUtil.RUBY, TIMESTAMP
+        );
 
     private static final String RUBY_HASH_AS_STRING = "{}";
-
-    @Before
-    public void _setup() {
-        //hacky workaround using the toString method to avoid mocking the Ruby runtime
-        when(rubyHash.toString()).thenReturn(RUBY_HASH_AS_STRING);
-        when(rubyTimestamp.getTimestamp()).thenReturn(timestamp);
-    }
 
     @Test
     public void getValue() {
@@ -62,13 +50,13 @@ public class LazyDelegatingGaugeTest {
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_TEXT);
 
         //Ruby Hash
-        gauge = new LazyDelegatingGauge("bar", rubyHash);
+        gauge = new LazyDelegatingGauge("bar", RUBY_HASH);
         assertThat(gauge.getValue().toString()).isEqualTo(RUBY_HASH_AS_STRING);
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_RUBYHASH);
 
         //Ruby Timestamp
-        gauge = new LazyDelegatingGauge("bar", rubyTimestamp);
-        assertThat(gauge.getValue()).isEqualTo(timestamp);
+        gauge = new LazyDelegatingGauge("bar", RUBY_TIMESTAMP);
+        assertThat(gauge.getValue()).isEqualTo(TIMESTAMP);
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_RUBYTIMESTAMP);
 
         //Unknown
@@ -128,14 +116,14 @@ public class LazyDelegatingGaugeTest {
 
         //Ruby Hash
         gauge = new LazyDelegatingGauge("bar");
-        gauge.set(rubyHash);
+        gauge.set(RUBY_HASH);
         assertThat(gauge.getValue().toString()).isEqualTo(RUBY_HASH_AS_STRING);
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_RUBYHASH);
 
         //Ruby Timestamp
         gauge = new LazyDelegatingGauge("bar");
-        gauge.set(rubyTimestamp);
-        assertThat(gauge.getValue()).isEqualTo(timestamp);
+        gauge.set(RUBY_TIMESTAMP);
+        assertThat(gauge.getValue()).isEqualTo(TIMESTAMP);
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_RUBYTIMESTAMP);
 
         //Unknown

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/RubyTimeStampGaugeTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/RubyTimeStampGaugeTest.java
@@ -1,16 +1,14 @@
 package org.logstash.instrument.metrics.gauge;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.logstash.RubyUtil;
 import org.logstash.Timestamp;
-import org.logstash.ext.JrubyTimestampExtLibrary.RubyTimestamp;
+import org.logstash.ext.JrubyTimestampExtLibrary;
 import org.logstash.instrument.metrics.MetricType;
-import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link RubyTimeStampGauge}
@@ -18,20 +16,17 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class RubyTimeStampGaugeTest {
 
-    @Mock
-    private RubyTimestamp rubyTimestamp;
+    private static final Timestamp TIMESTAMP = new Timestamp();
 
-    private final Timestamp timestamp = new Timestamp();
-
-    @Before
-    public void _setup() {
-        when(rubyTimestamp.getTimestamp()).thenReturn(timestamp);
-    }
+    private static final JrubyTimestampExtLibrary.RubyTimestamp RUBY_TIMESTAMP =
+        JrubyTimestampExtLibrary.RubyTimestamp.newRubyTimestamp(
+            RubyUtil.RUBY, TIMESTAMP
+        );
 
     @Test
     public void getValue() {
-        RubyTimeStampGauge gauge = new RubyTimeStampGauge("bar", rubyTimestamp);
-        assertThat(gauge.getValue()).isEqualTo(rubyTimestamp.getTimestamp());
+        RubyTimeStampGauge gauge = new RubyTimeStampGauge("bar", RUBY_TIMESTAMP);
+        assertThat(gauge.getValue()).isEqualTo(RUBY_TIMESTAMP.getTimestamp());
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_RUBYTIMESTAMP);
 
         //Null initialize
@@ -43,8 +38,8 @@ public class RubyTimeStampGaugeTest {
     @Test
     public void set() {
         RubyTimeStampGauge gauge = new RubyTimeStampGauge("bar");
-        gauge.set(rubyTimestamp);
-        assertThat(gauge.getValue()).isEqualTo(rubyTimestamp.getTimestamp());
+        gauge.set(RUBY_TIMESTAMP);
+        assertThat(gauge.getValue()).isEqualTo(RUBY_TIMESTAMP.getTimestamp());
         assertThat(gauge.getType()).isEqualTo(MetricType.GAUGE_RUBYTIMESTAMP);
     }
 }


### PR DESCRIPTION
Another step for #7701 => down to 67 warnings in production code :P 

* Also cleaned up our extension libraries as much as possible to make things `final` where I could especially when it comes to `RubyTimestamp` and `Timestamp`. 
** Those two classes are used in the hot path together with reflection (`getClass()`) so it can't hurt to make them `final` performance and correctness wise. Adjusted the tests accordingly, mocking isn't necessary anymore now that we hold a global reference to the `Ruby` runtime here anyways.
* And removed some dead constructors and factory method from the `RubyTimestamp` logic