### PR TITLE
test fix: don't use stdin for blocking pipeline

### DIFF
--- a/qa/integration/specs/secret_store_spec.rb
+++ b/qa/integration/specs/secret_store_spec.rb
@@ -53,7 +53,7 @@ describe "Test that Logstash" do
   it "expands secret store variables from settings" do
     test_env["LOGSTASH_KEYSTORE_PASS"] = "keystore_pa9454w3rd"
     @logstash.env_variables = test_env
-    @logstash.spawn_logstash("-e", "input {stdin {}} output { }", "--path.settings", settings_dir)
+    @logstash.spawn_logstash("-e", "input {heartbeat {}} output { }", "--path.settings", settings_dir)
     @logstash.wait_for_logstash
     Stud.try(num_retries.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
       result = @logstash.monitoring_api.node_stats rescue nil


### PR DESCRIPTION
This test really doesn't care which input is used, as long it blocks long enough to check the pipeline name... which for some reason (not totally understood) stdin doesn't block the child LS process as expected [1]. 


Change is trivial and should fix the intermittent test failures. 

[1] 
There is special logic w/r/t to using the stdin that i suspect helps to keep it from dying immediately after starting and also manipulates the io for the child process. That special logic doesn't accept settings as a parameter, so I can't use it without unecessary changes. 
