### PR TITLE
[CLEANUP] refactor page read deserialization out of the page into batch

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Batch.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Batch.java
@@ -2,6 +2,7 @@ package org.logstash.ackedqueue;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.logstash.ackedqueue.io.LongVector;
@@ -19,6 +20,10 @@ public class Batch implements Closeable {
         this.seqNums = seqNums;
         this.queue = q;
         this.closed = new AtomicBoolean(false);
+    }
+
+    public Batch(SequencedList<byte[]> serialized, Queue q) {
+        this(deserializeElements(serialized.getElements(), q), serialized.getSeqNums(), q);
     }
 
     // close acks the batch ackable events
@@ -43,5 +48,19 @@ public class Batch implements Closeable {
 
     public Queue getQueue() {
         return queue;
+    }
+
+    /**
+     *
+     * @param serialized Collection of serialized elements
+     * @param q {@link Queue} instance
+     * @return Collection of deserialized {@link Queueable} elements
+     */
+    private static List<Queueable> deserializeElements(List<byte[]> serialized, Queue q) {
+        final List<Queueable> deserialized = new ArrayList<>(serialized.size());
+        for (final byte[] element : serialized) {
+            deserialized.add(q.deserialize(element));
+        }
+        return deserialized;
     }
 }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/HeadPage.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/HeadPage.java
@@ -36,13 +36,6 @@ public class HeadPage extends Page {
         return this.pageIO.hasSpace((byteSize));
     }
 
-    // NOTE:
-    // we have a page concern inconsistency where readBatch() takes care of the
-    // deserialization and returns a Batch object which contains the deserialized
-    // elements objects of the proper elementClass but HeadPage.write() deals with
-    // a serialized element byte[] and serialization is done at the Queue level to
-    // be able to use the Page.hasSpace() method with the serialized element byte size.
-    //
     public void write(byte[] bytes, long seqNum, int checkpointMaxWrites) throws IOException {
         this.pageIO.write(bytes, seqNum);
 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Page.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Page.java
@@ -38,34 +38,22 @@ public abstract class Page implements Closeable {
         return "pageNum=" + this.pageNum + ", minSeqNum=" + this.minSeqNum + ", elementCount=" + this.elementCount + ", firstUnreadSeqNum=" + this.firstUnreadSeqNum;
     }
 
-    // NOTE:
-    // we have a page concern inconsistency where readBatch() takes care of the
-    // deserialization and returns a Batch object which contains the deserialized
-    // elements objects of the proper elementClass but HeadPage.write() deals with
-    // a serialized element byte[] and serialization is done at the Queue level to
-    // be able to use the Page.hasSpace() method with the serialized element byte size.
-    //
-    // @param limit the batch size limit
-    // @param elementClass the concrete element class for deserialization
-    // @return Batch batch of elements read when the number of elements can be <= limit
-    public Batch readBatch(int limit) throws IOException {
+    /**
+     * @param limit the maximum number of elements to read
+     * @return {@link SequencedList}<byte[]> collection of elements read. the number of elements can be <= limit
+     */
+    public SequencedList<byte[]> read(int limit) throws IOException {
 
         // first make sure this page is activated, activating previously activated is harmless
         this.pageIO.activate();
 
         SequencedList<byte[]> serialized = this.pageIO.read(this.firstUnreadSeqNum, limit);
-        List<byte[]> elements = serialized.getElements();
-        final int count = elements.size();
-        List<Queueable> deserialized = new ArrayList<>(count);
-        for (final byte[] element : elements) {
-            deserialized.add(this.queue.deserialize(element));
-        }
         assert serialized.getSeqNums().get(0) == this.firstUnreadSeqNum :
             String.format("firstUnreadSeqNum=%d != first result seqNum=%d", this.firstUnreadSeqNum, serialized.getSeqNums().get(0));
 
-        this.firstUnreadSeqNum += count;
+        this.firstUnreadSeqNum += serialized.getElements().size();
 
-        return new Batch(deserialized, serialized.getSeqNums(), this.queue);
+        return serialized;
     }
 
     /**
@@ -149,10 +137,6 @@ public abstract class Page implements Closeable {
 
     public int getElementCount() {
         return elementCount;
-    }
-
-    public Queue getQueue() {
-        return queue;
     }
 
     public PageIO getPageIO() {

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -571,13 +571,14 @@ public final class Queue implements Closeable {
     private Batch _readPageBatch(Page p, int limit) throws IOException {
         boolean wasFull = isFull();
 
-        Batch b = p.readBatch(limit);
-        this.unreadCount -= b.size();
+        SequencedList<byte[]> serialized = p.read(limit);
+
+        this.unreadCount -= serialized.getElements().size();
 
         if (p.isFullyRead()) { removeUnreadPage(p); }
         if (wasFull) { notFull.signalAll(); }
 
-        return b;
+        return new Batch(serialized, this);
     }
 
     private static class TailPageResult {

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/HeadPageTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/HeadPageTest.java
@@ -61,7 +61,7 @@ public class HeadPageTest {
             assertThat(p.hasSpace(element.serialize().length), is(true));
             p.write(element.serialize(), seqNum, 1);
 
-            Batch b = p.readBatch(1);
+            Batch b = new Batch(p.read(1), q);
 
             assertThat(b.getElements().size(), is(equalTo(1)));
             assertThat(b.getElements().get(0).toString(), is(equalTo(element.toString())));
@@ -104,7 +104,7 @@ public class HeadPageTest {
             assertThat(p.hasSpace(element.serialize().length), is(true));
             p.write(element.serialize(), seqNum, 1);
 
-            Batch b = p.readBatch(10);
+            Batch b = new Batch(p.read(10), q);
 
             assertThat(b.getElements().size(), is(equalTo(1)));
             assertThat(b.getElements().get(0).toString(), is(equalTo(element.toString())));

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
@@ -864,7 +864,7 @@ public class QueueTest {
             // work directly on the tail page and not the queue to avoid habing the queue purge the page
             // but make sure the tail page checkpoint marks it as fully acked
             TailPage tp = q.tailPages.get(0);
-            Batch b = tp.readBatch(1);
+            Batch b = new Batch(tp.read(1), q);
             assertThat(b.getElements().get(0), is(element1));
             tp.ack(b.getSeqNums(), 1);
             assertThat(tp.isFullyAcked(), is(true));


### PR DESCRIPTION
This is a cleanup to move the page read deserialization out of the Page and into the Batch. Now Page classes do not have knowledge of the Batch which happen at the Queue level. 

Part of #8674 for the PQ Batch size maximization