### PR TITLE
[doc] missing role for config management integration (#10341)

### DIFF
--- a/docs/static/management/configuring-centralized-pipelines.asciidoc
+++ b/docs/static/management/configuring-centralized-pipelines.asciidoc
@@ -31,8 +31,8 @@ centrally manage.
 . Restart Logstash.
 
 . If your Elasticsearch cluster is protected with basic authentication, assign
-the `logstash_admin` role to any users who will use centralized pipeline
-management. See <<ls-security>>.
+the built-in `logstash_admin` role as well as the `logstash_writer` role to any users who will use centralized pipeline
+management. See <<ls-security>> for more information.
 
 NOTE: Centralized management is disabled until you configure and enable
 {security-features}.

--- a/docs/static/settings/configuration-management-settings.asciidoc
+++ b/docs/static/settings/configuration-management-settings.asciidoc
@@ -52,9 +52,9 @@ section in your Logstash configuration, or a different one. Defaults to
 
 If your {es} cluster is protected with basic authentication, these settings
 provide the username and password that the Logstash instance uses to
-authenticate for accessing the configuration data.
-The username you specify here should have the `logstash_admin` role, which
-provides access to `.logstash-*` indices for managing configurations.
+authenticate for accessing the configuration data. The username you specify here
+should have the built-in `logstash_admin` role and the customized `logstash_writer` role, which provides access to `.logstash-*`
+indices for managing configurations. 
 
 `xpack.management.elasticsearch.ssl.certificate_authority`::
 


### PR DESCRIPTION
Backports: #10341 
logstash_admin role is not enough.
As the ls-security page mentions correctly:
"The user you specify here must have the built-in logstash_admin role as well as the logstash_writer role that you created earlier"

Updates static settings for extra role needed

Co-authored-by: Karen Metts <35154725+karenzone@users.noreply.github.com>