### PR TITLE
JAVAFICATION: Move remaining Logstash::Timestamp Ruby Code to Java

### DIFF
--- a/logstash-core/lib/logstash/event.rb
+++ b/logstash-core/lib/logstash/event.rb
@@ -2,7 +2,6 @@
 
 require "logstash/namespace"
 require "logstash/json"
-require "logstash/timestamp"
 
 # transient pipeline events for normal in-flow signaling as opposed to
 # flow altering exceptions. for now having base classes is adequate and

--- a/logstash-core/lib/logstash/timestamp.rb
+++ b/logstash-core/lib/logstash/timestamp.rb
@@ -1,25 +1,2 @@
-# encoding: utf-8
-
-require "logstash/namespace"
-
-module LogStash
-
-  class Timestamp
-    include Comparable
-
-    def eql?(other)
-      self.== other
-    end
-
-    # TODO (colin) implement in Java
-    def +(other)
-      self.time + other
-    end
-
-    # TODO (colin) implement in Java
-    def -(value)
-      self.time - (value.is_a?(Timestamp) ? value.time : value)
-    end
-
-  end
-end
+# The contents of this file have been ported to Java. It is included for for compatibility
+# with plugins that directly require "logstash/timestamp".

--- a/logstash-core/spec/logstash/legacy_ruby_timestamp_spec.rb
+++ b/logstash-core/spec/logstash/legacy_ruby_timestamp_spec.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 require "spec_helper"
-require "logstash/timestamp"
 require "bigdecimal"
 
 describe LogStash::Timestamp do

--- a/logstash-core/spec/logstash/timestamp_spec.rb
+++ b/logstash-core/spec/logstash/timestamp_spec.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 require "spec_helper"
-require "logstash/timestamp"
 
 describe LogStash::Timestamp do
   context "constructors" do


### PR DESCRIPTION
Just resolving the todos here :)

Notes:
* Had to keep the `timestamp.rb` file, otherwise at least the date filter breaks
* I know there is an inconsistency between the `+` and `-` methods, I simply ported this 100% and it should probably be fixed. Didn't want to change behavior in this step though so I left it as is or easier reviewing :)
* Other than that the approach is pretty standard for JRuby I think, including `Comparable` doesn't actually inherit any methods => had to code the comparisons manually and did so exactly the same way it's done in `RubyString`