### PR TITLE
Added links to X-Pack release notes

### DIFF
--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -1,7 +1,13 @@
 [[breaking-changes]]
-== Breaking changes
+== Breaking Changes
 
 This section discusses the changes that you need to be aware of when migrating to Logstash 6.0.0 from the previous major releases.
+
+ifdef::include-xpack[]
+See also:
+
+* <<breaking-changes-xls>>
+endif::include-xpack[]
 
 [float]
 === Changes in Logstash Core
@@ -12,18 +18,18 @@ These changes can impact any instance of Logstash and are plugin agnostic, but o
 ==== Application Settings
 
 * The setting `config.reload.interval` has been changed to use time value strings such as `5m`, `10s` etc.
-  Previously, users had to convert this to a millisecond time value themselves. 
+  Previously, users had to convert this to a millisecond time value themselves.
 
 [float]
 ==== RPM/Deb package changes
 
-* For `rpm` and `deb` release artifacts, config files that match the `*.conf` glob pattern must be in the conf.d folder, 
+* For `rpm` and `deb` release artifacts, config files that match the `*.conf` glob pattern must be in the conf.d folder,
   or the files will not be loaded.
-  
+
 [float]
 ==== Command Line Interface behavior
 
-* The `-e` and `-f` CLI options are now mutually exclusive. This also applies to the corresponding long form options `config.string` and 
+* The `-e` and `-f` CLI options are now mutually exclusive. This also applies to the corresponding long form options `config.string` and
   `path.config`. This means any configurations  provided via `-e` will no longer be appended to the configurations provided via `-f`.
 * Configurations provided with `-f` or `config.path` will not be appended with `stdin` input and `stdout` output automatically.
 

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -8,7 +8,10 @@ This section summarizes the changes in the following releases:
 * <<logstash-6-0-0-beta1,Logstash 6.0.0-beta1>>
 * <<logstash-6-0-0-alpha2,Logstash 6.0.0-alpha2>>
 * <<logstash-6-0-0-alpha1,Logstash 6.0.0-alpha1>>
+
 ifdef::include-xpack[]
+See also:
+
 * <<release-notes-xls>>
 endif::include-xpack[]
 


### PR DESCRIPTION
This pull request adds links to the corresponding X-Pack information from the Logstash "Breaking Changes" and "Release Notes" sections. 