### PR TITLE
[Doc]Add redirects page

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -272,6 +272,8 @@ include::static/breaking-changes.asciidoc[]
 
 // Release Notes
 
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/releasenotes.asciidoc
+:edit_url!:
 include::static/releasenotes.asciidoc[]
 
+:edit_url:
+include::static/redirects.asciidoc[]

--- a/docs/static/redirects.asciidoc
+++ b/docs/static/redirects.asciidoc
@@ -1,0 +1,5 @@
+["appendix",role="exclude",id="redirects"]
+= Deleted pages
+
+The following pages have moved or been deleted.
+


### PR DESCRIPTION
Adds a redirects page to help prevent broken links and to make fixing them easier and quicker. The page is coded so that it won't appear in the Table of Contents.

**PREVIEW:** http://logstash_11790.docs-preview.app.elstc.co/guide/en/logstash/master/redirects.html