### PR TITLE
[Test] Enable fallback to sleep if nc not installed

### DIFF
--- a/qa/integration/services/helpers.sh
+++ b/qa/integration/services/helpers.sh
@@ -23,7 +23,7 @@ wait_for_port() {
 }
 
 test_port() {
-    if command -v ncd 2>/dev/null; then
+    if command -v nc 2>/dev/null; then
       test_port_nc "$1"
     else
       test_port_ruby "$1"

--- a/qa/integration/services/helpers.sh
+++ b/qa/integration/services/helpers.sh
@@ -12,6 +12,14 @@ setup_install_dir() {
 }
 
 wait_for_port() {
+    if command -v nc 2>/dev/null; then
+        wait_for_port_nc "$@"
+    else
+        wait_for_port_sleep "$@"
+    fi
+}
+
+wait_for_port_nc() {
     count=$PORT_WAIT_COUNT
     port=$1
     while ! nc -z localhost $port && [[ $count -ne 0 ]]; do
@@ -21,6 +29,12 @@ wait_for_port() {
     done
     # just in case, one more time
     nc -z localhost $port
+
+}
+
+wait_for_port_sleep() {
+  echo "nc not installed on this machine. Sleeping for 10 seconds"
+  sleep 10
 }
 
 clean_install_dir() {

--- a/qa/integration/services/helpers.sh
+++ b/qa/integration/services/helpers.sh
@@ -12,29 +12,30 @@ setup_install_dir() {
 }
 
 wait_for_port() {
-    if command -v nc 2>/dev/null; then
-        wait_for_port_nc "$@"
-    else
-        wait_for_port_sleep "$@"
-    fi
-}
-
-wait_for_port_nc() {
     count=$PORT_WAIT_COUNT
-    port=$1
-    while ! nc -z localhost $port && [[ $count -ne 0 ]]; do
+    while ! test_port "$1"  && [[ $count -ne 0 ]]; do
         count=$(( $count - 1 ))
         [[ $count -eq 0 ]] && return 1
         sleep 0.5
     done
     # just in case, one more time
-    nc -z localhost $port
-
+    test_port "$1"
 }
 
-wait_for_port_sleep() {
-  echo "nc not installed on this machine. Sleeping for 10 seconds"
-  sleep 10
+test_port() {
+    if command -v ncd 2>/dev/null; then
+      test_port_nc "$1"
+    else
+      test_port_ruby "$1"
+    fi
+}
+
+test_port_nc() {
+  nc -z localhost $1
+}
+
+test_port_ruby() {
+  ruby -rsocket -e "TCPSocket.new('localhost', $1) rescue exit(1)"
 }
 
 clean_install_dir() {


### PR DESCRIPTION
Fixture test scripts use `nc` to wait for the port to determine
whether a test fixture is up and running. This commit adds a fall
back option to sleep if `nc` is not available - it is not installed
on Jenkins centos worker nodes.