### PR TITLE
JAVAFICATION: Port memory queue read client to Java. …

### DIFF
--- a/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_synchronous_queue.rb
@@ -17,112 +17,11 @@ module LogStash; module Util
     end
 
     def read_client
-      ReadClient.new(@queue)
+      LogStash::MemoryReadClient.new(@queue, 125, 50)
     end
 
     def close
       # ignore
-    end
-
-    class ReadClient
-      # We generally only want one thread at a time able to access pop/take/poll operations
-      # from this queue. We also depend on this to be able to block consumers while we snapshot
-      # in-flight buffers
-
-      def initialize(queue, batch_size = 125, wait_for = 50)
-        @queue = queue
-        # Note that @inflight_batches as a central mechanism for tracking inflight
-        # batches will fail if we have multiple read clients in the pipeline.
-        @inflight_batches = Concurrent::Map.new
-
-        # allow the worker thread to report the execution time of the filter + output
-        @inflight_clocks = Concurrent::Map.new
-        @batch_size = batch_size
-        @wait_for = TimeUnit::NANOSECONDS.convert(wait_for, TimeUnit::MILLISECONDS)
-      end
-
-      def close
-        # noop, compat with acked queue read client
-      end
-
-      def empty?
-        @queue.isEmpty
-      end
-
-      def set_batch_dimensions(batch_size, wait_for)
-        @batch_size = batch_size
-        @wait_for = TimeUnit::NANOSECONDS.convert(wait_for, TimeUnit::MILLISECONDS)
-      end
-
-      def set_events_metric(metric)
-        @event_metric = metric
-        @event_metric_out = @event_metric.counter(:out)
-        @event_metric_filtered = @event_metric.counter(:filtered)
-        @event_metric_time = @event_metric.counter(:duration_in_millis)
-        define_initial_metrics_values(@event_metric)
-      end
-
-      def set_pipeline_metric(metric)
-        @pipeline_metric = metric
-        @pipeline_metric_out = @pipeline_metric.counter(:out)
-        @pipeline_metric_filtered = @pipeline_metric.counter(:filtered)
-        @pipeline_metric_time = @pipeline_metric.counter(:duration_in_millis)
-        define_initial_metrics_values(@pipeline_metric)
-      end
-
-      def define_initial_metrics_values(namespaced_metric)
-        namespaced_metric.report_time(:duration_in_millis, 0)
-        namespaced_metric.increment(:filtered, 0)
-        namespaced_metric.increment(:out, 0)
-      end
-
-      def inflight_batches
-        @inflight_batches
-      end
-
-      # create a new empty batch
-      # @return [ReadBatch] a new empty read batch
-      def new_batch
-        LogStash::MemoryReadBatch.new(java.util.LinkedHashSet.new(0))
-      end
-
-      def read_batch
-        batch = LogStash::MemoryReadBatch.new(LsQueueUtils.drain(@queue, @batch_size, @wait_for))
-        start_metrics(batch)
-        batch
-      end
-
-      def start_metrics(batch)
-        thread = Thread.current
-        @inflight_batches[thread] = batch
-        @inflight_clocks[thread] = java.lang.System.nano_time
-      end
-
-      def close_batch(batch)
-        thread = Thread.current
-        @inflight_batches.delete(thread)
-        start_time = @inflight_clocks.get_and_set(thread, nil)
-        unless start_time.nil?
-          if batch.size > 0
-            # only stop (which also records) the metrics if the batch is non-empty.
-            # start_clock is now called at empty batch creation and an empty batch could
-            # stay empty all the way down to the close_batch call.
-            time_taken = (java.lang.System.nano_time - start_time) / 1_000_000
-            @event_metric_time.increment(time_taken)
-            @pipeline_metric_time.increment(time_taken)
-          end
-        end
-      end
-
-      def add_filtered_metrics(filtered_size)
-        @event_metric_filtered.increment(filtered_size)
-        @pipeline_metric_filtered.increment(filtered_size)
-      end
-
-      def add_output_metrics(filtered_size)
-        @event_metric_out.increment(filtered_size)
-        @pipeline_metric_out.increment(filtered_size)
-      end
     end
 
     class WriteClient

--- a/logstash-core/spec/logstash/util/wrapped_synchronous_queue_spec.rb
+++ b/logstash-core/spec/logstash/util/wrapped_synchronous_queue_spec.rb
@@ -16,7 +16,7 @@ describe LogStash::Util::WrappedSynchronousQueue do
 
     context "when requesting a read client" do
       it "returns a client" do
-        expect(subject.read_client).to be_a(LogStash::Util::WrappedSynchronousQueue::ReadClient)
+        expect(subject.read_client).to be_a(LogStash::MemoryReadClient)
       end
     end
 

--- a/logstash-core/src/main/java/org/logstash/RubyUtil.java
+++ b/logstash-core/src/main/java/org/logstash/RubyUtil.java
@@ -13,6 +13,7 @@ import org.logstash.ackedqueue.ext.RubyAckedBatch;
 import org.logstash.ext.JRubyWrappedWriteClientExt;
 import org.logstash.ext.JrubyEventExtLibrary;
 import org.logstash.ext.JrubyMemoryReadBatchExt;
+import org.logstash.ext.JrubyMemoryReadClientExt;
 import org.logstash.ext.JrubyTimestampExtLibrary;
 
 /**
@@ -48,6 +49,8 @@ public final class RubyUtil {
 
     public static final RubyClass WRAPPED_WRITE_CLIENT_CLASS;
 
+    public static final RubyClass MEMORY_READ_CLIENT_CLASS;
+
     static {
         RUBY = Ruby.getGlobalRuntime();
         LOGSTASH_MODULE = RUBY.getOrCreateModule("LogStash");
@@ -58,6 +61,8 @@ public final class RubyUtil {
             setupLogstashClass(JrubyMemoryReadBatchExt::new, JrubyMemoryReadBatchExt.class);
         WRAPPED_WRITE_CLIENT_CLASS =
             setupLogstashClass(JRubyWrappedWriteClientExt::new, JRubyWrappedWriteClientExt.class);
+        MEMORY_READ_CLIENT_CLASS =
+            setupLogstashClass(JrubyMemoryReadClientExt::new, JrubyMemoryReadClientExt.class);
         RUBY_EVENT_CLASS = setupLogstashClass(
             JrubyEventExtLibrary.RubyEvent::new, JrubyEventExtLibrary.RubyEvent.class
         );

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryReadBatchExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryReadBatchExt.java
@@ -11,6 +11,7 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.logstash.RubyUtil;
 
 @JRubyClass(name = "MemoryReadBatch")
 public class JrubyMemoryReadBatchExt extends RubyObject {
@@ -18,13 +19,24 @@ public class JrubyMemoryReadBatchExt extends RubyObject {
     private LinkedHashSet<IRubyObject> events;
 
     public JrubyMemoryReadBatchExt(final Ruby runtime, final RubyClass metaClass) {
-        super(runtime, metaClass);
+        this(runtime, metaClass, new LinkedHashSet<>());
     }
 
-    @JRubyMethod(name = "initialize", required = 1)
-    @SuppressWarnings("unchecked")
-    public void ruby_initialize(final ThreadContext context, final IRubyObject events) {
-        this.events = (LinkedHashSet<IRubyObject>) events.toJava(LinkedHashSet.class);
+    public JrubyMemoryReadBatchExt(final Ruby runtime, final RubyClass metaClass, final LinkedHashSet<IRubyObject> events) {
+        super(runtime, metaClass);
+        this.events = events;
+    }
+
+    public static JrubyMemoryReadBatchExt create(LinkedHashSet<IRubyObject> events) {
+        JrubyMemoryReadBatchExt batch = new JrubyMemoryReadBatchExt(RubyUtil.RUBY,
+                RubyUtil.MEMORY_READ_BATCH_CLASS, events);
+        return batch;
+    }
+
+    public static JrubyMemoryReadBatchExt create() {
+        JrubyMemoryReadBatchExt batch = new JrubyMemoryReadBatchExt(RubyUtil.RUBY,
+                RubyUtil.MEMORY_READ_BATCH_CLASS, new LinkedHashSet<>());
+        return batch;
     }
 
     @JRubyMethod(name = "to_a")
@@ -47,6 +59,10 @@ public class JrubyMemoryReadBatchExt extends RubyObject {
     @JRubyMethod(name = "filtered_size", alias = "size")
     public IRubyObject filteredSize(final ThreadContext context) {
         return context.runtime.newFixnum(events.size());
+    }
+
+    public int filteredSize() {
+        return events.size();
     }
 
     @JRubyMethod

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryReadClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryReadClientExt.java
@@ -1,0 +1,182 @@
+package org.logstash.ext;
+
+import org.jruby.Ruby;
+import org.jruby.RubyBasicObject;
+import org.jruby.RubyClass;
+import org.jruby.RubyHash;
+import org.jruby.RubyNumeric;
+import org.jruby.RubyObject;
+import org.jruby.RubySymbol;
+import org.jruby.anno.JRubyClass;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.java.proxies.JavaProxy;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.logstash.RubyUtil;
+import org.logstash.common.LsQueueUtils;
+import org.logstash.instrument.metrics.counter.LongCounter;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+@JRubyClass(name = "MemoryReadClient")
+public class JrubyMemoryReadClientExt extends RubyObject {
+
+    private static final RubySymbol OUT_KEY = RubyUtil.RUBY.newSymbol("out");
+    private static final RubySymbol FILTERED_KEY = RubyUtil.RUBY.newSymbol("filtered");
+    private static final RubySymbol DURATION_IN_MILLIS_KEY =
+            RubyUtil.RUBY.newSymbol("duration_in_millis");
+
+    private static final LongCounter DUMMY_COUNTER = new LongCounter("dummy");
+
+    private BlockingQueue queue;
+    private ConcurrentHashMap<Long, IRubyObject> inflightBatches;
+    private ConcurrentHashMap<Long, Long> inflightClocks;
+    private int batchSize;
+    private long waitForNanos;
+    private LongCounter eventMetricOut;
+    private LongCounter eventMetricFiltered;
+    private LongCounter eventMetricTime;
+    private LongCounter pipelineMetricOut;
+    private LongCounter pipelineMetricFiltered;
+    private LongCounter pipelineMetricTime;
+
+    public JrubyMemoryReadClientExt(final Ruby runtime, final RubyClass metaClass) {
+        super(runtime, metaClass);
+    }
+
+    @JRubyMethod(name = "initialize")
+    @SuppressWarnings("unchecked")
+    public void rubyInitialize(final ThreadContext context, IRubyObject queue,
+                               IRubyObject batchSize, IRubyObject waitForMillis) {
+        this.queue = (BlockingQueue) (((JavaProxy) queue).getObject());
+
+        // Note that @inflight_batches as a central mechanism for tracking inflight
+        // batches will fail if we have multiple read clients in the pipeline.
+        inflightBatches = new ConcurrentHashMap<>();
+
+        // allow the worker thread to report the execution time of the filter + output
+        inflightClocks = new ConcurrentHashMap<>();
+        this.batchSize = ((RubyNumeric) batchSize).getIntValue();
+        waitForNanos = TimeUnit.NANOSECONDS.convert(
+                ((RubyNumeric) waitForMillis).getIntValue(), TimeUnit.MILLISECONDS);
+    }
+
+    @JRubyMethod(name = "close")
+    public void rubyClose(final ThreadContext context) {
+        // noop, for compatibility with acked queue read client
+    }
+
+    public boolean isEmpty() {
+        return queue.isEmpty();
+    }
+
+    @JRubyMethod(name = "empty?")
+    public IRubyObject rubyIsEmpty(final ThreadContext context) {
+        return context.runtime.newBoolean(isEmpty());
+    }
+
+    public void setBatchDimensions(int batchSize, int waitForMillis) {
+        this.batchSize = batchSize;
+        waitForNanos = TimeUnit.NANOSECONDS.convert(waitForMillis, TimeUnit.MILLISECONDS);
+    }
+
+    @JRubyMethod(name = "set_batch_dimensions")
+    public IRubyObject rubySetBatchDimensions(final ThreadContext context, IRubyObject batchSize,
+                                              IRubyObject waitForMillis) {
+        setBatchDimensions(((RubyNumeric) batchSize).getIntValue(),
+                ((RubyNumeric) waitForMillis).getIntValue());
+        return this;
+    }
+
+    @JRubyMethod(name = "set_events_metric", required = 1)
+    public IRubyObject setEventsMetric(final ThreadContext context, IRubyObject metric) {
+        eventMetricOut = getCounter(metric, OUT_KEY);
+        eventMetricFiltered = getCounter(metric, FILTERED_KEY);
+        eventMetricTime = getCounter(metric, DURATION_IN_MILLIS_KEY);
+        return this;
+    }
+
+    @JRubyMethod(name = "set_pipeline_metric", required = 1)
+    public IRubyObject setPipelineMetric(final ThreadContext context, IRubyObject metric) {
+        pipelineMetricOut = getCounter(metric, OUT_KEY);
+        pipelineMetricFiltered = getCounter(metric, FILTERED_KEY);
+        pipelineMetricTime = getCounter(metric, DURATION_IN_MILLIS_KEY);
+        return this;
+    }
+
+    @JRubyMethod(name = "inflight_batches")
+    public IRubyObject rubyGetInflightBatches(final ThreadContext context) {
+        return RubyHash.newHash(context.runtime, inflightBatches, RubyBasicObject.UNDEF);
+    }
+
+    // create a new, empty batch
+    @JRubyMethod(name = "new_batch")
+    public IRubyObject newBatch(final ThreadContext context) {
+        return JrubyMemoryReadBatchExt.create();
+    }
+
+    @JRubyMethod(name = "read_batch")
+    public IRubyObject readBatch(final ThreadContext context) throws InterruptedException {
+        JrubyMemoryReadBatchExt batch = JrubyMemoryReadBatchExt.create(
+                LsQueueUtils.drain(queue, batchSize, waitForNanos));
+        startMetrics(batch);
+        return batch;
+    }
+
+    @JRubyMethod(name = "start_metrics")
+    public IRubyObject rubyStartMetrics(final ThreadContext context, IRubyObject batch) {
+        startMetrics((JrubyMemoryReadBatchExt) batch);
+        return this;
+    }
+
+    private void startMetrics(JrubyMemoryReadBatchExt batch) {
+        long threadId = Thread.currentThread().getId();
+        inflightBatches.put(threadId, batch);
+        inflightClocks.put(threadId, System.nanoTime());
+    }
+
+    @JRubyMethod(name = "close_batch", required = 1)
+    public IRubyObject closeBatch(final ThreadContext context, IRubyObject batch) {
+        JrubyMemoryReadBatchExt typedBatch = (JrubyMemoryReadBatchExt) batch;
+        inflightBatches.remove(Thread.currentThread().getId());
+        Long startTime = inflightClocks.remove(Thread.currentThread().getId());
+        if (startTime != null && typedBatch.filteredSize() > 0) {
+            // stop timer and record metrics iff the batch is non-empty.
+            long elapsedTimeMillis = (System.nanoTime() - startTime) / 1_000_000;
+            eventMetricTime.increment(elapsedTimeMillis);
+            pipelineMetricTime.increment(elapsedTimeMillis);
+        }
+        return this;
+    }
+
+    @JRubyMethod(name = "add_filtered_metrics", required = 1)
+    public IRubyObject addFilteredMetrics(final ThreadContext context, IRubyObject filteredSize) {
+        int typedFilteredSize = ((RubyNumeric) filteredSize).getIntValue();
+        eventMetricFiltered.increment(typedFilteredSize);
+        pipelineMetricFiltered.increment(typedFilteredSize);
+        return this;
+    }
+
+    @JRubyMethod(name = "add_output_metrics", required = 1)
+    public IRubyObject addOutputMetrics(final ThreadContext context, IRubyObject filteredSize) {
+        int typedFilteredSize = ((RubyNumeric) filteredSize).getIntValue();
+        eventMetricOut.increment(typedFilteredSize);
+        pipelineMetricOut.increment(typedFilteredSize);
+        return this;
+    }
+
+    private static LongCounter getCounter(final IRubyObject metric, final RubySymbol key) {
+        final ThreadContext context = RubyUtil.RUBY.getCurrentContext();
+        final IRubyObject counter = metric.callMethod(context, "counter", key);
+        counter.callMethod(context, "increment", context.runtime.newFixnum(0));
+        if (LongCounter.class.isAssignableFrom(counter.getJavaClass())) {
+            return (LongCounter) counter.toJava(LongCounter.class);
+        } else {
+            // Metrics deactivated, we didn't get an actual counter from the base metric.
+            return DUMMY_COUNTER;
+        }
+    }
+
+}


### PR DESCRIPTION
Also uses Java counters more efficiently per Armin's work in #8985. Rough throughput testing with generator input shows 15-20% increase due mainly to the metrics improvements.