### PR TITLE
WIP: Change the requires when building the documentation

### DIFF
--- a/ci/ci_docs.sh
+++ b/ci/ci_docs.sh
@@ -11,4 +11,4 @@ echo "Generate json with plugins version"
 # Since we generate the lock file and we try to resolve dependencies we will need
 # to use the bundle wrapper to correctly find the rake cli. If we don't do this we
 # will get an activation error,
-./bin/bundle exec rake generate_plugins_version
+#./bin/bundle exec rake generate_plugins_version

--- a/rakelib/plugins_docs_dependencies.rake
+++ b/rakelib/plugins_docs_dependencies.rake
@@ -128,7 +128,6 @@ task :generate_plugins_version do
   require "bundler"
   require "bundler/dsl"
   require "json"
-  Bundler.setup(:default)
   require "pluginmanager/gemfile"
   require "bootstrap/environment"
 


### PR DESCRIPTION
Loading only the default gems when building the docs make the generation
fails to find some dependencies, even if they were default dependencies.

Also remove the need to bundle exec and use the rake task directly, It
was a bit more stable with the installed gems in the JRuby 9k
environment.

*Note:*

This not ready for review, I am currently waiting on a new release of ruby-ftw to correctly build the 6.0 docs.