### PR TITLE
Better logging info for intermittent source related CI failures

### DIFF
--- a/logstash-core/lib/logstash/config/source_loader.rb
+++ b/logstash-core/lib/logstash/config/source_loader.rb
@@ -52,6 +52,9 @@ module LogStash module Config
       if sources_loaders.empty?
         # This shouldn't happen with the settings object or with any external plugins.
         # but lets add a guard so we fail fast.
+        @sources_lock.synchronize do
+          @logger.error "No source loaders matched! This shouldn't happen", :sources => @sources
+        end
         raise LogStash::InvalidSourceLoaderSettingError, "Can't find an appropriate config loader with current settings"
       else
         begin


### PR DESCRIPTION
As seen in https://logstash-ci.elastic.co/job/elastic+logstash+pull-request+multijob-ruby-unit-tests/111/consoleFull
sometimes specs fail due to this failing invariant.

The exact error was:

```
[ERROR] 2018-03-14 23:26:12.985 [[main]-pipeline-manager] agent - An exception happened when converging configuration {:exception=>LogStash::InvalidSourceLoaderSettingError, :message=>"Can't find an appropriate config loader with current settings", :backtrace=>["/opt/logstash/logstash-core/lib/logstash/config/source_loader.rb:55:in `fetch'", "/opt/logstash/logstash-core/lib/logstash/agent.rb:148:in `converge_state_and_update'", "/opt/logstash/logstash-core/lib/logstash/agent.rb:90:in `execute'", "/opt/logstash/logstash-core/spec/support/shared_contexts.rb:26:in `block in (root)'", "org/jruby/RubyBasicObject.java:1728:in `instance_exec'", "/tmp/vendor/bundle/jruby/2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/hooks.rb:350:in `run'", "/tmp/vendor/bundle/jruby/2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/hooks.rb:509:in `block in run_owned_hooks_for'", "org/jruby/RubyArray.java:1734:in `each'", "/tmp/vendor/bundle/jruby/2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/hooks.rb:508:in `run_owned_hooks_for'", "/tmp/vendor/bundle/jruby/2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/hooks.rb:460:in `run'", "/tmp/vendor/bundle/jruby/2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/example_group.rb:537:in `block in run_before_context_hooks'", "/tmp/vendor/bundle/jruby/2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/memoized_helpers.rb:186:in `block in isolate_for_context_hook'", "org/jruby/RubyBasicObject.java:1728:in `instance_exec'", "/tmp/vendor/bundle/jruby/2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/memoized_helpers.rb:182:in `isolate_for_context_hook'", "/tmp/vendor/bundle/jruby/2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/example_group.rb:536:in `run_before_context_hooks'", "/tmp/vendor/bundle/jruby/2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/example_group.rb:589:in `run'", "/tmp/vendor/bundle/jruby/2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:118:in `block in run_specs'", "org/jruby/RubyArray.java:2486:in `map'", "/tmp/vendor/bundle/jruby/2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:118:in `block in run_specs'", "/tmp/vendor/bundle/jruby/2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/configuration.rb:1926:in `with_suite_hooks'", "/tmp/vendor/bundle/jruby/2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:113:in `block in run_specs'", "/tmp/vendor/bundle/jruby/2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/reporter.rb:79:in `report'", "/tmp/vendor/bundle/jruby/2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:112:in `run_specs'", "/tmp/vendor/bundle/jruby/2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:87:in `run'", "/tmp/vendor/bundle/jruby/2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:71:in `run'", "/opt/logstash/lib/bootstrap/rspec.rb:13:in `<main>'"]}
```

I think more detail here would be useful, hence the additional log line. Hopefully if/when this happens again we'll have enough to actually debug it.