### PR TITLE
[DOCS] Fixes links to Stack Overview

### DIFF
--- a/docs/static/azure-module.asciidoc
+++ b/docs/static/azure-module.asciidoc
@@ -492,7 +492,7 @@ the event originated.
 ==== Deploying the module in production 
 
 Use security best practices to secure your configuration.
-See {stack-ov}/elasticsearch-security.html[Securing the {stack}] for details and recommendations.
+See {ref}/secure-cluster.html[Secure a cluster] for details and recommendations.
 
 [[azure-resources]]
 ==== Microsoft Azure resources 

--- a/docs/static/deploying.asciidoc
+++ b/docs/static/deploying.asciidoc
@@ -124,7 +124,7 @@ Enterprise-grade security is available across the entire delivery chain.
 * There’s a wealth of security options when communicating with Elasticsearch
 including basic authentication, TLS, PKI, LDAP, AD, and other custom realms.
 To enable Elasticsearch security, see 
-{stack-ov}/elasticsearch-security.html[Securing the {stack}].
+{ref}/secure-cluster.html[Secure a cluster].
 
 [float]
 ==== Monitoring

--- a/docs/static/monitoring/monitoring-internal.asciidoc
+++ b/docs/static/monitoring/monitoring-internal.asciidoc
@@ -58,7 +58,7 @@ is disabled in {es} and data is ignored from all other sources.
 . Configure your Logstash nodes to send metrics by setting the
 `xpack.monitoring.elasticsearch.hosts` in `logstash.yml`. If {security} is
 enabled, you also need to specify the credentials for the
-{stack-ov}/built-in-users.html[built-in `logstash_system` user]. For more
+{ref}/built-in-users.html[built-in `logstash_system` user]. For more
 information about these settings, see <<monitoring-settings>>.
 +
 --

--- a/docs/static/monitoring/monitoring-mb.asciidoc
+++ b/docs/static/monitoring/monitoring-mb.asciidoc
@@ -119,7 +119,7 @@ it using HTTPS. For example, use a `hosts` setting like `https://localhost:9600`
 ID and password so that {metricbeat} can collect metrics successfully: 
 
 .. Create a user on the production cluster that has the 
-`remote_monitoring_collector` {stack-ov}/built-in-roles.html[built-in role]. 
+`remote_monitoring_collector` {ref}/built-in-roles.html[built-in role]. 
 
 .. Add the `username` and `password` settings to the module configuration 
 file (`logstash-xpack.yml`).
@@ -180,9 +180,9 @@ must provide a valid user ID and password so that {metricbeat} can send metrics
 successfully: 
 
 .. Create a user on the monitoring cluster that has the 
-`remote_monitoring_agent` {stack-ov}/built-in-roles.html[built-in role]. 
+`remote_monitoring_agent` {ref}/built-in-roles.html[built-in role]. 
 Alternatively, use the `remote_monitoring_user` 
-{stack-ov}/built-in-users.html[built-in user]. 
+{ref}/built-in-users.html[built-in user]. 
 +
 TIP: If you're using index lifecycle management, the remote monitoring user
 requires additional privileges to create and read indices. For more

--- a/docs/static/security/logstash.asciidoc
+++ b/docs/static/security/logstash.asciidoc
@@ -204,7 +204,7 @@ data to a secure cluster, you need to configure the username and password that
 Logstash uses to authenticate for shipping monitoring data.
 
 {security} comes preconfigured with a
-{stack-ov}/built-in-users.html[`logstash_system` built-in user]
+{ref}/built-in-users.html[`logstash_system` built-in user]
 for this purpose. This user has the minimum permissions necessary for the
 monitoring function, and _should not_ be used for any other purpose - it is
 specifically _not intended_ for use within a Logstash pipeline.


### PR DESCRIPTION
This PR updates links to the Stack Overview, in particular for pages that have moved elsewhere.
There are deleted pages and redirects in place, but the links should nonetheless be fixed in the source files in master (and 7.x) branches.