### PR TITLE
[Documentation] Add the "Compile to JAR file" build command

### DIFF
--- a/docs/static/include/javapluginpkg.asciidoc
+++ b/docs/static/include/javapluginpkg.asciidoc
@@ -19,6 +19,11 @@ The Java plugin should be compiled and assembled into a fat jar with the
 into a single jar and write it to the correct folder for later packaging into a
 Ruby gem.
 
+To build the jar file, run the following command from the plugin directory:
+-----
+./gradlew vendor
+-----
+
 [float]
 ==== Manually package as Ruby gem 
 


### PR DESCRIPTION
Hi there,
The command to compile to JAR file is missing from the doc. Let me add it for clarification.
Should I also create similar PR for every other branch or do you have another way to backport this easily?