### PR TITLE
MINOR: Fix Readme section on running just the Java tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Most of the unit tests in Logstash are written using [rspec](http://rspec.info/)
     
 3- To run the subset of tests covering the Java codebase only run:
     
-    ./gradlew test
+    ./gradlew javaTests
 
 ### Plugins tests
 


### PR DESCRIPTION
As of #8517, the Gradle goal for running just the Java tests has changed to `javaTests`