### PR TITLE
[Doc]Remove edit_me link overrides for monitoring topics

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -186,13 +186,11 @@ include::static/deploying.asciidoc[]
 include::static/performance-checklist.asciidoc[]
 
 // Monitoring 
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/monitoring.asciidoc
+:edit_url!:
 include::static/monitoring/monitoring.asciidoc[]
 
 // X-Pack Monitoring 
-
-//:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/monitoring/configuring-logstash.asciidoc
+:edit_url!:
 include::static/monitoring/monitoring-overview.asciidoc[]
 
 


### PR DESCRIPTION
Logstash has traditionally used hard-coded edit_me links to accommodate situations where the source was somewhere other than the target repo and file.  This PR changes the monitoring content to use the default linking behavior for simplicity.