### PR TITLE
Preserve input event ordering with single pipeline worker

### DIFF
--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -238,7 +238,7 @@ module LogStash; class JavaPipeline < JavaBasePipeline
           Util.set_thread_name("[#{pipeline_id}]>worker#{t}")
           org.logstash.execution.WorkerLoop.new(
               lir_execution, filter_queue_client, @events_filtered, @events_consumed,
-              @flushRequested, @flushing, @shutdownRequested, @drain_queue).run
+              @flushRequested, @flushing, @shutdownRequested, @drain_queue, pipeline_workers == 1).run
         end
         @worker_threads << thread
       end

--- a/logstash-core/spec/conditionals_spec.rb
+++ b/logstash-core/spec/conditionals_spec.rb
@@ -519,18 +519,18 @@ describe "conditionals in filter" do
     CONFIG
 
     sample_one({"type" => "original"}) do
-      clone_event_1 = subject[0]
-      expect(clone_event_1.get("type")).to eq("clone1")
-      expect(clone_event_1.get("cond1")).to eq("true")
-      expect(clone_event_1.get("cond2")).to eq(nil)
-      clone_event_2 = subject[1]
-      expect(clone_event_2.get("type")).to eq("clone2")
-      expect(clone_event_2.get("cond1")).to eq(nil)
-      expect(clone_event_2.get("cond2")).to eq("true")
-      original_event = subject[2]
+      original_event = subject[0]
       expect(original_event.get("type")).to eq("original")
       expect(original_event.get("cond1")).to eq(nil)
       expect(original_event.get("cond2")).to eq(nil)
+      clone_event_1 = subject[1]
+      expect(clone_event_1.get("type")).to eq("clone1")
+      expect(clone_event_1.get("cond1")).to eq("true")
+      expect(clone_event_1.get("cond2")).to eq(nil)
+      clone_event_2 = subject[2]
+      expect(clone_event_2.get("type")).to eq("clone2")
+      expect(clone_event_2.get("cond1")).to eq(nil)
+      expect(clone_event_2.get("cond2")).to eq("true")
     end
   end
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/Utils.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/Utils.java
@@ -3,6 +3,7 @@ package org.logstash.config.ir.compiler;
 import org.logstash.ext.JrubyEventExtLibrary;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -29,6 +30,18 @@ public class Utils {
             } else {
                 unfulfilled.add(e);
             }
+        }
+    }
+
+    /**
+     * Comparator for events based on the sequence of their instantiation. Used to maintain input event
+     * ordering with a single pipeline worker.
+     */
+    public static class EventSequenceComparator implements Comparator<JrubyEventExtLibrary.RubyEvent> {
+
+        @Override
+        public int compare(JrubyEventExtLibrary.RubyEvent o1, JrubyEventExtLibrary.RubyEvent o2) {
+            return Long.compare(o1.sequence(), o2.sequence());
         }
     }
 

--- a/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
+++ b/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
@@ -40,10 +40,11 @@ public final class WorkerLoop implements Runnable {
     public WorkerLoop(final CompiledPipeline pipeline, final QueueReadClient readClient,
         final LongAdder filteredCounter, final LongAdder consumedCounter,
         final AtomicBoolean flushRequested, final AtomicBoolean flushing,
-        final AtomicBoolean shutdownRequested, final boolean drainQueue) {
+        final AtomicBoolean shutdownRequested, final boolean drainQueue,
+        final boolean orderedEvents) {
         this.consumedCounter = consumedCounter;
         this.filteredCounter = filteredCounter;
-        this.execution = pipeline.buildExecution();
+        this.execution = pipeline.buildExecution(orderedEvents);
         this.drainQueue = drainQueue;
         this.readClient = readClient;
         this.flushRequested = flushRequested;

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -40,14 +40,16 @@ public final class JrubyEventExtLibrary {
          * Hashcode of this instance. Used to avoid the more expensive {@link RubyObject#hashCode()}
          * since we only care about reference equality for this class anyway.
          */
-        private final int hash = nextHash();
+        private final int hash;
 
-        private final long sequence = SEQUENCE_GENERATOR.get();
+        private final long sequence;
 
         private Event event;
 
         public RubyEvent(final Ruby runtime, final RubyClass klass) {
             super(runtime, klass);
+            this.sequence = SEQUENCE_GENERATOR.incrementAndGet();
+            this.hash = (int) (sequence ^ sequence >>> 32) + 31;
         }
 
         public static RubyEvent newRubyEvent(Ruby runtime) {
@@ -349,15 +351,6 @@ public final class JrubyEventExtLibrary {
 
         private void setEvent(Event event) {
             this.event = event;
-        }
-
-        /**
-         * Generates a fixed hashcode.
-         * @return HashCode value
-         */
-        private static int nextHash() {
-            final long sequence = SEQUENCE_GENERATOR.incrementAndGet();
-            return (int) (sequence ^ sequence >>> 32) + 31;
         }
     }
 }

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -42,6 +42,8 @@ public final class JrubyEventExtLibrary {
          */
         private final int hash = nextHash();
 
+        private final long sequence = SEQUENCE_GENERATOR.get();
+
         private Event event;
 
         public RubyEvent(final Ruby runtime, final RubyClass klass) {
@@ -275,6 +277,10 @@ public final class JrubyEventExtLibrary {
             }
             this.event.setTimestamp(((JrubyTimestampExtLibrary.RubyTimestamp)value).getTimestamp());
             return value;
+        }
+
+        public long sequence() {
+            return sequence;
         }
 
         @Override

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/DatasetCompilerTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/DatasetCompilerTest.java
@@ -1,6 +1,5 @@
 package org.logstash.config.ir.compiler;
 
-import java.util.Collections;
 import org.jruby.RubyArray;
 import org.junit.Test;
 import org.logstash.Event;
@@ -8,6 +7,8 @@ import org.logstash.FieldReference;
 import org.logstash.RubyUtil;
 import org.logstash.config.ir.PipelineTestUtil;
 import org.logstash.ext.JrubyEventExtLibrary;
+
+import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -24,7 +25,7 @@ public final class DatasetCompilerTest {
             DatasetCompiler.outputDataset(
                 Collections.emptyList(),
                 PipelineTestUtil.buildOutput(events -> {}),
-                true
+                true, false
             ).instantiate().compute(RubyUtil.RUBY.newArray(), false, false),
             nullValue()
         );

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/DatasetCompilerTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/DatasetCompilerTest.java
@@ -25,7 +25,8 @@ public final class DatasetCompilerTest {
             DatasetCompiler.outputDataset(
                 Collections.emptyList(),
                 PipelineTestUtil.buildOutput(events -> {}),
-                true, false
+                true,
+                false
             ).instantiate().compute(RubyUtil.RUBY.newArray(), false, false),
             nullValue()
         );


### PR DESCRIPTION
In cases where an LIR output node has multiple input parent nodes such as a filter node with a conditional, the Java execution engine transfers the events from each of the parent nodes to the output node in succession. In most cases, this presents no problem because either the function of the parent conditional node is to selectively send events to the output or because there are multiple pipeline workers in which case there can be no expectation of event ordering.

This does break event ordering in the case where there is a single pipeline worker and an output node has multiple parent nodes that do not function to selectively send events to the output (see #10938 for an example). This PR adds code to preserve event ordering in that specific scenario by sorting all the events by the order in which they were emitted from their respective parent nodes before adding them to the output batch. While the sort algorithm that is used is optimized for the use case of sorting concatenated sorted arrays, there is obviously a runtime cost associated with preserving this event ordering. As such, this code is generated _only_ for pipelines with a single worker since that is the only scenario in which event ordering can be guaranteed. 

Fixes #10938. 
