### PR TITLE
Optimize out empty ifs

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ObjectMappers.java
+++ b/logstash-core/src/main/java/org/logstash/ObjectMappers.java
@@ -107,7 +107,7 @@ public final class ObjectMappers {
                 typeSer.typeId(value, RubyString.class, JsonToken.VALUE_STRING);
             typeSer.writeTypePrefix(jgen, typeId);
             final ByteList bytes = value.getByteList();
-            jgen.writeBinary(bytes.getUnsafeBytes(), 0, bytes.length());
+            jgen.writeBinary(bytes.getUnsafeBytes(), bytes.begin(), bytes.length());
             typeSer.writeTypeSuffix(jgen, typeId);
         }
     }

--- a/logstash-core/src/main/java/org/logstash/config/ir/imperative/IfStatement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/imperative/IfStatement.java
@@ -84,6 +84,12 @@ public class IfStatement extends Statement {
         Graph trueGraph = getTrueStatement().toGraph();
         Graph falseGraph = getFalseStatement().toGraph();
 
+        // If there is nothing in the true or false sections of this if statement,
+        // we can omit the if statement altogether!
+        if (trueGraph.isEmpty() && falseGraph.isEmpty()) {
+            return new Graph();
+        }
+
         Graph.GraphCombinationResult combination = Graph.combine(trueGraph, falseGraph);
         Graph newGraph = combination.graph;
         Collection<Vertex> trueRoots = trueGraph.roots().map(combination.oldToNewVertices::get).collect(Collectors.toList());

--- a/logstash-core/src/test/java/org/logstash/EventTest.java
+++ b/logstash-core/src/test/java/org/logstash/EventTest.java
@@ -10,7 +10,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
+import org.jruby.RubyString;
 import org.jruby.RubySymbol;
 import org.jruby.RubyTime;
 import org.jruby.java.proxies.ConcreteJavaProxy;
@@ -81,6 +81,18 @@ public final class EventTest {
         assertEquals(timestamp, er.getField("time"));
         assertEquals(list, er.getField("list"));
         assertEquals(e.getTimestamp().toString(), er.getTimestamp().toString());
+    }
+
+    @Test
+    public void toBinaryRoundtripSubstring() throws Exception {
+        Event e = new Event();
+        e.setField(
+            "foo",
+            RubyString.newString(RubyUtil.RUBY, "--bar--").substr(RubyUtil.RUBY, 2, 3)
+        );
+        final RubyString before = (RubyString) e.getUnconvertedField("foo");
+        Event er = Event.deserialize(e.serialize());
+        assertEquals(before, er.getUnconvertedField("foo"));
     }
 
     /**

--- a/logstash-core/src/test/java/org/logstash/config/ir/imperative/IfStatementTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/imperative/IfStatementTest.java
@@ -37,7 +37,7 @@ public class IfStatementTest {
     @Test
     public void testIfWithOneTrueStatement() throws InvalidIRException {
         PluginDefinition pluginDef = testPluginDefinition();
-        Statement trueStatement = new PluginStatement(randMeta(), testPluginDefinition());
+        Statement trueStatement = new PluginStatement(randMeta(), pluginDef);
         Statement falseStatement = new NoopStatement(randMeta());
         BooleanExpression ifExpression = createTestExpression();
         IfStatement ifStatement = new IfStatement(
@@ -53,7 +53,7 @@ public class IfStatementTest {
         Graph expected = new Graph();
         IfVertex expectedIf = DSL.gIf(randMeta(), ifExpression);
         expected.addVertex(expectedIf);
-        PluginVertex expectedT = DSL.gPlugin(randMeta(), testPluginDefinition());
+        PluginVertex expectedT = DSL.gPlugin(randMeta(), pluginDef);
         expected.chainVertices(true, expectedIf, expectedT);
 
         assertSyntaxEquals(expected, ifStatementGraph);

--- a/logstash-core/src/test/java/org/logstash/config/ir/imperative/IfStatementTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/imperative/IfStatementTest.java
@@ -62,8 +62,10 @@ public class IfStatementTest {
 
     @Test
     public void testIfWithOneFalseStatement() throws InvalidIRException {
+        PluginDefinition pluginDef = testPluginDefinition();
         Statement trueStatement = new NoopStatement(randMeta());
-        Statement falseStatement = new PluginStatement(randMeta(), testPluginDefinition());
+        Statement falseStatement = new PluginStatement(randMeta(), pluginDef);
+        BooleanExpression ifExpression = createTestExpression();
         IfStatement ifStatement = new IfStatement(
                 randMeta(),
                 createTestExpression(),
@@ -74,27 +76,22 @@ public class IfStatementTest {
         Graph ifStatementGraph = ifStatement.toGraph();
         assertFalse(ifStatementGraph.isEmpty());
 
-        Stream<Vertex> trueVertices = ifStatementGraph
-                .edges()
-                .filter(e -> e instanceof BooleanEdge)
-                .map(e -> (BooleanEdge) e)
-                .filter(e -> e.getEdgeType() == true)
-                .map(e -> e.getTo());
-        assertEquals(0, trueVertices.count());
+        Graph expected = new Graph();
+        IfVertex expectedIf = DSL.gIf(randMeta(), ifExpression);
+        expected.addVertex(expectedIf);
 
-        Stream<Vertex> falseVertices = ifStatementGraph
-                .edges()
-                .filter(e -> e instanceof BooleanEdge)
-                .map(e -> (BooleanEdge) e)
-                .filter(e -> e.getEdgeType() == false)
-                .map(e -> e.getTo());
-        assertEquals(1, falseVertices.count());
+        PluginVertex expectedF = DSL.gPlugin(randMeta(), pluginDef);
+        expected.chainVertices(false, expectedIf, expectedF);
+
+        assertSyntaxEquals(expected, ifStatementGraph);
     }
 
     @Test
     public void testIfWithOneTrueOneFalseStatement() throws InvalidIRException {
-        Statement trueStatement = new PluginStatement(randMeta(), testPluginDefinition());
-        Statement falseStatement = new PluginStatement(randMeta(), testPluginDefinition());
+        PluginDefinition pluginDef = testPluginDefinition();
+        Statement trueStatement = new PluginStatement(randMeta(), pluginDef);
+        Statement falseStatement = new PluginStatement(randMeta(), pluginDef);
+        BooleanExpression ifExpression = createTestExpression();
         IfStatement ifStatement = new IfStatement(
                 randMeta(),
                 createTestExpression(),
@@ -105,20 +102,16 @@ public class IfStatementTest {
         Graph ifStatementGraph = ifStatement.toGraph();
         assertFalse(ifStatementGraph.isEmpty());
 
-        Stream<Vertex> trueVertices = ifStatementGraph
-                .edges()
-                .filter(e -> e instanceof BooleanEdge)
-                .map(e -> (BooleanEdge) e)
-                .filter(e -> e.getEdgeType() == true)
-                .map(e -> e.getTo());
-        assertEquals(1, trueVertices.count());
+        Graph expected = new Graph();
+        IfVertex expectedIf = DSL.gIf(randMeta(), ifExpression);
+        expected.addVertex(expectedIf);
 
-        Stream<Vertex> falseVertices = ifStatementGraph
-                .edges()
-                .filter(e -> e instanceof BooleanEdge)
-                .map(e -> (BooleanEdge) e)
-                .filter(e -> e.getEdgeType() == false)
-                .map(e -> e.getTo());
-        assertEquals(1, falseVertices.count());
+        PluginVertex expectedT = DSL.gPlugin(randMeta(), pluginDef);
+        expected.chainVertices(true, expectedIf, expectedT);
+
+        PluginVertex expectedF = DSL.gPlugin(randMeta(), pluginDef);
+        expected.chainVertices(false, expectedIf, expectedF);
+
+        assertSyntaxEquals(expected, ifStatementGraph);
     }
 }

--- a/logstash-core/src/test/java/org/logstash/config/ir/imperative/IfStatementTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/imperative/IfStatementTest.java
@@ -1,25 +1,127 @@
 package org.logstash.config.ir.imperative;
 
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import java.util.stream.Stream;
 
 import org.logstash.config.ir.InvalidIRException;
+import org.logstash.config.ir.graph.BooleanEdge;
 import org.logstash.config.ir.graph.Graph;
+import org.logstash.config.ir.graph.Vertex;
 
 import static org.logstash.config.ir.IRHelpers.*;
 
 public class IfStatementTest {
 
     @Test
-    public void testEmptyIfStatement() throws InvalidIRException {
+    public void testEmptyIf() throws InvalidIRException {
+        Statement trueStatement = new NoopStatement(randMeta());
+        Statement falseStatement = new NoopStatement(randMeta());
         IfStatement ifStatement = new IfStatement(
-            randMeta(),
-            createTestExpression(),
-            new NoopStatement(randMeta()),
-            new NoopStatement(randMeta())
+                randMeta(),
+                createTestExpression(),
+                trueStatement,
+                falseStatement
         );
 
         Graph ifStatementGraph = ifStatement.toGraph();
         assertTrue(ifStatementGraph.isEmpty());
+    }
+
+    @Test
+    public void testIfWithOneTrueStatement() throws InvalidIRException {
+        Statement trueStatement = new PluginStatement(randMeta(), testPluginDefinition());
+        Statement falseStatement = new NoopStatement(randMeta());
+        IfStatement ifStatement = new IfStatement(
+                randMeta(),
+                createTestExpression(),
+                trueStatement,
+                falseStatement
+        );
+
+        Graph ifStatementGraph = ifStatement.toGraph();
+        assertFalse(ifStatementGraph.isEmpty());
+
+        Stream<Vertex> trueVertices = ifStatementGraph
+                .edges()
+                .filter(e -> e instanceof BooleanEdge)
+                .map(e -> (BooleanEdge) e)
+                .filter(e -> e.getEdgeType() == true)
+                .map(e -> e.getTo());
+        assertEquals(1, trueVertices.count());
+
+        Stream<Vertex> falseVertices = ifStatementGraph
+                .edges()
+                .filter(e -> e instanceof BooleanEdge)
+                .map(e -> (BooleanEdge) e)
+                .filter(e -> e.getEdgeType() == false)
+                .map(e -> e.getTo());
+        assertEquals(0, falseVertices.count());
+    }
+
+
+    @Test
+    public void testIfWithOneFalseStatement() throws InvalidIRException {
+        Statement trueStatement = new NoopStatement(randMeta());
+        Statement falseStatement = new PluginStatement(randMeta(), testPluginDefinition());
+        IfStatement ifStatement = new IfStatement(
+                randMeta(),
+                createTestExpression(),
+                trueStatement,
+                falseStatement
+        );
+
+        Graph ifStatementGraph = ifStatement.toGraph();
+        assertFalse(ifStatementGraph.isEmpty());
+
+        Stream<Vertex> trueVertices = ifStatementGraph
+                .edges()
+                .filter(e -> e instanceof BooleanEdge)
+                .map(e -> (BooleanEdge) e)
+                .filter(e -> e.getEdgeType() == true)
+                .map(e -> e.getTo());
+        assertEquals(0, trueVertices.count());
+
+        Stream<Vertex> falseVertices = ifStatementGraph
+                .edges()
+                .filter(e -> e instanceof BooleanEdge)
+                .map(e -> (BooleanEdge) e)
+                .filter(e -> e.getEdgeType() == false)
+                .map(e -> e.getTo());
+        assertEquals(1, falseVertices.count());
+    }
+
+    @Test
+    public void testIfWithOneTrueOneFalseStatement() throws InvalidIRException {
+        Statement trueStatement = new PluginStatement(randMeta(), testPluginDefinition());
+        Statement falseStatement = new PluginStatement(randMeta(), testPluginDefinition());
+        IfStatement ifStatement = new IfStatement(
+                randMeta(),
+                createTestExpression(),
+                trueStatement,
+                falseStatement
+        );
+
+        Graph ifStatementGraph = ifStatement.toGraph();
+        assertFalse(ifStatementGraph.isEmpty());
+
+        Stream<Vertex> trueVertices = ifStatementGraph
+                .edges()
+                .filter(e -> e instanceof BooleanEdge)
+                .map(e -> (BooleanEdge) e)
+                .filter(e -> e.getEdgeType() == true)
+                .map(e -> e.getTo());
+        assertEquals(1, trueVertices.count());
+
+        Stream<Vertex> falseVertices = ifStatementGraph
+                .edges()
+                .filter(e -> e instanceof BooleanEdge)
+                .map(e -> (BooleanEdge) e)
+                .filter(e -> e.getEdgeType() == false)
+                .map(e -> e.getTo());
+        assertEquals(1, falseVertices.count());
     }
 }

--- a/logstash-core/src/test/java/org/logstash/config/ir/imperative/IfStatementTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/imperative/IfStatementTest.java
@@ -1,0 +1,25 @@
+package org.logstash.config.ir.imperative;
+
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+
+import org.logstash.config.ir.InvalidIRException;
+import org.logstash.config.ir.graph.Graph;
+
+import static org.logstash.config.ir.IRHelpers.*;
+
+public class IfStatementTest {
+
+    @Test
+    public void testEmptyIfStatement() throws InvalidIRException {
+        IfStatement ifStatement = new IfStatement(
+            randMeta(),
+            createTestExpression(),
+            new NoopStatement(randMeta()),
+            new NoopStatement(randMeta())
+        );
+
+        Graph ifStatementGraph = ifStatement.toGraph();
+        assertTrue(ifStatementGraph.isEmpty());
+    }
+}


### PR DESCRIPTION
Resolves #9301.

If an if statement has no true or false sub-statements, there is no point including the if statement in the LIR graph. So instead of constructing a sub-graph for the if statement — which would include an empty if vertex and nothing else — and returning it, we return an empty graph object.