### PR TITLE
remove line+column passing. avoid one big sourceWithMetadata

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
@@ -132,8 +132,7 @@ public final class CompiledPipeline {
             final PluginDefinition def = v.getPluginDefinition();
             final SourceWithMetadata source = v.getSourceWithMetadata();
             res.put(v.getId(), pluginFactory.buildOutput(
-                    RubyUtil.RUBY.newString(def.getName()), RubyUtil.RUBY.newFixnum(source.getLine()),
-                    RubyUtil.RUBY.newFixnum(source.getColumn()), convertArgs(def), convertJavaArgs(def, cve)
+                    RubyUtil.RUBY.newString(def.getName()), source, convertArgs(def), convertJavaArgs(def, cve)
             ));
         });
         return res;
@@ -150,8 +149,7 @@ public final class CompiledPipeline {
             final PluginDefinition def = vertex.getPluginDefinition();
             final SourceWithMetadata source = vertex.getSourceWithMetadata();
             res.put(vertex.getId(), pluginFactory.buildFilter(
-                    RubyUtil.RUBY.newString(def.getName()), RubyUtil.RUBY.newFixnum(source.getLine()),
-                    RubyUtil.RUBY.newFixnum(source.getColumn()), convertArgs(def), convertJavaArgs(def, cve)
+                    RubyUtil.RUBY.newString(def.getName()), source, convertArgs(def), convertJavaArgs(def, cve)
             ));
         }
         return res;
@@ -167,8 +165,7 @@ public final class CompiledPipeline {
             final PluginDefinition def = v.getPluginDefinition();
             final SourceWithMetadata source = v.getSourceWithMetadata();
             IRubyObject o = pluginFactory.buildInput(
-                    RubyUtil.RUBY.newString(def.getName()), RubyUtil.RUBY.newFixnum(source.getLine()),
-                    RubyUtil.RUBY.newFixnum(source.getColumn()), convertArgs(def), convertJavaArgs(def, cve));
+                    RubyUtil.RUBY.newString(def.getName()), source, convertArgs(def), convertJavaArgs(def, cve));
             nodes.add(o);
         });
         return nodes;

--- a/logstash-core/src/main/java/org/logstash/config/ir/ConfigCompiler.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/ConfigCompiler.java
@@ -1,5 +1,6 @@
 package org.logstash.config.ir;
 
+import org.jruby.RubyArray;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.RubyUtil;
@@ -14,6 +15,27 @@ public final class ConfigCompiler {
 
     private ConfigCompiler() {
         // Utility Class
+    }
+
+    /**
+     * @param sources Logstash Config Parts
+     * @param supportEscapes The value of the setting {@code config.support_escapes}
+     * @return Compiled {@link PipelineIR}
+     * @throws IncompleteSourceWithMetadataException On Broken Configuration
+     */
+    public static PipelineIR configToPipelineIR(final @SuppressWarnings("rawtypes") RubyArray sources, final boolean supportEscapes)
+            throws IncompleteSourceWithMetadataException {
+        final IRubyObject compiler = RubyUtil.RUBY.executeScript(
+                "require 'logstash/compiler'\nLogStash::Compiler",
+                ""
+        );
+        final IRubyObject code =
+                compiler.callMethod(RubyUtil.RUBY.getCurrentContext(), "compile_sources",
+                        new IRubyObject[]{
+                                sources,
+                                RubyUtil.RUBY.newBoolean(supportEscapes)
+                        });
+        return code.toJava(PipelineIR.class);
     }
 
     /**

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/PluginFactory.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/PluginFactory.java
@@ -8,6 +8,7 @@ import co.elastic.logstash.api.Configuration;
 import co.elastic.logstash.api.Context;
 import co.elastic.logstash.api.Filter;
 import co.elastic.logstash.api.Input;
+import org.logstash.common.SourceWithMetadata;
 
 import java.util.Map;
 
@@ -18,9 +19,7 @@ public interface PluginFactory extends RubyIntegration.PluginFactory {
 
     Input buildInput(String name, String id, Configuration configuration, Context context);
 
-    Filter buildFilter(
-            String name, String id, Configuration configuration, Context context
-    );
+    Filter buildFilter(String name, String id, Configuration configuration, Context context);
 
     final class Default implements PluginFactory {
 
@@ -41,23 +40,21 @@ public interface PluginFactory extends RubyIntegration.PluginFactory {
         }
 
         @Override
-        public IRubyObject buildInput(final RubyString name, final RubyInteger line, final RubyInteger column,
+        public IRubyObject buildInput(final RubyString name, final SourceWithMetadata source,
                                       final IRubyObject args, Map<String, Object> pluginArgs) {
-            return rubyFactory.buildInput(name, line, column, args, pluginArgs);
+            return rubyFactory.buildInput(name, source, args, pluginArgs);
         }
 
         @Override
-        public AbstractOutputDelegatorExt buildOutput(final RubyString name, final RubyInteger line,
-                                                      final RubyInteger column, final IRubyObject args,
+        public AbstractOutputDelegatorExt buildOutput(final RubyString name, final SourceWithMetadata source, final IRubyObject args,
                                                       final Map<String, Object> pluginArgs) {
-            return rubyFactory.buildOutput(name, line, column, args, pluginArgs);
+            return rubyFactory.buildOutput(name, source, args, pluginArgs);
         }
 
         @Override
-        public AbstractFilterDelegatorExt buildFilter(final RubyString name, final RubyInteger line,
-                                                      final RubyInteger column, final IRubyObject args,
+        public AbstractFilterDelegatorExt buildFilter(final RubyString name, final SourceWithMetadata source, final IRubyObject args,
                                                       final Map<String, Object> pluginArgs) {
-            return rubyFactory.buildFilter(name, line, column, args, pluginArgs);
+            return rubyFactory.buildFilter(name, source, args, pluginArgs);
         }
 
         @Override

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
@@ -4,6 +4,7 @@ import co.elastic.logstash.api.Codec;
 import org.jruby.RubyInteger;
 import org.jruby.RubyString;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.logstash.common.SourceWithMetadata;
 
 import java.util.Map;
 
@@ -21,14 +22,14 @@ public final class RubyIntegration {
      */
     public interface PluginFactory {
 
-        IRubyObject buildInput(RubyString name, RubyInteger line, RubyInteger column,
+        IRubyObject buildInput(RubyString name, SourceWithMetadata source,
             IRubyObject args, Map<String, Object> pluginArgs);
 
-        AbstractOutputDelegatorExt buildOutput(RubyString name, RubyInteger line, RubyInteger column,
+        AbstractOutputDelegatorExt buildOutput(RubyString name, SourceWithMetadata source,
             IRubyObject args, Map<String, Object> pluginArgs);
 
-        AbstractFilterDelegatorExt buildFilter(RubyString name, RubyInteger line, RubyInteger column, IRubyObject args,
-            Map<String, Object> pluginArgs);
+        AbstractFilterDelegatorExt buildFilter(RubyString name, SourceWithMetadata source,
+            IRubyObject args, Map<String, Object> pluginArgs);
 
         IRubyObject buildCodec(RubyString name, IRubyObject args, Map<String, Object> pluginArgs);
 

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -91,6 +91,8 @@ public class AbstractPipelineExt extends RubyBasicObject {
 
     private AbstractNamespacedMetricExt dlqMetric;
 
+    private @SuppressWarnings({"rawtypes"}) RubyArray configParts;
+
     private RubyString configString;
 
     private RubyString configHash;
@@ -132,6 +134,7 @@ public class AbstractPipelineExt extends RubyBasicObject {
                 MessageDigest.getInstance("SHA1").digest(configString.getBytes())
             )
         );
+        configParts = (RubyArray) pipelineSettings.callMethod(context, "config_parts");
         settings = pipelineSettings.callMethod(context, "settings");
         final IRubyObject id = getSetting(context, "pipeline.id");
         if (id.isNil()) {
@@ -154,7 +157,7 @@ public class AbstractPipelineExt extends RubyBasicObject {
             }
         }
         lir = ConfigCompiler.configToPipelineIR(
-            configString.asJavaString(),
+            configParts,
             getSetting(context, "config.support_escapes").isTrue()
         );
         return this;

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
@@ -24,6 +24,7 @@ import org.logstash.RubyUtil;
 import org.logstash.common.AbstractDeadLetterQueueWriterExt;
 import org.logstash.common.DLQWriterAdapter;
 import org.logstash.common.NullDeadLetterQueueWriter;
+import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.PipelineIR;
 import org.logstash.config.ir.compiler.AbstractFilterDelegatorExt;
 import org.logstash.config.ir.compiler.AbstractOutputDelegatorExt;
@@ -57,8 +58,7 @@ import java.util.UUID;
 public final class PluginFactoryExt {
 
     @JRubyClass(name = "PluginFactory")
-    public static final class Plugins extends RubyBasicObject
-        implements RubyIntegration.PluginFactory {
+    public static final class Plugins extends RubyBasicObject implements RubyIntegration.PluginFactory {
 
         private static final long serialVersionUID = 1L;
 
@@ -114,7 +114,6 @@ public final class PluginFactoryExt {
         }
 
         @SuppressWarnings("unchecked")
-        @Override
         public IRubyObject buildInput(final RubyString name, final SourceWithMetadata source,
                                       final IRubyObject args, Map<String, Object> pluginArgs) {
             return plugin(
@@ -126,7 +125,6 @@ public final class PluginFactoryExt {
 
 
         @SuppressWarnings("unchecked")
-        @Override
         public AbstractOutputDelegatorExt buildOutput(final RubyString name, final SourceWithMetadata source,
                                                       final IRubyObject args,
                                                       Map<String, Object> pluginArgs) {
@@ -140,7 +138,6 @@ public final class PluginFactoryExt {
 
 
         @SuppressWarnings("unchecked")
-        @Override
         public AbstractFilterDelegatorExt buildFilter(final RubyString name, final SourceWithMetadata source, final IRubyObject args,
                                                       Map<String, Object> pluginArgs) {
             return (AbstractFilterDelegatorExt) plugin(
@@ -151,7 +148,6 @@ public final class PluginFactoryExt {
         }
 
         @SuppressWarnings("unchecked")
-        @Override
         public IRubyObject buildCodec(final RubyString name, final IRubyObject args, Map<String, Object> pluginArgs) {
             SourceWithMetadata emptySource = null;
             return plugin(
@@ -160,7 +156,6 @@ public final class PluginFactoryExt {
             );
         }
 
-        @Override
         public Codec buildDefaultCodec(String codecName) {
             SourceWithMetadata emptySource = null;
             return (Codec) JavaUtil.unwrapJavaValue(plugin(

--- a/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
@@ -25,6 +25,7 @@ import org.logstash.ConvertedMap;
 import org.logstash.Event;
 import org.logstash.RubyUtil;
 import org.logstash.common.IncompleteSourceWithMetadataException;
+import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.compiler.AbstractFilterDelegatorExt;
 import org.logstash.config.ir.compiler.AbstractOutputDelegatorExt;
 import org.logstash.config.ir.compiler.FilterDelegatorExt;
@@ -476,20 +477,19 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
         }
 
         @Override
-        public IRubyObject buildInput(final RubyString name, final RubyInteger line,
-            final RubyInteger column, final IRubyObject args, Map<String, Object> pluginArgs) {
+        public IRubyObject buildInput(final RubyString name, final SourceWithMetadata source,
+                                      final IRubyObject args, Map<String, Object> pluginArgs) {
             return setupPlugin(name, inputs);
         }
 
         @Override
-        public AbstractOutputDelegatorExt buildOutput(final RubyString name, final RubyInteger line,
-            final RubyInteger column, final IRubyObject args, Map<String, Object> pluginArgs) {
+        public AbstractOutputDelegatorExt buildOutput(final RubyString name, final SourceWithMetadata source,
+                                                      final IRubyObject args, Map<String, Object> pluginArgs) {
             return PipelineTestUtil.buildOutput(setupPlugin(name, outputs));
         }
 
         @Override
-        public AbstractFilterDelegatorExt buildFilter(final RubyString name, final RubyInteger line,
-                                                      final RubyInteger column, final IRubyObject args,
+        public AbstractFilterDelegatorExt buildFilter(final RubyString name, final SourceWithMetadata source, final IRubyObject args,
                                                       Map<String, Object> pluginArgs) {
             return new FilterDelegatorExt(
                 RubyUtil.RUBY, RubyUtil.FILTER_DELEGATOR_CLASS)

--- a/logstash-core/src/test/java/org/logstash/plugins/TestPluginFactory.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/TestPluginFactory.java
@@ -4,6 +4,7 @@ import co.elastic.logstash.api.Codec;
 import org.jruby.RubyInteger;
 import org.jruby.RubyString;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.compiler.AbstractFilterDelegatorExt;
 import org.logstash.config.ir.compiler.AbstractOutputDelegatorExt;
 import org.logstash.config.ir.compiler.RubyIntegration;
@@ -15,17 +16,17 @@ import java.util.Map;
 public class TestPluginFactory implements RubyIntegration.PluginFactory {
 
     @Override
-    public IRubyObject buildInput(RubyString name, RubyInteger line, RubyInteger column, IRubyObject args, Map<String, Object> pluginArgs) {
+    public IRubyObject buildInput(RubyString name, SourceWithMetadata source, IRubyObject args, Map<String, Object> pluginArgs) {
         return null;
     }
 
     @Override
-    public AbstractOutputDelegatorExt buildOutput(RubyString name, RubyInteger line, RubyInteger column, IRubyObject args, Map<String, Object> pluginArgs) {
+    public AbstractOutputDelegatorExt buildOutput(RubyString name, SourceWithMetadata source, IRubyObject args, Map<String, Object> pluginArgs) {
         return null;
     }
 
     @Override
-    public AbstractFilterDelegatorExt buildFilter(RubyString name, RubyInteger line, RubyInteger column, IRubyObject args, Map<String, Object> pluginArgs) {
+    public AbstractFilterDelegatorExt buildFilter(RubyString name, SourceWithMetadata source, IRubyObject args, Map<String, Object> pluginArgs) {
         return null;
     }
 


### PR DESCRIPTION
This PR tries to remove the current unnecessary collapse of config sources into a single one, as we lose track of the original files that were read from.

So we try to take the list of SourceWithMetadata created from the ConfigSource/PipelineConfig, and carry that to the Compiler, which already accepts a list of SourceWithMetadata.

Then, we go through the PluginFactoryExt and replace all cases where the line and column are passed separate with a single SourceWithMetadata.

This PR also fixes a bug in the plugin ID generation, where we search the graph for plugins that match the line and column to find the ID. This only works if there's a single block of text. By introducing one source per file we expose this limitation in the graph search. This change can be found [here](https://github.com/jsvd/logstash/blob/e71f9c3f044302e0bc3a982eb011bbe0125f9e8b/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java#L197).

Because this PR changes some of the method signatures in a classes that are JRuby extensions, it currently breaks the ruby pipeline.  Adjusting the calls to `PluginFactory.plugin` may be enough to make it work again.