### PR TITLE
Improve breaking PQ change doc for 6.3.0

### DIFF
--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -1,14 +1,14 @@
 [[breaking-changes]]
 
-== Breaking Changes Across PQ Versions
+== Breaking Changes Across PQ Versions Prior to Logstash 6.3.0
 
-We regret to say that due to several serialization issues users will have to take some extra steps when upgrading Logstash instances using persistent queues. While we do strive to maintain backward compatibility within a given major release these bugs have forced us to break that compatibility to ensure correctness of operation. For more technical details on this issue please check our tracking github issue for this matter, https://github.com/elastic/logstash/issues/9494[#9494].
+The following applies only to users upgrading from Logstash installations that used the persistent queue prior to 6.3.0.
 
-If you are upgrading Logstash and use the persistent queue, we strongly recommend that you drain or delete the persistent queue before you upgrade.
+We regret to say that due to several serialization issues prior to Logstash 6.3.0 users will have to take some extra steps when upgrading Logstash instances using persistent queues. While we do strive to maintain backward compatibility within a given major release these bugs forced us to break that compatibility in version 6.3.0 to ensure correctness of operation. For more technical details on this issue please check our tracking github issue for this matter, https://github.com/elastic/logstash/issues/9494[#9494].
+
+If you are upgrading Logstash from a pre 6.3.0 version and use the persistent queue, we strongly recommend that you drain or delete the persistent queue before you upgrade.
 
 To drain the queue, enable the `queue.drain` setting, and then shutdown Logstash. Wait for it to shutdown completely. This may take a while if you have a large queue backlog.
-
-We are working to resolve issues with data incompatibilities in our 6.3.0 release. These steps won’t be required when you upgrade from a 6.3.0 or greater release to a later 6.x Logstash release.
 
 == Breaking Changes in 6.0.0
 


### PR DESCRIPTION
Once 6.3.0 is the newest release the phrasing should reflect that.

This only targets the 6.3.0 and 6.x branches