### PR TITLE
Fix links

### DIFF
--- a/docs/index-shared1.asciidoc
+++ b/docs/index-shared1.asciidoc
@@ -37,45 +37,45 @@ volume and variety of data.
 
 // Introduction
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/introduction.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/introduction.asciidoc
 include::static/introduction.asciidoc[]
 
 // Glossary and core concepts go here
 
 // Getting Started with Logstash
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/getting-started-with-logstash.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/getting-started-with-logstash.asciidoc
 include::static/getting-started-with-logstash.asciidoc[]
 
 // Advanced LS Pipelines
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/advanced-pipeline.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/advanced-pipeline.asciidoc
 include::static/advanced-pipeline.asciidoc[]
 
 // Processing Pipeline
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/life-of-an-event.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/life-of-an-event.asciidoc
 include::static/life-of-an-event.asciidoc[]
 
 // Lostash setup
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/setting-up-logstash.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/setting-up-logstash.asciidoc
 include::static/setting-up-logstash.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/settings-file.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/settings-file.asciidoc
 include::static/settings-file.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/running-logstash-command-line.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/running-logstash-command-line.asciidoc
 include::static/running-logstash-command-line.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/running-logstash.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/running-logstash.asciidoc
 include::static/running-logstash.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/docker.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/docker.asciidoc
 include::static/docker.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/logging.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/logging.asciidoc
 include::static/logging.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/shutdown.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/shutdown.asciidoc
 include::static/shutdown.asciidoc[]

--- a/docs/index-shared3.asciidoc
+++ b/docs/index-shared3.asciidoc
@@ -1,84 +1,88 @@
 
 // Upgrading Logstash
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/upgrading.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/upgrading.asciidoc
 include::static/upgrading.asciidoc[]
 
 // Configuring Logstash
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/configuration.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/configuration.asciidoc
 include::static/configuration.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/multiple-pipelines.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/multiple-pipelines.asciidoc
 include::static/multiple-pipelines.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/reloading-config.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/reloading-config.asciidoc
 include::static/reloading-config.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/managing-multiline-events.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/managing-multiline-events.asciidoc
 include::static/managing-multiline-events.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/glob-support.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/glob-support.asciidoc
 include::static/glob-support.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/ingest-convert.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/ingest-convert.asciidoc
 include::static/ingest-convert.asciidoc[]
 
 // Centralized configuration managements
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/config-management.asciidoc
 include::static/config-management.asciidoc[]
 
 // Working with Logstash Modules
 
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/modules.asciidoc
 include::static/modules.asciidoc[]
 
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/arcsight-module.asciidoc
 include::static/arcsight-module.asciidoc[]
 
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/netflow-module.asciidoc
 include::static/netflow-module.asciidoc[]
 
 // Working with Filebeat Modules
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/filebeat-modules.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/filebeat-modules.asciidoc
 include::static/filebeat-modules.asciidoc[]
 
 // Data resiliency
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/resiliency.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/resiliency.asciidoc
 include::static/resiliency.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/persistent-queues.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/persistent-queues.asciidoc
 include::static/persistent-queues.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/dead-letter-queues.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/dead-letter-queues.asciidoc
 include::static/dead-letter-queues.asciidoc[]
 
 // Transforming Data
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/transforming-data.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/transforming-data.asciidoc
 include::static/transforming-data.asciidoc[]
 
 // Deploying & Scaling
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/deploying.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/deploying.asciidoc
 include::static/deploying.asciidoc[]
 
 // Troubleshooting performance
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/performance-checklist.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/performance-checklist.asciidoc
 include::static/performance-checklist.asciidoc[]
 
 // Monitoring overview
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/monitoring.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/monitoring.asciidoc
 include::static/monitoring.asciidoc[]
 
 // Monitoring APIs
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/monitoring-apis.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/monitoring-apis.asciidoc
 include::static/monitoring-apis.asciidoc[]
 
 // Working with Plugins
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/plugin-manager.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/plugin-manager.asciidoc
 include::static/plugin-manager.asciidoc[]
 
 // These files do their own pass blocks
@@ -101,12 +105,12 @@ include::static/output.asciidoc[]
 
 // Contributing a Patch to a Logstash Plugin
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/contributing-patch.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/contributing-patch.asciidoc
 include::static/contributing-patch.asciidoc[]
 
 // Logstash Community Maintainer Guide
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/maintainer-guide.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/maintainer-guide.asciidoc
 include::static/maintainer-guide.asciidoc[]
 
 // A space is necessary here ^^^
@@ -114,12 +118,12 @@ include::static/maintainer-guide.asciidoc[]
 
 // Submitting a Plugin
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/submitting-a-plugin.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/submitting-a-plugin.asciidoc
 include::static/submitting-a-plugin.asciidoc[]
 
 // Glossary of Terms
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/glossary.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/glossary.asciidoc
 include::static/glossary.asciidoc[]
 
 // This is in the pluginbody.asciidoc itself
@@ -127,5 +131,5 @@ include::static/glossary.asciidoc[]
 
 // Release Notes
 
-:edit_url: https://github.com/elastic/logstash/edit/master/docs/static/releasenotes.asciidoc
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/releasenotes.asciidoc
 include::static/releasenotes.asciidoc[]

--- a/docs/static/introduction.asciidoc
+++ b/docs/static/introduction.asciidoc
@@ -29,9 +29,7 @@ Where it all started.
 * Handle all types of logging data
 ** Easily ingest a multitude of web logs like {logstash-ref}/advanced-pipeline.html[Apache], and application
 logs like {logstash-ref}/plugins-inputs-log4j.html[log4j] for Java
-** Capture many other log formats like {logstash-ref}/plugins-inputs-syslog.html[syslog],
-//{logstash-ref}/plugins-inputs-eventlog.html[
-Windows event logs, networking and firewall logs, and more
+** Capture many other log formats like {logstash-ref}/plugins-inputs-syslog.html[syslog], networking and firewall logs, and more
 * Enjoy complementary secure log forwarding capabilities with https://www.elastic.co/products/beats/filebeat[Filebeat]
 * Collect metrics from {logstash-ref}/plugins-inputs-ganglia.html[Ganglia], {logstash-ref}/plugins-codecs-collectd.html[collectd],
 {logstash-ref}/plugins-codecs-netflow.html[NetFlow], {logstash-ref}/plugins-inputs-jmx.html[JMX], and many other infrastructure
@@ -58,9 +56,7 @@ Discover more value from the data you already own.
 * Better understand your data from any relational database or NoSQL store with a
 {logstash-ref}/plugins-inputs-jdbc.html[JDBC] interface
 * Unify diverse data streams from messaging queues like Apache {logstash-ref}/plugins-outputs-kafka.html[Kafka],
-{logstash-ref}/plugins-outputs-rabbitmq.html[RabbitMQ], {logstash-ref}/plugins-outputs-sqs.html[Amazon SQS], and
-//{logstash-ref}/plugins-outputs-zeromq.html[
-ZeroMQ
+{logstash-ref}/plugins-outputs-rabbitmq.html[RabbitMQ] and {logstash-ref}/plugins-outputs-sqs.html[Amazon SQS]
 
 [float]
 === Sensors and IoT
@@ -107,7 +103,6 @@ analyzing, and taking action on your data.
 
 * {logstash-ref}/plugins-outputs-webhdfs.html[HDFS]
 * {logstash-ref}/plugins-outputs-s3.html[S3]
-//* {logstash-ref}/plugins-outputs-google_cloud_storage.html[Google Cloud Storage]
 
 *Monitoring*
 


### PR DESCRIPTION
@andrewvc When we flipped the versions for 6.2, we had some broken links because [this commit ](https://github.com/elastic/logstash/commit/a5462f516b9a6d97e75cab130814edb2114f8b06#diff-27ef4dc573a26a68662c5664a6706d7aL33) was never made to 6.2 (and, I'm assuming, 6.x).

I've fixed the link related issues, but I don't want to make changes to the breaking changes because I assume there have been other changes since you made your commit. Can you take a look and let me know if there's anything else from [your commit](https://github.com/elastic/logstash/commit/a5462f516b9a6d97e75cab130814edb2114f8b06#diff-27ef4dc573a26a68662c5664a6706d7aL33) that needs to go into 6.2 and 6.x?