### PR TITLE
Add wait functionality to `stop_es` integration test helper function

### DIFF
--- a/qa/integration/services/elasticsearch_teardown.sh
+++ b/qa/integration/services/elasticsearch_teardown.sh
@@ -7,9 +7,18 @@ source "$current_dir/helpers.sh"
 ES_HOME="$current_dir/../../../build/elasticsearch"
 
 stop_es() {
-    pid=$(cat $ES_HOME/elasticsearch.pid)
-    [ "x$pid" != "x" ] && [ "$pid" -gt 0 ]
-    kill -SIGTERM $pid
+    local count=10
+    [ ! -f $ES_HOME/elasticsearch.pid ] && return 0
+    pid=$(cat $ES_HOME/elasticsearch.pid) 2>/dev/null
+    if [ "x$pid" != "x" ] && [ "$pid" -gt 0 ]
+    then
+      while kill -SIGTERM "$pid" 2>/dev/null && [ $count -ne 0 ]; do
+         echo "waiting for elasticsearch to stop"
+         count=$(( $count - 1 ))
+         [[ $count -eq 0 ]] && echo "killing elasticsearch" && kill -9 $pid 2>/dev/null || true
+         sleep 0.5
+      done
+    fi
 }
 
 stop_es


### PR DESCRIPTION
Integration tests may fail during elasticsearch teardown, as currently
the stop_es function sends a `SIGTERM` to Elasticsearch, but does not
wait for the process to exit. That can lead to issues when deleting
data directories from a still running process. This commit adds
wait functionality to `stop_es` to wait for a short period of time,
sending a `SIGKILL` if Elasticsearch does not terminate in time.