### PR TITLE
MINOR: Remove unused purge method from FileCheckpointIO

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/CheckpointIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/CheckpointIO.java
@@ -14,8 +14,6 @@ public interface CheckpointIO {
 
     void purge(String fileName) throws IOException;
 
-    void purge();
-
     // @return the head page checkpoint file name
     String headFileName();
 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/FileCheckpointIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/FileCheckpointIO.java
@@ -77,12 +77,6 @@ public class FileCheckpointIO implements CheckpointIO {
         Files.delete(path);
     }
 
-    @Override
-    public void purge() {
-        // TODO: dir traversal and delete all checkpoints?
-        throw new UnsupportedOperationException("purge() is not supported");
-    }
-
     // @return the head page checkpoint file name
     @Override
     public String headFileName() {


### PR DESCRIPTION
The method is neither implemented nor used -> removed.