### PR TITLE
Allow users to specify --pipeline.id from the CLI

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -29,6 +29,10 @@
 #
 # ------------ Pipeline Settings --------------
 #
+# The ID of the pipeline.
+#
+# pipeline.id: main
+#
 # Set the number of workers that will, in parallel, execute the filters+outputs
 # stage of the pipeline.
 #

--- a/docs/static/running-logstash-command-line.asciidoc
+++ b/docs/static/running-logstash-command-line.asciidoc
@@ -84,6 +84,9 @@ With this command, Logstash concatenates three config files, `/tmp/one`, `/tmp/t
   that setting will be used.  The `-M` flag is only used in conjunction with the `--modules`
   flag.  It will be ignored if the `--modules` flag is absent.
 
+*`--pipeline.id ID`*::
+  Sets the ID of pipeline. The default is `main`.
+
 *`-w, --pipeline.workers COUNT`*::
   Sets the number of pipeline workers to run. This option sets the number of workers that will,
   in parallel, execute the filter and output stages of the pipeline. If you find that events are

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -77,6 +77,10 @@ The `logstash.yml` file includes the following settings:
 | The directory that Logstash and its plugins use for any persistent needs.
 |`LOGSTASH_HOME/data`
 
+| `pipeline.id`
+| The ID of the pipeline.
+| `main`
+
 | `pipeline.workers`
 | The number of workers that will, in parallel, execute the filter and output stages of the pipeline.
   If you find that events are backing up, or that the

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -85,6 +85,11 @@ class LogStash::Runner < Clamp::StrictCommand
     :attribute_name => "cloud.auth"
 
   # Pipeline settings
+  option ["--pipeline.id"], "ID",
+    I18n.t("logstash.runner.flag.pipeline-id"),
+    :attribute_name => "pipeline.id",
+    :default => LogStash::SETTINGS.get_default("pipeline.id")
+
   option ["-w", "--pipeline.workers"], "COUNT",
     I18n.t("logstash.runner.flag.pipeline-workers"),
     :attribute_name => "pipeline.workers",

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -262,6 +262,8 @@ en:
           Check configuration for valid syntax and then exit.
         http_host: Web API binding host
         http_port: Web API http port
+        pipeline-id: |+
+          Sets the ID of the pipeline.
         pipeline-workers: |+
           Sets the number of pipeline workers to run.
         experimental-java-execution: |+


### PR DESCRIPTION
Resolves #8867.

This will allow users to override the pipeline id from the default, "main", to something else while running pipelines via either the `-e` or `-f` options.

### Examples

#### Users can override the `pipeline.id` from the CLI
```
$ ./bin/logstash -e 'input { stdin {} } output { stdout {} }' --pipeline.id notmain
Sending Logstash's logs to /Users/shaunak/development/github/ycombinator/logstash/logs which is now configured via log4j2.properties
[2017-12-20T10:09:09,249][INFO ][logstash.modules.scaffold] Initializing module {:module_name=>"netflow", :directory=>"/Users/shaunak/development/github/ycombinator/logstash/modules/netflow/configuration"}
[2017-12-20T10:09:09,273][INFO ][logstash.modules.scaffold] Initializing module {:module_name=>"fb_apache", :directory=>"/Users/shaunak/development/github/ycombinator/logstash/modules/fb_apache/configuration"}
[2017-12-20T10:09:11,285][INFO ][logstash.modules.scaffold] Initializing module {:module_name=>"arcsight", :directory=>"/Users/shaunak/development/github/ycombinator/logstash/vendor/bundle/jruby/2.3.0/gems/x-pack-7.0.0.alpha1.SNAPSHOT-java/modules/arcsight/configuration"}
[2017-12-20T10:09:12,204][WARN ][logstash.config.source.multilocal] Ignoring the 'pipelines.yml' file because modules or command line options are specified
[2017-12-20T10:09:13,414][INFO ][logstash.runner          ] Starting Logstash {"logstash.version"=>"7.0.0-alpha1"}
[2017-12-20T10:09:13,998][INFO ][logstash.agent           ] Successfully started Logstash API endpoint {:port=>9600}
[2017-12-20T10:09:15,506][WARN ][logstash.outputs.elasticsearch] You are using a deprecated config setting "document_type" set in elasticsearch. Deprecated settings will continue to work, but are scheduled for removal from logstash in the future. Document types are being deprecated in Elasticsearch 6.0, and removed entirely in 7.0. You should avoid this feature If you have any questions about this, please visit the #logstash channel on freenode irc. {:name=>"document_type", :plugin=><LogStash::Outputs::ElasticSearch hosts=>["http://localhost:9200/"], bulk_path=>"/_xpack/monitoring/_bulk?system_id=logstash&system_api_version=2&interval=1s", manage_template=>"false", document_type=>"%{[@metadata][document_type]}", sniffing=>"false", user=>"logstash_system", password=>"qwertyuiopasdfghjkl", id=>"1f92ba00671eb6e012407198599517f0dd3c553df0d500c0348f1ee42f2764c8">}
[2017-12-20T10:09:16,298][INFO ][logstash.outputs.elasticsearch] Elasticsearch pool URLs updated {:changes=>{:removed=>[], :added=>[http://logstash_system:xxxxxx@localhost:9200/]}}
[2017-12-20T10:09:16,323][INFO ][logstash.outputs.elasticsearch] Running health check to see if an Elasticsearch connection is working {:healthcheck_url=>http://logstash_system:xxxxxx@localhost:9200/, :path=>"/"}
[2017-12-20T10:09:16,631][WARN ][logstash.outputs.elasticsearch] Restored connection to ES instance {:url=>"http://logstash_system:xxxxxx@localhost:9200/"}
[2017-12-20T10:09:16,703][INFO ][logstash.outputs.elasticsearch] ES Output version determined {:es_version=>nil}
[2017-12-20T10:09:16,708][WARN ][logstash.outputs.elasticsearch] Detected a 6.x and above cluster: the `type` event field won't be used to determine the document _type {:es_version=>7}
[2017-12-20T10:09:16,734][INFO ][logstash.outputs.elasticsearch] New Elasticsearch output {:class=>"LogStash::Outputs::ElasticSearch", :hosts=>["http://localhost:9200/"]}
[2017-12-20T10:09:16,765][INFO ][logstash.javapipeline    ] Starting pipeline {:pipeline_id=>".monitoring-logstash", "pipeline.workers"=>1, "pipeline.batch.size"=>2, "pipeline.batch.delay"=>5, "pipeline.max_inflight"=>2, :thread=>"#<Thread:0xe1a3da9 run>"}
[2017-12-20T10:09:17,095][INFO ][logstash.licensechecker.licensereader] Elasticsearch pool URLs updated {:changes=>{:removed=>[], :added=>[http://logstash_system:xxxxxx@localhost:9200/]}}
[2017-12-20T10:09:17,098][INFO ][logstash.licensechecker.licensereader] Running health check to see if an Elasticsearch connection is working {:healthcheck_url=>http://logstash_system:xxxxxx@localhost:9200/, :path=>"/"}
[2017-12-20T10:09:17,106][WARN ][logstash.licensechecker.licensereader] Restored connection to ES instance {:url=>"http://logstash_system:xxxxxx@localhost:9200/"}
[2017-12-20T10:09:17,112][INFO ][logstash.licensechecker.licensereader] ES Output version determined {:es_version=>nil}
[2017-12-20T10:09:17,113][WARN ][logstash.licensechecker.licensereader] Detected a 6.x and above cluster: the `type` event field won't be used to determine the document _type {:es_version=>7}
[2017-12-20T10:09:17,280][INFO ][logstash.javapipeline    ] Pipeline started {"pipeline.id"=>".monitoring-logstash"}
[2017-12-20T10:09:17,563][INFO ][logstash.javapipeline    ] Starting pipeline {:pipeline_id=>"notmain", "pipeline.workers"=>8, "pipeline.batch.size"=>125, "pipeline.batch.delay"=>5, "pipeline.max_inflight"=>1000, :thread=>"#<Thread:0xf5f235a run>"}
[2017-12-20T10:09:17,617][INFO ][logstash.javapipeline    ] Pipeline started {"pipeline.id"=>"notmain"}
The stdin plugin is now waiting for input:
[2017-12-20T10:09:17,710][INFO ][logstash.agent           ] Pipelines running {:count=>2, :pipelines=>[".monitoring-logstash", "notmain"]}
[2017-12-20T10:09:17,736][INFO ][logstash.inputs.metrics  ] Monitoring License OK
```

#### Not overriding the `pipeline.id` from the CLI defaults it to `main`, as before
```
./bin/logstash -e 'input { stdin {} } output { stdout {} }'
Sending Logstash's logs to /Users/shaunak/development/github/ycombinator/logstash/logs which is now configured via log4j2.properties
[2017-12-20T10:15:52,559][INFO ][logstash.modules.scaffold] Initializing module {:module_name=>"netflow", :directory=>"/Users/shaunak/development/github/ycombinator/logstash/modules/netflow/configuration"}
[2017-12-20T10:15:52,575][INFO ][logstash.modules.scaffold] Initializing module {:module_name=>"fb_apache", :directory=>"/Users/shaunak/development/github/ycombinator/logstash/modules/fb_apache/configuration"}
[2017-12-20T10:15:53,533][INFO ][logstash.modules.scaffold] Initializing module {:module_name=>"arcsight", :directory=>"/Users/shaunak/development/github/ycombinator/logstash/vendor/bundle/jruby/2.3.0/gems/x-pack-7.0.0.alpha1.SNAPSHOT-java/modules/arcsight/configuration"}
[2017-12-20T10:15:53,792][WARN ][logstash.config.source.multilocal] Ignoring the 'pipelines.yml' file because modules or command line options are specified
[2017-12-20T10:15:54,590][INFO ][logstash.runner          ] Starting Logstash {"logstash.version"=>"7.0.0-alpha1"}
[2017-12-20T10:15:54,897][INFO ][logstash.agent           ] Successfully started Logstash API endpoint {:port=>9600}
[2017-12-20T10:15:56,035][WARN ][logstash.outputs.elasticsearch] You are using a deprecated config setting "document_type" set in elasticsearch. Deprecated settings will continue to work, but are scheduled for removal from logstash in the future. Document types are being deprecated in Elasticsearch 6.0, and removed entirely in 7.0. You should avoid this feature If you have any questions about this, please visit the #logstash channel on freenode irc. {:name=>"document_type", :plugin=><LogStash::Outputs::ElasticSearch hosts=>["http://localhost:9200/"], bulk_path=>"/_xpack/monitoring/_bulk?system_id=logstash&system_api_version=2&interval=1s", manage_template=>"false", document_type=>"%{[@metadata][document_type]}", sniffing=>"false", user=>"logstash_system", password=>"qwertyuiopasdfghjkl", id=>"1f92ba00671eb6e012407198599517f0dd3c553df0d500c0348f1ee42f2764c8">}
[2017-12-20T10:15:56,621][INFO ][logstash.outputs.elasticsearch] Elasticsearch pool URLs updated {:changes=>{:removed=>[], :added=>[http://logstash_system:xxxxxx@localhost:9200/]}}
[2017-12-20T10:15:56,643][INFO ][logstash.outputs.elasticsearch] Running health check to see if an Elasticsearch connection is working {:healthcheck_url=>http://logstash_system:xxxxxx@localhost:9200/, :path=>"/"}
[2017-12-20T10:15:56,876][WARN ][logstash.outputs.elasticsearch] Restored connection to ES instance {:url=>"http://logstash_system:xxxxxx@localhost:9200/"}
[2017-12-20T10:15:56,929][INFO ][logstash.outputs.elasticsearch] ES Output version determined {:es_version=>nil}
[2017-12-20T10:15:56,932][WARN ][logstash.outputs.elasticsearch] Detected a 6.x and above cluster: the `type` event field won't be used to determine the document _type {:es_version=>7}
[2017-12-20T10:15:56,958][INFO ][logstash.outputs.elasticsearch] New Elasticsearch output {:class=>"LogStash::Outputs::ElasticSearch", :hosts=>["http://localhost:9200/"]}
[2017-12-20T10:15:56,980][INFO ][logstash.javapipeline    ] Starting pipeline {:pipeline_id=>".monitoring-logstash", "pipeline.workers"=>1, "pipeline.batch.size"=>2, "pipeline.batch.delay"=>5, "pipeline.max_inflight"=>2, :thread=>"#<Thread:0x1c1aab11 run>"}
[2017-12-20T10:15:57,300][INFO ][logstash.licensechecker.licensereader] Elasticsearch pool URLs updated {:changes=>{:removed=>[], :added=>[http://logstash_system:xxxxxx@localhost:9200/]}}
[2017-12-20T10:15:57,301][INFO ][logstash.licensechecker.licensereader] Running health check to see if an Elasticsearch connection is working {:healthcheck_url=>http://logstash_system:xxxxxx@localhost:9200/, :path=>"/"}
[2017-12-20T10:15:57,310][WARN ][logstash.licensechecker.licensereader] Restored connection to ES instance {:url=>"http://logstash_system:xxxxxx@localhost:9200/"}
[2017-12-20T10:15:57,315][INFO ][logstash.licensechecker.licensereader] ES Output version determined {:es_version=>nil}
[2017-12-20T10:15:57,315][WARN ][logstash.licensechecker.licensereader] Detected a 6.x and above cluster: the `type` event field won't be used to determine the document _type {:es_version=>7}
[2017-12-20T10:15:57,415][INFO ][logstash.javapipeline    ] Pipeline started {"pipeline.id"=>".monitoring-logstash"}
[2017-12-20T10:15:57,690][INFO ][logstash.javapipeline    ] Starting pipeline {:pipeline_id=>"main", "pipeline.workers"=>8, "pipeline.batch.size"=>125, "pipeline.batch.delay"=>5, "pipeline.max_inflight"=>1000, :thread=>"#<Thread:0x3304f26a run>"}
[2017-12-20T10:15:57,731][INFO ][logstash.javapipeline    ] Pipeline started {"pipeline.id"=>"main"}
The stdin plugin is now waiting for input:
[2017-12-20T10:15:57,786][INFO ][logstash.agent           ] Pipelines running {:count=>2, :pipelines=>[".monitoring-logstash", "main"]}
[2017-12-20T10:15:57,800][INFO ][logstash.inputs.metrics  ] Monitoring License OK
```

#### CLI usage text shows `--pipeline.id` option
```
$ ./bin/logstash -h | grep -C3 'pipeline.id'
    --cloud.auth CLOUD_AUTH       Sets the elasticsearch and kibana username and password
                                  for module connections in Elastic Cloud
                                  e.g. 'username:<password>'
    --pipeline.id ID              Sets the ID of the pipeline.
                                   (default: "main")
    -w, --pipeline.workers COUNT  Sets the number of pipeline workers to run.
                                   (default: 8)
```
