### PR TITLE
skip dev and build gems during bootstrap

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,7 @@ def assemblyDeps = [downloadAndInstallJRuby, assemble] + subprojects.collect {
 }
 
 task installBundler(dependsOn: assemblyDeps) {
-  outputs.files file("${projectDir}/vendor/bundle/bin/bundle")
+  outputs.dir("${projectDir}/vendor/bundle")
   doLast {
       gem(projectDir, buildDir, "bundler", "1.17.3", "${projectDir}/vendor/bundle/jruby/2.5.0")
   }

--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -134,7 +134,7 @@ void setupJruby(File projectDir, File buildDir) {
     executeJruby projectDir, buildDir, { ScriptingContainer jruby ->
         jruby.currentDirectory = projectDir
         jruby.runScriptlet("require '${projectDir}/lib/bootstrap/environment'")
-        jruby.runScriptlet("LogStash::Bundler.invoke!")
+        jruby.runScriptlet("LogStash::Bundler.invoke!(:without => [:build, :development])")
     }
 }
 


### PR DESCRIPTION
this prevents artifact builds to contain development gems