### PR TITLE
bump es output dependency to 9.0.2

### DIFF
--- a/Gemfile.jruby-2.3.lock.release
+++ b/Gemfile.jruby-2.3.lock.release
@@ -412,7 +412,7 @@ GEM
       logstash-filter-json
       logstash-input-generator
       logstash-output-file
-    logstash-output-elasticsearch (9.0.0-java)
+    logstash-output-elasticsearch (9.0.2-java)
       cabin (~> 0.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       manticore (>= 0.5.4, < 1.0.0)


### PR DESCRIPTION
includes elasticsearch output plugin fix https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/712