### PR TITLE
MINOR: Move some dynamic ruby calls to typed calls, clean up some duplicate constants

### DIFF
--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -68,8 +68,6 @@ public class AbstractPipelineExt extends RubyBasicObject {
 
     private static final RubySymbol STATS_KEY = RubyUtil.RUBY.newSymbol("stats");
 
-    private static final RubySymbol PIPELINES_KEY = RubyUtil.RUBY.newSymbol("pipelines");
-
     private static final RubySymbol TYPE_KEY = RubyUtil.RUBY.newSymbol("type");
 
     private static final RubySymbol QUEUE_KEY = RubyUtil.RUBY.newSymbol("queue");
@@ -265,7 +263,7 @@ public class AbstractPipelineExt extends RubyBasicObject {
             context,
             RubyArray.newArray(
                 context.runtime,
-                Arrays.asList(STATS_KEY, PIPELINES_KEY, pipelineId.asString().intern(), QUEUE_KEY)
+                Arrays.asList(STATS_KEY, MetricKeys.PIPELINES_KEY, pipelineId.asString().intern(), QUEUE_KEY)
             )
         );
         pipelineMetric.gauge(context, TYPE_KEY, getSetting(context, "queue.type"));
@@ -320,7 +318,7 @@ public class AbstractPipelineExt extends RubyBasicObject {
                 context, RubyArray.newArray(
                     context.runtime,
                     Arrays.asList(
-                        STATS_KEY, PIPELINES_KEY, pipelineId.asString().intern(), DLQ_KEY
+                        STATS_KEY, MetricKeys.PIPELINES_KEY, pipelineId.asString().intern(), DLQ_KEY
                     )
                 )
             );

--- a/logstash-core/src/main/java/org/logstash/ext/JRubyWrappedWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JRubyWrappedWriteClientExt.java
@@ -9,10 +9,11 @@ import org.jruby.RubyObject;
 import org.jruby.RubySymbol;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
-import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.RubyUtil;
+import org.logstash.instrument.metrics.AbstractMetricExt;
+import org.logstash.instrument.metrics.MetricKeys;
 import org.logstash.instrument.metrics.counter.LongCounter;
 
 @JRubyClass(name = "WrappedWriteClient")
@@ -21,12 +22,7 @@ public final class JRubyWrappedWriteClientExt extends RubyObject {
     private static final RubySymbol PUSH_DURATION_KEY =
         RubyUtil.RUBY.newSymbol("queue_push_duration_in_millis");
 
-    private static final RubySymbol IN_KEY = RubyUtil.RUBY.newSymbol("in");
-
-    private DynamicMethod pushOne;
-    private DynamicMethod pushBatch;
-
-    private IRubyObject writeClient;
+    private JRubyAbstractQueueWriteClientExt writeClient;
 
     private LongCounter eventsMetricsCounter;
     private LongCounter eventsMetricsTime;
@@ -41,53 +37,50 @@ public final class JRubyWrappedWriteClientExt extends RubyObject {
         super(runtime, metaClass);
     }
 
-    @JRubyMethod(name = "initialize", optional = 4)
-    public IRubyObject ruby_initialize(final ThreadContext context, final IRubyObject[] args) {
-        this.writeClient = args[0];
+    @JRubyMethod(required = 4)
+    public IRubyObject initialize(final ThreadContext context, final IRubyObject[] args) {
+        this.writeClient = (JRubyAbstractQueueWriteClientExt) args[0];
         final String pipelineId = args[1].asJavaString();
-        final IRubyObject metric = args[2];
+        final AbstractMetricExt metric = (AbstractMetricExt) args[2];
         // Synchronize on the metric since setting up new fields on it is not threadsafe
         synchronized (metric) {
             final IRubyObject pluginId = args[3];
             final IRubyObject eventsMetrics = getMetric(metric, "stats", "events");
-            eventsMetricsCounter = LongCounter.fromRubyBase(eventsMetrics, IN_KEY);
+            eventsMetricsCounter = LongCounter.fromRubyBase(eventsMetrics, MetricKeys.IN_KEY);
             eventsMetricsTime = LongCounter.fromRubyBase(eventsMetrics, PUSH_DURATION_KEY);
             final IRubyObject pipelineMetrics =
                 getMetric(metric, "stats", "pipelines", pipelineId, "events");
-            pipelineMetricsCounter = LongCounter.fromRubyBase(pipelineMetrics, IN_KEY);
+            pipelineMetricsCounter = LongCounter.fromRubyBase(pipelineMetrics, MetricKeys.IN_KEY);
             pipelineMetricsTime = LongCounter.fromRubyBase(pipelineMetrics, PUSH_DURATION_KEY);
             final IRubyObject pluginMetrics = getMetric(
                 metric, "stats", "pipelines", pipelineId, "plugins", "inputs",
                 pluginId.asJavaString(), "events"
             );
             pluginMetricsCounter =
-                LongCounter.fromRubyBase(pluginMetrics, context.runtime.newSymbol("out"));
+                LongCounter.fromRubyBase(pluginMetrics, MetricKeys.OUT_KEY);
             pluginMetricsTime = LongCounter.fromRubyBase(pluginMetrics, PUSH_DURATION_KEY);
-            final RubyClass writerClass = writeClient.getMetaClass();
-            pushOne = writerClass.searchMethod("push");
-            pushBatch = writerClass.searchMethod("push_batch");
         }
         return this;
     }
 
     @JRubyMethod(name = {"push", "<<"}, required = 1)
-    public IRubyObject push(final ThreadContext context, final IRubyObject event) {
+    public IRubyObject push(final ThreadContext context, final IRubyObject event)
+        throws InterruptedException {
         final long start = System.nanoTime();
         incrementCounters(1L);
-        final IRubyObject res = pushOne.call(
-            context, writeClient, RubyUtil.WRAPPED_WRITE_CLIENT_CLASS, "push", event
-        );
+        final IRubyObject res = writeClient.doPush(context, (JrubyEventExtLibrary.RubyEvent) event);
         incrementTimers(start);
         return res;
     }
 
     @SuppressWarnings("unchecked")
     @JRubyMethod(name = "push_batch", required = 1)
-    public IRubyObject pushBatch(final ThreadContext context, final IRubyObject batch) {
+    public IRubyObject pushBatch(final ThreadContext context, final IRubyObject batch)
+        throws InterruptedException {
         final long start = System.nanoTime();
         incrementCounters((long) ((Collection<IRubyObject>) batch).size());
-        final IRubyObject res = pushBatch.call(
-            context, writeClient, RubyUtil.WRAPPED_WRITE_CLIENT_CLASS, "push_batch", batch
+        final IRubyObject res = writeClient.doPushBatch(
+            context, (Collection<JrubyEventExtLibrary.RubyEvent>) batch
         );
         incrementTimers(start);
         return res;
@@ -120,10 +113,8 @@ public final class JRubyWrappedWriteClientExt extends RubyObject {
         pluginMetricsTime.increment(increment);
     }
 
-    private static IRubyObject getMetric(final IRubyObject base, final String... keys) {
-        return base.callMethod(
-            RubyUtil.RUBY.getCurrentContext(), "namespace", toSymbolArray(keys)
-        );
+    private static IRubyObject getMetric(final AbstractMetricExt base, final String... keys) {
+        return base.namespace(RubyUtil.RUBY.getCurrentContext(), toSymbolArray(keys));
     }
 
     private static IRubyObject toSymbolArray(final String... strings) {

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricKeys.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricKeys.java
@@ -9,6 +9,8 @@ public final class MetricKeys {
         // Constant Holder
     }
 
+    public static final RubySymbol PIPELINES_KEY = RubyUtil.RUBY.newSymbol("pipelines");
+
     public static final RubySymbol NAME_KEY = RubyUtil.RUBY.newSymbol("name");
 
     public static final RubySymbol EVENTS_KEY = RubyUtil.RUBY.newSymbol("events");

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
@@ -30,6 +30,7 @@ import org.logstash.config.ir.graph.Vertex;
 import org.logstash.execution.ExecutionContextExt;
 import org.logstash.instrument.metrics.AbstractMetricExt;
 import org.logstash.instrument.metrics.AbstractNamespacedMetricExt;
+import org.logstash.instrument.metrics.MetricKeys;
 import org.logstash.instrument.metrics.NullMetricExt;
 
 public final class PluginFactoryExt {
@@ -39,8 +40,6 @@ public final class PluginFactoryExt {
         implements RubyIntegration.PluginFactory {
 
         private static final RubyString ID_KEY = RubyUtil.RUBY.newString("id");
-
-        private static final RubySymbol NAME_KEY = RubyUtil.RUBY.newSymbol("name");
 
         private final Collection<String> pluginsById = new HashSet<>();
 
@@ -233,7 +232,7 @@ public final class PluginFactoryExt {
                 } else {
                     final IRubyObject pluginInstance = klass.callMethod(context, "new", rubyArgs);
                     final AbstractNamespacedMetricExt scopedMetric = typeScopedMetric.namespace(context, RubyUtil.RUBY.newSymbol(id));
-                    scopedMetric.gauge(context, NAME_KEY, pluginInstance.callMethod(context, "config_name"));
+                    scopedMetric.gauge(context, MetricKeys.NAME_KEY, pluginInstance.callMethod(context, "config_name"));
                     pluginInstance.callMethod(context, "metric=", scopedMetric);
                     pluginInstance.callMethod(context, "execution_context=", executionCntx);
                     return pluginInstance;
@@ -282,8 +281,6 @@ public final class PluginFactoryExt {
 
         private static final RubySymbol STATS = RubyUtil.RUBY.newSymbol("stats");
 
-        private static final RubySymbol PIPELINES = RubyUtil.RUBY.newSymbol("pipelines");
-
         private static final RubySymbol PLUGINS = RubyUtil.RUBY.newSymbol("plugins");
 
         private RubySymbol pipelineId;
@@ -311,7 +308,7 @@ public final class PluginFactoryExt {
             return metric.namespace(
                 context,
                 RubyArray.newArray(
-                    context.runtime, Arrays.asList(STATS, PIPELINES, pipelineId, PLUGINS)
+                    context.runtime, Arrays.asList(STATS, MetricKeys.PIPELINES_KEY, pipelineId, PLUGINS)
                 )
             ).namespace(
                 context, RubyUtil.RUBY.newSymbol(String.format("%ss", pluginType.asJavaString()))


### PR DESCRIPTION
It's in the title :) Just taking advantage of some recent progress here.