### PR TITLE
#9255 Speedup pipeline compilation by making IfVertex more efficient

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
@@ -348,7 +348,7 @@ public final class CompiledPipeline {
                         );
                         // It is important that we double check that we are actually dealing with the
                         // positive/left branch of the if condition
-                        if (ifvert.getOutgoingBooleanEdgesByType(true).stream()
+                        if (ifvert.outgoingBooleanEdgesByType(true)
                             .anyMatch(edge -> Objects.equals(edge.getTo(), start))) {
                             return ifDataset;
                         } else {

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/IfVertex.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/IfVertex.java
@@ -1,13 +1,12 @@
 package org.logstash.config.ir.graph;
 
-import org.logstash.config.ir.SourceComponent;
-import org.logstash.common.SourceWithMetadata;
-import org.logstash.config.ir.expression.BooleanExpression;
-
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.logstash.common.SourceWithMetadata;
+import org.logstash.config.ir.SourceComponent;
+import org.logstash.config.ir.expression.BooleanExpression;
 
 /**
  * Created by andrewvc on 9/15/16.
@@ -61,13 +60,8 @@ public class IfVertex extends Vertex {
         return (e instanceof BooleanEdge);
     }
 
-    public Collection<BooleanEdge> getOutgoingBooleanEdges() {
-        // Wish there was a way to do this as a java a cast without an operation
-        return getOutgoingEdges().stream().map(e -> (BooleanEdge) e).collect(Collectors.toList());
-    }
-
-    public Collection<BooleanEdge> getOutgoingBooleanEdgesByType(boolean edgeType) {
-        return getOutgoingBooleanEdges().stream().filter(e -> e.getEdgeType() == edgeType).collect(Collectors.toList());
+    public Stream<BooleanEdge> outgoingBooleanEdgesByType(boolean edgeType) {
+        return outgoingEdges().map(e -> (BooleanEdge) e).filter(e -> e.getEdgeType() == edgeType);
     }
 
     // The easiest readable version of this for a human.

--- a/logstash-core/src/test/java/org/logstash/config/ir/graph/IfVertexTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/graph/IfVertexTest.java
@@ -53,8 +53,8 @@ public class IfVertexTest {
         assertThat(ifV.getUnusedOutgoingEdgeFactories().isEmpty(), is(true));
 
 
-        BooleanEdge trueEdge = ifV.getOutgoingBooleanEdgesByType(true).stream().findAny().get();
-        BooleanEdge falseEdge = ifV.getOutgoingBooleanEdgesByType(false).stream().findAny().get();
+        BooleanEdge trueEdge = ifV.outgoingBooleanEdgesByType(true).findAny().get();
+        BooleanEdge falseEdge = ifV.outgoingBooleanEdgesByType(false).findAny().get();
         assertThat(trueEdge.getEdgeType(), is(true));
         assertThat(falseEdge.getEdgeType(), is(false));
     }


### PR DESCRIPTION
Obvious fix, removing a lot of `Stream` to `Collection` conversion => causes a speedup from `60s` to `40s` for the example config in #9255. 

Update: Also pushed another commit here that inlines the parent vertex compilation so that we only compile (or look up from the compile cache) children when we actually need them and don't do so before the cache lookup. I realize that commit number 2 here makes the code less readable  :( ... but **it brings down total compile time of the example to ~2-3s**