### PR TITLE
Never use gradle daemon on CI servers

### DIFF
--- a/ci/acceptance_tests.sh
+++ b/ci/acceptance_tests.sh
@@ -5,7 +5,7 @@ set -e
 # uses at least 1g of memory, If we don't do this we can get OOM issues when
 # installing gems. See https://github.com/elastic/logstash/issues/5179
 export JRUBY_OPTS="-J-Xmx1g"
-export GRADLE_OPTS="-Xmx2g"
+export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false"
 
 SELECTED_TEST_SUITE=$1
 

--- a/ci/acceptance_tests.sh
+++ b/ci/acceptance_tests.sh
@@ -5,7 +5,7 @@ set -e
 # uses at least 1g of memory, If we don't do this we can get OOM issues when
 # installing gems. See https://github.com/elastic/logstash/issues/5179
 export JRUBY_OPTS="-J-Xmx1g"
-export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false"
+export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info"
 
 SELECTED_TEST_SUITE=$1
 

--- a/ci/ci_docs.sh
+++ b/ci/ci_docs.sh
@@ -2,7 +2,7 @@
 set -e
 
 export JRUBY_OPTS="-J-Xmx2g"
-export GRADLE_OPTS="-Xmx2g"
+export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false"
 
 rake bootstrap
 # needed to workaround `group => :development`

--- a/ci/integration_tests.sh
+++ b/ci/integration_tests.sh
@@ -5,7 +5,7 @@
 # uses at least 1g of memory, If we don't do this we can get OOM issues when
 # installing gems. See https://github.com/elastic/logstash/issues/5179
 export JRUBY_OPTS="-J-Xmx1g"
-export GRADLE_OPTS="-Xmx2g"
+export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false"
 
 export SPEC_OPTS="--order rand --format documentation"
 export CI=true
@@ -41,4 +41,5 @@ elif [[ !  -z  $@  ]]; then
 else
     echo "Running all integration tests"
     ./gradlew runIntegrationTests --console=plain
-fi
+ADLE_OPTS
+nnn

--- a/ci/integration_tests.sh
+++ b/ci/integration_tests.sh
@@ -5,7 +5,7 @@
 # uses at least 1g of memory, If we don't do this we can get OOM issues when
 # installing gems. See https://github.com/elastic/logstash/issues/5179
 export JRUBY_OPTS="-J-Xmx1g"
-export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false"
+export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info"
 
 export SPEC_OPTS="--order rand --format documentation"
 export CI=true
@@ -41,5 +41,4 @@ elif [[ !  -z  $@  ]]; then
 else
     echo "Running all integration tests"
     ./gradlew runIntegrationTests --console=plain
-ADLE_OPTS
-nnn
+fi

--- a/ci/unit_tests.bat
+++ b/ci/unit_tests.bat
@@ -40,7 +40,7 @@ echo Using drive !use_drive! for %WORKSPACE%
 !use_drive!
 
 echo Running core tests..
-call .\gradlew.bat test --console=plain --no-daemon
+call .\gradlew.bat test --console=plain --no-daemon --info
 
 if errorlevel 1 (
   echo Error: failed to run core tests. Aborting..

--- a/ci/unit_tests.bat
+++ b/ci/unit_tests.bat
@@ -40,7 +40,7 @@ echo Using drive !use_drive! for %WORKSPACE%
 !use_drive!
 
 echo Running core tests..
-call .\gradlew.bat test --console=plain
+call .\gradlew.bat test --console=plain --no-daemon
 
 if errorlevel 1 (
   echo Error: failed to run core tests. Aborting..

--- a/ci/unit_tests.sh
+++ b/ci/unit_tests.sh
@@ -5,7 +5,7 @@
 # uses at least 1g of memory, If we don't do this we can get OOM issues when
 # installing gems. See https://github.com/elastic/logstash/issues/5179
 export JRUBY_OPTS="-J-Xmx1g"
-export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false"
+export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info"
 
 export SPEC_OPTS="--order rand --format documentation"
 export CI=true

--- a/ci/unit_tests.sh
+++ b/ci/unit_tests.sh
@@ -5,7 +5,7 @@
 # uses at least 1g of memory, If we don't do this we can get OOM issues when
 # installing gems. See https://github.com/elastic/logstash/issues/5179
 export JRUBY_OPTS="-J-Xmx1g"
-export GRADLE_OPTS="-Xmx2g"
+export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false"
 
 export SPEC_OPTS="--order rand --format documentation"
 export CI=true


### PR DESCRIPTION
We've had some issues with builds crashing the gradle daemon on CI servers. This can obfuscate errors.
This patch removes its usage in CI.

This is considered a gradle best practice: https://docs.gradle.org/current/userguide/gradle_daemon.html#sec:stopping_an_existing_daemon