### PR TITLE
Pass FEATURE_FLAG as Docker environment variable

### DIFF
--- a/ci/docker_integration_tests.sh
+++ b/ci/docker_integration_tests.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
+# we may pass "persistent_queues" to FEATURE_FLAG to enable PQ in the integration tests
+export DOCKER_ENV_OPTS="${DOCKER_ENV_OPTS} -e FEATURE_FLAG"
 ci/docker_run.sh logstash-integration-tests ci/integration_tests.sh $@


### PR DESCRIPTION
Some QA tests reads the FEATURE_FLAG environment variable, for example to test PQ functionality.
This PR passthrough the environement variable inside the Docker instance.

To run it locally use:
```
bash> FEATURE_FLAG=persistent_queues ci/docker_integration_tests.sh specs/monitoring_api_spec.rb
```