### PR TITLE
pick jvm.options for rspec.bat

### DIFF
--- a/bin/rspec.bat
+++ b/bin/rspec.bat
@@ -1,15 +1,30 @@
 @echo off
+setlocal enabledelayedexpansion
+set params='%*'
 
-SETLOCAL
-
-set SCRIPT_DIR=%~dp0
-CALL "%SCRIPT_DIR%\setup.bat"
-
-:EXEC
-if "%VENDORED_JRUBY%" == "" (
-  %RUBYCMD% "%LS_HOME%\lib\bootstrap\rspec.rb" %*
-) else (
-  %JRUBY_BIN% %jruby_opts% "%LS_HOME%\lib\bootstrap\rspec.rb" %*
+call "%~dp0setup.bat" || exit /b 1
+if errorlevel 1 (
+	if not defined nopauseonerror (
+		pause
+	)
+	exit /B %ERRORLEVEL%
 )
 
-ENDLOCAL
+rem if explicit jvm.options is not found use default location
+if "%LS_JVM_OPTIONS_CONFIG%" == "" (
+  set LS_JVM_OPTIONS_CONFIG=%LS_HOME%\config\jvm.options
+)
+
+rem extract the options from the JVM options file %LS_JVM_OPTIONS_CONFIG%
+rem such options are the lines beginning with '-', thus "findstr /b"
+if exist %LS_JVM_OPTIONS_CONFIG% (
+  for /F "usebackq delims=" %%a in (`findstr /b \- %LS_JVM_OPTIONS_CONFIG%`) do set options=!options! %%a
+  set "LS_JAVA_OPTS=!options! %LS_JAVA_OPTS%"
+) else (
+  echo "warning: no jvm.options file found"
+)
+set JAVA_OPTS=%LS_JAVA_OPTS%
+
+%JRUBY_BIN% "%LS_HOME%\lib\bootstrap\rspec.rb" %*
+
+endlocal


### PR DESCRIPTION
windows `bin/rspect.bat` should pickup `jvm.options` just like when launching `bin/logstash` so that the specs run in the same JVM environment.

This has already been back-introduced in 5.5 in #8354

I would like to merge this to master, 6.x & 6.0.