### PR TITLE
Acknowledgement bus

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -37,7 +37,7 @@ class LogStash::Agent
   include LogStash::Util::Loggable
   STARTED_AT = Time.now.freeze
 
-  attr_reader :metric, :name, :settings, :dispatcher, :ephemeral_id, :pipeline_bus
+  attr_reader :metric, :name, :settings, :dispatcher, :ephemeral_id, :pipeline_bus, :acknowledge_bus
   attr_accessor :logger
 
   # initialize method for LogStash::Agent
@@ -59,6 +59,11 @@ class LogStash::Agent
 
     # Special bus object for inter-pipelines communications. Used by the `pipeline` input/output
     @pipeline_bus = org.logstash.plugins.pipeline.PipelineBus.new
+
+    # Special bus object for pipeline-plugin acknowledge communications.
+    # Used by Acknowledgable plugins, like an external queue plugin.
+    # Also used by `pipeline` input/output
+    @acknowledge_bus = org.logstash.plugins.acknowledge.AcknowledgeBus.new
 
     @pipelines_registry = LogStash::PipelinesRegistry.new
 

--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -44,6 +44,8 @@ module LogStash; class JavaPipeline < JavaBasePipeline
     super pipeline_config, namespaced_metric, @logger, agent
     open_queue
 
+    @acknowledge_bus = agent.nil? ? nil : agent.acknowledge_bus
+
     @worker_threads = []
 
     @drain_queue =  settings.get_value("queue.drain") || settings.get("queue.type") == "memory"
@@ -525,6 +527,7 @@ module LogStash; class JavaPipeline < JavaBasePipeline
       org.logstash.execution.WorkerLoop.new(
         lir_execution,
         filter_queue_client,
+        @acknowledge_bus,
         @events_filtered,
         @events_consumed,
         @flushRequested,

--- a/logstash-core/lib/logstash/plugins/builtin.rb
+++ b/logstash-core/lib/logstash/plugins/builtin.rb
@@ -18,7 +18,9 @@
 module ::LogStash::Plugins::Builtin
   require 'logstash/plugins/builtin/pipeline/input'
   require 'logstash/plugins/builtin/pipeline/output'
+  require 'logstash/plugins/builtin/acknowledge/acked_heartbeat'
 
   LogStash::PLUGIN_REGISTRY.add(:input, "pipeline", LogStash::Plugins::Builtin::Pipeline::Input)
   LogStash::PLUGIN_REGISTRY.add(:output, "pipeline", LogStash::Plugins::Builtin::Pipeline::Output)
+  LogStash::PLUGIN_REGISTRY.add(:input, "acked_heartbeat", LogStash::Plugins::Builtin::Acknowledge::AckedHeartbeat)
 end

--- a/logstash-core/lib/logstash/plugins/builtin/acknowledge/acked_heartbeat.rb
+++ b/logstash-core/lib/logstash/plugins/builtin/acknowledge/acked_heartbeat.rb
@@ -1,0 +1,99 @@
+# encoding: utf-8
+require "logstash/inputs/threadable"
+require "logstash/namespace"
+require "stud/interval"
+require "socket" # for Socket.gethostname
+require 'concurrent'
+
+# Generate heartbeat messages.
+#
+# The general intention of this is to test the performance and
+# availability of Logstash.
+#
+module ::LogStash; module Plugins; module Builtin; module Acknowledge;
+  class AckedHeartbeat < LogStash::Inputs::Threadable
+    config_name "acked_heartbeat"
+
+    default :codec, "plain"
+
+    # The message string to use in the event.
+    #
+    # If you set this to `epoch` then this plugin will use the current
+    # timestamp in unix timestamp (which is by definition, UTC).  It will
+    # output this value into a field called `clock`
+    #
+    # If you set this to `sequence` then this plugin will send a sequence of
+    # numbers beginning at 0 and incrementing each interval.  It will
+    # output this value into a field called `clock`
+    #
+    # Otherwise, this value will be used verbatim as the event message. It
+    # will output this value into a field called `message`
+    config :message, :validate => :string, :default => "ok"
+
+    # Set how frequently messages should be sent.
+    #
+    # The default, `60`, means send a message every 60 seconds.
+    config :interval, :validate => :number, :default => 60
+
+    # How many times to iterate.
+    # This is typically used only for testing purposes.
+    config :count, :validate => :number, :default => -1
+
+    attr_reader :ack_token_generator, :acknowledge_bus
+
+    def register
+      @host = Socket.gethostname
+      @acknowledge_bus = execution_context.agent.acknowledge_bus
+      @ack_token_generator = @acknowledge_bus.registerPlugin(self)
+      @await_count = Concurrent::AtomicFixnum.new(0)
+    end
+
+    def acknowledge(id)
+      puts "Received acknowledge for " + id
+      res = @await_count.decrement
+      if stop? && res == 0
+        @count_down_latch.count_down
+      end
+      return true
+    end
+
+    def notifyCloned(id)
+      puts "Received notify clone for " + id
+      @await_count.increment
+      return true
+    end
+
+    def run(queue)
+      @count_down_latch = Concurrent::CountDownLatch.new(1)
+      sequence = 0
+
+      while !stop?
+        start = Time.now
+
+        sequence += 1
+        event = generate_message(sequence)
+        decorate(event)
+        queue << event
+        break if sequence == @count || stop?
+
+        sleep_for = @interval - (Time.now - start)
+        Stud.stoppable_sleep(sleep_for) { stop? } if sleep_for > 0
+      end
+      if @await_count.value > 0
+        @count_down_latch.wait()
+      end
+    end
+
+    def generate_message(sequence)
+      token = ack_token_generator.generateToken(sequence.to_s)
+      @await_count.increment
+      if @message == "epoch"
+        LogStash::Event.new("@acknowledge_token" => token, "clock" => Time.now.to_i, "host" => @host)
+      elsif @message == "sequence"
+        LogStash::Event.new("@acknowledge_token" => token, "clock" => sequence, "host" => @host)
+      else
+        LogStash::Event.new("@acknowledge_token" => token, "message" => @message, "host" => @host)
+      end
+    end
+  end
+end; end; end; end

--- a/logstash-core/lib/logstash/plugins/builtin/pipeline/output.rb
+++ b/logstash-core/lib/logstash/plugins/builtin/pipeline/output.rb
@@ -26,15 +26,17 @@ module ::LogStash; module Plugins; module Builtin; module Pipeline; class Output
 
   config :ensure_delivery, :validate => :boolean, :default => true
 
-  attr_reader :pipeline_bus
+  attr_reader :pipeline_bus, :acknowledge_bus
 
   def register
     @pipeline_bus = execution_context.agent.pipeline_bus
+    @acknowledge_bus = execution_context.agent.acknowledge_bus
     pipeline_bus.registerSender(self, @send_to)
   end
 
   def multi_receive(events)
     pipeline_bus.sendEvents(self, events, ensure_delivery)
+    acknowledge_bus.notifyClonedEvents(events)
   end
 
   def close

--- a/logstash-core/lib/logstash/plugins/builtin/pipeline/output.rb
+++ b/logstash-core/lib/logstash/plugins/builtin/pipeline/output.rb
@@ -35,8 +35,8 @@ module ::LogStash; module Plugins; module Builtin; module Pipeline; class Output
   end
 
   def multi_receive(events)
-    pipeline_bus.sendEvents(self, events, ensure_delivery)
     acknowledge_bus.notifyClonedEvents(events)
+    pipeline_bus.sendEvents(self, events, ensure_delivery)
   end
 
   def close

--- a/logstash-core/spec/logstash/execution_context_spec.rb
+++ b/logstash-core/spec/logstash/execution_context_spec.rb
@@ -28,6 +28,7 @@ describe LogStash::ExecutionContext do
   before do
     allow(pipeline).to receive(:agent).and_return(agent)
     allow(pipeline).to receive(:pipeline_id).and_return(pipeline_id)
+    allow(pipeline).to receive(:acknowledge_bus).and_return(nil)
   end
 
   subject { described_class.new(pipeline, agent, plugin_id, plugin_type, dlq_writer) }

--- a/logstash-core/spec/logstash/pipeline_action/create_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_action/create_spec.rb
@@ -30,6 +30,7 @@ describe LogStash::PipelineAction::Create do
 
   before do
     clear_data_dir
+    allow(agent).to receive(:acknowledge_bus).and_return(nil)
   end
 
   subject { described_class.new(pipeline_config, metric) }

--- a/logstash-core/spec/logstash/pipeline_action/reload_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_action/reload_spec.rb
@@ -34,6 +34,7 @@ describe LogStash::PipelineAction::Reload do
 
   before do
     clear_data_dir
+    allow(agent).to receive(:acknowledge_bus).and_return(nil)
     pipeline.start
   end
 

--- a/logstash-core/spec/logstash/plugins/builtin/pipeline_input_output_spec.rb
+++ b/logstash-core/spec/logstash/plugins/builtin/pipeline_input_output_spec.rb
@@ -25,6 +25,7 @@ describe ::LogStash::Plugins::Builtin::Pipeline do
   let(:execution_context) { double("execution_context" )}
   let(:agent) { double("agent") }
   let(:pipeline_bus) { org.logstash.plugins.pipeline.PipelineBus.new }
+  let(:acknowledge_bus) { org.logstash.plugins.acknowledge.AcknowledgeBus.new }
 
   let(:queue) { Queue.new }
 
@@ -36,6 +37,7 @@ describe ::LogStash::Plugins::Builtin::Pipeline do
 
   before(:each) do
     allow(execution_context).to receive(:agent).and_return(agent)
+    allow(agent).to receive(:acknowledge_bus).and_return(acknowledge_bus)
     allow(agent).to receive(:pipeline_bus).and_return(pipeline_bus)
     inputs.each do |i|
       allow(i).to receive(:execution_context).and_return(execution_context)
@@ -53,7 +55,7 @@ describe ::LogStash::Plugins::Builtin::Pipeline do
     def start_input
       input.register
 
-      @input_thread = Thread.new do 
+      @input_thread = Thread.new do
         input.run(queue)
       end
 
@@ -93,7 +95,7 @@ describe ::LogStash::Plugins::Builtin::Pipeline do
           expect(subject.to_hash_with_metadata).not_to match(event.to_hash_with_metadata)
         end
       end
-      
+
       after(:each) do
         stop_input
         output.do_close
@@ -153,7 +155,7 @@ describe ::LogStash::Plugins::Builtin::Pipeline do
         output.register
 
         @input_threads = inputs_queues.map do |input_plugin,input_queue|
-          Thread.new do 
+          Thread.new do
             input_plugin.run(input_queue)
           end
         end
@@ -197,7 +199,7 @@ describe ::LogStash::Plugins::Builtin::Pipeline do
           expect(inputs_queues[other_input].size).to eql(0)
         end
       end
-      
+
       after(:each) do
         inputs.each(&:do_stop)
         inputs.each(&:do_close)

--- a/logstash-core/src/main/java/co/elastic/logstash/api/Acknowledgable.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/Acknowledgable.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package co.elastic.logstash.api;
+
+/**
+ * Interface for the acknowledgeTokens added to Events if a
+ * acknoledgement of processing is desired for the event.
+ * Concrete implementations should be threadsafe and should be created
+ * by {@link AcknowledgeTokenFactory} instances managed by {@link AcknowledgeBus}
+ * and not directly by plugins themselves.
+ */
+public interface Acknowledgable {
+
+    /**
+     * Returns acknowledgeToken if it is present
+     * if not it shoudl return null
+     *
+     * @return Returns {@link AcknowledgeToken} or null
+     */
+    AcknowledgeToken getAcknowledgeToken();
+}

--- a/logstash-core/src/main/java/co/elastic/logstash/api/AcknowledgablePlugin.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/AcknowledgablePlugin.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package co.elastic.logstash.api;
+
+import co.elastic.logstash.api.Plugin;
+
+public interface AcknowledgablePlugin extends Plugin{
+    /**
+     * Accepts an acknowledgeId which was put into the event at creation by the plugin.
+     *
+     * @param acknowledgeId acknowledgeId added to event on creation by the plugin
+     * @return true if the event was successfully received
+     */
+    boolean acknowledge(final String acknowledgeId);
+
+    /**
+     * Accepts an acknowledgeId which was put into the event at creation by the plugin.
+     * Is called when event is a clone event is put onto the acknowledge bus, like when
+     * it is passed to other pipeline in the case of multi pipeline communication.
+     *
+     * @param acknowledgeId acknowledgeId added to event on creation by the plugin
+     * @return true if the event was successfully received
+     */
+    boolean notifyCloned(final String acknowledgeId);
+
+}

--- a/logstash-core/src/main/java/co/elastic/logstash/api/AcknowledgablePlugin.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/AcknowledgablePlugin.java
@@ -20,9 +20,7 @@
 
 package co.elastic.logstash.api;
 
-import co.elastic.logstash.api.Plugin;
-
-public interface AcknowledgablePlugin extends Plugin{
+public interface AcknowledgablePlugin extends Plugin {
     /**
      * Accepts an acknowledgeId which was put into the event at creation by the plugin.
      *

--- a/logstash-core/src/main/java/co/elastic/logstash/api/AcknowledgeBus.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/AcknowledgeBus.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package co.elastic.logstash.api;
+
+import java.util.Collection;
+
+/**
+ * This class is the communication bus for acknowledgements at pipeline ends.
+ * Implementations should be threadsafe.
+ */
+public interface AcknowledgeBus {
+
+    /**
+     * Acknowledges events if it contains acknowledge token.
+     * Should be called at the end of a pipeline
+     *
+     * @param events A collection of Acknowledgable
+     */
+    void acknowledgeEvents(final Collection<? extends Acknowledgable> events);
+
+
+    /**
+     * Notify clone of events if it contains acknowledge token
+     * when that means an acknowledgeToken can reach end of pipeline
+     * multiple times. Like in the case of inter-pipeline communication.
+     *
+     * @param events A collection of Acknowledgable
+     */
+    void notifyClonedEvents(final Collection<? extends Acknowledgable> events);
+
+    /**
+     * Should be called by a plugin on register
+     *
+     * @param plugin    plugin to be registered
+     * @return an AcknowledgeTokenGenerator instance
+     */
+    AcknowledgeTokenFactory registerPlugin(final AcknowledgablePlugin plugin);
+
+    /**
+     * Should be called by an plugin on close
+     *
+     * @param plugin    output that will be unregistered
+     * @return false if plugin wasn't registered otherwise true
+     */
+    boolean unregisterPlugin(final AcknowledgablePlugin plugin);
+
+}

--- a/logstash-core/src/main/java/co/elastic/logstash/api/AcknowledgeToken.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/AcknowledgeToken.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package co.elastic.logstash.api;
+
+/**
+ * Interface for the acknowledgeTokens added to Events if a
+ * acknoledgement of processing is desired for the event.
+ * Concrete implementations should be threadsafe and should be created
+ * by {@link AcknowledgeTokenFactory} instances managed by {@link AcknowledgeBus}
+ * and not directly by plugins themselves.
+ */
+public interface AcknowledgeToken {
+
+    /**
+     * Returns unique pluginId that issued acknowledgeToken
+     *
+     * @return Returns pluginId that issued acknowledgeToken
+     */
+    String getPluginId();
+
+    /**
+     * Returns acknowledgeId that identifies the event(s) for the plugin
+     * wanting to receive acknowlegement. The combination acknowledgeId
+     * and pluginId must be unique.
+     *
+     * @return Returns pluginId that issued acknowledgeToken
+     */
+    String getAcknowledgeId();
+
+}

--- a/logstash-core/src/main/java/co/elastic/logstash/api/AcknowledgeTokenFactory.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/AcknowledgeTokenFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package co.elastic.logstash.api;
+
+
+public interface AcknowledgeTokenFactory {
+
+    /**
+     * Should return immutable AcknowledgeToken object to be added
+     * to Events, requiring acknowledgement
+     *
+     * @return Returns AcknowledgeToken object
+     */
+    AcknowledgeToken generateToken(String AcknowledgeId);
+}

--- a/logstash-core/src/main/java/co/elastic/logstash/api/Context.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/Context.java
@@ -63,11 +63,10 @@ public interface Context {
     EventFactory getEventFactory();
 
     /**
-     * Provides an {@link AcknowledgeBus}, if configured, to register plugin to.
-     * If not configured or not an instance {@link AcknowledgablePlugin}
-     * {@code null} will be returned
+     * Provides an {@link AcknowledgeBus}, if configured, to input plugins.
+     * If no bus configured or the plugin is not an input, {@code null} will be returned.
      *
-     * @return The acknowledgeBus.
+     * @return {@link AcknowledgeBus} instance if available or {@code null} otherwise.
      */
     default AcknowledgeBus getAcknowledgeBus(){
         return null;

--- a/logstash-core/src/main/java/co/elastic/logstash/api/Context.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/Context.java
@@ -62,4 +62,15 @@ public interface Context {
      */
     EventFactory getEventFactory();
 
+    /**
+     * Provides an {@link AcknowledgeBus}, if configured, to register plugin to.
+     * If not configured or not an instance {@link AcknowledgablePlugin}
+     * {@code null} will be returned
+     *
+     * @return The acknowledgeBus.
+     */
+    default AcknowledgeBus getAcknowledgeBus(){
+        return null;
+    }
+
 }

--- a/logstash-core/src/main/java/co/elastic/logstash/api/Event.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/Event.java
@@ -32,6 +32,10 @@ public interface Event extends Acknowledgable {
     Map<String, Object> getData();
 
     Map<String, Object> getMetadata();
+    
+    default AcknowledgeToken getAcknowledgeToken(){
+        return null;
+    }
 
     void cancel();
 
@@ -66,8 +70,4 @@ public interface Event extends Acknowledgable {
     String toString();
 
     void tag(String tag);
-
-    default AcknowledgeToken getAcknowledgeToken(){
-        return null;
-    }
 }

--- a/logstash-core/src/main/java/co/elastic/logstash/api/Event.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/Event.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * Event interface for Java plugins. Java plugins should be not rely on the implementation details of any
  * concrete implementations of the Event interface.
  */
-public interface Event {
+public interface Event extends Acknowledgable {
     Map<String, Object> getData();
 
     Map<String, Object> getMetadata();
@@ -66,4 +66,8 @@ public interface Event {
     String toString();
 
     void tag(String tag);
+
+    default AcknowledgeToken getAcknowledgeToken(){
+        return null;
+    }
 }

--- a/logstash-core/src/main/java/org/logstash/Valuefier.java
+++ b/logstash-core/src/main/java/org/logstash/Valuefier.java
@@ -46,6 +46,8 @@ import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.ext.JrubyTimestampExtLibrary;
 
+import co.elastic.logstash.api.AcknowledgeToken;
+
 public final class Valuefier {
 
     public static final Valuefier.Converter IDENTITY = input -> input;
@@ -133,6 +135,7 @@ public final class Valuefier {
         converters.put(RubyBoolean.class, IDENTITY);
         converters.put(RubyBignum.class, IDENTITY);
         converters.put(RubyBigDecimal.class, IDENTITY);
+        converters.put(AcknowledgeToken.class, IDENTITY);
         converters.put(String.class, input -> RubyUtil.RUBY.newString((String) input));
         converters.put(Float.class, FLOAT_CONVERTER);
         converters.put(Double.class, FLOAT_CONVERTER);

--- a/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
+++ b/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.Logger;
 import org.logstash.config.ir.CompiledPipeline;
 
 import co.elastic.logstash.api.AcknowledgeBus;
-import co.elastic.logstash.api.Acknowledgable;
 
 public final class WorkerLoop implements Runnable {
 

--- a/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
+++ b/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 import org.logstash.config.ir.CompiledPipeline;
 
 import co.elastic.logstash.api.AcknowledgeBus;
+import co.elastic.logstash.api.Acknowledgable;
 
 public final class WorkerLoop implements Runnable {
 

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -60,9 +60,8 @@ public final class JrubyEventExtLibrary {
         private static final AtomicLong SEQUENCE_GENERATOR = new AtomicLong(1L);
 
         /**
-         * Hashcode of this instance. Used to avoid the more expensive
-         * {@link RubyObject#hashCode()} since we only care about reference equality for
-         * this class anyway.
+         * Hashcode of this instance. Used to avoid the more expensive {@link RubyObject#hashCode()}
+         * since we only care about reference equality for this class anyway.
          */
         private final int hash = nextHash();
 
@@ -77,7 +76,8 @@ public final class JrubyEventExtLibrary {
         }
 
         public static RubyEvent newRubyEvent(Ruby runtime, Event event) {
-            final RubyEvent ruby = new RubyEvent(runtime, RubyUtil.RUBY_EVENT_CLASS);
+            final RubyEvent ruby =
+                new RubyEvent(runtime, RubyUtil.RUBY_EVENT_CLASS);
             ruby.setEvent(event);
             return ruby;
         }
@@ -87,33 +87,34 @@ public final class JrubyEventExtLibrary {
         }
 
         // def initialize(data = {})
-        @JRubyMethod(name = "initialize", optional = 1)
+        @JRubyMethod(name = "initialize", optional = 2)
         public IRubyObject ruby_initialize(ThreadContext context, IRubyObject[] args) {
-            final IRubyObject data = args.length > 0 ? args[0] : null;
-            if (data instanceof RubyHash) {
-                this.event = new Event(ConvertedMap.newFromRubyHash(context, (RubyHash) data));
-            } else if (data != null && data.getJavaClass().equals(Event.class)) {
-                this.event = data.toJava(Event.class);
-            } else {
-                initializeFallback(context, data);
+            if (args.length == 1 && args[0] instanceof RubyHash) {
+                this.event = new Event(ConvertedMap.newFromRubyHash(context, (RubyHash) args[0]));
+
+                return context.nil;
             }
-            return context.nil;
+            return initializeFallback(context, args);
         }
 
         @JRubyMethod(name = "get", required = 1)
-        public IRubyObject ruby_get_field(ThreadContext context, RubyString reference) {
-            return Rubyfier.deep(context.runtime, this.event.getUnconvertedField(extractFieldReference(reference)));
+        public IRubyObject ruby_get_field(ThreadContext context, RubyString reference)
+        {
+            return Rubyfier.deep(
+                context.runtime,
+                this.event.getUnconvertedField(extractFieldReference(reference))
+            );
         }
 
         @JRubyMethod(name = "set", required = 2)
-        public IRubyObject ruby_set_field(ThreadContext context, RubyString reference, IRubyObject value) {
+        public IRubyObject ruby_set_field(ThreadContext context, RubyString reference, IRubyObject value)
+        {
             final FieldReference r = extractFieldReference(reference);
             if (r.equals(FieldReference.TIMESTAMP_REFERENCE)) {
                 if (!(value instanceof JrubyTimestampExtLibrary.RubyTimestamp)) {
-                    throw context.runtime.newTypeError(
-                            "wrong argument type " + value.getMetaClass() + " (expected LogStash::Timestamp)");
+                    throw context.runtime.newTypeError("wrong argument type " + value.getMetaClass() + " (expected LogStash::Timestamp)");
                 }
-                this.event.setTimestamp(((JrubyTimestampExtLibrary.RubyTimestamp) value).getTimestamp());
+                this.event.setTimestamp(((JrubyTimestampExtLibrary.RubyTimestamp)value).getTimestamp());
             } else {
                 this.event.setField(r, safeValueifierConvert(value));
             }
@@ -121,56 +122,66 @@ public final class JrubyEventExtLibrary {
         }
 
         @JRubyMethod(name = "cancel")
-        public IRubyObject ruby_cancel(ThreadContext context) {
+        public IRubyObject ruby_cancel(ThreadContext context)
+        {
             this.event.cancel();
             return context.tru;
         }
 
         @JRubyMethod(name = "uncancel")
-        public IRubyObject ruby_uncancel(ThreadContext context) {
+        public IRubyObject ruby_uncancel(ThreadContext context)
+        {
             this.event.uncancel();
             return context.fals;
         }
 
         @JRubyMethod(name = "cancelled?")
-        public IRubyObject ruby_cancelled(ThreadContext context) {
+        public IRubyObject ruby_cancelled(ThreadContext context)
+        {
             return RubyBoolean.newBoolean(context.runtime, this.event.isCancelled());
         }
 
         @JRubyMethod(name = "include?", required = 1)
         public IRubyObject ruby_includes(ThreadContext context, RubyString reference) {
-            return RubyBoolean.newBoolean(context.runtime, this.event.includes(extractFieldReference(reference)));
+            return RubyBoolean.newBoolean(
+                context.runtime, this.event.includes(extractFieldReference(reference))
+            );
         }
 
         @JRubyMethod(name = "remove", required = 1)
         public IRubyObject ruby_remove(ThreadContext context, RubyString reference) {
-            return Rubyfier.deep(context.runtime, this.event.remove(extractFieldReference(reference)));
+            return Rubyfier.deep(
+                context.runtime,
+                this.event.remove(extractFieldReference(reference))
+            );
         }
 
         @JRubyMethod(name = "clone")
-        public IRubyObject rubyClone(ThreadContext context) {
+        public IRubyObject rubyClone(ThreadContext context)
+        {
             return rubyClone(context.runtime);
         }
 
-        public RubyEvent rubyClone(Ruby runtime) {
+        public RubyEvent rubyClone(Ruby runtime)
+        {
             return RubyEvent.newRubyEvent(runtime, this.event.clone());
         }
 
         @JRubyMethod(name = "overwrite", required = 1)
-        public IRubyObject ruby_overwrite(ThreadContext context, IRubyObject value) {
+        public IRubyObject ruby_overwrite(ThreadContext context, IRubyObject value)
+        {
             if (!(value instanceof RubyEvent)) {
-                throw context.runtime
-                        .newTypeError("wrong argument type " + value.getMetaClass() + " (expected LogStash::Event)");
+                throw context.runtime.newTypeError("wrong argument type " + value.getMetaClass() + " (expected LogStash::Event)");
             }
 
             return RubyEvent.newRubyEvent(context.runtime, this.event.overwrite(((RubyEvent) value).event));
         }
 
         @JRubyMethod(name = "append", required = 1)
-        public IRubyObject ruby_append(ThreadContext context, IRubyObject value) {
+        public IRubyObject ruby_append(ThreadContext context, IRubyObject value)
+        {
             if (!(value instanceof RubyEvent)) {
-                throw context.runtime
-                        .newTypeError("wrong argument type " + value.getMetaClass() + " (expected LogStash::Event)");
+                throw context.runtime.newTypeError("wrong argument type " + value.getMetaClass() + " (expected LogStash::Event)");
             }
 
             this.event.append(((RubyEvent) value).getEvent());
@@ -188,7 +199,8 @@ public final class JrubyEventExtLibrary {
         }
 
         @JRubyMethod(name = "to_s")
-        public IRubyObject ruby_to_s(ThreadContext context) {
+        public IRubyObject ruby_to_s(ThreadContext context)
+        {
             return RubyString.newString(context.runtime, event.toString());
         }
 
@@ -209,12 +221,14 @@ public final class JrubyEventExtLibrary {
         }
 
         @JRubyMethod(name = "to_java")
-        public IRubyObject ruby_to_java(ThreadContext context) {
+        public IRubyObject ruby_to_java(ThreadContext context)
+        {
             return JavaUtil.convertJavaToUsableRubyObject(context.runtime, this.event);
         }
 
         @JRubyMethod(name = "to_json", rest = true)
-        public IRubyObject ruby_to_json(ThreadContext context, IRubyObject[] args) {
+        public IRubyObject ruby_to_json(ThreadContext context, IRubyObject[] args)
+        {
             try {
                 return RubyString.newString(context.runtime, event.toJson());
             } catch (Exception e) {
@@ -222,12 +236,12 @@ public final class JrubyEventExtLibrary {
             }
         }
 
-        // @param value [String] the json string. A json object/map will
-        // newFromRubyArray to an array containing a single Event.
+        // @param value [String] the json string. A json object/map will newFromRubyArray to an array containing a single Event.
         // and a json array will newFromRubyArray each element into individual Event
         // @return Array<Event> array of events
         @JRubyMethod(name = "from_json", required = 1, meta = true)
-        public static IRubyObject ruby_from_json(ThreadContext context, IRubyObject recv, RubyString value) {
+        public static IRubyObject ruby_from_json(ThreadContext context, IRubyObject recv, RubyString value)
+        {
             Event[] events;
             try {
                 events = Event.fromJson(value.asJavaString());
@@ -248,14 +262,16 @@ public final class JrubyEventExtLibrary {
         }
 
         @JRubyMethod(name = "validate_value", required = 1, meta = true)
-        public static IRubyObject ruby_validate_value(ThreadContext context, IRubyObject recv, IRubyObject value) {
+        public static IRubyObject ruby_validate_value(ThreadContext context, IRubyObject recv, IRubyObject value)
+        {
             // TODO: add UTF-8 validation
             return value;
         }
 
         @JRubyMethod(name = "tag", required = 1)
-        public IRubyObject ruby_tag(ThreadContext context, RubyString value) {
-            // TODO(guy) should these tags be BiValues?
+        public IRubyObject ruby_tag(ThreadContext context, RubyString value)
+        {
+            //TODO(guy) should these tags be BiValues?
             this.event.tag(value.asJavaString());
             return context.nil;
         }
@@ -268,12 +284,12 @@ public final class JrubyEventExtLibrary {
         }
 
         @JRubyMethod(name = "timestamp=", required = 1)
-        public IRubyObject ruby_set_timestamp(ThreadContext context, IRubyObject value) {
+        public IRubyObject ruby_set_timestamp(ThreadContext context, IRubyObject value)
+        {
             if (!(value instanceof JrubyTimestampExtLibrary.RubyTimestamp)) {
-                throw context.runtime.newTypeError(
-                        "wrong argument type " + value.getMetaClass() + " (expected LogStash::Timestamp)");
+                throw context.runtime.newTypeError("wrong argument type " + value.getMetaClass() + " (expected LogStash::Timestamp)");
             }
-            this.event.setTimestamp(((JrubyTimestampExtLibrary.RubyTimestamp) value).getTimestamp());
+            this.event.setTimestamp(((JrubyTimestampExtLibrary.RubyTimestamp)value).getTimestamp());
             return value;
         }
 
@@ -290,32 +306,72 @@ public final class JrubyEventExtLibrary {
         /**
          * Cold path for the Ruby constructor
          * {@link JrubyEventExtLibrary.RubyEvent#ruby_initialize(ThreadContext, IRubyObject[])}
-         * for when its argument is not a {@link RubyHash}.
+         * for when its argument is not just a {@link RubyHash}.
+         *
+         * Supported argument combinations:
+         * Event.new()
+         * Event.new({@link RubyHash})
+         * Event.new({@link org.logstash.Event})
+         * Event.new({@link AcknowledgeToken})
+         * Event.new({@link RubyHash}, {@link AcknowledgeToken})
+         * Event.new({@link JavaMapProxy})
+         * Event.new({@link JavaMapProxy}, {@link AcknowledgeToken})
          *
          * @param context Ruby {@link ThreadContext}
-         * @param data    Either {@code null}, {@link org.jruby.RubyNil} or an instance
-         *                of {@link MapJavaProxy}
+         * @param args    Argument list to hot constructor
          */
         @SuppressWarnings("unchecked")
-        private void initializeFallback(final ThreadContext context, final IRubyObject data) {
-            if (data == null || data.isNil()) {
-                this.event = new Event();
-            } else if (data instanceof MapJavaProxy) {
-                this.event = new Event(
-                        ConvertedMap.newFromMap((Map<String, Object>) ((MapJavaProxy) data).getObject()));
-            } else {
-                throw context.runtime.newTypeError("wrong argument type " + data.getMetaClass() + " (expected Hash)");
+        private IRubyObject initializeFallback(final ThreadContext context, final IRubyObject[] args) {
+            AcknowledgeToken token = null;
+            if (args.length > 1) {
+                if (args[1] != null && !args[1].isNil()) {
+                    if (args[0].getJavaClass().equals(AcknowledgeToken.class)) {
+                        token = args[0].toJava(AcknowledgeToken.class);
+                    } else {
+                        throw context.runtime.newTypeError(
+                                "wrong argument type " + args[1].getMetaClass() + " (expected AcknowledgeToken)");
+                    }
+                }
             }
+            if (args.length > 0) {
+                if (args[0] != null && !args[0].isNil()) {
+                    // check if RubyHash
+                    if (args[0] instanceof RubyHash) {
+                        this.event = new Event(ConvertedMap.newFromRubyHash(context, (RubyHash) args[0]), token);
+                    }
+                    // check if Event
+                    else if (args[0].getJavaClass().equals(Event.class)) {
+                        if (token != null) {
+                            throw context.runtime.newArgumentError(
+                                    "wrong number of arguments, only single argument is allowed when providing event");
+                        }
+                        this.event = args[0].toJava(Event.class);
+                    } else if (args[0] instanceof MapJavaProxy) {
+                        this.event = new Event(
+                                ConvertedMap.newFromMap((Map<String, Object>) ((MapJavaProxy) args[0]).getObject()),
+                                token);
+                    }
+                    // check if token
+                    else if (args[0].getJavaClass().equals(AcknowledgeToken.class)) {
+                        this.event = new Event(args[0].toJava(AcknowledgeToken.class));
+                    } else {
+                        throw context.runtime
+                                .newTypeError("wrong argument type " + args[0].getMetaClass() + " (expected Hash)");
+                    }
+                }
+            } else {
+                this.event = new Event();
+            }
+            return context.nil;
         }
 
         /**
-         * Shared logic to wrap {@link FieldReference.IllegalSyntaxException}s that are
-         * raised by {@link FieldReference#from(RubyString)} when encountering illegal
-         * syntax in a ruby-exception that can be easily handled within the ruby plugins
+         * Shared logic to wrap {@link FieldReference.IllegalSyntaxException}s that are raised by
+         * {@link FieldReference#from(RubyString)} when encountering illegal syntax in a ruby-exception
+         * that can be easily handled within the ruby plugins
          *
          * @param reference a {@link RubyString} representing the path to a field
-         * @return the corresponding {@link FieldReference} (see:
-         *         {@link FieldReference#from(RubyString)})
+         * @return the corresponding {@link FieldReference} (see: {@link FieldReference#from(RubyString)})
          */
         private static FieldReference extractFieldReference(final RubyString reference) {
             try {
@@ -326,12 +382,11 @@ public final class JrubyEventExtLibrary {
         }
 
         /**
-         * Shared logic to wrap {@link FieldReference.IllegalSyntaxException}s that are
-         * raised by {@link Valuefier#convert(Object)} when encountering illegal syntax
-         * in a ruby-exception that can be easily handled within the ruby plugins
+         * Shared logic to wrap {@link FieldReference.IllegalSyntaxException}s that are raised by
+         * {@link Valuefier#convert(Object)} when encountering illegal syntax in a ruby-exception
+         * that can be easily handled within the ruby plugins
          *
-         * @param value a {@link Object} to be passed to
-         *              {@link Valuefier#convert(Object)}
+         * @param value a {@link Object} to be passed to {@link Valuefier#convert(Object)}
          * @return the resulting {@link Object} (see: {@link Valuefier#convert(Object)})
          */
         private static Object safeValueifierConvert(final Object value) {
@@ -342,13 +397,13 @@ public final class JrubyEventExtLibrary {
             }
         }
 
+
         private void setEvent(Event event) {
             this.event = event;
         }
 
         /**
          * Generates a fixed hashcode.
-         *
          * @return HashCode value
          */
         private static int nextHash() {

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -44,10 +44,13 @@ import org.logstash.RubyUtil;
 import org.logstash.Rubyfier;
 import org.logstash.Valuefier;
 
+import co.elastic.logstash.api.Acknowledgable;
+import co.elastic.logstash.api.AcknowledgeToken;
+
 public final class JrubyEventExtLibrary {
 
     @JRubyClass(name = "Event")
-    public static final class RubyEvent extends RubyObject {
+    public static final class RubyEvent extends RubyObject implements Acknowledgable {
 
         private static final long serialVersionUID = 1L;
 
@@ -57,8 +60,9 @@ public final class JrubyEventExtLibrary {
         private static final AtomicLong SEQUENCE_GENERATOR = new AtomicLong(1L);
 
         /**
-         * Hashcode of this instance. Used to avoid the more expensive {@link RubyObject#hashCode()}
-         * since we only care about reference equality for this class anyway.
+         * Hashcode of this instance. Used to avoid the more expensive
+         * {@link RubyObject#hashCode()} since we only care about reference equality for
+         * this class anyway.
          */
         private final int hash = nextHash();
 
@@ -73,8 +77,7 @@ public final class JrubyEventExtLibrary {
         }
 
         public static RubyEvent newRubyEvent(Ruby runtime, Event event) {
-            final RubyEvent ruby =
-                new RubyEvent(runtime, RubyUtil.RUBY_EVENT_CLASS);
+            final RubyEvent ruby = new RubyEvent(runtime, RubyUtil.RUBY_EVENT_CLASS);
             ruby.setEvent(event);
             return ruby;
         }
@@ -88,9 +91,7 @@ public final class JrubyEventExtLibrary {
         public IRubyObject ruby_initialize(ThreadContext context, IRubyObject[] args) {
             final IRubyObject data = args.length > 0 ? args[0] : null;
             if (data instanceof RubyHash) {
-                this.event = new Event(
-                    ConvertedMap.newFromRubyHash(context, (RubyHash) data)
-                );
+                this.event = new Event(ConvertedMap.newFromRubyHash(context, (RubyHash) data));
             } else if (data != null && data.getJavaClass().equals(Event.class)) {
                 this.event = data.toJava(Event.class);
             } else {
@@ -100,23 +101,19 @@ public final class JrubyEventExtLibrary {
         }
 
         @JRubyMethod(name = "get", required = 1)
-        public IRubyObject ruby_get_field(ThreadContext context, RubyString reference)
-        {
-            return Rubyfier.deep(
-                context.runtime,
-                this.event.getUnconvertedField(extractFieldReference(reference))
-            );
+        public IRubyObject ruby_get_field(ThreadContext context, RubyString reference) {
+            return Rubyfier.deep(context.runtime, this.event.getUnconvertedField(extractFieldReference(reference)));
         }
 
         @JRubyMethod(name = "set", required = 2)
-        public IRubyObject ruby_set_field(ThreadContext context, RubyString reference, IRubyObject value)
-        {
+        public IRubyObject ruby_set_field(ThreadContext context, RubyString reference, IRubyObject value) {
             final FieldReference r = extractFieldReference(reference);
             if (r.equals(FieldReference.TIMESTAMP_REFERENCE)) {
                 if (!(value instanceof JrubyTimestampExtLibrary.RubyTimestamp)) {
-                    throw context.runtime.newTypeError("wrong argument type " + value.getMetaClass() + " (expected LogStash::Timestamp)");
+                    throw context.runtime.newTypeError(
+                            "wrong argument type " + value.getMetaClass() + " (expected LogStash::Timestamp)");
                 }
-                this.event.setTimestamp(((JrubyTimestampExtLibrary.RubyTimestamp)value).getTimestamp());
+                this.event.setTimestamp(((JrubyTimestampExtLibrary.RubyTimestamp) value).getTimestamp());
             } else {
                 this.event.setField(r, safeValueifierConvert(value));
             }
@@ -124,66 +121,56 @@ public final class JrubyEventExtLibrary {
         }
 
         @JRubyMethod(name = "cancel")
-        public IRubyObject ruby_cancel(ThreadContext context)
-        {
+        public IRubyObject ruby_cancel(ThreadContext context) {
             this.event.cancel();
             return context.tru;
         }
 
         @JRubyMethod(name = "uncancel")
-        public IRubyObject ruby_uncancel(ThreadContext context)
-        {
+        public IRubyObject ruby_uncancel(ThreadContext context) {
             this.event.uncancel();
             return context.fals;
         }
 
         @JRubyMethod(name = "cancelled?")
-        public IRubyObject ruby_cancelled(ThreadContext context)
-        {
+        public IRubyObject ruby_cancelled(ThreadContext context) {
             return RubyBoolean.newBoolean(context.runtime, this.event.isCancelled());
         }
 
         @JRubyMethod(name = "include?", required = 1)
         public IRubyObject ruby_includes(ThreadContext context, RubyString reference) {
-            return RubyBoolean.newBoolean(
-                context.runtime, this.event.includes(extractFieldReference(reference))
-            );
+            return RubyBoolean.newBoolean(context.runtime, this.event.includes(extractFieldReference(reference)));
         }
 
         @JRubyMethod(name = "remove", required = 1)
         public IRubyObject ruby_remove(ThreadContext context, RubyString reference) {
-            return Rubyfier.deep(
-                context.runtime,
-                this.event.remove(extractFieldReference(reference))
-            );
+            return Rubyfier.deep(context.runtime, this.event.remove(extractFieldReference(reference)));
         }
 
         @JRubyMethod(name = "clone")
-        public IRubyObject rubyClone(ThreadContext context)
-        {
+        public IRubyObject rubyClone(ThreadContext context) {
             return rubyClone(context.runtime);
         }
 
-        public RubyEvent rubyClone(Ruby runtime)
-        {
+        public RubyEvent rubyClone(Ruby runtime) {
             return RubyEvent.newRubyEvent(runtime, this.event.clone());
         }
 
         @JRubyMethod(name = "overwrite", required = 1)
-        public IRubyObject ruby_overwrite(ThreadContext context, IRubyObject value)
-        {
+        public IRubyObject ruby_overwrite(ThreadContext context, IRubyObject value) {
             if (!(value instanceof RubyEvent)) {
-                throw context.runtime.newTypeError("wrong argument type " + value.getMetaClass() + " (expected LogStash::Event)");
+                throw context.runtime
+                        .newTypeError("wrong argument type " + value.getMetaClass() + " (expected LogStash::Event)");
             }
 
             return RubyEvent.newRubyEvent(context.runtime, this.event.overwrite(((RubyEvent) value).event));
         }
 
         @JRubyMethod(name = "append", required = 1)
-        public IRubyObject ruby_append(ThreadContext context, IRubyObject value)
-        {
+        public IRubyObject ruby_append(ThreadContext context, IRubyObject value) {
             if (!(value instanceof RubyEvent)) {
-                throw context.runtime.newTypeError("wrong argument type " + value.getMetaClass() + " (expected LogStash::Event)");
+                throw context.runtime
+                        .newTypeError("wrong argument type " + value.getMetaClass() + " (expected LogStash::Event)");
             }
 
             this.event.append(((RubyEvent) value).getEvent());
@@ -201,8 +188,7 @@ public final class JrubyEventExtLibrary {
         }
 
         @JRubyMethod(name = "to_s")
-        public IRubyObject ruby_to_s(ThreadContext context)
-        {
+        public IRubyObject ruby_to_s(ThreadContext context) {
             return RubyString.newString(context.runtime, event.toString());
         }
 
@@ -223,14 +209,12 @@ public final class JrubyEventExtLibrary {
         }
 
         @JRubyMethod(name = "to_java")
-        public IRubyObject ruby_to_java(ThreadContext context)
-        {
+        public IRubyObject ruby_to_java(ThreadContext context) {
             return JavaUtil.convertJavaToUsableRubyObject(context.runtime, this.event);
         }
 
         @JRubyMethod(name = "to_json", rest = true)
-        public IRubyObject ruby_to_json(ThreadContext context, IRubyObject[] args)
-        {
+        public IRubyObject ruby_to_json(ThreadContext context, IRubyObject[] args) {
             try {
                 return RubyString.newString(context.runtime, event.toJson());
             } catch (Exception e) {
@@ -238,12 +222,12 @@ public final class JrubyEventExtLibrary {
             }
         }
 
-        // @param value [String] the json string. A json object/map will newFromRubyArray to an array containing a single Event.
+        // @param value [String] the json string. A json object/map will
+        // newFromRubyArray to an array containing a single Event.
         // and a json array will newFromRubyArray each element into individual Event
         // @return Array<Event> array of events
         @JRubyMethod(name = "from_json", required = 1, meta = true)
-        public static IRubyObject ruby_from_json(ThreadContext context, IRubyObject recv, RubyString value)
-        {
+        public static IRubyObject ruby_from_json(ThreadContext context, IRubyObject recv, RubyString value) {
             Event[] events;
             try {
                 events = Event.fromJson(value.asJavaString());
@@ -264,16 +248,14 @@ public final class JrubyEventExtLibrary {
         }
 
         @JRubyMethod(name = "validate_value", required = 1, meta = true)
-        public static IRubyObject ruby_validate_value(ThreadContext context, IRubyObject recv, IRubyObject value)
-        {
+        public static IRubyObject ruby_validate_value(ThreadContext context, IRubyObject recv, IRubyObject value) {
             // TODO: add UTF-8 validation
             return value;
         }
 
         @JRubyMethod(name = "tag", required = 1)
-        public IRubyObject ruby_tag(ThreadContext context, RubyString value)
-        {
-            //TODO(guy) should these tags be BiValues?
+        public IRubyObject ruby_tag(ThreadContext context, RubyString value) {
+            // TODO(guy) should these tags be BiValues?
             this.event.tag(value.asJavaString());
             return context.nil;
         }
@@ -286,12 +268,12 @@ public final class JrubyEventExtLibrary {
         }
 
         @JRubyMethod(name = "timestamp=", required = 1)
-        public IRubyObject ruby_set_timestamp(ThreadContext context, IRubyObject value)
-        {
+        public IRubyObject ruby_set_timestamp(ThreadContext context, IRubyObject value) {
             if (!(value instanceof JrubyTimestampExtLibrary.RubyTimestamp)) {
-                throw context.runtime.newTypeError("wrong argument type " + value.getMetaClass() + " (expected LogStash::Timestamp)");
+                throw context.runtime.newTypeError(
+                        "wrong argument type " + value.getMetaClass() + " (expected LogStash::Timestamp)");
             }
-            this.event.setTimestamp(((JrubyTimestampExtLibrary.RubyTimestamp)value).getTimestamp());
+            this.event.setTimestamp(((JrubyTimestampExtLibrary.RubyTimestamp) value).getTimestamp());
             return value;
         }
 
@@ -307,32 +289,33 @@ public final class JrubyEventExtLibrary {
 
         /**
          * Cold path for the Ruby constructor
-         * {@link JrubyEventExtLibrary.RubyEvent#ruby_initialize(ThreadContext, IRubyObject[])} for
-         * when its argument is not a {@link RubyHash}.
+         * {@link JrubyEventExtLibrary.RubyEvent#ruby_initialize(ThreadContext, IRubyObject[])}
+         * for when its argument is not a {@link RubyHash}.
+         *
          * @param context Ruby {@link ThreadContext}
-         * @param data Either {@code null}, {@link org.jruby.RubyNil} or an instance of
-         * {@link MapJavaProxy}
+         * @param data    Either {@code null}, {@link org.jruby.RubyNil} or an instance
+         *                of {@link MapJavaProxy}
          */
         @SuppressWarnings("unchecked")
         private void initializeFallback(final ThreadContext context, final IRubyObject data) {
             if (data == null || data.isNil()) {
                 this.event = new Event();
             } else if (data instanceof MapJavaProxy) {
-                this.event = new Event(ConvertedMap.newFromMap(
-                    (Map<String, Object>)((MapJavaProxy)data).getObject())
-                );
+                this.event = new Event(
+                        ConvertedMap.newFromMap((Map<String, Object>) ((MapJavaProxy) data).getObject()));
             } else {
                 throw context.runtime.newTypeError("wrong argument type " + data.getMetaClass() + " (expected Hash)");
             }
         }
 
         /**
-         * Shared logic to wrap {@link FieldReference.IllegalSyntaxException}s that are raised by
-         * {@link FieldReference#from(RubyString)} when encountering illegal syntax in a ruby-exception
-         * that can be easily handled within the ruby plugins
+         * Shared logic to wrap {@link FieldReference.IllegalSyntaxException}s that are
+         * raised by {@link FieldReference#from(RubyString)} when encountering illegal
+         * syntax in a ruby-exception that can be easily handled within the ruby plugins
          *
          * @param reference a {@link RubyString} representing the path to a field
-         * @return the corresponding {@link FieldReference} (see: {@link FieldReference#from(RubyString)})
+         * @return the corresponding {@link FieldReference} (see:
+         *         {@link FieldReference#from(RubyString)})
          */
         private static FieldReference extractFieldReference(final RubyString reference) {
             try {
@@ -343,11 +326,12 @@ public final class JrubyEventExtLibrary {
         }
 
         /**
-         * Shared logic to wrap {@link FieldReference.IllegalSyntaxException}s that are raised by
-         * {@link Valuefier#convert(Object)} when encountering illegal syntax in a ruby-exception
-         * that can be easily handled within the ruby plugins
+         * Shared logic to wrap {@link FieldReference.IllegalSyntaxException}s that are
+         * raised by {@link Valuefier#convert(Object)} when encountering illegal syntax
+         * in a ruby-exception that can be easily handled within the ruby plugins
          *
-         * @param value a {@link Object} to be passed to {@link Valuefier#convert(Object)}
+         * @param value a {@link Object} to be passed to
+         *              {@link Valuefier#convert(Object)}
          * @return the resulting {@link Object} (see: {@link Valuefier#convert(Object)})
          */
         private static Object safeValueifierConvert(final Object value) {
@@ -358,18 +342,23 @@ public final class JrubyEventExtLibrary {
             }
         }
 
-
         private void setEvent(Event event) {
             this.event = event;
         }
 
         /**
          * Generates a fixed hashcode.
+         *
          * @return HashCode value
          */
         private static int nextHash() {
             final long sequence = SEQUENCE_GENERATOR.incrementAndGet();
             return (int) (sequence ^ sequence >>> 32) + 31;
+        }
+
+        @Override
+        public AcknowledgeToken getAcknowledgeToken() {
+            return (this.event == null) ? null : this.event.getAcknowledgeToken();
         }
     }
 }

--- a/logstash-core/src/main/java/org/logstash/plugins/ContextImpl.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/ContextImpl.java
@@ -31,16 +31,24 @@ import java.util.Map;
 
 public class ContextImpl implements Context {
 
-    private DeadLetterQueueWriter dlqWriter;
+    private final DeadLetterQueueWriter dlqWriter;
+
+    private final AcknowledgeBus acknowledgeBus;
 
     /**
      * This is a reference to the [stats, pipelines, *name*, plugins] metric namespace.
      */
     private Metric pluginsScopedMetric;
 
-    public ContextImpl(DeadLetterQueueWriter dlqWriter, Metric metric) {
+    public ContextImpl(DeadLetterQueueWriter dlqWriter, Metric metric, AcknowledgeBus acknowledgeBus) {
         this.dlqWriter = dlqWriter;
         this.pluginsScopedMetric = metric;
+        this.acknowledgeBus = acknowledgeBus;
+    }
+
+
+    public ContextImpl(DeadLetterQueueWriter dlqWriter, Metric metric) {
+        this(dlqWriter, metric, null);
     }
 
     @Override
@@ -79,5 +87,10 @@ public class ContextImpl implements Context {
                 return new org.logstash.Event(data);
             }
         };
+    }
+
+    @Override
+    public AcknowledgeBus getAcknowledgeBus() {
+        return acknowledgeBus;
     }
 }

--- a/logstash-core/src/main/java/org/logstash/plugins/acknowledge/AcknowledgeBus.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/acknowledge/AcknowledgeBus.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.logstash.plugins.acknowledge;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import co.elastic.logstash.api.Acknowledgable;
+import co.elastic.logstash.api.AcknowledgablePlugin;
+import co.elastic.logstash.api.AcknowledgeToken;
+import co.elastic.logstash.api.AcknowledgeTokenFactory;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
+
+/**
+ * This class is the communication bus for the `pipeline` inputs and outputs to
+ * talk to each other.
+ *
+ * This class is threadsafe.
+ */
+public class AcknowledgeBus implements co.elastic.logstash.api.AcknowledgeBus {
+
+    final ConcurrentHashMap<String, AcknowledgablePlugin> acknowledgeIdMapping = new ConcurrentHashMap<>();
+    volatile boolean blockOnUnlisten = false;
+    private static final Logger logger = LogManager.getLogger(AcknowledgeBus.class);
+
+    private final class AcknowledgeTokenImpl implements AcknowledgeToken {
+        private final String pluginId;
+        private final String acknowledgeId;
+
+        AcknowledgeTokenImpl(final String pluginId, final String acknowledgeId) {
+            if (pluginId == null)
+                throw new IllegalArgumentException("pluginId cannot be null");
+            if (acknowledgeId == null)
+                throw new IllegalArgumentException("acknowledgeId cannot be null");
+            this.pluginId = pluginId;
+            this.acknowledgeId = acknowledgeId;
+        }
+
+        @Override
+        public String getPluginId() {
+            return pluginId;
+        }
+
+        @Override
+        public String getAcknowledgeId() {
+            return acknowledgeId;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (o == this)
+                return true;
+            if (!(o instanceof AcknowledgeToken))
+                return false;
+            final AcknowledgeTokenImpl other = (AcknowledgeTokenImpl) o;
+            if (!other.canEqual((Object) this))
+                return false;
+            if (this.getPluginId() == null ? other.getPluginId() != null
+                    : !this.getPluginId().equals(other.getPluginId()))
+                return false;
+            if (this.getAcknowledgeId() == null ? other.getAcknowledgeId() != null
+                    : !this.getAcknowledgeId().equals(other.getAcknowledgeId()))
+                return false;
+            return true;
+        }
+
+        protected boolean canEqual(final Object other) {
+            return other instanceof AcknowledgeTokenImpl;
+        }
+
+        @Override
+        public int hashCode() {
+            final int PRIME = 59;
+            int result = 1;
+            result = (result * PRIME) + (this.pluginId == null ? 43 : this.pluginId.hashCode());
+            result = (result * PRIME) + (this.acknowledgeId == null ? 43 : this.acknowledgeId.hashCode());
+            return result;
+        }
+
+    }
+
+    @Override
+    public void acknowledgeEvents(final Collection<? extends Acknowledgable> events) {
+        this.proccessEvents(events, AcknowledgablePlugin::acknowledge, "Acknowledge");
+    }
+
+    @Override
+    public void notifyClonedEvents(final Collection<? extends Acknowledgable> events) {
+        this.proccessEvents(events, AcknowledgablePlugin::notifyCloned, "Notification cloned Acknowledge");
+    }
+
+    private void proccessEvents(final Collection<? extends Acknowledgable> events, BiFunction<AcknowledgablePlugin, String, Boolean> processId, String processName){
+        if (events.isEmpty())
+            return; // This can happen on pipeline shutdown or in some other situations
+
+        events.stream().forEach(event -> {
+            final AcknowledgeToken token = event.getAcknowledgeToken();
+            if (token != null) {
+                final AcknowledgablePlugin plugin = acknowledgeIdMapping.get(token.getPluginId());
+                if (plugin != null) {
+                    if (!processId.apply(plugin, token.getAcknowledgeId())) {
+                        logger.warn( processName + " for plugin: " + plugin.getId() + " was unsuccesful for id: "
+                                + token.getAcknowledgeId());
+                    }
+                } else {
+                    logger.warn("Received " + processName + " for unknown plugin: " + token.getPluginId());
+                }
+            }
+        });
+    }
+
+    /**
+     * Should be called by a plugin on register
+     *
+     * @param plugin plugin to be registered
+     * @return an AcknowledgeTokenGenerator instance
+     */
+    @Override
+    public AcknowledgeTokenFactory registerPlugin(final AcknowledgablePlugin plugin) {
+        synchronized (plugin) {
+            acknowledgeIdMapping.put(plugin.getId(), plugin);
+
+            return id -> new AcknowledgeTokenImpl(plugin.getId(), id);
+        }
+    }
+
+    /**
+     * Should be called by an plugin on close
+     *
+     * @param plugin output that will be unregistered
+     */
+    @Override
+    public boolean unregisterPlugin(final AcknowledgablePlugin plugin) {
+        synchronized (plugin) {
+            return acknowledgeIdMapping.remove(plugin.getId()) != null;
+        }
+    }
+
+
+}

--- a/logstash-core/src/main/java/org/logstash/plugins/acknowledge/AcknowledgeTokenImpl.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/acknowledge/AcknowledgeTokenImpl.java
@@ -1,0 +1,76 @@
+package org.logstash.plugins.acknowledge;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import co.elastic.logstash.api.AcknowledgeToken;
+
+public final class AcknowledgeTokenImpl implements AcknowledgeToken {
+    private final String pluginId;
+    private final String acknowledgeId;
+    // private String pluginId;
+    // private String acknowledgeId;
+
+    // AcknowledgeTokenImpl(){}
+
+    @JsonCreator
+    AcknowledgeTokenImpl(@JsonProperty("pluginId") final String pluginId, @JsonProperty("acknowledgeId") final String acknowledgeId) {
+        if (pluginId == null)
+            throw new IllegalArgumentException("pluginId cannot be null");
+        if (acknowledgeId == null)
+            throw new IllegalArgumentException("acknowledgeId cannot be null");
+        this.pluginId = pluginId;
+        this.acknowledgeId = acknowledgeId;
+    }
+
+    @Override
+    public String getPluginId() {
+        return pluginId;
+    }
+
+    // public void setPluginId(String pluginId) {
+    //     this.pluginId = pluginId;
+    // }
+
+    @Override
+    public String getAcknowledgeId() {
+        return acknowledgeId;
+    }
+
+
+    // public void setAcknowledgeId(String acknowledgeId) {
+    //     this.acknowledgeId = acknowledgeId;
+    // }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (o == this)
+            return true;
+        if (!(o instanceof AcknowledgeToken))
+            return false;
+        final AcknowledgeTokenImpl other = (AcknowledgeTokenImpl) o;
+        if (!other.canEqual((Object) this))
+            return false;
+        if (this.getPluginId() == null ? other.getPluginId() != null
+                : !this.getPluginId().equals(other.getPluginId()))
+            return false;
+        if (this.getAcknowledgeId() == null ? other.getAcknowledgeId() != null
+                : !this.getAcknowledgeId().equals(other.getAcknowledgeId()))
+            return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof AcknowledgeTokenImpl;
+    }
+
+    @Override
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        result = (result * PRIME) + (this.pluginId == null ? 43 : this.pluginId.hashCode());
+        result = (result * PRIME) + (this.acknowledgeId == null ? 43 : this.acknowledgeId.hashCode());
+        return result;
+    }
+}
+

--- a/logstash-core/src/main/java/org/logstash/plugins/inputs/AckedGenerator.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/inputs/AckedGenerator.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.logstash.plugins.inputs;
+
+import co.elastic.logstash.api.AcknowledgablePlugin;
+import co.elastic.logstash.api.AcknowledgeBus;
+import co.elastic.logstash.api.AcknowledgeTokenFactory;
+import co.elastic.logstash.api.Configuration;
+import co.elastic.logstash.api.Context;
+import co.elastic.logstash.api.LogstashPlugin;
+import co.elastic.logstash.api.PluginConfigSpec;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+import org.apache.logging.log4j.Logger;
+import org.joda.time.DateTime;
+
+@LogstashPlugin(name = "java_acked_generator")
+public class AckedGenerator extends Generator implements AcknowledgablePlugin {
+
+    private final Logger logger;
+    private final AcknowledgeBus acknowledgeBus;
+    private final AcknowledgeTokenFactory acknowledgeTokenFactory;
+    private final AtomicLong tokenCount;
+    private final AtomicLong awaitCount;
+    private final CountDownLatch countDownLatch;
+    private boolean isStopping;
+
+    /**
+     * Required constructor.
+     *
+     * @param id            Plugin id
+     * @param configuration Logstash Configuration
+     * @param context       Logstash Context
+     */
+    public AckedGenerator(final String id, final Configuration configuration, final Context context) {
+        super(id, configuration, context);
+        this.logger = context.getLogger(this);
+        this.acknowledgeBus = context.getAcknowledgeBus();
+        this.tokenCount = new AtomicLong();
+        this.awaitCount = new AtomicLong();
+        this.countDownLatch = new CountDownLatch(1);
+        this.isStopping = false;
+        if (this.acknowledgeBus == null
+                || (this.acknowledgeTokenFactory = this.acknowledgeBus.registerPlugin(this)) == null) {
+            throw new RuntimeException("Unable to register plugin on acknowledgeBus");
+        }
+    }
+
+    @Override
+    public void start(Consumer<Map<String, Object>> writer) {
+        Consumer<Map<String, Object>> wrappedWriter = (map) -> {
+            String token = Long.toString(this.tokenCount.getAndIncrement());
+            this.awaitCount.incrementAndGet();
+            map.put("@acknowledge_token",
+                    acknowledgeTokenFactory.generateToken(token));
+            logger.info("[{}] Pushing generated event number: {}", DateTime.now(), token);
+            writer.accept(map);
+        };
+        super.start(wrappedWriter);
+    }
+
+    @Override
+    public void stop() {
+        super.stop();
+        this.isStopping = true;
+    }
+
+    @Override
+    public void awaitStop() throws InterruptedException {
+        super.awaitStop();
+        if (this.awaitCount.get() > 0) {
+            logger.info("Awaiting {} acknowledges before stopping", this.awaitCount.get());
+            this.countDownLatch.await();
+        }
+    }
+
+    @Override
+    public Collection<PluginConfigSpec<?>> configSchema() {
+        return super.configSchema();
+    }
+
+    @Override
+    public String getId() {
+        return super.getId();
+    }
+
+    @Override
+    public boolean acknowledge(String acknowledgeId) {
+        logger.info("Acknowledged generated event number: {}", acknowledgeId);
+        long count = this.awaitCount.decrementAndGet();
+        logger.info("Awaiting {} acknowledges", count);
+        if (this.isStopping && count == 0){
+            this.countDownLatch.countDown();
+        }
+        return true;
+    }
+
+    @Override
+    public boolean notifyCloned(String acknowledgeId) {
+        logger.info("Generated event number: {} crossed pipeline boundries/was cloned", acknowledgeId);
+        this.awaitCount.incrementAndGet();
+        return false;
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/plugins/acknowledge/AcknowledgeBusTest.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/acknowledge/AcknowledgeBusTest.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.logstash.plugins.acknowledge;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.logstash.Event;
+import org.logstash.RubyUtil;
+import org.logstash.ext.JrubyEventExtLibrary;
+
+import co.elastic.logstash.api.AcknowledgablePlugin;
+import co.elastic.logstash.api.AcknowledgeBus;
+import co.elastic.logstash.api.AcknowledgeToken;
+import co.elastic.logstash.api.AcknowledgeTokenFactory;
+import co.elastic.logstash.api.PluginConfigSpec;
+
+public class AcknowledgeBusTest {
+
+    AcknowledgeBus bus;
+    TestAcknowledgePlugin plugin;
+    static String pluginId = "test_acknowledge_input";
+
+    @Before
+    public void setup() {
+        bus = new org.logstash.plugins.acknowledge.AcknowledgeBus();
+        plugin = new TestAcknowledgePlugin(pluginId);
+    }
+
+    @Test
+    public void registerUnregister() throws InterruptedException {
+        Object factory = bus.registerPlugin(plugin);
+        assertThat(factory).isInstanceOf(AcknowledgeTokenFactory.class);
+
+        assertThat(bus.unregisterPlugin(plugin)).isTrue();
+        assertThat(bus.unregisterPlugin(plugin)).isFalse();
+    }
+
+    @Test
+    public void registerAndReceiveAcknowledge() throws InterruptedException {
+        AcknowledgeTokenFactory factory = bus.registerPlugin(plugin);
+        Collection<JrubyEventExtLibrary.RubyEvent> events = Arrays.asList(
+            rubyEvent(),
+            rubyEvent(factory.generateToken("1")),
+            rubyEvent(),
+            rubyEvent(factory.generateToken("2")),
+            rubyEvent()
+        );
+        bus.acknowledgeEvents(events);
+        assertThat(plugin.acknowledged.size()).isEqualTo(2);
+        assertThat(plugin.acknowledged).contains("2", "1");
+        assertThat(plugin.cloned.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void registerAndReceiveCloned() throws InterruptedException {
+        AcknowledgeTokenFactory factory = bus.registerPlugin(plugin);
+        Collection<JrubyEventExtLibrary.RubyEvent> events = Arrays.asList(
+            rubyEvent(),
+            rubyEvent(factory.generateToken("1")),
+            rubyEvent(),
+            rubyEvent(factory.generateToken("2")),
+            rubyEvent()
+        );
+        bus.notifyClonedEvents(events);
+        assertThat(plugin.cloned.size()).isEqualTo(2);
+        assertThat(plugin.cloned).contains("2", "1");
+        assertThat(plugin.acknowledged.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void registerUnregisterNoReceiveCloned() throws InterruptedException {
+        AcknowledgeTokenFactory factory = bus.registerPlugin(plugin);
+        Collection<JrubyEventExtLibrary.RubyEvent> events = Arrays.asList(
+            rubyEvent(),
+            rubyEvent(factory.generateToken("1")),
+            rubyEvent(),
+            rubyEvent(factory.generateToken("2")),
+            rubyEvent()
+        );
+        assertThat(bus.unregisterPlugin(plugin)).isTrue();
+
+        bus.notifyClonedEvents(events);
+        assertThat(plugin.cloned.size()).isEqualTo(0);
+        assertThat(plugin.acknowledged.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void registerUnregisterNoReceiveAcknowledged() throws InterruptedException {
+        AcknowledgeTokenFactory factory = bus.registerPlugin(plugin);
+        Collection<JrubyEventExtLibrary.RubyEvent> events = Arrays.asList(
+            rubyEvent(),
+            rubyEvent(factory.generateToken("1")),
+            rubyEvent(),
+            rubyEvent(factory.generateToken("2")),
+            rubyEvent()
+        );
+        assertThat(bus.unregisterPlugin(plugin)).isTrue();
+
+        bus.acknowledgeEvents(events);
+        assertThat(plugin.cloned.size()).isEqualTo(0);
+        assertThat(plugin.acknowledged.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void registerDoubleIdReturnsNull() throws InterruptedException {
+        TestAcknowledgePlugin plugin2 = new TestAcknowledgePlugin(pluginId);
+        Object factory1 = bus.registerPlugin(plugin);
+        Object factory2 = bus.registerPlugin(plugin2);
+
+        assertThat(factory1).isNotNull();
+        assertThat(factory1).isInstanceOf(AcknowledgeTokenFactory.class);
+        assertThat(factory2).isNull();
+    }
+
+    @Test
+    public void registerMultipleReceiveBySingle() throws InterruptedException {
+        TestAcknowledgePlugin plugin2 = new TestAcknowledgePlugin("plugin2");
+        AcknowledgeTokenFactory factory1 = bus.registerPlugin(plugin);
+        AcknowledgeTokenFactory factory2 = bus.registerPlugin(plugin2);
+        Collection<JrubyEventExtLibrary.RubyEvent> events = Arrays.asList(
+            rubyEvent(),
+            rubyEvent(factory1.generateToken("1")),
+            rubyEvent(factory2.generateToken("1")),
+            rubyEvent(factory1.generateToken("2")),
+            rubyEvent(factory1.generateToken("3")),
+            rubyEvent(factory2.generateToken("4"))
+        );
+        bus.acknowledgeEvents(events);
+        bus.notifyClonedEvents(events);
+        assertThat(plugin.cloned.size()).isEqualTo(3);
+        assertThat(plugin.cloned).contains("2", "3", "1");
+        assertThat(plugin.acknowledged.size()).isEqualTo(3);
+        assertThat(plugin.acknowledged).contains("2", "3", "1");
+        assertThat(plugin2.cloned.size()).isEqualTo(2);
+        assertThat(plugin2.cloned).contains("4", "1");
+        assertThat(plugin2.acknowledged.size()).isEqualTo(2);
+        assertThat(plugin2.acknowledged).contains("4", "1");
+    }
+
+    @Test
+    public void receiveAcknowledgeUnknownPlugin() throws InterruptedException {
+        bus.registerPlugin(plugin);
+        AcknowledgeToken token = new AcknowledgeToken(){
+            @Override
+            public String getPluginId() {
+                return "Non_existing_plugin";
+            }
+
+            @Override
+            public String getAcknowledgeId() {
+                return "dummyId";
+            }
+        };
+        Collection<JrubyEventExtLibrary.RubyEvent> events = Arrays.asList(
+            rubyEvent(token),
+            rubyEvent()
+        );
+
+        bus.acknowledgeEvents(events);
+        bus.notifyClonedEvents(events);
+
+        assertThat(plugin.cloned.size()).isEqualTo(0);
+        assertThat(plugin.acknowledged.size()).isEqualTo(0);
+    }
+
+    private JrubyEventExtLibrary.RubyEvent rubyEvent() {
+        return JrubyEventExtLibrary.RubyEvent.newRubyEvent(RubyUtil.RUBY);
+    }
+    private JrubyEventExtLibrary.RubyEvent rubyEvent(AcknowledgeToken token) {
+        return JrubyEventExtLibrary.RubyEvent.newRubyEvent(RubyUtil.RUBY, new Event(token));
+    }
+
+    static class TestAcknowledgePlugin implements AcknowledgablePlugin {
+        public List<String> acknowledged = new ArrayList<>();
+        public List<String> cloned = new ArrayList<>();
+
+        private String id;
+
+        TestAcknowledgePlugin(String id){
+            this.id = id;
+        }
+
+        @Override
+        public Collection<PluginConfigSpec<?>> configSchema() {
+            return null;
+        }
+
+        @Override
+        public String getId() {
+            return id;
+        }
+
+        @Override
+        public boolean acknowledge(String acknowledgeId) {
+            return acknowledged.add(acknowledgeId);
+        }
+
+        @Override
+        public boolean notifyCloned(String acknowledgeId) {
+            return cloned.add(acknowledgeId);
+        }
+    }
+
+}


### PR DESCRIPTION
Merge request with possible implementation solving: https://github.com/elastic/logstash/issues/8514

* I created a bus where at the end of the workerloop the events in the inflight batch are acknowledged based on the presence of an acknowledgetoken in the event. That token(which contains a plugin generated id) is/can be added on event creation.
* Plugins can register themselves(which gives them a token generator). When they add token to an event they get notified when it reaches the end of a pipeline.
*  It should even work with cross pipeline communication and the original input plugin is notified of the "clone" when crossing pipeline boundries so the plugin knows it might need to wait for another acknowledge to have the event fully processed.
* For plugins that clone an event in a pipeline(like the clone plugin) there is no need for notification, since the original event(that we want to have acknowledged) always reaches the end of the pipeline(though might be cancelled).
* It works with both the memory and persisted queues
* The token can only be added on event creation so filter plugins cannot modify the event(they can cancel the event but it will reach the end of the pipeline) and therefore will still have token at the end of the loop.
* It should be backwards compatible and can opted in by plugins

I didn't go the route of a new queueless type, since an acknowledgable plugin then would force all pipelines(in the case of cross pipeline communication) to all have that queue type. Nor did I integrate it with the current acked queue since it was extremely hard to get a global reference to something like an acknowledgebus to propagate down to the concrete queue implementations and this would create more coupling.

*Open ideas/questions*:
Possible extension idea which I haven't worked out(but might good idea in case of persisted queue). To add expiration to the acknowledgement token. So if deserialized/read from queue from (persisted) queue but is expired we could immediately cancel the event since it most likely will be retried. 

*TODOS*:
Add more testing
