### PR TITLE
move queue opening bits from constructor to open_queue method

### DIFF
--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -22,6 +22,8 @@ module LogStash; class JavaPipeline < JavaBasePipeline
   def initialize(pipeline_config, namespaced_metric = nil, agent = nil)
     @logger = self.logger
     super pipeline_config, namespaced_metric, @logger, agent
+    open_queue
+
     @worker_threads = []
 
     @drain_queue =  settings.get_value("queue.drain") || settings.get("queue.type") == "memory"

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -88,6 +88,7 @@ module LogStash; class Pipeline < BasePipeline
 
   def initialize(pipeline_config, namespaced_metric = nil, agent = nil)
     super
+    open_queue
 
     @worker_threads = []
 


### PR DESCRIPTION
clean backport of #9985 on 6.x
fix confirmed on 6.x with a before/after manual test.