### PR TITLE
Use logger not @logger in source_loader

### DIFF
--- a/logstash-core/lib/logstash/config/source_loader.rb
+++ b/logstash-core/lib/logstash/config/source_loader.rb
@@ -52,7 +52,7 @@ module LogStash module Config
         # This shouldn't happen with the settings object or with any external plugins.
         # but lets add a guard so we fail fast.
         @sources_lock.synchronize do
-          @logger.error "No source loaders matched! This shouldn't happen", :sources => @sources
+          logger.error "No source loaders matched! This shouldn't happen", :sources => @sources
         end
         raise LogStash::InvalidSourceLoaderSettingError, "Can't find an appropriate config loader with current settings"
       else


### PR DESCRIPTION
This makes it consistent with the rest of the class.

I noticed we have some test failures due to @logger not existing. Probably an issue
from when the logger was javafied. This is causing test failures like: https://logstash-ci.elastic.co/job/elastic+logstash+6.x+multijob-unix-compatibility/os=oraclelinux/140/consoleFull

Will open a separate issue about the missing @logger var (created here: https://github.com/elastic/logstash/issues/9690 )

```
An exception happened when converging configuration {:exception=>NoMethodError, :message=>"undefined method `error' for nil:NilClass", :backtrace=>["/var/lib/jenkins/workspace/elastic+logstash+6.x+multijob-unix-compatibility/os/oraclelinux/logstash-core/lib/logstash/config/source_loader.rb:55:in `block in fetch'", "org/jruby/ext/thread/Mutex.java:148:in `synchronize'", "/var/lib/jenkins/workspace/elastic+logstash+6.x+multijob-unix-compatibility/os/oraclelinux/logstash-core/lib/logstash/config/source_loader.rb:54:in `fetch'", "/var/lib/jenkins/workspace/elastic+logstash+6.x+multijob-unix-compatibility/os/oraclelinux/logstash-core/lib/logstash/agent.rb:133:in `converge_state_and_update'", "/var/lib/jenkins/workspace/elastic+logstash+6.x+multijob-unix-compatibility/os/oraclelinux/logstash-core/lib/logstash/agent.rb:84:in `execute'", "/var/lib/jenkins/workspace/elastic+logstash+6.x+multijob-unix-compatibility/os/oraclelinux/logstash-core/spec/support/shared_contexts.rb:26:in `block in (root)'", "org/jruby/RubyBasicObject.java:1728:in `instance_exec'", "/var/lib/jenkins/workspace/elastic+logstash+6.x+multijob-unix-compatibility/os/oraclelinux/vendor/bundle/jruby/2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/hooks.rb:350:in `run'", "/var/lib/jenkins/workspace/elastic+logstash+6.x+multijob-unix-compatibility/os/oraclelinux/vendor/bundle/jruby/2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/hooks.rb:509:in `block in run_owned_hooks_for'", "org/jruby/RubyArray.java:1734:in `each'", "/var/lib/jenkins/workspace/elastic+logstash+6.x+multijob-unix-compatibility/os/oraclelinux/vendor/bundle/jruby/2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/hooks.rb:508:in `run_owned_hooks_for'", "/var/
```