### PR TITLE
bump gems for 6.2.3

### DIFF
--- a/Gemfile.jruby-2.3.lock.release
+++ b/Gemfile.jruby-2.3.lock.release
@@ -81,7 +81,7 @@ GEM
     equalizer (0.0.10)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.18-java)
+    ffi (1.9.21-java)
     filesize (0.0.4)
     filewatch (0.9.0)
     fivemat (1.3.5)
@@ -115,7 +115,7 @@ GEM
     jls-lumberjack (0.0.26)
       concurrent-ruby
     jmespath (1.3.1)
-    jrjackson (0.4.4-java)
+    jrjackson (0.4.5-java)
     jruby-openssl (0.9.21-java)
     jruby-stdin-channel (0.2.0-java)
     json (1.8.6-java)
@@ -138,7 +138,7 @@ GEM
     logstash-codec-es_bulk (3.0.6)
       logstash-codec-line
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-codec-fluent (3.1.5-java)
+    logstash-codec-fluent (3.2.0-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       msgpack (~> 1.1)
     logstash-codec-graphite (3.0.5)
@@ -158,7 +158,7 @@ GEM
       jls-grok (~> 0.11.1)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-patterns-core
-    logstash-codec-netflow (3.11.0)
+    logstash-codec-netflow (3.11.2)
       bindata (>= 1.5.0)
       logstash-core-plugin-api (~> 2.0)
     logstash-codec-plain (3.0.6)
@@ -208,7 +208,7 @@ GEM
       murmurhash3
     logstash-filter-geoip (5.0.3-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-grok (4.0.2)
+    logstash-filter-grok (4.0.3)
       jls-grok (~> 0.11.3)
       logstash-core (>= 5.6.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -226,13 +226,13 @@ GEM
       sequel
     logstash-filter-json (3.0.5)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-kv (4.0.3)
+    logstash-filter-kv (4.1.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-metrics (4.0.5)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       metriks
       thread_safe
-    logstash-filter-mutate (3.2.0)
+    logstash-filter-mutate (3.3.1)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-ruby (3.1.3)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -259,7 +259,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       nokogiri
       xml-simple
-    logstash-input-beats (5.0.6-java)
+    logstash-input-beats (5.0.10-java)
       concurrent-ruby (~> 1.0)
       jar-dependencies (~> 0.3.4)
       logstash-codec-multiline (>= 2.0.5)
@@ -325,7 +325,7 @@ GEM
       mail (~> 2.6.3)
       mime-types (= 2.6.2)
       stud (~> 0.0.22)
-    logstash-input-jdbc (4.3.3)
+    logstash-input-jdbc (4.3.4)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       rufus-scheduler
@@ -366,7 +366,7 @@ GEM
       jruby-stdin-channel
       logstash-codec-line
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-input-syslog (3.2.4)
+    logstash-input-syslog (3.4.0)
       concurrent-ruby
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -415,7 +415,7 @@ GEM
       logstash-filter-json
       logstash-input-generator
       logstash-output-file
-    logstash-output-elasticsearch (9.0.2-java)
+    logstash-output-elasticsearch (9.0.3-java)
       cabin (~> 0.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       manticore (>= 0.5.4, < 1.0.0)
@@ -492,7 +492,7 @@ GEM
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
     manticore (0.6.1-java)
-    march_hare (3.0.0-java)
+    march_hare (3.1.0-java)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     method_source (0.8.2)
@@ -529,7 +529,7 @@ GEM
     public_suffix (1.4.6)
     puma (2.16.0-java)
     rack (1.6.6)
-    rack-protection (1.5.3)
+    rack-protection (1.5.4)
       rack
     rack-test (0.8.2)
       rack (>= 1.0, < 3)
@@ -557,7 +557,7 @@ GEM
     sawyer (0.6.0)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
-    sequel (5.4.0)
+    sequel (5.5.0)
     simple_oauth (0.3.1)
     sinatra (1.4.8)
       rack (~> 1.5)
@@ -590,7 +590,7 @@ GEM
       memoizable (~> 0.4.0)
       naught (~> 1.0)
       simple_oauth (~> 0.3.0)
-    tzinfo (1.2.4)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     tzinfo-data (1.2018.3)
       tzinfo (>= 1.0.0)


### PR DESCRIPTION
Supersedes https://github.com/elastic/logstash/pull/9174 as that one had a bad Gemfile.