### PR TITLE
allow skipping docker artifacts during artifact:all

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -208,9 +208,11 @@ namespace "artifact" do
     Rake::Task["artifact:zip_oss"].invoke
     Rake::Task["artifact:tar"].invoke
     Rake::Task["artifact:tar_oss"].invoke
-    Rake::Task["artifact:docker"].invoke
-    Rake::Task["artifact:docker_oss"].invoke
-    Rake::Task["artifact:dockerfile"].invoke
+    unless ENV['SKIP_DOCKER'] == "1"
+      Rake::Task["artifact:docker"].invoke
+      Rake::Task["artifact:docker_oss"].invoke
+      Rake::Task["artifact:dockerfiles"].invoke
+    end
   end
 
   task "generate_build_metadata" do


### PR DESCRIPTION
building docker images and dockerfile tarball is part of the `rake artifact:all` task.

This PR allows skipping these tasks as they're quite new and can create problems. For this, you only need to set the environment variable `SKIP_DOCKER=1`