### PR TITLE
Bump octokit to 4.18.0 due to gem yanking

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -553,7 +553,7 @@ GEM
     nio4r (2.5.2-java)
     nokogiri (1.10.9-java)
     numerizer (0.1.1)
-    octokit (4.17.0)
+    octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     openssl_pkcs8_pure (0.0.0.2)


### PR DESCRIPTION
Since version 4.17.0 was yanked: https://github.com/octokit/octokit.rb/releases/tag/v4.17.0, this PR bumps the version to 4.18.0.