### PR TITLE
PQ/DLQ Monitoring: Fix X-Pack and multi-pipeline monitoring

### DIFF
--- a/logstash-core/lib/logstash/instrument/periodic_poller/dlq.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/dlq.rb
@@ -10,10 +10,15 @@ module LogStash module Instrument module PeriodicPoller
     end
 
     def collect
-      _, pipeline = @agent.with_running_pipelines { |pipelines| pipelines.first }
-      unless pipeline.nil?
-        pipeline.collect_dlq_stats
+      pipelines = @agent.with_running_user_defined_pipelines {|pipelines| pipelines}
+      unless pipelines.nil?
+        pipelines.each {|_, pipeline|
+          unless pipeline.nil?
+            pipeline.collect_dlq_stats
+          end
+        }
       end
     end
   end
 end end end
+

--- a/logstash-core/lib/logstash/instrument/periodic_poller/pq.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/pq.rb
@@ -11,9 +11,13 @@ module LogStash module Instrument module PeriodicPoller
     end
 
     def collect
-      pipeline_id, pipeline = @agent.with_running_pipelines {|pipelines| pipelines.first }
-      unless pipeline.nil?
-        pipeline.collect_stats
+      pipelines = @agent.with_running_user_defined_pipelines {|pipelines| pipelines}
+      unless pipelines.nil?
+        pipelines.each {|_, pipeline|
+          unless pipeline.nil?
+            pipeline.collect_stats
+          end
+        }
       end
     end
   end


### PR DESCRIPTION
When X-Pack is installed an internal (hidden) pipeline named .monitoring-logstash is also running. This means that for X-Pack is there N +1 pipelines where N = user defined pipelines. The code currently only supports monitoring 1 pipeline, and it is possible that the internal pipeline gets picked up instead of the intended pipeline.

When multiple user pipelines are enabled (6.0+), the code still only supports monitoring 1 pipeline.

The change here is to ignore the system pipelines, and monitor as many user defined pipelines that may exist.

Fixes: #8382 

Note - there are no existing tests for this for, and did not add any since one of my next tasks is to move this code into Java (if possible) 