### PR TITLE
fix: jruby-openssl conflict after running bin/logstash-plugin update

### DIFF
--- a/Gemfile.jruby-2.3.lock.release
+++ b/Gemfile.jruby-2.3.lock.release
@@ -120,7 +120,7 @@ GEM
       concurrent-ruby
     jmespath (1.4.0)
     jrjackson (0.4.6-java)
-    jruby-openssl (0.10.0-java)
+    jruby-openssl (0.10.1-java)
     jruby-stdin-channel (0.2.0-java)
     json (1.8.6-java)
     json-schema (2.6.2)


### PR DESCRIPTION
From #9816:

> Since the release of `jruby-openssl` `v0.10.1` on 2018-06-22, invocations of `bin/logstash-plugin update` have pulled in an updated `jruby-openssl` dependency, but have failed to update the dependency entry in the lockfile.
> 
> Subsequent invocations of `bin/logstash-plugin` produce an obscure error message, which isn't helpful since our `bin/bundle` executable doesn't replicate the `bundle exec` functionality and users don't necessarily have `bundle` on their paths:
> 
> ~~~
> Gem::LoadError: You have already activated jruby-openssl 0.10.1, but your Gemfile requires jruby-> openssl 0.10.0. Prepending `bundle exec` to your command may solve this.
> ~~~

This patch updates the `jruby-openssl` gem in our release template lockfile to `0.10.1`, the latest available as of this writing, mitigating the issue until the gem is next updated but not solving the underlying problem.