### PR TITLE
Minor fix to make wording consistent

### DIFF
--- a/docs/include/plugin_header.asciidoc
+++ b/docs/include/plugin_header.asciidoc
@@ -15,8 +15,8 @@ endif::[]
 
 ifeval::["{versioned_docs}"!="true"]
 
-For other plugin versions, see the
-{lsplugindocs}/{type}-{plugin}-index.html[Versioned {plugin} {type} plugin docs].
+For other versions, see the
+{lsplugindocs}/{type}-{plugin}-index.html[Versioned plugin docs].
 
 endif::[]
 


### PR DESCRIPTION
The link will point to the correct docs for the selected plugin, but having the name in the link text just makes it harder to read.  