### PR TITLE
PQ Docs: add note about upgrading

### DIFF
--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -29,6 +29,15 @@ messages stored in the persistent queue until delivery succeeds at least once.
 NOTE: You must set `queue.checkpoint.writes: 1` explicitly to guarantee
 maximum durability for all input events. See <<durability-persistent-queues>>.
 
++
+NOTE: The Persistent Queue is under active development and continues to improve
+with each release of Logstash; using the latest available version of Logstash
+will ensure you're using the best available version of this and other features.
+To enable the smoothest transition when upgrading, especially from versions
+prior to 6.3.0, you're encouraged to
+<<upgrading-logstash-pqs#_drain_the_persistent_queue,drain the queue>> prior to
+performing an upgrade.
+
 [[persistent-queues-limitations]]
 ==== Limitations of Persistent Queues
 


### PR DESCRIPTION
Since the PQ was released as GA in 5.4, to ensure that the note shows up on generated docs pages, this note on upgrading should be back-ported to every major/minor branch since:
 - [ ] `6.x`,
 - [ ] `6.3`,
 - [ ] `6.2`,
 - [ ] `6.1`,
 - [ ] `6.0`,
 - [ ] `5.6`,
 - [ ] `5.5`, and
 - [ ] `5.4`