### PR TITLE
PERFORMANCE: Simplify batch iteration

### DIFF
--- a/logstash-core/spec/logstash/util/wrapped_synchronous_queue_spec.rb
+++ b/logstash-core/spec/logstash/util/wrapped_synchronous_queue_spec.rb
@@ -100,7 +100,7 @@ describe LogStash::Util::WrappedSynchronousQueue do
           write_client.push_batch(batch)
           read_batch = read_client.read_batch
           expect(read_batch.size).to eq(5)
-          read_batch.each do |data|
+          read_batch.to_a.each do |data|
             message = data.get("message")
             expect(messages).to include(message)
             messages.delete(message)


### PR DESCRIPTION
We can get another small speedup on the batch iterations leveraging #8428:

* As a result of #8428 we don't have any more concurrent modifications on the data underlying a batch since the filters always take all the events in a single call and will only `merge` in generated events after the batch generated an array via `to_a` :) => we can save ourselves the trouble of having temporary collections for holding generated events entirely
   * note that I had to adjust one spec to use `to_a.each` instead of just `each` as a result since that spec was actually doing concurrent modifications in its test code
* For the in-memory Queue, this effectively reduces the batch to just being a `HashSet` wrapper
  * Also for the sync queue batch, we could nicely inline the each block over a `Collection` which is a little faster than custom each blocks  
* For the acked queue, we also saved one data structure but still track generated and original events separately (I think we can clean this fact up in another PR though, something is weird with the counts here since filtered_size is synonymous with size for the in-memory Queue but not for the acked queue => will add an issue for that soon)