### PR TITLE
prevent tests from stalling by ensuring files we check get flushed

### DIFF
--- a/qa/integration/fixtures/01_logstash_bin_smoke_spec.yml
+++ b/qa/integration/fixtures/01_logstash_bin_smoke_spec.yml
@@ -10,6 +10,9 @@ config: |-
     generator { count => 5 }
   }
   output {
-    file { path => '<%=options[:random_file]%>' }
+    file {
+      path => '<%=options[:random_file]%>'
+      flush_interval => 0
+    }
   }
 

--- a/qa/integration/specs/multiple_pipeline_spec.rb
+++ b/qa/integration/specs/multiple_pipeline_spec.rb
@@ -69,7 +69,7 @@ describe "Test Logstash service when multiple pipelines are used" do
           "pipeline.id" => "test2",
           "pipeline.workers" => 1,
           "pipeline.batch.size" => 1,
-          "config.string" => "input { pipeline { address => testaddr } } output { file { path => \"#{temporary_out_file_1}\" } }"
+          "config.string" => "input { pipeline { address => testaddr } } output { file { path => \"#{temporary_out_file_1}\" flush_interval => 0} }"
         }
       ]
     end


### PR DESCRIPTION
Replaces elastic/logstash#9790 to target `master`, can be safely cherry-pick backported to `6.3` and `6.x`:

> Several tests in 6.3 were stalling out in CI while waiting for a file to be written to as evidence that the pipeline had started, but the file output plugin wasn't explicitly configured to flush to disk, so would  [stall out](https://logstash-ci.elastic.co/job/elastic+logstash+6.3+multijob-integration-1/70/console) waiting for the precondition to be met.
