### PR TITLE
MINOR: Add some context to unclean shutdown exceptions

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Logstash.java
+++ b/logstash-core/src/main/java/org/logstash/Logstash.java
@@ -85,13 +85,13 @@ public final class Logstash implements Runnable, AutoCloseable {
                 final IRubyObject status =
                     rexep.callMethod(ruby.getCurrentContext(), "status");
                 if (status != null && !status.isNil() && RubyNumeric.fix2int(status) != 0) {
-                    throw new IllegalStateException(ex);
+                    uncleanShutdown(ex);
                 }
             } else {
-                throw new IllegalStateException(ex);
+                uncleanShutdown(ex);
             }
         } catch (final IOException ex) {
-            throw new IllegalStateException(ex);
+            uncleanShutdown(ex);
         }
     }
 
@@ -136,5 +136,9 @@ public final class Logstash implements Runnable, AutoCloseable {
             throw new IllegalArgumentException(String.format("Missing: %s.", resolved));
         }
         return resolved.toString();
+    }
+
+    private static void uncleanShutdown(final Exception ex) {
+        throw new IllegalStateException("Logstash stopped processing because of an error:", ex);
     }
 }


### PR DESCRIPTION
Adding some context to rethrows on unclean shutdown to avoid the hard to interpret last line:

```sh
[2018-01-22T17:12:25,958][ERROR][org.logstash.Logstash    ] java.lang.IllegalStateException: org.jruby.exceptions.RaiseException: (SystemExit) exit
```

that currently gets logged when LS stops because of an exception in the main loop.