### PR TITLE
Update java dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'org.yaml:snakeyaml:1.17'
+        classpath 'org.yaml:snakeyaml:1.23'
         classpath "gradle.plugin.com.github.jk1:gradle-license-report:0.7.1"
     }
 }

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -118,15 +118,15 @@ def customJRubyDir = project.hasProperty("custom.jruby.path") ? project.property
 def customJRubyVersion = customJRubyDir == "" ? "" : Files.readAllLines(Paths.get(customJRubyDir, "VERSION")).get(0).trim()
 
 dependencies {
-    compile 'org.apache.logging.log4j:log4j-api:2.9.1'
-    compile 'org.apache.logging.log4j:log4j-core:2.9.1'
-    runtime 'org.apache.logging.log4j:log4j-slf4j-impl:2.9.1'
+    compile 'org.apache.logging.log4j:log4j-api:2.11.1'
+    compile 'org.apache.logging.log4j:log4j-core:2.11.1'
+    runtime 'org.apache.logging.log4j:log4j-slf4j-impl:2.11.1'
     compile 'commons-codec:commons-codec:1.11'
     // Jackson version moved to versions.yml in the project root (the JrJackson version is there too)
     compile "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
     compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
     compile "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
-    compile 'org.codehaus.janino:janino:3.0.8'
+    compile 'org.codehaus.janino:janino:3.0.11'
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jacksonVersion}"
     if (customJRubyDir == "") {
         compile "org.jruby:jruby-complete:${jrubyVersion}"
@@ -139,11 +139,11 @@ dependencies {
     compile('com.google.googlejavaformat:google-java-format:1.1') {
         exclude group: 'com.google.guava', module: 'guava'
     }
-    compile 'org.javassist:javassist:3.22.0-GA'
+    compile 'org.javassist:javassist:3.24.0-GA'
     compile 'com.google.guava:guava:20.0'
-    testCompile 'org.apache.logging.log4j:log4j-core:2.9.1:tests'
+    testCompile 'org.apache.logging.log4j:log4j-core:2.11.1:tests'
     testCompile 'junit:junit:4.12'
-    testCompile 'net.javacrumbs.json-unit:json-unit:1.9.0'
+    testCompile 'net.javacrumbs.json-unit:json-unit:2.3.0'
     testCompile 'org.elasticsearch:securemock:1.2'
-    testCompile 'org.assertj:assertj-core:3.8.0'
+    testCompile 'org.assertj:assertj-core:3.11.1'
 }

--- a/versions.yml
+++ b/versions.yml
@@ -22,4 +22,4 @@ jruby:
 #       bundler evaluates the gemspec via bin/logstash
 # Ensure Jackson version here is kept in sync with version used by jrjackson gem
 jrjackson: 0.4.6
-jackson: 2.9.5
+jackson: 2.9.8


### PR DESCRIPTION
Updates the following Java dependencies:
* snakeyaml: 1.17 -> 1.23
* log4j: 2.9.1 -> 2.11.1
* jackson: 2.9.5 -> 2.9.8
* janino: 3.0.8 -> 3.0.11
* javassist: 3.22.0-GA -> 3.24.0-GA
* json-unit: 1.9.0 -> 2.3.0
* assertj-core: 3.8.0 -> 3.11.1
