### PR TITLE
Changed: base JRUBY_OPTS to default to --dev (for 'fast' scripts)

### DIFF
--- a/bin/logstash-keystore
+++ b/bin/logstash-keystore
@@ -6,6 +6,6 @@ setup
 
 # bin/logstash-keystore is a short lived ruby script thus we can use aggressive "faster starting JRuby options"
 # see https://github.com/jruby/jruby/wiki/Improving-startup-time
-export JRUBY_OPTS="$JRUBY_OPTS -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -X-C -Xcompile.invokedynamic=false"
+export JRUBY_OPTS="${JRUBY_OPTS---dev}"
 
 ruby_exec "${LOGSTASH_HOME}/lib/secretstore/cli.rb" "$@"

--- a/bin/logstash-plugin
+++ b/bin/logstash-plugin
@@ -6,6 +6,6 @@ setup
 
 # bin/logstash-plugin is a short lived ruby script thus we can use aggressive "faster starting JRuby options"
 # see https://github.com/jruby/jruby/wiki/Improving-startup-time
-export JRUBY_OPTS="$JRUBY_OPTS -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -X-C -Xcompile.invokedynamic=false"
+export JRUBY_OPTS="${JRUBY_OPTS---dev}"
 
 ruby_exec "${LOGSTASH_HOME}/lib/pluginmanager/main.rb" "$@"

--- a/bin/rspec
+++ b/bin/rspec
@@ -5,6 +5,6 @@ unset CDPATH
 setup
 
 # use faster starting JRuby options see https://github.com/jruby/jruby/wiki/Improving-startup-time
-export JRUBY_OPTS="$JRUBY_OPTS -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1"
+export JRUBY_OPTS="${JRUBY_OPTS---dev}"
 
 ruby_exec "${LOGSTASH_HOME}/lib/bootstrap/rspec.rb" "$@"

--- a/bin/ruby
+++ b/bin/ruby
@@ -12,7 +12,7 @@
 #   DEBUG=1 to output debugging information
 
 # use faster starting JRuby options see https://github.com/jruby/jruby/wiki/Improving-startup-time
-export JRUBY_OPTS="$JRUBY_OPTS -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1"
+export JRUBY_OPTS="${JRUBY_OPTS---dev}"
 
 unset CDPATH
 


### PR DESCRIPTION
either take the provide `JRUBY_OPTS` or use `--dev`
its confusing when provided `JRUBY_OPTS` are being mixed, any reasoning for that?

NOTE: `--dev` is pretty much exactly the same (works on JRuby 9K) as: 
`-J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -X-C -Xcompile.invokedynamic=false`

details at: https://github.com/jruby/jruby/blob/9.2.9.0/bin/.dev_mode.java_opts
