### PR TITLE
Fix default codec and buffer handling in Java stdout output

### DIFF
--- a/logstash-core/src/main/java/org/logstash/plugins/outputs/Stdout.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/outputs/Stdout.java
@@ -20,7 +20,7 @@ import java.util.concurrent.CountDownLatch;
 public class Stdout implements Output {
 
     public static final PluginConfigSpec<Codec> CODEC_CONFIG =
-            PluginConfigSpec.codecSetting("codec", "java-line");
+            PluginConfigSpec.codecSetting("codec", "java_line");
 
     private Codec codec;
     private OutputStream outputStream;
@@ -57,7 +57,7 @@ public class Stdout implements Output {
                 do {
                     encodeCompleted = codec.encode(e, encodeBuffer);
                     outputStream.write(encodeBuffer.array(), encodeBuffer.position(), encodeBuffer.limit());
-                    encodeBuffer.flip();
+                    encodeBuffer.clear();
                 }
                 while (!encodeCompleted);
             }


### PR DESCRIPTION
Correctly sets the default codec to `java_line`. Fixes buffer handling for events whose encodings do not fit into the buffer.