### PR TITLE
Add directories to rpm packages

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -460,6 +460,7 @@ namespace "artifact" do
         out.attributes[:rpm_user] = "root"
         out.attributes[:rpm_group] = "root"
         out.attributes[:rpm_os] = "linux"
+        out.attributes[:rpm_auto_add_directories?] = true
         out.config_files << "/etc/logstash/startup.options"
         out.config_files << "/etc/logstash/jvm.options"
         out.config_files << "/etc/logstash/log4j2.properties"


### PR DESCRIPTION
This ensures that the rpm can be removed or upgraded cleanly without leaving any dangling directories.

Fixes #11014 