### PR TITLE
[Doc]Prepare core plugin docs for inclusion in LS ref

### DIFF
--- a/docs/include/plugin_header-core.asciidoc
+++ b/docs/include/plugin_header-core.asciidoc
@@ -1,0 +1,14 @@
+[subs="attributes"]
+++++
+<titleabbrev>{plugin}</titleabbrev>
+++++
+
+*{ls} Core Plugin.* The {plugin} {type} plugin cannot be
+installed or uninstalled independently of {ls}.
+
+==== Getting Help
+
+For questions about the plugin, open a topic in the
+http://discuss.elastic.co[Discuss] forums. For bugs or feature requests, open an
+issue in https://github.com/logstash[Github].
+

--- a/docs/static/core-plugins/codecs/java_dots.asciidoc
+++ b/docs/static/core-plugins/codecs/java_dots.asciidoc
@@ -1,4 +1,4 @@
-:plugin: java_dots
+:plugin: jdots
 :type: codec
 
 ///////////////////////////////////////////
@@ -11,7 +11,7 @@ END - REPLACES GENERATED VARIABLES
 
 [id="plugins-{type}s-{plugin}"]
 
-=== Java_dots codec plugin
+=== Jdots codec plugin
 
 include::{include_path}/plugin_header-core.asciidoc[]
 

--- a/docs/static/core-plugins/codecs/java_dots.asciidoc
+++ b/docs/static/core-plugins/codecs/java_dots.asciidoc
@@ -1,22 +1,19 @@
-:plugin: jdots
+:plugin: java_dots
 :type: codec
 
 ///////////////////////////////////////////
-START - GENERATED VARIABLES, DO NOT EDIT!
+REPLACES GENERATED VARIABLES
 ///////////////////////////////////////////
-:version: %VERSION%
-:release_date: %RELEASE_DATE%
-:changelog_url: %CHANGELOG_URL%
-:include_path: ../../../../logstash/docs/include
+:include_path: ../../../../../logstash/docs/include
 ///////////////////////////////////////////
-END - GENERATED VARIABLES, DO NOT EDIT!
+END - REPLACES GENERATED VARIABLES
 ///////////////////////////////////////////
 
 [id="plugins-{type}s-{plugin}"]
 
-=== Java dots codec plugin
+=== Java_dots codec plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-core.asciidoc[]
 
 ==== Description
 

--- a/docs/static/core-plugins/codecs/java_line.asciidoc
+++ b/docs/static/core-plugins/codecs/java_line.asciidoc
@@ -1,35 +1,36 @@
-:plugin: java_plain
+:plugin: java_line
 :type: codec
 
 ///////////////////////////////////////////
-START - GENERATED VARIABLES, DO NOT EDIT!
+REPLACES GENERATED VARIABLES
 ///////////////////////////////////////////
-:version: %VERSION%
-:release_date: %RELEASE_DATE%
-:changelog_url: %CHANGELOG_URL%
-:include_path: ../../../../logstash/docs/include
+:include_path: ../../../../../logstash/docs/include
 ///////////////////////////////////////////
-END - GENERATED VARIABLES, DO NOT EDIT!
+END - REPLACES GENERATED VARIABLES
 ///////////////////////////////////////////
 
 [id="plugins-{type}s-{plugin}"]
 
-=== Java plain codec plugin
+=== Java_line codec plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-core.asciidoc[]
 
 ==== Description
 
-The `java_plain` codec is for text data with no delimiters between events. It is useful mainly for inputs and outputs that
-already have a defined framing in their transport protocol such as ZeroMQ, RabbitMQ, Redis, etc.
+Encodes and decodes line-oriented text data.
+
+Decoding behavior: All text data between specified delimiters will be decoded as distinct events.
+
+Encoding behavior: Each event will be emitted with the specified trailing delimiter.
 
 [id="plugins-{type}s-{plugin}-options"]
-==== Plain Codec Configuration Options
+==== Java_line Codec Configuration Options
 
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-charset>> |<<string,string>>, one of `["ASCII-8BIT", "UTF-8", "US-ASCII", "Big5", "Big5-HKSCS", "Big5-UAO", "CP949", "Emacs-Mule", "EUC-JP", "EUC-KR", "EUC-TW", "GB2312", "GB18030", "GBK", "ISO-8859-1", "ISO-8859-2", "ISO-8859-3", "ISO-8859-4", "ISO-8859-5", "ISO-8859-6", "ISO-8859-7", "ISO-8859-8", "ISO-8859-9", "ISO-8859-10", "ISO-8859-11", "ISO-8859-13", "ISO-8859-14", "ISO-8859-15", "ISO-8859-16", "KOI8-R", "KOI8-U", "Shift_JIS", "UTF-16BE", "UTF-16LE", "UTF-32BE", "UTF-32LE", "Windows-31J", "Windows-1250", "Windows-1251", "Windows-1252", "IBM437", "IBM737", "IBM775", "CP850", "IBM852", "CP852", "IBM855", "CP855", "IBM857", "IBM860", "IBM861", "IBM862", "IBM863", "IBM864", "IBM865", "IBM866", "IBM869", "Windows-1258", "GB1988", "macCentEuro", "macCroatian", "macCyrillic", "macGreek", "macIceland", "macRoman", "macRomania", "macThai", "macTurkish", "macUkraine", "CP950", "CP951", "IBM037", "stateless-ISO-2022-JP", "eucJP-ms", "CP51932", "EUC-JIS-2004", "GB12345", "ISO-2022-JP", "ISO-2022-JP-2", "CP50220", "CP50221", "Windows-1256", "Windows-1253", "Windows-1255", "Windows-1254", "TIS-620", "Windows-874", "Windows-1257", "MacJapanese", "UTF-7", "UTF8-MAC", "UTF-16", "UTF-32", "UTF8-DoCoMo", "SJIS-DoCoMo", "UTF8-KDDI", "SJIS-KDDI", "ISO-2022-JP-KDDI", "stateless-ISO-2022-JP-KDDI", "UTF8-SoftBank", "SJIS-SoftBank", "BINARY", "CP437", "CP737", "CP775", "IBM850", "CP857", "CP860", "CP861", "CP862", "CP863", "CP864", "CP865", "CP866", "CP869", "CP1258", "Big5-HKSCS:2008", "ebcdic-cp-us", "eucJP", "euc-jp-ms", "EUC-JISX0213", "eucKR", "eucTW", "EUC-CN", "eucCN", "CP936", "ISO2022-JP", "ISO2022-JP2", "ISO8859-1", "ISO8859-2", "ISO8859-3", "ISO8859-4", "ISO8859-5", "ISO8859-6", "CP1256", "ISO8859-7", "CP1253", "ISO8859-8", "CP1255", "ISO8859-9", "CP1254", "ISO8859-10", "ISO8859-11", "CP874", "ISO8859-13", "CP1257", "ISO8859-14", "ISO8859-15", "ISO8859-16", "CP878", "MacJapan", "ASCII", "ANSI_X3.4-1968", "646", "CP65000", "CP65001", "UTF-8-MAC", "UTF-8-HFS", "UCS-2BE", "UCS-4BE", "UCS-4LE", "CP932", "csWindows31J", "SJIS", "PCK", "CP1250", "CP1251", "CP1252", "external", "locale"]`|No
+| <<plugins-{type}s-{plugin}-delimiter>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-format>> |<<string,string>>|No
 |=======================================================================
 
@@ -41,8 +42,16 @@ already have a defined framing in their transport protocol such as ZeroMQ, Rabbi
   * Value can be any of: `ASCII-8BIT`, `UTF-8`, `US-ASCII`, `Big5`, `Big5-HKSCS`, `Big5-UAO`, `CP949`, `Emacs-Mule`, `EUC-JP`, `EUC-KR`, `EUC-TW`, `GB2312`, `GB18030`, `GBK`, `ISO-8859-1`, `ISO-8859-2`, `ISO-8859-3`, `ISO-8859-4`, `ISO-8859-5`, `ISO-8859-6`, `ISO-8859-7`, `ISO-8859-8`, `ISO-8859-9`, `ISO-8859-10`, `ISO-8859-11`, `ISO-8859-13`, `ISO-8859-14`, `ISO-8859-15`, `ISO-8859-16`, `KOI8-R`, `KOI8-U`, `Shift_JIS`, `UTF-16BE`, `UTF-16LE`, `UTF-32BE`, `UTF-32LE`, `Windows-31J`, `Windows-1250`, `Windows-1251`, `Windows-1252`, `IBM437`, `IBM737`, `IBM775`, `CP850`, `IBM852`, `CP852`, `IBM855`, `CP855`, `IBM857`, `IBM860`, `IBM861`, `IBM862`, `IBM863`, `IBM864`, `IBM865`, `IBM866`, `IBM869`, `Windows-1258`, `GB1988`, `macCentEuro`, `macCroatian`, `macCyrillic`, `macGreek`, `macIceland`, `macRoman`, `macRomania`, `macThai`, `macTurkish`, `macUkraine`, `CP950`, `CP951`, `IBM037`, `stateless-ISO-2022-JP`, `eucJP-ms`, `CP51932`, `EUC-JIS-2004`, `GB12345`, `ISO-2022-JP`, `ISO-2022-JP-2`, `CP50220`, `CP50221`, `Windows-1256`, `Windows-1253`, `Windows-1255`, `Windows-1254`, `TIS-620`, `Windows-874`, `Windows-1257`, `MacJapanese`, `UTF-7`, `UTF8-MAC`, `UTF-16`, `UTF-32`, `UTF8-DoCoMo`, `SJIS-DoCoMo`, `UTF8-KDDI`, `SJIS-KDDI`, `ISO-2022-JP-KDDI`, `stateless-ISO-2022-JP-KDDI`, `UTF8-SoftBank`, `SJIS-SoftBank`, `BINARY`, `CP437`, `CP737`, `CP775`, `IBM850`, `CP857`, `CP860`, `CP861`, `CP862`, `CP863`, `CP864`, `CP865`, `CP866`, `CP869`, `CP1258`, `Big5-HKSCS:2008`, `ebcdic-cp-us`, `eucJP`, `euc-jp-ms`, `EUC-JISX0213`, `eucKR`, `eucTW`, `EUC-CN`, `eucCN`, `CP936`, `ISO2022-JP`, `ISO2022-JP2`, `ISO8859-1`, `ISO8859-2`, `ISO8859-3`, `ISO8859-4`, `ISO8859-5`, `ISO8859-6`, `CP1256`, `ISO8859-7`, `CP1253`, `ISO8859-8`, `CP1255`, `ISO8859-9`, `CP1254`, `ISO8859-10`, `ISO8859-11`, `CP874`, `ISO8859-13`, `CP1257`, `ISO8859-14`, `ISO8859-15`, `ISO8859-16`, `CP878`, `MacJapan`, `ASCII`, `ANSI_X3.4-1968`, `646`, `CP65000`, `CP65001`, `UTF-8-MAC`, `UTF-8-HFS`, `UCS-2BE`, `UCS-4BE`, `UCS-4LE`, `CP932`, `csWindows31J`, `SJIS`, `PCK`, `CP1250`, `CP1251`, `CP1252`, `external`, `locale`
   * Default value is `"UTF-8"`
 
-The character encoding used in this input. Examples include `UTF-8` and `cp1252`. This setting is useful if your data
-is in a character set other than `UTF-8`.
+The character encoding used by this input. Examples include `UTF-8` and `cp1252`. This setting is useful if your
+inputs are in `Latin-1` (aka `cp1252`) or other character sets than `UTF-8`.
+
+[id="plugins-{type}s-{plugin}-delimiter"]
+===== `delimiter`
+
+  * Value type is <<string,string>>
+  * Default value is the system-dependent line separator ("\n" for UNIX systems; "\r\n" for Microsoft Windows)
+
+Specifies the delimiter that indicates end-of-line.
 
 [id="plugins-{type}s-{plugin}-format"]
 ===== `format`

--- a/docs/static/core-plugins/codecs/java_plain.asciidoc
+++ b/docs/static/core-plugins/codecs/java_plain.asciidoc
@@ -1,39 +1,32 @@
-:plugin: java_line
+:plugin: java_plain
 :type: codec
 
 ///////////////////////////////////////////
-START - GENERATED VARIABLES, DO NOT EDIT!
+REPLACES GENERATED VARIABLES
 ///////////////////////////////////////////
-:version: %VERSION%
-:release_date: %RELEASE_DATE%
-:changelog_url: %CHANGELOG_URL%
-:include_path: ../../../../logstash/docs/include
+:include_path: ../../../../../logstash/docs/include
 ///////////////////////////////////////////
-END - GENERATED VARIABLES, DO NOT EDIT!
+END - REPLACES GENERATED VARIABLES
 ///////////////////////////////////////////
 
 [id="plugins-{type}s-{plugin}"]
 
-=== Java line codec plugin
+=== Java_plain codec plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-core.asciidoc[]
 
 ==== Description
 
-Encodes and decodes line-oriented text data.
-
-Decoding behavior: All text data between specified delimiters will be decoded as distinct events.
-
-Encoding behavior: Each event will be emitted with the specified trailing delimiter.
+The `java_plain` codec is for text data with no delimiters between events. It is useful mainly for inputs and outputs that
+already have a defined framing in their transport protocol such as ZeroMQ, RabbitMQ, Redis, etc.
 
 [id="plugins-{type}s-{plugin}-options"]
-==== Line Codec Configuration Options
+==== Java_plain Codec Configuration Options
 
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-charset>> |<<string,string>>, one of `["ASCII-8BIT", "UTF-8", "US-ASCII", "Big5", "Big5-HKSCS", "Big5-UAO", "CP949", "Emacs-Mule", "EUC-JP", "EUC-KR", "EUC-TW", "GB2312", "GB18030", "GBK", "ISO-8859-1", "ISO-8859-2", "ISO-8859-3", "ISO-8859-4", "ISO-8859-5", "ISO-8859-6", "ISO-8859-7", "ISO-8859-8", "ISO-8859-9", "ISO-8859-10", "ISO-8859-11", "ISO-8859-13", "ISO-8859-14", "ISO-8859-15", "ISO-8859-16", "KOI8-R", "KOI8-U", "Shift_JIS", "UTF-16BE", "UTF-16LE", "UTF-32BE", "UTF-32LE", "Windows-31J", "Windows-1250", "Windows-1251", "Windows-1252", "IBM437", "IBM737", "IBM775", "CP850", "IBM852", "CP852", "IBM855", "CP855", "IBM857", "IBM860", "IBM861", "IBM862", "IBM863", "IBM864", "IBM865", "IBM866", "IBM869", "Windows-1258", "GB1988", "macCentEuro", "macCroatian", "macCyrillic", "macGreek", "macIceland", "macRoman", "macRomania", "macThai", "macTurkish", "macUkraine", "CP950", "CP951", "IBM037", "stateless-ISO-2022-JP", "eucJP-ms", "CP51932", "EUC-JIS-2004", "GB12345", "ISO-2022-JP", "ISO-2022-JP-2", "CP50220", "CP50221", "Windows-1256", "Windows-1253", "Windows-1255", "Windows-1254", "TIS-620", "Windows-874", "Windows-1257", "MacJapanese", "UTF-7", "UTF8-MAC", "UTF-16", "UTF-32", "UTF8-DoCoMo", "SJIS-DoCoMo", "UTF8-KDDI", "SJIS-KDDI", "ISO-2022-JP-KDDI", "stateless-ISO-2022-JP-KDDI", "UTF8-SoftBank", "SJIS-SoftBank", "BINARY", "CP437", "CP737", "CP775", "IBM850", "CP857", "CP860", "CP861", "CP862", "CP863", "CP864", "CP865", "CP866", "CP869", "CP1258", "Big5-HKSCS:2008", "ebcdic-cp-us", "eucJP", "euc-jp-ms", "EUC-JISX0213", "eucKR", "eucTW", "EUC-CN", "eucCN", "CP936", "ISO2022-JP", "ISO2022-JP2", "ISO8859-1", "ISO8859-2", "ISO8859-3", "ISO8859-4", "ISO8859-5", "ISO8859-6", "CP1256", "ISO8859-7", "CP1253", "ISO8859-8", "CP1255", "ISO8859-9", "CP1254", "ISO8859-10", "ISO8859-11", "CP874", "ISO8859-13", "CP1257", "ISO8859-14", "ISO8859-15", "ISO8859-16", "CP878", "MacJapan", "ASCII", "ANSI_X3.4-1968", "646", "CP65000", "CP65001", "UTF-8-MAC", "UTF-8-HFS", "UCS-2BE", "UCS-4BE", "UCS-4LE", "CP932", "csWindows31J", "SJIS", "PCK", "CP1250", "CP1251", "CP1252", "external", "locale"]`|No
-| <<plugins-{type}s-{plugin}-delimiter>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-format>> |<<string,string>>|No
 |=======================================================================
 
@@ -45,16 +38,8 @@ Encoding behavior: Each event will be emitted with the specified trailing delimi
   * Value can be any of: `ASCII-8BIT`, `UTF-8`, `US-ASCII`, `Big5`, `Big5-HKSCS`, `Big5-UAO`, `CP949`, `Emacs-Mule`, `EUC-JP`, `EUC-KR`, `EUC-TW`, `GB2312`, `GB18030`, `GBK`, `ISO-8859-1`, `ISO-8859-2`, `ISO-8859-3`, `ISO-8859-4`, `ISO-8859-5`, `ISO-8859-6`, `ISO-8859-7`, `ISO-8859-8`, `ISO-8859-9`, `ISO-8859-10`, `ISO-8859-11`, `ISO-8859-13`, `ISO-8859-14`, `ISO-8859-15`, `ISO-8859-16`, `KOI8-R`, `KOI8-U`, `Shift_JIS`, `UTF-16BE`, `UTF-16LE`, `UTF-32BE`, `UTF-32LE`, `Windows-31J`, `Windows-1250`, `Windows-1251`, `Windows-1252`, `IBM437`, `IBM737`, `IBM775`, `CP850`, `IBM852`, `CP852`, `IBM855`, `CP855`, `IBM857`, `IBM860`, `IBM861`, `IBM862`, `IBM863`, `IBM864`, `IBM865`, `IBM866`, `IBM869`, `Windows-1258`, `GB1988`, `macCentEuro`, `macCroatian`, `macCyrillic`, `macGreek`, `macIceland`, `macRoman`, `macRomania`, `macThai`, `macTurkish`, `macUkraine`, `CP950`, `CP951`, `IBM037`, `stateless-ISO-2022-JP`, `eucJP-ms`, `CP51932`, `EUC-JIS-2004`, `GB12345`, `ISO-2022-JP`, `ISO-2022-JP-2`, `CP50220`, `CP50221`, `Windows-1256`, `Windows-1253`, `Windows-1255`, `Windows-1254`, `TIS-620`, `Windows-874`, `Windows-1257`, `MacJapanese`, `UTF-7`, `UTF8-MAC`, `UTF-16`, `UTF-32`, `UTF8-DoCoMo`, `SJIS-DoCoMo`, `UTF8-KDDI`, `SJIS-KDDI`, `ISO-2022-JP-KDDI`, `stateless-ISO-2022-JP-KDDI`, `UTF8-SoftBank`, `SJIS-SoftBank`, `BINARY`, `CP437`, `CP737`, `CP775`, `IBM850`, `CP857`, `CP860`, `CP861`, `CP862`, `CP863`, `CP864`, `CP865`, `CP866`, `CP869`, `CP1258`, `Big5-HKSCS:2008`, `ebcdic-cp-us`, `eucJP`, `euc-jp-ms`, `EUC-JISX0213`, `eucKR`, `eucTW`, `EUC-CN`, `eucCN`, `CP936`, `ISO2022-JP`, `ISO2022-JP2`, `ISO8859-1`, `ISO8859-2`, `ISO8859-3`, `ISO8859-4`, `ISO8859-5`, `ISO8859-6`, `CP1256`, `ISO8859-7`, `CP1253`, `ISO8859-8`, `CP1255`, `ISO8859-9`, `CP1254`, `ISO8859-10`, `ISO8859-11`, `CP874`, `ISO8859-13`, `CP1257`, `ISO8859-14`, `ISO8859-15`, `ISO8859-16`, `CP878`, `MacJapan`, `ASCII`, `ANSI_X3.4-1968`, `646`, `CP65000`, `CP65001`, `UTF-8-MAC`, `UTF-8-HFS`, `UCS-2BE`, `UCS-4BE`, `UCS-4LE`, `CP932`, `csWindows31J`, `SJIS`, `PCK`, `CP1250`, `CP1251`, `CP1252`, `external`, `locale`
   * Default value is `"UTF-8"`
 
-The character encoding used by this input. Examples include `UTF-8` and `cp1252`. This setting is useful if your
-inputs are in `Latin-1` (aka `cp1252`) or other character sets than `UTF-8`.
-
-[id="plugins-{type}s-{plugin}-delimiter"]
-===== `delimiter`
-
-  * Value type is <<string,string>>
-  * Default value is the system-dependent line separator ("\n" for UNIX systems; "\r\n" for Microsoft Windows)
-
-Specifies the delimiter that indicates end-of-line.
+The character encoding used in this input. Examples include `UTF-8` and `cp1252`. This setting is useful if your data
+is in a character set other than `UTF-8`.
 
 [id="plugins-{type}s-{plugin}-format"]
 ===== `format`

--- a/docs/static/core-plugins/filters/java_uuid.asciidoc
+++ b/docs/static/core-plugins/filters/java_uuid.asciidoc
@@ -2,21 +2,19 @@
 :type: filter
 
 ///////////////////////////////////////////
-START - GENERATED VARIABLES, DO NOT EDIT!
+REPLACES GENERATED VARIABLES
 ///////////////////////////////////////////
-:version: %VERSION%
-:release_date: %RELEASE_DATE%
-:changelog_url: %CHANGELOG_URL%
 :include_path: ../../../../../logstash/docs/include
 ///////////////////////////////////////////
-END - GENERATED VARIABLES, DO NOT EDIT!
+END - REPLACES GENERATED VARIABLES
 ///////////////////////////////////////////
+
 
 [id="plugins-{type}s-{plugin}"]
 
-=== Java UUID filter plugin
+=== Java_uuid filter plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-core.asciidoc[]
 
 ==== Description
 
@@ -36,7 +34,7 @@ represented in standard hexadecimal string format, e.g.
 "e08806fe-02af-406c-bbde-8a5ae4475e57".
 
 [id="plugins-{type}s-{plugin}-options"]
-==== Uuid Filter Configuration Options
+==== Java_uuid Filter Configuration Options
 
 This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
 

--- a/docs/static/core-plugins/inputs/java_generator.asciidoc
+++ b/docs/static/core-plugins/inputs/java_generator.asciidoc
@@ -3,32 +3,29 @@
 :default_codec: plain
 
 ///////////////////////////////////////////
-START - GENERATED VARIABLES, DO NOT EDIT!
+REPLACES GENERATED VARIABLES
 ///////////////////////////////////////////
-:version: %VERSION%
-:release_date: %RELEASE_DATE%
-:changelog_url: %CHANGELOG_URL%
-:include_path: ../../../../logstash/docs/include
+:include_path: ../../../../../logstash/docs/include
 ///////////////////////////////////////////
-END - GENERATED VARIABLES, DO NOT EDIT!
+END - REPLACES GENERATED VARIABLES
 ///////////////////////////////////////////
 
 [id="plugins-{type}s-{plugin}"]
 
-=== Java generator input plugin
+=== Java_generator input plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-core.asciidoc[]
 
 ==== Description
 
-Generate synthethic log events.
+Generate synthetic log events.
 
 This plugin generates a stream of synthetic events that can be used to test the correctness or performance of a
 Logstash pipeline.
 
 
 [id="plugins-{type}s-{plugin}-options"]
-==== Generator Input Configuration Options
+==== Java_generator Input Configuration Options
 
 This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
 

--- a/docs/static/core-plugins/inputs/java_stdin.asciidoc
+++ b/docs/static/core-plugins/inputs/java_stdin.asciidoc
@@ -3,21 +3,18 @@
 :default_codec: java_line
 
 ///////////////////////////////////////////
-START - GENERATED VARIABLES, DO NOT EDIT!
+REPLACES GENERATED VARIABLES
 ///////////////////////////////////////////
-:version: %VERSION%
-:release_date: %RELEASE_DATE%
-:changelog_url: %CHANGELOG_URL%
-:include_path: ../../../../logstash/docs/include
+:include_path: ../../../../../logstash/docs/include
 ///////////////////////////////////////////
-END - GENERATED VARIABLES, DO NOT EDIT!
+END - REPLACES GENERATED VARIABLES
 ///////////////////////////////////////////
 
 [id="plugins-{type}s-{plugin}"]
 
-=== Java stdin input plugin
+=== Java_stdin input plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-core.asciidoc[]
 
 ==== Description
 
@@ -27,7 +24,7 @@ By default, each event is assumed to be terminated by end-of-line. If you want e
 method, you'll need to use a codec with support for that encoding.
 
 [id="plugins-{type}s-{plugin}-options"]
-==== Stdin Input Configuration Options
+==== Java_stdin Input Configuration Options
 
 There are no special configuration options for this plugin,
 but it does support the <<plugins-{type}s-{plugin}-common-options>>.

--- a/docs/static/core-plugins/outputs/java_sink.asciidoc
+++ b/docs/static/core-plugins/outputs/java_sink.asciidoc
@@ -1,23 +1,20 @@
-:plugin: sink
+:plugin: java_sink
 :type: output
 :default_codec!:
 
 ///////////////////////////////////////////
-START - GENERATED VARIABLES, DO NOT EDIT!
+REPLACES GENERATED VARIABLES
 ///////////////////////////////////////////
-:version: %VERSION%
-:release_date: %RELEASE_DATE%
-:changelog_url: %CHANGELOG_URL%
-:include_path: ../../../../logstash/docs/include
+:include_path: ../../../../../logstash/docs/include
 ///////////////////////////////////////////
-END - GENERATED VARIABLES, DO NOT EDIT!
+END - REPLACES GENERATED VARIABLES
 ///////////////////////////////////////////
 
 [id="plugins-{type}s-{plugin}"]
 
-=== Sink output plugin
+=== Java_sink output plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-core.asciidoc[]
 
 ==== Description
 
@@ -25,7 +22,7 @@ An event sink that discards any events received. Generally useful for testing th
 and filters.
 
 [id="plugins-{type}s-{plugin}-options"]
-==== Sink Output Configuration Options
+==== Java_sink Output Configuration Options
 
 There are no special configuration options for this plugin,
 but it does support the <<plugins-{type}s-{plugin}-common-options>>.

--- a/docs/static/core-plugins/outputs/java_stdout.asciidoc
+++ b/docs/static/core-plugins/outputs/java_stdout.asciidoc
@@ -3,21 +3,18 @@
 :default_codec: java_line
 
 ///////////////////////////////////////////
-START - GENERATED VARIABLES, DO NOT EDIT!
+REPLACES GENERATED VARIABLES
 ///////////////////////////////////////////
-:version: %VERSION%
-:release_date: %RELEASE_DATE%
-:changelog_url: %CHANGELOG_URL%
-:include_path: ../../../../logstash/docs/include
+:include_path: ../../../../../logstash/docs/include
 ///////////////////////////////////////////
-END - GENERATED VARIABLES, DO NOT EDIT!
+END - REPLACES GENERATED VARIABLES
 ///////////////////////////////////////////
 
 [id="plugins-{type}s-{plugin}"]
 
-=== Java stdout output plugin
+=== Java_stdout output plugin
 
-include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header-core.asciidoc[]
 
 ==== Description
 
@@ -42,7 +39,7 @@ java_stdout.
     }
 
 [id="plugins-{type}s-{plugin}-options"]
-==== Stdout Output Configuration Options
+==== Java_stdout Output Configuration Options
 
 There are no special configuration options for this plugin,
 but it does support the <<plugins-{type}s-{plugin}-common-options>>.


### PR DESCRIPTION
* Adds new plugin-header for core plugins and adds it to files
* Renames doc files for consistency with other plugin docs

IMPORTANT:  This PR must be merged before changes to index files in `logstash-docs` repo (https://github.com/elastic/logstash-docs/pull/740) can be merged. 