### PR TITLE
docs index file renamed to docs/index.asciidoc

### DIFF
--- a/rakelib/version.rake
+++ b/rakelib/version.rake
@@ -2,7 +2,7 @@ require 'yaml'
 
 VERSION_FILE = "versions.yml"
 README_FILE = "README.md"
-INDEX_SHARED1_FILE = "docs/index-shared1.asciidoc"
+INDEX_SHARED1_FILE = "docs/index.asciidoc"
 
 def get_versions
   yaml_versions = YAML.safe_load(IO.read(VERSION_FILE))


### PR DESCRIPTION
the `docs/` index file has been renamed from `index-shared1.asciidoc` to `index.asciidoc` in 6.3+ 

This should be merged in 6.x and master.