### PR TITLE
5x: Use 5x base image for 5x builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM container-registry-test.elastic.co/logstash-test/logstash-base:latest
+FROM container-registry-test.elastic.co/logstash-test/logstash-base-5x:latest
 
 RUN ln -s /tmp/vendor /opt/logstash/vendor
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -25,17 +25,17 @@ ENV PATH "/home/logstash/.rbenv/bin:$PATH"
 
 #Only used to help bootstrap the build (not to run Logstash itself)
 RUN echo 'eval "$(rbenv init -)"' >> .bashrc && \
-    rbenv install jruby-9.1.12.0 && \
     rbenv install jruby-1.7.27 && \
-    rbenv global jruby-9.1.12.0 && \
+    rbenv global jruby-1.7.27 && \
     bash -i -c 'gem install bundler' && \
-    rbenv local jruby-9.1.12.0 && \
+    rbenv local jruby-1.7.27 && \
     mkdir -p /opt/logstash/data
 
 
-# Create a cache for the dependencies based on the current master, any dependencies not cached will be downloaded at runtime
+# Create a cache for the dependencies based on the 5.6 branch, any dependencies not cached will be downloaded at runtime
 RUN git clone https://github.com/elastic/logstash.git /tmp/logstash && \
     cd /tmp/logstash && \
+    git checkout 5.6 && \
     rake test:install-core && \
     ./gradlew compileJava compileTestJava && \
     cd qa/integration && \

--- a/ci/docker_update_base_image.sh
+++ b/ci/docker_update_base_image.sh
@@ -6,7 +6,7 @@ else
     echo "Building logstash-base image from scratch." #Keep the global -e flag but allow the remove command to fail.
 fi
 
-docker build -f Dockerfile.base -t logstash-base .
+docker build -f Dockerfile.base -t logstash-base-5x .
 docker login --username=logstashci container-registry-test.elastic.co #will prompt for password
-docker tag logstash-base container-registry-test.elastic.co/logstash-test/logstash-base
-docker push container-registry-test.elastic.co/logstash-test/logstash-base
+docker tag logstash-base-5x container-registry-test.elastic.co/logstash-test/logstash-base-5x
+docker push container-registry-test.elastic.co/logstash-test/logstash-base-5x


### PR DESCRIPTION
* This allows for faster 5x builds since the base Docker image gem and jar cache is closer to the 5x dependencies.
* This prevents the Ruby 9k dependencies from sneaking into the build (had issues w/r/t jruby openssl)

Note - this should also fix the Jenkins 5.5 and 5.6 Jenkins builds due to a Jruby openssl issue (I don't fully understand) that occurs when Ruby 9k is installed first. 