### PR TITLE
disable frequently failing test concurrentWritesTest

### DIFF
--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
@@ -683,6 +683,7 @@ public class QueueTest {
         }
     }
 
+    @Ignore("This test frequently times out on Windows and Linux. Issue: https://github.com/elastic/logstash/issues/9878")
     @Test(timeout = 50_000)
     public void concurrentWritesTest() throws IOException, InterruptedException, ExecutionException {
 

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
@@ -22,6 +22,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.Ignore;
 import org.junit.rules.TemporaryFolder;
 import org.logstash.ackedqueue.io.MmapPageIOV2;
 


### PR DESCRIPTION
CI Failure: https://logstash-ci.elastic.co/job/elastic+logstash+master+multijob-windows-compatibility/lastBuild/console

This also failed in 6.x: https://logstash-ci.elastic.co/job/elastic+logstash+6.x+multijob-unix-compatibility/os=ubuntu/8/console