### PR TITLE
Fix: avoid gsub (frame dependent) usage from Java

### DIFF
--- a/logstash-core/src/main/java/org/logstash/log/DeprecationLoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/DeprecationLoggerExt.java
@@ -40,10 +40,19 @@ public class DeprecationLoggerExt extends RubyObject {
         super(runtime, metaClass);
     }
 
+    DeprecationLoggerExt(final Ruby runtime, final RubyClass metaClass, final String loggerName) {
+        super(runtime, metaClass);
+        initialize(loggerName);
+    }
+
     @JRubyMethod
     public DeprecationLoggerExt initialize(final ThreadContext context, final IRubyObject loggerName) {
-        logger = new DefaultDeprecationLogger(loggerName.asJavaString());
+        initialize(loggerName.asJavaString());
         return this;
+    }
+
+    private void initialize(final String loggerName) {
+        logger = new DefaultDeprecationLogger(loggerName);
     }
 
     @JRubyMethod(name = "deprecated", required = 1, optional = 1)

--- a/logstash-core/src/main/java/org/logstash/log/SlowLoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/SlowLoggerExt.java
@@ -55,15 +55,34 @@ public class SlowLoggerExt extends RubyObject {
         super(runtime, metaClass);
     }
 
+    SlowLoggerExt(final Ruby runtime, final RubyClass metaClass, final String loggerName,
+                  final long warnThreshold, final long infoThreshold,
+                  final long debugThreshold, final long traceThreshold) {
+        super(runtime, metaClass);
+        initialize(loggerName, warnThreshold, infoThreshold, debugThreshold, traceThreshold);
+    }
+
     @JRubyMethod(required = 5)
     public SlowLoggerExt initialize(final ThreadContext context, final IRubyObject[] args) {
-        String loggerName = args[0].asJavaString();
-        slowLogger = LogManager.getLogger("slowlog." + loggerName);
-        warnThreshold = ((RubyNumeric) args[1]).getLongValue();
-        infoThreshold = ((RubyNumeric) args[2]).getLongValue();
-        debugThreshold = ((RubyNumeric) args[3]).getLongValue();
-        traceThreshold = ((RubyNumeric) args[4]).getLongValue();
+        initialize(args[0].asJavaString(), toLong(args[1]), toLong(args[2]), toLong(args[3]), toLong(args[4]));
         return this;
+    }
+
+    private void initialize(final String loggerName,
+                            final long warnThreshold, final long infoThreshold,
+                            final long debugThreshold, final long traceThreshold) {
+        slowLogger = LogManager.getLogger("slowlog." + loggerName);
+        this.warnThreshold = warnThreshold;
+        this.infoThreshold = infoThreshold;
+        this.debugThreshold = debugThreshold;
+        this.traceThreshold = traceThreshold;
+    }
+
+    static long toLong(final IRubyObject value) {
+        if (!(value instanceof RubyNumeric)) {
+            throw RubyUtil.RUBY.newTypeError("Numeric expected, got " + value.getMetaClass());
+        }
+        return ((RubyNumeric) value).getLongValue();
     }
 
     private RubyHash asData(final ThreadContext context, final IRubyObject pluginParams,


### PR DESCRIPTION
`RubyString#gsub` requires a (Ruby) frame to be present.
The method attempts to set a backref for the current caller's frame.
When the frame stack is empty there isn't really a place to set $~.

This can happen when a `LogStash::Util::Loggable#logger` is retrieved,
from the input worker thread while not being nested in any block.

Resolves https://github.com/elastic/logstash/issues/11854

---

Also refactored the logger name for anonymous modules - was `"module"` previously.
For classes the anonymous class name is used, so this is the same for modules now.
Please note that it's unlikely for anonymous classes/modules used within the LS ecosystem.