### PR TITLE
use the timeout value as a hard time limit to fill a batch

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/LsQueueUtils.java
+++ b/logstash-core/src/main/java/org/logstash/common/LsQueueUtils.java
@@ -31,10 +31,9 @@ public final class LsQueueUtils {
 
     /**
      * <p>Drains {@link JrubyEventExtLibrary.RubyEvent} from {@link BlockingQueue} with a timeout.</p>
-     * <p>The timeout will be reset as soon as a single {@link JrubyEventExtLibrary.RubyEvent} was
-     * drained from the {@link BlockingQueue}. Draining {@link JrubyEventExtLibrary.RubyEvent}
+     * <p>Draining {@link JrubyEventExtLibrary.RubyEvent}
      * stops as soon as either the required number of {@link JrubyEventExtLibrary.RubyEvent}s
-     * were pulled from the queue or the timeout value has gone by without an event drained.</p>
+     * were pulled from the queue or the timeout value has gone by.</p>
      * @param queue Blocking Queue to drain {@link JrubyEventExtLibrary.RubyEvent}s
      * from
      * @param count Number of {@link JrubyEventExtLibrary.RubyEvent}s to drain from
@@ -49,13 +48,23 @@ public final class LsQueueUtils {
         final BlockingQueue<JrubyEventExtLibrary.RubyEvent> queue, final int count, final long nanos
     ) throws InterruptedException {
         int left = count;
+        final long deadline = System.nanoTime() + nanos;
+        long drainTimeout = nanos;
+
         final Collection<JrubyEventExtLibrary.RubyEvent> collection =
             new HashSet<>(4 * count / 3 + 1);
+
         do {
-            final int drained = drain(queue, collection, left, nanos);
+            final int drained = drain(queue, collection, left, drainTimeout);
             if (drained == 0) {
                 break;
             }
+
+            drainTimeout = deadline - System.nanoTime();
+            if (drainTimeout <= 0) {
+                break;
+            }
+
             left -= drained;
         } while (left > 0);
         return collection;
@@ -78,17 +87,24 @@ public final class LsQueueUtils {
         final Collection<JrubyEventExtLibrary.RubyEvent> collection, final int count,
         final long nanos) throws InterruptedException {
         final long deadline = System.nanoTime() + nanos;
+        long pollTimeout = nanos;
         int added = 0;
         do {
             added += queue.drainTo(collection, count - added);
+            
             if (added < count) {
+                if (pollTimeout <= 0) {
+                    break;
+                }
                 final JrubyEventExtLibrary.RubyEvent event =
-                    queue.poll(deadline - System.nanoTime(), TimeUnit.NANOSECONDS);
+                    queue.poll(pollTimeout, TimeUnit.NANOSECONDS);
                 if (event == null) {
                     break;
                 }
                 collection.add(event);
                 added++;
+
+                pollTimeout = deadline - System.nanoTime();
             }
         } while (added < count);
         return added;


### PR DESCRIPTION
The new memory queue draining logic does not respect the idea of the `pipeline.batch.delay` configuration option which is documented as
```
# How long to wait before dispatching an undersized batch to filters+workers
# Value is in milliseconds.
```
Prior to this fix the public `drain()` method would reset the timeout after successfully reading elements from the queue and continue like this up to hitting the maximum number of elements requested. This means that the total time to perform the drain could be longer than the requested timeout. 

There were no specific tests harness around this new Java code and I did not add any either. For now I am comfortable to rely on the other tests since this is such a core function any problem with it would surface. Ideally I would want specific tests added around this method. Depending on the result of this PR I would like to followup with an issue to add tests.
