### PR TITLE
WIP: Write Segments + their Hash Atomically

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReader.java
@@ -53,7 +53,7 @@ public final class DeadLetterQueueReader implements Closeable {
         this.queuePath.register(
             watchService, new WatchEvent.Kind[]{
                 StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE
-            }, 
+            },
             SensitivityWatchEventModifier.HIGH
         );
         this.segments = new ConcurrentSkipListSet<>(Comparator.comparing(
@@ -87,14 +87,10 @@ public final class DeadLetterQueueReader implements Closeable {
             .filter(Boolean::booleanValue).count() == 0L) {
             WatchKey key = watchService.poll(timeout, TimeUnit.MILLISECONDS);
             if (key != null) {
-                for (WatchEvent<?> watchEvent : key.pollEvents()) {
-                    if (watchEvent.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
-                        getSegmentPaths(queuePath).forEach(segments::add);
-                        break;
-                    }
-                }
+                key.pollEvents();
                 key.reset();
             }
+            getSegmentPaths(queuePath).forEach(segments::add);
         }
         return System.currentTimeMillis() - startTime;
     }

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReader.java
@@ -82,7 +82,7 @@ public final class DeadLetterQueueReader implements Closeable {
 
     private long pollNewSegments(long timeout) throws IOException, InterruptedException {
         long startTime = System.currentTimeMillis();
-        //We have to actually count on the stream to add all new segments
+        // We have to actually count on the stream to add all new segments
         if (getSegmentPaths(queuePath).map(segments::add)
             .filter(Boolean::booleanValue).count() == 0L) {
             WatchKey key = watchService.poll(timeout, TimeUnit.MILLISECONDS);

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -18,15 +18,6 @@
  */
 package org.logstash.common.io;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.logstash.DLQEntry;
-import org.logstash.Event;
-import org.logstash.FieldReference;
-import org.logstash.FileLockFactory;
-import org.logstash.PathCache;
-import org.logstash.Timestamp;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.channels.FileLock;
@@ -35,7 +26,16 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.logstash.DLQEntry;
+import org.logstash.Event;
+import org.logstash.FieldReference;
+import org.logstash.FileLockFactory;
+import org.logstash.PathCache;
+import org.logstash.Timestamp;
 
 import static org.logstash.common.io.RecordIOWriter.RECORD_HEADER_SIZE;
 
@@ -102,7 +102,10 @@ public final class DeadLetterQueueWriter implements Closeable {
     }
 
     static Stream<Path> getSegmentPaths(Path path) throws IOException {
-        return Files.list(path).filter((p) -> p.toString().endsWith(".log"));
+        try(final Stream<Path> files = Files.list(path)) {
+            return files.filter(p -> p.toString().endsWith(".log"))
+                .collect(Collectors.toList()).stream();
+        }
     }
 
     public synchronized void writeEntry(DLQEntry entry) throws IOException {

--- a/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
@@ -165,7 +165,7 @@ public final class RecordIOReader implements Closeable {
              return -1;
          }
          while (true) {
-             RecordType type = RecordType.fromByte(currentBlock.array()[currentBlock.arrayOffset() + currentBlock.position()]);
+             RecordType type = RecordType.fromByte(currentBlock.get(currentBlock.position()));
              if (RecordType.COMPLETE.equals(type) || RecordType.START.equals(type)) {
                  return currentBlock.position();
              } else if (RecordType.END.equals(type)) {

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
@@ -19,6 +19,13 @@
 
 package org.logstash.common.io;
 
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -26,13 +33,6 @@ import org.junit.rules.TemporaryFolder;
 import org.logstash.DLQEntry;
 import org.logstash.Event;
 import org.logstash.LockException;
-
-import java.io.IOException;
-import java.nio.channels.FileChannel;
-import java.nio.channels.OverlappingFileLockException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 
 import static junit.framework.TestCase.assertFalse;
 import static org.hamcrest.CoreMatchers.is;
@@ -144,9 +144,9 @@ public class DeadLetterQueueWriterTest {
     }
 
     private long dlqLength() throws IOException {
-        return Files.list(dir)
-                .filter(p -> p.toString().endsWith(".log"))
-                .mapToLong(p -> p.toFile().length())
-                .sum();
+        try(final Stream<Path> files = Files.list(dir)) {
+            return files.filter(p -> p.toString().endsWith(".log"))
+                .mapToLong(p -> p.toFile().length()).sum();
+        }
     }
 }


### PR DESCRIPTION
For #8142 good mix of issues here:

* A segment + its accompanying hash must be written atomically
   * Also made the CRC32 reusable here and not (only) for performance reasons: It's just a nice double check to do it this way, if we get a broken CRC32 written, we instantly know it's aconcurrency issue now with the writer ... ignoring HW problems
   * I would suggest to keep going in another issue here btw. and make these writes atomic per event + speed this up some more. I already fixed at least `writeRecordHeader` but there is many spots like this, making it take ~10s to write 3k events which makes tests take forever + is likely a real issue in production, putting a lot of load on things once the DLQ kicks in.
* The DLQ reader was actually polling for segments when reaching the last segment, before trying to simply get a list of files without the event triggers (note that there are no hard guarantees on the `WatchService` on all filesystems/OS, if you are unlucky and miss the event for a file creating this will break tests by missing the last file) in `org.logstash.common.io.DeadLetterQueueReader#pollEntryBytes(long)`. This caused `org.logstash.common.io.DeadLetterQueueReaderTest#testReadFromTwoSegments` to take more than `10s`, after this fix it only takes `~0.5s`
* Last but not least: `Files.list(path)` returns a `Stream<Path>` that needs to be closed as it has an underlying fd on the DLQ directory. Example `lsof -p` output without this fix:

```sh
java    37798 brownbear  138r    DIR               1,4        68 43494065 /private/var/folders/fq/hx0pm7gd5d91p9lkgj11fvtr0000gn/T/junit6972758946827880057/junit5980346763334154665
java    37798 brownbear  139r    DIR               1,4        68 43494065 /private/var/folders/fq/hx0pm7gd5d91p9lkgj11fvtr0000gn/T/junit6972758946827880057/junit5980346763334154665
java    37798 brownbear  140r    DIR               1,4        68 43494065 /private/var/folders/fq/hx0pm7gd5d91p9lkgj11fvtr0000gn/T/junit6972758946827880057/junit5980346763334154665
java    37798 brownbear  141r    DIR               1,4        68 43494065 /private/var/folders/fq/hx0pm7gd5d91p9lkgj11fvtr0000gn/T/junit6972758946827880057/junit5980346763334154665
java    37798 brownbear  142r    DIR               1,4        68 43494065 /private/var/folders/fq/hx0pm7gd5d91p9lkgj11fvtr0000gn/T/junit6972758946827880057/junit5980346763334154665
java    37798 brownbear  143r    DIR               1,4        68 43494065 /private/var/folders/fq/hx0pm7gd5d91p9lkgj11fvtr0000gn/T/junit6972758946827880057/junit5980346763334154665
java    37798 brownbear  144r    DIR               1,4        68 43494065 /private/var/folders/fq/hx0pm7gd5d91p9lkgj11fvtr0000gn/T/junit6972758946827880057/junit5980346763334154665
java    37798 brownbear  145r    DIR               1,4        68 43494065 /private/var/folders/fq/hx0pm7gd5d91p9lkgj11fvtr0000gn/T/junit6972758946827880057/junit5980346763334154665
java    37798 brownbear  146r    DIR               1,4        68 43494065 /private/var/folders/fq/hx0pm7gd5d91p9lkgj11fvtr0000gn/T/junit6972758946827880057/junit5980346763334154665
java    37798 brownbear  147r    DIR               1,4        68 43494065 /private/var/folders/fq/hx0pm7gd5d91p9lkgj11fvtr0000gn/T/junit6972758946827880057/junit5980346763334154665
java    37798 brownbear  148r    DIR               1,4        68 43494065 /private/var/folders/fq/hx0pm7gd5d91p9lkgj11fvtr0000gn/T/junit6972758946827880057/junit5980346763334154665
java    37798 brownbear  149r    DIR               1,4        68 43494065 /private/var/folders/fq/hx0pm7gd5d91p9lkgj11fvtr0000gn/T/junit6972758946827880057/junit5980346763334154665
java    37798 brownbear  150r    DIR               1,4        68 43494065 /private/var/folders/fq/hx0pm7gd5d91p9lkgj11fvtr0000gn/T/junit6972758946827880057/junit5980346763334154665
java    37798 brownbear  151r    DIR               1,4        68 43494065 /private/var/folders/fq/hx0pm7gd5d91p9lkgj11fvtr0000gn/T/junit6972758946827880057/junit5980346763334154665
java    37798 brownbear  152r    DIR               1,4        68 43494065 /private/var/folders/fq/hx0pm7gd5d91p9lkgj11fvtr0000gn/T/junit6972758946827880057/junit5980346763334154665
java    37798 brownbear  153r    DIR               1,4        68 43494065 /private/var/folders/fq/hx0pm7gd5d91p9lkgj11fvtr0000gn/T/junit6972758946827880057/junit5980346763334154665
java    37798 brownbear  154r    DIR               1,4        68 43494065 /private/var/folders/fq/hx0pm7gd5d91p9lkgj11fvtr0000gn/T/junit6972758946827880057/junit5980346763334154665
java    37798 brownbear  155r    DIR               1,4        68 43494065 /private/var/folders/fq/hx0pm7gd5d91p9lkgj11fvtr0000gn/T/junit6972758946827880057/junit5980346763334154665
java    37798 brownbear  156r    DIR               1,4        68 43494065 /private/var/folders/fq/hx0pm7gd5d91p9lkgj11fvtr0000gn/T/junit6972758946827880057/junit5980346763334154665
java    37798 brownbear  157r    DIR               1,4        68 43494065 /private/var/folders/fq/hx0pm7gd5d91p9lkgj11fvtr0000gn/T/junit6972758946827880057/junit5980346763334154665
```
(this causes a major slowdown and outright crashes by running out of FDs in continuous operation eventually, breaking the DLQ in general imo)