### PR TITLE
Test fix: add longer wait for agent startup for converge tests

### DIFF
--- a/logstash-core/spec/support/helpers.rb
+++ b/logstash-core/spec/support/helpers.rb
@@ -77,7 +77,8 @@ def start_agent(agent)
     end
   end
 
-  sleep(0.1) unless subject.running?
+  wait(5).for { agent.running? }.to be(true)
+  
   agent_task
 end
 


### PR DESCRIPTION
Fixes #8204 (i think)

Note - I spent along time trying to reproduce the error this is trying to fix, and could not. This is my best guess to root cause.  