### PR TITLE
Document use of keystore values in pipelines.yml

### DIFF
--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -27,8 +27,8 @@ pipeline.batch.size: 125
 pipeline.batch.delay: 50
 -------------------------------------------------------------------------------------
 
-The `logstash.yml` file also supports bash-style interpolation of environment variables in
-setting values.
+The `logstash.yml` file also supports bash-style interpolation of environment variables and
+keystore secrets in setting values.
 
 [source,yaml]
 -------------------------------------------------------------------------------------


### PR DESCRIPTION
Tested with a keystore secret called "secret"
```
/tmp/logstash-7.8.0
❯ bin/logstash-keystore list     
secret
```
And a pipelines.yml that has a pipeline uses both a keystore secret and an environment variable:

```yml
- pipeline.id: test
  pipeline.workers: 1
  pipeline.batch.size: 1
  config.string: "input { generator { count => 1 message => \"${ENV_VAR}\"} } filter { mutate { add_field => { \"secret\" => \"${SECRET}\"} } } output { stdout { codec => rubydebug } }"
```

```
/tmp/logstash-7.8.0 ❯ ENV_VAR=enviroment bin/logstash
[2020-07-22T16:40:36,945][INFO ][logstash.runner          ] Starting Logstash {"logstash.version"=>"7.8.0", "jruby.version"=>"jruby 9.2.11.1 (2.5.7) 2020-03-25 b1f55b1a40 OpenJDK 64-Bit Server VM 11.0.5+10 on 11.0.5+10 +indy +jit [darwin-x86_64]"}
[2020-07-22T16:40:40,016][INFO ][logstash.javapipeline    ][test] Starting pipeline {:pipeline_id=>"test", "pipeline.workers"=>1, "pipeline.batch.size"=>1, "pipeline.batch.delay"=>50, "pipeline.max_inflight"=>1, "pipeline.sources"=>["config string"], :thread=>"#<Thread:0x47281903 run>"}
[2020-07-22T16:40:40,615][INFO ][logstash.javapipeline    ][test] Pipeline started {"pipeline.id"=>"test"}
[2020-07-22T16:40:40,669][INFO ][logstash.agent           ] Pipelines running {:count=>1, :running_pipelines=>[:test], :non_running_pipelines=>[]}
[2020-07-22T16:40:40,849][INFO ][logstash.agent           ] Successfully started Logstash API endpoint {:port=>9600}
{
    "@timestamp" => 2020-07-22T15:40:40.642Z,
          "host" => "joaos-mbp.lan",
      "@version" => "1",
        "secret" => "hahaha",
      "sequence" => 0,
       "message" => "enviroment"
}
[2020-07-22T16:40:42,260][INFO ][logstash.runner          ] Logstash shut down.
```
