### PR TITLE
 #4640 make Event#clone clone metadata as well

### DIFF
--- a/logstash-core/spec/logstash/event_spec.rb
+++ b/logstash-core/spec/logstash/event_spec.rb
@@ -352,4 +352,61 @@ describe LogStash::Event do
       expect { subject.baz() }.to raise_error(NoMethodError, /undefined method `baz' for/)
     end
   end
+
+  describe "#clone" do
+    let(:fieldref) { "[@metadata][fancy]" }
+    let(:event1) { LogStash::Event.new("hello" => "world", "@metadata" => { "fancy" => "pants" }) }
+    let(:event2) { LogStash::Event.new("hello" => "world", "@metadata" => { "fancy" => {"fancy2" => "pants2"} }) }
+    let(:event3) { LogStash::Event.new("hello" => "world", "@metadata" => { "fancy" => {"fancy2" => {"fancy3" => "pants2"}} }) }
+    let(:event4) { LogStash::Event.new("hello" => "world", "@metadata" => { "fancy" => {"fancy2" => ["pants1", "pants2"]} }) }
+    let(:event5) { LogStash::Event.new("hello" => "world", "@metadata" => { "fancy" => "pants", "smarty" => "pants2" }) }
+
+    it "should clone metadata fields" do
+      cloned = event1.clone
+      expect(cloned.get(fieldref)).to eq("pants")
+      expect(cloned.to_hash_with_metadata).to include("@metadata")
+    end
+
+    it "should clone metadata fields with nested json" do
+      cloned = event2.clone
+      expect(cloned.get(fieldref)).to eq({"fancy2" => "pants2"})
+      expect(cloned.get("hello")).to eq("world")
+      expect(cloned.to_hash).not_to include("@metadata")
+      expect(cloned.to_hash_with_metadata).to include("@metadata")
+    end
+
+    it "should clone metadata fields with 2-level nested json" do
+      cloned = event3.clone
+      expect(cloned.get(fieldref)).to eq({"fancy2" => {"fancy3" => "pants2"}})
+      expect(cloned.to_hash).not_to include("@metadata")
+      expect(cloned.to_hash_with_metadata).to include("@metadata")
+    end
+
+    it "should clone metadata fields with nested json and array value" do
+      cloned = event4.clone
+      expect(cloned.get(fieldref)).to eq({"fancy2" => ["pants1", "pants2"]})
+      expect(cloned.to_hash_with_metadata).to include("@metadata")
+    end
+
+    it "should clone metadata fields with multiple keys" do
+      cloned = event5.clone
+      expect(cloned.get(fieldref)).to eq("pants")
+      expect(cloned.get("[@metadata][smarty]")).to eq("pants2")
+      expect(cloned.to_hash_with_metadata).to include("@metadata")
+    end
+
+    it "mutating cloned event should not affect the original event" do
+      cloned = event1.clone
+      cloned.set("hello", "foobar")
+      expect(cloned.get("hello")).to eq("foobar")
+      expect(event1.get("hello")).to eq("world")
+    end
+
+    it "mutating cloned event's metadata should not affect the original event metadata" do
+      cloned = event1.clone
+      cloned.set("[@metadata][fancy]", "foobar")
+      expect(cloned.get("[@metadata][fancy]")).to eq("foobar")
+      expect(event1.get("[@metadata][fancy]")).to eq("pants")
+    end
+  end
 end

--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -263,7 +263,10 @@ public final class Event implements Cloneable, Queueable {
 
     @Override
     public Event clone() {
-        return new Event(Cloner.<Map<String, Object>>deep(this.data));
+        final ConvertedMap map =
+            ConvertedMap.newFromMap(Cloner.<Map<String, Object>>deep(data));
+        map.putInterned(METADATA, Cloner.<Map<String, Object>>deep(metadata));
+        return new Event(map);
     }
 
     public String toString() {


### PR DESCRIPTION
Fixes #4640 

* Add cloned metadata to cloned data map
* Copy (and slightly adjust for 5.x) tests from https://github.com/elastic/logstash/pull/5656/files#diff-42cd4d2f6f981839921777c8e4a5ba2bR662 