### PR TITLE
Support for UTF-16 and other multi-byte-character logfiles

### DIFF
--- a/logstash-core/lib/logstash/config/string_escape.rb
+++ b/logstash-core/lib/logstash/config/string_escape.rb
@@ -19,6 +19,8 @@ module LogStash; module Config; module StringEscape
         "\r"
       when "t"
         "\t"
+      when "0"
+        "\x00"
       else
         value
       end

--- a/logstash-core/spec/logstash/config/string_escape_spec.rb
+++ b/logstash-core/spec/logstash/config/string_escape_spec.rb
@@ -11,6 +11,7 @@ describe LogStash::Config::StringEscape do
     "\\r" => "\r",
     "\\t" => "\t",
     "\\\\" => "\\",
+    "\\0" => "\x00",
   }
 
   table.each do |input, expected|


### PR DESCRIPTION
When `config.support_escapes: true` is set in logstash.yaml, escape characters can be used in any string, most notably the string "delimiter" from input.file.
This works great for traditional logfiles under Windows/Mac/Unix.
But for modern logfiles, produced in a multibyte characterset, this facility is still insufficient.
e.g. under UTF-16LE the delimiter is actually "\r\0\n\0", but that format cannot be specified. I expect the same problems for the UTF-16BE, UTF-32BE, UTF-32LE, UTF-16, UTF-32, UCS-2BE, UCS-4BE or UCS-4LE character sets.

The suggested solution in this PR is simple:
Update [logstash-core/lib/logstash/config/string_escape.rb] to support "\0".