### PR TITLE
Bug fix: Fix Ruby loggers by fixing log4j2 setup

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -223,7 +223,9 @@ class LogStash::Runner < Clamp::StrictCommand
       log4j_config_location = ::File.join(setting("path.settings"), "log4j2.properties")
 
       # Windows safe way to produce a file: URI.
-      LogStash::Logging::Logger::reconfigure(URI.join("file:///" + File.absolute_path(log4j_config_location)).to_s)
+      file_schema = "file://" + (LogStash::Environment.windows? ? "/" : "")
+      LogStash::Logging::Logger::reconfigure(URI.join(file_schema + File.absolute_path(log4j_config_location)).to_s)
+
     end
     # override log level that may have been introduced from a custom log4j config file
     LogStash::Logging::Logger::configure_logging(setting("log.level"))


### PR DESCRIPTION

I think this may have been a bad merge. I just copied the exact code from master, and all is well. (I didn't test from Windows)

Note - this issue is only present on the 5.6 branch 