### PR TITLE
Revert "Add .lock.release to the test docker container"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ ADD bin /opt/logstash/bin
 ADD modules /opt/logstash/modules
 ADD ci /opt/logstash/ci
 ADD settings.gradle /opt/logstash/settings.gradle
-ADD Gemfile.jruby-2.3.lock.release /opt/logstash/Gemfile.jruby-2.3.lock.release
 
 USER root
 RUN rm -rf build && \


### PR DESCRIPTION
This reverts commit f5e4da585b6c2e74f919cff4c533f585d939af52.

Reverting since 6.x does not have .lock.release file.