### PR TITLE
bump clone filter in lock file

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -193,7 +193,7 @@ GEM
       murmurhash3
     logstash-filter-cidr (3.1.2-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-clone (3.0.6)
+    logstash-filter-clone (4.0.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-csv (3.0.8)
       logstash-core-plugin-api (>= 1.60, <= 2.99)


### PR DESCRIPTION
this bump makes `clones` parameter of the clone filter a required field