### PR TITLE
field_refefence: handle illegal field references in converted maps

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -96,7 +96,7 @@ public final class JrubyEventExtLibrary {
                 }
                 this.event.setTimestamp(((JrubyTimestampExtLibrary.RubyTimestamp)value).getTimestamp());
             } else {
-                this.event.setField(r, Valuefier.convert(value));
+                this.event.setField(r, safeValueifierConvert(value));
             }
             return value;
         }
@@ -317,6 +317,22 @@ public final class JrubyEventExtLibrary {
         private static FieldReference extractFieldReference(final RubyString reference) {
             try {
                 return FieldReference.from(reference);
+            } catch (FieldReference.IllegalSyntaxException ise) {
+                throw RubyUtil.RUBY.newRuntimeError(ise.getMessage());
+            }
+        }
+
+        /**
+         * Shared logic to wrap {@link FieldReference.IllegalSyntaxException}s that are raised by
+         * {@link Valuefier#convert(Object)} when encountering illegal syntax in a ruby-exception
+         * that can be easily handled within the ruby plugins
+         *
+         * @param value a {@link Object} to be passed to {@link Valuefier#convert(Object)}
+         * @return the resulting {@link Object} (see: {@link Valuefier#convert(Object)})
+         */
+        private static Object safeValueifierConvert(final Object value) {
+            try {
+                return Valuefier.convert(value);
             } catch (FieldReference.IllegalSyntaxException ise) {
                 throw RubyUtil.RUBY.newRuntimeError(ise.getMessage());
             }


### PR DESCRIPTION
When using the Jruby event API, re-cast java exceptions produced by illegal
field references to ruby `RuntimeError`s, which can be caught by the ruby-based
plugins.

This is similar to what we already do in the Jruby event API when directly
handling field references, but catches a case where the `Valuifier` encounters
an illegal reference when creating a `ConvertedMap`.