### PR TITLE
update the filter list options

### DIFF
--- a/docs/static/plugin-manager.asciidoc
+++ b/docs/static/plugin-manager.asciidoc
@@ -56,7 +56,7 @@ available in your deployment:
 ----------------------------------
 bin/logstash-plugin list <1>
 bin/logstash-plugin list --verbose <2>
-bin/logstash-plugin list '*namefragment*' <3>
+bin/logstash-plugin list '.*namefragment.*' <3>
 bin/logstash-plugin list --group output <4>
 ----------------------------------
 <1> Will list all installed plugins


### PR DESCRIPTION
As the following command accepts a regex, i.e. logstash-plugin list '*namefragment*', added '.' to indicate any character. Without this it gives error. Hence, the new command syntax is logstash-plugin list '.*namefragment.*'