### PR TITLE
Fix logging in Docker container image to include pipeline.id #11566

### DIFF
--- a/docker/data/logstash/config/log4j2.properties
+++ b/docker/data/logstash/config/log4j2.properties
@@ -4,7 +4,7 @@ name = LogstashPropertiesConfig
 appender.console.type = Console
 appender.console.name = plain_console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %m%n
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c]%notEmpty{[%X{pipeline.id}]} %m%n
 
 appender.json_console.type = Console
 appender.json_console.name = json_console


### PR DESCRIPTION
Updated the log4j2.properties file that the Docker container image uses so that it logs the pipeline.id field. This should match the behavior of logging to the console outside of a container.

This is a fix for #11566 

