### PR TITLE
BUILD: Execute RSPEC from JUnit

### DIFF
--- a/lib/bootstrap/rspec.rb
+++ b/lib/bootstrap/rspec.rb
@@ -10,5 +10,8 @@ require "rspec/core"
 require "rspec"
 require 'ci/reporter/rake/rspec_loader'
 
-status = RSpec::Core::Runner.run(ARGV.empty? ? ["spec"] : ARGV).to_i
+status = RSpec::Core::Runner.run(ARGV.empty? ? ($JUNIT_ARGV || ["spec"]) : ARGV).to_i
+if ENV["IS_JUNIT_RUN"]
+  return status
+end
 exit status if status != 0

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -70,6 +70,10 @@ configurations.archives {
     extendsFrom configurations.javadoc
 }
 
+task javaTests(type: Test) {
+    exclude '/org/logstash/RSpecTests.class'
+}
+
 artifacts {
     sources(sourcesJar) {
         // Weird Gradle quirk where type will be used for the extension, but only for sources
@@ -113,6 +117,7 @@ dependencies {
     testCompile 'net.javacrumbs.json-unit:json-unit:1.9.0'
     testCompile 'org.elasticsearch:securemock:1.2'
     testCompile 'org.assertj:assertj-core:3.8.0'
+    testCompile "org.jruby:jruby-complete:${jrubyVersion}"
     provided "org.jruby:jruby-core:${jrubyVersion}"
 }
 

--- a/logstash-core/src/test/java/org/logstash/RSpecTests.java
+++ b/logstash-core/src/test/java/org/logstash/RSpecTests.java
@@ -1,0 +1,38 @@
+package org.logstash;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import org.assertj.core.util.Files;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Runs the Logstash RSpec suit.
+ */
+public final class RSpecTests {
+
+    @Test
+    public void rspecTests() throws Exception {
+        final String root = Files.currentFolder().getParent();
+        RubyUtil.RUBY.getENV().put("IS_JUNIT_RUN", "true");
+        RubyUtil.RUBY.setCurrentDirectory(root);
+        RubyUtil.RUBY.getGlobalVariables().set(
+            "$JUNIT_ARGV",
+            Rubyfier.deep(
+                RubyUtil.RUBY, Arrays.asList(
+                    "-fd", "--pattern", "spec/unit/**/*_spec.rb,logstash-core/spec/**/*_spec.rb"
+                ))
+        );
+        final Path rspec = Paths.get(root, "lib/bootstrap/rspec.rb");
+        final IRubyObject result = RubyUtil.RUBY.executeScript(
+            new String(java.nio.file.Files.readAllBytes(rspec), StandardCharsets.UTF_8),
+            rspec.toFile().getAbsolutePath()
+        );
+        if (!result.toJava(Long.class).equals(0L)) {
+            Assert.fail("RSpec test suit saw at least one failure.");
+        }
+    }
+}

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -8,7 +8,7 @@ namespace "test" do
 
   desc "run the java unit tests"
   task "core-java" do
-    exit(1) unless system './gradlew clean test'
+    exit(1) unless system('./gradlew clean javaTests')
   end
 
   desc "run the ruby unit tests"
@@ -24,8 +24,8 @@ namespace "test" do
   end
 
   desc "run all core specs"
-  task "core-slow" => ["core-java"] do
-    exit 1 unless system(*default_spec_command)
+  task "core-slow" do
+    exit 1 unless system('./gradlew clean test')
   end
 
   desc "run core specs excluding slower tests like stress tests"


### PR DESCRIPTION
This makes the RSpecs run from JUnit to:

* Move more logic to Java :P 
* Speed up the test run (saves about a minute compared to `rake test:core` for me)
* Allow for debugging of Java code in Ruby Specs from the IDE
* Allows for moving some test only Java code to the test classpath. Currently, the in memory-serialized queue is the biggest offender here, but there are a few others that needlessly complicate our production code.
* **Most importantly:** this gives us a starting point for loading Logstash's infrastructure for JUnit tests for #8442 

This shouldn't change any anything in what the individual `rake` tasks do since the `slow` goal was the only one to run Ruby + Java.
This is still the case and I added a new task that can be invoked by the `core-java` goal and doesn't run the RSpec JUnit invoker.