### PR TITLE
Adds LogStash::PluginMetadata for simple key/value plugin metadata

### DIFF
--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -313,9 +313,14 @@ module LogStash; class JavaPipeline < JavaBasePipeline
       # Assuming the failure that caused this exception is transient,
       # let's sleep for a bit and execute #run again
       sleep(1)
+      begin
+        plugin.do_close
+      rescue => close_exception
+        @logger.debug("Input plugin raised exception while closing, ignoring",
+                      default_logging_keys(:plugin => plugin.class.config_name, :exception => close_exception.message,
+                                           :backtrace => close_exception.backtrace))
+      end
       retry
-    ensure
-      plugin.do_close
     end
   end # def inputworker
 

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -442,9 +442,14 @@ module LogStash; class Pipeline < BasePipeline
       # Assuming the failure that caused this exception is transient,
       # let's sleep for a bit and execute #run again
       sleep(1)
+      begin
+        plugin.do_close
+      rescue => close_exception
+        @logger.debug("Input plugin raised exception while closing, ignoring",
+                      default_logging_keys(:plugin => plugin.class.config_name, :exception => close_exception.message,
+                                           :backtrace => close_exception.backtrace))
+      end
       retry
-    ensure
-      plugin.do_close
     end
   end # def inputworker
 

--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -3,6 +3,8 @@ require "logstash/config/mixin"
 require "concurrent"
 require "securerandom"
 
+require_relative 'plugin_metadata'
+
 class LogStash::Plugin
   include LogStash::Util::Loggable
 
@@ -135,5 +137,23 @@ class LogStash::Plugin
   def self.lookup(type, name)
     require "logstash/plugins/registry"
     LogStash::PLUGIN_REGISTRY.lookup_pipeline_plugin(type, name)
+  end
+
+  ##
+  # Returns this plugin's metadata key/value store.
+  #
+  # @see LogStash::PluginMetadata for restrictions and caveats.
+  # @since 7.1
+  #
+  # @usage:
+  # ~~~
+  # if defined?(plugin_metadata)
+  #   plugin_metadata.set(:foo, 'value')
+  # end
+  # ~~~
+  #
+  # @return [LogStash::PluginMetadata]
+  def plugin_metadata
+    LogStash::PluginMetadata.for_plugin(self.id)
   end
 end # class LogStash::Plugin

--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -72,7 +72,11 @@ class LogStash::Plugin
   # main task terminates
   def do_close
     @logger.debug("Closing", :plugin => self.class.name)
-    close
+    begin
+      close
+    ensure
+      LogStash::PluginMetadata.delete_for_plugin(self.id)
+    end
   end
 
   # Subclasses should implement this close method if you need to perform any

--- a/logstash-core/lib/logstash/plugin_metadata.rb
+++ b/logstash-core/lib/logstash/plugin_metadata.rb
@@ -21,13 +21,14 @@ module LogStash
   # that doesn't break when installed onto a Logstash that doesn't have those features, e.g.:
   #
   # ~~~
-  # if defined?(LogStash::PluginMetadata)
-  #   LogStash::PluginMetadata.set(id, :foo, bar)
-  # end
+  #
+  # plugin_metadata.set(:foo, bar) if defined?(plugin_metadata?)
+  #
   # ~~~
   #
   # @since 7.1
   class PluginMetadata
+
     Thread.exclusive do
       @registry = ThreadSafe::Cache.new unless defined?(@registry)
     end
@@ -53,6 +54,17 @@ module LogStash
       # @return [Boolean]
       def exists?(plugin_id)
         @registry.key?(plugin_id)
+      end
+
+      ##
+      # Deletes, and then clears the contents of an existing PluginMetadata object for the given plugin id if one exists
+      #
+      # @param plugin_id [String]
+      #
+      # @return [Boolean]
+      def delete_for_plugin(plugin_id)
+        old_registry = @registry.delete(plugin_id)
+        old_registry.clear unless old_registry.nil?
       end
 
       ##
@@ -103,6 +115,24 @@ module LogStash
     # @return [Boolean]: true if the plugin includes metadata for the key
     def set?(key)
       @datastore.key?(key)
+    end
+
+    ##
+    # Delete the metadata key for this plugin, returning the previous value (if any)
+    #
+    # @param key [Symbol]
+    #
+    # @return [Object]
+    def delete(key)
+      @datastore.delete(key)
+    end
+
+    ##
+    # Clear all metadata keys for this plugin
+    #
+    # @return [Object]
+    def clear
+      @datastore.clear
     end
   end
 end

--- a/logstash-core/lib/logstash/plugin_metadata.rb
+++ b/logstash-core/lib/logstash/plugin_metadata.rb
@@ -1,0 +1,108 @@
+# encoding: utf-8
+
+require 'thread_safe/cache'
+
+module LogStash
+  ##
+  # `PluginMetadata` provides a space to store key/value metadata about a plugin, typically metadata about
+  # external resources that can be gleaned during plugin registration.
+  #
+  # Data is persisted across pipeline reloads, and no effort is made to clean up metadata from pipelines
+  # that no longer exist after a pipeline reload.
+  #
+  #  - It MUST NOT be used to store processing state
+  #  - It SHOULD NOT be updated frequently.
+  #  - Individual metadata keys MUST be Symbols and SHOULD NOT be dynamically generated
+  #
+  # USAGE FROM PLUGINS
+  # ------------------
+  #
+  # Since we allow plugins to be updated, it is important to introduce bindings to new Logstash features in a way
+  # that doesn't break when installed onto a Logstash that doesn't have those features, e.g.:
+  #
+  # ~~~
+  # if defined?(LogStash::PluginMetadata)
+  #   LogStash::PluginMetadata.set(id, :foo, bar)
+  # end
+  # ~~~
+  #
+  # @since 7.1
+  class PluginMetadata
+    Thread.exclusive do
+      @registry = ThreadSafe::Cache.new unless defined?(@registry)
+    end
+
+    class << self
+      ##
+      # Get the PluginMetadata object corresponding to the given plugin id
+      #
+      # @param plugin_id [String]
+      #
+      # @return [PluginMetadata]: the metadata object for the provided `plugin_id`; if no
+      #                           metadata object exists, it will be created.
+      def for_plugin(plugin_id)
+        @registry.compute_if_absent(plugin_id) { PluginMetadata.new }
+      end
+
+      ##
+      # Determine if we have an existing PluginMetadata object for the given plugin id
+      # This allows us to avoid creating a metadata object if we don't already have one.
+      #
+      # @param plugin_id [String]
+      #
+      # @return [Boolean]
+      def exists?(plugin_id)
+        @registry.key?(plugin_id)
+      end
+
+      ##
+      # @api private
+      def reset!
+        @registry.clear
+      end
+    end
+
+    ##
+    # @see [LogStash::PluginMetadata#for_plugin(String)]
+    # @api private
+    def initialize
+      @datastore = ThreadSafe::Cache.new
+    end
+
+    ##
+    # Set the metadata key for this plugin, returning the previous value (if any)
+    #
+    # @param key [Symbol]
+    # @param value [Object]
+    #
+    # @return [Object]
+    def set(key, value)
+      if value.nil?
+        @datastore.delete(key)
+      else
+        @datastore.get_and_set(key, value)
+      end
+    end
+
+    ##
+    # Get the metadata value for the given key on this plugin
+    #
+    # @param key [Symbol]
+    #
+    # @return [Object]: the value object associated with the given key on this
+    #                   plugin, or nil if no value is associated
+    def get(key)
+      @datastore.get(key)
+    end
+
+    ##
+    # Determine whether specific key/value metadata exists for this plugin
+    #
+    # @param key [Symbol]: the key
+    #
+    # @return [Boolean]: true if the plugin includes metadata for the key
+    def set?(key)
+      @datastore.key?(key)
+    end
+  end
+end

--- a/logstash-core/lib/logstash/plugin_metadata.rb
+++ b/logstash-core/lib/logstash/plugin_metadata.rb
@@ -7,8 +7,7 @@ module LogStash
   # `PluginMetadata` provides a space to store key/value metadata about a plugin, typically metadata about
   # external resources that can be gleaned during plugin registration.
   #
-  # Data is persisted across pipeline reloads, and no effort is made to clean up metadata from pipelines
-  # that no longer exist after a pipeline reload.
+  # Data should not be persisted across pipeline reloads, and should be cleaned up after a pipeline reload
   #
   #  - It MUST NOT be used to store processing state
   #  - It SHOULD NOT be updated frequently.
@@ -28,6 +27,7 @@ module LogStash
   #
   # @since 7.1
   class PluginMetadata
+    include LogStash::Util::Loggable
 
     Thread.exclusive do
       @registry = ThreadSafe::Cache.new unless defined?(@registry)
@@ -63,6 +63,7 @@ module LogStash
       #
       # @return [Boolean]
       def delete_for_plugin(plugin_id)
+        logger.debug("Removing metadata for plugin #{plugin_id}")
         old_registry = @registry.delete(plugin_id)
         old_registry.clear unless old_registry.nil?
       end

--- a/logstash-core/spec/logstash/plugin_spec.rb
+++ b/logstash-core/spec/logstash/plugin_spec.rb
@@ -312,6 +312,10 @@ describe LogStash::Plugin do
               expect(plugin_instance.plugin_metadata).to be_a_kind_of(LogStash::PluginMetadata)
             end
 
+            it "PluginMetadata is defined" do
+              expect(defined?(plugin_instance.plugin_metadata)).to be_truthy
+            end
+
             if config_override.include?('id')
               it "will be shared between instance of plugins" do
                 expect(plugin_instance.plugin_metadata).to equal(plugin.new(config).plugin_metadata)

--- a/logstash-core/spec/logstash/plugin_spec.rb
+++ b/logstash-core/spec/logstash/plugin_spec.rb
@@ -328,6 +328,14 @@ describe LogStash::Plugin do
               expect(old_value).to be_nil
               expect(plugin_instance.plugin_metadata.get(:foo)).to eq(new_value)
             end
+
+            it 'removes metadata when the plugin is closed' do
+              new_value = 'foo'
+              plugin_instance.plugin_metadata.set(:foo, new_value)
+              expect(plugin_instance.plugin_metadata.get(:foo)).to eq(new_value)
+              plugin_instance.do_close
+              expect(plugin_instance.plugin_metadata.set?(:foo)).to be_falsey
+            end
           end
         end
       end

--- a/logstash-core/spec/logstash/plugin_spec.rb
+++ b/logstash-core/spec/logstash/plugin_spec.rb
@@ -267,6 +267,69 @@ describe LogStash::Plugin do
     end
   end
 
+  describe "#plugin_metadata" do
+    plugin_types = [
+        LogStash::Filters::Base,
+        LogStash::Codecs::Base,
+        LogStash::Outputs::Base,
+        LogStash::Inputs::Base
+    ]
+
+    before(:each) { LogStash::PluginMetadata::reset! }
+
+    plugin_types.each do |plugin_type|
+      let(:plugin) do
+        Class.new(plugin_type) do
+          config_name "simple_plugin"
+
+          config :host, :validate => :string
+          config :export, :validate => :boolean
+
+          def register; end
+        end
+      end
+
+      let(:config) do
+        {
+            "host" => "127.0.0.1",
+            "export" => true
+        }
+      end
+
+      subject(:plugin_instance) { plugin.new(config) }
+
+      context "plugin type is #{plugin_type}" do
+        {
+            'when there is not ID configured for the plugin' => {},
+            'when a user provide an ID for the plugin' => { 'id' => 'ABC' },
+        }.each do |desc, config_override|
+
+
+          context(desc) do
+            let(:config) { super.merge(config_override) }
+
+            it "has a PluginMetadata" do
+              expect(plugin_instance.plugin_metadata).to be_a_kind_of(LogStash::PluginMetadata)
+            end
+
+            if config_override.include?('id')
+              it "will be shared between instance of plugins" do
+                expect(plugin_instance.plugin_metadata).to equal(plugin.new(config).plugin_metadata)
+              end
+            end
+
+            it 'stores metadata' do
+              new_value = 'foo'
+              old_value = plugin_instance.plugin_metadata.set(:foo, new_value)
+              expect(old_value).to be_nil
+              expect(plugin_instance.plugin_metadata.get(:foo)).to eq(new_value)
+            end
+          end
+        end
+      end
+    end
+  end
+
   describe "#id" do
     let(:plugin) do
       Class.new(LogStash::Filters::Base,) do

--- a/logstash-core/spec/plugin_metadata_spec.rb
+++ b/logstash-core/spec/plugin_metadata_spec.rb
@@ -33,6 +33,20 @@ describe LogStash::PluginMetadata do
         end
       end
     end
+    describe '#delete_for_plugin' do
+      before(:each) { registry.for_plugin(plugin_id).set(:foo, 'bar') }
+      it 'deletes the registry' do
+        expect(registry.exists?(plugin_id)).to be true
+        registry.delete_for_plugin(plugin_id)
+        expect(registry.exists?(plugin_id)).to be false
+      end
+      it 'deletes the data inside the registry' do
+        plugin_registry = registry.for_plugin(plugin_id)
+        registry.delete_for_plugin(plugin_id)
+        expect(plugin_registry.set?(:foo)).to be false
+      end
+    end
+
   end
 
   describe 'instance' do
@@ -49,14 +63,15 @@ describe LogStash::PluginMetadata do
         end
       end
       context 'when the key is set' do
-        before(:each) { instance.set(:foo, 'bananas') }
+        let (:val) { 'bananas'}
+        before(:each) { instance.set(:foo, val) }
 
         it 'sets the new value' do
           instance.set(:foo, 'bar')
           expect(instance.get(:foo)).to eq('bar')
         end
         it 'returns the previous associated value' do
-          expect(instance.set(:foo, 'bar')).to eq('bananas')
+          expect(instance.set(:foo, 'bar')).to eq(val)
         end
         context 'when the new value is nil' do
           it 'unsets the value' do
@@ -91,6 +106,44 @@ describe LogStash::PluginMetadata do
       context 'when the key is not set' do
         it 'returns false' do
           expect(instance.set?(:foo)).to be false
+        end
+      end
+    end
+
+    describe '#delete' do
+      context 'when the key is set' do
+        let (:val) { 'bananas' }
+        before(:each) { instance.set(:foo, val)}
+        it 'returns the value' do
+          expect(instance.delete(:foo)).to be val
+        end
+        it 'removes the key' do
+          instance.delete(:foo)
+          expect(instance.set?(:foo)).to be false
+        end
+      end
+      context 'when the key is not set' do
+        it 'returns nil' do
+          expect(instance.delete(:foo)).to be nil
+        end
+
+        it 'should not be set' do
+          instance.delete(:foo)
+          expect(instance.set?(:foo)).to be false
+        end
+      end
+    end
+
+    describe '#clear' do
+      context 'when the key is set' do
+        before(:each) do
+          instance.set(:foo, 'bananas')
+          instance.set(:bar, 'more bananas')
+        end
+        it 'removes all keys' do
+          instance.clear
+          expect(instance.set?(:foo)).to be false
+          expect(instance.set?(:bar)).to be false
         end
       end
     end

--- a/logstash-core/spec/plugin_metadata_spec.rb
+++ b/logstash-core/spec/plugin_metadata_spec.rb
@@ -1,0 +1,98 @@
+# encoding: utf-8
+
+require 'spec_helper'
+require 'logstash/plugin_metadata'
+require 'securerandom'
+
+describe LogStash::PluginMetadata do
+
+  let(:registry) { described_class }
+  before(:each) { registry.reset! }
+
+  let(:plugin_id) { SecureRandom.uuid }
+
+  describe 'registry' do
+    describe '#for_plugin' do
+      it 'returns the same instance when given the same id' do
+        expect(registry.for_plugin(plugin_id)).to be(registry.for_plugin(plugin_id))
+      end
+      it 'returns different instances when given different ids' do
+        expect(registry.for_plugin(plugin_id)).to_not equal(registry.for_plugin(plugin_id.next))
+      end
+    end
+    describe '#exists?' do
+      context 'when the plugin has not yet been registered' do
+        it 'returns false' do
+          expect(registry.exists?(plugin_id)).to be false
+        end
+      end
+      context 'when the plugin has already been registered' do
+        before(:each) { registry.for_plugin(plugin_id).set(:foo, 'bar') }
+        it 'returns true' do
+          expect(registry.exists?(plugin_id)).to be true
+        end
+      end
+    end
+  end
+
+  describe 'instance' do
+    let(:instance) { registry.for_plugin(plugin_id) }
+
+    describe '#set' do
+      context 'when the key is not set' do
+        it 'sets the new value' do
+          instance.set(:foo, 'bar')
+          expect(instance.get(:foo)).to eq('bar')
+        end
+        it 'returns the nil' do
+          expect(instance.set(:foo, 'bar')).to be_nil
+        end
+      end
+      context 'when the key is set' do
+        before(:each) { instance.set(:foo, 'bananas') }
+
+        it 'sets the new value' do
+          instance.set(:foo, 'bar')
+          expect(instance.get(:foo)).to eq('bar')
+        end
+        it 'returns the previous associated value' do
+          expect(instance.set(:foo, 'bar')).to eq('bananas')
+        end
+        context 'when the new value is nil' do
+          it 'unsets the value' do
+            instance.set(:foo, nil)
+            expect(instance.set?(:foo)).to be false
+          end
+        end
+      end
+    end
+
+    describe '#get' do
+      context 'when the key is set' do
+        before(:each) { instance.set(:foo, 'bananas') }
+        it 'returns the associated value' do
+          expect(instance.get(:foo)).to eq('bananas')
+        end
+      end
+      context 'when the key is not set' do
+        it 'returns nil' do
+          expect(instance.get(:foo)).to be_nil
+        end
+      end
+    end
+
+    describe '#set?' do
+      context 'when the key is set' do
+        before(:each) { instance.set(:foo, 'bananas')}
+        it 'returns true' do
+          expect(instance.set?(:foo)).to be true
+        end
+      end
+      context 'when the key is not set' do
+        it 'returns false' do
+          expect(instance.set?(:foo)).to be false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Continuation of #10636, which will also attempt to clean up after a plugin is shutdown