### PR TITLE
Central management typeless API

### DIFF
--- a/x-pack/lib/config_management/elasticsearch_source.rb
+++ b/x-pack/lib/config_management/elasticsearch_source.rb
@@ -20,7 +20,6 @@ module LogStash
       class RemoteConfigError < LogStash::Error; end
 
       PIPELINE_INDEX = ".logstash"
-      PIPELINE_TYPE = "doc"
       VALID_LICENSES = %w(trial standard gold platinum)
       FEATURE_INTERNAL = 'management'
       FEATURE_EXTERNAL = 'logstash'
@@ -138,7 +137,7 @@ module LogStash
       end
 
       def config_path
-        "#{PIPELINE_INDEX}/#{PIPELINE_TYPE}/_mget"
+        "#{PIPELINE_INDEX}/_mget"
       end
 
       def populate_license_state(xpack_info)

--- a/x-pack/spec/config_management/elasticsearch_source_spec.rb
+++ b/x-pack/spec/config_management/elasticsearch_source_spec.rb
@@ -132,7 +132,7 @@ describe LogStash::ConfigManagement::ElasticsearchSource do
           } }
 
     it "generates the path to get the configuration" do
-      expect(subject.config_path).to eq("#{described_class::PIPELINE_INDEX}/#{described_class::PIPELINE_TYPE}/_mget")
+      expect(subject.config_path).to eq("#{described_class::PIPELINE_INDEX}/_mget")
     end
   end
 
@@ -168,7 +168,7 @@ describe LogStash::ConfigManagement::ElasticsearchSource do
     let(:pipeline_id) { "apache" }
     let(:mock_client)  { double("http_client") }
     let(:settings) { super.merge({ "xpack.management.pipeline.id" => pipeline_id }) }
-    let(:es_path) { "#{described_class::PIPELINE_INDEX}/#{described_class::PIPELINE_TYPE}/_mget" }
+    let(:es_path) { "#{described_class::PIPELINE_INDEX}/_mget" }
     let(:request_body_string) { LogStash::Json.dump({ "docs" => [{ "_id" => pipeline_id }] }) }
 
     before do


### PR DESCRIPTION
This commit adopts Elasticsearch's typeless API for central management.

Relates: https://github.com/elastic/elasticsearch/issues/38637

----
Note this PR should only be merged AFTER https://github.com/elastic/kibana/pull/30546 , and should only be back ported to the same releases. Else, this change will break central management.  
