### PR TITLE
BUG: Fix incorrect pipeline shutdown logging

### DIFF
--- a/logstash-core/src/main/java/org/logstash/execution/ShutdownWatcherExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/ShutdownWatcherExt.java
@@ -151,7 +151,8 @@ public final class ShutdownWatcherExt extends RubyBasicObject {
                     reports.remove(0);
                 }
                 if (cycleNumber == reportEvery - 1) {
-                    LOGGER.warn(reports.get(reports.size() - 1).anyToString().asJavaString());
+                    LOGGER.warn(reports.get(reports.size() - 1).callMethod(context, "to_s")
+                        .asJavaString());
                     if (shutdownStalled(context).isTrue()) {
                         if (stalledCount == 0) {
                             LOGGER.error(


### PR DESCRIPTION
Minor mistake made when moving this code to Java, caused the pipeline shutdown to log garbage like:

```sh
[2018-05-30T18:29:16,035][WARN ][org.logstash.execution.ShutdownWatcherExt] #<LogStash::PipelineReporter::Snapshot:0x38ee6a5a>
```

Fixed, now it properly logs:

```sh
[2018-05-30T18:32:37,756][WARN ][org.logstash.execution.ShutdownWatcherExt] {"inflight_count"=>0, "stalling_threads_info"=>{["LogStash::Filters::Sleep", {"time"=>1, "id"=>"f0d29856c2c65ead635922caf25bfd73d5a42173afe23259fd43e3ac3fbdbd5b"}]=>[{"thread_id"=>20, "name"=>nil, "current_call"=>"[...]/vendor/bundle/jruby/2.3.0/gems/logstash-filter-sleep-3.0.6/lib/logstash/filters/sleep.rb:105:in `sleep'"}, {"thread_id"=>21, "name"=>nil, "current_call"=>"[...]/vendor/bundle/jruby/2.3.0/gems/logstash-filter-sleep-3.0.6/lib/logstash/filters/sleep.rb:105:in `sleep'"}, {"thread_id"=>22, "name"=>nil, "current_call"=>"[...]/vendor/bundle/jruby/2.3.0/gems/logstash-filter-sleep-3.0.6/lib/logstash/filters/sleep.rb:105:in `sleep'"}, {"thread_id"=>23, "name"=>nil, "current_call"=>"[...]/vendor/bundle/jruby/2.3.0/gems/logstash-filter-sleep-3.0.6/lib/logstash/filters/sleep.rb:105:in `sleep'"}, {"thread_id"=>24, "name"=>nil, "current_call"=>"[...]/vendor/bundle/jruby/2.3.0/gems/logstash-filter-sleep-3.0.6/lib/logstash/filters/sleep.rb:105:in `sleep'"}, {"thread_id"=>25, "name"=>nil, "current_call"=>"[...]/vendor/bundle/jruby/2.3.0/gems/logstash-filter-sleep-3.0.6/lib/logstash/filters/sleep.rb:105:in `sleep'"}, {"thread_id"=>26, "name"=>nil, "current_call"=>"[...]/vendor/bundle/jruby/2.3.0/gems/logstash-filter-sleep-3.0.6/lib/logstash/filters/sleep.rb:105:in `sleep'"}, {"thread_id"=>27, "name"=>nil, "current_call"=>"[...]/vendor/bundle/jruby/2.3.0/gems/logstash-filter-sleep-3.0.6/lib/logstash/filters/sleep.rb:105:in `sleep'"}]}}
```

Can't really write an easy test for this I'm afraid, but verified manually.