### PR TITLE
Update monitoring HTTP end point

### DIFF
--- a/x-pack/lib/template.cfg.erb
+++ b/x-pack/lib/template.cfg.erb
@@ -13,7 +13,7 @@ input {
 output {
   elasticsearch {
     hosts => <%= es_hosts %>
-    bulk_path => "/_xpack/monitoring/_bulk?system_id=logstash&system_api_version=<%= system_api_version %>&interval=1s"
+    bulk_path => "/_monitoring/bulk?system_id=logstash&system_api_version=<%= system_api_version %>&interval=1s"
     manage_template => false
     document_type => "%{[@metadata][document_type]}"
     index => ""


### PR DESCRIPTION
This commit changes /_xpack/monitoring/_bulk to /_monitoring/bulk.
The former is deprecated as of 7.0.0.

Relates https://github.com/elastic/elasticsearch/pull/36130
Relates https://github.com/elastic/elasticsearch/issues/35958

-------

This prevents alot of deprecation warnings in the logs. 