### PR TITLE
FieldReference: handle illegal syntax gracefully

### DIFF
--- a/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
+++ b/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
@@ -17,28 +17,28 @@ public final class FieldReferenceTest {
     public void testParseSingleBareField() throws Exception {
         FieldReference f = FieldReference.from("foo");
         assertEquals(0, f.getPath().length);
-        assertEquals(f.getKey(), "foo");
+        assertEquals("foo", f.getKey());
     }
 
     @Test
     public void testParseSingleFieldPath() throws Exception {
         FieldReference f = FieldReference.from("[foo]");
         assertEquals(0, f.getPath().length);
-        assertEquals(f.getKey(), "foo");
+        assertEquals("foo", f.getKey());
     }
 
     @Test
     public void testParse2FieldsPath() throws Exception {
         FieldReference f = FieldReference.from("[foo][bar]");
-        assertArrayEquals(f.getPath(), new String[]{"foo"});
-        assertEquals(f.getKey(), "bar");
+        assertArrayEquals(new String[]{"foo"}, f.getPath());
+        assertEquals("bar", f.getKey());
     }
 
     @Test
     public void testParse3FieldsPath() throws Exception {
         FieldReference f = FieldReference.from("[foo][bar]]baz]");
-        assertArrayEquals(f.getPath(), new String[]{"foo", "bar"});
-        assertEquals(f.getKey(), "baz");
+        assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
+        assertEquals("baz", f.getKey());
     }
 
     @Test

--- a/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
+++ b/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
@@ -36,9 +36,79 @@ public final class FieldReferenceTest {
 
     @Test
     public void testParse3FieldsPath() throws Exception {
-        FieldReference f = FieldReference.from("[foo][bar]]baz]");
+        FieldReference f = FieldReference.from("[foo][bar][baz]");
         assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
         assertEquals("baz", f.getKey());
+    }
+
+    @Test
+    public void testParseInvalidNoCloseBracket() throws Exception {
+        FieldReference f = FieldReference.from("[foo][bar][baz");
+        assertEquals(0, f.getPath().length);
+        assertEquals("[foo][bar][baz", f.getKey());
+    }
+
+    @Test
+    public void testParseInvalidNoInitialOpenBracket() throws Exception {
+        FieldReference f = FieldReference.from("foo[bar][baz]");
+        assertEquals(0, f.getPath().length);
+        assertEquals("foo[bar][baz]", f.getKey());
+    }
+
+    @Test
+    public void testParseInvalidMissingMiddleBracket() throws Exception {
+        FieldReference f = FieldReference.from("[foo]bar[baz]");
+        assertEquals(0, f.getPath().length);
+        assertEquals("[foo]bar[baz]", f.getKey());
+    }
+
+    @Test
+    public void testParseInvalidOnlyOpenBracket() throws Exception {
+        FieldReference f = FieldReference.from("[");
+        assertEquals(0, f.getPath().length);
+        assertEquals("[", f.getKey());
+    }
+
+    @Test
+    public void testParseInvalidOnlyCloseBracket() throws Exception {
+        FieldReference f = FieldReference.from("]");
+        assertEquals(0, f.getPath().length);
+        assertEquals("]", f.getKey());
+    }
+
+    @Test
+    public void testParseInvalidLotsOfOpenBrackets() throws Exception {
+        FieldReference f = FieldReference.from("[[[[[[[[[[[]");
+        assertEquals(0, f.getPath().length);
+        assertEquals("[[[[[[[[[[[]", f.getKey());
+    }
+
+    @Test
+    public void testParseInvalidDoubleCloseBrackets() throws Exception {
+        FieldReference f = FieldReference.from("[foo]][bar]");
+        assertEquals(0, f.getPath().length);
+        assertEquals("[foo]][bar]", f.getKey());
+    }
+
+    @Test
+    public void testParseNestingSquareBrackets() throws Exception {
+        FieldReference f = FieldReference.from("[this[is]terrible]");
+        assertEquals(0, f.getPath().length);
+        assertEquals("this[is]terrible", f.getKey());
+    }
+
+    @Test
+    public void testParseChainedNestingSquareBrackets() throws Exception {
+        FieldReference f = FieldReference.from("[this[is]terrible][but][it[should[work]]]");
+        assertArrayEquals(new String[]{"this[is]terrible", "but"}, f.getPath());
+        assertEquals("it[should[work]]", f.getKey());
+    }
+
+    @Test
+    public void testParseLiteralSquareBrackets() throws Exception {
+        FieldReference f = FieldReference.from("this[index]");
+        assertEquals(0, f.getPath().length);
+        assertEquals("this[index]", f.getKey());
     }
 
     @Test


### PR DESCRIPTION
Rewrite of the parsing loop in `FieldReference#parse(CharSequece)` to prevent
crashes; when it encounters illegal syntax, it simply emits the input verbatim
as the resulting `FieldReference`'s key with an empty path.

Previously it either chunked the input in an undefined manner or in some cases
crashed the Logstash process with a `java.lang.ArrayIndexOutOfBoundsException`.

Additionally, it supports the presence of square brackets in keys fragments,
as long as they are balanced.

Below are a few examples of the change in behaviour in a selection of
illegal-syntax inputs (in {`path`}`key` format):

| input              | before               | after               |
|--------------------|----------------------|---------------------|
| `[`                | *crash*              | {}`[`               |
| `[[[[[[[[]`        | *crash*              | {}`[[[[[[[[]`       |
| `[foo[bar[baz`     | {`foo`,`bar`}`baz`   | {}`[foo[bar[baz`    |
| `[foo]][bar]`      | {`foo`}`bar`         | {}`[foo]][bar]`     |
| `[foo[bar]baz`     | {`foo`,`bar`}`baz`   | {}`[foo[bar]baz`    |
| `[what[the]heck]`  | {`what`,`the`}`heck` | {}`what[the]heck`   |
| `[this][is[cool]]` | {`this`,`is`}`cool`  | {`this`}`is[cool]`  |
| `oh[my]`           | {`oh`}`my`           | {}`oh[my]`          |

Reasolves: elastic/logstash#9524