### PR TITLE
Some QA builds are exiting due to an inability to allocate heap.

### DIFF
--- a/qa/Vagrantfile
+++ b/qa/Vagrantfile
@@ -9,7 +9,7 @@ Vagrant.configure(2) do |config|
     config.vm.define platform.name do |machine|
       machine.vm.box = platform.box
       machine.vm.provider "virtualbox" do |v|
-        v.memory = 2096
+        v.memory = 4096
         v.cpus = 4
       end
       machine.vm.synced_folder "../build", "/logstash-build", create: true


### PR DESCRIPTION
We should just bump the available memory to 4GB, which is plenty reasonable,
as a starting point.

See https://logstash-ci.elastic.co/job/elastic+logstash+6.x+multijob-acceptance/label=metal,suite=redhat/84/console for an example