### PR TITLE
[7x backport] Escape test fixture service scripts

### DIFF
--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -95,7 +95,7 @@ class LogstashService < Service
   # Given an input this pipes it to LS. Expects a stdin input in LS
   def start_with_input(config, input)
     Bundler.with_clean_env do
-      `cat #{input} | #{@logstash_bin} -e \'#{config}\'`
+      `cat #{Shellwords.escape(input)} | #{Shellwords.escape(@logstash_bin)} -e \'#{config}\'`
     end
   end
 


### PR DESCRIPTION
Backport of #11931

Escape test fixture service scripts to avoid test failures when run in
Jenkins using multiple yaml configuration files, which causes directories
to be constructed like `centos-7&&immutable` which cause issues with
the service runners cutting off directory locations before '&&'

This commit deviates from the original commit by not setting @setup_script
and @teardown_script variable with the Shellwords escape, as this was removed
in a subsequent commit (#11944)