### PR TITLE
Replace generated for-loops with static method calls

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/Utils.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/Utils.java
@@ -1,0 +1,34 @@
+package org.logstash.config.ir.compiler;
+
+import org.jruby.RubyArray;
+import org.logstash.ext.JrubyEventExtLibrary;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Static utility methods that replace common blocks of generated code in the Java execution.
+ */
+public class Utils {
+
+    // has field1.compute(batchArg, flushArg, shutdownArg) passed as input
+    public static void copyNonCancelledEvents(Collection<JrubyEventExtLibrary.RubyEvent> input, RubyArray output) {
+        for (JrubyEventExtLibrary.RubyEvent e : input) {
+            if (!(e.getEvent().isCancelled())) {
+                output.add(e);
+            }
+        }
+    }
+
+    public static void filterEvents(Collection<JrubyEventExtLibrary.RubyEvent> input, EventCondition filter,
+                                    ArrayList fulfilled, ArrayList unfulfilled) {
+        for (JrubyEventExtLibrary.RubyEvent e : input) {
+            if (filter.fulfilled(e)) {
+                fulfilled.add(e);
+            } else {
+                unfulfilled.add(e);
+            }
+        }
+    }
+
+}

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/Utils.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/Utils.java
@@ -1,10 +1,9 @@
 package org.logstash.config.ir.compiler;
 
-import org.jruby.RubyArray;
 import org.logstash.ext.JrubyEventExtLibrary;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Static utility methods that replace common blocks of generated code in the Java execution.
@@ -12,7 +11,7 @@ import java.util.Collection;
 public class Utils {
 
     // has field1.compute(batchArg, flushArg, shutdownArg) passed as input
-    public static void copyNonCancelledEvents(Collection<JrubyEventExtLibrary.RubyEvent> input, RubyArray output) {
+    public static void copyNonCancelledEvents(Collection<JrubyEventExtLibrary.RubyEvent> input, List output) {
         for (JrubyEventExtLibrary.RubyEvent e : input) {
             if (!(e.getEvent().isCancelled())) {
                 output.add(e);
@@ -21,7 +20,7 @@ public class Utils {
     }
 
     public static void filterEvents(Collection<JrubyEventExtLibrary.RubyEvent> input, EventCondition filter,
-                                    ArrayList fulfilled, ArrayList unfulfilled) {
+                                    List fulfilled, List unfulfilled) {
         for (JrubyEventExtLibrary.RubyEvent e : input) {
             if (filter.fulfilled(e)) {
                 fulfilled.add(e);


### PR DESCRIPTION
This change replaces the frequently-generated for loops in `CompiledDataset` classes with calls to static utility methods with the same behavior. This has the advantage of simplifying the generated code, reducing the volume of generated code, and providing some hooks from generated code into static code where debugging may be simplified.
