### PR TITLE
Add test deps that x-pack will use

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -21,6 +21,7 @@ gem "rack-test", :require => "rack/test", :group => :development
 gem "flores", "~> 0.0.6", :group => :development
 gem "term-ansicolor", "~> 1.3.2", :group => :development
 gem "json-schema", "~> 2.6", :group => :development
+gem "belzebuth", :group => :development
 gem "pleaserun", "~>0.0.28"
 gem 'webrick', '~> 1.3.1'
 gem "atomic", "<= 1.1.99"


### PR DESCRIPTION
When we merge x-pack in we will axe its gemspec, which isn't used anyway.
It does need a couple more test deps, which we add in here