### PR TITLE
Create secret store from correct settings path

### DIFF
--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -365,19 +365,28 @@ public class AbstractPipelineExt extends RubyBasicObject {
     }
 
     protected final IRubyObject getSetting(final ThreadContext context, final String name) {
-        return settings.callMethod(context, "get_value", context.runtime.newString(name));
+        return getSetting(context, settings, name);
     }
 
     protected final boolean hasSetting(final ThreadContext context, final String name) {
+        return hasSetting(context, settings, name);
+    }
+
+    private IRubyObject getSetting(final ThreadContext context, IRubyObject settings, final String name) {
+        return settings.callMethod(context, "get_value", context.runtime.newString(name));
+    }
+
+    private boolean hasSetting(final ThreadContext context, final IRubyObject settings, final String name) {
         return settings.callMethod(context, "registered?", context.runtime.newString(name)) == context.tru;
     }
 
     protected SecretStore getSecretStore(final ThreadContext context) {
-        String keystoreFile = hasSetting(context, "keystore.file")
-                ? getSetting(context, "keystore.file").asJavaString()
+        IRubyObject settings = context.runtime.evalScriptlet("LogStash::SETTINGS");
+        String keystoreFile = hasSetting(context, settings, "keystore.file")
+                ? getSetting(context, settings, "keystore.file").asJavaString()
                 : null;
-        String keystoreClassname = hasSetting(context, "keystore.classname")
-                ? getSetting(context, "keystore.classname").asJavaString()
+        String keystoreClassname = hasSetting(context, settings, "keystore.classname")
+                ? getSetting(context, settings, "keystore.classname").asJavaString()
                 : null;
         return (keystoreFile != null && keystoreClassname != null)
                 ? SecretStoreExt.getIfExists(keystoreFile, keystoreClassname)


### PR DESCRIPTION
This augments https://github.com/elastic/logstash/pull/11043 to properly create the secret store in cases where the `path.settings` value is something other than the default of `LOGSTASH_HOME/config`. In such cases, the `LogStash::SETTINGS` singleton is updated during Logstash startup with the non-default value:

https://github.com/elastic/logstash/blob/4d36bb06a30e7b28cbb93171c1ce60fa35fae340/logstash-core/lib/logstash/util/settings_helper.rb#L35

The secret store that was instantiated in `AbstractPipelineExt` , though, was based on the `settings` member variable that is created from a copy of the settings _before_ that update was made, so it always looked in `LOGSTASH_HOME/config`. This was the root cause of https://github.com/elastic/logstash/issues/11055 and this PR resolves that by retrieving all secret store settings from the updated `LogStash::SETTINGS` singleton.
