### PR TITLE
test fix: pin rack-test to 0.7.0. newer versions require Ruby 2.2.2+

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -25,7 +25,7 @@ gem "gems", "~> 0.8.3", :group => :build
 gem "rack", "1.6.6"
 gem "redis", "~> 3.3.3"
 # ------- end pinning
-gem "rack-test", :require => "rack/test", :group => :development
+gem "rack-test", "0.7.0", :require => "rack/test", :group => :development
 gem "flores", "~> 0.0.6", :group => :development
 gem "term-ansicolor", "~> 1.3.2", :group => :development
 gem "docker-api", "1.31.0", :group => :development


### PR DESCRIPTION
only needed for 5.x branch(es) of code.. 