### PR TITLE
fix plugin version bump rake task

### DIFF
--- a/tools/release/bump_plugin_versions.rb
+++ b/tools/release/bump_plugin_versions.rb
@@ -53,7 +53,9 @@ puts "Generating new Gemfile.template file with computed dependencies"
 gemfile = IO.read("Gemfile.template")
 base_plugin_versions.each do |plugin, version|
   dependency = compute_dependecy(version, allow_bump_for)
-  gemfile.gsub!(/"#{plugin}".*$/, "\"#{plugin}\", \"#{dependency}\"")
+  if gemfile.gsub!(/"#{plugin}".*$/, "\"#{plugin}\", \"#{dependency}\"").nil?
+    gemfile << "gem \"#{plugin}\", \"#{dependency}\"\n"
+  end
 end
 
 IO.write("Gemfile.template", gemfile)


### PR DESCRIPTION
By removing the default plugins from the Gemfile.template
the current task that modified the template was not working correctly.

This commit either replaces the dependency entry if it exists or
otherwise creates it.

This can be tested by running `./tools/release/bump_plugin_versions.rb 7.2 7.2.0 patch` in the 7.2 branch. You can verify that some plugins are bumped by minors and majors (not just patches).
Applying this patch and rerunning the command will yield only patch bumps as expected.