### PR TITLE
[Doc]Set docs release state to released

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -17,7 +17,7 @@
 //////////
 release-state can be: released | prerelease | unreleased
 //////////
-:release-state:         unreleased
+:release-state:         released
 :versioned_docs:        false
 
 :jdk:                   1.8.0


### PR DESCRIPTION
Doc version was set to `7.3.0` when we cut the branch. This PR sets the docs release state to `released`.