### PR TITLE
BUILD: Fix the docker build script to correctly see exit code

### DIFF
--- a/ci/docker_run.sh
+++ b/ci/docker_run.sh
@@ -28,18 +28,18 @@ exit_code=$?; [[ $exit_code != 0 ]] && exit $exit_code
 
 cleanup() {
   if [ -e docker_cid ]; then
-    cat docker_cid | xargs docker rm --force -v 
+    cat docker_cid | xargs docker rm --force -v
   fi
 }
 trap cleanup EXIT
 
 # Run the command, skip the first argument, which is the image name
 docker run $DOCKER_ENV_OPTS --cidfile=docker_cid --sig-proxy=true --rm $IMAGE_NAME ${@:2}
+exit_code=$?
 
 # Remove the container cid since we ran cleanly, no need to force rm it if we got to this point
 rm docker_cid
 
-exit_code=$?
 [[ $REMOVE_IMAGE == "true" ]] && docker rmi $IMAGE_NAME
 echo "exiting with code: '$exit_code'"
 exit $exit_code #preserve the exit code from the test run


### PR DESCRIPTION
If we do it like this, the exit code is always `0` because we get the exit code of the `rm` operation :( We currently have at least one failing test that we missed because of it here https://logstash-ci.elastic.co/job/elastic+logstash+master+multijob--ruby-unit-tests/135/console (still goes green after the failure)