### PR TITLE
Updated: JRuby to 9.2.11.1

### DIFF
--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -25,7 +25,7 @@ buildscript {
     dependencies {
         classpath 'org.yaml:snakeyaml:1.23'
         classpath "de.undercouch:gradle-download-task:3.2.0"
-        classpath "org.jruby:jruby-complete:9.2.11.0"
+        classpath "org.jruby:jruby-complete:9.2.11.1"
     }
 }
 

--- a/versions.yml
+++ b/versions.yml
@@ -7,8 +7,8 @@ logstash-core-plugin-api: 2.1.16
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time
 jruby:
-  version: 9.2.11.0
-  sha1: c92bf2e52132b4d6d120f8dfbae15b36ab20d9d4
+  version: 9.2.11.1
+  sha1: cceb81635fe3cd39f895c7632428e94b503e8e3d
 
 # jruby-runtime-override, if specified, will override the jruby version installed in vendor/jruby for logstash runtime only,
 # not for the compile-time jars


### PR DESCRIPTION
contains a single bugfix for precision leaks using `%s` in `sprintf` : 

> There's an issue in JRuby 9.2.7.0 - 9.2.11.0 affecting format("%.#{prec}s", shared_str) 
a.k.a. `Kernel.sprintf`
Only `%s` with precision specified is affected.
The result is that 'invalid' content leaks into the result if the string argument shares a buffer internally e.g. :
`str = '0123456789'; shared_str = str[4, 5]; Kernel.sprintf("%.3s", shared_str)` 
\# invalid: `"456789\u0000"`

Plugins and LS does not use precision in `%s`, still better :sake: then :sob: 