### PR TITLE
License checker does not fail build

### DIFF
--- a/tools/dependencies-report/src/main/java/org/logstash/dependencies/Main.java
+++ b/tools/dependencies-report/src/main/java/org/logstash/dependencies/Main.java
@@ -39,7 +39,7 @@ public class Main {
         );
 
         // If there were unknown results in the report, exit with a non-zero status
-        System.exit(reportResult ? 0 : 1);
+        //System.exit(reportResult ? 0 : 1);
 
     }
 


### PR DESCRIPTION
Temporarily disable the exit(1) in case of dependencies with unidentified licenses so the release-manager build passes until we can get all the dependency licenses sorted out.