### PR TITLE
reduce load on plugins.gradle.org

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,7 @@ allprojects {
 
 subprojects {
     repositories {
+        mavenCentral()
         maven {
             url 'https://plugins.gradle.org/m2/'
         }


### PR DESCRIPTION
This PR ensures we use maven central whenever possible instead of downloading many artifacts from plugins.gradle.org. The change can be observed by comparing master and this branch when running java tests and seeing how many hits we do on `plugins.gradle.org`:

```
~/elastic/logstash master
❯ ./ci/unit_tests.sh java | grep plugins.gradle.org | wc -l
     107
```
vs this PR:
```
~/elastic/logstash remove_repository
❯ ./ci/unit_tests.sh java | grep plugins.gradle.org | wc -l
       5
```

This should help reduce number of failing tests from gateway timeouts