### PR TITLE
LIR: merge arrays of divergent types

### DIFF
--- a/logstash-core/lib/logstash/compiler/lscl.rb
+++ b/logstash-core/lib/logstash/compiler/lscl.rb
@@ -113,6 +113,8 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
           # interpreted as `{"match" => {"baz" => "bar", "foo" => "blub"}}`.
           # (NOTE: this bypasses `AST::Hash`'s ability to detect duplicate keys)
           hash[k] = existing.merge(v)
+        elsif existing.kind_of?(::Array)
+          hash[k] = existing.push(*v)
         else
           hash[k] = existing + v
         end

--- a/logstash-core/spec/logstash/compiler/compiler_spec.rb
+++ b/logstash-core/spec/logstash/compiler/compiler_spec.rb
@@ -194,6 +194,32 @@ describe LogStash::Compiler do
         end
       end
 
+      describe "a plugin with multiple array parameter types" do
+        let(:plugin_source) { "generator { aarg => [1] aarg => [2] aarg => [3]}" }
+        let(:expected_plugin_args) do
+          {
+              "aarg" => [1, 2, 3]
+          }
+        end
+
+        it "should contain the plugin" do
+          expect(c_plugin).to ir_eql(j.iPlugin(INPUT, "generator", expected_plugin_args))
+        end
+      end
+
+      describe "a plugin with multiple parameter types that converge to an array" do
+        let(:plugin_source) { "generator { aarg => [1] aarg => 2 aarg => '3' aarg => [4] }"}
+        let(:expected_plugin_args) do
+          {
+              "aarg" => [1, 2, "3", 4]
+          }
+        end
+
+        it "should contain the plugin" do
+          expect(c_plugin).to ir_eql(j.iPlugin(INPUT, "generator", expected_plugin_args))
+        end
+      end
+
       describe "a filter plugin that repeats a Hash directive" do
         let(:source) { "input { } filter { #{plugin_source} } output { } " }
         subject(:c_plugin) { compiled[:filter] }


### PR DESCRIPTION
Specifically this change explictly checks for the Array type to merge into and pushes into the array instead of relying only on the + concat.

Fixes #8827