### PR TITLE
[DOC]Update to include verification mode switch

### DIFF
--- a/docs/static/settings/monitoring-settings.asciidoc
+++ b/docs/static/settings/monitoring-settings.asciidoc
@@ -81,6 +81,11 @@ the client’s certificate.
 
 Optional settings that provide the password to the keystore.
 
+`xpack.monitoring.elasticsearch.ssl.verification_mode`::
+
+Option to validate the server’s certificate. Defaults to `certificate`. To
+disable, set to `none`. Disabling this severely compromises security.
+
 [[monitoring-additional-settings]]
 ===== Additional settings
 
@@ -99,3 +104,5 @@ If you're using {es} in {ecloud}, you can set your auth credentials here.
 This setting is an alternative to both `xpack.monitoring.elasticsearch.username`
 and `xpack.monitoring.elasticsearch.password`. If `cloud_auth` is configured,
 those settings should not be used.
+
+


### PR DESCRIPTION
Backport of #11284 (after conflict resolution)

As of 6.4.1 (https://www.elastic.co/guide/en/logstash/6.4/logstash-6-4-1.html#logstash-6-4-1 and https://github.com/elastic/support-dev-help/issues/4770), we allow setting the monitoring and management ssl verification to either certificate or none, with certificate being the default.