### PR TITLE
 #8004 fix load order to start webserver after pipeline

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -84,11 +84,11 @@ class LogStash::Agent
     @thread = Thread.current # this var is implicitly used by Stud.stop?
     logger.debug("Starting agent")
 
-    start_webserver
-
     transition_to_running
 
     converge_state_and_update
+
+    start_webserver
 
     if auto_reload?
       # `sleep_then_run` instead of firing the interval right away

--- a/qa/integration/framework/helpers.rb
+++ b/qa/integration/framework/helpers.rb
@@ -20,13 +20,11 @@ def wait_for_port(port, retry_attempts)
 end
 
 def is_port_open?(port)
-  begin
-    s = TCPSocket.open("localhost", port)
-    s.close
+  TCPSocket.open("localhost", port) do
     return true
-  rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
-    return false
   end
+rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+  return false
 end
 
 def send_data(port, data)

--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -17,7 +17,7 @@ class LogstashService < Service
   SETTINGS_CLI_FLAG = "--path.settings"
 
   STDIN_CONFIG = "input {stdin {}} output { }"
-  RETRY_ATTEMPTS = 10
+  RETRY_ATTEMPTS = 60
 
   @process = nil
 
@@ -115,7 +115,6 @@ class LogstashService < Service
       @env_variables.map { |k, v|  @process.environment[k] = v} unless @env_variables.nil?
       @process.io.inherit!
       @process.start
-      wait_for_logstash
       puts "Logstash started with PID #{@process.pid}" if @process.alive?
     end
   end
@@ -164,12 +163,13 @@ class LogstashService < Service
     tries = RETRY_ATTEMPTS
     while tries > 0
       if is_port_open?
-        break
+        return
       else
         sleep 1
       end
       tries -= 1
     end
+    raise "Logstash REST API did not come up after #{RETRY_ATTEMPTS}s."
   end
 
   # this method only overwrites existing config with new config

--- a/qa/integration/specs/secret_store_spec.rb
+++ b/qa/integration/specs/secret_store_spec.rb
@@ -69,7 +69,6 @@ describe "Test that Logstash" do
       test_env["LOGSTASH_KEYSTORE_PASS"] = "WRONG_PASSWRD"
       @logstash.env_variables = test_env
       @logstash.spawn_logstash("-e", "input {generator { count => 1 }} output { }", "--path.settings", settings_dir)
-      @logstash.wait_for_logstash
       try(num_retries) do
         expect(@logstash.exited?).to be(true)
       end
@@ -83,7 +82,6 @@ describe "Test that Logstash" do
       test_env["LOGSTASH_KEYSTORE_PASS"] = "WRONG_PASSWRD"
       @logstash.env_variables = test_env
       @logstash.spawn_logstash("-e", "input {generator { count => 1 }} output { }", "--path.settings", settings_dir)
-      @logstash.wait_for_logstash
       try(num_retries) do
         expect(@logstash.exited?).to be(true)
       end
@@ -97,7 +95,6 @@ describe "Test that Logstash" do
       test_env["LOGSTASH_KEYSTORE_PASS"] = "keystore_pa9454w3rd"
       @logstash.env_variables = test_env
       @logstash.spawn_logstash("-e", "input {stdin {}} output { }", "--path.settings", settings_dir)
-      @logstash.wait_for_logstash
       try(num_retries) do
         expect(@logstash.exited?).to be(true)
       end

--- a/qa/integration/specs/settings_spec.rb
+++ b/qa/integration/specs/settings_spec.rb
@@ -15,13 +15,13 @@ describe "Test Logstash instance whose default settings are overridden" do
   after(:all) {
     @fixture.teardown
   }
-  
+
   before(:each) {
     FileUtils.rm(@logstash_default_logs) if File.exists?(@logstash_default_logs)
     # backup the application settings file -- logstash.yml
     FileUtils.cp(@logstash_service.application_settings_file, "#{@logstash_service.application_settings_file}.original")
   }
-  
+
   after(:each) {
     @logstash_service.teardown
     # restore the application settings file -- logstash.yml
@@ -32,17 +32,17 @@ describe "Test Logstash instance whose default settings are overridden" do
   let(:test_port) { random_port }
   let(:temp_dir) { Stud::Temporary.directory("logstash-settings-test") }
   let(:tcp_config) { @fixture.config("root", { :port => test_port }) }
-  
+
   def change_setting(name, value)
     settings = {}
     settings[name] = value
     overwrite_settings(settings)
   end
-  
+
   def overwrite_settings(settings)
     IO.write(@logstash_service.application_settings_file, settings.to_yaml)
   end
-  
+
   it "should start with a new data dir" do
     change_setting("path.data", temp_dir)
     @logstash_service.spawn_logstash("-e", tcp_config)
@@ -52,7 +52,7 @@ describe "Test Logstash instance whose default settings are overridden" do
       expect(is_port_open?(test_port)).to be true
     end
   end
-  
+
   it "should write logs to a new dir" do
     change_setting("path.logs", temp_dir)
     @logstash_service.spawn_logstash("-e", tcp_config)
@@ -63,7 +63,7 @@ describe "Test Logstash instance whose default settings are overridden" do
     end
     expect(File.exists?("#{temp_dir}/logstash-plain.log")).to be true
   end
-  
+
   it "should read config from the specified dir in logstash.yml" do
     change_setting("path.config", temp_dir)
     test_config_path = File.join(temp_dir, "test.config")
@@ -76,7 +76,7 @@ describe "Test Logstash instance whose default settings are overridden" do
       expect(is_port_open?(test_port)).to be true
     end
   end
-  
+
   it "should exit when config test_and_exit is set" do
     test_config_path = File.join(temp_dir, "test.config")
     IO.write(test_config_path, "#{tcp_config}")
@@ -91,7 +91,7 @@ describe "Test Logstash instance whose default settings are overridden" do
       expect(@logstash_service.exited?).to be true
     end
     expect(@logstash_service.exit_code).to eq(0)
-    
+
     # now with bad config
     IO.write(test_config_path, "#{tcp_config} filters {} ")
     expect(File.exists?(test_config_path)).to be true
@@ -127,16 +127,13 @@ describe "Test Logstash instance whose default settings are overridden" do
     http_port = random_port
     change_setting("http.port", http_port)
     @logstash_service.spawn_logstash("-e", tcp_config)
-    @logstash_service.wait_for_logstash
-    
-    try(num_retries) do
-      expect(is_port_open?(http_port)).to be true
-    end
+    wait_for_port(http_port, 60)
+    expect(is_port_open?(http_port)).to be true
     # check LS is up and running with new data path
     try(num_retries) do
       expect(is_port_open?(test_port)).to be true
     end
-    
+
     expect(File.exists?(@logstash_default_logs)).to be true
 
     resp = Manticore.get("http://localhost:#{http_port}/_node").body


### PR DESCRIPTION
Cleanup of #8509 : 

The fix is sound I think. Just start the webserver once the pipeline is up. If it doesn't come up LS will go down anyways so there's little point in bringing the webserver up without the pipeline runnning.

Had to fix the ITs a little:
* Only waiting 10s for the webserver to come up is way too little. This worked accidentally without this fix since: 
  * All the tests wait for some side effect of the pipeline before checking the metrics as well. If we bring up the webserver a few `ms` after the pipeline side-effects have happened we could run into them not being available
  * Timing out on waiting for the metrics didn't throw an error and behaved indistinguishably from timing out
* This change also allowed removing a bunch of `wait_for_logstash` calls that would always wait for 10s to timeout in tests that don't expect LS to actually start => saves 60s+ on the overall `./gradlew check` target for me locally
* Also fixed the fact that we're leaving a bunch of sockets unclosed when checking for open ports and failing to help stability a little by using the `Block` style opening of sockets that ensures the `close` is call on exceptions.

=> no more weird error 500 in the logs :)