### PR TITLE
plugin config: support space-deliminated URIs on list-type params

### DIFF
--- a/docs/static/cross-plugin-concepts.asciidoc
+++ b/docs/static/cross-plugin-concepts.asciidoc
@@ -1,7 +1,7 @@
 [[plugin-concepts]]
 === Cross-plugin concepts and features
 
-New section for concepts, features, and behaviors that apply to multiple plugins.
+New section for concepts, features, and behaviours that apply to multiple plugins.
 
 [[space-delimited-uris-in-list-params]]
 ==== Space-deliminated URIs in list-type params

--- a/docs/static/cross-plugin-concepts.asciidoc
+++ b/docs/static/cross-plugin-concepts.asciidoc
@@ -1,0 +1,17 @@
+[[plugin-concepts]]
+=== Cross-plugin concepts and features
+
+New section for concepts, features, and behaviors that apply to multiple plugins.
+
+[[space-delimited-uris-in-list-params]]
+==== Space-deliminated URIs in list-type params
+
+List-type URI parameters will automatically expand strings that contain multiple
+whitespace-delimited URIs into separate entries. This behaviour enables the expansion
+of an arbitrary list of URIs from a single Environment- or Keystore-variable.
+
+Examples of plugins and options that support this functionality:
+
+* <<plugins-inputs-elasticsearch-hosts,Elasticsearch input plugin - `hosts`>>
+* <<plugins-outputs-elasticsearch-hosts,Elasticsearch output plugin - `hosts`>>
+* <<plugins-filters-elasticsearch-hosts,Elasticsearch filter plugin - `hosts`>>

--- a/docs/static/plugin-manager.asciidoc
+++ b/docs/static/plugin-manager.asciidoc
@@ -153,6 +153,8 @@ bin/logstash-plugin install logstash-output-kafka
 
 Once set, plugin commands install, update can be used through this proxy.
 
+include::cross-plugin-concepts.asciidoc[]
+
 include::plugin-generator.asciidoc[]
 
 include::offline-plugins.asciidoc[]

--- a/logstash-core/lib/logstash/util/safe_uri.rb
+++ b/logstash-core/lib/logstash/util/safe_uri.rb
@@ -45,6 +45,17 @@ class LogStash::Util::SafeURI
     raise ArgumentError, "URI is not valid - host is not specified" if @uri.host.nil?
   end
 
+  ##
+  # Attempts to efficiently return an instance of `SafeURI` from the given object.
+  # @param object [Object]: an object that may or may not already be a `SafeURI`.
+  # @return [SafeURI]: if the given `object` was a `SafeURI`, returns it unmodified.
+  #                    otherwise, a new `SafeURI` is initialized using the `object`.
+  def self.from(object)
+    return object if object.kind_of?(self)
+
+    new(object)
+  end
+
   def to_s
     sanitized.to_s
   end


### PR DESCRIPTION
Since whitespace is illegal in URIs, we can safely use it as a delimiter when
validating `list`-type `URI` params, enabling the expansion of an arbitrary
list of URIs from a single Environment- or Keystore-variable.

TODO:
 - [x] figure out where/how to document this. Any plugin that defines an option has both `:list => true` and `:validate => :uri` will get this for free when running on a Logstash that includes the change, but the feature is heavily dependent on the specific version of Logstash that is running (e.g., `hosts` in ES Input/Filter/Output plugins, perhaps others; cc: @karenzone ) 

Resolves: https://github.com/elastic/logstash/issues/8157
Resolves: https://github.com/elastic/logstash/issues/6366