### PR TITLE
Feat: enable JRuby runtime management mbean

### DIFF
--- a/config/jvm.options
+++ b/config/jvm.options
@@ -51,6 +51,8 @@
 -Djruby.jit.threshold=0
 # Make sure joni regexp interruptability is enabled
 -Djruby.regexp.interruptible=true
+# Export runtime MBean for convenience
+-Djruby.management.enabled=true
 
 ## heap dumps
 


### PR DESCRIPTION
this is useful for a number of things e.g.
- getting a Ruby thread-dumps wout the Java dump 'noise'
- checking/changing stuff in a running LS (executing ruby)
- simple performance metrics such as number of exceptions

most of these is useful during development/testing.

some of these might be considered to be available in the LS API.