### PR TITLE
Doc:Fix link to monitoring docs

### DIFF
--- a/docs/static/security/logstash.asciidoc
+++ b/docs/static/security/logstash.asciidoc
@@ -196,10 +196,11 @@ output {
     Authority's certificate.
 
 [float]
+[role="xpack"]
 [[ls-monitoring-user]]
 ==== Configuring Credentials for Logstash Monitoring
 
-If you plan to ship Logstash {logstash-ref}/monitoring-logstash.html[monitoring]
+If you plan to ship Logstash {logstash-ref}/configuring-logstash.html[monitoring]
 data to a secure cluster, you need to configure the username and password that
 Logstash uses to authenticate for shipping monitoring data.
 
@@ -232,6 +233,7 @@ PUT _security/user/logstash_system/_enable
 // CONSOLE
 
 [float]
+[role="xpack"]
 [[ls-pipeline-management-user]]
 ==== Configuring Credentials for Centralized Pipeline Management
 


### PR DESCRIPTION
Replaces the link to monitoring with APIs with a more appropriate monitoring link. 

**PREVIEW:**  https://logstash_11960.docs-preview.app.elstc.co/guide/en/logstash/master/ls-security.html#ls-monitoring-user
