### PR TITLE
Fixed timeformat that introduced flaky tests depending on time

### DIFF
--- a/x-pack/lib/monitoring/inputs/metrics/state_event_factory.rb
+++ b/x-pack/lib/monitoring/inputs/metrics/state_event_factory.rb
@@ -17,7 +17,7 @@ module LogStash; module Inputs; class Metrics;
           "logstash_state" => pipeline_doc,
           "cluster_uuid" => cluster_uuid,
           "interval_ms" => collection_interval * 1000,
-          "timestamp" => DateTime.now.strftime('%Y-%m-%dT%k:%M:%S.%L%z')
+          "timestamp" => DateTime.now.strftime('%Y-%m-%dT%H:%M:%S.%L%z')
         }
       else
         event_body = pipeline_doc

--- a/x-pack/lib/monitoring/inputs/metrics/stats_event_factory.rb
+++ b/x-pack/lib/monitoring/inputs/metrics/stats_event_factory.rb
@@ -33,7 +33,7 @@ module LogStash; module Inputs; class Metrics;
           "logstash_stats" => metrics_doc,
           "cluster_uuid" => @cluster_uuid,
           "interval_ms" => collection_interval * 1000,
-          "timestamp" => DateTime.now.strftime('%Y-%m-%dT%k:%M:%S.%L%z')
+          "timestamp" => DateTime.now.strftime('%Y-%m-%dT%H:%M:%S.%L%z')
         }
       else
         event_body = metrics_doc


### PR DESCRIPTION
With PR #11541 we formated the date_time field to be pushed to ES with bad format, used `%k` instead of `%H`, so in some cases (when hour < 10AM) generating hour with space instead of padding 0, for example`...T 8:...` instead of `..T08:..`.