### PR TITLE
update core jars. remove dependency on org.eclipse

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -127,18 +127,18 @@ def customJRubyDir = project.hasProperty("custom.jruby.path") ? project.property
 def customJRubyVersion = customJRubyDir == "" ? "" : Files.readAllLines(Paths.get(customJRubyDir, "VERSION")).get(0).trim()
 
 dependencies {
-    compile 'org.apache.logging.log4j:log4j-api:2.11.1'
-    compile 'org.apache.logging.log4j:log4j-core:2.11.1'
-    runtime 'org.apache.logging.log4j:log4j-slf4j-impl:2.11.1'
+    compile 'org.apache.logging.log4j:log4j-api:2.12.1'
+    compile 'org.apache.logging.log4j:log4j-core:2.12.1'
+    runtime 'org.apache.logging.log4j:log4j-slf4j-impl:2.12.1'
     compile('org.reflections:reflections:0.9.11') {
         exclude group: 'com.google.guava', module: 'guava'
     }
-    compile 'commons-codec:commons-codec:1.11'
+    compile 'commons-codec:commons-codec:1.13'
     // Jackson version moved to versions.yml in the project root (the JrJackson version is there too)
     compile "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
     compile "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
     compile "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
-    compile 'org.codehaus.janino:janino:3.0.11'
+    compile 'org.codehaus.janino:janino:3.0.15'
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jacksonVersion}"
     if (customJRubyDir == "") {
         compile "org.jruby:jruby-complete:${jrubyVersion}"
@@ -148,12 +148,12 @@ dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '22.0'
     // Do not upgrade this, later versions require GPL licensed code in javac-shaded that is
     // Apache2 incompatible
-    compile('com.google.googlejavaformat:google-java-format:1.1') {
+    compile('com.google.googlejavaformat:google-java-format:1.7') {
         exclude group: 'com.google.guava', module: 'guava'
     }
-    compile 'org.javassist:javassist:3.24.0-GA'
-    compile 'com.google.guava:guava:20.0'
-    testCompile 'org.apache.logging.log4j:log4j-core:2.11.1:tests'
+    compile 'org.javassist:javassist:3.26.0-GA'
+    compile 'com.google.guava:guava:22.0'
+    testCompile 'org.apache.logging.log4j:log4j-core:2.12.1:tests'
     testCompile 'junit:junit:4.12'
     testCompile 'net.javacrumbs.json-unit:json-unit:2.3.0'
     testCompile 'org.elasticsearch:securemock:1.2'

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -152,7 +152,6 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
     }
     compile 'org.javassist:javassist:3.26.0-GA'
-    //compile 'com.google.guava:guava:22.0'
     testCompile 'org.apache.logging.log4j:log4j-core:2.12.1:tests'
     testCompile 'junit:junit:4.12'
     testCompile 'net.javacrumbs.json-unit:json-unit:2.3.0'

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -138,7 +138,7 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
     compile "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
     compile "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
-    compile 'org.codehaus.janino:janino:3.0.15'
+    compile 'org.codehaus.janino:janino:3.1.0'
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jacksonVersion}"
     if (customJRubyDir == "") {
         compile "org.jruby:jruby-complete:${jrubyVersion}"
@@ -152,7 +152,7 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
     }
     compile 'org.javassist:javassist:3.26.0-GA'
-    compile 'com.google.guava:guava:22.0'
+    //compile 'com.google.guava:guava:22.0'
     testCompile 'org.apache.logging.log4j:log4j-core:2.12.1:tests'
     testCompile 'junit:junit:4.12'
     testCompile 'net.javacrumbs.json-unit:json-unit:2.3.0'

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/ComputeStepSyntaxElement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/ComputeStepSyntaxElement.java
@@ -15,8 +15,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.codehaus.commons.compiler.CompileException;
-import org.codehaus.commons.compiler.ICookable;
 import org.codehaus.commons.compiler.ISimpleCompiler;
+import org.codehaus.janino.Scanner;
 import org.codehaus.janino.SimpleCompiler;
 
 /**
@@ -132,7 +132,7 @@ public final class ComputeStepSyntaxElement<T extends Dataset> {
         Path sourceDir = null;
         try {
             final Path parentDir;
-            final String dir = System.getProperty(ICookable.SYSTEM_PROPERTY_SOURCE_DEBUGGING_DIR);
+            final String dir = System.getProperty(Scanner.SYSTEM_PROPERTY_SOURCE_DEBUGGING_DIR);
             if (dir != null) {
                 parentDir = Paths.get(dir);
                 sourceDir = parentDir.resolve("org").resolve("logstash").resolve("generated");


### PR DESCRIPTION
Current used version of google-java-format (1.1) depends on org.eclipse https://mvnrepository.com/artifact/com.google.googlejavaformat/google-java-format/1.1

Newer versions like [1.7 no longer do this](https://mvnrepository.com/artifact/com.google.googlejavaformat/google-java-format/1.7) so we can remove dependency on org.eclipse jars and remove some megabytes from the builds 

this PR also bumps versions of some of the other jars used in core