### PR TITLE
Expose input source metadata trhough http api

### DIFF
--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricKeys.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricKeys.java
@@ -13,6 +13,14 @@ public final class MetricKeys {
 
     public static final RubySymbol NAME_KEY = RubyUtil.RUBY.newSymbol("name");
 
+    public static final RubySymbol CONFIG_REF_KEY = RubyUtil.RUBY.newSymbol("config-ref");
+
+    public static final RubySymbol CONFIG_SOURCE_KEY = RubyUtil.RUBY.newSymbol("source");
+
+    public static final RubySymbol CONFIG_LINE_KEY = RubyUtil.RUBY.newSymbol("line");
+
+    public static final RubySymbol CONFIG_COLUMN_KEY = RubyUtil.RUBY.newSymbol("column");
+
     public static final RubySymbol EVENTS_KEY = RubyUtil.RUBY.newSymbol("events");
 
     public static final RubySymbol OUT_KEY = RubyUtil.RUBY.newSymbol("out");

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
@@ -236,6 +236,7 @@ public final class PluginFactoryExt {
                     final IRubyObject pluginInstance = klass.callMethod(context, "new", rubyArgs);
                     final AbstractNamespacedMetricExt scopedMetric = typeScopedMetric.namespace(context, RubyUtil.RUBY.newSymbol(id));
                     scopedMetric.gauge(context, MetricKeys.NAME_KEY, pluginInstance.callMethod(context, "config_name"));
+                    initConfigMetrics(context, source, scopedMetric);
                     pluginInstance.callMethod(context, "metric=", scopedMetric);
                     pluginInstance.callMethod(context, "execution_context=", executionCntx);
                     return pluginInstance;
@@ -338,6 +339,14 @@ public final class PluginFactoryExt {
                 }
             }
         }
+    }
+
+    private static void initConfigMetrics(ThreadContext context, SourceWithMetadata source,
+                                          AbstractNamespacedMetricExt scopedMetric) {
+        AbstractNamespacedMetricExt metricConfigReference = scopedMetric.namespace(context, MetricKeys.CONFIG_REF_KEY);
+        metricConfigReference.gauge(context, MetricKeys.CONFIG_SOURCE_KEY, RubyUtil.RUBY.newString(source.getId()));
+        metricConfigReference.gauge(context, MetricKeys.CONFIG_LINE_KEY, RubyUtil.RUBY.newFixnum(source.getLine()));
+        metricConfigReference.gauge(context, MetricKeys.CONFIG_COLUMN_KEY, RubyUtil.RUBY.newFixnum(source.getColumn()));
     }
 
     @JRubyClass(name = "ExecutionContextFactory")

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginFactoryExt.java
@@ -310,7 +310,8 @@ public final class PluginFactoryExt {
                     }
 
                     if (input != null) {
-                        return JavaInputDelegatorExt.create((JavaBasePipelineExt) executionContext.pipeline, typeScopedMetric, input, pluginArgs);
+                        return JavaInputDelegatorExt.create((JavaBasePipelineExt) executionContext.pipeline,
+                                typeScopedMetric, input, pluginArgs, source);
                     } else {
                         throw new IllegalStateException("Unable to instantiate input: " + pluginClass);
                     }
@@ -323,7 +324,7 @@ public final class PluginFactoryExt {
                             final Context pluginContext = executionContext.toContext(type, metrics.getRoot(context));
                             final Codec codec = ctor.newInstance(config, pluginContext);
                             PluginUtil.validateConfig(codec, config);
-                            return JavaUtil.convertJavaToRuby(RubyUtil.RUBY, new JavaCodecDelegator(pluginContext, codec));
+                            return JavaUtil.convertJavaToRuby(RubyUtil.RUBY, new JavaCodecDelegator(pluginContext, codec, source));
                         } catch (NoSuchMethodException | IllegalAccessException | InstantiationException | InvocationTargetException ex) {
                             if (ex instanceof InvocationTargetException && ex.getCause() != null) {
                                 throw new IllegalStateException((ex).getCause());

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/JavaCodecDelegatorTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/JavaCodecDelegatorTest.java
@@ -2,7 +2,6 @@ package org.logstash.config.ir.compiler;
 
 import co.elastic.logstash.api.Codec;
 import co.elastic.logstash.api.Event;
-import co.elastic.logstash.api.Metric;
 import co.elastic.logstash.api.PluginConfigSpec;
 import com.google.common.collect.ImmutableMap;
 import org.jruby.RubyHash;
@@ -198,7 +197,7 @@ public class JavaCodecDelegatorTest extends MetricTestCase {
     }
 
     private JavaCodecDelegator constructCodecDelegator() {
-        return new JavaCodecDelegator(new ContextImpl(null, this.getInstance()), codec);
+        return new JavaCodecDelegator(new ContextImpl(null, this.getInstance()), codec, null);
     }
 
     private abstract class AbstractCodec implements Codec {

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -160,9 +160,6 @@ describe "Test Monitoring API" do
       inputs_stats = result.fetch("plugins").fetch("inputs")[0]
       config_ref = inputs_stats.fetch("config-ref")
       expect_source_reference(config_ref, "config_string", 1, 8)
-#       expect(config_ref.fetch("source")).to eq("config_string")
-#       expect(config_ref.fetch("line")).to eq(1)
-#       expect(config_ref.fetch("column")).to eq(8)
     end
   end
 
@@ -253,7 +250,6 @@ describe "Test Monitoring API" do
   end
 
   def expect_source_reference_file(config_ref, filename, line, column)
-#     expect(config_ref.fetch("source")).to match("\/tmp\/logstash-splitted-pipeline-config-test.*\/#{filename}")
     expect(config_ref.fetch("source")).to match(".*#{filename}")
     expect(config_ref.fetch("line")).to eq(line)
     expect(config_ref.fetch("column")).to eq(column)


### PR DESCRIPTION
This pull request exposes the input and codec plugin source reference through the http stats pipeline.
It leverages on the source with metadata linked to each plugin definition, works with Ruby and Java pipelines and with Ruby and Java plugins.

To test it you cold use the cURL and verify that input and codec sections has sub-part with source file, line and column reference:
```
curl -X GET 'localhost:9600/_node/stats/pipelines?pretty' 
```

In attachment you can find 2 folders with simple LS pipeline definitions
[pipeline_splitted_javaplugins.zip](https://github.com/elastic/logstash/files/4059266/pipeline_splitted_javaplugins.zip)
[pipeline_splitted_rubyplugins.zip](https://github.com/elastic/logstash/files/4059267/pipeline_splitted_rubyplugins.zip)

For Ruby plugins:
`bin/logstash -f "pipeline_splitted_rubyplugins/" --java-execution=false|true`

For Java plugins:
`bin/logstash -f "pipeline_splitted_javaplugins/" --java-execution=true`
