### PR TITLE
Use correct return values for pipeline lifecycle events

### DIFF
--- a/logstash-core/lib/logstash/pipeline_action/create.rb
+++ b/logstash-core/lib/logstash/pipeline_action/create.rb
@@ -43,10 +43,12 @@ module LogStash module PipelineAction
       status = nil
       pipelines.compute(pipeline_id) do |id,value|
         if value
-          LogStash::ConvergeResult::ActionResult.create(self, true)
+          # Something started it ahead of us, nothing to do here
+          status = true
+        else
+          status = pipeline.start # block until the pipeline is correctly started or crashed
+          pipeline # The pipeline is successfully started we can add it to the map
         end
-        status = pipeline.start # block until the pipeline is correctly started or crashed
-        pipeline # The pipeline is successfully started we can add it to the map
       end
 
 

--- a/logstash-core/lib/logstash/pipeline_action/reload.rb
+++ b/logstash-core/lib/logstash/pipeline_action/reload.rb
@@ -47,16 +47,18 @@ module LogStash module PipelineAction
 
       logger.info("Reloading pipeline", "pipeline.id" => pipeline_id)
 
+      status = nil
       pipelines.compute(pipeline_id) do |_,pipeline|
         status = Stop.new(pipeline_id).execute(agent, pipelines)
 
         if status
-          return Create.new(@pipeline_config, @metric).execute(agent, pipelines)
-        else
-          return status
+          status Create.new(@pipeline_config, @metric).execute(agent, pipelines)
         end
+
         pipeline
       end
+
+      LogStash::ConvergeResult::ActionResult.create(self, status)
     end
   end
 end end

--- a/logstash-core/lib/logstash/pipeline_action/stop.rb
+++ b/logstash-core/lib/logstash/pipeline_action/stop.rb
@@ -12,7 +12,8 @@ module LogStash module PipelineAction
     end
 
     def execute(agent, pipelines)
-      pipelines.compute(pipeline_id) do |_,pipeline|
+      # We only have work to do if the pipeline does, in-fact, exist
+      pipelines.computeIfPresent(pipeline_id) do |_,pipeline|
         pipeline.shutdown { LogStash::ShutdownWatcher.start(pipeline) }
         pipeline.thread.join
         nil # delete the pipeline


### PR DESCRIPTION
We can't use `return` inside a compute because that isn't allowed.

The intent here was correct, but the code was wrong. I'd like to eventually port this to Java and use something like the actor model to handle these state transitions.

WIP. Needs tests