### PR TITLE
[Doc] Added section for `monitoring.cluster_uuid`

### DIFF
--- a/docs/static/monitoring/monitoring-mb.asciidoc
+++ b/docs/static/monitoring/monitoring-mb.asciidoc
@@ -48,7 +48,6 @@ in configuration file (logstash.yml):
 monitoring.cluster_uuid: PRODUCTION_ES_CLUSTER_UUID
 ----------------------------------
 
---
 
 
 [float]

--- a/docs/static/monitoring/monitoring-mb.asciidoc
+++ b/docs/static/monitoring/monitoring-mb.asciidoc
@@ -36,6 +36,20 @@ Remove the `#` at the beginning of the line to enable the setting.
 
 --
 
+[float]
+[[define-cluster__uuid]]
+==== Define `cluster_uuid`
+To bind the metrics of {ls} to a specifi cluster, define the `monitoring.cluster_uuid` 
+in configuration file (logstash.yml):
+
+
+[source,yaml]
+----------------------------------
+monitoring.cluster_uuid: PRODUCTION_ES_CLUSTER_UUID
+----------------------------------
+
+--
+
 
 [float]
 [[configure-metricbeat]]

--- a/docs/static/monitoring/monitoring-mb.asciidoc
+++ b/docs/static/monitoring/monitoring-mb.asciidoc
@@ -40,7 +40,7 @@ Remove the `#` at the beginning of the line to enable the setting.
 [[define-cluster__uuid]]
 ==== Define `cluster_uuid`
 To bind the metrics of {ls} to a specific cluster, define the `monitoring.cluster_uuid` 
-in configuration file (logstash.yml):
+in the configuration file (logstash.yml):
 
 
 [source,yaml]

--- a/docs/static/monitoring/monitoring-mb.asciidoc
+++ b/docs/static/monitoring/monitoring-mb.asciidoc
@@ -39,7 +39,7 @@ Remove the `#` at the beginning of the line to enable the setting.
 [float]
 [[define-cluster__uuid]]
 ==== Define `cluster_uuid`
-To bind the metrics of {ls} to a specifi cluster, define the `monitoring.cluster_uuid` 
+To bind the metrics of {ls} to a specific cluster, define the `monitoring.cluster_uuid` 
 in configuration file (logstash.yml):
 
 


### PR DESCRIPTION
`monitoring.cluster_uuid` is the Elasticsearch cluster UUID to bind to Logstash metrics. This should go also on `7.7` version