### PR TITLE
[WIP] maximize PQ read batch size

### DIFF
--- a/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/QueueRWBenchmark.java
+++ b/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/QueueRWBenchmark.java
@@ -100,7 +100,7 @@ public class QueueRWBenchmark {
             }
         });
         for (int i = 0; i < EVENTS_PER_INVOCATION / BATCH_SIZE; ++i) {
-            try (Batch batch = queuePersisted.readBatch(BATCH_SIZE)) {
+            try (Batch batch = queuePersisted.readBatch(BATCH_SIZE, Queue.TIMEOUT_SECOND)) {
                 for (final Queueable elem : batch.getElements()) {
                     blackhole.consume(elem);
                 }
@@ -122,7 +122,7 @@ public class QueueRWBenchmark {
             }
         });
         for (int i = 0; i < EVENTS_PER_INVOCATION / BATCH_SIZE; ++i) {
-            try (Batch batch = queueMemory.readBatch(BATCH_SIZE)) {
+            try (Batch batch = queueMemory.readBatch(BATCH_SIZE, Queue.TIMEOUT_SECOND)) {
                 for (final Queueable elem : batch.getElements()) {
                     blackhole.consume(elem);
                 }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Batch.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Batch.java
@@ -15,15 +15,15 @@ public class Batch implements Closeable {
     private final Queue queue;
     private final AtomicBoolean closed;
 
-    public Batch(List<Queueable> elements, LongVector seqNums, Queue q) {
-        this.elements = elements;
+    public Batch(SequencedList<byte[]> serialized, Queue q) {
+        this(serialized.getElements(), serialized.getSeqNums(), q);
+    }
+
+    public Batch(List<byte[]> elements, LongVector seqNums, Queue q) {
+        this.elements = deserializeElements(elements, q);
         this.seqNums = seqNums;
         this.queue = q;
         this.closed = new AtomicBoolean(false);
-    }
-
-    public Batch(SequencedList<byte[]> serialized, Queue q) {
-        this(deserializeElements(serialized.getElements(), q), serialized.getSeqNums(), q);
     }
 
     // close acks the batch ackable events

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Page.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Page.java
@@ -210,13 +210,14 @@ public class Page implements Closeable {
         // first thing that must be done after beheading is to create a new checkpoint for that new tail page
         // tail page checkpoint does NOT includes a fsync
         checkpoint();
+    }
 
-        // TODO: should we have a better deactivation strategy to avoid too rapid reactivation scenario?
-        Page firstUnreadPage = queue.firstUnreadPage();
-        if (firstUnreadPage == null || (this.getPageNum() > firstUnreadPage.getPageNum())) {
-            // deactivate if this new tailPage is not where the read is occurring
-            this.getPageIO().deactivate();
-        }
+    /**
+     * signal that this page is not active and resources can be released
+     * @throws IOException
+     */
+    public void deactivate() throws IOException {
+        this.getPageIO().deactivate();
     }
 
     public boolean hasSpace(int byteSize) {

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Page.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Page.java
@@ -202,14 +202,16 @@ public class Page implements Closeable {
     }
 
     public void behead() throws IOException {
-        checkpoint();
+        assert this.writable == true : "cannot behead a tail page";
+
+        headPageCheckpoint();
 
         this.writable = false;
         this.lastCheckpoint = new Checkpoint(0, 0, 0, 0, 0);
 
         // first thing that must be done after beheading is to create a new checkpoint for that new tail page
         // tail page checkpoint does NOT includes a fsync
-        checkpoint();
+        tailPageCheckpoint();
     }
 
     /**

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/LongVector.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/LongVector.java
@@ -25,6 +25,22 @@ public final class LongVector {
     }
 
     /**
+     * Store the {@code long[]} to the underlying {@code long[]}, resizing it if necessary.
+     * @param nums {@code long[]} to store
+     */
+    public void add(final LongVector nums) {
+        if (data.length < count + nums.size()) {
+            final long[] old = data;
+            data = new long[(data.length << 1) + nums.size()];
+            System.arraycopy(old, 0, data, 0, old.length);
+        }
+        for (int i = 0; i < nums.size(); i++) {
+            data[count + i] = nums.get(i);
+        }
+        count += nums.size();
+    }
+
+    /**
      * Get value stored at given index.
      * @param index Array index (only values smaller than {@link LongVector#count} are valid)
      * @return Int

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/HeadPageTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/HeadPageTest.java
@@ -84,7 +84,7 @@ public class HeadPageTest {
             assertThat(p.isEmpty(), is(true));
             p.write(element.serialize(), 1, 1);
             assertThat(p.isEmpty(), is(false));
-            Batch b = q.readBatch(1);
+            Batch b = q.readBatch(1, Queue.TIMEOUT_SECOND);
             assertThat(p.isEmpty(), is(false));
             b.close();
             assertThat(p.isEmpty(), is(true));

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/io/LongVectorTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/io/LongVectorTest.java
@@ -19,4 +19,22 @@ public class LongVectorTest {
             assertThat((long) i, is(vector.get(i)));
         }
     }
+
+    @Test
+    public void storesVecorAndResizes() {
+        final int count = 1000;
+        final LongVector vector1 = new LongVector(count);
+        for (long i = 0L; i < count; ++i) {
+            vector1.add(i);
+        }
+        final LongVector vector2 = new LongVector(count);
+        for (long i = 0L + count; i < 2 * count; ++i) {
+            vector2.add(i);
+        }
+        vector1.add(vector2);
+        assertThat(vector1.size(), is(2 * count));
+        for (int i = 0; i < 2 * count; ++i) {
+            assertThat((long) i, is(vector1.get(i)));
+        }
+    }
 }

--- a/logstash-core/src/test/java/org/logstash/stress/Concurrent.java
+++ b/logstash-core/src/test/java/org/logstash/stress/Concurrent.java
@@ -75,7 +75,7 @@ public class Concurrent {
 
             try {
                 while (consumedCount < ELEMENT_COUNT) {
-                    Batch b = q.readBatch(BATCH_SIZE);
+                    Batch b = q.readBatch(BATCH_SIZE, Queue.TIMEOUT_SECOND);
 //                    if (b.getElements().size() < BATCH_SIZE) {
 //                        System.out.println("read small batch=" + b.getElements().size());
 //                    } else {
@@ -129,7 +129,7 @@ public class Concurrent {
             consumers.add(new Thread(() -> {
                 try {
                     while (output.size() < ELEMENT_COUNT) {
-                        Batch b = q.readBatch(BATCH_SIZE);
+                        Batch b = q.readBatch(BATCH_SIZE, Queue.TIMEOUT_SECOND);
 //                        if (b.getElements().size() < BATCH_SIZE) {
 //                            System.out.println("read small batch=" + b.getElements().size());
 //                        } else {


### PR DESCRIPTION
This PR is based and depends on #8690 

💥  NOTE that this PR also includes Javadoc cleanups, particularly in the `Queue` class.

Work in this PR is about doing batch size maximization on read per #8674. The main logic is located in the `Queue` `_readPageBatch()` method. 

A simple test for this has been added in `QueueTest` `maximizeBatch()`. 

TODOs:
- [ ] perform comparative benchmarks pre/post read batch maximization
- [ ] perform ES output tests to validate bulk size maximization as per #7243

