### PR TITLE
don't rely on expect match and last_match in qa test

### DIFF
--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/list.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/list.rb
@@ -33,7 +33,8 @@ shared_examples "logstash list" do |logstash|
         stdout = StringIO.new(result.stdout)
         stdout.set_encoding(Encoding::UTF_8)
         while line = stdout.gets
-          expect(line).to match(/^#{plugin_name_with_version}$/)
+          match = line.match(/^#{plugin_name_with_version}$/)
+          expect(match).to_not be_nil
 
           # Integration Plugins list their sub-plugins, e.g.,
           # ~~~
@@ -41,9 +42,10 @@ shared_examples "logstash list" do |logstash|
           # ├── logstash-input-kafka
           # └── logstash-output-kafka
           # ~~~
-          if Regexp.last_match[:type] == 'integration'
+          if match[:type] == 'integration'
             while line = stdout.gets
-              expect(line).to match(/^(?: [├└]── )#{plugin_name}$/)
+              match = line.match(/^(?: [├└]── )#{plugin_name}$/)
+              expect(match).to_not be_nil
               break if line.start_with?(' └')
             end
           end


### PR DESCRIPTION
for some reason the match expect and last_match aren't playing well together, this pr uses plain String#match instead.

See example CI failures:
- https://logstash-ci.elastic.co/job/elastic+logstash+7.5+multijob-acceptance/label=metal,suite=redhat/5/console
- https://logstash-ci.elastic.co/job/elastic+logstash+7.4+multijob-acceptance/label=metal,suite=debian/11/console
- https://logstash-ci.elastic.co/job/elastic+logstash+master+multijob-acceptance/label=metal,suite=debian/35/console