### PR TITLE
Add link to xpack settings

### DIFF
--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -63,7 +63,7 @@ modules:
 
 IMPORTANT: If the <<command-line-flags,command-line flag>> `--modules` is used, any modules defined in the `logstash.yml` file will be ignored.
 
-The `logstash.yml` file includes the following settings:
+The `logstash.yml` file includes the following settings. If you are using X-Pack, also see {logstash-ref}/settings-xpack.html[X-Pack Settings in Logstash].
 
 [options="header"]
 |=======================================================================
@@ -228,4 +228,3 @@ The log level. Valid options are:
 | Platform-specific. See <<dir-layout>>.
 
 |=======================================================================
-


### PR DESCRIPTION
The logstash.yml settings are documented in this topic: https://www.elastic.co/guide/en/logstash/current/logstash-settings-file.html. Added a cross reference to X-Pack settings (https://www.elastic.co/guide/en/logstash/current/settings-xpack.html) so that users have easy access to all logstash.yml settings.

