### PR TITLE
JAVAFICATION: Move Ruby output calls to caching callsites

### DIFF
--- a/logstash-core/spec/logstash/java_pipeline_spec.rb
+++ b/logstash-core/spec/logstash/java_pipeline_spec.rb
@@ -125,10 +125,6 @@ class NilFlushingFilterPeriodic < DummyFlushingFilter
   end
 end
 
-class JavaTestPipeline < LogStash::JavaPipeline
-  attr_reader :outputs, :settings
-end
-
 describe LogStash::JavaPipeline do
   let(:worker_thread_count)     { 5 }
   let(:safe_thread_count)       { 1 }

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -118,10 +118,6 @@ class DummyFlushingFilterPeriodic < DummyFlushingFilter
   end
 end
 
-class TestPipeline < LogStash::Pipeline
-  attr_reader :outputs, :settings
-end
-
 describe LogStash::Pipeline do
   let(:worker_thread_count)     { 5 }
   let(:safe_thread_count)       { 1 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputDelegatorExt.java
@@ -25,17 +25,17 @@ public final class OutputDelegatorExt extends AbstractOutputDelegatorExt {
 
     private OutputStrategyExt.AbstractOutputStrategyExt strategy;
 
-    @JRubyMethod(name = "initialize", optional = 5)
+    @JRubyMethod(required = 5)
     public OutputDelegatorExt initialize(final ThreadContext context, final IRubyObject[] arguments) {
         return initialize(
-            context, (RubyHash) arguments[4], arguments[0], (AbstractMetricExt) arguments[1],
+            context, (RubyHash) arguments[4], (RubyClass) arguments[0], (AbstractMetricExt) arguments[1],
             (ExecutionContextExt) arguments[2],
             (OutputStrategyExt.OutputStrategyRegistryExt) arguments[3]
         );
     }
 
     public OutputDelegatorExt initialize(final ThreadContext context, final RubyHash args,
-        final IRubyObject outputClass, final AbstractMetricExt metric,
+        final RubyClass outputClass, final AbstractMetricExt metric,
         final ExecutionContextExt executionContext,
         final OutputStrategyExt.OutputStrategyRegistryExt strategyRegistry) {
         this.outputClass = outputClass;
@@ -58,7 +58,7 @@ public final class OutputDelegatorExt extends AbstractOutputDelegatorExt {
 
     @JRubyMethod
     @VisibleForTesting
-    public IRubyObject strategy() {
+    public OutputStrategyExt.AbstractOutputStrategyExt strategy() {
         return strategy;
     }
 

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/NamespacedMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/NamespacedMetricExt.java
@@ -32,7 +32,7 @@ public final class NamespacedMetricExt extends AbstractNamespacedMetricExt {
     }
 
     @JRubyMethod(visibility = Visibility.PRIVATE)
-    public IRubyObject initialize(final ThreadContext context, final IRubyObject metric,
+    public NamespacedMetricExt initialize(final ThreadContext context, final IRubyObject metric,
         final IRubyObject namespaceName) {
         this.metric = (MetricExt) metric;
         if (namespaceName instanceof RubyArray) {


### PR DESCRIPTION
Significant speedup of the output delegator here by caching its callsites.

* To enable this, I had to fix up the Java tests for `OutputDelegatorExt` a little. Some of the methods that belong on the class and not the instances were not `static`.
* Annoyingly enough we also needed a way to get a hold of the last instantiated instance of the fake output class (this was the only alternative to adding a bunch of getters to the output delegator and output strategy classes ... mainly did it this way be cause it was shorter and I'm hoping we will further simplify this code soon once specs have to more Java or at least less mocking)
  * At least marked the test as not thread-safe to warn of the danger :)
Also:
* Remvoed some dead code in RSpec tests (the test pipeline extensions)
* Fixed some dead code (redundant `context` inputs) and incorrect `@JRubyMethod` annotations