### PR TITLE
FieldReference: add opt-in strict-mode for 6.x

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -45,6 +45,16 @@ class LogStash::Agent
     # Generate / load the persistent uuid
     id
 
+    # Set the global FieldReference parsing mode
+    parsing_mode = case setting('config.field_reference.parser')
+                   when 'COMPAT' then org.logstash.FieldReference::ParsingMode::COMPAT;
+                   when 'LEGACY' then org.logstash.FieldReference::ParsingMode::LEGACY;
+                   when 'STRICT' then org.logstash.FieldReference::ParsingMode::STRICT;
+                   else fail('Unsupported FieldReference parsing mode')
+                   end
+    logger.debug("Setting global FieldReference parsing mode: #{parsing_mode}")
+    org.logstash.FieldReference::set_parsing_mode(parsing_mode)
+
     # This is for backward compatibility in the tests
     if source_loader.nil?
       @source_loader = LogStash::Config::SourceLoader.new

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -33,6 +33,7 @@ module LogStash
            Setting::Boolean.new("config.reload.automatic", false),
            Setting::TimeValue.new("config.reload.interval", "3s"), # in seconds
            Setting::Boolean.new("config.support_escapes", false),
+            Setting::String.new("config.field_reference.parser", "COMPAT", true, %w(STRICT COMPAT LEGACY)),
            Setting::Boolean.new("metric.collect", true),
             Setting::String.new("pipeline.id", "main"),
            Setting::Boolean.new("pipeline.system", false),

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -68,6 +68,11 @@ class LogStash::Runner < Clamp::StrictCommand
     :default => LogStash::SETTINGS.get_default("config.string"),
     :attribute_name => "config.string"
 
+  option ["--field-reference-parser"], "MODE",
+         I18n.t("logstash.runner.flag.field-reference-parser"),
+         :attribute_name => "config.field_reference.parser",
+         :default => LogStash::SETTINGS.get_default("config.field_reference.parser")
+
   # Module settings
   option ["--modules"], "MODULES",
     I18n.t("logstash.runner.flag.modules"),

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -228,6 +228,33 @@ en:
           "%{default_output}"
           If you wish to use both defaults, please use
           the empty string for the '-e' flag.
+        field-reference-parser: |+
+          Use the given MODE when parsing field
+          references.
+
+          The field reference parser is used to expand
+          field references in your pipeline configs,
+          and will be becoming more strict to better
+          handle illegal and ambbiguous inputs in a
+          future release of Logstash.
+
+          Available MODEs are:
+           - `LEGACY`: parse with the legacy parser,
+             which is known to handle ambiguous- and
+             illegal-syntax in surprising ways;
+             warnings will not be emitted.
+           - `COMPAT`: warn once for each distinct
+             ambiguous- or illegal-syntax input, but
+             continue to expand field references with
+             the legacy parser.
+           - `STRICT`: parse in a strict manner; when
+             given ambiguous- or illegal-syntax input,
+             raises a runtime exception that should
+             be handled by the calling plugin.
+
+           The MODE can also be set with
+           `config.field_reference.parser`
+
         modules: |+
           Load Logstash modules.
           Modules can be defined using multiple instances

--- a/logstash-core/spec/logstash/event_spec.rb
+++ b/logstash-core/spec/logstash/event_spec.rb
@@ -76,6 +76,17 @@ describe LogStash::Event do
         expect(e.get("[foo][-1]")).to eq(list[-1])
       end
     end
+
+    context 'with illegal-syntax field reference' do
+      # NOTE: in true-legacy-mode FieldReference parsing, the input `[` caused Logstash
+      # to crash entirely with a Java ArrayIndexOutOfBounds exception; this spec ensures that
+      # we instead raise a RuntimeException that can be handled normally within the
+      # Ruby runtime.
+      it 'raises a RuntimeError' do
+        e = LogStash::Event.new
+        expect { e.get('[') }.to raise_exception(::RuntimeError)
+      end
+    end
   end
 
   context "#set" do
@@ -154,6 +165,17 @@ describe LogStash::Event do
       # s2 = e.get("test")
       # expect(s2.encoding.name).to eq("UTF-8")
       # expect(s2.valid_encoding?).to eq(true)
+    end
+
+    context 'with illegal-syntax field reference' do
+      # NOTE: in true-legacy-mode FieldReference parsing, the input `[` caused Logstash
+      # to crash entirely with a Java ArrayIndexOutOfBounds exception; this spec ensures that
+      # we instead raise a RuntimeException that can be handled normally within the
+      # Ruby runtime.
+      it 'raises a RuntimeError' do
+        e = LogStash::Event.new
+        expect { e.set('[', 'value') }.to raise_exception(::RuntimeError)
+      end
     end
   end
 

--- a/logstash-core/src/main/java/org/logstash/FieldReference.java
+++ b/logstash-core/src/main/java/org/logstash/FieldReference.java
@@ -1,10 +1,16 @@
 package org.logstash;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 import java.util.concurrent.ConcurrentHashMap;
 import org.jruby.RubyString;
@@ -19,6 +25,8 @@ public final class FieldReference {
             super(message);
         }
     }
+
+    private static final Logger LOGGER = LogManager.getLogger(FieldReference.class);
 
     /**
      * This type indicates that the referenced that is the metadata of an {@link Event} found in
@@ -45,6 +53,8 @@ public final class FieldReference {
 
     /**
      * Controls the global parsing mode, in support of the transition to strict-mode parsing.
+     *
+     * See {@link FieldReference#setParsingMode(ParsingMode)}.
      */
     private static ParsingMode PARSING_MODE = ParsingMode.LEGACY;
 
@@ -52,8 +62,10 @@ public final class FieldReference {
      * The {@link ParsingMode} enum holds references to the supported parsing modes, in
      * support of the transition to strict-mode parsing.
      */
-    enum ParsingMode {
+    public enum ParsingMode {
         LEGACY(new LegacyTokenizer()),
+        COMPAT(new StrictTokenizer(LEGACY.tokenizer)),
+        STRICT(new StrictTokenizer()),
         ;
 
         final Tokenizer tokenizer;
@@ -119,6 +131,25 @@ public final class FieldReference {
             return result;
         }
         return parseToCache(reference);
+    }
+
+    /**
+     * Sets the global {@link ParsingMode}
+     *
+     * @param newParsingMode a {@link ParsingMode} to be used globally
+     * @return the previous {@link ParsingMode}, enabling tests to reset to default behaviour
+     */
+    public static ParsingMode setParsingMode(final ParsingMode newParsingMode) {
+        final ParsingMode originalParsingMode = PARSING_MODE;
+        PARSING_MODE = newParsingMode;
+        return originalParsingMode;
+    }
+
+    /**
+     * @return the current global {@link ParsingMode}.
+     */
+    static ParsingMode getParsingMode() {
+        return PARSING_MODE;
     }
 
     /**
@@ -255,6 +286,136 @@ public final class FieldReference {
             path.trimToSize();
 
             return path;
+        }
+    }
+
+    /**
+     * The {@link StrictTokenizer} parses field-references in a strict manner; when illegal syntax is encountered,
+     * the input is considered ambiguous.
+     *
+     * If instantiated with a fallback {@link Tokenizer}, when it encounters ambiguous input it will always return
+     * an output that is identical to the output of the fallback {@link Tokenizer#tokenize(CharSequence)}; when their
+     * outputs would differ, it also emits a warning to the logger for each distinct illegal input it encounters.
+     */
+    private static class StrictTokenizer implements Tokenizer {
+        private static final Set<CharSequence> AMBIGUOUS_INPUTS = new HashSet<>();
+
+        final Tokenizer legacyTokenizer;
+
+        StrictTokenizer(final Tokenizer legacyTokenizer) {
+            this.legacyTokenizer = Objects.requireNonNull(legacyTokenizer,
+                                                          "to run strict without a fallbackTokenizer, " +
+                                                          "use zero-arg variant");
+        }
+
+        StrictTokenizer() {
+            this.legacyTokenizer = null;
+        }
+
+        @Override
+        public List<String> tokenize(CharSequence reference) {
+            ArrayList<String> path = new ArrayList<>();
+            final int length = reference.length();
+
+            boolean strictMode = !Objects.nonNull(legacyTokenizer);
+
+            boolean potentiallyAmbiguousSyntaxDetected = false;
+            boolean seenBracket = false;
+            int depth = 0;
+            int splitPoint = 0;
+            char current = 0;
+            char previous = 0;
+            scan: for (int i=0 ; i < length; i++) {
+                previous = current;
+                current = reference.charAt(i);
+                switch (current) {
+                    case '[':
+                        seenBracket = true;
+                        if (splitPoint != i) {
+                            // if the current split point isn't the previous character, we have ambiguous input,
+                            // such as a mix of square-bracket and top-level unbracketed chunks, or an embedded
+                            // field reference that doesn't wholly occupy an outer fragment, and cannot
+                            // reasonably recover.
+                            potentiallyAmbiguousSyntaxDetected = true;
+                            break scan;
+                        }
+
+                        depth++;
+                        splitPoint = i + 1;
+                        continue scan;
+
+                    case ']':
+                        seenBracket = true;
+                        if (depth <= 0) {
+                            // if we get to a close-bracket without having previously hit an open-bracket,
+                            // we have an illegal field reference and cannot reasonably recover.
+                            potentiallyAmbiguousSyntaxDetected = true;
+                            break scan;
+                        }
+                        if (splitPoint == i && previous != ']') {
+                            // if we have a zero-length fragment and are not closing an embedded fieldreference,
+                            // we have an illegal field reference and cannot possibly recover.
+                            potentiallyAmbiguousSyntaxDetected = true;
+                            break scan;
+                        }
+
+                        if (splitPoint < i) {
+                            // if we have something to add, add it.
+                            path.add(reference.subSequence(splitPoint, i).toString().intern());
+                        }
+
+                        depth--;
+                        splitPoint = i + 1;
+                        continue scan;
+
+                    default:
+                        if (seenBracket && previous == ']') {
+                            // if we have seen a bracket and encounter one or more characters that are _not_ enclosed
+                            // in brackets, we have illegal syntax and cannot reasonably recover.
+                            potentiallyAmbiguousSyntaxDetected = true;
+                            break scan;
+                        }
+
+                        continue scan;
+                }
+            }
+
+            if (!seenBracket) {
+                // if we saw no brackets, this is a top-level reference that can be emitted as-is without
+                // further processing
+                path.add(reference.toString());
+                return path;
+            } else if (depth > 0) {
+                // when we hit the end-of-input while still in an open bracket, we have an invalid field reference
+                potentiallyAmbiguousSyntaxDetected = true;
+            }
+
+            // if we have encountered ambiguous syntax and are not in strict-mode,
+            // fall back to legacy parser.
+            if (potentiallyAmbiguousSyntaxDetected) {
+                if (strictMode) {
+                    throw new FieldReference.IllegalSyntaxException(String.format("Invalid FieldReference: `%s`", reference.toString()));
+                } else {
+                    final List<String> legacyPath = legacyTokenizer.tokenize(reference);
+                    if (!path.equals(legacyPath)) {
+                        warnAmbiguous(reference, legacyPath);
+                    }
+                    return legacyPath;
+                }
+            }
+
+            path.trimToSize();
+            return path;
+        }
+
+        private void warnAmbiguous(final CharSequence reference, final List<String> expansion) {
+            if (AMBIGUOUS_INPUTS.size() > 10_000) {
+                return;
+            }
+            if (AMBIGUOUS_INPUTS.add(reference)) {
+                // TODO: i18n
+                LOGGER.warn(String.format("Detected ambiguous Field Reference `%s`, which we expanded to the path `%s`; in a future release of Logstash, ambiguous Field References will not be expanded.", reference.toString(), expansion));
+            }
         }
     }
 }

--- a/logstash-core/src/main/java/org/logstash/FieldReference.java
+++ b/logstash-core/src/main/java/org/logstash/FieldReference.java
@@ -8,6 +8,15 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.jruby.RubyString;
 
 public final class FieldReference {
+    /**
+     * A custom unchecked {@link RuntimeException} that can be thrown by parsing methods when
+     * when they encounter an input with illegal syntax.
+     */
+    public static class IllegalSyntaxException extends RuntimeException {
+        IllegalSyntaxException(String message) {
+            super(message);
+        }
+    }
 
     /**
      * This type indicates that the referenced that is the metadata of an {@link Event} found in
@@ -181,6 +190,13 @@ public final class FieldReference {
         }
         if (splitPoint < length || length == 0) {
             path.add(reference.subSequence(splitPoint, length).toString().intern());
+        }
+        if (path.isEmpty()) {
+            // https://github.com/elastic/logstash/issues/9524
+            // prevents an ArrayIndexOutOfBounds exception that would crash the entire Logstash process.
+            // If the path is empty, we have an illegal syntax input and are unable to build a valid
+            // FieldReference; throw a runtime exception, which can be handled downstream.
+            throw new IllegalSyntaxException(String.format("Invalid FieldReference: `%s`", reference.toString()));
         }
         path.trimToSize();
         final String key = path.remove(path.size() - 1).intern();

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -82,14 +82,14 @@ public final class JrubyEventExtLibrary {
         {
             return Rubyfier.deep(
                 context.runtime,
-                this.event.getUnconvertedField(FieldReference.from(reference))
+                this.event.getUnconvertedField(extractFieldReference(reference))
             );
         }
 
         @JRubyMethod(name = "set", required = 2)
         public IRubyObject ruby_set_field(ThreadContext context, RubyString reference, IRubyObject value)
         {
-            final FieldReference r = FieldReference.from(reference);
+            final FieldReference r = extractFieldReference(reference);
             if (r.equals(FieldReference.TIMESTAMP_REFERENCE)) {
                 if (!(value instanceof JrubyTimestampExtLibrary.RubyTimestamp)) {
                     throw context.runtime.newTypeError("wrong argument type " + value.getMetaClass() + " (expected LogStash::Timestamp)");
@@ -124,7 +124,7 @@ public final class JrubyEventExtLibrary {
         @JRubyMethod(name = "include?", required = 1)
         public IRubyObject ruby_includes(ThreadContext context, RubyString reference) {
             return RubyBoolean.newBoolean(
-                context.runtime, this.event.includes(FieldReference.from(reference))
+                context.runtime, this.event.includes(extractFieldReference(reference))
             );
         }
 
@@ -132,7 +132,7 @@ public final class JrubyEventExtLibrary {
         public IRubyObject ruby_remove(ThreadContext context, RubyString reference) {
             return Rubyfier.deep(
                 context.runtime,
-                this.event.remove(FieldReference.from(reference))
+                this.event.remove(extractFieldReference(reference))
             );
         }
 
@@ -303,6 +303,23 @@ public final class JrubyEventExtLibrary {
                 throw context.runtime.newTypeError("wrong argument type " + data.getMetaClass() + " (expected Hash)");
             }
         }
+
+        /**
+         * Shared logic to wrap {@link FieldReference.IllegalSyntaxException}s that are raised by
+         * {@link FieldReference#from(RubyString)} when encountering illegal syntax in a ruby-exception
+         * that can be easily handled within the ruby plugins
+         *
+         * @param reference a {@link RubyString} representing the path to a field
+         * @return the corresponding {@link FieldReference} (see: {@link FieldReference#from(RubyString)})
+         */
+        private static FieldReference extractFieldReference(final RubyString reference) {
+            try {
+                return FieldReference.from(reference);
+            } catch (FieldReference.IllegalSyntaxException ise) {
+                throw RubyUtil.RUBY.newRuntimeError(ise.getMessage());
+            }
+        }
+
 
         private void setEvent(Event event) {
             this.event = event;

--- a/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
+++ b/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
@@ -36,9 +36,86 @@ public final class FieldReferenceTest {
 
     @Test
     public void testParse3FieldsPath() throws Exception {
+        FieldReference f = FieldReference.from("[foo][bar][baz]");
+        assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
+        assertEquals("baz", f.getKey());
+    }
+
+    @Test
+    public void testParseInvalid3FieldsPath() throws Exception {
         FieldReference f = FieldReference.from("[foo][bar]]baz]");
         assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
         assertEquals("baz", f.getKey());
+    }
+
+    @Test
+    public void testParseInvalidNoCloseBracket() throws Exception {
+        FieldReference f = FieldReference.from("[foo][bar][baz");
+        assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
+        assertEquals("baz", f.getKey());
+    }
+
+    @Test
+    public void testParseInvalidNoInitialOpenBracket() throws Exception {
+        FieldReference f = FieldReference.from("foo[bar][baz]");
+        assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
+        assertEquals("baz", f.getKey());
+    }
+
+    @Test
+    public void testParseInvalidMissingMiddleBracket() throws Exception {
+        FieldReference f = FieldReference.from("[foo]bar[baz]");
+        assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
+        assertEquals("baz", f.getKey());
+    }
+
+    @Test(expected=FieldReference.IllegalSyntaxException.class)
+    public void testParseInvalidOnlyOpenBracket() throws Exception {
+        // was: hard-crash, now strict-by-default
+        FieldReference f = FieldReference.from("[");
+    }
+
+    @Test(expected=FieldReference.IllegalSyntaxException.class)
+    public void testParseInvalidOnlyCloseBracket() throws Exception {
+        // was: hard-crash, now strict-by-default
+        FieldReference f = FieldReference.from("]");
+    }
+
+    @Test(expected=FieldReference.IllegalSyntaxException.class)
+    public void testParseInvalidLotsOfOpenBrackets() throws Exception {
+        // was: hard-crash, now strict-by-default
+        FieldReference f = FieldReference.from("[[[[[[[[[[[]");
+    }
+
+    @Test
+    public void testParseInvalidDoubleCloseBrackets() throws Exception {
+        FieldReference f = FieldReference.from("[foo]][bar]");
+        assertEquals(1, f.getPath().length);
+        assertArrayEquals(new String[]{"foo"}, f.getPath());
+        assertEquals("bar", f.getKey());
+    }
+
+    @Test
+    public void testParseNestingSquareBrackets() throws Exception {
+        FieldReference f = FieldReference.from("[this[is]terrible]");
+        assertEquals(2, f.getPath().length);
+        assertArrayEquals(new String[]{"this", "is"}, f.getPath());
+        assertEquals("terrible", f.getKey());
+    }
+
+    @Test
+    public void testParseChainedNestingSquareBrackets() throws Exception {
+        FieldReference f = FieldReference.from("[this[is]terrible][and][it[should[not][work]]]");
+        assertArrayEquals(new String[]{"this","is","terrible", "and", "it", "should", "not"}, f.getPath());
+        assertEquals("work", f.getKey());
+    }
+
+    @Test
+    public void testParseLiteralSquareBrackets() throws Exception {
+        FieldReference f = FieldReference.from("this[index]");
+        assertEquals(1, f.getPath().length);
+        assertArrayEquals(new String[]{"this"}, f.getPath());
+        assertEquals("index", f.getKey());
     }
 
     @Test

--- a/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
+++ b/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
@@ -3,7 +3,11 @@ package org.logstash;
 import java.lang.reflect.Field;
 import java.util.Map;
 import org.hamcrest.CoreMatchers;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -11,116 +15,199 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        FieldReferenceTest.LegacyMode.class,
+        FieldReferenceTest.CompatMode.class,
+        FieldReferenceTest.StrictMode.class,
+})
 public final class FieldReferenceTest {
 
-    @Test
-    public void testParseSingleBareField() throws Exception {
-        FieldReference f = FieldReference.from("foo");
-        assertEquals(0, f.getPath().length);
-        assertEquals("foo", f.getKey());
+    private static abstract class Base {
+        FieldReference.ParsingMode previousParsingMode;
+
+        @Before
+        public void setParsingMode() {
+            previousParsingMode = FieldReference.setParsingMode(parsingMode());
+        }
+
+        @Before
+        public void clearParsingCache() throws Exception {
+            final Field cacheField = FieldReference.class.getDeclaredField("CACHE");
+            cacheField.setAccessible(true);
+            final Map<CharSequence, FieldReference> cache =
+                    (Map<CharSequence, FieldReference>) cacheField.get(null);
+            cache.clear();
+        }
+
+        @Before
+        public void clearDedupCache() throws Exception  {
+            final Field cacheField = FieldReference.class.getDeclaredField("DEDUP");
+            cacheField.setAccessible(true);
+            final Map<CharSequence, FieldReference> cache =
+                    (Map<CharSequence, FieldReference>) cacheField.get(null);
+            cache.clear();
+        }
+
+        @After
+        public void restoreParsingMode() {
+            FieldReference.setParsingMode(previousParsingMode);
+        }
+
+        abstract FieldReference.ParsingMode parsingMode();
+
+        @Test
+        public void deduplicatesTimestamp() throws Exception {
+            assertTrue(FieldReference.from("@timestamp") == FieldReference.from("[@timestamp]"));
+        }
+
+        @Test
+        public void testParseEmptyString() {
+            final FieldReference emptyReference = FieldReference.from("");
+            assertNotNull(emptyReference);
+            assertEquals(
+                    emptyReference, FieldReference.from(RubyUtil.RUBY.newString(""))
+            );
+        }
+
+        @Test
+        public void testCacheUpperBound() throws NoSuchFieldException, IllegalAccessException {
+            final Field cacheField = FieldReference.class.getDeclaredField("CACHE");
+            cacheField.setAccessible(true);
+            final Map<CharSequence, FieldReference> cache =
+                    (Map<CharSequence, FieldReference>) cacheField.get(null);
+            final int initial = cache.size();
+            for (int i = 0; i < 10_001 - initial; ++i) {
+                FieldReference.from(String.format("[array][%d]", i));
+            }
+            assertThat(cache.size(), CoreMatchers.is(10_000));
+        }
     }
 
-    @Test
-    public void testParseSingleFieldPath() throws Exception {
-        FieldReference f = FieldReference.from("[foo]");
-        assertEquals(0, f.getPath().length);
-        assertEquals("foo", f.getKey());
-    }
+    public static class LegacyMode extends Base {
+        @Override
+        FieldReference.ParsingMode parsingMode() {
+            return FieldReference.ParsingMode.LEGACY;
+        }
 
-    @Test
-    public void testParse2FieldsPath() throws Exception {
-        FieldReference f = FieldReference.from("[foo][bar]");
-        assertArrayEquals(new String[]{"foo"}, f.getPath());
-        assertEquals("bar", f.getKey());
-    }
+        @Test
+        public void testParseSingleBareField() throws Exception {
+            FieldReference f = FieldReference.from("foo");
+            assertEquals(0, f.getPath().length);
+            assertEquals("foo", f.getKey());
+        }
 
-    @Test
-    public void testParse3FieldsPath() throws Exception {
-        FieldReference f = FieldReference.from("[foo][bar][baz]");
-        assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
-        assertEquals("baz", f.getKey());
-    }
+        @Test
+        public void testParseSingleFieldPath() throws Exception {
+            FieldReference f = FieldReference.from("[foo]");
+            assertEquals(0, f.getPath().length);
+            assertEquals("foo", f.getKey());
+        }
 
-    @Test
-    public void testParseInvalid3FieldsPath() throws Exception {
-        FieldReference f = FieldReference.from("[foo][bar]]baz]");
-        assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
-        assertEquals("baz", f.getKey());
-    }
+        @Test
+        public void testParse2FieldsPath() throws Exception {
+            FieldReference f = FieldReference.from("[foo][bar]");
+            assertArrayEquals(new String[]{"foo"}, f.getPath());
+            assertEquals("bar", f.getKey());
+        }
 
-    @Test
-    public void testParseInvalidNoCloseBracket() throws Exception {
-        FieldReference f = FieldReference.from("[foo][bar][baz");
-        assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
-        assertEquals("baz", f.getKey());
-    }
+        @Test
+        public void testParse3FieldsPath() throws Exception {
+            FieldReference f = FieldReference.from("[foo][bar][baz]");
+            assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
+            assertEquals("baz", f.getKey());
+        }
 
-    @Test
-    public void testParseInvalidNoInitialOpenBracket() throws Exception {
-        FieldReference f = FieldReference.from("foo[bar][baz]");
-        assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
-        assertEquals("baz", f.getKey());
-    }
+        @Test
+        public void testParseInvalid3FieldsPath() throws Exception {
+            FieldReference f = FieldReference.from("[foo][bar]]baz]");
+            assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
+            assertEquals("baz", f.getKey());
+        }
 
-    @Test
-    public void testParseInvalidMissingMiddleBracket() throws Exception {
-        FieldReference f = FieldReference.from("[foo]bar[baz]");
-        assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
-        assertEquals("baz", f.getKey());
-    }
+        @Test
+        public void testParseInvalidNoCloseBracket() throws Exception {
+            FieldReference f = FieldReference.from("[foo][bar][baz");
+            assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
+            assertEquals("baz", f.getKey());
+        }
 
-    @Test(expected=FieldReference.IllegalSyntaxException.class)
-    public void testParseInvalidOnlyOpenBracket() throws Exception {
-        // was: hard-crash, now strict-by-default
-        FieldReference f = FieldReference.from("[");
-    }
+        @Test
+        public void testParseInvalidNoInitialOpenBracket() throws Exception {
+            FieldReference f = FieldReference.from("foo[bar][baz]");
+            assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
+            assertEquals("baz", f.getKey());
+        }
 
-    @Test(expected=FieldReference.IllegalSyntaxException.class)
-    public void testParseInvalidOnlyCloseBracket() throws Exception {
-        // was: hard-crash, now strict-by-default
-        FieldReference f = FieldReference.from("]");
-    }
+        @Test
+        public void testParseInvalidMissingMiddleBracket() throws Exception {
+            FieldReference f = FieldReference.from("[foo]bar[baz]");
+            assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
+            assertEquals("baz", f.getKey());
+        }
 
-    @Test(expected=FieldReference.IllegalSyntaxException.class)
-    public void testParseInvalidLotsOfOpenBrackets() throws Exception {
-        // was: hard-crash, now strict-by-default
-        FieldReference f = FieldReference.from("[[[[[[[[[[[]");
-    }
+        @Test(expected=FieldReference.IllegalSyntaxException.class)
+        public void testParseInvalidOnlyOpenBracket() throws Exception {
+            // was: hard-crash, now strict-by-default
+            FieldReference f = FieldReference.from("[");
+        }
 
-    @Test
-    public void testParseInvalidDoubleCloseBrackets() throws Exception {
-        FieldReference f = FieldReference.from("[foo]][bar]");
-        assertEquals(1, f.getPath().length);
-        assertArrayEquals(new String[]{"foo"}, f.getPath());
-        assertEquals("bar", f.getKey());
-    }
+        @Test(expected=FieldReference.IllegalSyntaxException.class)
+        public void testParseInvalidOnlyCloseBracket() throws Exception {
+            // was: hard-crash, now strict-by-default
+            FieldReference f = FieldReference.from("]");
+        }
 
-    @Test
-    public void testParseNestingSquareBrackets() throws Exception {
-        FieldReference f = FieldReference.from("[this[is]terrible]");
-        assertEquals(2, f.getPath().length);
-        assertArrayEquals(new String[]{"this", "is"}, f.getPath());
-        assertEquals("terrible", f.getKey());
-    }
+        @Test(expected=FieldReference.IllegalSyntaxException.class)
+        public void testParseInvalidLotsOfOpenBrackets() throws Exception {
+            // was: hard-crash, now strict-by-default
+            FieldReference f = FieldReference.from("[[[[[[[[[[[]");
+        }
 
-    @Test
-    public void testParseChainedNestingSquareBrackets() throws Exception {
-        FieldReference f = FieldReference.from("[this[is]terrible][and][it[should[not][work]]]");
-        assertArrayEquals(new String[]{"this","is","terrible", "and", "it", "should", "not"}, f.getPath());
-        assertEquals("work", f.getKey());
-    }
+        @Test
+        public void testParseInvalidDoubleCloseBrackets() throws Exception {
+            FieldReference f = FieldReference.from("[foo]][bar]");
+            assertEquals(1, f.getPath().length);
+            assertArrayEquals(new String[]{"foo"}, f.getPath());
+            assertEquals("bar", f.getKey());
+        }
 
-    @Test
-    public void testParseLiteralSquareBrackets() throws Exception {
-        FieldReference f = FieldReference.from("this[index]");
-        assertEquals(1, f.getPath().length);
-        assertArrayEquals(new String[]{"this"}, f.getPath());
-        assertEquals("index", f.getKey());
-    }
+        @Test
+        public void testParseNestingSquareBrackets() throws Exception {
+            FieldReference f = FieldReference.from("[this[is]terrible]");
+            assertEquals(2, f.getPath().length);
+            assertArrayEquals(new String[]{"this", "is"}, f.getPath());
+            assertEquals("terrible", f.getKey());
+        }
 
-    @Test
-    public void deduplicatesTimestamp() throws Exception {
-        assertTrue(FieldReference.from("@timestamp") == FieldReference.from("[@timestamp]"));
+        @Test
+        public void testParseChainedNestingSquareBrackets() throws Exception {
+            FieldReference f = FieldReference.from("[this[is]terrible][and][it[should[not][work]]]");
+            assertArrayEquals(new String[]{"this","is","terrible", "and", "it", "should", "not"}, f.getPath());
+            assertEquals("work", f.getKey());
+        }
+
+        @Test
+        public void testParseLiteralSquareBrackets() throws Exception {
+            FieldReference f = FieldReference.from("this[index]");
+            assertEquals(1, f.getPath().length);
+            assertArrayEquals(new String[]{"this"}, f.getPath());
+            assertEquals("index", f.getKey());
+        }
+
+        @Test
+        public void testEmbeddedSingleReference() throws Exception {
+            FieldReference f = FieldReference.from("[[foo]][bar]");
+            assertArrayEquals(new String[]{"foo"}, f.getPath());
+            assertEquals("bar", f.getKey());
+        }
+
+        @Test
+        public void testEmbeddedDeepReference() throws Exception {
+            FieldReference f = FieldReference.from("[[foo][bar]][baz]");
+            assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
+            assertEquals("baz", f.getKey());
+        }
     }
 
     @Test
@@ -128,20 +215,124 @@ public final class FieldReferenceTest {
         final FieldReference emptyReference = FieldReference.from("");
         assertNotNull(emptyReference);
         assertEquals(
-            emptyReference, FieldReference.from(RubyUtil.RUBY.newString(""))
+                emptyReference, FieldReference.from(RubyUtil.RUBY.newString(""))
         );
     }
 
-    @Test
-    public void testCacheUpperBound() throws NoSuchFieldException, IllegalAccessException {
-        final Field cacheField = FieldReference.class.getDeclaredField("CACHE");
-        cacheField.setAccessible(true);
-        final Map<CharSequence, FieldReference> cache =
-            (Map<CharSequence, FieldReference>) cacheField.get(null);
-        final int initial = cache.size();
-        for (int i = 0; i < 10_001 - initial; ++i) {
-            FieldReference.from(String.format("[array][%d]", i));
+    public static class CompatMode extends LegacyMode {
+        @Override
+        FieldReference.ParsingMode parsingMode() {
+            return FieldReference.ParsingMode.LEGACY;
         }
-        assertThat(cache.size(), CoreMatchers.is(10_000));
+    }
+
+
+    public static class StrictMode extends Base {
+        @Override
+        FieldReference.ParsingMode parsingMode() {
+            return FieldReference.ParsingMode.STRICT;
+        }
+
+        @Test
+        public void testParseSingleBareField() throws Exception {
+            FieldReference f = FieldReference.from("foo");
+            assertEquals(0, f.getPath().length);
+            assertEquals("foo", f.getKey());
+        }
+
+        @Test
+        public void testParseSingleFieldPath() throws Exception {
+            FieldReference f = FieldReference.from("[foo]");
+            assertEquals(0, f.getPath().length);
+            assertEquals("foo", f.getKey());
+        }
+
+        @Test
+        public void testParse2FieldsPath() throws Exception {
+            FieldReference f = FieldReference.from("[foo][bar]");
+            assertArrayEquals(new String[]{"foo"}, f.getPath());
+            assertEquals("bar", f.getKey());
+        }
+
+        @Test
+        public void testParse3FieldsPath() throws Exception {
+            FieldReference f = FieldReference.from("[foo][bar][baz]");
+            assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
+            assertEquals("baz", f.getKey());
+        }
+
+        @Test
+        public void testEmbeddedSingleReference() throws Exception {
+            FieldReference f = FieldReference.from("[[foo]][bar]");
+            assertArrayEquals(new String[]{"foo"}, f.getPath());
+            assertEquals("bar", f.getKey());
+        }
+
+        @Test
+        public void testEmbeddedDeepReference() throws Exception {
+            FieldReference f = FieldReference.from("[[foo][bar]][baz]");
+            assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
+            assertEquals("baz", f.getKey());
+        }
+
+        @Test(expected=FieldReference.IllegalSyntaxException.class)
+        public void testParseInvalidEmbeddedDeepReference() throws Exception {
+            FieldReference f = FieldReference.from("[[foo][bar]nope][baz]");
+        }
+
+        @Test(expected=FieldReference.IllegalSyntaxException.class)
+        public void testParseInvalidEmbeddedDeepReference2() throws Exception {
+            FieldReference f = FieldReference.from("[nope[foo][bar]][baz]");
+        }
+
+        @Test(expected=FieldReference.IllegalSyntaxException.class)
+        public void testParseInvalidNoCloseBracket() throws Exception {
+            FieldReference.from("[foo][bar][baz");
+        }
+
+        @Test(expected=FieldReference.IllegalSyntaxException.class)
+        public void testParseInvalidNoInitialOpenBracket() throws Exception {
+            FieldReference.from("foo[bar][baz]");
+        }
+
+        @Test(expected=FieldReference.IllegalSyntaxException.class)
+        public void testParseInvalidMissingMiddleBracket() throws Exception {
+            FieldReference.from("[foo]bar[baz]");
+        }
+
+        @Test(expected=FieldReference.IllegalSyntaxException.class)
+        public void testParseInvalidOnlyOpenBracket() throws Exception {
+            FieldReference.from("[");
+        }
+
+        @Test(expected=FieldReference.IllegalSyntaxException.class)
+        public void testParseInvalidOnlyCloseBracket() throws Exception {
+            FieldReference.from("]");
+        }
+
+        @Test(expected=FieldReference.IllegalSyntaxException.class)
+        public void testParseInvalidLotsOfOpenBrackets() throws Exception {
+            FieldReference.from("[[[[[[[[[[[]");
+        }
+
+        @Test(expected=FieldReference.IllegalSyntaxException.class)
+        public void testParseInvalidDoubleCloseBrackets() throws Exception {
+            FieldReference.from("[foo]][bar]");
+        }
+
+        @Test(expected=FieldReference.IllegalSyntaxException.class)
+        public void testParseNestingSquareBrackets() throws Exception {
+            FieldReference.from("[this[is]terrible]");
+        }
+
+        @Test(expected=FieldReference.IllegalSyntaxException.class)
+        public void testParseChainedNestingSquareBrackets() throws Exception {
+            FieldReference.from("[this[is]terrible][and][it[should-not[work]]]");
+        }
+
+        @Test(expected=FieldReference.IllegalSyntaxException.class)
+        public void testParseLiteralSquareBrackets() throws Exception {
+            FieldReference.from("this[index]");
+        }
     }
 }

--- a/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
+++ b/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
@@ -17,28 +17,28 @@ public final class FieldReferenceTest {
     public void testParseSingleBareField() throws Exception {
         FieldReference f = FieldReference.from("foo");
         assertEquals(0, f.getPath().length);
-        assertEquals(f.getKey(), "foo");
+        assertEquals("foo", f.getKey());
     }
 
     @Test
     public void testParseSingleFieldPath() throws Exception {
         FieldReference f = FieldReference.from("[foo]");
         assertEquals(0, f.getPath().length);
-        assertEquals(f.getKey(), "foo");
+        assertEquals("foo", f.getKey());
     }
 
     @Test
     public void testParse2FieldsPath() throws Exception {
         FieldReference f = FieldReference.from("[foo][bar]");
-        assertArrayEquals(f.getPath(), new String[]{"foo"});
-        assertEquals(f.getKey(), "bar");
+        assertArrayEquals(new String[]{"foo"}, f.getPath());
+        assertEquals("bar", f.getKey());
     }
 
     @Test
     public void testParse3FieldsPath() throws Exception {
         FieldReference f = FieldReference.from("[foo][bar]]baz]");
-        assertArrayEquals(f.getPath(), new String[]{"foo", "bar"});
-        assertEquals(f.getKey(), "baz");
+        assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
+        assertEquals("baz", f.getKey());
     }
 
     @Test


### PR DESCRIPTION
This is a backport to 6.x of a chain of commits from elastic/logstash#9543 (which covers the transition from the current `FieldReference` parser to something more strict); as discussed in the full transition PR, this backport to 6.x:
 - fixes inputs that currently crash Logstash by preemptively moving these specific inputs to strict-mode
 - warns when strict-mode would expand a field reference differently than the legacy-mode, and includes the ability for a user to opt-in to strict-mode in advance of their migration to 7.x where strict-mode will be the default:

> ## 6.x
> 
> For 6.x, the first _four_ commits in this PR can safely be backported.
> 
> We add an opt-in strict-mode parser, and implement a compat-mode parser that will always produce the same path and key as if we were using the legacy-mode parser. It does this by identifying potentially-ambiguous inputs, and falling back to the legacy-mode parser. When it detects a _difference_ between the two parsers, it emits a warning to the logs.
> 
> We enable the user to opt-in to the strict-mode with either a command-line flag `--field-reference-parser=<MODE>` or a settings-file directive `config.field_reference.parser`, and default to `COMPAT`-mode:
> 
> > ~~~
> >     --field-reference-parser MODE Use the given MODE when parsing field
> >                                   references.
> >                                   
> >                                   The field reference parser is used to expand
> >                                   field references in your pipeline configs,
> >                                   and will be becoming more strict to better
> >                                   handle ambiguous inputs in a future release
> >                                   of Logstash.
> >                                   
> >                                   Available MODEs are:
> >                                    - `LEGACY`: parse with the legacy parser,
> >                                      which is known to handle ambiguous and
> >                                      illegal-syntax in surprising ways;
> >                                      warnings will not be emitted.
> >                                    - `COMPAT`: warn once for each distinct
> >                                      ambiguous or illegal input, but continue
> >                                      to expand field references with the
> >                                      legacy parser.
> >                                    - `STRICT`: parse in a strict manner; when
> >                                      given ambiguous input, do not expand the
> >                                      reference.
> >                                   
> >                                    The MODE can also be set with
> >                                    `config.field_reference.parser`
> >                                   
> >                                    (default: "COMPAT")
> > ~~~
> > -- `bin/logstash --help` output
> 
> I elected to give three options instead of just two, because although `COMPAT` and `LEGACY` are _tested_ to behave identically, I wanted to provide an escape-hatch to fall all the way back to the verbatim code if customers or community users experience issues.