### PR TITLE
 #9191 PQ must allow reading empty batches

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -539,7 +539,7 @@ public final class Queue implements Closeable {
         // NOTE: the tricky thing here is that upon entering this method, if p is initially a head page
         // it could become a tail page upon returning from the notEmpty.await call.
 
-        do {
+        while (left > 0) {
             if (isHeadPage(p) && p.isFullyRead()) {
                 boolean elapsed;
                 // a head page is fully read but can be written to so let's wait for more data
@@ -576,13 +576,13 @@ public final class Queue implements Closeable {
             if (isTailPage(p) && p.isFullyRead()) {
                 break;
             }
-        } while (left > 0);
+        }
 
         if (isTailPage(p) && p.isFullyRead()) {
             removeUnreadPage(p);
         }
 
-        return (left >= limit) ? null :  new Batch(elements, seqNums, this);
+        return new Batch(elements, seqNums, this);
     }
 
     private static class TailPageResult {
@@ -644,6 +644,9 @@ public final class Queue implements Closeable {
      * @throws IOException
      */
     public void ack(LongVector seqNums) throws IOException {
+        if (seqNums.size() == 0) {
+            return;
+        }
         // as a first implementation we assume that all batches are created from the same page
         // so we will avoid multi pages acking here for now
 

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
@@ -107,6 +107,18 @@ public class QueueTest {
         }
     }
 
+    @Test
+    public void canReadBatchZeroSize() throws IOException {
+        final int page = MmapPageIO.MIN_CAPACITY;
+        try (Queue q = new Queue(
+            TestSettings.persistedQueueSettings(page, page * 2 - 1, dataPath))) {
+            q.open();
+            try (Batch b = q.readBatch(0, 500L)) {
+                assertThat(b.getElements().size(), is(0));
+            }
+        }
+    }
+
     /**
      * This test ensures that the {@link Queue} functions properly when pagesize is equal to overall
      * queue size (i.e. there is only a single page).


### PR DESCRIPTION
This actually resolves a pretty serious bug resulting from the Javafication that also randomly shows up as test failures in #9191.

The problem is that the PQ did return `null` instead of empty batches.
This caused this code in the `WorkerLoop` to trigger a failing assertion:

```java
            final QueueBatch batch = readClient.newBatch(); // goes for a zero sized batch
```

```
20:18:05     Exception in thread "Ruby-0-Thread-129@[main]>worker4: /var/lib/jenkins/workspace/elastic+logstash+master+multijob-unix-compatibility/os/amazon/logstash-core/lib/logstash/java_pipeline.rb:371" java.lang.IllegalStateException: java.lang.ArrayIndexOutOfBoundsException: 0
20:18:05     	at org.logstash.execution.WorkerLoop.run(org/logstash/execution/WorkerLoop.java:75)
20:18:05     	at java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)
20:18:05     	at org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:438)
20:18:05     	at org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:302)
20:18:05     	at var.lib.jenkins.workspace.elastic_plus_logstash_plus_master_plus_multijob_minus_unix_minus_compatibility.os.amazon.logstash_minus_core.lib.logstash.java_pipeline.invokeOther13:run(var/lib/jenkins/workspace/elastic_plus_logstash_plus_master_plus_multijob_minus_unix_minus_compatibility/os/amazon/logstash_minus_core/lib/logstash//var/lib/jenkins/workspace/elastic+logstash+master+multijob-unix-compatibility/os/amazon/logstash-core/lib/logstash/java_pipeline.rb:373)
20:18:05     	at var.lib.jenkins.workspace.elastic_plus_logstash_plus_master_plus_multijob_minus_unix_minus_compatibility.os.amazon.logstash_minus_core.lib.logstash.java_pipeline.block in start_workers(/var/lib/jenkins/workspace/elastic+logstash+master+multijob-unix-compatibility/os/amazon/logstash-core/lib/logstash/java_pipeline.rb:373)
20:18:05     	at org.jruby.RubyProc.call(org/jruby/RubyProc.java:289)
20:18:05     	at org.jruby.RubyProc.call(org/jruby/RubyProc.java:246)
20:18:05     	at java.lang.Thread.run(java/lang/Thread.java:748)
20:18:05     Caused by: java.lang.ArrayIndexOutOfBoundsException: 0
20:18:05     	at org.logstash.ackedqueue.io.LongVector.get(LongVector.java:49)
20:18:05     	at org.logstash.ackedqueue.Page.read(Page.java:56)
20:18:05     	at org.logstash.ackedqueue.Queue._readPageBatch(Queue.java:562)
20:18:05     	at org.logstash.ackedqueue.Queue.readBatch(Queue.java:519)
20:18:05     	at org.logstash.ackedqueue.ext.JRubyAckedQueueExt.readBatch(JRubyAckedQueueExt.java:153)
20:18:05     	at org.logstash.ackedqueue.AckedReadBatch.<init>(AckedReadBatch.java:34)
20:18:05     	at org.logstash.ackedqueue.AckedReadBatch.create(AckedReadBatch.java:27)
20:18:05     	at org.logstash.ext.JrubyAckedReadClientExt.newBatch(JrubyAckedReadClientExt.java:58)
20:18:05     	at org.logstash.execution.WorkerLoop.run(WorkerLoop.java:66)
20:18:05     	at sun.reflect.GeneratedMethodAccessor28.invoke(Unknown Source)
20:18:05     	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43
```

=> PQ never shuts down cleanly because of an assert: =>  you don't see this in test runs because our logging is light in default Gradle runs => tests that check metric counts that rely on flush randomly fail if they run through too quickly so that no periodic flush is triggered since they don't hit the periodic flush.

* Fixed by allowing for zero sized batches.
  * Don't even read from disk when using limit `0` (`do` -> `while`)
  * Break out of `ack` early (otherwise the same kind of assert in `Queue.java` dies from out of bounds)
  * Added test that makes sure `0` batches are actually read