### PR TITLE
Performance: improve event.clone memory usage

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Cloner.java
+++ b/logstash-core/src/main/java/org/logstash/Cloner.java
@@ -42,7 +42,8 @@ public final class Cloner {
         } else if (input instanceof List<?>) {
             return (T) deepList((List<?>) input);
         } else if (input instanceof RubyString) {
-            return (T) ((RubyString) input).doClone();
+            // new instance but sharing ByteList (until either String is modified)
+            return (T) ((RubyString) input).dup();
         } else if (input instanceof Collection<?>) {
             throw new ClassCastException("unexpected Collection type " + input.getClass());
         }

--- a/logstash-core/src/test/java/org/logstash/ClonerTest.java
+++ b/logstash-core/src/test/java/org/logstash/ClonerTest.java
@@ -21,6 +21,9 @@
 package org.logstash;
 
 import org.jruby.RubyString;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.ByteList;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -33,14 +36,61 @@ public class ClonerTest {
 
         RubyString result = Cloner.deep(original);
         // Check object identity
-        assertTrue(result != original);
-
-        // Check different underlying bytes
-        assertTrue(result.getByteList() != original.getByteList());
-
+        assertNotSame(original, result);
         // Check string equality
-        assertEquals(result, original);
+        assertEquals(original, result);
 
         assertEquals(javaString, result.asJavaString());
+    }
+
+    @Test
+    public void testRubyStringCloningAndAppend() {
+        String javaString = "fooBar";
+        RubyString original = RubyString.newString(RubyUtil.RUBY, javaString);
+
+        RubyString result = Cloner.deep(original);
+
+        result.append(RubyUtil.RUBY.newString("X"));
+
+        assertNotEquals(result, original);
+
+        ThreadContext context = RubyUtil.RUBY.getCurrentContext();
+        assertTrue(original.op_equal(context, RubyString.newString(RubyUtil.RUBY, javaString)).isTrue());
+        assertEquals(javaString, original.asJavaString());
+    }
+
+    @Test
+    public void testRubyStringCloningAndChangeOriginal() {
+        String javaString = "fooBar";
+        RubyString original = RubyString.newString(RubyUtil.RUBY, javaString);
+
+        RubyString result = Cloner.deep(original);
+
+        ThreadContext context = RubyUtil.RUBY.getCurrentContext();
+        IRubyObject index = RubyUtil.RUBY.newFixnum(5);
+        original.op_aset(context, index, RubyUtil.RUBY.newString("z")); // original[5] = 'z'
+
+        assertNotEquals(result, original);
+
+        assertTrue(result.op_equal(context, RubyString.newString(RubyUtil.RUBY, javaString)).isTrue());
+        assertEquals(javaString, result.asJavaString());
+        assertEquals("fooBaz", original.asJavaString());
+    }
+
+    @Test // @Tag("Performance Optimization")
+    public void testRubyStringCloningMemoryOptimization() {
+        ByteList bytes = ByteList.create("0123456789");
+        RubyString original = RubyString.newString(RubyUtil.RUBY, bytes);
+
+        RubyString result = Cloner.deep(original);
+        assertNotSame(original, result);
+
+        assertSame(bytes, original.getByteList());
+        // NOTE: this is an implementation detail or the underlying sharing :
+        assertSame(bytes, result.getByteList()); // bytes-list shared
+
+        // but when string is modified it will stop using the same byte container
+        result.concat(RubyUtil.RUBY.getCurrentContext(), RubyUtil.RUBY.newString(" "));
+        assertNotSame(bytes, result.getByteList()); // byte-list copied on write
     }
 }


### PR DESCRIPTION
by doing copy-on-write strings when deep cloning

this is motivated "big" events reaching plugins such as split
which might produce several new events out of a single one ...

did a naive test using `LS_JAVA_OPTS="-Xms300m -Xmx300m"` with a JSON event prototype:
```ruby
input {
  generator {
    message => '
{ "data":
  [{"type": "articles",
    "id": "1",
    "attributes": {
      "title": "JSON:API paints my bikeshed!",
      "body": "The shortest article. Ever. Well maybe not, but still quite short ... 01234567890",
      "created": "2015-05-22T14:56:29.000Z",
      "updated": "2015-05-22T14:56:28.000Z"
    }
  },
  {"type": "articles",
    "id": "2",
    "attributes": {
      "title": "2JSON:API paints my bikeshed!",
      "body": "The shortest article. Ever.",
      "created": "2015-05-22T14:56:29.000Z",
      "updated": "2015-05-22T14:56:28.000Z"
    }
  },
  {"type": "articles",
    "id": "3",
    "attributes": {
      "title": "3JSON:API paints my bikeshed!",
      "body": "The shortest article. Ever.",
      "created": "2015-05-22T14:56:29.000Z",
      "updated": "2015-05-22T14:56:28.000Z"
    }
  },
  {"type": "articles",
    "id": "4",
    "attributes": {
      "title": "4JSON:API paints my bikeshed!",
      "body": "              ",
      "created": "2015-05-22T14:56:29.000Z",
      "updated": "2015-05-22T14:56:28.000Z"
    }
  },
  {"type": "articles",
    "id": "5",
    "attributes": {
      "title": "55555",
      "body": "a body - a body - a body - a body - a body",
      "created": "2015-05-22T14:56:29.000Z",
      "updated": "2015-05-22T14:56:28.000Z"
    }
  }
  ]
}
'
    codec => 'json'
    count => 1800
  }
}

filter {
  mutate { copy => { "sequence" => "[data][0][sequence]" } }
  mutate { copy => { "sequence" => "[data][1][sequence]" } }
  mutate { copy => { "sequence" => "[data][2][sequence]" } }
  mutate { copy => { "sequence" => "[data][3][sequence]" } }
  mutate { copy => { "sequence" => "[data][4][sequence]" } }
  split {
    field => 'data' # each event -> 5 clones
    target => 'json1_data'
  }
  split {
    field => 'data' # each event -> 5 clones
    target => 'json2_data'
  }
  split {
    field => 'data' # each event -> 5 clones
    target => 'json3_data'
  }
}
```

(1) `doClone` is getting out-of-memory spliting ~ **850-th event** (after 5:30 minutes)
(1) `strDup` COW is getting stuck ~ **1550-th event** (after 6:00 minutes)

The setup is very artificial but serves well and was motivated by a real-world scenario which was actually way more "agressive" - spliting on an array with 100s of elements (here we only have 5).