### PR TITLE
Docs: Different edit_me overrides for asciidoctor

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -227,7 +227,12 @@ include::static/best-practice.asciidoc[]
 // :edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/troubleshooting.asciidoc
 include::static/troubleshooting.asciidoc[]
 
+ifdef::asciidoctor[]
+:edit_url!:
+endif::[]
+ifndef::asciidoctor[]
 :edit_url:
+endif::[]
 
 // Contributing to Logstash
 

--- a/tools/logstash-docgen/templates/index-codecs.asciidoc.erb
+++ b/tools/logstash-docgen/templates/index-codecs.asciidoc.erb
@@ -18,4 +18,9 @@ The following codec plugins are available:
 include::<%=plugin.type%>/<%=plugin.name%>.asciidoc[]
 <% end %>
 
+ifdef::asciidoctor[]
+:edit_url!:
+endif::[]
+ifndef::asciidoctor[]
 :edit_url:
+endif::[]

--- a/tools/logstash-docgen/templates/index-filters.asciidoc.erb
+++ b/tools/logstash-docgen/templates/index-filters.asciidoc.erb
@@ -18,4 +18,9 @@ The following filter plugins are available:
 include::<%=plugin.type%>/<%=plugin.name%>.asciidoc[]
 <% end %>
 
+ifdef::asciidoctor[]
+:edit_url!:
+endif::[]
+ifndef::asciidoctor[]
 :edit_url:
+endif::[]

--- a/tools/logstash-docgen/templates/index-inputs.asciidoc.erb
+++ b/tools/logstash-docgen/templates/index-inputs.asciidoc.erb
@@ -17,4 +17,9 @@ The following input plugins are available:
 include::<%=plugin.type%>/<%=plugin.name%>.asciidoc[]
 <% end %>
 
+ifdef::asciidoctor[]
+:edit_url!:
+endif::[]
+ifndef::asciidoctor[]
 :edit_url:
+endif::[]

--- a/tools/logstash-docgen/templates/index-outputs.asciidoc.erb
+++ b/tools/logstash-docgen/templates/index-outputs.asciidoc.erb
@@ -17,4 +17,9 @@ The following output plugins are available:
 include::<%=plugin.type%>/<%=plugin.name%>.asciidoc[]
 <% end %>
 
+ifdef::asciidoctor[]
+:edit_url!:
+endif::[]
+ifndef::asciidoctor[]
 :edit_url:
+endif::[]


### PR DESCRIPTION
We added support for setting `edit_url` to override the url in the
`edit_me` style links used by asciidoctor. This "override" doesn't
properly emulate asciidoc when you set the `edit_url` to an empty string
with lines like:
```
:edit_url:
```

While we *could* make it work the same way it is a conceptual mismatch
with the whole "override" mechanics. Thus I propose we change logstash
to use conditional evaluation in those lines. This does the right thing
for AsciiDoc and for Asciidoctor. Once we switch to the build to
Asciidoctor we can drop the conditions in a cleanup change.