### PR TITLE
Revert "Bump minitar version for security fix even though we aren't vulnerable"

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -64,7 +64,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "i18n", "= 0.6.9" #(MIT license)
 
   # filetools and rakelib
-  gem.add_runtime_dependency "minitar", "~> 0.6.1"
+  gem.add_runtime_dependency "minitar", "~> 0.5.4"
   gem.add_runtime_dependency "rubyzip", "~> 1.1.7"
   gem.add_runtime_dependency "thread_safe", "~> 0.3.5" #(Apache 2.0 license)
 

--- a/rakelib/dependency.rake
+++ b/rakelib/dependency.rake
@@ -9,7 +9,7 @@ namespace "dependency" do
   end # task rbx-stdlib
 
   task "archive-tar-minitar" do
-    Rake::Task["gem:require"].invoke("minitar", "0.6.1")
+    Rake::Task["gem:require"].invoke("minitar", "0.5.4")
   end # task archive-minitar
 
   task "stud" do


### PR DESCRIPTION
This reverts commit 96706a99be380423a9c2e8af7d05e66409b87b20.

This is being reverted for the 5.6 branch since it requires transitive Ruby 2.x dependencies (and breaks the build)

Fixes #8746