### PR TITLE
#6961 use codegen to invoke the appropriate ByteBuffer Cleaner depending on JVM version

### DIFF
--- a/logstash-core/src/main/java/org/logstash/LogstashJavaCompat.java
+++ b/logstash-core/src/main/java/org/logstash/LogstashJavaCompat.java
@@ -1,0 +1,72 @@
+package org.logstash;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collection;
+import org.codehaus.janino.ClassBodyEvaluator;
+import org.logstash.ackedqueue.io.ByteBufferCleaner;
+
+/**
+ * Logic around ensuring compatibility with Java 8 and 9 simultaneously.
+ */
+public final class LogstashJavaCompat {
+
+    /**
+     * True if current JVM is a Java 9 implementation.
+     */
+    public static final boolean IS_JAVA_9_OR_GREATER = isAtLeastJava9();
+
+    /**
+     * Sets up an appropriate implementation of {@link ByteBufferCleaner} depending no whether or
+     * not the current JVM is a Java 9 implementation.
+     * @return ByteBufferCleaner
+     */
+    public static ByteBufferCleaner setupBytebufferCleaner() {
+        final ClassBodyEvaluator se = new ClassBodyEvaluator();
+        final Collection<String> imports = new ArrayList<>();
+        imports.add("java.nio.MappedByteBuffer");
+        final String cleanerCode;
+        final String ctorCode;
+        final String fieldsCode;
+        if (isAtLeastJava9()) {
+            imports.add("sun.misc.Unsafe");
+            imports.add("java.lang.reflect.Field");
+            cleanerCode = "unsafe.invokeCleaner(buffer);";
+            ctorCode = "Field unsafeField = Unsafe.class.getDeclaredField(\"theUnsafe\");" +
+                "unsafeField.setAccessible(true);" +
+                "unsafe = (Unsafe) unsafeField.get(null);";
+            fieldsCode = "private final Unsafe unsafe;";
+        } else {
+            imports.add("sun.misc.Cleaner");
+            imports.add("sun.nio.ch.DirectBuffer");
+            cleanerCode = "Cleaner c=((DirectBuffer)buffer).cleaner();if(c != null){c.clean();}";
+            ctorCode = "";
+            fieldsCode = "";
+        }
+        se.setImplementedInterfaces(new Class[]{ByteBufferCleaner.class});
+        se.setClassName("ByteBufferCleanerImpl");
+        se.setDefaultImports(imports.toArray(new String[0]));
+        try {
+            return (ByteBufferCleaner) se.createInstance(
+                new StringReader(String.format(
+                    "%s public ByteBufferCleanerImpl() throws Exception{%s} public void clean(MappedByteBuffer buffer){%s}",
+                    fieldsCode, ctorCode, cleanerCode
+                ))
+            );
+        } catch (final Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    /**
+     * Identifies whether we're running on Java 9 by parsing the first component of the
+     * {@code "java.version"} system property. For Java 9 this value is assumed to start with a
+     * {@code "9"}.
+     * @return True iff running on Java 9
+     */
+    private static boolean isAtLeastJava9() {
+        final String version = System.getProperty("java.version");
+        final int end = version.indexOf('.');
+        return Integer.parseInt(version.substring(0, end > 0 ? end : version.length())) >= 9;
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/ByteBufferCleaner.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/ByteBufferCleaner.java
@@ -1,0 +1,16 @@
+package org.logstash.ackedqueue.io;
+
+import java.nio.MappedByteBuffer;
+
+/**
+ * Function that forces garbage collection of a {@link MappedByteBuffer}.
+ */
+@FunctionalInterface
+public interface ByteBufferCleaner {
+
+    /**
+     * Forces garbage collection of given buffer.
+     * @param buffer ByteBuffer to GC
+     */
+    void clean(MappedByteBuffer buffer);
+}

--- a/logstash-core/src/test/java/org/logstash/instruments/monitors/MemoryMonitorTest.java
+++ b/logstash-core/src/test/java/org/logstash/instruments/monitors/MemoryMonitorTest.java
@@ -1,6 +1,7 @@
 package org.logstash.instruments.monitors;
 
 import org.junit.Test;
+import org.logstash.LogstashJavaCompat;
 import org.logstash.instrument.monitors.MemoryMonitor;
 
 import java.util.Map;
@@ -17,7 +18,11 @@ public class MemoryMonitorTest {
     public void testEachHeapSpaceRepresented() {
         Map<String, Map<String, Object>> heap = MemoryMonitor.detect(MemoryMonitor.Type.All).getHeap();
         assertThat(heap, notNullValue());
-        assertThat(heap.keySet(), hasItems("PS Survivor Space", "PS Old Gen", "PS Eden Space"));
+        if (LogstashJavaCompat.IS_JAVA_9_OR_GREATER) {
+            assertThat(heap.keySet(), hasItems("G1 Old Gen", "G1 Survivor Space", "G1 Eden Space"));
+        } else {
+            assertThat(heap.keySet(), hasItems("PS Survivor Space", "PS Old Gen", "PS Eden Space"));
+        }
     }
 
     @Test


### PR DESCRIPTION
fixes Java9 compatibility being broken by #6961:

* Use code gen to either use `sun.misc.Unsafe#invokeCleaner` (Java 9) or `sun.misc.Cleaner` (Java 8) to force `munmap` of the `mmap`ed memory region backing `MmapPageIO`
   * Essentially this is the same approach used by Lucene but in a lot less code, thanks to us having Janino available at Runtime
* Fix memory monitor test to pass on Java 9 (Java 9 will run G1 here during tests since they use the default GC, so the old GCs naming doesn't apply)

---------------------------------

This makes at least `./gradlew javaTests` (this means JUnit only, RSpec still breaks but should be fine once JRuby `9.1.14.0` is out) pass on Java 9. Without this change, the code doesn't compile on Java 9 because of the unavailability of `sun.misc.Cleaner` there.