### PR TITLE
BUILD: Stop using Exec tasks for ITs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -237,16 +237,14 @@ def qaVendorPath = "${buildDir}/qa/integration/vendor"
 def qaBundledGemPath = "${qaVendorPath}/jruby/2.3.0"
 def qaBundleBin = "${qaBundledGemPath}/bin/bundle"
 
-task installIntegrationTestBundler(dependsOn: unpackTarDistribution, type: Exec) {
+task installIntegrationTestBundler(dependsOn: unpackTarDistribution) {
   outputs.files fileTree("${qaBundledGemPath}/gems/bundler-1.16.0")
-  standardOutput = new ExecLogOutputStream(System.out)
-  errorOutput =  new ExecLogOutputStream(System.err)
-  // directly invoke bin/gem to install bundlers and force install dir "-i" into qaBundledGemPath
-  commandLine "${projectDir}/vendor/jruby/bin/gem", "install", "bundler", "-v", "1.16.0", "-i", qaBundledGemPath
+  doLast {
+    rubyGradleUtils.gem("bundler", "1.16.0", qaBundledGemPath)
+  }
 }
 
-task installIntegrationTestGems(dependsOn: installIntegrationTestBundler, type: Exec) {
-  workingDir "${projectDir}/qa/integration"
+task installIntegrationTestGems(dependsOn: installIntegrationTestBundler) {
   inputs.files file("${projectDir}/qa/integration/Gemfile")
   inputs.files file("${projectDir}/qa/integration/integration_tests.gemspec")
   inputs.files file("${logstashBuildDir}/Gemfile")
@@ -254,29 +252,27 @@ task installIntegrationTestGems(dependsOn: installIntegrationTestBundler, type: 
   inputs.files file("${logstashBuildDir}/logstash-core/logstash-core.gemspec")
   outputs.files fileTree("${qaVendorPath}")
   outputs.files file("${projectDir}/qa/integration/Gemfile.lock")
-  standardOutput = new ExecLogOutputStream(System.out)
-  errorOutput =  new ExecLogOutputStream(System.err)
-  // directly invoke bin/bundler and force install gem path to qaVendorPath
-  // note that bundler appends jruby/2.3.0 to the install path
-  commandLine qaBundleBin, "install", "--path", qaVendorPath
+  doLast {
+    rubyGradleUtils.bundle(
+      "${projectDir}/qa/integration", qaBundleBin, ['install', '--path', qaVendorPath],
+      [LS_GEM_PATH: qaBundledGemPath, LS_GEM_HOME: qaBundledGemPath]
+    )
+  }
 }
 
-def rubyIntegrationSpecs = project.hasProperty("rubyIntegrationSpecs") ? ((String) project.property("rubyIntegrationSpecs")).split(/\s+/) : []
-def rubyBin = "${projectDir}" +
-  (System.getProperty("os.name").startsWith("Windows") ? '/vendor/jruby/bin/jruby.bat' : '/bin/ruby')
+def rubyIntegrationSpecs = project.hasProperty("rubyIntegrationSpecs") ? ((String) project.property("rubyIntegrationSpecs")).split(/\s+/).join(",") : "specs/**/*_spec.rb"
+def integrationTestPwd = "${projectDir}/qa/integration"
 
-task runIntegrationTests(dependsOn: installIntegrationTestGems, type: Exec) {
-  workingDir "${projectDir}/qa/integration"
-  environment "LS_GEM_PATH", qaBundledGemPath
-  environment "LS_GEM_HOME", qaBundledGemPath
-  // FEATURE_FLAG is set in the CI to configure testing with enabled PQ
-  environment "FEATURE_FLAG", System.getenv('FEATURE_FLAG')
-  standardOutput = new ExecLogOutputStream(System.out)
-  errorOutput =  new ExecLogOutputStream(System.err)
-  // indirect launching of bin/bundle via bin/ruby so that the bundle exec command inherit
-  // the correct gem path environment which is not settable by command line
-  commandLine([rubyBin, qaBundleBin, "exec", "rspec"].plus((Collection<String>)rubyIntegrationSpecs))
+project(":logstash-integration-tests") {
+    tasks.getByPath(":logstash-integration-tests:integrationTests").configure {
+      systemProperty 'org.logstash.integration.specs', rubyIntegrationSpecs
+      environment "FEATURE_FLAG", System.getenv('FEATURE_FLAG')
+      workingDir integrationTestPwd
+      dependsOn installIntegrationTestGems
+  }
 }
+
+task runIntegrationTests(dependsOn: [tasks.getByPath(":logstash-integration-tests:integrationTests")]) {}
 
 // If you are running a JRuby snapshot we will skip the integrity check.
 verifyFile.onlyIf { doChecksum }

--- a/buildSrc/src/main/groovy/org/logstash/gradle/RubyGradleUtils.groovy
+++ b/buildSrc/src/main/groovy/org/logstash/gradle/RubyGradleUtils.groovy
@@ -1,6 +1,7 @@
 package org.logstash.gradle
 
 import org.jruby.Ruby
+import org.jruby.embed.PathType
 import org.jruby.embed.ScriptingContainer
 
 final class RubyGradleUtils {
@@ -12,6 +13,54 @@ final class RubyGradleUtils {
   RubyGradleUtils(File buildDir, File projectDir) {
     this.buildDir = buildDir
     this.projectDir = projectDir
+  }
+
+  /**
+   * Executes a bundler bin script with given parameters.
+   * @param pwd Current worker directory to execute in
+   * @param bundleBin Bundler Bin Script
+   * @param args CLI Args to Use with Bundler
+   */
+  void bundle(String pwd, String bundleBin, Iterable<String> args) {
+    bundle(pwd, bundleBin, args, Collections.emptyMap())
+  }
+
+  /**
+   * Executes a bundler bin script with given parameters.
+   * @param pwd Current worker directory to execute in
+   * @param bundleBin Bundler Bin Script
+   * @param args CLI Args to Use with Bundler
+   * @param env Environment Variables to Set
+   */
+  void bundle(String pwd, String bundleBin, Iterable<String> args, Map<String, String> env) {
+    executeJruby { ScriptingContainer jruby ->
+      jruby.environment.putAll(env)
+      jruby.currentDirectory = pwd
+      jruby.argv = args.toList().toArray()
+      jruby.runScriptlet(PathType.ABSOLUTE, bundleBin)
+    }
+  }
+
+  /**
+   * Installs a Gem with the given version to the given path.
+   * @param gem Gem Name
+   * @param version Version to Install
+   * @param path Path to Install to
+   */
+  void gem(String gem, String version, String path) {
+    executeJruby { ScriptingContainer jruby ->
+      jruby.currentDirectory = projectDir
+      jruby.runScriptlet(
+        "require 'rubygems/commands/install_command'\n" +
+          "cmd = Gem::Commands::InstallCommand.new\n" +
+          "cmd.handle_options [\"--no-ri\", \"--no-rdoc\", '${gem}', '-v', '${version}', '-i', '${path}']\n" +
+          "begin \n" +
+          "  cmd.execute\n" +
+          "rescue Gem::SystemExitException => e\n" +
+          "  raise e unless e.exit_code == 0\n" +
+          "end"
+      )
+    }
   }
 
   /**

--- a/qa/integration/build.gradle
+++ b/qa/integration/build.gradle
@@ -1,0 +1,30 @@
+description = """Logstash Integration Tests"""
+
+repositories {
+  mavenCentral()
+}
+
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+}
+
+dependencies {
+  testCompile project(':logstash-core')
+  testCompile 'org.assertj:assertj-core:3.8.0'
+  testCompile 'junit:junit:4.12'
+}
+
+test {
+  exclude '/**'
+}
+
+task integrationTests(type: Test) {
+  inputs.files fileTree("${projectDir}/services")
+  inputs.files fileTree("${projectDir}/framework")
+  inputs.files fileTree("${projectDir}/fixtures")
+  inputs.files fileTree("${projectDir}/specs")
+  systemProperty 'logstash.core.root.dir', projectDir.absolutePath
+  include '/org/logstash/integration/RSpecTests.class'
+}

--- a/qa/integration/rspec.rb
+++ b/qa/integration/rspec.rb
@@ -1,0 +1,17 @@
+# encoding: utf-8
+
+require 'rubygems'
+
+::Gem.clear_paths
+
+ENV['GEM_HOME'] = ENV['GEM_PATH'] = ::File.expand_path(
+    ::File.join(__FILE__, "..", "..", "..", "build", "qa", "integration", "vendor", "jruby", "2.3.0")
+)
+
+require "bundler"
+::Bundler.setup
+
+require "rspec/core"
+require "rspec"
+
+return RSpec::Core::Runner.run($JUNIT_ARGV).to_i

--- a/qa/integration/services/filebeat_service.rb
+++ b/qa/integration/services/filebeat_service.rb
@@ -10,7 +10,6 @@ class FilebeatService < Service
       @process = ChildProcess.build(*cmd)
       @process.duplex = true
       @process.io.stdout = @process.io.stderr = @client_out
-      ChildProcess.posix_spawn = true
     end
 
     def start

--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -20,7 +20,7 @@ class LogstashService < Service
   RETRY_ATTEMPTS = 10
 
   @process = nil
-  
+
   attr_reader :logstash_home
   attr_reader :default_settings_file
   attr_writer :env_variables
@@ -43,7 +43,7 @@ class LogstashService < Service
       @logstash_bin = File.join("#{@logstash_home}", LS_BIN)
       raise "Logstash binary not found in path #{@logstash_home}" unless File.file? @logstash_bin
     end
-    
+
     @default_settings_file = File.join(@logstash_home, LS_CONFIG_FILE)
     @monitoring_api = MonitoringAPI.new
   end
@@ -55,14 +55,14 @@ class LogstashService < Service
       @process.alive?
     end
   end
-  
+
   def exited?
     @process.exited?
   end
-  
+
   def exit_code
     @process.exit_code
-  end  
+  end
 
   # Starts a LS process in background with a given config file
   # and shuts it down after input is completely processed
@@ -171,22 +171,22 @@ class LogstashService < Service
       tries -= 1
     end
   end
-  
+
   # this method only overwrites existing config with new config
-  # it does not assume that LS pipeline is fully reloaded after a 
+  # it does not assume that LS pipeline is fully reloaded after a
   # config change. It is up to the caller to validate that.
   def reload_config(initial_config_file, reload_config_file)
     FileUtils.cp(reload_config_file, initial_config_file)
-  end  
-  
+  end
+
   def get_version
     `#{@logstash_bin} --version`.split("\n").last
   end
-  
+
   def get_version_yml
     LS_VERSION_FILE
-  end   
-  
+  end
+
   def process_id
     @process.pid
   end

--- a/qa/integration/settings.gradle
+++ b/qa/integration/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'integration-tests'

--- a/qa/integration/src/test/java/org/logstash/integration/RSpecTests.java
+++ b/qa/integration/src/test/java/org/logstash/integration/RSpecTests.java
@@ -1,0 +1,35 @@
+package org.logstash.integration;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.logstash.RubyUtil;
+import org.logstash.Rubyfier;
+
+/**
+ * JUnit Wrapper for RSpec Integration Tests.
+ */
+public final class RSpecTests {
+
+    @Test
+    public void rspecTests() throws Exception {
+        RubyUtil.RUBY.getGlobalVariables().set(
+            "$JUNIT_ARGV", Rubyfier.deep(RubyUtil.RUBY, Arrays.asList(
+                "-fd", "--pattern", System.getProperty("org.logstash.integration.specs", "specs/**/*_spec.rb")
+            ))
+        );
+        final Path rspec = Paths.get("rspec.rb");
+        final IRubyObject result = RubyUtil.RUBY.executeScript(
+            new String(Files.readAllBytes(rspec), StandardCharsets.UTF_8),
+            rspec.toFile().getAbsolutePath()
+        );
+        if (!result.toJava(Long.class).equals(0L)) {
+            Assert.fail("RSpec test suit saw at least one failure.");
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
-include ':logstash-core', 'logstash-core-benchmarks', 'ingest-converter', 'benchmark-cli'
+include ':logstash-core', 'logstash-core-benchmarks', 'ingest-converter', 'benchmark-cli', 'logstash-integration-tests'
 project(':logstash-core').projectDir = new File('./logstash-core')
 project(':logstash-core-benchmarks').projectDir = new File('./logstash-core/benchmarks')
+project(':logstash-integration-tests').projectDir = new File('./qa/integration')
 project(':ingest-converter').projectDir = new File('./tools/ingest-converter')
 project(':benchmark-cli').projectDir = new File('./tools/benchmark-cli')


### PR DESCRIPTION
Ported the execution of the Rspec ITs to Java Rspec wrapper like we have in core :)