### PR TITLE
[DOCS] Replaces occurrences of xpack-ref

### DIFF
--- a/docs/static/docker.asciidoc
+++ b/docs/static/docker.asciidoc
@@ -9,7 +9,7 @@ https://github.com/elastic/logstash/tree/{branch}[GitHub].
 
 These images are free to use under the Elastic license. They contain open source 
 and free commercial features and access to paid commercial features.  
-{xpack-ref}/license-management.html[Start a 30-day trial] to try out all of the 
+{stack-ov}/license-management.html[Start a 30-day trial] to try out all of the 
 paid commercial features. See the 
 https://www.elastic.co/subscriptions[Subscriptions] page for information about 
 Elastic license levels.

--- a/docs/static/getting-started-with-logstash.asciidoc
+++ b/docs/static/getting-started-with-logstash.asciidoc
@@ -57,7 +57,7 @@ contains colon (:) characters.
 --
 These packages are free to use under the Elastic license. They contain open 
 source and free commercial features and access to paid commercial features.  
-{xpack-ref}/license-management.html[Start a 30-day trial] to try out all of the 
+{stack-ov}/license-management.html[Start a 30-day trial] to try out all of the 
 paid commercial features. See the 
 https://www.elastic.co/subscriptions[Subscriptions] page for information about 
 Elastic license levels. 

--- a/docs/static/management/configuring-centralized-pipelines.asciidoc
+++ b/docs/static/management/configuring-centralized-pipelines.asciidoc
@@ -13,7 +13,7 @@ feature.
 +
 --
 For more information, see https://www.elastic.co/subscriptions and 
-{xpack-ref}/license-management.html[License Management].
+{stack-ov}/license-management.html[License management].
 --
 
 . Specify 

--- a/docs/static/setup/setting-up-xpack.asciidoc
+++ b/docs/static/setup/setting-up-xpack.asciidoc
@@ -7,6 +7,6 @@ monitoring, machine learning, pipeline management, and many other capabilities.
 By default, when you install Logstash, {xpack} is installed. 
 
 If you want to try all of the {xpack} features, you can 
-{xpack-ref}/license-management.html[start a 30-day trial]. At the end of the 
+{stack-ov}/license-management.html[start a 30-day trial]. At the end of the 
 trial period, you can purchase a subscription to keep using the full 
 functionality of the {xpack} components. For more information, see https://www.elastic.co/subscriptions.


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/1490 and https://github.com/elastic/logstash/pull/11360

This PR replaces usage of the {xpack-ref} shared attribute in the Logstash Reference

