### PR TITLE
Fix issue setting 'enable_metric => false' on a plugin

### DIFF
--- a/logstash-core/spec/logstash/filters/base_spec.rb
+++ b/logstash-core/spec/logstash/filters/base_spec.rb
@@ -322,4 +322,18 @@ describe LogStash::Filters::NOOP do
     end
 
   end
+
+  describe "when metrics are disabled" do
+    describe "An error should not be raised, and the event should be processed" do
+      config <<-CONFIG
+        filter {
+          noop { enable_metric => false }
+        }
+      CONFIG
+
+      sample_one("type" => "noop", "tags" => {"blackhole" => "go"}) do
+        expect(subject.get("[tags][blackhole]")).to eq("go")
+      end
+    end
+  end
 end

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/NullNamespacedMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/NullNamespacedMetricExt.java
@@ -39,7 +39,7 @@ public final class NullNamespacedMetricExt extends AbstractNamespacedMetricExt {
     @JRubyMethod(optional = 2)
     public NullNamespacedMetricExt initialize(final ThreadContext context,
         final IRubyObject[] args) {
-        this.metric = args.length > 0 && !args[0].isNil() ? (NullMetricExt) args[0] : new NullMetricExt(context.runtime, metaClass);
+        this.metric = args.length > 0 && !args[0].isNil() && (args[0] instanceof NullMetricExt) ? (NullMetricExt) args[0] : new NullMetricExt(context.runtime, metaClass);
         final IRubyObject namespaceName = args.length == 2 ? args[1] : NULL;
         if (namespaceName instanceof RubyArray) {
             this.namespaceName = (RubyArray) namespaceName;


### PR DESCRIPTION
This commit fixes a ClassCastException which happens when
 a plugin has the `enable_metric` setting set to false - a
 NullMetricExt is assumed, but that is only created when
 'metric.collect' is set to 'false' in the Logstash configuration,
 not when an individual plugin disables its metrics.