### PR TITLE
Add note that pline-pline also supports files

### DIFF
--- a/docs/static/pipeline-pipeline-config.asciidoc
+++ b/docs/static/pipeline-pipeline-config.asciidoc
@@ -58,6 +58,9 @@ You can use the `pipeline` input and output to better organize code, streamline 
 * <<forked-path-pattern>>
 * <<collector-pattern>>
 
+NOTE: These examples use `config.string` to illustrate the flows.
+You can also use configuration files for pipeline-to-pipeline communication.
+
 [[distributor-pattern]]
 ===== The distributor pattern
 


### PR DESCRIPTION
Examples use `config.string` to illustrate flows. Add a note to indicate that files are supported, too. 