### PR TITLE
5.x Test fix: pin integration tests to devutils 1.3.4

### DIFF
--- a/qa/integration/integration_tests.gemspec
+++ b/qa/integration/integration_tests.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'manticore'
   s.add_development_dependency 'stud'
   s.add_development_dependency 'pry'
-  s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'logstash-devutils', '= 1.3.4'
   s.add_development_dependency 'flores'
   s.add_development_dependency 'rubyzip'
 end


### PR DESCRIPTION
Fixes #8518 

This is due to a commit which removes some 6.0+ redundant (and possibly buggy) logging initialization. 