### PR TITLE
MINOR: Cleanup dead code left over from Graph hashing fixes

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/Graph.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/Graph.java
@@ -1,5 +1,14 @@
 package org.logstash.config.ir.graph;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.logstash.common.Util;
 import org.logstash.config.ir.Hashable;
 import org.logstash.config.ir.SourceComponent;
@@ -9,8 +18,6 @@ import org.logstash.config.ir.graph.algorithms.BreadthFirst;
 import org.logstash.config.ir.graph.algorithms.GraphDiff;
 import org.logstash.config.ir.graph.algorithms.TopologicalSort;
 
-import java.security.MessageDigest;
-import java.util.*;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/Vertex.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/Vertex.java
@@ -1,20 +1,16 @@
 package org.logstash.config.ir.graph;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
-
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.logstash.common.SourceWithMetadata;
 import org.logstash.common.Util;
 import org.logstash.config.ir.HashableWithSource;
-import org.logstash.config.ir.SourceComponent;
 import org.logstash.config.ir.InvalidIRException;
+import org.logstash.config.ir.SourceComponent;
 import org.logstash.config.ir.graph.algorithms.DepthFirst;
-
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Created by andrewvc on 9/15/16.
@@ -31,9 +27,7 @@ public abstract class Vertex implements SourceComponent, HashableWithSource {
 
     private Graph graph;
 
-    private volatile String contextualHashCache;
     private volatile String hashCache;
-    private volatile String individualHashSourceCache;
     private volatile String generatedId;
 
     protected Vertex(SourceWithMetadata meta) {
@@ -219,8 +213,6 @@ public abstract class Vertex implements SourceComponent, HashableWithSource {
 
     public void clearCache() {
         this.hashCache = null;
-        this.contextualHashCache = null;
-        this.individualHashSourceCache = null;
     }
 
     @Override

--- a/logstash-core/src/test/java/org/logstash/config/ir/IRHelpers.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/IRHelpers.java
@@ -1,5 +1,10 @@
 package org.logstash.config.ir;
 
+import java.util.HashMap;
+import java.util.Objects;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.Callable;
 import org.hamcrest.MatcherAssert;
 import org.logstash.common.IncompleteSourceWithMetadataException;
 import org.logstash.common.SourceWithMetadata;
@@ -10,18 +15,17 @@ import org.logstash.config.ir.graph.Edge;
 import org.logstash.config.ir.graph.Graph;
 import org.logstash.config.ir.graph.Vertex;
 import org.logstash.config.ir.graph.algorithms.GraphDiff;
-import org.logstash.config.ir.imperative.Statement;
 
-import javax.xml.transform.Source;
-import java.util.HashMap;
-import java.util.Objects;
-import java.util.Random;
-import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.stream.IntStream;
-
-import static org.logstash.config.ir.DSL.*;
-import static org.logstash.config.ir.PluginDefinition.Type.*;
+import static org.logstash.config.ir.DSL.eEq;
+import static org.logstash.config.ir.DSL.eEventValue;
+import static org.logstash.config.ir.DSL.eGt;
+import static org.logstash.config.ir.DSL.eValue;
+import static org.logstash.config.ir.DSL.iComposeParallel;
+import static org.logstash.config.ir.DSL.iIf;
+import static org.logstash.config.ir.DSL.iPlugin;
+import static org.logstash.config.ir.PluginDefinition.Type.FILTER;
+import static org.logstash.config.ir.PluginDefinition.Type.INPUT;
+import static org.logstash.config.ir.PluginDefinition.Type.OUTPUT;
 
 /**
  * Created by andrewvc on 9/19/16.
@@ -86,10 +90,6 @@ public class IRHelpers {
         Vertex v2 = createTestVertex();
         return new TestEdge(v1,v2);
 
-    }
-
-    public static Edge createTestEdge(Vertex from, Vertex to) throws InvalidIRException {
-        return new TestEdge(from, to);
     }
 
     public static final class TestEdge extends Edge {

--- a/logstash-core/src/test/java/org/logstash/config/ir/graph/GraphTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/graph/GraphTest.java
@@ -1,20 +1,18 @@
 package org.logstash.config.ir.graph;
 
-import org.junit.Test;
-import org.logstash.common.SourceWithMetadata;
-import org.logstash.config.ir.DSL;
-import org.logstash.config.ir.IRHelpers;
-import org.logstash.config.ir.InvalidIRException;
-import org.logstash.config.ir.PluginDefinition;
-import org.logstash.config.ir.imperative.IfStatement;
-
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Random;
+import org.junit.Test;
+import org.logstash.common.SourceWithMetadata;
+import org.logstash.config.ir.IRHelpers;
+import org.logstash.config.ir.InvalidIRException;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.logstash.config.ir.IRHelpers.createTestExpression;
 import static org.logstash.config.ir.IRHelpers.createTestVertex;
 import static org.logstash.config.ir.IRHelpers.randMeta;
@@ -26,8 +24,8 @@ public class GraphTest {
     @Test
     public void testGraphBasics() throws InvalidIRException {
         Graph g = Graph.empty();
-        Vertex v1 = IRHelpers.createTestVertex();
-        Vertex v2 = IRHelpers.createTestVertex();
+        Vertex v1 = createTestVertex();
+        Vertex v2 = createTestVertex();
         g.chainVertices(v1, v2);
         Edge e = v1.outgoingEdges().findFirst().get();
         assertEquals("Connects vertex edges correctly", v1.getOutgoingEdges(), v2.getIncomingEdges());
@@ -37,11 +35,11 @@ public class GraphTest {
     }
 
     // Expect an Invalid IR Exception from the cycle
-    @Test(expected = org.logstash.config.ir.InvalidIRException.class)
+    @Test(expected = InvalidIRException.class)
     public void testGraphCycleDetection() throws InvalidIRException {
         Graph g = Graph.empty();
-        Vertex v1 = IRHelpers.createTestVertex();
-        Vertex v2 = IRHelpers.createTestVertex();
+        Vertex v1 = createTestVertex();
+        Vertex v2 = createTestVertex();
         g.chainVertices(v1, v2);
         g.chainVertices(v2, v1);
     }
@@ -98,8 +96,8 @@ public class GraphTest {
     @Test
     public void testThreading() throws InvalidIRException {
         Graph graph = Graph.empty();
-        Vertex v1 = IRHelpers.createTestVertex();
-        Vertex v2 = IRHelpers.createTestVertex();
+        Vertex v1 = createTestVertex();
+        Vertex v2 = createTestVertex();
         graph.chainVertices(v1, v2);
         assertVerticesConnected(v1, v2);
         Edge v1Edge = v1.outgoingEdges().findFirst().get();
@@ -111,9 +109,9 @@ public class GraphTest {
     @Test
     public void testThreadingMulti() throws InvalidIRException {
         Graph graph = Graph.empty();
-        Vertex v1 = IRHelpers.createTestVertex();
-        Vertex v2 = IRHelpers.createTestVertex();
-        Vertex v3 = IRHelpers.createTestVertex();
+        Vertex v1 = createTestVertex();
+        Vertex v2 = createTestVertex();
+        Vertex v3 = createTestVertex();
         Collection<Edge> multiEdges = graph.chainVertices(v1, v2, v3);
 
         assertThat(v1.getOutgoingVertices(), is(Collections.singletonList(v2)));
@@ -126,7 +124,7 @@ public class GraphTest {
     public void testThreadingTyped() throws InvalidIRException {
         Graph graph = Graph.empty();
         Vertex if1 = new IfVertex(randMeta(), createTestExpression());
-        Vertex condT = IRHelpers.createTestVertex();
+        Vertex condT = createTestVertex();
         Edge tEdge = graph.chainVertices(BooleanEdge.trueFactory, if1, condT).stream().findFirst().get();
         assertThat(tEdge, instanceOf(BooleanEdge.class));
         BooleanEdge tBooleanEdge = (BooleanEdge) tEdge;


### PR DESCRIPTION
Just some trivial static cleanups, removing dead code/imports/qualifiers left over after recent fixes to this codebase. 