### PR TITLE
Use multiple pipelines feature by default.

### DIFF
--- a/docs/static/setting-up-logstash.asciidoc
+++ b/docs/static/setting-up-logstash.asciidoc
@@ -95,8 +95,8 @@ locations for the system:
 
 | conf
   | Logstash pipeline configuration files
-  | `/etc/logstash/conf.d`
-  | `path.config`
+  | `/etc/logstash/conf.d/*.conf`
+  | See `/etc/logstash/pipelines.yml`
 
 | logs
   | Log files

--- a/pkg/centos/after-install.sh
+++ b/pkg/centos/after-install.sh
@@ -2,7 +2,6 @@ chown -R logstash:logstash /usr/share/logstash
 chown -R logstash /var/log/logstash
 chown logstash:logstash /var/lib/logstash
 sed -i \
-  -e 's|# path.config:|path.config: /etc/logstash/conf.d/*.conf|' \
   -e 's|# path.logs:|path.logs: /var/log/logstash|' \
   -e 's|# path.data:|path.data: /var/lib/logstash|' \
   /etc/logstash/logstash.yml

--- a/pkg/debian/after-install.sh
+++ b/pkg/debian/after-install.sh
@@ -5,7 +5,6 @@ chown -R logstash /var/log/logstash
 chown logstash:logstash /var/lib/logstash
 chmod 755 /etc/logstash
 sed -i \
-  -e 's|# path.config:|path.config: /etc/logstash/conf.d/*.conf|' \
   -e 's|# path.logs:|path.logs: /var/log/logstash|' \
   -e 's|# path.data:|path.data: /var/lib/logstash|' \
   /etc/logstash/logstash.yml

--- a/pkg/pipelines.yml
+++ b/pkg/pipelines.yml
@@ -1,0 +1,6 @@
+# This file is where you define your pipelines. You can define multiple.
+# For more information on multiple pipelines, see the documentation:
+#   https://www.elastic.co/guide/en/logstash/current/multiple-pipelines.html
+
+- pipeline.id: main
+  path.config: "/etc/logstash/conf.d/*.conf"

--- a/pkg/ubuntu/after-install.sh
+++ b/pkg/ubuntu/after-install.sh
@@ -4,7 +4,6 @@ chown -R logstash:logstash /usr/share/logstash
 chown -R logstash /var/log/logstash
 chown logstash:logstash /var/lib/logstash
 sed -i \
-  -e 's|# path.config:|path.config: /etc/logstash/conf.d/*.conf|' \
   -e 's|# path.logs:|path.logs: /var/log/logstash|' \
   -e 's|# path.data:|path.data: /var/lib/logstash|' \
   /etc/logstash/logstash.yml


### PR DESCRIPTION
Use multiple pipelines feature by default in RPM and Debian packages.

This change keeps the previous behavior but implements it using multiple
pipelines (pipelines.yml) instead of with `path.config`.

* The default pipeline name is still "main"
* Default config path is still /etc/logstash/conf.d/*.conf

Other small changes included:
* Specify fpm workdir. Otherwise rpmbuild is given an empty value for
  its temporary directory. It's unclear if this is a bug in fpm or in my
  environment, but I like the change anyway to put fpm's build activity
  in the build directory.
* DRY's up the common files going in /etc/logstash for both rpm and deb
  packages.

For #8893 