### PR TITLE
Fix converge spec that didn't wait for agent to converge

### DIFF
--- a/logstash-core/spec/logstash/agent/converge_spec.rb
+++ b/logstash-core/spec/logstash/agent/converge_spec.rb
@@ -117,7 +117,8 @@ describe LogStash::Agent do
           end
 
           it "converge only once" do
-            expect(source_loader.fetch_count).to eq(1)
+            wait(60).for { source_loader.fetch_count }.to eq(1)
+
             expect(subject).to have_running_pipeline?(pipeline_config)
 
             subject.shutdown


### PR DESCRIPTION
This spec had a race, the start_agent invocation this depends on doesn't wait
until the state has converged at least once.

An example failure is here: https://logstash-ci.elastic.co/job/elastic+logstash+6.x+multijob-unix-compatibility/os=debian/121/console

The message was:

```
22:34:08     Failures:
22:34:08
22:34:08       1) LogStash::Agent Agent execute options when `config.reload.automatic` is set to`FALSE` and successfully load the config converge only once
22:34:08          Failure/Error: expect(source_loader.fetch_count).to eq(1)
22:34:08
22:34:08            expected: 1
22:34:08                 got: 0
22:34:08
22:34:08            (compared using ==)
22:34:08          # /var/lib/jenkins/workspace/elastic+logstash+6.x+multijob-unix-compatibility/os/debian/logstash-core/spec/logstash/agent/converge_spec.rb:120:in `block in (root)'
22:34:08          # /var/lib/jenkins/workspace/elastic+logstash+6.x+multijob-unix-compatibility/os/debian/spec/spec_helper.rb:50:in `block in /var/lib/jenkins/workspace/elastic+logstash+6.x+multijob-unix-compatibility/os/debian/spec/spec_helper.rb'
22:34:08          # /var/lib/jenkins/workspace/elastic+logstash+6.x+multijob-unix-compatibility/os/debian/spec/spec_helper.rb:43:in `block in /var/lib/jenkins/workspace/elastic+logstash+6.x+multijob-unix-compatibility/os/debian/spec/spec_helper.rb'
22:34:08          # /var/lib/jenkins/workspace/elastic+logstash+6.x+multijob-unix-compatibility/os/debian/vendor/bundle/jruby/2.3.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block in /var/lib/jenkins/workspace/elastic+logstash+6.x+multijob-unix-compatibility/os/debian/vendor/bundle/jruby/2.3.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb'
22:34:08          # /var/lib/jenkins/workspace/elastic+logstash+6.x+multijob-unix-compatibility/os/debian/lib/bootstrap/rspec.rb:13:in `<main>'
22:34:08
22:34:08     Finished in 5 minutes 27 seconds (files took 8.75 seconds to load)
22:34:08     2877 examples, 1 failure, 5 pending
```