### PR TITLE
Fixes the ES endpoint to asks license

### DIFF
--- a/docs/static/monitoring/troubleshooting.asciidoc
+++ b/docs/static/monitoring/troubleshooting.asciidoc
@@ -17,7 +17,7 @@ disabled for security reasons. To resume monitoring:
 --
 [source, sh]
 ---------------------------------------------------------------
-PUT _xpack/security/user/logstash_system/_password
+PUT _security/user/logstash_system/_password
 {
   "password": "newpassword"
 }
@@ -30,7 +30,7 @@ PUT _xpack/security/user/logstash_system/_password
 --
 [source, sh]
 ---------------------------------------------------------------
-PUT _xpack/security/user/logstash_system/_enable
+PUT _security/user/logstash_system/_enable
 ---------------------------------------------------------------
 //CONSOLE
 --

--- a/docs/static/security/logstash.asciidoc
+++ b/docs/static/security/logstash.asciidoc
@@ -44,7 +44,7 @@ management], also add `manage_ilm` for cluster and `manage` and `manage_ilm` for
 +
 [source, sh]
 ---------------------------------------------------------------
-POST _xpack/security/role/logstash_writer
+POST _security/role/logstash_writer
 {
   "cluster": ["manage_index_templates", "monitor", "manage_ilm"], <1>
   "indices": [
@@ -71,7 +71,7 @@ the `user` API:
 +
 [source, sh]
 ---------------------------------------------------------------
-POST _xpack/security/user/logstash_internal
+POST _security/user/logstash_internal
 {
   "password" : "x-pack-test-password",
   "roles" : [ "logstash_writer"],
@@ -121,7 +121,7 @@ privileges  for the Logstash indices. You can create roles from the
 +
 [source, sh]
 ---------------------------------------------------------------
-POST _xpack/security/role/logstash_reader
+POST _security/role/logstash_reader
 {
   "indices": [
     {
@@ -142,7 +142,7 @@ also assign the `logstash_admin` role. You can create and manage users from the
 +
 [source, sh]
 ---------------------------------------------------------------
-POST _xpack/security/user/logstash_user
+POST _security/user/logstash_user
 {
   "password" : "x-pack-test-password",
   "roles" : [ "logstash_reader", "logstash_admin"], <1>
@@ -215,7 +215,7 @@ password API:
 
 [source,js]
 ---------------------------------------------------------------------
-PUT _xpack/security/user/logstash_system/_password
+PUT _security/user/logstash_system/_password
 {
   "password": "t0p.s3cr3t"
 }
@@ -236,7 +236,7 @@ You can enable the user through the `user` API:
 
 [source,js]
 ---------------------------------------------------------------------
-PUT _xpack/security/user/logstash_system/_enable
+PUT _security/user/logstash_system/_enable
 ---------------------------------------------------------------------
 // CONSOLE
 

--- a/x-pack/qa/integration/support/elasticsearch/api/actions/update_password.rb
+++ b/x-pack/qa/integration/support/elasticsearch/api/actions/update_password.rb
@@ -9,7 +9,7 @@ module Elasticsearch
       # Update the password of the specified user
       def update_password(arguments={})
         method = HTTP_PUT
-        path   = Utils.__pathify '_xpack/security/user/',
+        path   = Utils.__pathify '_security/user/',
                                  Utils.__escape(arguments[:user]),
                                  '/_password'
         params = {}

--- a/x-pack/qa/integration/support/helpers.rb
+++ b/x-pack/qa/integration/support/helpers.rb
@@ -57,8 +57,8 @@ def elasticsearch(options = {})
 end
 
 def start_es_xpack_trial
-  if elasticsearch_client.perform_request(:get, '_xpack/license').body['license']['type'] != 'trial'
-    resp = elasticsearch_client.perform_request(:post, '_xpack/license/start_trial', "acknowledge" => true)
+  if elasticsearch_client.perform_request(:get, '_license').body['license']['type'] != 'trial'
+    resp = elasticsearch_client.perform_request(:post, '_license/start_trial', "acknowledge" => true)
     if resp.body["trial_was_started"] != true
       raise "Trial not started: #{resp.body}"
     end


### PR DESCRIPTION
In ES version 8 the end point for license check changed from `_xpack/license` to `_license`