### PR TITLE
specs: improve isolation with tmpdir-per-spec

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,29 +37,20 @@ RSpec.configure do |c|
   c.include LogStashHelper
   c.extend LogStashHelper
 
-  c.before(:each) do
-    # TODO: commented out on post-merged in master - the logger has moved to log4j
-    #
-    #
-    # Force Cabin to always have a JSON subscriber.  The main purpose of this
-    # is to catch crashes in json serialization for our logs. JSONIOThingy
-    # exists to validate taht what LogStash::Logging::JSON emits is always
-    # valid JSON.
-    # jsonvalidator = JSONIOThingy.new
-    # allow(Cabin::Channel).to receive(:new).and_wrap_original do |m, *args|
-    #   logger = m.call(*args)
-    #   logger.level = :debug
-    #   logger.subscribe(LogStash::Logging::JSON.new(jsonvalidator))
-    #
-    #   logger
-    # end
+  # Some tests mess with LogStash::SETTINGS, and data on the filesystem can leak state
+  # from one spec to another; run each spec with its own temporary data directory for `path.data`
+  c.around(:each) do |example|
+    Dir.mktmpdir do |temp_directory|
+      # Some tests mess with the settings. This ensures one test cannot pollute another
+      LogStash::SETTINGS.reset
 
-    # Some tests mess with the settings. This ensures one test cannot pollute another
-    LogStash::SETTINGS.reset
+      LogStash::SETTINGS.set("queue.type", "persisted")
+      LogStash::SETTINGS.set("queue.page_capacity", 1024 * 1024)
+      LogStash::SETTINGS.set("queue.max_events", 250)
+      LogStash::SETTINGS.set("path.data", temp_directory)
 
-    LogStash::SETTINGS.set("queue.type", "persisted")
-    LogStash::SETTINGS.set("queue.page_capacity", 1024 * 1024)
-    LogStash::SETTINGS.set("queue.max_events", 250)
+      example.run
+    end
   end
 end
 


### PR DESCRIPTION
By isolating the execution of specs with ~a mutex and~ a fresh tmpdir for our `path.data`, we should be able to eliminate a fair bit of fragility in our specs.

This is _likely_ to remedy the types of test failures identified in:
 - #9504 (PQ leakage?)
 - #9507 (Threadsafety?)

If you're not familiar with Rspec's `around`, it has [ordering guarantees](https://relishapp.com/rspec/rspec-core/v/3-0/docs/hooks/around-hooks) that make it possible to define multiple hooks ~as done here~ instead of nesting blocks in blocks in blocks (which can get confusing); the first-defined hook in a context will wrap subsequently-defined `around(:each)` hooks, which in turn wrap `before(:each)` hooks.