### PR TITLE
Minor: Remove JRuby 1.7 from the docker base image (it is not used)

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -26,7 +26,6 @@ ENV PATH "/home/logstash/.rbenv/bin:$PATH"
 #Only used to help bootstrap the build (not to run Logstash itself)
 RUN echo 'eval "$(rbenv init -)"' >> .bashrc && \
     rbenv install jruby-9.1.12.0 && \
-    rbenv install jruby-1.7.27 && \
     rbenv global jruby-9.1.12.0 && \
     bash -i -c 'gem install bundler' && \
     rbenv local jruby-9.1.12.0 && \


### PR DESCRIPTION
JRuby 1.7 was never used, even for 5.6 builds.

Over at https://github.com/elastic/logstash/pull/8329 we will use a different base image that is specific to for 5.x, so this PR is simply minor clean up. 