### PR TITLE
Inject hash and ephemeral_id into stats

### DIFF
--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -152,6 +152,8 @@ module LogStash
             # if extended_stats were provided, enrich the return value
             if extended_stats
               ret[:queue]    = extended_stats["queue"] if extended_stats.include?("queue")
+              ret[:hash] = extended_stats["hash"]
+              ret[:ephemeral_id] = extended_stats["ephemeral_id"]
               if opts[:vertices] && extended_stats.include?("vertices")
                 ret[:vertices] = extended_stats["vertices"].map { |vertex| decorate_vertex(vertex) }
               end


### PR DESCRIPTION
Resolve this comment: https://github.com/elastic/logstash/issues/10120#issuecomment-504671395

This was lost during the review process for https://github.com/elastic/logstash/pull/10576/ and simply needed to be included inserted into the API return as we parse the extended_stats data structure.