### PR TITLE
[7.x backport] Use task avoidance API in gradle scripts (#11914)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,39 +148,45 @@ def assemblyDeps = [downloadAndInstallJRuby, assemble] + subprojects.collect {
   it.tasks.findByName("assemble")
 }
 
-task installBundler(dependsOn: assemblyDeps) {
-  outputs.files file("${projectDir}/vendor/bundle/jruby/2.5.0/bin/bundle")
-  doLast {
+tasks.register("installBundler") {
+    dependsOn assemblyDeps
+    outputs.files file("${projectDir}/vendor/bundle/jruby/2.5.0/bin/bundle")
+    doLast {
       gem(projectDir, buildDir, "bundler", "1.17.3", "${projectDir}/vendor/bundle/jruby/2.5.0")
   }
 }
 
-task bootstrap(dependsOn: installBundler) {
-  doLast {
+tasks.register("bootstrap"){
+    dependsOn installBundler
+    doLast {
       setupJruby(projectDir, buildDir)
   }
 }
 
 
-task installDefaultGems(dependsOn: bootstrap) {
+tasks.register("installDefaultGems") {
+    dependsOn bootstrap
   doLast {
       rake(projectDir, buildDir, 'plugin:install-default')
   }
 }
 
-task installTestGems(dependsOn: bootstrap) {
-  doLast {
+tasks.register("installTestGems") {
+    dependsOn bootstrap
+    doLast {
       rake(projectDir, buildDir, 'plugin:install-development-dependencies')
   }
 }
 
-task compileGrammar(dependsOn: bootstrap) {
+tasks.register("compileGrammar") {
+    dependsOn bootstrap
     doLast {
         rake(projectDir, buildDir, 'compile:grammar')
     }
 }
 
-task assembleTarDistribution(dependsOn: bootstrap) {
+tasks.register("assembleTarDistribution") {
+  dependsOn bootstrap
   inputs.files fileTree("${projectDir}/rakelib")
   inputs.files fileTree("${projectDir}/bin")
   inputs.files fileTree("${projectDir}/config")
@@ -196,7 +202,8 @@ task assembleTarDistribution(dependsOn: bootstrap) {
   }
 }
 
-task assembleOssTarDistribution(dependsOn: bootstrap) {
+tasks.register("assembleOssTarDistribution") {
+  dependsOn bootstrap
   inputs.files fileTree("${projectDir}/rakelib")
   inputs.files fileTree("${projectDir}/bin")
   inputs.files fileTree("${projectDir}/config")
@@ -210,7 +217,8 @@ task assembleOssTarDistribution(dependsOn: bootstrap) {
   }
 }
 
-task assembleZipDistribution(dependsOn: bootstrap) {
+tasks.register("assembleZipDistribution") {
+  dependsOn bootstrap
   inputs.files fileTree("${projectDir}/rakelib")
   inputs.files fileTree("${projectDir}/bin")
   inputs.files fileTree("${projectDir}/config")
@@ -226,7 +234,8 @@ task assembleZipDistribution(dependsOn: bootstrap) {
   }
 }
 
-task assembleOssZipDistribution(dependsOn: bootstrap) {
+tasks.register("assembleOssZipDistribution") {
+  dependsOn bootstrap
   inputs.files fileTree("${projectDir}/rakelib")
   inputs.files fileTree("${projectDir}/bin")
   inputs.files fileTree("${projectDir}/config")
@@ -252,7 +261,8 @@ project(":logstash-core") {
 
 def logstashBuildDir = "${buildDir}/logstash-${project.version}-SNAPSHOT"
 
-task unpackTarDistribution(dependsOn: assembleTarDistribution, type: Copy) {
+tasks.register("unpackTarDistribution", Copy) {
+  dependsOn assembleTarDistribution
   def tar = file("${buildDir}/logstash-${project.version}-SNAPSHOT.tar.gz")
   inputs.files tar
   outputs.files fileTree(logstashBuildDir)
@@ -264,14 +274,16 @@ def qaVendorPath = "${buildDir}/qa/integration/vendor"
 def qaBundledGemPath = "${qaVendorPath}/jruby/2.5.0"
 def qaBundleBin = "${qaBundledGemPath}/bin/bundle"
 
-task installIntegrationTestBundler(dependsOn: unpackTarDistribution) {
-  outputs.files fileTree("${qaBundledGemPath}/gems/bundler-1.17.3")
+tasks.register("installIntegrationTestBundler"){
+    dependsOn unpackTarDistribution
+    outputs.files fileTree("${qaBundledGemPath}/gems/bundler-1.17.3")
   doLast {
       gem(projectDir, buildDir, "bundler", "1.17.3", qaBundledGemPath)
   }
 }
 
-task installIntegrationTestGems(dependsOn: installIntegrationTestBundler) {
+tasks.register("installIntegrationTestGems") {
+  dependsOn installIntegrationTestBundler
   inputs.files file("${projectDir}/qa/integration/Gemfile")
   inputs.files file("${projectDir}/qa/integration/integration_tests.gemspec")
   inputs.files file("${logstashBuildDir}/Gemfile")
@@ -300,11 +312,13 @@ project(":logstash-integration-tests") {
   }
 }
 
-task runIntegrationTests(dependsOn: [tasks.getByPath(":logstash-integration-tests:integrationTests")]) {}
+tasks.register("runIntegrationTests"){
+    dependsOn tasks.getByPath(":logstash-integration-tests:integrationTests")
+}
 
-task generateLicenseReport(type: JavaExec) {
-    dependsOn("generateLicenseReportInputs")
-    dependsOn(":dependencies-report:assemble")
+tasks.register("generateLicenseReport", JavaExec) {
+    dependsOn generateLicenseReportInputs
+    dependsOn ":dependencies-report:assemble"
 
     def jarFile = project('dependencies-report').getBuildDir().toString() + "/libs/dependencies-report.jar"
 
@@ -319,7 +333,7 @@ task generateLicenseReport(type: JavaExec) {
       licenseReportOutputCSV, noticePath
 }
 
-task generateLicenseReportInputs() {
+tasks.register("generateLicenseReportInputs") {
     dependsOn subprojects.generateLicenseReport
 
     // write location of all license reports for subprojects containing artifacts that are distributed to single file
@@ -342,7 +356,8 @@ task generateLicenseReportInputs() {
     }
 }
 
-task generatePluginsVersion(dependsOn: installDefaultGems) {
+tasks.register("generatePluginsVersion") {
+  dependsOn installDefaultGems
   doLast {
       rake(projectDir, buildDir, 'generate_plugins_version')
   }
@@ -355,7 +370,7 @@ check.dependsOn runIntegrationTests
 
 String artifactsVersionApi = "https://artifacts-api.elastic.co/v1/versions/"
 
-task downloadEs(type: Download) {
+tasks.register("downloadEs", Download) {
     description "Download ES Snapshot for current branch version: ${version}"
 
     doFirst {
@@ -425,11 +440,12 @@ task downloadEs(type: Download) {
     }
 }
 
-task deleteLocalEs(type: Delete) {
+tasks.register("deleteLocalEs", Delete) {
     delete ('./build/elasticsearch')
 }
 
-task copyEs(type: Copy, dependsOn: [downloadEs, deleteLocalEs]) {
+tasks.register("copyEs", Copy){
+    dependsOn = [downloadEs, deleteLocalEs]
     from tarTree(resources.gzip(project.ext.elasticsearchDownloadLocation))
     into "./build/"
     doLast {

--- a/logstash-core/benchmarks/build.gradle
+++ b/logstash-core/benchmarks/build.gradle
@@ -76,7 +76,9 @@ shadowJar {
   archiveVersion = ''
 }
 
-task jmh(type: JavaExec, dependsOn: [':logstash-core-benchmarks:clean', ':logstash-core-benchmarks:shadowJar']) {
+tasks.register("jmh", JavaExec) {
+
+ dependsOn=[':logstash-core-benchmarks:clean', ':logstash-core-benchmarks:shadowJar']
 
   main = "-jar"
 

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -43,31 +43,34 @@ buildscript {
     }
 }
 
-task sourcesJar(type: Jar, dependsOn: classes) {
+tasks.register("sourcesJar", Jar) {
+    dependsOn classes
     from sourceSets.main.allSource
     archiveClassifier = 'sources'
     archiveExtension = 'jar'
 }
 
-task javadocJar(type: Jar, dependsOn: javadoc) {
+tasks.register("javadocJar", Jar) {
+    dependsOn javadoc
     from javadoc.destinationDir
     archiveClassifier = 'javadoc'
     archiveExtension = 'jar'
 }
 
-task copyRuntimeLibs(type: Copy) {
+tasks.register("copyRuntimeLibs", Copy) {
     into project.file('lib/jars/')
     from configurations.compileClasspath, configurations.runtimeClasspath
 }
 
 // copy jar file into the gem lib dir but without the version number in filename
-task copyGemjar(type: Copy, dependsOn: [sourcesJar, copyRuntimeLibs]) {
+tasks.register("copyGemjar", Copy) {
+    dependsOn=[sourcesJar, copyRuntimeLibs]
     from project.jar
     into project.file('lib/jars/')
     rename(/(.+)-${project.version}.jar/, '$1.jar')
 }
 
-task cleanGemjar {
+tasks.register("cleanGemjar") {
     delete fileTree(project.file('lib/jars/')) {
         include '*.jar'
     }
@@ -84,7 +87,7 @@ configurations.archives {
     extendsFrom configurations.javadoc
 }
 
-task javaTests(type: Test) {
+tasks.register("javaTests", Test) {
     exclude '/org/logstash/RSpecTests.class'
     exclude '/org/logstash/config/ir/ConfigCompilerTest.class'
     exclude '/org/logstash/config/ir/CompiledPipelineTest.class'
@@ -96,7 +99,7 @@ task javaTests(type: Test) {
     exclude '/org/logstash/plugins/PluginFactoryExtTest.class'
 }
 
-task rubyTests(type: Test) {
+tasks.register("rubyTests", Test) {
     inputs.files fileTree("${projectDir}/lib")
     inputs.files fileTree("${projectDir}/spec")
     systemProperty 'logstash.core.root.dir', projectDir.absolutePath

--- a/qa/integration/build.gradle
+++ b/qa/integration/build.gradle
@@ -39,7 +39,7 @@ test {
   exclude '/**'
 }
 
-task integrationTests(type: Test) {
+tasks.register("integrationTests", Test) {
   inputs.files fileTree("${projectDir}/services")
   inputs.files fileTree("${projectDir}/framework")
   inputs.files fileTree("${projectDir}/fixtures")

--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -208,7 +208,7 @@ def customJRubyDir = project.hasProperty("custom.jruby.path") ? project.property
 def customJRubyVersion = customJRubyDir == "" ? "" : Files.readAllLines(Paths.get(customJRubyDir, "VERSION")).get(0).trim()
 def customJRubyTar = customJRubyDir == "" ? "" : (customJRubyDir + "/maven/jruby-dist/target/jruby-dist-${customJRubyVersion}-bin.tar.gz")
 
-task downloadJRuby(type: Download) {
+tasks.register("downloadJRuby", Download) {
     description "Download JRuby artifact from this specific URL: ${jRubyURL}"
     src jRubyURL
     onlyIfNewer true
@@ -219,7 +219,8 @@ task downloadJRuby(type: Download) {
 
 downloadJRuby.onlyIf { customJRubyDir == "" }
 
-task verifyFile(dependsOn: downloadJRuby, type: Verify) {
+tasks.register("verifyFile", Verify) {
+    dependsOn downloadJRuby
     description "Verify the SHA1 of the download JRuby artifact"
     inputs.file(jrubyTarPath)
     outputs.file(jrubyTarPath)
@@ -231,7 +232,7 @@ task verifyFile(dependsOn: downloadJRuby, type: Verify) {
 verifyFile.onlyIf { customJRubyDir == "" }
 verifyFile.onlyIf { doChecksum }
 
-task buildCustomJRuby(type: Exec) {
+tasks.register("buildCustomJRuby", Exec) {
     description "Build tar.gz and .jar artifacts from JRuby source directory"
     workingDir (customJRubyDir == "" ? "./" : customJRubyDir)
     commandLine './mvnw', 'clean', 'install', '-Pdist', '-Pcomplete'
@@ -244,7 +245,8 @@ task buildCustomJRuby(type: Exec) {
 
 buildCustomJRuby.onlyIf { customJRubyDir != "" }
 
-task installCustomJRuby(dependsOn: buildCustomJRuby, type: Copy) {
+tasks.register("installCustomJRuby", Copy) {
+    dependsOn buildCustomJRuby
     description "Install custom built JRuby in the vendor directory"
     inputs.file(customJRubyTar)
     outputs.dir("${projectDir}/vendor/jruby")
@@ -260,7 +262,8 @@ task installCustomJRuby(dependsOn: buildCustomJRuby, type: Copy) {
 installCustomJRuby.onlyIf { customJRubyDir != "" }
 
 
-task downloadAndInstallJRuby(dependsOn: [verifyFile, installCustomJRuby], type: Copy) {
+tasks.register("downloadAndInstallJRuby", Copy) {
+    dependsOn=[verifyFile, installCustomJRuby]
     description "Install JRuby in the vendor directory"
     inputs.file(jrubyTarPath)
     outputs.dir("${projectDir}/vendor/jruby")

--- a/x-pack/build.gradle
+++ b/x-pack/build.gradle
@@ -26,7 +26,7 @@ test {
   exclude '/**'
 }
 
-task rubyTests(type: Test) {
+tasks.register("rubyTests", Test) {
   inputs.files fileTree("${projectDir}/spec")
   inputs.files fileTree("${projectDir}/lib")
   inputs.files fileTree("${projectDir}/modules")
@@ -34,7 +34,7 @@ task rubyTests(type: Test) {
   include '/org/logstash/xpack/test/RSpecTests.class'
 }
 
-task rubyIntegrationTests(type: Test) {
+tasks.register("rubyIntegrationTests", Test) {
   inputs.files fileTree("${projectDir}/qa")
   inputs.files fileTree("${projectDir}/lib")
   inputs.files fileTree("${projectDir}/modules")


### PR DESCRIPTION
7.x backport of #11914

This commit uses the task avoidance api (tasks.register vs task.create/
task DSL), as recommended since Gradle 5.1

This should reduce the execution of unnecessary tasks in build jobs, and
hopefully improve build resiliency and execution time.