### PR TITLE
Update README.md to support build fail

### DIFF
--- a/tools/benchmark-cli/README.md
+++ b/tools/benchmark-cli/README.md
@@ -7,6 +7,8 @@ To build a self-contained archive of the benchmark tool simply run:
 ```bash
 gradle clean assemble
 ```
+If the build fails, install an earlier gradle version, like gradle 4.8.
+
 
 which will create the output jar under `build/libs/benchmark-cli.jar`.
 


### PR DESCRIPTION
Add a note regarding gradle, as build fails on recent versions of gradle, like 6.2.2.