### PR TITLE
Disable flaky test "should include the http address"

### DIFF
--- a/spec/support/resource_dsl_methods.rb
+++ b/spec/support/resource_dsl_methods.rb
@@ -45,6 +45,7 @@ module ResourceDSLMethods
         end
 
         it "should include the http address" do
+          skip("flaky test tracked in https://github.com/elastic/logstash/issues/11385")
           expect(payload["http_address"]).to eql("127.0.0.1:#{::LogStash::WebServer::DEFAULT_PORTS.first}")
         end
 


### PR DESCRIPTION
follow up at https://github.com/elastic/logstash/issues/11385

[edit] we use `skip("reason")` instead of `xit` because `xit` it doesn't give us a way to point the tracking github issue other than adding a code comment.