### PR TITLE
Fix/refact use source with metadata instead of plain text

### DIFF
--- a/logstash-core/lib/logstash/compiler.rb
+++ b/logstash-core/lib/logstash/compiler.rb
@@ -6,8 +6,14 @@ java_import org.logstash.config.ir.graph.Graph
 module LogStash; class Compiler
   include ::LogStash::Util::Loggable
 
+   def self.empty_or_space(str)
+     str.match(/\A\s*\Z/).nil? == false
+   end
+
   def self.compile_sources(sources_with_metadata, support_escapes)
-    graph_sections = sources_with_metadata.map do |swm|
+    graph_sections = sources_with_metadata.reject do |swm|
+       self.empty_or_space(swm.text)
+    end.map do |swm|
       self.compile_graph(swm, support_escapes)
     end
 

--- a/logstash-core/lib/logstash/config/config_ast.rb
+++ b/logstash-core/lib/logstash/config/config_ast.rb
@@ -233,12 +233,12 @@ module LogStash; module Config; module AST
       # If any parent is a Plugin, this must be a codec.
 
       if attributes.elements.nil?
-        return "plugin(#{plugin_type.inspect}, #{plugin_name.inspect}, #{source_meta.line}, #{source_meta.column})" << (plugin_type == "codec" ? "" : "\n")
+        return "plugin(#{plugin_type.inspect}, #{plugin_name.inspect}, line_to_source(#{source_meta.line}, #{source_meta.column}))" << (plugin_type == "codec" ? "" : "\n")
       else
         settings = attributes.recursive_select(Attribute).collect(&:compile).reject(&:empty?)
 
         attributes_code = "LogStash::Util.hash_merge_many(#{settings.map { |c| "{ #{c} }" }.join(", ")})"
-        return "plugin(#{plugin_type.inspect}, #{plugin_name.inspect}, #{source_meta.line}, #{source_meta.column}, #{attributes_code})" << (plugin_type == "codec" ? "" : "\n")
+        return "plugin(#{plugin_type.inspect}, #{plugin_name.inspect}, line_to_source(#{source_meta.line}, #{source_meta.column}), #{attributes_code})" << (plugin_type == "codec" ? "" : "\n")
       end
     end
 
@@ -255,7 +255,7 @@ module LogStash; module Config; module AST
       when "codec"
         settings = attributes.recursive_select(Attribute).collect(&:compile).reject(&:empty?)
         attributes_code = "LogStash::Util.hash_merge_many(#{settings.map { |c| "{ #{c} }" }.join(", ")})"
-        return "plugin(#{plugin_type.inspect}, #{plugin_name.inspect}, #{source_meta.line}, #{source_meta.column}, #{attributes_code})"
+        return "plugin(#{plugin_type.inspect}, #{plugin_name.inspect}, line_to_source(#{source_meta.line}, #{source_meta.column}), #{attributes_code})"
       end
     end
 

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -54,6 +54,10 @@ module LogStash; class BasePipeline < AbstractPipeline
     end
   end
 
+  def line_to_source(line, column)
+    pipeline_config.lookup_source(line, column)
+  end
+
   def reloadable?
     configured_as_reloadable? && reloadable_plugins?
   end
@@ -69,8 +73,8 @@ module LogStash; class BasePipeline < AbstractPipeline
   private
 
 
-  def plugin(plugin_type, name, line, column, *args)
-    @plugin_factory.plugin(plugin_type, name, line, column, *args)
+  def plugin(plugin_type, name, source, *args)
+    @plugin_factory.plugin(plugin_type, name, source, *args)
   end
 
   def default_logging_keys(other_keys = {})

--- a/logstash-core/spec/logstash/compiler/compiler_spec.rb
+++ b/logstash-core/spec/logstash/compiler/compiler_spec.rb
@@ -32,6 +32,24 @@ describe LogStash::Compiler do
     end
   end
 
+  describe "compile with empty source" do
+    subject(:source_id) { "fake_sourcefile" }
+    let(:source_with_metadata) { org.logstash.common.SourceWithMetadata.new(source_protocol, source_id, 0, 0, source) }
+    subject(:compiled) { puts "PCOMP"; described_class.compile_pipeline(source_with_metadata, settings) }
+
+    let(:sources_with_metadata) do
+      [
+        org.logstash.common.SourceWithMetadata.new("str", "in_plugin", 0, 0, "input { input_0 {} } "),
+        org.logstash.common.SourceWithMetadata.new("str", "out_plugin", 0, 0, "output { output_0 {} } "),
+        org.logstash.common.SourceWithMetadata.new("str", "<empty>", 0, 0, "     ")
+      ]
+    end
+
+    it "should compile only the text parts" do
+      described_class.compile_sources(sources_with_metadata, false)
+    end
+  end
+
   describe "compiling to Pipeline" do
     subject(:source_id) { "fake_sourcefile" }
     let(:source_with_metadata) { org.logstash.common.SourceWithMetadata.new(source_protocol, source_id, 0, 0, source) }

--- a/logstash-core/spec/logstash/config/config_ast_spec.rb
+++ b/logstash-core/spec/logstash/config/config_ast_spec.rb
@@ -209,6 +209,7 @@ describe LogStashConfigParser do
           eval(@code)
         end
         def plugin(*args);end
+        def line_to_source(*args);end
       end
     end
     context "(filters)" do
@@ -262,6 +263,7 @@ describe LogStashConfigParser do
           eval(@code)
         end
         def plugin(*args);end
+        def line_to_source(*args);end
       end
     end
 

--- a/logstash-core/spec/logstash/config/pipeline_config_spec.rb
+++ b/logstash-core/spec/logstash/config/pipeline_config_spec.rb
@@ -72,4 +72,79 @@ describe LogStash::Config::PipelineConfig do
       end
     end
   end
+
+  describe "source and line remapping" do
+    context "when pipeline is constructed from single file single line" do
+      let (:pipeline_conf_string) { 'input { generator1 }' }
+      subject { described_class.new(source, pipeline_id, [org.logstash.common.SourceWithMetadata.new("file", "/tmp/1", 0, 0, pipeline_conf_string)], settings) }
+      it "return the same line of the queried" do
+        expect(subject.lookup_source(1, 0).getLine()).to eq(1)
+      end
+    end
+
+    context "when pipeline is constructed from single file" do
+      let (:pipeline_conf_string) { 'input {
+                                       generator1
+                                     }' }
+      subject { described_class.new(source, pipeline_id, [org.logstash.common.SourceWithMetadata.new("file", "/tmp/1", 0, 0, pipeline_conf_string)], settings) }
+
+      it "return the same line of the queried" do
+        expect(subject.lookup_source(1, 0).getLine()).to eq(1)
+        expect(subject.lookup_source(2, 0).getLine()).to eq(2)
+      end
+
+      it "throw exception if line is out of bound" do
+        expect { subject.lookup_source(100, -1) }.to raise_exception(IndexError)
+      end
+    end
+
+    context "when pipeline is constructed from multiple files" do
+      let (:pipeline_conf_string_part1) { 'input {
+                                             generator1
+                                           }' }
+      let (:pipeline_conf_string_part2) { 'output {
+                                             stdout
+                                           }' }
+      let(:merged_config_parts) do
+        [
+          org.logstash.common.SourceWithMetadata.new("file", "/tmp/input", 0, 0, pipeline_conf_string_part1),
+          org.logstash.common.SourceWithMetadata.new("file", "/tmp/output", 0, 0, pipeline_conf_string_part2)
+        ]
+      end
+      subject { described_class.new(source, pipeline_id, merged_config_parts, settings) }
+
+      it "return the line of first segment" do
+        expect(subject.lookup_source(2, 0).getLine()).to eq(2)
+        expect(subject.lookup_source(2, 0).getId()).to eq("/tmp/input")
+      end
+
+      it "return the line of second segment" do
+        expect(subject.lookup_source(4, 0).getLine()).to eq(1)
+        expect(subject.lookup_source(4, 0).getId()).to eq("/tmp/output")
+      end
+
+      it "throw exception if line is out of bound" do
+        expect { subject.lookup_source(100, 0) }.to raise_exception(IndexError)
+      end
+    end
+
+    context "when pipeline is constructed from multiple files and the first has trailing newline" do
+        let (:pipeline_conf_string_part1) { "input {\n  generator1\n}\n" }
+        let (:pipeline_conf_string_part2) { 'output {
+                                               stdout
+                                             }' }
+        let(:merged_config_parts) do
+          [
+            org.logstash.common.SourceWithMetadata.new("file", "/tmp/input", 0, 0, pipeline_conf_string_part1),
+            org.logstash.common.SourceWithMetadata.new("file", "/tmp/output", 0, 0, pipeline_conf_string_part2)
+          ]
+        end
+        subject { described_class.new(source, pipeline_id, merged_config_parts, settings) }
+
+        it "shouldn't slide the mapping of subsequent" do
+          expect(subject.lookup_source(4, 0).getLine()).to eq(1)
+          expect(subject.lookup_source(4, 0).getId()).to eq("/tmp/output")
+        end
+    end
+  end
 end

--- a/logstash-core/src/main/java/org/logstash/common/SourceWithMetadata.java
+++ b/logstash-core/src/main/java/org/logstash/common/SourceWithMetadata.java
@@ -18,6 +18,7 @@ public class SourceWithMetadata implements HashableWithSource {
     private final Integer line;
     private final Integer column;
     private final String text;
+    private int linesCount;
 
     public String getProtocol() {
         return this.protocol;
@@ -60,11 +61,13 @@ public class SourceWithMetadata implements HashableWithSource {
           badAttributes.add(this.getText());
         }
 
-        if (!badAttributes.isEmpty()){
+        if (!badAttributes.isEmpty()) {
             String message = "Missing attributes in SourceWithMetadata: (" + badAttributes + ") "
                     + this.toString();
             throw new IncompleteSourceWithMetadataException(message);
         }
+
+        this.linesCount = text.split("\\n").length;
     }
 
     public SourceWithMetadata(String protocol, String id, String text) throws IncompleteSourceWithMetadataException {
@@ -92,5 +95,16 @@ public class SourceWithMetadata implements HashableWithSource {
     // Fields used in the hashSource and hashCode methods to ensure uniqueness
     private Collection<Object> hashableAttributes() {
         return Arrays.asList(this.getId(), this.getProtocol(), this.getLine(), this.getColumn(), this.getText());
+    }
+
+    public int getLinesCount() {
+        return linesCount;
+    }
+
+    public boolean equalsWithoutText(SourceWithMetadata other) {
+        return getProtocol().equals(other.getProtocol())
+                && getId().equals(other.getId())
+                && getLine().equals(other.getLine())
+                && getColumn().equals(other.getColumn());
     }
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
@@ -132,8 +132,7 @@ public final class CompiledPipeline {
             final PluginDefinition def = v.getPluginDefinition();
             final SourceWithMetadata source = v.getSourceWithMetadata();
             res.put(v.getId(), pluginFactory.buildOutput(
-                    RubyUtil.RUBY.newString(def.getName()), RubyUtil.RUBY.newFixnum(source.getLine()),
-                    RubyUtil.RUBY.newFixnum(source.getColumn()), convertArgs(def), convertJavaArgs(def, cve)
+                    RubyUtil.RUBY.newString(def.getName()), source, convertArgs(def), convertJavaArgs(def, cve)
             ));
         });
         return res;
@@ -150,8 +149,7 @@ public final class CompiledPipeline {
             final PluginDefinition def = vertex.getPluginDefinition();
             final SourceWithMetadata source = vertex.getSourceWithMetadata();
             res.put(vertex.getId(), pluginFactory.buildFilter(
-                    RubyUtil.RUBY.newString(def.getName()), RubyUtil.RUBY.newFixnum(source.getLine()),
-                    RubyUtil.RUBY.newFixnum(source.getColumn()), convertArgs(def), convertJavaArgs(def, cve)
+                    RubyUtil.RUBY.newString(def.getName()), source, convertArgs(def), convertJavaArgs(def, cve)
             ));
         }
         return res;
@@ -167,8 +165,7 @@ public final class CompiledPipeline {
             final PluginDefinition def = v.getPluginDefinition();
             final SourceWithMetadata source = v.getSourceWithMetadata();
             IRubyObject o = pluginFactory.buildInput(
-                    RubyUtil.RUBY.newString(def.getName()), RubyUtil.RUBY.newFixnum(source.getLine()),
-                    RubyUtil.RUBY.newFixnum(source.getColumn()), convertArgs(def), convertJavaArgs(def, cve));
+                    RubyUtil.RUBY.newString(def.getName()), source, convertArgs(def), convertJavaArgs(def, cve));
             nodes.add(o);
         });
         return nodes;
@@ -189,10 +186,11 @@ public final class CompiledPipeline {
             final Object toput;
             if (value instanceof PluginStatement) {
                 final PluginDefinition codec = ((PluginStatement) value).getPluginDefinition();
+                SourceWithMetadata source = ((PluginStatement) value).getSourceWithMetadata();
                 toput = pluginFactory.buildCodec(
                     RubyUtil.RUBY.newString(codec.getName()),
-                    Rubyfier.deep(RubyUtil.RUBY, codec.getArguments()),
-                    codec.getArguments()
+                        source, Rubyfier.deep(RubyUtil.RUBY, codec.getArguments()),
+                        codec.getArguments()
                 );
             } else {
                 toput = value;
@@ -217,10 +215,11 @@ public final class CompiledPipeline {
             final IRubyObject toput;
             if (value instanceof PluginStatement) {
                 final PluginDefinition codec = ((PluginStatement) value).getPluginDefinition();
+                SourceWithMetadata source = ((PluginStatement) value).getSourceWithMetadata();
                 Map<String, Object> codecArgs = expandConfigVariables(cve, codec.getArguments());
                 toput = pluginFactory.buildCodec(
                         RubyUtil.RUBY.newString(codec.getName()),
-                        Rubyfier.deep(RubyUtil.RUBY, codec.getArguments()),
+                        source, Rubyfier.deep(RubyUtil.RUBY, codec.getArguments()),
                         codecArgs
                 );
                 Codec javaCodec = (Codec)JavaUtil.unwrapJavaValue(toput);

--- a/logstash-core/src/main/java/org/logstash/config/ir/ConfigCompiler.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/ConfigCompiler.java
@@ -1,5 +1,7 @@
 package org.logstash.config.ir;
 
+import org.jruby.RubyArray;
+import org.jruby.RubyClass;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.RubyUtil;
@@ -17,28 +19,19 @@ public final class ConfigCompiler {
     }
 
     /**
-     * @param config Logstash Config String
+     * @param sourcesWithMetadata Logstash Config partitioned
      * @param supportEscapes The value of the setting {@code config.support_escapes}
      * @return Compiled {@link PipelineIR}
-     * @throws IncompleteSourceWithMetadataException On Broken Configuration
      */
-    public static PipelineIR configToPipelineIR(final String config, final boolean supportEscapes)
-        throws IncompleteSourceWithMetadataException {
+    public static PipelineIR configToPipelineIR(final @SuppressWarnings("rawtypes") RubyArray sourcesWithMetadata,
+                                                final boolean supportEscapes) {
         final IRubyObject compiler = RubyUtil.RUBY.executeScript(
-            "require 'logstash/compiler'\nLogStash::Compiler",
-            ""
+                "require 'logstash/compiler'\nLogStash::Compiler",
+                ""
         );
         final IRubyObject code =
             compiler.callMethod(RubyUtil.RUBY.getCurrentContext(), "compile_sources",
-                new IRubyObject[]{
-                    RubyUtil.RUBY.newArray(
-                        JavaUtil.convertJavaToRuby(
-                            RubyUtil.RUBY,
-                            new SourceWithMetadata("str", "pipeline", 0, 0, config)
-                        )
-                    ),
-                    RubyUtil.RUBY.newBoolean(supportEscapes)
-                }
+                new IRubyObject[]{sourcesWithMetadata, RubyUtil.RUBY.newBoolean(supportEscapes)}
             );
         return code.toJava(PipelineIR.class);
     }

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/PluginFactory.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/PluginFactory.java
@@ -1,13 +1,13 @@
 package org.logstash.config.ir.compiler;
 
 import co.elastic.logstash.api.Codec;
-import org.jruby.RubyInteger;
 import org.jruby.RubyString;
 import org.jruby.runtime.builtin.IRubyObject;
 import co.elastic.logstash.api.Configuration;
 import co.elastic.logstash.api.Context;
 import co.elastic.logstash.api.Filter;
 import co.elastic.logstash.api.Input;
+import org.logstash.common.SourceWithMetadata;
 
 import java.util.Map;
 
@@ -18,9 +18,7 @@ public interface PluginFactory extends RubyIntegration.PluginFactory {
 
     Input buildInput(String name, String id, Configuration configuration, Context context);
 
-    Filter buildFilter(
-            String name, String id, Configuration configuration, Context context
-    );
+    Filter buildFilter(String name, String id, Configuration configuration, Context context);
 
     final class Default implements PluginFactory {
 
@@ -41,28 +39,27 @@ public interface PluginFactory extends RubyIntegration.PluginFactory {
         }
 
         @Override
-        public IRubyObject buildInput(final RubyString name, final RubyInteger line, final RubyInteger column,
+        public IRubyObject buildInput(final RubyString name, SourceWithMetadata source,
                                       final IRubyObject args, Map<String, Object> pluginArgs) {
-            return rubyFactory.buildInput(name, line, column, args, pluginArgs);
+            return rubyFactory.buildInput(name, source, args, pluginArgs);
         }
 
         @Override
-        public AbstractOutputDelegatorExt buildOutput(final RubyString name, final RubyInteger line,
-                                                      final RubyInteger column, final IRubyObject args,
-                                                      final Map<String, Object> pluginArgs) {
-            return rubyFactory.buildOutput(name, line, column, args, pluginArgs);
+        public AbstractOutputDelegatorExt buildOutput(final RubyString name, SourceWithMetadata source,
+                                                      final IRubyObject args, final Map<String, Object> pluginArgs) {
+            return rubyFactory.buildOutput(name, source, args, pluginArgs);
         }
 
         @Override
-        public AbstractFilterDelegatorExt buildFilter(final RubyString name, final RubyInteger line,
-                                                      final RubyInteger column, final IRubyObject args,
-                                                      final Map<String, Object> pluginArgs) {
-            return rubyFactory.buildFilter(name, line, column, args, pluginArgs);
+        public AbstractFilterDelegatorExt buildFilter(final RubyString name, SourceWithMetadata source,
+                                                      final IRubyObject args, final Map<String, Object> pluginArgs) {
+            return rubyFactory.buildFilter(name, source, args, pluginArgs);
         }
 
         @Override
-        public IRubyObject buildCodec(final RubyString name, final IRubyObject args, Map<String, Object> pluginArgs) {
-            return rubyFactory.buildCodec(name, args, pluginArgs);
+        public IRubyObject buildCodec(final RubyString name, SourceWithMetadata source, final IRubyObject args,
+                                      Map<String, Object> pluginArgs) {
+            return rubyFactory.buildCodec(name, source, args, pluginArgs);
         }
 
         @Override

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
@@ -1,9 +1,9 @@
 package org.logstash.config.ir.compiler;
 
 import co.elastic.logstash.api.Codec;
-import org.jruby.RubyInteger;
 import org.jruby.RubyString;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.logstash.common.SourceWithMetadata;
 
 import java.util.Map;
 
@@ -21,16 +21,17 @@ public final class RubyIntegration {
      */
     public interface PluginFactory {
 
-        IRubyObject buildInput(RubyString name, RubyInteger line, RubyInteger column,
-            IRubyObject args, Map<String, Object> pluginArgs);
+        IRubyObject buildInput(RubyString name, SourceWithMetadata source,
+                               IRubyObject args, Map<String, Object> pluginArgs);
 
-        AbstractOutputDelegatorExt buildOutput(RubyString name, RubyInteger line, RubyInteger column,
-            IRubyObject args, Map<String, Object> pluginArgs);
+        AbstractOutputDelegatorExt buildOutput(RubyString name, SourceWithMetadata source,
+                                               IRubyObject args, Map<String, Object> pluginArgs);
 
-        AbstractFilterDelegatorExt buildFilter(RubyString name, RubyInteger line, RubyInteger column, IRubyObject args,
-            Map<String, Object> pluginArgs);
+        AbstractFilterDelegatorExt buildFilter(RubyString name, SourceWithMetadata source, IRubyObject args,
+                                               Map<String, Object> pluginArgs);
 
-        IRubyObject buildCodec(RubyString name, IRubyObject args, Map<String, Object> pluginArgs);
+        IRubyObject buildCodec(RubyString name, SourceWithMetadata source, IRubyObject args,
+                               Map<String, Object> pluginArgs);
 
         Codec buildDefaultCodec(String codecName);
 

--- a/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
@@ -14,7 +14,6 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.jruby.RubyInteger;
 import org.jruby.RubyString;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.junit.After;
@@ -25,6 +24,7 @@ import org.logstash.ConvertedMap;
 import org.logstash.Event;
 import org.logstash.RubyUtil;
 import org.logstash.common.IncompleteSourceWithMetadataException;
+import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.compiler.AbstractFilterDelegatorExt;
 import org.logstash.config.ir.compiler.AbstractOutputDelegatorExt;
 import org.logstash.config.ir.compiler.FilterDelegatorExt;
@@ -97,7 +97,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
     @Test
     public void buildsTrivialPipeline() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
-            "input {mockinput{}} output{mockoutput{}}", false
+                IRHelpers.toSourceWithMetadata("input {mockinput{}} output{mockoutput{}}"), false
         );
         final JrubyEventExtLibrary.RubyEvent testEvent =
             JrubyEventExtLibrary.RubyEvent.newRubyEvent(RubyUtil.RUBY, new Event());
@@ -116,7 +116,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
     @Test
     public void buildsStraightPipeline() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
-            "input {mockinput{}} filter { mockfilter {} mockfilter {} mockfilter {}} output{mockoutput{}}",
+                IRHelpers.toSourceWithMetadata("input {mockinput{}} filter { mockfilter {} mockfilter {} mockfilter {}} output{mockoutput{}}"),
             false
         );
         final JrubyEventExtLibrary.RubyEvent testEvent =
@@ -136,7 +136,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
 
     @Test
     public void buildsForkedPipeline() throws Exception {
-        final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
+        final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(IRHelpers.toSourceWithMetadata(
             "input {mockinput{}} filter { " +
                 "if [foo] != \"bar\" { " +
                 "mockfilter {} " +
@@ -144,7 +144,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
                 "if [foo] != \"bar\" { " +
                 "mockfilter {} " +
                 "}} " +
-                "} output {mockoutput{} }",
+                "} output {mockoutput{} }"),
             false
         );
         final JrubyEventExtLibrary.RubyEvent testEvent =
@@ -268,9 +268,9 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
 
         new CompiledPipeline(
                 ConfigCompiler.configToPipelineIR(
-                        "input {mockinput{}} output { " +
+                        IRHelpers.toSourceWithMetadata("input {mockinput{}} output { " +
                                 String.format("if \"z\" %s /z/ { ", operator) +
-                                " mockoutput{} } }",
+                                " mockoutput{} } }"),
                         false
                 ),
                 new CompiledPipelineTest.MockPluginFactory(
@@ -289,7 +289,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
     @Test
     public void equalityCheckOnCompositeField() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
-                "input {mockinput{}} filter { if 4 == [list] { mockaddfilter {} } if 5 == [map] { mockaddfilter {} } } output {mockoutput{} }",
+                IRHelpers.toSourceWithMetadata("input {mockinput{}} filter { if 4 == [list] { mockaddfilter {} } if 5 == [map] { mockaddfilter {} } } output {mockoutput{} }"),
                 false
         );
         final Collection<String> s = new ArrayList<>();
@@ -320,7 +320,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
     @Test
     public void conditionalWithNullField() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
-                "input {mockinput{}} filter { if [foo] == [bar] { mockaddfilter {} } } output {mockoutput{} }",
+                IRHelpers.toSourceWithMetadata("input {mockinput{}} filter { if [foo] == [bar] { mockaddfilter {} } } output {mockoutput{} }"),
                 false
         );
         final JrubyEventExtLibrary.RubyEvent testEvent =
@@ -344,7 +344,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
     @Test
     public void conditionalNestedMetaFieldPipeline() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
-            "input {mockinput{}} filter { if [@metadata][foo][bar] { mockaddfilter {} } } output {mockoutput{} }",
+                IRHelpers.toSourceWithMetadata("input {mockinput{}} filter { if [@metadata][foo][bar] { mockaddfilter {} } } output {mockoutput{} }"),
             false
         );
         final JrubyEventExtLibrary.RubyEvent testEvent =
@@ -369,7 +369,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
     @Test
     public void moreThan255Parents() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
-            "input {mockinput{}} filter { " +
+                IRHelpers.toSourceWithMetadata("input {mockinput{}} filter { " +
                 "if [foo] != \"bar\" { " +
                 "mockfilter {} " +
                 "mockaddfilter {} " +
@@ -377,7 +377,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
                 "mockfilter {} " +
                 Strings.repeat("} else if [foo] != \"bar\" {" +
                     "mockfilter {} ", 300) + " } } " +
-                "} output {mockoutput{} }",
+                "} output {mockoutput{} }"),
             false
         );
         final JrubyEventExtLibrary.RubyEvent testEvent =
@@ -426,11 +426,11 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
 
         new CompiledPipeline(
             ConfigCompiler.configToPipelineIR(
-                "input {mockinput{}} filter { " +
+                    IRHelpers.toSourceWithMetadata("input {mockinput{}} filter { " +
                     String.format("if %s { ", conditional) +
                     " mockaddfilter {} " +
                     "} " +
-                    "} output {mockoutput{} }",
+                    "} output {mockoutput{} }"),
                 false
             ),
             new CompiledPipelineTest.MockPluginFactory(
@@ -476,28 +476,28 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
         }
 
         @Override
-        public IRubyObject buildInput(final RubyString name, final RubyInteger line,
-            final RubyInteger column, final IRubyObject args, Map<String, Object> pluginArgs) {
+        public IRubyObject buildInput(final RubyString name, SourceWithMetadata source,
+                                      final IRubyObject args, Map<String, Object> pluginArgs) {
             return setupPlugin(name, inputs);
         }
 
         @Override
-        public AbstractOutputDelegatorExt buildOutput(final RubyString name, final RubyInteger line,
-            final RubyInteger column, final IRubyObject args, Map<String, Object> pluginArgs) {
+        public AbstractOutputDelegatorExt buildOutput(final RubyString name, SourceWithMetadata source,
+                                                      final IRubyObject args, Map<String, Object> pluginArgs) {
             return PipelineTestUtil.buildOutput(setupPlugin(name, outputs));
         }
 
         @Override
-        public AbstractFilterDelegatorExt buildFilter(final RubyString name, final RubyInteger line,
-                                                      final RubyInteger column, final IRubyObject args,
-                                                      Map<String, Object> pluginArgs) {
+        public AbstractFilterDelegatorExt buildFilter(final RubyString name, SourceWithMetadata source,
+                                                      final IRubyObject args, Map<String, Object> pluginArgs) {
             return new FilterDelegatorExt(
                 RubyUtil.RUBY, RubyUtil.FILTER_DELEGATOR_CLASS)
                 .initForTesting(setupPlugin(name, filters));
         }
 
         @Override
-        public IRubyObject buildCodec(final RubyString name, final IRubyObject args, Map<String, Object> pluginArgs) {
+        public IRubyObject buildCodec(final RubyString name, SourceWithMetadata source, final IRubyObject args,
+                                      Map<String, Object> pluginArgs) {
             throw new IllegalStateException("No codec setup expected in this test.");
         }
 

--- a/logstash-core/src/test/java/org/logstash/config/ir/ConfigCompilerTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/ConfigCompilerTest.java
@@ -2,8 +2,13 @@ package org.logstash.config.ir;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+
+import org.jruby.javasupport.JavaUtil;
+import org.jruby.runtime.builtin.IRubyObject;
 import org.junit.Test;
+import org.logstash.RubyUtil;
 import org.logstash.common.IncompleteSourceWithMetadataException;
+import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.graph.Graph;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -13,8 +18,10 @@ public class ConfigCompilerTest extends RubyEnvTestCase {
 
     @Test
     public void testConfigToPipelineIR() throws Exception {
+        IRubyObject swm = JavaUtil.convertJavaToRuby(
+                RubyUtil.RUBY, new SourceWithMetadata("proto", "path", 1, 1, "input {stdin{}} output{stdout{}}"));
         final PipelineIR pipelineIR =
-            ConfigCompiler.configToPipelineIR("input {stdin{}} output{stdout{}}", false);
+            ConfigCompiler.configToPipelineIR(RubyUtil.RUBY.newArray(swm), false);
         assertThat(pipelineIR.getOutputPluginVertices().size(), is(1));
         assertThat(pipelineIR.getFilterPluginVertices().size(), is(0));
     }
@@ -60,8 +67,9 @@ public class ConfigCompilerTest extends RubyEnvTestCase {
         assertThat(graphHash(config), is(first));
     }
 
-    private static String graphHash(final String config)
-        throws IncompleteSourceWithMetadataException {
-        return ConfigCompiler.configToPipelineIR(config, false).uniqueHash();
+    private static String graphHash(final String config) throws IncompleteSourceWithMetadataException {
+        IRubyObject swm = JavaUtil.convertJavaToRuby(
+                RubyUtil.RUBY, new SourceWithMetadata("proto", "path", 1, 1, config));
+        return ConfigCompiler.configToPipelineIR(RubyUtil.RUBY.newArray(swm), false).uniqueHash();
     }
 }

--- a/logstash-core/src/test/java/org/logstash/config/ir/EventConditionTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/EventConditionTest.java
@@ -55,12 +55,12 @@ public final class EventConditionTest extends RubyEnvTestCase {
     @SuppressWarnings("rawtypes")
     public void testInclusionWithFieldInField() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
-                "input {mockinput{}} filter { " +
+                IRHelpers.toSourceWithMetadata("input {mockinput{}} filter { " +
                         "mockfilter {} } " +
                         "output { " +
                         "  if [left] in [right] { " +
                         "    mockoutput{}" +
-                        "  } }",
+                        "  } }"),
                 false
         );
 
@@ -136,12 +136,12 @@ public final class EventConditionTest extends RubyEnvTestCase {
 
     private void testConditionWithConstantValue(String condition, int expectedMatches) throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
-                "input {mockinput{}} filter { " +
+                IRHelpers.toSourceWithMetadata("input {mockinput{}} filter { " +
                         "mockfilter {} } " +
                         "output { " +
                         "  if " + condition + " { " +
                         "    mockoutput{}" +
-                        "  } }",
+                        "  } }"),
                 false
         );
 

--- a/logstash-core/src/test/java/org/logstash/config/ir/IRHelpers.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/IRHelpers.java
@@ -1,6 +1,9 @@
 package org.logstash.config.ir;
 
 import org.hamcrest.MatcherAssert;
+import org.jruby.RubyArray;
+import org.jruby.javasupport.JavaUtil;
+import org.logstash.RubyUtil;
 import org.logstash.common.IncompleteSourceWithMetadataException;
 import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.expression.BooleanExpression;
@@ -164,5 +167,12 @@ public class IRHelpers {
             out.append(RANDOM_CHARS.charAt(pos));
         }
         return out.toString();
+    }
+
+
+    @SuppressWarnings("rawtypes")
+    public static RubyArray toSourceWithMetadata(String config) throws IncompleteSourceWithMetadataException {
+        return RubyUtil.RUBY.newArray(JavaUtil.convertJavaToRuby(
+                RubyUtil.RUBY, new SourceWithMetadata("proto", "path", 1, 1, config)));
     }
 }

--- a/logstash-core/src/test/java/org/logstash/plugins/TestPluginFactory.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/TestPluginFactory.java
@@ -1,9 +1,9 @@
 package org.logstash.plugins;
 
 import co.elastic.logstash.api.Codec;
-import org.jruby.RubyInteger;
 import org.jruby.RubyString;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.compiler.AbstractFilterDelegatorExt;
 import org.logstash.config.ir.compiler.AbstractOutputDelegatorExt;
 import org.logstash.config.ir.compiler.RubyIntegration;
@@ -15,22 +15,26 @@ import java.util.Map;
 public class TestPluginFactory implements RubyIntegration.PluginFactory {
 
     @Override
-    public IRubyObject buildInput(RubyString name, RubyInteger line, RubyInteger column, IRubyObject args, Map<String, Object> pluginArgs) {
+    public IRubyObject buildInput(RubyString name, SourceWithMetadata source,
+                                  IRubyObject args, Map<String, Object> pluginArgs) {
         return null;
     }
 
     @Override
-    public AbstractOutputDelegatorExt buildOutput(RubyString name, RubyInteger line, RubyInteger column, IRubyObject args, Map<String, Object> pluginArgs) {
+    public AbstractOutputDelegatorExt buildOutput(RubyString name, SourceWithMetadata source,
+                                                  IRubyObject args, Map<String, Object> pluginArgs) {
         return null;
     }
 
     @Override
-    public AbstractFilterDelegatorExt buildFilter(RubyString name, RubyInteger line, RubyInteger column, IRubyObject args, Map<String, Object> pluginArgs) {
+    public AbstractFilterDelegatorExt buildFilter(RubyString name, SourceWithMetadata source,
+                                                  IRubyObject args, Map<String, Object> pluginArgs) {
         return null;
     }
 
     @Override
-    public IRubyObject buildCodec(RubyString name, IRubyObject args, Map<String, Object> pluginArgs) {
+    public IRubyObject buildCodec(RubyString name, SourceWithMetadata source, IRubyObject args,
+                                  Map<String, Object> pluginArgs) {
         return null;
     }
 


### PR DESCRIPTION
This is the implementation of the draft idea exposed in PR #11429  to avoid merge of text fragments in SourceWithMetadata. The idea is to spread the use of SourceWithMetadata because contains all references to the source of a configuration and is useful to simplify PR #11288 