### PR TITLE
support more than 3 identifiers in cloud id

### DIFF
--- a/logstash-core/lib/logstash/util/cloud_setting_id.rb
+++ b/logstash-core/lib/logstash/util/cloud_setting_id.rb
@@ -12,6 +12,7 @@ module LogStash module Util class CloudSettingId
   attr_reader :original, :decoded, :label
   attr_reader :elasticsearch_host, :elasticsearch_scheme, :elasticsearch_port
   attr_reader :kibana_host, :kibana_scheme, :kibana_port
+  attr_reader :other_identifiers
 
   # The constructor is expecting a 'cloud.id', a string in 2 variants.
   # 1 part example: 'dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRub3RhcmVhbCRpZGVudGlmaWVy'
@@ -41,8 +42,8 @@ module LogStash module Util class CloudSettingId
 
     @decoded = @decoded.encode(Encoding::UTF_8, :invalid => :replace, :undef => :replace)
 
-    unless @decoded.count("$") == 2
-      raise ArgumentError.new("Cloud Id does not decode. You may need to enable Kibana in the Cloud UI. Received: \"#{@decoded}\".")
+    if @decoded.count("$") < 2
+      raise ArgumentError.new("Cloud Id, after decoding, is invalid. Format: '<segment1>$<segment2>$<segment3>'. Received: \"#{@decoded}\".")
     end
 
     segments = @decoded.split("$")
@@ -54,11 +55,12 @@ module LogStash module Util class CloudSettingId
     cloud_host, cloud_port = cloud_host.split(":")
     cloud_port ||= CLOUD_PORT
 
-    @elasticsearch_host, @kibana_host = segments
+    @elasticsearch_host, @kibana_host, *@other_identifiers = segments
     @elasticsearch_host, @elasticsearch_port = @elasticsearch_host.split(":")
     @kibana_host, @kibana_port = @kibana_host.split(":")
     @elasticsearch_port ||= cloud_port
     @kibana_port ||= cloud_port
+    @other_identifiers ||= []
 
     if @elasticsearch_host == "undefined"
       raise ArgumentError.new("Cloud Id, after decoding, elasticsearch segment is 'undefined', literally.")

--- a/logstash-core/spec/logstash/settings/modules_spec.rb
+++ b/logstash-core/spec/logstash/settings/modules_spec.rb
@@ -34,19 +34,19 @@ describe LogStash::Setting::Modules do
     subject { described_class.new("mycloudid", LogStash::Util::CloudSettingId) }
     context "when given a string which is not a cloud id" do
       it "should raise an exception" do
-        expect { subject.set("foobarbaz") }.to raise_error(ArgumentError, /Cloud Id does not decode/)
+        expect { subject.set("foobarbaz") }.to raise_error(ArgumentError, /Cloud Id.*is invalid/)
       end
     end
 
     context "when given a string which is empty" do
       it "should raise an exception" do
-        expect { subject.set("") }.to raise_error(ArgumentError, /Cloud Id does not decode/)
+        expect { subject.set("") }.to raise_error(ArgumentError, /Cloud Id.*is invalid/)
       end
     end
 
     context "when given a string which is has environment prefix only" do
       it "should raise an exception" do
-        expect { subject.set("testing:") }.to raise_error(ArgumentError, /Cloud Id does not decode/)
+        expect { subject.set("testing:") }.to raise_error(ArgumentError, /Cloud Id.*is invalid/)
       end
     end
 

--- a/logstash-core/spec/logstash/util/cloud_setting_id_spec.rb
+++ b/logstash-core/spec/logstash/util/cloud_setting_id_spec.rb
@@ -25,7 +25,7 @@ describe LogStash::Util::CloudSettingId do
       let(:raw) {%w(first second)}
       let(:input) { described_class.cloud_id_encode(*raw) }
       it "raises an error" do
-        expect{subject}.to raise_exception(ArgumentError, "Cloud Id does not decode. You may need to enable Kibana in the Cloud UI. Received: \"#{raw[0]}$#{raw[1]}\".")
+        expect{subject}.to raise_exception(ArgumentError, "Cloud Id, after decoding, is invalid. Format: '<segment1>$<segment2>$<segment3>'. Received: \"#{raw[0]}$#{raw[1]}\".")
       end
     end
 
@@ -128,6 +128,19 @@ describe LogStash::Util::CloudSettingId do
     end
     it "overrides cloud port with the kibana port" do
       expect(subject.kibana_host).to eq("a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9244")
+    end
+  end
+  context "when cloud id defines extra data" do
+    let(:input) { "extra-items:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJGFjMzFlYmI5MDI0MTc3MzE1NzA0M2MzNGZkMjZmZDQ2JGE0YzA2MjMwZTQ4YzhmY2U3YmU4OGEwNzRhM2JiM2UwJGFub3RoZXJpZCRhbmRhbm90aGVy" }
+
+    it "captures the elasticsearch host" do
+      expect(subject.elasticsearch_host).to eq("ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:443")
+    end
+    it "captures the kibana host" do
+      expect(subject.kibana_host).to eq("a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:443")
+    end
+    it "captures the remaining identifiers" do
+      expect(subject.other_identifiers).to eq(["anotherid", "andanother"])
     end
   end
 end


### PR DESCRIPTION
This PR adds a similar [behaviour as beats](https://github.com/elastic/beats/pull/7916) for handling cloud ids that have more than 3 identifiers.