### PR TITLE
Modules: Set default credentials for Kibana if es info is present

### DIFF
--- a/logstash-core/lib/logstash/config/modules_common.rb
+++ b/logstash-core/lib/logstash/config/modules_common.rb
@@ -65,6 +65,7 @@ module LogStash module Config
           pipeline_id = alt_name
           module_settings.set("pipeline.id", pipeline_id)
           LogStash::Modules::SettingsMerger.merge_cloud_settings(module_hash, module_settings)
+          LogStash::Modules::SettingsMerger.merge_kibana_auth!(module_hash)
           current_module.with_settings(module_hash)
           config_test = settings.get("config.test_and_exit")
           modul_setup = settings.get("modules_setup")

--- a/logstash-core/lib/logstash/modules/settings_merger.rb
+++ b/logstash-core/lib/logstash/modules/settings_merger.rb
@@ -54,6 +54,11 @@ module LogStash module Modules module SettingsMerger
     end
   end
 
+  def merge_kibana_auth!(module_settings)
+    module_settings["var.kibana.username"] = module_settings["var.elasticsearch.username"] if module_settings["var.kibana.username"].nil?
+    module_settings["var.kibana.password"] = module_settings["var.elasticsearch.password"] if module_settings["var.kibana.password"].nil?
+  end
+
   def format_module_settings(settings_before, settings_after)
     output = []
     output << "-------- Module Settings ---------"

--- a/logstash-core/spec/logstash/modules/settings_merger_spec.rb
+++ b/logstash-core/spec/logstash/modules/settings_merger_spec.rb
@@ -28,6 +28,36 @@ describe LogStash::Modules::SettingsMerger do
     end
   end
 
+  describe "#merge_kibana_auth" do
+
+    before do
+      described_class.merge_kibana_auth!(mod_settings)
+    end
+
+    context 'only elasticsearch username and password is set' do
+      let(:mod_settings) { {"name"=>"mod1", "var.input.tcp.port"=>2222, "var.elasticsearch.username"=>"rupert", "var.elasticsearch.password"=>"fotherington" } }
+      it "sets kibana username and password" do
+        expect(mod_settings["var.elasticsearch.username"]).to eq("rupert")
+        expect(mod_settings["var.elasticsearch.password"]).to eq("fotherington")
+        expect(mod_settings["var.kibana.username"]).to eq("rupert")
+        expect(mod_settings["var.kibana.password"]).to eq("fotherington")
+      end
+    end
+
+    context 'elasticsearch and kibana usernames and passwords are set' do
+      let(:mod_settings) { {"name"=>"mod1", "var.input.tcp.port"=>2222, "var.elasticsearch.username"=>"rupert", "var.elasticsearch.password"=>"fotherington",
+                                                               "var.kibana.username"=>"davey", "var.kibana.password"=>"stott"} }
+
+      it "keeps existing kibana username and password" do
+        expect(mod_settings["var.elasticsearch.username"]).to eq("rupert")
+        expect(mod_settings["var.elasticsearch.password"]).to eq("fotherington")
+        expect(mod_settings["var.kibana.username"]).to eq("davey")
+        expect(mod_settings["var.kibana.password"]).to eq("stott")
+      end
+    end
+
+  end
+
   describe "#merge_cloud_settings" do
     let(:cloud_id) { LogStash::Util::CloudSettingId.new("label:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRub3RhcmVhbCRpZGVudGlmaWVy") }
     let(:cloud_auth) { LogStash::Util::CloudSettingAuth.new("elastix:bigwhoppingfairytail") }


### PR DESCRIPTION
If modules configuration has elasticsearch credentials set, but not
kibana, attempt to use elasticsearch credentials for Kibana login.

Fixes #8422