### PR TITLE
Update jackson deps to 2.9.5

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -20,5 +20,5 @@ jruby:
 # Note: this file is copied to the root of logstash-core because its gemspec needs it when
 #       bundler evaluates the gemspec via bin/logstash
 # Ensure Jackson version here is kept in sync with version used by jrjackson gem
-jrjackson: 0.4.5
-jackson: 2.9.4
+jrjackson: 0.4.6
+jackson: 2.9.5


### PR DESCRIPTION

Do not merge until [JR Jackson](https://rubygems.org/gems/jrjackson) `0.4.6` is released. Related PRs: https://github.com/guyboertje/jrjackson/pull/68, https://github.com/logstash-plugins/logstash-input-beats/pull/314

Note: need to merge back to 5.6 branch
