### PR TITLE
make java execution beta

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -108,8 +108,8 @@ class LogStash::Runner < Clamp::StrictCommand
     :attribute_name => "pipeline.workers",
     :default => LogStash::SETTINGS.get_default("pipeline.workers")
 
-  option ["--experimental-java-execution"], :flag,
-         I18n.t("logstash.runner.flag.experimental-java-execution"),
+  option ["--java-execution"], :flag,
+         I18n.t("logstash.runner.flag.java-execution"),
          :attribute_name => "pipeline.java_execution",
          :default => LogStash::SETTINGS.get_default("pipeline.java_execution")
 

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -288,8 +288,8 @@ en:
           Sets the ID of the pipeline.
         pipeline-workers: |+
           Sets the number of pipeline workers to run.
-        experimental-java-execution: |+
-          (Experimental) Use new Java execution engine.
+        java-execution: |+
+          (Beta) Use new Java execution engine.
         pipeline-batch-size: |+
           Size of batches the pipeline is to work in.
         pipeline-batch-delay: |+


### PR DESCRIPTION
Make java execution a beta feature during the course of 6.5 with the goal of making it GA in 6.6