### PR TITLE
download exact version artifact for release build otherwise download snapshot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,9 @@ def versionQualifier = System.getenv('VERSION_QUALIFIER')
 if (versionQualifier) {
     version = "$version-$versionQualifier"
 }
+// a release build will try to download the exact version artifact and not append -SNAPSHOT to it see
+// the downloadEs task below
+def isReleaseBuild = System.getenv('RELEASE') == "1" || versionQualifier
 
 // Tasks
 
@@ -330,7 +333,7 @@ task downloadEs(type: Download) {
 
     doFirst {
         if (!project.ext.versionFound) {
-            throw new GradleException("could not find the current artifact from the artifact-api ${artifactsVersionApi} for version: ${version}")
+            throw new GradleException("could not find the current artifact from the artifact-api ${artifactsVersionApi} for " + (isReleaseBuild ? "release" : "snapshot") + " version: ${version}")
         }
     }
 
@@ -340,7 +343,9 @@ task downloadEs(type: Download) {
     // in the normal PR type builds it is plain '7.0.0'
     // in the build invoked by the release manager it is '7.0.0-alpha1' etc.
     // the artifacts-api will return JSON like this: `{"versions":["5.6.13-SNAPSHOT","6.4.3-SNAPSHOT","6.5.0-SNAPSHOT","6.6.0-SNAPSHOT","7.0.0-alpha1-SNAPSHOT"]}`
-    String qualifiedVersion = dlVersions['versions'].grep(~/^${version}.*/)[0]
+    
+    String qualifiedVersion = dlVersions['versions'].grep(isReleaseBuild ? ~/^${version}$/ : ~/^${version}-SNAPSHOT/)[0]
+
     if (qualifiedVersion == null) {
         // the version is not found in the versions API, for now just set dummy values so the
         // task parameters like src and dest below sees these dummy values but also set


### PR DESCRIPTION
when  `RELEASE=1` or  `VERSION_QUALIFIER` is set, assume this is a release build and the exact version match ES artifact will be downloaded, otherwise download a `-SNAPSHOT` artifact.
