### PR TITLE
Catch only specific exceptions in PQ checkpoint retry

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/FileCheckpointIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/FileCheckpointIO.java
@@ -88,7 +88,7 @@ public class FileCheckpointIO implements CheckpointIO {
                     logger.error("Retrying after exception writing checkpoint: " + ex);
                     Thread.sleep(500);
                     Files.move(tmpPath, dirPath.resolve(fileName), StandardCopyOption.ATOMIC_MOVE);
-                } catch (Exception ex2) {
+                } catch (IOException | InterruptedException ex2) {
                     logger.error("Aborting after second exception writing checkpoint: " + ex2);
                     throw ex;
                 }


### PR DESCRIPTION
Amends https://github.com/elastic/logstash/pull/10234 to catch only `IOException` and `InterruptedException` rather than `Exception`.
