### PR TITLE
MINOR: Remove dead code supporting non-java platforms

### DIFF
--- a/lib/bootstrap/environment.rb
+++ b/lib/bootstrap/environment.rb
@@ -40,10 +40,6 @@ module LogStash
       ::Gem.win_platform?
     end
 
-    def jruby?
-      @jruby ||= !!(RUBY_PLATFORM == "java")
-    end
-
     def logstash_gem_home
       ::File.join(BUNDLE_DIR, ruby_engine, gem_ruby_version)
     end

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -132,8 +132,6 @@ module LogStash
     end
 
     def load_jars!(pattern)
-      raise(LogStash::EnvironmentError, I18n.t("logstash.environment.jruby-required")) unless LogStash::Environment.jruby?
-
       jar_files = find_jars(pattern)
       require_jars! jar_files
     end
@@ -154,10 +152,6 @@ module LogStash
 
     def ruby_bin
       ENV["USE_RUBY"] == "1" ? "ruby" : File.join("vendor", "jruby", "bin", "jruby")
-    end
-
-    def jruby?
-      @jruby ||= !!(RUBY_PLATFORM == "java")
     end
 
     def windows?

--- a/logstash-core/lib/logstash/json.rb
+++ b/logstash-core/lib/logstash/json.rb
@@ -1,12 +1,8 @@
 # encoding: utf-8
 require "logstash/environment"
 require "logstash/errors"
-if LogStash::Environment.jruby?
-  require "jrjackson"
-  require "logstash/java_integration"
-else
-  require  "oj"
-end
+require "jrjackson"
+require "logstash/java_integration"
 
 module LogStash
   module Json
@@ -14,22 +10,6 @@ module LogStash
     class GeneratorError < LogStash::Error; end
 
     extend self
-
-    ### MRI
-
-    def mri_load(data, options = {})
-      Oj.load(data)
-    rescue Oj::ParseError => e
-      raise LogStash::Json::ParserError.new(e.message)
-    end
-
-    def mri_dump(o)
-      Oj.dump(o, :mode => :compat, :use_to_json => true)
-    rescue => e
-      raise LogStash::Json::GeneratorError.new(e.message)
-    end
-
-    ### JRuby
 
     def jruby_load(data, options = {})
       # TODO [guyboertje] remove these comments in 5.0
@@ -52,9 +32,8 @@ module LogStash
       raise LogStash::Json::GeneratorError.new(e.message)
     end
 
-    prefix = LogStash::Environment.jruby? ? "jruby" : "mri"
-    alias_method :load, "#{prefix}_load".to_sym
-    alias_method :dump, "#{prefix}_dump".to_sym
+    alias_method :load, "jruby_load".to_sym
+    alias_method :dump, "jruby_dump".to_sym
 
   end
 end

--- a/logstash-core/lib/logstash/patches/bugfix_jruby_2558.rb
+++ b/logstash-core/lib/logstash/patches/bugfix_jruby_2558.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 require "logstash/environment"
 
-if LogStash::Environment.windows? && LogStash::Environment.jruby?
+if LogStash::Environment.windows?
   require "socket"
   module JRubyBug2558SocketPeerAddrBugFix
     def peeraddr(*args)

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -407,7 +407,7 @@ class LogStash::Runner < Clamp::StrictCommand
 
     if logger.info?
       show_version_ruby
-      show_version_java if LogStash::Environment.jruby?
+      show_version_java
       show_gems if logger.debug?
     end
   end # def show_version

--- a/logstash-core/lib/logstash/util.rb
+++ b/logstash-core/lib/logstash/util.rb
@@ -147,28 +147,20 @@ module LogStash::Util
   # to support these pure Ruby object monkey patches.
   # see logstash/json.rb and logstash/java_integration.rb
 
-  if LogStash::Environment.jruby?
-    require "java"
-
-    # recursively convert any Java LinkedHashMap and ArrayList to pure Ruby.
-    # will not recurse into pure Ruby objects. Pure Ruby object should never
-    # contain LinkedHashMap and ArrayList since these are only created at
-    # initial deserialization, anything after (deeper) will be pure Ruby.
-    def self.normalize(o)
-      case o
-      when Java::JavaUtil::LinkedHashMap
-        o.inject({}){|r, (k, v)| r[k] = normalize(v); r}
-      when Java::JavaUtil::ArrayList
-        o.map{|i| normalize(i)}
-      else
-        o
-      end
+  require "java"
+  # recursively convert any Java LinkedHashMap and ArrayList to pure Ruby.
+  # will not recurse into pure Ruby objects. Pure Ruby object should never
+  # contain LinkedHashMap and ArrayList since these are only created at
+  # initial deserialization, anything after (deeper) will be pure Ruby.
+  def self.normalize(o)
+    case o
+    when Java::JavaUtil::LinkedHashMap
+      o.inject({}){|r, (k, v)| r[k] = normalize(v); r}
+    when Java::JavaUtil::ArrayList
+      o.map{|i| normalize(i)}
+    else
+      o
     end
-
-  else
-
-    # identity function, pure Ruby object don't need normalization.
-    def self.normalize(o); o; end
   end
 
   def self.stringify_symbols(o)

--- a/logstash-core/lib/logstash/util/java_version.rb
+++ b/logstash-core/lib/logstash/util/java_version.rb
@@ -3,7 +3,6 @@
 module LogStash::Util::JavaVersion
   # Return the current java version string. Returns nil if this is a non-java platform (e.g. MRI).
   def self.version
-    return nil unless LogStash::Environment.jruby?
     java.lang.System.getProperty("java.runtime.version")
   end
 

--- a/logstash-core/spec/logstash/environment_spec.rb
+++ b/logstash-core/spec/logstash/environment_spec.rb
@@ -10,11 +10,6 @@ describe LogStash::Environment do
     let(:default_runtime_location) { File.join(default_jars_location,"runtime-jars","*.jar") }
     let(:default_test_location)    { File.join(default_jars_location,"test-jars","*.jar") }
 
-    it "raises an exception if jruby is not available" do
-      expect(subject).to receive(:jruby?).and_return(false)
-      expect { subject.load_runtime_jars! }.to raise_error
-    end
-
     it "find runtime jars in the default location" do
       expect(subject).to receive(:find_jars).with(default_runtime_location).and_return([])
       subject.load_runtime_jars!

--- a/logstash-core/spec/logstash/json_spec.rb
+++ b/logstash-core/spec/logstash/json_spec.rb
@@ -33,60 +33,42 @@ describe "LogStash::Json" do
     ]
   }
 
-  if LogStash::Environment.jruby?
+  # Former expectation in this code were removed because of https://github.com/rspec/rspec-mocks/issues/964
+  # as soon as is fix we can re introduce them if desired, however for now the completeness of the test
+  # is also not affected as the conversion would not work if the expectation where not meet.
+  ###
+  context "jruby deserialize" do
+    it "should respond to load and deserialize object" do
+      expect(LogStash::Json.load(json_hash)).to eql(hash)
+    end
+  end
 
-    ### JRuby specific
-    # Former expectation in this code were removed because of https://github.com/rspec/rspec-mocks/issues/964
-    # as soon as is fix we can re introduce them if desired, however for now the completeness of the test
-    # is also not affected as the conversion would not work if the expectation where not meet.
-    ###
-    context "jruby deserialize" do
-      it "should respond to load and deserialize object" do
-        expect(LogStash::Json.load(json_hash)).to eql(hash)
-      end
+  context "jruby serialize" do
+    it "should respond to dump and serialize object" do
+      expect(LogStash::Json.dump(string)).to eql(json_string)
     end
 
-    context "jruby serialize" do
-      it "should respond to dump and serialize object" do
-        expect(LogStash::Json.dump(string)).to eql(json_string)
-      end
-
-      it "should call JrJackson::Raw.generate for Hash" do
-        expect(LogStash::Json.dump(hash)).to eql(json_hash)
-      end
-
-      it "should call JrJackson::Raw.generate for Array" do
-        expect(LogStash::Json.dump(array)).to eql(json_array)
-      end
-
-      context "pretty print" do
-
-        let(:hash) { { "foo" => "bar", :zoo => 2 } }
-
-        it "should serialize with pretty print" do
-          pprint_json = LogStash::Json.dump(hash, :pretty => true)
-          expect(pprint_json).to include("\n")
-        end
-
-        it "should by default do no pretty print" do
-          pprint_json = LogStash::Json.dump(hash)
-          expect(pprint_json).not_to include("\n")
-        end
-      end
+    it "should call JrJackson::Raw.generate for Hash" do
+      expect(LogStash::Json.dump(hash)).to eql(json_hash)
     end
 
-  else
-
-    ### MRI specific
-
-    it "should respond to load and deserialize object on mri" do
-      expect(Oj).to receive(:load).with(json).and_call_original
-      expect(LogStash::Json.load(json)).to eql(hash)
+    it "should call JrJackson::Raw.generate for Array" do
+      expect(LogStash::Json.dump(array)).to eql(json_array)
     end
 
-    it "should respond to dump and serialize object on mri" do
-      expect(Oj).to receive(:dump).with(hash, anything).and_call_original
-      expect(LogStash::Json.dump(hash)).to eql(json)
+    context "pretty print" do
+
+      let(:hash) { { "foo" => "bar", :zoo => 2 } }
+
+      it "should serialize with pretty print" do
+        pprint_json = LogStash::Json.dump(hash, :pretty => true)
+        expect(pprint_json).to include("\n")
+      end
+
+      it "should by default do no pretty print" do
+        pprint_json = LogStash::Json.dump(hash)
+        expect(pprint_json).not_to include("\n")
+      end
     end
   end
 

--- a/logstash-core/spec/logstash/util/java_version_spec.rb
+++ b/logstash-core/spec/logstash/util/java_version_spec.rb
@@ -6,9 +6,7 @@ describe "LogStash::Util::JavaVersion" do
   subject(:mod) { LogStash::Util::JavaVersion }
 
   it "should get the current java version if we're on Java" do
-    if LogStash::Environment.jruby?
-      expect(LogStash::Util::JavaVersion.version).to be_a(String)
-    end
+    expect(LogStash::Util::JavaVersion.version).to be_a(String)
   end
 
   it "should mark a bad beta version as bad" do


### PR DESCRIPTION
I think we can remove all of this code, it's all just branching around the platform and with the current code requiring `jar_dependencies` in `lib/bootstrap/environment.rb` there is no way to get to any off the removed on a non JRuby platform imo right?