### PR TITLE
performance: share a single secret store during `Plugin::Mixin#config_init`

### DIFF
--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -46,7 +46,17 @@ module LogStash::Config::Mixin
     base.extend(LogStash::Config::Mixin::DSL)
   end
 
+  # Enable multiple invocations of the substitution variable replacement within
+  # the config initialisation to share a single secret store for performance reasons.
+  #
+  # See: [LogStash::Util::SubstitutionVariables#with_exclusive_secret_store]
   def config_init(params)
+    with_exclusive_secret_store do
+      _config_init(params)
+    end
+  end
+
+  def config_init_internal(params)
     # Validation will modify the values inside params if necessary.
     # For example: converting a string to a number, etc.
 
@@ -138,7 +148,8 @@ module LogStash::Config::Mixin
     end
 
     @config = params
-  end # def config_init
+  end # def config_init_internal
+  private :config_init_internal
 
   module DSL
 

--- a/logstash-core/lib/logstash/util/substitution_variables.rb
+++ b/logstash-core/lib/logstash/util/substitution_variables.rb
@@ -42,7 +42,7 @@ module ::LogStash::Util::SubstitutionVariables
       logger.debug("Replacing `#{placeholder}` with actual value")
 
       #check the secret store if it exists
-      secret_store = SecretStoreExt.getIfExists(LogStash::SETTINGS.get_setting("keystore.file").value, LogStash::SETTINGS.get_setting("keystore.classname").value)
+      secret_store = get_or_load_secret_store
       replacement = secret_store.nil? ? nil : secret_store.retrieveSecret(SecretStoreExt.getStoreId(name))
       #check the environment
       replacement = ENV.fetch(name, default) if replacement.nil?
@@ -54,4 +54,51 @@ module ::LogStash::Util::SubstitutionVariables
     end
   end # def replace_placeholders
 
+  # helper method to cache a single secret_store for the current thread
+  # across all calls within the provided block, cleaning up when finished
+  #
+  # @yield control
+  def with_exclusive_secret_store
+    subsitution_variable_mutex.synchronize do
+      begin
+        logger.info("Setting up exclusive keystore for #{self.inspect}...")
+        @_secret_store = load_secret_store
+        yield
+      ensure
+        @_secret_store = nil
+        logger.info("Revoking exclusive keystore for #{self.inspect}...")
+      end
+    end
+  end
+
+  private
+
+  # get a secret_store, using a cached value if available.
+  # @api private
+  # @return [SecretStoreExt,nil]
+  def get_or_load_secret_store
+    return @_secret_store if subsitution_variable_mutex.owned?
+
+    load_secret_store
+  end
+
+  # loads a secret_store from disk if available
+  # @api private
+  # # @return [SecretStoreExt,nil]
+  def load_secret_store
+    SecretStoreExt.getIfExists(LogStash::SETTINGS.get_setting("keystore.file").value, LogStash::SETTINGS.get_setting("keystore.classname").value)
+  end
+
+  # returns an instance-specific mutex, for use
+  # @api private
+  def subsitution_variable_mutex
+    # to ensure that the instance that this module is mixed into
+    # gets EXACTLY ONE mutex, we briefly use a global mutex.
+    @_subsitution_variable_mutex || MUTEX.synchronize do
+      @_subsitution_variable_mutex ||= Mutex.new
+    end
+  end
+
+  MUTEX = Mutex.new
+  private_constant :MUTEX
 end


### PR DESCRIPTION
Loading a Java Keystore can take anywhere from ~0.3s on a hot SSH to upwards of 3s, so the
pattern of loading one per variable we need to replace adds a significant
amount of overhead on pipelines that use these variables, whether or not they
are provided by the keystore (e.g., even if they are provided as normal environment
variables).

By wrapping a plugin's #config_init with a helper that sets up, uses, and tears down
a shared keystore, we are able to amortise this cost.

They are still only shared _per plugin_, but I have not found a better way to wrap
them (e.g., at an appropriate point in pipeline or agent when groups of plugins
get initialised) that doesn't also increase complexity significantly.

Possible solution to https://github.com/elastic/logstash/issues/10126