### PR TITLE
MINOR: Clean up some dead code around PQ + PQ Benchmarks

### DIFF
--- a/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/EventSerializationBenchmark.java
+++ b/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/EventSerializationBenchmark.java
@@ -1,7 +1,6 @@
 package org.logstash.benchmark;
 
 import java.io.DataOutputStream;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -39,7 +38,7 @@ public class EventSerializationBenchmark {
     private static final Event EVENT = new Event();
 
     @Setup
-    public void setUp() throws IOException {
+    public void setUp() {
         EVENT.setField("Foo", "Bar");
         EVENT.setField("Foo1", "Bar1");
         EVENT.setField("Foo2", "Bar2");

--- a/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/EventSprintfBenchmark.java
+++ b/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/EventSprintfBenchmark.java
@@ -1,6 +1,5 @@
 package org.logstash.benchmark;
 
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import org.logstash.Event;
 import org.logstash.Timestamp;
@@ -34,7 +33,7 @@ public class EventSprintfBenchmark {
     private static final Event EVENT = new Event();
 
     @Setup
-    public void setUp() throws IOException {
+    public void setUp() {
         EVENT.setField("Foo", "Bar");
         EVENT.setField("Foo1", "Bar1");
         EVENT.setField("Foo2", "Bar2");

--- a/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/QueueRWBenchmark.java
+++ b/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/QueueRWBenchmark.java
@@ -66,7 +66,7 @@ public class QueueRWBenchmark {
     private ExecutorService exec;
 
     @Setup
-    public void setUp() throws IOException, CloneNotSupportedException {
+    public void setUp() throws IOException {
         final Settings settingsPersisted = settings(true);
         EVENT.setField("Foo", "Bar");
         EVENT.setField("Foo1", "Bar1");

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -740,7 +740,7 @@ public class Queue implements Closeable {
         }
     }
 
-    protected Page firstUnreadPage() throws IOException {
+    protected Page firstUnreadPage() {
         // look at head page if no unreadTailPages
         return (this.unreadTailPages.isEmpty()) ? (this.headPage.isFullyRead() ? null : this.headPage) : this.unreadTailPages.get(0);
     }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/QueueRuntimeException.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/QueueRuntimeException.java
@@ -2,28 +2,8 @@ package org.logstash.ackedqueue;
 
 public class QueueRuntimeException extends RuntimeException {
 
-    public static QueueRuntimeException newFormatMessage(String fmt, Object... args) {
-        return new QueueRuntimeException(
-                String.format(fmt, args)
-        );
-    }
-
-    public QueueRuntimeException() {
-    }
-
-    public QueueRuntimeException(String message) {
-        super(message);
-    }
-
     public QueueRuntimeException(String message, Throwable cause) {
         super(message, cause);
     }
 
-    public QueueRuntimeException(Throwable cause) {
-        super(cause);
-    }
-
-    public QueueRuntimeException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
-        super(message, cause, enableSuppression, writableStackTrace);
-    }
 }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/AbstractByteBufferPageIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/AbstractByteBufferPageIO.java
@@ -185,7 +185,7 @@ public abstract class AbstractByteBufferPageIO implements PageIO {
     }
 
     @Override
-    public void write(byte[] bytes, long seqNum) throws IOException {
+    public void write(byte[] bytes, long seqNum) {
         write(bytes, seqNum, bytes.length, checksum(bytes));
     }
 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/ByteBufferPageIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/ByteBufferPageIO.java
@@ -1,25 +1,24 @@
 package org.logstash.ackedqueue.io;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 
 public class ByteBufferPageIO extends AbstractByteBufferPageIO {
 
     private final ByteBuffer buffer;
 
-    public ByteBufferPageIO(int pageNum, int capacity, String path) throws IOException {
+    public ByteBufferPageIO(int pageNum, int capacity, String path) {
         this(capacity, new byte[0]);
     }
 
-    public ByteBufferPageIO(int capacity) throws IOException {
+    public ByteBufferPageIO(int capacity) {
         this(capacity, new byte[0]);
     }
 
-    public ByteBufferPageIO(int capacity, byte[] initialBytes) throws IOException {
+    public ByteBufferPageIO(int capacity, byte[] initialBytes) {
         super(0, capacity);
 
         if (initialBytes.length > capacity) {
-            throw new IOException("initial bytes greater than capacity");
+            throw new IllegalArgumentException("initial bytes greater than capacity");
         }
 
         this.buffer = ByteBuffer.allocate(capacity);

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/CheckpointIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/CheckpointIO.java
@@ -14,7 +14,7 @@ public interface CheckpointIO {
 
     void purge(String fileName) throws IOException;
 
-    void purge() throws IOException;
+    void purge();
 
     // @return the head page checkpoint file name
     String headFileName();

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/FileCheckpointIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/FileCheckpointIO.java
@@ -83,7 +83,7 @@ public class FileCheckpointIO implements CheckpointIO {
     }
 
     @Override
-    public void purge() throws IOException {
+    public void purge() {
         // TODO: dir traversal and delete all checkpoints?
         throw new UnsupportedOperationException("purge() is not supported");
     }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/MemoryCheckpointIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/MemoryCheckpointIO.java
@@ -37,14 +37,14 @@ public class MemoryCheckpointIO implements CheckpointIO {
     }
 
     @Override
-    public Checkpoint write(String fileName, int pageNum, int firstUnackedPageNum, long firstUnackedSeqNum, long minSeqNum, int elementCount) throws IOException {
+    public Checkpoint write(String fileName, int pageNum, int firstUnackedPageNum, long firstUnackedSeqNum, long minSeqNum, int elementCount) {
         Checkpoint checkpoint = new Checkpoint(pageNum, firstUnackedPageNum, firstUnackedSeqNum, minSeqNum, elementCount);
         write(fileName, checkpoint);
         return checkpoint;
     }
 
     @Override
-    public void write(String fileName, Checkpoint checkpoint) throws IOException {
+    public void write(String fileName, Checkpoint checkpoint) {
         Map<String, Checkpoint> ns = sources.get(dirPath);
         if (ns == null) {
             ns = new HashMap<>();

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/PageIOFactory.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/PageIOFactory.java
@@ -1,8 +1,6 @@
 package org.logstash.ackedqueue.io;
 
-import java.io.IOException;
-
 @FunctionalInterface
 public interface PageIOFactory {
-    PageIO build(int pageNum, int capacity, String dirPath) throws IOException;
+    PageIO build(int pageNum, int capacity, String dirPath);
 }

--- a/logstash-core/src/main/java/org/logstash/common/io/ByteBufferStreamInput.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/ByteBufferStreamInput.java
@@ -13,7 +13,7 @@ public class ByteBufferStreamInput extends StreamInput {
     }
 
     @Override
-    public int read() throws IOException {
+    public int read() {
         if (!buffer.hasRemaining()) {
             return -1;
         }
@@ -29,7 +29,7 @@ public class ByteBufferStreamInput extends StreamInput {
     }
 
     @Override
-    public int read(byte[] b, int off, int len) throws IOException {
+    public int read(byte[] b, int off, int len) {
         if (!buffer.hasRemaining()) {
             return -1;
         }
@@ -59,7 +59,7 @@ public class ByteBufferStreamInput extends StreamInput {
     }
 
     @Override
-    public void reset() throws IOException {
+    public void reset() {
         buffer.reset();
     }
 
@@ -68,7 +68,7 @@ public class ByteBufferStreamInput extends StreamInput {
     }
 
     @Override
-    public int available() throws IOException {
+    public int available() {
         return buffer.remaining();
     }
 
@@ -83,7 +83,7 @@ public class ByteBufferStreamInput extends StreamInput {
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
     }
 }
 

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/io/ByteBufferPageIOTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/io/ByteBufferPageIOTest.java
@@ -51,7 +51,7 @@ public class ByteBufferPageIOTest {
         return io;
     }
 
-    private static ByteBufferPageIO newPageIO(int capacity, byte[] bytes) throws IOException {
+    private static ByteBufferPageIO newPageIO(int capacity, byte[] bytes) {
         return new ByteBufferPageIO(capacity, bytes);
     }
 


### PR DESCRIPTION
Just some randomness I found researching the deadlock issue. Trivial stuff that is just shown to be right by still compiling.

Except for maybe adjusting the Exception in `org.logstash.ackedqueue.io.ByteBufferPageIO#ByteBufferPageIO(int, byte[])`:
* `IOException` is just wrong here, the arguments we get are not the result of any IO operation, in fact in production `initalbytes` is always `byte[0]` anyway => it's an `IllegalArgumentException` and we can save ourselves the upstream `IOException` handling :)
