### PR TITLE
 6.2 release notes (undo revert)

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in the following releases:
 
+* <<logstash-6-2-0,Logstash 6.2.0>>
 * <<logstash-6-1-3,Logstash 6.1.3>>
 * <<logstash-6-1-2,Logstash 6.1.2>>
 * <<logstash-6-1-1,Logstash 6.1.1>>
@@ -14,6 +15,35 @@ See also:
 * <<release-notes-xls>>
 endif::include-xpack[]
 
+[[logstash-6-2-0]]
+=== Logstash 6.2.0 Release Notes
+
+* Added support to protect sensitive settings and configuration in a https://www.elastic.co/guide/en/logstash/current/keystore.html[keystore]
+* Added https://www.elastic.co/guide/en/logstash/current/plugins-filters-jdbc_static.html[JDBC static filter] as a default plugin
+* Set better defaults to allow for higher throughput under load. https://github.com/elastic/logstash/issues/8707[#8707] https://github.com/elastic/logstash/issues/8702[#8702]
+* Set default configuration for RPM/DEB/Docker installations to use https://www.elastic.co/guide/en/logstash/current/multiple-pipelines.html[Multiple pipelines]
+* Added default max size value (100MB) for log files.
+* Added compression when log files are rolled (for ZIP-based installs).
+* Added ability to specify `--pipeline.id` from the command line https://github.com/elastic/logstash/issues/8868[#8868]
+* Implemented continued improvements to the next generation of execution. Give it a try with the command line switch `--experimental-java-execution`
+
+==== Plugins
+
+*JDBC Static Filter*
+
+* Initial release
+
+*Dissect Filter*
+
+* Bug fixes. See plugin release notes for https://github.com/logstash-plugins/logstash-filter-dissect/blob/master/CHANGELOG.md#113[1.1.3]
+
+*Grok Filter*
+
+* Fix thread leak on when Logstash is reloaded
+
+*Kafka Output*
+
+* Improve error logging when a producer cannot be created.
 
 [[logstash-6-1-3]]
 === Logstash 6.1.3 Release Notes

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -18,10 +18,10 @@ endif::include-xpack[]
 [[logstash-6-2-0]]
 === Logstash 6.2.0 Release Notes
 
-* Added support to protect sensitive settings and configuration in a https://www.elastic.co/guide/en/logstash/current/keystore.html[keystore]
-* Added https://www.elastic.co/guide/en/logstash/current/plugins-filters-jdbc_static.html[JDBC static filter] as a default plugin
+* Added support to protect sensitive settings and configuration in a keystore
+* Added {logstash-ref}/plugins-filters-jdbc_static.html[JDBC static filter] as a default plugin
 * Set better defaults to allow for higher throughput under load. https://github.com/elastic/logstash/issues/8707[#8707] https://github.com/elastic/logstash/issues/8702[#8702]
-* Set default configuration for RPM/DEB/Docker installations to use https://www.elastic.co/guide/en/logstash/current/multiple-pipelines.html[Multiple pipelines]
+* Set default configuration for RPM/DEB/Docker installations to use {logstash-ref}/multiple-pipelines.html[Multiple pipelines]
 * Added default max size value (100MB) for log files.
 * Added compression when log files are rolled (for ZIP-based installs).
 * Added ability to specify `--pipeline.id` from the command line https://github.com/elastic/logstash/issues/8868[#8868]


### PR DESCRIPTION
@dedemorton - The original merge seemed to cause an issue with doc build. Can you please assist in troubleshoot why this may have caused a failure. 

This PR re-introduces the reverted commit. 