### PR TITLE
Skip 3.2.3 user agent filter

### DIFF
--- a/Gemfile.jruby-2.3.lock.release
+++ b/Gemfile.jruby-2.3.lock.release
@@ -255,7 +255,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-urldecode (3.0.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-useragent (3.2.3-java)
+    logstash-filter-useragent (3.2.2-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-xml (4.0.5)
       logstash-core-plugin-api (>= 1.60, <= 2.99)


### PR DESCRIPTION
this is related to https://github.com/elastic/logstash/issues/10017

version 3.2.3 updates the regular expressions and introduces many changes in how strings are parsed, which may be too disruptive for the typical user.