### PR TITLE
Add instructions on how to run license audit tool

### DIFF
--- a/bin/dependencies-report
+++ b/bin/dependencies-report
@@ -29,9 +29,5 @@ fi
 . "$(cd `dirname ${SOURCEPATH}`/..; pwd)/bin/logstash.lib.sh"
 setup
 
-SCRIPT=$(readlink -f "$0")
-SCRIPTPATH=$(dirname "$SCRIPT")
-
-
 mkdir -p build
 ruby_exec "logstash-core/lib/logstash/dependency_report_runner.rb" "$@"

--- a/tools/dependencies-report/README.md
+++ b/tools/dependencies-report/README.md
@@ -14,3 +14,7 @@ The dependency audit tool enumerates all the dependencies, Ruby and Java, direct
 for Logstash core and the default plugins. If any dependencies are found that do not conform to
 the criteria above, the name of the dependency(ies) along with instructions for resolving are 
 printed to the console and the tool exits with a non-zero return code.
+
+The dependency audit tool should be run using the script in the `bin` folder:
+
+`$LS_HOME/bin/dependencies-report --csv report.csv`


### PR DESCRIPTION
Also removes unused call to `readlink` in script
