### PR TITLE
[DOCS] Added troubleshooting info for monitoring

### DIFF
--- a/docs/static/monitoring.asciidoc
+++ b/docs/static/monitoring.asciidoc
@@ -14,9 +14,10 @@ runtime stats.
 
 You can use the basic <<monitoring,monitoring APIs>> providing by Logstash
 to retrieve these metrics. These APIs are available by default without
-requiring any extra configuration. 
+requiring any extra configuration.
 
 ifdef::include-xpack[]
 :edit_url!:
 include::{xls-repo-dir}/monitoring/intro.asciidoc[]
+include::{xls-repo-dir}/monitoring/troubleshooting.asciidoc[]
 endif::include-xpack[]


### PR DESCRIPTION
This PR adds a link to troubleshooting information in the "Monitoring Logstash" section of the documentation. 