### PR TITLE
better thread identification and pipeline thread context setup

### DIFF
--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -4,7 +4,7 @@ name = LogstashPropertiesConfig
 appender.console.type = Console
 appender.console.name = plain_console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %m%n
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-15c{1.}]%notEmpty{[%X{pipeline.id}]} %m%n
 
 appender.json_console.type = Console
 appender.json_console.name = json_console

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -82,6 +82,7 @@ class LogStash::Agent
 
   def execute
     @thread = Thread.current # this var is implicitly used by Stud.stop?
+    LogStash::Util.set_thread_name("Agent thread")
     logger.debug("Starting agent")
 
     transition_to_running
@@ -287,7 +288,7 @@ class LogStash::Agent
 
     pipeline_actions.map do |action|
       Thread.new do
-        java.lang.Thread.currentThread().setName("Converge #{action}");
+        LogStash::Util.set_thread_name("Converge #{action}")
         # We execute every task we need to converge the current state of pipelines
         # for every task we will record the action result, that will help us
         # the results of all the task will determine if the converge was successful or not

--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -219,7 +219,7 @@ module LogStash; class JavaPipeline < JavaBasePipeline
               lir_execution, filter_queue_client, @events_filtered, @events_consumed,
               @flushRequested, @flushing, @shutdownRequested, @drain_queue).run
         end
-        Util.set_thread_name("[#{pipeline_id}]>worker#{t}")
+        thread.name="[#{pipeline_id}]>worker#{t}"
         @worker_threads << thread
       end
 


### PR DESCRIPTION
This PR sets the thread names in a few more locations for pipelines and their flusher threads.
It also sets up the Thread Context for the logger to have the pipelineid