### PR TITLE
[DOCS] Removes coming tag

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -34,8 +34,6 @@ This section summarizes the changes in the following releases:
 [[logstash-7-8-1]]
 === Logstash 7.8.1 Release Notes
 
-coming::[7.8.1]
-
 ==== Performance improvements and notable issues fixed
 
 ===== Fixed performance regression during pipeline compilation


### PR DESCRIPTION
This PR removes the "coming" tag from the 7.8.1 release notes: https://www.elastic.co/guide/en/logstash/current/logstash-7-8-1.html