### PR TITLE
Add ci script for license check

### DIFF
--- a/ci/license_check.sh
+++ b/ci/license_check.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -ie
+export GRADLE_OPTS="-Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info"
+
+bin/dependencies-report --csv report.csv
+# We want this to show on the CI server
+cat report.csv


### PR DESCRIPTION
We use these scripts by convention for CI jobs. We'll need one before I can add the job.