### PR TITLE
Safely invoke Kernel#system in build

### DIFF
--- a/rakelib/compile.rake
+++ b/rakelib/compile.rake
@@ -11,9 +11,16 @@ namespace "compile" do
 
   task "grammar" => "logstash-core/lib/logstash/config/grammar.rb"
 
+  def safe_system(*args)
+    if !system(*args)
+      status = $?
+      raise "Got exit status #{status.exitstatus} attempting to execute #{args.inspect}!"
+    end
+  end
+
   task "logstash-core-java" do
     puts("Building logstash-core using gradle")
-    system("./gradlew", "assemble")
+    safe_system("./gradlew", "assemble")
   end
 
   desc "Build everything"


### PR DESCRIPTION
A failing call to system will not fail rake. So we have to inspect the return value and fail the build ourselves if a call to Kernel#system fails. This commit backports the same logic from master to 5.6.