### PR TITLE
The initial implementation of inter-pipeline comms doesn't handle inter-pipeline dependencies correctly.

### DIFF
--- a/docs/static/pipeline-pipeline-config.asciidoc
+++ b/docs/static/pipeline-pipeline-config.asciidoc
@@ -1,5 +1,5 @@
 [[pipeline-to-pipeline]]
-=== Pipeline-to-Pipeline Communication
+=== Pipeline-to-Pipeline Communication (Beta)
 
 When using the multiple pipeline feature of Logstash, you may want to connect multiple pipelines within the same Logstash instance. This configuration can be useful to isolate the execution of these pipelines, as well as to help break-up the logic of complex pipelines. The `pipeline` input/output enables a number of advanced architectural patterns discussed later in this document.
 
@@ -40,6 +40,8 @@ In its standard configuration the `pipeline` input/output has at-least-once deli
 By default, the `ensure_delivery` option on the `pipeline` output is set to `true.` If you change the `ensure_delivery` flag to `false`, an unavailable downstream pipeline causes the sent message to be discarded. Use `ensure_delivery => false` when you want the ability to temporarily disable a downstream pipeline without the upstream one waiting for it.
 
 A blocked downstream pipeline blocks the sending output/pipeline regardless of the value of the `ensure_delivery` flag.
+
+These delivery guarantees also inform the shutdown behavior of this feature. When performing a pipeline reload, changes will be made immediately as the user requests, even if that means removing a downstream pipeline an upstream pipeline sends to. This will cause the upstream pipeline to block. You must restore the downstream pipeline to cleanly shutdown Logstash. You may issue a force kill, but inflight events may be lost, unless the persistent queue is in use.
 
 [[avoid-cycles]]
 ===== Avoid cycles

--- a/logstash-core/lib/logstash/pipeline_action/create.rb
+++ b/logstash-core/lib/logstash/pipeline_action/create.rb
@@ -42,9 +42,7 @@ module LogStash module PipelineAction
       status = nil
       pipelines.compute(pipeline_id) do |id,value|
         if value
-          message = "Attempted to create a pipeline that already exists! This shouldn't be possible"
-          logger.error(message, :pipeline_id => id, :pipelines => pipelines)
-          raise message
+          LogStash::ConvergeResult::ActionResult.create(self, true)
         end
         status = pipeline.start # block until the pipeline is correctly started or crashed
         pipeline # The pipeline is successfully started we can add it to the map

--- a/logstash-core/lib/logstash/plugins/builtin/pipeline/output.rb
+++ b/logstash-core/lib/logstash/plugins/builtin/pipeline/output.rb
@@ -20,10 +20,6 @@ module ::LogStash; module Plugins; module Builtin; module Pipeline; class Output
     pipeline_bus.sendEvents(self, events, ensure_delivery)
   end
 
-  def pipeline_shutting_down?
-    execution_context.pipeline.inputs.all? {|input| input.stop?}
-  end
-
   def close
     pipeline_bus.unregisterSender(self, @send_to)
   end

--- a/logstash-core/src/main/java/org/logstash/plugins/pipeline/AddressState.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/pipeline/AddressState.java
@@ -39,9 +39,14 @@ public class AddressState {
      * @return true if successful, false if another input is listening
      */
     public synchronized boolean assignInputIfMissing(PipelineInput newInput) {
-        if (input != newInput && input != null) return false;
-        this.input = newInput;
-        return true;
+        if (input == null) {
+            input = newInput;
+            return true;
+        } else if (input == newInput) {
+            return true; // We aren't changing anything
+        }
+
+        return false;
     }
 
     /**

--- a/logstash-core/src/test/java/org/logstash/plugins/pipeline/PipelineBusTest.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/pipeline/PipelineBusTest.java
@@ -2,7 +2,10 @@ package org.logstash.plugins.pipeline;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import static junit.framework.TestCase.assertTrue;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.core.Is.is;
 
 import org.logstash.RubyUtil;
 import org.logstash.ext.JrubyEventExtLibrary;
@@ -30,7 +33,7 @@ public class PipelineBusTest {
     }
 
     @Test
-    public void subscribeUnsubscribe() {
+    public void subscribeUnsubscribe() throws InterruptedException {
         assertThat(bus.listen(input, address)).isTrue();
         assertThat(bus.addressStates.get(address).getInput()).isSameAs(input);
 
@@ -56,7 +59,7 @@ public class PipelineBusTest {
     public void activeSenderPreventsPrune() {
         bus.registerSender(output, addresses);
         bus.listen(input, address);
-        bus.unlisten(input, address);
+        bus.unlistenNonblock(input, address);
 
         assertThat(bus.addressStates.containsKey(address)).isTrue();
         bus.unregisterSender(output, addresses);
@@ -65,7 +68,7 @@ public class PipelineBusTest {
 
 
     @Test
-    public void activeListenerPreventsPrune() {
+    public void activeListenerPreventsPrune() throws InterruptedException {
         bus.registerSender(output, addresses);
         bus.listen(input, address);
         bus.unregisterSender(output, addresses);
@@ -92,7 +95,7 @@ public class PipelineBusTest {
     }
 
     @Test
-    public void listenUnlistenUpdatesOutputReceivers() {
+    public void listenUnlistenUpdatesOutputReceivers() throws InterruptedException {
         bus.registerSender(output, addresses);
         bus.listen(input, address);
 
@@ -110,6 +113,12 @@ public class PipelineBusTest {
         // The new event went to the new input, not the old one
         assertThat(newInput.eventCount.longValue()).isEqualTo(1L);
         assertThat(input.eventCount.longValue()).isEqualTo(1L);
+    }
+
+    @Test
+    public void sendingEmptyListToNowhereStillReturns() {
+        bus.registerSender(output, Arrays.asList("not_an_address"));
+        bus.sendEvents(output, Collections.emptyList(), true);
     }
 
     @Test
@@ -139,6 +148,41 @@ public class PipelineBusTest {
         sendThread.join();
 
         assertThat(input.eventCount.longValue()).isEqualTo(1L);
+    }
+
+    @Test
+    public void whenInDefaultNonBlockingModeInputsShutdownInstantly() throws InterruptedException {
+        // Test confirms the default. If we decide to change the default we should change this test
+        assertThat(bus.isBlockOnUnlisten()).isFalse();
+
+        bus.registerSender(output, addresses);
+        bus.listen(input, address);
+
+        bus.unlisten(input, address); // This test would block forever if this is not non-block
+        bus.unregisterSender(output, addresses);
+    }
+
+    @Test
+    public void whenInBlockingModeInputsShutdownLast() throws InterruptedException {
+        bus.registerSender(output, addresses);
+        bus.listen(input, address);
+
+        bus.setBlockOnUnlisten(true);
+
+        Thread unlistenThread = new Thread( () -> {
+            try {
+                bus.unlisten(input, address);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        });
+        unlistenThread.start();
+
+        // This should unblock the listener thread
+        bus.unregisterSender(output, addresses);
+        unlistenThread.join();
+
+        assertThat(bus.addressStates).isEmpty();
     }
 
 


### PR DESCRIPTION

It just blocks and doesn't handle the concurrency situation. One can think of the network of connected pipelines as a DAG (We explicitly ask users not to create cycles in our docs). In fact there are two different correct answers to the pipeline shutdown and reload problem.

When reloading pipelines we should assume the user understands whatever changes they're making to the topology. If a downstream pipeline is to be removed, we can assume that's intentional. We don't lose any data from upstream pipelines since those block until that downstream pipeline is restored. To accomplish this none of the `PipelineBus` methods block by default.

When shutting down Logstash we must: 1.) not lose in-flight data, and 2.) not deadlock. The only way to do both is to shutdown the pipelines in order. All state changes happen simultaneously on all piping via multithreading. As a result we don't need to implement a Topological sort or other algorithm to order dependencies, we simply issue a shutdown to all pipelines, and have ones that are dependent block waiting for upstream pipelines.

This patch also correctly handles the case where multiple signals cause pipeline actions to be created simultaneously. If we see two concurrent creates or stops, one of those actions becomes a noop.

Currently the Logstash plugin API has lifecycle methods for starting and stopping, but not reloading. We need to call a different method when a `pipeline` input is stopped due to a pipeline reload vs an agent shutdown. Ideally, we would enrich our plugin API. In the interest of expedience here, however, I added a flag to the `PipelineBus` that changes the shutdown mode of `pipeline` inputs, to be either blocking or non-blocking. It is switched to blocking if a shutdown is triggered.

This also reverts b78d32dedecdebc99f77bf9bd7283d60342ef72c in favor of a better more concurrent approach without mutexes

This is a forward port of https://github.com/elastic/logstash/pull/9650 to master / 6.x