### PR TITLE
make sure joni regexp interruptability is enabled

### DIFF
--- a/config/jvm.options
+++ b/config/jvm.options
@@ -49,6 +49,8 @@
 -Djruby.compile.invokedynamic=true
 # Force Compilation
 -Djruby.jit.threshold=0
+# Make sure joni regexp interruptability is enabled
+-Djruby.regexp.interruptible=true
 
 ## heap dumps
 


### PR DESCRIPTION
Related to #10976 

Setting `-Djruby.regexp.interruptible=true` force the interruptibility of the joni regexp library.