### PR TITLE
Update getting-started-with-logstash.asciidoc

### DIFF
--- a/docs/static/getting-started-with-logstash.asciidoc
+++ b/docs/static/getting-started-with-logstash.asciidoc
@@ -260,7 +260,7 @@ example:
 ["source","sh",subs="attributes"]
 --------------------------------------------------
 cd logstash-{logstash_version}
-bin/logstash -e 'input { stdin { } } output { stdout {} }'
+bin/logstash -e 'input { stdin { } } output { stdout {} }' --path.data=/tmp --path.logs=/tmp
 --------------------------------------------------
 
 NOTE: The location of the `bin` directory varies by platform. See {logstash-ref}/dir-layout.html[Directory layout]


### PR DESCRIPTION
On a Debian install at least, running the logstash binary directly as a user requires specifying a writable path.data and path.logs