### PR TITLE
fix queue open bug for fully acked in-between pages plus new test

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -269,11 +269,6 @@ public final class Queue implements Closeable {
             if (this.tailPages.size() == 0) {
                 // this is the first tail page and it is fully acked so just purge it
                 this.checkpointIO.purge(this.checkpointIO.tailFileName(checkpoint.getPageNum()));
-            } else {
-                // create a tail page with a null PageIO and add it to tail pages but not unreadTailPages
-                // since it is fully read because also fully acked
-                // TODO: I don't like this null pageIO tail page...
-                this.tailPages.add(PageFactory.newTailPage(checkpoint, this, null));
             }
         } else {
             pageIO.open(checkpoint.getMinSeqNum(), checkpoint.getElementCount());
@@ -309,11 +304,6 @@ public final class Queue implements Closeable {
             if (this.tailPages.size() == 0) {
                 // this is the first tail page and it is fully acked so just purge it
                 this.checkpointIO.purge(this.checkpointIO.tailFileName(checkpoint.getPageNum()));
-            } else {
-                // create a tail page with a null PageIO and add it to tail pages but not unreadTailPages
-                // since it is fully read because also fully acked
-                // TODO: I don't like this null pageIO tail page...
-                this.tailPages.add(PageFactory.newTailPage(checkpoint, this, null));
             }
         } else {
             this.tailPages.add(page);


### PR DESCRIPTION
Fixes #8769 

This removes the insertion of dummy pages in the `tailPages` collection for in-between fully acked pages in the `open()` on an existing queue. This is completely unnecessary since the `ack()` method actually removes these pages in the normal process. 

Added a new tests to harness this edge case. Also validated manually with existing queue data which surfaced this problem.

This is pretty severe and should be prioritized for merging into 6.0.1 and downto 5.6. 