### PR TITLE
Clean up es data and log folders after ITs

### DIFF
--- a/qa/integration/services/elasticsearch_setup.sh
+++ b/qa/integration/services/elasticsearch_setup.sh
@@ -26,7 +26,7 @@ setup_es() {
 
 start_es() {
   es_args=$@
-  $ES_HOME/bin/elasticsearch $es_args -p $ES_HOME/elasticsearch.pid > /tmp/elasticsearch.log 2>/dev/null &
+  $ES_HOME/bin/elasticsearch -Epath.data=/tmp/ls_integration/es-data -Epath.logs=/tmp/ls_integration/es-logs $es_args -p $ES_HOME/elasticsearch.pid > /tmp/elasticsearch.log 2>/dev/null &
   count=120
   echo "Waiting for elasticsearch to respond..."
   while ! curl --silent localhost:9200 && [[ $count -ne 0 ]]; do

--- a/qa/integration/services/elasticsearch_teardown.sh
+++ b/qa/integration/services/elasticsearch_teardown.sh
@@ -13,3 +13,6 @@ stop_es() {
 }
 
 stop_es
+
+rm -rf /tmp/ls_integration/es-data
+rm -rf /tmp/ls_integration/es-logs


### PR DESCRIPTION
Change the data and log directories to be in /tmp/ls_integrations
(matching the kafka service folder structure), and delete
them in the teardown script.