### PR TITLE
Added retry in deletion of log file during integration test (deprecation logger)

### DIFF
--- a/logstash-core/src/test/java/org/logstash/log/LogTestUtils.java
+++ b/logstash-core/src/test/java/org/logstash/log/LogTestUtils.java
@@ -3,6 +3,7 @@ package org.logstash.log;
 import org.apache.logging.log4j.core.LoggerContext;
 
 import java.io.IOException;
+import java.nio.file.FileSystemException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,6 +30,31 @@ class LogTestUtils {
     static void deleteLogFile(String logfileName) throws IOException {
         Path path = FileSystems.getDefault()
                 .getPath(System.getProperty("user.dir"), System.getProperty("ls.logs"), logfileName);
-        Files.deleteIfExists(path);
+        pollingDelete(path, 5, TimeUnit.SECONDS);
+    }
+
+    static void pollingDelete(Path path, int sleep, TimeUnit timeUnit) throws IOException {
+        final int maxRetries = 5;
+        int retries = 0;
+        do {
+            try {
+                Files.deleteIfExists(path);
+                break;
+            } catch (FileSystemException fsex) {
+                System.out.println("FS access error while deleting, " + fsex.getReason() + " deleting: " + fsex.getOtherFile());
+            }
+
+            try {
+                Thread.sleep(timeUnit.toMillis(sleep));
+            } catch (InterruptedException e) {
+                // follows up
+                Thread.currentThread().interrupt();
+                break;
+            }
+
+            retries++;
+        } while (retries < maxRetries);
+
+        assertTrue("Exhausted 5 retries to delete the file: " + path,retries < maxRetries);
     }
 }


### PR DESCRIPTION
Changed the deletion of log files to use retry mechanism and avoid flaky errors on Windows builds (related to #11307)