### PR TITLE
 #8755 throw more readable exception on config parse failure

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/expression/BinaryBooleanExpression.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/expression/BinaryBooleanExpression.java
@@ -31,10 +31,10 @@ public abstract class BinaryBooleanExpression extends BooleanExpression {
         return left;
     }
 
-    public BinaryBooleanExpression(SourceWithMetadata meta,
-                                   Expression left,
-                                   Expression right) {
+    protected BinaryBooleanExpression(SourceWithMetadata meta, Expression left, Expression right) {
         super(meta);
+        ensureNotNull(left, "left", meta);
+        ensureNotNull(right, "right", meta);
         this.left = left;
         this.right = right;
     }
@@ -48,5 +48,16 @@ public abstract class BinaryBooleanExpression extends BooleanExpression {
 
     public String uniqueHash() {
         return Util.digest(this.getClass().getCanonicalName() + "[" + getLeft().hashSource() + "|" + getRight().hashSource() + "]");
+    }
+
+    private static void ensureNotNull(final Expression expression, final String side,
+        final SourceWithMetadata meta) {
+        if (expression == null) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Failed to parse %s-hand side of conditional %s", side, String.valueOf(meta)
+                )
+            );
+        }
     }
 }


### PR DESCRIPTION
Improves error message for #8755 

Now the situation outlined in #8755 throws:

```sh
and side of conditional [str]pipeline:6:8:```\n[foo] != /bar/\n```", :backtrace=>["org.logstash.config.ir.expression.BinaryBooleanExpression.ensureNotNull(org/logstash/config/ir/expression/BinaryBooleanExpression.java:57)", "org.logstash.config.ir.expression.BinaryBooleanExpression.<init>(org/logstash/config/ir/expression/BinaryBooleanExpression.java:37)", "org.logstash.config.ir.expression.binary.Neq.<init>(org/logstash/config/ir/expression/binary/Neq.java:12)", "org.logstash.config.ir.DSL.eNeq(org/logstash/config/ir/DSL.java:161)", "java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)", "org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:423)", "org.jruby.javasupport.JavaMethod.invokeStaticDirect(org/jruby/javasupport/JavaMethod.java:355)", "org.jruby.RubyMethod.call(org/jruby/RubyMethod.java:127)", "org.jruby.RubyMethod$INVOKER$i$call.call(org/jruby/RubyMethod$INVOKER$i$call.gen)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.lscl.expr(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash/compiler//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler/lscl.rb:436)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.lscl.RUBY$method$expr$0$__VARARGS__(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash/compiler//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler/lscl.rb)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.lscl.expr(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash/compiler//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler/lscl.rb:411)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.lscl.RUBY$method$expr$0$__VARARGS__(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash/compiler//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler/lscl.rb)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.lscl.block in join_conditions(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash/compiler//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler/lscl.rb:358)", "org.jruby.RubyArray.each(org/jruby/RubyArray.java:1734)", "org.jruby.RubyArray$INVOKER$i$0$0$each.call(org/jruby/RubyArray$INVOKER$i$0$0$each.gen)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.lscl.join_conditions(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash/compiler//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler/lscl.rb:357)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.lscl.RUBY$method$join_conditions$0$__VARARGS__(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash/compiler//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler/lscl.rb)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.lscl.expr(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash/compiler//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler/lscl.rb:306)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.lscl.RUBY$method$expr$0$__VARARGS__(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash/compiler//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler/lscl.rb)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.lscl.expr_cond(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash/compiler//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler/lscl.rb:275)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.lscl.RUBY$method$expr_cond$0$__VARARGS__(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash/compiler//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler/lscl.rb)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.lscl.block in expr(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash/compiler//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler/lscl.rb:224)", "org.jruby.RubyArray.each(org/jruby/RubyArray.java:1734)", "org.jruby.RubyArray$INVOKER$i$0$0$each.call(org/jruby/RubyArray$INVOKER$i$0$0$each.gen)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.lscl.expr(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash/compiler//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler/lscl.rb:221)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.lscl.RUBY$method$expr$0$__VARARGS__(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash/compiler//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler/lscl.rb)", "org.jruby.RubySymbol$SymbolProcBody.yieldInner(org/jruby/RubySymbol.java:1041)", "org.jruby.RubySymbol$SymbolProcBody.doYield(org/jruby/RubySymbol.java:1057)", "org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2472)", "org.jruby.RubyArray.map(org/jruby/RubyArray.java:2486)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.lscl.expr(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash/compiler//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler/lscl.rb:69)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.lscl.RUBY$method$expr$0$__VARARGS__(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash/compiler//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler/lscl.rb)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.lscl.block in compile(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash/compiler//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler/lscl.rb:48)", "org.jruby.RubyArray.each(org/jruby/RubyArray.java:1734)", "org.jruby.RubyArray$INVOKER$i$0$0$each.call(org/jruby/RubyArray$INVOKER$i$0$0$each.gen)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.lscl.compile(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash/compiler//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler/lscl.rb:46)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.compile_imperative(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler.rb:46)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.RUBY$method$compile_imperative$0$__VARARGS__(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler.rb)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.compile_graph(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler.rb:50)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.RUBY$method$compile_graph$0$__VARARGS__(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler.rb)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.block in compile_sources(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler.rb:12)", "org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2472)", "org.jruby.RubyArray.map(org/jruby/RubyArray.java:2486)", "org.jruby.RubyArray$INVOKER$i$0$0$map19.call(org/jruby/RubyArray$INVOKER$i$0$0$map19.gen)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.compile_sources(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler.rb:11)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.compiler.RUBY$method$compile_sources$0$__VARARGS__(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/compiler.rb)", "org.jruby.RubyClass.finvoke(org/jruby/RubyClass.java:899)", "org.jruby.RubyBasicObject.callMethod(org/jruby/RubyBasicObject.java:372)", "org.logstash.config.ir.ConfigCompiler.configToPipelineIR(org/logstash/config/ir/ConfigCompiler.java:37)", "java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)", "org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:423)", "org.jruby.javasupport.JavaMethod.invokeStaticDirect(org/jruby/javasupport/JavaMethod.java:355)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.java_pipeline.initialize(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/java_pipeline.rb:50)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.java_pipeline.initialize(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/java_pipeline.rb:161)", "org.jruby.RubyClass.newInstance(org/jruby/RubyClass.java:1022)", "org.jruby.RubyClass$INVOKER$i$newInstance.call(org/jruby/RubyClass$INVOKER$i$newInstance.gen)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.pipeline_action.create.execute(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash/pipeline_action//Users/brownbear/src/logstash/logstash-core/lib/logstash/pipeline_action/create.rb:38)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.pipeline_action.create.RUBY$method$execute$0$__VARARGS__(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash/pipeline_action//Users/brownbear/src/logstash/logstash-core/lib/logstash/pipeline_action/create.rb)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.agent.block in converge_state(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/agent.rb:335)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.agent.with_pipelines(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/agent.rb:141)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.agent.RUBY$method$with_pipelines$0$__VARARGS__(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/agent.rb)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.agent.block in converge_state(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/agent.rb:332)", "org.jruby.RubyArray.each(org/jruby/RubyArray.java:1734)", "org.jruby.RubyArray$INVOKER$i$0$0$each.call(org/jruby/RubyArray$INVOKER$i$0$0$each.gen)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.agent.converge_state(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/agent.rb:319)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.agent.RUBY$method$converge_state$0$__VARARGS__(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/agent.rb)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.agent.block in converge_state_and_update(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/agent.rb:166)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.agent.with_pipelines(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/agent.rb:141)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.agent.RUBY$method$with_pipelines$0$__VARARGS__(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/agent.rb)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.agent.converge_state_and_update(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/agent.rb:164)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.agent.RUBY$method$converge_state_and_update$0$__VARARGS__(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/agent.rb)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.agent.execute(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/agent.rb:90)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.agent.RUBY$method$execute$0$__VARARGS__(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/agent.rb)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.runner.block in execute(Users/brownbear/src/logstash/logstash_minus_core/lib/logstash//Users/brownbear/src/logstash/logstash-core/lib/logstash/runner.rb:343)", "org.jruby.RubyProc.call(org/jruby/RubyProc.java:289)", "org.jruby.RubyProc.call19(org/jruby/RubyProc.java:273)", "org.jruby.RubyProc$INVOKER$i$0$0$call19.call(org/jruby/RubyProc$INVOKER$i$0$0$call19.gen)", "Users.brownbear.src.logstash.vendor.bundle.jruby.$2_dot_3_dot_0.gems.stud_minus_0_dot_0_dot_23.lib.stud.task.block in initialize(Users/brownbear/src/logstash/vendor/bundle/jruby/$2_dot_3_dot_0/gems/stud_minus_0_dot_0_dot_23/lib/stud//Users/brownbear/src/logstash/vendor/bundle/jruby/2.3.0/gems/stud-0.0.23/lib/stud/task.rb:24)", "org.jruby.RubyProc.call(org/jruby/RubyProc.java:289)", "org.jruby.RubyProc.call(org/jruby/RubyProc.java:246)", "java.lang.Thread.run(java/lang/Thread.java:748)"]}
```

It would be great if we didn't have to validate like this, but as far as I can see that would require a big change to the grammar (the issue here is that it sets `nil/null` for an event value expression on parse failure all over the place) and I don't think we want to go there just yet right :)?
Also fixed the constructor here, to be properly `protected` for readability since it's an abstract class and with the deep inheritance here these details make tracking things like this down take always just a needless 5% longer :)