### PR TITLE
Doc:Add JAVA_HOME requirement to troubleshooting section

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -14,7 +14,6 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 :versioned_docs:        false
 
-:jdk:                   1.8.0
 :lsissue:               https://github.com/elastic/logstash/issues
 :lsplugindocs:          https://www.elastic.co/guide/en/logstash-versioned-plugins/current
 

--- a/docs/static/troubleshooting.asciidoc
+++ b/docs/static/troubleshooting.asciidoc
@@ -60,9 +60,9 @@ If `JAVA_HOME` is not set, you may see errors similar to these:
 WARNING: ERRORS GO HERE
 -----
 
-*Note to developers:* `JAVA_HOME` is a system variable. If you need to test with
-another Java version, you can use the `BUILD_JAVA_HOME` setting to specify a
-different version.
+*Note to developers:* `JAVA_HOME` is an environment variable. If you need to
+test with another Java version, you can use the `BUILD_JAVA_HOME` environment
+variable to specify a different version.
 
 [float] 
 [[ts-illegal-reflective-error]] 

--- a/docs/static/troubleshooting.asciidoc
+++ b/docs/static/troubleshooting.asciidoc
@@ -49,12 +49,28 @@ Operation not permitted
 == {ls} start up
 
 [float] 
+[[ts-java-home]] 
+=== [add decription] errors
+
+The `JAVA_HOME` version must be set before you start {ls}.
+If `JAVA_HOME` is not set, you may see errors similar to these: 
+
+[source,sh]
+-----
+WARNING: ERRORS GO HERE
+-----
+
+*Note to developers:* `JAVA_HOME` is a system variable. If you need to test with
+another Java version, you can use the `BUILD_JAVA_HOME` setting to specify a
+different version.
+
+[float] 
 [[ts-illegal-reflective-error]] 
 === 'Illegal reflective access' errors
 
 // https://github.com/elastic/logstash/issues/10496 and https://github.com/elastic/logstash/issues/10498
 
-Running Logstash with Java 11 results in warnings similar to these:
+Running Logstash with Java 11 or Java 14 results in warnings similar to these:
 
 [source,sh]
 -----
@@ -89,8 +105,8 @@ Try adding these values to the `jvm.options` file.
 
 *Notes:*
 
-* These settings allow Logstash to start without warnings in Java 11, but they
-prevent Logstash from starting on Java 8.
+* These settings allow Logstash to start without warnings in Java 11 or Java 14, but they
+prevent {ls} from starting on Java 8 and earlier versions.
 * This workaround has been tested with simple pipelines. If you have experiences
 to share, please comment in the
 https://github.com/elastic/logstash/issues/10496[issue].


### PR DESCRIPTION
Removes unused doc attribute (variable) that sets the JDK version to 1.8.0. This variable doesn't appear to be in use anywhere.  

Updates troubleshooting to include Java 14 and JAVA_HOME in startup errors section. (WIP)

To do:
- [ ] Add appropriate heading that describes errors
- [ ] Include sample error messages
- [ ] Expand description of symptoms and remedy

**PREVIEW:** https://logstash_11983.docs-preview.app.elstc.co/guide/en/logstash/master/troubleshooting.html#ts-java-home