### PR TITLE
Fix/permit commented out config sources

### DIFF
--- a/logstash-core/lib/logstash/compiler.rb
+++ b/logstash-core/lib/logstash/compiler.rb
@@ -6,14 +6,8 @@ java_import org.logstash.config.ir.graph.Graph
 module LogStash; class Compiler
   include ::LogStash::Util::Loggable
 
-   def self.empty_or_space(str)
-     str.match(/\A\s*\Z/).nil? == false
-   end
-
   def self.compile_sources(sources_with_metadata, support_escapes)
-    graph_sections = sources_with_metadata.reject do |swm|
-       self.empty_or_space(swm.text)
-    end.map do |swm|
+    graph_sections = sources_with_metadata.map do |swm|
       self.compile_graph(swm, support_escapes)
     end
 

--- a/logstash-core/lib/logstash/compiler/lscl/lscl_grammar.rb
+++ b/logstash-core/lib/logstash/compiler/lscl/lscl_grammar.rb
@@ -22,20 +22,8 @@ module LogStashCompilerLSCLGrammar
   end
 
   module Config1
-    def _1
-      elements[0]
-    end
-
-    def plugin_section
+    def _
       elements[1]
-    end
-
-    def _2
-      elements[2]
-    end
-
-    def _3
-      elements[4]
     end
   end
 
@@ -51,45 +39,33 @@ module LogStashCompilerLSCLGrammar
     end
 
     i0, s0 = index, []
-    r1 = _nt__
+    s1, i1 = [], index
+    loop do
+      i2, s2 = index, []
+      r3 = _nt__
+      s2 << r3
+      if r3
+        r4 = _nt_plugin_section
+        s2 << r4
+      end
+      if s2.last
+        r2 = instantiate_node(SyntaxNode,input, i2...index, s2)
+        r2.extend(Config0)
+      else
+        @index = i2
+        r2 = nil
+      end
+      if r2
+        s1 << r2
+      else
+        break
+      end
+    end
+    r1 = instantiate_node(SyntaxNode,input, i1...index, s1)
     s0 << r1
     if r1
-      r2 = _nt_plugin_section
-      s0 << r2
-      if r2
-        r3 = _nt__
-        s0 << r3
-        if r3
-          s4, i4 = [], index
-          loop do
-            i5, s5 = index, []
-            r6 = _nt__
-            s5 << r6
-            if r6
-              r7 = _nt_plugin_section
-              s5 << r7
-            end
-            if s5.last
-              r5 = instantiate_node(SyntaxNode,input, i5...index, s5)
-              r5.extend(Config0)
-            else
-              @index = i5
-              r5 = nil
-            end
-            if r5
-              s4 << r5
-            else
-              break
-            end
-          end
-          r4 = instantiate_node(SyntaxNode,input, i4...index, s4)
-          s0 << r4
-          if r4
-            r8 = _nt__
-            s0 << r8
-          end
-        end
-      end
+      r5 = _nt__
+      s0 << r5
     end
     if s0.last
       r0 = instantiate_node(LogStash::Compiler::LSCL::AST::Config,input, i0...index, s0)

--- a/logstash-core/lib/logstash/compiler/lscl/lscl_grammar.treetop
+++ b/logstash-core/lib/logstash/compiler/lscl/lscl_grammar.treetop
@@ -3,7 +3,7 @@ require "logstash/compiler/lscl.rb"
 
 grammar LogStashCompilerLSCLGrammar
   rule config
-    _ plugin_section _ (_ plugin_section)* _ <LogStash::Compiler::LSCL::AST::Config>
+    (_ plugin_section)* _ <LogStash::Compiler::LSCL::AST::Config>
   end
 
   rule comment

--- a/logstash-core/spec/logstash/compiler/compiler_spec.rb
+++ b/logstash-core/spec/logstash/compiler/compiler_spec.rb
@@ -33,10 +33,6 @@ describe LogStash::Compiler do
   end
 
   describe "compile with empty source" do
-    subject(:source_id) { "fake_sourcefile" }
-    let(:source_with_metadata) { org.logstash.common.SourceWithMetadata.new(source_protocol, source_id, 0, 0, source) }
-    subject(:compiled) { puts "PCOMP"; described_class.compile_pipeline(source_with_metadata, settings) }
-
     let(:sources_with_metadata) do
       [
         org.logstash.common.SourceWithMetadata.new("str", "in_plugin", 0, 0, "input { input_0 {} } "),
@@ -46,6 +42,20 @@ describe LogStash::Compiler do
     end
 
     it "should compile only the text parts" do
+      described_class.compile_sources(sources_with_metadata, false)
+    end
+  end
+
+  describe "compile with fully commented source" do
+    let(:sources_with_metadata) do
+      [
+        org.logstash.common.SourceWithMetadata.new("str", "in_plugin", 0, 0, "input { input_0 {} } "),
+        org.logstash.common.SourceWithMetadata.new("str", "commented_filter", 0, 0, "#filter{...}\n"),
+        org.logstash.common.SourceWithMetadata.new("str", "out_plugin", 0, 0, "output { output_0 {} } "),
+      ]
+    end
+
+    it "should compile only non commented text parts" do
       described_class.compile_sources(sources_with_metadata, false)
     end
   end


### PR DESCRIPTION
Solves #11598 
This PR changes the grammar used to parse config files avoid to force the user to insert at least one plugins section, so this let the users to comment out entirely a file that is used as part of full pipeline configuration. 
The ugly part is that after the  last commented line there must be a newline