### PR TITLE
Bump to 6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ For the daring, snapshot builds are available. These builds are created nightly 
 
 | artifact |
 | --- |
-| [tar](https://snapshots.elastic.co/downloads/logstash/logstash-6.2.0-SNAPSHOT.tar.gz) |
-| [zip](https://snapshots.elastic.co/downloads/logstash/logstash-6.2.0-SNAPSHOT.zip) |
-| [deb](https://snapshots.elastic.co/downloads/logstash/logstash-6.2.0-SNAPSHOT.deb) |
-| [rpm](https://snapshots.elastic.co/downloads/logstash/logstash-6.2.0-SNAPSHOT.rpm) |
+| [tar](https://snapshots.elastic.co/downloads/logstash/logstash-6.3.0-SNAPSHOT.tar.gz) |
+| [zip](https://snapshots.elastic.co/downloads/logstash/logstash-6.3.0-SNAPSHOT.zip) |
+| [deb](https://snapshots.elastic.co/downloads/logstash/logstash-6.3.0-SNAPSHOT.deb) |
+| [rpm](https://snapshots.elastic.co/downloads/logstash/logstash-6.3.0-SNAPSHOT.rpm) |
 
 ## Need Help?
 

--- a/versions.yml
+++ b/versions.yml
@@ -1,6 +1,6 @@
 ---
-logstash: 6.2.0
-logstash-core: 6.2.0
+logstash: 6.3.0
+logstash-core: 6.3.0
 logstash-core-plugin-api: 2.1.16
 
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url


### PR DESCRIPTION
6.2 branch has been created, so bumping version via `rake version:set[6.3.0]`