### PR TITLE
Fix rpm post-install scriptlet

### DIFF
--- a/pkg/centos/after-install.sh
+++ b/pkg/centos/after-install.sh
@@ -1,6 +1,6 @@
 chown -R logstash:logstash /usr/share/logstash
 chown -R logstash /var/log/logstash
-chown logstash:logstash /var/lib/logstash
+chown -R logstash:logstash /var/lib/logstash
 sed -i \
   -e 's|# path.logs:|path.logs: /var/log/logstash|' \
   -e 's|# path.data:|path.data: /var/lib/logstash|' \


### PR DESCRIPTION
`/var/lib/logstash` may contain files and folders from a previous installation. In case a user removes logstash, and later decides to install it again, logstash may not work due to wrong ownership.