### PR TITLE
Interpolate `Logstash::Util::Password` vars during plugin init

### DIFF
--- a/logstash-core/lib/logstash/util/substitution_variables.rb
+++ b/logstash-core/lib/logstash/util/substitution_variables.rb
@@ -30,17 +30,17 @@ module ::LogStash::Util::SubstitutionVariables
   # If value matches the pattern, returns the following precedence : Secret store value, Environment entry value, default value as provided in the pattern
   # If the value does not match the pattern, the 'value' param returns as-is
   def replace_placeholders(value)
-    if value.is_a?(String)
-      interpolate = value
-      was_a_password = false
-    elsif value.is_a?(::LogStash::Util::Password)
-      was_a_password = true
-      interpolate = value.value.to_s
+    case value
+    when String
+      unwrapped = value
+    when ::LogStash::Util::Password
+      unwrapped = value.value.to_s
     else
       return value
     end
+    klass = value.class
 
-    interpolated = interpolate.gsub(SUBSTITUTION_PLACEHOLDER_REGEX) do |placeholder|
+    interpolated = unwrapped.gsub(SUBSTITUTION_PLACEHOLDER_REGEX) do |placeholder|
       # Note: Ruby docs claim[1] Regexp.last_match is thread-local and scoped to
       # the call, so this should be thread-safe.
       #
@@ -60,7 +60,7 @@ module ::LogStash::Util::SubstitutionVariables
       end
       replacement.to_s
     end
-    return was_a_password ? ::LogStash::Util::Password.new(interpolated) : interpolated
+    klass.new(interpolated)
   end # def replace_placeholders
 
 end

--- a/logstash-core/lib/logstash/util/substitution_variables.rb
+++ b/logstash-core/lib/logstash/util/substitution_variables.rb
@@ -30,9 +30,15 @@ module ::LogStash::Util::SubstitutionVariables
   # If value matches the pattern, returns the following precedence : Secret store value, Environment entry value, default value as provided in the pattern
   # If the value does not match the pattern, the 'value' param returns as-is
   def replace_placeholders(value)
-    return value unless value.is_a?(String)
+    if value.is_a?(String)
+      interpolate = value
+    elsif value.is_a?(::LogStash::Util::Password)
+      interpolate = value.value.to_s
+    else
+      return value
+    end
 
-    value.gsub(SUBSTITUTION_PLACEHOLDER_REGEX) do |placeholder|
+    interpolate.gsub(SUBSTITUTION_PLACEHOLDER_REGEX) do |placeholder|
       # Note: Ruby docs claim[1] Regexp.last_match is thread-local and scoped to
       # the call, so this should be thread-safe.
       #

--- a/logstash-core/lib/logstash/util/substitution_variables.rb
+++ b/logstash-core/lib/logstash/util/substitution_variables.rb
@@ -32,13 +32,15 @@ module ::LogStash::Util::SubstitutionVariables
   def replace_placeholders(value)
     if value.is_a?(String)
       interpolate = value
+      was_a_password = false
     elsif value.is_a?(::LogStash::Util::Password)
+      was_a_password = true
       interpolate = value.value.to_s
     else
       return value
     end
 
-    interpolate.gsub(SUBSTITUTION_PLACEHOLDER_REGEX) do |placeholder|
+    interpolated = interpolate.gsub(SUBSTITUTION_PLACEHOLDER_REGEX) do |placeholder|
       # Note: Ruby docs claim[1] Regexp.last_match is thread-local and scoped to
       # the call, so this should be thread-safe.
       #
@@ -58,6 +60,7 @@ module ::LogStash::Util::SubstitutionVariables
       end
       replacement.to_s
     end
+    return was_a_password ? ::LogStash::Util::Password.new(interpolated) : interpolated
   end # def replace_placeholders
 
 end


### PR DESCRIPTION
I'm not sure if this functionality was left out deliberately, but Logstash does not currently attempt interpolate variables of type `LogStash::Util::Password` with values from the environment or Logstash secret store; this seems odd to me as those are the variables one would most wish to protect and keep out of a plain text pipeline definition.

This PR resolves this by pulling the original value from the Password object and attempting to interpolate that.