### PR TITLE
[Doc]Add known issue for TLS v1.3 and Docker

### DIFF
--- a/docs/static/releasenotes-knownissues.asciidoc
+++ b/docs/static/releasenotes-knownissues.asciidoc
@@ -1,0 +1,11 @@
+==== Known issue
+
+**TLS v1.3 with Docker images 7.2.0 - 7.4.1**
+
+Bugs in some JDK versions can prevent {ls} from successfully conducting a TLS
+v1.3 handshake. This issue impacts:
+
+* {ls} Docker images 7.2.0 - 7.4.1 when you use TLS v1.3.
+
+If you encounter this issue, we recommend upgrading to {ls} Docker images 7.4.2
+or later. If you cannot upgrade, try using and enforcing TLS v1.2.

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -151,6 +151,10 @@ https://github.com/elastic/logstash/pull/11113[#11113]
 [[logstash-7-3-2]]
 === Logstash 7.3.2 Release Notes
 
+include::releasenotes-knownissues.asciidoc[]
+
+==== New features and improvements
+
 * Bugfix: Avoid variable collision in pipeline stats api (backport of #11059 to 7.x) https://github.com/elastic/logstash/pull/11062[#11062]
 * Bugfix: Give multiple pipelines all the settings https://github.com/elastic/logstash/pull/11076[#11076]
 * Docs: Hint plugins need to be installed before bundle https://github.com/elastic/logstash/pull/11080[#11080]
@@ -161,6 +165,10 @@ https://github.com/elastic/logstash/pull/11113[#11113]
 
 [[logstash-7-3-1]]
 === Logstash 7.3.1 Release Notes
+
+include::releasenotes-knownissues.asciidoc[]
+
+==== New features and improvements
 
 * Add regex support for conditionals with constants https://github.com/elastic/logstash/pull/11017[#11017]
 * Fix compilation of "[field] in [field]" event conditions https://github.com/elastic/logstash/pull/11026[#11026]
@@ -174,6 +182,10 @@ https://github.com/elastic/logstash/pull/11113[#11113]
 
 [[logstash-7-3-0]]
 === Logstash 7.3.0 Release Notes
+
+include::releasenotes-knownissues.asciidoc[]
+
+==== New features and improvements
 
 * Fixes a crash that could occur when an illegal field reference was used as part of a field key https://github.com/elastic/logstash/pull/10839[#10839]
 * Fixes a stall that could occur when using the Beta Pipeline-to-Pipeline feature by ensuring that a Pipeline Input will not shut down before its upstream pipeline https://github.com/elastic/logstash/pull/10872[#10872]
@@ -256,6 +268,10 @@ https://github.com/elastic/logstash/pull/11113[#11113]
 [[logstash-7-2-1]]
 === Logstash 7.2.1 Release Notes
 
+include::releasenotes-knownissues.asciidoc[]
+
+==== New features and improvements
+
 * Changed: Make sure joni regexp interruptability is enabled Fixes https://github.com/elastic/logstash/pull/10978[#10978]
 * Fixed: Java core plugin support for Java 11 https://github.com/elastic/logstash/pull/10951[#10951]
 * Updated: Jinja2 docker dependency https://github.com/elastic/logstash/pull/10986[#10986]
@@ -278,6 +294,10 @@ https://github.com/elastic/logstash/pull/11113[#11113]
 
 [[logstash-7-2-0]]
 === Logstash 7.2.0 Release Notes
+
+include::releasenotes-knownissues.asciidoc[]
+
+==== New features and improvements
 
 * Native support for Java Plugins (GA) https://github.com/elastic/logstash/pull/10620[#10620]. Changes to Java plugins for GA include:
 

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -29,6 +29,10 @@ No user facing changes in this release.
 [[logstash-7-4-1]]
 === Logstash 7.4.1 Release Notes
 
+include::releasenotes-knownissues.asciidoc[]
+
+==== New features and improvements
+
 * Update patch plugin versions in gemfile lock for 7.4.1 https://github.com/elastic/logstash/pull/11181[#11181]
 * Update JrJackson to 0.4.10 https://github.com/elastic/logstash/pull/11184[#11184]
 * Remove 10k character truncation from log4j2.properties https://github.com/elastic/logstash/pull/11206[#11206]
@@ -83,6 +87,10 @@ No user facing changes in this release.
 
 [[logstash-7-4-0]]
 === Logstash 7.4.0 Release Notes
+
+include::releasenotes-knownissues.asciidoc[]
+
+==== New features and improvements
 
 * Improved logging of version mismatch in DLQ file reader (RecordIOReader) https://github.com/elastic/logstash/pull/11039[#11039]
 * Update jruby to 9.2.8.0 https://github.com/elastic/logstash/pull/11041[#11041]


### PR DESCRIPTION
Bugs in some JDK versions can prevent LS from making a successful TLS handshake.
Affects Docker images 7.2.0 - 7.4.1 when you use TLS v1.3.

**PREVIEW:** https://logstash_12022.docs-preview.app.elstc.co/guide/en/logstash/7.4/logstash-7-4-1.html