### PR TITLE
Resolve compiler warnings for jruby_9_2 branch

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ConvertedList.java
+++ b/logstash-core/src/main/java/org/logstash/ConvertedList.java
@@ -37,7 +37,7 @@ public final class ConvertedList extends ArrayList<Object> {
         return result;
     }
 
-    public static ConvertedList newFromRubyArray(RubyArray a) {
+    public static ConvertedList newFromRubyArray(@SuppressWarnings("rawtypes") RubyArray a) {
         final ConvertedList result = new ConvertedList(a.size());
 
         for (IRubyObject o : a.toJavaArray()) {

--- a/logstash-core/src/main/java/org/logstash/RubyUtil.java
+++ b/logstash-core/src/main/java/org/logstash/RubyUtil.java
@@ -1,6 +1,5 @@
 package org.logstash;
 
-import org.jruby.NativeException;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
@@ -562,9 +561,10 @@ public final class RubyUtil {
      * @param e the Java exception to wrap
      * @return RaiseException the wrapped IOError
      */
+    @SuppressWarnings("deprecation")
     public static RaiseException newRubyIOError(Ruby runtime, Throwable e) {
         // will preserve Java stacktrace & bubble up as a Ruby IOError
-        return new RaiseException(e, new NativeException(runtime, runtime.getIOError(), e));
+        return new RaiseException(e, new org.jruby.NativeException(runtime, runtime.getIOError(), e));
     }
 
     /**

--- a/logstash-core/src/main/java/org/logstash/Rubyfier.java
+++ b/logstash-core/src/main/java/org/logstash/Rubyfier.java
@@ -55,6 +55,7 @@ public final class Rubyfier {
         return fallbackConvert(runtime, input, cls);
     }
 
+    @SuppressWarnings("rawtypes")
     private static RubyArray deepList(final Ruby runtime, final Collection<?> list) {
         final int length = list.size();
         final RubyArray array = runtime.newArray(length);

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/AckedReadBatch.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/AckedReadBatch.java
@@ -52,7 +52,7 @@ public final class AckedReadBatch implements QueueBatch {
         }
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public RubyArray to_a() {
         ThreadContext context = RUBY.getCurrentContext();

--- a/logstash-core/src/main/java/org/logstash/common/AbstractDeadLetterQueueWriterExt.java
+++ b/logstash-core/src/main/java/org/logstash/common/AbstractDeadLetterQueueWriterExt.java
@@ -141,7 +141,7 @@ public abstract class AbstractDeadLetterQueueWriterExt extends RubyObject {
             final IRubyObject pluginType) {
             writerWrapper = innerWriter;
             if (writerWrapper.getJavaClass().equals(DeadLetterQueueWriter.class)) {
-                this.innerWriter = (DeadLetterQueueWriter) writerWrapper.toJava(
+                this.innerWriter = writerWrapper.toJava(
                     DeadLetterQueueWriter.class
                 );
             }

--- a/logstash-core/src/main/java/org/logstash/common/BufferedTokenizerExt.java
+++ b/logstash-core/src/main/java/org/logstash/common/BufferedTokenizerExt.java
@@ -18,7 +18,7 @@ public class BufferedTokenizerExt extends RubyObject {
 
     private static final IRubyObject MINUS_ONE = RubyUtil.RUBY.newFixnum(-1);
 
-    private RubyArray input = RubyUtil.RUBY.newArray();
+    private @SuppressWarnings("rawtypes") RubyArray input = RubyUtil.RUBY.newArray();
     private IRubyObject delimiter = RubyUtil.RUBY.newString("\n");
     private int sizeLimit;
     private boolean hasSizeLimit;
@@ -53,6 +53,7 @@ public class BufferedTokenizerExt extends RubyObject {
      * @return Extracted tokens
      */
     @JRubyMethod
+    @SuppressWarnings("rawtypes")
     public RubyArray extract(final ThreadContext context, IRubyObject data) {
         final RubyArray entities = ((RubyString) data).split(context, delimiter, MINUS_ONE);
         if (hasSizeLimit) {

--- a/logstash-core/src/main/java/org/logstash/config/ir/ConfigCompiler.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/ConfigCompiler.java
@@ -40,6 +40,6 @@ public final class ConfigCompiler {
                     RubyUtil.RUBY.newBoolean(supportEscapes)
                 }
             );
-        return (PipelineIR) code.toJava(PipelineIR.class);
+        return code.toJava(PipelineIR.class);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java
@@ -107,7 +107,7 @@ public abstract class AbstractFilterDelegatorExt extends RubyObject {
     }
 
     @JRubyMethod(name = "multi_filter")
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public RubyArray multiFilter(final IRubyObject input) {
         RubyArray batch = (RubyArray) input;
         eventMetricIn.increment((long) batch.size());
@@ -124,9 +124,11 @@ public abstract class AbstractFilterDelegatorExt extends RubyObject {
         return result;
     }
 
+    @SuppressWarnings({"rawtypes"})
     protected abstract RubyArray doMultiFilter(final RubyArray batch);
 
     @JRubyMethod(name = "flush")
+    @SuppressWarnings("rawtypes")
     public RubyArray flush(final IRubyObject input) {
         RubyHash options = (RubyHash) input;
         final ThreadContext context = WorkerLoop.THREAD_CONTEXT.get();

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java
@@ -93,6 +93,7 @@ public abstract class AbstractOutputDelegatorExt extends RubyObject {
     @SuppressWarnings("unchecked")
     @JRubyMethod(name = OUTPUT_METHOD_NAME)
     public IRubyObject multiReceive(final IRubyObject events) {
+        @SuppressWarnings("rawtypes")
         final RubyArray batch = (RubyArray) events;
         final int count = batch.size();
         eventMetricIn.increment((long) count);

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/Dataset.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/Dataset.java
@@ -24,7 +24,8 @@ public interface Dataset {
     Dataset IDENTITY = new Dataset() {
         @SuppressWarnings("unchecked")
         @Override
-        public Collection<JrubyEventExtLibrary.RubyEvent> compute(final RubyArray batch, final boolean flush, final boolean shutdown) {
+        public Collection<JrubyEventExtLibrary.RubyEvent> compute(final @SuppressWarnings("rawtypes") RubyArray batch,
+                                                                  final boolean flush, final boolean shutdown) {
             return batch;
         }
 
@@ -43,7 +44,7 @@ public interface Dataset {
      * the pipeline it belongs to is shut down
      * @return Computed {@link RubyArray} of {@link org.logstash.ext.JrubyEventExtLibrary.RubyEvent}
      */
-    Collection<JrubyEventExtLibrary.RubyEvent> compute(RubyArray batch,
+    Collection<JrubyEventExtLibrary.RubyEvent> compute(@SuppressWarnings({"rawtypes"}) RubyArray batch,
         boolean flush, boolean shutdown);
 
     /**

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/DatasetCompiler.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/DatasetCompiler.java
@@ -95,6 +95,7 @@ public final class DatasetCompiler {
         } else {
             final Collection<ValueSyntaxElement> parentFields =
                 parents.stream().map(fields::add).collect(Collectors.toList());
+            @SuppressWarnings("rawtypes")
             final RubyArray inputBuffer = RubyUtil.RUBY.newArray();
             clear.add(clearSyntax(parentFields));
             final ValueSyntaxElement inputBufferField = fields.add(inputBuffer);
@@ -167,6 +168,7 @@ public final class DatasetCompiler {
         } else {
             final Collection<ValueSyntaxElement> parentFields =
                 parents.stream().map(fields::add).collect(Collectors.toList());
+            @SuppressWarnings("rawtypes")
             final RubyArray buffer = RubyUtil.RUBY.newArray();
             final Closure inlineClear;
             if (terminal) {
@@ -371,8 +373,8 @@ public final class DatasetCompiler {
         }
 
         @Override
-        public Collection<JrubyEventExtLibrary.RubyEvent> compute(final RubyArray batch,
-            final boolean flush, final boolean shutdown) {
+        public Collection<JrubyEventExtLibrary.RubyEvent> compute(@SuppressWarnings("rawtypes") final RubyArray batch,
+                                                                  final boolean flush, final boolean shutdown) {
             if (done) {
                 return data;
             }

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
@@ -94,6 +94,7 @@ public final class FilterDelegatorExt extends AbstractFilterDelegatorExt {
     }
 
     @Override
+    @SuppressWarnings({"rawtypes"})
     protected RubyArray doMultiFilter(final RubyArray batch) {
         return (RubyArray) filterMethod.call(
                 WorkerLoop.THREAD_CONTEXT.get(), filter, filterClass, FILTER_METHOD_NAME, batch);

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaFilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaFilterDelegatorExt.java
@@ -45,7 +45,7 @@ public class JavaFilterDelegatorExt extends AbstractFilterDelegatorExt {
         return instance;
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked","rawtypes"})
     @Override
     protected RubyArray doMultiFilter(final RubyArray batch) {
         List<Event> inputEvents = (List<Event>)batch.stream()

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
@@ -148,7 +148,7 @@ public final class OutputStrategyExt {
 
         private IRubyObject workerCount;
 
-        private RubyArray workers;
+        private @SuppressWarnings({"rawtypes"}) RubyArray workers;
 
         public LegacyOutputStrategyExt(final Ruby runtime, final RubyClass metaClass) {
             super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -45,10 +45,10 @@ public class AbstractPipelineExt extends RubyBasicObject {
 
     private static final Logger LOGGER = LogManager.getLogger(AbstractPipelineExt.class);
 
-    private static final RubyArray CAPACITY_NAMESPACE =
+    private static final @SuppressWarnings("rawtypes") RubyArray CAPACITY_NAMESPACE =
         RubyArray.newArray(RubyUtil.RUBY, RubyUtil.RUBY.newSymbol("capacity"));
 
-    private static final RubyArray DATA_NAMESPACE =
+    private static final @SuppressWarnings("rawtypes") RubyArray DATA_NAMESPACE =
         RubyArray.newArray(RubyUtil.RUBY, RubyUtil.RUBY.newSymbol("data"));
 
     private static final RubySymbol PAGE_CAPACITY_IN_BYTES =
@@ -76,7 +76,7 @@ public class AbstractPipelineExt extends RubyBasicObject {
 
     private static final RubySymbol DLQ_KEY = RubyUtil.RUBY.newSymbol("dlq");
 
-    private static final RubyArray EVENTS_METRIC_NAMESPACE = RubyArray.newArray(
+    private static final @SuppressWarnings("rawtypes") RubyArray EVENTS_METRIC_NAMESPACE = RubyArray.newArray(
         RubyUtil.RUBY, new IRubyObject[]{MetricKeys.STATS_KEY, MetricKeys.EVENTS_KEY}
     );
 
@@ -182,7 +182,7 @@ public class AbstractPipelineExt extends RubyBasicObject {
                     context.runtime,
                     new IRubyObject[]{
                         MetricKeys.STATS_KEY, MetricKeys.PIPELINES_KEY,
-                        pipelineId.convertToString().intern19(), MetricKeys.EVENTS_KEY
+                        pipelineId.convertToString().intern(), MetricKeys.EVENTS_KEY
                     }
                 )
             )

--- a/logstash-core/src/main/java/org/logstash/execution/JavaBasePipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/JavaBasePipelineExt.java
@@ -30,11 +30,11 @@ public final class JavaBasePipelineExt extends AbstractPipelineExt {
 
     private CompiledPipeline lirExecution;
 
-    private RubyArray inputs;
+    private @SuppressWarnings("rawtypes") RubyArray inputs;
 
-    private RubyArray filters;
+    private @SuppressWarnings("rawtypes") RubyArray filters;
 
-    private RubyArray outputs;
+    private @SuppressWarnings("rawtypes") RubyArray outputs;
 
     public JavaBasePipelineExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);
@@ -75,16 +75,19 @@ public final class JavaBasePipelineExt extends AbstractPipelineExt {
     }
 
     @JRubyMethod
+    @SuppressWarnings("rawtypes")
     public RubyArray inputs() {
         return inputs;
     }
 
     @JRubyMethod
+    @SuppressWarnings("rawtypes")
     public RubyArray filters() {
         return filters;
     }
 
     @JRubyMethod
+    @SuppressWarnings("rawtypes")
     public RubyArray outputs() {
         return outputs;
     }
@@ -100,7 +103,7 @@ public final class JavaBasePipelineExt extends AbstractPipelineExt {
         return nonReloadablePlugins(context).isEmpty() ? context.tru : context.fals;
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "rawtypes"})
     @JRubyMethod(name = "non_reloadable_plugins")
     public RubyArray nonReloadablePlugins(final ThreadContext context) {
         final RubyArray result = RubyArray.newArray(context.runtime);

--- a/logstash-core/src/main/java/org/logstash/execution/MemoryReadBatch.java
+++ b/logstash-core/src/main/java/org/logstash/execution/MemoryReadBatch.java
@@ -30,6 +30,7 @@ public final class MemoryReadBatch implements QueueBatch {
     }
 
     @Override
+    @SuppressWarnings({"rawtypes"})
     public RubyArray to_a() {
         ThreadContext context = RUBY.getCurrentContext();
         final RubyArray result = context.runtime.newArray(events.size());

--- a/logstash-core/src/main/java/org/logstash/execution/PipelineReporterExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/PipelineReporterExt.java
@@ -104,6 +104,7 @@ public final class PipelineReporterExt extends RubyBasicObject {
         final RubyHash batchMap = (RubyHash) pipeline
             .callMethod(context, "filter_queue_client")
             .callMethod(context, "inflight_batches");
+        @SuppressWarnings("rawtypes")
         final RubyArray workerStates = workerStates(context, batchMap);
         result.op_aset(context, WORKER_STATES_KEY, workerStates);
         result.op_aset(
@@ -131,7 +132,7 @@ public final class PipelineReporterExt extends RubyBasicObject {
         return result;
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked","rawtypes"})
     private RubyArray workerStates(final ThreadContext context, final RubyHash batchMap) {
         final RubyArray result = context.runtime.newArray();
         ((Iterable<IRubyObject>) pipeline.callMethod(context, "worker_threads"))
@@ -155,7 +156,7 @@ public final class PipelineReporterExt extends RubyBasicObject {
         return result;
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked","rawtypes"})
     private RubyArray outputInfo(final ThreadContext context) {
         final RubyArray result = context.runtime.newArray();
         final IRubyObject outputs = pipeline.callMethod(context, "outputs");

--- a/logstash-core/src/main/java/org/logstash/execution/QueueBatch.java
+++ b/logstash-core/src/main/java/org/logstash/execution/QueueBatch.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 
 public interface QueueBatch {
     int filteredSize();
-    RubyArray to_a();
+    @SuppressWarnings({"rawtypes"}) RubyArray to_a();
     void merge(IRubyObject event);
     void close() throws IOException;
 }

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyAckedWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyAckedWriteClientExt.java
@@ -28,10 +28,10 @@ public final class JrubyAckedWriteClientExt extends JRubyAbstractQueueWriteClien
         final IRubyObject queue, final IRubyObject closed) {
         return new JrubyAckedWriteClientExt(
             context.runtime, RubyUtil.ACKED_WRITE_CLIENT_CLASS,
-            (JRubyAckedQueueExt) queue.toJava(
+            queue.toJava(
                 JRubyAckedQueueExt.class
             ),
-            (AtomicBoolean) closed.toJava(AtomicBoolean.class)
+            closed.toJava(AtomicBoolean.class)
         );
     }
 

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -174,7 +174,7 @@ public final class JrubyEventExtLibrary {
             try {
                 return RubyString.newString(context.runtime, event.sprintf(format.toString()));
             } catch (IOException e) {
-                throw new RaiseException(getRuntime(), RubyUtil.LOGSTASH_ERROR, "timestamp field is missing", true);
+                throw RaiseException.from(getRuntime(), RubyUtil.LOGSTASH_ERROR, "timestamp field is missing");
             }
         }
 
@@ -212,7 +212,7 @@ public final class JrubyEventExtLibrary {
             try {
                 return RubyString.newString(context.runtime, event.toJson());
             } catch (Exception e) {
-                throw new RaiseException(context.runtime, RubyUtil.GENERATOR_ERROR, e.getMessage(), true);
+                throw RaiseException.from(context.runtime, RubyUtil.GENERATOR_ERROR, e.getMessage());
             }
         }
 
@@ -226,9 +226,10 @@ public final class JrubyEventExtLibrary {
             try {
                 events = Event.fromJson(value.asJavaString());
             } catch (Exception e) {
-                throw new RaiseException(context.runtime, RubyUtil.PARSER_ERROR, e.getMessage(), true);
+                throw RaiseException.from(context.runtime, RubyUtil.PARSER_ERROR, e.getMessage());
             }
 
+            @SuppressWarnings("rawtypes")
             RubyArray result = RubyArray.newArray(context.runtime, events.length);
 
             if (events.length == 1) {

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
@@ -63,10 +63,9 @@ public final class JrubyTimestampExtLibrary {
                 try {
                     this.timestamp = new Timestamp(time.toString());
                 } catch (IllegalArgumentException e) {
-                    throw new RaiseException(
+                    throw RaiseException.from(
                         getRuntime(), RubyUtil.TIMESTAMP_PARSER_ERROR,
-                        "invalid timestamp string format " + time,
-                        true
+                        "invalid timestamp string format " + time
                     );
 
                 }
@@ -151,10 +150,9 @@ public final class JrubyTimestampExtLibrary {
                     return context.runtime.getNil();
                 }
              } catch (IllegalArgumentException e) {
-                throw new RaiseException(
+                throw RaiseException.from(
                         context.runtime, RubyUtil.TIMESTAMP_PARSER_ERROR,
-                        "invalid timestamp format " + e.getMessage(),
-                        true
+                        "invalid timestamp format " + e.getMessage()
                 );
 
             }
@@ -167,10 +165,9 @@ public final class JrubyTimestampExtLibrary {
                 try {
                     return fromRString(context.runtime, (RubyString) time);
                 } catch (IllegalArgumentException e) {
-                    throw new RaiseException(
+                    throw RaiseException.from(
                             context.runtime, RubyUtil.TIMESTAMP_PARSER_ERROR,
-                            "invalid timestamp format " + e.getMessage(),
-                            true
+                            "invalid timestamp format " + e.getMessage()
                     );
 
                 }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractNamespacedMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractNamespacedMetricExt.java
@@ -51,6 +51,7 @@ public abstract class AbstractNamespacedMetricExt extends AbstractMetricExt {
     }
 
     @JRubyMethod(name = "namespace_name")
+    @SuppressWarnings("rawtypes")
     public RubyArray namespaceName(final ThreadContext context) {
         return getNamespaceName(context);
     }
@@ -58,6 +59,7 @@ public abstract class AbstractNamespacedMetricExt extends AbstractMetricExt {
     protected abstract IRubyObject getGauge(ThreadContext context, IRubyObject key,
         IRubyObject value);
 
+    @SuppressWarnings("rawtypes")
     protected abstract RubyArray getNamespaceName(ThreadContext context);
 
     protected abstract IRubyObject getCounter(ThreadContext context, IRubyObject key);

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/NamespacedMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/NamespacedMetricExt.java
@@ -16,12 +16,12 @@ public final class NamespacedMetricExt extends AbstractNamespacedMetricExt {
 
     private static final long serialVersionUID = 1L;
 
-    private RubyArray namespaceName;
+    private @SuppressWarnings("rawtypes") RubyArray namespaceName;
 
     private MetricExt metric;
 
     public static NamespacedMetricExt create(final MetricExt metric,
-        final RubyArray namespaceName) {
+        final @SuppressWarnings("rawtypes") RubyArray namespaceName) {
         final NamespacedMetricExt res =
             new NamespacedMetricExt(RubyUtil.RUBY, RubyUtil.NAMESPACED_METRIC_CLASS);
         res.metric = metric;
@@ -93,6 +93,7 @@ public final class NamespacedMetricExt extends AbstractNamespacedMetricExt {
     }
 
     @Override
+    @SuppressWarnings("rawtypes")
     protected RubyArray getNamespaceName(final ThreadContext context) {
         return namespaceName;
     }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/NullNamespacedMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/NullNamespacedMetricExt.java
@@ -19,12 +19,12 @@ public final class NullNamespacedMetricExt extends AbstractNamespacedMetricExt {
 
     private static final RubySymbol NULL = RubyUtil.RUBY.newSymbol("null");
 
-    private RubyArray namespaceName;
+    private @SuppressWarnings("rawtypes") RubyArray namespaceName;
 
     private NullMetricExt metric;
 
     public static AbstractNamespacedMetricExt create(final NullMetricExt metric,
-        final RubyArray namespaceName) {
+        final @SuppressWarnings("rawtypes") RubyArray namespaceName) {
         final NullNamespacedMetricExt res =
             new NullNamespacedMetricExt(RubyUtil.RUBY, RubyUtil.NULL_NAMESPACED_METRIC_CLASS);
         res.metric = metric;
@@ -88,6 +88,7 @@ public final class NullNamespacedMetricExt extends AbstractNamespacedMetricExt {
     }
 
     @Override
+    @SuppressWarnings("rawtypes")
     protected RubyArray getNamespaceName(final ThreadContext context) {
         return namespaceName;
     }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/SnapshotExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/SnapshotExt.java
@@ -28,7 +28,7 @@ public final class SnapshotExt extends RubyBasicObject {
         if (args.length == 2) {
             createdAt = (RubyTime) args[1];
         } else {
-            createdAt = (RubyTime) RubyTime.newInstance(context, context.runtime.getTime());
+            createdAt = RubyTime.newInstance(context, context.runtime.getTime());
         }
         return this;
     }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/counter/LongCounter.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/counter/LongCounter.java
@@ -37,7 +37,7 @@ public class LongCounter extends AbstractMetric<Long> implements CounterMetric<L
         counter.callMethod(context, "increment", context.runtime.newFixnum(0));
         final LongCounter javaCounter;
         if (LongCounter.class.isAssignableFrom(counter.getJavaClass())) {
-            javaCounter = (LongCounter) counter.toJava(LongCounter.class);
+            javaCounter = counter.toJava(LongCounter.class);
         } else {
             javaCounter = DUMMY_COUNTER;
         }

--- a/logstash-core/src/main/java/org/logstash/log/LoggableExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/LoggableExt.java
@@ -54,7 +54,7 @@ public final class LoggableExt {
         return ((RubyString) ((RubyString) name).gsub(
             context, RubyUtil.RUBY.newString("::"), RubyUtil.RUBY.newString("."),
             Block.NULL_BLOCK
-        )).downcase19(context);
+        )).downcase(context);
     }
 
     /**

--- a/logstash-core/src/main/java/org/logstash/log/StructuredMessage.java
+++ b/logstash-core/src/main/java/org/logstash/log/StructuredMessage.java
@@ -14,7 +14,7 @@ public class StructuredMessage implements Message {
     private final String message;
     private final Map<Object, Object> params;
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked","rawtypes"})
     public StructuredMessage(String message) {
         this(message, (Map) null);
     }

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
@@ -73,7 +73,7 @@ public final class PluginFactoryExt {
             final RubyString id = (RubyString) arguments.op_aref(context, ID_KEY);
             filterInstance.callMethod(
                     context, "metric=",
-                    ((AbstractMetricExt) args[3]).namespace(context, id.intern19())
+                    ((AbstractMetricExt) args[3]).namespace(context, id.intern())
             );
             filterInstance.callMethod(context, "execution_context=", args[4]);
             return new FilterDelegatorExt(context.runtime, RubyUtil.FILTER_DELEGATOR_CLASS)
@@ -88,7 +88,7 @@ public final class PluginFactoryExt {
         public PluginFactoryExt.Plugins initialize(final ThreadContext context,
                                                    final IRubyObject[] args) {
             return init(
-                    (PipelineIR) args[0].toJava(PipelineIR.class),
+                    args[0].toJava(PipelineIR.class),
                     (PluginFactoryExt.Metrics) args[1], (PluginFactoryExt.ExecutionContext) args[2],
                     (RubyClass) args[3]
             );
@@ -391,7 +391,7 @@ public final class PluginFactoryExt {
         @JRubyMethod
         public PluginFactoryExt.Metrics initialize(final ThreadContext context,
             final IRubyObject pipelineId, final IRubyObject metrics) {
-            this.pipelineId = pipelineId.convertToString().intern19();
+            this.pipelineId = pipelineId.convertToString().intern();
             if (metrics.isNil()) {
                 this.metric = new NullMetricExt(context.runtime, RubyUtil.NULL_METRIC_CLASS);
             } else {

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/ConfigurationBuilder.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/ConfigurationBuilder.java
@@ -29,7 +29,7 @@ public final class ConfigurationBuilder implements Configuration {
         urls = Sets.newHashSet();
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked","rawtypes"})
     public static ConfigurationBuilder build(final Object... params) {
         ConfigurationBuilder builder = new ConfigurationBuilder();
 

--- a/logstash-core/src/test/java/org/logstash/RubyfierTest.java
+++ b/logstash-core/src/test/java/org/logstash/RubyfierTest.java
@@ -52,6 +52,7 @@ public class RubyfierTest {
         List<String> data = new ArrayList<>();
         data.add("foo");
 
+        @SuppressWarnings("rawtypes")
         RubyArray rubyArray = (RubyArray)Rubyfier.deep(RubyUtil.RUBY, data);
 
         // toJavaArray does not newFromRubyArray inner elements to Java types \o/
@@ -88,6 +89,7 @@ public class RubyfierTest {
         List<Integer> data = new ArrayList<>();
         data.add(1);
 
+        @SuppressWarnings("rawtypes")
         RubyArray rubyArray = (RubyArray)Rubyfier.deep(RubyUtil.RUBY, data);
 
         // toJavaArray does not newFromRubyArray inner elements to Java types \o/
@@ -124,6 +126,7 @@ public class RubyfierTest {
         List<Float> data = new ArrayList<>();
         data.add(1.0F);
 
+        @SuppressWarnings("rawtypes")
         RubyArray rubyArray = (RubyArray)Rubyfier.deep(RubyUtil.RUBY, data);
 
         // toJavaArray does not newFromRubyArray inner elements to Java types \o/
@@ -160,6 +163,7 @@ public class RubyfierTest {
         List<Double> data = new ArrayList<>();
         data.add(1.0D);
 
+        @SuppressWarnings("rawtypes")
         RubyArray rubyArray = (RubyArray)Rubyfier.deep(RubyUtil.RUBY, data);
 
         // toJavaArray does not newFromRubyArray inner elements to Java types \o/
@@ -197,6 +201,7 @@ public class RubyfierTest {
         List<BigDecimal> data = new ArrayList<>();
         data.add(new BigDecimal(1));
 
+        @SuppressWarnings("rawtypes")
         RubyArray rubyArray = (RubyArray)Rubyfier.deep(RubyUtil.RUBY, data);
 
         // toJavaArray does not newFromRubyArray inner elements to Java types \o/

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/DatasetCompilerTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/DatasetCompilerTest.java
@@ -41,6 +41,7 @@ public final class DatasetCompilerTest {
         final JrubyEventExtLibrary.RubyEvent falseEvent =
             JrubyEventExtLibrary.RubyEvent.newRubyEvent(RubyUtil.RUBY, new Event());
         final Dataset right = left.right();
+        @SuppressWarnings("rawtypes")
         final RubyArray batch = RubyUtil.RUBY.newArray(
             JrubyEventExtLibrary.RubyEvent.newRubyEvent(RubyUtil.RUBY, trueEvent), falseEvent
         );


### PR DESCRIPTION
_#10244 added `-werror` flag, and this PR addresses the fall-out after the `jruby_9_2` branch was rebased on top of that work_

***

There are 3 types of compiler warnings that are either resolved or suppressed:

1. Rawtypes: In JRuby 9.2, `RubyArray` is a generic, so references throughout
   our codebase to the now "raw" type trigger warnings. In most cases we cannot
   actually resolve the issue, since the JRuby-provided methods for creating
   `RubyArray`s still return the raw type, so these have been suppressed.

2. Deprecations:
   - `RubyString#intern19()` -> `RubyString#intern()`
   - `RubyString#downcase19(ThreadContext)` -> `RubyString#downcase(ThreadContext)`
   - `NativeException`: remove import & reference directly; suppress usage
     warnings
   - `RaiseException()`: migrate to equivalent non-deprecated methods wherever
     possible; in some cases where we are using this in conjunction with the
     also-deprecated `NativeException` to preserve java stacktraces, there
     seems to be no non-deprecated path forward, so these cases have been
     suppressed.

3. Redundant Casts
   - Resolved