### PR TITLE
 #9708: Correctly handle non unicode event keys in serialization

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ConvertedMap.java
+++ b/logstash-core/src/main/java/org/logstash/ConvertedMap.java
@@ -99,6 +99,6 @@ public final class ConvertedMap extends IdentityHashMap<String, Object> {
      * @return Interned String
      */
     private static String convertKey(final RubyString key) {
-        return FieldReference.from(key.getByteList()).getKey();
+        return FieldReference.from(key).getKey();
     }
 }

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -82,14 +82,14 @@ public final class JrubyEventExtLibrary {
         {
             return Rubyfier.deep(
                 context.runtime,
-                this.event.getUnconvertedField(FieldReference.from(reference.getByteList()))
+                this.event.getUnconvertedField(FieldReference.from(reference))
             );
         }
 
         @JRubyMethod(name = "set", required = 2)
         public IRubyObject ruby_set_field(ThreadContext context, RubyString reference, IRubyObject value)
         {
-            final FieldReference r = FieldReference.from(reference.getByteList());
+            final FieldReference r = FieldReference.from(reference);
             if (r.equals(FieldReference.TIMESTAMP_REFERENCE)) {
                 if (!(value instanceof JrubyTimestampExtLibrary.RubyTimestamp)) {
                     throw context.runtime.newTypeError("wrong argument type " + value.getMetaClass() + " (expected LogStash::Timestamp)");
@@ -124,7 +124,7 @@ public final class JrubyEventExtLibrary {
         @JRubyMethod(name = "include?", required = 1)
         public IRubyObject ruby_includes(ThreadContext context, RubyString reference) {
             return RubyBoolean.newBoolean(
-                context.runtime, this.event.includes(FieldReference.from(reference.getByteList()))
+                context.runtime, this.event.includes(FieldReference.from(reference))
             );
         }
 
@@ -132,7 +132,7 @@ public final class JrubyEventExtLibrary {
         public IRubyObject ruby_remove(ThreadContext context, RubyString reference) {
             return Rubyfier.deep(
                 context.runtime,
-                this.event.remove(FieldReference.from(reference.getByteList()))
+                this.event.remove(FieldReference.from(reference))
             );
         }
 

--- a/logstash-core/src/test/java/org/logstash/AccessorsTest.java
+++ b/logstash-core/src/test/java/org/logstash/AccessorsTest.java
@@ -194,20 +194,20 @@ public class AccessorsTest {
         set(data, "[foo][bar]", "Another String");
     }
 
-    private static Object get(final ConvertedMap data, final CharSequence reference) {
+    private static Object get(final ConvertedMap data, final String reference) {
         return Accessors.get(data, FieldReference.from(reference));
     }
 
-    private static Object set(final ConvertedMap data, final CharSequence reference,
+    private static Object set(final ConvertedMap data, final String reference,
         final Object value) {
         return Accessors.set(data, FieldReference.from(reference), value);
     }
 
-    private static Object del(final ConvertedMap data, final CharSequence reference) {
+    private static Object del(final ConvertedMap data, final String reference) {
         return Accessors.del(data, FieldReference.from(reference));
     }
 
-    private static boolean includes(final ConvertedMap data, final CharSequence reference) {
+    private static boolean includes(final ConvertedMap data, final String reference) {
         return Accessors.includes(data, FieldReference.from(reference));
     }
 }

--- a/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
+++ b/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
@@ -51,7 +51,7 @@ public final class FieldReferenceTest {
         final FieldReference emptyReference = FieldReference.from("");
         assertNotNull(emptyReference);
         assertEquals(
-            emptyReference, FieldReference.from(RubyUtil.RUBY.newString("").getByteList())
+            emptyReference, FieldReference.from(RubyUtil.RUBY.newString(""))
         );
     }
 

--- a/logstash-core/src/test/java/org/logstash/ext/JrubyEventExtLibraryTest.java
+++ b/logstash-core/src/test/java/org/logstash/ext/JrubyEventExtLibraryTest.java
@@ -43,6 +43,18 @@ public final class JrubyEventExtLibraryTest {
         }
     }
 
+    @Test
+    public void correctlyHandlesNonAsciiKeys() {
+        final RubyString key = rubyString("[テストフィールド]");
+        final RubyString value = rubyString("someValue");
+        final ThreadContext context = RubyUtil.RUBY.getCurrentContext();
+        final JrubyEventExtLibrary.RubyEvent event =
+            JrubyEventExtLibrary.RubyEvent.newRubyEvent(context.runtime);
+        event.ruby_set_field(context, key, value);
+        Assertions.assertThat(event.ruby_to_json(context, new IRubyObject[0]).asJavaString())
+            .contains("\"テストフィールド\":\"someValue\"");
+    }
+
     private static RubyString rubyString(final String java) {
         return RubyUtil.RUBY.newString(java);
     }


### PR DESCRIPTION
fixes #9708 :

the mistake I made here was using JRuby's `BytesList` as a `Charsequence`, trying to map it back to a `String` during serialization. This is not correct if the `BytesList` doesn't contain data in the default encoding because only its wrapping `RubyString` has the encoding information.

* Fixed by caching `FieldReference` in a separate cache by `RubyString` key instead of using the single cache for Java and Ruby.