### PR TITLE
Add note outlining where cloud ID is used for LS modules

### DIFF
--- a/docs/static/modules.asciidoc
+++ b/docs/static/modules.asciidoc
@@ -139,6 +139,12 @@ Logstash comes with two settings that simplify using modules with https://cloud.
 The Elasticsearch and Kibana hostnames in Elastic Cloud may be hard to set
 in the Logstash config or on the commandline, so a Cloud ID can be used instead.
 
+NOTE: Cloud ID applies only when a Logstash module is enabled, otherwise
+specifying Cloud ID has no effect. Cloud ID applies to data that gets sent via
+the module, to runtime metrics sent via {xpack} monitoring, and to the endpoint
+used by {xpack} central management features of Logstash, unless explicit
+overrides to {xpack} settings are specified in `logstash.yml`.
+
 ==== Cloud ID
 
 The Cloud ID, which can be found in the Elastic Cloud web console, is used by


### PR DESCRIPTION
This note was added to the cloud docs in https://github.com/elastic/cloud/pull/9695. I think it's worth including here, too.