### PR TITLE
add custom clamp appender to fix path.plugin

### DIFF
--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -24,6 +24,8 @@ module LogStash
     Setting::NullableString.new("config.string", nil, false),
            Setting::Modules.new("modules.cli", LogStash::Util::ModulesSettingArray, []),
            Setting::Modules.new("modules", LogStash::Util::ModulesSettingArray, []),
+                    Setting.new("modules_list", Array, []),
+                    Setting.new("modules_variable_list", Array, []),
            Setting::Modules.new("cloud.id", LogStash::Util::CloudSettingId),
            Setting::Modules.new("cloud.auth",LogStash::Util::CloudSettingAuth),
            Setting::Boolean.new("modules_setup", false),

--- a/logstash-core/lib/logstash/patches/clamp.rb
+++ b/logstash-core/lib/logstash/patches/clamp.rb
@@ -48,6 +48,12 @@ module Clamp
         end
       end
 
+      def define_appender_for(option)
+        define_method(option.append_method) do |value|
+          LogStash::SETTINGS.get_value(option.attribute_name) << value
+        end
+      end
+
       def define_deprecated_accessors_for(option, opts, &block)
         define_deprecated_writer_for(option, opts, &block)
       end

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -276,7 +276,7 @@ class LogStash::Runner < Clamp::StrictCommand
 
     return start_shell(setting("interactive"), binding) if setting("interactive")
 
-    module_parser = LogStash::Modules::CLIParser.new(@modules_list, @modules_variable_list)
+    module_parser = LogStash::Modules::CLIParser.new(setting("modules_list"), setting("modules_variable_list"))
     # Now populate Setting for modules.list with our parsed array.
     @settings.set("modules.cli", module_parser.output)
 

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -42,6 +42,10 @@ describe LogStash::Runner do
     allow(agent).to receive(:shutdown)
   end
 
+  after(:each) do
+    LogStash::SETTINGS.get_value("modules_list").clear
+  end
+
   describe "argument precedence" do
     let(:config) { "input {} output {}" }
     let(:cli_args) { ["-e", config, "-w", "20"] }
@@ -82,23 +86,27 @@ describe LogStash::Runner do
 
   context "--pluginpath" do
     subject { LogStash::Runner.new("") }
-    let(:single_path) { "/some/path" }
-    let(:multiple_paths) { ["/some/path1", "/some/path2"] }
+    let(:valid_directory) { Stud::Temporary.directory }
+    let(:invalid_directory) { "/a/path/that/doesnt/exist" }
+    let(:multiple_paths) { [Stud::Temporary.directory, Stud::Temporary.directory] }
+
+    it "should pass -p contents to the configure_plugin_paths method" do
+      args = ["-p", valid_directory]
+      expect(subject).to receive(:configure_plugin_paths).with([valid_directory])
+      expect { subject.run(args) }.to_not raise_error
+    end
 
     it "should add single valid dir path to the environment" do
-      expect(File).to receive(:directory?).and_return(true)
-      expect(LogStash::Environment).to receive(:add_plugin_path).with(single_path)
-      subject.configure_plugin_paths(single_path)
+      expect(LogStash::Environment).to receive(:add_plugin_path).with(valid_directory)
+      subject.configure_plugin_paths(valid_directory)
     end
 
     it "should fail with single invalid dir path" do
-      expect(File).to receive(:directory?).and_return(false)
       expect(LogStash::Environment).not_to receive(:add_plugin_path)
-      expect{subject.configure_plugin_paths(single_path)}.to raise_error(Clamp::UsageError)
+      expect{subject.configure_plugin_paths(invalid_directory)}.to raise_error(Clamp::UsageError)
     end
 
     it "should add multiple valid dir path to the environment" do
-      expect(File).to receive(:directory?).exactly(multiple_paths.size).times.and_return(true)
       multiple_paths.each{|path| expect(LogStash::Environment).to receive(:add_plugin_path).with(path)}
       subject.configure_plugin_paths(multiple_paths)
     end


### PR DESCRIPTION
the path.plugin setting is a multi valued option, clamp uses
an implicit appender method for adding values to an array.
because we patch Clamp to use LogStash::SETTINGS underneath,
we must tune both reading/writing and appending values.
This last wasn't being customized, so this path redefines the
append_method method to add an element to a setting's value

fixes #8799 