### PR TITLE
Expose DLQ writers to all types of plugins, not just Ruby outputs

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -71,6 +71,8 @@ public final class JrubyEventExtLibrary {
                 this.event = new Event(
                     ConvertedMap.newFromRubyHash(context, (RubyHash) data)
                 );
+            } else if (data != null && data.getJavaClass().equals(Event.class)) {
+                this.event = data.toJava(Event.class);
             } else {
                 initializeFallback(context, data);
             }

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
@@ -398,18 +398,17 @@ public final class PluginFactoryExt {
 
         public Context toContext(PluginLookup.PluginType pluginType, AbstractNamespacedMetricExt metric) {
             DeadLetterQueueWriter dlq = NullDeadLetterQueueWriter.getInstance();
-            if (pluginType == PluginLookup.PluginType.OUTPUT) {
-                if (dlqWriter instanceof AbstractDeadLetterQueueWriterExt.PluginDeadLetterQueueWriterExt) {
-                    IRubyObject innerWriter =
-                            ((AbstractDeadLetterQueueWriterExt.PluginDeadLetterQueueWriterExt) dlqWriter)
-                                    .innerWriter(RubyUtil.RUBY.getCurrentContext());
-
-                    if (innerWriter != null) {
-                         if (org.logstash.common.io.DeadLetterQueueWriter.class.isAssignableFrom(innerWriter.getJavaClass())) {
-                            dlq = new DLQWriterAdapter(innerWriter.toJava(org.logstash.common.io.DeadLetterQueueWriter.class));
-                        }
+            if (dlqWriter instanceof AbstractDeadLetterQueueWriterExt.PluginDeadLetterQueueWriterExt) {
+                IRubyObject innerWriter =
+                        ((AbstractDeadLetterQueueWriterExt.PluginDeadLetterQueueWriterExt) dlqWriter)
+                                .innerWriter(RubyUtil.RUBY.getCurrentContext());
+                if (innerWriter != null) {
+                    if (org.logstash.common.io.DeadLetterQueueWriter.class.isAssignableFrom(innerWriter.getJavaClass())) {
+                        dlq = new DLQWriterAdapter(innerWriter.toJava(org.logstash.common.io.DeadLetterQueueWriter.class));
                     }
                 }
+            } else if (dlqWriter.getJavaClass().equals(DeadLetterQueueWriter.class)) {
+                dlq = dlqWriter.toJava(DeadLetterQueueWriter.class);
             }
 
             return new ContextImpl(dlq, new NamespacedMetricImpl(RubyUtil.RUBY.getCurrentContext(), metric));


### PR DESCRIPTION
Closes #10732 

We have a custom Java codec plugin that sends incorrectly formatted logs along with debugging information in `@metadata` to the DLQ, but this isn't saved for two reasons:

1. DLQ writers are not made available to Java plugins, fixed by d0a3bfa
2. `dead_letter_queue` uses `Event#toMap` to serialise events, which only copies data and not metadata: https://github.com/elastic/logstash/blob/c28ded78c9ed503bf49121d472cc6569047e4d47/logstash-core/src/main/java/org/logstash/Event.java#L260 (fixed by 6c31502)

I'll send a separate pull request for the `dead_letter_queue` input, so that `@metadata` written by plugins into the DLQ is preserved.

Thanks!

cc @w4 