### PR TITLE
BUILD: Remove  `system` invocations in rake tasks

### DIFF
--- a/rakelib/dependency.rake
+++ b/rakelib/dependency.rake
@@ -4,6 +4,10 @@ namespace "dependency" do
     Rake::Task["gem:require"].invoke("bundler", "~> 1.9.4")
   end
 
+  task "clamp" do
+    Rake::Task["gem:require"].invoke("clamp", "~> 0.6.5")
+  end
+
   task "rbx-stdlib" do
     Rake::Task["gem:require"].invoke("rubysl", ">= 0")
   end # task rbx-stdlib

--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -4,8 +4,8 @@ require 'rubygems'
 namespace "plugin" do
 
   def install_plugins(*args)
-    system("bin/logstash-plugin", "install", *args)
-    raise(RuntimeError, $!.to_s) unless $?.success?
+    require_relative "../lib/pluginmanager/main"
+    LogStash::PluginManager::Main.run("bin/logstash-plugin", ["install"] + args)
   end
 
   task "install-development-dependencies" => "bootstrap" do

--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -9,22 +9,6 @@ namespace "vendor" do
 
   task "all" => "jruby"
 
-  task "system_gem", :jruby_bin, :name, :version do |task, args|
-    jruby_bin = args[:jruby_bin]
-    name = args[:name]
-    version = args[:version]
-
-    IO.popen([jruby_bin, "-S", "gem", "list", name, "--version", version, "--installed"], "r") do |io|
-      io.readlines # ignore
-    end
-    unless $?.success?
-      puts("Installing #{name} #{version} because the build process needs it.")
-      system(jruby_bin, "-S", "gem", "install", name, "-v", version, "--no-ri", "--no-rdoc")
-      raise RuntimeError, $!.to_s unless $?.success?
-    end
-    task.reenable # Allow this task to be run again
-  end
-
   namespace "force" do
     task "gems" => ["vendor:gems"]
   end
@@ -32,6 +16,7 @@ namespace "vendor" do
   task "gems", [:bundle] do |task, args|
     require "bootstrap/environment"
 
+    Rake::Task["dependency:clamp"].invoke
     Rake::Task["dependency:bundler"].invoke
 
     puts("Invoking bundler install...")


### PR DESCRIPTION
Top to bottom:

* Inline call to plugin manager from `rake` instead of shelling out
   * Seems to make the build ~30s faster overall, locally as well as on Jenkins
* Install `clamp` because the plugin manager has it as a dependency
* Remove `system_gem` target since it's not used anywhere