### PR TITLE
[Doc]Add a new header for integration plugins

### DIFF
--- a/docs/include/plugin_header-integration.asciidoc
+++ b/docs/include/plugin_header-integration.asciidoc
@@ -1,0 +1,39 @@
+ifeval::["{versioned_docs}"!="true"]
+[subs="attributes"]
+++++
+<titleabbrev>{plugin}</titleabbrev>
+++++
+endif::[]
+ifeval::["{versioned_docs}"=="true"]
+[subs="attributes"]
+++++
+<titleabbrev>{version}</titleabbrev>
+++++
+endif::[]
+
+* A component of the <<plugins-integrations-{plugin},{plugin} integration plugin>> 
+* Integration version: {version}
+* Released on: {release_date}
+* {changelog_url}[Changelog]
+
+ifeval::["{versioned_docs}"!="true"]
+
+For other versions, see the
+{lsplugindocs}/{type}-{plugin}-index.html[Versioned plugin docs].
+
+endif::[]
+
+ifeval::["{versioned_docs}"=="true"]
+
+For other versions, see the <<integration-{plugin}-index,overview list>>.
+
+To learn more about Logstash, see the {logstash-ref}/index.html[Logstash Reference].
+
+endif::[]
+
+==== Getting Help
+
+For questions about the plugin, open a topic in the http://discuss.elastic.co[Discuss] forums. 
+For bugs or feature requests, open an issue in https://github.com/logstash-plugins/logstash-integration-{plugin}[Github].
+For the list of Elastic supported plugins, please consult the https://www.elastic.co/support/matrix#matrix_logstash_plugins[Elastic Support Matrix].
+


### PR DESCRIPTION
Integration plugin repos have different configurations and requirements from traditional plugins. This PR creates an plugin header file more appropriate for integrations. 

To test:
1. Check out this PR (as usual). 
2. Check out this [test PR #882](https://github.com/elastic/logstash-docs/pull/882) for `logstash-docs`. 
3. Build docs locally: `docbldlsx --open`

Next steps (@karenzone):
- [ ] Replace `include::{include_path}/plugin_header.asciidoc[]` for all integration plugins with `include::{include_path}/plugin_header-integration.asciidoc[]`
