### PR TITLE
remove currentByteSize

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Page.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Page.java
@@ -4,6 +4,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.BitSet;
 
+import org.codehaus.commons.nullanalysis.NotNull;
 import org.logstash.ackedqueue.io.CheckpointIO;
 import org.logstash.ackedqueue.io.LongVector;
 import org.logstash.ackedqueue.io.PageIO;
@@ -23,7 +24,7 @@ public final class Page implements Closeable {
     protected BitSet ackedSeqNums;
     protected Checkpoint lastCheckpoint;
 
-    public Page(int pageNum, Queue queue, long minSeqNum, int elementCount, long firstUnreadSeqNum, BitSet ackedSeqNums, PageIO pageIO, boolean writable) {
+    public Page(int pageNum, Queue queue, long minSeqNum, int elementCount, long firstUnreadSeqNum, BitSet ackedSeqNums, @NotNull PageIO pageIO, boolean writable) {
         this.pageNum = pageNum;
         this.queue = queue;
 
@@ -34,6 +35,8 @@ public final class Page implements Closeable {
         this.lastCheckpoint = new Checkpoint(0, 0, 0, 0, 0);
         this.pageIO = pageIO;
         this.writable = writable;
+
+        assert this.pageIO != null : "invalid null pageIO";
     }
 
     public String toString() {
@@ -238,15 +241,11 @@ public final class Page implements Closeable {
 
     public void close() throws IOException {
         checkpoint();
-        if (this.pageIO != null) {
-            this.pageIO.close();
-        }
+        this.pageIO.close();
     }
 
     public void purge() throws IOException {
-        if (this.pageIO != null) {
-            this.pageIO.purge(); // page IO purge calls close
-        }
+        this.pageIO.purge(); // page IO purge calls close
     }
 
     public int getPageNum() {

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyAckedQueueExt.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyAckedQueueExt.java
@@ -76,11 +76,6 @@ public final class JRubyAckedQueueExt extends RubyObject {
         return context.runtime.newString(queue.getDirPath());
     }
 
-    @JRubyMethod(name = "current_byte_size")
-    public IRubyObject ruby_current_byte_size(ThreadContext context) {
-        return context.runtime.newFixnum(queue.getCurrentByteSize());
-    }
-
     @JRubyMethod(name = "persisted_size_in_bytes")
     public IRubyObject ruby_persisted_size_in_bytes(ThreadContext context) {
         return context.runtime.newFixnum(queue.getPersistedByteSize());

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/MmapPageIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/MmapPageIO.java
@@ -206,6 +206,7 @@ public final class MmapPageIO implements PageIO {
     public void purge() throws IOException {
         close();
         Files.delete(this.file.toPath());
+        this.head = 0;
     }
 
     @Override

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/HeadPageTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/HeadPageTest.java
@@ -12,7 +12,7 @@ import org.logstash.ackedqueue.io.PageIO;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.logstash.ackedqueue.QueueTestHelpers.singleElementCapacityForByteBufferPageIO;
+import static org.logstash.ackedqueue.QueueTestHelpers.computeCapacityForMmapPageIO;
 
 public class HeadPageTest {
 
@@ -49,7 +49,7 @@ public class HeadPageTest {
         Queueable element = new StringElement("foobarbaz");
 
         Settings s = TestSettings.persistedQueueSettings(
-            singleElementCapacityForByteBufferPageIO(element), dataPath
+                computeCapacityForMmapPageIO(element), dataPath
         );
         try(Queue q = new Queue(s)) {
             q.open();
@@ -68,9 +68,8 @@ public class HeadPageTest {
     public void pageWriteAndReadSingle() throws IOException {
         long seqNum = 1L;
         Queueable element = new StringElement("foobarbaz");
-        int singleElementCapacity = singleElementCapacityForByteBufferPageIO(element);
 
-        Settings s = TestSettings.persistedQueueSettings(singleElementCapacity, dataPath);
+        Settings s = TestSettings.persistedQueueSettings(computeCapacityForMmapPageIO(element), dataPath);
         try(Queue q = new Queue(s)) {
             q.open();
             Page p = q.headPage;
@@ -114,7 +113,7 @@ public class HeadPageTest {
         Queueable element = new StringElement("foobarbaz");
 
         Settings s = TestSettings.persistedQueueSettings(
-            singleElementCapacityForByteBufferPageIO(element), dataPath
+                computeCapacityForMmapPageIO(element), dataPath
         );
         try(Queue q = new Queue(s)) {
             q.open();
@@ -140,7 +139,7 @@ public class HeadPageTest {
 //        URL url = FileCheckpointIOTest.class.getResource("checkpoint.head");
 //        String dirPath = Paths.get(url.toURI()).getParent().toString();
 //        Queueable element = new StringElement("foobarbaz");
-//        int singleElementCapacity = singleElementCapacityForByteBufferPageIO(element);
+//        int singleElementCapacity = computeCapacityForByteBufferPageIO(element);
 //        Settings s = TestSettings.persistedQueueSettings(singleElementCapacity, dirPath);
 //        TestQueue q = new TestQueue(s);
 //        try {

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
-import static org.logstash.ackedqueue.QueueTestHelpers.singleElementCapacityForByteBufferPageIO;
+import static org.logstash.ackedqueue.QueueTestHelpers.computeCapacityForMmapPageIO;
 
 public class QueueTest {
 
@@ -174,9 +174,8 @@ public class QueueTest {
     @Test
     public void writeMultiPage() throws IOException {
         List<Queueable> elements = Arrays.asList(new StringElement("foobarbaz1"), new StringElement("foobarbaz2"), new StringElement("foobarbaz3"), new StringElement("foobarbaz4"));
-        int singleElementCapacity = singleElementCapacityForByteBufferPageIO(elements.get(0));
         try (Queue q = new Queue(
-            TestSettings.persistedQueueSettings(2 * singleElementCapacity, dataPath))) {
+            TestSettings.persistedQueueSettings(computeCapacityForMmapPageIO(elements.get(0), 2), dataPath))) {
             q.open();
 
             for (Queueable e : elements) {
@@ -218,9 +217,8 @@ public class QueueTest {
     @Test
     public void writeMultiPageWithInOrderAcking() throws IOException {
         List<Queueable> elements = Arrays.asList(new StringElement("foobarbaz1"), new StringElement("foobarbaz2"), new StringElement("foobarbaz3"), new StringElement("foobarbaz4"));
-        int singleElementCapacity = singleElementCapacityForByteBufferPageIO(elements.get(0));
         try (Queue q = new Queue(
-            TestSettings.persistedQueueSettings(2 * singleElementCapacity, dataPath))) {
+            TestSettings.persistedQueueSettings(computeCapacityForMmapPageIO(elements.get(0), 2), dataPath))) {
             q.open();
 
             for (Queueable e : elements) {
@@ -260,10 +258,9 @@ public class QueueTest {
     public void writeMultiPageWithInOrderAckingCheckpoints() throws IOException {
         List<Queueable> elements1 = Arrays.asList(new StringElement("foobarbaz1"), new StringElement("foobarbaz2"));
         List<Queueable> elements2 = Arrays.asList(new StringElement("foobarbaz3"), new StringElement("foobarbaz4"));
-        int singleElementCapacity = singleElementCapacityForByteBufferPageIO(elements1.get(0));
 
         Settings settings = SettingsImpl.builder(
-            TestSettings.persistedQueueSettings(2 * singleElementCapacity, dataPath)
+            TestSettings.persistedQueueSettings(computeCapacityForMmapPageIO(elements1.get(0), 2), dataPath)
         ).checkpointMaxWrites(1024) // arbitrary high enough threshold so that it's not reached (default for TestSettings is 1)
         .build();
         try (Queue q = new Queue(settings)) {
@@ -360,9 +357,8 @@ public class QueueTest {
             for (int i = 0; i < page_count; i++) {
                 elements.add(new StringElement(String.format("%0" + digits + "d", i)));
             }
-            int singleElementCapacity = singleElementCapacityForByteBufferPageIO(elements.get(0));
             try (Queue q = new Queue(
-                TestSettings.persistedQueueSettings(singleElementCapacity, dataPath))) {
+                TestSettings.persistedQueueSettings(computeCapacityForMmapPageIO(elements.get(0)), dataPath))) {
                 q.open();
 
                 for (Queueable e : elements) {
@@ -392,7 +388,7 @@ public class QueueTest {
     @Test(timeout = 50_000)
     public void reachMaxUnread() throws IOException, InterruptedException, ExecutionException {
         Queueable element = new StringElement("foobarbaz");
-        int singleElementCapacity = singleElementCapacityForByteBufferPageIO(element);
+        int singleElementCapacity = computeCapacityForMmapPageIO(element);
 
         Settings settings = SettingsImpl.builder(
             TestSettings.persistedQueueSettings(singleElementCapacity, dataPath)
@@ -485,11 +481,9 @@ public class QueueTest {
     public void reachMaxSizeTest() throws IOException, InterruptedException {
         Queueable element = new StringElement("0123456789"); // 10 bytes
 
-        int singleElementCapacity = singleElementCapacityForByteBufferPageIO(element);
-
         // allow 10 elements per page but only 100 events in total
         Settings settings = TestSettings.persistedQueueSettings(
-            singleElementCapacity * 10, singleElementCapacity * 100L, dataPath
+                computeCapacityForMmapPageIO(element, 10), computeCapacityForMmapPageIO(element, 100), dataPath
         );
         try (Queue q = new Queue(settings)) {
             q.open();
@@ -515,11 +509,9 @@ public class QueueTest {
 
         Queueable element = new StringElement("0123456789"); // 10 bytes
 
-        int singleElementCapacity = singleElementCapacityForByteBufferPageIO(element);
-
         // allow 10 elements per page but only 100 events in total
         Settings settings = TestSettings.persistedQueueSettings(
-            singleElementCapacity * 10, singleElementCapacity * 100L, dataPath
+                computeCapacityForMmapPageIO(element, 10), computeCapacityForMmapPageIO(element, 100), dataPath
         );
         try (Queue q = new Queue(settings)) {
             q.open();
@@ -553,11 +545,9 @@ public class QueueTest {
     public void resumeWriteOnNoLongerFullQueueTest() throws IOException, InterruptedException, ExecutionException {
         Queueable element = new StringElement("0123456789"); // 10 bytes
 
-        int singleElementCapacity = singleElementCapacityForByteBufferPageIO(element);
-
         // allow 10 elements per page but only 100 events in total
         Settings settings = TestSettings.persistedQueueSettings(
-            singleElementCapacity * 10, singleElementCapacity * 100L, dataPath
+                computeCapacityForMmapPageIO(element, 10),  computeCapacityForMmapPageIO(element, 100), dataPath
         );
         try (Queue q = new Queue(settings)) {
             q.open();
@@ -593,11 +583,9 @@ public class QueueTest {
 
         Queueable element = new StringElement("0123456789"); // 10 bytes
 
-        int singleElementCapacity = singleElementCapacityForByteBufferPageIO(element);
-
         // allow 10 elements per page but only 100 events in total
         Settings settings = TestSettings.persistedQueueSettings(
-            singleElementCapacity * 10, singleElementCapacity * 100L, dataPath
+                computeCapacityForMmapPageIO(element, 10), computeCapacityForMmapPageIO(element, 100), dataPath
         );
         try (Queue q = new Queue(settings)) {
             q.open();
@@ -743,9 +731,8 @@ public class QueueTest {
     @Test
     public void fullyAckedHeadPageBeheadingTest() throws IOException {
         Queueable element = new StringElement("foobarbaz1");
-        int singleElementCapacity = singleElementCapacityForByteBufferPageIO(element);
         try (Queue q = new Queue(
-            TestSettings.persistedQueueSettings(2 * singleElementCapacity, dataPath))) {
+            TestSettings.persistedQueueSettings(computeCapacityForMmapPageIO(element, 2), dataPath))) {
             q.open();
 
             Batch b;
@@ -801,8 +788,7 @@ public class QueueTest {
     @Test
     public void getsPersistedByteSizeCorrectlyForFullyAckedDeletedTailPages() throws Exception {
         final Queueable element = new StringElement("0123456789"); // 10 bytes
-        final int singleElementCapacity = singleElementCapacityForByteBufferPageIO(element);
-        final Settings settings = TestSettings.persistedQueueSettings(singleElementCapacity, dataPath);
+        final Settings settings = TestSettings.persistedQueueSettings(computeCapacityForMmapPageIO(element), dataPath);
 
         try (Queue q = new Queue(settings)) {
             q.open();
@@ -903,8 +889,7 @@ public class QueueTest {
     @Test
     public void testZeroByteFullyAckedPageOnOpen() throws IOException {
         Queueable element = new StringElement("0123456789"); // 10 bytes
-        int singleElementCapacity = singleElementCapacityForByteBufferPageIO(element);
-        Settings settings = TestSettings.persistedQueueSettings(singleElementCapacity, dataPath);
+        Settings settings = TestSettings.persistedQueueSettings(computeCapacityForMmapPageIO(element), dataPath);
 
         // the goal here is to recreate a condition where the queue has a tail page of size zero with
         // a checkpoint that indicates it is full acknowledged
@@ -954,9 +939,8 @@ public class QueueTest {
     @Test
     public void pageCapacityChangeOnExistingQueue() throws IOException {
         final Queueable element = new StringElement("foobarbaz1");
-        final int singleElementCapacity = singleElementCapacityForByteBufferPageIO(element);
-        final int ORIGINAL_CAPACITY = 2 * singleElementCapacity;
-        final int NEW_CAPACITY = 10 * singleElementCapacity;
+        final int ORIGINAL_CAPACITY = computeCapacityForMmapPageIO(element, 2);
+        final int NEW_CAPACITY = computeCapacityForMmapPageIO(element, 10);
 
         try (Queue q = new Queue(TestSettings.persistedQueueSettings(ORIGINAL_CAPACITY, dataPath))) {
             q.open();

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTestHelpers.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTestHelpers.java
@@ -14,7 +14,17 @@ public class QueueTestHelpers {
      * @return int - capacity required for the supplied element
      * @throws IOException Throws if a serialization error occurs
      */
-    public static int singleElementCapacityForByteBufferPageIO(final Queueable element) throws IOException {
-        return MmapPageIO.WRAPPER_SIZE + element.serialize().length;
+    public static int computeCapacityForMmapPageIO(final Queueable element) throws IOException {
+        return computeCapacityForMmapPageIO(element, 1);
+    }
+
+    /**
+     * Returns the {@link org.logstash.ackedqueue.io.MmapPageI} capacity require to hold a multiple elements including all headers and other metadata.
+     * @param element
+     * @return int - capacity required for the supplied number of elements
+     * @throws IOException Throws if a serialization error occurs
+     */
+    public static int computeCapacityForMmapPageIO(final Queueable element, int count) throws IOException {
+        return MmapPageIO.HEADER_SIZE + (count * (MmapPageIO.SEQNUM_SIZE + MmapPageIO.LENGTH_SIZE + element.serialize().length + MmapPageIO.CHECKSUM_SIZE));
     }
 }


### PR DESCRIPTION
Relates to #8936

This removes `currentByteSize` handling in PQ which computes queue size based on page capacity times the number of live pages. 

Per #6508, #6518 and #7010 we have settled to using the sum of the actual persisted bytes (head position) for each sparsely allocated page of the queue to compute the queue disk size. There is no reason to keep this `currentByteSize` around. 

**IMPORTANT** This PR introduces an inefficiency in the `isFull()` method which now needs to call `getPersistedByteSize()`  instead of using the `volatile long currentByteSize`. Calling `getPersistedByteSize()` is clearly less efficient because it needs to iterate through all the tail pages to sum the head position but it is now a "correct" implementation. I suggest we move forward with this change here and open a new issue to work on a way to optimize this. 

Note that while doing this I realized that the tests using `singleElementCapacityForByteBufferPageIO` for computing the queue max size were wrong and I added `multipleElementsCapacityForByteBufferPageIO` to correctly do this.