### PR TITLE
tolerate arity of 0 or 1 in use_event_type?

### DIFF
--- a/x-pack/lib/monitoring/outputs/elasticsearch_monitoring.rb
+++ b/x-pack/lib/monitoring/outputs/elasticsearch_monitoring.rb
@@ -9,7 +9,7 @@ module LogStash module Outputs
     # This is need to avoid deprecation warning in output
     config :document_type, :validate => :string
 
-    def use_event_type?(client)
+    def use_event_type?(client = nil)
       !LogStash::MonitoringExtension.use_direct_shipping?(LogStash::SETTINGS)
     end
   end


### PR DESCRIPTION
WARNING: this PR is created as an example of how to work around the issue, maybe not be the right fix.

a change in the ES output made the `use_event_type?` method receive 0 arguments instead of 1.
Our x-pack ES output overrides this method so it needs to be aligned with the source implementation.
By overriding with an optional argument we can tolerate invocations with 0 (new) or 1 (old) arguments.

This causes x-pack integration tests to fail, e.g. https://logstash-ci.elastic.co/job/elastic+logstash+master+multijob-x-pack-integration/352/console

The commit that introduced the change in ES output is https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/952/commits/2dacfcbc09a3d5700f34b286c2af644274a0efbc