### PR TITLE
Add port forwarding to the docker command

### DIFF
--- a/docs/static/docker.asciidoc
+++ b/docs/static/docker.asciidoc
@@ -101,14 +101,14 @@ files:
 
 ["source","sh",subs="attributes"]
 --------------------------------------------
-docker run --rm -it -v ~/settings/:/usr/share/logstash/config/ {docker-image}
+docker run --rm -it -p 5044:5044 -v ~/settings/:/usr/share/logstash/config/ {docker-image}
 --------------------------------------------
 
 Alternatively, a single file can be mounted:
 
 ["source","sh",subs="attributes"]
 --------------------------------------------
-docker run --rm -it -v ~/settings/logstash.yml:/usr/share/logstash/config/logstash.yml {docker-image}
+docker run --rm -it -p 5044:5044 -v ~/settings/logstash.yml:/usr/share/logstash/config/logstash.yml {docker-image}
 --------------------------------------------
 
 NOTE: Bind-mounted configuration files will retain the same permissions and


### PR DESCRIPTION
I found it was necessary to add the `-p` flag and bind it so my host could connect to it (and thus my filebeats)