### PR TITLE
Update to 5.6.15 release notes

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -23,6 +23,9 @@ This section summarizes the changes in the following releases:
 [[logstash-5-6-15]]
 === Logstash 5.6.15 Release Notes
 
+* Fixes a problem with how Logstash logs malformed URLs. (CVE-2019-7612). See
+https://www.elastic.co/community/security[Security issues].
+
 ==== Plugins
 
 *Es_bulk Codec*


### PR DESCRIPTION
Adds CVE-2019-7612 and link to Security Issues to 5.6.15 release notes