### PR TITLE
Backport: Add anchor for draining PQ and remove version numbers

### DIFF
--- a/docs/static/upgrading.asciidoc
+++ b/docs/static/upgrading.asciidoc
@@ -108,24 +108,16 @@ practical and because some Logstash 6.0 plugins may attempt to use features of E
 in earlier versions.
 
 [[upgrading-logstash-pqs]]
-=== Upgrading Persistent Queue from Logstash 6.2.x and Earlier
+=== Upgrading with the Persistent Queue Enabled
 
-The following applies only if you are upgrading from Logstash version 6.2.x or
-earlier with the persistent queue enabled.
+The following applies only if you are upgrading Logstash and have the persistent
+queue enabled.
 
-We regret to say that due to several serialization issues in Logstash 6.2.x and
-earlier, users will have to take some extra steps when upgrading Logstash with
-the persistent queue enabled. While we strive to maintain backward compatibility
-within a given major release, these bugs require us to break that compatibility
-in version 6.3.0 to ensure correctness of operation. For more technical details
-on this issue, please check our tracking github issue for this matter,
-https://github.com/elastic/logstash/issues/9494[#9494].
-
+[[drain-pq]]
 ==== Drain the Persistent Queue
 
-If you are upgrading from Logstash version 6.2.x or earlier and use the persistent
-queue, we strongly recommend that you drain or delete the persistent queue
-before you upgrade.
+If you use the persistent queue, we strongly recommend that you drain or delete
+it before you upgrade.
 
 To drain the queue:
  
@@ -138,5 +130,5 @@ When the queue is empty:
 . Complete the upgrade.
 . Restart Logstash.
 
-We are working to resolve issues with data incompatibilities in our 6.3.0
-release so that these steps won’t be required for future upgrades.
+We are working to resolve issues with data incompatibilities so that these steps
+won’t be required for future upgrades.


### PR DESCRIPTION
Summary:
- Added an anchor ([[drain-pq]])for Draining the Persistent Queue to make it easier for others to link to.
- Removed references to version numbers where they didn't provide additional clarity

NOTE: Merge into 6.2 only