### PR TITLE
 #8293 fix concurrent access to PQ persisted bytesize throwing

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -139,14 +139,19 @@ public class Queue implements Closeable {
     }
 
     public long getPersistedByteSize() {
-        final long size;
-        if (headPage == null) {
-            size = 0L;
-        } else {
-            size = headPage.getPageIO().getHead()
-                + tailPages.stream().mapToLong(p -> p.getPageIO().getHead()).sum();
+        lock.lock();
+        try {
+            final long size;
+            if (headPage == null) {
+                size = 0L;
+            } else {
+                size = headPage.getPageIO().getHead()
+                    + tailPages.stream().mapToLong(p -> p.getPageIO().getHead()).sum();
+            }
+            return size;
+        } finally {
+            lock.unlock();
         }
-        return size;
     }
 
     public int getPageCapacity() {


### PR DESCRIPTION
See error reported in #8293, obviously looping over the tail pages will throw on concurrent modification of the underlying `ArrayList`.
Unfortunately, the stack trace of that error doesn't get forwarded to Ruby and also seems to prevent the mutex covering the PQ data poll on the Ruby side from unlocking (that's a different issue imo, no clue why this is happening). 
=> Either way, fixed by locking that operation in PQ and preventing concurrent modification exceptions.

* I'm aware that this needs a stronger fix, in the long run, it's not ok having to lock the pipeline for this, but for the current implementation, I see no other fix that doesn't add the same degree of locking.