### PR TITLE
MINOR: Cleanup RubyAckedBatch constructors

### DIFF
--- a/logstash-core/src/main/java/org/logstash/RubyUtil.java
+++ b/logstash-core/src/main/java/org/logstash/RubyUtil.java
@@ -8,7 +8,6 @@ import org.jruby.RubyModule;
 import org.jruby.anno.JRubyClass;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ObjectAllocator;
-import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.ackedqueue.ext.AbstractJRubyQueue;
 import org.logstash.ackedqueue.ext.RubyAckedBatch;
 import org.logstash.ext.JrubyEventExtLibrary;
@@ -82,15 +81,12 @@ public final class RubyUtil {
         RUBY_EVENT_CLASS.setConstant("VERSION_ONE", RUBY.newString(Event.VERSION_ONE));
         RUBY_EVENT_CLASS.defineAnnotatedMethods(JrubyEventExtLibrary.RubyEvent.class);
         RUBY_EVENT_CLASS.defineAnnotatedConstants(JrubyEventExtLibrary.RubyEvent.class);
-        RUBY_ACKED_BATCH_CLASS = setupLogstashClass("AckedBatch", new ObjectAllocator() {
-            @Override
-            public IRubyObject allocate(final Ruby runtime, final RubyClass rubyClass) {
-                return new RubyAckedBatch(runtime, rubyClass);
-            }
-        }, RubyAckedBatch.class);
         final RubyClass abstractQueue = setupLogstashClass(
             "AbstractAckedQueue", ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR,
             AbstractJRubyQueue.class
+        );
+        RUBY_ACKED_BATCH_CLASS = setupLogstashClass(
+            "AckedBatch", RubyAckedBatch::new, RubyAckedBatch.class
         );
         setupLogstashClass(
             "AckedQueue", abstractQueue, AbstractJRubyQueue.RubyAckedQueue::new,
@@ -132,7 +128,7 @@ public final class RubyUtil {
     /**
      * Sets up a Java-defined {@link RubyClass} in the Logstash Ruby module.
      * @param name Name of the class
-     * @param parent Parent RubyClass 
+     * @param parent Parent RubyClass
      * @param allocator Allocator of the class
      * @param jclass Underlying Java class that is annotated by {@link JRubyClass}
      * @return RubyClass

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/AbstractJRubyQueue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/AbstractJRubyQueue.java
@@ -117,7 +117,7 @@ public abstract class AbstractJRubyQueue extends RubyObject {
             throw RubyUtil.newRubyIOError(context.runtime, e);
         }
         // TODO: return proper Batch object
-        return (b == null) ? context.nil : new RubyAckedBatch(context.runtime, b);
+        return (b == null) ? context.nil : RubyAckedBatch.create(context.runtime, b);
     }
 
     @JRubyMethod(name = "is_fully_acked?")

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/RubyAckedBatch.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/RubyAckedBatch.java
@@ -27,9 +27,11 @@ public final class RubyAckedBatch extends RubyObject {
         super(runtime, klass);
     }
 
-    public RubyAckedBatch(Ruby runtime, Batch batch) {
-        super(runtime, RubyUtil.RUBY_ACKED_BATCH_CLASS);
-        this.batch = batch;
+    public static RubyAckedBatch create(Ruby runtime, Batch batch) {
+        final RubyAckedBatch ackedBatch =
+            new RubyAckedBatch(runtime, RubyUtil.RUBY_ACKED_BATCH_CLASS);
+        ackedBatch.batch = batch;
+        return ackedBatch;
     }
 
     @SuppressWarnings("unchecked") // for the getList() calls


### PR DESCRIPTION
Same as #8609 moving to a single constructor simplifying the bootstrap in `RubyUtils`.