### PR TITLE
Test fixes: This should fix a couple different test failures.

### DIFF
--- a/logstash-core/spec/support/helpers.rb
+++ b/logstash-core/spec/support/helpers.rb
@@ -77,7 +77,7 @@ def start_agent(agent)
     end
   end
 
-  sleep(0.1) unless subject.running?
+  wait(30).for { agent.running? }.to be(true)
   agent_task
 end
 

--- a/logstash-core/spec/support/shared_contexts.rb
+++ b/logstash-core/spec/support/shared_contexts.rb
@@ -21,12 +21,21 @@ shared_context "api setup" do
     settings = mock_settings
     config_string = "input { generator {id => 'api-generator-pipeline' count => 100 } } output { dummyoutput {} }"
     settings.set("config.string", config_string)
+    settings.set("config.reload.automatic", false)
     @agent = make_test_agent(settings)
     @agent.execute
+    pipeline_config = mock_pipeline_config(:main, "input { generator { id => '123' } } output { null {} }")
+    pipeline_creator =  LogStash::PipelineAction::Create.new(pipeline_config, @agent.metric)
+    @pipelines = Hash.new
+    expect(pipeline_creator.execute(@agent, @pipelines)).to be_truthy
   end
 
   after :all do
     @agent.shutdown
+    @pipelines.each do |_, pipeline|
+      pipeline.shutdown
+      pipeline.thread.join
+    end
   end
 
   include Rack::Test::Methods


### PR DESCRIPTION
* Fixes #8344 - Ruby Unit Test can hang with no information as to why
* Fixes #7227 - MetricStore::MetricNotFound
* Fixes #8204 - `config.reload.automatic` is set to`FALSE

I am only certain it fixes #8344 and #7227, since that is the only one I can reproduce.