### PR TITLE
Download JDK and create distribution artifacts with JDK

### DIFF
--- a/bin/logstash
+++ b/bin/logstash
@@ -1,7 +1,5 @@
 #!/bin/bash
-# Run logstash from source
-#
-# This is most useful when done from a git checkout.
+# Run logstash
 #
 # Usage:
 #   bin/logstash <command> [arguments]

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -22,8 +22,18 @@ rem ### 2: set java
 
 if defined JAVA_HOME (
   set JAVA="%JAVA_HOME%\bin\java.exe"
+  echo Using JAVA_HOME defined java: %JAVA_HOME%
+  if exist "%LS_HOME%\jdk" (
+    echo WARNING, using JAVA_HOME while Logstash distribution comes with a bundled JDK
+  )
 ) else (
-  for %%I in (java.exe) do set JAVA="%%~$PATH:I"
+  if exist "%LS_HOME%\jdk" (
+    set JAVA="%LS_HOME%\jdk\bin\java.exe"
+    echo "Using bundled JDK: %JAVA%""
+  ) else (
+    for %%I in (java.exe) do set JAVA="%%~$PATH:I"
+    echo "Using system java: %JAVA%"
+  )
 )
 
 if not exist %JAVA% (

--- a/bin/system-install
+++ b/bin/system-install
@@ -61,7 +61,7 @@ done
 
 # bin/logstash-plugin is a short lived ruby script thus we can use aggressive "faster starting JRuby options"
 # see https://github.com/jruby/jruby/wiki/Improving-startup-time
-export JRUBY_OPTS="$JRUBY_OPTS -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -X-C -Xcompile.invokedynamic=false"
+export JRUBY_OPTS="$JRUBY_OPTS $OPEN_JAVA_MODULES -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -X-C -Xcompile.invokedynamic=false"
 
 tempfile=$(mktemp)
 if [ "x${PRESTART}" == "x" ]; then

--- a/build.gradle
+++ b/build.gradle
@@ -25,18 +25,20 @@ buildscript {
         }
     }
     dependencies {
+        classpath 'org.yaml:snakeyaml:1.17'
         classpath "gradle.plugin.com.github.jk1:gradle-license-report:0.7.1"
     }
 }
 
 plugins {
     id "de.undercouch.download" version "4.0.4"
+    id "com.dorongold.task-tree" version "1.5"
 }
 
 apply plugin: 'de.undercouch.download'
 apply from: "rubyUtils.gradle"
 
-
+import org.yaml.snakeyaml.Yaml
 import de.undercouch.gradle.tasks.download.Download
 import groovy.json.JsonSlurper
 
@@ -242,7 +244,7 @@ tasks.register("assembleTarDistribution") {
   inputs.files fileTree("${projectDir}/x-pack")
   outputs.files file("${buildDir}/logstash-${project.version}-SNAPSHOT.tar.gz")
   doLast {
-      rake(projectDir, buildDir, 'artifact:tar')
+      rake(projectDir, buildDir, 'artifact:no_bundle_jdk_tar')
   }
 }
 
@@ -257,7 +259,7 @@ tasks.register("assembleOssTarDistribution") {
   inputs.files fileTree("${projectDir}/logstash-core/lib")
   inputs.files fileTree("${projectDir}/logstash-core/src")
   doLast {
-      rake(projectDir, buildDir, 'artifact:tar_oss')
+      rake(projectDir, buildDir, 'artifact:archives_oss')
   }
 }
 
@@ -274,7 +276,7 @@ tasks.register("assembleZipDistribution") {
   inputs.files fileTree("${projectDir}/x-pack")
   outputs.files file("${buildDir}/logstash-${project.version}.zip")
   doLast {
-      rake(projectDir, buildDir, 'artifact:zip')
+      rake(projectDir, buildDir, 'artifact:archives')
   }
 }
 
@@ -290,7 +292,7 @@ tasks.register("assembleOssZipDistribution") {
   inputs.files fileTree("${projectDir}/logstash-core/src")
   outputs.files file("${buildDir}/logstash-${project.version}.zip")
   doLast {
-      rake(projectDir, buildDir, 'artifact:zip_oss')
+      rake(projectDir, buildDir, 'artifact:archives_oss')
 
   }
 }
@@ -422,7 +424,7 @@ tasks.register("deleteLocalEs", Delete) {
     delete ('./build/elasticsearch')
 }
 
-tasks.register("copyEs", Copy){
+tasks.register("copyEs", Copy) {
     dependsOn = [downloadEs, deleteLocalEs]
     from tarTree(resources.gzip(project.ext.elasticsearchDownloadLocation))
     into "./build/"
@@ -509,11 +511,165 @@ bootstrap.dependsOn assemblyDeps
 // Elasticsearch doesn't yet have a build we can fetch
 // So for now we'll remove this to unblock builds, but finding a way
 // to compartimentalize failures is needed going forward
-//check.dependsOn runIntegrationTests
+//check.dependsOn runIntegrationTest
 
-Boolean oss = System.getenv('OSS').equals('true')
+runIntegrationTests.shouldRunAfter tasks.getByPath(":logstash-core:test")
 
-if (!oss) {
+def selectOsType() {
+    if (project.ext.has("jdk_bundle_os")) {
+        return project.ext.jdk_bundle_os
+    }
+    String osName = System.properties['os.name']
+    switch (osName.toLowerCase()) {
+        case ~/mac os x/:
+            return "darwin"
+        case ~/windows.*/:
+            return "windows"
+        case ~/linux/:
+            return "linux"
+        default:
+            throw new IllegalArgumentException("Can't determine OS type from name: $osName")
+    }
+}
+
+class JDKDetails {
+    final String revision
+    final String build
+    final String vendor
+    final int major
+    private final String osName
+    private final String extension
+    final String localPackageName
+    final String unpackedJdkName
+    private String arch = "x64"
+
+    JDKDetails(versionYml, osName) {
+        revision = versionYml.bundled_jdk.revision
+        build = versionYml.bundled_jdk.build
+        vendor = versionYml.bundled_jdk.vendor
+        major = revision.split('\\.').first() as int
+        this.osName = osName
+
+        switch (osName) {
+            case "windows":
+                extension = "zip"
+                break
+            default:
+                extension = "tar.gz"
+        }
+        unpackedJdkName = "jdk-${revision}-${osName}"
+        localPackageName = "${unpackedJdkName}.${extension}"
+    }
+
+    String createDownloadUrl() {
+        switch (vendor) {
+            case "adoptopenjdk":
+                String releaseName = major > 8 ?
+                        "jdk-${revision}+${build}":
+                        "jdk${revision}u${build}"
+                String adoptOsName = adaptOsName(osName)
+                return "https://api.adoptopenjdk.net/v3/binary/version/${releaseName}/${adoptOsName}/${arch}/jdk/hotspot/normal/${vendor}"
+            default:
+                throw RuntimeException("Can't handle vendor: ${vendor}")
+        }
+    }
+
+    private String adaptOsName(String osName) {
+        if (osName == "darwin")
+            return "mac"
+        return osName
+    }
+}
+
+tasks.register("downloadJdk", Download) {
+    // CLI project properties: -Pjdk_bundle_os=[windows|linux|darwin]
+
+    project.ext.set("versionFound", true)
+    String osName = selectOsType()
+
+    def versionYml = new Yaml().load(new File("$projectDir/versions.yml").text)
+    def jdkDetails = new JDKDetails(versionYml, osName)
+
+    description "Download JDK ${jdkDetails.major}, OS: ${osName}"
+
+    // find url of build artifact
+    String artifactApiUrl = jdkDetails.createDownloadUrl()
+
+    project.ext.set("jdkURL", System.getenv("JDK_URL") ?: artifactApiUrl)
+    project.ext.set("jdkDownloadLocation", "${projectDir}/build/${jdkDetails.localPackageName}")
+    project.ext.set("jdkDirectory", "${projectDir}/build/${jdkDetails.unpackedJdkName}")
+
+    String jdkFolderName = osName == "darwin" ? "jdk.app" : "jdk"
+    project.ext.set("jdkBundlingDirectory", "${projectDir}/${jdkFolderName}")
+
+    src project.ext.jdkURL
+    onlyIfNewer true
+    overwrite false
+    inputs.file("${projectDir}/versions.yml")
+    outputs.file(project.ext.jdkDownloadLocation)
+    dest new File(project.ext.jdkDownloadLocation)
+
+    doLast {
+        mkdir project.ext.jdkBundlingDirectory
+        println "Downloaded to ${project.ext.jdkDownloadLocation}"
+    }
+}
+
+tasks.register("deleteLocalJdk", Delete) {
+    // CLI project properties: -Pjdk_bundle_os=[windows|linux|darwin]
+    String osName = selectOsType()
+    String jdkFolderName = osName == "darwin" ? "jdk.app" : "jdk"
+    String jdkBundlingDirectory = "${projectDir}/${jdkFolderName}"
+    delete jdkBundlingDirectory
+}
+
+// Cannot use tarTree as it does not handle symlinks
+tasks.register("untarJdk", Exec) {
+    dependsOn downloadJdk
+    description = "unpack the downloaded JDK's tar.gz"
+    commandLine 'tar', 'xf', project.ext.jdkDownloadLocation, '-C', project.ext.jdkBundlingDirectory, '--strip-components', '1'
+    inputs.file(project.ext.jdkDownloadLocation)
+    outputs.dir(project.ext.jdkBundlingDirectory)
+}
+
+tasks.register("unzipJdk", Copy) {
+    dependsOn downloadJdk
+    description = "unpack the downloaded JDK's zip"
+    String rootName = null
+    from(zipTree("$project.ext.jdkDownloadLocation")) {
+        eachFile { fcd ->
+            rootName = rootName ?: fcd.relativePath.segments[0]
+            fcd.relativePath = new RelativePath(true, fcd.relativePath.segments.drop(1))
+        }
+    }
+    into project.ext.jdkBundlingDirectory
+    doLast {
+        delete "${project.ext.jdkBundlingDirectory}/$rootName"
+    }
+}
+
+tasks.register("decompressJdk") {
+    description = "unpack the downloaded JDK's (wrapper task for unzipJdk, untarJdk)"
+    String osName = selectOsType()
+    switch (osName) {
+        case "windows":
+            dependsOn ":unzipJdk"
+            break
+        default:
+            dependsOn ":untarJdk"
+    }
+}
+
+tasks.register("copyJdk", Copy) {
+    dependsOn = [decompressJdk, bootstrap]
+    description = "Download, unpack and copy the JDK"
+    // CLI project properties: -Pjdk_bundle_os=[windows|linux|darwin]
+    doLast {
+        System.out.println "Download location is ${project.ext.jdkDownloadLocation}, Decompressing ${project.ext.jdkDirectory} to \"${project.ext.jdkBundlingDirectory}\""
+    }
+}
+
+if (System.getenv('OSS') != 'true') {
   project(":logstash-xpack") {
     ["rubyTests", "rubyIntegrationTests", "test"].each { tsk ->
       tasks.getByPath(":logstash-xpack:" + tsk).configure {

--- a/docker/templates/Dockerfile.j2
+++ b/docker/templates/Dockerfile.j2
@@ -6,10 +6,10 @@
 {% endif -%}
 
 {% if image_flavor == 'oss' -%}
-  {% set tarball = 'logstash-oss-%s.tar.gz' % elastic_version -%}
+  {% set tarball = 'logstash-oss-%s-linux-x86_64.tar.gz' % elastic_version -%}
   {% set license = 'Apache 2.0' -%}
 {% else -%}
-  {% set tarball = 'logstash-%s.tar.gz' % elastic_version -%}
+  {% set tarball = 'logstash-%s-linux-x86_64.tar.gz' % elastic_version -%}
   {% set license = 'Elastic License' -%}
 {% endif -%}
 
@@ -29,7 +29,7 @@ FROM {{ base_image }}
 # Install Java and the "which" command, which is needed by Logstash's shell
 # scripts.
 # Minimal distributions also require findutils tar gzip (procps for integration tests)
-RUN {{ package_manager }} update -y && {{ package_manager }} install -y procps findutils tar gzip java-11-openjdk-devel which && \
+RUN {{ package_manager }} update -y && {{ package_manager }} install -y procps findutils tar gzip which shadow-utils && \
     {{ package_manager }} clean all
 
 # Provide a non-root user to run the process.

--- a/qa/acceptance/spec/lib/artifact_operation_spec.rb
+++ b/qa/acceptance/spec/lib/artifact_operation_spec.rb
@@ -17,6 +17,7 @@
 
 require_relative '../spec_helper'
 require_relative '../shared_examples/installed'
+require_relative '../shared_examples/installed_with_jdk'
 require_relative '../shared_examples/running'
 require_relative '../shared_examples/updated'
 
@@ -26,6 +27,7 @@ describe "artifacts operation" do
   config.servers.each do |address|
     logstash = ServiceTester::Artifact.new(address, config.lookup[address])
     it_behaves_like "installable", logstash
+    it_behaves_like "installable_with_jdk", logstash
     it_behaves_like "updated", logstash
   end
 end

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/list.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/list.rb
@@ -49,6 +49,7 @@ shared_examples "logstash list" do |logstash|
         stdout = StringIO.new(result.stdout)
         stdout.set_encoding(Encoding::UTF_8)
         while line = stdout.gets
+          next if line.match(/^Using system java:.*$/)
           match = line.match(/^#{plugin_name_with_version}$/)
           expect(match).to_not be_nil
 

--- a/qa/docker/shared_examples/container.rb
+++ b/qa/docker/shared_examples/container.rb
@@ -11,7 +11,17 @@ shared_examples_for 'the container is configured correctly' do |flavor|
 
   context 'logstash' do
     it 'should run with the correct version' do
-      expect(exec_in_container(@container, 'logstash --version')).to match /#{version}/
+      console_out = exec_in_container(@container, 'logstash --version')
+      console_filtered = console_out.split("\n")
+            .delete_if do |line|
+              line =~ /Using JAVA_HOME defined java|Using system java: /
+            end.join
+      expect(console_filtered).to match /#{version}/
+    end
+
+    it 'should run with the bundled JDK' do
+      first_console_line = exec_in_container(@container, 'logstash --version').split("\n")[0]
+      expect(first_console_line).to match /Using bundled JDK: \/usr\/share\/logstash\/jdk/
     end
 
     it 'should be running an API server on port 9600' do
@@ -42,8 +52,8 @@ shared_examples_for 'the container is configured correctly' do |flavor|
     end
 
     it 'should have all files owned by the logstash user' do
-      expect(exec_in_container(@container, 'find /usr/share/logstash ! -user logstash')).to be_nil
-      expect(exec_in_container(@container, 'find /usr/share/logstash -user logstash')).not_to be_nil
+      expect(exec_in_container(@container, 'find /usr/share/logstash ! -user logstash')).to be_empty
+      expect(exec_in_container(@container, 'find /usr/share/logstash -user logstash')).not_to be_empty
     end
 
     it 'should have a logstash user with uid 1000' do

--- a/qa/docker/spec/spec_helper.rb
+++ b/qa/docker/spec/spec_helper.rb
@@ -77,7 +77,7 @@ def java_process(container, column)
 end
 
 def exec_in_container(container, command)
-  container.exec(command.split)[0][0]
+  container.exec(command.split)[0].join
 end
 
 def architecture_for_flavor(flavor)

--- a/qa/integration/specs/cli/prepare_offline_pack_spec.rb
+++ b/qa/integration/specs/cli/prepare_offline_pack_spec.rb
@@ -86,7 +86,7 @@ describe "CLI > logstash-plugin prepare-offline-pack" do
       filters = @logstash_plugin.list(plugins_to_pack.first)
                                 .stderr_and_stdout.split("\n")
                                 .delete_if do |line|
-                                  line =~ /cext|├──|└──|logstash-integration|JAVA_OPT|fatal|^WARNING|^warning: ignoring JAVA_TOOL_OPTIONS|^OpenJDK 64-Bit Server VM warning|Option \w+ was deprecated/
+                                  line =~ /cext|├──|└──|logstash-integration|JAVA_OPT|fatal|^WARNING|^warning: ignoring JAVA_TOOL_OPTIONS|^OpenJDK 64-Bit Server VM warning|Option \w+ was deprecated|Using JAVA_HOME defined java|Using system java: |\[\[: not found/
                                 end
 
       expect(unpacked.plugins.collect(&:name)).to include(*filters)

--- a/qa/rspec/commands.rb
+++ b/qa/rspec/commands.rb
@@ -42,6 +42,8 @@ module ServiceTester
       @host    = host
       @options = options
       @client  = CommandsFactory.fetch(options["type"], options["host"])
+      @bundled_jdk = false
+      @skip_jdk_infix = false
     end
 
     def hostname
@@ -74,7 +76,10 @@ module ServiceTester
 
     def install(options={})
       base      = options.fetch(:base, ServiceTester::Base::LOCATION)
-      package   = client.package_for(filename(options), base)
+      @bundled_jdk = options.fetch(:bundled_jdk, false)
+      @skip_jdk_infix = options.fetch(:skip_jdk_infix, false)
+      filename = filename(options)
+      package   = client.package_for(filename, @skip_jdk_infix, @bundled_jdk, base)
       client.install(package, host)
     end
 

--- a/qa/rspec/commands/base.rb
+++ b/qa/rspec/commands/base.rb
@@ -82,5 +82,23 @@ module ServiceTester
     def delete_file(path, host)
       run_command("rm -rf #{path}", host)
     end
+
+    def package_for(filename, skip_jdk_infix, bundled_jdk, base=ServiceTester::Base::LOCATION)
+      jdk_arch_ext = jdk_architecture_extension(skip_jdk_infix, bundled_jdk)
+      File.join(base, "#{filename}#{jdk_arch_ext}.#{package_extension}")
+    end
+
+    private
+    def jdk_architecture_extension(skip_jdk_infix, bundled_jdk)
+      if skip_jdk_infix
+        ""
+      else
+        if bundled_jdk
+          "-" + architecture_extension
+        else
+          "-no-jdk"
+        end
+      end
+    end
   end
 end

--- a/qa/rspec/commands/debian.rb
+++ b/qa/rspec/commands/debian.rb
@@ -32,8 +32,12 @@ module ServiceTester
       stdout.match(/^Status: install ok installed$/)
     end
 
-    def package_for(filename, base=ServiceTester::Base::LOCATION)
-      File.join(base, "#{filename}.deb")
+    def package_extension
+      "deb"
+    end
+
+    def architecture_extension
+      "amd64"
     end
 
     def install(package, host=nil)

--- a/qa/rspec/commands/redhat.rb
+++ b/qa/rspec/commands/redhat.rb
@@ -32,8 +32,12 @@ module ServiceTester
       stdout.match(/^logstash.noarch/)
     end
 
-    def package_for(filename, base=ServiceTester::Base::LOCATION)
-      File.join(base, "#{filename}.rpm")
+    def package_extension
+      "rpm"
+    end
+
+    def architecture_extension
+      "x86_64"
     end
 
     def install(package, host=nil)

--- a/qa/rspec/commands/suse.rb
+++ b/qa/rspec/commands/suse.rb
@@ -29,8 +29,12 @@ module ServiceTester
       stdout.match(/^i | logstash | An extensible logging pipeline | package$/)
     end
 
-    def package_for(filename, base=ServiceTester::Base::LOCATION)
-      File.join(base, "#{filename}.rpm")
+    def package_extension()
+      "rpm"
+    end
+
+    def architecture_extension()
+      "x86_64"
     end
 
     def install(package, host=nil)

--- a/qa/rspec/commands/system_helpers.rb
+++ b/qa/rspec/commands/system_helpers.rb
@@ -19,14 +19,16 @@ require_relative "base"
 
 module ServiceTester
   module SystemD
-    def running?(hosts, package)
+    def running?(hosts, package, jdk_path='/usr/bin/java')
       stdout = ""
       at(hosts, {in: :serial}) do |host|
         cmd = sudo_exec!("service #{package} status")
         stdout = cmd.stdout
       end
+      stdout.force_encoding(Encoding::UTF_8)
       (
         stdout.match(/Active: active \(running\)/) &&
+        stdout.match(/^\s*└─\d*\s.*#{jdk_path}/) &&
         stdout.match(/#{package}.service - #{package}/)
       )
     end
@@ -40,13 +42,19 @@ module ServiceTester
   end
 
   module InitD
-    def running?(hosts, package)
+    def running?(hosts, package, jdk_path='/usr/bin/java')
       stdout = ""
       at(hosts, {in: :serial}) do |host|
         cmd = sudo_exec!("initctl status #{package}")
         stdout = cmd.stdout
       end
-      stdout.match(/#{package} start\/running/)
+      running = stdout.match(/#{package} start\/running/)
+      pid = stdout.match(/#{package} start\/running, process (\d*)/).captures[0]
+      at(hosts, {in: :serial}) do |host|
+        cmd = sudo_exec!("ps ax | grep #{pid}")
+        stdout = cmd.stdout
+      end
+      (running && stdout.match(/#{jdk_path}/))
     end
 
     def service_manager(service, action, host=nil)

--- a/qa/rspec/matchers/be_running.rb
+++ b/qa/rspec/matchers/be_running.rb
@@ -23,3 +23,9 @@ RSpec::Matchers.define :be_running do
     subject.running?(subject.hosts, subject.name)
   end
 end
+
+RSpec::Matchers.define :be_running_with do |expected_jdk_path|
+  match do |subject|
+    subject.running?(subject.hosts, subject.name, expected_jdk_path)
+  end
+end

--- a/versions.yml
+++ b/versions.yml
@@ -4,6 +4,12 @@ logstash: 8.0.0
 logstash-core: 8.0.0
 logstash-core-plugin-api: 2.1.16
 
+bundled_jdk:
+  # for AdoptOpenJDK/OpenJDK jdk-14.0.1+7.1, the revision is 14.0.1 while the build is 7.1
+  vendor: "adoptopenjdk"
+  revision: 11.0.8
+  build: 10
+
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time
 jruby:


### PR DESCRIPTION
This PR add the bundling of JDK to existing artifacts tasks
The artifacts are:
- Linux distribution's packages: `deb/rpm`
- normal packages `tar.gz` (Linux, MacOS) `.zip` for windows
- Docker images

The JDK to bundle is configured in `versions.yml` file, and are the same for all platform (AdoptOpenJDK 11)

The launch scripts has changed with the following meaning, in case of a bundled package:
use the JVM provided by JAVA_HOME if set, warning the user that he is using a bundled package. If not set use the bundled one if present. As last resource (only on *nix platforms) check for other java with `command -v java`, if no JVM is present quit with error.

On DEB package with JDK bundled removes the dependency on a Java DEB.

----
This PR bring an effort from @robbavey  and proposes changes to adapt current Logstash packaging scripts to create artifacts containing the JDK. 
- [x] download JDK to bundle from an Elastic repository, (Adopt for Linux and Zulu for Windows)
- [x] bundle the JDK with tar.gz distribution (keeping also a distribution without it)
- [x] change launching scripts in `bin/`to use the shipped JDK if present
- [x] add deb/rpm with also bundled JDK, in this case the dependency on Java should be eliminated (because it bundles one JDK)
- [x] align the JDK selection to what does elasticsearch, if JAVA_HOME is already set use that, else use the bundled one without changing the JAVA_HOME