### PR TITLE
[doc] Change plugin name from java_sink to sink

### DIFF
--- a/docs/static/core-plugins/outputs/java_sink.asciidoc
+++ b/docs/static/core-plugins/outputs/java_sink.asciidoc
@@ -1,4 +1,4 @@
-:plugin: java_sink
+:plugin: sink
 :type: output
 :default_codec!:
 
@@ -12,7 +12,7 @@ END - REPLACES GENERATED VARIABLES
 
 [id="plugins-{type}s-{plugin}"]
 
-=== Java_sink output plugin
+=== Sink output plugin
 
 include::{include_path}/plugin_header-core.asciidoc[]
 
@@ -22,7 +22,7 @@ An event sink that discards any events received. Generally useful for testing th
 and filters.
 
 [id="plugins-{type}s-{plugin}-options"]
-==== Java_sink Output Configuration Options
+==== Sink Output Configuration Options
 
 There are no special configuration options for this plugin,
 but it does support the <<plugins-{type}s-{plugin}-common-options>>.


### PR DESCRIPTION
In the docs templating, the plugin name is used to autogenerate a code example of how
to configure specific plugin. As such, if a plugin name is different from how you
configure it, this results in an example of how to configure this plugin with an
incorrect name.

This changes the java_sink plugin name to sink to correctly autogenerate the example.

Fixes: #11675, Fixes: #11214