### PR TITLE
setting a list config to empty array should not result in nil

### DIFF
--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -323,7 +323,7 @@ module LogStash::Config::Mixin
       if config_settings[:list]
         value = Array(value) # coerce scalars to lists
         # Empty lists are converted to nils
-        return true, nil if value.empty?
+        return true, [] if value.empty?
 
         validated_items = value.map {|v| validate_value(v, config_val)}
         is_valid = validated_items.all? {|sr| sr[0] }

--- a/logstash-core/spec/logstash/config/mixin_spec.rb
+++ b/logstash-core/spec/logstash/config/mixin_spec.rb
@@ -132,8 +132,8 @@ describe LogStash::Config::Mixin do
     context "with an empty list" do
       let(:strings) { [] }
 
-      it "should return nil" do
-        expect(subject.strings).to be_nil
+      it "should return an empty list" do
+        expect(subject.strings).to be_empty
       end
     end
 


### PR DESCRIPTION
if a plugin author defines a config parameter as:

  `config :retryable_codes, :validate => :number, :list => true, :default => [429]`

And a user configures the plugin as:

  `plugin { retryable_codes => [] }`

It's expected that the retryable_codes parameter is an empty array and not a nil object

This PR changes this behaviour to generate an empty array

This nil behaviour causes unexpected errors like in https://github.com/logstash-plugins/logstash-output-http/issues/98