### PR TITLE
fix require of manticore to avoid warnings at startup

### DIFF
--- a/logstash-core/lib/logstash/modules/kibana_client.rb
+++ b/logstash-core/lib/logstash/modules/kibana_client.rb
@@ -2,7 +2,7 @@
 require "logstash/namespace"
 require "logstash/logging"
 require "logstash/json"
-require "manticore/client"
+require "manticore"
 
 module LogStash module Modules class KibanaClient
   include LogStash::Util::Loggable


### PR DESCRIPTION
because we require "manticore/client" instead of just "manticore", we cause constant redefinition warnings at startup:

```
/tmp/logstash-7.0.0-alpha1-SNAPSHOT % bin/logstash  -e ""
/tmp/logstash-7.0.0-alpha1-SNAPSHOT/vendor/bundle/jruby/2.3.0/gems/manticore-0.6.1-java/lib/manticore/client.rb:108: warning: already initialized constant DEFAULT_MAX_POOL_SIZE
/tmp/logstash-7.0.0-alpha1-SNAPSHOT/vendor/bundle/jruby/2.3.0/gems/manticore-0.6.1-java/lib/manticore/client.rb:110: warning: already initialized constant DEFAULT_REQUEST_TIMEOUT
/tmp/logstash-7.0.0-alpha1-SNAPSHOT/vendor/bundle/jruby/2.3.0/gems/manticore-0.6.1-java/lib/manticore/client.rb:111: warning: already initialized constant DEFAULT_SOCKET_TIMEOUT
/tmp/logstash-7.0.0-alpha1-SNAPSHOT/vendor/bundle/jruby/2.3.0/gems/manticore-0.6.1-java/lib/manticore/client.rb:112: warning: already initialized constant DEFAULT_CONNECT_TIMEOUT
/tmp/logstash-7.0.0-alpha1-SNAPSHOT/vendor/bundle/jruby/2.3.0/gems/manticore-0.6.1-java/lib/manticore/client.rb:113: warning: already initialized constant DEFAULT_MAX_REDIRECTS
/tmp/logstash-7.0.0-alpha1-SNAPSHOT/vendor/bundle/jruby/2.3.0/gems/manticore-0.6.1-java/lib/manticore/client.rb:114: warning: already initialized constant DEFAULT_EXPECT_CONTINUE
/tmp/logstash-7.0.0-alpha1-SNAPSHOT/vendor/bundle/jruby/2.3.0/gems/manticore-0.6.1-java/lib/manticore/client.rb:115: warning: already initialized constant DEFAULT_STALE_CHECK
/tmp/logstash-7.0.0-alpha1-SNAPSHOT/vendor/bundle/jruby/2.3.0/gems/manticore-0.6.1-java/lib/manticore/client.rb:590: warning: already initialized constant ISO_8859_1
/tmp/logstash-7.0.0-alpha1-SNAPSHOT/vendor/bundle/jruby/2.3.0/gems/manticore-0.6.1-java/lib/manticore/client.rb:641: warning: already initialized constant KEY_EXTRACTION_REGEXP
Sending Logstash's logs to /tmp/logstash-7.0.0-alpha1-SNAPSHOT/logs which is now configured via log4j2.properties
[2017-12-12T11:57:40,684][INFO ][logstash.modules.scaffold] Initializing module {:module_name=>"fb_apache", :directory=>"/tmp/logstash-7.0.0-alpha1-SNAPSHOT/modules/fb_apache/configuration"}
[2017-12-12T11:57:40,725][INFO ][logstash.modules.scaffold] Initializing module {:module_name=>"netflow", :directory=>"/tmp/logstash-7.0.0-alpha1-SNAPSHOT/modules/netflow/configuration"}
[2017-12-12T11:57:41,066][WARN ][logstash.config.source.multilocal] Ignoring the 'pipelines.yml' file because modules or command line options are specified
[2017-12-12T11:57:41,891][INFO ][logstash.runner          ] Starting Logstash {"logstash.version"=>"7.0.0-alpha1"}
[2017-12-12T11:57:42,528][INFO ][logstash.agent           ] Successfully started Logstash API endpoint {:port=>9600}
[2017-12-12T11:57:46,123][INFO ][logstash.javapipeline    ] Starting pipeline {:pipeline_id=>"main", "pipeline.workers"=>4, "pipeline.batch.size"=>125, "pipeline.batch.delay"=>50, "pipeline.max_inflight"=>500, :thread=>"#<Thread:0x7b1ff711 run>"}
[2017-12-12T11:57:46,498][INFO ][logstash.javapipeline    ] Pipeline started {"pipeline.id"=>"main"}
The stdin plugin is now waiting for input:
```

This patch removes that warning by just requiring "manticore":

```
/tmp/logstash-7.0.0-alpha1-SNAPSHOT % bin/logstash  -e ""
Sending Logstash's logs to /tmp/logstash-7.0.0-alpha1-SNAPSHOT/logs which is now configured via log4j2.properties
[2017-12-12T11:56:42,063][INFO ][logstash.modules.scaffold] Initializing module {:module_name=>"fb_apache", :directory=>"/tmp/logstash-7.0.0-alpha1-SNAPSHOT/modules/fb_apache/configuration"}
[2017-12-12T11:56:42,090][INFO ][logstash.modules.scaffold] Initializing module {:module_name=>"netflow", :directory=>"/tmp/logstash-7.0.0-alpha1-SNAPSHOT/modules/netflow/configuration"}
[2017-12-12T11:56:42,530][WARN ][logstash.config.source.multilocal] Ignoring the 'pipelines.yml' file because modules or command line options are specified
[2017-12-12T11:56:43,397][INFO ][logstash.runner          ] Starting Logstash {"logstash.version"=>"7.0.0-alpha1"}
[2017-12-12T11:56:43,860][INFO ][logstash.agent           ] Successfully started Logstash API endpoint {:port=>9600}
[2017-12-12T11:56:47,140][INFO ][logstash.javapipeline    ] Starting pipeline {:pipeline_id=>"main", "pipeline.workers"=>4, "pipeline.batch.size"=>125, "pipeline.batch.delay"=>50, "pipeline.max_inflight"=>500, :thread=>"#<Thread:0x2bc86c12 run>"}
[2017-12-12T11:56:47,565][INFO ][logstash.javapipeline    ] Pipeline started {"pipeline.id"=>"main"}
The stdin plugin is now waiting for input:
```