### PR TITLE
Added deprecation notice when internal monitoring collector is used.

### DIFF
--- a/x-pack/lib/monitoring/monitoring.rb
+++ b/x-pack/lib/monitoring/monitoring.rb
@@ -104,6 +104,12 @@ module LogStash
 
         return unless monitoring_enabled?(runner.settings)
 
+        deprecation_logger.deprecated(
+            "Internal collectors option for Logstash monitoring is deprecated and targeted for removal in the next major version.\n"\
+            "Please configure Metricbeat to monitor Logstash. Documentation can be found at: \n"\
+            "https://www.elastic.co/guide/en/logstash/current/monitoring-with-metricbeat.html"
+            )
+
         logger.trace("registering the metrics pipeline")
         LogStash::SETTINGS.set("node.uuid", runner.agent.id)
         internal_pipeline_source = LogStash::Monitoring::InternalPipelineSource.new(setup_metrics_pipeline, runner.agent)


### PR DESCRIPTION
This PR simply use deprecation logger to write a warn message once the internal monitoring collector is used, because it's going do be removed in version 8.
Solves  #11346

NB must be included in LS [7.7..8)