### PR TITLE
Java pipeline part of PR #11155

### DIFF
--- a/logstash-core/lib/logstash/compiler.rb
+++ b/logstash-core/lib/logstash/compiler.rb
@@ -7,7 +7,7 @@ module LogStash; class Compiler
   include ::LogStash::Util::Loggable
 
   def self.compile_sources(pipeline_config, support_escapes)
-   sources_with_metadata = [org.logstash.common.SourceWithMetadata.new("str", "pipeline", 0, 0, pipeline_config.config_string)]
+    sources_with_metadata = [org.logstash.common.SourceWithMetadata.new("str", "pipeline", 0, 0, pipeline_config.config_string)]
     graph_sections = sources_with_metadata.map do |swm|
       self.compile_graph(pipeline_config, swm, support_escapes)
     end

--- a/logstash-core/lib/logstash/compiler.rb
+++ b/logstash-core/lib/logstash/compiler.rb
@@ -6,9 +6,10 @@ java_import org.logstash.config.ir.graph.Graph
 module LogStash; class Compiler
   include ::LogStash::Util::Loggable
 
-  def self.compile_sources(sources_with_metadata, support_escapes)
+  def self.compile_sources(pipeline_config, support_escapes)
+   sources_with_metadata = [org.logstash.common.SourceWithMetadata.new("str", "pipeline", 0, 0, pipeline_config.config_string)]
     graph_sections = sources_with_metadata.map do |swm|
-      self.compile_graph(swm, support_escapes)
+      self.compile_graph(pipeline_config, swm, support_escapes)
     end
 
     input_graph = Graph.combine(*graph_sections.map {|s| s[:input] }).graph
@@ -29,7 +30,7 @@ module LogStash; class Compiler
     PipelineIR.new(input_graph, filter_graph, output_graph, original_source)
   end
 
-  def self.compile_imperative(source_with_metadata, support_escapes)
+  def self.compile_imperative(pipeline_config, source_with_metadata, support_escapes)
     if !source_with_metadata.is_a?(org.logstash.common.SourceWithMetadata)
       raise ArgumentError, "Expected 'org.logstash.common.SourceWithMetadata', got #{source_with_metadata.class}"
     end
@@ -41,11 +42,23 @@ module LogStash; class Compiler
       raise ConfigurationError, grammar.failure_reason
     end
 
+    plugins = config.recursive_select(LogStashCompilerLSCLGrammar::LogStash::Compiler::LSCL::AST::Plugin)
+    added_source_line_column(pipeline_config, plugins)
+
     config.process_escape_sequences = support_escapes
     config.compile(source_with_metadata)
   end
 
-  def self.compile_graph(source_with_metadata, support_escapes)
-    Hash[compile_imperative(source_with_metadata, support_escapes).map {|section,icompiled| [section, icompiled.toGraph]}]
+  def self.compile_graph(pipeline_config, source_with_metadata, support_escapes)
+    Hash[compile_imperative(pipeline_config, source_with_metadata, support_escapes).map {|section,icompiled| [section, icompiled.toGraph]}]
   end
+
+  def self.added_source_line_column(pipeline_config, plugins)
+    plugins.each do |plugin|
+      remapped_line = pipeline_config.lookup_source_and_line(plugin.line_and_column[0])
+      plugin.source_file = remapped_line[0]
+      plugin.source_line = remapped_line[1]
+    end
+  end
+
 end; end

--- a/logstash-core/lib/logstash/compiler/lscl.rb
+++ b/logstash-core/lib/logstash/compiler/lscl.rb
@@ -76,8 +76,7 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
     attr_accessor :source_file, :source_line
 
     def expr
-#       jdsl.iPlugin(source_meta, plugin_type_enum, self.plugin_name, source_file, source_line, self.expr_attributes)
-      jdsl.iPlugin(source_meta, plugin_type_enum, self.plugin_name, self.expr_attributes)
+      jdsl.iPlugin(source_meta, plugin_type_enum, self.plugin_name, source_file, source_line, self.expr_attributes)
     end
 
     def plugin_type_enum

--- a/logstash-core/lib/logstash/compiler/lscl.rb
+++ b/logstash-core/lib/logstash/compiler/lscl.rb
@@ -72,7 +72,11 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
 
   class Plugins < Node; end
   class Plugin < Node
+
+    attr_accessor :source_file, :source_line
+
     def expr
+#       jdsl.iPlugin(source_meta, plugin_type_enum, self.plugin_name, source_file, source_line, self.expr_attributes)
       jdsl.iPlugin(source_meta, plugin_type_enum, self.plugin_name, self.expr_attributes)
     end
 
@@ -95,7 +99,11 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
 
     def expr_attributes
       # Turn attributes into a hash map
-      self.attributes.recursive_select(Attribute).map(&:expr).map {|k,v|
+      self.attributes.recursive_select(Attribute).map {|attribute|
+        attribute.source_file = source_file
+        attribute.source_line = source_line
+        attribute
+      }.map(&:expr).map {|k,v|
         if v.java_kind_of?(Java::OrgLogstashConfigIrExpression::ValueExpression)
           [k, v.get]
         else
@@ -130,7 +138,12 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
   end
 
   class Attribute < Node
+    attr_accessor :source_file, :source_line
     def expr
+      if value.is_a?(Plugin)
+        value.source_file = source_file
+        value.source_line = source_line
+      end
       [name.text_value, value.expr]
     end
   end

--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -411,7 +411,9 @@ module LogStash::Config::Mixin
         case validator
           when :codec
             if value.first.is_a?(String)
-              value = LogStash::Codecs::Delegator.new LogStash::Plugin.lookup("codec", value.first).new
+              parent_plugin_name = self.config_name
+              codec = LogStash::Plugin.lookup("codec", value.first).new
+              value = LogStash::Codecs::Delegator.new(codec, parent_plugin_name)
               return true, value
             else
               value = value.first

--- a/logstash-core/lib/logstash/config/pipeline_config.rb
+++ b/logstash-core/lib/logstash/config/pipeline_config.rb
@@ -1,10 +1,10 @@
 # encoding: utf-8
 require "digest"
 
-java_import org.logstash.config.ir.ConfigSourceSegment
-
 module LogStash module Config
   class PipelineConfig
+    java_import org.logstash.config.ir.ConfigSourceSegment
+
     include LogStash::Util::Loggable
 
     attr_reader :source, :pipeline_id, :config_parts, :settings, :read_at

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -70,7 +70,7 @@ module LogStash; class BasePipeline < AbstractPipeline
 
 
   def plugin(plugin_type, name, line, column, *args)
-    @plugin_factory.plugin(plugin_type, name, line, column, *args)
+    @plugin_factory.plugin(plugin_type, name, line, column, "", -1, *args)
   end
 
   def default_logging_keys(other_keys = {})

--- a/logstash-core/spec/logstash/codecs/delegator_spec.rb
+++ b/logstash-core/spec/logstash/codecs/delegator_spec.rb
@@ -23,7 +23,7 @@ describe LogStash::Codecs::Delegator do
   let(:codec) { LogStash::Codecs::MockCodec.new }
 
   subject do
-    delegator = described_class.new(codec)
+    delegator = described_class.new(codec, "MockCodec")
     delegator.metric = metric.namespace([:stats, :pipelines, :main, :plugins, :codecs, :my_id])
     delegator
   end

--- a/logstash-core/spec/logstash/compiler/compiler_spec.rb
+++ b/logstash-core/spec/logstash/compiler/compiler_spec.rb
@@ -66,20 +66,6 @@ describe LogStash::Compiler do
       it "should provide the original source" do
         expect(pipeline.original_source).to eq(sources.join("\n"))
       end
-
-#       describe "applying protocol and id metadata" do
-#         it "should apply the correct source metadata to all components" do
-#           # TODO: seems to be a jruby regression we cannot currently call each on a stream
-#           pipeline.get_plugin_vertices.each do |pv|
-#             name_idx = pv.plugin_definition.name.split("_").last
-#             source_protocol_idx = pv.source_with_metadata.protocol.split("_").last
-#             source_id_idx = pv.source_with_metadata.id.split("_").last
-#
-#             expect(name_idx).to eq(source_protocol_idx)
-#             expect(name_idx).to eq(source_id_idx)
-#           end
-#         end
-#       end
     end
 
     describe "complex configs" do

--- a/logstash-core/spec/logstash/config/pipeline_config_spec.rb
+++ b/logstash-core/spec/logstash/config/pipeline_config_spec.rb
@@ -72,4 +72,76 @@ describe LogStash::Config::PipelineConfig do
       end
     end
   end
+
+  describe "source and line remapping" do
+    context "when pipeline is constructed from single file single line" do
+      let (:pipeline_conf_string) { 'input { generator1 }' }
+      subject { described_class.new(source, pipeline_id, [org.logstash.common.SourceWithMetadata.new("file", "/tmp/1", 0, 0, pipeline_conf_string)], settings) }
+      it "return the same line of the queried" do
+        expect(subject.lookup_source_and_line(1)[1]).to eq(1)
+      end
+    end
+
+    context "when pipeline is constructed from single file" do
+      let (:pipeline_conf_string) { 'input {
+                                       generator1
+                                     }' }
+      subject { described_class.new(source, pipeline_id, [org.logstash.common.SourceWithMetadata.new("file", "/tmp/1", 0, 0, pipeline_conf_string)], settings) }
+
+      it "return the same line of the queried" do
+        expect(subject.lookup_source_and_line(1)[1]).to eq(1)
+        expect(subject.lookup_source_and_line(2)[1]).to eq(2)
+      end
+
+      it "throw exception if line is out of bound" do
+        expect { subject.lookup_source_and_line(100) }.to raise_exception(IndexError)
+      end
+    end
+
+    context "when pipeline is constructed from multiple files" do
+      let (:pipeline_conf_string_part1) { 'input {
+                                             generator1
+                                           }' }
+      let (:pipeline_conf_string_part2) { 'output {
+                                             stdout
+                                           }' }
+      let(:merged_config_parts) do
+        [
+          org.logstash.common.SourceWithMetadata.new("file", "/tmp/input", 0, 0, pipeline_conf_string_part1),
+          org.logstash.common.SourceWithMetadata.new("file", "/tmp/output", 0, 0, pipeline_conf_string_part2)
+        ]
+      end
+      subject { described_class.new(source, pipeline_id, merged_config_parts, settings) }
+
+      it "return the line of first segment" do
+        expect(subject.lookup_source_and_line(2)).to eq(["/tmp/input", 2])
+      end
+
+      it "return the line of second segment" do
+        expect(subject.lookup_source_and_line(4)).to eq(["/tmp/output", 1])
+      end
+
+      it "throw exception if line is out of bound" do
+        expect { subject.lookup_source_and_line(100) }.to raise_exception(IndexError)
+      end
+    end
+
+    context "when pipeline is constructed from multiple files and the first has trailing newline" do
+        let (:pipeline_conf_string_part1) { "input {\n  generator1\n}\n" }
+        let (:pipeline_conf_string_part2) { 'output {
+                                               stdout
+                                             }' }
+        let(:merged_config_parts) do
+          [
+            org.logstash.common.SourceWithMetadata.new("file", "/tmp/input", 0, 0, pipeline_conf_string_part1),
+            org.logstash.common.SourceWithMetadata.new("file", "/tmp/output", 0, 0, pipeline_conf_string_part2)
+          ]
+        end
+        subject { described_class.new(source, pipeline_id, merged_config_parts, settings) }
+
+        it "shouldn't slide the mapping of subsequent" do
+          expect(subject.lookup_source_and_line(4)).to eq(["/tmp/output", 1])
+        end
+      end
+  end
 end

--- a/logstash-core/spec/logstash/filter_delegator_spec.rb
+++ b/logstash-core/spec/logstash/filter_delegator_spec.rb
@@ -11,7 +11,7 @@ describe LogStash::FilterDelegator do
 
   let(:filter_id) { "my-filter" }
   let(:config) do
-    { "host" => "127.0.0.1", "id" => filter_id }
+    { "host" => "127.0.0.1", "id" => filter_id, "config-ref" => "S: <filter_delegator_spec.rb> L: 14" }
   end
   let(:collector) {LogStash::Instrument::Collector.new}
   let(:metric) { LogStash::Instrument::Metric.new(collector).namespace(:null) }

--- a/logstash-core/spec/logstash/java_filter_delegator_spec.rb
+++ b/logstash-core/spec/logstash/java_filter_delegator_spec.rb
@@ -17,7 +17,7 @@ describe LogStash::FilterDelegator do
 
   let(:filter_id) { "my_filter" }
   let(:config) do
-    { "host" => "127.0.0.1", "id" => filter_id }
+    { "host" => "127.0.0.1", "id" => filter_id, "config-ref" => "S:<test source>, L: 1"}
   end
   let(:metric) {
     LogStash::Instrument::NamespacedMetric.new(

--- a/logstash-core/src/main/java/org/logstash/common/SourceWithMetadata.java
+++ b/logstash-core/src/main/java/org/logstash/common/SourceWithMetadata.java
@@ -39,6 +39,10 @@ public class SourceWithMetadata implements HashableWithSource {
         return text;
     }
 
+    public int getLinesCount() {
+        return text.split("\\n").length;
+    }
+
     private static final Pattern emptyString = Pattern.compile("^\\s*$");
 
     public SourceWithMetadata(String protocol, String id, Integer line, Integer column, String text) throws IncompleteSourceWithMetadataException {
@@ -56,11 +60,11 @@ public class SourceWithMetadata implements HashableWithSource {
             return false;
         }).collect(Collectors.toList());
 
-        if (!(this.getText() instanceof String)) {
-          badAttributes.add(this.getText());
+        if (getText() == null) {
+          badAttributes.add("text is null");
         }
 
-        if (!badAttributes.isEmpty()){
+        if (!badAttributes.isEmpty()) {
             String message = "Missing attributes in SourceWithMetadata: (" + badAttributes + ") "
                     + this.toString();
             throw new IncompleteSourceWithMetadataException(message);

--- a/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
@@ -166,9 +166,11 @@ public final class CompiledPipeline {
         vertices.forEach(v -> {
             final PluginDefinition def = v.getPluginDefinition();
             final SourceWithMetadata source = v.getSourceWithMetadata();
+            final String sourceFile = v.getSourceFile();
+            final int sourceLine = v.getSourceLine();
             IRubyObject o = pluginFactory.buildInput(
                     RubyUtil.RUBY.newString(def.getName()), RubyUtil.RUBY.newFixnum(source.getLine()),
-                    RubyUtil.RUBY.newFixnum(source.getColumn()), convertArgs(def), convertJavaArgs(def, cve));
+                    RubyUtil.RUBY.newFixnum(source.getColumn()), sourceFile, sourceLine, convertArgs(def), convertJavaArgs(def, cve));
             nodes.add(o);
         });
         return nodes;

--- a/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
@@ -149,9 +149,11 @@ public final class CompiledPipeline {
         for (final PluginVertex vertex : filterPlugins) {
             final PluginDefinition def = vertex.getPluginDefinition();
             final SourceWithMetadata source = vertex.getSourceWithMetadata();
+            final String sourceFile = vertex.getSourceFile();
+            final int sourceLine = vertex.getSourceLine();
             res.put(vertex.getId(), pluginFactory.buildFilter(
                     RubyUtil.RUBY.newString(def.getName()), RubyUtil.RUBY.newFixnum(source.getLine()),
-                    RubyUtil.RUBY.newFixnum(source.getColumn()), convertArgs(def), convertJavaArgs(def, cve)
+                    RubyUtil.RUBY.newFixnum(source.getColumn()), sourceFile, sourceLine, convertArgs(def), convertJavaArgs(def, cve)
             ));
         }
         return res;

--- a/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
@@ -131,9 +131,11 @@ public final class CompiledPipeline {
         outs.forEach(v -> {
             final PluginDefinition def = v.getPluginDefinition();
             final SourceWithMetadata source = v.getSourceWithMetadata();
+            final String sourceFile = v.getSourceFile();
+            final int sourceLine = v.getSourceLine();
             res.put(v.getId(), pluginFactory.buildOutput(
                     RubyUtil.RUBY.newString(def.getName()), RubyUtil.RUBY.newFixnum(source.getLine()),
-                    RubyUtil.RUBY.newFixnum(source.getColumn()), convertArgs(def), convertJavaArgs(def, cve)
+                    RubyUtil.RUBY.newFixnum(source.getColumn()), sourceFile, sourceLine, convertArgs(def), convertJavaArgs(def, cve)
             ));
         });
         return res;

--- a/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
@@ -190,9 +190,13 @@ public final class CompiledPipeline {
             final String key = entry.getKey();
             final Object toput;
             if (value instanceof PluginStatement) {
-                final PluginDefinition codec = ((PluginStatement) value).getPluginDefinition();
+                PluginStatement pluginStatement = (PluginStatement) value;
+                final String sourceFile = pluginStatement.getSourceFile();
+                final int sourceLine = pluginStatement.getSourceLine();
+                final PluginDefinition codec = pluginStatement.getPluginDefinition();
                 toput = pluginFactory.buildCodec(
                     RubyUtil.RUBY.newString(codec.getName()),
+                    sourceFile, sourceLine,
                     Rubyfier.deep(RubyUtil.RUBY, codec.getArguments()),
                     codec.getArguments()
                 );
@@ -218,10 +222,14 @@ public final class CompiledPipeline {
             final String key = entry.getKey();
             final IRubyObject toput;
             if (value instanceof PluginStatement) {
-                final PluginDefinition codec = ((PluginStatement) value).getPluginDefinition();
+                PluginStatement pluginStatement = (PluginStatement) value;
+                final String sourceFile = pluginStatement.getSourceFile();
+                final int sourceLine = pluginStatement.getSourceLine();
+                final PluginDefinition codec = pluginStatement.getPluginDefinition();
                 Map<String, Object> codecArgs = expandConfigVariables(cve, codec.getArguments());
                 toput = pluginFactory.buildCodec(
                         RubyUtil.RUBY.newString(codec.getName()),
+                        sourceFile, sourceLine,
                         Rubyfier.deep(RubyUtil.RUBY, codec.getArguments()),
                         codecArgs
                 );

--- a/logstash-core/src/main/java/org/logstash/config/ir/ConfigCompiler.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/ConfigCompiler.java
@@ -17,27 +17,18 @@ public final class ConfigCompiler {
     }
 
     /**
-     * @param config Logstash Config String
+     * @param pipelineConfig Logstash single pipeline's Config
      * @param supportEscapes The value of the setting {@code config.support_escapes}
      * @return Compiled {@link PipelineIR}
-     * @throws IncompleteSourceWithMetadataException On Broken Configuration
      */
-    public static PipelineIR configToPipelineIR(final String config, final boolean supportEscapes)
-        throws IncompleteSourceWithMetadataException {
+    public static PipelineIR configToPipelineIR(final IRubyObject pipelineConfig, final boolean supportEscapes) {
         final IRubyObject compiler = RubyUtil.RUBY.executeScript(
             "require 'logstash/compiler'\nLogStash::Compiler",
             ""
         );
         final IRubyObject code =
             compiler.callMethod(RubyUtil.RUBY.getCurrentContext(), "compile_sources",
-                new IRubyObject[]{
-                    RubyUtil.RUBY.newArray(
-                        JavaUtil.convertJavaToRuby(
-                            RubyUtil.RUBY,
-                            new SourceWithMetadata("str", "pipeline", 0, 0, config)
-                        )
-                    ),
-                    RubyUtil.RUBY.newBoolean(supportEscapes)
+                new IRubyObject[]{pipelineConfig, RubyUtil.RUBY.newBoolean(supportEscapes)
                 }
             );
         return code.toJava(PipelineIR.class);

--- a/logstash-core/src/main/java/org/logstash/config/ir/ConfigSourceSegment.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/ConfigSourceSegment.java
@@ -1,0 +1,36 @@
+package org.logstash.config.ir;
+
+public final class ConfigSourceSegment {
+
+    private final String source;
+    private final int offset;
+    private final int length;
+
+    public ConfigSourceSegment(String source, int offset, int length) {
+        this.source = source;
+        this.offset = offset;
+        this.length = length;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public int getLength() {
+        return length;
+    }
+
+    public boolean contains(int lineNumber) {
+        int rebased_line_number = lineNumber - this.offset;
+        return 1 <= rebased_line_number && rebased_line_number <= this.length;
+    }
+
+    public int rebase(int lineNumber) {
+        return lineNumber - this.offset;
+    }
+
+    @Override
+    public String toString() {
+        return "ConfigSourceSegment{source='" + source + "', offset=" + offset + ", length=" + length + '}';
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/config/ir/DSL.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/DSL.java
@@ -5,6 +5,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import org.jruby.RubyInteger;
+import org.jruby.RubyString;
 import org.logstash.common.IncompleteSourceWithMetadataException;
 import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.expression.BooleanExpression;
@@ -228,6 +230,11 @@ public class DSL {
             throw new RuntimeException("Noop could not instantiate metadata, this should never happen");
         }
         return new NoopStatement(null);
+    }
+
+    public static PluginStatement iPlugin(SourceWithMetadata meta, PluginDefinition.Type pluginType, String pluginName,
+                                          RubyString sourceFile, RubyInteger sourceLine, Map<String, Object> pluginArguments) {
+        return new PluginStatement(meta, new PluginDefinition(pluginType, pluginName, pluginArguments), sourceFile, sourceLine);
     }
 
     public static PluginStatement iPlugin(SourceWithMetadata meta, PluginDefinition.Type pluginType, String pluginName, Map<String, Object> pluginArguments) {

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java
@@ -39,7 +39,7 @@ public abstract class AbstractFilterDelegatorExt extends RubyObject {
         super(runtime, metaClass);
     }
 
-    protected void initMetrics(final String id, final AbstractNamespacedMetricExt namespacedMetric) {
+    protected void initMetrics(final String id, final AbstractNamespacedMetricExt namespacedMetric, String codeRef) {
         final ThreadContext context = RubyUtil.RUBY.getCurrentContext();
         this.id = RubyString.newString(context.runtime, id);
         synchronized(namespacedMetric.getMetric()) {
@@ -48,6 +48,9 @@ public abstract class AbstractFilterDelegatorExt extends RubyObject {
             eventMetricIn = LongCounter.fromRubyBase(metricEvents, MetricKeys.IN_KEY);
             eventMetricTime = LongCounter.fromRubyBase(metricEvents, MetricKeys.DURATION_IN_MILLIS_KEY);
             namespacedMetric.gauge(context, MetricKeys.NAME_KEY, configName(context));
+            if (codeRef != null) {
+                namespacedMetric.gauge(context, MetricKeys.CONFIG_REF_KEY, RubyUtil.RUBY.newString(codeRef));
+            }
         }
     }
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java
@@ -104,7 +104,7 @@ public abstract class AbstractOutputDelegatorExt extends RubyObject {
         return this;
     }
 
-    protected void initMetrics(final String id, final AbstractMetricExt metric) {
+    protected void initMetrics(final String id, final AbstractMetricExt metric, final String codeRef) {
         this.metric = metric;
         final ThreadContext context = RubyUtil.RUBY.getCurrentContext();
         this.id = RubyString.newString(context.runtime, id);
@@ -112,6 +112,9 @@ public abstract class AbstractOutputDelegatorExt extends RubyObject {
             namespacedMetric = metric.namespace(context, context.runtime.newSymbol(id));
             metricEvents = namespacedMetric.namespace(context, MetricKeys.EVENTS_KEY);
             namespacedMetric.gauge(context, MetricKeys.NAME_KEY, configName(context));
+            if (codeRef != null) {
+                namespacedMetric.gauge(context, MetricKeys.CONFIG_REF_KEY, RubyUtil.RUBY.newString(codeRef));
+            }
             eventMetricOut = LongCounter.fromRubyBase(metricEvents, MetricKeys.OUT_KEY);
             eventMetricIn = LongCounter.fromRubyBase(metricEvents, MetricKeys.IN_KEY);
             eventMetricTime = LongCounter.fromRubyBase(metricEvents, MetricKeys.DURATION_IN_MILLIS_KEY);

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
@@ -32,13 +32,14 @@ public final class FilterDelegatorExt extends AbstractFilterDelegatorExt {
     private boolean flushes;
 
     @JRubyMethod(name="initialize")
-    public IRubyObject initialize(final ThreadContext context, final IRubyObject filter, final IRubyObject id) {
+    public IRubyObject initialize(final ThreadContext context, final IRubyObject filter, final IRubyObject id,
+                                  final RubyString configRef) {
         this.id = (RubyString) id;
         this.filter = filter;
         filterClass = filter.getSingletonClass().getRealClass();
         filterMethod = filterClass.searchMethod(FILTER_METHOD_NAME);
         final AbstractNamespacedMetricExt namespacedMetric = (AbstractNamespacedMetricExt) filter.callMethod(context, "metric");
-        initMetrics(this.id.asJavaString(), namespacedMetric);
+        initMetrics(this.id.asJavaString(), namespacedMetric, configRef.asJavaString());
         flushes = filter.respondsTo("flush");
         return this;
     }

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaCodecDelegator.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaCodecDelegator.java
@@ -41,13 +41,16 @@ public class JavaCodecDelegator implements Codec {
     protected final CounterMetric decodeMetricTime;
 
 
-    public JavaCodecDelegator(final Context context, final Codec codec) {
+    public JavaCodecDelegator(final Context context, final Codec codec, final String codeRef) {
         this.codec = codec;
 
         final NamespacedMetric metric = context.getMetric(codec);
 
         synchronized(metric.root()) {
             metric.gauge(MetricKeys.NAME_KEY.asJavaString(), codec.getName());
+            if (codeRef != null) {
+                metric.gauge(MetricKeys.CONFIG_REF_KEY.asJavaString(), RubyUtil.RUBY.newString(codeRef));
+            }
 
             final NamespacedMetric encodeMetric = metric.namespace(ENCODE_KEY);
             encodeMetricIn = encodeMetric.counter(IN_KEY);

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaFilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaFilterDelegatorExt.java
@@ -42,13 +42,14 @@ public class JavaFilterDelegatorExt extends AbstractFilterDelegatorExt {
 
     public static JavaFilterDelegatorExt create(final String configName, final String id,
                                                 final AbstractNamespacedMetricExt metric,
-                                                final Filter filter, final Map<String, Object> pluginArgs) {
+                                                final Filter filter, final Map<String, Object> pluginArgs,
+                                                final String configReference) {
         final JavaFilterDelegatorExt instance =
                 new JavaFilterDelegatorExt(RubyUtil.RUBY, RubyUtil.JAVA_FILTER_DELEGATOR_CLASS);
         instance.configName = RubyUtil.RUBY.newString(configName);
         AbstractNamespacedMetricExt scopedMetric =
                 metric.namespace(RubyUtil.RUBY.getCurrentContext(), RubyUtil.RUBY.newSymbol(filter.getId()));
-        instance.initMetrics(id, scopedMetric);
+        instance.initMetrics(id, scopedMetric, configReference);
         instance.filter = filter;
         instance.initializeFilterMatchListener(pluginArgs);
         return instance;

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaInputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaInputDelegatorExt.java
@@ -38,11 +38,12 @@ public class JavaInputDelegatorExt extends RubyObject {
 
     public static JavaInputDelegatorExt create(final JavaBasePipelineExt pipeline,
                                                final AbstractNamespacedMetricExt metric, final Input input,
-                                               final Map<String, Object> pluginArgs) {
+                                               final Map<String, Object> pluginArgs, String configRef) {
         final JavaInputDelegatorExt instance =
                 new JavaInputDelegatorExt(RubyUtil.RUBY, RubyUtil.JAVA_INPUT_DELEGATOR_CLASS);
         AbstractNamespacedMetricExt scopedMetric = metric.namespace(RubyUtil.RUBY.getCurrentContext(), RubyUtil.RUBY.newSymbol(input.getId()));
         scopedMetric.gauge(RubyUtil.RUBY.getCurrentContext(), MetricKeys.NAME_KEY, RubyUtil.RUBY.newString(input.getName()));
+        scopedMetric.gauge(RubyUtil.RUBY.getCurrentContext(), MetricKeys.CONFIG_REF_KEY, RubyUtil.RUBY.newString(configRef));
         instance.setMetric(RubyUtil.RUBY.getCurrentContext(), scopedMetric);
         instance.input = input;
         instance.pipeline = pipeline;

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaOutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaOutputDelegatorExt.java
@@ -42,11 +42,11 @@ public final class JavaOutputDelegatorExt extends AbstractOutputDelegatorExt {
     public static JavaOutputDelegatorExt create(final String configName, final String id,
         final AbstractMetricExt metric,
         final Consumer<Collection<JrubyEventExtLibrary.RubyEvent>> outputFunction,
-        final Runnable closeAction, final Runnable registerAction) {
+        final Runnable closeAction, final Runnable registerAction, String configReference) {
         final JavaOutputDelegatorExt instance =
             new JavaOutputDelegatorExt(RubyUtil.RUBY, RubyUtil.JAVA_OUTPUT_DELEGATOR_CLASS);
         instance.configName = RubyUtil.RUBY.newString(configName);
-        instance.initMetrics(id, metric);
+        instance.initMetrics(id, metric, configReference);
         instance.outputFunction = outputFunction;
         instance.closeAction = closeAction;
         instance.registerAction = registerAction;
@@ -55,11 +55,11 @@ public final class JavaOutputDelegatorExt extends AbstractOutputDelegatorExt {
 
     public static JavaOutputDelegatorExt create(final String configName, final String id,
                                                 final AbstractMetricExt metric,
-                                                final Output output) {
+                                                final Output output, String configReference) {
         final JavaOutputDelegatorExt instance =
                 new JavaOutputDelegatorExt(RubyUtil.RUBY, RubyUtil.JAVA_OUTPUT_DELEGATOR_CLASS);
         instance.configName = RubyUtil.RUBY.newString(configName);
-        instance.initMetrics(id, metric);
+        instance.initMetrics(id, metric, configReference);
         instance.output = output;
         instance.outputFunction = instance::outputRubyEvents;
         instance.closeAction = instance::outputClose;

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputDelegatorExt.java
@@ -43,14 +43,14 @@ public final class OutputDelegatorExt extends AbstractOutputDelegatorExt {
 
         String id = args.op_aref(context, RubyString.newString(context.runtime, "id")).asJavaString();
         RubyString configRefKey = RubyString.newString(context.runtime, "config-ref");
-        String configRef = args.op_aref(context, configRefKey).asJavaString();
-        initMetrics(id, metric, configRef);
+        RubyString configRefValue = (RubyString) args.op_aref(context, configRefKey);
+        initMetrics(id, metric, configRefValue.asJavaString());
 
         args.remove(configRefKey);
         strategy = (OutputStrategyExt.AbstractOutputStrategyExt) strategyRegistry.classFor(
             context, concurrency(context)
         ).newInstance(
-            context, new IRubyObject[]{outputClass, namespacedMetric, executionContext, RubyUtil.RUBY.newString(configRef), args},
+            context, new IRubyObject[]{outputClass, namespacedMetric, executionContext, configRefValue, args},
             Block.NULL_BLOCK
         );
         return this;

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
@@ -231,13 +231,13 @@ public final class OutputStrategyExt {
             output = args[0].callMethod(context, "new", args[4]);
             initOutputCallsite(outputClass);
 
-            final IRubyObject codecDelegatorClass = RubyUtil.RUBY.executeScript(
+            final RubyClass codecDelegatorClass = (RubyClass) RubyUtil.RUBY.executeScript(
                     "require 'logstash/codecs/delegator'\nLogStash::Codecs::Delegator",
                     "");
             // WARNING: order is important since metric= create gauges with data assigned from parent_config_reference=
             IRubyObject codec = output.callMethod(context, "codec");
             if (codec instanceof RubyBasicObject) {
-                if (((RubyBasicObject) codec).instance_of_p(context, codecDelegatorClass).isTrue()) {
+                if (codecDelegatorClass.isInstance(codec)) {
                     codec.callMethod(context, "parent_config_reference=", args[3]);
                 }
             }

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
@@ -3,12 +3,8 @@ package org.logstash.config.ir.compiler;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.stream.Collectors;
-import org.jruby.Ruby;
-import org.jruby.RubyArray;
-import org.jruby.RubyClass;
-import org.jruby.RubyFixnum;
-import org.jruby.RubyHash;
-import org.jruby.RubyObject;
+
+import org.jruby.*;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.internal.runtime.methods.DynamicMethod;
@@ -154,9 +150,9 @@ public final class OutputStrategyExt {
             super(runtime, metaClass);
         }
 
-        @JRubyMethod(required = 4)
+        @JRubyMethod(required = 5)
         public IRubyObject initialize(final ThreadContext context, final IRubyObject[] args) {
-            final RubyHash pluginArgs = (RubyHash) args[3];
+            final RubyHash pluginArgs = (RubyHash) args[4];
             workerCount = pluginArgs.op_aref(context, context.runtime.newString("workers"));
             if (workerCount.isNil()) {
                 workerCount = RubyFixnum.one(context.runtime);
@@ -169,6 +165,9 @@ public final class OutputStrategyExt {
                 // Calling "new" here manually to allow mocking the ctor in RSpec Tests
                 final IRubyObject output = outputClass.callMethod(context, "new", pluginArgs);
                 initOutputCallsite(outputClass);
+                // WARNING: order is important since metric= create gauges with data assigned from parent_config_reference=
+                IRubyObject codec = output.callMethod(context, "codec");
+                codec.callMethod(context, "parent_config_reference=", args[3]);
                 output.callMethod(context, "metric=", args[1]);
                 output.callMethod(context, "execution_context=", args[2]);
                 workers.append(output);
@@ -225,12 +224,23 @@ public final class OutputStrategyExt {
             super(runtime, metaClass);
         }
 
-        @JRubyMethod(required = 4)
+        @JRubyMethod(required = 5)
         public IRubyObject initialize(final ThreadContext context, final IRubyObject[] args) {
             final RubyClass outputClass = (RubyClass) args[0];
             // Calling "new" here manually to allow mocking the ctor in RSpec Tests
-            output = args[0].callMethod(context, "new", args[3]);
+            output = args[0].callMethod(context, "new", args[4]);
             initOutputCallsite(outputClass);
+
+            final IRubyObject codecDelegatorClass = RubyUtil.RUBY.executeScript(
+                    "require 'logstash/codecs/delegator'\nLogStash::Codecs::Delegator",
+                    "");
+            // WARNING: order is important since metric= create gauges with data assigned from parent_config_reference=
+            IRubyObject codec = output.callMethod(context, "codec");
+            if (codec instanceof RubyBasicObject) {
+                if (((RubyBasicObject) codec).instance_of_p(context, codecDelegatorClass).isTrue()) {
+                    codec.callMethod(context, "parent_config_reference=", args[3]);
+                }
+            }
             output.callMethod(context, "metric=", args[1]);
             output.callMethod(context, "execution_context=", args[2]);
             return this;

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/PluginFactory.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/PluginFactory.java
@@ -42,8 +42,9 @@ public interface PluginFactory extends RubyIntegration.PluginFactory {
 
         @Override
         public IRubyObject buildInput(final RubyString name, final RubyInteger line, final RubyInteger column,
+                                      final String sourceFile, final int sourceLine,
                                       final IRubyObject args, Map<String, Object> pluginArgs) {
-            return rubyFactory.buildInput(name, line, column, args, pluginArgs);
+            return rubyFactory.buildInput(name, line, column, sourceFile, sourceLine, args, pluginArgs);
         }
 
         @Override

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/PluginFactory.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/PluginFactory.java
@@ -49,9 +49,10 @@ public interface PluginFactory extends RubyIntegration.PluginFactory {
 
         @Override
         public AbstractOutputDelegatorExt buildOutput(final RubyString name, final RubyInteger line,
-                                                      final RubyInteger column, final IRubyObject args,
+                                                      final RubyInteger column, final String sourceFile,
+                                                      final int sourceLine, final IRubyObject args,
                                                       final Map<String, Object> pluginArgs) {
-            return rubyFactory.buildOutput(name, line, column, args, pluginArgs);
+            return rubyFactory.buildOutput(name, line, column, sourceFile, sourceLine, args, pluginArgs);
         }
 
         @Override

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/PluginFactory.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/PluginFactory.java
@@ -62,8 +62,9 @@ public interface PluginFactory extends RubyIntegration.PluginFactory {
         }
 
         @Override
-        public IRubyObject buildCodec(final RubyString name, final IRubyObject args, Map<String, Object> pluginArgs) {
-            return rubyFactory.buildCodec(name, args, pluginArgs);
+        public IRubyObject buildCodec(final RubyString name, final String sourceFile, final int sourceLine,
+                                      final IRubyObject args, Map<String, Object> pluginArgs) {
+            return rubyFactory.buildCodec(name, sourceFile, sourceLine, args, pluginArgs);
         }
 
         @Override

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/PluginFactory.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/PluginFactory.java
@@ -56,9 +56,10 @@ public interface PluginFactory extends RubyIntegration.PluginFactory {
 
         @Override
         public AbstractFilterDelegatorExt buildFilter(final RubyString name, final RubyInteger line,
-                                                      final RubyInteger column, final IRubyObject args,
+                                                      final RubyInteger column, final String sourceFile,
+                                                      final int sourceLine, final IRubyObject args,
                                                       final Map<String, Object> pluginArgs) {
-            return rubyFactory.buildFilter(name, line, column, args, pluginArgs);
+            return rubyFactory.buildFilter(name, line, column, sourceFile, sourceLine, args, pluginArgs);
         }
 
         @Override

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
@@ -27,7 +27,7 @@ public final class RubyIntegration {
         AbstractOutputDelegatorExt buildOutput(RubyString name, RubyInteger line, RubyInteger column,
             IRubyObject args, Map<String, Object> pluginArgs);
 
-        AbstractFilterDelegatorExt buildFilter(RubyString name, RubyInteger line, RubyInteger column, IRubyObject args,
+        AbstractFilterDelegatorExt buildFilter(RubyString name, RubyInteger line, RubyInteger column, String sourceFile, int sourceLine, IRubyObject args,
             Map<String, Object> pluginArgs);
 
         IRubyObject buildCodec(RubyString name, String sourceFile, int sourceLine, IRubyObject args, Map<String, Object> pluginArgs);

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
@@ -24,7 +24,7 @@ public final class RubyIntegration {
         IRubyObject buildInput(RubyString name, RubyInteger line, RubyInteger column, String sourceFile, int sourceLine,
             IRubyObject args, Map<String, Object> pluginArgs);
 
-        AbstractOutputDelegatorExt buildOutput(RubyString name, RubyInteger line, RubyInteger column,
+        AbstractOutputDelegatorExt buildOutput(RubyString name, RubyInteger line, RubyInteger column, String sourceFile, int sourceLine,
             IRubyObject args, Map<String, Object> pluginArgs);
 
         AbstractFilterDelegatorExt buildFilter(RubyString name, RubyInteger line, RubyInteger column, String sourceFile, int sourceLine, IRubyObject args,

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
@@ -30,7 +30,7 @@ public final class RubyIntegration {
         AbstractFilterDelegatorExt buildFilter(RubyString name, RubyInteger line, RubyInteger column, IRubyObject args,
             Map<String, Object> pluginArgs);
 
-        IRubyObject buildCodec(RubyString name, IRubyObject args, Map<String, Object> pluginArgs);
+        IRubyObject buildCodec(RubyString name, String sourceFile, int sourceLine, IRubyObject args, Map<String, Object> pluginArgs);
 
         Codec buildDefaultCodec(String codecName);
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
@@ -21,7 +21,7 @@ public final class RubyIntegration {
      */
     public interface PluginFactory {
 
-        IRubyObject buildInput(RubyString name, RubyInteger line, RubyInteger column,
+        IRubyObject buildInput(RubyString name, RubyInteger line, RubyInteger column, String sourceFile, int sourceLine,
             IRubyObject args, Map<String, Object> pluginArgs);
 
         AbstractOutputDelegatorExt buildOutput(RubyString name, RubyInteger line, RubyInteger column,

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/PluginVertex.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/PluginVertex.java
@@ -6,16 +6,23 @@ import org.logstash.config.ir.SourceComponent;
 
 public class PluginVertex extends Vertex {
     private final PluginDefinition pluginDefinition;
+    private final String sourceFile;
+    private final int sourceLine;
 
     public PluginDefinition getPluginDefinition() {
         return pluginDefinition;
     }
 
-
     public PluginVertex(SourceWithMetadata meta, PluginDefinition pluginDefinition) {
+        this(meta, pluginDefinition, null, -1);
+    }
+
+    public PluginVertex(SourceWithMetadata meta, PluginDefinition pluginDefinition, String sourceFile, int sourceLine) {
         // We know that if the ID value exists it will be as a string
         super(meta, (String) pluginDefinition.getArguments().get("id"));
         this.pluginDefinition = pluginDefinition;
+        this.sourceFile = sourceFile;
+        this.sourceLine = sourceLine;
     }
 
     public String toString() {
@@ -24,7 +31,7 @@ public class PluginVertex extends Vertex {
 
     @Override
     public PluginVertex copy() {
-        return new PluginVertex(this.getSourceWithMetadata(), pluginDefinition);
+        return new PluginVertex(this.getSourceWithMetadata(), pluginDefinition, sourceFile, sourceLine);
     }
 
     @Override
@@ -38,5 +45,13 @@ public class PluginVertex extends Vertex {
             return otherV.getPluginDefinition().sourceComponentEquals(this.getPluginDefinition());
         }
         return false;
+    }
+
+    public String getSourceFile() {
+        return sourceFile;
+    }
+
+    public int getSourceLine() {
+        return sourceLine;
     }
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/imperative/PluginStatement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/imperative/PluginStatement.java
@@ -1,5 +1,7 @@
 package org.logstash.config.ir.imperative;
 
+import org.jruby.RubyInteger;
+import org.jruby.RubyString;
 import org.logstash.config.ir.SourceComponent;
 import org.logstash.config.ir.InvalidIRException;
 import org.logstash.config.ir.PluginDefinition;
@@ -10,10 +12,34 @@ import org.logstash.config.ir.graph.Vertex;
 
 public class PluginStatement extends Statement {
     private final PluginDefinition pluginDefinition;
+    private String sourceFile;
+    private int sourceLine;
 
     public PluginStatement(SourceWithMetadata meta, PluginDefinition pluginDefinition) {
         super(meta);
         this.pluginDefinition = pluginDefinition;
+    }
+
+    public PluginStatement(SourceWithMetadata meta, PluginDefinition pluginDefinition, RubyString sourceFile, RubyInteger sourceLine) {
+        this(meta, pluginDefinition);
+        if (sourceFile == null) {
+            this.sourceFile = "<CLI>";
+        } else {
+            this.sourceFile = sourceFile.asJavaString();
+        }
+        if (sourceLine == null) {
+            this.sourceLine = -1;
+        } else {
+            this.sourceLine = sourceLine.getIntValue();
+        }
+    }
+
+    public String getSourceFile() {
+        return sourceFile;
+    }
+
+    public int getSourceLine() {
+        return sourceLine;
     }
 
     @Override
@@ -34,7 +60,7 @@ public class PluginStatement extends Statement {
 
     @Override
     public Graph toGraph() throws InvalidIRException {
-        Vertex pluginVertex = new PluginVertex(getSourceWithMetadata(), pluginDefinition);
+        Vertex pluginVertex = new PluginVertex(getSourceWithMetadata(), pluginDefinition, sourceFile, sourceLine);
         Graph g = Graph.empty();
         g.addVertex(pluginVertex);
         return g;

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -121,7 +121,7 @@ public class AbstractPipelineExt extends RubyBasicObject {
     public final AbstractPipelineExt initialize(final ThreadContext context,
         final IRubyObject pipelineConfig, final IRubyObject namespacedMetric,
         final IRubyObject rubyLogger)
-        throws NoSuchAlgorithmException, IncompleteSourceWithMetadataException {
+        throws NoSuchAlgorithmException {
         reporter = new PipelineReporterExt(
             context.runtime, RubyUtil.PIPELINE_REPORTER_CLASS).initialize(context, rubyLogger, this
         );
@@ -153,9 +153,8 @@ public class AbstractPipelineExt extends RubyBasicObject {
                 );
             }
         }
-        lir = ConfigCompiler.configToPipelineIR(
-            configString.asJavaString(),
-            getSetting(context, "config.support_escapes").isTrue()
+        lir = ConfigCompiler.configToPipelineIR(pipelineSettings,
+                getSetting(context, "config.support_escapes").isTrue()
         );
         return this;
     }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricKeys.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricKeys.java
@@ -13,6 +13,8 @@ public final class MetricKeys {
 
     public static final RubySymbol NAME_KEY = RubyUtil.RUBY.newSymbol("name");
 
+    public static final RubySymbol CONFIG_REF_KEY = RubyUtil.RUBY.newSymbol("config-ref");
+
     public static final RubySymbol EVENTS_KEY = RubyUtil.RUBY.newSymbol("events");
 
     public static final RubySymbol OUT_KEY = RubyUtil.RUBY.newSymbol("out");

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
@@ -161,10 +161,11 @@ public final class PluginFactoryExt {
 
         @SuppressWarnings("unchecked")
         @Override
-        public IRubyObject buildCodec(final RubyString name, final IRubyObject args, Map<String, Object> pluginArgs) {
+        public IRubyObject buildCodec(final RubyString name, final String sourceFile, final int sourceLine,
+                                      final IRubyObject args, Map<String, Object> pluginArgs) {
             return plugin(
                     RubyUtil.RUBY.getCurrentContext(), PluginLookup.PluginType.CODEC,
-                    name.asJavaString(), 0, 0,  "TODO", -1, (Map<String, IRubyObject>) args, pluginArgs
+                    name.asJavaString(), 0, 0, sourceFile, sourceLine, (Map<String, IRubyObject>) args, pluginArgs
             );
         }
 
@@ -172,7 +173,7 @@ public final class PluginFactoryExt {
         public Codec buildDefaultCodec(String codecName) {
             return (Codec) JavaUtil.unwrapJavaValue(plugin(
                     RubyUtil.RUBY.getCurrentContext(), PluginLookup.PluginType.CODEC,
-                    codecName, 0, 0, "TODO", -1, Collections.emptyMap(), Collections.emptyMap()
+                    codecName, 0, 0, "<implicit codec>", 0, Collections.emptyMap(), Collections.emptyMap()
             ));
         }
 
@@ -365,7 +366,7 @@ public final class PluginFactoryExt {
                             final Context pluginContext = executionContext.toContext(type, metrics.getRoot(context));
                             final Codec codec = ctor.newInstance(config, pluginContext);
                             PluginUtil.validateConfig(codec, config);
-                            return JavaUtil.convertJavaToRuby(RubyUtil.RUBY, new JavaCodecDelegator(pluginContext, codec));
+                            return JavaUtil.convertJavaToRuby(RubyUtil.RUBY, new JavaCodecDelegator(pluginContext, codec, configReference));
                         } catch (NoSuchMethodException | IllegalAccessException | InstantiationException | InvocationTargetException ex) {
                             if (ex instanceof InvocationTargetException && ex.getCause() != null) {
                                 throw new IllegalStateException((ex).getCause());

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
@@ -132,20 +132,23 @@ public final class PluginFactoryExt {
         @SuppressWarnings("unchecked")
         @Override
         public AbstractOutputDelegatorExt buildOutput(final RubyString name, final RubyInteger line,
-                                                      final RubyInteger column, final IRubyObject args,
+                                                      final RubyInteger column, final String sourceFile,
+                                                      final int sourceLine,final IRubyObject args,
                                                       Map<String, Object> pluginArgs) {
             return (AbstractOutputDelegatorExt) plugin(
                     RubyUtil.RUBY.getCurrentContext(), PluginLookup.PluginType.OUTPUT,
-                    name.asJavaString(), line.getIntValue(), column.getIntValue(), "TODO", -1,
+                    name.asJavaString(), line.getIntValue(), column.getIntValue(), sourceFile, sourceLine,
                     (Map<String, IRubyObject>) args, pluginArgs
             );
         }
 
-        @JRubyMethod(required = 4)
+        @JRubyMethod(required = 6)
         public AbstractOutputDelegatorExt buildOutput(final ThreadContext context,
                                                       final IRubyObject[] args) {
             return buildOutput(
-                    (RubyString) args[0], args[1].convertToInteger(), args[2].convertToInteger(), args[3], null
+                    (RubyString) args[0], args[1].convertToInteger(), args[2].convertToInteger(), args[3].asJavaString(),
+                    args[4].convertToInteger().getIntValue(),
+                    args[5], null
             );
         }
 
@@ -251,6 +254,7 @@ public final class PluginFactoryExt {
                 final RubyHash rubyArgs = RubyHash.newHash(context.runtime);
                 rubyArgs.putAll(newArgs);
                 if (type == PluginLookup.PluginType.OUTPUT) {
+                    rubyArgs.put("config-ref", configReference);
                     return new OutputDelegatorExt(context.runtime, RubyUtil.RUBY_OUTPUT_DELEGATOR_CLASS).initialize(
                             context,
                             new IRubyObject[]{
@@ -313,7 +317,7 @@ public final class PluginFactoryExt {
                     }
 
                     if (output != null) {
-                        return JavaOutputDelegatorExt.create(name, id, typeScopedMetric, output);
+                        return JavaOutputDelegatorExt.create(name, id, typeScopedMetric, output, configReference);
                     } else {
                         throw new IllegalStateException("Unable to instantiate output: " + pluginClass);
                     }

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
@@ -284,7 +284,7 @@ public final class PluginFactoryExt {
 
                         // WARNING: order is important since metric= create gauges with data assigned from parent_config_reference=
                         IRubyObject codec = pluginInstance.callMethod(context, "codec");
-                        if (codec.getType().instance_of_p(context, codecDelegatorClass).isTrue()) {
+                        if (((RubyClass) codecDelegatorClass).isInstance(codec)) {
                             codec.callMethod(context, "parent_config_reference=", RubyUtil.RUBY.newString(configReference));
                         }
                         pluginInstance.callMethod(context, "metric=", scopedMetric);

--- a/logstash-core/src/test/java/org/logstash/common/SourceWithMetadataTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/SourceWithMetadataTest.java
@@ -6,6 +6,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 
+import static org.junit.Assert.assertEquals;
+
 @RunWith(Parameterized.class)
 public class SourceWithMetadataTest {
     private final ParameterGroup parameterGroup;
@@ -54,5 +56,16 @@ public class SourceWithMetadataTest {
     @Test(expected = IncompleteSourceWithMetadataException.class)
     public void itShouldThrowWhenMissingAField() throws IncompleteSourceWithMetadataException {
         new SourceWithMetadata(parameterGroup.protocol, parameterGroup.path, parameterGroup.line, parameterGroup.column, parameterGroup.text);
+    }
+
+    @Test
+    public void testCountLinesStripTrailingNewline() throws IncompleteSourceWithMetadataException {
+        String text = "input {\n " +
+                "  stdin {}\n" +
+                "}\n" +
+                "\n";
+        SourceWithMetadata sut = new SourceWithMetadata("proto", "path", 1, 1, text);
+
+        assertEquals("Trailing newline MUSTN'T be counted as line",3, sut.getLinesCount());
     }
 }

--- a/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
@@ -512,7 +512,9 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
 
         @Override
         public AbstractOutputDelegatorExt buildOutput(final RubyString name, final RubyInteger line,
-            final RubyInteger column, final IRubyObject args, Map<String, Object> pluginArgs) {
+            final RubyInteger column, final String sourceFile, final int sourceLine, final IRubyObject args,
+             Map<String, Object> pluginArgs)
+        {
             return PipelineTestUtil.buildOutput(setupPlugin(name, outputs));
         }
 

--- a/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
@@ -504,8 +504,9 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
         }
 
         @Override
-        public IRubyObject buildInput(final RubyString name, final RubyInteger line,
-            final RubyInteger column, final IRubyObject args, Map<String, Object> pluginArgs) {
+        public IRubyObject buildInput(final RubyString name, final RubyInteger line, final RubyInteger column,
+                                      final String sourceFile, final int sourceLine, final IRubyObject args,
+                                      Map<String, Object> pluginArgs) {
             return setupPlugin(name, inputs);
         }
 

--- a/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
@@ -526,7 +526,8 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
         }
 
         @Override
-        public IRubyObject buildCodec(final RubyString name, final IRubyObject args, Map<String, Object> pluginArgs) {
+        public IRubyObject buildCodec(final RubyString name, final String sourceFile, final int sourceLine,
+                                      final IRubyObject args, Map<String, Object> pluginArgs) {
             throw new IllegalStateException("No codec setup expected in this test.");
         }
 

--- a/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
@@ -15,9 +15,11 @@ import java.util.function.Supplier;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.jruby.RubyArray;
+import org.jruby.RubyClass;
 import org.jruby.RubyInteger;
 import org.jruby.RubyString;
 import org.jruby.javasupport.JavaUtil;
+import org.jruby.runtime.Block;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.junit.After;
 import org.junit.Before;
@@ -112,13 +114,13 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
         );
 
         final IRubyObject pipelineConfig =
-                pipelineConfigClass.callMethod(RubyUtil.RUBY.getCurrentContext(), "new",
+                ((RubyClass) pipelineConfigClass).newInstance(RubyUtil.RUBY.getCurrentContext(),
                         new IRubyObject[] {
                                 RubyUtil.RUBY.getNil(), /*source*/
                                 RubyUtil.RUBY.newString("main"), /*pipeline_id*/
                                 configParts,
                                 RubyUtil.RUBY.getNil(), /*settings*/
-                        });
+                        }, Block.NULL_BLOCK);
         return pipelineConfig;
     }
 

--- a/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
@@ -518,7 +518,8 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
 
         @Override
         public AbstractFilterDelegatorExt buildFilter(final RubyString name, final RubyInteger line,
-                                                      final RubyInteger column, final IRubyObject args,
+                                                      final RubyInteger column, final String sourceFile,
+                                                      final int sourceLine, final IRubyObject args,
                                                       Map<String, Object> pluginArgs) {
             return new FilterDelegatorExt(
                 RubyUtil.RUBY, RubyUtil.FILTER_DELEGATOR_CLASS)

--- a/logstash-core/src/test/java/org/logstash/config/ir/ConfigCompilerTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/ConfigCompilerTest.java
@@ -8,13 +8,14 @@ import org.logstash.config.ir.graph.Graph;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.logstash.config.ir.CompiledPipelineTest.createRubyPipelineConfig;
 
 public class ConfigCompilerTest extends RubyEnvTestCase {
 
     @Test
     public void testConfigToPipelineIR() throws Exception {
         final PipelineIR pipelineIR =
-            ConfigCompiler.configToPipelineIR("input {stdin{}} output{stdout{}}", false);
+            ConfigCompiler.configToPipelineIR(createRubyPipelineConfig("input {stdin{}} output{stdout{}}"), false);
         assertThat(pipelineIR.getOutputPluginVertices().size(), is(1));
         assertThat(pipelineIR.getFilterPluginVertices().size(), is(0));
     }
@@ -62,6 +63,6 @@ public class ConfigCompilerTest extends RubyEnvTestCase {
 
     private static String graphHash(final String config)
         throws IncompleteSourceWithMetadataException {
-        return ConfigCompiler.configToPipelineIR(config, false).uniqueHash();
+        return ConfigCompiler.configToPipelineIR(createRubyPipelineConfig(config), false).uniqueHash();
     }
 }

--- a/logstash-core/src/test/java/org/logstash/config/ir/EventConditionTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/EventConditionTest.java
@@ -19,6 +19,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static org.logstash.config.ir.CompiledPipelineTest.IDENTITY_FILTER;
+import static org.logstash.config.ir.CompiledPipelineTest.createRubyPipelineConfig;
 import static org.logstash.ext.JrubyEventExtLibrary.RubyEvent;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -55,12 +56,12 @@ public final class EventConditionTest extends RubyEnvTestCase {
     @SuppressWarnings("rawtypes")
     public void testInclusionWithFieldInField() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
-                "input {mockinput{}} filter { " +
+                createRubyPipelineConfig("input {mockinput{}} filter { " +
                         "mockfilter {} } " +
                         "output { " +
                         "  if [left] in [right] { " +
                         "    mockoutput{}" +
-                        "  } }",
+                        "  } }"),
                 false
         );
 
@@ -136,12 +137,12 @@ public final class EventConditionTest extends RubyEnvTestCase {
 
     private void testConditionWithConstantValue(String condition, int expectedMatches) throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
-                "input {mockinput{}} filter { " +
+                createRubyPipelineConfig("input {mockinput{}} filter { " +
                         "mockfilter {} } " +
                         "output { " +
                         "  if " + condition + " { " +
                         "    mockoutput{}" +
-                        "  } }",
+                        "  } }"),
                 false
         );
 

--- a/logstash-core/src/test/java/org/logstash/config/ir/PipelineTestUtil.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/PipelineTestUtil.java
@@ -17,7 +17,7 @@ public final class PipelineTestUtil {
         final Consumer<Collection<JrubyEventExtLibrary.RubyEvent>> consumer) {
         return JavaOutputDelegatorExt.create(
             "someClassName", "someId", NullMetricExt.create(), consumer, () -> {},
-            () -> {}
+            () -> {}, "L:test, C:test"
         );
     }
 }

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/FakeOutClass.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/FakeOutClass.java
@@ -5,6 +5,7 @@ import org.jruby.RubyClass;
 import org.jruby.RubyObject;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.RubyUtil;
@@ -63,14 +64,12 @@ public class FakeOutClass extends RubyObject {
 
     @JRubyMethod(name = "codec")
     public IRubyObject codec() {
-        final IRubyObject codecDelegatorClass = RubyUtil.RUBY.executeScript(
+        final RubyClass codecDelegatorClass = (RubyClass) RubyUtil.RUBY.executeScript(
                 "require 'logstash/codecs/delegator'\nLogStash::Codecs::Delegator",
                 ""
         );
-        final IRubyObject codecDelegator =
-                codecDelegatorClass.callMethod(RubyUtil.RUBY.getCurrentContext(), "new",
-                        new IRubyObject[]{RubyUtil.RUBY.newString("Fake Codec Object"),  null}
-                );
+        final IRubyObject codecDelegator = codecDelegatorClass.newInstance(RubyUtil.RUBY.getCurrentContext(),
+                RubyUtil.RUBY.newString("Fake Codec Object"), Block.NULL_BLOCK);
         return codecDelegator;
     }
 

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/FakeOutClass.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/FakeOutClass.java
@@ -7,6 +7,7 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.logstash.RubyUtil;
 
 import static org.logstash.RubyUtil.RUBY;
 
@@ -58,6 +59,19 @@ public class FakeOutClass extends RubyObject {
     public IRubyObject register() {
         registerCallCount++;
         return this;
+    }
+
+    @JRubyMethod(name = "codec")
+    public IRubyObject codec() {
+        final IRubyObject codecDelegatorClass = RubyUtil.RUBY.executeScript(
+                "require 'logstash/codecs/delegator'\nLogStash::Codecs::Delegator",
+                ""
+        );
+        final IRubyObject codecDelegator =
+                codecDelegatorClass.callMethod(RubyUtil.RUBY.getCurrentContext(), "new",
+                        new IRubyObject[]{RubyUtil.RUBY.newString("Fake Codec Object"),  null}
+                );
+        return codecDelegator;
     }
 
     @JRubyMethod(name = "metric=")

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/JavaCodecDelegatorTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/JavaCodecDelegatorTest.java
@@ -2,7 +2,6 @@ package org.logstash.config.ir.compiler;
 
 import co.elastic.logstash.api.Codec;
 import co.elastic.logstash.api.Event;
-import co.elastic.logstash.api.Metric;
 import co.elastic.logstash.api.PluginConfigSpec;
 import com.google.common.collect.ImmutableMap;
 import org.jruby.RubyHash;
@@ -198,7 +197,7 @@ public class JavaCodecDelegatorTest extends MetricTestCase {
     }
 
     private JavaCodecDelegator constructCodecDelegator() {
-        return new JavaCodecDelegator(new ContextImpl(null, this.getInstance()), codec);
+        return new JavaCodecDelegator(new ContextImpl(null, this.getInstance()), codec, null);
     }
 
     private abstract class AbstractCodec implements Codec {

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/OutputDelegatorTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/OutputDelegatorTest.java
@@ -41,6 +41,7 @@ public class OutputDelegatorTest extends PluginDelegatorTestCase {
         pluginArgs = RubyHash.newHash(RUBY);
         pluginArgs.put("id", "foo");
         pluginArgs.put("arg1", "val1");
+        pluginArgs.put("config-ref", "<Test only config reference>");
     }
 
     @Override
@@ -114,6 +115,7 @@ public class OutputDelegatorTest extends PluginDelegatorTestCase {
 
     @Test
     public void singleConcurrencyStrategyIsDefault() {
+        pluginArgs.put("config-ref", "<Test only config reference>");
         OutputDelegatorExt outputDelegator = constructOutputDelegator();
         IRubyObject concurrency = outputDelegator.concurrency(RUBY.getCurrentContext());
         assertEquals(RUBY.newSymbol("single"), concurrency);
@@ -128,6 +130,7 @@ public class OutputDelegatorTest extends PluginDelegatorTestCase {
         };
 
         for (StrategyPair pair : outputStrategies) {
+            pluginArgs.put("config-ref", "<Test only config reference>");
             FakeOutClass.setOutStrategy(RUBY.getCurrentContext(), null, pair.symbol);
             OutputDelegatorExt outputDelegator = constructOutputDelegator();
 
@@ -153,6 +156,7 @@ public class OutputDelegatorTest extends PluginDelegatorTestCase {
         };
         final ThreadContext context = RUBY.getCurrentContext();
         for (RubySymbol symbol : outputStrategies) {
+            pluginArgs.put("config-ref", "<Test only config reference>");
             FakeOutClass.create().initialize(context);
             FakeOutClass.setOutStrategy(RUBY.getCurrentContext(), null, symbol);
             OutputDelegatorExt outputDelegator = constructOutputDelegator();

--- a/logstash-core/src/test/java/org/logstash/plugins/TestPluginFactory.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/TestPluginFactory.java
@@ -20,7 +20,7 @@ public class TestPluginFactory implements RubyIntegration.PluginFactory {
     }
 
     @Override
-    public AbstractOutputDelegatorExt buildOutput(RubyString name, RubyInteger line, RubyInteger column, IRubyObject args, Map<String, Object> pluginArgs) {
+    public AbstractOutputDelegatorExt buildOutput(RubyString name, RubyInteger line, RubyInteger column, String sourceFile, int sourceLine, IRubyObject args, Map<String, Object> pluginArgs) {
         return null;
     }
 

--- a/logstash-core/src/test/java/org/logstash/plugins/TestPluginFactory.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/TestPluginFactory.java
@@ -25,7 +25,7 @@ public class TestPluginFactory implements RubyIntegration.PluginFactory {
     }
 
     @Override
-    public AbstractFilterDelegatorExt buildFilter(RubyString name, RubyInteger line, RubyInteger column, IRubyObject args, Map<String, Object> pluginArgs) {
+    public AbstractFilterDelegatorExt buildFilter(RubyString name, RubyInteger line, RubyInteger column, String sourceFile, int sourceLine, IRubyObject args, Map<String, Object> pluginArgs) {
         return null;
     }
 

--- a/logstash-core/src/test/java/org/logstash/plugins/TestPluginFactory.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/TestPluginFactory.java
@@ -30,7 +30,7 @@ public class TestPluginFactory implements RubyIntegration.PluginFactory {
     }
 
     @Override
-    public IRubyObject buildCodec(RubyString name, IRubyObject args, Map<String, Object> pluginArgs) {
+    public IRubyObject buildCodec(RubyString name, String sourceFile, int sourceLine, IRubyObject args, Map<String, Object> pluginArgs) {
         return null;
     }
 

--- a/logstash-core/src/test/java/org/logstash/plugins/TestPluginFactory.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/TestPluginFactory.java
@@ -15,7 +15,7 @@ import java.util.Map;
 public class TestPluginFactory implements RubyIntegration.PluginFactory {
 
     @Override
-    public IRubyObject buildInput(RubyString name, RubyInteger line, RubyInteger column, IRubyObject args, Map<String, Object> pluginArgs) {
+    public IRubyObject buildInput(RubyString name, RubyInteger line, RubyInteger column, String sourceFile, int sourceLine, IRubyObject args, Map<String, Object> pluginArgs) {
         return null;
     }
 

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -153,14 +153,12 @@ describe "Test Monitoring API" do
     Stud.try(max_retry.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
       # event_stats can fail if the stats subsystem isn't ready
       result = logstash_service.monitoring_api.pipeline_stats("main") rescue nil
-      puts "<><><> #{result} <><><>"
       expect(result).not_to be_nil
 
       # we use fetch here since we want failed fetches to raise an exception
       # and trigger the retry block
        inputs_stats = result.fetch("plugins").fetch("inputs")[0]
        config_ref = inputs_stats.fetch("config-ref")
-       puts ">>> inputs_stats: #{inputs_stats} <<<"
        expect(config_ref).to eq("S: config_string, L:1, C:8")
     end
   end

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -48,7 +48,7 @@ describe "Test Monitoring API" do
     end
   end
 
-  it 'can retrieve dlq stats' do
+  it "can retrieve dlq stats" do
     logstash_service = @fixture.get_service("logstash")
     logstash_service.start_with_stdin
     logstash_service.wait_for_logstash
@@ -145,6 +145,89 @@ describe "Test Monitoring API" do
     end
   end
 
+  it "can retrieve pipeline metrics stats - config string" do
+    logstash_service = @fixture.get_service("logstash")
+    logstash_service.start_with_stdin
+    logstash_service.wait_for_logstash
+
+    Stud.try(max_retry.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
+      # event_stats can fail if the stats subsystem isn't ready
+      result = logstash_service.monitoring_api.pipeline_stats("main") rescue nil
+      puts "<><><> #{result} <><><>"
+      expect(result).not_to be_nil
+
+      # we use fetch here since we want failed fetches to raise an exception
+      # and trigger the retry block
+       inputs_stats = result.fetch("plugins").fetch("inputs")[0]
+       config_ref = inputs_stats.fetch("config-ref")
+       puts ">>> inputs_stats: #{inputs_stats} <<<"
+       expect(config_ref).to eq("S: config_string, L:1, C:8")
+    end
+  end
+
+  describe "multifile pipelines" do
+
+    let!(:settings_dir) { Stud::Temporary.directory("logstash-splitted-pipeline-config-test") }
+
+    it "can retrieve pipeline metrics stats - multiple files" do
+      IO.write(settings_dir + "/pipeline_1_piece.conf", """
+      input {
+      	stdin {
+      	  codec => json {
+      	    charset => \"UTF-8\"
+      	  }
+      	}
+      }
+
+      filter {
+      	sleep {
+      		time => 1
+      	}
+      }
+      """)
+
+      IO.write(settings_dir + "/pipeline_2_piece.conf", """
+      output {
+       	stdout {
+       	  codec => rubydebug
+       	}
+      }
+      """)
+
+      logstash_service = @fixture.get_service("logstash")
+      logstash_service.spawn_logstash("--path.config", settings_dir)
+      logstash_service.wait_for_logstash
+
+      Stud.try(max_retry.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
+        # event_stats can fail if the stats subsystem isn't ready
+        result = logstash_service.monitoring_api.pipeline_stats("main") rescue nil
+        expect(result).not_to be_nil
+
+        inputs_stats = result.fetch("plugins").fetch("inputs")[0]
+        config_ref = inputs_stats.fetch("config-ref")
+        expect_source_ref(config_ref, "pipeline_1_piece.conf", 3, 8)
+
+        input_codec_stats = result.fetch("plugins").fetch("codecs").select { |c| c["name"] == "json"}.first
+        expect(input_codec_stats).not_to be_nil
+        config_ref = input_codec_stats.fetch("config-ref")
+        expect_source_ref(config_ref, "pipeline_1_piece.conf", 3, 0)
+
+        filters_stats = result.fetch("plugins").fetch("filters")[0]
+        config_ref = filters_stats.fetch("config-ref")
+        expect_source_ref(config_ref, "pipeline_1_piece.conf", 11, 8)
+
+        outputs_stats = result.fetch("plugins").fetch("outputs")[0]
+        config_ref = outputs_stats.fetch("config-ref")
+        expect_source_ref(config_ref, "pipeline_2_piece.conf", 3, 9)
+
+        output_codec_stats = result.fetch("plugins").fetch("codecs").select { |c| c["name"] == "rubydebug"}.first
+        expect(output_codec_stats).not_to be_nil
+        config_ref = output_codec_stats.fetch("parent-config-ref")
+        expect_source_ref(config_ref, "pipeline_2_piece.conf", 3, 9)
+      end
+    end
+  end
+
   private
 
   def logging_get_assert(logstash_service, logstash_level, slowlog_level)
@@ -160,6 +243,10 @@ describe "Test Monitoring API" do
 
   def logging_put_assert(result)
     expect(result["acknowledged"]).to be(true)
+  end
+
+  def expect_source_ref(config_ref, filename, expected_line, expected_column)
+    expect(config_ref).to match("S: \/tmp\/logstash-splitted-pipeline-config-test.*\/#{filename}, L:#{expected_line}, C:#{expected_column}")
   end
 
 end

--- a/x-pack/spec/monitoring/inputs/metrics/state_event/lir_serializer_spec.rb
+++ b/x-pack/spec/monitoring/inputs/metrics/state_event/lir_serializer_spec.rb
@@ -4,6 +4,7 @@
 
 require "spec_helper"
 require "logstash/environment"
+require "logstash/config/pipeline_config"
 
 describe ::LogStash::Config::LIRSerializer do
   let(:config) do
@@ -21,8 +22,10 @@ describe ::LogStash::Config::LIRSerializer do
     [org.logstash.common.SourceWithMetadata.new("string", "spec", config)]
   end
 
+  let(:pipeline_config) { LogStash::Config::PipelineConfig.new("x-pack_lir_serializer_test", "lir", config_source_with_metadata, LogStash::SETTINGS) }
+
   let(:lir_pipeline) do
-    ::LogStash::Compiler.compile_sources(config_source_with_metadata, LogStash::SETTINGS)
+    ::LogStash::Compiler.compile_sources(pipeline_config, LogStash::SETTINGS)
   end
 
   describe "#serialize" do


### PR DESCRIPTION
**Abstract**
This PR contains the implementation to expose through HTTP API  the triple (file, line, column) source's config of every plugin. It contains also shared part with Ruby's one.

**Description**
This PR introduce the ground part to carry out some metadata from the configuration scripts, these metadata regards source file, line and column in which a specific plugin is defined inside the pipeline and associate it with its runtime generated uuid. These data is exposed inside the metrics of each plugin so that the connection between plugin UUID -> config file reference should be more walkable.

This PR is for java execution pipeline, so interest Java and Ruby plugins executed by the Java pipeline. 

Changed PipelineCompiler to accept PipelineConfig instead of SourceWithMetadata array because in PipelineConfig has been introduced a remapping method from global line number (because SourceWithMeta comes with a string that's the join of all pipiline's config files, e.g. inputs in one file, filter in another etc, then before compile that files are merge din one big string) while a single SourceWithMetadata doesn't have visibility on all segments. This happen with help of ConfigSourceSegment.

After this remapping phase, done before the pipeline creation, we have to store the information related to the triple (source, line, column) into the AST Nod so that can be used during the instantiation of plugins, because every instance of a plugin has to carry this information because has to be exposed in the metrics.

Rest of the PR is to propagate and expose this information in the 4 kind of plugins we have, plus the fixing of tests.