### PR TITLE
Upgrade to PQ V2

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/QueueUpgrade.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/QueueUpgrade.java
@@ -21,7 +21,7 @@ import org.logstash.ackedqueue.io.MmapPageIOV1;
 import org.logstash.ackedqueue.io.MmapPageIOV2;
 import org.logstash.ackedqueue.io.PageIO;
 
-final class QueueUpgrade {
+public final class QueueUpgrade {
 
     private static final Logger LOGGER = LogManager.getLogger(QueueUpgrade.class);
 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/QueueUpgrade.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/QueueUpgrade.java
@@ -1,0 +1,91 @@
+package org.logstash.ackedqueue;
+
+import com.google.common.primitives.Ints;
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.logstash.Event;
+import org.logstash.ackedqueue.io.CheckpointIO;
+import org.logstash.ackedqueue.io.FileCheckpointIO;
+import org.logstash.ackedqueue.io.MmapPageIOV1;
+import org.logstash.ackedqueue.io.MmapPageIOV2;
+
+public final class QueueUpgrade {
+
+    private static final Logger LOGGER = LogManager.getLogger(QueueUpgrade.class);
+
+    private static final Pattern PAGE_NAME_PATTERN = Pattern.compile("page\\.\\d+");
+
+    private QueueUpgrade() {
+        // Utility Class.
+    }
+
+    public static void upgradeQueueDirectoryToV2(final Path path) throws IOException {
+        final File upgradeFile = path.resolve(".queue-version").toFile();
+        if (!upgradeFile.exists()) {
+            LOGGER.info("No PQ version file found, upgrading to PQ v2.");
+            try (final DirectoryStream<Path> files = Files.newDirectoryStream(path)) {
+                final Collection<File> oldFiles = new ArrayList<>();
+                files.forEach(file -> {
+                    final Matcher matcher = PAGE_NAME_PATTERN.matcher(file.getFileName().toString());
+                    if (matcher.matches()) {
+                        oldFiles.add(file.toFile());
+                    }
+                });
+                final CheckpointIO cpIo = new FileCheckpointIO(path);
+                for (final File v1PageFile : oldFiles) {
+                    final int num =
+                        Integer.parseInt(v1PageFile.getName().substring("page.".length()));
+                    try (final MmapPageIOV1 iov1 = new MmapPageIOV1(
+                        num, Ints.checkedCast(v1PageFile.length()), path
+                    )) {
+                        final Checkpoint cp = cpIo.read(cpIo.tailFileName(num));
+                        final int count = cp.getElementCount();
+                        final long minSeqNum = cp.getMinSeqNum();
+                        iov1.open(minSeqNum, count);
+                        for (int i = 0; i < count; ++i) {
+                            try {
+                                Event.deserialize(
+                                    iov1.read(minSeqNum + 1L, 1).getElements().get(0)
+                                );
+                            } catch (final IOException ex) {
+                                throw new IllegalStateException(
+                                    "Logstash was unable to upgrade your persistent queue." +
+                                        "Please either downgrade to version 6.2.3 and fully drain " +
+                                        "your persistent queue or delete your queue data.dir if you " +
+                                        "don't need to retain the data currently in your queue.", ex
+                                );
+                            }
+                        }
+                    }
+                }
+                for (final File v1PageFile : oldFiles) {
+                    try (final RandomAccessFile raf = new RandomAccessFile(v1PageFile, "rw")) {
+                        raf.seek(0L);
+                        raf.writeByte((int) MmapPageIOV2.VERSION_TWO);
+                    }
+                }
+            } catch (final Exception ex) {
+                throw new IllegalStateException("Queue upgrade to V2 failed.", ex);
+            }
+            Files.write(upgradeFile.toPath(), Ints.toByteArray(2), StandardOpenOption.CREATE);
+        } else {
+            if (Ints.fromByteArray(Files.readAllBytes(upgradeFile.toPath())) != 2) {
+                throw new IllegalStateException(
+                    "Unexpected upgrade file contents found."
+                );
+            }
+            LOGGER.debug("PQ version file with correct version information (v2) found.");
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/QueueUpgrade.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/QueueUpgrade.java
@@ -8,10 +8,10 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.logstash.Event;
@@ -19,8 +19,9 @@ import org.logstash.ackedqueue.io.CheckpointIO;
 import org.logstash.ackedqueue.io.FileCheckpointIO;
 import org.logstash.ackedqueue.io.MmapPageIOV1;
 import org.logstash.ackedqueue.io.MmapPageIOV2;
+import org.logstash.ackedqueue.io.PageIO;
 
-public final class QueueUpgrade {
+final class QueueUpgrade {
 
     private static final Logger LOGGER = LogManager.getLogger(QueueUpgrade.class);
 
@@ -32,64 +33,86 @@ public final class QueueUpgrade {
 
     public static void upgradeQueueDirectoryToV2(final Path path) throws IOException {
         final File upgradeFile = path.resolve(".queue-version").toFile();
-        if (!upgradeFile.exists()) {
-            LOGGER.info("No PQ version file found, upgrading to PQ v2.");
-            try (final DirectoryStream<Path> files = Files.newDirectoryStream(path)) {
-                final Collection<File> oldFiles = new ArrayList<>();
-                files.forEach(file -> {
-                    final Matcher matcher = PAGE_NAME_PATTERN.matcher(file.getFileName().toString());
-                    if (matcher.matches()) {
-                        oldFiles.add(file.toFile());
-                    }
-                });
-                final CheckpointIO cpIo = new FileCheckpointIO(path);
-                for (final File v1PageFile : oldFiles) {
-                    final int num =
-                        Integer.parseInt(v1PageFile.getName().substring("page.".length()));
-                    try (final MmapPageIOV1 iov1 = new MmapPageIOV1(
-                        num, Ints.checkedCast(v1PageFile.length()), path
-                    )) {
-                        final String cpFilename = cpIo.tailFileName(num);
-                        final Checkpoint cp;
-                        if (path.resolve(cpFilename).toFile().exists()) {
-                            cp = cpIo.read(cpFilename);
-                        } else {
-                            cp = cpIo.read("checkpoint.head");
-                        }
-                        final int count = cp.getElementCount();
-                        final long minSeqNum = cp.getMinSeqNum();
-                        iov1.open(minSeqNum, count);
-                        for (int i = 0; i < count; ++i) {
-                            try {
-                                Event.deserialize(
-                                    iov1.read(minSeqNum + 1L, 1).getElements().get(0)
-                                );
-                            } catch (final IOException ex) {
-                                throw new IllegalStateException(
-                                    "Logstash was unable to upgrade your persistent queue." +
-                                        "Please either downgrade to version 6.2.3 and fully drain " +
-                                        "your persistent queue or delete your queue data.dir if you " +
-                                        "don't need to retain the data currently in your queue.", ex
-                                );
-                            }
-                        }
-                    }
-                }
-                for (final File v1PageFile : oldFiles) {
-                    try (final RandomAccessFile raf = new RandomAccessFile(v1PageFile, "rw")) {
-                        raf.seek(0L);
-                        raf.writeByte((int) MmapPageIOV2.VERSION_TWO);
-                    }
-                }
-            }
-            Files.write(upgradeFile.toPath(), Ints.toByteArray(2), StandardOpenOption.CREATE);
-        } else {
+        if (upgradeFile.exists()) {
             if (Ints.fromByteArray(Files.readAllBytes(upgradeFile.toPath())) != 2) {
                 throw new IllegalStateException(
                     "Unexpected upgrade file contents found."
                 );
             }
             LOGGER.debug("PQ version file with correct version information (v2) found.");
+        } else {
+            LOGGER.info("No PQ version file found, upgrading to PQ v2.");
+            try (final DirectoryStream<Path> files = Files.newDirectoryStream(path)) {
+                final Collection<File> pageFiles = StreamSupport.stream(
+                    files.spliterator(), false
+                ).filter(
+                    file -> PAGE_NAME_PATTERN.matcher(file.getFileName().toString()).matches()
+                ).map(Path::toFile).collect(Collectors.toList());
+                final CheckpointIO cpIo = new FileCheckpointIO(path);
+                pageFiles.forEach(p -> validatePageFile(path, cpIo, p));
+                pageFiles.forEach(QueueUpgrade::setV2);
+            }
+            Files.write(upgradeFile.toPath(), Ints.toByteArray(2), StandardOpenOption.CREATE);
         }
+    }
+
+    private static void validatePageFile(final Path path, final CheckpointIO cpIo, final File v1PageFile) {
+        final int num =
+            Integer.parseInt(v1PageFile.getName().substring("page.".length()));
+        try (final MmapPageIOV1 iov1 = new MmapPageIOV1(
+            num, Ints.checkedCast(v1PageFile.length()), path
+        )) {
+            final Checkpoint cp = loadCheckpoint(path, cpIo, num);
+            final int count = cp.getElementCount();
+            final long minSeqNum = cp.getMinSeqNum();
+            iov1.open(minSeqNum, count);
+            for (int i = 0; i < count; ++i) {
+                verifyEvent(iov1, minSeqNum + i);
+            }
+        } catch (final IOException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    private static void verifyEvent(final PageIO iov1, final long seqNum) {
+        try {
+            Event.deserialize(iov1.read(seqNum, 1).getElements().get(0));
+        } catch (final IOException ex) {
+            failValidation(ex);
+        }
+    }
+
+    private static void setV2(final File v1PageFile) {
+        try (final RandomAccessFile raf = new RandomAccessFile(v1PageFile, "rw")) {
+            raf.seek(0L);
+            raf.writeByte((int) MmapPageIOV2.VERSION_TWO);
+        } catch (final IOException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    private static Checkpoint loadCheckpoint(final Path path, final CheckpointIO cpIo,
+        final int num) throws IOException {
+        final String cpFilename = cpIo.tailFileName(num);
+        final Checkpoint cp;
+        if (path.resolve(cpFilename).toFile().exists()) {
+            cp = cpIo.read(cpFilename);
+        } else {
+            cp = cpIo.read("checkpoint.head");
+            if (cp.getPageNum() != num) {
+                throw new IllegalStateException(
+                    String.format("No checkpoint file found for page %d", num)
+                );
+            }
+        }
+        return cp;
+    }
+
+    private static void failValidation(final Throwable ex) {
+        LOGGER.error("Logstash was unable to upgrade your persistent queue data." +
+            "Please either downgrade to version 6.2.3 and fully drain " +
+            "your persistent queue or delete your queue data.dir if you " +
+            "don't need to retain the data currently in your queue.");
+        throw new IllegalStateException(ex);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/MmapPageIOV2.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/MmapPageIOV2.java
@@ -1,0 +1,391 @@
+package org.logstash.ackedqueue.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.CRC32;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.logstash.LogstashJavaCompat;
+import org.logstash.ackedqueue.SequencedList;
+
+public final class MmapPageIOV2 implements PageIO {
+
+    public static final byte VERSION_TWO = (byte) 2;
+    public static final int VERSION_SIZE = Byte.BYTES;
+    public static final int CHECKSUM_SIZE = Integer.BYTES;
+    public static final int LENGTH_SIZE = Integer.BYTES;
+    public static final int SEQNUM_SIZE = Long.BYTES;
+    public static final int MIN_CAPACITY = VERSION_SIZE + SEQNUM_SIZE + LENGTH_SIZE + 1 + CHECKSUM_SIZE; // header overhead plus elements overhead to hold a single 1 byte element
+    public static final int HEADER_SIZE = 1;     // version byte
+    public static final boolean VERIFY_CHECKSUM = true;
+
+    private static final Logger LOGGER = LogManager.getLogger(MmapPageIOV2.class);
+
+    /**
+     * Cleaner function for forcing unmapping of backing {@link MmapPageIOV2#buffer}.
+     */
+    private static final ByteBufferCleaner BUFFER_CLEANER =
+        LogstashJavaCompat.setupBytebufferCleaner();
+
+    private final File file;
+
+    private final CRC32 checkSummer;
+
+    private final IntVector offsetMap;
+
+    private int capacity; // page capacity is an int per the ByteBuffer class.
+    private long minSeqNum; // TODO: to make minSeqNum final we have to pass in the minSeqNum in the constructor and not set it on first write
+    private int elementCount;
+    private int head; // head is the write position and is an int per ByteBuffer class position
+    private byte version;
+
+    private MappedByteBuffer buffer;
+
+    public MmapPageIOV2(int pageNum, int capacity, Path dirPath) {
+        this.minSeqNum = 0;
+        this.elementCount = 0;
+        this.version = 0;
+        this.head = 0;
+        this.capacity = capacity;
+        this.offsetMap = new IntVector();
+        this.checkSummer = new CRC32();
+        this.file = dirPath.resolve("page." + pageNum).toFile();
+    }
+
+    @Override
+    public void open(long minSeqNum, int elementCount) throws IOException {
+        mapFile();
+        buffer.position(0);
+        this.version = buffer.get();
+        validateVersion(this.version);
+        this.head = 1;
+
+        this.minSeqNum = minSeqNum;
+        this.elementCount = elementCount;
+
+        if (this.elementCount > 0) {
+            // verify first seqNum to be same as expected minSeqNum
+            long seqNum = buffer.getLong();
+            if (seqNum != this.minSeqNum) {
+                throw new IOException(String.format("first seqNum=%d is different than minSeqNum=%d", seqNum, this.minSeqNum));
+            }
+
+            // reset back position to first seqNum
+            buffer.position(this.head);
+
+            for (int i = 0; i < this.elementCount; i++) {
+                // verify that seqNum must be of strict + 1 increasing order
+                readNextElement(this.minSeqNum + i, !VERIFY_CHECKSUM);
+            }
+        }
+    }
+
+    @Override
+    public SequencedList<byte[]> read(long seqNum, int limit) throws IOException {
+        assert seqNum >= this.minSeqNum :
+            String.format("seqNum=%d < minSeqNum=%d", seqNum, this.minSeqNum);
+        assert seqNum <= maxSeqNum() :
+            String.format("seqNum=%d is > maxSeqNum=%d", seqNum, maxSeqNum());
+
+        List<byte[]> elements = new ArrayList<>();
+        final LongVector seqNums = new LongVector(limit);
+
+        int offset = this.offsetMap.get((int) (seqNum - this.minSeqNum));
+
+        buffer.position(offset);
+
+        for (int i = 0; i < limit; i++) {
+            long readSeqNum = buffer.getLong();
+
+            assert readSeqNum == (seqNum + i) :
+                String.format("unmatched seqNum=%d to readSeqNum=%d", seqNum + i, readSeqNum);
+
+            int readLength = buffer.getInt();
+            byte[] readBytes = new byte[readLength];
+            buffer.get(readBytes);
+            int checksum = buffer.getInt();
+            int computedChecksum = checksum(readBytes);
+            if (computedChecksum != checksum) {
+                throw new IOException(String.format("computed checksum=%d != checksum for file=%d", computedChecksum, checksum));
+            }
+
+            elements.add(readBytes);
+            seqNums.add(readSeqNum);
+
+            if (seqNum + i >= maxSeqNum()) {
+                break;
+            }
+        }
+
+        return new SequencedList<>(elements, seqNums);
+    }
+
+    // recover will overwrite/update/set this object minSeqNum, capacity and elementCount attributes
+    // to reflect what it recovered from the page
+    @Override
+    public void recover() throws IOException {
+        mapFile();
+        buffer.position(0);
+        this.version = buffer.get();
+        validateVersion(this.version);
+        this.head = 1;
+
+        // force minSeqNum to actual first element seqNum
+        this.minSeqNum = buffer.getLong();
+        // reset back position to first seqNum
+        buffer.position(this.head);
+
+        // reset elementCount to 0 and increment to octal number of valid elements found
+        this.elementCount = 0;
+
+        for (int i = 0; ; i++) {
+            try {
+                // verify that seqNum must be of strict + 1 increasing order
+                readNextElement(this.minSeqNum + i, VERIFY_CHECKSUM);
+                this.elementCount += 1;
+            } catch (MmapPageIOV2.PageIOInvalidElementException e) {
+                // simply stop at first invalid element
+                LOGGER.debug("PageIO recovery element index:{}, readNextElement exception: {}", i, e.getMessage());
+                break;
+            }
+        }
+
+        // if we were not able to read any element just reset minSeqNum to zero
+        if (this.elementCount <= 0) {
+            this.minSeqNum = 0;
+        }
+    }
+
+    @Override
+    public void create() throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(this.file, "rw")) {
+            this.buffer = raf.getChannel().map(FileChannel.MapMode.READ_WRITE, 0, this.capacity);
+        }
+        buffer.position(0);
+        buffer.put(VERSION_TWO);
+        this.head = 1;
+        this.minSeqNum = 0L;
+        this.elementCount = 0;
+    }
+
+    @Override
+    public void deactivate() {
+        close(); // close can be called multiple times
+    }
+
+    @Override
+    public void activate() throws IOException {
+        if (this.buffer == null) {
+            try (RandomAccessFile raf = new RandomAccessFile(this.file, "rw")) {
+                this.buffer = raf.getChannel().map(FileChannel.MapMode.READ_WRITE, 0, this.capacity);
+            }
+            this.buffer.load();
+        }
+        // TODO: do we need to check is the channel is still open? not sure how it could be closed
+    }
+
+    @Override
+    public void ensurePersisted() {
+        this.buffer.force();
+    }
+
+    @Override
+    public void purge() throws IOException {
+        close();
+        Files.delete(this.file.toPath());
+        this.head = 0;
+    }
+
+    @Override
+    public void write(byte[] bytes, long seqNum) {
+        write(bytes, seqNum, bytes.length, checksum(bytes));
+    }
+
+    @Override
+    public void close() {
+        if (this.buffer != null) {
+            this.buffer.force();
+            BUFFER_CLEANER.clean(buffer);
+
+        }
+        this.buffer = null;
+    }
+
+    @Override
+    public int getCapacity() {
+        return this.capacity;
+    }
+
+    @Override
+    public long getMinSeqNum() {
+        return this.minSeqNum;
+    }
+
+    @Override
+    public int getElementCount() {
+        return this.elementCount;
+    }
+
+    @Override
+    public boolean hasSpace(int bytes) {
+        int bytesLeft = this.capacity - this.head;
+        return persistedByteCount(bytes) <= bytesLeft;
+    }
+
+    @Override
+    public int persistedByteCount(int byteCount) {
+        return SEQNUM_SIZE + LENGTH_SIZE + byteCount + CHECKSUM_SIZE;
+    }
+
+    @Override
+    public int getHead() {
+        return this.head;
+    }
+
+    private int checksum(byte[] bytes) {
+        checkSummer.reset();
+        checkSummer.update(bytes, 0, bytes.length);
+        return (int) checkSummer.getValue();
+    }
+
+    private long maxSeqNum() {
+        return this.minSeqNum + this.elementCount - 1;
+    }
+
+    // memory map data file to this.buffer and read initial version byte
+    private void mapFile() throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(this.file, "rw")) {
+
+            if (raf.length() > Integer.MAX_VALUE) {
+                throw new IOException("Page file too large " + this.file);
+            }
+            int pageFileCapacity = (int) raf.length();
+
+            // update capacity to actual raf length. this can happen if a page size was changed on a non empty queue directory for example.
+            this.capacity = pageFileCapacity;
+
+            if (this.capacity < MIN_CAPACITY) {
+                throw new IOException(String.format("Page file size is too small to hold elements"));
+            }
+            this.buffer = raf.getChannel().map(FileChannel.MapMode.READ_WRITE, 0, this.capacity);
+        }
+        this.buffer.load();
+    }
+
+    // read and validate next element at page head
+    // @param verifyChecksum if true the actual element data will be read + checksumed and compared to written checksum
+    private void readNextElement(long expectedSeqNum, boolean verifyChecksum) throws MmapPageIOV2.PageIOInvalidElementException {
+        // if there is no room for the seqNum and length bytes stop here
+        // TODO: I know this isn't a great exception message but at the time of writing I couldn't come up with anything better :P
+        if (this.head + SEQNUM_SIZE + LENGTH_SIZE > capacity) {
+            throw new MmapPageIOV2.PageIOInvalidElementException(
+                "cannot read seqNum and length bytes past buffer capacity");
+        }
+
+        int elementOffset = this.head;
+        int newHead = this.head;
+
+        long seqNum = buffer.getLong();
+        newHead += SEQNUM_SIZE;
+
+        if (seqNum != expectedSeqNum) {
+            throw new MmapPageIOV2.PageIOInvalidElementException(
+                String.format("Element seqNum %d is expected to be %d", seqNum, expectedSeqNum));
+        }
+
+        int length = buffer.getInt();
+        newHead += LENGTH_SIZE;
+
+        // length must be > 0
+        if (length <= 0) {
+            throw new MmapPageIOV2.PageIOInvalidElementException("Element invalid length");
+        }
+
+        // if there is no room for the proposed data length and checksum just stop here
+        if (newHead + length + CHECKSUM_SIZE > capacity) {
+            throw new MmapPageIOV2.PageIOInvalidElementException(
+                "cannot read element payload and checksum past buffer capacity");
+        }
+
+        if (verifyChecksum) {
+            // read data and compute checksum;
+            this.checkSummer.reset();
+            final int prevLimit = buffer.limit();
+            buffer.limit(buffer.position() + length);
+            this.checkSummer.update(buffer);
+            buffer.limit(prevLimit);
+            int checksum = buffer.getInt();
+            int computedChecksum = (int) this.checkSummer.getValue();
+            if (computedChecksum != checksum) {
+                throw new MmapPageIOV2.PageIOInvalidElementException(
+                    "Element invalid checksum");
+            }
+        }
+
+        // at this point we recovered a valid element
+        this.offsetMap.add(elementOffset);
+        this.head = newHead + length + CHECKSUM_SIZE;
+
+        buffer.position(this.head);
+    }
+
+    private int write(byte[] bytes, long seqNum, int length, int checksum) {
+        // since writes always happen at head, we can just append head to the offsetMap
+        assert this.offsetMap.size() == this.elementCount :
+            String.format("offsetMap size=%d != elementCount=%d", this.offsetMap.size(), this.elementCount);
+
+        int initialHead = this.head;
+        buffer.position(this.head);
+        buffer.putLong(seqNum);
+        buffer.putInt(length);
+        buffer.put(bytes);
+        buffer.putInt(checksum);
+        this.head += persistedByteCount(bytes.length);
+
+        assert this.head == buffer.position() :
+            String.format("head=%d != buffer position=%d", this.head, buffer.position());
+
+        if (this.elementCount <= 0) {
+            this.minSeqNum = seqNum;
+        }
+        this.offsetMap.add(initialHead);
+        this.elementCount++;
+
+        return initialHead;
+    }
+
+    // we don't have different versions yet so simply check if the version is VERSION_ONE for basic integrity check
+    // and if an unexpected version byte is read throw PageIOInvalidVersionException
+    private static void validateVersion(byte version)
+        throws MmapPageIOV2.PageIOInvalidVersionException {
+        if (version != VERSION_TWO) {
+            throw new MmapPageIOV2.PageIOInvalidVersionException(String
+                .format("Expected page version=%d but found version=%d", VERSION_TWO, version));
+        }
+    }
+
+    public static final class PageIOInvalidElementException extends IOException {
+
+        private static final long serialVersionUID = 1L;
+
+        public PageIOInvalidElementException(String message) {
+            super(message);
+        }
+    }
+
+    public static final class PageIOInvalidVersionException extends IOException {
+
+        private static final long serialVersionUID = 1L;
+
+        public PageIOInvalidVersionException(String message) {
+            super(message);
+        }
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/HeadPageTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/HeadPageTest.java
@@ -7,7 +7,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.logstash.ackedqueue.io.MmapPageIO;
+import org.logstash.ackedqueue.io.MmapPageIOV2;
 import org.logstash.ackedqueue.io.PageIO;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -33,7 +33,7 @@ public class HeadPageTest {
         // Close method on Page requires an instance of Queue that has already been opened.
         try (Queue q = new Queue(s)) {
             q.open();
-            PageIO pageIO = new MmapPageIO(0, 100, Paths.get(dataPath));
+            PageIO pageIO = new MmapPageIOV2(0, 100, Paths.get(dataPath));
             pageIO.create();
             try (final Page p = PageFactory.newHeadPage(0, q, pageIO)) {
                 assertThat(p.getPageNum(), is(equalTo(0)));

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
@@ -24,7 +24,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.logstash.ackedqueue.io.LongVector;
-import org.logstash.ackedqueue.io.MmapPageIO;
+import org.logstash.ackedqueue.io.MmapPageIOV2;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -91,7 +91,7 @@ public class QueueTest {
     @Test(timeout = 5000)
     public void writeToFullyAckedHeadpage() throws IOException {
         final Queueable element = new StringElement("foobarbaz");
-        final int page = element.serialize().length * 2 + MmapPageIO.MIN_CAPACITY;
+        final int page = element.serialize().length * 2 + MmapPageIOV2.MIN_CAPACITY;
         // Queue that can only hold one element per page.
         try (Queue q = new Queue(
             TestSettings.persistedQueueSettings(page, page * 2 - 1, dataPath))) {
@@ -109,7 +109,7 @@ public class QueueTest {
 
     @Test
     public void canReadBatchZeroSize() throws IOException {
-        final int page = MmapPageIO.MIN_CAPACITY;
+        final int page = MmapPageIOV2.MIN_CAPACITY;
         try (Queue q = new Queue(
             TestSettings.persistedQueueSettings(page, page * 2 - 1, dataPath))) {
             q.open();

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTestHelpers.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTestHelpers.java
@@ -1,7 +1,7 @@
 package org.logstash.ackedqueue;
 
 import java.io.IOException;
-import org.logstash.ackedqueue.io.MmapPageIO;
+import org.logstash.ackedqueue.io.MmapPageIOV2;
 
 /**
  * Class containing common methods to help DRY up acked queue tests.
@@ -9,7 +9,7 @@ import org.logstash.ackedqueue.io.MmapPageIO;
 public class QueueTestHelpers {
 
     /**
-     * Returns the {@link org.logstash.ackedqueue.io.MmapPageIO} capacity required for the supplied element
+     * Returns the {@link MmapPageIOV2} capacity required for the supplied element
      * @param element
      * @return int - capacity required for the supplied element
      * @throws IOException Throws if a serialization error occurs
@@ -25,6 +25,6 @@ public class QueueTestHelpers {
      * @throws IOException Throws if a serialization error occurs
      */
     public static int computeCapacityForMmapPageIO(final Queueable element, int count) throws IOException {
-        return MmapPageIO.HEADER_SIZE + (count * (MmapPageIO.SEQNUM_SIZE + MmapPageIO.LENGTH_SIZE + element.serialize().length + MmapPageIO.CHECKSUM_SIZE));
+        return MmapPageIOV2.HEADER_SIZE + (count * (MmapPageIOV2.SEQNUM_SIZE + MmapPageIOV2.LENGTH_SIZE + element.serialize().length + MmapPageIOV2.CHECKSUM_SIZE));
     }
 }

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/io/FileMmapIOTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/io/FileMmapIOTest.java
@@ -17,8 +17,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FileMmapIOTest {
     private Path folder;
-    private MmapPageIO writeIo;
-    private MmapPageIO readIo;
+    private MmapPageIOV2 writeIo;
+    private MmapPageIOV2 readIo;
     private int pageNum;
 
     @Rule
@@ -30,8 +30,8 @@ public class FileMmapIOTest {
         folder = temporaryFolder
                 .newFolder("pages")
                 .toPath();
-        writeIo = new MmapPageIO(pageNum, 1024, folder);
-        readIo = new MmapPageIO(pageNum, 1024, folder);
+        writeIo = new MmapPageIOV2(pageNum, 1024, folder);
+        readIo = new MmapPageIOV2(pageNum, 1024, folder);
     }
 
     @Test

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/io/MmapPageIOTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/io/MmapPageIOTest.java
@@ -30,11 +30,11 @@ public class MmapPageIOTest {
         final int NEW_CAPACITY = 2048;
         final int PAGE_NUM = 0;
 
-        try (PageIO io1 = new MmapPageIO(PAGE_NUM, ORIGINAL_CAPACITY, dir)) {
+        try (PageIO io1 = new MmapPageIOV2(PAGE_NUM, ORIGINAL_CAPACITY, dir)) {
             io1.create();
         }
 
-        try (PageIO io2 = new MmapPageIO(PAGE_NUM, NEW_CAPACITY, dir)) {
+        try (PageIO io2 = new MmapPageIOV2(PAGE_NUM, NEW_CAPACITY, dir)) {
             io2.open(0, PAGE_NUM);
             assertThat(io2.getCapacity(), is(equalTo(ORIGINAL_CAPACITY)));
         }


### PR DESCRIPTION
Implemented the upgrade/check functionality as such:

* Check if version file exists
  * If it exists, do nothing
  * If it doesn't exist:
     * Try to read through all pages assuming they are v1 (created a special `PageIO` for this that mounts in read only mode to be 100% sure that we don't do any writes to the PQ before we verify/upgrade it ... the invocation of this functionality also is the first thing we do in the PQ before anything else)
     * If and only if all pages pass validation (meaning every `Event` in them deserialises without `Exception`, we change the version byte in all of them from `0x01` to `0x02`)
Failed upgrade would look like:

Should be safe right?

Error message on failure:

```sh
018-05-09T08:53:33,874][INFO ][org.logstash.ackedqueue.QueueUpgrade] No PQ version file found, upgrading to PQ v2.
[2018-05-09T08:53:34,129][ERROR][org.logstash.ackedqueue.QueueUpgrade] Logstash was unable to upgrade your persistent queue data.Please either downgrade to version 6.2.3 and fully drain your persistent queue or delete your queue data.dir if you don't need to retain the data currently in your queue.
[2018-05-09T08:53:34,150][ERROR][logstash.javapipeline    ] Logstash failed to create queue {:pipeline_id=>"main", "exception"=>"com.fasterxml.jackson.databind.JsonMappingException: (was java.lang.NullPointerException) (through reference chain: java.util.HashMap[\"DATA\"]->org.logstash.ConvertedMap[\"message\"])", "backtrace"=>["org.logstash.ackedqueue.QueueUpgrade.failValidation(QueueUpgrade.java:116)", "org.logstash.ackedqueue.QueueUpgrade.verifyEvent(QueueUpgrade.java:81)", "org.logstash.ackedqueue.QueueUpgrade.validatePageFile(QueueUpgrade.java:70)", "org.logstash.ackedqueue.QueueUpgrade.lambda$upgradeQueueDirectoryToV2$1(QueueUpgrade.java:52)", "java.util.ArrayList.forEach(ArrayList.java:1249)", "org.logstash.ackedqueue.QueueUpgrade.upgradeQueueDirectoryToV2(QueueUpgrade.java:52)", "org.logstash.ackedqueue.Queue.open(Queue.java:159)", "org.logstash.ackedqueue.ext.JRubyAckedQueueExt.open(JRubyAckedQueueExt.java:96)", "org.logstash.ackedqueue.ext.JRubyWrappedAckedQueueExt.ruby_initialize(JRubyWrappedAckedQueueExt.java:37)", "org.logstash.ackedqueue.ext.JRubyWrappedAckedQueueExt$INVOKER$i$0$7$ruby_initialize.call(JRubyWrappedAckedQueueExt$INVOKER$i$0$7$ruby_initialize.gen)", "org.jruby.internal.runtime.methods.JavaMethod$JavaMethodN.call(JavaMethod.java:743)", "org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:298)", "org.jruby.runtime.callsite.CachingCallSite.callBlock(CachingCallSite.java:79)", "org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:83)", "org.jruby.RubyClass.newInstance(RubyClass.java:1022)", "org.jruby.RubyClass$INVOKER$i$newInstance.call(RubyClass$INVOKER$i$newInstance.gen)", "org.jruby.ir.targets.InvokeSite.invoke(InvokeSite.java:145)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.queue_factory.RUBY$method$create$0(/Users/brownbear/src/logstash/logstash-core/lib/logstash/queue_factory.rb:22)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.queue_factory.RUBY$method$create$0$__VARARGS__(/Users/brownbear/src/logstash/logstash-core/lib/logstash/queue_factory.rb)", "org.jruby.internal.runtime.methods.CompiledIRMethod.call(CompiledIRMethod.java:77)", "org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:93)", "org.jruby.ir.targets.InvokeSite.invoke(InvokeSite.java:145)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.java_pipeline.RUBY$method$initialize$0(/Users/brownbear/src/logstash/logstash-core/lib/logstash/java_pipeline.rb:131)", "org.jruby.internal.runtime.methods.CompiledIRMethod.call(CompiledIRMethod.java:77)", "org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:93)", "org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:298)", "org.jruby.runtime.callsite.CachingCallSite.callBlock(CachingCallSite.java:79)", "org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:83)", "org.jruby.RubyClass.newInstance(RubyClass.java:1022)", "org.jruby.RubyClass$INVOKER$i$newInstance.call(RubyClass$INVOKER$i$newInstance.gen)", "org.jruby.ir.targets.InvokeSite.invoke(InvokeSite.java:145)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.pipeline_action.create.RUBY$method$execute$0(/Users/brownbear/src/logstash/logstash-core/lib/logstash/pipeline_action/create.rb:38)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.pipeline_action.create.RUBY$method$execute$0$__VARARGS__(/Users/brownbear/src/logstash/logstash-core/lib/logstash/pipeline_action/create.rb)", "org.jruby.internal.runtime.methods.CompiledIRMethod.call(CompiledIRMethod.java:77)", "org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:93)", "org.jruby.ir.targets.InvokeSite.invoke(InvokeSite.java:145)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.agent.RUBY$block$converge_state$2(/Users/brownbear/src/logstash/logstash-core/lib/logstash/agent.rb:298)", "org.jruby.runtime.CompiledIRBlockBody.callDirect(CompiledIRBlockBody.java:145)", "org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:71)", "org.jruby.runtime.Block.call(Block.java:124)", "org.jruby.RubyProc.call(RubyProc.java:289)", "org.jruby.RubyProc.call(RubyProc.java:246)", "org.jruby.internal.runtime.RubyRunnable.run(RubyRunnable.java:104)", "java.lang.Thread.run(Thread.java:748)"]}
[2018-05-09T08:53:34,160][ERROR][logstash.agent           ] Failed to execute action {:action=>LogStash::PipelineAction::Create/pipeline_id:main, :exception=>"Java::JavaLang::IllegalStateException", :message=>"com.fasterxml.jackson.databind.JsonMappingException: (was java.lang.NullPointerException) (through reference chain: java.util.HashMap[\"DATA\"]->org.logstash.ConvertedMap[\"message\"])", :backtrace=>["org.logstash.ackedqueue.QueueUpgrade.failValidation(QueueUpgrade.java:116)", "org.logstash.ackedqueue.QueueUpgrade.verifyEvent(QueueUpgrade.java:81)", "org.logstash.ackedqueue.QueueUpgrade.validatePageFile(QueueUpgrade.java:70)", "org.logstash.ackedqueue.QueueUpgrade.lambda$upgradeQueueDirectoryToV2$1(QueueUpgrade.java:52)", "java.util.ArrayList.forEach(ArrayList.java:1249)", "org.logstash.ackedqueue.QueueUpgrade.upgradeQueueDirectoryToV2(QueueUpgrade.java:52)", "org.logstash.ackedqueue.Queue.open(Queue.java:159)", "org.logstash.ackedqueue.ext.JRubyAckedQueueExt.open(JRubyAckedQueueExt.java:96)", "org.logstash.ackedqueue.ext.JRubyWrappedAckedQueueExt.ruby_initialize(JRubyWrappedAckedQueueExt.java:37)", "org.logstash.ackedqueue.ext.JRubyWrappedAckedQueueExt$INVOKER$i$0$7$ruby_initialize.call(JRubyWrappedAckedQueueExt$INVOKER$i$0$7$ruby_initialize.gen)", "org.jruby.internal.runtime.methods.JavaMethod$JavaMethodN.call(JavaMethod.java:743)", "org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:298)", "org.jruby.runtime.callsite.CachingCallSite.callBlock(CachingCallSite.java:79)", "org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:83)", "org.jruby.RubyClass.newInstance(RubyClass.java:1022)", "org.jruby.RubyClass$INVOKER$i$newInstance.call(RubyClass$INVOKER$i$newInstance.gen)", "org.jruby.ir.targets.InvokeSite.invoke(InvokeSite.java:145)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.queue_factory.RUBY$method$create$0(/Users/brownbear/src/logstash/logstash-core/lib/logstash/queue_factory.rb:22)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.queue_factory.RUBY$method$create$0$__VARARGS__(/Users/brownbear/src/logstash/logstash-core/lib/logstash/queue_factory.rb)", "org.jruby.internal.runtime.methods.CompiledIRMethod.call(CompiledIRMethod.java:77)", "org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:93)", "org.jruby.ir.targets.InvokeSite.invoke(InvokeSite.java:145)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.java_pipeline.RUBY$method$initialize$0(/Users/brownbear/src/logstash/logstash-core/lib/logstash/java_pipeline.rb:131)", "org.jruby.internal.runtime.methods.CompiledIRMethod.call(CompiledIRMethod.java:77)", "org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:93)", "org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:298)", "org.jruby.runtime.callsite.CachingCallSite.callBlock(CachingCallSite.java:79)", "org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:83)", "org.jruby.RubyClass.newInstance(RubyClass.java:1022)", "org.jruby.RubyClass$INVOKER$i$newInstance.call(RubyClass$INVOKER$i$newInstance.gen)", "org.jruby.ir.targets.InvokeSite.invoke(InvokeSite.java:145)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.pipeline_action.create.RUBY$method$execute$0(/Users/brownbear/src/logstash/logstash-core/lib/logstash/pipeline_action/create.rb:38)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.pipeline_action.create.RUBY$method$execute$0$__VARARGS__(/Users/brownbear/src/logstash/logstash-core/lib/logstash/pipeline_action/create.rb)", "org.jruby.internal.runtime.methods.CompiledIRMethod.call(CompiledIRMethod.java:77)", "org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:93)", "org.jruby.ir.targets.InvokeSite.invoke(InvokeSite.java:145)", "Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.agent.RUBY$block$converge_state$2(/Users/brownbear/src/logstash/logstash-core/lib/logstash/agent.rb:298)", "org.jruby.runtime.CompiledIRBlockBody.callDirect(CompiledIRBlockBody.java:145)", "org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:71)", "org.jruby.runtime.Block.call(Block.java:124)", "org.jruby.RubyProc.call(RubyProc.java:289)", "org.jruby.RubyProc.call(RubyProc.java:246)", "org.jruby.internal.runtime.RubyRunnable.run(RubyRunnable.java:104)", "java.lang.Thread.run(Thread.java:748)"]}
[2018-05-09T08:53:34,246][FATAL][logstash.runner          ] An unexpected error occurred! {:error=>#<LogStash::Error: Don't know how to handle `Java::JavaLang::IllegalStateException` for `PipelineAction::Create<main>`>, :backtrace=>["/Users/brownbear/src/logstash/logstash-core/lib/logstash/converge_result.rb:26:in `create'", "/Users/brownbear/src/logstash/logstash-core/lib/logstash/converge_result.rb:66:in `add'", "/Users/brownbear/src/logstash/logstash-core/lib/logstash/agent.rb:310:in `block in converge_state'"]}
[2018-05-09T08:53:34,337][ERROR][org.logstash.Logstash    ] java.lang.IllegalStateException: Logstash stopped processing because of an error: (SystemExit) exit
```

I know it's a little verbose, but I think the level of detail is well worth it for handling issues if they come up right?