### PR TITLE
Rework monitoring to avoid using deprecated `getSystemCpuLoad` method…

### DIFF
--- a/logstash-core/src/main/java/org/logstash/LogstashJavaCompat.java
+++ b/logstash-core/src/main/java/org/logstash/LogstashJavaCompat.java
@@ -97,7 +97,7 @@ public final class LogstashJavaCompat {
      * @return True if running on Java whose major version is greater than or equal to the
      *         specified version.
      */
-    public static boolean isJavaAtLeast(int version){
+    public static boolean isJavaAtLeast(int version) {
         final String value = System.getProperty("java.specification.version");
         final int actualVersion;
         // Java specification version prior to Java 9 were of the format `1.X`, and after the format `X`

--- a/logstash-core/src/main/java/org/logstash/LogstashJavaCompat.java
+++ b/logstash-core/src/main/java/org/logstash/LogstashJavaCompat.java
@@ -90,4 +90,23 @@ public final class LogstashJavaCompat {
         final int end = version.indexOf('.');
         return Integer.parseInt(version.substring(0, end > 0 ? end : version.length())) >= 9;
     }
+
+    /**
+     * Identifies whether we are running on a versiongreater than or equal to the version parameter specified.
+     * @param version The version to test against. This must be the Major version of Java
+     * @return True if running on Java whose major version is greater than or equal to the
+     *         specified version.
+     */
+    public static boolean isJavaAtLeast(int version){
+        final String value = System.getProperty("java.specification.version");
+        final int actualVersion;
+        // Java specification version prior to Java 9 were of the format `1.X`, and after the format `X`
+        // See https://openjdk.java.net/jeps/223
+        if (value.startsWith("1.")) {
+            actualVersion = Integer.parseInt(value.split("\\.")[1]);
+        } else {
+            actualVersion = Integer.parseInt(value);
+        }
+        return actualVersion >= version;
+    }
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/monitors/ProcessMonitor.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/monitors/ProcessMonitor.java
@@ -28,12 +28,16 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.logstash.Logstash;
 import org.logstash.LogstashJavaCompat;
 
 public class ProcessMonitor {
 
     private static final OperatingSystemMXBean osMxBean = ManagementFactory.getOperatingSystemMXBean();
     private static final Method CPU_LOAD_METHOD = getCpuLoadMethod();
+    private static final Logger LOGGER = LogManager.getLogger(ProcessMonitor.class);
 
     public static class Report {
         private long memTotalVirtualInBytes = -1;
@@ -97,7 +101,7 @@ public class ProcessMonitor {
         // The method `getSystemCpuLoad` is deprecated in favour of `getCpuLoad` since JDK14
         // This method uses reflection to use the correct method depending on the version of
         // the JDK being used.
-        private short getSystemCpuLoad(){
+        private short getSystemCpuLoad() {
             if (CPU_LOAD_METHOD == null){
                 return -1;
             }
@@ -118,6 +122,7 @@ public class ProcessMonitor {
             String methodName = (LogstashJavaCompat.isJavaAtLeast(14)) ? "getCpuLoad" : "getSystemCpuLoad";
             return Class.forName("com.sun.management.OperatingSystemMXBean").getMethod(methodName);
         } catch (ReflectiveOperationException e){
+            LOGGER.warn("OperatingSystemMXBean CPU load method not available, CPU load will not be measured", e);
             return null;
         }
     }


### PR DESCRIPTION
… with JDK14

JDK14 prefers the use of `getCpuLoad` over `getSystemCpuLoad`. This commit
reworks the call to use reflection to use the appropriate method call
depending on the version of the JDK being used.