### PR TITLE
FieldReference: prevent crashes on illegal input for 6.3

### DIFF
--- a/logstash-core/spec/logstash/event_spec.rb
+++ b/logstash-core/spec/logstash/event_spec.rb
@@ -76,6 +76,17 @@ describe LogStash::Event do
         expect(e.get("[foo][-1]")).to eq(list[-1])
       end
     end
+
+    context 'with illegal-syntax field reference' do
+      # NOTE: in true-legacy-mode FieldReference parsing, the input `[` caused Logstash
+      # to crash entirely with a Java ArrayIndexOutOfBounds exception; this spec ensures that
+      # we instead raise a RuntimeException that can be handled normally within the
+      # Ruby runtime.
+      it 'raises a RuntimeError' do
+        e = LogStash::Event.new
+        expect { e.get('[') }.to raise_exception(::RuntimeError)
+      end
+    end
   end
 
   context "#set" do
@@ -180,6 +191,17 @@ describe LogStash::Event do
       # s2 = e.get("test")
       # expect(s2.encoding.name).to eq("UTF-8")
       # expect(s2.valid_encoding?).to eq(true)
+    end
+
+    context 'with illegal-syntax field reference' do
+      # NOTE: in true-legacy-mode FieldReference parsing, the input `[` caused Logstash
+      # to crash entirely with a Java ArrayIndexOutOfBounds exception; this spec ensures that
+      # we instead raise a RuntimeException that can be handled normally within the
+      # Ruby runtime.
+      it 'raises a RuntimeError' do
+        e = LogStash::Event.new
+        expect { e.set('[', 'value') }.to raise_exception(::RuntimeError)
+      end
     end
   end
 

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -82,14 +82,14 @@ public final class JrubyEventExtLibrary {
         {
             return Rubyfier.deep(
                 context.runtime,
-                this.event.getUnconvertedField(FieldReference.from(reference))
+                this.event.getUnconvertedField(extractFieldReference(reference))
             );
         }
 
         @JRubyMethod(name = "set", required = 2)
         public IRubyObject ruby_set_field(ThreadContext context, RubyString reference, IRubyObject value)
         {
-            final FieldReference r = FieldReference.from(reference);
+            final FieldReference r = extractFieldReference(reference);
             if (r.equals(FieldReference.TIMESTAMP_REFERENCE)) {
                 if (!(value instanceof JrubyTimestampExtLibrary.RubyTimestamp)) {
                     throw context.runtime.newTypeError("wrong argument type " + value.getMetaClass() + " (expected LogStash::Timestamp)");
@@ -124,7 +124,7 @@ public final class JrubyEventExtLibrary {
         @JRubyMethod(name = "include?", required = 1)
         public IRubyObject ruby_includes(ThreadContext context, RubyString reference) {
             return RubyBoolean.newBoolean(
-                context.runtime, this.event.includes(FieldReference.from(reference))
+                context.runtime, this.event.includes(extractFieldReference(reference))
             );
         }
 
@@ -132,7 +132,7 @@ public final class JrubyEventExtLibrary {
         public IRubyObject ruby_remove(ThreadContext context, RubyString reference) {
             return Rubyfier.deep(
                 context.runtime,
-                this.event.remove(FieldReference.from(reference))
+                this.event.remove(extractFieldReference(reference))
             );
         }
 
@@ -303,6 +303,23 @@ public final class JrubyEventExtLibrary {
                 throw context.runtime.newTypeError("wrong argument type " + data.getMetaClass() + " (expected Hash)");
             }
         }
+
+        /**
+         * Shared logic to wrap {@link FieldReference.IllegalSyntaxException}s that are raised by
+         * {@link FieldReference#from(RubyString)} when encountering illegal syntax in a ruby-exception
+         * that can be easily handled within the ruby plugins
+         *
+         * @param reference a {@link RubyString} representing the path to a field
+         * @return the corresponding {@link FieldReference} (see: {@link FieldReference#from(RubyString)})
+         */
+        private static FieldReference extractFieldReference(final RubyString reference) {
+            try {
+                return FieldReference.from(reference);
+            } catch (FieldReference.IllegalSyntaxException ise) {
+                throw RubyUtil.RUBY.newRuntimeError(ise.getMessage());
+            }
+        }
+
 
         private void setEvent(Event event) {
             this.event = event;

--- a/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
+++ b/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
@@ -36,9 +36,86 @@ public final class FieldReferenceTest {
 
     @Test
     public void testParse3FieldsPath() throws Exception {
+        FieldReference f = FieldReference.from("[foo][bar][baz]");
+        assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
+        assertEquals("baz", f.getKey());
+    }
+
+    @Test
+    public void testParseInvalid3FieldsPath() throws Exception {
         FieldReference f = FieldReference.from("[foo][bar]]baz]");
         assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
         assertEquals("baz", f.getKey());
+    }
+
+    @Test
+    public void testParseInvalidNoCloseBracket() throws Exception {
+        FieldReference f = FieldReference.from("[foo][bar][baz");
+        assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
+        assertEquals("baz", f.getKey());
+    }
+
+    @Test
+    public void testParseInvalidNoInitialOpenBracket() throws Exception {
+        FieldReference f = FieldReference.from("foo[bar][baz]");
+        assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
+        assertEquals("baz", f.getKey());
+    }
+
+    @Test
+    public void testParseInvalidMissingMiddleBracket() throws Exception {
+        FieldReference f = FieldReference.from("[foo]bar[baz]");
+        assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
+        assertEquals("baz", f.getKey());
+    }
+
+    @Test(expected=FieldReference.IllegalSyntaxException.class)
+    public void testParseInvalidOnlyOpenBracket() throws Exception {
+        // was: hard-crash, now strict-by-default
+        FieldReference f = FieldReference.from("[");
+    }
+
+    @Test(expected=FieldReference.IllegalSyntaxException.class)
+    public void testParseInvalidOnlyCloseBracket() throws Exception {
+        // was: hard-crash, now strict-by-default
+        FieldReference f = FieldReference.from("]");
+    }
+
+    @Test(expected=FieldReference.IllegalSyntaxException.class)
+    public void testParseInvalidLotsOfOpenBrackets() throws Exception {
+        // was: hard-crash, now strict-by-default
+        FieldReference f = FieldReference.from("[[[[[[[[[[[]");
+    }
+
+    @Test
+    public void testParseInvalidDoubleCloseBrackets() throws Exception {
+        FieldReference f = FieldReference.from("[foo]][bar]");
+        assertEquals(1, f.getPath().length);
+        assertArrayEquals(new String[]{"foo"}, f.getPath());
+        assertEquals("bar", f.getKey());
+    }
+
+    @Test
+    public void testParseNestingSquareBrackets() throws Exception {
+        FieldReference f = FieldReference.from("[this[is]terrible]");
+        assertEquals(2, f.getPath().length);
+        assertArrayEquals(new String[]{"this", "is"}, f.getPath());
+        assertEquals("terrible", f.getKey());
+    }
+
+    @Test
+    public void testParseChainedNestingSquareBrackets() throws Exception {
+        FieldReference f = FieldReference.from("[this[is]terrible][and][it[should[not][work]]]");
+        assertArrayEquals(new String[]{"this","is","terrible", "and", "it", "should", "not"}, f.getPath());
+        assertEquals("work", f.getKey());
+    }
+
+    @Test
+    public void testParseLiteralSquareBrackets() throws Exception {
+        FieldReference f = FieldReference.from("this[index]");
+        assertEquals(1, f.getPath().length);
+        assertArrayEquals(new String[]{"this"}, f.getPath());
+        assertEquals("index", f.getKey());
     }
 
     @Test

--- a/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
+++ b/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
@@ -17,28 +17,28 @@ public final class FieldReferenceTest {
     public void testParseSingleBareField() throws Exception {
         FieldReference f = FieldReference.from("foo");
         assertEquals(0, f.getPath().length);
-        assertEquals(f.getKey(), "foo");
+        assertEquals("foo", f.getKey());
     }
 
     @Test
     public void testParseSingleFieldPath() throws Exception {
         FieldReference f = FieldReference.from("[foo]");
         assertEquals(0, f.getPath().length);
-        assertEquals(f.getKey(), "foo");
+        assertEquals("foo", f.getKey());
     }
 
     @Test
     public void testParse2FieldsPath() throws Exception {
         FieldReference f = FieldReference.from("[foo][bar]");
-        assertArrayEquals(f.getPath(), new String[]{"foo"});
-        assertEquals(f.getKey(), "bar");
+        assertArrayEquals(new String[]{"foo"}, f.getPath());
+        assertEquals("bar", f.getKey());
     }
 
     @Test
     public void testParse3FieldsPath() throws Exception {
         FieldReference f = FieldReference.from("[foo][bar]]baz]");
-        assertArrayEquals(f.getPath(), new String[]{"foo", "bar"});
-        assertEquals(f.getKey(), "baz");
+        assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
+        assertEquals("baz", f.getKey());
     }
 
     @Test


### PR DESCRIPTION
This is a backport to 6.3 of a chain of commits from elastic/logstash#9543 (which covers the transition from the current `FieldReference` parser to something more strict); as discussed in the full transition PR, this backport to 6.3 _only_ include the bit that prevents a crash:

> ## 6.3
> 
> For 6.3, the first _two_ commits in this PR can safely be backported (whether in the first patch-release or as a part of the in-progress 6.3.0 release).
> 
> We simply fix the scenarios where a pathological input would cause a crash, and in those scenarios raise a runtime error; this is compatible with the upcoming strict-mode, and is a non-breaking change.