### PR TITLE
Add details about Elastic Search dependency

### DIFF
--- a/docs/static/configuration.asciidoc
+++ b/docs/static/configuration.asciidoc
@@ -23,7 +23,7 @@ Then, run logstash and specify the configuration file with the `-f` flag.
 bin/logstash -f logstash-simple.conf
 ----------------------------------
 
-Et voilà! Logstash reads  the specified configuration file and outputs to both Elasticsearch and stdout. Before we
+Et voilà! Logstash reads  the specified configuration file and outputs to both Elasticsearch and stdout. Note that if you see a message in stdout that reads "Elasticsearch Unreachable" that you will need to make sure Elasticsearch is installed and up and reachable on port 9200. Before we
 move on to some <<config-examples,more complex examples>>, let's take a closer look at what's in a config file.
 
 [[configuration-file-structure]]


### PR DESCRIPTION
No Elastic Search dependency is mentioned in the guide for Logstash up to this point. This would be good for those who are getting started to Log Stash without knowing much about Elastic Search and unaware that it isn't already packages along with the install of Logstash.