### PR TITLE
Use standard name for Gemfile's lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ qa/.vm_ssh_config
 qa/.vagrant
 qa/acceptance/.vagrant
 qa/Gemfile.lock
-Gemfile.jruby-2.3.lock
+Gemfile.lock
 Gemfile
 *.ipr
 *.iws

--- a/ci/ci_acceptance.sh
+++ b/ci/ci_acceptance.sh
@@ -13,7 +13,7 @@ SELECTED_TEST_SUITE=$1
 # we will clear them out to make sure we use the latest version of theses files
 # If we don't do this we will run into gem Conflict error.
 [ -f Gemfile ] && rm Gemfile
-[ -f Gemfile.jruby-2.3.lock ] && rm Gemfile.jruby-2.3.lock
+[ -f Gemfile.lock ] && rm Gemfile.lock
 
 if [[ $SELECTED_TEST_SUITE == $"redhat" ]]; then
   echo "Generating the RPM, make sure you start with a clean environment before generating other packages."

--- a/lib/bootstrap/bundler.rb
+++ b/lib/bootstrap/bundler.rb
@@ -7,15 +7,6 @@ module LogStash
     extend self
 
     def patch!
-      # Patch bundler to write a .lock file specific to the version of ruby.
-      # This keeps MRI/JRuby/RBX from conflicting over the Gemfile.lock updates
-      ::Bundler::SharedHelpers.module_exec do
-        def default_lockfile
-          ruby = "#{Environment.ruby_engine}-#{Environment.ruby_abi_version}"
-          Pathname.new("#{default_gemfile}.#{ruby}.lock")
-        end
-      end
-
       # Patch to prevent Bundler to save a .bundle/config file in the root
       # of the application
       ::Bundler::Settings.module_exec do
@@ -107,7 +98,7 @@ module LogStash
         )
       end
       # create Gemfile.jruby-1.9.lock from template iff a template exists it itself does not exist
-      lock_template = ::File.join(ENV["LOGSTASH_HOME"], "Gemfile.jruby-2.3.lock.release")
+      lock_template = ::File.join(ENV["LOGSTASH_HOME"], "Gemfile.lock.release")
       if ::File.exists?(lock_template) && !::File.exists?(Environment::LOCKFILE)
         FileUtils.copy(lock_template, Environment::LOCKFILE)
       end

--- a/lib/bootstrap/environment.rb
+++ b/lib/bootstrap/environment.rb
@@ -18,7 +18,7 @@ module LogStash
     GEMFILE_PATH = ::File.join(LOGSTASH_HOME, "Gemfile")
     LOCAL_GEM_PATH = ::File.join(LOGSTASH_HOME, 'vendor', 'local_gems')
     CACHE_PATH = ::File.join(LOGSTASH_HOME, "vendor", "cache")
-    LOCKFILE = Pathname.new(::File.join(LOGSTASH_HOME, "Gemfile.jruby-2.3.lock"))
+    LOCKFILE = Pathname.new(::File.join(LOGSTASH_HOME, "Gemfile.lock"))
     GEMFILE = Pathname.new(::File.join(LOGSTASH_HOME, "Gemfile"))
 
     # @return [String] the ruby version string bundler uses to craft its gem path

--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -205,7 +205,7 @@ class LogstashService < Service
   end
 
   def lock_file
-    File.join(@logstash_home, "Gemfile.jruby-2.3.lock")
+    File.join(@logstash_home, "Gemfile.lock")
   end
 
   class PluginCli

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -39,7 +39,7 @@ namespace "artifact" do
       # See more in https://github.com/elastic/logstash/issues/4818
       "vendor/??*/**/.mvn/**/*",
       "Gemfile",
-      "Gemfile.jruby-2.3.lock",
+      "Gemfile.lock",
     ]
   end
 


### PR DESCRIPTION
In previous iteration of logstash < 1.5 we were trying as much as
possible to make the code compatible with different ruby
implementations. This features required use to create a lock specific
for each Ruby version, with the migration to Java code we are only
targetting JRuby implementation.

Reference: #8207