### PR TITLE
Merge config values in LIR

### DIFF
--- a/logstash-core/lib/logstash/compiler/lscl.rb
+++ b/logstash-core/lib/logstash/compiler/lscl.rb
@@ -111,7 +111,7 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
           # hash value; e.g., `{"match" => {"baz" => "bar"}, "match" => {"foo" => "bulb"}}` is
           # interpreted as `{"match" => {"baz" => "bar", "foo" => "blub"}}`.
           # (NOTE: this bypasses `AST::Hash`'s ability to detect duplicate keys)
-          hash[k] = existing.merge(v)
+          hash[k] = ::LogStash::Util.hash_merge_many(existing, v)
         elsif existing.kind_of?(::Array)
           hash[k] = existing.push(*v)
         else

--- a/logstash-core/spec/logstash/compiler/compiler_spec.rb
+++ b/logstash-core/spec/logstash/compiler/compiler_spec.rb
@@ -252,6 +252,34 @@ describe LogStash::Compiler do
           expect(c_plugin).to ir_eql(j.iPlugin(rand_meta, FILTER, "grok", expected_plugin_args))
         end
 
+        describe "a filter plugin with a repeated hash directive with duplicated keys" do
+          let(:source) { "input { } filter { #{plugin_source} } output { } " }
+          let(:plugin_source) do
+            %q[
+              grok {
+                match => { "message" => "foo" }
+                match => { "message" => "bar" }
+                break_on_match => false
+              }
+          ]
+          end
+          subject(:c_plugin) { compiled[:filter] }
+
+          let(:expected_plugin_args) do
+            {
+                "match" => {
+                    "message" => ["foo", "bar"]
+                },
+                "break_on_match" => "false"
+            }
+          end
+
+          it "should merge the values of the duplicate keys into an array" do
+            expect(c_plugin).to ir_eql(j.iPlugin(rand_meta, FILTER, "grok", expected_plugin_args))
+          end
+
+        end
+
         describe "a filter plugin that has nested Hash directives" do
           let(:source) { "input { } filter { #{plugin_source} } output { } " }
           let(:plugin_source) do


### PR DESCRIPTION
This is another case in which the LIR processes pipeline definitions differently than the parallel but separately constructed block of Ruby code that is executed in the Ruby engine. This change unifies the merging of config values in the LIR and generated Ruby code to achieve functional parity in both the Java and Ruby execution engines.

Fixes #10818.
