### PR TITLE
Correctly start x-pack trial on ES

### DIFF
--- a/x-pack/qa/integration/support/helpers.rb
+++ b/x-pack/qa/integration/support/helpers.rb
@@ -45,6 +45,7 @@ def elasticsearch(options = {})
 
   # Launch in the background and wait for /started/ stdout
   cmd = "bin/elasticsearch #{settings_arguments.join(' ')}"
+  puts "Running elasticsearch: #{cmd}"
   response = Belzebuth.run(cmd, { :directory => get_elasticsearch_path, :wait_condition => /license.*valid/, :timeout => 15 * 60 })
   unless response.successful?
     raise "Could not start Elasticsearch, response: #{response}"
@@ -57,7 +58,10 @@ end
 
 def start_es_xpack_trial
   if elasticsearch_client.perform_request(:get, '_xpack/license').body['license']['type'] != 'trial'
-    elasticsearch_client.perform_request(:post, '_xpack/license/start_trial')
+    resp = elasticsearch_client.perform_request(:post, '_xpack/license/start_trial', "acknowledge" => true)
+    if resp.body["trial_was_started"] != true
+      raise "Trial not started: #{resp.body}"
+    end
   end
 end
 


### PR DESCRIPTION
This now requires an extra acknowledge parameter to start the trial

This changes also makes debugging these issues simpler with better logging during tests