### PR TITLE
Fixed: avoid touch of log files before deleting it (issue #11307)

### DIFF
--- a/logstash-core/src/test/java/org/logstash/log/DefaultDeprecationLoggerTest.java
+++ b/logstash-core/src/test/java/org/logstash/log/DefaultDeprecationLoggerTest.java
@@ -40,9 +40,8 @@ public class DefaultDeprecationLoggerTest {
 
     @After
     public void tearDown() throws IOException {
-        LogTestUtils.reloadLogConfiguration();
-
         LogTestUtils.deleteLogFile("logstash-deprecation.log");
+        LogTestUtils.reloadLogConfiguration();
     }
 
     @Test


### PR DESCRIPTION
This PR invert the steps of deletion of log files and recreation of log context (which itself creates the log file), trying to avoid issue #11307 