### PR TITLE
download kafka from another mirror

### DIFF
--- a/qa/integration/services/kafka_setup.sh
+++ b/qa/integration/services/kafka_setup.sh
@@ -22,7 +22,7 @@ setup_kafka() {
     local version=$1
     if [ ! -d $KAFKA_HOME ]; then
         echo "Downloading Kafka version $version"
-        curl -s -o $INSTALL_DIR/kafka.tgz "http://ftp.wayne.edu/apache/kafka/$version/kafka_2.11-$version.tgz"
+        curl -s -o $INSTALL_DIR/kafka.tgz "https://mirrors.ocf.berkeley.edu/apache/kafka/$version/kafka_2.11-$version.tgz"
         mkdir $KAFKA_HOME && tar xzf $INSTALL_DIR/kafka.tgz -C $KAFKA_HOME --strip-components 1
         rm $INSTALL_DIR/kafka.tgz
     fi


### PR DESCRIPTION
the current mirror now refuses connections for the past 36 hours

```
❯ curl -I http://ftp.wayne.edu/apache/kafka/2.4.1/kafka_2.11-2.4.1.tgz            
curl: (7) Failed to connect to ftp.wayne.edu port 80: Connection refused
```

Moving to a new mirror:

```
❯ curl -I https://mirrors.ocf.berkeley.edu/apache/kafka/2.4.1/kafka_2.11-2.4.1.tgz
HTTP/1.1 200 OK
Date: Mon, 11 May 2020 06:44:02 GMT
Server: Apache/2.4
Last-Modified: Wed, 11 Mar 2020 18:49:30 GMT
ETag: "42e8dc5-5a098b25140d8"
Accept-Ranges: bytes
Content-Length: 70159813
Content-Type: application/x-gzip
```