### PR TITLE
Use v1.1 of java code format

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -120,7 +120,9 @@ dependencies {
     compile 'org.codehaus.janino:janino:3.0.8'
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jacksonVersion}"
     compile "org.jruby:jruby-complete:${jrubyVersion}"
-    compile 'com.google.googlejavaformat:google-java-format:1.5'
+    // Do not upgrade this, later versions require GPL licensed code in javac-shaded that is
+    // Apache2 incompatible
+    compile 'com.google.googlejavaformat:google-java-format:1.1'
     testCompile 'org.apache.logging.log4j:log4j-core:2.9.1:tests'
     testCompile 'junit:junit:4.12'
     testCompile 'net.javacrumbs.json-unit:json-unit:1.9.0'


### PR DESCRIPTION
Downgrade to avoid the javac-shaded dep