### PR TITLE
Fix config.reload.interval documentation

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -76,7 +76,7 @@
 #
 # config.reload.automatic: false
 #
-# How often to check if the pipeline configuration has changed (in seconds)
+# How often to check if the pipeline configuration has changed (in milliseconds)
 #
 # config.reload.interval: 3s
 #


### PR DESCRIPTION
This value, if entered without unit, is handled as a millisecond value, instead of a second.
Setting this value with something like 10 will make the CPU usage increase to 100%.