### PR TITLE
[7x backport]Fix docker image certification

### DIFF
--- a/docker/templates/Dockerfile.j2
+++ b/docker/templates/Dockerfile.j2
@@ -45,8 +45,12 @@ RUN curl -Lo - {{ url_root }}/{{ tarball }} | \
     chown --recursive logstash:logstash /usr/share/logstash/ && \
     chown -R logstash:root /usr/share/logstash && \
     chmod -R g=u /usr/share/logstash && \
+    mkdir /licenses/ && \
+    mv /usr/share/logstash/NOTICE.TXT /licenses/NOTICE.TXT && \
+    mv /usr/share/logstash/LICENSE.txt /licenses/LICENSE.txt && \
     find /usr/share/logstash -type d -exec chmod g+s {} \; && \
     ln -s /usr/share/logstash /opt/logstash
+
 
 WORKDIR /usr/share/logstash
 
@@ -92,7 +96,12 @@ LABEL  org.label-schema.schema-version="1.0" \
   org.label-schema.license="{{ license }}" \
   org.opencontainers.image.licenses="{{ license }}" \
   org.label-schema.build-date={{ created_date }} \
-  org.opencontainers.image.created={{ created_date }}
+  org.opencontainers.image.created={{ created_date }} \
+  description="Logstash is a free and open server-side data processing pipeline that ingests data from a multitude of sources, transforms it, and then sends it to your favorite 'stash.'" \
+  name="logstash" \
+  maintainer="info@elastic.co" \
+  summary="Logstash is a free and open server-side data processing pipeline that ingests data from a multitude of sources, transforms it, and then sends it to your favorite 'stash.'" \
+  vendor="Elastic"
 
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]

--- a/qa/docker/shared_examples/container.rb
+++ b/qa/docker/shared_examples/container.rb
@@ -22,7 +22,11 @@ shared_examples_for 'the container is configured correctly' do |flavor|
 
   context 'container files' do
     it 'should have the correct license agreement' do
-      expect(exec_in_container(@container, 'cat /usr/share/logstash/LICENSE.txt')).to have_correct_license_agreement(flavor)
+      expect(exec_in_container(@container, 'cat /licenses/LICENSE.txt')).to have_correct_license_agreement(flavor)
+    end
+
+    it 'should have the license notices file' do
+      expect(exec_in_container(@container, 'cat /licenses/NOTICE.TXT')).to match /Notice for/
     end
 
     it 'should have the correct user' do

--- a/qa/docker/shared_examples/image_metadata.rb
+++ b/qa/docker/shared_examples/image_metadata.rb
@@ -19,13 +19,25 @@ shared_examples_for 'the metadata is set correctly' do |flavor|
     end
   end
 
-  %w(org.label-schema.name org.opencontainers.image.title).each do |label|
+  %w(name org.label-schema.name org.opencontainers.image.title).each do |label|
     it "should set the name label #{label} correctly" do
       expect(@labels[label]).to eql "logstash"
     end
   end
 
-  %w(org.opencontainers.image.vendor).each do |label|
+  %w(maintainer).each do |label|
+    it "should set the name label #{label} correctly" do
+      expect(@labels[label]).to eql "info@elastic.co"
+    end
+  end
+
+  %w(description summary).each do |label|
+    it "should set the name label #{label} correctly" do
+      expect(@labels[label]).to eql "Logstash is a free and open server-side data processing pipeline that ingests data from a multitude of sources, transforms it, and then sends it to your favorite 'stash.'"
+    end
+  end
+
+  %w(vendor org.opencontainers.image.vendor).each do |label|
     it "should set the vendor label #{label} correctly" do
       expect(@labels[label]).to eql "Elastic"
     end


### PR DESCRIPTION
Clean backport of #12242

This commit includes the required changes to pass RedHat docker image certification.
This includes:
 Moving license files to /licenses folder
 Adding required base labels for name, description, vendor and summary

Relates: https://github.com/elastic/dev/issues/1287