### PR TITLE
[Doc] Fix links in the Contributing to Logstash Page

### DIFF
--- a/docs/static/contributing-to-logstash.asciidoc
+++ b/docs/static/contributing-to-logstash.asciidoc
@@ -12,9 +12,9 @@ deploying your own plugin:
 
 * <<plugin-generator,Generating a New Plugin>>
 * <<input-new-plugin,How to write a Logstash input plugin>>
-* <<input-new-plugin,How to write a Logstash codec plugin>>
-* <<input-new-plugin,How to write a Logstash filter plugin>>
-* <<input-new-plugin,How to write a Logstash output plugin>>
+* <<codec-new-plugin,How to write a Logstash codec plugin>>
+* <<filter-new-plugin,How to write a Logstash filter plugin>>
+* <<output-new-plugin,How to write a Logstash output plugin>>
 * <<plugin-doc,Documenting your plugin>>
 * <<contributing-patch-plugin,Contributing a Patch to a Logstash Plugin>>
 * <<community-maintainer,Community Maintainer's Guide>>


### PR DESCRIPTION
On the "Contributing to Logstash" page, the following links all go to the same page:

* How to write a Logstash input plugin
* How to write a Logstash codec plugin
* How to write a Logstash filter plugin
* How to write a Logstash output plugin

This PR fixes this, by using the corresponding link for each entry.