### PR TITLE
Do not shut down API webserver until after pipelines have been shut down

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -186,9 +186,9 @@ class LogStash::Agent
     pipeline_bus.setBlockOnUnlisten(true)
 
     stop_collecting_metrics
-    stop_webserver
     transition_to_stopped
     converge_result = shutdown_pipelines
+    stop_webserver
     converge_result
   end
 


### PR DESCRIPTION
This change allows for the monitoring APIs to continue to function during the pipeline shutdown process. All monitoring endpoints (hot threads, plugins, event stats, etc.) remain functional. The only functional difference is that for any pipeline that has completed shutdown, its metrics in the pipeline stats endpoint will be returned as blank or empty values. E.g., in the case below, the `pipeline1` pipeline has completed shutdown and no longer provides metrics though metrics remain available for other pipelines that have not yet completed shutdown:

```
  "pipelines" : {
    "pipeline1" : {
      "events" : null,
      "plugins" : {
        "inputs" : [ ],
        "codecs" : [ ],
        "filters" : [ ],
        "outputs" : [ ]
      },
      "reloads" : {
        "last_error" : null,
        "failures" : 0,
        "last_success_timestamp" : null,
        "last_failure_timestamp" : null,
        "successes" : 0
      },
      "queue" : {
        "type" : "memory"
      }
    }
```