### PR TITLE
[6.6 clean backport of #10113] synchronize ruby pipeline initialization to fix concurrency bug (#10113)

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -33,6 +33,10 @@ class LogStash::Agent
     @auto_reload = setting("config.reload.automatic")
     @ephemeral_id = SecureRandom.uuid
 
+    # Mutex to synchonize in the exclusive method
+    # Initial usage for the Ruby pipeline initialization which is not thread safe
+    @exclusive_lock = Mutex.new
+
     # Special bus object for inter-pipelines communications. Used by the `pipeline` input/output
     @pipeline_bus = org.logstash.plugins.pipeline.PipelineBus.new
 
@@ -82,6 +86,10 @@ class LogStash::Agent
     dispatcher.fire(:after_initialize)
 
     @running = Concurrent::AtomicBoolean.new(false)
+  end
+
+  def exclusive(&block)
+    @exclusive_lock.synchronize { block.call }
   end
 
   def execute

--- a/logstash-core/lib/logstash/pipeline_action/create.rb
+++ b/logstash-core/lib/logstash/pipeline_action/create.rb
@@ -35,7 +35,12 @@ module LogStash module PipelineAction
         if @pipeline_config.settings.get_value("pipeline.java_execution")
           LogStash::JavaPipeline.new(@pipeline_config, @metric, agent)
         else
-          LogStash::Pipeline.new(@pipeline_config, @metric, agent)
+          agent.exclusive do
+            # The Ruby pipeline initialization is not thread safe because of the module level
+            # shared state in LogsStash::Config::AST. When using multiple pipelines this gets
+            # executed simultaneously in different threads and we need to synchonize this initialization.
+            LogStash::Pipeline.new(@pipeline_config, @metric, agent)
+          end
         end
 
       status = nil

--- a/logstash-core/lib/logstash/pipeline_action/reload.rb
+++ b/logstash-core/lib/logstash/pipeline_action/reload.rb
@@ -32,7 +32,12 @@ module LogStash module PipelineAction
           if @pipeline_config.settings.get_value("pipeline.java_execution")
             LogStash::JavaBasePipeline.new(@pipeline_config, nil, logger, nil)
           else
-            LogStash::BasePipeline.new(@pipeline_config)
+            agent.exclusive do
+              # The Ruby pipeline initialization is not thread safe because of the module level
+              # shared state in LogsStash::Config::AST. When using multiple pipelines this can gets
+              # executed simultaneously in different threads and we need to synchonize this initialization.
+              LogStash::BasePipeline.new(@pipeline_config)
+            end
           end
       rescue => e
         return LogStash::ConvergeResult::FailedAction.from_exception(e)

--- a/logstash-core/spec/logstash/pipeline_action/create_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_action/create_spec.rb
@@ -33,21 +33,25 @@ describe LogStash::PipelineAction::Create do
     let(:pipeline_config) { mock_pipeline_config(:main, "input { generator { count => 1 } } output { null {} }") }
 
     it "returns a successful execution status" do
+      allow(agent).to receive(:exclusive) { |&arg| arg.call }
       expect(subject.execute(agent, pipelines)).to be_truthy
     end
   end
 
   context "when the pipeline successfully start" do
     it "adds the pipeline to the current pipelines" do
+      allow(agent).to receive(:exclusive) { |&arg| arg.call }
       expect { subject.execute(agent, pipelines) }.to change(pipelines, :size).by(1)
     end
 
     it "starts the pipeline" do
+      allow(agent).to receive(:exclusive) { |&arg| arg.call }
       subject.execute(agent, pipelines)
       expect(pipelines[:main].running?).to be_truthy
     end
 
     it "returns a successful execution status" do
+      allow(agent).to receive(:exclusive) { |&arg| arg.call }
       expect(subject.execute(agent, pipelines)).to be_truthy
     end
   end
@@ -65,6 +69,7 @@ describe LogStash::PipelineAction::Create do
       let(:pipeline_config) { mock_pipeline_config(:main, "input { generator { id => '123' } } filter { ruby { init => '1/0' code => '1+2' } } output { null {} }") }
 
       it "returns false" do
+        allow(agent).to receive(:exclusive) { |&arg| arg.call }
         expect(subject.execute(agent, pipelines)).not_to be_a_successful_action
       end
     end

--- a/logstash-core/spec/logstash/pipeline_action/reload_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_action/reload_spec.rb
@@ -33,15 +33,18 @@ describe LogStash::PipelineAction::Reload do
 
   context "when existing pipeline and new pipeline are both reloadable" do
     it "stop the previous pipeline" do
+      allow(agent).to receive(:exclusive) { |&arg| arg.call }
       expect { subject.execute(agent, pipelines) }.to change(pipeline, :running?).from(true).to(false)
     end
 
     it "start the new pipeline" do
+      allow(agent).to receive(:exclusive) { |&arg| arg.call }
       subject.execute(agent, pipelines)
       expect(pipelines[pipeline_id].running?).to be_truthy
     end
 
     it "run the new pipeline code" do
+      allow(agent).to receive(:exclusive) { |&arg| arg.call }
       subject.execute(agent, pipelines)
       expect(pipelines[pipeline_id].config_hash).to eq(new_pipeline_config.config_hash)
     end
@@ -61,6 +64,7 @@ describe LogStash::PipelineAction::Reload do
     let(:new_pipeline_config) { mock_pipeline_config(pipeline_id, "input { generator { id => 'new' } } output { null {} }", { "pipeline.reloadable" => false}) }
 
     it "cannot successfully execute the action" do
+      allow(agent).to receive(:exclusive) { |&arg| arg.call }
       expect(subject.execute(agent, pipelines)).not_to be_a_successful_action
     end
   end
@@ -69,6 +73,7 @@ describe LogStash::PipelineAction::Reload do
     let(:new_pipeline_config) { mock_pipeline_config(pipeline_id, "input generator { id => 'new' } } output { null {} }", { "pipeline.reloadable" => false}) }
 
     it "cannot successfully execute the action" do
+      allow(agent).to receive(:exclusive) { |&arg| arg.call }
       expect(subject.execute(agent, pipelines)).not_to be_a_successful_action
     end
   end
@@ -79,6 +84,7 @@ describe LogStash::PipelineAction::Reload do
     end
 
     it "cannot successfully execute the action" do
+      allow(agent).to receive(:exclusive) { |&arg| arg.call }
       expect(subject.execute(agent, pipelines)).not_to be_a_successful_action
     end
   end


### PR DESCRIPTION
6.6 clean backport of #10113