### PR TITLE
5.6 backport Add .lock.release to the test docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ ADD bin /opt/logstash/bin
 ADD modules /opt/logstash/modules
 ADD ci /opt/logstash/ci
 ADD settings.gradle /opt/logstash/settings.gradle
+ADD Gemfile.jruby-1.9.lock.release /opt/logstash/Gemfile.jruby-1.9.lock.release
 
 USER root
 RUN rm -rf build && \


### PR DESCRIPTION
Fixes #8759 (for 5.6)
The ci test will likely fail until https://github.com/elastic/logstash/pull/8758 lands (and this will need to be rebased)