### PR TITLE
Java API: Allow ruby filters and outputs to appear as Java processors and outputs.

### DIFF
--- a/logstash-core/src/main/java/org/logstash/plugin/RubyOutput.java
+++ b/logstash-core/src/main/java/org/logstash/plugin/RubyOutput.java
@@ -1,0 +1,29 @@
+package org.logstash.plugin;
+
+import org.jruby.RubyArray;
+import org.jruby.RubyObject;
+import org.logstash.Event;
+import org.logstash.ext.JrubyEventExtLibrary;
+
+import java.util.Collection;
+
+public class RubyOutput implements Output {
+    private static final String MULTI_RECEIVE_METHOD = "multi_receive";
+    private RubyObject plugin;
+    private RubyArray events;
+    private Output handler;
+
+    public RubyOutput(RubyObject plugin) {
+        // XXX: assert that `plugin` is a subclass of LogStash::Filter::Base
+        this.plugin = plugin;
+        events = RubyArray.newArray(plugin.getRuntime());
+
+
+    }
+    @Override
+    public void process(Collection<Event> events) {
+        final RubyArray rubyEvents = RubyArray.newArray(plugin.getRuntime());
+        events.forEach(event -> rubyEvents.add(JrubyEventExtLibrary.RubyEvent.newRubyEvent(plugin.getRuntime(), event)));
+        plugin.callMethod(plugin.getRuntime().getCurrentContext(), MULTI_RECEIVE_METHOD, rubyEvents);
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/plugin/RubyProcessor.java
+++ b/logstash-core/src/main/java/org/logstash/plugin/RubyProcessor.java
@@ -1,0 +1,45 @@
+package org.logstash.plugin;
+
+import org.jruby.RubyArray;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.logstash.Event;
+import org.logstash.ext.JrubyEventExtLibrary.RubyEvent;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RubyProcessor implements Processor {
+    private static final Collection<Event> EMPTY_RESULT = Collections.emptyList();
+
+    private static final String MULTI_FILTER_METHOD = "multi_filter";
+    private IRubyObject plugin;
+    private Processor handler;
+
+    public RubyProcessor(IRubyObject plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public Collection<Event> process(Collection<Event> events) {
+        final RubyArray rubyEvents = RubyArray.newArray(plugin.getRuntime());
+        events.forEach(event -> rubyEvents.add(RubyEvent.newRubyEvent(plugin.getRuntime(), event)));
+
+        // filters/base.rb provides a basic multi_filter even if the actual plugin itself does not.
+        IRubyObject result = plugin.callMethod(plugin.getRuntime().getCurrentContext(), MULTI_FILTER_METHOD, rubyEvents);
+
+        if (result.isNil()) {
+            return EMPTY_RESULT;
+        }
+
+        // `result` must be a RubyArray containing RubyEvent's
+        if (result instanceof RubyArray) {
+            @SuppressWarnings("unchecked") // RubyArray is not generic, but satisfies `List`.
+            final List<RubyEvent> newRubyEvents = (RubyArray) result;
+            return newRubyEvents.stream().map(RubyEvent::getEvent).collect(Collectors.toList());
+        } else {
+            throw new IllegalArgumentException("Return value from a filter must be nil or an array of events, but got " + result.getClass().getCanonicalName());
+        }
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/plugin/RubyProcessorTest.java
+++ b/logstash-core/src/test/java/org/logstash/plugin/RubyProcessorTest.java
@@ -1,0 +1,85 @@
+package org.logstash.plugin;
+
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.RubyHash;
+import org.jruby.RubyModule;
+import org.jruby.embed.ScriptingContainer;
+import org.jruby.runtime.Block;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.logstash.Event;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RubyProcessorTest {
+    private ScriptingContainer container = new ScriptingContainer();
+    private Ruby ruby = container.getProvider().getRuntime();
+
+    static {
+        //setupRuby();
+    }
+
+    @Before
+    public void setup() throws IOException {
+        Path root = Paths.get("..").toRealPath();
+
+        // Setup the load path.
+        // XXX: I did this before with ScriptContainer.getLoadPath + setLoadPath but it wasn't working correctly...
+        // XXX: So I choose to modify $: instead.
+        Object loadPath = container.runScriptlet("$:");
+        container.callMethod(loadPath, "<<", root.resolve("lib").toString());
+        container.callMethod(loadPath, "<<", root.resolve("logstash-core/lib").toString());
+        container.callMethod(loadPath, "<<", root.resolve("logstash-core/src/test/resources/org/logstash/plugin/lib/").toString());
+
+        Map env = container.getEnvironment();
+        env.put("GEM_HOME", root.resolve("vendor/bundle/jruby/2.3.0").toString());
+        env.put("GEM_PATH", root.resolve("vendor/bundle/jruby/2.3.0").toString());
+        env.put("GEM_SPEC_CACHE", root.resolve("vendor/bundle/jruby/2.3.0/specifications").toString());
+        container.setEnvironment(env);
+
+        RubyModule kernel = ruby.getKernel();
+        container.callMethod(kernel, "require", "bootstrap/environment");
+        long n = System.nanoTime();
+        container.runScriptlet("LogStash::Bundler.setup!({:without => [:build, :development]})");
+        System.out.println("Bundler setup took: " + (System.nanoTime() - n) / 1000000 + "ms");
+        container.callMethod(kernel, "require", "logstash/plugin");
+    }
+
+    private IRubyObject plugin(String type, String name, Map<String, Object> config) {
+        RubyHash hash = new RubyHash(ruby);
+        if (config != null) {
+            hash.putAll(config);
+        }
+        RubyClass pluginClass = (RubyClass) container.runScriptlet("LogStash::Plugin.lookup('filter', 'test')");
+        IRubyObject plugin = pluginClass.newInstance(ruby.getCurrentContext(), hash, Block.NULL_BLOCK);
+        plugin.callMethod(ruby.getCurrentContext(), "register");
+
+        return plugin;
+    }
+
+    @Test
+    public void testRubyFilter() throws IOException {
+        IRubyObject plugin = plugin("filter", "test", null);
+
+        RubyProcessor processor = new RubyProcessor(plugin);
+
+        Collection<Event> events = Collections.singletonList(new Event());
+        Collection<Event> newEvents = processor.process(events);
+
+        for (Event event : events) {
+            assertEquals(1L, event.getField("test"));
+        }
+
+        assertTrue("The test filter should return null and not create any additional events", newEvents.isEmpty());
+    }
+}


### PR DESCRIPTION
This PR primarily exists as a demonstration.

My intent is to show that we could move to a pure-java execution and still support Ruby plugins.

Filters and outputs are supported. Inputs are not yet implemented, but it would be easy to do so.