### PR TITLE
replace decreasing timeout with fixed timeout

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/LsQueueUtils.java
+++ b/logstash-core/src/main/java/org/logstash/common/LsQueueUtils.java
@@ -77,13 +77,12 @@ public final class LsQueueUtils {
     private static int drain(final BlockingQueue<JrubyEventExtLibrary.RubyEvent> queue,
         final Collection<JrubyEventExtLibrary.RubyEvent> collection, final int count,
         final long nanos) throws InterruptedException {
-        final long deadline = System.nanoTime() + nanos;
         int added = 0;
         do {
             added += queue.drainTo(collection, count - added);
             if (added < count) {
                 final JrubyEventExtLibrary.RubyEvent event =
-                    queue.poll(deadline - System.nanoTime(), TimeUnit.NANOSECONDS);
+                    queue.poll(nanos, TimeUnit.NANOSECONDS);
                 if (event == null) {
                     break;
                 }


### PR DESCRIPTION
Followup of #8632 and related to #8633 I think the decreasing timeout is unnecessary WRT to the eager reading & batch maximization strategy. We agreed that the idea of the timeout is that it should be applied per blocking read so fixing a global & fixed timeout *deadline* here should not be required. Also this avoids a call to `System.nanoTime()` in the read loop.

Let me know if I am missing something here @original-brownbear ? 

