### PR TITLE
Fix Cloner to properly clone ruby strings (5.6 backport)

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Cloner.java
+++ b/logstash-core/src/main/java/org/logstash/Cloner.java
@@ -1,6 +1,15 @@
 package org.logstash;
 
-import java.util.*;
+import org.jruby.RubyString;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 public final class Cloner {
 
@@ -11,6 +20,8 @@ public final class Cloner {
             return (T) deepMap((Map<?, ?>) input);
         } else if (input instanceof List<?>) {
             return (T) deepList((List<?>) input);
+        } else if (input instanceof RubyString) {
+            return (T) ((RubyString) input).doClone();
         } else if (input instanceof Collection<?>) {
             throw new ClassCastException("unexpected Collection type " + input.getClass());
         }

--- a/logstash-core/src/test/java/org/logstash/ClonerTest.java
+++ b/logstash-core/src/test/java/org/logstash/ClonerTest.java
@@ -1,0 +1,26 @@
+package org.logstash;
+
+import org.jruby.RubyString;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ClonerTest {
+    @Test
+    public void testRubyStringCloning() {
+        String javaString = "fooBar";
+        RubyString original = RubyString.newString(RubyUtil.RUBY, javaString);
+
+        RubyString result = Cloner.deep(original);
+        // Check object identity
+        assertTrue(result != original);
+
+        // Check different underlying bytes
+        assertTrue(result.getByteList() != original.getByteList());
+
+        // Check string equality
+        assertEquals(result, original);
+
+        assertEquals(javaString, result.asJavaString());
+    }
+}


### PR DESCRIPTION
Backport of #9650 for 5.6