### PR TITLE
 Enhance `GET /` API for Metricbeat

### DIFF
--- a/logstash-core/lib/logstash/api/commands/default_metadata.rb
+++ b/logstash-core/lib/logstash/api/commands/default_metadata.rb
@@ -13,7 +13,9 @@ module LogStash
            :id => service.agent.id,
            :name => service.agent.name,
            :ephemeral_id => service.agent.ephemeral_id,
-           :status_green => "green"}  # This is hard-coded to mirror x-pack behavior
+           :status => "green",  # This is hard-coded to mirror x-pack behavior
+           :snapshot => ::BUILD_INFO["build_snapshot"],
+           }
         end
 
         def host

--- a/logstash-core/lib/logstash/api/commands/default_metadata.rb
+++ b/logstash-core/lib/logstash/api/commands/default_metadata.rb
@@ -12,7 +12,8 @@ module LogStash
            :http_address => http_address,
            :id => service.agent.id,
            :name => service.agent.name,
-           :ephemeral_id => service.agent.ephemeral_id}
+           :ephemeral_id => service.agent.ephemeral_id,
+           :status_green => "green"}  # This is hard-coded to mirror x-pack behavior
         end
 
         def host

--- a/logstash-core/lib/logstash/api/commands/default_metadata.rb
+++ b/logstash-core/lib/logstash/api/commands/default_metadata.rb
@@ -7,8 +7,12 @@ module LogStash
     module Commands
       class DefaultMetadata < Commands::Base
         def all
-          {:host => host, :version => version, :http_address => http_address,
-           :id => service.agent.id, :name => service.agent.name}
+          {:host => host,
+           :version => version,
+           :http_address => http_address,
+           :id => service.agent.id,
+           :name => service.agent.name,
+           :ephemeral_id => service.agent.ephemeral_id}
         end
 
         def host


### PR DESCRIPTION
Add the following fields:

 *   status: Status of node (green, etc.)
 *   ephemeral_id: Ephemeral ID of node
 *   name: Name of node, could be different from host
 *   snapshot: Whether the node is working off a snapshot build

Note that `uuid` was requested in [the issue](https://github.com/elastic/logstash/issues/10121) but this data seems to be available already in `id`.

Closes https://github.com/elastic/logstash/issues/10121