### PR TITLE
MINOR: Fix Ruby path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,8 +137,12 @@ task downloadAndInstallJRuby(dependsOn: verifyFile, type: Copy) {
     into "${projectDir}/vendor/jruby"
 }
 
-def jrubyBin = "${projectDir}/vendor/jruby/bin/jruby" +
-  (System.getProperty("os.name").startsWith("Windows") ? '.bat' : '')
+def isWindows = System.getProperty("os.name").startsWith("Windows")
+// The default environment loaded by bin/ruby segfaults on CI for unknown reasons. For now we work
+// around this fact by directly invoking the jruby binary on CI.
+def jrubyBin = System.getenv('CI') || isWindows ?
+  ("${projectDir}/vendor/jruby/bin/jruby" + (isWindows ? '.bat' : ''))
+  : "${projectDir}/bin/ruby"
 
 def rakeBin = "${projectDir}/vendor/jruby/bin/rake"
 


### PR DESCRIPTION
Follow up for #8896. Unfortunately we only  fixed the `Ruby` entry point case there. The Gradle case needs the same fix using `bin/ruby` instead of the `vendor/jruby` path.

@jsvd can you take a look please since you understand this one already :)?