### PR TITLE
Revert "Fix: cloud_id not propagating from monitoring config"

### DIFF
--- a/x-pack/lib/license_checker/license_reader.rb
+++ b/x-pack/lib/license_checker/license_reader.rb
@@ -4,6 +4,8 @@
 
 require 'logstash/logging/logger'
 require 'logstash/outputs/elasticsearch'
+require 'logstash/json'
+require 'json'
 
 module LogStash
   module LicenseChecker
@@ -15,7 +17,8 @@ module LogStash
       def initialize(settings, feature, options)
         @namespace = "xpack.#{feature}"
         @settings = settings
-        @es_options = options.merge('resurrect_delay' => 30)
+        @es_options = options
+        @es_options.merge!("resurrect_delay" => 30)
       end
 
       ##
@@ -59,10 +62,8 @@ module LogStash
       # # log originate from the `ElasticsearchSource`
       def build_client
         es = LogStash::Outputs::ElasticSearch.new(@es_options)
-        es.instance_variable_set :@logger, logger
-        es.fill_hosts_from_cloud_id
-        es.fill_user_password_from_cloud_auth
-        es.setup_hosts
+        new_logger = logger
+        es.instance_eval { @logger = new_logger }
         es.build_client
       end
 

--- a/x-pack/spec/license_checker/license_reader_spec.rb
+++ b/x-pack/spec/license_checker/license_reader_spec.rb
@@ -3,13 +3,15 @@
 # you may not use this file except in compliance with the Elastic License.
 
 require "spec_helper"
-require 'support/helpers'
+require "logstash/json"
 require "license_checker/license_reader"
 require "helpers/elasticsearch_options"
 require "monitoring/monitoring"
+require "stud/temporary"
+
 
 describe LogStash::LicenseChecker::LicenseReader do
-  let(:elasticsearch_url) { "https://localhost:9898" }
+  let(:elasticsearch_url) { ["https://localhost:9898"] }
   let(:elasticsearch_username) { "elastictest" }
   let(:elasticsearch_password) { "testchangeme" }
   let(:extension) { LogStash::MonitoringExtension.new }
@@ -23,7 +25,7 @@ describe LogStash::LicenseChecker::LicenseReader do
   let(:settings) do
     {
       "xpack.monitoring.enabled" => true,
-      "xpack.monitoring.elasticsearch.hosts" => [ elasticsearch_url ],
+      "xpack.monitoring.elasticsearch.hosts" => elasticsearch_url,
       "xpack.monitoring.elasticsearch.username" => elasticsearch_username,
       "xpack.monitoring.elasticsearch.password" => elasticsearch_password,
     }
@@ -97,35 +99,6 @@ describe LogStash::LicenseChecker::LicenseReader do
       it 'returns an XPackInfo indicating that X-Pack is not installed' do
         expect(subject.fetch_xpack_info).to eq(xpack_info_class.xpack_not_installed)
       end
-    end
-  end
-
-  it "builds ES client" do
-    expect( subject.client.options[:hosts].size ).to eql 1
-    expect( subject.client.options[:hosts][0].to_s ).to eql elasticsearch_url # URI#to_s
-    expect( subject.client.options ).to include(:user => elasticsearch_username, :password => elasticsearch_password)
-  end
-
-  context 'with cloud_id' do
-    let(:cloud_id) do
-      'westeurope-1:d2VzdGV1cm9wZS5henVyZS5lbGFzdGljLWNsb3VkLmNvbTo5MjQzJGUxZTYzMTIwMWZiNjRkNTVhNzVmNDMxZWI2MzQ5NTg5JDljYzYwMGUwMGQwYjRhMThiNmY2NmU2ZTcyMTQwODA3'
-    end
-    let(:cloud_auth) do
-      'elastic:LnWMLeK3EQPTf3G3F1IBdFvO'
-    end
-
-    let(:settings) do
-      {
-          "xpack.monitoring.enabled" => true,
-          "xpack.monitoring.elasticsearch.cloud_id" => cloud_id,
-          "xpack.monitoring.elasticsearch.cloud_auth" => cloud_auth
-      }
-    end
-
-    it "builds ES client" do
-      expect( subject.client.options[:hosts].size ).to eql 1
-      expect( subject.client.options[:hosts][0].to_s ).to eql 'https://e1e631201fb64d55a75f431eb6349589.westeurope.azure.elastic-cloud.com:9243'
-      expect( subject.client.options ).to include(:user => 'elastic', :password => 'LnWMLeK3EQPTf3G3F1IBdFvO')
     end
   end
 end


### PR DESCRIPTION
This reverts commit 76dc55f463e51a9a64fe0fd39921bd302d9353b0 in the 7.7 branch

The reason for this revert is that the fix will be implemented by
having the ES output set up credentials/hosts and cloud.id during
build_client method. With this there will be no need for changing
code on the Logstash core side.

We will later reintroduce the spec part of this commit.