### PR TITLE
Update jrjackson, jackson versions

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -9,6 +9,7 @@ description = """Logstash Core Java"""
 version = versionMap['logstash-core']
 String jrubyVersion = versionMap['jruby']['version']
 String jacksonVersion = versionMap['jackson']
+String jacksonDatabindVersion = versionMap['jackson-databind']
 
 repositories {
     mavenCentral()
@@ -124,7 +125,7 @@ dependencies {
     compile 'commons-codec:commons-codec:1.11'
     // Jackson version moved to versions.yml in the project root (the JrJackson version is there too)
     compile "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
-    compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    compile "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
     compile "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
     compile 'org.codehaus.janino:janino:3.0.8'
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jacksonVersion}"

--- a/versions.yml
+++ b/versions.yml
@@ -20,5 +20,6 @@ jruby:
 # Note: this file is copied to the root of logstash-core because its gemspec needs it when
 #       bundler evaluates the gemspec via bin/logstash
 # Ensure Jackson version here is kept in sync with version used by jrjackson gem
-jrjackson: 0.4.8
-jackson: 2.9.8
+jrjackson: 0.4.9
+jackson: 2.9.9
+jackson-databind: 2.9.9.3


### PR DESCRIPTION
Also splits out jackson and jackson databind versions to allow separate revisions
 for databind.

Backport of #11040