### PR TITLE
logstash-input-twitter as a default plugin

### DIFF
--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -391,7 +391,7 @@
     "skip-list": false
   },
   "logstash-input-twitter": {
-    "default-plugins": false,
+    "default-plugins": true,
     "skip-list": false
   },
   "logstash-input-udp": {


### PR DESCRIPTION
This simply sets `"default-plugins": true` on the `logstash-input-twitter`.

This is a followup on #10928 where setting logstash-input-twitter as a default plugin resulted in a build failure. It was reverted for the sake of moving forward the BC builds.

We can now deal with build issues here separately. 


