### PR TITLE
 #8888 Fix RubyTimestamp clone method

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
@@ -117,6 +117,16 @@ public final class JrubyTimestampExtLibrary {
             return JavaUtil.convertJavaToUsableRubyObject(context.runtime, this.timestamp);
         }
 
+        @JRubyMethod(name = "clone")
+        public IRubyObject ruby_clone(ThreadContext context) {
+            return RubyTimestamp.newRubyTimestamp(context.runtime, this.timestamp);
+        }
+
+        @JRubyMethod(name = "dup")
+        public IRubyObject ruby_dup(ThreadContext context) {
+            return ruby_clone(context);
+        }
+
         @JRubyMethod(name = "to_json", rest = true)
         public IRubyObject ruby_to_json(ThreadContext context, IRubyObject[] args)
         {

--- a/logstash-core/src/test/java/org/logstash/ext/TimestampTest.java
+++ b/logstash-core/src/test/java/org/logstash/ext/TimestampTest.java
@@ -1,0 +1,23 @@
+package org.logstash.ext;
+
+import org.junit.Test;
+import org.logstash.RubyUtil;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public final class TimestampTest {
+
+    @Test
+    public void testClone() {
+        assertThat(
+            RubyUtil.RUBY.executeScript("LogStash::Timestamp.now.clone.to_java", ""),
+            not(is(RubyUtil.RUBY.getNil()))
+        );
+        assertThat(
+            RubyUtil.RUBY.executeScript("LogStash::Timestamp.now.dup.to_java", ""),
+            not(is(RubyUtil.RUBY.getNil()))
+        );
+    }
+}


### PR DESCRIPTION
Fixes #8888 by properly implementing a clone method for the `RubyTimestamp` :)