### PR TITLE
PQ: Improve stability of ack logic

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Page.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Page.java
@@ -1,12 +1,11 @@
 package org.logstash.ackedqueue;
 
+import com.google.common.primitives.Ints;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.BitSet;
-
 import org.codehaus.commons.nullanalysis.NotNull;
 import org.logstash.ackedqueue.io.CheckpointIO;
-import org.logstash.ackedqueue.io.LongVector;
 import org.logstash.ackedqueue.io.PageIO;
 
 public final class Page implements Closeable {
@@ -99,10 +98,9 @@ public final class Page implements Closeable {
     }
 
     public boolean isFullyAcked() {
-        // TODO: it should be something similar to this when we use a proper bitset class like ES
-        // this.ackedSeqNum.firstUnackedBit >= this.elementCount;
-        // TODO: for now use a naive & inefficient mechanism with a simple Bitset
-        return this.elementCount > 0 && this.ackedSeqNums.cardinality() >= this.elementCount;
+        final int cardinality = ackedSeqNums.cardinality();
+        return elementCount > 0 && cardinality == ackedSeqNums.length()
+            && cardinality == elementCount;
     }
 
     public long unreadCount() {
@@ -116,29 +114,25 @@ public final class Page implements Closeable {
      * the head page to update firstUnackedPageNum because it will be updated in the next upcoming head page checkpoint
      * and in a crash condition, the Queue open recovery will detect and purge fully acked pages
      *
-     * @param seqNums the list of same-page seqNums to ack
+     * @param firstSeqNum Lowest sequence number to ack
+     * @param count Number of elements to ack
      * @param checkpointMaxAcks number of acks before forcing a checkpoint
      * @throws IOException
      */
-    public void ack(LongVector seqNums, int checkpointMaxAcks) throws IOException {
-        final int count = seqNums.size();
-        for (int i = 0; i < count; ++i) {
-            final long seqNum = seqNums.get(i);
-            // TODO: eventually refactor to use new bit handling class
-
-            assert seqNum >= this.minSeqNum :
-                    String.format("seqNum=%d is smaller than minSeqnum=%d", seqNum, this.minSeqNum);
-
-            assert seqNum < this.minSeqNum + this.elementCount :
-                    String.format("seqNum=%d is greater than minSeqnum=%d + elementCount=%d = %d", seqNum, this.minSeqNum, this.elementCount, this.minSeqNum + this.elementCount);
-            int index = (int)(seqNum - this.minSeqNum);
-
-            this.ackedSeqNums.set(index);
-        }
-
+    public void ack(long firstSeqNum, int count, int checkpointMaxAcks) throws IOException {
+        assert firstSeqNum >= this.minSeqNum :
+            String.format("seqNum=%d is smaller than minSeqnum=%d", firstSeqNum, this.minSeqNum);
+        final long maxSeqNum = firstSeqNum + count;
+        assert maxSeqNum <= this.minSeqNum + this.elementCount :
+            String.format(
+                "seqNum=%d is greater than minSeqnum=%d + elementCount=%d = %d", maxSeqNum,
+                this.minSeqNum, this.elementCount, this.minSeqNum + this.elementCount
+            );
+        final int offset = Ints.checkedCast(firstSeqNum - this.minSeqNum);
+        ackedSeqNums.flip(offset, offset + count);
         // checkpoint if totally acked or we acked more than checkpointMaxAcks elements in this page since last checkpoint
         // note that fully acked pages cleanup is done at queue level in Queue.ack()
-        long firstUnackedSeqNum = firstUnackedSeqNum();
+        final long firstUnackedSeqNum = firstUnackedSeqNum();
 
         if (isFullyAcked()) {
             checkpoint();
@@ -146,7 +140,7 @@ public final class Page implements Closeable {
             assert firstUnackedSeqNum >= this.minSeqNum + this.elementCount - 1:
                     String.format("invalid firstUnackedSeqNum=%d for minSeqNum=%d and elementCount=%d and cardinality=%d", firstUnackedSeqNum, this.minSeqNum, this.elementCount, this.ackedSeqNums.cardinality());
 
-        } else if (checkpointMaxAcks > 0 && (firstUnackedSeqNum >= this.lastCheckpoint.getFirstUnackedSeqNum() + checkpointMaxAcks)) {
+        } else if (checkpointMaxAcks > 0 && firstUnackedSeqNum >= this.lastCheckpoint.getFirstUnackedSeqNum() + checkpointMaxAcks) {
             // did we acked more than checkpointMaxAcks elements? if so checkpoint now
             checkpoint();
         }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -24,7 +24,6 @@ import org.logstash.FileLockFactory;
 import org.logstash.LockException;
 import org.logstash.ackedqueue.io.CheckpointIO;
 import org.logstash.ackedqueue.io.FileCheckpointIO;
-import org.logstash.ackedqueue.io.LongVector;
 import org.logstash.ackedqueue.io.MmapPageIOV2;
 import org.logstash.ackedqueue.io.PageIO;
 import org.logstash.common.FsUtil;
@@ -508,11 +507,11 @@ public final class Queue implements Closeable {
      * @return {@link Batch} the batch containing 1 or more element up to the required limit or null of no elements were available
      * @throws IOException
      */
-    public Batch nonBlockReadBatch(int limit) throws IOException {
+    public synchronized Batch nonBlockReadBatch(int limit) throws IOException {
         lock.lock();
         try {
             Page p = nextReadPage();
-            return (isHeadPage(p) && p.isFullyRead()) ? null : _readPageBatch(p, limit, 0L);
+            return (isHeadPage(p) && p.isFullyRead()) ? null : readPageBatch(p, limit, 0L);
         } finally {
             lock.unlock();
         }
@@ -525,10 +524,10 @@ public final class Queue implements Closeable {
      * @return the read {@link Batch} or null if no element upon timeout
      * @throws IOException
      */
-    public Batch readBatch(int limit, long timeout) throws IOException {
+    public synchronized Batch readBatch(int limit, long timeout) throws IOException {
         lock.lock();
         try {
-            return _readPageBatch(nextReadPage(), limit, timeout);
+            return readPageBatch(nextReadPage(), limit, timeout);
         } finally {
             lock.unlock();
         }
@@ -543,14 +542,13 @@ public final class Queue implements Closeable {
      * @return {@link Batch} with read elements or null if nothing was read
      * @throws IOException
      */
-    private Batch _readPageBatch(Page p, int limit, long timeout) throws IOException {
+    private Batch readPageBatch(Page p, int limit, long timeout) throws IOException {
         int left = limit;
         final List<byte[]> elements = new ArrayList<>(limit);
-        final LongVector seqNums = new LongVector(limit);
 
         // NOTE: the tricky thing here is that upon entering this method, if p is initially a head page
         // it could become a tail page upon returning from the notEmpty.await call.
-
+        long firstSeqNum = -1L;
         while (left > 0) {
             if (isHeadPage(p) && p.isFullyRead()) {
                 boolean elapsed;
@@ -575,7 +573,9 @@ public final class Queue implements Closeable {
                 int n = serialized.getElements().size();
                 assert n > 0 : "page read returned 0 elements";
                 elements.addAll(serialized.getElements());
-                seqNums.add(serialized.getSeqNums());
+                if (firstSeqNum == -1L) {
+                    firstSeqNum = serialized.getSeqNums().get(0);
+                }
 
                 this.unreadCount -= n;
                 left -= n;
@@ -594,7 +594,7 @@ public final class Queue implements Closeable {
             removeUnreadPage(p);
         }
 
-        return new Batch(elements, seqNums, this);
+        return new Batch(elements, firstSeqNum, this);
     }
 
     private static class TailPageResult {
@@ -652,18 +652,13 @@ public final class Queue implements Closeable {
      * same-page elements. A fully acked page will trigger a checkpoint for that page. Also if a page has more than checkpointMaxAcks
      * acks since last checkpoint it will also trigger a checkpoint.
      *
-     * @param seqNums the list of same-page sequence numbers to ack
+     * @param firstAckSeqNum First Sequence Number to Ack
+     * @param ackCount Number of Elements to Ack
      * @throws IOException
      */
-    public void ack(LongVector seqNums) throws IOException {
-        if (seqNums.size() == 0) {
-            return;
-        }
+    public void ack(final long firstAckSeqNum, final int ackCount) throws IOException {
         // as a first implementation we assume that all batches are created from the same page
         // so we will avoid multi pages acking here for now
-
-        // find the page to ack by traversing from oldest tail page
-        long firstAckSeqNum = seqNums.get(0);
 
         lock.lock();
         try {
@@ -686,17 +681,14 @@ public final class Queue implements Closeable {
                         String.format("seqNum=%d is not in head page with minSeqNum=%d", firstAckSeqNum, this.headPage.getMinSeqNum());
 
                 // page acking checkpoints fully acked pages
-                this.headPage.ack(seqNums, this.checkpointMaxAcks);
+                this.headPage.ack(firstAckSeqNum, ackCount, this.checkpointMaxAcks);
             } else {
                 // page acking also checkpoints fully acked pages or upon reaching the checkpointMaxAcks threshold
-                result.page.ack(seqNums, this.checkpointMaxAcks);
+                result.page.ack(firstAckSeqNum, ackCount, this.checkpointMaxAcks);
 
                 // cleanup fully acked tail page
                 if (result.page.isFullyAcked()) {
-                    boolean wasFull = isFull();
-
                     this.tailPages.remove(result.index);
-
                     // remove page data file regardless if it is the first or a middle tail page to free resources
                     result.page.purge();
 
@@ -715,8 +707,7 @@ public final class Queue implements Closeable {
                             nextPageNum++;
                         }
                     }
-
-                    if (wasFull) { notFull.signalAll(); }
+                    notFull.signalAll();
                 }
 
                 this.headPage.checkpoint();


### PR DESCRIPTION
Improving the stability and complexity of the PQ asking logic here.

The actual behaviour change happens by making the read methods `synchronized`. **This ensures that all elements in a batch have contiguous sequence numbers.** The reason for this is, that now only a single reader goes to sleep on the `empty` `Condition` at any given time.

Having ensured that, the ack logic could be (and has been) way simplified because now we only need to know the number of events and their first sequence number to ack.
This also allowed putting less state into `org.logstash.ackedqueue.Batch` because it now doesn't need to track a bunch of sequence numbers, which saves us a little memory :)

--------------------------------

I know I could've simplified away stuff like `org.logstash.ackedqueue.SequencedList` but I wanted to just get the main idea of having contiguous sequence numbers in first. We can always evaluate whether or not we want to simplify this particular codebase further or not after imo :)