### PR TITLE
[MINOR] bad bad javadoc

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Page.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Page.java
@@ -40,7 +40,7 @@ public abstract class Page implements Closeable {
 
     /**
      * @param limit the maximum number of elements to read
-     * @return {@link SequencedList}<byte[]> collection of elements read. the number of elements can be <= limit
+     * @return {@link SequencedList} collection of elements read. the number of elements can be {@literal <=} limit
      */
     public SequencedList<byte[]> read(int limit) throws IOException {
 


### PR DESCRIPTION
`<` broke the javadoc generation and thus broke the build 😿 