### PR TITLE
avoid variable collision in pipeline stats api (backport of #11059 to 7.x)

### DIFF
--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -65,8 +65,8 @@ module LogStash
             service.agent,
             service.snapshot.metric_store,
             true).each_with_object({}) do |pipeline_stats, memo|
-              pipeline_id = pipeline_stats["id"].to_s
-              memo[pipeline_id] = pipeline_stats
+              p_id = pipeline_stats["id"].to_s
+              memo[p_id] = pipeline_stats
             end
 
           if pipeline_id.nil?

--- a/logstash-core/spec/logstash/api/commands/stats_spec.rb
+++ b/logstash-core/spec/logstash/api/commands/stats_spec.rb
@@ -49,4 +49,41 @@ describe LogStash::Api::Commands::Stats do
     end
 
   end
+
+  describe "pipeline stats" do
+    let(:report_method) { :pipeline }
+    it "returns information on existing pipeline" do
+      expect(report.keys).to include(:main)
+    end
+    context "for each pipeline" do
+      it "returns information on pipeline" do
+        expect(report[:main].keys).to include(
+          :events,
+          :plugins,
+          :reloads,
+          :queue,
+        )
+      end
+      it "returns event information" do
+        expect(report[:main][:events].keys).to include(
+          :in,
+          :filtered,
+          :duration_in_millis,
+          :out,
+          :queue_push_duration_in_millis
+        )
+      end
+    end
+    context "when using multiple pipelines" do
+      before(:each) do
+        expect(LogStash::Config::PipelinesInfo).to receive(:format_pipelines_info).and_return([
+          {"id" => :main},
+          {"id" => :secondary},
+        ])
+      end
+      it "contains metrics for all pipelines" do
+        expect(report.keys).to include(:main, :secondary)
+      end
+    end
+  end
 end

--- a/logstash-core/spec/support/shared_contexts.rb
+++ b/logstash-core/spec/support/shared_contexts.rb
@@ -24,9 +24,12 @@ shared_context "api setup" do
     settings.set("config.reload.automatic", false)
     @agent = make_test_agent(settings)
     @agent.execute
+    @pipelines_registry = LogStash::PipelinesRegistry.new
     pipeline_config = mock_pipeline_config(:main, "input { generator { id => '123' } } output { null {} }")
     pipeline_creator =  LogStash::PipelineAction::Create.new(pipeline_config, @agent.metric)
-    @pipelines_registry = LogStash::PipelinesRegistry.new
+    expect(pipeline_creator.execute(@agent, @pipelines_registry)).to be_truthy
+    pipeline_config = mock_pipeline_config(:secondary, "input { generator { id => '123' } } output { null {} }")
+    pipeline_creator =  LogStash::PipelineAction::Create.new(pipeline_config, @agent.metric)
     expect(pipeline_creator.execute(@agent, @pipelines_registry)).to be_truthy
   end
 


### PR DESCRIPTION
backport of #11059 to 7.x