### PR TITLE
Version bump to 6.0.0-rc2

### DIFF
--- a/Gemfile.jruby-2.3.lock.release
+++ b/Gemfile.jruby-2.3.lock.release
@@ -1,7 +1,7 @@
 PATH
   remote: ./logstash-core
   specs:
-    logstash-core (6.0.0.rc1-java)
+    logstash-core (6.0.0.rc2-java)
       chronic_duration (= 0.10.6)
       clamp (~> 0.6.5)
       concurrent-ruby (~> 1.0, >= 1.0.5)
@@ -10,7 +10,7 @@ PATH
       gems (~> 0.8.3)
       i18n (= 0.6.9)
       jar-dependencies
-      jrjackson (~> 0.4.2)
+      jrjackson (~> 0.4.3)
       jruby-openssl (>= 0.9.20)
       manticore (>= 0.5.4, < 1.0.0)
       minitar (~> 0.5.4)
@@ -28,7 +28,7 @@ PATH
   remote: ./logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 6.0.0.rc1)
+      logstash-core (= 6.0.0.rc2)
 
 GEM
   remote: https://rubygems.org/
@@ -55,7 +55,7 @@ GEM
     buftok (0.2.0)
     builder (3.2.3)
     cabin (0.9.0)
-    childprocess (0.7.1)
+    childprocess (0.8.0)
       ffi (~> 1.0, >= 1.0.11)
     chronic_duration (0.10.6)
       numerizer (~> 0.1.1)
@@ -121,8 +121,10 @@ GEM
     jar-dependencies (0.3.11)
     jls-grok (0.11.4)
       cabin (>= 0.6.0)
+    jls-lumberjack (0.0.26)
+      concurrent-ruby
     jmespath (1.3.1)
-    jrjackson (0.4.2-java)
+    jrjackson (0.4.3-java)
     jruby-openssl (0.9.21-java)
     jruby-stdin-channel (0.2.0-java)
     json (1.8.6-java)
@@ -165,7 +167,7 @@ GEM
       jls-grok (~> 0.11.1)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-patterns-core
-    logstash-codec-netflow (3.5.2)
+    logstash-codec-netflow (3.7.0)
       bindata (>= 1.5.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-codec-plain (3.0.4)
@@ -184,6 +186,11 @@ GEM
       rspec (~> 3.0)
       rspec-wait
       stud (>= 0.0.20)
+    logstash-filter-aggregate (2.6.3)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-anonymize (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      murmurhash3
     logstash-filter-cidr (3.1.1-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-clone (3.0.4)
@@ -192,6 +199,8 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-date (3.1.8)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-de_dot (1.0.2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-dissect (1.0.12)
       jar-dependencies
       logstash-core-plugin-api (>= 2.1.1, <= 2.99)
@@ -199,6 +208,9 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       lru_redux (~> 1.1.0)
     logstash-filter-drop (3.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-elasticsearch (3.1.6)
+      elasticsearch (>= 5.0.3, < 6.0.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-fingerprint (3.1.1)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -210,6 +222,10 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-patterns-core
       stud (~> 0.0.22)
+    logstash-filter-jdbc_streaming (1.0.2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      lru_redux
+      sequel
     logstash-filter-json (3.0.4)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-kv (4.0.2)
@@ -235,6 +251,8 @@ GEM
       thread_safe
     logstash-filter-translate (3.0.3)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-truncate (1.0.3)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-urldecode (3.0.5)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-useragent (3.2.1-java)
@@ -250,10 +268,10 @@ GEM
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       thread_safe (~> 0.3.5)
-    logstash-input-dead_letter_queue (1.1.0)
+    logstash-input-dead_letter_queue (1.1.1)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-input-elasticsearch (4.0.5)
+    logstash-input-elasticsearch (4.0.6)
       elasticsearch (>= 5.0.3, < 6.0.0)
       logstash-codec-json
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -292,7 +310,7 @@ GEM
       puma (~> 2.16, >= 2.16.0)
       rack (~> 1)
       stud
-    logstash-input-http_poller (4.0.2)
+    logstash-input-http_poller (4.0.3)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-http_client (>= 6.0.0, < 7.0.0)
@@ -393,11 +411,15 @@ GEM
       logstash-filter-json
       logstash-input-generator
       logstash-output-file
-    logstash-output-elasticsearch (8.1.1-java)
+    logstash-output-elasticsearch (9.0.0-java)
       cabin (~> 0.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       manticore (>= 0.5.4, < 1.0.0)
       stud (~> 0.0, >= 0.0.17)
+    logstash-output-email (4.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      mail (~> 2.6.3)
+      mime-types (< 3)
     logstash-output-file (4.1.1)
       logstash-codec-json_lines
       logstash-codec-line
@@ -411,6 +433,10 @@ GEM
       logstash-codec-json
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-lumberjack (3.1.5)
+      jls-lumberjack (>= 0.0.26)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud
     logstash-output-nagios (3.0.4)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -423,14 +449,14 @@ GEM
     logstash-output-pipe (3.0.4)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-output-rabbitmq (5.0.1-java)
+    logstash-output-rabbitmq (5.0.2-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-rabbitmq_connection (>= 5.0.0, < 6.0.0)
     logstash-output-redis (4.0.2)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       redis (~> 3)
       stud
-    logstash-output-s3 (4.0.10)
+    logstash-output-s3 (4.0.11)
       concurrent-ruby
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-aws
@@ -478,7 +504,7 @@ GEM
     murmurhash3 (0.1.6-java)
     mustache (0.99.8)
     naught (1.1.0)
-    nokogiri (1.8.0-java)
+    nokogiri (1.8.1-java)
     numerizer (0.1.1)
     octokit (3.8.0)
       sawyer (~> 0.6.0, >= 0.5.3)
@@ -504,7 +530,7 @@ GEM
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
     rake (12.1.0)
-    redis (3.3.3)
+    redis (3.3.5)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
       rspec-expectations (~> 3.6.0)
@@ -523,6 +549,7 @@ GEM
     ruby-maven (3.3.12)
       ruby-maven-libs (~> 3.3.9)
     ruby-maven-libs (3.3.9)
+    ruby-progressbar (1.8.3)
     rubyzip (1.2.1)
     rufus-scheduler (3.0.9)
       tzinfo
@@ -608,16 +635,21 @@ DEPENDENCIES
   logstash-core!
   logstash-core-plugin-api!
   logstash-devutils
+  logstash-filter-aggregate
+  logstash-filter-anonymize
   logstash-filter-cidr
   logstash-filter-clone
   logstash-filter-csv
   logstash-filter-date
+  logstash-filter-de_dot
   logstash-filter-dissect
   logstash-filter-dns
   logstash-filter-drop
+  logstash-filter-elasticsearch
   logstash-filter-fingerprint
   logstash-filter-geoip
   logstash-filter-grok
+  logstash-filter-jdbc_streaming
   logstash-filter-json
   logstash-filter-kv
   logstash-filter-metrics
@@ -628,6 +660,7 @@ DEPENDENCIES
   logstash-filter-syslog_pri
   logstash-filter-throttle
   logstash-filter-translate
+  logstash-filter-truncate
   logstash-filter-urldecode
   logstash-filter-useragent
   logstash-filter-xml
@@ -661,10 +694,12 @@ DEPENDENCIES
   logstash-output-cloudwatch
   logstash-output-csv
   logstash-output-elasticsearch
+  logstash-output-email
   logstash-output-file
   logstash-output-graphite
   logstash-output-http
   logstash-output-kafka
+  logstash-output-lumberjack
   logstash-output-nagios
   logstash-output-null
   logstash-output-pagerduty
@@ -683,7 +718,7 @@ DEPENDENCIES
   pleaserun (~> 0.0.28)
   rack-test
   rspec (~> 3.5)
-  ruby-progressbar (~> 1.8.3)
+  ruby-progressbar (~> 1.8.1)
   rubyzip (~> 1.2.1)
   simplecov
   stud (~> 0.0.22)

--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -34,6 +34,17 @@ These changes can impact any instance of Logstash and are plugin agnostic, but o
 * Configurations provided with `-f` or `config.path` will not be appended with `stdin` input and `stdout` output automatically.
 
 [float]
+
+==== Elasticsearch output changes
+
+* The default `document_type` used has changed from `logs` to `doc`. 
+  Furthermore, users are advised that Elasticsearch 6.0 deprecates doctypes, and 7.0 will remove them. 
+  See https://www.elastic.co/guide/en/elasticsearch/reference/master/removal-of-types.html[Removal of Mapping Types] for more info.
+* The options `:flush_size; `:idle_flush_time` are obsolete and may no longer be used
+* Please note that the https://www.elastic.co/guide/en/elasticsearch/reference/6.0/mapping-all-field.html[_all] field is deprecated in 6.0.
+  The new mapping template has been updated to reflect that. If you are using a custom mapping template you may need to update it to reflect that.
+
+[float]
 ==== List of plugins bundled with Logstash
 
 The following plugins were removed from the 5.0 default bundle based on usage data. You can still install these plugins manually:

--- a/logstash-core-plugin-api/logstash-core-plugin-api.gemspec
+++ b/logstash-core-plugin-api/logstash-core-plugin-api.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = LOGSTASH_CORE_PLUGIN_API
 
-  gem.add_runtime_dependency "logstash-core", "6.0.0.rc1"
+  gem.add_runtime_dependency "logstash-core", "6.0.0.rc2"
 
   # Make sure we dont build this gem from a non jruby
   # environment.

--- a/logstash-core/lib/logstash-core_jars.rb
+++ b/logstash-core/lib/logstash-core_jars.rb
@@ -8,7 +8,7 @@ rescue LoadError
   require 'org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar'
   require 'com/fasterxml/jackson/core/jackson-annotations/2.9.1/jackson-annotations-2.9.1.jar'
   require 'org/apache/logging/log4j/log4j-slf4j-impl/2.6.2/log4j-slf4j-impl-2.6.2.jar'
-  require 'com/fasterxml/jackson/module/jackson-module-afterburner/2.7.3/jackson-module-afterburner-2.9.1.jar'
+  require 'com/fasterxml/jackson/module/jackson-module-afterburner/2.9.1/jackson-module-afterburner-2.9.1.jar'
   require 'com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.9.1/jackson-dataformat-cbor-2.9.1.jar'
   require 'com/fasterxml/jackson/core/jackson-core/2.9.1/jackson-core-2.9.1.jar'
 end

--- a/versions.yml
+++ b/versions.yml
@@ -1,6 +1,6 @@
 ---
-logstash: 6.0.0-rc1
-logstash-core: 6.0.0-rc1
+logstash: 6.0.0-rc2
+logstash-core: 6.0.0-rc2
 logstash-core-plugin-api: 2.1.16
 jruby:
   version: 9.1.13.0


### PR DESCRIPTION
This also updates the breaking changes for the ES output since this bump updates that as well.