### PR TITLE
 #8271 fix one excess '/' added to log config file uri on *nix in runner.rb

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -251,7 +251,8 @@ class LogStash::Runner < Clamp::StrictCommand
       log4j_config_location = ::File.join(setting("path.settings"), "log4j2.properties")
 
       # Windows safe way to produce a file: URI.
-      LogStash::Logging::Logger::reconfigure(URI.join("file:///" + File.absolute_path(log4j_config_location)).to_s)
+      file_schema = "file://" + (LogStash::Environment.windows? ? "/" : "")
+      LogStash::Logging::Logger::reconfigure(URI.join(file_schema + File.absolute_path(log4j_config_location)).to_s)
     end
     # override log level that may have been introduced from a custom log4j config file
     LogStash::Logging::Logger::configure_logging(setting("log.level"))


### PR DESCRIPTION
Fixes #8271 

On Windows, we have `file:///c:/WINDOWS/file.txt` and absolute file seems to return `c:/...`, but on *nix we were adding four `////` since absolute file already brought its own leading `/` :)
