### PR TITLE
Keystore: Change default permission to 644

### DIFF
--- a/logstash-core/src/main/java/org/logstash/secret/store/backend/JavaKeyStore.java
+++ b/logstash-core/src/main/java/org/logstash/secret/store/backend/JavaKeyStore.java
@@ -50,7 +50,7 @@ public final class JavaKeyStore implements SecretStore {
     private boolean useDefaultPass = false;
     private Lock writeLock;
     //package private for testing
-    static String filePermissions = "rw-rw----";
+    static String filePermissions = "rw-r--r--";
     private static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
 
     /**

--- a/logstash-core/src/test/java/org/logstash/secret/store/backend/JavaKeyStoreTest.java
+++ b/logstash-core/src/test/java/org/logstash/secret/store/backend/JavaKeyStoreTest.java
@@ -332,7 +332,7 @@ public class JavaKeyStoreTest {
         // if we got attributes, lets assert them.
         if (attrs != null) {
             Set<PosixFilePermission> permissions = attrs.readAttributes().permissions();
-            EnumSet<PosixFilePermission> expected = EnumSet.of(OWNER_READ, OWNER_WRITE, GROUP_READ, GROUP_WRITE);
+            EnumSet<PosixFilePermission> expected = EnumSet.of(OWNER_READ, OWNER_WRITE, GROUP_READ, OTHERS_READ);
             assertThat(permissions.toArray()).containsExactlyInAnyOrder(expected.toArray());
         }
     }

--- a/pkg/centos/after-install.sh
+++ b/pkg/centos/after-install.sh
@@ -6,3 +6,6 @@ sed -i \
   -e 's|# path.data:|path.data: /var/lib/logstash|' \
   /etc/logstash/logstash.yml
 /usr/share/logstash/bin/system-install /etc/logstash/startup.options
+chmod 600 /etc/logstash/startup.options
+chmod 600 /etc/default/logstash
+

--- a/pkg/debian/after-install.sh
+++ b/pkg/debian/after-install.sh
@@ -9,3 +9,6 @@ sed -i \
   -e 's|# path.data:|path.data: /var/lib/logstash|' \
   /etc/logstash/logstash.yml
 /usr/share/logstash/bin/system-install /etc/logstash/startup.options
+chmod 600 /etc/logstash/startup.options
+chmod 600 /etc/default/logstash
+

--- a/pkg/ubuntu/after-install.sh
+++ b/pkg/ubuntu/after-install.sh
@@ -8,3 +8,5 @@ sed -i \
   -e 's|# path.data:|path.data: /var/lib/logstash|' \
   /etc/logstash/logstash.yml
 /usr/share/logstash/bin/system-install /etc/logstash/startup.options
+chmod 600 /etc/logstash/startup.options
+chmod 600 /etc/default/logstash


### PR DESCRIPTION
When Logstash is package installed (rpm/deb), the cli tool will be installed with root/root, but the service is run as logstash/logstash.  Changing to allow global read access to allow the logstash user read the keystore. Documentation will be provided for how to setup the keystore password such that you will need root access to obtain the keystore password, thereby requiring root access to do anything with the keystore as long as the password is set.

Part of #8735 

(this will be merged to 6.2 and newer)