### PR TITLE
Remove license header from pipelines_info.rb

### DIFF
--- a/logstash-core/lib/logstash/config/pipelines_info.rb
+++ b/logstash-core/lib/logstash/config/pipelines_info.rb
@@ -1,7 +1,3 @@
-# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-# or more contributor license agreements. Licensed under the Elastic License;
-# you may not use this file except in compliance with the Elastic License.
-#
 module LogStash; module Config;
   class PipelinesInfo
     def self.format_pipelines_info(agent, metric_store, extended_performance_collection)


### PR DESCRIPTION
This code was moved to the apache 2.0 license part of the distribution and should not have the license header any more

fixes #11344 