### PR TITLE
CLEANUP+JAVAFICATION+PERFORMANCE: Keep hard reference to Ruby ThreadContext, simplify code accordingly

### DIFF
--- a/logstash-core/spec/logstash/java_filter_delegator_spec.rb
+++ b/logstash-core/spec/logstash/java_filter_delegator_spec.rb
@@ -83,20 +83,19 @@ describe LogStash::JavaFilterDelegator do
 
     context "when the flush return events" do
       it "increments the out" do
-        ruby_context = RubyUtil::RUBY.getCurrentContext
-        subject.to_java.multiFilter(ruby_context, [LogStash::Event.new])
+        subject.to_java.multiFilter([LogStash::Event.new])
         event_metrics = metric.collector.snapshot_metric.metric_store.get_with_path(
             "filter/my_filter"
         )[:filter][:my_filter][:events]
         expect(event_metrics[:out].value).to eq(0)
-        subject.to_java.flush(ruby_context, {})
+        subject.to_java.flush({})
         expect(event_metrics[:out].value).to eq(1)
       end
     end
 
     context "when the flush doesn't return anything" do
       it "doesnt increment the out" do
-        subject.to_java.flush(RubyUtil::RUBY.getCurrentContext, {})
+        subject.to_java.flush({})
         expect(
             metric.collector.snapshot_metric.metric_store.
                 get_with_path("filter/my_filter")[:filter][:my_filter][:events][:duration_in_millis].value
@@ -107,7 +106,7 @@ describe LogStash::JavaFilterDelegator do
     context "when the filter buffer events" do
 
       it "has incremented :in" do
-        subject.to_java.multiFilter(RubyUtil::RUBY.getCurrentContext, events)
+        subject.to_java.multiFilter(events)
         expect(
             metric.collector.snapshot_metric.metric_store.
                 get_with_path("filter/my_filter")[:filter][:my_filter][:events][:in].value
@@ -115,7 +114,7 @@ describe LogStash::JavaFilterDelegator do
       end
 
       it "has not incremented :out" do
-        subject.to_java.multiFilter(RubyUtil::RUBY.getCurrentContext, events)
+        subject.to_java.multiFilter(events)
         expect(
             metric.collector.snapshot_metric.metric_store.
                 get_with_path("filter/my_filter")[:filter][:my_filter][:events][:out].value
@@ -140,7 +139,7 @@ describe LogStash::JavaFilterDelegator do
       end
 
       it "increments the in/out of the metric" do
-        subject.to_java.multiFilter(RubyUtil::RUBY.getCurrentContext, events)
+        subject.to_java.multiFilter(events)
         event_metrics = metric.collector.snapshot_metric.metric_store.get_with_path(
             "filter/my_filter"
         )[:filter][:my_filter][:events]
@@ -171,7 +170,7 @@ describe LogStash::JavaFilterDelegator do
     end
 
     it "increments the in/out of the metric" do
-      subject.to_java.multiFilter(RubyUtil::RUBY.getCurrentContext, events)
+      subject.to_java.multiFilter(events)
       event_metrics = metric.collector.snapshot_metric.metric_store.get_with_path(
           "filter/my_filter"
       )[:filter][:my_filter][:events]

--- a/logstash-core/src/main/java/org/logstash/ConvertedMap.java
+++ b/logstash-core/src/main/java/org/logstash/ConvertedMap.java
@@ -8,6 +8,7 @@ import org.jruby.RubyHash;
 import org.jruby.RubyString;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.logstash.execution.WorkerLoop;
 
 /**
  * <p>This class is an internal API and behaves very different from a standard {@link Map}.</p>
@@ -60,7 +61,7 @@ public final class ConvertedMap extends IdentityHashMap<String, Object> {
     }
 
     public static ConvertedMap newFromRubyHash(final RubyHash o) {
-        return newFromRubyHash(o.getRuntime().getCurrentContext(), o);
+        return newFromRubyHash(WorkerLoop.THREAD_CONTEXT.get(), o);
     }
 
     public static ConvertedMap newFromRubyHash(final ThreadContext context, final RubyHash o) {

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/Closure.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/Closure.java
@@ -1,12 +1,9 @@
 package org.logstash.config.ir.compiler;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.jruby.Ruby;
-import org.jruby.runtime.ThreadContext;
 
 /**
  * A syntactic closure.
@@ -17,28 +14,6 @@ final class Closure implements MethodLevelSyntaxElement {
      * Empty and immutable {@link Closure}.
      */
     public static final Closure EMPTY = new Closure(Collections.emptyList());
-
-    /**
-     * Variable declaration for the Ruby thread-context,
-     * renders as {@code final ThreadContext context}.
-     */
-    private static final VariableDefinition RUBY_THREAD_CONTEXT =
-        new VariableDefinition(ThreadContext.class, "context");
-
-    /**
-     * Variable declaration for the Ruby thread-context,
-     * renders as {@code final ThreadContext context = RubyUtil.RUBY.getCurrentContext()}.
-     */
-    private static final MethodLevelSyntaxElement CACHE_RUBY_THREADCONTEXT =
-        SyntaxFactory.definition(
-            RUBY_THREAD_CONTEXT, ValueSyntaxElement.GET_RUBY_THREAD_CONTEXT
-        );
-
-    /**
-     * Variable referencing the current Ruby thread context.
-     */
-    private static final ValueSyntaxElement CACHED_RUBY_THREADCONTEXT =
-        RUBY_THREAD_CONTEXT.access();
 
     private final List<MethodLevelSyntaxElement> statements;
 
@@ -78,50 +53,10 @@ final class Closure implements MethodLevelSyntaxElement {
 
     @Override
     public String generateCode() {
-        final Collection<MethodLevelSyntaxElement> optimized =
-            this.optimizeRubyThreadContexts().statements;
-        return optimized.isEmpty() ? "" : SyntaxFactory.join(
-            optimized.stream().map(MethodLevelSyntaxElement::generateCode).collect(
+        return statements.isEmpty() ? "" : SyntaxFactory.join(
+            statements.stream().map(MethodLevelSyntaxElement::generateCode).collect(
                 Collectors.joining(";\n")
             ), ";"
         );
-    }
-
-    /**
-     * Removes duplicate calls to {@link Ruby#getCurrentContext()} by caching them to a variable.
-     * @return Copy of this Closure without redundant calls to {@link Ruby#getCurrentContext()}
-     */
-    private Closure optimizeRubyThreadContexts() {
-        final ArrayList<Integer> rubyCalls = new ArrayList<>();
-        for (int i = 0; i < statements.size(); ++i) {
-            if (statements.get(i).count(ValueSyntaxElement.GET_RUBY_THREAD_CONTEXT) > 0) {
-                rubyCalls.add(i);
-            }
-        }
-        final Closure optimized;
-        if (rubyCalls.size() > 1) {
-            optimized = (Closure) new Closure().add(this).replace(
-                ValueSyntaxElement.GET_RUBY_THREAD_CONTEXT, CACHED_RUBY_THREADCONTEXT
-            );
-            optimized.statements.add(rubyCalls.get(0), CACHE_RUBY_THREADCONTEXT);
-        } else {
-            optimized = this;
-        }
-        return optimized;
-    }
-
-    @Override
-    public MethodLevelSyntaxElement replace(final MethodLevelSyntaxElement search,
-        final MethodLevelSyntaxElement replacement) {
-        final Closure result = new Closure();
-        for (final MethodLevelSyntaxElement element : this.statements) {
-            result.add(element.replace(search, replacement));
-        }
-        return result;
-    }
-
-    @Override
-    public int count(final MethodLevelSyntaxElement search) {
-        return statements.stream().mapToInt(child -> child.count(search)).sum();
     }
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/DatasetCompiler.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/DatasetCompiler.java
@@ -187,7 +187,7 @@ public final class DatasetCompiler {
 
     private static ValueSyntaxElement invokeOutput(final ValueSyntaxElement output,
         final MethodLevelSyntaxElement events) {
-        return output.call("multiReceive", ValueSyntaxElement.GET_RUBY_THREAD_CONTEXT, events);
+        return output.call("multiReceive", events);
     }
 
     private static Closure filterBody(final ValueSyntaxElement outputBuffer,
@@ -195,12 +195,7 @@ public final class DatasetCompiler {
         final FilterDelegatorExt plugin) {
         final ValueSyntaxElement filterField = fields.add(plugin);
         final Closure body = Closure.wrap(
-            buffer(
-                outputBuffer,
-                filterField.call(
-                    "multiFilter", ValueSyntaxElement.GET_RUBY_THREAD_CONTEXT, inputBuffer
-                )
-            )
+            buffer(outputBuffer, filterField.call("multiFilter", inputBuffer))
         );
         if (plugin.hasFlush()) {
             body.add(callFilterFlush(fields, outputBuffer, filterField, !plugin.periodicFlush()));
@@ -317,13 +312,7 @@ public final class DatasetCompiler {
             );
         }
         return SyntaxFactory.ifCondition(
-            condition,
-            Closure.wrap(
-                buffer(
-                    resultBuffer,
-                    filterPlugin.call(FLUSH, ValueSyntaxElement.GET_RUBY_THREAD_CONTEXT, flushArgs)
-                )
-            )
+            condition, Closure.wrap(buffer(resultBuffer, filterPlugin.call(FLUSH, flushArgs)))
         );
     }
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/EventCondition.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/EventCondition.java
@@ -31,6 +31,7 @@ import org.logstash.config.ir.expression.binary.Or;
 import org.logstash.config.ir.expression.binary.RegexEq;
 import org.logstash.config.ir.expression.unary.Not;
 import org.logstash.config.ir.expression.unary.Truthy;
+import org.logstash.execution.WorkerLoop;
 import org.logstash.ext.JrubyEventExtLibrary;
 
 /**
@@ -598,7 +599,7 @@ public interface EventCondition {
             public boolean fulfilled(final JrubyEventExtLibrary.RubyEvent event) {
                 final Object tomatch = event.getEvent().getUnconvertedField(field);
                 return tomatch instanceof RubyString &&
-                    !((RubyString) tomatch).match(RubyUtil.RUBY.getCurrentContext(), regex).isNil();
+                    !((RubyString) tomatch).match(WorkerLoop.THREAD_CONTEXT.get(), regex).isNil();
             }
         }
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
@@ -15,6 +15,7 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.RubyUtil;
+import org.logstash.execution.WorkerLoop;
 import org.logstash.ext.JrubyEventExtLibrary;
 import org.logstash.instrument.metrics.MetricKeys;
 import org.logstash.instrument.metrics.counter.LongCounter;
@@ -127,7 +128,8 @@ public final class FilterDelegatorExt extends RubyObject {
     }
 
     @SuppressWarnings("unchecked")
-    public RubyArray multiFilter(final ThreadContext context, final RubyArray batch) {
+    public RubyArray multiFilter(final RubyArray batch) {
+        final ThreadContext context = WorkerLoop.THREAD_CONTEXT.get();
         eventMetricIn.increment((long) batch.size());
         final long start = System.nanoTime();
         final RubyArray result = (RubyArray) filter.callMethod(context, "multi_filter", batch);
@@ -144,7 +146,8 @@ public final class FilterDelegatorExt extends RubyObject {
         return result;
     }
 
-    public RubyArray flush(final ThreadContext context, final RubyHash options) {
+    public RubyArray flush(final RubyHash options) {
+        final ThreadContext context = WorkerLoop.THREAD_CONTEXT.get();
         final IRubyObject newEvents = filter.callMethod(context, "flush", options);
         final RubyArray result;
         if (newEvents.isNil()) {

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/MethodLevelSyntaxElement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/MethodLevelSyntaxElement.java
@@ -9,20 +9,4 @@ interface MethodLevelSyntaxElement extends SyntaxElement {
      * Syntax element that generates {@code return null}.
      */
     MethodLevelSyntaxElement RETURN_NULL = SyntaxFactory.ret(SyntaxFactory.value("null"));
-
-    /**
-     * Replace any occurrences of {@code search} by {@code replacement} in this element.
-     * @param search Syntax element to replace
-     * @param replacement Replacement
-     * @return A copy of this element with the replacement applied
-     */
-    MethodLevelSyntaxElement replace(MethodLevelSyntaxElement search,
-        MethodLevelSyntaxElement replacement);
-
-    /**
-     * Count the number of occurrences of {@code search} in this element.
-     * @param search Element to count
-     * @return Number of occurrences
-     */
-    int count(MethodLevelSyntaxElement search);
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputDelegatorExt.java
@@ -14,6 +14,7 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.logstash.execution.WorkerLoop;
 import org.logstash.instrument.metrics.MetricKeys;
 import org.logstash.instrument.metrics.counter.LongCounter;
 
@@ -132,6 +133,10 @@ public final class OutputDelegatorExt extends RubyObject {
     @JRubyMethod
     public IRubyObject strategy(final ThreadContext context) {
         return strategy;
+    }
+
+    public IRubyObject multiReceive(final RubyArray events) {
+        return multiReceive(WorkerLoop.THREAD_CONTEXT.get(), events);
     }
 
     @JRubyMethod(name = "multi_receive")

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/SyntaxFactory.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/SyntaxFactory.java
@@ -41,38 +41,13 @@ final class SyntaxFactory {
         return new SyntaxFactory.Assignment(target, value);
     }
 
-    public static MethodLevelSyntaxElement definition(final VariableDefinition declaration,
-        final MethodLevelSyntaxElement value) {
-        return new SyntaxFactory.Assignment(declaration, value);
-    }
-
     public static ValueSyntaxElement cast(final Class<?> clazz, final ValueSyntaxElement argument) {
         return new SyntaxFactory.TypeCastStatement(clazz, argument);
     }
 
     public static MethodLevelSyntaxElement and(final ValueSyntaxElement left,
         final ValueSyntaxElement right) {
-        return new MethodLevelSyntaxElement() {
-
-            @Override
-            public String generateCode() {
-                return join("(", left.generateCode(), "&&", right.generateCode(), ")");
-            }
-
-            @Override
-            public MethodLevelSyntaxElement replace(final MethodLevelSyntaxElement search,
-                final MethodLevelSyntaxElement replacement) {
-                return and(
-                    (ValueSyntaxElement) left.replace(search, replacement),
-                    (ValueSyntaxElement) right.replace(search, replacement)
-                );
-            }
-
-            @Override
-            public int count(final MethodLevelSyntaxElement search) {
-                return left.count(search) + right.count(search);
-            }
-        };
+        return () -> join("(", left.generateCode(), "&&", right.generateCode(), ")");
     }
 
     public static ValueSyntaxElement ternary(final ValueSyntaxElement condition,
@@ -81,50 +56,15 @@ final class SyntaxFactory {
     }
 
     public static MethodLevelSyntaxElement not(final ValueSyntaxElement var) {
-        return new MethodLevelSyntaxElement() {
-            @Override
-            public MethodLevelSyntaxElement replace(final MethodLevelSyntaxElement search,
-                final MethodLevelSyntaxElement replacement) {
-                return not((ValueSyntaxElement) var.replace(search, replacement));
-            }
-
-            @Override
-            public int count(final MethodLevelSyntaxElement search) {
-                return var.count(search);
-            }
-
-            @Override
-            public String generateCode() {
-                return join("!(", var.generateCode(), ")");
-            }
-        };
+        return () -> join("!(", var.generateCode(), ")");
     }
 
     public static MethodLevelSyntaxElement forLoop(final VariableDefinition element,
         final MethodLevelSyntaxElement iterable, final Closure body) {
-        return new MethodLevelSyntaxElement() {
-            @Override
-            public MethodLevelSyntaxElement replace(final MethodLevelSyntaxElement search,
-                final MethodLevelSyntaxElement replacement) {
-                return forLoop(
-                    element, iterable.replace(search, replacement),
-                    (Closure) body.replace(search, replacement)
-                );
-            }
-
-            @Override
-            public int count(final MethodLevelSyntaxElement search) {
-                return iterable.count(search) + iterable.count(search);
-            }
-
-            @Override
-            public String generateCode() {
-                return join(
-                    "for (", element.generateCode(), " : ",
-                    iterable.generateCode(), ") {\n", body.generateCode(), "\n}"
-                );
-            }
-        };
+        return () -> join(
+            "for (", element.generateCode(), " : ",
+            iterable.generateCode(), ") {\n", body.generateCode(), "\n}"
+        );
     }
 
     public static MethodLevelSyntaxElement ifCondition(final MethodLevelSyntaxElement condition,
@@ -134,37 +74,13 @@ final class SyntaxFactory {
 
     public static MethodLevelSyntaxElement ifCondition(final MethodLevelSyntaxElement condition,
         final Closure left, final Closure right) {
-        return new MethodLevelSyntaxElement() {
-            @Override
-            public String generateCode() {
-                return join(
-                    "if(", condition.generateCode(), ") {\n", left.generateCode(),
-                    "\n}",
-                    right.empty() ? "" : join(" else {\n", right.generateCode(), "\n}")
-                );
-            }
-
-            @Override
-            public MethodLevelSyntaxElement replace(final MethodLevelSyntaxElement search,
-                final MethodLevelSyntaxElement replacement) {
-                return ifCondition(
-                    condition.replace(search, replacement),
-                    (Closure) left.replace(search, replacement),
-                    (Closure) right.replace(search, replacement)
-                );
-            }
-
-            @Override
-            public int count(final MethodLevelSyntaxElement search) {
-                return condition.count(search) + left.count(search) + right.count(search);
-            }
-        };
+        return () -> join(
+            "if(", condition.generateCode(), ") {\n", left.generateCode(),
+            "\n}",
+            right.empty() ? "" : join(" else {\n", right.generateCode(), "\n}")
+        );
     }
 
-    /**
-     * Syntax Element that cannot be replaced via
-     * {@link MethodLevelSyntaxElement#replace(MethodLevelSyntaxElement, MethodLevelSyntaxElement)}.
-     */
     public static final class IdentifierStatement implements ValueSyntaxElement {
 
         private final String value;
@@ -176,17 +92,6 @@ final class SyntaxFactory {
         @Override
         public String generateCode() {
             return value;
-        }
-
-        @Override
-        public MethodLevelSyntaxElement replace(final MethodLevelSyntaxElement search,
-            final MethodLevelSyntaxElement replacement) {
-            return this;
-        }
-
-        @Override
-        public int count(final MethodLevelSyntaxElement search) {
-            return this == search ? 1 : 0;
         }
     }
 
@@ -208,17 +113,6 @@ final class SyntaxFactory {
         public String generateCode() {
             return join(field.generateCode(), "=", value.generateCode());
         }
-
-        @Override
-        public MethodLevelSyntaxElement replace(final MethodLevelSyntaxElement search,
-            final MethodLevelSyntaxElement replacement) {
-            return new SyntaxFactory.Assignment(field, value.replace(search, replacement));
-        }
-
-        @Override
-        public int count(final MethodLevelSyntaxElement search) {
-            return value.count(search);
-        }
     }
 
     /**
@@ -235,17 +129,6 @@ final class SyntaxFactory {
         @Override
         public String generateCode() {
             return value;
-        }
-
-        @Override
-        public MethodLevelSyntaxElement replace(final MethodLevelSyntaxElement search,
-            final MethodLevelSyntaxElement replacement) {
-            return this.equals(search) ? replacement : this;
-        }
-
-        @Override
-        public int count(final MethodLevelSyntaxElement search) {
-            return this.equals(search) ? 1 : 0;
         }
 
         @Override
@@ -288,22 +171,6 @@ final class SyntaxFactory {
         }
 
         @Override
-        public MethodLevelSyntaxElement replace(final MethodLevelSyntaxElement search,
-            final MethodLevelSyntaxElement replacement) {
-            return this.equals(search) ? replacement : new SyntaxFactory.MethodCallReturnValue(
-                instance.replace(search, replacement), method,
-                args.stream().map(var -> var.replace(search, replacement))
-                    .toArray(ValueSyntaxElement[]::new)
-            );
-        }
-
-        @Override
-        public int count(final MethodLevelSyntaxElement search) {
-            return this.equals(search) ? 1 :
-                instance.count(search) + args.stream().mapToInt(v -> v.count(search)).sum();
-        }
-
-        @Override
         public String generateCode() {
             return join(
                 instance.generateCode(), ".", method, "(", String.join(
@@ -340,19 +207,6 @@ final class SyntaxFactory {
         }
 
         @Override
-        public MethodLevelSyntaxElement replace(final MethodLevelSyntaxElement search,
-            final MethodLevelSyntaxElement replacement) {
-            return new SyntaxFactory.TypeCastStatement(
-                clazz, (ValueSyntaxElement) argument.replace(search, replacement)
-            );
-        }
-
-        @Override
-        public int count(final MethodLevelSyntaxElement search) {
-            return argument.count(search);
-        }
-
-        @Override
         public String generateCode() {
             return join("((", clazz.getName(), ")", argument.generateCode(), ")");
         }
@@ -369,17 +223,6 @@ final class SyntaxFactory {
         @Override
         public String generateCode() {
             return join("return ", value.generateCode());
-        }
-
-        @Override
-        public MethodLevelSyntaxElement replace(final MethodLevelSyntaxElement search,
-            final MethodLevelSyntaxElement replacement) {
-            return new SyntaxFactory.ReturnStatement(value.replace(search, replacement));
-        }
-
-        @Override
-        public int count(final MethodLevelSyntaxElement search) {
-            return value.count(search);
         }
     }
 
@@ -404,21 +247,6 @@ final class SyntaxFactory {
                 "(", condition.generateCode(), " ? ", left.generateCode(), " : ",
                 right.generateCode(), ")"
             );
-        }
-
-        @Override
-        public MethodLevelSyntaxElement replace(final MethodLevelSyntaxElement search,
-            final MethodLevelSyntaxElement replacement) {
-            return new SyntaxFactory.TernaryStatement(
-                (ValueSyntaxElement) condition.replace(search, replacement),
-                (ValueSyntaxElement) left.replace(search, replacement),
-                (ValueSyntaxElement) right.replace(search, replacement)
-            );
-        }
-
-        @Override
-        public int count(final MethodLevelSyntaxElement search) {
-            return left.count(search) + right.count(search);
         }
     }
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/ValueSyntaxElement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/ValueSyntaxElement.java
@@ -1,19 +1,9 @@
 package org.logstash.config.ir.compiler;
 
-import org.jruby.Ruby;
-import org.logstash.RubyUtil;
-
 /**
  * An instance that can methods can be invoked on.
  */
 interface ValueSyntaxElement extends MethodLevelSyntaxElement {
-
-    /**
-     * Return of the method call to {@link Ruby#getCurrentContext()} that has the current Ruby
-     * thread-context as its return value.
-     */
-    ValueSyntaxElement GET_RUBY_THREAD_CONTEXT =
-        SyntaxFactory.constant(RubyUtil.class, "RUBY").call("getCurrentContext");
 
     /**
      * Call method on instance.

--- a/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
+++ b/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
@@ -4,10 +4,20 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.LongAdder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jruby.runtime.ThreadContext;
+import org.logstash.RubyUtil;
 import org.logstash.config.ir.CompiledPipeline;
 import org.logstash.config.ir.compiler.Dataset;
 
 public final class WorkerLoop implements Runnable {
+
+    /**
+     * Hard Reference to the Ruby {@link ThreadContext} for this thread. It is ok to keep
+     * a hard reference instead of Ruby's weak references here since we can expect worker threads
+     * to be runnable most of the time.
+     */
+    public static final ThreadLocal<ThreadContext> THREAD_CONTEXT =
+        ThreadLocal.withInitial(RubyUtil.RUBY::getCurrentContext);
 
     private static final Logger LOGGER = LogManager.getLogger(WorkerLoop.class);
 

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/DatasetCompilerTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/DatasetCompilerTest.java
@@ -2,7 +2,6 @@ package org.logstash.config.ir.compiler;
 
 import java.util.Collections;
 import org.jruby.RubyArray;
-import org.jruby.runtime.ThreadContext;
 import org.junit.Test;
 import org.logstash.Event;
 import org.logstash.FieldReference;
@@ -49,29 +48,5 @@ public final class DatasetCompilerTest {
         );
         assertThat(left.compute(batch, false, false).size(), is(1));
         assertThat(right.compute(batch, false, false).size(), is(1));
-    }
-
-    @Test
-    public void optimizesRedundantRubyThreadContext() {
-        assertThat(
-            Closure.wrap(
-                SyntaxFactory.definition(
-                    new VariableDefinition(ThreadContext.class, "context1"),
-                    ValueSyntaxElement.GET_RUBY_THREAD_CONTEXT
-                ),
-                SyntaxFactory.definition(
-                    new VariableDefinition(ThreadContext.class, "context2"),
-                    ValueSyntaxElement.GET_RUBY_THREAD_CONTEXT
-                )
-            ).generateCode(),
-            is(
-                String.join(
-                    "\n",
-                    "org.jruby.runtime.ThreadContext context=org.logstash.RubyUtil.RUBY.getCurrentContext();",
-                    "org.jruby.runtime.ThreadContext context1=context;",
-                    "org.jruby.runtime.ThreadContext context2=context;"
-                )
-            )
-        );
     }
 }

--- a/logstash-core/src/test/java/org/logstash/ext/JrubyMemoryReadClientExtTest.java
+++ b/logstash-core/src/test/java/org/logstash/ext/JrubyMemoryReadClientExtTest.java
@@ -6,10 +6,9 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import org.jruby.RubyHash;
 import org.jruby.runtime.ThreadContext;
-import org.jruby.runtime.builtin.IRubyObject;
 import org.junit.Test;
-import org.logstash.RubyUtil;
 import org.logstash.execution.QueueBatch;
+import org.logstash.execution.WorkerLoop;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -25,7 +24,7 @@ public final class JrubyMemoryReadClientExtTest {
             new ArrayBlockingQueue<>(10);
         final JrubyMemoryReadClientExt client =
             JrubyMemoryReadClientExt.create(queue, 5, 50);
-        final ThreadContext context = RubyUtil.RUBY.getCurrentContext();
+        final ThreadContext context = WorkerLoop.THREAD_CONTEXT.get();
         final QueueBatch batch = client.readBatch();
         final RubyHash inflight = (RubyHash) client.rubyGetInflightBatches(context);
         assertThat(inflight.size(), is(1));


### PR DESCRIPTION
I realized we can keep Ruby's thread context strongly referenced in workers since those threads are always hot and have a clearly defined lifecycle.

* This allows for a massive simplification for the invocation of filters and outputs from the Java execution
   * Also makes the filters and outputs look the same way the new Java API will look functionally :)
   * Allows for the removal of a lot of optimizations around getting a hold of the thread context in the generated Java execution code!

---------------------

PS: I know that some of the remaining syntax generation code may be a little redundant now  as well. Will keep cleaning this up further in subsequent PRs. This one is large enough already IMO :)