### PR TITLE
test codec against class name string to prevent class equivalence bug with a Delegator

### DIFF
--- a/logstash-core/lib/logstash/inputs/base.rb
+++ b/logstash-core/lib/logstash/inputs/base.rb
@@ -131,11 +131,12 @@ class LogStash::Inputs::Base < LogStash::Plugin
     require "logstash/codecs/line"
     require "logstash/codecs/json"
     require "logstash/codecs/json_lines"
-    case @codec
-      when LogStash::Codecs::Plain
+
+    case @codec.class.name
+      when "LogStash::Codecs::Plain"
         @logger.info("Automatically switching from #{@codec.class.config_name} to line codec", :plugin => self.class.config_name)
         @codec = LogStash::Codecs::Line.new("charset" => @codec.charset)
-      when LogStash::Codecs::JSON
+      when "LogStash::Codecs::JSON"
         @logger.info("Automatically switching from #{@codec.class.config_name} to json_lines codec", :plugin => self.class.config_name)
         @codec = LogStash::Codecs::JSONLines.new("charset" => @codec.charset)
     end

--- a/logstash-core/spec/logstash/inputs/base_spec.rb
+++ b/logstash-core/spec/logstash/inputs/base_spec.rb
@@ -113,4 +113,32 @@ describe "LogStash::Inputs::Base#fix_streaming_codecs" do
     tcp.instance_eval { fix_streaming_codecs }
     expect(tcp.codec.charset).to eq("CP1252")
   end
+
+  it "should switch plain codec to line" do
+    require "logstash/inputs/tcp"
+    require "logstash/codecs/plain"
+    require "logstash/codecs/line"
+
+    # it is important to use "codec" => "plain" here and not the LogStash::Codecs::Plain instance so that
+    # the config parsing wrap the codec into the delagator which was causing the codec identification bug
+    # per https://github.com/elastic/logstash/issues/11140
+    tcp = LogStash::Inputs::Tcp.new("codec" => "plain", "port" => 0)
+    tcp.register
+
+    expect(tcp.codec.class.name).to eq("LogStash::Codecs::Line")
+  end
+
+  it "should switch json codec to json_lines" do
+    require "logstash/inputs/tcp"
+    require "logstash/codecs/plain"
+    require "logstash/codecs/line"
+
+    # it is important to use "codec" => "json" here and not the LogStash::Codecs::Plain instance so that
+    # the config parsing wrap the codec into the delagator which was causing the codec identification bug
+    # per https://github.com/elastic/logstash/issues/11140
+    tcp = LogStash::Inputs::Tcp.new("codec" => "json", "port" => 0)
+    tcp.register
+
+    expect(tcp.codec.class.name).to eq("LogStash::Codecs::JSONLines")
+  end
 end


### PR DESCRIPTION
Fixes #11140

Since 7.2.0 our codecs are wrapped in a `Delegator` class when instantiated through the config parser and the  `fix_streaming_codec` method is testing against the class using the `case`/`when` statement which does not work with the codec wrapped in a delegator. 

Ideally we should fix the Delegator to also correctly support the `===` operator which is necessary for `case`/`when` statements on classes to avoid potential future bugs related to tests on the codec classes.