### PR TITLE
PERFORMANCE: More efficiently store offsets in AbstractByteBufferPageIO

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/AbstractByteBufferPageIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/AbstractByteBufferPageIO.java
@@ -42,7 +42,7 @@ public abstract class AbstractByteBufferPageIO implements PageIO {
     protected int head; // head is the write position and is an int per ByteBuffer class position
     protected byte version;
     private CRC32 checkSummer;
-    private final List<Integer> offsetMap; // has to be extendable
+    private final IntVector offsetMap;
 
     public AbstractByteBufferPageIO(int pageNum, int capacity) {
         this.minSeqNum = 0;
@@ -51,7 +51,7 @@ public abstract class AbstractByteBufferPageIO implements PageIO {
         this.head = 0;
         this.pageNum = pageNum;
         this.capacity = capacity;
-        this.offsetMap = new ArrayList<>();
+        this.offsetMap = new IntVector();
         this.checkSummer = new CRC32();
     }
 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/IntVector.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/IntVector.java
@@ -1,0 +1,42 @@
+package org.logstash.ackedqueue.io;
+
+final class IntVector {
+
+    private int count;
+
+    private int[] data;
+
+    IntVector() {
+        data = new int[1024];
+        count = 0;
+    }
+
+    /**
+     * Store the {@code int} to the underlying {@code int[]}, resizing it if necessary.
+     * @param num Int to store
+     */
+    public void add(final int num) {
+        if (data.length < count + 1) {
+            final int[] old = data;
+            data = new int[data.length << 1];
+            System.arraycopy(old, 0, data, 0, old.length);
+        }
+        data[count++] = num;
+    }
+
+    /**
+     * Get value stored at given index.
+     * @param index Array index (only values < {@link IntVector#count} are valid)
+     * @return Int
+     */
+    public int get(final int index) {
+        return data[index];
+    }
+
+    /**
+     * @return Number of elements stored in this instance
+     */
+    public int size() {
+        return count;
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/io/IntVectorTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/io/IntVectorTest.java
@@ -1,0 +1,22 @@
+package org.logstash.ackedqueue.io;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class IntVectorTest {
+
+    @Test
+    public void storesAndResizes() {
+        final int count = 10_000;
+        final IntVector vector = new IntVector();
+        for (int i = 0; i < count; ++i) {
+            vector.add(i);
+        }
+        assertThat(vector.size(), is(count));
+        for (int i = 0; i < count; ++i) {
+            assertThat(i, is(vector.get(i)));
+        }
+    }
+}


### PR DESCRIPTION
Extended benchmarking tool to PQ and found this one:

* Storing `ints` into a large `ArrayList<Integer>` is extremely costly (hundreds of MB of old gen heap for the Apache benchmark with `-b 128 -w 4`)
   * This causes a lot of load GC wise slowing down every part of LS
   * It's so bad that it introduces major GC like in below screenshot from `master`

<img width="2230" alt="screen shot 2017-09-20 at 09 54 07" src="https://user-images.githubusercontent.com/6490959/30635112-b139d986-9df1-11e7-8ccf-90957c8dc1b1.png">

This situation is much improved by this simple change, moving to a manually grown `int[]` (though not fully fixed, even manually allocating these arrays is pretty costly, we need re-use here)

But for now, this is what it looks like after this patch:

<img width="2253" alt="screen shot 2017-09-20 at 10 53 00" src="https://user-images.githubusercontent.com/6490959/30635258-269dd2e0-9df2-11e7-9be0-642121c4619b.png">

-> average GC time down by `~50%`, old gen grow rate also down by `~50%`  :)
-> throughput up (~15% in base-line, seemingly (and theoretically it should be so) more in the Apache dataset, didn't have time for a long run here ...)