### PR TITLE
[WIP] fix gradle jruby build env

### DIFF
--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -152,12 +152,9 @@ setup_vendored_jruby() {
   fi
 }
 
-# the setup of java opts can be skipped using SKIP_SETUP_JAVA_OPTS
 setup() {
   setup_java
-  if [ -z "$SKIP_SETUP_JAVA_OPTS" ] ; then
-    setup_java_opts
-  fi
+  setup_java_opts
   setup_vendored_jruby
 }
 

--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -118,6 +118,7 @@ setup_java() {
   export JAVA_OPTS
 }
 
+# custom GEM_HOME and GEM_PATH can be injected using LS_GEM_HOME and LS_GEM_PATH
 setup_vendored_jruby() {
   if [ "$DEBUG" ] ; then
     echo "Setting up vendored JRuby"
@@ -134,33 +135,26 @@ setup_vendored_jruby() {
 
   if [ -z "$LS_GEM_HOME" ] ; then
     export GEM_HOME="${LOGSTASH_HOME}/vendor/bundle/jruby/2.3.0"
-    if [ "$DEBUG" ] ; then
-      echo "Using GEM_HOME=${GEM_HOME}"
-    fi
   else
     export GEM_HOME=${LS_GEM_HOME}
-    if [ "$DEBUG" ] ; then
-      echo "Using LS_GEM_HOME=${LS_GEM_HOME}"
-    fi
+  fi
+  if [ "$DEBUG" ] ; then
+    echo "Using GEM_HOME=${GEM_HOME}"
   fi
 
   if [ -z "$LS_GEM_PATH" ] ; then
     export GEM_PATH=${GEM_HOME}
-    if [ "$DEBUG" ] ; then
-      echo "Using GEM_PATH=${GEM_PATH}"
-    fi
   else
     export GEM_PATH=${LS_GEM_PATH}
-    if [ "$DEBUG" ] ; then
-      echo "Using LS_GEM_PATH=${LS_GEM_PATH}"
-    fi
+  fi
+  if [ "$DEBUG" ] ; then
+    echo "Using GEM_PATH=${GEM_PATH}"
   fi
 }
 
+# the setup of java opts can be skipped using SKIP_SETUP_JAVA_OPTS
 setup() {
-  if [ -z "$SKIP_SETUP_JAVA" ] ; then
-    setup_java
-  fi
+  setup_java
   if [ -z "$SKIP_SETUP_JAVA_OPTS" ] ; then
     setup_java_opts
   fi

--- a/build.gradle
+++ b/build.gradle
@@ -233,7 +233,7 @@ task runIntegrationTests(dependsOn: installIntegrationTestGems, type: Exec) {
   workingDir "${projectDir}/qa/integration"
   environment "LS_GEM_PATH", qaBundledGemPath
   environment "LS_GEM_HOME", qaBundledGemPath
-  //environment "SKIP_SETUP_JAVA_OPTS", "1"
+  environment "SKIP_SETUP_JAVA_OPTS", "1"
   // FEATURE_FLAG is set in the CI to configure testing with enabled PQ
   environment "FEATURE_FLAG", System.getenv('FEATURE_FLAG')
   standardOutput = new ExecLogOutputStream(System.out)

--- a/build.gradle
+++ b/build.gradle
@@ -236,7 +236,7 @@ task runIntegrationTests(dependsOn: installIntegrationTestGems, type: Exec) {
   workingDir "${projectDir}/qa/integration"
   environment "LS_GEM_PATH", qaBundledGemPath
   environment "LS_GEM_HOME", qaBundledGemPath
-  environment "SKIP_SETUP_JAVA_OPTS", "1"
+//  environment "SKIP_SETUP_JAVA_OPTS", "1"
   // FEATURE_FLAG is set in the CI to configure testing with enabled PQ
   environment "FEATURE_FLAG", System.getenv('FEATURE_FLAG')
   standardOutput = new ExecLogOutputStream(System.out)

--- a/build.gradle
+++ b/build.gradle
@@ -211,16 +211,16 @@ task installIntegrationTestBundler(dependsOn: unpackTarDistribution, type: Exec)
 
 task installIntegrationTestGems(dependsOn: installIntegrationTestBundler, type: Exec) {
   workingDir "${projectDir}/qa/integration"
-  environment "LS_GEM_PATH", qaGemPath
-  environment "LS_GEM_HOME", qaGemPath
-  environment "SKIP_SETUP_JAVA_OPTS", "1"
   inputs.files file("${projectDir}/qa/integration/Gemfile")
+  inputs.files file("${projectDir}/qa/integration/integration_tests.gemspec")
   inputs.files file("${logstashBuildDir}/Gemfile")
   inputs.files file("${logstashBuildDir}/Gemfile.lock")
   inputs.files file("${logstashBuildDir}/logstash-core/logstash-core.gemspec")
-  inputs.files file("${projectDir}/qa/integration/integration_tests.gemspec")
   outputs.files fileTree("${qaGemPath}")
   outputs.files file("${projectDir}/qa/integration/Gemfile.lock")
+  environment "LS_GEM_PATH", qaGemPath
+  environment "LS_GEM_HOME", qaGemPath
+  environment "SKIP_SETUP_JAVA_OPTS", "1"
   standardOutput = new ExecLogOutputStream(System.out)
   errorOutput =  new ExecLogOutputStream(System.err)
   commandLine jrubyBin, "-S", qaBundleBin, "install"

--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,9 @@ clean {
   delete "${projectDir}/Gemfile.lock"
   delete "${projectDir}/vendor"
   delete "${projectDir}/NOTICE.TXT"
+  delete "${projectDir}/.bundle"
+  delete "${projectDir}/qa/integration/Gemfile.lock"
+  delete "${projectDir}/qa/integration/.bundle"
 }
 
 task bootstrap {}
@@ -230,7 +233,7 @@ task runIntegrationTests(dependsOn: installIntegrationTestGems, type: Exec) {
   workingDir "${projectDir}/qa/integration"
   environment "LS_GEM_PATH", qaBundledGemPath
   environment "LS_GEM_HOME", qaBundledGemPath
-  environment "SKIP_SETUP_JAVA_OPTS", "1"
+  //environment "SKIP_SETUP_JAVA_OPTS", "1"
   // FEATURE_FLAG is set in the CI to configure testing with enabled PQ
   environment "FEATURE_FLAG", System.getenv('FEATURE_FLAG')
   standardOutput = new ExecLogOutputStream(System.out)

--- a/build.gradle
+++ b/build.gradle
@@ -201,8 +201,8 @@ def qaBundleBin = "${buildDir}/qa/integration/vendor/bin/bundle"
 
 task installIntegrationTestBundler(dependsOn: unpackTarDistribution, type: Exec) {
   outputs.files fileTree("${qaGemPath}/gems/bundler-1.16.0")
-  environment "GEM_PATH", qaGemPath
-  environment "GEM_HOME", qaGemPath
+  environment "LS_GEM_PATH", qaGemPath
+  environment "LS_GEM_HOME", qaGemPath
   environment "SKIP_SETUP_JAVA_OPTS", "1"
   standardOutput = new ExecLogOutputStream(System.out)
   errorOutput =  new ExecLogOutputStream(System.err)

--- a/build.gradle
+++ b/build.gradle
@@ -236,7 +236,6 @@ task runIntegrationTests(dependsOn: installIntegrationTestGems, type: Exec) {
   workingDir "${projectDir}/qa/integration"
   environment "LS_GEM_PATH", qaBundledGemPath
   environment "LS_GEM_HOME", qaBundledGemPath
-//  environment "SKIP_SETUP_JAVA_OPTS", "1"
   // FEATURE_FLAG is set in the CI to configure testing with enabled PQ
   environment "FEATURE_FLAG", System.getenv('FEATURE_FLAG')
   standardOutput = new ExecLogOutputStream(System.out)

--- a/build.gradle
+++ b/build.gradle
@@ -203,6 +203,7 @@ task installIntegrationTestBundler(dependsOn: unpackTarDistribution, type: Exec)
   outputs.files fileTree("${qaGemPath}/gems/bundler-1.16.0")
   environment "GEM_PATH", qaGemPath
   environment "GEM_HOME", qaGemPath
+  environment "SKIP_SETUP_JAVA_OPTS", "1"
   standardOutput = new ExecLogOutputStream(System.out)
   errorOutput =  new ExecLogOutputStream(System.err)
   commandLine jrubyBin, "-S", "${projectDir}/vendor/jruby/bin/gem", "install", "bundler", "-v", "1.16.0"
@@ -210,8 +211,9 @@ task installIntegrationTestBundler(dependsOn: unpackTarDistribution, type: Exec)
 
 task installIntegrationTestGems(dependsOn: installIntegrationTestBundler, type: Exec) {
   workingDir "${projectDir}/qa/integration"
-  environment "GEM_PATH", qaGemPath
-  environment "GEM_HOME", qaGemPath
+  environment "LS_GEM_PATH", qaGemPath
+  environment "LS_GEM_HOME", qaGemPath
+  environment "SKIP_SETUP_JAVA_OPTS", "1"
   inputs.files file("${projectDir}/qa/integration/Gemfile")
   inputs.files file("${logstashBuildDir}/Gemfile")
   inputs.files file("${logstashBuildDir}/Gemfile.lock")
@@ -228,9 +230,9 @@ def rubyIntegrationSpecs = project.hasProperty("rubyIntegrationSpecs") ? ((Strin
 
 task runIntegrationTests(dependsOn: installIntegrationTestGems, type: Exec) {
   workingDir "${projectDir}/qa/integration"
-  environment "JAVA_OPTS", ""
-  environment "GEM_PATH", qaGemPath
-  environment "GEM_HOME", qaGemPath
+  environment "LS_GEM_PATH", qaGemPath
+  environment "LS_GEM_HOME", qaGemPath
+  environment "SKIP_SETUP_JAVA_OPTS", "1"
   // FEATURE_FLAG is set in the CI to configure testing with enabled PQ
   environment "FEATURE_FLAG", System.getenv('FEATURE_FLAG')
   standardOutput = new ExecLogOutputStream(System.out)

--- a/build.gradle
+++ b/build.gradle
@@ -146,13 +146,16 @@ task downloadAndInstallJRuby(dependsOn: verifyFile, type: Copy) {
 def jrubyBin = "${projectDir}/vendor/jruby/bin/jruby" +
   (System.getProperty("os.name").startsWith("Windows") ? '.bat' : '')
 
+def rubyBin = "${projectDir}/bin/ruby" +
+  (System.getProperty("os.name").startsWith("Windows") ? '.bat' : '')
+
 task installTestGems(dependsOn: downloadAndInstallJRuby) {
   inputs.files file("${projectDir}/Gemfile.template")
   inputs.files fileTree("${projectDir}/rakelib")
   inputs.files file("${projectDir}/versions.yml")
   outputs.files file("${projectDir}/Gemfile")
   outputs.files file("${projectDir}/Gemfile.lock")
-  outputs.files fileTree("${projectDir}/vendor/bundle/gems")
+  outputs.files fileTree("${projectDir}/vendor/bundle/jruby/2.3.0/gems")
   outputs.files fileTree("${projectDir}/vendor/jruby")
   doLast {
     rubyGradleUtils.rake('test:install-core')
@@ -238,9 +241,9 @@ task runIntegrationTests(dependsOn: installIntegrationTestGems, type: Exec) {
   environment "FEATURE_FLAG", System.getenv('FEATURE_FLAG')
   standardOutput = new ExecLogOutputStream(System.out)
   errorOutput =  new ExecLogOutputStream(System.err)
-  // indirect launching of bin/bundle via bin/jruby so that the bundle exec command inherit
+  // indirect launching of bin/bundle via bin/ruby so that the bundle exec command inherit
   // the correct gem path environment which is not settable by command line
-  commandLine([jrubyBin, qaBundleBin, "exec", "rspec"].plus((Collection<String>)rubyIntegrationSpecs))
+  commandLine([rubyBin, qaBundleBin, "exec", "rspec"].plus((Collection<String>)rubyIntegrationSpecs))
 }
 
 // If you are running a JRuby snapshot we will skip the integrity check.

--- a/build.gradle
+++ b/build.gradle
@@ -196,8 +196,8 @@ task unpackTarDistribution(dependsOn: assembleTarDistribution, type: Copy) {
   into {buildDir}
 }
 
-def bundleBin = "${projectDir}/vendor/bundle/jruby/2.3.0/bin/bundle"
 def qaGemPath = "${buildDir}/qa/integration/vendor"
+def qaBundleBin = "${buildDir}/qa/integration/vendor/bin/bundle"
 
 task installIntegrationTestBundler(dependsOn: unpackTarDistribution, type: Exec) {
   outputs.files fileTree("${qaGemPath}/gems/bundler-1.16.0")
@@ -223,7 +223,7 @@ task installIntegrationTestGems(dependsOn: installIntegrationTestBundler, type: 
   outputs.files file("${projectDir}/qa/integration/Gemfile.lock")
   standardOutput = new ExecLogOutputStream(System.out)
   errorOutput =  new ExecLogOutputStream(System.err)
-  commandLine jrubyBin, "-S", bundleBin, "install"
+  commandLine jrubyBin, "-S", qaBundleBin, "install"
 }
 
 def rubyIntegrationSpecs = project.hasProperty("rubyIntegrationSpecs") ? ((String) project.property("rubyIntegrationSpecs")).split(/\s+/) : []
@@ -237,7 +237,7 @@ task runIntegrationTests(dependsOn: installIntegrationTestGems, type: Exec) {
   environment "FEATURE_FLAG", System.getenv('FEATURE_FLAG')
   standardOutput = new ExecLogOutputStream(System.out)
   errorOutput =  new ExecLogOutputStream(System.err)
-  commandLine([jrubyBin, "-S", bundleBin, "exec", "rspec"].plus((Collection<String>)rubyIntegrationSpecs))
+  commandLine([jrubyBin, "-S", qaBundleBin, "exec", "rspec"].plus((Collection<String>)rubyIntegrationSpecs))
 }
 
 // If you are running a JRuby snapshot we will skip the integrity check.

--- a/build.gradle
+++ b/build.gradle
@@ -197,31 +197,31 @@ task unpackTarDistribution(dependsOn: assembleTarDistribution, type: Copy) {
 }
 
 def bundleBin = "${projectDir}/vendor/bundle/jruby/2.3.0/bin/bundle"
-def gemPath = "${buildDir}/qa/integration/gems"
+def qaGemPath = "${buildDir}/qa/integration/vendor"
 
 task installIntegrationTestBundler(dependsOn: unpackTarDistribution, type: Exec) {
-  outputs.files fileTree("${gemPath}/gems/bundler-1.16.0")
-  environment "GEM_PATH", gemPath
-  environment "GEM_HOME", gemPath
+  outputs.files fileTree("${qaGemPath}/gems/bundler-1.16.0")
+  environment "GEM_PATH", qaGemPath
+  environment "GEM_HOME", qaGemPath
   standardOutput = new ExecLogOutputStream(System.out)
   errorOutput =  new ExecLogOutputStream(System.err)
-  commandLine jrubyBin, "${projectDir}/vendor/jruby/bin/gem", "install", "bundler", "-v", "1.16.0"
+  commandLine jrubyBin, "-S", "${projectDir}/vendor/jruby/bin/gem", "install", "bundler", "-v", "1.16.0"
 }
 
 task installIntegrationTestGems(dependsOn: installIntegrationTestBundler, type: Exec) {
   workingDir "${projectDir}/qa/integration"
-  environment "GEM_PATH", gemPath
-  environment "GEM_HOME", gemPath
+  environment "GEM_PATH", qaGemPath
+  environment "GEM_HOME", qaGemPath
   inputs.files file("${projectDir}/qa/integration/Gemfile")
   inputs.files file("${logstashBuildDir}/Gemfile")
   inputs.files file("${logstashBuildDir}/Gemfile.lock")
   inputs.files file("${logstashBuildDir}/logstash-core/logstash-core.gemspec")
   inputs.files file("${projectDir}/qa/integration/integration_tests.gemspec")
-  outputs.files fileTree("${gemPath}/gems")
+  outputs.files fileTree("${qaGemPath}")
   outputs.files file("${projectDir}/qa/integration/Gemfile.lock")
   standardOutput = new ExecLogOutputStream(System.out)
   errorOutput =  new ExecLogOutputStream(System.err)
-  commandLine jrubyBin, bundleBin, "install"
+  commandLine jrubyBin, "-S", bundleBin, "install"
 }
 
 def rubyIntegrationSpecs = project.hasProperty("rubyIntegrationSpecs") ? ((String) project.property("rubyIntegrationSpecs")).split(/\s+/) : []
@@ -229,13 +229,13 @@ def rubyIntegrationSpecs = project.hasProperty("rubyIntegrationSpecs") ? ((Strin
 task runIntegrationTests(dependsOn: installIntegrationTestGems, type: Exec) {
   workingDir "${projectDir}/qa/integration"
   environment "JAVA_OPTS", ""
-  environment "GEM_PATH", gemPath
-  environment "GEM_HOME", gemPath
+  environment "GEM_PATH", qaGemPath
+  environment "GEM_HOME", qaGemPath
   // FEATURE_FLAG is set in the CI to configure testing with enabled PQ
   environment "FEATURE_FLAG", System.getenv('FEATURE_FLAG')
   standardOutput = new ExecLogOutputStream(System.out)
   errorOutput =  new ExecLogOutputStream(System.err)
-  commandLine([jrubyBin, bundleBin, "exec", "rspec"].plus((Collection<String>)rubyIntegrationSpecs))
+  commandLine([jrubyBin, "-S", bundleBin, "exec", "rspec"].plus((Collection<String>)rubyIntegrationSpecs))
 }
 
 // If you are running a JRuby snapshot we will skip the integrity check.

--- a/build.gradle
+++ b/build.gradle
@@ -196,17 +196,16 @@ task unpackTarDistribution(dependsOn: assembleTarDistribution, type: Copy) {
   into {buildDir}
 }
 
-def qaGemPath = "${buildDir}/qa/integration/vendor"
-def qaBundleBin = "${buildDir}/qa/integration/vendor/bin/bundle"
+def qaVendorPath = "${buildDir}/qa/integration/vendor"
+def qaBundledGemPath = "${qaVendorPath}/jruby/2.3.0"
+def qaBundleBin = "${qaBundledGemPath}/bin/bundle"
 
 task installIntegrationTestBundler(dependsOn: unpackTarDistribution, type: Exec) {
-  outputs.files fileTree("${qaGemPath}/gems/bundler-1.16.0")
-  environment "LS_GEM_PATH", qaGemPath
-  environment "LS_GEM_HOME", qaGemPath
-  environment "SKIP_SETUP_JAVA_OPTS", "1"
+  outputs.files fileTree("${qaBundledGemPath}/gems/bundler-1.16.0")
   standardOutput = new ExecLogOutputStream(System.out)
   errorOutput =  new ExecLogOutputStream(System.err)
-  commandLine jrubyBin, "-S", "${projectDir}/vendor/jruby/bin/gem", "install", "bundler", "-v", "1.16.0"
+  // directly invoke bin/gem to install bundlers and force install dir "-i" into qaBundledGemPath
+  commandLine "${projectDir}/vendor/jruby/bin/gem", "install", "bundler", "-v", "1.16.0", "-i", qaBundledGemPath
 }
 
 task installIntegrationTestGems(dependsOn: installIntegrationTestBundler, type: Exec) {
@@ -216,27 +215,28 @@ task installIntegrationTestGems(dependsOn: installIntegrationTestBundler, type: 
   inputs.files file("${logstashBuildDir}/Gemfile")
   inputs.files file("${logstashBuildDir}/Gemfile.lock")
   inputs.files file("${logstashBuildDir}/logstash-core/logstash-core.gemspec")
-  outputs.files fileTree("${qaGemPath}")
+  outputs.files fileTree("${qaVendorPath}")
   outputs.files file("${projectDir}/qa/integration/Gemfile.lock")
-  environment "LS_GEM_PATH", qaGemPath
-  environment "LS_GEM_HOME", qaGemPath
-  environment "SKIP_SETUP_JAVA_OPTS", "1"
   standardOutput = new ExecLogOutputStream(System.out)
   errorOutput =  new ExecLogOutputStream(System.err)
-  commandLine jrubyBin, "-S", qaBundleBin, "install"
+  // directly invoke bin/bundler and force install gem path to qaVendorPath
+  // note that bundler appends jruby/2.3.0 to the install path
+  commandLine qaBundleBin, "install", "--path", qaVendorPath
 }
 
 def rubyIntegrationSpecs = project.hasProperty("rubyIntegrationSpecs") ? ((String) project.property("rubyIntegrationSpecs")).split(/\s+/) : []
 
 task runIntegrationTests(dependsOn: installIntegrationTestGems, type: Exec) {
   workingDir "${projectDir}/qa/integration"
-  environment "LS_GEM_PATH", qaGemPath
-  environment "LS_GEM_HOME", qaGemPath
+  environment "LS_GEM_PATH", qaBundledGemPath
+  environment "LS_GEM_HOME", qaBundledGemPath
   environment "SKIP_SETUP_JAVA_OPTS", "1"
   // FEATURE_FLAG is set in the CI to configure testing with enabled PQ
   environment "FEATURE_FLAG", System.getenv('FEATURE_FLAG')
   standardOutput = new ExecLogOutputStream(System.out)
   errorOutput =  new ExecLogOutputStream(System.err)
+  // indirect launching of bin/bundle via bin/jruby so that the bundle exec command inherit
+  // the correct gem path environment which is not settable by command line
   commandLine([jrubyBin, "-S", qaBundleBin, "exec", "rspec"].plus((Collection<String>)rubyIntegrationSpecs))
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -240,7 +240,7 @@ task runIntegrationTests(dependsOn: installIntegrationTestGems, type: Exec) {
   errorOutput =  new ExecLogOutputStream(System.err)
   // indirect launching of bin/bundle via bin/jruby so that the bundle exec command inherit
   // the correct gem path environment which is not settable by command line
-  commandLine([jrubyBin, "-S", qaBundleBin, "exec", "rspec"].plus((Collection<String>)rubyIntegrationSpecs))
+  commandLine([jrubyBin, qaBundleBin, "exec", "rspec"].plus((Collection<String>)rubyIntegrationSpecs))
 }
 
 // If you are running a JRuby snapshot we will skip the integrity check.


### PR DESCRIPTION
This fixes the jruby build env and replaces #8907 and is a followup of #8896 

I think keeping `vendor/jruby` instead of `bin/ruby` is probably better to avoid inheriting all the runtime JVM options set for running LS but that are probably overkill for the build. 

`gradle build` now works locally from clean env, including  running all tests and integration tests.
  