### PR TITLE
Fix the license check CI task

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -35,8 +35,7 @@ RUN echo 'eval "$(rbenv init -)"' >> .bashrc && \
 # Create a cache for the dependencies based on the current master, any dependencies not cached will be downloaded at runtime
 RUN git clone https://github.com/elastic/logstash.git /tmp/logstash && \
     cd /tmp/logstash && \
-    rake test:install-core && \
-    ./gradlew compileJava compileTestJava && \
+    ./gradlew bootstrap compileJava compileTestJava && \
     cd qa/integration && \
     /home/logstash/.rbenv/shims/bundle install && \
     mv /tmp/logstash/vendor /tmp/vendor && \

--- a/build.gradle
+++ b/build.gradle
@@ -173,6 +173,19 @@ task downloadAndInstallJRuby(dependsOn: verifyFile, type: Copy) {
     into "${projectDir}/vendor/jruby"
 }
 
+task installDefaultGems(dependsOn: downloadAndInstallJRuby) {
+  inputs.files file("${projectDir}/Gemfile.template")
+  inputs.files fileTree("${projectDir}/rakelib")
+  inputs.files file("${projectDir}/versions.yml")
+  outputs.file("${projectDir}/Gemfile")
+  outputs.file("${projectDir}/Gemfile.lock")
+  outputs.dir("${projectDir}/logstash-core/lib/jars")
+  outputs.dir("${projectDir}/vendor/bundle/jruby/2.3.0")
+  doLast {
+    rubyGradleUtils.rake('plugin:install-default')
+  }
+}
+
 task installTestGems(dependsOn: downloadAndInstallJRuby) {
   inputs.files file("${projectDir}/Gemfile.template")
   inputs.files fileTree("${projectDir}/rakelib")

--- a/ci/license_check.sh
+++ b/ci/license_check.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -i
 export GRADLE_OPTS="-Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info"
 
-rake plugin:install-default
+./gradlew installDefaultGems
 bin/dependencies-report --csv report.csv
 # We want this to show on the CI server
 cat report.csv

--- a/logstash-core/lib/logstash/dependency_report.rb
+++ b/logstash-core/lib/logstash/dependency_report.rb
@@ -27,13 +27,6 @@ class LogStash::DependencyReport < Clamp::Command
     end
     puts "Wrote temporary ruby deps CSV to #{ruby_output_path}"
 
-
-    # Copy in COPYING.csv which is a best-effort, hand-maintained file of dependency license information.
-    File.open(ruby_output_path, "a+") do |file|
-      extra = File.join(File.dirname(__FILE__), "..", "..", "..", "COPYING.csv")
-      file.write(IO.read(extra))
-    end
-
     # Use gradle to find the rest and add to the ruby CSV
     puts "Find gradle jar dependencies #{Dir.pwd}"
     command = ["./gradlew", "generateLicenseReport", "-PlicenseReportInputCSV=#{ruby_output_path}", "-PlicenseReportOutputCSV=#{output_path}"]


### PR DESCRIPTION
This does a few small things:

1. Prefer invoking rake tasks via ./gradlew vs rake. This prevents Java from segfaulting on docker for unknown reasons
2. Remove use of COPYING.csv which has already been removed