### PR TITLE
#7549 fix unsafe concurreny in PQ count getters

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -768,16 +768,26 @@ public class Queue implements Closeable {
     }
 
     public long getAckedCount() {
-        return headPage.ackedSeqNums.cardinality() + tailPages.stream()
-                .mapToLong(page -> page.ackedSeqNums.cardinality())
-                .sum();
+        lock.lock();
+        try {
+            return headPage.ackedSeqNums.cardinality() + tailPages.stream()
+                .mapToLong(page -> page.ackedSeqNums.cardinality()).sum();
+        } finally {
+            lock.unlock();
+        }
     }
 
     public long getUnackedCount() {
-        long headPageCount = (headPage.getElementCount() - headPage.ackedSeqNums.cardinality());
-        long tailPagesCount = tailPages.stream()
-                .mapToLong(page -> (page.getElementCount() - page.ackedSeqNums.cardinality())).sum();
-        return headPageCount + tailPagesCount;
+        lock.lock();
+        try {
+            long headPageCount = (headPage.getElementCount() - headPage.ackedSeqNums.cardinality());
+            long tailPagesCount = tailPages.stream()
+                .mapToLong(page -> (page.getElementCount() - page.ackedSeqNums.cardinality()))
+                .sum();
+            return headPageCount + tailPagesCount;
+        } finally {
+            lock.unlock();
+        }
     }
 
     protected long nextSeqNum() {


### PR DESCRIPTION
Fixing #7549:

* Obviously this will throw `ConcurrentModificationException` if not guarded by a lock as explained in the issue
* Basically this is the same as #8317 here