### PR TITLE
BUG: Fix input shutting down prematurely

### DIFF
--- a/logstash-core/spec/logstash/java_pipeline_spec.rb
+++ b/logstash-core/spec/logstash/java_pipeline_spec.rb
@@ -614,7 +614,7 @@ describe LogStash::JavaPipeline do
 
     before do
       allow(::LogStash::Outputs::DummyOutput).to receive(:new).with(any_args).and_return(output)
-      allow(LogStash::Plugin).to receive(:lookup).with("input", "dummy_input").and_return(DummyInput)
+      allow(LogStash::Plugin).to receive(:lookup).with("input", "dummy_input").and_return(LogStash::Inputs::DummyBlockingInput)
       allow(LogStash::Plugin).to receive(:lookup).with("filter", "dummy_flushing_filter").and_return(DummyFlushingFilterPeriodic)
       allow(LogStash::Plugin).to receive(:lookup).with("output", "dummy_output").and_return(::LogStash::Outputs::DummyOutput)
       allow(LogStash::Plugin).to receive(:lookup).with("codec", "plain").and_return(LogStash::Codecs::Plain)


### PR DESCRIPTION
@danhermann lets trigger Jenkins a few times to make sure, but I think this is the issue.
The input doesn't block for long enough and the flush happens after the pipeline already shut down. I applied the same fix for the nested conditional wrapping test below this one, but it seems we now changed the timing here in a way that hits this test as well.