### PR TITLE
more resilient testing of logging level setting

### DIFF
--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -129,10 +129,10 @@ describe "Test Monitoring API" do
       result = logstash_service.monitoring_api.logging_get
       result["loggers"].each do | k, v |
         #since we explicitly set the logstash.agent logger above, the logger.logstash parent logger will not take precedence
-        if k.eql?("logstash.agent") || k.start_with?("org.logstash") || k.eql?("org.reflections.Reflections")
-          expect(v).to eq("INFO")
-        else
+        if !k.eql?("logstash.agent") && (k.start_with?("logstash") || k.start_with?("slowlog"))
           expect(v).to eq("ERROR")
+        else
+          expect(v).to eq("INFO")
         end
       end
 


### PR DESCRIPTION
fix failure:

```
12:21:52       1) Test Monitoring API can configure logging
12:21:52          Failure/Error: Unable to find matching line from backtrace
12:21:52          
12:21:52            expected: "INFO"
12:21:52                 got: "ERROR"
12:21:52          
12:21:52            (compared using ==)
12:21:52 
12:21:52     Finished in 21 minutes 56 seconds (files took 6.1 seconds to load)
12:21:52     25 examples, 1 failure, 1 pending
12:21:52 
12:21:52     Failed examples:
12:21:52 
12:21:52     rspec ./specs/monitoring_api_spec.rb:100 # Test Monitoring API can configure logging
```

Seen for example in https://logstash-ci.elastic.co/job/elastic+logstash+master+multijob-integration-pq-1/94/console