### PR TITLE
[Doc] Force reload doesn't work in WinOS

### DIFF
--- a/docs/static/reloading-config.asciidoc
+++ b/docs/static/reloading-config.asciidoc
@@ -21,7 +21,7 @@ checks the config files for changes (in seconds).
 
 If Logstash is already running without auto-reload enabled, you can force Logstash to
 reload the config file and restart the pipeline by sending a SIGHUP (signal hangup) to the
-process running Logstash. For example:
+process running Logstash, but it's not supported on Windows OS. For example:
 
 [source,shell]
 ----------------------------------


### PR DESCRIPTION
In issue #5230 a user correctly spotted that the force reload with SIGHUP doens't works on Windows OS.
Added clarification in the documentation.