### PR TITLE
Correct the lockfile for 5.6.3

### DIFF
--- a/Gemfile.jruby-1.9.lock.release
+++ b/Gemfile.jruby-1.9.lock.release
@@ -1,0 +1,746 @@
+PATH
+  remote: ./logstash-core
+  specs:
+    logstash-core (5.6.3-java)
+      chronic_duration (= 0.10.6)
+      clamp (~> 0.6.5)
+      concurrent-ruby (~> 1.0, >= 1.0.5)
+      elasticsearch (~> 5.0, >= 5.0.4)
+      filesize (= 0.0.4)
+      gems (~> 0.8.3)
+      i18n (= 0.6.9)
+      jar-dependencies
+      jrjackson (~> 0.4.0)
+      jruby-openssl (= 0.9.19)
+      manticore (>= 0.5.4, < 1.0.0)
+      minitar (~> 0.5.4)
+      pry (~> 0.10.1)
+      puma (~> 2.16)
+      rack (= 1.6.6)
+      ruby-maven (~> 3.3.9)
+      rubyzip (~> 1.1.7)
+      sinatra (~> 1.4, >= 1.4.6)
+      stud (~> 0.0.19)
+      thread_safe (~> 0.3.5)
+      treetop (< 1.5.0)
+
+PATH
+  remote: ./logstash-core-plugin-api
+  specs:
+    logstash-core-plugin-api (2.1.12-java)
+      logstash-core (= 5.6.3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.3.8)
+    arr-pm (0.0.10)
+      cabin (> 0)
+    atomic (1.1.99-java)
+    avl_tree (1.2.1)
+      atomic (~> 1.1)
+    awesome_print (1.8.0)
+    aws-sdk (2.3.22)
+      aws-sdk-resources (= 2.3.22)
+    aws-sdk-core (2.3.22)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.3.22)
+      aws-sdk-core (= 2.3.22)
+    aws-sdk-v1 (1.67.0)
+      json (~> 1.4)
+      nokogiri (~> 1)
+    backports (3.8.0)
+    benchmark-ips (2.7.2)
+    bindata (2.4.1)
+    buftok (0.2.0)
+    builder (3.2.3)
+    cabin (0.9.0)
+    childprocess (0.8.0)
+      ffi (~> 1.0, >= 1.0.11)
+    chronic_duration (0.10.6)
+      numerizer (~> 0.1.1)
+    ci_reporter (2.0.0)
+      builder (>= 2.1.2)
+    ci_reporter_rspec (1.0.0)
+      ci_reporter (~> 2.0)
+      rspec (>= 2.14, < 4)
+    cinch (2.3.4)
+    clamp (0.6.5)
+    coderay (1.1.2)
+    concurrent-ruby (1.0.5-java)
+    diff-lcs (1.3)
+    docile (1.1.5)
+    docker-api (1.31.0)
+      excon (>= 0.38.0)
+      json
+    domain_name (0.5.20170404)
+      unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.2.1)
+    edn (1.1.1)
+    elasticsearch (5.0.4)
+      elasticsearch-api (= 5.0.4)
+      elasticsearch-transport (= 5.0.4)
+    elasticsearch-api (5.0.4)
+      multi_json
+    elasticsearch-transport (5.0.4)
+      faraday
+      multi_json
+    equalizer (0.0.10)
+    excon (0.59.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    ffi (1.9.18-java)
+    file-dependencies (0.1.6)
+      minitar
+    filesize (0.0.4)
+    filewatch (0.9.0)
+    fivemat (1.3.5)
+    flores (0.0.7)
+    fpm (1.3.3)
+      arr-pm (~> 0.0.9)
+      backports (>= 2.6.2)
+      cabin (>= 0.6.0)
+      childprocess
+      clamp (~> 0.6)
+      ffi
+      json (>= 1.7.7)
+    gelfd (0.2.0)
+    gem_publisher (1.5.0)
+    gems (0.8.3)
+    hitimes (1.2.6-java)
+    http (0.9.9)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 1.0.1)
+      http_parser.rb (~> 0.6.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    http-form_data (1.0.1)
+    http_parser.rb (0.6.0-java)
+    i18n (0.6.9)
+    insist (1.0.0)
+    jar-dependencies (0.3.11)
+    jls-grok (0.11.4)
+      cabin (>= 0.6.0)
+    jls-lumberjack (0.0.26)
+      concurrent-ruby
+    jmespath (1.3.1)
+    jrjackson (0.4.3-java)
+    jruby-openssl (0.9.19-java)
+    jruby-stdin-channel (0.2.0-java)
+    json (1.8.6-java)
+    kramdown (1.14.0)
+    logstash-codec-cef (4.1.4-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-collectd (3.0.7)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-dots (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-edn (3.0.5)
+      edn
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-edn_lines (3.0.5)
+      edn
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-es_bulk (3.0.5)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-fluent (3.1.3-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      msgpack
+    logstash-codec-graphite (3.0.4)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-json (3.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-json_lines (3.0.4)
+      logstash-codec-line (>= 2.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-line (3.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-msgpack (3.0.5-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      msgpack-jruby
+    logstash-codec-multiline (3.0.7)
+      jls-grok (~> 0.11.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-patterns-core
+    logstash-codec-netflow (3.5.2)
+      bindata (>= 1.5.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-plain (3.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-rubydebug (3.0.4)
+      awesome_print
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-devutils (1.3.4-java)
+      fivemat
+      gem_publisher
+      insist (= 1.0.0)
+      kramdown (= 1.14.0)
+      logstash-core-plugin-api (>= 2.0, <= 2.99)
+      minitar
+      rake
+      rspec (~> 3.0)
+      rspec-wait
+      stud (>= 0.0.20)
+    logstash-filter-cidr (3.1.1-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-clone (3.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-csv (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-date (3.1.8)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-dissect (1.0.12)
+      jar-dependencies
+      logstash-core-plugin-api (>= 2.1.1, <= 2.99)
+    logstash-filter-dns (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      lru_redux (~> 1.1.0)
+    logstash-filter-drop (3.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-fingerprint (3.1.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      murmurhash3
+    logstash-filter-geoip (4.3.1-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-grok (3.4.3)
+      jls-grok (~> 0.11.3)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-patterns-core
+      stud (~> 0.0.22)
+    logstash-filter-json (3.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-kv (4.0.2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-metrics (4.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      metriks
+      thread_safe
+    logstash-filter-mutate (3.1.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-ruby (3.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-filter-date
+    logstash-filter-sleep (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-split (3.1.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-syslog_pri (3.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-throttle (4.0.3)
+      atomic
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      thread_safe
+    logstash-filter-translate (3.0.3)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-urldecode (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-useragent (3.2.1-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-uuid (3.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-xml (4.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      nokogiri
+      xml-simple
+    logstash-input-beats (3.1.24-java)
+      concurrent-ruby (~> 1.0)
+      jar-dependencies (~> 0.3.4)
+      logstash-codec-multiline (>= 2.0.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      thread_safe (~> 0.3.5)
+    logstash-input-couchdb_changes (3.1.3)
+      json
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (>= 0.0.22)
+    logstash-input-dead_letter_queue (1.1.1)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-input-elasticsearch (4.0.6)
+      elasticsearch (>= 5.0.3, < 6.0.0)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-input-exec (3.1.4)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (~> 0.0.22)
+    logstash-input-file (4.0.3)
+      addressable
+      filewatch (~> 0.8, >= 0.8.1)
+      logstash-codec-multiline (~> 3.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-input-ganglia (3.1.2)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (~> 0.0.22)
+    logstash-input-gelf (3.0.6)
+      gelfd (= 0.2.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (~> 0.0.22)
+    logstash-input-generator (3.0.4)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-input-graphite (3.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-input-tcp
+    logstash-input-heartbeat (3.0.4)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud
+    logstash-input-http (3.0.6)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      puma (~> 2.16, >= 2.16.0)
+      rack (~> 1)
+      stud
+    logstash-input-http_poller (3.3.4)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-http_client (>= 5.0.0, < 6.0.0)
+      rufus-scheduler (~> 3.0.9)
+      stud (~> 0.0.22)
+    logstash-input-imap (3.0.4)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      mail (~> 2.6.3)
+      mime-types (= 2.6.2)
+      stud (~> 0.0.22)
+    logstash-input-irc (3.0.4)
+      cinch
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (~> 0.0.22)
+    logstash-input-jdbc (4.2.4)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      rufus-scheduler
+      sequel
+      tzinfo
+      tzinfo-data
+    logstash-input-kafka (5.1.11)
+      logstash-codec-json
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (>= 0.0.22, < 0.1.0)
+    logstash-input-log4j (3.1.1-java)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-input-lumberjack (3.1.3)
+      concurrent-ruby
+      jls-lumberjack (~> 0.0.26)
+      logstash-codec-multiline (~> 3.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-input-pipe (3.0.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (~> 0.0.22)
+    logstash-input-rabbitmq (5.2.5)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-rabbitmq_connection (>= 4.3.0, < 5.0.0)
+    logstash-input-redis (3.1.5)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      redis (~> 3)
+    logstash-input-s3 (3.1.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-aws
+      stud (~> 0.0.18)
+    logstash-input-snmptrap (3.0.4)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      snmp
+    logstash-input-sqs (3.0.5)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-aws (>= 1.0.0)
+    logstash-input-stdin (3.2.4)
+      concurrent-ruby
+      jruby-stdin-channel
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-input-syslog (3.2.2)
+      concurrent-ruby
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-filter-date
+      logstash-filter-grok
+      stud (>= 0.0.22, < 0.1.0)
+      thread_safe
+    logstash-input-tcp (4.2.4-java)
+      logstash-codec-json
+      logstash-codec-json_lines
+      logstash-codec-line
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-input-twitter (3.0.6)
+      http-form_data (<= 1.0.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      public_suffix (<= 1.4.6)
+      stud (>= 0.0.22, < 0.1)
+      twitter (= 5.15.0)
+    logstash-input-udp (3.1.2)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (~> 0.0.22)
+    logstash-input-unix (3.0.5)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-input-xmpp (3.1.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      xmpp4r (~> 0.5.6)
+    logstash-mixin-aws (4.2.3)
+      aws-sdk (~> 2.3.0)
+      aws-sdk-v1 (>= 1.61.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-mixin-http_client (5.2.1)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      manticore (>= 0.5.2, < 1.0.0)
+    logstash-mixin-rabbitmq_connection (4.3.1-java)
+      march_hare (~> 3.0.0)
+      stud (~> 0.0.22)
+    logstash-output-cloudwatch (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-aws (>= 1.0.0)
+      rufus-scheduler (~> 3.0.9)
+    logstash-output-csv (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-filter-json
+      logstash-input-generator
+      logstash-output-file
+    logstash-output-elasticsearch (7.4.2-java)
+      cabin (~> 0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      manticore (>= 0.5.4, < 1.0.0)
+      stud (~> 0.0, >= 0.0.17)
+    logstash-output-file (4.1.1)
+      logstash-codec-json_lines
+      logstash-codec-line
+      logstash-core-plugin-api (>= 2.0.0, < 2.99)
+    logstash-output-graphite (3.1.3)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-http (4.4.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-http_client (>= 5.1.0, < 6.0.0)
+    logstash-output-irc (3.0.4)
+      cinch
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-kafka (5.1.10)
+      logstash-codec-json
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-nagios (3.0.4)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-null (3.0.4)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-pagerduty (3.0.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-pipe (3.0.4)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-rabbitmq (4.0.11-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-rabbitmq_connection (>= 4.3.0, < 5.0.0)
+    logstash-output-redis (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      redis
+      stud
+    logstash-output-s3 (4.0.11)
+      concurrent-ruby
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-aws
+      stud (~> 0.0.22)
+    logstash-output-sns (4.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-aws (>= 1.0.0)
+    logstash-output-sqs (4.0.3)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-aws (>= 1.0.0)
+    logstash-output-statsd (3.1.3)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-input-generator
+      statsd-ruby (= 1.2.0)
+    logstash-output-stdout (3.1.2)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60.1, < 2.99)
+    logstash-output-tcp (4.0.2)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud
+    logstash-output-udp (3.0.4)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-webhdfs (3.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      snappy (= 0.0.12)
+      webhdfs
+    logstash-output-xmpp (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      xmpp4r (~> 0.5.6)
+    logstash-patterns-core (4.1.2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    lru_redux (1.1.0)
+    mail (2.6.6)
+      mime-types (>= 1.16, < 4)
+    manticore (0.6.1-java)
+    march_hare (3.0.0-java)
+    memoizable (0.4.2)
+      thread_safe (~> 0.3, >= 0.3.1)
+    method_source (0.8.2)
+    metriks (0.9.9.8)
+      atomic (~> 1.0)
+      avl_tree (~> 1.2.0)
+      hitimes (~> 1.1)
+    mime-types (2.6.2)
+    minitar (0.5.4)
+    msgpack (1.1.0-java)
+    msgpack-jruby (1.4.1-java)
+    multi_json (1.12.2)
+    multipart-post (2.0.0)
+    murmurhash3 (0.1.6-java)
+    mustache (0.99.8)
+    naught (1.1.0)
+    netrc (0.11.0)
+    nokogiri (1.8.1-java)
+    numerizer (0.1.1)
+    octokit (3.8.0)
+      sawyer (~> 0.6.0, >= 0.5.3)
+    paquet (0.2.1)
+    pleaserun (0.0.30)
+      cabin (> 0)
+      clamp
+      dotenv
+      insist
+      mustache (= 0.99.8)
+      stud
+    polyglot (0.3.5)
+    pry (0.10.4-java)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+      spoon (~> 0.0)
+    public_suffix (1.4.6)
+    puma (2.16.0-java)
+    rack (1.6.6)
+    rack-protection (1.5.3)
+      rack
+    rack-test (0.7.0)
+      rack (>= 1.0, < 3)
+    rake (12.1.0)
+    redis (3.3.3)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.7)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.3)
+      rspec-support (~> 3.1.0)
+    rspec-support (3.1.2)
+    rspec-wait (0.0.9)
+      rspec (>= 3, < 4)
+    ruby-maven (3.3.12)
+      ruby-maven-libs (~> 3.3.9)
+    ruby-maven-libs (3.3.9)
+    ruby-progressbar (1.8.3)
+    rubyzip (1.1.7)
+    rufus-scheduler (3.0.9)
+      tzinfo
+    sawyer (0.6.0)
+      addressable (~> 2.3.5)
+      faraday (~> 0.8, < 0.10)
+    sequel (5.0.0)
+    simple_oauth (0.3.1)
+    simplecov (0.15.1)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    sinatra (1.4.8)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    slop (3.6.0)
+    snappy (0.0.12-java)
+      snappy-jars (~> 1.1.0)
+    snappy-jars (1.1.0.1.2-java)
+    snmp (1.2.0)
+    spoon (0.0.6)
+      ffi
+    statsd-ruby (1.2.0)
+    stud (0.0.23)
+    term-ansicolor (1.3.2)
+      tins (~> 1.0)
+    thread_safe (0.3.6-java)
+    tilt (2.0.8)
+    tins (1.6.0)
+    treetop (1.4.15)
+      polyglot
+      polyglot (>= 0.3.1)
+    twitter (5.15.0)
+      addressable (~> 2.3)
+      buftok (~> 0.2.0)
+      equalizer (= 0.0.10)
+      faraday (~> 0.9.0)
+      http (>= 0.4, < 0.10)
+      http_parser.rb (~> 0.6.0)
+      json (~> 1.8)
+      memoizable (~> 0.4.0)
+      naught (~> 1.0)
+      simple_oauth (~> 0.3.0)
+    tzinfo (1.2.3)
+      thread_safe (~> 0.1)
+    tzinfo-data (1.2017.2)
+      tzinfo (>= 1.0.0)
+    unf (0.1.4-java)
+    webhdfs (0.8.0)
+      addressable
+    xml-simple (1.1.5)
+    xmpp4r (0.5.6)
+
+PLATFORMS
+  java
+
+DEPENDENCIES
+  benchmark-ips
+  builder (~> 3.2.2)
+  ci_reporter_rspec (= 1.0.0)
+  docker-api (= 1.31.0)
+  file-dependencies (= 0.1.6)
+  flores (~> 0.0.6)
+  fpm (~> 1.3.3)
+  gems (~> 0.8.3)
+  logstash-codec-cef (~> 4)
+  logstash-codec-collectd
+  logstash-codec-dots
+  logstash-codec-edn
+  logstash-codec-edn_lines
+  logstash-codec-es_bulk
+  logstash-codec-fluent
+  logstash-codec-graphite
+  logstash-codec-json
+  logstash-codec-json_lines
+  logstash-codec-line
+  logstash-codec-msgpack
+  logstash-codec-multiline
+  logstash-codec-netflow (~> 3)
+  logstash-codec-plain
+  logstash-codec-rubydebug
+  logstash-core!
+  logstash-core-plugin-api!
+  logstash-devutils
+  logstash-filter-cidr
+  logstash-filter-clone
+  logstash-filter-csv
+  logstash-filter-date
+  logstash-filter-dissect
+  logstash-filter-dns
+  logstash-filter-drop
+  logstash-filter-fingerprint
+  logstash-filter-geoip (~> 4)
+  logstash-filter-grok
+  logstash-filter-json
+  logstash-filter-kv
+  logstash-filter-metrics
+  logstash-filter-mutate
+  logstash-filter-ruby
+  logstash-filter-sleep
+  logstash-filter-split
+  logstash-filter-syslog_pri
+  logstash-filter-throttle
+  logstash-filter-translate
+  logstash-filter-urldecode
+  logstash-filter-useragent (~> 3)
+  logstash-filter-uuid
+  logstash-filter-xml
+  logstash-input-beats (~> 3)
+  logstash-input-couchdb_changes
+  logstash-input-dead_letter_queue
+  logstash-input-elasticsearch
+  logstash-input-exec
+  logstash-input-file
+  logstash-input-ganglia
+  logstash-input-gelf
+  logstash-input-generator
+  logstash-input-graphite
+  logstash-input-heartbeat
+  logstash-input-http
+  logstash-input-http_poller (~> 3)
+  logstash-input-imap
+  logstash-input-irc
+  logstash-input-jdbc
+  logstash-input-kafka (~> 5)
+  logstash-input-log4j
+  logstash-input-lumberjack
+  logstash-input-pipe
+  logstash-input-rabbitmq (~> 5)
+  logstash-input-redis
+  logstash-input-s3
+  logstash-input-snmptrap
+  logstash-input-sqs
+  logstash-input-stdin
+  logstash-input-syslog
+  logstash-input-tcp (~> 4)
+  logstash-input-twitter
+  logstash-input-udp
+  logstash-input-unix
+  logstash-input-xmpp
+  logstash-output-cloudwatch
+  logstash-output-csv
+  logstash-output-elasticsearch (~> 7)
+  logstash-output-file
+  logstash-output-graphite
+  logstash-output-http (~> 4)
+  logstash-output-irc
+  logstash-output-kafka (~> 5)
+  logstash-output-nagios
+  logstash-output-null
+  logstash-output-pagerduty
+  logstash-output-pipe
+  logstash-output-rabbitmq (~> 4)
+  logstash-output-redis (~> 3)
+  logstash-output-s3
+  logstash-output-sns
+  logstash-output-sqs (~> 4)
+  logstash-output-statsd
+  logstash-output-stdout
+  logstash-output-tcp (~> 4)
+  logstash-output-udp
+  logstash-output-webhdfs
+  logstash-output-xmpp
+  octokit (= 3.8.0)
+  paquet (~> 0.2.0)
+  pleaserun (~> 0.0.28)
+  rack (= 1.6.6)
+  rack-test
+  redis (~> 3.3.3)
+  rest-client (= 1.8.0)
+  rspec (~> 3.1.0)
+  ruby-progressbar (~> 1.8.1)
+  rubyzip (~> 1.1.7)
+  simplecov
+  stud (~> 0.0.22)
+  term-ansicolor (~> 1.3.2)
+  tins (= 1.6)


### PR DESCRIPTION
This was accidentally removed in #8390 , this bumps it correctly.

You will want to diff it against 03287b4ee63874f94b997a199097ccff2144d848 (right before #8390) to see what changed.