### PR TITLE
Extract kibana and elasticsearch client ssl config

### DIFF
--- a/logstash-core/lib/logstash/elasticsearch_client.rb
+++ b/logstash-core/lib/logstash/elasticsearch_client.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "elasticsearch"
 require "elasticsearch/transport/transport/http/manticore"
+require 'logstash/util/manticore_ssl_config_helper'
 
 module LogStash class ElasticsearchClient
   include LogStash::Util::Loggable
@@ -20,21 +21,14 @@ module LogStash class ElasticsearchClient
   end
 
   class RubyClient
+    include LogStash::Util::ManticoreSSLConfigHelper
+
     def initialize(settings, logger)
       @settings = settings
       @logger = logger
       @client_args = client_args
 
-      ssl_options = {}
-
-      # boolean settings may be strings if set through the cli
-      # or booleans if set through the yaml file, so we use .to_s
-      if @settings["var.elasticsearch.ssl.enabled"].to_s == "true"
-        ssl_options[:verify] = @settings.fetch("var.elasticsearch.ssl.verification_mode", true)
-        ssl_options[:ca_file] = @settings.fetch("var.elasticsearch.ssl.certificate_authority", nil)
-        ssl_options[:client_cert] = @settings.fetch("var.elasticsearch.ssl.certificate", nil)
-        ssl_options[:client_key] = @settings.fetch("var.elasticsearch.ssl.key", nil)
-      end
+      ssl_options = manticore_ssl_options_from_config('elasticsearch', settings)
 
       @client_args[:ssl] = ssl_options
 

--- a/logstash-core/lib/logstash/modules/kibana_client.rb
+++ b/logstash-core/lib/logstash/modules/kibana_client.rb
@@ -1,9 +1,12 @@
 # encoding: utf-8
 require "logstash/json"
 require "manticore"
+require 'logstash/util/manticore_ssl_config_helper'
 
 module LogStash module Modules class KibanaClient
   include LogStash::Util::Loggable
+
+  include LogStash::Util::ManticoreSSLConfigHelper
 
   class Response
     # to create a custom response with body as an Object (Hash or Array)
@@ -37,17 +40,8 @@ module LogStash module Modules class KibanaClient
       pool_max_per_route: 2
     }
 
-    ssl_options = {}
-
-    # boolean settings may be strings if set through the cli
-    # or booleans if set through the yaml file, so we use .to_s
-    ssl_enabled = @settings["var.kibana.ssl.enabled"].to_s == "true"
-    if ssl_enabled
-      ssl_options[:verify] = @settings.fetch("var.kibana.ssl.verification_mode", "strict").to_sym
-      ssl_options[:ca_file] = @settings.fetch("var.kibana.ssl.certificate_authority", nil)
-      ssl_options[:client_cert] = @settings.fetch("var.kibana.ssl.certificate", nil)
-      ssl_options[:client_key] = @settings.fetch("var.kibana.ssl.key", nil)
-    end
+    ssl_options = manticore_ssl_options_from_config('kibana', settings)
+    ssl_enabled = ssl_options.any?
 
     client_options[:ssl] = ssl_options
 

--- a/logstash-core/lib/logstash/util/manticore_ssl_config_helper.rb
+++ b/logstash-core/lib/logstash/util/manticore_ssl_config_helper.rb
@@ -1,0 +1,71 @@
+# encoding: utf-8
+
+module LogStash; module Util; module ManticoreSSLConfigHelper
+  extend self
+
+  ##
+  # Extract Manticore-style SSL directives from the given configuration.
+  #
+  # @param namespace [String] a string namespace (e.g., `kibana` in `var.kibana.ssl.*`)
+  # @param settings [Hash<String,Object>] a collection of Manticore-friendly SSL directives.
+  #                                       if SSL explicitly disabled, an _empty_ hash will be returned.
+  #
+  # @return [Hash<Symbol,Object>]
+  def manticore_ssl_options_from_config(namespace, settings)
+    ssl_settings = strip_prefix(settings, "var.#{namespace}.ssl.")
+
+    # boolean settings may be strings if set through the cli
+    # or booleans if set through the yaml file, so we use .to_s
+    if ssl_settings.include?('enabled') && !coerce_boolean(ssl_settings['enabled'])
+      logger.warn('SSL explicitly disabled; other SSL settings will be ignored') if logger && ssl_settings.size > 1
+      return {}
+    end
+
+    {
+        :verify      => ssl_settings.fetch('verification_mode', :strict).to_sym,
+        :ca_file     => ssl_settings.fetch('certificate_authority', nil),
+        :client_cert => ssl_settings.fetch('certificate', nil),
+        :client_key  => ssl_settings.fetch('key', nil),
+    }
+  end
+
+  private
+
+  ##
+  # Returns the subset of the hash whose keys match the given prefix, with the prefix removed
+  #
+  # @param hash [Hash<String,Object>]
+  # @param prefix [String]
+  # @return [Hash<String,Object>]
+  def strip_prefix(hash, prefix)
+    hash.each_with_object({}) do |(key, value), memo|
+      next unless key.start_with?(prefix)
+      unprefixed_key = key[prefix.length..-1]
+      memo[unprefixed_key] = value
+    end
+  end
+
+  ##
+  # Coerces the non-nil input to boolean
+  #
+  # @param value [Boolean,String,Integer]
+  # @return [Boolean]
+  def coerce_boolean(value)
+    case value
+    when true, "true", "T", 1 then true
+    when false, "false", "F", 0 then false
+    else
+      fail("Boolean value required, received `#{value}`")
+    end
+  end
+
+  ##
+  # Adapter to enable logging via the including class' `#logger` method or `@logger` instance variable
+  #
+  # @return [Logger,nil]
+  def logger
+    return super if defined?(super)
+
+    @logger
+  end
+end end end


### PR DESCRIPTION
Shared helper does not ignore ssl options when user fails to supply
the `${MODULE}.var.${TARGET}.ssl.enabled=true` directive.

Fixes: https://github.com/elastic/logstash/issues/9664