### PR TITLE
dont use qualifier or snapshot in logstash core version

### DIFF
--- a/logstash-core-plugin-api/lib/logstash-core-plugin-api/version.rb
+++ b/logstash-core-plugin-api/lib/logstash-core-plugin-api/version.rb
@@ -28,6 +28,5 @@ unless defined?(LOGSTASH_CORE_PLUGIN_API)
 end
 
 unless defined?(LOGSTASH_CORE_VERSION)
-  # PACKAGE_SUFFIX is declared in the artifact namespace from artifacts.rake
-  LOGSTASH_CORE_VERSION = defined?(PACKAGE_SUFFIX) ? "#{ALL_VERSIONS.fetch("logstash-core")}#{PACKAGE_SUFFIX}" : ALL_VERSIONS.fetch("logstash-core")
+  LOGSTASH_CORE_VERSION = ALL_VERSIONS.fetch("logstash-core")
 end

--- a/logstash-core/lib/logstash-core/version.rb
+++ b/logstash-core/lib/logstash-core/version.rb
@@ -24,6 +24,5 @@ if !defined?(ALL_VERSIONS)
 end
 
 if !defined?(LOGSTASH_CORE_VERSION)
-  # PACKAGE_SUFFIX is declared in the artifact namespace from artifacts.rake
-  LOGSTASH_CORE_VERSION = defined?(PACKAGE_SUFFIX) ? "#{ALL_VERSIONS.fetch("logstash-core")}#{PACKAGE_SUFFIX}" : ALL_VERSIONS.fetch("logstash-core")
+  LOGSTASH_CORE_VERSION = ALL_VERSIONS.fetch("logstash-core")
 end


### PR DESCRIPTION
Currently by default doing a `./gradlew installDefaultGems` will introduce the -SNAPSHOT suffix in the local logstash-core version, which will be injected in the lock file. This causes the lock file to be partially invalidated, and causes gems to be installed with different versions compared to the lock file.

This occasional causes ci failures in licensing checks in release branches like 7.6 and may cause unpredictable failures as gem versions are used outside of those in the lock file.

We can observe this by finding one of the recent "updated licenses in 7.6" commits in 7.6 branch such as ef0f302a3 and running the following commands in the previous commit (i.e. ef0f302a3~1):

```
$ git checkout ef0f302a3~1
# normal license check will fail
$ ./ci/docker_license_check.sh ; echo $?
1  
# using RELEASE=1 doesn't add the SNAPSHOT suffix so the lock file is respected
$ RELEASE=1 DOCKER_ENV_OPTS="-e RELEASE" ./ci/docker_license_check.sh ; echo $?
0
```

This PR causes the license check pass on that commit:

```
$ git checkout ef0f302a3~1
$ curl https://patch-diff.githubusercontent.com/raw/elastic/logstash/pull/11813.patch | patch -p1
$ ./ci/docker_license_check.sh ; echo $?
0  
```

removing this use of the PACKAGE_SUFFIX still allows us to build snapshot packages as that's handled in the `rakelib/artifacs.rake` file, which we don't touch.