### PR TITLE
Support for integration plugins in plugin manager

### DIFF
--- a/lib/pluginmanager/install.rb
+++ b/lib/pluginmanager/install.rb
@@ -57,11 +57,42 @@ class LogStash::PluginManager::Install < LogStash::PluginManager::Command
       verify_remote!(gems) if !local? && verify?
     end
 
+    check_for_integrations(gems)
     install_gems_list!(gems)
     remove_unused_locally_installed_gems!
+    remove_unused_integration_overlaps!
   end
 
   private
+
+  def remove_unused_integration_overlaps!
+    installed_plugin_specs = plugins_arg.flat_map do |plugin_arg|
+      if LogStash::PluginManager.plugin_file?(plugin_arg)
+        LogStash::PluginManager.plugin_file_spec(plugin_arg)
+      else
+        LogStash::PluginManager.find_plugins_gem_specs(plugin_arg)
+      end
+    end.select do |spec|
+      LogStash::PluginManager.integration_plugin_spec?(spec)
+    end.flat_map do |spec|
+      LogStash::PluginManager.integration_plugin_provides(spec)
+    end.select do |plugin_name|
+      LogStash::PluginManager.installed_plugin?(plugin_name, gemfile)
+    end.each do |plugin_name|
+      puts "Removing '#{plugin_name}' since it is provided by an integration plugin"
+      ::Bundler::LogstashUninstall.uninstall!(plugin_name)
+    end
+  end
+
+  def check_for_integrations(gems)
+    gems.each do |plugin, _version|
+      integration_plugin = LogStash::PluginManager.which_integration_plugin_provides(plugin, gemfile)
+      if integration_plugin
+        signal_error("Installation aborted, plugin '#{plugin}' is already provided by '#{integration_plugin.name}'")
+      end
+    end
+  end
+
   def validate_cli_options!
     if development?
       signal_usage_error("Cannot specify plugin(s) with --development, it will add the development dependencies of the currently installed plugins") unless plugins_arg.empty?
@@ -121,8 +152,8 @@ class LogStash::PluginManager::Install < LogStash::PluginManager::Command
     # Add plugins/gems to the current gemfile
     puts("Installing" + (install_list.empty? ? "..." : " " + install_list.collect(&:first).join(", ")))
     install_list.each do |plugin, version, options|
+      plugin_gem = gemfile.find(plugin)
       if preserve?
-        plugin_gem = gemfile.find(plugin)
         puts("Preserving Gemfile gem options for plugin #{plugin}") if plugin_gem && !plugin_gem.options.empty?
         gemfile.update(plugin, version, options)
       else
@@ -169,7 +200,7 @@ class LogStash::PluginManager::Install < LogStash::PluginManager::Command
       # paquet will lookup in the cache directory before going to rubygems.
       FileUtils.cp(plugin, ::File.join(LogStash::Environment::CACHE_PATH, ::File.basename(plugin)))
       package, path = LogStash::Rubygems.unpack(plugin, LogStash::Environment::LOCAL_GEM_PATH)
-      [package.spec.name, package.spec.version, { :path => relative_path(path) }]
+      [package.spec.name, package.spec.version, { :path => relative_path(path) }, package.spec]
     end
   end
 

--- a/lib/pluginmanager/remove.rb
+++ b/lib/pluginmanager/remove.rb
@@ -20,6 +20,11 @@ class LogStash::PluginManager::Remove < LogStash::PluginManager::Command
     # them toward the OSS-only distribution of Logstash
     LogStash::PluginManager::XPackInterceptor::Remove.intercept!(plugin)
 
+    # if the plugin is provided by an integration plugin. abort.
+    if integration_plugin = LogStash::PluginManager.which_integration_plugin_provides(plugin, gemfile)
+      signal_error("This plugin is already provided by '#{integration_plugin.name}' so it can't be removed individually")
+    end
+
     # make sure this is an installed plugin and present in Gemfile.
     # it is not possible to uninstall a dependency not listed in the Gemfile, for example a dependent codec
     signal_error("This plugin has not been previously installed") unless LogStash::PluginManager.installed_plugin?(plugin, gemfile)

--- a/lib/pluginmanager/util.rb
+++ b/lib/pluginmanager/util.rb
@@ -103,6 +103,30 @@ module LogStash::PluginManager
     !!gemfile.find(plugin) && find_plugins_gem_specs(plugin).any?
   end
 
+  # @param spec [Gem::Specification] plugin specification
+  # @return [Boolean] true if the gemspec is from an integration plugin
+  def self.integration_plugin_spec?(spec)
+    spec.metadata &&
+      spec.metadata["logstash_plugin"] == "true" &&
+      spec.metadata["logstash_group"] == "integration"
+  end
+
+  # @param spec [Gem::Specification] plugin specification
+  # @return [Array] array of [plugin name] representing plugins a given integration plugin provides
+  def self.integration_plugin_provides(spec)
+    spec.metadata["integration_plugins"].split(",")
+  end
+
+  # @param name [String] plugin name
+  # @return [Gem::Specification] Gem specification of integration plugin that provides plugin
+  def self.which_integration_plugin_provides(name, gemfile)
+    all_installed_plugins_gem_specs(gemfile) \
+      .select {|spec| integration_plugin_spec?(spec) }
+      .find do |integration_plugin|
+        integration_plugin_provides(integration_plugin).any? {|plugin| plugin == name }
+      end
+  end
+
   # @param plugin_list [Array] array of [plugin name, version] tuples
   # @return [Array] array of [plugin name, version, ...] tuples when duplicate names have been merged and non duplicate version requirements added
   def self.merge_duplicates(plugin_list)

--- a/qa/acceptance/spec/lib/cli_operation_spec.rb
+++ b/qa/acceptance/spec/lib/cli_operation_spec.rb
@@ -7,6 +7,7 @@ require_relative "../shared_examples/cli/logstash-plugin/uninstall"
 require_relative "../shared_examples/cli/logstash-plugin/remove"
 require_relative "../shared_examples/cli/logstash-plugin/update"
 require_relative "../shared_examples/cli/logstash-plugin/generate"
+require_relative "../shared_examples/cli/logstash-plugin/integration_plugin"
 
 # This is the collection of test for the CLI interface, this include the plugin manager behaviour, 
 # it also include the checks for other CLI options.
@@ -20,6 +21,7 @@ describe "CLI operation" do
     it_behaves_like "logstash uninstall", logstash
     it_behaves_like "logstash remove", logstash
     it_behaves_like "logstash update", logstash
+    it_behaves_like "integration plugins compatible", logstash
 #    it_behaves_like "logstash generate", logstash
   end
 end

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/integration_plugin.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/integration_plugin.rb
@@ -1,0 +1,93 @@
+# encoding: utf-8
+require_relative "../../../spec_helper"
+require "logstash/version"
+require "fileutils"
+
+shared_examples "integration plugins compatible" do |logstash|
+  describe "logstash-plugin install on #{logstash.hostname}" do
+    let(:plugin) { "logstash-integration-rabbitmq" }
+    before :each do
+      logstash.install({:version => LOGSTASH_VERSION})
+    end
+
+    after :each do
+      logstash.uninstall
+    end
+
+    context "when the integration is installed" do
+      before(:each) do
+        logstash.run_command_in_path("bin/logstash-plugin install logstash-integration-rabbitmq")
+      end
+      context "trying to install an inner plugin separately" do
+        it "fails to install" do
+          result = logstash.run_command_in_path("bin/logstash-plugin install logstash-input-rabbitmq")
+          expect(result.stderr).to match(/is already provided by/)
+        end
+      end
+    end
+    context "when the integration is not installed" do
+      context "if an inner plugin is installed" do
+        before(:each) do
+          logstash.run_command_in_path("bin/logstash-plugin install logstash-input-rabbitmq")
+        end
+        it "installing the integrations uninstalls the inner plugin" do
+          logstash.run_command_in_path("bin/logstash-plugin install logstash-integration-rabbitmq")
+          result = logstash.run_command_in_path("bin/logstash-plugin list logstash-input-rabbitmq")
+          expect(result.stdout).to_not match(/^logstash-input-rabbitmq/)
+        end
+      end
+    end
+  end
+
+  describe "logstash-plugin uninstall on #{logstash.hostname}" do
+    let(:plugin) { "logstash-integration-rabbitmq" }
+    before :each do
+      logstash.install({:version => LOGSTASH_VERSION})
+    end
+
+    after :each do
+      logstash.uninstall
+    end
+
+    context "when the integration is installed" do
+      before(:each) do
+        logstash.run_command_in_path("bin/logstash-plugin install logstash-integration-rabbitmq")
+      end
+      context "trying to uninstall an inner plugin" do
+        it "fails to uninstall it" do
+          result = logstash.run_command_in_path("bin/logstash-plugin uninstall logstash-input-rabbitmq")
+          expect(result.stderr).to match(/is already provided by/)
+        end
+      end
+    end
+  end
+
+  describe "logstash-plugin list on #{logstash.hostname}" do
+    let(:plugin) { "logstash-integration-rabbitmq" }
+    before :each do
+      logstash.install({:version => LOGSTASH_VERSION})
+    end
+
+    after :each do
+      logstash.uninstall
+    end
+
+    context "when the integration is installed" do
+      before(:each) do
+        logstash.run_command_in_path("bin/logstash-plugin install logstash-integration-rabbitmq")
+      end
+      context "listing an integration" do
+        let(:result) { logstash.run_command_in_path("bin/logstash-plugin list logstash-integration-rabbitmq") }
+        it "shows its inner plugin" do
+          expect(result.stdout).to match(/logstash-input-rabbitmq/m)
+        end
+      end
+      context "listing an inner plugin" do
+        let(:result) { logstash.run_command_in_path("bin/logstash-plugin list logstash-input-rabbitmq") }
+        it "matches the integration that contains it" do
+          expect(result.stdout).to match(/logstash-integration-rabbitmq/m)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [x] List action shows integration and provided plugins
- [x] List action shows integration when searching by inner plugin
- [x] Install action removed plugins provided by integration
- [x] Install action aborts if plugin is provided by an integration
- [x] Remove action aborts if plugin is provided by an integration
- [x] Add acceptance tests

Fixes #9802 

Example situation of installing an integration plugin:

```
% bin/logstash-plugin list --verbose rabbitmq
logstash-input-rabbitmq (6.0.3)
logstash-output-rabbitmq (5.1.1)
% bin/logstash-plugin install logstash-integration-rabbitmq
Validating logstash-integration-rabbitmq
Installing logstash-integration-rabbitmq
Installation successful
Removing 'logstash-input-rabbitmq' since it is provided by an integration plugin
Resolving dependencies...............
Successfully removed logstash-input-rabbitmq
Removing 'logstash-output-rabbitmq' since it is provided by an integration plugin
Resolving dependencies...............
Successfully removed logstash-output-rabbitmq
% bin/logstash-plugin list --verbose rabbitmq
logstash-integration-rabbitmq (1.0.0)
 ├── logstash-input-rabbitmq
 └── logstash-output-rabbitmq
```