### PR TITLE
BUG: Inflight batches for in memory queue reader fixed

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryReadClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryReadClientExt.java
@@ -4,7 +4,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import org.jruby.Ruby;
-import org.jruby.RubyBasicObject;
 import org.jruby.RubyClass;
 import org.jruby.RubyHash;
 import org.jruby.RubyNumeric;
@@ -101,7 +100,9 @@ public final class JrubyMemoryReadClientExt extends RubyObject {
 
     @JRubyMethod(name = "inflight_batches")
     public IRubyObject rubyGetInflightBatches(final ThreadContext context) {
-        return RubyHash.newHash(context.runtime, inflightBatches, RubyBasicObject.UNDEF);
+        final RubyHash result = RubyHash.newHash(context.runtime);
+        result.putAll(inflightBatches);
+        return result;
     }
 
     // create a new, empty batch

--- a/logstash-core/src/test/java/org/logstash/ext/JrubyMemoryReadClientExtTest.java
+++ b/logstash-core/src/test/java/org/logstash/ext/JrubyMemoryReadClientExtTest.java
@@ -1,0 +1,34 @@
+package org.logstash.ext;
+
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import org.jruby.RubyHash;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.junit.Test;
+import org.logstash.RubyUtil;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests for {@link JrubyMemoryReadClientExt}.
+ */
+public final class JrubyMemoryReadClientExtTest {
+
+    @Test
+    public void testInflightBatchesTracking() throws InterruptedException {
+        final BlockingQueue<JrubyEventExtLibrary.RubyEvent> queue =
+            new ArrayBlockingQueue<>(10);
+        final JrubyMemoryReadClientExt client =
+            JrubyMemoryReadClientExt.create(queue, 5, 50);
+        final ThreadContext context = RubyUtil.RUBY.getCurrentContext();
+        final IRubyObject batch = client.readBatch(context);
+        final RubyHash inflight = (RubyHash) client.rubyGetInflightBatches(context);
+        assertThat(inflight.size(), is(1));
+        assertThat(inflight.get(Thread.currentThread().getId()), is(batch));
+        client.closeBatch(context, batch);
+        assertThat(((Map<?, ?>) client.rubyGetInflightBatches(context)).size(), is(0));
+    }
+}


### PR DESCRIPTION
Obvious bug, my bad :)

```java
return RubyHash.newHash(context.runtime, inflightBatches, RubyBasicObject.UNDEF);
```

This only works if the input Map (`inflightBatches`) is `<IRubyObject,IRubyObject>` which it isn't.
The auto conversion from Java to Ruby only happens for `putAll`:

* adjusted accordingly
* added tests