### PR TITLE
7x index templates

### DIFF
--- a/modules/fb_apache/configuration/elasticsearch/fb_apache.json
+++ b/modules/fb_apache/configuration/elasticsearch/fb_apache.json
@@ -1,9 +1,5 @@
 {
   "mappings": {
-    "_default_": {
-      "_all": {
-        "norms": false
-      },
       "_meta": {
         "version": "5.4.0"
       },
@@ -668,12 +664,11 @@
           "type": "keyword"
         }
       }
-    }
   },
   "order": 0,
   "settings": {
     "index.mapping.total_fields.limit": 10000,
     "index.refresh_interval": "5s"
   },
-  "template": "fb_apache-*"
+  "index_patterns": "fb_apache-*"
 }

--- a/modules/fb_apache/configuration/elasticsearch/fb_apache.json
+++ b/modules/fb_apache/configuration/elasticsearch/fb_apache.json
@@ -1,669 +1,669 @@
 {
   "mappings": {
-      "_meta": {
-        "version": "5.4.0"
-      },
-      "date_detection": false,
-      "dynamic_templates": [
-        {
-          "strings_as_keyword": {
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "match_mapping_type": "string"
-          }
-        }
-      ],
-      "properties": {
-        "@timestamp": {
-          "type": "date"
-        },
-        "apache2": {
-          "properties": {
-            "access": {
-              "properties": {
-                "agent": {
-                  "norms": false,
-                  "type": "text"
-                },
-                "body_sent": {
-                  "properties": {
-                    "bytes": {
-                      "type": "long"
-                    }
-                  }
-                },
-                "geoip": {
-                  "properties": {
-                    "continent_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "country_iso_code": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "location": {
-                      "type": "geo_point"
-                    }
-                  }
-                },
-                "http_version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "method": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "referrer": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "remote_ip": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "response_code": {
-                  "type": "long"
-                },
-                "url": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "user_agent": {
-                  "properties": {
-                    "device": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "major": {
-                      "type": "long"
-                    },
-                    "minor": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "os": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "os_major": {
-                      "type": "long"
-                    },
-                    "os_minor": {
-                      "type": "long"
-                    },
-                    "os_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "patch": {
-                      "type": "long"
-                    }
-                  }
-                },
-                "user_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "error": {
-              "properties": {
-                "client": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "level": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "message": {
-                  "norms": false,
-                  "type": "text"
-                },
-                "module": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "pid": {
-                  "type": "long"
-                },
-                "tid": {
-                  "type": "long"
-                }
-              }
-            }
-          }
-        },
-        "auditd": {
-          "properties": {
-            "log": {
-              "properties": {
-                "a0": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "acct": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "geoip": {
-                  "properties": {
-                    "city_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "continent_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "country_iso_code": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "location": {
-                      "type": "geo_point"
-                    },
-                    "region_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "item": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "items": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "new_auid": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "new_ses": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "old_auid": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "old_ses": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "pid": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ppid": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "record_type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "res": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sequence": {
-                  "type": "long"
-                }
-              }
-            }
-          }
-        },
-        "beat": {
-          "properties": {
-            "hostname": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        "error": {
-          "ignore_above": 1024,
-          "type": "keyword"
-        },
-        "fields": {
-          "properties": {}
-        },
-        "fileset": {
-          "properties": {
-            "module": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        "input_type": {
-          "ignore_above": 1024,
-          "type": "keyword"
-        },
-        "message": {
-          "norms": false,
-          "type": "text"
-        },
-        "meta": {
-          "properties": {
-            "cloud": {
-              "properties": {
-                "availability_zone": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "instance_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "machine_type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "project_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "provider": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            }
-          }
-        },
-        "mysql": {
-          "properties": {
-            "error": {
-              "properties": {
-                "level": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "message": {
-                  "norms": false,
-                  "type": "text"
-                },
-                "thread_id": {
-                  "type": "long"
-                },
-                "timestamp": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "slowlog": {
-              "properties": {
-                "host": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "type": "long"
-                },
-                "ip": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "lock_time": {
-                  "properties": {
-                    "sec": {
-                      "type": "float"
-                    }
-                  }
-                },
-                "query": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "query_time": {
-                  "properties": {
-                    "sec": {
-                      "type": "float"
-                    }
-                  }
-                },
-                "rows_examined": {
-                  "type": "long"
-                },
-                "rows_sent": {
-                  "type": "long"
-                },
-                "timestamp": {
-                  "type": "long"
-                },
-                "user": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            }
-          }
-        },
-        "nginx": {
-          "properties": {
-            "access": {
-              "properties": {
-                "agent": {
-                  "norms": false,
-                  "type": "text"
-                },
-                "body_sent": {
-                  "properties": {
-                    "bytes": {
-                      "type": "long"
-                    }
-                  }
-                },
-                "geoip": {
-                  "properties": {
-                    "continent_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "country_iso_code": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "location": {
-                      "type": "geo_point"
-                    }
-                  }
-                },
-                "http_version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "method": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "referrer": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "remote_ip": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "response_code": {
-                  "type": "long"
-                },
-                "url": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "user_agent": {
-                  "properties": {
-                    "device": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "major": {
-                      "type": "long"
-                    },
-                    "minor": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "os": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "os_major": {
-                      "type": "long"
-                    },
-                    "os_minor": {
-                      "type": "long"
-                    },
-                    "os_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "patch": {
-                      "type": "long"
-                    }
-                  }
-                },
-                "user_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "error": {
-              "properties": {
-                "connection_id": {
-                  "type": "long"
-                },
-                "level": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "message": {
-                  "norms": false,
-                  "type": "text"
-                },
-                "pid": {
-                  "type": "long"
-                },
-                "tid": {
-                  "type": "long"
-                }
-              }
-            }
-          }
-        },
-        "offset": {
-          "type": "long"
-        },
-        "read_timestamp": {
-          "ignore_above": 1024,
-          "type": "keyword"
-        },
-        "source": {
-          "ignore_above": 1024,
-          "type": "keyword"
-        },
-        "system": {
-          "properties": {
-            "auth": {
-              "properties": {
-                "groupadd": {
-                  "properties": {
-                    "gid": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "hostname": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "message": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "pid": {
-                  "type": "long"
-                },
-                "program": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ssh": {
-                  "properties": {
-                    "dropped_ip": {
-                      "type": "ip"
-                    },
-                    "event": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "geoip": {
-                      "properties": {
-                        "city_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "continent_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country_iso_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "location": {
-                          "type": "geo_point"
-                        },
-                        "region_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "ip": {
-                      "type": "ip"
-                    },
-                    "method": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "port": {
-                      "type": "long"
-                    },
-                    "signature": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "sudo": {
-                  "properties": {
-                    "command": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "error": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "pwd": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "tty": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "user": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "timestamp": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "user": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "useradd": {
-                  "properties": {
-                    "gid": {
-                      "type": "long"
-                    },
-                    "home": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "shell": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "uid": {
-                      "type": "long"
-                    }
-                  }
-                }
-              }
-            },
-            "syslog": {
-              "properties": {
-                "hostname": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "message": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "pid": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "program": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "timestamp": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            }
-          }
-        },
-        "tags": {
-          "ignore_above": 1024,
-          "type": "keyword"
-        },
-        "type": {
-          "ignore_above": 1024,
-          "type": "keyword"
+    "_meta": {
+      "version": "5.4.0"
+    },
+    "date_detection": false,
+    "dynamic_templates": [
+      {
+        "strings_as_keyword": {
+          "mapping": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "match_mapping_type": "string"
         }
       }
+    ],
+    "properties": {
+      "@timestamp": {
+        "type": "date"
+      },
+      "apache2": {
+        "properties": {
+          "access": {
+            "properties": {
+              "agent": {
+                "norms": false,
+                "type": "text"
+              },
+              "body_sent": {
+                "properties": {
+                  "bytes": {
+                    "type": "long"
+                  }
+                }
+              },
+              "geoip": {
+                "properties": {
+                  "continent_name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "country_iso_code": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "location": {
+                    "type": "geo_point"
+                  }
+                }
+              },
+              "http_version": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "method": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "referrer": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "remote_ip": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "response_code": {
+                "type": "long"
+              },
+              "url": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "user_agent": {
+                "properties": {
+                  "device": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "major": {
+                    "type": "long"
+                  },
+                  "minor": {
+                    "type": "long"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "os": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "os_major": {
+                    "type": "long"
+                  },
+                  "os_minor": {
+                    "type": "long"
+                  },
+                  "os_name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "patch": {
+                    "type": "long"
+                  }
+                }
+              },
+              "user_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
+          "error": {
+            "properties": {
+              "client": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "level": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "message": {
+                "norms": false,
+                "type": "text"
+              },
+              "module": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "pid": {
+                "type": "long"
+              },
+              "tid": {
+                "type": "long"
+              }
+            }
+          }
+        }
+      },
+      "auditd": {
+        "properties": {
+          "log": {
+            "properties": {
+              "a0": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "acct": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "geoip": {
+                "properties": {
+                  "city_name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "continent_name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "country_iso_code": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "location": {
+                    "type": "geo_point"
+                  },
+                  "region_name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "item": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "items": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "new_auid": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "new_ses": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "old_auid": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "old_ses": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "pid": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "ppid": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "record_type": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "res": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "sequence": {
+                "type": "long"
+              }
+            }
+          }
+        }
+      },
+      "beat": {
+        "properties": {
+          "hostname": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "name": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "version": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          }
+        }
+      },
+      "error": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      },
+      "fields": {
+        "properties": {}
+      },
+      "fileset": {
+        "properties": {
+          "module": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "name": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          }
+        }
+      },
+      "input_type": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      },
+      "message": {
+        "norms": false,
+        "type": "text"
+      },
+      "meta": {
+        "properties": {
+          "cloud": {
+            "properties": {
+              "availability_zone": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "instance_id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "machine_type": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "project_id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "provider": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          }
+        }
+      },
+      "mysql": {
+        "properties": {
+          "error": {
+            "properties": {
+              "level": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "message": {
+                "norms": false,
+                "type": "text"
+              },
+              "thread_id": {
+                "type": "long"
+              },
+              "timestamp": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
+          "slowlog": {
+            "properties": {
+              "host": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "id": {
+                "type": "long"
+              },
+              "ip": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "lock_time": {
+                "properties": {
+                  "sec": {
+                    "type": "float"
+                  }
+                }
+              },
+              "query": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "query_time": {
+                "properties": {
+                  "sec": {
+                    "type": "float"
+                  }
+                }
+              },
+              "rows_examined": {
+                "type": "long"
+              },
+              "rows_sent": {
+                "type": "long"
+              },
+              "timestamp": {
+                "type": "long"
+              },
+              "user": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          }
+        }
+      },
+      "nginx": {
+        "properties": {
+          "access": {
+            "properties": {
+              "agent": {
+                "norms": false,
+                "type": "text"
+              },
+              "body_sent": {
+                "properties": {
+                  "bytes": {
+                    "type": "long"
+                  }
+                }
+              },
+              "geoip": {
+                "properties": {
+                  "continent_name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "country_iso_code": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "location": {
+                    "type": "geo_point"
+                  }
+                }
+              },
+              "http_version": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "method": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "referrer": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "remote_ip": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "response_code": {
+                "type": "long"
+              },
+              "url": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "user_agent": {
+                "properties": {
+                  "device": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "major": {
+                    "type": "long"
+                  },
+                  "minor": {
+                    "type": "long"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "os": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "os_major": {
+                    "type": "long"
+                  },
+                  "os_minor": {
+                    "type": "long"
+                  },
+                  "os_name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "patch": {
+                    "type": "long"
+                  }
+                }
+              },
+              "user_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
+          "error": {
+            "properties": {
+              "connection_id": {
+                "type": "long"
+              },
+              "level": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "message": {
+                "norms": false,
+                "type": "text"
+              },
+              "pid": {
+                "type": "long"
+              },
+              "tid": {
+                "type": "long"
+              }
+            }
+          }
+        }
+      },
+      "offset": {
+        "type": "long"
+      },
+      "read_timestamp": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      },
+      "source": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      },
+      "system": {
+        "properties": {
+          "auth": {
+            "properties": {
+              "groupadd": {
+                "properties": {
+                  "gid": {
+                    "type": "long"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "hostname": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "message": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "pid": {
+                "type": "long"
+              },
+              "program": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "ssh": {
+                "properties": {
+                  "dropped_ip": {
+                    "type": "ip"
+                  },
+                  "event": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "geoip": {
+                    "properties": {
+                      "city_name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "continent_name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "country_iso_code": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "location": {
+                        "type": "geo_point"
+                      },
+                      "region_name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    }
+                  },
+                  "ip": {
+                    "type": "ip"
+                  },
+                  "method": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "port": {
+                    "type": "long"
+                  },
+                  "signature": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "sudo": {
+                "properties": {
+                  "command": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "error": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "pwd": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "tty": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "user": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "timestamp": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "user": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "useradd": {
+                "properties": {
+                  "gid": {
+                    "type": "long"
+                  },
+                  "home": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "shell": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "uid": {
+                    "type": "long"
+                  }
+                }
+              }
+            }
+          },
+          "syslog": {
+            "properties": {
+              "hostname": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "message": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "pid": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "program": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "timestamp": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          }
+        }
+      },
+      "tags": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      },
+      "type": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      }
+    }
   },
   "order": 0,
   "settings": {

--- a/modules/netflow/configuration/elasticsearch/netflow.json
+++ b/modules/netflow/configuration/elasticsearch/netflow.json
@@ -2,1050 +2,1050 @@
     "order": 0,
     "index_patterns": "netflow-*",
     "mappings": {
-            "_meta": {
-                "version": "7.0.0"
+        "_meta": {
+            "version": "7.0.0"
+        },
+        "dynamic_templates": [
+            {
+                "application_id": {
+                    "path_match": "netflow.application_id",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
             },
-            "dynamic_templates": [
-                {
-                    "application_id": {
-                        "path_match": "netflow.application_id",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "bgp_ipv4_next_hop": {
-                        "path_match": "netflow.bgp_ipv4_next_hop",
-                        "mapping": {
-                            "type": "ip"
-                        }
-                    }
-                },
-                {
-                    "bgp_ipv6_next_hop": {
-                        "path_match": "netflow.bgp_ipv6_next_hop",
-                        "mapping": {
-                            "type": "ip"
-                        }
-                    }
-                },
-                {
-                    "conn_id": {
-                        "path_match": "netflow.conn_id",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "dst_as": {
-                        "path_match": "netflow.dst_as",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "dst_tos": {
-                        "path_match": "netflow.dst_tos",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "dst_vlan": {
-                        "path_match": "netflow.dst_vlan",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "engine_id": {
-                        "path_match": "netflow.engine_id",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "engine_type": {
-                        "path_match": "netflow.engine_type",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "event_time_msec": {
-                        "path_match": "netflow.event_time_msec",
-                        "mapping": {
-                            "type": "long"
-                        }
-                    }
-                },
-                {
-                    "flow_active_timeout": {
-                        "path_match": "netflow.flow_active_timeout",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "flow_end_reason": {
-                        "path_match": "netflow.flow_end_reason",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "flow_inactive_timeout": {
-                        "path_match": "netflow.flow_inactive_timeout",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "flow_records": {
-                        "path_match": "netflow.flow_records",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "flow_sampler_id": {
-                        "path_match": "netflow.flow_sampler_id",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "flow_sampler_mode": {
-                        "path_match": "netflow.flow_sampler_mode",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "flow_sampler_random_interval": {
-                        "path_match": "netflow.flow_sampler_random_interval",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "flow_start_msec": {
-                        "path_match": "netflow.flow_start_msec",
-                        "mapping": {
-                            "type": "long"
-                        }
-                    }
-                },
-                {
-                    "flows": {
-                        "path_match": "netflow.flows",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "flowset_id": {
-                        "path_match": "netflow.flowset_id",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "fw_event": {
-                        "path_match": "netflow.fw_event",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "fw_ext_event": {
-                        "path_match": "netflow.fw_ext_event",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "fwd_flow_delta_bytes": {
-                        "path_match": "netflow.fwd_flow_delta_bytes",
-                        "mapping": {
-                            "type": "long"
-                        }
-                    }
-                },
-                {
-                    "icmp_code": {
-                        "path_match": "netflow.icmp_code",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "icmp_code_ipv6": {
-                        "path_match": "netflow.icmp_code_ipv6",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "icmp_type": {
-                        "path_match": "netflow.icmp_type",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "icmp_type_ipv6": {
-                        "path_match": "netflow.icmp_type_ipv6",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "if_desc": {
-                        "path_match": "netflow.if_desc",
-                        "mapping": {
-                            "type": "keyword",
-                            "norms": false
-                        }
-                    }
-                },
-                {
-                    "if_name": {
-                        "path_match": "netflow.if_name",
-                        "mapping": {
-                            "type": "keyword",
-                            "norms": false
-                        }
-                    }
-                },
-                {
-                    "in_bytes": {
-                        "path_match": "netflow.in_bytes",
-                        "mapping": {
-                            "type": "long"
-                        }
-                    }
-                },
-                {
-                    "in_dst_mac": {
-                        "path_match": "netflow.in_dst_mac",
-                        "mapping": {
-                            "type": "keyword",
-                            "norms": false
-                        }
-                    }
-                },
-                {
-                    "in_permanent_bytes": {
-                        "path_match": "netflow.in_permanent_bytes",
-                        "mapping": {
-                            "type": "long"
-                        }
-                    }
-                },
-                {
-                    "in_permanent_pkts": {
-                        "path_match": "netflow.in_permanent_pkts",
-                        "mapping": {
-                            "type": "long"
-                        }
-                    }
-                },
-                {
-                    "in_pkts": {
-                        "path_match": "netflow.in_pkts",
-                        "mapping": {
-                            "type": "long"
-                        }
-                    }
-                },
-                {
-                    "in_src_mac": {
-                        "path_match": "netflow.in_src_mac",
-                        "mapping": {
-                            "type": "keyword",
-                            "norms": false
-                        }
-                    }
-                },
-                {
-                    "ip_protocol_version": {
-                        "path_match": "netflow.ip_protocol_version",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "ipv4_dst_addr": {
-                        "path_match": "netflow.ipv4_dst_addr",
-                        "mapping": {
-                            "type": "ip"
-                        }
-                    }
-                },
-                {
-                    "ipv4_dst_prefix": {
-                        "path_match": "netflow.ipv4_dst_prefix",
-                        "mapping": {
-                            "type": "ip"
-                        }
-                    }
-                },
-                {
-                    "ipv4_ident": {
-                        "path_match": "netflow.ipv4_ident",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "ipv4_next_hop": {
-                        "path_match": "netflow.ipv4_next_hop",
-                        "mapping": {
-                            "type": "ip"
-                        }
-                    }
-                },
-                {
-                    "ipv4_src_addr": {
-                        "path_match": "netflow.ipv4_src_addr",
-                        "mapping": {
-                            "type": "ip"
-                        }
-                    }
-                },
-                {
-                    "ipv4_src_prefix": {
-                        "path_match": "netflow.ipv4_src_prefix",
-                        "mapping": {
-                            "type": "ip"
-                        }
-                    }
-                },
-                {
-                    "ipv6_dst_addr": {
-                        "path_match": "netflow.ipv6_dst_addr",
-                        "mapping": {
-                            "type": "ip"
-                        }
-                    }
-                },
-                {
-                    "ipv6_dst_mask": {
-                        "path_match": "netflow.ipv6_dst_mask",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "ipv6_flow_label": {
-                        "path_match": "netflow.ipv6_flow_label",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "ipv6_next_hop": {
-                        "path_match": "netflow.ipv6_next_hop",
-                        "mapping": {
-                            "type": "ip"
-                        }
-                    }
-                },
-                {
-                    "ipv6_option_headers": {
-                        "path_match": "netflow.ipv6_option_headers",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "ipv6_src_addr": {
-                        "path_match": "netflow.ipv6_src_addr",
-                        "mapping": {
-                            "type": "ip"
-                        }
-                    }
-                },
-                {
-                    "ipv6_src_mask": {
-                        "path_match": "netflow.ipv6_src_mask",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "l4_dst_port": {
-                        "path_match": "netflow.l4_dst_port",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "l4_src_port": {
-                        "path_match": "netflow.l4_src_port",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "max_pkt_length": {
-                        "path_match": "netflow.max_pkt_length",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "max_ttl": {
-                        "path_match": "netflow.max_ttl",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "min_pkt_length": {
-                        "path_match": "netflow.min_pkt_length",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "min_ttl": {
-                        "path_match": "netflow.min_ttl",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "mpls_label_stack_octets.bottom_of_stack": {
-                        "path_match": "netflow.mpls_label_stack_octets.bottom_of_stack",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "mpls_label_stack_octets.experimental": {
-                        "path_match": "netflow.mpls_label_stack_octets.experimental",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "mpls_label_stack_octets.label": {
-                        "path_match": "netflow.mpls_label_stack_octets.label",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "mpls_label_stack_octets.ttl": {
-                        "path_match": "netflow.mpls_label_stack_octets.ttl",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "mpls_top_label_ip_addr": {
-                        "path_match": "netflow.mpls_top_label_ip_addr",
-                        "mapping": {
-                            "type": "ip"
-                        }
-                    }
-                },
-                {
-                    "mpls_top_label_type": {
-                        "path_match": "netflow.mpls_top_label_type",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "mul_dst_bytes": {
-                        "path_match": "netflow.mul_dst_bytes",
-                        "mapping": {
-                            "type": "long"
-                        }
-                    }
-                },
-                {
-                    "mul_dst_pkts": {
-                        "path_match": "netflow.mul_dst_pkts",
-                        "mapping": {
-                            "type": "long"
-                        }
-                    }
-                },
-                {
-                    "mul_igmp_type": {
-                        "path_match": "netflow.mul_igmp_type",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "out_bytes": {
-                        "path_match": "netflow.out_bytes",
-                        "mapping": {
-                            "type": "long"
-                        }
-                    }
-                },
-                {
-                    "out_dst_mac": {
-                        "path_match": "netflow.out_dst_mac",
-                        "mapping": {
-                            "type": "keyword",
-                            "norms": false
-                        }
-                    }
-                },
-                {
-                    "out_pkts": {
-                        "path_match": "netflow.out_pkts",
-                        "mapping": {
-                            "type": "long"
-                        }
-                    }
-                },
-                {
-                    "out_src_mac": {
-                        "path_match": "netflow.out_src_mac",
-                        "mapping": {
-                            "type": "keyword",
-                            "norms": false
-                        }
-                    }
-                },
-                {
-                    "rev_flow_delta_bytes": {
-                        "path_match": "netflow.rev_flow_delta_bytes",
-                        "mapping": {
-                            "type": "long"
-                        }
-                    }
-                },
-                {
-                    "sampler_name": {
-                        "path_match": "netflow.sampler_name",
-                        "mapping": {
-                            "type": "keyword",
-                            "norms": false
-                        }
-                    }
-                },
-                {
-                    "sampling_algorithm": {
-                        "path_match": "netflow.sampling_algorithm",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "src_as": {
-                        "path_match": "netflow.src_as",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "src_mask": {
-                        "path_match": "netflow.src_mask",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "src_tos": {
-                        "path_match": "netflow.src_tos",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "src_vlan": {
-                        "path_match": "netflow.src_vlan",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "tcp_dst_port": {
-                        "path_match": "netflow.tcp_dst_port",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "tcp_src_port": {
-                        "path_match": "netflow.tcp_src_port",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "total_bytes_exp": {
-                        "path_match": "netflow.total_bytes_exp",
-                        "mapping": {
-                            "type": "long"
-                        }
-                    }
-                },
-                {
-                    "total_flows_exp": {
-                        "path_match": "netflow.total_flows_exp",
-                        "mapping": {
-                            "type": "long"
-                        }
-                    }
-                },
-                {
-                    "total_pkts_exp": {
-                        "path_match": "netflow.total_pkts_exp",
-                        "mapping": {
-                            "type": "long"
-                        }
-                    }
-                },
-                {
-                    "udp_dst_port": {
-                        "path_match": "netflow.udp_dst_port",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "udp_src_port": {
-                        "path_match": "netflow.udp_src_port",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "username": {
-                        "path_match": "netflow.username",
-                        "mapping": {
-                            "type": "keyword",
-                            "norms": false
-                        }
-                    }
-                },
-                {
-                    "xlate_dst_addr_ipv4": {
-                        "path_match": "netflow.xlate_dst_addr_ipv4",
-                        "mapping": {
-                            "type": "ip"
-                        }
-                    }
-                },
-                {
-                    "xlate_dst_addr_ipv6": {
-                        "path_match": "netflow.xlate_dst_addr_ipv6",
-                        "mapping": {
-                            "type": "ip"
-                        }
-                    }
-                },
-                {
-                    "xlate_dst_port": {
-                        "path_match": "netflow.xlate_dst_port",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "xlate_src_addr_ipv4": {
-                        "path_match": "netflow.xlate_src_addr_ipv4",
-                        "mapping": {
-                            "type": "ip"
-                        }
-                    }
-                },
-                {
-                    "xlate_src_addr_ipv6": {
-                        "path_match": "netflow.xlate_src_addr_ipv6",
-                        "mapping": {
-                            "type": "ip"
-                        }
-                    }
-                },
-                {
-                    "xlate_src_port": {
-                        "path_match": "netflow.xlate_src_port",
-                        "mapping": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "string_fields": {
-                        "mapping": {
-                            "norms": false,
-                            "type": "keyword"
-                        },
-                        "match_mapping_type": "string",
-                        "match": "*"
+            {
+                "bgp_ipv4_next_hop": {
+                    "path_match": "netflow.bgp_ipv4_next_hop",
+                    "mapping": {
+                        "type": "ip"
                     }
                 }
-            ],
-            "properties": {
-                "@version": {
-                    "type": "keyword"
-                },
-                "@timestamp": {
-                    "type": "date"
-                },
-                "geoip": {
-                    "dynamic": true,
-                    "properties": {
-                        "asn": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "as_org": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "autonomous_system": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "city_name": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "continent_code": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "country_code2": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "country_code3": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "country_name": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "dma_code": {
-                            "type": "integer"
-                        },
-                        "ip": {
-                            "type": "ip"
-                        },
-                        "latitude": {
-                            "type": "float"
-                        },
-                        "location": {
-                            "type": "geo_point"
-                        },
-                        "longitude": {
-                            "type": "float"
-                        },
-                        "postal_code": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "region_code": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "region_name": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "timezone": {
-                            "type": "keyword",
-                            "norms": false
-                        }
-                    }
-                },
-                "geoip_dst": {
-                    "dynamic": true,
-                    "properties": {
-                        "asn": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "as_org": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "autonomous_system": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "city_name": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "continent_code": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "country_code2": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "country_code3": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "country_name": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "dma_code": {
-                            "type": "integer"
-                        },
-                        "ip": {
-                            "type": "ip"
-                        },
-                        "latitude": {
-                            "type": "float"
-                        },
-                        "location": {
-                            "type": "geo_point"
-                        },
-                        "longitude": {
-                            "type": "float"
-                        },
-                        "postal_code": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "region_code": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "region_name": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "timezone": {
-                            "type": "keyword",
-                            "norms": false
-                        }
-                    }
-                },
-                "geoip_src": {
-                    "dynamic": true,
-                    "properties": {
-                        "asn": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "as_org": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "autonomous_system": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "city_name": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "continent_code": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "country_code2": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "country_code3": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "country_name": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "dma_code": {
-                            "type": "integer"
-                        },
-                        "ip": {
-                            "type": "ip"
-                        },
-                        "latitude": {
-                            "type": "float"
-                        },
-                        "location": {
-                            "type": "geo_point"
-                        },
-                        "longitude": {
-                            "type": "float"
-                        },
-                        "postal_code": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "region_code": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "region_name": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "timezone": {
-                            "type": "keyword",
-                            "norms": false
-                        }
-                    }
-                },
-                "netflow": {
-                    "dynamic": true,
-                    "type": "object",
-                    "properties": {
-                        "bytes": {
-                            "type": "long"
-                        },
-                        "direction": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "dst_addr": {
-                            "type": "ip"
-                        },
-                        "dst_mask_len": {
-                            "type": "integer"
-                        },
-                        "dst_port": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "dst_port_name": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "first_switched": {
-                            "type": "date"
-                        },
-                        "flow_seq_num": {
-                            "type": "long"
-                        },
-                        "input_snmp": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "ip_version": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "last_switched": {
-                            "type": "date"
-                        },
-                        "next_hop": {
-                            "type": "ip"
-                        },
-                        "output_snmp": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "packets": {
-                            "type": "long"
-                        },
-                        "protocol": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "protocol_name": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "sampling_interval": {
-                            "type": "integer"
-                        },
-                        "src_addr": {
-                            "type": "ip"
-                        },
-                        "src_mask_len": {
-                            "type": "integer"
-                        },
-                        "src_port": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "src_port_name": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "tcp_flags": {
-                            "type": "integer"
-                        },
-                        "tcp_flags_label": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "tos": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "version": {
-                            "type": "keyword",
-                            "norms": false
-                        },
-                        "vlan": {
-                            "type": "keyword",
-                            "norms": false
-                        }
+            },
+            {
+                "bgp_ipv6_next_hop": {
+                    "path_match": "netflow.bgp_ipv6_next_hop",
+                    "mapping": {
+                        "type": "ip"
                     }
                 }
+            },
+            {
+                "conn_id": {
+                    "path_match": "netflow.conn_id",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "dst_as": {
+                    "path_match": "netflow.dst_as",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "dst_tos": {
+                    "path_match": "netflow.dst_tos",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "dst_vlan": {
+                    "path_match": "netflow.dst_vlan",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "engine_id": {
+                    "path_match": "netflow.engine_id",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "engine_type": {
+                    "path_match": "netflow.engine_type",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "event_time_msec": {
+                    "path_match": "netflow.event_time_msec",
+                    "mapping": {
+                        "type": "long"
+                    }
+                }
+            },
+            {
+                "flow_active_timeout": {
+                    "path_match": "netflow.flow_active_timeout",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "flow_end_reason": {
+                    "path_match": "netflow.flow_end_reason",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "flow_inactive_timeout": {
+                    "path_match": "netflow.flow_inactive_timeout",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "flow_records": {
+                    "path_match": "netflow.flow_records",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "flow_sampler_id": {
+                    "path_match": "netflow.flow_sampler_id",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "flow_sampler_mode": {
+                    "path_match": "netflow.flow_sampler_mode",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "flow_sampler_random_interval": {
+                    "path_match": "netflow.flow_sampler_random_interval",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "flow_start_msec": {
+                    "path_match": "netflow.flow_start_msec",
+                    "mapping": {
+                        "type": "long"
+                    }
+                }
+            },
+            {
+                "flows": {
+                    "path_match": "netflow.flows",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "flowset_id": {
+                    "path_match": "netflow.flowset_id",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "fw_event": {
+                    "path_match": "netflow.fw_event",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "fw_ext_event": {
+                    "path_match": "netflow.fw_ext_event",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "fwd_flow_delta_bytes": {
+                    "path_match": "netflow.fwd_flow_delta_bytes",
+                    "mapping": {
+                        "type": "long"
+                    }
+                }
+            },
+            {
+                "icmp_code": {
+                    "path_match": "netflow.icmp_code",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "icmp_code_ipv6": {
+                    "path_match": "netflow.icmp_code_ipv6",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "icmp_type": {
+                    "path_match": "netflow.icmp_type",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "icmp_type_ipv6": {
+                    "path_match": "netflow.icmp_type_ipv6",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "if_desc": {
+                    "path_match": "netflow.if_desc",
+                    "mapping": {
+                        "type": "keyword",
+                        "norms": false
+                    }
+                }
+            },
+            {
+                "if_name": {
+                    "path_match": "netflow.if_name",
+                    "mapping": {
+                        "type": "keyword",
+                        "norms": false
+                    }
+                }
+            },
+            {
+                "in_bytes": {
+                    "path_match": "netflow.in_bytes",
+                    "mapping": {
+                        "type": "long"
+                    }
+                }
+            },
+            {
+                "in_dst_mac": {
+                    "path_match": "netflow.in_dst_mac",
+                    "mapping": {
+                        "type": "keyword",
+                        "norms": false
+                    }
+                }
+            },
+            {
+                "in_permanent_bytes": {
+                    "path_match": "netflow.in_permanent_bytes",
+                    "mapping": {
+                        "type": "long"
+                    }
+                }
+            },
+            {
+                "in_permanent_pkts": {
+                    "path_match": "netflow.in_permanent_pkts",
+                    "mapping": {
+                        "type": "long"
+                    }
+                }
+            },
+            {
+                "in_pkts": {
+                    "path_match": "netflow.in_pkts",
+                    "mapping": {
+                        "type": "long"
+                    }
+                }
+            },
+            {
+                "in_src_mac": {
+                    "path_match": "netflow.in_src_mac",
+                    "mapping": {
+                        "type": "keyword",
+                        "norms": false
+                    }
+                }
+            },
+            {
+                "ip_protocol_version": {
+                    "path_match": "netflow.ip_protocol_version",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "ipv4_dst_addr": {
+                    "path_match": "netflow.ipv4_dst_addr",
+                    "mapping": {
+                        "type": "ip"
+                    }
+                }
+            },
+            {
+                "ipv4_dst_prefix": {
+                    "path_match": "netflow.ipv4_dst_prefix",
+                    "mapping": {
+                        "type": "ip"
+                    }
+                }
+            },
+            {
+                "ipv4_ident": {
+                    "path_match": "netflow.ipv4_ident",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "ipv4_next_hop": {
+                    "path_match": "netflow.ipv4_next_hop",
+                    "mapping": {
+                        "type": "ip"
+                    }
+                }
+            },
+            {
+                "ipv4_src_addr": {
+                    "path_match": "netflow.ipv4_src_addr",
+                    "mapping": {
+                        "type": "ip"
+                    }
+                }
+            },
+            {
+                "ipv4_src_prefix": {
+                    "path_match": "netflow.ipv4_src_prefix",
+                    "mapping": {
+                        "type": "ip"
+                    }
+                }
+            },
+            {
+                "ipv6_dst_addr": {
+                    "path_match": "netflow.ipv6_dst_addr",
+                    "mapping": {
+                        "type": "ip"
+                    }
+                }
+            },
+            {
+                "ipv6_dst_mask": {
+                    "path_match": "netflow.ipv6_dst_mask",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "ipv6_flow_label": {
+                    "path_match": "netflow.ipv6_flow_label",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "ipv6_next_hop": {
+                    "path_match": "netflow.ipv6_next_hop",
+                    "mapping": {
+                        "type": "ip"
+                    }
+                }
+            },
+            {
+                "ipv6_option_headers": {
+                    "path_match": "netflow.ipv6_option_headers",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "ipv6_src_addr": {
+                    "path_match": "netflow.ipv6_src_addr",
+                    "mapping": {
+                        "type": "ip"
+                    }
+                }
+            },
+            {
+                "ipv6_src_mask": {
+                    "path_match": "netflow.ipv6_src_mask",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "l4_dst_port": {
+                    "path_match": "netflow.l4_dst_port",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "l4_src_port": {
+                    "path_match": "netflow.l4_src_port",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "max_pkt_length": {
+                    "path_match": "netflow.max_pkt_length",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "max_ttl": {
+                    "path_match": "netflow.max_ttl",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "min_pkt_length": {
+                    "path_match": "netflow.min_pkt_length",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "min_ttl": {
+                    "path_match": "netflow.min_ttl",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "mpls_label_stack_octets.bottom_of_stack": {
+                    "path_match": "netflow.mpls_label_stack_octets.bottom_of_stack",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "mpls_label_stack_octets.experimental": {
+                    "path_match": "netflow.mpls_label_stack_octets.experimental",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "mpls_label_stack_octets.label": {
+                    "path_match": "netflow.mpls_label_stack_octets.label",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "mpls_label_stack_octets.ttl": {
+                    "path_match": "netflow.mpls_label_stack_octets.ttl",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "mpls_top_label_ip_addr": {
+                    "path_match": "netflow.mpls_top_label_ip_addr",
+                    "mapping": {
+                        "type": "ip"
+                    }
+                }
+            },
+            {
+                "mpls_top_label_type": {
+                    "path_match": "netflow.mpls_top_label_type",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "mul_dst_bytes": {
+                    "path_match": "netflow.mul_dst_bytes",
+                    "mapping": {
+                        "type": "long"
+                    }
+                }
+            },
+            {
+                "mul_dst_pkts": {
+                    "path_match": "netflow.mul_dst_pkts",
+                    "mapping": {
+                        "type": "long"
+                    }
+                }
+            },
+            {
+                "mul_igmp_type": {
+                    "path_match": "netflow.mul_igmp_type",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "out_bytes": {
+                    "path_match": "netflow.out_bytes",
+                    "mapping": {
+                        "type": "long"
+                    }
+                }
+            },
+            {
+                "out_dst_mac": {
+                    "path_match": "netflow.out_dst_mac",
+                    "mapping": {
+                        "type": "keyword",
+                        "norms": false
+                    }
+                }
+            },
+            {
+                "out_pkts": {
+                    "path_match": "netflow.out_pkts",
+                    "mapping": {
+                        "type": "long"
+                    }
+                }
+            },
+            {
+                "out_src_mac": {
+                    "path_match": "netflow.out_src_mac",
+                    "mapping": {
+                        "type": "keyword",
+                        "norms": false
+                    }
+                }
+            },
+            {
+                "rev_flow_delta_bytes": {
+                    "path_match": "netflow.rev_flow_delta_bytes",
+                    "mapping": {
+                        "type": "long"
+                    }
+                }
+            },
+            {
+                "sampler_name": {
+                    "path_match": "netflow.sampler_name",
+                    "mapping": {
+                        "type": "keyword",
+                        "norms": false
+                    }
+                }
+            },
+            {
+                "sampling_algorithm": {
+                    "path_match": "netflow.sampling_algorithm",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "src_as": {
+                    "path_match": "netflow.src_as",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "src_mask": {
+                    "path_match": "netflow.src_mask",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "src_tos": {
+                    "path_match": "netflow.src_tos",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "src_vlan": {
+                    "path_match": "netflow.src_vlan",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "tcp_dst_port": {
+                    "path_match": "netflow.tcp_dst_port",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "tcp_src_port": {
+                    "path_match": "netflow.tcp_src_port",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "total_bytes_exp": {
+                    "path_match": "netflow.total_bytes_exp",
+                    "mapping": {
+                        "type": "long"
+                    }
+                }
+            },
+            {
+                "total_flows_exp": {
+                    "path_match": "netflow.total_flows_exp",
+                    "mapping": {
+                        "type": "long"
+                    }
+                }
+            },
+            {
+                "total_pkts_exp": {
+                    "path_match": "netflow.total_pkts_exp",
+                    "mapping": {
+                        "type": "long"
+                    }
+                }
+            },
+            {
+                "udp_dst_port": {
+                    "path_match": "netflow.udp_dst_port",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "udp_src_port": {
+                    "path_match": "netflow.udp_src_port",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "username": {
+                    "path_match": "netflow.username",
+                    "mapping": {
+                        "type": "keyword",
+                        "norms": false
+                    }
+                }
+            },
+            {
+                "xlate_dst_addr_ipv4": {
+                    "path_match": "netflow.xlate_dst_addr_ipv4",
+                    "mapping": {
+                        "type": "ip"
+                    }
+                }
+            },
+            {
+                "xlate_dst_addr_ipv6": {
+                    "path_match": "netflow.xlate_dst_addr_ipv6",
+                    "mapping": {
+                        "type": "ip"
+                    }
+                }
+            },
+            {
+                "xlate_dst_port": {
+                    "path_match": "netflow.xlate_dst_port",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "xlate_src_addr_ipv4": {
+                    "path_match": "netflow.xlate_src_addr_ipv4",
+                    "mapping": {
+                        "type": "ip"
+                    }
+                }
+            },
+            {
+                "xlate_src_addr_ipv6": {
+                    "path_match": "netflow.xlate_src_addr_ipv6",
+                    "mapping": {
+                        "type": "ip"
+                    }
+                }
+            },
+            {
+                "xlate_src_port": {
+                    "path_match": "netflow.xlate_src_port",
+                    "mapping": {
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "string_fields": {
+                    "mapping": {
+                        "norms": false,
+                        "type": "keyword"
+                    },
+                    "match_mapping_type": "string",
+                    "match": "*"
+                }
+            }
+        ],
+        "properties": {
+            "@version": {
+                "type": "keyword"
+            },
+            "@timestamp": {
+                "type": "date"
+            },
+            "geoip": {
+                "dynamic": true,
+                "properties": {
+                    "asn": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "as_org": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "autonomous_system": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "city_name": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "continent_code": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "country_code2": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "country_code3": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "country_name": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "dma_code": {
+                        "type": "integer"
+                    },
+                    "ip": {
+                        "type": "ip"
+                    },
+                    "latitude": {
+                        "type": "float"
+                    },
+                    "location": {
+                        "type": "geo_point"
+                    },
+                    "longitude": {
+                        "type": "float"
+                    },
+                    "postal_code": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "region_code": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "region_name": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "timezone": {
+                        "type": "keyword",
+                        "norms": false
+                    }
+                }
+            },
+            "geoip_dst": {
+                "dynamic": true,
+                "properties": {
+                    "asn": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "as_org": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "autonomous_system": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "city_name": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "continent_code": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "country_code2": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "country_code3": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "country_name": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "dma_code": {
+                        "type": "integer"
+                    },
+                    "ip": {
+                        "type": "ip"
+                    },
+                    "latitude": {
+                        "type": "float"
+                    },
+                    "location": {
+                        "type": "geo_point"
+                    },
+                    "longitude": {
+                        "type": "float"
+                    },
+                    "postal_code": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "region_code": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "region_name": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "timezone": {
+                        "type": "keyword",
+                        "norms": false
+                    }
+                }
+            },
+            "geoip_src": {
+                "dynamic": true,
+                "properties": {
+                    "asn": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "as_org": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "autonomous_system": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "city_name": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "continent_code": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "country_code2": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "country_code3": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "country_name": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "dma_code": {
+                        "type": "integer"
+                    },
+                    "ip": {
+                        "type": "ip"
+                    },
+                    "latitude": {
+                        "type": "float"
+                    },
+                    "location": {
+                        "type": "geo_point"
+                    },
+                    "longitude": {
+                        "type": "float"
+                    },
+                    "postal_code": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "region_code": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "region_name": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "timezone": {
+                        "type": "keyword",
+                        "norms": false
+                    }
+                }
+            },
+            "netflow": {
+                "dynamic": true,
+                "type": "object",
+                "properties": {
+                    "bytes": {
+                        "type": "long"
+                    },
+                    "direction": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "dst_addr": {
+                        "type": "ip"
+                    },
+                    "dst_mask_len": {
+                        "type": "integer"
+                    },
+                    "dst_port": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "dst_port_name": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "first_switched": {
+                        "type": "date"
+                    },
+                    "flow_seq_num": {
+                        "type": "long"
+                    },
+                    "input_snmp": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "ip_version": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "last_switched": {
+                        "type": "date"
+                    },
+                    "next_hop": {
+                        "type": "ip"
+                    },
+                    "output_snmp": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "packets": {
+                        "type": "long"
+                    },
+                    "protocol": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "protocol_name": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "sampling_interval": {
+                        "type": "integer"
+                    },
+                    "src_addr": {
+                        "type": "ip"
+                    },
+                    "src_mask_len": {
+                        "type": "integer"
+                    },
+                    "src_port": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "src_port_name": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "tcp_flags": {
+                        "type": "integer"
+                    },
+                    "tcp_flags_label": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "tos": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "version": {
+                        "type": "keyword",
+                        "norms": false
+                    },
+                    "vlan": {
+                        "type": "keyword",
+                        "norms": false
+                    }
+                }
+            }
         }
     },
     "aliases": { }

--- a/modules/netflow/configuration/elasticsearch/netflow.json
+++ b/modules/netflow/configuration/elasticsearch/netflow.json
@@ -1,8 +1,7 @@
 {
     "order": 0,
-    "template": "netflow-*",
+    "index_patterns": "netflow-*",
     "mappings": {
-        "_default_": {
             "_meta": {
                 "version": "7.0.0"
             },
@@ -1047,7 +1046,6 @@
                         }
                     }
                 }
-            }
         }
     },
     "aliases": { }

--- a/x-pack/modules/arcsight/configuration/elasticsearch/arcsight.json
+++ b/x-pack/modules/arcsight/configuration/elasticsearch/arcsight.json
@@ -2,219 +2,219 @@
   "order": 0,
   "index_patterns": "arcsight-*",
   "mappings": {
-      "_meta": {
-        "version": "7.0.0"
-      },
-      "dynamic": true,
-      "dynamic_templates": [
-        {
-          "string_fields": {
-            "mapping": {
-              "type": "keyword"
-            },
-            "match_mapping_type": "string",
-            "match": "*"
-          }
-        }
-      ],
-      "properties": {
-        "destinationPort": {
-          "type": "integer"
-        },
-        "flexDate1": {
-          "format": "epoch_millis||epoch_second||date_time||MMM dd YYYY HH:mm:ss z||MMM dd yyyy HH:mm:ss",
-          "type": "date"
-        },
-        "sourcePort": {
-          "type": "integer"
-        },
-        "baseEventCount": {
-          "type": "integer"
-        },
-        "destinationAddress": {
-          "type": "ip"
-        },
-        "destinationProcessId": {
-          "type": "integer"
-        },
-        "oldFileSize": {
-          "type": "integer"
-        },
-        "destination": {
-          "dynamic": false,
-          "type": "object",
-          "properties": {
-            "city_name": {
-              "type": "keyword"
-            },
-            "country_name": {
-              "type": "keyword"
-            },
-            "country_code2": {
-                "type": "keyword"
-              },
-            "location": {
-              "type": "geo_point"
-            },
-            "region_name": {
-              "type": "keyword"
-            }
-          }
-        },
-        "source": {
-          "dynamic": false,
-          "type": "object",
-          "properties": {
-            "city_name": {
-              "type": "keyword"
-            },
-            "country_name": {
-              "type": "keyword"
-            },
-            "country_code2": {
-                "type": "keyword"
-              },
-            "location": {
-              "type": "geo_point"
-            },
-            "region_name": {
-              "type": "keyword"
-            }
-          }
-        },
-        "deviceReceiptTime": {
-          "format": "epoch_millis||epoch_second||date_time||MMM dd YYYY HH:mm:ss z||MMM dd yyyy HH:mm:ss",
-          "type": "date"
-        },
-        "destinationTranslatedPort": {
-          "type": "integer"
-        },
-        "deviceTranslatedAddress": {
-          "type": "ip"
-        },
-        "deviceAddress": {
-          "type": "ip"
-        },
-        "agentReceiptTime": {
-          "format": "epoch_millis||epoch_second||date_time||MMM dd YYYY HH:mm:ss z||MMM dd yyyy HH:mm:ss",
-          "type": "date"
-        },
-        "startTime": {
-          "format": "epoch_millis||epoch_second||date_time||MMM dd YYYY HH:mm:ss z||MMM dd yyyy HH:mm:ss",
-          "type": "date"
-        },
-        "sourceProcessId": {
-          "type": "integer"
-        },
-        "bytesIn": {
-          "type": "integer"
-        },
-        "bytesOut": {
-          "type": "integer"
-        },
-        "severity": {
-          "type": "keyword"
-        },
-        "deviceProcessId": {
-          "type": "integer"
-        },
-        "agentAddress": {
-          "type": "ip"
-        },
-        "sourceAddress": {
-          "type": "ip"
-        },
-        "sourceTranslatedPort": {
-          "type": "integer"
-        },
-        "deviceCustomDate2": {
-          "format": "epoch_millis||epoch_second||date_time||MMM dd YYYY HH:mm:ss z||MMM dd yyyy HH:mm:ss",
-          "type": "date"
-        },
-        "deviceCustomDate1": {
-          "format": "epoch_millis||epoch_second||date_time||MMM dd YYYY HH:mm:ss z||MMM dd yyyy HH:mm:ss",
-          "type": "date"
-        },
-        "flexNumber1": {
-          "type": "long"
-        },
-        "deviceCustomFloatingPoint1": {
-          "type": "float"
-        },
-        "oldFileModificationTime": {
-          "format": "epoch_millis||epoch_second||date_time||MMM dd YYYY HH:mm:ss z||MMM dd yyyy HH:mm:ss",
-          "type": "date"
-        },
-        "deviceCustomFloatingPoint2": {
-          "type": "float"
-        },
-        "oldFileCreateTime": {
-          "format": "epoch_millis||epoch_second||date_time||MMM dd YYYY HH:mm:ss z||MMM dd yyyy HH:mm:ss",
-          "type": "date"
-        },
-        "deviceCustomFloatingPoint3": {
-          "type": "float"
-        },
-        "sourceTranslatedAddress": {
-          "type": "ip"
-        },
-        "deviceCustomFloatingPoint4": {
-          "type": "float"
-        },
-        "flexNumber2": {
-          "type": "long"
-        },
-        "fileCreateTime": {
-          "format": "epoch_millis||epoch_second||date_time||MMM dd YYYY HH:mm:ss z||MMM dd yyyy HH:mm:ss",
-          "type": "date"
-        },
-        "fileModificationTime": {
-          "format": "epoch_millis||epoch_second||date_time||MMM dd YYYY HH:mm:ss z||MMM dd yyyy HH:mm:ss",
-          "type": "date"
-        },
-        "fileSize": {
-          "type": "integer"
-        },
-        "destinationTranslatedAddress": {
-          "type": "ip"
-        },
-        "endTime": {
-          "format": "epoch_millis||epoch_second||date_time||MMM dd YYYY HH:mm:ss z||MMM dd yyyy HH:mm:ss",
-          "type": "date"
-        },
-        "deviceCustomNumber1": {
-          "type": "long"
-        },
-        "deviceDirection": {
-          "type": "integer"
-        },
-        "device": {
-          "dynamic": false,
-          "type": "object",
-          "properties": {
-            "city_name": {
-              "type": "keyword"
-            },
-            "country_name": {
-              "type": "keyword"
-            },
-            "country_code2": {
-                "type": "keyword"
-              },
-            "location": {
-              "type": "geo_point"
-            },
-            "region_name": {
-              "type": "keyword"
-            }
-          }
-        },
-        "deviceCustomNumber3": {
-          "type": "long"
-        },
-        "deviceCustomNumber2": {
-          "type": "long"
+    "_meta": {
+      "version": "7.0.0"
+    },
+    "dynamic": true,
+    "dynamic_templates": [
+      {
+        "string_fields": {
+          "mapping": {
+            "type": "keyword"
+          },
+          "match_mapping_type": "string",
+          "match": "*"
         }
       }
+    ],
+    "properties": {
+      "destinationPort": {
+        "type": "integer"
+      },
+      "flexDate1": {
+        "format": "epoch_millis||epoch_second||date_time||MMM dd YYYY HH:mm:ss z||MMM dd yyyy HH:mm:ss",
+        "type": "date"
+      },
+      "sourcePort": {
+        "type": "integer"
+      },
+      "baseEventCount": {
+        "type": "integer"
+      },
+      "destinationAddress": {
+        "type": "ip"
+      },
+      "destinationProcessId": {
+        "type": "integer"
+      },
+      "oldFileSize": {
+        "type": "integer"
+      },
+      "destination": {
+        "dynamic": false,
+        "type": "object",
+        "properties": {
+          "city_name": {
+            "type": "keyword"
+          },
+          "country_name": {
+            "type": "keyword"
+          },
+          "country_code2": {
+              "type": "keyword"
+            },
+          "location": {
+            "type": "geo_point"
+          },
+          "region_name": {
+            "type": "keyword"
+          }
+        }
+      },
+      "source": {
+        "dynamic": false,
+        "type": "object",
+        "properties": {
+          "city_name": {
+            "type": "keyword"
+          },
+          "country_name": {
+            "type": "keyword"
+          },
+          "country_code2": {
+              "type": "keyword"
+            },
+          "location": {
+            "type": "geo_point"
+          },
+          "region_name": {
+            "type": "keyword"
+          }
+        }
+      },
+      "deviceReceiptTime": {
+        "format": "epoch_millis||epoch_second||date_time||MMM dd YYYY HH:mm:ss z||MMM dd yyyy HH:mm:ss",
+        "type": "date"
+      },
+      "destinationTranslatedPort": {
+        "type": "integer"
+      },
+      "deviceTranslatedAddress": {
+        "type": "ip"
+      },
+      "deviceAddress": {
+        "type": "ip"
+      },
+      "agentReceiptTime": {
+        "format": "epoch_millis||epoch_second||date_time||MMM dd YYYY HH:mm:ss z||MMM dd yyyy HH:mm:ss",
+        "type": "date"
+      },
+      "startTime": {
+        "format": "epoch_millis||epoch_second||date_time||MMM dd YYYY HH:mm:ss z||MMM dd yyyy HH:mm:ss",
+        "type": "date"
+      },
+      "sourceProcessId": {
+        "type": "integer"
+      },
+      "bytesIn": {
+        "type": "integer"
+      },
+      "bytesOut": {
+        "type": "integer"
+      },
+      "severity": {
+        "type": "keyword"
+      },
+      "deviceProcessId": {
+        "type": "integer"
+      },
+      "agentAddress": {
+        "type": "ip"
+      },
+      "sourceAddress": {
+        "type": "ip"
+      },
+      "sourceTranslatedPort": {
+        "type": "integer"
+      },
+      "deviceCustomDate2": {
+        "format": "epoch_millis||epoch_second||date_time||MMM dd YYYY HH:mm:ss z||MMM dd yyyy HH:mm:ss",
+        "type": "date"
+      },
+      "deviceCustomDate1": {
+        "format": "epoch_millis||epoch_second||date_time||MMM dd YYYY HH:mm:ss z||MMM dd yyyy HH:mm:ss",
+        "type": "date"
+      },
+      "flexNumber1": {
+        "type": "long"
+      },
+      "deviceCustomFloatingPoint1": {
+        "type": "float"
+      },
+      "oldFileModificationTime": {
+        "format": "epoch_millis||epoch_second||date_time||MMM dd YYYY HH:mm:ss z||MMM dd yyyy HH:mm:ss",
+        "type": "date"
+      },
+      "deviceCustomFloatingPoint2": {
+        "type": "float"
+      },
+      "oldFileCreateTime": {
+        "format": "epoch_millis||epoch_second||date_time||MMM dd YYYY HH:mm:ss z||MMM dd yyyy HH:mm:ss",
+        "type": "date"
+      },
+      "deviceCustomFloatingPoint3": {
+        "type": "float"
+      },
+      "sourceTranslatedAddress": {
+        "type": "ip"
+      },
+      "deviceCustomFloatingPoint4": {
+        "type": "float"
+      },
+      "flexNumber2": {
+        "type": "long"
+      },
+      "fileCreateTime": {
+        "format": "epoch_millis||epoch_second||date_time||MMM dd YYYY HH:mm:ss z||MMM dd yyyy HH:mm:ss",
+        "type": "date"
+      },
+      "fileModificationTime": {
+        "format": "epoch_millis||epoch_second||date_time||MMM dd YYYY HH:mm:ss z||MMM dd yyyy HH:mm:ss",
+        "type": "date"
+      },
+      "fileSize": {
+        "type": "integer"
+      },
+      "destinationTranslatedAddress": {
+        "type": "ip"
+      },
+      "endTime": {
+        "format": "epoch_millis||epoch_second||date_time||MMM dd YYYY HH:mm:ss z||MMM dd yyyy HH:mm:ss",
+        "type": "date"
+      },
+      "deviceCustomNumber1": {
+        "type": "long"
+      },
+      "deviceDirection": {
+        "type": "integer"
+      },
+      "device": {
+        "dynamic": false,
+        "type": "object",
+        "properties": {
+          "city_name": {
+            "type": "keyword"
+          },
+          "country_name": {
+            "type": "keyword"
+          },
+          "country_code2": {
+              "type": "keyword"
+            },
+          "location": {
+            "type": "geo_point"
+          },
+          "region_name": {
+            "type": "keyword"
+          }
+        }
+      },
+      "deviceCustomNumber3": {
+        "type": "long"
+      },
+      "deviceCustomNumber2": {
+        "type": "long"
+      }
+    }
   }
 }

--- a/x-pack/modules/arcsight/configuration/elasticsearch/arcsight.json
+++ b/x-pack/modules/arcsight/configuration/elasticsearch/arcsight.json
@@ -1,8 +1,7 @@
 {
   "order": 0,
-  "template": "arcsight-*",
+  "index_patterns": "arcsight-*",
   "mappings": {
-    "_default_": {
       "_meta": {
         "version": "7.0.0"
       },
@@ -217,6 +216,5 @@
           "type": "long"
         }
       }
-    }
   }
 }

--- a/x-pack/modules/azure/configuration/elasticsearch/azure.json
+++ b/x-pack/modules/azure/configuration/elasticsearch/azure.json
@@ -6,7 +6,6 @@
     "number_of_shards": 1
   },
   "mappings" : {
-    "_doc" : {
       "dynamic_templates" : [ {
         "message_field" : {
           "path_match" : "message",
@@ -41,6 +40,5 @@
           }
         }
       }
-    }
   }
 }

--- a/x-pack/modules/azure/configuration/elasticsearch/azure.json
+++ b/x-pack/modules/azure/configuration/elasticsearch/azure.json
@@ -6,39 +6,39 @@
     "number_of_shards": 1
   },
   "mappings" : {
-      "dynamic_templates" : [ {
-        "message_field" : {
-          "path_match" : "message",
-          "match_mapping_type" : "string",
-          "mapping" : {
-            "type" : "text",
-            "norms" : false
-          }
+    "dynamic_templates" : [ {
+      "message_field" : {
+        "path_match" : "message",
+        "match_mapping_type" : "string",
+        "mapping" : {
+          "type" : "text",
+          "norms" : false
         }
-      }, {
-        "string_fields" : {
-          "match" : "*",
-          "match_mapping_type" : "string",
-          "mapping" : {
-            "type" : "text", "norms" : false,
-            "fields" : {
-              "keyword" : { "type": "keyword", "ignore_above": 256 }
-            }
-          }
-        }
-      } ],
-      "properties" : {
-        "@timestamp": { "type": "date"},
-        "@version": { "type": "keyword"},
-        "geoip"  : {
-          "dynamic": true,
-          "properties" : {
-            "ip": { "type": "ip" },
-            "location" : { "type" : "geo_point" },
-            "latitude" : { "type" : "half_float" },
-            "longitude" : { "type" : "half_float" }
+      }
+    }, {
+      "string_fields" : {
+        "match" : "*",
+        "match_mapping_type" : "string",
+        "mapping" : {
+          "type" : "text", "norms" : false,
+          "fields" : {
+            "keyword" : { "type": "keyword", "ignore_above": 256 }
           }
         }
       }
+    } ],
+    "properties" : {
+      "@timestamp": { "type": "date"},
+      "@version": { "type": "keyword"},
+      "geoip"  : {
+        "dynamic": true,
+        "properties" : {
+          "ip": { "type": "ip" },
+          "location" : { "type" : "geo_point" },
+          "latitude" : { "type" : "half_float" },
+          "longitude" : { "type" : "half_float" }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This commit updates the Elasticsearch index templates to be compatible with 7.x
* removes types
* remove _all
* template -> index_patterns

----

In order for index templates to work with 7.x either the types need to be removed, or an extra parameter (include_type_name=true) needs to be set. This change also includes the removal of _all from a template (that is no longer supported in 7.x) and updates template -> index_patterns (fixes a deprecation warning)