### PR TITLE
Expose xpack.monitoring.elasticsearch.proxy setting as Docker env varible

### DIFF
--- a/docker/data/logstash/env2yaml/env2yaml.go
+++ b/docker/data/logstash/env2yaml/env2yaml.go
@@ -99,6 +99,7 @@ func normalizeSetting(setting string) (string, error) {
 		"xpack.monitoring.elasticsearch.hosts",
 		"xpack.monitoring.elasticsearch.username",
 		"xpack.monitoring.elasticsearch.password",
+		"xpack.monitoring.elasticsearch.proxy",
 		"xpack.monitoring.elasticsearch.ssl.certificate_authority",
 		"xpack.monitoring.elasticsearch.ssl.truststore.path",
 		"xpack.monitoring.elasticsearch.ssl.truststore.password",


### PR DESCRIPTION
In PR #11799 we missed to add the exposure of proxy also as docker env variable so that uses can connect the dockerzied Logstash to a proxed monitoring cluster