### PR TITLE
Added line and columns to plugin name

### DIFF
--- a/logstash-core/lib/logstash/codecs/base.rb
+++ b/logstash-core/lib/logstash/codecs/base.rb
@@ -13,8 +13,9 @@ module LogStash::Codecs; class Base < LogStash::Plugin
   end
 
   def initialize(params={})
+    puts "initalize in Base::Codec"
     super
-    config_init(@params)
+    config_init(nil, @params)
     register if respond_to?(:register)
     setup_multi_encode!
   end

--- a/logstash-core/lib/logstash/codecs/base.rb
+++ b/logstash-core/lib/logstash/codecs/base.rb
@@ -14,7 +14,7 @@ module LogStash::Codecs; class Base < LogStash::Plugin
 
   def initialize(params={})
     super
-    config_init(nil, @params)
+    config_init(@params)
     register if respond_to?(:register)
     setup_multi_encode!
   end

--- a/logstash-core/lib/logstash/codecs/base.rb
+++ b/logstash-core/lib/logstash/codecs/base.rb
@@ -13,7 +13,6 @@ module LogStash::Codecs; class Base < LogStash::Plugin
   end
 
   def initialize(params={})
-    puts "initalize in Base::Codec"
     super
     config_init(nil, @params)
     register if respond_to?(:register)

--- a/logstash-core/lib/logstash/codecs/delegator.rb
+++ b/logstash-core/lib/logstash/codecs/delegator.rb
@@ -16,8 +16,8 @@ module LogStash::Codecs
       __getobj__.metric = metric
 
       __getobj__.metric.gauge(:name, __getobj__.class.config_name)
-      __getobj__.metric.gauge("parent-code-ref", @parent_code_reference)
-      __getobj__.metric.gauge("parent-name", @parent_plugin_name)
+      __getobj__.metric.gauge(:"parent-code-ref", @parent_code_reference)
+      __getobj__.metric.gauge(:"parent-name", @parent_plugin_name)
 
       @encode_metric = __getobj__.metric.namespace(:encode)
       @encode_metric.counter(:writes_in)

--- a/logstash-core/lib/logstash/codecs/delegator.rb
+++ b/logstash-core/lib/logstash/codecs/delegator.rb
@@ -1,9 +1,9 @@
 module LogStash::Codecs
   class Delegator < SimpleDelegator
-    def initialize(obj, parent_plugin_name, parent_code_reference)
+    def initialize(obj, parent_plugin_name)
       super(obj)
       @parent_plugin_name = parent_plugin_name
-      @parent_code_reference = parent_code_reference
+      @parent_code_reference = nil
       @encode_metric = LogStash::Instrument::NamespacedNullMetric.new
       @decode_metric = LogStash::Instrument::NamespacedNullMetric.new
     end
@@ -27,6 +27,10 @@ module LogStash::Codecs
       @decode_metric.counter(:writes_in)
       @decode_metric.counter(:out)
       @decode_metric.report_time(:duration_in_millis, 0)
+    end
+
+    def parent_code_reference=(parent_code_reference)
+      @parent_code_reference = parent_code_reference
     end
 
     def encode(event)

--- a/logstash-core/lib/logstash/codecs/delegator.rb
+++ b/logstash-core/lib/logstash/codecs/delegator.rb
@@ -1,7 +1,9 @@
 module LogStash::Codecs
   class Delegator < SimpleDelegator
-    def initialize(obj)
+    def initialize(obj, parent_plugin_name, parent_code_reference)
       super(obj)
+      @parent_plugin_name = parent_plugin_name
+      @parent_code_reference = parent_code_reference
       @encode_metric = LogStash::Instrument::NamespacedNullMetric.new
       @decode_metric = LogStash::Instrument::NamespacedNullMetric.new
     end
@@ -14,6 +16,8 @@ module LogStash::Codecs
       __getobj__.metric = metric
 
       __getobj__.metric.gauge(:name, __getobj__.class.config_name)
+      __getobj__.metric.gauge("parent-code-ref", @parent_code_reference)
+      __getobj__.metric.gauge("parent-name", @parent_plugin_name)
 
       @encode_metric = __getobj__.metric.namespace(:encode)
       @encode_metric.counter(:writes_in)

--- a/logstash-core/lib/logstash/codecs/delegator.rb
+++ b/logstash-core/lib/logstash/codecs/delegator.rb
@@ -3,7 +3,7 @@ module LogStash::Codecs
     def initialize(obj, parent_plugin_name)
       super(obj)
       @parent_plugin_name = parent_plugin_name
-      @parent_code_reference = nil
+      @parent_config_reference = nil
       @encode_metric = LogStash::Instrument::NamespacedNullMetric.new
       @decode_metric = LogStash::Instrument::NamespacedNullMetric.new
     end
@@ -16,7 +16,7 @@ module LogStash::Codecs
       __getobj__.metric = metric
 
       __getobj__.metric.gauge(:name, __getobj__.class.config_name)
-      __getobj__.metric.gauge(:"parent-code-ref", @parent_code_reference)
+      __getobj__.metric.gauge(:"parent-config-ref", @parent_config_reference)
       __getobj__.metric.gauge(:"parent-name", @parent_plugin_name)
 
       @encode_metric = __getobj__.metric.namespace(:encode)
@@ -29,8 +29,8 @@ module LogStash::Codecs
       @decode_metric.report_time(:duration_in_millis, 0)
     end
 
-    def parent_code_reference=(parent_code_reference)
-      @parent_code_reference = parent_code_reference
+    def parent_config_reference=(parent_config_reference)
+      @parent_config_reference = parent_config_reference
     end
 
     def encode(event)

--- a/logstash-core/lib/logstash/compiler.rb
+++ b/logstash-core/lib/logstash/compiler.rb
@@ -7,7 +7,7 @@ module LogStash; class Compiler
   include ::LogStash::Util::Loggable
 
   def self.compile_sources(pipeline_config, support_escapes)
-    sources_with_metadata = pipeline_config.config_parts#[org.logstash.common.SourceWithMetadata.new("str", "pipeline", 0, 0, pipeline_config.config_string)]
+   sources_with_metadata = [org.logstash.common.SourceWithMetadata.new("str", "pipeline", 0, 0, pipeline_config.config_string)]
     graph_sections = sources_with_metadata.map do |swm|
       self.compile_graph(pipeline_config, swm, support_escapes)
     end

--- a/logstash-core/lib/logstash/compiler.rb
+++ b/logstash-core/lib/logstash/compiler.rb
@@ -7,7 +7,7 @@ module LogStash; class Compiler
   include ::LogStash::Util::Loggable
 
   def self.compile_sources(pipeline_config, support_escapes)
-    sources_with_metadata = [org.logstash.common.SourceWithMetadata.new("str", "pipeline", 0, 0, pipeline_config.config_string)]
+    sources_with_metadata = pipeline_config.config_parts#[org.logstash.common.SourceWithMetadata.new("str", "pipeline", 0, 0, pipeline_config.config_string)]
     graph_sections = sources_with_metadata.map do |swm|
       self.compile_graph(pipeline_config, swm, support_escapes)
     end

--- a/logstash-core/lib/logstash/compiler.rb
+++ b/logstash-core/lib/logstash/compiler.rb
@@ -7,8 +7,6 @@ module LogStash; class Compiler
   include ::LogStash::Util::Loggable
 
   def self.compile_sources(pipeline_config, support_escapes)
-    puts ">>> call stack Compiler#compile_sources"; caller.each { |frame| puts "#{frame}"}
-
     sources_with_metadata = [org.logstash.common.SourceWithMetadata.new("str", "pipeline", 0, 0, pipeline_config.config_string)]
     graph_sections = sources_with_metadata.map do |swm|
       self.compile_graph(pipeline_config, swm, support_escapes)

--- a/logstash-core/lib/logstash/compiler.rb
+++ b/logstash-core/lib/logstash/compiler.rb
@@ -6,9 +6,12 @@ java_import org.logstash.config.ir.graph.Graph
 module LogStash; class Compiler
   include ::LogStash::Util::Loggable
 
-  def self.compile_sources(sources_with_metadata, support_escapes)
+  def self.compile_sources(pipeline_config, support_escapes)
+    puts ">>> call stack Compiler#compile_sources"; caller.each { |frame| puts "#{frame}"}
+
+    sources_with_metadata = [org.logstash.common.SourceWithMetadata.new("str", "pipeline", 0, 0, pipeline_config.config_string)]
     graph_sections = sources_with_metadata.map do |swm|
-      self.compile_graph(swm, support_escapes)
+      self.compile_graph(pipeline_config, swm, support_escapes)
     end
 
     input_graph = Graph.combine(*graph_sections.map {|s| s[:input] }).graph
@@ -29,7 +32,7 @@ module LogStash; class Compiler
     PipelineIR.new(input_graph, filter_graph, output_graph, original_source)
   end
 
-  def self.compile_imperative(source_with_metadata, support_escapes)
+  def self.compile_imperative(pipeline_config, source_with_metadata, support_escapes)
     if !source_with_metadata.is_a?(org.logstash.common.SourceWithMetadata)
       raise ArgumentError, "Expected 'org.logstash.common.SourceWithMetadata', got #{source_with_metadata.class}"
     end
@@ -41,11 +44,23 @@ module LogStash; class Compiler
       raise ConfigurationError, grammar.failure_reason
     end
 
+    plugins = config.recursive_select(LogStashCompilerLSCLGrammar::LogStash::Compiler::LSCL::AST::Plugin)
+    added_source_line_column(pipeline_config, plugins)
+
     config.process_escape_sequences = support_escapes
     config.compile(source_with_metadata)
   end
 
-  def self.compile_graph(source_with_metadata, support_escapes)
-    Hash[compile_imperative(source_with_metadata, support_escapes).map {|section,icompiled| [section, icompiled.toGraph]}]
+  def self.compile_graph(pipeline_config, source_with_metadata, support_escapes)
+    Hash[compile_imperative(pipeline_config, source_with_metadata, support_escapes).map {|section,icompiled| [section, icompiled.toGraph]}]
   end
+
+  def self.added_source_line_column(pipeline_config, plugins)
+    for plugin in plugins do
+      remapped_line = pipeline_config.lookup_source_and_line(plugin.line_and_column[0])
+      plugin.source_file = remapped_line[0]
+      plugin.source_line = remapped_line[1]
+    end
+  end
+
 end; end

--- a/logstash-core/lib/logstash/compiler.rb
+++ b/logstash-core/lib/logstash/compiler.rb
@@ -54,7 +54,7 @@ module LogStash; class Compiler
   end
 
   def self.added_source_line_column(pipeline_config, plugins)
-    for plugin in plugins do
+    plugins.each do |plugin|
       remapped_line = pipeline_config.lookup_source_and_line(plugin.line_and_column[0])
       plugin.source_file = remapped_line[0]
       plugin.source_line = remapped_line[1]

--- a/logstash-core/lib/logstash/compiler/lscl.rb
+++ b/logstash-core/lib/logstash/compiler/lscl.rb
@@ -72,8 +72,11 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
 
   class Plugins < Node; end
   class Plugin < Node
+
+    attr_accessor :source_file, :source_line
+
     def expr
-      jdsl.iPlugin(source_meta, plugin_type_enum, self.plugin_name, self.expr_attributes)
+      jdsl.iPlugin(source_meta, plugin_type_enum, self.plugin_name, source_file, source_line, self.expr_attributes)
     end
 
     def plugin_type_enum

--- a/logstash-core/lib/logstash/compiler/lscl.rb
+++ b/logstash-core/lib/logstash/compiler/lscl.rb
@@ -90,7 +90,11 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
     end
 
     def plugin_name
-      return name.text_value + "L:#{line_and_column[0]},C:#{line_and_column[1]}"
+      return name.text_value
+    end
+
+    def plugin_name_extended
+      return plugin_name + "L:#{line_and_column[0]},C:#{line_and_column[1]}"
     end
 
     def expr_attributes

--- a/logstash-core/lib/logstash/compiler/lscl.rb
+++ b/logstash-core/lib/logstash/compiler/lscl.rb
@@ -96,10 +96,6 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
       return name.text_value
     end
 
-    def plugin_name_extended
-      return plugin_name + "L:#{line_and_column[0]},C:#{line_and_column[1]}"
-    end
-
     def expr_attributes
       # Turn attributes into a hash map
       self.attributes.recursive_select(Attribute).map(&:expr).map {|k,v|

--- a/logstash-core/lib/logstash/compiler/lscl.rb
+++ b/logstash-core/lib/logstash/compiler/lscl.rb
@@ -98,7 +98,11 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
 
     def expr_attributes
       # Turn attributes into a hash map
-      self.attributes.recursive_select(Attribute).map(&:expr).map {|k,v|
+      self.attributes.recursive_select(Attribute).map {|attribute|
+        attribute.source_file = source_file
+        attribute.source_line = source_line
+        attribute
+      }.map(&:expr).map {|k,v|
         if v.java_kind_of?(Java::OrgLogstashConfigIrExpression::ValueExpression)
           [k, v.get]
         else
@@ -133,7 +137,12 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
   end
 
   class Attribute < Node
+    attr_accessor :source_file, :source_line
     def expr
+      if value.is_a?(Plugin)
+        value.source_file = source_file
+        value.source_line = source_line
+      end
       [name.text_value, value.expr]
     end
   end

--- a/logstash-core/lib/logstash/compiler/lscl.rb
+++ b/logstash-core/lib/logstash/compiler/lscl.rb
@@ -90,7 +90,7 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
     end
 
     def plugin_name
-      return name.text_value
+      return name.text_value + "L:#{line_and_column[0]},C:#{line_and_column[1]}"
     end
 
     def expr_attributes

--- a/logstash-core/lib/logstash/config/config_ast.rb
+++ b/logstash-core/lib/logstash/config/config_ast.rb
@@ -233,8 +233,6 @@ module LogStash; module Config; module AST
 
     def compile_initializer
       # If any parent is a Plugin, this must be a codec.
-      puts ">>> calling compile_initializer() for #{plugin_type}"
-
       if attributes.elements.nil?
         return "plugin(#{plugin_type.inspect}, #{plugin_name.inspect}, #{source_meta.line}, #{source_meta.column}, #{source_file.inspect}, #{source_line.inspect})" << (plugin_type == "codec" ? "" : "\n")
       else

--- a/logstash-core/lib/logstash/config/config_ast.rb
+++ b/logstash-core/lib/logstash/config/config_ast.rb
@@ -213,6 +213,8 @@ module LogStash; module Config; module AST
 
   class Plugins < Node; end
   class Plugin < Node
+    attr_accessor :source_file, :source_line
+
     def plugin_type
       if recursive_select_parent(Plugin).any?
         return "codec"
@@ -233,12 +235,12 @@ module LogStash; module Config; module AST
       # If any parent is a Plugin, this must be a codec.
 
       if attributes.elements.nil?
-        return "plugin(#{plugin_type.inspect}, #{plugin_name.inspect}, #{source_meta.line}, #{source_meta.column})" << (plugin_type == "codec" ? "" : "\n")
+        return "plugin(#{plugin_type.inspect}, #{plugin_name.inspect}, #{source_meta.line}, #{source_meta.column}, #{source_file.inspect}, #{source_line.inspect})" << (plugin_type == "codec" ? "" : "\n")
       else
         settings = attributes.recursive_select(Attribute).collect(&:compile).reject(&:empty?)
 
         attributes_code = "LogStash::Util.hash_merge_many(#{settings.map { |c| "{ #{c} }" }.join(", ")})"
-        return "plugin(#{plugin_type.inspect}, #{plugin_name.inspect}, #{source_meta.line}, #{source_meta.column}, #{attributes_code})" << (plugin_type == "codec" ? "" : "\n")
+        return "plugin(#{plugin_type.inspect}, #{plugin_name.inspect}, #{source_meta.line}, #{source_meta.column}, #{source_file.inspect}, #{source_line.inspect}, #{attributes_code})" << (plugin_type == "codec" ? "" : "\n")
       end
     end
 
@@ -255,7 +257,7 @@ module LogStash; module Config; module AST
       when "codec"
         settings = attributes.recursive_select(Attribute).collect(&:compile).reject(&:empty?)
         attributes_code = "LogStash::Util.hash_merge_many(#{settings.map { |c| "{ #{c} }" }.join(", ")})"
-        return "plugin(#{plugin_type.inspect}, #{plugin_name.inspect}, #{source_meta.line}, #{source_meta.column}, #{attributes_code})"
+        return "plugin(#{plugin_type.inspect}, #{plugin_name.inspect}, #{source_meta.line}, #{source_meta.column}, #{source_file.inspect}, #{source_line.inspect}, #{attributes_code})"
       end
     end
 

--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -46,7 +46,7 @@ module LogStash::Config::Mixin
     base.extend(LogStash::Config::Mixin::DSL)
   end
 
-  def config_init(parent_code_reference, params)
+  def config_init(params)
     # Validation will modify the values inside params if necessary.
     # For example: converting a string to a number, etc.
 
@@ -83,14 +83,14 @@ module LogStash::Config::Mixin
       params[name.to_s] = deep_replace(value)
     end
 
-    if !self.class.validate(parent_code_reference, params)
+    if !self.class.validate(params)
       raise LogStash::ConfigurationError,
         I18n.t("logstash.runner.configuration.invalid_plugin_settings")
     end
 
     # now that we know the parameters are valid, we can obfuscate the original copy
     # of the parameters before storing them as an instance variable
-    self.class.secure_params!(parent_code_reference, original_params)
+    self.class.secure_params!(original_params)
     @original_params = original_params
 
     # warn about deprecated variable use
@@ -223,7 +223,7 @@ module LogStash::Config::Mixin
       @@version_notice_given = false
     end # def inherited
 
-    def validate(parent_code_reference, params)
+    def validate(params)
       @plugin_name = config_name
       @plugin_type = ancestors.find { |a| a.name =~ /::Base$/ }.config_name
       is_valid = true
@@ -232,7 +232,7 @@ module LogStash::Config::Mixin
 
       is_valid &&= validate_check_invalid_parameter_names(params)
       is_valid &&= validate_check_required_parameter_names(params)
-      is_valid &&= validate_check_parameter_values(parent_code_reference, params)
+      is_valid &&= validate_check_parameter_values(params)
 
       return is_valid
     end # def validate
@@ -318,7 +318,7 @@ module LogStash::Config::Mixin
       return is_valid
     end
 
-    def process_parameter_value(parent_code_reference, value, config_settings)
+    def process_parameter_value(value, config_settings)
       config_val = config_settings[:validate]
 
       if config_settings[:list]
@@ -326,17 +326,17 @@ module LogStash::Config::Mixin
         # Empty lists are converted to nils
         return true, [] if value.empty?
 
-        validated_items = value.map {|v| validate_value(parent_code_reference, v, config_val)}
+        validated_items = value.map {|v| validate_value(v, config_val)}
         is_valid = validated_items.all? {|sr| sr[0] }
         processed_value = validated_items.map {|sr| sr[1]}
       else
-        is_valid, processed_value = validate_value(parent_code_reference, value, config_val)
+        is_valid, processed_value = validate_value(value, config_val)
       end
 
       return [is_valid, processed_value]
     end
 
-    def validate_check_parameter_values(parent_code_reference, params)
+    def validate_check_parameter_values(params)
       # Filter out parameters that match regexp keys.
       # These are defined in plugins like this:
       #   config /foo.*/ => ...
@@ -349,7 +349,7 @@ module LogStash::Config::Mixin
 
           config_settings = @config[config_key]
 
-          is_valid, processed_value = process_parameter_value(parent_code_reference, value, config_settings)
+          is_valid, processed_value = process_parameter_value(value, config_settings)
 
           if is_valid
             # Accept coerced value if valid
@@ -382,7 +382,7 @@ module LogStash::Config::Mixin
       return nil
     end
 
-    def validate_value(parent_code_reference, value, validator)
+    def validate_value(value, validator)
       # Validator comes from the 'config' pieces of plugins.
       # They look like this
       #   config :mykey => lambda do |value| ... end
@@ -413,7 +413,7 @@ module LogStash::Config::Mixin
             if value.first.is_a?(String)
               parent_plugin_name = self.config_name
               codec = LogStash::Plugin.lookup("codec", value.first).new
-              value = LogStash::Codecs::Delegator.new(codec, parent_plugin_name, parent_code_reference)
+              value = LogStash::Codecs::Delegator.new(codec, parent_plugin_name)
               return true, value
             else
               value = value.first
@@ -547,10 +547,10 @@ module LogStash::Config::Mixin
       return true, result
     end # def validate_value
 
-    def secure_params!(code_reference, params)
+    def secure_params!(params)
       params.each do |key, value|
         if [:uri, :password].include? @config[key][:validate]
-          is_valid, processed_value = process_parameter_value(code_reference, value, @config[key])
+          is_valid, processed_value = process_parameter_value(value, @config[key])
           params[key] = processed_value
         end
       end

--- a/logstash-core/lib/logstash/config/pipeline_config.rb
+++ b/logstash-core/lib/logstash/config/pipeline_config.rb
@@ -44,5 +44,19 @@ module LogStash module Config
       logger.debug("Merged config")
       logger.debug("\n\n#{config_string}")
     end
+
+    def lookup_source_and_line(merged_config_line)
+      remaining_lines = merged_config_line
+      matching_part = nil
+      for source_with_meta in @config_parts do
+        if remaining_lines < source_with_meta.lines_count
+          matching_part = source_with_meta
+          break
+        end
+        remaining_lines = remaining_lines - source_with_meta.lines_count
+      end
+      raise IndexError if matching_part == nil && remaining_lines > 0
+      return matching_part.id, remaining_lines
+    end
   end
 end end

--- a/logstash-core/lib/logstash/config/pipeline_config.rb
+++ b/logstash-core/lib/logstash/config/pipeline_config.rb
@@ -49,7 +49,7 @@ module LogStash module Config
       remaining_lines = merged_config_line
       matching_part = nil
       @config_parts.each do |source_with_meta|
-        if remaining_lines < source_with_meta.lines_count
+        if remaining_lines <= source_with_meta.lines_count
           matching_part = source_with_meta
           break
         end

--- a/logstash-core/lib/logstash/config/pipeline_config.rb
+++ b/logstash-core/lib/logstash/config/pipeline_config.rb
@@ -48,14 +48,14 @@ module LogStash module Config
     def lookup_source_and_line(merged_config_line)
       remaining_lines = merged_config_line
       matching_part = nil
-      for source_with_meta in @config_parts do
+      @config_parts.each do |source_with_meta|
         if remaining_lines < source_with_meta.lines_count
           matching_part = source_with_meta
           break
         end
         remaining_lines = remaining_lines - source_with_meta.lines_count
       end
-      raise IndexError if matching_part == nil && remaining_lines > 0
+      raise IndexError if matching_part.nil? && remaining_lines > 0
       return matching_part.id, remaining_lines
     end
   end

--- a/logstash-core/lib/logstash/filters/base.rb
+++ b/logstash-core/lib/logstash/filters/base.rb
@@ -123,7 +123,7 @@ class LogStash::Filters::Base < LogStash::Plugin
   public
   def initialize(params)
     super
-    config_init(nil, @params)
+    config_init(@params)
     @threadsafe = true
   end # def initialize
 

--- a/logstash-core/lib/logstash/filters/base.rb
+++ b/logstash-core/lib/logstash/filters/base.rb
@@ -121,11 +121,10 @@ class LogStash::Filters::Base < LogStash::Plugin
   end
 
   public
-  def initialize(code_reference, params)
-    super(params)
+  def initialize(params)
+    super
     config_init(nil, @params)
     @threadsafe = true
-    @code_reference = code_reference
   end # def initialize
 
   public
@@ -174,11 +173,6 @@ class LogStash::Filters::Base < LogStash::Plugin
   public
   def threadsafe?
     @threadsafe
-  end
-
-  public
-  def code_reference
-    @code_reference
   end
 
   # a filter instance should call filter_matched from filter if the event

--- a/logstash-core/lib/logstash/filters/base.rb
+++ b/logstash-core/lib/logstash/filters/base.rb
@@ -121,10 +121,11 @@ class LogStash::Filters::Base < LogStash::Plugin
   end
 
   public
-  def initialize(params)
-    super
-    config_init(@params)
+  def initialize(code_reference, params)
+    super(params)
+    config_init(nil, @params)
     @threadsafe = true
+    @code_reference = code_reference
   end # def initialize
 
   public
@@ -173,6 +174,11 @@ class LogStash::Filters::Base < LogStash::Plugin
   public
   def threadsafe?
     @threadsafe
+  end
+
+  public
+  def code_reference
+    @code_reference
   end
 
   # a filter instance should call filter_matched from filter if the event

--- a/logstash-core/lib/logstash/inputs/base.rb
+++ b/logstash-core/lib/logstash/inputs/base.rb
@@ -53,12 +53,13 @@ class LogStash::Inputs::Base < LogStash::Plugin
   end
 
   public
-  def initialize(params={})
-    super
+  def initialize(code_reference, params={})
+    super(params)
     @threadable = false
     @stop_called = Concurrent::AtomicBoolean.new(false)
-    config_init(@params)
+    config_init(code_reference, @params)
     @tags ||= []
+    @code_reference = code_reference
   end # def initialize
 
   public
@@ -91,6 +92,11 @@ class LogStash::Inputs::Base < LogStash::Plugin
   public
   def stop?
     @stop_called.value
+  end
+
+  public
+  def code_reference
+    @code_reference
   end
 
   def clone

--- a/logstash-core/lib/logstash/inputs/base.rb
+++ b/logstash-core/lib/logstash/inputs/base.rb
@@ -99,6 +99,10 @@ class LogStash::Inputs::Base < LogStash::Plugin
     cloned
   end
 
+  def codec_attribute
+    @codec
+  end
+
   def codec
     params["codec"]
   end

--- a/logstash-core/lib/logstash/inputs/base.rb
+++ b/logstash-core/lib/logstash/inputs/base.rb
@@ -59,7 +59,6 @@ class LogStash::Inputs::Base < LogStash::Plugin
     @stop_called = Concurrent::AtomicBoolean.new(false)
     config_init(code_reference, @params)
     @tags ||= []
-    @code_reference = code_reference
   end # def initialize
 
   public
@@ -92,11 +91,6 @@ class LogStash::Inputs::Base < LogStash::Plugin
   public
   def stop?
     @stop_called.value
-  end
-
-  public
-  def code_reference
-    @code_reference
   end
 
   def clone

--- a/logstash-core/lib/logstash/inputs/base.rb
+++ b/logstash-core/lib/logstash/inputs/base.rb
@@ -53,11 +53,11 @@ class LogStash::Inputs::Base < LogStash::Plugin
   end
 
   public
-  def initialize(code_reference, params={})
-    super(params)
+  def initialize(params={})
+    super
     @threadable = false
     @stop_called = Concurrent::AtomicBoolean.new(false)
-    config_init(code_reference, @params)
+    config_init(@params)
     @tags ||= []
   end # def initialize
 
@@ -97,6 +97,10 @@ class LogStash::Inputs::Base < LogStash::Plugin
     cloned = super
     cloned.codec = @codec.clone if @codec
     cloned
+  end
+
+  def codec
+    params["codec"]
   end
 
   def metric=(metric)

--- a/logstash-core/lib/logstash/inputs/base.rb
+++ b/logstash-core/lib/logstash/inputs/base.rb
@@ -99,6 +99,7 @@ class LogStash::Inputs::Base < LogStash::Plugin
     cloned
   end
 
+  #used only in tests
   def codec_attribute
     @codec
   end

--- a/logstash-core/lib/logstash/outputs/base.rb
+++ b/logstash-core/lib/logstash/outputs/base.rb
@@ -55,9 +55,10 @@ class LogStash::Outputs::Base < LogStash::Plugin
   end
 
   public
-  def initialize(params={})
-    super
-    config_init(@params)
+  def initialize(code_reference, params={})
+    super(params)
+    @code_reference = code_reference
+    config_init(code_reference, @params)
 
     if self.workers != 1
       raise LogStash::ConfigurationError, "You are using a plugin that doesn't support workers but have set the workers value explicitly! This plugin uses the #{concurrency} and doesn't need this option"
@@ -88,6 +89,11 @@ class LogStash::Outputs::Base < LogStash::Plugin
     else
       events.each {|event| receive(event) }
     end
+  end
+
+  public
+  def code_reference
+    @code_reference
   end
 
   def workers_not_supported(message=nil)

--- a/logstash-core/lib/logstash/outputs/base.rb
+++ b/logstash-core/lib/logstash/outputs/base.rb
@@ -57,7 +57,6 @@ class LogStash::Outputs::Base < LogStash::Plugin
   public
   def initialize(code_reference, params={})
     super(params)
-    @code_reference = code_reference
     config_init(code_reference, @params)
 
     if self.workers != 1
@@ -89,11 +88,6 @@ class LogStash::Outputs::Base < LogStash::Plugin
     else
       events.each {|event| receive(event) }
     end
-  end
-
-  public
-  def code_reference
-    @code_reference
   end
 
   def workers_not_supported(message=nil)

--- a/logstash-core/lib/logstash/outputs/base.rb
+++ b/logstash-core/lib/logstash/outputs/base.rb
@@ -55,9 +55,9 @@ class LogStash::Outputs::Base < LogStash::Plugin
   end
 
   public
-  def initialize(code_reference, params={})
-    super(params)
-    config_init(code_reference, @params)
+  def initialize(params={})
+    super
+    config_init(@params)
 
     if self.workers != 1
       raise LogStash::ConfigurationError, "You are using a plugin that doesn't support workers but have set the workers value explicitly! This plugin uses the #{concurrency} and doesn't need this option"

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -72,7 +72,7 @@ module LogStash; class BasePipeline < AbstractPipeline
   private
 
   def added_source_line_column(pipeline_config, plugins)
-    for plugin in plugins do
+    plugins.each do |plugin|
       remapped_line = pipeline_config.lookup_source_and_line(plugin.line_and_column[0])
       plugin.source_file = remapped_line[0]
       plugin.source_line = remapped_line[1]

--- a/logstash-core/spec/logstash/codecs/delegator_spec.rb
+++ b/logstash-core/spec/logstash/codecs/delegator_spec.rb
@@ -23,7 +23,7 @@ describe LogStash::Codecs::Delegator do
   let(:codec) { LogStash::Codecs::MockCodec.new }
 
   subject do
-    delegator = described_class.new(codec)
+    delegator = described_class.new(codec, "MockCodec")
     delegator.metric = metric.namespace([:stats, :pipelines, :main, :plugins, :codecs, :my_id])
     delegator
   end

--- a/logstash-core/spec/logstash/compiler/compiler_spec.rb
+++ b/logstash-core/spec/logstash/compiler/compiler_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 require "logstash/compiler"
 require "support/helpers"
+require "logstash/config/pipeline_config"
 java_import Java::OrgLogstashConfigIr::DSL
 
 describe LogStash::Compiler do
@@ -50,8 +51,9 @@ describe LogStash::Compiler do
           org.logstash.common.SourceWithMetadata.new("#{source_protocol}_#{idx}", "#{source_id}_#{idx}", 0, 0, source)
         end
       end
+      let(:pipeline_config) {LogStash::Config::PipelineConfig.new LogStash::Config::Source::Local, "test_pipeline", sources_with_metadata, LogStash::SETTINGS}
 
-      subject(:pipeline) { described_class.compile_sources(sources_with_metadata, false) }
+      subject(:pipeline) { described_class.compile_sources(pipeline_config, false) }
 
       it "should generate a hash" do
         expect(pipeline.unique_hash).to be_a(String)
@@ -104,7 +106,8 @@ describe LogStash::Compiler do
   describe "compiling imperative" do
     let(:source_id) { "fake_sourcefile" }
     let(:source_with_metadata) { org.logstash.common.SourceWithMetadata.new(source_protocol, source_id, 0, 0, source) }
-    subject(:compiled) { described_class.compile_imperative(source_with_metadata, settings.get_value("config.support_escapes")) }
+    let(:pipeline_config) {LogStash::Config::PipelineConfig.new LogStash::Config::Source::Local, "test_pipeline", [source_with_metadata], LogStash::SETTINGS}
+    subject(:compiled) { described_class.compile_imperative(pipeline_config, source_with_metadata, settings.get_value("config.support_escapes")) }
 
     context "when config.support_escapes" do
       let(:parser) { LogStashCompilerLSCLGrammarParser.new }

--- a/logstash-core/spec/logstash/compiler/compiler_spec.rb
+++ b/logstash-core/spec/logstash/compiler/compiler_spec.rb
@@ -66,20 +66,6 @@ describe LogStash::Compiler do
       it "should provide the original source" do
         expect(pipeline.original_source).to eq(sources.join("\n"))
       end
-
-      describe "applying protocol and id metadata" do
-        it "should apply the correct source metadata to all components" do
-          # TODO: seems to be a jruby regression we cannot currently call each on a stream
-          pipeline.get_plugin_vertices.each do |pv|
-            name_idx = pv.plugin_definition.name.split("_").last
-            source_protocol_idx = pv.source_with_metadata.protocol.split("_").last
-            source_id_idx = pv.source_with_metadata.id.split("_").last
-
-            expect(name_idx).to eq(source_protocol_idx)
-            expect(name_idx).to eq(source_id_idx)
-          end
-        end
-      end
     end
 
     describe "complex configs" do

--- a/logstash-core/spec/logstash/config/pipeline_config_spec.rb
+++ b/logstash-core/spec/logstash/config/pipeline_config_spec.rb
@@ -72,4 +72,50 @@ describe LogStash::Config::PipelineConfig do
       end
     end
   end
+
+  describe "source and line remapping" do
+    context "when pipeline is constructed from single file" do
+      let (:pipeline_conf_string) { 'input {
+                                       generator1
+                                     }' }
+      subject { described_class.new(source, pipeline_id, [org.logstash.common.SourceWithMetadata.new("file", "/tmp/1", 0, 0, pipeline_conf_string)], settings) }
+
+      it "return the same line of the queried" do
+        expect(subject.lookup_source_and_line(0)[1]).to eq(0)
+        expect(subject.lookup_source_and_line(2)[1]).to eq(2)
+      end
+
+      it "throw exception if line is out of bound" do
+        expect { subject.lookup_source_and_line(100) }.to raise_exception(IndexError)
+      end
+    end
+
+    context "when pipeline is constructed from multiple files" do
+      let (:pipeline_conf_string_part1) { 'input {
+                                             generator1
+                                           }' }
+      let (:pipeline_conf_string_part2) { 'output {
+                                             stdout
+                                           }' }
+      let(:merged_config_parts) do
+        [
+          org.logstash.common.SourceWithMetadata.new("file", "/tmp/input", 0, 0, pipeline_conf_string_part1),
+          org.logstash.common.SourceWithMetadata.new("file", "/tmp/output", 0, 0, pipeline_conf_string_part2)
+        ]
+      end
+      subject { described_class.new(source, pipeline_id, merged_config_parts, settings) }
+
+      it "return the line of first segment" do
+        expect(subject.lookup_source_and_line(2)).to eq(["/tmp/input", 2])
+      end
+
+      it "return the line of second segment" do
+        expect(subject.lookup_source_and_line(3)).to eq(["/tmp/output", 0])
+      end
+
+      it "throw exception if line is out of bound" do
+        expect { subject.lookup_source_and_line(100) }.to raise_exception(IndexError)
+      end
+    end
+  end
 end

--- a/logstash-core/spec/logstash/config/pipeline_config_spec.rb
+++ b/logstash-core/spec/logstash/config/pipeline_config_spec.rb
@@ -74,6 +74,14 @@ describe LogStash::Config::PipelineConfig do
   end
 
   describe "source and line remapping" do
+    context "when pipeline is constructed from single file single line" do
+      let (:pipeline_conf_string) { 'input { generator1 }' }
+      subject { described_class.new(source, pipeline_id, [org.logstash.common.SourceWithMetadata.new("file", "/tmp/1", 0, 0, pipeline_conf_string)], settings) }
+      it "return the same line of the queried" do
+        expect(subject.lookup_source_and_line(1)[1]).to eq(1)
+      end
+    end
+
     context "when pipeline is constructed from single file" do
       let (:pipeline_conf_string) { 'input {
                                        generator1
@@ -81,7 +89,7 @@ describe LogStash::Config::PipelineConfig do
       subject { described_class.new(source, pipeline_id, [org.logstash.common.SourceWithMetadata.new("file", "/tmp/1", 0, 0, pipeline_conf_string)], settings) }
 
       it "return the same line of the queried" do
-        expect(subject.lookup_source_and_line(0)[1]).to eq(0)
+        expect(subject.lookup_source_and_line(1)[1]).to eq(1)
         expect(subject.lookup_source_and_line(2)[1]).to eq(2)
       end
 
@@ -110,7 +118,7 @@ describe LogStash::Config::PipelineConfig do
       end
 
       it "return the line of second segment" do
-        expect(subject.lookup_source_and_line(3)).to eq(["/tmp/output", 0])
+        expect(subject.lookup_source_and_line(4)).to eq(["/tmp/output", 1])
       end
 
       it "throw exception if line is out of bound" do

--- a/logstash-core/spec/logstash/filter_delegator_spec.rb
+++ b/logstash-core/spec/logstash/filter_delegator_spec.rb
@@ -11,7 +11,7 @@ describe LogStash::FilterDelegator do
 
   let(:filter_id) { "my-filter" }
   let(:config) do
-    { "host" => "127.0.0.1", "id" => filter_id }
+    { "host" => "127.0.0.1", "id" => filter_id, "config-ref" => "S: <filter_delegator_spec.rb> L: 14" }
   end
   let(:collector) {LogStash::Instrument::Collector.new}
   let(:metric) { LogStash::Instrument::Metric.new(collector).namespace(:null) }

--- a/logstash-core/spec/logstash/inputs/base_spec.rb
+++ b/logstash-core/spec/logstash/inputs/base_spec.rb
@@ -95,7 +95,7 @@ describe "LogStash::Inputs::Base#decorate" do
     end
 
     it "should clone the codec when cloned" do
-      expect(input.codec).not_to eq(cloned.codec)
+      expect(input.codec_attribute).not_to eq(cloned.codec_attribute)
     end
 
     it "should preserve codec params" do

--- a/logstash-core/spec/logstash/java_filter_delegator_spec.rb
+++ b/logstash-core/spec/logstash/java_filter_delegator_spec.rb
@@ -17,7 +17,7 @@ describe LogStash::FilterDelegator do
 
   let(:filter_id) { "my_filter" }
   let(:config) do
-    { "host" => "127.0.0.1", "id" => filter_id }
+    { "host" => "127.0.0.1", "id" => filter_id, "config-ref" => "S:<test source>, L: 1"}
   end
   let(:metric) {
     LogStash::Instrument::NamespacedMetric.new(

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -66,7 +66,7 @@ class DummyCodec < LogStash::Codecs::Base
     self
   end
 
-  def parent_code_reference=(code_ref)
+  def parent_config_reference=(code_ref)
   end
 end
 

--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -61,6 +61,13 @@ class DummyCodec < LogStash::Codecs::Base
 
   def close
   end
+
+  def codec
+    self
+  end
+
+  def parent_code_reference=(code_ref)
+  end
 end
 
 class DummyOutputMore < ::LogStash::Outputs::DummyOutput

--- a/logstash-core/src/main/java/org/logstash/common/SourceWithMetadata.java
+++ b/logstash-core/src/main/java/org/logstash/common/SourceWithMetadata.java
@@ -1,5 +1,6 @@
 package org.logstash.common;
 
+import org.jruby.anno.JRubyMethod;
 import org.logstash.config.ir.HashableWithSource;
 
 import java.util.Arrays;
@@ -37,6 +38,11 @@ public class SourceWithMetadata implements HashableWithSource {
 
     public String getText() {
         return text;
+    }
+
+    @JRubyMethod(name = "lines_count")
+    public int getLinesCount() {
+        return text.split("\\n").length;
     }
 
     private static final Pattern emptyString = Pattern.compile("^\\s*$");

--- a/logstash-core/src/main/java/org/logstash/common/SourceWithMetadata.java
+++ b/logstash-core/src/main/java/org/logstash/common/SourceWithMetadata.java
@@ -1,6 +1,5 @@
 package org.logstash.common;
 
-import org.jruby.anno.JRubyMethod;
 import org.logstash.config.ir.HashableWithSource;
 
 import java.util.Arrays;
@@ -40,7 +39,6 @@ public class SourceWithMetadata implements HashableWithSource {
         return text;
     }
 
-    @JRubyMethod(name = "lines_count")
     public int getLinesCount() {
         return text.split("\\n").length;
     }

--- a/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
@@ -194,9 +194,13 @@ public final class CompiledPipeline {
             final String key = entry.getKey();
             final Object toput;
             if (value instanceof PluginStatement) {
-                final PluginDefinition codec = ((PluginStatement) value).getPluginDefinition();
+                PluginStatement pluginStatement = (PluginStatement) value;
+                final String sourceFile = pluginStatement.getSourceFile();
+                final int sourceLine = pluginStatement.getSourceLine();
+                final PluginDefinition codec = pluginStatement.getPluginDefinition();
                 toput = pluginFactory.buildCodec(
                     RubyUtil.RUBY.newString(codec.getName()),
+                    sourceFile, sourceLine,
                     Rubyfier.deep(RubyUtil.RUBY, codec.getArguments()),
                     codec.getArguments()
                 );
@@ -222,10 +226,14 @@ public final class CompiledPipeline {
             final String key = entry.getKey();
             final IRubyObject toput;
             if (value instanceof PluginStatement) {
-                final PluginDefinition codec = ((PluginStatement) value).getPluginDefinition();
+                PluginStatement pluginStatement = (PluginStatement) value;
+                final String sourceFile = pluginStatement.getSourceFile();
+                final int sourceLine = pluginStatement.getSourceLine();
+                final PluginDefinition codec = pluginStatement.getPluginDefinition();
                 Map<String, Object> codecArgs = expandConfigVariables(cve, codec.getArguments());
                 toput = pluginFactory.buildCodec(
                         RubyUtil.RUBY.newString(codec.getName()),
+                        sourceFile, sourceLine,
                         Rubyfier.deep(RubyUtil.RUBY, codec.getArguments()),
                         codecArgs
                 );

--- a/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
@@ -131,9 +131,11 @@ public final class CompiledPipeline {
         outs.forEach(v -> {
             final PluginDefinition def = v.getPluginDefinition();
             final SourceWithMetadata source = v.getSourceWithMetadata();
+            final String sourceFile = v.getSourceFile();
+            final int sourceLine = v.getSourceLine();
             res.put(v.getId(), pluginFactory.buildOutput(
                     RubyUtil.RUBY.newString(def.getName()), RubyUtil.RUBY.newFixnum(source.getLine()),
-                    RubyUtil.RUBY.newFixnum(source.getColumn()), convertArgs(def), convertJavaArgs(def, cve)
+                    RubyUtil.RUBY.newFixnum(source.getColumn()), sourceFile, sourceLine, convertArgs(def), convertJavaArgs(def, cve)
             ));
         });
         return res;
@@ -149,9 +151,11 @@ public final class CompiledPipeline {
         for (final PluginVertex vertex : filterPlugins) {
             final PluginDefinition def = vertex.getPluginDefinition();
             final SourceWithMetadata source = vertex.getSourceWithMetadata();
+            final String sourceFile = vertex.getSourceFile();
+            final int sourceLine = vertex.getSourceLine();
             res.put(vertex.getId(), pluginFactory.buildFilter(
                     RubyUtil.RUBY.newString(def.getName()), RubyUtil.RUBY.newFixnum(source.getLine()),
-                    RubyUtil.RUBY.newFixnum(source.getColumn()), convertArgs(def), convertJavaArgs(def, cve)
+                    RubyUtil.RUBY.newFixnum(source.getColumn()), sourceFile, sourceLine, convertArgs(def), convertJavaArgs(def, cve)
             ));
         }
         return res;
@@ -166,9 +170,11 @@ public final class CompiledPipeline {
         vertices.forEach(v -> {
             final PluginDefinition def = v.getPluginDefinition();
             final SourceWithMetadata source = v.getSourceWithMetadata();
+            final String sourceFile = v.getSourceFile();
+            final int sourceLine = v.getSourceLine();
             IRubyObject o = pluginFactory.buildInput(
                     RubyUtil.RUBY.newString(def.getName()), RubyUtil.RUBY.newFixnum(source.getLine()),
-                    RubyUtil.RUBY.newFixnum(source.getColumn()), convertArgs(def), convertJavaArgs(def, cve));
+                    RubyUtil.RUBY.newFixnum(source.getColumn()), sourceFile, sourceLine, convertArgs(def), convertJavaArgs(def, cve));
             nodes.add(o);
         });
         return nodes;

--- a/logstash-core/src/main/java/org/logstash/config/ir/ConfigCompiler.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/ConfigCompiler.java
@@ -17,27 +17,18 @@ public final class ConfigCompiler {
     }
 
     /**
-     * @param config Logstash Config String
+     * @param pipelineConfig Logstash single pipeline's Config
      * @param supportEscapes The value of the setting {@code config.support_escapes}
      * @return Compiled {@link PipelineIR}
-     * @throws IncompleteSourceWithMetadataException On Broken Configuration
      */
-    public static PipelineIR configToPipelineIR(final String config, final boolean supportEscapes)
-        throws IncompleteSourceWithMetadataException {
+    public static PipelineIR configToPipelineIR(final IRubyObject pipelineConfig, final boolean supportEscapes) {
         final IRubyObject compiler = RubyUtil.RUBY.executeScript(
             "require 'logstash/compiler'\nLogStash::Compiler",
             ""
         );
         final IRubyObject code =
             compiler.callMethod(RubyUtil.RUBY.getCurrentContext(), "compile_sources",
-                new IRubyObject[]{
-                    RubyUtil.RUBY.newArray(
-                        JavaUtil.convertJavaToRuby(
-                            RubyUtil.RUBY,
-                            new SourceWithMetadata("str", "pipeline", 0, 0, config)
-                        )
-                    ),
-                    RubyUtil.RUBY.newBoolean(supportEscapes)
+                new IRubyObject[]{pipelineConfig, RubyUtil.RUBY.newBoolean(supportEscapes)
                 }
             );
         return code.toJava(PipelineIR.class);

--- a/logstash-core/src/main/java/org/logstash/config/ir/ConfigSourceSegment.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/ConfigSourceSegment.java
@@ -1,0 +1,36 @@
+package org.logstash.config.ir;
+
+public final class ConfigSourceSegment {
+
+    private final String source;
+    private final int offset;
+    private final int length;
+
+    public ConfigSourceSegment(String source, int offset, int length) {
+        this.source = source;
+        this.offset = offset;
+        this.length = length;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public int getLength() {
+        return length;
+    }
+
+    public boolean contains(int lineNumber) {
+        int rebased_line_number = lineNumber - this.offset;
+        return 1 <= rebased_line_number && rebased_line_number <= this.length;
+    }
+
+    public int rebase(int lineNumber) {
+        return lineNumber - this.offset;
+    }
+
+    @Override
+    public String toString() {
+        return "ConfigSourceSegment{source='" + source + "', offset=" + offset + ", length=" + length + '}';
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/config/ir/DSL.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/DSL.java
@@ -5,6 +5,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import org.jruby.RubyInteger;
+import org.jruby.RubyString;
 import org.logstash.common.IncompleteSourceWithMetadataException;
 import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.expression.BooleanExpression;
@@ -228,6 +230,11 @@ public class DSL {
             throw new RuntimeException("Noop could not instantiate metadata, this should never happen");
         }
         return new NoopStatement(null);
+    }
+
+    public static PluginStatement iPlugin(SourceWithMetadata meta, PluginDefinition.Type pluginType, String pluginName,
+                                          RubyString sourceFile, RubyInteger sourceLine, Map<String, Object> pluginArguments) {
+        return new PluginStatement(meta, new PluginDefinition(pluginType, pluginName, pluginArguments), sourceFile, sourceLine);
     }
 
     public static PluginStatement iPlugin(SourceWithMetadata meta, PluginDefinition.Type pluginType, String pluginName, Map<String, Object> pluginArguments) {

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java
@@ -39,10 +39,6 @@ public abstract class AbstractFilterDelegatorExt extends RubyObject {
         super(runtime, metaClass);
     }
 
-    protected void initMetrics(final String id, final AbstractNamespacedMetricExt namespacedMetric) {
-        initMetrics(id, namespacedMetric, null);
-    }
-
     protected void initMetrics(final String id, final AbstractNamespacedMetricExt namespacedMetric, String codeRef) {
         final ThreadContext context = RubyUtil.RUBY.getCurrentContext();
         this.id = RubyString.newString(context.runtime, id);

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java
@@ -40,6 +40,10 @@ public abstract class AbstractFilterDelegatorExt extends RubyObject {
     }
 
     protected void initMetrics(final String id, final AbstractNamespacedMetricExt namespacedMetric) {
+        initMetrics(id, namespacedMetric, null);
+    }
+
+    protected void initMetrics(final String id, final AbstractNamespacedMetricExt namespacedMetric, String codeRef) {
         final ThreadContext context = RubyUtil.RUBY.getCurrentContext();
         this.id = RubyString.newString(context.runtime, id);
         synchronized(namespacedMetric.getMetric()) {
@@ -48,6 +52,9 @@ public abstract class AbstractFilterDelegatorExt extends RubyObject {
             eventMetricIn = LongCounter.fromRubyBase(metricEvents, MetricKeys.IN_KEY);
             eventMetricTime = LongCounter.fromRubyBase(metricEvents, MetricKeys.DURATION_IN_MILLIS_KEY);
             namespacedMetric.gauge(context, MetricKeys.NAME_KEY, configName(context));
+            if (codeRef != null) {
+                namespacedMetric.gauge(context, MetricKeys.CONFIG_REF_KEY, RubyUtil.RUBY.newString(codeRef));
+            }
         }
     }
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java
@@ -104,7 +104,7 @@ public abstract class AbstractOutputDelegatorExt extends RubyObject {
         return this;
     }
 
-    protected void initMetrics(final String id, final AbstractMetricExt metric) {
+    protected void initMetrics(final String id, final AbstractMetricExt metric, final String codeRef) {
         this.metric = metric;
         final ThreadContext context = RubyUtil.RUBY.getCurrentContext();
         this.id = RubyString.newString(context.runtime, id);
@@ -112,6 +112,9 @@ public abstract class AbstractOutputDelegatorExt extends RubyObject {
             namespacedMetric = metric.namespace(context, context.runtime.newSymbol(id));
             metricEvents = namespacedMetric.namespace(context, MetricKeys.EVENTS_KEY);
             namespacedMetric.gauge(context, MetricKeys.NAME_KEY, configName(context));
+            if (codeRef != null) {
+                namespacedMetric.gauge(context, MetricKeys.CONFIG_REF_KEY, RubyUtil.RUBY.newString(codeRef));
+            }
             eventMetricOut = LongCounter.fromRubyBase(metricEvents, MetricKeys.OUT_KEY);
             eventMetricIn = LongCounter.fromRubyBase(metricEvents, MetricKeys.IN_KEY);
             eventMetricTime = LongCounter.fromRubyBase(metricEvents, MetricKeys.DURATION_IN_MILLIS_KEY);

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
@@ -32,13 +32,14 @@ public final class FilterDelegatorExt extends AbstractFilterDelegatorExt {
     private boolean flushes;
 
     @JRubyMethod(name="initialize")
-    public IRubyObject initialize(final ThreadContext context, final IRubyObject filter, final IRubyObject id) {
+    public IRubyObject initialize(final ThreadContext context, final IRubyObject filter, final IRubyObject id,
+                                  final RubyString configRef) {
         this.id = (RubyString) id;
         this.filter = filter;
         filterClass = filter.getSingletonClass().getRealClass();
         filterMethod = filterClass.searchMethod(FILTER_METHOD_NAME);
         final AbstractNamespacedMetricExt namespacedMetric = (AbstractNamespacedMetricExt) filter.callMethod(context, "metric");
-        initMetrics(this.id.asJavaString(), namespacedMetric);
+        initMetrics(this.id.asJavaString(), namespacedMetric, configRef.asJavaString());
         flushes = filter.respondsTo("flush");
         return this;
     }

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaCodecDelegator.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaCodecDelegator.java
@@ -41,13 +41,16 @@ public class JavaCodecDelegator implements Codec {
     protected final CounterMetric decodeMetricTime;
 
 
-    public JavaCodecDelegator(final Context context, final Codec codec) {
+    public JavaCodecDelegator(final Context context, final Codec codec, final String codeRef) {
         this.codec = codec;
 
         final NamespacedMetric metric = context.getMetric(codec);
 
         synchronized(metric.root()) {
             metric.gauge(MetricKeys.NAME_KEY.asJavaString(), codec.getName());
+            if (codeRef != null) {
+                metric.gauge(MetricKeys.CONFIG_REF_KEY.asJavaString(), RubyUtil.RUBY.newString(codeRef));
+            }
 
             final NamespacedMetric encodeMetric = metric.namespace(ENCODE_KEY);
             encodeMetricIn = encodeMetric.counter(IN_KEY);

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaFilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaFilterDelegatorExt.java
@@ -42,13 +42,14 @@ public class JavaFilterDelegatorExt extends AbstractFilterDelegatorExt {
 
     public static JavaFilterDelegatorExt create(final String configName, final String id,
                                                 final AbstractNamespacedMetricExt metric,
-                                                final Filter filter, final Map<String, Object> pluginArgs) {
+                                                final Filter filter, final Map<String, Object> pluginArgs,
+                                                final String configReference) {
         final JavaFilterDelegatorExt instance =
                 new JavaFilterDelegatorExt(RubyUtil.RUBY, RubyUtil.JAVA_FILTER_DELEGATOR_CLASS);
         instance.configName = RubyUtil.RUBY.newString(configName);
         AbstractNamespacedMetricExt scopedMetric =
                 metric.namespace(RubyUtil.RUBY.getCurrentContext(), RubyUtil.RUBY.newSymbol(filter.getId()));
-        instance.initMetrics(id, scopedMetric);
+        instance.initMetrics(id, scopedMetric, configReference);
         instance.filter = filter;
         instance.initializeFilterMatchListener(pluginArgs);
         return instance;

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaInputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaInputDelegatorExt.java
@@ -38,11 +38,12 @@ public class JavaInputDelegatorExt extends RubyObject {
 
     public static JavaInputDelegatorExt create(final JavaBasePipelineExt pipeline,
                                                final AbstractNamespacedMetricExt metric, final Input input,
-                                               final Map<String, Object> pluginArgs) {
+                                               final Map<String, Object> pluginArgs, String configRef) {
         final JavaInputDelegatorExt instance =
                 new JavaInputDelegatorExt(RubyUtil.RUBY, RubyUtil.JAVA_INPUT_DELEGATOR_CLASS);
         AbstractNamespacedMetricExt scopedMetric = metric.namespace(RubyUtil.RUBY.getCurrentContext(), RubyUtil.RUBY.newSymbol(input.getId()));
         scopedMetric.gauge(RubyUtil.RUBY.getCurrentContext(), MetricKeys.NAME_KEY, RubyUtil.RUBY.newString(input.getName()));
+        scopedMetric.gauge(RubyUtil.RUBY.getCurrentContext(), MetricKeys.CONFIG_REF_KEY, RubyUtil.RUBY.newString(configRef));
         instance.setMetric(RubyUtil.RUBY.getCurrentContext(), scopedMetric);
         instance.input = input;
         instance.pipeline = pipeline;

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaOutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaOutputDelegatorExt.java
@@ -42,11 +42,11 @@ public final class JavaOutputDelegatorExt extends AbstractOutputDelegatorExt {
     public static JavaOutputDelegatorExt create(final String configName, final String id,
         final AbstractMetricExt metric,
         final Consumer<Collection<JrubyEventExtLibrary.RubyEvent>> outputFunction,
-        final Runnable closeAction, final Runnable registerAction) {
+        final Runnable closeAction, final Runnable registerAction, String configReference) {
         final JavaOutputDelegatorExt instance =
             new JavaOutputDelegatorExt(RubyUtil.RUBY, RubyUtil.JAVA_OUTPUT_DELEGATOR_CLASS);
         instance.configName = RubyUtil.RUBY.newString(configName);
-        instance.initMetrics(id, metric);
+        instance.initMetrics(id, metric, configReference);
         instance.outputFunction = outputFunction;
         instance.closeAction = closeAction;
         instance.registerAction = registerAction;
@@ -55,11 +55,11 @@ public final class JavaOutputDelegatorExt extends AbstractOutputDelegatorExt {
 
     public static JavaOutputDelegatorExt create(final String configName, final String id,
                                                 final AbstractMetricExt metric,
-                                                final Output output) {
+                                                final Output output, String configReference) {
         final JavaOutputDelegatorExt instance =
                 new JavaOutputDelegatorExt(RubyUtil.RUBY, RubyUtil.JAVA_OUTPUT_DELEGATOR_CLASS);
         instance.configName = RubyUtil.RUBY.newString(configName);
-        instance.initMetrics(id, metric);
+        instance.initMetrics(id, metric, configReference);
         instance.output = output;
         instance.outputFunction = instance::outputRubyEvents;
         instance.closeAction = instance::outputClose;

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputDelegatorExt.java
@@ -50,7 +50,7 @@ public final class OutputDelegatorExt extends AbstractOutputDelegatorExt {
         strategy = (OutputStrategyExt.AbstractOutputStrategyExt) strategyRegistry.classFor(
             context, concurrency(context)
         ).newInstance(
-            context, new IRubyObject[]{outputClass, namespacedMetric, executionContext, args},
+            context, new IRubyObject[]{outputClass, namespacedMetric, executionContext, RubyUtil.RUBY.newString(configRef), args},
             Block.NULL_BLOCK
         );
         return this;

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputDelegatorExt.java
@@ -50,7 +50,7 @@ public final class OutputDelegatorExt extends AbstractOutputDelegatorExt {
         strategy = (OutputStrategyExt.AbstractOutputStrategyExt) strategyRegistry.classFor(
             context, concurrency(context)
         ).newInstance(
-            context, new IRubyObject[]{outputClass, namespacedMetric, executionContext, RubyUtil.RUBY.newString(configRef), args},
+            context, new IRubyObject[]{outputClass, namespacedMetric, executionContext, args},
             Block.NULL_BLOCK
         );
         return this;

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
@@ -229,8 +229,11 @@ public final class OutputStrategyExt {
         public IRubyObject initialize(final ThreadContext context, final IRubyObject[] args) {
             final RubyClass outputClass = (RubyClass) args[0];
             // Calling "new" here manually to allow mocking the ctor in RSpec Tests
-            output = args[0].callMethod(context, "new", new IRubyObject[]{args[3], args[4]});
+            output = args[0].callMethod(context, "new", args[4]);
             initOutputCallsite(outputClass);
+            // WARNING: order is important since metric= create gauges with data assigned from parent_code_reference=
+            IRubyObject codec = output.callMethod(context, "codec");
+            codec.callMethod(context, "parent_code_reference=", args[3]);
             output.callMethod(context, "metric=", args[1]);
             output.callMethod(context, "execution_context=", args[2]);
             return this;

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
@@ -169,9 +169,9 @@ public final class OutputStrategyExt {
                 // Calling "new" here manually to allow mocking the ctor in RSpec Tests
                 final IRubyObject output = outputClass.callMethod(context, "new", pluginArgs);
                 initOutputCallsite(outputClass);
-                // WARNING: order is important since metric= create gauges with data assigned from parent_code_reference=
+                // WARNING: order is important since metric= create gauges with data assigned from parent_config_reference=
                 IRubyObject codec = output.callMethod(context, "codec");
-                codec.callMethod(context, "parent_code_reference=", args[3]);
+                codec.callMethod(context, "parent_config_reference=", args[3]);
                 output.callMethod(context, "metric=", args[1]);
                 output.callMethod(context, "execution_context=", args[2]);
                 workers.append(output);
@@ -234,9 +234,9 @@ public final class OutputStrategyExt {
             // Calling "new" here manually to allow mocking the ctor in RSpec Tests
             output = args[0].callMethod(context, "new", args[4]);
             initOutputCallsite(outputClass);
-            // WARNING: order is important since metric= create gauges with data assigned from parent_code_reference=
+            // WARNING: order is important since metric= create gauges with data assigned from parent_config_reference=
             IRubyObject codec = output.callMethod(context, "codec");
-            codec.callMethod(context, "parent_code_reference=", args[3]);
+            codec.callMethod(context, "parent_config_reference=", args[3]);
             output.callMethod(context, "metric=", args[1]);
             output.callMethod(context, "execution_context=", args[2]);
             return this;

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
@@ -154,9 +154,9 @@ public final class OutputStrategyExt {
             super(runtime, metaClass);
         }
 
-        @JRubyMethod(required = 4)
+        @JRubyMethod(required = 5)
         public IRubyObject initialize(final ThreadContext context, final IRubyObject[] args) {
-            final RubyHash pluginArgs = (RubyHash) args[3];
+            final RubyHash pluginArgs = (RubyHash) args[4];
             workerCount = pluginArgs.op_aref(context, context.runtime.newString("workers"));
             if (workerCount.isNil()) {
                 workerCount = RubyFixnum.one(context.runtime);
@@ -169,6 +169,9 @@ public final class OutputStrategyExt {
                 // Calling "new" here manually to allow mocking the ctor in RSpec Tests
                 final IRubyObject output = outputClass.callMethod(context, "new", pluginArgs);
                 initOutputCallsite(outputClass);
+                // WARNING: order is important since metric= create gauges with data assigned from parent_code_reference=
+                IRubyObject codec = output.callMethod(context, "codec");
+                codec.callMethod(context, "parent_code_reference=", args[3]);
                 output.callMethod(context, "metric=", args[1]);
                 output.callMethod(context, "execution_context=", args[2]);
                 workers.append(output);

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
@@ -225,11 +225,11 @@ public final class OutputStrategyExt {
             super(runtime, metaClass);
         }
 
-        @JRubyMethod(required = 4)
+        @JRubyMethod(required = 5)
         public IRubyObject initialize(final ThreadContext context, final IRubyObject[] args) {
             final RubyClass outputClass = (RubyClass) args[0];
             // Calling "new" here manually to allow mocking the ctor in RSpec Tests
-            output = args[0].callMethod(context, "new", args[3]);
+            output = args[0].callMethod(context, "new", new IRubyObject[]{args[3], args[4]});
             initOutputCallsite(outputClass);
             output.callMethod(context, "metric=", args[1]);
             output.callMethod(context, "execution_context=", args[2]);

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/PluginFactory.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/PluginFactory.java
@@ -42,22 +42,25 @@ public interface PluginFactory extends RubyIntegration.PluginFactory {
 
         @Override
         public IRubyObject buildInput(final RubyString name, final RubyInteger line, final RubyInteger column,
+                                      final String sourceFile, final int sourceLine,
                                       final IRubyObject args, Map<String, Object> pluginArgs) {
-            return rubyFactory.buildInput(name, line, column, args, pluginArgs);
+            return rubyFactory.buildInput(name, line, column, sourceFile, sourceLine, args, pluginArgs);
         }
 
         @Override
         public AbstractOutputDelegatorExt buildOutput(final RubyString name, final RubyInteger line,
-                                                      final RubyInteger column, final IRubyObject args,
+                                                      final RubyInteger column, final String sourceFile,
+                                                      final int sourceLine, final IRubyObject args,
                                                       final Map<String, Object> pluginArgs) {
-            return rubyFactory.buildOutput(name, line, column, args, pluginArgs);
+            return rubyFactory.buildOutput(name, line, column, sourceFile, sourceLine, args, pluginArgs);
         }
 
         @Override
         public AbstractFilterDelegatorExt buildFilter(final RubyString name, final RubyInteger line,
-                                                      final RubyInteger column, final IRubyObject args,
+                                                      final RubyInteger column, final String sourceFile,
+                                                      final int sourceLine, final IRubyObject args,
                                                       final Map<String, Object> pluginArgs) {
-            return rubyFactory.buildFilter(name, line, column, args, pluginArgs);
+            return rubyFactory.buildFilter(name, line, column, sourceFile, sourceLine, args, pluginArgs);
         }
 
         @Override

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/PluginFactory.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/PluginFactory.java
@@ -64,8 +64,9 @@ public interface PluginFactory extends RubyIntegration.PluginFactory {
         }
 
         @Override
-        public IRubyObject buildCodec(final RubyString name, final IRubyObject args, Map<String, Object> pluginArgs) {
-            return rubyFactory.buildCodec(name, args, pluginArgs);
+        public IRubyObject buildCodec(final RubyString name, final String sourceFile, final int sourceLine,
+                                      final IRubyObject args, Map<String, Object> pluginArgs) {
+            return rubyFactory.buildCodec(name, sourceFile, sourceLine, args, pluginArgs);
         }
 
         @Override

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
@@ -30,7 +30,7 @@ public final class RubyIntegration {
         AbstractFilterDelegatorExt buildFilter(RubyString name, RubyInteger line, RubyInteger column, String sourceFile, int sourceLine, IRubyObject args,
             Map<String, Object> pluginArgs);
 
-        IRubyObject buildCodec(RubyString name, IRubyObject args, Map<String, Object> pluginArgs);
+        IRubyObject buildCodec(RubyString name, String sourceFile, int sourceLine, IRubyObject args, Map<String, Object> pluginArgs);
 
         Codec buildDefaultCodec(String codecName);
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
@@ -21,13 +21,13 @@ public final class RubyIntegration {
      */
     public interface PluginFactory {
 
-        IRubyObject buildInput(RubyString name, RubyInteger line, RubyInteger column,
+        IRubyObject buildInput(RubyString name, RubyInteger line, RubyInteger column, String sourceFile, int sourceLine,
             IRubyObject args, Map<String, Object> pluginArgs);
 
-        AbstractOutputDelegatorExt buildOutput(RubyString name, RubyInteger line, RubyInteger column,
+        AbstractOutputDelegatorExt buildOutput(RubyString name, RubyInteger line, RubyInteger column, String sourceFile, int sourceLine,
             IRubyObject args, Map<String, Object> pluginArgs);
 
-        AbstractFilterDelegatorExt buildFilter(RubyString name, RubyInteger line, RubyInteger column, IRubyObject args,
+        AbstractFilterDelegatorExt buildFilter(RubyString name, RubyInteger line, RubyInteger column, String sourceFile, int sourceLine, IRubyObject args,
             Map<String, Object> pluginArgs);
 
         IRubyObject buildCodec(RubyString name, IRubyObject args, Map<String, Object> pluginArgs);

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/PluginVertex.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/PluginVertex.java
@@ -6,16 +6,23 @@ import org.logstash.config.ir.SourceComponent;
 
 public class PluginVertex extends Vertex {
     private final PluginDefinition pluginDefinition;
+    private final String sourceFile;
+    private final int sourceLine;
 
     public PluginDefinition getPluginDefinition() {
         return pluginDefinition;
     }
 
-
     public PluginVertex(SourceWithMetadata meta, PluginDefinition pluginDefinition) {
+        this(meta, pluginDefinition, null, -1);
+    }
+
+    public PluginVertex(SourceWithMetadata meta, PluginDefinition pluginDefinition, String sourceFile, int sourceLine) {
         // We know that if the ID value exists it will be as a string
         super(meta, (String) pluginDefinition.getArguments().get("id"));
         this.pluginDefinition = pluginDefinition;
+        this.sourceFile = sourceFile;
+        this.sourceLine = sourceLine;
     }
 
     public String toString() {
@@ -24,7 +31,7 @@ public class PluginVertex extends Vertex {
 
     @Override
     public PluginVertex copy() {
-        return new PluginVertex(this.getSourceWithMetadata(), pluginDefinition);
+        return new PluginVertex(this.getSourceWithMetadata(), pluginDefinition, sourceFile, sourceLine);
     }
 
     @Override
@@ -38,5 +45,13 @@ public class PluginVertex extends Vertex {
             return otherV.getPluginDefinition().sourceComponentEquals(this.getPluginDefinition());
         }
         return false;
+    }
+
+    public String getSourceFile() {
+        return sourceFile;
+    }
+
+    public int getSourceLine() {
+        return sourceLine;
     }
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/imperative/PluginStatement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/imperative/PluginStatement.java
@@ -1,5 +1,7 @@
 package org.logstash.config.ir.imperative;
 
+import org.jruby.RubyInteger;
+import org.jruby.RubyString;
 import org.logstash.config.ir.SourceComponent;
 import org.logstash.config.ir.InvalidIRException;
 import org.logstash.config.ir.PluginDefinition;
@@ -10,10 +12,18 @@ import org.logstash.config.ir.graph.Vertex;
 
 public class PluginStatement extends Statement {
     private final PluginDefinition pluginDefinition;
+    private String sourceFile;
+    private int sourceLine;
 
     public PluginStatement(SourceWithMetadata meta, PluginDefinition pluginDefinition) {
         super(meta);
         this.pluginDefinition = pluginDefinition;
+    }
+
+    public PluginStatement(SourceWithMetadata meta, PluginDefinition pluginDefinition, RubyString sourceFile, RubyInteger sourceLine) {
+        this(meta, pluginDefinition);
+        this.sourceFile = sourceFile.asJavaString();
+        this.sourceLine = sourceLine.getIntValue();
     }
 
     @Override
@@ -34,7 +44,7 @@ public class PluginStatement extends Statement {
 
     @Override
     public Graph toGraph() throws InvalidIRException {
-        Vertex pluginVertex = new PluginVertex(getSourceWithMetadata(), pluginDefinition);
+        Vertex pluginVertex = new PluginVertex(getSourceWithMetadata(), pluginDefinition, sourceFile, sourceLine);
         Graph g = Graph.empty();
         g.addVertex(pluginVertex);
         return g;

--- a/logstash-core/src/main/java/org/logstash/config/ir/imperative/PluginStatement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/imperative/PluginStatement.java
@@ -34,6 +34,14 @@ public class PluginStatement extends Statement {
         }
     }
 
+    public String getSourceFile() {
+        return sourceFile;
+    }
+
+    public int getSourceLine() {
+        return sourceLine;
+    }
+
     @Override
     public boolean sourceComponentEquals(SourceComponent sourceComponent) {
         if (sourceComponent == null) return false;

--- a/logstash-core/src/main/java/org/logstash/config/ir/imperative/PluginStatement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/imperative/PluginStatement.java
@@ -22,8 +22,16 @@ public class PluginStatement extends Statement {
 
     public PluginStatement(SourceWithMetadata meta, PluginDefinition pluginDefinition, RubyString sourceFile, RubyInteger sourceLine) {
         this(meta, pluginDefinition);
-        this.sourceFile = sourceFile.asJavaString();
-        this.sourceLine = sourceLine.getIntValue();
+        if (sourceFile == null) {
+            this.sourceFile = "<CLI>";
+        } else {
+            this.sourceFile = sourceFile.asJavaString();
+        }
+        if (sourceLine == null) {
+            this.sourceLine = -1;
+        } else {
+            this.sourceLine = sourceLine.getIntValue();
+        }
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -153,9 +153,8 @@ public class AbstractPipelineExt extends RubyBasicObject {
                 );
             }
         }
-        lir = ConfigCompiler.configToPipelineIR(
-            configString.asJavaString(),
-            getSetting(context, "config.support_escapes").isTrue()
+        lir = ConfigCompiler.configToPipelineIR(pipelineSettings,
+                getSetting(context, "config.support_escapes").isTrue()
         );
         return this;
     }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricKeys.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricKeys.java
@@ -13,6 +13,8 @@ public final class MetricKeys {
 
     public static final RubySymbol NAME_KEY = RubyUtil.RUBY.newSymbol("name");
 
+    public static final RubySymbol CONFIG_REF_KEY = RubyUtil.RUBY.newSymbol("config-ref");
+
     public static final RubySymbol EVENTS_KEY = RubyUtil.RUBY.newSymbol("events");
 
     public static final RubySymbol OUT_KEY = RubyUtil.RUBY.newSymbol("out");

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
@@ -80,7 +80,7 @@ public final class PluginFactoryExt {
             final RubyHash arguments = (RubyHash) args[2];
             final RubyString id = (RubyString) arguments.op_aref(context, ID_KEY);
             RubyString configRefKey = RubyString.newString(context.runtime, "config-ref");
-            arguments.remove(configRefKey);
+            RubyString configRefValue = (RubyString) arguments.remove(configRefKey);
             final IRubyObject filterInstance = args[1].callMethod(context, "new", arguments);
             filterInstance.callMethod(
                     context, "metric=",
@@ -88,7 +88,7 @@ public final class PluginFactoryExt {
             );
             filterInstance.callMethod(context, "execution_context=", args[4]);
             return new FilterDelegatorExt(context.runtime, RubyUtil.FILTER_DELEGATOR_CLASS)
-                    .initialize(context, filterInstance, id);
+                    .initialize(context, filterInstance, id, configRefValue);
         }
 
         public Plugins(final Ruby runtime, final RubyClass metaClass) {
@@ -118,50 +118,56 @@ public final class PluginFactoryExt {
         @SuppressWarnings("unchecked")
         @Override
         public IRubyObject buildInput(final RubyString name, final RubyInteger line, final RubyInteger column,
+                                      final String sourceFile, final int sourceLine,
                                       final IRubyObject args, Map<String, Object> pluginArgs) {
             return plugin(
                     RubyUtil.RUBY.getCurrentContext(), PluginLookup.PluginType.INPUT,
-                    name.asJavaString(), line.getIntValue(), column.getIntValue(), null, 0,
+                    name.asJavaString(), line.getIntValue(), column.getIntValue(), sourceFile, sourceLine,
                     (Map<String, IRubyObject>) args, pluginArgs
             );
         }
 
-        @JRubyMethod(required = 4)
+        @JRubyMethod(required = 6)
         public IRubyObject buildInput(final ThreadContext context, final IRubyObject[] args) {
             return buildInput(
                     (RubyString) args[0], args[1].convertToInteger(), args[2].convertToInteger(),
-                    args[3], null
+                    args[3].asJavaString(), args[4].convertToInteger().getIntValue(),
+                    args[5], null
             );
         }
 
         @SuppressWarnings("unchecked")
         @Override
         public AbstractOutputDelegatorExt buildOutput(final RubyString name, final RubyInteger line,
-                                                      final RubyInteger column, final IRubyObject args,
+                                                      final RubyInteger column, final String sourceFile,
+                                                      final int sourceLine,final IRubyObject args,
                                                       Map<String, Object> pluginArgs) {
             return (AbstractOutputDelegatorExt) plugin(
                     RubyUtil.RUBY.getCurrentContext(), PluginLookup.PluginType.OUTPUT,
-                    name.asJavaString(), line.getIntValue(), column.getIntValue(), null, 0,
+                    name.asJavaString(), line.getIntValue(), column.getIntValue(), sourceFile, sourceLine,
                     (Map<String, IRubyObject>) args, pluginArgs
             );
         }
 
-        @JRubyMethod(required = 4)
+        @JRubyMethod(required = 6)
         public AbstractOutputDelegatorExt buildOutput(final ThreadContext context,
                                                       final IRubyObject[] args) {
             return buildOutput(
-                    (RubyString) args[0], args[1].convertToInteger(), args[2].convertToInteger(), args[3], null
+                    (RubyString) args[0], args[1].convertToInteger(), args[2].convertToInteger(), args[3].asJavaString(),
+                    args[4].convertToInteger().getIntValue(),
+                    args[5], null
             );
         }
 
         @SuppressWarnings("unchecked")
         @Override
         public AbstractFilterDelegatorExt buildFilter(final RubyString name, final RubyInteger line,
-                                                      final RubyInteger column, final IRubyObject args,
+                                                      final RubyInteger column, final String sourceFile,
+                                                      final int sourceLine, final IRubyObject args,
                                                       Map<String, Object> pluginArgs) {
             return (AbstractFilterDelegatorExt) plugin(
                     RubyUtil.RUBY.getCurrentContext(), PluginLookup.PluginType.FILTER,
-                    name.asJavaString(), line.getIntValue(), column.getIntValue(), null, 0,
+                    name.asJavaString(), line.getIntValue(), column.getIntValue(), sourceFile, sourceLine,
                     (Map<String, IRubyObject>) args, pluginArgs
             );
         }

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
@@ -78,8 +78,10 @@ public final class PluginFactoryExt {
         public static IRubyObject filterDelegator(final ThreadContext context,
                                                   final IRubyObject recv, final IRubyObject[] args) {
             final RubyHash arguments = (RubyHash) args[2];
-            final IRubyObject filterInstance = args[1].callMethod(context, "new", arguments);
             final RubyString id = (RubyString) arguments.op_aref(context, ID_KEY);
+            RubyString configRefKey = RubyString.newString(context.runtime, "config-ref");
+            arguments.remove(configRefKey);
+            final IRubyObject filterInstance = args[1].callMethod(context, "new", arguments);
             filterInstance.callMethod(
                     context, "metric=",
                     ((AbstractMetricExt) args[3]).namespace(context, id.intern())
@@ -87,20 +89,6 @@ public final class PluginFactoryExt {
             filterInstance.callMethod(context, "execution_context=", args[4]);
             return new FilterDelegatorExt(context.runtime, RubyUtil.FILTER_DELEGATOR_CLASS)
                     .initialize(context, filterInstance, id);
-//            final RubyString id = (RubyString) arguments.op_aref(context, ID_KEY);
-//            RubyString configRefKey = RubyString.newString(context.runtime, "config-ref");
-//            String configRef = arguments.op_aref(context, configRefKey).asJavaString();
-//            arguments.remove(configRefKey);
-//
-//            final IRubyObject filterInstance = args[1].callMethod(context, "new", new IRubyObject[]{RubyUtil.RUBY.newString(configRef), arguments});
-//            final AbstractMetricExt typeScopedMetric = (AbstractMetricExt) args[3];
-//            final AbstractNamespacedMetricExt scopedMetric = typeScopedMetric.namespace(context, id.intern());
-//            scopedMetric.gauge(context, MetricKeys.CONFIG_REF_KEY, RubyUtil.RUBY.newString(configRef));
-//
-//            filterInstance.callMethod(context, "metric=", scopedMetric);
-//            filterInstance.callMethod(context, "execution_context=", args[4]);
-//            return new FilterDelegatorExt(context.runtime, RubyUtil.FILTER_DELEGATOR_CLASS)
-//                    .initialize(context, filterInstance, id);
         }
 
         public Plugins(final Ruby runtime, final RubyClass metaClass) {

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
@@ -167,10 +167,11 @@ public final class PluginFactoryExt {
 
         @SuppressWarnings("unchecked")
         @Override
-        public IRubyObject buildCodec(final RubyString name, final IRubyObject args, Map<String, Object> pluginArgs) {
+        public IRubyObject buildCodec(final RubyString name, final String sourceFile, final int sourceLine,
+                                      final IRubyObject args, Map<String, Object> pluginArgs) {
             return plugin(
                     RubyUtil.RUBY.getCurrentContext(), PluginLookup.PluginType.CODEC,
-                    name.asJavaString(), 0, 0, null, 0, (Map<String, IRubyObject>) args, pluginArgs
+                    name.asJavaString(), 0, 0, sourceFile, sourceLine, (Map<String, IRubyObject>) args, pluginArgs
             );
         }
 
@@ -280,9 +281,10 @@ public final class PluginFactoryExt {
                         final IRubyObject codecDelegatorClass = RubyUtil.RUBY.executeScript(
                                 "require 'logstash/codecs/delegator'\nLogStash::Codecs::Delegator",
                                 "");
-                        if (pluginInstance.getType().instance_of_p(context, codecDelegatorClass).isTrue()) {
-                            // WARNING: order is important since metric= create gauges with data assigned from parent_code_reference=
-                            IRubyObject codec = pluginInstance.callMethod(context, "codec");
+
+                        // WARNING: order is important since metric= create gauges with data assigned from parent_code_reference=
+                        IRubyObject codec = pluginInstance.callMethod(context, "codec");
+                        if (codec.getType().instance_of_p(context, codecDelegatorClass).isTrue()) {
                             codec.callMethod(context, "parent_code_reference=", RubyUtil.RUBY.newString(configReference));
                         }
                         pluginInstance.callMethod(context, "metric=", scopedMetric);

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
@@ -278,10 +278,13 @@ public final class PluginFactoryExt {
                             }
                     );
                 } else {
-                    final IRubyObject pluginInstance = klass.callMethod(context, "new", new IRubyObject[]{RubyUtil.RUBY.newString(configReference), rubyArgs});
+                    final IRubyObject pluginInstance = klass.callMethod(context, "new", rubyArgs);
                     final AbstractNamespacedMetricExt scopedMetric = typeScopedMetric.namespace(context, RubyUtil.RUBY.newSymbol(id));
                     scopedMetric.gauge(context, MetricKeys.NAME_KEY, pluginInstance.callMethod(context, "config_name"));
                     scopedMetric.gauge(context, MetricKeys.CONFIG_REF_KEY, RubyUtil.RUBY.newString(configReference));
+                    // WARNING: order is important since metric= create gauges with data assigned from parent_code_reference=
+                    IRubyObject codec = pluginInstance.callMethod(context, "codec");
+                    codec.callMethod(context, "parent_code_reference=", RubyUtil.RUBY.newString(configReference));
                     pluginInstance.callMethod(context, "metric=", scopedMetric);
                     pluginInstance.callMethod(context, "execution_context=", executionCntx);
                     return pluginInstance;

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
@@ -78,20 +78,29 @@ public final class PluginFactoryExt {
         public static IRubyObject filterDelegator(final ThreadContext context,
                                                   final IRubyObject recv, final IRubyObject[] args) {
             final RubyHash arguments = (RubyHash) args[2];
+            final IRubyObject filterInstance = args[1].callMethod(context, "new", arguments);
             final RubyString id = (RubyString) arguments.op_aref(context, ID_KEY);
-            RubyString configRefKey = RubyString.newString(context.runtime, "config-ref");
-            String configRef = arguments.op_aref(context, configRefKey).asJavaString();
-            arguments.remove(configRefKey);
-
-            final IRubyObject filterInstance = args[1].callMethod(context, "new", new IRubyObject[]{RubyUtil.RUBY.newString(configRef), arguments});
-            final AbstractMetricExt typeScopedMetric = (AbstractMetricExt) args[3];
-            final AbstractNamespacedMetricExt scopedMetric = typeScopedMetric.namespace(context, id.intern());
-            scopedMetric.gauge(context, MetricKeys.CONFIG_REF_KEY, RubyUtil.RUBY.newString(configRef));
-
-            filterInstance.callMethod(context, "metric=", scopedMetric);
+            filterInstance.callMethod(
+                    context, "metric=",
+                    ((AbstractMetricExt) args[3]).namespace(context, id.intern())
+            );
             filterInstance.callMethod(context, "execution_context=", args[4]);
             return new FilterDelegatorExt(context.runtime, RubyUtil.FILTER_DELEGATOR_CLASS)
                     .initialize(context, filterInstance, id);
+//            final RubyString id = (RubyString) arguments.op_aref(context, ID_KEY);
+//            RubyString configRefKey = RubyString.newString(context.runtime, "config-ref");
+//            String configRef = arguments.op_aref(context, configRefKey).asJavaString();
+//            arguments.remove(configRefKey);
+//
+//            final IRubyObject filterInstance = args[1].callMethod(context, "new", new IRubyObject[]{RubyUtil.RUBY.newString(configRef), arguments});
+//            final AbstractMetricExt typeScopedMetric = (AbstractMetricExt) args[3];
+//            final AbstractNamespacedMetricExt scopedMetric = typeScopedMetric.namespace(context, id.intern());
+//            scopedMetric.gauge(context, MetricKeys.CONFIG_REF_KEY, RubyUtil.RUBY.newString(configRef));
+//
+//            filterInstance.callMethod(context, "metric=", scopedMetric);
+//            filterInstance.callMethod(context, "execution_context=", args[4]);
+//            return new FilterDelegatorExt(context.runtime, RubyUtil.FILTER_DELEGATOR_CLASS)
+//                    .initialize(context, filterInstance, id);
         }
 
         public Plugins(final Ruby runtime, final RubyClass metaClass) {

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
@@ -282,10 +282,10 @@ public final class PluginFactoryExt {
                                 "require 'logstash/codecs/delegator'\nLogStash::Codecs::Delegator",
                                 "");
 
-                        // WARNING: order is important since metric= create gauges with data assigned from parent_code_reference=
+                        // WARNING: order is important since metric= create gauges with data assigned from parent_config_reference=
                         IRubyObject codec = pluginInstance.callMethod(context, "codec");
                         if (codec.getType().instance_of_p(context, codecDelegatorClass).isTrue()) {
-                            codec.callMethod(context, "parent_code_reference=", RubyUtil.RUBY.newString(configReference));
+                            codec.callMethod(context, "parent_config_reference=", RubyUtil.RUBY.newString(configReference));
                         }
                         pluginInstance.callMethod(context, "metric=", scopedMetric);
                         pluginInstance.callMethod(context, "execution_context=", executionCntx);

--- a/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
@@ -528,7 +528,8 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
         }
 
         @Override
-        public IRubyObject buildCodec(final RubyString name, final IRubyObject args, Map<String, Object> pluginArgs) {
+        public IRubyObject buildCodec(final RubyString name, final String sourceFile, final int sourceLine,
+                                      final IRubyObject args, Map<String, Object> pluginArgs) {
             throw new IllegalStateException("No codec setup expected in this test.");
         }
 

--- a/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
@@ -14,8 +14,10 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
+import org.jruby.RubyArray;
 import org.jruby.RubyInteger;
 import org.jruby.RubyString;
+import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.junit.After;
 import org.junit.Before;
@@ -25,6 +27,7 @@ import org.logstash.ConvertedMap;
 import org.logstash.Event;
 import org.logstash.RubyUtil;
 import org.logstash.common.IncompleteSourceWithMetadataException;
+import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.compiler.AbstractFilterDelegatorExt;
 import org.logstash.config.ir.compiler.AbstractOutputDelegatorExt;
 import org.logstash.config.ir.compiler.FilterDelegatorExt;
@@ -94,10 +97,35 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
         EVENT_SINKS.remove(runId);
     }
 
+    static IRubyObject createRubyPipelineConfig(String configString) throws IncompleteSourceWithMetadataException {
+        final IRubyObject pipelineConfigClass = RubyUtil.RUBY.executeScript(
+                "require 'logstash/config/pipeline_config'\nLogStash::Config::PipelineConfig",
+                ""
+        );
+
+        @SuppressWarnings("unchecked")
+        RubyArray<IRubyObject> configParts = (RubyArray<IRubyObject>) RubyUtil.RUBY.newArray(
+                JavaUtil.convertJavaToRuby(
+                        RubyUtil.RUBY,
+                        new SourceWithMetadata("str", "pipeline", 0, 0, configString)
+                )
+        );
+
+        final IRubyObject pipelineConfig =
+                pipelineConfigClass.callMethod(RubyUtil.RUBY.getCurrentContext(), "new",
+                        new IRubyObject[] {
+                                RubyUtil.RUBY.getNil(), /*source*/
+                                RubyUtil.RUBY.newString("main"), /*pipeline_id*/
+                                configParts,
+                                RubyUtil.RUBY.getNil(), /*settings*/
+                        });
+        return pipelineConfig;
+    }
+
     @Test
     public void buildsTrivialPipeline() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
-            "input {mockinput{}} output{mockoutput{}}", false
+                createRubyPipelineConfig("input {mockinput{}} output{mockoutput{}}"), false
         );
         final JrubyEventExtLibrary.RubyEvent testEvent =
             JrubyEventExtLibrary.RubyEvent.newRubyEvent(RubyUtil.RUBY, new Event());
@@ -116,7 +144,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
     @Test
     public void buildsStraightPipeline() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
-            "input {mockinput{}} filter { mockfilter {} mockfilter {} mockfilter {}} output{mockoutput{}}",
+                createRubyPipelineConfig("input {mockinput{}} filter { mockfilter {} mockfilter {} mockfilter {}} output{mockoutput{}}"),
             false
         );
         final JrubyEventExtLibrary.RubyEvent testEvent =
@@ -137,14 +165,14 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
     @Test
     public void buildsForkedPipeline() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
-            "input {mockinput{}} filter { " +
+                createRubyPipelineConfig("input {mockinput{}} filter { " +
                 "if [foo] != \"bar\" { " +
                 "mockfilter {} " +
                 "mockaddfilter {} " +
                 "if [foo] != \"bar\" { " +
                 "mockfilter {} " +
                 "}} " +
-                "} output {mockoutput{} }",
+                "} output {mockoutput{} }"),
             false
         );
         final JrubyEventExtLibrary.RubyEvent testEvent =
@@ -268,9 +296,9 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
 
         new CompiledPipeline(
                 ConfigCompiler.configToPipelineIR(
-                        "input {mockinput{}} output { " +
+                        createRubyPipelineConfig("input {mockinput{}} output { " +
                                 String.format("if \"z\" %s /z/ { ", operator) +
-                                " mockoutput{} } }",
+                                " mockoutput{} } }"),
                         false
                 ),
                 new CompiledPipelineTest.MockPluginFactory(
@@ -289,7 +317,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
     @Test
     public void equalityCheckOnCompositeField() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
-                "input {mockinput{}} filter { if 4 == [list] { mockaddfilter {} } if 5 == [map] { mockaddfilter {} } } output {mockoutput{} }",
+                createRubyPipelineConfig("input {mockinput{}} filter { if 4 == [list] { mockaddfilter {} } if 5 == [map] { mockaddfilter {} } } output {mockoutput{} }"),
                 false
         );
         final Collection<String> s = new ArrayList<>();
@@ -320,7 +348,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
     @Test
     public void conditionalWithNullField() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
-                "input {mockinput{}} filter { if [foo] == [bar] { mockaddfilter {} } } output {mockoutput{} }",
+                createRubyPipelineConfig("input {mockinput{}} filter { if [foo] == [bar] { mockaddfilter {} } } output {mockoutput{} }"),
                 false
         );
         final JrubyEventExtLibrary.RubyEvent testEvent =
@@ -344,7 +372,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
     @Test
     public void conditionalNestedMetaFieldPipeline() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
-            "input {mockinput{}} filter { if [@metadata][foo][bar] { mockaddfilter {} } } output {mockoutput{} }",
+                createRubyPipelineConfig("input {mockinput{}} filter { if [@metadata][foo][bar] { mockaddfilter {} } } output {mockoutput{} }"),
             false
         );
         final JrubyEventExtLibrary.RubyEvent testEvent =
@@ -369,7 +397,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
     @Test
     public void moreThan255Parents() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
-            "input {mockinput{}} filter { " +
+                createRubyPipelineConfig("input {mockinput{}} filter { " +
                 "if [foo] != \"bar\" { " +
                 "mockfilter {} " +
                 "mockaddfilter {} " +
@@ -377,7 +405,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
                 "mockfilter {} " +
                 Strings.repeat("} else if [foo] != \"bar\" {" +
                     "mockfilter {} ", 300) + " } } " +
-                "} output {mockoutput{} }",
+                "} output {mockoutput{} }"),
             false
         );
         final JrubyEventExtLibrary.RubyEvent testEvent =
@@ -426,11 +454,11 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
 
         new CompiledPipeline(
             ConfigCompiler.configToPipelineIR(
-                "input {mockinput{}} filter { " +
+                    createRubyPipelineConfig("input {mockinput{}} filter { " +
                     String.format("if %s { ", conditional) +
                     " mockaddfilter {} " +
                     "} " +
-                    "} output {mockoutput{} }",
+                    "} output {mockoutput{} }"),
                 false
             ),
             new CompiledPipelineTest.MockPluginFactory(
@@ -467,29 +495,32 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
         private final Map<String, Supplier<Consumer<Collection<JrubyEventExtLibrary.RubyEvent>>>> outputs;
 
         MockPluginFactory(final Map<String, Supplier<IRubyObject>> inputs,
-            final Map<String, Supplier<IRubyObject>> filters,
-            final Map<String, Supplier<Consumer<Collection<JrubyEventExtLibrary.RubyEvent>>>> outputs
-        ) {
+                          final Map<String, Supplier<IRubyObject>> filters,
+                          final Map<String, Supplier<Consumer<Collection<JrubyEventExtLibrary.RubyEvent>>>> outputs) {
             this.inputs = inputs;
             this.filters = filters;
             this.outputs = outputs;
         }
 
         @Override
-        public IRubyObject buildInput(final RubyString name, final RubyInteger line,
-            final RubyInteger column, final IRubyObject args, Map<String, Object> pluginArgs) {
+        public IRubyObject buildInput(final RubyString name, final RubyInteger line, final RubyInteger column,
+                                      final String sourceFile, final int sourceLine, final IRubyObject args,
+                                      Map<String, Object> pluginArgs) {
             return setupPlugin(name, inputs);
         }
 
         @Override
         public AbstractOutputDelegatorExt buildOutput(final RubyString name, final RubyInteger line,
-            final RubyInteger column, final IRubyObject args, Map<String, Object> pluginArgs) {
+            final RubyInteger column, final String sourceFile, final int sourceLine, final IRubyObject args,
+             Map<String, Object> pluginArgs)
+        {
             return PipelineTestUtil.buildOutput(setupPlugin(name, outputs));
         }
 
         @Override
         public AbstractFilterDelegatorExt buildFilter(final RubyString name, final RubyInteger line,
-                                                      final RubyInteger column, final IRubyObject args,
+                                                      final RubyInteger column, final String sourceFile,
+                                                      final int sourceLine, final IRubyObject args,
                                                       Map<String, Object> pluginArgs) {
             return new FilterDelegatorExt(
                 RubyUtil.RUBY, RubyUtil.FILTER_DELEGATOR_CLASS)

--- a/logstash-core/src/test/java/org/logstash/config/ir/ConfigCompilerTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/ConfigCompilerTest.java
@@ -8,13 +8,14 @@ import org.logstash.config.ir.graph.Graph;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.logstash.config.ir.CompiledPipelineTest.createRubyPipelineConfig;
 
 public class ConfigCompilerTest extends RubyEnvTestCase {
 
     @Test
     public void testConfigToPipelineIR() throws Exception {
         final PipelineIR pipelineIR =
-            ConfigCompiler.configToPipelineIR("input {stdin{}} output{stdout{}}", false);
+            ConfigCompiler.configToPipelineIR(createRubyPipelineConfig("input {stdin{}} output{stdout{}}"), false);
         assertThat(pipelineIR.getOutputPluginVertices().size(), is(1));
         assertThat(pipelineIR.getFilterPluginVertices().size(), is(0));
     }
@@ -62,6 +63,6 @@ public class ConfigCompilerTest extends RubyEnvTestCase {
 
     private static String graphHash(final String config)
         throws IncompleteSourceWithMetadataException {
-        return ConfigCompiler.configToPipelineIR(config, false).uniqueHash();
+        return ConfigCompiler.configToPipelineIR(createRubyPipelineConfig(config), false).uniqueHash();
     }
 }

--- a/logstash-core/src/test/java/org/logstash/config/ir/EventConditionTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/EventConditionTest.java
@@ -19,6 +19,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static org.logstash.config.ir.CompiledPipelineTest.IDENTITY_FILTER;
+import static org.logstash.config.ir.CompiledPipelineTest.createRubyPipelineConfig;
 import static org.logstash.ext.JrubyEventExtLibrary.RubyEvent;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -55,12 +56,12 @@ public final class EventConditionTest extends RubyEnvTestCase {
     @SuppressWarnings("rawtypes")
     public void testInclusionWithFieldInField() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
-                "input {mockinput{}} filter { " +
+                createRubyPipelineConfig("input {mockinput{}} filter { " +
                         "mockfilter {} } " +
                         "output { " +
                         "  if [left] in [right] { " +
                         "    mockoutput{}" +
-                        "  } }",
+                        "  } }"),
                 false
         );
 
@@ -136,12 +137,12 @@ public final class EventConditionTest extends RubyEnvTestCase {
 
     private void testConditionWithConstantValue(String condition, int expectedMatches) throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
-                "input {mockinput{}} filter { " +
+                createRubyPipelineConfig("input {mockinput{}} filter { " +
                         "mockfilter {} } " +
                         "output { " +
                         "  if " + condition + " { " +
                         "    mockoutput{}" +
-                        "  } }",
+                        "  } }"),
                 false
         );
 

--- a/logstash-core/src/test/java/org/logstash/config/ir/PipelineTestUtil.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/PipelineTestUtil.java
@@ -17,7 +17,7 @@ public final class PipelineTestUtil {
         final Consumer<Collection<JrubyEventExtLibrary.RubyEvent>> consumer) {
         return JavaOutputDelegatorExt.create(
             "someClassName", "someId", NullMetricExt.create(), consumer, () -> {},
-            () -> {}
+            () -> {}, "L:test, C:test"
         );
     }
 }

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/FakeOutClass.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/FakeOutClass.java
@@ -7,6 +7,7 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.logstash.RubyUtil;
 
 import static org.logstash.RubyUtil.RUBY;
 
@@ -58,6 +59,19 @@ public class FakeOutClass extends RubyObject {
     public IRubyObject register() {
         registerCallCount++;
         return this;
+    }
+
+    @JRubyMethod(name = "codec")
+    public IRubyObject codec() {
+        final IRubyObject codecDelegatorClass = RubyUtil.RUBY.executeScript(
+                "require 'logstash/codecs/delegator'\nLogStash::Codecs::Delegator",
+                ""
+        );
+        final IRubyObject codecDelegator =
+                codecDelegatorClass.callMethod(RubyUtil.RUBY.getCurrentContext(), "new",
+                        new IRubyObject[]{RubyUtil.RUBY.newString("Fake Codec Object"),  null}
+                );
+        return codecDelegator;
     }
 
     @JRubyMethod(name = "metric=")

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/JavaCodecDelegatorTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/JavaCodecDelegatorTest.java
@@ -198,7 +198,7 @@ public class JavaCodecDelegatorTest extends MetricTestCase {
     }
 
     private JavaCodecDelegator constructCodecDelegator() {
-        return new JavaCodecDelegator(new ContextImpl(null, this.getInstance()), codec);
+        return new JavaCodecDelegator(new ContextImpl(null, this.getInstance()), codec, null);
     }
 
     private abstract class AbstractCodec implements Codec {

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/OutputDelegatorTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/OutputDelegatorTest.java
@@ -41,6 +41,7 @@ public class OutputDelegatorTest extends PluginDelegatorTestCase {
         pluginArgs = RubyHash.newHash(RUBY);
         pluginArgs.put("id", "foo");
         pluginArgs.put("arg1", "val1");
+        pluginArgs.put("config-ref", "<Test only config reference>");
     }
 
     @Override
@@ -114,6 +115,7 @@ public class OutputDelegatorTest extends PluginDelegatorTestCase {
 
     @Test
     public void singleConcurrencyStrategyIsDefault() {
+        pluginArgs.put("config-ref", "<Test only config reference>");
         OutputDelegatorExt outputDelegator = constructOutputDelegator();
         IRubyObject concurrency = outputDelegator.concurrency(RUBY.getCurrentContext());
         assertEquals(RUBY.newSymbol("single"), concurrency);
@@ -128,6 +130,7 @@ public class OutputDelegatorTest extends PluginDelegatorTestCase {
         };
 
         for (StrategyPair pair : outputStrategies) {
+            pluginArgs.put("config-ref", "<Test only config reference>");
             FakeOutClass.setOutStrategy(RUBY.getCurrentContext(), null, pair.symbol);
             OutputDelegatorExt outputDelegator = constructOutputDelegator();
 
@@ -153,6 +156,7 @@ public class OutputDelegatorTest extends PluginDelegatorTestCase {
         };
         final ThreadContext context = RUBY.getCurrentContext();
         for (RubySymbol symbol : outputStrategies) {
+            pluginArgs.put("config-ref", "<Test only config reference>");
             FakeOutClass.create().initialize(context);
             FakeOutClass.setOutStrategy(RUBY.getCurrentContext(), null, symbol);
             OutputDelegatorExt outputDelegator = constructOutputDelegator();

--- a/logstash-core/src/test/java/org/logstash/plugins/TestPluginFactory.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/TestPluginFactory.java
@@ -15,17 +15,17 @@ import java.util.Map;
 public class TestPluginFactory implements RubyIntegration.PluginFactory {
 
     @Override
-    public IRubyObject buildInput(RubyString name, RubyInteger line, RubyInteger column, IRubyObject args, Map<String, Object> pluginArgs) {
+    public IRubyObject buildInput(RubyString name, RubyInteger line, RubyInteger column, String sourceFile, int sourceLine, IRubyObject args, Map<String, Object> pluginArgs) {
         return null;
     }
 
     @Override
-    public AbstractOutputDelegatorExt buildOutput(RubyString name, RubyInteger line, RubyInteger column, IRubyObject args, Map<String, Object> pluginArgs) {
+    public AbstractOutputDelegatorExt buildOutput(RubyString name, RubyInteger line, RubyInteger column, String sourceFile, int sourceLine, IRubyObject args, Map<String, Object> pluginArgs) {
         return null;
     }
 
     @Override
-    public AbstractFilterDelegatorExt buildFilter(RubyString name, RubyInteger line, RubyInteger column, IRubyObject args, Map<String, Object> pluginArgs) {
+    public AbstractFilterDelegatorExt buildFilter(RubyString name, RubyInteger line, RubyInteger column, String sourceFile, int sourceLine, IRubyObject args, Map<String, Object> pluginArgs) {
         return null;
     }
 

--- a/logstash-core/src/test/java/org/logstash/plugins/TestPluginFactory.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/TestPluginFactory.java
@@ -30,7 +30,7 @@ public class TestPluginFactory implements RubyIntegration.PluginFactory {
     }
 
     @Override
-    public IRubyObject buildCodec(RubyString name, IRubyObject args, Map<String, Object> pluginArgs) {
+    public IRubyObject buildCodec(RubyString name, String sourceFile, int sourceLine, IRubyObject args, Map<String, Object> pluginArgs) {
         return null;
     }
 

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -219,7 +219,7 @@ describe "Test Monitoring API" do
 
         output_codec_stats = result.fetch("plugins").fetch("codecs").select { |c| c["name"] == "rubydebug"}.first
         expect(output_codec_stats).not_to be_nil
-        config_ref = output_codec_stats.fetch("parent-code-ref")
+        config_ref = output_codec_stats.fetch("parent-config-ref")
         expect_source_ref(config_ref, "pipeline_2_piece.conf", 3, 9)
       end
     end

--- a/x-pack/spec/monitoring/inputs/metrics/state_event/lir_serializer_spec.rb
+++ b/x-pack/spec/monitoring/inputs/metrics/state_event/lir_serializer_spec.rb
@@ -4,6 +4,7 @@
 
 require "spec_helper"
 require "logstash/environment"
+require "logstash/config/pipeline_config"
 
 describe ::LogStash::Config::LIRSerializer do
   let(:config) do
@@ -21,8 +22,10 @@ describe ::LogStash::Config::LIRSerializer do
     [org.logstash.common.SourceWithMetadata.new("string", "spec", config)]
   end
 
+  let(:pipeline_config) { LogStash::Config::PipelineConfig.new("x-pack_lir_serializer_test", "lir", config_source_with_metadata, LogStash::SETTINGS) }
+
   let(:lir_pipeline) do
-    ::LogStash::Compiler.compile_sources(config_source_with_metadata, LogStash::SETTINGS)
+    ::LogStash::Compiler.compile_sources(pipeline_config, LogStash::SETTINGS)
   end
 
   describe "#serialize" do


### PR DESCRIPTION
**Note**
this PR is superseeded by #11288  for the Java pipeline part, for the Ruby pipeline we have to check if it worthwhile

[Feature Discussion]

We want to give a more useful name/id to the plugin so that could be easily mapped to which point in the pipeline it refers to. I think the best option would be to have a line number referring the position into the pipeline config file, like input-L5. What do you think about it?

solves #11154