### PR TITLE
#9136 Put upper limit of FieldReference cache size

### DIFF
--- a/logstash-core/src/main/java/org/logstash/FieldReference.java
+++ b/logstash-core/src/main/java/org/logstash/FieldReference.java
@@ -139,8 +139,11 @@ public final class FieldReference {
     }
 
     private static FieldReference parseToCache(final CharSequence reference) {
-        final FieldReference result = parse(reference);
-        CACHE.put(reference, result);
+        FieldReference result = parse(reference);
+        if (CACHE.size() < 10_000) {
+            result = deduplicate(result);
+            CACHE.put(reference, result);
+        }
         return result;
     }
 
@@ -169,11 +172,11 @@ public final class FieldReference {
         if (empty && key.equals(Event.METADATA)) {
             return METADATA_PARENT_REFERENCE;
         } else if (!empty && path.get(0).equals(Event.METADATA)) {
-            return deduplicate(new FieldReference(
-                path.subList(1, path.size()).toArray(EMPTY_STRING_ARRAY), key, META_CHILD));
+            return new FieldReference(
+                path.subList(1, path.size()).toArray(EMPTY_STRING_ARRAY), key, META_CHILD
+            );
         } else {
-            return deduplicate(
-                new FieldReference(path.toArray(EMPTY_STRING_ARRAY), key, DATA_CHILD));
+            return new FieldReference(path.toArray(EMPTY_STRING_ARRAY), key, DATA_CHILD);
         }
     }
 }

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -86,7 +86,7 @@ public final class JrubyEventExtLibrary {
         public IRubyObject ruby_set_field(ThreadContext context, RubyString reference, IRubyObject value)
         {
             final FieldReference r = FieldReference.from(reference.getByteList());
-            if (r  == FieldReference.TIMESTAMP_REFERENCE) {
+            if (r.equals(FieldReference.TIMESTAMP_REFERENCE)) {
                 if (!(value instanceof JrubyTimestampExtLibrary.RubyTimestamp)) {
                     throw context.runtime.newTypeError("wrong argument type " + value.getMetaClass() + " (expected LogStash::Timestamp)");
                 }

--- a/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
+++ b/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
@@ -1,10 +1,14 @@
 package org.logstash;
 
+import java.lang.reflect.Field;
+import java.util.Map;
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public final class FieldReferenceTest {
@@ -49,5 +53,18 @@ public final class FieldReferenceTest {
         assertEquals(
             emptyReference, FieldReference.from(RubyUtil.RUBY.newString("").getByteList())
         );
+    }
+
+    @Test
+    public void testCacheUpperBound() throws NoSuchFieldException, IllegalAccessException {
+        final Field cacheField = FieldReference.class.getDeclaredField("CACHE");
+        cacheField.setAccessible(true);
+        final Map<CharSequence, FieldReference> cache =
+            (Map<CharSequence, FieldReference>) cacheField.get(null);
+        final int initial = cache.size();
+        for (int i = 0; i < 10_001 - initial; ++i) {
+            FieldReference.from(String.format("[array][%d]", i));
+        }
+        assertThat(cache.size(), CoreMatchers.is(10_000));
     }
 }


### PR DESCRIPTION
Fixes #9136 by simply only caching and deduping `FieldReference` when the cache size is below 10k `FieldReferences`.