### PR TITLE
Fix double password wrap

### DIFF
--- a/logstash-core/lib/logstash/util/modules_setting_array.rb
+++ b/logstash-core/lib/logstash/util/modules_setting_array.rb
@@ -16,7 +16,7 @@ module LogStash module Util class ModulesSettingArray
     @original = value
     # wrap passwords
     @original.each do |hash|
-      hash.keys.select{|key| key.to_s.end_with?('password')}.each do |key|
+      hash.keys.select{|key| key.to_s.end_with?('password') && !hash[key].is_a?(LogStash::Util::Password)}.each do |key|
         hash[key] = LogStash::Util::Password.new(hash[key])
       end
     end

--- a/logstash-core/spec/logstash/settings/modules_spec.rb
+++ b/logstash-core/spec/logstash/settings/modules_spec.rb
@@ -9,12 +9,23 @@ describe LogStash::Setting::Modules do
   describe "Modules.Cli" do
     subject { described_class.new("mycloudid", LogStash::Util::ModulesSettingArray, []) }
     context "when given an array of hashes that contains a password key" do
+      let(:secret) { 'some_secret'}
       it "should convert password Strings to Password" do
-        source = [{"var.kibana.password" => "some_secret"}]
+        source = [{"var.kibana.password" => secret}]
         setting = subject.set(source)
         expect(setting).to be_a(Array)
         expect(setting.__class__).to eq(LogStash::Util::ModulesSettingArray)
         expect(setting.first.fetch("var.kibana.password")).to be_a(LogStash::Util::Password)
+        expect(setting.first.fetch("var.kibana.password").value).to eq(secret)
+      end
+
+      it 'should not wrap values that are already passwords' do
+        source = [{"var.kibana.password" => LogStash::Util::Password.new(secret)}]
+        setting = subject.set(source)
+        expect(setting).to be_a(Array)
+        expect(setting.__class__).to eq(LogStash::Util::ModulesSettingArray)
+        expect(setting.first.fetch("var.kibana.password")).to be_a(LogStash::Util::Password)
+        expect(setting.first.fetch("var.kibana.password").value).to eq(secret)
       end
     end
   end


### PR DESCRIPTION
Password settings for Modules supplied via a yml file were being wrapped inside a
LogStash::Utils::Password object twice during startup - once in from_yaml, and once
in validate. Disallow this from happening by skipping the wrap if the password is
already wrapped

This should complete the fix for #8224