### PR TITLE
[DOCS] Clarify methods for stopping Logstash

### DIFF
--- a/docs/static/shutdown.asciidoc
+++ b/docs/static/shutdown.asciidoc
@@ -1,7 +1,7 @@
 [[shutdown]]
 === Shutting Down Logstash
 
-To shut down Logstash, use one of the following commands:
+If you're running {ls} as a service, use one of the following commands to stop it:
 
 * On systemd, use:
 +
@@ -24,12 +24,16 @@ initctl stop logstash
 /etc/init.d/logstash stop
 ----
 
-* If you have the PID, use:
-+
+If you're running {ls} directory, you can stop it by entering *Ctrl-C* if you’re 
+running {ls} in the console. Alternatively, you can send SIGTERM to the {ls} 
+process on a POSIX system. For example:
+
 [source,shell]
 ----
 kill -TERM {logstash_pid}
 ----
+
+
 
 ==== What Happens During a Controlled Shutdown?
 

--- a/docs/static/shutdown.asciidoc
+++ b/docs/static/shutdown.asciidoc
@@ -24,14 +24,15 @@ initctl stop logstash
 /etc/init.d/logstash stop
 ----
 
-If you're running {ls} directory, you can stop it by entering *Ctrl-C* if you’re 
-running {ls} in the console. Alternatively, you can send SIGTERM to the {ls} 
-process on a POSIX system. For example:
+If you're running {ls} directly in the console on a POSIX system, you can stop 
+it by sending SIGTERM to the {ls} process. For example:
 
 [source,shell]
 ----
 kill -TERM {logstash_pid}
 ----
+
+Alternatively, enter *Ctrl-C* in the console.
 
 
 


### PR DESCRIPTION
I was linking to this page from a Getting Started tutorial in the Stack Overview and I noticed that it didn't mention that you could stop Logstash by using Ctrl-C. 

This PR therefore adds Ctrl-C to the list of methods in shutdown.asciidoc.  It also clarifies that the first options apply only when you're running Logstash as a service. 