### PR TITLE
Update pipeline-pipeline-config.asciidoc

### DIFF
--- a/docs/static/pipeline-pipeline-config.asciidoc
+++ b/docs/static/pipeline-pipeline-config.asciidoc
@@ -74,9 +74,9 @@ Here is an example distributor pattern configuration.
   config.string: |
     input { beats { port => 5044 } }
     output {
-        if [type] == apache {
+        if [type] == "apache" {
           pipeline { send_to => weblogs }
-        } else if [type] == system {
+        } else if [type] == "system" {
           pipeline { send_to => syslog }
         } else {
           pipeline { send_to => fallback }
@@ -101,7 +101,7 @@ Here is an example distributor pattern configuration.
       elasticsearch { hosts => [es_cluster_b_host] }
     }
 - pipeline.id: fallback-processing
-    config.string: |
+  config.string: |
     input { pipeline { address => fallback } }
     output { elasticsearch { hosts => [es_cluster_b_host] } }
 ----


### PR DESCRIPTION
Current example in the documentation does not work. 

1. By not putting matched field in quotes Logstash fails to start with ERROR in logs ```[2019-03-20T16:27:01,768][ERROR][logstash.agent           ] Failed to execute action {:action=>LogStash::PipelineAction::Create/pipeline_id:beats-server, :exception=>"LogStash::ConfigurationError", :message=>"Expected one of #, ( at line 3, column 23 (byte 65) after output {\n  if [type] == apache ", :backtrace=>["/usr/share/logstash/logstash-core/lib/logstash/compiler.rb:41:in `compile_imperative'", "/usr/share/logstash/logstash-core/lib/logstash/compiler.rb:49:in `compile_graph'", "/usr/share/logstash/logstash-core/lib/logstash/compiler.rb:11:in `block in compile_sources'", "org/jruby/RubyArray.java:2486:in `map'", "/usr/share/logstash/logstash-core/lib/logstash/compiler.rb:10:in `compile_sources'", "org/logstash/execution/AbstractPipelineExt.java:149:in `initialize'", "/usr/share/logstash/logstash-core/lib/logstash/pipeline.rb:22:in `initialize'", "/usr/share/logstash/logstash-core/lib/logstash/pipeline.rb:90:in `initialize'", "/usr/share/logstash/logstash-core/lib/logstash/pipeline_action/create.rb:43:in `block in execute'", "/usr/share/logstash/logstash-core/lib/logstash/agent.rb:94:in `block in exclusive'", "org/jruby/ext/thread/Mutex.java:148:in `synchronize'", "/usr/share/logstash/logstash-core/lib/logstash/agent.rb:94:in `exclusive'", "/usr/share/logstash/logstash-core/lib/logstash/pipeline_action/create.rb:39:in `execute'", "/usr/share/logstash/logstash-core/lib/logstash/agent.rb:327:in `block in converge_state'"]}
```
2. Indentation in `pipeline.id: fallback-processing` for line `config.string: |` is incorrect. It must be in line with `pipeline.id`