### PR TITLE
remove explicit return from Mutex#synchronize in Plugin Registry

### DIFF
--- a/logstash-core/lib/logstash/plugins/registry.rb
+++ b/logstash-core/lib/logstash/plugins/registry.rb
@@ -188,7 +188,7 @@ module LogStash module Plugins
           raise LoadError, "Block validation fails for plugin named #{plugin_name} of type #{type}," unless block.call(plugin_spec.klass, plugin_name)
         end
 
-        return plugin_spec.klass
+        plugin_spec.klass
       end
     end
 


### PR DESCRIPTION
ruby produces a LocalJumpError: unexpected return
error if there's a return in a block so this changes just uses
the value of the last expression as the value of the block