### PR TITLE
Load x-pack automatically when located in a subdirectory

### DIFF
--- a/logstash-core/lib/logstash/plugins/registry.rb
+++ b/logstash-core/lib/logstash/plugins/registry.rb
@@ -102,6 +102,7 @@ module LogStash module Plugins
     end
 
     def setup!
+      load_xpack unless LogStash::OSS
       load_available_plugins
       execute_universal_plugins
     end
@@ -114,6 +115,11 @@ module LogStash module Plugins
 
     def plugins_with_type(type)
       @registry.values.select { |specification| specification.type.to_sym == type.to_sym }.collect(&:klass)
+    end
+
+    def load_xpack
+      logger.info("Loading x-pack")
+      require_relative(::File.join(LogStash::ROOT, "x-pack/lib/logstash_registry"))
     end
 
     def load_available_plugins

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -3,6 +3,15 @@ Thread.abort_on_exception = true
 Encoding.default_external = Encoding::UTF_8
 $DEBUGLIST = (ENV["DEBUG"] || "").split(",")
 
+require 'pathname'
+LogStash::ROOT = Pathname.new(File.join(File.expand_path(File.dirname(__FILE__)), "..", "..", "..")).cleanpath.to_s
+LogStash::XPACK_PATH = File.join(LogStash::ROOT, "x-pack")
+LogStash::OSS = ENV["OSS"] == "true" || !File.exists?(LogStash::XPACK_PATH)
+
+if !LogStash::OSS
+  $LOAD_PATH << File.join(LogStash::XPACK_PATH, "lib")
+end
+
 require "clamp"
 require "net/http"
 


### PR DESCRIPTION
This is in preparation for our opening of x-pack https://www.elastic.co/products/x-pack/open .

X-Pack can be disabled by setting the environment variable OSS=true, or by removing the X-Pack folder.