### PR TITLE
Fix intro links in getting-started-with-logstash.asciidoc

### DIFF
--- a/docs/static/getting-started-with-logstash.asciidoc
+++ b/docs/static/getting-started-with-logstash.asciidoc
@@ -9,8 +9,8 @@ This section includes the following topics:
 
 * <<installing-logstash>>
 * <<first-event>>
-* {logstash-ref}/advanced-pipeline.html[Advanced Pipeline]
-* {logstash-ref}/multiple-input-output-plugins.html[Multiple Output Plugins]
+* {logstash-ref}/advanced-pipeline.html[Parsing Logs with Logstash]
+* {logstash-ref}/multiple-input-output-plugins.html[Stitching Together Multiple Input and Output Plugins]
 
 [[installing-logstash]]
 === Installing Logstash


### PR DESCRIPTION
Updated links to match the topic titles.

Note that some of these links use the {logstash-ref}/ format (rather than the usual link format) because Deb had to convert them to external links to create standalone getting started guides for translation. 

This should be merged into master, 6.x, 6.2, and (if it exists at the time of the merge) 6.3.