### PR TITLE
MINOR: Upgrade to newest devutils

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -11,7 +11,7 @@ gem "ci_reporter_rspec", "1.0.0", :group => :development
 gem "simplecov", :group => :development
 gem "tins", "1.6", :group => :development
 gem "rspec", "~> 3.5", :group => :development
-gem "logstash-devutils", :group => :development
+gem "logstash-devutils", "= 1.3.5", :group => :development
 gem "benchmark-ips", :group => :development
 gem "octokit", "3.8.0", :group => :build
 gem "stud", "~> 0.0.22", :group => :build

--- a/qa/integration/integration_tests.gemspec
+++ b/qa/integration/integration_tests.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'manticore'
   s.add_development_dependency 'stud'
   s.add_development_dependency 'pry'
-  s.add_development_dependency 'logstash-devutils', '= 1.3.3'
+  s.add_development_dependency 'logstash-devutils', '= 1.3.5'
   s.add_development_dependency 'flores'
   s.add_development_dependency 'rubyzip'
 end


### PR DESCRIPTION
version `1.3.5` is out, let's upgrade.