### PR TITLE
Fix: Logstash fails to run if data.path is a symlink

### DIFF
--- a/logstash-core/src/main/java/org/logstash/FileLockFactory.java
+++ b/logstash-core/src/main/java/org/logstash/FileLockFactory.java
@@ -49,7 +49,7 @@ public class FileLockFactory {
     private static final Map<FileLock, String> LOCK_MAP =  Collections.synchronizedMap(new HashMap<>());
 
     public static FileLock obtainLock(Path dirPath, String lockName) throws IOException {
-        Files.createDirectories(dirPath);
+        if (!Files.isDirectory(dirPath)) { Files.createDirectories(dirPath); }
         Path lockPath = dirPath.resolve(lockName);
 
         try {


### PR DESCRIPTION
This fixes the issue described at https://discuss.elastic.co/t/logstash-fails-to-run-if-data-path-is-a-symlink/134674
Logstash fails to start when /var/lib/logstash is a symlink - it tries to recreate directories, but the symlink already exist. The fix is just check that data.dir dont exist before trying to create it.
```An unexpected error occurred! {:error=>java.nio.file.FileAlreadyExistsException: /var/lib/logstash, :backtrace=>["sun.nio.fs.UnixException.translateToIOException(sun/nio/fs/UnixException.java:88)", "sun.nio.fs.UnixException.rethrowAsIOException(sun/nio/fs/UnixException.java:102)", "sun.nio.fs.UnixException.rethrowAsIOException(sun/nio/fs/UnixException.java:107)", "sun.nio.fs.UnixFileSystemProvider.createDirectory(sun/nio/fs/UnixFileSystemProvider.java:384)", "java.nio.file.Files.createDirectory(java/nio/file/Files.java:674)", "java.nio.file.Files.createAndCheckIsDirectory(java/nio/file/Files.java:781)", "java.nio.file.Files.createDirectories(java/nio/file/Files.java:727)", "org.logstash.FileLockFactory.obtainLock(org/logstash/FileLockFactory.java:57)", "java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)", "org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:468)", "org.jruby.javasupport.JavaMethod.invokeStaticDirect(org/jruby/javasupport/JavaMethod.java:370)", "RUBY.execute(/usr/share/logstash/logstash-core/lib/logstash/runner.rb:335)", "RUBY.run(/usr/share/logstash/vendor/bundle/jruby/2.3.0/gems/clamp-0.6.5/lib/clamp/command.rb:67)", "RUBY.run(/usr/share/logstash/logstash-core/lib/logstash/runner.rb:219)", "RUBY.run(/usr/share/logstash/vendor/bundle/jruby/2.3.0/gems/clamp-0.6.5/lib/clamp/command.rb:132)", "usr.share.logstash.lib.bootstrap.environment.invokeOther55:run(usr/share/logstash/lib/bootstrap//usr/share/logstash/lib/bootstrap/environment.rb:67)", "usr.share.logstash.lib.bootstrap.environment.<main>(/usr/share/logstash/lib/bootstrap/environment.rb:67)", "java.lang.invoke.MethodHandle.invokeWithArguments(java/lang/invoke/MethodHandle.java:627)", "org.jruby.Ruby.runScript(org/jruby/Ruby.java:828)", "org.jruby.Ruby.runNormally(org/jruby/Ruby.java:747)", "org.jruby.Ruby.runNormally(org/jruby/Ruby.java:765)", "org.jruby.Ruby.runFromMain(org/jruby/Ruby.java:578)", "org.logstash.Logstash.run(org/logstash/Logstash.java:81)", "org.logstash.Logstash.main(org/logstash/Logstash.java:45)"]}```