### PR TITLE
Bump to jackson 2.9.4 and pin jrjackson to exact version

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -68,7 +68,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "rubyzip", "~> 1.2.1"
   gem.add_runtime_dependency "thread_safe", "~> 0.3.5" #(Apache 2.0 license)
 
-  gem.add_runtime_dependency "jrjackson", "~> #{ALL_VERSIONS.fetch('jrjackson')}" #(Apache 2.0 license)
+  gem.add_runtime_dependency "jrjackson", "= #{ALL_VERSIONS.fetch('jrjackson')}" #(Apache 2.0 license)
 
   gem.add_runtime_dependency "elasticsearch", "~> 5.0", ">= 5.0.4" # Ruby client for ES (Apache 2.0 license)
   gem.add_runtime_dependency "manticore", '>= 0.5.4', '< 1.0.0'

--- a/versions.yml
+++ b/versions.yml
@@ -20,5 +20,5 @@ jruby:
 # Note: this file is copied to the root of logstash-core because its gemspec needs it when
 #       bundler evaluates the gemspec via bin/logstash
 # Ensure Jackson version here is kept in sync with version used by jrjackson gem
-jrjackson: 0.4.4
-jackson: 2.9.1
+jrjackson: 0.4.5
+jackson: 2.9.4


### PR DESCRIPTION
The exact pin will further ensure that versions are kept in sync. For example, jrjackson is released, but version here is not bumped...without the exact pin, the shipped version of jrjackson can get ahead of the version defined here. 