### PR TITLE
Fix: allow trailing newlines in config fragments

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/PipelineConfig.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/PipelineConfig.java
@@ -59,7 +59,7 @@ public final class PipelineConfig {
     private RubyObject settings;
     private LocalDateTime readAt;
     private String configHash;
-    private String configString;
+    private volatile String configString;
     private List<LineToSource> sourceRefs;
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -108,7 +108,15 @@ public final class PipelineConfig {
     }
 
     public String configString() {
-        this.configString = confParts.stream().map(SourceWithMetadata::getText).collect(Collectors.joining("\n"));
+        if (this.configString == null) {
+            synchronized(this) {
+                if (this.configString == null) {
+                    this.configString = confParts.stream()
+                            .map(SourceWithMetadata::getText)
+                            .collect(Collectors.joining("\n"));
+                }
+            }
+        }
         return this.configString;
     }
 

--- a/logstash-core/src/test/java/org/logstash/config/ir/PipelineConfigTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/PipelineConfigTest.java
@@ -83,8 +83,11 @@ public class PipelineConfigTest extends RubyEnvTestCase {
 
         void appendSource(final String protocol, final String id, final int line, final int column, final String text) throws IncompleteSourceWithMetadataException {
             orderedConfigParts.add(new SourceWithMetadata(protocol, id, line, column, text));
+
+            if (compositeSource.length() > 0 && !compositeSource.toString().endsWith("\n")) {
+                compositeSource.append("\n");
+            }
             compositeSource.append(text);
-            compositeSource.append("\n");
         }
 
         String compositeSource() {
@@ -103,11 +106,11 @@ public class PipelineConfigTest extends RubyEnvTestCase {
         pipelineIdSym = RubySymbol.newSymbol(RubyUtil.RUBY, PIPELINE_ID);
 
         final SourceCollector sourceCollector = new SourceCollector();
-        sourceCollector.appendSource("file", "/tmp/1", 0, 0, "input { generator1 }");
+        sourceCollector.appendSource("file", "/tmp/1", 0, 0, "input { generator1 }\n");
         sourceCollector.appendSource("file", "/tmp/2", 0, 0, "input { generator2 }");
-        sourceCollector.appendSource("file", "/tmp/3", 0, 0, "input { generator3 }");
+        sourceCollector.appendSource("file", "/tmp/3", 0, 0, "input { generator3 }\n");
         sourceCollector.appendSource("file", "/tmp/4", 0, 0, "input { generator4 }");
-        sourceCollector.appendSource("file", "/tmp/5", 0, 0, "input { generator5 }");
+        sourceCollector.appendSource("file", "/tmp/5", 0, 0, "input { generator5 }\n");
         sourceCollector.appendSource("file", "/tmp/6", 0, 0, "input { generator6 }");
         sourceCollector.appendSource("string", "config_string", 0, 0, "input { generator1 }");
 


### PR DESCRIPTION
Our internal representation of the composite config file needs only to inject
newline delimiters if they are missing, and to avoid doing so if they are
present. This allows `PipelineConfig#sourceReferences()`, used to map back from
the composite line/column to source file/column, to correctly track an offset
using the source fragments `SourceWithMetadata#getLinesCount()`.

Resolves: #12155 

Separately, this change-set contains separate commits for:
 - refactoring a test to avoid verbatim copy/paste of the implementation we are testing against
 - fixes a failed attempt to memoize the `PipelineConfig#configString()` that was _generating_ the composite config at every invocation and storing it to never be accessed.