### PR TITLE
stop gradle from deleting NOTICE.TXT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,6 @@ clean {
   delete "${projectDir}/Gemfile"
   delete "${projectDir}/Gemfile.lock"
   delete "${projectDir}/vendor"
-  delete "${projectDir}/NOTICE.TXT"
   delete "${projectDir}/.bundle"
   delete "${projectDir}/qa/integration/Gemfile.lock"
   delete "${projectDir}/qa/integration/.bundle"


### PR DESCRIPTION
this is a follow up to https://github.com/elastic/logstash/pull/9886 that adds a manually constructed NOTICE.TXT

this fixes build failures such as https://logstash-ci.elastic.co/job/elastic+logstash+6.4+multijob-integration-1/7/console