### PR TITLE
fix crash during exit when reporting on already-reaped thread

### DIFF
--- a/logstash-core/lib/logstash/util.rb
+++ b/logstash-core/lib/logstash/util.rb
@@ -37,7 +37,8 @@ module LogStash::Util
   end
 
   def self.thread_info(thread)
-    backtrace = thread.backtrace.map do |line|
+    # When the `thread` is dead, `Thread#backtrace` returns `nil`; fall back to an empty array.
+    backtrace = (thread.backtrace || []).map do |line|
       line.gsub(LogStash::Environment::LOGSTASH_HOME, "[...]")
     end
 


### PR DESCRIPTION
Although `LogStash::JavaBasePipeline#plugin_threads_info` attempts to only report on
living threads, it is possible for a thread to die/complete after the check and before
we attempt to extract status in `LogStash::Util#thread_info`; since `Thread#backtrace`
can return `nil` when the thread is no longer living, this causes a crash.

By falling back to an empty array when the backtrace cannot be ascertained from the
given thread, we can emit a thread status even if the thread has already completed.