### PR TITLE
MINOR: Some cleanups of Java in-memory Queue JRuby Ext classes

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryReadBatchExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryReadBatchExt.java
@@ -14,9 +14,9 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.RubyUtil;
 
 @JRubyClass(name = "MemoryReadBatch")
-public class JrubyMemoryReadBatchExt extends RubyObject {
+public final class JrubyMemoryReadBatchExt extends RubyObject {
 
-    private LinkedHashSet<IRubyObject> events;
+    private final LinkedHashSet<IRubyObject> events;
 
     public JrubyMemoryReadBatchExt(final Ruby runtime, final RubyClass metaClass) {
         this(runtime, metaClass, new LinkedHashSet<>());
@@ -34,9 +34,7 @@ public class JrubyMemoryReadBatchExt extends RubyObject {
     }
 
     public static JrubyMemoryReadBatchExt create() {
-        JrubyMemoryReadBatchExt batch = new JrubyMemoryReadBatchExt(RubyUtil.RUBY,
-                RubyUtil.MEMORY_READ_BATCH_CLASS, new LinkedHashSet<>());
-        return batch;
+        return create(new LinkedHashSet<>());
     }
 
     @JRubyMethod(name = "to_a")

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryReadClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryReadClientExt.java
@@ -1,5 +1,8 @@
 package org.logstash.ext;
 
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import org.jruby.Ruby;
 import org.jruby.RubyBasicObject;
 import org.jruby.RubyClass;
@@ -9,19 +12,14 @@ import org.jruby.RubyObject;
 import org.jruby.RubySymbol;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
-import org.jruby.java.proxies.JavaProxy;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.RubyUtil;
 import org.logstash.common.LsQueueUtils;
 import org.logstash.instrument.metrics.counter.LongCounter;
 
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-
 @JRubyClass(name = "MemoryReadClient")
-public class JrubyMemoryReadClientExt extends RubyObject {
+public final class JrubyMemoryReadClientExt extends RubyObject {
 
     private static final RubySymbol OUT_KEY = RubyUtil.RUBY.newSymbol("out");
     private static final RubySymbol FILTERED_KEY = RubyUtil.RUBY.newSymbol("filtered");
@@ -50,16 +48,6 @@ public class JrubyMemoryReadClientExt extends RubyObject {
         this.queue = queue;
         this.batchSize = batchSize;
         waitForNanos = TimeUnit.NANOSECONDS.convert(waitForMillis, TimeUnit.MILLISECONDS);
-    }
-
-    @JRubyMethod(name = "initialize")
-    @SuppressWarnings("unchecked")
-    public void rubyInitialize(final ThreadContext context, IRubyObject queue,
-                               IRubyObject batchSize, IRubyObject waitForMillis) {
-        this.queue = (BlockingQueue) (((JavaProxy) queue).getObject());
-        this.batchSize = ((RubyNumeric) batchSize).getIntValue();
-        waitForNanos = TimeUnit.NANOSECONDS.convert(
-                ((RubyNumeric) waitForMillis).getIntValue(), TimeUnit.MILLISECONDS);
     }
 
     public static JrubyMemoryReadClientExt create(BlockingQueue queue, int batchSize,

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryWriteClientExt.java
@@ -1,21 +1,19 @@
 package org.logstash.ext;
 
+import java.util.Collection;
+import java.util.concurrent.BlockingQueue;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyObject;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
-import org.jruby.java.proxies.JavaProxy;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.RubyUtil;
 import org.logstash.common.LsQueueUtils;
 
-import java.util.Collection;
-import java.util.concurrent.BlockingQueue;
-
 @JRubyClass(name = "MemoryWriteClient")
-public class JrubyMemoryWriteClientExt extends RubyObject {
+public final class JrubyMemoryWriteClientExt extends RubyObject {
 
     private BlockingQueue<JrubyEventExtLibrary.RubyEvent> queue;
 
@@ -33,13 +31,6 @@ public class JrubyMemoryWriteClientExt extends RubyObject {
             BlockingQueue<JrubyEventExtLibrary.RubyEvent> queue) {
         return new JrubyMemoryWriteClientExt(RubyUtil.RUBY,
                 RubyUtil.MEMORY_WRITE_CLIENT_CLASS, queue);
-    }
-
-    @JRubyMethod(name = "initialize")
-    @SuppressWarnings("unchecked")
-    public void rubyInitialize(final ThreadContext context, IRubyObject queue) {
-        this.queue =
-                (BlockingQueue<JrubyEventExtLibrary.RubyEvent>) (((JavaProxy) queue).getObject());
     }
 
     @JRubyMethod(name = {"push", "<<"}, required = 1)

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyWrappedSynchronousQueueExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyWrappedSynchronousQueueExt.java
@@ -13,7 +13,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
 @JRubyClass(name = "WrappedSynchronousQueue")
-public class JrubyWrappedSynchronousQueueExt extends RubyObject {
+public final class JrubyWrappedSynchronousQueueExt extends RubyObject {
 
     private BlockingQueue<JrubyEventExtLibrary.RubyEvent> queue;
 


### PR DESCRIPTION
Keeping the entropy lower here :)

* The Ruby `initialize` constructors are already obsolete any never get called thanks to #8991 :)
* Made `final` what I could make `final` here just to make things a little more readable (especially since we do in fact have inheritance in the PQ path of this ... at least until after #8999 :))
* Removed one redundant reference to `RubyUtil.MEMORY_READ_BATCH_CLASS` (just as a side note we should keep references to `RubyUtil` to a minimum wherever possible since we will need to clean up the global `Ruby` reference eventually)