### PR TITLE
Detect invalid proxy and raise error

### DIFF
--- a/lib/pluginmanager/proxy_support.rb
+++ b/lib/pluginmanager/proxy_support.rb
@@ -36,6 +36,7 @@ end
 # Apply HTTP_PROXY and HTTPS_PROXY to the current environment
 # this will be used by any JRUBY calls
 def apply_env_proxy_settings(settings)
+  $stderr.puts("Using proxy #{settings}") if ENV["DEBUG"]
   scheme = settings[:protocol].downcase
   java.lang.System.setProperty("#{scheme}.proxyHost", settings[:host])
   java.lang.System.setProperty("#{scheme}.proxyPort", settings[:port].to_s)
@@ -44,7 +45,6 @@ def apply_env_proxy_settings(settings)
 end
 
 def extract_proxy_values_from_uri(proxy_uri)
-  proxy_uri = URI(proxy_uri)
   {
     :protocol => proxy_uri.scheme,
     :host => proxy_uri.host,
@@ -54,27 +54,38 @@ def extract_proxy_values_from_uri(proxy_uri)
   }
 end
 
+def parse_proxy_string(proxy_string)
+  proxy_uri = URI.parse(proxy_string)
+  if proxy_uri.kind_of?(URI::HTTP) # URI::HTTPS is already a subclass of URI::HTTP
+    proxy_uri
+  else
+    raise "Invalid proxy `#{proxy_uri}`. The URI is not HTTP/HTTPS."
+  end
+end
+
 def get_proxy(key)
   ENV[key.downcase] || ENV[key.upcase]
 end
 
-def valid_proxy?(proxy)
+def proxy_string_exists?(proxy)
   !proxy.nil? && !proxy.strip.empty?
 end
 
 def configure_proxy
   proxies = []
   proxy = get_proxy("http_proxy")
-  if valid_proxy?(proxy)
-    proxy_settings = extract_proxy_values_from_uri(proxy)
+  if proxy_string_exists?(proxy)
+    proxy_uri = parse_proxy_string(proxy)
+    proxy_settings = extract_proxy_values_from_uri(proxy_uri)
     proxy_settings[:protocol] = "http"
     apply_env_proxy_settings(proxy_settings)
     proxies << proxy_settings
   end
 
   proxy = get_proxy("https_proxy")
-  if valid_proxy?(proxy)
-    proxy_settings = extract_proxy_values_from_uri(proxy)
+  if proxy_string_exists?(proxy)
+    proxy_uri = parse_proxy_string(proxy)
+    proxy_settings = extract_proxy_values_from_uri(proxy_uri)
     proxy_settings[:protocol] = "https"
     apply_env_proxy_settings(proxy_settings)
     proxies << proxy_settings

--- a/spec/unit/plugin_manager/proxy_support_spec.rb
+++ b/spec/unit/plugin_manager/proxy_support_spec.rb
@@ -128,4 +128,18 @@ describe "Proxy support" do
       expect { configure_proxy }.not_to raise_exception
     end
   end
+
+  context "when proxies are set to invalid values" do
+    let(:environments) {
+      {
+        "http_proxy" => "myproxy:8080",   # missing scheme
+        "https_proxy" => "myproxy:8080"
+      }
+    }
+
+
+    it "raises an exception" do
+      expect { configure_proxy }.to raise_error(RuntimeError)
+    end
+  end
 end


### PR DESCRIPTION
As reported in #9132, if one sets `http_proxy=myproxy:8080` the URL
gets parsed to scheme=myproxy and host=nil. This results in a
NullPointerException.

To solve it, we check that the URL is really valid as HTTP and raise a slightly
better error message.