### PR TITLE
Fix password support for Modules

### DIFF
--- a/logstash-core/lib/logstash/modules/logstash_config.rb
+++ b/logstash-core/lib/logstash/modules/logstash_config.rb
@@ -69,7 +69,7 @@ module LogStash module Modules class LogStashConfig
     password = @settings["var.elasticsearch.password"]
     lines = ["hosts => #{hosts}", "index => \"#{index}\""]
     lines.push(user ? "user => \"#{user}\"" : nil)
-    lines.push(password ? "password => \"#{password}\"" : nil)
+    lines.push(password ? "password => \"#{password_value(password)}\"" : nil)
     lines.push(type_string ? "document_type => #{type_string}" : nil)
     lines.push("ssl => #{@settings.fetch('var.elasticsearch.ssl.enabled', false)}")
     if cacert = @settings["var.elasticsearch.ssl.certificate_authority"]
@@ -82,6 +82,10 @@ elasticsearch {
     manage_template => false
   }
 CONF
+  end
+
+  def password_value(password)
+    password.is_a?(LogStash::Util::Password) ? password.value : password
   end
 
   def config_string

--- a/logstash-core/lib/logstash/modules/logstash_config.rb
+++ b/logstash-core/lib/logstash/modules/logstash_config.rb
@@ -69,7 +69,7 @@ module LogStash module Modules class LogStashConfig
     password = @settings["var.elasticsearch.password"]
     lines = ["hosts => #{hosts}", "index => \"#{index}\""]
     lines.push(user ? "user => \"#{user}\"" : nil)
-    lines.push(password ? "password => \"#{password_value(password)}\"" : nil)
+    lines.push(password ? "password => \"#{password.value}\"" : nil)
     lines.push(type_string ? "document_type => #{type_string}" : nil)
     lines.push("ssl => #{@settings.fetch('var.elasticsearch.ssl.enabled', false)}")
     if cacert = @settings["var.elasticsearch.ssl.certificate_authority"]
@@ -82,10 +82,6 @@ elasticsearch {
     manage_template => false
   }
 CONF
-  end
-
-  def password_value(password)
-    password.is_a?(LogStash::Util::Password) ? password.value : password
   end
 
   def config_string

--- a/logstash-core/spec/logstash/modules/logstash_config_spec.rb
+++ b/logstash-core/spec/logstash/modules/logstash_config_spec.rb
@@ -3,7 +3,7 @@ require "logstash/modules/logstash_config"
 
 describe LogStash::Modules::LogStashConfig do
   let(:mod) { instance_double("module", :directory => Stud::Temporary.directory, :module_name => "testing") }
-  let(:settings) { {"var.logstash.testing.pants" => "fancy" }}
+  let(:settings) { {"var.logstash.testing.pants" => "fancy", "var.elasticsearch.password" => LogStash::Util::Password.new('correct_horse_battery_staple') }}
   subject { described_class.new(mod, settings) }
 
   describe "configured inputs" do
@@ -33,6 +33,12 @@ describe LogStash::Modules::LogStashConfig do
   describe "array to logstash array string" do
     it "return an escaped string" do
       expect(subject.array_to_string(["hello", "ninja"])).to eq("['hello', 'ninja']")
+    end
+  end
+
+  describe 'elastic_search_config' do
+    it 'should put the password in correctly' do
+      expect(subject.elasticsearch_output_config()).to include("password => \"correct_horse_battery_staple\"")
     end
   end
 

--- a/logstash-core/spec/logstash/modules/scaffold_spec.rb
+++ b/logstash-core/spec/logstash/modules/scaffold_spec.rb
@@ -81,7 +81,7 @@ ERB
 
     it "provides a logstash config" do
       expect(test_module.logstash_configuration).to be_nil
-      test_module.with_settings(module_settings)
+      test_module.with_settings(LogStash::Util::ModulesSettingArray.new([module_settings]).first)
       expect(test_module.logstash_configuration).not_to be_nil
       config_string = test_module.config_string
       expect(config_string).to include("port => 5606")


### PR DESCRIPTION
Module settings should use value field for setting password in
Elasticsearch output config, not the implicit, obfuscated to_s value.

Fixes #8224 