### PR TITLE
BUG: Fix exceptions that aren't system exit type to be swallowed

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Logstash.java
+++ b/logstash-core/src/main/java/org/logstash/Logstash.java
@@ -96,6 +96,8 @@ public final class Logstash implements Runnable, AutoCloseable {
                 if (status != null && !status.isNil() && RubyNumeric.fix2int(status) != 0) {
                     throw new IllegalStateException(ex);
                 }
+            } else {
+                throw new IllegalStateException(ex);
             }
         }
     }


### PR DESCRIPTION
@danhermann brought this to my attention.

I missed a case here when setting up the Java entry point and swallowed all exceptions that aren't necessarily triggering a `Ruby` runtime exit. Annoyingly enough there appears to be a subset of exceptions that have to be swallowed and return `0`, those are caught by the `if` branch that is copied 1:1 from JRuby's own entry point. What was missing was to rethrow those exceptions that aren't necessarily causing System exit.

Without this fix, running LS with e.g. missing gems in the `vendor` dir just exits `0` quietly without any error logged.

No unit test, because I can't really write one as long as we have a global `Ruby` instance that I can't kill :(