### PR TITLE
[Plugin Generator] Update template files

### DIFF
--- a/lib/pluginmanager/templates/codec-plugin/.travis.yml
+++ b/lib/pluginmanager/templates/codec-plugin/.travis.yml
@@ -1,0 +1,18 @@
+---
+sudo: false
+language: ruby
+cache: bundler
+matrix:
+  include:
+  - rvm: jruby-9.1.13.0
+    env: LOGSTASH_BRANCH=master
+  - rvm: jruby-9.1.13.0
+    env: LOGSTASH_BRANCH=6.x
+  - rvm: jruby-9.1.13.0
+    env: LOGSTASH_BRANCH=6.0
+  - rvm: jruby-1.7.27
+    env: LOGSTASH_BRANCH=5.6
+  fast_finish: true
+install: true
+script: ci/build.sh
+jdk: oraclejdk8

--- a/lib/pluginmanager/templates/codec-plugin/Gemfile
+++ b/lib/pluginmanager/templates/codec-plugin/Gemfile
@@ -1,3 +1,11 @@
 source 'https://rubygems.org'
 gemspec
 
+logstash_path = ENV["LOGSTASH_PATH"] || "../../logstash"
+use_logstash_source = ENV["LOGSTASH_SOURCE"] && ENV["LOGSTASH_SOURCE"].to_s == "1"
+
+
+if Dir.exist?(logstash_path) && use_logstash_source
+  gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
+  gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
+end

--- a/lib/pluginmanager/templates/codec-plugin/README.md
+++ b/lib/pluginmanager/templates/codec-plugin/README.md
@@ -6,9 +6,9 @@ It is fully free and fully open source. The license is Apache 2.0, meaning you a
 
 ## Documentation
 
-Logstash provides infrastructure to automatically generate documentation for this plugin. We use the asciidoc format to write documentation so any comments in the source code will be first converted into asciidoc and then into html. All plugin documentation are placed under one [central location](http://www.elastic.co/guide/en/logstash/current/).
+Logstash provides infrastructure to automatically build documentation for this plugin. We provide a template file, index.asciidoc, where you can add documentation. The contents of this file will be converted into html and then placed with other plugin documentation in a [central location](http://www.elastic.co/guide/en/logstash/current/).
 
-- For formatting code or config example, you can use the asciidoc `[source,ruby]` directive
+- For formatting config examples, you can use the asciidoc `[source,json]` directive
 - For more asciidoc formatting tips, see the excellent reference here https://github.com/elastic/docs#asciidoc-guide
 
 ## Need Help?

--- a/lib/pluginmanager/templates/filter-plugin/.travis.yml
+++ b/lib/pluginmanager/templates/filter-plugin/.travis.yml
@@ -1,0 +1,18 @@
+---
+sudo: false
+language: ruby
+cache: bundler
+matrix:
+  include:
+  - rvm: jruby-9.1.13.0
+    env: LOGSTASH_BRANCH=master
+  - rvm: jruby-9.1.13.0
+    env: LOGSTASH_BRANCH=6.x
+  - rvm: jruby-9.1.13.0
+    env: LOGSTASH_BRANCH=6.0
+  - rvm: jruby-1.7.27
+    env: LOGSTASH_BRANCH=5.6
+  fast_finish: true
+install: true
+script: ci/build.sh
+jdk: oraclejdk8

--- a/lib/pluginmanager/templates/filter-plugin/Gemfile
+++ b/lib/pluginmanager/templates/filter-plugin/Gemfile
@@ -1,3 +1,11 @@
 source 'https://rubygems.org'
 gemspec
 
+logstash_path = ENV["LOGSTASH_PATH"] || "../../logstash"
+use_logstash_source = ENV["LOGSTASH_SOURCE"] && ENV["LOGSTASH_SOURCE"].to_s == "1"
+
+
+if Dir.exist?(logstash_path) && use_logstash_source
+  gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
+  gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
+end

--- a/lib/pluginmanager/templates/filter-plugin/README.md
+++ b/lib/pluginmanager/templates/filter-plugin/README.md
@@ -6,9 +6,9 @@ It is fully free and fully open source. The license is Apache 2.0, meaning you a
 
 ## Documentation
 
-Logstash provides infrastructure to automatically generate documentation for this plugin. We use the asciidoc format to write documentation so any comments in the source code will be first converted into asciidoc and then into html. All plugin documentation are placed under one [central location](http://www.elastic.co/guide/en/logstash/current/).
+Logstash provides infrastructure to automatically build documentation for this plugin. We provide a template file, index.asciidoc, where you can add documentation. The contents of this file will be converted into html and then placed with other plugin documentation in a [central location](http://www.elastic.co/guide/en/logstash/current/).
 
-- For formatting code or config example, you can use the asciidoc `[source,ruby]` directive
+- For formatting config examples, you can use the asciidoc `[source,json]` directive
 - For more asciidoc formatting tips, see the excellent reference here https://github.com/elastic/docs#asciidoc-guide
 
 ## Need Help?

--- a/lib/pluginmanager/templates/input-plugin/.travis.yml
+++ b/lib/pluginmanager/templates/input-plugin/.travis.yml
@@ -1,0 +1,18 @@
+---
+sudo: false
+language: ruby
+cache: bundler
+matrix:
+  include:
+  - rvm: jruby-9.1.13.0
+    env: LOGSTASH_BRANCH=master
+  - rvm: jruby-9.1.13.0
+    env: LOGSTASH_BRANCH=6.x
+  - rvm: jruby-9.1.13.0
+    env: LOGSTASH_BRANCH=6.0
+  - rvm: jruby-1.7.27
+    env: LOGSTASH_BRANCH=5.6
+  fast_finish: true
+install: true
+script: ci/build.sh
+jdk: oraclejdk8

--- a/lib/pluginmanager/templates/input-plugin/Gemfile
+++ b/lib/pluginmanager/templates/input-plugin/Gemfile
@@ -1,3 +1,10 @@
 source 'https://rubygems.org'
 gemspec
 
+logstash_path = ENV["LOGSTASH_PATH"] || "../../logstash"
+use_logstash_source = ENV["LOGSTASH_SOURCE"] && ENV["LOGSTASH_SOURCE"].to_s == "1"
+
+if Dir.exist?(logstash_path) && use_logstash_source
+  gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
+  gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
+end

--- a/lib/pluginmanager/templates/input-plugin/README.md
+++ b/lib/pluginmanager/templates/input-plugin/README.md
@@ -6,9 +6,9 @@ It is fully free and fully open source. The license is Apache 2.0, meaning you a
 
 ## Documentation
 
-Logstash provides infrastructure to automatically generate documentation for this plugin. We use the asciidoc format to write documentation so any comments in the source code will be first converted into asciidoc and then into html. All plugin documentation are placed under one [central location](http://www.elastic.co/guide/en/logstash/current/).
+Logstash provides infrastructure to automatically build documentation for this plugin. We provide a template file, index.asciidoc, where you can add documentation. The contents of this file will be converted into html and then placed with other plugin documentation in a [central location](http://www.elastic.co/guide/en/logstash/current/).
 
-- For formatting code or config example, you can use the asciidoc `[source,ruby]` directive
+- For formatting config examples, you can use the asciidoc `[source,json]` directive
 - For more asciidoc formatting tips, see the excellent reference here https://github.com/elastic/docs#asciidoc-guide
 
 ## Need Help?

--- a/lib/pluginmanager/templates/output-plugin/.travis.yml
+++ b/lib/pluginmanager/templates/output-plugin/.travis.yml
@@ -1,0 +1,18 @@
+---
+sudo: false
+language: ruby
+cache: bundler
+matrix:
+  include:
+  - rvm: jruby-9.1.13.0
+    env: LOGSTASH_BRANCH=master
+  - rvm: jruby-9.1.13.0
+    env: LOGSTASH_BRANCH=6.x
+  - rvm: jruby-9.1.13.0
+    env: LOGSTASH_BRANCH=6.0
+  - rvm: jruby-1.7.27
+    env: LOGSTASH_BRANCH=5.6
+  fast_finish: true
+install: true
+script: ci/build.sh
+jdk: oraclejdk8

--- a/lib/pluginmanager/templates/output-plugin/Gemfile
+++ b/lib/pluginmanager/templates/output-plugin/Gemfile
@@ -1,3 +1,11 @@
 source 'https://rubygems.org'
 gemspec
 
+logstash_path = ENV["LOGSTASH_PATH"] || "../../logstash"
+use_logstash_source = ENV["LOGSTASH_SOURCE"] && ENV["LOGSTASH_SOURCE"].to_s == "1"
+
+
+if Dir.exist?(logstash_path) && use_logstash_source
+  gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
+  gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
+end

--- a/lib/pluginmanager/templates/output-plugin/README.md
+++ b/lib/pluginmanager/templates/output-plugin/README.md
@@ -6,9 +6,9 @@ It is fully free and fully open source. The license is Apache 2.0, meaning you a
 
 ## Documentation
 
-Logstash provides infrastructure to automatically generate documentation for this plugin. We use the asciidoc format to write documentation so any comments in the source code will be first converted into asciidoc and then into html. All plugin documentation are placed under one [central location](http://www.elastic.co/guide/en/logstash/current/).
+Logstash provides infrastructure to automatically build documentation for this plugin. We provide a template file, index.asciidoc, where you can add documentation. The contents of this file will be converted into html and then placed with other plugin documentation in a [central location](http://www.elastic.co/guide/en/logstash/current/).
 
-- For formatting code or config example, you can use the asciidoc `[source,ruby]` directive
+- For formatting config examples, you can use the asciidoc `[source,json]` directive
 - For more asciidoc formatting tips, see the excellent reference here https://github.com/elastic/docs#asciidoc-guide
 
 ## Need Help?


### PR DESCRIPTION
I recently (about a couple weeks ago) created a new logstash filter plugin using the plugin generator (`bin/logstash-plugin generate ...`). In the PR review for my plugin I got some feedback on elements that were generated by the plugin generator. So I figured I should address that feedback in the plugin generator templates as well, in order to aid future plugin authors who use the plugin generator. This PR does that.

Specifically, this PR:

* Updates the instructions about how we build docs to no longer say that we parse comments from plugin code.
* Adds a snippet to the `Gemfile` that allows testing against multiple branch versions.
* Adds the config file for Travis CI.
