### PR TITLE
Fix pipeline state logic and worker thread error handling

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -200,7 +200,9 @@ class LogStash::Agent
 
     converge_result
   rescue => e
-    logger.error("An exception happened when converging configuration", :exception => e.class, :message => e.message, :backtrace => e.backtrace)
+    attributes = {:exception => e.class, :message => e.message}
+    attributes.merge!({:backtrace => e.backtrace}) if logger.debug?
+    logger.error("An exception happened when converging configuration", attributes)
   end
 
   # Calculate the Logstash uptime in milliseconds

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -402,8 +402,10 @@ module LogStash; class Pipeline < BasePipeline
     #
     # Users need to check their configuration or see if there is a bug in the
     # plugin.
-    @logger.error("Exception in pipelineworker, the pipeline stopped processing new events, please check your filter configuration and restart Logstash.",
-                  default_logging_keys("exception" => e.message, "backtrace" => e.backtrace))
+    @logger.error(
+      "Pipeline worker error, the pipeline will be stopped",
+      default_logging_keys("exception" => e.message, "backtrace" => e.backtrace)
+    )
 
     raise e
   end

--- a/logstash-core/lib/logstash/pipelines_registry.rb
+++ b/logstash-core/lib/logstash/pipelines_registry.rb
@@ -17,40 +17,100 @@
 
 module LogStash
   class PipelineState
-    attr_reader :pipeline_id, :pipeline
+    attr_reader :pipeline_id
 
     def initialize(pipeline_id, pipeline)
       @pipeline_id = pipeline_id
       @pipeline = pipeline
-      @reloading = Concurrent::AtomicBoolean.new(false)
+      @loading = Concurrent::AtomicBoolean.new(false)
+
+      # this class uses a lock to ensure thread safe visibility.
+      @lock = Mutex.new
     end
 
     def terminated?
-      # a reloading pipeline is never considered terminated
-      @reloading.false? && @pipeline.finished_execution?
+      @lock.synchronize do
+        # a loading pipeline is never considered terminated
+        @loading.false? && @pipeline.finished_execution?
+      end
     end
 
-    def set_reloading(is_reloading)
-      @reloading.value = is_reloading
+    def set_loading(is_loading)
+      @lock.synchronize do
+        @loading.value = is_loading
+      end
     end
 
     def set_pipeline(pipeline)
-      raise(ArgumentError, "invalid nil pipeline") if pipeline.nil?
-      @pipeline = pipeline
+      @lock.synchronize do
+        raise(ArgumentError, "invalid nil pipeline") if pipeline.nil?
+        @pipeline = pipeline
+      end
+    end
+
+    def pipeline
+      @lock.synchronize { @pipeline }
     end
   end
+
+  class PipelineStates
+
+    def initialize
+      @states = {}
+      @locks = {}
+      @lock = Mutex.new
+    end
+
+    def get(pipeline_id)
+      @lock.synchronize do
+        @states[pipeline_id]
+      end
+    end
+
+    def put(pipeline_id, state)
+      @lock.synchronize do
+        @states[pipeline_id] = state
+      end
+    end
+
+    def remove(pipeline_id)
+      @lock.synchronize do
+        @states.delete(pipeline_id)
+        @locks.delete(pipeline_id)
+      end
+    end
+
+    def size
+      @lock.synchronize do
+        @states.size
+      end
+    end
+
+    def empty?
+      @lock.synchronize do
+        @states.empty?
+      end
+    end
+
+    def each_with_object(init, &block)
+      states = @lock.synchronize { @states.dup }
+      states.each_with_object(init, &block)
+    end
+
+    def get_lock(pipeline_id)
+      @lock.synchronize do
+        @locks[pipeline_id] ||= Mutex.new
+      end
+    end
+  end
+
 
   class PipelinesRegistry
     attr_reader :states
     include LogStash::Util::Loggable
 
     def initialize
-      # we leverage the semantic of the Java ConcurrentHashMap for the
-      # compute() method which is atomic; calling compute() concurrently
-      # will block until the other compute finishes so no mutex is necessary
-      # for synchronizing compute calls
-      @states = java.util.concurrent.ConcurrentHashMap.new
-      @locks = java.util.concurrent.ConcurrentHashMap.new
+      @states = PipelineStates.new
     end
 
     # Execute the passed creation logic block and create a new state upon success
@@ -62,23 +122,35 @@ module LogStash
     #
     # @return [Boolean] new pipeline creation success
     def create_pipeline(pipeline_id, pipeline, &create_block)
-      lock = get_lock(pipeline_id)
+      lock = @states.get_lock(pipeline_id)
       lock.lock
-
       success = false
 
       state = @states.get(pipeline_id)
-      if state
-        if state.terminated?
-          success = yield
-          state.set_pipeline(pipeline)
-        else
-          logger.error("Attempted to create a pipeline that already exists", :pipeline_id => pipeline_id)
-        end
+
+      if state && !state.terminated?
+        logger.error("Attempted to create a pipeline that already exists", :pipeline_id => pipeline_id)
+        return false
+      end
+
+      if state.nil?
+        state = PipelineState.new(pipeline_id, pipeline)
+        state.set_loading(true)
         @states.put(pipeline_id, state)
+        begin
+          success = yield
+        ensure
+          state.set_loading(false)
+          @states.remove(pipeline_id) unless success
+        end
       else
-        success = yield
-        @states.put(pipeline_id, PipelineState.new(pipeline_id, pipeline)) if success
+        state.set_loading(true)
+        state.set_pipeline(pipeline)
+        begin
+          success = yield
+        ensure
+          state.set_loading(false)
+        end
       end
 
       success
@@ -92,22 +164,20 @@ module LogStash
     #
     # @yieldparam [Pipeline] the pipeline to terminate
     def terminate_pipeline(pipeline_id, &stop_block)
-      lock = get_lock(pipeline_id)
+      lock = @states.get_lock(pipeline_id)
       lock.lock
 
       state = @states.get(pipeline_id)
       if state.nil?
         logger.error("Attempted to terminate a pipeline that does not exists", :pipeline_id => pipeline_id)
-        @states.remove(pipeline_id)
       else
         yield(state.pipeline)
-        @states.put(pipeline_id, state)
       end
     ensure
       lock.unlock
     end
 
-    # Execute the passed reloading logic block in the context of the reloading state and set new pipeline in state
+    # Execute the passed reloading logic block in the context of the loading state and set new pipeline in state
     # @param pipeline_id [String, Symbol] the pipeline id
     # @param reload_block [Block] the reloading execution logic
     #
@@ -115,26 +185,26 @@ module LogStash
     #
     # @return [Boolean] new pipeline creation success
     def reload_pipeline(pipeline_id, &reload_block)
-      lock = get_lock(pipeline_id)
+      lock = @states.get_lock(pipeline_id)
       lock.lock
       success = false
 
       state = @states.get(pipeline_id)
+
       if state.nil?
         logger.error("Attempted to reload a pipeline that does not exists", :pipeline_id => pipeline_id)
-        @states.remove(pipeline_id)
-      else
-        state.set_reloading(true)
-        begin
-          success, new_pipeline = yield
-          state.set_pipeline(new_pipeline)
-        ensure
-          state.set_reloading(false)
-        end
-        @states.put(pipeline_id, state)
+        return false
       end
 
-    success
+      state.set_loading(true)
+      begin
+        success, new_pipeline = yield
+        state.set_pipeline(new_pipeline)
+      ensure
+        state.set_loading(false)
+      end
+
+      success
     ensure
       lock.unlock
     end
@@ -153,7 +223,7 @@ module LogStash
 
     # @return [Boolean] true if the states collection is empty.
     def empty?
-      @states.isEmpty
+      @states.empty?
     end
 
     # @return [Hash{String=>Pipeline}]
@@ -187,12 +257,6 @@ module LogStash
         if state && (!block_given? || yield(state))
           memo[id] = state.pipeline
         end
-      end
-    end
-
-    def get_lock(pipeline_id)
-      @locks.compute_if_absent(pipeline_id) do |k|
-        java.util.concurrent.locks.ReentrantLock.new
       end
     end
   end

--- a/logstash-core/spec/support/matchers.rb
+++ b/logstash-core/spec/support/matchers.rb
@@ -92,9 +92,9 @@ RSpec::Matchers.define :have_running_pipeline? do |pipeline_config|
     try(30) do
       pipeline = agent.get_pipeline(pipeline_config.pipeline_id)
       expect(pipeline).to_not be_nil
+      expect(pipeline.running?).to be_truthy
     end
     expect(pipeline.config_str).to eq(pipeline_config.config_string)
-    expect(pipeline.running?).to be_truthy
     expect(agent.running_pipelines.keys.map(&:to_s)).to include(pipeline_config.pipeline_id.to_s)
   end
 

--- a/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
+++ b/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
@@ -98,10 +98,6 @@ public final class WorkerLoop implements Runnable {
             execution.compute(batch, true, true);
             readClient.closeBatch(batch);
         } catch (final Exception ex) {
-            LOGGER.error(
-                "Exception in pipelineworker, the pipeline stopped processing new events, please check your filter configuration and restart Logstash.",
-                ex
-            );
             throw new IllegalStateException(ex);
         }
     }


### PR DESCRIPTION
Relates to #12005 and fixes the issues in (2).
Should fix #10611

This PR fixes the following issues:

- A pipeline in the process of being created was not marked as such in the pipeline registry resulting in a situation where a slow to initialize pipeline would be recreated on state convergence resulting in a PQ `LockException` because that pipeline was already existing and held the PQ lock. 
- The worker threads were not correctly monitored for a worker loop exception resulting in a complete logstash crash upon any exception even when multiple pipelines are running. Now only the failed pipeline is terminated. If pipeline reloading is enabled, it is possible to edit the config and have that failed pipeline reloaded.

### TODO
- [x] review  build errors
- [X] make sure same logic is applied to the Ruby pipeline - followup issue created in #12106 