### PR TITLE
[DOCS] Fixes out-dated monitoring links

### DIFF
--- a/docs/static/management/configuring-centralized-pipelines.asciidoc
+++ b/docs/static/management/configuring-centralized-pipelines.asciidoc
@@ -35,7 +35,7 @@ the `logstash_admin` role to any users who will use centralized pipeline
 management. See <<ls-security>>.
 
 NOTE: Centralized management is disabled until you configure and enable
-{security}.
+{security-features}.
 
 IMPORTANT: After you've configured Logstash to use centralized pipeline
 management, you can no longer specify local pipeline configurations. This means

--- a/docs/static/monitoring/monitoring-internal.asciidoc
+++ b/docs/static/monitoring/monitoring-internal.asciidoc
@@ -58,8 +58,8 @@ production cluster. If that setting is `false`, the collection of monitoring dat
 is disabled in {es} and data is ignored from all other sources.
 
 . Configure your Logstash nodes to send metrics by setting the
-`xpack.monitoring.elasticsearch.hosts` in `logstash.yml`. If {security} is
-enabled, you also need to specify the credentials for the
+`xpack.monitoring.elasticsearch.hosts` in `logstash.yml`. If {security-features}
+are enabled, you also need to specify the credentials for the
 {ref}/built-in-users.html[built-in `logstash_system` user]. For more
 information about these settings, see <<monitoring-settings>>.
 +
@@ -76,8 +76,8 @@ connect through HTTPS. As of v5.2.1, you can specify multiple
 Elasticsearch hosts as an array as well as specifying a single
 host as a string. If multiple URLs are specified, Logstash
 can round-robin requests to these production nodes.
-<2> If {security} is disabled on the production cluster, you can omit these 
-`username` and `password` settings. 
+<2> If {security-features} are disabled on the production cluster, you can omit 
+these `username` and `password` settings. 
 --
 
 . If SSL/TLS is enabled on the production {es} cluster, specify the trusted

--- a/docs/static/monitoring/monitoring-output.asciidoc
+++ b/docs/static/monitoring/monitoring-output.asciidoc
@@ -32,8 +32,8 @@ All data produced by {monitoring} for Logstash is indexed in the monitoring
 cluster by using the `.monitoring-logstash` template, which is managed by the
 {ref}/es-monitoring-exporters.html[exporters] within {es}. 
 
-If you are working with a cluster that has {security} enabled, extra steps are 
-necessary to properly configure Logstash. For more information, see 
+If you are working with a cluster that has {security-features} enabled, extra
+steps are necessary to properly configure Logstash. For more information, see 
 <<configuring-logstash>>. 
 
 IMPORTANT: When discussing security relative to the `elasticsearch` output, it

--- a/docs/static/security/logstash.asciidoc
+++ b/docs/static/security/logstash.asciidoc
@@ -3,7 +3,7 @@
 === Configuring Security in Logstash
 [subs="attributes"]
 ++++
-<titleabbrev>{security}</titleabbrev>
+<titleabbrev>Configuring Security</titleabbrev>
 ++++
 
 The Logstash {es} plugins ({logstash-ref}/plugins-outputs-elasticsearch.html[output],
@@ -203,7 +203,7 @@ If you plan to ship Logstash {logstash-ref}/monitoring-logstash.html[monitoring]
 data to a secure cluster, you need to configure the username and password that
 Logstash uses to authenticate for shipping monitoring data.
 
-{security} comes preconfigured with a
+The {security-features} come preconfigured with a
 {ref}/built-in-users.html[`logstash_system` built-in user]
 for this purpose. This user has the minimum permissions necessary for the
 monitoring function, and _should not_ be used for any other purpose - it is

--- a/docs/static/troubleshooting.asciidoc
+++ b/docs/static/troubleshooting.asciidoc
@@ -114,7 +114,7 @@ that the bulk failed because the ingest queue is full. Logstash will retry sendi
 
 Check {es} to see if it needs attention.
 
-* {ref}/cluster-stats.html[cluster stats API]
+* {ref}/cluster-stats.html[Cluster stats API]
 * {ref}/monitor-elasticsearch-cluster.html[Monitor a cluster]
 
 *Sample error*

--- a/docs/static/troubleshooting.asciidoc
+++ b/docs/static/troubleshooting.asciidoc
@@ -114,8 +114,8 @@ that the bulk failed because the ingest queue is full. Logstash will retry sendi
 
 Check {es} to see if it needs attention.
 
-* {ref}/cluster-stats.html
-* {ref}/es-monitoring.html
+* {ref}/cluster-stats.html[cluster stats API]
+* {ref}/monitor-elasticsearch-cluster.html[Monitor a cluster]
 
 *Sample error*
 


### PR DESCRIPTION
This PR updates links that were pointing to a deleted page (https://www.elastic.co/guide/en/elasticsearch/reference/master/es-monitoring.html)

Related to elastic/elasticsearch#52790

It also fixes the use of an out-dated "X-Pack Security" attribute.