### PR TITLE
fix Settings equality test which broke the PipelineConfig equality

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/PipelineConfig.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/PipelineConfig.java
@@ -126,7 +126,7 @@ public final class PipelineConfig {
         PipelineConfig cother = (PipelineConfig) other;
         return configHash().equals(cother.configHash()) &&
                 this.pipelineId.equals(cother.pipelineId) &&
-                this.settings.eql(cother.settings);
+                this.settings.equals(cother.settings);
     }
 
     @Override

--- a/logstash-core/src/test/java/org/logstash/config/ir/PipelineConfigTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/PipelineConfigTest.java
@@ -65,7 +65,7 @@ public class PipelineConfigTest extends RubyEnvTestCase {
     private final static RubyObject SETTINGS = (RubyObject) RubyUtil.RUBY.evalScriptlet(
             "require 'logstash/environment'\n" + // this is needed to register "pipeline.system" setting
             "require 'logstash/settings'\n" +
-            "LogStash::SETTINGS");;
+            "LogStash::SETTINGS");
     private PipelineConfig sut;
     private SourceWithMetadata[] orderedConfigParts;
     public static final String PIPELINE_CONFIG_PART_2 =
@@ -125,6 +125,10 @@ public class PipelineConfigTest extends RubyEnvTestCase {
     public void testObjectEqualityOnConfigHashAndPipelineId() {
         PipelineConfig anotherExactPipeline = new PipelineConfig(source, pipelineIdSym, toRubyArray(orderedConfigParts), SETTINGS);
         assertEquals(anotherExactPipeline, sut);
+
+        final RubyObject CLONED_SETTINGS = (RubyObject)SETTINGS.callMethod("clone");
+        PipelineConfig anotherExactPipelineWithClonedSettings = new PipelineConfig(source, pipelineIdSym, toRubyArray(orderedConfigParts), CLONED_SETTINGS);
+        assertEquals(anotherExactPipelineWithClonedSettings, sut);
 
         PipelineConfig notMatchingPipeline = new PipelineConfig(source, pipelineIdSym, RubyArray.newEmptyArray(RubyUtil.RUBY), SETTINGS);
         assertNotEquals(notMatchingPipeline, sut);


### PR DESCRIPTION
`PipelineConfig.equals` was calling `Settings#eql` but should be using `Settings#equals` which wires on the overloaded `Settings#==` method. 

The symptom was that when pipeline reloading was triggered, the pipeline would always be reloaded regardless if it changed or not. 