### PR TITLE
CLEANUP: Use paquet from source tree?

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -4,7 +4,7 @@
 source "https://rubygems.org"
 gem "logstash-core", :path => "./logstash-core"
 gem "logstash-core-plugin-api", :path => "./logstash-core-plugin-api"
-gem "paquet", "~> 0.2.0"
+gem "paquet", :path => "./tools/paquet"
 gem "ruby-progressbar", "~> 1.8.1"
 gem "builder", "~> 3.2.2"
 gem "ci_reporter_rspec", "1.0.0", :group => :development


### PR DESCRIPTION
Random find I made :D We have the sources for `paquet` in this repo, but we're pulling it from Rubygems?

Shouldn't we be using the version from source?