### PR TITLE
wip: initial implementation of plugin search

### DIFF
--- a/lib/pluginmanager/main.rb
+++ b/lib/pluginmanager/main.rb
@@ -17,6 +17,7 @@ require "pluginmanager/gemfile"
 require "pluginmanager/install"
 require "pluginmanager/remove"
 require "pluginmanager/list"
+require "pluginmanager/search"
 require "pluginmanager/update"
 require "pluginmanager/pack"
 require "pluginmanager/unpack"
@@ -30,6 +31,7 @@ module LogStash
     class Error < StandardError; end
 
     class Main < Clamp::Command
+      subcommand "search", "Search Rubygems.org for plugins", LogStash::PluginManager::Search
       subcommand "list", "List all installed Logstash plugins", LogStash::PluginManager::List
       subcommand "install", "Install a Logstash plugin", LogStash::PluginManager::Install
       subcommand "remove", "Remove a Logstash plugin", LogStash::PluginManager::Remove

--- a/lib/pluginmanager/search.rb
+++ b/lib/pluginmanager/search.rb
@@ -1,0 +1,28 @@
+# encoding: utf-8
+require 'rubygems/spec_fetcher'
+require "pluginmanager/command"
+
+class LogStash::PluginManager::Search < LogStash::PluginManager::Command
+
+  parameter "[REGEX]", "regular expression to use"
+
+  option "--author", "NAME", "Show only plugins authored by this name"
+
+  def execute
+    LogStash::Bundler.setup!({:without => [:build, :development]})
+    fetcher = Gem::SpecFetcher.fetcher
+    regex_obj = Regexp.new(regex)
+    results = fetcher.detect(:latest) {|name_tuple| name_tuple.name.match(regex_obj) }
+    results.map {|name_tuple, source| source.fetch_spec(name_tuple) }.each do |spec|
+      next unless spec.metadata["logstash_plugin"] == "true"
+      if author
+        next unless spec.authors.include?(author)
+      end
+      puts "#{spec.name} - #{spec.version}"
+      puts "  Date: #{spec.date}"
+      puts "  Author: #{spec.authors.join(', ')}"
+      puts "  Homepage: #{spec.homepage}"
+      puts "  Description: #{spec.summary}"
+    end
+  end
+end


### PR DESCRIPTION
Searches rubygems for plugins. This is equivalent to `gem search --details regex` + some validation:

```
% bin/logstash-plugin search "logstash-.*-.*kinesis.*"
logstash-input-kinesis - 2.0.7
  Date: 2017-11-14 00:00:00 UTC
  Author: Brian Palmer
  Homepage: https://github.com/logstash-plugins/logstash-input-kinesis
  Description: Receives events through an AWS Kinesis stream
logstash-input-kinesis-cloudwatch-log-subscription - 1.3.6
  Date: 2015-07-14 00:00:00 UTC
  Author: Laurence MacGuire
  Homepage: https://github.com/leprechaun/logstash-input-kinesis-cloudwatch-log-subscription
  Description: Logstash plugin for Kinesis input from cloudwatch log subscriptions
logstash-output-kinesis - 5.1.1
  Date: 2018-01-26 00:00:00 UTC
  Author: Sam Day
  Homepage: https://www.github.com/samcday/logstash-output-kinesis
  Description: This output plugin sends records to Kinesis using the Kinesis Producer Library (KPL)
logstash-output-kinesis-leprechaun-fork - 0.1.4
  Date: 2016-04-28 00:00:00 UTC
  Author: Elasticsearch, Laurence MacGuire
  Homepage: https://github.com/leprechaun/logstash-output-kinesis
  Description: Push events to an Amazon Web Services Kinesis stream.

% bin/logstash-plugin search --author="Sam Day" "logstash-.*-.*kinesis.*"      
logstash-output-kinesis - 5.1.1
  Date: 2018-01-26 00:00:00 UTC
  Author: Sam Day
  Homepage: https://www.github.com/samcday/logstash-output-kinesis
  Description: This output plugin sends records to Kinesis using the Kinesis Producer Library (KPL)
```