### PR TITLE
MINOR: Clean up Logstash Module RubyClass Setup

### DIFF
--- a/logstash-core/src/main/java/org/logstash/RubyUtil.java
+++ b/logstash-core/src/main/java/org/logstash/RubyUtil.java
@@ -2,6 +2,7 @@ package org.logstash;
 
 import org.jruby.NativeException;
 import org.jruby.Ruby;
+import org.jruby.RubyModule;
 import org.jruby.exceptions.RaiseException;
 
 /**
@@ -10,27 +11,21 @@ import org.jruby.exceptions.RaiseException;
 public final class RubyUtil {
 
     /**
-     * Name of the Logstash JRuby module we register.
-     */
-    public static final String LS_MODULE_NAME = "LogStash";
-
-    /**
      * Reference to the global {@link Ruby} runtime.
      */
-    public static final Ruby RUBY = setupRuby();
-
-    private RubyUtil() {
-    }
+    public static final Ruby RUBY;
 
     /**
-     * Sets up the global {@link Ruby} runtime and ensures the creation of the "LogStash" module
-     * on it.
-     * @return Global {@link Ruby} Runtime
+     * Logstash Ruby Module.
      */
-    private static Ruby setupRuby() {
-        final Ruby ruby = Ruby.getGlobalRuntime();
-        ruby.getOrCreateModule(LS_MODULE_NAME);
-        return ruby;
+    public static final RubyModule LOGSTASH_MODULE;
+
+    static {
+        RUBY = Ruby.getGlobalRuntime();
+        LOGSTASH_MODULE = RUBY.getOrCreateModule("LogStash");
+    }
+
+    private RubyUtil() {
     }
 
     /**

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedBatchExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedBatchExtLibrary.java
@@ -6,7 +6,6 @@ import java.util.List;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyClass;
-import org.jruby.RubyModule;
 import org.jruby.RubyObject;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
@@ -25,13 +24,11 @@ public final class JrubyAckedBatchExtLibrary implements Library {
 
     @Override
     public void load(Ruby runtime, boolean wrap) {
-        RubyModule module = runtime.defineModule(RubyUtil.LS_MODULE_NAME);
-
         RubyClass clazz = runtime.defineClassUnder("AckedBatch", runtime.getObject(), new ObjectAllocator() {
             public IRubyObject allocate(Ruby runtime, RubyClass rubyClass) {
                 return new RubyAckedBatch(runtime, rubyClass);
             }
-        }, module);
+        }, RubyUtil.LOGSTASH_MODULE);
 
         clazz.defineAnnotatedMethods(RubyAckedBatch.class);
     }
@@ -47,7 +44,7 @@ public final class JrubyAckedBatchExtLibrary implements Library {
         }
 
         public RubyAckedBatch(Ruby runtime, Batch batch) {
-            super(runtime, runtime.getModule(RubyUtil.LS_MODULE_NAME).getClass("AckedBatch"));
+            super(runtime, RubyUtil.LOGSTASH_MODULE.getClass("AckedBatch"));
             this.batch = batch;
         }
 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java
@@ -27,7 +27,7 @@ public final class JrubyAckedQueueExtLibrary implements Library {
     public void load(Ruby runtime, boolean wrap) {
         runtime.defineClassUnder(
             "AckedQueue", runtime.getObject(), JrubyAckedQueueExtLibrary.RubyAckedQueue::new,
-            runtime.defineModule(RubyUtil.LS_MODULE_NAME)
+            RubyUtil.LOGSTASH_MODULE
         ).defineAnnotatedMethods(JrubyAckedQueueExtLibrary.RubyAckedQueue.class);
     }
 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueMemoryExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueMemoryExtLibrary.java
@@ -28,7 +28,7 @@ public final class JrubyAckedQueueMemoryExtLibrary implements Library {
         runtime.defineClassUnder(
             "AckedMemoryQueue", runtime.getObject(),
             JrubyAckedQueueMemoryExtLibrary.RubyAckedMemoryQueue::new,
-            runtime.defineModule(RubyUtil.LS_MODULE_NAME)
+            RubyUtil.LOGSTASH_MODULE
         ).defineAnnotatedMethods(JrubyAckedQueueMemoryExtLibrary.RubyAckedMemoryQueue.class);
     }
 

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -8,7 +8,6 @@ import org.jruby.RubyArray;
 import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyHash;
-import org.jruby.RubyModule;
 import org.jruby.RubyObject;
 import org.jruby.RubyString;
 import org.jruby.anno.JRubyClass;
@@ -35,10 +34,9 @@ public final class JrubyEventExtLibrary implements Library {
 
     @Override
     public void load(Ruby runtime, boolean wrap) {
-        final RubyModule module = runtime.defineModule(RubyUtil.LS_MODULE_NAME);
 
         RubyClass clazz = runtime.defineClassUnder(
-            "Event", runtime.getObject(), RubyEvent::new, module
+            "Event", runtime.getObject(), RubyEvent::new, RubyUtil.LOGSTASH_MODULE
         );
 
         clazz.setConstant("METADATA", runtime.newString(Event.METADATA));
@@ -51,15 +49,15 @@ public final class JrubyEventExtLibrary implements Library {
         clazz.defineAnnotatedMethods(RubyEvent.class);
         clazz.defineAnnotatedConstants(RubyEvent.class);
 
-        PARSER_ERROR = module.defineOrGetModuleUnder("Json").getClass("ParserError");
+        PARSER_ERROR = RubyUtil.LOGSTASH_MODULE.defineOrGetModuleUnder("Json").getClass("ParserError");
         if (PARSER_ERROR == null) {
             throw new RaiseException(runtime, runtime.getClass("StandardError"), "Could not find LogStash::Json::ParserError class", true);
         }
-        GENERATOR_ERROR = module.defineOrGetModuleUnder("Json").getClass("GeneratorError");
+        GENERATOR_ERROR = RubyUtil.LOGSTASH_MODULE.defineOrGetModuleUnder("Json").getClass("GeneratorError");
         if (GENERATOR_ERROR == null) {
             throw new RaiseException(runtime, runtime.getClass("StandardError"), "Could not find LogStash::Json::GeneratorError class", true);
         }
-        LOGSTASH_ERROR = module.getClass("Error");
+        LOGSTASH_ERROR = RubyUtil.LOGSTASH_MODULE.getClass("Error");
         if (LOGSTASH_ERROR == null) {
             throw new RaiseException(runtime, runtime.getClass("StandardError"), "Could not find LogStash::Error class", true);
         }
@@ -89,7 +87,7 @@ public final class JrubyEventExtLibrary implements Library {
 
         public static RubyEvent newRubyEvent(Ruby runtime, Event event) {
             final RubyEvent ruby =
-                new RubyEvent(runtime, runtime.getModule(RubyUtil.LS_MODULE_NAME).getClass("Event"));
+                new RubyEvent(runtime, RubyUtil.LOGSTASH_MODULE.getClass("Event"));
             ruby.setEvent(event);
             return ruby;
         }

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
@@ -5,7 +5,6 @@ import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyFloat;
-import org.jruby.RubyModule;
 import org.jruby.RubyObject;
 import org.jruby.RubyString;
 import org.jruby.RubyTime;
@@ -38,8 +37,8 @@ public final class JrubyTimestampExtLibrary implements Library {
     }
 
     public static RubyClass createTimestamp(Ruby runtime) {
-        RubyModule module = runtime.defineModule(RubyUtil.LS_MODULE_NAME);
-        RubyClass clazz = runtime.defineClassUnder("Timestamp", runtime.getObject(), ALLOCATOR, module);
+        RubyClass clazz =
+            runtime.defineClassUnder("Timestamp", runtime.getObject(), ALLOCATOR, RubyUtil.LOGSTASH_MODULE);
         clazz.defineAnnotatedMethods(RubyTimestamp.class);
         return clazz;
     }
@@ -102,7 +101,7 @@ public final class JrubyTimestampExtLibrary implements Library {
                 } catch (IllegalArgumentException e) {
                     throw new RaiseException(
                             getRuntime(),
-                            getRuntime().getModule(RubyUtil.LS_MODULE_NAME).getClass("TimestampParserError"),
+                            RubyUtil.LOGSTASH_MODULE.getClass("TimestampParserError"),
                             "invalid timestamp string format " + time,
                             true
                     );
@@ -181,7 +180,7 @@ public final class JrubyTimestampExtLibrary implements Library {
              } catch (IllegalArgumentException e) {
                 throw new RaiseException(
                         context.runtime,
-                        context.runtime.getModule(RubyUtil.LS_MODULE_NAME).getClass("TimestampParserError"),
+                        RubyUtil.LOGSTASH_MODULE.getClass("TimestampParserError"),
                         "invalid timestamp format " + e.getMessage(),
                         true
                 );
@@ -198,7 +197,7 @@ public final class JrubyTimestampExtLibrary implements Library {
                 } catch (IllegalArgumentException e) {
                     throw new RaiseException(
                             context.runtime,
-                            context.runtime.getModule(RubyUtil.LS_MODULE_NAME).getClass("TimestampParserError"),
+                            RubyUtil.LOGSTASH_MODULE.getClass("TimestampParserError"),
                             "invalid timestamp format " + e.getMessage(),
                             true
                     );


### PR DESCRIPTION
We shouldn't get the Logstash module redundantly all over the place, we know this is a global constant since we always work from just a single `Ruby` runtime instance per JVM.