### PR TITLE
Encourage central management UI users to add the `monitoring_user` role as well

### DIFF
--- a/docs/static/management/centralized-pipelines.asciidoc
+++ b/docs/static/management/centralized-pipelines.asciidoc
@@ -26,7 +26,9 @@ Before using the pipeline management UI, you must:
 * <<configuring-centralized-pipelines, Configure centralized pipeline management>>.
 * If {kib} is protected with basic authentication, make sure your {kib} user has
 the `logstash_admin` role as well as the `logstash_writer` role that you created
-when you <<ls-security,configured Logstash to use basic authentication>>. 
+when you <<ls-security,configured Logstash to use basic authentication>>. Additionally,
+in order to view (as read-only) non-centrally-managed pipelines in the pipeline management
+UI, make sure your {kib} user has the `monitoring_user` role as well.
 
 To manage Logstash pipelines in {kib}:
 


### PR DESCRIPTION
Resolves https://github.com/elastic/logstash/issues/9475.

Starting with 6.3.0, users of the Logstash Central Management UI have the ability to see — as read-only — non-centrally-managed Logstash pipelines in the UI as well. This requires users to have the `monitoring_user` role assigned to them. This PR adds a note about this to our docs.