### PR TITLE
MINOR: Cleanup Java Test Code in Production Classpath

### DIFF
--- a/logstash-core/spec/logstash/event_spec.rb
+++ b/logstash-core/spec/logstash/event_spec.rb
@@ -146,7 +146,7 @@ describe LogStash::Event do
     end
 
     it "should set XXJavaProxy Jackson crafted" do
-      proxy = org.logstash.Util.getMapFixtureJackson()
+      proxy = org.logstash.RspecTestUtils.getMapFixtureJackson()
       # proxy is {"string": "foo", "int": 42, "float": 42.42, "array": ["bar","baz"], "hash": {"string":"quux"} }
       e = LogStash::Event.new()
       e.set("[proxy]", proxy)
@@ -159,7 +159,7 @@ describe LogStash::Event do
     end
 
     it "should set XXJavaProxy hand crafted" do
-      proxy = org.logstash.Util.getMapFixtureHandcrafted()
+      proxy = org.logstash.RspecTestUtils.getMapFixtureHandcrafted()
       # proxy is {"string": "foo", "int": 42, "float": 42.42, "array": ["bar","baz"], "hash": {"string":"quux"} }
       e = LogStash::Event.new()
       e.set("[proxy]", proxy)

--- a/logstash-core/src/main/java/org/logstash/Util.java
+++ b/logstash-core/src/main/java/org/logstash/Util.java
@@ -1,9 +1,6 @@
 package org.logstash;
 
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -11,29 +8,6 @@ import java.util.Map;
 
 public class Util {
     private Util() {}
-
-    public static Object getMapFixtureJackson() throws IOException {
-        StringBuilder json = new StringBuilder();
-        json.append("{");
-        json.append("\"string\": \"foo\", ");
-        json.append("\"int\": 42, ");
-        json.append("\"float\": 42.42, ");
-        json.append("\"array\": [\"bar\",\"baz\"], ");
-        json.append("\"hash\": {\"string\":\"quux\"} }");
-        return ObjectMappers.JSON_MAPPER.readValue(json.toString(), Object.class);
-    }
-
-    public static Map<String, Object> getMapFixtureHandcrafted() {
-        HashMap<String, Object> inner = new HashMap<>();
-        inner.put("string", "quux");
-        HashMap<String, Object> map = new HashMap<>();
-        map.put("string", "foo");
-        map.put("int", 42);
-        map.put("float", 42.42);
-        map.put("array", Arrays.asList("bar", "baz"));
-        map.put("hash", inner);
-        return map;
-    }
 
     @SuppressWarnings("unchecked")
     public static void mapMerge(final Map<String, Object> target, final Map<String, Object> add) {

--- a/logstash-core/src/test/java/org/logstash/RspecTestUtils.java
+++ b/logstash-core/src/test/java/org/logstash/RspecTestUtils.java
@@ -1,0 +1,35 @@
+package org.logstash;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility Methods used in RSpec Tests.
+ */
+public final class RspecTestUtils {
+
+    public static Object getMapFixtureJackson() throws IOException {
+        StringBuilder json = new StringBuilder();
+        json.append("{");
+        json.append("\"string\": \"foo\", ");
+        json.append("\"int\": 42, ");
+        json.append("\"float\": 42.42, ");
+        json.append("\"array\": [\"bar\",\"baz\"], ");
+        json.append("\"hash\": {\"string\":\"quux\"} }");
+        return ObjectMappers.JSON_MAPPER.readValue(json.toString(), Object.class);
+    }
+
+    public static Map<String, Object> getMapFixtureHandcrafted() {
+        HashMap<String, Object> inner = new HashMap<>();
+        inner.put("string", "quux");
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("string", "foo");
+        map.put("int", 42);
+        map.put("float", 42.42);
+        map.put("array", Arrays.asList("bar", "baz"));
+        map.put("hash", inner);
+        return map;
+    }
+}


### PR DESCRIPTION
Thanks for #8517 there is no more need for keeping code used in `rspec` only on the production classpath.
=> Moved these two methods to the test classpath.