### PR TITLE
MINOR: Remove ununsed queue methods

### DIFF
--- a/logstash-core/spec/logstash/acked_queue_concurrent_stress_spec.rb
+++ b/logstash-core/spec/logstash/acked_queue_concurrent_stress_spec.rb
@@ -111,7 +111,7 @@ describe LogStash::WrappedAckedQueue, :stress_test => true do
           output_strings << e.message
         end
 
-        queue.queue.close
+        queue.close
 
         if output_strings.any?
           output_strings << __memoized.reject{|k,v| reject_memo_keys.include?(k)}.inspect

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyAckedQueueExt.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyAckedQueueExt.java
@@ -168,16 +168,6 @@ public final class JRubyAckedQueueExt extends RubyObject {
         return queue.isEmpty();
     }
 
-    @JRubyMethod(name = "close")
-    public IRubyObject ruby_close(ThreadContext context) {
-        try {
-            close();
-        } catch (IOException e) {
-            throw RubyUtil.newRubyIOError(context.runtime, e);
-        }
-        return context.nil;
-    }
-
     public void close() throws IOException {
         queue.close();
     }

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyAckedReadClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyAckedReadClientExt.java
@@ -9,7 +9,6 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.RubyUtil;
 import org.logstash.ackedqueue.AckedReadBatch;
 import org.logstash.ackedqueue.ext.JRubyAckedQueueExt;
-import org.logstash.ackedqueue.ext.JRubyWrappedAckedQueueExt;
 import org.logstash.execution.QueueBatch;
 import org.logstash.execution.QueueReadClient;
 import org.logstash.execution.QueueReadClientBase;


### PR DESCRIPTION
ping @danhermann, just dropping a bunch of Ruby methods that aren't' used anymore due to new Java wrappers you and I added.
Tests still pass and this stuff isn't exposed externally -> this should be safe :)