### PR TITLE
5.6 backport: bump JrJackson/Jackson versions, source all version refs from version…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ pkg/*.deb
 pkg/*.rpm
 *.class
 .rbx
-.rbx
 *.tar.gz
 *.jar
 .bundle
@@ -49,3 +48,6 @@ qa/integration/services/installed/
 logstash-core/bin
 plugins_version_docs.json
 tools/benchmark-cli/out/
+qa/integration/fixtures/offline_wrapper/offline
+qa/integration/fixtures/offline_wrapper/offline.o
+logstash-core/versions-gem-copy.yml

--- a/bin/logstash
+++ b/bin/logstash
@@ -27,7 +27,7 @@ if [ -L "$0" ]; then
   RL="$(which readlink)"
   if [ $? -eq 0 ]; then
     # readlink exists
-    SOURCEPATH="$($RL $0)"
+    SOURCEPATH="$(${RL} $0)"
   else
     # readlink not found, attempt to parse the output of stat
     SOURCEPATH="$(stat -c %N $0 | awk '{print $3}' | sed -e 's/\‘//' -e 's/\’//')"
@@ -43,13 +43,23 @@ else
   SOURCEPATH="$0"
 fi
 
-. "$(cd `dirname $SOURCEPATH`/..; pwd)/bin/logstash.lib.sh"
+. "$(cd `dirname ${SOURCEPATH}`/..; pwd)/bin/logstash.lib.sh"
 setup
 
-if [ "$1" = "-V" ] || [ "$1" = "--version" ];
-then
-  LOGSTASH_VERSION_FILE="${LOGSTASH_HOME}/logstash-core/lib/logstash/version.rb"
-  LOGSTASH_VERSION="$(sed -ne 's/^LOGSTASH_VERSION = "\([^*]*\)"$/\1/p' $LOGSTASH_VERSION_FILE)"
+if [ "$1" = "-V" ] || [ "$1" = "--version" ]; then
+  LOGSTASH_VERSION_FILE1="${LOGSTASH_HOME}/logstash-core/versions-gem-copy.yml"
+  LOGSTASH_VERSION_FILE2="${LOGSTASH_HOME}/versions.yml"
+  if [ -f ${LOGSTASH_VERSION_FILE1} ]; then
+    # this file is present in zip, deb and rpm artifacts and after bundle install
+    # but might not be for a git checkout type install
+    LOGSTASH_VERSION="$(sed -ne 's/^logstash: \([^*]*\)$/\1/p' ${LOGSTASH_VERSION_FILE1})"
+  elif [ -f ${LOGSTASH_VERSION_FILE2} ]; then
+    # this file is present for a git checkout type install
+    # but its not in zip, deb and rpm artifacts (and in integration tests)
+    LOGSTASH_VERSION="$(sed -ne 's/^logstash: \([^*]*\)$/\1/p' ${LOGSTASH_VERSION_FILE2})"
+  else
+    LOGSTASH_VERSION="Version not detected"
+  fi
   echo "logstash $LOGSTASH_VERSION"
 else
   ruby_exec "${LOGSTASH_HOME}/lib/bootstrap/environment.rb" "logstash/runner.rb" "$@"

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -5,6 +5,7 @@ def versionMap = (Map) (new Yaml()).load(new File("$projectDir/../versions.yml")
 
 description = """Logstash Core Java"""
 version = versionMap['logstash-core']
+String jacksonVersion = versionMap['jackson']
 
 repositories {
     mavenCentral()
@@ -100,10 +101,12 @@ dependencies {
     compile 'org.apache.logging.log4j:log4j-api:2.6.2'
     compile 'org.apache.logging.log4j:log4j-core:2.6.2'
     runtime 'org.apache.logging.log4j:log4j-slf4j-impl:2.6.2'
-    compile 'com.fasterxml.jackson.core:jackson-core:2.7.4'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.7.4'
-    compile 'com.fasterxml.jackson.module:jackson-module-afterburner:2.7.4'
-    compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.7.4'
+    // Jackson version moved to versions.yml in the project root (the JrJackson version is there too)
+    compile "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
+    compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    compile "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+    compile "com.fasterxml.jackson.module:jackson-module-afterburner:${jacksonVersion}"
+    compile "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jacksonVersion}"
     testCompile 'org.apache.logging.log4j:log4j-core:2.6.2:tests'
     testCompile 'org.apache.logging.log4j:log4j-api:2.6.2:tests'
     testCompile 'junit:junit:4.12'

--- a/logstash-core/gemspec_jars.rb
+++ b/logstash-core/gemspec_jars.rb
@@ -4,7 +4,8 @@
 
 gem.requirements << "jar org.apache.logging.log4j:log4j-api, 2.6.2"
 gem.requirements << "jar org.apache.logging.log4j:log4j-core, 2.6.2"
-gem.requirements << "jar com.fasterxml.jackson.core:jackson-core, 2.7.4"
-gem.requirements << "jar com.fasterxml.jackson.core:jackson-databind, 2.7.4"
-gem.requirements << "jar com.fasterxml.jackson.module:jackson-module-afterburner, 2.7.4"
-gem.requirements << "jar com.fasterxml.jackson.dataformat:jackson-dataformat-cbor, 2.7.4"
+gem.requirements << "jar com.fasterxml.jackson.core:jackson-core, 2.9.1"
+gem.requirements << "jar com.fasterxml.jackson.core:jackson-databind, 2.9.1"
+gem.requirements << "jar com.fasterxml.jackson.core:jackson-annotations, 2.9.1"
+gem.requirements << "jar com.fasterxml.jackson.module:jackson-module-afterburner, 2.9.1"
+gem.requirements << "jar com.fasterxml.jackson.dataformat:jackson-dataformat-cbor, 2.9.1"

--- a/logstash-core/lib/logstash-core/version.rb
+++ b/logstash-core/lib/logstash-core/version.rb
@@ -2,7 +2,11 @@
 
 # The version of logstash core gem.
 #
-# Note to authors: this should not include dashes because 'gem' barfs if
-# you include a dash in the version string.
-
-LOGSTASH_CORE_VERSION = "5.6.3"
+# sourced from a copy of the master versions.yml file, see logstash-core/logstash-core.gemspec
+if !defined?(ALL_VERSIONS)
+  require 'yaml'
+  ALL_VERSIONS = YAML.load_file(File.expand_path("../../versions-gem-copy.yml", File.dirname(__FILE__)))
+end
+if !defined?(LOGSTASH_CORE_VERSION)
+  LOGSTASH_CORE_VERSION = ALL_VERSIONS.fetch("logstash-core")
+end

--- a/logstash-core/lib/logstash-core_jars.rb
+++ b/logstash-core/lib/logstash-core_jars.rb
@@ -3,20 +3,24 @@ begin
   require 'jar_dependencies'
 rescue LoadError
   require 'org/apache/logging/log4j/log4j-core/2.6.2/log4j-core-2.6.2.jar'
-  require 'com/fasterxml/jackson/module/jackson-module-afterburner/2.7.4/jackson-module-afterburner-2.7.4.jar'
+  require 'com/fasterxml/jackson/core/jackson-databind/2.9.1/jackson-databind-2.9.1.jar'
   require 'org/apache/logging/log4j/log4j-api/2.6.2/log4j-api-2.6.2.jar'
-  require 'com/fasterxml/jackson/core/jackson-core/2.7.4/jackson-core-2.7.4.jar'
-  require 'com/fasterxml/jackson/core/jackson-annotations/2.7.0/jackson-annotations-2.7.0.jar'
-  require 'com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.7.4/jackson-dataformat-cbor-2.7.4.jar'
-  require 'com/fasterxml/jackson/core/jackson-databind/2.7.4/jackson-databind-2.7.4.jar'
+  require 'org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar'
+  require 'com/fasterxml/jackson/core/jackson-annotations/2.9.1/jackson-annotations-2.9.1.jar'
+  require 'org/apache/logging/log4j/log4j-slf4j-impl/2.6.2/log4j-slf4j-impl-2.6.2.jar'
+  require 'com/fasterxml/jackson/module/jackson-module-afterburner/2.7.3/jackson-module-afterburner-2.9.1.jar'
+  require 'com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.9.1/jackson-dataformat-cbor-2.9.1.jar'
+  require 'com/fasterxml/jackson/core/jackson-core/2.9.1/jackson-core-2.9.1.jar'
 end
 
 if defined? Jars
   require_jar( 'org.apache.logging.log4j', 'log4j-core', '2.6.2' )
-  require_jar( 'com.fasterxml.jackson.module', 'jackson-module-afterburner', '2.7.4' )
+  require_jar( 'com.fasterxml.jackson.core', 'jackson-databind', '2.9.1' )
   require_jar( 'org.apache.logging.log4j', 'log4j-api', '2.6.2' )
-  require_jar( 'com.fasterxml.jackson.core', 'jackson-core', '2.7.4' )
-  require_jar( 'com.fasterxml.jackson.core', 'jackson-annotations', '2.7.0' )
-  require_jar( 'com.fasterxml.jackson.dataformat', 'jackson-dataformat-cbor', '2.7.4' )
-  require_jar( 'com.fasterxml.jackson.core', 'jackson-databind', '2.7.4' )
+  require_jar( 'org.slf4j', 'slf4j-api', '1.7.21' )
+  require_jar( 'com.fasterxml.jackson.core', 'jackson-annotations', '2.9.1' )
+  require_jar( 'org.apache.logging.log4j', 'log4j-slf4j-impl', '2.6.2' )
+  require_jar( 'com.fasterxml.jackson.module', 'jackson-module-afterburner', '2.9.1' )
+  require_jar( 'com.fasterxml.jackson.dataformat', 'jackson-dataformat-cbor', '2.9.1' )
+  require_jar( 'com.fasterxml.jackson.core', 'jackson-core', '2.9.1' )
 end

--- a/logstash-core/lib/logstash/version.rb
+++ b/logstash-core/lib/logstash/version.rb
@@ -2,13 +2,11 @@
 
 # The version of the logstash package (not the logstash-core gem version).
 #
-# Note to authors: this should not include dashes because 'gem' barfs if
-# you include a dash in the version string.
-
-# TODO: (colin) the logstash-core gem uses it's own version number in logstash-core/lib/logstash-core/version.rb
-#       there are some dependencies in logstash-core on the LOGSTASH_VERSION constant this is why
-#       the logstash version is currently defined here in logstash-core/lib/logstash/version.rb but
-#       eventually this file should be in the root logstash lib fir and dependencies in logstash-core should be
-#       fixed.
-
-LOGSTASH_VERSION = "5.6.3"
+# sourced from a copy of the master versions.yml file, see logstash-core/logstash-core.gemspec
+if !defined?(ALL_VERSIONS)
+  require 'yaml'
+  ALL_VERSIONS = YAML.load_file(File.expand_path("../../versions-gem-copy.yml", File.dirname(__FILE__)))
+end
+if !defined?(LOGSTASH_VERSION)
+  LOGSTASH_VERSION = ALL_VERSIONS.fetch("logstash")
+end

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -1,6 +1,25 @@
 # -*- encoding: utf-8 -*-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+project_versions_yaml_path = File.expand_path("../versions.yml", File.dirname(__FILE__))
+if File.exist?(project_versions_yaml_path)
+  # we need to copy the project level versions.yml into the gem root
+  # to be able to package it into the gems file structure
+  # as the require 'logstash-core/version' loads the yaml file from within the gem root.
+  #
+  # we ignore the copy in git and we overwrite an existing file
+  # each time we build the logstash-core gem
+  original_lines = IO.readlines(project_versions_yaml_path)
+  original_lines << ""
+  original_lines << "# This is a copy the project level versions.yml into this gem's root and it is created when the gemspec is evaluated."
+  gem_versions_yaml_path = File.expand_path("./versions-gem-copy.yml", File.dirname(__FILE__))
+  File.open(gem_versions_yaml_path, 'w') do |new_file|
+    # create or overwrite
+    new_file.puts(original_lines)
+  end
+end
+
 require 'logstash-core/version'
 
 Gem::Specification.new do |gem|
@@ -11,7 +30,10 @@ Gem::Specification.new do |gem|
   gem.homepage      = "http://www.elastic.co/guide/en/logstash/current/index.html"
   gem.license       = "Apache License (2.0)"
 
-  gem.files         = Dir.glob(["logstash-core.gemspec", "gemspec_jars.rb", "lib/**/*.rb", "spec/**/*.rb", "locales/*", "lib/logstash/api/init.ru", "lib/logstash-core/logstash-core.jar"])
+  gem.files         = Dir.glob(
+    %w(versions-gem-copy.yml logstash-core.gemspec gemspec_jars.rb lib/**/*.rb spec/**/*.rb locales/*
+    lib/logstash/api/init.ru lib/logstash-core/logstash-core.jar)
+  )
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "logstash-core"
   gem.require_paths = ["lib"]
@@ -46,7 +68,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "rubyzip", "~> 1.1.7"
   gem.add_runtime_dependency "thread_safe", "~> 0.3.5" #(Apache 2.0 license)
 
-  gem.add_runtime_dependency "jrjackson", "~> 0.4.0" #(Apache 2.0 license)
+  gem.add_runtime_dependency "jrjackson", "~> #{ALL_VERSIONS.fetch('jrjackson')}" #(Apache 2.0 license)
 
   gem.add_runtime_dependency "jar-dependencies"
   # as of Feb 3rd 2016, the ruby-maven gem is resolved to version 3.3.3 and that version

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -1,5 +1,3 @@
-require "logstash/version"
-
 namespace "artifact" do
 
   SNAPSHOT_BUILD = ENV["RELEASE"] != "1"
@@ -22,6 +20,7 @@ namespace "artifact" do
       "logstash-core/lib/**/*",
       "logstash-core/locales/**/*",
       "logstash-core/vendor/**/*",
+      "logstash-core/versions-gem-copy.yml",
       "logstash-core/*.gemspec",
       "logstash-core/gemspec_jars.rb",
 
@@ -202,11 +201,21 @@ namespace "artifact" do
       ["bootstrap", "plugin:install-all", "artifact:clean-bundle-config"].each {|task| Rake::Task[task].invoke }
     end
   end
+  
+  
+  def ensure_logstash_version_constant_defined
+    # we do not want this file required when rake (ruby) parses this file
+    # only when there is a task executing, not at the very top of this file
+    if !defined?(LOGSTASH_VERSION)
+      require "logstash/version"
+    end
+  end
+
 
   def build_tar(tar_suffix = nil)
     require "zlib"
     require "archive/tar/minitar"
-    require "logstash/version"
+    ensure_logstash_version_constant_defined
     tarpath = "build/logstash#{tar_suffix}-#{LOGSTASH_VERSION}#{PACKAGE_SUFFIX}.tar.gz"
     puts("[artifact:tar] building #{tarpath}")
     gz = Zlib::GzipWriter.new(File.new(tarpath, "wb"), Zlib::BEST_COMPRESSION)
@@ -250,6 +259,7 @@ namespace "artifact" do
 
   def build_zip(zip_suffix = "")
     require 'zip'
+    ensure_logstash_version_constant_defined
     zippath = "build/logstash#{zip_suffix}-#{LOGSTASH_VERSION}#{PACKAGE_SUFFIX}.zip"
     puts("[artifact:zip] building #{zippath}")
     File.unlink(zippath) if File.exists?(zippath)
@@ -304,7 +314,8 @@ namespace "artifact" do
     File.join(basedir, "pkg", "log4j2.properties").tap do |path|
       dir.input("#{path}=/etc/logstash")
     end
-    
+
+    ensure_logstash_version_constant_defined
     package_filename = "logstash-#{LOGSTASH_VERSION}#{PACKAGE_SUFFIX}.TYPE"
 
     case platform

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -57,14 +57,18 @@ namespace "test" do
     exit(RSpec::Core::Runner.run(["--order", "rand", test_files]))
   end
 
+  desc "install core plugins and dev dependencies"
   task "install-core" => ["bootstrap", "plugin:install-core", "plugin:install-development-dependencies"]
 
+  desc "install default plugins and dev dependencies"
   task "install-default" => ["bootstrap", "plugin:install-default", "plugin:install-development-dependencies"]
 
   task "install-all" => ["bootstrap", "plugin:install-all", "plugin:install-development-dependencies"]
-
+  
+  desc "install vendor plugins and dev dependencies"
   task "install-vendor-plugins" => ["bootstrap", "plugin:install-vendor", "plugin:install-development-dependencies"]
 
+  desc "install jar dependencies and dev dependencies"
   task "install-jar-dependencies-plugins" => ["bootstrap", "plugin:install-jar-dependencies", "plugin:install-development-dependencies"]
 
   # Setup simplecov to group files per functional modules, like this is easier to spot places with small coverage

--- a/versions.yml
+++ b/versions.yml
@@ -2,3 +2,9 @@
 logstash: 5.6.3
 logstash-core: 5.6.3
 logstash-core-plugin-api: 2.1.12
+
+# Note: this file is copied to the root of logstash-core because its gemspec needs it when
+#       bundler evaluates the gemspec via bin/logstash
+# Ensure Jackson version here is kept in sync with version used by jrjackson gem
+jrjackson: 0.4.3
+jackson: 2.9.1


### PR DESCRIPTION
…s.yml

final (I hope) fixes for consolidated versioning.

After testing with rake artifact:zip, need to try both files.
Add desc to rake test:install-* tasks, tired of
  not seeing them in rake -vT

changes requested via review

Fixes #8373

Fixes #8389