### PR TITLE
make monitoring specs resilient to internal api number changes

### DIFF
--- a/x-pack/qa/integration/spec_helper.rb
+++ b/x-pack/qa/integration/spec_helper.rb
@@ -2,7 +2,7 @@
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
-MONITORING_INDEXES = ".monitoring-logstash-2*,.monitoring-logstash-6*"
+MONITORING_INDEXES = ".monitoring-logstash-*"
 
 require_relative "support/helpers"
 require_relative "support/shared_examples"


### PR DESCRIPTION
This PR fixes the currently failing 7.x and master x-pack integration tests (see https://logstash-ci.elastic.co/job/elastic+logstash+master+multijob-x-pack-integration/ and https://logstash-ci.elastic.co/job/elastic+logstash+7.x+multijob-x-pack-integration/)