### PR TITLE
Release notes for 6.1.3

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in the following releases:
 
+* <<logstash-6-1-3,Logstash 6.1.3>>
 * <<logstash-6-1-2,Logstash 6.1.2>>
 * <<logstash-6-1-1,Logstash 6.1.1>>
 * <<logstash-6-1-0,Logstash 6.1.0>>
@@ -12,6 +13,44 @@ See also:
 
 * <<release-notes-xls>>
 endif::include-xpack[]
+
+[[logstash-6-1-3]]
+=== Logstash 6.1.3 Release Notes
+
+* Fix bug where with terminating input plugins in-memory queue might not be drained. This could happen in some situations with inputs like the stdin input or the Elasticsearch input. This could result in some messages not being processed. See 
+* Correctly handle paths with spaces on Windows. See https://github.com/elastic/logstash/pull/8931[#8931] for details.
+
+=== Plugins
+
+*Multiline Codec*
+
+* Fixed concurrency issue causing random failures when multiline codec was used together with a multi-threaded input plugin
+
+*CSV Filter*
+
+* Added support for tagging empty rows which users can reference to conditionally drop events
+
+*Elasticsearch Filter*
+
+* If elasticsearch response contains a shard failure, then tag_on_failure tags are added to Logstash event
+* Enhancement : add support for nested fields
+* Enhancement : add 'docinfo_fields' option
+* Enhancement : add 'aggregation_fields' option
+
+*Elasticsearch Input*
+
+* Add support for scheduling periodic execution of the query
+
+*RabbitMQ Input/Output*
+
+* Bug Fix: undefined method `value' for nil:NilClass with SSL enabled, but no certificates provided
+* Output Only: Use shared concurrency / multiple channels for performance
+
+*HTTP Output*
+
+* Added json_batch format
+* Make 429 responses log at debug, not error level. They are really just flow control
+
 
 [[logstash-6-1-2]]
 === Logstash 6.1.2 Release Notes


### PR DESCRIPTION
Does what it says on the tin.

Diff: `git log v6.1.2..ff7c29c`