### PR TITLE
Fix misdirected links

### DIFF
--- a/docs/static/include/pluginbody.asciidoc
+++ b/docs/static/include/pluginbody.asciidoc
@@ -1275,10 +1275,10 @@ we always welcome new plugins!
 Some of the many benefits of having your plugin in the logstash-plugins
 repository are:
 
-* **Discovery** Your plugin will appear in the http://www.elasticsearch.org/guide/en/logstash/current/index.html[Logstash Reference],
+* **Discovery** Your plugin will appear in the {logstash-ref}/index.html[Logstash Reference],
 where Logstash users look first for plugins and documentation.
 * **Documentation** Your plugin documentation will automatically be added to the
- http://www.elasticsearch.org/guide/en/logstash/current/index.html[Logstash Reference].
+ {logstash-ref}/index.html[Logstash Reference].
 * **Testing** With our testing infrastructure, your plugin will be continuously
 tested against current and future releases of Logstash.  As a result, users will
 have the assurance that if incompatibilities arise, they will be quickly

--- a/docs/static/java-codec.asciidoc
+++ b/docs/static/java-codec.asciidoc
@@ -17,9 +17,13 @@
 //:methodheader: Logstash codecs must implement the `register` method, and the `decode` method or the `encode` method (or both).
 
 [[java-codec-plugin]]
+
 === How to write a Java codec plugin
 
 beta[]
+
+NOTE: Java codecs are currently supported only for Java input and output plugins. They will not work with Ruby
+input or output plugins.
 
 // Pulls in shared section: Setting Up Environment
 include::include/javapluginsetup.asciidoc[]


### PR DESCRIPTION
Contributing text contained links that were redirecting to the main site (elastic.co). Updated links to point to Logstash Reference. 