### PR TITLE
make PQ and DLQ tests use less space

### DIFF
--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -545,7 +545,8 @@ describe LogStash::Agent do
 
   describe "using persisted queue" do
     it_behaves_like "all Agent tests" do
-      let(:agent_settings) { mock_settings("queue.type" => "persisted", "queue.drain" => true) }
+      let(:agent_settings) { mock_settings("queue.type" => "persisted", "queue.drain" => true,
+                                           "queue.page_capacity" => "8mb", "queue.max_bytes" => "64mb") }
     end
   end
 end

--- a/logstash-core/spec/logstash/pipeline_pq_file_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_pq_file_spec.rb
@@ -95,9 +95,9 @@ describe LogStash::Pipeline do
   let(:this_queue_folder) { File.join(base_queue_path, SecureRandom.hex(8)) }
 
   let(:worker_thread_count) { 8 } # 1 4 8
-  let(:number_of_events) { 100_000 }
-  let(:page_capacity) { 1 * 1024 * 512 } # 1 128
-  let(:max_bytes) { 1024 * 1024 * 1024 } # 1 gb
+  let(:number_of_events) { 10_000 }
+  let(:page_capacity) { 1 * 1024 * 1024 } # 1 mb
+  let(:max_bytes) { 64 * 1024 * 1024 } # 64 mb
   let(:times) { [] }
 
   let(:collected_metric) { metric_store.get_with_path("stats/pipelines/") }

--- a/logstash-core/spec/logstash/queue_factory_spec.rb
+++ b/logstash-core/spec/logstash/queue_factory_spec.rb
@@ -24,8 +24,8 @@ describe LogStash::QueueFactory do
     [
       LogStash::Setting::WritableDirectory.new("path.queue", Stud::Temporary.pathname),
       LogStash::Setting::String.new("queue.type", "memory", true, ["persisted", "memory"]),
-      LogStash::Setting::Bytes.new("queue.page_capacity", "64mb"),
-      LogStash::Setting::Bytes.new("queue.max_bytes", "1024mb"),
+      LogStash::Setting::Bytes.new("queue.page_capacity", "8mb"),
+      LogStash::Setting::Bytes.new("queue.max_bytes", "64mb"),
       LogStash::Setting::Numeric.new("queue.max_events", 0),
       LogStash::Setting::Numeric.new("queue.checkpoint.acks", 1024),
       LogStash::Setting::Numeric.new("queue.checkpoint.writes", 1024),

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
@@ -79,7 +79,7 @@ public class DeadLetterQueueWriterTest {
     @Test
     public void testLockFileManagement() throws Exception {
         Path lockFile = dir.resolve(".lock");
-        DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 1000000);
+        DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 100000);
         assertTrue(Files.exists(lockFile));
         writer.close();
         assertFalse(Files.exists(lockFile));
@@ -87,9 +87,9 @@ public class DeadLetterQueueWriterTest {
 
     @Test
     public void testFileLocking() throws Exception {
-        DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 1000000);
+        DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 100000);
         try {
-            new DeadLetterQueueWriter(dir, 1000, 100000);
+            new DeadLetterQueueWriter(dir, 100, 1000);
             fail();
         } catch (LockException e) {
         } finally {
@@ -101,7 +101,7 @@ public class DeadLetterQueueWriterTest {
     public void testUncleanCloseOfPreviousWriter() throws Exception {
         Path lockFilePath = dir.resolve(".lock");
         boolean created = lockFilePath.toFile().createNewFile();
-        DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 1000000);
+        DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 100000);
 
         FileChannel channel = FileChannel.open(lockFilePath, StandardOpenOption.WRITE);
         try {
@@ -116,7 +116,7 @@ public class DeadLetterQueueWriterTest {
 
     @Test
     public void testWrite() throws Exception {
-        DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 1000000);
+        DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 100000);
         DLQEntry entry = new DLQEntry(new Event(), "type", "id", "reason");
         writer.writeEntry(entry);
         writer.close();
@@ -129,7 +129,7 @@ public class DeadLetterQueueWriterTest {
         DLQEntry entry = new DLQEntry(new Event(), "type", "id", "reason");
         DLQEntry dlqEntry = new DLQEntry(dlqEvent, "type", "id", "reason");
 
-        try (DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 1000000);) {
+        try (DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 100000);) {
             writer.writeEntry(entry);
             long dlqLengthAfterEvent  = dlqLength();
 


### PR DESCRIPTION
Many DLQ and PQ tests are run with default settings for their size, or otherwise set to values such as 1GB.
This means that the container/machine the test runs on needs a lot of disk space (1GB for the test + 1GB for OS and Logstash + some more free space).

This PR reduces the disk space needed at any time for these tests, which helps the windows tests pass as we see here: https://logstash-ci.elastic.co/job/elastic+logstash+master+multijob-windows-compatibility/170/ (this test suite has been failing for a month since windows workers don't have a lot of disk space)