### PR TITLE
Fix: condition to check environment variable was inverted

### DIFF
--- a/ci/unit_tests.bat
+++ b/ci/unit_tests.bat
@@ -40,7 +40,7 @@ echo Using drive !use_drive! for %WORKSPACE%
 !use_drive!
 
 echo Running core tests..
-if "%BUILD_JAVA_HOME%" == "" (
+if defined BUILD_JAVA_HOME (
   GRADLE_OPTS="%GRADLE_OPTS% -Dorg.gradle.java.home=%BUILD_JAVA_HOME%"
 )
 call .\gradlew.bat test --console=plain --no-daemon --info


### PR DESCRIPTION
To run unit tests with specific JDKs under Windows OS we have to check for the existence of BUILD_JAVA_HOME. The test logic was inverted