### PR TITLE
JRuby 9.2 bundler shenanigans

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -21,7 +21,7 @@ gem "rack-test", :require => "rack/test", :group => :development
 gem "flores", "~> 0.0.6", :group => :development
 gem "term-ansicolor", "~> 1.3.2", :group => :development
 gem "json-schema", "~> 2.6", :group => :development
-gem "webmock", "~> 2.3.2", :group => :development
+gem "webmock", "~> 3.5.1", :group => :development
 gem "belzebuth", :group => :development
 gem "pleaserun", "~>0.0.28"
 gem 'webrick', '~> 1.3.1'

--- a/build.gradle
+++ b/build.gradle
@@ -331,9 +331,9 @@ def qaBundledGemPath = "${qaVendorPath}/jruby/2.5.0"
 def qaBundleBin = "${qaBundledGemPath}/bin/bundle"
 
 task installIntegrationTestBundler(dependsOn: unpackTarDistribution) {
-  outputs.files fileTree("${qaBundledGemPath}/gems/bundler-1.16.0")
+  outputs.files fileTree("${qaBundledGemPath}/gems/bundler-1.17.1")
   doLast {
-    rubyGradleUtils.gem("bundler", "1.16.0", qaBundledGemPath)
+    rubyGradleUtils.gem("bundler", "1.17.1", qaBundledGemPath)
   }
 }
 

--- a/lib/bootstrap/bundler.rb
+++ b/lib/bootstrap/bundler.rb
@@ -10,15 +10,20 @@ module LogStash
       # Patch to prevent Bundler to save a .bundle/config file in the root
       # of the application
       ::Bundler::Settings.module_exec do
-        def set_key(key, value, hash, file)
-          key = key_for(key)
+        def set_local(key, value)
+          set_key(key, value, @local_config, nil)
+        end
+      end
 
-          unless hash[key] == value
-            hash[key] = value
-            hash.delete(key) if value.nil?
-          end
-
-          value
+      # In recent versions (currently 1.17.1) Bundler calls reset_paths! early during
+      # Bundler::CLI.start (https://github.com/bundler/bundler/blob/v1.17.1/lib/bundler/cli.rb#L39)
+      # This breaks our setting up of gemfile and bundle paths, the without group setting etc
+      # We need to tone down this very aggressive resetter (https://github.com/bundler/bundler/blob/v1.17.1/lib/bundler.rb#L487-L500)
+      # So we reimplement it here to only nullify the definition object, so that it can be computed
+      # again if necessary with all the configuration in place.
+      ::Bundler.module_exec do
+        def self.reset_paths!
+          @definition = nil
         end
       end
 
@@ -47,11 +52,11 @@ module LogStash
       require "bundler"
       LogStash::Bundler.patch!
 
-      ::Bundler.settings[:path] = Environment::BUNDLE_DIR
-      ::Bundler.settings[:without] = options[:without].join(":")
+      ::Bundler.settings.set_local(:path, Environment::BUNDLE_DIR)
+      ::Bundler.settings.set_local(:without, options[:without])
       # in the context of Bundler.setup it looks like this is useless here because Gemfile path can only be specified using
       # the ENV, see https://github.com/bundler/bundler/blob/v1.8.3/lib/bundler/shared_helpers.rb#L103
-      ::Bundler.settings[:gemfile] = Environment::GEMFILE_PATH
+      ::Bundler.settings.set_local(:gemfile, Environment::GEMFILE_PATH)
 
       ::Bundler.reset!
       ::Bundler.setup
@@ -103,10 +108,10 @@ module LogStash
       # force Rubygems sources to our Gemfile sources
       ::Gem.sources = ::Gem::SourceList.from(options[:rubygems_source]) if options[:rubygems_source]
 
-      ::Bundler.settings[:path] = LogStash::Environment::BUNDLE_DIR
-      ::Bundler.settings[:gemfile] = LogStash::Environment::GEMFILE_PATH
-      ::Bundler.settings[:without] = options[:without].join(":")
-      ::Bundler.settings[:force] = options[:force]
+      ::Bundler.settings.set_local(:path, LogStash::Environment::BUNDLE_DIR)
+      ::Bundler.settings.set_local(:gemfile, LogStash::Environment::GEMFILE_PATH)
+      ::Bundler.settings.set_local(:without, options[:without])
+      ::Bundler.settings.set_local(:force, options[:force])
 
       if !debug?
         # Will deal with transient network errors

--- a/lib/pluginmanager/bundler/logstash_injector.rb
+++ b/lib/pluginmanager/bundler/logstash_injector.rb
@@ -67,7 +67,7 @@ module Bundler
       gemfile = LogStash::Gemfile.new(File.new(gemfile_path, "r+")).load
 
       begin
-        @new_deps.each do |dependency|
+        @deps.each do |dependency|
           gemfile.update(dependency.name, dependency.requirement)
         end
 

--- a/lib/pluginmanager/bundler/logstash_injector.rb
+++ b/lib/pluginmanager/bundler/logstash_injector.rb
@@ -56,41 +56,36 @@ module Bundler
     # And managing the gemfile is down by using our own Gemfile parser, this allow us to
     # make it work with gems that are already defined in the gemfile.
     def inject(gemfile_path, lockfile_path, dependencies)
-      if Bundler.settings[:frozen]
-        # ensure the lock and Gemfile are synced
-        Bundler.definition.ensure_equivalent_gemfile_and_lockfile(true)
-        # temporarily remove frozen while we inject
-        frozen = Bundler.settings.delete(:frozen)
-      end
+      Bundler.definition.ensure_equivalent_gemfile_and_lockfile(true) if Bundler.settings[:frozen]
 
-      builder = Dsl.new
-      gemfile = LogStash::Gemfile.new(File.new(gemfile_path, "r+")).load
+      Bundler.settings.temporary(:frozen => false) do
+        builder = Dsl.new
+        gemfile = LogStash::Gemfile.new(File.new(gemfile_path, "r+")).load
 
-      begin
-        @deps.each do |dependency|
-          gemfile.update(dependency.name, dependency.requirement)
-        end
-
-        # If the dependency is defined in the gemfile, lets try to update the version with the one we have
-        # with the pack.
-        dependencies.each do |dependency|
-          if gemfile.defined_in_gemfile?(dependency.name)
+        begin
+          @deps.each do |dependency|
             gemfile.update(dependency.name, dependency.requirement)
           end
-        end
 
-        builder.eval_gemfile("bundler file", gemfile.generate())
-        definition = builder.to_definition(lockfile_path, {})
-        definition.lock(lockfile_path)
-        gemfile.save
-      rescue => e
-        # the error should be handled elsewhere but we need to get the original file if we dont
-        # do this logstash will be in an inconsistent state
-        gemfile.restore!
-        raise e
+          # If the dependency is defined in the gemfile, lets try to update the version with the one we have
+          # with the pack.
+          dependencies.each do |dependency|
+            if gemfile.defined_in_gemfile?(dependency.name)
+              gemfile.update(dependency.name, dependency.requirement)
+            end
+          end
+
+          builder.eval_gemfile("bundler file", gemfile.generate())
+          definition = builder.to_definition(lockfile_path, {})
+          definition.lock(lockfile_path)
+          gemfile.save
+        rescue => e
+          # the error should be handled elsewhere but we need to get the original file if we dont
+          # do this logstash will be in an inconsistent state
+          gemfile.restore!
+          raise e
+        end
       end
-    ensure
-      Bundler.settings[:frozen] = "1" if frozen
     end
   end
 end

--- a/lib/pluginmanager/bundler/logstash_uninstall.rb
+++ b/lib/pluginmanager/bundler/logstash_uninstall.rb
@@ -71,13 +71,11 @@ Failed to remove \"#{gem_name}\" because the following plugins or libraries depe
     end
 
     def unfreeze_gemfile
-      if Bundler.settings[:frozen]
-        Bundler.definition.ensure_equivalent_gemfile_and_lockfile(true)
-        frozen = Bundler.settings.delete(:frozen)
+      Bundler.definition.ensure_equivalent_gemfile_and_lockfile(true) if Bundler.settings[:frozen]
+
+      Bundler.settings.temporary(:frozen => false) do
+        yield
       end
-      yield
-    ensure
-      Bundler.settings[:frozen] = "1" if frozen
     end
 
     def self.uninstall!(gem_name, options = { :gemfile => LogStash::Environment::GEMFILE, :lockfile => LogStash::Environment::LOCKFILE })

--- a/qa/integration/specs/cli/remove_spec.rb
+++ b/qa/integration/specs/cli/remove_spec.rb
@@ -45,7 +45,7 @@ describe "CLI > logstash-plugin remove" do
 
             expect(execute.exit_code).to eq(1)
             expect(execute.stderr_and_stdout).to match(/Failed to remove "logstash-codec-json"/)
-            expect(execute.stderr_and_stdout).to match(/logstash-input-beats/) # one of the dependency
+            expect(execute.stderr_and_stdout).to match(/logstash-input-kafka/) # one of the dependency
             expect(execute.stderr_and_stdout).to match(/logstash-output-udp/) # one of the dependency
 
             presence_check = @logstash_plugin.list("logstash-codec-json")
@@ -78,7 +78,7 @@ describe "CLI > logstash-plugin remove" do
 
           expect(execute.exit_code).to eq(1)
           expect(execute.stderr_and_stdout).to match(/Failed to remove "logstash-codec-json"/)
-          expect(execute.stderr_and_stdout).to match(/logstash-input-beats/) # one of the dependency
+          expect(execute.stderr_and_stdout).to match(/logstash-input-kafka/) # one of the dependency
           expect(execute.stderr_and_stdout).to match(/logstash-output-udp/) # one of the dependency
 
           presence_check = @logstash_plugin.list("logstash-codec-json")

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -29,6 +29,7 @@ namespace "artifact" do
       "logstash-core/*.gemspec",
 
       "logstash-core-plugin-api/lib/**/*",
+      "logstash-core-plugin-api/versions-gem-copy.yml",
       "logstash-core-plugin-api/*.gemspec",
 
       "patterns/**/*",

--- a/rakelib/dependency.rake
+++ b/rakelib/dependency.rake
@@ -1,7 +1,7 @@
 
 namespace "dependency" do
   task "bundler" do
-    Rake::Task["gem:require"].invoke("bundler", "~> 1.9.4")
+    Rake::Task["gem:require"].invoke("bundler", "~> 1.17.1")
   end
 
   task "clamp" do

--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -7,8 +7,6 @@ namespace "vendor" do
     system('./gradlew downloadAndInstallJRuby') unless File.exists?(File.join("vendor", "jruby"))
   end # jruby
 
-  task "all" => "jruby"
-
   namespace "force" do
     task "gems" => ["vendor:gems"]
   end

--- a/spec/unit/bootstrap/bundler_spec.rb
+++ b/spec/unit/bootstrap/bundler_spec.rb
@@ -44,7 +44,7 @@ describe LogStash::Bundler do
     after do
       expect(::Bundler.settings[:path]).to eq(LogStash::Environment::BUNDLE_DIR)
       expect(::Bundler.settings[:gemfile]).to eq(LogStash::Environment::GEMFILE_PATH)
-      expect(::Bundler.settings[:without]).to eq(options.fetch(:without, []).join(':'))
+      expect(::Bundler.settings[:without]).to eq(options.fetch(:without, []))
 
       expect(ENV['GEM_PATH']).to eq(LogStash::Environment.logstash_gem_home)
 

--- a/spec/unit/license_spec.rb
+++ b/spec/unit/license_spec.rb
@@ -33,7 +33,8 @@ describe "Project licenses" do
       # Skipped because version 2.6.2 which we use has multiple licenses: MIT, ARTISTIC 2.0, GPL-2
       # See https://rubygems.org/gems/mime-types/versions/2.6.2
       # version 3.0 of mime-types (which is only compatible with Ruby 2.0) is MIT licensed
-      "mime-types"
+      "mime-types",
+      "logstash-core-plugin-api"
     ]
   end
 


### PR DESCRIPTION
 - Re-adds previously-reverted work to unpin bundler #9395
 - Updates plugin management's helpers to use Bundler 1.17.x-compatible APIs
 - Resolves dependency conflicts