### PR TITLE
[6.8 backport] Fix keystore thread safety (#12233)

### DIFF
--- a/logstash-core/src/test/java/org/logstash/secret/store/backend/JavaKeyStoreTest.java
+++ b/logstash-core/src/test/java/org/logstash/secret/store/backend/JavaKeyStoreTest.java
@@ -26,15 +26,18 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static java.nio.file.attribute.PosixFilePermission.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
-import static org.hamcrest.CoreMatchers.isA;
 import static org.logstash.secret.store.SecretStoreFactory.LOGSTASH_MARKER;
 
 /**
@@ -668,5 +671,32 @@ public class JavaKeyStoreTest {
         thrown.expect(SecretStoreException.AccessException.class);
         withDefinedPassConfig.add(SecretStoreFactory.KEYSTORE_ACCESS_KEY, "wrongpassword".toCharArray());
         new JavaKeyStore().load(withDefinedPassConfig);
+    }
+
+    @Test(timeout = 40_000)
+    public void concurrentReadTest() throws Exception {
+
+        final int KEYSTORE_COUNT = 250;
+
+        final ExecutorService executorService = Executors.newFixedThreadPool(KEYSTORE_COUNT);
+        String password = "pAssW3rd!";
+        keyStore.persistSecret(new SecretIdentifier("password"), password.getBytes(StandardCharsets.UTF_8));
+        try{
+            Callable<byte[]> reader = () -> keyStore.retrieveSecret(new SecretIdentifier("password"));
+
+            List<Future<byte[]>> futures = new ArrayList<>();
+            for (int i = 0; i < KEYSTORE_COUNT; i++) {
+                futures.add(executorService.submit(reader));
+            }
+
+            for (Future<byte[]> future : futures) {
+                byte[] result = future.get();
+                assertThat(result).isNotNull();
+                assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo(password);
+            }
+        } finally {
+            executorService.shutdownNow();
+            executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+        }
     }
 }


### PR DESCRIPTION
Clean backport of #12233

This commit is intended to fix thread safety issues with the  JavaKeystore implementation of the secret store.
From reading the code, it appears that thread safety for the keystore was intended to be provided by
a ReentrantReadWriteLock, a read lock for accessing secrets from the keystore, and a write lock for updating
secrets in the keystore.

In practice, this was insufficient, the act of accessing a secret from the keystore involved the mutation of
a shared keyStore object - the keyStore is `load`ed every time a secret is retrieved from the store.

Previous to https://github.com/elastic/logstash/pull/10794, this did not matter, each pipeline held its
own instance of the secret store, effectively meaning that only a single thread would ever access a key
store at any one time. This PR moved to using a shared keystore instance for substitution variables,
exposing the lack of thread safety in the JavaKeystore class.

This commit is intended to be the simplest change to fix the underlying issue, and does not address whether
we *need* to reload the secrets every time they are read.

Relates #12229