### PR TITLE
Docs: Fix backticks in how to docs

### DIFF
--- a/docs/static/codec.asciidoc
+++ b/docs/static/codec.asciidoc
@@ -10,6 +10,6 @@
 
 :getstarted: Let's step through creating a {plugintype} plugin using the https://github.com/logstash-plugins/logstash-codec-example/[example {plugintype} plugin].
 
-:methodheader: Logstash codecs must implement the `register` method, and the `decode` method or the `encode` method (or both).
+:methodheader: pass:m[Logstash codecs must implement the `register` method, and the `decode` method or the `encode` method (or both).]
 
 include::include/pluginbody.asciidoc[]

--- a/docs/static/filter.asciidoc
+++ b/docs/static/filter.asciidoc
@@ -9,6 +9,6 @@
 
 :getstarted: Let's step through creating a {plugintype} plugin using the https://github.com/logstash-plugins/logstash-filter-example/[example {plugintype} plugin].
 
-:methodheader: Logstash filters must implement the `register` and `filter` methods.
+:methodheader: pass:m[Logstash filters must implement the `register` and `filter` methods.]
 
 include::include/pluginbody.asciidoc[]

--- a/docs/static/input.asciidoc
+++ b/docs/static/input.asciidoc
@@ -7,6 +7,6 @@
 
 :getstarted: Let's step through creating an {plugintype} plugin using the https://github.com/logstash-plugins/logstash-input-example/[example {plugintype} plugin].
 
-:methodheader: Logstash inputs must implement two main methods: `register` and `run`.
+:methodheader: pass:m[Logstash inputs must implement two main methods: `register` and `run`.]
 
 include::include/pluginbody.asciidoc[]

--- a/docs/static/output.asciidoc
+++ b/docs/static/output.asciidoc
@@ -9,6 +9,6 @@
 
 :getstarted: Let's step through creating an {plugintype} plugin using the https://github.com/logstash-plugins/logstash-output-example/[example {plugintype} plugin].
 
-:methodheader: Logstash outputs must implement the `register` and `multi_receive` methods.
+:methodheader: pass:m[Logstash outputs must implement the `register` and `multi_receive` methods.]
 
 include::include/pluginbody.asciidoc[]


### PR DESCRIPTION
In the "methods" sections of the how to develop a plugin docs
Asciidoctor as incorrectly passing backticks into the output when it
should have marked the words surrounded by backticks as code. I'm not
100% sure why it did that. The fix is to force macro evaluation
immediately on attribute assignment.