### PR TITLE
accept @timestamp numeric value as epoch in event initialization

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.joda.time.DateTime;
+import org.jruby.RubyFixnum;
 import org.jruby.RubyNil;
 import org.jruby.RubyString;
 import org.jruby.RubySymbol;
@@ -317,6 +318,8 @@ public final class Event implements Cloneable, Queueable {
                 return new Timestamp((Date) o);
             } else if (o instanceof RubySymbol) {
                 return new Timestamp(((RubySymbol) o).asJavaString());
+            } else if (o instanceof RubyFixnum) {
+                return new Timestamp(RubyFixnum.num2long((RubyFixnum)o) * 1000); // Timestamp(long) expects epoch as milliseconds
             } else {
                 logger.warn("Unrecognized " + TIMESTAMP + " value type=" + o.getClass().toString());
             }


### PR DESCRIPTION
While looking at a `@timestamp` issue in `Event` initialization I ran into this problem; numeric values in a `@timestamp` field at `Event` initialization are not supported. 

```
$ bin/logstash -e 'input{stdin {codec => json_lines}} output { stdout {codec => rubydebug}}'
...
{"a":1, "@timestamp":1483239600}

[2019-01-31T10:13:13,217][WARN ][org.logstash.Event       ] Unrecognized @timestamp value type=class org.jruby.RubyFixnum
{
           "host" => "mbp15r",
    "_@timestamp" => 1483239600,
              "a" => 1,
       "@version" => "1",
     "@timestamp" => 2019-01-31T15:13:13.223Z,
           "tags" => [
        [0] "_timestampparsefailure"
    ]
}
```

It seems fair to assume that a numeric value is in fact an epoch value. After this patch this now works:

```
bin/logstash -e 'input{stdin {codec => json_lines}} output { stdout {codec => rubydebug}}'
...
{"a":1, "@timestamp":1483239600}

{
          "host" => "mbp15r",
    "@timestamp" => 2017-01-01T03:00:00.000Z,
             "a" => 1,
      "@version" => "1"
}
```

I haven't found much specs around the accepted initialization values for the Event `@timestamp` field - unless there is objection to this patch I will add a better spec suite for that.