### PR TITLE
pin google-java-format back to 1.1 for licensing reasons

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -147,9 +147,10 @@ dependencies {
         compile files(customJRubyDir + "/maven/jruby-complete/target/jruby-complete-${customJRubyVersion}.jar")
     }
     compile group: 'com.google.guava', name: 'guava', version: '22.0'
-    // Do not upgrade this, later versions require GPL licensed code in javac-shaded that is
+    // WARNING: DO NOT UPGRADE "google-java-format"
+    // later versions require GPL licensed code in javac-shaded that is
     // Apache2 incompatible
-    compile('com.google.googlejavaformat:google-java-format:1.7') {
+    compile('com.google.googlejavaformat:google-java-format:1.1') {
         exclude group: 'com.google.guava', module: 'guava'
     }
     compile 'org.javassist:javassist:3.26.0-GA'


### PR DESCRIPTION
as mentioned in the code comment section:

```
    // WARNING: DO NOT UPGRADE "google-java-format"
    // later versions require GPL licensed code in javac-shaded that is
    // Apache2 incompatible
```

This PR revers the upgrade to a version that does not bring in GPLv2 code, namely https://mvnrepository.com/artifact/com.google.errorprone/javac-shaded