### PR TITLE
[Doc]Add section for conceptual info

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -55,6 +55,11 @@ include::static/advanced-pipeline.asciidoc[]
 :edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/life-of-an-event.asciidoc
 include::static/life-of-an-event.asciidoc[]
 
+// Processing details
+
+:edit_url!:
+include::static/processing-info.asciidoc[]
+
 // Logstash setup
 
 :edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/setting-up-logstash.asciidoc

--- a/docs/static/life-of-an-event.asciidoc
+++ b/docs/static/life-of-an-event.asciidoc
@@ -96,3 +96,4 @@ By default, Logstash uses in-memory bounded queues between pipeline stages
 unsafely, any events that are stored in memory will be lost. To help prevent data
 loss, you can enable Logstash to persist in-flight events to disk. See
 <<persistent-queues>> for more information.
+

--- a/docs/static/processing-info.asciidoc
+++ b/docs/static/processing-info.asciidoc
@@ -1,0 +1,18 @@
+[[processing]]
+=== Processing Details
+
+Understanding how {ls} works and how components interrelate can help you make better
+decisions when you are setting up or adjusting your {ls} environment. This
+section is designed to elevate concepts to assist with that level of
+knowledge.
+
+NOTE: This is a new section. We're still working on it.
+
+[float] 
+[[event-ordering]] 
+==== Event ordering 
+
+Event ordering info goes here. 
+
+//todo: Document event ordering guaranties or lack thereof with multiple worker versus single worker
+

--- a/docs/static/processing-info.asciidoc
+++ b/docs/static/processing-info.asciidoc
@@ -16,7 +16,7 @@ By design and by default, {ls} does not guarantee event order. Reordering can
 occur in two places:
 
 * Events within a batch can be reordered during filter processing.
-* In-flight batches can be reordered when one or more batches process faster than
+* In-flight batches can be reordered when one or more batches are processed faster than
 others. 
 
 When maintaining event order is important, use a single worker. 

--- a/docs/static/processing-info.asciidoc
+++ b/docs/static/processing-info.asciidoc
@@ -1,9 +1,9 @@
 [[processing]]
 === Processing Details
 
-Understanding how {ls} works and how components interrelate can help you make better
-decisions when you are setting up or adjusting your {ls} environment. This
-section is designed to elevate concepts to assist with that level of
+Understanding how {ls} works and how components interrelate can help you make
+better decisions when you are setting up or adjusting your {ls} environment.
+This section is designed to elevate concepts to assist with that level of
 knowledge.
 
 NOTE: This is a new section. We're still working on it.
@@ -11,6 +11,21 @@ NOTE: This is a new section. We're still working on it.
 [float] 
 [[event-ordering]] 
 ==== Event ordering 
+
+By design and by default, {ls} does not guarantee event order. Reordering can
+occur in two places:
+
+* Events within a batch can be reordered during filter processing.
+* In-flight batches can be reordered when one or more batches process faster than
+others. 
+
+When maintaining event order is important, use a single worker. 
+This approach ensures that batches are computed one-after-the-other, and
+that events maintain their order within the batch.
+
+[float] 
+[[order-setting]] 
+===== 'pipeline.ordered' setting
 
 The `pipeline.ordered` setting in <<logstash-settings-file,logstash.yml>>
 gives you more control over event ordering for single worker pipelines.
@@ -28,8 +43,3 @@ processing cost required to preserve order.
 The Java pipeline initialization time appears in the startup logs at INFO level.
 Initialization time is the time it takes to compile the pipeline config and
 instantiate the compiled execution for all workers.
-
-If you notice a slowdown, ...
-
-
-

--- a/docs/static/processing-info.asciidoc
+++ b/docs/static/processing-info.asciidoc
@@ -12,7 +12,24 @@ NOTE: This is a new section. We're still working on it.
 [[event-ordering]] 
 ==== Event ordering 
 
-Event ordering info goes here. 
+The `pipeline.ordered` setting in <<logstash-settings-file,logstash.yml>>
+gives you more control over event ordering for single worker pipelines.
 
-//todo: Document event ordering guaranties or lack thereof with multiple worker versus single worker
+`auto` automatically enables ordering if the `pipeline.workers` setting is also
+set to `1`. `true` will enforce ordering on the pipeline and prevent logstash
+from starting if there are multiple workers. `false` will disable the processing
+required to preserve order. Ordering will not be guaranteed, but you save the
+processing cost required to preserve order.
+
+[float] 
+[[pipeline-init-time]] 
+==== Java pipeline initialization time
+
+The Java pipeline initialization time appears in the startup logs at INFO level.
+Initialization time is the time it takes to compile the pipeline config and
+instantiate the compiled execution for all workers.
+
+If you notice a slowdown, ...
+
+
 

--- a/docs/static/processing-info.asciidoc
+++ b/docs/static/processing-info.asciidoc
@@ -19,7 +19,8 @@ occur in two places:
 * In-flight batches can be reordered when one or more batches are processed faster than
 others. 
 
-When maintaining event order is important, use a single worker. 
+When maintaining event order is important, use a single worker and set
+'pipeline.ordered => true'.
 This approach ensures that batches are computed one-after-the-other, and
 that events maintain their order within the batch.
 


### PR DESCRIPTION
Important info that customers need can be buried way down in the details. This PR adds a section for bubbling up and curating that information.

Replaces #11581 

**PREVIEW:** http://logstash_11715.docs-preview.app.elstc.co/guide/en/logstash/master/processing.html