### PR TITLE
add dependency notice for amazing_print

### DIFF
--- a/tools/dependencies-report/src/main/resources/licenseMapping.csv
+++ b/tools/dependencies-report/src/main/resources/licenseMapping.csv
@@ -3,6 +3,7 @@ dependency,dependencyUrl,licenseOverride
 "atomic:",http://github.com/ruby-concurrency/atomic,Apache-2.0
 "avl_tree:",https://github.com/nahi/avl_tree,BSD-2-Clause-FreeBSD
 "avro:",https://github.com/apache/avro/tree/master/lang/ruby,Apache-2.0
+"amazing_print:",https://github.com/amazing-print/amazing_print,MIT
 "awesome_print:",https://github.com/awesome-print/awesome_print,MIT
 "aws-eventstream:",https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-eventstream,Apache-2.0
 "aws-sdk-core:",http://github.com/aws/aws-sdk-ruby,Apache-2.0

--- a/tools/dependencies-report/src/main/resources/notices/amazing_print-NOTICE.txt
+++ b/tools/dependencies-report/src/main/resources/notices/amazing_print-NOTICE.txt
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2010-2019 Michael Dvorkin
+Copyright (c) 2020 AmazingPrint
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
fixes the license check test currently failing in master. This dependency is brought by the new release of the logstash-codec-rubydebug that dropped the awesome_print library in favor of amazing_print.