### PR TITLE
Refactor: avoid ThreadContext retrieval + use Ruby API

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/AckedBatch.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/AckedBatch.java
@@ -1,8 +1,9 @@
 package org.logstash.ackedqueue;
 
 import java.io.IOException;
+import org.jruby.Ruby;
+import org.jruby.RubyBoolean;
 import org.jruby.RubyHash;
-import org.jruby.runtime.ThreadContext;
 import org.logstash.Event;
 import org.logstash.ext.JrubyEventExtLibrary;
 
@@ -15,11 +16,12 @@ public final class AckedBatch {
         return ackedBatch;
     }
 
-    public RubyHash toRubyHash(ThreadContext context) {
-        final RubyHash result = RubyHash.newHash(context.runtime);
-        this.batch.getElements().forEach(e -> result.put(
-            JrubyEventExtLibrary.RubyEvent.newRubyEvent(context.runtime, (Event) e),
-            context.tru
+    public RubyHash toRubyHash(final Ruby runtime) {
+        final RubyBoolean trueValue = runtime.getTrue();
+        final RubyHash result = RubyHash.newHash(runtime);
+        this.batch.getElements().forEach(e -> result.fastASet(
+            JrubyEventExtLibrary.RubyEvent.newRubyEvent(runtime, (Event) e),
+            trueValue
             )
         );
         return result;

--- a/logstash-core/src/main/java/org/logstash/execution/MemoryReadBatch.java
+++ b/logstash-core/src/main/java/org/logstash/execution/MemoryReadBatch.java
@@ -1,7 +1,6 @@
 package org.logstash.execution;
 
 import org.jruby.RubyArray;
-import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.ext.JrubyEventExtLibrary;
 
@@ -32,11 +31,10 @@ public final class MemoryReadBatch implements QueueBatch {
     @Override
     @SuppressWarnings({"rawtypes"})
     public RubyArray to_a() {
-        ThreadContext context = RUBY.getCurrentContext();
-        final RubyArray result = context.runtime.newArray(events.size());
+        final RubyArray result = RUBY.newArray(events.size());
         for (final IRubyObject event : events) {
             if (!isCancelled(event)) {
-                result.add(event);
+                result.append(event);
             }
         }
         return result;


### PR DESCRIPTION
- thread-context isn't needed - only the runtime is really used
- native Ruby types do not need to pass through Java coercion

`RubyHash`/`RubyArray` API used is considered stable and makes sense to be used, saves a few cycles (and probably improve inlining since there will be less byte-code in the way) - not that it matters.