### PR TITLE
MINOR: Remove unimplemented methods from batch interface

### DIFF
--- a/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
@@ -271,12 +271,6 @@ module LogStash; module Util
         @generated[event] = true
       end
 
-      def cancel(event)
-        # TODO: disabled for https://github.com/elastic/logstash/issues/6055 - will have to properly refactor
-        raise("cancel is unsupported")
-        # @cancelled[event] = true
-      end
-
       def to_a
         events = []
         each {|e| events << e}
@@ -304,12 +298,6 @@ module LogStash; module Util
 
       def filtered_size
         @originals.size + @generated.size
-      end
-
-      def cancelled_size
-        # TODO: disabled for https://github.com/elastic/logstash/issues/6055 = will have to properly refactor
-        raise("cancelled_size is unsupported ")
-        # @cancelled.size
       end
 
       def shutdown_signal_received?

--- a/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
@@ -169,12 +169,6 @@ module LogStash; module Util
         @originals.add(event)
       end
 
-      def cancel(event)
-        # TODO: disabled for https://github.com/elastic/logstash/issues/6055 - will have to properly refactor
-        raise("cancel is unsupported")
-        # @cancelled[event] = true
-      end
-
       def to_a
         events = []
         @originals.each {|e| events << e unless e.cancelled?}
@@ -192,12 +186,6 @@ module LogStash; module Util
       end
 
       alias_method(:size, :filtered_size)
-
-      def cancelled_size
-      # TODO: disabled for https://github.com/elastic/logstash/issues/6055 = will have to properly refactor
-      raise("cancelled_size is unsupported ")
-        # @cancelled.size
-      end
     end
 
     class WriteClient


### PR DESCRIPTION
These are just noise I think. Given that we're moving this functionality to Java once #7950 is in, it's probably best to just kill this for now and see what will be the best approach to `cancel` in whatever a Java implementation will look like? 