### PR TITLE
 #8345 adjust test stacktrace size example to work in all cases

### DIFF
--- a/logstash-core/src/test/java/org/logstash/instruments/monitors/HotThreadMonitorTest.java
+++ b/logstash-core/src/test/java/org/logstash/instruments/monitors/HotThreadMonitorTest.java
@@ -1,14 +1,17 @@
 package org.logstash.instruments.monitors;
 
 
-import org.junit.Test;
-import org.logstash.instrument.monitors.HotThreadsMonitor;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import org.logstash.instrument.monitors.HotThreadsMonitor;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 
@@ -45,17 +48,38 @@ public class HotThreadMonitorTest {
     }
 
     @Test
-    public void testStackTraceSizeOption(){
+    public void testStackTraceSizeOption() throws InterruptedException {
         final String testStackSize = "4";
-        Map<String, String> options = new HashMap<>();
-        options.put("stacktrace_size", testStackSize);
-        HotThreadsMonitor.detect(options).stream().filter(tr -> !tr.getThreadName().equals("Signal Dispatcher") &&
-                                                                      !tr.getThreadName().equals("Reference Handler") &&
-                                                                            !tr.getThreadName().equals("Attach Listener"))
-                                                        .forEach(tr -> {
-            List stackTrace = (List)tr.toMap().get("thread.stacktrace");
-            assertThat(stackTrace.size(), is(Integer.valueOf(testStackSize)));
-        });
+        final CountDownLatch latch = new CountDownLatch(1);
+        final Thread thread = new Thread() {
+            @Override
+            public void run() {
+                waitEnd();
+            }
+
+            void waitEnd() {
+                try {
+                    latch.await();
+                } catch (final InterruptedException ex) {
+                    throw new IllegalArgumentException(ex);
+                }
+            }
+        };
+        try {
+            thread.start();
+            TimeUnit.MILLISECONDS.sleep(300L);
+            final Map<String, String> options = new HashMap<>();
+            options.put("stacktrace_size", testStackSize);
+            assertThat(
+                ((List) HotThreadsMonitor.detect(options).stream()
+                    .filter(tr -> thread.getName().equals(tr.getThreadName())).findFirst()
+                    .get().toMap().get("thread.stacktrace")).size(),
+                is(Integer.parseInt(testStackSize))
+            );
+        } finally {
+            latch.countDown();
+            thread.join();
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #8345 by running against a defined thread with guaranteed stacktrace depth > 4 to avoid randomly using the `Finalizer` thread that can be in various places of its execution and randomly have values `< 4` as seen in below stacktraces.

<img width="489" alt="screen shot 2017-09-21 at 09 46 47" src="https://user-images.githubusercontent.com/6490959/30684677-82291e2e-9eb2-11e7-8d31-4af13eefe9ab.png">
<img width="768" alt="screen shot 2017-09-21 at 09 49 59" src="https://user-images.githubusercontent.com/6490959/30684678-8229adf8-9eb2-11e7-83d5-97f31354bead.png">
