### PR TITLE
[WIP] dynamically assign drive letter to WORKSPACE env var

### DIFF
--- a/ci/unit_tests.bat
+++ b/ci/unit_tests.bat
@@ -1,35 +1,86 @@
 @echo off
+setlocal enabledelayedexpansion
 
-setlocal
-
-REM Since we are using the system jruby, we need to make sure our jvm process
-REM uses at least 1g of memory, If we don't do this we can get OOM issues when
-REM installing gems. See https://github.com/elastic/logstash/issues/5179
-
-SET JRUBY_OPTS="-J-Xmx1g"
-SET SELECTEDTESTSUITE=%1
-SET /p JRUBYVERSION=<.ruby-version
-
-IF NOT EXIST %JRUBYSRCDIR% (
-  echo "Variable JRUBYSRCDIR must be declared with a valid directory. Aborting.."
+if "%WORKSPACE%" == "" (
+  echo Error: environment variable WORKSPACE must be defined. Aborting..
   exit /B 1
 )
 
-SET JRUBYPATH=%JRUBYSRCDIR%\%JRUBYVERSION%
+:: see if %WORKSPACE% is alread mapped to a drive
+for /f "tokens=1* delims==> " %%G IN ('subst') do (
+  set sdrive=%%G
+  :: removing extra space
+  set sdrive=!sdrive:~0,2!
+  set spath=%%H
 
-IF NOT EXIST %JRUBYPATH% (
-  echo "Could not find JRuby in %JRUBYPATH%. Aborting.."
+  if /I "!spath!" == "%WORKSPACE%" (
+    set use_drive=!sdrive!
+    goto :found_drive
+  )
+)
+
+:: no existing mapping
+:: try to assign "%WORKSPACE%" to the first drive letter which works
+for %%i in (A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z) do (
+    set "drive=%%i:"
+    subst !drive! "%WORKSPACE%" >nul
+    if not errorlevel 1 (
+        set use_drive=!drive!
+        goto :found_drive
+    )
+)
+
+echo Error: unable to subst drive to path %WORKSPACE%. Aborting...
+exit /B 1
+
+:found_drive
+echo Using drive !use_drive! for %WORKSPACE%
+
+:: change current directory to that drive
+!use_drive!
+
+:: Since we are using the system jruby, we need to make sure our jvm process
+:: uses at least 1g of memory, If we don't do this we can get OOM issues when
+:: installing gems. See https://github.com/elastic/logstash/issues/5179
+
+set JRUBY_OPTS="-J-Xmx1g"
+set SELECTEDTESTSUITE=%1
+set /p JRUBYVERSION=<.ruby-version
+
+if "%JRUBYSRCDIR%" == "" (
+  echo Error: environment variable JRUBYSRCDIR must be defined. Aborting..
   exit /B 1
 )
 
-SET RAKEPATH=%JRUBYPATH%\bin\rake
+if not exist %JRUBYSRCDIR% (
+  echo Error: variable JRUBYSRCDIR must be declared with a valid directory. Aborting..
+  exit /B 1
+)
 
-IF "%SELECTEDTESTSUITE%"=="core-fail-fast" (
-  echo "Running core-fail-fast tests"
-  %RAKEPATH% test:install-core
-  %RAKEPATH% test:core-fail-fast
-) ELSE (
-  echo "Running core tests"
-  %RAKEPATH% test:install-core
-  %RAKEPATH% test:core
+set JRUBYPATH=%JRUBYSRCDIR%\%JRUBYVERSION%
+
+if not exist %JRUBYPATH% (
+  echo Error: could not find JRuby in %JRUBYPATH%. Aborting..
+  exit /B 1
+)
+
+set RAKEPATH=%JRUBYPATH%\bin\rake
+
+echo Installing core plugins..
+call %RAKEPATH% test:install-core
+if errorlevel 1 (
+  echo Error: failed to install core plugins. Aborting..
+  exit /B 1
+)
+
+if "%SELECTEDTESTSUITE%" == "core-fail-fast" (
+  echo Running core-fail-fast tests..
+  call %RAKEPATH% test:core-fail-fast
+) else (
+  echo Running core tests..
+  call %RAKEPATH% test:core
+)
+if errorlevel 1 (
+  echo Error: failed to run core tests. Aborting..
+  exit /B 1
 )


### PR DESCRIPTION
Try to assign a drive letter to the `WORKSPACE` env var to shorten the current path to avoid hitting the 260 chars limits in Windows.

Strategy:
- first loop through the list of `subst` drives to see if `WORKSPACE` was already assigned to a drive and reuse it
- otherwise try to `subst` the first free drive letter to `WORKSPACE`

The idea is to avoid just assigning new drive letters blindly since this is a long-running server. The number of used drive letters will top at the number of unique `WORKSPACE` paths which shoud avoid depletion. 

Relates to #7767 