### PR TITLE
[7.x clean backport or #11737] simplify batch classes, do not compute JE empty batches, refactor RE worker loop

### DIFF
--- a/logstash-core/spec/logstash/util/wrapped_synchronous_queue_spec.rb
+++ b/logstash-core/spec/logstash/util/wrapped_synchronous_queue_spec.rb
@@ -119,19 +119,16 @@ describe LogStash::WrappedSynchronousQueue do
             message = data.get("message")
             expect(messages).to include(message)
             messages.delete(message)
-            # read_batch.cancel("value-#{i}") if i > 2     # TODO: disabled for https://github.com/elastic/logstash/issues/6055 - will have to properly refactor
             if message.match /value-[3-4]/
               data.cancel
-              read_batch.merge(LogStash::Event.new({ "message" => message.gsub(/value/, 'generated') }))
             end
           end
-          # expect(read_batch.cancelled_size).to eq(2) # disabled for https://github.com/elastic/logstash/issues/6055
           received = []
           read_batch.to_a.each do |data|
             received << data.get("message")
           end
+          expect(received.size).to eq(3)
           (0..2).each {|i| expect(received).to include("value-#{i}")}
-          (3..4).each {|i| expect(received).to include("generated-#{i}")}
         end
 
         it "handles Java proxied read-batch object" do

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/AckedBatch.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/AckedBatch.java
@@ -21,11 +21,12 @@
 package org.logstash.ackedqueue;
 
 import java.io.IOException;
-import org.jruby.Ruby;
-import org.jruby.RubyBoolean;
-import org.jruby.RubyHash;
+import java.util.ArrayList;
+import java.util.Collection;
 import org.logstash.Event;
-import org.logstash.ext.JrubyEventExtLibrary;
+import org.logstash.ext.JrubyEventExtLibrary.RubyEvent;
+
+import static org.logstash.RubyUtil.RUBY;
 
 public final class AckedBatch {
     private Batch batch;
@@ -36,14 +37,11 @@ public final class AckedBatch {
         return ackedBatch;
     }
 
-    public RubyHash toRubyHash(final Ruby runtime) {
-        final RubyBoolean trueValue = runtime.getTrue();
-        final RubyHash result = RubyHash.newHash(runtime);
-        this.batch.getElements().forEach(e -> result.fastASet(
-            JrubyEventExtLibrary.RubyEvent.newRubyEvent(runtime, (Event) e),
-            trueValue
-            )
-        );
+    public Collection<RubyEvent> events() {
+        final ArrayList<RubyEvent> result = new ArrayList<>(this.batch.size());
+        for (final Queueable e : batch.getElements()) {
+            result.add(RubyEvent.newRubyEvent(RUBY, (Event) e));
+        }
         return result;
     }
 

--- a/logstash-core/src/main/java/org/logstash/common/LsQueueUtils.java
+++ b/logstash-core/src/main/java/org/logstash/common/LsQueueUtils.java
@@ -20,11 +20,11 @@
 
 package org.logstash.common;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
-import org.logstash.ext.JrubyEventExtLibrary;
+import org.logstash.ext.JrubyEventExtLibrary.RubyEvent;
 
 /**
  * Utilities around {@link BlockingQueue}.
@@ -42,9 +42,12 @@ public final class LsQueueUtils {
      * @param events Events to add to Queue
      * @throws InterruptedException On interrupt during blocking queue add
      */
-    public static void addAll(final BlockingQueue<JrubyEventExtLibrary.RubyEvent> queue,
-        final Collection<JrubyEventExtLibrary.RubyEvent> events) throws InterruptedException {
-        for (final JrubyEventExtLibrary.RubyEvent event : events) {
+    public static void addAll(
+        final BlockingQueue<RubyEvent> queue,
+        final Collection<RubyEvent> events)
+        throws InterruptedException
+    {
+        for (final RubyEvent event : events) {
             queue.put(event);
         }
     }
@@ -65,13 +68,14 @@ public final class LsQueueUtils {
      * @throws InterruptedException On Interrupt during {@link BlockingQueue#poll()} or
      * {@link BlockingQueue#drainTo(Collection)}
      */
-    public static LinkedHashSet<JrubyEventExtLibrary.RubyEvent> drain(
-        final BlockingQueue<JrubyEventExtLibrary.RubyEvent> queue, final int count, final long nanos
-    ) throws InterruptedException {
+    public static Collection<RubyEvent> drain(
+        final BlockingQueue<RubyEvent> queue,
+        final int count,
+        final long nanos)
+        throws InterruptedException
+    {
         int left = count;
-        //todo: make this an ArrayList once we remove the Ruby pipeline/execution
-        final LinkedHashSet<JrubyEventExtLibrary.RubyEvent> collection =
-            new LinkedHashSet<>(4 * count / 3 + 1);
+        final ArrayList<RubyEvent> collection = new ArrayList<>(4 * count / 3 + 1);
         do {
             final int drained = drain(queue, collection, left, nanos);
             if (drained == 0) {
@@ -95,15 +99,18 @@ public final class LsQueueUtils {
      * @throws InterruptedException On Interrupt during {@link BlockingQueue#poll()} or
      * {@link BlockingQueue#drainTo(Collection)}
      */
-    private static int drain(final BlockingQueue<JrubyEventExtLibrary.RubyEvent> queue,
-        final Collection<JrubyEventExtLibrary.RubyEvent> collection, final int count,
-        final long nanos) throws InterruptedException {
+    private static int drain(
+        final BlockingQueue<RubyEvent> queue,
+        final Collection<RubyEvent> collection,
+        final int count,
+        final long nanos)
+        throws InterruptedException
+    {
         int added = 0;
         do {
             added += queue.drainTo(collection, count - added);
             if (added < count) {
-                final JrubyEventExtLibrary.RubyEvent event =
-                    queue.poll(nanos, TimeUnit.NANOSECONDS);
+                final RubyEvent event = queue.poll(nanos, TimeUnit.NANOSECONDS);
                 if (event == null) {
                     break;
                 }

--- a/logstash-core/src/main/java/org/logstash/execution/MemoryReadBatch.java
+++ b/logstash-core/src/main/java/org/logstash/execution/MemoryReadBatch.java
@@ -21,53 +21,48 @@ package org.logstash.execution;
 
 import org.jruby.RubyArray;
 import org.logstash.ext.JrubyEventExtLibrary.RubyEvent;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashSet;
+
 import static org.logstash.RubyUtil.RUBY;
 
 public final class MemoryReadBatch implements QueueBatch {
 
-    private final LinkedHashSet<RubyEvent> events;
-
-    public MemoryReadBatch(final LinkedHashSet<RubyEvent> events) {
-        this.events = events;
-    }
+    private final Collection<RubyEvent> events;
 
     public static boolean isCancelled(final RubyEvent event) {
         return event.getEvent().isCancelled();
     }
 
-    public static MemoryReadBatch create(LinkedHashSet<RubyEvent> events) {
+    public static MemoryReadBatch create(Collection<RubyEvent> events) {
         return new MemoryReadBatch(events);
     }
 
     public static MemoryReadBatch create() {
-        return create(new LinkedHashSet<>());
+        return new MemoryReadBatch(new ArrayList<>());
+    }
+
+    private MemoryReadBatch(final Collection<RubyEvent> events) {
+        this.events = events;
     }
 
     @Override
-    @SuppressWarnings({"rawtypes"})
-    public RubyArray to_a() {
-        final RubyArray result = RUBY.newArray(events.size());
-        for (final RubyEvent event : events) {
-            if (!isCancelled(event)) {
-                result.append(event);
+    public RubyArray<RubyEvent> to_a() {
+        @SuppressWarnings({"unchecked"}) final RubyArray<RubyEvent> result = RUBY.newArray(events.size());
+        for (final RubyEvent e : events) {
+            if (!isCancelled(e)) {
+                result.append(e);
             }
         }
         return result;
     }
 
     @Override
-    public Collection<RubyEvent> collection() {
+    public Collection<RubyEvent> events() {
         // This does not filter cancelled events because it is
         // only used in the WorkerLoop where there are no cancelled
         // events yet.
         return events;
-    }
-
-    @Override
-    public void merge(final RubyEvent event) {
-        events.add(event);
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/execution/QueueBatch.java
+++ b/logstash-core/src/main/java/org/logstash/execution/QueueBatch.java
@@ -26,8 +26,7 @@ import java.util.Collection;
 
 public interface QueueBatch {
     int filteredSize();
-    @SuppressWarnings({"rawtypes"}) RubyArray to_a();
-    Collection<RubyEvent> collection();
-    void merge(RubyEvent event);
+    RubyArray<RubyEvent> to_a();
+    Collection<RubyEvent> events();
     void close() throws IOException;
 }

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyAckedReadClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyAckedReadClientExt.java
@@ -76,13 +76,12 @@ public final class JrubyAckedReadClientExt extends QueueReadClientBase implement
 
     @Override
     public QueueBatch newBatch() {
-        return AckedReadBatch.create(queue, 0, 0);
+        return AckedReadBatch.create();
     }
 
     @Override
     public QueueBatch readBatch() {
-        AckedReadBatch batch =
-            AckedReadBatch.create(queue, batchSize, waitForMillis);
+        final AckedReadBatch batch = AckedReadBatch.create(queue, batchSize, waitForMillis);
         startMetrics(batch);
         return batch;
     }

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryReadClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryReadClientExt.java
@@ -77,8 +77,7 @@ public final class JrubyMemoryReadClientExt extends QueueReadClientBase {
     @Override
     @SuppressWarnings("unchecked")
     public QueueBatch readBatch() throws InterruptedException {
-        MemoryReadBatch batch = MemoryReadBatch.create(
-                LsQueueUtils.drain(queue, batchSize, waitForNanos));
+        final MemoryReadBatch batch = MemoryReadBatch.create(LsQueueUtils.drain(queue, batchSize, waitForNanos));
         startMetrics(batch);
         return batch;
     }

--- a/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
@@ -34,6 +34,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
+import org.jruby.RubyArray;
 import org.jruby.RubyObject;
 import org.jruby.RubyString;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -115,6 +116,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
         EVENT_SINKS.remove(runId);
     }
 
+    @SuppressWarnings({"unchecked"})
     @Test
     public void buildsTrivialPipeline() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
@@ -134,6 +136,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
         MatcherAssert.assertThat(outputEvents.contains(testEvent), CoreMatchers.is(true));
     }
 
+    @SuppressWarnings({"unchecked"})
     @Test
     public void buildsStraightPipeline() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
@@ -155,6 +158,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
         MatcherAssert.assertThat(outputEvents.contains(testEvent), CoreMatchers.is(true));
     }
 
+    @SuppressWarnings({"unchecked"})
     @Test
     public void buildsForkedPipeline() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(IRHelpers.toSourceWithMetadata(
@@ -280,6 +284,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
         verifyRegex("!~", 0);
     }
 
+    @SuppressWarnings({"unchecked"})
     private void verifyRegex(String operator, int expectedEvents)
             throws IncompleteSourceWithMetadataException {
         final Event event = new Event();
@@ -307,6 +312,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
         outputEvents.clear();
     }
 
+    @SuppressWarnings({"unchecked"})
     @Test
     public void equalityCheckOnCompositeField() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
@@ -338,6 +344,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
         MatcherAssert.assertThat(testEvent.getEvent().getField("foo"), CoreMatchers.nullValue());
     }
 
+    @SuppressWarnings({"unchecked"})
     @Test
     public void conditionalWithNullField() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
@@ -362,6 +369,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
         MatcherAssert.assertThat(testEvent.getEvent().getField("foo"), CoreMatchers.is("bar"));
     }
 
+    @SuppressWarnings({"unchecked"})
     @Test
     public void conditionalNestedMetaFieldPipeline() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
@@ -387,6 +395,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
         MatcherAssert.assertThat(testEvent.getEvent().getField("foo"), CoreMatchers.nullValue());
     }
 
+    @SuppressWarnings({"unchecked"})
     @Test
     public void moreThan255Parents() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
@@ -440,6 +449,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
         verifyComparison(expected, String.format("[brr] %s [baz]", op), event);
     }
 
+    @SuppressWarnings({"unchecked"})
     private void verifyComparison(final boolean expected, final String conditional,
         final Event event) throws IncompleteSourceWithMetadataException {
         final JrubyEventExtLibrary.RubyEvent testEvent =

--- a/logstash-core/src/test/java/org/logstash/config/ir/EventConditionTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/EventConditionTest.java
@@ -72,7 +72,7 @@ public final class EventConditionTest extends RubyEnvTestCase {
     }
 
     @Test
-    @SuppressWarnings("rawtypes")
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public void testInclusionWithFieldInField() throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
                 IRHelpers.toSourceWithMetadata("input {mockinput{}} filter { " +
@@ -154,6 +154,7 @@ public final class EventConditionTest extends RubyEnvTestCase {
         testConditionWithConstantValue("\"\"", 0);
     }
 
+    @SuppressWarnings({"unchecked"})
     private void testConditionWithConstantValue(String condition, int expectedMatches) throws Exception {
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
                 IRHelpers.toSourceWithMetadata("input {mockinput{}} filter { " +

--- a/x-pack/spec/monitoring/inputs/metrics_spec.rb
+++ b/x-pack/spec/monitoring/inputs/metrics_spec.rb
@@ -2,11 +2,11 @@
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
+require 'spec_helper'
 require "logstash-core"
 require "logstash/agent"
 require "monitoring/inputs/metrics"
 require "rspec/wait"
-require 'spec_helper'
 require "json"
 require "json-schema"
 require 'monitoring/monitoring'


### PR DESCRIPTION
7.x clean backport or #11737