### PR TITLE
Fix Modules doc incorrectly doc referring to Kibana

### DIFF
--- a/docs/static/shared-module-options.asciidoc
+++ b/docs/static/shared-module-options.asciidoc
@@ -70,7 +70,7 @@ concerns.
 --
 +
 The path to an X.509 certificate to use to validate SSL certificates when
-communicating with Kibana.
+communicating with Elasticsearch.
 
 *`var.elasticsearch.ssl.certificate`*::
 +


### PR DESCRIPTION
var.elasticsearch.ssl.certificate_authority should not refer to Kibana in the
description of the value.