### PR TITLE
retry on failed gradlew wrapper command in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY --chown=logstash:logstash gradlew /opt/logstash/gradlew
 COPY --chown=logstash:logstash gradle/wrapper /opt/logstash/gradle/wrapper
 COPY --chown=logstash:logstash settings.gradle /opt/logstash/settings.gradle
 WORKDIR /opt/logstash
-RUN ./gradlew wrapper --warning-mode all
+RUN for iter in `seq 1 10`; do ./gradlew wrapper --warning-mode all && exit_code=0 && break || exit_code=$? && echo "gradlew error: retry $iter in 10s" && sleep 10; done; exit $exit_code
 WORKDIR /home/logstash
 
 ADD versions.yml /opt/logstash/versions.yml


### PR DESCRIPTION
fixes temporary network failures like https://logstash-ci.elastic.co/job/elastic+logstash+pull-request+multijob-integration-pq-2/1648/console