### PR TITLE
properly exclude bundler 1.16.6 during jruby installation

### DIFF
--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -237,7 +237,7 @@ task downloadAndInstallJRuby(dependsOn: [verifyFile, installCustomJRuby], type: 
     exclude "**/stdlib/rdoc/**"
     exclude "**/stdlib/bundler/**"
     exclude "**/stdlib/bundler.rb"
-    exclude "**/bundler-1.16.6/*"
+    exclude "**/bundler-1.16.6/**"
     exclude "**/bundler-1.16.6.*"
 
     includeEmptyDirs = false


### PR DESCRIPTION
before:
```
 % ./gradlew clean downloadAndInstallJRuby
...                                                                                                                                                                               
~/elastic/logstash % find vendor -name *bundler*
vendor/jruby/lib/ruby/stdlib/rubygems/bundler_version_finder.rb
vendor/jruby/lib/ruby/gems/shared/gems/bundler-1.16.6
vendor/jruby/lib/ruby/gems/shared/gems/bundler-1.16.6/lib/bundler.rb
vendor/jruby/lib/ruby/gems/shared/gems/bundler-1.16.6/lib/bundler
vendor/jruby/lib/ruby/gems/shared/gems/bundler-1.16.6/lib/bundler/templates/Executable.bundler
vendor/jruby/lib/ruby/gems/shared/gems/bundler-1.16.6/exe/bundler
```

after:

```
~/elastic/logstash % find vendor -name *bundler*
vendor/jruby/lib/ruby/stdlib/rubygems/bundler_version_finder.rb
```

This correctly excludes the bundler that ships with jruby 9.2.7.0 so that we can install 1.17