### PR TITLE
Fix integration tests related to logs when persistent_queue FEATURE_FLAG is enabled

### DIFF
--- a/qa/integration/fixtures/persistent_queues/log4j2.properties
+++ b/qa/integration/fixtures/persistent_queues/log4j2.properties
@@ -4,7 +4,7 @@ name = LogstashPropertiesConfig
 appender.console.type = Console
 appender.console.name = plain_console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %m%n
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c]%notEmpty{[%X{pipeline.id}]}%notEmpty{[%X{plugin.id}]} %m%n
 
 appender.json_console.type = Console
 appender.json_console.name = json_console
@@ -21,7 +21,16 @@ appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
 appender.rolling.policies.time.interval = 1
 appender.rolling.policies.time.modulate = true
 appender.rolling.layout.type = PatternLayout
-appender.rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %-.10000m%n
+appender.rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c]%notEmpty{[%X{pipeline.id}]}%notEmpty{[%X{plugin.id}]} %m%n
+appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
+appender.rolling.policies.size.size = 100MB
+appender.rolling.strategy.type = DefaultRolloverStrategy
+appender.rolling.strategy.max = 30
+appender.rolling.avoid_pipelined_filter.type = ScriptFilter
+appender.rolling.avoid_pipelined_filter.script.type = Script
+appender.rolling.avoid_pipelined_filter.script.name = filter_no_pipelined
+appender.rolling.avoid_pipelined_filter.script.language = JavaScript
+appender.rolling.avoid_pipelined_filter.script.value = ${sys:ls.pipeline.separate_logs} == false || !(logEvent.getContextData().containsKey("pipeline.id"))
 
 appender.json_rolling.type = RollingFile
 appender.json_rolling.name = json_rolling
@@ -34,11 +43,43 @@ appender.json_rolling.policies.time.modulate = true
 appender.json_rolling.layout.type = JSONLayout
 appender.json_rolling.layout.compact = true
 appender.json_rolling.layout.eventEol = true
+appender.json_rolling.policies.size.type = SizeBasedTriggeringPolicy
+appender.json_rolling.policies.size.size = 100MB
+appender.json_rolling.strategy.type = DefaultRolloverStrategy
+appender.json_rolling.strategy.max = 30
+appender.json_rolling.avoid_pipelined_filter.type = ScriptFilter
+appender.json_rolling.avoid_pipelined_filter.script.type = Script
+appender.json_rolling.avoid_pipelined_filter.script.name = filter_no_pipelined
+appender.json_rolling.avoid_pipelined_filter.script.language = JavaScript
+appender.json_rolling.avoid_pipelined_filter.script.value = ${sys:ls.pipeline.separate_logs} == false || !(logEvent.getContextData().containsKey("pipeline.id"))
 
+appender.routing.type = Routing
+appender.routing.name = pipeline_routing_appender
+appender.routing.routes.type = Routes
+appender.routing.routes.script.type = Script
+appender.routing.routes.script.name = routing_script
+appender.routing.routes.script.language = JavaScript
+appender.routing.routes.script.value = logEvent.getContextData().containsKey("pipeline.id") ? logEvent.getContextData().getValue("pipeline.id") : "sink";
+appender.routing.routes.route_pipelines.type = Route
+appender.routing.routes.route_pipelines.rolling.type = RollingFile
+appender.routing.routes.route_pipelines.rolling.name = appender-${ctx:pipeline.id}
+appender.routing.routes.route_pipelines.rolling.fileName = ${sys:ls.logs}/pipeline_${ctx:pipeline.id}.log
+appender.routing.routes.route_pipelines.rolling.filePattern = ${sys:ls.logs}/pipeline_${ctx:pipeline.id}.%i.log.gz
+appender.routing.routes.route_pipelines.rolling.layout.type = PatternLayout
+appender.routing.routes.route_pipelines.rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %m%n
+appender.routing.routes.route_pipelines.rolling.policy.type = SizeBasedTriggeringPolicy
+appender.routing.routes.route_pipelines.rolling.policy.size = 100MB
+appender.routing.routes.route_pipelines.strategy.type = DefaultRolloverStrategy
+appender.routing.routes.route_pipelines.strategy.max = 30
+appender.routing.routes.route_sink.type = Route
+appender.routing.routes.route_sink.key = sink
+appender.routing.routes.route_sink.null.type = Null
+appender.routing.routes.route_sink.null.name = drop-appender
 
 rootLogger.level = ${sys:ls.log.level}
 rootLogger.appenderRef.console.ref = ${sys:ls.log.format}_console
 rootLogger.appenderRef.rolling.ref = ${sys:ls.log.format}_rolling
+rootLogger.appenderRef.routing.ref = pipeline_routing_appender
 
 # Slowlog
 
@@ -62,7 +103,7 @@ appender.rolling_slowlog.policies.time.type = TimeBasedTriggeringPolicy
 appender.rolling_slowlog.policies.time.interval = 1
 appender.rolling_slowlog.policies.time.modulate = true
 appender.rolling_slowlog.layout.type = PatternLayout
-appender.rolling_slowlog.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %.10000m%n
+appender.rolling_slowlog.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %m%n
 
 appender.json_rolling_slowlog.type = RollingFile
 appender.json_rolling_slowlog.name = json_rolling_slowlog
@@ -81,3 +122,29 @@ logger.slowlog.level = trace
 logger.slowlog.appenderRef.console_slowlog.ref = ${sys:ls.log.format}_console_slowlog
 logger.slowlog.appenderRef.rolling_slowlog.ref = ${sys:ls.log.format}_rolling_slowlog
 logger.slowlog.additivity = false
+
+# Deprecation log
+appender.deprecation_rolling.type = RollingFile
+appender.deprecation_rolling.name = deprecation_plain_rolling
+appender.deprecation_rolling.fileName = ${sys:ls.logs}/logstash-deprecation.log
+appender.deprecation_rolling.filePattern = ${sys:ls.logs}/logstash-deprecation-%d{yyyy-MM-dd}.log.gz
+appender.deprecation_rolling.policies.type = Policies
+appender.deprecation_rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.deprecation_rolling.policies.time.interval = 1
+appender.deprecation_rolling.policies.time.modulate = true
+appender.deprecation_rolling.layout.type = PatternLayout
+appender.deprecation_rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c]%notEmpty{[%X{pipeline.id}]}%notEmpty{[%X{plugin.id}]} %m%n
+appender.deprecation_rolling.policies.size.type = SizeBasedTriggeringPolicy
+appender.deprecation_rolling.policies.size.size = 100MB
+appender.deprecation_rolling.strategy.type = DefaultRolloverStrategy
+appender.deprecation_rolling.strategy.max = 30
+
+logger.deprecation.name = org.logstash.deprecation, deprecation
+logger.deprecation.level = WARN
+logger.deprecation.appenderRef.deprecation_rolling.ref = deprecation_plain_rolling
+logger.deprecation.additivity = false
+
+logger.deprecation_root.name = deprecation
+logger.deprecation_root.level = WARN
+logger.deprecation_root.appenderRef.deprecation_rolling.ref = deprecation_plain_rolling
+logger.deprecation_root.additivity = false


### PR DESCRIPTION
Updated log4j definitions used when FEATURE_FLAG=persistent_queue is used.

Fixes fails 1, 3,4,5 in issue #11924 while the 2 is solved by PR #11923