### PR TITLE
JAVAFICATION: Use Longadder instead of Ruby Concurrent AtomicLong for pipeline counters

### DIFF
--- a/logstash-core/lib/logstash/pipeline_reporter.rb
+++ b/logstash-core/lib/logstash/pipeline_reporter.rb
@@ -70,11 +70,11 @@ module LogStash; class PipelineReporter
   private
 
   def events_filtered
-    pipeline.events_filtered.value
+    pipeline.events_filtered.sum
   end
 
   def events_consumed
-    pipeline.events_consumed.value
+    pipeline.events_consumed.sum
   end
 
   def plugin_threads


### PR DESCRIPTION
Trivial fix allowing us to remove another two instances of `IRubyObject#call` in the `WorkerLoop` :)
Simply changed `Concurrent::AtomicFixnum` to `LongAdder` and adjusted all callsites accordingly :) 