### PR TITLE
Do not set Xmx and Xms

### DIFF
--- a/docker/templates/Dockerfile.j2
+++ b/docker/templates/Dockerfile.j2
@@ -46,7 +46,9 @@ ADD config/pipelines.yml config/pipelines.yml
 ADD config/logstash-{{ image_flavor }}.yml config/logstash.yml
 ADD config/log4j2.properties config/
 ADD pipeline/default.conf pipeline/logstash.conf
-RUN chown --recursive logstash:root config/ pipeline/
+# set permissions and comment out Xmx and Xms options to use container limits
+RUN chown --recursive logstash:root config/ pipeline/  && \
+  sed -i -e 's/^-Xm\([xs]\)/#-Xm\1/' config/jvm.options
 
 # Ensure Logstash gets a UTF-8 locale by default.
 ENV LANG='en_US.UTF-8' LC_ALL='en_US.UTF-8'


### PR DESCRIPTION
So we can take advantage of container limits using

* -XX:InitialRAMPercentage
* -XX:MaxRAMPercentage

Before, a 512m container would try to use 1GB as it is hardcoded in `/usr/share/logstash/config/jvm.options` and crash. A 1GB+ container would not use all the memory available

```
docker run --name logstash -m 512m -e LS_JAVA_OPTS="-XshowSettings:vm -XX:+PrintFlagsFinal -XX:MaxRAMPercentage=99 -XX:InitialRAMPercentage=99" -ti --rm logstash | grep HeapSize
   size_t InitialHeapSize                          = 1073741824                                {product} {command line}
   size_t MaxHeapSize                              = 1073741824                                {product} {command line}
```

After, we can leave the JVM to calculate the heap (1/4 of total by default)

```
docker run --name logstash -m 512m -e LS_JAVA_OPTS="-XshowSettings:vm -XX:+PrintFlagsFinal" -ti --rm logstash:csanchez | grep HeapSize
   size_t InitialHeapSize                          = 8388608                                   {product} {ergonomic}
   size_t MaxHeapSize                              = 134217728                                 {product} {ergonomic}
```

Or we can set a percentage of the memory with `-XX:MaxRAMPercentage` and `-XX:InitialRAMPercentage`

```
docker run --name logstash -m 512m -e LS_JAVA_OPTS="-XshowSettings:vm -XX:+PrintFlagsFinal -XX:MaxRAMPercentage=99 -XX:InitialRAMPercentage=99" -ti --rm logstash:csanchez | grep HeapSize
   size_t InitialHeapSize                          = 532676608                                 {product} {ergonomic}
   size_t MaxHeapSize                              = 532676608                                 {product} {ergonomic}
```
