### PR TITLE
PERFORMANCE[30%+ improvement!]: filter_func can optionally take an array of events to make batched filters much faster

### DIFF
--- a/logstash-core/lib/logstash/config/config_ast.rb
+++ b/logstash-core/lib/logstash/config/config_ast.rb
@@ -77,7 +77,7 @@ module LogStash; module Config; module AST
         # of the output/filter function
         definitions << "define_singleton_method :#{type}_func do |event|"
         definitions << "  targeted_outputs = []" if type == "output"
-        definitions << "  events = [event]" if type == "filter"
+        definitions << "  events = event" if type == "filter"
         definitions << "  @logger.debug? && @logger.debug(\"#{type} received\", \"event\" => event.to_hash)"
 
         sections.select { |s| s.plugin_type.text_value == type }.each do |s|

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -495,11 +495,9 @@ module LogStash; class Pipeline < BasePipeline
   end
 
   def filter_batch(batch)
-    batch.each do |event|
-      filter_func(event).each do |e|
-        #these are both original and generated events
-        batch.merge(e) unless e.cancelled?
-      end
+    filter_func(batch.to_a).each do |e|
+      #these are both original and generated events
+      batch.merge(e) unless e.cancelled?
     end
     @filter_queue_client.add_filtered_metrics(batch)
     @events_filtered.increment(batch.size)
@@ -652,7 +650,7 @@ module LogStash; class Pipeline < BasePipeline
   def filter(event, &block)
     maybe_setup_out_plugins
     # filter_func returns all filtered events, including cancelled ones
-    filter_func(event).each {|e| block.call(e)}
+    filter_func([event]).each {|e| block.call(e)}
   end
 
   # perform filters flush and yield flushed event to the passed block

--- a/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
@@ -285,6 +285,12 @@ module LogStash; module Util
         # @cancelled[event] = true
       end
 
+      def to_a
+        events = []
+        each {|e| events << e}
+        events
+      end
+
       def each(&blk)
         # take care not to cause @originals or @generated to change during iteration
 

--- a/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
@@ -204,6 +204,12 @@ module LogStash; module Util
         # @cancelled[event] = true
       end
 
+      def to_a
+        events = []
+        each {|e| events << e}
+        events
+      end
+
       def each(&blk)
         # take care not to cause @originals or @generated to change during iteration
         @is_iterating = true

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -618,9 +618,9 @@ describe LogStash::Pipeline do
 
     it "should handle evaluating different config" do
       expect(pipeline1.output_func(LogStash::Event.new)).not_to include(nil)
-      expect(pipeline1.filter_func(LogStash::Event.new)).not_to include(nil)
+      expect(pipeline1.filter_func([LogStash::Event.new])).not_to include(nil)
       expect(pipeline2.output_func(LogStash::Event.new)).not_to include(nil)
-      expect(pipeline1.filter_func(LogStash::Event.new)).not_to include(nil)
+      expect(pipeline1.filter_func([LogStash::Event.new])).not_to include(nil)
     end
   end
 
@@ -700,9 +700,9 @@ describe LogStash::Pipeline do
       # in the current instance and was returning an array containing nil values for
       # the match.
       expect(pipeline1.output_func(LogStash::Event.new)).not_to include(nil)
-      expect(pipeline1.filter_func(LogStash::Event.new)).not_to include(nil)
+      expect(pipeline1.filter_func([LogStash::Event.new])).not_to include(nil)
       expect(pipeline2.output_func(LogStash::Event.new)).not_to include(nil)
-      expect(pipeline1.filter_func(LogStash::Event.new)).not_to include(nil)
+      expect(pipeline1.filter_func([LogStash::Event.new])).not_to include(nil)
     end
   end
 


### PR DESCRIPTION
This one is kinda frustrating when seen in relation to #8357 :( but a huge and trivial performance gain :)
Just thought I'd level the playing field a little when comparing Java and Ruby exec and well this is the result.

Simply fixing the batched filter execution in the Ruby execution gets us within to about 90% (I can add more scientific numbers tomorrow or so, but it's basically this for the Apache example: master **35k/s**, this **50k/s** and the full Java exec **56k/s** ) of the throughput of the pure java exec in #8357.
For baseline (and simple filters like only UA filter) this version wins over `master` and the Java exec by a wide margin. Here it's `master` and Java exec both at **~300k/s** and this one at **~380k/s**. 

To better understand this one, take a look at a compiled `filter_func`:

example:
```rb
  define_singleton_method :filter_func do |event|
    events = [event]
    @logger.debug? && @logger.debug("filter received", "event" => event.to_hash)
              events = @generated_objects[:filter_dlq_commit_2].multi_filter(events)

    events
  end
```

=> there is no point turning the events into arrays one by one if we can simply turn the batch into an array and input that.
=> trivial fix by allowing `Array` to be passed through `filter_func` and adding the `to_a` method from #8357 to the batch implementations