### PR TITLE
Make SETTINGS_DIR consistent with CWD

### DIFF
--- a/bin/system-install
+++ b/bin/system-install
@@ -65,9 +65,9 @@ export JRUBY_OPTS="$JRUBY_OPTS -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=
 
 tempfile=$(mktemp)
 if [ "x${PRESTART}" == "x" ]; then
-  opts=("--log" "$tempfile" "--overwrite" "--install" "--name" "${SERVICE_NAME}" "--user" "${LS_USER}" "--group" "${LS_GROUP}" "--description" "${SERVICE_DESCRIPTION}" "--nice" "${LS_NICE}" "--limit-open-files" "${LS_OPEN_FILES}")
+  opts=("--log" "$tempfile" "--overwrite" "--install" "--name" "${SERVICE_NAME}" "--user" "${LS_USER}" "--group" "${LS_GROUP}" "--description" "${SERVICE_DESCRIPTION}" "--nice" "${LS_NICE}" "--limit-open-files" "${LS_OPEN_FILES}" "--chdir" "${LS_SETTINGS_DIR}")
 else
-  opts=("--log" "$tempfile" "--overwrite" "--install" "--name" "${SERVICE_NAME}" "--user" "${LS_USER}" "--group" "${LS_GROUP}" "--description" "${SERVICE_DESCRIPTION}" "--nice" "${LS_NICE}" "--limit-open-files" "${LS_OPEN_FILES}" "--prestart" "${PRESTART}")
+  opts=("--log" "$tempfile" "--overwrite" "--install" "--name" "${SERVICE_NAME}" "--user" "${LS_USER}" "--group" "${LS_GROUP}" "--description" "${SERVICE_DESCRIPTION}" "--nice" "${LS_NICE}" "--limit-open-files" "${LS_OPEN_FILES}" "--chdir" "${LS_SETTINGS_DIR}"  "--prestart" "${PRESTART}")
 fi
 
 if [[ $2 ]]; then


### PR DESCRIPTION
During init script generation, the `pleaserun` defaults CWD to `/`. This results in an inconsistency between Logstash as a service and Docker, where the default CWD is /usr/share/logstash. 

Making `pleaserun` use LS_SETTINGS_DIR makes the behavior consistent.