### PR TITLE
MINOR: Remove duplication and fix docs in bundler shim

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -2,27 +2,17 @@
 
 # This is basically a copy of the original bundler "bundle" shim
 # with the addition of the loading of our Bundler patches that
-# modifies the .lock file naming. Without this, using the original Bundler bundle
-# shim would result in creating or failing on a Gemfile.lock file.
+# modify Bundler's caching behaviour.
 
 # Exit cleanly from an early interrupt
 Signal.trap("INT") { exit 1 }
 
 require_relative "../lib/bootstrap/environment"
-::Gem.clear_paths
 
-ENV['GEM_HOME'] = ENV['GEM_PATH'] = LogStash::Environment.logstash_gem_home
-::Gem.paths = ENV
+LogStash::Bundler.setup!
 
-ENV["BUNDLE_GEMFILE"] = LogStash::Environment::GEMFILE_PATH
-
-require "bundler"
 require "bundler/cli"
 require "bundler/friendly_errors"
-LogStash::Bundler.patch!
-
-::Bundler.settings[:path] = LogStash::Environment::BUNDLE_DIR
-::Bundler.settings[:gemfile] = LogStash::Environment::GEMFILE_PATH
 
 ::Bundler.with_friendly_errors do
   ::Bundler::CLI.start(ARGV, :debug => true)


### PR DESCRIPTION
Two things here:

* The documentation isn't factually correct anymore (and was incomplete since we still hack the caching behavior) as of #8525 => fixed it
* The code in `LogStash::Bundler.setup!` is the same as the code I deleted here, today it reads:

```rb
    def setup!(options = {})
      options = {:without => [:development]}.merge(options)
      options[:without] = Array(options[:without])

      ::Gem.clear_paths
      ENV['GEM_HOME'] = ENV['GEM_PATH'] = Environment.logstash_gem_home
      ::Gem.paths = ENV

      # set BUNDLE_GEMFILE ENV before requiring bundler to avoid bundler recurse and load unrelated Gemfile(s)
      ENV["BUNDLE_GEMFILE"] = Environment::GEMFILE_PATH

      require "bundler"
      LogStash::Bundler.patch!

      ::Bundler.settings[:path] = Environment::BUNDLE_DIR
      ::Bundler.settings[:without] = options[:without].join(":")
      # in the context of Bundler.setup it looks like this is useless here because Gemfile path can only be specified using
      # the ENV, see https://github.com/bundler/bundler/blob/v1.8.3/lib/bundler/shared_helpers.rb#L103
      ::Bundler.settings[:gemfile] = Environment::GEMFILE_PATH

      ::Bundler.reset!
      ::Bundler.setup
    end
```

=> we should really dry this up like I did here, these hacks are super tricky to understand. If we duplicate them it'll take even longer to clean those up that we don't require anymore :)