### PR TITLE
test fix: use single worker in test to avoid concurrency issue in sleep filter

### DIFF
--- a/qa/integration/specs/slowlog_spec.rb
+++ b/qa/integration/specs/slowlog_spec.rb
@@ -36,7 +36,7 @@ describe "Test Logstash Slowlog" do
       "slowlog.threshold.warn" => "500ms"
     }
     IO.write(@ls.application_settings_file, settings.to_yaml)
-    @ls.spawn_logstash("-e", config)
+    @ls.spawn_logstash("-w", "1" , "-e", config)
     @ls.wait_for_logstash
     sleep 2 until @ls.exited?
     slowlog_file = "#{temp_dir}/logstash-slowlog-plain.log"


### PR DESCRIPTION
Per @original-brownbear [comment](https://github.com/elastic/logstash/issues/8073#issuecomment-330681296) setting the workers to 1 can fix this issue. ...so this PR sets the workers to 1.  Kinda an ugly 'fix' , but the test is valid independent of how many workers are configured. 

See: https://github.com/elastic/logstash/issues/8073
See: https://github.com/logstash-plugins/logstash-filter-sleep/issues/7

Fixes: #8974