### PR TITLE
fix bug for non-https https-proxies and uri escaped proxy user or pass

### DIFF
--- a/lib/pluginmanager/proxy_support.rb
+++ b/lib/pluginmanager/proxy_support.rb
@@ -51,9 +51,8 @@ end
 
 # Apply HTTP_PROXY and HTTPS_PROXY to the current environment
 # this will be used by any JRUBY calls
-def apply_env_proxy_settings(settings)
-  $stderr.puts("Using proxy #{settings}") if ENV["DEBUG"]
-  scheme = settings[:protocol].downcase
+def apply_env_proxy_settings(scheme, settings)
+  $stderr.puts("Using proxy #{settings} for #{scheme}") if ENV["DEBUG"]
   java.lang.System.setProperty("#{scheme}.proxyHost", settings[:host])
   java.lang.System.setProperty("#{scheme}.proxyPort", settings[:port].to_s)
   java.lang.System.setProperty("#{scheme}.proxyUsername", settings[:username].to_s)

--- a/lib/pluginmanager/proxy_support.rb
+++ b/lib/pluginmanager/proxy_support.rb
@@ -92,8 +92,7 @@ def configure_proxy
   if proxy_string_exists?(proxy)
     proxy_uri = parse_proxy_string(proxy)
     proxy_settings = extract_proxy_values_from_uri(proxy_uri)
-    proxy_settings[:protocol] = "http"
-    apply_env_proxy_settings(proxy_settings)
+    apply_env_proxy_settings("http", proxy_settings)
     proxies << proxy_settings
   end
 
@@ -101,8 +100,7 @@ def configure_proxy
   if proxy_string_exists?(proxy)
     proxy_uri = parse_proxy_string(proxy)
     proxy_settings = extract_proxy_values_from_uri(proxy_uri)
-    proxy_settings[:protocol] = "https"
-    apply_env_proxy_settings(proxy_settings)
+    apply_env_proxy_settings("https", proxy_settings)
     proxies << proxy_settings
   end
 

--- a/lib/pluginmanager/utils/http_client.rb
+++ b/lib/pluginmanager/utils/http_client.rb
@@ -27,7 +27,10 @@ module LogStash module PluginManager module Utils
       proxy_url = ENV["https_proxy"] || ENV["HTTPS_PROXY"] || ""
       proxy_uri = URI(proxy_url)
 
-      Net::HTTP.start(uri.host, uri.port, proxy_uri.host, proxy_uri.port, proxy_uri.user, proxy_uri.password, http_options(uri)) { |http| yield http }
+      proxy_uri_user = URI.unescape(proxy_uri.user)
+      proxy_uri_password = URI.unescape(proxy_uri.password)
+
+      Net::HTTP.start(uri.host, uri.port, proxy_uri.host, proxy_uri.port, proxy_uri_user, proxy_uri_password, http_options(uri)) { |http| yield http }
     end
 
     def self.http_options(uri)


### PR DESCRIPTION
1. In pluginmanager, when setting `https_proxy `or `HTTPS_PROXY `with a non-https proxy, the protocol is always forced to "https". This should not happen in my opinion since proxy setups can use non-http proxies as https-proxies.

2. When calling `logstash-plugin install` with an ENV configured proxy, we have to use an URI version of our username and password, since otherwise URI will throw an error. But Net::HTTP does not unescape our username and password before using it. But for proxies, the unescaped username and password is required. So right now the pluginmanager does not work behind a proxy when you have some username or password which requires URI escaping.