### PR TITLE
[DOCS] Moves X-Pack configuration pages in table of contents

### DIFF
--- a/docs/index-shared3.asciidoc
+++ b/docs/index-shared3.asciidoc
@@ -30,6 +30,20 @@ include::static/ingest-convert.asciidoc[]
 :edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/ls-ls-config.asciidoc
 include::static/ls-ls-config.asciidoc[]
 
+ifdef::include-xpack[]
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/x-pack/docs/en/setup/configuring-xls.asciidoc
+include::{xls-repo-dir}/setup/configuring-xls.asciidoc[]
+
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/x-pack/docs/en/management/configuring-centralized-pipelines.asciidoc
+include::{xls-repo-dir}/management/configuring-centralized-pipelines.asciidoc[]
+
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/x-pack/docs/en/monitoring/configuring-logstash.asciidoc
+include::{xls-repo-dir}/monitoring/configuring-logstash.asciidoc[]
+
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/x-pack/docs/en/security/logstash.asciidoc
+include::{xls-repo-dir}/security/logstash.asciidoc[]
+endif::include-xpack[]
+
 // Centralized configuration managements
 :edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/config-management.asciidoc
 include::static/config-management.asciidoc[]

--- a/docs/index-shared3.asciidoc
+++ b/docs/index-shared3.asciidoc
@@ -31,9 +31,6 @@ include::static/ingest-convert.asciidoc[]
 include::static/ls-ls-config.asciidoc[]
 
 ifdef::include-xpack[]
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/x-pack/docs/en/setup/configuring-xls.asciidoc
-include::{xls-repo-dir}/setup/configuring-xls.asciidoc[]
-
 :edit_url: https://github.com/elastic/logstash/edit/{branch}/x-pack/docs/en/management/configuring-centralized-pipelines.asciidoc
 include::{xls-repo-dir}/management/configuring-centralized-pipelines.asciidoc[]
 
@@ -42,6 +39,9 @@ include::{xls-repo-dir}/monitoring/configuring-logstash.asciidoc[]
 
 :edit_url: https://github.com/elastic/logstash/edit/{branch}/x-pack/docs/en/security/logstash.asciidoc
 include::{xls-repo-dir}/security/logstash.asciidoc[]
+
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/x-pack/docs/en/setup/configuring-xls.asciidoc
+include::{xls-repo-dir}/setup/configuring-xls.asciidoc[]
 endif::include-xpack[]
 
 // Centralized configuration managements

--- a/x-pack/docs/en/management/configuring-centralized-pipelines.asciidoc
+++ b/x-pack/docs/en/management/configuring-centralized-pipelines.asciidoc
@@ -1,6 +1,9 @@
 [role="xpack"]
 [[configuring-centralized-pipelines]]
 === Configuring Centralized Pipeline Management
+++++
+<titleabbrev>Centralized Pipeline Management</titleabbrev>
+++++
 
 To configure
 {logstash-ref}/logstash-centralized-pipeline-management.html[centralized pipeline management]:

--- a/x-pack/docs/en/monitoring/configuring-logstash.asciidoc
+++ b/x-pack/docs/en/monitoring/configuring-logstash.asciidoc
@@ -2,7 +2,7 @@
 [[configuring-logstash]]
 === Configuring Monitoring for Logstash Nodes
 ++++
-<titleabbrev>Configuring Monitoring</titleabbrev>
+<titleabbrev>{monitoring}</titleabbrev>
 ++++
 
 To monitor Logstash nodes:

--- a/x-pack/docs/en/security/logstash.asciidoc
+++ b/x-pack/docs/en/security/logstash.asciidoc
@@ -2,7 +2,7 @@
 [[ls-security]]
 === Configuring Security in Logstash
 ++++
-<titleabbrev>Configuring Security</titleabbrev>
+<titleabbrev>{security}</titleabbrev>
 ++++
 
 The Logstash {es} plugins (

--- a/x-pack/docs/en/setup/setting-up-xpack.asciidoc
+++ b/x-pack/docs/en/setup/setting-up-xpack.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[setup-xpack]]
-== Setting Up X-Pack
+=== Setting Up X-Pack
 
 {xpack} is an Elastic Stack extension that provides security, alerting,
 monitoring, machine learning, pipeline management, and many other capabilities. 
@@ -10,8 +10,3 @@ If you want to try all of the {xpack} features, you can
 {xpack-ref}/license-management.html[start a 30-day trial]. At the end of the 
 trial period, you can purchase a subscription to keep using the full 
 functionality of the {xpack} components. For more information, see https://www.elastic.co/subscriptions.
-
-include::configuring-xls.asciidoc[]
-include::{xls-repo-dir}/management/configuring-centralized-pipelines.asciidoc[]
-include::{xls-repo-dir}/monitoring/configuring-logstash.asciidoc[]
-include::{xls-repo-dir}/security/logstash.asciidoc[]


### PR DESCRIPTION
Related to https://github.com/elastic/logstash/issues/9596

This PR removes the "Set Up X-Pack" section from the highest level of the Kibana User Guide's table of contents.  Instead, that content is moved under the existing "Setting Up and Running Logstash" and "Configuring Logstash" sections.  For example:

![logstash-toc1](https://user-images.githubusercontent.com/26471269/40200391-0521c1ee-59d1-11e8-83c7-b986dc97aae9.png)

and 

![logstash-toc2](https://user-images.githubusercontent.com/26471269/40200407-0efc0e4a-59d1-11e8-957a-980c91450c6f.png)


This is a superficial change, but sets the stage for ultimately moving those source files into the logstash/docs folder. In the long run, I expect the "Set up X-Pack" page to be removed when its contents are merged into the appropriate Logstash page.

P.S.  These pages are just about one-time setup of these features, but you could definitely make a case for putting some of them under appropriate "Managing Logstash", "Monitoring Logstash", and "Securing Logstash" sections instead.  Whatever you prefer, let me know and I'll help make it so.

