### PR TITLE
Fail fast when integration test fixtures cannot be setup.

### DIFF
--- a/qa/integration/services/service.rb
+++ b/qa/integration/services/service.rb
@@ -44,7 +44,7 @@ class Service
     puts "Tearing down #{@name} service"
     if File.exists?(@teardown_script)
       `#{@teardown_script}`
-      puts "#{@teardown_scipt} FAILED with exit status #{$?}" unless $?.success?
+      raise "#{@teardown_script} FAILED with exit status #{$?}" unless $?.success?
     else
       puts "Teardown script not found for #{@name}"
     end

--- a/qa/integration/services/service.rb
+++ b/qa/integration/services/service.rb
@@ -33,6 +33,7 @@ class Service
     puts "Setting up #{@name} service"
     if File.exists?(@setup_script)
       `#{@setup_script}`
+      raise "#{@setup_script} FAILED with exit status #{$?}" unless $?.success?
     else
       puts "Setup script not found for #{@name}"
     end
@@ -43,6 +44,7 @@ class Service
     puts "Tearing down #{@name} service"
     if File.exists?(@teardown_script)
       `#{@teardown_script}`
+      puts "#{@teardown_scipt} FAILED with exit status #{$?}" unless $?.success?
     else
       puts "Teardown script not found for #{@name}"
     end


### PR DESCRIPTION
Currently when integration test fixture setup fails, the tests proceed as usual,
resulting in noisy logs where the source of the error is not easy to discover.
This commit will raise an exception and log the exit status if the script fails to
setup.
It will also log but not raise if the teardown script fails to run correctly,
preferring to inform rather than fail tests when teardown scripts return error
exit codes.