### PR TITLE
avoid processing empty batches in java execution worker loop

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/AckedReadBatch.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/AckedReadBatch.java
@@ -42,25 +42,35 @@ public final class AckedReadBatch implements QueueBatch {
 
     private RubyHash generated;
 
-    public static AckedReadBatch create(final JRubyAckedQueueExt queue, final int size,
-                                        final long timeout) {
-        return new AckedReadBatch(queue, size, timeout);
-    }
+    public static AckedReadBatch create(
+            final JRubyAckedQueueExt queue,
+            final int size,
+            final long timeout)
+    {
+        if (size == 0) { return new AckedReadBatch(); }
 
-    private AckedReadBatch(final JRubyAckedQueueExt queue, final int size, final long timeout) {
         AckedBatch batch;
         try {
             batch = queue.readBatch(size, timeout);
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }
-        if (batch == null) {
-            originals = RubyHash.newHash(RUBY);
-            ackedBatch = null;
-        } else {
-            ackedBatch = batch;
-            originals = ackedBatch.toRubyHash(RUBY);
-        }
+        return ((batch == null) ? new AckedReadBatch() : new AckedReadBatch(batch));
+     }
+
+    public static AckedReadBatch create() {
+        return new AckedReadBatch();
+    }
+
+    private AckedReadBatch() {
+        ackedBatch = null;
+        originals = RubyHash.newHash(RUBY);
+        generated = RubyHash.newHash(RUBY);
+    }
+
+    private AckedReadBatch(AckedBatch batch) {
+        ackedBatch = batch;
+        originals = ackedBatch.toRubyHash(RUBY);
         generated = RubyHash.newHash(RUBY);
     }
 

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyAckedReadClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyAckedReadClientExt.java
@@ -76,13 +76,12 @@ public final class JrubyAckedReadClientExt extends QueueReadClientBase implement
 
     @Override
     public QueueBatch newBatch() {
-        return AckedReadBatch.create(queue, 0, 0);
+        return AckedReadBatch.create();
     }
 
     @Override
     public QueueBatch readBatch() {
-        AckedReadBatch batch =
-            AckedReadBatch.create(queue, batchSize, waitForMillis);
+        AckedReadBatch batch = AckedReadBatch.create(queue, batchSize, waitForMillis);
         startMetrics(batch);
         return batch;
     }


### PR DESCRIPTION
- This optimizes the java execution worker loop to avoid processing empty batches which are the result of timing out the queue read operation. I tried removing the creation of empty batches altogether upon timing out the read but changed my mind; it will require a more thorough refactoring because many moving parts are tied to this. I believe we should do it at some point to avoid the unnecessary empty objects at each timed out read. Will create a followup issue.

- I also slightly refactored the `AckedReadBatch` with new constructors to simplify and clarify the `create` method.