### PR TITLE
pin childprocess to 0.9

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -15,6 +15,7 @@ gem "octokit", "~> 4", :group => :build
 gem "stud", "~> 0.0.22", :group => :build
 gem "rack-test", :require => "rack/test", :group => :development
 gem "fpm", "~> 1.3.3", :group => :build
+gem "childprocess", "~> 0.9", :group => :build
 gem "rubyzip", "~> 1", :group => :build
 gem "gems", "~> 1", :group => :build
 gem "flores", "~> 0.0.6", :group => :development


### PR DESCRIPTION
childprocess 1.x causes builds to fail like https://logstash-ci.elastic.co/job/elastic+logstash+7.x+multijob-unix-compatibility/os=centos&&immutable/1/console