### PR TITLE
 #9247 and #9281: Fix incorrect serialization offsets RubyString

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ObjectMappers.java
+++ b/logstash-core/src/main/java/org/logstash/ObjectMappers.java
@@ -107,7 +107,7 @@ public final class ObjectMappers {
                 typeSer.typeId(value, RubyString.class, JsonToken.VALUE_STRING);
             typeSer.writeTypePrefix(jgen, typeId);
             final ByteList bytes = value.getByteList();
-            jgen.writeBinary(bytes.getUnsafeBytes(), 0, bytes.length());
+            jgen.writeBinary(bytes.getUnsafeBytes(), bytes.begin(), bytes.length());
             typeSer.writeTypeSuffix(jgen, typeId);
         }
     }

--- a/logstash-core/src/test/java/org/logstash/EventTest.java
+++ b/logstash-core/src/test/java/org/logstash/EventTest.java
@@ -10,7 +10,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
+import org.jruby.RubyString;
 import org.jruby.RubySymbol;
 import org.jruby.RubyTime;
 import org.jruby.java.proxies.ConcreteJavaProxy;
@@ -81,6 +81,18 @@ public final class EventTest {
         assertEquals(timestamp, er.getField("time"));
         assertEquals(list, er.getField("list"));
         assertEquals(e.getTimestamp().toString(), er.getTimestamp().toString());
+    }
+
+    @Test
+    public void toBinaryRoundtripSubstring() throws Exception {
+        Event e = new Event();
+        e.setField(
+            "foo",
+            RubyString.newString(RubyUtil.RUBY, "--bar--").substr(RubyUtil.RUBY, 2, 3)
+        );
+        final RubyString before = (RubyString) e.getUnconvertedField("foo");
+        Event er = Event.deserialize(e.serialize());
+        assertEquals(before, er.getUnconvertedField("foo"));
     }
 
     /**


### PR DESCRIPTION
Fixes #9247 and #9281 

The problem with those two tickets is, that we are serializing `RubyString` that came out of a matching, substring or similar operation and may not have offset `0` pointing at their underlying `BytesList`.
Fixed by serializing the correct part of the `BytesList` + added reproducer.