### PR TITLE
name rpm/deb oss packages as logstash-oss

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -498,7 +498,7 @@ namespace "artifact" do
 
     # TODO(sissel): Invoke Pleaserun to generate the init scripts/whatever
 
-    out.name = "logstash"
+    out.name = oss ? "logstash-oss" : "logstash"
     out.version = "#{LOGSTASH_VERSION}#{PACKAGE_SUFFIX}".gsub(/[.-]([[:alpha:]])/, '~\1')
     out.architecture = "all"
     # TODO(sissel): Include the git commit hash?


### PR DESCRIPTION
For RPM/DEB packages of the OSS distribution we should name the package "logstash-oss".
Otherwise the same repository won't index correctly the default + oss distributions.

fixes https://github.com/elastic/logstash/issues/10698