### PR TITLE
 #8341 raise tolerance in timestamp_spec.rb tests

### DIFF
--- a/logstash-core/spec/logstash/timestamp_spec.rb
+++ b/logstash-core/spec/logstash/timestamp_spec.rb
@@ -13,10 +13,10 @@ describe LogStash::Timestamp do
     # we may need to use `be_within(0.000999999).of()` in other places too
     it "should work" do
       t = LogStash::Timestamp.new
-      expect(t.time.to_i).to be_within(1).of Time.now.to_i
+      expect(t.time.to_i).to be_within(2).of Time.now.to_i
 
       t = LogStash::Timestamp.now
-      expect(t.time.to_i).to be_within(1).of Time.now.to_i
+      expect(t.time.to_i).to be_within(2).of Time.now.to_i
 
       now = DateTime.now.to_time.utc
       t = LogStash::Timestamp.new(now)


### PR DESCRIPTION
Just like we did in https://github.com/elastic/logstash/commit/f64762fd05926fb07e30d8d4028a5ae21fa6124e just a matter of rounding down to `int` and having some jitter in `System#currentTimeMillis` (which Joda seems to be using under the hood).