### PR TITLE
Revert "remove forced dependency on old bundler (#9395)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -324,9 +324,9 @@ def qaBundledGemPath = "${qaVendorPath}/jruby/2.3.0"
 def qaBundleBin = "${qaBundledGemPath}/bin/bundle"
 
 task installIntegrationTestBundler(dependsOn: unpackTarDistribution) {
-  outputs.files fileTree("${qaBundledGemPath}/gems/bundler-1.17.1")
+  outputs.files fileTree("${qaBundledGemPath}/gems/bundler-1.16.0")
   doLast {
-    rubyGradleUtils.gem("bundler", "1.17.1", qaBundledGemPath)
+    rubyGradleUtils.gem("bundler", "1.16.0", qaBundledGemPath)
   }
 }
 

--- a/lib/pluginmanager/bundler/logstash_injector.rb
+++ b/lib/pluginmanager/bundler/logstash_injector.rb
@@ -67,7 +67,7 @@ module Bundler
       gemfile = LogStash::Gemfile.new(File.new(gemfile_path, "r+")).load
 
       begin
-        @deps.each do |dependency|
+        @new_deps.each do |dependency|
           gemfile.update(dependency.name, dependency.requirement)
         end
 

--- a/qa/integration/specs/cli/remove_spec.rb
+++ b/qa/integration/specs/cli/remove_spec.rb
@@ -45,7 +45,7 @@ describe "CLI > logstash-plugin remove" do
 
             expect(execute.exit_code).to eq(1)
             expect(execute.stderr_and_stdout).to match(/Failed to remove "logstash-codec-json"/)
-            expect(execute.stderr_and_stdout).to match(/logstash-input-kafka/) # one of the dependency
+            expect(execute.stderr_and_stdout).to match(/logstash-input-beats/) # one of the dependency
             expect(execute.stderr_and_stdout).to match(/logstash-output-udp/) # one of the dependency
 
             presence_check = @logstash_plugin.list("logstash-codec-json")
@@ -78,7 +78,7 @@ describe "CLI > logstash-plugin remove" do
 
           expect(execute.exit_code).to eq(1)
           expect(execute.stderr_and_stdout).to match(/Failed to remove "logstash-codec-json"/)
-          expect(execute.stderr_and_stdout).to match(/logstash-input-kafka/) # one of the dependency
+          expect(execute.stderr_and_stdout).to match(/logstash-input-beats/) # one of the dependency
           expect(execute.stderr_and_stdout).to match(/logstash-output-udp/) # one of the dependency
 
           presence_check = @logstash_plugin.list("logstash-codec-json")

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -29,7 +29,6 @@ namespace "artifact" do
       "logstash-core/*.gemspec",
 
       "logstash-core-plugin-api/lib/**/*",
-      "logstash-core-plugin-api/versions-gem-copy.yml",
       "logstash-core-plugin-api/*.gemspec",
 
       "patterns/**/*",

--- a/rakelib/dependency.rake
+++ b/rakelib/dependency.rake
@@ -1,7 +1,7 @@
 
 namespace "dependency" do
   task "bundler" do
-    Rake::Task["gem:require"].invoke("bundler", "~> 1.17.1")
+    Rake::Task["gem:require"].invoke("bundler", "~> 1.9.4")
   end
 
   task "clamp" do

--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -7,6 +7,8 @@ namespace "vendor" do
     system('./gradlew downloadAndInstallJRuby') unless File.exists?(File.join("vendor", "jruby"))
   end # jruby
 
+  task "all" => "jruby"
+
   namespace "force" do
     task "gems" => ["vendor:gems"]
   end

--- a/spec/unit/bootstrap/bundler_spec.rb
+++ b/spec/unit/bootstrap/bundler_spec.rb
@@ -44,7 +44,7 @@ describe LogStash::Bundler do
     after do
       expect(::Bundler.settings[:path]).to eq(LogStash::Environment::BUNDLE_DIR)
       expect(::Bundler.settings[:gemfile]).to eq(LogStash::Environment::GEMFILE_PATH)
-      expect(::Bundler.settings[:without]).to eq(options.fetch(:without, []))
+      expect(::Bundler.settings[:without]).to eq(options.fetch(:without, []).join(':'))
 
       expect(ENV['GEM_PATH']).to eq(LogStash::Environment.logstash_gem_home)
 

--- a/spec/unit/license_spec.rb
+++ b/spec/unit/license_spec.rb
@@ -33,8 +33,7 @@ describe "Project licenses" do
       # Skipped because version 2.6.2 which we use has multiple licenses: MIT, ARTISTIC 2.0, GPL-2
       # See https://rubygems.org/gems/mime-types/versions/2.6.2
       # version 3.0 of mime-types (which is only compatible with Ruby 2.0) is MIT licensed
-      "mime-types",
-      "logstash-core-plugin-api"
+      "mime-types"
     ]
   end
 


### PR DESCRIPTION
This reverts commit ab20b40e478ce818cecef5720a4875bdbb099e8a.

Due to failing tests like https://logstash-ci.elastic.co/job/elastic+logstash+master+multijob--ruby-unit-tests/86/