### PR TITLE
Don't warn on array type

### DIFF
--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGauge.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGauge.java
@@ -3,6 +3,7 @@ package org.logstash.instrument.metrics.gauge;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jruby.RubyHash;
+import org.jruby.RubyArray;
 import org.logstash.ext.JrubyTimestampExtLibrary.RubyTimestamp;
 import org.logstash.instrument.metrics.AbstractMetric;
 import org.logstash.instrument.metrics.MetricType;
@@ -91,8 +92,10 @@ public class LazyDelegatingGauge extends AbstractMetric<Object> implements Gauge
             } else if (value instanceof RubyTimestamp) {
                 lazyMetric = new RubyTimeStampGauge(key, (RubyTimestamp) value);
             } else {
-                LOGGER.warn("A gauge metric of an unknown type ({}) has been create for key: {}. This may result in invalid serialization.  It is recommended to " +
-                        "log an issue to the responsible developer/development team.", value.getClass().getCanonicalName(), key);
+                if (!(value instanceof RubyArray)) {
+                    LOGGER.warn("A gauge metric of an unknown type ({}) has been create for key: {}. This may result in invalid serialization.  It is recommended to " +
+                            "log an issue to the responsible developer/development team.", value.getClass().getCanonicalName(), key);
+                }
                 lazyMetric = new UnknownGauge(key, value);
             }
         }


### PR DESCRIPTION
**Warning: I am not 100% sure this is the correct fix**

This addresses the warning message from https://github.com/elastic/logstash/issues/10886

To begin, I attempted to model the [same approach taken for RubyHashes ](https://github.com/elastic/logstash/blob/master/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/RubyHashGauge.java). However, I could not get this to work. I received the following error when running `gradlew assemble`:

```
> Task :logstash-core:compileJava
/Users/mp/devel/logstash/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/RubyArrayGauge.java:12: warning: [rawtypes] found raw type: RubyArray
public class RubyArrayGauge extends AbstractGaugeMetric<RubyArray> {
                                                        ^
  missing type arguments for generic class RubyArray<T>
  where T is a type-variable:
    T extends IRubyObject declared in class RubyArray
/Users/mp/devel/logstash/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/RubyArrayGauge.java:33: warning: [rawtypes] found raw type: RubyArray
    protected RubyArrayGauge(String name, RubyArray initialValue) {
                                          ^
  missing type arguments for generic class RubyArray<T>
  where T is a type-variable:
    T extends IRubyObject declared in class RubyArray
error: warnings found and -Werror specified
1 error
2 warnings

> Task :logstash-core:compileJava FAILED

FAILURE: Build failed with an exception.
```

Therefore, am not certain whether it is worth trying to make a specialized `RubyArrayGauge` or whether we can simply fall back to using the `UnknownGauage`, which is what is happening right now. If we're fine with the `UnknownGauage`, this PR simply avoids the warning message.

So, please consider this PR as a point of discussion. If we want to proceed with making a `RubyArrayGauge`, that's fine of course and we can close this. I'm interested in what people think. Thanks!

