### PR TITLE
Use longer timeout for x-pack reload spec

### DIFF
--- a/x-pack/qa/integration/management/multiple_pipelines_spec.rb
+++ b/x-pack/qa/integration/management/multiple_pipelines_spec.rb
@@ -69,7 +69,7 @@ describe "Read configuration from elasticsearch" do
   end
 
   it "should immediately register a new pipeline state document when the pipeline is reloaded" do
-    wait(20).for do
+    wait(40).for do
       count_hashes(@pipelines.keys)
     end.to eq(2)
 
@@ -84,7 +84,7 @@ describe "Read configuration from elasticsearch" do
       push_elasticsearch_config(pipeline_id, config)
     end
 
-    wait(20).for do
+    wait(40).for do
       count_hashes(@pipelines.keys)
     end.to eq(4)
   end


### PR DESCRIPTION
This test flaked out on CI, so let's give it some more time before digging deeper.