### PR TITLE
 #8623 make Java execution the default

### DIFF
--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -40,7 +40,7 @@ module LogStash
    Setting::PositiveInteger.new("pipeline.batch.size", 125),
            Setting::Numeric.new("pipeline.batch.delay", 5), # in milliseconds
            Setting::Boolean.new("pipeline.unsafe_shutdown", false),
-           Setting::Boolean.new("pipeline.java_execution", false),
+           Setting::Boolean.new("pipeline.java_execution", true),
            Setting::Boolean.new("pipeline.reloadable", true),
                     Setting.new("path.plugins", Array, []),
     Setting::NullableString.new("interactive", nil, false),

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -65,7 +65,7 @@ describe LogStash::Agent do
     let(:agent_args) { { "config.string" => config_string } }
 
     it "should delegate settings to new pipeline" do
-      expect(LogStash::Pipeline).to receive(:new) do |arg1, arg2|
+      expect(LogStash::JavaPipeline).to receive(:new) do |arg1, arg2|
         expect(arg1).to eq(config_string)
         expect(arg2.to_hash).to include(agent_args)
       end


### PR DESCRIPTION
Fixes #8623 by making the Java execution the default execution engine in `master`