### PR TITLE
[Doc]Restructure configuration content

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -94,40 +94,45 @@ include::static/upgrading.asciidoc[]
 
 // Configuring Logstash
 
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/configuration.asciidoc
+:edit_url!:
 include::static/configuration.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/multiple-pipelines.asciidoc
+// Advanced Logstash Configurion
+
+:edit_url!:
+include::static/configuration-advanced.asciidoc[]
+
+:edit_url!:
 include::static/multiple-pipelines.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/pipeline-pipeline-config.asciidoc
+:edit_url!:
 include::static/pipeline-pipeline-config.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/reloading-config.asciidoc
+:edit_url!:
 include::static/reloading-config.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/managing-multiline-events.asciidoc
+:edit_url!:
 include::static/managing-multiline-events.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/glob-support.asciidoc
+:edit_url!:
 include::static/glob-support.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/ingest-convert.asciidoc
+:edit_url!:
 include::static/ingest-convert.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/ls-ls-config.asciidoc
+:edit_url!:
 include::static/ls-ls-config.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/management/configuring-centralized-pipelines.asciidoc
+:edit_url!:
 include::static/management/configuring-centralized-pipelines.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/security/logstash.asciidoc
+:edit_url!:
 include::static/security/logstash.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/setup/configuring-xls.asciidoc
+:edit_url!:
 include::static/setup/configuring-xls.asciidoc[]
 
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/field-reference.asciidoc
+:edit_url!:
 include::static/field-reference.asciidoc[]
 
 //The `field-reference.asciidoc` file (included above) contains a
@@ -135,7 +140,7 @@ include::static/field-reference.asciidoc[]
 //Ref, but not appear in the main TOC. The `exclude`attribute was carrying
 //forward for all subsequent topics under the `configuration.asciidoc` heading.
 //This include should remain after includes for all other topics under the
-//`Configuring Logstash` heading.
+//`Advanced Logstash Configuration` heading.
 
 // Centralized configuration managements
 :edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/config-management.asciidoc

--- a/docs/static/configuration-advanced.asciidoc
+++ b/docs/static/configuration-advanced.asciidoc
@@ -1,0 +1,6 @@
+[[configuration-advanced]]
+== Advanced Logstash Configurations
+
+You can take {ls} beyond basic configuration to handle more advanced
+requirements, such as multiple pipelines, communication between {ls} pipelines,
+and multiple line events. 

--- a/docs/static/pipeline-pipeline-config.asciidoc
+++ b/docs/static/pipeline-pipeline-config.asciidoc
@@ -34,7 +34,7 @@ When events are sent across pipelines, their data is fully copied. Modifications
 The `pipeline` plugin may be the most efficient way to communicate between pipelines, but it still incurs a performance cost. Logstash must duplicate each event in full on the Java heap for each downstream pipeline. Using this feature may affect the heap memory utilization of Logstash.
 
 [[delivery-guarantees]]
-===== Delivery Guarantees
+===== Delivery guarantees
 In its standard configuration the `pipeline` input/output has at-least-once delivery guarantees. The output will be
 blocked if the address is blocked or unavailable.
 


### PR DESCRIPTION
Divide configuring content into core and advanced sections in preparation for more restructuring.
Overrides more hard-coded edit URLs. Default will resolve for these topics. 