### PR TITLE
[DOCS] Synchronize location of Breaking Changes

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -91,12 +91,6 @@ include::static/shutdown.asciidoc[]
 :edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/setting-up-xpack.asciidoc
 include::static/setup/setting-up-xpack.asciidoc[]
 
-// Breaking Changes
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/breaking-changes.asciidoc
-include::static/breaking-changes.asciidoc[]
-
-
 // Upgrading Logstash
 
 :edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/upgrading.asciidoc
@@ -248,6 +242,11 @@ include::static/glossary.asciidoc[]
 
 // This is in the pluginbody.asciidoc itself
 //
+
+// Breaking Changes
+
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/breaking-changes.asciidoc
+include::static/breaking-changes.asciidoc[]
 
 // Release Notes
 


### PR DESCRIPTION
Related to https://github.com/elastic/docs/issues/382, https://github.com/elastic/kibana/pull/22939,  and https://github.com/elastic/elasticsearch/pull/33588

This PR moves the "Breaking Changes" section nearer the "Release Notes" section, to synchronize the location of this information across the library.