### PR TITLE
Handle duplicate config entries

### DIFF
--- a/logstash-core/lib/logstash/compiler/lscl.rb
+++ b/logstash-core/lib/logstash/compiler/lscl.rb
@@ -115,7 +115,7 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
         elsif existing.kind_of?(::Array)
           hash[k] = existing.push(*v)
         else
-          hash[k] = existing + v
+          hash[k] = [existing, v] unless v == existing
         end
         hash
       end


### PR DESCRIPTION
This resolves an error that was observed in Java execution when an input was incorrectly configured as such:

```
input {
  kafka {
    auto_offset_reset => latest
    group_id => ....
    ...
    auto_offset_reset => latest
  }
}
```
Note the duplicate `auto_offset_reset` entries. The values for the duplicate entries were being concatenated into a nonsensical value of `latestlatest` which was rejected by the input. With Ruby execution, the duplicate config values are merged into an array if they are not duplicates. This PR duplicates that behavior in Java execution in code that is common to both engines.

Fixes #10615.
