### PR TITLE
upgrade puma to 4.x

### DIFF
--- a/NOTICE.TXT
+++ b/NOTICE.TXT
@@ -12981,7 +12981,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------
-Library: puma v2.16.0
+Library: puma v4.2.1
 Url: http://puma.io
 License: BSD-3-Clause
 

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "concurrent-ruby", "~> 1"
   gem.add_runtime_dependency "rack", '~> 1', '>= 1.6.11'
   gem.add_runtime_dependency "sinatra", '~> 1', '>= 1.4.6'
-  gem.add_runtime_dependency 'puma', '~> 2'
+  gem.add_runtime_dependency 'puma', '~> 4'
   gem.add_runtime_dependency "jruby-openssl", "~> 0.10" # >= 0.9.13 Required to support TLSv1.2
 
   gem.add_runtime_dependency "treetop", "~> 1" #(MIT license)


### PR DESCRIPTION
we're using quite an old version of Puma (2.x) although ci failures like https://logstash-ci.elastic.co/job/elastic+logstash+7.5+multijob--ruby-unit-tests/7/console may not be solved by in 4.x, it's still desirable to keep this dependency updated.