### PR TITLE
[DOCS] Fixes links to built-in users

### DIFF
--- a/x-pack/docs/en/monitoring/configuring-logstash.asciidoc
+++ b/x-pack/docs/en/monitoring/configuring-logstash.asciidoc
@@ -25,7 +25,7 @@ is disabled in {es} and data is ignored from all other sources.
 . Configure your Logstash nodes to send metrics by setting the
 `xpack.monitoring.elasticsearch.url` in `logstash.yml`. If {security} is enabled,
 you also need to specify the credentials for the 
-{xpack-ref}/setting-up-authentication.html#built-in-users[built-in `logstash_system` user]. For more information about these settings, see <<monitoring-settings>>.
+{stack-ov}/built-in-users.html[built-in `logstash_system` user]. For more information about these settings, see <<monitoring-settings>>.
 +
 --
 [source,yaml]

--- a/x-pack/docs/en/security/logstash.asciidoc
+++ b/x-pack/docs/en/security/logstash.asciidoc
@@ -198,7 +198,7 @@ data to a secure cluster, you need to configure the username and password that
 Logstash uses to authenticate for shipping monitoring data.
 
 {security} comes preconfigured with a
-{xpack-ref}/setting-up-authentication.html#built-in-users[`logstash_system` built-in user]
+{stack-ov}/built-in-users.html[`logstash_system` built-in user]
 for this purpose. This user has the minimum permissions necessary for the
 monitoring function, and _should not_ be used for any other purpose - it is
 specifically _not intended_ for use within a Logstash pipeline.


### PR DESCRIPTION
This PR fixes broken links from the Logstash Reference to the Stack Overview.

Related to https://github.com/elastic/elasticsearch/pull/30280