### PR TITLE
opening x-pack: make plugin install/remove error helpfully

### DIFF
--- a/lib/bootstrap/environment.rb
+++ b/lib/bootstrap/environment.rb
@@ -36,6 +36,12 @@ module LogStash
       RUBY_ENGINE
     end
 
+    def oss_only?
+      return true if ENV['OSS']=="true"
+
+      !File.exists?(File.join(LogStash::Environment::LOGSTASH_HOME, "x-pack"))
+    end
+
     def windows?
       ::Gem.win_platform?
     end

--- a/lib/pluginmanager/install_strategy_factory.rb
+++ b/lib/pluginmanager/install_strategy_factory.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require "pluginmanager/ui"
+require "pluginmanager/x_pack_interceptor"
 require "pluginmanager/pack_fetch_strategy/repository"
 require "pluginmanager/pack_fetch_strategy/uri"
 
@@ -13,6 +14,10 @@ module LogStash module PluginManager
     def self.create(plugins_args)
       plugin_name_or_uri = plugins_args.first
       return false if plugin_name_or_uri.nil? || plugin_name_or_uri.strip.empty?
+
+      # if the user is attempting to install X-Pack, present helpful output to guide
+      # them toward the default distribution of Logstash
+      XPackInterceptor::Install.intercept!(plugin_name_or_uri)
 
       AVAILABLES_STRATEGIES.each do |strategy|
         if installer = strategy.get_installer_for(plugin_name_or_uri)

--- a/lib/pluginmanager/remove.rb
+++ b/lib/pluginmanager/remove.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require "pluginmanager/bundler/logstash_uninstall"
+require "pluginmanager/x_pack_interceptor.rb"
 require "pluginmanager/command"
 
 class LogStash::PluginManager::Remove < LogStash::PluginManager::Command
@@ -14,6 +15,10 @@ class LogStash::PluginManager::Remove < LogStash::PluginManager::Command
     # finding the plugins
     ##
     LogStash::Bundler.setup!({:without => [:build, :development]})
+
+    # If a user is attempting to uninstall X-Pack, present helpful output to guide
+    # them toward the OSS-only distribution of Logstash
+    LogStash::PluginManager::XPackInterceptor::Remove.intercept!(plugin)
 
     # make sure this is an installed plugin and present in Gemfile.
     # it is not possible to uninstall a dependency not listed in the Gemfile, for example a dependent codec

--- a/lib/pluginmanager/x_pack_interceptor.rb
+++ b/lib/pluginmanager/x_pack_interceptor.rb
@@ -1,0 +1,50 @@
+# encoding: utf-8
+
+module LogStash; module PluginManager
+
+  # Centralised messaging about installing and removing x-pack, which is no longer a plugin, but
+  # part of the distribution.
+  module XPackInterceptor
+
+    module Install
+      extend self
+
+      def intercept!(plugin_name_or_path)
+        return unless plugin_name_or_path.downcase == 'x-pack'
+
+        if Environment.oss_only?
+          $stderr.puts <<~MESSAGE
+            You are using the OSS-only distribution of Logstash. As of version 6.3+ X-Pack
+            is bundled in the standard distribution of this software by default;
+            consequently it is no longer available as a plugin. Please use the standard
+            distribution of Logstash if you wish to use X-Pack features.
+          MESSAGE
+        else
+          $stderr.puts <<~MESSAGE
+            Logstash now contains X-Pack by default, there is no longer any need to install
+            it as it is already present.
+          MESSAGE
+        end
+
+        raise LogStash::PluginManager::InvalidPackError.new('x-pack not an installable plugin')
+      end
+    end
+
+    module Remove
+      extend self
+
+      def intercept!(plugin_name)
+        return unless plugin_name.downcase == 'x-pack'
+        return if Environment.oss_only?
+
+        $stderr.puts <<~MESSAGE
+          As of 6.3+ X-Pack is part of the default distribution and cannot be uninstalled;
+          to remove all X-Pack features, you must install the OSS-only distribution of
+          Logstash.
+        MESSAGE
+
+        raise LogStash::PluginManager::InvalidPackError.new('x-pack not a removable plugin')
+      end
+    end
+  end
+end; end


### PR DESCRIPTION
Since we are opening x-pack and making it part of the distribution, the install- and remove- steps will no longer function as expected; in order to prevent inexplicable errors, intercept these instructions and error helpfully.

Example output:


## Install

### OSS-only Artifact
> ~~~
> ╭─{ yaauie@castrovel:~/src/elastic/snapshots/logstash-oss-6.3.0-SNAPSHOT }
> ╰─● bin/logstash-plugin install x-pack
> You are using the OSS-only distribution of Logstash. As of version 6.3+ X-Pack
> is bundled in the standard distribution of this software by default;
> consequently it is no longer available as a plugin. Please use the standard
> distribution of Logstash if you wish to use X-Pack features.
> ERROR: Invalid pack for: x-pack, reason: x-pack not an installable plugin, message: x-pack not an installable plugin
> [error: 1]
> ~~~

### Source, OSS-Only Mode via `OSS=true`
> ~~~
> ╭─{ yaauie@castrovel:~/src/elastic/logstash (✘ xpack-not-installable) }
> ╰─● OSS=true bin/logstash-plugin install x-pack
> You are using the OSS-only distribution of Logstash. As of version 6.3+ X-Pack
> is bundled in the standard distribution of this software by default;
> consequently it is no longer available as a plugin. Please use the standard
> distribution of Logstash if you wish to use X-Pack features.
> ERROR: Invalid pack for: x-pack, reason: x-pack not an installable plugin, message: x-pack not an installable plugin
> [error: 1]
> ~~~

### Default Artifact:
> ~~~
> ╭─{ yaauie@castrovel:~/src/elastic/snapshots/logstash-6.3.0-SNAPSHOT }
> ╰─● bin/logstash-plugin install x-pack
> Logstash now contains X-Pack by default, there is no longer any need to install
> it as it is already present.
> ERROR: Invalid pack for: x-pack, reason: x-pack not an installable plugin, message: x-pack not an installable plugin
> [error: 1]
> ~~~

### Source, Default Mode
> ~~~
> ╭─{ yaauie@castrovel:~/src/elastic/logstash (✘ xpack-not-installable) }
> ╰─● bin/logstash-plugin install x-pack
> Logstash now contains X-Pack by default, there is no longer any need to install
> it as it is already present.
> ERROR: Invalid pack for: x-pack, reason: x-pack not an installable plugin, message: x-pack not an installable plugin
> [error: 1]
> ~~~

## Remove

### OSS-only Artifact
> ~~~
> ╭─{ yaauie@castrovel:~/src/elastic/snapshots/logstash-oss-6.3.0-SNAPSHOT }
> ╰─● bin/logstash-plugin remove x-pack
> ERROR: Operation aborted, cannot remove plugin., message: This plugin has not been previously installed
> [error: 1]
> ~~~

### Source, OSS-Only Mode via `OSS=true`
> ~~~
> ╭─{ yaauie@castrovel:~/src/elastic/logstash (✘ xpack-not-installable) }
> ╰─● OSS=true bin/logstash-plugin remove x-pack
> ERROR: Operation aborted, cannot remove plugin., message: This plugin has not been previously installed
> [error: 1]
> ~~~

### Default Artifact:
> ~~~
> ╭─{ yaauie@castrovel:~/src/elastic/snapshots/logstash-6.3.0-SNAPSHOT }
> ╰─● bin/logstash-plugin remove x-pack
> As of 6.3+ X-Pack is part of the default distribution and cannot be uninstalled;
> to remove all X-Pack features, you must install the OSS-only distribution of
> Logstash.
> ERROR: Operation aborted, cannot remove plugin., message: x-pack not a removable plugin
> [error: 1]
> ~~~

### Source, Default Mode
> ~~~
> ╭─{ yaauie@castrovel:~/src/elastic/logstash (✘ xpack-not-installable) }
> ╰─● bin/logstash-plugin remove x-pack
> As of 6.3+ X-Pack is part of the default distribution and cannot be uninstalled;
> to remove all X-Pack features, you must install the OSS-only distribution of
> Logstash.
> ERROR: Operation aborted, cannot remove plugin., message: x-pack not a removable plugin
> [error: 1]
> ~~~
