### PR TITLE
Correctly Serialize RubyNil values when serializing to JSON

### DIFF
--- a/logstash-core/spec/logstash/event_spec.rb
+++ b/logstash-core/spec/logstash/event_spec.rb
@@ -10,6 +10,11 @@ TIMESTAMP = "@timestamp"
 
 describe LogStash::Event do
   context "to_json" do
+    it "should correctly serialize RubyNil values a Null values" do
+      e = LogStash::Event.new({ "null_value" => nil, TIMESTAMP => "2015-05-28T23:02:05.350Z"})
+      expect(JSON.parse(e.to_json)).to eq(JSON.parse("{\"null_value\":null,\"@timestamp\":\"2015-05-28T23:02:05.350Z\",\"@version\":\"1\"}"))
+    end
+
     it "should serialize simple values" do
       e = LogStash::Event.new({"foo" => "bar", "bar" => 1, "baz" => 1.0, TIMESTAMP => "2015-05-28T23:02:05.350Z"})
       expect(JSON.parse(e.to_json)).to eq(JSON.parse("{\"foo\":\"bar\",\"bar\":1,\"baz\":1.0,\"@timestamp\":\"2015-05-28T23:02:05.350Z\",\"@version\":\"1\"}"))

--- a/logstash-core/src/main/java/org/logstash/ObjectMappers.java
+++ b/logstash-core/src/main/java/org/logstash/ObjectMappers.java
@@ -314,7 +314,7 @@ public final class ObjectMappers {
         @Override
         public void serialize(final RubyNil value, final JsonGenerator jgen,
             final SerializerProvider provider) throws IOException {
-            jgen.writeString("");
+            jgen.writeNull();
         }
 
         @Override


### PR DESCRIPTION
The custom serializer introduced in #8371 did change the behavior or JSON
serialization when one of the field was a RubyNil values.

The orignal behavior was to serialize RubyNil values into their
Javascript Null. The PR #8371 changed that behavior to instead
serialized an empty string and changed the expected type.

This commit revert the behavior to serialize to Null and also tests
around the events class to prevent that.