### PR TITLE
replace non ascii character failing javadoc compilation

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/RecordIOWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/RecordIOWriter.java
@@ -36,7 +36,7 @@ import static org.logstash.common.io.RecordType.START;
 /**
  *
  * File Format
- * | — magic number (4bytes) --|
+ * | - magic number (4bytes) --|
  *
  * [  32kbyte block....
  *    --- 1 byte RecordHeader Type ---


### PR DESCRIPTION
this is currently causing ci failures:

```
11:48:05 :logstash-core:javadoc/opt/logstash/logstash-core/src/main/java/org/logstash/common/io/RecordIOWriter.java:39: error: unmappable character for encoding ASCII
11:48:05  * | ??? magic number (4bytes) --|
11:48:05      ^
11:48:05 /opt/logstash/logstash-core/src/main/java/org/logstash/common/io/RecordIOWriter.java:39: error: unmappable character for encoding ASCII
11:48:05  * | ??? magic number (4bytes) --|
11:48:05       ^
```

example of failed job: https://logstash-ci.elastic.co/job/elastic+logstash+5.6+multijob--ruby-unit-tests/lastBuild/console