### PR TITLE
Add a command for building the artifacts inside Docker

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -260,6 +260,10 @@ task assembleOssZipDistribution(dependsOn: downloadAndInstallJRuby) {
   }
 }
 
+task dockerBuildArtifacts(type: Exec) {
+	commandLine "sh", "-c", "./ci/docker_build_artifacts.sh"
+}
+
 def logstashBuildDir = "${buildDir}/logstash-${project.version}-SNAPSHOT"
 
 task unpackTarDistribution(dependsOn: assembleTarDistribution, type: Copy) {

--- a/ci/docker_build_artifacts.sh
+++ b/ci/docker_build_artifacts.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# This should be called from top repository folder.
+# It runs the `rake artifact:all` command in a docker image that has the required
+# dependencies.
+#
+# The artifacts will be placed in the build/ folder.
+
+docker build -f rakelib/Dockerfile.artifacts -t ls-artifacts rakelib/
+docker run --rm \
+	-v $(pwd):/logstash:delegated \
+	ls-artifacts \
+	sh -c "cd logstash && rake artifact:all"

--- a/rakelib/Dockerfile.artifacts
+++ b/rakelib/Dockerfile.artifacts
@@ -1,0 +1,18 @@
+# This image contains the right dependencies to run `rake artifacts:all`
+# Example usage:
+#
+#  docker build -f rakelib/Dockerfile.artifacts -t ls-artifacts rakelib/
+#  docker run -it --rm -v `pwd`:/logstash:delegated ls-artifacts sh -c "cd logstash && rake artifact:all"
+#
+# Note that it seems that rake is a particularly bad case scenario for the
+# docker osxfs driver (it touches 10s of K of files). Hence the `:delegated`
+# parameter above is needed to get things to work at all, but it is still slow
+# and it's going to consume a lot of CPU.
+#
+# See https://docs.docker.com/docker-for-mac/osxfs/#performance-issues-solutions-and-roadmap
+FROM jruby:9
+
+RUN \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        default-jdk git binutils rpm


### PR DESCRIPTION
This adds:

* A Dockerfile.artifacts with the dependencies required to run the
  `rake artifact:all` command inside Docker
* A `./ci/docker_build_artifacts.sh` script that makes use of this image
* A gradle task that simply executes that script