### PR TITLE
fix ArrayIndexOutOfBoundsException from empty String field reference

### DIFF
--- a/logstash-core/src/main/java/org/logstash/FieldReference.java
+++ b/logstash-core/src/main/java/org/logstash/FieldReference.java
@@ -44,6 +44,9 @@ public final class FieldReference {
     private static final FieldReference METADATA_PARENT_REFERENCE =
         new FieldReference(EMPTY_STRING_ARRAY, Event.METADATA, META_PARENT);
 
+    static final FieldReference DATA_EMPTY_STRING_REFERENCE =
+            new FieldReference(EMPTY_STRING_ARRAY, "", DATA_CHILD);
+
     /**
      * Cache of all existing {@link FieldReference}.
      */
@@ -70,6 +73,9 @@ public final class FieldReference {
     }
 
     public static FieldReference from(final CharSequence reference) {
+        if( reference == null || reference.length() == 0){
+            return DATA_EMPTY_STRING_REFERENCE;
+        }
         // atomicity between the get and put is not important
         final FieldReference result = CACHE.get(reference);
         if (result != null) {

--- a/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
+++ b/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
@@ -40,4 +40,14 @@ public final class FieldReferenceTest {
     public void deduplicatesTimestamp() throws Exception {
         assertTrue(FieldReference.from("@timestamp") == FieldReference.from("[@timestamp]"));
     }
+
+    @Test
+    public void testParseEmptyString(){
+        assertEquals(FieldReference.from(""), FieldReference.DATA_EMPTY_STRING_REFERENCE);
+    }
+
+    @Test
+    public void testParseNull(){
+        assertEquals(FieldReference.from(null), FieldReference.DATA_EMPTY_STRING_REFERENCE);
+    }
 }


### PR DESCRIPTION
Cherry-picked backport from  #8824

Fixes #8823
