### PR TITLE
verify available disk space for PQ.

### DIFF
--- a/logstash-core/lib/logstash/bootstrap_check/persisted_queue_config.rb
+++ b/logstash-core/lib/logstash/bootstrap_check/persisted_queue_config.rb
@@ -1,0 +1,15 @@
+# encoding: utf-8
+require 'logstash/errors'
+
+module LogStash
+  module BootstrapCheck
+    class PersistedQueueConfig
+      def self.check(settings)
+        return unless settings.get('queue.type') == 'persisted'
+        if settings.get('queue.page_capacity') > settings.get('queue.max_bytes')
+          raise(LogStash::BootstrapCheckError, I18n.t("logstash.bootstrap_check.persisted_queue_config.page-capacity"))
+        end
+      end
+    end
+  end
+end

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -25,6 +25,7 @@ require "logstash/modules/util"
 require "logstash/bootstrap_check/default_config"
 require "logstash/bootstrap_check/bad_java"
 require "logstash/bootstrap_check/bad_ruby"
+require "logstash/bootstrap_check/persisted_queue_config"
 require "set"
 
 java_import 'org.logstash.FileLockFactory'
@@ -39,7 +40,8 @@ class LogStash::Runner < Clamp::StrictCommand
   DEFAULT_BOOTSTRAP_CHECKS = [
       LogStash::BootstrapCheck::BadRuby,
       LogStash::BootstrapCheck::BadJava,
-      LogStash::BootstrapCheck::DefaultConfig
+      LogStash::BootstrapCheck::DefaultConfig,
+      LogStash::BootstrapCheck::PersistedQueueConfig
   ]
 
   # Node Settings

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -8,6 +8,10 @@ en:
   logstash:
     error: >-
       Error: %{error}
+    bootstrap_check:
+      persisted_queue_config:
+        page-capacity: >-
+          Invalid configuration, 'queue.page_capacity' must be less than or equal to 'queue.max_bytes'
     environment:
       jruby-required:  >-
         JRuby is required

--- a/logstash-core/spec/logstash/bootstrap_check/persisted_queue_config_spec.rb
+++ b/logstash-core/spec/logstash/bootstrap_check/persisted_queue_config_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+require "tmpdir"
+require "logstash/bootstrap_check/persisted_queue_config"
+
+describe LogStash::BootstrapCheck::PersistedQueueConfig do
+
+  context("when persisted queues are enabled") do
+    let(:settings) do
+      settings = LogStash::SETTINGS.dup
+      settings.set_value("queue.type", "persisted")
+      settings.set_value("queue.page_capacity", 1024)
+      settings.set_value("path.queue", ::File.join(Dir.tmpdir, "some/path"))
+      settings
+    end
+
+    context("and 'queue.max_bytes' is set to a value less than the value of 'queue.page_capacity'") do
+      it "should throw" do
+        settings.set_value("queue.max_bytes", 512)
+        expect { LogStash::BootstrapCheck::PersistedQueueConfig.check(settings) }.to raise_error
+      end
+    end
+  end
+end

--- a/logstash-core/src/main/java/org/logstash/common/FsUtil.java
+++ b/logstash-core/src/main/java/org/logstash/common/FsUtil.java
@@ -1,0 +1,41 @@
+package org.logstash.common;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * File System Utility Methods.
+ */
+public final class FsUtil {
+
+    private FsUtil() {
+    }
+
+    /**
+     * Checks if the request number of bytes of free disk space are available under the given
+     * path.
+     * @param path Directory to check
+     * @param size Bytes of free space requested
+     * @return True iff the
+     * @throws IOException on failure to determine free space for given path's partition
+     */
+    public static boolean hasFreeSpace(final String path, final long size)
+        throws IOException
+    {
+        final Set<File> partitionRoots = new HashSet<>(Arrays.asList(File.listRoots()));
+
+        // crawl up file path until we find a root partition
+        File location = new File(path).getCanonicalFile();
+        while (!partitionRoots.contains(location)) {
+            location = location.getParentFile();
+            if (location == null) {
+                throw new IllegalStateException(String.format("Unable to determine the partition that contains '%s'", path));
+            }
+        }
+
+        return location.getFreeSpace() >= size;
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/common/FsUtilTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/FsUtilTest.java
@@ -1,0 +1,40 @@
+package org.logstash.common;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests for {@link FsUtil}.
+ */
+public final class FsUtilTest {
+
+    @Rule
+    public final TemporaryFolder temp = new TemporaryFolder();
+
+    /**
+     * {@link FsUtil#hasFreeSpace(String, long)} should return true when asked for 1kb of free
+     * space in a subfolder of the system's TEMP location.
+     */
+    @Test
+    public void trueIfEnoughSpace() throws Exception {
+        MatcherAssert.assertThat(
+                FsUtil.hasFreeSpace(temp.newFolder().getAbsolutePath(), 1024L),
+                CoreMatchers.is(true)
+        );
+    }
+
+    /**
+     * {@link FsUtil#hasFreeSpace(String, long)} should return false when asked for
+     * {@link Long#MAX_VALUE} of free space in a subfolder of the system's TEMP location.
+     */
+    @Test
+    public void falseIfNotEnoughSpace() throws Exception {
+        MatcherAssert.assertThat(
+                FsUtil.hasFreeSpace(temp.newFolder().getAbsolutePath(), Long.MAX_VALUE),
+                CoreMatchers.is(false)
+        );
+    }
+}


### PR DESCRIPTION
This is a reboot of #6998 originally by @original-brownbear.

Fixes #6552 

* Implemented free disk space check in Java
* Added JUnit test for the Java file system logic
* Added new bootstrap check to checks against the max of (`queue.max_bytes` and `queue.page_capacity`)
* `Queue.open()` will throw an exception if there is not enough disk space to allocate  `queue.max_bytes`  minus existing pages sizes.