### PR TITLE
JAVAFICATION: Move more of the pipelines to Java

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyWrappedAckedQueueExt.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyWrappedAckedQueueExt.java
@@ -13,6 +13,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.RubyUtil;
 import org.logstash.execution.AbstractWrappedQueueExt;
+import org.logstash.execution.QueueReadClientBase;
 import org.logstash.ext.JRubyAbstractQueueWriteClientExt;
 import org.logstash.ext.JrubyAckedReadClientExt;
 import org.logstash.ext.JrubyAckedWriteClientExt;
@@ -77,7 +78,7 @@ public final class JRubyWrappedAckedQueueExt extends AbstractWrappedQueueExt {
     }
 
     @Override
-    protected IRubyObject getReadClient() {
+    protected QueueReadClientBase getReadClient() {
         return JrubyAckedReadClientExt.create(queue);
     }
 

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractWrappedQueueExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractWrappedQueueExt.java
@@ -22,7 +22,7 @@ public abstract class AbstractWrappedQueueExt extends RubyBasicObject {
     }
 
     @JRubyMethod(name = "read_client")
-    public final IRubyObject readClient() {
+    public final QueueReadClientBase readClient() {
         return getReadClient();
     }
 
@@ -35,5 +35,5 @@ public abstract class AbstractWrappedQueueExt extends RubyBasicObject {
 
     protected abstract JRubyAbstractQueueWriteClientExt getWriteClient(ThreadContext context);
 
-    protected abstract IRubyObject getReadClient();
+    protected abstract QueueReadClientBase getReadClient();
 }

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyWrappedSynchronousQueueExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyWrappedSynchronousQueueExt.java
@@ -10,6 +10,7 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.execution.AbstractWrappedQueueExt;
+import org.logstash.execution.QueueReadClientBase;
 
 @JRubyClass(name = "WrappedSynchronousQueue")
 public final class JrubyWrappedSynchronousQueueExt extends AbstractWrappedQueueExt {
@@ -35,7 +36,7 @@ public final class JrubyWrappedSynchronousQueueExt extends AbstractWrappedQueueE
     }
 
     @Override
-    protected IRubyObject getReadClient() {
+    protected QueueReadClientBase getReadClient() {
         // batch size and timeout are currently hard-coded to 125 and 50ms as values observed
         // to be reasonable tradeoffs between latency and throughput per PR #8707
         return JrubyMemoryReadClientExt.create(queue, 125, 50);

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricKeys.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricKeys.java
@@ -23,4 +23,6 @@ public final class MetricKeys {
         RubyUtil.RUBY.newSymbol("duration_in_millis");
 
     public static final RubySymbol FILTERED_KEY = RubyUtil.RUBY.newSymbol("filtered");
+
+    public static final RubySymbol STATS_KEY = RubyUtil.RUBY.newSymbol("stats");
 }

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
@@ -279,8 +279,6 @@ public final class PluginFactoryExt {
     @JRubyClass(name = "PluginMetricFactory")
     public static final class Metrics extends RubyBasicObject {
 
-        private static final RubySymbol STATS = RubyUtil.RUBY.newSymbol("stats");
-
         private static final RubySymbol PLUGINS = RubyUtil.RUBY.newSymbol("plugins");
 
         private RubySymbol pipelineId;
@@ -308,7 +306,10 @@ public final class PluginFactoryExt {
             return metric.namespace(
                 context,
                 RubyArray.newArray(
-                    context.runtime, Arrays.asList(STATS, MetricKeys.PIPELINES_KEY, pipelineId, PLUGINS)
+                    context.runtime,
+                    Arrays.asList(
+                        MetricKeys.STATS_KEY, MetricKeys.PIPELINES_KEY, pipelineId, PLUGINS
+                    )
                 )
             ).namespace(
                 context, RubyUtil.RUBY.newSymbol(String.format("%ss", pluginType.asJavaString()))


### PR DESCRIPTION
Another small step here, moved the setup of the filter queue client and since that became possible as a result, the `close` method.