### PR TITLE
 #9478: Fix error from repeatedly trying to register the same setting in the runner

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -209,6 +209,10 @@ class LogStash::Runner < Clamp::StrictCommand
     I18n.t("logstash.runner.flag.quiet"),
     :new_flag => "log.level", :new_value => "error"
 
+  # We configure the registry and load any plugin that can register hooks
+  # with logstash, this needs to be done before any operation.
+  LogStash::PLUGIN_REGISTRY.setup!
+
   attr_reader :agent, :settings, :source_loader
   attr_accessor :bootstrap_checks
 
@@ -264,10 +268,6 @@ class LogStash::Runner < Clamp::StrictCommand
 
     # Add local modules to the registry before everything else
     LogStash::Modules::Util.register_local_modules(LogStash::Environment::LOGSTASH_HOME)
-
-    # We configure the registry and load any plugin that can register hooks
-    # with logstash, this need to be done before any operation.
-    LogStash::PLUGIN_REGISTRY.setup!
 
     @dispatcher = LogStash::EventDispatcher.new(self)
     LogStash::PLUGIN_REGISTRY.hooks.register_emitter(self.class, @dispatcher)


### PR DESCRIPTION
Fixes #9478 the call to `LogStash::PLUGIN_REGISTRY.setup!` can only be done once during the lifetime of the `Ruby` runtime. We did it in the non-static context of `runner#execute` => error when repeatedly invoking that method in specs as seen in #9478 => moved the call to the static context so it only happens once for the lifetime of the static `LogStash::PLUGIN_REGISTRY`.