### PR TITLE
Add `sudo` into the rpm import GPG-KEY

### DIFF
--- a/docs/static/getting-started-with-logstash.asciidoc
+++ b/docs/static/getting-started-with-logstash.asciidoc
@@ -172,7 +172,7 @@ Download and install the public signing key:
 
 [source,sh]
 --------------------------------------------------
-rpm --import https://artifacts.elastic.co/GPG-KEY-elasticsearch
+sudo rpm --import https://artifacts.elastic.co/GPG-KEY-elasticsearch
 --------------------------------------------------
 
 Add the following in your `/etc/yum.repos.d/` directory


### PR DESCRIPTION
If not sudo, this happend.

```
$ rpm --import https://artifacts.elastic.co/GPG-KEY-elasticsearch
error: cannot open Packages index using db5 - Permission denied (13)
error: cannot open Packages database in /var/lib/rpm
error: https://artifacts.elastic.co/GPG-KEY-elasticsearch: key 1 import failed.
```

so, we should add sudo at this place.