### PR TITLE
Fix: handle cloud-id with an empty kibana part

### DIFF
--- a/logstash-core/lib/logstash/util/cloud_setting_id.rb
+++ b/logstash-core/lib/logstash/util/cloud_setting_id.rb
@@ -57,7 +57,7 @@ module LogStash module Util class CloudSettingId
 
     @elasticsearch_host, @kibana_host, *@other_identifiers = segments
     @elasticsearch_host, @elasticsearch_port = @elasticsearch_host.split(":")
-    @kibana_host, @kibana_port = @kibana_host.split(":")
+    @kibana_host, @kibana_port = @kibana_host.split(":") if @kibana_host
     @elasticsearch_port ||= cloud_port
     @kibana_port ||= cloud_port
     @other_identifiers ||= []
@@ -72,7 +72,9 @@ module LogStash module Util class CloudSettingId
     if @kibana_host == "undefined"
       raise ArgumentError.new("Cloud Id, after decoding, the kibana segment is 'undefined', literally. You may need to enable Kibana in the Cloud UI.")
     end
+
     @kibana_scheme = "https"
+    @kibana_host ||= String.new # non-sense really to have '.my-host:443' but we're mirroring others
     @kibana_host.concat(cloud_host)
     @kibana_host.concat(":#{@kibana_port}")
   end

--- a/logstash-core/spec/logstash/util/cloud_setting_id_spec.rb
+++ b/logstash-core/spec/logstash/util/cloud_setting_id_spec.rb
@@ -143,4 +143,34 @@ describe LogStash::Util::CloudSettingId do
       expect(subject.other_identifiers).to eq(["anotherid", "andanother"])
     end
   end
+
+  describe "when given acceptable input (with empty kibana uuid), the accessors:" do
+    let(:input) { "a-test:ZWNlLmhvbWUubGFuJHRlc3Qk" } # ece.home.lan$test$
+
+    it '#original has a value' do
+      expect(subject.original).to eq(input)
+    end
+    it '#decoded has a value' do
+      expect(subject.decoded).to eq("ece.home.lan$test$")
+    end
+    it '#label has a value' do
+      expect(subject.label).to eq("a-test")
+    end
+    it '#elasticsearch_host has a value' do
+      expect(subject.elasticsearch_host).to eq("test.ece.home.lan:443")
+    end
+    it '#elasticsearch_scheme has a value' do
+      expect(subject.elasticsearch_scheme).to eq("https")
+    end
+    it '#kibana_host has a value' do
+      # NOTE: kibana part is not relevant -> this is how python/beats(go) code behaves
+      expect(subject.kibana_host).to eq(".ece.home.lan:443")
+    end
+    it '#kibana_scheme has a value' do
+      expect(subject.kibana_scheme).to eq("https")
+    end
+    it '#to_s has a value of #decoded' do
+      expect(subject.to_s).to eq(subject.decoded)
+    end
+  end
 end

--- a/logstash-core/spec/logstash/util/cloud_setting_id_spec.rb
+++ b/logstash-core/spec/logstash/util/cloud_setting_id_spec.rb
@@ -173,4 +173,30 @@ describe LogStash::Util::CloudSettingId do
       expect(subject.to_s).to eq(subject.decoded)
     end
   end
+
+  describe "a lengthy real-world input, the accessors:" do
+    let(:input) do
+      "ZWFzdHVzMi5henVyZS5lbGFzdGljLWNsb3VkLmNvbTo5MjQzJDQwYjM0MzExNmNmYTRlYmNiNzZjMTFlZTIzMjlmOTJkJDQzZDA5MjUyNTAyYzQxODlhMzc2ZmQwY2YyY2QwODQ4"
+      # eastus2.azure.elastic-cloud.com:9243$40b343116cfa4ebcb76c11ee2329f92d$43d09252502c4189a376fd0cf2cd0848
+    end
+
+    it '#original has a value' do
+      expect(subject.original).to eq(input)
+    end
+    it '#decoded has a value' do
+      expect(subject.decoded).to eq("eastus2.azure.elastic-cloud.com:9243$40b343116cfa4ebcb76c11ee2329f92d$43d09252502c4189a376fd0cf2cd0848")
+    end
+    it '#label has a value' do
+      expect(subject.label).to eq("")
+    end
+    it '#elasticsearch_host has a value' do
+      expect(subject.elasticsearch_host).to eq("40b343116cfa4ebcb76c11ee2329f92d.eastus2.azure.elastic-cloud.com:9243")
+    end
+    it '#kibana_host has a value' do
+      expect(subject.kibana_host).to eq("43d09252502c4189a376fd0cf2cd0848.eastus2.azure.elastic-cloud.com:9243")
+    end
+    it '#to_s has a value of #decoded' do
+      expect(subject.to_s).to eq(subject.decoded)
+    end
+  end
 end


### PR DESCRIPTION
LS should not fail with an exception as demonstrated in GH-10747
 ... while the cloud-id seems invalid other parts of the stack parse just fine, namely checked:

- https://github.com/elastic/elasticsearch-py/commit/60d254860bb81df438d308a74ebb7213fcdc2043#diff-0b411057f27f7107b1f7c96c9ee81a92R64
- https://github.com/elastic/beats/blob/7.5/libbeat/cloudid/cloudid.go#L144 

