### PR TITLE
MINOR: Remove ununsed methods from java_pipeline.rb and pipeline.rb

### DIFF
--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -38,15 +38,16 @@ module LogStash; class JavaBasePipeline
     )
 
     @pipeline_id = @settings.get_value("pipeline.id") || self.object_id
-    @agent = agent
     @dlq_writer = dlq_writer
-    @plugin_factory = LogStash::Plugins::PluginFactory.new(
-      # use NullMetric if called in the BasePipeline context otherwise use the @metric value
-      @lir, LogStash::Plugins::PluginMetricFactory.new(pipeline_id, @metric || Instrument::NullMetric.new),
-      LogStash::Plugins::ExecutionContextFactory.new(@agent, self, @dlq_writer),
-      JavaFilterDelegator
+    @lir_execution = CompiledPipeline.new(
+        @lir,
+        LogStash::Plugins::PluginFactory.new(
+            # use NullMetric if called in the BasePipeline context otherwise use the @metric value
+            @lir, LogStash::Plugins::PluginMetricFactory.new(pipeline_id, @metric),
+            LogStash::Plugins::ExecutionContextFactory.new(agent, self, @dlq_writer),
+            JavaFilterDelegator
+        )
     )
-    @lir_execution = CompiledPipeline.new(@lir, @plugin_factory)
     if settings.get_value("config.debug") && @logger.debug?
       @logger.debug("Compiled pipeline code", default_logging_keys(:code => @lir.get_graph.to_string))
     end
@@ -68,26 +69,6 @@ module LogStash; class JavaBasePipeline
     if settings.get_value("dead_letter_queue.enable")
       DeadLetterQueueFactory.release(pipeline_id)
     end
-  end
-
-  def buildOutput(name, line, column, *args)
-    plugin("output", name, line, column, *args)
-  end
-
-  def buildFilter(name, line, column, *args)
-    plugin("filter", name, line, column, *args)
-  end
-
-  def buildInput(name, line, column, *args)
-    plugin("input", name, line, column, *args)
-  end
-
-  def buildCodec(name, *args)
-   plugin("codec", name, 0, 0, *args)
-  end
-
-  def plugin(plugin_type, name, line, column, *args)
-    @plugin_factory.plugin(plugin_type, name, line, column, *args)
   end
 
   def reloadable?

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -53,7 +53,7 @@ module LogStash; class BasePipeline
 
     @plugin_factory = LogStash::Plugins::PluginFactory.new(
       # use NullMetric if called in the BasePipeline context otherwise use the @metric value
-      @lir, LogStash::Plugins::PluginMetricFactory.new(pipeline_id, @metric || Instrument::NullMetric.new),
+      @lir, LogStash::Plugins::PluginMetricFactory.new(pipeline_id, @metric),
       LogStash::Plugins::ExecutionContextFactory.new(@agent, self, @dlq_writer),
       FilterDelegator
     )
@@ -98,10 +98,6 @@ module LogStash; class BasePipeline
     )
   end
 
-  def plugin(plugin_type, name, line, column, *args)
-    @plugin_factory.plugin(plugin_type, name, line, column, *args)
-  end
-
   def reloadable?
     configured_as_reloadable? && reloadable_plugins?
   end
@@ -119,6 +115,11 @@ module LogStash; class BasePipeline
   end
 
   private
+
+
+  def plugin(plugin_type, name, line, column, *args)
+    @plugin_factory.plugin(plugin_type, name, line, column, *args)
+  end
 
   def default_logging_keys(other_keys = {})
     { :pipeline_id => pipeline_id }.merge(other_keys)

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
@@ -14,6 +14,7 @@ import org.logstash.RubyUtil;
 import org.logstash.execution.ExecutionContextExt;
 import org.logstash.instrument.metrics.AbstractMetricExt;
 import org.logstash.instrument.metrics.AbstractNamespacedMetricExt;
+import org.logstash.instrument.metrics.NullMetricExt;
 
 public final class PluginFactoryExt {
 
@@ -71,7 +72,11 @@ public final class PluginFactoryExt {
         public PluginFactoryExt.Metrics initialize(final ThreadContext context,
             final IRubyObject pipelineId, final IRubyObject metrics) {
             this.pipelineId = pipelineId.convertToString().intern19();
-            this.metric = (AbstractMetricExt) metrics;
+            if (metrics.isNil()) {
+                this.metric = new NullMetricExt(context.runtime, RubyUtil.NULL_METRIC_CLASS);
+            } else {
+                this.metric = (AbstractMetricExt) metrics;
+            }
             return this;
         }
 


### PR DESCRIPTION
Just making the surface area of the plugin classes a little smaller before porting them to Java.

* The `plugin` methods weren't used at all in the Java pipeline -> removed
   * In the Ruby pipeline they're only used by the config `eval` statement -> private
* As a result, the `plugin_factory` does not have to be a field in the Java pipeline, neither does the `agent` have to be a field
