### PR TITLE
#9255 speed up concurrent Eventcondition compilations

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/EventCondition.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/EventCondition.java
@@ -1,9 +1,9 @@
 package org.logstash.config.ir.compiler;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import org.jruby.RubyInteger;
 import org.jruby.RubyNumeric;
 import org.jruby.RubyString;
@@ -67,7 +67,7 @@ public interface EventCondition {
         /**
          * Cache of all compiled {@link EventCondition}.
          */
-        private static final Map<String, EventCondition> CACHE = new HashMap<>(10);
+        private static final Map<String, EventCondition> CACHE = new ConcurrentHashMap<>(10);
 
         private Compiler() {
             //Utility Class.
@@ -82,9 +82,13 @@ public interface EventCondition {
          * @return Compiled {@link EventCondition}
          */
         public static EventCondition buildCondition(final BooleanExpression expression) {
+            final String cachekey = expression.toRubyString();
+            EventCondition cached = CACHE.get(cachekey);
+            if (cached != null) {
+                return cached;
+            }
             synchronized (CACHE) {
-                final String cachekey = expression.toRubyString();
-                final EventCondition cached = CACHE.get(cachekey);
+                cached = CACHE.get(cachekey);
                 if (cached != null) {
                     return cached;
                 }


### PR DESCRIPTION
Fixes #9255 (compilation time goes from 50min+ to 2min):

The performance issue there is mostly in the fact that every lookup on the `CACHE` is synchronized while the compilation of a new `EventCondition` takes quite a bit of time.

Fixed by looking up from a `ConcurrentHashMap` in a non-blocking way before going into the sync block.

Note:
* We have to try and look up from the cache again inside the synced block to avoid duplicate compilations
* This implementation is much much faster than using `computeIfAbsent` because compute if absent will block if the key is present but the bin is modified concurrently
   * Also https://bugs.openjdk.java.net/browse/JDK-8062841 breaks JDK older than 8b88 here in practice (reproduced by me) => we don't want to use it. 