### PR TITLE
BUILD: Fix Rake Version Conflict + Gradle File Encoding Issues

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -25,6 +25,7 @@ gem "belzebuth", :group => :development
 gem "pleaserun", "~>0.0.28"
 gem 'webrick', '~> 1.3.1'
 gem "atomic", "<= 1.1.99"
+gem "rake", "~> 12.2.1", :group => :build
 gem "logstash-codec-cef"
 gem "logstash-codec-collectd"
 gem "logstash-codec-dots"

--- a/ci/acceptance_tests.sh
+++ b/ci/acceptance_tests.sh
@@ -6,7 +6,7 @@ set -x
 # uses at least 1g of memory, If we don't do this we can get OOM issues when
 # installing gems. See https://github.com/elastic/logstash/issues/5179
 export JRUBY_OPTS="-J-Xmx1g"
-export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info"
+export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info -Dfile.encoding=UTF-8"
 export OSS=true
 
 SELECTED_TEST_SUITE=$1

--- a/ci/integration_tests.sh
+++ b/ci/integration_tests.sh
@@ -5,7 +5,7 @@
 # uses at least 1g of memory, If we don't do this we can get OOM issues when
 # installing gems. See https://github.com/elastic/logstash/issues/5179
 export JRUBY_OPTS="-J-Xmx1g"
-export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info"
+export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info -Dfile.encoding=UTF-8"
 
 export SPEC_OPTS="--order rand --format documentation"
 export CI=true

--- a/ci/license_check.sh
+++ b/ci/license_check.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -i
-export GRADLE_OPTS="-Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info"
+export GRADLE_OPTS="-Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info -Dfile.encoding=UTF-8"
 
 ./gradlew installDefaultGems
 bin/dependencies-report --csv report.csv

--- a/ci/unit_tests.sh
+++ b/ci/unit_tests.sh
@@ -5,7 +5,7 @@
 # uses at least 1g of memory, If we don't do this we can get OOM issues when
 # installing gems. See https://github.com/elastic/logstash/issues/5179
 export JRUBY_OPTS="-J-Xmx1g"
-export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info"
+export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info -Dfile.encoding=UTF-8"
 
 export SPEC_OPTS="--order rand --format documentation"
 export CI=true


### PR DESCRIPTION
2 issues here:

* For some reason our builds stopped using `UTF-8` as their Java file encoding (maybe something in the CI's Docker file changed?) => fixed by simply forcing the encoding in CI scripts
* Also, starting yesterday it seems some plugin test dependency forces rake `12.2.x` but we install rake `12.3.x` in the initial gem install for LS core => forced that to `12.2.x` to repair the build.

both issues can be found in e.g.:

https://logstash-ci.elastic.co/job/elastic+logstash+pull-request+multijob-ruby-unit-tests/707/console

```sh
02:04:15 Installing logstash-devutils, logstash-input-generator, logstash-codec-json, logstash-output-null, benchmark-ips, rspec, jar-dependencies, timecop, childprocess, jdbc-derby, jdbc-mysql, logstash-filter-mutate, logstash-patterns-core, logstash-filter-grok, flores, stud, pry, rspec-wait, rspec-sequencing, gmetric, gelf, logstash-codec-json_lines, manticore, logstash-codec-plain, logstash-codec-multiline, logstash-codec-cef, logstash-codec-line, elasticsearch, rumbster, gserver, logstash-filter-kv, logstash-filter-ruby, sinatra, webrick, poseidon, snappy, webmock, rake
02:04:15 Preserving Gemfile gem options for plugin logstash-devutils
02:04:15 Preserving Gemfile gem options for plugin benchmark-ips
02:04:15 Preserving Gemfile gem options for plugin rspec
02:04:15 Preserving Gemfile gem options for plugin flores
02:04:15 Preserving Gemfile gem options for plugin stud
02:04:18 Plugin not found, aborting
02:04:18 ERROR: Installation Aborted, message: You have requested:
02:04:18   rake ~> 12.2.1
02:04:18 
02:04:18 The bundle currently has rake locked at 12.3.1.
02:04:18 Try running `bundle update rake`
```

```
02:04:22 All input files are considered out-of-date for incremental task ':logstash-core:compileTestJava'.
02:04:22 Compiling with JDK Java compiler API.
02:04:22 /opt/logstash/logstash-core/src/test/java/org/logstash/EventTest.java:102: error: unmappable character for encoding ASCII
02:04:22         e.setField("foo", "b??r");
02:04:22                             ^
02:04:22 /opt/logstash/logstash-core/src/test/java/org/logstash/EventTest.java:102: error: unmappable character for encoding ASCII
02:04:22         e.setField("foo", "b??r");
02:04:22                              ^
02:04:25 Note: Some input files use or override a deprecated API.
02:04:25 Note: Recompile with -Xlint:deprecation for details.
```