### PR TITLE
Doc:Add redirect from multiline filter to multiline codec

### DIFF
--- a/docs/static/redirects.asciidoc
+++ b/docs/static/redirects.asciidoc
@@ -3,3 +3,15 @@
 
 The following pages have moved or been deleted.
 
+[role="exclude",id="plugins-filters-multiline"]
+=== Multiline filter plugin
+
+The <<plugins-codecs-multiline,multiline codec plugin>> replaces the multiline
+filter plugin. The multiline codec is better equipped to handle multi-worker
+pipelines and threading.
+
+If you need to <fill-in-functionality-here>, {filebeat-ref}[Filebeat]
+is a better option. 
+
+
+

--- a/docs/static/redirects.asciidoc
+++ b/docs/static/redirects.asciidoc
@@ -10,8 +10,20 @@ The <<plugins-codecs-multiline,multiline codec plugin>> replaces the multiline
 filter plugin. The multiline codec is better equipped to handle multi-worker
 pipelines and threading.
 
-If you need to <fill-in-functionality-here>, {filebeat-ref}[Filebeat]
-is a better option. 
+Here's why. Multiline takes individual lines of text and groups them according
+to some criteria. 
+Accomplishing this operation in the filter stage is possible only if the
+pipeline has a single worker. Otherwise, chunks would end up in different
+workers, and the resulting composition would not make sense.
 
+The <<plugins-codecs-multiline,multiline codec plugin>> allows input plugins to
+create separate codec instances per “identity.” For example, each file or tcp
+connection can have its own codec instance.
 
+[role="exclude",id="alt-fb"]
+==== {filebeat} modules 
 
+If your use case involves reading files that contain multiline entries,
+{filebeat-ref}[{filebeat}] might be a better option.
+{filebeat} offers {filebeat-ref}/filebeat-modules.html[modules] for processing logs
+from many known apps, such as nginx or apache.


### PR DESCRIPTION
The functionality in the `multiline filter plugin` has been replaced by `multiline codec plugin` and/or Filebeat. The original page results in a 404.  This PR is intended to provide users with more helpful info and point them toward alternatives.  

**PREVIEW:**  https://logstash_12208.docs-preview.app.elstc.co/guide/en/logstash/master/plugins-filters-multiline.html

Note: The new page will be hidden, but available if a user clicks a link that targets the page that was removed. 