### PR TITLE
Fix edit url links

### DIFF
--- a/docs/index-shared1.asciidoc
+++ b/docs/index-shared1.asciidoc
@@ -36,45 +36,45 @@ volume and variety of data.
 
 // Introduction
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/introduction.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/introduction.asciidoc
 include::static/introduction.asciidoc[]
 
 // Glossary and core concepts go here
 
 // Getting Started with Logstash
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/getting-started-with-logstash.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/getting-started-with-logstash.asciidoc
 include::static/getting-started-with-logstash.asciidoc[]
 
 // Advanced LS Pipelines
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/advanced-pipeline.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/advanced-pipeline.asciidoc
 include::static/advanced-pipeline.asciidoc[]
 
 // Processing Pipeline
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/life-of-an-event.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/life-of-an-event.asciidoc
 include::static/life-of-an-event.asciidoc[]
 
 // Lostash setup
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/setting-up-logstash.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/setting-up-logstash.asciidoc
 include::static/setting-up-logstash.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/settings-file.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/settings-file.asciidoc
 include::static/settings-file.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/running-logstash-command-line.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/running-logstash-command-line.asciidoc
 include::static/running-logstash-command-line.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/running-logstash.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/running-logstash.asciidoc
 include::static/running-logstash.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/docker.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/docker.asciidoc
 include::static/docker.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/logging.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/logging.asciidoc
 include::static/logging.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/shutdown.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/shutdown.asciidoc
 include::static/shutdown.asciidoc[]

--- a/docs/index-shared2.asciidoc
+++ b/docs/index-shared2.asciidoc
@@ -1,5 +1,5 @@
 
 // Breaking Changes
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/breaking-changes.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/breaking-changes.asciidoc
 include::static/breaking-changes.asciidoc[]

--- a/docs/index-shared3.asciidoc
+++ b/docs/index-shared3.asciidoc
@@ -1,89 +1,92 @@
 
 // Upgrading Logstash
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/upgrading.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/upgrading.asciidoc
 include::static/upgrading.asciidoc[]
 
 // Configuring Logstash
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/configuration.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/configuration.asciidoc
 include::static/configuration.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/multiple-pipelines.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/multiple-pipelines.asciidoc
 include::static/multiple-pipelines.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/reloading-config.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/reloading-config.asciidoc
 include::static/reloading-config.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/managing-multiline-events.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/managing-multiline-events.asciidoc
 include::static/managing-multiline-events.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/glob-support.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/glob-support.asciidoc
 include::static/glob-support.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/ingest-convert.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/ingest-convert.asciidoc
 include::static/ingest-convert.asciidoc[]
 
 // Centralized configuration managements
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/config-management.asciidoc
 include::static/config-management.asciidoc[]
 
 // Working with Logstash Modules
-
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/modules.asciidoc
 include::static/modules.asciidoc[]
 
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/arcsight-module.asciidoc
 include::static/arcsight-module.asciidoc[]
 
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/netflow-module.asciidoc
 include::static/netflow-module.asciidoc[]
 
 // Working with Filebeat Modules
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/filebeat-modules.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/filebeat-modules.asciidoc
 include::static/filebeat-modules.asciidoc[]
 
 // Data resiliency
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/resiliency.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/resiliency.asciidoc
 include::static/resiliency.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/persistent-queues.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/persistent-queues.asciidoc
 include::static/persistent-queues.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/dead-letter-queues.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/dead-letter-queues.asciidoc
 include::static/dead-letter-queues.asciidoc[]
 
 // Transforming Data
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/transforming-data.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/transforming-data.asciidoc
 include::static/transforming-data.asciidoc[]
 
 // Deploying & Scaling
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/deploying.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/deploying.asciidoc
 include::static/deploying.asciidoc[]
 
 // Troubleshooting performance
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/performance-checklist.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/performance-checklist.asciidoc
 include::static/performance-checklist.asciidoc[]
 
 // Monitoring overview
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/monitoring.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/monitoring.asciidoc
 include::static/monitoring.asciidoc[]
 
 // Pipeline viewer
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/pipeline-viewer.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/pipeline-viewer.asciidoc
 include::static/pipeline-viewer.asciidoc[]
 
 // Monitoring APIs
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/monitoring-apis.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/monitoring-apis.asciidoc
 include::static/monitoring-apis.asciidoc[]
 
 // Working with Plugins
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/plugin-manager.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/plugin-manager.asciidoc
 include::static/plugin-manager.asciidoc[]
 
 // These files do their own pass blocks
@@ -106,12 +109,12 @@ include::static/output.asciidoc[]
 
 // Contributing a Patch to a Logstash Plugin
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/contributing-patch.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/contributing-patch.asciidoc
 include::static/contributing-patch.asciidoc[]
 
 // Logstash Community Maintainer Guide
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/maintainer-guide.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/maintainer-guide.asciidoc
 include::static/maintainer-guide.asciidoc[]
 
 // A space is necessary here ^^^
@@ -119,12 +122,12 @@ include::static/maintainer-guide.asciidoc[]
 
 // Submitting a Plugin
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/submitting-a-plugin.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/submitting-a-plugin.asciidoc
 include::static/submitting-a-plugin.asciidoc[]
 
 // Glossary of Terms
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/glossary.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/glossary.asciidoc
 include::static/glossary.asciidoc[]
 
 // This is in the pluginbody.asciidoc itself
@@ -132,5 +135,5 @@ include::static/glossary.asciidoc[]
 
 // Release Notes
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/releasenotes.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/releasenotes.asciidoc
 include::static/releasenotes.asciidoc[]


### PR DESCRIPTION
Adds missing edit URL links and fixes the edit URL so that the links point to the correct version for the static docs. (For the plugin docs, the edit URL always points to master.)

The old way of sending users to master for all fixes made it easier for us but confusing to users, especially for content that was refactored between releases.  This way, the user will always find the expected content at the URL, and the burden is on us to cherry-pick edits into master. 