### PR TITLE
additional version bumps for 5.6.9, pin atomic gem #9194

### DIFF
--- a/Gemfile.jruby-1.9.lock.release
+++ b/Gemfile.jruby-1.9.lock.release
@@ -1,7 +1,7 @@
 PATH
   remote: ./logstash-core
   specs:
-    logstash-core (5.6.8-java)
+    logstash-core (5.6.9-java)
       chronic_duration (= 0.10.6)
       clamp (~> 0.6.5)
       concurrent-ruby (~> 1.0, >= 1.0.5)
@@ -10,7 +10,7 @@ PATH
       gems (~> 0.8.3)
       i18n (= 0.6.9)
       jar-dependencies
-      jrjackson (~> 0.4.3)
+      jrjackson (= 0.4.5)
       jruby-openssl (= 0.9.19)
       manticore (>= 0.5.4, < 1.0.0)
       minitar (~> 0.6.1)
@@ -28,7 +28,7 @@ PATH
   remote: ./logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.29-java)
-      logstash-core (= 5.6.8)
+      logstash-core (= 5.6.9)
 
 GEM
   remote: https://rubygems.org/
@@ -89,12 +89,12 @@ GEM
     excon (0.60.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.21-java)
+    ffi (1.9.23-java)
     file-dependencies (0.1.6)
       minitar
     filesize (0.0.4)
     filewatch (0.9.0)
-    fivemat (1.3.5)
+    fivemat (1.3.6)
     flores (0.0.7)
     fpm (1.3.3)
       arr-pm (~> 0.0.9)
@@ -323,7 +323,7 @@ GEM
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       stud (~> 0.0.22)
-    logstash-input-jdbc (4.3.4)
+    logstash-input-jdbc (4.3.5)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       rufus-scheduler
@@ -404,7 +404,7 @@ GEM
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       xmpp4r (~> 0.5.6)
-    logstash-mixin-aws (4.2.3)
+    logstash-mixin-aws (4.2.4)
       aws-sdk (~> 2.3.0)
       aws-sdk-v1 (>= 1.61.0)
       logstash-codec-plain
@@ -630,6 +630,7 @@ PLATFORMS
   java
 
 DEPENDENCIES
+  atomic (<= 1.1.99)
   backports (~> 3.9.1)
   benchmark-ips
   builder (~> 3.2.2)

--- a/Gemfile.template
+++ b/Gemfile.template
@@ -4,6 +4,7 @@
 source "https://rubygems.org"
 gem "logstash-core", :path => "./logstash-core"
 gem "logstash-core-plugin-api", :path => "./logstash-core-plugin-api"
+gem "atomic", "<= 1.1.99"
 gem "paquet", "~> 0.2.0"
 gem "ruby-progressbar", "~> 1.8.1"
 gem "builder", "~> 3.2.2"

--- a/NOTICE.TXT
+++ b/NOTICE.TXT
@@ -57,29 +57,6 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================================================
-RubyGem: jar-dependencies Version: 0.3.12
-Copyright (c) 2014 Christian Meier
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-==========================================================================
 RubyGem: lru_redux Version: 1.1.0
 Copyright (c) 2013 Sam Saffron
 
@@ -143,8 +120,8 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================================================
-RubyGem: tzinfo Version: 1.2.4
-Copyright (c) 2005-2017 Philip Ross
+RubyGem: tzinfo Version: 1.2.5
+Copyright (c) 2005-2018 Philip Ross
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 


### PR DESCRIPTION
The driving force here is pinning of the atomic gem to fix #9194 