### PR TITLE
Bump http filter to 1.0.0

### DIFF
--- a/Gemfile.jruby-2.3.lock.release
+++ b/Gemfile.jruby-2.3.lock.release
@@ -219,7 +219,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-patterns-core
       stud (~> 0.0.22)
-    logstash-filter-http (0.1.0)
+    logstash-filter-http (1.0.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-http_client (>= 5.0.0, < 9.0.0)
     logstash-filter-jdbc_static (1.0.6)


### PR DESCRIPTION
this plugin was bumped to 1.0.0 to avoid clashing with the 0.5.4 versions of the rest filter of which this plugin was based on.