### PR TITLE
[DOC]Clarify internal collectors deprecation status for 7.6

### DIFF
--- a/docs/static/monitoring/monitoring-internal.asciidoc
+++ b/docs/static/monitoring/monitoring-internal.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Internal collection</titleabbrev>
 ++++
 
-IMPORTANT: This functionality will be deprecated in 7.7.0
+IMPORTANT: This functionality is scheduled for deprecation in 7.7.0
 
 Using internal collectors for {ls} {monitoring} these components:
 

--- a/docs/static/monitoring/monitoring-internal.asciidoc
+++ b/docs/static/monitoring/monitoring-internal.asciidoc
@@ -2,10 +2,10 @@
 [[monitoring-internal-collection]]
 === Collect {ls} monitoring data using internal collectors
 ++++
-<titleabbrev>Internal collection (deprecated)</titleabbrev>
+<titleabbrev>Internal collection</titleabbrev>
 ++++
 
-deprecated[7.7.0]
+IMPORTANT: This functionality will be deprecated in 7.7.0
 
 Using internal collectors for {ls} {monitoring} these components:
 

--- a/docs/static/monitoring/monitoring-overview.asciidoc
+++ b/docs/static/monitoring/monitoring-overview.asciidoc
@@ -17,7 +17,7 @@ Make sure monitoring is enabled on your {es} cluster. Then configure *one* of
 these methods to collect {ls} metrics:
 
 * <<monitoring-with-metricbeat, {metricbeat} collection>>
-* <<monitoring-internal-collection,Internal collection (deprecated)>>
+* <<monitoring-internal-collection,Internal collection>>
 
 
 include::monitoring-mb.asciidoc[]


### PR DESCRIPTION
We wanted to alert users that internal collectors would be deprecated in 7.7.  The current tagging is misleading, and this PR is an attempt to clarify. 

PREVIEW:  http://logstash_11607.docs-preview.app.elstc.co/guide/en/logstash/7.6/configuring-logstash.html