### PR TITLE
[7x_backport] Add link conversion from Markdown to AsciiDoctor (#11508)

### DIFF
--- a/tools/release/generate_release_notes.rb
+++ b/tools/release/generate_release_notes.rb
@@ -97,6 +97,7 @@ plugin_changes.each do |plugin, versions|
     next if line.match(/^##/)
     line.gsub!(/^\+/, "")
     line.gsub!(/ #(?<number>\d+)\s*$/, " https://github.com/logstash-plugins/#{plugin}/issues/\\k<number>[#\\k<number>]")
+    line.gsub!(/\[#(?<number>\d+)\]\((?<url>[^)]*)\)/, "\\k<url>[#\\k<number>]")
     line.gsub!(/^\s+-/, "*")
     report << line
   end


### PR DESCRIPTION
Backport of #11508 to convert links from Markdown to AsciiDoctor while generating
release notes.