### PR TITLE
MINOR: Cleanup wrong PluginFactory Codec type

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
@@ -52,6 +52,6 @@ public final class RubyIntegration {
         RubyIntegration.Filter buildFilter(RubyString name, RubyInteger line, RubyInteger column,
             IRubyObject args);
 
-        RubyIntegration.Filter buildCodec(RubyString name, IRubyObject args);
+        IRubyObject buildCodec(RubyString name, IRubyObject args);
     }
 }

--- a/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
@@ -202,7 +202,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
         }
 
         @Override
-        public RubyIntegration.Filter buildCodec(final RubyString name, final IRubyObject args) {
+        public IRubyObject buildCodec(final RubyString name, final IRubyObject args) {
             throw new IllegalStateException("No codec setup expected in this test.");
         }
 


### PR DESCRIPTION
Really random and trivial thing. Currently, the `buildCodec` call isn't made from the Java side, only from Ruby so this typo didn't cause any trouble, but obviously, the return from `buildCodec` isn't a `RubyIntegration.Filter` and trying to use this code in the Java Plugin work it failed :)