### PR TITLE
Collect and expose codec metrics

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -69,6 +69,7 @@ task javaTests(type: Test) {
     exclude '/org/logstash/config/ir/ConfigCompilerTest.class'
     exclude '/org/logstash/config/ir/CompiledPipelineTest.class'
     exclude '/org/logstash/config/ir/compiler/OutputDelegatorTest.class'
+    exclude '/org/logstash/config/ir/compiler/JavaCodecDelegatorTest.class'
 }
 
 task rubyTests(type: Test) {
@@ -79,6 +80,7 @@ task rubyTests(type: Test) {
     include '/org/logstash/config/ir/ConfigCompilerTest.class'
     include '/org/logstash/config/ir/CompiledPipelineTest.class'
     include '/org/logstash/config/ir/compiler/OutputDelegatorTest.class'
+    include '/org/logstash/config/ir/compiler/JavaCodecDelegatorTest.class'
 }
 
 test {

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -115,6 +115,7 @@ module LogStash
               :events => stats[:events],
               :plugins => {
                 :inputs => plugin_stats(stats, :inputs),
+                :codecs => plugin_stats(stats, :codecs),
                 :filters => plugin_stats(stats, :filters),
                 :outputs => plugin_stats(stats, :outputs)
               },

--- a/logstash-core/lib/logstash/codecs/delegator.rb
+++ b/logstash-core/lib/logstash/codecs/delegator.rb
@@ -1,0 +1,52 @@
+module LogStash::Codecs
+  class Delegator < SimpleDelegator
+    def initialize(obj)
+      super(obj)
+      @encode_metric = LogStash::Instrument::NamespacedNullMetric.new
+      @decode_metric = LogStash::Instrument::NamespacedNullMetric.new
+    end
+
+    def class
+      __getobj__.class
+    end
+
+    def metric=(metric)
+      __getobj__.metric = metric
+
+      __getobj__.metric.gauge(:name, __getobj__.class.config_name)
+
+      @encode_metric = __getobj__.metric.namespace(:encode)
+      @encode_metric.counter(:writes_in)
+      @encode_metric.report_time(:duration_in_millis, 0)
+
+      @decode_metric = __getobj__.metric.namespace(:decode)
+      @decode_metric.counter(:writes_in)
+      @decode_metric.counter(:out)
+      @decode_metric.report_time(:duration_in_millis, 0)
+    end
+
+    def encode(event)
+      @encode_metric.increment(:writes_in)
+      @encode_metric.time(:duration_in_millis) do
+        __getobj__.encode(event)
+      end
+    end
+
+    def multi_encode(events)
+      @encode_metric.increment(:writes_in, events.length)
+      @encode_metric.time(:duration_in_millis) do
+        __getobj__.multi_encode(events)
+      end
+    end
+
+    def decode(data)
+      @decode_metric.increment(:writes_in)
+      @decode_metric.time(:duration_in_millis) do
+        __getobj__.decode(data) do |event|
+          @decode_metric.increment(:out)
+          yield event
+        end
+      end
+    end
+  end
+end

--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -4,6 +4,7 @@ require "logstash/util/safe_uri"
 require "logstash/version"
 require "logstash/environment"
 require "logstash/util/plugin_version"
+require "logstash/codecs/delegator"
 require "filesize"
 
 LogStash::Environment.load_locale!
@@ -410,7 +411,7 @@ module LogStash::Config::Mixin
         case validator
           when :codec
             if value.first.is_a?(String)
-              value = LogStash::Plugin.lookup("codec", value.first).new
+              value = LogStash::Codecs::Delegator.new LogStash::Plugin.lookup("codec", value.first).new
               return true, value
             else
               value = value.first

--- a/logstash-core/lib/logstash/inputs/base.rb
+++ b/logstash-core/lib/logstash/inputs/base.rb
@@ -99,6 +99,13 @@ class LogStash::Inputs::Base < LogStash::Plugin
     cloned
   end
 
+  def metric=(metric)
+    super
+    # Hack to create a new metric namespace using 'plugins' as the root
+    @codec.metric = metric.root.namespace(metric.namespace_name[0...-2].push(:codecs, codec.id))
+    metric
+  end
+
   def execution_context=(context)
     super
     # There is no easy way to propage an instance variable into the codec, because the codec

--- a/logstash-core/lib/logstash/outputs/base.rb
+++ b/logstash-core/lib/logstash/outputs/base.rb
@@ -102,6 +102,13 @@ class LogStash::Outputs::Base < LogStash::Plugin
     self.class.concurrency
   end
 
+  def metric=(metric)
+    super
+    # Hack to create a new metric namespace using 'plugins' as the root
+    @codec.metric = metric.root.namespace(metric.namespace_name[0...-2].push(:codecs, codec.id))
+    metric
+  end
+
   def execution_context=(context)
     super
     # There is no easy way to propage an instance variable into the codec, because the codec

--- a/logstash-core/spec/logstash/codecs/delegator_spec.rb
+++ b/logstash-core/spec/logstash/codecs/delegator_spec.rb
@@ -1,0 +1,85 @@
+# encoding: utf-8
+require "spec_helper"
+
+class LogStash::Codecs::MockCodec < LogStash::Codecs::Base
+  config_name "my_name"
+
+  def multi_encode(e)
+  end
+
+  def encode(e)
+  end
+
+  def decode(e)
+    for i in e.split('|')
+      yield i
+    end
+  end
+end
+
+describe LogStash::Codecs::Delegator do
+  let(:collector)   { LogStash::Instrument::Collector.new }
+  let(:metric) { LogStash::Instrument::Metric.new(collector) }
+  let(:codec) { LogStash::Codecs::MockCodec.new }
+
+  subject do
+    delegator = described_class.new(codec)
+    delegator.metric = metric.namespace([:stats, :pipelines, :main, :plugins, :codecs, :my_id])
+    delegator
+  end
+
+  let(:snapshot_store) { collector.snapshot_metric.metric_store }
+
+  let(:snapshot_metric) { snapshot_store.get_shallow(:stats) }
+
+  describe "#encode" do
+    it "should delegate call to codec" do
+      expect(codec).to receive(:encode).with("abcdef")
+      subject.encode("abcdef")
+    end
+
+    it "should increment metrics" do
+      subject.encode("test")
+      expect(snapshot_metric[:pipelines][:main][:plugins][:codecs][:my_id][:encode][:writes_in].value).to eq(1)
+    end
+  end
+
+  describe "#multi_encode" do
+    it "should delegate call to codec" do
+      expect(codec).to receive(:multi_encode).with(%w(ay laa))
+      subject.multi_encode(%w(ay laa))
+    end
+
+    it "should increment metrics" do
+      subject.multi_encode(%w(ay test))
+      expect(snapshot_metric[:pipelines][:main][:plugins][:codecs][:my_id][:encode][:writes_in].value).to eq(2)
+    end
+  end
+
+  describe "#decode" do
+    it "should delegate call to codec" do
+      expect(codec).to receive(:decode).with("ayooooo")
+      subject.decode("ayooooo")
+    end
+
+    it "should increment metrics" do
+      subject.decode("bird|law") {}
+      expect(snapshot_metric[:pipelines][:main][:plugins][:codecs][:my_id][:decode][:writes_in].value).to eq(1)
+      expect(snapshot_metric[:pipelines][:main][:plugins][:codecs][:my_id][:decode][:out].value).to eq(2)
+    end
+  end
+
+  describe "#close" do
+    it "should delegate call to codec" do
+      expect(codec).to receive(:close)
+      subject.close
+    end
+  end
+
+  describe "#plugin_type" do
+    it "should delegate call to codec" do
+      expect(codec).to receive(:plugin_type)
+      subject.plugin_type
+    end
+  end
+end

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaCodecDelegator.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaCodecDelegator.java
@@ -1,0 +1,130 @@
+package org.logstash.config.ir.compiler;
+
+import co.elastic.logstash.api.Codec;
+import co.elastic.logstash.api.Event;
+import co.elastic.logstash.api.PluginConfigSpec;
+import org.jruby.RubySymbol;
+import org.jruby.runtime.ThreadContext;
+import org.logstash.RubyUtil;
+import org.logstash.instrument.metrics.AbstractNamespacedMetricExt;
+import org.logstash.instrument.metrics.MetricKeys;
+import org.logstash.instrument.metrics.counter.LongCounter;
+
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+public class JavaCodecDelegator implements Codec {
+
+    public static final RubySymbol ENCODE_KEY = RubyUtil.RUBY.newSymbol("encode");
+    public static final RubySymbol DECODE_KEY = RubyUtil.RUBY.newSymbol("decode");
+    public static final RubySymbol IN_KEY = RubyUtil.RUBY.newSymbol("writes_in");
+
+    private final String configName;
+
+    private final String id;
+
+    private final Codec codec;
+
+    protected final AbstractNamespacedMetricExt metricEncode;
+
+    protected final AbstractNamespacedMetricExt metricDecode;
+
+    protected final LongCounter encodeMetricIn;
+
+    protected final LongCounter encodeMetricTime;
+
+    protected final LongCounter decodeMetricIn;
+
+    protected final LongCounter decodeMetricOut;
+
+    protected final LongCounter decodeMetricTime;
+
+
+    public JavaCodecDelegator(final String configName, final String id,
+                               final AbstractNamespacedMetricExt metric,
+                               final Codec codec) {
+        this.configName = configName;
+        this.id = id;
+        this.codec = codec;
+
+        final ThreadContext context = RubyUtil.RUBY.getCurrentContext();
+        final AbstractNamespacedMetricExt namespacedMetric =
+            metric.namespace(context, RubyUtil.RUBY.newSymbol(codec.getId()));
+        synchronized(namespacedMetric.getMetric()) {
+            metricEncode = namespacedMetric.namespace(context, ENCODE_KEY);
+            encodeMetricIn = LongCounter.fromRubyBase(metricEncode, IN_KEY);
+            encodeMetricTime = LongCounter.fromRubyBase(metricEncode, MetricKeys.DURATION_IN_MILLIS_KEY);
+
+            metricDecode = namespacedMetric.namespace(context, DECODE_KEY);
+            decodeMetricIn = LongCounter.fromRubyBase(metricDecode, IN_KEY);
+            decodeMetricOut = LongCounter.fromRubyBase(metricDecode, MetricKeys.OUT_KEY);
+            decodeMetricTime = LongCounter.fromRubyBase(metricDecode, MetricKeys.DURATION_IN_MILLIS_KEY);
+
+            namespacedMetric.gauge(context, MetricKeys.NAME_KEY, RubyUtil.RUBY.newString(configName));
+        }
+    }
+
+    @Override
+    public void decode(final ByteBuffer buffer, final Consumer<Map<String, Object>> eventConsumer) {
+        decodeMetricIn.increment();
+
+        final long start = System.nanoTime();
+
+        codec.decode(buffer, (event) -> {
+            decodeMetricOut.increment();
+            eventConsumer.accept(event);
+        });
+
+        decodeMetricTime.increment(TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS));
+    }
+
+    @Override
+    public void flush(final ByteBuffer buffer, final Consumer<Map<String, Object>> eventConsumer) {
+        decodeMetricIn.increment();
+
+        final long start = System.nanoTime();
+
+        codec.flush(buffer, (event) -> {
+            decodeMetricOut.increment();
+            eventConsumer.accept(event);
+        });
+
+        decodeMetricTime.increment(TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS));
+    }
+
+    @Override
+    public boolean encode(final Event event, final ByteBuffer buffer) throws EncodeException {
+        encodeMetricIn.increment();
+
+        final long start = System.nanoTime();
+
+        final boolean ret = codec.encode(event, buffer);
+
+        decodeMetricTime.increment(TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS));
+
+        return ret;
+    }
+
+    @Override
+    public Codec cloneCodec() {
+        return codec.cloneCodec();
+    }
+
+    @Override
+    public Collection<PluginConfigSpec<?>> configSchema() {
+        return codec.configSchema();
+    }
+
+    @Override
+    public String getName() {
+        return codec.getName();
+    }
+
+    @Override
+    public String getId() {
+        return codec.getId();
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaCodecDelegator.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaCodecDelegator.java
@@ -22,10 +22,6 @@ public class JavaCodecDelegator implements Codec {
     public static final RubySymbol DECODE_KEY = RubyUtil.RUBY.newSymbol("decode");
     public static final RubySymbol IN_KEY = RubyUtil.RUBY.newSymbol("writes_in");
 
-    private final String configName;
-
-    private final String id;
-
     private final Codec codec;
 
     protected final AbstractNamespacedMetricExt metricEncode;
@@ -43,11 +39,8 @@ public class JavaCodecDelegator implements Codec {
     protected final LongCounter decodeMetricTime;
 
 
-    public JavaCodecDelegator(final String configName, final String id,
-                               final AbstractNamespacedMetricExt metric,
+    public JavaCodecDelegator(final AbstractNamespacedMetricExt metric,
                                final Codec codec) {
-        this.configName = configName;
-        this.id = id;
         this.codec = codec;
 
         final ThreadContext context = RubyUtil.RUBY.getCurrentContext();
@@ -63,7 +56,7 @@ public class JavaCodecDelegator implements Codec {
             decodeMetricOut = LongCounter.fromRubyBase(metricDecode, MetricKeys.OUT_KEY);
             decodeMetricTime = LongCounter.fromRubyBase(metricDecode, MetricKeys.DURATION_IN_MILLIS_KEY);
 
-            namespacedMetric.gauge(context, MetricKeys.NAME_KEY, RubyUtil.RUBY.newString(configName));
+            namespacedMetric.gauge(context, MetricKeys.NAME_KEY, RubyUtil.RUBY.newString(codec.getName()));
         }
     }
 

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractNamespacedMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractNamespacedMetricExt.java
@@ -56,6 +56,11 @@ public abstract class AbstractNamespacedMetricExt extends AbstractMetricExt {
         return getNamespaceName(context);
     }
 
+    @JRubyMethod(name = "root")
+    public AbstractMetricExt root(final ThreadContext context) {
+        return getMetric();
+    }
+
     protected abstract IRubyObject getGauge(ThreadContext context, IRubyObject key,
         IRubyObject value);
 

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
@@ -26,6 +26,7 @@ import org.logstash.config.ir.PipelineIR;
 import org.logstash.config.ir.compiler.AbstractFilterDelegatorExt;
 import org.logstash.config.ir.compiler.AbstractOutputDelegatorExt;
 import org.logstash.config.ir.compiler.FilterDelegatorExt;
+import org.logstash.config.ir.compiler.JavaCodecDelegator;
 import org.logstash.config.ir.compiler.JavaFilterDelegatorExt;
 import org.logstash.config.ir.compiler.JavaInputDelegatorExt;
 import org.logstash.config.ir.compiler.JavaOutputDelegatorExt;
@@ -338,7 +339,7 @@ public final class PluginFactoryExt {
                     }
 
                     if (codec != null) {
-                        return JavaUtil.convertJavaToRuby(RubyUtil.RUBY, codec);
+                        return JavaUtil.convertJavaToRuby(RubyUtil.RUBY, new JavaCodecDelegator(name, id, typeScopedMetric, codec));
                     } else {
                         throw new IllegalStateException("Unable to instantiate codec: " + pluginClass);
                     }

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
@@ -339,7 +339,7 @@ public final class PluginFactoryExt {
                     }
 
                     if (codec != null) {
-                        return JavaUtil.convertJavaToRuby(RubyUtil.RUBY, new JavaCodecDelegator(name, id, typeScopedMetric, codec));
+                        return JavaUtil.convertJavaToRuby(RubyUtil.RUBY, new JavaCodecDelegator(typeScopedMetric, codec));
                     } else {
                         throw new IllegalStateException("Unable to instantiate codec: " + pluginClass);
                     }

--- a/logstash-core/src/test/java/org/logstash/config/ir/RubyEnvTestCase.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/RubyEnvTestCase.java
@@ -3,9 +3,12 @@ package org.logstash.config.ir;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.jruby.RubyHash;
+import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.load.LoadService;
 import org.junit.BeforeClass;
 import org.logstash.RubyUtil;
+
+import static org.logstash.RubyUtil.RUBY;
 
 public abstract class RubyEnvTestCase {
 

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/JavaCodecDelegatorTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/JavaCodecDelegatorTest.java
@@ -1,0 +1,243 @@
+package org.logstash.config.ir.compiler;
+
+import co.elastic.logstash.api.Codec;
+import co.elastic.logstash.api.Event;
+import co.elastic.logstash.api.PluginConfigSpec;
+import com.google.common.collect.ImmutableMap;
+import org.jruby.RubyHash;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
+
+public class JavaCodecDelegatorTest extends PluginDelegatorTestCase {
+    private Codec codec;
+
+    @Before
+    public void setup() {
+        this.codec = Mockito.mock(AbstractCodec.class);
+        Mockito.when(this.codec.getId()).thenCallRealMethod();
+        Mockito.when(this.codec.getName()).thenCallRealMethod();
+
+        super.setup();
+    }
+
+    @Override
+    protected String getBaseMetricsPath() {
+        return "codec/foo";
+    }
+
+    @Test
+    public void plainCodecDelegatorInitializesCleanly() {
+        constructCodecDelegator();
+    }
+
+    @Test
+    public void plainCodecPluginPushesPluginNameToMetric() {
+        constructCodecDelegator();
+        final RubyHash metricStore = getMetricStore(new String[]{"codec", "foo"});
+        final String pluginName = getMetricStringValue(metricStore, "name");
+
+        assertEquals(codec.getName(), pluginName);
+    }
+
+    @Test
+    public void delegatesClone() {
+        final JavaCodecDelegator codecDelegator = constructCodecDelegator();
+        codecDelegator.cloneCodec();
+        Mockito.verify(codec, Mockito.times(1)).cloneCodec();
+    }
+
+    @Test
+    public void delegatesConfigSchema() {
+        final JavaCodecDelegator codecDelegator = constructCodecDelegator();
+        codecDelegator.configSchema();
+        Mockito.verify(codec, Mockito.times(1)).configSchema();
+    }
+
+    @Test
+    public void delegatesGetName() {
+        Mockito.when(codec.getName()).thenReturn("MyLogstashPluginName");
+        final JavaCodecDelegator codecDelegator = constructCodecDelegator();
+        assertEquals("MyLogstashPluginName", codecDelegator.getName());
+    }
+
+    @Test
+    public void delegatesGetId() {
+        Mockito.when(codec.getId()).thenReturn("MyLogstashPluginId");
+        final JavaCodecDelegator codecDelegator = constructCodecDelegator();
+        assertEquals("MyLogstashPluginId", codecDelegator.getId());
+    }
+
+    @Test
+    public void decodeDelegatesCall() {
+        final Map<String, Object> ret = ImmutableMap.of("message", "abcdef");
+
+        codec = Mockito.spy(new AbstractCodec() {
+            @Override
+            public void decode(final ByteBuffer buffer, final Consumer<Map<String, Object>> eventConsumer) {
+                eventConsumer.accept(ret);
+            }
+        });
+
+        final JavaCodecDelegator codecDelegator = constructCodecDelegator();
+
+        final ByteBuffer buf = ByteBuffer.wrap(new byte[] {1, 2, 3});
+        @SuppressWarnings("unchecked")
+        final Consumer<Map<String, Object>> consumer = (Consumer<Map<String, Object>>) Mockito.mock(Consumer.class);
+
+        codecDelegator.decode(buf, consumer);
+
+        Mockito.verify(codec, Mockito.times(1)).decode(Mockito.eq(buf), Mockito.any());
+        Mockito.verify(consumer, Mockito.times(1)).accept(ret);
+    }
+
+    @Test
+    public void decodeIncrementsEventCount() {
+        codec = new AbstractCodec() {
+            @Override
+            public void decode(final ByteBuffer buffer, final Consumer<Map<String, Object>> eventConsumer) {
+                eventConsumer.accept(ImmutableMap.of("message", "abcdef"));
+                eventConsumer.accept(ImmutableMap.of("message", "1234567"));
+            }
+        };
+
+        final JavaCodecDelegator codecDelegator = constructCodecDelegator();
+
+        codecDelegator.decode(ByteBuffer.wrap(new byte[] {1, 2, 3}), (e) -> {});
+
+        assertEquals(1, getMetricLongValue("decode", "writes_in"));
+        assertEquals(2, getMetricLongValue("decode", "out"));
+    }
+
+    @Test
+    public void flushDelegatesCall() {
+        final Map<String, Object> ret = ImmutableMap.of("message", "abcdef");
+
+        codec = Mockito.spy(new AbstractCodec() {
+            @Override
+            public void flush(final ByteBuffer buffer, final Consumer<Map<String, Object>> eventConsumer) {
+                eventConsumer.accept(ret);
+            }
+        });
+
+        final JavaCodecDelegator codecDelegator = constructCodecDelegator();
+
+        final ByteBuffer buf = ByteBuffer.wrap(new byte[] {1, 2, 3});
+        @SuppressWarnings("unchecked")
+        final Consumer<Map<String, Object>> consumer = (Consumer<Map<String, Object>>) Mockito.mock(Consumer.class);
+
+        codecDelegator.flush(buf, consumer);
+
+        Mockito.verify(codec, Mockito.times(1)).flush(Mockito.eq(buf), Mockito.any());
+        Mockito.verify(consumer, Mockito.times(1)).accept(ret);
+    }
+
+    @Test
+    public void flushIncrementsEventCount() {
+        codec = new AbstractCodec() {
+            @Override
+            public void flush(final ByteBuffer buffer, final Consumer<Map<String, Object>> eventConsumer) {
+                eventConsumer.accept(ImmutableMap.of("message", "abcdef"));
+                eventConsumer.accept(ImmutableMap.of("message", "1234567"));
+            }
+        };
+
+        final JavaCodecDelegator codecDelegator = constructCodecDelegator();
+
+        codecDelegator.flush(ByteBuffer.wrap(new byte[] {1, 2, 3}), (e) -> {});
+
+        assertEquals(1, getMetricLongValue("decode", "writes_in"));
+        assertEquals(2, getMetricLongValue("decode", "out"));
+    }
+
+    @Test
+    public void encodeDelegatesCall() throws Codec.EncodeException {
+        codec = Mockito.spy(new AbstractCodec() {
+            @Override
+            public boolean encode(final Event event, final ByteBuffer buffer) {
+                return true;
+            }
+        });
+
+        final JavaCodecDelegator codecDelegator = constructCodecDelegator();
+
+        final Event e = new org.logstash.Event();
+        final ByteBuffer b = ByteBuffer.wrap(new byte[] {});
+
+        codecDelegator.encode(e, b);
+
+        Mockito.verify(codec, Mockito.times(1)).encode(e, b);
+    }
+
+    @Test
+    public void encodeIncrementsEventCount() throws Codec.EncodeException {
+        codec = new AbstractCodec() {
+            @Override
+            public boolean encode(final Event event, final ByteBuffer buffer) {
+                return true;
+            }
+        };
+
+        final JavaCodecDelegator codecDelegator = constructCodecDelegator();
+
+        codecDelegator.encode(new org.logstash.Event(), ByteBuffer.wrap(new byte[] {}));
+
+        assertEquals(1, getMetricLongValue("encode", "writes_in"));
+    }
+
+    private RubyHash getMetricStore(final String type) {
+        return getMetricStore(new String[]{"codec", "foo", type});
+    }
+
+    private long getMetricLongValue(final String type, final String symbolName) {
+        return getMetricLongValue(getMetricStore(type), symbolName);
+    }
+
+    private JavaCodecDelegator constructCodecDelegator() {
+        return new JavaCodecDelegator(metric, codec);
+    }
+
+    private abstract class AbstractCodec implements Codec {
+        @Override
+        public void decode(final ByteBuffer buffer, final Consumer<Map<String, Object>> eventConsumer) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void flush(final ByteBuffer buffer, final Consumer<Map<String, Object>> eventConsumer) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean encode(final Event event, final ByteBuffer buffer) throws EncodeException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Codec cloneCodec() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Collection<PluginConfigSpec<?>> configSchema() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getId() {
+            return "foo";
+        }
+
+        @Override
+        public String getName() {
+            return "bar";
+        }
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/OutputDelegatorTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/OutputDelegatorTest.java
@@ -4,33 +4,23 @@ import javax.annotation.concurrent.NotThreadSafe;
 import org.assertj.core.data.Percentage;
 import org.jruby.RubyArray;
 import org.jruby.RubyClass;
-import org.jruby.RubyFixnum;
 import org.jruby.RubyHash;
-import org.jruby.RubyString;
 import org.jruby.RubySymbol;
-import org.jruby.java.proxies.ConcreteJavaProxy;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.logstash.Event;
-import org.logstash.config.ir.RubyEnvTestCase;
-import org.logstash.execution.ExecutionContextExt;
-import org.logstash.instrument.metrics.NamespacedMetricExt;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.logstash.RubyUtil.EXECUTION_CONTEXT_CLASS;
-import static org.logstash.RubyUtil.NAMESPACED_METRIC_CLASS;
 import static org.logstash.RubyUtil.RUBY;
 import static org.logstash.RubyUtil.RUBY_OUTPUT_DELEGATOR_CLASS;
 
 @SuppressWarnings("rawtypes")
 @NotThreadSafe
-public class OutputDelegatorTest extends RubyEnvTestCase {
+public class OutputDelegatorTest extends PluginDelegatorTestCase {
 
-    private NamespacedMetricExt metric;
-    private ExecutionContextExt executionContext;
     private RubyHash pluginArgs;
     private RubyArray events;
     private static final int EVENT_COUNT = 7;
@@ -43,23 +33,19 @@ public class OutputDelegatorTest extends RubyEnvTestCase {
 
     @Before
     public void setup() {
+        super.setup();
         events = RUBY.newArray(EVENT_COUNT);
         for (int k = 0; k < EVENT_COUNT; k++) {
             events.add(k, new Event());
         }
-        final ThreadContext context = RUBY.getCurrentContext();
-        RubyArray namespaces = RubyArray.newArray(RUBY, 1);
-        namespaces.add(0, RubySymbol.newSymbol(RUBY, "output"));
-        IRubyObject metricWithCollector =
-                runRubyScript("require \"logstash/instrument/collector\"\n" +
-                        "metricWithCollector = LogStash::Instrument::Metric.new(LogStash::Instrument::Collector.new)");
-
-        metric = new NamespacedMetricExt(RUBY, NAMESPACED_METRIC_CLASS)
-                .initialize(context, metricWithCollector, namespaces);
-        executionContext = new ExecutionContextExt(RUBY, EXECUTION_CONTEXT_CLASS);
         pluginArgs = RubyHash.newHash(RUBY);
         pluginArgs.put("id", "foo");
         pluginArgs.put("arg1", "val1");
+    }
+
+    @Override
+    protected String getBaseMetricsPath() {
+        return "output/foo";
     }
 
     @Test
@@ -183,11 +169,6 @@ public class OutputDelegatorTest extends RubyEnvTestCase {
 
     }
 
-    private static IRubyObject runRubyScript(String script) {
-        IRubyObject m = RUBY.evalScriptlet(script);
-        return m;
-    }
-
     private OutputDelegatorExt constructOutputDelegator() {
         return new OutputDelegatorExt(RUBY, RUBY_OUTPUT_DELEGATOR_CLASS).initialize(RUBY.getCurrentContext(), new IRubyObject[]{
             FAKE_OUT_CLASS,
@@ -202,33 +183,8 @@ public class OutputDelegatorTest extends RubyEnvTestCase {
         return getMetricStore(new String[]{"output", "foo", "events"});
     }
 
-    private RubyHash getMetricStore(String[] path) {
-        RubyHash metricStore = (RubyHash) metric.collector(RUBY.getCurrentContext())
-                .callMethod(RUBY.getCurrentContext(), "snapshot_metric")
-                .callMethod(RUBY.getCurrentContext(), "metric_store")
-                .callMethod(RUBY.getCurrentContext(), "get_with_path", new IRubyObject[]{RUBY.newString("output/foo")});
-
-        RubyHash rh = metricStore;
-        for (String p : path) {
-            rh = (RubyHash) rh.op_aref(RUBY.getCurrentContext(), RUBY.newSymbol(p));
-        }
-        return rh;
-    }
-
-    private String getMetricStringValue(RubyHash metricStore, String symbolName) {
-        ConcreteJavaProxy counter = (ConcreteJavaProxy) metricStore.op_aref(RUBY.getCurrentContext(), RUBY.newSymbol(symbolName));
-        RubyString value = (RubyString) counter.callMethod("value");
-        return value.asJavaString();
-    }
-
     private long getMetricLongValue(String symbolName) {
         return getMetricLongValue(getMetricStore(), symbolName);
-    }
-
-    private long getMetricLongValue(RubyHash metricStore, String symbolName) {
-        ConcreteJavaProxy counter = (ConcreteJavaProxy) metricStore.op_aref(RUBY.getCurrentContext(), RUBY.newSymbol(symbolName));
-        RubyFixnum count = (RubyFixnum) counter.callMethod("value");
-        return count.getLongValue();
     }
 
     private static class StrategyPair {

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/PluginDelegatorTestCase.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/PluginDelegatorTestCase.java
@@ -1,0 +1,71 @@
+package org.logstash.config.ir.compiler;
+
+import org.jruby.RubyArray;
+import org.jruby.RubyFixnum;
+import org.jruby.RubyHash;
+import org.jruby.RubyString;
+import org.jruby.RubySymbol;
+import org.jruby.java.proxies.ConcreteJavaProxy;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.junit.Before;
+import org.logstash.config.ir.RubyEnvTestCase;
+import org.logstash.execution.ExecutionContextExt;
+import org.logstash.instrument.metrics.AbstractNamespacedMetricExt;
+import org.logstash.instrument.metrics.NamespacedMetricExt;
+
+import static org.logstash.RubyUtil.EXECUTION_CONTEXT_CLASS;
+import static org.logstash.RubyUtil.NAMESPACED_METRIC_CLASS;
+import static org.logstash.RubyUtil.RUBY;
+
+public abstract class PluginDelegatorTestCase extends RubyEnvTestCase {
+    protected AbstractNamespacedMetricExt metric;
+    protected ExecutionContextExt executionContext;
+
+    @Before
+    public void setup() {
+        final ThreadContext context = RUBY.getCurrentContext();
+        @SuppressWarnings("rawtypes")
+        final RubyArray namespaces = RubyArray.newArray(RUBY, 1);
+        namespaces.add(0, RubySymbol.newSymbol(RUBY, getBaseMetricsPath().split("/")[0]));
+        IRubyObject metricWithCollector =
+            runRubyScript("require \"logstash/instrument/collector\"\n" +
+                              "metricWithCollector = LogStash::Instrument::Metric.new(LogStash::Instrument::Collector.new)");
+
+        metric = new NamespacedMetricExt(RUBY, NAMESPACED_METRIC_CLASS)
+            .initialize(context, metricWithCollector, namespaces);
+        executionContext = new ExecutionContextExt(RUBY, EXECUTION_CONTEXT_CLASS);
+    }
+
+    protected static IRubyObject runRubyScript(String script) {
+        IRubyObject m = RUBY.evalScriptlet(script);
+        return m;
+    }
+
+    protected RubyHash getMetricStore(String[] path) {
+        RubyHash metricStore = (RubyHash) metric.collector(RUBY.getCurrentContext())
+            .callMethod(RUBY.getCurrentContext(), "snapshot_metric")
+            .callMethod(RUBY.getCurrentContext(), "metric_store")
+            .callMethod(RUBY.getCurrentContext(), "get_with_path", new IRubyObject[]{RUBY.newString(getBaseMetricsPath())});
+
+        RubyHash rh = metricStore;
+        for (String p : path) {
+            rh = (RubyHash) rh.op_aref(RUBY.getCurrentContext(), RUBY.newSymbol(p));
+        }
+        return rh;
+    }
+
+    protected abstract String getBaseMetricsPath();
+
+    protected String getMetricStringValue(RubyHash metricStore, String symbolName) {
+        ConcreteJavaProxy counter = (ConcreteJavaProxy) metricStore.op_aref(RUBY.getCurrentContext(), RUBY.newSymbol(symbolName));
+        RubyString value = (RubyString) counter.callMethod("value");
+        return value.asJavaString();
+    }
+
+    protected long getMetricLongValue(RubyHash metricStore, String symbolName) {
+        ConcreteJavaProxy counter = (ConcreteJavaProxy) metricStore.op_aref(RUBY.getCurrentContext(), RUBY.newSymbol(symbolName));
+        RubyFixnum count = (RubyFixnum) counter.callMethod("value");
+        return count.getLongValue();
+    }
+}

--- a/x-pack/spec/monitoring/inputs/metrics_spec.rb
+++ b/x-pack/spec/monitoring/inputs/metrics_spec.rb
@@ -81,7 +81,7 @@ describe LogStash::Inputs::Metrics do
 
         wait(60).for { agent.get_pipeline(:main) }.to_not be_nil
 
-        metrics_input.metric = agent.metric
+        metrics_input.metric = agent.metric.namespace(:test)
 
         metrics_input.register
         metrics_input.run(queue)


### PR DESCRIPTION
Resolves #10607. Provides a means of monitoring codec metrics via the monitoring APIs.

Codec metrics are currently in the following format:

```json
{
  "plugins": {
    "codecs": [
      {
        "id": "f0fc8b52-e61e-43f0-87d3-8d4882cd5eb3",
        "encode": {
          "writes_in": 0,
          "duration_in_millis": 0
        },
        "decode": {
          "writes_in": 1,
          "out": 1,
          "duration_in_millis": 9
        },
        "name": "java_line"
      },
      {
        "id": "rubydebug_c8d305dc-505e-40ac-825e-956c9c899201",
        "encode": {
          "writes_in": 1,
          "duration_in_millis": 221
        },
        "decode": {
          "writes_in": 0,
          "out": 0,
          "duration_in_millis": 0
        },
        "name": "rubydebug"
      }
    ]
  }
}
```

Please let me know if you'd prefer a different schema.