### PR TITLE
TESTS+BUG: Pass FEATURE_FLAG environment to Integration Tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,6 +210,8 @@ task runIntegrationTests(dependsOn: installIntegrationTestGems, type: Exec) {
   environment "JAVA_OPTS", ""
   environment "GEM_PATH", gemPath
   environment "GEM_HOME", gemPath
+  // FEATURE_FLAG is set in the CI to configure testing with enabled PQ
+  environment "FEATURE_FLAG", System.getenv('FEATURE_FLAG')
   standardOutput = new ExecLogOutputStream(System.out)
   errorOutput =  new ExecLogOutputStream(System.err)
   commandLine([jrubyBin, bundleBin, "exec", "rspec"].plus((Collection<String>)rubyIntegrationSpecs))


### PR DESCRIPTION
My bad just now in #8599, sorry :)

Gradle `Exec` won't pass environment transient variables down to `Exec` tasks by itself => PQ enabled tests don't actually run PQ right now => pass down `FEATURE_FLAG` to fix this.