### PR TITLE
[7.7 clean backport of #11844] Update JrJackson and Jackson Databind versions

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -21,6 +21,6 @@ jruby:
 # Note: this file is copied to the root of logstash-core because its gemspec needs it when
 #       bundler evaluates the gemspec via bin/logstash
 # Ensure Jackson version here is kept in sync with version used by jrjackson gem
-jrjackson: 0.4.11
+jrjackson: 0.4.12
 jackson: 2.9.10
-jackson-databind: 2.9.10.1
+jackson-databind: 2.9.10.4


### PR DESCRIPTION
Update the versions of JrJackson and jackson databind to the
latest available versions
