### PR TITLE
bump gems for 5.6.9

### DIFF
--- a/Gemfile.jruby-1.9.lock.release
+++ b/Gemfile.jruby-1.9.lock.release
@@ -89,7 +89,7 @@ GEM
     excon (0.60.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.18-java)
+    ffi (1.9.21-java)
     file-dependencies (0.1.6)
       minitar
     filesize (0.0.4)
@@ -125,7 +125,7 @@ GEM
     jls-lumberjack (0.0.26)
       concurrent-ruby
     jmespath (1.3.1)
-    jrjackson (0.4.4-java)
+    jrjackson (0.4.5-java)
     jruby-openssl (0.9.19-java)
     jruby-stdin-channel (0.2.0-java)
     json (1.8.6-java)
@@ -146,7 +146,7 @@ GEM
     logstash-codec-es_bulk (3.0.6)
       logstash-codec-line
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-codec-fluent (3.1.5-java)
+    logstash-codec-fluent (3.2.0-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       msgpack (~> 1.1)
     logstash-codec-graphite (3.0.5)
@@ -166,7 +166,7 @@ GEM
       jls-grok (~> 0.11.1)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-patterns-core
-    logstash-codec-netflow (3.11.0)
+    logstash-codec-netflow (3.11.2)
       bindata (>= 1.5.0)
       logstash-core-plugin-api (~> 2.0)
     logstash-codec-plain (3.0.6)
@@ -206,7 +206,7 @@ GEM
       murmurhash3
     logstash-filter-geoip (4.3.1-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-grok (4.0.2)
+    logstash-filter-grok (4.0.3)
       jls-grok (~> 0.11.3)
       logstash-core (>= 5.6.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -214,13 +214,13 @@ GEM
       stud (~> 0.0.22)
     logstash-filter-json (3.0.5)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-kv (4.0.3)
+    logstash-filter-kv (4.1.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-metrics (4.0.5)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       metriks
       thread_safe
-    logstash-filter-mutate (3.2.0)
+    logstash-filter-mutate (3.3.1)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-ruby (3.1.3)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -247,7 +247,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       nokogiri
       xml-simple
-    logstash-input-beats (3.1.26-java)
+    logstash-input-beats (3.1.29-java)
       concurrent-ruby (~> 1.0)
       jar-dependencies (~> 0.3.4)
       logstash-codec-multiline (>= 2.0.5)
@@ -323,7 +323,7 @@ GEM
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       stud (~> 0.0.22)
-    logstash-input-jdbc (4.3.3)
+    logstash-input-jdbc (4.3.4)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       rufus-scheduler
@@ -373,7 +373,7 @@ GEM
       jruby-stdin-channel
       logstash-codec-line
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-input-syslog (3.2.4)
+    logstash-input-syslog (3.4.0)
       concurrent-ruby
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -542,7 +542,7 @@ GEM
     public_suffix (1.4.6)
     puma (2.16.0-java)
     rack (1.6.6)
-    rack-protection (1.5.3)
+    rack-protection (1.5.4)
       rack
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
@@ -615,7 +615,7 @@ GEM
       memoizable (~> 0.4.0)
       naught (~> 1.0)
       simple_oauth (~> 0.3.0)
-    tzinfo (1.2.4)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     tzinfo-data (1.2018.3)
       tzinfo (>= 1.0.0)


### PR DESCRIPTION
Supersedes https://github.com/elastic/logstash/pull/9175 as that one had a bad Gemfile.