### PR TITLE
Remove excess period from logstash-plugin error reporting

### DIFF
--- a/lib/pluginmanager/remove.rb
+++ b/lib/pluginmanager/remove.rb
@@ -28,6 +28,6 @@ class LogStash::PluginManager::Remove < LogStash::PluginManager::Command
 
     remove_unused_locally_installed_gems!
   rescue => exception
-    report_exception("Operation aborted, cannot remove plugin.", exception)
+    report_exception("Operation aborted, cannot remove plugin", exception)
   end
 end


### PR DESCRIPTION
The error is supplemented by ", message: " + exception:
```
ERROR: Operation aborted, cannot remove plugin., message: File /usr/share/logstash/Gemfile does not exist or is not writable, aborting
```
As such, a period is unhelpful.

