### PR TITLE
[build] Ensure more gradle tasks using task avoidance API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -450,12 +450,9 @@ tasks.register("runIntegrationTests"){
     dependsOn tasks.getByPath(":logstash-integration-tests:integrationTests")
     dependsOn copyEs
     dependsOn copyFilebeat
+    shouldRunAfter ":logstash-core:test"
 }
 
-bootstrap.dependsOn assemblyDeps
-
-runIntegrationTests.shouldRunAfter tasks.getByPath(":logstash-core:test")
-check.dependsOn runIntegrationTests
 
 
 tasks.register("generateLicenseReport", JavaExec) {
@@ -506,10 +503,7 @@ tasks.register("generatePluginsVersion") {
 }
 
 bootstrap.dependsOn assemblyDeps
-
-runIntegrationTests.shouldRunAfter tasks.getByPath(":logstash-core:test")
 check.dependsOn runIntegrationTests
-
 
 Boolean oss = System.getenv('OSS').equals('true')
 
@@ -520,11 +514,12 @@ if (!oss) {
         dependsOn installTestGems
       }
     }
-    tasks.getByPath(":logstash-xpack:rubyIntegrationTests").configure {
-      dependsOn copyEs
-    }
   }
-
-  task runXPackUnitTests(dependsOn: [tasks.getByPath(":logstash-xpack:rubyTests")]) {}
-  task runXPackIntegrationTests(dependsOn: [tasks.getByPath(":logstash-xpack:rubyIntegrationTests")]) {}
 }
+
+ tasks.register("runXPackUnitTests"){
+   dependsOn ":logstash-xpack:rubyTests"
+ }
+ tasks.register("runXPackIntegrationTests"){
+   dependsOn ":logstash-xpack:rubyIntegrationTests"
+ }

--- a/x-pack/build.gradle
+++ b/x-pack/build.gradle
@@ -35,6 +35,7 @@ tasks.register("rubyTests", Test) {
 }
 
 tasks.register("rubyIntegrationTests", Test) {
+  dependsOn (":copyEs")
   inputs.files fileTree("${projectDir}/qa")
   inputs.files fileTree("${projectDir}/lib")
   inputs.files fileTree("${projectDir}/modules")


### PR DESCRIPTION
Release Manager builds were failing as `downloadEs` task was being
needlessly run during `rake artifact:all` task. When run with
`RELEASE=1`. this was causing build failures due to the non-availability
of Elasticsearch release artifacts. This commit aims to avoid running
the `downloadES` task when it is not needed, continuing the work done
in #11914

This commit also removes code that was repeated in different parts of
the build script.