### PR TITLE
Doc:Restructure troubleshooting docs and add plugin tracing

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -222,7 +222,7 @@ include::static/best-practice.asciidoc[]
 include::static/config-details.asciidoc[]
 
 :edit_url!:
-include::static/troubleshooting.asciidoc[]
+include::static/troubleshoot/troubleshooting.asciidoc[]
 
 :edit_url:
 

--- a/docs/static/troubleshoot/plugin-tracing.asciidoc
+++ b/docs/static/troubleshoot/plugin-tracing.asciidoc
@@ -2,3 +2,95 @@
 [[ts-plugin-tracing]] 
 ==== Plugin tracing
 
+When you troubleshoot {ls} deployments, you might check the node stats API to
+look for plugins that are taking too long to process data, dropping data, or
+never received the data in the first place. After you identify a plugin whose
+metrics indicate a potential issue, it's time to identify which plugin this
+is, and where it is declared in the configuration files. 
+
+While you can define an "id" for each plugin to facilitate this discovery,
+naming each plugin is not practical, especially for very large pipelines
+containing hundreds of plugins. 
+
+You can use the information from the Logstash APIs to fetch link an auto
+generated ID of a plugin to its declaration (starting with 7.6.0).
+
+Here's how:
+
+. <<browse-stats>>
+. <<find-declaration>>
+. <<lookup-def>>
+
+[discrete]
+[[browse-stats]]
+===== Browse stats API and find a plugin you want to investigate
+
+Example: "Give me any filter whose in/out events counters don't match"
+
+[source,shell]
+-----
+❯ curl -s localhost:9600/_node/stats | jq '.pipelines.main.plugins.filters[] | select(.events.in!=.events.out)'
+-----
+
+[source,json]
+-----
+{
+  "id": "75afda0f03a5af46279c4cba9408ca87664b9c988bf477e2a2cca535e59e856f",
+  "events": {
+    "in": 1,
+    "out": 0,
+    "duration_in_millis": 5
+  },
+  "name": "drop"
+}
+-----
+
+[discrete]
+[[find-declaration]]
+===== Find the plugin declaration in the pipeline graph
+
+Take the id from step 1 and use it to find the plugin in the pipeline graph:
+
+[source,shell]
+-----
+❯ curl -s localhost:9600/_node/pipelines?graph=true | jq '.pipelines.main.graph.graph.vertices[] | select(.id=="75afda0f03a5af46279c4cba9408ca87664b9c988bf477e2a2cca535e59e856f")'
+-----
+
+[source,json]
+-----
+{
+  "config_name": "drop",
+  "plugin_type": "filter",
+  "meta": {
+    "source": {
+      "protocol": "file",
+      "id": "/private/tmp/logstash-7.9.1/cfg",
+      "line": 10,
+      "column": 5
+    }
+  },
+  "id": "75afda0f03a5af46279c4cba9408ca87664b9c988bf477e2a2cca535e59e856f",
+  "explicit_id": false,
+  "type": "plugin"
+}
+-----
+
+[discrete]
+[[lookup-def]]
+===== Lookup the plugin's definition in the source files
+
+Here's a simple script to do the lookup.
+
+[source,shell]
+-----
+❯ cat /private/tmp/logstash-7.9.1/cfg |  ruby -e 'line = 10; $stdin.read.split("\n").each_with_index {|l, i| puts "#{i+1}: #{l}" if (i+1).between?(line-1, line + 5) }'
+9:   } else if [message] == "d" {
+10:     drop {}
+11:   } else if [message] == "e" {
+12:     drop {}
+13:   } else if [message] == "f" {
+14:     drop {}
+15:   } else if [message] == "g" {
+-----
+
+Or, you can open the file and go to the line.

--- a/docs/static/troubleshoot/plugin-tracing.asciidoc
+++ b/docs/static/troubleshoot/plugin-tracing.asciidoc
@@ -1,0 +1,4 @@
+[discrete]
+[[ts-plugin-tracing]] 
+==== Plugin tracing
+

--- a/docs/static/troubleshoot/troubleshooting.asciidoc
+++ b/docs/static/troubleshoot/troubleshooting.asciidoc
@@ -1,0 +1,30 @@
+[[troubleshooting]] 
+== Troubleshooting 
+
+If you have issues installing or running {ls}, check out these sections:
+
+* <<ts-logstash>>
+* <<ts-plugins-general>>
+* <<ts-plugins>>
+
+We are adding more troubleshooting tips, so please check back soon.
+
+[discrete]
+[[add-tips]]
+=== Contribute tips
+If you have something to add, please:
+
+* create an issue at
+https://github.com/elastic/logstash/issues, or
+* create a pull request with your proposed changes at https://github.com/elastic/logstash.
+
+[discrete]
+[[discuss]]
+=== Discussion forums
+Also check out the https://discuss.elastic.co/c/logstash[Logstash discussion
+forum].
+
+include::ts-logstash.asciidoc[]
+include::ts-plugins-general.asciidoc[]
+include::ts-plugins.asciidoc[]
+include::ts-other-issues.asciidoc[]

--- a/docs/static/troubleshoot/ts-kafka.asciidoc
+++ b/docs/static/troubleshoot/ts-kafka.asciidoc
@@ -1,192 +1,9 @@
-[[troubleshooting]] 
-== Troubleshooting Common Problems
-
-We are adding more troubleshooting tips, so please check back soon. If you
-have something to add, please:
-
-* create an issue at
-https://github.com/elastic/logstash/issues, or
-* create a pull request with your proposed changes at https://github.com/elastic/logstash.
-
-Also check out the https://discuss.elastic.co/c/logstash[Logstash discussion
-forum].
-
-
-[float] 
-[[ts-install]] 
-== Installation and setup
-
-
-[float] 
-[[ts-temp-dir]] 
-=== Inaccessible temp directory
-
-Certain versions of the JRuby runtime and libraries
-in certain plugins (the Netty network library in the TCP input, for example) copy
-executable files to the temp directory. This situation causes subsequent failures when
-`/tmp` is mounted `noexec`. 
-
-*Sample error*
-
-[source,sh]
------
-[2018-03-25T12:23:01,149][ERROR][org.logstash.Logstash ]
-java.lang.IllegalStateException: org.jruby.exceptions.RaiseException:
-(LoadError) Could not load FFI Provider: (NotImplementedError) FFI not
-available: java.lang.UnsatisfiedLinkError: /tmp/jffi5534463206038012403.so:
-/tmp/jffi5534463206038012403.so: failed to map segment from shared object:
-Operation not permitted
------
-
-*Possible solutions*
-
-* Change setting to mount `/tmp` with `exec`.
-* Specify an alternate directory using the `-Djava.io.tmpdir` setting in the `jvm.options` file.
- 
-
-[float] 
-[[ts-startup]] 
-== {ls} start up
-
-[float] 
-[[ts-illegal-reflective-error]] 
-=== 'Illegal reflective access' errors
-
-// https://github.com/elastic/logstash/issues/10496 and https://github.com/elastic/logstash/issues/10498
-
-Running Logstash with Java 11 results in warnings similar to these:
-
-[source,sh]
------
-WARNING: An illegal reflective access operation has occurred
-WARNING: Illegal reflective access by org.jruby.ext.openssl.SecurityHelper (file:/{...}/jruby{...}jopenssl.jar) to field java.security.MessageDigest.provider
-WARNING: Please consider reporting this to the maintainers of org.jruby.ext.openssl.SecurityHelper
-WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
-WARNING: All illegal access operations will be denied in a future release
------
-
-These errors appear related to https://github.com/jruby/jruby/issues/4834[a known issue with JRuby].
-
-*Work around*
-
-Try adding these values to the `jvm.options` file.
-
-[source,sh]
------
---add-opens=java.base/java.security=ALL-UNNAMED
---add-opens=java.base/java.io=ALL-UNNAMED
---add-opens=java.base/java.nio.channels=org.jruby.dist
---add-opens=java.base/sun.nio.ch=org.jruby.dist
---add-opens=java.management/sun.management=org.jruby.dist
------
-
-*Notes:*
-
-* These settings allow Logstash to start without warnings in Java 11, but they
-prevent Logstash from starting on Java 8.
-* This workaround has been tested with simple pipelines. If you have experiences
-to share, please comment in the
-https://github.com/elastic/logstash/issues/10496[issue].
-
-
-[float] 
-[[ts-ingest]] 
-== Data ingestion
-
-[float] 
-[[ts-429]] 
-=== Error response code 429
-
-A `429` message indicates that an application is busy handling other requests. For
-example, Elasticsearch sends a `429` code to notify Logstash (or other indexers)
-that the bulk failed because the ingest queue is full. Logstash will retry sending documents.
-
-*Possible actions*
-
-Check {es} to see if it needs attention.
-
-* {ref}/cluster-stats.html[Cluster stats API]
-* {ref}/monitor-elasticsearch-cluster.html[Monitor a cluster]
-
-*Sample error*
-
------
-[2018-08-21T20:05:36,111][INFO ][logstash.outputs.elasticsearch] retrying
-failed action with response code: 429
-({"type"=>"es_rejected_execution_exception", "reason"=>"rejected execution of
-org.elasticsearch.transport.TransportService$7@85be457 on
-EsThreadPoolExecutor[bulk, queue capacity = 200,
-org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor@538c9d8a[Running,
-pool size = 16, active threads = 16, queued tasks = 200, completed tasks =
-685]]"})
------
-
-
-[float] 
-[[ts-performance]] 
-== General performance tuning
-
-For general performance tuning tips and guidelines, see <<performance-tuning>>.
-
-
-
-[float] 
-[[ts-pipeline]] 
-== Troubleshooting a pipeline
-
-Pipelines, by definition, are unique. Here are some guidelines to help you get
-started.
-
-* Identify the offending pipeline.
-* Start small. Create a minimum pipeline that manifests the problem.
-
-
-For basic pipelines, this configuration could be enough to make the problem show itself.
-
-[source,ruby]
------
-input {stdin{}} output {stdout{}}
------
-
-{ls} can separate logs by pipeline. This feature can help you identify the offending pipeline. 
-Set `pipeline.separate_logs: true` in your `logstash.yml` to enable the log per pipeline feature.
-
-For more complex pipelines, the problem could be caused by a series of plugins in
-a specific order. Troubleshooting these pipelines usually requires trial and error.
-Start by systematically removing input and output plugins until you're left with
-the minimum set that manifest the issue.
-
-We want to expand this section to make it more helpful. If you have
-troubleshooting tips to share, please:
-
-* create an issue at https://github.com/elastic/logstash/issues, or
-* create a pull request with your proposed changes at https://github.com/elastic/logstash.
-
-[float] 
-[[ts-pipeline-logging-level-performance]]
-=== Logging level can affect performances
-
-*Symptoms* 
-
-Simple filters such as `mutate` or `json` filter can take several milliseconds per event to execute.
-Inputs and outputs might be affected, too.
-
-*Background*
-
-The different plugins running on Logstash can be quite verbose if the logging level is set to `debug` or `trace`.
-As the logging library used in Logstash is synchronous, heavy logging can affect performances.
-
-*Solution*
-
-Reset the logging level to `info`.
-
-[float] 
 [[ts-kafka]] 
-== Common Kafka support issues and solutions
+==== Kafka issues and solutions
  
 [float] 
 [[ts-kafka-timeout]] 
-=== Kafka session timeout issues (input side)
+===== Kafka session timeout issues (input)
 
 *Symptoms* 
 
@@ -270,7 +87,7 @@ evidence of stalling outputs, such as `ES output logging status 429`.
 
 [float] 
 [[ts-kafka-many-offset-commits]] 
-=== Large number of offset commits (Kafka input side)
+===== Large number of offset commits (input)
 
 *Symptoms*
 
@@ -295,7 +112,7 @@ this scenario. For example, raising it by 10x will lead to 10x fewer offset comm
 
 [float] 
 [[ts-kafka-codec-errors-input]] 
-=== Codec Errors in Kafka Input (before Plugin Version 6.3.4 only) 
+===== Codec Errors in Kafka Input (before Plugin Version 6.3.4 only) 
 
 *Symptoms*
 
@@ -328,24 +145,6 @@ https://github.com/logstash-plugins/logstash-input-kafka/issues/210
 
 * Upgrade Kafka Input plugin to v. 6.3.4 or later. 
 * If (and only if) upgrading is not possible, set `consumer_threads` to `1`.
-
-
-[float] 
-[[ts-other]] 
-== Other issues
-
-Coming soon
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/docs/static/troubleshoot/ts-logstash.asciidoc
+++ b/docs/static/troubleshoot/ts-logstash.asciidoc
@@ -1,0 +1,161 @@
+[[ts-logstash]] 
+=== Troubleshooting {ls}
+
+
+[[ts-install]] 
+==== Installation and setup
+
+[[ts-temp-dir]] 
+===== Inaccessible temp directory
+
+Certain versions of the JRuby runtime and libraries
+in certain plugins (the Netty network library in the TCP input, for example) copy
+executable files to the temp directory. This situation causes subsequent failures when
+`/tmp` is mounted `noexec`. 
+
+*Sample error*
+
+[source,sh]
+-----
+[2018-03-25T12:23:01,149][ERROR][org.logstash.Logstash ]
+java.lang.IllegalStateException: org.jruby.exceptions.RaiseException:
+(LoadError) Could not load FFI Provider: (NotImplementedError) FFI not
+available: java.lang.UnsatisfiedLinkError: /tmp/jffi5534463206038012403.so:
+/tmp/jffi5534463206038012403.so: failed to map segment from shared object:
+Operation not permitted
+-----
+
+*Possible solutions*
+
+* Change setting to mount `/tmp` with `exec`.
+* Specify an alternate directory using the `-Djava.io.tmpdir` setting in the `jvm.options` file.
+ 
+
+[[ts-startup]] 
+==== {ls} start up
+ 
+[[ts-illegal-reflective-error]] 
+===== 'Illegal reflective access' errors
+
+// https://github.com/elastic/logstash/issues/10496 and https://github.com/elastic/logstash/issues/10498
+
+Running Logstash with Java 11 results in warnings similar to these:
+
+[source,sh]
+-----
+WARNING: An illegal reflective access operation has occurred
+WARNING: Illegal reflective access by org.jruby.ext.openssl.SecurityHelper (file:/{...}/jruby{...}jopenssl.jar) to field java.security.MessageDigest.provider
+WARNING: Please consider reporting this to the maintainers of org.jruby.ext.openssl.SecurityHelper
+WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
+WARNING: All illegal access operations will be denied in a future release
+-----
+
+These errors appear related to https://github.com/jruby/jruby/issues/4834[a known issue with JRuby].
+
+*Work around*
+
+Try adding these values to the `jvm.options` file.
+
+[source,sh]
+-----
+--add-opens=java.base/java.security=ALL-UNNAMED
+--add-opens=java.base/java.io=ALL-UNNAMED
+--add-opens=java.base/java.nio.channels=org.jruby.dist
+--add-opens=java.base/sun.nio.ch=org.jruby.dist
+--add-opens=java.management/sun.management=org.jruby.dist
+-----
+
+*Notes:*
+
+* These settings allow Logstash to start without warnings in Java 11, but they
+prevent Logstash from starting on Java 8.
+* This workaround has been tested with simple pipelines. If you have experiences
+to share, please comment in the
+https://github.com/elastic/logstash/issues/10496[issue].
+
+
+[[ts-ingest]] 
+==== Data ingestion
+
+[[ts-429]] 
+===== Error response code 429
+
+A `429` message indicates that an application is busy handling other requests. For
+example, Elasticsearch sends a `429` code to notify Logstash (or other indexers)
+that the bulk failed because the ingest queue is full. Logstash will retry sending documents.
+
+*Possible actions*
+
+Check {es} to see if it needs attention.
+
+* {ref}/cluster-stats.html[Cluster stats API]
+* {ref}/monitor-elasticsearch-cluster.html[Monitor a cluster]
+
+*Sample error*
+
+-----
+[2018-08-21T20:05:36,111][INFO ][logstash.outputs.elasticsearch] retrying
+failed action with response code: 429
+({"type"=>"es_rejected_execution_exception", "reason"=>"rejected execution of
+org.elasticsearch.transport.TransportService$7@85be457 on
+EsThreadPoolExecutor[bulk, queue capacity = 200,
+org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor@538c9d8a[Running,
+pool size = 16, active threads = 16, queued tasks = 200, completed tasks =
+685]]"})
+-----
+
+
+[[ts-performance]] 
+==== Performance
+
+For general performance tuning tips and guidelines, see <<performance-tuning>>.
+
+
+[[ts-pipeline]] 
+==== Troubleshooting a pipeline
+
+Pipelines, by definition, are unique. Here are some guidelines to help you get
+started.
+
+* Identify the offending pipeline.
+* Start small. Create a minimum pipeline that manifests the problem.
+
+
+For basic pipelines, this configuration could be enough to make the problem show itself.
+
+[source,ruby]
+-----
+input {stdin{}} output {stdout{}}
+-----
+
+{ls} can separate logs by pipeline. This feature can help you identify the offending pipeline. 
+Set `pipeline.separate_logs: true` in your `logstash.yml` to enable the log per pipeline feature.
+
+For more complex pipelines, the problem could be caused by a series of plugins in
+a specific order. Troubleshooting these pipelines usually requires trial and error.
+Start by systematically removing input and output plugins until you're left with
+the minimum set that manifest the issue.
+
+We want to expand this section to make it more helpful. If you have
+troubleshooting tips to share, please:
+
+* create an issue at https://github.com/elastic/logstash/issues, or
+* create a pull request with your proposed changes at https://github.com/elastic/logstash.
+
+
+[[ts-pipeline-logging-level-performance]]
+==== Logging level can affect performances
+
+*Symptoms* 
+
+Simple filters such as `mutate` or `json` filter can take several milliseconds per event to execute.
+Inputs and outputs might be affected, too.
+
+*Background*
+
+The different plugins running on Logstash can be quite verbose if the logging level is set to `debug` or `trace`.
+As the logging library used in Logstash is synchronous, heavy logging can affect performances.
+
+*Solution*
+
+Reset the logging level to `info`.

--- a/docs/static/troubleshoot/ts-other-issues.asciidoc
+++ b/docs/static/troubleshoot/ts-other-issues.asciidoc
@@ -1,0 +1,14 @@
+[discrete]
+[[ts-other]] 
+== Other issues
+
+Coming soon, and you can help! If you have something to add, please:
+
+* create an issue at
+https://github.com/elastic/logstash/issues, or
+* create a pull request with your proposed changes at https://github.com/elastic/logstash.
+
+Also check out the https://discuss.elastic.co/c/logstash[Logstash discussion
+forum].
+
+

--- a/docs/static/troubleshoot/ts-plugins-general.asciidoc
+++ b/docs/static/troubleshoot/ts-plugins-general.asciidoc
@@ -1,0 +1,5 @@
+[[ts-plugins-general]] 
+=== Troubleshooting plugins
+
+include::plugin-tracing.asciidoc[]
+

--- a/docs/static/troubleshoot/ts-plugins.asciidoc
+++ b/docs/static/troubleshoot/ts-plugins.asciidoc
@@ -2,4 +2,3 @@
 === Troubleshooting specific plugins
 
 include::ts-kafka.asciidoc[]
-s

--- a/docs/static/troubleshoot/ts-plugins.asciidoc
+++ b/docs/static/troubleshoot/ts-plugins.asciidoc
@@ -1,0 +1,5 @@
+[[ts-plugins]] 
+=== Troubleshooting specific plugins
+
+include::ts-kafka.asciidoc[]
+s


### PR DESCRIPTION
Restructures troubleshooting docs in preparation for expanding content. 
Adds info for plugin tracing to help users track down plugins that might be causing problems.

**PREVIEW:** https://logstash_12270.docs-preview.app.elstc.co/guide/en/logstash/master/troubleshooting.html

Related: #12228 

