### PR TITLE
PR for issue #11792 :  Expose way to add files to Logstash's classpath

### DIFF
--- a/bin/logstash
+++ b/bin/logstash
@@ -10,6 +10,7 @@
 #
 # Supported environment variables:
 #   LS_JAVA_OPTS="xxx" to append extra options to the JVM options provided by logstash
+#   LS_EXTERNAL_CP="xxx yyyy" to append extra entries xxx and yyy to Logstash's classpath
 #
 # Development environment variables:
 #   DEBUG=1 to output debugging information
@@ -62,5 +63,10 @@ else
   for J in $(cd "${LOGSTASH_JARS}"; ls *.jar); do
     CLASSPATH=${CLASSPATH}${CLASSPATH:+:}${LOGSTASH_JARS}/${J}
   done
+  
+  for CP_ENTRY in ${LS_EXTERNAL_CP}; do 
+    CLASSPATH=${CLASSPATH}:${CP_ENTRY}
+  done
+  
   exec "${JAVACMD}" ${JAVA_OPTS} -cp "${CLASSPATH}" org.logstash.Logstash "$@"
 fi

--- a/bin/logstash.bat
+++ b/bin/logstash.bat
@@ -52,6 +52,12 @@ for %%i in ("%LS_HOME%\logstash-core\lib\jars\*.jar") do (
 	call :concat "%%i"
 )
 
+IF defined LS_EXTERNAL_CP (
+  for %%i in (%LS_EXTERNAL_CP%) do (
+    call :concat "%%i"
+  )
+)
+
 %JAVA% %JAVA_OPTS% -cp "%CLASSPATH%" org.logstash.Logstash %*
 
 goto :end


### PR DESCRIPTION
This PR fixes https://github.com/elastic/logstash/issues/11792#issue-600305301

It exposes a new variable **LS_EXTERNAL_CP** to both bash/bat Logstash's launchers.
The content of this variable is appened  (at the end) to the classpath of Logstahs once it has been filled with its jars.

The variable is appended to the classpath using the classpath separator ( ; / : )

**Example :** To append two jars to the classpath 

- On Windows use : 
```
set LS_EXTERNAL_CP=path/to/jar1 path/to/jar2
call logstash.bat -f myConf.conf
```

- On unix use : 
```
export LS_EXTERNAL_CP="path/to/jar1 path/to/jar2"
./logstash -f myConf.conf
```