### PR TITLE
Feature/deprecation logger

### DIFF
--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -133,3 +133,29 @@ logger.slowlog.additivity = false
 
 logger.licensereader.name = logstash.licensechecker.licensereader
 logger.licensereader.level = error
+
+# Deprecation log
+appender.deprecation_rolling.type = RollingFile
+appender.deprecation_rolling.name = deprecation_plain_rolling
+appender.deprecation_rolling.fileName = ${sys:ls.logs}/logstash-deprecation.log
+appender.deprecation_rolling.filePattern = ${sys:ls.logs}/logstash-deprecation-%d{yyyy-MM-dd}-%i.log.gz
+appender.deprecation_rolling.policies.type = Policies
+appender.deprecation_rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.deprecation_rolling.policies.time.interval = 1
+appender.deprecation_rolling.policies.time.modulate = true
+appender.deprecation_rolling.layout.type = PatternLayout
+appender.deprecation_rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c]%notEmpty{[%X{pipeline.id}]} %m%n
+appender.deprecation_rolling.policies.size.type = SizeBasedTriggeringPolicy
+appender.deprecation_rolling.policies.size.size = 100MB
+appender.deprecation_rolling.strategy.type = DefaultRolloverStrategy
+appender.deprecation_rolling.strategy.max = 30
+
+logger.deprecation.name = org.logstash.deprecation, deprecation
+logger.deprecation.level = WARN
+logger.deprecation.appenderRef.deprecation_rolling.ref = deprecation_plain_rolling
+logger.deprecation.additivity = false
+
+logger.deprecation_root.name = deprecation
+logger.deprecation_root.level = WARN
+logger.deprecation_root.appenderRef.deprecation_rolling.ref = deprecation_plain_rolling
+logger.deprecation_root.additivity = false

--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -46,6 +46,7 @@ class LogStash::Plugin
 
   def initialize(params=nil)
     @logger = self.logger
+    @deprecation_logger = self.deprecation_logger
     # need to access settings statically because plugins are initialized in config_ast with no context.
     settings = LogStash::SETTINGS
     @slow_logger = self.slow_logger(settings.get("slowlog.threshold.warn"),

--- a/logstash-core/spec/logstash/plugin_spec.rb
+++ b/logstash-core/spec/logstash/plugin_spec.rb
@@ -7,6 +7,15 @@ require "logstash/inputs/base"
 require "logstash/filters/base"
 require "support/shared_contexts"
 
+class CustomFilterDeprecable < LogStash::Filters::Base
+  config_name "simple_plugin"
+    config :host, :validate => :string
+
+    def register
+      @deprecation_logger.deprecated("Deprecated feature {}", "hydrocarbon car")
+    end
+end
+
 describe LogStash::Plugin do
   context "reloadable" do
     context "by default" do
@@ -377,6 +386,22 @@ describe LogStash::Plugin do
     end
   end
 
+  describe "deprecation logger" do
+    let(:config) do
+      {
+        "host" => "127.0.0.1"
+      }
+    end
+
+    context "when a plugin is registered" do
+      subject { CustomFilterDeprecable.new(config) }
+
+      it "deprecation logger is available to be used" do
+        subject.register
+        expect(subject.deprecation_logger).not_to be_nil
+      end
+    end
+  end
 
   context "When the plugin record a metric" do
     let(:config) { {} }

--- a/logstash-core/src/main/java/co/elastic/logstash/api/Context.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/Context.java
@@ -30,6 +30,13 @@ public interface Context {
     Logger getLogger(Plugin plugin);
 
     /**
+     * Provides a {@link Logger} instance to plugins.
+     * @param plugin The plugin for which the logger should be supplied.
+     * @return       The supplied Logger instance.
+     */
+    DeprecationLogger getDeprecationLogger(Plugin plugin);
+
+    /**
      * Provides an {@link EventFactory} to constructs instance of {@link Event}.
      * @return The event factory.
      */

--- a/logstash-core/src/main/java/co/elastic/logstash/api/DeprecationLogger.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/DeprecationLogger.java
@@ -1,0 +1,16 @@
+package co.elastic.logstash.api;
+
+/**
+ * Used to log deprecation notices.
+ * */
+public interface DeprecationLogger {
+
+    /**
+     * Print to deprecation log the message with placeholder replaced by param values. The placeholder
+     * are {} form, like in log4j's syntax.
+     *
+     * @param message string message with parameter's placeholders.
+     * @param params var args with all the replacement parameters.
+     * */
+    void deprecated(String message, Object... params);
+}

--- a/logstash-core/src/main/java/org/logstash/RubyUtil.java
+++ b/logstash-core/src/main/java/org/logstash/RubyUtil.java
@@ -46,6 +46,7 @@ import org.logstash.instrument.metrics.NamespacedMetricExt;
 import org.logstash.instrument.metrics.NullMetricExt;
 import org.logstash.instrument.metrics.NullNamespacedMetricExt;
 import org.logstash.instrument.metrics.SnapshotExt;
+import org.logstash.log.DeprecationLoggerExt;
 import org.logstash.log.LoggableExt;
 import org.logstash.log.LoggerExt;
 import org.logstash.log.SlowLoggerExt;
@@ -176,6 +177,8 @@ public final class RubyUtil {
     public static final RubyClass LOGGER;
 
     public static final RubyModule LOGGABLE_MODULE;
+
+    public static final RubyClass DEPRECATION_LOGGER;
 
     public static final RubyClass SLOW_LOGGER;
 
@@ -446,6 +449,10 @@ public final class RubyUtil {
         SLOW_LOGGER = loggingModule.defineClassUnder(
             "SlowLogger", RUBY.getObject(), SlowLoggerExt::new);
         SLOW_LOGGER.defineAnnotatedMethods(SlowLoggerExt.class);
+        DEPRECATION_LOGGER = loggingModule.defineClassUnder(
+            "DeprecationLogger", RUBY.getObject(), DeprecationLoggerExt::new);
+        DEPRECATION_LOGGER.defineAnnotatedMethods(DeprecationLoggerExt.class);
+
         LOGGABLE_MODULE = UTIL_MODULE.defineModuleUnder("Loggable");
         LOGGABLE_MODULE.defineAnnotatedMethods(LoggableExt.class);
         ABSTRACT_PIPELINE_CLASS =

--- a/logstash-core/src/main/java/org/logstash/log/DefaultDeprecationLogger.java
+++ b/logstash-core/src/main/java/org/logstash/log/DefaultDeprecationLogger.java
@@ -1,0 +1,48 @@
+package org.logstash.log;
+
+import co.elastic.logstash.api.DeprecationLogger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Logger used to output deprecation warnings. It handles specific log4j loggers
+ *
+ * Inspired by ElasticSearch's org.elasticsearch.common.logging.DeprecationLogger
+ * */
+public class DefaultDeprecationLogger implements DeprecationLogger {
+
+    private final Logger logger;
+
+    /**
+     * Creates a new deprecation logger based on the parent logger. Automatically
+     * prefixes the logger name with "deprecation", if it starts with "org.logstash.",
+     * it replaces "org.logstash" with "org.logstash.deprecation" to maintain
+     * the "org.logstash" namespace.
+     *
+     * @param parentLogger parent logger to decorate
+     */
+    public DefaultDeprecationLogger(Logger parentLogger) {
+        String name = parentLogger.getName();
+        name = reworkLoggerName(name);
+        this.logger = LogManager.getLogger(name);
+    }
+
+    DefaultDeprecationLogger(String pluginName) {
+        String name = reworkLoggerName(pluginName);
+        this.logger = LogManager.getLogger(name);
+    }
+
+    private String reworkLoggerName(String name) {
+        if (name.startsWith("org.logstash")) {
+            name = name.replace("org.logstash.", "org.logstash.deprecation.");
+        } else {
+            name = "deprecation." + name;
+        }
+        return name;
+    }
+
+    @Override
+    public void deprecated(String message, Object... params) {
+        logger.warn(message, params);
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/log/DeprecationLoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/DeprecationLoggerExt.java
@@ -1,0 +1,38 @@
+package org.logstash.log;
+
+import co.elastic.logstash.api.DeprecationLogger;
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.RubyObject;
+import org.jruby.anno.JRubyClass;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+@JRubyClass(name = "DeprecationLogger")
+public class DeprecationLoggerExt extends RubyObject {
+
+    private static final long serialVersionUID = 1L;
+
+    private DeprecationLogger logger;
+
+    public DeprecationLoggerExt(final Ruby runtime, final RubyClass metaClass) {
+        super(runtime, metaClass);
+    }
+
+    @JRubyMethod
+    public DeprecationLoggerExt initialize(final ThreadContext context, final IRubyObject loggerName) {
+        logger = new DefaultDeprecationLogger(loggerName.asJavaString());
+        return this;
+    }
+
+    @JRubyMethod(name = "deprecated", required = 1, optional = 1)
+    public IRubyObject rubyDeprecated(final ThreadContext context, final IRubyObject[] args) {
+        if (args.length > 1) {
+            logger.deprecated(args[0].asJavaString(), args[1]);
+        } else {
+            logger.deprecated(args[0].asJavaString());
+        }
+        return this;
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/plugins/ContextImpl.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/ContextImpl.java
@@ -1,15 +1,10 @@
 package org.logstash.plugins;
 
-import co.elastic.logstash.api.Context;
-import co.elastic.logstash.api.DeadLetterQueueWriter;
-import co.elastic.logstash.api.Event;
-import co.elastic.logstash.api.EventFactory;
-import co.elastic.logstash.api.Metric;
-import co.elastic.logstash.api.NamespacedMetric;
-import co.elastic.logstash.api.Plugin;
+import co.elastic.logstash.api.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.logstash.ConvertedMap;
+import org.logstash.log.DefaultDeprecationLogger;
 
 import java.io.Serializable;
 import java.util.Map;
@@ -41,6 +36,11 @@ public class ContextImpl implements Context {
     @Override
     public Logger getLogger(Plugin plugin) {
         return LogManager.getLogger(plugin.getClass());
+    }
+
+    @Override
+    public DeprecationLogger getDeprecationLogger(Plugin plugin) {
+        return new DefaultDeprecationLogger(getLogger(plugin));
     }
 
     @Override

--- a/logstash-core/src/test/java/org/logstash/log/DefaultDeprecationLoggerTest.java
+++ b/logstash-core/src/test/java/org/logstash/log/DefaultDeprecationLoggerTest.java
@@ -1,0 +1,69 @@
+package org.logstash.log;
+
+import org.apache.logging.log4j.LogManager;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.After;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+
+public class DefaultDeprecationLoggerTest {
+
+    private static final String CONFIG = "log4j2-log-deprecation-test.properties";
+    private static SystemPropsSnapshotHelper snapshotHelper = new SystemPropsSnapshotHelper();
+
+    @BeforeClass
+    public static void beforeClass() {
+        snapshotHelper.takeSnapshot("log4j.configurationFile", "ls.log.format", "ls.logs",
+                LogstashConfigurationFactory.PIPELINE_SEPARATE_LOGS);
+        LogTestUtils.reloadLogConfiguration();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        snapshotHelper.restoreSnapshot("log4j.configurationFile", "ls.log.format", "ls.logs",
+                LogstashConfigurationFactory.PIPELINE_SEPARATE_LOGS);
+    }
+
+    @Before
+    public void setUp() throws IOException {
+        System.setProperty("log4j.configurationFile", CONFIG);
+        System.setProperty("ls.log.format", "plain");
+        System.setProperty("ls.logs", "build/logs");
+
+        LogTestUtils.deleteLogFile("logstash-deprecation.log");
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        LogTestUtils.reloadLogConfiguration();
+
+        LogTestUtils.deleteLogFile("logstash-deprecation.log");
+    }
+
+    @Test
+    public void testDeprecationLoggerWriteOut_root() throws IOException {
+        final DefaultDeprecationLogger deprecationLogger = new DefaultDeprecationLogger(LogManager.getLogger("test"));
+
+        // Exercise
+        deprecationLogger.deprecated("Simple deprecation message");
+
+        String logs = LogTestUtils.loadLogFileContent("logstash-deprecation.log");
+        assertTrue("Deprecation logs MUST contains the out line", logs.matches(".*\\[deprecation\\.test.*\\].*Simple deprecation message"));
+    }
+
+    @Test
+    public void testDeprecationLoggerWriteOut_nested() throws IOException {
+        final DefaultDeprecationLogger deprecationLogger = new DefaultDeprecationLogger(LogManager.getLogger("org.logstash.my_nested_logger"));
+
+        // Exercise
+        deprecationLogger.deprecated("Simple deprecation message");
+
+        String logs = LogTestUtils.loadLogFileContent("logstash-deprecation.log");
+        assertTrue("Deprecation logs MUST contains the out line", logs.matches(".*\\[org\\.logstash\\.deprecation\\.my_nested_logger.*\\].*Simple deprecation message"));
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/log/LogTestUtils.java
+++ b/logstash-core/src/test/java/org/logstash/log/LogTestUtils.java
@@ -1,0 +1,34 @@
+package org.logstash.log;
+
+import org.apache.logging.log4j.core.LoggerContext;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertTrue;
+
+class LogTestUtils {
+
+    static String loadLogFileContent(String logfileName) throws IOException {
+        Path path = FileSystems.getDefault()
+                .getPath(System.getProperty("user.dir"), System.getProperty("ls.logs"), logfileName);
+
+        assertTrue("Log [" + path.toString() + "] file MUST exists", Files.exists(path));
+        return Files.lines(path).collect(Collectors.joining());
+    }
+
+    static void reloadLogConfiguration() {
+        LoggerContext context = LoggerContext.getContext(false);
+        context.stop(1, TimeUnit.SECONDS); // this forces the Log4j config to be discarded
+    }
+
+    static void deleteLogFile(String logfileName) throws IOException {
+        Path path = FileSystems.getDefault()
+                .getPath(System.getProperty("user.dir"), System.getProperty("ls.logs"), logfileName);
+        Files.deleteIfExists(path);
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/log/LogstashConfigurationFactoryTest.java
+++ b/logstash-core/src/test/java/org/logstash/log/LogstashConfigurationFactoryTest.java
@@ -13,7 +13,6 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.test.appender.ListAppender;
 import org.junit.*;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -25,39 +24,21 @@ public class LogstashConfigurationFactoryTest {
 
     private static final String CONFIG = "log4j2-log-pipeline-test.properties";
 
-    private static Map<String, String> systemPropertiesDump = new HashMap<>();
     private static Map<String, String> dumpedLog4jThreadContext;
+    private static SystemPropsSnapshotHelper snapshotHelper = new SystemPropsSnapshotHelper();
 
     @BeforeClass
     public static void beforeClass() {
-        dumpSystemProperty("log4j.configurationFile");
-        dumpSystemProperty("ls.log.format");
-        dumpSystemProperty("ls.logs");
-        dumpSystemProperty(LogstashConfigurationFactory.PIPELINE_SEPARATE_LOGS);
-
+        snapshotHelper.takeSnapshot("log4j.configurationFile", "ls.log.format", "ls.logs",
+                LogstashConfigurationFactory.PIPELINE_SEPARATE_LOGS);
         dumpedLog4jThreadContext = ThreadContext.getImmutableContext();
-    }
-
-    private static void dumpSystemProperty(String propertyName) {
-        systemPropertiesDump.put(propertyName, System.getProperty(propertyName));
     }
 
     @AfterClass
     public static void afterClass() {
         ThreadContext.putAll(dumpedLog4jThreadContext);
-
-        restoreSystemProperty("log4j.configurationFile");
-        restoreSystemProperty("ls.log.format");
-        restoreSystemProperty("ls.logs");
-        restoreSystemProperty(LogstashConfigurationFactory.PIPELINE_SEPARATE_LOGS);
-    }
-
-    private static void restoreSystemProperty(String propertyName) {
-        if (systemPropertiesDump.get(propertyName) == null) {
-            System.clearProperty(propertyName);
-        } else {
-            System.setProperty(propertyName, systemPropertiesDump.get(propertyName));
-        }
+        snapshotHelper.restoreSnapshot("log4j.configurationFile", "ls.log.format", "ls.logs",
+                LogstashConfigurationFactory.PIPELINE_SEPARATE_LOGS);
     }
 
     @Before

--- a/logstash-core/src/test/java/org/logstash/log/PluginDeprecationLoggerTest.java
+++ b/logstash-core/src/test/java/org/logstash/log/PluginDeprecationLoggerTest.java
@@ -1,0 +1,61 @@
+package org.logstash.log;
+
+import org.junit.*;
+import org.logstash.Event;
+import org.logstash.plugins.ConfigurationImpl;
+import org.logstash.plugins.ContextImpl;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+
+public class PluginDeprecationLoggerTest {
+
+    private static final String CONFIG = "log4j2-log-deprecation-test.properties";
+    private static SystemPropsSnapshotHelper snapshotHelper = new SystemPropsSnapshotHelper();
+
+    @BeforeClass
+    public static void beforeClass() {
+        snapshotHelper.takeSnapshot("log4j.configurationFile", "ls.log.format", "ls.logs",
+                LogstashConfigurationFactory.PIPELINE_SEPARATE_LOGS);
+        LogTestUtils.reloadLogConfiguration();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        snapshotHelper.restoreSnapshot("log4j.configurationFile", "ls.log.format", "ls.logs",
+                LogstashConfigurationFactory.PIPELINE_SEPARATE_LOGS);
+    }
+
+    @Before
+    public void setUp() throws IOException {
+        System.setProperty("log4j.configurationFile", CONFIG);
+        System.setProperty("ls.log.format", "plain");
+        System.setProperty("ls.logs", "build/logs");
+
+        LogTestUtils.deleteLogFile("logstash-deprecation.log");
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        LogTestUtils.reloadLogConfiguration();
+        LogTestUtils.deleteLogFile("logstash-deprecation.log");
+    }
+
+    @Test
+    public void testJavaPluginUsesDeprecationLogger() throws IOException {
+        Map<String, Object> config = new HashMap<>();
+        TestingDeprecationPlugin sut = new TestingDeprecationPlugin(new ConfigurationImpl(config), new ContextImpl(null, null));
+
+        // Exercise
+        Event evt = new Event(Collections.singletonMap("message", "Spock move me back"));
+        sut.encode(evt, null);
+
+        // Verify
+        String logs = LogTestUtils.loadLogFileContent("logstash-deprecation.log");
+        assertTrue("Deprecation logs MUST contains the out line", logs.matches(".*Deprecated feature teleportation"));
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/log/SystemPropsSnapshotHelper.java
+++ b/logstash-core/src/test/java/org/logstash/log/SystemPropsSnapshotHelper.java
@@ -1,0 +1,36 @@
+package org.logstash.log;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility class to save & restore a specified list of System properties
+ * */
+class SystemPropsSnapshotHelper {
+
+    private final Map<String, String> systemPropertiesDump = new HashMap<>();
+
+    public void takeSnapshot(String... propertyNames) {
+        for (String propertyName : propertyNames) {
+            dumpSystemProperty(propertyName);
+        }
+    }
+
+    public void restoreSnapshot(String... propertyNames) {
+        for (String propertyName : propertyNames) {
+            dumpSystemProperty(propertyName);
+        }
+    }
+
+    private void dumpSystemProperty(String propertyName) {
+        systemPropertiesDump.put(propertyName, System.getProperty(propertyName));
+    }
+
+    private void restoreSystemProperty(String propertyName) {
+        if (systemPropertiesDump.get(propertyName) == null) {
+            System.clearProperty(propertyName);
+        } else {
+            System.setProperty(propertyName, systemPropertiesDump.get(propertyName));
+        }
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/log/TestingDeprecationPlugin.java
+++ b/logstash-core/src/test/java/org/logstash/log/TestingDeprecationPlugin.java
@@ -1,0 +1,56 @@
+package org.logstash.log;
+
+import co.elastic.logstash.api.*;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Consumer;
+
+@LogstashPlugin(name = "java_deprecation_plugin")
+public class TestingDeprecationPlugin implements Codec {
+
+    private final DeprecationLogger deprecationLogger;
+
+    /**
+     * Required constructor.
+     *
+     * @param configuration Logstash Configuration
+     * @param context       Logstash Context
+     */
+    public TestingDeprecationPlugin(final Configuration configuration, final Context context) {
+        deprecationLogger = context.getDeprecationLogger(this);
+    }
+
+    @Override
+    public Collection<PluginConfigSpec<?>> configSchema() {
+        return null;
+    }
+
+    @Override
+    public String getId() {
+        return null;
+    }
+
+    @Override
+    public void decode(ByteBuffer buffer, Consumer<Map<String, Object>> eventConsumer) {
+
+    }
+
+    @Override
+    public void flush(ByteBuffer buffer, Consumer<Map<String, Object>> eventConsumer) {
+
+    }
+
+    @Override
+    public void encode(Event event, OutputStream output) throws IOException {
+        deprecationLogger.deprecated("Deprecated feature {}", "teleportation");
+    }
+
+    @Override
+    public Codec cloneCodec() {
+        return null;
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/plugins/TestContext.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/TestContext.java
@@ -1,10 +1,6 @@
 package org.logstash.plugins;
 
-import co.elastic.logstash.api.Context;
-import co.elastic.logstash.api.DeadLetterQueueWriter;
-import co.elastic.logstash.api.EventFactory;
-import co.elastic.logstash.api.NamespacedMetric;
-import co.elastic.logstash.api.Plugin;
+import co.elastic.logstash.api.*;
 import org.apache.logging.log4j.Logger;
 
 public class TestContext implements Context {
@@ -21,6 +17,11 @@ public class TestContext implements Context {
 
     @Override
     public Logger getLogger(Plugin plugin) {
+        return null;
+    }
+
+    @Override
+    public DeprecationLogger getDeprecationLogger(Plugin plugin) {
         return null;
     }
 

--- a/logstash-core/src/test/resources/log4j2-log-deprecation-test.properties
+++ b/logstash-core/src/test/resources/log4j2-log-deprecation-test.properties
@@ -1,0 +1,28 @@
+status = error
+name = LogstashPropertiesConfig
+
+# Deprecation log
+appender.deprecation_rolling.type = RollingFile
+appender.deprecation_rolling.name = deprecation_plain_rolling
+appender.deprecation_rolling.fileName = ${sys:ls.logs}/logstash-deprecation.log
+appender.deprecation_rolling.filePattern = ${sys:ls.logs}/logstash-deprecation-%d{yyyy-MM-dd}-%i.log.gz
+appender.deprecation_rolling.policies.type = Policies
+appender.deprecation_rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.deprecation_rolling.policies.time.interval = 1
+appender.deprecation_rolling.policies.time.modulate = true
+appender.deprecation_rolling.layout.type = PatternLayout
+appender.deprecation_rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c]%notEmpty{[%X{pipeline.id}]} %m%n
+appender.deprecation_rolling.policies.size.type = SizeBasedTriggeringPolicy
+appender.deprecation_rolling.policies.size.size = 100MB
+appender.deprecation_rolling.strategy.type = DefaultRolloverStrategy
+appender.deprecation_rolling.strategy.max = 30
+
+logger.deprecation.name = org.logstash.deprecation
+logger.deprecation.level = WARN
+logger.deprecation.appenderRef.deprecation_rolling.ref = deprecation_plain_rolling
+logger.deprecation.additivity = false
+
+logger.deprecation_root.name = deprecation
+logger.deprecation_root.level = WARN
+logger.deprecation_root.appenderRef.deprecation_rolling.ref = deprecation_plain_rolling
+logger.deprecation_root.additivity = false

--- a/qa/integration/fixtures/deprecation_log_spec.yml
+++ b/qa/integration/fixtures/deprecation_log_spec.yml
@@ -1,0 +1,17 @@
+---
+services:
+  - logstash
+config: |-
+ input {
+    generator {
+      count => 4
+    }
+ }
+ filter {
+  ruby {
+    code => '@deprecation_logger.deprecated "Teleport"'
+  }
+ }
+ output {
+   null {}
+ }

--- a/qa/integration/specs/deprecation_log_spec.rb
+++ b/qa/integration/specs/deprecation_log_spec.rb
@@ -1,0 +1,59 @@
+require_relative '../framework/fixture'
+require_relative '../framework/settings'
+require_relative '../services/logstash_service'
+require_relative '../framework/helpers'
+require "logstash/devutils/rspec/spec_helper"
+require "yaml"
+
+describe "Test Logstash Pipeline id" do
+  before(:all) {
+    @fixture = Fixture.new(__FILE__)
+    # used in multiple LS tests
+    @ls = @fixture.get_service("logstash")
+  }
+
+  after(:all) {
+    @fixture.teardown
+  }
+
+  before(:each) {
+    # backup the application settings file -- logstash.yml
+    FileUtils.cp(@ls.application_settings_file, "#{@ls.application_settings_file}.original")
+  }
+
+  after(:each) {
+    @ls.teardown
+    # restore the application settings file -- logstash.yml
+    FileUtils.mv("#{@ls.application_settings_file}.original", @ls.application_settings_file)
+  }
+
+  let(:temp_dir) { Stud::Temporary.directory("logstash-pipelinelog-test") }
+  let(:config) { @fixture.config("root") }
+  let(:initial_config_file) { config_to_temp_file(@fixture.config("root")) }
+
+  it "should not create separate pipelines log files if not enabled" do
+    pipeline_name = "custom_pipeline"
+    settings = {
+      "path.logs" => temp_dir,
+      "pipeline.id" => pipeline_name,
+      "pipeline.separate_logs" => false
+    }
+    IO.write(@ls.application_settings_file, settings.to_yaml)
+    @ls.spawn_logstash("-w", "1" , "-e", config)
+    wait_logstash_process_terminate
+
+    deprecation_log_file = "#{temp_dir}/logstash-deprecation.log"
+    expect(File.exists?(deprecation_log_file)).to be true
+    deprecation_log_content = IO.read(deprecation_log_file)
+    expect(deprecation_log_content =~ /\[deprecation.logstash.filters.ruby\].*Teleport/).to be > 0
+  end
+
+  @private
+  def wait_logstash_process_terminate
+    num_retries = 100
+    try(num_retries) do
+      expect(@ls.exited?).to be(true)
+    end
+    expect(@ls.exit_code).to be >= 0
+  end
+end

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -126,10 +126,13 @@ describe "Test Monitoring API" do
       logging_put_assert logstash_service.monitoring_api.logging_put({"logger.logstash" => "ERROR"})
       logging_put_assert logstash_service.monitoring_api.logging_put({"logger.slowlog" => "ERROR"})
 
+      #deprecation package loggers
+      logging_put_assert logstash_service.monitoring_api.logging_put({"logger.deprecation.logstash" => "ERROR"})
+
       result = logstash_service.monitoring_api.logging_get
       result["loggers"].each do | k, v |
         #since we explicitly set the logstash.agent logger above, the logger.logstash parent logger will not take precedence
-        if !k.eql?("logstash.agent") && (k.start_with?("logstash") || k.start_with?("slowlog"))
+        if !k.eql?("logstash.agent") && (k.start_with?("logstash") || k.start_with?("slowlog") || k.start_with?("deprecation"))
           expect(v).to eq("ERROR")
         else
           expect(v).to eq("INFO")


### PR DESCRIPTION
Related to issue #11049

This PR introduce the DeprecationLogger to internal classes and to Plugins, usable to write deprecation notices to a separate log file, so that could be easily identified and fixed.