### PR TITLE
Fixes to JMH launch after upgrade to Gradle 5

### DIFF
--- a/logstash-core/benchmarks/build.gradle
+++ b/logstash-core/benchmarks/build.gradle
@@ -32,15 +32,13 @@ jar {
 }
 
 ext {
-  jmh = 1.18
+  jmh = 1.22
 }
 
 dependencies {
   compile project(':logstash-core')
   compile "org.openjdk.jmh:jmh-core:$jmh"
-  compile "org.openjdk.jmh:jmh-generator-annprocess:$jmh"
-  compile "org.openjdk.jmh:jmh-core-benchmarks:$jmh"
-  compile 'net.sf.jopt-simple:jopt-simple:5.0.3'
+  annotationProcessor "org.openjdk.jmh:jmh-generator-annprocess:$jmh"
   compile 'com.google.guava:guava:21.0'
   compile 'commons-io:commons-io:2.5'
   runtime 'joda-time:joda-time:2.8.2'
@@ -68,7 +66,7 @@ task jmh(type: JavaExec, dependsOn: [':logstash-core-benchmarks:clean', ':logsta
   doFirst {
     args = [
             "-Djava.io.tmpdir=${buildDir.absolutePath}",
-            "-XX:+UseParNewGC", "-XX:+UseConcMarkSweepGC", "-XX:CMSInitiatingOccupancyFraction=75",
+            "-XX:+UseConcMarkSweepGC", "-XX:CMSInitiatingOccupancyFraction=75",
             "-XX:+UseCMSInitiatingOccupancyOnly", "-XX:+DisableExplicitGC",
             "-XX:+HeapDumpOnOutOfMemoryError", "-Xms2g", "-Xmx2g",
             shadowJar.archivePath,

--- a/tools/ingest-converter/build.gradle
+++ b/tools/ingest-converter/build.gradle
@@ -23,7 +23,7 @@ buildscript {
 }
 
 dependencies {
-  compile 'net.sf.jopt-simple:jopt-simple:5.0.3'
+  compile 'net.sf.jopt-simple:jopt-simple:4.6'
   testCompile "junit:junit:4.12"
   testCompile 'commons-io:commons-io:2.5'
 }


### PR DESCRIPTION
This PR fixes the following problems:
- JMH requires jopt-simple 4.6 while the 5.0.3 has a breaking change that throws NoSuchMethod, they changed the signature of OptionDescriptor from [Collection<String> options()](https://github.com/jopt-simple/jopt-simple/blob/jopt-simple-4.6/src/main/java/joptsimple/OptionDescriptor.java#L43) to  [List<String> options()](https://github.com/jopt-simple/jopt-simple/blob/jopt-simple-5.0.2/src/main/java/joptsimple/OptionDescriptor.java#L42)
- Updates JMH from version 1.18 to 1.22
- With Gradle 5 annotation processors dependencies can't use anymore  `compile` but has its own `annotationProcessor`
- Use detection of JDK because in JDK > 8 `-XX:+UseParNewGC` has been removed an that made to fail JMH in JDK 11

