### PR TITLE
#8299 Adjust IT environment to be in line with master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 sudo: required
-services:
-  - docker
 language: ruby
 cache:
   directories:
@@ -16,9 +14,6 @@ env:
   - INTEGRATION=false FEATURE_FLAG=persistent_queues SPEC_OPTS="--order rand --format documentation" JRUBY_OPTS='-Xcompile.invokedynamic=false'
   - INTEGRATION=true FEATURE_FLAG=persistent_queues SPEC_OPTS="--order rand --format documentation" JRUBY_OPTS='-Xcompile.invokedynamic=false'
 before_install:
-  - sudo apt-get update && sudo apt-get install -y docker-ce
-  - sudo service docker stop
-  - sudo dockerd --disable-legacy-registry &>/dev/null &
   - export JRUBY_OPTS=""
   # Force bundler 1.12.5 because version 1.13 has issues, see https://github.com/fastlane/fastlane/issues/6065#issuecomment-246044617
   - yes | gem uninstall -q -i /home/travis/.rvm/gems/jruby-9.1.10.0@global bundler

--- a/Gemfile.jruby-2.3.lock.release
+++ b/Gemfile.jruby-2.3.lock.release
@@ -523,7 +523,6 @@ GEM
     ruby-maven (3.3.12)
       ruby-maven-libs (~> 3.3.9)
     ruby-maven-libs (3.3.9)
-    ruby-progressbar (1.8.1)
     rubyzip (1.2.1)
     rufus-scheduler (3.0.9)
       tzinfo
@@ -684,7 +683,7 @@ DEPENDENCIES
   pleaserun (~> 0.0.28)
   rack-test
   rspec (~> 3.5)
-  ruby-progressbar (~> 1.8.1)
+  ruby-progressbar (~> 1.8.3)
   rubyzip (~> 1.2.1)
   simplecov
   stud (~> 0.0.22)

--- a/qa/integration/services/service.rb
+++ b/qa/integration/services/service.rb
@@ -1,3 +1,5 @@
+require_relative '../../../logstash-core/lib/logstash-core.rb'
+
 # Base class for a service like Kafka, ES, Logstash
 class Service
 

--- a/qa/integration/specs/cli/prepare_offline_pack_spec.rb
+++ b/qa/integration/specs/cli/prepare_offline_pack_spec.rb
@@ -47,7 +47,7 @@ describe "CLI > logstash-plugin prepare-offline-pack" do
 
       unpacked = unpack(temporary_zip_file)
 
-      filters = @logstash_plugin.list(plugins_to_pack.first).stderr_and_stdout.split("\n").delete_if { |f| f =~ /cext/ }
+      filters = @logstash_plugin.list(plugins_to_pack.first).stderr_and_stdout.split("\n").delete_if { |f| f =~ /cext/ || f =~ /JAVA_OPT/ }
 
       expect(unpacked.plugins.collect(&:name)).to include(*filters)
       expect(unpacked.plugins.size).to eq(filters.size)


### PR DESCRIPTION
Fixes #8299 by:

* Adjusting IT environment to be 100% equal to `master`
* Adjust conflicting GEM version for Ruby progress-bar
   * Urgh I hate this one since it's just a random consequence of how bundler works (pulls 1.8.3 now as a default instead of 1.8.1 => if you later also pull something that uses 1.8.3 it works, obviously still would break if you had something else on the path that uses 1.8.1, but looks like we don't ), but it was the only way to comply with the `1.8.3` requirement by one of the plugins pull in the install spec