### PR TITLE
upgrade google-java-format library to 1.9

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -177,10 +177,7 @@ dependencies {
         api files(customJRubyDir + "/maven/jruby-complete/target/jruby-complete-${customJRubyVersion}.jar")
     }
     implementation group: 'com.google.guava', name: 'guava', version: '24.1.1-jre'
-    // WARNING: DO NOT UPGRADE "google-java-format"
-    // later versions require GPL licensed code in javac-shaded that is
-    // Apache2 incompatible
-    implementation('com.google.googlejavaformat:google-java-format:1.1') {
+    implementation('com.google.googlejavaformat:google-java-format:1.9') {
         exclude group: 'com.google.guava', module: 'guava'
     }
     implementation 'org.javassist:javassist:3.26.0-GA'


### PR DESCRIPTION
Fixes #11765

No user-facing change but simply an upgrade to latest 1.9 version which skips previous versions licensing conflicts.

