### PR TITLE
Remove separator vertices and associated edges from serialized output

### DIFF
--- a/logstash-core/lib/logstash/config/lir_serializer.rb
+++ b/logstash-core/lib/logstash/config/lir_serializer.rb
@@ -121,7 +121,11 @@ module LogStash;
       edges.each do |e|
         if vertex_type(e.to) == :separator
           e.to.getOutgoingEdges.each do |outgoing|
-            edges_with_separators_removed << edge(org.logstash.config.ir.graph.PlainEdge.new(e.from, outgoing.to))
+            if e.java_kind_of?(org.logstash.config.ir.graph.BooleanEdge)
+              edges_with_separators_removed << edge(org.logstash.config.ir.graph.BooleanEdge.new(e.edgeType, e.from, outgoing.to))
+            else
+              edges_with_separators_removed << edge(org.logstash.config.ir.graph.PlainEdge.factory.make(e.from, outgoing.to))
+            end
           end
         elsif vertex_type(e.from) == :separator
           # Skip the edges coming from the 'from' separator

--- a/x-pack/spec/monitoring/inputs/metrics/state_event/lir_serializer_spec.rb
+++ b/x-pack/spec/monitoring/inputs/metrics/state_event/lir_serializer_spec.rb
@@ -10,7 +10,7 @@ describe ::LogStash::Config::LIRSerializer do
     <<-EOC
       input { fake_input {} }
       filter { 
-        if ([foo] > 2) {
+        if ([foo] < 2) {
           fake_filter {} 
         }
       }


### PR DESCRIPTION
The separator vertices are an implementation detail of the serialized
output of the LIR, and are not meaningful to the pipeline viewer.

This commit removes the separator vertices, and reworks the edges to
account for this.