### PR TITLE
Zulu is Windows's preferred JDK, removed Zulu from Unix JDK matrix

### DIFF
--- a/.ci/matrix-unix-runtime-javas.yml
+++ b/.ci/matrix-unix-runtime-javas.yml
@@ -6,13 +6,7 @@
 # or 'openjdk' followed by the major release number.
 
 LS_RUNTIME_JAVA:
-#  - java8
-#  - zulu8
-#  - adoptopenjdk8
-#  - java11
   - openjdk11
   - adoptopenjdk11
-  - zulu11
   - openjdk14
   - adoptopenjdk14
-  - zulu14


### PR DESCRIPTION
This PR removes the Zulu JDKs from Linux from testing matrix