### PR TITLE
Doc:Fix name of monitoring settings

### DIFF
--- a/docs/static/security/logstash.asciidoc
+++ b/docs/static/security/logstash.asciidoc
@@ -218,8 +218,8 @@ Then configure the user and password in the `logstash.yml` configuration file:
 
 [source,yaml]
 ----------------------------------------------------------
-monitoring.elasticsearch.username: logstash_system
-monitoring.elasticsearch.password: t0p.s3cr3t
+xpack.monitoring.elasticsearch.username: logstash_system
+xpack.monitoring.elasticsearch.password: t0p.s3cr3t
 ----------------------------------------------------------
 
 If you initially installed an older version of {xpack} and then upgraded, the


### PR DESCRIPTION
Corrects monitoring settings by adding the `xpack.` prefix.

**PREVIEW:** https://logstash_12153.docs-preview.app.elstc.co/guide/en/logstash/master/ls-security.html#ls-monitoring-user