### PR TITLE
MINOR: Remove unnecessary logger fields from filter and output delegators

### DIFF
--- a/logstash-core/lib/logstash/filter_delegator.rb
+++ b/logstash-core/lib/logstash/filter_delegator.rb
@@ -16,8 +16,7 @@ module LogStash
 
     attr_reader :id
 
-    def initialize(logger, klass, metric, execution_context, plugin_args)
-      @logger = logger
+    def initialize(klass, metric, execution_context, plugin_args)
       @klass = klass
       @id = plugin_args["id"]
       @filter = klass.new(plugin_args)

--- a/logstash-core/lib/logstash/java_filter_delegator.rb
+++ b/logstash-core/lib/logstash/java_filter_delegator.rb
@@ -17,8 +17,7 @@ module LogStash
 
     attr_reader :id
 
-    def initialize(logger, klass, metric, execution_context, plugin_args)
-      @logger = logger
+    def initialize(klass, metric, execution_context, plugin_args)
       @klass = klass
       @id = plugin_args["id"]
       @filter = klass.new(plugin_args)

--- a/logstash-core/lib/logstash/output_delegator.rb
+++ b/logstash-core/lib/logstash/output_delegator.rb
@@ -8,7 +8,6 @@ module LogStash class OutputDelegator
   attr_reader :metric, :metric_events, :strategy, :namespaced_metric, :metric_events, :id
 
   def initialize(logger, output_class, metric, execution_context, strategy_registry, plugin_args)
-    @logger = logger
     @output_class = output_class
     @metric = metric
     @id = plugin_args["id"]
@@ -24,7 +23,7 @@ module LogStash class OutputDelegator
     @time_metric = @metric_events.counter(:duration_in_millis)
     @strategy = strategy_registry.
                   class_for(self.concurrency).
-                  new(@logger, @output_class, @namespaced_metric, execution_context, plugin_args)
+                  new(logger, @output_class, @namespaced_metric, execution_context, plugin_args)
   end
 
   def config_name

--- a/logstash-core/lib/logstash/plugins/plugin_factory.rb
+++ b/logstash-core/lib/logstash/plugins/plugin_factory.rb
@@ -85,7 +85,7 @@ module LogStash
         if plugin_type == "output"
           OutputDelegator.new(@logger, klass, type_scoped_metric, execution_context, OutputDelegatorStrategyRegistry.instance, args)
         elsif plugin_type == "filter"
-          @filter_class.new(@logger, klass, type_scoped_metric, execution_context, args)
+          @filter_class.new(klass, type_scoped_metric, execution_context, args)
         else # input or codec plugin
           plugin_instance = klass.new(args)
           scoped_metric = type_scoped_metric.namespace(id.to_sym)

--- a/logstash-core/spec/logstash/filter_delegator_spec.rb
+++ b/logstash-core/spec/logstash/filter_delegator_spec.rb
@@ -14,8 +14,7 @@ describe LogStash::FilterDelegator do
   end
 
   include_context "execution_context"
-  
-  let(:logger) { double(:logger) }
+
   let(:filter_id) { "my-filter" }
   let(:config) do
     { "host" => "127.0.0.1", "id" => filter_id }
@@ -43,11 +42,11 @@ describe LogStash::FilterDelegator do
     end
   end
 
-  subject { described_class.new(logger, plugin_klass, metric, execution_context, config) }
+  subject { described_class.new(plugin_klass, metric, execution_context, config) }
 
   it "create a plugin with the passed options" do
     expect(plugin_klass).to receive(:new).with(config).and_return(plugin_klass.new(config))
-    described_class.new(logger, plugin_klass, metric, execution_context, config)
+    described_class.new(plugin_klass, metric, execution_context, config)
   end
 
   context "when the plugin support flush" do

--- a/logstash-core/spec/logstash/java_filter_delegator_spec.rb
+++ b/logstash-core/spec/logstash/java_filter_delegator_spec.rb
@@ -14,8 +14,7 @@ describe LogStash::JavaFilterDelegator do
   end
 
   include_context "execution_context"
-  
-  let(:logger) { double(:logger) }
+
   let(:filter_id) { "my-filter" }
   let(:config) do
     { "host" => "127.0.0.1", "id" => filter_id }
@@ -43,11 +42,11 @@ describe LogStash::JavaFilterDelegator do
     end
   end
 
-  subject { described_class.new(logger, plugin_klass, metric, execution_context, config) }
+  subject { described_class.new(plugin_klass, metric, execution_context, config) }
 
   it "create a plugin with the passed options" do
     expect(plugin_klass).to receive(:new).with(config).and_return(plugin_klass.new(config))
-    described_class.new(logger, plugin_klass, metric, execution_context, config)
+    described_class.new(plugin_klass, metric, execution_context, config)
   end
 
   context "when the plugin support flush" do


### PR DESCRIPTION
Random find when investigating what we could bring to Java next :)

* `@logger` fields are never used
   * can completely remove them everywhere for the filter delegator
   * have to still pass the logger through in the constructor of the output delegator but don't need that field either

=> making it at least slightly easier to bring this over to Java :)