### PR TITLE
correctly handle paths with spaces

### DIFF
--- a/bin/logstash.bat
+++ b/bin/logstash.bat
@@ -32,7 +32,7 @@ for /F "usebackq tokens=1-2* delims= " %%A in (!params!) do (
 
 rem if explicit jvm.options is not found use default location
 if "%LS_JVM_OPTIONS_CONFIG%" == "" (
-  set LS_JVM_OPTIONS_CONFIG=%LS_HOME%\config\jvm.options
+  set LS_JVM_OPTIONS_CONFIG="%LS_HOME%\config\jvm.options"
 )
 
 rem extract the options from the JVM options file %LS_JVM_OPTIONS_CONFIG%

--- a/bin/rspec.bat
+++ b/bin/rspec.bat
@@ -12,7 +12,7 @@ if errorlevel 1 (
 
 rem if explicit jvm.options is not found use default location
 if "%LS_JVM_OPTIONS_CONFIG%" == "" (
-  set LS_JVM_OPTIONS_CONFIG=%LS_HOME%\config\jvm.options
+  set LS_JVM_OPTIONS_CONFIG="%LS_HOME%\config\jvm.options"
 )
 
 rem extract the options from the JVM options file %LS_JVM_OPTIONS_CONFIG%

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -47,7 +47,7 @@ if not "%JAVA_OPTS%" == "" (
 rem ### 3: set jruby
 
 set JRUBY_BIN="%LS_HOME%\vendor\jruby\bin\jruby"
-if not exist "%JRUBY_BIN%" (
+if not exist %JRUBY_BIN% (
   echo "could not find jruby in %LS_HOME%\vendor\jruby" 1>&2
   exit /b 1
 )

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -236,7 +236,7 @@ class LogStash::Runner < Clamp::StrictCommand
 
       # Windows safe way to produce a file: URI.
       file_schema = "file://" + (LogStash::Environment.windows? ? "/" : "")
-      LogStash::Logging::Logger::reconfigure(URI.join(file_schema + File.absolute_path(log4j_config_location)).to_s)
+      LogStash::Logging::Logger::reconfigure(URI.encode(file_schema + File.absolute_path(log4j_config_location)))
     end
     # override log level that may have been introduced from a custom log4j config file
     LogStash::Logging::Logger::configure_logging(setting("log.level"))


### PR DESCRIPTION
Solves #8901 

- Windows startup scripts did not correctly handled paths with spaces.
- The logger configuration was buggy by using a useless `join` and not escaping the path as as URI.