### PR TITLE
BUILD: Fix inconsistent naming of output tar.gz

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,7 +172,7 @@ task assembleTarDistribution(dependsOn: downloadAndInstallJRuby) {
   inputs.files fileTree("${projectDir}/logstash-core/lib")
   inputs.files fileTree("${projectDir}/logstash-core/src")
   inputs.files fileTree("${projectDir}/x-pack")
-  outputs.files file("${buildDir}/logstash-${project.version}.tar.gz")
+  outputs.files file("${buildDir}/logstash-${project.version}-SNAPSHOT.tar.gz")
   doLast {
     rubyGradleUtils.rake('artifact:tar')
   }


### PR DESCRIPTION
I missed adding the `-SNAPSHOT` suffix to the output paths here when creating the task. This causes the Gradle caching to not work properly and leads to rebuilding the `tar.gz` archive between IT runs even if the LS core code hasn't changed.
=> fixed by adding the suffix like in the dependent task `unpackTarDistribution` :)