### PR TITLE
Feat: ship log4j2 commons-logging bridge with LS

### DIFF
--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -134,6 +134,10 @@ logger.slowlog.additivity = false
 logger.licensereader.name = logstash.licensechecker.licensereader
 logger.licensereader.level = error
 
+# Silence http-client by default
+logger.apache_http_client.name = org.apache.http
+logger.apache_http_client.level = fatal
+
 # Deprecation log
 appender.deprecation_rolling.type = RollingFile
 appender.deprecation_rolling.name = deprecation_plain_rolling

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -157,6 +157,10 @@ dependencies {
     annotationProcessor 'org.apache.logging.log4j:log4j-core:2.13.3'
     api 'org.apache.logging.log4j:log4j-core:2.13.3'
     runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.13.3'
+    // concerns libraries such as manticore's http-client 4.5 (using commons-logging)
+    runtimeOnly 'org.apache.logging.log4j:log4j-jcl:2.13.3'
+    // for the log4j-jcl bridge to work commons-logging needs to be on the same class-path
+    runtimeOnly 'commons-logging:commons-logging:1.2'
     implementation('org.reflections:reflections:0.9.11') {
         exclude group: 'com.google.guava', module: 'guava'
     }


### PR DESCRIPTION
Having the jar around would allow us to fine tune logging for libraries
such as manticore's http-client (4.5) using LS's `log4j2.properties`
e.g.

```
logger.http_headers.name = org.apache.http.headers
logger.http_headers.level = DEBUG
```
... to log http headers for each request : 

```
[2020-04-30T14:17:42,977][DEBUG][org.apache.http.headers  ][main][920ea2400ec23952b1af206783db2c10e025c753ac595bfe3fc0947d9e065bb6] http-outgoing-0 >> POST /_bulk HTTP/1.1
[2020-04-30T14:17:42,978][DEBUG][org.apache.http.headers  ][main][920ea2400ec23952b1af206783db2c10e025c753ac595bfe3fc0947d9e065bb6] http-outgoing-1 >> POST /_bulk HTTP/1.1
[2020-04-30T14:17:42,984][DEBUG][org.apache.http.headers  ][main][920ea2400ec23952b1af206783db2c10e025c753ac595bfe3fc0947d9e065bb6] http-outgoing-0 >> Connection: Keep-Alive
[2020-04-30T14:17:42,985][DEBUG][org.apache.http.headers  ][main][920ea2400ec23952b1af206783db2c10e025c753ac595bfe3fc0947d9e065bb6] http-outgoing-0 >> Content-Type: application/json
[2020-04-30T14:17:42,985][DEBUG][org.apache.http.headers  ][main][920ea2400ec23952b1af206783db2c10e025c753ac595bfe3fc0947d9e065bb6] http-outgoing-1 >> Connection: Keep-Alive
[2020-04-30T14:17:42,986][DEBUG][org.apache.http.headers  ][main][920ea2400ec23952b1af206783db2c10e025c753ac595bfe3fc0947d9e065bb6] http-outgoing-0 >> Content-Length: 201
[2020-04-30T14:17:42,986][DEBUG][org.apache.http.headers  ][main][920ea2400ec23952b1af206783db2c10e025c753ac595bfe3fc0947d9e065bb6] http-outgoing-1 >> Content-Type: application/json
[2020-04-30T14:17:42,987][DEBUG][org.apache.http.headers  ][main][920ea2400ec23952b1af206783db2c10e025c753ac595bfe3fc0947d9e065bb6] http-outgoing-0 >> Host: 127.0.0.1:9200
[2020-04-30T14:17:42,987][DEBUG][org.apache.http.headers  ][main][920ea2400ec23952b1af206783db2c10e025c753ac595bfe3fc0947d9e065bb6] http-outgoing-1 >> Content-Length: 240
[2020-04-30T14:17:42,992][DEBUG][org.apache.http.headers  ][main][920ea2400ec23952b1af206783db2c10e025c753ac595bfe3fc0947d9e065bb6] http-outgoing-0 >> User-Agent: Manticore 0.6.4
[2020-04-30T14:17:42,993][DEBUG][org.apache.http.headers  ][main][920ea2400ec23952b1af206783db2c10e025c753ac595bfe3fc0947d9e065bb6] http-outgoing-1 >> Host: 127.0.0.1:9200
[2020-04-30T14:17:42,994][DEBUG][org.apache.http.headers  ][main][920ea2400ec23952b1af206783db2c10e025c753ac595bfe3fc0947d9e065bb6] http-outgoing-0 >> Accept-Encoding: gzip,deflate
[2020-04-30T14:17:42,994][DEBUG][org.apache.http.headers  ][main][920ea2400ec23952b1af206783db2c10e025c753ac595bfe3fc0947d9e065bb6] http-outgoing-1 >> User-Agent: Manticore 0.6.4
[2020-04-30T14:17:42,995][DEBUG][org.apache.http.headers  ][main][920ea2400ec23952b1af206783db2c10e025c753ac595bfe3fc0947d9e065bb6] http-outgoing-0 >> Authorization: Basic ZWxhc3RpYzpwYXNzd29yZA==
[2020-04-30T14:17:42,995][DEBUG][org.apache.http.headers  ][main][920ea2400ec23952b1af206783db2c10e025c753ac595bfe3fc0947d9e065bb6] http-outgoing-1 >> Accept-Encoding: gzip,deflate
[2020-04-30T14:17:42,996][DEBUG][org.apache.http.headers  ][main][920ea2400ec23952b1af206783db2c10e025c753ac595bfe3fc0947d9e065bb6] http-outgoing-1 >> Authorization: Basic ZWxhc3RpYzpwYXNzd29yZA==
```

This wouldn't be the official way to "debug" http requests in LS but still helpful at times ...

TODOs
- [x] review libraries using commons-logging and silent them by default?
  e.g.  `logger.http.name = org.apache.http; logger.http.level = FATAL` (or even `OFF` by default)
- [ ] if we silence by default than we should also review libraries using log4j2
  for consistency - e.g. is it okay that Kafka client is noisy with info and warnings by default?