### PR TITLE
 support old config options and add deprecation warnings

### DIFF
--- a/x-pack/lib/config_management/extension.rb
+++ b/x-pack/lib/config_management/extension.rb
@@ -26,8 +26,15 @@ module LogStash
         settings.register(LogStash::Setting::ArrayCoercible.new("xpack.management.pipeline.id", String, ["main"]))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.username", "logstash_system"))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.password"))
+
+        # .url changed to .hosts in 7.0. In 6.7+ .url is still accepted but with a deprecation warning in Runner
+        settings.register(LogStash::Setting::ArrayCoercible.new("xpack.management.elasticsearch.url", String, [ "https://localhost:9200" ] ))
         settings.register(LogStash::Setting::ArrayCoercible.new("xpack.management.elasticsearch.hosts", String, [ "https://localhost:9200" ] ))
+
+        # .ca changed to .certificate_authority in 7.0. In 6.7+ .ca is still accepted but with a deprecation warning in Runner
+        settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.ssl.ca"))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.ssl.certificate_authority"))
+
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.ssl.truststore.path"))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.ssl.truststore.password"))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.ssl.keystore.path"))

--- a/x-pack/lib/monitoring/monitoring.rb
+++ b/x-pack/lib/monitoring/monitoring.rb
@@ -169,12 +169,20 @@ module LogStash
       logger.trace("registering additionals_settings")
 
       settings.register(LogStash::Setting::Boolean.new("xpack.monitoring.enabled", false))
+
+      # .url changed to .hosts in 7.0. In 6.7+ .url is still accepted but with a deprecation warning in Runner
       settings.register(LogStash::Setting::ArrayCoercible.new("xpack.monitoring.elasticsearch.hosts", String, [ "http://localhost:9200" ] ))
+      settings.register(LogStash::Setting::ArrayCoercible.new("xpack.monitoring.elasticsearch.url", String, [ "http://localhost:9200" ] ))
+
       settings.register(LogStash::Setting::TimeValue.new("xpack.monitoring.collection.interval", "10s"))
       settings.register(LogStash::Setting::TimeValue.new("xpack.monitoring.collection.timeout_interval", "10m"))
       settings.register(LogStash::Setting::NullableString.new("xpack.monitoring.elasticsearch.username", "logstash_system"))
       settings.register(LogStash::Setting::NullableString.new("xpack.monitoring.elasticsearch.password"))
+
+      # .ca changed to .certificate_authority in 7.0. In 6.7+ .ca is still accepted but with a deprecation warning in Runner
       settings.register(LogStash::Setting::NullableString.new("xpack.monitoring.elasticsearch.ssl.certificate_authority"))
+      settings.register(LogStash::Setting::NullableString.new("xpack.monitoring.elasticsearch.ssl.ca"))
+
       settings.register(LogStash::Setting::NullableString.new("xpack.monitoring.elasticsearch.ssl.truststore.path"))
       settings.register(LogStash::Setting::NullableString.new("xpack.monitoring.elasticsearch.ssl.truststore.password"))
       settings.register(LogStash::Setting::NullableString.new("xpack.monitoring.elasticsearch.ssl.keystore.path"))


### PR DESCRIPTION
This PR adds on top of #10380/#10391 to support the older config names and add deprecation warning.  