### PR TITLE
BUG: Memory Queue needs to always be drained

### DIFF
--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -171,7 +171,7 @@ module LogStash; class JavaPipeline < JavaBasePipeline
     @filter_queue_client.set_pipeline_metric(
         metric.namespace([:stats, :pipelines, pipeline_id.to_s.to_sym, :events])
     )
-    @drain_queue =  @settings.get_value("queue.drain")
+    @drain_queue =  @settings.get_value("queue.drain") || settings.get("queue.type") == "memory"
 
     @events_filtered = Concurrent::AtomicFixnum.new(0)
     @events_consumed = Concurrent::AtomicFixnum.new(0)

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -183,7 +183,7 @@ module LogStash; class Pipeline < BasePipeline
     @filter_queue_client.set_pipeline_metric(
         metric.namespace([:stats, :pipelines, pipeline_id.to_s.to_sym, :events])
     )
-    @drain_queue =  @settings.get_value("queue.drain")
+    @drain_queue =  @settings.get_value("queue.drain") || settings.get("queue.type") == "memory"
 
 
     @events_filtered = Concurrent::AtomicFixnum.new(0)

--- a/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
+++ b/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
@@ -66,7 +66,7 @@ public final class WorkerLoop implements Runnable {
                 if (isFlush) {
                     flushing.set(false);
                 }
-            } while (!shutdownRequested && !isDraining(context));
+            } while (!shutdownRequested || isDraining(context));
             //we are shutting down, queue is drained if it was required, now  perform a final flush.
             //for this we need to create a new empty batch to contain the final flushed events
             final IRubyObject batch = readClient.callMethod(context, "new_batch");


### PR DESCRIPTION
Fixes the issue of finite pipeline runs not processing all events because they don't drain the in-memory queue.
This was introduced by `6.1` moving to an `ArrayBlockingQueue` instead of a `SynchronousQueue` introducing a capacity into the pipeline there.
=> trivial to fix by always draining the in-memory queue.
=> Also I found that the worker loop condition regarding the draining was logically wrong :( => fixed

--------------

* This needs a slightly different backport to `6.1` because we don't have the `WorkerLoop` in Java there (so it's just a one-liner in `6.1`).
* I have no idea how to write a test for this since all the Ruby specs have the PQ hardcoded in the global static settings. We'll have to revisit this once we have better infrastructure there imo.
