### PR TITLE
Explicitly depend on guava 22

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -120,6 +120,7 @@ dependencies {
     compile 'org.codehaus.janino:janino:3.0.8'
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jacksonVersion}"
     compile "org.jruby:jruby-complete:${jrubyVersion}"
+    compile group: 'com.google.guava', name: 'guava', version: '22.0'
     // Do not upgrade this, later versions require GPL licensed code in javac-shaded that is
     // Apache2 incompatible
     compile 'com.google.googlejavaformat:google-java-format:1.1'


### PR DESCRIPTION
We only depended on it transitively in the past, this makes it explicit.

This caused an issue in the google pubsub plugins, reported here: https://github.com/elastic/logstash/issues/9592

In the future, this will be a non-concern when our java plugin API launches with classloader isolation.

Resolves #9592