### PR TITLE
Update doc to reflect S3 input breaking change

### DIFF
--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -180,6 +180,19 @@ for the full list of changed names.
 * Removed obsolete `interval` option
 * Removed obsolete `ssl_certificate_verify` option
 
+*S3 Input*
+
+* Keys must now be set without quotes, i.e. 
+[source, ruby]
+-----
+bucket => "amazon_bucket_01"
+-----
+instead of 
+[source, ruby]
+-----
+"bucket" => "amazon_bucket_01"
+-----
+
 *Tcp Input*
 
 * Removed obsolete `data_timeout` option


### PR DESCRIPTION
S3 input keys need to be not-quoted.  In 6.x, you could have settings like `"bucket" => "test"`, but in 7.x, you can't have quotes wrapping your key, e.g. `bucket => "test"`