### PR TITLE
ignore default username when no password is set to not use authentication in xpack monitoring and management

### DIFF
--- a/x-pack/spec/config_management/elasticsearch_source_spec.rb
+++ b/x-pack/spec/config_management/elasticsearch_source_spec.rb
@@ -151,8 +151,12 @@ describe LogStash::ConfigManagement::ElasticsearchSource do
           }
         end
 
-        it "should raise an ArgumentError" do
-          expect { described_class.new(system_settings) }.to raise_error(ArgumentError)
+        it "will rely on username and password settings" do
+          # since cloud_id and cloud_auth are simply containers for host and username/password
+          # both could be set independently and if cloud_auth is not set then authn will be done
+          # using the provided username/password settings, which can be set or not if not auth is
+          # required.
+          expect { described_class.new(system_settings) }.to_not raise_error
         end
       end
     end

--- a/x-pack/spec/helpers/elasticsearch_options_spec.rb
+++ b/x-pack/spec/helpers/elasticsearch_options_spec.rb
@@ -107,10 +107,11 @@ describe LogStash::Helpers::ElasticsearchOptions do
         }
       end
 
-      it "fails without password" do
-        expect {
-          test_class.es_options_from_settings_or_modules('monitoring', system_settings)
-        }.to raise_error(ArgumentError, /password must be set/)
+      it "ignores the implicit default username when no password is set" do
+        # when no explicit password is set then the default/implicit username should be ignored
+        es_options = test_class.es_options_from_settings_or_modules('monitoring', system_settings)
+        expect(es_options).to_not include("user")
+        expect(es_options).to_not include("password")
       end
 
       context "with cloud_auth" do
@@ -296,13 +297,10 @@ describe LogStash::Helpers::ElasticsearchOptions do
       end
 
       context "when cloud_auth is not set" do
-
-        it "raises for invalid configuration" do
-          # if not other authn is provided it will assume basic auth using the default username
-          # but the password is missing.
-          expect {
-            test_class.es_options_from_settings_or_modules('monitoring', system_settings)
-          }.to raise_error(ArgumentError, /With the default.*?username,.*?password must be set/)
+        it "does not use authentication and ignores the default username" do
+          es_options = test_class.es_options_from_settings_or_modules('monitoring', system_settings)
+          expect(es_options).to include("cloud_id")
+          expect(es_options.keys).to_not include("hosts", "user", "password")
         end
 
         context 'username and password set' do


### PR DESCRIPTION
This fixes a regression introduced with the api_key support for xpack monitoring and management in #11864 which disabled the possibility to not use any authentication by relying on the default options and only enabling monitoring for example. 

This PR now ignores the default `username` option when no password is explicitly set.

