### PR TITLE
Revert over-eager logstash version change in doc

### DIFF
--- a/docs/index-shared1.asciidoc
+++ b/docs/index-shared1.asciidoc
@@ -1,8 +1,8 @@
 :branch:                5.6
 :major-version:         5.x
-:logstash_version:      5.6.5
-:elasticsearch_version: 5.6.5
-:kibana_version:        5.6.5
+:logstash_version:      5.6.4
+:elasticsearch_version: 5.6.4
+:kibana_version:        5.6.4
 :docker-image:          docker.elastic.co/logstash/logstash:{logstash_version}
 
 //////////


### PR DESCRIPTION
Docs are showing up on elastic.co refering to 5.6.5, which does not
exist yet. Revert doc versions back down to 5.6.4

Fixes #8637