### PR TITLE
#8589 make Gradle bootstrap compatible with Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,6 +136,9 @@ task downloadAndInstallJRuby(dependsOn: verifyFile, type: Copy) {
     into "${projectDir}/vendor/jruby"
 }
 
+def jrubyBin = './vendor/jruby/bin/jruby' +
+  (System.getProperty("os.name").startsWith("Windows") ? '.bat' : '')
+
 task installTestGems(dependsOn: downloadAndInstallJRuby, type: Exec) {
   workingDir projectDir
   inputs.files file("${projectDir}/Gemfile.template")
@@ -145,9 +148,12 @@ task installTestGems(dependsOn: downloadAndInstallJRuby, type: Exec) {
   outputs.files file("${projectDir}/Gemfile.lock")
   outputs.files fileTree("${projectDir}/vendor/bundle/gems")
   outputs.files fileTree("${projectDir}/vendor/jruby")
+  // Override z_rubycheck.rb because we execute the vendored JRuby and don't have to guard against
+  // any Ruby environment leaking into the build
+  environment "GEM_PATH", "1"
   standardOutput = new ExecLogOutputStream(System.out)
   errorOutput =  new ExecLogOutputStream(System.err)
-  commandLine './vendor/jruby/bin/jruby', "${projectDir}/vendor/jruby/bin/rake".toString(), "test:install-core"
+  commandLine jrubyBin, "${projectDir}/vendor/jruby/bin/rake", "test:install-core"
 }
 
 // If you are running a JRuby snapshot we will skip the integrity check.


### PR DESCRIPTION
One obvious and one not so obvious fix:

* We need to invoke `jruby.bat` on Windows => made sure of that
* `z_rubycheck.rb` doesn't work properly on Windows (`jruby.bat` doesn't set up the Gem paths correctly which breaks the check against `Gem.ruby` (it's also broken because it uses `/` path separators, but no point in fixing that because of the `jruby.bat` issue)), but we don't need it to when calling from Gradle => just put our override for that file `USE_RUBY=1` in to turn the check off.

Now bootstrap + RSpec tests all pass fine on Windows again. Output of `./gradlew clean test`:

<img width="563" alt="screen shot 2017-11-08 at 10 15 18" src="https://user-images.githubusercontent.com/6490959/32540737-dd5f3860-c46d-11e7-8942-c7f9fc895320.png">
