### PR TITLE
keystore: instances of `CharsetEncoder` are stateful and cannot be shared

### DIFF
--- a/logstash-core/src/main/java/org/logstash/secret/store/backend/JavaKeyStore.java
+++ b/logstash-core/src/main/java/org/logstash/secret/store/backend/JavaKeyStore.java
@@ -41,7 +41,7 @@ public final class JavaKeyStore implements SecretStore {
     private static final String KEYSTORE_TYPE = "pkcs12";
     private static final Logger LOGGER = LogManager.getLogger(JavaKeyStore.class);
     private static final String PATH_KEY = "keystore.file";
-    private static final CharsetEncoder asciiEncoder = StandardCharsets.US_ASCII.newEncoder();
+    private final CharsetEncoder asciiEncoder = StandardCharsets.US_ASCII.newEncoder();
     private KeyStore keyStore;
     private char[] keyStorePass;
     private Path keyStorePath;


### PR DESCRIPTION
Fixes a crash that occurs on pipeline load and/or reload when using both the
java keystore and the multi-pipeline feature, when more than one pipeline
references `${}`-style variables.

> ~~~
> [2019-02-06T21:31:36,342][ERROR][logstash.agent           ] Failed to execute action {:action=>LogStash::PipelineAction::Create/pipeline_id:zero, :exception=>"Java::OrgLogstashSecretStore::SecretStoreException::UnknownException", :message=>"Error while trying to load the Logstash keystore", :backtrace=>["org.logstash.secret.store.backend.JavaKeyStore.load(org/logstash/secret/store/backend/JavaKeyStore.java:280)", "org.logstash.secret.store.backend.JavaKeyStore.load(org/logstash/secret/store/backend/JavaKeyStore.java:40)", "org.logstash.secret.store.SecretStoreFactory.doIt(org/logstash/secret/store/SecretStoreFactory.java:107)", "org.logstash.secret.store.SecretStoreFactory.load(org/logstash/secret/store/SecretStoreFactory.java:93)", "org.logstash.secret.store.SecretStoreExt.getIfExists(org/logstash/secret/store/SecretStoreExt.java:37)", "java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)", "org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:423)", "org.jruby.javasupport.JavaMethod.invokeStaticDirect(org/jruby/javasupport/JavaMethod.java:355)", "Users.yaauie.src.elastic.logstash.logstash_minus_core.lib.logstash.util.substitution_variables.block in replace_placeholders(/Users/yaauie/src/elastic/logstash/logstash-core/lib/logstash/util/substitution_variables.rb:45)", "org.jruby.RubyString.gsubCommon19(org/jruby/RubyString.java:2629)", "org.jruby.RubyString.gsubCommon19(org/jruby/RubyString.java:2583)", "org.jruby.RubyString.gsub(org/jruby/RubyString.java:2541)", "org.jruby.RubyString$INVOKER$i$gsub19.call(org/jruby/RubyString$INVOKER$i$gsub19.gen)", "Users.yaauie.src.elastic.logstash.logstash_minus_core.lib.logstash.util.substitution_variables.replace_placeholders(/Users/yaauie/src/elastic/logstash/logstash-core/lib/logstash/util/substitution_variables.rb:35)", "Users.yaauie.src.elastic.logstash.logstash_minus_core.lib.logstash.util.substitution_variables.RUBY$method$replace_placeholders$0$__VARARGS__(Users/yaauie/src/elastic/logstash/logstash_minus_core/lib/logstash/util//Users/yaauie/src/elastic/logstash/logstash-core/lib/logstash/util/substitution_variables.rb)", "Users.yaauie.src.elastic.logstash.logstash_minus_core.lib.logstash.util.substitution_variables.deep_replace(/Users/yaauie/src/elastic/logstash/logstash-core/lib/logstash/util/substitution_variables.rb:23)", "Users.yaauie.src.elastic.logstash.logstash_minus_core.lib.logstash.util.substitution_variables.RUBY$method$deep_replace$0$__VARARGS__(Users/yaauie/src/elastic/logstash/logstash_minus_core/lib/logstash/util//Users/yaauie/src/elastic/logstash/logstash-core/lib/logstash/util/substitution_variables.rb)", "Users.yaauie.src.elastic.logstash.logstash_minus_core.lib.logstash.config.mixin.block in config_init(/Users/yaauie/src/elastic/logstash/logstash-core/lib/logstash/config/mixin.rb:82)", "org.jruby.RubyHash$12.visit(org/jruby/RubyHash.java:1362)", "org.jruby.RubyHash$12.visit(org/jruby/RubyHash.java:1359)", "org.jruby.RubyHash.visitLimited(org/jruby/RubyHash.java:662)", "org.jruby.RubyHash.visitAll(org/jruby/RubyHash.java:647)", "org.jruby.RubyHash.iteratorVisitAll(org/jruby/RubyHash.java:1319)", "org.jruby.RubyHash.each_pairCommon(org/jruby/RubyHash.java:1354)", "org.jruby.RubyHash.each(org/jruby/RubyHash.java:1343)", "org.jruby.RubyHash$INVOKER$i$0$0$each.call(org/jruby/RubyHash$INVOKER$i$0$0$each.gen)", "RUBY.config_init(/Users/yaauie/src/elastic/logstash/logstash-core/lib/logstash/config/mixin.rb:81)", "RUBY.initialize(/Users/yaauie/src/elastic/logstash/logstash-core/lib/logstash/inputs/base.rb:60)", "Users.yaauie.src.elastic.logstash.logstash_minus_core.lib.logstash.inputs.threadable.initialize(/Users/yaauie/src/elastic/logstash/logstash-core/lib/logstash/inputs/threadable.rb:13)", "org.jruby.RubyClass.newInstance(org/jruby/RubyClass.java:1001)", "org.jruby.RubyClass$INVOKER$i$newInstance.call(org/jruby/RubyClass$INVOKER$i$newInstance.gen)", "org.jruby.RubyClass.finvoke(org/jruby/RubyClass.java:908)", "org.jruby.RubyBasicObject.callMethod(org/jruby/RubyBasicObject.java:363)", "org.logstash.plugins.PluginFactoryExt$Plugins.plugin(org/logstash/plugins/PluginFactoryExt.java:233)", "org.logstash.plugins.PluginFactoryExt$Plugins.plugin(org/logstash/plugins/PluginFactoryExt.java:166)", "Users.yaauie.src.elastic.logstash.logstash_minus_core.lib.logstash.pipeline.plugin(/Users/yaauie/src/elastic/logstash/logstash-core/lib/logstash/pipeline.rb:71)", "RUBY.<eval>((eval):8)", "org.jruby.RubyKernel.evalCommon(org/jruby/RubyKernel.java:1027)", "org.jruby.RubyKernel.eval(org/jruby/RubyKernel.java:994)", "org.jruby.RubyKernel$INVOKER$s$0$3$eval19.call(org/jruby/RubyKernel$INVOKER$s$0$3$eval19.gen)", "RUBY.initialize(/Users/yaauie/src/elastic/logstash/logstash-core/lib/logstash/pipeline.rb:49)", "Users.yaauie.src.elastic.logstash.logstash_minus_core.lib.logstash.pipeline.initialize(/Users/yaauie/src/elastic/logstash/logstash-core/lib/logstash/pipeline.rb:90)", "org.jruby.RubyClass.newInstance(org/jruby/RubyClass.java:1022)", "org.jruby.RubyClass$INVOKER$i$newInstance.call(org/jruby/RubyClass$INVOKER$i$newInstance.gen)", "Users.yaauie.src.elastic.logstash.logstash_minus_core.lib.logstash.pipeline_action.create.execute(/Users/yaauie/src/elastic/logstash/logstash-core/lib/logstash/pipeline_action/create.rb:38)", "Users.yaauie.src.elastic.logstash.logstash_minus_core.lib.logstash.pipeline_action.create.RUBY$method$execute$0$__VARARGS__(Users/yaauie/src/elastic/logstash/logstash_minus_core/lib/logstash/pipeline_action//Users/yaauie/src/elastic/logstash/logstash-core/lib/logstash/pipeline_action/create.rb)", "Users.yaauie.src.elastic.logstash.logstash_minus_core.lib.logstash.agent.block in converge_state(/Users/yaauie/src/elastic/logstash/logstash-core/lib/logstash/agent.rb:309)", "org.jruby.RubyProc.call(org/jruby/RubyProc.java:289)", "org.jruby.RubyProc.call(org/jruby/RubyProc.java:246)", "java.lang.Thread.run(java/lang/Thread.java:748)"]}
> [2019-02-06T21:31:36,544][FATAL][logstash.runner          ] An unexpected error occurred! {:error=>#<LogStash::Error: Don't know how to handle `Java::OrgLogstashSecretStore::SecretStoreException::UnknownException` for `PipelineAction::Create<zero>`>, :backtrace=>["org/logstash/execution/ConvergeResultExt.java:103:in `create'", "org/logstash/execution/ConvergeResultExt.java:34:in `add'", "/Users/yaauie/src/elastic/logstash/logstash-core/lib/logstash/agent.rb:324:in `block in converge_state'"]}
> ~~~

targets: `master`, `7.x`, `7.0`, `6.7`, `6.6`