### PR TITLE
LIR support for octal literals in pipeline definitions

### DIFF
--- a/logstash-core/lib/logstash/compiler/lscl.rb
+++ b/logstash-core/lib/logstash/compiler/lscl.rb
@@ -164,8 +164,8 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
   class Number < Value
     def expr
       jdsl.eValue(source_meta, text_value.include?(".") ?
-        text_value.to_f :
-        text_value.to_i)
+                                   Float(text_value) :
+                                   Integer(text_value))
     end
   end
 

--- a/logstash-core/spec/logstash/config/config_ast_spec.rb
+++ b/logstash-core/spec/logstash/config/config_ast_spec.rb
@@ -143,6 +143,21 @@ describe LogStashConfigParser do
 
         expect(config).to be_nil
       end
+
+      it "supports octal literals" do
+        parser = LogStashConfigParser.new
+        config = parser.parse(%q(
+          input {
+            example {
+              foo => 010
+            }
+          }
+        ))
+
+        compiled_number = eval(config.recursive_select(LogStash::Config::AST::Number).first.compile)
+
+        expect(compiled_number).to be == 8
+      end
     end
 
     context "when config.support_escapes" do


### PR DESCRIPTION
The LIR never supported octal literals which resulted in different behavior between the Java and Ruby execution engines since the former executes the LIR directly and the latter `eval`s a parallel but separately constructed block of Ruby code. This change unifies the evaluation of numeric literals in both scenarios.

Fixes #10826.
