### PR TITLE
 #8888: Fix Logstash::Util.deep_clone for Timestamp

### DIFF
--- a/logstash-core/lib/logstash/util.rb
+++ b/logstash-core/lib/logstash/util.rb
@@ -198,6 +198,8 @@ module LogStash::Util
       o.clone
     when String
       o.clone #need to keep internal state e.g. frozen
+    when LogStash::Timestamp
+      o.clone
     else
       Marshal.load(Marshal.dump(o))
     end

--- a/logstash-core/spec/logstash/util_spec.rb
+++ b/logstash-core/spec/logstash/util_spec.rb
@@ -43,6 +43,13 @@ describe LogStash::Util do
     end
   end
 
+  context "deep_clone" do
+    it "correctly clones a LogStash::Timestamp" do
+      timestamp = LogStash::Timestamp.now
+      expect(LogStash::Util.deep_clone(timestamp).inspect).to eq(timestamp.inspect)
+    end
+  end
+
   describe ".class_name" do
     context "when the class is a top level class" do
       let(:klass) { ClassNameTest.new }


### PR DESCRIPTION
Fixes #8888 by using cloning instead of marshaling for the timestamp since the Java field in the timestamp doesn't get correctly marshaled.