### PR TITLE
tests: support more-precise clocks in Java 11

### DIFF
--- a/logstash-core/src/test/java/org/logstash/TimestampTest.java
+++ b/logstash-core/src/test/java/org/logstash/TimestampTest.java
@@ -49,7 +49,9 @@ public class TimestampTest {
         Instant i = Instant.now();
         Timestamp t1 = new Timestamp(i.toEpochMilli());
         long usec = t1.usec();
-        Assert.assertEquals(i.getNano() / 1000, usec);
+
+        // since our Timestamp was created with epoch millis, it cannot be more precise.
+        Assert.assertEquals(i.getNano() / 1_000_000, usec / 1_000);
     }
 
     @Test


### PR DESCRIPTION
targets: `master`, `6.x` (same targets as Java Plugin API that introduced these tests).

In Java 8, `java.lang.Instant#now()` used the system clock, which only had millisecond-level precision, but [starting with Java 9](https://bugs.openjdk.java.net/browse/JDK-8068730), the system clock is much more precise.

Since we create our `org.logstash.Timestamp` with `long epoch_milliseconds`, it cannot represent a time more precisely than milliseconds.

Ensure that the output of `Timestamp#usec` is rounded before comparing it with milliseconds, in order to avoid asserting greater precision than we can create.