### PR TITLE
Add java plugin examples to skiplist for 6.8

### DIFF
--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -62,6 +62,10 @@
 		"test-vendor-plugins": false,
 		"skip-list": false
 	},
+	"logstash-codec-java_codec_example": {
+    "default-plugins": false,
+    "skip-list": true
+  },
 	"logstash-codec-json": {
 		"default-plugins": true,
 		"core-specs": false,
@@ -195,6 +199,10 @@
 		"test-vendor-plugins": false,
 		"skip-list": false
 	},
+	"logstash-filter-java_filter_example": {
+    "default-plugins": false,
+    "skip-list": true
+  },
 	"logstash-filter-json": {
 		"default-plugins": true,
 		"core-specs": false,
@@ -377,6 +385,10 @@
 		"test-vendor-plugins": false,
 		"skip-list": true
 	},
+	"logstash-input-java_input_example": {
+    "default-plugins": false,
+    "skip-list": true
+  },
 	"logstash-input-pipe": {
 		"default-plugins": true,
 		"core-specs": false,
@@ -531,6 +543,10 @@
 		"test-vendor-plugins": false,
 		"skip-list": false
 	},
+	"logstash-output-java_output_example": {
+    "default-plugins": false,
+    "skip-list": true
+  },
 	"logstash-output-kafka": {
 		"default-plugins": true,
 		"core-specs": false,

--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -63,9 +63,9 @@
 		"skip-list": false
 	},
 	"logstash-codec-java_codec_example": {
-    "default-plugins": false,
-    "skip-list": true
-  },
+		"default-plugins": false,
+		"skip-list": true
+	},
 	"logstash-codec-json": {
 		"default-plugins": true,
 		"core-specs": false,
@@ -200,9 +200,9 @@
 		"skip-list": false
 	},
 	"logstash-filter-java_filter_example": {
-    "default-plugins": false,
-    "skip-list": true
-  },
+		"default-plugins": false,
+		"skip-list": true
+	},
 	"logstash-filter-json": {
 		"default-plugins": true,
 		"core-specs": false,
@@ -386,9 +386,9 @@
 		"skip-list": true
 	},
 	"logstash-input-java_input_example": {
-    "default-plugins": false,
-    "skip-list": true
-  },
+		"default-plugins": false,
+		"skip-list": true
+	},
 	"logstash-input-pipe": {
 		"default-plugins": true,
 		"core-specs": false,
@@ -544,9 +544,9 @@
 		"skip-list": false
 	},
 	"logstash-output-java_output_example": {
-    "default-plugins": false,
-    "skip-list": true
-  },
+		"default-plugins": false,
+		"skip-list": true
+	},
 	"logstash-output-kafka": {
 		"default-plugins": true,
 		"core-specs": false,


### PR DESCRIPTION
One of the java plugin examples showed up in the latest plugin docgen for 6.8. Looks like they all should be added to the skiplist. 