### PR TITLE
Increase default number of threads reported by hot_threads

### DIFF
--- a/docs/static/monitoring-apis.asciidoc
+++ b/docs/static/monitoring-apis.asciidoc
@@ -720,7 +720,7 @@ Example response:
 The parameters allowed are:
 
 [horizontal]
-`threads`:: 	        The number of hot threads to return. The default is 3.
+`threads`:: 	        The number of hot threads to return. The default is 10.
 `human`:: 	            If true, returns plain text instead of JSON format. The default is false.
 `ignore_idle_threads`:: If true, does not return idle threads. The default is true.
 

--- a/logstash-core/lib/logstash/api/modules/stats.rb
+++ b/logstash-core/lib/logstash/api/modules/stats.rb
@@ -10,7 +10,7 @@ module LogStash
         # return hot threads information
         get "/jvm/hot_threads" do
           begin
-            top_threads_count = params["threads"] || 3
+            top_threads_count = params["threads"] || 10
             ignore_idle_threads = params["ignore_idle_threads"] || true
             options = {
               :threads => top_threads_count.to_i,

--- a/logstash-core/lib/logstash/util/thread_dump.rb
+++ b/logstash-core/lib/logstash/util/thread_dump.rb
@@ -5,7 +5,7 @@ module LogStash
   module Util
     class ThreadDump
       SKIPPED_THREADS             = [ "Finalizer", "Reference Handler", "Signal Dispatcher" ].freeze
-      THREADS_COUNT_DEFAULT       = 3.freeze
+      THREADS_COUNT_DEFAULT       = 10.freeze
       IGNORE_IDLE_THREADS_DEFAULT = true.freeze
 
       attr_reader :top_count, :ignore, :dump


### PR DESCRIPTION
The default output of the Hot Threads API is often provided for troubleshooting and a higher number of threads would often be more helpful in identifying problems.
