### PR TITLE
Build: fix bundle bin path in bundler task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,7 @@ def assemblyDeps = [downloadAndInstallJRuby, assemble] + subprojects.collect {
 }
 
 task installBundler(dependsOn: assemblyDeps) {
-  outputs.files file("${projectDir}/vendor/bundle/bin/bundle")
+  outputs.files file("${projectDir}/vendor/bundle/jruby/2.5.0/bin/bundle")
   doLast {
       gem(projectDir, buildDir, "bundler", "1.17.3", "${projectDir}/vendor/bundle/jruby/2.5.0")
   }


### PR DESCRIPTION
follow-up on d65f78728be7e702c43cea5682b8ddc93054a231

as we've seen some issues with gradle, `./gradlew clean installDefaultGems`
and also a reduced `./gradlew clean installBundler` would sometimes skip the installBundler task

NOTE: `bin/bundle` should not be there as it gets excluded during JRuby install