### PR TITLE
Add sample configuration file

### DIFF
--- a/config/logstash-sample.conf
+++ b/config/logstash-sample.conf
@@ -1,0 +1,17 @@
+# Sample Logstash configuration for creating a simple
+# Beats -> Logstash -> Elasticsearch pipeline.
+
+input {
+  beats {
+    port => 5044
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => ["http://localhost:9200"]
+    index => "%{[@metadata][beat]}-%{[@metadata][version]}-%{+YYYY.MM.dd}"
+    #user => "elastic"
+    #password => "changeme"
+  }
+}

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -394,6 +394,9 @@ namespace "artifact" do
     File.join(basedir, "config", "logstash.yml").tap do |path|
       dir.input("#{path}=/etc/logstash")
     end
+    File.join(basedir, "config", "logstash-sample.conf").tap do |path|
+      dir.input("#{path}=/etc/logstash")
+    end
     File.join(basedir, "pkg", "pipelines.yml").tap do |path|
       dir.input("#{path}=/etc/logstash")
     end
@@ -415,6 +418,7 @@ namespace "artifact" do
         out.config_files << "/etc/logstash/jvm.options"
         out.config_files << "/etc/logstash/log4j2.properties"
         out.config_files << "/etc/logstash/logstash.yml"
+        out.config_files << "/etc/logstash/logstash-sample.conf"
         out.config_files << "/etc/logstash/pipelines.yml"
       when "debian", "ubuntu"
         require "fpm/package/deb"
@@ -430,6 +434,7 @@ namespace "artifact" do
         out.config_files << "/etc/logstash/jvm.options"
         out.config_files << "/etc/logstash/log4j2.properties"
         out.config_files << "/etc/logstash/logstash.yml"
+        out.config_files << "/etc/logstash/logstash-sample.conf"
         out.config_files << "/etc/logstash/pipelines.yml"
     end
 


### PR DESCRIPTION
This adds a simple Logstash config sample that works as a standard
Beats -> Logstash -> Elasticsearch starting point.

It's being deployed in packages, typically under /etc/logstash/logstash-sample.conf

This also adds a Dockerfile that can be used to build the artifacts.