### PR TITLE
#8154 break cyclic dependency () between Java and Ruby

### DIFF
--- a/logstash-core/lib/logstash/timestamp.rb
+++ b/logstash-core/lib/logstash/timestamp.rb
@@ -2,8 +2,11 @@
 
 require "logstash/namespace"
 
+# Force loading the RubyUtil to ensure its loaded before the Timestamp class is set up in Ruby since
+# Timestamp depends on Ruby classes that are dynamically set up by Java code.
+java_import org.logstash.RubyUtil
+
 module LogStash
-  class TimestampParserError < StandardError; end
 
   class Timestamp
     include Comparable

--- a/logstash-core/src/main/java/org/logstash/RubyUtil.java
+++ b/logstash-core/src/main/java/org/logstash/RubyUtil.java
@@ -42,6 +42,8 @@ public final class RubyUtil {
 
     public static final RubyClass LOGSTASH_ERROR;
 
+    public static final RubyClass TIMESTAMP_PARSER_ERROR;
+
     static {
         RUBY = Ruby.getGlobalRuntime();
         LOGSTASH_MODULE = RUBY.getOrCreateModule("LogStash");
@@ -56,11 +58,15 @@ public final class RubyUtil {
             "Event", JrubyEventExtLibrary.RubyEvent::new, JrubyEventExtLibrary.RubyEvent.class
         );
         final RubyModule json = LOGSTASH_MODULE.defineOrGetModuleUnder("Json");
+        final RubyClass stdErr = RUBY.getStandardError();
         LOGSTASH_ERROR = LOGSTASH_MODULE.defineClassUnder(
-            "Error", RUBY.getStandardError(), RubyUtil.LogstashRubyError::new
+            "Error", stdErr, RubyUtil.LogstashRubyError::new
         );
         PARSER_ERROR = json.defineClassUnder(
             "ParserError", LOGSTASH_ERROR, RubyUtil.LogstashRubyParserError::new
+        );
+        TIMESTAMP_PARSER_ERROR = LOGSTASH_MODULE.defineClassUnder(
+            "TimestampParserError", stdErr, RubyUtil.LogstashTimestampParserError::new
         );
         GENERATOR_ERROR = json.defineClassUnder("GeneratorError", LOGSTASH_ERROR,
             RubyUtil.LogstashRubyGeneratorError::new
@@ -147,6 +153,14 @@ public final class RubyUtil {
     public static final class LogstashRubyGeneratorError extends RubyException {
 
         public LogstashRubyGeneratorError(final Ruby runtime, final RubyClass metaClass) {
+            super(runtime, metaClass);
+        }
+    }
+
+    @JRubyClass(name = "TimestampParserError")
+    public static final class LogstashTimestampParserError extends RubyException {
+
+        public LogstashTimestampParserError(final Ruby runtime, final RubyClass metaClass) {
             super(runtime, metaClass);
         }
     }

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
@@ -78,8 +78,7 @@ public final class JrubyTimestampExtLibrary {
                     this.timestamp = new Timestamp(time.toString());
                 } catch (IllegalArgumentException e) {
                     throw new RaiseException(
-                            getRuntime(),
-                            RubyUtil.LOGSTASH_MODULE.getClass("TimestampParserError"),
+                            getRuntime(), RubyUtil.TIMESTAMP_PARSER_ERROR,
                             "invalid timestamp string format " + time,
                             true
                     );
@@ -157,8 +156,7 @@ public final class JrubyTimestampExtLibrary {
                 }
              } catch (IllegalArgumentException e) {
                 throw new RaiseException(
-                        context.runtime,
-                        RubyUtil.LOGSTASH_MODULE.getClass("TimestampParserError"),
+                        context.runtime, RubyUtil.TIMESTAMP_PARSER_ERROR,
                         "invalid timestamp format " + e.getMessage(),
                         true
                 );
@@ -174,8 +172,7 @@ public final class JrubyTimestampExtLibrary {
                     return fromRString(context.runtime, (RubyString) time);
                 } catch (IllegalArgumentException e) {
                     throw new RaiseException(
-                            context.runtime,
-                            RubyUtil.LOGSTASH_MODULE.getClass("TimestampParserError"),
+                            context.runtime, RubyUtil.TIMESTAMP_PARSER_ERROR,
                             "invalid timestamp format " + e.getMessage(),
                             true
                     );


### PR DESCRIPTION
Exactly the same as #8529, simply missed one error class in that PR.
Motivation and justification for this change can be found in #8529 and applies 1:1