### PR TITLE
bump jruby to 9.2.12.0

### DIFF
--- a/docs/static/troubleshooting.asciidoc
+++ b/docs/static/troubleshooting.asciidoc
@@ -59,8 +59,8 @@ Running Logstash with Java 11 results in warnings similar to these:
 [source,sh]
 -----
 WARNING: An illegal reflective access operation has occurred
-WARNING: Illegal reflective access by org.jruby.util.SecurityHelper (file:/Users/chrisuser/logstash-6.7.0/logstash-core/lib/jars/jruby-complete-9.2.6.0.jar) to field java.lang.reflect.Field.modifiers
-WARNING: Please consider reporting this to the maintainers of org.jruby.util.SecurityHelper
+WARNING: Illegal reflective access by org.jruby.ext.openssl.SecurityHelper (file:/{...}/jruby{...}jopenssl.jar) to field java.security.MessageDigest.provider
+WARNING: Please consider reporting this to the maintainers of org.jruby.ext.openssl.SecurityHelper
 WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
 WARNING: All illegal access operations will be denied in a future release
 -----
@@ -73,18 +73,11 @@ Try adding these values to the `jvm.options` file.
 
 [source,sh]
 -----
---add-opens=java.base/java.lang=ALL-UNNAMED 
---add-opens=java.base/java.security=ALL-UNNAMED 
---add-opens=java.base/java.util=ALL-UNNAMED 
---add-opens=java.base/java.security.cert=ALL-UNNAMED 
---add-opens=java.base/java.util.zip=ALL-UNNAMED 
---add-opens=java.base/java.lang.reflect=ALL-UNNAMED 
---add-opens=java.base/java.util.regex=ALL-UNNAMED 
---add-opens=java.base/java.net=ALL-UNNAMED 
---add-opens=java.base/java.io=ALL-UNNAMED 
---add-opens=java.base/java.lang=ALL-UNNAMED
---add-opens=java.base/javax.crypto=ALL-UNNAMED
---add-opens=java.management/sun.management=ALL-UNNAMED
+--add-opens=java.base/java.security=ALL-UNNAMED
+--add-opens=java.base/java.io=ALL-UNNAMED
+--add-opens=java.base/java.nio.channels=org.jruby.dist
+--add-opens=java.base/sun.nio.ch=org.jruby.dist
+--add-opens=java.management/sun.management=org.jruby.dist
 -----
 
 *Notes:*
@@ -324,7 +317,6 @@ https://github.com/logstash-plugins/logstash-input-kafka/issues/210
 == Other issues
 
 Coming soon
-
 
 
 

--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -25,7 +25,7 @@ buildscript {
     dependencies {
         classpath 'org.yaml:snakeyaml:1.23'
         classpath "de.undercouch:gradle-download-task:4.0.4"
-        classpath "org.jruby:jruby-complete:9.2.11.1"
+        classpath "org.jruby:jruby-complete:9.2.12.0"
     }
 }
 

--- a/versions.yml
+++ b/versions.yml
@@ -7,8 +7,8 @@ logstash-core-plugin-api: 2.1.16
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time
 jruby:
-  version: 9.2.11.1
-  sha1: cceb81635fe3cd39f895c7632428e94b503e8e3d
+  version: 9.2.12.0
+  sha1: bccc2034e773cb1aba2cc4b8b40921265f6e857f
 
 # jruby-runtime-override, if specified, will override the jruby version installed in vendor/jruby for logstash runtime only,
 # not for the compile-time jars


### PR DESCRIPTION
Also tweak the documentation since most of the add-opens are no longer needed, except two:
* java.io due to https://github.com/colinsurprenant/jruby-stdin-channel/issues/1
* java.security due to jruby-openssl