### PR TITLE
#8216 Use standard name for Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ qa/.vm_ssh_config
 qa/.vagrant
 qa/acceptance/.vagrant
 qa/Gemfile.lock
-Gemfile.jruby-2.3.lock
+Gemfile.lock
 Gemfile
 *.ipr
 *.iws

--- a/ci/acceptance_tests.sh
+++ b/ci/acceptance_tests.sh
@@ -13,7 +13,7 @@ SELECTED_TEST_SUITE=$1
 # we will clear them out to make sure we use the latest version of theses files
 # If we don't do this we will run into gem Conflict error.
 [ -f Gemfile ] && rm Gemfile
-[ -f Gemfile.jruby-2.3.lock ] && rm Gemfile.jruby-2.3.lock
+[ -f Gemfile.lock ] && rm Gemfile.lock
 
 # When running these tests in a Jenkins matrix, in parallel, once one Vagrant job is done, the Jenkins ProcessTreeKiller will kill any other Vagrant processes with the same
 # BUILD_ID unless you set this magic flag:  https://wiki.jenkins.io/display/JENKINS/ProcessTreeKiller

--- a/lib/bootstrap/bundler.rb
+++ b/lib/bootstrap/bundler.rb
@@ -7,15 +7,6 @@ module LogStash
     extend self
 
     def patch!
-      # Patch bundler to write a .lock file specific to the version of ruby.
-      # This keeps MRI/JRuby/RBX from conflicting over the Gemfile.lock updates
-      ::Bundler::SharedHelpers.module_exec do
-        def default_lockfile
-          ruby = "#{Environment.ruby_engine}-#{Environment.ruby_abi_version}"
-          Pathname.new("#{default_gemfile}.#{ruby}.lock")
-        end
-      end
-
       # Patch to prevent Bundler to save a .bundle/config file in the root
       # of the application
       ::Bundler::Settings.module_exec do

--- a/lib/bootstrap/environment.rb
+++ b/lib/bootstrap/environment.rb
@@ -18,7 +18,7 @@ module LogStash
     GEMFILE_PATH = ::File.join(LOGSTASH_HOME, "Gemfile")
     LOCAL_GEM_PATH = ::File.join(LOGSTASH_HOME, 'vendor', 'local_gems')
     CACHE_PATH = ::File.join(LOGSTASH_HOME, "vendor", "cache")
-    LOCKFILE = Pathname.new(::File.join(LOGSTASH_HOME, "Gemfile.jruby-2.3.lock"))
+    LOCKFILE = Pathname.new(::File.join(LOGSTASH_HOME, "Gemfile.lock"))
     GEMFILE = Pathname.new(::File.join(LOGSTASH_HOME, "Gemfile"))
 
     # @return [String] the ruby version string bundler uses to craft its gem path

--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -205,7 +205,7 @@ class LogstashService < Service
   end
 
   def lock_file
-    File.join(@logstash_home, "Gemfile.jruby-2.3.lock")
+    File.join(@logstash_home, "Gemfile.lock")
   end
 
   class PluginCli

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -38,7 +38,7 @@ namespace "artifact" do
       # See more in https://github.com/elastic/logstash/issues/4818
       "vendor/??*/**/.mvn/**/*",
       "Gemfile",
-      "Gemfile.jruby-2.3.lock",
+      "Gemfile.lock",
     ]
   end
 


### PR DESCRIPTION
Just a rebase of #8216 credit goes to @ph but I'd really like to have this one asap to improve the Java-Ruby interaction in JUnit tests.

This was already reviewed by me in #8216 but just never merged and started to conflict now.