### PR TITLE
[Doc] better specification of the behaviour of in operator in various contexts

### DIFF
--- a/docs/static/configuration.asciidoc
+++ b/docs/static/configuration.asciidoc
@@ -452,7 +452,9 @@ output {
 }
 ----------------------------------
 
-You can use the `in` operator to test whether a field contains a specific string, key, or (for lists) element:
+You can use the `in` operator to test whether a field contains a specific string, key, or list element.
+Note that the semantic meaning of `in` can vary, based on the target type. For example, when applied to
+a string. `in` means "is a substring of". When applied to a collection type, `in` means "collection contains the exact value".
 
 [source,js]
 ----------------------------------


### PR DESCRIPTION
This PR is intended to try to describe better the behavior of `in` operator used in conditionals inside pipeline configurations. It translates to Ruby's `include?` method and in some cases could not be clear that it does an exact match (like in collections) or a regexp match (like substring in a string)