### PR TITLE
MINOR: Simplify inflight batch tracking

### DIFF
--- a/logstash-core/lib/logstash/pipeline_reporter.rb
+++ b/logstash-core/lib/logstash/pipeline_reporter.rb
@@ -53,11 +53,10 @@ module LogStash; class PipelineReporter
 
   def to_hash
     # pipeline.filter_queue_client.inflight_batches is synchronized
-    pipeline.filter_queue_client.inflight_batches do |batch_map|
-      worker_states_snap = worker_states(batch_map) # We only want to run this once
-      inflight_count = worker_states_snap.map {|s| s[:inflight_count] }.reduce(0, :+)
-
-      {
+    batch_map = pipeline.filter_queue_client.inflight_batches
+    worker_states_snap = worker_states(batch_map) # We only want to run this once
+    inflight_count = worker_states_snap.map {|s| s[:inflight_count]}.reduce(0, :+)
+    {
         :events_filtered => events_filtered,
         :events_consumed => events_consumed,
         :inflight_count => inflight_count,
@@ -65,8 +64,7 @@ module LogStash; class PipelineReporter
         :output_info => output_info,
         :thread_info => pipeline.plugin_threads_info,
         :stalling_threads_info => pipeline.stalling_threads_info
-      }
-    end
+    }
   end
 
   private
@@ -103,7 +101,7 @@ module LogStash; class PipelineReporter
       {
         :type => output_delegator.config_name,
         :id => output_delegator.id,
-        :concurrency => output_delegator.concurrency,        
+        :concurrency => output_delegator.concurrency,
       }
     end
   end

--- a/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
@@ -77,7 +77,7 @@ module LogStash; module Util
       end
 
       def inflight_batches
-        yield(@inflight_batches)
+        @inflight_batches
       end
 
       # create a new empty batch


### PR DESCRIPTION
This one was long overdue :D Motivation here was initially that `yield` is hard to port to Java so I redid the `inflight_batches` method and its only called to not require `yield`.

* Just return instead of `yield` the map, `yield` was only necessary when we needed locking around the iteration for the map, this was already redundant for the sync queue since there there was no lock around the `yield`
* Needed a concurrency safe iterator => had that already in the sync queue => moved the acked queue to use a concurrent map as well (the solution is safe since all operations on the Java queue are locked on the Java side, same as for the `ArrayBlockingQueue` that back the sync queue implementation which works fine without locks and just using a concurrent hashmap) 