### PR TITLE
[7.9 backport]  Fix keystore thread safety (#12233)

### DIFF
--- a/logstash-core/src/main/java/org/logstash/secret/store/backend/JavaKeyStore.java
+++ b/logstash-core/src/main/java/org/logstash/secret/store/backend/JavaKeyStore.java
@@ -47,8 +47,7 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.util.*;
 import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static org.logstash.secret.store.SecretStoreFactory.LOGSTASH_MARKER;
 
@@ -66,9 +65,8 @@ public final class JavaKeyStore implements SecretStore {
     private char[] keyStorePass;
     private Path keyStorePath;
     private ProtectionParameter protectionParameter;
-    private Lock readLock;
+    private Lock lock;
     private boolean useDefaultPass = false;
-    private Lock writeLock;
     //package private for testing
     static String filePermissions = "rw-r--r--";
     private static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
@@ -89,7 +87,7 @@ public final class JavaKeyStore implements SecretStore {
         }
         try {
             init(config);
-            writeLock.lock();
+            lock.lock();
             LOGGER.debug("Creating new keystore at {}.", keyStorePath.toAbsolutePath());
             String keyStorePermissions = filePermissions;
             //create the keystore on disk with a default entry to identify this as a logstash keystore
@@ -120,7 +118,7 @@ public final class JavaKeyStore implements SecretStore {
         } catch (Exception e) { //should never happen
             throw new SecretStoreException.UnknownException("Error while trying to create the Logstash keystore. ", e);
         } finally {
-            releaseLock(writeLock);
+            releaseLock(lock);
             config.clearValues();
         }
     }
@@ -129,7 +127,7 @@ public final class JavaKeyStore implements SecretStore {
     public void delete(SecureConfig config) {
         try {
             initLocks();
-            writeLock.lock();
+            lock.lock();
             if (exists(config)) {
                 Files.delete(Paths.get(new String(config.getPlainText(PATH_KEY))));
             }
@@ -138,7 +136,7 @@ public final class JavaKeyStore implements SecretStore {
         } catch (Exception e) { //should never happen
             throw new SecretStoreException.UnknownException("Error while trying to delete the Logstash keystore", e);
         } finally {
-            releaseLock(writeLock);
+            releaseLock(lock);
             config.clearValues();
         }
     }
@@ -234,16 +232,14 @@ public final class JavaKeyStore implements SecretStore {
     }
 
     private void initLocks(){
-        ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
-        readLock = readWriteLock.readLock();
-        writeLock = readWriteLock.writeLock();
+        lock = new ReentrantLock();
     }
 
     @Override
     public Collection<SecretIdentifier> list() {
         Set<SecretIdentifier> identifiers = new HashSet<>();
         try {
-            readLock.lock();
+            lock.lock();
             loadKeyStore();
             Enumeration<String> aliases = keyStore.aliases();
             while (aliases.hasMoreElements()) {
@@ -253,7 +249,7 @@ public final class JavaKeyStore implements SecretStore {
         } catch (Exception e) {
             throw new SecretStoreException.ListException(e);
         } finally {
-            releaseLock(readLock);
+            releaseLock(lock);
         }
         return identifiers;
     }
@@ -275,7 +271,7 @@ public final class JavaKeyStore implements SecretStore {
         }
         try {
             init(config);
-            readLock.lock();
+            lock.lock();
             try (final InputStream is = Files.newInputStream(keyStorePath)) {
                 try {
                     keyStore.load(is, this.keyStorePass);
@@ -302,7 +298,7 @@ public final class JavaKeyStore implements SecretStore {
         } catch (Exception e) { //should never happen
             throw new SecretStoreException.UnknownException("Error while trying to load the Logstash keystore", e);
         } finally {
-            releaseLock(readLock);
+            releaseLock(lock);
             config.clearValues();
         }
     }
@@ -319,7 +315,7 @@ public final class JavaKeyStore implements SecretStore {
     @Override
     public void persistSecret(SecretIdentifier identifier, byte[] secret) {
         try {
-            writeLock.lock();
+            lock.lock();
             loadKeyStore();
             SecretKeyFactory factory = SecretKeyFactory.getInstance("PBE");
             //PBEKey requires an ascii password, so base64 encode it
@@ -337,14 +333,14 @@ public final class JavaKeyStore implements SecretStore {
         } catch (Exception e) {
             throw new SecretStoreException.PersistException(identifier, e);
         } finally {
-            releaseLock(writeLock);
+            releaseLock(lock);
         }
     }
 
     @Override
     public void purgeSecret(SecretIdentifier identifier) {
         try {
-            writeLock.lock();
+            lock.lock();
             loadKeyStore();
             keyStore.deleteEntry(identifier.toExternalForm());
             saveKeyStore();
@@ -352,7 +348,7 @@ public final class JavaKeyStore implements SecretStore {
         } catch (Exception e) {
             throw new SecretStoreException.PurgeException(identifier, e);
         } finally {
-            releaseLock(writeLock);
+            releaseLock(lock);
         }
     }
 
@@ -366,7 +362,7 @@ public final class JavaKeyStore implements SecretStore {
     public byte[] retrieveSecret(SecretIdentifier identifier) {
         if (identifier != null && identifier.getKey() != null && !identifier.getKey().isEmpty()) {
             try {
-                readLock.lock();
+                lock.lock();
                 loadKeyStore();
                 SecretKeyFactory factory = SecretKeyFactory.getInstance("PBE");
                 KeyStore.SecretKeyEntry secretKeyEntry = (KeyStore.SecretKeyEntry) keyStore.getEntry(identifier.toExternalForm(), protectionParameter);
@@ -385,7 +381,7 @@ public final class JavaKeyStore implements SecretStore {
             } catch (Exception e) {
                 throw new SecretStoreException.RetrievalException(identifier, e);
             } finally {
-                releaseLock(readLock);
+                releaseLock(lock);
             }
         }
         return null;

--- a/logstash-core/src/test/java/org/logstash/secret/store/backend/JavaKeyStoreTest.java
+++ b/logstash-core/src/test/java/org/logstash/secret/store/backend/JavaKeyStoreTest.java
@@ -46,15 +46,18 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static java.nio.file.attribute.PosixFilePermission.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
-import static org.hamcrest.CoreMatchers.isA;
 import static org.logstash.secret.store.SecretStoreFactory.LOGSTASH_MARKER;
 
 /**
@@ -688,5 +691,32 @@ public class JavaKeyStoreTest {
         thrown.expect(SecretStoreException.AccessException.class);
         withDefinedPassConfig.add(SecretStoreFactory.KEYSTORE_ACCESS_KEY, "wrongpassword".toCharArray());
         new JavaKeyStore().load(withDefinedPassConfig);
+    }
+
+    @Test(timeout = 40_000)
+    public void concurrentReadTest() throws Exception {
+
+        final int KEYSTORE_COUNT = 250;
+
+        final ExecutorService executorService = Executors.newFixedThreadPool(KEYSTORE_COUNT);
+        String password = "pAssW3rd!";
+        keyStore.persistSecret(new SecretIdentifier("password"), password.getBytes(StandardCharsets.UTF_8));
+        try{
+            Callable<byte[]> reader = () -> keyStore.retrieveSecret(new SecretIdentifier("password"));
+
+            List<Future<byte[]>> futures = new ArrayList<>();
+            for (int i = 0; i < KEYSTORE_COUNT; i++) {
+                futures.add(executorService.submit(reader));
+            }
+
+            for (Future<byte[]> future : futures) {
+                byte[] result = future.get();
+                assertThat(result).isNotNull();
+                assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo(password);
+            }
+        } finally {
+            executorService.shutdownNow();
+            executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+        }
     }
 }


### PR DESCRIPTION
Clean backport of #12233

This commit is intended to fix thread safety issues with the  JavaKeystore implementation of the secret store.
From reading the code, it appears that thread safety for the keystore was intended to be provided by
a ReentrantReadWriteLock, a read lock for accessing secrets from the keystore, and a write lock for updating
secrets in the keystore.

In practice, this was insufficient, the act of accessing a secret from the keystore involved the mutation of
a shared keyStore object - the keyStore is `load`ed every time a secret is retrieved from the store.

Previous to https://github.com/elastic/logstash/pull/10794, this did not matter, each pipeline held its
own instance of the secret store, effectively meaning that only a single thread would ever access a key
store at any one time. This PR moved to using a shared keystore instance for substitution variables,
exposing the lack of thread safety in the JavaKeystore class.

This commit is intended to be the simplest change to fix the underlying issue, and does not address whether
we *need* to reload the secrets every time they are read.

Relates #12229