### PR TITLE
Fix empty array in boolean condition, NPE in boolean comparison

### DIFF
--- a/logstash-core/lib/logstash/compiler/treetop_monkeypatches.rb
+++ b/logstash-core/lib/logstash/compiler/treetop_monkeypatches.rb
@@ -90,4 +90,16 @@ class Treetop::Runtime::SyntaxNode
         ""
       )
   end
+
+  def _parse_context(context = self)
+    start = interval.min
+    "line #{input.line_of(start)}, " +
+        "column #{input.column_of(start)} (byte #{start+1}) " +
+        "in `#{context.text_value}`"
+  end
+
+  def _node_type_name
+    name = self.class.name
+    name ? name.split('::').last : 'SyntaxNode'
+  end
 end

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/EventCondition.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/EventCondition.java
@@ -577,9 +577,10 @@ public interface EventCondition {
             }
 
             @Override
-            public boolean fulfilled(final JrubyEventExtLibrary.RubyEvent event) {
-                return event.getEvent().getUnconvertedField(one)
-                    .equals(event.getEvent().getUnconvertedField(other));
+            public boolean fulfilled(final JrubyEventExtLibrary.RubyEvent eventWrapper) {
+                final Event event = eventWrapper.getEvent();
+                return Objects.equals(event.getUnconvertedField(one),
+                                      event.getUnconvertedField(other));
             }
         }
 


### PR DESCRIPTION
Merge-targets:
 - `master`,
 - `6.x`,
 - `6.2` (currently feature frozen for pending 6.2.0)

Fixes two separate issues:

 - NPE when LHS of boolean-equals or boolean-not-equals expression references unset field
 - Pipeline compilation error when configuration specifies literal empty array

Each commit contains rationale, etc.