### PR TITLE
 #8672 adjust gradle to use plain output on CI

### DIFF
--- a/ci/integration_tests.sh
+++ b/ci/integration_tests.sh
@@ -24,10 +24,10 @@ elif [[ $1 == "split" ]]; then
     cd ../..
     if [[ $2 == 0 ]]; then
        echo "Running the first half of integration specs: $specs0"
-       ./gradlew runIntegrationTests -PrubyIntegrationSpecs="$specs0"
+       ./gradlew runIntegrationTests -PrubyIntegrationSpecs="$specs0" --console=plain
     elif [[ $2 == 1 ]]; then
        echo "Running the second half of integration specs: $specs1"
-       ./gradlew runIntegrationTests -PrubyIntegrationSpecs="$specs1"
+       ./gradlew runIntegrationTests -PrubyIntegrationSpecs="$specs1" --console=plain
     else
        echo "Error, must specify 0 or 1 after the split. For example ci/integration_tests.sh split 0"
        exit 1
@@ -35,9 +35,9 @@ elif [[ $1 == "split" ]]; then
 
 elif [[ !  -z  $@  ]]; then
     echo "Running integration tests 'rspec $@'"
-    ./gradlew runIntegrationTests -PrubyIntegrationSpecs="$@"
+    ./gradlew runIntegrationTests -PrubyIntegrationSpecs="$@" --console=plain
 
 else
     echo "Running all integration tests"
-    ./gradlew runIntegrationTests
+    ./gradlew runIntegrationTests --console=plain
 fi

--- a/ci/unit_tests.sh
+++ b/ci/unit_tests.sh
@@ -19,11 +19,11 @@ if [[ $SELECTED_TEST_SUITE == $"core-fail-fast" ]]; then
   rake test:core-fail-fast
 elif [[ $SELECTED_TEST_SUITE == $"java" ]]; then
   echo "Running Java Tests"
-  ./gradlew javaTests
+  ./gradlew javaTests --console=plain
 elif [[ $SELECTED_TEST_SUITE == $"ruby" ]]; then
   echo "Running Ruby unit tests"
-  ./gradlew rubyTests
+  ./gradlew rubyTests --console=plain
 else
   echo "Running Java and Ruby unit tests"
-  ./gradlew test
+  ./gradlew test --console=plain
 fi


### PR DESCRIPTION
It's in the title, make the output on CI non-interactive to to make it readable in Jenkins logs.
No more weird Gradle status lines mixed into everything :)