### PR TITLE
Add coming tag to 7.2.1 release notes

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -18,6 +18,8 @@ This section summarizes the changes in the following releases:
 [[logstash-7-2-1]]
 === Logstash 7.2.1 Release Notes
 
+coming[7.2.1]
+
 * Fixes pipeline to pipeline shutdown ordering https://github.com/elastic/logstash/pull/10872[#10872]
 * Changed: Do not shut down API webserver until after pipelines have been shut down https://github.com/elastic/logstash/pull/10880[#10880]
 * Documentation: documentation for java plugins:


### PR DESCRIPTION
Adds `Coming` tag to release notes. Should be removed on day of release. 

<img width="507" alt="Screen Shot 2019-07-16 at 10 56 32 AM" src="https://user-images.githubusercontent.com/35154725/61305214-6dd4e280-a7b8-11e9-8c06-dda5f7e14686.png">
