### PR TITLE
Fix: use 'light' match-ing (not depending on scope)

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/EventCondition.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/EventCondition.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 import java.util.function.Predicate;
 
 import org.jruby.Ruby;
+import org.jruby.RubyRegexp;
 import org.jruby.RubyString;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
@@ -467,22 +468,30 @@ public interface EventCondition {
                     !Boolean.toString(false).equals(other);
         }
 
+        private static RubyRegexp newRegexp(String pattern) {
+            final Ruby runtime = RubyUtil.RUBY;
+            return RubyRegexp.newRegexpFromStr(runtime, runtime.newString(pattern), 0);
+        }
+
+        private static boolean matches(RubyString str, RubyRegexp regexp) {
+            return regexp.match_p(RubyUtil.RUBY.getCurrentContext(), str).isTrue(); // match? returns true/false
+        }
+
         private static final class FieldMatches implements EventCondition {
 
             private final FieldReference field;
 
-            private final RubyString regex;
+            private final RubyRegexp regexp;
 
-            private FieldMatches(final String field, final String regex) {
+            private FieldMatches(final String field, final String pattern) {
                 this.field = FieldReference.from(field);
-                this.regex = RubyUtil.RUBY.newString(regex);
+                this.regexp = newRegexp(pattern);
             }
 
             @Override
             public boolean fulfilled(final JrubyEventExtLibrary.RubyEvent event) {
-                final Object tomatch = event.getEvent().getUnconvertedField(field);
-                return tomatch instanceof RubyString &&
-                    !((RubyString) tomatch).match(RubyUtil.RUBY.getCurrentContext(), regex).isNil();
+                final Object toMatch = event.getEvent().getUnconvertedField(field);
+                return toMatch instanceof RubyString && matches((RubyString) toMatch, regexp);
             }
         }
 
@@ -490,12 +499,9 @@ public interface EventCondition {
 
             private final boolean matches;
 
-            private ConstantMatches(final Object constant, final String regex) {
-                final Ruby runtime = RubyUtil.RUBY;
+            private ConstantMatches(final Object constant, final String pattern) {
                 this.matches = constant instanceof String &&
-                        !(runtime.newString((String) constant).match(
-                                runtime.getCurrentContext(),
-                                runtime.newString(regex)).isNil());
+                        matches(RubyUtil.RUBY.newString((String) constant), newRegexp(pattern));
             }
 
             @Override


### PR DESCRIPTION
this was wrong on LS' end - as calling `String#match` impl expects a frame (due `$~`)

in theory this was setting the backref at the wrong place (so I am considering that a 'silent' bug), depending on the caller on Field/Constant matches. due the direct `RubyString` invocation we would end up setting `$~` wherever the current caller Ruby method was scoped (e.g. on the `Thread.new {  }` block scope). does not seem like this was problematic but if any code read `$~` (unexpectedly - wout a previous regexp operation) it might have lead to unexpected results.

... got revealed by a few tests [(in 9.2.11.0)](https://github.com/elastic/logstash/pull/11647) due JRuby reducing frame usage for blocks