### PR TITLE
Add commercially supported plugins to be default

### DIFF
--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -747,5 +747,61 @@
 		"test-jar-dependencies": false,
 		"test-vendor-plugins": false,
 		"skip-list": true
+	},
+	"logstash-filter-aggregate": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-anonymize": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-de_dot": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-elasticsearch": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-jdbc_streaming": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-filter-truncate": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-email": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
+	},
+	"logstash-output-lumberjack": {
+		"default-plugins": true,
+		"core-specs": false,
+		"test-jar-dependencies": false,
+		"test-vendor-plugins": false,
+		"skip-list": false
 	}
 }


### PR DESCRIPTION
Our intent is to ship all commercially supported[1] plugins with
Logstash. By some mistakes, we have omitted a few plugins, and this
commit resolves those omissions.

Fixes #8287