### PR TITLE
Cache compiled classes by vertex ID

### DIFF
--- a/config/pipelines.yml
+++ b/config/pipelines.yml
@@ -75,3 +75,9 @@
 #   Default is path.data/dead_letter_queue
 #
 #   path.dead_letter_queue:
+
+
+ - pipeline.id: test
+   config.string: "input { generator {} } filter { drop { id => 'sleep1' } } output { stdout { id => 'sleep1' } }"
+ - pipeline.id: another_test
+   config.string: "input { generator {} } filter { drop { id => 'sleep1' } } output { stdout { id => 'toto' } }"

--- a/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
@@ -309,7 +309,7 @@ public final class CompiledPipeline {
             if (outputNodes.isEmpty()) {
                 return Dataset.IDENTITY;
             } else {
-                return DatasetCompiler.terminalDataset(outputNodes.stream().map(
+                return DatasetCompiler.terminalDataset(pipelineIR.uniqueHash(), outputNodes.stream().map(
                     leaf -> outputDataset(leaf, flatten(Collections.emptyList(), leaf))
                 ).collect(Collectors.toList()));
             }
@@ -331,7 +331,7 @@ public final class CompiledPipeline {
                                                       filters.get(vertexId));
                 LOGGER.debug("Compiled filter\n {} \n into \n {}", vertex, prepared);
 
-                plugins.put(vertexId, prepared.instantiate());
+                plugins.put(vertexId, prepared.instantiate(vertexId));
             }
 
             return plugins.get(vertexId);
@@ -353,7 +353,7 @@ public final class CompiledPipeline {
                                                       outputs.get(vertexId),
                                                      outputs.size() == 1);
                 LOGGER.debug("Compiled output\n {} \n into \n {}", vertex, prepared);
-                plugins.put(vertexId, prepared.instantiate());
+                plugins.put(vertexId, prepared.instantiate(vertexId));
             }
 
             return plugins.get(vertexId);
@@ -382,7 +382,7 @@ public final class CompiledPipeline {
                     LOGGER.debug(
                         "Compiled conditional\n {} \n into \n {}", vertex, prepared
                     );
-                    conditional = prepared.instantiate();
+                    conditional = prepared.instantiate(key);
                     iffs.put(key, conditional);
                 }
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
@@ -327,11 +327,11 @@ public final class CompiledPipeline {
 
             if (!plugins.containsKey(vertexId)) {
                 final ComputeStepSyntaxElement<Dataset> prepared =
-                        DatasetCompiler.filterDataset(flatten(datasets, vertex),
+                        DatasetCompiler.filterDataset(vertexId, flatten(datasets, vertex),
                                                       filters.get(vertexId));
                 LOGGER.debug("Compiled filter\n {} \n into \n {}", vertex, prepared);
 
-                plugins.put(vertexId, prepared.instantiate(vertexId));
+                plugins.put(vertexId, prepared.instantiate());
             }
 
             return plugins.get(vertexId);
@@ -349,11 +349,11 @@ public final class CompiledPipeline {
 
             if (!plugins.containsKey(vertexId)) {
                 final ComputeStepSyntaxElement<Dataset> prepared =
-                        DatasetCompiler.outputDataset(flatten(datasets, vertex),
+                        DatasetCompiler.outputDataset(vertexId, flatten(datasets, vertex),
                                                       outputs.get(vertexId),
                                                      outputs.size() == 1);
                 LOGGER.debug("Compiled output\n {} \n into \n {}", vertex, prepared);
-                plugins.put(vertexId, prepared.instantiate(vertexId));
+                plugins.put(vertexId, prepared.instantiate());
             }
 
             return plugins.get(vertexId);
@@ -378,11 +378,11 @@ public final class CompiledPipeline {
                 // by requiring its else branch.
                 if (conditional == null) {
                     final ComputeStepSyntaxElement<SplitDataset> prepared =
-                        DatasetCompiler.splitDataset(dependencies, condition);
+                        DatasetCompiler.splitDataset(key, dependencies, condition);
                     LOGGER.debug(
                         "Compiled conditional\n {} \n into \n {}", vertex, prepared
                     );
-                    conditional = prepared.instantiate(key);
+                    conditional = prepared.instantiate();
                     iffs.put(key, conditional);
                 }
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
@@ -369,21 +369,22 @@ public final class CompiledPipeline {
          */
         private SplitDataset split(final Collection<Dataset> datasets,
             final EventCondition condition, final Vertex vertex) {
-            final String key = vertex.getId();
-            SplitDataset conditional = iffs.get(key);
+            final String vertexId = vertex.getId();
+            SplitDataset conditional = iffs.get(vertexId);
+
             if (conditional == null) {
                 final Collection<Dataset> dependencies = flatten(datasets, vertex);
-                conditional = iffs.get(key);
+                conditional = iffs.get(vertexId);
                 // Check that compiling the dependencies did not already instantiate the conditional
                 // by requiring its else branch.
                 if (conditional == null) {
                     final ComputeStepSyntaxElement<SplitDataset> prepared =
-                        DatasetCompiler.splitDataset(key, dependencies, condition);
+                        DatasetCompiler.splitDataset(vertexId, dependencies, condition);
                     LOGGER.debug(
                         "Compiled conditional\n {} \n into \n {}", vertex, prepared
                     );
                     conditional = prepared.instantiate();
-                    iffs.put(key, conditional);
+                    iffs.put(vertexId, conditional);
                 }
 
             }

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/ComputeStepSyntaxElement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/ComputeStepSyntaxElement.java
@@ -60,19 +60,23 @@ public final class ComputeStepSyntaxElement<T extends Dataset> {
 
     public static <T extends Dataset> ComputeStepSyntaxElement<T> create(
         final String id,
-        final Iterable<MethodSyntaxElement> methods, final ClassFields fields,
-        final Class<T> interfce) {
+        final Iterable<MethodSyntaxElement> methods,
+        final ClassFields fields,
+        final Class<T> interfce)
+    {
         return new ComputeStepSyntaxElement<>(id, methods, fields, interfce);
     }
 
-    private ComputeStepSyntaxElement(final String id,
+    private ComputeStepSyntaxElement(
+        final String id,
         final Iterable<MethodSyntaxElement> methods,
-        final ClassFields fields, final Class<T> interfce)
+        final ClassFields fields,
+        final Class<T> interfce)
     {
+        this.id = id;
         this.methods = methods;
         this.fields = fields;
         type = interfce;
-        this.id = id;
     }
 
     @SuppressWarnings("unchecked")

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/DatasetCompiler.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/DatasetCompiler.java
@@ -76,8 +76,12 @@ public final class DatasetCompiler {
             );
         }
         return ComputeStepSyntaxElement.create(
-            vertexId, Arrays.asList(compute.compute(), compute.clear(),
-            MethodSyntaxElement.right(right)), compute.fields(), SplitDataset.class
+            vertexId,
+            Arrays.asList(compute.compute(),
+            compute.clear(),
+            MethodSyntaxElement.right(right)),
+            compute.fields(),
+            SplitDataset.class
         );
     }
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/DatasetCompiler.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/DatasetCompiler.java
@@ -113,10 +113,11 @@ public final class DatasetCompiler {
      * trivial dataset that does not invoke any computation whatsoever.</p>
      * {@link Dataset#compute(RubyArray, boolean, boolean)} is always
      * {@link Collections#emptyList()}.
+     * @param key String {@link String} unique key for this {@link Dataset}
      * @param parents Parent {@link Dataset} to sum and terminate
      * @return Dataset representing the sum of given parent {@link Dataset}
      */
-    public static Dataset terminalDataset(final Collection<Dataset> parents) {
+    public static Dataset terminalDataset(final String key, final Collection<Dataset> parents) {
         final int count = parents.size();
         final Dataset result;
         if (count > 1) {
@@ -128,7 +129,7 @@ public final class DatasetCompiler {
                     parentFields.stream().map(DatasetCompiler::computeDataset)
                         .toArray(MethodLevelSyntaxElement[]::new)
                 ).add(clearSyntax(parentFields)), Closure.EMPTY, fields
-            ).instantiate();
+            ).instantiate(key);
         } else if (count == 1) {
             // No need for a terminal dataset here, if there is only a single parent node we can
             // call it directly.

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/DatasetCompilerTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/DatasetCompilerTest.java
@@ -22,10 +22,11 @@ public final class DatasetCompilerTest {
     public void compilesOutputDataset() {
         assertThat(
             DatasetCompiler.outputDataset(
+                "foo",
                 Collections.emptyList(),
                 PipelineTestUtil.buildOutput(events -> {}),
                 true
-            ).instantiate("foo").compute(RubyUtil.RUBY.newArray(), false, false),
+            ).instantiate().compute(RubyUtil.RUBY.newArray(), false, false),
             nullValue()
         );
     }
@@ -34,8 +35,9 @@ public final class DatasetCompilerTest {
     public void compilesSplitDataset() {
         final FieldReference key = FieldReference.from("foo");
         final SplitDataset left = DatasetCompiler.splitDataset(
+            "bar",
             Collections.emptyList(), event -> event.getEvent().includes(key)
-        ).instantiate("bar");
+        ).instantiate();
         final Event trueEvent = new Event();
         trueEvent.setField(key, "val");
         final JrubyEventExtLibrary.RubyEvent falseEvent =

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/DatasetCompilerTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/DatasetCompilerTest.java
@@ -25,7 +25,7 @@ public final class DatasetCompilerTest {
                 Collections.emptyList(),
                 PipelineTestUtil.buildOutput(events -> {}),
                 true
-            ).instantiate().compute(RubyUtil.RUBY.newArray(), false, false),
+            ).instantiate("foo").compute(RubyUtil.RUBY.newArray(), false, false),
             nullValue()
         );
     }
@@ -35,7 +35,7 @@ public final class DatasetCompilerTest {
         final FieldReference key = FieldReference.from("foo");
         final SplitDataset left = DatasetCompiler.splitDataset(
             Collections.emptyList(), event -> event.getEvent().includes(key)
-        ).instantiate();
+        ).instantiate("bar");
         final Event trueEvent = new Event();
         trueEvent.setField(key, "val");
         final JrubyEventExtLibrary.RubyEvent falseEvent =


### PR DESCRIPTION
Fixes #11105 
Relates to #11175

This fixes the compiled classes cache problem where the compiled classes were cached using the `ComputeStepSyntaxElement` instance object as the cache key. The problem is that new `ComputeStepSyntaxElement` instances are created per worker threads `CompiledExecution` thus the cached classes were never reused. 

This solution proposes to use the `DataSet` associated vertex ID as the cache key. For this the `ComputeStepSyntaxElement` class now has a unique ID `String` field which is propagated from the `CompiledPipeline` where the vertex ID is known and used as the cache key. 

