### PR TITLE
Fix typo in proxy_support.rb

### DIFF
--- a/lib/pluginmanager/proxy_support.rb
+++ b/lib/pluginmanager/proxy_support.rb
@@ -101,7 +101,7 @@ def configure_proxy
 
     if ::File.exist?(target)
       if template_content != ::File.read(target)
-        puts "WARNING: A maven settings file already exist at #{target}, please review the content to make sure it include your proxies configuration."
+        puts "WARNING: A maven settings file already exist at #{target}, please review the content to make sure it includes your proxies configuration."
       end
     else
       ::File.open(target, "w") { |f| f.write(template_content) }


### PR DESCRIPTION
Fixed a typo I noticed when running into problems configuring logstash.