### PR TITLE
prevent DeprecatedRemovedSetting from fatally stopping logstash

### DIFF
--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -598,7 +598,7 @@ module LogStash
       end
 
       def set(value)
-        fail(RuntimeError, "The setting `#{name}` has been deprecated and removed from Logstash; #{@guidance}")
+        fail(ArgumentError, "The setting `#{name}` has been deprecated and removed from Logstash; #{@guidance}")
       end
     end
 

--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -600,10 +600,6 @@ module LogStash
       def set(value)
         fail(RuntimeError, "The setting `#{name}` has been deprecated and removed from Logstash; #{@guidance}")
       end
-
-      def value
-        fail(ArgumentError, "The setting `#{name}` has been deprecated and removed from Logstash")
-      end
     end
 
     # Useful when a setting has been renamed but otherwise is semantically identical

--- a/logstash-core/spec/logstash/settings/deprecated_and_renamed_spec.rb
+++ b/logstash-core/spec/logstash/settings/deprecated_and_renamed_spec.rb
@@ -16,15 +16,4 @@ describe LogStash::Setting::DeprecatedAndRenamed do
       end
     end
   end
-
-  describe '#value' do
-    it 'fails with deprecation argument error' do
-      expect { setting.value }.to raise_exception do |exception|
-        expect(exception).to be_a_kind_of(ArgumentError)
-        expect(exception.message).to match(/deprecated and removed/)
-        expect(exception.message).to include("option.deprecated")
-      end
-    end
-  end
-
 end

--- a/logstash-core/spec/logstash/settings/deprecated_and_renamed_spec.rb
+++ b/logstash-core/spec/logstash/settings/deprecated_and_renamed_spec.rb
@@ -9,7 +9,7 @@ describe LogStash::Setting::DeprecatedAndRenamed do
   describe '#set' do
     it 'fails with deprecation runtime error and helpful guidance' do
       expect { setting.set(value) }.to raise_exception do |exception|
-        expect(exception).to be_a_kind_of(RuntimeError)
+        expect(exception).to be_a_kind_of(ArgumentError)
         expect(exception.message).to match(/deprecated and removed/)
         expect(exception.message).to include("option.deprecated")
         expect(exception.message).to include("option.current")


### PR DESCRIPTION
We should only throw an error if the value is set. By also failing on `value` logstash terminates at startup even if the setting isn't set:

```
% bin/logstash -e ""
Sending Logstash logs to /Users/joaoduarte/elastic/logstash/logs which is now configured via log4j2.properties
[2019-04-05T10:01:43,198][FATAL][logstash.runner          ] An unexpected error occurred! {:error=>#<ArgumentError: The setting `xpack.management.elasticsearch.url` has been deprecated and removed from Logstash>, :backtrace=>["/Users/joaoduarte/elastic/logstash/logstash-core/lib/logstash/settings.rb:605:in `value'", "/Users/joaoduarte/elastic/logstash/logstash-core/lib/logstash/settings.rb:96:in `block in format_settings'", "org/jruby/RubyHash.java:1419:in `each'", "/Users/joaoduarte/elastic/logstash/logstash-core/lib/logstash/settings.rb:95:in `format_settings'", "/Users/joaoduarte/elastic/logstash/logstash-core/lib/logstash/runner.rb:302:in `execute'", "/Users/joaoduarte/elastic/logstash/vendor/bundle/jruby/2.5.0/gems/clamp-0.6.5/lib/clamp/command.rb:67:in `run'", "/Users/joaoduarte/elastic/logstash/logstash-core/lib/logstash/runner.rb:237:in `run'", "/Users/joaoduarte/elastic/logstash/vendor/bundle/jruby/2.5.0/gems/clamp-0.6.5/lib/clamp/command.rb:132:in `run'", "/Users/joaoduarte/elastic/logstash/lib/bootstrap/environment.rb:73:in `<main>'"]}
[2019-04-05T10:01:43,212][ERROR][org.logstash.Logstash    ] java.lang.IllegalStateException: Logstash stopped processing because of an error: (SystemExit) exit
```

With this PR logstash starts correctly, unless `xpack.management.elasticsearch.url` is set:

```
% bin/logstash -e ""
ERROR: Failed to load settings file from "path.settings". Aborting... path.setting=/Users/joaoduarte/elastic/logstash/config, exception=RuntimeError, message=>The setting `xpack.monitoring.elasticsearch.url` has been deprecated and removed from Logstash; please update your configuration to use `xpack.monitoring.elasticsearch.hosts` instead.
[ERROR] 2019-04-05 10:05:32.193 [main] Logstash - java.lang.IllegalStateException: Logstash stopped processing because of an error: (SystemExit) exit
```

fixes #10656 