### PR TITLE
support page capacity change on existing queue

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/AbstractByteBufferPageIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/AbstractByteBufferPageIO.java
@@ -31,7 +31,6 @@ public abstract class AbstractByteBufferPageIO implements PageIO {
     public static final int WRAPPER_SIZE = HEADER_SIZE + SEQNUM_SIZE + LENGTH_SIZE + CHECKSUM_SIZE;
 
     public static final boolean VERIFY_CHECKSUM = true;
-    public static final boolean STRICT_CAPACITY = true;
 
     private static final Logger logger = LogManager.getLogger(AbstractByteBufferPageIO.class);
 

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/io/MmapPageIOTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/io/MmapPageIOTest.java
@@ -1,0 +1,43 @@
+package org.logstash.ackedqueue.io;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.logstash.ackedqueue.io.MmapPageIO;
+import org.logstash.ackedqueue.io.PageIO;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+public class MmapPageIOTest {
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private String dir;
+
+    @Before
+    public void setUp() throws Exception {
+        dir = temporaryFolder.newFolder().getPath();
+    }
+
+    @Test
+    public void adjustToExistingCapacity() throws IOException {
+        final int ORIGINAL_CAPACITY = 1024;
+        final int NEW_CAPACITY = 2048;
+        final int PAGE_NUM = 0;
+
+        try (PageIO io1 = new MmapPageIO(PAGE_NUM, ORIGINAL_CAPACITY, dir)) {
+            io1.create();
+        }
+
+        try (PageIO io2 = new MmapPageIO(PAGE_NUM, NEW_CAPACITY, dir)) {
+            io2.open(0, PAGE_NUM);
+            assertThat(io2.getCapacity(), is(equalTo(ORIGINAL_CAPACITY)));
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes #7581 

It removes the strict check for a configured page capacity to necessarily equal the the capacity of an existing page file. The problem with this is that a page capacity change in the configuration while there is an existing non-empty queue would prevent logstash from starting. 

It seems reasonable that someone would want to tweak a page capacity for new pages moving forward while old pages would still exist at their original capacity until all purged. 