### PR TITLE
make worker thread names visbile to OS, fixes #9968

### DIFF
--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -217,7 +217,7 @@ module LogStash; class JavaPipeline < JavaBasePipeline
               lir_execution, filter_queue_client, @events_filtered, @events_consumed,
               @flushRequested, @flushing, @shutdownRequested, @drain_queue).run
         end
-        thread.name="[#{pipeline_id}]>worker#{t}"
+        Util.set_thread_name("[#{pipeline_id}]>worker#{t}")
         @worker_threads << thread
       end
 

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -284,7 +284,7 @@ module LogStash; class Pipeline < BasePipeline
         thread = Thread.new(batch_size, batch_delay, self) do |_b_size, _b_delay, _pipeline|
           _pipeline.worker_loop(_b_size, _b_delay)
         end
-        thread.name="[#{pipeline_id}]>worker#{t}"
+        Util.set_thread_name("[#{pipeline_id}]>worker#{t}")
         @worker_threads << thread
       end
 


### PR DESCRIPTION
Make worker filter/output threadnames visible in operation system tools like top/ps etc