### PR TITLE
Fix: do not leak ThreadContext into the system

### DIFF
--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -8,10 +8,11 @@ require "logstash/instrument/collector"
 require "logstash/compiler"
 require "logstash/config/lir_serializer"
 
-java_import org.apache.logging.log4j.ThreadContext
-
 module LogStash; class JavaPipeline < JavaBasePipeline
   include LogStash::Util::Loggable
+
+  java_import org.apache.logging.log4j.ThreadContext
+
   attr_reader \
     :worker_threads,
     :events_consumed,

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -12,10 +12,10 @@ require "logstash/instrument/collector"
 require "logstash/filter_delegator"
 require "logstash/compiler"
 
-java_import org.apache.logging.log4j.ThreadContext
-
 module LogStash; class BasePipeline < AbstractPipeline
   include LogStash::Util::Loggable
+
+  java_import org.apache.logging.log4j.ThreadContext
 
   attr_reader :inputs, :filters, :outputs
 


### PR DESCRIPTION
this is fairly recent - since 7.4 (added in GH-11075)

there's a risk plugins would assume ThreadContext to
exist or collide the 'global' constant - usually best
to import where the Java class actually gets used ...