### PR TITLE
Update Dockerfile to use ubuntu:focal instead of bionic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 RUN apt-get update && \
     apt-get install -y zlib1g-dev build-essential vim rake git curl libssl-dev libreadline-dev libyaml-dev  \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:focal
 
+ENV DEBIAN_FRONTEND noninteractive
+
 RUN apt-get update && \
     apt-get install -y zlib1g-dev build-essential vim rake git curl libssl-dev libreadline-dev libyaml-dev  \
       libxml2-dev libxslt-dev openjdk-11-jdk-headless curl iputils-ping netcat && \


### PR DESCRIPTION
Ubuntu focal is the newest LTS release of Ubuntu. It uses updated libraries (e.g. no more Python 2.7) which is better for future support.