### PR TITLE
[7.6] bump elasticsearch output dependency to 10.4.2

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -465,7 +465,7 @@ GEM
     logstash-output-elastic_app_search (1.0.0)
       logstash-codec-plain
       logstash-core-plugin-api (~> 2.0)
-    logstash-output-elasticsearch (10.3.3-java)
+    logstash-output-elasticsearch (10.4.2-java)
       cabin (~> 0.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       manticore (>= 0.5.4, < 1.0.0)


### PR DESCRIPTION
This bumps ES output dependency on v10.4.2 which includes the authentication validation and `cloud_id` fix. 
Relates to #11830