### PR TITLE
Change logstash-core-plugin-api to properly follow versions.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ tools/benchmark-cli/out/
 qa/integration/fixtures/offline_wrapper/offline
 qa/integration/fixtures/offline_wrapper/offline.o
 logstash-core/versions-gem-copy.yml
+versions-gem-copy.yml

--- a/Gemfile.jruby-1.9.lock.release
+++ b/Gemfile.jruby-1.9.lock.release
@@ -1,7 +1,7 @@
 PATH
   remote: ./logstash-core
   specs:
-    logstash-core (5.6.7-java)
+    logstash-core (5.6.8-java)
       chronic_duration (= 0.10.6)
       clamp (~> 0.6.5)
       concurrent-ruby (~> 1.0, >= 1.0.5)
@@ -18,7 +18,7 @@ PATH
       puma (~> 2.16)
       rack (= 1.6.6)
       ruby-maven (~> 3.3.9)
-      rubyzip (~> 1.1.7)
+      rubyzip (~> 1.2.1)
       sinatra (~> 1.4, >= 1.4.6)
       stud (~> 0.0.19)
       thread_safe (~> 0.3.5)
@@ -28,7 +28,7 @@ PATH
   remote: ./logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.29-java)
-      logstash-core (= 5.6.7)
+      logstash-core (= 5.6.8)
 
 GEM
   remote: https://rubygems.org/
@@ -51,7 +51,7 @@ GEM
       nokogiri (~> 1)
     backports (3.9.1)
     benchmark-ips (2.7.2)
-    bindata (2.4.1)
+    bindata (2.4.2)
     buftok (0.2.0)
     builder (3.2.3)
     cabin (0.9.0)
@@ -166,9 +166,9 @@ GEM
       jls-grok (~> 0.11.1)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-patterns-core
-    logstash-codec-netflow (3.10.0)
+    logstash-codec-netflow (3.11.0)
       bindata (>= 1.5.0)
-      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-core-plugin-api (~> 2.0)
     logstash-codec-plain (3.0.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-codec-rubydebug (3.0.5)
@@ -193,7 +193,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-date (3.1.9)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-dissect (1.1.2)
+    logstash-filter-dissect (1.1.3)
       jar-dependencies
       logstash-core-plugin-api (>= 2.1.1, <= 2.99)
     logstash-filter-dns (3.0.7)
@@ -206,7 +206,7 @@ GEM
       murmurhash3
     logstash-filter-geoip (4.3.1-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-grok (4.0.1)
+    logstash-filter-grok (4.0.2)
       jls-grok (~> 0.11.3)
       logstash-core (>= 5.6.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -521,7 +521,7 @@ GEM
     mustache (0.99.8)
     naught (1.1.0)
     netrc (0.11.0)
-    nokogiri (1.8.1-java)
+    nokogiri (1.8.2-java)
     numerizer (0.1.1)
     octokit (3.8.0)
       sawyer (~> 0.6.0, >= 0.5.3)
@@ -570,13 +570,13 @@ GEM
       ruby-maven-libs (~> 3.3.9)
     ruby-maven-libs (3.3.9)
     ruby-progressbar (1.8.3)
-    rubyzip (1.1.7)
+    rubyzip (1.2.1)
     rufus-scheduler (3.0.9)
       tzinfo
     sawyer (0.6.0)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
-    sequel (5.4.0)
+    sequel (5.5.0)
     simple_oauth (0.3.1)
     simplecov (0.15.1)
       docile (~> 1.1.0)
@@ -617,7 +617,7 @@ GEM
       simple_oauth (~> 0.3.0)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
-    tzinfo-data (1.2017.3)
+    tzinfo-data (1.2018.3)
       tzinfo (>= 1.0.0)
     unf (0.1.4-java)
     webhdfs (0.8.0)
@@ -747,7 +747,7 @@ DEPENDENCIES
   rest-client (= 1.8.0)
   rspec (~> 3.1.0)
   ruby-progressbar (~> 1.8.1)
-  rubyzip (~> 1.1.7)
+  rubyzip (~> 1.2.1)
   simplecov
   stud (~> 0.0.22)
   term-ansicolor (~> 1.3.2)

--- a/Gemfile.template
+++ b/Gemfile.template
@@ -19,7 +19,7 @@ gem "benchmark-ips", :group => :development
 gem "octokit", "3.8.0", :group => :build
 gem "stud", "~> 0.0.22", :group => :build
 gem "fpm", "~> 1.3.3", :group => :build
-gem "rubyzip", "~> 1.1.7", :group => :build
+gem "rubyzip", "~> 1.2.1", :group => :build
 gem "gems", "~> 0.8.3", :group => :build
 # ------- Pinned till we have Jruby 9k with ruby 2.0 support
 gem "rack", "1.6.6"

--- a/NOTICE.TXT
+++ b/NOTICE.TXT
@@ -57,6 +57,29 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================================================
+RubyGem: jar-dependencies Version: 0.3.12
+Copyright (c) 2014 Christian Meier
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================================================
 RubyGem: lru_redux Version: 1.1.0
 Copyright (c) 2013 Sam Saffron
 
@@ -98,9 +121,9 @@ RubyGem: elasticsearch Version: 5.0.4
    limitations under the License.
 
 ==========================================================================
-RubyGem: sequel Version: 5.4.0
+RubyGem: sequel Version: 5.5.0
 Copyright (c) 2007-2008 Sharon Rosner
-Copyright (c) 2008-2017 Jeremy Evans
+Copyright (c) 2008-2018 Jeremy Evans
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -142,8 +165,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==========================================================================
-RubyGem: tzinfo-data Version: 1.2017.3
-Copyright (c) 2005-2017 Philip Ross
+RubyGem: tzinfo-data Version: 1.2018.3
+Copyright (c) 2005-2018 Philip Ross
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/logstash-core-plugin-api/lib/logstash-core-plugin-api/version.rb
+++ b/logstash-core-plugin-api/lib/logstash-core-plugin-api/version.rb
@@ -1,1 +1,17 @@
-LOGSTASH_CORE_PLUGIN_API = "2.1.29"
+# encoding: utf-8
+
+# The version of logstash core plugin api gem.
+#
+# sourced from a copy of the master versions.yml file, see logstash-core/logstash-core.gemspec
+if !defined?(ALL_VERSIONS)
+  require 'yaml'
+  ALL_VERSIONS = YAML.load_file(File.expand_path("../../versions-gem-copy.yml", File.dirname(__FILE__)))
+end
+
+unless defined?(LOGSTASH_CORE_PLUGIN_API)
+  LOGSTASH_CORE_PLUGIN_API = ALL_VERSIONS.fetch("logstash-core-plugin-api")
+end
+
+unless defined?(LOGSTASH_CORE_VERSION)
+  LOGSTASH_CORE_VERSION = ALL_VERSIONS.fetch("logstash-core")
+end

--- a/logstash-core-plugin-api/logstash-core-plugin-api.gemspec
+++ b/logstash-core-plugin-api/logstash-core-plugin-api.gemspec
@@ -1,6 +1,25 @@
 # -*- encoding: utf-8 -*-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+project_versions_yaml_path = File.expand_path("../versions.yml", File.dirname(__FILE__))
+if File.exist?(project_versions_yaml_path)
+  # we need to copy the project level versions.yml into the gem root
+  # to be able to package it into the gems file structure
+  # as the require 'logstash-core-plugin-api/version' loads the yaml file from within the gem root.
+  #
+  # we ignore the copy in git and we overwrite an existing file
+  # each time we build the logstash-core gem
+  original_lines = IO.readlines(project_versions_yaml_path)
+  original_lines << ""
+  original_lines << "# This is a copy the project level versions.yml into this gem's root and it is created when the gemspec is evaluated."
+  gem_versions_yaml_path = File.expand_path("./versions-gem-copy.yml", File.dirname(__FILE__))
+  File.open(gem_versions_yaml_path, 'w') do |new_file|
+    # create or overwrite
+    new_file.puts(original_lines)
+  end
+end
+
 require "logstash-core-plugin-api/version"
 
 Gem::Specification.new do |gem|
@@ -17,7 +36,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = LOGSTASH_CORE_PLUGIN_API
 
-  gem.add_runtime_dependency "logstash-core", "5.6.7"
+  gem.add_runtime_dependency "logstash-core", LOGSTASH_CORE_VERSION.gsub("-", ".")
 
   # Make sure we dont build this gem from a non jruby
   # environment.

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |gem|
 
   # Later versions are ruby 2.0 only. We should remove the rack dep once we support 9k
   gem.add_runtime_dependency "rack", '1.6.6'
-  
+
   gem.add_runtime_dependency "sinatra", '~> 1.4', '>= 1.4.6'
   gem.add_runtime_dependency 'puma', '~> 2.16'
   gem.add_runtime_dependency "jruby-openssl", "0.9.19" # >= 0.9.13 Required to support TLSv1.2
@@ -65,7 +65,7 @@ Gem::Specification.new do |gem|
 
   # filetools and rakelib
   gem.add_runtime_dependency "minitar", "~> 0.6.1"
-  gem.add_runtime_dependency "rubyzip", "~> 1.1.7"
+  gem.add_runtime_dependency "rubyzip", "~> 1.2.1"
   gem.add_runtime_dependency "thread_safe", "~> 0.3.5" #(Apache 2.0 license)
 
   gem.add_runtime_dependency "jrjackson", "~> #{ALL_VERSIONS.fetch('jrjackson')}" #(Apache 2.0 license)


### PR DESCRIPTION
This unifies the 5.6, 6.X and 7.X mechanism for only needing to change version number in `versions.yml`

Fixes
https://internal-ci.elastic.co/job/elastic+release-manager+5.6+unified-snapshot/202/console
and
https://travis-ci.org/logstash-plugins/logstash-filter-mutate/jobs/335999317

Tested with `rake artifact:zip` and running a few configs through the unpacked artifact.