### PR TITLE
[DOCS] Changed release to 6.1.1

### DIFF
--- a/docs/index-shared1.asciidoc
+++ b/docs/index-shared1.asciidoc
@@ -1,9 +1,9 @@
 
 :branch:                6.1
 :major-version:         6.x
-:logstash_version:      6.1.0
-:elasticsearch_version: 6.1.0
-:kibana_version:        6.1.0
+:logstash_version:      6.1.1
+:elasticsearch_version: 6.1.1
+:kibana_version:        6.1.1
 :docker-repo:           docker.elastic.co/logstash/logstash
 :docker-image:          {docker-repo}:{logstash_version}
 


### PR DESCRIPTION
This PR updates the version from 6.1.0 to 6.1.1 in preparation for the next documentation release.