### PR TITLE
Changed: avoid JavaObject wrapping in Ruby methods

### DIFF
--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -281,11 +281,7 @@ module LogStash; class JavaPipeline < JavaBasePipeline
 
   def wait_inputs
     @input_threads.each do |thread|
-      if thread.class == Java::JavaObject
-        thread.to_java.join
-      else
-        thread.join
-      end
+      thread.join # Thread or java.lang.Thread (both have #join)
     end
   end
 

--- a/logstash-core/spec/logstash/util/wrapped_synchronous_queue_spec.rb
+++ b/logstash-core/spec/logstash/util/wrapped_synchronous_queue_spec.rb
@@ -117,6 +117,16 @@ describe LogStash::WrappedSynchronousQueue do
           (0..2).each {|i| expect(received).to include("value-#{i}")}
           (3..4).each {|i| expect(received).to include("generated-#{i}")}
         end
+
+        it "handles Java proxied read-batch object" do
+          batch = []
+          3.times { |i| batch.push(LogStash::Event.new({"message" => "value-#{i}"})) }
+          write_client.push_batch(batch)
+
+          read_batch = read_client.read_batch
+          expect { read_client.close_batch(read_batch) }.to_not raise_error
+          expect { read_client.close_batch(read_batch.to_java) }.to_not raise_error
+        end
       end
     end
   end

--- a/logstash-core/src/main/java/org/logstash/RubyUtil.java
+++ b/logstash-core/src/main/java/org/logstash/RubyUtil.java
@@ -5,7 +5,9 @@ import org.jruby.RubyClass;
 import org.jruby.RubyModule;
 import org.jruby.anno.JRubyClass;
 import org.jruby.exceptions.RaiseException;
+import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.ObjectAllocator;
+import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.ackedqueue.QueueFactoryExt;
 import org.logstash.ackedqueue.ext.JRubyAckedQueueExt;
 import org.logstash.ackedqueue.ext.JRubyWrappedAckedQueueExt;
@@ -599,6 +601,15 @@ public final class RubyUtil {
         );
         clazz.defineAnnotatedMethods(jclass);
         return clazz;
+    }
+
+    /**
+     * Convert a Java object to a Ruby representative.
+     * @param javaObject the object to convert (might be null)
+     * @return a Ruby wrapper
+     */
+    public static IRubyObject toRubyObject(Object javaObject) {
+        return JavaUtil.convertJavaToRuby(RUBY, javaObject);
     }
 
 }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyAckedQueueExt.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyAckedQueueExt.java
@@ -9,7 +9,6 @@ import org.jruby.RubyObject;
 import org.jruby.RubyString;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
-import org.jruby.javasupport.JavaObject;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.Event;
@@ -114,16 +113,14 @@ public final class JRubyAckedQueueExt extends RubyObject {
     }
 
     @JRubyMethod(name = "read_batch", required = 2)
-    public IRubyObject ruby_read_batch(ThreadContext context, IRubyObject limit,
-        IRubyObject timeout) {
+    public IRubyObject ruby_read_batch(ThreadContext context, IRubyObject limit, IRubyObject timeout) {
         AckedBatch b;
         try {
             b = readBatch(RubyFixnum.num2int(limit), RubyFixnum.num2int(timeout));
         } catch (IOException e) {
             throw RubyUtil.newRubyIOError(context.runtime, e);
         }
-        // TODO: return proper Batch object
-        return (b == null) ? context.nil : JavaObject.wrap(context.runtime, b);
+        return RubyUtil.toRubyObject(b);
     }
 
     public AckedBatch readBatch(int limit, long timeout) throws IOException {

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaInputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaInputDelegatorExt.java
@@ -6,7 +6,6 @@ import org.jruby.RubyClass;
 import org.jruby.RubyObject;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
-import org.jruby.javasupport.JavaObject;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.RubyUtil;
@@ -66,7 +65,7 @@ public class JavaInputDelegatorExt extends RubyObject {
         });
         t.setName(pipeline.pipelineId().asJavaString() + "_" + input.getName() + "_" + input.getId());
         t.start();
-        return JavaObject.wrap(context.getRuntime(), t);
+        return RubyUtil.toRubyObject(t);
     }
 
     @JRubyMethod(name = "metric=")

--- a/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBase.java
+++ b/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBase.java
@@ -7,8 +7,7 @@ import org.jruby.RubyNumeric;
 import org.jruby.RubyObject;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
-import org.jruby.java.proxies.JavaProxy;
-import org.jruby.javasupport.JavaObject;
+import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.RubyUtil;
@@ -103,7 +102,7 @@ public abstract class QueueReadClientBase extends RubyObject implements QueueRea
 
     @JRubyMethod(name = "read_batch")
     public IRubyObject rubyReadBatch(final ThreadContext context) throws InterruptedException {
-        return JavaObject.wrap(context.runtime, readBatch());
+        return RubyUtil.toRubyObject(readBatch());
     }
 
     @Override
@@ -148,11 +147,7 @@ public abstract class QueueReadClientBase extends RubyObject implements QueueRea
      * @return Extracted queue batch
      */
     private static QueueBatch extractQueueBatch(final IRubyObject batch) {
-        if (batch instanceof JavaProxy) {
-            return (QueueBatch) ((JavaObject)batch.dataGetStruct()).getValue();
-        } else {
-            return (QueueBatch)((JavaObject)batch).getValue();
-        }
+        return JavaUtil.unwrapIfJavaObject(batch);
     }
 
     /**


### PR DESCRIPTION
aligns the Ruby/Java returns as they happen in scripted Java
e.g. as `java.lang.Thread.new` returns a JavaProxy instance

there's really no reason to use JavaObject which always needs `to_java`
conversion to be useful (and is considered legacy in JRuby).

considered breaking change e.g. `LogStash::MemoryReadClient#read_batch`
will now return a proper JavaProxy instead of the JavaObject