### PR TITLE
Defensively mark x-pack as a distributed artifact

### DIFF
--- a/x-pack/gradle.properties
+++ b/x-pack/gradle.properties
@@ -1,0 +1,2 @@
+isDistributedArtifact=true
+


### PR DESCRIPTION
Right now the project is simply used for testing, but if we add runtime libs
we want them added to the license report