### PR TITLE
 #9167 Serialize Encoding with RubyString

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ObjectMappers.java
+++ b/logstash-core/src/main/java/org/logstash/ObjectMappers.java
@@ -27,7 +27,6 @@ import org.jruby.RubyNil;
 import org.jruby.RubyString;
 import org.jruby.RubySymbol;
 import org.jruby.ext.bigdecimal.RubyBigDecimal;
-import org.jruby.util.ByteList;
 import org.logstash.ext.JrubyTimestampExtLibrary;
 
 public final class ObjectMappers {
@@ -106,8 +105,7 @@ public final class ObjectMappers {
             final WritableTypeId typeId =
                 typeSer.typeId(value, RubyString.class, JsonToken.VALUE_STRING);
             typeSer.writeTypePrefix(jgen, typeId);
-            final ByteList bytes = value.getByteList();
-            jgen.writeBinary(bytes.getUnsafeBytes(), bytes.begin(), bytes.length());
+            jgen.writeString(value.asJavaString());
             typeSer.writeTypeSuffix(jgen, typeId);
         }
     }
@@ -121,7 +119,7 @@ public final class ObjectMappers {
         @Override
         public RubyString deserialize(final JsonParser p, final DeserializationContext ctxt)
             throws IOException {
-            return RubyString.newString(RubyUtil.RUBY, p.getBinaryValue());
+            return RubyString.newString(RubyUtil.RUBY, p.getValueAsString());
         }
     }
 

--- a/logstash-core/src/test/java/org/logstash/EventTest.java
+++ b/logstash-core/src/test/java/org/logstash/EventTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public final class EventTest {
 
@@ -93,6 +94,16 @@ public final class EventTest {
         final RubyString before = (RubyString) e.getUnconvertedField("foo");
         Event er = Event.deserialize(e.serialize());
         assertEquals(before, er.getUnconvertedField("foo"));
+    }
+
+    @Test
+    public void toBinaryRoundtripNonAscii() throws Exception {
+        Event e = new Event();
+        e.setField("foo", "bör");
+        final RubyString before = (RubyString) e.getUnconvertedField("foo");
+        Event er = Event.deserialize(e.serialize());
+        assertEquals(before, er.getUnconvertedField("foo"));
+        assertTrue(before.op_cmp((RubyString)er.getUnconvertedField("foo")) == 0);
     }
 
     /**

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
@@ -209,7 +209,7 @@ public class DeadLetterQueueReaderTest {
     @Test
     public void testBlockBoundary() throws Exception {
 
-        final int PAD_FOR_BLOCK_SIZE_EVENT = 32516;
+        final int PAD_FOR_BLOCK_SIZE_EVENT = 32490;
         Event event = new Event();
         char[] field = new char[PAD_FOR_BLOCK_SIZE_EVENT];
         Arrays.fill(field, 'e');
@@ -234,7 +234,7 @@ public class DeadLetterQueueReaderTest {
     @Test
     public void testBlockBoundaryMultiple() throws Exception {
         Event event = new Event(Collections.emptyMap());
-        char[] field = new char[7934];
+        char[] field = new char[7929];
         Arrays.fill(field, 'x');
         event.setField("message", new String(field));
         long startTime = System.currentTimeMillis();
@@ -259,7 +259,7 @@ public class DeadLetterQueueReaderTest {
     // This test tests for a single event that ends on a block and segment boundary
     @Test
     public void testBlockAndSegmentBoundary() throws Exception {
-        final int PAD_FOR_BLOCK_SIZE_EVENT = 32516;
+        final int PAD_FOR_BLOCK_SIZE_EVENT = 32490;
         Event event = new Event();
         event.setField("T", generateMessageContent(PAD_FOR_BLOCK_SIZE_EVENT));
         Timestamp timestamp = new Timestamp();


### PR DESCRIPTION
* Write 0xff prefix to signal encoding is serialized before the string
* Serialize Encoding by classname
* Fallback to old deserialization strategy if 0xff prefix isn't found

-----------------------------

Note:
* Had to change sizes in DLQ tests since `RubyString` now serializes to more bytes
* I decided not to reuse/cache a buffer for serialization in `RubyStringSerializer` because this could lead to significant memory issues for use cases that periodically run into very large `RubyString` fields (we, unfortunately, have some of those)
* This is the only solution that I could think of, that would make the PQ fully transparent for `RubyString` fields. An alternative solution would be to force UTF-8 or UTF-16 encoding on all Strings passing through the PQ and give up on it being 100% transparent. Two points pro/con on that:
   * If we force UTF-16 we're 100% transparent from the Java perspective
   * The overhead of the current solution isn't that much in terms of performance (not noticeable for me locally, the PQ is IO bound by its random access `msync` and the size increase of contiguous memory segments here doesn't hurt things that much) (though for short strings there's a 100%+ overhead in size).