### PR TITLE
logging: add missing `Logger#info?` to JRuby Ext class

### DIFF
--- a/logstash-core/src/main/java/org/logstash/log/LoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/LoggerExt.java
@@ -51,6 +51,11 @@ public class LoggerExt extends RubyObject {
         return logger.isWarnEnabled() ? context.tru : context.fals;
     }
 
+    @JRubyMethod(name = "info?")
+    public RubyBoolean isInfo(final ThreadContext context) {
+        return logger.isInfoEnabled() ? context.tru : context.fals;
+    }
+
     @JRubyMethod(name = "fatal?")
     public RubyBoolean isFatal(final ThreadContext context) {
         return logger.isDebugEnabled() ? context.tru : context.fals;


### PR DESCRIPTION
Fixes a regression introduced in elastic/logstash#9520 in which `Logger#info?` was missed in the porting of the logger to Java implementation.