### PR TITLE
fix ArrayIndexOutOfBoundsException from empty String field reference

### DIFF
--- a/logstash-core/src/main/java/org/logstash/FieldReference.java
+++ b/logstash-core/src/main/java/org/logstash/FieldReference.java
@@ -43,6 +43,9 @@ public final class FieldReference {
     private static final FieldReference METADATA_PARENT_REFERENCE =
         new FieldReference(EMPTY_STRING_ARRAY, Event.METADATA, META_PARENT);
 
+    static final FieldReference DATA_EMPTY_STRING_REFERENCE =
+            new FieldReference(EMPTY_STRING_ARRAY, "", DATA_CHILD);
+
     private final String[] path;
 
     private final String key;
@@ -63,6 +66,9 @@ public final class FieldReference {
     }
 
     public static FieldReference parse(final CharSequence reference) {
+        if( reference == null || reference.length() == 0){
+            return DATA_EMPTY_STRING_REFERENCE;
+        }
         final String[] parts = SPLIT_PATTERN.split(reference);
         final List<String> path = new ArrayList<>(parts.length);
         for (final String part : parts) {

--- a/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
+++ b/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
@@ -40,4 +40,14 @@ public final class FieldReferenceTest {
     public void deduplicatesTimestamp() throws Exception {
         assertTrue(FieldReference.parse("@timestamp") == FieldReference.parse("[@timestamp]"));
     }
+
+    @Test
+    public void testParseEmptyString(){
+        assertEquals(FieldReference.parse(""), FieldReference.DATA_EMPTY_STRING_REFERENCE);
+    }
+
+    @Test
+    public void testParseNull(){
+        assertEquals(FieldReference.parse(null), FieldReference.DATA_EMPTY_STRING_REFERENCE);
+    }
 }


### PR DESCRIPTION
Backport of #8823 for 5.6 (1f7116a461d2df51284e4e6e445e241704b1c5b2)

Attempting to get this in before the 2018-08-14 feature freeze for the 5.6.11 release.