### PR TITLE
fix javadoc warning for Codec.java

### DIFF
--- a/logstash-core/src/main/java/co/elastic/logstash/api/Codec.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/Codec.java
@@ -47,6 +47,7 @@ public interface Codec extends Plugin {
      * Encodes an {@link Event} and writes it to the specified {@link OutputStream}.
      * @param event The event to encode.
      * @param output The stream to which the encoded event should be written.
+     * @throws java.io.IOException Exceptions coming from the output stream
      */
     void encode(Event event, OutputStream output) throws IOException;
 


### PR DESCRIPTION
fixes the following:

```
13:25:38 logstash-core/src/main/java/co/elastic/logstash/api/Codec.java:51: warning: no @throws for java.io.IOException
13:25:38     void encode(Event event, OutputStream output) throws IOException;
13:25:38          ^
13:25:44 1 warning
13:25:44 Problems generating Javadoc.
```

[edit] running `./gradlew :logstash-core:javadoc` is enough to test