### PR TITLE
[DOCS] Add data directory info to setting up logstash doc

### DIFF
--- a/docs/static/setting-up-logstash.asciidoc
+++ b/docs/static/setting-up-logstash.asciidoc
@@ -50,7 +50,7 @@ config and the logs directories so that you do not delete important data later o
   | Configuration files, including `logstash.yml` and `jvm.options`
   | `{extract.path}/config`
   | `path.settings`
-  
+
 | logs
   | Log files
   | `{extract.path}/logs`
@@ -60,6 +60,11 @@ config and the logs directories so that you do not delete important data later o
   | Local, non Ruby-Gem plugin files. Each plugin is contained in a subdirectory. Recommended for development only.
   | `{extract.path}/plugins`
   | `path.plugins`
+
+| data
+  | Data files used by logstash and its plugins for any persistent needs.
+  | `{extract.path}/data`
+  | `path.data`
 
 |=======================================================================
 
@@ -102,6 +107,11 @@ locations for the system:
   | Local, non Ruby-Gem plugin files. Each plugin is contained in a subdirectory. Recommended for development only.
   | `/usr/share/logstash/plugins`
   | `path.plugins`
+
+| data
+  | Data files used by logstash and its plugins for any persistent needs.
+  | `/var/lib/logstash`
+  | `path.data`
 
 |=======================================================================
 


### PR DESCRIPTION
Data directory info is missing in setting-up-logstash.asciidoc as reported in #8423. This fixes that.