### PR TITLE
Remove CHANGELOG.md from list of packaged files

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -8,7 +8,6 @@ namespace "artifact" do
   def package_files
     [
       "LICENSE",
-      "CHANGELOG.md",
       "NOTICE.TXT",
       "CONTRIBUTORS",
       "bin/**/*",


### PR DESCRIPTION
CHANGELOG.md has been removed, so it should no longer be packaged

Fixes #8255