### PR TITLE
ensure logstash terminates on second sigint

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -465,7 +465,10 @@ class LogStash::Runner < Clamp::StrictCommand
     Stud::trap("INT") do
       if @interrupted_once
         logger.fatal(I18n.t("logstash.agent.forced_sigint"))
-        exit(1)
+        # calling just Kernel.exit only raises SystemExit exception
+        # and doesn't guarantee the process will terminate
+        # We must call Kernel.exit! so java.lang.System.exit is called
+        exit!(1)
       else
         logger.warn(I18n.t("logstash.agent.sigint"))
         Thread.new(logger) {|lg| sleep 5; lg.warn(I18n.t("logstash.agent.slow_shutdown")) }


### PR DESCRIPTION
As more java code is being used in logstash, it's likely that
java.lang.Threads which aren't set as daemon may be running when
`exit(1)` is called.

Because System.exit only raises a SystemExit exception, it's possible
that threads will continue to execute, and if they're not set as daemon
then the JVM won't terminate.

By calling `System.exit!` instead we ensure jruby calls the underlying
java.lang.System.exit and logstash terminates immediately.