### PR TITLE
Improved logging of version mismatch in DLQ file reader (RecordIOReader)

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
@@ -55,8 +55,12 @@ public final class RecordIOReader implements Closeable {
         ByteBuffer versionBuffer = ByteBuffer.allocate(1);
         this.channel.read(versionBuffer);
         versionBuffer.rewind();
-        if (versionBuffer.get() != VERSION) {
-            throw new RuntimeException("Invalid file. check version");
+        byte versionInFile = versionBuffer.get();
+        if (versionInFile != VERSION) {
+            this.channel.close();
+            throw new RuntimeException(String.format(
+                    "Invalid version on PQ data file %s. Expected version: %c. Version found on file: %c",
+                    path, VERSION, versionInFile));
         }
         this.channelPosition = this.channel.position();
     }


### PR DESCRIPTION
When DLQ file is read, there is a possibility of a version mismatch as indicated in https://github.com/elastic/logstash/issues/11035 The version is currently fixed but thinking forward, the log is not clear enough about the problem and as the file is a binary file, the user does not have a way of figuring out what is the mismatch.

This commit makes the logging a bit more verbose and highlights the mismatch.