### PR TITLE
update jruby to 9.2.9.0

### DIFF
--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -6,7 +6,7 @@ buildscript {
     dependencies {
         classpath 'org.yaml:snakeyaml:1.23'
         classpath "de.undercouch:gradle-download-task:3.2.0"
-        classpath "org.jruby:jruby-complete:9.2.8.0"
+        classpath "org.jruby:jruby-complete:9.2.9.0"
     }
 }
 

--- a/versions.yml
+++ b/versions.yml
@@ -7,8 +7,8 @@ logstash-core-plugin-api: 2.1.16
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time
 jruby:
-  version: 9.2.8.0
-  sha1: 5b0b73b3d696afaeac92e6f8879dedcc63ac39d8
+  version: 9.2.9.0
+  sha1: 39ef88eb5e7319402b15c048f638f26e2b9c4f4c
 
 # jruby-runtime-override, if specified, will override the jruby version installed in vendor/jruby for logstash runtime only,
 # not for the compile-time jars


### PR DESCRIPTION
Release notes: https://www.jruby.org/2019/10/30/jruby-9-2-9-0.html