### PR TITLE
:logstash-core module Gradle utils

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -90,6 +90,19 @@ task rubyTests(type: Test) {
     include '/org/logstash/plugins/CounterMetricImplTest.class'
 }
 
+task singleRubyTest(type: Test) {
+    if (!project.hasProperty("rubySingleSpec")) {
+        throw new GradleException('-PrubySingleSpec MUST be passed, example ./gradlew singleRubyTest ' +
+                '-PrubySingleSpec=logstash-core/spec/logstash/api/commands/default_metadata_spec.rb')
+    }
+    def rubySingleSpec = ((String) project.property("rubySingleSpec")).split(/\s+/).join(",")
+    systemProperty 'org.logstash.single.specs', rubySingleSpec
+    systemProperty 'logstash.core.root.dir', projectDir.absolutePath
+    inputs.files fileTree("${projectDir}/lib")
+    inputs.files fileTree("${projectDir}/spec")
+    include '/org/logstash/RSpecSingleTests.class'
+}
+
 test {
     exclude '/**'
 }

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -91,16 +91,19 @@ task rubyTests(type: Test) {
 }
 
 task singleRubyTest(type: Test) {
-    if (!project.hasProperty("rubySingleSpec")) {
-        throw new GradleException('-PrubySingleSpec MUST be passed, example ./gradlew singleRubyTest ' +
-                '-PrubySingleSpec=logstash-core/spec/logstash/api/commands/default_metadata_spec.rb')
-    }
     def rubySingleSpec = ((String) project.property("rubySingleSpec")).split(/\s+/).join(",")
     systemProperty 'org.logstash.single.specs', rubySingleSpec
     systemProperty 'logstash.core.root.dir', projectDir.absolutePath
     inputs.files fileTree("${projectDir}/lib")
     inputs.files fileTree("${projectDir}/spec")
     include '/org/logstash/RSpecSingleTests.class'
+
+    doFirst {
+        if (!project.hasProperty("rubySingleSpec")) {
+            throw new GradleException('-PrubySingleSpec MUST be passed, example ./gradlew singleRubyTest ' +
+                    '-PrubySingleSpec=logstash-core/spec/logstash/api/commands/default_metadata_spec.rb')
+        }
+    }
 }
 
 test {

--- a/logstash-core/src/test/java/org/logstash/RSpecSingleTests.java
+++ b/logstash-core/src/test/java/org/logstash/RSpecSingleTests.java
@@ -1,0 +1,39 @@
+package org.logstash;
+
+import org.jruby.runtime.builtin.IRubyObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+/**
+ * Runs a single Logstash RSpec suit.
+ */
+public final class RSpecSingleTests {
+
+    @Test
+    public void rspecTests() throws Exception {
+        final String root = org.assertj.core.util.Files.currentFolder().getParent();
+        RubyUtil.RUBY.getENV().put("IS_JUNIT_RUN", "true");
+        RubyUtil.RUBY.setCurrentDirectory(root);
+        RubyUtil.RUBY.getGlobalVariables().set(
+                "$JUNIT_ARGV", Rubyfier.deep(RubyUtil.RUBY, Arrays.asList(
+                        "-fd", "--pattern", System.getProperty("org.logstash.single.specs")
+                ))
+        );
+        System.out.println("Running test (org.logstash.single.specs): " + System.getProperty("org.logstash.single.specs") + "\n from root: " + root);
+        final Path rspec = Paths.get(root, "lib/bootstrap/rspec.rb");
+//        final Path rspec = Paths.get("rspec.rb");
+        final IRubyObject result = RubyUtil.RUBY.executeScript(
+                new String(Files.readAllBytes(rspec), StandardCharsets.UTF_8),
+                rspec.toFile().getAbsolutePath()
+        );
+        if (!result.toJava(Long.class).equals(0L)) {
+            Assert.fail("RSpec test suit saw at least one failure.");
+        }
+    }
+}


### PR DESCRIPTION
Sometimes it's a need to run a single spec test with Gradle task `rubyTests`.
This PR adds the `singleRubyTest` Gradle task to module `:logstash-core` that accepts a Gradle's property selecting the spec to execute.

Example:
```
./gradlew :logstash-core:singleRubyTest \
 -PrubySingleSpec=logstash-core/spec/logstash/api/commands/default_metadata_spec.rb
```