### PR TITLE
Correct template_overwrite in upgrade instructions

### DIFF
--- a/docs/static/upgrading.asciidoc
+++ b/docs/static/upgrading.asciidoc
@@ -67,7 +67,7 @@ If you are installing Logstash with other components in the Elastic Stack, also 
 {stack-ref}/index.html[Elastic Stack installation and upgrade documentation].
 
 If you are using the default mapping templates in Logstash, to continue using these after migrating Elasticsearch to 6.0, you must override the existing template with the 6.x template.
- This can be done by starting a pipeline with the `overwrite_template => true` option in the Elasticsearch output definition in the Logstash config.
+ This can be done by starting a pipeline with the `template_overwrite => true` option in the Elasticsearch output definition in the Logstash config.
 
 Note that multiple doctypes are no longer supported in Elasticsearch 6.0. Please refer to
  {ref}/removal-of-types.html[Removal of mapping types] and {ref}/breaking-changes.html[Breaking changes] for more information.


### PR DESCRIPTION
I believe overwrite_template should actually be template_overwrite
https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html#plugins-outputs-elasticsearch-template_overwrite