### PR TITLE
 #8360 fix tests by enforcing IPV4 in Benchmark tool UTs

### DIFF
--- a/tools/benchmark-cli/build.gradle
+++ b/tools/benchmark-cli/build.gradle
@@ -46,6 +46,9 @@ javadoc {
 }
 
 test {
+  // We need to force IPV4 usage to make WireMock tests portable between *nix and Windows.
+  // For details see: https://github.com/elastic/logstash/pull/8372
+  jvmArgs '-Djava.net.preferIPv4Stack=true'
   exclude '**/org/logstash/benchmark/cli/MainTest*'
   exclude '**/org/logstash/benchmark/cli/MainEsStorageTest*'
 }


### PR DESCRIPTION
fixes #8360 (at least for me):

* Wiremock seems to not work with IPV6, even if I use a dynamic approach to getting the loopback/localhost instead of hard `127.0.0.1` => adjust this in the Gradle properties