### PR TITLE
Need additional guides to access the plug-in

### DIFF
--- a/docs/static/plugin-manager.asciidoc
+++ b/docs/static/plugin-manager.asciidoc
@@ -82,6 +82,7 @@ bin/logstash-plugin install logstash-output-kafka
 
 Once the plugin is successfully installed, you can start using it in your configuration file.
 
+Need to add a guide to change the permissions so that users running Logstash can access the plug-ins installed
 [[installing-local-plugins]]
 [float]
 ==== Advanced: Adding a locally built plugin


### PR DESCRIPTION
I'm not sure if it's correct to ask for this modification.
Post the content in the document to request replenishment.

we actually do not mention anything in our documentation regarding the permissions or which user should be used to install the offline plugin pack.
Customers are often asked to install the plug-in as a user with a different privilege than the user running Logstash and receive an error stating that it cannot be used.
After installing the plug-in to this document, it seems that a guide to change the permissions to be accessible to users running Logstash should be added.