### PR TITLE
[7.6 clean backport of #11688]  support quoted plugin option key

### DIFF
--- a/logstash-core/lib/logstash/compiler/lscl.rb
+++ b/logstash-core/lib/logstash/compiler/lscl.rb
@@ -131,7 +131,7 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
 
   class Attribute < Node
     def expr
-      [name.text_value, value.expr]
+      [name.is_a?(AST::String) ? name.text_value[1...-1] : name.text_value, value.expr]
     end
   end
 

--- a/logstash-core/spec/logstash/compiler/compiler_spec.rb
+++ b/logstash-core/spec/logstash/compiler/compiler_spec.rb
@@ -226,6 +226,21 @@ describe LogStash::Compiler do
         end
       end
 
+      describe "a plugin with quoted parameter keys" do
+        let(:plugin_source) { "generator { notquoted => 1 'singlequoted' => 2 \"doublequoted\" => 3}" }
+        let(:expected_plugin_args) do
+          {
+            "notquoted" => 1,
+            "singlequoted" => 2,
+            "doublequoted" => 3,
+          }
+        end
+
+        it "should contain the plugin" do
+          expect(c_plugin).to ir_eql(j.iPlugin(rand_meta, INPUT, "generator", expected_plugin_args))
+        end
+      end
+
       describe "a plugin with multiple array parameter types" do
         let(:plugin_source) { "generator { aarg => [1] aarg => [2] aarg => [3]}" }
         let(:expected_plugin_args) do


### PR DESCRIPTION
Clean backport of #11688.