### PR TITLE
JAVAFICATION: Cache filter callsite and dedup some method names

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java
@@ -21,6 +21,8 @@ import org.logstash.instrument.metrics.counter.LongCounter;
 @JRubyClass(name = "AbstractOutputDelegator")
 public abstract class AbstractOutputDelegatorExt extends RubyObject {
 
+    public static final String OUTPUT_METHOD_NAME = "multi_receive";
+
     private AbstractMetricExt metric;
 
     protected AbstractNamespacedMetricExt namespacedMetric;
@@ -86,7 +88,7 @@ public abstract class AbstractOutputDelegatorExt extends RubyObject {
         return metricEvents;
     }
 
-    @JRubyMethod(name = "multi_receive")
+    @JRubyMethod(name = OUTPUT_METHOD_NAME)
     public IRubyObject multiReceive(final IRubyObject events) {
         final RubyArray batch = (RubyArray) events;
         final int count = batch.size();

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
@@ -108,20 +108,23 @@ public final class OutputStrategyExt {
             return close(context);
         }
 
-        @JRubyMethod(name = "multi_receive")
+        @JRubyMethod(name = AbstractOutputDelegatorExt.OUTPUT_METHOD_NAME)
         public final IRubyObject multiReceive(final ThreadContext context, final IRubyObject events)
             throws InterruptedException {
             return output(context, events);
         }
 
         protected final void initOutputCallsite(final RubyClass outputClass) {
-            outputMethod = outputClass.searchMethod("multi_receive");
+            outputMethod = outputClass.searchMethod(AbstractOutputDelegatorExt.OUTPUT_METHOD_NAME);
             this.outputClass = outputClass;
         }
 
         protected final void invokeOutput(final ThreadContext context, final IRubyObject batch,
             final IRubyObject pluginInstance) {
-            outputMethod.call(context, pluginInstance, outputClass, "multi_receive", batch);
+            outputMethod.call(
+                context, pluginInstance, outputClass, AbstractOutputDelegatorExt.OUTPUT_METHOD_NAME,
+                batch
+            );
         }
 
         protected abstract IRubyObject output(ThreadContext context, IRubyObject events)

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/FakeOutClass.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/FakeOutClass.java
@@ -70,7 +70,7 @@ public class FakeOutClass extends RubyObject {
         return this;
     }
 
-    @JRubyMethod(name = "multi_receive")
+    @JRubyMethod(name = AbstractOutputDelegatorExt.OUTPUT_METHOD_NAME)
     public IRubyObject multiReceive(final IRubyObject args) {
         multiReceiveCallCount++;
         multiReceiveArgs = args;


### PR DESCRIPTION
Same as #9751 

Also:
* deduped some of the method names involved here to constants to make things a little easier to further simplify 