### PR TITLE
LIR: merge hash attributes of same name to support legacy configurations

### DIFF
--- a/logstash-core/lib/logstash/compiler/lscl.rb
+++ b/logstash-core/lib/logstash/compiler/lscl.rb
@@ -101,9 +101,21 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
         else
           [k,v]
         end
-      }.reduce({}) do |hash,kv|
-        k,v = kv
-        hash[k] = v
+      }.reduce({}) do |hash, kv|
+        k, v = kv
+        existing = hash[k]
+        if existing.nil?
+          hash[k] = v
+        elsif existing.kind_of?(::Hash)
+          # For legacy reasons, a config can contain multiple `AST::Attribute`s with the same name
+          # and a hash-type value (e.g., "match" in the grok filter), which are merged into a single
+          # hash value; e.g., `{"match" => {"baz" => "bar"}, "match" => {"foo" => "bulb"}}` is
+          # interpreted as `{"match" => {"baz" => "bar", "foo" => "blub"}}`.
+          # (NOTE: this bypasses `AST::Hash`'s ability to detect duplicate keys)
+          hash[k] = existing.merge(v)
+        else
+          hash[k] = existing + v
+        end
         hash
       end
 

--- a/logstash-core/spec/logstash/compiler/compiler_spec.rb
+++ b/logstash-core/spec/logstash/compiler/compiler_spec.rb
@@ -193,6 +193,35 @@ describe LogStash::Compiler do
           expect(c_plugin).to ir_eql(j.iPlugin(INPUT, "generator", expected_plugin_args))
         end
       end
+
+      describe "a filter plugin that repeats a Hash directive" do
+        let(:source) { "input { } filter { #{plugin_source} } output { } " }
+        subject(:c_plugin) { compiled[:filter] }
+
+        let(:plugin_source) do
+          %q[
+              grok {
+                match => { "message" => "%{WORD:word}" }
+                match => { "examplefield" => "%{NUMBER:num}" }
+                break_on_match => false
+              }
+          ]
+        end
+
+        let(:expected_plugin_args) do
+          {
+            "match" => {
+              "message" => "%{WORD:word}",
+              "examplefield" => "%{NUMBER:num}"
+            },
+            "break_on_match" => "false"
+          }
+        end
+
+        it "should merge the contents of the individual directives" do
+          expect(c_plugin).to ir_eql(j.iPlugin(FILTER, "grok", expected_plugin_args))
+        end
+      end
     end
 
     context "inputs" do


### PR DESCRIPTION
Backports #8597 to 6.0

> This is a bug so it is valid to be merged into 6.0
> --  [@andrewvc  on #8597](https://github.com/elastic/logstash/pull/8597#issuecomment-342633075)