### PR TITLE
Added gradle version requirement for build process to work (benchmark-cli tool)

### DIFF
--- a/tools/benchmark-cli/README.md
+++ b/tools/benchmark-cli/README.md
@@ -1,6 +1,7 @@
 ### Benchmark CLI
 
 #### Build
+The build process will require Gradle 3.3 and OpenJDK 1.8.
 
 To build a self-contained archive of the benchmark tool simply run:
 


### PR DESCRIPTION
Specific version of Gradle (3.3) is required for the build process to work - including this in doc