### PR TITLE
[Test] Fix service script execution when path includes `&&`

### DIFF
--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -206,7 +206,7 @@ class LogstashService < Service
   end
 
   def get_version
-    `#{@logstash_bin} --version`.split("\n").last
+    `#{Shellwords.escape(@logstash_bin)} --version`.split("\n").last
   end
 
   def get_version_yml

--- a/qa/integration/services/service.rb
+++ b/qa/integration/services/service.rb
@@ -26,7 +26,7 @@ class Service
     @name = name
     @settings = settings
     @setup_script = File.expand_path("../#{name}_setup.sh", __FILE__)
-    @teardown_script = Shellwords.escape(File.expand_path("../#{name}_teardown.sh", __FILE__))
+    @teardown_script = File.expand_path("../#{name}_teardown.sh", __FILE__)
   end
 
   def setup

--- a/qa/integration/services/service.rb
+++ b/qa/integration/services/service.rb
@@ -25,14 +25,14 @@ class Service
   def initialize(name, settings)
     @name = name
     @settings = settings
-    @setup_script = Shellwords.escape(File.expand_path("../#{name}_setup.sh", __FILE__))
+    @setup_script = File.expand_path("../#{name}_setup.sh", __FILE__)
     @teardown_script = Shellwords.escape(File.expand_path("../#{name}_teardown.sh", __FILE__))
   end
 
   def setup
     puts "Setting up #{@name} service"
     if File.exists?(@setup_script)
-      `#{@setup_script}`
+      `#{Shellwords.escape(@setup_script)}`
       raise "#{@setup_script} FAILED with exit status #{$?}" unless $?.success?
     else
       puts "Setup script not found for #{@name}"
@@ -43,7 +43,7 @@ class Service
   def teardown
     puts "Tearing down #{@name} service"
     if File.exists?(@teardown_script)
-      `#{@teardown_script}`
+      `#{Shellwords.escape(@teardown_script)}`
       raise "#{@teardown_script} FAILED with exit status #{$?}" unless $?.success?
     else
       puts "Teardown script not found for #{@name}"


### PR DESCRIPTION
A previous commit attempted to fix this issue by adding `Shellwords.escape` to `setup_script` and `teardown_script` locations, but `File.exists?` returns false when called against a filename escaped by `Shellwords.escape`. This commit localizes the escaping to where the
file is executed.

This commit also adds `Shellwords.escape` to teardown script runner and the method used to execute logstash to retrieve version. This is to enable tests to run correctly when Jenkins creates execution environments with folders named with `&&`, eg `centos-7&&immutable`

