### PR TITLE
Fix/jmh perf writer test

### DIFF
--- a/logstash-core/benchmarks/build.gradle
+++ b/logstash-core/benchmarks/build.gradle
@@ -62,6 +62,7 @@ dependencies {
   implementation 'commons-io:commons-io:2.5'
   runtimeOnly 'joda-time:joda-time:2.8.2'
   api "org.jruby:jruby-core:$jrubyVersion"
+  testImplementation 'junit:junit:4.12'
 }
 
 javadoc {

--- a/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/QueueWriteBenchmark.java
+++ b/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/QueueWriteBenchmark.java
@@ -23,6 +23,10 @@ package org.logstash.benchmark;
 import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.logstash.Event;
@@ -30,6 +34,7 @@ import org.logstash.Timestamp;
 import org.logstash.ackedqueue.Queue;
 import org.logstash.ackedqueue.Settings;
 import org.logstash.ackedqueue.SettingsImpl;
+import org.logstash.benchmark.singlewriterqueue.AppendOnlyQueue;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -59,8 +64,12 @@ public class QueueWriteBenchmark {
 
     private String path;
 
+    private AppendOnlyQueue baselineQueue;
+    private Path baselineQueueDirectory;
+    private byte[] data;
+
     @Setup
-    public void setUp() throws IOException {
+    public void setUp() throws IOException, NoSuchAlgorithmException {
         final Settings settings = settings();
         EVENT.setField("Foo", "Bar");
         EVENT.setField("Foo1", "Bar1");
@@ -70,12 +79,45 @@ public class QueueWriteBenchmark {
         path = settings.getDirPath();
         queue = new Queue(settings);
         queue.open();
+
+        setupBaselineQueue();
+    }
+
+    private void setupBaselineQueue() throws IOException, NoSuchAlgorithmException {
+        final Path queuePath = FileSystems.getDefault().getPath("/tmp/queue");
+        if (queuePath.toFile().exists()) {
+            baselineQueueDirectory = queuePath;
+        } else {
+            baselineQueueDirectory = java.nio.file.Files.createDirectory(queuePath);
+        }
+        baselineQueue = new AppendOnlyQueue(baselineQueueDirectory.toString());
+        data = generateRandomData(1024);
+    }
+
+    private static byte[] generateRandomData(int size) throws NoSuchAlgorithmException {
+        final SecureRandom random = SecureRandom.getInstance("SHA1PRNG");
+        final byte[] res = new byte[size];
+        random.nextBytes(res);
+        return res;
     }
 
     @TearDown
     public void tearDown() throws IOException {
         queue.close();
         FileUtils.deleteDirectory(new File(path));
+
+        baselineQueue.close();
+        FileUtils.deleteDirectory(baselineQueueDirectory.toFile());
+//        java.nio.file.Files.list(baselineQueueDirectory).forEach(p -> p.toFile().delete());
+//        baselineQueueDirectory.toFile().delete();
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(EVENTS_PER_INVOCATION)
+    public void baseline() throws IOException {
+        for (int i = 0; i < EVENTS_PER_INVOCATION; i++) {
+            baselineQueue.write(data);
+        }
     }
 
     @Benchmark
@@ -91,7 +133,7 @@ public class QueueWriteBenchmark {
     private static Settings settings() {
         return SettingsImpl.fileSettingsBuilder(Files.createTempDir().getPath())
             .capacity(256 * 1024 * 1024)
-            .queueMaxBytes(Long.MAX_VALUE)
+            .queueMaxBytes(EVENTS_PER_INVOCATION * 1024 * 15)
             .checkpointMaxWrites(1024)
             .checkpointMaxAcks(1024)
             .elementClass(Event.class).build();

--- a/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/singlewriterqueue/AppendOnlyQueue.java
+++ b/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/singlewriterqueue/AppendOnlyQueue.java
@@ -1,0 +1,57 @@
+package org.logstash.benchmark.singlewriterqueue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+
+/**
+ * Not thread-safe, it thought to measure single thread writing segmented (64Mb) files on disk
+ */
+public class AppendOnlyQueue {
+
+    private final Path dirPath;
+    private File head;
+    int headBytes = 0;
+    int pageNum = 0;
+    static final long PAGE_SIZE = 64 * 1024 * 1024;
+    private MappedByteBuffer buffer;
+
+    public AppendOnlyQueue(String path) throws IOException {
+        this.dirPath = FileSystems.getDefault().getPath(path);
+        this.head = dirPath.resolve("page." + pageNum).toFile();
+        mapFile();
+    }
+
+    // NB data is supposed to be 1/2/4/8 Kb
+    public void write(byte[] data) throws IOException {
+        if (headBytes < PAGE_SIZE) {
+            buffer.put(data);
+            headBytes += data.length;
+        } else {
+            this.buffer.force(); //TODO unclean like in Logstash?
+            pageNum ++;
+            this.head = dirPath.resolve("page." + pageNum).toFile();
+            mapFile();
+            buffer.put(data);
+            headBytes = data.length;
+//            System.out.println("switched page file counter to: " + pageNum);
+        }
+    }
+
+    // memory map data file to this.buffer and read initial version byte
+    private void mapFile() throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(this.head, "rw")) {
+            this.buffer = raf.getChannel().map(FileChannel.MapMode.READ_WRITE, 0, PAGE_SIZE);
+        }
+        this.buffer.load();
+        this.buffer.position(0);
+    }
+
+    public void close() {
+        this.buffer.force();
+    }
+}

--- a/logstash-core/benchmarks/src/test/java/org/logstash/benchmark/singlewriterqueue/AppendOnlyQueueTest.java
+++ b/logstash-core/benchmarks/src/test/java/org/logstash/benchmark/singlewriterqueue/AppendOnlyQueueTest.java
@@ -1,0 +1,88 @@
+package org.logstash.benchmark.singlewriterqueue;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+import static org.junit.Assert.*;
+
+class AppendOnlyQueueTest {
+
+    private static byte[] sampleRandomData;
+    private AppendOnlyQueue sut;
+    private static Path queuePath;
+
+    @BeforeClass
+    public static void beforeAll() throws NoSuchAlgorithmException {
+        sampleRandomData = generateRandom(1024);
+        queuePath = FileSystems.getDefault().getPath("/tmp/queue");
+    }
+
+    @Before
+    public void setUp() throws IOException {
+        sut = new AppendOnlyQueue("/tmp/queue");
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        sut.close();
+        FileUtils.deleteDirectory(queuePath.toFile());
+    }
+
+    @Test
+    public void testSimpleWriteOnEmptyPage() throws IOException, NoSuchAlgorithmException {
+        sut.write(sampleRandomData);
+
+        assertEquals(0, sut.pageNum);
+        assertEquals(1024, sut.headBytes);
+    }
+
+    private static byte[] generateRandom(int size) throws NoSuchAlgorithmException {
+        final SecureRandom random = SecureRandom.getInstance("SHA1PRNG");
+        final byte[] res = new byte[size];
+        random.nextBytes(res);
+        return res;
+    }
+
+    @Test
+    public void testWriteOnPageEdge() throws IOException {
+        // almost fill the page
+        int loops = (int) (AppendOnlyQueue.PAGE_SIZE / 1024 - 1);
+        for (int i = 0; i < loops; i++) {
+            sut.write(sampleRandomData);
+        }
+
+        // exercise
+        sut.write(sampleRandomData);
+
+        assertEquals(0, sut.pageNum);
+        assertEquals(AppendOnlyQueue.PAGE_SIZE, sut.headBytes);
+    }
+
+    @Test
+    public void testWriteOnSecondPageWhenHeadIsFull() throws IOException {
+        // almost fill the page
+        int loops = (int) (AppendOnlyQueue.PAGE_SIZE / 1024);
+        for (int i = 0; i < loops; i++) {
+            sut.write(sampleRandomData);
+        }
+
+        // exercise
+        sut.write(sampleRandomData);
+
+        assertEquals(1, sut.pageNum);
+        assertEquals(1024, sut.headBytes);
+        final long numPageFiles = Files.list(queuePath).count();
+        assertEquals(2, numPageFiles);
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Page.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Page.java
@@ -34,13 +34,13 @@ public final class Page implements Closeable {
     protected int elementCount;
     protected long firstUnreadSeqNum;
     protected final Queue queue;
-    protected PageIO pageIO;
+    protected final PageIO pageIO;
     private boolean writable;
 
     // bit 0 is minSeqNum
     // TODO: go steal LocalCheckpointService in feature/seq_no from ES
     // TODO: https://github.com/elastic/elasticsearch/blob/feature/seq_no/core/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointService.java
-    protected BitSet ackedSeqNums;
+    protected final BitSet ackedSeqNums;
     protected Checkpoint lastCheckpoint;
 
     public Page(int pageNum, Queue queue, long minSeqNum, int elementCount, long firstUnreadSeqNum, BitSet ackedSeqNums, @NotNull PageIO pageIO, boolean writable) {


### PR DESCRIPTION
This PR contains some minor fix, like adding `final` to a couple of `Page`'s attributes and setting `max_bytes` to a value `Long.MAX_VALUE`.

The other part, is related to have a baselines for this test. The baseline is a queue implementation that's not thread safe, and simply write raw data of `1024` multiples chucks.

The results on my machine exposes:
```
Benchmark                                  Mode  Cnt    Score    Error   Units
QueueWriteBenchmark.baseline              thrpt   10  782.830 ± 80.119  ops/ms
QueueWriteBenchmark.pushToPersistedQueue  thrpt   10  108.965 ±  0.730  ops/ms
``` 

and helps contextualize the raw numbers of `pushToPersistedQueue`