### PR TITLE
avoid clashes between Environment class methods

### DIFF
--- a/lib/bootstrap/environment.rb
+++ b/lib/bootstrap/environment.rb
@@ -42,7 +42,7 @@ module LogStash
       !File.exists?(File.join(LogStash::Environment::LOGSTASH_HOME, "x-pack"))
     end
 
-    def windows?
+    def win_platform?
       ::Gem.win_platform?
     end
 

--- a/lib/pluginmanager/pack.rb
+++ b/lib/pluginmanager/pack.rb
@@ -2,8 +2,8 @@
 require_relative "pack_command"
 
 class LogStash::PluginManager::Pack < LogStash::PluginManager::PackCommand
-  option "--tgz", :flag, "compress package as a tar.gz file", :default => !LogStash::Environment.windows?
-  option "--zip", :flag, "compress package as a zip file", :default => LogStash::Environment.windows?
+  option "--tgz", :flag, "compress package as a tar.gz file", :default => !LogStash::Environment.win_platform?
+  option "--zip", :flag, "compress package as a zip file", :default => LogStash::Environment.win_platform?
   option "--[no-]clean", :flag, "clean up the generated dump of plugins", :default => true
   option "--overwrite", :flag, "Overwrite a previously generated package file", :default => false
 

--- a/lib/pluginmanager/unpack.rb
+++ b/lib/pluginmanager/unpack.rb
@@ -2,8 +2,8 @@
 require_relative "pack_command"
 
 class LogStash::PluginManager::Unpack < LogStash::PluginManager::PackCommand
-  option "--tgz", :flag, "unpack a packaged tar.gz file", :default => !LogStash::Environment.windows?
-  option "--zip", :flag, "unpack a packaged  zip file", :default => LogStash::Environment.windows?
+  option "--tgz", :flag, "unpack a packaged tar.gz file", :default => !LogStash::Environment.win_platform?
+  option "--zip", :flag, "unpack a packaged  zip file", :default => LogStash::Environment.win_platform?
 
   parameter "file", "the package file name", :attribute_name => :package_file, :required => true
 

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -164,11 +164,15 @@ module LogStash
     end
 
     def windows?
-      RbConfig::CONFIG['host_os'] =~ WINDOW_OS_RE
+      host_os =~ WINDOW_OS_RE
     end
 
     def linux?
-      RbConfig::CONFIG['host_os'] =~ LINUX_OS_RE
+      host_os =~ LINUX_OS_RE
+    end
+
+    def host_os
+      RbConfig::CONFIG['host_os']
     end
 
     def locales_path(path)

--- a/logstash-core/spec/logstash/environment_spec.rb
+++ b/logstash-core/spec/logstash/environment_spec.rb
@@ -57,14 +57,14 @@ describe LogStash::Environment do
     context "windows" do
       windows_host_os.each do |host|
         it "#{host} returns true" do
-          expect(RbConfig::CONFIG).to receive(:[]).with("host_os").and_return(host)
+          allow(LogStash::Environment).to receive(:host_os).and_return(host)
           expect(LogStash::Environment.windows?).to be_truthy
         end
       end
 
       linux_host_os.each do |host|
         it "#{host} returns false" do
-          expect(RbConfig::CONFIG).to receive(:[]).with("host_os").and_return(host)
+          allow(LogStash::Environment).to receive(:host_os).and_return(host)
           expect(LogStash::Environment.windows?).to be_falsey
         end
       end
@@ -73,14 +73,14 @@ describe LogStash::Environment do
     context "Linux" do
       windows_host_os.each do |host|
         it "#{host} returns true" do
-          expect(RbConfig::CONFIG).to receive(:[]).with("host_os").and_return(host)
+          allow(LogStash::Environment).to receive(:host_os).and_return(host)
           expect(LogStash::Environment.linux?).to be_falsey
         end
       end
 
       linux_host_os.each do |host|
         it "#{host} returns false" do
-          expect(RbConfig::CONFIG).to receive(:[]).with("host_os").and_return(host)
+          allow(LogStash::Environment).to receive(:host_os).and_return(host)
           expect(LogStash::Environment.linux?).to be_truthy
         end
       end


### PR DESCRIPTION
Logstash core depends on `LogStash::Environment` methods `windows?` and `linux?` that are defined in `logstash-core/lib/logstash/environment.rb`.

The Plugin manager depends on `LogStash::Environment` method `windows?`  that is defined in `lib/bootstrap/environment.rb`.

The fact that both files define `LogStash::Environment.windows?` is not a problem since the bootstrap environment is only used when starting logstash - that spawns a new process - where only the logstash-core version of environment.rb is read.

However, the java/gradle driven tests like `org.logstash.config.ir.CompiledPipelineTest` load the bootstrap environment within the same process that runs the tests.

This leads to problems in tests where rspec may fail to mock or call the right implementation of the `windows?` predicate.

This PR simply renames one of the `windows?` predicates to avoid clashes. A more structure solution means changing `lib/bootstrap/environment` to not use `LogStash::Environment` module.