### PR TITLE
Change internal document type to push "_doc" instead of "doc"

### DIFF
--- a/x-pack/qa/integration/support/helpers.rb
+++ b/x-pack/qa/integration/support/helpers.rb
@@ -95,7 +95,7 @@ def elasticsearch_client(options = { :url => "http://elastic:#{elastic_password}
 end
 
 def push_elasticsearch_config(pipeline_id, config)
-  elasticsearch_client.index :index => '.logstash', :type => "doc", id: pipeline_id, :body => { :pipeline => config }
+  elasticsearch_client.index :index => '.logstash', :type => "_doc", id: pipeline_id, :body => { :pipeline => config }
 end
 
 def cleanup_elasticsearch(index = MONITORING_INDEXES)


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/39888 removed the "doc"
 type from internal indices, causing breakage in the x-pack integration
 tests. This commit changes the type to "_doc" for consistency.