### PR TITLE
Provide DLQ writer interface to Java plugins

### DIFF
--- a/logstash-core/src/main/java/co/elastic/logstash/api/Context.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/Context.java
@@ -1,7 +1,6 @@
 package co.elastic.logstash.api;
 
 import org.apache.logging.log4j.Logger;
-import org.logstash.common.io.DeadLetterQueueWriter;
 
 /**
  * Provides Logstash context to plugins.

--- a/logstash-core/src/main/java/co/elastic/logstash/api/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/DeadLetterQueueWriter.java
@@ -1,0 +1,12 @@
+package co.elastic.logstash.api;
+
+import java.io.IOException;
+
+public interface DeadLetterQueueWriter {
+
+    void writeEntry(Event event, Plugin plugin, String reason) throws IOException;
+
+    boolean isOpen();
+
+    long getCurrentQueueSize();
+}

--- a/logstash-core/src/main/java/org/logstash/common/DLQWriterAdapter.java
+++ b/logstash-core/src/main/java/org/logstash/common/DLQWriterAdapter.java
@@ -1,0 +1,32 @@
+package org.logstash.common;
+
+import co.elastic.logstash.api.DeadLetterQueueWriter;
+import co.elastic.logstash.api.Event;
+import co.elastic.logstash.api.Plugin;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class DLQWriterAdapter implements DeadLetterQueueWriter {
+
+    private final org.logstash.common.io.DeadLetterQueueWriter dlqWriter;
+
+    public DLQWriterAdapter(org.logstash.common.io.DeadLetterQueueWriter dlqWriter) {
+        this.dlqWriter = Objects.requireNonNull(dlqWriter);
+    }
+
+    @Override
+    public void writeEntry(Event event, Plugin plugin, String reason) throws IOException {
+        dlqWriter.writeEntry((org.logstash.Event) event, plugin.getName(), plugin.getId(), reason);
+    }
+
+    @Override
+    public boolean isOpen() {
+        return dlqWriter != null && dlqWriter.isOpen();
+    }
+
+    @Override
+    public long getCurrentQueueSize() {
+        return dlqWriter != null ? dlqWriter.getCurrentQueueSize() : 0;
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/common/NullDeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/NullDeadLetterQueueWriter.java
@@ -1,0 +1,33 @@
+package org.logstash.common;
+
+import co.elastic.logstash.api.DeadLetterQueueWriter;
+import co.elastic.logstash.api.Event;
+import co.elastic.logstash.api.Plugin;
+
+import java.io.IOException;
+
+public class NullDeadLetterQueueWriter implements DeadLetterQueueWriter {
+    private static final NullDeadLetterQueueWriter INSTANCE = new NullDeadLetterQueueWriter();
+
+    private NullDeadLetterQueueWriter() {
+    }
+
+    public static NullDeadLetterQueueWriter getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public void writeEntry(Event event, Plugin plugin, String reason) throws IOException {
+        // no-op
+    }
+
+    @Override
+    public boolean isOpen() {
+        return false;
+    }
+
+    @Override
+    public long getCurrentQueueSize() {
+        return 0;
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/plugins/ContextImpl.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/ContextImpl.java
@@ -1,6 +1,7 @@
 package org.logstash.plugins;
 
 import co.elastic.logstash.api.Context;
+import co.elastic.logstash.api.DeadLetterQueueWriter;
 import co.elastic.logstash.api.Event;
 import co.elastic.logstash.api.EventFactory;
 import co.elastic.logstash.api.Metric;
@@ -9,7 +10,6 @@ import co.elastic.logstash.api.Plugin;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.logstash.ConvertedMap;
-import org.logstash.common.io.DeadLetterQueueWriter;
 
 import java.io.Serializable;
 import java.util.Map;

--- a/logstash-core/src/test/java/org/logstash/plugins/TestContext.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/TestContext.java
@@ -1,11 +1,11 @@
 package org.logstash.plugins;
 
 import co.elastic.logstash.api.Context;
+import co.elastic.logstash.api.DeadLetterQueueWriter;
 import co.elastic.logstash.api.EventFactory;
 import co.elastic.logstash.api.NamespacedMetric;
 import co.elastic.logstash.api.Plugin;
 import org.apache.logging.log4j.Logger;
-import org.logstash.common.io.DeadLetterQueueWriter;
 
 public class TestContext implements Context {
 


### PR DESCRIPTION
Note that a number of public methods on the `DeadLetterQueueWriter` implementation are intentionally not exposed to plugins.

Resolves https://github.com/elastic/logstash/issues/10731.
