### PR TITLE
[Doc] added description of xpack.monitoring.elasticsearch.proxy

### DIFF
--- a/docs/static/settings/monitoring-settings-legacy.asciidoc
+++ b/docs/static/settings/monitoring-settings-legacy.asciidoc
@@ -28,11 +28,18 @@ Logstash metrics must be routed through your production cluster. You can specify
 a single host as a string, or specify multiple hosts as an array. Defaults to
 `http://localhost:9200`.
 
-NOTE: If your Elasticsearch cluster is configured with dedicated master-eliglble
+NOTE: If your Elasticsearch cluster is configured with dedicated master-eligible
 nodes, Logstash metrics should _not_ be routed to these nodes, as doing so can
 create resource contention and impact the stability of the Elasticsearch
 cluster. Therefore, do not include such nodes in
 `xpack.monitoring.elasticsearch.hosts`.
+
+`xpack.monitoring.elasticsearch.proxy`::
+
+The monitoring {es} instance and monitored Logstash can be separated by a proxy.
+To enable Logstash to connect to a proxied {es}, set this value to the URI of the intermediate
+proxy using the standard URI format, `<protocol>://<host>` for example `http://192.168.1.1`.
+An empty string is treated as if proxy was not set.
 
 `xpack.monitoring.elasticsearch.username` and `xpack.monitoring.elasticsearch.password`::
 


### PR DESCRIPTION
This PR is document the work done in #11799 to expose the `proxy` setting when Logstash and monitoring Elasticsearch cluster are separated by a forward proxy.