### PR TITLE
Update elasticsearch gem dependency requirements

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -69,6 +69,6 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "jrjackson", "= #{ALL_VERSIONS.fetch('jrjackson')}" #(Apache 2.0 license)
 
-  gem.add_runtime_dependency "elasticsearch", "~> 5"
+  gem.add_runtime_dependency "elasticsearch", '~> 7'
   gem.add_runtime_dependency "manticore", '~> 0.6'
 end


### PR DESCRIPTION
Currently, the version of the elasticsearch gem bundled with Logstash requires the type
 field to be set, which is incompatible Elasticsearch 8.x after types were removed.