### PR TITLE
JAVAFICATION: ExecutionContext ported to Java

### DIFF
--- a/logstash-core/lib/logstash/execution_context.rb
+++ b/logstash-core/lib/logstash/execution_context.rb
@@ -1,19 +1,2 @@
-# encoding: utf-8
-
-module LogStash
-  class ExecutionContext
-    attr_reader :pipeline, :agent, :dlq_writer
-
-    def initialize(pipeline, agent, plugin_id, plugin_type, dlq_writer)
-      @pipeline = pipeline
-      @agent = agent
-      @plugin_id = plugin_id
-      @plugin_type = plugin_type
-      @dlq_writer = LogStash::Util::PluginDeadLetterQueueWriter.new(dlq_writer, @plugin_id, @plugin_type)
-    end
-
-    def pipeline_id
-      @pipeline.pipeline_id
-    end
-  end
-end
+# The contents of this file have been ported to Java. It is included for for compatibility
+# with plugins that directly include it.

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -19,7 +19,6 @@ require "logstash/filter_delegator"
 require "logstash/queue_factory"
 require "logstash/plugins/plugin_factory"
 require "logstash/compiler"
-require "logstash/execution_context"
 require "securerandom"
 
 java_import org.logstash.common.DeadLetterQueueFactory

--- a/logstash-core/spec/logstash/execution_context_spec.rb
+++ b/logstash-core/spec/logstash/execution_context_spec.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 require "spec_helper"
-require "logstash/execution_context"
 
 describe LogStash::ExecutionContext do
   let(:pipeline) { double("pipeline") }

--- a/logstash-core/spec/logstash/filter_delegator_spec.rb
+++ b/logstash-core/spec/logstash/filter_delegator_spec.rb
@@ -3,7 +3,6 @@ require "spec_helper"
 require "logstash/filter_delegator"
 require "logstash/instrument/null_metric"
 require "logstash/event"
-require "logstash/execution_context"
 require "support/shared_contexts"
 
 describe LogStash::FilterDelegator do

--- a/logstash-core/spec/logstash/inputs/base_spec.rb
+++ b/logstash-core/spec/logstash/inputs/base_spec.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 require "spec_helper"
-require "logstash/execution_context"
 require "logstash/inputs/base"
 require "support/shared_contexts"
 
@@ -90,15 +89,15 @@ describe "LogStash::Inputs::Base#decorate" do
     let(:input) do
       LogStash::Inputs::NOOP.new("add_field" => {"field" => ["value1", "value2"], "field2" => "value"})
     end
-    
+
     let(:cloned) do
       input.clone
     end
-    
+
     it "should clone the codec when cloned" do
       expect(input.codec).not_to eq(cloned.codec)
-    end  
-    
+    end
+
     it "should preserve codec params" do
       expect(input.codec.params).to eq(cloned.codec.params)
     end

--- a/logstash-core/spec/logstash/java_filter_delegator_spec.rb
+++ b/logstash-core/spec/logstash/java_filter_delegator_spec.rb
@@ -3,7 +3,6 @@ require "spec_helper"
 require "logstash/filter_delegator"
 require "logstash/instrument/null_metric"
 require "logstash/event"
-require "logstash/execution_context"
 require "support/shared_contexts"
 
 java_import org.logstash.RubyUtil

--- a/logstash-core/spec/logstash/output_delegator_spec.rb
+++ b/logstash-core/spec/logstash/output_delegator_spec.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/execution_context"
 require "spec_helper"
 require "support/shared_contexts"
 

--- a/logstash-core/spec/logstash/outputs/base_spec.rb
+++ b/logstash-core/spec/logstash/outputs/base_spec.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 require "spec_helper"
 require "logstash/outputs/base"
-require "logstash/execution_context"
 require "support/shared_contexts"
 
 # use a dummy NOOP output to test Outputs::Base
@@ -20,7 +19,7 @@ end
 
 class LogStash::Outputs::NOOPShared < ::LogStash::Outputs::Base
   concurrency :shared
-  
+
   def register; end
 end
 
@@ -30,7 +29,7 @@ end
 
 class LogStash::Outputs::NOOPMultiReceiveEncoded < ::LogStash::Outputs::Base
   concurrency :single
-  
+
   def register; end
 
   def multi_receive_encoded(events_and_encoded)
@@ -38,12 +37,12 @@ class LogStash::Outputs::NOOPMultiReceiveEncoded < ::LogStash::Outputs::Base
 end
 
 describe "LogStash::Outputs::Base#new" do
-  let(:params) { {} }  
+  let(:params) { {} }
   subject(:instance) { klass.new(params.dup) }
 
   context "single" do
     let(:klass) { LogStash::Outputs::NOOPSingle }
-    
+
     it "should instantiate cleanly" do
       params = { "dummy_option" => "potatoes", "codec" => "json", "workers" => 2 }
       worker_params = params.dup; worker_params["workers"] = 1
@@ -58,7 +57,7 @@ describe "LogStash::Outputs::Base#new" do
 
   context "shared" do
     let(:klass) { LogStash::Outputs::NOOPShared }
-    
+
     it "should set concurrency correctly" do
       expect(subject.concurrency).to eq(:shared)
     end
@@ -66,7 +65,7 @@ describe "LogStash::Outputs::Base#new" do
 
   context "legacy" do
     let(:klass) { LogStash::Outputs::NOOPLegacy }
-    
+
     it "should set concurrency correctly" do
       expect(subject.concurrency).to eq(:legacy)
     end
@@ -105,16 +104,16 @@ describe "LogStash::Outputs::Base#new" do
   describe "dispatching multi_receive" do
     let(:event) { double("event") }
     let(:events) { [event] }
-    
+
     context "with multi_receive_encoded" do
       let(:klass) { LogStash::Outputs::NOOPMultiReceiveEncoded }
       let(:codec) { double("codec") }
       let(:encoded) { double("encoded") }
-      
+
       before do
         allow(codec).to receive(:multi_encode).with(events).and_return(encoded)
         allow(instance).to receive(:codec).and_return(codec)
-        allow(instance).to receive(:multi_receive_encoded)        
+        allow(instance).to receive(:multi_receive_encoded)
         instance.multi_receive(events)
       end
 

--- a/logstash-core/spec/logstash/pipeline_dlq_commit_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_dlq_commit_spec.rb
@@ -75,9 +75,6 @@ describe LogStash::Pipeline do
     let(:pipeline_id) { "test-dlq" }
 
     it "retrieves proper pipeline-level DLQ writer" do
-      expect(LogStash::Util::PluginDeadLetterQueueWriter).to receive(:new).with(anything, "input_id", "singlegenerator").and_call_original
-      expect(LogStash::Util::PluginDeadLetterQueueWriter).to receive(:new).with(anything, "filter_id", "dlq_commit").and_call_original
-      expect(LogStash::Util::PluginDeadLetterQueueWriter).to receive(:new).with(anything, "output_id", "dummyoutput").and_call_original
       expect_any_instance_of(org.logstash.common.io.DeadLetterQueueWriter).to receive(:close).and_call_original
       subject.run
       dlq_path = java.nio.file.Paths.get(pipeline_settings_obj.get("path.dead_letter_queue"), pipeline_id)
@@ -94,9 +91,6 @@ describe LogStash::Pipeline do
     let(:pipeline_id) { "test-without-dlq" }
 
     it "does not write to the DLQ" do
-      expect(LogStash::Util::PluginDeadLetterQueueWriter).to receive(:new).with(anything, "input_id", "singlegenerator").and_call_original
-      expect(LogStash::Util::PluginDeadLetterQueueWriter).to receive(:new).with(anything, "filter_id", "dlq_commit").and_call_original
-      expect(LogStash::Util::PluginDeadLetterQueueWriter).to receive(:new).with(anything, "output_id", "dummyoutput").and_call_original
       expect(LogStash::Util::DummyDeadLetterQueueWriter).to receive(:new).and_call_original
       expect_any_instance_of(LogStash::Util::DummyDeadLetterQueueWriter).to receive(:close).and_call_original
       subject.run

--- a/logstash-core/spec/logstash/plugin_spec.rb
+++ b/logstash-core/spec/logstash/plugin_spec.rb
@@ -5,7 +5,6 @@ require "logstash/outputs/base"
 require "logstash/codecs/base"
 require "logstash/inputs/base"
 require "logstash/filters/base"
-require "logstash/execution_context"
 require "support/shared_contexts"
 
 describe LogStash::Plugin do
@@ -319,7 +318,7 @@ describe LogStash::Plugin do
         end
       end
 
-      subject { plugin.new(config) } 
+      subject { plugin.new(config) }
 
       context "when no metric is set to the plugin" do
         context "when `enable_metric` is TRUE" do

--- a/logstash-core/src/main/java/org/logstash/RubyUtil.java
+++ b/logstash-core/src/main/java/org/logstash/RubyUtil.java
@@ -10,11 +10,12 @@ import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ObjectAllocator;
 import org.logstash.ackedqueue.ext.JRubyAckedQueueExt;
 import org.logstash.ackedqueue.ext.JRubyWrappedAckedQueueExt;
-import org.logstash.common.BufferedTokenizerExt;
 import org.logstash.common.AbstractDeadLetterQueueWriterExt;
+import org.logstash.common.BufferedTokenizerExt;
 import org.logstash.config.ir.compiler.FilterDelegatorExt;
 import org.logstash.config.ir.compiler.OutputDelegatorExt;
 import org.logstash.config.ir.compiler.OutputStrategyExt;
+import org.logstash.execution.ExecutionContextExt;
 import org.logstash.execution.QueueReadClientBase;
 import org.logstash.ext.JRubyWrappedWriteClientExt;
 import org.logstash.ext.JrubyAckedReadClientExt;
@@ -104,6 +105,8 @@ public final class RubyUtil {
     public static final RubyClass DUMMY_DLQ_WRITER_CLASS;
 
     public static final RubyClass PLUGIN_DLQ_WRITER_CLASS;
+
+    public static final RubyClass EXECUTION_CONTEXT_CLASS;
 
     /**
      * Logstash Ruby Module.
@@ -208,6 +211,9 @@ public final class RubyUtil {
         );
         outputStrategyRegistry.register(
             RUBY.getCurrentContext(), RUBY.newSymbol("single"), OUTPUT_STRATEGY_SINGLE
+        );
+        EXECUTION_CONTEXT_CLASS = setupLogstashClass(
+            ExecutionContextExt::new, ExecutionContextExt.class
         );
         RUBY_TIMESTAMP_CLASS = setupLogstashClass(
             JrubyTimestampExtLibrary.RubyTimestamp::new, JrubyTimestampExtLibrary.RubyTimestamp.class

--- a/logstash-core/src/main/java/org/logstash/common/AbstractDeadLetterQueueWriterExt.java
+++ b/logstash-core/src/main/java/org/logstash/common/AbstractDeadLetterQueueWriterExt.java
@@ -130,8 +130,8 @@ public abstract class AbstractDeadLetterQueueWriterExt extends RubyObject {
         }
 
         @JRubyMethod
-        public IRubyObject initialize(final ThreadContext context,
-            final IRubyObject innerWriter, final IRubyObject pluginId,
+        public AbstractDeadLetterQueueWriterExt.PluginDeadLetterQueueWriterExt initialize(
+            final ThreadContext context, final IRubyObject innerWriter, final IRubyObject pluginId,
             final IRubyObject pluginType) {
             writerWrapper = innerWriter;
             if (writerWrapper.getJavaClass().equals(DeadLetterQueueWriter.class)) {

--- a/logstash-core/src/main/java/org/logstash/execution/ExecutionContextExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/ExecutionContextExt.java
@@ -1,0 +1,56 @@
+package org.logstash.execution;
+
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.RubyObject;
+import org.jruby.anno.JRubyClass;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.logstash.RubyUtil;
+import org.logstash.common.AbstractDeadLetterQueueWriterExt;
+
+@JRubyClass(name = "ExecutionContext")
+public final class ExecutionContextExt extends RubyObject {
+
+    private AbstractDeadLetterQueueWriterExt dlqWriter;
+
+    private IRubyObject agent;
+
+    private IRubyObject pipeline;
+
+    public ExecutionContextExt(final Ruby runtime, final RubyClass metaClass) {
+        super(runtime, metaClass);
+    }
+
+    @JRubyMethod(required = 5)
+    public IRubyObject initialize(final ThreadContext context,
+        final IRubyObject[] args) {
+        pipeline = args[0];
+        agent = args[1];
+        dlqWriter = new AbstractDeadLetterQueueWriterExt.PluginDeadLetterQueueWriterExt(
+            context.runtime, RubyUtil.PLUGIN_DLQ_WRITER_CLASS
+        ).initialize(context, args[4], args[2], args[3]);
+        return this;
+    }
+
+    @JRubyMethod(name = "dlq_writer")
+    public AbstractDeadLetterQueueWriterExt dlqWriter(final ThreadContext context) {
+        return dlqWriter;
+    }
+
+    @JRubyMethod
+    public IRubyObject agent(final ThreadContext context) {
+        return agent;
+    }
+
+    @JRubyMethod
+    public IRubyObject pipeline(final ThreadContext context) {
+        return pipeline;
+    }
+
+    @JRubyMethod(name = "pipeline_id")
+    public IRubyObject pipelineId(final ThreadContext context) {
+        return pipeline.callMethod(context, "pipeline_id");
+    }
+}


### PR DESCRIPTION
1:1 port of `Logstash::ExecutionContext` without behaviour changes.

Note:

I know I dropped a few assertions in 

```diff
-      expect(LogStash::Util::PluginDeadLetterQueueWriter).to receive(:new).with(anything, "input_id", "singlegenerator").and_call_original		
-      expect(LogStash::Util::PluginDeadLetterQueueWriter).to receive(:new).with(anything, "filter_id", "dlq_commit").and_call_original		
-      expect(LogStash::Util::PluginDeadLetterQueueWriter).to receive(:new).with(anything, "output_id", "dummyoutput").and_call_original
```

I cannot create a Java equivalent of these tests, because instead of `new` and actual Java constructor is called now. In my opinion, these assertions are fairly pointless anyway, they don't confirm that any concrete behaviour and simply make sure that the DLQ writer is instantiated with certain parameters.
Given that we have tests for the actual DLQ behaviour these are redundant IMO (+ we shouldn't write tests/assertions like that in the first place, they don't add any value).