### PR TITLE
Bump minitar version for security fix even though we aren't vulnerable

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -64,7 +64,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "i18n", "= 0.6.9" #(MIT license)
 
   # filetools and rakelib
-  gem.add_runtime_dependency "minitar", "~> 0.5.4"
+  gem.add_runtime_dependency "minitar", "~> 0.6.1"
   gem.add_runtime_dependency "rubyzip", "~> 1.1.7"
   gem.add_runtime_dependency "thread_safe", "~> 0.3.5" #(Apache 2.0 license)
 

--- a/rakelib/dependency.rake
+++ b/rakelib/dependency.rake
@@ -9,7 +9,7 @@ namespace "dependency" do
   end # task rbx-stdlib
 
   task "archive-tar-minitar" do
-    Rake::Task["gem:require"].invoke("minitar", "0.5.4")
+    Rake::Task["gem:require"].invoke("minitar", "0.6.1")
   end # task archive-minitar
 
   task "stud" do


### PR DESCRIPTION
Backport of #8714 to 5.6 , merge wasn't clean.