### PR TITLE
Add docker ci script for license check

### DIFF
--- a/ci/docker_license_check.sh
+++ b/ci/docker_license_check.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+ci/docker_run.sh ci/license_check.sh


### PR DESCRIPTION
When I merged #9513 I forgot to add this shortcut which follows the conventions of our other ci scripts.