### PR TITLE
Add  geoip.autonomous_system when src is public.

### DIFF
--- a/modules/netflow/configuration/logstash/netflow.conf.erb
+++ b/modules/netflow/configuration/logstash/netflow.conf.erb
@@ -536,24 +536,24 @@ filter {
                 source => "[netflow][dst_addr]"
                 default_database_type => "ASN"
             }
-            # Populate geoip.autonomous_system.
-            if [geoip][as_org] {
-                if [geoip][asn] {
-                    mutate {
-                        id => "netflow-postproc-as-from-as_org-asn"
-                        add_field => { "[geoip][autonomous_system]" => "%{[geoip][as_org]} (%{[geoip][asn]})" }
-                    }
-                } else {
-                    mutate {
-                        id => "netflow-postproc-as-from-as_org"
-                        add_field => { "[geoip][autonomous_system]" => "%{[geoip][as_org]}" }
-                    }
-                }
-            } else if [geoip][asn] {
+        }
+        # Populate geoip.autonomous_system.
+        if [geoip][as_org] {
+            if [geoip][asn] {
                 mutate {
-                    id => "netflow-postproc-as-from-asn"
-                    add_field => { "[geoip][autonomous_system]" => "%{[geoip][asn]}" }
+                    id => "netflow-postproc-as-from-as_org-asn"
+                    add_field => { "[geoip][autonomous_system]" => "%{[geoip][as_org]} (%{[geoip][asn]})" }
                 }
+            } else {
+                mutate {
+                    id => "netflow-postproc-as-from-as_org"
+                    add_field => { "[geoip][autonomous_system]" => "%{[geoip][as_org]}" }
+                }
+            }
+        } else if [geoip][asn] {
+            mutate {
+                id => "netflow-postproc-as-from-asn"
+                add_field => { "[geoip][autonomous_system]" => "%{[geoip][asn]}" }
             }
         }
     }


### PR DESCRIPTION
Currently, geoip.autonomous_system is only filled when [netflow][dst_locality]  is public. This change fills geoip.autonomous_system when [netflow][src_locality] is public.