### PR TITLE
Fix logger handling of RubyNil in `#configure_logging`

### DIFF
--- a/logstash-core/src/main/java/org/logstash/log/LoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/LoggerExt.java
@@ -130,7 +130,7 @@ public class LoggerExt extends RubyObject {
     public static IRubyObject configureLogging(final ThreadContext context, final IRubyObject self,
                                         final IRubyObject args[]) {
         synchronized (CONFIG_LOCK) {
-            RubyString path = args.length > 1 ? (RubyString) args[1] : null;
+            IRubyObject path = args.length > 1 ? args[1] : null;
             String level = args[0].asJavaString();
             try {
                 setLevel(level, (path == null || path.isNil()) ? null : path.asJavaString());


### PR DESCRIPTION
We occasionally are getting errors (listed below) since refactoring this class into Java.

This skips the unnecessary cast and corrects the failing spec.

```
14:37:42       1) Test Monitoring API can configure logging
14:37:42          Failure/Error: expect(result["acknowledged"]).to be(true)
14:37:42
14:37:42            expected true
14:37:42                 got nil
14:37:42          # ./specs/monitoring_api_spec.rb:159:in `logging_put_assert'
14:37:42          # ./specs/monitoring_api_spec.rb:114:in `block in /opt/logstash/qa/integration/specs/monitoring_api_spec.rb'
14:37:42          # /opt/logstash/build/qa/integration/vendor/jruby/2.3.0/gems/stud-0.0.23/lib/stud/try.rb:79:in `block in try'
14:37:42          # /opt/logstash/build/qa/integration/vendor/jruby/2.3.0/gems/stud-0.0.23/lib/stud/try.rb:95:in `block in try'
14:37:42          # /opt/logstash/build/qa/integration/vendor/jruby/2.3.0/gems/stud-0.0.23/lib/stud/try.rb:91:in `try'
14:37:42          # /opt/logstash/build/qa/integration/vendor/jruby/2.3.0/gems/stud-0.0.23/lib/stud/try.rb:123:in `try'
14:37:42          # ./specs/monitoring_api_spec.rb:105:in `block in (root)'
14:37:42          # /opt/logstash/build/qa/integration/vendor/jruby/2.3.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block in (root)'
14:37:42          # ./rspec.rb:17:in `<main>'
14:37:42
14:37:42     Finished in 17 minutes 22 seconds (files took 3.23 seconds to load)
14:37:42     23 examples, 1 failure
14:37:42
```