### PR TITLE
fix a few issues with proxy handling when installing plugins

### DIFF
--- a/lib/bootstrap/patches/remote_fetcher.rb
+++ b/lib/bootstrap/patches/remote_fetcher.rb
@@ -1,0 +1,23 @@
+require 'rubygems/remote_fetcher' 
+
+class Gem::RemoteFetcher
+  def api_endpoint(uri)
+    host = uri.host
+
+    begin
+      res = @dns.getresource "_rubygems._tcp.#{host}",
+                             Resolv::DNS::Resource::IN::SRV
+    rescue Resolv::ResolvError, SocketError => e # patch adds SocketError to list of possible exceptions
+      verbose "Getting SRV record failed: #{e}"
+      uri
+    else
+      target = res.target.to_s.strip
+
+      if /\.#{Regexp.quote(host)}\z/ =~ target
+        return URI.parse "#{uri.scheme}://#{target}#{uri.path}"
+      end
+
+      uri
+    end
+  end
+end

--- a/lib/pluginmanager/util.rb
+++ b/lib/pluginmanager/util.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require "rubygems/package"
+require_relative "../bootstrap/patches/remote_fetcher"
 
 module LogStash::PluginManager
 

--- a/lib/pluginmanager/utils/http_client.rb
+++ b/lib/pluginmanager/utils/http_client.rb
@@ -6,11 +6,12 @@ module LogStash module PluginManager module Utils
     HTTPS_SCHEME = "https"
     REDIRECTION_LIMIT = 5
 
-    # Proxies should be handled by the library
-    # https://ruby-doc.org/stdlib-2.3.1/libdoc/net/http/rdoc/Net/HTTP.html#class-Net::HTTP-label-Proxies
     def self.start(uri)
       uri = URI(uri)
-      Net::HTTP.start(uri.host, uri.port, http_options(uri)) { |http| yield http }
+      proxy_url = ENV["https_proxy"] || ENV["HTTPS_PROXY"] || ""
+      proxy_uri = URI(proxy_url)
+
+      Net::HTTP.start(uri.host, uri.port, proxy_uri.host, proxy_uri.port, proxy_uri.user, proxy_uri.password, http_options(uri)) { |http| yield http }
     end
 
     def self.http_options(uri)


### PR DESCRIPTION
* allow installing a plugin using proxy without having to use the `--no-verify` flag
* allow the use of proxies that have basic authentication

fixes #8421