### PR TITLE
JAVAFICATION: Port namespace definitions to Java

### DIFF
--- a/lib/pluginmanager/templates/codec-plugin/lib/logstash/codecs/example.rb.erb
+++ b/lib/pluginmanager/templates/codec-plugin/lib/logstash/codecs/example.rb.erb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 require "logstash/codecs/base"
-require "logstash/namespace"
 
 # This <%= @plugin_name %> codec will append a string to the message field
 # of an event, either in the decoding or encoding methods

--- a/lib/pluginmanager/templates/filter-plugin/lib/logstash/filters/example.rb.erb
+++ b/lib/pluginmanager/templates/filter-plugin/lib/logstash/filters/example.rb.erb
@@ -1,8 +1,7 @@
 # encoding: utf-8
 require "logstash/filters/base"
-require "logstash/namespace"
 
-# This <%= @plugin_name %> filter will replace the contents of the default 
+# This <%= @plugin_name %> filter will replace the contents of the default
 # message field with whatever you specify in the configuration.
 #
 # It is only intended to be used as an <%= @plugin_name %>.
@@ -18,14 +17,14 @@ class LogStash::Filters::<%= classify(plugin_name) %> < LogStash::Filters::Base
   # }
   #
   config_name "<%= plugin_name %>"
-  
+
   # Replace the message with this value.
   config :message, :validate => :string, :default => "Hello World!"
-  
+
 
   public
   def register
-    # Add instance variables 
+    # Add instance variables
   end # def register
 
   public

--- a/lib/pluginmanager/templates/input-plugin/lib/logstash/inputs/example.rb.erb
+++ b/lib/pluginmanager/templates/input-plugin/lib/logstash/inputs/example.rb.erb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 require "logstash/inputs/base"
-require "logstash/namespace"
 require "stud/interval"
 require "socket" # for Socket.gethostname
 

--- a/lib/pluginmanager/templates/output-plugin/lib/logstash/outputs/example.rb.erb
+++ b/lib/pluginmanager/templates/output-plugin/lib/logstash/outputs/example.rb.erb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 require "logstash/outputs/base"
-require "logstash/namespace"
 
 # An <%= plugin_name %> output that does nothing.
 class LogStash::Outputs::<%= classify(plugin_name) %> < LogStash::Outputs::Base

--- a/lib/secretstore/cli.rb
+++ b/lib/secretstore/cli.rb
@@ -2,7 +2,6 @@ $LOAD_PATH.push(File.expand_path(File.dirname(__FILE__) + "/../../logstash-core/
 require_relative "../bootstrap/environment"
 LogStash::Bundler.setup!({:without => [:build, :development]})
 
-require "logstash/namespace"
 require "logstash-core/logstash-core"
 require "logstash/util/settings_helper"
 require "logstash/util/secretstore"

--- a/logstash-core/lib/logstash/codecs/base.rb
+++ b/logstash-core/lib/logstash/codecs/base.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/event"
 require "logstash/plugin"
 require "logstash/logging"
@@ -41,12 +40,12 @@ module LogStash::Codecs; class Base < LogStash::Plugin
   # over the current API for shared plugins
   # It is best if the codec implements this directly
   def multi_encode(events)
-    if @has_encode_sync              
+    if @has_encode_sync
       events.map {|event| [event, self.encode_sync(event)]}
     else
       batch = Thread.current[:logstash_output_codec_batch] ||= []
       batch.clear
-      
+
       events.each {|event| self.encode(event) }
       batch
     end

--- a/logstash-core/lib/logstash/config/cpu_core_strategy.rb
+++ b/logstash-core/lib/logstash/config/cpu_core_strategy.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/config/defaults"
 
 module LogStash module Config module CpuCoreStrategy

--- a/logstash-core/lib/logstash/config/defaults.rb
+++ b/logstash-core/lib/logstash/config/defaults.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "concurrent"
 
 module LogStash module Config module Defaults

--- a/logstash-core/lib/logstash/config/file.rb
+++ b/logstash-core/lib/logstash/config/file.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/config/grammar"
 require "logstash/config/config_ast"
 require "logstash/errors"

--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/plugins/registry"
 require "logstash/logging"
 require "logstash/util/password"
@@ -33,21 +32,21 @@ LogStash::Environment.load_locale!
 # }
 #
 module LogStash::Config::Mixin
-  
+
   include LogStash::Util::SubstitutionVariables
-  
+
   attr_accessor :config
   attr_accessor :original_params
 
   PLUGIN_VERSION_1_0_0 = LogStash::Util::PluginVersion.new(1, 0, 0)
   PLUGIN_VERSION_0_9_0 = LogStash::Util::PluginVersion.new(0, 9, 0)
-  
+
   # This method is called when someone does 'include LogStash::Config'
   def self.included(base)
     # Add the DSL methods to the 'base' given.
     base.extend(LogStash::Config::Mixin::DSL)
   end
-  
+
   def config_init(params)
     # Validation will modify the values inside params if necessary.
     # For example: converting a string to a number, etc.

--- a/logstash-core/lib/logstash/dependency_report.rb
+++ b/logstash-core/lib/logstash/dependency_report.rb
@@ -4,7 +4,6 @@ Encoding.default_external = Encoding::UTF_8
 $DEBUGLIST = (ENV["DEBUG"] || "").split(",")
 
 require "clamp"
-require "logstash/namespace"
 require "rubygems"
 require "jars/gemspec_artifacts"
 
@@ -30,7 +29,7 @@ class LogStash::DependencyReport < Clamp::Command
   end
 
   def gems
-    # @mgreau requested `logstash-*` dependencies be removed from this list: 
+    # @mgreau requested `logstash-*` dependencies be removed from this list:
     # https://github.com/elastic/logstash/pull/8837#issuecomment-351859433
     Gem::Specification.reject { |g| g.name =~ /^logstash-/ }.collect do |gem|
       licenses = ("UNKNOWN" if gem.licenses.empty?) || (gem.licenses.map { |l| SPDX.map(l) }.join("|") if !gem.licenses.empty?)

--- a/logstash-core/lib/logstash/dependency_report_runner.rb
+++ b/logstash-core/lib/logstash/dependency_report_runner.rb
@@ -8,10 +8,9 @@ if $0 == __FILE__
     raise
   end
 
-  require "logstash/namespace"
   require_relative "../../../lib/bootstrap/patches/jar_dependencies"
   require "logstash/dependency_report"
 
-  exit_status = LogStash::DependencyReport.run 
+  exit_status = LogStash::DependencyReport.run
   exit(exit_status || 0)
 end

--- a/logstash-core/lib/logstash/elasticsearch_client.rb
+++ b/logstash-core/lib/logstash/elasticsearch_client.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/logging"
 require "elasticsearch"
 require "elasticsearch/transport/transport/http/manticore"

--- a/logstash-core/lib/logstash/event.rb
+++ b/logstash-core/lib/logstash/event.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 
-require "logstash/namespace"
 require "logstash/json"
 
 # transient pipeline events for normal in-flow signaling as opposed to

--- a/logstash-core/lib/logstash/filters/base.rb
+++ b/logstash-core/lib/logstash/filters/base.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/event"
 require "logstash/logging"
 require "logstash/plugin"

--- a/logstash-core/lib/logstash/inputs/base.rb
+++ b/logstash-core/lib/logstash/inputs/base.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/event"
 require "logstash/plugin"
 require "logstash/logging"
@@ -94,7 +93,7 @@ class LogStash::Inputs::Base < LogStash::Plugin
   def stop?
     @stop_called.value
   end
-  
+
   def clone
     cloned = super
     cloned.codec = @codec.clone if @codec
@@ -105,7 +104,7 @@ class LogStash::Inputs::Base < LogStash::Plugin
     super
     # There is no easy way to propage an instance variable into the codec, because the codec
     # are created at the class level
-    # TODO(talevy): Codecs should have their own execution_context, for now they will inherit their 
+    # TODO(talevy): Codecs should have their own execution_context, for now they will inherit their
     #               parent plugin's
     @codec.execution_context = context
     context

--- a/logstash-core/lib/logstash/inputs/threadable.rb
+++ b/logstash-core/lib/logstash/inputs/threadable.rb
@@ -1,15 +1,14 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/inputs/base"
 
-# This is the threadable class for logstash inputs. 
+# This is the threadable class for logstash inputs.
 # Use this class in your inputs if it can support multiple threads
 class LogStash::Inputs::Threadable < LogStash::Inputs::Base
 
   # Set this to the number of threads you want this input to spawn.
   # This is the same as declaring the input multiple times
   config :threads, :validate => :number, :default => 1
- 
+
   def initialize(params)
     super
     @threadable = true

--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 require "thread"
 require "concurrent"
-require "logstash/namespace"
 require "logstash/errors"
 require "logstash/event"
 require "logstash/filters/base"

--- a/logstash-core/lib/logstash/logging.rb
+++ b/logstash-core/lib/logstash/logging.rb
@@ -1,3 +1,2 @@
 # encoding: utf-8
 require "logstash/logging/logger"
-require "logstash/namespace"

--- a/logstash-core/lib/logstash/modules/cli_parser.rb
+++ b/logstash-core/lib/logstash/modules/cli_parser.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/logging"
 require "logstash/errors"
 

--- a/logstash-core/lib/logstash/modules/elasticsearch_config.rb
+++ b/logstash-core/lib/logstash/modules/elasticsearch_config.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/logging"
 
 require_relative "elasticsearch_resource"

--- a/logstash-core/lib/logstash/modules/elasticsearch_importer.rb
+++ b/logstash-core/lib/logstash/modules/elasticsearch_importer.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/logging"
 
 module LogStash module Modules class ElasticsearchImporter

--- a/logstash-core/lib/logstash/modules/elasticsearch_resource.rb
+++ b/logstash-core/lib/logstash/modules/elasticsearch_resource.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require_relative "resource_base"
 
 module LogStash module Modules class ElasticsearchResource

--- a/logstash-core/lib/logstash/modules/file_reader.rb
+++ b/logstash-core/lib/logstash/modules/file_reader.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/logging"
 require "logstash/json"
 

--- a/logstash-core/lib/logstash/modules/kibana_base.rb
+++ b/logstash-core/lib/logstash/modules/kibana_base.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/json"
 
 module LogStash module Modules class KibanaBase

--- a/logstash-core/lib/logstash/modules/kibana_client.rb
+++ b/logstash-core/lib/logstash/modules/kibana_client.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/logging"
 require "logstash/json"
 require "manticore"

--- a/logstash-core/lib/logstash/modules/kibana_config.rb
+++ b/logstash-core/lib/logstash/modules/kibana_config.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/logging"
 
 require_relative "file_reader"

--- a/logstash-core/lib/logstash/modules/kibana_dashboards.rb
+++ b/logstash-core/lib/logstash/modules/kibana_dashboards.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/logging"
 require_relative "kibana_base"
 

--- a/logstash-core/lib/logstash/modules/kibana_importer.rb
+++ b/logstash-core/lib/logstash/modules/kibana_importer.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/logging"
 
 module LogStash module Modules class KibanaImporter

--- a/logstash-core/lib/logstash/modules/kibana_resource.rb
+++ b/logstash-core/lib/logstash/modules/kibana_resource.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require_relative "resource_base"
 
 module LogStash module Modules class KibanaResource

--- a/logstash-core/lib/logstash/modules/kibana_settings.rb
+++ b/logstash-core/lib/logstash/modules/kibana_settings.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/logging"
 require_relative "kibana_base"
 

--- a/logstash-core/lib/logstash/modules/logstash_config.rb
+++ b/logstash-core/lib/logstash/modules/logstash_config.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require_relative "file_reader"
 require "logstash/settings"
 

--- a/logstash-core/lib/logstash/modules/resource_base.rb
+++ b/logstash-core/lib/logstash/modules/resource_base.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/json"
 require_relative "file_reader"
 

--- a/logstash-core/lib/logstash/modules/scaffold.rb
+++ b/logstash-core/lib/logstash/modules/scaffold.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/logging"
 require "logstash/util/loggable"
 require "erb"

--- a/logstash-core/lib/logstash/modules/settings_merger.rb
+++ b/logstash-core/lib/logstash/modules/settings_merger.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/util"
 require "logstash/util/loggable"
 

--- a/logstash-core/lib/logstash/namespace.rb
+++ b/logstash-core/lib/logstash/namespace.rb
@@ -1,15 +1,2 @@
-# encoding: utf-8
-module LogStash
-  module Inputs; end
-  module Outputs; end
-  module Filters; end
-  module Search; end
-  module Config; end
-  module File; end
-  module Web; end
-  module Util; end
-  module PluginMixins; end
-  module PluginManager; end
-  module Api; end
-  module Modules; end
-end # module LogStash
+# The contents of this file have been ported to Java. It is included for for compatibility
+# with plugins that directly require it.

--- a/logstash-core/lib/logstash/outputs/base.rb
+++ b/logstash-core/lib/logstash/outputs/base.rb
@@ -2,7 +2,6 @@
 require "logstash/event"
 require "logstash/logging"
 require "logstash/plugin"
-require "logstash/namespace"
 require "logstash/config/mixin"
 require "concurrent/atomic/atomic_fixnum"
 
@@ -24,7 +23,7 @@ class LogStash::Outputs::Base < LogStash::Plugin
   # when we no longer support the :legacy type
   # This is hacky, but it can only be herne
   config :workers, :type => :number, :default => 1
-  
+
   # Set or return concurrency type
   def self.concurrency(type=nil)
     if type
@@ -68,7 +67,7 @@ class LogStash::Outputs::Base < LogStash::Plugin
     # If we're running with a single thread we must enforce single-threaded concurrency by default
     # Maybe in a future version we'll assume output plugins are threadsafe
     @single_worker_mutex = Mutex.new
-    
+
     @receives_encoded = self.methods.include?(:multi_receive_encoded)
   end
 
@@ -108,7 +107,7 @@ class LogStash::Outputs::Base < LogStash::Plugin
     super
     # There is no easy way to propage an instance variable into the codec, because the codec
     # are created at the class level
-    # TODO(talevy): Codecs should have their own execution_context, for now they will inherit their 
+    # TODO(talevy): Codecs should have their own execution_context, for now they will inherit their
     #               parent plugin's
     @codec.execution_context = context
     context

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -2,7 +2,6 @@
 require "thread"
 require "stud/interval"
 require "concurrent"
-require "logstash/namespace"
 require "logstash/errors"
 require "logstash-core/logstash-core"
 require "logstash/event"

--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/logging"
 require "logstash/config/mixin"
 require "logstash/instrument/null_metric"

--- a/logstash-core/lib/logstash/queue_factory.rb
+++ b/logstash-core/lib/logstash/queue_factory.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 require "fileutils"
 require "logstash/event"
-require "logstash/namespace"
 
 module LogStash
   class QueueFactory

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -15,7 +15,6 @@ end
 require "clamp"
 require "net/http"
 
-require "logstash/namespace"
 require "logstash-core/logstash-core"
 require "logstash/environment"
 require "logstash/modules/cli_parser"

--- a/logstash-core/lib/logstash/util.rb
+++ b/logstash-core/lib/logstash/util.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/environment"
 
 module LogStash::Util

--- a/logstash-core/lib/logstash/util/byte_value.rb
+++ b/logstash-core/lib/logstash/util/byte_value.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 
 module LogStash; module Util; module ByteValue
   module_function
@@ -23,7 +22,7 @@ module LogStash; module Util; module ByteValue
 
   def multiplier(text)
     case text
-      when /(?:k|kb)$/ 
+      when /(?:k|kb)$/
         KB
       when /(?:m|mb)$/
         MB
@@ -35,7 +34,7 @@ module LogStash; module Util; module ByteValue
         PB
       when /(?:b)$/
         B
-      else 
+      else
         raise ArgumentError, "Unknown bytes value '#{text}'"
     end
   end

--- a/logstash-core/lib/logstash/util/charset.rb
+++ b/logstash-core/lib/logstash/util/charset.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/util"
 
 class LogStash::Util::Charset

--- a/logstash-core/lib/logstash/util/cloud_setting_auth.rb
+++ b/logstash-core/lib/logstash/util/cloud_setting_auth.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/util/password"
 
 module LogStash module Util class CloudSettingAuth

--- a/logstash-core/lib/logstash/util/cloud_setting_id.rb
+++ b/logstash-core/lib/logstash/util/cloud_setting_id.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "base64"
 
 module LogStash module Util class CloudSettingId

--- a/logstash-core/lib/logstash/util/decorators.rb
+++ b/logstash-core/lib/logstash/util/decorators.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/util"
 
 module LogStash::Util

--- a/logstash-core/lib/logstash/util/loggable.rb
+++ b/logstash-core/lib/logstash/util/loggable.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 require "logstash/logging/logger"
-require "logstash/namespace"
 
 module LogStash module Util
   module Loggable

--- a/logstash-core/lib/logstash/util/modules_setting_array.rb
+++ b/logstash-core/lib/logstash/util/modules_setting_array.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/util/password"
 
 module LogStash module Util class ModulesSettingArray

--- a/logstash-core/lib/logstash/util/password.rb
+++ b/logstash-core/lib/logstash/util/password.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 
 # This class exists to quietly wrap a password string so that, when printed or
 # logged, you don't accidentally print the password itself.

--- a/logstash-core/lib/logstash/util/safe_uri.rb
+++ b/logstash-core/lib/logstash/util/safe_uri.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/util"
 require "forwardable"
 
@@ -8,14 +7,14 @@ require "forwardable"
 class LogStash::Util::SafeURI
   PASS_PLACEHOLDER = "xxxxxx".freeze
   HOSTNAME_PORT_REGEX=/\A(?<hostname>([A-Za-z0-9\.\-]+)|\[[0-9A-Fa-f\:]+\])(:(?<port>\d+))?\Z/
-  
+
   extend Forwardable
-  
-  
+
+
   attr_reader :uri
 
   public
-  def initialize(arg)    
+  def initialize(arg)
     @uri = case arg
            when String
              arg = "//#{arg}" if HOSTNAME_PORT_REGEX.match(arg)
@@ -39,7 +38,7 @@ class LogStash::Util::SafeURI
 
   def sanitized
     return uri unless password # nothing to sanitize here!
-    
+
     user_info = user ? "#{user}:#{PASS_PLACEHOLDER}" : nil
 
     make_uri(scheme, user_info, host, port, path, query, fragment)
@@ -64,7 +63,7 @@ class LogStash::Util::SafeURI
     new_query = query
     new_fragment = fragment
 
-    case field 
+    case field
     when :scheme
       new_scheme = value
     when :user
@@ -124,7 +123,7 @@ class LogStash::Util::SafeURI
     # In java this is an int
     uri.port < 1 ? nil : uri.port
   end
- 
+
   def port=(new_port)
     update(:port, new_port)
   end

--- a/logstash-core/lib/logstash/util/worker_threads_default_printer.rb
+++ b/logstash-core/lib/logstash/util/worker_threads_default_printer.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/namespace"
 require "logstash/util"
 
 # This class exists to format the settings for default worker threads

--- a/logstash-core/spec/logstash/modules/scaffold_spec.rb
+++ b/logstash-core/spec/logstash/modules/scaffold_spec.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 #
-require "logstash/namespace"
 require "logstash/elasticsearch_client"
 require "logstash/modules/kibana_client"
 require "logstash/modules/kibana_config"

--- a/logstash-core/src/main/java/org/logstash/RubyUtil.java
+++ b/logstash-core/src/main/java/org/logstash/RubyUtil.java
@@ -1,5 +1,6 @@
 package org.logstash;
 
+import java.util.stream.Stream;
 import org.jruby.NativeException;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
@@ -118,6 +119,10 @@ public final class RubyUtil {
     static {
         RUBY = Ruby.getGlobalRuntime();
         LOGSTASH_MODULE = RUBY.getOrCreateModule("LogStash");
+        Stream.of(
+            "Inputs", "Outputs", "Filters", "Search", "Config", "File", "Web", "PluginMixins",
+            "PluginManager", "Api", "Modules"
+        ).forEach(module -> RUBY.defineModuleUnder(module, LOGSTASH_MODULE));
         final RubyModule instrumentModule =
             RUBY.defineModuleUnder("Instrument", LOGSTASH_MODULE);
         METRIC_EXCEPTION_CLASS = instrumentModule.defineClassUnder(

--- a/qa/integration/fixtures/logstash-dummy-pack/lib/logstash/outputs/secret.rb
+++ b/qa/integration/fixtures/logstash-dummy-pack/lib/logstash/outputs/secret.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 require "logstash/outputs/base"
-require "logstash/namespace"
 
 # An secret output that does nothing.
 class LogStash::Outputs::Secret < LogStash::Outputs::Base


### PR DESCRIPTION
Ported all module definitions to Java (the list in the `Stream` doesn't contain all that we in the Ruby file because I left out those that were already defined in Java before this PR (and hence redundant in Ruby)).