### PR TITLE
MINOR: Remove two dead methods from Acked queue

### DIFF
--- a/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
+++ b/logstash-core/lib/logstash/util/wrapped_acked_queue.rb
@@ -250,14 +250,6 @@ module LogStash; module Util
       def filtered_size
         @originals.size + @generated.size
       end
-
-      def shutdown_signal_received?
-        false
-      end
-
-      def flush_signal_received?
-        false
-      end
     end
 
     class WriteClient


### PR DESCRIPTION
Just preparing the move to Java here, these methods are unused (they're not found on the synchronous queue impl. => they can't have any functional impact here either, also they have no point and just return `false` :P anyways)