### PR TITLE
ensure pipeline terminates execution before doing assertion

### DIFF
--- a/logstash-core/spec/logstash/java_pipeline_spec.rb
+++ b/logstash-core/spec/logstash/java_pipeline_spec.rb
@@ -903,6 +903,7 @@ describe LogStash::JavaPipeline do
     it "correctly distributes events" do
       pipeline = mock_java_pipeline_from_string(config, pipeline_settings_obj)
       pipeline.start
+      sleep 0.01 until pipeline.finished_execution?
       pipeline.shutdown
       expect(output.events.size).to eq(60)
       expect(output.events.count {|e| e.get("cloned") == "cloned"}).to eq(30)


### PR DESCRIPTION
This test relies on the generator input sending 10 events and observing
the output. Calling shutdown immediately after start can cause the
plugin to abort earily.
This change waits for the execution to finish before performing the
test assertions.

This fixes tests failures such as https://logstash-ci.elastic.co/job/elastic+logstash+7.x+multijob--ruby-unit-tests/312/console:

```
21:37:10       1) LogStash::JavaPipeline with multiple outputs correctly distributes events
21:37:10          Failure/Error: expect(output.events.size).to eq(60)
21:37:10          
21:37:10            expected: 60
21:37:10                 got: 0
21:37:10          
21:37:10            (compared using ==)
21:37:10          # ./logstash-core/spec/logstash/java_pipeline_spec.rb:907:in `block in <main>'
21:37:10          # ./spec/spec_helper.rb:66:in `block in /opt/logstash/spec/spec_helper.rb'
21:37:10          # ./logstash-core/lib/logstash/util.rb:43:in `set_thread_name'
21:37:10          # ./spec/spec_helper.rb:65:in `block in /opt/logstash/spec/spec_helper.rb'
21:37:10          # ./spec/spec_helper.rb:58:in `block in /opt/logstash/spec/spec_helper.rb'
21:37:10          # ./vendor/bundle/jruby/2.5.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block in /opt/logstash/vendor/bundle/jruby/2.5.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb'
21:37:10          # ./lib/bootstrap/rspec.rb:31:in `<main>'
21:37:10 
21:37:10     Finished in 12 minutes 49 seconds (files took 13.68 seconds to load)
21:37:10     3333 examples, 1 failure, 22 pending
21:37:10 
21:37:10     Failed examples:
21:37:10 
21:37:10     rspec ./logstash-core/spec/logstash/java_pipeline_spec.rb:903 # LogStash::JavaPipeline with multiple outputs correctly distributes events
```