### PR TITLE
CLEANUP: Remove unused Ruby Constructor from RubyAckedBatch

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/RubyAckedBatch.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/RubyAckedBatch.java
@@ -1,8 +1,6 @@
 package org.logstash.ackedqueue.ext;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.List;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyClass;
@@ -14,8 +12,6 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.Event;
 import org.logstash.RubyUtil;
 import org.logstash.ackedqueue.Batch;
-import org.logstash.ackedqueue.Queueable;
-import org.logstash.ackedqueue.io.LongVector;
 import org.logstash.ext.JrubyEventExtLibrary;
 
 @JRubyClass(name = "AckedBatch")
@@ -32,30 +28,6 @@ public final class RubyAckedBatch extends RubyObject {
             new RubyAckedBatch(runtime, RubyUtil.RUBY_ACKED_BATCH_CLASS);
         ackedBatch.batch = batch;
         return ackedBatch;
-    }
-
-    @SuppressWarnings("unchecked") // for the getList() calls
-    @JRubyMethod(name = "initialize", required = 3)
-    public IRubyObject ruby_initialize(ThreadContext context, IRubyObject events,
-        IRubyObject seqNums, IRubyObject queue) {
-        if (!(events instanceof RubyArray)) {
-            context.runtime.newArgumentError("expected events array");
-        }
-        if (!(seqNums instanceof RubyArray)) {
-            context.runtime.newArgumentError("expected seqNums array");
-        }
-        if (!(queue instanceof AbstractJRubyQueue.RubyAckedQueue)) {
-            context.runtime.newArgumentError("expected queue AckedQueue");
-        }
-        final Collection<Long> seqList = (List<Long>) seqNums;
-        final LongVector seqs = new LongVector(seqList.size());
-        for (final long seq : seqList) {
-            seqs.add(seq);
-        }
-        this.batch = new Batch((List<Queueable>) events, seqs,
-            ((AbstractJRubyQueue.RubyAckedQueue) queue).getQueue()
-        );
-        return context.nil;
     }
 
     @JRubyMethod(name = "get_elements")


### PR DESCRIPTION
This is just dead code, the constructor is never called from Ruby code.
Grepping the codebase shows this:

```sh
➜  logstash git:(remove-dead-batch-code) ag -S AckedBatch
logstash-core/src/main/java/org/logstash/ackedqueue/ext/RubyAckedBatch.java
17:@JRubyClass(name = "AckedBatch")
18:public final class RubyAckedBatch extends RubyObject {
22:    public RubyAckedBatch(Ruby runtime, RubyClass klass) {
26:    public RubyAckedBatch(Ruby runtime, Batch batch) {

logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueExtLibrary.java
157:            return (b == null) ? context.nil : new RubyAckedBatch(context.runtime, b);

logstash-core/src/main/java/org/logstash/ackedqueue/ext/JrubyAckedQueueMemoryExtLibrary.java
154:            return (b == null) ? context.nil : new RubyAckedBatch(context.runtime, b);

logstash-core/src/main/java/org/logstash/RubyUtil.java
14:import org.logstash.ackedqueue.ext.RubyAckedBatch;
89:        RUBY_ACKED_BATCH_CLASS = setupLogstashClass("AckedBatch", new ObjectAllocator() {
92:                return new RubyAckedBatch(runtime, rubyClass);
94:        }, RubyAckedBatch.class);
```

=> no references to the Ruby class-name in any `.rb` file. We always initiate this thing from Java code => dead code => removed (especially since every `Ruby` runtime reference in Java adds work when it comes to cleaning up the Java entrypoint implementation).