### PR TITLE
MINOR: Remove unused method in java pipeline

### DIFF
--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -623,10 +623,6 @@ module LogStash; class JavaPipeline < JavaBasePipeline
     keys
   end
 
-  def draining_queue?
-    @drain_queue ? !@filter_queue_client.empty? : false
-  end
-
   def wrapped_write_client(plugin_id)
     #need to ensure that metrics are initialized one plugin at a time, else a race condition can exist.
     @mutex.synchronize do


### PR DESCRIPTION
This one isn't used anymore since the worker loop is now in Java as a result of #8988 