### PR TITLE
Harmonize license with apache.org and other Elastic repos

### DIFF
--- a/licenses/APACHE-LICENSE-2.0.txt
+++ b/licenses/APACHE-LICENSE-2.0.txt
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/


### PR DESCRIPTION
The Logstash version of the Apache V2 license differs from the one
published at apache.org and in our other repos by a single newline.
This commit adds the newline.