### PR TITLE
Make release notes script add version in plugin entries

### DIFF
--- a/tools/release/generate_release_notes.rb
+++ b/tools/release/generate_release_notes.rb
@@ -87,7 +87,7 @@ report << "==== Plugins\n"
 
 plugin_changes.each do |plugin, versions|
   _, type, name = plugin.split("-")
-  header = "*#{name.capitalize} #{type.capitalize}*"
+  header = "*#{name.capitalize} #{type.capitalize} - #{versions.last}*"
   start_changelog_file = Tempfile.new(plugin + 'start')
   end_changelog_file = Tempfile.new(plugin + 'end')
   changelog = `curl https://raw.githubusercontent.com/logstash-plugins/#{plugin}/v#{versions.last}/CHANGELOG.md`.split("\n")


### PR DESCRIPTION
Resulting output example:

```md
==== Plugins

*Grok Filter - 4.3.0*

*  Added: added target support [#156](https://github.com/logstash-plugins/logstash-filter-grok/pull/156)

*Xml Filter - 4.1.0*

* Feat: added parser_options for more control over XML parsing [#68](https://github.com/logstash-plugins/logstash-filter-xml/pull/68)
```

resolves #11759 