### PR TITLE
Change title to improve SEO

### DIFF
--- a/docs/static/keystore.asciidoc
+++ b/docs/static/keystore.asciidoc
@@ -1,5 +1,5 @@
 [[keystore]]
-=== Secrets keystore
+=== Secrets keystore for secure settings
 
 When you configure Logstash, you might need to specify sensitive settings or
 configuration, such as passwords. Rather than relying on file system permissions


### PR DESCRIPTION
Support team mentioned that they weren't finding the Logstash keystore topic by searching on "secure settings" (corresponds to how they search for Elasticsearch keystore info). 