### PR TITLE
[Doc]Fix monitoring setting name

### DIFF
--- a/docs/static/monitoring/monitoring-mb.asciidoc
+++ b/docs/static/monitoring/monitoring-mb.asciidoc
@@ -29,7 +29,7 @@ commented out:
 
 [source,yaml]
 ----------------------------------
-monitoring.enabled: false
+xpack.monitoring.enabled: false
 ----------------------------------
 
 Remove the `#` at the beginning of the line to enable the setting.


### PR DESCRIPTION
Fixes #11596 

Changes `monitoring.enabled` to `xpack.monitoring.enabled`