### PR TITLE
Remove codec-cloudtrail from skiplist

### DIFF
--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -767,7 +767,7 @@
 		"core-specs": false,
 		"test-jar-dependencies": false,
 		"test-vendor-plugins": false,
-		"skip-list": true
+		"skip-list": false
 	},
 	"logstash-filter-aggregate": {
 		"default-plugins": true,


### PR DESCRIPTION
Generate `codecs/cloudtrail.asciidoc` for Logstash Reference Guide.
This PR is a prereq for merging https://github.com/elastic/logstash-docs/pull/634