### PR TITLE
monitoring: bump to system_api_version 7

### DIFF
--- a/x-pack/lib/monitoring/monitoring.rb
+++ b/x-pack/lib/monitoring/monitoring.rb
@@ -83,7 +83,7 @@ module LogStash
       include LogStash::Util::Loggable, LogStash::Helpers::ElasticsearchOptions
 
       PIPELINE_ID = ".monitoring-logstash"
-      API_VERSION = 6
+      API_VERSION = 7
 
       def initialize
         # nothing to do here


### PR DESCRIPTION
As part of the type removals for monitoring data in 7.0,
the system_api_version has been bumped to `7`. While
`6` will continue to work, it would ideally be bumped
to `7` to allow for future `8` to work gracefully. 
(note Elasticsearch only support current - 1 versions)
