### PR TITLE
Introduce an Exception when native thread is nil

### DIFF
--- a/logstash-core/lib/logstash/util.rb
+++ b/logstash-core/lib/logstash/util.rb
@@ -39,7 +39,12 @@ module LogStash::Util
 
   def self.get_thread_id(thread)
     if RUBY_ENGINE == "jruby"
-      JRuby.reference(thread).native_thread.id
+      native_thread = JRuby.reference(thread).native_thread
+      if native_thread
+        native_thread.id
+      else
+        raise Exception.new("Native thread is nil")
+      end
     else
       raise Exception.new("Native thread IDs aren't supported outside of JRuby")
     end


### PR DESCRIPTION
For https://github.com/elastic/logstash/issues/11450, I think we should at least throw a proper exception to begin with. I would like to understand the cause of it and possible remediation.