### PR TITLE
Ensure that metadata keys are valuefied

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -153,10 +153,11 @@ public final class Event implements Cloneable, Queueable {
     public void setField(final FieldReference field, final Object value) {
         switch (field.type()) {
             case FieldReference.META_PARENT:
+                // ConvertedMap.newFromMap already does valuefication
                 this.metadata = ConvertedMap.newFromMap((Map<String, Object>) value);
                 break;
             case FieldReference.META_CHILD:
-                Accessors.set(metadata, field, value);
+                Accessors.set(metadata, field, Valuefier.convert(value));
                 break;
             default:
                 Accessors.set(data, field, Valuefier.convert(value));

--- a/logstash-core/src/test/java/org/logstash/EventTest.java
+++ b/logstash-core/src/test/java/org/logstash/EventTest.java
@@ -6,6 +6,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -14,7 +15,6 @@ import org.jruby.RubySymbol;
 import org.jruby.RubyTime;
 import org.jruby.java.proxies.ConcreteJavaProxy;
 import org.junit.Test;
-import org.logstash.ext.JrubyTimestampExtLibrary;
 
 import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
 import static org.hamcrest.CoreMatchers.is;
@@ -397,5 +397,35 @@ public final class EventTest {
             RubyUtil.RUBY_TIMESTAMP_CLASS, timestamp
         ));
         assertThat(event.getField("timestamp"), is(timestamp));
+    }
+
+    @Test
+    public void metadataFieldsShouldBeValuefied() {
+        final Event event = new Event();
+        event.setField("[@metadata][foo]", Collections.emptyMap());
+        assertEquals(HashMap.class, event.getField("[@metadata][foo]").getClass());
+
+        event.setField("[@metadata][bar]", Collections.singletonList("hello"));
+        final List list = (List) event.getField("[@metadata][bar]");
+        assertEquals(ArrayList.class, list.getClass());
+        assertEquals(list, Arrays.asList("hello"));
+    }
+
+    @Test
+    public void metadataRootShouldBeValueified() {
+        final Event event = new Event();
+
+        final Map<String, Object> metadata = new HashMap<>();
+        metadata.put("foo", Collections.emptyMap());
+        metadata.put("bar", Collections.singletonList("hello"));
+
+        event.setField("@metadata", metadata);
+
+        assertEquals(HashMap.class, event.getField("[@metadata][foo]").getClass());
+
+        final List list = (List) event.getField("[@metadata][bar]");
+        assertEquals(ArrayList.class, list.getClass());
+        assertEquals(list, Arrays.asList("hello"));
+
     }
 }


### PR DESCRIPTION
It was previously the case that setting metadata might not convert values set to metadata.
This could cause type errors.

Fixes https://github.com/elastic/logstash/issues/9295