### PR TITLE
MINOR: Remove outdated Rubygems hack

### DIFF
--- a/lib/bootstrap/bundler.rb
+++ b/lib/bootstrap/bundler.rb
@@ -46,8 +46,6 @@ module LogStash
       options = {:without => [:development]}.merge(options)
       options[:without] = Array(options[:without])
 
-      # make sure we use our own installed bundler
-      LogStash::Rubygems.patch!
       ::Gem.clear_paths
       ENV['GEM_HOME'] = ENV['GEM_PATH'] = Environment.logstash_gem_home
       ::Gem.paths = ENV
@@ -86,9 +84,6 @@ module LogStash
       options[:without] = Array(options[:without])
       options[:update] = Array(options[:update]) if options[:update]
 
-      # make sure we use our own installed bundler
-      # require "logstash/patches/rubygems" # patch rubygems before clear_paths
-      LogStash::Rubygems.patch!
       ::Gem.clear_paths
       ENV['GEM_HOME'] = ENV['GEM_PATH'] = LogStash::Environment.logstash_gem_home
       ::Gem.paths = ENV

--- a/lib/bootstrap/rubygems.rb
+++ b/lib/bootstrap/rubygems.rb
@@ -3,46 +3,6 @@ module LogStash
   module Rubygems
     extend self
 
-    def patch!
-      # monkey patch RubyGems to silence ffi warnings:
-      #
-      # WARN: Unresolved specs during Gem::Specification.reset:
-      #       ffi (>= 0)
-      # WARN: Clearing out unresolved specs.
-      # Please report a bug if this causes problems.
-      #
-      # see https://github.com/elasticsearch/logstash/issues/2556 and https://github.com/rubygems/rubygems/issues/1070
-      #
-      # this code is from Rubygems v2.1.9 in JRuby 1.7.17. Per tickets this issue should be solved at JRuby >= 1.7.20.
-      #
-      # this method implementation works for Rubygems version 2.1.0 and up, verified up to 2.4.6
-      if ::Gem::Version.new(::Gem::VERSION) >= ::Gem::Version.new("2.1.0") && ::Gem::Version.new(::Gem::VERSION) < ::Gem::Version.new("2.5.0")
-        ::Gem::Specification.class_exec do
-          def self.reset
-            @@dirs = nil
-            ::Gem.pre_reset_hooks.each { |hook| hook.call }
-            @@all = nil
-            @@stubs = nil
-            _clear_load_cache
-            unresolved = unresolved_deps
-            unless unresolved.empty?
-              unless (unresolved.size == 1 && unresolved["ffi"])
-                w = "W" + "ARN"
-                warn "#{w}: Unresolved specs during Gem::Specification.reset:"
-                unresolved.values.each do |dep|
-                  warn "      #{dep}"
-                end
-                warn "#{w}: Clearing out unresolved specs."
-                warn "Please report a bug if this causes problems."
-              end
-              unresolved.clear
-            end
-            ::Gem.post_reset_hooks.each { |hook| hook.call }
-          end
-        end
-      end
-    end
-
     ##
     # Take a plugin name and get the latest versions available in the gem repository.
     # @param [String] The plugin name


### PR DESCRIPTION
JRuby 9k uses Rubygems 2.6.x => this hack is just dead code => removed :)