### PR TITLE
Revert #9516 ([X-Pack Monitoring] Report pipeline protocol) from 6.x

### DIFF
--- a/logstash-core/lib/logstash/config/pipeline_config.rb
+++ b/logstash-core/lib/logstash/config/pipeline_config.rb
@@ -5,23 +5,14 @@ module LogStash module Config
   class PipelineConfig
     include LogStash::Util::Loggable
 
-    attr_reader :source, :pipeline_id, :config_parts, :protocol, :settings, :read_at
+    attr_reader :source, :pipeline_id, :config_parts, :settings, :read_at
 
     def initialize(source, pipeline_id, config_parts, settings)
-      config_parts_array = config_parts.is_a?(Array) ? config_parts : [config_parts]
-      unique_protocols = config_parts_array
-        .map { |config_part| config_part.protocol.to_s }
-        .uniq
-
-      if unique_protocols.length > 1
-        raise(ArgumentError, "There should be exactly 1 unique protocol in config_parts. Found #{unique_protocols.length.to_s}.")
-      end
-        
       @source = source
       @pipeline_id = pipeline_id
       # We can't use Array() since config_parts may be a java object!
+      config_parts_array = config_parts.is_a?(Array) ? config_parts : [config_parts]
       @config_parts = config_parts_array.sort_by { |config_part| [config_part.protocol.to_s, config_part.id] }
-      @protocol = unique_protocols[0]
       @settings = settings
       @read_at = Time.now
     end

--- a/logstash-core/spec/logstash/config/pipeline_config_spec.rb
+++ b/logstash-core/spec/logstash/config/pipeline_config_spec.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 require "logstash/config/pipeline_config"
 require "logstash/config/source/local"
-require_relative "../../support/helpers"
 
 describe LogStash::Config::PipelineConfig do
   let(:source) { LogStash::Config::Source::Local }
@@ -14,6 +13,7 @@ describe LogStash::Config::PipelineConfig do
       org.logstash.common.SourceWithMetadata.new("file", "/tmp/4", 0, 0, "input { generator4 }"),
       org.logstash.common.SourceWithMetadata.new("file", "/tmp/5", 0, 0, "input { generator5 }"),
       org.logstash.common.SourceWithMetadata.new("file", "/tmp/6", 0, 0, "input { generator6 }"),
+      org.logstash.common.SourceWithMetadata.new("string", "config_string", 0, 0, "input { generator1 }"),
     ]
   end
 
@@ -71,14 +71,5 @@ describe LogStash::Config::PipelineConfig do
         expect(subject.system?).to be_falsey
       end
     end
-  end
-
-  it "returns the pipeline's protocol" do
-    expect(subject.protocol).to eq((ordered_config_parts.uniq { | config_part | config_part.protocol })[0].protocol)
-  end
-
-  it "raises an ArgumentError when multiple protocols are supplied" do
-    unordered_config_parts << org.logstash.common.SourceWithMetadata.new("string", "config_string", 0, 0, "input { generator0 }")
-    expect { described_class.new(source, pipeline_id, unordered_config_parts, settings) }.to raise_error ArgumentError, /.+Found 2\./
   end
 end

--- a/x-pack/lib/config_management/elasticsearch_source.rb
+++ b/x-pack/lib/config_management/elasticsearch_source.rb
@@ -32,7 +32,6 @@ module LogStash
         queue.max_bytes
         queue.checkpoint.writes
       )
-      CENTRALLY_MANAGED_PIPELINE_PROTOCOL = "x-pack-config-management"
 
       def initialize(settings)
         super(settings)
@@ -99,7 +98,7 @@ module LogStash
 
         raise RemoteConfigError, "Empty configuration for pipeline_id: #{pipeline_id}" if config_string.nil? || config_string.empty?
 
-        config_part = org.logstash.common.SourceWithMetadata.new(CENTRALLY_MANAGED_PIPELINE_PROTOCOL, pipeline_id.to_s, config_string)
+        config_part = org.logstash.common.SourceWithMetadata.new("x-pack-config-management", pipeline_id.to_s, config_string)
 
         # We don't support multiple pipelines, so use the global settings from the logstash.yml file
         settings = @settings.clone

--- a/x-pack/lib/monitoring/inputs/metrics/state_event_factory.rb
+++ b/x-pack/lib/monitoring/inputs/metrics/state_event_factory.rb
@@ -27,7 +27,6 @@ module LogStash; module Inputs; class Metrics;
         "id" => pipeline.pipeline_id,
         "hash" => pipeline.lir.unique_hash,
         "ephemeral_id" => pipeline.ephemeral_id,
-        "protocol" => pipeline.pipeline_config.protocol,
         "workers" =>  pipeline.settings.get("pipeline.workers"),
         "batch_size" =>  pipeline.settings.get("pipeline.batch.size"),
         "representation" => ::LogStash::Inputs::Metrics::StateEvent::LIRSerializer.serialize(pipeline.lir)


### PR DESCRIPTION
This is because the backport of #9516 from `master` to `6.x` broke unit tests on `6.x`.