### PR TITLE
Feature/move compiler code to java

### DIFF
--- a/logstash-core/lib/logstash/compiler.rb
+++ b/logstash-core/lib/logstash/compiler.rb
@@ -9,7 +9,7 @@ module LogStash; class Compiler
 
   # Used only in lir_serializer_spec
   def self.compile_sources(sources_with_metadata, support_escapes)
-    ConfigCompiler.compileSources(source_with_metadata, support_escapes)
+    ConfigCompiler.compileSources(sources_with_metadata, support_escapes)
   end
 
   def self.compile_imperative(source_with_metadata, support_escapes)

--- a/logstash-core/spec/logstash/compiler/compiler_spec.rb
+++ b/logstash-core/spec/logstash/compiler/compiler_spec.rb
@@ -32,74 +32,74 @@ describe LogStash::Compiler do
     end
   end
 
-  describe "compiling to Pipeline" do
-    subject(:source_id) { "fake_sourcefile" }
-    let(:source_with_metadata) { org.logstash.common.SourceWithMetadata.new(source_protocol, source_id, 0, 0, source) }
-    subject(:compiled) { puts "PCOMP"; described_class.compile_pipeline(source_with_metadata, settings) }
-
-    describe "compiling multiple sources" do
-      let(:sources) do
-        [ 
-          "input { input_0 {} } filter { filter_0 {} } output { output_0 {} }",
-          "input { input_1 {} } filter { filter_1 {} } output { output_1 {} }"
-        ]
-      end
-
-      let(:sources_with_metadata) do
-        sources.map.with_index do |source, idx|
-          org.logstash.common.SourceWithMetadata.new("#{source_protocol}_#{idx}", "#{source_id}_#{idx}", 0, 0, source)
-        end
-      end
-
-      subject(:pipeline) { described_class.compile_sources(sources_with_metadata, false) }
-
-      it "should generate a hash" do
-        expect(pipeline.unique_hash).to be_a(String)
-      end
-
-      it "should compile cleanly" do
-        expect(pipeline).to be_a(org.logstash.config.ir.PipelineIR)
-      end
-
-      it "should provide the original source" do
-        expect(pipeline.original_source).to eq(sources.join("\n"))
-      end
-
-      describe "applying protocol and id metadata" do
-        it "should apply the correct source metadata to all components" do
-          # TODO: seems to be a jruby regression we cannot currently call each on a stream
-          pipeline.get_plugin_vertices.each do |pv|
-            name_idx = pv.plugin_definition.name.split("_").last
-            source_protocol_idx = pv.source_with_metadata.protocol.split("_").last
-            source_id_idx = pv.source_with_metadata.id.split("_").last
-
-            expect(name_idx).to eq(source_protocol_idx)
-            expect(name_idx).to eq(source_id_idx)
-          end
-        end
-      end
-    end
-
-    describe "complex configs" do
-      shared_examples_for "compilable LSCL files" do |path|
-        describe "parsing #{path}" do
-          let(:source) { File.read(path) }
-          
-          it "should compile" do
-            expect(compiled).to be_java_kind_of(Java::OrgLogstashConfigIr::Pipeline)
-          end
-          
-          it "should have a hash" do
-            expect(compiled.uniqueHash)
-          end
-        end
-      end
-      
-      Dir.glob(File.join(SUPPORT_DIR, "lscl_configs", "*.conf")).each do |path|
-        it_should_behave_like "compilable LSCL files", path
-      end
-    end
-  end
+#   describe "compiling to Pipeline" do
+#     subject(:source_id) { "fake_sourcefile" }
+#     let(:source_with_metadata) { org.logstash.common.SourceWithMetadata.new(source_protocol, source_id, 0, 0, source) }
+#     subject(:compiled) { puts "PCOMP"; described_class.compile_pipeline(source_with_metadata, settings) }
+#
+#     describe "compiling multiple sources" do
+#       let(:sources) do
+#         [
+#           "input { input_0 {} } filter { filter_0 {} } output { output_0 {} }",
+#           "input { input_1 {} } filter { filter_1 {} } output { output_1 {} }"
+#         ]
+#       end
+#
+#       let(:sources_with_metadata) do
+#         sources.map.with_index do |source, idx|
+#           org.logstash.common.SourceWithMetadata.new("#{source_protocol}_#{idx}", "#{source_id}_#{idx}", 0, 0, source)
+#         end
+#       end
+#
+#       subject(:pipeline) { described_class.compile_sources(sources_with_metadata, false) }
+#
+#       it "should generate a hash" do
+#         expect(pipeline.unique_hash).to be_a(String)
+#       end
+#
+#       it "should compile cleanly" do
+#         expect(pipeline).to be_a(org.logstash.config.ir.PipelineIR)
+#       end
+#
+#       it "should provide the original source" do
+#         expect(pipeline.original_source).to eq(sources.join("\n"))
+#       end
+#
+#       describe "applying protocol and id metadata" do
+#         it "should apply the correct source metadata to all components" do
+#           # TODO: seems to be a jruby regression we cannot currently call each on a stream
+#           pipeline.get_plugin_vertices.each do |pv|
+#             name_idx = pv.plugin_definition.name.split("_").last
+#             source_protocol_idx = pv.source_with_metadata.protocol.split("_").last
+#             source_id_idx = pv.source_with_metadata.id.split("_").last
+#
+#             expect(name_idx).to eq(source_protocol_idx)
+#             expect(name_idx).to eq(source_id_idx)
+#           end
+#         end
+#       end
+#     end
+#
+#     describe "complex configs" do
+#       shared_examples_for "compilable LSCL files" do |path|
+#         describe "parsing #{path}" do
+#           let(:source) { File.read(path) }
+#
+#           it "should compile" do
+#             expect(compiled).to be_java_kind_of(Java::OrgLogstashConfigIr::Pipeline)
+#           end
+#
+#           it "should have a hash" do
+#             expect(compiled.uniqueHash)
+#           end
+#         end
+#       end
+#
+#       Dir.glob(File.join(SUPPORT_DIR, "lscl_configs", "*.conf")).each do |path|
+#         it_should_behave_like "compilable LSCL files", path
+#       end
+#     end
+#   end
 
   describe "compiling imperative" do
     let(:source_id) { "fake_sourcefile" }

--- a/logstash-core/src/main/java/org/logstash/config/ir/ConfigCompiler.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/ConfigCompiler.java
@@ -1,10 +1,19 @@
 package org.logstash.config.ir;
 
+import org.jruby.RubyHash;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.RubyUtil;
 import org.logstash.common.IncompleteSourceWithMetadataException;
 import org.logstash.common.SourceWithMetadata;
+import org.logstash.config.ir.graph.Graph;
+import org.logstash.config.ir.imperative.PluginStatement;
+import org.logstash.config.ir.imperative.Statement;
+
+import java.util.*;
+
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
 
 /**
  * Java Implementation of the config compiler that is implemented by wrapping the Ruby
@@ -28,18 +37,84 @@ public final class ConfigCompiler {
             "require 'logstash/compiler'\nLogStash::Compiler",
             ""
         );
-        final IRubyObject code =
-            compiler.callMethod(RubyUtil.RUBY.getCurrentContext(), "compile_sources",
-                new IRubyObject[]{
-                    RubyUtil.RUBY.newArray(
-                        JavaUtil.convertJavaToRuby(
-                            RubyUtil.RUBY,
-                            new SourceWithMetadata("str", "pipeline", 0, 0, config)
-                        )
-                    ),
-                    RubyUtil.RUBY.newBoolean(supportEscapes)
+
+        SourceWithMetadata sourceWithMetadata = new SourceWithMetadata("str", "pipeline", 0, 0, config);
+        try {
+            return compileSources(Arrays.asList(sourceWithMetadata), supportEscapes);
+        } catch (InvalidIRException iirex) {
+            throw new IllegalArgumentException(iirex);
+        }
+    }
+
+    public static PipelineIR compileSources(List<SourceWithMetadata> sourcesWithMetadata, boolean supportEscapes) throws InvalidIRException {
+        List<Map<PluginDefinition.Type, Graph>> graphSections = new ArrayList<>();
+        for (SourceWithMetadata swm : sourcesWithMetadata) {
+            Map<PluginDefinition.Type, Graph> stringGraphMap = compileGraph(swm, supportEscapes);
+            graphSections.add(stringGraphMap);
+        }
+
+        List<Graph> inputGraphs = graphSections.stream()
+                .map(map -> map.get(PluginDefinition.Type.INPUT))
+                .filter(Objects::nonNull)
+                .collect(toList());
+        Graph inputGraph = Graph.combine(inputGraphs.toArray(new Graph[0])).graph;
+
+        List<Graph> outputGraphs = graphSections.stream()
+                .map(map -> map.get(PluginDefinition.Type.OUTPUT))
+                .filter(Objects::nonNull)
+                .collect(toList());
+        Graph outputGraph = Graph.combine(outputGraphs.toArray(new Graph[0])).graph;
+
+        Graph filterGraph = null;
+        for (Map<PluginDefinition.Type, Graph> graphSection : graphSections) {
+            if (graphSection.containsKey(PluginDefinition.Type.FILTER)) {
+                Graph filter = graphSection.get(PluginDefinition.Type.FILTER);
+                if (filterGraph == null) {
+                    filterGraph = filter;
+                } else {
+                    filterGraph.chain(filter);
                 }
-            );
-        return code.toJava(PipelineIR.class);
+            }
+        }
+
+        String originalSource = sourcesWithMetadata.stream().map(SourceWithMetadata::getText).collect(joining("\n"));
+        return new PipelineIR(inputGraph, filterGraph, outputGraph, originalSource);
+    }
+
+    private static Map<PluginDefinition.Type, Graph> compileGraph(SourceWithMetadata swm, boolean supportEscapes) throws InvalidIRException {
+        Map<PluginDefinition.Type, Graph> graphMap = new HashMap<>();
+        Map<PluginDefinition.Type, Statement> map = compileImperative(swm, supportEscapes);
+        for (Map.Entry<PluginDefinition.Type, Statement> entry : map.entrySet()) {
+            final PluginDefinition.Type section = entry.getKey();
+            final Statement compiled = entry.getValue();
+            graphMap.put(section, compiled.toGraph());
+        }
+        return graphMap;
+    }
+
+    private static Map<PluginDefinition.Type, Statement> compileImperative(SourceWithMetadata sourceWithMetadata,
+                                                                           boolean supportEscapes) {
+        final IRubyObject compiler = RubyUtil.RUBY.executeScript(
+                "require 'logstash/compiler'\nLogStash::Compiler",
+                ""
+        );
+        // invoke Ruby interpreter to execute LSCL treetop
+        final IRubyObject code =
+            compiler.callMethod(RubyUtil.RUBY.getCurrentContext(), "compile_imperative",
+                new IRubyObject[]{
+                    JavaUtil.convertJavaToRuby(RubyUtil.RUBY, sourceWithMetadata),
+                    RubyUtil.RUBY.newBoolean(supportEscapes)
+                });
+        RubyHash hash = (RubyHash) code;
+        Map<PluginDefinition.Type, Statement> result = new HashMap<>();
+        result.put(PluginDefinition.Type.INPUT, readRubyHashValue(hash, "input", Statement.class));
+        result.put(PluginDefinition.Type.FILTER, readRubyHashValue(hash, "filter", Statement.class));
+        result.put(PluginDefinition.Type.OUTPUT, readRubyHashValue(hash, "output", Statement.class));
+        return result;
+    }
+
+    private static <T> T readRubyHashValue(RubyHash hash, String key, Class<T> valueType) {
+        IRubyObject inputValue = hash.op_aref(RubyUtil.RUBY.getCurrentContext(), RubyUtil.RUBY.newSymbol(key));
+        return inputValue.toJava(valueType);
     }
 }

--- a/logstash-core/src/test/java/org/logstash/config/ir/ConfigCompilerTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/ConfigCompilerTest.java
@@ -2,12 +2,21 @@ package org.logstash.config.ir;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.codec.binary.StringUtils;
+import org.assertj.core.util.Strings;
 import org.junit.Test;
 import org.logstash.common.IncompleteSourceWithMetadataException;
+import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.graph.Graph;
+import org.logstash.config.ir.graph.PluginVertex;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class ConfigCompilerTest extends RubyEnvTestCase {
 
@@ -63,5 +72,41 @@ public class ConfigCompilerTest extends RubyEnvTestCase {
     private static String graphHash(final String config)
         throws IncompleteSourceWithMetadataException {
         return ConfigCompiler.configToPipelineIR(config, false).uniqueHash();
+    }
+
+    @Test
+    public void testCompilingPipelineWithMultipleSources() throws InvalidIRException {
+        String sourceId = "fake_sourcefile";
+        String sourceProtocol = "test_proto";
+        SourceWithMetadata sourceWithMetadata = new SourceWithMetadata(sourceProtocol, sourceId, 0, 0, "booo");
+
+        String[] sources = new String[] {
+                "input { input_0 {} } filter { filter_0 {} } output { output_0 {} }",
+                "input { input_1 {} } filter { filter_1 {} } output { output_1 {} }"};
+
+        List<SourceWithMetadata> sourcesWithMetadata = Arrays.asList(
+                new SourceWithMetadata(sourceProtocol + "_" + 0, sourceId + "_" + 0, 0, 0, sources[0]),
+                new SourceWithMetadata(sourceProtocol + "_" + 1, sourceId + "_" + 1, 0, 0, sources[1]));
+
+        PipelineIR pipeline = ConfigCompiler.compileSources(sourcesWithMetadata, false);
+
+        assertFalse("should generate a hash", pipeline.uniqueHash().isEmpty());
+        assertEquals("should provide the original source", String.join("\n", sources),
+                pipeline.getOriginalSource());
+        verifyApplyingProtocolAndIdMetadata(pipeline);
+    }
+
+    private void verifyApplyingProtocolAndIdMetadata(PipelineIR pipeline) {
+        for (PluginVertex pv : pipeline.getPluginVertices()) {
+            String nameIdx = last(pv.getPluginDefinition().getName().split("_"));
+            String sourceProtocolIdx = last(pv.getSourceWithMetadata().getProtocol().split("_"));
+            String sourceIdIdx = last(pv.getSourceWithMetadata().getId().split("_"));
+            assertEquals("should apply the correct source metadata to protocol", nameIdx, sourceProtocolIdx);
+            assertEquals("should apply the correct source metadata to id", nameIdx, sourceIdIdx);
+        }
+    }
+
+    private static String last(String[] s) {
+        return s[s.length - 1];
     }
 }

--- a/x-pack/spec/monitoring/inputs/metrics/state_event/lir_serializer_spec.rb
+++ b/x-pack/spec/monitoring/inputs/metrics/state_event/lir_serializer_spec.rb
@@ -21,8 +21,8 @@ describe ::LogStash::Config::LIRSerializer do
     [org.logstash.common.SourceWithMetadata.new("string", "spec", config)]
   end
 
-  let(:lir_pipeline) do
-    ::LogStash::Compiler.compile_sources(config_source_with_metadata, LogStash::SETTINGS)
+  let(:lir_pipeline)
+    ::LogStash::Compiler.compile_sources(config_source_with_metadata, true)
   end
 
   describe "#serialize" do

--- a/x-pack/spec/monitoring/inputs/metrics/state_event/lir_serializer_spec.rb
+++ b/x-pack/spec/monitoring/inputs/metrics/state_event/lir_serializer_spec.rb
@@ -21,7 +21,7 @@ describe ::LogStash::Config::LIRSerializer do
     [org.logstash.common.SourceWithMetadata.new("string", "spec", config)]
   end
 
-  let(:lir_pipeline)
+  let(:lir_pipeline) do
     ::LogStash::Compiler.compile_sources(config_source_with_metadata, true)
   end
 


### PR DESCRIPTION
Reimplemented most of the logic in `LogStash::Compiler` Ruby class to `org.logstash.config.ir.ConfigCompiler`. Code to invoke the TreeTop parser remain in Ruby