### PR TITLE
FieldReference: add formal grammar definition docs

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -107,6 +107,9 @@ include::static/upgrading.asciidoc[]
 :edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/configuration.asciidoc
 include::static/configuration.asciidoc[]
 
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/field-reference.asciidoc
+include::static/field-reference.asciidoc[]
+
 :edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/multiple-pipelines.asciidoc
 include::static/multiple-pipelines.asciidoc[]
 

--- a/docs/static/configuration.asciidoc
+++ b/docs/static/configuration.asciidoc
@@ -319,9 +319,9 @@ will not work in an input block.
 ==== Field References
 
 It is often useful to be able to refer to a field by name. To do this,
-you can use the Logstash field reference syntax.
+you can use the Logstash <<field-references,field reference syntax>>.
 
-The syntax to access a field is `[fieldname]`. If you are referring to a
+The basic syntax to access a field is `[fieldname]`. If you are referring to a
 **top-level field**, you can omit the `[]` and simply use `fieldname`.
 To refer to a **nested field**, you specify
 the full path to that field: `[top-level field][nested field]`.

--- a/docs/static/event-api.asciidoc
+++ b/docs/static/event-api.asciidoc
@@ -35,7 +35,7 @@ The getter is a read-only access of field-based data in an Event.
 numeric or timestamp scalar value.
 
 `field` is a structured field sent to Logstash or created after the transformation process. `field` can also 
-be a nested field reference such as `[field][bar]`.
+be a nested <<field-references,field reference>> such as `[field][bar]`.
 
 Examples:
 

--- a/docs/static/field-reference.asciidoc
+++ b/docs/static/field-reference.asciidoc
@@ -1,0 +1,122 @@
+[[field-references]]
+== Field References
+
+It is often useful to be able to refer to a field or collection of fields by name. To do this,
+you can use the Logstash field reference syntax.
+
+The syntax to access a field specifies the entire path to the field, with each fragment wrapped in square brackets.
+
+_Field References_ can be expressed literally within <<conditionals,_Conditional_>> statements in your pipeline configurations,
+as string arguments to your pipeline plugins, or within sprintf statements that will be used by your pipeline plugins:
+
+[source,pipelineconf]
+filter {
+  #  +----literal----+     +----literal----+
+  #  |               |     |               |
+  if [@metadata][date] and [@metadata][time] {
+    mutate {
+      add_field {
+        "[@metadata][timestamp]" => "%{[@metadata][date]} %{[@metadata][time]}"
+      # |                      |    |  |               |    |               | |
+      # +----string-argument---+    |  +--field-ref----+    +--field-ref----+ |
+      #                             +-------- sprintf format string ----------+
+      }
+    }
+  }
+}
+
+[[formal-grammar]]
+=== Formal Grammar
+
+Below is the formal grammar of the Field Reference, with notes and examples.
+
+[[formal-grammar-field-reference-literal]]
+==== Field Reference Literal
+
+A _Field Reference Literal_ is a sequence of one or more _Path Fragments_ that can be used directly in Logstash pipeline <<conditionals,conditionals>> without any additional quoting (e.g. `[request]`, `[response][status]`).
+
+[source,antlr]
+fieldReferenceLiteral
+  : ( pathFragment )+
+  ;
+
+[[formal-grammar-field-reference]]
+==== Field Reference (Event APIs)
+
+The Event API's methods for manipulating the fields of an event or using the sprintf syntax are more flexible than the pipeline grammar in what they accept as a Field Reference.
+Top-level fields can be referenced directly by their _Field Name_ without the square brackets, and there is some support for _Composite Field References_, simplifying use of programmatically-generated Field References.
+
+A _Field Reference_ for use with the Event API is therefore one of:
+
+ - a single _Field Reference Literal_; OR
+ - a single _Field Name_ (referencing a top-level field); OR
+ - a single _Composite Field Reference_.
+
+[source,antlr]
+eventApiFieldReference
+  : fieldReferenceLiteral
+  | fieldName
+  | compositeFieldReference
+  ;
+
+[[formal-grammar-path-fragment]]
+==== Path Fragment
+
+A _Path Fragment_ is a _Field Name_ wrapped in square brackets (e.g., `[request]`).
+
+[source,antlr]
+pathFragment
+  : '[' fieldName ']'
+  ;
+
+[[formal-grammar-field-name]]
+==== Field Name
+
+A _Field Name_ is a sequence of characters that are _not_ square brackets (`[` or `]`).
+
+[source,antlr]
+fieldName
+  : ( ~( '[' | ']' ) )+
+  ;
+
+[[formal-grammar-event-api-composite-field-reference]]
+==== Composite Field Reference
+
+In some cases, it may be necessary to programmatically _compose_ a Field Reference from one or more Field References,
+such as when manipulating fields in a plugin or while using the Ruby Filter plugin and the Event API.
+
+[source,ruby]
+    fieldReference = "[path][to][deep nested field]"
+    compositeFieldReference = "[@metadata][#{fieldReference}][size]"
+    # => "[@metadata][[path][to][deep nested field]][size]"
+
+// NOTE: table below uses "plus for passthrough" quoting to prevent double square-brackets
+//       from being interpreted as asciidoc anchors when converted to HTML.
+.Canonical Representations of Composite Field References
+|===
+| Acceptable _Composite Field Reference_ | Canonical _Field Reference_ Representation
+
+| `+[[deep][nesting]][field]+`           | `+[deep][nesting][field]+`
+| `+[foo][[bar]][bingo]+`                | `+[foo][bar][bingo]+`
+| `+[[ok]]+`                             | `+[ok]+`
+|===
+
+A _Composite Field Reference_ is a sequence of one or more _Path Fragments_ or _Embedded Field References_.
+
+[source,antlr]
+compositeFieldReference
+  : ( pathFragment | embeddedFieldReference )+
+  ;
+
+_Composite Field References_ are supported by the Event API, but are _not_ supported as literals in the Pipeline Configuration.
+
+[[formal-grammar-event-api-embedded-field-reference]]
+==== Embedded Field Reference
+
+[source,antlr]
+embeddedFieldReference
+  : '[' fieldReference ']'
+  ;
+
+An _Embedded Field Reference_ is a _Field Reference_ that is itself wrapped in square brackets (`[` and `]`), and can be a component of a _Composite Field Reference_.
+


### PR DESCRIPTION
These are the docs extracted from #9543 and define the formal grammar that is implemented by strict-mode FieldReference parsing. It should be back-ported to 6.4 and 6.x.

## Background:

As initially implemented, the field reference syntax was only loosely defined in docs, and was coupled with a parser that silently did very unexpected things when encountering syntax that wasn't in the spirit of the documentation. To address this, we did several things:
 - in `6.3.x`, fix a bug on a specific set of bad inputs that could cause Logstash to crash; in these cases we reject input.
 - in `6.4`, add an opt-in strict mode that rejects invalid input; when using the normal *compat*-mode parser, _warn_ the user when input wouldn't pass the strict-mode but use the result from the old lenient parser.
- in `7.x`, the parser is _always_ strict and _only_ accepts input that is legal in the formal grammar.

The formal grammar defined in this PR is valid for _all_ branches, whether or not Logstash is configured to operate in *strict*-mode. The difference is that *compat*- and *legacy*-modes will _accept_ additional input that is outside of the formal grammar (and in these cases, the behaviour of inputs that do _not_ pass this formal grammar is undefined).
