### PR TITLE
[Test Stability] Shutdown agent after pipelines

### DIFF
--- a/logstash-core/spec/support/shared_contexts.rb
+++ b/logstash-core/spec/support/shared_contexts.rb
@@ -31,11 +31,11 @@ shared_context "api setup" do
   end
 
   after :all do
-    @agent.shutdown
     @pipelines.each do |_, pipeline|
       pipeline.shutdown
       pipeline.thread.join
     end
+    @agent.shutdown
   end
 
   include Rack::Test::Methods


### PR DESCRIPTION
I actually am not sure if this matters, but it seems like it won't hurt,
and is a more sane ordering of things. I have a suspicion that in some cases
the agents get stuck and don't shut down because of this ordering, but I can't
prove it