### PR TITLE
Remove pipeline.output.workers from  logstash.yml

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -40,10 +40,6 @@
 #
 # pipeline.workers: 2
 #
-# How many workers should be used per output plugin instance
-#
-# pipeline.output.workers: 1
-#
 # How many events to retrieve from inputs before sending to filters+workers
 #
 # pipeline.batch.size: 125


### PR DESCRIPTION
Closes https://github.com/elastic/logstash/issues/7884.

Note that https://github.com/elastic/logstash/pull/8562 removes the setting from the docs.