### PR TITLE
Test fix: ensure 'fatal: Not a git repository' is not picked up as expectation for integration test

### DIFF
--- a/qa/integration/specs/cli/prepare_offline_pack_spec.rb
+++ b/qa/integration/specs/cli/prepare_offline_pack_spec.rb
@@ -47,7 +47,7 @@ describe "CLI > logstash-plugin prepare-offline-pack" do
 
       unpacked = unpack(temporary_zip_file)
 
-      filters = @logstash_plugin.list(plugins_to_pack.first).stderr_and_stdout.split("\n").delete_if { |f| f =~ /cext/ || f =~ /JAVA_OPT/ }
+      filters = @logstash_plugin.list(plugins_to_pack.first).stderr_and_stdout.split("\n").delete_if { |f| f =~ /cext/ || f =~ /JAVA_OPT/  || f =~ /fatal/}
 
       expect(unpacked.plugins.collect(&:name)).to include(*filters)
       expect(unpacked.plugins.size).to eq(filters.size)


### PR DESCRIPTION
Fixes #8319