### PR TITLE
revert #11482 and fix redundant code generation

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/ComputeStepSyntaxElement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/ComputeStepSyntaxElement.java
@@ -11,13 +11,12 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.codehaus.commons.compiler.CompileException;
-import org.codehaus.commons.compiler.ISimpleCompiler;
 import org.codehaus.janino.Scanner;
+import org.codehaus.commons.compiler.ISimpleCompiler;
 import org.codehaus.janino.SimpleCompiler;
 
 /**
@@ -33,9 +32,11 @@ public final class ComputeStepSyntaxElement<T extends Dataset> {
     private static final ISimpleCompiler COMPILER = new SimpleCompiler();
 
     /**
-     * Sequential counter to generate the class name
+     * Global cache of runtime compiled classes to prevent duplicate classes being compiled.
+     * across pipelines and workers.
      */
-    private static final AtomicLong classSeqCount = new AtomicLong();
+    private static final Map<ComputeStepSyntaxElement<?>, Class<? extends Dataset>> CLASS_CACHE
+        = new HashMap<>(5000);
 
     /**
      * Pattern to remove redundant {@code ;} from formatted code since {@link Formatter} does not
@@ -43,74 +44,94 @@ public final class ComputeStepSyntaxElement<T extends Dataset> {
      */
     private static final Pattern REDUNDANT_SEMICOLON = Pattern.compile("\n[ ]*;\n");
 
+    private static final String CLASS_NAME_PLACEHOLDER = "CLASS_NAME_PLACEHOLDER";
+
+    private static final Pattern CLASS_NAME_PLACEHOLDER_REGEX = Pattern.compile(CLASS_NAME_PLACEHOLDER);
+
     private final Iterable<MethodSyntaxElement> methods;
 
     private final ClassFields fields;
 
     private final Class<T> type;
 
-    private final long classSeq;
+    private final String normalizedSource;
 
     public static <T extends Dataset> ComputeStepSyntaxElement<T> create(
-        final Iterable<MethodSyntaxElement> methods, final ClassFields fields,
-        final Class<T> interfce) {
+        final Iterable<MethodSyntaxElement> methods,
+        final ClassFields fields,
+        final Class<T> interfce)
+    {
         return new ComputeStepSyntaxElement<>(methods, fields, interfce);
     }
 
-    private ComputeStepSyntaxElement(final Iterable<MethodSyntaxElement> methods,
-        final ClassFields fields, final Class<T> interfce) {
+    private ComputeStepSyntaxElement(
+        final Iterable<MethodSyntaxElement> methods,
+        final ClassFields fields,
+        final Class<T> interfce)
+    {
         this.methods = methods;
         this.fields = fields;
         type = interfce;
-        classSeq = classSeqCount.incrementAndGet();
+
+        // normalizes away the name of the class so that two classes of different name but otherwise
+        // equivalent syntax get correctly compared by {@link #equals(Object)}.
+        normalizedSource = generateCode(CLASS_NAME_PLACEHOLDER);
     }
 
     @SuppressWarnings("unchecked")
-    public T instantiate(Class<? extends Dataset> clazz) {
-        try {
-            return (T) clazz.<T>getConstructor(Map.class).newInstance(ctorArguments());
+    public T instantiate() {
+         try {
+             final Class<? extends Dataset> clazz = compile();
+             return (T) clazz.getConstructor(Map.class).newInstance(ctorArguments());
         } catch (final NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException ex) {
             throw new IllegalStateException(ex);
         }
     }
 
-    @SuppressWarnings("unchecked")
-    public Class<? extends Dataset> compile() {
-        // We need to globally synchronize to avoid concurrency issues with the internal class loader
-        // Per https://github.com/elastic/logstash/pull/11482 we should review this lock. 
-        synchronized (COMPILER) {
-            try {
-                final Class<? extends Dataset> clazz;
-                final String name = String.format("CompiledDataset%d", classSeq);
-                final String code = generateCode(name);
-                if (SOURCE_DIR != null) {
-                    final Path sourceFile = SOURCE_DIR.resolve(String.format("%s.java", name));
-                    Files.write(sourceFile, code.getBytes(StandardCharsets.UTF_8));
-                    COMPILER.cookFile(sourceFile.toFile());
-                } else {
-                    COMPILER.cook(code);
-                }
-                COMPILER.setParentClassLoader(COMPILER.getClassLoader());
-                clazz = (Class<? extends Dataset>)COMPILER.getClassLoader().loadClass(
-                        String.format("org.logstash.generated.%s", name)
-                );
+    /**
+     * This method is NOT thread-safe, and must have exclusive access to `COMPILER`
+     * so that the resulting `ClassLoader` after each `SimpleCompiler#cook()` operation
+     * can be teed up as the parent for the next cook operation.
+     * Also note that synchronizing on `COMPILER` also protects the global CLASS_CACHE.
+     */
 
+    @SuppressWarnings("unchecked")
+    private  Class<? extends Dataset> compile() {
+        try {
+            synchronized (COMPILER) {
+                Class<? extends Dataset> clazz = CLASS_CACHE.get(this);
+                if (clazz == null) {
+                    final String name = String.format("CompiledDataset%d", CLASS_CACHE.size());
+                    final String code = CLASS_NAME_PLACEHOLDER_REGEX.matcher(normalizedSource).replaceAll(name);
+                    if (SOURCE_DIR != null) {
+                        final Path sourceFile = SOURCE_DIR.resolve(String.format("%s.java", name));
+                        Files.write(sourceFile, code.getBytes(StandardCharsets.UTF_8));
+                        COMPILER.cookFile(sourceFile.toFile());
+                    } else {
+                        COMPILER.cook(code);
+                    }
+                    COMPILER.setParentClassLoader(COMPILER.getClassLoader());
+                    clazz = (Class<T>) COMPILER.getClassLoader().loadClass(
+                        String.format("org.logstash.generated.%s", name)
+                    );
+                    CLASS_CACHE.put(this, clazz);
+                }
                 return clazz;
-            } catch (final CompileException | ClassNotFoundException | IOException ex) {
-                throw new IllegalStateException(ex);
             }
+        } catch (final CompileException | ClassNotFoundException | IOException ex) {
+            throw new IllegalStateException(ex);
         }
     }
 
     @Override
     public int hashCode() {
-        return normalizedSource().hashCode();
+        return normalizedSource.hashCode();
     }
 
     @Override
     public boolean equals(final Object other) {
         return other instanceof ComputeStepSyntaxElement &&
-            normalizedSource().equals(((ComputeStepSyntaxElement<?>) other).normalizedSource());
+            normalizedSource.equals(((ComputeStepSyntaxElement<?>) other).normalizedSource);
     }
 
     private String generateCode(final String name) {
@@ -160,15 +181,6 @@ public final class ComputeStepSyntaxElement<T extends Dataset> {
                 result.put(fieldDefinition.getName(), fieldDefinition.getCtorArgument())
         );
         return result;
-    }
-
-    /**
-     * Normalizes away the name of the class so that two classes of different name but otherwise
-     * equivalent syntax get correctly compared by {@link #equals(Object)}.
-     * @return Source of this class, with its name set to {@code CONSTANT}.
-     */
-    private String normalizedSource() {
-        return this.generateCode("CONSTANT");
     }
 
     /**

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/DatasetCompilerTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/DatasetCompilerTest.java
@@ -20,13 +20,12 @@ public final class DatasetCompilerTest {
      */
     @Test
     public void compilesOutputDataset() {
-        final ComputeStepSyntaxElement<Dataset> prepared = DatasetCompiler.outputDataset(
-            Collections.emptyList(),
-            PipelineTestUtil.buildOutput(events -> {}),
-            true
-        );
         assertThat(
-            prepared.instantiate(prepared.compile()).compute(RubyUtil.RUBY.newArray(), false, false),
+            DatasetCompiler.outputDataset(
+                Collections.emptyList(),
+                PipelineTestUtil.buildOutput(events -> {}),
+                true
+            ).instantiate().compute(RubyUtil.RUBY.newArray(), false, false),
             nullValue()
         );
     }
@@ -34,10 +33,9 @@ public final class DatasetCompilerTest {
     @Test
     public void compilesSplitDataset() {
         final FieldReference key = FieldReference.from("foo");
-        final ComputeStepSyntaxElement<SplitDataset> prepared = DatasetCompiler.splitDataset(
+        final SplitDataset left = DatasetCompiler.splitDataset(
             Collections.emptyList(), event -> event.getEvent().includes(key)
-        );
-        final SplitDataset left = prepared.instantiate(prepared.compile());
+        ).instantiate();
         final Event trueEvent = new Event();
         trueEvent.setField(key, "val");
         final JrubyEventExtLibrary.RubyEvent falseEvent =


### PR DESCRIPTION
Fixes #11560 

The fix for the Java execution slowdown relative to the number of worker in #11482 introduced a regression when using multiple pipelines. By analyzing the regression we realized that although the fix was solving the problem for the single pipeline with multiple workers it actually did not correctly solve the root cause of the problem. By removing the global class cache it prevented cross-pipelines class caching, which resulted in the regression.

This PR reverts the previous fix and correctly address the root cause. The real problem was that the  configuration Java code was being generated multiple times through the `hashCode()` and `equals()` methods which were calling the `normalizedSource()` method multiple times.  The fix addresses this by memoizing the `hashCode()` and `normalizedSource()` methods. A few other optimizations have also been made.

The result is that the multiple worker slowdown is still solved and the regression is also fixed. 