### PR TITLE
Backport guava dependency to 6.3

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -120,6 +120,7 @@ dependencies {
     compile 'org.codehaus.janino:janino:3.0.8'
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jacksonVersion}"
     compile "org.jruby:jruby-complete:${jrubyVersion}"
+    compile group: 'com.google.guava', name: 'guava', version: '22.0'
     // Do not upgrade this, later versions require GPL licensed code in javac-shaded that is
     // Apache2 incompatible
     compile 'com.google.googlejavaformat:google-java-format:1.1'


### PR DESCRIPTION
This is a clean backport of #9622 that was intended for the 6.3 branch but not merged into that branch.
