### PR TITLE
 #8728 Fix RubyTimestamp's '<=>' implementation to correctly compare to other types

### DIFF
--- a/logstash-core/lib/logstash/timestamp.rb
+++ b/logstash-core/lib/logstash/timestamp.rb
@@ -8,11 +8,6 @@ module LogStash
   class Timestamp
     include Comparable
 
-    # TODO (colin) implement in Java
-    def <=>(other)
-      self.time <=> other.time
-    end
-
     def eql?(other)
       self.== other
     end

--- a/logstash-core/spec/logstash/timestamp_spec.rb
+++ b/logstash-core/spec/logstash/timestamp_spec.rb
@@ -36,6 +36,11 @@ describe LogStash::Timestamp do
       expect{LogStash::Timestamp.new("foobar")}.to raise_error
     end
 
+    it "compares to any type" do
+      t = LogStash::Timestamp.new
+      expect(t == '-').to be_falsey
+    end
+
   end
 
 end

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
@@ -254,5 +254,15 @@ public class JrubyTimestampExtLibrary implements Library {
         {
             return RubyFixnum.newFixnum(context.runtime, this.timestamp.getTime().getYear());
         }
+
+        @JRubyMethod(name = "<=>", required = 1)
+        public IRubyObject op_cmp(final ThreadContext context, final IRubyObject other) {
+            if (other instanceof JrubyTimestampExtLibrary.RubyTimestamp) {
+                return ((RubyTime) ruby_time(context)).op_cmp(
+                    context, ((JrubyTimestampExtLibrary.RubyTimestamp) other).ruby_time(context)
+                );
+            }
+            return context.nil;
+        }
     }
 }


### PR DESCRIPTION
Backport of #8730