### PR TITLE
Fix the config.reload.interval comment

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -76,7 +76,7 @@
 #
 # config.reload.automatic: false
 #
-# How often to check if the pipeline configuration has changed (in seconds)
+# How often to check if the pipeline configuration has changed (in milliseconds)
 #
 # config.reload.interval: 3s
 #


### PR DESCRIPTION
The default unit of this option is the "millisecond" instead of the "second".
Setting a low value like 10 without specifying unit will make the CPU usage increase to 100%.