### PR TITLE
JAVAFICATION: Move Flusher Thread to Java

### DIFF
--- a/logstash-core/src/main/java/org/logstash/execution/PeriodicFlush.java
+++ b/logstash-core/src/main/java/org/logstash/execution/PeriodicFlush.java
@@ -1,0 +1,53 @@
+package org.logstash.execution;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jruby.runtime.builtin.IRubyObject;
+
+public final class PeriodicFlush implements AutoCloseable {
+
+    private static final Logger LOGGER = LogManager.getLogger(PeriodicFlush.class);
+
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(
+        r -> new Thread(r, "logstash-pipeline-flush")
+    );
+
+    private final BlockingQueue<IRubyObject> queue;
+
+    private final IRubyObject signal;
+
+    private final AtomicBoolean flushing;
+
+    public PeriodicFlush(final BlockingQueue<IRubyObject> queue, final IRubyObject signal,
+        final AtomicBoolean flushing) {
+        this.queue = queue;
+        this.signal = signal;
+        this.flushing = flushing;
+    }
+
+    public void start() {
+        executor.scheduleAtFixedRate(() -> {
+            if (flushing.compareAndSet(false, true)) {
+                LOGGER.debug("Pushing flush onto pipeline.");
+                try {
+                    queue.put(signal);
+                } catch (final InterruptedException ex) {
+                    throw new IllegalStateException(ex);
+                }
+            }
+        }, 0L, 5L, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void close() throws InterruptedException {
+        executor.shutdown();
+        if (!executor.awaitTermination(10L, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("Failed to stop period flush action.");
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
+++ b/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
@@ -1,6 +1,7 @@
 package org.logstash.execution;
 
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jruby.RubyArray;
@@ -19,7 +20,7 @@ public final class WorkerLoop implements Runnable {
 
     private final IRubyObject readClient;
 
-    private final IRubyObject flushing;
+    private final AtomicBoolean flushing;
 
     private final IRubyObject consumedCounter;
 
@@ -29,7 +30,7 @@ public final class WorkerLoop implements Runnable {
 
     public WorkerLoop(final Dataset execution, final BlockingQueue<IRubyObject> signalQueue,
         final IRubyObject readClient, final IRubyObject filteredCounter,
-        final IRubyObject consumedCounter, final IRubyObject flushing, final boolean drainQueue) {
+        final IRubyObject consumedCounter, final AtomicBoolean flushing, final boolean drainQueue) {
         this.consumedCounter = consumedCounter;
         this.filteredCounter = filteredCounter;
         this.execution = execution;
@@ -63,7 +64,7 @@ public final class WorkerLoop implements Runnable {
                 readClient.callMethod(context, "add_filtered_metrics", filteredSize);
                 readClient.callMethod(context, "close_batch", batch);
                 if (isFlush) {
-                    flushing.callMethod(context, "set", context.fals);
+                    flushing.set(false);
                 }
             } while (!shutdownRequested && !isDraining(context));
             //we are shutting down, queue is drained if it was required, now  perform a final flush.


### PR DESCRIPTION
Trivial but it allows for one less roundtrip to Ruby for the `flushing` state and shortens the `java_pipeline.rb` which is always nice :)