### PR TITLE
update jruby-openssl license notice for 7.6.x

### DIFF
--- a/NOTICE.TXT
+++ b/NOTICE.TXT
@@ -5471,10 +5471,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ==========
-Notice for: jruby-openssl-0.10.2
+Notice for: jruby-openssl-0.10.4
 ----------
 
-source: https://github.com/jruby/jruby-openssl/blob/v0.9.21/LICENSE.txt
+source: https://github.com/jruby/jruby-openssl/blob/v0.10.4/LICENSE.txt
 
 JRuby-OpenSSL is distributed under the same license as JRuby a tri EPL/GPL/LGPL
 license. You can use it, redistribute it and/or modify it under the terms of the:

--- a/tools/dependencies-report/src/main/resources/licenseMapping.csv
+++ b/tools/dependencies-report/src/main/resources/licenseMapping.csv
@@ -91,7 +91,7 @@ dependency,dependencyUrl,licenseOverride
 "joni","https://github.com/jruby/joni/",MIT
 "jrjackson:0.4.11",https://github.com/guyboertje/jrjackson,Apache-2.0
 "jruby-jms:1.3.0",https://github.com/reidmorrison/jruby-jms,Apache-2.0
-"jruby-openssl:0.10.2","https://github.com/jruby/jruby-openssl/",EPL-1.0
+"jruby-openssl:0.10.4","https://github.com/jruby/jruby-openssl/",EPL-1.0
 "jruby-readline","https://github.com/jruby/jruby-readline",EPL-1.0
 "jruby-stdin-channel:0.2.0","https://github.com/colinsurprenant/jruby-stdin-channel",Apache-2.0
 "json-generator","https://github.com/tmattia/json-generator/",MIT

--- a/tools/dependencies-report/src/main/resources/notices/jruby-openssl-0.10.4-NOTICE.txt
+++ b/tools/dependencies-report/src/main/resources/notices/jruby-openssl-0.10.4-NOTICE.txt
@@ -1,4 +1,4 @@
-source: https://github.com/jruby/jruby-openssl/blob/v0.9.21/LICENSE.txt
+source: https://github.com/jruby/jruby-openssl/blob/v0.10.4/LICENSE.txt
 
 JRuby-OpenSSL is distributed under the same license as JRuby a tri EPL/GPL/LGPL
 license. You can use it, redistribute it and/or modify it under the terms of the:


### PR DESCRIPTION
We are automatically pulling in a patch-level update to jruby-openssl as a part of the `installDefaultGems` task, and need to update our notices to reflect the version we are including.