### PR TITLE
BUILD: Add Java wrapper for xpack integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,9 @@ plugins {
 
 apply plugin: 'de.undercouch.download'
 
+
 import de.undercouch.gradle.tasks.download.Download
 import de.undercouch.gradle.tasks.download.Verify
-import org.logstash.gradle.ExecLogOutputStream
 import org.logstash.gradle.RubyGradleUtils
 import org.yaml.snakeyaml.Yaml
 
@@ -391,21 +391,17 @@ task copyEs(type: Copy, dependsOn: [downloadEs, deleteLocalEs]) {
 Boolean oss = System.getenv('OSS').equals('true')
 
 if (!oss) {
-  task runXPackIntegrationTests(type: Exec, dependsOn: [installTestGems, copyEs]) {
-      workingDir "${projectDir}/x-pack"
-      standardOutput = new ExecLogOutputStream(System.out)
-      errorOutput = new ExecLogOutputStream(System.err)
-      commandLine(['../bin/rspec', '-fd', 'qa/integration'])
-  }
-
-  task runXPackUnitTests(dependsOn: [tasks.getByPath(":logstash-xpack:rubyTests")]) {}
-
   project(":logstash-xpack") {
-    ["rubyTests", "test"].each { tsk ->
+    ["rubyTests", "rubyIntegrationTests", "test"].each { tsk ->
       tasks.getByPath(":logstash-xpack:" + tsk).configure {
         dependsOn bootstrap
       }
     }
+    tasks.getByPath(":logstash-xpack:rubyIntegrationTests").configure {
+      dependsOn copyEs
+    }
   }
 
+  task runXPackUnitTests(dependsOn: [tasks.getByPath(":logstash-xpack:rubyTests")]) {}
+  task runXPackIntegrationTests(dependsOn: [tasks.getByPath(":logstash-xpack:rubyIntegrationTests")]) {}
 }

--- a/x-pack/build.gradle
+++ b/x-pack/build.gradle
@@ -27,3 +27,11 @@ task rubyTests(type: Test) {
   systemProperty 'logstash.core.root.dir', projectDir.absolutePath
   include '/org/logstash/xpack/test/RSpecTests.class'
 }
+
+task rubyIntegrationTests(type: Test) {
+  inputs.files fileTree("${projectDir}/qa")
+  inputs.files fileTree("${projectDir}/lib")
+  inputs.files fileTree("${projectDir}/modules")
+  systemProperty 'logstash.core.root.dir', projectDir.absolutePath
+  include '/org/logstash/xpack/test/RSpecIntegrationTests.class'
+}

--- a/x-pack/src/test/java/org/logstash/xpack/test/RSpecIntegrationTests.java
+++ b/x-pack/src/test/java/org/logstash/xpack/test/RSpecIntegrationTests.java
@@ -1,0 +1,34 @@
+package org.logstash.xpack.test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.logstash.RubyUtil;
+import org.logstash.Rubyfier;
+
+public final class RSpecIntegrationTests {
+    @Test
+    public void rspecTests() throws Exception {
+        RubyUtil.RUBY.getENV().put("IS_JUNIT_RUN", "true");
+        RubyUtil.RUBY.getGlobalVariables().set(
+            "$JUNIT_ARGV", Rubyfier.deep(RubyUtil.RUBY, Arrays.asList(
+                "-fd", "qa/integration"
+            ))
+        );
+        final Path rspec = Paths.get(
+            org.assertj.core.util.Files.currentFolder().getParent(), "lib/bootstrap/rspec.rb"
+        );
+        final IRubyObject result = RubyUtil.RUBY.executeScript(
+            new String(Files.readAllBytes(rspec), StandardCharsets.UTF_8),
+            rspec.toFile().getAbsolutePath()
+        );
+        if (!result.toJava(Long.class).equals(0L)) {
+            Assert.fail("RSpec test suit saw at least one failure.");
+        }
+    }
+}


### PR DESCRIPTION
Same as for all the other RSpec tests we run, added a JUnit wrapper to RSpec for better portability.