### PR TITLE
Fix parsing of boolean options provided to Java plugins

### DIFF
--- a/logstash-core/src/main/java/org/logstash/plugins/ConfigurationImpl.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/ConfigurationImpl.java
@@ -44,6 +44,8 @@ public final class ConfigurationImpl implements Configuration {
                 return (T) o;
             } else if (configSpec.type() == Double.class && o.getClass() == Long.class) {
                 return configSpec.type().cast(((Long)o).doubleValue());
+            } else if (configSpec.type() == Boolean.class && o instanceof String) {
+                return configSpec.type().cast(Boolean.parseBoolean((String) o));
             } else if (configSpec.type() == Codec.class && o instanceof String && pluginFactory != null) {
                 Codec codec = pluginFactory.buildDefaultCodec((String) o);
                 return configSpec.type().cast(codec);

--- a/logstash-core/src/test/java/org/logstash/plugins/ConfigurationImplTest.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/ConfigurationImplTest.java
@@ -188,4 +188,26 @@ public class ConfigurationImplTest {
         Assert.assertEquals("<password>", p.toString());
     }
 
+    @Test
+    public void testBooleanValues() {
+        PluginConfigSpec<Boolean> booleanConfig = PluginConfigSpec.booleanSetting(booleanKey, false, false, false);
+        Configuration config = new ConfigurationImpl(Collections.singletonMap(booleanKey, "tRuE"));
+        boolean value = config.get(booleanConfig);
+        Assert.assertTrue(value);
+
+        config = new ConfigurationImpl(Collections.singletonMap(booleanKey, "false"));
+        value = config.get(booleanConfig);
+        Assert.assertFalse(value);
+
+        booleanConfig = PluginConfigSpec.booleanSetting(booleanKey, false, false, false);
+        config = new ConfigurationImpl(Collections.emptyMap());
+        value = config.get(booleanConfig);
+        Assert.assertFalse(value);
+
+        booleanConfig = PluginConfigSpec.booleanSetting(booleanKey, true, false, false);
+        config = new ConfigurationImpl(Collections.emptyMap());
+        value = config.get(booleanConfig);
+        Assert.assertTrue(value);
+    }
+
 }


### PR DESCRIPTION
The values for boolean plugin options are presented as strings and must be parsed as booleans to function correctly.
