### PR TITLE
MINOR: Bring log4j version in line with ES

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -119,9 +119,9 @@ idea {
 }
 
 dependencies {
-    compile 'org.apache.logging.log4j:log4j-api:2.6.2'
-    compile 'org.apache.logging.log4j:log4j-core:2.6.2'
-    runtime 'org.apache.logging.log4j:log4j-slf4j-impl:2.6.2'
+    compile 'org.apache.logging.log4j:log4j-api:2.9.1'
+    compile 'org.apache.logging.log4j:log4j-core:2.9.1'
+    runtime 'org.apache.logging.log4j:log4j-slf4j-impl:2.9.1'
     // Jackson version moved to versions.yml in the project root (the JrJackson version is there too)
     compile "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
     compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"

--- a/logstash-core/gemspec_jars.rb
+++ b/logstash-core/gemspec_jars.rb
@@ -2,9 +2,9 @@
 # runtime dependencies to generate this gemspec dependencies file to be eval'ed by the gemspec
 # for the jar-dependencies requirements.
 
-gem.requirements << "jar org.apache.logging.log4j:log4j-slf4j-impl, 2.6.2"
-gem.requirements << "jar org.apache.logging.log4j:log4j-api, 2.6.2"
-gem.requirements << "jar org.apache.logging.log4j:log4j-core, 2.6.2"
+gem.requirements << "jar org.apache.logging.log4j:log4j-slf4j-impl, 2.9.1"
+gem.requirements << "jar org.apache.logging.log4j:log4j-api, 2.9.1"
+gem.requirements << "jar org.apache.logging.log4j:log4j-core, 2.9.1"
 gem.requirements << "jar com.fasterxml.jackson.core:jackson-core, 2.9.1"
 gem.requirements << "jar com.fasterxml.jackson.core:jackson-databind, 2.9.1"
 gem.requirements << "jar com.fasterxml.jackson.core:jackson-annotations, 2.9.1"

--- a/logstash-core/lib/logstash-core_jars.rb
+++ b/logstash-core/lib/logstash-core_jars.rb
@@ -2,27 +2,27 @@
 begin
   require 'jar_dependencies'
 rescue LoadError
-  require 'org/apache/logging/log4j/log4j-core/2.6.2/log4j-core-2.6.2.jar'
+  require 'org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar'
   require 'com/fasterxml/jackson/core/jackson-databind/2.9.1/jackson-databind-2.9.1.jar'
-  require 'org/apache/logging/log4j/log4j-api/2.6.2/log4j-api-2.6.2.jar'
-  require 'org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar'
   require 'com/fasterxml/jackson/core/jackson-annotations/2.9.1/jackson-annotations-2.9.1.jar'
-  require 'org/apache/logging/log4j/log4j-slf4j-impl/2.6.2/log4j-slf4j-impl-2.6.2.jar'
+  require 'org/apache/logging/log4j/log4j-api/2.9.1/log4j-api-2.9.1.jar'
+  require 'org/apache/logging/log4j/log4j-core/2.9.1/log4j-core-2.9.1.jar'
   require 'com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.9.1/jackson-dataformat-cbor-2.9.1.jar'
   require 'org/codehaus/janino/commons-compiler/3.0.7/commons-compiler-3.0.7.jar'
+  require 'org/apache/logging/log4j/log4j-slf4j-impl/2.9.1/log4j-slf4j-impl-2.9.1.jar'
   require 'com/fasterxml/jackson/core/jackson-core/2.9.1/jackson-core-2.9.1.jar'
   require 'org/codehaus/janino/janino/3.0.7/janino-3.0.7.jar'
 end
 
 if defined? Jars
-  require_jar( 'org.apache.logging.log4j', 'log4j-core', '2.6.2' )
+  require_jar( 'org.slf4j', 'slf4j-api', '1.7.25' )
   require_jar( 'com.fasterxml.jackson.core', 'jackson-databind', '2.9.1' )
-  require_jar( 'org.apache.logging.log4j', 'log4j-api', '2.6.2' )
-  require_jar( 'org.slf4j', 'slf4j-api', '1.7.21' )
   require_jar( 'com.fasterxml.jackson.core', 'jackson-annotations', '2.9.1' )
-  require_jar( 'org.apache.logging.log4j', 'log4j-slf4j-impl', '2.6.2' )
+  require_jar( 'org.apache.logging.log4j', 'log4j-api', '2.9.1' )
+  require_jar( 'org.apache.logging.log4j', 'log4j-core', '2.9.1' )
   require_jar( 'com.fasterxml.jackson.dataformat', 'jackson-dataformat-cbor', '2.9.1' )
   require_jar( 'org.codehaus.janino', 'commons-compiler', '3.0.7' )
+  require_jar( 'org.apache.logging.log4j', 'log4j-slf4j-impl', '2.9.1' )
   require_jar( 'com.fasterxml.jackson.core', 'jackson-core', '2.9.1' )
   require_jar( 'org.codehaus.janino', 'janino', '3.0.7' )
 end


### PR DESCRIPTION
This would be very nice to have for implementing the clustering prototype :) I can't run the ES JUnit framework with log4j `2.6.2`, upgrading it to `2.9.1` which is what ES uses too fixes the issues I'm experiencing.
Since we shouldn't use ancient versions here anyways I don't see why we can't upgrade this one in `master` and `6.x` :) 