### PR TITLE
Changed GemInstaller to don't blank  gemspec attribute

### DIFF
--- a/lib/pluginmanager/gem_installer.rb
+++ b/lib/pluginmanager/gem_installer.rb
@@ -38,7 +38,13 @@ module LogStash module PluginManager
 
     private
     def spec
-      @gem.spec
+      gem_spec = @gem.spec
+      def gem_spec.for_cache
+        spec = dup
+        spec.test_files = nil
+        spec
+      end
+      gem_spec
     end
 
     def spec_dir


### PR DESCRIPTION
This PR tries to solve issue #11325.
The main problem seems to be that during the installation the `Gem::Specification.for_cache` method clean out the `files` and `test_files` attributes(https://github.com/jruby/jruby/blob/master/lib/ruby/stdlib/rubygems/specification.rb#L1995). Cleaning the attribute skip the processing in `to_ruby` method.
https://github.com/jruby/jruby/blob/master/lib/ruby/stdlib/rubygems/specification.rb#L2607-L2609
https://github.com/jruby/jruby/blob/master/lib/ruby/stdlib/rubygems/specification.rb#L2550-L2557.

The solution proposed with this PR is to overwrite the method `def for_cache` in the gem's instance to avoid the blanking of the field