### PR TITLE
QA: prevent webmock from intercepting http calls to localhost

### DIFF
--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -22,6 +22,8 @@ describe LogStash::Runner do
   before :each do
     clear_data_dir
 
+    WebMock.disable_net_connect!(allow_localhost: true)
+
     allow(LogStash::Runner).to receive(:logger).and_return(logger)
     allow(logger).to receive(:debug?).and_return(true)
     allow(logger).to receive(:subscribe).with(any_args)


### PR DESCRIPTION
Fixes a scenario where one or more specs that attempt to connect to an unmocked kibana on localhost, _AFTER_ a spec or spec group has been run that configures Webmock to intercept all connections, fails because the request has not been mocked.

Resolves #10274 

This is a cherry-pick of a commit that has already landed in `master` and `6.x`. Merge target is `6.6`.

