### PR TITLE
MINOR: Cleanup dead field and wrong ruby path in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,11 +143,8 @@ task downloadAndInstallJRuby(dependsOn: verifyFile, type: Copy) {
     into "${projectDir}/vendor/jruby"
 }
 
-def jrubyBin = "${projectDir}/vendor/jruby/bin/jruby" +
-  (System.getProperty("os.name").startsWith("Windows") ? '.bat' : '')
-
-def rubyBin = "${projectDir}/bin/ruby" +
-  (System.getProperty("os.name").startsWith("Windows") ? '.bat' : '')
+def rubyBin = "${projectDir}" +
+  (System.getProperty("os.name").startsWith("Windows") ? '/vendor/jruby/bin/jruby.bat' : '/bin/ruby')
 
 task installTestGems(dependsOn: downloadAndInstallJRuby) {
   inputs.files file("${projectDir}/Gemfile.template")


### PR DESCRIPTION
* `jrubyBin` wasn't used anymore and just snuck back in via a merge issue it seems
  * Removed it
* Also, there is no `/bin/ruby.bat` we only have `bin/ruby` => pointed the Windows version at the unwrapped `ruby` executable for now