### PR TITLE
support port customization in cloud id

### DIFF
--- a/logstash-core/lib/logstash/util/cloud_setting_id.rb
+++ b/logstash-core/lib/logstash/util/cloud_setting_id.rb
@@ -7,9 +7,11 @@ module LogStash module Util class CloudSettingId
     Base64.urlsafe_encode64(args.join("$"))
   end
   DOT_SEPARATOR = "."
-  CLOUD_PORT = ":443"
+  CLOUD_PORT = "443"
 
-  attr_reader :original, :decoded, :label, :elasticsearch_host, :elasticsearch_scheme, :kibana_host, :kibana_scheme
+  attr_reader :original, :decoded, :label
+  attr_reader :elasticsearch_host, :elasticsearch_scheme, :elasticsearch_port
+  attr_reader :kibana_host, :kibana_scheme, :kibana_port
 
   # The constructor is expecting a 'cloud.id', a string in 2 variants.
   # 1 part example: 'dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRub3RhcmVhbCRpZGVudGlmaWVy'
@@ -48,20 +50,29 @@ module LogStash module Util class CloudSettingId
       raise ArgumentError.new("Cloud Id, after decoding, is invalid. Format: '<segment1>$<segment2>$<segment3>'. Received: \"#{@decoded}\".")
     end
     cloud_base = segments.shift
-    cloud_host = "#{DOT_SEPARATOR}#{cloud_base}#{CLOUD_PORT}"
+    cloud_host = "#{DOT_SEPARATOR}#{cloud_base}"
+    cloud_host, cloud_port = cloud_host.split(":")
+    cloud_port ||= CLOUD_PORT
 
     @elasticsearch_host, @kibana_host = segments
+    @elasticsearch_host, @elasticsearch_port = @elasticsearch_host.split(":")
+    @kibana_host, @kibana_port = @kibana_host.split(":")
+    @elasticsearch_port ||= cloud_port
+    @kibana_port ||= cloud_port
+
     if @elasticsearch_host == "undefined"
       raise ArgumentError.new("Cloud Id, after decoding, elasticsearch segment is 'undefined', literally.")
     end
     @elasticsearch_scheme = "https"
     @elasticsearch_host.concat(cloud_host)
+    @elasticsearch_host.concat(":#{@elasticsearch_port}")
 
     if @kibana_host == "undefined"
       raise ArgumentError.new("Cloud Id, after decoding, the kibana segment is 'undefined', literally. You may need to enable Kibana in the Cloud UI.")
     end
     @kibana_scheme = "https"
     @kibana_host.concat(cloud_host)
+    @kibana_host.concat(":#{@kibana_port}")
   end
 
   def to_s

--- a/logstash-core/spec/logstash/util/cloud_setting_id_spec.rb
+++ b/logstash-core/spec/logstash/util/cloud_setting_id_spec.rb
@@ -90,4 +90,44 @@ describe LogStash::Util::CloudSettingId do
       expect(subject.to_s).to eq(subject.decoded)
     end
   end
+  context "when cloud id contains port descriptions for ES and Kibana" do
+    let(:input) { "different-es-kb-port:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJGFjMzFlYmI5MDI0MTc3MzE1NzA0M2MzNGZkMjZmZDQ2OjkyNDMkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA6OTI0NA==" }
+
+    it "decodes the elasticsearch port corretly" do
+      expect(subject.elasticsearch_host).to eq("ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:9243")
+    end
+    it "decodes the kibana port corretly" do
+      expect(subject.kibana_host).to eq("a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9244")
+    end
+  end
+  context "when cloud id contains cloud port" do
+    let(:input) { "custom-port:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvOjkyNDMkYWMzMWViYjkwMjQxNzczMTU3MDQzYzM0ZmQyNmZkNDYkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA=" }
+
+    it "decodes the elasticsearch port corretly" do
+      expect(subject.elasticsearch_host).to eq("ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:9243")
+    end
+    it "decodes the kibana port corretly" do
+      expect(subject.kibana_host).to eq("a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9243")
+    end
+  end
+  context "when cloud id only defines kibana port" do
+    let(:input) { "only-kb-set:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJGFjMzFlYmI5MDI0MTc3MzE1NzA0M2MzNGZkMjZmZDQ2JGE0YzA2MjMwZTQ4YzhmY2U3YmU4OGEwNzRhM2JiM2UwOjkyNDQ=" }
+
+    it "defaults the elasticsearch port to 443" do
+      expect(subject.elasticsearch_host).to eq("ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:443")
+    end
+    it "decodes the kibana port corretly" do
+      expect(subject.kibana_host).to eq("a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9244")
+    end
+  end
+  context "when cloud id defines cloud port and kibana port" do
+    let(:input) { "host-and-kb-set:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvOjkyNDMkYWMzMWViYjkwMjQxNzczMTU3MDQzYzM0ZmQyNmZkNDYkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA6OTI0NA==" }
+
+    it "sets the elasticsearch port to cloud port" do
+      expect(subject.elasticsearch_host).to eq("ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:9243")
+    end
+    it "overrides cloud port with the kibana port" do
+      expect(subject.kibana_host).to eq("a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9244")
+    end
+  end
 end


### PR DESCRIPTION
this uses the same test suite as beats: https://github.com/elastic/beats/pull/7887/files#diff-a16426b789d5647f0fbf7342204f8403R55

solves #9870