### PR TITLE
License checker reports unused dependencies

### DIFF
--- a/tools/dependencies-report/src/main/java/org/logstash/dependencies/Main.java
+++ b/tools/dependencies-report/src/main/java/org/logstash/dependencies/Main.java
@@ -4,6 +4,7 @@ import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -32,6 +33,7 @@ public class Main {
         }
         FileWriter licenseCSVWriter = new FileWriter(args[2]);
         FileWriter noticeWriter = new FileWriter(args[3]);
+        StringWriter unusedLicenseWriter = new StringWriter();
 
         boolean reportResult = new ReportGenerator().generateReport(
                 getResourceAsStream(LICENSE_MAPPING_PATH),
@@ -39,12 +41,12 @@ public class Main {
                 rubyDependenciesStream,
                 javaDependenciesStreams,
                 licenseCSVWriter,
-                noticeWriter
+                noticeWriter,
+                unusedLicenseWriter
         );
 
         // If there were unknown results in the report, exit with a non-zero status
-        //System.exit(reportResult ? 0 : 1);
-
+        System.exit(reportResult ? 0 : 1);
     }
 
     static InputStream getResourceAsStream(String resourcePath) {

--- a/tools/dependencies-report/src/main/java/org/logstash/dependencies/ReportGenerator.java
+++ b/tools/dependencies-report/src/main/java/org/logstash/dependencies/ReportGenerator.java
@@ -9,9 +9,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.Writer;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -31,23 +28,26 @@ import java.util.TreeSet;
 public class ReportGenerator {
 
     final String UNKNOWN_LICENSE = "UNKNOWN";
-    final Collection<Dependency> UNKNOWN_LICENSES = new ArrayList<Dependency>();
+    final Collection<Dependency> UNKNOWN_LICENSES = new ArrayList<>();
     final String[] CSV_HEADERS = {"name", "version", "revision", "url", "license", "copyright"};
-    public final Collection<Dependency> MISSING_NOTICE = new ArrayList<Dependency>();
+    final Collection<Dependency> MISSING_NOTICE = new ArrayList<>();
+    final HashMap<Dependency, Boolean> UNUSED_DEPENDENCIES = new HashMap<>();
 
-    public boolean generateReport(
+    boolean generateReport(
             InputStream licenseMappingStream,
             InputStream acceptableLicensesStream,
             InputStream rubyDependenciesStream,
             InputStream[] javaDependenciesStreams,
             Writer licenseOutput,
-            Writer noticeOutput) throws IOException {
+            Writer noticeOutput,
+            Writer unusedLicenseOutput) throws IOException {
         SortedSet<Dependency> dependencies = new TreeSet<>();
 
         Dependency.addDependenciesFromRubyReport(rubyDependenciesStream, dependencies);
         addJavaDependencies(javaDependenciesStreams, dependencies);
 
-        checkDependencyLicenses(licenseMappingStream, acceptableLicensesStream, dependencies);
+        Map<String, LicenseUrlPair> licenseMapping = new HashMap<>();
+        checkDependencyLicenses(licenseMappingStream, acceptableLicensesStream, licenseMapping, dependencies);
         checkDependencyNotices(noticeOutput, dependencies);
 
         writeLicenseCSV(licenseOutput, dependencies);
@@ -57,6 +57,7 @@ public class ReportGenerator {
 
         reportUnknownLicenses();
         reportMissingNotices();
+        reportUnusedLicenseMappings(unusedLicenseOutput, licenseMapping);
 
         licenseOutput.close();
         noticeOutput.close();
@@ -70,8 +71,8 @@ public class ReportGenerator {
         }
     }
 
-    private void checkDependencyLicenses(InputStream licenseMappingStream, InputStream acceptableLicensesStream, SortedSet<Dependency> dependencies) throws IOException {
-        Map<String, LicenseUrlPair> licenseMapping = new HashMap<>();
+    private void checkDependencyLicenses(InputStream licenseMappingStream, InputStream acceptableLicensesStream,
+                                         Map<String, LicenseUrlPair> licenseMapping, SortedSet<Dependency> dependencies) throws IOException {
         readLicenseMapping(licenseMappingStream, licenseMapping);
         List<String> acceptableLicenses = new ArrayList<>();
         readAcceptableLicenses(acceptableLicensesStream, acceptableLicenses);
@@ -110,6 +111,27 @@ public class ReportGenerator {
             for (Dependency dependency : UNKNOWN_LICENSES) {
                 System.out.println(
                         String.format("\"%s:%s\"", dependency.name, dependency.version));
+            }
+        }
+    }
+
+    private void reportUnusedLicenseMappings(Writer unusedLicenseWriter, Map<String, LicenseUrlPair> licenseMapping) throws IOException {
+        SortedSet<String> unusedDependencies = new TreeSet<>();
+
+        for (Map.Entry<String, LicenseUrlPair> entry : licenseMapping.entrySet()) {
+            if (entry.getValue().isUnused) {
+                unusedDependencies.add(entry.getKey());
+            }
+        }
+
+        if (unusedDependencies.size() > 0) {
+            String msg = String.format("The following %d license mappings were specified but unused:", unusedDependencies.size());
+            System.out.println(msg);
+            unusedLicenseWriter.write(msg + System.lineSeparator());
+
+            for (String dep : unusedDependencies) {
+                System.out.println(dep);
+                unusedLicenseWriter.write(dep + System.lineSeparator());
             }
         }
     }
@@ -154,6 +176,7 @@ public class ReportGenerator {
             if (hasAcceptableLicense) {
                 dependency.spdxLicense = pair.license;
                 dependency.url = pair.url;
+                pair.isUnused = false;
             } else {
                 // unacceptable license or missing URL
                 UNKNOWN_LICENSES.add(dependency);
@@ -191,6 +214,7 @@ public class ReportGenerator {
 class LicenseUrlPair {
     String license;
     String url;
+    boolean isUnused = true;
 
     LicenseUrlPair(String license, String url) {
         this.license = license;


### PR DESCRIPTION
This makes it easier to clean up old/obsolete dependencies in the license mapping file.

Also, a non-zero exit code is returned if license violations are found now that the license mappings are up to date.