### PR TITLE
reference properly-namespaced ConfigurationError when failing

### DIFF
--- a/logstash-core/lib/logstash/compiler/lscl.rb
+++ b/logstash-core/lib/logstash/compiler/lscl.rb
@@ -181,7 +181,7 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
       duplicate_values = find_duplicate_keys
 
       if duplicate_values.size > 0
-        raise ConfigurationError.new(
+        raise ::LogStash::ConfigurationError.new(
           I18n.t("logstash.runner.configuration.invalid_plugin_settings_duplicate_keys",
             :keys => duplicate_values.join(', '),
             :line => input.line_of(interval.first),


### PR DESCRIPTION
Previous code was failing to resolve `ConfigurationError` at runtime,
because there is no `ConfigurationError` on the lexical scope or included
into the LSCL AST.

Instead of emitting the helpful error intended, it blew up with a
`NameError` that adds noise to the problem instead of being helpful as
intended.

Initially reported in the [Logstash Forums](https://discuss.elastic.co/t/unhelpful-error-message-for-duplicate-xpath-reference-in-xml-filter/127389) by Badger.