### PR TITLE
Add configuration parameter webserver_disabled

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -215,6 +215,10 @@
 # Flag to output log lines of each pipeline in its separate log file. Each log filename contains the pipeline.name
 # Default is false
 # pipeline.separate_logs: false
+
+# Flag to disable the webserver
+# Default is false
+# webserver.disabled: false
 #
 # ------------ X-Pack Settings (not applicable for OSS build)--------------
 #

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -96,7 +96,7 @@ class LogStash::Agent
 
     converge_state_and_update
 
-    start_webserver
+    start_webserver_if
 
     if auto_reload?
       # `sleep_then_run` instead of firing the interval right away
@@ -368,6 +368,19 @@ class LogStash::Agent
     end
   end
 
+  # Start the webserver, only if parameter 'webserver.disabled' is set to false (default value)
+  def start_webserver_if
+    if webserver_disabled == false
+      start_webserver
+    else
+      @logger.info("Disabled webserver via parameter 'webserver.disabled' in 'logstash.yml' configuration file")
+    end
+  end
+
+  def webserver_disabled
+    return @settings.get_setting("webserver.disabled").value
+  end
+
   def start_webserver
     @webserver_control_lock.synchronize do
       options = {:http_host => @http_host, :http_ports => @http_port, :http_environment => @http_environment }
@@ -378,6 +391,7 @@ class LogStash::Agent
       end
     end
   end
+
 
   def stop_webserver
     @webserver_control_lock.synchronize do

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -71,7 +71,8 @@ module LogStash
             Setting::TimeValue.new("slowlog.threshold.debug", "-1"),
             Setting::TimeValue.new("slowlog.threshold.trace", "-1"),
             Setting::String.new("keystore.classname", "org.logstash.secret.store.backend.JavaKeyStore"),
-            Setting::String.new("keystore.file", ::File.join(::File.join(LogStash::Environment::LOGSTASH_HOME, "config"), "logstash.keystore"), false) # will be populated on
+            Setting::String.new("keystore.file", ::File.join(::File.join(LogStash::Environment::LOGSTASH_HOME, "config"), "logstash.keystore"), false), # will be populated on
+            Setting::Boolean.new("webserver.disabled", false)
   # post_process
   ].each {|setting| SETTINGS.register(setting) }
 


### PR DESCRIPTION
Hello, 

I asked a couple of questions in [the issue 9408](https://github.com/elastic/logstash/issues/9408), that I can repeat here maybe:

1. Can you clarify  or give some examples for this use case ? I guess that we don't want to start a webserver for simple file manipulation for instance, or local transformations.
2. I only tested at first 'manually' the config option with the following test cases: no entry in logstash.yml, the entry set to _true_ and the entry set to _false_. Next step is to add them into the test suite, I didn't do it right away because I should investigate first how to assert that a webserver is launched.
3. Is the configuration entry at the right place in _logstash.yml_ ? It's currently in _Other Settings_ section, I didn't see anything better, or we can create a new section.
4. Are there manual, tutorials, release notes somewhere to update with this new configuration parameter ?

Cheers