### PR TITLE
remove docker-compose symlink

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,1 +1,0 @@
-docker-compose-full.yml


### PR DESCRIPTION
symlink `docker/docker-compose.yml` is created during the docker image building so it should not be present in git