### PR TITLE
Improve performance of Event#cancel

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -101,14 +101,14 @@ public final class JrubyEventExtLibrary {
         public IRubyObject ruby_cancel(ThreadContext context)
         {
             this.event.cancel();
-            return RubyBoolean.createTrueClass(context.runtime);
+            return context.runtime.getTrue();
         }
 
         @JRubyMethod(name = "uncancel")
         public IRubyObject ruby_uncancel(ThreadContext context)
         {
             this.event.uncancel();
-            return RubyBoolean.createFalseClass(context.runtime);
+            return context.runtime.getFalse();
         }
 
         @JRubyMethod(name = "cancelled?")


### PR DESCRIPTION
This method was creating a ton of expensive objects making execution slow.

In local tests this improved performance massively, at least 5x in one test with the drop filter.