### PR TITLE
Respect JAVACMD and update Drip docs to reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ hello world
 
 [Drip](https://github.com/ninjudd/drip) is a tool that solves the slow JVM startup problem while developing Logstash. The drip script is intended to be a drop-in replacement for the java command. We recommend using drip during development, in particular for running tests. Using drip, the first invocation of a command will not be faster but the subsequent commands will be swift.
 
-To tell logstash to use drip, either set the `USE_DRIP=1` environment variable or set `` JAVACMD=`which drip` ``.
+To tell logstash to use drip, set the environment variable `` JAVACMD=`which drip` ``.
 
 Example (but see the *Testing* section below before running rspec for the first time):
 
-    USE_DRIP=1 bin/rspec
+    JAVACMD=`which drip` bin/rspec
 
 **Caveats**
 

--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -73,12 +73,14 @@ parse_jvm_options() {
 
 setup_java() {
   # set the path to java into JAVACMD which will be picked up by JRuby to launch itself
-  if [ -x "$JAVA_HOME/bin/java" ]; then
-    JAVACMD="$JAVA_HOME/bin/java"
-  else
-    set +e
-    JAVACMD=`command -v java`
-    set -e
+  if [ -z "$JAVACMD" ]; then
+    if [ -x "$JAVA_HOME/bin/java" ]; then
+      JAVACMD="$JAVA_HOME/bin/java"
+    else
+      set +e
+      JAVACMD=`command -v java`
+      set -e
+    fi
   fi
 
   if [ ! -x "$JAVACMD" ]; then


### PR DESCRIPTION
Fix so that `bin/logstash.lib.sh` respects and uses `JAVACMD` if it's set and doesn't overwrite it.

Also update Drip docs so they reflect reality. #8178 missed removing `USE_DRIP` from the README.