### PR TITLE
BUG: Fix filter_func logging for config.debug=true

### DIFF
--- a/logstash-core/lib/logstash/config/config_ast.rb
+++ b/logstash-core/lib/logstash/config/config_ast.rb
@@ -78,7 +78,8 @@ module LogStash; module Config; module AST
         definitions << "define_singleton_method :#{type}_func do |event|"
         definitions << "  targeted_outputs = []" if type == "output"
         definitions << "  events = event" if type == "filter"
-        definitions << "  @logger.debug? && @logger.debug(\"#{type} received\", \"event\" => event.to_hash)"
+        definitions << "  @logger.debug? && @logger.debug(\"#{type} received\", \"event\" => event.to_hash)" if type == "output"
+        definitions << "  @logger.debug? && events.each { |e| @logger.debug(\"#{type} received\", \"event\" => e.to_hash)}" if type == "filter"
 
         sections.select { |s| s.plugin_type.text_value == type }.each do |s|
           definitions << s.compile.split("\n", -1).map { |e| "  #{e}" }

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -254,6 +254,14 @@ describe LogStash::Pipeline do
           pipeline = mock_pipeline_from_string(test_config_with_filters, pipeline_settings_obj)
           pipeline.close
         end
+
+        it "should log each filtered event if config.debug is set to true" do
+          pipeline_settings_obj.set("config.debug", true)
+          pipeline = mock_pipeline_from_string(test_config_with_filters, pipeline_settings_obj)
+          expect(logger).to receive(:debug).with(/filter received/, anything)
+          pipeline.filter_func([LogStash::Event.new])
+          pipeline.close
+        end
       end
 
       context "when there is no command line -w N set" do


### PR DESCRIPTION
Fixes this error reported by @ruflin :

```sh
logstash_1       | [2017-10-09T11:57:22,917][ERROR][logstash.pipeline        ] Exception in pipelineworker, the pipeline stopped processing new events, please check your filter configuration and restart Logstash. {:pipeline_id=>"main", "exception"=>"undefined method `to_hash' for [#<LogStash::Event:0x2122ce71>]:Array\nDid you mean?  to_h", "backtrace"=>["(eval):22:in `block in filter_func'", "/opt/logstash-7.0.0-alpha1-SNAPSHOT/logstash-core/lib/logstash/pipeline.rb:499:in `filter_batch'", "/opt/logstash-7.0.0-alpha1-SNAPSHOT/logstash-core/lib/logstash/pipeline.rb:478:in `worker_loop'", "/opt/logstash-7.0.0-alpha1-SNAPSHOT/logstash-core/lib/logstash/pipeline.rb:437:in `block in start_workers'"], :thread=>"#<Thread:0x6d57e27d sleep>"}
```

that resulted from `events` now being an `[]` for `filter` here as a result of #8428.

I know this isn't 100% perfect since we're now not logging each event before it hits the filter itself, but rather logging the whole batch before running the filter on it.
But the `multi_filter` method on `FilterDelegator` simply is what it is and works on batches instead of single events.