### PR TITLE
Adds matrix-runtime-javas.yml

### DIFF
--- a/.ci/matrix-runtime-javas.yml
+++ b/.ci/matrix-runtime-javas.yml
@@ -1,0 +1,14 @@
+# This file is used as part of a matrix build in Jenkins where the
+# values below are included as an axis of the matrix.
+
+# This axis of the build matrix represents the versions of Java on
+# which Elasticsearch will be tested.  Valid Java versions are 'java'
+# or 'openjdk' followed by the major release number.
+
+LS_RUNTIME_JAVA:
+  - openjdk11
+  - openjdk14
+  - adoptopenjdk11
+  - adoptopenjdk14
+  - zulu11
+  - zulu14

--- a/.ci/matrix-runtime-javas.yml
+++ b/.ci/matrix-runtime-javas.yml
@@ -2,8 +2,7 @@
 # values below are included as an axis of the matrix.
 
 # This axis of the build matrix represents the versions of Java on
-# which Elasticsearch will be tested.  Valid Java versions are 'java'
-# or 'openjdk' followed by the major release number.
+# which Logstash can be tested against.
 
 LS_RUNTIME_JAVA:
   - openjdk11


### PR DESCRIPTION
This adds the .ci/matrix-runtime-javas.yml file that defines all
the JDKs logstash could be tested against. This is meant to be
used for the Matrix Combinations Jenkins plugin to be able to
select which JDK to test against dynamically.