### PR TITLE
 #8589 make Gradle bootstrap compatible with Windows (follow up)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,7 +150,7 @@ task installTestGems(dependsOn: downloadAndInstallJRuby, type: Exec) {
   outputs.files fileTree("${projectDir}/vendor/jruby")
   // Override z_rubycheck.rb because we execute the vendored JRuby and don't have to guard against
   // any Ruby environment leaking into the build
-  environment "GEM_PATH", "1"
+  environment "USE_RUBY", "1"
   standardOutput = new ExecLogOutputStream(System.out)
   errorOutput =  new ExecLogOutputStream(System.err)
   commandLine jrubyBin, "${projectDir}/vendor/jruby/bin/rake", "test:install-core"


### PR DESCRIPTION
@jakelandis argh I made a mistake when rebasing #8607 after the review yesterday and somehow messed up the env variable when merging. This was supposed to be `USE_RUBY` to override the `z_rubycheck.rb` as explained in that PR (and the comment).

Can you take a quick look please ?+ Sorry for the stupid noise :)