### PR TITLE
Log successful shutdowns

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -369,6 +369,8 @@ class LogStash::Runner < Clamp::StrictCommand
 
     @agent.shutdown
 
+    logger.info("Logstash shut down.")
+
     # flush any outstanding log messages during shutdown
     org.apache.logging.log4j.LogManager.shutdown
 


### PR DESCRIPTION
When troubleshooting various Logstash issues, it would be helpful in the logs contained entries for the intentional, successful shutdown of Logstash. Since shutdowns are infrequent, this will add negligible logging volume.
