### PR TITLE
added new PQ checking tool bin/pqcheck

### DIFF
--- a/bin/pqcheck
+++ b/bin/pqcheck
@@ -1,0 +1,31 @@
+#!/usr/bin/env bin/ruby
+
+DEFAULT_PQ_DIR = "data/queue/main"
+
+argv0 = ARGV[0].to_s.strip
+if argv0 == "-h" || argv0 == "--help"
+  puts("usage: pqcheck [PQ dir path]\n  default [PQ dir path] is #{DEFAULT_PQ_DIR}")
+  exit(0)
+end
+
+dir = argv0.empty? ? DEFAULT_PQ_DIR : argv0
+if (!Dir.exist?(dir))
+  puts("error: invalid PQ dir path: #{dir}")
+  exit(1)
+end
+
+puts("checking queue dir: #{dir}")
+
+Dir.glob("#{dir}/checkpoint.*").sort_by { |x| x[/[0-9]+$/].to_i }.each do |checkpoint|
+  data = File.read(checkpoint)
+
+  if data.size == 33
+    version, page, firstUnackedPage, firstUnackedSeq, minSeq, elementCount, crc32 = data.unpack("nNNQ>Q>NN")
+    fa = firstUnackedSeq >= (minSeq + elementCount)
+    ps = File.exist?("#{dir}/page.#{page}") ? File.size("#{dir}/page.#{page}") : nil
+    print("#{File.basename(checkpoint)}, fully-acked: #{fa ? "YES" : "NO"}, page.#{page} size: #{ps ? ps : "NOT FOUND"}, ")
+    p(version: version, page: page, firstUnackedPage: firstUnackedPage, firstUnackedSeq: firstUnackedSeq, minSeq: minSeq, elementCount: elementCount, crc32: crc32)
+  else
+    puts("#{File.basename(checkpoint)}, invalid size: #{data.size} ")
+  end
+end


### PR DESCRIPTION
`bin/pqcheck` new tool to verify a PQ dir files structure. 

This is based on the original one-liner script @jordansissel produced as part of a diagnostic thread.

This tool can take dir path as parameter or use the default `data/queue/main` and will look into each checkpoint files and print it content. Il also prints the corresponding page file size and prints if it is fully acked or not. 

example output:
```
$ bin/pqcheck
checking queue dir: data/queue/main
checkpoint.head, FA, 67108864, {:version=>1, :page=>141, :firstUnackedPage=>141, :firstUnackedSeq=>17075891, :minSeq=>16974637, :elementCount=>101254, :crc32=>3485132876}
checkpoint.1, FA, NA, {:version=>0, :page=>0, :firstUnackedPage=>0, :firstUnackedSeq=>0, :minSeq=>0, :elementCount=>0, :crc32=>0}
```

