### PR TITLE
MINOR: Align behaviour of acked queue Ruby wrappers with behaviour of in memory queue wrappers

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/RubyAckedBatch.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/RubyAckedBatch.java
@@ -2,8 +2,8 @@ package org.logstash.ackedqueue.ext;
 
 import java.io.IOException;
 import org.jruby.Ruby;
-import org.jruby.RubyArray;
 import org.jruby.RubyClass;
+import org.jruby.RubyHash;
 import org.jruby.RubyObject;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
@@ -32,9 +32,12 @@ public final class RubyAckedBatch extends RubyObject {
 
     @JRubyMethod(name = "get_elements")
     public IRubyObject ruby_get_elements(ThreadContext context) {
-        RubyArray result = context.runtime.newArray();
-        this.batch.getElements().forEach(e -> result.add(
-            JrubyEventExtLibrary.RubyEvent.newRubyEvent(context.runtime, (Event) e)));
+        final RubyHash result = RubyHash.newHash(context.runtime);
+        this.batch.getElements().forEach(e -> result.put(
+            JrubyEventExtLibrary.RubyEvent.newRubyEvent(context.runtime, (Event) e),
+            context.tru
+            )
+        );
         return result;
     }
 


### PR DESCRIPTION
Aligning behaviour between acked and in memory queue some more before the Java port:

* `poll` for just a single element isn't exposed for the in memory queue => don't expose it here either
* In memory queue reads directly when constructing the batch => do the same here (also gives better performance)
   * `read_next` is simply redundant since it's always called after instantiating the batch in normal operation (can just instantiate a batch of size `0` for the final flush)
* Make `acked_batch.get_elements` return a `Hash` since it's only used in a single place and that place wants a `Hash` => no need for the redundant in between array
