### PR TITLE
Error in testing your Logstash installation

### DIFF
--- a/docs/static/getting-started-with-logstash.asciidoc
+++ b/docs/static/getting-started-with-logstash.asciidoc
@@ -242,7 +242,7 @@ example:
 ["source","sh",subs="attributes"]
 --------------------------------------------------
 cd logstash-{logstash_version}
-bin/logstash -e 'input { stdin { } } output { stdout {} }'
+bin/logstash -e "input { stdin { } } output { stdout {} }"
 --------------------------------------------------
 
 NOTE: The location of the `bin` directory varies by platform. See {logstash-ref}/dir-layout.html[Directory layout]


### PR DESCRIPTION
For the step of 
bin/logstash -e 'input { stdin { } } output { stdout {} }'
in this way it doesn't work , the alternative to work is:
bin/logstash -e "input { stdin { } } output { stdout {} }"