### PR TITLE
Update jruby artifact downloading (backport of #9806 to 6.3)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ if (versionMap["jruby-runtime-override"]) {
 } else {
     jRubyVersion = versionMap["jruby"]["version"]
     jRubySha1 = versionMap["jruby"]["sha1"]
-    jRubyURL = "http://jruby.org.s3.amazonaws.com/downloads/${jRubyVersion}/jruby-bin-${jRubyVersion}.tar.gz"
+    jRubyURL = "https://repo1.maven.org/maven2/org/jruby/jruby-dist/${jRubyVersion}/jruby-dist-${jRubyVersion}-bin.tar.gz"
     doChecksum = true
 }
 
@@ -116,7 +116,7 @@ project(":logstash-core") {
   }
 }
 
-def jrubyTarPath = "${projectDir}/vendor/_/jruby-bin-${jRubyVersion}.tar.gz"
+def jrubyTarPath = "${projectDir}/vendor/_/jruby-dist-${jRubyVersion}-bin.tar.gz"
 
 task downloadJRuby(type: Download) {
     description "Download JRuby artifact from this specific URL: ${jRubyURL}"
@@ -124,7 +124,7 @@ task downloadJRuby(type: Download) {
     onlyIfNewer true
     inputs.file("${projectDir}/versions.yml")
     outputs.file(jrubyTarPath)
-    dest new File("${projectDir}/vendor/_", "jruby-bin-${jRubyVersion}.tar.gz")
+    dest new File("${projectDir}/vendor/_", "jruby-dist-${jRubyVersion}-bin.tar.gz")
 }
 
 task verifyFile(dependsOn: downloadJRuby, type: Verify) {


### PR DESCRIPTION
* download urls moved to maven
* tarball naming scheme has changed

related #9806