### PR TITLE
Backport of #11312 [put document_type for /_monitoring]

### DIFF
--- a/x-pack/lib/monitoring/outputs/elasticsearch_monitoring.rb
+++ b/x-pack/lib/monitoring/outputs/elasticsearch_monitoring.rb
@@ -1,0 +1,16 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+module LogStash module Outputs
+  class ElasticSearchMonitoring < LogStash::Outputs::ElasticSearch
+    config_name "elasticsearch_monitoring"
+
+    # This is need to avoid deprecation warning in output
+    config :document_type, :validate => :string
+
+    def use_event_type?(client)
+      true
+    end
+  end
+end; end

--- a/x-pack/lib/template.cfg.erb
+++ b/x-pack/lib/template.cfg.erb
@@ -11,7 +11,7 @@ input {
   }
 }
 output {
-  elasticsearch {
+  elasticsearch_monitoring {
   <% if cloud_id? %>
     cloud_id => "<%= cloud_id %>"
     <% if cloud_auth %>

--- a/x-pack/lib/x-pack/logstash_registry.rb
+++ b/x-pack/lib/x-pack/logstash_registry.rb
@@ -11,11 +11,13 @@ require "logstash/plugins/registry"
 require "logstash/modules/util"
 require "monitoring/monitoring"
 require "monitoring/inputs/metrics"
+require "monitoring/outputs/elasticsearch_monitoring"
 require "config_management/extension"
 require "modules/xpack_scaffold"
 require "filters/azure_event"
 
 LogStash::PLUGIN_REGISTRY.add(:input, "metrics", LogStash::Inputs::Metrics)
+LogStash::PLUGIN_REGISTRY.add(:output, "elasticsearch_monitoring", LogStash::Outputs::ElasticSearchMonitoring)
 LogStash::PLUGIN_REGISTRY.add(:universal, "monitoring", LogStash::MonitoringExtension)
 LogStash::PLUGIN_REGISTRY.add(:universal, "config_management", LogStash::ConfigManagement::Extension)
 


### PR DESCRIPTION
Backport of #11312 

> 
> Changed the xpack metrics pipeline to use a customized ES output plugin to put document_type for /_monitoring, closes #11312
> 
> Backport commit to 7.x
> Fixes #11321