### PR TITLE
Prefer gradle for installing default gems in license check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,6 +149,19 @@ task downloadAndInstallJRuby(dependsOn: verifyFile, type: Copy) {
     into "${projectDir}/vendor/jruby"
 }
 
+task installDefaultGems(dependsOn: downloadAndInstallJRuby) {
+  inputs.files file("${projectDir}/Gemfile.template")
+  inputs.files fileTree("${projectDir}/rakelib")
+  inputs.files file("${projectDir}/versions.yml")
+  outputs.file("${projectDir}/Gemfile")
+  outputs.file("${projectDir}/Gemfile.lock")
+  outputs.dir("${projectDir}/logstash-core/lib/jars")
+  outputs.dir("${projectDir}/vendor/bundle/jruby/2.3.0")
+  doLast {
+    rubyGradleUtils.rake('plugin:install-default')
+  }
+}
+
 task installTestGems(dependsOn: downloadAndInstallJRuby) {
   inputs.files file("${projectDir}/Gemfile.template")
   inputs.files fileTree("${projectDir}/rakelib")

--- a/ci/license_check.sh
+++ b/ci/license_check.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -i
 export GRADLE_OPTS="-Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info"
 
-rake plugin:install-default
+./gradlew installDefaultGems 
 bin/dependencies-report --csv report.csv
 # We want this to show on the CI server
 cat report.csv


### PR DESCRIPTION
This prevents JVM segfaults, as seen in https://logstash-ci.elastic.co/job/elastic+logstash+6.3+multijob-license-check/34/console.

Invoking rake directly in docker causes these presently.

This was originally fixed in 8f03e82 and reverted in 31461b5. The revert, fixed the universal build system, but broke our jenkins / docker CI tasks.