### PR TITLE
Remove unused NodeStats#mem_payload

### DIFF
--- a/logstash-core/lib/logstash/api/modules/node_stats.rb
+++ b/logstash-core/lib/logstash/api/modules/node_stats.rb
@@ -53,10 +53,6 @@ module LogStash
           @stats.process
         end
 
-        def mem_payload
-          @stats.memory
-        end
-
         def pipeline_payload(val = nil)
           opts = {:vertices => as_boolean(params.fetch("vertices", false))}
           @stats.pipeline(val, opts)


### PR DESCRIPTION
The method was added in https://github.com/elastic/logstash/pull/5381/files#diff-5b309943da7f980637d1fb663cacd01a.
AFAICT it's not used at the moment.

```
$ git grep mem_payload
logstash-core/lib/logstash/api/modules/node_stats.rb:        def mem_payload
```