### PR TITLE
support quoted plugin option keys

### DIFF
--- a/logstash-core/lib/logstash/compiler/lscl.rb
+++ b/logstash-core/lib/logstash/compiler/lscl.rb
@@ -147,7 +147,7 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
 
   class Attribute < Node
     def expr
-      [name.text_value, value.expr]
+      [name.is_a?(AST::String) ? name.text_value[1...-1] : name.text_value, value.expr]
     end
   end
 

--- a/logstash-core/spec/logstash/compiler/compiler_spec.rb
+++ b/logstash-core/spec/logstash/compiler/compiler_spec.rb
@@ -243,6 +243,21 @@ describe LogStash::Compiler do
         end
       end
 
+      describe "a plugin with quoted parameter keys" do
+        let(:plugin_source) { "generator { notquoted => 1 'singlequoted' => 2 \"doublequoted\" => 3}" }
+        let(:expected_plugin_args) do
+          {
+            "notquoted" => 1,
+            "singlequoted" => 2,
+            "doublequoted" => 3,
+          }
+        end
+
+        it "should contain the plugin" do
+          expect(c_plugin).to ir_eql(j.iPlugin(rand_meta, INPUT, "generator", expected_plugin_args))
+        end
+      end
+
       describe "a plugin with multiple array parameter types" do
         let(:plugin_source) { "generator { aarg => [1] aarg => [2] aarg => [3]}" }
         let(:expected_plugin_args) do


### PR DESCRIPTION
Fixes #11222


This makes sure that parsed plugins option keys are stripped of their quotes so that the actual key string does not contain quotes. Added related spec (which breaks without the patch).