### PR TITLE
Check free space on specified path rather than root folder

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/FsUtil.java
+++ b/logstash-core/src/main/java/org/logstash/common/FsUtil.java
@@ -1,11 +1,6 @@
 package org.logstash.common;
 
-import java.io.File;
-import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -25,24 +20,11 @@ public final class FsUtil {
      * path.
      * @param path Directory to check
      * @param size Bytes of free space requested
-     * @return True iff the
-     * @throws IOException on failure to determine free space for given path's partition
+     * @return True iff the free space in the specified path meets or exceeds the requested space
      */
     public static boolean hasFreeSpace(final Path path, final long size)
-        throws IOException
     {
-        final Set<File> partitionRoots = new HashSet<>(Arrays.asList(File.listRoots()));
-
-        // crawl up file path until we find a root partition
-        File location = path.toFile().getCanonicalFile();
-        while (!partitionRoots.contains(location)) {
-            location = location.getParentFile();
-            if (location == null) {
-                throw new IllegalStateException(String.format("Unable to determine the partition that contains '%s'", path));
-            }
-        }
-
-        final long freeSpace = location.getFreeSpace();
+        final long freeSpace = path.toFile().getFreeSpace();
 
         if (freeSpace == 0L && IS_WINDOWS) {
             // On Windows, SUBST'ed drives report 0L from getFreeSpace().
@@ -50,10 +32,10 @@ public final class FsUtil {
             // There is no straightforward fix for this and it seems a fix is included in Java 9.
             // One alternative is to launch and parse a DIR command and look at the reported free space.
             // This is a temporary fix to get the CI tests going which relies on SUBST'ed drives to manage long paths.
-            logger.warn("Cannot retrieve free space on " +  location.toString() +  ". This is probably a SUBST'ed drive.");
+            logger.warn("Cannot retrieve free space on " +  path.toString() +  ". This is probably a SUBST'ed drive.");
             return true;
         }
 
-        return location.getFreeSpace() >= size;
+        return freeSpace >= size;
     }
 }


### PR DESCRIPTION
The previous implementation that walked up the directory tree until hitting a root partition did not work with Unix mount points. This implementation checks the specified path directly and works on both Linux and Windows.

Fixes #9766.