### PR TITLE
BUILD: Fix wrong paths and wrong output declarations on installTestGems task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,24 +116,30 @@ project(":logstash-core") {
   }
 }
 
+def jrubyTarPath = "${projectDir}/vendor/_/jruby-bin-${jRubyVersion}.tar.gz"
+
 task downloadJRuby(type: Download) {
     description "Download JRuby artifact from this specific URL: ${jRubyURL}"
     src jRubyURL
     onlyIfNewer true
+    inputs.file("${projectDir}/versions.yml")
+    outputs.file(jrubyTarPath)
     dest new File("${projectDir}/vendor/_", "jruby-bin-${jRubyVersion}.tar.gz")
 }
 
 task verifyFile(dependsOn: downloadJRuby, type: Verify) {
     description "Verify the SHA1 of the download JRuby artifact"
-    src new File("${projectDir}/vendor/_/jruby-bin-${jRubyVersion}.tar.gz")
+    inputs.file(jrubyTarPath)
+    outputs.file(jrubyTarPath)
+    src new File(jrubyTarPath)
     algorithm 'SHA-1'
     checksum jRubySha1
 }
 
 task downloadAndInstallJRuby(dependsOn: verifyFile, type: Copy) {
     description "Install JRuby in the vendor directory"
-    inputs.files file("${projectDir}/versions.yml")
-    outputs.files fileTree("${projectDir}/vendor/jruby")
+    inputs.file(jrubyTarPath)
+    outputs.dir("${projectDir}/vendor/jruby")
     from tarTree(downloadJRuby.dest)
     eachFile { f ->
       f.path = f.path.replaceFirst("^jruby-${jRubyVersion}", '')
@@ -143,17 +149,13 @@ task downloadAndInstallJRuby(dependsOn: verifyFile, type: Copy) {
     into "${projectDir}/vendor/jruby"
 }
 
-def rubyBin = "${projectDir}" +
-  (System.getProperty("os.name").startsWith("Windows") ? '/vendor/jruby/bin/jruby.bat' : '/bin/ruby')
-
 task installTestGems(dependsOn: downloadAndInstallJRuby) {
   inputs.files file("${projectDir}/Gemfile.template")
   inputs.files fileTree("${projectDir}/rakelib")
   inputs.files file("${projectDir}/versions.yml")
-  outputs.files file("${projectDir}/Gemfile")
-  outputs.files file("${projectDir}/Gemfile.lock")
-  outputs.files fileTree("${projectDir}/vendor/bundle/jruby/2.3.0/gems")
-  outputs.files fileTree("${projectDir}/vendor/jruby")
+  outputs.file("${projectDir}/Gemfile")
+  outputs.file("${projectDir}/Gemfile.lock")
+  outputs.dir("${projectDir}/vendor/bundle/jruby/2.3.0")
   doLast {
     rubyGradleUtils.rake('test:install-core')
   }
@@ -228,6 +230,8 @@ task installIntegrationTestGems(dependsOn: installIntegrationTestBundler, type: 
 }
 
 def rubyIntegrationSpecs = project.hasProperty("rubyIntegrationSpecs") ? ((String) project.property("rubyIntegrationSpecs")).split(/\s+/) : []
+def rubyBin = "${projectDir}" +
+  (System.getProperty("os.name").startsWith("Windows") ? '/vendor/jruby/bin/jruby.bat' : '/bin/ruby')
 
 task runIntegrationTests(dependsOn: installIntegrationTestGems, type: Exec) {
   workingDir "${projectDir}/qa/integration"

--- a/buildSrc/src/main/groovy/org/logstash/gradle/RubyGradleUtils.groovy
+++ b/buildSrc/src/main/groovy/org/logstash/gradle/RubyGradleUtils.groovy
@@ -39,7 +39,7 @@ final class RubyGradleUtils {
   Object executeJruby(Closure<?> block) {
     def jruby = new ScriptingContainer()
     def env = jruby.environment
-    def gemDir = "${projectDir}/bundle/jruby/2.3.0".toString()
+    def gemDir = "${projectDir}/vendor/bundle/jruby/2.3.0".toString()
     env.put "USE_RUBY", "1"
     env.put "GEM_HOME", gemDir
     env.put "GEM_SPEC_CACHE", "${buildDir}/cache".toString()


### PR DESCRIPTION
This fixes the obviously wrong `GEM_PATH` in `RubyGradleUtils.groovy` that caused one to have to run the Gradle `clean` goal needlessly (can reproduce this with `master` locally and also observed this together with @danhermann the other day).

* reproducer for concrete issue `./gradle clean test && ./gradlew test` => second `./gradlew test` fails because it can't find `bundler` in the wrong `GEM_DIR`

This issue isn't visible on CI because only `./gradlew clean test` still works (and CI always starts from a  clean state). Running the `test` goal without previously having run the `installTestGems` task (as a reult of a previous `clean`) was broken because now the gems weren't loaded correctly for subsequent tasks. 

Moreover, there were an additional two issues with the `installTestGems` task declaring its outputs:
* The `vendor/jruby` folder isn't an output of this task, it's an output of a previous task, this was causing some confusion for Gradle
* Using `fileTree` for output directories isn't stable in Gradle since `fileTree` is evaluated lazily. Moved to `.dir` and `.file` to fix wrong output declarations
   * This wasn't really visible before because the path declaration for `installTestGems` was wrong but then fixed by #8984 ... so what happened was that no change to the gem dir was ever registered because it was looking at the wrong non-existent dir => you needed to run the `clean` goal if your `bundle/jruby/2.3.0/gems` dir changed.

------------------------

Also:

* Fixed `verifyFile` task to have proper input and output declarations to be able to test that we actually don't run any more redundant tasks
* moved `def rubyBin` to a lower place in the build file where it's actually used to make things a little less confusing