### PR TITLE
Restore UUID lookup to node

### DIFF
--- a/logstash-core/lib/logstash/api/commands/node.rb
+++ b/logstash-core/lib/logstash/api/commands/node.rb
@@ -83,7 +83,7 @@ module LogStash
 
         private
         ##
-        # Returns a vertex, decorated with additional metadata if available.
+        # Returns a vertex, decorated with the cluster UUID metadata retrieved from ES
         # Does not mutate the passed `vertex` object.
         # @api private
         # @param vertex [Hash{String=>Object}]

--- a/logstash-core/lib/logstash/api/commands/node.rb
+++ b/logstash-core/lib/logstash/api/commands/node.rb
@@ -39,7 +39,7 @@ module LogStash
           ).reject{|_, v|v.nil?}
           if options.fetch(:graph, false)
             extended_stats = extract_metrics([:stats, :pipelines, pipeline_id.to_sym, :config], :graph)
-            decorated_vertices = extended_stats[:graph]["graph"]["vertices"].map { |vertex| decorate_vertex(vertex)  }
+            decorated_vertices = extended_stats[:graph]["graph"]["vertices"].map { |vertex| decorate_with_cluster_uuids(vertex)  }
             extended_stats[:graph]["graph"]["vertices"] = decorated_vertices
             metrics.merge!(extended_stats)
           end
@@ -88,7 +88,7 @@ module LogStash
         # @api private
         # @param vertex [Hash{String=>Object}]
         # @return [Hash{String=>Object}]
-        def decorate_vertex(vertex)
+        def decorate_with_cluster_uuids(vertex)
           plugin_id = vertex["id"]&.to_s
           return vertex unless plugin_id && LogStash::PluginMetadata.exists?(plugin_id)
 

--- a/logstash-core/lib/logstash/api/commands/node.rb
+++ b/logstash-core/lib/logstash/api/commands/node.rb
@@ -39,8 +39,8 @@ module LogStash
           ).reject{|_, v|v.nil?}
           if options.fetch(:graph, false)
             extended_stats = extract_metrics([:stats, :pipelines, pipeline_id.to_sym, :config], :graph)
-            graph = extended_stats[:graph]["graph"]
-            extended_stats[:vertices] = graph["vertices"].map { |vertex| decorate_vertex(vertex)  }
+            decorated_vertices = extended_stats[:graph]["graph"]["vertices"].map { |vertex| decorate_vertex(vertex)  }
+            extended_stats[:graph]["graph"]["vertices"] = decorated_vertices
             metrics.merge!(extended_stats)
           end
           metrics

--- a/logstash-core/lib/logstash/api/commands/node.rb
+++ b/logstash-core/lib/logstash/api/commands/node.rb
@@ -38,11 +38,32 @@ module LogStash
             :dead_letter_queue_path,
           ).reject{|_, v|v.nil?}
           if options.fetch(:graph, false)
-            metrics.merge!(extract_metrics([:stats, :pipelines, pipeline_id.to_sym, :config], :graph))
+            extended_stats = extract_metrics([:stats, :pipelines, pipeline_id.to_sym, :config], :graph)
+            graph = extended_stats[:graph]["graph"]
+            extended_stats[:vertices] = graph["vertices"].map { |vertex| decorate_vertex(vertex)  }
+            metrics.merge!(extended_stats)
           end
           metrics
         rescue
           {}
+        end
+
+        private
+        ##
+        # Returns a vertex, decorated with additional metadata if available.
+        # Does not mutate the passed `vertex` object.
+        # @api private
+        # @param vertex [Hash{String=>Object}]
+        # @return [Hash{String=>Object}]
+        def decorate_vertex(vertex)
+          plugin_id = vertex["id"]&.to_s
+          return vertex unless plugin_id && LogStash::PluginMetadata.exists?(plugin_id)
+
+          plugin_metadata = LogStash::PluginMetadata.for_plugin(plugin_id)
+          cluster_uuid = plugin_metadata&.get(:cluster_uuid)
+          vertex = vertex.merge("cluster_uuid" => cluster_uuid) unless cluster_uuid.nil?
+
+          vertex
         end
 
         def os

--- a/logstash-core/lib/logstash/api/commands/node.rb
+++ b/logstash-core/lib/logstash/api/commands/node.rb
@@ -48,24 +48,6 @@ module LogStash
           {}
         end
 
-        private
-        ##
-        # Returns a vertex, decorated with additional metadata if available.
-        # Does not mutate the passed `vertex` object.
-        # @api private
-        # @param vertex [Hash{String=>Object}]
-        # @return [Hash{String=>Object}]
-        def decorate_vertex(vertex)
-          plugin_id = vertex["id"]&.to_s
-          return vertex unless plugin_id && LogStash::PluginMetadata.exists?(plugin_id)
-
-          plugin_metadata = LogStash::PluginMetadata.for_plugin(plugin_id)
-          cluster_uuid = plugin_metadata&.get(:cluster_uuid)
-          vertex = vertex.merge("cluster_uuid" => cluster_uuid) unless cluster_uuid.nil?
-
-          vertex
-        end
-
         def os
           {
             :name => java.lang.System.getProperty("os.name"),
@@ -97,6 +79,24 @@ module LogStash
 
         def hot_threads(options={})
           HotThreadsReport.new(self, options)
+        end
+
+        private
+        ##
+        # Returns a vertex, decorated with additional metadata if available.
+        # Does not mutate the passed `vertex` object.
+        # @api private
+        # @param vertex [Hash{String=>Object}]
+        # @return [Hash{String=>Object}]
+        def decorate_vertex(vertex)
+          plugin_id = vertex["id"]&.to_s
+          return vertex unless plugin_id && LogStash::PluginMetadata.exists?(plugin_id)
+
+          plugin_metadata = LogStash::PluginMetadata.for_plugin(plugin_id)
+          cluster_uuid = plugin_metadata&.get(:cluster_uuid)
+          vertex = vertex.merge("cluster_uuid" => cluster_uuid) unless cluster_uuid.nil?
+
+          vertex
         end
       end
     end


### PR DESCRIPTION
Fixes https://github.com/elastic/logstash/issues/10883

During the review process, @yaauie wisely suggested that we move the UUID lookup out of the LIR serializer to avoid mutating the structure and to safeguard against future bugs. In doing so, though, I neglected to note that the `node` endpoint was relying on this functionality as well. This PR moves the lookup functionality into the API layer at the `node` endpoint.

@yaauie You will see some code duplication here between the `node` endpoint and the `stats` endpoint. (Note also that I explicitly marked this version as private.) 

I briefly considered moving the vertex decorator into `base.rb` but wasn't certain whether or not it fit into the paradigm for that file. Please let me know if you think we should keep the duplication as-is or if you have a suggestion for a better home for the vertex decoration method which could be called from a single location by both `node.rb` and from `stats.rb`. 