### PR TITLE
move queue opening bits from constructor to open_queue method

### DIFF
--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -21,6 +21,8 @@ module LogStash; class JavaPipeline < JavaBasePipeline
   def initialize(pipeline_config, namespaced_metric = nil, agent = nil)
     @logger = self.logger
     super pipeline_config, namespaced_metric, @logger, agent
+    open_queue
+
     @worker_threads = []
 
     @drain_queue =  settings.get_value("queue.drain") || settings.get("queue.type") == "memory"

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -88,6 +88,7 @@ module LogStash; class Pipeline < BasePipeline
 
   def initialize(pipeline_config, namespaced_metric = nil, agent = nil)
     super
+    open_queue
 
     @worker_threads = []
 


### PR DESCRIPTION
Fixes #9978 

The [`BasePipeline`/`JavaBasePipeline`  is used to validate configurations](https://github.com/elastic/logstash/blob/234add03dc5bcd1f8f673862457022f74b39caf0/logstash-core/lib/logstash/pipeline_action/reload.rb#L32-L36) prior to [initializing the actual `Pipeline`/`JavaPipeline`](https://github.com/elastic/logstash/blob/234add03dc5bcd1f8f673862457022f74b39caf0/logstash-core/lib/logstash/pipeline_action/create.rb#L35-L39) and the validation process should not open the queue.

The queue opening code which was part of the `AbstractPipeline` constructor is now move out into an `open_queue` method which is now called only from the `Pipeline`/`JavaPipeline` constructor. 

To reproduce the problem:
- enable PQ `queue.type: persisted`
- enable reloading `config.reload.automatic: true`
- create a dummy config that can be reloaded 
- start logstash
- edit config

Without the fix logstash will crash upon reloading and with the fix it does not. 

We should followup with a better test harness for this case, #9979