### PR TITLE
Conditionally add monitoring structure to top-level of output in API

### DIFF
--- a/logstash-core/lib/logstash/api/commands/default_metadata.rb
+++ b/logstash-core/lib/logstash/api/commands/default_metadata.rb
@@ -7,20 +7,31 @@ module LogStash
     module Commands
       class DefaultMetadata < Commands::Base
         def all
-          {:host => host,
-           :version => version,
-           :http_address => http_address,
-           :id => service.agent.id,
-           :name => service.agent.name,
-           :ephemeral_id => service.agent.ephemeral_id,
-           :status => "green",  # This is hard-coded to mirror x-pack behavior
-           :snapshot => ::BUILD_INFO["build_snapshot"],
-           :pipeline => {
-             :workers => LogStash::SETTINGS.get("pipeline.workers"),
-             :batch_size => LogStash::SETTINGS.get("pipeline.batch.size"),
-             :batch_delay => LogStash::SETTINGS.get("pipeline.batch.delay"),
-           }
-           }
+          res = {:host => host,
+             :version => version,
+             :http_address => http_address,
+             :id => service.agent.id,
+             :name => service.agent.name,
+             :ephemeral_id => service.agent.ephemeral_id,
+             :status => "green",  # This is hard-coded to mirror x-pack behavior
+             :snapshot => ::BUILD_INFO["build_snapshot"],
+             :pipeline => {
+               :workers => LogStash::SETTINGS.get("pipeline.workers"),
+               :batch_size => LogStash::SETTINGS.get("pipeline.batch.size"),
+               :batch_delay => LogStash::SETTINGS.get("pipeline.batch.delay"),
+             },
+            }
+          monitoring = {}
+          if enabled_xpack_monitoring?
+            monitoring = monitoring.merge({
+                        :hosts => LogStash::SETTINGS.get("xpack.monitoring.elasticsearch.hosts"),
+                        :username => LogStash::SETTINGS.get("xpack.monitoring.elasticsearch.username")
+                        })
+          end
+          if LogStash::SETTINGS.set?("monitoring.cluster_uuid")
+            monitoring = monitoring.merge({:cluster_uuid => LogStash::SETTINGS.get("monitoring.cluster_uuid")})
+          end
+          res.merge(monitoring.empty? ? {} : {:monitoring => monitoring})
         end
 
         def host
@@ -35,6 +46,12 @@ module LogStash
           @http_address ||= service.get_shallow(:http_address).value
         rescue ::LogStash::Instrument::MetricStore::MetricNotFound, NoMethodError => e
           nil
+        end
+
+        private
+        def enabled_xpack_monitoring?
+          LogStash::SETTINGS.registered?("xpack.monitoring.enabled") &&
+          LogStash::SETTINGS.get("xpack.monitoring.enabled")
         end
       end
     end

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -71,7 +71,8 @@ module LogStash
             Setting::TimeValue.new("slowlog.threshold.debug", "-1"),
             Setting::TimeValue.new("slowlog.threshold.trace", "-1"),
             Setting::String.new("keystore.classname", "org.logstash.secret.store.backend.JavaKeyStore"),
-            Setting::String.new("keystore.file", ::File.join(::File.join(LogStash::Environment::LOGSTASH_HOME, "config"), "logstash.keystore"), false) # will be populated on
+            Setting::String.new("keystore.file", ::File.join(::File.join(LogStash::Environment::LOGSTASH_HOME, "config"), "logstash.keystore"), false), # will be populated on
+            Setting::NullableString.new("monitoring.cluster_uuid")
   # post_process
   ].each {|setting| SETTINGS.register(setting) }
 

--- a/logstash-core/spec/logstash/api/commands/default_metadata_spec.rb
+++ b/logstash-core/spec/logstash/api/commands/default_metadata_spec.rb
@@ -4,6 +4,10 @@ require "spec_helper"
 describe LogStash::Api::Commands::DefaultMetadata do
   include_context "api setup"
 
+  def registerIfNot(setting)
+    LogStash::SETTINGS.register(setting) unless LogStash::SETTINGS.registered?(setting.name)
+  end
+
   let(:report_method) { :all }
   subject(:report) do
     factory = ::LogStash::Api::CommandFactory.new(LogStash::Api::Service.new(@agent))
@@ -12,9 +16,43 @@ describe LogStash::Api::Commands::DefaultMetadata do
 
   let(:report_class) { described_class }
 
+  before :all do
+    registerIfNot(LogStash::Setting::Boolean.new("xpack.monitoring.enabled", false))
+    registerIfNot(LogStash::Setting::ArrayCoercible.new("xpack.monitoring.elasticsearch.hosts", String, [ "http://localhost:9200" ] ))
+    registerIfNot(LogStash::Setting::NullableString.new("xpack.monitoring.elasticsearch.username", "logstash_TEST system"))
+    registerIfNot(LogStash::Setting::NullableString.new("xpack.monitoring.elasticsearch.username", "logstash_TEST system"))
+  end
+
+  after :each do
+    LogStash::SETTINGS.set_value("xpack.monitoring.enabled", false)
+  end
+
   describe "#plugins_stats_report" do
     let(:report_method) { :all }
+
     # Enforce just the structure
+    it "check monitoring exist when cluster_uuid has been defined" do
+      LogStash::SETTINGS.set_value("monitoring.cluster_uuid", "cracking_cluster")
+      expect(report.keys).to include(
+        :monitoring
+        )
+    end
+
+    it "check monitoring exist when monitoring is enabled" do
+      LogStash::SETTINGS.set_value("xpack.monitoring.enabled", true)
+      expect(report.keys).to include(
+        :monitoring
+        )
+    end
+
+    it "check monitoring does not appear when not enabled and nor cluster_uuid is defined" do
+      LogStash::SETTINGS.set_value("xpack.monitoring.enabled", false)
+      LogStash::SETTINGS.get_setting("monitoring.cluster_uuid").reset
+      expect(report.keys).not_to include(
+        :monitoring
+        )
+    end
+
     it "check keys" do
       expect(report.keys).to include(
         :host,


### PR DESCRIPTION
Refs: https://github.com/elastic/logstash/issues/11066

Adds a new setting to Logstash called `xpack.monitoring.cluster_uuid`. If the setting is discovered to be set by the user, it is added to the top-level of API responses.

@ycombinator I have included instructions below for you to have a look and see if it agrees with what you were expecting:

### Testing

1) Add `xpack.monitoring.cluster_uuid: OVERRIDE` to `logstash.yml` configuration file.
2) Start logstash
3) Issue an HTTP GET to an endpoint such as `http://localhost:9600/_node/stats`
4) Verify that the response contains the following key-value pair at the top-level of the dictionary: `"cluster_uuid: OVERRIDE"`
5) Stop Logstash
6) Modify `logstash.yml` and comment out the setting in step 1
7) Restart Logstash and re-issue the query in step 3. Observe that the top-level `cluster_uuid` does not exist.

### Questions

From reading the issue it seems like the only requested functionality is to _add_ the key to the API response and not to modify the return in any other way. Is that understanding correct?