### PR TITLE
Docs: Add more missing subs for asciidoctor

### DIFF
--- a/docs/static/monitoring/configuring-logstash.asciidoc
+++ b/docs/static/monitoring/configuring-logstash.asciidoc
@@ -1,6 +1,7 @@
 [role="xpack"]
 [[configuring-logstash]]
 === Configuring Monitoring for Logstash Nodes
+[subs="attributes"]
 ++++
 <titleabbrev>{monitoring}</titleabbrev>
 ++++

--- a/docs/static/security/logstash.asciidoc
+++ b/docs/static/security/logstash.asciidoc
@@ -1,6 +1,7 @@
 [role="xpack"]
 [[ls-security]]
 === Configuring Security in Logstash
+[subs="attributes"]
 ++++
 <titleabbrev>{security}</titleabbrev>
 ++++

--- a/docs/static/setup/configuring-xls.asciidoc
+++ b/docs/static/setup/configuring-xls.asciidoc
@@ -1,6 +1,7 @@
 [role="xpack"]
 [[settings-xpack]]
 === {xpack} Settings in Logstash
+[subs="attributes"]
 ++++
 <titleabbrev>{xpack} Settings</titleabbrev>
 ++++


### PR DESCRIPTION
Adds a few missing `[attributes="subs"]` clauses for asciidoctor.