### PR TITLE
[DOCS] Removes alternative docker pull example

### DIFF
--- a/docs/static/docker.asciidoc
+++ b/docs/static/docker.asciidoc
@@ -7,17 +7,12 @@ A list of all published Docker images and tags can be found at
 https://www.docker.elastic.co[www.docker.elastic.co]. The source code can be
 found on https://github.com/elastic/logstash-docker/tree/{branch}[GitHub].
 
-==== Image types
-
 These images are free to use under the Elastic license. They contain open source 
 and free commercial features and access to paid commercial features.  
 {xpack-ref}/license-management.html[Start a 30-day trial] to try out all of the 
 paid commercial features. See the 
 https://www.elastic.co/subscriptions[Subscriptions] page for information about 
 Elastic license levels.
-
-Alternatively, you can download `-oss` images, which contain only features that 
-are available under the Apache 2.0 license. 
 
 ==== Pulling the image
 Obtaining Logstash for Docker is as simple as issuing a +docker
@@ -38,6 +33,10 @@ For example, Docker images can be retrieved with the following command:
 --------------------------------------------
 docker pull {docker-image}
 --------------------------------------------
+
+Alternatively, you can download other Docker images that contain only features
+that are available under the Apache 2.0 license. See 
+https://www.docker.elastic.co[www.docker.elastic.co]. 
 
 endif::[]
 

--- a/docs/static/docker.asciidoc
+++ b/docs/static/docker.asciidoc
@@ -27,7 +27,7 @@ endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
 
-For example, Docker images can be retrieved with the following command:
+For example, the Docker image can be retrieved with the following command:
 
 ["source","sh",subs="attributes"]
 --------------------------------------------

--- a/docs/static/docker.asciidoc
+++ b/docs/static/docker.asciidoc
@@ -32,12 +32,11 @@ endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
 
-Docker images can be retrieved with the following commands:
+For example, Docker images can be retrieved with the following command:
 
 ["source","sh",subs="attributes"]
 --------------------------------------------
 docker pull {docker-image}
-docker pull {docker-repo}-oss:{logstash_version}
 --------------------------------------------
 
 endif::[]

--- a/docs/static/docker.asciidoc
+++ b/docs/static/docker.asciidoc
@@ -35,7 +35,7 @@ docker pull {docker-image}
 --------------------------------------------
 
 Alternatively, you can download other Docker images that contain only features
-that are available under the Apache 2.0 license. See 
+that are available under the Apache 2.0 license from 
 https://www.docker.elastic.co[www.docker.elastic.co]. 
 
 endif::[]


### PR DESCRIPTION
This PR removes the alternative "docker pull" command so that the instructions are focused on the default path.

cc'ing @jarpy, who added this information in https://github.com/elastic/logstash/pull/8587

Related to https://github.com/elastic/kibana/pull/20624 and https://github.com/elastic/elasticsearch/pull/31934