### PR TITLE
 #8004 fix load order to start webserver after pipeline

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -83,11 +83,11 @@ class LogStash::Agent
     @thread = Thread.current # this var is implicitly used by Stud.stop?
     logger.debug("starting agent")
 
-    start_webserver
-
     transition_to_running
 
     converge_state_and_update
+
+    start_webserver
 
     if auto_reload?
       # `sleep_then_run` instead of firing the interval right away

--- a/qa/integration/specs/01_logstash_bin_smoke_spec.rb
+++ b/qa/integration/specs/01_logstash_bin_smoke_spec.rb
@@ -53,7 +53,9 @@ describe "Test Logstash instance" do
       FileUtils.mkdir_p(tmp_data_path)
       @ls1.spawn_logstash("-f", config1, "--path.data", tmp_data_path)
       sleep(0.1) until File.exist?(file_config1) && File.size(file_config1) > 0 # Everything is started successfully at this point
-      expect(is_port_open?(9600)).to be true
+      try(num_retries) do
+        expect(is_port_open?(9600)).to be(true)
+      end
 
       @ls2.spawn_logstash("-f", config2, "--path.data", tmp_data_path)
       try(num_retries) do
@@ -71,7 +73,9 @@ describe "Test Logstash instance" do
       FileUtils.mkdir_p(tmp_data_path_2)
       @ls1.spawn_logstash("-f", config1, "--path.data", tmp_data_path_1)
       sleep(0.1) until File.exist?(file_config1) && File.size(file_config1) > 0 # Everything is started successfully at this point
-      expect(is_port_open?(9600)).to be true
+      try(num_retries) do
+        expect(is_port_open?(9600)).to be(true)
+      end
 
       @ls2.spawn_logstash("-f", config2, "--path.data", tmp_data_path_2)
       sleep(0.1) until File.exist?(file_config2) && File.size(file_config2) > 0 # Everything is started successfully at this point
@@ -82,7 +86,9 @@ describe "Test Logstash instance" do
       if @ls2.settings.feature_flag != "persistent_queues"
         @ls1.spawn_logstash("-f", config1)
         sleep(0.1) until File.exist?(file_config1) && File.size(file_config1) > 0 # Everything is started successfully at this point
-        expect(is_port_open?(9600)).to be true
+        try(num_retries) do
+          expect(is_port_open?(9600)).to be(true)
+        end
 
         puts "will try to start the second LS instance on 9601"
 
@@ -92,7 +98,9 @@ describe "Test Logstash instance" do
         FileUtils.mkdir_p(tmp_data_path)
         @ls2.spawn_logstash("-f", config2, "--path.data", tmp_data_path)
         sleep(0.1) until File.exist?(file_config2) && File.size(file_config2) > 0 # Everything is started successfully at this point
-        expect(is_port_open?(9601)).to be true
+        try(num_retries) do
+          expect(is_port_open?(9601)).to be(true)
+        end
         expect(@ls1.process_id).not_to eq(@ls2.process_id)
       else
         # Make sure that each instance use a different `path.data`
@@ -104,7 +112,9 @@ describe "Test Logstash instance" do
 
         @ls1.spawn_logstash("--path.settings", path, "-f", config1)
         sleep(0.1) until File.exist?(file_config1) && File.size(file_config1) > 0 # Everything is started successfully at this point
-        expect(is_port_open?(9600)).to be true
+        try(num_retries) do
+          expect(is_port_open?(9600)).to be(true)
+        end
 
         puts "will try to start the second LS instance on 9601"
 
@@ -116,7 +126,9 @@ describe "Test Logstash instance" do
         IO.write(File.join(path, "logstash.yml"), YAML.dump(settings))
         @ls2.spawn_logstash("--path.settings", path, "-f", config2)
         sleep(0.1) until File.exist?(file_config2) && File.size(file_config2) > 0 # Everything is started successfully at this point
-        expect(is_port_open?(9601)).to be true
+        try(num_retries) do
+          expect(is_port_open?(9601)).to be(true)
+        end
 
         expect(@ls1.process_id).not_to eq(@ls2.process_id)
       end

--- a/qa/integration/specs/reload_config_spec.rb
+++ b/qa/integration/specs/reload_config_spec.rb
@@ -39,7 +39,7 @@ describe "Test Logstash service when config reload is enabled" do
     end
     
     # check metrics
-    try(num_retries) do
+    try(retry_attempts) do
       result = logstash_service.monitoring_api.event_stats
       expect(result["in"]).to eq(1)
       expect(result["out"]).to eq(1)
@@ -60,7 +60,7 @@ describe "Test Logstash service when config reload is enabled" do
     end
     
     # check instance metrics. It should not be reset
-    try(num_retries) do
+    try(retry_attempts) do
       instance_event_stats = logstash_service.monitoring_api.event_stats
       expect(instance_event_stats["in"]).to eq(2)
       expect(instance_event_stats["out"]).to eq(2)

--- a/qa/integration/specs/reload_config_spec.rb
+++ b/qa/integration/specs/reload_config_spec.rb
@@ -39,9 +39,11 @@ describe "Test Logstash service when config reload is enabled" do
     end
     
     # check metrics
-    result = logstash_service.monitoring_api.event_stats
-    expect(result["in"]).to eq(1)
-    expect(result["out"]).to eq(1)
+    try(num_retries) do
+      result = logstash_service.monitoring_api.event_stats
+      expect(result["in"]).to eq(1)
+      expect(result["out"]).to eq(1)
+    end
     
     # do a reload
     logstash_service.reload_config(initial_config_file, reload_config_file)
@@ -58,9 +60,11 @@ describe "Test Logstash service when config reload is enabled" do
     end
     
     # check instance metrics. It should not be reset
-    instance_event_stats = logstash_service.monitoring_api.event_stats
-    expect(instance_event_stats["in"]).to eq(2)
-    expect(instance_event_stats["out"]).to eq(2)
+    try(num_retries) do
+      instance_event_stats = logstash_service.monitoring_api.event_stats
+      expect(instance_event_stats["in"]).to eq(2)
+      expect(instance_event_stats["out"]).to eq(2)
+    end
 
     # check pipeline metrics. It should be reset
     pipeline_event_stats = logstash_service.monitoring_api.pipeline_stats("main")["events"]

--- a/qa/integration/specs/settings_spec.rb
+++ b/qa/integration/specs/settings_spec.rb
@@ -117,9 +117,11 @@ describe "Test Logstash instance whose default settings are overridden" do
     end
 
     # now check monitoring API to validate
-    node_info = @logstash_service.monitoring_api.node_info
-    expect(node_info["pipelines"]["main"]["workers"]).to eq(workers)
-    expect(node_info["pipelines"]["main"]["batch_size"]).to eq(batch_size)
+    try(num_retries) do
+      node_info = @logstash_service.monitoring_api.node_info
+      expect(node_info["pipelines"]["main"]["workers"]).to eq(workers)
+      expect(node_info["pipelines"]["main"]["batch_size"]).to eq(batch_size)
+    end
   end
 
   it "start on a different HTTP port" do


### PR DESCRIPTION
Fixes #8004 

The web-server was started before the pipeline could populate the metrics. Fixed by changing the load order accordingly. 

I had to change the tests to wait for the web-server port because the pipeline now creates the output file before the server is up.