### PR TITLE
Enhance load average metrics

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -75,6 +75,7 @@ Contributors:
 * Leandro Moreira (leandromoreira)
 * Hao Chen (haoch)
 * Jake Landis (jakelandis)
+* Mike Place (cachedout)
 
 Note: If you've sent me patches, bug reports, or otherwise contributed to
 logstash, and you aren't on the list above and want to be, please let me know

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -49,7 +49,7 @@ module LogStash
             :peak_open_file_descriptors,
             :max_file_descriptors,
             [:mem, [:total_virtual_in_bytes]],
-            [:cpu, [:total_in_millis, :percent, :load_average]]
+            [:cpu, [:total_in_millis, :percent, :load_average, :num_cpus]]
           )
         end
 

--- a/logstash-core/lib/logstash/instrument/periodic_poller/jvm.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/jvm.rb
@@ -15,6 +15,7 @@ java_import 'javax.management.AttributeList'
 java_import 'javax.naming.directory.Attribute'
 java_import 'org.logstash.instrument.reports.MemoryReport'
 java_import 'org.logstash.instrument.reports.ProcessReport'
+java_import 'org.logstash.instrument.reports.SystemReport'
 
 
 module LogStash module Instrument module PeriodicPoller
@@ -58,6 +59,7 @@ module LogStash module Instrument module PeriodicPoller
       collect_process_metrics
       collect_gc_stats
       collect_load_average
+      collect_num_cpus
     end
 
     def collect_gc_stats
@@ -103,6 +105,11 @@ module LogStash module Instrument module PeriodicPoller
 
       metric.gauge(path + [:mem], :total_virtual_in_bytes, process_metrics["mem"]["total_virtual_in_bytes"])
 
+    end
+
+    def collect_num_cpus
+      sys_report = SystemReport.generate
+      metric.gauge([:jvm, :process, :cpu], :num_cpus, sys_report["system.available_processors"] )
     end
 
     def collect_load_average

--- a/logstash-core/lib/logstash/instrument/periodic_poller/load_average.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/load_average.rb
@@ -27,11 +27,13 @@ module LogStash module Instrument module PeriodicPoller
     class Other
       def self.get()
         load_average_1m = ManagementFactory.getOperatingSystemMXBean().getSystemLoadAverage()
+        system_cpus = ManagementFactory.getOperatingSystemMXBean().getAvailableProcessors()
 
         return nil if load_average_1m.nil?
 
         {
-          :"1m" => load_average_1m
+          :"1m" => load_average_1m,
+          :"norm" => {:"1m" => load_average_1m / system_cpus}
         }
       end
     end

--- a/logstash-core/spec/logstash/instrument/periodic_poller/load_average_spec.rb
+++ b/logstash-core/spec/logstash/instrument/periodic_poller/load_average_spec.rb
@@ -42,6 +42,7 @@ describe LogStash::Instrument::PeriodicPoller::LoadAverage do
 
         before do
           expect(ManagementFactory).to receive(:getOperatingSystemMXBean).and_return(double("OperatingSystemMXBean", :getSystemLoadAverage => load_avg))
+          expect(ManagementFactory).to receive(:getOperatingSystemMXBean).and_return(double("OperatingSystemMXBean", :getAvailableProcessors => 4))
         end
 
         it "returns the value" do
@@ -52,6 +53,7 @@ describe LogStash::Instrument::PeriodicPoller::LoadAverage do
       context "when 'OperatingSystemMXBean.getSystemLoadAverage' doesn't return anything" do
         before do
           expect(ManagementFactory).to receive(:getOperatingSystemMXBean).and_return(double("OperatingSystemMXBean", :getSystemLoadAverage => nil))
+          expect(ManagementFactory).to receive(:getOperatingSystemMXBean).and_return(double("OperatingSystemMXBean", :getAvailableProcessors => 4))
         end
 
         it "returns nothing" do

--- a/logstash-core/src/main/java/org/logstash/instrument/reports/SystemReport.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/reports/SystemReport.java
@@ -1,0 +1,17 @@
+package org.logstash.instrument.reports;
+
+import org.logstash.instrument.monitors.SystemMonitor;
+
+import java.util.Map;
+
+public class SystemReport {
+    private SystemReport() { }
+
+    /**
+     * Build a report with current System information
+     * @return a Map with the current system report
+     */
+    public static Map<String, Object> generate() {
+        return SystemMonitor.detect().toMap();
+    }
+}

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -48,6 +48,18 @@ describe "Test Monitoring API" do
     end
   end
 
+  it "can retrive system stats" do
+    logstash_service = @fixture.get_service("logstash")
+    logstash_service.start_with_stdin
+    logstash_service.wait_for_logstash
+    Stud.try(max_retry.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
+      result = logstash_service.monitoring_api.node_stats rescue nil
+      expect(result).not_to be_nil
+      expect(result["process"]["cpu"]["num_cpus"]).to be > 0
+    end
+  end
+
+
   it 'can retrieve dlq stats' do
     logstash_service = @fixture.get_service("logstash")
     logstash_service.start_with_stdin

--- a/x-pack/lib/monitoring/inputs/metrics/stats_event_factory.rb
+++ b/x-pack/lib/monitoring/inputs/metrics/stats_event_factory.rb
@@ -73,6 +73,8 @@ module LogStash; module Inputs; class Metrics;
       else
         {:cpu => load_average}
       end
+      num_cpus = stats.extract_metrics([:jvm, :process, :cpu], :num_cpus)
+      {:num_cpus => num_cpus}
     end
 
     # OS stats are not available on all platforms

--- a/x-pack/lib/monitoring/inputs/metrics/stats_event_factory.rb
+++ b/x-pack/lib/monitoring/inputs/metrics/stats_event_factory.rb
@@ -65,16 +65,15 @@ module LogStash; module Inputs; class Metrics;
 
     def format_os_stats(stats)
       load_average = stats.extract_metrics([:jvm, :process, :cpu], :load_average)
+      num_cpus = stats.extract_metrics([:jvm, :process, :cpu], :num_cpus)
       if os_stats?(stats)
         cpuacct = stats.extract_metrics([:os, :cgroup, :cpuacct], :control_group, :usage_nanos)
         cgroups_stats = stats.extract_metrics([:os, :cgroup, :cpu, :stat], :number_of_elapsed_periods, :number_of_times_throttled, :time_throttled_nanos)
         control_group = stats.get_shallow(:os, :cgroup, :cpu, :control_group).value
-        {:cpu => load_average, :cgroup => {:cpuacct =>  cpuacct, :cpu => {:control_group => control_group, :stat => cgroups_stats}}}
+        {:cpu => [load_average, num_cpus], :cgroup => {:cpuacct =>  cpuacct, :cpu => {:control_group => control_group, :stat => cgroups_stats}}}
       else
-        {:cpu => load_average}
+        {:cpu => [load_average, num_cpus]}
       end
-      num_cpus = stats.extract_metrics([:jvm, :process, :cpu], :num_cpus)
-      {:num_cpus => num_cpus}
     end
 
     # OS stats are not available on all platforms

--- a/x-pack/lib/monitoring/inputs/metrics/stats_event_factory.rb
+++ b/x-pack/lib/monitoring/inputs/metrics/stats_event_factory.rb
@@ -65,7 +65,6 @@ module LogStash; module Inputs; class Metrics;
 
     def format_os_stats(stats)
       load_average = stats.extract_metrics([:jvm, :process, :cpu], :load_average)
-      print(load_average)
       num_cpus = stats.extract_metrics([:jvm, :process, :cpu], :num_cpus)
       if os_stats?(stats)
         cpuacct = stats.extract_metrics([:os, :cgroup, :cpuacct], :control_group, :usage_nanos)

--- a/x-pack/lib/monitoring/inputs/metrics/stats_event_factory.rb
+++ b/x-pack/lib/monitoring/inputs/metrics/stats_event_factory.rb
@@ -65,14 +65,15 @@ module LogStash; module Inputs; class Metrics;
 
     def format_os_stats(stats)
       load_average = stats.extract_metrics([:jvm, :process, :cpu], :load_average)
+      print(load_average)
       num_cpus = stats.extract_metrics([:jvm, :process, :cpu], :num_cpus)
       if os_stats?(stats)
         cpuacct = stats.extract_metrics([:os, :cgroup, :cpuacct], :control_group, :usage_nanos)
         cgroups_stats = stats.extract_metrics([:os, :cgroup, :cpu, :stat], :number_of_elapsed_periods, :number_of_times_throttled, :time_throttled_nanos)
         control_group = stats.get_shallow(:os, :cgroup, :cpu, :control_group).value
-        {:cpu => [load_average, num_cpus], :cgroup => {:cpuacct =>  cpuacct, :cpu => {:control_group => control_group, :stat => cgroups_stats}}}
+        {:cpu => {:load_average => load_average[:load_average], :num_cpus => num_cpus[:num_cpus]}, :cgroup => {:cpuacct =>  cpuacct, :cpu => {:control_group => control_group, :stat => cgroups_stats}}}
       else
-        {:cpu => [load_average, num_cpus]}
+        {:cpu => {:load_average => load_average[:load_average], :num_cpus => num_cpus[:num_cpus]}}
       end
     end
 

--- a/x-pack/spec/monitoring/schemas/monitoring_document_schema.json
+++ b/x-pack/spec/monitoring/schemas/monitoring_document_schema.json
@@ -94,9 +94,8 @@
       "required": ["cpu"],
       "properties": {
         "cpu": {
-          "type": "array",
-          "minItems": 1,
-          "required": ["load_average"],
+          "type": "object",
+          "required": ["load_average", "num_cpus"],
           "properties": {
             "load_average": {
               "type": "object",
@@ -105,14 +104,14 @@
                 "1m": {"type": "number"},
                 "5m": {"type": "number"},
                 "15m": {"type": "number"}
-              },
-              "num_cpus": {
-                "type": "number"
               }
+            },
+             "num_cpus": {
+               "type": "number"
             }
           }
+         }
         }
-      }
     },
     "events": {"$ref": "#/definitions/events"},
     "queue": {

--- a/x-pack/spec/monitoring/schemas/monitoring_document_schema.json
+++ b/x-pack/spec/monitoring/schemas/monitoring_document_schema.json
@@ -94,7 +94,8 @@
       "required": ["cpu"],
       "properties": {
         "cpu": {
-          "type": "object",
+          "type": "array",
+          "minItems": 1,
           "required": ["load_average"],
           "properties": {
             "load_average": {
@@ -104,6 +105,9 @@
                 "1m": {"type": "number"},
                 "5m": {"type": "number"},
                 "15m": {"type": "number"}
+              },
+              "num_cpus": {
+                "type": "number"
               }
             }
           }


### PR DESCRIPTION
This adds a a field for the number of CPUs on a system. 

Additionally, it adds a new fields called `norm` to the load average metrics, which represents the load average divided by number of CPUs detected.

Refs: https://github.com/elastic/stack-monitoring/issues/39