### PR TITLE
fix pipeline spec that didn't wait for pipeline to terminate

### DIFF
--- a/logstash-core/spec/logstash/pipeline_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_spec.rb
@@ -371,20 +371,6 @@ describe LogStash::Pipeline do
       eos
     }
 
-    let(:test_config_with_output_workers) {
-      <<-eos
-      input {
-        dummyinput {}
-      }
-
-      output {
-        dummyoutput {
-          workers => 2
-        }
-      }
-      eos
-    }
-
     context "output close" do
       let(:pipeline) { mock_pipeline_from_string(test_config_without_output_workers) }
       let(:output) { pipeline.outputs.first }
@@ -393,13 +379,9 @@ describe LogStash::Pipeline do
         allow(output).to receive(:do_close)
       end
 
-      after do
-        pipeline.shutdown
-      end
-
       it "should call close of output without output-workers" do
         pipeline.start
-
+        pipeline.shutdown
         expect(output).to have_received(:do_close).once
       end
     end


### PR DESCRIPTION
this test only called "pipeline.start" and expected an output to receive
the "do_close" method call. Therefore it relies on a race condition that
the pipeline shuts down quickly enough, which could fail.
This change ensures the pipeline fully terminated before making the
assertion

Fixes test failures such as https://logstash-ci.elastic.co/job/elastic+logstash+master+multijob--ruby-unit-tests/334/console:

```
21:36:04       1) LogStash::Pipeline close output close should call close of output without output-workers
21:36:04          Failure/Error: expect(output).to have_received(:do_close).once
21:36:04          
21:36:04            (#<LogStash::OutputDelegator:0x34a0c4ad>).do_close(*(any args))
21:36:04                expected: 1 time with any arguments
21:36:04                received: 0 times with any arguments
21:36:04          # ./logstash-core/spec/logstash/pipeline_spec.rb:403:in `block in <main>'
21:36:04          # ./spec/spec_helper.rb:66:in `block in /opt/logstash/spec/spec_helper.rb'
21:36:04          # ./logstash-core/lib/logstash/util.rb:43:in `set_thread_name'
21:36:04          # ./spec/spec_helper.rb:65:in `block in /opt/logstash/spec/spec_helper.rb'
21:36:04          # ./spec/spec_helper.rb:58:in `block in /opt/logstash/spec/spec_helper.rb'
21:36:04          # ./vendor/bundle/jruby/2.5.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block in /opt/logstash/vendor/bundle/jruby/2.5.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb'
21:36:04          # ./lib/bootstrap/rspec.rb:31:in `<main>'
21:36:04 
21:36:04     Finished in 12 minutes 17 seconds (files took 11.67 seconds to load)
21:36:04     2505 examples, 1 failure, 22 pending
21:36:04 
21:36:04     Failed examples:
21:36:04 
21:36:04     rspec ./logstash-core/spec/logstash/pipeline_spec.rb:400 
```