### PR TITLE
Enable TEST_DEBUG on CI servers

### DIFF
--- a/ci/unit_tests.sh
+++ b/ci/unit_tests.sh
@@ -10,6 +10,7 @@ export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=
 export SPEC_OPTS="--order rand --format documentation"
 export CI=true
 export OSS=true
+export TEST_DEBUG=true
 
 SELECTED_TEST_SUITE=$1
 


### PR DESCRIPTION
Some tests are impossible to debug since log messages are not echoed without this,
including fatal/error messages. This makes output more verbose, but actually debuggable.

We should really delete this 'functionality' from https://github.com/elastic/logstash-devutils/blob/master/lib/logstash/devutils/rspec/spec_helper.rb#L36
since it does more harm than good.