### PR TITLE
ensure 'starting logstash' log entry happens first

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -301,6 +301,8 @@ class LogStash::Runner < Clamp::StrictCommand
       return 0
     end
 
+    logger.info("Starting Logstash", "logstash.version" => LOGSTASH_VERSION, "jruby.version" => RUBY_DESCRIPTION)
+
     # Add local modules to the registry before everything else
     LogStash::Modules::Util.register_local_modules(LogStash::Environment::LOGSTASH_HOME)
 
@@ -380,8 +382,6 @@ class LogStash::Runner < Clamp::StrictCommand
 
     # lock path.data before starting the agent
     @data_path_lock = FileLockFactory.obtainLock(java.nio.file.Paths.get(setting("path.data")).to_absolute_path, ".lock")
-
-    logger.info("Starting Logstash", "logstash.version" => LOGSTASH_VERSION, "jruby.version" => RUBY_DESCRIPTION)
 
     @dispatcher.fire(:before_agent)
     @agent = create_agent(@settings, @source_loader)


### PR DESCRIPTION
This makes reading the logs much easier to the eye. Instead of logging it after a warning:

```
❯ bin/logstash -e "" 
Sending Logstash logs to /Users/joaoduarte/elastic/logstash/logs which is now configured via log4j2.properties
[2020-07-03T17:47:35,972][WARN ][logstash.config.source.multilocal] Ignoring the 'pipelines.yml' file because modules or command line options are specified
[2020-07-03T17:47:36,097][INFO ][logstash.runner          ] Starting Logstash {"logstash.version"=>"8.0.0", "jruby.version"=>"jruby 9.2.11.1 (2.5.7) 2020-03-25 b1f55b1a40 OpenJDK 64-Bit Server VM 11.0.5+10 on 11.0.5+10 +indy +jit [darwin-x86_64]"}
```

We now see:

```
❯ bin/logstash -e "" 
Sending Logstash logs to /Users/joaoduarte/elastic/logstash/logs which is now configured via log4j2.properties
[2020-07-06T11:16:19,819][INFO ][logstash.runner          ] Starting Logstash {"logstash.version"=>"8.0.0", "jruby.version"=>"jruby 9.2.12.0 (2.5.7) 2020-07-01 db01a49ba6 OpenJDK 64-Bit Server VM 11.0.5+10 on 11.0.5+10 +indy +jit [darwin-x86_64]"}
[2020-07-06T11:16:19,996][WARN ][logstash.config.source.multilocal] Ignoring the 'pipelines.yml' file because modules or command line options are specified
```