### PR TITLE
Apache pipeline - Wrong message parsing if body_sent is not set

### DIFF
--- a/docs/static/filebeat_modules/apache2/pipeline.conf
+++ b/docs/static/filebeat_modules/apache2/pipeline.conf
@@ -8,7 +8,7 @@ filter {
   if [fileset][module] == "apache2" {
     if [fileset][name] == "access" {
       grok {
-        match => { "message" => ["%{IPORHOST:[apache2][access][remote_ip]} - %{DATA:[apache2][access][user_name]} \[%{HTTPDATE:[apache2][access][time]}\] \"%{WORD:[apache2][access][method]} %{DATA:[apache2][access][url]} HTTP/%{NUMBER:[apache2][access][http_version]}\" %{NUMBER:[apache2][access][response_code]} %{NUMBER:[apache2][access][body_sent][bytes]}( \"%{DATA:[apache2][access][referrer]}\")?( \"%{DATA:[apache2][access][agent]}\")?",
+        match => { "message" => ["%{IPORHOST:[apache2][access][remote_ip]} - %{DATA:[apache2][access][user_name]} \[%{HTTPDATE:[apache2][access][time]}\] \"%{WORD:[apache2][access][method]} %{DATA:[apache2][access][url]} HTTP/%{NUMBER:[apache2][access][http_version]}\" %{NUMBER:[apache2][access][response_code]} ((%{NUMBER:[apache2][access][body_sent][bytes]})|-)( \"%{DATA:[apache2][access][referrer]}\")?( \"%{DATA:[apache2][access][agent]}\")?",
           "%{IPORHOST:[apache2][access][remote_ip]} - %{DATA:[apache2][access][user_name]} \\[%{HTTPDATE:[apache2][access][time]}\\] \"-\" %{NUMBER:[apache2][access][response_code]} -" ] }
         remove_field => "message"
       }


### PR DESCRIPTION
Apache can output log messages without body sent. If body sent isn't set, character "-" is provided in message and therefore message isn't parsed correctly.
Tested on Apache 2.4 with default "LogFormat" directive .

Documentation: 
http://httpd.apache.org/docs/current/mod/mod_log_config.html#formats
see. "%b - Size of response in bytes, excluding HTTP headers. In CLF format, i.e. a '-' rather than a 0 when no bytes are sent."