### PR TITLE
BUG: Fix incorrect type handling between Java pipeline and Ruby pipeline

### DIFF
--- a/logstash-core/spec/logstash/pipeline_reporter_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_reporter_spec.rb
@@ -6,12 +6,12 @@ require_relative "../support/mocks_classes"
 
 #TODO: Figure out how to add more tests that actually cover inflight events
 #This will require some janky multithreading stuff
-describe LogStash::PipelineReporter do
+shared_examples "a pipeline reporter" do |pipeline_setup|
   let(:generator_count) { 5 }
   let(:config) do
     "input { generator { count => #{generator_count} } } output { dummyoutput {} } "
   end
-  let(:pipeline) { mock_pipeline_from_string(config)}
+  let(:pipeline) { Kernel.send(pipeline_setup, config)}
   let(:reporter) { pipeline.reporter }
 
   before do
@@ -27,6 +27,16 @@ describe LogStash::PipelineReporter do
 
   after do
     pipeline.shutdown
+  end
+
+  describe "stalling threads info" do
+    it "should start with no stalled threads" do
+      expect(@pre_snapshot.stalling_threads_info).to eql([])
+    end
+
+    it "should end with no stalled threads" do
+      expect(@pre_snapshot.stalling_threads_info).to eql([])
+    end
   end
 
   describe "events filtered" do
@@ -58,4 +68,9 @@ describe LogStash::PipelineReporter do
       expect(@post_snapshot.inflight_count).to eql(0)
     end
   end
+end
+
+describe LogStash::PipelineReporter do
+  it_behaves_like "a pipeline reporter", :mock_pipeline_from_string
+  it_behaves_like "a pipeline reporter", :mock_java_pipeline_from_string
 end

--- a/logstash-core/src/main/java/org/logstash/execution/PipelineReporterExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/PipelineReporterExt.java
@@ -155,7 +155,14 @@ public final class PipelineReporterExt extends RubyBasicObject {
     @SuppressWarnings("unchecked")
     private RubyArray outputInfo(final ThreadContext context) {
         final RubyArray result = context.runtime.newArray();
-        ((Iterable<?>) pipeline.callMethod(context, "outputs")).forEach(output -> {
+        final IRubyObject outputs = pipeline.callMethod(context, "outputs");
+        final Iterable<IRubyObject> outputIterable;
+        if (outputs instanceof Iterable) {
+            outputIterable = (Iterable<IRubyObject>) outputs;
+        } else {
+            outputIterable = (Iterable<IRubyObject>) outputs.toJava(Iterable.class);
+        }
+        outputIterable.forEach(output -> {
             final OutputDelegatorExt delegator = (OutputDelegatorExt) output;
             final RubyHash hash = RubyHash.newHash(context.runtime);
             hash.op_aset(context, TYPE_KEY, delegator.configName(context));
@@ -186,7 +193,7 @@ public final class PipelineReporterExt extends RubyBasicObject {
             RubyUtil.RUBY.newString("inflight_count").newFrozen();
 
         private static final RubyString STALLING_THREADS_KEY =
-            RubyUtil.RUBY.newString("stalling_thread_info").newFrozen();
+            RubyUtil.RUBY.newString("stalling_threads_info").newFrozen();
 
         private static final RubyString PLUGIN_KEY =
             RubyUtil.RUBY.newString("plugin").newFrozen();


### PR DESCRIPTION
2 straightforward bugs fixed here:

### NPE in Pipeline Reporter

Saw this lately after porting the pipeline reporter to Java:

```sh
Exception in thread "Ruby-0-Thread-16: :1" java.lang.NullPointerException
	at org.logstash.execution.PipelineReporterExt$SnapshotExt.formatThreadsByPlugin(PipelineReporterExt.java:239)
	at org.logstash.execution.PipelineReporterExt$SnapshotExt.toSimpleHash(PipelineReporterExt.java:221)
	at org.logstash.execution.PipelineReporterExt$SnapshotExt.toStr(PipelineReporterExt.java:227)
	at org.logstash.execution.PipelineReporterExt$SnapshotExt$INVOKER$i$0$0$toStr.call(PipelineReporterExt$SnapshotExt$INVOKER$i$0$0$toStr.gen)
	at org.jruby.internal.runtime.methods.JavaMethod$JavaMethodN.call(JavaMethod.java:737)
	at org.jruby.ir.targets.InvokeSite.invoke(InvokeSite.java:145)
```

* solved by adding the missing `s` to the key symbol
* added spec for this case since we didn't have one

### Exception when Shutting down Java Pipeline

```sh
Exception in thread "Ruby-0-Thread-16: :1" java.lang.ClassCastException: org.jruby.java.proxies.ConcreteJavaProxy cannot be cast to java.lang.Iterable
	at org.logstash.execution.PipelineReporterExt.outputInfo(PipelineReporterExt.java:158)
	at org.logstash.execution.PipelineReporterExt.toHash(PipelineReporterExt.java:116)
	at org.logstash.execution.PipelineReporterExt.snapshot(PipelineReporterExt.java:94)
	at org.logstash.execution.PipelineReporterExt$INVOKER$i$0$0$snapshot.call(PipelineReporterExt$INVOKER$i$0$0$snapshot.gen)
	at org.jruby.internal.runtime.methods.JavaMethod$JavaMethodN.call(JavaMethod.java:737)
	at org.jruby.ir.targets.InvokeSite.invoke(InvokeSite.java:145)
	at Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.shutdown_watcher.RUBY$method$pipeline_report_snapshot$0(/Users/brownbear/src/logstash/logstash-core/lib/logstash/shutdown_watcher.rb:88)
	at Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.shutdown_watcher.RUBY$method$pipeline_report_snapshot$0$__VARARGS__(/Users/brownbear/src/logstash/logstash-core/lib/logstash/shutdown_watcher.rb)
	at org.jruby.internal.runtime.methods.CompiledIRMethod.call(CompiledIRMethod.java:77)
	at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:93)
	at org.jruby.ir.targets.InvokeSite.invoke(InvokeSite.java:145)
	at Users.brownbear.src.logstash.logstash_minus_core.lib.logstash.shutdown_watcher.RUBY$block$start$1(/Users/brownbear/src/logstash/logstash-core/lib/logstash/shutdown_watcher.rb:63)
	at org.jruby.runtime.CompiledIRBlockBody.callDirect(CompiledIRBlockBody.java:145)
	at org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:71)
```

* Java pipeline returned the `Iterable` of output plugins wrapped in a Java proxy (since we're not using proper `@JRubyMethod` wrapping on the LIR)
  * Since this isn't performance relevant code => just added a type check and handling according to type see
* Generalized the spec to test both Java and Ruby execution pipeline