### PR TITLE
bump fpm dependency

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -14,7 +14,7 @@ gem "logstash-devutils", "= 1.3.5", :group => :development
 gem "benchmark-ips", :group => :development
 gem "octokit", "3.8.0", :group => :build
 gem "stud", "~> 0.0.22", :group => :build
-gem "fpm", "~> 1.3.3", :group => :build
+gem "fpm", "~> 1.11", :group => :build
 gem "rubyzip", "~> 1.2.1", :group => :build
 gem "gems", "~> 0.8.3", :group => :build
 gem "rack-test", :require => "rack/test", :group => :development

--- a/Gemfile.template
+++ b/Gemfile.template
@@ -14,7 +14,8 @@ gem "logstash-devutils", "= 1.3.5", :group => :development
 gem "benchmark-ips", :group => :development
 gem "octokit", "3.8.0", :group => :build
 gem "stud", "~> 0.0.22", :group => :build
-gem "fpm", "~> 1.11", :group => :build
+gem "fpm", "~> 1", :group => :build
+gem "childprocess", "~> 0.9", :group => :build
 gem "rubyzip", "~> 1.2.1", :group => :build
 gem "gems", "~> 0.8.3", :group => :build
 gem "rack-test", :require => "rack/test", :group => :development


### PR DESCRIPTION
this prevents childprocess 1.x to be installed as it contains native
extensions which we don't need and create troubles in CI