### PR TITLE
Include G1 in JVM heap metrics

### DIFF
--- a/logstash-core/lib/logstash/instrument/periodic_poller/jvm.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/jvm.rb
@@ -153,12 +153,15 @@ module LogStash module Instrument module PeriodicPoller
       old  = {}
       old = old.merge!(heap["CMS Old Gen"]) if heap.has_key?("CMS Old Gen")
       old = old.merge!(heap["PS Old Gen"])  if heap.has_key?("PS Old Gen")
+      old = old.merge!(heap["G1 Old Gen"])  if heap.has_key?("G1 Old Gen")
       young = {}
       young = young.merge!(heap["Par Eden Space"]) if heap.has_key?("Par Eden Space")
       young = young.merge!(heap["PS Eden Space"])  if heap.has_key?("PS Eden Space")
+      young = young.merge!(heap["G1 Eden Space"])  if heap.has_key?("G1 Eden Space")
       survivor = {}
       survivor = survivor.merge!(heap["Par Survivor Space"]) if heap.has_key?("Par Survivor Space")
       survivor = survivor.merge!(heap["PS Survivor Space"])  if heap.has_key?("PS Survivor Space")
+      survivor = survivor.merge!(heap["G1 Survivor Space"])  if heap.has_key?("G1 Survivor Space")
       {
         "young"    => aggregate_information_for(young),
         "old"      => aggregate_information_for(old),


### PR DESCRIPTION
Fixes #10726.

Only cause for concern I've seen is the output of the max fields for the young gen since in G1 it's unbounded:

```
    "mem": {
      "heap_used_percent": 22,
      "heap_committed_in_bytes": 1073741824,
      "heap_max_in_bytes": 1073741822,
      "heap_used_in_bytes": 241172480,
      "non_heap_used_in_bytes": 139341592,
      "non_heap_committed_in_bytes": 160690176,
      "pools": {
        "survivor": {
          "used_in_bytes": 22020096,
          "committed_in_bytes": 22020096,
>         "peak_max_in_bytes": -1,
          "peak_used_in_bytes": 35651584,
>         "max_in_bytes": -1
        },
        "young": {
          "used_in_bytes": 119537664,
          "committed_in_bytes": 537919488,
>         "peak_max_in_bytes": -1,
          "peak_used_in_bytes": 343932928,
>         "max_in_bytes": -1
        },
        "old": {
          "used_in_bytes": 99614720,
          "committed_in_bytes": 513802240,
          "peak_max_in_bytes": 1073741824,
          "peak_used_in_bytes": 99614720,
          "max_in_bytes": 1073741824
        }
      }
    },
```

Returning -1 is [documented functionality of JMX's MemoryUsage](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryUsage.html#getMax()) however this might break the expected schema for some tools (like our Logstash monitoring scripts for example) which expect the sizes to be unsigned ints, should this default to 0 or are there any other ideas for this?

Cheers