### PR TITLE
6.0 backport: Pin webrick to compatible version

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -25,6 +25,7 @@ gem "term-ansicolor", "~> 1.3.2", :group => :development
 gem "docker-api", "1.33.4", :group => :development
 gem "json-schema", "~> 2.6", :group => :development
 gem "pleaserun", "~>0.0.28"
+gem 'webrick', '~> 1.3.1'
 gem "backports", "~> 3.8.0"
 gem "rake", "~> 12.1.0"
 gem "logstash-input-heartbeat"


### PR DESCRIPTION
Fixes #8845
Fixes #8846