### PR TITLE
Bump version to 6.0.0

### DIFF
--- a/Gemfile.jruby-2.3.lock.release
+++ b/Gemfile.jruby-2.3.lock.release
@@ -1,7 +1,7 @@
 PATH
   remote: ./logstash-core
   specs:
-    logstash-core (6.0.0.rc2-java)
+    logstash-core (6.0.0-java)
       chronic_duration (= 0.10.6)
       clamp (~> 0.6.5)
       concurrent-ruby (~> 1.0, >= 1.0.5)
@@ -28,7 +28,7 @@ PATH
   remote: ./logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 6.0.0.rc2)
+      logstash-core (= 6.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/versions.yml
+++ b/versions.yml
@@ -1,6 +1,6 @@
 ---
-logstash: 6.0.0-rc2
-logstash-core: 6.0.0-rc2
+logstash: 6.0.0
+logstash-core: 6.0.0
 logstash-core-plugin-api: 2.1.16
 jruby:
   version: 9.1.13.0


### PR DESCRIPTION
This commit bumps the Logstash version from 6.0.0-rc2 to 6.0.0.