### PR TITLE
update to send api version 6

### DIFF
--- a/x-pack/lib/monitoring/monitoring.rb
+++ b/x-pack/lib/monitoring/monitoring.rb
@@ -83,7 +83,7 @@ module LogStash
       include LogStash::Util::Loggable, LogStash::Helpers::ElasticsearchOptions
 
       PIPELINE_ID = ".monitoring-logstash"
-      API_VERSION = 2
+      API_VERSION = 6
 
       def initialize
         # nothing to do here


### PR DESCRIPTION
This is part of effort to remove types from our internal indexes, Elasticsearch will be bumping the current monitoring API from `6` to `7`. Only N-1 versions are supported, so this allows Logstash monitoring to continue to work on 7.0.  

I did a quick spot of the code/payload/Kibana with version bump and all seemed well. However, another manual test would be appreciated. 

This change needs to go back to `6.7`. 