### PR TITLE
Expose again the pipelines queue.data and queue.capacity subdocument

### DIFF
--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -167,7 +167,7 @@ module LogStash
 
             # if extended_stats were provided, enrich the return value
             if extended_stats
-              ret[:queue]    = extended_stats["queue"] if extended_stats.include?("queue")
+              ret[:queue].merge!(extended_stats["queue"]) if extended_stats.include?("queue")
               ret[:hash] = extended_stats["hash"]
               ret[:ephemeral_id] = extended_stats["ephemeral_id"]
               if opts[:vertices] && extended_stats.include?("vertices")


### PR DESCRIPTION
This is a backport PR of #11923 to `7.8` to fix `_node/stats` JSON response