### PR TITLE
BUG: DLQ FD leak in org.logstash.common.io.DeadLetterQueueWriter#getSegmentPaths fixed

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -18,15 +18,6 @@
  */
 package org.logstash.common.io;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.logstash.DLQEntry;
-import org.logstash.Event;
-import org.logstash.FieldReference;
-import org.logstash.FileLockFactory;
-import org.logstash.PathCache;
-import org.logstash.Timestamp;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.channels.FileLock;
@@ -35,7 +26,16 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.logstash.DLQEntry;
+import org.logstash.Event;
+import org.logstash.FieldReference;
+import org.logstash.FileLockFactory;
+import org.logstash.PathCache;
+import org.logstash.Timestamp;
 
 import static org.logstash.common.io.RecordIOWriter.RECORD_HEADER_SIZE;
 
@@ -102,7 +102,10 @@ public final class DeadLetterQueueWriter implements Closeable {
     }
 
     static Stream<Path> getSegmentPaths(Path path) throws IOException {
-        return Files.list(path).filter((p) -> p.toString().endsWith(".log"));
+        try(final Stream<Path> files = Files.list(path)) {
+            return files.filter(p -> p.toString().endsWith(".log"))
+                .collect(Collectors.toList()).stream();
+        }
     }
 
     public synchronized void writeEntry(DLQEntry entry) throws IOException {

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
@@ -19,6 +19,13 @@
 
 package org.logstash.common.io;
 
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -26,13 +33,6 @@ import org.junit.rules.TemporaryFolder;
 import org.logstash.DLQEntry;
 import org.logstash.Event;
 import org.logstash.LockException;
-
-import java.io.IOException;
-import java.nio.channels.FileChannel;
-import java.nio.channels.OverlappingFileLockException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 
 import static junit.framework.TestCase.assertFalse;
 import static org.hamcrest.CoreMatchers.is;
@@ -144,9 +144,9 @@ public class DeadLetterQueueWriterTest {
     }
 
     private long dlqLength() throws IOException {
-        return Files.list(dir)
-                .filter(p -> p.toString().endsWith(".log"))
-                .mapToLong(p -> p.toFile().length())
-                .sum();
+        try(final Stream<Path> files = Files.list(dir)) {
+            return files.filter(p -> p.toString().endsWith(".log"))
+                .mapToLong(p -> p.toFile().length()).sum();
+        }
     }
 }


### PR DESCRIPTION
Extracted from #8432 

The stream returned by `Files.list(path)` is an `AutoClosable` that must actually be closed since it's backed by an FD on the underlying directory.
Not fixing this leads to every call to this method leaking one `DIR` type file descriptor.

This should be backported to all versions using DLQ imo since it will eventually make every DLQ reader run out of FDs.