### PR TITLE
Passing JAVA_HOME to bash file executed from docker

### DIFF
--- a/ci/acceptance_tests.sh
+++ b/ci/acceptance_tests.sh
@@ -6,7 +6,7 @@ set -x
 # uses at least 1g of memory, If we don't do this we can get OOM issues when
 # installing gems. See https://github.com/elastic/logstash/issues/5179
 export JRUBY_OPTS="-J-Xmx1g"
-export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info -Dfile.encoding=UTF-8"
+export GRADLE_OPTS="-Xmx4g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info -Dfile.encoding=UTF-8"
 export OSS=true
 
 SELECTED_TEST_SUITE=$1

--- a/ci/docker_run.sh
+++ b/ci/docker_run.sh
@@ -6,6 +6,7 @@ set -x # We want verbosity here, this mostly runs on CI and we want to easily de
 #Note - ensure that the -e flag is NOT set, and explicitly check the $? status to allow for clean up
 
 REMOVE_IMAGE=false
+DOCKER_EXTERNAL_JDK=""
 if [ -z "$branch_specifier" ]; then
     # manual
     REMOVE_IMAGE=true
@@ -33,8 +34,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
+if [ -n "$JDK" ]; then
+  echo "JDK to use $JDK"
+  DOCKER_EXTERNAL_JDK="--mount type=bind,source=$JDK,target=$JDK,readonly --env BUILD_JAVA_HOME=$JDK"
+fi
+
 # Run the command, skip the first argument, which is the image name
-docker run $DOCKER_ENV_OPTS --cidfile=docker_cid --sig-proxy=true --rm $IMAGE_NAME ${@:2}
+docker run $DOCKER_ENV_OPTS --cidfile=docker_cid --sig-proxy=true $DOCKER_EXTERNAL_JDK --rm $IMAGE_NAME ${@:2}
 exit_code=$?
 
 # Remove the container cid since we ran cleanly, no need to force rm it if we got to this point

--- a/ci/integration_tests.sh
+++ b/ci/integration_tests.sh
@@ -5,11 +5,15 @@
 # uses at least 1g of memory, If we don't do this we can get OOM issues when
 # installing gems. See https://github.com/elastic/logstash/issues/5179
 export JRUBY_OPTS="-J-Xmx1g"
-export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info -Dfile.encoding=UTF-8"
+export GRADLE_OPTS="-Xmx4g -Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info -Dfile.encoding=UTF-8"
 
 export SPEC_OPTS="--order rand --format documentation"
 export CI=true
 export OSS=true
+
+if [ -n "$BUILD_JAVA_HOME" ]; then
+  GRADLE_OPTS="$GRADLE_OPTS -Dorg.gradle.java.home=$BUILD_JAVA_HOME"
+fi
 
 if [[ $1 = "setup" ]]; then
  echo "Setup only, no tests will be run"

--- a/ci/unit_tests.sh
+++ b/ci/unit_tests.sh
@@ -5,12 +5,16 @@
 # uses at least 1g of memory, If we don't do this we can get OOM issues when
 # installing gems. See https://github.com/elastic/logstash/issues/5179
 export JRUBY_OPTS="-J-Xmx1g"
-export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info -Dfile.encoding=UTF-8"
+export GRADLE_OPTS="-Xmx4g -Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info -Dfile.encoding=UTF-8"
 
 export SPEC_OPTS="--order rand --format documentation"
 export CI=true
 export OSS=true
 export TEST_DEBUG=true
+
+if [ -n "$BUILD_JAVA_HOME" ]; then
+  GRADLE_OPTS="$GRADLE_OPTS -Dorg.gradle.java.home=$BUILD_JAVA_HOME"
+fi
 
 SELECTED_TEST_SUITE=$1
 

--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -118,9 +118,11 @@ class LogstashService < Service
       # pipe STDOUT and STDERR to a file
       @process.io.stdout = @process.io.stderr = out
       @process.duplex = true
+      java_home = java.lang.System.getProperty('java.home')
+      @process.environment['JAVA_HOME'] = java_home
       @process.start
       wait_for_logstash
-      puts "Logstash started with PID #{@process.pid}" if alive?
+      puts "Logstash started with PID #{@process.pid}, JAVA_HOME: #{java_home}" if alive?
     end
   end
 
@@ -135,9 +137,11 @@ class LogstashService < Service
     Bundler.with_clean_env do
       @process = build_child_process(*args)
       @env_variables.map { |k, v|  @process.environment[k] = v} unless @env_variables.nil?
+      java_home = java.lang.System.getProperty('java.home')
+      @process.environment['JAVA_HOME'] = java_home
       @process.io.inherit!
       @process.start
-      puts "Logstash started with PID #{@process.pid}" if @process.alive?
+      puts "Logstash started with PID #{@process.pid}, JAVA_HOME: #{java_home}" if @process.alive?
     end
   end
 

--- a/x-pack/ci/docker_integration_tests.sh
+++ b/x-pack/ci/docker_integration_tests.sh
@@ -3,9 +3,7 @@
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
-
 if [ -n "${ELASTICSEARCH_SNAPSHOT_URL}" ]; then
   export DOCKER_ENV_OPTS="${DOCKER_ENV_OPTS} --env ELASTICSEARCH_SNAPSHOT_URL=${ELASTICSEARCH_SNAPSHOT_URL}"
 fi
-
 ci/docker_run.sh logstash-xpack-integration-tests x-pack/ci/integration_tests.sh $@

--- a/x-pack/ci/docker_unit_tests.sh
+++ b/x-pack/ci/docker_unit_tests.sh
@@ -3,5 +3,4 @@
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
-
 ci/docker_run.sh logstash-xpack-unit-tests x-pack/ci/unit_tests.sh $@

--- a/x-pack/ci/integration_tests.sh
+++ b/x-pack/ci/integration_tests.sh
@@ -9,7 +9,11 @@
 # uses at least 1g of memory, If we don't do this we can get OOM issues when
 # installing gems. See https://github.com/elastic/logstash/issues/5179
 export JRUBY_OPTS="-J-Xmx1g"
-export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info"
+export GRADLE_OPTS="-Xmx4g -Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info"
 export CI=true
+
+if [ -n "$BUILD_JAVA_HOME" ]; then
+  GRADLE_OPTS="$GRADLE_OPTS -Dorg.gradle.java.home=$BUILD_JAVA_HOME"
+fi
 
 ./gradlew runXPackIntegrationTests

--- a/x-pack/ci/unit_tests.sh
+++ b/x-pack/ci/unit_tests.sh
@@ -9,7 +9,11 @@
 # uses at least 1g of memory, If we don't do this we can get OOM issues when
 # installing gems. See https://github.com/elastic/logstash/issues/5179
 export JRUBY_OPTS="-J-Xmx1g"
-export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info"
+export GRADLE_OPTS="-Xmx4g -Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info"
 export CI=true
+
+if [ -n "$BUILD_JAVA_HOME" ]; then
+  GRADLE_OPTS="$GRADLE_OPTS -Dorg.gradle.java.home=$BUILD_JAVA_HOME"
+fi
 
 ./gradlew runXPackUnitTests


### PR DESCRIPTION
In this PR introduces the usage of the optional environment variable `JDK` which contains the path to the a JDK installation on the host filesystem. This path is mounted as bind FS in the Docker container and used to populate the value of Gradle's `org.gradle.java.home` property.

To select a specific local JDK, export the env variable before running:
```bash
export JDK="/opt/jdk/jdk-12.0.2+10/"
```