### PR TITLE
Make the sample command easier to follow

### DIFF
--- a/docs/static/reloading-config.asciidoc
+++ b/docs/static/reloading-config.asciidoc
@@ -25,7 +25,7 @@ process running Logstash. For example:
 
 [source,shell]
 ----------------------------------
-kill -1 14175
+kill -SIGHUP 14175
 ----------------------------------
 
 Where 14175 is the ID of the process running Logstash.


### PR DESCRIPTION
A tiny change suggestion due to:

- `-SIGHUP` was mentioned in the previous text
- `-SIGHUP` is easier to read than `-1`
- `-1` can be easily mixed up with `-l`