### PR TITLE
MINOR: Remove JMH main EntryPoints

### DIFF
--- a/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/EventSerializationBenchmark.java
+++ b/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/EventSerializationBenchmark.java
@@ -17,10 +17,6 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.runner.Runner;
-import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
-import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.util.NullOutputStream;
 
 @Warmup(iterations = 3, time = 500, timeUnit = TimeUnit.MILLISECONDS)
@@ -66,13 +62,5 @@ public class EventSerializationBenchmark {
         for (int i = 0; i < EVENTS_PER_INVOCATION; ++i) {
             SINK.writeBytes(EVENT.toJson());
         }
-    }
-
-    public static void main(final String... args) throws RunnerException {
-        Options opt = new OptionsBuilder()
-            .include(EventSerializationBenchmark.class.getSimpleName())
-            .forks(2)
-            .build();
-        new Runner(opt).run();
     }
 }

--- a/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/EventSprintfBenchmark.java
+++ b/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/EventSprintfBenchmark.java
@@ -15,10 +15,6 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
-import org.openjdk.jmh.runner.Runner;
-import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
-import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 @Warmup(iterations = 3, time = 100, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
@@ -48,13 +44,5 @@ public class EventSprintfBenchmark {
         for (int i = 0; i < EVENTS_PER_INVOCATION; ++i) {
             blackhole.consume(EVENT.sprintf(i + "-%{[Foo]}"));
         }
-    }
-
-    public static void main(final String... args) throws RunnerException {
-        Options opt = new OptionsBuilder()
-            .include(EventSprintfBenchmark.class.getSimpleName())
-            .forks(2)
-            .build();
-        new Runner(opt).run();
     }
 }

--- a/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/QueueRWBenchmark.java
+++ b/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/QueueRWBenchmark.java
@@ -34,10 +34,6 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
-import org.openjdk.jmh.runner.Runner;
-import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
-import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 @Warmup(iterations = 3, time = 100, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
@@ -151,14 +147,6 @@ public class QueueRWBenchmark {
             blackhole.consume(queueArrayBlocking.take());
         }
         future.get();
-    }
-
-    public static void main(final String... args) throws RunnerException {
-        Options opt = new OptionsBuilder()
-            .include(QueueRWBenchmark.class.getSimpleName())
-            .forks(2)
-            .build();
-        new Runner(opt).run();
     }
 
     private static Settings settings(final boolean persisted) {

--- a/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/QueueWriteBenchmark.java
+++ b/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/QueueWriteBenchmark.java
@@ -24,10 +24,6 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.runner.Runner;
-import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
-import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 @Warmup(iterations = 3, time = 100, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
@@ -72,14 +68,6 @@ public class QueueWriteBenchmark {
             evnt.setTimestamp(Timestamp.now());
             queue.write(evnt);
         }
-    }
-
-    public static void main(final String... args) throws RunnerException {
-        Options opt = new OptionsBuilder()
-            .include(QueueWriteBenchmark.class.getSimpleName())
-            .forks(2)
-            .build();
-        new Runner(opt).run();
     }
 
     private static Settings settings() {


### PR DESCRIPTION
These entry points are completely useless, I only added them initially for comfort when running from Idea. The idea JMH plugin is able to run benchmarks without them though (didn't realize that at the time) => just dead code.