### PR TITLE
X-Pack monitoring: prevent failures to emit events before Agent initialized

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -333,7 +333,7 @@ class LogStash::Agent
       when LogStash::PipelineAction::Reload
         dispatcher.fire(:pipeline_stopped, get_pipeline(action.pipeline_id))
       when LogStash::PipelineAction::Stop
-        dispatcher.fire(:pipeline_started, get_pipeline(action.pipeline_id))
+        dispatcher.fire(:pipeline_stopped, get_pipeline(action.pipeline_id))
       end
     end
   end

--- a/x-pack/lib/monitoring/inputs/metrics.rb
+++ b/x-pack/lib/monitoring/inputs/metrics.rb
@@ -54,7 +54,6 @@ module LogStash module Inputs
       @last_updated_pipeline_hashes = []
       @es_options = es_options_from_settings_or_modules(FEATURE, @settings)
       setup_license_checker(FEATURE)
-      configure_snapshot_poller
     end
 
     def pipeline_started(agent, pipeline)
@@ -70,7 +69,7 @@ module LogStash module Inputs
         :execution_interval => @collection_interval,
         :timeout_interval => @collection_timeout_interval
       }) do
-        update(metric.collector.snapshot_metric)
+        update(metric.collector.snapshot_metric) unless @agent.nil?
       end
 
       @timer_task.add_observer(TimerTaskLogger.new)
@@ -79,6 +78,8 @@ module LogStash module Inputs
       def run(arg_queue)
         @logger.debug("Metric: input started")
         @queue = arg_queue
+
+        configure_snapshot_poller
 
         # This must be invoked here because we need a queue to store the data
         LogStash::PLUGIN_REGISTRY.hooks.register_hooks(LogStash::Agent, self)


### PR DESCRIPTION
Before the monitoring pipeline is started, it is not possible to emit events
from the metrics input; not only is the `agent` nil (resulting in a cryptic
`NoMethodError` when we attempt to get its `ephemeral_id`), but the `queue`
will also be `nil` until the `run` method is invoked.

Instead, start the poller once we are sent `run` and are guaranteed to have a
`queue` on which to put the events; when the snapshot poller is running, skip
any invocations before `agent` is available.

Also fixes an issue in which we incorrectly were firing `pipeline_started` when
a pipeline is stopped (first noticed in elastic/logstash#9444).