### PR TITLE
Integration test for Java plugins

### DIFF
--- a/qa/integration/fixtures/java_api_spec.yml
+++ b/qa/integration/fixtures/java_api_spec.yml
@@ -1,0 +1,20 @@
+---
+services:
+- logstash
+config: |-
+  input {
+    java_generator {
+      count => 1
+    }
+  }
+  filter {
+    java_uuid {
+      target => "uuid"
+    }
+    sleep {
+      time => 10
+    }
+  }
+  output {
+    java_stdout { }
+  }

--- a/qa/integration/specs/java_api_spec.rb
+++ b/qa/integration/specs/java_api_spec.rb
@@ -1,0 +1,51 @@
+require_relative '../framework/fixture'
+require_relative '../framework/settings'
+require_relative '../framework/helpers'
+require "stud/temporary"
+require "stud/try"
+require "rspec/wait"
+require "yaml"
+require "fileutils"
+
+describe "Java plugin API" do
+  before(:all) do
+    @fixture = Fixture.new(__FILE__)
+  end
+
+  before(:each) {
+    @logstash = @fixture.get_service("logstash")
+  }
+
+  after(:all) {
+    @fixture.teardown
+  }
+
+  after(:each) {
+    @logstash.teardown
+  }
+
+  let(:max_retry) { 120 }
+  let!(:settings_dir) { Stud::Temporary.directory }
+
+  it "successfully sends events through Java plugins" do
+
+    @logstash.start_background_with_config_settings(config_to_temp_file(@fixture.config), settings_dir)
+
+    # wait for Logstash to start
+    started = false
+    while !started
+      begin
+        sleep(1)
+        result = @logstash.monitoring_api.event_stats
+        started = !result.nil?
+      rescue
+        retry
+      end
+    end
+
+    Stud.try(max_retry.times, RSpec::Expectations::ExpectationNotMetError) do
+      result = @logstash.monitoring_api.event_stats
+      expect(result["in"]).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
Adds an integration test that exercises Java plugins with an input, filter, and output.

Relates to #8429.
