### PR TITLE
ensure output of plugin list is utf8

### DIFF
--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/list.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/list.rb
@@ -31,6 +31,7 @@ shared_examples "logstash list" do |logstash|
         result = logstash.run_command_in_path("bin/logstash-plugin list --verbose")
 
         stdout = StringIO.new(result.stdout)
+        stdout.set_encoding(Encoding::UTF_8)
         while line = stdout.gets
           expect(line).to match(/^#{plugin_name_with_version}$/)
 


### PR DESCRIPTION
after running pkg installation and starting tests, the encoding maybe ascii instead of utf8. this makes the integration plugin specs fail (see [this example](https://logstash-ci.elastic.co/job/elastic+logstash+7.4+multijob-acceptance/label=metal,suite=debian/10/console)). this pr ensures the output of the plugin list command is utf8

