### PR TITLE
 #7135 add Gradle task for bootstrapping and running all integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ Most of the unit tests in Logstash are written using [rspec](http://rspec.info/)
     
     ./gradlew javaTests
 
+3- To execute the complete test-suite including the integration tests run:
+
+    ./gradlew check
+
 ### Plugins tests
 
 To run the tests of all currently installed plugins:

--- a/build.gradle
+++ b/build.gradle
@@ -200,7 +200,7 @@ task installIntegrationTestGems(dependsOn: installIntegrationTestBundler, type: 
   outputs.files file("${projectDir}/qa/integration/Gemfile.lock")
   standardOutput = new ExecLogOutputStream(System.out)
   errorOutput =  new ExecLogOutputStream(System.err)
-  commandLine jrubyBin, bundleBin, "update"
+  commandLine jrubyBin, bundleBin, "install"
 }
 
 def rubyIntegrationSpecs = project.hasProperty("rubyIntegrationSpecs") ? ((String) project.property("rubyIntegrationSpecs")).split(/\s+/) : []

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ allprojects {
 
 // fetch version from Logstash's master versions.yml file
 def versionMap = (Map) (new Yaml()).load(new File("${projectDir}/versions.yml").text)
+version = versionMap['logstash-core']
 
 String jRubyURL
 String jRubyVersion
@@ -136,8 +137,10 @@ task downloadAndInstallJRuby(dependsOn: verifyFile, type: Copy) {
     into "${projectDir}/vendor/jruby"
 }
 
-def jrubyBin = './vendor/jruby/bin/jruby' +
+def jrubyBin = "${projectDir}/vendor/jruby/bin/jruby" +
   (System.getProperty("os.name").startsWith("Windows") ? '.bat' : '')
+
+def rakeBin = "${projectDir}/vendor/jruby/bin/rake"
 
 task installTestGems(dependsOn: downloadAndInstallJRuby, type: Exec) {
   workingDir projectDir
@@ -153,9 +156,68 @@ task installTestGems(dependsOn: downloadAndInstallJRuby, type: Exec) {
   environment "USE_RUBY", "1"
   standardOutput = new ExecLogOutputStream(System.out)
   errorOutput =  new ExecLogOutputStream(System.err)
-  commandLine jrubyBin, "${projectDir}/vendor/jruby/bin/rake", "test:install-core"
+  commandLine jrubyBin, rakeBin, "test:install-core"
+}
+
+task assembleTarDistribution(dependsOn: installTestGems, type: Exec) {
+  workingDir projectDir
+  inputs.files fileTree("${projectDir}/rakelib")
+  inputs.files fileTree("${projectDir}/logstash-core/lib")
+  inputs.files fileTree("${projectDir}/logstash-core/src")
+  outputs.files file("${buildDir}/logstash-${project.version}.tar.gz")
+  standardOutput = new ExecLogOutputStream(System.out)
+  errorOutput =  new ExecLogOutputStream(System.err)
+  commandLine jrubyBin, rakeBin, "artifact:tar"
+}
+
+task unpackTarDistribution(dependsOn: assembleTarDistribution, type: Copy) {
+  def tar = file("${buildDir}/logstash-${project.version}-SNAPSHOT.tar.gz")
+  inputs.files tar
+  outputs.files fileTree("${buildDir}/logstash-${project.version}-SNAPSHOT")
+  from tarTree(tar)
+  into {buildDir}
+}
+
+def bundleBin = "${projectDir}/vendor/bundle/jruby/2.3.0/bin/bundle"
+def gemPath = "${buildDir}/qa/integration/gems"
+
+task installIntegrationTestBundler(dependsOn: unpackTarDistribution, type: Exec) {
+  outputs.files fileTree("${gemPath}/gems/bundler-1.16.0")
+  environment "GEM_PATH", gemPath
+  environment "GEM_HOME", gemPath
+  standardOutput = new ExecLogOutputStream(System.out)
+  errorOutput =  new ExecLogOutputStream(System.err)
+  commandLine jrubyBin, "${projectDir}/vendor/jruby/bin/gem", "install", "bundler", "-v", "1.16.0"
+}
+
+task installIntegrationTestGems(dependsOn: installIntegrationTestBundler, type: Exec) {
+  workingDir "${projectDir}/qa/integration"
+  environment "GEM_PATH", gemPath
+  environment "GEM_HOME", gemPath
+  inputs.files file("${projectDir}/qa/integration/Gemfile")
+  inputs.files file("${projectDir}/qa/integration/integration_tests.gemspec")
+  outputs.files fileTree("${gemPath}/gems")
+  outputs.files file("${projectDir}/qa/integration/Gemfile.lock")
+  standardOutput = new ExecLogOutputStream(System.out)
+  errorOutput =  new ExecLogOutputStream(System.err)
+  commandLine jrubyBin, bundleBin, "update"
+}
+
+def rubyIntegrationSpecs = project.hasProperty("rubyIntegrationSpecs") ? ((String) project.property("rubyIntegrationSpecs")).split(/\s+/) : []
+
+task runIntegrationTests(dependsOn: installIntegrationTestGems, type: Exec) {
+  workingDir "${projectDir}/qa/integration"
+  environment "JAVA_OPTS", ""
+  environment "GEM_PATH", gemPath
+  environment "GEM_HOME", gemPath
+  standardOutput = new ExecLogOutputStream(System.out)
+  errorOutput =  new ExecLogOutputStream(System.err)
+  commandLine([jrubyBin, bundleBin, "exec", "rspec"].plus((Collection<String>)rubyIntegrationSpecs))
 }
 
 // If you are running a JRuby snapshot we will skip the integrity check.
 verifyFile.onlyIf { doChecksum }
 bootstrap.dependsOn installTestGems
+
+runIntegrationTests.shouldRunAfter tasks.getByPath(":logstash-core:test")
+check.dependsOn runIntegrationTests

--- a/ci/integration_tests.sh
+++ b/ci/integration_tests.sh
@@ -9,35 +9,26 @@ export JRUBY_OPTS="-J-Xmx1g"
 export SPEC_OPTS="--order rand --format documentation"
 export CI=true
 
-rm -rf build && mkdir build
-
-echo "Building tar"
-rake artifact:tar
-cd build
-tar xf *.tar.gz
-
-cd ../qa/integration
-echo "Installing test dependencies"
-bundle install
-
 if [[ $1 = "setup" ]]; then
  echo "Setup only, no tests will be run"
  exit 0
 
 elif [[ $1 == "split" ]]; then
+    cd qa/integration 
     glob1=(specs/*spec.rb)
     glob2=(specs/**/*spec.rb)
     all_specs=("${glob1[@]}" "${glob2[@]}")
 
     specs0=${all_specs[@]::$((${#all_specs[@]} / 2 ))}
     specs1=${all_specs[@]:$((${#all_specs[@]} / 2 ))}
-
+    cd ..
+    cd ..
     if [[ $2 == 0 ]]; then
        echo "Running the first half of integration specs: $specs0"
-       bundle exec rspec $specs0
+       ./gradlew runIntegrationTests -PrubyIntegrationSpecs="$specs0"
     elif [[ $2 == 1 ]]; then
        echo "Running the second half of integration specs: $specs1"
-       bundle exec rspec $specs1
+       ./gradlew runIntegrationTests -PrubyIntegrationSpecs="$specs1"
     else
        echo "Error, must specify 0 or 1 after the split. For example ci/integration_tests.sh split 0"
        exit 1
@@ -45,9 +36,9 @@ elif [[ $1 == "split" ]]; then
 
 elif [[ !  -z  $@  ]]; then
     echo "Running integration tests 'rspec $@'"
-    bundle exec rspec $@
+    ./gradlew runIntegrationTests -PrubyIntegrationSpecs="$@"
 
 else
     echo "Running all integration tests"
-    bundle exec rspec
+    ./gradlew runIntegrationTests
 fi

--- a/ci/integration_tests.sh
+++ b/ci/integration_tests.sh
@@ -21,8 +21,7 @@ elif [[ $1 == "split" ]]; then
 
     specs0=${all_specs[@]::$((${#all_specs[@]} / 2 ))}
     specs1=${all_specs[@]:$((${#all_specs[@]} / 2 ))}
-    cd ..
-    cd ..
+    cd ../..
     if [[ $2 == 0 ]]; then
        echo "Running the first half of integration specs: $specs0"
        ./gradlew runIntegrationTests -PrubyIntegrationSpecs="$specs0"

--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -180,7 +180,7 @@ class LogstashService < Service
   end  
   
   def get_version
-    `#{@logstash_bin} --version`
+    `#{@logstash_bin} --version`.split("\n").last
   end
   
   def get_version_yml


### PR DESCRIPTION
This gives us a clean all-in-one Gradle build including the ITs, complete with Gradle caching and bootstrapping of IT dependencies to resolve #7135.

* All in one build runs fine without any JRuby or Ruby installed on  (ran on a slow VM, my bad :)):
`./gradlew clean check`:

```sh

BUILD SUCCESSFUL in 41m 50s
36 actionable tasks: 24 executed, 12 up-to-date
➜  logstash git:(gradle-integration-tests)                 
```

* Added an optional parameter to run specific IT specs to the build to not change Jenkins behavior.
* Had to improve stability of the LS version IT by only reading the last line from stdout (in the Gradle env there are JAVA_OPTS set no matter what <= you get a line warning you about that in a version check call => only read version from the last line of stdout
* Adjusted readme.

----------------------

I think this is pretty neat for locally running/bootstrapping ITs + a lot more portable than the `rake` based approach since it's totally isolated from whatever local Ruby environment you have + it allows outside contributors to run the full suite in one command locally/easily without waiting for us to trigger Jenkins :)