### PR TITLE
MINOR: Move test specific ruby classloading hack to test code

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/ConfigCompiler.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/ConfigCompiler.java
@@ -1,11 +1,7 @@
 package org.logstash.config.ir;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import org.jruby.RubyHash;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.runtime.load.LoadService;
 import org.logstash.RubyUtil;
 import org.logstash.common.IncompleteSourceWithMetadataException;
 import org.logstash.common.SourceWithMetadata;
@@ -28,7 +24,6 @@ public final class ConfigCompiler {
      */
     public static PipelineIR configToPipelineIR(final String config, final boolean supportEscapes)
         throws IncompleteSourceWithMetadataException {
-        ensureLoadpath();
         final IRubyObject compiler = RubyUtil.RUBY.executeScript(
             "require 'logstash/compiler'\nLogStash::Compiler",
             ""
@@ -46,24 +41,5 @@ public final class ConfigCompiler {
                 }
             );
         return (PipelineIR) code.toJava(PipelineIR.class);
-    }
-
-    /**
-     * Loads the logstash-core/lib path if the load service can't find {@code logstash/compiler}.
-     */
-    private static void ensureLoadpath() {
-        final LoadService loader = RubyUtil.RUBY.getLoadService();
-        if (loader.findFileForLoad("logstash/compiler").library == null) {
-            final RubyHash environment = RubyUtil.RUBY.getENV();
-            final Path root = Paths.get(
-                System.getProperty("logstash.core.root.dir", "")
-            ).toAbsolutePath();
-            final String gems = root.getParent().resolve("vendor").resolve("bundle")
-                .resolve("jruby").resolve("2.3.0").toFile().getAbsolutePath();
-            environment.put("GEM_HOME", gems);
-            environment.put("GEM_PATH", gems);
-            loader.addPaths(root.resolve("lib").toFile().getAbsolutePath()
-            );
-        }
     }
 }

--- a/logstash-core/src/test/java/org/logstash/config/ir/ConfigCompilerTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/ConfigCompilerTest.java
@@ -2,7 +2,13 @@ package org.logstash.config.ir;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.jruby.RubyHash;
+import org.jruby.runtime.load.LoadService;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.logstash.RubyUtil;
 import org.logstash.common.IncompleteSourceWithMetadataException;
 import org.logstash.config.ir.graph.Graph;
 
@@ -10,6 +16,11 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ConfigCompilerTest {
+
+    @BeforeClass
+    public static void before() {
+        ensureLoadpath();
+    }
 
     @Test
     public void testConfigToPipelineIR() throws Exception {
@@ -63,5 +74,25 @@ public class ConfigCompilerTest {
     private static String graphHash(final String config)
         throws IncompleteSourceWithMetadataException {
         return ConfigCompiler.configToPipelineIR(config, false).uniqueHash();
+    }
+
+    /**
+     * Loads the logstash-core/lib path if the load service can't find {@code logstash/compiler}
+     * because {@code environment.rb} hasn't been loaded yet.
+     */
+    private static void ensureLoadpath() {
+        final LoadService loader = RubyUtil.RUBY.getLoadService();
+        if (loader.findFileForLoad("logstash/compiler").library == null) {
+            final RubyHash environment = RubyUtil.RUBY.getENV();
+            final Path root = Paths.get(
+                System.getProperty("logstash.core.root.dir", "")
+            ).toAbsolutePath();
+            final String gems = root.getParent().resolve("vendor").resolve("bundle")
+                .resolve("jruby").resolve("2.3.0").toFile().getAbsolutePath();
+            environment.put("GEM_HOME", gems);
+            environment.put("GEM_PATH", gems);
+            loader.addPaths(root.resolve("lib").toFile().getAbsolutePath()
+            );
+        }
     }
 }


### PR DESCRIPTION
This hacky code manually forcing the correct `GEM_PATH` and `GEM_DIR` for the config compiler Java wrapper is only used in tests (in production code `environment.rb` loads before the config compiler wrapper is ever touched and sets all of this up correctly). 

=> this hack should be in the tests codebase :)