### PR TITLE
[Doc] Reorder files in index to expose topics

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -101,9 +101,6 @@ include::static/upgrading.asciidoc[]
 :edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/configuration.asciidoc
 include::static/configuration.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/field-reference.asciidoc
-include::static/field-reference.asciidoc[]
-
 :edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/multiple-pipelines.asciidoc
 include::static/multiple-pipelines.asciidoc[]
 
@@ -124,6 +121,16 @@ include::static/ingest-convert.asciidoc[]
 
 :edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/ls-ls-config.asciidoc
 include::static/ls-ls-config.asciidoc[]
+
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/field-reference.asciidoc
+include::static/field-reference.asciidoc[]
+
+//The `field-reference.asciidoc` file (included above) contains a
+//`role="exclude"` attribute to pull in the topic and make it linkable in the LS
+//Ref, but not appear in the main TOC. The `exclude`attribute was carrying
+//forward for all subsequent topics under the `configuration.asciidoc` heading.
+//This include should remain after includes for all other topics under the
+//`Configuring Logstash` heading.
 
 ifdef::include-xpack[]
 :edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/management/configuring-centralized-pipelines.asciidoc


### PR DESCRIPTION
The field references deep dive topic uses the `role="exclude"` attribute so that the topic appears and can be linked in the LS Ref, but doesn't appear in the main TOC.  The `exclude`attribute was carrying forward for all subsequent topics in the `configuration.asciidoc` file. 

This PR moves the include statement for `field-reference.asciidoc` so that the `role="exclude"` attribute will not affect other topics. 

Targets: `master` `7.x` `7.0` `6.7` `6.6` `6.5` `6.4`

<img width="1050" alt="screen shot 2019-02-12 at 10 43 53 am" src="https://user-images.githubusercontent.com/35154725/52647820-68930500-2eb3-11e9-910b-8f93b8e419a2.png">
