### PR TITLE
Doc:Add coming tag to 7.8.1 release notes

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -34,6 +34,8 @@ This section summarizes the changes in the following releases:
 [[logstash-7-8-1]]
 === Logstash 7.8.1 Release Notes
 
+coming::[7.8.1]
+
 ==== Performance improvements and notable issues fixed
 
 ===== Fixed performance regression during pipeline compilation


### PR DESCRIPTION
Tag release notes with a "Coming in..." tag. 
Tag will be removed after release. 

**PREVIEW:** https://logstash_12118.docs-preview.app.elstc.co/guide/en/logstash/current/logstash-7-8-1.html