### PR TITLE
bubble up java stack trace from wrapped exception

### DIFF
--- a/logstash-core/src/main/java/org/logstash/RubyUtil.java
+++ b/logstash-core/src/main/java/org/logstash/RubyUtil.java
@@ -1,6 +1,8 @@
 package org.logstash;
 
+import org.jruby.NativeException;
 import org.jruby.Ruby;
+import org.jruby.exceptions.RaiseException;
 
 /**
  * Utilities around interaction with the {@link Ruby} runtime.
@@ -29,5 +31,17 @@ public final class RubyUtil {
         final Ruby ruby = Ruby.getGlobalRuntime();
         ruby.getOrCreateModule(LS_MODULE_NAME);
         return ruby;
+    }
+
+    /**
+     * Wraps a Java exception in a JRuby IOError NativeException.
+     * This preserves the Java stacktrace and bubble up as a Ruby IOError
+     * @param runtime the Ruby runtime context
+     * @param e the Java exception to wrap
+     * @return RaiseException the wrapped IOError
+     */
+    public static RaiseException newRubyIOError(Ruby runtime, Throwable e) {
+        // will preserve Java stacktrace & bubble up as a Ruby IOError
+        return new RaiseException(e, new NativeException(runtime, runtime.getIOError(), e));
     }
 }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedBatchExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedBatchExtLibrary.java
@@ -17,7 +17,6 @@ import org.logstash.ackedqueue.Batch;
 import org.logstash.Event;
 import org.logstash.ackedqueue.Queueable;
 import org.logstash.ext.JrubyEventExtLibrary;
-
 import java.io.IOException;
 
 public final class JrubyAckedBatchExtLibrary implements Library {
@@ -84,7 +83,7 @@ public final class JrubyAckedBatchExtLibrary implements Library {
             try {
                 this.batch.close();
             } catch (IOException e) {
-                throw context.runtime.newIOErrorFromException(e);
+                throw RubyUtil.newRubyIOError(context.runtime, e);
             }
 
             return context.nil;

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java
@@ -128,7 +128,7 @@ public final class JrubyAckedQueueExtLibrary implements Library {
             try {
                 this.queue.open();
             } catch (IOException e) {
-                throw context.runtime.newIOErrorFromException(e);
+                throw RubyUtil.newRubyIOError(context.runtime, e);
             }
 
             return context.nil;
@@ -145,7 +145,7 @@ public final class JrubyAckedQueueExtLibrary implements Library {
             try {
                 seqNum = this.queue.write(((JrubyEventExtLibrary.RubyEvent) event).getEvent());
             } catch (IOException e) {
-                throw context.runtime.newIOErrorFromException(e);
+                throw RubyUtil.newRubyIOError(context.runtime, e);
             }
 
             return context.runtime.newFixnum(seqNum);
@@ -159,7 +159,7 @@ public final class JrubyAckedQueueExtLibrary implements Library {
             try {
                 b = this.queue.readBatch(RubyFixnum.num2int(limit), RubyFixnum.num2int(timeout));
             } catch (IOException e) {
-                throw context.runtime.newIOErrorFromException(e);
+                throw RubyUtil.newRubyIOError(context.runtime, e);
             }
 
             // TODO: return proper Batch object
@@ -184,7 +184,7 @@ public final class JrubyAckedQueueExtLibrary implements Library {
             try {
                 this.queue.close();
             } catch (IOException e) {
-                throw context.runtime.newIOErrorFromException(e);
+                throw RubyUtil.newRubyIOError(context.runtime, e);
             }
 
             return context.nil;

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueMemoryExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueMemoryExtLibrary.java
@@ -126,7 +126,7 @@ public final class JrubyAckedQueueMemoryExtLibrary implements Library {
                 this.queue.getCheckpointIO().purge();
                 this.queue.open();
             } catch (IOException e) {
-                throw context.runtime.newIOErrorFromException(e);
+                throw RubyUtil.newRubyIOError(context.runtime, e);
             }
 
             return context.nil;
@@ -143,7 +143,7 @@ public final class JrubyAckedQueueMemoryExtLibrary implements Library {
             try {
                 seqNum = this.queue.write(((JrubyEventExtLibrary.RubyEvent) event).getEvent());
             } catch (IOException e) {
-                throw context.runtime.newIOErrorFromException(e);
+                throw RubyUtil.newRubyIOError(context.runtime, e);
             }
 
             return context.runtime.newFixnum(seqNum);
@@ -157,7 +157,7 @@ public final class JrubyAckedQueueMemoryExtLibrary implements Library {
             try {
                 b = this.queue.readBatch(RubyFixnum.num2int(limit), RubyFixnum.num2int(timeout));
             } catch (IOException e) {
-                throw context.runtime.newIOErrorFromException(e);
+                throw RubyUtil.newRubyIOError(context.runtime, e);
             }
 
             // TODO: return proper Batch object
@@ -182,7 +182,7 @@ public final class JrubyAckedQueueMemoryExtLibrary implements Library {
             try {
                 this.queue.close();
             } catch (IOException e) {
-                throw context.runtime.newIOErrorFromException(e);
+                throw RubyUtil.newRubyIOError(context.runtime, e);
             }
 
             return context.nil;


### PR DESCRIPTION
solves #7759 

This PR correctly provides the Java stack trace in the rethrown Ruby exception.

For example, this is an example of the stack trace we were getting for a Java exception within the Queue open method, note that the stack trace stopped at Queue open Ruby method from the JRuby extension wrapper:

```
Logstash failed to create queue {:pipeline_id=>"main", "exception"=>"Checkpoint checksum mismatch, expected: 1228426236, actual: 1228426236", "backtrace"=>["org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java:145:in `open'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/util/wrapped_acked_queue.rb:41:in `with_queue'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/util/wrapped_acked_queue.rb:30:in `create_file_based'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/queue_factory.rb:29:in `create'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/pipeline.rb:218:in `initialize'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/pipeline_action/create.rb:35:in `execute'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:335:in `block in converge_state'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:141:in `with_pipelines'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:332:in `block in converge_state'", "org/jruby/RubyArray.java:1734:in `each'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:319:in `converge_state'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:166:in `block in converge_state_and_update'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:141:in `with_pipelines'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:164:in `converge_state_and_update'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:90:in `execute'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/runner.rb:359:in `block in execute'", "/Users/colin/dev/src/elasticsearch/logstash/vendor/bundle/jruby/2.3.0/gems/stud-0.0.23/lib/stud/task.rb:24:in `block in initialize'"]}
```

Now this is the same exception with the deeper Java stack trace:
```
Logstash failed to create queue {:pipeline_id=>"main", "exception"=>"java.io.IOException: Checkpoint checksum mismatch, expected: 1228426236, actual: 1228426236", "backtrace"=>["org/logstash/ackedqueue/io/FileCheckpointIO.java:115:in `read'", "org/logstash/ackedqueue/io/FileCheckpointIO.java:53:in `read'", "org/logstash/ackedqueue/Queue.java:175:in `open'", "org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java:139:in `open'", "org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary$RubyAckedQueue$INVOKER$i$0$0$ruby_open.gen:-1:in `call'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/util/wrapped_acked_queue.rb:41:in `with_queue'", "Users/colin/dev/src/elasticsearch/logstash/logstash_minus_core/lib/logstash/util//Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/util/wrapped_acked_queue.rb:-1:in `RUBY$method$with_queue$0$__VARARGS__'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/util/wrapped_acked_queue.rb:30:in `create_file_based'", "Users/colin/dev/src/elasticsearch/logstash/logstash_minus_core/lib/logstash/util//Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/util/wrapped_acked_queue.rb:-1:in `RUBY$method$create_file_based$0$__VARARGS__'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/queue_factory.rb:29:in `create'", "Users/colin/dev/src/elasticsearch/logstash/logstash_minus_core/lib/logstash//Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/queue_factory.rb:-1:in `RUBY$method$create$0$__VARARGS__'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/pipeline.rb:218:in `initialize'", "org/jruby/RubyClass.java:1022:in `newInstance'", "org/jruby/RubyClass$INVOKER$i$newInstance.gen:-1:in `call'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/pipeline_action/create.rb:35:in `execute'", "Users/colin/dev/src/elasticsearch/logstash/logstash_minus_core/lib/logstash/pipeline_action//Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/pipeline_action/create.rb:-1:in `RUBY$method$execute$0$__VARARGS__'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:335:in `block in converge_state'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:141:in `with_pipelines'", "Users/colin/dev/src/elasticsearch/logstash/logstash_minus_core/lib/logstash//Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:-1:in `RUBY$method$with_pipelines$0$__VARARGS__'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:332:in `block in converge_state'", "org/jruby/RubyArray.java:1734:in `each'", "org/jruby/RubyArray$INVOKER$i$0$0$each.gen:-1:in `call'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:319:in `converge_state'", "Users/colin/dev/src/elasticsearch/logstash/logstash_minus_core/lib/logstash//Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:-1:in `RUBY$method$converge_state$0$__VARARGS__'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:166:in `block in converge_state_and_update'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:141:in `with_pipelines'", "Users/colin/dev/src/elasticsearch/logstash/logstash_minus_core/lib/logstash//Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:-1:in `RUBY$method$with_pipelines$0$__VARARGS__'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:164:in `converge_state_and_update'", "Users/colin/dev/src/elasticsearch/logstash/logstash_minus_core/lib/logstash//Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:-1:in `RUBY$method$converge_state_and_update$0$__VARARGS__'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:90:in `execute'", "Users/colin/dev/src/elasticsearch/logstash/logstash_minus_core/lib/logstash//Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/agent.rb:-1:in `RUBY$method$execute$0$__VARARGS__'", "/Users/colin/dev/src/elasticsearch/logstash/logstash-core/lib/logstash/runner.rb:359:in `block in execute'", "org/jruby/RubyProc.java:289:in `call'", "org/jruby/RubyProc.java:273:in `call19'", "org/jruby/RubyProc$INVOKER$i$0$0$call19.gen:-1:in `call'", "/Users/colin/dev/src/elasticsearch/logstash/vendor/bundle/jruby/2.3.0/gems/stud-0.0.23/lib/stud/task.rb:24:in `block in initialize'", "org/jruby/RubyProc.java:289:in `call'", "org/jruby/RubyProc.java:246:in `call'", "java/lang/Thread.java:748:in `run'"]}
```
