### PR TITLE
upgrade google-java-format to 1.8

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -173,10 +173,7 @@ dependencies {
         api files(customJRubyDir + "/maven/jruby-complete/target/jruby-complete-${customJRubyVersion}.jar")
     }
     implementation group: 'com.google.guava', name: 'guava', version: '24.1.1-jre'
-    // WARNING: DO NOT UPGRADE "google-java-format"
-    // later versions require GPL licensed code in javac-shaded that is
-    // Apache2 incompatible
-    implementation('com.google.googlejavaformat:google-java-format:1.1') {
+    implementation('com.google.googlejavaformat:google-java-format:1.8') {
         exclude group: 'com.google.guava', module: 'guava'
     }
     implementation 'org.javassist:javassist:3.26.0-GA'


### PR DESCRIPTION
Historically we haven't upgraded from 1.1 since newer versions depended on javac-shaded which is gpl-2.0.

[google-java-format 1.8](https://mvnrepository.com/artifact/com.google.googlejavaformat/google-java-format/1.8) drops this dependency.