### PR TITLE
[X-Pack Monitoring] Report pipeline protocol

### DIFF
--- a/logstash-core/lib/logstash/config/pipeline_config.rb
+++ b/logstash-core/lib/logstash/config/pipeline_config.rb
@@ -29,6 +29,10 @@ module LogStash module Config
       @settings.get("pipeline.system")
     end
 
+    def protocol
+      @config_parts[0].protocol.to_s
+    end
+
     def ==(other)
       config_hash == other.config_hash && pipeline_id == other.pipeline_id && settings == other.settings
     end

--- a/logstash-core/lib/logstash/config/pipeline_config.rb
+++ b/logstash-core/lib/logstash/config/pipeline_config.rb
@@ -29,8 +29,8 @@ module LogStash module Config
       @settings.get("pipeline.system")
     end
 
-    def protocol
-      @config_parts[0].protocol.to_s
+    def protocols
+      @config_parts.map { |config_part| config_part.protocol }
     end
 
     def ==(other)

--- a/logstash-core/lib/logstash/config/pipeline_config.rb
+++ b/logstash-core/lib/logstash/config/pipeline_config.rb
@@ -8,6 +8,11 @@ module LogStash module Config
     attr_reader :source, :pipeline_id, :config_parts, :settings, :read_at
 
     def initialize(source, pipeline_id, config_parts, settings)
+      num_unique_protocols = (config_parts.uniq { |config_part | config_part.protocol.to_s }).length
+      if num_unique_protocols > 1
+        raise ArgumentError 'There should be exactly one unique protocol in config_parts. Found ' + num_unique_protocols
+      end
+        
       @source = source
       @pipeline_id = pipeline_id
       # We can't use Array() since config_parts may be a java object!

--- a/logstash-core/spec/logstash/config/pipeline_config_spec.rb
+++ b/logstash-core/spec/logstash/config/pipeline_config_spec.rb
@@ -13,7 +13,7 @@ describe LogStash::Config::PipelineConfig do
       org.logstash.common.SourceWithMetadata.new("file", "/tmp/3", 0, 0, "input { generator3 }"),
       org.logstash.common.SourceWithMetadata.new("file", "/tmp/4", 0, 0, "input { generator4 }"),
       org.logstash.common.SourceWithMetadata.new("file", "/tmp/5", 0, 0, "input { generator5 }"),
-      org.logstash.common.SourceWithMetadata.new("file", "/tmp/6", 0, 0, "input { generator6 }")
+      org.logstash.common.SourceWithMetadata.new("file", "/tmp/6", 0, 0, "input { generator6 }"),
     ]
   end
 

--- a/logstash-core/spec/logstash/config/pipeline_config_spec.rb
+++ b/logstash-core/spec/logstash/config/pipeline_config_spec.rb
@@ -13,8 +13,7 @@ describe LogStash::Config::PipelineConfig do
       org.logstash.common.SourceWithMetadata.new("file", "/tmp/3", 0, 0, "input { generator3 }"),
       org.logstash.common.SourceWithMetadata.new("file", "/tmp/4", 0, 0, "input { generator4 }"),
       org.logstash.common.SourceWithMetadata.new("file", "/tmp/5", 0, 0, "input { generator5 }"),
-      org.logstash.common.SourceWithMetadata.new("file", "/tmp/6", 0, 0, "input { generator6 }"),
-      org.logstash.common.SourceWithMetadata.new("string", "config_string", 0, 0, "input { generator1 }"),
+      org.logstash.common.SourceWithMetadata.new("file", "/tmp/6", 0, 0, "input { generator6 }")
     ]
   end
 
@@ -75,6 +74,11 @@ describe LogStash::Config::PipelineConfig do
   end
 
   it "returns the pipeline's protocol" do
-    expect(subject.protocol).to eq((ordered_config_parts.uniq { | config_part | config_part.protocol })[0].protocol
+    expect(subject.protocol).to eq((ordered_config_parts.uniq { | config_part | config_part.protocol })[0].protocol)
+  end
+
+  it "raises an ArgumentError when multiple protocols are supplied" do
+    unordered_config_parts << org.logstash.common.SourceWithMetadata.new("string", "config_string", 0, 0, "input { generator0 }")
+    expect { described_class.new(source, pipeline_id, unordered_config_parts, settings) }.to raise_error ArgumentError, /.+Found 2\./
   end
 end

--- a/logstash-core/spec/logstash/config/pipeline_config_spec.rb
+++ b/logstash-core/spec/logstash/config/pipeline_config_spec.rb
@@ -73,7 +73,7 @@ describe LogStash::Config::PipelineConfig do
     end
   end
 
-  it "returns the pipeline's protocols" do
-    expect(subject.protocols).to eq(ordered_config_parts.map { | config_part | config_part.protocol })
+  it "returns the pipeline's protocol" do
+    expect(subject.protocol).to eq((ordered_config_parts.uniq { | config_part | config_part.protocol })[0].protocol
   end
 end

--- a/logstash-core/spec/logstash/config/pipeline_config_spec.rb
+++ b/logstash-core/spec/logstash/config/pipeline_config_spec.rb
@@ -72,4 +72,8 @@ describe LogStash::Config::PipelineConfig do
       end
     end
   end
+
+  it "returns the pipeline's protocols" do
+    expect(subject.protocols).to eq(ordered_config_parts.map { | config_part | config_part.protocol })
+  end
 end

--- a/logstash-core/spec/logstash/config/pipeline_config_spec.rb
+++ b/logstash-core/spec/logstash/config/pipeline_config_spec.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/config/pipeline_config"
 require "logstash/config/source/local"
+require_relative "../../support/helpers"
 
 describe LogStash::Config::PipelineConfig do
   let(:source) { LogStash::Config::Source::Local }

--- a/x-pack/lib/config_management/elasticsearch_source.rb
+++ b/x-pack/lib/config_management/elasticsearch_source.rb
@@ -32,6 +32,7 @@ module LogStash
         queue.max_bytes
         queue.checkpoint.writes
       )
+      PIPELINE_PROTOCOL = "x-pack-config-management"
 
       def initialize(settings)
         super(settings)
@@ -98,7 +99,7 @@ module LogStash
 
         raise RemoteConfigError, "Empty configuration for pipeline_id: #{pipeline_id}" if config_string.nil? || config_string.empty?
 
-        config_part = org.logstash.common.SourceWithMetadata.new("x-pack-config-management", pipeline_id.to_s, config_string)
+        config_part = org.logstash.common.SourceWithMetadata.new(PIPELINE_PROTOCOL, pipeline_id.to_s, config_string)
 
         # We don't support multiple pipelines, so use the global settings from the logstash.yml file
         settings = @settings.clone

--- a/x-pack/lib/config_management/elasticsearch_source.rb
+++ b/x-pack/lib/config_management/elasticsearch_source.rb
@@ -32,7 +32,7 @@ module LogStash
         queue.max_bytes
         queue.checkpoint.writes
       )
-      PIPELINE_PROTOCOL = "x-pack-config-management"
+      CENTRALLY_MANAGED_PIPELINE_PROTOCOL = "x-pack-config-management"
 
       def initialize(settings)
         super(settings)
@@ -99,7 +99,7 @@ module LogStash
 
         raise RemoteConfigError, "Empty configuration for pipeline_id: #{pipeline_id}" if config_string.nil? || config_string.empty?
 
-        config_part = org.logstash.common.SourceWithMetadata.new(PIPELINE_PROTOCOL, pipeline_id.to_s, config_string)
+        config_part = org.logstash.common.SourceWithMetadata.new(CENTRALLY_MANAGED_PIPELINE_PROTOCOL, pipeline_id.to_s, config_string)
 
         # We don't support multiple pipelines, so use the global settings from the logstash.yml file
         settings = @settings.clone

--- a/x-pack/lib/monitoring/inputs/metrics/state_event_factory.rb
+++ b/x-pack/lib/monitoring/inputs/metrics/state_event_factory.rb
@@ -27,7 +27,7 @@ module LogStash; module Inputs; class Metrics;
         "id" => pipeline.pipeline_id,
         "hash" => pipeline.lir.unique_hash,
         "ephemeral_id" => pipeline.ephemeral_id,
-        "protocols" => pipeline.pipeline_config.protocols.uniq,
+        "protocol" => pipeline.pipeline_config.protocol,
         "workers" =>  pipeline.settings.get("pipeline.workers"),
         "batch_size" =>  pipeline.settings.get("pipeline.batch.size"),
         "representation" => ::LogStash::Inputs::Metrics::StateEvent::LIRSerializer.serialize(pipeline.lir)

--- a/x-pack/lib/monitoring/inputs/metrics/state_event_factory.rb
+++ b/x-pack/lib/monitoring/inputs/metrics/state_event_factory.rb
@@ -27,7 +27,7 @@ module LogStash; module Inputs; class Metrics;
         "id" => pipeline.pipeline_id,
         "hash" => pipeline.lir.unique_hash,
         "ephemeral_id" => pipeline.ephemeral_id,
-        "protocol" => pipeline.pipeline_config.protocol,
+        "protocols" => pipeline.pipeline_config.protocols,
         "workers" =>  pipeline.settings.get("pipeline.workers"),
         "batch_size" =>  pipeline.settings.get("pipeline.batch.size"),
         "representation" => ::LogStash::Inputs::Metrics::StateEvent::LIRSerializer.serialize(pipeline.lir)

--- a/x-pack/lib/monitoring/inputs/metrics/state_event_factory.rb
+++ b/x-pack/lib/monitoring/inputs/metrics/state_event_factory.rb
@@ -27,7 +27,7 @@ module LogStash; module Inputs; class Metrics;
         "id" => pipeline.pipeline_id,
         "hash" => pipeline.lir.unique_hash,
         "ephemeral_id" => pipeline.ephemeral_id,
-        "protocols" => pipeline.pipeline_config.protocols,
+        "protocols" => pipeline.pipeline_config.protocols.uniq,
         "workers" =>  pipeline.settings.get("pipeline.workers"),
         "batch_size" =>  pipeline.settings.get("pipeline.batch.size"),
         "representation" => ::LogStash::Inputs::Metrics::StateEvent::LIRSerializer.serialize(pipeline.lir)

--- a/x-pack/lib/monitoring/inputs/metrics/state_event_factory.rb
+++ b/x-pack/lib/monitoring/inputs/metrics/state_event_factory.rb
@@ -27,6 +27,7 @@ module LogStash; module Inputs; class Metrics;
         "id" => pipeline.pipeline_id,
         "hash" => pipeline.lir.unique_hash,
         "ephemeral_id" => pipeline.ephemeral_id,
+        "protocol" => pipeline.pipeline_config.protocol,
         "workers" =>  pipeline.settings.get("pipeline.workers"),
         "batch_size" =>  pipeline.settings.get("pipeline.batch.size"),
         "representation" => ::LogStash::Inputs::Metrics::StateEvent::LIRSerializer.serialize(pipeline.lir)


### PR DESCRIPTION
Resolves #9470.

Each pipeline can have a single origin (file, x-pack centralized management, string, etc.). This origin is internally represented via a `protocol` field in pipeline metadata.

This PR makes it so that a pipeline's protocol is reported to X-Pack Monitoring as part of `logstash_state` documents.

### Testing this PR
1. Setup X-Pack Monitoring for Logstash.
2. Start one pipeline via the `-e` option.
3. Start another pipeline via the `-f` option.
4. Setup X-Pack Management for Logstash.
5. Create and deploy a third pipeline from the Logstash Centralized Management UI.
6. Query the Logstash Monitoring indices with the query below:

   ```
   GET .monitoring-logstash-*/_search?q=type:logstash_state&filter_path=hits.hits._source.logstash_state.pipeline.id,hits.hits._source.logstash_state.pipeline.protocol
   ```

7. Verify that all three pipelines are reported in Logstash Monitoring indices, along with each of their respective protocols.