### PR TITLE
[DOCS] Fixes links to monitoring content

### DIFF
--- a/docs/static/monitoring/configuring-logstash.asciidoc
+++ b/docs/static/monitoring/configuring-logstash.asciidoc
@@ -10,7 +10,7 @@ To monitor Logstash nodes:
 
 . Identify where to send monitoring data. This cluster is often referred to as
 the _production cluster_. For examples of typical monitoring architectures, see
-{xpack-ref}/how-monitoring-works.html[How Monitoring Works].
+{ref}/how-monitoring-works.html[How monitoring works].
 +
 --
 IMPORTANT: To visualize Logstash as part of the Elastic Stack (as shown in Step
@@ -102,6 +102,6 @@ image:static/monitoring/images/monitoring-ui.png["Monitoring",link="monitoring/i
 
 When upgrading from older versions of {xpack}, the built-in `logstash_system`
 user is disabled for security reasons. To resume monitoring,
-{xpack-ref}/monitoring-troubleshooting.html[change the password and re-enable the logstash_system user].
+change the password and re-enable the `logstash_system` user.
 
 include::{log-repo-dir}/static/settings/monitoring-settings.asciidoc[]

--- a/docs/static/monitoring/monitoring-overview.asciidoc
+++ b/docs/static/monitoring/monitoring-overview.asciidoc
@@ -29,7 +29,7 @@ expected to be the production cluster. This configuration enables the production
 {es} cluster to add metadata (for example, its cluster UUID) to the Logstash
 monitoring data then route it to the monitoring clusters. For more information 
 about typical monitoring architectures, see 
-{xpack-ref}/how-monitoring-works.html[How Monitoring Works]. 
+{ref}/how-monitoring-works.html[How monitoring works]. 
 
 include::collectors.asciidoc[]
 include::monitoring-output.asciidoc[]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/46718

This PR updates links to monitoring content that has moved from the Stack Overview to the Elasticsearch Reference. 

It also removes a link to the "troubleshooting" content, since the most recent versions of the destination page no longer covers the described problem.


