### PR TITLE
Add default log retention settings

### DIFF
--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -24,6 +24,8 @@ appender.rolling.layout.type = PatternLayout
 appender.rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %-.10000m%n
 appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
 appender.rolling.policies.size.size = 100MB
+appender.rolling.strategy.type = DefaultRolloverStrategy
+appender.rolling.strategy.max = 30
 
 appender.json_rolling.type = RollingFile
 appender.json_rolling.name = json_rolling
@@ -38,7 +40,8 @@ appender.json_rolling.layout.compact = true
 appender.json_rolling.layout.eventEol = true
 appender.json_rolling.policies.size.type = SizeBasedTriggeringPolicy
 appender.json_rolling.policies.size.size = 100MB
-
+appender.json_rolling.strategy.type = DefaultRolloverStrategy
+appender.json_rolling.strategy.max = 30
 
 rootLogger.level = ${sys:ls.log.level}
 rootLogger.appenderRef.console.ref = ${sys:ls.log.format}_console
@@ -69,6 +72,8 @@ appender.rolling_slowlog.layout.type = PatternLayout
 appender.rolling_slowlog.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %.10000m%n
 appender.rolling_slowlog.policies.size.type = SizeBasedTriggeringPolicy
 appender.rolling_slowlog.policies.size.size = 100MB
+appender.rolling_slowlog.strategy.type = DefaultRolloverStrategy
+appender.rolling_slowlog.strategy.max = 30
 
 appender.json_rolling_slowlog.type = RollingFile
 appender.json_rolling_slowlog.name = json_rolling_slowlog
@@ -83,6 +88,8 @@ appender.json_rolling_slowlog.layout.compact = true
 appender.json_rolling_slowlog.layout.eventEol = true
 appender.json_rolling_slowlog.policies.size.type = SizeBasedTriggeringPolicy
 appender.json_rolling_slowlog.policies.size.size = 100MB
+appender.json_rolling_slowlog.strategy.type = DefaultRolloverStrategy
+appender.json_rolling_slowlog.strategy.max = 30
 
 logger.slowlog.name = slowlog
 logger.slowlog.level = trace


### PR DESCRIPTION
The default retention setting of 20 files was arrived at by assuming a conservative 50% compression ratio on rotated log files for a total of 1GB (20 files * 50% compression * 100MB max size). Note that the 1GB limit would apply per appender.

Relates to #7842
