### PR TITLE
#8619 Fix filter flush events in nested conditionals being passed to the wrong conditional branch

### DIFF
--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -663,6 +663,7 @@ module LogStash; class JavaPipeline < JavaBasePipeline
     filtered_size = batch.filtered_size
     @filter_queue_client.add_output_metrics(filtered_size)
     @filter_queue_client.add_filtered_metrics(filtered_size)
+    @flushing.set(false) if flush
   rescue Exception => e
     # Plugins authors should manage their own exceptions in the plugin code
     # but if an exception is raised up to the worker thread they are considered

--- a/logstash-core/spec/support/mocks_classes.rb
+++ b/logstash-core/spec/support/mocks_classes.rb
@@ -13,6 +13,23 @@ module LogStash
         # noop
       end
     end
+
+    class DummyBlockingInput < LogStash::Inputs::Base
+      config_name "dummyblockinginput"
+      milestone 2
+
+      def register
+        @latch = java.util.concurrent.CountDownLatch.new(1)
+      end
+
+      def run(_)
+        @latch.await
+      end
+
+      def stop
+        @latch.count_down
+      end
+    end
   end
 
   module Filters


### PR DESCRIPTION
Fixes #8619, the problem was that we were not excluding the highest (up the AST) branches.

So a nested if like in 

```
    if [type] == "generator" {
        if [@timestamp] {
            metrics {
                meter => "events"
                add_tag => "metric"
            }
        }
    } else {
        drop {
        }
    }
```

was should have ignored not only the `if [@timestamp] {` condition, but also the` if [type] == "generator"` condition for any event created in the `metrics` filter node.
This patch adjusts the logic for finding the dead sibling branches accordingly.

PS:

Sorry for just duplicating the test between Ruby and Java pipeline, but I think putting effort towards drying this stuff isn't worth it anymore with the Ruby one going away eventually.