### PR TITLE
[Doc]Note that unit qualifier is required for config.reload.interval

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -86,6 +86,9 @@ pipeline.ordered: auto
 # config.reload.automatic: false
 #
 # How often to check if the pipeline configuration has changed (in seconds)
+# Note that the unit value (s) is required. Values without a qualifier (e.g. 60) 
+# are treated as nanoseconds.
+# Setting the interval this way is not recommended and might change in later versions.
 #
 # config.reload.interval: 3s
 #

--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -249,6 +249,7 @@ Changes to Logstash Core are plugin agnostic.
 
 * The setting `config.reload.interval` has been changed to use time value strings such as `5m`, `10s` etc.
   Previously, users had to convert this to a millisecond time value themselves.
+  Note that the unit qualifier (`s`) is required.
 
 [float]
 ===== RPM/Deb package changes

--- a/docs/static/reloading-config.asciidoc
+++ b/docs/static/reloading-config.asciidoc
@@ -16,7 +16,9 @@ in configuration settings from the command-line.
 
 By default, Logstash checks for configuration changes every 3 seconds. To change this interval,
 use the `--config.reload.interval <interval>` option,  where `interval` specifies how often Logstash
-checks the config files for changes (in seconds).
+checks the config files for changes (in seconds). 
+
+Note that the unit qualifier (`s`) is required.
 
 [[force-reload]]
 ==== Force reloading the config file

--- a/docs/static/running-logstash-command-line.asciidoc
+++ b/docs/static/running-logstash-command-line.asciidoc
@@ -209,6 +209,7 @@ With this command, Logstash concatenates three config files, `/tmp/one`, `/tmp/t
 
 *`--config.reload.interval RELOAD_INTERVAL`*::
   How frequently to poll the configuration location for changes. The default value is "3s".
+  Note that the unit qualifier (`s`) is required.
 
 *`--http.host HTTP_HOST`*::
   Web API binding host. This option specifies the bind address for the metrics REST endpoint. The default is "127.0.0.1".

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -157,7 +157,7 @@ guaranteed, but you save the processing cost of preserving order.
 | `false`
 
 | `config.reload.interval`
-| How often in seconds Logstash checks the config files for changes.
+| How often in seconds Logstash checks the config files for changes. Note that the unit qualifier (`s`) is required.
 | `3s`
 
 | `config.debug`


### PR DESCRIPTION
Alert users that `s` is a required part of the value. If seconds `s` is not specified, nanoseconds is assumed.  

**DOC PREVIEWS:**
* http://logstash_11771.docs-preview.app.elstc.co/guide/en/logstash/master/breaking-6.0.html
* http://logstash_11771.docs-preview.app.elstc.co/guide/en/logstash/master/logstash-settings-file.html
* http://logstash_11771.docs-preview.app.elstc.co/guide/en/logstash/master/reloading-config.html
* http://logstash_11771.docs-preview.app.elstc.co/guide/en/logstash/master/running-logstash-command-line.html
