### PR TITLE
Syntax error causing abort on startup

### DIFF
--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -40,8 +40,9 @@ if not "%JAVA_TOOL_OPTIONS%" == "" (
 rem JAVA_OPTS is not a built-in JVM mechanism but some people think it is so we
 rem warn them that we are not observing the value of %JAVA_OPTS%
 if not "%JAVA_OPTS%" == "" (
-  echo|set /p="warning: ignoring JAVA_OPTS=%JAVA_OPTS%; "
+  echo warning: ignoring JAVA_OPTS=%JAVA_OPTS%;
   echo pass JVM parameters via LS_JAVA_OPTS
+  set JAVA_OPTS=
 )
 
 rem ### 3: set jruby


### PR DESCRIPTION
The syntax of command set is not correct and this causes a abort with no error logs when a user have the JAVA_OPTS env variable defined on your system.