### PR TITLE
Bump gemspecs for 5.6.5/5.6.6

### DIFF
--- a/Gemfile.jruby-1.9.lock.release
+++ b/Gemfile.jruby-1.9.lock.release
@@ -166,12 +166,12 @@ GEM
       jls-grok (~> 0.11.1)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-patterns-core
-    logstash-codec-netflow (3.7.1)
+    logstash-codec-netflow (3.8.3)
       bindata (>= 1.5.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-codec-plain (3.0.5)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-codec-rubydebug (3.0.4)
+    logstash-codec-rubydebug (3.0.5)
       awesome_print
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-devutils (1.3.6-java)
@@ -206,8 +206,9 @@ GEM
       murmurhash3
     logstash-filter-geoip (4.3.1-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-grok (3.4.4)
+    logstash-filter-grok (4.0.0)
       jls-grok (~> 0.11.3)
+      logstash-core (>= 5.6.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-patterns-core
       stud (~> 0.0.22)
@@ -219,9 +220,9 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       metriks
       thread_safe
-    logstash-filter-mutate (3.1.7)
+    logstash-filter-mutate (3.2.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-ruby (3.1.1)
+    logstash-filter-ruby (3.1.2)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-filter-date
     logstash-filter-sleep (3.0.6)
@@ -279,7 +280,7 @@ GEM
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       stud (~> 0.0.22)
-    logstash-input-gelf (3.0.6)
+    logstash-input-gelf (3.0.7)
       gelfd (= 0.2.0)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -312,7 +313,7 @@ GEM
       mail (~> 2.6.3)
       mime-types (= 2.6.2)
       stud (~> 0.0.22)
-    logstash-input-irc (3.0.4)
+    logstash-input-irc (3.0.5)
       cinch
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -424,7 +425,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       manticore (>= 0.5.4, < 1.0.0)
       stud (~> 0.0, >= 0.0.17)
-    logstash-output-file (4.1.2)
+    logstash-output-file (4.2.1)
       logstash-codec-json_lines
       logstash-codec-line
       logstash-core-plugin-api (>= 2.0.0, < 2.99)
@@ -447,10 +448,10 @@ GEM
     logstash-output-null (3.0.4)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-output-pagerduty (3.0.5)
+    logstash-output-pagerduty (3.0.6)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-output-pipe (3.0.4)
+    logstash-output-pipe (3.0.5)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-output-rabbitmq (4.0.11-java)
@@ -460,36 +461,36 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       redis
       stud
-    logstash-output-s3 (4.0.12)
+    logstash-output-s3 (4.0.13)
       concurrent-ruby
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-aws
       stud (~> 0.0.22)
-    logstash-output-sns (4.0.5)
+    logstash-output-sns (4.0.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-aws (>= 1.0.0)
     logstash-output-sqs (4.0.3)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-aws (>= 1.0.0)
-    logstash-output-statsd (3.1.3)
+    logstash-output-statsd (3.1.4)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-input-generator
       statsd-ruby (= 1.2.0)
-    logstash-output-stdout (3.1.2)
+    logstash-output-stdout (3.1.3)
       logstash-codec-line
       logstash-core-plugin-api (>= 1.60.1, < 2.99)
     logstash-output-tcp (4.0.2)
       logstash-codec-json
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       stud
-    logstash-output-udp (3.0.4)
+    logstash-output-udp (3.0.5)
       logstash-codec-json
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-output-webhdfs (3.0.4)
+    logstash-output-webhdfs (3.0.5)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       snappy (= 0.0.12)
       webhdfs
-    logstash-output-xmpp (3.0.6)
+    logstash-output-xmpp (3.0.7)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       xmpp4r (~> 0.5.6)
     logstash-patterns-core (4.1.2)
@@ -734,7 +735,7 @@ DEPENDENCIES
   paquet (~> 0.2.0)
   pleaserun (~> 0.0.28)
   rack (= 1.6.6)
-  rack-test
+  rack-test (= 0.7.0)
   rake (~> 12.1.0)
   redis (~> 3.3.3)
   rest-client (= 1.8.0)


### PR DESCRIPTION
We already have a BC for 5.6.5 so this may not make it, which is fine, there's nothing critical here.

If it doesn't, this can wait for 5.6.6