### PR TITLE
Add release note for fix for broken plugin installs in 6.2.2

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -20,7 +20,7 @@ endif::include-xpack[]
 [[logstash-6-2-2]]
 === Logstash 6.2.2 Release Notes
 
-* There are no user facing changes in this release
+* Fix issue introduced in 6.2.1 where `bin/logstash-plugin` could not install or upgrade plugins
 
 [[logstash-6-2-1]]
 === Logstash 6.2.1 Release Notes


### PR DESCRIPTION
6.2.2 unbreaks the plugin manager, fixes bugs like: https://github.com/elastic/logstash/issues/9163#issuecomment-366978438 . That should be in our release notes.

Users will probably check the release notes to see if their problems will be fixed, so we should have this in there.