### PR TITLE
support substitutions in pipelines.yml file

### DIFF
--- a/logstash-core/lib/logstash/config/source/multi_local.rb
+++ b/logstash-core/lib/logstash/config/source/multi_local.rb
@@ -4,6 +4,7 @@ require "logstash/settings"
 
 module LogStash module Config module Source
   class MultiLocal < Local
+    include LogStash::Util::SubstitutionVariables
     include LogStash::Util::Loggable
 
     def initialize(settings)
@@ -13,7 +14,7 @@ module LogStash module Config module Source
     end
 
     def pipeline_configs
-      pipelines = retrieve_yaml_pipelines()
+      pipelines = deep_replace(retrieve_yaml_pipelines())
       pipelines_settings = pipelines.map do |pipeline_settings|
         clone = @original_settings.clone
         clone.merge_pipeline_settings(pipeline_settings)


### PR DESCRIPTION
How to test:

1. Create the following `config/pipelines.yml`:
```yaml
- pipeline.id: "${PIPELINE_NAME}"
  pipeline.workers: 1
  pipeline.batch.size: 1
  config.string: "input { generator {} } filter { sleep { time => 1 } } output { stdout { codec => dots } }"
```

2. Start logstash with `PIPELINE_NAME=my_name bin/logstash`
3. See the log line: 
```
[2019-08-30T12:27:01,624][INFO ][logstash.javapipeline    ][${PIPELINE_NAME}] Pipeline started {"pipeline.id"=>"${PIPELINE_NAME}"}
```

4. Stop logstash, apply patch with:

```
curl https://patch-diff.githubusercontent.com/raw/elastic/logstash/pull/11081.patch | patch -p1
```

5. Restarting logstash will now show:

```
[2019-08-30T12:27:51,557][INFO ][logstash.javapipeline    ][my_name] Pipeline started {"pipeline.id"=>"my_name"}
```

Fixes https://github.com/elastic/logstash/issues/11064