### PR TITLE
[DOCS] Change links to refactored Beats getting started docs

### DIFF
--- a/docs/static/advanced-pipeline.asciidoc
+++ b/docs/static/advanced-pipeline.asciidoc
@@ -31,7 +31,7 @@ input plugin enables Logstash to receive events from the Elastic Beats framework
 to work with the Beats framework, such as Packetbeat and Metricbeat, can also send event data to Logstash.
 
 To install Filebeat on your data source machine, download the appropriate package from the Filebeat https://www.elastic.co/downloads/beats/filebeat[product page]. You can also refer to
-{filebeat-ref}/filebeat-getting-started.html[Getting Started with Filebeat] in the Beats documentation for additional
+{filebeat-ref}/filebeat-installation-configuration.html[Filebeat quick start] for additional
 installation instructions.
 
 After installing Filebeat, you need to configure it. Open the `filebeat.yml` file located in your Filebeat installation
@@ -654,7 +654,7 @@ If you are using Kibana to visualize your data, you can also explore the Filebea
 
 image::static/images/kibana-filebeat-data.png[Discovering Filebeat data in Kibana]
 
-See the {filebeat-ref}/filebeat-getting-started.html[Filebeat getting started docs] for info about loading the Kibana
+See the {filebeat-ref}/filebeat-installation-configuration.html[Filebeat quick start docs] for info about loading the Kibana
 index pattern for Filebeat.
 
 You've successfully created a pipeline that uses Filebeat to take Apache web logs as input, parses those logs to

--- a/docs/static/fb-ls-kafka-example.asciidoc
+++ b/docs/static/fb-ls-kafka-example.asciidoc
@@ -28,8 +28,8 @@ The `-e` flag is optional and sends output to standard error instead of syslog.
 A connection to {es} and {kib} is required for this one-time setup
 step because {filebeat} needs to create the index template in {es} and
 load the sample dashboards into {kib}. For more information about configuring
-the connection to {es}, see the Filebeat modules
-{filebeat-ref}/filebeat-modules-quickstart.html[quick start].
+the connection to {es}, see the Filebeat
+{filebeat-ref}/filebeat-installation-configuration.html[quick start].
 +
 After the template and dashboards are loaded, you'll see the message `INFO
 {kib} dashboards successfully loaded. Loaded dashboards`.

--- a/docs/static/monitoring/monitoring-mb.asciidoc
+++ b/docs/static/monitoring/monitoring-mb.asciidoc
@@ -52,7 +52,7 @@ monitoring.cluster_uuid: PRODUCTION_ES_CLUSTER_UUID
 [[configure-metricbeat]]
 ==== Install and configure {metricbeat}
 
-. {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}] on the
+. {metricbeat-ref}/metricbeat-installation-configuration.html[Install {metricbeat}] on the
 same server as {ls}. 
 
 . Enable the `logstash-xpack` module in {metricbeat}. +


### PR DESCRIPTION
Updates links to reflect changes added in elastic/beats#19302.

This change applies to 7.9 and later.