### PR TITLE
synchronize ruby pipeline initialization to fix concurrency bug

### DIFF
--- a/logstash-core/lib/logstash/pipeline_action/create.rb
+++ b/logstash-core/lib/logstash/pipeline_action/create.rb
@@ -35,7 +35,12 @@ module LogStash module PipelineAction
         if @pipeline_config.settings.get_value("pipeline.java_execution")
           LogStash::JavaPipeline.new(@pipeline_config, @metric, agent)
         else
-          LogStash::Pipeline.new(@pipeline_config, @metric, agent)
+          agent.exclusive do
+            # The Ruby pipeline initialization is not thread safe because of the module level
+            # shared state in LogsStash::Config::AST. When using multiple pipelines this gets
+            # executed simultaneously in different threads and we need to synchonize this initialization.
+            LogStash::Pipeline.new(@pipeline_config, @metric, agent)
+          end
         end
 
       status = nil

--- a/logstash-core/lib/logstash/pipeline_action/reload.rb
+++ b/logstash-core/lib/logstash/pipeline_action/reload.rb
@@ -32,7 +32,12 @@ module LogStash module PipelineAction
           if @pipeline_config.settings.get_value("pipeline.java_execution")
             LogStash::JavaBasePipeline.new(@pipeline_config, nil, logger, nil)
           else
-            LogStash::BasePipeline.new(@pipeline_config)
+            agent.exclusive do
+              # The Ruby pipeline initialization is not thread safe because of the module level
+              # shared state in LogsStash::Config::AST. When using multiple pipelines this can gets
+              # executed simultaneously in different threads and we need to synchonize this initialization.
+              LogStash::BasePipeline.new(@pipeline_config)
+            end
           end
       rescue => e
         return LogStash::ConvergeResult::FailedAction.from_exception(e)


### PR DESCRIPTION
This solves a concurrency problem when using multiple pipelines. The Ruby pipeline configuration compilation code is not thread safe and uses a shared state in the `LogsStash::Config::AST` module. This compilation is done in the pipeline constructor which gets called simultaneously in multiple threads when using multiple pipelines resulting in sometimes corrupted generated pipeline code and eventually resulting exceptions such as
- `undefined method 'multi_filter' for nil:NilClass` ... `in block in filter_func'"`
- `undefined method 'call' for nil:NilClass` ... `in block in filter_func'"`

I validated this fix by first inspecting the compiled code of each pipeline when using multiple pipelines  all using the same config. I noticed that the number of `@generated_objects[:cond_func_XX] = ...` blocks was growing as more pipelines were added. Also the resulting code was different for each pipeline.

This explains the above exception as these `multi_filter` and `call` methods are both done on the `@generated_objects[:cond_func_XX].call(events)`  or `@generated_objects[:filter_mutate_XX].multi_filter(events)` and because of the concurrency corruption, some `@generated_objects[...]` where `nil`.

After this fix, all resulting generated code is identical for all pipelines using same config and there are no more superfluous `@generated_objects[:cond_func_XX] = ...` blocks.
