### PR TITLE
fix agent silent exit upon pipelines reloading

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -8,6 +8,7 @@ require "logstash/webserver"
 require "logstash/config/source_loader"
 require "logstash/pipeline_action"
 require "logstash/state_resolver"
+require "logstash/pipelines_registry"
 require "stud/trap"
 require "uri"
 require "socket"
@@ -19,7 +20,7 @@ class LogStash::Agent
   include LogStash::Util::Loggable
   STARTED_AT = Time.now.freeze
 
-  attr_reader :metric, :name, :settings, :webserver, :dispatcher, :ephemeral_id, :pipelines, :pipeline_bus
+  attr_reader :metric, :name, :settings, :webserver, :dispatcher, :ephemeral_id, :pipeline_bus
   attr_accessor :logger
 
   # initialize method for LogStash::Agent
@@ -40,7 +41,7 @@ class LogStash::Agent
     # Special bus object for inter-pipelines communications. Used by the `pipeline` input/output
     @pipeline_bus = org.logstash.plugins.pipeline.PipelineBus.new
 
-    @pipelines = java.util.concurrent.ConcurrentHashMap.new();
+    @pipelines_registry = LogStash::PipelinesRegistry.new
 
     @name = setting("node.name")
     @http_host = setting("http.host")
@@ -114,14 +115,17 @@ class LogStash::Agent
         converge_state_and_update unless stopped?
       end
     else
-      return 1 if clean_state?
+      # exit with error status if the initial converge_state_and_update did not create any pipeline
+      return 1 if @pipelines_registry.empty?
 
       while !Stud.stop?
-        if clean_state? || running_user_defined_pipelines?
-          sleep(0.5)
-        else
-          break
-        end
+        # exit if all pipelines are terminated and none are reloading
+        break if no_pipeline?
+
+        # exit if there are no user defined pipelines (not system pipeline) and none are reloading
+        break if !running_user_defined_pipelines?
+
+        sleep(0.5)
       end
     end
 
@@ -135,11 +139,11 @@ class LogStash::Agent
   end
 
   def running?
-    @running.value
+    @running.true?
   end
 
   def stopped?
-    !@running.value
+    @running.false?
   end
 
   def converge_state_and_update
@@ -233,43 +237,48 @@ class LogStash::Agent
     @id_path ||= ::File.join(settings.get("path.data"), "uuid")
   end
 
+  #
+  # Backward compatibility proxies to the PipelineRegistry
+  #
+
   def get_pipeline(pipeline_id)
-    pipelines.get(pipeline_id)
+    @pipelines_registry.get_pipeline(pipeline_id)
   end
 
   def pipelines_count
-    pipelines.size
+    @pipelines_registry.size
   end
 
   def running_pipelines
-    pipelines.select {|id,pipeline| running_pipeline?(id) }
-  end
+    @pipelines_registry.running_pipelines
+   end
 
   def non_running_pipelines
-    pipelines.select {|id,pipeline| !running_pipeline?(id) }
+    @pipelines_registry.non_running_pipelines
   end
 
   def running_pipelines?
-    running_pipelines_count > 0
+    @pipelines_registry.running_pipelines.any?
   end
 
   def running_pipelines_count
-    running_pipelines.size
+    @pipelines_registry.running_pipelines.size
   end
 
   def running_user_defined_pipelines?
-    !running_user_defined_pipelines.empty?
+    @pipelines_registry.running_user_defined_pipelines.any?
   end
 
   def running_user_defined_pipelines
-    pipelines.select {|id, pipeline| running_pipeline?(id) && !pipeline.system? }
+    @pipelines_registry.running_user_defined_pipelines
   end
 
-  def with_running_user_defined_pipelines
-    yield running_user_defined_pipelines
+  def no_pipeline?
+    @pipelines_registry.running_pipelines.empty?
   end
 
   private
+
   def transition_to_stopped
     @running.make_false
   end
@@ -294,7 +303,7 @@ class LogStash::Agent
     converge_result = LogStash::ConvergeResult.new(pipeline_actions.size)
 
     pipeline_actions.map do |action|
-      Thread.new do
+      Thread.new(action, converge_result) do |action, converge_result|
         java.lang.Thread.currentThread().setName("Converge #{action}");
         # We execute every task we need to converge the current state of pipelines
         # for every task we will record the action result, that will help us
@@ -310,34 +319,35 @@ class LogStash::Agent
         # that we currently have.
         begin
           logger.debug("Executing action", :action => action)
-          action_result = action.execute(self, pipelines)
+          action_result = action.execute(self, @pipelines_registry)
           converge_result.add(action, action_result)
 
           unless action_result.successful?
-            logger.error("Failed to execute action", :id => action.pipeline_id,
-                         :action_type => action_result.class, :message => action_result.message,
-                         :backtrace => action_result.backtrace)
+            logger.error("Failed to execute action",
+              :id => action.pipeline_id,
+              :action_type => action_result.class,
+              :message => action_result.message,
+              :backtrace => action_result.backtrace
+            )
           end
-        rescue SystemExit => e
-          converge_result.add(action, e)
-        rescue Exception => e
+        rescue SystemExit, Exception => e
           logger.error("Failed to execute action", :action => action, :exception => e.class.name, :message => e.message, :backtrace => e.backtrace)
           converge_result.add(action, e)
         end
       end
     end.each(&:join)
 
-    if logger.trace?
-      logger.trace("Converge results", :success => converge_result.success?,
-                   :failed_actions => converge_result.failed_actions.collect { |a, r| "id: #{a.pipeline_id}, action_type: #{a.class}, message: #{r.message}" },
-                   :successful_actions => converge_result.successful_actions.collect { |a, r| "id: #{a.pipeline_id}, action_type: #{a.class}" })
-    end
+    logger.trace? && logger.trace("Converge results",
+      :success => converge_result.success?,
+      :failed_actions => converge_result.failed_actions.collect { |a, r| "id: #{a.pipeline_id}, action_type: #{a.class}, message: #{r.message}" },
+      :successful_actions => converge_result.successful_actions.collect { |a, r| "id: #{a.pipeline_id}, action_type: #{a.class}" }
+    )
 
     converge_result
   end
 
   def resolve_actions(pipeline_configs)
-    @state_resolver.resolve(@pipelines, pipeline_configs)
+    @state_resolver.resolve(@pipelines_registry, pipeline_configs)
   end
 
   def dispatch_events(converge_results)
@@ -395,7 +405,7 @@ class LogStash::Agent
   end
 
   def shutdown_pipelines
-    logger.debug("Shutting down all pipelines", :pipelines_count => pipelines_count)
+    logger.debug("Shutting down all pipelines", :pipelines_count => running_pipelines_count)
 
     # In this context I could just call shutdown, but I've decided to
     # use the stop action implementation for that so we have the same code.
@@ -404,16 +414,6 @@ class LogStash::Agent
     converge_state(pipeline_actions)
   end
 
-  def running_pipeline?(pipeline_id)
-    pipeline = get_pipeline(pipeline_id)
-    return false unless pipeline
-    thread = pipeline.thread
-    thread.is_a?(Thread) && thread.alive?
-  end
-
-  def clean_state?
-    pipelines.empty?
-  end
 
   def setting(key)
     @settings.get(key)

--- a/logstash-core/lib/logstash/instrument/periodic_poller/dlq.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/dlq.rb
@@ -10,13 +10,11 @@ module LogStash module Instrument module PeriodicPoller
     end
 
     def collect
-      pipelines = @agent.with_running_user_defined_pipelines {|pipelines| pipelines}
-      unless pipelines.nil?
-        pipelines.each {|_, pipeline|
-          unless pipeline.nil?
-            pipeline.collect_dlq_stats
-          end
-        }
+      pipelines = @agent.running_user_defined_pipelines
+      pipelines.each do |_, pipeline|
+        unless pipeline.nil?
+          pipeline.collect_dlq_stats
+        end
       end
     end
   end

--- a/logstash-core/lib/logstash/instrument/periodic_poller/pq.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/pq.rb
@@ -11,14 +11,12 @@ module LogStash module Instrument module PeriodicPoller
     end
 
     def collect
-      pipelines = @agent.with_running_user_defined_pipelines {|pipelines| pipelines}
-      unless pipelines.nil?
-        pipelines.each {|_, pipeline|
-          unless pipeline.nil?
-            pipeline.collect_stats
-          end
-        }
+      pipelines = @agent.running_user_defined_pipelines
+      pipelines.each do |_, pipeline|
+        unless pipeline.nil?
+          pipeline.collect_stats
+        end
       end
     end
   end
-end; end; end
+end end end

--- a/logstash-core/lib/logstash/instrument/periodic_pollers.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_pollers.rb
@@ -11,12 +11,12 @@ module LogStash module Instrument
   class PeriodicPollers
     attr_reader :metric
 
-    def initialize(metric, queue_type, pipelines)
+    def initialize(metric, queue_type, agent)
       @metric = metric
       @periodic_pollers = [PeriodicPoller::Os.new(metric),
                            PeriodicPoller::JVM.new(metric),
-                           PeriodicPoller::PersistentQueue.new(metric, queue_type, pipelines),
-                           PeriodicPoller::DeadLetterQueue.new(metric, pipelines)]
+                           PeriodicPoller::PersistentQueue.new(metric, queue_type, agent),
+                           PeriodicPoller::DeadLetterQueue.new(metric, agent)]
     end
 
     def start

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -107,7 +107,22 @@ module LogStash; class Pipeline < BasePipeline
     @flushing = Concurrent::AtomicReference.new(false)
     @outputs_registered = Concurrent::AtomicBoolean.new(false)
     @worker_shutdown = java.util.concurrent.atomic.AtomicBoolean.new(false)
+
+    # @finished_execution signals that the pipeline thread has finished its execution
+    # regardless of any exceptions; it will always be true when the thread completes
+    @finished_execution = Concurrent::AtomicBoolean.new(false)
+
+    # @finished_run signals that the run methods called in the pipeline thread was completed
+    # without errors and it will NOT be set if the run method exits from an exception; this
+    # is by design and necessary for the wait_until_started semantic
+    @finished_run = Concurrent::AtomicBoolean.new(false)
+
+    @thread = nil
   end # def initialize
+
+  def finished_execution?
+    @finished_execution.true?
+  end
 
   def ready?
     @ready.value
@@ -152,16 +167,19 @@ module LogStash; class Pipeline < BasePipeline
       "pipeline.batch.size" => settings.get("pipeline.batch.size"),
       "pipeline.batch.delay" => settings.get("pipeline.batch.delay")))
 
-    @finished_execution = Concurrent::AtomicBoolean.new(false)
+    @finished_execution.make_false
+    @finished_run.make_false
 
     @thread = Thread.new do
       begin
         LogStash::Util.set_thread_name("pipeline.#{pipeline_id}")
         run
-        @finished_execution.make_true
+        @finished_run.make_true
       rescue => e
         close
         @logger.error("Pipeline aborted due to error", default_logging_keys(:exception => e, :backtrace => e.backtrace))
+      ensure
+        @finished_execution.make_true
       end
     end
 
@@ -176,15 +194,14 @@ module LogStash; class Pipeline < BasePipeline
 
   def wait_until_started
     while true do
-      # This should be changed with an appropriate FSM
-      # It's an edge case, if we have a pipeline with
-      # a generator { count => 1 } its possible that `Thread#alive?` doesn't return true
-      # because the execution of the thread was successful and complete
-      if @finished_execution.true?
+      if @finished_run.true?
+        # it completed run without exception
         return true
-      elsif !thread.alive?
+      elsif thread.nil? || !thread.alive?
+        # some exception occured and the thread is dead
         return false
       elsif running?
+        # fully initialized and running
         return true
       else
         sleep 0.01

--- a/logstash-core/lib/logstash/pipeline_action/base.rb
+++ b/logstash-core/lib/logstash/pipeline_action/base.rb
@@ -12,7 +12,7 @@ module LogStash module PipelineAction
     end
     alias_method :to_s, :inspect
 
-    def execute(agent, pipelines)
+    def execute(agent, pipelines_registry)
       raise "`#execute` Not implemented!"
     end
 

--- a/logstash-core/lib/logstash/pipeline_action/reload.rb
+++ b/logstash-core/lib/logstash/pipeline_action/reload.rb
@@ -20,8 +20,12 @@ module LogStash module PipelineAction
       "PipelineAction::Reload<#{pipeline_id}>"
     end
 
-    def execute(agent, pipelines)
-      old_pipeline = pipelines[pipeline_id]
+    def execute(agent, pipelines_registry)
+      old_pipeline = pipelines_registry.get_pipeline(pipeline_id)
+
+      if old_pipeline.nil?
+        return LogStash::ConvergeResult::FailedAction.new("Cannot reload pipeline, because the pipeline does not exist")
+      end
 
       if !old_pipeline.reloadable?
         return LogStash::ConvergeResult::FailedAction.new("Cannot reload pipeline, because the existing pipeline is not reloadable")
@@ -49,13 +53,35 @@ module LogStash module PipelineAction
 
       logger.info("Reloading pipeline", "pipeline.id" => pipeline_id)
 
-      stop_result = Stop.new(pipeline_id).execute(agent, pipelines)
+      success = pipelines_registry.reload_pipeline(pipeline_id) do
+        # important NOT to explicitly return from block here
+        # the block must emit a success boolean value
 
-      if stop_result.successful?
-        Create.new(@pipeline_config, @metric).execute(agent, pipelines)
-      else
-        stop_result
+        # First shutdown old pipeline
+        old_pipeline.shutdown { LogStash::ShutdownWatcher.start(old_pipeline) }
+        old_pipeline.thread.join
+
+        # Then create a new pipeline
+        new_pipeline =
+          if @pipeline_config.settings.get_value("pipeline.java_execution")
+            LogStash::JavaPipeline.new(@pipeline_config, @metric, agent)
+          else
+            agent.exclusive do
+              # The Ruby pipeline initialization is not thread safe because of the module level
+              # shared state in LogsStash::Config::AST. When using multiple pipelines this gets
+              # executed simultaneously in different threads and we need to synchronize this initialization.
+              LogStash::Pipeline.new(@pipeline_config, @metric, agent)
+            end
+          end
+
+        success = new_pipeline.start # block until the pipeline is correctly started or crashed
+
+        # return success and new_pipeline to registry reload_pipeline
+        [success, new_pipeline]
       end
+
+      LogStash::ConvergeResult::ActionResult.create(self, success)
     end
+
   end
 end end

--- a/logstash-core/lib/logstash/pipeline_action/stop.rb
+++ b/logstash-core/lib/logstash/pipeline_action/stop.rb
@@ -9,11 +9,10 @@ module LogStash module PipelineAction
       @pipeline_id = pipeline_id
     end
 
-    def execute(agent, pipelines)
-      pipelines.compute(pipeline_id) do |_, pipeline|
+    def execute(agent, pipelines_registry)
+      pipelines_registry.terminate_pipeline(pipeline_id) do |pipeline|
         pipeline.shutdown { LogStash::ShutdownWatcher.start(pipeline) }
         pipeline.thread.join
-        nil # remove pipeline from pipelines
       end
 
       LogStash::ConvergeResult::SuccessfulAction.new

--- a/logstash-core/lib/logstash/pipelines_registry.rb
+++ b/logstash-core/lib/logstash/pipelines_registry.rb
@@ -1,0 +1,166 @@
+# encoding: utf-8
+
+module LogStash
+  class PipelineState
+    attr_reader :pipeline_id, :pipeline
+
+    def initialize(pipeline_id, pipeline)
+      @pipeline_id = pipeline_id
+      @pipeline = pipeline
+      @reloading = Concurrent::AtomicBoolean.new(false)
+    end
+
+    def terminated?
+      # a reloading pipeline is never considered terminated
+      @reloading.false? && @pipeline.finished_execution?
+    end
+
+    def set_reloading(is_reloading)
+      @reloading.value = is_reloading
+    end
+
+    def set_pipeline(pipeline)
+      raise(ArgumentError, "invalid nil pipeline") if pipeline.nil?
+      @pipeline = pipeline
+    end
+  end
+
+  class PipelinesRegistry
+    attr_reader :states
+    include LogStash::Util::Loggable
+
+    def initialize
+      # we leverage the semantic of the Java ConcurrentHashMap for the
+      # compute() method which is atomic; calling compute() concurrently
+      # will block until the other compute finishes so no mutex is necessary
+      # for synchronizing compute calls
+      @states = java.util.concurrent.ConcurrentHashMap.new
+    end
+
+    # Execute the passed creation logic block and create a new state upon success
+    # @param pipeline_id [String, Symbol] the pipeline id
+    # @param pipeline [Pipeline] the new pipeline to create
+    # @param create_block [Block] the creation execution logic
+    #
+    # @yieldreturn [Boolean] the new pipeline creation success
+    #
+    # @return [Boolean] new pipeline creation success
+    def create_pipeline(pipeline_id, pipeline, &create_block)
+      success = false
+
+      @states.compute(pipeline_id) do |_, state|
+        if state
+          if state.terminated?
+            success = yield
+            state.set_pipeline(pipeline)
+          else
+            logger.error("Attempted to create a pipeline that already exists", :pipeline_id => pipeline_id)
+          end
+          state
+        else
+          success = yield
+          success ? PipelineState.new(pipeline_id, pipeline) : nil
+        end
+      end
+
+      success
+    end
+
+    # Execute the passed termination logic block
+    # @param pipeline_id [String, Symbol] the pipeline id
+    # @param stop_block [Block] the termination execution logic
+    #
+    # @yieldparam [Pipeline] the pipeline to terminate
+    def terminate_pipeline(pipeline_id, &stop_block)
+      @states.compute(pipeline_id) do |_, state|
+        if state.nil?
+          logger.error("Attempted to terminate a pipeline that does not exists", :pipeline_id => pipeline_id)
+          nil
+        else
+          yield(state.pipeline)
+          state
+        end
+      end
+    end
+
+    # Execute the passed reloading logic block in the context of the reloading state and set new pipeline in state
+    # @param pipeline_id [String, Symbol] the pipeline id
+    # @param reload_block [Block] the reloading execution logic
+    #
+    # @yieldreturn [Array<Boolean, Pipeline>] the new pipeline creation success and new pipeline object
+    #
+    # @return [Boolean] new pipeline creation success
+    def reload_pipeline(pipeline_id, &reload_block)
+      success = false
+
+      @states.compute(pipeline_id) do |_, state|
+        if state.nil?
+          logger.error("Attempted to reload a pipeline that does not exists", :pipeline_id => pipeline_id)
+          nil
+        else
+          state.set_reloading(true)
+          begin
+            success, new_pipeline = yield
+            state.set_pipeline(new_pipeline)
+          ensure
+            state.set_reloading(false)
+          end
+          state
+        end
+      end
+
+      success
+    end
+
+    # @param pipeline_id [String, Symbol] the pipeline id
+    # @return [Pipeline] the pipeline object or nil if none for pipeline_id
+    def get_pipeline(pipeline_id)
+      state = @states.get(pipeline_id)
+      state.nil? ? nil : state.pipeline
+    end
+
+    # @return [Fixnum] number of items in the states collection
+    def size
+      @states.size
+    end
+
+    # @return [Boolean] true if the states collection is empty.
+    def empty?
+      @states.isEmpty
+    end
+
+    # @return [Hash{String=>Pipeline}]
+    def running_pipelines
+      select_pipelines { |state| !state.terminated? }
+    end
+
+    # @return [Hash{String=>Pipeline}]
+    def non_running_pipelines
+      select_pipelines { |state| state.terminated? }
+    end
+
+    # @return [Hash{String=>Pipeline}]
+    def running_user_defined_pipelines
+      select_pipelines { |state | !state.terminated? && !state.pipeline.system? }
+    end
+
+    private
+
+    # Returns a mapping of pipelines by their ids.
+    # Pipelines can optionally be filtered by their `PipelineState` by passing
+    # a block that returns truthy when a pipeline should be included in the
+    # result.
+    #
+    # @yieldparam [PipelineState]
+    # @yieldreturn [Boolean]
+    #
+    # @return [Hash{String=>Pipeline}]
+    def select_pipelines(&optional_state_filter)
+      @states.each_with_object({}) do |(id, state), memo|
+        if state && (!block_given? || yield(state))
+          memo[id] = state.pipeline
+        end
+      end
+    end
+  end
+end

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -119,7 +119,7 @@ describe LogStash::Agent do
         context "if state is clean" do
           before :each do
             allow(subject).to receive(:running_user_defined_pipelines?).and_return(true)
-            allow(subject).to receive(:clean_state?).and_return(false)
+            allow(subject).to receive(:no_pipeline?).and_return(false)
           end
 
           it "should not converge state more than once" do
@@ -142,7 +142,7 @@ describe LogStash::Agent do
             it "does not upgrade the new config" do
               t = Thread.new { subject.execute }
               wait(timeout)
-                  .for { subject.running_pipelines? && subject.pipelines.values.first.ready? }
+                  .for { subject.running_pipelines? && subject.running_pipelines.values.first.ready? }
                   .to eq(true)
               expect(subject.converge_state_and_update).not_to be_a_successful_converge
               expect(subject).to have_running_pipeline?(mock_config_pipeline)
@@ -162,7 +162,7 @@ describe LogStash::Agent do
             it "does upgrade the new config" do
               t = Thread.new { subject.execute }
               Timeout.timeout(timeout) do
-                sleep(0.1) until subject.pipelines_count > 0 && subject.pipelines.values.first.ready?
+                sleep(0.1) until subject.running_pipelines_count > 0 && subject.running_pipelines.values.first.ready?
               end
 
               expect(subject.converge_state_and_update).to be_a_successful_converge
@@ -186,7 +186,7 @@ describe LogStash::Agent do
             it "does not try to reload the pipeline" do
               t = Thread.new { subject.execute }
               Timeout.timeout(timeout) do
-                sleep(0.1) until subject.running_pipelines? && subject.pipelines.values.first.running?
+                sleep(0.1) until subject.running_pipelines? && subject.running_pipelines.values.first.running?
               end
               expect(subject.converge_state_and_update).not_to be_a_successful_converge
               expect(subject).to have_running_pipeline?(mock_config_pipeline)
@@ -206,7 +206,7 @@ describe LogStash::Agent do
             it "tries to reload the pipeline" do
               t = Thread.new { subject.execute }
               Timeout.timeout(timeout) do
-                sleep(0.1) until subject.running_pipelines? && subject.pipelines.values.first.running?
+                sleep(0.1) until subject.running_pipelines? && subject.running_pipelines.values.first.running?
               end
 
               expect(subject.converge_state_and_update).to be_a_successful_converge

--- a/logstash-core/spec/logstash/pipeline_action/create_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_action/create_spec.rb
@@ -2,13 +2,14 @@
 require "spec_helper"
 require_relative "../../support/helpers"
 require_relative "../../support/matchers"
+require "logstash/pipelines_registry"
 require "logstash/pipeline_action/create"
 require "logstash/inputs/generator"
 
 describe LogStash::PipelineAction::Create do
   let(:metric) { LogStash::Instrument::NullMetric.new(LogStash::Instrument::Collector.new) }
-  let(:pipeline_config) { mock_pipeline_config(:main, "input { generator { id => '123' } } output { null {} }") }
-  let(:pipelines) { java.util.concurrent.ConcurrentHashMap.new }
+  let(:pipeline_config) { mock_pipeline_config(:main, "input { dummyblockinginput { id => '123' } } output { null {} }") }
+  let(:pipelines) { LogStash::PipelinesRegistry.new }
   let(:agent) { double("agent") }
 
   before do
@@ -18,7 +19,7 @@ describe LogStash::PipelineAction::Create do
   subject { described_class.new(pipeline_config, metric) }
 
   after do
-    pipelines.each do |_, pipeline|
+    pipelines.running_pipelines do |_, pipeline|
       pipeline.shutdown
       pipeline.thread.join
     end
@@ -44,7 +45,7 @@ describe LogStash::PipelineAction::Create do
 
     it "starts the pipeline" do
       subject.execute(agent, pipelines)
-      expect(pipelines[:main].running?).to be_truthy
+      expect(pipelines.get_pipeline(:main).running?).to be_truthy
     end
 
     it "returns a successful execution status" do
@@ -54,7 +55,7 @@ describe LogStash::PipelineAction::Create do
 
   context  "when the pipeline doesn't start" do
     context "with a syntax error" do
-      let(:pipeline_config) { mock_pipeline_config(:main, "input { generator { id => '123' } } output { stdout ") } # bad syntax
+      let(:pipeline_config) { mock_pipeline_config(:main, "input { dummyblockinginput { id => '123' } } output { stdout ") } # bad syntax
 
       it "raises the exception upstream" do
         expect { subject.execute(agent, pipelines) }.to raise_error
@@ -62,7 +63,7 @@ describe LogStash::PipelineAction::Create do
     end
 
     context "with an error raised during `#register`" do
-      let(:pipeline_config) { mock_pipeline_config(:main, "input { generator { id => '123' } } filter { ruby { init => '1/0' code => '1+2' } } output { null {} }") }
+      let(:pipeline_config) { mock_pipeline_config(:main, "input { dummyblockinginput { id => '123' } } filter { ruby { init => '1/0' code => '1+2' } } output { null {} }") }
 
       it "returns false" do
         expect(subject.execute(agent, pipelines)).not_to be_a_successful_action
@@ -71,8 +72,8 @@ describe LogStash::PipelineAction::Create do
   end
 
   context "when sorting create action" do
-    let(:pipeline_config) { mock_pipeline_config(:main, "input { generator { id => '123' } } output { null {} }") }
-    let(:system_pipeline_config) { mock_pipeline_config(:main_2, "input { generator { id => '123' } } output { null {} }", { "pipeline.system" => true }) }
+    let(:pipeline_config) { mock_pipeline_config(:main, "input { dummyblockinginput { id => '123' } } output { null {} }") }
+    let(:system_pipeline_config) { mock_pipeline_config(:main_2, "input { dummyblockinginput { id => '123' } } output { null {} }", { "pipeline.system" => true }) }
 
     it "should give higher priority to system pipeline" do
       action_user_pipeline = described_class.new(pipeline_config, metric)

--- a/logstash-core/spec/logstash/pipeline_action/reload_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_action/reload_spec.rb
@@ -2,15 +2,16 @@
 require "spec_helper"
 require_relative "../../support/helpers"
 require_relative "../../support/matchers"
+require "logstash/pipelines_registry"
 require "logstash/pipeline_action/reload"
 
 describe LogStash::PipelineAction::Reload do
   let(:metric) { LogStash::Instrument::NullMetric.new(LogStash::Instrument::Collector.new) }
   let(:pipeline_id) { :main }
-  let(:new_pipeline_config) { mock_pipeline_config(pipeline_id, "input { generator { id => 'new' } } output { null {} }", { "pipeline.reloadable" => true}) }
-  let(:pipeline_config) { "input { generator {} } output { null {} }" }
+  let(:new_pipeline_config) { mock_pipeline_config(pipeline_id, "input { dummyblockinginput { id => 'new' } } output { null {} }", { "pipeline.reloadable" => true}) }
+  let(:pipeline_config) { "input { dummyblockinginput {} } output { null {} }" }
   let(:pipeline) { mock_pipeline_from_string(pipeline_config, mock_settings("pipeline.reloadable" => true)) }
-  let(:pipelines) { chm = java.util.concurrent.ConcurrentHashMap.new; chm[pipeline_id] = pipeline; chm }
+  let(:pipelines) { r = LogStash::PipelinesRegistry.new; r.create_pipeline(pipeline_id, pipeline) { true }; r }
   let(:agent) { double("agent") }
 
   subject { described_class.new(new_pipeline_config, metric) }
@@ -21,7 +22,7 @@ describe LogStash::PipelineAction::Reload do
   end
 
   after do
-    pipelines.each do |_, pipeline|
+    pipelines.running_pipelines do |_, pipeline|
       pipeline.shutdown
       pipeline.thread.join
     end
@@ -38,12 +39,12 @@ describe LogStash::PipelineAction::Reload do
 
     it "start the new pipeline" do
       subject.execute(agent, pipelines)
-      expect(pipelines[pipeline_id].running?).to be_truthy
+      expect(pipelines.get_pipeline(pipeline_id).running?).to be_truthy
     end
 
     it "run the new pipeline code" do
       subject.execute(agent, pipelines)
-      expect(pipelines[pipeline_id].config_hash).to eq(new_pipeline_config.config_hash)
+      expect(pipelines.get_pipeline(pipeline_id).config_hash).to eq(new_pipeline_config.config_hash)
     end
   end
 
@@ -58,7 +59,7 @@ describe LogStash::PipelineAction::Reload do
   end
 
   context "when the new pipeline is not reloadable" do
-    let(:new_pipeline_config) { mock_pipeline_config(pipeline_id, "input { generator { id => 'new' } } output { null {} }", { "pipeline.reloadable" => false}) }
+    let(:new_pipeline_config) { mock_pipeline_config(pipeline_id, "input { dummyblockinginput { id => 'new' } } output { null {} }", { "pipeline.reloadable" => false}) }
 
     it "cannot successfully execute the action" do
       expect(subject.execute(agent, pipelines)).not_to be_a_successful_action
@@ -66,7 +67,7 @@ describe LogStash::PipelineAction::Reload do
   end
 
   context "when the new pipeline has syntax errors" do
-    let(:new_pipeline_config) { mock_pipeline_config(pipeline_id, "input generator { id => 'new' } } output { null {} }", { "pipeline.reloadable" => false}) }
+    let(:new_pipeline_config) { mock_pipeline_config(pipeline_id, "input dummyblockinginput { id => 'new' } } output { null {} }", { "pipeline.reloadable" => false}) }
 
     it "cannot successfully execute the action" do
       expect(subject.execute(agent, pipelines)).not_to be_a_successful_action
@@ -75,7 +76,7 @@ describe LogStash::PipelineAction::Reload do
 
   context "when there is an error in the register" do
     before do
-      allow_any_instance_of(LogStash::Inputs::Generator).to receive(:register).and_raise("Bad value")
+      allow_any_instance_of(LogStash::Inputs::DummyBlockingInput).to receive(:register).and_raise("Bad value")
     end
 
     it "cannot successfully execute the action" do

--- a/logstash-core/spec/logstash/pipelines_registry_spec.rb
+++ b/logstash-core/spec/logstash/pipelines_registry_spec.rb
@@ -1,0 +1,220 @@
+# encoding: utf-8
+require "spec_helper"
+require "logstash/pipelines_registry"
+
+describe LogStash::PipelinesRegistry do
+
+  let(:pipeline_id) { "test" }
+  let(:pipeline) { double("Pipeline") }
+  let (:logger) { double("Logger") }
+
+  context "at object creation" do
+    it "should be empty" do
+      expect(subject.size).to eq(0)
+      expect(subject.empty?).to be_truthy
+      expect(subject.running_pipelines).to be_empty
+      expect(subject.non_running_pipelines).to be_empty
+      expect(subject.running_user_defined_pipelines).to be_empty
+    end
+  end
+
+  context "creating a pipeline" do
+    context "without existing same pipeline id" do
+      it "registry should not have a state for pipeline_id" do
+        expect(subject.get_pipeline(pipeline_id)).to be_nil
+      end
+
+      it "should return block return value" do
+        expect(subject.create_pipeline(pipeline_id, pipeline) { "dummy" }).to eq("dummy")
+      end
+
+      it "should register the new pipeline upon successful create block" do
+        subject.create_pipeline(pipeline_id, pipeline) { true }
+        expect(subject.get_pipeline(pipeline_id)).to eq(pipeline)
+      end
+
+      it "should not register the new pipeline upon unsuccessful create block" do
+        subject.create_pipeline(pipeline_id, pipeline) { false }
+        expect(subject.get_pipeline(pipeline_id)).to be_nil
+      end
+    end
+
+    context "with existing pipeline id" do
+      before :each do
+        subject.create_pipeline(pipeline_id, pipeline) { true }
+      end
+
+      it "registry should have a state for pipeline_id" do
+        expect(subject.get_pipeline(pipeline_id)).to eq(pipeline)
+      end
+
+      context "when existing pipeline is not terminated" do
+        before :each do
+          expect(pipeline).to receive(:finished_execution?).and_return(false)
+        end
+
+        it "should return false" do
+          expect(subject.create_pipeline(pipeline_id, pipeline) { "dummy" }).to be_falsey
+        end
+
+        it "should not call block and log error if pipeline is not terminated" do
+          expect(LogStash::PipelinesRegistry).to receive(:logger).and_return(logger)
+          expect(logger).to receive(:error)
+          expect { |b| subject.create_pipeline(pipeline_id, pipeline, &b) }.not_to yield_control
+        end
+      end
+
+      context "when existing pipeline is terminated" do
+        let (:new_pipeline) { double("New Pipeline") }
+
+        before :each do
+          expect(pipeline).to receive(:finished_execution?).and_return(true)
+        end
+
+        it "should return block value" do
+          expect(subject.create_pipeline(pipeline_id, new_pipeline) { "dummy" }).to eq("dummy")
+        end
+
+        it "should return block value" do
+          expect(subject.create_pipeline(pipeline_id, new_pipeline) { "dummy" }).to eq("dummy")
+        end
+
+        it "should register new pipeline" do
+          subject.create_pipeline(pipeline_id, new_pipeline) { true }
+          expect(subject.get_pipeline(pipeline_id)).to eq(new_pipeline)
+        end
+      end
+    end
+  end
+
+  context "terminating a pipeline" do
+    context "without existing pipeline id" do
+      it "should log error" do
+        expect(LogStash::PipelinesRegistry).to receive(:logger).and_return(logger)
+        expect(logger).to receive(:error)
+        subject.terminate_pipeline(pipeline_id) { "dummy" }
+      end
+
+      it "should not yield to block" do
+        expect { |b| subject.terminate_pipeline(pipeline_id, &b) }.not_to yield_control
+      end
+    end
+
+    context "with existing pipeline id" do
+      before :each do
+        subject.create_pipeline(pipeline_id, pipeline) { true }
+      end
+
+      it "should yield to block" do
+        expect { |b| subject.terminate_pipeline(pipeline_id, &b) }.to yield_control
+      end
+
+      it "should keep pipeline id" do
+        subject.terminate_pipeline(pipeline_id) { "dummy" }
+        expect(subject.get_pipeline(pipeline_id)).to eq(pipeline)
+      end
+    end
+  end
+
+  context "reloading a pipeline" do
+    it "should log error with inexistent pipeline id" do
+      expect(LogStash::PipelinesRegistry).to receive(:logger).and_return(logger)
+      expect(logger).to receive(:error)
+      subject.reload_pipeline(pipeline_id) { }
+    end
+
+    context "with existing pipeline id" do
+      before :each do
+        subject.create_pipeline(pipeline_id, pipeline) { true }
+      end
+
+      it "should return block value" do
+        expect(subject.reload_pipeline(pipeline_id) { ["dummy", pipeline] }).to eq("dummy")
+      end
+
+      it "should not be terminated while reloading" do
+        expect(pipeline).to receive(:finished_execution?).and_return(false, true, true)
+
+        # 1st call: finished_execution? is false
+        expect(subject.running_pipelines).not_to be_empty
+
+        # 2nd call: finished_execution? is true
+        expect(subject.running_pipelines).to be_empty
+
+
+        queue = Queue.new # threadsafe queue
+        in_block = Concurrent::AtomicBoolean.new(false)
+
+        thread = Thread.new(subject, pipeline_id, pipeline, queue, in_block) do |subject, pipeline_id, pipeline, queue, in_block|
+          subject.reload_pipeline(pipeline_id) do
+            in_block.make_true
+            queue.pop
+            [true, pipeline]
+          end
+        end
+
+        # make sure we entered the block executioin
+        wait(10).for {in_block.true?}.to be_truthy
+
+        # at this point the thread is suspended waiting on queue
+
+        # since in reloading state, running_pipelines is not empty
+        expect(subject.running_pipelines).not_to be_empty
+
+        # unblock thread
+        queue.push(:dummy)
+        thread.join
+
+        # 3rd call: finished_execution? is true
+        expect(subject.running_pipelines).to be_empty
+      end
+    end
+  end
+
+  context "pipelines collections" do
+    context "with a non terminated pipelines" do
+      before :each do
+        subject.create_pipeline(pipeline_id, pipeline) { true }
+        expect(pipeline).to receive(:finished_execution?).and_return(false)
+      end
+
+      it "should find running pipelines" do
+        expect(subject.running_pipelines).not_to be_empty
+      end
+
+      it "should not find non_running pipelines" do
+        expect(subject.non_running_pipelines).to be_empty
+      end
+
+      it "should find running_user_defined_pipelines" do
+        expect(pipeline).to receive(:system?).and_return(false)
+        expect(subject.running_user_defined_pipelines).not_to be_empty
+      end
+
+      it "should not find running_user_defined_pipelines" do
+        expect(pipeline).to receive(:system?).and_return(true)
+        expect(subject.running_user_defined_pipelines).to be_empty
+      end
+    end
+
+    context "with a terminated pipelines" do
+      before :each do
+        subject.create_pipeline(pipeline_id, pipeline) { true }
+        expect(pipeline).to receive(:finished_execution?).and_return(true)
+      end
+
+      it "should not find running pipelines" do
+        expect(subject.running_pipelines).to be_empty
+      end
+
+      it "should find non_running pipelines" do
+        expect(subject.non_running_pipelines).not_to be_empty
+      end
+
+      it "should not find running_user_defined_pipelines" do
+        expect(subject.running_user_defined_pipelines).to be_empty
+      end
+    end
+
+  end
+end

--- a/logstash-core/spec/support/shared_contexts.rb
+++ b/logstash-core/spec/support/shared_contexts.rb
@@ -26,12 +26,12 @@ shared_context "api setup" do
     @agent.execute
     pipeline_config = mock_pipeline_config(:main, "input { generator { id => '123' } } output { null {} }")
     pipeline_creator =  LogStash::PipelineAction::Create.new(pipeline_config, @agent.metric)
-    @pipelines = java.util.concurrent.ConcurrentHashMap.new
-    expect(pipeline_creator.execute(@agent, @pipelines)).to be_truthy
+    @pipelines_registry = LogStash::PipelinesRegistry.new
+    expect(pipeline_creator.execute(@agent, @pipelines_registry)).to be_truthy
   end
 
   after :all do
-    @pipelines.each do |_, pipeline|
+    @pipelines_registry.running_pipelines.each do |_, pipeline|
       pipeline.shutdown
       pipeline.thread.join
     end

--- a/logstash-core/src/main/java/org/logstash/plugins/HooksRegistryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/HooksRegistryExt.java
@@ -9,6 +9,7 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -50,6 +51,15 @@ public final class HooksRegistryExt extends RubyObject {
         callbacks.add(callback);
         return syncHooks(context);
     }
+
+    @JRubyMethod(name = "remove_hooks")
+    public IRubyObject remove_hooks(final ThreadContext context, final IRubyObject emitterScope, final IRubyObject callback) {
+        final List<IRubyObject> callbacks = registeredHooks.get(emitterScope);
+        if (callbacks == null) {
+            return context.fals;
+        }
+        return callbacks.removeAll(Collections.singleton(callback)) ? context.tru : context.fals;
+     }
 
     @JRubyMethod(name = "emitters_count")
     public IRubyObject emittersCount(final ThreadContext context) {

--- a/x-pack/lib/monitoring/inputs/metrics/stats_event/pipelines_info.rb
+++ b/x-pack/lib/monitoring/inputs/metrics/stats_event/pipelines_info.rb
@@ -9,7 +9,7 @@ module LogStash; module Inputs; class Metrics; module StatsEvent;
       # metrics pipelines. This prevents race conditions as pipeline stats may be
       # populated before the agent has it in its own pipelines state
       stats = metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines]
-      agent.pipelines.map do |pipeline_id, pipeline|
+      agent.running_pipelines.map do |pipeline_id, pipeline|
         p_stats = stats[pipeline_id]
         # Don't record stats for system pipelines
         next nil if pipeline.system?


### PR DESCRIPTION
Fixes #10345

This PR introduces a new `PipelinesRegistry` class to encapsulate the old `Agent` `@pipelines` `ConcurrentHashMap`.  

One of the problem was the termination condition of the agent which was checking if all pipelines threads were **not** `Threah#alive?` and assumed it could exit. The problem is that the reload action did shutdown a pipeline to later on restart a new one, and in that period, all pipelines thread could have been seen as **not** `Threah#alive?`. This PR solves this condition by taking into account the reloading sequence as a period where a pipeline is not considered dead regardless if shutdown part of the reload accured or not.

### Main Changes
-  new `PipelinesRegistry` is an abstraction for the registration a management of the pipeline states which replaces the old `@pipelines` instance variable which had a getter and was directly used in other parts of the code
- correctly pass action thread parameters
- fix periodic_pollers.rb wrong parameter names
- introduce new `@finished_run`  `AtomicBoolean`
- change `@finished_execution` to **always** be true regardless of pipeline termination condition
- document semantic of both `@finished_run` and `@finished_execution`
- refactor non-autoreload agent loop 
- change `Pipeline#wait_until_started` to use `@finished_run` and document logic
- change pipeline actions to use new registry `create_pipeline`, `reload_pipeline` and `terminate_pipeline`
- change usage of `@pipelines` to use new registry collection methods

### Other Changes

- change usage of the `generator` plugin in specs with a new `dummyblockinginput`. while fixing tests these were making it almost impossible to follow the debug traces of the build because the generator inputs were outputting gigamounts of debug logs, one per emitted event. Also generator input is a waste of ressource and probably slows down the tests too. 
- made changes to make some specs more resilient to timing problems when testing the actions and agent.
- added new `HookRegistry#remove_hooks` method to the metrics input to be able to cleanup the global and static `LogStash::PLUGIN_REGISTRY` when finished - this was causing weird problems in the metrics specs where the `pipeline_started` action was being fires on unused instances of the plugin when instantiated multiple times in the specs.
- refactored `x-pack/spec/monitoring/inputs/metrics_spec.rb` to be more resilient to timing related errors (specs were always passing locally but not on slower Jenkins execution).