### PR TITLE
setup jruby and bundler/rake before artifact rake tasks

### DIFF
--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -4,7 +4,7 @@ namespace "vendor" do
   end
 
   task "jruby" do |task, args|
-    system('./gradlew downloadAndInstallJRuby') unless File.exists?(File.join("vendor", "jruby"))
+    system('./gradlew bootstrap') unless File.exists?(File.join("vendor", "jruby"))
   end # jruby
 
   namespace "force" do


### PR DESCRIPTION
this makes it so that `rake artifact:deb` and other rake artifact tasks can be run after d65f78728 was merged.

This is because `downloadAndInstallJRuby` only installs jruby, but bootstrap sets up bundler environment correctly.

To test this out just run `rake artifact:deb` in master with and without the patch.