### PR TITLE
Remove output workers setting from the doc

### DIFF
--- a/docs/include/output.asciidoc
+++ b/docs/include/output.asciidoc
@@ -8,7 +8,6 @@ The following configuration options are supported by all output plugins:
 | <<plugins-{type}s-{plugin}-codec>> |<<codec,codec>>|No
 | <<plugins-{type}s-{plugin}-enable_metric>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-id>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-workers>> |<<number,number>>|No
 |=======================================================================
 
 [id="plugins-{type}s-{plugin}-codec"]
@@ -50,8 +49,3 @@ output {
 ---------------------------------------------------------------------------------------------------
 
 
-[id="plugins-{type}s-{plugin}-workers"]
-===== `workers`
-
-  * Value type is <<string,string>>
-  * Default value is `1`

--- a/docs/static/performance-checklist.asciidoc
+++ b/docs/static/performance-checklist.asciidoc
@@ -82,7 +82,7 @@ following suggestions:
 
 * Threads in Java have names and you can use the `jstack`, `top`, and the VisualVM graphical tools to figure out which resources a given thread uses.
 
-* On Linux platforms, Logstash labels all the threads it can with something descriptive. For example, inputs show up as `[base]<inputname`, and filter workers show up as `[base]>workerN`, where N is an integer.  Where possible, other threads are also labeled to help you identify their purpose.
+* On Linux platforms, Logstash labels all the threads it can with something descriptive. For example, inputs show up as `[base]<inputname`, and pipeline workers show up as `[base]>workerN`, where N is an integer.  Where possible, other threads are also labeled to help you identify their purpose.
 
 [float]
 [[profiling-the-heap]]

--- a/docs/static/performance-checklist.asciidoc
+++ b/docs/static/performance-checklist.asciidoc
@@ -48,7 +48,6 @@ You may be tempted to jump ahead and change settings like `pipeline.workers` (`-
 . *Tune Logstash worker settings:*
 +
 * Begin by scaling up the number of pipeline workers by using the `-w` flag. This will increase the number of threads available for filters and outputs. It is safe to scale this up to a multiple of CPU cores, if need be, as the threads can become idle on I/O.
-* Each output can only be active in a single pipeline worker thread by default. You can increase this by changing the `workers` setting in the configuration block for each output. Never make this value larger than the number of pipeline workers.
 * You may also tune the output batch size. For many outputs, such as the Elasticsearch output, this setting will correspond to the size of I/O operations. In the case of the Elasticsearch output, this setting corresponds to the batch size.
 
 [[tuning-logstash]]
@@ -83,7 +82,7 @@ following suggestions:
 
 * Threads in Java have names and you can use the `jstack`, `top`, and the VisualVM graphical tools to figure out which resources a given thread uses.
 
-* On Linux platforms, Logstash labels all the threads it can with something descriptive. For example, inputs show up as `[base]<inputname`, filter/output workers show up as `[base]>workerN`, where N is an integer.  Where possible, other threads are also labeled to help you identify their purpose.
+* On Linux platforms, Logstash labels all the threads it can with something descriptive. For example, inputs show up as `[base]<inputname`, and filter workers show up as `[base]>workerN`, where N is an integer.  Where possible, other threads are also labeled to help you identify their purpose.
 
 [float]
 [[profiling-the-heap]]

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -83,10 +83,6 @@ The `logstash.yml` file includes the following settings:
   CPU is not saturated, consider increasing this number to better utilize machine processing power.
 | Number of the host's CPU cores
 
-| `pipeline.output.workers`
-| The number of workers to use per output plugin instance.
-| `1`
-
 | `pipeline.batch.size`
 | The maximum number of events an individual worker thread will collect from inputs
   before attempting to execute its filters and outputs.


### PR DESCRIPTION
Removed the output workers settings plus pipeline.output.workers. Resolves the doc-related issues described in https://github.com/elastic/logstash/issues/7512 and  https://github.com/elastic/logstash/issues/7884. However the losgstash.yml file still needs to be updated as requested in https://github.com/elastic/logstash/issues/7884. Should I do that, too?

@jordansissel Can you review and also look at the section about performance tuning to verify that it's accurate for 6.0? 

I ran some tests in 5.0, and it looks like the workers output setting is not used there either. Should I backport all of these changes to 5.6, too?