### PR TITLE
bump jruby to 9.2.13.0

### DIFF
--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -25,7 +25,7 @@ buildscript {
     dependencies {
         classpath 'org.yaml:snakeyaml:1.23'
         classpath "de.undercouch:gradle-download-task:4.0.4"
-        classpath "org.jruby:jruby-complete:9.2.12.0"
+        classpath "org.jruby:jruby-complete:9.2.13.0"
     }
 }
 

--- a/versions.yml
+++ b/versions.yml
@@ -7,8 +7,8 @@ logstash-core-plugin-api: 2.1.16
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time
 jruby:
-  version: 9.2.12.0
-  sha1: bccc2034e773cb1aba2cc4b8b40921265f6e857f
+  version: 9.2.13.0
+  sha1: 876bee4475c1d22b1acd437fcdf7f38b682f0e60
 
 # jruby-runtime-override, if specified, will override the jruby version installed in vendor/jruby for logstash runtime only,
 # not for the compile-time jars


### PR DESCRIPTION
Note: this is to be merged now to: master and 7.x, and then backported to 7.9 once 7.9.0 is released.