### PR TITLE
fix events_count to return total

### DIFF
--- a/x-pack/lib/monitoring/inputs/metrics/stats_event_factory.rb
+++ b/x-pack/lib/monitoring/inputs/metrics/stats_event_factory.rb
@@ -93,8 +93,6 @@ module LogStash; module Inputs; class Metrics;
     end
 
     def format_queue_stats(agent, stats)
-      events = 0
-
       pipelines_stats = stats.get_shallow(:stats, :pipelines)
 
       total_queued_events = 0
@@ -103,7 +101,7 @@ module LogStash; module Inputs; class Metrics;
         pipeline = agent.get_pipeline(pipeline_id)
         # Check if pipeline is nil to avoid race condition where metrics system refers pipeline that has been stopped already
         next if pipeline.nil? || pipeline.system? || type != 'persisted'
-        total_queued_events = p_stats[:queue][:events].value
+        total_queued_events += p_stats[:queue][:events].value
       end
 
       {:events_count => total_queued_events}


### PR DESCRIPTION
A bug in the `StatsEventFactory` prevents it from reporting the _total_ queued items across multiple pipelines.

When iterating over the list of stats, we need to sum up matching items instead of setting the total to the last one seen.

_All of the testing infrastructure for this code relies on injecting a single pipeline directly into the `logstash.yml`, so I don't have an adequate way to improve coverage without significant effort._