### PR TITLE
Log top-level fatal errors with more detail

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Logstash.java
+++ b/logstash-core/src/main/java/org/logstash/Logstash.java
@@ -44,7 +44,7 @@ public final class Logstash implements Runnable, AutoCloseable {
         ) {
             logstash.run();
         } catch (final Throwable t) {
-            LOGGER.error(t.toString());
+            LOGGER.error("Logstash encountered an unexpected fatal error!", t);
             System.exit(1);
         }
         System.exit(0);


### PR DESCRIPTION
Without this patch you'd get a message, but no stack trace, etc.
These errors should only be triggered by outright bugs in the code, so no tests here.

Without this test dev can be frustrating because of the lack of a stack trace.