### PR TITLE
Escape test fixture service scripts

### DIFF
--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -95,7 +95,7 @@ class LogstashService < Service
   # Given an input this pipes it to LS. Expects a stdin input in LS
   def start_with_input(config, input)
     Bundler.with_clean_env do
-      `cat #{input} | #{@logstash_bin} -e \'#{config}\'`
+      `cat #{Shellwords.escape(input)} | #{Shellwords.escape(@logstash_bin)} -e \'#{config}\'`
     end
   end
 

--- a/qa/integration/services/service.rb
+++ b/qa/integration/services/service.rb
@@ -25,8 +25,8 @@ class Service
   def initialize(name, settings)
     @name = name
     @settings = settings
-    @setup_script = File.expand_path("../#{name}_setup.sh", __FILE__)
-    @teardown_script = File.expand_path("../#{name}_teardown.sh", __FILE__)
+    @setup_script = Shellwords.escape(File.expand_path("../#{name}_setup.sh", __FILE__))
+    @teardown_script = Shellwords.escape(File.expand_path("../#{name}_teardown.sh", __FILE__))
   end
 
   def setup


### PR DESCRIPTION
Escape test fixture service scripts to avoid test failures when run in
Jenkins using multiple yaml configuration files, which causes directories
to be constructed like `centos-7&&immutable` which cause issues with
the service runners cutting off directory locations before '&&'