### PR TITLE
[DOCS] Fixes Stack Overview links

### DIFF
--- a/docs/gs-index.asciidoc
+++ b/docs/gs-index.asciidoc
@@ -20,7 +20,6 @@ release-state can be: released | prerelease | unreleased
 :filebeat:              https://www.elastic.co/guide/en/beats/filebeat/{branch}/
 :lsissue:               https://github.com/elastic/logstash/issues/
 :security:              X-Pack Security
-:stack:                 https://www.elastic.co/guide/en/elastic-stack/current/
 
 [[introduction]]
 == Logstash Introduction

--- a/docs/static/docker.asciidoc
+++ b/docs/static/docker.asciidoc
@@ -9,7 +9,7 @@ https://github.com/elastic/logstash/tree/{branch}[GitHub].
 
 These images are free to use under the Elastic license. They contain open source 
 and free commercial features and access to paid commercial features.  
-{stack-ov}/license-management.html[Start a 30-day trial] to try out all of the 
+{kibana-ref}/managing-licenses.html[Start a 30-day trial] to try out all of the 
 paid commercial features. See the 
 https://www.elastic.co/subscriptions[Subscriptions] page for information about 
 Elastic license levels.

--- a/docs/static/getting-started-with-logstash.asciidoc
+++ b/docs/static/getting-started-with-logstash.asciidoc
@@ -34,7 +34,7 @@ contains colon (:) characters.
 --
 These packages are free to use under the Elastic license. They contain open 
 source and free commercial features and access to paid commercial features.  
-{stack-ov}/license-management.html[Start a 30-day trial] to try out all of the 
+{kibana-ref}/managing-licenses.html[Start a 30-day trial] to try out all of the 
 paid commercial features. See the 
 https://www.elastic.co/subscriptions[Subscriptions] page for information about 
 Elastic license levels. 

--- a/docs/static/management/centralized-pipelines.asciidoc
+++ b/docs/static/management/centralized-pipelines.asciidoc
@@ -10,7 +10,7 @@ with the basic license. If you want to try all of the features, you can start a
 30-day trial. At the end of the trial period, you can purchase a subscription to
 keep using the full functionality of the {xpack} components. For more
 information, see https://www.elastic.co/subscriptions and
-{stack-ov}/license-management.html[License
+{kibana-ref}/managing-licenses.html[License
 Management].
 
 You can control multiple Logstash instances from the pipeline management UI in

--- a/docs/static/management/configuring-centralized-pipelines.asciidoc
+++ b/docs/static/management/configuring-centralized-pipelines.asciidoc
@@ -13,7 +13,7 @@ feature.
 +
 --
 For more information, see https://www.elastic.co/subscriptions and 
-{stack-ov}/license-management.html[License management].
+{kibana-ref}/managing-licenses.html[License management].
 --
 
 . Specify 

--- a/docs/static/setup/setting-up-xpack.asciidoc
+++ b/docs/static/setup/setting-up-xpack.asciidoc
@@ -7,6 +7,6 @@ monitoring, machine learning, pipeline management, and many other capabilities.
 By default, when you install Logstash, {xpack} is installed. 
 
 If you want to try all of the {xpack} features, you can 
-{stack-ov}/license-management.html[start a 30-day trial]. At the end of the 
+{kibana-ref}/managing-licenses.html[start a 30-day trial]. At the end of the 
 trial period, you can purchase a subscription to keep using the full 
 functionality of the {xpack} components. For more information, see https://www.elastic.co/subscriptions.


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/1870

This PR removes out-dated links to the Stack Overview, which is no longer used.

### Preview
https://logstash_12025.docs-preview.app.elstc.co/diff