### PR TITLE
Update logstash.bat to enable CLASSPATH with spaces

### DIFF
--- a/bin/logstash.bat
+++ b/bin/logstash.bat
@@ -52,7 +52,7 @@ for %%i in ("%LS_HOME%\logstash-core\lib\jars\*.jar") do (
 	call :concat "%%i"
 )
 
-%JAVA% %JAVA_OPTS% -cp %CLASSPATH% org.logstash.Logstash %*
+%JAVA% %JAVA_OPTS% -cp "%CLASSPATH%" org.logstash.Logstash %*
 
 goto :end
 


### PR DESCRIPTION
I wanted to run logstash on Windows 10 with the command ```bin/logstash -e 'input { stdin { } } output { stdout {} }'```, which resulted in: ```Error: Could not find or load main class Files\Java\jdk1.8.0_172 org.logstash.Logstash -e input```

I had C:\Program Files\Java\jdk1.8.0_172 (with whitespaces) as part of my classpath, which caused this error. After adding " arround %CLASSPATH% it worked fine for me