### PR TITLE
Integration plugin docs support

### DIFF
--- a/rakelib/plugins_docs_dependencies.rake
+++ b/rakelib/plugins_docs_dependencies.rake
@@ -5,6 +5,15 @@ class PluginVersionWorking
   EXPORT_FILE = ::File.expand_path(::File.join(::File.dirname(__FILE__), "..", "plugins_version_docs.json"))
   PLUGIN_METADATA = JSON.parse(IO.read(::File.expand_path(::File.join(::File.dirname(__FILE__), "plugins-metadata.json"))))
 
+  PLUGIN_PACKAGE_TYPES = %w(
+    input
+    output
+    codec
+    filter
+  ).freeze
+
+  PLUGIN_PACKAGE_NAME_PATTERN = %r{^logstash-#{Regexp::union(PLUGIN_PACKAGE_TYPES)}-}
+
   # Simple class to make sure we get the right version for the document
   # since we will record multiple versions for one plugin
   class VersionDependencies
@@ -117,7 +126,7 @@ class PluginVersionWorking
     # Bundler doesn't seem to provide us with `spec.metadata` for remotely
     # discovered plugins (via rubygems.org api), so we have to choose by
     # a name pattern instead of by checking spec.metadata["logstash_plugin"]
-    definition.resolve.select { |spec| spec.name =~ /^logstash-(input|filter|output|codec)-/ }.each do |spec|
+    definition.resolve.select { |spec| spec.name =~ PLUGIN_PACKAGE_NAME_PATTERN }.each do |spec|
       dependencies[spec.name] ||= []
       dependencies[spec.name] << VersionDependencies.new(spec.version, from)
     end

--- a/rakelib/plugins_docs_dependencies.rake
+++ b/rakelib/plugins_docs_dependencies.rake
@@ -10,6 +10,7 @@ class PluginVersionWorking
     output
     codec
     filter
+    integration
   ).freeze
 
   PLUGIN_PACKAGE_NAME_PATTERN = %r{^logstash-#{Regexp::union(PLUGIN_PACKAGE_TYPES)}-}


### PR DESCRIPTION
The rake task that generates a json manifest of installed plugin versions for [doc generation's `plugindocs.rb`](https://github.com/elastic/docs-tools/blob/2291ca1feab8835383e54c1d31a222e8aaa80d55/plugindocs.rb#L18) selects the subset of logstash dependencies matching a specific pattern, but this pattern does not include the new integration plugins that are set to ship with Logstash 7.5.

This PR first refactors the list of acceptable plugin types out of a regular expression into a more readable array, and then adds `integration` to the mix.

Merge targets: `master`, `7.x`, `7.5`