### PR TITLE
[DOCS] Update offline-plugins.asciidoc

### DIFF
--- a/docs/static/offline-plugins.asciidoc
+++ b/docs/static/offline-plugins.asciidoc
@@ -24,7 +24,7 @@ access the Internet.
 +
 [source, shell]
 -------------------------------------------------------------------------------
-bin/logstash-plugin prepare-offline-pack --output OUTPUT [PLUGINS] --overwrite
+bin/logstash-plugin prepare-offline-pack --output OUTPUT --overwrite [PLUGINS]
 -------------------------------------------------------------------------------
 +
 where:


### PR DESCRIPTION
Because:
`./logstash-plugin prepare-offline-pack logstash-input-beats --overwrite`
`ERROR: Cannot create the offline archive, message: Cannot find plugins matching: --overwrite`
Only works:
`./logstash-plugin prepare-offline-pack --overwrite logstash-input-beats`
`Offline package created at: /usr/share/logstash/logstash-offline-plugins-7.2.0.zip
You can install it with this command bin/logstash-plugin install file:///usr/share/logstash/logstash-offline-plugins-7.2.0.zip`