### PR TITLE
change batch delay to 50ms and page size to 64mb

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -44,10 +44,10 @@
 #
 # pipeline.batch.size: 125
 #
-# How long to wait before dispatching an undersized batch to filters+workers
-# Value is in milliseconds.
+# How long to wait in milliseconds while polling for the next event
+# before dispatching an undersized batch to filters+outputs
 #
-# pipeline.batch.delay: 5
+# pipeline.batch.delay: 50
 #
 # Force Logstash to exit during shutdown even if there are still inflight
 # events in memory. By default, logstash will refuse to quit until all
@@ -135,9 +135,9 @@
 # path.queue:
 #
 # If using queue.type: persisted, the page data files size. The queue data consists of
-# append-only data files separated into pages. Default is 250mb
+# append-only data files separated into pages. Default is 64mb
 #
-# queue.page_capacity: 250mb
+# queue.page_capacity: 64mb
 #
 # If using queue.type: persisted, the maximum number of unread events in the queue.
 # Default is 0 (unlimited)

--- a/config/pipelines.yml
+++ b/config/pipelines.yml
@@ -31,8 +31,9 @@
 #   # How many events to retrieve from inputs before sending to filters+workers
 #   pipeline.batch.size: 125
 #
-#   # How long to wait before dispatching an undersized batch to filters+workers
-#   pipeline.batch.delay: 5
+#   # How long to wait in milliseconds while polling for the next event
+#   # before dispatching an undersized batch to filters+outputs
+#   pipeline.batch.delay: 50
 #
 #   # How many workers should be used per output plugin instance
 #   pipeline.output.workers: 1
@@ -42,8 +43,8 @@
 #   queue.type: memory
 #
 #   # If using queue.type: persisted, the page data files size. The queue data consists of
-#   # append-only data files separated into pages. Default is 250mb
-#   queue.page_capacity: 250mb
+#   # append-only data files separated into pages. Default is 64mb
+#   queue.page_capacity: 64mb
 #
 #   # If using queue.type: persisted, the maximum number of unread events in the queue.
 #   # Default is 0 (unlimited)

--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -83,7 +83,7 @@ Logstash <<logstash-settings-file,settings file>>:
 
 * `queue.type`: Specify `persisted` to enable persistent queues. By default, persistent queues are disabled (default: `queue.type: memory`).
 * `path.queue`: The directory path where the data files will be stored. By default, the files are stored in `path.data/queue`. 
-* `queue.page_capacity`: The maximum size of a queue page in bytes. The queue data consists of append-only files called "pages". The default size is 250mb. Changing this value is unlikely to have performance benefits.
+* `queue.page_capacity`: The maximum size of a queue page in bytes. The queue data consists of append-only files called "pages". The default size is 64mb. Changing this value is unlikely to have performance benefits.
 * `queue.drain`: Specify `true` if you want Logstash to wait until the persistent queue is drained before shutting down. The amount of time it takes to drain the queue depends on the number of events that have accumulated in the queue. Therefore, you should avoid using this setting unless the queue, even when full, is relatively small and can be drained quickly. 
 // Technically, I know, this isn't "maximum number of events" it's really maximum number of events not yet read by the pipeline worker. We only use this for testing and users generally shouldn't be setting this.
 * `queue.max_events`:  The maximum number of events that are allowed in the queue. The default is 0 (unlimited). This value is used internally for the Logstash test suite.

--- a/docs/static/running-logstash-command-line.asciidoc
+++ b/docs/static/running-logstash-command-line.asciidoc
@@ -100,7 +100,7 @@ With this command, Logstash concatenates three config files, `/tmp/one`, `/tmp/t
 *`-u, --pipeline.batch.delay DELAY_IN_MS`*::
   When creating pipeline batches, how long to wait while polling for the next event. This option defines
   how long in milliseconds to wait while polling for the next event before dispatching an undersized batch
-  to filters and workers. The default is 250ms.
+  to filters and outputs. The default is 50ms.
 
 *`--pipeline.unsafe_shutdown`*::
   Force Logstash to exit during shutdown even if there are still inflight events

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -16,7 +16,7 @@ hierarchical form to set the pipeline batch size and batch delay, you specify:
 pipeline:
   batch:
     size: 125
-    delay: 5
+    delay: 50
 -------------------------------------------------------------------------------------
 
 To express the same values as flat keys, you specify:
@@ -24,7 +24,7 @@ To express the same values as flat keys, you specify:
 [source,yaml]
 -------------------------------------------------------------------------------------
 pipeline.batch.size: 125
-pipeline.batch.delay: 5
+pipeline.batch.delay: 50
 -------------------------------------------------------------------------------------
 
 The `logstash.yml` file also supports bash-style interpolation of environment variables in
@@ -35,7 +35,7 @@ setting values.
 pipeline:
   batch:
     size: ${BATCH_SIZE}
-    delay: ${BATCH_DELAY:5}
+    delay: ${BATCH_DELAY:50}
 node:
   name: "node_${LS_NODE_NAME}"
 path:
@@ -43,7 +43,7 @@ path:
 -------------------------------------------------------------------------------------
 
 Note that the `${VAR_NAME:default_value}` notation is supported, setting a default batch delay
-of `5` and a default `path.queue` of `/tmp/queue` in the above example.
+of `50` and a default `path.queue` of `/tmp/queue` in the above example.
 
 Modules may also be specified in the `logstash.yml` file. The modules definition will have
 this format:
@@ -94,7 +94,7 @@ The `logstash.yml` file includes the following settings:
 | `pipeline.batch.delay`
 | When creating pipeline event batches, how long in milliseconds to wait for
   each event before dispatching an undersized batch to pipeline workers.
-| `5`
+| `50`
 
 | `pipeline.unsafe_shutdown`
 | When set to `true`, forces Logstash to exit during shutdown even if there are still inflight events
@@ -152,7 +152,7 @@ The `logstash.yml` file includes the following settings:
 
 | `queue.page_capacity`
 | The size of the page data files used when persistent queues are enabled (`queue.type: persisted`). The queue data consists of append-only data files separated into pages.
-| 250mb
+| 64mb
 
 | `queue.max_events`
 | The maximum number of unread events in the queue when persistent queues are enabled (`queue.type: persisted`).

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -38,7 +38,7 @@ module LogStash
    Setting::PositiveInteger.new("pipeline.workers", LogStash::Config::CpuCoreStrategy.maximum),
    Setting::PositiveInteger.new("pipeline.output.workers", 1),
    Setting::PositiveInteger.new("pipeline.batch.size", 125),
-           Setting::Numeric.new("pipeline.batch.delay", 5), # in milliseconds
+           Setting::Numeric.new("pipeline.batch.delay", 50), # in milliseconds
            Setting::Boolean.new("pipeline.unsafe_shutdown", false),
            Setting::Boolean.new("pipeline.java_execution", true),
            Setting::Boolean.new("pipeline.reloadable", true),
@@ -54,7 +54,7 @@ module LogStash
             Setting::String.new("http.environment", "production"),
             Setting::String.new("queue.type", "memory", true, ["persisted", "memory", "memory_acked"]),
             Setting::Boolean.new("queue.drain", false),
-            Setting::Bytes.new("queue.page_capacity", "250mb"),
+            Setting::Bytes.new("queue.page_capacity", "64mb"),
             Setting::Bytes.new("queue.max_bytes", "1024mb"),
             Setting::Numeric.new("queue.max_events", 0), # 0 is unlimited
             Setting::Numeric.new("queue.checkpoint.acks", 1024), # 0 is unlimited

--- a/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
@@ -94,7 +94,7 @@ module LogStash; module Util
       # from this queue. We also depend on this to be able to block consumers while we snapshot
       # in-flight buffers
 
-      def initialize(queue, batch_size = 125, wait_for = 250)
+      def initialize(queue, batch_size = 125, wait_for = 50)
         @queue = queue
         @mutex = Mutex.new
         # Note that @inflight_batches as a central mechanism for tracking inflight

--- a/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
@@ -29,7 +29,7 @@ module LogStash; module Util
       # from this queue. We also depend on this to be able to block consumers while we snapshot
       # in-flight buffers
 
-      def initialize(queue, batch_size = 125, wait_for = 250)
+      def initialize(queue, batch_size = 125, wait_for = 50)
         @queue = queue
         # Note that @inflight_batches as a central mechanism for tracking inflight
         # batches will fail if we have multiple read clients in the pipeline.

--- a/logstash-core/spec/logstash/queue_factory_spec.rb
+++ b/logstash-core/spec/logstash/queue_factory_spec.rb
@@ -9,7 +9,7 @@ describe LogStash::QueueFactory do
     [
       LogStash::Setting::WritableDirectory.new("path.queue", Stud::Temporary.pathname),
       LogStash::Setting::String.new("queue.type", "memory", true, ["persisted", "memory", "memory_acked"]),
-      LogStash::Setting::Bytes.new("queue.page_capacity", "250mb"),
+      LogStash::Setting::Bytes.new("queue.page_capacity", "64mb"),
       LogStash::Setting::Bytes.new("queue.max_bytes", "1024mb"),
       LogStash::Setting::Numeric.new("queue.max_events", 0),
       LogStash::Setting::Numeric.new("queue.checkpoint.acks", 1024),


### PR DESCRIPTION
Fixes #8707 
Relates to #8702, #8674 

Change the default values for `pipeline.batch.delay` from `5ms` to `50ms` and `queue.page_capacity` from `250mb` to `64mb`.

Also fixes documentation & comments inconsistencies. 