### PR TITLE
 #8668 fix NPE in pipeline_reporter's worker_states method

### DIFF
--- a/logstash-core/lib/logstash/pipeline_reporter.rb
+++ b/logstash-core/lib/logstash/pipeline_reporter.rb
@@ -87,7 +87,8 @@ module LogStash; class PipelineReporter
   def worker_states(batch_map)
     pipeline.worker_threads.map.with_index do |thread, idx|
       status = thread.status || "dead"
-      inflight_count = batch_map[thread] ? batch_map[thread].size : 0
+      batch = batch_map[thread]
+      inflight_count = batch ? batch.size : 0
       {
         :status => status,
         :alive => thread.alive?,


### PR DESCRIPTION
fixes #8668 , `batch_map` is a concurrent hash map now (as a result of https://github.com/original-brownbear/logstash/commit/b651f30f99f261d6b3aeb9011bb4d053e6c4feea). The means that 

```rb
batch_map[thread] ? batch_map[thread].size : 0
```

is not safe. Only a single `get` on the map is atomic/threadsafe here.  The `[]` in the conditional could be `!= nil` while the call after the `?` could be nil with the map having changed in between calls to it.

=> only use a single `get` on the map and work from the result.