### PR TITLE
JEE: nix global compiler lock by normalizing to Dataset interface #12047

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/ComputeStepSyntaxElement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/ComputeStepSyntaxElement.java
@@ -32,6 +32,8 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -50,14 +52,16 @@ public final class ComputeStepSyntaxElement<T extends Dataset> {
 
     private static final Path SOURCE_DIR = debugDir();
 
-    private static final ISimpleCompiler COMPILER = new SimpleCompiler();
+    private static final ThreadLocal<ISimpleCompiler> COMPILER = ThreadLocal.withInitial(SimpleCompiler::new);
 
     /**
      * Global cache of runtime compiled classes to prevent duplicate classes being compiled.
      * across pipelines and workers.
      */
-    private static final Map<ComputeStepSyntaxElement<?>, Class<? extends Dataset>> CLASS_CACHE
-        = new HashMap<>(5000);
+    private static final ConcurrentHashMap<ComputeStepSyntaxElement<?>, Class<? extends Dataset>> CLASS_CACHE
+        = new ConcurrentHashMap<>(500);
+
+    private static final AtomicLong DATASET_CLASS_INDEX = new AtomicLong(0);
 
     /**
      * Pattern to remove redundant {@code ;} from formatted code since {@link Formatter} does not
@@ -125,39 +129,34 @@ public final class ComputeStepSyntaxElement<T extends Dataset> {
         }
     }
 
-    /**
-     * This method is NOT thread-safe, and must have exclusive access to `COMPILER`
-     * so that the resulting `ClassLoader` after each `SimpleCompiler#cook()` operation
-     * can be teed up as the parent for the next cook operation.
-     * Also note that synchronizing on `COMPILER` also protects the global CLASS_CACHE.
-     */
-
     @SuppressWarnings("unchecked")
+    /*
+     * Returns a {@link Class<? extends Dataset>} for this {@link ComputeStepSyntaxElement}, reusing an existing
+     * equivalent implementation from the global class cache when one is available, or otherwise compiling one.
+     *
+     * This method _is_ thread-safe, and uses the locking semantics of {@link ConcurrentHashMap#computeIfAbsent}.
+     * To do so, it relies on {@link #hashCode()} and {@link #equals(Object)}.
+     */
     private  Class<? extends Dataset> compile() {
-        try {
-            synchronized (COMPILER) {
-                Class<? extends Dataset> clazz = CLASS_CACHE.get(this);
-                if (clazz == null) {
-                    final String name = String.format("CompiledDataset%d", CLASS_CACHE.size());
-                    final String code = CLASS_NAME_PLACEHOLDER_REGEX.matcher(normalizedSource).replaceAll(name);
-                    if (SOURCE_DIR != null) {
-                        final Path sourceFile = SOURCE_DIR.resolve(String.format("%s.java", name));
-                        Files.write(sourceFile, code.getBytes(StandardCharsets.UTF_8));
-                        COMPILER.cookFile(sourceFile.toFile());
-                    } else {
-                        COMPILER.cook(code);
-                    }
-                    COMPILER.setParentClassLoader(COMPILER.getClassLoader());
-                    clazz = (Class<T>) COMPILER.getClassLoader().loadClass(
-                        String.format("org.logstash.generated.%s", name)
-                    );
-                    CLASS_CACHE.put(this, clazz);
+        return CLASS_CACHE.computeIfAbsent(this, (__)->{
+            try {
+                final ISimpleCompiler compiler = COMPILER.get();
+                final String name = String.format("CompiledDataset%d", DATASET_CLASS_INDEX.incrementAndGet());
+                final String code = CLASS_NAME_PLACEHOLDER_REGEX.matcher(normalizedSource).replaceAll(name);
+                if (SOURCE_DIR != null) {
+                    final Path sourceFile = SOURCE_DIR.resolve(String.format("%s.java", name));
+                    Files.write(sourceFile, code.getBytes(StandardCharsets.UTF_8));
+                    compiler.cookFile(sourceFile.toFile());
+                } else {
+                    compiler.cook(code);
                 }
-                return clazz;
+                return (Class<T>) compiler.getClassLoader().loadClass(
+                    String.format("org.logstash.generated.%s", name)
+                );
+            } catch (final CompileException | ClassNotFoundException | IOException ex) {
+                throw new IllegalStateException(ex);
             }
-        } catch (final CompileException | ClassNotFoundException | IOException ex) {
-            throw new IllegalStateException(ex);
-        }
+        });
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/ComputeStepSyntaxElement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/ComputeStepSyntaxElement.java
@@ -101,7 +101,6 @@ public final class ComputeStepSyntaxElement<T extends Dataset> {
     public static void cleanClassCache() {
         synchronized (COMPILER) {
             CLASS_CACHE.clear();
-            COMPILER.setParentClassLoader(null);
         }
     }
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/ComputeStepSyntaxElement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/ComputeStepSyntaxElement.java
@@ -59,7 +59,7 @@ public final class ComputeStepSyntaxElement<T extends Dataset> {
      * across pipelines and workers.
      */
     private static final ConcurrentHashMap<ComputeStepSyntaxElement<?>, Class<? extends Dataset>> CLASS_CACHE
-        = new ConcurrentHashMap<>(500);
+        = new ConcurrentHashMap<>(100);
 
     private static final AtomicLong DATASET_CLASS_INDEX = new AtomicLong(0);
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/VariableDefinition.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/VariableDefinition.java
@@ -72,6 +72,8 @@ final class VariableDefinition implements SyntaxElement {
             safe = EventCondition.class;
         } else if (DynamicMethod.class.isAssignableFrom(clazz)) {
             safe = DynamicMethod.class;
+        } else if (Dataset.class.isAssignableFrom(clazz)) {
+            safe = Dataset.class;
         } else {
             safe = clazz;
         }

--- a/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
@@ -615,12 +615,12 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
 
         final CompiledPipeline testCompiledPipeline = new CompiledPipeline(testPipelineIR, pluginFactory);
 
-        final long compilationBaseline = time(ChronoUnit.SECONDS, () -> {
+        final long compilationBaseline = time(ChronoUnit.MILLIS, () -> {
             final CompiledPipeline.CompiledExecution compiledExecution = baselineCompiledPipeline.buildExecution();
             compiledExecution.compute(RubyUtil.RUBY.newArray(testEvent), false, false);
         });
 
-        final long compilationTest = time(ChronoUnit.SECONDS, () -> {
+        final long compilationTest = time(ChronoUnit.MILLIS, () -> {
             final CompiledPipeline.CompiledExecution compiledExecution = testCompiledPipeline.buildExecution();
             compiledExecution.compute(RubyUtil.RUBY.newArray(testEvent), false, false);
         });

--- a/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
@@ -586,12 +586,47 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
                 IRHelpers.toSourceWithMetadataFromPath("org/logstash/config/ir/cache/pipeline2.conf"),
                 false);
         final CompiledPipeline cPipelineWithDifferentId = new CompiledPipeline(pipelineWithDifferentId, pluginFactory);
-        
+
         // actual test: compiling a pipeline with an extra filter should only create 1 extra class
         ComputeStepSyntaxElement.cleanClassCache();
         cBaselinePipeline.buildExecution();
         final int cachedBefore = ComputeStepSyntaxElement.classCacheSize();
         cPipelineWithDifferentId.buildExecution();
+        final int cachedAfter = ComputeStepSyntaxElement.classCacheSize();
+
+        final String message = String.format("unexpected cache size, cachedAfter: %d, cachedBefore: %d", cachedAfter, cachedBefore);
+        assertEquals(message, 0, cachedAfter - cachedBefore);
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked"})
+    public void testReuseCompiledClasses() throws IOException, InvalidIRException {
+        final FixedPluginFactory pluginFactory = new FixedPluginFactory(
+                () -> null,
+                () -> IDENTITY_FILTER,
+                mockOutputSupplier()
+        );
+
+        // this pipeline generates 10 classes
+        // - 7 for the filters for the nested and leaf Datasets
+        // - 3 for the sequence of outputs with a conditional
+        final PipelineIR baselinePipeline = ConfigCompiler.configToPipelineIR(
+                IRHelpers.toSourceWithMetadataFromPath("org/logstash/config/ir/cache/pipeline_reuse_baseline.conf"),
+                false);
+        final CompiledPipeline cBaselinePipeline = new CompiledPipeline(baselinePipeline, pluginFactory);
+
+        // this pipeline is much bigger than the baseline
+        // but is carefully crafted to reuse the same classes as the baseline pipeline
+        final PipelineIR pipelineTwiceAsBig = ConfigCompiler.configToPipelineIR(
+                IRHelpers.toSourceWithMetadataFromPath("org/logstash/config/ir/cache/pipeline_reuse_test.conf"),
+                false);
+        final CompiledPipeline cPipelineTwiceAsBig = new CompiledPipeline(pipelineTwiceAsBig, pluginFactory);
+
+        // test: compiling a much bigger pipeline and asserting no additional classes are generated
+        ComputeStepSyntaxElement.cleanClassCache();
+        cBaselinePipeline.buildExecution();
+        final int cachedBefore = ComputeStepSyntaxElement.classCacheSize();
+        cPipelineTwiceAsBig.buildExecution();
         final int cachedAfter = ComputeStepSyntaxElement.classCacheSize();
 
         final String message = String.format("unexpected cache size, cachedAfter: %d, cachedBefore: %d", cachedAfter, cachedBefore);

--- a/logstash-core/src/test/resources/org/logstash/config/ir/cache/pipeline_reuse_baseline.conf
+++ b/logstash-core/src/test/resources/org/logstash/config/ir/cache/pipeline_reuse_baseline.conf
@@ -1,0 +1,31 @@
+input {
+  stdin { }
+}
+
+filter {
+  if [a] {
+    noop {}
+    if [a] { noop {} }
+  }
+  if [a] {
+    if [a] {
+      noop {}
+      if [a] { noop {} }
+      if [a] { noop {} }
+    }
+  }
+  if [a] {
+    if [a] {
+      if [a] {
+        noop {}
+        if [a] { noop {} }
+      }
+    }
+  }
+}
+output {
+  if [a] { noop {} }
+  stdout {}
+  stdout {}
+  stdout {}
+}

--- a/logstash-core/src/test/resources/org/logstash/config/ir/cache/pipeline_reuse_test.conf
+++ b/logstash-core/src/test/resources/org/logstash/config/ir/cache/pipeline_reuse_test.conf
@@ -1,0 +1,84 @@
+input {
+  stdin { }
+  stdin { }
+  stdin { }
+  stdin { }
+  stdin { }
+}
+
+filter {
+  if [a] {
+    noop {}
+    if [a] { noop {} }
+    if [a] { noop {} }
+    if [a] { noop {} }
+    if [a] { noop {} }
+    if [a] { noop {} }
+  }
+  if [a] {
+    noop {}
+    noop {}
+    noop {}
+    if [a] { noop {} }
+    if [a] { noop {} }
+    if [a] { noop {} }
+    if [a] { noop {} }
+  }
+  if [a] {
+    noop {}
+    if [a] { noop {} }
+  }
+  if [a] {
+    if [a] {
+      noop {}
+      if [a] { noop {} }
+    }
+  }
+  if [a] {
+    if [a] {
+      noop {}
+      if [a] { noop {} }
+    }
+  }
+  if [a] {
+    if [a] {
+      noop {}
+      if [a] { noop {} }
+    }
+    if [a] {
+      noop {}
+      if [a] { noop {} }
+    }
+  }
+  if [a] {
+    if [a] {
+      noop {}
+      if [a] { noop {} }
+      if [a] { noop {} }
+      if [a] { noop {} }
+    }
+  }
+  if [a] {
+    if [a] {
+      if [a] {
+        noop {}
+        if [a] { noop {} }
+        if [a] { noop {} }
+        if [a] { noop {} }
+      }
+    }
+  }
+}
+output {
+  if [a] {
+    noop {}
+  } else {
+    noop {}
+  }
+  if [a] {
+    noop {}
+  } else {
+    noop {}
+  }
+}
+


### PR DESCRIPTION
Continuing from https://github.com/elastic/logstash/pull/12047.
Also adds with a new `testReuseCompiledClasses` that tests the tremendous save in class generation, and fixes `compilerBenchmark` since compilation can now easily be sub second.

> Generated implementations of `BaseDataset` often have fields referencing
> other specifically-generated `BaseDataset`, despite only using public methods
> defined on the `BaseDataset` abstract class.
> 
> By allowing the code generation to reference the abstract class instead of
> the specific implementation, we eliminate the need for the compiler to chain
> parent class loaders indefinitely, thereby eliminating the need for a global
> mutual exclusion when compiling.
> 
> This chage moves the locking semantics from the compiler to the non-evicting
> cache itself, relying on tried-and-true `ConcurrentHashMap#computeIfAbsent`
> to minimize synchronization and cache-priming stampedes.
> 
> I believe that this also vastly reduces the scope of `BaseDataset`
> implementations that we need to generate, because datasets will no longer
> need to reference the specific implementation details of all "downstream"
> datasets and will therefore be more likely to match an implementation
> that has already been compiled and cached.