### PR TITLE
Feat: x-pack cloud id/auth for monitoring/management

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -225,7 +225,7 @@
 #xpack.monitoring.elasticsearch.password: password
 #xpack.monitoring.elasticsearch.hosts: ["https://es1:9200", "https://es2:9200"]
 # an alternative to hosts + username/password settings is to use cloud_id/cloud_auth
-#xpack.monitoring.elasticsearch.cloud_id: xxxxxxxxxx
+#xpack.monitoring.elasticsearch.cloud_id: monitoring_cluster_id:xxxxxxxxxx
 #xpack.monitoring.elasticsearch.cloud_auth: logstash_system:password
 #xpack.monitoring.elasticsearch.ssl.certificate_authority: [ "/path/to/ca.crt" ]
 #xpack.monitoring.elasticsearch.ssl.truststore.path: path/to/file
@@ -245,7 +245,7 @@
 #xpack.management.elasticsearch.password: password
 #xpack.management.elasticsearch.hosts: ["https://es1:9200", "https://es2:9200"]
 # an alternative to hosts + username/password settings is to use cloud_id/cloud_auth
-#xpack.management.elasticsearch.cloud_id: xxxxxxxxxx
+#xpack.management.elasticsearch.cloud_id: management_cluster_id:xxxxxxxxxx
 #xpack.management.elasticsearch.cloud_auth: logstash_admin_user:password
 #xpack.management.elasticsearch.ssl.certificate_authority: [ "/path/to/ca.crt" ]
 #xpack.management.elasticsearch.ssl.truststore.path: /path/to/file

--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -225,7 +225,7 @@
 #xpack.monitoring.elasticsearch.password: password
 #xpack.monitoring.elasticsearch.hosts: ["https://es1:9200", "https://es2:9200"]
 # an alternative to hosts + username/password settings is to use cloud_id/cloud_auth
-#xpack.monitoring.elasticsearch.cloud_id: monitoring:xxxxxxxxxx
+#xpack.monitoring.elasticsearch.cloud_id: xxxxxxxxxx
 #xpack.monitoring.elasticsearch.cloud_auth: logstash_system:password
 #xpack.monitoring.elasticsearch.ssl.certificate_authority: [ "/path/to/ca.crt" ]
 #xpack.monitoring.elasticsearch.ssl.truststore.path: path/to/file
@@ -245,7 +245,7 @@
 #xpack.management.elasticsearch.password: password
 #xpack.management.elasticsearch.hosts: ["https://es1:9200", "https://es2:9200"]
 # an alternative to hosts + username/password settings is to use cloud_id/cloud_auth
-#xpack.management.elasticsearch.cloud_id: management:xxxxxxxxxx
+#xpack.management.elasticsearch.cloud_id: xxxxxxxxxx
 #xpack.management.elasticsearch.cloud_auth: logstash_admin_user:password
 #xpack.management.elasticsearch.ssl.certificate_authority: [ "/path/to/ca.crt" ]
 #xpack.management.elasticsearch.ssl.truststore.path: /path/to/file

--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -224,6 +224,9 @@
 #xpack.monitoring.elasticsearch.username: logstash_system
 #xpack.monitoring.elasticsearch.password: password
 #xpack.monitoring.elasticsearch.hosts: ["https://es1:9200", "https://es2:9200"]
+# an alternative to hosts + username/password settings is to use cloud_id/cloud_auth
+#xpack.monitoring.elasticsearch.cloud_id: monitoring:xxxxxxxxxx
+#xpack.monitoring.elasticsearch.cloud_auth: logstash_system:password
 #xpack.monitoring.elasticsearch.ssl.certificate_authority: [ "/path/to/ca.crt" ]
 #xpack.monitoring.elasticsearch.ssl.truststore.path: path/to/file
 #xpack.monitoring.elasticsearch.ssl.truststore.password: password
@@ -241,6 +244,9 @@
 #xpack.management.elasticsearch.username: logstash_admin_user
 #xpack.management.elasticsearch.password: password
 #xpack.management.elasticsearch.hosts: ["https://es1:9200", "https://es2:9200"]
+# an alternative to hosts + username/password settings is to use cloud_id/cloud_auth
+#xpack.management.elasticsearch.cloud_id: management:xxxxxxxxxx
+#xpack.management.elasticsearch.cloud_auth: logstash_admin_user:password
 #xpack.management.elasticsearch.ssl.certificate_authority: [ "/path/to/ca.crt" ]
 #xpack.management.elasticsearch.ssl.truststore.path: /path/to/file
 #xpack.management.elasticsearch.ssl.truststore.password: password

--- a/docs/static/settings/configuration-management-settings.asciidoc
+++ b/docs/static/settings/configuration-management-settings.asciidoc
@@ -92,5 +92,5 @@ If you're using Elasticsearch cloud, you can set your auth credentials here.
 This is an alternative to having `xpack.management.elasticsearch.username`
 and `xpack.management.elasticsearch.password` - those should not be used if
 `cloud_auth` is configured.
-The username you specify here should have the `logstash_admin` role, which
+The credentials you specify here should be for a user with the `logstash_admin` role, which
 provides access to `.logstash-*` indices for managing configurations.

--- a/docs/static/settings/configuration-management-settings.asciidoc
+++ b/docs/static/settings/configuration-management-settings.asciidoc
@@ -83,7 +83,7 @@ Optional setting that provides the password to the keystore.
 
 If you're using Elasticsearch cloud, you should specify the identifier here.
 This is an alternative to specifying `xpack.management.elasticsearch.hosts`,
-if `cloud_id` is set having also a `hosts` configuration makes no sense.
+which should not be used if `cloud_id` is configured.
 This {es} instance will store the Logstash pipeline configurations and metadata.
 
 `xpack.management.elasticsearch.cloud_auth`::

--- a/docs/static/settings/configuration-management-settings.asciidoc
+++ b/docs/static/settings/configuration-management-settings.asciidoc
@@ -82,15 +82,15 @@ Optional setting that provides the password to the keystore.
 `xpack.management.elasticsearch.cloud_id`::
 
 If you're using {es} in {ecloud}, you should specify the identifier here.
-This is an alternative to specifying `xpack.management.elasticsearch.hosts`,
-which should not be used if `cloud_id` is configured.
+This setting is an alternative to `xpack.management.elasticsearch.hosts`.
+If `cloud_id` is configured, `xpack.management.elasticsearch.hosts` should not be used.
 This {es} instance will store the Logstash pipeline configurations and metadata.
 
 `xpack.management.elasticsearch.cloud_auth`::
 
 If you're using {es} in {ecloud}, you can set your auth credentials here.
-This is an alternative to having `xpack.management.elasticsearch.username`
-and `xpack.management.elasticsearch.password` - those should not be used if
-`cloud_auth` is configured.
+This setting is an alternative to both `xpack.management.elasticsearch.username`
+and `xpack.management.elasticsearch.password`. If `cloud_auth` is configured,
+those settings should not be used.
 The credentials you specify here should be for a user with the `logstash_admin` role, which
 provides access to `.logstash-*` indices for managing configurations.

--- a/docs/static/settings/configuration-management-settings.asciidoc
+++ b/docs/static/settings/configuration-management-settings.asciidoc
@@ -52,9 +52,9 @@ section in your Logstash configuration, or a different one. Defaults to
 
 If your {es} cluster is protected with basic authentication, these settings
 provide the username and password that the Logstash instance uses to
-authenticate for accessing the configuration data. The username you specify here
-should have the `logstash_admin` role, which provides access to `.logstash-*`
-indices for managing configurations. 
+authenticate for accessing the configuration data.
+The username you specify here should have the `logstash_admin` role, which
+provides access to `.logstash-*` indices for managing configurations.
 
 `xpack.management.elasticsearch.ssl.certificate_authority`::
 
@@ -78,3 +78,19 @@ the client’s certificate.
 `xpack.management.elasticsearch.ssl.keystore.password`::
 
 Optional setting that provides the password to the keystore.
+
+`xpack.management.elasticsearch.cloud_id`::
+
+If you're using Elasticsearch cloud, you should specify the identifier here.
+This is an alternative to specifying `xpack.management.elasticsearch.hosts`,
+if `cloud_id` is set having also a `hosts` configuration makes no sense.
+This {es} instance will store the Logstash pipeline configurations and metadata.
+
+`xpack.management.elasticsearch.cloud_auth`::
+
+If you're using Elasticsearch cloud, you can set your auth credentials here.
+This is an alternative to having `xpack.management.elasticsearch.username`
+and `xpack.management.elasticsearch.password` - those should not be used if
+`cloud_auth` is configured.
+The username you specify here should have the `logstash_admin` role, which
+provides access to `.logstash-*` indices for managing configurations.

--- a/docs/static/settings/configuration-management-settings.asciidoc
+++ b/docs/static/settings/configuration-management-settings.asciidoc
@@ -81,14 +81,14 @@ Optional setting that provides the password to the keystore.
 
 `xpack.management.elasticsearch.cloud_id`::
 
-If you're using Elasticsearch cloud, you should specify the identifier here.
+If you're using {es} in {ecloud}, you should specify the identifier here.
 This is an alternative to specifying `xpack.management.elasticsearch.hosts`,
 which should not be used if `cloud_id` is configured.
 This {es} instance will store the Logstash pipeline configurations and metadata.
 
 `xpack.management.elasticsearch.cloud_auth`::
 
-If you're using Elasticsearch cloud, you can set your auth credentials here.
+If you're using {es} in {ecloud}, you can set your auth credentials here.
 This is an alternative to having `xpack.management.elasticsearch.username`
 and `xpack.management.elasticsearch.password` - those should not be used if
 `cloud_auth` is configured.

--- a/docs/static/settings/monitoring-settings.asciidoc
+++ b/docs/static/settings/monitoring-settings.asciidoc
@@ -88,7 +88,7 @@ Optional settings that provide the password to the keystore.
 
 If you're using Elasticsearch cloud, you should specify the identifier here.
 This is an alternative to specifying `xpack.monitoring.elasticsearch.hosts`,
-if `cloud_id` is set having also a `hosts` configuration makes no sense.
+which should not be used if `cloud_id` is configured.
 The {es} instances that you want to ship your Logstash metrics to. This might be
 the same {es} instance specified in the `outputs` section in your Logstash
 configuration, or a different one.

--- a/docs/static/settings/monitoring-settings.asciidoc
+++ b/docs/static/settings/monitoring-settings.asciidoc
@@ -86,7 +86,7 @@ Optional settings that provide the password to the keystore.
 
 `xpack.monitoring.elasticsearch.cloud_id`::
 
-If you're using Elasticsearch cloud, you should specify the identifier here.
+If you're using {es} in {ecloud}, you should specify the identifier here.
 This is an alternative to specifying `xpack.monitoring.elasticsearch.hosts`,
 which should not be used if `cloud_id` is configured.
 The {es} instances that you want to ship your Logstash metrics to. This might be
@@ -95,7 +95,7 @@ configuration, or a different one.
 
 `xpack.monitoring.elasticsearch.cloud_auth`::
 
-If you're using Elasticsearch cloud, you can set your auth credentials here.
+If you're using {es} in {ecloud}, you can set your auth credentials here.
 This is an alternative to having `xpack.monitoring.elasticsearch.username`
 and `xpack.monitoring.elasticsearch.password` - those should not be used if
 `cloud_auth` is configured.

--- a/docs/static/settings/monitoring-settings.asciidoc
+++ b/docs/static/settings/monitoring-settings.asciidoc
@@ -87,8 +87,8 @@ Optional settings that provide the password to the keystore.
 `xpack.monitoring.elasticsearch.cloud_id`::
 
 If you're using {es} in {ecloud}, you should specify the identifier here.
-This is an alternative to specifying `xpack.monitoring.elasticsearch.hosts`,
-which should not be used if `cloud_id` is configured.
+This setting is an alternative to `xpack.monitoring.elasticsearch.hosts`.
+If `cloud_id` is configured, `xpack.monitoring.elasticsearch.hosts` should not be used.
 The {es} instances that you want to ship your Logstash metrics to. This might be
 the same {es} instance specified in the `outputs` section in your Logstash
 configuration, or a different one.
@@ -96,6 +96,6 @@ configuration, or a different one.
 `xpack.monitoring.elasticsearch.cloud_auth`::
 
 If you're using {es} in {ecloud}, you can set your auth credentials here.
-This is an alternative to having `xpack.monitoring.elasticsearch.username`
-and `xpack.monitoring.elasticsearch.password` - those should not be used if
-`cloud_auth` is configured.
+This setting is an alternative to both `xpack.monitoring.elasticsearch.username`
+and `xpack.monitoring.elasticsearch.password`. If `cloud_auth` is configured,
+those settings should not be used.

--- a/docs/static/settings/monitoring-settings.asciidoc
+++ b/docs/static/settings/monitoring-settings.asciidoc
@@ -80,3 +80,22 @@ the client’s certificate.
 `xpack.monitoring.elasticsearch.ssl.keystore.password`::
 
 Optional settings that provide the password to the keystore.
+
+[[monitoring-additional-settings]]
+===== Additional settings
+
+`xpack.monitoring.elasticsearch.cloud_id`::
+
+If you're using Elasticsearch cloud, you should specify the identifier here.
+This is an alternative to specifying `xpack.monitoring.elasticsearch.hosts`,
+if `cloud_id` is set having also a `hosts` configuration makes no sense.
+The {es} instances that you want to ship your Logstash metrics to. This might be
+the same {es} instance specified in the `outputs` section in your Logstash
+configuration, or a different one.
+
+`xpack.monitoring.elasticsearch.cloud_auth`::
+
+If you're using Elasticsearch cloud, you can set your auth credentials here.
+This is an alternative to having `xpack.monitoring.elasticsearch.username`
+and `xpack.monitoring.elasticsearch.password` - those should not be used if
+`cloud_auth` is configured.

--- a/x-pack/lib/config_management/elasticsearch_source.rb
+++ b/x-pack/lib/config_management/elasticsearch_source.rb
@@ -38,7 +38,8 @@ module LogStash
         if @settings.get("xpack.management.enabled")
           if @settings.get_setting("xpack.management.elasticsearch.cloud_id").set?
             if !@settings.get_setting("xpack.management.elasticsearch.cloud_auth").set?
-              raise ArgumentError.new("You must set credentials using \"xpack.management.elasticsearch.cloud_auth\" in logstash.yml")
+              raise ArgumentError.new("You must set credentials using \"xpack.management.elasticsearch.cloud_auth\", " +
+                                      "when using \"xpack.management.elasticsearch.cloud_id\" in logstash.yml")
             end
           else
             if !@settings.get_setting("xpack.management.elasticsearch.password").set?

--- a/x-pack/lib/config_management/elasticsearch_source.rb
+++ b/x-pack/lib/config_management/elasticsearch_source.rb
@@ -35,8 +35,16 @@ module LogStash
 
       def initialize(settings)
         super(settings)
-        if @settings.get("xpack.management.enabled") && !@settings.get_setting("xpack.management.elasticsearch.password").set?
-          raise ArgumentError.new("You must set the password using the \"xpack.management.elasticsearch.password\" in logstash.yml")
+        if @settings.get("xpack.management.enabled")
+          if @settings.get_setting("xpack.management.elasticsearch.cloud_id").set?
+            if !@settings.get_setting("xpack.management.elasticsearch.cloud_auth").set?
+              raise ArgumentError.new("You must set credentials using \"xpack.management.elasticsearch.cloud_auth\" in logstash.yml")
+            end
+          else
+            if !@settings.get_setting("xpack.management.elasticsearch.password").set?
+              raise ArgumentError.new("You must set the password using \"xpack.management.elasticsearch.password\" in logstash.yml")
+            end
+          end
         end
 
         @es_options = es_options_from_settings('management', settings)

--- a/x-pack/lib/config_management/extension.rb
+++ b/x-pack/lib/config_management/extension.rb
@@ -6,6 +6,7 @@ require "logstash/environment"
 require "config_management/hooks"
 require "config_management/elasticsearch_source"
 require "config_management/bootstrap_check"
+require 'helpers/elasticsearch_options'
 
 module LogStash
   module ConfigManagement
@@ -21,12 +22,14 @@ module LogStash
         require "logstash/runner"
         logger.trace("Registering additionals settings")
 
+        default_host = LogStash::Helpers::ElasticsearchOptions::DEFAULT_HOST
+
         settings.register(LogStash::Setting::Boolean.new("xpack.management.enabled", false))
         settings.register(LogStash::Setting::TimeValue.new("xpack.management.logstash.poll_interval", "5s"))
         settings.register(LogStash::Setting::ArrayCoercible.new("xpack.management.pipeline.id", String, ["main"]))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.username", "logstash_system"))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.password"))
-        settings.register(LogStash::Setting::ArrayCoercible.new("xpack.management.elasticsearch.hosts", String, [ "https://localhost:9200" ] ))
+        settings.register(LogStash::Setting::ArrayCoercible.new("xpack.management.elasticsearch.hosts", String, [ default_host ] ))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.cloud_id"))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.cloud_auth"))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.ssl.certificate_authority"))

--- a/x-pack/lib/config_management/extension.rb
+++ b/x-pack/lib/config_management/extension.rb
@@ -6,7 +6,6 @@ require "logstash/environment"
 require "config_management/hooks"
 require "config_management/elasticsearch_source"
 require "config_management/bootstrap_check"
-require 'helpers/elasticsearch_options'
 
 module LogStash
   module ConfigManagement
@@ -22,14 +21,12 @@ module LogStash
         require "logstash/runner"
         logger.trace("Registering additionals settings")
 
-        default_host = LogStash::Helpers::ElasticsearchOptions::DEFAULT_HOST
-
         settings.register(LogStash::Setting::Boolean.new("xpack.management.enabled", false))
         settings.register(LogStash::Setting::TimeValue.new("xpack.management.logstash.poll_interval", "5s"))
         settings.register(LogStash::Setting::ArrayCoercible.new("xpack.management.pipeline.id", String, ["main"]))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.username", "logstash_system"))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.password"))
-        settings.register(LogStash::Setting::ArrayCoercible.new("xpack.management.elasticsearch.hosts", String, [ default_host ] ))
+        settings.register(LogStash::Setting::ArrayCoercible.new("xpack.management.elasticsearch.hosts", String, [ "https://localhost:9200" ] ))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.cloud_id"))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.cloud_auth"))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.ssl.certificate_authority"))

--- a/x-pack/lib/config_management/extension.rb
+++ b/x-pack/lib/config_management/extension.rb
@@ -27,6 +27,8 @@ module LogStash
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.username", "logstash_system"))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.password"))
         settings.register(LogStash::Setting::ArrayCoercible.new("xpack.management.elasticsearch.hosts", String, [ "https://localhost:9200" ] ))
+        settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.cloud_id"))
+        settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.cloud_auth"))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.ssl.certificate_authority"))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.ssl.truststore.path"))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.ssl.truststore.password"))

--- a/x-pack/lib/helpers/elasticsearch_options.rb
+++ b/x-pack/lib/helpers/elasticsearch_options.rb
@@ -7,9 +7,15 @@ module LogStash module Helpers
     extend self
 
     ES_SETTINGS =%w(
-      ssl.certificate_authority ssl.truststore.path ssl.keystore.path
-      hosts username password cloud_id cloud_auth
-    )
+        ssl.certificate_authority
+        ssl.truststore.path
+        ssl.keystore.path
+        hosts
+        username
+        password
+        cloud_id
+        cloud_auth
+      )
 
     # Retrieve elasticsearch options from either specific settings, or modules if the setting is not there and the
     # feature supports falling back to modules if the feature is not specified in logstash.yml

--- a/x-pack/lib/helpers/elasticsearch_options.rb
+++ b/x-pack/lib/helpers/elasticsearch_options.rb
@@ -17,8 +17,6 @@ module LogStash module Helpers
         cloud_auth
       )
 
-    DEFAULT_HOST = 'https://localhost:9200'.freeze
-
     # Retrieve elasticsearch options from either specific settings, or modules if the setting is not there and the
     # feature supports falling back to modules if the feature is not specified in logstash.yml
     def es_options_from_settings_or_modules(feature, settings)
@@ -30,8 +28,6 @@ module LogStash module Helpers
     def es_options_from_settings(feature, settings)
       opts = {}
 
-      # NOTE: both management and monitoring register hosts with a "localhost:9200" default,
-      # ES output does not allow both to be configured thus only fill hosts when cloud_id not set
       if cloud_id = settings.get("xpack.#{feature}.elasticsearch.cloud_id")
         opts['cloud_id'] = cloud_id
         check_cloud_id_configuration!(feature, settings)

--- a/x-pack/lib/monitoring/monitoring.rb
+++ b/x-pack/lib/monitoring/monitoring.rb
@@ -179,8 +179,10 @@ module LogStash
     def additionals_settings(settings)
       logger.trace("registering additionals_settings")
 
+      default_host = LogStash::Helpers::ElasticsearchOptions::DEFAULT_HOST
+
       settings.register(LogStash::Setting::Boolean.new("xpack.monitoring.enabled", false))
-      settings.register(LogStash::Setting::ArrayCoercible.new("xpack.monitoring.elasticsearch.hosts", String, [ "http://localhost:9200" ] ))
+      settings.register(LogStash::Setting::ArrayCoercible.new("xpack.monitoring.elasticsearch.hosts", String, [ default_host ] ))
       settings.register(LogStash::Setting::TimeValue.new("xpack.monitoring.collection.interval", "10s"))
       settings.register(LogStash::Setting::TimeValue.new("xpack.monitoring.collection.timeout_interval", "10m"))
       settings.register(LogStash::Setting::NullableString.new("xpack.monitoring.elasticsearch.username", "logstash_system"))

--- a/x-pack/lib/monitoring/monitoring.rb
+++ b/x-pack/lib/monitoring/monitoring.rb
@@ -179,10 +179,8 @@ module LogStash
     def additionals_settings(settings)
       logger.trace("registering additionals_settings")
 
-      default_host = LogStash::Helpers::ElasticsearchOptions::DEFAULT_HOST
-
       settings.register(LogStash::Setting::Boolean.new("xpack.monitoring.enabled", false))
-      settings.register(LogStash::Setting::ArrayCoercible.new("xpack.monitoring.elasticsearch.hosts", String, [ default_host ] ))
+      settings.register(LogStash::Setting::ArrayCoercible.new("xpack.monitoring.elasticsearch.hosts", String, [ "http://localhost:9200" ] ))
       settings.register(LogStash::Setting::TimeValue.new("xpack.monitoring.collection.interval", "10s"))
       settings.register(LogStash::Setting::TimeValue.new("xpack.monitoring.collection.timeout_interval", "10m"))
       settings.register(LogStash::Setting::NullableString.new("xpack.monitoring.elasticsearch.username", "logstash_system"))

--- a/x-pack/lib/template.cfg.erb
+++ b/x-pack/lib/template.cfg.erb
@@ -12,13 +12,20 @@ input {
 }
 output {
   elasticsearch {
+  <% if cloud_id? %>
+    cloud_id => "<%= cloud_id %>"
+    <% if cloud_auth %>
+    cloud_auth => "<%= cloud_auth %>"
+    <% end %>
+  <% else %>
     hosts => <%= es_hosts %>
+  <% end %>
     bulk_path => "/_monitoring/bulk?system_id=logstash&system_api_version=<%= system_api_version %>&interval=1s"
     manage_template => false
     document_type => "%{[@metadata][document_type]}"
     index => ""
     sniffing => <%= sniffing %>
-  <% if auth? %>
+  <% if auth? && !cloud_auth? %>
     user => "<%= user %>"
     password => "<%= password %>"
   <% end %>

--- a/x-pack/spec/config_management/extension_spec.rb
+++ b/x-pack/spec/config_management/extension_spec.rb
@@ -41,6 +41,16 @@ describe LogStash::ConfigManagement::Extension do
         "xpack.management.elasticsearch.ssl.keystore.password" => [LogStash::Setting::NullableString, nil]
       )
 
+      it "has a cloud_id setting" do
+        name = "xpack.management.elasticsearch.cloud_id"
+        expect { settings.get_setting(name) }.not_to raise_error
+      end
+
+      it "has a cloud_auth setting" do
+        name = "xpack.management.elasticsearch.cloud_auth"
+        expect { settings.get_setting(name) }.not_to raise_error
+      end
+
       describe 'deprecated and renamed settings' do
         define_deprecated_and_renamed_settings(
             "xpack.management.elasticsearch.url"    => "xpack.management.elasticsearch.hosts",

--- a/x-pack/spec/helpers/elasticsearch_options_spec.rb
+++ b/x-pack/spec/helpers/elasticsearch_options_spec.rb
@@ -132,6 +132,32 @@ describe LogStash::Helpers::ElasticsearchOptions do
         expect(es_options.keys).to_not include("username")
         expect(es_options.keys).to_not include("password")
       end
+
+      context 'hosts also set' do
+        let(:settings) do
+          super.merge(
+              "xpack.monitoring.elasticsearch.hosts" => 'https://localhost:9200'
+          )
+        end
+
+        it "raises due invalid configuration" do
+          expect { test_class.es_options_from_settings_or_modules('monitoring', system_settings) }.
+              to raise_error(ArgumentError, /Both.*?cloud_id.*?and.*?hosts.*?specified/)
+        end
+      end
+
+      context 'username also set' do
+        let(:settings) do
+          super.merge(
+              "xpack.monitoring.elasticsearch.username" => 'elastic'
+          )
+        end
+
+        it "raises due invalid configuration" do
+          expect { test_class.es_options_from_settings_or_modules('monitoring', system_settings) }.
+              to raise_error(ArgumentError, /Both.*?cloud_auth.*?and.*?username.*?specified/)
+        end
+      end
     end
   end
 

--- a/x-pack/spec/helpers/elasticsearch_options_spec.rb
+++ b/x-pack/spec/helpers/elasticsearch_options_spec.rb
@@ -15,7 +15,6 @@ shared_examples "elasticsearch options hash is populated without security" do
                                                                                                    "user" => expected_username,
                                                                                                    "password" => expected_password
                                                                                                )
-
   end
 end
 
@@ -109,6 +108,31 @@ describe LogStash::Helpers::ElasticsearchOptions do
 
     it_behaves_like 'elasticsearch options hash is populated without security'
     it_behaves_like 'elasticsearch options hash is populated with secure options'
+
+    context 'when cloud id and auth are set' do
+      let(:cloud_name) { 'thebigone'}
+      let(:cloud_domain) { 'elastic.co'}
+      let(:cloud_id) { "monitoring:#{Base64.urlsafe_encode64("#{cloud_domain}$#{cloud_name}$ignored")}" }
+      let(:cloud_username) { 'elastic' }
+      let(:cloud_password) { 'passw0rd'}
+      let(:cloud_auth) { "#{cloud_username}:#{cloud_password}" }
+      let(:expected_url) { ["https://#{cloud_name}.#{cloud_domain}:443"] }
+      let(:settings) do
+        {
+            "xpack.monitoring.enabled" => true,
+            "xpack.monitoring.elasticsearch.cloud_id" => cloud_id,
+            "xpack.monitoring.elasticsearch.cloud_auth" => cloud_auth,
+        }
+      end
+
+      it "creates the elasticsearch output options hash" do
+        es_options = test_class.es_options_from_settings_or_modules('monitoring', system_settings)
+        expect(es_options).to include("cloud_id" => cloud_id, "cloud_auth" => cloud_auth)
+        expect(es_options.keys).to_not include("hosts")
+        expect(es_options.keys).to_not include("username")
+        expect(es_options.keys).to_not include("password")
+      end
+    end
   end
 
   describe 'es_options_from_settings_or_modules' do


### PR DESCRIPTION
depends on recent ES output plugin (https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/906)

resolves https://github.com/elastic/logstash/issues/11488