### PR TITLE
Add read_timestamp to Nginx errors, keep @timestamp

### DIFF
--- a/docs/static/filebeat_modules/nginx/pipeline.conf
+++ b/docs/static/filebeat_modules/nginx/pipeline.conf
@@ -34,7 +34,7 @@ filter {
         remove_field => "message"
       }
       mutate {
-        rename => { "@timestamp" => "read_timestamp" }
+        add_field => { "read_timestamp" => "%{@timestamp}" }
       }
       date {
         match => [ "[nginx][error][time]", "YYYY/MM/dd H:m:s" ]


### PR DESCRIPTION
Add `read_timestamp` field instead of removing `@timestamp` for Nginx error log messages exactly like the access rules (above it). This will keep logstash from crashing when trying to ingest error log messages due to a missing time stamp.

See official suggestion here: https://discuss.elastic.co/t/keep-logstash-from-crashing/90392/6