### PR TITLE
JAVAFICATION+PERFORMANCE: Call output delegator Java method directly

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
@@ -19,6 +19,7 @@ import org.logstash.config.ir.compiler.ComputeStepSyntaxElement;
 import org.logstash.config.ir.compiler.Dataset;
 import org.logstash.config.ir.compiler.DatasetCompiler;
 import org.logstash.config.ir.compiler.EventCondition;
+import org.logstash.config.ir.compiler.OutputDelegatorExt;
 import org.logstash.config.ir.compiler.RubyIntegration;
 import org.logstash.config.ir.compiler.SplitDataset;
 import org.logstash.config.ir.graph.IfVertex;
@@ -56,7 +57,7 @@ public final class CompiledPipeline {
     /**
      * Configured outputs.
      */
-    private final Map<String, IRubyObject> outputs;
+    private final Map<String, OutputDelegatorExt> outputs;
 
     /**
      * Parsed pipeline configuration graph.
@@ -101,9 +102,9 @@ public final class CompiledPipeline {
     /**
      * Sets up all Ruby outputs learnt from {@link PipelineIR}.
      */
-    private Map<String, IRubyObject> setupOutputs() {
+    private Map<String, OutputDelegatorExt> setupOutputs() {
         final Collection<PluginVertex> outs = pipelineIR.getOutputPluginVertices();
-        final Map<String, IRubyObject> res = new HashMap<>(outs.size());
+        final Map<String, OutputDelegatorExt> res = new HashMap<>(outs.size());
         outs.forEach(v -> {
             final PluginDefinition def = v.getPluginDefinition();
             final SourceWithMetadata source = v.getSourceWithMetadata();

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputDelegatorExt.java
@@ -1,5 +1,6 @@
 package org.logstash.config.ir.compiler;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.TimeUnit;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
@@ -67,6 +68,15 @@ public final class OutputDelegatorExt extends RubyObject {
             new IRubyObject[]{outputClass, namespacedMetric, arguments[2], args},
             Block.NULL_BLOCK
         );
+        return this;
+    }
+
+    @VisibleForTesting
+    public OutputDelegatorExt initForTesting(final IRubyObject strategy) {
+        eventMetricOut = LongCounter.DUMMY_COUNTER;
+        eventMetricIn = LongCounter.DUMMY_COUNTER;
+        eventMetricTime = LongCounter.DUMMY_COUNTER;
+        this.strategy = strategy;
         return this;
     }
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
@@ -46,7 +46,7 @@ public final class RubyIntegration {
         IRubyObject buildInput(RubyString name, RubyInteger line, RubyInteger column,
             IRubyObject args);
 
-        IRubyObject buildOutput(RubyString name, RubyInteger line, RubyInteger column,
+        OutputDelegatorExt buildOutput(RubyString name, RubyInteger line, RubyInteger column,
             IRubyObject args);
 
         RubyIntegration.Filter buildFilter(RubyString name, RubyInteger line, RubyInteger column,

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/counter/LongCounter.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/counter/LongCounter.java
@@ -16,7 +16,7 @@ public class LongCounter extends AbstractMetric<Long> implements CounterMetric<L
     /**
      * Dummy counter used by some functionality as a placeholder when metrics are disabled.
      */
-    private static final LongCounter DUMMY_COUNTER = new LongCounter("dummy");
+    public static final LongCounter DUMMY_COUNTER = new LongCounter("dummy");
 
     private static final IllegalArgumentException NEGATIVE_COUNT_EXCEPTION = new IllegalArgumentException("Counters can not be incremented by negative values");
     private LongAdder longAdder;

--- a/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
@@ -18,6 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.logstash.Event;
 import org.logstash.RubyUtil;
+import org.logstash.config.ir.compiler.OutputDelegatorExt;
 import org.logstash.config.ir.compiler.RubyIntegration;
 import org.logstash.ext.JrubyEventExtLibrary;
 
@@ -190,9 +191,11 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
         }
 
         @Override
-        public IRubyObject buildOutput(final RubyString name, final RubyInteger line,
+        public OutputDelegatorExt buildOutput(final RubyString name, final RubyInteger line,
             final RubyInteger column, final IRubyObject args) {
-            return setupPlugin(name, outputs);
+            return new OutputDelegatorExt(
+                RubyUtil.RUBY, RubyUtil.OUTPUT_DELEGATOR_CLASS)
+                .initForTesting(setupPlugin(name, outputs));
         }
 
         @Override

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/DatasetCompilerTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/DatasetCompilerTest.java
@@ -23,9 +23,10 @@ public final class DatasetCompilerTest {
         assertThat(
             DatasetCompiler.outputDataset(
                 Collections.emptyList(),
-                RubyUtil.RUBY.evalScriptlet(
-                    "output = Object.new\noutput.define_singleton_method(:multi_receive) do |batch|\nend\noutput"
-                ),
+                new OutputDelegatorExt(RubyUtil.RUBY, RubyUtil.OUTPUT_DELEGATOR_CLASS)
+                    .initForTesting(RubyUtil.RUBY.evalScriptlet(
+                        "output = Object.new\noutput.define_singleton_method(:multi_receive) do |batch|\nend\noutput"
+                    )),
                 true
             ).instantiate().compute(RubyUtil.RUBY.newArray(), false, false),
             nullValue()


### PR DESCRIPTION
With the `OutputDelegator` now being implemented in Java, we can make the config compiler generate code that invokes `multiReceive` directly, saving us the indirection of caching the Ruby call-site and invoking that (like we still do for filters, but that PR is incoming as well).

* Unfortunately had to add the `initForTesting` method as an alternative constructor to the `OutputDelegatorExt` since it's constructor is so complicated and depends on Ruby metrics code (we don't wanna invoke that from JUnit tests since that creates circular dependencies between Java and Ruby).

=> small performance gain <= removed one Java -> Ruby step from the compiled pipeline