### PR TITLE
MINOR: Remove unnecessary logger fields from output delegator strategy and plugin factory

### DIFF
--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -57,7 +57,7 @@ module LogStash; class JavaBasePipeline
     @plugin_factory = LogStash::Plugins::PluginFactory.new(
       # use NullMetric if called in the BasePipeline context otherwise use the @metric value
       @lir, LogStash::Plugins::PluginMetricFactory.new(pipeline_id, @metric || Instrument::NullMetric.new),
-      @logger, LogStash::Plugins::ExecutionContextFactory.new(@agent, self, @dlq_writer),
+      LogStash::Plugins::ExecutionContextFactory.new(@agent, self, @dlq_writer),
       JavaFilterDelegator
     )
     @lir_execution = CompiledPipeline.new(@lir, @plugin_factory)

--- a/logstash-core/lib/logstash/output_delegator.rb
+++ b/logstash-core/lib/logstash/output_delegator.rb
@@ -7,7 +7,7 @@ require "logstash/output_delegator_strategies/legacy"
 module LogStash class OutputDelegator
   attr_reader :metric, :metric_events, :strategy, :namespaced_metric, :metric_events, :id
 
-  def initialize(logger, output_class, metric, execution_context, strategy_registry, plugin_args)
+  def initialize(output_class, metric, execution_context, strategy_registry, plugin_args)
     @output_class = output_class
     @metric = metric
     @id = plugin_args["id"]
@@ -23,7 +23,7 @@ module LogStash class OutputDelegator
     @time_metric = @metric_events.counter(:duration_in_millis)
     @strategy = strategy_registry.
                   class_for(self.concurrency).
-                  new(logger, @output_class, @namespaced_metric, execution_context, plugin_args)
+                  new(@output_class, @namespaced_metric, execution_context, plugin_args)
   end
 
   def config_name

--- a/logstash-core/lib/logstash/output_delegator_strategies/legacy.rb
+++ b/logstash-core/lib/logstash/output_delegator_strategies/legacy.rb
@@ -1,8 +1,8 @@
 # Remove this in Logstash 6.0
 module LogStash module OutputDelegatorStrategies class Legacy
   attr_reader :worker_count, :workers
-  
-  def initialize(logger, klass, metric, execution_context, plugin_args)
+
+  def initialize(klass, metric, execution_context, plugin_args)
     @worker_count = (plugin_args["workers"] || 1).to_i
     @workers = @worker_count.times.map { klass.new(plugin_args) }
     @workers.each do |w|
@@ -12,11 +12,11 @@ module LogStash module OutputDelegatorStrategies class Legacy
     @worker_queue = SizedQueue.new(@worker_count)
     @workers.each {|w| @worker_queue << w}
   end
-  
+
   def register
     @workers.each(&:register)
   end
-  
+
   def multi_receive(events)
     worker = @worker_queue.pop
     worker.multi_receive(events)

--- a/logstash-core/lib/logstash/output_delegator_strategies/shared.rb
+++ b/logstash-core/lib/logstash/output_delegator_strategies/shared.rb
@@ -1,10 +1,10 @@
 module LogStash module OutputDelegatorStrategies class Shared
-  def initialize(logger, klass, metric, execution_context, plugin_args)
+  def initialize(klass, metric, execution_context, plugin_args)
     @output = klass.new(plugin_args)
     @output.metric = metric
     @output.execution_context = execution_context
   end
-  
+
   def register
     @output.register
   end
@@ -13,10 +13,10 @@ module LogStash module OutputDelegatorStrategies class Shared
     @output.multi_receive(events)
   end
 
-  def do_close    
+  def do_close
     @output.do_close
   end
 
-  ::LogStash::OutputDelegatorStrategyRegistry.instance.register(:shared, self)  
+  ::LogStash::OutputDelegatorStrategyRegistry.instance.register(:shared, self)
 end; end; end
 

--- a/logstash-core/lib/logstash/output_delegator_strategies/single.rb
+++ b/logstash-core/lib/logstash/output_delegator_strategies/single.rb
@@ -1,5 +1,5 @@
 module LogStash module OutputDelegatorStrategies class Single
-  def initialize(logger, klass, metric, execution_context, plugin_args)
+  def initialize(klass, metric, execution_context, plugin_args)
     @output = klass.new(plugin_args)
     @output.metric = metric
     @output.execution_context = execution_context
@@ -9,7 +9,7 @@ module LogStash module OutputDelegatorStrategies class Single
   def register
     @output.register
   end
-  
+
   def multi_receive(events)
     @mutex.synchronize do
       @output.multi_receive(events)

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -64,7 +64,7 @@ module LogStash; class BasePipeline
     @plugin_factory = LogStash::Plugins::PluginFactory.new(
       # use NullMetric if called in the BasePipeline context otherwise use the @metric value
       @lir, LogStash::Plugins::PluginMetricFactory.new(pipeline_id, @metric || Instrument::NullMetric.new),
-      @logger, LogStash::Plugins::ExecutionContextFactory.new(@agent, self, @dlq_writer),
+      LogStash::Plugins::ExecutionContextFactory.new(@agent, self, @dlq_writer),
       FilterDelegator
     )
     grammar = LogStashConfigParser.new

--- a/logstash-core/lib/logstash/plugins/plugin_factory.rb
+++ b/logstash-core/lib/logstash/plugins/plugin_factory.rb
@@ -32,11 +32,10 @@ module LogStash
     class PluginFactory
       include org.logstash.config.ir.compiler.RubyIntegration::PluginFactory
 
-      def initialize(lir, metric_factory, logger, exec_factory, filter_class)
+      def initialize(lir, metric_factory, exec_factory, filter_class)
         @lir = lir
         @plugins_by_id = {}
         @metric_factory = metric_factory
-        @logger = logger
         @exec_factory = exec_factory
         @filter_class = filter_class
       end
@@ -83,7 +82,7 @@ module LogStash
         execution_context = @exec_factory.create(id, klass.config_name)
 
         if plugin_type == "output"
-          OutputDelegator.new(@logger, klass, type_scoped_metric, execution_context, OutputDelegatorStrategyRegistry.instance, args)
+          OutputDelegator.new(klass, type_scoped_metric, execution_context, OutputDelegatorStrategyRegistry.instance, args)
         elsif plugin_type == "filter"
           @filter_class.new(klass, type_scoped_metric, execution_context, args)
         else # input or codec plugin

--- a/logstash-core/spec/logstash/output_delegator_spec.rb
+++ b/logstash-core/spec/logstash/output_delegator_spec.rb
@@ -11,7 +11,6 @@ describe LogStash::OutputDelegator do
     end
   end
 
-  let(:logger) { double("logger") }
   let(:events) { 7.times.map { LogStash::Event.new }}
   let(:plugin_args) { {"id" => "foo", "arg1" => "val1"} }
   let(:collector) { [] }
@@ -22,7 +21,7 @@ describe LogStash::OutputDelegator do
 
   include_context "execution_context"
 
-  subject { described_class.new(logger, out_klass, metric, execution_context, ::LogStash::OutputDelegatorStrategyRegistry.instance, plugin_args) }
+  subject { described_class.new(out_klass, metric, execution_context, ::LogStash::OutputDelegatorStrategyRegistry.instance, plugin_args) }
 
   context "with a plain output plugin" do
     let(:out_klass) { double("output klass") }
@@ -47,7 +46,6 @@ describe LogStash::OutputDelegator do
       allow(out_inst).to receive(:id).and_return("a-simple-plugin")
 
       allow(subject.metric_events).to receive(:increment).with(any_args)
-      allow(logger).to receive(:debug).with(any_args)
     end
 
     it "should initialize cleanly" do
@@ -56,7 +54,7 @@ describe LogStash::OutputDelegator do
 
     it "should push the name of the plugin to the metric" do
       expect(metric).to receive(:gauge).with(:name, out_klass.config_name)
-      described_class.new(logger, out_klass, metric, execution_context, ::LogStash::OutputDelegatorStrategyRegistry.instance, plugin_args)
+      described_class.new(out_klass, metric, execution_context, ::LogStash::OutputDelegatorStrategyRegistry.instance, plugin_args)
     end
 
     context "after having received a batch of events" do
@@ -112,7 +110,7 @@ describe LogStash::OutputDelegator do
           it "should find the correct concurrency type for the output" do
             expect(subject.concurrency).to eq(strategy_concurrency)
           end
-          
+
           it "should find the correct Strategy class for the worker" do
             expect(subject.strategy).to be_a(klass)
           end
@@ -130,7 +128,7 @@ describe LogStash::OutputDelegator do
               before do
                 allow(subject.strategy).to receive(method)
               end
-              
+
               it "should delegate #{method} to the strategy" do
                 subject.send(method, *args)
                 if args
@@ -145,7 +143,7 @@ describe LogStash::OutputDelegator do
               before do
                 allow(out_inst).to receive(method)
               end
-              
+
               it "should delegate #{method} to the strategy" do
                 subject.send(method, *args)
                 if args


### PR DESCRIPTION
Same as #8957, `@logger` field isn't used in any of these classes and just needlessly complicates things.