### PR TITLE
log Logstash version in structured logs at startup

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -364,6 +364,8 @@ class LogStash::Runner < Clamp::StrictCommand
     sigint_id = trap_sigint()
     sigterm_id = trap_sigterm()
 
+    logger.info("Starting Logstash", "logstash.version" => LOGSTASH_VERSION)
+
     @agent_task = Stud::Task.new { @agent.execute }
 
     # no point in enabling config reloading before the agent starts


### PR DESCRIPTION
Adds a new INFO-level log message at Logstash startup indicating that
Logstash is starting, including a structured-log key `logstash.version`
populated with the current logstash version.

This message will only be emitted if the runner gets far enough to actually
start up (e.g., if it is not passed a flag that causes it to bail early)

Resolves elastic/logstash#8512