### PR TITLE
[Doc] Add info about deprecation logger support mixin

### DIFF
--- a/docs/static/include/pluginbody.asciidoc
+++ b/docs/static/include/pluginbody.asciidoc
@@ -779,6 +779,24 @@ will be discussed further in the testing section of this document.
 Another kind of external dependency is on jar files.  This will be described
 in the "Add a `gemspec` file" section.
 
+===== Deprecated features
+
+As a plugin evolves, an option or feature may no longer serve the
+intended purpose, and the developer may want to _deprecate_ its usage.
+Deprecation warns users about the option's status, so they aren't caught by
+surprise when it is removed in a later release.
+
+{ls} 7.6 introduced a _deprecation logger_ to make handling those situations
+easier. You can use the
+https://github.com/logstash-plugins/logstash-mixin-deprecation_logger_support[adapter]
+to ensure that your plugin can use the deprecation logger while still supporting
+older versions of {ls}. See the
+https://github.com/logstash-plugins/logstash-mixin-deprecation_logger_support/blob/master/README.md[readme]
+for more information and for instructions on using the adapter.
+
+Deprecations are noted in the `logstash-deprecation.log` file in the
+`log` directory.
+
 ===== Add a Gemfile
 
 Gemfiles allow Ruby's Bundler to maintain the dependencies for your plugin.


### PR DESCRIPTION
The deprecation logger support mixin gives plugin developers a way to have their plugin continue to work with older versions with Logstash.  This document exposes that option/requirement to plugin developers. 

Notes: 
* This draft contains questions and notes where we need to add clarification.  It's intended to help continue discussions, not end discussions as the final word. 
* I'm putting up this PR in draft format to capture answers/continued discussions/etc. It is intended as a continuation of the discussion in slack. 

@andsel @yaauie  Thanks for the great input so far. Let's keep it going. 


**PREVIEW:**  http://logstash_11486.docs-preview.app.elstc.co/guide/en/logstash/master/input-new-plugin.html#_deprecated_features

Note:  The same text/file is re-used for codec, filter, and output plugins.