### PR TITLE
Bump docs + release notes for 6.0.0 GA

### DIFF
--- a/docs/index-shared1.asciidoc
+++ b/docs/index-shared1.asciidoc
@@ -1,9 +1,9 @@
 
 :branch:                6.0
 :major-version:         6.x
-:logstash_version:      6.0.0-rc2
-:elasticsearch_version: 6.0.0-rc2
-:kibana_version:        6.0.0-rc2
+:logstash_version:      6.0.0
+:elasticsearch_version: 6.0.0
+:kibana_version:        6.0.0
 :docker-repo:           docker.elastic.co/logstash/logstash
 :docker-image:          {docker-repo}:{logstash_version}
 

--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -75,7 +75,7 @@ Note that the list of plugins included with Logstash has changed. Please check t
 === TCP Input Changes
 * Changed the behaviour of the host field to contain the resolved peer hostname for a connection instead of its peer IP.
 * Removed the `data_timeout` and `ssl_cacert` options because they are now obsolete.
-* Poved the peer's IP to the new field `ip_address`.
+* Moved the peer's IP to the new field `ip_address`.
 
 [float]
 === TCP Output Changes

--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -70,6 +70,43 @@ These changes can impact any instance of Logstash and are plugin agnostic, but o
 * The options `congestion_threshold` and `target_field_for_codec` are now obsolete.
 
 [float]
+=== TCP Input Changes
+* Changed the behaviour of the host field to contain the resolved peer hostname for a connection instead of its peer IP
+* Mark deprecated :data_timeout and :ssl_cacert options as obsolete and moved the peer's IP to the new field ip_address
+
+[float]
+=== TCP Output Changes
+* Breaking: mark deprecated option message_format as obsolete
+
+[float]
+=== SQS Output Changes
+* Breaking: mark deprecated batch and batch_timeout options as obsolete
+
+[float]
+=== Redis Output Changes
+* Mark deprecated name and queue configuration parameters as obsolete 
+
+[float]
+=== RabbitMQ Input/Output Changes
+* Mark deprecated options `debug`, `tls_certificate_path` and `tls_certificate_password` as obsolete
+
+[float]
+=== Logstash Output HTTP
+* Breaking: mark ssl_certificate_verify as obsolete
+
+[float]
+=== Logstash Input HTTP Poller
+* Breaking: mark ssl_certificate_verify as obsolete
+
+[float]
+=== GeoIP Changes
+* Make deprecated field lru_cache_size obsolete
+
+[float]
+=== CEF Codec Changes
+* move sev and deprecated_v1_fields fields from deprecated to obsolete
+
+[float]
 ==== List of plugins bundled with Logstash
 
 The following plugins were removed from the 6.0 default bundle based on usage data. You can still install these plugins manually:

--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -23,8 +23,8 @@ These changes can impact any instance of Logstash and are plugin agnostic, but o
 [float]
 ==== RPM/Deb package changes
 
-* For `rpm` and `deb` release artifacts, config files that match the `*.conf` glob pattern must be in the conf.d folder,
-  or the files will not be loaded.
+* For `rpm` and `deb` release artifacts, config files that match the `*.conf` glob pattern must be in the conf.d folder, 
+  or the files will not be loaded. If there are non-configuration files in this folder this can be problematic.
 
 [float]
 ==== Command Line Interface behavior
@@ -35,6 +35,8 @@ These changes can impact any instance of Logstash and are plugin agnostic, but o
 
 [float]
 === Plugin Changes
+
+Note that the list of plugins included with Logstash has changed. Please check that the new plugin list still includes all plugins you use.
 
 [float]
 ==== Elasticsearch output changes
@@ -71,40 +73,41 @@ These changes can impact any instance of Logstash and are plugin agnostic, but o
 
 [float]
 === TCP Input Changes
-* Changed the behaviour of the host field to contain the resolved peer hostname for a connection instead of its peer IP
-* Mark deprecated :data_timeout and :ssl_cacert options as obsolete and moved the peer's IP to the new field ip_address
+* Changed the behaviour of the host field to contain the resolved peer hostname for a connection instead of its peer IP.
+* Removed the `data_timeout` and `ssl_cacert` options because they are now obsolete.
+* Poved the peer's IP to the new field `ip_address`.
 
 [float]
 === TCP Output Changes
-* Breaking: mark deprecated option message_format as obsolete
+* Breaking: removed the `message_format` option because it is now obsolete.
 
 [float]
 === SQS Output Changes
-* Breaking: mark deprecated batch and batch_timeout options as obsolete
+* Breaking: removed the `batch` and `batch_timeout` options because they are now obsolete.
 
 [float]
 === Redis Output Changes
-* Mark deprecated name and queue configuration parameters as obsolete 
+* Removed the `name` and `queue` options because they are now obsolete.
 
 [float]
 === RabbitMQ Input/Output Changes
-* Mark deprecated options `debug`, `tls_certificate_path` and `tls_certificate_password` as obsolete
+* Removed the `debug`, `tls_certificate_path`, and `tls_certificate_password` options because they are now obsolete.
 
 [float]
 === Logstash Output HTTP
-* Breaking: mark ssl_certificate_verify as obsolete
+* Removed the `ssl_certificate_verify` option because it is now obsolete.
 
 [float]
 === Logstash Input HTTP Poller
-* Breaking: mark ssl_certificate_verify as obsolete
+* Removed the `ssl_certificate_verify` option because it is now obsolete.
 
 [float]
 === GeoIP Changes
-* Make deprecated field lru_cache_size obsolete
+* Removed the `lru_cache_size` option because it is now obsolete.
 
 [float]
 === CEF Codec Changes
-* move sev and deprecated_v1_fields fields from deprecated to obsolete
+* Removed the `sev` and `deprecated_v1_fields` options because they are now obsolete.
 
 [float]
 ==== List of plugins bundled with Logstash

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -14,35 +14,29 @@ endif::include-xpack[]
 [[logstash-6-0-0]]
 === Logstash 6.0.0 Release Notes
 
-* Breaking: The setting `config.reload.interval` has been changed to use time value strings such as `5m`, `10s`, etc for
-  convenience. Previously, users had to convert this to a second time value themselves.
-* Breaking: The list of plugins bundled with Logstash 6.0.0-beta1 release has changed. Please consult the breaking changes document
-  for a complete list.
-* Breaking: Currently, when Logstash is installed and set up via package managers, it loads all files found
-  in `/etc/logstash/conf.d` as configuration. This can be problematic if there are non-configuration files in this
-  folder. Starting from alpha2, Logstash will only glob files ending with `.conf` extension in `/etc/logstash/conf.d` ({lsissue}6979)[Issue 6979)]).
+* This list does not include all breaking changes, please consult the <<breaking-changes,breaking changes>> document separately.
 * Added new `logstash.yml` setting: `config.support_escapes`. When enabled, Logstash will interpret escape sequences in
   strings in the pipeline configuration.
-* Added an explicit `--setup` phase for modules which is used to install dashboards and Elasticsearch template.
+* Added an explicit --setup phase for modules. This phase is used to install dashboards and the Elasticsearch template.
 * Added support for running multiple pipelines in the same Logstash instance. Running multiple pipelines
-  allow users to isolate data flow, provide separate runtime pipeline parameters and helps simplify complex
+  allows users to isolate data flow, provide separate runtime pipeline parameters and helps simplify complex
   configurations. This can be configured via the new `pipelines.yml` file.
-* https://github.com/elastic/logstash/commit/840439722d8ef4737c7e8101c59652ced191bbea[Improved performance]
-* https://github.com/elastic/logstash/commit/546951fa889902d8ec56f8a7cec1dc41a21088ff[Modules: Set default credentials for Kibana if es info is present]
-* A variety of small consistency / testing fixes for the Windows platform
-* https://github.com/elastic/logstash/pull/8318[Added all commercially supported plugins to bundled plugins]
-* Existing `JAVA_OPTS` env var is now ignored for consistency with Elasticsearch
-* JAVA_TOOL_OPTIONS env var is cleared for consistency with Elasticsearch
+* https://github.com/elastic/logstash/commit/840439722d8ef4737c7e8101c59652ced191bbea[Improved performance].
+* https://github.com/elastic/logstash/commit/546951fa889902d8ec56f8a7cec1dc41a21088ff[Modules: Set default credentials for Kibana if es info is present].
+* A variety of small consistency and testing fixes for the Windows platform
+* https://github.com/elastic/logstash/pull/8318[Added all commercially supported plugins to bundled plugins].
+* The existing `JAVA_OPTS` env var is now ignored for consistency with Elasticsearch.
+* JAVA_TOOL_OPTIONS env var is cleared for consistency with Elasticsearch.
 * Now only LS_JAVA_OPTS env var is supported to append options to parsed options from the jvm.options file.
-* Dropped support of the LS_JVM_OPTS env var
-* Dropped support of the USE_RUBY and USE_DRIP environment variables
+* Dropped support for the LS_JVM_OPTS environment variable.
+* Dropped support for the USE_RUBY and USE_DRIP environment variables.
 * Added `cloud.id` and `cloud.auth` support for modules to provide an easy way to integrate with Elastic Cloud service.
-* Enabled DLQ support for multipipelines
+* Enabled DLQ support for multipipelines.
 * Added an {xpack} feature to manage Logstash configurations centrally in Elasticsearch. We've also added a UI to manage
   configurations directly in Kibana without having to restart Logstash.
 * Users can now visualize the Logstash configuration pipeline as part of the {xpack} monitoring feature.
 
 ==== Plugins
 
-*`GeoIP Filter`: You can now use MaxMind's commercial database to get enriched Geo information. ASN data can be
+* `GeoIP Filter`: You can now use MaxMind's commercial database to get enriched Geo information. ASN data can be
   obtained via the GeoIP2-ISP database.

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -3,12 +3,7 @@
 
 This section summarizes the changes in the following releases:
 
-* <<logstash-6-0-0-rc2,Logstash 6.0.0-rc2>>
-* <<logstash-6-0-0-rc1,Logstash 6.0.0-rc1>>
-* <<logstash-6-0-0-beta2,Logstash 6.0.0-beta2>>
-* <<logstash-6-0-0-beta1,Logstash 6.0.0-beta1>>
-* <<logstash-6-0-0-alpha2,Logstash 6.0.0-alpha2>>
-* <<logstash-6-0-0-alpha1,Logstash 6.0.0-alpha1>>
+* <<logstash-6-0-0,Logstash 6.0.0>>
 
 ifdef::include-xpack[]
 See also:
@@ -16,68 +11,38 @@ See also:
 * <<release-notes-xls>>
 endif::include-xpack[]
 
-[[logstash-6-0-0-rc2]]
-=== Logstash 6.0.0-rc2 Release Notes
+[[logstash-6-0-0]]
+=== Logstash 6.0.0 Release Notes
 
-* https://github.com/elastic/logstash/commit/840439722d8ef4737c7e8101c59652ced191bbea[Improved performance]
-* https://github.com/elastic/logstash/commit/546951fa889902d8ec56f8a7cec1dc41a21088ff[Modules: Set default credentials for Kibana if es info is present]
-* More small consistency fixes for Windows 
-* Fix bug where the Elasticsearch output would not correctly log errors but rather log an exception in the error handler, thus hiding the actual error message.
-
-[[logstash-6-0-0-rc1]]
-=== Logstash 6.0.0-rc1 Release Notes
-
-* https://github.com/elastic/logstash/pull/8318[Added all commercially supported plugins to bundled plugins]
-* existing `JAVA_OPTS` env var is now ignored for consistency with Elasticsearch
-* JAVA_TOOL_OPTIONS env var is cleared for consistency with Elasticsearch
-* Now only LS_JAVA_OPTS env var is supported to append options to parsed options from the jvm.options file.
-* dropped support of the LS_JVM_OPTS env var
-* dropped support of the USE_RUBY and USE_DRIP environment variables
-* Fixed  https://github.com/elastic/logstash/pull/8226[password support] in modules
-* A variety of small consistency / testing fixes for the Windows platform
-* Misc stability fixes
-
-[[logstash-6-0-0-beta2]]
-=== Logstash 6.0.0-beta2 Release Notes
-
-* Added `cloud.id` and `cloud.auth` support for modules to provide an easy way to integrate with Elastic Cloud service.
-* Added an explicit `--setup` phase for modules which is used to install dashboards and Elasticsearch template.
-* Enabled DLQ support for multipipelines
-
-[[logstash-6-0-0-beta1]]
-=== Logstash 6.0.0-beta1 Release Notes
-
-* Added new `logstash.yml` setting: `config.support_escapes`. When enabled, Logstash will interpret escape sequences in
-  strings in the pipeline configuration.
 * Breaking: The setting `config.reload.interval` has been changed to use time value strings such as `5m`, `10s`, etc for
   convenience. Previously, users had to convert this to a second time value themselves.
 * Breaking: The list of plugins bundled with Logstash 6.0.0-beta1 release has changed. Please consult the breaking changes document
   for a complete list.
-* Added an {xpack} feature to manage Logstash configurations centrally in Elasticsearch. We've also added a UI to manage
-  configurations directly in Kibana without having to restart Logstash.
-* Users can now visualize the Logstash configuration pipeline as part of the {xpack} monitoring feature.
-* We now report an error if config file referenced in the `pipelines.yml` is missing.
-
-[[logstash-6-0-0-alpha2]]
-=== Logstash 6.0.0-alpha2 Release Notes
-
 * Breaking: Currently, when Logstash is installed and set up via package managers, it loads all files found
   in `/etc/logstash/conf.d` as configuration. This can be problematic if there are non-configuration files in this
   folder. Starting from alpha2, Logstash will only glob files ending with `.conf` extension in `/etc/logstash/conf.d` ({lsissue}6979)[Issue 6979)]).
+* Added new `logstash.yml` setting: `config.support_escapes`. When enabled, Logstash will interpret escape sequences in
+  strings in the pipeline configuration.
+* Added an explicit `--setup` phase for modules which is used to install dashboards and Elasticsearch template.
 * Added support for running multiple pipelines in the same Logstash instance. Running multiple pipelines
   allow users to isolate data flow, provide separate runtime pipeline parameters and helps simplify complex
-  configurations.
-* A new `pipelines.yml` configuration file has been added to define pipelines.
+  configurations. This can be configured via the new `pipelines.yml` file.
+* https://github.com/elastic/logstash/commit/840439722d8ef4737c7e8101c59652ced191bbea[Improved performance]
+* https://github.com/elastic/logstash/commit/546951fa889902d8ec56f8a7cec1dc41a21088ff[Modules: Set default credentials for Kibana if es info is present]
+* A variety of small consistency / testing fixes for the Windows platform
+* https://github.com/elastic/logstash/pull/8318[Added all commercially supported plugins to bundled plugins]
+* Existing `JAVA_OPTS` env var is now ignored for consistency with Elasticsearch
+* JAVA_TOOL_OPTIONS env var is cleared for consistency with Elasticsearch
+* Now only LS_JAVA_OPTS env var is supported to append options to parsed options from the jvm.options file.
+* Dropped support of the LS_JVM_OPTS env var
+* Dropped support of the USE_RUBY and USE_DRIP environment variables
+* Added `cloud.id` and `cloud.auth` support for modules to provide an easy way to integrate with Elastic Cloud service.
+* Enabled DLQ support for multipipelines
+* Added an {xpack} feature to manage Logstash configurations centrally in Elasticsearch. We've also added a UI to manage
+  configurations directly in Kibana without having to restart Logstash.
+* Users can now visualize the Logstash configuration pipeline as part of the {xpack} monitoring feature.
 
-[[logstash-6-0-0-alpha1]]
-=== Logstash 6.0.0-alpha1 Release Notes
+==== Plugins
 
-* Introducing a new internal representation for the existing Logstash configuration that forms the
-  foundation of many new features. This is not a breaking change, and existing configs will work as is.
-
-[float]
-
-==== Filter Plugins
-
-*`GeoIP`*: You can now use MaxMind's commercial database to get enriched Geo information. ASN data can be
+*`GeoIP Filter`: You can now use MaxMind's commercial database to get enriched Geo information. ASN data can be
   obtained via the GeoIP2-ISP database.


### PR DESCRIPTION
This has a variety of changes. I rolled up more breaking plugin changes in here.
I also rolled up all 6.0 release notes and diffed them with 5.6.3. I removed release notes
that only dealt with improvements across 6.0 pre-release versions