### PR TITLE
BUILD: Stabilize Integration Tests

### DIFF
--- a/qa/integration/specs/01_logstash_bin_smoke_spec.rb
+++ b/qa/integration/specs/01_logstash_bin_smoke_spec.rb
@@ -53,7 +53,7 @@ describe "Test Logstash instance" do
       FileUtils.mkdir_p(tmp_data_path)
       @ls1.spawn_logstash("-f", config1, "--path.data", tmp_data_path)
       sleep(0.1) until File.exist?(file_config1) && File.size(file_config1) > 0 # Everything is started successfully at this point
-      expect(is_port_open?(9600)).to be true
+      @ls1.wait_for_logstash
 
       @ls2.spawn_logstash("-f", config2, "--path.data", tmp_data_path)
       try(num_retries) do
@@ -82,7 +82,7 @@ describe "Test Logstash instance" do
       if @ls2.settings.feature_flag != "persistent_queues"
         @ls1.spawn_logstash("-f", config1)
         sleep(0.1) until File.exist?(file_config1) && File.size(file_config1) > 0 # Everything is started successfully at this point
-        expect(is_port_open?(9600)).to be true
+        @ls1.wait_for_logstash
 
         puts "will try to start the second LS instance on 9601"
 

--- a/qa/integration/specs/secret_store_spec.rb
+++ b/qa/integration/specs/secret_store_spec.rb
@@ -43,7 +43,6 @@ describe "Test that Logstash" do
     test_env["LOGSTASH_KEYSTORE_PASS"] = "keystore_pa9454w3rd"
     @logstash.env_variables = test_env
     @logstash.start_background_with_config_settings(config_to_temp_file(@fixture.config), settings_dir)
-    @logstash.wait_for_logstash
     Stud.try(num_retries.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
       # 10 generated outputs, mypath, and the tags all come from the secret store
       expect(IO.read(File.join(File.join(test_path, "mypath"), "logstash_secretstore_test.output")).gsub("\n", "")).to eq("Hello world! mytag1,mytag2.mytag3" * 10)
@@ -54,7 +53,6 @@ describe "Test that Logstash" do
     test_env["LOGSTASH_KEYSTORE_PASS"] = "keystore_pa9454w3rd"
     @logstash.env_variables = test_env
     @logstash.spawn_logstash("-e", "input {heartbeat {}} output { }", "--path.settings", settings_dir)
-    @logstash.wait_for_logstash
     Stud.try(num_retries.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
       result = @logstash.monitoring_api.node_stats rescue nil
       expect(result).not_to be_nil


### PR DESCRIPTION
Fixes build instabilities experienced in #9409:

* The change in the open port check makes sure that we actually wait for the open port (it comes up a few ms after the output file is generated, so with some bad luck in timing we fail those 2 tests)
* Remove the check for the open port (this always failed in the past, but silently) for checking the behaviour of finite pipelines (with some bad timing in our 1s waits between checks for the port we can miss the open port window) => no need for that check there anyways functionality is tested by other means