### PR TITLE
Move class caching from ComputeStepSyntaxElement to CompiledPipeline

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/ComputeStepSyntaxElement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/ComputeStepSyntaxElement.java
@@ -11,6 +11,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -32,10 +33,9 @@ public final class ComputeStepSyntaxElement<T extends Dataset> {
     private static final ISimpleCompiler COMPILER = new SimpleCompiler();
 
     /**
-     * Cache of runtime compiled classes to prevent duplicate classes being compiled.
+     * Sequential counter to generate the class name
      */
-    private static final Map<ComputeStepSyntaxElement<?>, Class<? extends Dataset>> CLASS_CACHE
-        = new HashMap<>();
+    private static final AtomicLong classSeqCount = new AtomicLong();
 
     /**
      * Pattern to remove redundant {@code ;} from formatted code since {@link Formatter} does not
@@ -49,6 +49,8 @@ public final class ComputeStepSyntaxElement<T extends Dataset> {
 
     private final Class<T> type;
 
+    private final long classSeq;
+
     public static <T extends Dataset> ComputeStepSyntaxElement<T> create(
         final Iterable<MethodSyntaxElement> methods, final ClassFields fields,
         final Class<T> interfce) {
@@ -60,37 +62,41 @@ public final class ComputeStepSyntaxElement<T extends Dataset> {
         this.methods = methods;
         this.fields = fields;
         type = interfce;
+        classSeq = classSeqCount.incrementAndGet();
     }
 
     @SuppressWarnings("unchecked")
-    public T instantiate() {
-        // We need to globally synchronize to avoid concurrency issues with the internal class
-        // loader and the CLASS_CACHE
+    public T instantiate(Class<? extends Dataset> clazz) {
+        try {
+            return (T) clazz.<T>getConstructor(Map.class).newInstance(ctorArguments());
+        } catch (final NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public Class<? extends Dataset> compile() {
+        // We need to globally synchronize to avoid concurrency issues with the internal class loader
+        // Per https://github.com/elastic/logstash/pull/11482 we should review this lock. 
         synchronized (COMPILER) {
             try {
                 final Class<? extends Dataset> clazz;
-                if (CLASS_CACHE.containsKey(this)) {
-                    clazz = CLASS_CACHE.get(this);
+                final String name = String.format("CompiledDataset%d", classSeq);
+                final String code = generateCode(name);
+                if (SOURCE_DIR != null) {
+                    final Path sourceFile = SOURCE_DIR.resolve(String.format("%s.java", name));
+                    Files.write(sourceFile, code.getBytes(StandardCharsets.UTF_8));
+                    COMPILER.cookFile(sourceFile.toFile());
                 } else {
-                    final String name = String.format("CompiledDataset%d", CLASS_CACHE.size());
-                    final String code = generateCode(name);
-                    if (SOURCE_DIR != null) {
-                        final Path sourceFile = SOURCE_DIR.resolve(String.format("%s.java", name));
-                        Files.write(sourceFile, code.getBytes(StandardCharsets.UTF_8));
-                        COMPILER.cookFile(sourceFile.toFile());
-                    } else {
-                        COMPILER.cook(code);
-                    }
-                    COMPILER.setParentClassLoader(COMPILER.getClassLoader());
-                    clazz = (Class<T>) COMPILER.getClassLoader().loadClass(
-                        String.format("org.logstash.generated.%s", name)
-                    );
-                    CLASS_CACHE.put(this, clazz);
+                    COMPILER.cook(code);
                 }
-                return (T) clazz.<T>getConstructor(Map.class).newInstance(ctorArguments());
-            } catch (final CompileException | ClassNotFoundException | IOException
-                | NoSuchMethodException | InvocationTargetException | InstantiationException
-                | IllegalAccessException ex) {
+                COMPILER.setParentClassLoader(COMPILER.getClassLoader());
+                clazz = (Class<? extends Dataset>)COMPILER.getClassLoader().loadClass(
+                        String.format("org.logstash.generated.%s", name)
+                );
+
+                return clazz;
+            } catch (final CompileException | ClassNotFoundException | IOException ex) {
                 throw new IllegalStateException(ex);
             }
         }

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/DatasetCompiler.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/DatasetCompiler.java
@@ -90,6 +90,7 @@ public final class DatasetCompiler {
         final ValueSyntaxElement outputBuffer = fields.add(new ArrayList<>());
         final Closure clear = Closure.wrap();
         final Closure compute;
+
         if (parents.isEmpty()) {
             compute = filterBody(outputBuffer, BATCH_ARG, fields, plugin);
         } else {
@@ -116,29 +117,16 @@ public final class DatasetCompiler {
      * @param parents Parent {@link Dataset} to sum and terminate
      * @return Dataset representing the sum of given parent {@link Dataset}
      */
-    public static Dataset terminalDataset(final Collection<Dataset> parents) {
-        final int count = parents.size();
-        final Dataset result;
-        if (count > 1) {
-            final ClassFields fields = new ClassFields();
-            final Collection<ValueSyntaxElement> parentFields =
-                parents.stream().map(fields::add).collect(Collectors.toList());
-            result = compileOutput(
-                Closure.wrap(
-                    parentFields.stream().map(DatasetCompiler::computeDataset)
-                        .toArray(MethodLevelSyntaxElement[]::new)
-                ).add(clearSyntax(parentFields)), Closure.EMPTY, fields
-            ).instantiate();
-        } else if (count == 1) {
-            // No need for a terminal dataset here, if there is only a single parent node we can
-            // call it directly.
-            result = parents.iterator().next();
-        } else {
-            throw new IllegalArgumentException(
-                "Cannot create Terminal Dataset for an empty number of parent datasets"
-            );
-        }
-        return result;
+    public static ComputeStepSyntaxElement<Dataset> terminalDataset(final Collection<Dataset> parents) {
+        final ClassFields fields = new ClassFields();
+        final Collection<ValueSyntaxElement> parentFields =
+            parents.stream().map(fields::add).collect(Collectors.toList());
+        return compileOutput(
+            Closure.wrap(
+                parentFields.stream().map(DatasetCompiler::computeDataset)
+                    .toArray(MethodLevelSyntaxElement[]::new)
+            ).add(clearSyntax(parentFields)), Closure.EMPTY, fields
+        );
     }
 
     /**

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/DatasetCompilerTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/DatasetCompilerTest.java
@@ -20,12 +20,13 @@ public final class DatasetCompilerTest {
      */
     @Test
     public void compilesOutputDataset() {
+        final ComputeStepSyntaxElement<Dataset> prepared = DatasetCompiler.outputDataset(
+            Collections.emptyList(),
+            PipelineTestUtil.buildOutput(events -> {}),
+            true
+        );
         assertThat(
-            DatasetCompiler.outputDataset(
-                Collections.emptyList(),
-                PipelineTestUtil.buildOutput(events -> {}),
-                true
-            ).instantiate().compute(RubyUtil.RUBY.newArray(), false, false),
+            prepared.instantiate(prepared.compile()).compute(RubyUtil.RUBY.newArray(), false, false),
             nullValue()
         );
     }
@@ -33,9 +34,10 @@ public final class DatasetCompilerTest {
     @Test
     public void compilesSplitDataset() {
         final FieldReference key = FieldReference.from("foo");
-        final SplitDataset left = DatasetCompiler.splitDataset(
+        final ComputeStepSyntaxElement<SplitDataset> prepared = DatasetCompiler.splitDataset(
             Collections.emptyList(), event -> event.getEvent().includes(key)
-        ).instantiate();
+        );
+        final SplitDataset left = prepared.instantiate(prepared.compile());
         final Event trueEvent = new Event();
         trueEvent.setField(key, "val");
         final JrubyEventExtLibrary.RubyEvent falseEvent =


### PR DESCRIPTION
Fixes #11105
Relates to #11175

This is an alternate implementation of #11479 where the compiles class caching is kept per-pipeline into the `CompiledPipeline` class. 

See #11479 for the problem details.

This approach has the following benefits:
- Solves a potential leak for a global cache upon pipeline reloads.
- Solves a potential class name collision for identical plugins IDs across multiple pipelines.
- Avoids dealing with cache invalidation altogether because the cache is cleared every time a pipeline is created/reloaded. 