### PR TITLE
Fix: rounded to 1 second in nanos to avoid random NaN error

### DIFF
--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/LsMetricsMonitor.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/LsMetricsMonitor.java
@@ -74,7 +74,7 @@ public final class LsMetricsMonitor implements Callable<EnumMap<LsMetricStats, L
                 final long newstrt = System.nanoTime();
                 stats.addValue(
                     (double) (newcount - count) /
-                        (double) TimeUnit.SECONDS.convert(newstrt - start, TimeUnit.NANOSECONDS)
+                        (double) TimeUnit.SECONDS.convert(Math.max(newstrt - start, 1_000_000_000), TimeUnit.NANOSECONDS)
                 );
                 start = newstrt;
                 count = newcount;


### PR DESCRIPTION
Conversion to seconds of values under 1_000_000_000 nanoseconds translates to value 0, and this led to NaN when used as denominator in a division.
A value of 996_920_400 nanoseconds once converted to seconds is not rounded to 1 second but to 0, this manifest on Windows OS when we read the nanosecond and we expected to wait for 1 second.