### PR TITLE
Add "enterprise" license level

### DIFF
--- a/x-pack/lib/config_management/elasticsearch_source.rb
+++ b/x-pack/lib/config_management/elasticsearch_source.rb
@@ -20,7 +20,8 @@ module LogStash
       class RemoteConfigError < LogStash::Error; end
 
       PIPELINE_INDEX = ".logstash"
-      VALID_LICENSES = %w(trial standard gold platinum)
+      # exclude basic
+      VALID_LICENSES = %w(trial standard gold platinum enterprise)
       FEATURE_INTERNAL = 'management'
       FEATURE_EXTERNAL = 'logstash'
       SUPPORTED_PIPELINE_SETTINGS = %w(

--- a/x-pack/lib/license_checker/license_manager.rb
+++ b/x-pack/lib/license_checker/license_manager.rb
@@ -18,8 +18,6 @@ module LogStash
 
       attr_reader :last_updated
 
-      LICENSE_TYPES = :trial, :basic, :standard, :gold, :platinum
-
       def initialize (reader, feature, refresh_period=30, refresh_unit=TimeUnit::SECONDS)
         @license_reader = reader
         @feature = feature

--- a/x-pack/lib/license_checker/x_pack_info.rb
+++ b/x-pack/lib/license_checker/x_pack_info.rb
@@ -9,10 +9,10 @@ java_import java.util.concurrent.TimeUnit
 
 module LogStash
   module LicenseChecker
+    LICENSE_TYPES = ['trial', 'basic', 'standard', 'gold', 'platinum']
+
     class XPackInfo
       include LogStash::Util::Loggable
-
-      LICENSE_TYPES = :trial, :basic, :standard, :gold, :platinum
 
       def initialize(license, features = nil, installed=true, failed = false)
         @license = license

--- a/x-pack/lib/license_checker/x_pack_info.rb
+++ b/x-pack/lib/license_checker/x_pack_info.rb
@@ -9,7 +9,7 @@ java_import java.util.concurrent.TimeUnit
 
 module LogStash
   module LicenseChecker
-    LICENSE_TYPES = ['trial', 'basic', 'standard', 'gold', 'platinum']
+    LICENSE_TYPES = ['trial', 'basic', 'standard', 'gold', 'platinum', 'enterprise']
 
     class XPackInfo
       include LogStash::Util::Loggable

--- a/x-pack/lib/monitoring/internal_pipeline_source.rb
+++ b/x-pack/lib/monitoring/internal_pipeline_source.rb
@@ -11,7 +11,6 @@ module LogStash module Monitoring
     include LogStash::LicenseChecker::Licensed
     include LogStash::Helpers::ElasticsearchOptions
     include LogStash::Util::Loggable
-    VALID_LICENSES = %w(basic trial standard gold platinum)
     FEATURE = 'monitoring'
 
     def initialize(pipeline_config, agent)
@@ -68,7 +67,7 @@ module LogStash module Monitoring
             :log_level => :error,
             :log_message => 'Monitoring is not available: License information is currently unavailable. Please make sure you have added your production elasticsearch connection info in the xpack.monitoring.elasticsearch settings.'
         }
-      elsif !xpack_info.license_one_of?(VALID_LICENSES)
+      elsif !xpack_info.license_one_of?(::LogStash::LicenseChecker::LICENSE_TYPES)
         {
             :state => :error,
             :log_level => :error,

--- a/x-pack/lib/x-pack/logstash_registry.rb
+++ b/x-pack/lib/x-pack/logstash_registry.rb
@@ -22,7 +22,7 @@ LogStash::PLUGIN_REGISTRY.add(:universal, "monitoring", LogStash::MonitoringExte
 LogStash::PLUGIN_REGISTRY.add(:universal, "config_management", LogStash::ConfigManagement::Extension)
 
 license_levels = Hash.new
-license_levels.default = ["basic", "trial", "standard", "gold", "platinum"]
+license_levels.default = LogStash::LicenseChecker::LICENSE_TYPES
 
 xpack_modules.each do |name|
   path = File.join(File.dirname(__FILE__), "..", "..", "modules", name, "configuration")

--- a/x-pack/spec/config_management/elasticsearch_source_spec.rb
+++ b/x-pack/spec/config_management/elasticsearch_source_spec.rb
@@ -336,8 +336,8 @@ describe LogStash::ConfigManagement::ElasticsearchSource do
         end
       end
 
-
-      %w(standard trial standard gold platinum).each do |license_type|
+      # config management can be used with any license type except basic
+      (::LogStash::LicenseChecker::LICENSE_TYPES - ["basic"]).each do |license_type|
         context "With a valid #{license_type} license, it should return a pipeline" do
 
           before do
@@ -356,7 +356,6 @@ describe LogStash::ConfigManagement::ElasticsearchSource do
           end
         end
       end
-
     end
 
     context "with multiples `pipeline_id` configured" do

--- a/x-pack/spec/license_checker/license_info_spec.rb
+++ b/x-pack/spec/license_checker/license_info_spec.rb
@@ -94,14 +94,14 @@ describe LogStash::LicenseChecker::XPackInfo do
       let(:status) { 'expired' }
       it_behaves_like 'available? returns correctly', true
       it_behaves_like 'active? returns correctly', false
-      it_behaves_like 'one_of? returns correctly', %w(basic trial standard gold platinum), true
+      it_behaves_like 'one_of? returns correctly', LogStash::LicenseChecker::LICENSE_TYPES, true
     end
 
     context 'the license is active' do
       let(:status) { 'active' }
       it_behaves_like 'available? returns correctly', true
       it_behaves_like 'active? returns correctly', true
-      it_behaves_like 'one_of? returns correctly', %w(basic trial standard gold platinum), true
+      it_behaves_like 'one_of? returns correctly', LogStash::LicenseChecker::LICENSE_TYPES, true
     end
   end
 

--- a/x-pack/spec/modules/module_license_checker_spec.rb
+++ b/x-pack/spec/modules/module_license_checker_spec.rb
@@ -8,6 +8,7 @@ require 'license_checker/x_pack_info'
 
 describe LogStash::LicenseChecker::ModuleLicenseChecker do
 
+  let(:license_types) { LogStash::LicenseChecker::LICENSE_TYPES }
 
   let(:settings) { LogStash::Runner::SYSTEM_SETTINGS }
 
@@ -55,7 +56,7 @@ describe LogStash::LicenseChecker::ModuleLicenseChecker do
   end
 
   context "any license" do
-    let(:subject) {LogStash::LicenseChecker::ModuleLicenseChecker.new(name,  ["basic", "trial", "standard", "gold", "platinum"])}
+    let(:subject) {LogStash::LicenseChecker::ModuleLicenseChecker.new(name, license_types)}
     let(:returned_license) {"basic"}
     let(:name) {"foo_module"}
     let(:settings) do
@@ -103,7 +104,7 @@ describe LogStash::LicenseChecker::ModuleLicenseChecker do
   end
 
   context "no license" do
-    let(:subject) {LogStash::LicenseChecker::ModuleLicenseChecker.new(name,  ["basic", "trial", "standard", "gold", "platinum"])}
+    let(:subject) {LogStash::LicenseChecker::ModuleLicenseChecker.new(name, license_types)}
     let(:name) {"foo_module"}
     let(:settings) do
       LogStash::SETTINGS.clone.tap do |settings|

--- a/x-pack/spec/monitoring/internal_pipeline_source_spec.rb
+++ b/x-pack/spec/monitoring/internal_pipeline_source_spec.rb
@@ -101,7 +101,7 @@ describe LogStash::Monitoring::InternalPipelineSource do
         end
       end
 
-      %w(basic standard trial gold platinum).each  do |license_type|
+      LogStash::LicenseChecker::LICENSE_TYPES.each  do |license_type|
         context "With a valid #{license_type} license" do
           let(:license_type) { license_type }
           let(:license) do


### PR DESCRIPTION
This PR does two things (in two separate commits):
- DRY up the list of license types as there were 10 places that listed the types explicitly
- Add the enterprise license level

fixes https://github.com/elastic/logstash/issues/11404