### PR TITLE
Add pipelines.yml to RPM/DEB configured files to avoid overwrite on updrade

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -340,6 +340,7 @@ namespace "artifact" do
         out.config_files << "/etc/logstash/jvm.options"
         out.config_files << "/etc/logstash/log4j2.properties"
         out.config_files << "/etc/logstash/logstash.yml"
+        out.config_files << "/etc/logstash/pipelines.yml"
       when "debian", "ubuntu"
         require "fpm/package/deb"
         out = dir.convert(FPM::Package::Deb)
@@ -351,6 +352,7 @@ namespace "artifact" do
         out.config_files << "/etc/logstash/jvm.options"
         out.config_files << "/etc/logstash/log4j2.properties"
         out.config_files << "/etc/logstash/logstash.yml"
+        out.config_files << "/etc/logstash/pipelines.yml"
     end
 
     # Packaging install/removal scripts


### PR DESCRIPTION

Fixes #9129

----
This needs to be patched back as far as the 6.2 branch where this file was introduced as part of the packaging. 