### PR TITLE
Fix VM halt task for acceptance tasks by CDing correctly

### DIFF
--- a/ci/acceptance_tests.sh
+++ b/ci/acceptance_tests.sh
@@ -21,8 +21,12 @@ SELECTED_TEST_SUITE=$1
 # BUILD_ID unless you set this magic flag:  https://wiki.jenkins.io/display/JENKINS/ProcessTreeKiller
 export BUILD_ID=dontKillMe
 
+
+QA_DIR="$PWD/qa"
+
 # Always run the halt, even if the test times out or an exit is sent
 cleanup() {
+  cd $QA_DIR
   bundle exec rake qa:vm:halt
 }
 trap cleanup EXIT


### PR DESCRIPTION
We were in the wrong dir before, we need to be in the qa dir to shutdown correctly