### PR TITLE
Bugfix: Example configuration have wrong syntax for ssl-ca path. Ther…

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -220,7 +220,7 @@
 #xpack.monitoring.elasticsearch.username: logstash_system
 #xpack.monitoring.elasticsearch.password: password
 #xpack.monitoring.elasticsearch.url: ["https://es1:9200", "https://es2:9200"]
-#xpack.monitoring.elasticsearch.ssl.ca: [ "/path/to/ca.crt" ]
+#xpack.monitoring.elasticsearch.ssl.ca: "/path/to/ca.crt"
 #xpack.monitoring.elasticsearch.ssl.truststore.path: path/to/file
 #xpack.monitoring.elasticsearch.ssl.truststore.password: password
 #xpack.monitoring.elasticsearch.ssl.keystore.path: /path/to/file
@@ -237,7 +237,7 @@
 #xpack.management.elasticsearch.username: logstash_admin_user
 #xpack.management.elasticsearch.password: password
 #xpack.management.elasticsearch.url: ["https://es1:9200", "https://es2:9200"]
-#xpack.management.elasticsearch.ssl.ca: [ "/path/to/ca.crt" ]
+#xpack.management.elasticsearch.ssl.ca: "/path/to/ca.crt"
 #xpack.management.elasticsearch.ssl.truststore.path: /path/to/file
 #xpack.management.elasticsearch.ssl.truststore.password: password
 #xpack.management.elasticsearch.ssl.keystore.path: /path/to/file


### PR DESCRIPTION
The example configuration is wrong for ssl-ca path. It shall be an string instead of an array.

As documented from elastic: https://www.elastic.co/guide/en/logstash/6.3/configuring-logstash.html#monitoring-ssl-settings 