### PR TITLE
test fix: pin rake gem to Ruby 1.x compatible version

### DIFF
--- a/qa/Gemfile
+++ b/qa/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 gem "runner-tool", :git => "https://github.com/purbon/runner-tool.git"
 gem "rspec", "~> 3.1.0"
-gem "rake"
+gem "rake", "12.1.0"
 gem "pry", :group => :test


### PR DESCRIPTION
This should fix the 5.6 builds. 

Fixes #8746 