### PR TITLE
Add UBI8 docker image to artifacts

### DIFF
--- a/ci/docker_acceptance_tests.sh
+++ b/ci/docker_acceptance_tests.sh
@@ -11,6 +11,7 @@ export GRADLE_OPTS="-Xmx4g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=
 # Can run either a specific flavor, or all flavors -
 # eg `ci/acceptance_tests.sh oss` will run tests for open source container
 #    `ci/acceptance_tests.sh full` will run tests for the default container
+#    `ci/acceptance_tests.sh ubi8` will run tests for the ubi8 based container
 #    `ci/acceptance_tests.sh` will run tests for all containers
 SELECTED_TEST_SUITE=$1
 
@@ -51,7 +52,7 @@ elif [[ $SELECTED_TEST_SUITE == "full" ]]; then
   echo "Acceptance: Running the tests"
   bundle exec rspec docker/spec/full/*_spec.rb
 elif [[ $SELECTED_TEST_SUITE == "ubi8" ]]; then
-  echo "building full docker images"
+  echo "building ubi8 docker images"
   cd $LS_HOME
   rake artifact:docker_ubi8
   echo "Acceptance: Installing dependencies"

--- a/ci/docker_acceptance_tests.sh
+++ b/ci/docker_acceptance_tests.sh
@@ -50,6 +50,16 @@ elif [[ $SELECTED_TEST_SUITE == "full" ]]; then
 
   echo "Acceptance: Running the tests"
   bundle exec rspec docker/spec/full/*_spec.rb
+elif [[ $SELECTED_TEST_SUITE == "ubi8" ]]; then
+  echo "building full docker images"
+  cd $LS_HOME
+  rake artifact:docker_ubi8
+  echo "Acceptance: Installing dependencies"
+  cd $QA_DIR
+  bundle install
+
+  echo "Acceptance: Running the tests"
+  bundle exec rspec docker/spec/ubi8/*_spec.rb
 else
   echo "Building all docker images"
   cd $LS_HOME

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -12,7 +12,7 @@ else
   VERSION_TAG := $(ELASTIC_VERSION)
 endif
 
-IMAGE_FLAVORS ?= oss full
+IMAGE_FLAVORS ?= oss full ubi8
 DEFAULT_IMAGE_FLAVOR ?= full
 
 IMAGE_TAG := $(ELASTIC_REGISTRY)/logstash/logstash
@@ -28,7 +28,7 @@ lint: venv
 
 # Build from artifacts on the local filesystem, using an http server (running
 # in a container) to provide the artifacts to the Dockerfile.
-build-from-local-artifacts: venv dockerfile env2yaml
+build-from-local-full-artifacts: venv dockerfile env2yaml
 	docker run --rm -d --name=$(HTTPD) \
 	           -p 8000:8000 --expose=8000 -v $(ARTIFACTS_DIR):/mnt \
 	           python:3 bash -c 'cd /mnt && python3 -m http.server'
@@ -46,6 +46,16 @@ build-from-local-oss-artifacts: venv dockerfile env2yaml
 	timeout 120 bash -c 'until curl -s localhost:8000 > /dev/null; do sleep 1; done'
 	pyfiglet -f puffy -w 160 "Building: oss"; \
 	docker build --network=host -t $(IMAGE_TAG)-oss:$(VERSION_TAG) -f $(ARTIFACTS_DIR)/Dockerfile-oss data/logstash || \
+	  (docker kill $(HTTPD); false);
+	-docker kill $(HTTPD)
+
+build-from-local-ubi8-artifacts: venv dockerfile env2yaml
+	docker run --rm -d --name=$(HTTPD) \
+	           -p 8000:8000 --expose=8000 -v $(ARTIFACTS_DIR):/mnt \
+	           python:3 bash -c 'cd /mnt && python3 -m http.server'
+	timeout 120 bash -c 'until curl -s localhost:8000 > /dev/null; do sleep 1; done'
+	pyfiglet -f puffy -w 160 "Building: oss"; \
+	docker build --network=host -t $(IMAGE_TAG)-ubi8:$(VERSION_TAG) -f $(ARTIFACTS_DIR)/Dockerfile-ubi8 data/logstash || \
 	  (docker kill $(HTTPD); false);
 	-docker kill $(HTTPD)
 
@@ -69,7 +79,7 @@ docker_paths:
 	mkdir -p $(ARTIFACTS_DIR)/docker/env2yaml
 	mkdir -p $(ARTIFACTS_DIR)/docker/pipeline
 
-public-dockerfiles: public-dockerfiles_oss public_dockerfiles_full
+public-dockerfiles: public-dockerfiles_oss public_dockerfiles_full public_dockerfiles_ubi8
 
 public-dockerfiles_full: venv templates/Dockerfile.j2 docker_paths $(COPY_FILES)
 	jinja2 \
@@ -96,6 +106,19 @@ public-dockerfiles_oss: venv templates/Dockerfile.j2 docker_paths $(COPY_FILES)
 	cd $(ARTIFACTS_DIR)/docker && \
 	cp $(ARTIFACTS_DIR)/Dockerfile-oss Dockerfile && \
 	tar -zcf ../logstash-oss-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile bin config env2yaml pipeline
+
+public-dockerfiles_ubi8: venv templates/Dockerfile.j2 docker_paths $(COPY_FILES)
+	jinja2 \
+	  -D created_date='$(DATE)' \
+	  -D elastic_version='$(ELASTIC_VERSION)' \
+	  -D version_tag='$(VERSION_TAG)' \
+	  -D image_flavor='ubi8' \
+	  -D local_artifacts='false' \
+	  -D release='$(RELEASE)' \
+	  templates/Dockerfile.j2 > $(ARTIFACTS_DIR)/Dockerfile-ubi8 && \
+	cd $(ARTIFACTS_DIR)/docker && \
+	cp $(ARTIFACTS_DIR)/Dockerfile-ubi8 Dockerfile && \
+	tar -zcf ../logstash-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile bin config env2yaml pipeline
 
 # Push the image to the dedicated push endpoint at "push.docker.elastic.co"
 push:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -54,7 +54,7 @@ build-from-local-ubi8-artifacts: venv dockerfile env2yaml
 	           -p 8000:8000 --expose=8000 -v $(ARTIFACTS_DIR):/mnt \
 	           python:3 bash -c 'cd /mnt && python3 -m http.server'
 	timeout 120 bash -c 'until curl -s localhost:8000 > /dev/null; do sleep 1; done'
-	pyfiglet -f puffy -w 160 "Building: oss"; \
+	pyfiglet -f puffy -w 160 "Building: ubi8"; \
 	docker build --network=host -t $(IMAGE_TAG)-ubi8:$(VERSION_TAG) -f $(ARTIFACTS_DIR)/Dockerfile-ubi8 data/logstash || \
 	  (docker kill $(HTTPD); false);
 	-docker kill $(HTTPD)

--- a/docker/templates/Dockerfile.j2
+++ b/docker/templates/Dockerfile.j2
@@ -13,13 +13,21 @@
   {% set license = 'Elastic License' -%}
 {% endif -%}
 
+{% if image_flavor == 'ubi8' -%}
+  {% set base_image = 'registry.access.redhat.com/ubi8/ubi-minimal' -%}
+  {% set package_manager = 'microdnf'  -%}
+{% else -%}
+  {% set base_image = 'centos:7'  -%}
+  {% set package_manager = 'yum' -%}
+{% endif -%}
 
-FROM centos:7
+FROM {{ base_image }}
 
 # Install Java and the "which" command, which is needed by Logstash's shell
 # scripts.
-RUN yum update -y && yum install -y java-11-openjdk-devel which && \
-    yum clean all
+# Minimal distributions also require findutils tar gzip (procps for integration tests)
+RUN {{ package_manager }} update -y && {{ package_manager }} install -y procps findutils tar gzip java-11-openjdk-devel which && \
+    {{ package_manager }} clean all
 
 # Provide a non-root user to run the process.
 RUN groupadd --gid 1000 logstash && \
@@ -45,13 +53,18 @@ ENV PATH=/usr/share/logstash/bin:$PATH
 # Provide a minimal configuration, so that simple invocations will provide
 # a good experience.
 ADD config/pipelines.yml config/pipelines.yml
-ADD config/logstash-{{ image_flavor }}.yml config/logstash.yml
+{% if image_flavor == 'oss' -%}
+ADD config/logstash-oss.yml config/logstash.yml
+{% else -%}
+ADD config/logstash-full.yml config/logstash.yml
+{% endif -%}
 ADD config/log4j2.properties config/
 ADD pipeline/default.conf pipeline/logstash.conf
 RUN chown --recursive logstash:root config/ pipeline/
 
 # Ensure Logstash gets a UTF-8 locale by default.
-ENV LANG='en_US.UTF-8' LC_ALL='en_US.UTF-8'
+# Minimal distributions do not ship with en language packs.
+ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'
 
 # Place the startup wrapper script.
 ADD bin/docker-entrypoint /usr/local/bin/

--- a/docker/templates/Dockerfile.j2
+++ b/docker/templates/Dockerfile.j2
@@ -16,9 +16,12 @@
 {% if image_flavor == 'ubi8' -%}
   {% set base_image = 'registry.access.redhat.com/ubi8/ubi-minimal' -%}
   {% set package_manager = 'microdnf'  -%}
+  # Minimal distributions do not ship with en language packs.
+  {% set locale = 'C.UTF-8' -%}
 {% else -%}
   {% set base_image = 'centos:7'  -%}
   {% set package_manager = 'yum' -%}
+  {% set locale = 'en_US.UTF-8' -%}
 {% endif -%}
 
 FROM {{ base_image }}
@@ -62,9 +65,8 @@ ADD config/log4j2.properties config/
 ADD pipeline/default.conf pipeline/logstash.conf
 RUN chown --recursive logstash:root config/ pipeline/
 
-# Ensure Logstash gets a UTF-8 locale by default.
-# Minimal distributions do not ship with en language packs.
-ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'
+# Ensure Logstash gets the correct locale by default.
+ENV LANG={{ locale }} LC_ALL={{ locale }}
 
 # Place the startup wrapper script.
 ADD bin/docker-entrypoint /usr/local/bin/

--- a/qa/docker/shared_examples/xpack.rb
+++ b/qa/docker/shared_examples/xpack.rb
@@ -1,0 +1,39 @@
+shared_examples_for 'a container with xpack features' do |flavor|
+  context 'when configuring xpack settings' do
+    before do
+      @image = find_image(flavor)
+      @container = start_container(@image, {'ENV' => env})
+    end
+
+    after do
+      cleanup_container(@container)
+    end
+
+    context 'when disabling xpack monitoring' do
+      let(:env) {['xpack.monitoring.enabled=false']}
+
+      it 'should set monitoring to false' do
+        expect(get_settings(@container)['xpack.monitoring.enabled']).to be_falsey
+      end
+    end
+
+    context 'when enabling xpack monitoring' do
+      let(:env) {['xpack.monitoring.enabled=true']}
+
+      it 'should set monitoring to true' do
+        expect(get_settings(@container)['xpack.monitoring.enabled']).to be_truthy
+      end
+    end
+
+    context 'when setting elasticsearch urls as an array' do
+      let(:env) { ['xpack.monitoring.elasticsearch.hosts=["http://node1:9200","http://node2:9200"]']}
+
+      it 'should set set the hosts property correctly' do
+        expect(get_settings(@container)['xpack.monitoring.elasticsearch.hosts']).to be_an(Array)
+        expect(get_settings(@container)['xpack.monitoring.elasticsearch.hosts']).to include('http://node1:9200')
+        expect(get_settings(@container)['xpack.monitoring.elasticsearch.hosts']).to include('http://node2:9200')
+      end
+    end
+  end
+end
+

--- a/qa/docker/spec/full/container_spec.rb
+++ b/qa/docker/spec/full/container_spec.rb
@@ -2,46 +2,11 @@ require_relative '../spec_helper'
 require_relative '../../shared_examples/container_config'
 require_relative '../../shared_examples/container_options'
 require_relative '../../shared_examples/container'
+require_relative '../../shared_examples/xpack'
 
 describe 'A container running the full image' do
   it_behaves_like 'the container is configured correctly', 'full'
   it_behaves_like 'it runs with different configurations', 'full'
   it_behaves_like 'it applies settings correctly', 'full'
-
-  context 'when configuring xpack settings' do
-    before do
-      @image = find_image('full')
-      @container = start_container(@image, {'ENV' => env})
-    end
-
-    after do
-      cleanup_container(@container)
-    end
-
-    context 'when disabling xpack monitoring' do
-      let(:env) {['xpack.monitoring.enabled=false']}
-
-      it 'should set monitoring to false' do
-        expect(get_settings(@container)['xpack.monitoring.enabled']).to be_falsey
-      end
-    end
-
-    context 'when enabling xpack monitoring' do
-      let(:env) {['xpack.monitoring.enabled=true']}
-
-      it 'should set monitoring to true' do
-        expect(get_settings(@container)['xpack.monitoring.enabled']).to be_truthy
-      end
-    end
-
-    context 'when setting elasticsearch urls as an array' do
-      let(:env) { ['xpack.monitoring.elasticsearch.hosts=["http://node1:9200","http://node2:9200"]']}
-
-      it 'should set set the hosts property correctly' do
-        expect(get_settings(@container)['xpack.monitoring.elasticsearch.hosts']).to be_an(Array)
-        expect(get_settings(@container)['xpack.monitoring.elasticsearch.hosts']).to include('http://node1:9200')
-        expect(get_settings(@container)['xpack.monitoring.elasticsearch.hosts']).to include('http://node2:9200')
-      end
-    end
-  end
+  it_behaves_like 'a container with xpack features', 'full'
 end

--- a/qa/docker/spec/ubi8/container_spec.rb
+++ b/qa/docker/spec/ubi8/container_spec.rb
@@ -1,0 +1,27 @@
+require_relative '../spec_helper'
+require_relative '../../shared_examples/container_config'
+require_relative '../../shared_examples/container_options'
+require_relative '../../shared_examples/container'
+require_relative '../../shared_examples/xpack'
+
+describe 'A container running the ubi8 image' do
+  it_behaves_like 'the container is configured correctly', 'ubi8'
+  it_behaves_like 'it runs with different configurations', 'ubi8'
+  it_behaves_like 'it applies settings correctly', 'ubi8'
+  it_behaves_like 'a container with xpack features', 'ubi8'
+
+  context 'The running container' do
+    before do
+      @image = find_image('ubi8')
+      @container = start_container(@image, {})
+    end
+
+    after do
+      cleanup_container(@container)
+    end
+
+    it 'should be based on Red Hat Enterprise Linux' do
+      expect(exec_in_container(@container, 'cat /etc/redhat-release').chomp).to match /Red Hat Enterprise Linux/
+    end
+  end
+end

--- a/qa/docker/spec/ubi8/image_spec.rb
+++ b/qa/docker/spec/ubi8/image_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../spec_helper'
+require_relative '../../shared_examples/image_metadata'
+
+describe 'An image with the full distribution' do
+  it_behaves_like 'the metadata is set correctly', 'ubi8'
+end


### PR DESCRIPTION
This commit adds the rake docker_ubi8 rake task, and associated
changes to the docker template and makefiles.

This commit also refactors the acceptance tests to extract xpack tests
into a helper class to allow the same tests to be used in both 'full'
and 'ubi8' docker image tests