### PR TITLE
[6.4 backport of #9950] avoid race condition when initializing events and pipelines metrics

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java
@@ -106,16 +106,18 @@ public abstract class AbstractOutputDelegatorExt extends RubyObject {
         this.metric = metric;
         final ThreadContext context = RubyUtil.RUBY.getCurrentContext();
         this.id = RubyString.newString(context.runtime, id);
-        namespacedMetric = metric.namespace(context, context.runtime.newSymbol(id));
-        metricEvents = namespacedMetric.namespace(context, MetricKeys.EVENTS_KEY);
-        namespacedMetric.gauge(
-            context, MetricKeys.NAME_KEY, configName(context)
-        );
-        eventMetricOut = LongCounter.fromRubyBase(metricEvents, MetricKeys.OUT_KEY);
-        eventMetricIn = LongCounter.fromRubyBase(metricEvents, MetricKeys.IN_KEY);
-        eventMetricTime = LongCounter.fromRubyBase(
-            metricEvents, MetricKeys.DURATION_IN_MILLIS_KEY
-        );
+        synchronized (metric) {
+            namespacedMetric = metric.namespace(context, context.runtime.newSymbol(id));
+            metricEvents = namespacedMetric.namespace(context, MetricKeys.EVENTS_KEY);
+            namespacedMetric.gauge(
+                context, MetricKeys.NAME_KEY, configName(context)
+            );
+            eventMetricOut = LongCounter.fromRubyBase(metricEvents, MetricKeys.OUT_KEY);
+            eventMetricIn = LongCounter.fromRubyBase(metricEvents, MetricKeys.IN_KEY);
+            eventMetricTime = LongCounter.fromRubyBase(
+                metricEvents, MetricKeys.DURATION_IN_MILLIS_KEY
+            );
+        }
     }
 
     protected abstract IRubyObject getConfigName(ThreadContext context);

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
@@ -53,15 +53,14 @@ public final class FilterDelegatorExt extends RubyObject {
         this.filter = filter;
         filterClass = filter.getSingletonClass().getRealClass();
         filterMethod = filterClass.searchMethod(FILTER_METHOD_NAME);
-        final AbstractNamespacedMetricExt namespacedMetric =
-            (AbstractNamespacedMetricExt) filter.callMethod(context, "metric");
-        metricEvents = namespacedMetric.namespace(context, MetricKeys.EVENTS_KEY);
-        eventMetricOut = LongCounter.fromRubyBase(metricEvents, MetricKeys.OUT_KEY);
-        eventMetricIn = LongCounter.fromRubyBase(metricEvents, MetricKeys.IN_KEY);
-        eventMetricTime = LongCounter.fromRubyBase(
-            metricEvents, MetricKeys.DURATION_IN_MILLIS_KEY
-        );
-        namespacedMetric.gauge(context, MetricKeys.NAME_KEY, configName(context));
+        final AbstractNamespacedMetricExt namespacedMetric = (AbstractNamespacedMetricExt) filter.callMethod(context, "metric");
+        synchronized(namespacedMetric.getMetric()) {
+            metricEvents = namespacedMetric.namespace(context, MetricKeys.EVENTS_KEY);
+            eventMetricOut = LongCounter.fromRubyBase(metricEvents, MetricKeys.OUT_KEY);
+            eventMetricIn = LongCounter.fromRubyBase(metricEvents, MetricKeys.IN_KEY);
+            eventMetricTime = LongCounter.fromRubyBase(metricEvents, MetricKeys.DURATION_IN_MILLIS_KEY);
+            namespacedMetric.gauge(context, MetricKeys.NAME_KEY, configName(context));
+        }
         flushes = filter.respondsTo("flush");
         return this;
     }

--- a/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBase.java
+++ b/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBase.java
@@ -52,19 +52,22 @@ public abstract class QueueReadClientBase extends RubyObject implements QueueRea
     @JRubyMethod(name = "set_events_metric")
     public IRubyObject setEventsMetric(final IRubyObject metric) {
         final AbstractNamespacedMetricExt namespacedMetric = (AbstractNamespacedMetricExt) metric;
-        eventMetricOut = LongCounter.fromRubyBase(namespacedMetric, MetricKeys.OUT_KEY);
-        eventMetricFiltered = LongCounter.fromRubyBase(namespacedMetric, MetricKeys.FILTERED_KEY);
-        eventMetricTime = LongCounter.fromRubyBase(namespacedMetric, MetricKeys.DURATION_IN_MILLIS_KEY);
+        synchronized(namespacedMetric.getMetric()) {
+            eventMetricOut = LongCounter.fromRubyBase(namespacedMetric, MetricKeys.OUT_KEY);
+            eventMetricFiltered = LongCounter.fromRubyBase(namespacedMetric, MetricKeys.FILTERED_KEY);
+            eventMetricTime = LongCounter.fromRubyBase(namespacedMetric, MetricKeys.DURATION_IN_MILLIS_KEY);
+        }
         return this;
     }
 
     @JRubyMethod(name = "set_pipeline_metric")
     public IRubyObject setPipelineMetric(final IRubyObject metric) {
         final AbstractNamespacedMetricExt namespacedMetric = (AbstractNamespacedMetricExt) metric;
-        pipelineMetricOut = LongCounter.fromRubyBase(namespacedMetric, MetricKeys.OUT_KEY);
-        pipelineMetricFiltered = LongCounter.fromRubyBase(namespacedMetric, MetricKeys.FILTERED_KEY);
-        pipelineMetricTime =
-            LongCounter.fromRubyBase(namespacedMetric, MetricKeys.DURATION_IN_MILLIS_KEY);
+        synchronized(namespacedMetric.getMetric()) {
+            pipelineMetricOut = LongCounter.fromRubyBase(namespacedMetric, MetricKeys.OUT_KEY);
+            pipelineMetricFiltered = LongCounter.fromRubyBase(namespacedMetric, MetricKeys.FILTERED_KEY);
+            pipelineMetricTime = LongCounter.fromRubyBase(namespacedMetric, MetricKeys.DURATION_IN_MILLIS_KEY);
+        }
         return this;
     }
 

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractNamespacedMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractNamespacedMetricExt.java
@@ -68,4 +68,6 @@ public abstract class AbstractNamespacedMetricExt extends AbstractMetricExt {
     protected abstract IRubyObject doIncrement(ThreadContext context, IRubyObject[] args);
 
     protected abstract IRubyObject doDecrement(ThreadContext context, IRubyObject[] args);
+
+    public abstract AbstractMetricExt getMetric();
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/NamespacedMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/NamespacedMetricExt.java
@@ -103,4 +103,7 @@ public final class NamespacedMetricExt extends AbstractNamespacedMetricExt {
             name instanceof RubyArray ? name : RubyArray.newArray(context.runtime, name)
         ));
     }
+
+    @Override
+    public AbstractMetricExt getMetric() { return this.metric; }
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/NullNamespacedMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/NullNamespacedMetricExt.java
@@ -37,7 +37,7 @@ public final class NullNamespacedMetricExt extends AbstractNamespacedMetricExt {
     @JRubyMethod(optional = 2)
     public NullNamespacedMetricExt initialize(final ThreadContext context,
         final IRubyObject[] args) {
-        this.metric = args.length > 0 && !args[0].isNil() ? (NullMetricExt) args[0] : null;
+        this.metric = args.length > 0 && !args[0].isNil() ? (NullMetricExt) args[0] : new NullMetricExt(context.runtime, metaClass);
         final IRubyObject namespaceName = args.length == 2 ? args[1] : NULL;
         if (namespaceName instanceof RubyArray) {
             this.namespaceName = (RubyArray) namespaceName;
@@ -98,6 +98,9 @@ public final class NullNamespacedMetricExt extends AbstractNamespacedMetricExt {
             name instanceof RubyArray ? name : RubyArray.newArray(context.runtime, name)
         ));
     }
+
+    @Override
+    public AbstractMetricExt getMetric() { return this.metric; }
 
     @JRubyClass(name = "NullCounter")
     public static final class NullCounter extends RubyObject {


### PR DESCRIPTION
This is a backport of #9950 on the 6.4 branch for inclusion in 6.4.1
There were no conflict in creating this backport.