### PR TITLE
Fix URL for versioned plugin reference

### DIFF
--- a/docs/index-shared1.asciidoc
+++ b/docs/index-shared1.asciidoc
@@ -19,7 +19,7 @@ release-state can be: released | prerelease | unreleased
 :filebeat:              https://www.elastic.co/guide/en/beats/filebeat/{branch}/
 :metricbeat:            https://www.elastic.co/guide/en/beats/metricbeat/{branch}/
 :lsissue:               https://github.com/elastic/logstash/issues/
-:lsplugindocs:          https://www.elastic.co/guide/en/logstash/versioned-plugins/current
+:lsplugindocs:          https://www.elastic.co/guide/en/logstash-versioned-plugins/current
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 


### PR DESCRIPTION
Changed the URL so that the versioned plugin reference build will not run *every* time the build is run with the --all option.