### PR TITLE
correctly handle pipeline actions

### DIFF
--- a/logstash-core/lib/logstash/pipeline_action/stop.rb
+++ b/logstash-core/lib/logstash/pipeline_action/stop.rb
@@ -10,14 +10,13 @@ module LogStash module PipelineAction
     end
 
     def execute(agent, pipelines)
-      pipelines.compute(pipeline_id) do |_,pipeline|
+      pipelines.compute(pipeline_id) do |_, pipeline|
         pipeline.shutdown { LogStash::ShutdownWatcher.start(pipeline) }
         pipeline.thread.join
-        nil # delete the pipeline
+        nil # remove pipeline from pipelines
       end
-      # If we reach this part of the code we have succeeded because
-      # the shutdown call will block.
-      return LogStash::ConvergeResult::SuccessfulAction.new
+
+      LogStash::ConvergeResult::SuccessfulAction.new
     end
 
     def to_s


### PR DESCRIPTION
Fixes #10330 

While investigating #10330 I noticed that there were actual bugs in the pipeline actions implementation around the usage the pipelines `ConcurrentHashMap` `compute` method. I refactored and cleaned all actions.

In particular the reload method was very problematic and I believe the cause of the thread context errors; 
https://github.com/elastic/logstash/blob/ce80262d02fd55d9a948f7e02aa65f226464ea08/logstash-core/lib/logstash/pipeline_action/reload.rb#L52-L61

This code calls `compute` on the `pipelines` `ConcurrentHashMap` and the block passed to `compute` should return a new value or nil to update the `ConcurrentHashMap` accordingly but here the block was actually calling `return` which actually returned from the method and was probably the cause of the frame errors. I actually do not understand how this was working in the first place. Also we see that the final `pipeline` block return value is never reached.

Also, within this reload `compute` call, both `Stop` and `Create` actions are called which themselves call `compute` to update `pipelines`. This `compute` call is unnecessary here in `reload` and I am not even sure about the semantic of re-entering into a compute call like this. In any case we should definitely avoid that here. 

The `create` action had this weird code where is created an action result without using it:
https://github.com/elastic/logstash/blob/ce80262d02fd55d9a948f7e02aa65f226464ea08/logstash-core/lib/logstash/pipeline_action/create.rb#L47-L50

Previously the `create` action was handling the case of trying to create an already existing pipeline. Now this condition check disappeared and was replaced by this weird do-nothing action result above. 

With these fixes applied I was not able to reproduce the problem yet. Still running more tests. 