### PR TITLE
Update logstash.asciidoc (Remove double "the")

### DIFF
--- a/docs/static/security/logstash.asciidoc
+++ b/docs/static/security/logstash.asciidoc
@@ -35,7 +35,7 @@ and write and delete documents in the indices it creates.
 
 To set up authentication credentials for Logstash:
 
-. Use the the **Management > Roles** UI in {kib} or the `role` API to create a
+. Use the **Management > Roles** UI in {kib} or the `role` API to create a
 `logstash_writer` role. For *cluster* privileges, add `manage_index_templates` and `monitor`. 
 For *indices* privileges, add `write`, `create`, `delete`, and `create_index`.
 +


### PR DESCRIPTION
Remove double "the" at line 38 "Use the the Management > Roles ..."