### PR TITLE
[Doc]Add default edit_me links to pages

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -211,10 +211,10 @@ include::{plugins-repo-dir}/plugins/codecs.asciidoc[]
 
 // FAQ and Troubleshooting
 
-// :edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/faq.asciidoc
+:edit_url!:
 include::static/best-practice.asciidoc[]
 
-// :edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/troubleshooting.asciidoc
+:edit_url!:
 include::static/troubleshooting.asciidoc[]
 
 :edit_url:


### PR DESCRIPTION
Adds `Edit` link to Tips and Best Practices and Troubleshooting sections in the Logstash Reference.  Uses default link to source pages.