### PR TITLE
Fix: Tags collision with user-defined tags and built-in tags

### DIFF
--- a/logstash-core/lib/logstash/filters/base.rb
+++ b/logstash-core/lib/logstash/filters/base.rb
@@ -196,6 +196,8 @@ class LogStash::Filters::Base < LogStash::Plugin
     # this is important because a construct like event["tags"].delete(tag) will not work
     # in the current Java event implementation. see https://github.com/elastic/logstash/issues/4140
 
+    return if @remove_tag.empty?
+
     tags = event.get("tags")
     return unless tags
 

--- a/logstash-core/spec/logstash/filters/base_spec.rb
+++ b/logstash-core/spec/logstash/filters/base_spec.rb
@@ -309,4 +309,17 @@ describe LogStash::Filters::NOOP do
       reject { subject }.include?("go")
     end
   end
+
+  describe "when neither add_tag not remove_tag is specified, the tags field is left untouched" do
+    config <<-CONFIG
+    filter {
+      noop {}
+    }
+    CONFIG
+
+    sample_one("type" => "noop", "go" => "away", "tags" => {"blackhole" => "go"}) do
+      expect(subject.get("[tags][blackhole]")).to eq("go")
+    end
+
+  end
 end

--- a/logstash-core/spec/logstash/filters/base_spec.rb
+++ b/logstash-core/spec/logstash/filters/base_spec.rb
@@ -310,7 +310,7 @@ describe LogStash::Filters::NOOP do
     end
   end
 
-  describe "when neither add_tag not remove_tag is specified, the tags field is left untouched" do
+  describe "when neither add_tag nor remove_tag is specified, the tags field is left untouched" do
     config <<-CONFIG
     filter {
       noop {}


### PR DESCRIPTION
See Issue #7859 

PR #6177 Introduced a change where the value of the `tags` field is always converted to an Array even if no filters added or removed tags at all.

Users want a mechanism to have a tags field that comes from, say JSON, rename it early, allow other filters to add tags (grok), use logic on the tags to process failures and then rename their external tags field back to tags just before the outputs.

