### PR TITLE
fix integration tests build

### DIFF
--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -1,3 +1,21 @@
+# This script is used to initialize a number of env variables and setup the
+# runtime environment of logstash. It sets to following env variables:
+#   LOGSTASH_HOME & LS_HOME
+#   SINCEDB_DIR
+#   JAVACMD
+#   JAVA_OPTS
+#   GEM_HOME & GEM_PATH
+#   DEBUG
+#
+# These functions are provided for the calling script:
+#   setup() to setup the environment
+#   ruby_exec() to execute a ruby script with using the setup runtime environment
+#
+# The following env var will be used by this script if set:
+#   LS_GEM_HOME and LS_GEM_PATH to overwrite the path assigned to GEM_HOME and GEM_PATH
+#   LS_JAVA_OPTS to append extra options to the JVM options provided by logstash
+#   JAVA_HOME to point to the java home
+
 unset CDPATH
 # This unwieldy bit of scripting is to try to catch instances where Logstash
 # was launched from a symlink, rather than a full path to the Logstash binary
@@ -116,8 +134,24 @@ setup_vendored_jruby() {
     echo "If you are a developer, please run 'rake bootstrap'. Running 'rake' requires the 'ruby' program be available."
     exit 1
   fi
-  export GEM_HOME="${LOGSTASH_HOME}/vendor/bundle/jruby/2.3.0"
-  export GEM_PATH=${GEM_HOME}
+
+  if [ -z "$LS_GEM_HOME" ] ; then
+    export GEM_HOME="${LOGSTASH_HOME}/vendor/bundle/jruby/2.3.0"
+  else
+    export GEM_HOME=${LS_GEM_HOME}
+  fi
+  if [ "$DEBUG" ] ; then
+    echo "Using GEM_HOME=${GEM_HOME}"
+  fi
+
+  if [ -z "$LS_GEM_PATH" ] ; then
+    export GEM_PATH=${GEM_HOME}
+  else
+    export GEM_PATH=${LS_GEM_PATH}
+  fi
+  if [ "$DEBUG" ] ; then
+    echo "Using GEM_PATH=${GEM_PATH}"
+  fi
 }
 
 setup() {

--- a/bin/ruby
+++ b/bin/ruby
@@ -5,12 +5,10 @@
 #   bin/ruby [arguments]
 #
 # Supported environment variables:
-#   LS_JVM_OPTS="xxx" path to file with JVM options
-#   LS_JAVA_OPTS="xxx" to append extra options to the defaults JAVA_OPTS provided by logstash
-#   JAVA_OPTS="xxx" to *completely override* the default set of JAVA_OPTS provided by logstash
+#   LS_JAVA_OPTS="xxx" to append extra options to the JVM options provided by logstash
+#   LS_GEM_HOME and LS_GEM_PATH to overwrite the path assigned to GEM_HOME and GEM_PATH
 #
 # Development environment variables:
-#   USE_RUBY=1 to force use the local "ruby" command to launch logstash instead of using the vendored JRuby
 #   DEBUG=1 to output debugging information
 
 # use faster starting JRuby options see https://github.com/jruby/jruby/wiki/Improving-startup-time

--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,9 @@ clean {
   delete "${projectDir}/Gemfile.lock"
   delete "${projectDir}/vendor"
   delete "${projectDir}/NOTICE.TXT"
+  delete "${projectDir}/.bundle"
+  delete "${projectDir}/qa/integration/Gemfile.lock"
+  delete "${projectDir}/qa/integration/.bundle"
 }
 
 task bootstrap {}
@@ -143,13 +146,16 @@ task downloadAndInstallJRuby(dependsOn: verifyFile, type: Copy) {
 def jrubyBin = "${projectDir}/vendor/jruby/bin/jruby" +
   (System.getProperty("os.name").startsWith("Windows") ? '.bat' : '')
 
+def rubyBin = "${projectDir}/bin/ruby" +
+  (System.getProperty("os.name").startsWith("Windows") ? '.bat' : '')
+
 task installTestGems(dependsOn: downloadAndInstallJRuby) {
   inputs.files file("${projectDir}/Gemfile.template")
   inputs.files fileTree("${projectDir}/rakelib")
   inputs.files file("${projectDir}/versions.yml")
   outputs.files file("${projectDir}/Gemfile")
   outputs.files file("${projectDir}/Gemfile.lock")
-  outputs.files fileTree("${projectDir}/vendor/bundle/gems")
+  outputs.files fileTree("${projectDir}/vendor/bundle/jruby/2.3.0/gems")
   outputs.files fileTree("${projectDir}/vendor/jruby")
   doLast {
     rubyGradleUtils.rake('test:install-core')
@@ -196,46 +202,47 @@ task unpackTarDistribution(dependsOn: assembleTarDistribution, type: Copy) {
   into {buildDir}
 }
 
-def bundleBin = "${projectDir}/vendor/bundle/jruby/2.3.0/bin/bundle"
-def gemPath = "${buildDir}/qa/integration/gems"
+def qaVendorPath = "${buildDir}/qa/integration/vendor"
+def qaBundledGemPath = "${qaVendorPath}/jruby/2.3.0"
+def qaBundleBin = "${qaBundledGemPath}/bin/bundle"
 
 task installIntegrationTestBundler(dependsOn: unpackTarDistribution, type: Exec) {
-  outputs.files fileTree("${gemPath}/gems/bundler-1.16.0")
-  environment "GEM_PATH", gemPath
-  environment "GEM_HOME", gemPath
+  outputs.files fileTree("${qaBundledGemPath}/gems/bundler-1.16.0")
   standardOutput = new ExecLogOutputStream(System.out)
   errorOutput =  new ExecLogOutputStream(System.err)
-  commandLine jrubyBin, "${projectDir}/vendor/jruby/bin/gem", "install", "bundler", "-v", "1.16.0"
+  // directly invoke bin/gem to install bundlers and force install dir "-i" into qaBundledGemPath
+  commandLine "${projectDir}/vendor/jruby/bin/gem", "install", "bundler", "-v", "1.16.0", "-i", qaBundledGemPath
 }
 
 task installIntegrationTestGems(dependsOn: installIntegrationTestBundler, type: Exec) {
   workingDir "${projectDir}/qa/integration"
-  environment "GEM_PATH", gemPath
-  environment "GEM_HOME", gemPath
   inputs.files file("${projectDir}/qa/integration/Gemfile")
+  inputs.files file("${projectDir}/qa/integration/integration_tests.gemspec")
   inputs.files file("${logstashBuildDir}/Gemfile")
   inputs.files file("${logstashBuildDir}/Gemfile.lock")
   inputs.files file("${logstashBuildDir}/logstash-core/logstash-core.gemspec")
-  inputs.files file("${projectDir}/qa/integration/integration_tests.gemspec")
-  outputs.files fileTree("${gemPath}/gems")
+  outputs.files fileTree("${qaVendorPath}")
   outputs.files file("${projectDir}/qa/integration/Gemfile.lock")
   standardOutput = new ExecLogOutputStream(System.out)
   errorOutput =  new ExecLogOutputStream(System.err)
-  commandLine jrubyBin, bundleBin, "install"
+  // directly invoke bin/bundler and force install gem path to qaVendorPath
+  // note that bundler appends jruby/2.3.0 to the install path
+  commandLine qaBundleBin, "install", "--path", qaVendorPath
 }
 
 def rubyIntegrationSpecs = project.hasProperty("rubyIntegrationSpecs") ? ((String) project.property("rubyIntegrationSpecs")).split(/\s+/) : []
 
 task runIntegrationTests(dependsOn: installIntegrationTestGems, type: Exec) {
   workingDir "${projectDir}/qa/integration"
-  environment "JAVA_OPTS", ""
-  environment "GEM_PATH", gemPath
-  environment "GEM_HOME", gemPath
+  environment "LS_GEM_PATH", qaBundledGemPath
+  environment "LS_GEM_HOME", qaBundledGemPath
   // FEATURE_FLAG is set in the CI to configure testing with enabled PQ
   environment "FEATURE_FLAG", System.getenv('FEATURE_FLAG')
   standardOutput = new ExecLogOutputStream(System.out)
   errorOutput =  new ExecLogOutputStream(System.err)
-  commandLine([jrubyBin, bundleBin, "exec", "rspec"].plus((Collection<String>)rubyIntegrationSpecs))
+  // indirect launching of bin/bundle via bin/ruby so that the bundle exec command inherit
+  // the correct gem path environment which is not settable by command line
+  commandLine([rubyBin, qaBundleBin, "exec", "rspec"].plus((Collection<String>)rubyIntegrationSpecs))
 }
 
 // If you are running a JRuby snapshot we will skip the integrity check.
@@ -244,3 +251,4 @@ bootstrap.dependsOn installTestGems
 
 runIntegrationTests.shouldRunAfter tasks.getByPath(":logstash-core:test")
 check.dependsOn runIntegrationTests
+


### PR DESCRIPTION
This is reboot of #8914 and it introduces the following changes:
- Allow overriding the `GEM_HOME` and `GEM_PATH` in `logstash.lib.sh`. This is useful when launching the integration tests through `bin/ruby` to make sure `GEM_HOME` and `GEM_PATH` will not be inherited by any local shell initialization.
- Adds a few missing clean paths
- Directly invoke `gem` and `bundler` in the integration tests setups.
- Invoke the integration specs through `bin/ruby` and not `vendor/jruby/bin/jruby` to avoid any `GEM_HOME` and `GEM_PATH` problem