### PR TITLE
Replace command 'which' with 'command -v' for compatibility

### DIFF
--- a/bin/logstash
+++ b/bin/logstash
@@ -20,7 +20,7 @@ unset CDPATH
 if [ -L "$0" ]; then
   # Launched from a symlink
   # --Test for the readlink binary
-  RL="$(which readlink)"
+  RL="$(command -v readlink)"
   if [ $? -eq 0 ]; then
     # readlink exists
     SOURCEPATH="$(${RL} $0)"

--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -4,7 +4,7 @@ unset CDPATH
 if [ -L "$0" ]; then
   # Launched from a symlink
   # --Test for the readlink binary
-  RL="$(which readlink)"
+  RL="$(command -v readlink)"
   if [ $? -eq 0 ]; then
     # readlink exists
     SOURCEPATH="$($RL $0)"
@@ -58,7 +58,7 @@ setup_java() {
     JAVACMD="$JAVA_HOME/bin/java"
   else
     set +e
-    JAVACMD=`which java`
+    JAVACMD=`command -v java`
     set -e
   fi
 


### PR DESCRIPTION
I think we should not check if a command exists which another command, in here 'which'.
Instead we should use a build-in method, in order that script still works in some environments
that, such as a basic docker image, do not have a "which" command.