### PR TITLE
MINOR: Cleanup dead code in PQ, fix unsafe resource handling in PQ pages

### DIFF
--- a/logstash-core/spec/logstash/acked_queue_concurrent_stress_spec.rb
+++ b/logstash-core/spec/logstash/acked_queue_concurrent_stress_spec.rb
@@ -105,12 +105,6 @@ describe LogStash::WrappedAckedQueue, :stress_test => true do
           output_strings.concat files
         end
 
-        begin
-          queue.queue.open
-        rescue Exception => e
-          output_strings << e.message
-        end
-
         queue.close
 
         if output_strings.any?

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/AckedBatch.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/AckedBatch.java
@@ -7,7 +7,6 @@ import org.logstash.Event;
 import org.logstash.ext.JrubyEventExtLibrary;
 
 public final class AckedBatch {
-    private static final long serialVersionUID = -3118949118637372130L;
     private Batch batch;
 
     public static AckedBatch create(Batch batch) {

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Batch.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Batch.java
@@ -27,6 +27,7 @@ public class Batch implements Closeable {
     }
 
     // close acks the batch ackable events
+    @Override
     public void close() throws IOException {
         if (closed.getAndSet(true) == false) {
               this.queue.ack(this.seqNums);

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyWrappedAckedQueueExt.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyWrappedAckedQueueExt.java
@@ -3,6 +3,7 @@ package org.logstash.ackedqueue.ext;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.jruby.Ruby;
+import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyObject;
@@ -14,6 +15,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.RubyUtil;
 import org.logstash.ext.JrubyAckedReadClientExt;
 import org.logstash.ext.JrubyAckedWriteClientExt;
+import org.logstash.ext.JrubyEventExtLibrary;
 
 @JRubyClass(name = "WrappedAckedQueue")
 public final class JRubyWrappedAckedQueueExt extends RubyObject {
@@ -62,9 +64,9 @@ public final class JRubyWrappedAckedQueueExt extends RubyObject {
     }
 
     @JRubyMethod(name = {"push", "<<"})
-    public void rubyPush(ThreadContext context, IRubyObject object) {
+    public void rubyPush(ThreadContext context, IRubyObject event) {
         checkIfClosed("write");
-        queue.ruby_write(context, object);
+        queue.rubyWrite(context, ((JrubyEventExtLibrary.RubyEvent) event).getEvent());
     }
 
     @JRubyMethod(name = "read_batch")
@@ -86,7 +88,7 @@ public final class JRubyWrappedAckedQueueExt extends RubyObject {
 
     @JRubyMethod(name = "is_empty?")
     public IRubyObject rubyIsEmpty(ThreadContext context) {
-        return queue.ruby_is_empty(context);
+        return RubyBoolean.newBoolean(context.runtime, this.queue.isEmpty());
     }
 
     private void checkIfClosed(String action) {

--- a/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBase.java
+++ b/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBase.java
@@ -182,6 +182,4 @@ public abstract class QueueReadClientBase extends RubyObject implements QueueRea
     }
 
     public abstract void close() throws IOException;
-    public abstract boolean isEmpty();
-
 }

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyAckedWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyAckedWriteClientExt.java
@@ -50,7 +50,7 @@ public final class JrubyAckedWriteClientExt extends RubyObject {
     @JRubyMethod(name = {"push", "<<"}, required = 1)
     public IRubyObject rubyPush(final ThreadContext context, IRubyObject event) {
         ensureOpen();
-        queue.ruby_write(context, event);
+        queue.rubyWrite(context, ((JrubyEventExtLibrary.RubyEvent) event).getEvent());
         return this;
     }
 
@@ -58,7 +58,7 @@ public final class JrubyAckedWriteClientExt extends RubyObject {
     public IRubyObject rubyPushBatch(final ThreadContext context, IRubyObject batch) {
         ensureOpen();
         for (final IRubyObject event : (Collection<JrubyEventExtLibrary.RubyEvent>) batch) {
-            queue.ruby_write(context, event);
+            queue.rubyWrite(context, ((JrubyEventExtLibrary.RubyEvent) event).getEvent());
         }
         return this;
     }


### PR DESCRIPTION
* RAF not properly handled by `try-with-resources` fixed
* Unused Ruby methods fixed (trying to get the Ruby out of `AckedQueue`/ `JRubyAckedQueueExt ` because we already have the Ruby wrapper `WrappedAckedQueue` and it makes an abstraction for Java use harder to have 2 levels of Ruby here, especially considering that most methods on there are used by specs only at this point :()
* Removed Queue `open` call for Ruby since Ruby can't invoke it without exception (the constructor for the wrapped queue will always open the acked queue -> removed the only `open` call that is in the specs (we didn't even use it in production code) since it errored everytime anyways.