### PR TITLE
Making config.test_and_exit more explicit for invalid configurations …

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -324,6 +324,7 @@ class LogStash::Runner < Clamp::StrictCommand
           puts "Configuration OK"
           logger.info "Using config.test_and_exit mode. Config Validation Result: OK. Exiting Logstash"
         else
+          puts "Configuration invalid. Check logstash-plain.log for clues"
           raise "Could not load the configuration file"
         end
         return 0


### PR DESCRIPTION
I would really like to give a user of Logstash an explicit error when the config check is running into problems. Please have a look at issue #9093 .

Although an error is raised in the function execute in logstash-core/lib/logstash/runner.rb, this isn't shown to the user. Successful configuration, however, is shown to the user.