### PR TITLE
Revert "upgrade google-java-format to 1.8"

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -173,7 +173,10 @@ dependencies {
         api files(customJRubyDir + "/maven/jruby-complete/target/jruby-complete-${customJRubyVersion}.jar")
     }
     implementation group: 'com.google.guava', name: 'guava', version: '24.1.1-jre'
-    implementation('com.google.googlejavaformat:google-java-format:1.8') {
+    // WARNING: DO NOT UPGRADE "google-java-format"
+    // later versions require GPL licensed code in javac-shaded that is
+    // Apache2 incompatible
+    implementation('com.google.googlejavaformat:google-java-format:1.1') {
         exclude group: 'com.google.guava', module: 'guava'
     }
     implementation 'org.javassist:javassist:3.26.0-GA'


### PR DESCRIPTION
This reverts commit 2229468f112134b1c7d6102e989e0c0ef057c74f.

google-java-format 1.8 is Java 11 only, so we can't use it as Logstash is supported on Java 8.