### PR TITLE
Add conditional coding to set correct default for codec

### DIFF
--- a/docs/include/input.asciidoc
+++ b/docs/include/input.asciidoc
@@ -56,7 +56,12 @@ endif::[]
 ===== `codec`
 
   * Value type is {logstash-ref}/configuration-file-structure.html#codec[codec]
+ifdef::default_codec[]
+  * Default value is +"{default_codec}"+
+endif::[]
+ifndef::default_codec[]
   * Default value is `"plain"`
+endif::[]
 
 The codec used for input data. Input codecs are a convenient method for decoding your data before it enters the input, without needing a separate filter in your Logstash pipeline.
 

--- a/docs/include/output.asciidoc
+++ b/docs/include/output.asciidoc
@@ -34,7 +34,12 @@ endif::[]
 ===== `codec`
 
   * Value type is {logstash-ref}/configuration-file-structure.html#codec[codec]
+ifdef::default_codec[]
+  * Default value is +"{default_codec}"+
+endif::[]
+ifndef::default_codec[]
   * Default value is `"plain"`
+endif::[]
 
 The codec used for output data. Output codecs are a convenient method for encoding your data before it leaves the output without needing a separate filter in your Logstash pipeline.
 


### PR DESCRIPTION
Fixes logstash-plugins/logstash-output-redis#47 and logstash-plugins/logstash-input-redis#57

If there are other plugins (more than 2 or 3) that use json for the default codec, I'll need to change my strategy and create an asciidoc attribute to set the codec.

This file needs to be copied to the versioned plugin reference after the changes are merged. 