### PR TITLE
Update lock file for 6.6

### DIFF
--- a/Gemfile.jruby-2.3.lock.release
+++ b/Gemfile.jruby-2.3.lock.release
@@ -1,5 +1,5 @@
 PATH
-  remote: logstash-core
+  remote: ./logstash-core
   specs:
     logstash-core (6.6.0-java)
       chronic_duration (= 0.10.6)
@@ -23,7 +23,7 @@ PATH
       treetop (< 1.5.0)
 
 PATH
-  remote: logstash-core-plugin-api
+  remote: ./logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
       logstash-core (= 6.6.0)
@@ -38,13 +38,13 @@ GEM
     avl_tree (1.2.1)
       atomic (~> 1.1)
     awesome_print (1.7.0)
-    aws-sdk (2.11.193)
-      aws-sdk-resources (= 2.11.193)
-    aws-sdk-core (2.11.193)
+    aws-sdk (2.11.202)
+      aws-sdk-resources (= 2.11.202)
+    aws-sdk-core (2.11.202)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.193)
-      aws-sdk-core (= 2.11.193)
+    aws-sdk-resources (2.11.202)
+      aws-sdk-core (= 2.11.202)
     aws-sdk-v1 (1.67.0)
       json (~> 1.4)
       nokogiri (~> 1)
@@ -73,7 +73,7 @@ GEM
     diff-lcs (1.3)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.5.0)
+    dotenv (2.6.0)
     edn (1.1.1)
     elasticsearch (5.0.5)
       elasticsearch-api (= 5.0.5)
@@ -86,7 +86,7 @@ GEM
     equalizer (0.0.10)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.25-java)
+    ffi (1.10.0-java)
     filesize (0.0.4)
     fivemat (1.3.7)
     flores (0.0.7)
@@ -236,7 +236,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-kv (4.2.1)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-memcached (0.1.0)
+    logstash-filter-memcached (0.1.1)
       dalli (~> 2.7)
       logstash-core-plugin-api (~> 2.0)
     logstash-filter-metrics (4.0.5)
@@ -249,7 +249,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-sleep (3.0.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-split (3.1.6)
+    logstash-filter-split (3.1.7)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-syslog_pri (3.0.5)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -299,7 +299,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       rufus-scheduler
       stud (~> 0.0.22)
-    logstash-input-file (4.1.8)
+    logstash-input-file (4.1.9)
       addressable
       logstash-codec-multiline (~> 3.0)
       logstash-codec-plain
@@ -346,7 +346,7 @@ GEM
       sequel
       tzinfo
       tzinfo-data
-    logstash-input-kafka (8.3.0)
+    logstash-input-kafka (8.3.1)
       logstash-codec-json
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -455,7 +455,7 @@ GEM
     logstash-output-http (5.2.3)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-http_client (>= 6.0.0, < 7.0.0)
-    logstash-output-kafka (7.3.0)
+    logstash-output-kafka (7.3.1)
       logstash-codec-json
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -469,7 +469,7 @@ GEM
     logstash-output-null (3.0.5)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-output-pagerduty (3.0.7)
+    logstash-output-pagerduty (3.0.8)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-output-pipe (3.0.6)
@@ -496,7 +496,7 @@ GEM
     logstash-output-stdout (3.1.4)
       logstash-codec-rubydebug
       logstash-core-plugin-api (>= 1.60.1, < 2.99)
-    logstash-output-tcp (5.0.3)
+    logstash-output-tcp (5.0.4)
       logstash-codec-json
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       stud
@@ -524,13 +524,13 @@ GEM
       hitimes (~> 1.1)
     mime-types (2.6.2)
     minitar (0.6.1)
-    msgpack (1.2.4-java)
+    msgpack (1.2.6-java)
     multi_json (1.13.1)
     multipart-post (2.0.0)
     murmurhash3 (0.1.6-java)
     mustache (0.99.8)
     naught (1.1.0)
-    nokogiri (1.9.1-java)
+    nokogiri (1.10.0-java)
     numerizer (0.1.1)
     octokit (3.8.0)
       sawyer (~> 0.6.0, >= 0.5.3)
@@ -580,7 +580,7 @@ GEM
     sawyer (0.6.0)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
-    sequel (5.15.0)
+    sequel (5.16.0)
     simple_oauth (0.3.1)
     sinatra (1.4.8)
       rack (~> 1.5)
@@ -613,9 +613,9 @@ GEM
       memoizable (~> 0.4.0)
       naught (~> 1.0)
       simple_oauth (~> 0.3.0)
-    tzinfo (1.2.5)
-      thread_safe (~> 0.1)
-    tzinfo-data (1.2018.7)
+    tzinfo (2.0.0)
+      concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2018.9)
       tzinfo (>= 1.0.0)
     unf (0.1.4-java)
     webhdfs (0.8.0)
@@ -649,7 +649,7 @@ DEPENDENCIES
   logstash-codec-line
   logstash-codec-msgpack
   logstash-codec-multiline
-  logstash-codec-netflow (>= 3.14.1, < 4.0.0)
+  logstash-codec-netflow
   logstash-codec-plain
   logstash-codec-rubydebug
   logstash-core!
@@ -732,7 +732,7 @@ DEPENDENCIES
   logstash-output-pipe
   logstash-output-rabbitmq
   logstash-output-redis
-  logstash-output-s3 (>= 4.0.9, < 5.0.0)
+  logstash-output-s3
   logstash-output-sns
   logstash-output-sqs
   logstash-output-stdout

--- a/Gemfile.jruby-2.3.lock.release
+++ b/Gemfile.jruby-2.3.lock.release
@@ -1,5 +1,5 @@
 PATH
-  remote: ./logstash-core
+  remote: logstash-core
   specs:
     logstash-core (6.6.0-java)
       chronic_duration (= 0.10.6)
@@ -23,7 +23,7 @@ PATH
       treetop (< 1.5.0)
 
 PATH
-  remote: ./logstash-core-plugin-api
+  remote: logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
       logstash-core (= 6.6.0)
@@ -751,3 +751,4 @@ DEPENDENCIES
   term-ansicolor (~> 1.3.2)
   tins (= 1.6)
   webrick (~> 1.3.1)
+  


### PR DESCRIPTION
This is the result of running `jruby ./tools/release/bump_plugin_versions.rb 6.6 6.5.4 minor` on the 6.6 branch