### PR TITLE
Fix grammar in enable_metric filter option

### DIFF
--- a/docs/include/filter.asciidoc
+++ b/docs/include/filter.asciidoc
@@ -118,8 +118,8 @@ endif::[]
   * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
   * Default value is `true`
 
-Disable or enable metric logging for this specific plugin instance
-by default we record all the metrics we can, but you can disable metrics collection
+Disable or enable metric logging for this specific plugin instance.
+By default we record all the metrics we can, but you can disable metrics collection
 for a specific plugin.
 
 ifeval::["{versioned_docs}"!="true"]


### PR DESCRIPTION
The description in the documentation for the common filter option enable_metric was a run-on sentence, so split the sentence into two.