### PR TITLE
CLEANUP+PERFORMANCE: Config Compiler Improvements

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/ClassFields.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/ClassFields.java
@@ -15,18 +15,6 @@ final class ClassFields {
     private final Collection<Closure> afterInit = new ArrayList<>();
 
     /**
-     * Add a field of given type that is initialized by the given {@link SyntaxElement} that will
-     * be executed in the class body.
-     * Renders as e.g. {@code private final Ruby field5 = RubyUtil.RUBY}.
-     * @param type Type of the field
-     * @param initializer Syntax to initialize it in-line.
-     * @return The field's syntax element that can be used in method bodies
-     */
-    public ValueSyntaxElement add(final Class<?> type, final SyntaxElement initializer) {
-        return addField(FieldDefinition.withInitializer(definitions.size(), type, initializer));
-    }
-
-    /**
      * Adds a field holding the given {@link Object}.
      * @param obj Object to add field for
      * @return The field's syntax element that can be used in method bodies

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/DatasetCompiler.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/DatasetCompiler.java
@@ -108,12 +108,8 @@ public final class DatasetCompiler {
                         .add(SyntaxFactory.ret(ifData))
                 ),
                 MethodSyntaxElement.clear(
-                    Closure.wrap(
-                        SyntaxFactory.ifCondition(
-                            done,
-                            clearSyntax(parentFields).add(clear(ifData)).add(clear(elseData))
-                                .add(SyntaxFactory.assignment(done, SyntaxFactory.FALSE))
-                        )
+                    clearIfDone(
+                        clearSyntax(parentFields).add(clear(ifData)).add(clear(elseData)), done
                     )
                 ),
                 MethodSyntaxElement.right(right)
@@ -166,15 +162,8 @@ public final class DatasetCompiler {
         return prepare(
             body.add(SyntaxFactory.assignment(done, SyntaxFactory.TRUE))
                 .add(SyntaxFactory.ret(outputBuffer)),
-            Closure.wrap(
-                SyntaxFactory.ifCondition(
-                    done,
-                    Closure.wrap(
-                        clearSyntax(parentFields), clear(outputBuffer),
-                        SyntaxFactory.assignment(done, SyntaxFactory.FALSE)
-                    )
-                )
-            ), fields
+            clearIfDone(Closure.wrap(clearSyntax(parentFields), clear(outputBuffer)), done),
+            fields
         );
     }
 
@@ -261,6 +250,23 @@ public final class DatasetCompiler {
                 inlineClear
             ),
             clearSyntax, fields
+        );
+    }
+
+    /**
+     * Generates code that clears a {@link Dataset}'s internal buffers if the given boolean flag
+     * is set to true, then sets the flag to false once done.
+     * @param clearAction Action for clearing buffers
+     * @param doneField Boolean field that must be true for the action to run
+     * @return Closure wrapping the conditional clear action
+     */
+    private static Closure clearIfDone(final Closure clearAction,
+        final MethodLevelSyntaxElement doneField) {
+        return Closure.wrap(
+            SyntaxFactory.ifCondition(
+                doneField,
+                Closure.wrap(clearAction, SyntaxFactory.assignment(doneField, SyntaxFactory.FALSE))
+            )
         );
     }
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/DatasetCompiler.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/DatasetCompiler.java
@@ -36,29 +36,15 @@ public final class DatasetCompiler {
      * the given set of {@link JrubyEventExtLibrary.RubyEvent} and have no state.
      */
     public static final Collection<Dataset> ROOT_DATASETS = Collections.singleton(
-        prepare(Closure.wrap(SyntaxFactory.ret(BATCH_ARG)), Closure.EMPTY, new ClassFields())
-            .instantiate()
+        prepare(
+            computeAndClear(
+                Closure.wrap(SyntaxFactory.ret(BATCH_ARG)), Closure.EMPTY, new ClassFields()
+            )
+        ).instantiate()
     );
 
     private DatasetCompiler() {
         // Utility Class
-    }
-
-    /**
-     * Compiles and subsequently instantiates a {@link Dataset} from given code snippets and
-     * constructor arguments.
-     * This method must be {@code synchronized} to avoid compiling duplicate classes.
-     * @param compute Method body of {@link Dataset#compute(RubyArray, boolean, boolean)}
-     * @param clear Method body of {@link Dataset#clear()}
-     * @param fieldValues Constructor Arguments
-     * @return Dataset Instance
-     */
-    public static synchronized ComputeStepSyntaxElement<Dataset> prepare(final Closure compute, final Closure clear,
-        final ClassFields fieldValues) {
-        return new ComputeStepSyntaxElement<>(
-            Arrays.asList(MethodSyntaxElement.compute(compute), MethodSyntaxElement.clear(clear)),
-            fieldValues, Dataset.class
-        );
     }
 
     public static ComputeStepSyntaxElement<SplitDataset> splitDataset(final Collection<Dataset> parents,
@@ -66,54 +52,45 @@ public final class DatasetCompiler {
         final ClassFields fields = new ClassFields();
         final Collection<ValueSyntaxElement> parentFields =
             parents.stream().map(fields::add).collect(Collectors.toList());
-        final SyntaxElement arrayInit =
-            SyntaxFactory.constant(RubyUtil.class, "RUBY").call("newArray");
-        final ValueSyntaxElement ifData = fields.add(RubyArray.class, arrayInit);
-        final ValueSyntaxElement elseData = fields.add(RubyArray.class, arrayInit);
-        final ValueSyntaxElement buffer = fields.add(RubyArray.class, arrayInit);
-        final ValueSyntaxElement done = fields.add(boolean.class);
+        final ValueSyntaxElement ifData = fields.add(new ArrayList<>());
+        final ValueSyntaxElement elseData = fields.add(new ArrayList<>());
+        final ValueSyntaxElement buffer = fields.add(new ArrayList<>());
         final ValueSyntaxElement right = fields.add(DatasetCompiler.Complement.class);
         final VariableDefinition event =
             new VariableDefinition(JrubyEventExtLibrary.RubyEvent.class, "event");
         final ValueSyntaxElement eventVal = event.access();
         fields.addAfterInit(
             Closure.wrap(
-                SyntaxFactory.assignment(right,
+                SyntaxFactory.assignment(
+                    right,
                     SyntaxFactory.cast(
                         DatasetCompiler.Complement.class, SyntaxFactory.constant(
                             DatasetCompiler.class, DatasetCompiler.Complement.class.getSimpleName()
-                        ).call("from", SyntaxFactory.THIS, elseData)
+                        ).call("from", SyntaxFactory.identifier("this"), elseData)
                     )
                 )
             )
         );
-        return new ComputeStepSyntaxElement<>(
-            Arrays.asList(
-                MethodSyntaxElement.compute(
-                    returnIffBuffered(ifData, done)
-                        .add(bufferParents(parentFields, buffer))
-                        .add(
-                            SyntaxFactory.forLoop(
-                                event, buffer,
-                                Closure.wrap(
-                                    SyntaxFactory.ifCondition(
-                                        fields.add(condition).call("fulfilled", eventVal),
-                                        Closure.wrap(ifData.call("add", eventVal)),
-                                        Closure.wrap(elseData.call("add", eventVal))
-                                    )
-                                )
+        final DatasetCompiler.ComputeAndClear compute = withOutputBuffering(
+            withInputBuffering(
+                Closure.wrap(
+                    SyntaxFactory.forLoop(
+                        event, buffer,
+                        Closure.wrap(
+                            SyntaxFactory.ifCondition(
+                                fields.add(condition).call("fulfilled", eventVal),
+                                Closure.wrap(ifData.call("add", eventVal)),
+                                Closure.wrap(elseData.call("add", eventVal))
                             )
-                        ).add(clear(buffer))
-                        .add(SyntaxFactory.assignment(done, SyntaxFactory.TRUE))
-                        .add(SyntaxFactory.ret(ifData))
-                ),
-                MethodSyntaxElement.clear(
-                    clearIfDone(
-                        clearSyntax(parentFields).add(clear(ifData)).add(clear(elseData)), done
+                        )
                     )
-                ),
-                MethodSyntaxElement.right(right)
-            ), fields, SplitDataset.class
+                ), parentFields, buffer
+            ),
+            clearSyntax(parentFields).add(clear(elseData)), ifData, fields
+        );
+        return ComputeStepSyntaxElement.create(
+            Arrays.asList(compute.compute(), compute.clear(), MethodSyntaxElement.right(right)),
+            compute.fields(), SplitDataset.class
         );
     }
 
@@ -129,27 +106,21 @@ public final class DatasetCompiler {
         final Collection<ValueSyntaxElement> parentFields =
             parents.stream().map(fields::add).collect(Collectors.toList());
         final RubyArray inputBuffer = RubyUtil.RUBY.newArray();
-        final ValueSyntaxElement inputBufferField = fields.add(inputBuffer);
         final ValueSyntaxElement outputBuffer = fields.add(new ArrayList<>());
         final IRubyObject filter = plugin.toRuby();
         final ValueSyntaxElement filterField = fields.add(filter);
-        final ValueSyntaxElement done = fields.add(boolean.class);
         final String multiFilter = "multi_filter";
-        final Closure body = returnIffBuffered(outputBuffer, done).add(
-            bufferParents(parentFields, inputBufferField)
-                .add(
-                    buffer(
-                        outputBuffer,
-                        SyntaxFactory.cast(
-                            RubyArray.class,
-                            callRubyCallsite(
-                                fields.add(rubyCallsite(filter, multiFilter)),
-                                fields.add(new IRubyObject[]{inputBuffer}), filterField,
-                                multiFilter
-                            )
-                        )
+        final Closure body = Closure.wrap(
+            buffer(
+                outputBuffer,
+                SyntaxFactory.cast(
+                    RubyArray.class,
+                    callRubyCallsite(
+                        fields.add(rubyCallsite(filter, multiFilter)),
+                        fields.add(new IRubyObject[]{inputBuffer}), filterField, multiFilter
                     )
-                ).add(clear(inputBufferField))
+                )
+            )
         );
         if (plugin.hasFlush()) {
             body.add(
@@ -160,10 +131,10 @@ public final class DatasetCompiler {
             );
         }
         return prepare(
-            body.add(SyntaxFactory.assignment(done, SyntaxFactory.TRUE))
-                .add(SyntaxFactory.ret(outputBuffer)),
-            clearIfDone(Closure.wrap(clearSyntax(parentFields), clear(outputBuffer)), done),
-            fields
+            withOutputBuffering(
+                withInputBuffering(body, parentFields, fields.add(inputBuffer)),
+                clearSyntax(parentFields), outputBuffer, fields
+            )
         );
     }
 
@@ -229,7 +200,6 @@ public final class DatasetCompiler {
         final Collection<ValueSyntaxElement> parentFields =
             parents.stream().map(fields::add).collect(Collectors.toList());
         final RubyArray buffer = RubyUtil.RUBY.newArray();
-        final ValueSyntaxElement inputBuffer = fields.add(buffer);
         final Closure clearSyntax;
         final Closure inlineClear;
         if (terminal) {
@@ -240,40 +210,90 @@ public final class DatasetCompiler {
             clearSyntax = clearSyntax(parentFields);
         }
         return compileOutput(
-            Closure.wrap(
-                bufferParents(parentFields, inputBuffer),
-                callRubyCallsite(
-                    fields.add(method), fields.add(new IRubyObject[]{buffer}),
-                    fields.add(output), MULTI_RECEIVE
-                ),
-                clear(inputBuffer),
-                inlineClear
+            withInputBuffering(
+                Closure.wrap(
+                    callRubyCallsite(
+                        fields.add(method), fields.add(new IRubyObject[]{buffer}),
+                        fields.add(output), MULTI_RECEIVE
+                    ), inlineClear
+                ), parentFields, fields.add(buffer)
             ),
             clearSyntax, fields
         );
     }
 
     /**
-     * Generates code that clears a {@link Dataset}'s internal buffers if the given boolean flag
-     * is set to true, then sets the flag to false once done.
-     * @param clearAction Action for clearing buffers
-     * @param doneField Boolean field that must be true for the action to run
-     * @return Closure wrapping the conditional clear action
+     * Compiles and subsequently instantiates a {@link Dataset} from given code snippets and
+     * constructor arguments.
+     * This method must be {@code synchronized} to avoid compiling duplicate classes.
+     * @param compute Method definitions for {@code compute} and {@code clear}
+     * @return Dataset Instance
      */
-    private static Closure clearIfDone(final Closure clearAction,
-        final MethodLevelSyntaxElement doneField) {
-        return Closure.wrap(
-            SyntaxFactory.ifCondition(
-                doneField,
-                Closure.wrap(clearAction, SyntaxFactory.assignment(doneField, SyntaxFactory.FALSE))
-            )
+    private static ComputeStepSyntaxElement<Dataset> prepare(final DatasetCompiler.ComputeAndClear compute) {
+        return ComputeStepSyntaxElement.create(
+            Arrays.asList(compute.compute(), compute.clear()), compute.fields(), Dataset.class
         );
     }
 
-    private static Closure returnIffBuffered(final MethodLevelSyntaxElement ifData,
-        final MethodLevelSyntaxElement done) {
+    /**
+     * Generates code that buffers all events that aren't cancelled from a given set of parent
+     * {@link Dataset} to a given collection, executes the given closure and then clears the
+     * collection used for buffering.
+     * @param compute Closure to execute
+     * @param parents Parents to buffer results for
+     * @param inputBuffer Buffer to store results in
+     * @return Closure wrapped by buffering parent results and clearing them
+     */
+    private static Closure withInputBuffering(final Closure compute,
+        final Collection<ValueSyntaxElement> parents, final ValueSyntaxElement inputBuffer) {
+        final VariableDefinition event =
+            new VariableDefinition(JrubyEventExtLibrary.RubyEvent.class, "e");
+        final ValueSyntaxElement eventVar = event.access();
         return Closure.wrap(
-            SyntaxFactory.ifCondition(done, Closure.wrap(SyntaxFactory.ret(ifData)))
+            parents.stream().map(par ->
+                SyntaxFactory.forLoop(
+                    event, computeDataset(par),
+                    Closure.wrap(
+                        SyntaxFactory.ifCondition(
+                            SyntaxFactory.not(
+                                eventVar.call("getEvent").call("isCancelled")
+                            ), Closure.wrap(inputBuffer.call("add", eventVar))
+                        )
+                    )
+                )
+            ).toArray(MethodLevelSyntaxElement[]::new)
+        ).add(compute).add(clear(inputBuffer));
+    }
+
+    /**
+     * Generates compute and clear actions with logic for setting a boolean {@code done}
+     * flag and caching the result of the computation in the {@code compute} closure.
+     * Wraps {@code clear} closure with condition to only execute the clear if the {@code done}
+     * flag is set to {@code true}. Also adds clearing the output buffer used for caching the
+     * {@code compute} result to the {@code clear} closure.
+     * @param compute Compute closure to execute
+     * @param clear Clear closure to execute
+     * @param outputBuffer Output buffer used for caching {@code compute} result
+     * @param fields Class fields
+     * @return ComputeAndClear with adjusted methods and {@code done} flag added to fields
+     */
+    private static DatasetCompiler.ComputeAndClear withOutputBuffering(final Closure compute,
+        final Closure clear, final ValueSyntaxElement outputBuffer, final ClassFields fields) {
+        final ValueSyntaxElement done = fields.add(boolean.class);
+        return computeAndClear(
+            Closure.wrap(
+                SyntaxFactory.ifCondition(done, Closure.wrap(SyntaxFactory.ret(outputBuffer)))
+            ).add(compute)
+                .add(SyntaxFactory.assignment(done, SyntaxFactory.identifier("true")))
+                .add(SyntaxFactory.ret(outputBuffer)),
+            Closure.wrap(
+                SyntaxFactory.ifCondition(
+                    done, Closure.wrap(
+                        clear.add(clear(outputBuffer)),
+                        SyntaxFactory.assignment(done, SyntaxFactory.identifier("false"))
+                    )
+                )
+            ), fields
         );
     }
 
@@ -320,27 +340,6 @@ public final class DatasetCompiler {
         return new IRubyObject[]{res};
     }
 
-    private static Closure bufferParents(final Collection<ValueSyntaxElement> parents,
-        final ValueSyntaxElement buffer) {
-        final VariableDefinition event =
-            new VariableDefinition(JrubyEventExtLibrary.RubyEvent.class, "e");
-        final ValueSyntaxElement eventVar = event.access();
-        return Closure.wrap(
-            parents.stream().map(par ->
-                SyntaxFactory.forLoop(
-                    event, computeDataset(par),
-                    Closure.wrap(
-                        SyntaxFactory.ifCondition(
-                            SyntaxFactory.not(
-                                eventVar.call("getEvent").call("isCancelled")
-                            ), Closure.wrap(buffer.call("add", eventVar))
-                        )
-                    )
-                )
-            ).toArray(MethodLevelSyntaxElement[]::new)
-        );
-    }
-
     /**
      * Special case optimization for when the output plugin is directly connected to the Queue
      * without any filters or conditionals in between. This special case does not arise naturally
@@ -366,7 +365,7 @@ public final class DatasetCompiler {
     private static ComputeStepSyntaxElement<Dataset> compileOutput(final Closure syntax,
         final Closure clearSyntax, final ClassFields fields) {
         return prepare(
-            syntax.add(MethodLevelSyntaxElement.RETURN_NULL), clearSyntax, fields
+            computeAndClear(syntax.add(MethodLevelSyntaxElement.RETURN_NULL), clearSyntax, fields)
         );
     }
 
@@ -396,6 +395,11 @@ public final class DatasetCompiler {
 
     private static DynamicMethod rubyCallsite(final IRubyObject rubyObject, final String name) {
         return rubyObject.getMetaClass().searchMethod(name);
+    }
+
+    private static DatasetCompiler.ComputeAndClear computeAndClear(final Closure compute, final Closure clear,
+        final ClassFields fields) {
+        return new DatasetCompiler.ComputeAndClear(compute, clear, fields);
     }
 
     /**
@@ -452,6 +456,38 @@ public final class DatasetCompiler {
                 parent.clear();
                 done = false;
             }
+        }
+    }
+
+    /**
+     * Represents the 3-tuple of {@code compute} method, {@code clear} method and
+     * {@link ClassFields} used by both methods.
+     */
+    private static final class ComputeAndClear {
+
+        private final MethodSyntaxElement compute;
+
+        private final MethodSyntaxElement clear;
+
+        private final ClassFields fields;
+
+        private ComputeAndClear(final Closure compute, final Closure clear,
+            final ClassFields fields) {
+            this.compute = MethodSyntaxElement.compute(compute);
+            this.clear = MethodSyntaxElement.clear(clear);
+            this.fields = fields;
+        }
+
+        public MethodSyntaxElement compute() {
+            return compute;
+        }
+
+        public MethodSyntaxElement clear() {
+            return clear;
+        }
+
+        public ClassFields fields() {
+            return fields;
         }
     }
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/SyntaxFactory.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/SyntaxFactory.java
@@ -9,12 +9,6 @@ import java.util.stream.Collectors;
  */
 final class SyntaxFactory {
 
-    public static final SyntaxFactory.IdentifierStatement THIS = identifier("this");
-
-    public static final SyntaxFactory.IdentifierStatement TRUE = identifier("true");
-
-    public static final SyntaxFactory.IdentifierStatement FALSE = identifier("false");
-
     /**
      * Joins given {@link String}s without delimiter.
      * @param parts Strings to join

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/DatasetCompilerTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/DatasetCompilerTest.java
@@ -1,6 +1,5 @@
 package org.logstash.config.ir.compiler;
 
-import java.util.Collection;
 import org.jruby.RubyArray;
 import org.jruby.runtime.ThreadContext;
 import org.junit.Test;
@@ -14,40 +13,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public final class DatasetCompilerTest {
-
-    @Test
-    public void compilesEmptyMethod() {
-        final Dataset func = DatasetCompiler.prepare(
-            Closure.wrap(SyntaxFactory.ret(DatasetCompiler.BATCH_ARG.call("to_a"))),
-            Closure.EMPTY, new ClassFields()
-        ).instantiate();
-        final RubyArray batch = RubyUtil.RUBY.newArray();
-        assertThat(func.compute(batch, false, false), is(batch));
-    }
-
-    @Test
-    public void compilesParametrizedMethod() {
-        final RubyArray batch = RubyUtil.RUBY.newArray(
-            JrubyEventExtLibrary.RubyEvent.newRubyEvent(RubyUtil.RUBY, new Event())
-        );
-        final VariableDefinition eventsDef = new VariableDefinition(Collection.class, "events");
-        final ValueSyntaxElement events = eventsDef.access();
-        final ClassFields fields = new ClassFields();
-        final Dataset func = DatasetCompiler.prepare(
-            Closure.wrap(
-                SyntaxFactory.definition(eventsDef, DatasetCompiler.BATCH_ARG.call("to_a")),
-                events.call(
-                    "add",
-                    fields.add(
-                        JrubyEventExtLibrary.RubyEvent.newRubyEvent(RubyUtil.RUBY, new Event())
-                    )
-                ),
-                SyntaxFactory.ret(events)
-            ),
-            Closure.EMPTY, fields
-        ).instantiate();
-        assertThat(func.compute(batch, false, false).size(), is(2));
-    }
 
     /**
      * Smoke test ensuring that output {@link Dataset} is compiled correctly.


### PR DESCRIPTION
Some improvements in preparation of Java plugins:

* Dry up logic around buffering in `Dataset`
* Use `ArrayList` instead of `RubyArray` for better performance in `SplitDataset`
* Ensure contiguous numbering of `Dataset` classes to make dependency relations easier to debug
* Remove redundant tests