### PR TITLE
[DOCS] Fixes occurrences of xpack-ref attribute

### DIFF
--- a/docs/static/azure-module.asciidoc
+++ b/docs/static/azure-module.asciidoc
@@ -492,7 +492,7 @@ the event originated.
 ==== Deploying the module in production 
 
 Use security best practices to secure your configuration.
-See {stack-ov}/xpack-security.html for details and recommendations.
+See {ref}/secure-cluster.html[Secure a cluster] for details and recommendations.
 
 [[azure-resources]]
 ==== Microsoft Azure resources 

--- a/docs/static/deploying.asciidoc
+++ b/docs/static/deploying.asciidoc
@@ -123,8 +123,8 @@ Enterprise-grade security is available across the entire delivery chain.
 {logstash-ref}/ls-security.html[Logstash to Elasticsearch].
 * There’s a wealth of security options when communicating with Elasticsearch
 including basic authentication, TLS, PKI, LDAP, AD, and other custom realms.
-To enable Elasticsearch security, consult the
-{xpack-ref}/xpack-security.html[X-Pack documentation].
+To enable Elasticsearch security, consult
+{ref}/secure-cluster.html[Secure a cluster].
 
 [float]
 ==== Monitoring

--- a/docs/static/docker.asciidoc
+++ b/docs/static/docker.asciidoc
@@ -9,7 +9,7 @@ https://github.com/elastic/logstash/tree/{branch}[GitHub].
 
 These images are free to use under the Elastic license. They contain open source 
 and free commercial features and access to paid commercial features.  
-{xpack-ref}/license-management.html[Start a 30-day trial] to try out all of the 
+{stack-ov}/license-management.html[Start a 30-day trial] to try out all of the 
 paid commercial features. See the 
 https://www.elastic.co/subscriptions[Subscriptions] page for information about 
 Elastic license levels.

--- a/docs/static/getting-started-with-logstash.asciidoc
+++ b/docs/static/getting-started-with-logstash.asciidoc
@@ -52,7 +52,7 @@ Unpack the file. Do not install Logstash into a directory path that contains col
 --
 These packages are free to use under the Elastic license. They contain open 
 source and free commercial features and access to paid commercial features.  
-{xpack-ref}/license-management.html[Start a 30-day trial] to try out all of the 
+{stack-ov}/license-management.html[Start a 30-day trial] to try out all of the 
 paid commercial features. See the 
 https://www.elastic.co/subscriptions[Subscriptions] page for information about 
 Elastic license levels. 

--- a/docs/static/management/configuring-centralized-pipelines.asciidoc
+++ b/docs/static/management/configuring-centralized-pipelines.asciidoc
@@ -13,7 +13,7 @@ feature.
 +
 --
 For more information, see https://www.elastic.co/subscriptions and 
-{xpack-ref}/license-management.html[License Management].
+{stack-ov}/license-management.html[License Management].
 --
 
 . Specify 

--- a/docs/static/monitoring/configuring-logstash.asciidoc
+++ b/docs/static/monitoring/configuring-logstash.asciidoc
@@ -10,7 +10,7 @@ To monitor Logstash nodes:
 
 . Identify where to send monitoring data. This cluster is often referred to as
 the _production cluster_. For examples of typical monitoring architectures, see
-{xpack-ref}/how-monitoring-works.html[How Monitoring Works].
+{ref}/how-monitoring-works.html[How monitoring works].
 +
 --
 IMPORTANT: To visualize Logstash as part of the Elastic Stack (as shown in Step

--- a/docs/static/monitoring/intro.asciidoc
+++ b/docs/static/monitoring/intro.asciidoc
@@ -16,4 +16,4 @@ each plugin in the view.
 
 This documentation focuses on the {monitoring} infrastructure and setup in
 Logstash. For an introduction to monitoring your Elastic stack, including {es}
-and {kib}, see {xpack-ref}/xpack-monitoring.html[Monitoring the Elastic Stack].
+and {kib}, see {ref}/monitor-elasticsearch-cluster.html[Monitor a cluster].

--- a/docs/static/monitoring/monitoring-overview.asciidoc
+++ b/docs/static/monitoring/monitoring-overview.asciidoc
@@ -29,7 +29,7 @@ expected to be the production cluster. This configuration enables the production
 {es} cluster to add metadata (for example, its cluster UUID) to the Logstash
 monitoring data then route it to the monitoring clusters. For more information 
 about typical monitoring architectures, see 
-{xpack-ref}/how-monitoring-works.html[How Monitoring Works]. 
+{ref}/how-monitoring-works.html[How monitoring works]. 
 
 include::collectors.asciidoc[]
 include::monitoring-output.asciidoc[]

--- a/docs/static/setup/setting-up-xpack.asciidoc
+++ b/docs/static/setup/setting-up-xpack.asciidoc
@@ -7,6 +7,6 @@ monitoring, machine learning, pipeline management, and many other capabilities.
 By default, when you install Logstash, {xpack} is installed. 
 
 If you want to try all of the {xpack} features, you can 
-{xpack-ref}/license-management.html[start a 30-day trial]. At the end of the 
+{stack-ov}/license-management.html[start a 30-day trial]. At the end of the 
 trial period, you can purchase a subscription to keep using the full 
 functionality of the {xpack} components. For more information, see https://www.elastic.co/subscriptions.


### PR DESCRIPTION
This PR fixes links that are incorrectly sending users to the X-Pack Reference or Stack Overview.

It also fixes the following links that will break in elastic/docs#1490

> 12:47:37 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/logstash/6.3/deploying-and-scaling.html:
12:47:37 INFO:build_docs:   - en/x-pack/6.2/xpack-security.html
12:47:37 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/logstash/6.4/deploying-and-scaling.html:
12:47:37 INFO:build_docs:   - en/x-pack/6.2/xpack-security.html
12:47:37 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/logstash/6.5/deploying-and-scaling.html:
12:47:37 INFO:build_docs:   - en/x-pack/6.2/xpack-security.html
12:47:37 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/logstash/6.6/deploying-and-scaling.html:
12:47:37 INFO:build_docs:   - en/x-pack/6.2/xpack-security.html
12:47:37 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/logstash/6.7/deploying-and-scaling.html:
12:47:37 INFO:build_docs:   - en/x-pack/6.2/xpack-security.html