### PR TITLE
Fix PQ stats with ruby pipeline

### DIFF
--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -679,7 +679,7 @@ module LogStash; class Pipeline < BasePipeline
   def collect_stats
     pipeline_metric = @metric.namespace([:stats, :pipelines, pipeline_id.to_s.to_sym, :queue])
     pipeline_metric.gauge(:type, settings.get("queue.type"))
-    if @queue.is_a?(LogStash::Util::WrappedAckedQueue) && @queue.queue.is_a?(LogStash::AckedQueue)
+    if @queue.is_a?(LogStash::WrappedAckedQueue) && @queue.queue.is_a?(LogStash::AckedQueue)
       queue = @queue.queue
       dir_path = queue.dir_path
       file_store = Files.get_file_store(Paths.get(dir_path))


### PR DESCRIPTION
Stats were not being collected when the PQ was enabled due to the
queue class type check not being updated after Javafication of
WrappedAckedQueue

Fixes https://github.com/elastic/x-pack-logstash/issues/335