### PR TITLE
Updating fields to new ECS names

### DIFF
--- a/docs/static/filebeat_modules/apache2/pipeline.conf
+++ b/docs/static/filebeat_modules/apache2/pipeline.conf
@@ -5,8 +5,8 @@ input {
   }
 }
 filter {
-  if [fileset][module] == "apache2" {
-    if [fileset][name] == "access" {
+  if [event][module] == "apache2" {
+    if [event][dataset] == "apache2.access" {
       grok {
         match => { "message" => ["%{IPORHOST:[apache2][access][remote_ip]} - %{DATA:[apache2][access][user_name]} \[%{HTTPDATE:[apache2][access][time]}\] \"%{WORD:[apache2][access][method]} %{DATA:[apache2][access][url]} HTTP/%{NUMBER:[apache2][access][http_version]}\" %{NUMBER:[apache2][access][response_code]} %{NUMBER:[apache2][access][body_sent][bytes]}( \"%{DATA:[apache2][access][referrer]}\")?( \"%{DATA:[apache2][access][agent]}\")?",
           "%{IPORHOST:[apache2][access][remote_ip]} - %{DATA:[apache2][access][user_name]} \\[%{HTTPDATE:[apache2][access][time]}\\] \"-\" %{NUMBER:[apache2][access][response_code]} -" ] }
@@ -29,7 +29,7 @@ filter {
         target => "[apache2][access][geoip]"
       }
     }
-    else if [fileset][name] == "error" {
+    else if [event][dataset] == "apache2.error" {
       grok {
         match => { "message" => ["\[%{APACHE_TIME:[apache2][error][timestamp]}\] \[%{LOGLEVEL:[apache2][error][level]}\]( \[client %{IPORHOST:[apache2][error][client]}\])? %{GREEDYDATA:[apache2][error][message]}",
           "\[%{APACHE_TIME:[apache2][error][timestamp]}\] \[%{DATA:[apache2][error][module]}:%{LOGLEVEL:[apache2][error][level]}\] \[pid %{NUMBER:[apache2][error][pid]}(:tid %{NUMBER:[apache2][error][tid]})?\]( \[client %{IPORHOST:[apache2][error][client]}\])? %{GREEDYDATA:[apache2][error][message1]}" ] }

--- a/docs/static/filebeat_modules/mysql/pipeline.conf
+++ b/docs/static/filebeat_modules/mysql/pipeline.conf
@@ -5,8 +5,8 @@ input {
   }
 }
 filter {
-  if [fileset][module] == "mysql" {
-    if [fileset][name] == "error" {
+  if [event][module] == "mysql" {
+    if [event][dataset] == "mysql.error" {
       grok {
         match => { "message" => ["%{LOCALDATETIME:[mysql][error][timestamp]} (\[%{DATA:[mysql][error][level]}\] )?%{GREEDYDATA:[mysql][error][message]}",
           "%{TIMESTAMP_ISO8601:[mysql][error][timestamp]} %{NUMBER:[mysql][error][thread_id]} \[%{DATA:[mysql][error][level]}\] %{GREEDYDATA:[mysql][error][message1]}",
@@ -27,7 +27,7 @@ filter {
         remove_field => "[mysql][error][time]"
       }
     }
-    else if [fileset][name] == "slowlog" {
+    else if [event][dataset] == "mysql.slowlog" {
       grok {
         match => { "message" => ["^# User@Host: %{USER:[mysql][slowlog][user]}(\[[^\]]+\])? @ %{HOSTNAME:[mysql][slowlog][host]} \[(IP:[mysql][slowlog][ip])?\](\s*Id:\s* %{NUMBER:[mysql][slowlog][id]})?\n# Query_time: %{NUMBER:[mysql][slowlog][query_time][sec]}\s* Lock_time: %{NUMBER:[mysql][slowlog][lock_time][sec]}\s* Rows_sent: %{NUMBER:[mysql][slowlog][rows_sent]}\s* Rows_examined: %{NUMBER:[mysql][slowlog][rows_examined]}\n(SET timestamp=%{NUMBER:[mysql][slowlog][timestamp]};\n)?%{GREEDYMULTILINE:[mysql][slowlog][query]}"] }
         pattern_definitions => {

--- a/docs/static/filebeat_modules/nginx/pipeline.conf
+++ b/docs/static/filebeat_modules/nginx/pipeline.conf
@@ -5,8 +5,8 @@ input {
   }
 }
 filter {
-  if [fileset][module] == "nginx" {
-    if [fileset][name] == "access" {
+  if [event][module] == "nginx" {
+    if [event][dataset] == "nginx.access" {
       grok {
         match => { "message" => ["%{IPORHOST:[nginx][access][remote_ip]} - %{DATA:[nginx][access][user_name]} \[%{HTTPDATE:[nginx][access][time]}\] \"%{WORD:[nginx][access][method]} %{DATA:[nginx][access][url]} HTTP/%{NUMBER:[nginx][access][http_version]}\" %{NUMBER:[nginx][access][response_code]} %{NUMBER:[nginx][access][body_sent][bytes]} \"%{DATA:[nginx][access][referrer]}\" \"%{DATA:[nginx][access][agent]}\""] }
         remove_field => "message"
@@ -28,7 +28,7 @@ filter {
         target => "[nginx][access][geoip]"
       }
     }
-    else if [fileset][name] == "error" {
+    else if [event][dataset] == "nginx.error" {
       grok {
         match => { "message" => ["%{DATA:[nginx][error][time]} \[%{DATA:[nginx][error][level]}\] %{NUMBER:[nginx][error][pid]}#%{NUMBER:[nginx][error][tid]}: (\*%{NUMBER:[nginx][error][connection_id]} )?%{GREEDYDATA:[nginx][error][message]}"] }
         remove_field => "message"

--- a/docs/static/filebeat_modules/system/pipeline.conf
+++ b/docs/static/filebeat_modules/system/pipeline.conf
@@ -5,8 +5,8 @@ input {
   }
 }
 filter {
-  if [fileset][module] == "system" {
-    if [fileset][name] == "auth" {
+  if [event][module] == "system" {
+    if [event][dataset] == "system.auth" {
       grok {
         match => { "message" => ["%{SYSLOGTIMESTAMP:[system][auth][timestamp]} %{SYSLOGHOST:[system][auth][hostname]} sshd(?:\[%{POSINT:[system][auth][pid]}\])?: %{DATA:[system][auth][ssh][event]} %{DATA:[system][auth][ssh][method]} for (invalid user )?%{DATA:[system][auth][user]} from %{IPORHOST:[system][auth][ssh][ip]} port %{NUMBER:[system][auth][ssh][port]} ssh2(: %{GREEDYDATA:[system][auth][ssh][signature]})?",
                   "%{SYSLOGTIMESTAMP:[system][auth][timestamp]} %{SYSLOGHOST:[system][auth][hostname]} sshd(?:\[%{POSINT:[system][auth][pid]}\])?: %{DATA:[system][auth][ssh][event]} user %{DATA:[system][auth][user]} from %{IPORHOST:[system][auth][ssh][ip]}",
@@ -28,7 +28,7 @@ filter {
         target => "[system][auth][ssh][geoip]"
       }
     }
-    else if [fileset][name] == "syslog" {
+    else if [event][dataset] == "system.syslog" {
       grok {
         match => { "message" => ["%{SYSLOGTIMESTAMP:[system][syslog][timestamp]} %{SYSLOGHOST:[system][syslog][hostname]} %{DATA:[system][syslog][program]}(?:\[%{POSINT:[system][syslog][pid]}\])?: %{GREEDYMULTILINE:[system][syslog][message]}"] }
         pattern_definitions => { "GREEDYMULTILINE" => "(.|\n)*" }


### PR DESCRIPTION
Motivated by https://discuss.elastic.co/t/logstash-pipelines-for-parsing-questions-no-fileset-in-output/228519.

This PR updates the documentation on https://www.elastic.co/guide/en/logstash/7.6/logstash-config-for-filebeat-modules.html. Specifically, it updates the sample Logstash pipelines shown on that page to reference ECS field names added by Beats modules instead of of old-style names.