### PR TITLE
#8442 Java Pipeline Compiler

### DIFF
--- a/ci/unit_tests.sh
+++ b/ci/unit_tests.sh
@@ -19,14 +19,14 @@ if [[ $SELECTED_TEST_SUITE == $"core-fail-fast" ]]; then
   rake test:core-fail-fast
 elif [[ $SELECTED_TEST_SUITE == $"java" ]]; then
   echo "Running Java unit tests"
-  echo "Running test:core-java"
-  rake test:core-java
+  echo "Running Java Tests"
+  ./gradlew javaTests
 elif [[ $SELECTED_TEST_SUITE == $"ruby" ]]; then
   echo "Running Ruby unit tests"
   echo "Running test:install-core"
   rake test:install-core
-  echo "Running test:core-ruby"
-  rake test:core-ruby
+  echo "Running Ruby Tests"
+  ./gradlew rubyTests
 else
   echo "Running Java and Ruby unit tests"
   echo "Running test:install-core"

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -72,6 +72,13 @@ configurations.archives {
 
 task javaTests(type: Test) {
     exclude '/org/logstash/RSpecTests.class'
+    exclude 'org/logstash/config/ir/ConfigCompilerTest.class'
+}
+
+task rubyTests(type: Test) {
+    systemProperty 'logstash.core.root.dir', projectDir.absolutePath
+    include '/org/logstash/RSpecTests.class'
+    include 'org/logstash/config/ir/ConfigCompilerTest.class'
 }
 
 artifacts {

--- a/logstash-core/spec/logstash/compiler/compiler_spec.rb
+++ b/logstash-core/spec/logstash/compiler/compiler_spec.rb
@@ -47,7 +47,7 @@ describe LogStash::Compiler do
         end
       end
 
-      subject(:pipeline) { described_class.compile_sources(sources_with_metadata, settings) }
+      subject(:pipeline) { described_class.compile_sources(sources_with_metadata, false) }
 
       it "should generate a hash" do
         expect(pipeline.unique_hash).to be_a(String)
@@ -100,7 +100,7 @@ describe LogStash::Compiler do
   describe "compiling imperative" do
     let(:source_id) { "fake_sourcefile" }
     let(:source_with_metadata) { org.logstash.common.SourceWithMetadata.new(source_protocol, source_id, 0, 0, source) }
-    subject(:compiled) { described_class.compile_imperative(source_with_metadata, settings) }
+    subject(:compiled) { described_class.compile_imperative(source_with_metadata, settings.get_value("config.support_escapes")) }
 
     context "when config.support_escapes" do
       let(:parser) { LogStashCompilerLSCLGrammarParser.new }

--- a/logstash-core/src/main/java/org/logstash/config/ir/ConfigCompiler.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/ConfigCompiler.java
@@ -1,0 +1,69 @@
+package org.logstash.config.ir;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.jruby.RubyHash;
+import org.jruby.javasupport.JavaUtil;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.runtime.load.LoadService;
+import org.logstash.RubyUtil;
+import org.logstash.common.IncompleteSourceWithMetadataException;
+import org.logstash.common.SourceWithMetadata;
+
+/**
+ * Java Implementation of the config compiler that is implemented by wrapping the Ruby
+ * {@code LogStash::Compiler}.
+ */
+public final class ConfigCompiler {
+
+    private ConfigCompiler() {
+        // Utility Class
+    }
+
+    /**
+     * @param config Logstash Config String
+     * @param supportEscapes The value of the setting {@code config.support_escapes}
+     * @return Compiled {@link PipelineIR}
+     * @throws IncompleteSourceWithMetadataException On Broken Configuration
+     */
+    public static PipelineIR configToPipelineIR(final String config, final boolean supportEscapes)
+        throws IncompleteSourceWithMetadataException {
+        ensureLoadpath();
+        final IRubyObject compiler = RubyUtil.RUBY.executeScript(
+            "require 'logstash/compiler'\nLogStash::Compiler",
+            ""
+        );
+        final IRubyObject code =
+            compiler.callMethod(RubyUtil.RUBY.getCurrentContext(), "compile_sources",
+                new IRubyObject[]{
+                    RubyUtil.RUBY.newArray(
+                        JavaUtil.convertJavaToRuby(
+                            RubyUtil.RUBY,
+                            new SourceWithMetadata("str", "pipeline", 0, 0, config)
+                        )
+                    ),
+                    RubyUtil.RUBY.newBoolean(supportEscapes)
+                }
+            );
+        return (PipelineIR) code.toJava(PipelineIR.class);
+    }
+
+    /**
+     * Loads the logstash-core/lib path if the load service can't find {@code logstash/compiler}.
+     */
+    private static void ensureLoadpath() {
+        final LoadService loader = RubyUtil.RUBY.getLoadService();
+        if (loader.findFileForLoad("logstash/compiler").library == null) {
+            final RubyHash environment = RubyUtil.RUBY.getENV();
+            final Path root = Paths.get(
+                System.getProperty("logstash.core.root.dir", "")
+            ).toAbsolutePath();
+            final String gems = root.getParent().resolve("vendor").resolve("bundle")
+                .resolve("jruby").resolve("2.3.0").toFile().getAbsolutePath();
+            environment.put("GEM_HOME", gems);
+            environment.put("GEM_PATH", gems);
+            loader.addPaths(root.resolve("lib").toFile().getAbsolutePath()
+            );
+        }
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/config/ir/ConfigCompilerTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/ConfigCompilerTest.java
@@ -1,0 +1,17 @@
+package org.logstash.config.ir;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ConfigCompilerTest {
+
+    @Test
+    public void testConfigToPipelineIR() throws Exception {
+        final PipelineIR pipelineIR =
+            ConfigCompiler.configToPipelineIR("input {stdin{}} output{stdout{}}", false);
+        assertThat(pipelineIR.getOutputPluginVertices().size(), is(1));
+        assertThat(pipelineIR.getFilterPluginVertices().size(), is(0));
+    }
+}


### PR DESCRIPTION
This allows writing end to end pipeline tests in Java/JUnit for #8442:

* Adds a Java wrapper for the pipeline compiler so it can be invoked from Java
   * The also cleans up the Ruby side of things a little in terms of duplication (though obviously the Ruby-Java-Ruby step makes things a little trickier .. still imo this is the only way to get this functionality into Java tests that doesn't require replacing `treetop`)
* Adds an example JUnit test for it

Now for the trickier build adjustments needed :)

* Moved the RSpec tests and the new tests under a new Gradle goal `RubyTests` and adjusted CI scripting accordingly
  * To me, it seemed like the cleanest approach to do it like this since it still leaves us with only 2 separate sets of unit tests without adding another Gradle + Rake interaction (Note here, that you need to have your `vendor` dir bootstrapped correctly for the new test as well as the existing JUnit RSpec wrapper to work. Unfortunately, a self-contained Gradle target for the RSpec tests requires larger changes to the build ... I coded those up and they can be found in #8543, but I don't think they should be mixed with this one :))