### PR TITLE
[Docs] Fix heading level in docker docs

### DIFF
--- a/docs/static/docker.asciidoc
+++ b/docs/static/docker.asciidoc
@@ -10,7 +10,7 @@ https://github.com/elastic/logstash-docker/tree/{branch}[GitHub].
 The images are shipped with https://www.elastic.co/products/x-pack[X-Pack]
 installed.
 
-=== Pulling the image
+==== Pulling the image
 Obtaining Logstash for Docker is as simple as issuing a +docker
 pull+ command against the Elastic Docker registry.
 


### PR DESCRIPTION
Incorrect heading level resulted in the doc build creating a new topic called "Pulling the image". I think all this content is meant to be kept under "Running Logstash on Docker" so I'm changing the heading level to ====. 

@jarpy  Can you check the rest of the headings to make sure they are at the level you expect?