### PR TITLE
Clean up trailing slashes in xrefs (cherry pick#9192 into 6.2)

### DIFF
--- a/docs/index-shared1.asciidoc
+++ b/docs/index-shared1.asciidoc
@@ -14,11 +14,7 @@ release-state can be: released | prerelease | unreleased
 :versioned_docs: false
 
 :jdk:                   1.8.0
-:guide:                 https://www.elastic.co/guide/en/elasticsearch/guide/current/
-:libbeat:               https://www.elastic.co/guide/en/beats/libbeat/{branch}/
-:filebeat:              https://www.elastic.co/guide/en/beats/filebeat/{branch}/
-:metricbeat:            https://www.elastic.co/guide/en/beats/metricbeat/{branch}/
-:lsissue:               https://github.com/elastic/logstash/issues/
+:lsissue:               https://github.com/elastic/logstash/issues
 :lsplugindocs:          https://www.elastic.co/guide/en/logstash-versioned-plugins/current
 
 include::{asciidoc-dir}/../../shared/attributes62.asciidoc[]

--- a/docs/static/advanced-pipeline.asciidoc
+++ b/docs/static/advanced-pipeline.asciidoc
@@ -31,7 +31,7 @@ input plugin enables Logstash to receive events from the Elastic Beats framework
 to work with the Beats framework, such as Packetbeat and Metricbeat, can also send event data to Logstash.
 
 To install Filebeat on your data source machine, download the appropriate package from the Filebeat https://www.elastic.co/downloads/beats/filebeat[product page]. You can also refer to
-{filebeat}filebeat-getting-started.html[Getting Started with Filebeat] in the Beats documentation for additional
+{filebeat-ref}/filebeat-getting-started.html[Getting Started with Filebeat] in the Beats documentation for additional
 installation instructions.
 
 After installing Filebeat, you need to configure it. Open the `filebeat.yml` file located in your Filebeat installation
@@ -63,7 +63,7 @@ sudo ./filebeat -e -c filebeat.yml -d "publish"
 --------------------------------------------------------------------------------
 
 NOTE: If you run Filebeat as root, you need to change ownership of the configuration file (see
-{libbeat}config-file-permissions.html[Config File Ownership and Permissions]
+{beats-ref}/config-file-permissions.html[Config File Ownership and Permissions]
 in the _Beats Platform Reference_).
 
 Filebeat will attempt to connect on port 5044. Until Logstash starts with an active Beats plugin, there
@@ -638,7 +638,7 @@ If you are using Kibana to visualize your data, you can also explore the Filebea
 
 image::static/images/kibana-filebeat-data.png[Discovering Filebeat data in Kibana]
 
-See the {filebeat}filebeat-getting-started.html[Filebeat getting started docs] for info about loading the Kibana
+See the {filebeat-ref}/filebeat-getting-started.html[Filebeat getting started docs] for info about loading the Kibana
 index pattern for Filebeat.
 
 You've successfully created a pipeline that uses Filebeat to take Apache web logs as input, parses those logs to

--- a/docs/static/deploying.asciidoc
+++ b/docs/static/deploying.asciidoc
@@ -18,10 +18,10 @@ recommendations provided here may vary based on your own requirements.
 
 For first time users, if you simply want to tail a log file to grasp the power
 of the Elastic Stack, we recommend trying
-{filebeat}filebeat-modules-overview.html[Filebeat Modules]. Filebeat Modules
+{filebeat-ref}/filebeat-modules-overview.html[Filebeat Modules]. Filebeat Modules
 enable you to quickly collect, parse, and index popular log types and view
 pre-built Kibana dashboards within minutes.
-{metricbeat}metricbeat-modules.html[Metricbeat Modules] provide a similar
+{metricbeat-ref}/metricbeat-modules.html[Metricbeat Modules] provide a similar
 experience, but with metrics data. In this context, Beats will ship data
 directly to Elasticsearch where {ref}/ingest.html[Ingest Nodes] will process
 and index your data.
@@ -75,7 +75,7 @@ streaming even through variable throughput loads. If the Logstash layer becomes
 an ingestion bottleneck, simply add more nodes to scale out. Here are a few
 general recommendations:
 
-* Beats should {filebeat}load-balancing.html[load balance] across a group of
+* Beats should {filebeat-ref}/load-balancing.html[load balance] across a group of
 Logstash nodes.
 * A minimum of two Logstash nodes are recommended for high availability.
 * It’s common to deploy just one Beats input per Logstash node, but multiple
@@ -119,7 +119,7 @@ Make sure to check out the other <<filter-plugins,available filter plugins>>.
 Enterprise-grade security is available across the entire delivery chain.
 
 * Wire encryption is recommended for both the transport from
-{filebeat}configuring-ssl-logstash.html[Beats to Logstash] and from
+{filebeat-ref}/configuring-ssl-logstash.html[Beats to Logstash] and from
 {logstash-ref}/ls-security.html[Logstash to Elasticsearch].
 * There’s a wealth of security options when communicating with Elasticsearch
 including basic authentication, TLS, PKI, LDAP, AD, and other custom realms.

--- a/docs/static/filebeat-modules.asciidoc
+++ b/docs/static/filebeat-modules.asciidoc
@@ -2,7 +2,7 @@
 
 == Working with Filebeat Modules
 
-Filebeat comes packaged with pre-built  {filebeat}filebeat-modules.html[modules]
+Filebeat comes packaged with pre-built  {filebeat-ref}/filebeat-modules.html[modules]
 that contain the configurations needed to collect, parse, enrich, and visualize
 data from various log file formats. Each Filebeat module consists of one or more
 filesets that contain ingest node pipelines, Elasticsearch templates, Filebeat
@@ -108,11 +108,11 @@ location expected by the module, you can set the `var.paths` option.
 +
 NOTE: Depending on how you've installed Filebeat, you might see errors
 related to file ownership or permissions when you try to run Filebeat modules.
-See {libbeat}/config-file-permissions.html[Config File Ownership and Permissions]
+See {beats-ref}/config-file-permissions.html[Config File Ownership and Permissions]
 in the _Beats Platform Reference_ if you encounter errors related to file
 ownership or permissions.
 +
-See {filebeat}/filebeat-starting.html[Starting Filebeat] for more info.
+See {filebeat-ref}/filebeat-starting.html[Starting Filebeat] for more info.
 
 [float]
 ==== Visualize the data
@@ -137,7 +137,7 @@ data sent collected by Filebeat modules:
 
 The Logstash pipeline configuration in this example shows how to ship and parse
 access and error logs collected by the
-{filebeat}filebeat-module-apache2.html[`apache2` Filebeat module].
+{filebeat-ref}/filebeat-module-apache2.html[`apache2` Filebeat module].
 
 [source,json]
 ----------------------------------------------------------------------------
@@ -150,7 +150,7 @@ include::filebeat_modules/apache2/pipeline.conf[]
 
 The Logstash pipeline configuration in this example shows how to ship and parse
 error and slowlog logs collected by the
-{filebeat}filebeat-module-mysql.html[`mysql` Filebeat module].
+{filebeat-ref}/filebeat-module-mysql.html[`mysql` Filebeat module].
 
 [source,json]
 ----------------------------------------------------------------------------
@@ -163,7 +163,7 @@ include::filebeat_modules/mysql/pipeline.conf[]
 
 The Logstash pipeline configuration in this example shows how to ship and parse
 access and error logs collected by the
-{filebeat}filebeat-module-nginx.html[`nginx` Filebeat module].
+{filebeat-ref}/filebeat-module-nginx.html[`nginx` Filebeat module].
 
 [source,json]
 ----------------------------------------------------------------------------
@@ -176,7 +176,7 @@ include::filebeat_modules/nginx/pipeline.conf[]
 
 The Logstash pipeline configuration in this example shows how to ship and parse
 system logs collected by the
-{filebeat}filebeat-module-system.html[`system` Filebeat module].
+{filebeat-ref}/filebeat-module-system.html[`system` Filebeat module].
 
 [source,json]
 ----------------------------------------------------------------------------

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -253,9 +253,9 @@ endif::include-xpack[]
 
 [[logstash-6-1-0]]
 === Logstash 6.1.0 Release Notes
-* Implemented a new experimental Java execution engine for Logstash pipelines. The Java engine is off by default, but can be enabled with --experimental-java-execution ({lsissue}7950[Issue 7950]).
-* Added support for changing the <<configuring-persistent-queues,page capacity>> for an existing queue ({lsissue}8628[Issue 8628]).
-* Made extensive improvements to pipeline execution performance and memory efficiency ({lsissue}7692[Issue 7692], {lsissue}8776[8776], {lsissue}8577[8577], {lsissue}8446[8446], {lsissue}8333[8333], {lsissue}8163[8163], {lsissue}8103[8103], {lsissue}8087[8087], and {lsissue}7691[7691]).
+* Implemented a new experimental Java execution engine for Logstash pipelines. The Java engine is off by default, but can be enabled with --experimental-java-execution ({lsissue}/7950[Issue 7950]).
+* Added support for changing the <<configuring-persistent-queues,page capacity>> for an existing queue ({lsissue}/8628[Issue 8628]).
+* Made extensive improvements to pipeline execution performance and memory efficiency ({lsissue}/7692[Issue 7692], {lsissue}/8776[8776], {lsissue}/8577[8577], {lsissue}/8446[8446], {lsissue}/8333[8333], {lsissue}/8163[8163], {lsissue}/8103[8103], {lsissue}/8087[8087], and {lsissue}/7691[7691]).
 
 [float]
 ==== Filter Plugins


### PR DESCRIPTION
Backport changes from PR #9192  (Issue #7571) to clean up cross references
Cherrypicked royalharsh's changes and then my changes from the 6.x branch into 6.2