### PR TITLE
CLEANUP: Remove unused methods from FilterDelegatorExt

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
@@ -117,16 +117,6 @@ public final class FilterDelegatorExt extends RubyObject {
         return id;
     }
 
-    @JRubyMethod(name = "metric_events")
-    public IRubyObject metricEvents(final ThreadContext context) {
-        return metricEvents;
-    }
-
-    @JRubyMethod
-    public IRubyObject strategy(final ThreadContext context) {
-        return filter;
-    }
-
     @SuppressWarnings("unchecked")
     public RubyArray multiFilter(final RubyArray batch) {
         final ThreadContext context = WorkerLoop.THREAD_CONTEXT.get();

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/VariableDefinition.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/VariableDefinition.java
@@ -1,7 +1,6 @@
 package org.logstash.config.ir.compiler;
 
 import org.jruby.internal.runtime.methods.DynamicMethod;
-import org.jruby.runtime.builtin.IRubyObject;
 
 /**
  * Definition of a variable.
@@ -49,9 +48,7 @@ final class VariableDefinition implements SyntaxElement {
      */
     private static Class<?> safeType(final Class<?> clazz) {
         final Class<?> safe;
-        if (clazz.getSimpleName().contains("JavaFilterDelegator")) {
-            safe = IRubyObject.class;
-        } else if (EventCondition.class.isAssignableFrom(clazz)) {
+        if (EventCondition.class.isAssignableFrom(clazz)) {
             safe = EventCondition.class;
         } else if (DynamicMethod.class.isAssignableFrom(clazz)) {
             safe = DynamicMethod.class;


### PR DESCRIPTION
These two I accidentally copied over from `OutputDelegatorExt`, they're not on the original Ruby class this was ported from and just dead code.
Also removed a hack for this class from this compiler that was only necessary in the past when invoking Ruby methods on it.