### PR TITLE
MINOR: Remove needless generic type from SequencedList

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Batch.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Batch.java
@@ -15,7 +15,7 @@ public class Batch implements Closeable {
     private final Queue queue;
     private final AtomicBoolean closed;
 
-    public Batch(SequencedList<byte[]> serialized, Queue q) {
+    public Batch(SequencedList serialized, Queue q) {
         this(serialized.getElements(), serialized.getSeqNums(), q);
     }
 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Page.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Page.java
@@ -48,11 +48,11 @@ public final class Page implements Closeable {
      * @return {@link SequencedList} collection of serialized elements read
      * @throws IOException
      */
-    public SequencedList<byte[]> read(int limit) throws IOException {
+    public SequencedList read(int limit) throws IOException {
         // first make sure this page is activated, activating previously activated is harmless
         this.pageIO.activate();
 
-        SequencedList<byte[]> serialized = this.pageIO.read(this.firstUnreadSeqNum, limit);
+        SequencedList serialized = this.pageIO.read(this.firstUnreadSeqNum, limit);
         assert serialized.getSeqNums().get(0) == this.firstUnreadSeqNum :
             String.format("firstUnreadSeqNum=%d != first result seqNum=%d", this.firstUnreadSeqNum, serialized.getSeqNums().get(0));
 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -559,7 +559,7 @@ public final class Queue implements Closeable {
             if (! p.isFullyRead()) {
                 boolean wasFull = isFull();
 
-                final SequencedList<byte[]> serialized = p.read(left);
+                final SequencedList serialized = p.read(left);
                 int n = serialized.getElements().size();
                 assert n > 0 : "page read returned 0 elements";
                 elements.addAll(serialized.getElements());

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/SequencedList.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/SequencedList.java
@@ -3,16 +3,16 @@ package org.logstash.ackedqueue;
 import java.util.List;
 import org.logstash.ackedqueue.io.LongVector;
 
-public class SequencedList<E> {
-    private final List<E> elements;
+public final class SequencedList {
+    private final List<byte[]> elements;
     private final LongVector seqNums;
 
-    public SequencedList(List<E> elements, LongVector seqNums) {
+    public SequencedList(List<byte[]> elements, LongVector seqNums) {
         this.elements = elements;
         this.seqNums = seqNums;
     }
 
-    public List<E> getElements() {
+    public List<byte[]> getElements() {
         return elements;
     }
 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/MmapPageIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/MmapPageIO.java
@@ -92,7 +92,7 @@ public final class MmapPageIO implements PageIO {
     }
 
     @Override
-    public SequencedList<byte[]> read(long seqNum, int limit) throws IOException {
+    public SequencedList read(long seqNum, int limit) throws IOException {
         assert seqNum >= this.minSeqNum :
             String.format("seqNum=%d < minSeqNum=%d", seqNum, this.minSeqNum);
         assert seqNum <= maxSeqNum() :
@@ -128,7 +128,7 @@ public final class MmapPageIO implements PageIO {
             }
         }
 
-        return new SequencedList<>(elements, seqNums);
+        return new SequencedList(elements, seqNums);
     }
 
     // recover will overwrite/update/set this object minSeqNum, capacity and elementCount attributes

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/PageIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/PageIO.java
@@ -32,7 +32,7 @@ public interface PageIO extends Closeable {
     void write(byte[] bytes, long seqNum) throws IOException;
 
     // read up to limit number of items starting at give seqNum
-    SequencedList<byte[]> read(long seqNum, int limit) throws IOException;
+    SequencedList read(long seqNum, int limit) throws IOException;
 
     // @return the data container total capacity in bytes
     int getCapacity();

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/wip/MemoryPageIOStream.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/wip/MemoryPageIOStream.java
@@ -142,9 +142,9 @@ public class MemoryPageIOStream implements PageIO {
     }
 
     @Override
-    public SequencedList<byte[]> read(long seqNum, int limit) throws IOException {
+    public SequencedList read(long seqNum, int limit) throws IOException {
         if (elementCount == 0) {
-            return new SequencedList<>(Collections.emptyList(), new LongVector(0));
+            return new SequencedList(Collections.emptyList(), new LongVector(0));
         }
         setReadPoint(seqNum);
         return read(limit);
@@ -255,7 +255,7 @@ public class MemoryPageIOStream implements PageIO {
         crcWrappedOutput.close();
     }
 
-    private SequencedList<byte[]> read(int limit) throws IOException {
+    private SequencedList read(int limit) throws IOException {
         int upto = available(limit);
         List<byte[]> elements = new ArrayList<>(upto);
         final LongVector seqNums = new LongVector(upto);
@@ -266,7 +266,7 @@ public class MemoryPageIOStream implements PageIO {
             elements.add(data);
             seqNums.add(seqNum);
         }
-        return new SequencedList<>(elements, seqNums);
+        return new SequencedList(elements, seqNums);
     }
 
     private long readSeqNum() throws IOException {

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/io/FileMmapIOTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/io/FileMmapIOTest.java
@@ -45,7 +45,7 @@ public class FileMmapIOTest {
         }
         writeIo.close();
         readIo.open(1, 16);
-        SequencedList<byte[]> result = readIo.read(1, 16);
+        SequencedList result = readIo.read(1, 16);
         for (byte[] bytes : result.getElements()) {
             StringElement element = StringElement.deserialize(bytes);
             readList.add(element);

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/io/wip/MemoryPageIOStreamTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/io/wip/MemoryPageIOStreamTest.java
@@ -108,7 +108,7 @@ public class MemoryPageIOStreamTest {
     @Test
     public void read() throws Exception {
         MemoryPageIOStream subj = subject();
-        SequencedList<byte[]> result = subj.read(1L, 1);
+        SequencedList result = subj.read(1L, 1);
         assertThat(result.getElements().isEmpty(), is(true));
     }
 
@@ -118,7 +118,7 @@ public class MemoryPageIOStreamTest {
         Queueable element = buildStringElement("foobarbaz");
         MemoryPageIOStream subj = subject();
         subj.write(element.serialize(), seqNum);
-        SequencedList<byte[]> result = subj.read(seqNum, 1);
+        SequencedList result = subj.read(seqNum, 1);
         assertThat(result.getElements().size(), is(equalTo(1)));
         Queueable readElement = StringElement.deserialize(result.getElements().get(0));
         assertThat(result.getSeqNums().get(0), is(equalTo(seqNum)));
@@ -131,7 +131,7 @@ public class MemoryPageIOStreamTest {
         Queueable element = buildStringElement("");
         MemoryPageIOStream subj = subject();
         subj.write(element.serialize(), seqNum);
-        SequencedList<byte[]> result = subj.read(seqNum, 1);
+        SequencedList result = subj.read(seqNum, 1);
         assertThat(result.getElements().size(), is(equalTo(1)));
         Queueable readElement = StringElement.deserialize(result.getElements().get(0));
         assertThat(result.getSeqNums().get(0), is(equalTo(seqNum)));
@@ -150,7 +150,7 @@ public class MemoryPageIOStreamTest {
         subj.write(element3.serialize(), 44L);
         subj.write(element4.serialize(), 46L);
         int batchSize = 11;
-        SequencedList<byte[]> result = subj.read(40L, batchSize);
+        SequencedList result = subj.read(40L, batchSize);
         assertThat(result.getElements().size(), is(equalTo(4)));
 
         assertThat(result.getSeqNums().get(0), is(equalTo(40L)));
@@ -177,7 +177,7 @@ public class MemoryPageIOStreamTest {
         MemoryPageIOStream subj = subject(stream.getBuffer(), 10L, 10);
         int batchSize = 3;
         seqNum = 13L;
-        SequencedList<byte[]> result = subj.read(seqNum, batchSize);
+        SequencedList result = subj.read(seqNum, batchSize);
         for (int i = 0; i < 3; i++) {
             Queueable ele = StringElement.deserialize(result.getElements().get(i));
             assertThat(result.getSeqNums().get(i), is(equalTo(seqNum + i)));


### PR DESCRIPTION
Minor cleanup of the interface in preparation for incoming improvements.
`SequencedList` is only used as a wrapper for a list of `byte[]` => remove the generic type.