### PR TITLE
Revert commit that broke dep report

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -35,7 +35,8 @@ RUN echo 'eval "$(rbenv init -)"' >> .bashrc && \
 # Create a cache for the dependencies based on the current master, any dependencies not cached will be downloaded at runtime
 RUN git clone https://github.com/elastic/logstash.git /tmp/logstash && \
     cd /tmp/logstash && \
-    ./gradlew bootstrap compileJava compileTestJava && \
+    rake test:install-core && \
+    ./gradlew compileJava compileTestJava && \
     cd qa/integration && \
     /home/logstash/.rbenv/shims/bundle install && \
     mv /tmp/logstash/vendor /tmp/vendor && \

--- a/build.gradle
+++ b/build.gradle
@@ -149,19 +149,6 @@ task downloadAndInstallJRuby(dependsOn: verifyFile, type: Copy) {
     into "${projectDir}/vendor/jruby"
 }
 
-task installDefaultGems(dependsOn: downloadAndInstallJRuby) {
-  inputs.files file("${projectDir}/Gemfile.template")
-  inputs.files fileTree("${projectDir}/rakelib")
-  inputs.files file("${projectDir}/versions.yml")
-  outputs.file("${projectDir}/Gemfile")
-  outputs.file("${projectDir}/Gemfile.lock")
-  outputs.dir("${projectDir}/logstash-core/lib/jars")
-  outputs.dir("${projectDir}/vendor/bundle/jruby/2.3.0")
-  doLast {
-    rubyGradleUtils.rake('plugin:install-default')
-  }
-}
-
 task installTestGems(dependsOn: downloadAndInstallJRuby) {
   inputs.files file("${projectDir}/Gemfile.template")
   inputs.files fileTree("${projectDir}/rakelib")

--- a/ci/license_check.sh
+++ b/ci/license_check.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -i
 export GRADLE_OPTS="-Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info"
 
-./gradlew installDefaultGems
+rake plugin:install-default
 bin/dependencies-report --csv report.csv
 # We want this to show on the CI server
 cat report.csv

--- a/logstash-core/lib/logstash/dependency_report.rb
+++ b/logstash-core/lib/logstash/dependency_report.rb
@@ -20,17 +20,11 @@ class LogStash::DependencyReport < Clamp::Command
       jars.each { |d| csv << d }
     end
 
-    puts "Wrote temporary ruby deps CSV to #{ruby_output_path}"
-
-    # Use gradle to find the rest and add to the ruby CSV
-    puts "Find gradle jar dependencies #{Dir.pwd}"
-    command = ["./gradlew", "generateLicenseReport", "-PlicenseReportInputCSV=#{ruby_output_path}", "-PlicenseReportOutputCSV=#{output_path}"]
-    puts "Executing #{command}"
-    system(*command)
-    if $?.exitstatus != 0
-      raise "Could not run gradle java deps! Exit status #{$?.exitstatus}"
+    # Copy in COPYING.csv which is a best-effort, hand-maintained file of dependency license information.
+    File.open(output_path, "a+") do |file|
+      extra = File.join(File.dirname(__FILE__), "..", "..", "..", "COPYING.csv")
+      file.write(IO.read(extra))
     end
-
     nil
   end
 

--- a/logstash-core/spec/logstash/plugin_spec.rb
+++ b/logstash-core/spec/logstash/plugin_spec.rb
@@ -1,4 +1,4 @@
-# encoding utf-8
+# encoding: utf-8
 require "spec_helper"
 require "logstash/plugin"
 require "logstash/outputs/base"


### PR DESCRIPTION
This reverts commit 8f03e822499d1c8c9f6c68739b419909a2bedb56.

That was part of a larger series of changes that shouldn't be in 6.3. This change broke the `bin/dependencies-report` command.