### PR TITLE
validate plugin list output respecting integration plugins

### DIFF
--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/list.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/list.rb
@@ -13,6 +13,9 @@ shared_examples "logstash list" do |logstash|
       logstash.uninstall
     end
 
+    let(:plugin_name) { /logstash-(?<type>\w+)-(?<name>\w+)/ }
+    let(:plugin_name_with_version) { /#{plugin_name}\s\(\d+\.\d+.\d+(.\w+)?\)/ }
+
     context "without a specific plugin" do
       it "display a list of plugins" do
         result = logstash.run_command_in_path("bin/logstash-plugin list")
@@ -26,8 +29,23 @@ shared_examples "logstash list" do |logstash|
 
       it "list the plugins with their versions" do
         result = logstash.run_command_in_path("bin/logstash-plugin list --verbose")
-        result.stdout.split("\n").each do |plugin|
-          expect(plugin).to match(/^logstash-\w+-\w+\s\(\d+\.\d+.\d+(.\w+)?\)/)
+
+        stdout = StringIO.new(result.stdout)
+        while line = stdout.gets
+          expect(line).to match(/^#{plugin_name_with_version}$/)
+
+          # Integration Plugins list their sub-plugins, e.g.,
+          # ~~~
+          # logstash-integration-kafka (10.0.0)
+          # ├── logstash-input-kafka
+          # └── logstash-output-kafka
+          # ~~~
+          if Regexp.last_match[:type] == 'integration'
+            while line = stdout.gets
+              expect(line).to match(/^(?: [├└]── )#{plugin_name}$/)
+              break if line.start_with?(' └')
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
our tests validating the output of `bin/logstash-plugin list --verbose` need to account for the multi-line output of integration plugins.