### PR TITLE
bump jruby to 9.1.16.0

### DIFF
--- a/lib/bootstrap/bundler.rb
+++ b/lib/bootstrap/bundler.rb
@@ -47,11 +47,11 @@ module LogStash
       require "bundler"
       LogStash::Bundler.patch!
 
-      ::Bundler.settings[:path] = Environment::BUNDLE_DIR
-      ::Bundler.settings[:without] = options[:without].join(":")
+      ::Bundler.settings.set_local(:path, Environment::BUNDLE_DIR)
+      ::Bundler.settings.set_local(:without, options[:without].join(":"))
       # in the context of Bundler.setup it looks like this is useless here because Gemfile path can only be specified using
       # the ENV, see https://github.com/bundler/bundler/blob/v1.8.3/lib/bundler/shared_helpers.rb#L103
-      ::Bundler.settings[:gemfile] = Environment::GEMFILE_PATH
+      ::Bundler.settings.set_local(:gemfile, Environment::GEMFILE_PATH)
 
       ::Bundler.reset!
       ::Bundler.setup
@@ -103,10 +103,10 @@ module LogStash
       # force Rubygems sources to our Gemfile sources
       ::Gem.sources = ::Gem::SourceList.from(options[:rubygems_source]) if options[:rubygems_source]
 
-      ::Bundler.settings[:path] = LogStash::Environment::BUNDLE_DIR
-      ::Bundler.settings[:gemfile] = LogStash::Environment::GEMFILE_PATH
-      ::Bundler.settings[:without] = options[:without].join(":")
-      ::Bundler.settings[:force] = options[:force]
+      ::Bundler.settings.set_local(:path, LogStash::Environment::BUNDLE_DIR)
+      ::Bundler.settings.set_local(:gemfile, LogStash::Environment::GEMFILE_PATH)
+      ::Bundler.settings.set_local(:without, options[:without].join(":"))
+      ::Bundler.settings.set_local(:force, options[:force])
 
       if !debug?
         # Will deal with transient network errors

--- a/rakelib/dependency.rake
+++ b/rakelib/dependency.rake
@@ -1,7 +1,7 @@
 
 namespace "dependency" do
   task "bundler" do
-    Rake::Task["gem:require"].invoke("bundler", "~> 1.9.4")
+    Rake::Task["gem:require"].invoke("bundler", "~> 1")
   end
 
   task "clamp" do

--- a/versions.yml
+++ b/versions.yml
@@ -6,8 +6,8 @@ logstash-core-plugin-api: 2.1.16
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time
 jruby:
-  version: 9.1.13.0
-  sha1: 815bac27d5daa1459a4477d6d80584f007ce6a68
+  version: 9.1.16.0
+  sha1: 375b578a074bb519fb327318c373136feef36ee0
 
 # jruby-runtime-override, if specified, will override the jruby version installed in vendor/jruby for logstash runtime only,
 # not for the compile-time jars


### PR DESCRIPTION
Unless there are known bugs with jruby, we can have the latest version in both master and 6.x