### PR TITLE
6.2.lockupdate

### DIFF
--- a/Gemfile.jruby-2.3.lock.release
+++ b/Gemfile.jruby-2.3.lock.release
@@ -1,0 +1,714 @@
+PATH
+  remote: ./logstash-core
+  specs:
+    logstash-core (6.1.2-java)
+      chronic_duration (= 0.10.6)
+      clamp (~> 0.6.5)
+      concurrent-ruby (~> 1.0, >= 1.0.5)
+      elasticsearch (~> 5.0, >= 5.0.4)
+      filesize (= 0.0.4)
+      gems (~> 0.8.3)
+      i18n (= 0.6.9)
+      jar-dependencies
+      jrjackson (~> 0.4.4)
+      jruby-openssl (>= 0.9.20)
+      manticore (>= 0.5.4, < 1.0.0)
+      minitar (~> 0.6.1)
+      pry (~> 0.10.1)
+      puma (~> 2.16)
+      rack (= 1.6.6)
+      ruby-maven (~> 3.3.9)
+      rubyzip (~> 1.2.1)
+      sinatra (~> 1.4, >= 1.4.6)
+      stud (~> 0.0.19)
+      thread_safe (~> 0.3.5)
+      treetop (< 1.5.0)
+
+PATH
+  remote: ./logstash-core-plugin-api
+  specs:
+    logstash-core-plugin-api (2.1.16-java)
+      logstash-core (= 6.1.2)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.3.8)
+    arr-pm (0.0.10)
+      cabin (> 0)
+    atomic (1.1.99-java)
+    avl_tree (1.2.1)
+      atomic (~> 1.1)
+    awesome_print (1.8.0)
+    aws-sdk (2.3.22)
+      aws-sdk-resources (= 2.3.22)
+    aws-sdk-core (2.3.22)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.3.22)
+      aws-sdk-core (= 2.3.22)
+    aws-sdk-v1 (1.67.0)
+      json (~> 1.4)
+      nokogiri (~> 1)
+    backports (3.10.3)
+    benchmark-ips (2.7.2)
+    bindata (2.4.1)
+    buftok (0.2.0)
+    builder (3.2.3)
+    cabin (0.9.0)
+    childprocess (0.8.0)
+      ffi (~> 1.0, >= 1.0.11)
+    chronic_duration (0.10.6)
+      numerizer (~> 0.1.1)
+    ci_reporter (2.0.0)
+      builder (>= 2.1.2)
+    ci_reporter_rspec (1.0.0)
+      ci_reporter (~> 2.0)
+      rspec (>= 2.14, < 4)
+    clamp (0.6.5)
+    coderay (1.1.2)
+    concurrent-ruby (1.0.5-java)
+    diff-lcs (1.3)
+    domain_name (0.5.20170404)
+      unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.2.1)
+    edn (1.1.1)
+    elasticsearch (5.0.4)
+      elasticsearch-api (= 5.0.4)
+      elasticsearch-transport (= 5.0.4)
+    elasticsearch-api (5.0.4)
+      multi_json
+    elasticsearch-transport (5.0.4)
+      faraday
+      multi_json
+    equalizer (0.0.10)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    ffi (1.9.18-java)
+    filesize (0.0.4)
+    filewatch (0.9.0)
+    fivemat (1.3.5)
+    flores (0.0.7)
+    fpm (1.3.3)
+      arr-pm (~> 0.0.9)
+      backports (>= 2.6.2)
+      cabin (>= 0.6.0)
+      childprocess
+      clamp (~> 0.6)
+      ffi
+      json (>= 1.7.7)
+    gelfd (0.2.0)
+    gem_publisher (1.5.0)
+    gems (0.8.3)
+    hitimes (1.2.6-java)
+    http (0.9.9)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 1.0.1)
+      http_parser.rb (~> 0.6.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    http-form_data (1.0.1)
+    http_parser.rb (0.6.0-java)
+    i18n (0.6.9)
+    insist (1.0.0)
+    jar-dependencies (0.3.12)
+    jls-grok (0.11.4)
+      cabin (>= 0.6.0)
+    jls-lumberjack (0.0.26)
+      concurrent-ruby
+    jmespath (1.3.1)
+    jrjackson (0.4.4-java)
+    jruby-openssl (0.9.21-java)
+    jruby-stdin-channel (0.2.0-java)
+    json (1.8.6-java)
+    json-schema (2.6.2)
+      addressable (~> 2.3.8)
+    kramdown (1.14.0)
+    logstash-codec-cef (5.0.2-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-collectd (3.0.8)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-dots (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-edn (3.0.6)
+      edn
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-edn_lines (3.0.6)
+      edn
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-es_bulk (3.0.6)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-fluent (3.1.5-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      msgpack (~> 1.1)
+    logstash-codec-graphite (3.0.5)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-json (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-json_lines (3.0.5)
+      logstash-codec-line (>= 2.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-line (3.0.8)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-msgpack (3.0.7-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      msgpack (~> 1.1)
+    logstash-codec-multiline (3.0.8)
+      jls-grok (~> 0.11.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-patterns-core
+    logstash-codec-netflow (3.10.0)
+      bindata (>= 1.5.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-plain (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-rubydebug (3.0.5)
+      awesome_print
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-devutils (1.3.5-java)
+      fivemat
+      gem_publisher
+      insist (= 1.0.0)
+      kramdown (= 1.14.0)
+      logstash-core-plugin-api (>= 2.0, <= 2.99)
+      minitar
+      rake
+      rspec (~> 3.0)
+      rspec-wait
+      stud (>= 0.0.20)
+    logstash-filter-aggregate (2.7.2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-anonymize (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      murmurhash3
+    logstash-filter-cidr (3.1.2-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-clone (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-csv (3.0.7)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-date (3.1.9)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-de_dot (1.0.3)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-dissect (1.1.2)
+      jar-dependencies
+      logstash-core-plugin-api (>= 2.1.1, <= 2.99)
+    logstash-filter-dns (3.0.7)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      lru_redux (~> 1.1.0)
+    logstash-filter-drop (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-elasticsearch (3.2.1)
+      elasticsearch (>= 5.0.3, < 6.0.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-fingerprint (3.1.2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      murmurhash3
+    logstash-filter-geoip (5.0.3-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-grok (4.0.1)
+      jls-grok (~> 0.11.3)
+      logstash-core (>= 5.6.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-patterns-core
+      stud (~> 0.0.22)
+    logstash-filter-jdbc_streaming (1.0.3)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      lru_redux
+      sequel
+    logstash-filter-json (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-kv (4.0.3)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-metrics (4.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      metriks
+      thread_safe
+    logstash-filter-mutate (3.2.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-ruby (3.1.3)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-filter-date
+    logstash-filter-sleep (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-split (3.1.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-syslog_pri (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-throttle (4.0.4)
+      atomic
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      thread_safe
+    logstash-filter-translate (3.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-truncate (1.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-urldecode (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-useragent (3.2.2-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-xml (4.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      nokogiri
+      xml-simple
+    logstash-input-beats (5.0.6-java)
+      concurrent-ruby (~> 1.0)
+      jar-dependencies (~> 0.3.4)
+      logstash-codec-multiline (>= 2.0.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      thread_safe (~> 0.3.5)
+    logstash-input-dead_letter_queue (1.1.2)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-input-elasticsearch (4.1.1)
+      elasticsearch (>= 5.0.3, < 6.0.0)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-input-exec (3.1.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (~> 0.0.22)
+    logstash-input-file (4.0.3)
+      addressable
+      filewatch (~> 0.8, >= 0.8.1)
+      logstash-codec-multiline (~> 3.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-input-ganglia (3.1.3)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (~> 0.0.22)
+    logstash-input-gelf (3.0.7)
+      gelfd (= 0.2.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (~> 0.0.22)
+    logstash-input-generator (3.0.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-input-graphite (3.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-input-tcp
+    logstash-input-heartbeat (3.0.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud
+    logstash-input-http (3.0.8)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      puma (~> 2.16, >= 2.16.0)
+      rack (~> 1)
+      stud
+    logstash-input-http_poller (4.0.4)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-http_client (>= 6.0.0, < 7.0.0)
+      rufus-scheduler (~> 3.0.9)
+      stud (~> 0.0.22)
+    logstash-input-imap (3.0.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      mail (~> 2.6.3)
+      mime-types (= 2.6.2)
+      stud (~> 0.0.22)
+    logstash-input-jdbc (4.3.3)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      rufus-scheduler
+      sequel
+      tzinfo
+      tzinfo-data
+    logstash-input-kafka (8.0.4)
+      logstash-codec-json
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (>= 0.0.22, < 0.1.0)
+    logstash-input-pipe (3.0.6)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (~> 0.0.22)
+    logstash-input-rabbitmq (6.0.2)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-rabbitmq_connection (>= 5.0.0, < 6.0.0)
+    logstash-input-redis (3.1.6)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      redis (~> 3)
+    logstash-input-s3 (3.2.0)
+      logstash-core-plugin-api (>= 2.1.12, <= 2.99)
+      logstash-mixin-aws
+      stud (~> 0.0.18)
+    logstash-input-snmptrap (3.0.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      snmp
+    logstash-input-sqs (3.0.6)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-aws (>= 1.0.0)
+    logstash-input-stdin (3.2.5)
+      concurrent-ruby
+      jruby-stdin-channel
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-input-syslog (3.2.4)
+      concurrent-ruby
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-filter-date
+      logstash-filter-grok
+      stud (>= 0.0.22, < 0.1.0)
+      thread_safe
+    logstash-input-tcp (5.0.3-java)
+      logstash-codec-json
+      logstash-codec-json_lines
+      logstash-codec-line
+      logstash-codec-multiline
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-input-twitter (3.0.7)
+      http-form_data (<= 1.0.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      public_suffix (<= 1.4.6)
+      stud (>= 0.0.22, < 0.1)
+      twitter (= 5.15.0)
+    logstash-input-udp (3.2.1)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (~> 0.0.22)
+    logstash-input-unix (3.0.6)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-mixin-aws (4.2.3)
+      aws-sdk (~> 2.3.0)
+      aws-sdk-v1 (>= 1.61.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-mixin-http_client (6.0.1)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      manticore (>= 0.5.2, < 1.0.0)
+    logstash-mixin-rabbitmq_connection (5.0.1-java)
+      march_hare (~> 3.0)
+      stud (~> 0.0.22)
+    logstash-output-cloudwatch (3.0.7)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-aws (>= 1.0.0)
+      rufus-scheduler (~> 3.0.9)
+    logstash-output-csv (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-filter-json
+      logstash-input-generator
+      logstash-output-file
+    logstash-output-elasticsearch (9.0.2-java)
+      cabin (~> 0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      manticore (>= 0.5.4, < 1.0.0)
+      stud (~> 0.0, >= 0.0.17)
+    logstash-output-email (4.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      mail (~> 2.6.3)
+      mime-types (< 3)
+    logstash-output-file (4.2.1)
+      logstash-codec-json_lines
+      logstash-codec-line
+      logstash-core-plugin-api (>= 2.0.0, < 2.99)
+    logstash-output-graphite (3.1.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-http (5.1.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-http_client (>= 6.0.0, < 7.0.0)
+    logstash-output-kafka (7.0.6)
+      logstash-codec-json
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-lumberjack (3.1.5)
+      jls-lumberjack (>= 0.0.26)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud
+    logstash-output-nagios (3.0.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-null (3.0.4)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-pagerduty (3.0.6)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-pipe (3.0.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-rabbitmq (5.0.3-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-rabbitmq_connection (>= 5.0.0, < 6.0.0)
+    logstash-output-redis (4.0.3)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      redis (~> 3)
+      stud
+    logstash-output-s3 (4.0.13)
+      concurrent-ruby
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-aws
+      stud (~> 0.0.22)
+    logstash-output-sns (4.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-aws (>= 1.0.0)
+    logstash-output-sqs (5.0.2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-aws (>= 1.0.0)
+    logstash-output-stdout (3.1.3)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60.1, < 2.99)
+    logstash-output-tcp (5.0.2)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud
+    logstash-output-udp (3.0.5)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-webhdfs (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      snappy (= 0.0.12)
+      webhdfs
+    logstash-patterns-core (4.1.2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    lru_redux (1.1.0)
+    mail (2.6.6)
+      mime-types (>= 1.16, < 4)
+    manticore (0.6.1-java)
+    march_hare (3.0.0-java)
+    memoizable (0.4.2)
+      thread_safe (~> 0.3, >= 0.3.1)
+    method_source (0.8.2)
+    metriks (0.9.9.8)
+      atomic (~> 1.0)
+      avl_tree (~> 1.2.0)
+      hitimes (~> 1.1)
+    mime-types (2.6.2)
+    minitar (0.6.1)
+    msgpack (1.2.1-java)
+    multi_json (1.13.0)
+    multipart-post (2.0.0)
+    murmurhash3 (0.1.6-java)
+    mustache (0.99.8)
+    naught (1.1.0)
+    nokogiri (1.8.1-java)
+    numerizer (0.1.1)
+    octokit (3.8.0)
+      sawyer (~> 0.6.0, >= 0.5.3)
+    paquet (0.2.1)
+    pleaserun (0.0.30)
+      cabin (> 0)
+      clamp
+      dotenv
+      insist
+      mustache (= 0.99.8)
+      stud
+    polyglot (0.3.5)
+    pry (0.10.4-java)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+      spoon (~> 0.0)
+    public_suffix (1.4.6)
+    puma (2.16.0-java)
+    rack (1.6.6)
+    rack-protection (1.5.3)
+      rack
+    rack-test (0.8.2)
+      rack (>= 1.0, < 3)
+    rake (12.3.0)
+    redis (3.3.5)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.0)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.0)
+    rspec-wait (0.0.9)
+      rspec (>= 3, < 4)
+    ruby-maven (3.3.12)
+      ruby-maven-libs (~> 3.3.9)
+    ruby-maven-libs (3.3.9)
+    ruby-progressbar (1.8.3)
+    rubyzip (1.2.1)
+    rufus-scheduler (3.0.9)
+      tzinfo
+    sawyer (0.6.0)
+      addressable (~> 2.3.5)
+      faraday (~> 0.8, < 0.10)
+    sequel (5.4.0)
+    simple_oauth (0.3.1)
+    sinatra (1.4.8)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    slop (3.6.0)
+    snappy (0.0.12-java)
+      snappy-jars (~> 1.1.0)
+    snappy-jars (1.1.0.1.2-java)
+    snmp (1.2.0)
+    spoon (0.0.6)
+      ffi
+    stud (0.0.23)
+    term-ansicolor (1.3.2)
+      tins (~> 1.0)
+    thread_safe (0.3.6-java)
+    tilt (2.0.8)
+    tins (1.6.0)
+    treetop (1.4.15)
+      polyglot
+      polyglot (>= 0.3.1)
+    twitter (5.15.0)
+      addressable (~> 2.3)
+      buftok (~> 0.2.0)
+      equalizer (= 0.0.10)
+      faraday (~> 0.9.0)
+      http (>= 0.4, < 0.10)
+      http_parser.rb (~> 0.6.0)
+      json (~> 1.8)
+      memoizable (~> 0.4.0)
+      naught (~> 1.0)
+      simple_oauth (~> 0.3.0)
+    tzinfo (1.2.4)
+      thread_safe (~> 0.1)
+    tzinfo-data (1.2017.3)
+      tzinfo (>= 1.0.0)
+    unf (0.1.4-java)
+    webhdfs (0.8.0)
+      addressable
+    webrick (1.3.1)
+    xml-simple (1.1.5)
+
+PLATFORMS
+  java
+
+DEPENDENCIES
+  benchmark-ips
+  builder (~> 3.2.2)
+  ci_reporter_rspec (= 1.0.0)
+  flores (~> 0.0.6)
+  fpm (~> 1.3.3)
+  gems (~> 0.8.3)
+  json-schema (~> 2.6)
+  logstash-codec-cef
+  logstash-codec-collectd
+  logstash-codec-dots
+  logstash-codec-edn
+  logstash-codec-edn_lines
+  logstash-codec-es_bulk
+  logstash-codec-fluent
+  logstash-codec-graphite
+  logstash-codec-json
+  logstash-codec-json_lines
+  logstash-codec-line
+  logstash-codec-msgpack
+  logstash-codec-multiline
+  logstash-codec-netflow
+  logstash-codec-plain
+  logstash-codec-rubydebug
+  logstash-core!
+  logstash-core-plugin-api!
+  logstash-devutils (= 1.3.5)
+  logstash-filter-aggregate
+  logstash-filter-anonymize
+  logstash-filter-cidr
+  logstash-filter-clone
+  logstash-filter-csv
+  logstash-filter-date
+  logstash-filter-de_dot
+  logstash-filter-dissect
+  logstash-filter-dns
+  logstash-filter-drop
+  logstash-filter-elasticsearch
+  logstash-filter-fingerprint
+  logstash-filter-geoip
+  logstash-filter-grok
+  logstash-filter-jdbc_streaming
+  logstash-filter-json
+  logstash-filter-kv
+  logstash-filter-metrics
+  logstash-filter-mutate
+  logstash-filter-ruby
+  logstash-filter-sleep
+  logstash-filter-split
+  logstash-filter-syslog_pri
+  logstash-filter-throttle
+  logstash-filter-translate
+  logstash-filter-truncate
+  logstash-filter-urldecode
+  logstash-filter-useragent
+  logstash-filter-xml
+  logstash-input-beats
+  logstash-input-dead_letter_queue
+  logstash-input-elasticsearch
+  logstash-input-exec
+  logstash-input-file
+  logstash-input-ganglia
+  logstash-input-gelf
+  logstash-input-generator
+  logstash-input-graphite
+  logstash-input-heartbeat
+  logstash-input-http
+  logstash-input-http_poller
+  logstash-input-imap
+  logstash-input-jdbc
+  logstash-input-kafka
+  logstash-input-pipe
+  logstash-input-rabbitmq
+  logstash-input-redis
+  logstash-input-s3
+  logstash-input-snmptrap
+  logstash-input-sqs
+  logstash-input-stdin
+  logstash-input-syslog
+  logstash-input-tcp
+  logstash-input-twitter
+  logstash-input-udp
+  logstash-input-unix
+  logstash-output-cloudwatch
+  logstash-output-csv
+  logstash-output-elasticsearch
+  logstash-output-email
+  logstash-output-file
+  logstash-output-graphite
+  logstash-output-http
+  logstash-output-kafka
+  logstash-output-lumberjack
+  logstash-output-nagios
+  logstash-output-null
+  logstash-output-pagerduty
+  logstash-output-pipe
+  logstash-output-rabbitmq
+  logstash-output-redis
+  logstash-output-s3 (>= 4.0.9, < 5.0.0)
+  logstash-output-sns
+  logstash-output-sqs
+  logstash-output-stdout
+  logstash-output-tcp
+  logstash-output-udp
+  logstash-output-webhdfs
+  octokit (= 3.8.0)
+  paquet (~> 0.2.0)
+  pleaserun (~> 0.0.28)
+  rack-test
+  rspec (~> 3.5)
+  ruby-progressbar (~> 1.8.1)
+  rubyzip (~> 1.2.1)
+  stud (~> 0.0.22)
+  term-ansicolor (~> 1.3.2)
+  tins (= 1.6)
+  webrick (~> 1.3.1)

--- a/Gemfile.jruby-2.3.lock.release
+++ b/Gemfile.jruby-2.3.lock.release
@@ -1,7 +1,7 @@
 PATH
   remote: ./logstash-core
   specs:
-    logstash-core (6.1.2-java)
+    logstash-core (6.2.0-java)
       chronic_duration (= 0.10.6)
       clamp (~> 0.6.5)
       concurrent-ruby (~> 1.0, >= 1.0.5)
@@ -9,7 +9,6 @@ PATH
       filesize (= 0.0.4)
       gems (~> 0.8.3)
       i18n (= 0.6.9)
-      jar-dependencies
       jrjackson (~> 0.4.4)
       jruby-openssl (>= 0.9.20)
       manticore (>= 0.5.4, < 1.0.0)
@@ -17,7 +16,6 @@ PATH
       pry (~> 0.10.1)
       puma (~> 2.16)
       rack (= 1.6.6)
-      ruby-maven (~> 3.3.9)
       rubyzip (~> 1.2.1)
       sinatra (~> 1.4, >= 1.4.6)
       stud (~> 0.0.19)
@@ -28,7 +26,7 @@ PATH
   remote: ./logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 6.1.2)
+      logstash-core (= 6.2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -49,7 +47,7 @@ GEM
     aws-sdk-v1 (1.67.0)
       json (~> 1.4)
       nokogiri (~> 1)
-    backports (3.10.3)
+    backports (3.11.0)
     benchmark-ips (2.7.2)
     bindata (2.4.1)
     buftok (0.2.0)
@@ -156,7 +154,7 @@ GEM
     logstash-codec-msgpack (3.0.7-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       msgpack (~> 1.1)
-    logstash-codec-multiline (3.0.8)
+    logstash-codec-multiline (3.0.9)
       jls-grok (~> 0.11.1)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-patterns-core
@@ -188,7 +186,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-clone (3.0.5)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-csv (3.0.7)
+    logstash-filter-csv (3.0.8)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-date (3.1.9)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -202,7 +200,7 @@ GEM
       lru_redux (~> 1.1.0)
     logstash-filter-drop (3.0.5)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-elasticsearch (3.2.1)
+    logstash-filter-elasticsearch (3.3.0)
       elasticsearch (>= 5.0.3, < 6.0.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-fingerprint (3.1.2)
@@ -216,6 +214,12 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-patterns-core
       stud (~> 0.0.22)
+    logstash-filter-jdbc_static (1.0.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      rufus-scheduler
+      sequel
+      tzinfo
+      tzinfo-data
     logstash-filter-jdbc_streaming (1.0.3)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       lru_redux
@@ -265,10 +269,15 @@ GEM
     logstash-input-dead_letter_queue (1.1.2)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-input-elasticsearch (4.1.1)
+    logstash-input-elasticsearch (4.2.0)
       elasticsearch (>= 5.0.3, < 6.0.0)
       logstash-codec-json
+      logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
+      rufus-scheduler
+      sequel
+      tzinfo
+      tzinfo-data
     logstash-input-exec (3.1.5)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -283,7 +292,7 @@ GEM
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       stud (~> 0.0.22)
-    logstash-input-gelf (3.0.7)
+    logstash-input-gelf (3.1.0)
       gelfd (= 0.2.0)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -411,20 +420,21 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       manticore (>= 0.5.4, < 1.0.0)
       stud (~> 0.0, >= 0.0.17)
-    logstash-output-email (4.0.6)
+    logstash-output-email (4.1.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       mail (~> 2.6.3)
       mime-types (< 3)
+      mustache (>= 0.99.8)
     logstash-output-file (4.2.1)
       logstash-codec-json_lines
       logstash-codec-line
       logstash-core-plugin-api (>= 2.0.0, < 2.99)
     logstash-output-graphite (3.1.4)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-output-http (5.1.1)
+    logstash-output-http (5.2.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-http_client (>= 6.0.0, < 7.0.0)
-    logstash-output-kafka (7.0.6)
+    logstash-output-kafka (7.0.7)
       logstash-codec-json
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -444,7 +454,7 @@ GEM
     logstash-output-pipe (3.0.5)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-output-rabbitmq (5.0.3-java)
+    logstash-output-rabbitmq (5.1.0-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-rabbitmq_connection (>= 5.0.0, < 6.0.0)
     logstash-output-redis (4.0.3)
@@ -492,8 +502,8 @@ GEM
       hitimes (~> 1.1)
     mime-types (2.6.2)
     minitar (0.6.1)
-    msgpack (1.2.1-java)
-    multi_json (1.13.0)
+    msgpack (1.2.2-java)
+    multi_json (1.13.1)
     multipart-post (2.0.0)
     murmurhash3 (0.1.6-java)
     mustache (0.99.8)
@@ -529,7 +539,7 @@ GEM
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
       rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.0)
+    rspec-core (3.7.1)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -540,9 +550,6 @@ GEM
     rspec-support (3.7.0)
     rspec-wait (0.0.9)
       rspec (>= 3, < 4)
-    ruby-maven (3.3.12)
-      ruby-maven-libs (~> 3.3.9)
-    ruby-maven-libs (3.3.9)
     ruby-progressbar (1.8.3)
     rubyzip (1.2.1)
     rufus-scheduler (3.0.9)
@@ -637,6 +644,7 @@ DEPENDENCIES
   logstash-filter-fingerprint
   logstash-filter-geoip
   logstash-filter-grok
+  logstash-filter-jdbc_static
   logstash-filter-jdbc_streaming
   logstash-filter-json
   logstash-filter-kv


### PR DESCRIPTION
Introduce the Gemfile lock on the (new) 6.2 branch.  Diff the to commits in this PR to see the difference since 6.1 : https://github.com/elastic/logstash/pull/8972/commits/5f8fb6b004bd639856e5f1a0bf19aee03365b170