### PR TITLE
Cleanup: Move classloading RubyUtil to a single entrypoint in Ruby code

### DIFF
--- a/logstash-core/lib/logstash-core/logstash-core.rb
+++ b/logstash-core/lib/logstash-core/logstash-core.rb
@@ -31,3 +31,7 @@ else
     raise("Error loading logstash-core/logstash-core.jar file, cause: #{e.message}")
   end
 end
+
+# Load Logstash's Java-defined RubyClasses by classloading RubyUtil which sets them up in its
+# static constructor
+java_import org.logstash.RubyUtil

--- a/logstash-core/lib/logstash/errors.rb
+++ b/logstash-core/lib/logstash/errors.rb
@@ -1,9 +1,5 @@
 # encoding: utf-8
 
-# Force loading the RubyUtil to ensure that the custom Exception types it sets up are ready at the
-# same time as those that are set by this script.
-java_import org.logstash.RubyUtil
-
 module LogStash
   class EnvironmentError < Error; end
   class ConfigurationError < Error; end

--- a/logstash-core/lib/logstash/event.rb
+++ b/logstash-core/lib/logstash/event.rb
@@ -4,10 +4,6 @@ require "logstash/namespace"
 require "logstash/json"
 require "logstash/timestamp"
 
-# Force loading the RubyUtil to ensure its loaded before the Event class is set up in Ruby since
-# Event depends on Ruby classes that are dynamically set up by Java code.
-java_import org.logstash.RubyUtil
-
 # transient pipeline events for normal in-flow signaling as opposed to
 # flow altering exceptions. for now having base classes is adequate and
 # in the future it might be necessary to refactor using like a BaseEvent

--- a/logstash-core/lib/logstash/timestamp.rb
+++ b/logstash-core/lib/logstash/timestamp.rb
@@ -2,10 +2,6 @@
 
 require "logstash/namespace"
 
-# Force loading the RubyUtil to ensure its loaded before the Timestamp class is set up in Ruby since
-# Timestamp depends on Ruby classes that are dynamically set up by Java code.
-java_import org.logstash.RubyUtil
-
 module LogStash
 
   class Timestamp

--- a/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
@@ -1,9 +1,5 @@
 # encoding: utf-8
 
-# Force loading the RubyUtil to ensure its loaded before the WrappedAckedQueue class is set up in
-# Ruby since WrappedAckedQueue depends on Ruby classes that are dynamically set up by Java code.
-java_import org.logstash.RubyUtil
-
 require "concurrent"
 # This is an adapted copy of the wrapped_synchronous_queue file
 # ideally this should be moved to Java/JRuby


### PR DESCRIPTION
Now that we don't have any circular dependencies between Java and Ruby anymore we should simply (class-)load `RubyUtil` as soon as we have our `.jar` or `.class` files on the path. This is achieved here by just loading it right after the `.jar` or `.class` files.
