### PR TITLE
Release notes for 5.6.4

### DIFF
--- a/docs/index-shared1.asciidoc
+++ b/docs/index-shared1.asciidoc
@@ -1,8 +1,8 @@
 :branch:                5.6
 :major-version:         5.x
-:logstash_version:      5.6.3
-:elasticsearch_version: 5.6.3
-:kibana_version:        5.6.3
+:logstash_version:      5.6.4
+:elasticsearch_version: 5.6.4
+:kibana_version:        5.6.4
 :docker-image:          docker.elastic.co/logstash/logstash:{logstash_version}
 
 //////////

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -3,10 +3,17 @@
 
 This section summarizes the changes in the following releases:
 
+* <<logstash-5-6-4,Logstash 5.6.4>>
 * <<logstash-5-6-3,Logstash 5.6.3>>
 * <<logstash-5-6-2,Logstash 5.6.2>>
 * <<logstash-5-6-1,Logstash 5.6.1>>
 * <<logstash-5-6-0,Logstash 5.6.0>>
+
+[[logstash-5-6-4]]
+=== Logstash 5.6.4 Release Notes
+* Fix bug where setting `log.level=debug` would cause Logstash to crash
+* Fix bug where queues configured to use a single page would not be able to process events. This also wound up being a small perf boost. https://github.com/elastic/logstash/pull/8275[#8275]
+* Fix bug where a `0` exit status could be emitted when exiting due to an error by the `logstash-plugin.bat` command on windows.
 
 [[logstash-5-6-3]]
 === Logstash 5.6.3 Release Notes


### PR DESCRIPTION
Covers the range `0a4bc...v5.6.3`

Also bumps the docs version.