### PR TITLE
depend on the elasticsearch output plugin >= 10.4.2

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -11,7 +11,7 @@ gem "paquet", "~> 0.2"
 gem "pleaserun", "~>0.0.28"
 gem "rake", "~> 12"
 gem "ruby-progressbar", "~> 1"
-gem "logstash-output-elasticsearch"
+gem "logstash-output-elasticsearch", ">= 10.4.2"
 gem "childprocess", "~> 0.9", :group => :build
 gem "fpm", "~> 1.3.3", :group => :build
 gem "gems", "~> 1", :group => :build


### PR DESCRIPTION
This ensures that we include versions >= 10.4.2 of the elasticsearch output plugin which includes the fix for authentication validation and `cloud_id` fix.

Plan is to merge in 7.6, 7.7, 7.x and master.

Relates to https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/939 and https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/934