### PR TITLE
Faster dataset clear and fix for #9292

### DIFF
--- a/config/jvm.options
+++ b/config/jvm.options
@@ -75,6 +75,3 @@
 
 # Entropy source for randomness
 -Djava.security.egd=file:/dev/urandom
--agentlib:jdwp=transport=dt_socket,server=n,address=localhost:5006,suspend=y
--Dorg.codehaus.janino.source_debugging.dir=/Users/brownbear/src/logstash/logs/debug
--Dorg.codehaus.janino.source_debugging.enable=true

--- a/config/jvm.options
+++ b/config/jvm.options
@@ -75,3 +75,6 @@
 
 # Entropy source for randomness
 -Djava.security.egd=file:/dev/urandom
+-agentlib:jdwp=transport=dt_socket,server=n,address=localhost:5006,suspend=y
+-Dorg.codehaus.janino.source_debugging.dir=/Users/brownbear/src/logstash/logs/debug
+-Dorg.codehaus.janino.source_debugging.enable=true

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/ClassFields.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/ClassFields.java
@@ -10,11 +10,9 @@ import java.util.stream.Collectors;
  */
 final class ClassFields {
 
-    private final Collection<FieldDefinition> definitions;
+    private final Collection<FieldDefinition> definitions = new ArrayList<>();
 
-    ClassFields() {
-        definitions = new ArrayList<>();
-    }
+    private final Collection<Closure> afterInit = new ArrayList<>();
 
     /**
      * Add a field of given type that is initialized by the given {@link SyntaxElement} that will
@@ -46,6 +44,14 @@ final class ClassFields {
      */
     public ValueSyntaxElement add(final Class<?> type) {
         return addField(FieldDefinition.mutableUnassigned(definitions.size(), type));
+    }
+
+    public void addAfterInit(final Closure closure) {
+        afterInit.add(closure);
+    }
+
+    public Closure afterInit() {
+        return Closure.wrap(afterInit.toArray(new Closure[0]));
     }
 
     /**

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/ClassFields.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/ClassFields.java
@@ -46,10 +46,20 @@ final class ClassFields {
         return addField(FieldDefinition.mutableUnassigned(definitions.size(), type));
     }
 
+    /**
+     * Add a {@link Closure} that should be executed in the constructor after field assignments
+     * have been executed.
+     * @param closure Closure to run after field assignments
+     */
     public void addAfterInit(final Closure closure) {
         afterInit.add(closure);
     }
 
+    /**
+     * Returns a closure of actions that should be run in the constructor after all field
+     * assignments have been executed.
+     * @return Closure that should be executed after field assignments are done
+     */
     public Closure afterInit() {
         return Closure.wrap(afterInit.toArray(new Closure[0]));
     }

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/ComputeStepSyntaxElement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/ComputeStepSyntaxElement.java
@@ -204,7 +204,10 @@ public final class ComputeStepSyntaxElement<T extends Dataset> implements Syntax
                 ctor.add(argVar);
             }
         }
-        return combine(ctorFields, MethodSyntaxElement.constructor(name, constructor, ctor));
+        return combine(
+            ctorFields,
+            MethodSyntaxElement.constructor(name, constructor.add(fields.afterInit()), ctor)
+        );
     }
 
     /**

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/MethodSyntaxElement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/MethodSyntaxElement.java
@@ -55,13 +55,7 @@ interface MethodSyntaxElement extends SyntaxElement {
      */
     static MethodSyntaxElement right(final ValueSyntaxElement elseData) {
         return new MethodSyntaxElement.MethodSyntaxElementImpl(Dataset.class, "right",
-            Closure.wrap(
-                SyntaxFactory.ret(
-                    SyntaxFactory.constant(
-                        DatasetCompiler.class, DatasetCompiler.Complement.class.getSimpleName()
-                    ).call("from", SyntaxFactory.THIS, elseData)
-                )
-            )
+            Closure.wrap(SyntaxFactory.ret(elseData))
         );
     }
 


### PR DESCRIPTION
fixes #9292 by:

* Avoiding recursive calls to `HashMap#computeIfAbsent`
* Avoiding redundant `clear` calls, by guarding them with the `done` flag