### PR TITLE
Fixes MissingConverterException when receiving data with the rabbitmq input plugin

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Valuefier.java
+++ b/logstash-core/src/main/java/org/logstash/Valuefier.java
@@ -33,6 +33,9 @@ public final class Valuefier {
     private static final Valuefier.Converter FLOAT_CONVERTER =
         input -> RubyUtil.RUBY.newFloat(((Number) input).doubleValue());
 
+    private static final Valuefier.Converter LONG_CONVERTER
+        = input -> RubyUtil.RUBY.newFixnum(((Number) input).longValue());
+
     /**
      * Unwraps a {@link JavaProxy} and passes the result to {@link Valuefier#convert(Object)}.
      * Handles {code IRubyObject[]} as a special case, since we do only receive this type wrapped
@@ -118,7 +121,10 @@ public final class Valuefier {
         converters.put(
             BigDecimal.class, value -> new RubyBigDecimal(RubyUtil.RUBY, (BigDecimal) value)
         );
-        converters.put(Number.class, input -> RubyUtil.RUBY.newFixnum(((Number) input).longValue()));
+        converters.put(Long.class, LONG_CONVERTER);
+        converters.put(Integer.class, LONG_CONVERTER);
+        converters.put(Short.class, LONG_CONVERTER);
+        converters.put(Byte.class, LONG_CONVERTER);
         converters.put(Boolean.class, input -> RubyUtil.RUBY.newBoolean((Boolean) input));
         converters.put(
             Timestamp.class,

--- a/logstash-core/src/main/java/org/logstash/Valuefier.java
+++ b/logstash-core/src/main/java/org/logstash/Valuefier.java
@@ -2,6 +2,7 @@ package org.logstash;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -31,9 +32,6 @@ public final class Valuefier {
 
     private static final Valuefier.Converter FLOAT_CONVERTER =
         input -> RubyUtil.RUBY.newFloat(((Number) input).doubleValue());
-
-    private static final Valuefier.Converter LONG_CONVERTER
-        = input -> RubyUtil.RUBY.newFixnum(((Number) input).longValue());
 
     /**
      * Unwraps a {@link JavaProxy} and passes the result to {@link Valuefier#convert(Object)}.
@@ -120,8 +118,7 @@ public final class Valuefier {
         converters.put(
             BigDecimal.class, value -> new RubyBigDecimal(RubyUtil.RUBY, (BigDecimal) value)
         );
-        converters.put(Long.class, LONG_CONVERTER);
-        converters.put(Integer.class, LONG_CONVERTER);
+        converters.put(Number.class, input -> RubyUtil.RUBY.newFixnum(((Number) input).longValue()));
         converters.put(Boolean.class, input -> RubyUtil.RUBY.newBoolean((Boolean) input));
         converters.put(
             Timestamp.class,
@@ -137,6 +134,11 @@ public final class Valuefier {
         converters.put(
             DateTime.class, input -> JrubyTimestampExtLibrary.RubyTimestamp.newRubyTimestamp(
                 RubyUtil.RUBY, new Timestamp((DateTime) input)
+            )
+        );
+        converters.put(
+                Date.class, input -> JrubyTimestampExtLibrary.RubyTimestamp.newRubyTimestamp(
+                RubyUtil.RUBY, new Timestamp((Date) input)
             )
         );
         converters.put(RubyHash.class, input -> ConvertedMap.newFromRubyHash((RubyHash) input));


### PR DESCRIPTION
logstash-plugins/logstash-input-rabbitmq#112 Fixes most cases of MissingConverterException when receiving data with the rabbitmq input plugin.

This is adding support for Byte, Short and (most importantly) Date. But to decrease verbosity I use the functionality in fallbackConvert to decode subclasses of the given classes.
See method ValueReader.readFieldValue in java package amqp-client for which types can appear over AMQP (except that LongString is changed to String by March Hare).