### PR TITLE
Parallel lifecycle

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -25,7 +25,7 @@ class LogStash::Agent
   include LogStash::Util::Loggable
   STARTED_AT = Time.now.freeze
 
-  attr_reader :metric, :name, :settings, :webserver, :dispatcher, :ephemeral_id
+  attr_reader :metric, :name, :settings, :webserver, :dispatcher, :ephemeral_id, :pipelines
   attr_accessor :logger
 
   # initialize method for LogStash::Agent
@@ -40,8 +40,7 @@ class LogStash::Agent
     @ephemeral_id = SecureRandom.uuid
 
     # Do not use @pipelines directly. Use #with_pipelines which does locking
-    @pipelines = {}
-    @pipelines_lock = java.util.concurrent.locks.ReentrantLock.new
+    @pipelines = java.util.concurrent.ConcurrentHashMap.new();
 
     @name = setting("node.name")
     @http_host = setting("http.host")
@@ -133,17 +132,6 @@ class LogStash::Agent
     !@running.value
   end
 
-  # Safely perform an operation on the pipelines hash
-  # Using the correct synchronization
-  def with_pipelines
-    begin
-      @pipelines_lock.lock
-      yield @pipelines
-    ensure
-      @pipelines_lock.unlock
-    end
-  end
-
   def converge_state_and_update
     results = @source_loader.fetch
 
@@ -161,11 +149,9 @@ class LogStash::Agent
     converge_result = nil
 
     # we don't use the variable here, but we want the locking
-    with_pipelines do |pipelines|
-      pipeline_actions = resolve_actions(results.response)
-      converge_result = converge_state(pipeline_actions)
-      update_metrics(converge_result)
-    end
+    pipeline_actions = resolve_actions(results.response)
+    converge_result = converge_state(pipeline_actions)
+    update_metrics(converge_result)
 
     report_currently_running_pipelines(converge_result)
     dispatch_events(converge_result)
@@ -229,21 +215,19 @@ class LogStash::Agent
   end
 
   def get_pipeline(pipeline_id)
-    with_pipelines do |pipelines|
-      pipelines[pipeline_id]
-    end
+    pipelines.get(pipeline_id)
   end
 
   def pipelines_count
-    with_pipelines do |pipelines|
-      pipelines.size
-    end
+    pipelines.size
+  end
+
+  def running_pipelines
+    pipelines.select {|id,pipeline| running_pipeline?(id) }
   end
 
   def with_running_pipelines
-    with_pipelines do |pipelines|
-      yield pipelines.select {|pipeline_id, _| running_pipeline?(pipeline_id) }
-    end
+    yield running_pipelines
   end
 
   def running_pipelines?
@@ -251,25 +235,19 @@ class LogStash::Agent
   end
 
   def running_pipelines_count
-    with_running_pipelines do |pipelines|
-      pipelines.size
-    end
+    running_pipelines.size
   end
 
   def running_user_defined_pipelines?
-    with_running_user_defined_pipelines do |pipelines|
-      pipelines.size > 0
-    end
+    !running_user_defined_pipelines.empty?
+  end
+
+  def running_user_defined_pipelines
+    pipelines.select {|id, pipeline| running_pipeline?(id) && !pipeline.system? }
   end
 
   def with_running_user_defined_pipelines
-    with_pipelines do |pipelines|
-      found = pipelines.select do |_, pipeline|
-        pipeline.running? && !pipeline.system?
-      end
-
-      yield found
-    end
+    yield running_user_defined_pipelines
   end
 
   private
@@ -296,29 +274,31 @@ class LogStash::Agent
 
     converge_result = LogStash::ConvergeResult.new(pipeline_actions.size)
 
+    threads = []
     pipeline_actions.each do |action|
-      # We execute every task we need to converge the current state of pipelines
-      # for every task we will record the action result, that will help us
-      # the results of all the task will determine if the converge was successful or not
-      #
-      # The ConvergeResult#add, will accept the following values
-      #  - boolean
-      #  - FailedAction
-      #  - SuccessfulAction
-      #  - Exception
-      #
-      # This give us a bit more extensibility with the current startup/validation model
-      # that we currently have.
-      with_pipelines do |pipelines|
-        begin
+      threads << Thread.new do
+        java.lang.Thread.currentThread().setName("Converge #{action}");
+        # We execute every task we need to converge the current state of pipelines
+        # for every task we will record the action result, that will help us
+        # the results of all the task will determine if the converge was successful or not
+        #
+        # The ConvergeResult#add, will accept the following values
+        #  - boolean
+        #  - FailedAction
+        #  - SuccessfulAction
+        #  - Exception
+        #
+        # This give us a bit more extensibility with the current startup/validation model
+        # that we currently have.
+        var = begin
           logger.debug("Executing action", :action => action)
-            action_result = action.execute(self, pipelines)
+          action_result = action.execute(self, pipelines)
           converge_result.add(action, action_result)
 
           unless action_result.successful?
             logger.error("Failed to execute action", :id => action.pipeline_id,
-                        :action_type => action_result.class, :message => action_result.message,
-                        :backtrace => action_result.backtrace)
+                         :action_type => action_result.class, :message => action_result.message,
+                         :backtrace => action_result.backtrace)
           end
         rescue SystemExit => e
           converge_result.add(action, e)
@@ -326,8 +306,10 @@ class LogStash::Agent
           logger.error("Failed to execute action", :action => action, :exception => e.class.name, :message => e.message, :backtrace => e.backtrace)
           converge_result.add(action, e)
         end
+        var
       end
     end
+    threads.each(&:join)
 
     if logger.trace?
       logger.trace("Converge results", :success => converge_result.success?,
@@ -339,14 +321,12 @@ class LogStash::Agent
   end
 
   def resolve_actions(pipeline_configs)
-    with_pipelines do |pipelines|
-      @state_resolver.resolve(pipelines, pipeline_configs)
-    end
+    @state_resolver.resolve(@pipelines, pipeline_configs)
   end
 
   def report_currently_running_pipelines(converge_result)
     if converge_result.success? && converge_result.total > 0
-      with_running_pipelines do |pipelines|
+      running_pipelines do |pipelines|
         number_of_running_pipeline = pipelines.size
         logger.info("Pipelines running", :count => number_of_running_pipeline, :pipelines => pipelines.values.collect(&:pipeline_id) )
       end
@@ -413,21 +393,19 @@ class LogStash::Agent
     # In this context I could just call shutdown, but I've decided to
     # use the stop action implementation for that so we have the same code.
     # This also give us some context into why a shutdown is failing
-    with_pipelines do |pipelines|
-      pipeline_actions = resolve_actions([]) # We stop all the pipeline, so we converge to a empty state
-      converge_state(pipeline_actions)
-    end
+    pipeline_actions = resolve_actions([]) # We stop all the pipeline, so we converge to a empty state
+    converge_state(pipeline_actions)
   end
 
   def running_pipeline?(pipeline_id)
-    thread = get_pipeline(pipeline_id).thread
+    pipeline = get_pipeline(pipeline_id)
+    return false unless pipeline
+    thread = pipeline.thread
     thread.is_a?(Thread) && thread.alive?
   end
 
   def clean_state?
-    with_pipelines do |pipelines|
-      pipelines.empty?
-    end
+    pipelines.empty?
   end
 
   def setting(key)

--- a/logstash-core/lib/logstash/converge_result.rb
+++ b/logstash-core/lib/logstash/converge_result.rb
@@ -60,7 +60,7 @@ module LogStash
 
     def initialize(expected_actions_count)
       @expected_actions_count = expected_actions_count
-      @actions = {}
+      @actions = java.util.concurrent.ConcurrentHashMap.new
     end
 
     def add(action, action_result)

--- a/logstash-core/lib/logstash/pipeline_action/create.rb
+++ b/logstash-core/lib/logstash/pipeline_action/create.rb
@@ -40,13 +40,19 @@ module LogStash module PipelineAction
           LogStash::Pipeline.new(@pipeline_config, @metric, agent)
         end
 
-      status = pipeline.start # block until the pipeline is correctly started or crashed
-
-      if status
-        pipelines[pipeline_id] = pipeline # The pipeline is successfully started we can add it to the hash
+      status = nil
+      pipelines.compute(pipeline_id) do |id,value|
+        status = pipeline.start # block until the pipeline is correctly started or crashed
+        pipeline # The pipeline is successfully started we can add it to the hash
       end
 
+
       LogStash::ConvergeResult::ActionResult.create(self, status)
+    end
+
+
+    def to_s
+      "PipelineAction::Create<#{pipeline_id}>"
     end
   end
 end end

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -134,7 +134,7 @@ describe LogStash::Agent do
           it "does not upgrade the new config" do
             t = Thread.new { subject.execute }
             Timeout.timeout(timeout) do
-              sleep(0.01) until subject.with_pipelines {|pipelines| subject.running_pipelines? && pipelines.values.first.ready? }
+              sleep(0.01) until subject.running_pipelines? && subject.pipelines.values.first.ready?
             end
             expect(subject.converge_state_and_update).not_to be_a_successful_converge
             expect(subject).to have_running_pipeline?(mock_config_pipeline)
@@ -154,7 +154,7 @@ describe LogStash::Agent do
           it "does upgrade the new config" do
             t = Thread.new { subject.execute }
             Timeout.timeout(timeout) do
-              sleep(0.01) until subject.with_pipelines {|pipelines| subject.pipelines_count > 0 && pipelines.values.first.ready? }
+              sleep(0.01) until subject.pipelines_count > 0 && subject.pipelines.values.first.ready?
             end
 
             expect(subject.converge_state_and_update).to be_a_successful_converge
@@ -178,7 +178,7 @@ describe LogStash::Agent do
           it "does not try to reload the pipeline" do
             t = Thread.new { subject.execute }
             Timeout.timeout(timeout) do
-              sleep(0.01) until subject.with_pipelines {|pipelines| subject.running_pipelines? && pipelines.values.first.running? }
+              sleep(0.01) until subject.running_pipelines? && subject.pipelines.values.first.running?
             end
             expect(subject.converge_state_and_update).not_to be_a_successful_converge
             expect(subject).to have_running_pipeline?(mock_config_pipeline)
@@ -198,7 +198,7 @@ describe LogStash::Agent do
           it "tries to reload the pipeline" do
             t = Thread.new { subject.execute }
             Timeout.timeout(timeout) do
-              sleep(0.01) until subject.with_pipelines {|pipelines| subject.running_pipelines? && pipelines.values.first.running? }
+              sleep(0.01) until subject.running_pipelines? && subject.pipelines.values.first.running?
             end
 
             expect(subject.converge_state_and_update).to be_a_successful_converge

--- a/logstash-core/spec/logstash/pipeline_action/create_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_action/create_spec.rb
@@ -9,7 +9,7 @@ require "logstash/inputs/generator"
 describe LogStash::PipelineAction::Create do
   let(:metric) { LogStash::Instrument::NullMetric.new(LogStash::Instrument::Collector.new) }
   let(:pipeline_config) { mock_pipeline_config(:main, "input { generator { id => '123' } } output { null {} }") }
-  let(:pipelines) {  Hash.new }
+  let(:pipelines) { java.util.concurrent.ConcurrentHashMap.new }
   let(:agent) { double("agent") }
 
   before do

--- a/logstash-core/spec/logstash/pipeline_action/reload_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_action/reload_spec.rb
@@ -11,7 +11,7 @@ describe LogStash::PipelineAction::Reload do
   let(:new_pipeline_config) { mock_pipeline_config(pipeline_id, "input { generator { id => 'new' } } output { null {} }", { "pipeline.reloadable" => true}) }
   let(:pipeline_config) { "input { generator {} } output { null {} }" }
   let(:pipeline) { mock_pipeline_from_string(pipeline_config, mock_settings("pipeline.reloadable" => true)) }
-  let(:pipelines) { { pipeline_id => pipeline } }
+  let(:pipelines) { chm = java.util.concurrent.ConcurrentHashMap.new; chm[pipeline_id] = pipeline; chm }
   let(:agent) { double("agent") }
 
   subject { described_class.new(new_pipeline_config, metric) }

--- a/logstash-core/spec/logstash/pipeline_action/stop_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_action/stop_spec.rb
@@ -9,7 +9,7 @@ describe LogStash::PipelineAction::Stop do
   let(:pipeline_config) { "input { generator {} } output { null {} }" }
   let(:pipeline_id) { :main }
   let(:pipeline) { mock_pipeline_from_string(pipeline_config) }
-  let(:pipelines) { { :main => pipeline } }
+  let(:pipelines) { chm = java.util.concurrent.ConcurrentHashMap.new; chm[:main] = pipeline; chm }
   let(:agent) { double("agent") }
 
   subject { described_class.new(pipeline_id) }

--- a/logstash-core/spec/support/shared_contexts.rb
+++ b/logstash-core/spec/support/shared_contexts.rb
@@ -26,7 +26,7 @@ shared_context "api setup" do
     @agent.execute
     pipeline_config = mock_pipeline_config(:main, "input { generator { id => '123' } } output { null {} }")
     pipeline_creator =  LogStash::PipelineAction::Create.new(pipeline_config, @agent.metric)
-    @pipelines = Hash.new
+    @pipelines = java.util.concurrent.ConcurrentHashMap.new
     expect(pipeline_creator.execute(@agent, @pipelines)).to be_truthy
   end
 

--- a/logstash-core/src/main/java/org/logstash/Logstash.java
+++ b/logstash-core/src/main/java/org/logstash/Logstash.java
@@ -139,6 +139,6 @@ public final class Logstash implements Runnable, AutoCloseable {
     }
 
     private static void uncleanShutdown(final Exception ex) {
-        throw new IllegalStateException("Logstash stopped processing because of an error:", ex);
+        throw new IllegalStateException("Logstash stopped processing because of an error: " + ex.getMessage(), ex);
     }
 }


### PR DESCRIPTION
This way, if one Logstash pipeline is blocked others won't be if they're in the same set of changes.

This is a requirement for https://github.com/logstash-plugins/logstash-integration-internal to work correctly. Without this, connected pipelines might block each other during shutdown. Upstream pipelines must shutdown first in that system, this lets them run simultaneously, thus sorting that issue out.

It possibly also makes booting multiple pipelines faster.

This breaks the plugin API x-pack uses, since `with_pipelines` is removed, but that's an easy patch to x-pack once it's merged into this repo.