### PR TITLE
MINOR: Prevent enviornment GEM_DIR and GEM_PATH from leaking into build

### DIFF
--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -115,6 +115,8 @@ setup_vendored_jruby() {
     echo "If you are a developer, please run 'rake bootstrap'. Running 'rake' requires the 'ruby' program be available."
     exit 1
   fi
+  export GEM_HOME="${LOGSTASH_HOME}/vendor/bundle/jruby/2.3.0"
+  export GEM_PATH=${GEM_HOME}
 }
 
 setup() {

--- a/rakelib/z_rubycheck.rake
+++ b/rakelib/z_rubycheck.rake
@@ -4,7 +4,7 @@ if ENV['USE_RUBY'] != '1'
 
     # Make sure we have JRuby, then rerun ourselves under jruby.
     Rake::Task["vendor:jruby"].invoke
-    jruby = File.join("vendor", "jruby", "bin", "jruby")
+    jruby = File.join("bin", "ruby")
     rake = File.join("vendor", "jruby", "bin", "rake")
 
     # if required at this point system gems can be installed using the system_gem task, for example:


### PR DESCRIPTION
This fixes environment `GEM_PATH` and `GEM_DIR` leaking into the build during integration tests if you have `rvm` or `rbenv` installed:

* both load their environment via login shell hooks
* ITs + rake tasks call `system(...)` in some spots => leaks in environment (mostly not an issue since our `.rb` scripts fix these paths manually, but at least for the plugin manager I see it using the gems from my local `.rvm` dir which at times caused build issues that were hard to fix without removing rvm from my `.profile`)
* Simply manually setting the correct path when we bootstrap the rest of the JRuby env anyways like done here fixes all of these issues just fine for me :)

