### PR TITLE
MINOR: Remove needless lock on acked batch read

### DIFF
--- a/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
@@ -167,12 +167,7 @@ module LogStash; module Util
         end
 
         batch = new_batch
-        @mutex.lock
-        begin
-          batch.read_next
-        ensure
-          @mutex.unlock
-        end
+        batch.read_next
         start_metrics(batch)
         batch
       end


### PR DESCRIPTION
Leftover from #8186: this lock is useless since the write operation (and all other Queue operations for that matter) is locked on the Java side.