### PR TITLE
Java API Proposal

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -121,6 +121,7 @@ dependencies {
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jacksonVersion}"
     compile "org.jruby:jruby-complete:${jrubyVersion}"
     compile 'com.google.googlejavaformat:google-java-format:1.5'
+    compile 'org.reflections:reflections:0.9.11'
     testCompile 'org.apache.logging.log4j:log4j-core:2.9.1:tests'
     testCompile 'junit:junit:4.12'
     testCompile 'net.javacrumbs.json-unit:json-unit:1.9.0'

--- a/logstash-core/src/main/java/org/logstash/execution/DiscoverPlugins.java
+++ b/logstash-core/src/main/java/org/logstash/execution/DiscoverPlugins.java
@@ -16,7 +16,7 @@ public final class DiscoverPlugins {
         for (final Class<?> cls : annotated) {
             System.out.println(cls.getName());
             System.out.println(((LogstashPlugin) cls.getAnnotations()[0]).name());
-            final Constructor<?> ctor = cls.getConstructor(LsConfiguration.class);
+            final Constructor<?> ctor = cls.getConstructor(LsConfiguration.class, LsContext.class);
             System.out.println("Found Ctor at : " + ctor.getName());
             if (Filter.class.isAssignableFrom(cls)) {
                 System.out.println("Filter");

--- a/logstash-core/src/main/java/org/logstash/execution/DiscoverPlugins.java
+++ b/logstash-core/src/main/java/org/logstash/execution/DiscoverPlugins.java
@@ -1,0 +1,32 @@
+package org.logstash.execution;
+
+import java.lang.reflect.Constructor;
+import java.util.Set;
+import org.reflections.Reflections;
+
+/**
+ * Quick demo of plugin discovery showing that the solution wouldn't require anything beyond
+ * the plugin classes on the classpath.
+ */
+public final class DiscoverPlugins {
+
+    public static void main(final String... args) throws NoSuchMethodException {
+        Reflections reflections = new Reflections("org.logstash");
+        Set<Class<?>> annotated = reflections.getTypesAnnotatedWith(LogstashPlugin.class);
+        for (final Class<?> cls : annotated) {
+            System.out.println(cls.getName());
+            System.out.println(((LogstashPlugin) cls.getAnnotations()[0]).name());
+            final Constructor<?> ctor = cls.getConstructor(LsConfiguration.class);
+            System.out.println("Found Ctor at : " + ctor.getName());
+            if (Filter.class.isAssignableFrom(cls)) {
+                System.out.println("Filter");
+            }
+            if (Output.class.isAssignableFrom(cls)) {
+                System.out.println("Output");
+            }
+            if (Input.class.isAssignableFrom(cls)) {
+                System.out.println("Input");
+            }
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/execution/Filter.java
+++ b/logstash-core/src/main/java/org/logstash/execution/Filter.java
@@ -21,8 +21,9 @@ public interface Filter extends AutoCloseable {
         /**
          * Required Constructor Signature only taking a {@link LsConfiguration}.
          * @param configuration Logstash Configuration
+         * @param context Logstash Context
          */
-        public Mutate(final LsConfiguration configuration) {
+        public Mutate(final LsConfiguration configuration, final LsContext context) {
             this.field = configuration.getString("ls.plugin.mutate.field");
             this.value = configuration.getString("ls.plugin.mutate.value");
         }

--- a/logstash-core/src/main/java/org/logstash/execution/Filter.java
+++ b/logstash-core/src/main/java/org/logstash/execution/Filter.java
@@ -1,11 +1,14 @@
 package org.logstash.execution;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import org.logstash.Event;
 
 /**
  * A Filter is simply a mapping of {@link QueueReader} to a new {@link QueueReader}.
  */
-public interface Filter extends AutoCloseable {
+public interface Filter extends LsPlugin {
 
     QueueReader filter(QueueReader reader);
 
@@ -62,8 +65,11 @@ public interface Filter extends AutoCloseable {
         }
 
         @Override
-        public void close() {
-            // Nothing to do here
+        public Collection<PluginConfigSpec<?>> configSchema() {
+            return Arrays.asList(
+                new PluginConfigSpec<>("field", String.class, null, false),
+                new PluginConfigSpec<>("value", String.class, null, false)
+            );
         }
     }
 
@@ -128,8 +134,8 @@ public interface Filter extends AutoCloseable {
         }
 
         @Override
-        public void close() {
-            // Nothing to do here
+        public Collection<PluginConfigSpec<?>> configSchema() {
+            return Collections.emptyList();
         }
     }
 }

--- a/logstash-core/src/main/java/org/logstash/execution/Filter.java
+++ b/logstash-core/src/main/java/org/logstash/execution/Filter.java
@@ -1,0 +1,68 @@
+package org.logstash.execution;
+
+import org.logstash.Event;
+
+/**
+ * A Filter is simply a mapping of {@link QueueReader} to a new {@link QueueReader}.
+ */
+public interface Filter extends AutoCloseable {
+
+    QueueReader filter(QueueReader reader);
+
+    void flush(boolean isShutdown);
+
+    @LogstashPlugin(name = "mutate")
+    final class Mutate implements Filter {
+
+        private final String field;
+
+        private final String value;
+
+        /**
+         * Required Constructor Signature only taking a {@link LsConfiguration}.
+         * @param configuration Logstash Configuration
+         */
+        public Mutate(final LsConfiguration configuration) {
+            this.field = configuration.getString("ls.plugin.mutate.field");
+            this.value = configuration.getString("ls.plugin.mutate.value");
+        }
+
+        @Override
+        public QueueReader filter(final QueueReader reader) {
+            return new QueueReader() {
+                @Override
+                public long poll(final Event event) {
+                    final long seq = reader.poll(event);
+                    if (seq > -1L) {
+                        event.setField(field, value);
+                    }
+                    return seq;
+                }
+
+                @Override
+                public long poll(final Event event, final long millis) {
+                    final long seq = reader.poll(event, millis);
+                    if (seq > -1L) {
+                        event.setField(field, value);
+                    }
+                    return seq;
+                }
+
+                @Override
+                public void acknowledge(final long sequenceNum) {
+                    reader.acknowledge(sequenceNum);
+                }
+            };
+        }
+
+        @Override
+        public void flush(final boolean isShutdown) {
+            // Nothing to do here
+        }
+
+        @Override
+        public void close() {
+            // Nothing to do here
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/execution/Filter.java
+++ b/logstash-core/src/main/java/org/logstash/execution/Filter.java
@@ -17,6 +17,12 @@ public interface Filter extends LsPlugin {
     @LogstashPlugin(name = "mutate")
     final class Mutate implements Filter {
 
+        private static final PluginConfigSpec<String> FIELD_CONFIG =
+            LsConfiguration.requiredStringSetting("field");
+
+        private static final PluginConfigSpec<String> VALUE_CONFIG =
+            LsConfiguration.requiredStringSetting("value");
+
         private final String field;
 
         private final String value;
@@ -27,8 +33,8 @@ public interface Filter extends LsPlugin {
          * @param context Logstash Context
          */
         public Mutate(final LsConfiguration configuration, final LsContext context) {
-            this.field = configuration.getString("field");
-            this.value = configuration.getString("value");
+            this.field = configuration.get(FIELD_CONFIG);
+            this.value = configuration.get(VALUE_CONFIG);
         }
 
         @Override
@@ -66,10 +72,7 @@ public interface Filter extends LsPlugin {
 
         @Override
         public Collection<PluginConfigSpec<?>> configSchema() {
-            return Arrays.asList(
-                new PluginConfigSpec<>("field", String.class, null, false),
-                new PluginConfigSpec<>("value", String.class, null, false)
-            );
+            return Arrays.asList(FIELD_CONFIG, VALUE_CONFIG);
         }
     }
 

--- a/logstash-core/src/main/java/org/logstash/execution/Filter.java
+++ b/logstash-core/src/main/java/org/logstash/execution/Filter.java
@@ -12,8 +12,6 @@ public interface Filter extends LsPlugin {
 
     QueueReader filter(QueueReader reader);
 
-    void flush(boolean isShutdown);
-
     @LogstashPlugin(name = "mutate")
     final class Mutate implements Filter {
 
@@ -63,11 +61,6 @@ public interface Filter extends LsPlugin {
                     reader.acknowledge(sequenceNum);
                 }
             };
-        }
-
-        @Override
-        public void flush(final boolean isShutdown) {
-            // Nothing to do here
         }
 
         @Override
@@ -129,11 +122,6 @@ public interface Filter extends LsPlugin {
                     reader.acknowledge(sequenceNum);
                 }
             };
-        }
-
-        @Override
-        public void flush(final boolean isShutdown) {
-            // Nothing to do here
         }
 
         @Override

--- a/logstash-core/src/main/java/org/logstash/execution/Input.java
+++ b/logstash-core/src/main/java/org/logstash/execution/Input.java
@@ -1,0 +1,77 @@
+package org.logstash.execution;
+
+import java.util.Collections;
+import java.util.Scanner;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * A Logstash Pipeline Input pushes to a {@link QueueWriter}.
+ */
+public interface Input extends AutoCloseable {
+
+    /**
+     * Start pushing {@link org.logstash.Event} to given {@link QueueWriter}.
+     * @param writer Queue Writer to Push to
+     */
+    void start(QueueWriter writer);
+
+    /**
+     * Stop the input.
+     * Stopping happens asynchronously, use {@link #awaitStop()} to make sure that the input has
+     * finished.
+     */
+    void stop();
+
+    /**
+     * Blocks until the input execution has finished.
+     * @throws InterruptedException On Interrupt
+     */
+    void awaitStop() throws InterruptedException;
+
+    @LogstashPlugin(name = "stream")
+    final class StreamInput implements Input {
+
+        private Scanner inpt;
+
+        private final CountDownLatch done = new CountDownLatch(1);
+
+        private volatile boolean stopped;
+
+        /**
+         * Required Constructor Signature only taking a {@link LsConfiguration}.
+         * @param configuration Logstash Configuration
+         */
+        public StreamInput(final LsConfiguration configuration) {
+            // Do whatever
+        }
+
+        @Override
+        public void start(final QueueWriter writer) {
+            inpt = new Scanner(System.in, "\n");
+            try {
+                while (!stopped && inpt.hasNext()) {
+                    final String message = inpt.next();
+                    writer.push(Collections.singletonMap("message", message));
+                }
+            } finally {
+                stopped = true;
+                done.countDown();
+            }
+        }
+
+        @Override
+        public void stop() {
+            stopped = true;
+        }
+
+        @Override
+        public void awaitStop() throws InterruptedException {
+            done.await();
+        }
+
+        @Override
+        public void close() {
+            inpt.close();
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/execution/Input.java
+++ b/logstash-core/src/main/java/org/logstash/execution/Input.java
@@ -40,8 +40,9 @@ public interface Input extends AutoCloseable {
         /**
          * Required Constructor Signature only taking a {@link LsConfiguration}.
          * @param configuration Logstash Configuration
+         * @param context Logstash Context
          */
-        public StreamInput(final LsConfiguration configuration) {
+        public StreamInput(final LsConfiguration configuration, final LsContext context) {
             // Do whatever
         }
 

--- a/logstash-core/src/main/java/org/logstash/execution/Input.java
+++ b/logstash-core/src/main/java/org/logstash/execution/Input.java
@@ -1,5 +1,6 @@
 package org.logstash.execution;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Scanner;
 import java.util.concurrent.CountDownLatch;
@@ -7,7 +8,7 @@ import java.util.concurrent.CountDownLatch;
 /**
  * A Logstash Pipeline Input pushes to a {@link QueueWriter}.
  */
-public interface Input extends AutoCloseable {
+public interface Input extends LsPlugin {
 
     /**
      * Start pushing {@link org.logstash.Event} to given {@link QueueWriter}.
@@ -71,8 +72,8 @@ public interface Input extends AutoCloseable {
         }
 
         @Override
-        public void close() {
-            inpt.close();
+        public Collection<PluginConfigSpec<?>> configSchema() {
+            return Collections.emptyList();
         }
     }
 }

--- a/logstash-core/src/main/java/org/logstash/execution/LogstashPlugin.java
+++ b/logstash-core/src/main/java/org/logstash/execution/LogstashPlugin.java
@@ -1,0 +1,16 @@
+package org.logstash.execution;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Logstash plugin annotation for finding plugins on the classpath and setting their name as used
+ * in the configuration syntax.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface LogstashPlugin {
+    String name();
+}

--- a/logstash-core/src/main/java/org/logstash/execution/LsConfiguration.java
+++ b/logstash-core/src/main/java/org/logstash/execution/LsConfiguration.java
@@ -1,0 +1,17 @@
+package org.logstash.execution;
+
+/**
+ * LS Configuration example. Should be implemented like Spark config or Hadoop job config classes.
+ */
+public final class LsConfiguration {
+
+    public String getString(final String key) {
+        return "";
+    }
+
+    public int getInt(final String key) {
+        return 0;
+    }
+
+    //TODO: all types we care about
+}

--- a/logstash-core/src/main/java/org/logstash/execution/LsConfiguration.java
+++ b/logstash-core/src/main/java/org/logstash/execution/LsConfiguration.java
@@ -1,5 +1,8 @@
 package org.logstash.execution;
 
+import java.util.Collection;
+import java.util.Properties;
+
 /**
  * LS Configuration example. Should be implemented like Spark config or Hadoop job config classes.
  */
@@ -13,5 +16,18 @@ public final class LsConfiguration {
         return 0;
     }
 
+    public Collection<Properties> allProperties() {
+        // TODO: Return list of all defined properties
+        return null;
+    }
+
     //TODO: all types we care about
+
+    public static final class Property {
+
+        public Property(final Class<?> type, final String name, final boolean deprecated) {
+            // TODO: So on and so forth add
+        }
+
+    }
 }

--- a/logstash-core/src/main/java/org/logstash/execution/LsConfiguration.java
+++ b/logstash-core/src/main/java/org/logstash/execution/LsConfiguration.java
@@ -1,33 +1,72 @@
 package org.logstash.execution;
 
+import java.nio.file.Path;
 import java.util.Collection;
-import java.util.Properties;
+import java.util.Map;
 
 /**
  * LS Configuration example. Should be implemented like Spark config or Hadoop job config classes.
  */
 public final class LsConfiguration {
 
-    public String getString(final String key) {
-        return "";
+    /**
+     * @param raw Configuration Settings Map. Values are serialized.
+     */
+    public LsConfiguration(final Map<String, String> raw) {
+
     }
 
-    public int getInt(final String key) {
-        return 0;
-    }
-
-    public Collection<Properties> allProperties() {
-        // TODO: Return list of all defined properties
+    public <T> T get(final PluginConfigSpec<T> configSpec) {
+        // TODO: Implement
         return null;
     }
 
-    //TODO: all types we care about
+    public boolean contains(final PluginConfigSpec<?> configSpec) {
+        // TODO: Implement
+        return false;
+    }
 
-    public static final class Property {
+    public Collection<String> allKeys() {
+        return null;
+    }
 
-        public Property(final Class<?> type, final String name, final boolean deprecated) {
-            // TODO: So on and so forth add
-        }
+    public static PluginConfigSpec<String> stringSetting(final String name) {
+        return new PluginConfigSpec<>(
+            name, String.class, null, false, false
+        );
+    }
 
+    public static PluginConfigSpec<String> requiredStringSetting(final String name) {
+        return new PluginConfigSpec<>(name, String.class, null, false, true);
+    }
+
+    public static PluginConfigSpec<Long> numSetting(final String name) {
+        return new PluginConfigSpec<>(
+            name, Long.class, null, false, false
+        );
+    }
+
+    public static PluginConfigSpec<Long> numSetting(final String name, final long defaultValue) {
+        return new PluginConfigSpec<>(
+            name, Long.class, defaultValue, false, false
+        );
+    }
+
+    public static PluginConfigSpec<Path> pathSetting(final String name) {
+        return new PluginConfigSpec<>(name, Path.class, null, false, false);
+    }
+
+    public static PluginConfigSpec<Boolean> booleanSetting(final String name) {
+        return new PluginConfigSpec<>(name, Boolean.class, null, false, false);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static PluginConfigSpec<Map<String, String>> hashSetting(final String name) {
+        return new PluginConfigSpec(name, Map.class, null, false, false);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static PluginConfigSpec<Map<String, String>> requiredHashSetting(final String name) {
+        return new PluginConfigSpec(name, Map.class, null, false, true);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/execution/LsConfiguration.java
+++ b/logstash-core/src/main/java/org/logstash/execution/LsConfiguration.java
@@ -66,7 +66,10 @@ public final class LsConfiguration {
     }
 
     @SuppressWarnings("unchecked")
-    public static PluginConfigSpec<Map<String, String>> requiredHashSetting(final String name) {
-        return new PluginConfigSpec(name, Map.class, null, false, true);
+    public static PluginConfigSpec<Map<String, LsConfiguration>> requiredHashSetting(
+        final String name, final Collection<PluginConfigSpec<?>> spec) {
+        return new PluginConfigSpec(
+            name, Map.class, null, false, true
+        );
     }
 }

--- a/logstash-core/src/main/java/org/logstash/execution/LsContext.java
+++ b/logstash-core/src/main/java/org/logstash/execution/LsContext.java
@@ -1,0 +1,15 @@
+package org.logstash.execution;
+
+import org.logstash.common.io.DeadLetterQueueWriter;
+
+/**
+ * Holds Logstash Environment.
+ */
+public final class LsContext {
+
+    // TODO: Add getters for metrics, logger etc.
+
+    public DeadLetterQueueWriter dlqWriter() {
+        return null;
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/execution/LsPlugin.java
+++ b/logstash-core/src/main/java/org/logstash/execution/LsPlugin.java
@@ -1,0 +1,8 @@
+package org.logstash.execution;
+
+import java.util.Collection;
+
+public interface LsPlugin {
+
+    Collection<PluginConfigSpec<?>> configSchema();
+}

--- a/logstash-core/src/main/java/org/logstash/execution/Output.java
+++ b/logstash-core/src/main/java/org/logstash/execution/Output.java
@@ -2,13 +2,15 @@ package org.logstash.execution;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import org.logstash.Event;
 
 /**
  * A Logstash Pipeline Output consumes a {@link QueueReader}.
  */
-public interface Output extends AutoCloseable {
+public interface Output extends LsPlugin {
 
     /**
      * Polls events from event reader and runs output action.
@@ -60,6 +62,7 @@ public interface Output extends AutoCloseable {
 
         @Override
         public void stop() {
+            outpt.close();
             stopped = true;
         }
 
@@ -69,8 +72,8 @@ public interface Output extends AutoCloseable {
         }
 
         @Override
-        public void close() {
-            outpt.close();
+        public Collection<PluginConfigSpec<?>> configSchema() {
+            return Collections.emptyList();
         }
     }
 }

--- a/logstash-core/src/main/java/org/logstash/execution/Output.java
+++ b/logstash-core/src/main/java/org/logstash/execution/Output.java
@@ -32,8 +32,9 @@ public interface Output extends AutoCloseable {
         /**
          * Required Constructor Signature only taking a {@link LsConfiguration}.
          * @param configuration Logstash Configuration
+         * @param context Logstash Context
          */
-        public StreamOutput(final LsConfiguration configuration) {
+        public StreamOutput(final LsConfiguration configuration, final LsContext context) {
             this.outpt = new PrintStream(System.out);
         }
 

--- a/logstash-core/src/main/java/org/logstash/execution/Output.java
+++ b/logstash-core/src/main/java/org/logstash/execution/Output.java
@@ -1,0 +1,75 @@
+package org.logstash.execution;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.concurrent.CountDownLatch;
+import org.logstash.Event;
+
+/**
+ * A Logstash Pipeline Output consumes a {@link QueueReader}.
+ */
+public interface Output extends AutoCloseable {
+
+    /**
+     * Polls events from event reader and runs output action.
+     * @param reader Reader to poll events from.
+     */
+    void output(QueueReader reader);
+
+    void stop();
+
+    void awaitStop() throws InterruptedException;
+
+    @LogstashPlugin(name = "output")
+    final class StreamOutput implements Output {
+
+        private final PrintStream outpt;
+
+        private volatile boolean stopped;
+
+        private final CountDownLatch done = new CountDownLatch(1);
+
+        /**
+         * Required Constructor Signature only taking a {@link LsConfiguration}.
+         * @param configuration Logstash Configuration
+         */
+        public StreamOutput(final LsConfiguration configuration) {
+            this.outpt = new PrintStream(System.out);
+        }
+
+        @Override
+        public void output(final QueueReader reader) {
+            final Event event = new Event();
+            try {
+                long sequence = reader.poll(event);
+                while (!stopped && sequence > -1L) {
+                    try {
+                        outpt.println(event.toJson());
+                        reader.acknowledge(sequence);
+                    } catch (final IOException ex) {
+                        throw new IllegalStateException(ex);
+                    }
+                    sequence = reader.poll(event);
+                }
+            } finally {
+                stopped = true;
+                done.countDown();
+            }
+        }
+
+        @Override
+        public void stop() {
+            stopped = true;
+        }
+
+        @Override
+        public void awaitStop() throws InterruptedException {
+            done.await();
+        }
+
+        @Override
+        public void close() {
+            outpt.close();
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/execution/PluginConfigSpec.java
+++ b/logstash-core/src/main/java/org/logstash/execution/PluginConfigSpec.java
@@ -8,18 +8,25 @@ public final class PluginConfigSpec<T> {
 
     private final boolean deprecated;
 
+    private final boolean required;
+
     private final T defaultValue;
 
     public PluginConfigSpec(final String name, final Class<T> type,
-        final T defaultValue, final boolean deprecated) {
+        final T defaultValue, final boolean deprecated, final boolean required) {
         this.name = name;
         this.type = type;
         this.defaultValue = defaultValue;
         this.deprecated = deprecated;
+        this.required = required;
     }
 
     public boolean deprecated() {
         return this.deprecated;
+    }
+
+    public boolean required() {
+        return this.required;
     }
 
     public T defaultValue() {

--- a/logstash-core/src/main/java/org/logstash/execution/PluginConfigSpec.java
+++ b/logstash-core/src/main/java/org/logstash/execution/PluginConfigSpec.java
@@ -1,5 +1,9 @@
 package org.logstash.execution;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
 public final class PluginConfigSpec<T> {
 
     private final String name;
@@ -12,13 +16,29 @@ public final class PluginConfigSpec<T> {
 
     private final T defaultValue;
 
+    private final Collection<PluginConfigSpec<?>> children;
+
     public PluginConfigSpec(final String name, final Class<T> type,
         final T defaultValue, final boolean deprecated, final boolean required) {
+        this(name, type, defaultValue, deprecated, required, Collections.emptyList());
+    }
+
+    public PluginConfigSpec(final String name, final Class<T> type,
+        final T defaultValue, final boolean deprecated, final boolean required,
+        final Collection<PluginConfigSpec<?>> children) {
         this.name = name;
         this.type = type;
         this.defaultValue = defaultValue;
         this.deprecated = deprecated;
         this.required = required;
+        if (!children.isEmpty() && !Map.class.isAssignableFrom(type)) {
+            throw new IllegalArgumentException("Only map type settings can have defined children.");
+        }
+        this.children = children;
+    }
+
+    public Collection<PluginConfigSpec<?>> children() {
+        return children;
     }
 
     public boolean deprecated() {

--- a/logstash-core/src/main/java/org/logstash/execution/PluginConfigSpec.java
+++ b/logstash-core/src/main/java/org/logstash/execution/PluginConfigSpec.java
@@ -1,0 +1,37 @@
+package org.logstash.execution;
+
+public final class PluginConfigSpec<T> {
+
+    private final String name;
+
+    private final Class<T> type;
+
+    private final boolean deprecated;
+
+    private final T defaultValue;
+
+    public PluginConfigSpec(final String name, final Class<T> type,
+        final T defaultValue, final boolean deprecated) {
+        this.name = name;
+        this.type = type;
+        this.defaultValue = defaultValue;
+        this.deprecated = deprecated;
+    }
+
+    public boolean deprecated() {
+        return this.deprecated;
+    }
+
+    public T defaultValue() {
+        return this.defaultValue;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public Class<T> type() {
+        return type;
+    }
+
+}

--- a/logstash-core/src/main/java/org/logstash/execution/QueueReader.java
+++ b/logstash-core/src/main/java/org/logstash/execution/QueueReader.java
@@ -1,0 +1,31 @@
+package org.logstash.execution;
+
+import org.logstash.Event;
+
+/**
+ * Reads from the Queue.
+ */
+public interface QueueReader {
+
+    /**
+     * Polls for the next event without timeout.
+     * @param event Event Pointer to write next Event to
+     * @return Sequence Number of the event, -1 on failure to poll an event
+     */
+    long poll(Event event);
+
+    /**
+     * Polls for the next event with a timeout.
+     * @param event Event Pointer to write next event to
+     * @param millis Timeout for polling the next even in ms
+     * @return Sequence Number of the event, -1 on failure to poll an event
+     */
+    long poll(Event event, long millis);
+
+    /**
+     * Acknowledges that an Event has passed through the pipeline and can be acknowledged to the
+     * input.
+     * @param sequenceNum Sequence number of the acknowledged event
+     */
+    void acknowledge(long sequenceNum);
+}

--- a/logstash-core/src/main/java/org/logstash/execution/QueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/execution/QueueWriter.java
@@ -1,6 +1,5 @@
 package org.logstash.execution;
 
-import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -15,36 +14,6 @@ public interface QueueWriter {
      * @return Sequence number of the event or -1 if push failed
      */
     long push(Map<String, Object> event);
-
-    /**
-     * Pushes a single event to the Queue, blocking for the given timeout if the Queue is not ready
-     * for a write.
-     * @param event Logstash Event Data
-     * @param millis Timeout in millis
-     * @return Sequence number of the event or -1 if push failed
-     */
-    long push(Map<String, Object> event, long millis);
-
-    /**
-     * Pushes a multiple events to the Queue, blocking for the given timeout if the Queue is not
-     * ready for a write.
-     * Guarantees that a return {@code != -1} means that all events were pushed to the Queue
-     * successfully and no partial writes of only a subset of the input events will ever occur.
-     * @param events Logstash Events Data
-     * @return Sequence number of the first event or -1 if push failed
-     */
-    long push(Collection<Map<String, Object>> events);
-
-    /**
-     * Pushes a multiple events to the Queue, blocking for the given timeout if the Queue is not
-     * ready for a write.
-     * Guarantees that a return {@code != -1} means that all events were pushed to the Queue
-     * successfully and no partial writes of only a subset of the input events will ever occur.
-     * @param events Logstash Events Data
-     * @param millis Timeout in millis
-     * @return Sequence number of the first event or -1 if push failed
-     */
-    long push(Collection<Map<String, Object>> events, long millis);
 
     /**
      * Returns the upper bound for acknowledged sequence numbers.

--- a/logstash-core/src/main/java/org/logstash/execution/QueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/execution/QueueWriter.java
@@ -1,0 +1,60 @@
+package org.logstash.execution;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Writes to the Queue.
+ */
+public interface QueueWriter {
+
+    /**
+     * Pushes a single event to the Queue, blocking indefinitely if the Queue is not ready for a
+     * write.
+     * @param event Logstash Event Data
+     * @return Sequence number of the event or -1 if push failed
+     */
+    long push(Map<String, Object> event);
+
+    /**
+     * Pushes a single event to the Queue, blocking for the given timeout if the Queue is not ready
+     * for a write.
+     * @param event Logstash Event Data
+     * @param millis Timeout in millis
+     * @return Sequence number of the event or -1 if push failed
+     */
+    long push(Map<String, Object> event, long millis);
+
+    /**
+     * Pushes a multiple events to the Queue, blocking for the given timeout if the Queue is not
+     * ready for a write.
+     * Guarantees that a return {@code != -1} means that all events were pushed to the Queue
+     * successfully and no partial writes of only a subset of the input events will ever occur.
+     * @param events Logstash Events Data
+     * @return Sequence number of the first event or -1 if push failed
+     */
+    long push(Collection<Map<String, Object>> events);
+
+    /**
+     * Pushes a multiple events to the Queue, blocking for the given timeout if the Queue is not
+     * ready for a write.
+     * Guarantees that a return {@code != -1} means that all events were pushed to the Queue
+     * successfully and no partial writes of only a subset of the input events will ever occur.
+     * @param events Logstash Events Data
+     * @param millis Timeout in millis
+     * @return Sequence number of the first event or -1 if push failed
+     */
+    long push(Collection<Map<String, Object>> events, long millis);
+
+    /**
+     * Returns the upper bound for acknowledged sequence numbers.
+     * @return upper bound for acknowledged sequence numbers
+     */
+    long watermark();
+
+    /**
+     * Returns the upper bound for unacknowledged sequence numbers.
+     * @return upper bound for unacknowledged sequence numbers
+     */
+    long highWatermark();
+}

--- a/logstash-core/src/main/java/org/logstash/execution/inputs/HttpPoller.java
+++ b/logstash-core/src/main/java/org/logstash/execution/inputs/HttpPoller.java
@@ -24,8 +24,13 @@ public final class HttpPoller implements Input {
     private static final PluginConfigSpec<Path> CA_CERT_CONFIG =
         LsConfiguration.pathSetting("cacert");
 
-    private static final PluginConfigSpec<Map<String, String>> URLS_CONFIG =
-        LsConfiguration.requiredHashSetting("urls");
+    private static final PluginConfigSpec<String> URL_METHOD_CONFIG =
+        LsConfiguration.stringSetting("method");
+
+    private static final PluginConfigSpec<Map<String, LsConfiguration>> URLS_CONFIG =
+        LsConfiguration.requiredHashSetting(
+            "urls", Arrays.asList(URL_METHOD_CONFIG, USER_CONFIG)
+        );
 
     private final LsConfiguration configuration;
 
@@ -42,6 +47,11 @@ public final class HttpPoller implements Input {
         } else {
             // no password things
         }
+        final Map<String, LsConfiguration> urls = configuration.get(URLS_CONFIG);
+        urls.forEach((key, config) -> {
+            System.out.println("Schema on method " + key + " is " + config.get(URL_METHOD_CONFIG));
+            System.out.println("User on method " + key + " is " + config.get(USER_CONFIG));
+        });
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/execution/inputs/HttpPoller.java
+++ b/logstash-core/src/main/java/org/logstash/execution/inputs/HttpPoller.java
@@ -1,0 +1,63 @@
+package org.logstash.execution.inputs;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import org.logstash.execution.Input;
+import org.logstash.execution.LsConfiguration;
+import org.logstash.execution.LsContext;
+import org.logstash.execution.PluginConfigSpec;
+import org.logstash.execution.QueueWriter;
+
+public final class HttpPoller implements Input {
+
+    private static final PluginConfigSpec<String> USER_CONFIG =
+        LsConfiguration.stringSetting("user");
+
+    private static final PluginConfigSpec<String> PASSWORD_CONFIG =
+        LsConfiguration.stringSetting("password");
+
+    private static final PluginConfigSpec<Long> AUTOMATIC_RETRIES_CONFIG =
+        LsConfiguration.numSetting("automatic_retries", 1L);
+
+    private static final PluginConfigSpec<Path> CA_CERT_CONFIG =
+        LsConfiguration.pathSetting("cacert");
+
+    private static final PluginConfigSpec<Map<String, String>> URLS_CONFIG =
+        LsConfiguration.requiredHashSetting("urls");
+
+    private final LsConfiguration configuration;
+
+    public HttpPoller(final LsConfiguration configuration, final LsContext context) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public void start(final QueueWriter writer) {
+        final String user = configuration.get(USER_CONFIG);
+        final String password;
+        if (configuration.contains(PASSWORD_CONFIG)) {
+            //  password things
+        } else {
+            // no password things
+        }
+    }
+
+    @Override
+    public void stop() {
+
+    }
+
+    @Override
+    public void awaitStop() throws InterruptedException {
+
+    }
+
+    @Override
+    public Collection<PluginConfigSpec<?>> configSchema() {
+        return Arrays.asList(
+            USER_CONFIG, PASSWORD_CONFIG, AUTOMATIC_RETRIES_CONFIG, CA_CERT_CONFIG, URLS_CONFIG
+        );
+    }
+}


### PR DESCRIPTION
@andrewvc @danhermann @yaauie 

Full suggestion for an API with:

* Discovery of plugins via annotation
* Definition of filter, input and output including sequence numbering for E2E acks
  * Could add one for codecs too but it didn't seem essential at this point. A codec is simply a mapping of `InputStream` to `Iterator<Event>` or better yet `Iterator<Map<String, Object>>` imo
* Low level Queue write and read clients
   * We could obviously provide slower high-level wrappers here, but the suggested version is the fastest interface I could think of for now and imo we should go for the fastest possible in step 0 and provide wrappers instead of going for easily usable directly and wasting an opportunity for significant gains for plugins that want to go the extra mile for performance
* Hope the JavaDoc is enough to get the general idea :)