### PR TITLE
Remove uneeded task to install all the possible plugins from the logstash-plugin organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,9 @@ To run the tests of all currently installed plugins:
 
     rake test:plugin
 
-You can install the default set of plugins included in the logstash package or all plugins:
+You can install the default set of plugins included in the logstash package:
 
     rake test:install-default
-    rake test:install-all
 
 ---
 Note that if a plugin is installed using the plugin manager `bin/logstash-plugin install ...` do not forget to also install the plugins development dependencies using the following command after the plugin installation:

--- a/ci/ci_test.bat
+++ b/ci/ci_test.bat
@@ -29,13 +29,7 @@ IF "%SELECTEDTESTSUITE%"=="core-fail-fast" (
   %RAKEPATH% test:install-core
   %RAKEPATH% test:core-fail-fast
 ) ELSE (
-  IF "%SELECTEDTESTSUITE%"=="all" (
-    echo "Running all plugins tests"
-    %RAKEPATH% test:install-all
-    %RAKEPATH% test:plugins
-  ) ELSE (
-    echo "Running core tests"
-    %RAKEPATH% test:install-core
-    %RAKEPATH% test:core
-  )
+  echo "Running core tests"
+  %RAKEPATH% test:install-core
+  %RAKEPATH% test:core
 )

--- a/ci/ci_test.sh
+++ b/ci/ci_test.sh
@@ -17,10 +17,6 @@ if [[ $SELECTED_TEST_SUITE == $"core-fail-fast" ]]; then
   echo "Running core-fail-fast tests"
   rake test:install-core    # Install core dependencies for testing.
   rake test:core-fail-fast  # Run core tests
-elif [[ $SELECTED_TEST_SUITE == $"all" ]]; then
-  echo "Running all plugins tests"
-  rake test:install-all     # Install all plugins in this logstash instance, including development dependencies
-  rake test:plugins         # Run all plugins tests
 else
   echo "Running core tests"
   rake test:install-core    # Install core dependencies for testing.

--- a/ci/unit_tests.bat
+++ b/ci/unit_tests.bat
@@ -29,13 +29,7 @@ IF "%SELECTEDTESTSUITE%"=="core-fail-fast" (
   %RAKEPATH% test:install-core
   %RAKEPATH% test:core-fail-fast
 ) ELSE (
-  IF "%SELECTEDTESTSUITE%"=="all" (
-    echo "Running all plugins tests"
-    %RAKEPATH% test:install-all
-    %RAKEPATH% test:plugins
-  ) ELSE (
-    echo "Running core tests"
-    %RAKEPATH% test:install-core
-    %RAKEPATH% test:core
-  )
+  echo "Running core tests"
+  %RAKEPATH% test:install-core
+  %RAKEPATH% test:core
 )

--- a/ci/unit_tests.sh
+++ b/ci/unit_tests.sh
@@ -17,12 +17,6 @@ if [[ $SELECTED_TEST_SUITE == $"core-fail-fast" ]]; then
   rake test:install-core
   echo "Running test:core-fail-fast"
   rake test:core-fail-fast
-elif [[ $SELECTED_TEST_SUITE == $"all" ]]; then
-  echo "Running all plugins tests"
-  echo "Running test:install-all"  # Install all plugins in this logstash instance, including development dependencies
-  rake test:install-all
-  echo "Running test:plugins"    # Run all plugins tests
-  rake test:plugins
 elif [[ $SELECTED_TEST_SUITE == $"java" ]]; then
   echo "Running Java unit tests"
   echo "Running test:core-java"

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -197,12 +197,6 @@ namespace "artifact" do
     end
   end
 
-  task "prepare-all" do
-    if ENV['SKIP_PREPARE'] != "1"
-      ["bootstrap", "plugin:install-all", "artifact:clean-bundle-config"].each {|task| Rake::Task[task].invoke }
-    end
-  end
-
   def build_tar(tar_suffix = nil)
     require "zlib"
     require "archive/tar/minitar"

--- a/rakelib/docs.rake
+++ b/rakelib/docs.rake
@@ -6,7 +6,6 @@ DEFAULT_DOC_DIRECTORY = ::File.join(::File.dirname(__FILE__), "..", "build", "do
 namespace "docs" do
   desc "Generate documentation for all plugins"
   task "generate" do
-    Rake::Task['plugin:install-all'].invoke
     Rake::Task['docs:generate-plugins'].invoke
   end
 

--- a/rakelib/package.rake
+++ b/rakelib/package.rake
@@ -7,7 +7,4 @@ namespace "package" do
 
   desc "Build a package with the default plugins, including dependencies, to be installed offline"
   task "plugins-default" => ["test:install-default", "bundle"]
-
-  desc "Build a package with all the plugins, including dependencies, to be installed offline"
-  task "plugins-all" => ["test:install-all", "bundle"]
 end

--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -44,13 +44,6 @@ namespace "plugin" do
     task.reenable # Allow this task to be run again
   end
 
-  task "install-vendor" => "bootstrap" do
-    puts("[plugin:install-jar-dependencies] Installing vendor plugins for testing")
-    install_plugins("--no-verify", "--preserve", *LogStash::RakeLib::TEST_VENDOR_PLUGINS)
-
-    task.reenable # Allow this task to be run again
-  end
-
   task "clean-local-core-gem", [:name, :path] do |task, args|
     name = args[:name]
     path = args[:path]

--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -51,24 +51,6 @@ namespace "plugin" do
     task.reenable # Allow this task to be run again
   end
 
-  task "install-all" => "bootstrap" do
-    puts("[plugin:install-all] Installing all plugins from https://github.com/logstash-plugins")
-    p = *LogStash::RakeLib.fetch_all_plugins
-    # Install plugin one by one, ignoring plugins that have issues. Otherwise, one bad plugin will
-    # blow up the entire install process.
-    # TODO Push this downstream to #install_plugins
-    p.each do |plugin|
-      begin
-        install_plugins("--no-verify", "--preserve", plugin)
-      rescue
-        puts "Unable to install #{plugin}. Skipping"
-        next
-      end
-    end
-
-    task.reenable # Allow this task to be run again
-  end
-
   task "clean-local-core-gem", [:name, :path] do |task, args|
     name = args[:name]
     path = args[:path]

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -62,8 +62,6 @@ namespace "test" do
 
   task "install-default" => ["bootstrap", "plugin:install-default", "plugin:install-development-dependencies"]
 
-  task "install-all" => ["bootstrap", "plugin:install-all", "plugin:install-development-dependencies"]
-
   task "install-vendor-plugins" => ["bootstrap", "plugin:install-vendor", "plugin:install-development-dependencies"]
 
   task "install-jar-dependencies-plugins" => ["bootstrap", "plugin:install-jar-dependencies", "plugin:install-development-dependencies"]


### PR DESCRIPTION
This command was error prone, some plugins on the logstash-plugin organization are currently broken and cannot be installed and we stopped making the uber logstash zip.