### PR TITLE
Remove unecessary dependency `file-dependencies`

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -7,7 +7,6 @@ gem "logstash-core-plugin-api", :path => "./logstash-core-plugin-api"
 gem "paquet", "~> 0.2.0"
 gem "ruby-progressbar", "~> 1.8.1"
 gem "builder", "~> 3.2.2"
-gem "file-dependencies", "0.1.6"
 gem "ci_reporter_rspec", "1.0.0", :group => :development
 gem "simplecov", :group => :development
 gem "tins", "1.6", :group => :development

--- a/lib/pluginmanager/install.rb
+++ b/lib/pluginmanager/install.rb
@@ -5,7 +5,6 @@ require "pluginmanager/ui"
 require "pluginmanager/errors"
 require "jar-dependencies"
 require "jar_install_post_install_hook"
-require "file-dependencies/gem"
 require "fileutils"
 
 class LogStash::PluginManager::Install < LogStash::PluginManager::Command

--- a/lib/pluginmanager/update.rb
+++ b/lib/pluginmanager/update.rb
@@ -2,7 +2,6 @@
 require "pluginmanager/command"
 require "jar-dependencies"
 require "jar_install_post_install_hook"
-require "file-dependencies/gem"
 
 class LogStash::PluginManager::Update < LogStash::PluginManager::Command
   REJECTED_OPTIONS = [:path, :git, :github]


### PR DESCRIPTION
To understand why we can now remove this gem we have to go back at the
history of LS 1.5 and the choice we made back them. In the begining
plugins depending on external files like the `user-agent` or the `filter-geoip`
were not bundling theses files in the gem.

The `file-dependencies` was providing a new hook when plugins were
installed to trigger the file download.

In the context of making the plugins work in an offline environment we
need to make sure that every plugins external resources are present in
the gem.

We have currently a few plugins that require external files and they all
bundle it. So I think its safe to remove that feature, also *the hook was
not triggered correctly. So it was a NOOP.*