### PR TITLE
Fix accidental semicolon that got in in 8f03e8224

### DIFF
--- a/logstash-core/spec/logstash/plugin_spec.rb
+++ b/logstash-core/spec/logstash/plugin_spec.rb
@@ -1,4 +1,4 @@
-:# encoding utf-8
+# encoding utf-8
 require "spec_helper"
 require "logstash/plugin"
 require "logstash/outputs/base"


### PR DESCRIPTION
Normally we don't require review or tests for backports, which is why this slipped in!