### PR TITLE
Rename filebeat.prospectors to filebeat.inputs

### DIFF
--- a/docs/static/advanced-pipeline.asciidoc
+++ b/docs/static/advanced-pipeline.asciidoc
@@ -40,7 +40,7 @@ directory, and replace the contents with the following lines. Make sure `paths` 
 
 [source,yaml]
 --------------------------------------------------------------------------------
-filebeat.prospectors:
+filebeat.inputs:
 - type: log
   paths:
     - /path/to/file/logstash-tutorial.log <1>
@@ -173,6 +173,9 @@ If your pipeline is working correctly, you should see a series of events like th
     "prospector" => {
         "type" => "log"
     },
+    "input" => {
+        "type" => "log"
+    },
         "source" => "/path/to/file/logstash-tutorial.log",
        "message" => "83.149.9.216 - - [04/Jan/2015:05:13:42 +0000] \"GET /presentations/logstash-monitorama-2013/images/kibana-search.png HTTP/1.1\" 200 203023 \"http://semicomplete.com/presentations/logstash-monitorama-2013/\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.77 Safari/537.36\"",
           "tags" => [
@@ -294,6 +297,9 @@ After Logstash applies the grok pattern, the events will have the following JSON
           "ident" => "-",
            "verb" => "GET",
      "prospector" => {
+        "type" => "log"
+    },
+     "input" => {
         "type" => "log"
     },
          "source" => "/path/to/file/logstash-tutorial.log",
@@ -534,6 +540,9 @@ You should get multiple hits back. For example:
           "prospector": {
             "type": "log"
           },
+          "input": {
+            "type": "log"
+          },
           "source": "/path/to/file/logstash-tutorial.log",
           "message": """83.149.9.216 - - [04/Jan/2015:05:13:45 +0000] "GET /presentations/logstash-monitorama-2013/images/frontend-response-codes.png HTTP/1.1" 200 52878 "http://semicomplete.com/presentations/logstash-monitorama-2013/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.77 Safari/537.36"""",
           "tags": [
@@ -616,6 +625,9 @@ A few log entries come from Buffalo, so the query produces the following respons
           "ident": "-",
           "verb": "GET",
           "prospector": {
+            "type": "log"
+          },
+          "input": {
             "type": "log"
           },
           "source": "/path/to/file/logstash-tutorial.log",
@@ -711,7 +723,7 @@ directory, and replace the contents with the following lines. Make sure `paths` 
 
 [source,shell]
 --------------------------------------------------------------------------------
-filebeat.prospectors:
+filebeat.inputs:
 - type: log
   paths:
     - /var/log/*.log <1>

--- a/docs/static/filebeat-modules.asciidoc
+++ b/docs/static/filebeat-modules.asciidoc
@@ -6,7 +6,7 @@ Filebeat comes packaged with pre-built  {filebeat-ref}/filebeat-modules.html[mod
 that contain the configurations needed to collect, parse, enrich, and visualize
 data from various log file formats. Each Filebeat module consists of one or more
 filesets that contain ingest node pipelines, Elasticsearch templates, Filebeat
-prospector configurations, and Kibana dashboards.
+input configurations, and Kibana dashboards.
 
 Filebeat modules are a great way to get started, but you might find that ingest
 pipelines don't offer the processing power that you require. If that's the case,

--- a/qa/integration/services/filebeat_setup.sh
+++ b/qa/integration/services/filebeat_setup.sh
@@ -8,7 +8,7 @@ if [ -n "${FILEBEAT_VERSION}" ]; then
   echo "Filebeat version is $FILEBEAT_VERSION"
   version=$FILEBEAT_VERSION
 else
-  version=5.0.1
+  version=6.4.2
 fi
 
 FB_HOME=$INSTALL_DIR/filebeat

--- a/qa/integration/specs/beats_input_spec.rb
+++ b/qa/integration/specs/beats_input_spec.rb
@@ -67,7 +67,7 @@ describe "Beat Input" do
     let(:filebeat_config) do
       {
         "filebeat" => {
-          "prospectors" => [{ "paths" => [log_path], "input_type" => "log" }],
+          "inputs" => [{ "paths" => [log_path], "input_type" => "log" }],
           "registry_file" => registry_file,
           "scan_frequency" => "1s"
         },
@@ -92,7 +92,7 @@ describe "Beat Input" do
       let(:filebeat_config) do
         {
           "filebeat" => {
-            "prospectors" => [{ "paths" => [log_path], "input_type" => "log" }],
+            "inputs" => [{ "paths" => [log_path], "input_type" => "log" }],
             "registry_file" => registry_file,
             "scan_frequency" => "1s"
           },
@@ -119,7 +119,7 @@ describe "Beat Input" do
       let(:filebeat_config) do
         {
           "filebeat" => {
-            "prospectors" => [{ "paths" => [log_path], "input_type" => "log" }],
+            "inputs" => [{ "paths" => [log_path], "input_type" => "log" }],
             "registry_file" => registry_file,
             "scan_frequency" => "1s"
           },


### PR DESCRIPTION
In filebeat prospectors settings have been renamed to inputs. When
prospectors is used a deprecation warning is printed. With 7.0
`filebeat.prospectors` will be removed.

This change updates all uses of prospectors with inputs. For now
filebeat events report `prospector.type` and `input.type` for
compatibility reasons.