### PR TITLE
prevent tests from stalling by ensuring files we check get flushed

### DIFF
--- a/qa/integration/fixtures/01_logstash_bin_smoke_spec.yml
+++ b/qa/integration/fixtures/01_logstash_bin_smoke_spec.yml
@@ -10,6 +10,9 @@ config: |-
     generator { count => 5 }
   }
   output {
-    file { path => '<%=options[:random_file]%>' }
+    file {
+      path => '<%=options[:random_file]%>'
+      flush_interval => 0
+    }
   }
 


### PR DESCRIPTION
Several tests in 6.3 were stalling out in CI while waiting for a file to be written to as evidence that the pipeline had started, but the file output plugin wasn't explicitly configured to flush to disk, so would  [stall out](https://logstash-ci.elastic.co/job/elastic+logstash+6.3+multijob-integration-1/70/console) waiting for the precondition to be met.

This fixes the 6.3 and 6.x builds for me, but I'm concerned that the problem isn't more widespread on our other branches that share these verbatim tests. Did we have an auto-flushing behaviour that got inadvertently removed from 6.3?