### PR TITLE
BUG: Fix Java execution not handling nil return from flush invocations

### DIFF
--- a/logstash-core/lib/logstash/java_filter_delegator.rb
+++ b/logstash-core/lib/logstash/java_filter_delegator.rb
@@ -67,11 +67,10 @@ module LogStash
     def flush(options = {})
       # we also need to trace the number of events
       # coming from a specific filters.
-      new_events = @filter.flush(options)
-
       # Filter plugins that does buffering or spooling of events like the
       # `Logstash-filter-aggregates` can return `NIL` and will flush on the next flush ticks.
-      @metric_events_out.increment(new_events.size) if new_events && new_events.size > 0
+      new_events = @filter.flush(options) || []
+      @metric_events_out.increment(new_events.size)
       new_events
     end
   end


### PR DESCRIPTION
Fixes https://github.com/elastic/logstash/issues/9255#issuecomment-376127356 by handling the `flush` call returning `nil` on the Ruby layer.

See https://github.com/elastic/logstash/issues/9255#issuecomment-376147688 for details.

Handled this validation on the Ruby end now, because Java plugins are incoming and I didn't wanna mix more Ruby specifics into the compiler.