### PR TITLE
Created release notes for release 7.5.1

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -23,10 +23,6 @@ This section summarizes the changes in the following releases:
 * <<logstash-7-0-0-alpha2,Logstash 7.0.0-alpha2>>
 * <<logstash-7-0-0-alpha1,Logstash 7.0.0-alpha1>>
 
-[[logstash-7-5-1]]
-=== Logstash 7.5.1 Release Notes
-
-=== Logstash Pull Requests with label v7.5.1
 
 * Mention the path of DLQ to indicate DLQ if full for which pipeline https://github.com/elastic/logstash/pull/11280[#11280]
 * Changed GemInstaller to don't blank  gemspec attribute https://github.com/elastic/logstash/pull/11340[#11340]

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in the following releases:
 
+* <<logstash-7-5-1,Logstash 7.5.1>>
 * <<logstash-7-5-0,Logstash 7.5.0>>
 * <<logstash-7-4-2,Logstash 7.4.2>>
 * <<logstash-7-4-1,Logstash 7.4.1>>
@@ -21,6 +22,87 @@ This section summarizes the changes in the following releases:
 * <<logstash-7-0-0-beta1,Logstash 7.0.0-beta1>>
 * <<logstash-7-0-0-alpha2,Logstash 7.0.0-alpha2>>
 * <<logstash-7-0-0-alpha1,Logstash 7.0.0-alpha1>>
+
+[[logstash-7-5-1]]
+=== Logstash 7.5.1 Release Notes
+
+=== Logstash Pull Requests with label v7.5.1
+
+* Mention the path of DLQ to indicate DLQ if full for which pipeline https://github.com/elastic/logstash/pull/11280[#11280]
+* Changed GemInstaller to don't blank  gemspec attribute https://github.com/elastic/logstash/pull/11340[#11340]
+* [7.5 clean backport of #11334] support remove_field on metadata and tests https://github.com/elastic/logstash/pull/11342[#11342]
+* Fix: do not leak ThreadContext into the system https://github.com/elastic/logstash/pull/11356[#11356]
+* bump version to 7.5.1 https://github.com/elastic/logstash/pull/11363[#11363]
+* [DOCS] Replaces occurrences of xpack-ref https://github.com/elastic/logstash/pull/11366[#11366]
+* test codec against class name string to prevent class equivalence bug with a Delegator https://github.com/elastic/logstash/pull/11401[#11401]
+* update grok filter to 4.2.0 (for LS 7.5.1) https://github.com/elastic/logstash/pull/11432[#11432]
+* Fix: handle cloud-id with an empty kibana part https://github.com/elastic/logstash/pull/11435[#11435]
+* bump dependencies for patch release https://github.com/elastic/logstash/pull/11438[#11438]
+
+
+==== Plugins
+
+*Dns Filter*
+
+* Added documentation on the `nameserver` option for relying on `/etc/resolv.conf` to configure the resolver
+
+*Elasticsearch Filter*
+
+* Loosen restrictions on Elasticsearch gem ([#120](https://github.com/logstash-plugins/logstash-filter-elasticsearch/pull/120))
+
+*Grok Filter*
+
+*  Added: support for timeout_scope [#153](https://github.com/logstash-plugins/logstash-filter-grok/pull/153)
+
+*Jdbc_static Filter*
+
+* Fixed issue with driver verification using Java 11 [#51](https://github.com/logstash-plugins/logstash-filter-jdbc_static/pull/51)
+
+*Jdbc_streaming Filter*
+
+* Fixed driver loading [#35](https://github.com/logstash-plugins/logstash-filter-jdbc_streaming/pull/35)
+
+* Added support for prepared statements [PR 32](https://github.com/logstash-plugins/logstash-filter-jdbc_streaming/pull/32)
+* Added support for `sequel_opts` to pass options to the 3rd party Sequel library.
+
+* Added support for driver loading in JDK 9+ [Issue 25](https://github.com/logstash-plugins/logstash-filter-jdbc_streaming/issues/25)
+* Added support for multiple driver jars [Issue #21](https://github.com/logstash-plugins/logstash-filter-jdbc_streaming/issues/21)
+
+*Elasticsearch Input*
+
+* Loosen restrictions on Elasticsearch gem [#110](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/110)
+
+*Http Input*
+
+* Update netty and tcnative dependency [#118](https://github.com/logstash-plugins/logstash-input-http/issues/118)
+
+* Added 201 to valid response codes [#114](https://github.com/logstash-plugins/logstash-input-http/issues/114)
+* Documented response\_code option
+
+*Jdbc Input*
+
+* Fixed issue where paging settings in configuration were not being honored [#361](https://github.com/logstash-plugins/logstash-input-jdbc/pull/361)
+
+* Fix issue with driver loading [#356](https://github.com/logstash-plugins/logstash-input-jdbc/pull/356)
+
+* Added documentation to provide more info about jdbc driver loading [#352](https://github.com/logstash-plugins/logstash-input-jdbc/pull/352)
+
+*Jms Input*
+
+* Docs: Added additional troubleshooting information [#38](https://github.com/logstash-plugins/logstash-input-jms/pull/38)
+
+*Rabbitmq Integration*
+
+* Fixes issue in Output where failure to register connection reovery hooks prevented the output from starting
+
+* Improves Input Plugin documentation to better align with upstream guidance [#4](https://github.com/logstash-plugins/logstash-integration-rabbitmq/pull/4)
+
+*Elasticsearch Output*
+
+* Opened type removal logic for extension. This allows X-Pack Elasticsearch output to continue using types for special case `/_monitoring` bulk endpoint, enabling a fix for LogStash #11312. [#900](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/900)
+
+* Fixed 8.x type removal compatibility issue [#892](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/892)
+
 
 [[logstash-7-5-0]]
 === Logstash 7.5.0 Release Notes


### PR DESCRIPTION
Created release notes for release 7.5.1 using the script `tools/release/generate_release_notes.rb` but without the part to autocommit and push