### PR TITLE
remove plugin internal validation call

### DIFF
--- a/x-pack/lib/license_checker/license_reader.rb
+++ b/x-pack/lib/license_checker/license_reader.rb
@@ -60,9 +60,6 @@ module LogStash
       def build_client
         es = LogStash::Outputs::ElasticSearch.new(@es_options)
         es.instance_variable_set :@logger, logger
-        es.fill_hosts_from_cloud_id
-        es.fill_user_password_from_cloud_auth
-        es.setup_hosts
         es.build_client
       end
 


### PR DESCRIPTION
This reverts part of #11800 to avoid calling plugin internals. Instead the plugin validation steps have been move into the `build_client` method per logstash-plugins/logstash-output-elasticsearch#934 

See https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/934#pullrequestreview-396203307 for more details.

**Note** This PR will fail until logstash-plugins/logstash-output-elasticsearch#934 is pushed and we wire the dependency to that new plugin version.

/cc @kares