### PR TITLE
MINOR: Improve Gradle rubyTests target to properly recognize changes in Ruby code

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -72,14 +72,21 @@ configurations.archives {
 
 task javaTests(type: Test) {
     exclude '/org/logstash/RSpecTests.class'
-    exclude 'org/logstash/config/ir/ConfigCompilerTest.class'
+    exclude '/org/logstash/config/ir/ConfigCompilerTest.class'
 }
 
 task rubyTests(type: Test) {
+    inputs.files fileTree("${projectDir}/lib")
+    inputs.files fileTree("${projectDir}/spec")
     systemProperty 'logstash.core.root.dir', projectDir.absolutePath
     include '/org/logstash/RSpecTests.class'
-    include 'org/logstash/config/ir/ConfigCompilerTest.class'
+    include '/org/logstash/config/ir/ConfigCompilerTest.class'
 }
+
+test {
+    exclude '/**'
+}
+test.dependsOn javaTests, rubyTests
 
 artifacts {
     sources(sourcesJar) {


### PR DESCRIPTION
This target runs our actual Ruby, but currently only watches for changes in the Java `src` path as per Gradle defaults, so a change to Ruby sources will not cause `rubyTests` to run again unless you also hit `clean`.

=> fixed by adding Ruby source paths as inputs for `rubyTests`.

I also fixed the `test` target, this was running all tests, which meant it ran the `rubyTests` target without its config/dependencies and just worked accidentally.

=> fixed by making `test` itself not run any tests, and simply be the parent for both `rubyTests` and `javaTests`. Any other solution would require duplicating config between `rubyTests` and `test` as far as I understand Gradle.