### PR TITLE
emit deprecation entry for netflow and azure modules

### DIFF
--- a/logstash-core/lib/logstash/modules/logstash_config.rb
+++ b/logstash-core/lib/logstash/modules/logstash_config.rb
@@ -19,6 +19,7 @@ require_relative "file_reader"
 require "logstash/settings"
 
 module LogStash module Modules class LogStashConfig
+  include LogStash::Util::Loggable
   # We name it `modul` here because `module` has meaning in Ruby.
   def initialize(modul, settings)
     @directory = ::File.join(modul.directory, "logstash")

--- a/modules/netflow/configuration/logstash/netflow.conf.erb
+++ b/modules/netflow/configuration/logstash/netflow.conf.erb
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+<% deprecation_logger.deprecated("The Netflow module has been deprecated in favor of the Beats Netflow module and may be removed in a future release. Learn more about the Beats Netflow module at https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-netflow.html") %>
 input {
     udp {
         type => "netflow"

--- a/x-pack/modules/azure/configuration/logstash/azure.conf.erb
+++ b/x-pack/modules/azure/configuration/logstash/azure.conf.erb
@@ -4,6 +4,7 @@
 
 input{
 <%=
+deprecation_logger.deprecated("The Azure module has been deprecated in favor of the Beats Azure module, and may be removed in a future release. Learn more about the Beats Azure module at https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-azure.html")
 require 'azure_module_config_generator'
 config_generator = LogStash::Azure::ConfigGenerator.new
 config_generator.generate_input(@settings)


### PR DESCRIPTION
To test start logstash `bin/logstash --modules netflow`
To test the azure notice you'll need to start an elasticsearch instance on localhost.