### PR TITLE
MINOR+BUG: Clean doesn't delete gem jars for logstash-core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,6 +155,7 @@ task installTestGems(dependsOn: downloadAndInstallJRuby) {
   inputs.files file("${projectDir}/versions.yml")
   outputs.file("${projectDir}/Gemfile")
   outputs.file("${projectDir}/Gemfile.lock")
+  outputs.dir("${projectDir}/logstash-core/lib/jars")
   outputs.dir("${projectDir}/vendor/bundle/jruby/2.3.0")
   doLast {
     rubyGradleUtils.rake('test:install-core')

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -46,7 +46,7 @@ task copyGemjar(type: Copy, dependsOn: [sourcesJar, copyRuntimeLibs]) {
 }
 
 task cleanGemjar {
-    delete fileTree(project.file('lib/logstash-core/')) {
+    delete fileTree(project.file('lib/jars/')) {
         include '*.jar'
     }
 }


### PR DESCRIPTION
The path of the jars changed when we moved to the Java entrypoint but the `clean` target here wasn't adjusted accordingly => fixed.
Also, correctly added the output path to the gem installation task.