### PR TITLE
[Doc] Added section for `monitoring.cluster_uuid`

### DIFF
--- a/docs/static/monitoring/monitoring-mb.asciidoc
+++ b/docs/static/monitoring/monitoring-mb.asciidoc
@@ -15,6 +15,7 @@ production cluster as described in <<monitoring-internal-collection>>.
 To collect and ship monitoring data:
 
 . <<disable-default,Disable default collection of monitoring metrics>>
+. <<define-cluster__uuid,Specify optionally the target `cluster_uuid`>>
 . <<configure-metricbeat,Install and configure {metricbeat} to collect monitoring data>>
 
 [float]
@@ -36,6 +37,16 @@ Remove the `#` at the beginning of the line to enable the setting.
 
 --
 
+[float]
+[[define-cluster__uuid]]
+==== Define `cluster_uuid` (Optional)
+To bind the metrics of {ls} to a specific cluster, optionally define the `monitoring.cluster_uuid`
+in the configuration file (logstash.yml):
+
+[source,yaml]
+----------------------------------
+monitoring.cluster_uuid: PRODUCTION_ES_CLUSTER_UUID
+----------------------------------
 
 [float]
 [[configure-metricbeat]]


### PR DESCRIPTION
`monitoring.cluster_uuid` is the Elasticsearch cluster UUID to bind to Logstash metrics. This should go also on `7.7` version