### PR TITLE
Update to include mgmt verification mode switch

### DIFF
--- a/docs/static/settings/configuration-management-settings.asciidoc
+++ b/docs/static/settings/configuration-management-settings.asciidoc
@@ -78,3 +78,7 @@ the client’s certificate.
 `xpack.management.elasticsearch.ssl.keystore.password`::
 
 Optional setting that provides the password to the keystore.
+
+`xpack.management.elasticsearch.ssl.verification_mode`::
+
+Option to validate the server’s certificate. Defaults to `certificate`. To disable, set to `none`. Disabling this severely compromises security.


### PR DESCRIPTION
As of 6.4.1 (https://www.elastic.co/guide/en/logstash/6.4/logstash-6-4-1.html#logstash-6-4-1 and https://github.com/elastic/support-dev-help/issues/4770), we allow setting the monitoring and management ssl verification to either certificate or none, with certificate being the default.