### PR TITLE
Bump memcache filter version to fix reference documentation

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -241,7 +241,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-kv (4.4.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-memcached (0.1.1)
+    logstash-filter-memcached (0.1.2)
       dalli (~> 2.7)
       logstash-core-plugin-api (~> 2.0)
     logstash-filter-metrics (4.0.6)


### PR DESCRIPTION
In the release reference docs, plugin documentation files aren't version, only their content is.

Because if this, any updates to the documentation overwrites the existing files, as we can't know that the existing file is "more up to date".

So to fix the continuous broken memcache ttl field reference link, I've released a new version of the 0.1.x series of the memcache filter, and bumping it here.

Newer logstash branches already have the 1.x version of this plugin where the fix has been published since 1.0.1.