### PR TITLE
disable reachMaxUnread [6.x]

### DIFF
--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
@@ -22,6 +22,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.Ignore;
 import org.junit.rules.TemporaryFolder;
 import org.logstash.ackedqueue.io.MmapPageIOV2;
 

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
@@ -396,6 +396,7 @@ public class QueueTest {
         }
     }
 
+    @Ignore("This test timed out on Linux. Issue: https://github.com/elastic/logstash/issues/9910")
     @Test(timeout = 50_000)
     public void reachMaxUnread() throws IOException, InterruptedException, ExecutionException {
         Queueable element = new StringElement("foobarbaz");


### PR DESCRIPTION
CI failure: https://logstash-ci.elastic.co/job/elastic+logstash+6.x+multijob-unix-compatibility/os=ubuntu/8/console

This also fails on master: https://logstash-ci.elastic.co/job/elastic+logstash+master+multijob-unix-compatibility/os=ubuntu/17/console