### PR TITLE
update lock file for the 6.4 branch

### DIFF
--- a/Gemfile.jruby-2.3.lock.release
+++ b/Gemfile.jruby-2.3.lock.release
@@ -1,7 +1,7 @@
 PATH
   remote: ./logstash-core
   specs:
-    logstash-core (6.4.3-java)
+    logstash-core (6.4.4-java)
       chronic_duration (= 0.10.6)
       clamp (~> 0.6.5)
       concurrent-ruby (~> 1.0, >= 1.0.5)
@@ -15,7 +15,7 @@ PATH
       minitar (~> 0.6.1)
       pry (~> 0.10.1)
       puma (~> 2.16)
-      rack (= 1.6.6)
+      rack (~> 1.6, >= 1.6.11)
       rubyzip (~> 1.2.1)
       sinatra (~> 1.4, >= 1.4.6)
       stud (~> 0.0.19)
@@ -26,7 +26,7 @@ PATH
   remote: ./logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 6.4.3)
+      logstash-core (= 6.4.4)
 
 GEM
   remote: https://rubygems.org/
@@ -38,13 +38,13 @@ GEM
     avl_tree (1.2.1)
       atomic (~> 1.1)
     awesome_print (1.7.0)
-    aws-sdk (2.11.154)
-      aws-sdk-resources (= 2.11.154)
-    aws-sdk-core (2.11.154)
+    aws-sdk (2.11.174)
+      aws-sdk-resources (= 2.11.174)
+    aws-sdk-core (2.11.174)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.154)
-      aws-sdk-core (= 2.11.154)
+    aws-sdk-resources (2.11.174)
+      aws-sdk-core (= 2.11.174)
     aws-sdk-v1 (1.67.0)
       json (~> 1.4)
       nokogiri (~> 1)
@@ -217,7 +217,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-patterns-core
       stud (~> 0.0.22)
-    logstash-filter-jdbc_static (1.0.5)
+    logstash-filter-jdbc_static (1.0.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       rufus-scheduler (< 3.5)
       sequel
@@ -255,9 +255,9 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-urldecode (3.0.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-useragent (3.2.2-java)
+    logstash-filter-useragent (3.2.3-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-xml (4.0.5)
+    logstash-filter-xml (4.0.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       nokogiri
       xml-simple
@@ -290,7 +290,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       rufus-scheduler
       stud (~> 0.0.22)
-    logstash-input-file (4.1.6)
+    logstash-input-file (4.1.7)
       addressable
       logstash-codec-multiline (~> 3.0)
       logstash-codec-plain
@@ -362,7 +362,7 @@ GEM
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       snmp
-    logstash-input-sqs (3.1.1)
+    logstash-input-sqs (3.1.2)
       logstash-codec-json
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-aws (>= 4.3.0)
@@ -420,7 +420,7 @@ GEM
       logstash-filter-json
       logstash-input-generator
       logstash-output-file
-    logstash-output-elasticsearch (9.2.1-java)
+    logstash-output-elasticsearch (9.2.4-java)
       cabin (~> 0.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       manticore (>= 0.5.4, < 1.0.0)
@@ -466,7 +466,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       redis (~> 3)
       stud
-    logstash-output-s3 (4.1.6)
+    logstash-output-s3 (4.1.7)
       concurrent-ruby
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-aws (>= 4.3.0)
@@ -535,7 +535,7 @@ GEM
       spoon (~> 0.0)
     public_suffix (1.4.6)
     puma (2.16.0-java)
-    rack (1.6.6)
+    rack (1.6.11)
     rack-protection (1.5.5)
       rack
     rack-test (1.1.0)
@@ -564,7 +564,7 @@ GEM
     sawyer (0.6.0)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
-    sequel (5.12.0)
+    sequel (5.14.0)
     simple_oauth (0.3.1)
     sinatra (1.4.8)
       rack (~> 1.5)
@@ -599,7 +599,7 @@ GEM
       simple_oauth (~> 0.3.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    tzinfo-data (1.2018.6)
+    tzinfo-data (1.2018.7)
       tzinfo (>= 1.0.0)
     unf (0.1.4-java)
     webhdfs (0.8.0)


### PR DESCRIPTION
this should address CI failures such as https://logstash-ci.elastic.co/job/elastic+logstash+6.4+multijob-legacy/3/console