### PR TITLE
performance: share a single secret store (7.7. backport of #10794)

### DIFF
--- a/logstash-core/lib/logstash/util/lazy_singleton.rb
+++ b/logstash-core/lib/logstash/util/lazy_singleton.rb
@@ -1,0 +1,33 @@
+require 'thread' # Mutex
+
+# A [LazySingleton] wraps the result of the provided block,
+# which is guaranteed to be called at-most-once, even if the
+# block's return value is nil.
+class ::LogStash::Util::LazySingleton
+
+  def initialize(&block)
+    @mutex = Mutex.new
+    @block = block
+    @instantiated = false
+  end
+
+  def instance
+    unless @instantiated
+      @mutex.synchronize do
+        unless @instantiated
+          @instance = @block.call
+          @instantiated = true
+        end
+      end
+    end
+
+    return @instance
+  end
+
+  def reset!
+    @mutex.synchronize do
+      @instantiated = false
+      @instance = nil
+    end
+  end
+end

--- a/logstash-core/spec/logstash/settings_spec.rb
+++ b/logstash-core/spec/logstash/settings_spec.rb
@@ -174,6 +174,11 @@ describe LogStash::Settings do
 
     before :each do
       LogStash::SETTINGS.set("keystore.file", File.join(File.dirname(__FILE__), "../../src/test/resources/logstash.keystore.with.default.pass"))
+      LogStash::Util::SubstitutionVariables.send(:reset_secret_store)
+    end
+
+    after(:each) do
+      LogStash::Util::SubstitutionVariables.send(:reset_secret_store)
     end
 
     context "placeholders in flat logstash.yml" do
@@ -227,6 +232,7 @@ describe LogStash::Settings do
 
     before :each do
       LogStash::SETTINGS.set("keystore.file", File.join(File.dirname(__FILE__), "../../src/test/resources/logstash.keystore.with.default.pass"))
+      LogStash::Util::SubstitutionVariables.send(:reset_secret_store)
     end
 
     before do
@@ -239,6 +245,10 @@ describe LogStash::Settings do
       ENV.delete('lsspecdomain_env')
       ENV.delete('lsspecdomain2_env')
       ENV.delete('a')
+    end
+
+    after(:each) do
+      LogStash::Util::SubstitutionVariables.send(:reset_secret_store)
     end
 
     subject do


### PR DESCRIPTION
Loading a Java Keystore can take anywhere from ~0.3s to upwards of 3s, so the
pattern of loading one per variable we need to replace adds a significant
amount of overhead on pipelines that use these variables, whether or not they
are provided by the keystore.

By providing a private, constant, lazy singleton, we ensure that we don't
incur the cost of repeatedly building the keystore.