### PR TITLE
MINOR: Move more dynamic Ruby calls to typed Java calls

### DIFF
--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -280,7 +280,7 @@ module LogStash; class JavaPipeline < JavaBasePipeline
   def inputworker(plugin)
     Util::set_thread_name("[#{pipeline_id}]<#{plugin.class.config_name}")
     begin
-      plugin.run(LogStash::WrappedWriteClient.new(input_queue_client, pipeline_id.to_s.to_sym, metric, plugin.id.to_sym))
+      plugin.run(wrapped_write_client(plugin.id.to_sym))
     rescue => e
       if plugin.stop?
         @logger.debug("Input plugin raised exception during shutdown, ignoring it.",

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -20,7 +20,6 @@ module LogStash; class BasePipeline < AbstractPipeline
   def initialize(pipeline_config, namespaced_metric = nil, agent = nil)
     @logger = self.logger
     super pipeline_config, namespaced_metric, @logger
-    @mutex = Mutex.new
 
     @inputs = nil
     @filters = nil
@@ -617,12 +616,5 @@ module LogStash; class Pipeline < BasePipeline
 
   def draining_queue?
     @drain_queue ? !@filter_queue_client.empty? : false
-  end
-
-  def wrapped_write_client(plugin_id)
-    #need to ensure that metrics are initialized one plugin at a time, else a race condition can exist.
-    @mutex.synchronize do
-      LogStash::WrappedWriteClient.new(input_queue_client, pipeline_id.to_s.to_sym, metric, plugin_id)
-    end
   end
 end; end

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java
@@ -25,7 +25,7 @@ public abstract class AbstractOutputDelegatorExt extends RubyObject {
 
     protected AbstractNamespacedMetricExt namespacedMetric;
 
-    private IRubyObject metricEvents;
+    private AbstractNamespacedMetricExt metricEvents;
 
     private RubyString id;
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
@@ -29,7 +29,7 @@ public final class FilterDelegatorExt extends RubyObject {
 
     private IRubyObject filter;
 
-    private IRubyObject metricEvents;
+    private AbstractNamespacedMetricExt metricEvents;
 
     private RubyString id;
 

--- a/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBase.java
+++ b/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBase.java
@@ -12,6 +12,7 @@ import org.jruby.javasupport.JavaObject;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.RubyUtil;
+import org.logstash.instrument.metrics.AbstractNamespacedMetricExt;
 import org.logstash.instrument.metrics.MetricKeys;
 import org.logstash.instrument.metrics.counter.LongCounter;
 
@@ -48,25 +49,28 @@ public abstract class QueueReadClientBase extends RubyObject implements QueueRea
         return result;
     }
 
-    @JRubyMethod(name = "set_events_metric", required = 1)
-    public IRubyObject setEventsMetric(final ThreadContext context, IRubyObject metric) {
-        eventMetricOut = LongCounter.fromRubyBase(metric, MetricKeys.OUT_KEY);
-        eventMetricFiltered = LongCounter.fromRubyBase(metric, MetricKeys.FILTERED_KEY);
-        eventMetricTime = LongCounter.fromRubyBase(metric, MetricKeys.DURATION_IN_MILLIS_KEY);
+    @JRubyMethod(name = "set_events_metric")
+    public IRubyObject setEventsMetric(final IRubyObject metric) {
+        final AbstractNamespacedMetricExt namespacedMetric = (AbstractNamespacedMetricExt) metric;
+        eventMetricOut = LongCounter.fromRubyBase(namespacedMetric, MetricKeys.OUT_KEY);
+        eventMetricFiltered = LongCounter.fromRubyBase(namespacedMetric, MetricKeys.FILTERED_KEY);
+        eventMetricTime = LongCounter.fromRubyBase(namespacedMetric, MetricKeys.DURATION_IN_MILLIS_KEY);
         return this;
     }
 
-    @JRubyMethod(name = "set_pipeline_metric", required = 1)
-    public IRubyObject setPipelineMetric(final ThreadContext context, IRubyObject metric) {
-        pipelineMetricOut = LongCounter.fromRubyBase(metric, MetricKeys.OUT_KEY);
-        pipelineMetricFiltered = LongCounter.fromRubyBase(metric, MetricKeys.FILTERED_KEY);
-        pipelineMetricTime = LongCounter.fromRubyBase(metric, MetricKeys.DURATION_IN_MILLIS_KEY);
+    @JRubyMethod(name = "set_pipeline_metric")
+    public IRubyObject setPipelineMetric(final IRubyObject metric) {
+        final AbstractNamespacedMetricExt namespacedMetric = (AbstractNamespacedMetricExt) metric;
+        pipelineMetricOut = LongCounter.fromRubyBase(namespacedMetric, MetricKeys.OUT_KEY);
+        pipelineMetricFiltered = LongCounter.fromRubyBase(namespacedMetric, MetricKeys.FILTERED_KEY);
+        pipelineMetricTime =
+            LongCounter.fromRubyBase(namespacedMetric, MetricKeys.DURATION_IN_MILLIS_KEY);
         return this;
     }
 
     @JRubyMethod(name = "set_batch_dimensions")
-    public IRubyObject rubySetBatchDimensions(final ThreadContext context, IRubyObject batchSize,
-                                              IRubyObject waitForMillis) {
+    public IRubyObject rubySetBatchDimensions(final IRubyObject batchSize,
+        final IRubyObject waitForMillis) {
         setBatchDimensions(((RubyNumeric) batchSize).getIntValue(),
                 ((RubyNumeric) waitForMillis).getIntValue());
         return this;
@@ -115,7 +119,7 @@ public abstract class QueueReadClientBase extends RubyObject implements QueueRea
      * original pipeline and rspec tests.
      */
     @JRubyMethod(name = "close_batch")
-    public void rubyCloseBatch(final ThreadContext context, IRubyObject batch) throws IOException {
+    public void rubyCloseBatch(final IRubyObject batch) throws IOException {
         closeBatch(extractQueueBatch(batch));
     }
 
@@ -124,7 +128,7 @@ public abstract class QueueReadClientBase extends RubyObject implements QueueRea
      * only in the original pipeline and rspec tests.
      */
     @JRubyMethod(name = "start_metrics")
-    public void rubyStartMetrics(final ThreadContext context, IRubyObject batch) {
+    public void rubyStartMetrics(final IRubyObject batch) {
         startMetrics(extractQueueBatch(batch));
     }
 
@@ -146,7 +150,7 @@ public abstract class QueueReadClientBase extends RubyObject implements QueueRea
      * only in the original pipeline and rspec tests.
      */
     @JRubyMethod(name = "add_filtered_metrics")
-    public void rubyAddFilteredMetrics(final ThreadContext context, IRubyObject size) {
+    public void rubyAddFilteredMetrics(final IRubyObject size) {
         addFilteredMetrics(((RubyNumeric)size).getIntValue());
     }
 
@@ -155,7 +159,7 @@ public abstract class QueueReadClientBase extends RubyObject implements QueueRea
      * only in the original pipeline and rspec tests.
      */
     @JRubyMethod(name = "add_output_metrics")
-    public void rubyAddOutputMetrics(final ThreadContext context, IRubyObject size) {
+    public void rubyAddOutputMetrics(final IRubyObject size) {
         addOutputMetrics(((RubyNumeric)size).getIntValue());
     }
 

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
@@ -134,7 +134,7 @@ public final class JrubyTimestampExtLibrary {
             return RubyString.newString(context.runtime,  "\"" + this.timestamp.toString() + "\"");
         }
 
-        @JRubyMethod(name = "coerce", required = 1, meta = true)
+        @JRubyMethod(name = "coerce", meta = true)
         public static IRubyObject ruby_coerce(ThreadContext context, IRubyObject recv, IRubyObject time)
         {
             try {
@@ -160,7 +160,7 @@ public final class JrubyTimestampExtLibrary {
             }
          }
 
-        @JRubyMethod(name = "parse_iso8601", required = 1, meta = true)
+        @JRubyMethod(name = "parse_iso8601", meta = true)
         public static IRubyObject ruby_parse_iso8601(ThreadContext context, IRubyObject recv, IRubyObject time)
         {
             if (time instanceof RubyString) {
@@ -199,13 +199,13 @@ public final class JrubyTimestampExtLibrary {
         }
 
         @JRubyMethod(name = "utc")
-        public IRubyObject ruby_utc(ThreadContext context)
+        public IRubyObject ruby_utc()
         {
             return this;
         }
 
         @JRubyMethod(name = "gmtime")
-        public IRubyObject ruby_gmtime(ThreadContext context)
+        public IRubyObject ruby_gmtime()
         {
             return this;
         }
@@ -222,7 +222,7 @@ public final class JrubyTimestampExtLibrary {
             return RubyFixnum.newFixnum(context.runtime, this.timestamp.getTime().getYear());
         }
 
-        @JRubyMethod(name = "<=>", required = 1)
+        @JRubyMethod(name = "<=>")
         public IRubyObject op_cmp(final ThreadContext context, final IRubyObject other) {
             if (other instanceof JrubyTimestampExtLibrary.RubyTimestamp) {
                 return ruby_time(context).op_cmp(
@@ -264,19 +264,19 @@ public final class JrubyTimestampExtLibrary {
             return RubyComparable.op_lt(context, this, other);
         }
 
-        @JRubyMethod(name = {"eql?", "=="}, required = 1)
+        @JRubyMethod(name = {"eql?", "=="})
         public IRubyObject eql(final ThreadContext context, final IRubyObject other) {
             return this == other || other.getClass() == JrubyTimestampExtLibrary.RubyTimestamp.class
                 && timestamp.equals(((JrubyTimestampExtLibrary.RubyTimestamp) other).timestamp)
                 ? context.tru : context.fals;
         }
 
-        @JRubyMethod(name = "+", required = 1)
+        @JRubyMethod(name = "+")
         public IRubyObject plus(final ThreadContext context, final IRubyObject val) {
             return this.ruby_time(context).callMethod(context, "+", val);
         }
 
-        @JRubyMethod(name = "-", required = 1)
+        @JRubyMethod(name = "-")
         public IRubyObject minus(final ThreadContext context, final IRubyObject val) {
             return this.ruby_time(context).callMethod(
                 context, "-",

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/counter/LongCounter.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/counter/LongCounter.java
@@ -6,6 +6,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.RubyUtil;
 import org.logstash.instrument.metrics.AbstractMetric;
+import org.logstash.instrument.metrics.AbstractNamespacedMetricExt;
 import org.logstash.instrument.metrics.MetricType;
 
 /**
@@ -29,9 +30,10 @@ public class LongCounter extends AbstractMetric<Long> implements CounterMetric<L
      * @return either the backing LongCounter or {@link #DUMMY_COUNTER} in case the input
      * {@code metric} was a Ruby {@code LogStash::Instrument::NullMetric}
      */
-    public static LongCounter fromRubyBase(final IRubyObject metric, final RubySymbol key) {
+    public static LongCounter fromRubyBase(final AbstractNamespacedMetricExt metric,
+        final RubySymbol key) {
         final ThreadContext context = RubyUtil.RUBY.getCurrentContext();
-        final IRubyObject counter = metric.callMethod(context, "counter", key);
+        final IRubyObject counter = metric.counter(context, key);
         counter.callMethod(context, "increment", context.runtime.newFixnum(0));
         final LongCounter javaCounter;
         if (LongCounter.class.isAssignableFrom(counter.getJavaClass())) {

--- a/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/ReloadWitness.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/witness/pipeline/ReloadWitness.java
@@ -26,7 +26,6 @@ public final class ReloadWitness implements SerializableWitness {
     private final RubyTimeStampGauge lastSuccessTimestamp;
     private final RubyTimeStampGauge lastFailureTimestamp;
     private final Snitch snitch;
-    private static final Serializer SERIALIZER = new Serializer();
 
     private static final String KEY = "reloads";
 

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
@@ -59,7 +59,7 @@ public final class PluginFactoryExt {
             final RubyString id = (RubyString) arguments.op_aref(context, ID_KEY);
             filterInstance.callMethod(
                 context, "metric=",
-                args[3].callMethod(context, "namespace", id.intern19())
+                ((AbstractMetricExt) args[3]).namespace(context, id.intern19())
             );
             filterInstance.callMethod(context, "execution_context=", args[4]);
             return args[0].callMethod(context, "new", new IRubyObject[]{filterInstance, id});


### PR DESCRIPTION
* More typed calls in metric setup
   * Had to remove the mocking in `filter_delegator_spec` as a result, now uses real `Collector` (this is kinda nice thinking about plans to port `Collector` to Java in as well since we don't really have many explicit tests for `Collector`) ... also using the real `Collector` is actually less code than mocking here
* Typed instantiation of the wrapped write client in the pipelines (the synchronisation in the Ruby pipeline can be safely dropped here since it was moved to Java earlier)
* Some dead param and annotation param removal :)