### PR TITLE
windows ci: remove rake in favor of gradle

### DIFF
--- a/ci/unit_tests.bat
+++ b/ci/unit_tests.bat
@@ -39,47 +39,9 @@ echo Using drive !use_drive! for %WORKSPACE%
 :: change current directory to that drive
 !use_drive!
 
-:: Since we are using the system jruby, we need to make sure our jvm process
-:: uses at least 1g of memory, If we don't do this we can get OOM issues when
-:: installing gems. See https://github.com/elastic/logstash/issues/5179
+echo Running core tests..
+call .\gradlew.bat test --console=plain
 
-set JRUBY_OPTS="-J-Xmx1g"
-set SELECTEDTESTSUITE=%1
-set /p JRUBYVERSION=<.ruby-version
-
-if "%JRUBYSRCDIR%" == "" (
-  echo Error: environment variable JRUBYSRCDIR must be defined. Aborting..
-  exit /B 1
-)
-
-if not exist %JRUBYSRCDIR% (
-  echo Error: variable JRUBYSRCDIR must be declared with a valid directory. Aborting..
-  exit /B 1
-)
-
-set JRUBYPATH=%JRUBYSRCDIR%\%JRUBYVERSION%
-
-if not exist %JRUBYPATH% (
-  echo Error: could not find JRuby in %JRUBYPATH%. Aborting..
-  exit /B 1
-)
-
-set RAKEPATH=%JRUBYPATH%\bin\rake
-
-echo Installing core plugins..
-call %RAKEPATH% test:install-core
-if errorlevel 1 (
-  echo Error: failed to install core plugins. Aborting..
-  exit /B 1
-)
-
-if "%SELECTEDTESTSUITE%" == "core-fail-fast" (
-  echo Running core-fail-fast tests..
-  call %RAKEPATH% test:core-fail-fast
-) else (
-  echo Running core tests..
-  call %RAKEPATH% test:core
-)
 if errorlevel 1 (
   echo Error: failed to run core tests. Aborting..
   exit /B 1


### PR DESCRIPTION
fixes #8732 

Note - this PR also removes support for `rake test:core-fail-fast` see https://github.com/elastic/logstash/issues/8742 for additional information. 

If there are objections to https://github.com/elastic/logstash/issues/8742 (complete removal of `rake test:core-fail-fast`) we will want to re-add support here at some later time when the Gradle wrappers support it.  

This PR should fix most of the builds (which are currently red).