### PR TITLE
Mention the path of DLQ to indicate DLQ if full for which pipeline

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -131,7 +131,7 @@ public final class DeadLetterQueueWriter implements Closeable {
         byte[] record = entry.serialize();
         int eventPayloadSize = RECORD_HEADER_SIZE + record.length;
         if (currentQueueSize.longValue() + eventPayloadSize > maxQueueSize) {
-            logger.error("cannot write event to DLQ: reached maxQueueSize of " + maxQueueSize);
+            logger.error("cannot write event to DLQ(path: " + this.queuePath + "): reached maxQueueSize of " + maxQueueSize);
             return;
         } else if (currentWriter.getPosition() + eventPayloadSize > maxSegmentSize) {
             currentWriter.close();


### PR DESCRIPTION
A series of messages of the following form do not indicate DLQ for which pipeline is full.
`[2019-10-30T11:53:33,801][ERROR][org.logstash.common.io.DeadLetterQueueWriter] cannot write event to DLQ: reached maxQueueSize of 1073741824`

So, it is probably better to let the user know the path of the DLQ file so that the user can:
1. know which pipeline is affected
2. clear the DLQ files manually if appropriate