### PR TITLE
Added elastic-app-search and jwt license definition and notices

### DIFF
--- a/tools/dependencies-report/src/main/resources/licenseMapping.csv
+++ b/tools/dependencies-report/src/main/resources/licenseMapping.csv
@@ -37,6 +37,7 @@ dependency,dependencyUrl,licenseOverride
 "domain_name:",https://github.com/knu/ruby-domain_name,BSD-2-Clause
 "dotenv:",https://github.com/bkeepers/dotenv,MIT
 "edn:",https://github.com/relevance/edn-ruby,MIT
+"elastic-app-search:",https://github.com/elastic/app-search-ruby,Apache-2.0
 "elasticsearch-api:",https://github.com/elastic/elasticsearch-ruby,Apache-2.0
 "elasticsearch-transport:",https://github.com/elastic/elasticsearch-ruby,Apache-2.0
 "elasticsearch:",https://github.com/elastic/elasticsearch-ruby,Apache-2.0
@@ -64,6 +65,7 @@ dependency,dependencyUrl,licenseOverride
 "jruby-jms:",https://github.com/reidmorrison/jruby-jms,Apache-2.0
 "jruby-openssl:","https://github.com/jruby/jruby-openssl/",EPL-1.0
 "jruby-stdin-channel:","https://github.com/colinsurprenant/jruby-stdin-channel",Apache-2.0
+"jwt:",https://github.com/jwt/ruby-jwt,MIT
 "json:",http://json-jruby.rubyforge.org/,Ruby
 "lru_redux:","https://github.com/SamSaffron/lru_redux/",MIT
 "mail:","https://github.com/mikel/mail/",MIT

--- a/tools/dependencies-report/src/main/resources/notices/elastic-app-search-NOTICE.txt
+++ b/tools/dependencies-report/src/main/resources/notices/elastic-app-search-NOTICE.txt
@@ -1,0 +1,5 @@
+source: https://github.com/elastic/app-search-ruby/blob/v7.8.0/NOTICE.txt
+
+Elastic App Search Ruby client.
+
+Copyright 2012-2019 Elasticsearch B.V.

--- a/tools/dependencies-report/src/main/resources/notices/jwt-NOTICE.txt
+++ b/tools/dependencies-report/src/main/resources/notices/jwt-NOTICE.txt
@@ -1,0 +1,9 @@
+source: https://github.com/jwt/ruby-jwt/blob/v2.2.2/LICENSE
+
+Copyright (c) 2011 Jeff Lindsay
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Fixed license after logstash-output-elastic_app_search plugin switched from Java library to Ruby