### PR TITLE
MINOR: Remove Redundant Methods and Method Calls from both Queue Implementations

### DIFF
--- a/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
@@ -149,10 +149,6 @@ module LogStash; module Util
         end
       end
 
-      def current_inflight_batch
-        @inflight_batches.fetch(Thread.current, [])
-      end
-
       # create a new empty batch
       # @return [ReadBatch] a new empty read batch
       def new_batch
@@ -171,36 +167,26 @@ module LogStash; module Util
       end
 
       def start_metrics(batch)
+        thread = Thread.current
         @mutex.lock
         begin
-          set_current_thread_inflight_batch(batch)
+          @inflight_batches[thread] = batch
         ensure
           @mutex.unlock
         end
-        start_clock
-      end
-
-      def set_current_thread_inflight_batch(batch)
-        @inflight_batches[Thread.current] = batch
+        @inflight_clocks[thread] = java.lang.System.nano_time
       end
 
       def close_batch(batch)
+        thread = Thread.current
         @mutex.lock
         begin
           batch.close
-          @inflight_batches.delete(Thread.current)
+          @inflight_batches.delete(thread)
         ensure
           @mutex.unlock
         end
-        stop_clock(batch)
-      end
-
-      def start_clock
-        @inflight_clocks[Thread.current] = java.lang.System.nano_time
-      end
-
-      def stop_clock(batch)
-        start_time = @inflight_clocks.get_and_set(Thread.current, nil)
+        start_time = @inflight_clocks.get_and_set(thread, nil)
         unless start_time.nil?
           if batch.size > 0
             # only stop (which also records) the metrics if the batch is non-empty.


### PR DESCRIPTION
* `current_inflight_batch` is never called anywhere, grepping the codebase for it doesn't return anything
  * That method seems really wrong anyways, defaulting to an empty array in place of a `Batch` (I guess it was once like this to allow iteration over the default)
* `start_clock` and `stop_clock` can both be inlined into their respective callers, saving us a few method calls and more importantly, saving the rather expensive `Thread.current` call to Java (neither of these matter much performance wise, but the simpler this code is, the easier porting it to Java becomes)