### PR TITLE
[DOC]Add plugin integrations to doc

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -207,6 +207,7 @@ include::{plugins-repo-dir}/plugins/inputs.asciidoc[]
 include::{plugins-repo-dir}/plugins/outputs.asciidoc[]
 include::{plugins-repo-dir}/plugins/filters.asciidoc[]
 include::{plugins-repo-dir}/plugins/codecs.asciidoc[]
+include::{plugins-repo-dir}/plugins/integrations.asciidoc[]
 
 // FAQ and Troubleshooting
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -203,11 +203,11 @@ include::static/plugin-manager.asciidoc[]
 
 // These files do their own pass blocks
 
+include::{plugins-repo-dir}/plugins/integrations.asciidoc[]
 include::{plugins-repo-dir}/plugins/inputs.asciidoc[]
 include::{plugins-repo-dir}/plugins/outputs.asciidoc[]
 include::{plugins-repo-dir}/plugins/filters.asciidoc[]
 include::{plugins-repo-dir}/plugins/codecs.asciidoc[]
-include::{plugins-repo-dir}/plugins/integrations.asciidoc[]
 
 // FAQ and Troubleshooting
 


### PR DESCRIPTION
Dependencies:
- [x] Integration asciidoc files must be present in `logstash-docs` repo
- [ ] Integrations landing page must be merged.
Note: `elasticsearch-ci/docs` will remain RED until that happens. 




