### PR TITLE
MINOR: Remove unused docker-api as development dependency

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -21,7 +21,6 @@ gem "gems", "~> 0.8.3", :group => :build
 gem "rack-test", :require => "rack/test", :group => :development
 gem "flores", "~> 0.0.6", :group => :development
 gem "term-ansicolor", "~> 1.3.2", :group => :development
-gem "docker-api", "1.33.4", :group => :development
 gem "json-schema", "~> 2.6", :group => :development
 gem "pleaserun", "~>0.0.28"
 gem "logstash-input-heartbeat"


### PR DESCRIPTION
We're not using Docker via Ruby APIs anymore => no need for this dep. :)