### PR TITLE
hint plugins need to be installed before bundle

### DIFF
--- a/lib/pluginmanager/offline_plugin_packager.rb
+++ b/lib/pluginmanager/offline_plugin_packager.rb
@@ -66,7 +66,7 @@ module LogStash module PluginManager
         if specs.size > 0
           specs
         else
-          raise LogStash::PluginManager::PluginNotFoundError, "Cannot find plugins matching: `#{plugin_pattern}`"
+          raise LogStash::PluginManager::PluginNotFoundError, "Cannot find plugins matching: `#{plugin_pattern}`. Please install these before creating the offline pack"
         end
       end.flatten
     end


### PR DESCRIPTION
Improve error to make it clearer that plugins are only bundled from locally installed list, not fetched and bundled.