### PR TITLE
Minor: Rename environment variables to substitution variables

### DIFF
--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -34,7 +34,7 @@ LogStash::Environment.load_locale!
 #
 module LogStash::Config::Mixin
   
-  include LogStash::Util::EnvironmentVariables
+  include LogStash::Util::SubstitutionVariables
   
   attr_accessor :config
   attr_accessor :original_params
@@ -144,7 +144,7 @@ module LogStash::Config::Mixin
 
   module DSL
 
-    include LogStash::Util::EnvironmentVariables
+    include LogStash::Util::SubstitutionVariables
 
     attr_accessor :flags
 

--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -2,13 +2,13 @@
 require "logstash/util/loggable"
 require "fileutils"
 require "logstash/util/byte_value"
-require "logstash/util/environment_variables"
+require "logstash/util/substitution_variables"
 require "logstash/util/time_value"
 
 module LogStash
   class Settings
 
-    include LogStash::Util::EnvironmentVariables
+    include LogStash::Util::SubstitutionVariables
     
     def initialize
       @settings = {}

--- a/logstash-core/lib/logstash/util/substitution_variables.rb
+++ b/logstash-core/lib/logstash/util/substitution_variables.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
-module ::LogStash::Util::EnvironmentVariables
+module ::LogStash::Util::SubstitutionVariables
 
-  ENV_PLACEHOLDER_REGEX = /\${(?<name>[a-zA-Z_.][a-zA-Z0-9_.]*)(:(?<default>[^}]*))?}/
+  SUBSTITUTION_PLACEHOLDER_REGEX = /\${(?<name>[a-zA-Z_.][a-zA-Z0-9_.]*)(:(?<default>[^}]*))?}/
 
   # Recursive method to replace environment variable references in parameters
   def deep_replace(value)
@@ -15,17 +15,19 @@ module ::LogStash::Util::EnvironmentVariables
           value[valueArrayIndex] = deep_replace(value[valueArrayIndex])
         end
       else
-        return replace_env_placeholders(value)
+        return replace_placeholders(value)
       end
     end
   end
 
-  # Replace all environment variable references in 'value' param by environment variable value and return updated value
-  # Process following patterns : $VAR, ${VAR}, ${VAR:defaultValue}
-  def replace_env_placeholders(value)
+  # Replace all substitution variable references in the 'value' param and returns the substituted value, or the original value if a substitution can not be made
+  # Process following patterns : ${VAR}, ${VAR:defaultValue}
+  # If value matches the pattern, returns the following precedence : Environment entry value, default value as provided in the pattern
+  # If the value does not match the pattern, the 'value' param returns as-is
+  def replace_placeholders(value)
     return value unless value.is_a?(String)
 
-    value.gsub(ENV_PLACEHOLDER_REGEX) do |placeholder|
+    value.gsub(SUBSTITUTION_PLACEHOLDER_REGEX) do |placeholder|
       # Note: Ruby docs claim[1] Regexp.last_match is thread-local and scoped to
       # the call, so this should be thread-safe.
       #
@@ -39,5 +41,5 @@ module ::LogStash::Util::EnvironmentVariables
       end
       replacement
     end
-  end # def replace_env_placeholders
+  end # def replace_placeholders
 end

--- a/logstash-core/spec/logstash/settings_spec.rb
+++ b/logstash-core/spec/logstash/settings_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 require "spec_helper"
-require "logstash/util/environment_variables"
+require "logstash/util/substitution_variables"
 require "logstash/settings"
 require "fileutils"
 


### PR DESCRIPTION
This is in support of a future change to also support substitution from the secret store in addition to the environment variables.

Part of #8353