### PR TITLE
[DOCS] Fixes broken link

### DIFF
--- a/x-pack/docs/en/management/centralized-pipelines.asciidoc
+++ b/x-pack/docs/en/management/centralized-pipelines.asciidoc
@@ -10,7 +10,7 @@ with the basic license. If you want to try all of the features, you can start a
 30-day trial. At the end of the trial period, you can purchase a subscription to
 keep using the full functionality of the {xpack} components. For more
 information, see https://www.elastic.co/subscriptions and
-https://www.elastic.co/guide/en/x-pack/master/license-management.html[License
+{stack-ov}/license-management.html[License
 Management].
 
 From within the pipeline


### PR DESCRIPTION
This PR fixes a broken link to the License Management page. 