### PR TITLE
dont mutate SETTINGS object in keystore specs

### DIFF
--- a/logstash-core/spec/logstash/util/secretstore_spec.rb
+++ b/logstash-core/spec/logstash/util/secretstore_spec.rb
@@ -5,31 +5,32 @@ java_import "org.logstash.secret.store.SecretStoreExt"
 describe SecretStoreExt do
 
   subject {SecretStoreExt}
+  let(:settings) { LogStash::SETTINGS.clone }
 
   describe "with missing keystore" do
     before :each do
-      LogStash::SETTINGS.set("keystore.file", File.join(File.dirname(__FILE__), "nothing_here"))
+      settings.set("keystore.file", File.join(File.dirname(__FILE__), "nothing_here"))
     end
 
     it "should be not exist" do
-      expect(subject.exists(LogStash::SETTINGS.get_setting("keystore.file").value, LogStash::SETTINGS.get_setting("keystore.classname").value)).to be_falsey
-      expect(subject.getIfExists(LogStash::SETTINGS.get_setting("keystore.file").value, LogStash::SETTINGS.get_setting("keystore.classname").value)).to be_nil
+      expect(subject.exists(settings.get_setting("keystore.file").value, settings.get_setting("keystore.classname").value)).to be_falsey
+      expect(subject.getIfExists(settings.get_setting("keystore.file").value, settings.get_setting("keystore.classname").value)).to be_nil
     end
   end
 
   describe "with implicit password keystore" do
     before :each do
-      LogStash::SETTINGS.set("keystore.file", File.join(File.dirname(__FILE__), "../../../src/test/resources/logstash.keystore.with.default.pass"))
+      settings.set("keystore.file", File.join(File.dirname(__FILE__), "../../../src/test/resources/logstash.keystore.with.default.pass"))
     end
 
     it "should be readable" do
-      expect(subject.getIfExists(LogStash::SETTINGS.get_setting("keystore.file").value, LogStash::SETTINGS.get_setting("keystore.classname").value).list).to include(subject.get_store_id("keystore.seed"))
+      expect(subject.getIfExists(settings.get_setting("keystore.file").value, settings.get_setting("keystore.classname").value).list).to include(subject.get_store_id("keystore.seed"))
     end
   end
 
   describe "with explicit password keystore" do
     before :each do
-      LogStash::SETTINGS.set("keystore.file", File.join(File.dirname(__FILE__), "../../../src/test/resources/logstash.keystore.with.defined.pass"))
+      settings.set("keystore.file", File.join(File.dirname(__FILE__), "../../../src/test/resources/logstash.keystore.with.defined.pass"))
     end
 
     describe "and correct password" do
@@ -42,7 +43,7 @@ describe SecretStoreExt do
       end
 
       it "should be readable" do
-        expect(subject.getIfExists(LogStash::SETTINGS.get_setting("keystore.file").value, LogStash::SETTINGS.get_setting("keystore.classname").value).list).to include(subject.get_store_id("keystore.seed"))
+        expect(subject.getIfExists(settings.get_setting("keystore.file").value, settings.get_setting("keystore.classname").value).list).to include(subject.get_store_id("keystore.seed"))
       end
     end
 
@@ -56,13 +57,13 @@ describe SecretStoreExt do
       end
 
       it "should be not readable" do
-        expect {subject.getIfExists(LogStash::SETTINGS.get_setting("keystore.file").value, LogStash::SETTINGS.get_setting("keystore.classname").value)}.to raise_error.with_message(/Can not access Logstash keystore/)
+        expect {subject.getIfExists(settings.get_setting("keystore.file").value, settings.get_setting("keystore.classname").value)}.to raise_error.with_message(/Can not access Logstash keystore/)
       end
     end
 
     describe "and missing password" do
       it "should be not readable" do
-        expect {subject.getIfExists(LogStash::SETTINGS.get_setting("keystore.file").value, LogStash::SETTINGS.get_setting("keystore.classname").value)}.to raise_error.with_message(/Could not determine keystore password/)
+        expect {subject.getIfExists(settings.get_setting("keystore.file").value, settings.get_setting("keystore.classname").value)}.to raise_error.with_message(/Could not determine keystore password/)
       end
     end
   end


### PR DESCRIPTION
fixes tests failures such as https://logstash-ci.elastic.co/job/elastic+logstash+7.4+multijob--ruby-unit-tests/38/console