### PR TITLE
Adding plugin.id to docker images

### DIFF
--- a/docker/data/logstash/config/log4j2.properties
+++ b/docker/data/logstash/config/log4j2.properties
@@ -4,7 +4,7 @@ name = LogstashPropertiesConfig
 appender.console.type = Console
 appender.console.name = plain_console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c]%notEmpty{[%X{pipeline.id}]} %m%n
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c]%notEmpty{[%X{pipeline.id}]}%notEmpty{[%X{plugin.id}]} %m%n
 
 appender.json_console.type = Console
 appender.json_console.name = json_console


### PR DESCRIPTION
After changes PR #11078  and  issue created for pipeline.id (issue #11566 PR #11567) also the plugin.id has to be configured in Docker's log4j properties