### PR TITLE
Integration plugins

### DIFF
--- a/qa/integration/specs/cli/remove_spec.rb
+++ b/qa/integration/specs/cli/remove_spec.rb
@@ -45,7 +45,7 @@ describe "CLI > logstash-plugin remove" do
 
             expect(execute.exit_code).to eq(1)
             expect(execute.stderr_and_stdout).to match(/Failed to remove "logstash-codec-json"/)
-            expect(execute.stderr_and_stdout).to match(/logstash-input-kafka/) # one of the dependency
+            expect(execute.stderr_and_stdout).to match(/logstash-integration-kafka/) # one of the dependency
             expect(execute.stderr_and_stdout).to match(/logstash-output-udp/) # one of the dependency
 
             presence_check = @logstash_plugin.list("logstash-codec-json")
@@ -78,7 +78,7 @@ describe "CLI > logstash-plugin remove" do
 
           expect(execute.exit_code).to eq(1)
           expect(execute.stderr_and_stdout).to match(/Failed to remove "logstash-codec-json"/)
-          expect(execute.stderr_and_stdout).to match(/logstash-input-kafka/) # one of the dependency
+          expect(execute.stderr_and_stdout).to match(/logstash-integration-kafka/) # one of the dependency
           expect(execute.stderr_and_stdout).to match(/logstash-output-udp/) # one of the dependency
 
           presence_check = @logstash_plugin.list("logstash-codec-json")

--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -329,8 +329,8 @@
     "skip-list": true
   },
   "logstash-input-kafka": {
-    "default-plugins": true,
-    "skip-list": false
+    "default-plugins": false,
+    "skip-list": true
   },
   "logstash-input-log4j2": {
     "default-plugins": false,
@@ -402,6 +402,10 @@
     "default-plugins": true,
     "skip-list": false
   },
+  "logstash-integration-kafka": {
+    "default-plugins": true,
+    "skip-list": false
+  },
   "logstash-integration-rabbitmq": {
     "default-plugins": true,
     "skip-list": false
@@ -453,8 +457,8 @@
     "skip-list": true
   },
   "logstash-output-kafka": {
-    "default-plugins": true,
-    "skip-list": false
+    "default-plugins": false,
+    "skip-list": true
   },
   "logstash-output-logentries": {
     "default-plugins": false,

--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -349,8 +349,8 @@
     "skip-list": false
   },
   "logstash-input-rabbitmq": {
-    "default-plugins": true,
-    "skip-list": false
+    "default-plugins": false,
+    "skip-list": true
   },
   "logstash-input-rackspace": {
     "default-plugins": false,
@@ -399,6 +399,10 @@
     "skip-list": false
   },
   "logstash-input-unix": {
+    "default-plugins": true,
+    "skip-list": false
+  },
+  "logstash-integration-rabbitmq": {
     "default-plugins": true,
     "skip-list": false
   },
@@ -482,8 +486,8 @@
     "skip-list": false
   },
   "logstash-output-rabbitmq": {
-    "default-plugins": true,
-    "skip-list": false
+    "default-plugins": false,
+    "skip-list": true
   },
   "logstash-output-rackspace": {
     "default-plugins": false,


### PR DESCRIPTION
This PR replaces the distinct input/output integration plugins for kafka and rabbitmq with the integration plugins providing the same functionality.

Depends on:
 - [x] https://github.com/logstash-plugins/logstash-integration-rabbitmq/pull/2
 - [x] https://github.com/logstash-plugins/logstash-integration-kafka/pull/1