### PR TITLE
Fix return code and finding Java in system-install

### DIFF
--- a/bin/system-install
+++ b/bin/system-install
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-unset CDPATH
-. "$(cd `dirname $0`/..; pwd)/bin/logstash.lib.sh"
-setup
-
 if [ -z "$1" ]; then
   if [ -r /etc/logstash/startup.options ]; then
     OPTIONS_PATH=/etc/logstash/startup.options
@@ -43,6 +39,10 @@ fi
 
 # Read in the env vars in the selected startup.options file...
 . "${OPTIONS_PATH}"
+
+unset CDPATH
+. "$(cd `dirname $0`/..; pwd)/bin/logstash.lib.sh"
+setup
 
 old_IFS=$IFS
 IFS=$'\n'
@@ -95,3 +95,4 @@ else
   echo "Successfully created system startup script for Logstash"
 fi
 rm $tempfile
+exit $exit_code


### PR DESCRIPTION
There are two bugs in _./bin/system-install_ that make it hard to work with in Puppet and your [puppet-logstash](https://github.com/elastic/puppet-logstash) module.

The return code of the JRuby call is trapped in a variable, but subsequent echos and rms mean that the system-install Bash will always return with zero, indicating it has always run successfully.  Puppet treats the return code of an Exec as gospel so we should really return the same exit code of the JRuby call so any error gets propagated to Puppet.

Second, I've moved the call to the setup() function to after loading the environment from startup.options. If you have a non-standard Java path like in /opt, you need JAVA_HOME set before setup() is called or the script won't be able to find the path to the Java binary.