### PR TITLE
replace YAML.parse with YAML.safe_load in release tool

### DIFF
--- a/tools/release/bump_plugin_versions.rb
+++ b/tools/release/bump_plugin_versions.rb
@@ -96,7 +96,7 @@ puts "Pushing commit.."
 `git remote add upstream git@github.com:elastic/logstash.git`
 `git push upstream #{branch_name}`
 
-current_release = YAML.parse(IO.read("versions.yml"))["logstash"]
+current_release = YAML.safe_load(IO.read("versions.yml"))["logstash"]
 puts "Creating Pull Request"
 pr_title = "bump lock file for #{current_release}"
 


### PR DESCRIPTION
YAML.parse returns Psych nodes that then need to be converted to plain ruby objects using to_ruby

Calling YAML.safe_load outputs basic ruby objects already and also increases security as it greatly restricts the classes it deserializes.