### PR TITLE
JEE: nix global compiler lock by normalizing to BaseDataset interface

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/ComputeStepSyntaxElement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/ComputeStepSyntaxElement.java
@@ -31,6 +31,8 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -49,14 +51,16 @@ public final class ComputeStepSyntaxElement<T extends Dataset> {
 
     private static final Path SOURCE_DIR = debugDir();
 
-    private static final ISimpleCompiler COMPILER = new SimpleCompiler();
+    private static final ThreadLocal<ISimpleCompiler> COMPILER = ThreadLocal.withInitial(SimpleCompiler::new);
 
     /**
      * Global cache of runtime compiled classes to prevent duplicate classes being compiled.
      * across pipelines and workers.
      */
-    private static final Map<ComputeStepSyntaxElement<?>, Class<? extends Dataset>> CLASS_CACHE
-        = new HashMap<>(5000);
+    private static final ConcurrentHashMap<ComputeStepSyntaxElement<?>, Class<? extends Dataset>> CLASS_CACHE
+        = new ConcurrentHashMap<>(500);
+
+    private static final AtomicLong DATASET_CLASS_INDEX = new AtomicLong(0);
 
     /**
      * Pattern to remove redundant {@code ;} from formatted code since {@link Formatter} does not
@@ -108,39 +112,34 @@ public final class ComputeStepSyntaxElement<T extends Dataset> {
         }
     }
 
-    /**
-     * This method is NOT thread-safe, and must have exclusive access to `COMPILER`
-     * so that the resulting `ClassLoader` after each `SimpleCompiler#cook()` operation
-     * can be teed up as the parent for the next cook operation.
-     * Also note that synchronizing on `COMPILER` also protects the global CLASS_CACHE.
-     */
-
     @SuppressWarnings("unchecked")
+    /*
+     * Returns a {@link Class<? extends Dataset>} for this {@link ComputeStepSyntaxElement}, reusing an existing
+     * equivalent implementation from the global class cache when one is available, or otherwise compiling one.
+     *
+     * This method _is_ thread-safe, and uses the locking semantics of {@link ConcurrentHashMap#computeIfAbsent}.
+     * To do so, it relies on {@link #hashCode()} and {@link #equals(Object)}.
+     */
     private  Class<? extends Dataset> compile() {
-        try {
-            synchronized (COMPILER) {
-                Class<? extends Dataset> clazz = CLASS_CACHE.get(this);
-                if (clazz == null) {
-                    final String name = String.format("CompiledDataset%d", CLASS_CACHE.size());
-                    final String code = CLASS_NAME_PLACEHOLDER_REGEX.matcher(normalizedSource).replaceAll(name);
-                    if (SOURCE_DIR != null) {
-                        final Path sourceFile = SOURCE_DIR.resolve(String.format("%s.java", name));
-                        Files.write(sourceFile, code.getBytes(StandardCharsets.UTF_8));
-                        COMPILER.cookFile(sourceFile.toFile());
-                    } else {
-                        COMPILER.cook(code);
-                    }
-                    COMPILER.setParentClassLoader(COMPILER.getClassLoader());
-                    clazz = (Class<T>) COMPILER.getClassLoader().loadClass(
-                        String.format("org.logstash.generated.%s", name)
-                    );
-                    CLASS_CACHE.put(this, clazz);
+        return CLASS_CACHE.computeIfAbsent(this, (__)->{
+            try {
+                final ISimpleCompiler compiler = COMPILER.get();
+                final String name = String.format("CompiledDataset%d", DATASET_CLASS_INDEX.incrementAndGet());
+                final String code = CLASS_NAME_PLACEHOLDER_REGEX.matcher(normalizedSource).replaceAll(name);
+                if (SOURCE_DIR != null) {
+                    final Path sourceFile = SOURCE_DIR.resolve(String.format("%s.java", name));
+                    Files.write(sourceFile, code.getBytes(StandardCharsets.UTF_8));
+                    compiler.cookFile(sourceFile.toFile());
+                } else {
+                    compiler.cook(code);
                 }
-                return clazz;
+                return (Class<T>) compiler.getClassLoader().loadClass(
+                    String.format("org.logstash.generated.%s", name)
+                );
+            } catch (final CompileException | ClassNotFoundException | IOException ex) {
+                throw new IllegalStateException(ex);
             }
-        } catch (final CompileException | ClassNotFoundException | IOException ex) {
-            throw new IllegalStateException(ex);
-        }
+        });
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/VariableDefinition.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/VariableDefinition.java
@@ -72,6 +72,8 @@ final class VariableDefinition implements SyntaxElement {
             safe = EventCondition.class;
         } else if (DynamicMethod.class.isAssignableFrom(clazz)) {
             safe = DynamicMethod.class;
+        } else if (BaseDataset.class.isAssignableFrom(clazz)) {
+            safe = BaseDataset.class;
         } else {
             safe = clazz;
         }


### PR DESCRIPTION
Generated implementations of `BaseDataset` often have fields referencing
other specifically-generated `BaseDataset`, despite only using public methods
defined on the `BaseDataset` abstract class.

By allowing the code generation to reference the abstract class instead of
the specific implementation, we eliminate the need for the compiler to chain
parent class loaders indefinitely, thereby eliminating the need for a global
mutual exclusion when compiling.

This chage moves the locking semantics from the compiler to the non-evicting
cache itself, relying on tried-and-true `ConcurrentHashMap#computeIfAbsent`
to minimize synchronization and cache-priming stampedes.

I believe that this also vastly reduces the scope of `BaseDataset`
implementations that we need to generate, because datasets will no longer
need to reference the specific implementation details of all "downstream"
datasets and will therefore be more likely to match an implementation
that has already been compiled and cached.