### PR TITLE
narrow scope of testCacheCompiledClassesWithDifferentId

### DIFF
--- a/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
@@ -570,7 +570,7 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
 
     @Test
     @SuppressWarnings({"unchecked"})
-    public void testCompilerCacheCompiledClasses() throws IOException, InvalidIRException {
+    public void testCacheCompiledClassesWithDifferentId() throws IOException, InvalidIRException {
         final FixedPluginFactory pluginFactory = new FixedPluginFactory(
                 () -> null,
                 () -> IDENTITY_FILTER,
@@ -582,20 +582,20 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
                 false);
         final CompiledPipeline cBaselinePipeline = new CompiledPipeline(baselinePipeline, pluginFactory);
 
-        final PipelineIR pipelineWithExtraFilter = ConfigCompiler.configToPipelineIR(
+        final PipelineIR pipelineWithDifferentId = ConfigCompiler.configToPipelineIR(
                 IRHelpers.toSourceWithMetadataFromPath("org/logstash/config/ir/cache/pipeline2.conf"),
                 false);
-        final CompiledPipeline cPipelineWithExtraFilter = new CompiledPipeline(pipelineWithExtraFilter, pluginFactory);
+        final CompiledPipeline cPipelineWithDifferentId = new CompiledPipeline(pipelineWithDifferentId, pluginFactory);
         
         // actual test: compiling a pipeline with an extra filter should only create 1 extra class
         ComputeStepSyntaxElement.cleanClassCache();
         cBaselinePipeline.buildExecution();
         final int cachedBefore = ComputeStepSyntaxElement.classCacheSize();
-        cPipelineWithExtraFilter.buildExecution();
+        cPipelineWithDifferentId.buildExecution();
         final int cachedAfter = ComputeStepSyntaxElement.classCacheSize();
-        
+
         final String message = String.format("unexpected cache size, cachedAfter: %d, cachedBefore: %d", cachedAfter, cachedBefore);
-        assertEquals(message, 1, cachedAfter - cachedBefore);
+        assertEquals(message, 0, cachedAfter - cachedBefore);
     }
 
     @Test

--- a/logstash-core/src/test/resources/org/logstash/config/ir/cache/pipeline1.conf
+++ b/logstash-core/src/test/resources/org/logstash/config/ir/cache/pipeline1.conf
@@ -1,19 +1,14 @@
 input {
-  stdin {}
+  stdin { id => "stdin_id_1" }
 }
 
 filter {
   mutate {
-    id => "ppl1_1"
+    id => "mutate_id_1"
     rename => ["a_field", "into_another"]
   }
-
-  mutate {
-      id => "ppl1_2"
-      rename => ["a_field", "into_another"]
-    }
 }
 
 output {
-  stdout {}
+  stdout { id => "stdout_id_1" }
 }

--- a/logstash-core/src/test/resources/org/logstash/config/ir/cache/pipeline2.conf
+++ b/logstash-core/src/test/resources/org/logstash/config/ir/cache/pipeline2.conf
@@ -1,24 +1,16 @@
+# pipeline similar to pipeline 1 but with different ids
+# no extra classes should be generated because of this
 input {
-  stdin {}
+  stdin { id => "stdin_id_1" }
 }
 
 filter {
   mutate {
-    id => "ppl2_1"
+    id => "mutate_id_1"
     rename => ["a_field", "into_another"]
   }
-
-  mutate {
-    id => "ppl2_2"
-    rename => ["a_field", "into_another"]
-  }
-
-    mutate {
-      id => "ppl2_3"
-      rename => ["a_field", "into_another"]
-    }
 }
 
 output {
-  stdout {}
+  stdout { id => "stdout_id_1" }
 }


### PR DESCRIPTION
This change forces the test to check that compiling a pipeline twice but with different ids doesn't produce more classes.

@andsel I know you wrote this recently, but I ended up doing this refactor as I prepare to add new tests for the speed improvement in https://github.com/elastic/logstash/pull/12047