### PR TITLE
MINOR: Cleanup redundant casts and other minor points in JRuby extensions

### DIFF
--- a/logstash-core/src/main/java/org/logstash/RubyUtil.java
+++ b/logstash-core/src/main/java/org/logstash/RubyUtil.java
@@ -120,8 +120,9 @@ public final class RubyUtil {
         OUTPUT_STRATEGY_SINGLE.defineAnnotatedMethods(OutputStrategyExt.SingleOutputStrategyExt.class);
         OUTPUT_STRATEGY_LEGACY.defineAnnotatedMethods(OutputStrategyExt.LegacyOutputStrategyExt.class);
         final OutputStrategyExt.OutputStrategyRegistryExt outputStrategyRegistry =
-            (OutputStrategyExt.OutputStrategyRegistryExt) OutputStrategyExt.OutputStrategyRegistryExt
-                .instance(RUBY.getCurrentContext(), OUTPUT_DELEGATOR_STRATEGIES);
+            OutputStrategyExt.OutputStrategyRegistryExt.instance(
+                RUBY.getCurrentContext(), OUTPUT_DELEGATOR_STRATEGIES
+            );
         outputStrategyRegistry.register(
             RUBY.getCurrentContext(), RUBY.newSymbol("shared"), OUTPUT_STRATEGY_SHARED
         );

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputDelegatorExt.java
@@ -62,14 +62,13 @@ public final class OutputDelegatorExt extends RubyObject {
         eventMetricTime = LongCounter.fromRubyBase(
             metricEvents, MetricKeys.DURATION_IN_MILLIS_KEY
         );
-        strategy = (OutputStrategyExt.AbstractOutputStrategyExt) ((RubyClass)
-            ((OutputStrategyExt.OutputStrategyRegistryExt) arguments[3])
-                .classFor(context, concurrency(context))
-        ).newInstance(
-            context,
-            new IRubyObject[]{outputClass, namespacedMetric, arguments[2], args},
-            Block.NULL_BLOCK
-        );
+        strategy = (OutputStrategyExt.AbstractOutputStrategyExt) (
+            (OutputStrategyExt.OutputStrategyRegistryExt) arguments[3])
+            .classFor(context, concurrency(context)).newInstance(
+                context,
+                new IRubyObject[]{outputClass, namespacedMetric, arguments[2], args},
+                Block.NULL_BLOCK
+            );
         return this;
     }
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
@@ -24,7 +24,7 @@ public final class OutputStrategyExt {
     @JRubyClass(name = "OutputDelegatorStrategyRegistry")
     public static final class OutputStrategyRegistryExt extends RubyObject {
 
-        private static OutputStrategyRegistryExt instance;
+        private static OutputStrategyExt.OutputStrategyRegistryExt instance;
 
         private RubyHash map;
 
@@ -33,10 +33,10 @@ public final class OutputStrategyExt {
         }
 
         @JRubyMethod(meta = true)
-        public static synchronized IRubyObject instance(final ThreadContext context,
-            final IRubyObject recv) {
+        public static synchronized OutputStrategyExt.OutputStrategyRegistryExt instance(
+            final ThreadContext context, final IRubyObject recv) {
             if (instance == null) {
-                instance = new OutputStrategyRegistryExt(
+                instance = new OutputStrategyExt.OutputStrategyRegistryExt(
                     context.runtime, RubyUtil.OUTPUT_STRATEGY_REGISTRY
                 );
                 instance.init(context);
@@ -68,7 +68,7 @@ public final class OutputStrategyExt {
 
         @JRubyMethod(name = "class_for")
         @SuppressWarnings("unchecked")
-        public IRubyObject classFor(final ThreadContext context, final IRubyObject type) {
+        public RubyClass classFor(final ThreadContext context, final IRubyObject type) {
             final IRubyObject klass = map.op_aref(context, type);
             if (!klass.isTrue()) {
                 throw new IllegalArgumentException(
@@ -80,7 +80,7 @@ public final class OutputStrategyExt {
                     )
                 );
             }
-            return klass;
+            return (RubyClass) klass;
         }
     }
 
@@ -192,7 +192,7 @@ public final class OutputStrategyExt {
 
         private IRubyObject output;
 
-        public SimpleAbstractOutputStrategyExt(final Ruby runtime, final RubyClass metaClass) {
+        protected SimpleAbstractOutputStrategyExt(final Ruby runtime, final RubyClass metaClass) {
             super(runtime, metaClass);
         }
 

--- a/logstash-core/src/main/java/org/logstash/execution/MemoryReadBatch.java
+++ b/logstash-core/src/main/java/org/logstash/execution/MemoryReadBatch.java
@@ -13,10 +13,6 @@ public final class MemoryReadBatch implements QueueBatch {
 
     private final LinkedHashSet<IRubyObject> events;
 
-    public MemoryReadBatch() {
-        this(new LinkedHashSet<>());
-    }
-
     public MemoryReadBatch(final LinkedHashSet<IRubyObject> events) {
         this.events = events;
     }

--- a/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBase.java
+++ b/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBase.java
@@ -22,25 +22,27 @@ import java.util.concurrent.TimeUnit;
 @JRubyClass(name = "QueueReadClientBase")
 public abstract class QueueReadClientBase extends RubyObject implements QueueReadClient {
 
-    protected final ConcurrentHashMap<Long, QueueBatch> inflightBatches =
-            new ConcurrentHashMap<>();
-    protected final ConcurrentHashMap<Long, Long> inflightClocks = new ConcurrentHashMap<>();
     protected int batchSize = 125;
     protected long waitForNanos = 50 * 1000 * 1000; // 50 millis to nanos
     protected long waitForMillis = 50;
-    protected LongCounter eventMetricOut;
-    protected LongCounter eventMetricFiltered;
-    protected LongCounter eventMetricTime;
-    protected LongCounter pipelineMetricOut;
-    protected LongCounter pipelineMetricFiltered;
-    protected LongCounter pipelineMetricTime;
+
+    private final ConcurrentHashMap<Long, QueueBatch> inflightBatches =
+            new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Long, Long> inflightClocks = new ConcurrentHashMap<>();
+
+    private LongCounter eventMetricOut;
+    private LongCounter eventMetricFiltered;
+    private LongCounter eventMetricTime;
+    private LongCounter pipelineMetricOut;
+    private LongCounter pipelineMetricFiltered;
+    private LongCounter pipelineMetricTime;
 
     protected QueueReadClientBase(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);
     }
 
     @JRubyMethod(name = "inflight_batches")
-    public IRubyObject rubyGetInflightBatches(final ThreadContext context) {
+    public RubyHash rubyGetInflightBatches(final ThreadContext context) {
         final RubyHash result = RubyHash.newHash(context.runtime);
         result.putAll(inflightBatches);
         return result;

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyAckedWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyAckedWriteClientExt.java
@@ -20,7 +20,7 @@ public final class JrubyAckedWriteClientExt extends RubyObject {
     private AtomicBoolean closed = new AtomicBoolean();
 
     @JRubyMethod(meta = true, required = 2)
-    public static IRubyObject create(final ThreadContext context, IRubyObject recv,
+    public static JrubyAckedWriteClientExt create(final ThreadContext context, IRubyObject recv,
         final IRubyObject queue, final IRubyObject closed) {
         return new JrubyAckedWriteClientExt(
             context.runtime, RubyUtil.ACKED_WRITE_CLIENT_CLASS,

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
@@ -77,7 +77,7 @@ public final class JrubyTimestampExtLibrary {
         }
 
         @JRubyMethod(name = "time")
-        public IRubyObject ruby_time(ThreadContext context)
+        public RubyTime ruby_time(ThreadContext context)
         {
             return RubyTime.newTime(context.runtime, this.timestamp.getTime());
         }
@@ -225,7 +225,7 @@ public final class JrubyTimestampExtLibrary {
         @JRubyMethod(name = "<=>", required = 1)
         public IRubyObject op_cmp(final ThreadContext context, final IRubyObject other) {
             if (other instanceof JrubyTimestampExtLibrary.RubyTimestamp) {
-                return ((RubyTime) ruby_time(context)).op_cmp(
+                return ruby_time(context).op_cmp(
                     context, ((JrubyTimestampExtLibrary.RubyTimestamp) other).ruby_time(context)
                 );
             }

--- a/logstash-core/src/test/java/org/logstash/ext/JrubyMemoryReadClientExtTest.java
+++ b/logstash-core/src/test/java/org/logstash/ext/JrubyMemoryReadClientExtTest.java
@@ -1,7 +1,6 @@
 package org.logstash.ext;
 
 import java.io.IOException;
-import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import org.jruby.RubyHash;
@@ -26,10 +25,10 @@ public final class JrubyMemoryReadClientExtTest {
             JrubyMemoryReadClientExt.create(queue, 5, 50);
         final ThreadContext context = WorkerLoop.THREAD_CONTEXT.get();
         final QueueBatch batch = client.readBatch();
-        final RubyHash inflight = (RubyHash) client.rubyGetInflightBatches(context);
+        final RubyHash inflight = client.rubyGetInflightBatches(context);
         assertThat(inflight.size(), is(1));
         assertThat(inflight.get(Thread.currentThread().getId()), is(batch));
         client.closeBatch(batch);
-        assertThat(((Map<?, ?>) client.rubyGetInflightBatches(context)).size(), is(0));
+        assertThat(client.rubyGetInflightBatches(context).size(), is(0));
     }
 }


### PR DESCRIPTION
Trivial stuff:

* `@JRubyMethod` does not force us to return `IRubyObject`, subtypes of it are fine too -> constrained the return type in a few spots I found and removed redundant casts downstream accordingly
* Removed unused constructor for `MemoryReadBatch`
* Lowered visibility for a few fields where it was too high