### PR TITLE
pin childprocess to 0.9 (backport to 7.0)

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -57,8 +57,8 @@ GEM
     buftok (0.2.0)
     builder (3.2.3)
     cabin (0.9.0)
-    childprocess (1.0.1)
-      rake (< 13.0)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
     chronic_duration (0.10.6)
       numerizer (~> 0.1.1)
     ci_reporter (2.0.0)
@@ -224,7 +224,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-patterns-core
       stud (~> 0.0.22)
-    logstash-filter-http (1.0.0)
+    logstash-filter-http (1.0.1)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-http_client (>= 5.0.0, < 9.0.0)
     logstash-filter-jdbc_static (1.0.6)
@@ -332,7 +332,7 @@ GEM
       jar-dependencies (~> 0.3, >= 0.3.4)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-input-http_poller (5.0.0)
+    logstash-input-http_poller (5.0.1)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-http_client (~> 7)
@@ -634,6 +634,7 @@ DEPENDENCIES
   belzebuth
   benchmark-ips
   builder (~> 3)
+  childprocess (~> 0.9)
   ci_reporter_rspec (~> 1)
   flores (~> 0.0.6)
   fpm (~> 1.3.3)

--- a/Gemfile.template
+++ b/Gemfile.template
@@ -15,6 +15,7 @@ gem "octokit", "~> 4", :group => :build
 gem "stud", "~> 0.0.22", :group => :build
 gem "rack-test", :require => "rack/test", :group => :development
 gem "fpm", "~> 1.3.3", :group => :build
+gem "childprocess", "~> 0.9", :group => :build
 gem "rubyzip", "~> 1", :group => :build
 gem "gems", "~> 1", :group => :build
 gem "flores", "~> 0.0.6", :group => :development


### PR DESCRIPTION
childprocess 1.x causes builds to fail like https://logstash-ci.elastic.co/job/elastic+logstash+7.x+multijob-unix-compatibility/os=centos&&immutable/1/console

backport of #10410 