### PR TITLE
Refactor: avoid array in case of single event

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -247,13 +247,15 @@ public final class Event implements Cloneable, Queueable, co.elastic.logstash.ap
         return JSON_MAPPER.writeValueAsString(this.data);
     }
 
+    private static final Event[] NULL_ARRAY = new Event[0];
+
     @SuppressWarnings("unchecked")
     public static Event[] fromJson(String json)
             throws IOException
     {
         // empty/blank json string does not generate an event
         if (json == null || json.trim().isEmpty()) {
-            return new Event[]{ };
+            return NULL_ARRAY;
         }
 
         Event[] result;

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -127,14 +127,14 @@ public final class JrubyEventExtLibrary {
         public IRubyObject ruby_cancel(ThreadContext context)
         {
             this.event.cancel();
-            return context.runtime.getTrue();
+            return context.tru;
         }
 
         @JRubyMethod(name = "uncancel")
         public IRubyObject ruby_uncancel(ThreadContext context)
         {
             this.event.uncancel();
-            return context.runtime.getFalse();
+            return context.fals;
         }
 
         @JRubyMethod(name = "cancelled?")
@@ -251,18 +251,16 @@ public final class JrubyEventExtLibrary {
                 throw RaiseException.from(context.runtime, RubyUtil.PARSER_ERROR, e.getMessage());
             }
 
-            @SuppressWarnings("rawtypes")
-            RubyArray result = RubyArray.newArray(context.runtime, events.length);
-
             if (events.length == 1) {
                 // micro optimization for the 1 event more common use-case.
-                result.set(0, RubyEvent.newRubyEvent(context.runtime, events[0]));
-            } else {
-                for (int i = 0; i < events.length; i++) {
-                    result.set(i, RubyEvent.newRubyEvent(context.runtime, events[i]));
-                }
+                return context.runtime.newArray(RubyEvent.newRubyEvent(context.runtime, events[0]));
             }
-            return result;
+
+            IRubyObject[] rubyEvents = new IRubyObject[events.length];
+            for (int i = 0; i < events.length; i++) {
+                rubyEvents[i] = RubyEvent.newRubyEvent(context.runtime, events[i]);
+            }
+            return context.runtime.newArrayNoCopy(rubyEvents);
         }
 
         @JRubyMethod(name = "validate_value", required = 1, meta = true)


### PR DESCRIPTION
*Few minor nitpicks as I was looking at the `Event` parts a lot last week.*

`runtime.newArray(object)` uses (unpacked) specialized array wout `IRubyObject[]`

while also making the array case cleaner & effective (since we avoid `List#set(int, Object)`)