### PR TITLE
MINOR(+PERFORMANCE): Cleanup Constructor of WrappedSynchronousQueue::ReadBatch

### DIFF
--- a/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
@@ -156,17 +156,12 @@ module LogStash; module Util
 
     class ReadBatch
       def initialize(queue, size, wait)
-        @queue = queue.queue
-        @size = size
-        @wait = wait
-
         # TODO: disabled for https://github.com/elastic/logstash/issues/6055 - will have to properly refactor
         # @cancelled = Hash.new
 
         #Sizing HashSet to size/load_factor to ensure no rehashing
         @is_iterating = false # Atomic Boolean maybe? Although batches are not shared across threads
-        @acked_batch = nil
-        @originals = LsQueueUtils.drain(@queue, @size, @wait)
+        @originals = LsQueueUtils.drain(queue.queue, size, wait)
       end
 
       def merge(event)


### PR DESCRIPTION
Not much to say here, never really noticed this, but all these fields are pointless since they're never referenced in any instance methods.
=> remove them
... also makes this constructor that is somewhat hot compile smaller (not a big gain obviously but still a win in principle :D) 