### PR TITLE
 #7403 follow up, fixing unsorted collection in Graph#chain

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/Graph.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/Graph.java
@@ -156,8 +156,8 @@ public final class Graph implements SourceComponent, Hashable {
 
         // Build these lists here since we do mutate the graph in place later
         // This isn't strictly necessary, but makes things less confusing
-        Collection<Vertex> fromLeaves = allLeaves().map(combineResult.oldToNewVertices::get).collect(Collectors.toSet());
-        Collection<Vertex> toRoots = otherGraph.roots().map(combineResult.oldToNewVertices::get).collect(Collectors.toSet());
+        Collection<Vertex> fromLeaves = allLeaves().map(combineResult.oldToNewVertices::get).collect(Collectors.toList());
+        Collection<Vertex> toRoots = otherGraph.roots().map(combineResult.oldToNewVertices::get).collect(Collectors.toList());
 
         return combineResult.graph.chain(fromLeaves, toRoots);
     }

--- a/logstash-core/src/test/java/org/logstash/config/ir/graph/GraphTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/graph/GraphTest.java
@@ -83,10 +83,11 @@ public class GraphTest {
 
     @Test
     public void complexConsistencyTest() throws InvalidIRException {
-        Graph g1 = IRHelpers.samplePipeline().getGraph();
-        Graph g2 = IRHelpers.samplePipeline().getGraph();
-
-        assertEquals(g1.uniqueHash(), g2.uniqueHash());
+        for (int i = 0; i < 10; ++i) {
+            Graph g1 = IRHelpers.samplePipeline().getGraph();
+            Graph g2 = IRHelpers.samplePipeline().getGraph();
+            assertEquals(g1.uniqueHash(), g2.uniqueHash());
+        }
     }
 
     @Test


### PR DESCRIPTION
Now that we don't sort the vertex hashes anymore after #8695, this piece of random sorting is hitting us if we run the test I changed to run 10x repeatedly.

Failed here:
https://logstash-ci.elastic.co/job/elastic+logstash+6.x+multijob-unix-compatibility/os=oraclelinux/231/console

Pretty obvious fix in my opinion, since the leaves we're mapping and filtering there are all coming from `LinkedHashMap`s we don't need to collect to a set => list is sorted and safe here.