### PR TITLE
Tests: Add support for alternative architectures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,16 +125,27 @@ version = versionMap['logstash-core']
 String artifactVersionsApi = "https://artifacts-api.elastic.co/v1/versions"
 
 tasks.register("configureArchitecture") {
-    String arch = "x86_64"
+    String arch = System.properties['os.arch']
     String osName = System.properties['os.name']
+    String beatsArch = arch
+    String esArch = arch
+
+    // For aarch64 architectures, beats and elasticsearch name their artifacts differently
+    if (arch == "aarch64") {i
+        beatsArch="arm64"
+        esArch="aarch64"
+    } else if (arch == "amd64") {
+        beatsArch="x86_64"
+        esArch="x86_64"
+    }
 
     if (osName ==~ /Mac OS X/) {
         osName = "darwin"
     } else {
         osName = "linux"
     }
-    String architecture = "${osName}-${arch}"
-    project.ext.set("architecture", architecture)
+    project.ext.set("beatsArchitecture", "${osName}-${beatsArch}")
+    project.ext.set("esArchitecture", "${osName}-${esArch}")
 }
 
 tasks.register("configureArtifactInfo") {
@@ -159,8 +170,7 @@ tasks.register("configureArtifactInfo") {
     def stackBuildVersion = dlBuilds["builds"][0]
 
     project.ext.set("artifactApiVersionedBuildUrl", "${artifactVersionsApi}/${qualifiedVersion}/builds/${stackBuildVersion}")
-    project.ext.set("stackArtifactSuffix", "${qualifiedVersion}-${project.ext.get('architecture')}")
-    project.ext.set("stackArtifactSuffixNoArch", qualifiedVersion)
+    project.ext.set("stackArtifactSuffix", qualifiedVersion)
 }
 
 
@@ -334,15 +344,13 @@ tasks.register("installIntegrationTestGems") {
   }
 }
 
-
-
 tasks.register("downloadFilebeat", Download) {
     dependsOn  configureArtifactInfo
     description "Download Filebeat Snapshot for current branch version: ${version}"
 
     project.ext.set("versionFound", true)
 
-    String downloadedFilebeatName = "filebeat-${project.ext.get("stackArtifactSuffix")}"
+    String downloadedFilebeatName = "filebeat-${project.ext.get("stackArtifactSuffix")}-${project.ext.get("beatsArchitecture")}"
     project.ext.set("unpackedFilebeatName", downloadedFilebeatName)
 
     // find url of build artifact
@@ -381,12 +389,13 @@ tasks.register("copyFilebeat", Copy){
     }
 }
 
+
 tasks.register("downloadEs", Download) {
     dependsOn  configureArtifactInfo
     description "Download ES Snapshot for current branch version: ${version}"
 
-    String downloadedElasticsearchName = "elasticsearch-${project.ext.get("stackArtifactSuffix")}"
-    project.ext.set("unpackedElasticsearchName", "elasticsearch-${project.ext.get("stackArtifactSuffixNoArch")}")
+    String downloadedElasticsearchName = "elasticsearch-${project.ext.get("stackArtifactSuffix")}-${project.ext.get("esArchitecture")}"
+    project.ext.set("unpackedElasticsearchName", "elasticsearch-${project.ext.get("stackArtifactSuffix")}")
 
     // find url of build artifact
     String artifactApiUrl = "${project.ext.get("artifactApiVersionedBuildUrl")}/projects/elasticsearch/packages/${downloadedElasticsearchName}.tar.gz"
@@ -425,17 +434,16 @@ tasks.register("copyEs", Copy){
     }
 }
 
-
 def rubyIntegrationSpecs = project.hasProperty("rubyIntegrationSpecs") ? ((String) project.property("rubyIntegrationSpecs")).split(/\s+/).join(",") : "specs/**/*_spec.rb"
 def integrationTestPwd = "${projectDir}/qa/integration"
 
 project(":logstash-integration-tests") {
     tasks.getByPath(":logstash-integration-tests:integrationTests").configure {
-      systemProperty 'org.logstash.integration.specs', rubyIntegrationSpecs
-      environment "FEATURE_FLAG", System.getenv('FEATURE_FLAG')
-      workingDir integrationTestPwd
-      dependsOn installIntegrationTestGems
-  }
+        systemProperty 'org.logstash.integration.specs', rubyIntegrationSpecs
+        environment "FEATURE_FLAG", System.getenv('FEATURE_FLAG')
+        workingDir integrationTestPwd
+        dependsOn installIntegrationTestGems
+    }
 }
 
 tasks.register("runIntegrationTests"){


### PR DESCRIPTION
Enable filebeat and elasticsearch downloads to pull different
architectures, Filebeat and Elasticsearch use different suffixes
to denote their aarch64 architectures, with beats using arm64 and
elasticsearch aarch64