### PR TITLE
CLEANUP: Remove redundant PageIOFactory

### DIFF
--- a/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/QueueRWBenchmark.java
+++ b/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/QueueRWBenchmark.java
@@ -17,8 +17,6 @@ import org.logstash.ackedqueue.Settings;
 import org.logstash.ackedqueue.SettingsImpl;
 import org.logstash.ackedqueue.io.CheckpointIOFactory;
 import org.logstash.ackedqueue.io.FileCheckpointIO;
-import org.logstash.ackedqueue.io.MmapPageIO;
-import org.logstash.ackedqueue.io.PageIOFactory;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -121,14 +119,10 @@ public class QueueRWBenchmark {
     }
 
     private static Settings settings() {
-        final PageIOFactory pageIOFactory;
-        final CheckpointIOFactory checkpointIOFactory;
-        pageIOFactory = MmapPageIO::new;
-        checkpointIOFactory = FileCheckpointIO::new;
+        final CheckpointIOFactory checkpointIOFactory = FileCheckpointIO::new;
         return SettingsImpl.fileSettingsBuilder(Files.createTempDir().getPath())
             .capacity(256 * 1024 * 1024)
             .queueMaxBytes(Long.MAX_VALUE)
-            .elementIOFactory(pageIOFactory)
             .checkpointMaxWrites(ACK_INTERVAL)
             .checkpointMaxAcks(ACK_INTERVAL)
             .checkpointIOFactory(checkpointIOFactory)

--- a/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/QueueWriteBenchmark.java
+++ b/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/QueueWriteBenchmark.java
@@ -11,7 +11,6 @@ import org.logstash.ackedqueue.Queue;
 import org.logstash.ackedqueue.Settings;
 import org.logstash.ackedqueue.SettingsImpl;
 import org.logstash.ackedqueue.io.FileCheckpointIO;
-import org.logstash.ackedqueue.io.MmapPageIO;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -74,7 +73,6 @@ public class QueueWriteBenchmark {
         return SettingsImpl.fileSettingsBuilder(Files.createTempDir().getPath())
             .capacity(256 * 1024 * 1024)
             .queueMaxBytes(Long.MAX_VALUE)
-            .elementIOFactory(MmapPageIO::new)
             .checkpointMaxWrites(1024)
             .checkpointMaxAcks(1024)
             .checkpointIOFactory(FileCheckpointIO::new)

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Settings.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Settings.java
@@ -1,13 +1,10 @@
 package org.logstash.ackedqueue;
 
 import org.logstash.ackedqueue.io.CheckpointIOFactory;
-import org.logstash.ackedqueue.io.PageIOFactory;
 
 public interface Settings {
 
     CheckpointIOFactory getCheckpointIOFactory();
-
-    PageIOFactory getPageIOFactory();
 
     Class<? extends Queueable> getElementClass();
 
@@ -22,12 +19,10 @@ public interface Settings {
     int getCheckpointMaxAcks();
 
     int getCheckpointMaxWrites();
-    
+
     interface Builder {
 
         Builder checkpointIOFactory(CheckpointIOFactory factory);
-
-        Builder elementIOFactory(PageIOFactory factory);
 
         Builder elementClass(Class<? extends Queueable> elementClass);
 
@@ -40,7 +35,7 @@ public interface Settings {
         Builder checkpointMaxAcks(int checkpointMaxAcks);
 
         Builder checkpointMaxWrites(int checkpointMaxWrites);
-        
+
         Settings build();
 
     }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/SettingsImpl.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/SettingsImpl.java
@@ -1,12 +1,10 @@
 package org.logstash.ackedqueue;
 
 import org.logstash.ackedqueue.io.CheckpointIOFactory;
-import org.logstash.ackedqueue.io.PageIOFactory;
 
 public class SettingsImpl implements Settings {
     private String dirForFiles;
     private CheckpointIOFactory checkpointIOFactory;
-    private PageIOFactory pageIOFactory;
     private Class<? extends Queueable> elementClass;
     private int capacity;
     private long queueMaxBytes;
@@ -16,8 +14,7 @@ public class SettingsImpl implements Settings {
 
     public static Builder builder(final Settings settings) {
         return new BuilderImpl(settings.getDirPath(),
-            settings.getCheckpointIOFactory(),
-            settings.getPageIOFactory(), settings.getElementClass(), settings.getCapacity(),
+            settings.getCheckpointIOFactory(), settings.getElementClass(), settings.getCapacity(),
             settings.getQueueMaxBytes(), settings.getMaxUnread(), settings.getCheckpointMaxAcks(),
             settings.getCheckpointMaxWrites()
         );
@@ -28,12 +25,11 @@ public class SettingsImpl implements Settings {
     }
 
     private SettingsImpl(final String dirForFiles, final CheckpointIOFactory checkpointIOFactory,
-        final PageIOFactory pageIOFactory, final Class<? extends Queueable> elementClass,
+        final Class<? extends Queueable> elementClass,
         final int capacity, final long queueMaxBytes, final int maxUnread,
         final int checkpointMaxAcks, final int checkpointMaxWrites) {
         this.dirForFiles = dirForFiles;
         this.checkpointIOFactory = checkpointIOFactory;
-        this.pageIOFactory = pageIOFactory;
         this.elementClass = elementClass;
         this.capacity = capacity;
         this.queueMaxBytes = queueMaxBytes;
@@ -55,10 +51,6 @@ public class SettingsImpl implements Settings {
     @Override
     public CheckpointIOFactory getCheckpointIOFactory() {
         return checkpointIOFactory;
-    }
-
-    public PageIOFactory getPageIOFactory() {
-        return pageIOFactory;
     }
 
     @Override
@@ -120,8 +112,6 @@ public class SettingsImpl implements Settings {
 
         private final CheckpointIOFactory checkpointIOFactory;
 
-        private final PageIOFactory pageIOFactory;
-
         private final Class<? extends Queueable> elementClass;
 
         private final int capacity;
@@ -135,18 +125,17 @@ public class SettingsImpl implements Settings {
         private final int checkpointMaxWrites;
 
         private BuilderImpl(final String dirForFiles) {
-            this(dirForFiles, null, null, null, DEFAULT_CAPACITY, DEFAULT_MAX_QUEUE_BYTES,
+            this(dirForFiles, null, null, DEFAULT_CAPACITY, DEFAULT_MAX_QUEUE_BYTES,
                 DEFAULT_MAX_UNREAD, DEFAULT_CHECKPOINT_MAX_ACKS, DEFAULT_CHECKPOINT_MAX_WRITES
             );
         }
 
         private BuilderImpl(final String dirForFiles, final CheckpointIOFactory checkpointIOFactory,
-            final PageIOFactory pageIOFactory, final Class<? extends Queueable> elementClass,
+            final Class<? extends Queueable> elementClass,
             final int capacity, final long queueMaxBytes, final int maxUnread,
             final int checkpointMaxAcks, final int checkpointMaxWrites) {
             this.dirForFiles = dirForFiles;
             this.checkpointIOFactory = checkpointIOFactory;
-            this.pageIOFactory = pageIOFactory;
             this.elementClass = elementClass;
             this.capacity = capacity;
             this.queueMaxBytes = queueMaxBytes;
@@ -158,17 +147,7 @@ public class SettingsImpl implements Settings {
         @Override
         public Builder checkpointIOFactory(final CheckpointIOFactory factory) {
             return new BuilderImpl(
-                this.dirForFiles, factory, this.pageIOFactory, this.elementClass, this.capacity,
-                this.queueMaxBytes, this.maxUnread, this.checkpointMaxAcks,
-                this.checkpointMaxWrites
-            );
-        }
-
-        @Override
-        public Builder elementIOFactory(final PageIOFactory factory) {
-            return new BuilderImpl(
-                this.dirForFiles, this.checkpointIOFactory, factory, this.elementClass,
-                this.capacity,
+                this.dirForFiles, factory, this.elementClass, this.capacity,
                 this.queueMaxBytes, this.maxUnread, this.checkpointMaxAcks,
                 this.checkpointMaxWrites
             );
@@ -177,9 +156,8 @@ public class SettingsImpl implements Settings {
         @Override
         public Builder elementClass(final Class<? extends Queueable> elementClass) {
             return new BuilderImpl(
-                this.dirForFiles, this.checkpointIOFactory, this.pageIOFactory, elementClass,
-                this.capacity,
-                this.queueMaxBytes, this.maxUnread, this.checkpointMaxAcks,
+                this.dirForFiles, this.checkpointIOFactory, elementClass,
+                this.capacity, this.queueMaxBytes, this.maxUnread, this.checkpointMaxAcks,
                 this.checkpointMaxWrites
             );
         }
@@ -187,7 +165,7 @@ public class SettingsImpl implements Settings {
         @Override
         public Builder capacity(final int capacity) {
             return new BuilderImpl(
-                this.dirForFiles, this.checkpointIOFactory, this.pageIOFactory, this.elementClass,
+                this.dirForFiles, this.checkpointIOFactory, this.elementClass,
                 capacity, this.queueMaxBytes, this.maxUnread, this.checkpointMaxAcks,
                 this.checkpointMaxWrites
             );
@@ -196,7 +174,7 @@ public class SettingsImpl implements Settings {
         @Override
         public Builder queueMaxBytes(final long size) {
             return new BuilderImpl(
-                this.dirForFiles, this.checkpointIOFactory, this.pageIOFactory, this.elementClass,
+                this.dirForFiles, this.checkpointIOFactory, this.elementClass,
                 this.capacity, size, this.maxUnread, this.checkpointMaxAcks,
                 this.checkpointMaxWrites
             );
@@ -205,7 +183,7 @@ public class SettingsImpl implements Settings {
         @Override
         public Builder maxUnread(final int maxUnread) {
             return new BuilderImpl(
-                this.dirForFiles, this.checkpointIOFactory, this.pageIOFactory, this.elementClass,
+                this.dirForFiles, this.checkpointIOFactory, this.elementClass,
                 this.capacity, this.queueMaxBytes, maxUnread, this.checkpointMaxAcks,
                 this.checkpointMaxWrites
             );
@@ -214,7 +192,7 @@ public class SettingsImpl implements Settings {
         @Override
         public Builder checkpointMaxAcks(final int checkpointMaxAcks) {
             return new BuilderImpl(
-                this.dirForFiles, this.checkpointIOFactory, this.pageIOFactory, this.elementClass,
+                this.dirForFiles, this.checkpointIOFactory, this.elementClass,
                 this.capacity, this.queueMaxBytes, this.maxUnread, checkpointMaxAcks,
                 this.checkpointMaxWrites
             );
@@ -223,7 +201,7 @@ public class SettingsImpl implements Settings {
         @Override
         public Builder checkpointMaxWrites(final int checkpointMaxWrites) {
             return new BuilderImpl(
-                this.dirForFiles, this.checkpointIOFactory, this.pageIOFactory, this.elementClass,
+                this.dirForFiles, this.checkpointIOFactory, this.elementClass,
                 this.capacity, this.queueMaxBytes, this.maxUnread, this.checkpointMaxAcks,
                 checkpointMaxWrites
             );
@@ -232,7 +210,7 @@ public class SettingsImpl implements Settings {
         @Override
         public Settings build() {
             return new SettingsImpl(
-                this.dirForFiles, this.checkpointIOFactory, this.pageIOFactory, this.elementClass,
+                this.dirForFiles, this.checkpointIOFactory, this.elementClass,
                 this.capacity, this.queueMaxBytes, this.maxUnread, this.checkpointMaxAcks,
                 this.checkpointMaxWrites
             );

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyAckedQueueExt.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyAckedQueueExt.java
@@ -17,7 +17,6 @@ import org.logstash.ackedqueue.Batch;
 import org.logstash.ackedqueue.Queue;
 import org.logstash.ackedqueue.SettingsImpl;
 import org.logstash.ackedqueue.io.FileCheckpointIO;
-import org.logstash.ackedqueue.io.MmapPageIO;
 import org.logstash.ext.JrubyEventExtLibrary;
 
 @JRubyClass(name = "AckedQueue")
@@ -50,7 +49,6 @@ public final class JRubyAckedQueueExt extends RubyObject {
                 .queueMaxBytes(queueMaxBytes)
                 .checkpointMaxAcks(checkpointMaxAcks)
                 .checkpointMaxWrites(checkpointMaxWrites)
-                .elementIOFactory(MmapPageIO::new)
                 .checkpointIOFactory(FileCheckpointIO::new)
                 .elementClass(Event.class)
                 .build()

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/PageIOFactory.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/PageIOFactory.java
@@ -1,6 +1,0 @@
-package org.logstash.ackedqueue.io;
-
-@FunctionalInterface
-public interface PageIOFactory {
-    PageIO build(int pageNum, int capacity, String dirPath);
-}

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/HeadPageTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/HeadPageTest.java
@@ -6,6 +6,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.logstash.ackedqueue.io.MmapPageIO;
 import org.logstash.ackedqueue.io.PageIO;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -31,8 +32,7 @@ public class HeadPageTest {
         // Close method on Page requires an instance of Queue that has already been opened.
         try (Queue q = new Queue(s)) {
             q.open();
-            PageIO pageIO = s.getPageIOFactory()
-                .build(0, 100, dataPath);
+            PageIO pageIO = new MmapPageIO(0, 100, dataPath);
             pageIO.create();
             try (final Page p = PageFactory.newHeadPage(0, q, pageIO)) {
                 assertThat(p.getPageNum(), is(equalTo(0)));

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/TestSettings.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/TestSettings.java
@@ -2,23 +2,19 @@ package org.logstash.ackedqueue;
 
 import org.logstash.ackedqueue.io.CheckpointIOFactory;
 import org.logstash.ackedqueue.io.FileCheckpointIO;
-import org.logstash.ackedqueue.io.MmapPageIO;
-import org.logstash.ackedqueue.io.PageIOFactory;
 
 public class TestSettings {
 
     public static Settings persistedQueueSettings(int capacity, String folder) {
-        PageIOFactory pageIOFactory = (pageNum, size, path) -> new MmapPageIO(pageNum, size, path);
         CheckpointIOFactory checkpointIOFactory = (source) -> new FileCheckpointIO(source);
-        return SettingsImpl.fileSettingsBuilder(folder).capacity(capacity).elementIOFactory(pageIOFactory)
+        return SettingsImpl.fileSettingsBuilder(folder).capacity(capacity)
             .checkpointMaxWrites(1).checkpointIOFactory(checkpointIOFactory)
             .elementClass(StringElement.class).build();
     }
 
     public static Settings persistedQueueSettings(int capacity, long size, String folder) {
-        PageIOFactory pageIOFactory = (pageNum, pageSize, path) -> new MmapPageIO(pageNum, pageSize, path);
         CheckpointIOFactory checkpointIOFactory = (source) -> new FileCheckpointIO(source);
-        return SettingsImpl.fileSettingsBuilder(folder).capacity(capacity).elementIOFactory(pageIOFactory)
+        return SettingsImpl.fileSettingsBuilder(folder).capacity(capacity)
             .queueMaxBytes(size).checkpointMaxWrites(1).checkpointIOFactory(checkpointIOFactory)
             .elementClass(StringElement.class).build();
     }

--- a/logstash-core/src/test/java/org/logstash/stress/Concurrent.java
+++ b/logstash-core/src/test/java/org/logstash/stress/Concurrent.java
@@ -17,8 +17,6 @@ import org.logstash.ackedqueue.Settings;
 import org.logstash.ackedqueue.StringElement;
 import org.logstash.ackedqueue.io.CheckpointIOFactory;
 import org.logstash.ackedqueue.io.FileCheckpointIO;
-import org.logstash.ackedqueue.io.MmapPageIO;
-import org.logstash.ackedqueue.io.PageIOFactory;
 
 public class Concurrent {
     final static int ELEMENT_COUNT = 2000000;
@@ -26,10 +24,8 @@ public class Concurrent {
     static Settings settings;
 
     public static Settings fileSettings(int capacity) {
-        PageIOFactory pageIOFactory = (pageNum, size, path) -> new MmapPageIO(pageNum, size, path);
         CheckpointIOFactory checkpointIOFactory = (source) -> new FileCheckpointIO(source);
         return SettingsImpl.fileSettingsBuilder("/tmp/queue").capacity(capacity)
-            .elementIOFactory(pageIOFactory)
             .checkpointIOFactory(checkpointIOFactory).elementClass(StringElement.class).build();
     }
 


### PR DESCRIPTION
`org.logstash.ackedqueue.io.MmapPageIO` is the only remaining `PageIO` implementation used by the `Queue` => no need for the factory abstraction, we can just use outright `new MmapPageIO(...)` instead throughout and save a lot of complication.

* Removed factory
* Simplified the `Settings`