### PR TITLE
MINOR: Cleanup RubyTimestamp Classload + Constructor

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
@@ -30,6 +30,8 @@ public final class JrubyTimestampExtLibrary implements Library {
         }
     };
 
+    private static final RubyClass TIMESTAMP_CLASS = createTimestamp(RubyUtil.RUBY);
+
     @Override
     public void load(Ruby runtime, boolean wrap) {
         createTimestamp(runtime);
@@ -60,7 +62,7 @@ public final class JrubyTimestampExtLibrary implements Library {
         }
 
         public RubyTimestamp(Ruby runtime, Timestamp timestamp) {
-            this(runtime, runtime.getModule(RubyUtil.LS_MODULE_NAME).getClass("Timestamp"), timestamp);
+            this(runtime, TIMESTAMP_CLASS, timestamp);
         }
 
         public RubyTimestamp(Ruby runtime) {


### PR DESCRIPTION
Cleaning up a little + making `RubyTimestamp` load faster.

This:

```java
 RubyClass clazz = runtime.defineClassUnder("Timestamp", runtime.getObject(), ALLOCATOR, module);
```

is pretty wasteful (especially considering this will be called a little more often as a result of #8334 ).

=> cache `RubyClass` in constant