### PR TITLE
 #9747 Fix Java Execution compilation breaking for datasets with more than 255 parents

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/MethodSyntaxElement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/MethodSyntaxElement.java
@@ -2,6 +2,7 @@ package org.logstash.config.ir.compiler;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.jruby.RubyArray;
@@ -15,12 +16,13 @@ interface MethodSyntaxElement extends SyntaxElement {
      * Builds a constructor from the given method body and arguments.
      * @param classname Name of the Class
      * @param body Constructor Method Body
-     * @param arguments Method Argument Definitions
      * @return Method Syntax
      */
-    static MethodSyntaxElement constructor(final String classname, final Closure body,
-        final Iterable<VariableDefinition> arguments) {
-        return new MethodSyntaxElement.MethodSyntaxElementImpl(classname, "", body, arguments);
+    static MethodSyntaxElement constructor(final String classname, final Closure body) {
+        return new MethodSyntaxElement.MethodSyntaxElementImpl(
+            classname, "", body,
+            Collections.singletonList(ComputeStepSyntaxElement.CTOR_ARGUMENT)
+        );
     }
 
     /**


### PR DESCRIPTION
Fixes #9747 :

The problem was that the constructors generated for the `Dataset`s used explicit arguments for each parent `Dataset`.

So we had something like:

```java
Dataset2000(Dataset1 arg1, Dataset2 arg2, ...) {
  field1 = arg1;
  field2 = arg2;
  ...
}
```

This breaks with more than 255 parents since that's the maximum argument count on a Java method.

=> Fixed by making the argument a map of field name to value and casting the individual values after lookup like so:

```java
Dataset2000(Map arguments) {
  field1 = (Dataset1) arguments.get("field1");
  field2 = (Dataset2) arguments.get("field2");
  ...
}
```

The added unites reproduced this and is green now :)  