### PR TITLE
update grok filter to 4.2.0 (for LS 7.5.1)

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -231,7 +231,7 @@ GEM
       murmurhash3
     logstash-filter-geoip (6.0.3-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-grok (4.1.1)
+    logstash-filter-grok (4.2.0)
       jls-grok (~> 0.11.3)
       logstash-core (>= 5.6.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)


### PR DESCRIPTION
4.2.0 includes support for `timeout_scope => event`