### PR TITLE
update README to have statements that remain true after x-pack added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Logstash
 
-Logstash is part of the [Elastic Stack](https://www.elastic.co/products) along with Beats, Elasticsearch and Kibana. Logstash is an open source, server-side data processing pipeline that ingests data from a multitude of sources simultaneously, transforms it, and then sends it to your favorite "stash." (Ours is Elasticsearch, naturally.). Logstash has over 200 plugins, and you can write your own very easily as well.
-
-The license is Apache 2.0, meaning you are pretty much free to use it however you want in whatever way.
+Logstash is part of the [Elastic Stack](https://www.elastic.co/products) along with Beats, Elasticsearch and Kibana. Logstash is a server-side data processing pipeline that ingests data from a multitude of sources simultaneously, transforms it, and then sends it to your favorite "stash." (Ours is Elasticsearch, naturally.). Logstash has over 200 plugins, and you can write your own very easily as well.
 
 For more info, see <https://www.elastic.co/products/logstash>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 ## Logstash Roadmap
 
-[Logstash](https://www.elastic.co/products/logstash "Logstash") is an open-source data collection engine, developed directly on Github and distributed under the Apache License 2.0. The roadmap is defined by the core themes of performance, resiliency, and manageability, along with the overall plugin ecosystem. User requirements are the main driving force behind our development efforts. If a user has a bad time, it’s a bug!  All submitted [issues](https://github.com/elastic/logstash/issues/new "New Issue"), suggestions, or ideas are greatly encouraged and appreciated.
+[Logstash](https://www.elastic.co/products/logstash "Logstash") is a data collection engine that is developed directly on Github. The roadmap is defined by the core themes of performance, resiliency, and manageability, along with the overall plugin ecosystem. User requirements are the main driving force behind our development efforts. If a user has a bad time, it’s a bug!  All submitted [issues](https://github.com/elastic/logstash/issues/new "New Issue"), suggestions, or ideas are greatly encouraged and appreciated.
 
 ### Logstash Core
 


### PR DESCRIPTION
The commit message is important here, because we want the intent of this change to be clear to anyone who may have fear about where we're going:

~~~
commit 1596f2c58ada13683f1f5920199a5cb21da05d7e (HEAD -> opening-xpack-readme-updates)
Author: Ry Biesemeyer <ry.biesemeyer@elastic.co>
Date:   Wed Mar 14 22:56:03 2018 +0000

    remove overly-broad statements about licensing from docs

    Elastic has recently announced that we are [opening x-pack][] code, which was
    previously private. It will be released under a commercial license and
    included in some distributions of Logstash, making certain distributions not
    fully-FOSS-compliant. For that reason, we want to avoid making overly-broad
    statements about "open-source" that could become confusing in the near future.

    Elastic continues to invest heavily in the Apache2-licensed open core of
    Logstash; we will continue to release and distribute OSS-only artifacts, and
    will empower our community to use and extend Logstash.

    [opening x-pack]: https://www.elastic.co/blog/doubling-down-on-open
~~~