### PR TITLE
generate tarballs for docker images

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -20,7 +20,7 @@ HTTPD ?= logstash-docker-artifact-server
 
 FIGLET := pyfiglet -w 160 -f puffy
 
-all: build-from-local-artifacts build-from-local-oss-artifacts public-dockerfile
+all: build-from-local-artifacts build-from-local-oss-artifacts public-dockerfiles
 
 lint: venv
 	flake8 tests
@@ -48,9 +48,10 @@ build-from-local-oss-artifacts: venv dockerfile env2yaml
 	  (docker kill $(HTTPD); false);
 	-docker kill $(HTTPD)
 
-COPY_FILES = $(ARTIFACTS_DIR)/docker/config/pipelines.yml $(ARTIFACTS_DIR)/docker/config/logstash-full.yml $(ARTIFACTS_DIR)/docker/config/log4j2.properties $(ARTIFACTS_DIR)/docker/pipeline/default.conf $(ARTIFACTS_DIR)/docker/bin/docker-entrypoint $(ARTIFACTS_DIR)/docker/env2yaml/env2yaml
+COPY_FILES = $(ARTIFACTS_DIR)/docker/config/pipelines.yml $(ARTIFACTS_DIR)/docker/config/logstash-oss.yml $(ARTIFACTS_DIR)/docker/config/logstash-full.yml $(ARTIFACTS_DIR)/docker/config/log4j2.properties $(ARTIFACTS_DIR)/docker/pipeline/default.conf $(ARTIFACTS_DIR)/docker/bin/docker-entrypoint $(ARTIFACTS_DIR)/docker/env2yaml/env2yaml
 
 $(ARTIFACTS_DIR)/docker/config/pipelines.yml: data/logstash/config/pipelines.yml
+$(ARTIFACTS_DIR)/docker/config/logstash-oss.yml: data/logstash/config/logstash-oss.yml
 $(ARTIFACTS_DIR)/docker/config/logstash-full.yml: data/logstash/config/logstash-full.yml
 $(ARTIFACTS_DIR)/docker/config/log4j2.properties: data/logstash/config/log4j2.properties
 $(ARTIFACTS_DIR)/docker/pipeline/default.conf: data/logstash/pipeline/default.conf
@@ -67,14 +68,26 @@ docker_paths:
 	mkdir -p $(ARTIFACTS_DIR)/docker/env2yaml
 	mkdir -p $(ARTIFACTS_DIR)/docker/pipeline
 
-public-dockerfile: venv templates/Dockerfile.j2 docker_paths $(COPY_FILES)
+public-dockerfiles: venv templates/Dockerfile.j2 docker_paths $(COPY_FILES)
 	jinja2 \
 	  -D elastic_version='$(ELASTIC_VERSION)' \
 	  -D version_tag='$(VERSION_TAG)' \
 	  -D image_flavor='full' \
-	  -D artifacts_dir='$(ARTIFACTS_DIR)' \
+	  -D local_artifacts='false' \
 	  -D release='$(RELEASE)' \
-	  templates/Dockerfile.j2 > $(ARTIFACTS_DIR)/docker/Dockerfile
+	  templates/Dockerfile.j2 > $(ARTIFACTS_DIR)/Dockerfile-full && \
+	jinja2 \
+	  -D elastic_version='$(ELASTIC_VERSION)' \
+	  -D version_tag='$(VERSION_TAG)' \
+	  -D image_flavor='oss' \
+	  -D local_artifacts='false' \
+	  -D release='$(RELEASE)' \
+	  templates/Dockerfile.j2 > $(ARTIFACTS_DIR)/Dockerfile-oss && \
+	cd $(ARTIFACTS_DIR)/docker && \
+	cp $(ARTIFACTS_DIR)/Dockerfile-full Dockerfile && \
+	tar -zcf ../logstash-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile bin config env2yaml pipeline && \
+	cp $(ARTIFACTS_DIR)/Dockerfile-oss Dockerfile && \
+	tar -zcf ../logstash-oss-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile bin config env2yaml pipeline
 
 # Push the image to the dedicated push endpoint at "push.docker.elastic.co"
 push:
@@ -123,7 +136,7 @@ dockerfile: venv templates/Dockerfile.j2
 	    -D elastic_version='$(ELASTIC_VERSION)' \
 	    -D version_tag='$(VERSION_TAG)' \
 	    -D image_flavor='$(FLAVOR)' \
-	    -D artifacts_dir='$(ARTIFACTS_DIR)' \
+	    -D local_artifacts='true' \
 	    templates/Dockerfile.j2 > $(ARTIFACTS_DIR)/Dockerfile-$(FLAVOR); \
 	)
 

--- a/docker/templates/Dockerfile.j2
+++ b/docker/templates/Dockerfile.j2
@@ -1,5 +1,5 @@
 # This Dockerfile was generated from templates/Dockerfile.j2
-{% if release -%}
+{% if local_artifacts == 'false' -%}
 {%   set url_root = 'https://artifacts.elastic.co/downloads/logstash' -%}
 {% else -%}
 {%   set url_root = 'http://localhost:8000' -%}

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -191,10 +191,10 @@ namespace "artifact" do
     build_docker(true)
   end
 
-  desc "Generate Dockerfile for default image"
-  task "dockerfile" => ["prepare", "generate_build_metadata"] do
-    puts("[dockerfile] Building Dockerfile")
-    build_dockerfile
+  desc "Generate Dockerfile for default and oss images"
+  task "dockerfiles" => ["prepare", "generate_build_metadata"] do
+    puts("[dockerfiles] Building Dockerfiles")
+    build_dockerfiles
   end
 
   # Auxiliary tasks
@@ -208,8 +208,9 @@ namespace "artifact" do
     Rake::Task["artifact:zip_oss"].invoke
     Rake::Task["artifact:tar"].invoke
     Rake::Task["artifact:tar_oss"].invoke
-    #Rake::Task["artifact:docker"].invoke
-    #Rake::Task["artifact:docker_oss"].invoke
+    Rake::Task["artifact:docker"].invoke
+    Rake::Task["artifact:docker_oss"].invoke
+    Rake::Task["artifact:dockerfile"].invoke
   end
 
   task "generate_build_metadata" do
@@ -551,15 +552,15 @@ namespace "artifact" do
     end
   end
 
-  def build_dockerfile
+  def build_dockerfiles
     env = {
       "ARTIFACTS_DIR" => ::File.join(Dir.pwd, "build"),
       "RELEASE" => ENV["RELEASE"],
       "VERSION_QUALIFIER" => VERSION_QUALIFIER
     }
     Dir.chdir("docker") do |dir|
-      system(env, "make public-dockerfile")
-      puts "Dockerfile created in #{::File.join(env['ARTIFACTS_DIR'], 'docker')}"
+      system(env, "make public-dockerfiles")
+      puts "Dockerfiles created in #{::File.join(env['ARTIFACTS_DIR'], 'docker')}"
     end
   end
 end


### PR DESCRIPTION
This PR introduces the ability to build tarballs that contain anything necessary to create docker images. The docker images are built by fetching logstash tarball from elastic.co, so at this point they only work with released versions.

To test this, cherry-pick the commit to a release branch like 7.1 and run:
```
RELEASE=1 rake artifact:docker artifact:docker_oss artifact:dockerfiles 
```
This will produce the default and oss docker images, and two tarballs with everything necessary to build the images:

```
% ls build/*.gz
build/logstash-7.1.0-docker-build-context.tar.gz      build/logstash-oss-7.1.0-docker-build-context.tar.gz
build/logstash-7.1.0.tar.gz                           build/logstash-oss-7.1.0.tar.gz
% docker image list | grep logstash
docker.elastic.co/logstash/logstash-oss    7.1.0               2c18f7e414bb        20 hours ago        837MB
docker.elastic.co/logstash/logstash-full   7.1.0               b91c40c1dd41        20 hours ago        838MB
docker.elastic.co/logstash/logstash        7.1.0               b91c40c1dd41        20 hours ago        838MB
```