### PR TITLE
MINOR: Remove pointless method from CompiledPipeline

### DIFF
--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -330,7 +330,10 @@ module LogStash; class JavaPipeline < JavaBasePipeline
   # @param plugins [Array[Plugin]] the list of plugins to register
   def register_plugins(plugins)
     registered = []
-    plugins.each { |plugin| registered << @lir_execution.registerPlugin(plugin) }
+    plugins.each do |plugin|
+      plugin.register
+      registered << plugin
+    end
   rescue => e
     registered.each(&:do_close)
     raise e

--- a/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
@@ -79,11 +79,6 @@ public final class CompiledPipeline {
         return inputs;
     }
 
-    public RubyIntegration.Plugin registerPlugin(final RubyIntegration.Plugin plugin) {
-        plugin.register();
-        return plugin;
-    }
-
     /**
      * This method contains the actual compilation of the {@link Dataset} representing the
      * underlying pipeline from the Queue to the outputs.


### PR DESCRIPTION
The Java method here obviously makes no sense. I think I had different plans here initially but with what we have no this is just dead code :)