### PR TITLE
Clarify monitoring hosts should not be master-only

### DIFF
--- a/docs/static/settings/monitoring-settings.asciidoc
+++ b/docs/static/settings/monitoring-settings.asciidoc
@@ -28,6 +28,12 @@ Logstash metrics must be routed through your production cluster. You can specify
 a single host as a string, or specify multiple hosts as an array. Defaults to
 `http://localhost:9200`.
 
+NOTE: If your Elasticsearch cluster is configured with dedicated master-eliglble
+nodes, Logstash metrics should _not_ be routed to these nodes, as doing so can
+create resource contention and impact the stability of the Elasticsearch
+cluster. Therefore, do not include such nodes in
+`xpack.monitoring.elasticsearch.hosts`.
+
 `xpack.monitoring.elasticsearch.username` and `xpack.monitoring.elasticsearch.password`::
 
 If your {es} is protected with basic authentication, these settings provide the


### PR DESCRIPTION
This commit clarifies that Logstash monitoring metrics should not be
routed through master-only nodes, and should instead prefer coordinating
nodes.

Supersedes #11145 