### PR TITLE
Doc:Adjust link for integration plugin header file

### DIFF
--- a/docs/include/plugin_header-integration.asciidoc
+++ b/docs/include/plugin_header-integration.asciidoc
@@ -11,7 +11,7 @@ ifeval::["{versioned_docs}"=="true"]
 ++++
 endif::[]
 
-* A component of the <<plugins-integrations-{plugin},{plugin} integration plugin>> 
+* A component of the <<plugins-integrations-{integration},{integration} integration plugin>> 
 * Integration version: {version}
 * Released on: {release_date}
 * {changelog_url}[Changelog]
@@ -25,7 +25,7 @@ endif::[]
 
 ifeval::["{versioned_docs}"=="true"]
 
-For other versions, see the <<integration-{plugin}-index,overview list>>.
+For other versions, see the <<{type}-{plugin}-index,overview list>>.
 
 To learn more about Logstash, see the {logstash-ref}/index.html[Logstash Reference].
 


### PR DESCRIPTION
Made some tweaks so that links make sense in context. For example, when you click "integration" from the plugin, you get the integration.   When you click "other versions" from an input, output, or filter, it makes sense to link to other versions of the individual plugin--not back to the integration. 

To test:
1.  Check out this PR (as usual).
2.  Check out this test [PR #890](https://github.com/elastic/logstash-docs/pull/890) for logstash-docs.
3.  Build docs locally: docbldlsx --open

NOTE: When you're checking links, be sure to navigate from the Table of Contents on the right.  If you're not careful, you will leave your local build `http://localhost:8000/guide` and be clicking live links.

Follow-up to #11891