### PR TITLE
Expand rake version:set to update README & index-shared1.asciidoc

### DIFF
--- a/rakelib/version.rake
+++ b/rakelib/version.rake
@@ -14,25 +14,25 @@ def get_versions
 end
 
 # Update the version file, keeping the comments in tact
-def update_version_file(hash, existing_versions)
+def update_version_file(old_version, new_version)
   versions_as_text = IO.read(VERSION_FILE)
   %w(logstash logstash-core logstash-core-plugin-api).each do |field|
-    versions_as_text.gsub!(/(?<=#{field}: )#{existing_versions[field]}/, "#{hash[field]}")
+    versions_as_text.gsub!(/(?<=#{field}: )#{old_version[field]}/, "#{new_version[field]}")
   end
   IO.write(VERSION_FILE, versions_as_text)
 end
 
-def update_index_shared1(hash, existing_versions)
+def update_index_shared1(old_version, new_version)
   index_shared1 = IO.read(INDEX_SHARED1_FILE)
   %w(logstash elasticsearch kibana).each do |field|
-    index_shared1.gsub!(/(:#{field}_version:\s+)#{existing_versions['logstash']}/) { "#{$1}#{hash['logstash']}" }
+    index_shared1.gsub!(/(:#{field}_version:\s+)#{old_version['logstash']}/) { "#{$1}#{new_version['logstash']}" }
   end
   IO.write(INDEX_SHARED1_FILE, index_shared1)
 end
 
-def update_readme(hash, existing_versions)
+def update_readme(old_version, new_version)
   readme = IO.read(README_FILE)
-  readme.gsub!(/(logstash\-)#{existing_versions['logstash']}/) { "#{$1}#{hash['logstash']}" }
+  readme.gsub!(/(logstash\-)#{old_version['logstash']}/) { "#{$1}#{new_version['logstash']}" }
   IO.write(README_FILE, readme)
 end
 
@@ -46,21 +46,21 @@ namespace :version do
 
   desc "set version of logstash, logstash-core"
   task :set, [:version] => [:validate] do |t, args|
-    hash = {}
+    new_version = {}
     get_versions.each do |component, version|
       # we just assume that, usually, all components except
       # "logstash-core-plugin-api" will be versioned together
       # so let's skip this one and have a separate task for it
       if component == "logstash-core-plugin-api"
-        hash[component] = version
+        new_version[component] = version
       else
-        hash[component] = args[:version]
+        new_version[component] = args[:version]
       end
     end
-    existing_versions = YAML.safe_load(File.read(VERSION_FILE))
-    update_index_shared1(hash, existing_versions)
-    update_readme(hash, existing_versions)
-    update_version_file(hash, existing_versions)
+    old_version = YAML.safe_load(File.read(VERSION_FILE))
+    update_index_shared1(old_version, new_version)
+    update_readme(old_version, new_version)
+    update_version_file(old_version, new_version)
   end
 
   desc "set version of logstash-core-plugin-api"

--- a/rakelib/version.rake
+++ b/rakelib/version.rake
@@ -65,15 +65,16 @@ namespace :version do
 
   desc "set version of logstash-core-plugin-api"
   task :set_plugin_api, [:version] => [:validate] do |t, args|
-    hash = {}
+    new_version = {}
     get_versions.each do |component, version|
       if component == "logstash-core-plugin-api"
-        hash[component] = args[:version]
+        new_version[component] = args[:version]
       else
-        hash[component] = version
+        new_version[component] = version
       end
     end
-    update_version_file(hash)
+    old_version = YAML.safe_load(File.read(VERSION_FILE))
+    update_version_file(old_version, new_version)
   end
 
   task :validate, :version do |t, args|


### PR DESCRIPTION
### What

This change expands `rake version:set` to also update links in README & variables index-shared1.asciidoc.

### Why

Manual update is error-prone as pointed out in #8114.