### PR TITLE
[DOCS] Fixes monitoring link

### DIFF
--- a/docs/static/monitoring/monitoring-overview.asciidoc
+++ b/docs/static/monitoring/monitoring-overview.asciidoc
@@ -5,8 +5,8 @@
 Use the {stack} {monitor-features} to gain insight into the health of
 {ls} instances running in your environment.
 
-For an introduction to monitoring your Elastic stack, including {es}
-and {kib}, see {xpack-ref}/xpack-monitoring.html[Monitoring the Elastic Stack].
+For an introduction to monitoring your Elastic stack, see
+{ref}/monitor-elasticsearch-cluster.html[Monitoring a cluster].
 
 
 [float]


### PR DESCRIPTION
Related to elastic/elasticsearch#46880

This PR fixes links to content that has moved from the Stack Overview to the Elasticsearch Reference.

In particular, this PR fixes the following broken link in https://github.com/elastic/stack-docs/pull/700

> 11:08:36 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/logstash/master/configuring-logstash.html:
11:08:36 INFO:build_docs:   - en/elastic-stack-overview/master/xpack-monitoring.html

Preview: http://logstash_11341.docs-preview.app.elstc.co/guide/en/logstash/master/configuring-logstash.html