### PR TITLE
update the filebeat.yml sample code

### DIFF
--- a/docs/static/advanced-pipeline.asciidoc
+++ b/docs/static/advanced-pipeline.asciidoc
@@ -40,7 +40,7 @@ directory, and replace the contents with the following lines. Make sure `paths` 
 
 [source,yaml]
 --------------------------------------------------------------------------------
-filebeat.prospectors:
+filebeat.inputs:
 - type: log
   paths:
     - /path/to/file/logstash-tutorial.log <1>


### PR DESCRIPTION
filebeat.prospectors has been removed in the latest filebeat version (7.x)