### PR TITLE
Remove obsolete setting from Elasticsearch integration test

### DIFF
--- a/x-pack/qa/integration/support/helpers.rb
+++ b/x-pack/qa/integration/support/helpers.rb
@@ -32,7 +32,7 @@ def elasticsearch(options = {})
   temporary_path_data = Stud::Temporary.directory
   default_settings = {
     "path.data" => temporary_path_data,
-    "xpack.monitoring.enabled" => true,
+
     "xpack.monitoring.collection.enabled" => true,
     "xpack.security.enabled" => true
   }


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/56211 removed the ability
to turn off certain features in Elasticsearch. This commit removes
the setting of `xpack.monitoring.enabled`, as this is now
obsolete.