### PR TITLE
Docker: Expose xpack.management.elasticsearch.proxy

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -256,6 +256,7 @@ pipeline.ordered: auto
 #xpack.monitoring.enabled: false
 #xpack.monitoring.elasticsearch.username: logstash_system
 #xpack.monitoring.elasticsearch.password: password
+#xpack.monitoring.elasticsearch.proxy: ["http://proxy:port"]
 #xpack.monitoring.elasticsearch.hosts: ["https://es1:9200", "https://es2:9200"]
 # an alternative to hosts + username/password settings is to use cloud_id/cloud_auth
 #xpack.monitoring.elasticsearch.cloud_id: monitoring_cluster_id:xxxxxxxxxx
@@ -278,6 +279,7 @@ pipeline.ordered: auto
 #xpack.management.pipeline.id: ["main", "apache_logs"]
 #xpack.management.elasticsearch.username: logstash_admin_user
 #xpack.management.elasticsearch.password: password
+#xpack.management.elasticsearch.proxy: ["http://proxy:port"]
 #xpack.management.elasticsearch.hosts: ["https://es1:9200", "https://es2:9200"]
 # an alternative to hosts + username/password settings is to use cloud_id/cloud_auth
 #xpack.management.elasticsearch.cloud_id: management_cluster_id:xxxxxxxxxx

--- a/docker/data/logstash/env2yaml/env2yaml.go
+++ b/docker/data/logstash/env2yaml/env2yaml.go
@@ -102,6 +102,7 @@ func normalizeSetting(setting string) (string, error) {
 		"xpack.management.elasticsearch.hosts",
 		"xpack.management.elasticsearch.username",
 		"xpack.management.elasticsearch.password",
+		"xpack.management.elasticsearch.proxy",
 		"xpack.management.elasticsearch.ssl.certificate_authority",
 		"xpack.management.elasticsearch.ssl.verification_mode",
 		"xpack.management.elasticsearch.ssl.truststore.path",


### PR DESCRIPTION
Follow up of #12151 

Additionally, fix .yml sample config to include proxy setting.