### PR TITLE
[7.x clean backport of #10934] logstash-input-twitter as a default plugin

### DIFF
--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -391,7 +391,7 @@
     "skip-list": false
   },
   "logstash-input-twitter": {
-    "default-plugins": false,
+    "default-plugins": true,
     "skip-list": false
   },
   "logstash-input-udp": {


### PR DESCRIPTION
[7.x clean backport of #10934] logstash-input-twitter as a default plugin