### PR TITLE
MINOR: Cleanup RubyTimestamp Constructors

### DIFF
--- a/logstash-core/src/main/java/org/logstash/RubyUtil.java
+++ b/logstash-core/src/main/java/org/logstash/RubyUtil.java
@@ -47,13 +47,10 @@ public final class RubyUtil {
     static {
         RUBY = Ruby.getGlobalRuntime();
         LOGSTASH_MODULE = RUBY.getOrCreateModule("LogStash");
-        RUBY_TIMESTAMP_CLASS = setupLogstashClass("Timestamp", new ObjectAllocator() {
-            @Override
-            public JrubyTimestampExtLibrary.RubyTimestamp allocate(final Ruby runtime,
-                final RubyClass rubyClass) {
-                return new JrubyTimestampExtLibrary.RubyTimestamp(runtime, rubyClass);
-            }
-        }, JrubyTimestampExtLibrary.RubyTimestamp.class);
+        RUBY_TIMESTAMP_CLASS = setupLogstashClass(
+            "Timestamp",
+            JrubyTimestampExtLibrary.RubyTimestamp::new, JrubyTimestampExtLibrary.RubyTimestamp.class
+        );
         RUBY_EVENT_CLASS = setupLogstashClass(
             "Event", JrubyEventExtLibrary.RubyEvent::new, JrubyEventExtLibrary.RubyEvent.class
         );

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
@@ -33,25 +33,10 @@ public final class JrubyTimestampExtLibrary {
             super(runtime, klass);
         }
 
-        public RubyTimestamp(Ruby runtime, RubyClass klass, Timestamp timestamp) {
-            this(runtime, klass);
-            this.timestamp = timestamp;
-        }
-
-        public RubyTimestamp(Ruby runtime, Timestamp timestamp) {
-            this(runtime, RubyUtil.RUBY_TIMESTAMP_CLASS, timestamp);
-        }
-
-        public RubyTimestamp(Ruby runtime) {
-            this(runtime, new Timestamp());
-        }
-
-        public static RubyTimestamp newRubyTimestamp(Ruby runtime) {
-            return new RubyTimestamp(runtime);
-        }
-
         public static RubyTimestamp newRubyTimestamp(Ruby runtime, Timestamp timestamp) {
-            return new RubyTimestamp(runtime, timestamp);
+            final RubyTimestamp stamp = new RubyTimestamp(runtime, RubyUtil.RUBY_TIMESTAMP_CLASS);
+            stamp.timestamp = timestamp;
+            return stamp;
         }
 
         public Timestamp getTimestamp() {
@@ -199,7 +184,7 @@ public final class JrubyTimestampExtLibrary {
         @JRubyMethod(name = "now", meta = true)
         public static IRubyObject ruby_now(ThreadContext context, IRubyObject recv)
         {
-            return RubyTimestamp.newRubyTimestamp(context.runtime);
+            return RubyTimestamp.newRubyTimestamp(context.runtime, new Timestamp());
         }
 
         @JRubyMethod(name = "utc")


### PR DESCRIPTION
Obvious cleanup, all these redundant constructors are unused as shown by this still passing all tests just fine.

The motivation for this is to cut down on static use sites of the `Ruby` runtime and stuff like `RubyUtil.RUBY_TIMESTAMP_CLASS` though to move to a non-static `Ruby` environment for the Java entrypoint (that's a huge, huge change => do it step by step :)).

Also should give us slightly better inlining to only have one constructor on that thing and reference it via a `static`, method reference (trivial effect though :)).