### PR TITLE
Update to 6.6.1 release notes

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -30,7 +30,7 @@ This section summarizes the changes in the following releases:
 [[logstash-6-6-1]]
 === Logstash 6.6.1 Release Notes
 
-* Fixes a problem with how Logstash logs malformed URLs. (CVE-2019-7612) See
+* Fixes a problem with how Logstash logs malformed URLs. (CVE-2019-7612). See
 https://www.elastic.co/community/security[Security issues].
 
 ==== Plugins

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -30,6 +30,9 @@ This section summarizes the changes in the following releases:
 [[logstash-6-6-1]]
 === Logstash 6.6.1 Release Notes
 
+* Fixes a problem with how Logstash logs malformed URLs. (CVE-2019-7612) See
+https://www.elastic.co/community/security[Security issues].
+
 ==== Plugins
 
 *Es_bulk Codec*


### PR DESCRIPTION
Adds CVE-2019-7612 and link to Security Issues to 6.6.1 release notes