### PR TITLE
use same jackson version in benchmark-cli

### DIFF
--- a/tools/benchmark-cli/build.gradle
+++ b/tools/benchmark-cli/build.gradle
@@ -24,6 +24,8 @@ def versionMap = (Map) (new Yaml()).load(new File("$projectDir/../../versions.ym
 
 description = """Logstash End to End Benchmarking Utility"""
 version = versionMap['logstash-core']
+String jacksonVersion = versionMap['jackson']
+String jacksonDatabindVersion = versionMap['jackson-databind']
 
 repositories {
   mavenCentral()
@@ -52,8 +54,8 @@ dependencies {
   implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.14'
   implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.6'
   implementation group: 'commons-io', name: 'commons-io', version: '2.5'
-  implementation 'com.fasterxml.jackson.core:jackson-core:2.7.4'
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.7.4'
+  implementation "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
+  api "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
   implementation group: 'org.elasticsearch.client', name: 'rest', version: elasticsearch
   implementation "org.openjdk.jmh:jmh-core:$jmh"
   testImplementation group: 'com.github.tomakehurst', name: 'wiremock-standalone', version: '2.6.0'

--- a/tools/benchmark-cli/build.gradle
+++ b/tools/benchmark-cli/build.gradle
@@ -44,16 +44,16 @@ buildscript {
 }
 
 ext {
-  jmh = '1.18'
-  elasticsearch = '5.5.0'
+  jmh = '1.23'
+  elasticsearch = '5.5.3'
 }
 
 dependencies {
   implementation 'net.sf.jopt-simple:jopt-simple:5.0.3'
   implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'
-  implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.14'
-  implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.6'
-  implementation group: 'commons-io', name: 'commons-io', version: '2.5'
+  implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.20'
+  implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
+  implementation group: 'commons-io', name: 'commons-io', version: '2.6'
   implementation "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
   api "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
   implementation group: 'org.elasticsearch.client', name: 'rest', version: elasticsearch


### PR DESCRIPTION
use same jackson version in benchmark-cli
update benchmark cli dependencies