### PR TITLE
 #8671 pass correct JVM opts to LS in ITs

### DIFF
--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -254,6 +254,7 @@ class LogstashService < Service
       environment.each do |k, v|
         process.environment[k] = v
       end
+      process.environment['LS_JAVA_OPTS'] = process.environment.delete('JAVA_OPTS')
       process.io.stdout = process.io.stderr = out
 
       Bundler.with_clean_env do


### PR DESCRIPTION
let's see if this does it already. LS is being ran at default `JAVA_OPTS` without the `Xss=2m` which seems somewhat important for JRuby + Bundler.