### PR TITLE
doc: replace unicode non-breaking hyphen U+8211 with ASCII hyphen

### DIFF
--- a/docs/static/reloading-config.asciidoc
+++ b/docs/static/reloading-config.asciidoc
@@ -9,7 +9,7 @@ command-line option specified. For example:
 
 [source,shell]
 ----------------------------------
-bin/logstash –f apache.config --config.reload.automatic
+bin/logstash -f apache.config --config.reload.automatic
 ----------------------------------
 
 NOTE: The `--config.reload.automatic` option is not available when you specify the `-e` flag to pass


### PR DESCRIPTION
A user copy/pasting from our docs encountered an odd failure because we included an UTF-8 non-breaking hyphen instead of an ASCII hyphen.

https://discuss.elastic.co/t/logstash-ver-7-4-0-in-docker-set-autoconfig-refresh/203515