### PR TITLE
Docs: Drops a stray `+` in a table

### DIFF
--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -123,7 +123,6 @@ The `logstash.yml` file includes the following settings:
 | `config.support_escapes`
 | When set to `true`, quoted strings will process the following escape sequences: `\n` becomes a literal newline (ASCII 10). `\r` becomes a literal carriage return (ASCII 13). `\t` becomes a literal tab (ASCII 9). `\\` becomes a literal backslash `\`. `\"` becomes a literal double quotation mark. `\'` becomes a literal quotation mark.
 | `false`
-+
 
 | `queue.type`
 | The internal queuing model to use for event buffering. Specify `memory` for legacy in-memory based queuing, or `persisted` for disk-based ACKed queueing (<<persistent-queues,persistent queues>>).


### PR DESCRIPTION
In asciidoc the `+` doens't do anything but it asciidoctor it renders as
a literal `+`. Dropping the line with the `+` seems to produce the same
output with both asciidoc and asciidoctor.