### PR TITLE
Add link to interactive upgrade guide

### DIFF
--- a/docs/static/upgrading.asciidoc
+++ b/docs/static/upgrading.asciidoc
@@ -9,8 +9,10 @@ Before upgrading Logstash:
 * Test upgrades in a development environment before upgrading your production cluster.
 ===========================================
 
-If you are installing Logstash with other components in the Elastic Stack, also see the
-{stack-ref}/index.html[Elastic Stack installation and upgrade documentation].
+If you're upgrading other products in the stack, also read the
+{stack-ref}/index.html[Elastic Stack Installation and Upgrade Guide]. Want an
+upgrade list that's tailored to your stack? Try out our
+{upgrade_guide}[Interactive Upgrade Guide].
 
 See the following topics for information about upgrading Logstash:
 


### PR DESCRIPTION
I didn't make this change in master because it looks like the 6.0 upgrade docs are not in master. Maybe intentional? I don't know.