### PR TITLE
Ruby event API fix to support non-ASCII keys

### DIFF
--- a/logstash-core/spec/logstash/event_spec.rb
+++ b/logstash-core/spec/logstash/event_spec.rb
@@ -417,23 +417,22 @@ describe LogStash::Event do
 
    describe "#event-UTF" do
     it "should set and get values for non-ASCII keys" do
-#      e = LogStash::Event.new()
-#      expect(e.set("фуу", "bar")).to eq("bar")
-#      expect(e.get("фуу")).to eq("bar")
+      e = LogStash::Event.new()
+      expect(e.set("фуу", "bar")).to eq("bar")
+      expect(e.get("фуу")).to eq("bar")
 
-#      e = LogStash::Event.new({"фуу" => "test"})
-#      expect(e.set("фуу", "bar")).to eq("bar")
-#      expect(e.get("фуу")).to eq("bar")
+      e = LogStash::Event.new({"фуу" => "test"})
+      expect(e.set("фуу", "bar")).to eq("bar")
+      expect(e.get("фуу")).to eq("bar")
     end
 
     it "should set and get values for non-ASCII keys through java APIs" do
       e = LogStash::Event.new()
       e.to_java.setField("фуу", "bar")
-#     expect(e.get("фуу")).to eq("bar")
-#      e.get("фуу").gsub!(/bar/, 'pff')
-#      expect(e.get("фуу")).to eq("pff")
-#      expect(e.to_java.getField("фуу")).to eq("pff")
-      expect(e.to_java.getField("фуу")).to eq("bar")
+      expect(e.get("фуу")).to eq("bar")
+      e.get("фуу").gsub!(/bar/, 'pff')
+      expect(e.get("фуу")).to eq("pff")
+      expect(e.to_java.getField("фуу")).to eq("pff")
     end
 
   end

--- a/logstash-core/spec/logstash/event_spec.rb
+++ b/logstash-core/spec/logstash/event_spec.rb
@@ -415,15 +415,15 @@ describe LogStash::Event do
     end
   end
 
-  context "#event-UTF" do
+   describe "#event-UTF" do
     it "should set and get values for non-ASCII keys" do
-      e = LogStash::Event.new()
-      expect(e.set("фуу", "bar")).to eq("bar")
-      expect(e.get("фуу")).to eq("bar")
+#      e = LogStash::Event.new()
+#      expect(e.set("фуу", "bar")).to eq("bar")
+#      expect(e.get("фуу")).to eq("bar")
 
-      e = LogStash::Event.new({"фуу" => "test"})
-      expect(e.set("фуу", "bar")).to eq("bar")
-      expect(e.get("фуу")).to eq("bar")
+#      e = LogStash::Event.new({"фуу" => "test"})
+#      expect(e.set("фуу", "bar")).to eq("bar")
+#      expect(e.get("фуу")).to eq("bar")
     end
 
     it "should set and get values for non-ASCII keys through java APIs" do

--- a/logstash-core/spec/logstash/event_spec.rb
+++ b/logstash-core/spec/logstash/event_spec.rb
@@ -425,6 +425,16 @@ describe LogStash::Event do
       expect(e.set("фуу", "bar")).to eq("bar")
       expect(e.get("фуу")).to eq("bar")
     end
+
+    it "should set and get values for non-ASCII keys through java APIs" do
+      e = LogStash::Event.new()
+      e.to_java.setField("фуу", "bar")
+      expect(e.get("фуу")).to eq("bar")
+      e.get("фуу").gsub!(/bar/, 'pff')
+      expect(e.get("фуу")).to eq("pff")
+      expect(e.to_java.getField("фуу")).to eq("pff")
+    end
+
   end
 
 end

--- a/logstash-core/spec/logstash/event_spec.rb
+++ b/logstash-core/spec/logstash/event_spec.rb
@@ -429,9 +429,9 @@ describe LogStash::Event do
     it "should set and get values for non-ASCII keys through java APIs" do
       e = LogStash::Event.new()
       e.to_java.setField("фуу", "bar")
-      expect(e.get("фуу")).to eq("bar")
-      e.get("фуу").gsub!(/bar/, 'pff')
-      expect(e.get("фуу")).to eq("pff")
+#     expect(e.get("фуу")).to eq("bar")
+#      e.get("фуу").gsub!(/bar/, 'pff')
+#      expect(e.get("фуу")).to eq("pff")
       expect(e.to_java.getField("фуу")).to eq("pff")
     end
 

--- a/logstash-core/spec/logstash/event_spec.rb
+++ b/logstash-core/spec/logstash/event_spec.rb
@@ -432,7 +432,8 @@ describe LogStash::Event do
 #     expect(e.get("фуу")).to eq("bar")
 #      e.get("фуу").gsub!(/bar/, 'pff')
 #      expect(e.get("фуу")).to eq("pff")
-      expect(e.to_java.getField("фуу")).to eq("pff")
+#      expect(e.to_java.getField("фуу")).to eq("pff")
+      expect(e.to_java.getField("фуу")).to eq("bar")
     end
 
   end

--- a/logstash-core/spec/logstash/event_spec.rb
+++ b/logstash-core/spec/logstash/event_spec.rb
@@ -88,21 +88,7 @@ describe LogStash::Event do
       expect(e.set("foo", "bar")).to eq("bar")
       expect(e.get("foo")).to eq("bar")
     end
-
-    
-  context "#event-UTF" do
-#    it "should set and get values for non-ASCII keys" do
-#      e = LogStash::Event.new()
-#      expect(e.set("фуу", "bar")).to eq("bar")
-#      expect(e.get("фуу")).to eq("bar")
-
-#      e = LogStash::Event.new({"фуу" => "test"})
-#      expect(e.set("фуу", "bar")).to eq("bar")
-#      expect(e.get("фуу")).to eq("bar")
-    end
-
-    
-    
+  
     it "should propagate changes to mutable strings to java APIs" do
       e = LogStash::Event.new()
       e.to_java.setField("foo", "bar")
@@ -428,4 +414,17 @@ describe LogStash::Event do
       expect(event1.get("[@metadata][fancy]")).to eq("pants")
     end
   end
+
+  context "#event-UTF" do
+    it "should set and get values for non-ASCII keys" do
+      e = LogStash::Event.new()
+      expect(e.set("фуу", "bar")).to eq("bar")
+      expect(e.get("фуу")).to eq("bar")
+
+      e = LogStash::Event.new({"фуу" => "test"})
+      expect(e.set("фуу", "bar")).to eq("bar")
+      expect(e.get("фуу")).to eq("bar")
+    end
+  end
+
 end

--- a/logstash-core/spec/logstash/event_spec.rb
+++ b/logstash-core/spec/logstash/event_spec.rb
@@ -89,6 +89,20 @@ describe LogStash::Event do
       expect(e.get("foo")).to eq("bar")
     end
 
+    
+  context "#event-UTF" do
+    it "should set and get values for non-ASCII keys" do
+      e = LogStash::Event.new()
+      expect(e.set("фуу", "bar")).to eq("bar")
+      expect(e.get("фуу")).to eq("bar")
+
+      e = LogStash::Event.new({"фуу" => "test"})
+      expect(e.set("фуу", "bar")).to eq("bar")
+      expect(e.get("фуу")).to eq("bar")
+    end
+
+    
+    
     it "should propagate changes to mutable strings to java APIs" do
       e = LogStash::Event.new()
       e.to_java.setField("foo", "bar")

--- a/logstash-core/spec/logstash/event_spec.rb
+++ b/logstash-core/spec/logstash/event_spec.rb
@@ -91,14 +91,14 @@ describe LogStash::Event do
 
     
   context "#event-UTF" do
-    it "should set and get values for non-ASCII keys" do
-      e = LogStash::Event.new()
-      expect(e.set("фуу", "bar")).to eq("bar")
-      expect(e.get("фуу")).to eq("bar")
+#    it "should set and get values for non-ASCII keys" do
+#      e = LogStash::Event.new()
+#      expect(e.set("фуу", "bar")).to eq("bar")
+#      expect(e.get("фуу")).to eq("bar")
 
-      e = LogStash::Event.new({"фуу" => "test"})
-      expect(e.set("фуу", "bar")).to eq("bar")
-      expect(e.get("фуу")).to eq("bar")
+#      e = LogStash::Event.new({"фуу" => "test"})
+#      expect(e.set("фуу", "bar")).to eq("bar")
+#      expect(e.get("фуу")).to eq("bar")
     end
 
     

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -120,7 +120,7 @@ public final class JrubyEventExtLibrary {
         @JRubyMethod(name = "include?", required = 1)
         public IRubyObject ruby_includes(ThreadContext context, RubyString reference) {
             return RubyBoolean.newBoolean(
-                context.runtime, this.event.includes(FieldReference.from(reference.getByteList()))
+                context.runtime, this.event.includes(FieldReference.from(reference.getValue()))
             );
         }
 

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -78,14 +78,14 @@ public final class JrubyEventExtLibrary {
         {
             return Rubyfier.deep(
                 context.runtime,
-                this.event.getUnconvertedField(FieldReference.from(reference.getByteList()))
+                this.event.getUnconvertedField(FieldReference.from(reference.getValue()))
             );
         }
 
         @JRubyMethod(name = "set", required = 2)
         public IRubyObject ruby_set_field(ThreadContext context, RubyString reference, IRubyObject value)
         {
-            final FieldReference r = FieldReference.from(reference.getByteList());
+            final FieldReference r = FieldReference.from(reference.getValue());
             if (r  == FieldReference.TIMESTAMP_REFERENCE) {
                 if (!(value instanceof JrubyTimestampExtLibrary.RubyTimestamp)) {
                     throw context.runtime.newTypeError("wrong argument type " + value.getMetaClass() + " (expected LogStash::Timestamp)");
@@ -128,7 +128,7 @@ public final class JrubyEventExtLibrary {
         public IRubyObject ruby_remove(ThreadContext context, RubyString reference) {
             return Rubyfier.deep(
                 context.runtime,
-                this.event.remove(FieldReference.from(reference.getByteList()))
+                this.event.remove(FieldReference.from(reference.getValue()))
             );
         }
 


### PR DESCRIPTION
Fix for https://github.com/elastic/logstash/issues/9789