### PR TITLE
CLEANUP: Dry up filter wrapper setup

### DIFF
--- a/logstash-core/lib/logstash/filter_delegator.rb
+++ b/logstash-core/lib/logstash/filter_delegator.rb
@@ -16,16 +16,13 @@ module LogStash
 
     attr_reader :id
 
-    def initialize(klass, metric, execution_context, plugin_args)
-      @klass = klass
-      @id = plugin_args["id"]
-      @filter = klass.new(plugin_args)
+    def initialize(filter, id)
+      @klass = filter.class
+      @id = id
+      @filter = filter
 
       # Scope the metrics to the plugin
-      namespaced_metric = metric.namespace(@id.to_sym)
-      @filter.metric = namespaced_metric
-      @filter.execution_context = execution_context
-
+      namespaced_metric = filter.metric
       @metric_events = namespaced_metric.namespace(:events)
       @metric_events_in = @metric_events.counter(:in)
       @metric_events_out = @metric_events.counter(:out)

--- a/logstash-core/lib/logstash/java_filter_delegator.rb
+++ b/logstash-core/lib/logstash/java_filter_delegator.rb
@@ -17,16 +17,13 @@ module LogStash
 
     attr_reader :id
 
-    def initialize(klass, metric, execution_context, plugin_args)
-      @klass = klass
-      @id = plugin_args["id"]
-      @filter = klass.new(plugin_args)
+    def initialize(filter, id)
+      @klass = filter.class
+      @id = id
+      @filter = filter
 
       # Scope the metrics to the plugin
-      namespaced_metric = metric.namespace(@id.to_sym)
-      @filter.metric = namespaced_metric
-      @filter.execution_context = execution_context
-
+      namespaced_metric = filter.metric
       @metric_events = namespaced_metric.namespace(:events)
       @metric_events_in = @metric_events.counter(:in)
       @metric_events_out = @metric_events.counter(:out)

--- a/logstash-core/lib/logstash/plugins/plugin_factory.rb
+++ b/logstash-core/lib/logstash/plugins/plugin_factory.rb
@@ -32,6 +32,14 @@ module LogStash
     class PluginFactory
       include org.logstash.config.ir.compiler.RubyIntegration::PluginFactory
 
+      def self.filter_delegator(wrapper_class, filter_class, args, filter_metrics, execution_context)
+        filter_instance = filter_class.new(args)
+        id = args["id"]
+        filter_instance.metric = filter_metrics.namespace(id.to_sym)
+        filter_instance.execution_context = execution_context
+        wrapper_class.new(filter_instance, id)
+      end
+
       def initialize(lir, metric_factory, exec_factory, filter_class)
         @lir = lir
         @plugins_by_id = {}
@@ -84,7 +92,7 @@ module LogStash
         if plugin_type == "output"
           OutputDelegator.new(klass, type_scoped_metric, execution_context, OutputDelegatorStrategyRegistry.instance, args)
         elsif plugin_type == "filter"
-          @filter_class.new(klass, type_scoped_metric, execution_context, args)
+          self.class.filter_delegator(@filter_class, klass, args, type_scoped_metric, execution_context)
         else # input or codec plugin
           plugin_instance = klass.new(args)
           scoped_metric = type_scoped_metric.namespace(id.to_sym)

--- a/logstash-core/spec/logstash/filter_delegator_spec.rb
+++ b/logstash-core/spec/logstash/filter_delegator_spec.rb
@@ -42,12 +42,11 @@ describe LogStash::FilterDelegator do
     end
   end
 
-  subject { described_class.new(plugin_klass, metric, execution_context, config) }
-
-  it "create a plugin with the passed options" do
-    expect(plugin_klass).to receive(:new).with(config).and_return(plugin_klass.new(config))
-    described_class.new(plugin_klass, metric, execution_context, config)
-  end
+  subject {
+    LogStash::Plugins::PluginFactory.filter_delegator(
+        described_class, plugin_klass, config, metric, execution_context
+    )
+  }
 
   context "when the plugin support flush" do
     let(:plugin_klass) do

--- a/logstash-core/spec/logstash/java_filter_delegator_spec.rb
+++ b/logstash-core/spec/logstash/java_filter_delegator_spec.rb
@@ -42,12 +42,11 @@ describe LogStash::JavaFilterDelegator do
     end
   end
 
-  subject { described_class.new(plugin_klass, metric, execution_context, config) }
-
-  it "create a plugin with the passed options" do
-    expect(plugin_klass).to receive(:new).with(config).and_return(plugin_klass.new(config))
-    described_class.new(plugin_klass, metric, execution_context, config)
-  end
+  subject {
+    LogStash::Plugins::PluginFactory.filter_delegator(
+        described_class, plugin_klass, config, metric, execution_context
+    )
+  }
 
   context "when the plugin support flush" do
     let(:plugin_klass) do


### PR DESCRIPTION
Minor, but makes porting `java_filter_delegator.rb` to Java a lot easier (crucial step for the Java plugin API branch that can go into `master` already), just factored this part out of the port for easier review.

* Set up filter class in plugin factory outside of delegators instead of in the delegator constructor -> drier and easier to read
* Adjusted tests accordingly