### PR TITLE
Change version of Logstash containing GA version of Java plugin API

### DIFF
--- a/docs/static/include/javapluginsetup.asciidoc
+++ b/docs/static/include/javapluginsetup.asciidoc
@@ -20,7 +20,7 @@ git clone --branch <branch_name> --single-branch https://github.com/elastic/logs
 The `branch_name` should correspond to the version of Logstash containing the
 preferred revision of the Java plugin API. 
 
-NOTE: The GA version of the Java plugin API is available in the `7.1`
+NOTE: The GA version of the Java plugin API is available in the `7.2`
 and later branches of the Logstash codebase.
 
 Specify the `target_folder` for your local copy of the Logstash codebase. If you


### PR DESCRIPTION
The plugin API ended up going out in the 7.2 release of Logstash.
