### PR TITLE
Eliminate compiler and javadoc warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,13 +35,13 @@ allprojects {
   project.targetCompatibility = JavaVersion.VERSION_1_8
 
   tasks.withType(JavaCompile).all {
-      def env = System.getenv()
-      boolean ci = env['CI']
+      options.compilerArgs.add("-Xlint:all")
+      options.compilerArgs.add("-Xlint:-processing")
+      options.compilerArgs.add("-Werror")
+  }
 
-      //don't lint when running CI builds
-      if(!ci){
-          options.compilerArgs.add("-Xlint:all")
-      }
+  tasks.withType(Javadoc) {
+      options.addStringOption("Xwerror", "-quiet")
   }
 
   clean {

--- a/logstash-core/src/main/java/co/elastic/logstash/api/Configuration.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/Configuration.java
@@ -82,12 +82,12 @@ public final class Configuration {
         return new PluginConfigSpec<>(name, Boolean.class, null, false, false);
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked","rawtypes"})
     public static PluginConfigSpec<Map<String, String>> hashSetting(final String name) {
         return new PluginConfigSpec(name, Map.class, null, false, false);
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked","rawtypes"})
     public static <T> PluginConfigSpec<Map<String, T>> requiredFlatHashSetting(
         final String name, Class<T> type) {
         //TODO: enforce subtype
@@ -96,7 +96,7 @@ public final class Configuration {
         );
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked","rawtypes"})
     public static PluginConfigSpec<Map<String, Configuration>> requiredNestedHashSetting(
         final String name, final Collection<PluginConfigSpec<?>> spec) {
         return new PluginConfigSpec(

--- a/logstash-core/src/main/java/co/elastic/logstash/api/PluginHelper.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/PluginHelper.java
@@ -43,6 +43,7 @@ public final class PluginHelper {
     /**
      * Returns a list of the options that are common to all input plugins.
      */
+    @SuppressWarnings("unchecked")
     public static Collection<PluginConfigSpec<?>> commonInputOptions() {
         return commonInputOptions(Collections.EMPTY_LIST);
     }
@@ -60,6 +61,7 @@ public final class PluginHelper {
     /**
      * Returns a list of the options that are common to all output plugins.
      */
+    @SuppressWarnings("unchecked")
     public static Collection<PluginConfigSpec<?>> commonOutputOptions() {
         return commonOutputOptions(Collections.EMPTY_LIST);
     }
@@ -76,6 +78,7 @@ public final class PluginHelper {
     /**
      * Returns a list of the options that are common to all filter plugins.
      */
+    @SuppressWarnings("unchecked")
     public static Collection<PluginConfigSpec<?>> commonFilterOptions() {
         return commonFilterOptions(Collections.EMPTY_LIST);
     }
@@ -91,6 +94,7 @@ public final class PluginHelper {
                 REMOVE_TAG_CONFIG*/));
     }
 
+    @SuppressWarnings("rawtypes")
     private static Collection<PluginConfigSpec<?>> combineOptions(
             Collection<PluginConfigSpec<?>> providedOptions,
             Collection<PluginConfigSpec<?>> commonOptions) {

--- a/logstash-core/src/main/java/org/logstash/Accessors.java
+++ b/logstash-core/src/main/java/org/logstash/Accessors.java
@@ -100,6 +100,8 @@ public final class Accessors {
     }
 
     public static class InvalidFieldSetException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
         public InvalidFieldSetException(final Object target, final String key, final Object value) {
             super(String.format(
                     "Could not set field '%s' on object '%s' to value '%s'." +

--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -65,6 +65,7 @@ public final class Event implements Cloneable, Queueable {
      * makes to its underlying data will be propagated to it.
      * @param data Converted Map
      */
+    @SuppressWarnings("unchecked")
     public Event(ConvertedMap data) {
         this.data = data;
         if (!this.data.containsKey(VERSION)) {
@@ -150,6 +151,7 @@ public final class Event implements Cloneable, Queueable {
         setField(FieldReference.from(reference), value);
     }
 
+    @SuppressWarnings("unchecked")
     public void setField(final FieldReference field, final Object value) {
         switch (field.type()) {
             case FieldReference.META_PARENT:
@@ -201,6 +203,7 @@ public final class Event implements Cloneable, Queueable {
         return JSON_MAPPER.writeValueAsString(this.data);
     }
 
+    @SuppressWarnings("unchecked")
     public static Event[] fromJson(String json)
             throws IOException
     {
@@ -348,6 +351,7 @@ public final class Event implements Cloneable, Queueable {
      * @param tags Existing Tag(s)
      * @param tag Tag to add
      */
+    @SuppressWarnings("unchecked")
     private void existingTag(final Object tags, final String tag) {
         if (tags instanceof List) {
             appendTag((List<String>) tags, tag);

--- a/logstash-core/src/main/java/org/logstash/FieldReference.java
+++ b/logstash-core/src/main/java/org/logstash/FieldReference.java
@@ -21,6 +21,7 @@ public final class FieldReference {
      * when they encounter an input with illegal syntax.
      */
     public static class IllegalSyntaxException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
         IllegalSyntaxException(String message) {
             super(message);
         }

--- a/logstash-core/src/main/java/org/logstash/LogstashJavaCompat.java
+++ b/logstash-core/src/main/java/org/logstash/LogstashJavaCompat.java
@@ -21,6 +21,7 @@ public final class LogstashJavaCompat {
      * not the current JVM is a Java 9 implementation.
      * @return ByteBufferCleaner
      */
+    @SuppressWarnings("rawtypes")
     public static ByteBufferCleaner setupBytebufferCleaner() {
         final ClassBodyEvaluator se = new ClassBodyEvaluator();
         final Collection<String> imports = new ArrayList<>();

--- a/logstash-core/src/main/java/org/logstash/ObjectMappers.java
+++ b/logstash-core/src/main/java/org/logstash/ObjectMappers.java
@@ -71,6 +71,8 @@ public final class ObjectMappers {
      */
     private abstract static class NonTypedScalarSerializer<T> extends StdScalarSerializer<T> {
 
+        private static final long serialVersionUID = -2292969459229763087L;
+
         NonTypedScalarSerializer(final Class<T> t) {
             super(t);
         }
@@ -87,6 +89,8 @@ public final class ObjectMappers {
      * simply serialize it as if it were a {@link String}.
      */
     private static final class RubyStringSerializer extends StdSerializer<RubyString> {
+
+        private static final long serialVersionUID = 7644231054988076676L;
 
         RubyStringSerializer() {
             super(RubyString.class);
@@ -112,6 +116,8 @@ public final class ObjectMappers {
 
     public static final class RubyStringDeserializer extends StdDeserializer<RubyString> {
 
+        private static final long serialVersionUID = -4444548655926831232L;
+
         RubyStringDeserializer() {
             super(RubyString.class);
         }
@@ -129,6 +135,8 @@ public final class ObjectMappers {
      */
     private static final class RubySymbolSerializer
         extends ObjectMappers.NonTypedScalarSerializer<RubySymbol> {
+
+        private static final long serialVersionUID = -1822329780680815791L;
 
         RubySymbolSerializer() {
             super(RubySymbol.class);
@@ -148,6 +156,8 @@ public final class ObjectMappers {
     private static final class RubyFloatSerializer
         extends ObjectMappers.NonTypedScalarSerializer<RubyFloat> {
 
+        private static final long serialVersionUID = 1480899084198662737L;
+
         RubyFloatSerializer() {
             super(RubyFloat.class);
         }
@@ -165,6 +175,8 @@ public final class ObjectMappers {
      */
     private static final class RubyBooleanSerializer
         extends ObjectMappers.NonTypedScalarSerializer<RubyBoolean> {
+
+        private static final long serialVersionUID = -8517286459600197793L;
 
         RubyBooleanSerializer() {
             super(RubyBoolean.class);
@@ -184,6 +196,8 @@ public final class ObjectMappers {
     private static final class RubyFixnumSerializer
         extends ObjectMappers.NonTypedScalarSerializer<RubyFixnum> {
 
+        private static final long serialVersionUID = 13956019593330324L;
+
         RubyFixnumSerializer() {
             super(RubyFixnum.class);
         }
@@ -201,6 +215,8 @@ public final class ObjectMappers {
      * deserialization happens via {@link ObjectMappers.TimestampDeserializer}.
      */
     public static final class TimestampSerializer extends StdSerializer<Timestamp> {
+
+        private static final long serialVersionUID = 5492714135094815910L;
 
         TimestampSerializer() {
             super(Timestamp.class);
@@ -225,6 +241,8 @@ public final class ObjectMappers {
 
     public static final class TimestampDeserializer extends StdDeserializer<Timestamp> {
 
+        private static final long serialVersionUID = -8802997528159345068L;
+
         TimestampDeserializer() {
             super(Timestamp.class);
         }
@@ -242,6 +260,8 @@ public final class ObjectMappers {
      */
     private static final class RubyBignumSerializer
         extends ObjectMappers.NonTypedScalarSerializer<RubyBignum> {
+
+        private static final long serialVersionUID = -8986657763732429619L;
 
         RubyBignumSerializer() {
             super(RubyBignum.class);
@@ -261,6 +281,8 @@ public final class ObjectMappers {
     private static final class RubyBigDecimalSerializer
         extends ObjectMappers.NonTypedScalarSerializer<RubyBigDecimal> {
 
+        private static final long serialVersionUID = 1648145951897474391L;
+
         RubyBigDecimalSerializer() {
             super(RubyBigDecimal.class);
         }
@@ -273,13 +295,15 @@ public final class ObjectMappers {
     }
 
     /**
-     * Serializer for {@link JrubyTimestampExtLibrary.RubyTimestamp} that serializes it exactly the
+     * Serializer for {@link org.logstash.ext.JrubyTimestampExtLibrary.RubyTimestamp} that serializes it exactly the
      * same way {@link ObjectMappers.TimestampSerializer} serializes
      * {@link Timestamp} to ensure consistent serialization across Java and Ruby
      * representation of {@link Timestamp}.
      */
     public static final class RubyTimestampSerializer
         extends StdSerializer<JrubyTimestampExtLibrary.RubyTimestamp> {
+
+        private static final long serialVersionUID = -6571512782595488363L;
 
         RubyTimestampSerializer() {
             super(JrubyTimestampExtLibrary.RubyTimestamp.class);
@@ -310,6 +334,8 @@ public final class ObjectMappers {
      */
     private static final class RubyNilSerializer extends StdSerializer<RubyNil> {
 
+        private static final long serialVersionUID = 7950663544839173004L;
+
         RubyNilSerializer() {
             super(RubyNil.class);
         }
@@ -332,6 +358,8 @@ public final class ObjectMappers {
     }
 
     private static final class RubyNilDeserializer extends StdDeserializer<RubyNil> {
+
+        private static final long serialVersionUID = 4903218049590688689L;
 
         RubyNilDeserializer() {
             super(RubyNil.class);

--- a/logstash-core/src/main/java/org/logstash/RubyJavaIntegration.java
+++ b/logstash-core/src/main/java/org/logstash/RubyJavaIntegration.java
@@ -35,6 +35,7 @@ public final class RubyJavaIntegration {
         // Utility class
     }
 
+    @SuppressWarnings("rawtypes")
     public static void setupRubyJavaIntegration(final Ruby ruby) {
         ruby.getArray().defineAnnotatedMethods(RubyJavaIntegration.RubyArrayOverride.class);
         ruby.getHash().defineAnnotatedMethods(RubyJavaIntegration.RubyHashOverride.class);

--- a/logstash-core/src/main/java/org/logstash/Timestamp.java
+++ b/logstash-core/src/main/java/org/logstash/Timestamp.java
@@ -85,6 +85,11 @@ public final class Timestamp implements Comparable<Timestamp>, Queueable {
     }
 
     @Override
+    public int hashCode() {
+        return time.hashCode();
+    }
+
+    @Override
     public byte[] serialize() {
         return toString().getBytes();
     }

--- a/logstash-core/src/main/java/org/logstash/Valuefier.java
+++ b/logstash-core/src/main/java/org/logstash/Valuefier.java
@@ -97,6 +97,7 @@ public final class Valuefier {
         throw new MissingConverterException(cls);
     }
 
+    @SuppressWarnings("unchecked")
     private static Map<Class<?>, Valuefier.Converter> initConverters() {
         final Map<Class<?>, Valuefier.Converter> converters =
             new ConcurrentHashMap<>(50, 0.2F, 1);

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/AckedReadBatch.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/AckedReadBatch.java
@@ -52,6 +52,7 @@ public final class AckedReadBatch implements QueueBatch {
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public RubyArray to_a() {
         ThreadContext context = RUBY.getCurrentContext();

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/QueueFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/QueueFactoryExt.java
@@ -19,6 +19,8 @@ import org.logstash.ext.JrubyWrappedSynchronousQueueExt;
 @JRubyClass(name = "QueueFactory")
 public final class QueueFactoryExt extends RubyBasicObject {
 
+    private static final long serialVersionUID = 1L;
+
     public QueueFactoryExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);
     }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/QueueRuntimeException.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/QueueRuntimeException.java
@@ -2,6 +2,8 @@ package org.logstash.ackedqueue;
 
 public class QueueRuntimeException extends RuntimeException {
 
+    private static final long serialVersionUID = 1L;
+
     public QueueRuntimeException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyWrappedAckedQueueExt.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyWrappedAckedQueueExt.java
@@ -22,6 +22,8 @@ import org.logstash.ext.JrubyEventExtLibrary;
 @JRubyClass(name = "WrappedAckedQueue")
 public final class JRubyWrappedAckedQueueExt extends AbstractWrappedQueueExt {
 
+    private static final long serialVersionUID = 1L;
+
     private JRubyAckedQueueExt queue;
     private final AtomicBoolean isClosed = new AtomicBoolean();
 

--- a/logstash-core/src/main/java/org/logstash/common/AbstractDeadLetterQueueWriterExt.java
+++ b/logstash-core/src/main/java/org/logstash/common/AbstractDeadLetterQueueWriterExt.java
@@ -15,6 +15,8 @@ import org.logstash.ext.JrubyEventExtLibrary;
 @JRubyClass(name = "AbstractDeadLetterQueueWriter")
 public abstract class AbstractDeadLetterQueueWriterExt extends RubyObject {
 
+    private static final long serialVersionUID = 1L;
+
     AbstractDeadLetterQueueWriterExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);
     }
@@ -67,6 +69,8 @@ public abstract class AbstractDeadLetterQueueWriterExt extends RubyObject {
     public static final class DummyDeadLetterQueueWriterExt
         extends AbstractDeadLetterQueueWriterExt {
 
+        private static final long serialVersionUID = 1L;
+
         public DummyDeadLetterQueueWriterExt(final Ruby runtime, final RubyClass metaClass) {
             super(runtime, metaClass);
         }
@@ -112,6 +116,8 @@ public abstract class AbstractDeadLetterQueueWriterExt extends RubyObject {
     @JRubyClass(name = "PluginDeadLetterQueueWriter")
     public static final class PluginDeadLetterQueueWriterExt
         extends AbstractDeadLetterQueueWriterExt {
+
+        private static final long serialVersionUID = 1L;
 
         private IRubyObject writerWrapper;
 

--- a/logstash-core/src/main/java/org/logstash/common/BufferedTokenizerExt.java
+++ b/logstash-core/src/main/java/org/logstash/common/BufferedTokenizerExt.java
@@ -14,6 +14,8 @@ import org.logstash.RubyUtil;
 @JRubyClass(name = "BufferedTokenizer")
 public class BufferedTokenizerExt extends RubyObject {
 
+    private static final long serialVersionUID = 1L;
+
     private static final IRubyObject MINUS_ONE = RubyUtil.RUBY.newFixnum(-1);
 
     private RubyArray input = RubyUtil.RUBY.newArray();

--- a/logstash-core/src/main/java/org/logstash/common/LsQueueUtils.java
+++ b/logstash-core/src/main/java/org/logstash/common/LsQueueUtils.java
@@ -16,7 +16,7 @@ public final class LsQueueUtils {
     }
 
     /**
-     * Adds all {@link JrubyEventExtLibrary.RubyEvent} in the given collection to the given queue
+     * Adds all {@link org.logstash.ext.JrubyEventExtLibrary.RubyEvent} in the given collection to the given queue
      * in a blocking manner, only returning once all events have been added to the queue.
      * @param queue Queue to add Events to
      * @param events Events to add to Queue
@@ -30,17 +30,17 @@ public final class LsQueueUtils {
     }
 
     /**
-     * <p>Drains {@link JrubyEventExtLibrary.RubyEvent} from {@link BlockingQueue} with a timeout.</p>
-     * <p>The timeout will be reset as soon as a single {@link JrubyEventExtLibrary.RubyEvent} was
-     * drained from the {@link BlockingQueue}. Draining {@link JrubyEventExtLibrary.RubyEvent}
-     * stops as soon as either the required number of {@link JrubyEventExtLibrary.RubyEvent}s
+     * <p>Drains {@link org.logstash.ext.JrubyEventExtLibrary.RubyEvent} from {@link BlockingQueue} with a timeout.</p>
+     * <p>The timeout will be reset as soon as a single {@link org.logstash.ext.JrubyEventExtLibrary.RubyEvent} was
+     * drained from the {@link BlockingQueue}. Draining {@link org.logstash.ext.JrubyEventExtLibrary.RubyEvent}
+     * stops as soon as either the required number of {@link org.logstash.ext.JrubyEventExtLibrary.RubyEvent}s
      * were pulled from the queue or the timeout value has gone by without an event drained.</p>
-     * @param queue Blocking Queue to drain {@link JrubyEventExtLibrary.RubyEvent}s
+     * @param queue Blocking Queue to drain {@link org.logstash.ext.JrubyEventExtLibrary.RubyEvent}s
      * from
-     * @param count Number of {@link JrubyEventExtLibrary.RubyEvent}s to drain from
+     * @param count Number of {@link org.logstash.ext.JrubyEventExtLibrary.RubyEvent}s to drain from
      * {@link BlockingQueue}
      * @param nanos Timeout in Nanoseconds
-     * @return Collection of {@link JrubyEventExtLibrary.RubyEvent} drained from
+     * @return Collection of {@link org.logstash.ext.JrubyEventExtLibrary.RubyEvent} drained from
      * {@link BlockingQueue}
      * @throws InterruptedException On Interrupt during {@link BlockingQueue#poll()} or
      * {@link BlockingQueue#drainTo(Collection)}
@@ -63,14 +63,14 @@ public final class LsQueueUtils {
     }
 
     /**
-     * Tries to drain a given number of {@link JrubyEventExtLibrary.RubyEvent} from
+     * Tries to drain a given number of {@link org.logstash.ext.JrubyEventExtLibrary.RubyEvent} from
      * {@link BlockingQueue} with a timeout.
-     * @param queue Blocking Queue to drain {@link JrubyEventExtLibrary.RubyEvent}s
+     * @param queue Blocking Queue to drain {@link org.logstash.ext.JrubyEventExtLibrary.RubyEvent}s
      * from
-     * @param count Number of {@link JrubyEventExtLibrary.RubyEvent}s to drain from
+     * @param count Number of {@link org.logstash.ext.JrubyEventExtLibrary.RubyEvent}s to drain from
      * {@link BlockingQueue}
      * @param nanos Timeout in Nanoseconds
-     * @return Collection of {@link JrubyEventExtLibrary.RubyEvent} drained from
+     * @return Collection of {@link org.logstash.ext.JrubyEventExtLibrary.RubyEvent} drained from
      * {@link BlockingQueue}
      * @throws InterruptedException On Interrupt during {@link BlockingQueue#poll()} or
      * {@link BlockingQueue#drainTo(Collection)}

--- a/logstash-core/src/main/java/org/logstash/config/ir/InvalidIRException.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/InvalidIRException.java
@@ -1,6 +1,8 @@
 package org.logstash.config.ir;
 
 public class InvalidIRException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     public InvalidIRException(String s) {
         super(s);
     }

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java
@@ -21,6 +21,8 @@ import org.logstash.instrument.metrics.counter.LongCounter;
 @JRubyClass(name = "AbstractOutputDelegator")
 public abstract class AbstractOutputDelegatorExt extends RubyObject {
 
+    private static final long serialVersionUID = 1L;
+
     public static final String OUTPUT_METHOD_NAME = "multi_receive";
 
     private AbstractMetricExt metric;
@@ -88,6 +90,7 @@ public abstract class AbstractOutputDelegatorExt extends RubyObject {
         return metricEvents;
     }
 
+    @SuppressWarnings("unchecked")
     @JRubyMethod(name = OUTPUT_METHOD_NAME)
     public IRubyObject multiReceive(final IRubyObject events) {
         final RubyArray batch = (RubyArray) events;

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/Dataset.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/Dataset.java
@@ -6,7 +6,7 @@ import org.logstash.ext.JrubyEventExtLibrary;
 
 /**
  * <p>A data structure backed by a {@link RubyArray} that represents one step of execution flow of a
- * batch is lazily filled with {@link JrubyEventExtLibrary.RubyEvent} computed from its dependent
+ * batch is lazily filled with {@link org.logstash.ext.JrubyEventExtLibrary.RubyEvent} computed from its dependent
  * {@link Dataset}.</p>
  * <p>Each {@link Dataset} either represents a filter, output or one branch of an {@code if}
  * statement in a Logstash configuration file.</p>
@@ -22,6 +22,7 @@ public interface Dataset {
      * Dataset that does not modify the input events.
      */
     Dataset IDENTITY = new Dataset() {
+        @SuppressWarnings("unchecked")
         @Override
         public Collection<JrubyEventExtLibrary.RubyEvent> compute(final RubyArray batch, final boolean flush, final boolean shutdown) {
             return batch;
@@ -35,12 +36,12 @@ public interface Dataset {
     /**
      * Compute the actual contents of the backing {@link RubyArray} and cache them.
      * Repeated invocations will be effectively free.
-     * @param batch Input {@link JrubyEventExtLibrary.RubyEvent} received at the root
+     * @param batch Input {@link org.logstash.ext.JrubyEventExtLibrary.RubyEvent} received at the root
      * of the execution
      * @param flush True if flushing flushable nodes while traversing the execution
      * @param shutdown True if this is the last call to this instance's compute method because
      * the pipeline it belongs to is shut down
-     * @return Computed {@link RubyArray} of {@link JrubyEventExtLibrary.RubyEvent}
+     * @return Computed {@link RubyArray} of {@link org.logstash.ext.JrubyEventExtLibrary.RubyEvent}
      */
     Collection<JrubyEventExtLibrary.RubyEvent> compute(RubyArray batch,
         boolean flush, boolean shutdown);

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/EventCondition.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/EventCondition.java
@@ -42,8 +42,8 @@ import org.logstash.ext.JrubyEventExtLibrary;
 public interface EventCondition {
 
     /**
-     * Checks if {@link JrubyEventExtLibrary.RubyEvent} fulfils the condition.
-     * @param event RubyEvent to check
+     * Checks if {@link org.logstash.ext.JrubyEventExtLibrary.RubyEvent} fulfils the condition.
+     * @param event org.logstash.ext.RubyEvent to check
      * @return True iff event fulfils condition
      */
     boolean fulfilled(JrubyEventExtLibrary.RubyEvent event);

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaFilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaFilterDelegatorExt.java
@@ -22,6 +22,8 @@ import java.util.stream.Collectors;
 @JRubyClass(name = "JavaFilterDelegator")
 public class JavaFilterDelegatorExt extends AbstractFilterDelegatorExt {
 
+    private static final long serialVersionUID = 1L;
+
     private static final RubySymbol CONCURRENCY = RubyUtil.RUBY.newSymbol("java");
 
     private RubyString configName;

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaOutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaOutputDelegatorExt.java
@@ -21,6 +21,8 @@ import org.logstash.instrument.metrics.AbstractMetricExt;
 @JRubyClass(name = "JavaOutputDelegator")
 public final class JavaOutputDelegatorExt extends AbstractOutputDelegatorExt {
 
+    private static final long serialVersionUID = 1L;
+
     private static final RubySymbol CONCURRENCY = RubyUtil.RUBY.newSymbol("java");
 
     private RubyString configName;

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
@@ -25,6 +25,8 @@ public final class OutputStrategyExt {
     @JRubyClass(name = "OutputDelegatorStrategyRegistry")
     public static final class OutputStrategyRegistryExt extends RubyObject {
 
+        private static final long serialVersionUID = 1L;
+
         private static OutputStrategyExt.OutputStrategyRegistryExt instance;
 
         private RubyHash map;
@@ -88,6 +90,8 @@ public final class OutputStrategyExt {
     @JRubyClass(name = "AbstractStrategy")
     public abstract static class AbstractOutputStrategyExt extends RubyObject {
 
+        private static final long serialVersionUID = 1L;
+
         private DynamicMethod outputMethod;
 
         private RubyClass outputClass;
@@ -137,6 +141,8 @@ public final class OutputStrategyExt {
 
     @JRubyClass(name = "Legacy", parent = "AbstractStrategy")
     public static final class LegacyOutputStrategyExt extends OutputStrategyExt.AbstractOutputStrategyExt {
+
+        private static final long serialVersionUID = 1L;
 
         private BlockingQueue<IRubyObject> workerQueue;
 
@@ -211,6 +217,8 @@ public final class OutputStrategyExt {
     public abstract static class SimpleAbstractOutputStrategyExt
         extends OutputStrategyExt.AbstractOutputStrategyExt {
 
+        private static final long serialVersionUID = 1L;
+
         private IRubyObject output;
 
         protected SimpleAbstractOutputStrategyExt(final Ruby runtime, final RubyClass metaClass) {
@@ -247,6 +255,8 @@ public final class OutputStrategyExt {
     @JRubyClass(name = "Single", parent = "SimpleAbstractStrategy")
     public static final class SingleOutputStrategyExt extends SimpleAbstractOutputStrategyExt {
 
+        private static final long serialVersionUID = 1L;
+
         public SingleOutputStrategyExt(final Ruby runtime, final RubyClass metaClass) {
             super(runtime, metaClass);
         }
@@ -261,6 +271,8 @@ public final class OutputStrategyExt {
 
     @JRubyClass(name = "Shared", parent = "SimpleAbstractStrategy")
     public static final class SharedOutputStrategyExt extends SimpleAbstractOutputStrategyExt {
+
+        private static final long serialVersionUID = 1L;
 
         public SharedOutputStrategyExt(final Ruby runtime, final RubyClass metaClass) {
             super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/SyntaxFactory.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/SyntaxFactory.java
@@ -2,6 +2,7 @@ package org.logstash.config.ir.compiler;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -141,6 +142,11 @@ final class SyntaxFactory {
             }
             return this.value.equals(((SyntaxFactory.ValueStatement) other).value);
         }
+
+        @Override
+        public int hashCode() {
+            return value.hashCode();
+        }
     }
 
     /**
@@ -192,6 +198,11 @@ final class SyntaxFactory {
                 (SyntaxFactory.MethodCallReturnValue) other;
             return this.instance.equals(that.instance) && this.method.equals(that.method)
                 && this.args.size() == that.args.size() && this.args.containsAll(that.args);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(instance, method, args);
         }
     }
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/Utils.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/Utils.java
@@ -10,6 +10,7 @@ import java.util.List;
  */
 public class Utils {
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     // has field1.compute(batchArg, flushArg, shutdownArg) passed as input
     public static void copyNonCancelledEvents(Collection<JrubyEventExtLibrary.RubyEvent> input, List output) {
         for (JrubyEventExtLibrary.RubyEvent e : input) {
@@ -19,6 +20,7 @@ public class Utils {
         }
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public static void filterEvents(Collection<JrubyEventExtLibrary.RubyEvent> input, EventCondition filter,
                                     List fulfilled, List unfulfilled) {
         for (JrubyEventExtLibrary.RubyEvent e : input) {

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -41,6 +41,8 @@ import org.logstash.instrument.metrics.NullMetricExt;
 @JRubyClass(name = "AbstractPipeline")
 public class AbstractPipelineExt extends RubyBasicObject {
 
+    private static final long serialVersionUID = 1L;
+
     private static final Logger LOGGER = LogManager.getLogger(AbstractPipelineExt.class);
 
     private static final RubyArray CAPACITY_NAMESPACE =

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractWrappedQueueExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractWrappedQueueExt.java
@@ -12,6 +12,8 @@ import org.logstash.ext.JRubyAbstractQueueWriteClientExt;
 @JRubyClass(name = "AbstractWrappedQueue")
 public abstract class AbstractWrappedQueueExt extends RubyBasicObject {
 
+    private static final long serialVersionUID = 1L;
+
     public AbstractWrappedQueueExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);
     }

--- a/logstash-core/src/main/java/org/logstash/execution/ConvergeResultExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/ConvergeResultExt.java
@@ -15,6 +15,9 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @JRubyClass(name = "ConvergeResult")
 public class ConvergeResultExt extends RubyObject {
+
+    private static final long serialVersionUID = 1L;
+
     private IRubyObject expectedActionsCount;
     private ConcurrentHashMap<IRubyObject, ActionResultExt> actions;
 
@@ -81,6 +84,9 @@ public class ConvergeResultExt extends RubyObject {
 
     @JRubyClass(name = "ActionResult")
     public static abstract class ActionResultExt extends RubyBasicObject {
+
+        private static final long serialVersionUID = 1L;
+
         private IRubyObject executedAt;
 
         protected ActionResultExt(Ruby runtime, RubyClass metaClass) {
@@ -129,6 +135,9 @@ public class ConvergeResultExt extends RubyObject {
 
     @JRubyClass(name = "FailedAction")
     public static final class FailedActionExt extends ActionResultExt {
+
+        private static final long serialVersionUID = 1L;
+
         private IRubyObject message;
         private IRubyObject backtrace;
 
@@ -182,6 +191,9 @@ public class ConvergeResultExt extends RubyObject {
 
     @JRubyClass(name = "SuccessfulAction")
     public static final class SuccessfulActionExt extends ActionResultExt {
+
+        private static final long serialVersionUID = 1L;
+
         public SuccessfulActionExt(Ruby runtime, RubyClass metaClass) {
             super(runtime, metaClass);
         }

--- a/logstash-core/src/main/java/org/logstash/execution/EventDispatcherExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/EventDispatcherExt.java
@@ -13,6 +13,8 @@ import org.jruby.runtime.builtin.IRubyObject;
 @JRubyClass(name = "EventDispatcher")
 public final class EventDispatcherExt extends RubyBasicObject {
 
+    private static final long serialVersionUID = 1L;
+
     private final Collection<IRubyObject> listeners = new CopyOnWriteArraySet<>();
 
     private IRubyObject emitter;

--- a/logstash-core/src/main/java/org/logstash/execution/ExecutionContextExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/ExecutionContextExt.java
@@ -13,6 +13,8 @@ import org.logstash.common.AbstractDeadLetterQueueWriterExt;
 @JRubyClass(name = "ExecutionContext")
 public final class ExecutionContextExt extends RubyObject {
 
+    private static final long serialVersionUID = 1L;
+
     private AbstractDeadLetterQueueWriterExt dlqWriter;
 
     private IRubyObject agent;

--- a/logstash-core/src/main/java/org/logstash/execution/JavaBasePipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/JavaBasePipelineExt.java
@@ -24,6 +24,8 @@ import org.logstash.plugins.PluginFactoryExt;
 @JRubyClass(name = "JavaBasePipeline")
 public final class JavaBasePipelineExt extends AbstractPipelineExt {
 
+    private static final long serialVersionUID = 1L;
+
     private static final Logger LOGGER = LogManager.getLogger(JavaBasePipelineExt.class);
 
     private CompiledPipeline lirExecution;

--- a/logstash-core/src/main/java/org/logstash/execution/PeriodicFlush.java
+++ b/logstash-core/src/main/java/org/logstash/execution/PeriodicFlush.java
@@ -7,6 +7,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+@SuppressWarnings("try")
 public final class PeriodicFlush implements AutoCloseable {
 
     private static final Logger LOGGER = LogManager.getLogger(PeriodicFlush.class);

--- a/logstash-core/src/main/java/org/logstash/execution/PipelineReporterExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/PipelineReporterExt.java
@@ -20,6 +20,8 @@ import java.util.Collection;
 @JRubyClass(name = "PipelineReporter")
 public final class PipelineReporterExt extends RubyBasicObject {
 
+    private static final long serialVersionUID = 1L;
+
     private static final RubySymbol EVENTS_FILTERED_KEY =
         RubyUtil.RUBY.newSymbol("events_filtered");
 
@@ -189,6 +191,8 @@ public final class PipelineReporterExt extends RubyBasicObject {
      */
     @JRubyClass(name = "Snapshot")
     public static final class SnapshotExt extends RubyBasicObject {
+
+        private static final long serialVersionUID = 1L;
 
         private static final RubyString INFLIGHT_COUNT_KEY =
             RubyUtil.RUBY.newString("inflight_count").newFrozen();

--- a/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBase.java
+++ b/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBase.java
@@ -23,6 +23,8 @@ import java.util.concurrent.TimeUnit;
 @JRubyClass(name = "QueueReadClientBase")
 public abstract class QueueReadClientBase extends RubyObject implements QueueReadClient {
 
+    private static final long serialVersionUID = 1L;
+
     protected int batchSize = 125;
     protected long waitForNanos = 50 * 1000 * 1000; // 50 millis to nanos
     protected long waitForMillis = 50;

--- a/logstash-core/src/main/java/org/logstash/execution/ShutdownWatcherExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/ShutdownWatcherExt.java
@@ -20,6 +20,8 @@ import org.logstash.RubyUtil;
 @JRubyClass(name = "ShutdownWatcher")
 public final class ShutdownWatcherExt extends RubyBasicObject {
 
+    private static final long serialVersionUID = 1L;
+
     private static final Logger LOGGER = LogManager.getLogger(ShutdownWatcherExt.class);
 
     private static final AtomicBoolean unsafeShutdown = new AtomicBoolean(false);

--- a/logstash-core/src/main/java/org/logstash/ext/JRubyAbstractQueueWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JRubyAbstractQueueWriteClientExt.java
@@ -13,6 +13,8 @@ import org.logstash.execution.queue.QueueWriter;
 @JRubyClass(name = "AbstractQueueWriteClient")
 public abstract class JRubyAbstractQueueWriteClientExt extends RubyBasicObject implements QueueWriter {
 
+    private static final long serialVersionUID = 1L;
+
     protected JRubyAbstractQueueWriteClientExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);
     }

--- a/logstash-core/src/main/java/org/logstash/ext/JRubyLogstashErrorsExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JRubyLogstashErrorsExt.java
@@ -14,6 +14,8 @@ public final class JRubyLogstashErrorsExt {
     @JRubyClass(name = "Error")
     public static final class LogstashRubyError extends RubyException {
 
+        private static final long serialVersionUID = 1L;
+
         public LogstashRubyError(final Ruby runtime, final RubyClass metaClass) {
             super(runtime, metaClass);
         }
@@ -21,6 +23,8 @@ public final class JRubyLogstashErrorsExt {
 
     @JRubyClass(name = "ParserError")
     public static final class LogstashRubyParserError extends RubyException {
+
+        private static final long serialVersionUID = 1L;
 
         public LogstashRubyParserError(final Ruby runtime, final RubyClass metaClass) {
             super(runtime, metaClass);
@@ -30,6 +34,8 @@ public final class JRubyLogstashErrorsExt {
     @JRubyClass(name = "GeneratorError")
     public static final class LogstashRubyGeneratorError extends RubyException {
 
+        private static final long serialVersionUID = 1L;
+
         public LogstashRubyGeneratorError(final Ruby runtime, final RubyClass metaClass) {
             super(runtime, metaClass);
         }
@@ -37,6 +43,8 @@ public final class JRubyLogstashErrorsExt {
 
     @JRubyClass(name = "TimestampParserError")
     public static final class LogstashTimestampParserError extends RubyException {
+
+        private static final long serialVersionUID = 1L;
 
         public LogstashTimestampParserError(final Ruby runtime, final RubyClass metaClass) {
             super(runtime, metaClass);
@@ -46,6 +54,8 @@ public final class JRubyLogstashErrorsExt {
     @JRubyClass(name = "EnvironmentError")
     public static final class LogstashEnvironmentError extends RubyException {
 
+        private static final long serialVersionUID = 1L;
+
         public LogstashEnvironmentError(final Ruby runtime, final RubyClass rubyClass) {
             super(runtime, rubyClass);
         }
@@ -53,6 +63,8 @@ public final class JRubyLogstashErrorsExt {
 
     @JRubyClass(name = "ConfigurationError")
     public static final class ConfigurationError extends RubyException {
+
+        private static final long serialVersionUID = 1L;
 
         public ConfigurationError(final Ruby runtime, final RubyClass rubyClass) {
             super(runtime, rubyClass);
@@ -62,6 +74,8 @@ public final class JRubyLogstashErrorsExt {
     @JRubyClass(name = "PluginLoadingError")
     public static final class PluginLoadingError extends RubyException {
 
+        private static final long serialVersionUID = 1L;
+
         public PluginLoadingError(final Ruby runtime, final RubyClass rubyClass) {
             super(runtime, rubyClass);
         }
@@ -69,6 +83,8 @@ public final class JRubyLogstashErrorsExt {
 
     @JRubyClass(name = "ShutdownSignal")
     public static final class ShutdownSignal extends RubyException {
+
+        private static final long serialVersionUID = 1L;
 
         public ShutdownSignal(final Ruby runtime, final RubyClass rubyClass) {
             super(runtime, rubyClass);
@@ -78,6 +94,8 @@ public final class JRubyLogstashErrorsExt {
     @JRubyClass(name = "PluginNoVersionError")
     public static final class PluginNoVersionError extends RubyException {
 
+        private static final long serialVersionUID = 1L;
+
         public PluginNoVersionError(final Ruby runtime, final RubyClass rubyClass) {
             super(runtime, rubyClass);
         }
@@ -85,6 +103,8 @@ public final class JRubyLogstashErrorsExt {
 
     @JRubyClass(name = "BootstrapCheckError")
     public static final class BootstrapCheckError extends RubyException {
+
+        private static final long serialVersionUID = 1L;
 
         public BootstrapCheckError(final Ruby runtime, final RubyClass rubyClass) {
             super(runtime, rubyClass);
@@ -94,6 +114,8 @@ public final class JRubyLogstashErrorsExt {
     @JRubyClass(name = "Bug")
     public static class Bug extends RubyException {
 
+        private static final long serialVersionUID = 1L;
+
         public Bug(final Ruby runtime, final RubyClass rubyClass) {
             super(runtime, rubyClass);
         }
@@ -101,6 +123,8 @@ public final class JRubyLogstashErrorsExt {
 
     @JRubyClass(name = "ThisMethodWasRemoved")
     public static final class ThisMethodWasRemoved extends JRubyLogstashErrorsExt.Bug {
+
+        private static final long serialVersionUID = 1L;
 
         public ThisMethodWasRemoved(final Ruby runtime, final RubyClass rubyClass) {
             super(runtime, rubyClass);
@@ -110,6 +134,8 @@ public final class JRubyLogstashErrorsExt {
     @JRubyClass(name = "ConfigLoadingError")
     public static final class ConfigLoadingError extends RubyException {
 
+        private static final long serialVersionUID = 1L;
+
         public ConfigLoadingError(final Ruby runtime, final RubyClass rubyClass) {
             super(runtime, rubyClass);
         }
@@ -117,6 +143,8 @@ public final class JRubyLogstashErrorsExt {
 
     @JRubyClass(name = "InvalidSourceLoaderSettingError")
     public static final class InvalidSourceLoaderSettingError extends RubyException {
+
+        private static final long serialVersionUID = 1L;
 
         public InvalidSourceLoaderSettingError(final Ruby runtime, final RubyClass rubyClass) {
             super(runtime, rubyClass);

--- a/logstash-core/src/main/java/org/logstash/ext/JRubyWrappedWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JRubyWrappedWriteClientExt.java
@@ -22,6 +22,8 @@ import org.logstash.instrument.metrics.counter.LongCounter;
 @JRubyClass(name = "WrappedWriteClient")
 public final class JRubyWrappedWriteClientExt extends RubyObject implements QueueWriter {
 
+    private static final long serialVersionUID = 1L;
+
     private static final RubySymbol PUSH_DURATION_KEY =
         RubyUtil.RUBY.newSymbol("queue_push_duration_in_millis");
 

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyAckedReadClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyAckedReadClientExt.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 @JRubyClass(name = "AckedReadClient", parent = "QueueReadClientBase")
 public final class JrubyAckedReadClientExt extends QueueReadClientBase implements QueueReadClient {
 
+    private static final long serialVersionUID = 1L;
+
     private JRubyAckedQueueExt queue;
 
     @JRubyMethod(meta = true, required = 1)

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyAckedWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyAckedWriteClientExt.java
@@ -17,6 +17,8 @@ import org.logstash.ackedqueue.ext.JRubyAckedQueueExt;
 @JRubyClass(name = "AckedWriteClient")
 public final class JrubyAckedWriteClientExt extends JRubyAbstractQueueWriteClientExt {
 
+    private static final long serialVersionUID = 1L;
+
     private JRubyAckedQueueExt queue;
 
     private AtomicBoolean closed = new AtomicBoolean();

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -292,6 +292,7 @@ public final class JrubyEventExtLibrary {
          * @param data Either {@code null}, {@link org.jruby.RubyNil} or an instance of
          * {@link MapJavaProxy}
          */
+        @SuppressWarnings("unchecked")
         private void initializeFallback(final ThreadContext context, final IRubyObject data) {
             if (data == null || data.isNil()) {
                 this.event = new Event();

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryReadClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryReadClientExt.java
@@ -14,12 +14,15 @@ import org.logstash.execution.QueueReadClientBase;
 @JRubyClass(name = "MemoryReadClient", parent = "QueueReadClientBase")
 public final class JrubyMemoryReadClientExt extends QueueReadClientBase {
 
-    private BlockingQueue queue;
+    private static final long serialVersionUID = 1L;
+
+    @SuppressWarnings("rawtypes") private BlockingQueue queue;
 
     public JrubyMemoryReadClientExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);
     }
 
+    @SuppressWarnings("rawtypes")
     private JrubyMemoryReadClientExt(final Ruby runtime, final RubyClass metaClass,
                                      BlockingQueue queue, int batchSize, int waitForMillis) {
         super(runtime, metaClass);
@@ -29,6 +32,7 @@ public final class JrubyMemoryReadClientExt extends QueueReadClientBase {
         this.waitForMillis = waitForMillis;
     }
 
+    @SuppressWarnings("rawtypes")
     public static JrubyMemoryReadClientExt create(BlockingQueue queue, int batchSize,
                                                   int waitForMillis) {
         return new JrubyMemoryReadClientExt(RubyUtil.RUBY,
@@ -51,6 +55,7 @@ public final class JrubyMemoryReadClientExt extends QueueReadClientBase {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public QueueBatch readBatch() throws InterruptedException {
         MemoryReadBatch batch = MemoryReadBatch.create(
                 LsQueueUtils.drain(queue, batchSize, waitForNanos));

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryWriteClientExt.java
@@ -14,6 +14,8 @@ import org.logstash.common.LsQueueUtils;
 @JRubyClass(name = "MemoryWriteClient")
 public final class JrubyMemoryWriteClientExt extends JRubyAbstractQueueWriteClientExt {
 
+    private static final long serialVersionUID = 1L;
+
     private BlockingQueue<JrubyEventExtLibrary.RubyEvent> queue;
 
     public JrubyMemoryWriteClientExt(final Ruby runtime, final RubyClass metaClass) {

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyWrappedSynchronousQueueExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyWrappedSynchronousQueueExt.java
@@ -15,6 +15,8 @@ import org.logstash.execution.QueueReadClientBase;
 @JRubyClass(name = "WrappedSynchronousQueue")
 public final class JrubyWrappedSynchronousQueueExt extends AbstractWrappedQueueExt {
 
+    private static final long serialVersionUID = 1L;
+
     private BlockingQueue<JrubyEventExtLibrary.RubyEvent> queue;
 
     public JrubyWrappedSynchronousQueueExt(final Ruby runtime, final RubyClass metaClass) {

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractMetricExt.java
@@ -11,6 +11,8 @@ import org.jruby.runtime.builtin.IRubyObject;
 @JRubyClass(name = "AbstractMetric")
 public abstract class AbstractMetricExt extends RubyObject {
 
+    private static final long serialVersionUID = 1L;
+
     public AbstractMetricExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);
     }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractNamespacedMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractNamespacedMetricExt.java
@@ -12,6 +12,8 @@ import org.jruby.runtime.builtin.IRubyObject;
 @JRubyClass(name = "AbstractNamespacedMetric")
 public abstract class AbstractNamespacedMetricExt extends AbstractMetricExt {
 
+    private static final long serialVersionUID = 1L;
+
     AbstractNamespacedMetricExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);
     }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractSimpleMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractSimpleMetricExt.java
@@ -11,6 +11,8 @@ import org.jruby.runtime.builtin.IRubyObject;
 @JRubyClass(name = "AbstractSimpleMetric")
 public abstract class AbstractSimpleMetricExt extends AbstractMetricExt {
 
+    private static final long serialVersionUID = 1L;
+
     AbstractSimpleMetricExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);
     }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricExt.java
@@ -20,6 +20,8 @@ import org.logstash.RubyUtil;
 @JRubyClass(name = "Metric")
 public final class MetricExt extends AbstractSimpleMetricExt {
 
+    private static final long serialVersionUID = 1L;
+
     public static final RubySymbol COUNTER = RubyUtil.RUBY.newSymbol("counter");
 
     private static final RubyFixnum ONE = RubyUtil.RUBY.newFixnum(1);
@@ -157,6 +159,8 @@ public final class MetricExt extends AbstractSimpleMetricExt {
     @JRubyClass(name = "TimedExecution")
     public static final class TimedExecution extends RubyObject {
 
+        private static final long serialVersionUID = 1L;
+
         private final long startTime = System.nanoTime();
 
         private MetricExt metric;
@@ -194,6 +198,8 @@ public final class MetricExt extends AbstractSimpleMetricExt {
     @JRubyClass(name = "MetricException")
     public static class MetricException extends RubyException {
 
+        private static final long serialVersionUID = 1L;
+
         public MetricException(final Ruby runtime, final RubyClass metaClass) {
             super(runtime, metaClass);
         }
@@ -201,6 +207,8 @@ public final class MetricExt extends AbstractSimpleMetricExt {
 
     @JRubyClass(name = "MetricNoKeyProvided", parent = "MetricException")
     public static final class MetricNoKeyProvided extends MetricException {
+
+        private static final long serialVersionUID = 1L;
 
         public MetricNoKeyProvided(final Ruby runtime, final RubyClass metaClass) {
             super(runtime, metaClass);
@@ -210,6 +218,8 @@ public final class MetricExt extends AbstractSimpleMetricExt {
     @JRubyClass(name = "MetricNoBlockProvided", parent = "MetricException")
     public static final class MetricNoBlockProvided extends MetricException {
 
+        private static final long serialVersionUID = 1L;
+
         public MetricNoBlockProvided(final Ruby runtime, final RubyClass metaClass) {
             super(runtime, metaClass);
         }
@@ -217,6 +227,8 @@ public final class MetricExt extends AbstractSimpleMetricExt {
 
     @JRubyClass(name = "MetricNoNamespaceProvided", parent = "MetricException")
     public static final class MetricNoNamespaceProvided extends MetricException {
+
+        private static final long serialVersionUID = 1L;
 
         public MetricNoNamespaceProvided(final Ruby runtime, final RubyClass metaClass) {
             super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/NamespacedMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/NamespacedMetricExt.java
@@ -14,6 +14,8 @@ import org.logstash.RubyUtil;
 @JRubyClass(name = "NamespacedMetric")
 public final class NamespacedMetricExt extends AbstractNamespacedMetricExt {
 
+    private static final long serialVersionUID = 1L;
+
     private RubyArray namespaceName;
 
     private MetricExt metric;

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/NullMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/NullMetricExt.java
@@ -15,6 +15,8 @@ import org.logstash.RubyUtil;
 @JRubyClass(name = "NullMetric")
 public final class NullMetricExt extends AbstractSimpleMetricExt {
 
+    private static final long serialVersionUID = 1L;
+
     private IRubyObject collector;
 
     public static NullMetricExt create() {
@@ -90,6 +92,8 @@ public final class NullMetricExt extends AbstractSimpleMetricExt {
 
     @JRubyClass(name = "NullTimedExecution")
     public static final class NullTimedExecution extends RubyObject {
+
+        private static final long serialVersionUID = 1L;
 
         private static final NullMetricExt.NullTimedExecution INSTANCE =
             new NullMetricExt.NullTimedExecution(RubyUtil.RUBY, RubyUtil.NULL_TIMED_EXECUTION_CLASS);

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/NullNamespacedMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/NullNamespacedMetricExt.java
@@ -15,6 +15,8 @@ import org.logstash.RubyUtil;
 @JRubyClass(name = "NamespacedNullMetric", parent = "AbstractNamespacedMetric")
 public final class NullNamespacedMetricExt extends AbstractNamespacedMetricExt {
 
+    private static final long serialVersionUID = 1L;
+
     private static final RubySymbol NULL = RubyUtil.RUBY.newSymbol("null");
 
     private RubyArray namespaceName;
@@ -104,6 +106,8 @@ public final class NullNamespacedMetricExt extends AbstractNamespacedMetricExt {
 
     @JRubyClass(name = "NullCounter")
     public static final class NullCounter extends RubyObject {
+
+        private static final long serialVersionUID = 1L;
 
         public static final NullNamespacedMetricExt.NullCounter INSTANCE =
             new NullNamespacedMetricExt.NullCounter(RubyUtil.RUBY, RubyUtil.NULL_COUNTER_CLASS);

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/SnapshotExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/SnapshotExt.java
@@ -12,6 +12,8 @@ import org.jruby.runtime.builtin.IRubyObject;
 @JRubyClass(name = "Snapshot")
 public final class SnapshotExt extends RubyBasicObject {
 
+    private static final long serialVersionUID = 1L;
+
     private IRubyObject metricStore;
 
     private RubyTime createdAt;

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGauge.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGauge.java
@@ -18,6 +18,7 @@ public class LazyDelegatingGauge extends AbstractMetric<Object> implements Gauge
 
     protected final String key;
 
+    @SuppressWarnings("rawtypes")
     private GaugeMetric lazyMetric;
 
     /**
@@ -60,6 +61,7 @@ public class LazyDelegatingGauge extends AbstractMetric<Object> implements Gauge
         return lazyMetric == null ? null : lazyMetric.getValue();
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void set(Object value) {
         if (lazyMetric == null) {
@@ -74,6 +76,7 @@ public class LazyDelegatingGauge extends AbstractMetric<Object> implements Gauge
      *
      * @param value The object used to set this value
      */
+    @SuppressWarnings("deprecation")
     private synchronized void wakeMetric(Object value) {
         if (lazyMetric == null && value != null) {
             //"quack quack"

--- a/logstash-core/src/main/java/org/logstash/log/CustomLogEvent.java
+++ b/logstash-core/src/main/java/org/logstash/log/CustomLogEvent.java
@@ -30,6 +30,9 @@ import java.util.List;
 
 @JsonSerialize(using = CustomLogEventSerializer.class)
 public class CustomLogEvent extends Log4jLogEvent {
+
+    private static final long serialVersionUID = 1L;
+
     public CustomLogEvent(final String loggerName, final Marker marker, final String loggerFQCN, final Level level,
                           final Message message, final List<Property> properties, final Throwable t) {
         super(loggerName, marker, loggerFQCN, level, message, properties, t);

--- a/logstash-core/src/main/java/org/logstash/log/LoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/LoggerExt.java
@@ -22,6 +22,8 @@ import java.net.URI;
 @JRubyClass(name = "Logger")
 public class LoggerExt extends RubyObject {
 
+    private static final long serialVersionUID = 1L;
+
     private static final Object CONFIG_LOCK = new Object();
     private Logger logger;
 

--- a/logstash-core/src/main/java/org/logstash/log/SlowLoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/SlowLoggerExt.java
@@ -17,6 +17,8 @@ import org.logstash.RubyUtil;
 @JRubyClass(name = "SlowLogger")
 public class SlowLoggerExt extends RubyObject {
 
+    private static final long serialVersionUID = 1L;
+
     private static final RubySymbol PLUGIN_PARAMS = RubyUtil.RUBY.newSymbol("plugin_params");
     private static final RubySymbol TOOK_IN_NANOS = RubyUtil.RUBY.newSymbol("took_in_nanos");
     private static final RubySymbol TOOK_IN_MILLIS = RubyUtil.RUBY.newSymbol("took_in_millis");

--- a/logstash-core/src/main/java/org/logstash/log/StructuredMessage.java
+++ b/logstash-core/src/main/java/org/logstash/log/StructuredMessage.java
@@ -8,6 +8,9 @@ import java.util.Map;
 
 @JsonSerialize(using = CustomLogEventSerializer.class)
 public class StructuredMessage implements Message {
+
+    private static final long serialVersionUID = 1L;
+
     private final String message;
     private final Map<Object, Object> params;
 

--- a/logstash-core/src/main/java/org/logstash/plugins/HooksRegistryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/HooksRegistryExt.java
@@ -15,6 +15,9 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 @JRubyClass(name = "HooksRegistry")
 public final class HooksRegistryExt extends RubyObject {
+
+    private static final long serialVersionUID = 1L;
+
     private ConcurrentHashMap<IRubyObject, IRubyObject> registeredEmitters;
     private ConcurrentHashMap<IRubyObject, List<IRubyObject>> registeredHooks;
 

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
@@ -51,6 +51,8 @@ public final class PluginFactoryExt {
     public static final class Plugins extends RubyBasicObject
         implements RubyIntegration.PluginFactory {
 
+        private static final long serialVersionUID = 1L;
+
         private static final RubyString ID_KEY = RubyUtil.RUBY.newString("id");
 
         private final Collection<String> pluginsById = new HashSet<>();
@@ -317,6 +319,8 @@ public final class PluginFactoryExt {
     @JRubyClass(name = "JavaInputWrapper")
     public static final class JavaInputWrapperExt extends RubyObject {
 
+        private static final long serialVersionUID = 1L;
+
         private Input input;
 
         public JavaInputWrapperExt(Ruby runtime, RubyClass metaClass) {
@@ -336,6 +340,8 @@ public final class PluginFactoryExt {
 
     @JRubyClass(name = "ExecutionContextFactory")
     public static final class ExecutionContext extends RubyBasicObject {
+
+        private static final long serialVersionUID = 1L;
 
         private IRubyObject agent;
 
@@ -369,6 +375,8 @@ public final class PluginFactoryExt {
 
     @JRubyClass(name = "PluginMetricFactory")
     public static final class Metrics extends RubyBasicObject {
+
+        private static final long serialVersionUID = 1L;
 
         private static final RubySymbol PLUGINS = RubyUtil.RUBY.newSymbol("plugins");
 

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginLookup.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginLookup.java
@@ -22,6 +22,7 @@ public final class PluginLookup {
         // Utility Class
     }
 
+    @SuppressWarnings("rawtypes")
     public static PluginLookup.PluginClass lookup(final PluginLookup.PluginType type, final String name) {
         Class javaClass = PluginRegistry.getPluginClass(type, name);
         if (javaClass != null) {

--- a/logstash-core/src/main/java/org/logstash/plugins/UniversalPluginExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/UniversalPluginExt.java
@@ -11,6 +11,8 @@ import org.jruby.runtime.builtin.IRubyObject;
 @JRubyClass(name = "UniversalPlugin")
 public final class UniversalPluginExt extends RubyBasicObject {
 
+    private static final long serialVersionUID = 1L;
+
     public UniversalPluginExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);
     }

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/AbstractScanner.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/AbstractScanner.java
@@ -67,11 +67,11 @@ public abstract class AbstractScanner implements Scanner {
         return fqn != null && resultFilter.apply(fqn);
     }
 
+    @SuppressWarnings("rawtypes")
     protected MetadataAdapter getMetadataAdapter() {
         return configuration.getMetadataAdapter();
     }
 
-    //
     @Override
     public boolean equals(Object o) {
         return this == o || o != null && getClass() == o.getClass();

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/Configuration.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/Configuration.java
@@ -19,7 +19,7 @@ public interface Configuration {
     /**
      * the metadata adapter used to fetch metadata from classes
      */
-    @SuppressWarnings("RawUseOfParameterizedType")
+    @SuppressWarnings("rawtypes")
     MetadataAdapter getMetadataAdapter();
 
     /**

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/ConfigurationBuilder.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/ConfigurationBuilder.java
@@ -15,7 +15,7 @@ public final class ConfigurationBuilder implements Configuration {
     private final Set<Scanner> scanners;
 
     private Set<URL> urls;
-    /*lazy*/ protected MetadataAdapter metadataAdapter;
+    @SuppressWarnings("rawtypes") protected MetadataAdapter metadataAdapter;
 
     private Predicate<String> inputsFilter;
 
@@ -158,6 +158,7 @@ public final class ConfigurationBuilder implements Configuration {
      * if javassist library exists in the classpath, this method returns {@link JavassistAdapter} otherwise defaults to {@link JavaReflectionAdapter}.
      * <p>the {@link JavassistAdapter} is preferred in terms of performance and class loading.
      */
+    @SuppressWarnings("rawtypes")
     @Override
     public MetadataAdapter getMetadataAdapter() {
         if (metadataAdapter != null) {

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/JavaReflectionAdapter.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/JavaReflectionAdapter.java
@@ -4,16 +4,14 @@ import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
 
-/** */
+@SuppressWarnings("rawtypes")
 public final class JavaReflectionAdapter implements MetadataAdapter<Class> {
 
     public List<String> getClassAnnotationNames(Class aClass) {
         return getAnnotationNames(aClass.getDeclaredAnnotations());
     }
 
-    public Class getOfCreateClassObject(Vfs.File file) {
-        return getOfCreateClassObject(file, null);
-    }
+    public Class getOfCreateClassObject(Vfs.File file) { return getOfCreateClassObject(file, new ClassLoader[]{}); }
 
     public Class getOfCreateClassObject(Vfs.File file, ClassLoader... loaders) {
         String name = file.getRelativePath().replace("/", ".").replace(".class", "");
@@ -42,7 +40,6 @@ public final class JavaReflectionAdapter implements MetadataAdapter<Class> {
         return file.endsWith(".class");
     }
 
-    //
     private List<String> getAnnotationNames(Annotation[] annotations) {
         List<String> names = new ArrayList<>(annotations.length);
         for (Annotation annotation : annotations) {
@@ -62,7 +59,7 @@ public final class JavaReflectionAdapter implements MetadataAdapter<Class> {
                 }
                 return cl.getName() + Utils.repeat("[]", dim);
             } catch (Throwable e) {
-                //
+                // do nothing
             }
         }
         return type.getName();

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
@@ -99,6 +99,7 @@ public final class PluginRegistry {
         return null;
     }
 
+    @SuppressWarnings({"unchecked","rawtypes"})
     private static Codec instantiateCodec(Class clazz, Configuration configuration, Context context) {
         try {
             Constructor<Codec> constructor = clazz.getConstructor(Configuration.class, Context.class);

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/ReflectionUtils.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/ReflectionUtils.java
@@ -85,9 +85,8 @@ public abstract class ReflectionUtils {
         return result;
     }
 
-    //
     private static List<String> primitiveNames;
-    private static List<Class> primitiveTypes;
+    @SuppressWarnings("rawtypes") private static List<Class> primitiveTypes;
     private static List<String> primitiveDescriptors;
 
     private static void initPrimitives() {
@@ -103,6 +102,7 @@ public abstract class ReflectionUtils {
         return primitiveNames;
     }
 
+    @SuppressWarnings("rawtypes")
     private static List<Class> getPrimitiveTypes() {
         initPrimitives();
         return primitiveTypes;

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/Reflections.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/Reflections.java
@@ -46,7 +46,7 @@ public class Reflections {
         this(ConfigurationBuilder.build(params));
     }
 
-    //
+    @SuppressWarnings("rawtypes")
     protected void scan() {
         if (configuration.getUrls() == null || configuration.getUrls().isEmpty()) {
             return;

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/ReflectionsException.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/ReflectionsException.java
@@ -2,6 +2,8 @@ package org.logstash.plugins.discovery;
 
 public class ReflectionsException extends RuntimeException {
 
+    private static final long serialVersionUID = 1L;
+
     public ReflectionsException(String message) {
         super(message);
     }

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/Store.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/Store.java
@@ -7,6 +7,7 @@ import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -46,7 +47,7 @@ public final class Store {
         if (mmap == null) {
             SetMultimap<String, String> multimap =
                 Multimaps.newSetMultimap(new HashMap<>(),
-                    () -> Sets.newSetFromMap(new ConcurrentHashMap<>()));
+                    () -> Collections.newSetFromMap(new ConcurrentHashMap<>()));
             mmap = concurrent ? Multimaps.synchronizedSetMultimap(multimap) : multimap;
             storeMap.put(index, mmap);
         }

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/Utils.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/Utils.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * a garbage can of convenient methods
+ * Convenient methods for plugin discovery.
  */
 public abstract class Utils {
 
@@ -45,7 +45,7 @@ public abstract class Utils {
         }
     }
 
-    public static String name(Class type) {
+    public static String name(@SuppressWarnings("rawtypes") Class type) {
         if (!type.isArray()) {
             return type.getName();
         } else {
@@ -68,7 +68,7 @@ public abstract class Utils {
         return names(Arrays.asList(types));
     }
 
-    public static String name(Constructor constructor) {
+    public static String name(@SuppressWarnings("rawtypes") Constructor constructor) {
         return constructor.getName() + "." + "<init>" + "(" + Joiner.on(", ").join(names(constructor.getParameterTypes())) + ")";
     }
 

--- a/logstash-core/src/main/java/org/logstash/plugins/pipeline/AddressState.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/pipeline/AddressState.java
@@ -1,6 +1,5 @@
 package org.logstash.plugins.pipeline;
 
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -19,7 +18,7 @@ public class AddressState {
     /**
      * Add the given output and ensure associated input's receivers are updated
      * @param output
-     * @return
+     * @return true if the output was not already added
      */
     public boolean addOutput(PipelineOutput output) {
         return outputs.add(output);

--- a/logstash-core/src/main/java/org/logstash/secret/SecretIdentifier.java
+++ b/logstash-core/src/main/java/org/logstash/secret/SecretIdentifier.java
@@ -59,7 +59,7 @@ public class SecretIdentifier {
         SecretIdentifier that = (SecretIdentifier) o;
 
         if (key != null ? !key.equals(that.key) : that.key != null) return false;
-        return VERSION != null ? VERSION.equals(that.VERSION) : that.VERSION == null;
+        return true;
     }
 
     /**

--- a/logstash-core/src/main/java/org/logstash/secret/cli/SecretStoreCli.java
+++ b/logstash-core/src/main/java/org/logstash/secret/cli/SecretStoreCli.java
@@ -43,7 +43,7 @@ public class SecretStoreCli {
 
     /**
      * Entry point to issue a command line command.
-     * @param primaryCommand The string representation of a {@link Command}, if the String does not map to a {@link Command}, then it will show the help menu.
+     * @param primaryCommand The string representation of a {@link SecretStoreCli.Command}, if the String does not map to a {@link SecretStoreCli.Command}, then it will show the help menu.
      * @param config The configuration needed to work a secret store. May be null for help.
      * @param argument This can be either the identifier for a secret, or a sub command like --help. May be null.
      */

--- a/logstash-core/src/main/java/org/logstash/secret/store/SecretStoreException.java
+++ b/logstash-core/src/main/java/org/logstash/secret/store/SecretStoreException.java
@@ -7,6 +7,8 @@ import org.logstash.secret.SecretIdentifier;
  */
 public class SecretStoreException extends RuntimeException {
 
+    private static final long serialVersionUID = 1L;
+
     private SecretStoreException(String message, Throwable cause) {
         super(message, cause);
     }
@@ -16,18 +18,21 @@ public class SecretStoreException extends RuntimeException {
     }
 
     static public class RetrievalException extends SecretStoreException {
+        private static final long serialVersionUID = 1L;
         public RetrievalException(SecretIdentifier secretIdentifier, Throwable cause) {
             super(String.format("Error while trying to retrieve secret %s", secretIdentifier.toExternalForm()), cause);
         }
     }
 
     static public class ListException extends SecretStoreException {
+        private static final long serialVersionUID = 1L;
         public ListException(Throwable cause) {
             super("Error while trying to list keys in secret store", cause);
         }
     }
 
     static public class CreateException extends SecretStoreException {
+        private static final long serialVersionUID = 1L;
         public CreateException(String message, Throwable cause) {
             super(message, cause);
         }
@@ -38,6 +43,7 @@ public class SecretStoreException extends RuntimeException {
     }
 
     static public class LoadException extends SecretStoreException {
+        private static final long serialVersionUID = 1L;
         public LoadException(String message, Throwable cause) {
             super(message, cause);
         }
@@ -48,30 +54,35 @@ public class SecretStoreException extends RuntimeException {
     }
 
     static public class PersistException extends SecretStoreException {
+        private static final long serialVersionUID = 1L;
         public PersistException(SecretIdentifier secretIdentifier, Throwable cause) {
             super(String.format("Error while trying to store secret %s", secretIdentifier.toExternalForm()), cause);
         }
     }
 
     static public class PurgeException extends SecretStoreException {
+        private static final long serialVersionUID = 1L;
         public PurgeException(SecretIdentifier secretIdentifier, Throwable cause) {
             super(String.format("Error while trying to purge secret %s", secretIdentifier.toExternalForm()), cause);
         }
     }
 
     static public class UnknownException extends SecretStoreException {
+        private static final long serialVersionUID = 1L;
         public UnknownException(String message, Throwable cause) {
             super(message, cause);
         }
     }
 
     static public class ImplementationNotFoundException extends SecretStoreException {
+        private static final long serialVersionUID = 1L;
         public ImplementationNotFoundException(String message, Throwable throwable) {
             super(message, throwable);
         }
     }
 
     static public class AccessException extends SecretStoreException {
+        private static final long serialVersionUID = 1L;
         public AccessException(String message, Throwable throwable) {
             super(message, throwable);
         }
@@ -82,12 +93,14 @@ public class SecretStoreException extends RuntimeException {
     }
 
     static public class AlreadyExistsException extends SecretStoreException {
+        private static final long serialVersionUID = 1L;
         public AlreadyExistsException(String message) {
             super(message);
         }
     }
 
     static public class InvalidConfigurationException extends SecretStoreException {
+        private static final long serialVersionUID = 1L;
         public InvalidConfigurationException(String message) {
             super(message);
         }

--- a/logstash-core/src/test/java/org/logstash/EventTest.java
+++ b/logstash-core/src/test/java/org/logstash/EventTest.java
@@ -422,6 +422,7 @@ public final class EventTest {
         assertThat(event.getField("timestamp"), is(timestamp));
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void metadataFieldsShouldBeValuefied() {
         final Event event = new Event();
@@ -434,6 +435,7 @@ public final class EventTest {
         assertEquals(list, Arrays.asList("hello"));
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void metadataRootShouldBeValueified() {
         final Event event = new Event();

--- a/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
+++ b/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
@@ -31,6 +31,7 @@ public final class FieldReferenceTest {
             previousParsingMode = FieldReference.setParsingMode(parsingMode());
         }
 
+        @SuppressWarnings("unchecked")
         @Before
         public void clearParsingCache() throws Exception {
             final Field cacheField = FieldReference.class.getDeclaredField("CACHE");
@@ -40,6 +41,7 @@ public final class FieldReferenceTest {
             cache.clear();
         }
 
+        @SuppressWarnings("unchecked")
         @Before
         public void clearDedupCache() throws Exception  {
             final Field cacheField = FieldReference.class.getDeclaredField("DEDUP");
@@ -70,6 +72,7 @@ public final class FieldReferenceTest {
             );
         }
 
+        @SuppressWarnings("unchecked")
         @Test
         public void testCacheUpperBound() throws NoSuchFieldException, IllegalAccessException {
             final Field cacheField = FieldReference.class.getDeclaredField("CACHE");

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
@@ -793,6 +793,7 @@ public class QueueTest {
         }
     }
 
+    @SuppressWarnings("try")
     @Test
     public void getsPersistedByteSizeCorrectlyForFullyAckedDeletedTailPages() throws Exception {
         final Queueable element = new StringElement("0123456789"); // 10 bytes

--- a/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
@@ -412,7 +412,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
 
     private Supplier<Consumer<Collection<JrubyEventExtLibrary.RubyEvent>>> mockOutputSupplier() {
         return () -> events -> events.forEach(
-            event -> EVENT_SINKS.get(runId).add((JrubyEventExtLibrary.RubyEvent) event)
+            event -> EVENT_SINKS.get(runId).add(event)
         );
     }
 

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/FakeOutClass.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/FakeOutClass.java
@@ -10,6 +10,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 
 import static org.logstash.RubyUtil.RUBY;
 
+@SuppressWarnings("serial")
 @JRubyClass(name = "FakeOutClass")
 public class FakeOutClass extends RubyObject {
 

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/OutputDelegatorTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/OutputDelegatorTest.java
@@ -25,6 +25,7 @@ import static org.logstash.RubyUtil.NAMESPACED_METRIC_CLASS;
 import static org.logstash.RubyUtil.RUBY;
 import static org.logstash.RubyUtil.RUBY_OUTPUT_DELEGATOR_CLASS;
 
+@SuppressWarnings("rawtypes")
 @NotThreadSafe
 public class OutputDelegatorTest extends RubyEnvTestCase {
 

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/RubyHashGaugeTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/RubyHashGaugeTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 /**
  * Unit tests for {@link RubyHashGauge}
  */
+@SuppressWarnings("deprecation")
 @RunWith(MockitoJUnitRunner.class)
 public class RubyHashGaugeTest {
 

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/RubyTimeStampGaugeTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/RubyTimeStampGaugeTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Unit tests for {@link RubyTimeStampGauge}
  */
+@SuppressWarnings("deprecation")
 @RunWith(MockitoJUnitRunner.class)
 public class RubyTimeStampGaugeTest {
 

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/UnknownGaugeTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/gauge/UnknownGaugeTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Unit tests for {@link UnknownGauge}
  */
+@SuppressWarnings("deprecation")
 public class UnknownGaugeTest {
 
     @Test

--- a/logstash-core/src/test/java/org/logstash/instruments/monitors/ProcessMonitorTest.java
+++ b/logstash-core/src/test/java/org/logstash/instruments/monitors/ProcessMonitorTest.java
@@ -34,6 +34,7 @@ public class ProcessMonitorTest {
     }
 
     @Test
+    @SuppressWarnings("rawtypes")
     public void testReportMemStats() {
         Map<String, Object> processStats = ProcessMonitor.detect().toMap();
         assumeTrue((Boolean) processStats.get("is_unix"));

--- a/logstash-core/src/test/java/org/logstash/plugins/codecs/LineTest.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/codecs/LineTest.java
@@ -231,7 +231,7 @@ public class LineTest {
 
         // decode with UTF-8
         flushConsumer.events.clear();
-        Line utf8decoder = new Line(new Configuration(Collections.EMPTY_MAP), null);
+        Line utf8decoder = new Line(new Configuration(Collections.emptyMap()), null);
         byte[] rightSingleQuoteInUtf8 = {(byte) 0xE2, (byte) 0x80, (byte) 0x99};
         ByteBuffer b2 = ByteBuffer.wrap(rightSingleQuoteInUtf8);
         utf8decoder.decode(b2, flushConsumer);

--- a/logstash-core/src/test/java/org/logstash/plugins/inputs/StdinTest.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/inputs/StdinTest.java
@@ -52,7 +52,7 @@ public class StdinTest {
     private static TestQueueWriter testStdin(byte[] input) throws IOException {
         TestQueueWriter queueWriter = new TestQueueWriter();
         try (FileChannel inChannel = getTestFileChannel(input)) {
-            Stdin stdin = new Stdin(new Configuration(Collections.EMPTY_MAP), null, inChannel);
+            Stdin stdin = new Stdin(new Configuration(Collections.emptyMap()), null, inChannel);
             Thread t = new Thread(() -> stdin.start(queueWriter));
             t.start();
             try {

--- a/logstash-core/src/test/java/org/logstash/plugins/outputs/StdoutTest.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/outputs/StdoutTest.java
@@ -31,7 +31,7 @@ public class StdoutTest {
                 super.close();
             }
         };
-        Stdout stdout = new Stdout(new Configuration(Collections.EMPTY_MAP), null, dummyOutputStream);
+        Stdout stdout = new Stdout(new Configuration(Collections.emptyMap()), null, dummyOutputStream);
         stdout.output(getTestEvents());
         stdout.stop();
 
@@ -47,7 +47,7 @@ public class StdoutTest {
         }
 
         OutputStream dummyOutputStream = new ByteArrayOutputStream(0);
-        Stdout stdout = new Stdout(new Configuration(Collections.EMPTY_MAP), null, dummyOutputStream);
+        Stdout stdout = new Stdout(new Configuration(Collections.emptyMap()), null, dummyOutputStream);
         stdout.output(testEvents);
         stdout.stop();
 

--- a/logstash-core/src/test/java/org/logstash/secret/store/SecretStoreFactoryTest.java
+++ b/logstash-core/src/test/java/org/logstash/secret/store/SecretStoreFactoryTest.java
@@ -23,6 +23,7 @@ import static org.logstash.secret.store.SecretStoreFactory.LOGSTASH_MARKER;
 /**
  * Unit tests for {@link SecretStoreFactory}
  */
+@SuppressWarnings({"serial", "rawtypes", "unchecked"})
 public class SecretStoreFactoryTest {
 
     @Rule

--- a/logstash-core/src/test/java/org/logstash/secret/store/SecureConfigTest.java
+++ b/logstash-core/src/test/java/org/logstash/secret/store/SecureConfigTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Unit tests for {@link SecureConfig}
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class SecureConfigTest {
 
     private SecureConfig secureConfig;


### PR DESCRIPTION
This is a separate back-port of https://github.com/elastic/logstash/pull/10241 to resolve merge conflicts with the `6.x` branch.
