### PR TITLE
Fix include path

### DIFF
--- a/docs/static/core-plugins/filters/java-uuid-filter.asciidoc
+++ b/docs/static/core-plugins/filters/java-uuid-filter.asciidoc
@@ -7,7 +7,7 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 :version: %VERSION%
 :release_date: %RELEASE_DATE%
 :changelog_url: %CHANGELOG_URL%
-:include_path: ../../../../logstash/docs/include
+:include_path: ../../../../../logstash/docs/include
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////


### PR DESCRIPTION
Note that since you are pulling this file in directly and building it (instead of having it moved to logstash-docs), you'll need to set the attributes (version, release_date, changelog_url) manually.

Not sure how you plan to handle this topic in the versioned plugin reference, but this change gets the doc to build. 