### PR TITLE
[DOCS] Enables editing links for X-Pack pages

### DIFF
--- a/x-pack/docs/en/index.asciidoc
+++ b/x-pack/docs/en/index.asciidoc
@@ -1,12 +1,9 @@
 
 include::{log-repo-dir}/index-shared1.asciidoc[]
 
-:edit_url!:
 include::setup/setting-up-xpack.asciidoc[]
 
-:edit_url:
 include::{log-repo-dir}/index-shared2.asciidoc[]
 
-:edit_url:
 include::{log-repo-dir}/index-shared3.asciidoc[]
 

--- a/x-pack/docs/en/index.asciidoc
+++ b/x-pack/docs/en/index.asciidoc
@@ -1,6 +1,7 @@
 
 include::{log-repo-dir}/index-shared1.asciidoc[]
 
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/x-pack/
 include::setup/setting-up-xpack.asciidoc[]
 
 include::{log-repo-dir}/index-shared2.asciidoc[]


### PR DESCRIPTION
This PR enables the "edit" links at the top of all the pages in the x-pack folder.