### PR TITLE
Fix NullPointerException in EventCondition$Compiler.compare

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/EventCondition.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/EventCondition.java
@@ -414,6 +414,8 @@ public interface EventCondition {
         private static int compare(final Object left, final Object right) {
             if (left instanceof Comparable<?>) {
                 return ((Comparable) left).compareTo(right);
+            } else if (left == null) {
+                return -1;
             }
             throw new EventCondition.Compiler.UnexpectedTypeException(left, right);
         }

--- a/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
@@ -304,6 +304,30 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
         MatcherAssert.assertThat(testEvent.getEvent().getField("foo"), CoreMatchers.is("bar"));
     }
 
+    @Test()
+    public void conditionalWithNullFieldAndComparison() throws Exception {
+        final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
+                "input {mockinput{}} filter { if [foo] > 0 { mockaddfilter {} } } output {mockoutput{} }",
+                false
+        );
+        final JrubyEventExtLibrary.RubyEvent testEvent =
+                JrubyEventExtLibrary.RubyEvent.newRubyEvent(RubyUtil.RUBY, new Event());
+        final Map<String, Supplier<IRubyObject>> filters = new HashMap<>();
+        filters.put("mockaddfilter", () -> ADD_FIELD_FILTER);
+        new CompiledPipeline(
+                pipelineIR,
+                new CompiledPipelineTest.MockPluginFactory(
+                        Collections.singletonMap("mockinput", () -> null),
+                        filters,
+                        Collections.singletonMap("mockoutput", mockOutputSupplier())
+                )
+        ).buildExecution().compute(RubyUtil.RUBY.newArray(testEvent), false, false);
+        final Collection<JrubyEventExtLibrary.RubyEvent> outputEvents = EVENT_SINKS.get(runId);
+        MatcherAssert.assertThat(outputEvents.size(), CoreMatchers.is(1));
+        MatcherAssert.assertThat(outputEvents.contains(testEvent), CoreMatchers.is(true));
+        MatcherAssert.assertThat(testEvent.getEvent().getField("foo"), CoreMatchers.nullValue());
+    }
+
     @Test
     public void conditionalNestedMetaFieldPipeline() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(


### PR DESCRIPTION
Attempt to fix #10706. The test shows the problem, but I don't know how to properly fix it:
* Either handle `null` in compare function? What result should be returned?
* Or handle `null` in `UnexpectedTypeException`? How is handled this exception in Logstash pipeline? Does it kill the worker thread like the NullPointerException? 