### PR TITLE
Added java.lang.Byte and java.lang.Short Valuefier support

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Valuefier.java
+++ b/logstash-core/src/main/java/org/logstash/Valuefier.java
@@ -112,6 +112,8 @@ public final class Valuefier {
         converters.put(RubyBignum.class, IDENTITY);
         converters.put(RubyBigDecimal.class, IDENTITY);
         converters.put(String.class, input -> RubyUtil.RUBY.newString((String) input));
+        converters.put(Byte.class, input -> RubyUtil.RUBY.newString(input.toString()));
+        converters.put(Short.class, LONG_CONVERTER);
         converters.put(Float.class, FLOAT_CONVERTER);
         converters.put(Double.class, FLOAT_CONVERTER);
         converters.put(


### PR DESCRIPTION
Faced this issue when dequeuing messages from an IBM MQ queue.
I added a couple more converters for java.lang.Byte and java.lang.Short which happened to be produced when the Logstash JMS plugin was deserializing the message headers.
Could not provide a meaningful (i.e. not trivial) unit test but I'd add one if asked/required.
