### PR TITLE
ensure singleton `TIMESTAMP_REFERENCE` `FieldReference`

### DIFF
--- a/logstash-core/src/main/java/org/logstash/FieldReference.java
+++ b/logstash-core/src/main/java/org/logstash/FieldReference.java
@@ -35,7 +35,7 @@ public final class FieldReference {
      * Unique {@link FieldReference} pointing at the timestamp field in a {@link Event}.
      */
     public static final FieldReference TIMESTAMP_REFERENCE =
-        deduplicate(new FieldReference(EMPTY_STRING_ARRAY, Event.TIMESTAMP, DATA_CHILD));
+        new FieldReference(EMPTY_STRING_ARRAY, Event.TIMESTAMP, DATA_CHILD);
 
     private static final FieldReference METADATA_PARENT_REFERENCE =
         new FieldReference(EMPTY_STRING_ARRAY, Event.METADATA, META_PARENT);
@@ -168,6 +168,8 @@ public final class FieldReference {
         final boolean empty = path.isEmpty();
         if (empty && key.equals(Event.METADATA)) {
             return METADATA_PARENT_REFERENCE;
+        } else if (empty && key.equals(Event.TIMESTAMP)) {
+            return TIMESTAMP_REFERENCE;
         } else if (!empty && path.get(0).equals(Event.METADATA)) {
             return deduplicate(new FieldReference(
                 path.subList(1, path.size()).toArray(EMPTY_STRING_ARRAY), key, META_CHILD));


### PR DESCRIPTION
Aligns how we do deduplication within `FieldReference`, ensuring that we never
generate `FieldReference` objects that are equivalent to `TIMESTAMP_REFERENCE`
in a manner that reflects the strategy taken with `META_PARENT_REFERENCE`.

In practice, this is not much of a net gain; with our current caching strategy
(cache everything), we'll only fall through the cache at most twice (once for
each equivalent string reference `@timestamp` and `[@timestamp]`), so it saves
us from a `DEDUP`-lookup and superfluous construction twice.

However, as we consider other caching strategies, this change will do no-harm
and could save us from some surprises.

Discovered while reviewing https://github.com/elastic/logstash/pull/9131
Complements cache-strategy changes in https://github.com/elastic/logstash/pull/9141