### PR TITLE
remove gcs output from skip list

### DIFF
--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -422,7 +422,7 @@
   },
   "logstash-output-google_cloud_storage": {
     "default-plugins": false,
-    "skip-list": true
+    "skip-list": false
   },
   "logstash-output-graphite": {
     "default-plugins": true,


### PR DESCRIPTION
the plugin being in the skip list causes it to not be listed in the logstash documentation page. this PR removes it from the skip list.