### PR TITLE
Docker Image permission consolidation

### DIFF
--- a/docker/templates/Dockerfile.j2
+++ b/docker/templates/Dockerfile.j2
@@ -29,10 +29,6 @@ RUN groupadd --gid 1000 logstash && \
 RUN curl -Lo - {{ url_root }}/{{ tarball }} | \
     tar zxf - -C /usr/share && \
     mv /usr/share/logstash-{{ elastic_version }} /usr/share/logstash && \
-    chown --recursive logstash:logstash /usr/share/logstash/ && \
-    chown -R logstash:root /usr/share/logstash && \
-    chmod -R g=u /usr/share/logstash && \
-    find /usr/share/logstash -type d -exec chmod g+s {} \; && \
     ln -s /usr/share/logstash /opt/logstash
 
 WORKDIR /usr/share/logstash
@@ -46,14 +42,18 @@ ADD config/pipelines.yml config/pipelines.yml
 ADD config/logstash-{{ image_flavor }}.yml config/logstash.yml
 ADD config/log4j2.properties config/
 ADD pipeline/default.conf pipeline/logstash.conf
-RUN chown --recursive logstash:root config/ pipeline/
 
 # Ensure Logstash gets a UTF-8 locale by default.
 ENV LANG='en_US.UTF-8' LC_ALL='en_US.UTF-8'
 
 # Place the startup wrapper script.
 ADD bin/docker-entrypoint /usr/local/bin/
-RUN chmod 0755 /usr/local/bin/docker-entrypoint
+
+# Fix permissions including openshift required permissions
+RUN chmod 0755 /usr/local/bin/docker-entrypoint && \
+    chown -R logstash:root /usr/share/logstash && \
+    chmod -R g=u /usr/share/logstash && \
+    find /usr/share/logstash -type d -exec chmod g+s {} \;
 
 USER 1000
 


### PR DESCRIPTION
Current images fail in OpenShift if env2yaml performs any action with a permission denied message.  Upon reviewing the Docker file template I saw there was an opportunity to reduce the number of layers and ease permission maintenance by consolidating filesystem permission changes into a single RUN and moving them to the end of the Dockerfile.  For my applications this makes debugging easier by having more uniform file permissions.