### PR TITLE
[Docs] Add note about CPM and local pipeline config

### DIFF
--- a/docs/static/management/centralized-pipelines.asciidoc
+++ b/docs/static/management/centralized-pipelines.asciidoc
@@ -18,6 +18,10 @@ You can control multiple Logstash instances from the pipeline management UI in
 side, you simply need to enable configuration management and register Logstash
 to use the centrally managed pipeline configurations.
 
+IMPORTANT: After you configure {ls} to use centralized pipeline management, you can
+no longer specify local pipeline configurations. The `pipelines.yml` file and
+settings such as `path.config` and `config.string` are inactive when centralized
+pipeline management is enabled.
 
 ==== Manage pipelines
 


### PR DESCRIPTION
It's not possible to specify local pipeline configurations if LS is set up to use centralized pipeline management.  Clarify in docs. 

Fixes #10014 