### PR TITLE
Fix to implement the blank? method that doesn't exists for String

### DIFF
--- a/logstash-core/lib/logstash/api/app_helpers.rb
+++ b/logstash-core/lib/logstash/api/app_helpers.rb
@@ -17,6 +17,7 @@
 
 require "logstash/json"
 require "logstash/api/errors"
+require "logstash/util"
 
 module LogStash::Api::AppHelpers
   # This method handle both of the normal flow *happy path*
@@ -60,10 +61,11 @@ module LogStash::Api::AppHelpers
 
   def as_boolean(string)
     return true   if string == true   || string =~ (/(true|t|yes|y|1)$/i)
-    return false  if string == false  || string.blank? || string =~ (/(false|f|no|n|0)$/i)
+    return false  if string == false  || LogStash::Util.blank?(string) || string =~ (/(false|f|no|n|0)$/i)
     raise ArgumentError.new("invalid value for Boolean: \"#{string}\"")
   end
 
+  protected
   def default_metadata
     @factory.build(:default_metadata).all
   end

--- a/logstash-core/lib/logstash/util.rb
+++ b/logstash-core/lib/logstash/util.rb
@@ -219,4 +219,20 @@ module LogStash::Util
       Marshal.load(Marshal.dump(o))
     end
   end
+
+  # Returns true if the object is considered blank.
+  # A blank includes things like '', '   ', nil,
+  # and arrays and hashes that have nothing in them.
+  #
+  # This logic is mostly shared with ActiveSupport's blank?
+  def self.blank?(value)
+    if value.kind_of?(NilClass)
+      true
+    elsif value.kind_of?(String)
+      value !~ /\S/
+    else
+      value.respond_to?(:empty?) ? value.empty? : !value
+    end
+  end
+
 end # module LogStash::Util

--- a/qa/integration/specs/reload_config_spec.rb
+++ b/qa/integration/specs/reload_config_spec.rb
@@ -22,6 +22,7 @@ require_relative '../framework/helpers'
 require "logstash/devutils/rspec/spec_helper"
 require "socket"
 require "json"
+require "logstash/util"
 
 describe "Test Logstash service when config reload is enabled" do
   before(:all) {
@@ -71,7 +72,7 @@ describe "Test Logstash service when config reload is enabled" do
     
     send_data(reload_port, sample_data)
     Stud.try(retry_attempts.times, RSpec::Expectations::ExpectationNotMetError) do
-      expect(IO.read(output_file2).blank?).to be false
+      expect(LogStash::Util.blank?(IO.read(output_file2))).to be false
     end
     
     # check instance metrics. It should not be reset
@@ -89,7 +90,7 @@ describe "Test Logstash service when config reload is enabled" do
     instance_reload_stats = logstash_service.monitoring_api.node_stats["reloads"]
     expect(pipeline_reload_stats["successes"]).to eq(1)
     expect(pipeline_reload_stats["failures"]).to eq(0)
-    expect(pipeline_reload_stats["last_success_timestamp"].blank?).to be false
+    expect(LogStash::Util.blank?(pipeline_reload_stats["last_success_timestamp"])).to be false
     expect(pipeline_reload_stats["last_error"]).to eq(nil)
     
     expect(instance_reload_stats["successes"]).to eq(1)


### PR DESCRIPTION
Fix to implement the blank? method that doesn't exists for String, is added by Rails framework