### PR TITLE
Fix docker image labels

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -21,6 +21,7 @@ HTTPD ?= logstash-docker-artifact-server
 FIGLET := pyfiglet -w 160 -f puffy
 
 all: build-from-local-artifacts build-from-local-oss-artifacts public-dockerfiles
+DATE:= $(shell date -u +'%Y-%m-%dT%H:%M:%S.%sZ')
 
 lint: venv
 	flake8 tests
@@ -70,6 +71,7 @@ docker_paths:
 
 public-dockerfiles: venv templates/Dockerfile.j2 docker_paths $(COPY_FILES)
 	jinja2 \
+	  -D created_date='$(DATE)' \
 	  -D elastic_version='$(ELASTIC_VERSION)' \
 	  -D version_tag='$(VERSION_TAG)' \
 	  -D image_flavor='full' \
@@ -77,6 +79,7 @@ public-dockerfiles: venv templates/Dockerfile.j2 docker_paths $(COPY_FILES)
 	  -D release='$(RELEASE)' \
 	  templates/Dockerfile.j2 > $(ARTIFACTS_DIR)/Dockerfile-full && \
 	jinja2 \
+	  -D created_date='$(DATE)' \
 	  -D elastic_version='$(ELASTIC_VERSION)' \
 	  -D version_tag='$(VERSION_TAG)' \
 	  -D image_flavor='oss' \
@@ -133,6 +136,7 @@ env2yaml: golang
 dockerfile: venv templates/Dockerfile.j2
 	$(foreach FLAVOR, $(IMAGE_FLAVORS), \
 	  jinja2 \
+	    -D created_date='$(DATE)' \
 	    -D elastic_version='$(ELASTIC_VERSION)' \
 	    -D version_tag='$(VERSION_TAG)' \
 	    -D image_flavor='$(FLAVOR)' \

--- a/docker/templates/Dockerfile.j2
+++ b/docker/templates/Dockerfile.j2
@@ -7,8 +7,10 @@
 
 {% if image_flavor == 'oss' -%}
   {% set tarball = 'logstash-oss-%s.tar.gz' % elastic_version -%}
+  {% set license = 'Apache 2.0' -%}
 {% else -%}
   {% set tarball = 'logstash-%s.tar.gz' % elastic_version -%}
+  {% set license = 'Elastic License' -%}
 {% endif -%}
 
 
@@ -62,17 +64,20 @@ ADD env2yaml/env2yaml /usr/local/bin/
 EXPOSE 9600 5044
 
 
-LABEL org.label-schema.schema-version="1.0" \
+LABEL  org.label-schema.schema-version="1.0" \
   org.label-schema.vendor="Elastic" \
+  org.opencontainers.image.vendor="Elastic" \
   org.label-schema.name="logstash" \
+  org.opencontainers.image.title="logstash" \
   org.label-schema.version="{{ elastic_version }}" \
+  org.opencontainers.image.version="{{ elastic_version }}" \
   org.label-schema.url="https://www.elastic.co/products/logstash" \
   org.label-schema.vcs-url="https://github.com/elastic/logstash" \
-{% if image_flavor == 'oss' -%}
-  license="Apache-2.0"
-{% else -%}
-  license="Elastic License"
-{% endif -%}
+  license="{{ license }}" \
+  org.label-schema.license="{{ license }}" \
+  org.opencontainers.image.licenses="{{ license }}" \
+  org.label-schema.build-date={{ created_date }} \
+  org.opencontainers.image.created={{ created_date }}
 
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]


### PR DESCRIPTION
Prior to this commit, the value of `org.label-schema.license` and
the values in `org.opencontainers.image.*` were not set, and therefore
would be inherited from the base OS image.