### PR TITLE
skip prerelease gems on plugin version bump rake task

### DIFF
--- a/rakelib/bump_plugin_versions.rake
+++ b/rakelib/bump_plugin_versions.rake
@@ -3,7 +3,9 @@ require 'uri'
 require 'fileutils'
 
 def compute_dependecy(version, allow_for)
-  major, minor, patch = Gem::Version.new(version).release.segments
+  gem_version = Gem::Version.new(version)
+  return version if gem_version.prerelease?
+  major, minor, patch = gem_version.release.segments
   case allow_for
   when "major"
     then "~> #{major}"


### PR DESCRIPTION
the script to bump the lock file didn't take into consideration prerelease gems.

Before, it took "1.0.0.beta1", called `.release` to make it "1.0.0", and performed the necessary bump depending on `major, minor, patch` argument. This would cause the resulting version to not contain the beta1 prerelease suffix.

This PR makes it so that prerelease gems aren't allowed to be bumped. These are often special cases so it makes sense to handle them case-by-case, manually.