### PR TITLE
Resolve review comments

### DIFF
--- a/docs/static/keystore.asciidoc
+++ b/docs/static/keystore.asciidoc
@@ -2,14 +2,12 @@
 === Secrets keystore
 
 When you configure Logstash, you might need to specify sensitive settings or
-configuration, such as passwords. Relying on the file system to protect these
-values is not sufficient. Logstash provides a keystore for storing secret values
-to use for configuration settings.
+configuration, such as passwords. Rather than relying on file system permissions
+to protect these values, you can use the Logstash keystore to securely store
+secret values for use in configuration settings.
 
-Unlike the Elasticsearch keystore, the Logstash keystore does not store
-actual configuration settings. Instead, you add a key and secret value to the
-keystore, and then use the key in place of the secret value when you configure
-sensitive settings.
+After adding a key and its secret value to the keystore, you can use the key in
+place of the secret value when you configure sensitive settings.
 
 The syntax for referencing keys is identical to the syntax for
 <<environment-variables, environment variables>>:
@@ -23,6 +21,11 @@ value `yourelasticsearchpassword`:
 
 * In configuration files, use: `output { elasticsearch {...password => "${ES_PWD}" } } }`
 * In `logstash.yml`, use: `xpack.management.elasticsearch.password: ${ES_PWD}`
+
+Notice that the Logstash keystore differs from the Elasticsearch keystore.
+Whereas the Elasticsearch keystore lets you store `elasticsearch.yml` values by
+name, the Logstash keystore lets you specify arbitrary names that you
+can reference in the Logstash configuration. 
 
 NOTE: Referencing keystore data from `pipelines.yml` or the command line (`-e`)
 is not currently supported.


### PR DESCRIPTION
Cleaned up the keystore description based on review comments from @jordansissel.

Moved the description of how LS keystore compares to ES to appear later in the document because it's not the main idea here and shouldn't be covered so early in the topic. 