### PR TITLE
 #7318 stop creating a new RubyTimestamp on every timestamp get

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -47,7 +47,7 @@ public final class Event implements Cloneable, Queueable {
         this.data = new ConvertedMap(10);
         this.data.putInterned(VERSION, VERSION_ONE);
         this.cancelled = false;
-        this.data.putInterned(TIMESTAMP, new Timestamp());
+        setTimestamp(Timestamp.now());
     }
 
     /**
@@ -82,7 +82,7 @@ public final class Event implements Cloneable, Queueable {
         Object providedTimestamp = data.get(TIMESTAMP);
         // keep reference to the parsedTimestamp for tagging below
         Timestamp parsedTimestamp = initTimestamp(providedTimestamp);
-        data.putInterned(TIMESTAMP, parsedTimestamp == null ? Timestamp.now() : parsedTimestamp);
+        setTimestamp(parsedTimestamp == null ? Timestamp.now() : parsedTimestamp);
         // the tag() method has to be called after the Accessors initialization
         if (parsedTimestamp == null) {
             tag(TIMESTAMP_FAILURE_TAG);
@@ -111,16 +111,19 @@ public final class Event implements Cloneable, Queueable {
     }
 
     public Timestamp getTimestamp() throws IOException {
-        final Timestamp timestamp = (Timestamp) data.get(TIMESTAMP);
+        final JrubyTimestampExtLibrary.RubyTimestamp timestamp = 
+            (JrubyTimestampExtLibrary.RubyTimestamp) data.get(TIMESTAMP);
         if (timestamp != null) {
-            return timestamp;
+            return timestamp.getTimestamp();
         } else {
             throw new IOException("fails");
         }
     }
 
     public void setTimestamp(Timestamp t) {
-        this.data.putInterned(TIMESTAMP, t);
+        this.data.putInterned(
+            TIMESTAMP, JrubyTimestampExtLibrary.RubyTimestamp.newRubyTimestamp(RubyUtil.RUBY, t)
+        );
     }
 
     public Object getField(final String reference) {

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -288,8 +288,10 @@ public final class JrubyEventExtLibrary implements Library {
         }
 
         @JRubyMethod(name = "timestamp")
-        public IRubyObject ruby_timestamp(ThreadContext context) throws IOException {
-            return new JrubyTimestampExtLibrary.RubyTimestamp(context.getRuntime(), this.event.getTimestamp());
+        public IRubyObject ruby_timestamp(ThreadContext context) {
+            // We can just cast to IRubyObject here, because we know that Event stores a
+            // RubyTimestamp internally.
+            return (IRubyObject) event.getUnconvertedField(FieldReference.TIMESTAMP_REFERENCE);
         }
 
         @JRubyMethod(name = "timestamp=", required = 1)


### PR DESCRIPTION
Fixing #7318 by simply storing `RubyTimestamp` instead of `Timstamp` in an `Event` by default. There is some value in this in addition to making the getter GC free, in that it also ensures that `setTimestamp` and `setField()` (which would use `Valuefier` to arrive at the same result), behave exactly the same.