### PR TITLE
remove uses of JSON.load in favor or JSON.parse

### DIFF
--- a/qa/integration/specs/reload_config_spec.rb
+++ b/qa/integration/specs/reload_config_spec.rb
@@ -95,7 +95,7 @@ describe "Test Logstash service when config reload is enabled" do
     expect(instance_reload_stats["successes"]).to eq(1)
     expect(instance_reload_stats["failures"]).to eq(0)
     # parse the results and validate
-    re = JSON.load(File.new(output_file2))
+    re = JSON.parse(IO.read(output_file2))
     expect(re["clientip"]).to eq("74.125.176.147")
     expect(re["response"]).to eq(200)
   end

--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -40,7 +40,7 @@ module LogStash
       # Lets use the standard library here, in the context of the bootstrap the
       # logstash-core could have failed to be installed.
       require "json"
-      JSON.load(::File.read("rakelib/plugins-metadata.json")).select do |_, metadata|
+      JSON.parse(::File.read("rakelib/plugins-metadata.json")).select do |_, metadata|
         metadata[type]
       end.keys
     end

--- a/rakelib/modules.rake
+++ b/rakelib/modules.rake
@@ -19,7 +19,7 @@ namespace "modules" do
 
   def unpacker(src_file, dest_dir)
     puts "Reading #{src_file}"
-    array = JSON.load(IO.read(src_file))
+    array = JSON.parse(IO.read(src_file))
 
     if !array.is_a?(Array)
       raise "#{src_file} does not contain a JSON array as the first object"


### PR DESCRIPTION
JSON.load allows the creation of complex objects, and should not
be given untrusted input. This commit changes the only three uses
of JSON.load in the codebase. These aren't user facing or present
in bundled product therefore not really an attack vector, so this is just
a cleanup to establish this best practice.