### PR TITLE
[Test] Set beats permission checking to strict=false

### DIFF
--- a/qa/integration/services/filebeat_service.rb
+++ b/qa/integration/services/filebeat_service.rb
@@ -16,7 +16,7 @@
 # under the License.
 
 class FilebeatService < Service
-  FILEBEAT_CMD = [File.join(File.dirname(__FILE__), "installed", "filebeat", "filebeat"), "-c"]
+  FILEBEAT_CMD = [File.join(File.dirname(__FILE__), "installed", "filebeat", "filebeat"), "--strict.perms=false", "-c"]
 
   class BackgroundProcess
     def initialize(cmd)


### PR DESCRIPTION
When running filebeats integration tests on centos-7, the tests
fail due to permsisions checks on the temporary configuration file
created for the test. This commit sets strict permissions checks
to false in order for the tests to be able to succeed.