### PR TITLE
MINOR: Update readme for building zip/tar distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ Note that if a plugin is installed using the plugin manager `bin/logstash-plugin
 You can build a Logstash snapshot package as tarball or zip file
 
 ```sh
-rake artifact:tar
-rake artifact:zip
+./gradlew assembleTarDistribution
+./gradlew assembleZipDistribution
 ```
 
 This will create the artifact `LS_HOME/build` directory

--- a/build.gradle
+++ b/build.gradle
@@ -159,7 +159,7 @@ task installTestGems(dependsOn: downloadAndInstallJRuby, type: Exec) {
   commandLine jrubyBin, rakeBin, "test:install-core"
 }
 
-task assembleTarDistribution(dependsOn: installTestGems, type: Exec) {
+task assembleTarDistribution(dependsOn: downloadAndInstallJRuby, type: Exec) {
   workingDir projectDir
   inputs.files fileTree("${projectDir}/rakelib")
   inputs.files fileTree("${projectDir}/bin")
@@ -173,6 +173,22 @@ task assembleTarDistribution(dependsOn: installTestGems, type: Exec) {
   standardOutput = new ExecLogOutputStream(System.out)
   errorOutput =  new ExecLogOutputStream(System.err)
   commandLine jrubyBin, rakeBin, "artifact:tar"
+}
+
+task assembleZipDistribution(dependsOn: downloadAndInstallJRuby, type: Exec) {
+  workingDir projectDir
+  inputs.files fileTree("${projectDir}/rakelib")
+  inputs.files fileTree("${projectDir}/bin")
+  inputs.files fileTree("${projectDir}/config")
+  inputs.files fileTree("${projectDir}/lib")
+  inputs.files fileTree("${projectDir}/modules")
+  inputs.files fileTree("${projectDir}/logstash-core-plugin-api")
+  inputs.files fileTree("${projectDir}/logstash-core/lib")
+  inputs.files fileTree("${projectDir}/logstash-core/src")
+  outputs.files file("${buildDir}/logstash-${project.version}.tar.gz")
+  standardOutput = new ExecLogOutputStream(System.out)
+  errorOutput =  new ExecLogOutputStream(System.err)
+  commandLine jrubyBin, rakeBin, "artifact:zip"
 }
 
 def logstashBuildDir = "${buildDir}/logstash-${project.version}-SNAPSHOT"


### PR DESCRIPTION
* Documented tar assembly task

Also realized, that it's dirty to not port zip then (at least as a wrapper for `rake`) and have zip and tar be built from separate build systems ... so:

* Moved wrapper for Zip build to Gradle too
   * Obviously kind of dirty now, but I'd suggest we clean this up in a separate step, by having shared logic in Gradle for assembling the archives