### PR TITLE
CLEANUP+PERFORMANCE: Further Compiler Movement to Java Plugin Compat

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
@@ -241,10 +241,10 @@ public final class CompiledPipeline {
                 .allLeaves().filter(CompiledPipeline.this::isOutput)
                 .collect(Collectors.toList());
             if (outputNodes.isEmpty()) {
-                return DatasetCompiler.ROOT_DATASETS.iterator().next();
+                return Dataset.IDENTITY;
             } else {
                 return DatasetCompiler.terminalDataset(outputNodes.stream().map(
-                    leaf -> outputDataset(leaf, flatten(DatasetCompiler.ROOT_DATASETS, leaf))
+                    leaf -> outputDataset(leaf, flatten(Collections.emptyList(), leaf))
                 ).collect(Collectors.toList()));
             }
         }

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/Dataset.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/Dataset.java
@@ -19,6 +19,20 @@ import org.logstash.ext.JrubyEventExtLibrary;
 public interface Dataset {
 
     /**
+     * Dataset that does not modify the input events.
+     */
+    Dataset IDENTITY = new Dataset() {
+        @Override
+        public Collection<JrubyEventExtLibrary.RubyEvent> compute(final RubyArray batch, final boolean flush, final boolean shutdown) {
+            return batch;
+        }
+
+        @Override
+        public void clear() {
+        }
+    };
+
+    /**
      * Compute the actual contents of the backing {@link RubyArray} and cache them.
      * Repeated invocations will be effectively free.
      * @param batch Input {@link JrubyEventExtLibrary.RubyEvent} received at the root

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/DatasetCompiler.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/DatasetCompiler.java
@@ -31,18 +31,6 @@ public final class DatasetCompiler {
     public static final SyntaxFactory.IdentifierStatement BATCH_ARG =
         SyntaxFactory.identifier("batchArg");
 
-    /**
-     * Root {@link Dataset}s at the beginning of the execution tree that simply pass through
-     * the given set of {@link JrubyEventExtLibrary.RubyEvent} and have no state.
-     */
-    public static final Collection<Dataset> ROOT_DATASETS = Collections.singleton(
-        prepare(
-            computeAndClear(
-                Closure.wrap(SyntaxFactory.ret(BATCH_ARG)), Closure.EMPTY, new ClassFields()
-            )
-        ).instantiate()
-    );
-
     private DatasetCompiler() {
         // Utility Class
     }
@@ -50,15 +38,11 @@ public final class DatasetCompiler {
     public static ComputeStepSyntaxElement<SplitDataset> splitDataset(final Collection<Dataset> parents,
         final EventCondition condition) {
         final ClassFields fields = new ClassFields();
-        final Collection<ValueSyntaxElement> parentFields =
-            parents.stream().map(fields::add).collect(Collectors.toList());
         final ValueSyntaxElement ifData = fields.add(new ArrayList<>());
         final ValueSyntaxElement elseData = fields.add(new ArrayList<>());
-        final ValueSyntaxElement buffer = fields.add(new ArrayList<>());
         final ValueSyntaxElement right = fields.add(DatasetCompiler.Complement.class);
         final VariableDefinition event =
             new VariableDefinition(JrubyEventExtLibrary.RubyEvent.class, "event");
-        final ValueSyntaxElement eventVal = event.access();
         fields.addAfterInit(
             Closure.wrap(
                 SyntaxFactory.assignment(
@@ -71,23 +55,25 @@ public final class DatasetCompiler {
                 )
             )
         );
-        final DatasetCompiler.ComputeAndClear compute = withOutputBuffering(
-            withInputBuffering(
-                Closure.wrap(
-                    SyntaxFactory.forLoop(
-                        event, buffer,
-                        Closure.wrap(
-                            SyntaxFactory.ifCondition(
-                                fields.add(condition).call("fulfilled", eventVal),
-                                Closure.wrap(ifData.call("add", eventVal)),
-                                Closure.wrap(elseData.call("add", eventVal))
-                            )
-                        )
-                    )
-                ), parentFields, buffer
-            ),
-            clearSyntax(parentFields).add(clear(elseData)), ifData, fields
-        );
+        final ValueSyntaxElement conditionField = fields.add(condition);
+        final DatasetCompiler.ComputeAndClear compute;
+        if (parents.isEmpty()) {
+            compute = withOutputBuffering(
+                conditionalLoop(event, BATCH_ARG, conditionField, ifData, elseData),
+                Closure.wrap(clear(elseData)), ifData, fields
+            );
+        } else {
+            final Collection<ValueSyntaxElement> parentFields =
+                parents.stream().map(fields::add).collect(Collectors.toList());
+            final ValueSyntaxElement inputBuffer = fields.add(new ArrayList<>());
+            compute = withOutputBuffering(
+                withInputBuffering(
+                    conditionalLoop(event, inputBuffer, conditionField, ifData, elseData),
+                    parentFields, inputBuffer
+                ),
+                clearSyntax(parentFields).add(clear(elseData)), ifData, fields
+            );
+        }
         return ComputeStepSyntaxElement.create(
             Arrays.asList(compute.compute(), compute.clear(), MethodSyntaxElement.right(right)),
             compute.fields(), SplitDataset.class
@@ -103,39 +89,31 @@ public final class DatasetCompiler {
     public static ComputeStepSyntaxElement<Dataset> filterDataset(final Collection<Dataset> parents,
         final RubyIntegration.Filter plugin) {
         final ClassFields fields = new ClassFields();
-        final Collection<ValueSyntaxElement> parentFields =
-            parents.stream().map(fields::add).collect(Collectors.toList());
-        final RubyArray inputBuffer = RubyUtil.RUBY.newArray();
         final ValueSyntaxElement outputBuffer = fields.add(new ArrayList<>());
-        final IRubyObject filter = plugin.toRuby();
-        final ValueSyntaxElement filterField = fields.add(filter);
-        final String multiFilter = "multi_filter";
-        final Closure body = Closure.wrap(
-            buffer(
-                outputBuffer,
-                SyntaxFactory.cast(
-                    RubyArray.class,
-                    callRubyCallsite(
-                        fields.add(rubyCallsite(filter, multiFilter)),
-                        fields.add(new IRubyObject[]{inputBuffer}), filterField, multiFilter
+        final Closure clear = Closure.wrap();
+        final Closure compute;
+        if (parents.isEmpty()) {
+            final ValueSyntaxElement inputBufferHolder = fields.add(new IRubyObject[1]);
+            compute = filterBody(
+                Closure.wrap(
+                    SyntaxFactory.assignment(
+                        SyntaxFactory.arrayField(inputBufferHolder, 0), BATCH_ARG
                     )
-                )
-            )
-        );
-        if (plugin.hasFlush()) {
-            body.add(
-                callFilterFlush(
-                    fields, outputBuffer, fields.add(rubyCallsite(filter, FLUSH)), filterField,
-                    !plugin.periodicFlush()
-                )
+                ), outputBuffer, inputBufferHolder, fields, plugin
+            );
+        } else {
+            final Collection<ValueSyntaxElement> parentFields =
+                parents.stream().map(fields::add).collect(Collectors.toList());
+            final RubyArray inputBuffer = RubyUtil.RUBY.newArray();
+            clear.add(clearSyntax(parentFields));
+            compute = withInputBuffering(
+                filterBody(
+                    Closure.wrap(), outputBuffer, fields.add(new IRubyObject[]{inputBuffer}),
+                    fields, plugin
+                ), parentFields, fields.add(inputBuffer)
             );
         }
-        return prepare(
-            withOutputBuffering(
-                withInputBuffering(body, parentFields, fields.add(inputBuffer)),
-                clearSyntax(parentFields), outputBuffer, fields
-            )
-        );
+        return prepare(withOutputBuffering(compute, clear, outputBuffer, fields));
     }
 
     /**
@@ -189,36 +167,86 @@ public final class DatasetCompiler {
      * @return Output Dataset
      */
     public static ComputeStepSyntaxElement<Dataset> outputDataset(final Collection<Dataset> parents,
-        final IRubyObject output,
-        final boolean terminal) {
+        final IRubyObject output, final boolean terminal) {
         final DynamicMethod method = rubyCallsite(output, MULTI_RECEIVE);
-        // Short-circuit trivial case of only output(s) in the pipeline
-        if (parents == ROOT_DATASETS) {
-            return outputDatasetFromRoot(output, method);
-        }
         final ClassFields fields = new ClassFields();
-        final Collection<ValueSyntaxElement> parentFields =
-            parents.stream().map(fields::add).collect(Collectors.toList());
-        final RubyArray buffer = RubyUtil.RUBY.newArray();
         final Closure clearSyntax;
-        final Closure inlineClear;
-        if (terminal) {
+        final Closure computeSyntax;
+        if (parents.isEmpty()) {
+            final ValueSyntaxElement args = fields.add(new IRubyObject[1]);
             clearSyntax = Closure.EMPTY;
-            inlineClear = clearSyntax(parentFields);
+            computeSyntax = Closure.wrap(
+                SyntaxFactory.assignment(SyntaxFactory.arrayField(args, 0), BATCH_ARG),
+                callRubyCallsite(fields.add(method), args, fields.add(output), MULTI_RECEIVE)
+            );
         } else {
-            inlineClear = Closure.EMPTY;
-            clearSyntax = clearSyntax(parentFields);
-        }
-        return compileOutput(
-            withInputBuffering(
+            final Collection<ValueSyntaxElement> parentFields =
+                parents.stream().map(fields::add).collect(Collectors.toList());
+            final RubyArray buffer = RubyUtil.RUBY.newArray();
+            final Closure inlineClear;
+            if (terminal) {
+                clearSyntax = Closure.EMPTY;
+                inlineClear = clearSyntax(parentFields);
+            } else {
+                inlineClear = Closure.EMPTY;
+                clearSyntax = clearSyntax(parentFields);
+            }
+            computeSyntax = withInputBuffering(
                 Closure.wrap(
                     callRubyCallsite(
                         fields.add(method), fields.add(new IRubyObject[]{buffer}),
                         fields.add(output), MULTI_RECEIVE
                     ), inlineClear
                 ), parentFields, fields.add(buffer)
-            ),
-            clearSyntax, fields
+            );
+        }
+        return compileOutput(computeSyntax, clearSyntax, fields);
+    }
+
+    private static Closure filterBody(final Closure body, final ValueSyntaxElement outputBuffer,
+        final ValueSyntaxElement inputBufferHolder, final ClassFields fields,
+        final RubyIntegration.Filter plugin) {
+        final String multiFilter = "multi_filter";
+        final IRubyObject filter = plugin.toRuby();
+        final ValueSyntaxElement filterField = fields.add(filter);
+        body.add(
+            buffer(
+                outputBuffer,
+                SyntaxFactory.cast(
+                    RubyArray.class,
+                    callRubyCallsite(
+                        fields.add(rubyCallsite(filter, multiFilter)), inputBufferHolder
+                        , filterField, multiFilter
+                    )
+                )
+            )
+        );
+        if (plugin.hasFlush()) {
+            body.add(
+                callFilterFlush(
+                    fields, outputBuffer, fields.add(rubyCallsite(filter, FLUSH)), filterField,
+                    !plugin.periodicFlush()
+                )
+            );
+        }
+        return body;
+    }
+
+    private static Closure conditionalLoop(final VariableDefinition event,
+        final MethodLevelSyntaxElement inputBuffer, final ValueSyntaxElement condition,
+        final ValueSyntaxElement ifData, final ValueSyntaxElement elseData) {
+        final ValueSyntaxElement eventVal = event.access();
+        return Closure.wrap(
+            SyntaxFactory.forLoop(
+                event, inputBuffer,
+                Closure.wrap(
+                    SyntaxFactory.ifCondition(
+                        condition.call("fulfilled", eventVal),
+                        Closure.wrap(ifData.call("add", eventVal)),
+                        Closure.wrap(elseData.call("add", eventVal))
+                    )
+                )
+            )
         );
     }
 
@@ -338,28 +366,6 @@ public final class DatasetCompiler {
         final RubyHash res = RubyHash.newHash(RubyUtil.RUBY);
         res.put(RubyUtil.RUBY.newSymbol("final"), RubyUtil.RUBY.newBoolean(fin));
         return new IRubyObject[]{res};
-    }
-
-    /**
-     * Special case optimization for when the output plugin is directly connected to the Queue
-     * without any filters or conditionals in between. This special case does not arise naturally
-     * from {@link DatasetCompiler#outputDataset(Collection, IRubyObject, boolean)} since it saves
-     * the internal buffering of events and instead forwards events directly from the batch to the
-     * Output plugin.
-     * @param output Output Plugin
-     * @return Dataset representing the Output
-     */
-    private static ComputeStepSyntaxElement<Dataset> outputDatasetFromRoot(final IRubyObject output,
-        final DynamicMethod method) {
-        final ClassFields fields = new ClassFields();
-        final ValueSyntaxElement args = fields.add(new IRubyObject[1]);
-        return compileOutput(
-            Closure.wrap(
-                SyntaxFactory.assignment(SyntaxFactory.arrayField(args, 0), BATCH_ARG),
-                callRubyCallsite(fields.add(method), args, fields.add(output), MULTI_RECEIVE)
-            ),
-            Closure.EMPTY, fields
-        );
     }
 
     private static ComputeStepSyntaxElement<Dataset> compileOutput(final Closure syntax,

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
@@ -14,17 +14,10 @@ public final class RubyIntegration {
     }
 
     /**
-     * A Ruby Plugin.
-     */
-    public interface Plugin {
-        void register();
-    }
-
-    /**
      * A Ruby Filter. Currently, this interface is implemented only by the Ruby class
      * {@code FilterDelegator}.
      */
-    public interface Filter extends RubyIntegration.Plugin {
+    public interface Filter {
 
         /**
          * Returns the underlying {@link IRubyObject} for this filter instance.

--- a/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
@@ -246,9 +246,6 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
             return false;
         }
 
-        @Override
-        public void register() {
-        }
     }
 
     /**
@@ -279,8 +276,5 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
             return false;
         }
 
-        @Override
-        public void register() {
-        }
     }
 }

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/DatasetCompilerTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/DatasetCompilerTest.java
@@ -1,5 +1,6 @@
 package org.logstash.config.ir.compiler;
 
+import java.util.Collections;
 import org.jruby.RubyArray;
 import org.jruby.runtime.ThreadContext;
 import org.junit.Test;
@@ -21,7 +22,7 @@ public final class DatasetCompilerTest {
     public void compilesOutputDataset() {
         assertThat(
             DatasetCompiler.outputDataset(
-                DatasetCompiler.ROOT_DATASETS,
+                Collections.emptyList(),
                 RubyUtil.RUBY.evalScriptlet(
                     "output = Object.new\noutput.define_singleton_method(:multi_receive) do |batch|\nend\noutput"
                 ),
@@ -35,7 +36,7 @@ public final class DatasetCompilerTest {
     public void compilesSplitDataset() {
         final FieldReference key = FieldReference.from("foo");
         final SplitDataset left = DatasetCompiler.splitDataset(
-            DatasetCompiler.ROOT_DATASETS, event -> event.getEvent().includes(key)
+            Collections.emptyList(), event -> event.getEvent().includes(key)
         ).instantiate();
         final Event trueEvent = new Event();
         trueEvent.setField(key, "val");


### PR DESCRIPTION
* Remove unused `Plugin#register` method
* Adjust compilation of the first node from the queue to not buffer input, remove now simplified away `ROOT_DATASET` approach
   * This comes with a certain speedup since we save one Collection copy + the redundant initial `ROOT_DATASETS` step:)

long story short:

instead of 2 datasets for the first filter in a pipeline where we compiled:

```java
package org.logstash.generated;

public final class CompiledDataset0 implements org.logstash.config.ir.compiler.Dataset {
  public CompiledDataset0() {}

  public java.util.Collection compute(
      org.jruby.RubyArray batchArg, boolean flushArg, boolean shutdownArg) {
    return batchArg;
  }

  public void clear() {}
}
```

and then:

```java
package org.logstash.generated;

public final class CompiledDataset1 implements org.logstash.config.ir.compiler.Dataset {
  private boolean field6;
  private final org.logstash.generated.CompiledDataset0 field0;
  private final java.util.ArrayList field1;
  private final org.jruby.runtime.builtin.IRubyObject field2;
  private final org.jruby.internal.runtime.methods.MixedModeIRMethod field3;
  private final org.jruby.runtime.builtin.IRubyObject[] field4;
  private final org.jruby.RubyArray field5;

  public CompiledDataset1(
      org.logstash.generated.CompiledDataset0 field0argument,
      java.util.ArrayList field1argument,
      org.jruby.runtime.builtin.IRubyObject field2argument,
      org.jruby.internal.runtime.methods.MixedModeIRMethod field3argument,
      org.jruby.runtime.builtin.IRubyObject[] field4argument,
      org.jruby.RubyArray field5argument) {
    field0 = field0argument;
    field1 = field1argument;
    field2 = field2argument;
    field3 = field3argument;
    field4 = field4argument;
    field5 = field5argument;
  }

  public java.util.Collection compute(
      org.jruby.RubyArray batchArg, boolean flushArg, boolean shutdownArg) {
    if (field6) {
      return field1;
    }
    for (org.logstash.ext.JrubyEventExtLibrary$RubyEvent e :
        field0.compute(batchArg, flushArg, shutdownArg)) {
      if (!(e.getEvent().isCancelled())) {
        field5.add(e);
      }
    }
    field1.addAll(
        ((org.jruby.RubyArray)
            field3.call(
                org.logstash.RubyUtil.RUBY.getCurrentContext(),
                field2,
                org.logstash.RubyUtil.LOGSTASH_MODULE,
                "multi_filter",
                field4,
                org.jruby.runtime.Block.NULL_BLOCK)));
    field5.clear();
    field6 = true;
    return field1;
  }

  public void clear() {
    if (field6) {
      field0.clear();
      field1.clear();
      field6 = false;
    }
  }
}
```

we now compile both into one:

```java
package org.logstash.generated;

public final class CompiledDataset0 implements org.logstash.config.ir.compiler.Dataset {
  private boolean field4;
  private final java.util.ArrayList field0;
  private final org.jruby.runtime.builtin.IRubyObject[] field1;
  private final org.jruby.runtime.builtin.IRubyObject field2;
  private final org.jruby.internal.runtime.methods.MixedModeIRMethod field3;

  public CompiledDataset0(
      java.util.ArrayList field0argument,
      org.jruby.runtime.builtin.IRubyObject[] field1argument,
      org.jruby.runtime.builtin.IRubyObject field2argument,
      org.jruby.internal.runtime.methods.MixedModeIRMethod field3argument) {
    field0 = field0argument;
    field1 = field1argument;
    field2 = field2argument;
    field3 = field3argument;
  }

  public java.util.Collection compute(
      org.jruby.RubyArray batchArg, boolean flushArg, boolean shutdownArg) {
    if (field4) {
      return field0;
    }
    field1[0] = batchArg;
    field0.addAll(
        ((org.jruby.RubyArray)
            field3.call(
                org.logstash.RubyUtil.RUBY.getCurrentContext(),
                field2,
                org.logstash.RubyUtil.LOGSTASH_MODULE,
                "multi_filter",
                field1,
                org.jruby.runtime.Block.NULL_BLOCK)));
    field4 = true;
    return field0;
  }

  public void clear() {
    if (field4) {
      field0.clear();
      field4 = false;
    }
  }
}
```

... and save one step of needless buffering :)