### PR TITLE
Update advanced-pipeline.asciidoc

### DIFF
--- a/docs/static/advanced-pipeline.asciidoc
+++ b/docs/static/advanced-pipeline.asciidoc
@@ -45,7 +45,7 @@ filebeat.prospectors:
   paths:
     - /path/to/file/logstash-tutorial.log <1>
 output.logstash:
-  hosts: ["localhost:5043"]
+  hosts: ["localhost:5044"]
 --------------------------------------------------------------------------------
 
 <1> Absolute path to the file or files that Filebeat processes.


### PR DESCRIPTION
Minor port change, from `5043` to `5044`, to make things consistent with the beats defaults.