### PR TITLE
add commented out options for api_key in logstash.yml

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -260,6 +260,8 @@ pipeline.ordered: auto
 # an alternative to hosts + username/password settings is to use cloud_id/cloud_auth
 #xpack.monitoring.elasticsearch.cloud_id: monitoring_cluster_id:xxxxxxxxxx
 #xpack.monitoring.elasticsearch.cloud_auth: logstash_system:password
+# another authentication alternative is to use an Elasticsearch API key
+#xpack.monitoring.elasticsearch.api_key: "id:api_key"
 #xpack.monitoring.elasticsearch.ssl.certificate_authority: [ "/path/to/ca.crt" ]
 #xpack.monitoring.elasticsearch.ssl.truststore.path: path/to/file
 #xpack.monitoring.elasticsearch.ssl.truststore.password: password
@@ -280,6 +282,8 @@ pipeline.ordered: auto
 # an alternative to hosts + username/password settings is to use cloud_id/cloud_auth
 #xpack.management.elasticsearch.cloud_id: management_cluster_id:xxxxxxxxxx
 #xpack.management.elasticsearch.cloud_auth: logstash_admin_user:password
+# another authentication alternative is to use an Elasticsearch API key
+#xpack.management.elasticsearch.api_key: "id:api_key"
 #xpack.management.elasticsearch.ssl.certificate_authority: [ "/path/to/ca.crt" ]
 #xpack.management.elasticsearch.ssl.truststore.path: /path/to/file
 #xpack.management.elasticsearch.ssl.truststore.password: password


### PR DESCRIPTION
This should be merged in master and 7.9 since api_key support for monitoring and management will be available starting in 7.9

Relates to #11788