### PR TITLE
Changed: handling of (frozen) config defaults

### DIFF
--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -300,14 +300,6 @@ module LogStash::Config::Mixin
       return true
     end # def validate_check_invalid_parameter_names
 
-    def validate_check_required_parameter(config_key, config_opts, k, v)
-      if config_key.is_a?(Regexp)
-        (k =~ config_key && v)
-      elsif config_key.is_a?(String)
-        k && v
-      end
-    end
-
     def validate_check_required_parameter_names(params)
       is_valid = true
 

--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -580,7 +580,7 @@ module LogStash::Config::Mixin
 
     def hash_or_array(value)
       if !value.is_a?(Hash)
-        value = [*value] # coerce scalar to array if necessary
+        value = Array(value) # coerce scalar to array if necessary
       end
       return value
     end

--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -335,6 +335,7 @@ module LogStash::Config::Mixin
 
       if config_settings[:list]
         value = Array(value) # coerce scalars to lists
+        return true, value if value.frozen?
         # Empty lists are converted to nils
         return true, [] if value.empty?
 
@@ -403,7 +404,7 @@ module LogStash::Config::Mixin
       # (see LogStash::Inputs::File for example)
       result = nil
 
-      value = deep_replace(value)
+      value = value.frozen? ? value : deep_replace(value)
 
       if validator.nil?
         return true, value

--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -337,7 +337,6 @@ module LogStash::Config::Mixin
         value = Array(value) # coerce scalars to lists
         return true, value if value.frozen?
         # Empty lists are converted to nils
-        return true, [] if value.empty?
 
         return validate_value(value, :uri_list) if config_val == :uri
 
@@ -348,7 +347,7 @@ module LogStash::Config::Mixin
         is_valid, processed_value = validate_value(value, config_val)
       end
 
-      return [is_valid, processed_value]
+      return is_valid, processed_value
     end
 
     def validate_check_parameter_values(params)

--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -77,15 +77,11 @@ module LogStash::Config::Mixin
     # Set defaults from 'config :foo, :default => somevalue'
     self.class.get_config.each do |name, opts|
       next if params.include?(name.to_s)
+
       if opts.include?(:default) and (name.is_a?(Symbol) or name.is_a?(String))
         # default values should be cloned if possible
-        # cloning prevents
-        case opts[:default]
-          when FalseClass, TrueClass, NilClass, Numeric
-            params[name.to_s] = opts[:default]
-          else
-            params[name.to_s] = opts[:default].clone
-        end
+        default = opts[:default]
+        params[name.to_s] = default.frozen? ? default : default.clone
       end
 
       # Allow plugins to override default values of config settings
@@ -96,7 +92,7 @@ module LogStash::Config::Mixin
 
     # Resolve environment variables references
     params.each do |name, value|
-      params[name.to_s] = deep_replace(value)
+      params[name.to_s] = deep_replace(value) if !value.frozen?
     end
 
     if !self.class.validate(params)

--- a/logstash-core/lib/logstash/util/substitution_variables.rb
+++ b/logstash-core/lib/logstash/util/substitution_variables.rb
@@ -15,11 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-java_import "org.logstash.secret.store.SecretStoreExt"
-
 require_relative 'lazy_singleton'
 
 module ::LogStash::Util::SubstitutionVariables
+
+  java_import "org.logstash.secret.store.SecretStoreExt"
 
   include LogStash::Util::Loggable
 
@@ -31,13 +31,19 @@ module ::LogStash::Util::SubstitutionVariables
   # Recursive method to replace substitution variable references in parameters
   def deep_replace(value)
     if value.is_a?(Hash)
-      value.each do |valueHashKey, valueHashValue|
-        value[valueHashKey.to_s] = deep_replace(valueHashValue)
+      value.each do |key, val|
+        repl = deep_replace(val)
+        if !val.eql?(repl) || !key.is_a?(String)
+          value[key.to_s] = repl
+        end
       end
     else
       if value.is_a?(Array)
-        value.each_index do | valueArrayIndex|
-          value[valueArrayIndex] = deep_replace(value[valueArrayIndex])
+        value.each_with_index do |elem, index|
+          repl = deep_replace(elem)
+          if !elem.eql?(repl)
+            value[index] = repl
+          end
         end
       else
         return replace_placeholders(value)

--- a/logstash-core/spec/logstash/config/mixin_spec.rb
+++ b/logstash-core/spec/logstash/config/mixin_spec.rb
@@ -554,4 +554,31 @@ describe LogStash::Config::Mixin do
       end
     end
   end
+
+  context "defaults" do
+    subject do
+      Class.new(LogStash::Filters::Base) do
+        include LogStash::Config::Mixin
+
+        @@frozen_string_default = "default".freeze
+        @@frozen_array_default = [ 'foo', 'bar' ].freeze
+        @@frozen_hash_default = { 'foo' => 'bar' }.freeze
+
+        config_name "test_defaults"
+        config :sample_opt, :validate => :string, :default => ""
+        config :frozen_opt, :validate => :string, :default => @@frozen_string_default
+        config :boolean_opt, :validate => :boolean, :default => true
+        config :array_opt, :validate => :array, :default => @@frozen_array_default
+        config :hashy_opt, :validate => :hash, :default => @@frozen_hash_default
+      end.new({})
+    end
+
+    it "should have defaults" do
+      expect( subject.sample_opt ).to eql '' # dup-ed
+      expect( subject.boolean_opt ).to eql true
+      expect( subject.frozen_opt ).to be subject.class.class_variable_get :@@frozen_string_default # not dup-ed
+      expect( subject.array_opt ).to be subject.class.class_variable_get :@@frozen_array_default
+      expect( subject.hashy_opt ).to be subject.class.class_variable_get :@@frozen_hash_default
+    end
+  end
 end


### PR DESCRIPTION
LS does a lot of processing for plugin configuration, this includes clone-ing and deep-replacing defaults.

Only special cases are excluded from being `clone`d: `true, false, nil` and `Numeric` types.
These are all `frozen?` so I would propose extending the list to anything that was `freeze`d.

The problem this is trying to solve is detecting whether user entered something or the configuration is default:

`config :string_field, validate: :string, default: 'foo'`

Sometimes we need to distinguish a user entered `string_field => 'foo'` from a default `'foo'` value.

Originally came up during ES cloud-id support - where we need to distinguish a `:default => [ DEFAULT_HOST ]` from a user-entered `[ '127.0.0.1' ]` value. In these cases it's possible to detect the default value as it isn't a `String` but a `SafeURI`.
However the need to potentially detect defaults is still valid.