### PR TITLE
Add conditional directives to handle plugins with no codec

### DIFF
--- a/docs/include/input.asciidoc
+++ b/docs/include/input.asciidoc
@@ -47,6 +47,7 @@ endif::[]
 
 Add a field to an event
 
+ifndef::no_codec[]
 ifeval::["{versioned_docs}"!="true"]
 [id="plugins-{type}s-{plugin}-codec"]
 endif::[]
@@ -64,6 +65,7 @@ ifndef::default_codec[]
 endif::[]
 
 The codec used for input data. Input codecs are a convenient method for decoding your data before it enters the input, without needing a separate filter in your Logstash pipeline.
+endif::no_codec[]
 
 ifeval::["{versioned_docs}"!="true"]
 [id="plugins-{type}s-{plugin}-enable_metric"]

--- a/docs/include/input.asciidoc
+++ b/docs/include/input.asciidoc
@@ -11,7 +11,9 @@ ifeval::["{versioned_docs}"!="true"]
 |=======================================================================
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-add_field>> |{logstash-ref}/configuration-file-structure.html#hash[hash]|No
+ifndef::no_codec[]
 | <<plugins-{type}s-{plugin}-codec>> |{logstash-ref}/configuration-file-structure.html#codec[codec]|No
+endif::no_codec[]
 | <<plugins-{type}s-{plugin}-enable_metric>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
 | <<plugins-{type}s-{plugin}-id>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
 | <<plugins-{type}s-{plugin}-tags>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
@@ -22,7 +24,9 @@ ifeval::["{versioned_docs}"=="true"]
 |=======================================================================
 |Setting |Input type|Required
 | <<{version}-plugins-{type}s-{plugin}-add_field>> |{logstash-ref}/configuration-file-structure.html#hash[hash]|No
+ifndef::no_codec[]
 | <<{version}-plugins-{type}s-{plugin}-codec>> |{logstash-ref}/configuration-file-structure.html#codec[codec]|No
+endif::no_codec[]
 | <<{version}-plugins-{type}s-{plugin}-enable_metric>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
 | <<{version}-plugins-{type}s-{plugin}-id>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
 | <<{version}-plugins-{type}s-{plugin}-tags>> |{logstash-ref}/configuration-file-structure.html#array[array]|No
@@ -66,6 +70,7 @@ endif::[]
 
 The codec used for input data. Input codecs are a convenient method for decoding your data before it enters the input, without needing a separate filter in your Logstash pipeline.
 endif::no_codec[]
+
 
 ifeval::["{versioned_docs}"!="true"]
 [id="plugins-{type}s-{plugin}-enable_metric"]

--- a/docs/include/output.asciidoc
+++ b/docs/include/output.asciidoc
@@ -25,6 +25,7 @@ ifeval::["{versioned_docs}"=="true"]
 |=======================================================================
 endif::[]
 
+ifndef::no_codec[]
 ifeval::["{versioned_docs}"!="true"]
 [id="plugins-{type}s-{plugin}-codec"]
 endif::[]
@@ -42,6 +43,7 @@ ifndef::default_codec[]
 endif::[]
 
 The codec used for output data. Output codecs are a convenient method for encoding your data before it leaves the output without needing a separate filter in your Logstash pipeline.
+endif::no_codec[]
 
 ifeval::["{versioned_docs}"!="true"]
 [id="plugins-{type}s-{plugin}-enable_metric"]

--- a/docs/include/output.asciidoc
+++ b/docs/include/output.asciidoc
@@ -10,7 +10,9 @@ ifeval::["{versioned_docs}"!="true"]
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
+ifndef::no_codec[]
 | <<plugins-{type}s-{plugin}-codec>> |{logstash-ref}/configuration-file-structure.html#codec[codec]|No
+endif::no_codec[]
 | <<plugins-{type}s-{plugin}-enable_metric>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
 | <<plugins-{type}s-{plugin}-id>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
 |=======================================================================
@@ -19,7 +21,9 @@ ifeval::["{versioned_docs}"=="true"]
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
+ifndef::no_codec[]
 | <<{version}-plugins-{type}s-{plugin}-codec>> |{logstash-ref}/configuration-file-structure.html#codec[codec]|No
+endif::no_codec[]
 | <<{version}-plugins-{type}s-{plugin}-enable_metric>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
 | <<{version}-plugins-{type}s-{plugin}-id>> |{logstash-ref}/configuration-file-structure.html#string[string]|No
 |=======================================================================


### PR DESCRIPTION
Update conditional logic in Common Options to allow for `no_codec`.
(Needed to support input-snmp and output-appsearch plugins.)

NOTE:  These changes need to go in for Versioned Plugin Ref: https://github.com/elastic/logstash-docs/tree/versioned_plugin_docs/docs/versioned-plugins/include/6.x