### PR TITLE
add proxy support (central management & monitoring)

### DIFF
--- a/docs/static/settings/configuration-management-settings.asciidoc
+++ b/docs/static/settings/configuration-management-settings.asciidoc
@@ -56,6 +56,11 @@ authenticate for accessing the configuration data.
 The username you specify here should have the `logstash_admin` role, which
 provides access to `.logstash-*` indices for managing configurations.
 
+`xpack.management.elasticsearch.proxy`::
+
+Optional setting that allows you to specify a proxy URL if Logstash needs to use a proxy
+to reach your Elasticsearch cluster.
+
 `xpack.management.elasticsearch.ssl.certificate_authority`::
 
 Optional setting that enables you to specify a path to the `.pem` file for the

--- a/docs/static/settings/monitoring-settings.asciidoc
+++ b/docs/static/settings/monitoring-settings.asciidoc
@@ -38,6 +38,10 @@ If your {es} is protected with basic authentication, these settings provide the
 username and password that the Logstash instance uses to authenticate for
 shipping monitoring data.
 
+`monitoring.elasticsearch.proxy`::
+
+Optional setting that allows you to specify a proxy URL if Logstash needs to use a proxy
+to reach your Elasticsearch cluster.
 
 [[monitoring-collection-settings]]
 ===== Monitoring collection settings

--- a/x-pack/lib/config_management/extension.rb
+++ b/x-pack/lib/config_management/extension.rb
@@ -29,6 +29,7 @@ module LogStash
         settings.register(LogStash::Setting::ArrayCoercible.new("xpack.management.elasticsearch.hosts", String, [ "https://localhost:9200" ] ))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.cloud_id"))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.cloud_auth"))
+        settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.proxy"))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.ssl.certificate_authority"))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.ssl.truststore.path"))
         settings.register(LogStash::Setting::NullableString.new("xpack.management.elasticsearch.ssl.truststore.password"))

--- a/x-pack/lib/helpers/elasticsearch_options.rb
+++ b/x-pack/lib/helpers/elasticsearch_options.rb
@@ -15,6 +15,7 @@ module LogStash module Helpers
         password
         cloud_id
         cloud_auth
+        proxy
       )
 
     # Retrieve elasticsearch options from either specific settings, or modules if the setting is not there and the
@@ -47,6 +48,10 @@ module LogStash module Helpers
         opts['user'] = settings.get("#{prefix}#{feature}.elasticsearch.username")
         opts['password'] = settings.get("#{prefix}#{feature}.elasticsearch.password")
       end
+      if proxysetting = settings.get("#{prefix}#{feature}.elasticsearch.proxy")
+        opts['proxy'] = proxysetting
+      end
+
       opts['sniffing'] = settings.get("#{prefix}#{feature}.elasticsearch.sniffing")
       opts['ssl_certificate_verification'] = settings.get("#{prefix}#{feature}.elasticsearch.ssl.verification_mode") == 'certificate'
 

--- a/x-pack/lib/monitoring/monitoring.rb
+++ b/x-pack/lib/monitoring/monitoring.rb
@@ -32,6 +32,7 @@ module LogStash
         @password = es_settings['password']
         @cloud_id = es_settings['cloud_id']
         @cloud_auth = es_settings['cloud_auth']
+        @proxy = es_settings['proxy']
         @ca_path = es_settings['cacert']
         @truststore_path = es_settings['truststore']
         @truststore_password = es_settings['truststore_password']
@@ -41,7 +42,7 @@ module LogStash
         @ssl_certificate_verification = (es_settings['verification_mode'] == 'certificate')
       end
 
-      attr_accessor :system_api_version, :es_hosts, :user, :password, :node_uuid, :cloud_id, :cloud_auth
+      attr_accessor :system_api_version, :es_hosts, :user, :password, :node_uuid, :cloud_id, :cloud_auth, :proxy
       attr_accessor :ca_path, :truststore_path, :truststore_password
       attr_accessor :keystore_path, :keystore_password, :sniffing, :ssl_certificate_verification
 
@@ -59,6 +60,10 @@ module LogStash
 
       def cloud_auth?
         !!cloud_auth && cloud_id?
+      end
+
+      def proxy?
+        proxy
       end
 
       def auth?
@@ -254,6 +259,7 @@ module LogStash
       settings.register(LogStash::Setting::TimeValue.new("#{prefix}monitoring.collection.timeout_interval", "10m"))
       settings.register(LogStash::Setting::NullableString.new("#{prefix}monitoring.elasticsearch.username", "logstash_system"))
       settings.register(LogStash::Setting::NullableString.new("#{prefix}monitoring.elasticsearch.password"))
+      settings.register(LogStash::Setting::NullableString.new("#{prefix}monitoring.elasticsearch.proxy"))
       settings.register(LogStash::Setting::NullableString.new("#{prefix}monitoring.elasticsearch.cloud_id"))
       settings.register(LogStash::Setting::NullableString.new("#{prefix}monitoring.elasticsearch.cloud_auth"))
       settings.register(LogStash::Setting::NullableString.new("#{prefix}monitoring.elasticsearch.ssl.certificate_authority"))

--- a/x-pack/lib/template.cfg.erb
+++ b/x-pack/lib/template.cfg.erb
@@ -25,6 +25,9 @@ output {
     document_type => "%{[@metadata][document_type]}"
     index => "<%= monitoring_index %>"
     sniffing => <%= sniffing %>
+  <% if proxy? %>
+    proxy => "<%= proxy %>"
+  <% end %>
   <% if auth? && !cloud_auth? %>
     user => "<%= user %>"
     password => "<%= password %>"


### PR DESCRIPTION
LS monitoring and centralized configuration features currently don't work when there is a proxy between LS and ES. This PR removes this limitation.
Related issues: #9560 and #11343

This replace the PR #11358 (as the code has been modified to take care of the latest 7.x updates)