### PR TITLE
BENCHMARK: Add Workercount and Batch size as configurable settings in benchmarks

### DIFF
--- a/tools/benchmark-cli/README.md
+++ b/tools/benchmark-cli/README.md
@@ -31,6 +31,10 @@ Option                           Description
 --local-path <String>            Path to the root of a local Logstash           
                                    distribution.                                
                                   E.g. `/opt/logstash`                          
+--ls-batch-size <Integer>        Logstash batch size (-b argument) to           
+                                   configure. (default: 128)                    
+--ls-workers <Integer>           Number of Logstash worker threads (-w          
+                                   argument) to configure. (default: 2)         
 --repeat-data <Integer>          Sets how often the test's dataset should be    
                                    run. (default: 1)                            
 --testcase <String>              Currently available test cases are 'baseline'  

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/BenchmarkMeta.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/BenchmarkMeta.java
@@ -1,0 +1,69 @@
+package org.logstash.benchmark.cli;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.lang3.SystemUtils;
+import org.logstash.benchmark.cli.ui.LsVersionType;
+
+public final class BenchmarkMeta {
+
+    private final String testcase;
+
+    private final String version;
+
+    private final LsVersionType vtype;
+
+    private final int workers;
+
+    private final int batchsize;
+
+    BenchmarkMeta(final String testcase, final String version, final LsVersionType vtype,
+        final int workers, final int batchsize) {
+        this.testcase = testcase;
+        this.version = version;
+        this.vtype = vtype;
+        this.workers = workers;
+        this.batchsize = batchsize;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getTestcase() {
+        return testcase;
+    }
+
+    public LsVersionType getVtype() {
+        return vtype;
+    }
+
+    public int getWorkers() {
+        return workers;
+    }
+
+    public int getBatchsize() {
+        return batchsize;
+    }
+
+    public Map<String, Object> asMap() {
+        final Map<String, Object> result = new HashMap<>();
+        result.put("test_name", testcase);
+        result.put("os_name", SystemUtils.OS_NAME);
+        result.put("os_version", SystemUtils.OS_VERSION);
+        try {
+            result.put("host_name", InetAddress.getLocalHost().getHostName());
+        } catch (final UnknownHostException ex) {
+            throw new IllegalStateException(ex);
+        }
+        result.put("cpu_cores", Runtime.getRuntime().availableProcessors());
+        result.put("version_type", vtype);
+        result.put("version", version);
+        result.put("batch_size", batchsize);
+        result.put("worker_threads", workers);
+        return Collections.unmodifiableMap(result);
+    }
+}

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/cases/ApacheLogsComplex.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/cases/ApacheLogsComplex.java
@@ -11,6 +11,7 @@ import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import org.apache.commons.io.IOUtils;
+import org.logstash.benchmark.cli.BenchmarkMeta;
 import org.logstash.benchmark.cli.DataStore;
 import org.logstash.benchmark.cli.LogstashInstallation;
 import org.logstash.benchmark.cli.LsBenchSettings;
@@ -46,14 +47,15 @@ public final class ApacheLogsComplex implements Case {
     private final int repeats;
 
     public ApacheLogsComplex(final DataStore store, final LogstashInstallation logstash,
-        final Path cwd, final Properties settings, final UserOutput output)
-        throws IOException, NoSuchAlgorithmException {
+        final Path cwd, final Properties settings, final UserOutput output,
+        final BenchmarkMeta runConfig) throws IOException, NoSuchAlgorithmException {
         data = cwd.resolve("data_apache").resolve("apache_access_logs").toFile();
         ensureDatafile(
             data.toPath().getParent().toFile(),
             settings.getProperty(LsBenchSettings.APACHE_DATASET_URL), output
         );
         this.logstash = logstash;
+        logstash.configure(runConfig);
         this.store = store;
         repeats = Integer.parseInt(settings.getProperty(LsBenchSettings.INPUT_DATA_REPEAT));
     }

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/cases/GeneratorToStdout.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/cases/GeneratorToStdout.java
@@ -5,6 +5,7 @@ import java.util.EnumMap;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import org.logstash.benchmark.cli.BenchmarkMeta;
 import org.logstash.benchmark.cli.DataStore;
 import org.logstash.benchmark.cli.LogstashInstallation;
 import org.logstash.benchmark.cli.LsBenchSettings;
@@ -29,8 +30,9 @@ public final class GeneratorToStdout implements Case {
     private final DataStore store;
 
     public GeneratorToStdout(final DataStore store, final LogstashInstallation logstash,
-        final Properties settings) {
+        final Properties settings, final BenchmarkMeta lsSettings) {
         this.logstash = logstash;
+        logstash.configure(lsSettings);
         this.store = store;
         configuration =
             String.format(

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/ui/UserInput.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/ui/UserInput.java
@@ -34,6 +34,20 @@ public final class UserInput {
     public static final String TEST_CASE_HELP =
         "Currently available test cases are 'baseline' and 'apache'.";
 
+    public static final String LS_WORKER_THREADS = "ls-workers";
+
+    public static final String LS_BATCH_SIZE = "ls-batch-size";
+
+    public static final int LS_BATCHSIZE_DEFAULT = 128;
+
+    public static final String LS_BATCH_SIZE_HELP =
+        "Logstash batch size (-b argument) to configure.";
+
+    public static final int LS_WORKER_THREADS_DEFAULT = 2;
+
+    public static final String LS_WORKER_THREADS_HELP =
+        "Number of Logstash worker threads (-w argument) to configure.";
+
     /**
      * Version parameter to use for Logstash build downloaded from elastic.co.
      */

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/util/LsBenchDownloader.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/util/LsBenchDownloader.java
@@ -14,7 +14,10 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 
 public final class LsBenchDownloader {
-    
+
+    private LsBenchDownloader() {
+    }
+
     public static void downloadDecompress(final File file, final String url)
         throws IOException, NoSuchAlgorithmException {
         if (file.exists()) {


### PR DESCRIPTION
Link #7784

Slightly dirty, but good enough imo (mostly need this to test a few corner cases in the Java execution):

* Added flags for running with custom batch-size and worker count
* Cleaned up the handling of LS params a little by grouping them via `BenchmarkMeta`