### PR TITLE
LIR: merge hash attributes of same name to support legacy configurations

### DIFF
--- a/logstash-core/spec/logstash/compiler/compiler_spec.rb
+++ b/logstash-core/spec/logstash/compiler/compiler_spec.rb
@@ -193,6 +193,35 @@ describe LogStash::Compiler do
           expect(c_plugin).to ir_eql(j.iPlugin(INPUT, "generator", expected_plugin_args))
         end
       end
+
+      describe "a filter plugin that repeats a Hash directive" do
+        let(:source) { "input { } filter { #{plugin_source} } output { } " }
+        subject(:c_plugin) { compiled[:filter] }
+
+        let(:plugin_source) do
+          %q[
+              grok {
+                match => { "message" => "%{WORD:word}" }
+                match => { "examplefield" => "%{NUMBER:num}" }
+                break_on_match => false
+              }
+          ]
+        end
+
+        let(:expected_plugin_args) do
+          {
+            "match" => {
+              "message" => "%{WORD:word}",
+              "examplefield" => "%{NUMBER:num}"
+            },
+            "break_on_match" => "false"
+          }
+        end
+
+        it "should merge the contents of the individual directives" do
+          expect(c_plugin).to ir_eql(j.iPlugin(FILTER, "grok", expected_plugin_args))
+        end
+      end
     end
 
     context "inputs" do


### PR DESCRIPTION
A [build failure][] of the grok plugin when run through LIR/lscl indicates that
there is an expectation for multiple Attributes of the same name to be merged
together.

This commit ports the failing spec in the plugin to an abstraction that can be
tested within logstash-core, and adds a caveat to the LSCL LIR-builder to
ensure that we merge the hashes in a way that is compatible with legacy
behaviour.

NOTE: when multiple Attributes of the same name are used in a single config,
it's possible to create configurations that circumvent `AST::Hash`'s ability to
report duplicate keys.

[build failure]: https://travis-ci.org/logstash-plugins/logstash-filter-grok/builds/293778268

Discovered while working on logstash-plugins/logstash-filter-grok#124