### PR TITLE
Provide a better error message for Event#set on non-collections

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Accessors.java
+++ b/logstash-core/src/main/java/org/logstash/Accessors.java
@@ -99,12 +99,25 @@ public final class Accessors {
         return target;
     }
 
+    public static class InvalidFieldSetException extends RuntimeException {
+        public InvalidFieldSetException(final Object target, final String key, final Object value) {
+            super(String.format(
+                    "Could not set field '%s' on object '%s' to value '%s'." +
+                    "This is probably due to trying to set a field like [foo][bar] = someValue" +
+                    "when [foo] is not either a map or a string",
+                    key, target, value
+            ));
+        }
+    }
+
     private static Object setChild(final Object target, final String key, final Object value) {
         if (target instanceof ConvertedMap) {
             ((ConvertedMap) target).putInterned(key, value);
             return value;
-        } else {
+        } else if (target instanceof ConvertedList) {
             return setOnList(key, value, (ConvertedList) target);
+        } else {
+            throw new InvalidFieldSetException(target, key, value);
         }
     }
 

--- a/logstash-core/src/test/java/org/logstash/AccessorsTest.java
+++ b/logstash-core/src/test/java/org/logstash/AccessorsTest.java
@@ -187,6 +187,13 @@ public class AccessorsTest {
         assertEquals(0, Accessors.listIndex(-10, 10));
     }
 
+    @Test(expected = Accessors.InvalidFieldSetException.class)
+    public void testSetOnNonMapOrList() {
+        final ConvertedMap data = new ConvertedMap(1);
+        set(data, "[foo]", "AString");
+        set(data, "[foo][bar]", "Another String");
+    }
+
     private static Object get(final ConvertedMap data, final CharSequence reference) {
         return Accessors.get(data, FieldReference.from(reference));
     }


### PR DESCRIPTION
When executing an Event#set on a nested field that is not a collection we
returned a poor exception. This fixes that.

Fixes https://github.com/elastic/logstash/issues/8777