### PR TITLE
JEE: remove global compiler lock

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/ComputeStepSyntaxElement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/ComputeStepSyntaxElement.java
@@ -30,8 +30,6 @@ public final class ComputeStepSyntaxElement<T extends Dataset> {
 
     private static final Path SOURCE_DIR = debugDir();
 
-    private static final ISimpleCompiler COMPILER = new SimpleCompiler();
-
     /**
      * Sequential counter to generate the class name
      */
@@ -76,29 +74,25 @@ public final class ComputeStepSyntaxElement<T extends Dataset> {
 
     @SuppressWarnings("unchecked")
     public Class<? extends Dataset> compile() {
-        // We need to globally synchronize to avoid concurrency issues with the internal class loader
-        // Per https://github.com/elastic/logstash/pull/11482 we should review this lock. 
-        synchronized (COMPILER) {
-            try {
-                final Class<? extends Dataset> clazz;
-                final String name = String.format("CompiledDataset%d", classSeq);
-                final String code = generateCode(name);
-                if (SOURCE_DIR != null) {
-                    final Path sourceFile = SOURCE_DIR.resolve(String.format("%s.java", name));
-                    Files.write(sourceFile, code.getBytes(StandardCharsets.UTF_8));
-                    COMPILER.cookFile(sourceFile.toFile());
-                } else {
-                    COMPILER.cook(code);
-                }
-                COMPILER.setParentClassLoader(COMPILER.getClassLoader());
-                clazz = (Class<? extends Dataset>)COMPILER.getClassLoader().loadClass(
-                        String.format("org.logstash.generated.%s", name)
-                );
-
-                return clazz;
-            } catch (final CompileException | ClassNotFoundException | IOException ex) {
-                throw new IllegalStateException(ex);
+        try {
+            final Class<? extends Dataset> clazz;
+            final String name = String.format("CompiledDataset%d", classSeq);
+            final String code = generateCode(name);
+            final ISimpleCompiler compiler = new SimpleCompiler();
+            if (SOURCE_DIR != null) {
+                final Path sourceFile = SOURCE_DIR.resolve(String.format("%s.java", name));
+                Files.write(sourceFile, code.getBytes(StandardCharsets.UTF_8));
+                compiler.cookFile(sourceFile.toFile());
+            } else {
+                compiler.cook(code);
             }
+            clazz = (Class<? extends Dataset>)compiler.getClassLoader().loadClass(
+                    String.format("org.logstash.generated.%s", name)
+            );
+
+            return clazz;
+        } catch (final CompileException | ClassNotFoundException | IOException ex) {
+            throw new IllegalStateException(ex);
         }
     }
 


### PR DESCRIPTION
Because our source files for java pipeline execution are independent of each
other, we do not need to share a single instance of `SimpleCompiler` nor chain
our `ClassLoader`s sequentially with `ISimpleCompiler#setParentClassLoader`.

Discovered while reviewing https://github.com/elastic/logstash/pull/11482

Additionally, I think this gives us the benefit of not having indefinitely chained classloaders, meaning pipelines that have been stopped _may_ be able to reclaim more of their memory once their classes are dereferenced.

A middle-ground implementation allowing us to continue the hacked reuse of `SimpleCompiler` would be to have a `static final ThreadLocal<ISimpleCompiler> COMPILER = ThreadLocal.withInitial(SimpleCompiler::new)`, which would ensure that we don't interleave calls to `ISimpleCompiler#cook` and `ISimpleCompiler#getClassLoader`.