### PR TITLE
[WIP]Upgrade to JRuby 9.1.15.0

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -6,8 +6,8 @@ logstash-core-plugin-api: 2.1.16
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time
 jruby:
-  version: 9.1.13.0
-  sha1: 815bac27d5daa1459a4477d6d80584f007ce6a68
+  version: 9.1.15.0
+  sha1: 852b3dfd8b56a314ea4bf9502022a1f9edb8d7f6
 
 # jruby-runtime-override, if specified, will override the jruby version installed in vendor/jruby for logstash runtime only,
 # not for the compile-time jars


### PR DESCRIPTION
We're still on `9.1.13.0` as result of #8738.

JRuby decided to not fix the behaviour change that led to #8738 in https://github.com/jruby/jruby/issues/4869#issuecomment-347440181 => we should go back to the latest version and fix things some other way if there is still an actual issue that could affect users.
