### PR TITLE
Write DLQ entries to temp file first

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -178,6 +178,14 @@
 # Default is 1024mb
 # dead_letter_queue.max_bytes: 1024mb
 
+# If using dead_letter_queue.enable: true, the interval in milliseconds where if no further events eligible for the DLQ
+# have been created, a dead letter queue file will be written. A low value here will mean that more, smaller, queue files
+# may be written, while a larger value will introduce more latency between items being "written" to the dead letter queue, and
+# being available to be read by the dead_letter_queue input when items are are written infrequently.
+# Default is 5000.
+#
+# dead_letter_queue.flush_interval: 5000
+
 # If using dead_letter_queue.enable: true, the directory path where the data files will be stored.
 # Default is path.data/dead_letter_queue
 #

--- a/config/pipelines.yml
+++ b/config/pipelines.yml
@@ -71,6 +71,15 @@
 #   Default is 1024mb
 #   dead_letter_queue.max_bytes: 1024mb
 #
+#   If using dead_letter_queue.enable: true, the interval in milliseconds where if no further events eligible for the DLQ
+#   have been created, a dead letter queue file will be written. A low value here will mean that more, smaller, queue files
+#   may be written, while a larger value will introduce more latency between items being "written" to the dead letter queue, and
+#   being available to be read by the dead_letter_queue input when items are are written infrequently.
+#   Default is 5000.
+#
+#   dead_letter_queue.flush_interval: 5000
+
+#
 #   If using dead_letter_queue.enable: true, the directory path where the data files will be stored.
 #   Default is path.data/dead_letter_queue
 #

--- a/docker/data/logstash/env2yaml/env2yaml.go
+++ b/docker/data/logstash/env2yaml/env2yaml.go
@@ -76,6 +76,7 @@ func normalizeSetting(setting string) (string, error) {
 		"queue.drain",
 		"dead_letter_queue.enable",
 		"dead_letter_queue.max_bytes",
+		"dead_letter_queue.flush_interval",
 		"path.dead_letter_queue",
 		"http.host",
 		"http.port",

--- a/docs/static/dead-letter-queues.asciidoc
+++ b/docs/static/dead-letter-queues.asciidoc
@@ -57,6 +57,25 @@ specify a different path for the files:
 path.dead_letter_queue: "path/to/data/dead_letter_queue"
 -------------------------------------------------------------------------------
 
+Dead letter queue entries are written to a temporary file, which is then renamed
+ to a dead letter queue file, which is then eligible for ingestion. The rename
+ happens either when this temporary file is considered 'full', or when a period
+ of time has elapsed since the last dead letter queue eligible event was written
+ to the temporary file.
+
+This length of time can be set using the `dead_letter_queue.flush_interval` setting.
+ This setting is in milliseconds, and defaults to 5000ms. A low value here will mean
+ in the event of infrequent writes to the dead letter queue more, smaller, queue
+ files may be written, while a larger value will introduce more latency between
+ items being "written" to the dead letter queue, and being made available for
+ reading by the dead_letter_queue input.
+
+ Note that this value cannot be set to lower than 1000ms.
+
+[source,yaml]
+-------------------------------------------------------------------------------
+dead_letter_queue.flush_interval: 5000
+-------------------------------------------------------------------------------
 
 NOTE: You may not use the same `dead_letter_queue` path for two different
 Logstash instances.

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -65,6 +65,7 @@ module LogStash
             Setting::Boolean.new("queue.checkpoint.retry", false),
             Setting::Boolean.new("dead_letter_queue.enable", false),
             Setting::Bytes.new("dead_letter_queue.max_bytes", "1024mb"),
+            Setting::Numeric.new("dead_letter_queue.flush_interval", 5000),
             Setting::TimeValue.new("slowlog.threshold.warn", "-1"),
             Setting::TimeValue.new("slowlog.threshold.info", "-1"),
             Setting::TimeValue.new("slowlog.threshold.debug", "-1"),

--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -18,6 +18,7 @@ module LogStash
       "config.reload.interval",
       "config.string",
       "dead_letter_queue.enable",
+      "dead_letter_queue.flush_interval",
       "dead_letter_queue.max_bytes",
       "metric.collect",
       "pipeline.java_execution",

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -6,6 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.UUID;
 import org.apache.commons.codec.binary.Hex;
@@ -247,10 +248,9 @@ public class AbstractPipelineExt extends RubyBasicObject {
                     DeadLetterQueueFactory.getWriter(
                         pipelineId.asJavaString(),
                         getSetting(context, "path.dead_letter_queue").asJavaString(),
-                        getSetting(context, "dead_letter_queue.max_bytes").convertToInteger()
-                            .getLongValue()
-                    )
-                );
+                        getSetting(context, "dead_letter_queue.max_bytes").convertToInteger().getLongValue(),
+                        Duration.ofMillis(getSetting(context, "dead_letter_queue.flush_interval").convertToInteger().getLongValue()))
+                    );
             } else {
                 dlqWriter = RubyUtil.DUMMY_DLQ_WRITER_CLASS.callMethod(context, "new");
             }

--- a/logstash-core/src/test/java/org/logstash/common/DeadLetterQueueFactoryTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/DeadLetterQueueFactoryTest.java
@@ -27,6 +27,7 @@ import org.logstash.common.io.DeadLetterQueueWriter;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 
 import static junit.framework.TestCase.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -47,9 +48,9 @@ public class DeadLetterQueueFactoryTest {
     public void testSameBeforeRelease() throws IOException {
         try {
             Path pipelineA = dir.resolve(PIPELINE_NAME);
-            DeadLetterQueueWriter writer = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000);
+            DeadLetterQueueWriter writer = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000, Duration.ofSeconds(1));
             assertTrue(writer.isOpen());
-            DeadLetterQueueWriter writer2 = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000);
+            DeadLetterQueueWriter writer2 = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000, Duration.ofSeconds(1));
             assertSame(writer, writer2);
             writer.close();
         } finally {
@@ -61,11 +62,11 @@ public class DeadLetterQueueFactoryTest {
     public void testOpenableAfterRelease() throws IOException {
         try {
             Path pipelineA = dir.resolve(PIPELINE_NAME);
-            DeadLetterQueueWriter writer = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000);
+            DeadLetterQueueWriter writer = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000, Duration.ofSeconds(1));
             assertTrue(writer.isOpen());
             writer.close();
             DeadLetterQueueFactory.release(PIPELINE_NAME);
-            writer = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000);
+            writer = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000, Duration.ofSeconds(1));
             assertTrue(writer.isOpen());
             writer.close();
         }finally{

--- a/logstash-core/src/test/java/org/logstash/common/io/RecordIOReaderTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/RecordIOReaderTest.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.OptionalInt;
 import java.util.function.Function;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -152,6 +153,39 @@ public class RecordIOReaderTest {
                 assertThat(toChar.apply(reader.readEvent()), equalTo(i));
             }
         }
+    }
+
+    @Test
+    public void testObviouslyInvalidSegment() throws Exception {
+        assertThat(RecordIOReader.validNonEmptySegment(file), is(false));
+    }
+
+    @Test
+    public void testPartiallyWrittenSegment() throws Exception {
+        try(RecordIOWriter writer = new RecordIOWriter(file)) {
+            writer.writeRecordHeader(
+                    new RecordHeader(RecordType.COMPLETE, 100, OptionalInt.empty(), 0));
+        }
+        assertThat(RecordIOReader.validNonEmptySegment(file), is(false));
+    }
+
+    @Test
+    public void testEmptySegment() throws Exception {
+        try(RecordIOWriter writer = new RecordIOWriter(file)){
+            // Do nothing. Creating a new writer is the same behaviour as starting and closing
+            // This line avoids a compiler warning.
+            writer.toString();
+        }
+        assertThat(RecordIOReader.validNonEmptySegment(file), is(false));
+    }
+
+    @Test
+    public void testValidSegment() throws Exception {
+        try(RecordIOWriter writer = new RecordIOWriter(file)){
+            writer.writeEvent(new byte[]{ 72, 101, 108, 108, 111});
+        }
+
+        assertThat(RecordIOReader.validNonEmptySegment(file), is(true));
     }
 
     @Test

--- a/qa/integration/build.gradle
+++ b/qa/integration/build.gradle
@@ -27,4 +27,13 @@ task integrationTests(type: Test) {
   inputs.files fileTree("${projectDir}/specs")
   systemProperty 'logstash.core.root.dir', projectDir.absolutePath
   include '/org/logstash/integration/RSpecTests.class'
+
+  outputs.upToDateWhen {
+    if (project.hasProperty('integrationTests.rerun')) {
+      println "Rerunning Integration Tests"
+      return false
+    } else {
+      return true
+    }
+  }
 }


### PR DESCRIPTION
This commit changes the DLQ writer to write to a temporary file
 which will be renamed on "completion", to avoid the possibility
 of the DLQ reader reading an incomplete DLQ segment. The temp file
 will be renamed and made available, either when the capacity of this
 segment is reached, or if a configurable 'flush interval' has elapsed
 since the last event reached the dead letter queue.

This commit fixes #8022, #10275, #10967