### PR TITLE
JAVAFICATION: Remove Ruby method_missing deprecation on Event

### DIFF
--- a/logstash-core/lib/logstash/event.rb
+++ b/logstash-core/lib/logstash/event.rb
@@ -33,21 +33,4 @@ module LogStash
   FLUSH = FlushEvent.new
   SHUTDOWN = ShutdownEvent.new
   NO_SIGNAL = NoSignal.new
-
-  class Event
-    MSG_BRACKETS_METHOD_MISSING = "Direct event field references (i.e. event['field']) have been disabled in favor of using event get and set methods (e.g. event.get('field')). Please consult the Logstash 5.0 breaking changes documentation for more details.".freeze
-    MSG_BRACKETS_EQUALS_METHOD_MISSING = "Direct event field references (i.e. event['field'] = 'value') have been disabled in favor of using event get and set methods (e.g. event.set('field', 'value')). Please consult the Logstash 5.0 breaking changes documentation for more details.".freeze
-    RE_BRACKETS_METHOD = /^\[\]$/.freeze
-    RE_BRACKETS_EQUALS_METHOD = /^\[\]=$/.freeze
-
-    def method_missing(method_name, *arguments, &block)
-      if RE_BRACKETS_METHOD.match(method_name.to_s)
-        raise NoMethodError.new(MSG_BRACKETS_METHOD_MISSING)
-      end
-      if RE_BRACKETS_EQUALS_METHOD.match(method_name.to_s)
-        raise NoMethodError.new(MSG_BRACKETS_EQUALS_METHOD_MISSING)
-      end
-      super
-    end
-  end
 end

--- a/logstash-core/spec/logstash/event_spec.rb
+++ b/logstash-core/spec/logstash/event_spec.rb
@@ -345,14 +345,6 @@ describe LogStash::Event do
   context "method missing exception messages" do
     subject { LogStash::Event.new({"foo" => "bar"}) }
 
-    it "#[] method raises a better exception message" do
-      expect { subject["foo"] }.to raise_error(NoMethodError, /Direct event field references \(i\.e\. event\['field'\]\)/)
-    end
-
-    it "#[]= method raises a better exception message" do
-      expect { subject["foo"] = "baz" }.to raise_error(NoMethodError, /Direct event field references \(i\.e\. event\['field'\] = 'value'\)/)
-    end
-
     it "other missing method raises normal exception message" do
       expect { subject.baz() }.to raise_error(NoMethodError, /undefined method `baz' for/)
     end


### PR DESCRIPTION
We're going for `7.0`, no need to keep this deprecation logic for `5.x` around any longer, especially when it taints the `Event` class that is otherwise set up in Java right?