### PR TITLE
Update to include verification mode switch

### DIFF
--- a/docs/static/settings/monitoring-settings.asciidoc
+++ b/docs/static/settings/monitoring-settings.asciidoc
@@ -80,3 +80,7 @@ the client’s certificate.
 `xpack.monitoring.elasticsearch.ssl.keystore.password`::
 
 Optional settings that provide the password to the keystore.
+
+`xpack.monitoring.elasticsearch.ssl.verification_mode`::
+
+Option to validate the server’s certificate. Defaults to `certificate`. To disable, set to `none`. Disabling this severely compromises security.


### PR DESCRIPTION
As of 6.4.1 (https://www.elastic.co/guide/en/logstash/6.4/logstash-6-4-1.html#logstash-6-4-1 and https://github.com/elastic/support-dev-help/issues/4770), we allow setting the monitoring and management ssl verification to either certificate or none, with certificate being the default.