### PR TITLE
Add openjdk14 to windows build matrix

### DIFF
--- a/.ci/matrix-windows-runtime-javas.yml
+++ b/.ci/matrix-windows-runtime-javas.yml
@@ -6,8 +6,6 @@
 # or 'openjdk' followed by the major release number.
 
 LS_RUNTIME_JAVA:
-#  - zulu8
-#  - adoptopenjdk8
   - zulu11
-  - zulu14
   - adoptopenjdk11
+  - openjdk14


### PR DESCRIPTION
openjdk14 appears to be the only version of java14 installed on jenkins windows
worker nodes, so use this instead of zulu14 and adoptopenjdk14