### PR TITLE
 #8883 Fix concurrent modification issue on RubyArray in mock output

### DIFF
--- a/logstash-core/spec/support/mocks_classes.rb
+++ b/logstash-core/spec/support/mocks_classes.rb
@@ -39,13 +39,17 @@ module LogStash
         super
         @num_closes = 0
         @events = []
+        @mutex = Mutex.new
       end
 
       def register
       end
 
       def receive(event)
+        @mutex.lock
         @events << event
+      ensure
+          @mutex.unlock
       end
 
       def close


### PR DESCRIPTION
Fixes #8883 

* Obvious problem here, the test runs multiple worker threads, concurrent pushes to a simple `RubyArray` will potentially drop events since it's not thread safe
  * Fixed by locking around the `RubyArray` instead of using some thread safe data structure to not alter behaviour more than I have to since we're using code in quite a few specs