### PR TITLE
Clarify monitoring and monitoring.collection

### DIFF
--- a/docs/static/monitoring/configuring-logstash.asciidoc
+++ b/docs/static/monitoring/configuring-logstash.asciidoc
@@ -20,26 +20,32 @@ monitoring cluster will show the Logstash metrics under the _monitoring_ cluster
 
 . Verify that the `xpack.monitoring.collection.enabled` setting is `true` on the
 production cluster. If that setting is `false`, the collection of monitoring data
-is disabled in {es} and data is ignored from all other sources.
+is disabled in {es} and data is ignored from all other sources. 
 
-. Configure your Logstash nodes to send metrics by setting the
-`xpack.monitoring.elasticsearch.url` in `logstash.yml`. If {security} is enabled,
-you also need to specify the credentials for the 
-{stack-ov}/built-in-users.html[built-in `logstash_system` user]. For more information about these settings, see <<monitoring-settings>>.
+. Configure your Logstash nodes to send metrics. 
+Set `xpack.monitoring.enabled` to `true` and set the
+`xpack.monitoring.elasticsearch.url` in `logstash.yml`. If {security} is
+enabled, you also need to specify the credentials for the
+{stack-ov}/built-in-users.html[built-in `logstash_system` user]. For more
+information about these settings, see <<monitoring-settings>>.
 +
 --
 [source,yaml]
 --------------------------------------------------
-xpack.monitoring.elasticsearch.url: ["http://es-prod-node-1:9200", "http://es-prod-node-2:9200"] <1>
-xpack.monitoring.elasticsearch.username: "logstash_system" <2>
+xpack.monitoring.enabled: true <1>
+xpack.monitoring.elasticsearch.url: ["http://es-prod-node-1:9200", "http://es-prod-node-2:9200"] <2>
+xpack.monitoring.elasticsearch.username: "logstash_system" <3>
 xpack.monitoring.elasticsearch.password: "changeme"
 --------------------------------------------------
-<1> If SSL/TLS is enabled on the production cluster, you must
+<1> Turns monitoring on. Note that the
+Elasticsearch `xpack.monitoring.collection.enabled: true` setting in the previous
+step is needed to start data collection.
+<2> If SSL/TLS is enabled on the production cluster, you must
 connect through HTTPS. As of v5.2.1, you can specify multiple
 Elasticsearch hosts as an array as well as specifying a single
 host as a string. If multiple URLs are specified, Logstash
 can round-robin requests to these production nodes.
-<2> If {security} is disabled on the production cluster, you can omit these 
+<3> If {security} is disabled on the production cluster, you can omit these 
 `username` and `password` settings. 
 --
 


### PR DESCRIPTION
State that both `xpack.monitoring.enabled` in Logstash config and `xpack.monitoring.collection.enabled` in Elasticsearch config are needed. 