### PR TITLE
Set `JAVA_HOME` to `BUILD_JAVA_HOME` in xpack integration tests

### DIFF
--- a/x-pack/ci/integration_tests.sh
+++ b/x-pack/ci/integration_tests.sh
@@ -14,6 +14,7 @@ export CI=true
 
 if [ -n "$BUILD_JAVA_HOME" ]; then
   GRADLE_OPTS="$GRADLE_OPTS -Dorg.gradle.java.home=$BUILD_JAVA_HOME"
+  export JAVA_HOME="$BUILD_JAVA_HOME"
 fi
 
 ./gradlew runXPackIntegrationTests


### PR DESCRIPTION
JDK xpack integration tests not using docker images are failing, as latest versions of Elasticsearch require java 11+ to run, whereas the default java on the worker nodes is java 8. 

This commit sets `JAVA_HOME` to be the same as `BUILD_JAVA_HOME` to mimic likely scenarios where elasticsearch and logstash use the same installed version of Java.

