### PR TITLE
Fix integration tests to work with the useragent filter at either version 3.2.2 or 3.2.3

### DIFF
--- a/qa/integration/specs/es_output_how_spec.rb
+++ b/qa/integration/specs/es_output_how_spec.rb
@@ -36,6 +36,6 @@ describe "Test Elasticsearch output" do
     expect(s["geoip"]["longitude"]).to be_between(-180, 180)
     expect(s["geoip"]["latitude"]).to be_between(-90, 90)
     expect(s["verb"]).to eq("GET")
-    expect(s["useragent"]["os"]).to eq("Windows")
+    expect(s["useragent"]["os"]).to match(/Windows/)
   end
 end


### PR DESCRIPTION
Replaces #10019.