### PR TITLE
[gradle] add rootProject.name

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,5 @@
+rootProject.name = "logstash"
+
 include ':logstash-core', 'logstash-core-benchmarks', 'ingest-converter', 'benchmark-cli', 'logstash-integration-tests', 'dependencies-report'
 project(':logstash-core').projectDir = new File('./logstash-core')
 project(':logstash-core-benchmarks').projectDir = new File('./logstash-core/benchmarks')


### PR DESCRIPTION
Since Logstash may not be cloned into a “logstash” directory (e.g. on Windows ci we mount it as A:/) gradle needs to be told the name of the top level project. 

CI failure example can be seen here: https://logstash-ci.elastic.co/blue/organizations/jenkins/elastic%2Blogstash%2Bmaster%2Bmultijob-windows-compatibility/detail/elastic%20logstash%20master%20multijob-windows-compatibility/101/pipeline#log-75