### PR TITLE
License checker handles dependencies with multiple licenses

### DIFF
--- a/tools/dependencies-report/src/main/java/org/logstash/dependencies/ReportGenerator.java
+++ b/tools/dependencies-report/src/main/java/org/logstash/dependencies/ReportGenerator.java
@@ -141,8 +141,16 @@ public class ReportGenerator {
         if (licenseMapping.containsKey(nameAndVersion)) {
             LicenseUrlPair pair = licenseMapping.get(nameAndVersion);
 
-            if (pair.url != null && !pair.url.equals("") &&
-               (acceptableLicenses.stream().anyMatch(pair.license::equalsIgnoreCase))) {
+            String[] dependencyLicenses = pair.license.split("\\|");
+            boolean hasAcceptableLicense = false;
+            for (int k = 0; k < dependencyLicenses.length && !hasAcceptableLicense; k++) {
+                if (pair.url != null && !pair.url.equals("") &&
+                   (acceptableLicenses.stream().anyMatch(dependencyLicenses[k]::equalsIgnoreCase))) {
+                    hasAcceptableLicense = true;
+                }
+            }
+
+            if (hasAcceptableLicense) {
                 dependency.spdxLicense = pair.license;
                 dependency.url = pair.url;
             } else {

--- a/tools/dependencies-report/src/main/java/org/logstash/dependencies/ReportGenerator.java
+++ b/tools/dependencies-report/src/main/java/org/logstash/dependencies/ReportGenerator.java
@@ -143,10 +143,11 @@ public class ReportGenerator {
 
             String[] dependencyLicenses = pair.license.split("\\|");
             boolean hasAcceptableLicense = false;
-            for (int k = 0; k < dependencyLicenses.length && !hasAcceptableLicense; k++) {
-                if (pair.url != null && !pair.url.equals("") &&
-                   (acceptableLicenses.stream().anyMatch(dependencyLicenses[k]::equalsIgnoreCase))) {
-                    hasAcceptableLicense = true;
+            if (pair.url != null && !pair.url.equals("")) {
+                for (int k = 0; k < dependencyLicenses.length && !hasAcceptableLicense; k++) {
+                    if (acceptableLicenses.stream().anyMatch(dependencyLicenses[k]::equalsIgnoreCase)) {
+                        hasAcceptableLicense = true;
+                    }
                 }
             }
 

--- a/tools/dependencies-report/src/test/resources/expectedOutput.txt
+++ b/tools/dependencies-report/src/test/resources/expectedOutput.txt
@@ -1,5 +1,5 @@
 name,version,revision,url,license,copyright
-bundler,1.16.0,,https://rubygems.org/gems/bundler/versions/1.16.0,MIT,
+bundler,1.16.0,,https://rubygems.org/gems/bundler/versions/1.16.0,UnacceptableLicense|MIT,
 bundler,1.16.1,,https://rubygems.org/gems/bundler/versions/1.16.1,MIT,
 com.fasterxml.jackson.core:jackson-core,2.7.3,,https://github.com/FasterXML/jackson-core/tree/jackson-core-2.7.3,Apache-2.0,
 com.fasterxml.jackson.core:jackson-core,2.9.1,,https://github.com/FasterXML/jackson-core/tree/jackson-core-2.9.1,Apache-2.0,

--- a/tools/dependencies-report/src/test/resources/licenseMapping-good.csv
+++ b/tools/dependencies-report/src/test/resources/licenseMapping-good.csv
@@ -1,6 +1,6 @@
 dependency,dependencyUrl,licenseOverride
 "webrick:1.3.1",,BSD-2-Clause-FreeBSD
-"bundler:1.16.0",https://rubygems.org/gems/bundler/versions/1.16.0,MIT
+"bundler:1.16.0",https://rubygems.org/gems/bundler/versions/1.16.0,UnacceptableLicense|MIT
 "webhdfs:0.8.0",,Apache-2.0
 "avl_tree:1.2.1",,BSD-2-Clause-FreeBSD
 "filesize:0.0.4",https://rubygems.org/gems/filesize/versions/0.0.4,MIT


### PR DESCRIPTION
Some dependencies may be licensed under multiple licenses. For example, minitar is licensed under both the Ruby and BSD licenses which may be specified in the license mapping file by including both licenses separated by the pipe character: `Ruby|BSD-2-Clause`. The license checker now recognizes that convention and permits a dependency so long as at least one of its licenses is contained in our list of acceptable licenses.