### PR TITLE
5.6 backport: PQ/DLQ Monitoring: Fix X-Pack monitoring

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -198,6 +198,16 @@ class LogStash::Agent
     end
   end
 
+  def get_running_user_defined_pipelines
+    found = @upgrade_mutex.synchronize do
+      @pipelines.select do |pipeline_id, _|
+        pipeline = @pipelines[pipeline_id]
+        pipeline.running? && !pipeline.system?
+      end
+    end
+    found
+  end
+
   def close_pipeline(id)
     pipeline = @pipelines[id]
     if pipeline

--- a/logstash-core/lib/logstash/instrument/periodic_poller/dlq.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/dlq.rb
@@ -10,10 +10,15 @@ module LogStash module Instrument module PeriodicPoller
     end
 
     def collect
-      _, pipeline = @agent.running_pipelines.first
-      unless pipeline.nil?
-        pipeline.collect_dlq_stats
+      pipelines = @agent.get_running_user_defined_pipelines
+      unless pipelines.nil?
+        pipelines.each {|_, pipeline|
+          unless pipeline.nil?
+            pipeline.collect_dlq_stats
+          end
+        }
       end
     end
   end
 end end end
+

--- a/logstash-core/lib/logstash/instrument/periodic_poller/pq.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/pq.rb
@@ -11,9 +11,13 @@ module LogStash module Instrument module PeriodicPoller
     end
 
     def collect
-      pipeline_id, pipeline = @agent.running_pipelines.first
-      unless pipeline.nil?
-        pipeline.collect_stats
+      pipelines = @agent.get_running_user_defined_pipelines
+      unless pipelines.nil?
+        pipelines.each {|_, pipeline|
+          unless pipeline.nil?
+            pipeline.collect_stats
+          end
+        }
       end
     end
   end


### PR DESCRIPTION
When X-Pack is installed an internal (hidden) pipeline named .monitoring-logstash is also running. This means that for X-Pack is there N +1 pipelines where N = user defined pipelines. The code currently only supports monitoring 1 pipeline, and it is possible that the internal pipeline gets picked up instead of the intended pipeline.

The change here is to ignore the system pipelines, and monitor as many user defined pipelines that may exist.

Fixes: #8382