### PR TITLE
Update gradle version to 6.3 (#11742)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,15 @@ WORKDIR /home/logstash
 # used by the purge policy
 LABEL retention="keep"
 
-ADD gradlew /opt/logstash/gradlew
-ADD gradle/wrapper /opt/logstash/gradle/wrapper
-RUN /opt/logstash/gradlew wrapper
+# Setup gradle wrapper. When running any `gradle` command, a `settings.gradle` is expected (and will soon be required).
+# This section adds the gradle wrapper, `settings.gradle` and sets the permissions (setting the user to root for `chown`
+# and working directory to allow this and then reverts back to the previous working directory and user.
+COPY --chown=logstash:logstash gradlew /opt/logstash/gradlew
+COPY --chown=logstash:logstash gradle/wrapper /opt/logstash/gradle/wrapper
+COPY --chown=logstash:logstash settings.gradle /opt/logstash/settings.gradle
+WORKDIR /opt/logstash
+RUN ./gradlew wrapper --warning-mode all
+WORKDIR /home/logstash
 
 ADD versions.yml /opt/logstash/versions.yml
 ADD LICENSE.txt /opt/logstash/LICENSE.txt
@@ -46,7 +52,6 @@ ADD bin /opt/logstash/bin
 ADD modules /opt/logstash/modules
 ADD x-pack /opt/logstash/x-pack
 ADD ci /opt/logstash/ci
-ADD settings.gradle /opt/logstash/settings.gradle
 
 USER root
 RUN rm -rf build && \
@@ -56,4 +61,3 @@ USER logstash
 WORKDIR /opt/logstash
 
 LABEL retention="prune"
-

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ buildscript {
 }
 
 plugins {
-    id "de.undercouch.download" version "3.2.0"
+    id "de.undercouch.download" version "4.0.4"
 }
 
 apply plugin: 'de.undercouch.download'
@@ -45,21 +45,26 @@ allprojects {
 
   apply plugin: 'java'
   apply plugin: 'idea'
+  apply plugin: 'java-library'
 
   project.sourceCompatibility = JavaVersion.VERSION_1_8
   project.targetCompatibility = JavaVersion.VERSION_1_8
 
-  tasks.withType(JavaCompile).all {
+  tasks.withType(JavaCompile).configureEach {
       options.compilerArgs.add("-Xlint:all")
       options.compilerArgs.add("-Xlint:-processing")
       options.compilerArgs.add("-Werror")
   }
 
-  tasks.withType(Javadoc) {
+  tasks.withType(Javadoc).configureEach {
       options.addStringOption("Xwerror", "-quiet")
       if (JavaVersion.current().compareTo(JavaVersion.VERSION_1_9) > 0) {
           options.addBooleanOption("html5", true)
       }
+  }
+
+  tasks.withType(Copy).configureEach {
+      duplicatesStrategy = DuplicatesStrategy.EXCLUDE
   }
 
   clean {
@@ -105,7 +110,7 @@ subprojects {
         }
     }
     dependencies {
-        compile "gradle.plugin.com.github.jk1:gradle-license-report:0.7.1"
+        implementation "gradle.plugin.com.github.jk1:gradle-license-report:0.7.1"
     }
 
     apply plugin: 'com.github.jk1.dependency-license-report'
@@ -427,7 +432,6 @@ task deleteLocalEs(type: Delete) {
 task copyEs(type: Copy, dependsOn: [downloadEs, deleteLocalEs]) {
     from tarTree(resources.gzip(project.ext.elasticsearchDownloadLocation))
     into "./build/"
-
     doLast {
         file("./build/${project.ext.unpackedElasticsearchName}").renameTo('./build/elasticsearch')
         System.out.println "Unzipped ${project.ext.elasticsearchDownloadLocation} to ./build/elasticsearch"

--- a/ci/license_check.sh
+++ b/ci/license_check.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -i
-export GRADLE_OPTS="-Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info -Dfile.encoding=UTF-8"
+export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info -Dfile.encoding=UTF-8"
 
 ./gradlew installDefaultGems
 bin/dependencies-report --csv report.csv

--- a/ci/unit_tests.sh
+++ b/ci/unit_tests.sh
@@ -16,10 +16,10 @@ SELECTED_TEST_SUITE=$1
 
 if [[ $SELECTED_TEST_SUITE == $"java" ]]; then
   echo "Running Java Tests"
-  ./gradlew javaTests --console=plain
+  ./gradlew javaTests --console=plain --warning-mode all
 elif [[ $SELECTED_TEST_SUITE == $"ruby" ]]; then
   echo "Running Ruby unit tests"
-  ./gradlew rubyTests --console=plain
+  ./gradlew rubyTests --console=plain --warning-mode all
 else
   echo "Running Java and Ruby unit tests"
   ./gradlew test --console=plain

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 org.gradle.daemon=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Apr 02 09:48:49 EDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -28,7 +28,7 @@ APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS=""
+DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -14,7 +14,7 @@ set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS=
+set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
 
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome

--- a/logstash-core/benchmarks/build.gradle
+++ b/logstash-core/benchmarks/build.gradle
@@ -38,7 +38,7 @@ buildscript {
   }
   dependencies {
     classpath 'org.yaml:snakeyaml:1.17'
-    classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
+    classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.4'
   }
 }
 
@@ -51,19 +51,17 @@ jar {
 }
 
 ext {
-  jmh = 1.18
+  jmh = 1.22
 }
 
 dependencies {
-  compile project(':logstash-core')
-  compile "org.openjdk.jmh:jmh-core:$jmh"
-  compile "org.openjdk.jmh:jmh-generator-annprocess:$jmh"
-  compile "org.openjdk.jmh:jmh-core-benchmarks:$jmh"
-  compile 'net.sf.jopt-simple:jopt-simple:5.0.3'
-  compile 'com.google.guava:guava:21.0'
-  compile 'commons-io:commons-io:2.5'
-  runtime 'joda-time:joda-time:2.8.2'
-  compile "org.jruby:jruby-core:$jrubyVersion"
+  implementation project(':logstash-core')
+  implementation "org.openjdk.jmh:jmh-core:$jmh"
+  annotationProcessor "org.openjdk.jmh:jmh-generator-annprocess:$jmh"
+  implementation 'com.google.guava:guava:21.0'
+  implementation 'commons-io:commons-io:2.5'
+  runtimeOnly 'joda-time:joda-time:2.8.2'
+  api "org.jruby:jruby-core:$jrubyVersion"
 }
 
 javadoc {
@@ -73,9 +71,9 @@ javadoc {
 apply plugin: 'com.github.johnrengelman.shadow'
 
 shadowJar {
-  baseName = 'logstash-core-benchmarks-all'
-  classifier = null
-  version = null
+  archiveBaseName = 'logstash-core-benchmarks-all'
+  archiveClassifier = null
+  archiveVersion = ''
 }
 
 task jmh(type: JavaExec, dependsOn: [':logstash-core-benchmarks:clean', ':logstash-core-benchmarks:shadowJar']) {
@@ -87,7 +85,7 @@ task jmh(type: JavaExec, dependsOn: [':logstash-core-benchmarks:clean', ':logsta
   doFirst {
     args = [
             "-Djava.io.tmpdir=${buildDir.absolutePath}",
-            "-XX:+UseParNewGC", "-XX:+UseConcMarkSweepGC", "-XX:CMSInitiatingOccupancyFraction=75",
+            "-XX:+UseConcMarkSweepGC", "-XX:CMSInitiatingOccupancyFraction=75",
             "-XX:+UseCMSInitiatingOccupancyOnly", "-XX:+DisableExplicitGC",
             "-XX:+HeapDumpOnOutOfMemoryError", "-Xms2g", "-Xmx2g",
             shadowJar.archivePath,

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -45,19 +45,19 @@ buildscript {
 
 task sourcesJar(type: Jar, dependsOn: classes) {
     from sourceSets.main.allSource
-    classifier 'sources'
-    extension 'jar'
+    archiveClassifier = 'sources'
+    archiveExtension = 'jar'
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
-    classifier 'javadoc'
-    extension 'jar'
+    archiveClassifier = 'javadoc'
+    archiveExtension = 'jar'
 }
 
 task copyRuntimeLibs(type: Copy) {
     into project.file('lib/jars/')
-    from configurations.compile, configurations.runtime
+    from configurations.compileClasspath, configurations.runtimeClasspath
 }
 
 // copy jar file into the gem lib dir but without the version number in filename
@@ -148,35 +148,36 @@ def customJRubyDir = project.hasProperty("custom.jruby.path") ? project.property
 def customJRubyVersion = customJRubyDir == "" ? "" : Files.readAllLines(Paths.get(customJRubyDir, "VERSION")).get(0).trim()
 
 dependencies {
-    compile 'org.apache.logging.log4j:log4j-api:2.12.1'
-    compile 'org.apache.logging.log4j:log4j-core:2.12.1'
-    runtime 'org.apache.logging.log4j:log4j-slf4j-impl:2.12.1'
-    compile('org.reflections:reflections:0.9.11') {
+    implementation 'org.apache.logging.log4j:log4j-api:2.12.1'
+    annotationProcessor 'org.apache.logging.log4j:log4j-core:2.12.1'
+    api 'org.apache.logging.log4j:log4j-core:2.12.1'
+    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.12.1'
+    implementation('org.reflections:reflections:0.9.11') {
         exclude group: 'com.google.guava', module: 'guava'
     }
-    compile 'commons-codec:commons-codec:1.13'
+    implementation 'commons-codec:commons-codec:1.13'
     // Jackson version moved to versions.yml in the project root (the JrJackson version is there too)
-    compile "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
-    compile "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
-    compile "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
-    compile 'org.codehaus.janino:janino:3.1.0'
-    compile "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jacksonVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
+    api "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
+    api "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+    implementation 'org.codehaus.janino:janino:3.1.0'
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jacksonVersion}"
     if (customJRubyDir == "") {
-        compile "org.jruby:jruby-complete:${jrubyVersion}"
+        api "org.jruby:jruby-complete:${jrubyVersion}"
     } else {
-        compile files(customJRubyDir + "/maven/jruby-complete/target/jruby-complete-${customJRubyVersion}.jar")
+        api files(customJRubyDir + "/maven/jruby-complete/target/jruby-complete-${customJRubyVersion}.jar")
     }
-    compile group: 'com.google.guava', name: 'guava', version: '22.0'
+    implementation group: 'com.google.guava', name: 'guava', version: '22.0'
     // WARNING: DO NOT UPGRADE "google-java-format"
     // later versions require GPL licensed code in javac-shaded that is
     // Apache2 incompatible
-    compile('com.google.googlejavaformat:google-java-format:1.1') {
+    implementation('com.google.googlejavaformat:google-java-format:1.1') {
         exclude group: 'com.google.guava', module: 'guava'
     }
-    compile 'org.javassist:javassist:3.26.0-GA'
-    testCompile 'org.apache.logging.log4j:log4j-core:2.12.1:tests'
-    testCompile 'junit:junit:4.12'
-    testCompile 'net.javacrumbs.json-unit:json-unit:2.3.0'
-    testCompile 'org.elasticsearch:securemock:1.2'
-    testCompile 'org.assertj:assertj-core:3.11.1'
+    implementation 'org.javassist:javassist:3.26.0-GA'
+    testImplementation 'org.apache.logging.log4j:log4j-core:2.12.1:tests'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'net.javacrumbs.json-unit:json-unit:2.3.0'
+    testImplementation 'org.elasticsearch:securemock:1.2'
+    testImplementation 'org.assertj:assertj-core:3.11.1'
 }

--- a/qa/integration/build.gradle
+++ b/qa/integration/build.gradle
@@ -30,9 +30,9 @@ buildscript {
 }
 
 dependencies {
-  testCompile project(':logstash-core')
-  testCompile 'org.assertj:assertj-core:3.8.0'
-  testCompile 'junit:junit:4.12'
+  testImplementation project(':logstash-core')
+  testImplementation 'org.assertj:assertj-core:3.8.0'
+  testImplementation 'junit:junit:4.12'
 }
 
 test {

--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -24,7 +24,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.yaml:snakeyaml:1.23'
-        classpath "de.undercouch:gradle-download-task:3.2.0"
+        classpath "de.undercouch:gradle-download-task:4.0.4"
         classpath "org.jruby:jruby-complete:9.2.11.1"
     }
 }
@@ -41,6 +41,7 @@ import org.jruby.embed.ScriptingContainer
 import java.lang.annotation.Annotation
 import java.nio.file.Files
 import java.nio.file.Paths
+
 
 ext {
     bundle = this.&bundle

--- a/tools/benchmark-cli/build.gradle
+++ b/tools/benchmark-cli/build.gradle
@@ -37,7 +37,7 @@ buildscript {
   }
   dependencies {
     classpath 'org.yaml:snakeyaml:1.17'
-    classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
+    classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.4'
   }
 }
 
@@ -47,17 +47,17 @@ ext {
 }
 
 dependencies {
-  compile 'net.sf.jopt-simple:jopt-simple:5.0.3'
-  compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'
-  compile group: 'org.apache.commons', name: 'commons-compress', version: '1.14'
-  compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.6'
-  compile group: 'commons-io', name: 'commons-io', version: '2.5'
-  compile 'com.fasterxml.jackson.core:jackson-core:2.7.4'
-  compile 'com.fasterxml.jackson.core:jackson-databind:2.7.4'
-  compile group: 'org.elasticsearch.client', name: 'rest', version: elasticsearch
-  compile "org.openjdk.jmh:jmh-core:$jmh"
-  testCompile group: 'com.github.tomakehurst', name: 'wiremock-standalone', version: '2.6.0'
-  testCompile "junit:junit:4.12"
+  implementation 'net.sf.jopt-simple:jopt-simple:5.0.3'
+  implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'
+  implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.14'
+  implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.6'
+  implementation group: 'commons-io', name: 'commons-io', version: '2.5'
+  implementation 'com.fasterxml.jackson.core:jackson-core:2.7.4'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.7.4'
+  implementation group: 'org.elasticsearch.client', name: 'rest', version: elasticsearch
+  implementation "org.openjdk.jmh:jmh-core:$jmh"
+  testImplementation group: 'com.github.tomakehurst', name: 'wiremock-standalone', version: '2.6.0'
+  testImplementation "junit:junit:4.12"
 }
 
 javadoc {
@@ -75,9 +75,9 @@ test {
 apply plugin: 'com.github.johnrengelman.shadow'
 
 shadowJar {
-  baseName = 'benchmark-cli'
-  classifier = null
-  version = null
+  archiveBaseName = 'benchmark-cli'
+  archiveClassifier = null
+  archiveVersion = ''
 }
 
 assemble.dependsOn shadowJar

--- a/tools/dependencies-report/build.gradle
+++ b/tools/dependencies-report/build.gradle
@@ -38,17 +38,17 @@ buildscript {
   }
   dependencies {
     classpath 'org.yaml:snakeyaml:1.17'
-    classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
+    classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.4'
   }
 }
 
 dependencies {
-  compile 'commons-io:commons-io:2.6'
-  compile 'org.apache.commons:commons-csv:1.5'
-  compile "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
-  compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
-  compile "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
-  testCompile 'junit:junit:4.12'
+  implementation 'commons-io:commons-io:2.6'
+  implementation 'org.apache.commons:commons-csv:1.5'
+  implementation "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
+  implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+  implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+  testImplementation 'junit:junit:4.12'
 }
 
 javadoc {
@@ -64,9 +64,9 @@ test {
 apply plugin: 'com.github.johnrengelman.shadow'
 
 shadowJar {
-  baseName = 'dependencies-report'
-  classifier = null
-  version = null
+  archiveBaseName = 'dependencies-report'
+  archiveClassifier = null
+  archiveVersion = ''
 }
 
 assemble.dependsOn shadowJar

--- a/tools/ingest-converter/build.gradle
+++ b/tools/ingest-converter/build.gradle
@@ -37,14 +37,14 @@ buildscript {
   }
   dependencies {
     classpath 'org.yaml:snakeyaml:1.17'
-    classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
+    classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.4'
   }
 }
 
 dependencies {
-  compile 'net.sf.jopt-simple:jopt-simple:5.0.3'
-  testCompile "junit:junit:4.12"
-  testCompile 'commons-io:commons-io:2.5'
+  implementation 'net.sf.jopt-simple:jopt-simple:4.6'
+  testImplementation "junit:junit:4.12"
+  testImplementation 'commons-io:commons-io:2.5'
 }
 
 javadoc {
@@ -54,9 +54,9 @@ javadoc {
 apply plugin: 'com.github.johnrengelman.shadow'
 
 shadowJar {
-  baseName = 'ingest-converter'
-  classifier = null
-  version = null
+  archiveBaseName = 'ingest-converter'
+  archiveClassifier = null
+  archiveVersion = ''
 }
 
 assemble.dependsOn shadowJar

--- a/x-pack/build.gradle
+++ b/x-pack/build.gradle
@@ -17,9 +17,9 @@ buildscript {
 }
 
 dependencies {
-  testCompile project(':logstash-core')
-  testCompile 'org.assertj:assertj-core:3.8.0'
-  testCompile 'junit:junit:4.12'
+  testImplementation project(':logstash-core')
+  testImplementation 'org.assertj:assertj-core:3.8.0'
+  testImplementation 'junit:junit:4.12'
 }
 
 test {


### PR DESCRIPTION
* Backport of #11742. Not a clean backport as `7.x` had not previously been upgraded to `5.6.4` as `master` had been.

* Update gradle version to 6.3

Gradle versions prior to 6.3 cannot run under JDK14.
This commit upgrades the version of Gradle to 6.3, and removes all deprecation warnings that can currently be removed.

Changes include:
* Increase gradle memory to 2g
* Increase gradle memory in the license check job to 2g
* Replace use of `testCompile`
* Replace `runtime` with `runtimeOnly`
* Remove`compile` depedencies from gradle files
* Replace deprecated archive methods
* Fix dependencies report build
* Make jruby dependencies 'api', fix archiveVersion
* Set `duplicatesStrategy` for all tasks of type Copy
* Use `configureEach` for global 'withType' calls
** Use the recommended Tasks API calls
(https://blog.gradle.org/preview-avoiding-task-configuration-time)
* Run `./gradlew wrapper` earlier to improve caching
* Use copy with chown for resources that need to be run during `./gradlew wrapper`