### PR TITLE
Remove unnecessary require for reporter specs from pipeline_specs

### DIFF
--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -4,7 +4,6 @@ require "logstash/inputs/generator"
 require "logstash/filters/drop"
 require_relative "../support/mocks_classes"
 require_relative "../support/helpers"
-require_relative "../logstash/pipeline_reporter_spec" # for DummyOutput class
 require "stud/try"
 require 'timeout'
 


### PR DESCRIPTION
Using require this way breaks the ability to run a specific spec with rspec since the require triggers
them to run. This patch fixes that.