### PR TITLE
Default stack trace size for hot threads to 50 and make it configurable

### DIFF
--- a/docs/static/monitoring-apis.asciidoc
+++ b/docs/static/monitoring-apis.asciidoc
@@ -721,6 +721,7 @@ The parameters allowed are:
 
 [horizontal]
 `threads`:: 	        The number of hot threads to return. The default is 10.
+`stacktrace_size`::     The depth of the stack trace to report for each thread. The default is 50.
 `human`:: 	            If true, returns plain text instead of JSON format. The default is false.
 `ignore_idle_threads`:: If true, does not return idle threads. The default is true.
 

--- a/logstash-core/lib/logstash/api/commands/hot_threads_reporter.rb
+++ b/logstash-core/lib/logstash/api/commands/hot_threads_reporter.rb
@@ -3,11 +3,11 @@ java_import 'org.logstash.instrument.reports.ThreadsReport'
 
 class HotThreadsReport
   STRING_SEPARATOR_LENGTH = 80.freeze
-  HOT_THREADS_STACK_TRACES_SIZE_DEFAULT = 10.freeze
+  HOT_THREADS_STACK_TRACES_SIZE_DEFAULT = 50.freeze
 
   def initialize(cmd, options)
     @cmd = cmd
-    filter = { :stacktrace_size => options.fetch(:stacktrace_size, HOT_THREADS_STACK_TRACES_SIZE_DEFAULT) }
+    filter = { 'stacktrace_size' => "#{options.fetch(:stacktrace_size, HOT_THREADS_STACK_TRACES_SIZE_DEFAULT)}" }
     @thread_dump = ::LogStash::Util::ThreadDump.new(options.merge(:dump => ThreadsReport.generate(filter)))
   end
 

--- a/logstash-core/lib/logstash/api/modules/node.rb
+++ b/logstash-core/lib/logstash/api/modules/node.rb
@@ -13,9 +13,10 @@ module LogStash
         get "/hot_threads" do
           begin
             ignore_idle_threads = params["ignore_idle_threads"] || true
-
             options = {:ignore_idle_threads => as_boolean(ignore_idle_threads)}
             options[:threads] = params["threads"].to_i if params.has_key?("threads")
+            options[:ordered_by] = params["ordered_by"] if params.has_key?("ordered_by")
+            options[:stacktrace_size] = params["stacktrace_size"] if params.has_key?("stacktrace_size")
 
             as = human? ? :string : :json
             respond_with(node.hot_threads(options), {:as => as})

--- a/logstash-core/src/main/java/org/logstash/instrument/monitors/HotThreadsMonitor.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/monitors/HotThreadsMonitor.java
@@ -133,7 +133,7 @@ public final class HotThreadsMonitor {
                 throw new IllegalArgumentException("Invalid sort order");
         }
 
-        Integer threadInfoMaxDepth = 3;
+        Integer threadInfoMaxDepth = 50;
         if (options.containsKey(STACKTRACE_SIZE)) {
             threadInfoMaxDepth = Integer.valueOf(options.get(STACKTRACE_SIZE));
         }


### PR DESCRIPTION
This will make it much easier to identify the origin (Logstash core, a plugin, etc.) of a particular problem when the final lines of the stack trace end up in code such as the joni regex engine that are used in many places.
