### PR TITLE
Add workers and batch_size to root request

### DIFF
--- a/logstash-core/lib/logstash/api/commands/default_metadata.rb
+++ b/logstash-core/lib/logstash/api/commands/default_metadata.rb
@@ -15,6 +15,10 @@ module LogStash
            :ephemeral_id => service.agent.ephemeral_id,
            :status => "green",  # This is hard-coded to mirror x-pack behavior
            :snapshot => ::BUILD_INFO["build_snapshot"],
+           :pipeline => {
+             :workers => LogStash::SETTINGS.get("pipeline.workers"),
+             :batch_size => LogStash::SETTINGS.get("pipeline.batch.size"),
+           }
            }
         end
 

--- a/logstash-core/lib/logstash/api/commands/default_metadata.rb
+++ b/logstash-core/lib/logstash/api/commands/default_metadata.rb
@@ -18,6 +18,7 @@ module LogStash
            :pipeline => {
              :workers => LogStash::SETTINGS.get("pipeline.workers"),
              :batch_size => LogStash::SETTINGS.get("pipeline.batch.size"),
+             :batch_delay => LogStash::SETTINGS.get("pipeline.batch.delay"),
            }
            }
         end


### PR DESCRIPTION
Adds request made by @ycombinator [here](https://github.com/elastic/logstash/issues/10121#issuecomment-477960900).

Adds the following fields to `GET /`:

```
"pipeline" : {
  "batch_size" : 125,
  "workers" : 8
}
```