### PR TITLE
Revert to Log4j2 2.6.2 to reennable jdk9 unit tests

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -121,8 +121,7 @@ dependencies {
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jacksonVersion}"
     compile "org.jruby:jruby-complete:${jrubyVersion}"
     compile 'com.google.googlejavaformat:google-java-format:1.5'
-    testCompile 'org.apache.logging.log4j:log4j-core:2.6.2:tests'
-    testCompile 'org.apache.logging.log4j:log4j-api:2.6.2:tests'
+    testCompile 'org.apache.logging.log4j:log4j-core:2.9.1:tests'
     testCompile 'junit:junit:4.12'
     testCompile 'net.javacrumbs.json-unit:json-unit:1.9.0'
     testCompile 'org.elasticsearch:securemock:1.2'


### PR DESCRIPTION
This fixes #8983. The removed dependency doesn't compile (throws NPE during compilation) with JDK9. It isn't necessary in version `2.9.1` (same as our production log4j2 version) anyways since tests still pass fine after removing it.