### PR TITLE
[POC][DISCUSS] preserve batched events order

### DIFF
--- a/logstash-core/src/main/java/org/logstash/execution/MemoryReadBatch.java
+++ b/logstash-core/src/main/java/org/logstash/execution/MemoryReadBatch.java
@@ -34,7 +34,9 @@ public final class MemoryReadBatch implements QueueBatch {
     public RubyArray to_a() {
         ThreadContext context = RUBY.getCurrentContext();
         final RubyArray result = context.runtime.newArray(events.size());
+        int i = 0;
         for (final IRubyObject event : events) {
+            ((JrubyEventExtLibrary.RubyEvent) event).getEvent().setField("order", i++);
             if (!isCancelled(event)) {
                 result.add(event);
             }


### PR DESCRIPTION
NOT FOR REVIEW, FOR DISCUSSION.

This is a quick and incomplete POC to demonstrate the idea of events ordering within batches as a possible solution for #10938 and #11062 

I will not go over the problem description, see the above issues, but the idea of this solution here is:
- First to assign a sequence number to the event as read from the queue. Currently this is done by adding an `order` field in the event with that sequence number, obviously this is just a POC and a *proper* sequence attribute should be implemented. 
- Then the OutputDelegator `multiReceive` method sorts the events based on that sequence number `order` field before passing them to the output plugin.

This implementation is incomplete and has a few caveats; only the memory queue assigns the sequence number, it does not take into account new events that are added by the filters. 

I don't think solving the case of the new events would be too difficult. 

With the following example:
```
input {
  generator {
    lines => [
      "line 1",
      "line a",
      "line 2",
      "line b",
      "line 3",
      "line c"
    ]
    count => 1
  }
}

filter {
  if [message] =~ "\d" {
    mutate { add_tag => "digit" }
  } else {
    mutate { add_tag => "letter" }
  }
}

output { stdout { codec => line } }
```

It preserves order correctly with this patch:
```
$ bin/logstash -w 1  -f tmp/ordering.conf
...
2019-08-29T21:03:44.603Z mbp15r.local line 1
2019-08-29T21:03:44.624Z mbp15r.local line a
2019-08-29T21:03:44.625Z mbp15r.local line 2
2019-08-29T21:03:44.625Z mbp15r.local line b
2019-08-29T21:03:44.626Z mbp15r.local line 3
2019-08-29T21:03:44.626Z mbp15r.local line c
```

It does not preserve order without the patch:
```
$ bin/logstash -w 1  -f tmp/ordering.conf
...
2019-08-29T21:06:44.554Z mbp15r.local line 1
2019-08-29T21:06:44.577Z mbp15r.local line 2
2019-08-29T21:06:44.578Z mbp15r.local line 3
2019-08-29T21:06:44.577Z mbp15r.local line a
2019-08-29T21:06:44.578Z mbp15r.local line b
2019-08-29T21:06:44.578Z mbp15r.local line c
```


WDYT?