### PR TITLE
[Doc] Fix broken link in filebeat module

### DIFF
--- a/docs/static/filebeat-modules.asciidoc
+++ b/docs/static/filebeat-modules.asciidoc
@@ -137,7 +137,7 @@ data sent collected by Filebeat modules:
 
 The Logstash pipeline configuration in this example shows how to ship and parse
 access and error logs collected by the
-{filebeat-ref}/filebeat-module-apache2.html[`apache2` Filebeat module].
+{filebeat-ref}/filebeat-module-apache.html[`apache` Filebeat module].
 
 [source,json]
 ----------------------------------------------------------------------------


### PR DESCRIPTION
Fix broken link from https://github.com/elastic/beats/pull/9402

To Do:  
Text around apache and apache2 may need to be tweaked, too. 
