### PR TITLE
Rebatch after filters when using pipeline.ordered

### DIFF
--- a/logstash-core/lib/logstash/config/lir_serializer.rb
+++ b/logstash-core/lib/logstash/config/lir_serializer.rb
@@ -63,6 +63,8 @@ module LogStash;
                            if_vertex(v)
                          when :queue
                            queue_vertex(v)
+                         when :separator
+                           separator_vertex(v)
                          end
 
       decorate_vertex(v, hashified_vertex)
@@ -75,6 +77,8 @@ module LogStash;
         :if
       elsif v.java_kind_of?(org.logstash.config.ir.graph.QueueVertex)
         :queue
+      elsif v.java_kind_of?(org.logstash.config.ir.graph.SeparatorVertex)
+        :separator
       else
         raise "Unexpected vertex type! #{v}"
       end
@@ -106,6 +110,10 @@ module LogStash;
       {}
     end
     
+    def separator_vertex(v)
+      {}
+    end
+
     def edge(e)
       e_json = {
         "from" => e.from.id,

--- a/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
@@ -17,12 +17,12 @@
  * under the License.
  */
 
-
 package org.logstash.config.ir;
 
 import co.elastic.logstash.api.Codec;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jruby.RubyArray;
 import org.jruby.RubyHash;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -38,11 +38,13 @@ import org.logstash.config.ir.compiler.DatasetCompiler;
 import org.logstash.config.ir.compiler.EventCondition;
 import org.logstash.config.ir.compiler.RubyIntegration;
 import org.logstash.config.ir.compiler.SplitDataset;
+import org.logstash.config.ir.graph.SeparatorVertex;
 import org.logstash.config.ir.graph.IfVertex;
 import org.logstash.config.ir.graph.PluginVertex;
 import org.logstash.config.ir.graph.Vertex;
 import org.logstash.config.ir.imperative.PluginStatement;
-import org.logstash.ext.JrubyEventExtLibrary;
+import org.logstash.execution.QueueBatch;
+import org.logstash.ext.JrubyEventExtLibrary.RubyEvent;
 import org.logstash.plugins.ConfigVariableExpander;
 import org.logstash.secret.store.SecretStore;
 
@@ -56,6 +58,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.logstash.config.ir.compiler.Utils.copyNonCancelledEvents;
 
 /**
  * <h2>Compiled Logstash Pipeline Configuration.</h2>
@@ -136,14 +140,27 @@ public final class CompiledPipeline {
     }
 
     /**
-     * This method contains the actual compilation of the {@link Dataset} representing the
-     * underlying pipeline from the Queue to the outputs.
-     * @return Compiled {@link Dataset} representation of the underlying {@link PipelineIR} topology
+     * Perform the actual compilation of the {@link Dataset} representing the
+     * underlying pipeline from the Queue to the outputs using the
+     * unordered  execution model.
+     * @return CompiledPipeline.CompiledExecution the compiled pipeline
      */
-    public Dataset buildExecution() {
-        return new CompiledPipeline.CompiledExecution().toDataset();
+    public CompiledPipeline.CompiledExecution buildExecution() {
+        return buildExecution(false);
     }
 
+    /**
+     * Perform the actual compilation of the {@link Dataset} representing the
+     * underlying pipeline from the Queue to the outputs using the ordered or
+     * unordered  execution model.
+     * @param orderedExecution determines whether to build an execution that enforces order or not
+     * @return CompiledPipeline.CompiledExecution the compiled pipeline
+     */
+    public CompiledPipeline.CompiledExecution buildExecution(boolean orderedExecution) {
+        return orderedExecution
+            ? new CompiledPipeline.CompiledOrderedExecution()
+            : new CompiledPipeline.CompiledUnorderedExecution();
+    }
 
     /**
      * Sets up all outputs learned from {@link PipelineIR}.
@@ -294,12 +311,58 @@ public final class CompiledPipeline {
         return outputs.containsKey(vertex.getId());
     }
 
+    public final class CompiledOrderedExecution extends CompiledExecution {
+
+        @Override
+        public void compute(final QueueBatch batch, final boolean flush, final boolean shutdown) {
+           compute(batch.collection(), flush, shutdown);
+        }
+
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        @Override
+        public void compute(final RubyArray batch, final boolean flush, final boolean shutdown) {
+            compute((Collection<RubyEvent>) batch, flush, shutdown);
+        }
+
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        private void compute(final Collection<RubyEvent> batch, final boolean flush, final boolean shutdown) {
+            final RubyArray<RubyEvent> outputBatch = RubyUtil.RUBY.newArray();
+            // send batch one-by-one as single-element batches down the filters
+            final RubyArray<RubyEvent> filterBatch = RubyUtil.RUBY.newArray(1);
+            for (final RubyEvent e : batch) {
+                filterBatch.set(0, e);
+                final Collection<RubyEvent> result = compiledFilters.compute(filterBatch, flush, shutdown);
+                copyNonCancelledEvents(result, outputBatch);
+                compiledFilters.clear();
+            }
+            compiledOutputs.compute(outputBatch, flush, shutdown);
+        }
+    }
+
+    public final class CompiledUnorderedExecution extends CompiledExecution {
+
+        @Override
+        public void compute(final QueueBatch batch, final boolean flush, final boolean shutdown) {
+            compute(batch.to_a(), flush, shutdown);
+        }
+
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        @Override
+        public void compute(final RubyArray batch, final boolean flush, final boolean shutdown) {
+            final RubyArray<RubyEvent> outputBatch = RubyUtil.RUBY.newArray();
+            final Collection<RubyEvent> result = compiledFilters.compute(batch, flush, shutdown);
+            copyNonCancelledEvents(result, outputBatch);
+            compiledFilters.clear();
+            compiledOutputs.compute(outputBatch, flush, shutdown);
+        }
+    }
+
     /**
      * Instances of this class represent a fully compiled pipeline execution. Note that this class
      * has a separate lifecycle from {@link CompiledPipeline} because it holds per (worker-thread)
      * state and thus needs to be instantiated once per thread.
      */
-    private final class CompiledExecution {
+    public abstract class CompiledExecution {
 
         /**
          * Compiled {@link IfVertex, indexed by their ID as returned by {@link Vertex#getId()}.
@@ -312,35 +375,51 @@ public final class CompiledPipeline {
          */
         private final Map<String, Dataset> plugins = new HashMap<>(50);
 
-        private final Dataset compiled;
+        protected final Dataset compiledFilters;
+        protected final Dataset compiledOutputs;
 
         CompiledExecution() {
-            compiled = compile();
+            compiledFilters = compileFilters();
+            compiledOutputs = compileOutputs();
         }
 
-        Dataset toDataset() {
-            return compiled;
+        public abstract void compute(final QueueBatch batch, final boolean flush, final boolean shutdown);
+
+        @SuppressWarnings({"rawtypes"})
+        public abstract void compute(final RubyArray batch, final boolean flush, final boolean shutdown);
+
+        /**
+         * Instantiates the graph of compiled filter section {@link Dataset}.
+         * @return Compiled {@link Dataset} representing the filter section of the pipeline.
+         */
+        private Dataset compileFilters() {
+            final Vertex separator = pipelineIR.getGraph()
+                .vertices()
+                .filter(v -> v instanceof SeparatorVertex)
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Missing Filter End Vertex"));
+           return DatasetCompiler.terminalFilterDataset(flatten(Collections.emptyList(), separator));
         }
 
         /**
-         * Instantiates the graph of compiled {@link Dataset}.
-         * @return Compiled {@link Dataset} representing the pipeline.
+         * Instantiates the graph of compiled output section {@link Dataset}.
+         * @return Compiled {@link Dataset} representing the output section of the pipeline.
          */
-        private Dataset compile() {
+        private Dataset compileOutputs() {
             final Collection<Vertex> outputNodes = pipelineIR.getGraph()
                 .allLeaves().filter(CompiledPipeline.this::isOutput)
                 .collect(Collectors.toList());
             if (outputNodes.isEmpty()) {
                 return Dataset.IDENTITY;
             } else {
-                return DatasetCompiler.terminalDataset(outputNodes.stream().map(
-                    leaf -> outputDataset(leaf, flatten(Collections.emptyList(), leaf))
-                ).collect(Collectors.toList()));
+                return DatasetCompiler.terminalOutputDataset(outputNodes.stream()
+                    .map(leaf -> outputDataset(leaf, flatten(Collections.emptyList(), leaf)))
+                    .collect(Collectors.toList()));
             }
         }
 
         /**
-         * Build a {@link Dataset} representing the {@link JrubyEventExtLibrary.RubyEvent}s after
+         * Build a {@link Dataset} representing the {@link RubyEvent}s after
          * the application of the given filter.
          * @param vertex Vertex of the filter to create this {@link Dataset} for
          * @param datasets All the datasets that have children passing into this filter
@@ -353,7 +432,8 @@ public final class CompiledPipeline {
                 final ComputeStepSyntaxElement<Dataset> prepared =
                     DatasetCompiler.filterDataset(
                         flatten(datasets, vertex),
-                        filters.get(vertexId));
+                        filters.get(vertexId)
+                    );
                 LOGGER.debug("Compiled filter\n {} \n into \n {}", vertex, prepared);
 
                 plugins.put(vertexId, prepared.instantiate());
@@ -363,7 +443,7 @@ public final class CompiledPipeline {
         }
 
         /**
-         * Build a {@link Dataset} representing the {@link JrubyEventExtLibrary.RubyEvent}s after
+         * Build a {@link Dataset} representing the {@link RubyEvent}s after
          * the application of the given output.
          * @param vertex Vertex of the output to create this {@link Dataset} for
          * @param datasets All the datasets that have children passing into this output
@@ -377,7 +457,8 @@ public final class CompiledPipeline {
                     DatasetCompiler.outputDataset(
                         flatten(datasets, vertex),
                         outputs.get(vertexId),
-                        outputs.size() == 1);
+                        outputs.size() == 1
+                    );
                 LOGGER.debug("Compiled output\n {} \n into \n {}", vertex, prepared);
 
                 plugins.put(vertexId, prepared.instantiate());
@@ -388,14 +469,17 @@ public final class CompiledPipeline {
 
         /**
          * Split the given {@link Dataset}s and return the dataset half of their elements that contains
-         * the {@link JrubyEventExtLibrary.RubyEvent} that fulfil the given {@link EventCondition}.
+         * the {@link RubyEvent} that fulfil the given {@link EventCondition}.
          * @param datasets Datasets that are the parents of the datasets to split
          * @param condition Condition that must be fulfilled
          * @param vertex Vertex id to cache the resulting {@link Dataset} under
          * @return The half of the datasets contents that fulfils the condition
          */
-        private SplitDataset split(final Collection<Dataset> datasets,
-            final EventCondition condition, final Vertex vertex) {
+        private SplitDataset split(
+            final Collection<Dataset> datasets,
+            final EventCondition condition,
+            final Vertex vertex)
+        {
             final String vertexId = vertex.getId();
             SplitDataset conditional = iffs.get(vertexId);
             if (conditional == null) {
@@ -425,9 +509,13 @@ public final class CompiledPipeline {
          * @param start Vertex to compile children for
          * @return Datasets originating from given {@link Vertex}
          */
-        private Collection<Dataset> flatten(final Collection<Dataset> datasets,
-            final Vertex start) {
-            final Collection<Dataset> result = compileDependencies(start, datasets,
+        private Collection<Dataset> flatten(
+            final Collection<Dataset> datasets,
+            final Vertex start)
+        {
+            final Collection<Dataset> result = compileDependencies(
+                start,
+                datasets,
                 start.incomingVertices().filter(v -> isFilter(v) || isOutput(v) || v instanceof IfVertex)
             );
             return result.isEmpty() ? datasets : result;
@@ -440,8 +528,11 @@ public final class CompiledPipeline {
          * @param dependencies Dependencies of {@code start}
          * @return Datasets compiled from vertex children
          */
-        private Collection<Dataset> compileDependencies(final Vertex start,
-            final Collection<Dataset> datasets, final Stream<Vertex> dependencies) {
+        private Collection<Dataset> compileDependencies(
+                final Vertex start,
+                final Collection<Dataset> datasets,
+                final Stream<Vertex> dependencies)
+        {
             return dependencies.map(
                 dependency -> {
                     if (isFilter(dependency)) {
@@ -460,13 +551,15 @@ public final class CompiledPipeline {
                         // It is important that we double check that we are actually dealing with the
                         // positive/left branch of the if condition
                         if (ifvert.outgoingBooleanEdgesByType(true)
-                            .anyMatch(edge -> Objects.equals(edge.getTo(), start))) {
+                            .anyMatch(edge -> Objects.equals(edge.getTo(), start)))
+                        {
                             return ifDataset;
                         } else {
                             return ifDataset.right();
                         }
                     }
-                }).collect(Collectors.toList());
+                }
+            ).collect(Collectors.toList());
         }
     }
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/PipelineIR.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/PipelineIR.java
@@ -28,6 +28,7 @@ import org.logstash.config.ir.graph.Graph;
 import org.logstash.config.ir.graph.PluginVertex;
 import org.logstash.config.ir.graph.QueueVertex;
 import org.logstash.config.ir.graph.Vertex;
+import org.logstash.config.ir.graph.SeparatorVertex;
 
 public final class PipelineIR implements Hashable {
 
@@ -42,7 +43,9 @@ public final class PipelineIR implements Hashable {
     }
 
     private final Graph graph;
+
     private final QueueVertex queue;
+
     // Temporary until we have LIR execution
     // Then we will no longer need this property here
     private final String originalSource;
@@ -62,6 +65,9 @@ public final class PipelineIR implements Hashable {
 
         // Now we connect the queue to the root of the filter section
         tempGraph = tempGraph.chain(filterSection);
+
+        // Connect the filter section to the filter end vertex to separate from the output section
+        tempGraph = tempGraph.chain(new SeparatorVertex("filter_to_output"));
 
         // Finally, connect the filter out node to all the outputs
         this.graph = tempGraph.chain(outputSection);

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/Graph.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/Graph.java
@@ -432,7 +432,7 @@ public final class Graph implements SourceComponent, Hashable {
 
     public String uniqueHash() {
         return Util.digest(this.vertices().
-                filter(v -> !(v instanceof QueueVertex)). // has no metadata
+                filter(v -> !(v instanceof QueueVertex) && !(v instanceof SeparatorVertex)). // has no metadata
                 map(Vertex::getSourceWithMetadata).
                 map(SourceWithMetadata::uniqueHash).
                 sorted().

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/SeparatorVertex.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/SeparatorVertex.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.logstash.config.ir.graph;
+
+import org.logstash.common.IncompleteSourceWithMetadataException;
+import org.logstash.common.Util;
+import org.logstash.config.ir.SourceComponent;
+import org.logstash.common.SourceWithMetadata;
+
+public final class SeparatorVertex extends Vertex {
+
+    public SeparatorVertex(String id) throws IncompleteSourceWithMetadataException {
+        super(new SourceWithMetadata("internal", id, 0,0,"separator"), id);
+    }
+
+    @Override
+    public String toString() {
+        return this.getId();
+    }
+
+    @Override
+    public SeparatorVertex copy() {
+        try {
+            return new SeparatorVertex(this.getId());
+        } catch (IncompleteSourceWithMetadataException e) {
+            // Never happens
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public boolean sourceComponentEquals(SourceComponent other) {
+        return other instanceof SeparatorVertex && ((SeparatorVertex)other).getId() == this.getId();
+    }
+
+    // Special vertices really have no metadata
+    @Override
+    public SourceWithMetadata getSourceWithMetadata() {
+        return null;
+    }
+
+    @Override
+    public String uniqueHash() {
+        return Util.digest("SEPARATOR_" + this.getId());
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/execution/QueueBatch.java
+++ b/logstash-core/src/main/java/org/logstash/execution/QueueBatch.java
@@ -17,17 +17,17 @@
  * under the License.
  */
 
-
 package org.logstash.execution;
 
 import org.jruby.RubyArray;
-import org.jruby.runtime.builtin.IRubyObject;
-
+import org.logstash.ext.JrubyEventExtLibrary.RubyEvent;
 import java.io.IOException;
+import java.util.Collection;
 
 public interface QueueBatch {
     int filteredSize();
     @SuppressWarnings({"rawtypes"}) RubyArray to_a();
-    void merge(IRubyObject event);
+    Collection<RubyEvent> collection();
+    void merge(RubyEvent event);
     void close() throws IOException;
 }

--- a/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
+++ b/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
@@ -17,24 +17,19 @@
  * under the License.
  */
 
-
 package org.logstash.execution;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.LongAdder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jruby.RubyArray;
-import org.jruby.runtime.ThreadContext;
-import org.logstash.RubyUtil;
 import org.logstash.config.ir.CompiledPipeline;
-import org.logstash.config.ir.compiler.Dataset;
 
 public final class WorkerLoop implements Runnable {
 
     private static final Logger LOGGER = LogManager.getLogger(WorkerLoop.class);
 
-    private final Dataset execution;
+    private final CompiledPipeline.CompiledExecution execution;
 
     private final QueueReadClient readClient;
 
@@ -65,7 +60,7 @@ public final class WorkerLoop implements Runnable {
     {
         this.consumedCounter = consumedCounter;
         this.filteredCounter = filteredCounter;
-        this.execution = pipeline.buildExecution();
+        this.execution = pipeline.buildExecution(preserveEventOrder);
         this.drainQueue = drainQueue;
         this.readClient = readClient;
         this.flushRequested = flushRequested;
@@ -84,7 +79,7 @@ public final class WorkerLoop implements Runnable {
                 consumedCounter.add(batch.filteredSize());
                 final boolean isFlush = flushRequested.compareAndSet(true, false);
                 readClient.startMetrics(batch);
-                compute(batch, isFlush, false);
+                execution.compute(batch, isFlush, false);
                 int filteredCount = batch.filteredSize();
                 filteredCounter.add(filteredCount);
                 readClient.addOutputMetrics(filteredCount);
@@ -98,7 +93,7 @@ public final class WorkerLoop implements Runnable {
             //for this we need to create a new empty batch to contain the final flushed events
             final QueueBatch batch = readClient.newBatch();
             readClient.startMetrics(batch);
-            compute(batch, true, true);
+            execution.compute(batch, true, true);
             readClient.closeBatch(batch);
         } catch (final Exception ex) {
             LOGGER.error(
@@ -106,20 +101,6 @@ public final class WorkerLoop implements Runnable {
                 ex
             );
             throw new IllegalStateException(ex);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private void compute(final QueueBatch batch, final boolean flush, final boolean shutdown) {
-        if (preserveEventOrder) {
-            // send batch events one-by-one as single-element batches
-            @SuppressWarnings({"rawtypes"}) final RubyArray singleElementBatch = RubyUtil.RUBY.newArray(1);
-            batch.to_a().forEach((e) -> {
-                singleElementBatch.set(0, e);
-                execution.compute(singleElementBatch, flush, shutdown);
-            });
-        } else {
-            execution.compute(batch.to_a(), flush, shutdown);
         }
     }
 


### PR DESCRIPTION
Fixes #11550
Relates to #11175

#### WIP TODOs
- [x] major cleanup
- [x] refactor & simplify the `filtersExecution` + `lastFilter` logic
- [x] re-enable and fix relevant java tests
- [x] benchmark

#### Description
When using `pipeline.ordered` the batch events are sent 1 by 1 down the filters and output. This PR rebatches after the filters so that full batches can be sent to the outputs. It does that by separating the filters and output execution with the introduction of a separator vertex in the pipeline graph between the filters and outputs and compiling both sections separately and in the worker_loop calling both compute separately which provides the possibility to rebatch after the filters.

