### PR TITLE
Added OSes definitions files to be used in compatibility test phases

### DIFF
--- a/.ci/matrix-unix-compatibility-linux-distros.yml
+++ b/.ci/matrix-unix-compatibility-linux-distros.yml
@@ -1,0 +1,28 @@
+# This file is used as part of a matrix build in Jenkins where the
+# values below are included as an axis of the matrix.
+
+# This axis of the build matrix represents the Linux distributions on
+# which Logstash will be tested.
+
+#os:
+#  - amazon
+#  - centos-6&&immutable
+#  - centos-7&&immutable
+#  - debian-8&&immutable
+#  - debian-9&&immutable
+#  - debian-10&&immutable
+#  - fedora-29&&immutable
+#  - opensuse-15-1&&immutable
+#  - oraclelinux-6&&immutable
+#  - oraclelinux-7&&immutable
+#  - ubuntu-18.04&&immutable
+#  - ubuntu-20.04&&immutable
+
+os:
+  - amazon
+  - centos&&immutable
+  - debian&&immutable
+  - fedora-29&&immutable
+  - opensuse-15-1&&immutable
+  - oraclelinux&&immutable
+  - ubuntu&&immutable

--- a/.ci/matrix-unix-linux-distros.yml
+++ b/.ci/matrix-unix-linux-distros.yml
@@ -1,0 +1,9 @@
+# This file is used as part of a matrix build in Jenkins where the
+# values below are included as an axis of the matrix.
+
+# This axis of the build matrix represents the Linux distributions on
+# which Logstash will be tested.
+
+os:
+  - centos-7&&immutable
+  - ubuntu-18.04&&immutable

--- a/.ci/matrix-windows-compatibility-versions.yml
+++ b/.ci/matrix-windows-compatibility-versions.yml
@@ -1,0 +1,10 @@
+# This file is used as part of a matrix build in Jenkins where the
+# values below are included as an axis of the matrix.
+
+# This axis of the build matrix represents the Linux distributions on
+# which Logstash will be tested.
+
+nodes:
+  - "windows-2012-r2"
+  - "windows-2016"
+  - "windows-2019"


### PR DESCRIPTION
To be unlinked from infra and made the selection of OSes that Logstash is tested against, the list is moved .ci specific yaml files.
By now the OSes are distinguished by Windows platform and by Linux distributions.