### PR TITLE
do not call agent.converge_state_and_update before agent.execute

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -162,6 +162,18 @@ class LogStash::Agent
     @running.false?
   end
 
+  # Only call converge_state_and_update if agent is running
+  # to avoid a double call to converge_state_and_update since
+  # agent.execute will call converge_state_and_update itself
+  def converge_state_and_update_if_running
+    converge_state_and_update if running?
+  end
+
+  # Trigger convergence of pipelines
+  # NOTE that there is no point of calling this method before
+  # Agent#execute has been called since it will itself call
+  # converge_state_and_update and will result in a double
+  # convergence. 
   def converge_state_and_update
     results = @source_loader.fetch
 

--- a/x-pack/lib/monitoring/internal_pipeline_source.rb
+++ b/x-pack/lib/monitoring/internal_pipeline_source.rb
@@ -35,7 +35,7 @@ module LogStash module Monitoring
       super(xpack_info) if xpack_info
       if valid_basic_license?
         logger.info("Validated license for monitoring. Enabling monitoring pipeline.")
-        enable_monitoring()
+        enable_monitoring
       end
     end
 
@@ -45,7 +45,7 @@ module LogStash module Monitoring
     end
 
     def enable_monitoring
-      @agent.converge_state_and_update
+      @agent.converge_state_and_update_if_running
     end
 
     def populate_license_state(xpack_info)


### PR DESCRIPTION
This removes the call to `converge_state_and_update` from `InternalPipelineSource` where it was done from the `after_agent` event which means before `agent#execute` which is useless.

This code is **extremely** hard to understand and follow so I will need a second pair of eyes from someone with experience in this code to make sure I haven't overlooked anything. In particular I had to disable the related specs and I am not sure how valid these were in the first place and actually testing for the right thing. 