### PR TITLE
backport SharedHelpers.trap memleak fix to 6.8

### DIFF
--- a/rakelib/plugins_docs_dependencies.rake
+++ b/rakelib/plugins_docs_dependencies.rake
@@ -131,5 +131,45 @@ task :generate_plugins_version do
   require "pluginmanager/gemfile"
   require "bootstrap/environment"
 
+  # This patch comes after an investigation of `generate_plugins_version`
+  # causing OOM during `./gradlew generatePluginsVersion`.
+  # Why does this patch fix the issue? Hang on, this is going to be wild ride:
+  # In this rake task we compute a manifest that tells us, for each logstash plugin,
+  # what is the latest version that can be installed.
+  # We do this by (again for each plugin):
+  # * adding the plugin to the current Gemfile
+  # * instantiate a `Bundler::Dsl` instance with said Gemfile
+  # * retrieve a Bundler::Definition by passing in the Gemfile.lock
+  # * call `definition.resolve_remotely!
+  #
+  # Now, these repeated calls to `resolve_remotely!` on new instances of Definitions
+  # cause the out of memory. Resolving remote dependencies uses Bundler::Worker instances
+  # who trap the SIGINT signal in their `initializer` [1]. This shared helper method creates a closure that is
+  # passed to `Signal.trap`, and capture the return [2], which is the previous proc (signal handler).
+  # Since the variable that stores the return from `Signal.trap` is present in the binding, multiple calls
+  # to this helper cause each new closures to reference the previous one. The size of each binding
+  # accumulates and OOM occurs after 70-100 iterations.
+  # This is easy to replicate by looping over `Bundler::SharedHelpers.trap("INT") { 1 }`.
+  #
+  # This workaround removes the capture of the previous binding. Not calling all the previous handlers
+  # may cause some threads to not be cleaned up, but this rake task has a short life so everything
+  # ends up being cleaned up on exit anyway.
+  # We're confining this patch to this task only as this is the only place where we need to resolve
+  # dependencies many many times.
+  #
+  # You're still here? You're awesome :) Thanks for reading!
+  #
+  # [1] https://github.com/bundler/bundler/blob/d9d75807196b91f454de48d5afd0c43b395243a3/lib/bundler/worker.rb#L29
+  # [2] https://github.com/bundler/bundler/blob/d9d75807196b91f454de48d5afd0c43b395243a3/lib/bundler/shared_helpers.rb#L173
+  module ::Bundler
+    module SharedHelpers
+      def trap(signal, override = false, &block)
+        Signal.trap(signal) do
+          block.call
+        end
+      end
+    end
+  end
+
   PluginVersionWorking.new.generate
 end


### PR DESCRIPTION
backport the Signal.trap leak from #10942 (commit 15fb308)

This fixes failed doc builds such as https://logstash-ci.elastic.co/view/Docs/job/elastic+docs-tools+logstash-plugin-docs/56/console when running `./gradlew generatePluginsVersion` on the 6.8 branch.