### PR TITLE
 #8343 return 400 on broken url

### DIFF
--- a/logstash-core/lib/logstash/api/modules/node.rb
+++ b/logstash-core/lib/logstash/api/modules/node.rb
@@ -11,13 +11,19 @@ module LogStash
         end
 
         get "/hot_threads" do
-          ignore_idle_threads = params["ignore_idle_threads"] || true
+          begin
+            ignore_idle_threads = params["ignore_idle_threads"] || true
 
-          options = { :ignore_idle_threads => as_boolean(ignore_idle_threads) }
-          options[:threads] = params["threads"].to_i if params.has_key?("threads")
+            options = {:ignore_idle_threads => as_boolean(ignore_idle_threads)}
+            options[:threads] = params["threads"].to_i if params.has_key?("threads")
 
-          as = human? ? :string : :json
-          respond_with(node.hot_threads(options), {:as => as})
+            as = human? ? :string : :json
+            respond_with(node.hot_threads(options), {:as => as})
+          rescue ArgumentError => e
+            response = respond_with({"error" => e.message})
+            status(400)
+            response
+          end
         end
 
         get "/pipelines/:id" do

--- a/logstash-core/lib/logstash/api/modules/stats.rb
+++ b/logstash-core/lib/logstash/api/modules/stats.rb
@@ -9,14 +9,20 @@ module LogStash
 
         # return hot threads information
         get "/jvm/hot_threads" do
-          top_threads_count = params["threads"] || 3
-          ignore_idle_threads = params["ignore_idle_threads"] || true
-          options = {
-            :threads => top_threads_count.to_i,
-            :ignore_idle_threads => as_boolean(ignore_idle_threads)
-          }
+          begin
+            top_threads_count = params["threads"] || 3
+            ignore_idle_threads = params["ignore_idle_threads"] || true
+            options = {
+              :threads => top_threads_count.to_i,
+              :ignore_idle_threads => as_boolean(ignore_idle_threads)
+            }
 
-          respond_with(stats_command.hot_threads(options))
+            respond_with(stats_command.hot_threads(options))
+          rescue ArgumentError => e
+            response = respond_with({"error" => e.message})
+            status(400)
+            response
+          end
         end
 
         # return hot threads information

--- a/logstash-core/spec/logstash/api/modules/node_spec.rb
+++ b/logstash-core/spec/logstash/api/modules/node_spec.rb
@@ -46,6 +46,17 @@ describe LogStash::Api::Modules::Node do
       end
     end
 
+    context "broken params in URL" do
+
+      before(:all) do
+        get "/hot_threads?human=?threads=5"
+      end
+
+      it "should return http status 400" do
+        expect(last_response.status).to eq(400)
+      end
+    end
+
     context "when asking for human output" do
       [
         "/hot_threads?human",


### PR DESCRIPTION
Fixes #8343 

The issue is the `as_boolean` method throwing `ArgumentError` and not being caught.
Fixed by covering all blocks I could find that use the method in a try-catch. 

P.S. The `respond_with` method always defaults to status 200 hence me setting the status after calling it.