### PR TITLE
Exposed again the pipelines queue.data and queue.capacity subdocuments for _node/stats

### DIFF
--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -167,7 +167,7 @@ module LogStash
 
             # if extended_stats were provided, enrich the return value
             if extended_stats
-              ret[:queue]    = extended_stats["queue"] if extended_stats.include?("queue")
+              ret[:queue].merge!(extended_stats["queue"]) if extended_stats.include?("queue")
               ret[:hash] = extended_stats["hash"]
               ret[:ephemeral_id] = extended_stats["ephemeral_id"]
               if opts[:vertices] && extended_stats.include?("vertices")


### PR DESCRIPTION
Avoid to reassign the subdocument for queue metrics preferring a merge
With PR #10576 the PluginsStats.report(stats) overwrites the subsection related to queue instead of merge with newly created entries.

With the overwriting of `queue` subdocument the HTTP with `extended_stats` return something like 
```json
"queue": {
  "type": "persisted",
  "events_count": 0,
  "queue_size_in_bytes": 1,
  "max_queue_size_in_bytes": 1073741824 
}
```

instead of the original form:
```json
"queue": {
  "type": "persisted",
  "capacity": {
    "max_queue_size_in_bytes": 1073741824,
    "page_capacity_in_bytes": 67108864,
    "queue_size_in_bytes": 1, 
    "max_unread_events": 0
  },
  "events": 0,
  "data": {
    "path": "/home/andrea/workspace/logstash_andsel/data/queue/main",
    "storage_type": "ext4",
    "free_space_in_bytes": 57728352256
  }
}
```

To not break anything published, this PR does the merge of both, duplicating some data
