### PR TITLE
[DOC] Pipeline-to-pipeline communication examples fix

### DIFF
--- a/docs/static/pipeline-pipeline-config.asciidoc
+++ b/docs/static/pipeline-pipeline-config.asciidoc
@@ -85,17 +85,17 @@ Here is an example distributor pattern configuration.
   config.string: |
     input { beats { port => 5044 } }
     output {
-        if [type] == apache {
-          pipeline { send_to => weblogs }
-        } else if [type] == system {
-          pipeline { send_to => syslog }
+        if [type] == "apache" {
+          pipeline { send_to => "weblogs" }
+        } else if [type] == "system" {
+          pipeline { send_to => "syslog" }
         } else {
-          pipeline { send_to => fallback }
+          pipeline { send_to => "fallback" }
         }
     }
 - pipeline.id: weblog-processing
   config.string: |
-    input { pipeline { address => weblogs } }
+    input { pipeline { address => "weblogs" } }
     filter {
        # Weblog filter statements here...
     }
@@ -104,7 +104,7 @@ Here is an example distributor pattern configuration.
     }
 - pipeline.id: syslog-processing
   config.string: |
-    input { pipeline { address => syslog } }
+    input { pipeline { address => "syslog" } }
     filter {
        # Syslog filter statements here...
     }
@@ -113,7 +113,7 @@ Here is an example distributor pattern configuration.
     }
 - pipeline.id: fallback-processing
     config.string: |
-    input { pipeline { address => fallback } }
+    input { pipeline { address => "fallback" } }
     output { elasticsearch { hosts => [es_cluster_b_host] } }
 ----
 
@@ -137,16 +137,16 @@ Here is an example of this scenario using the output isolator pattern.
   queue.type: persisted
   config.string: |
     input { beats { port => 5044 } }
-    output { pipeline { send_to => [es, http] } }
+    output { pipeline { send_to => ["es", "http"] } }
 - pipeline.id: buffered-es
   queue.type: persisted
   config.string: |
-    input { pipeline { address => es } }
+    input { pipeline { address => "es" } }
     output { elasticsearch { } }
 - pipeline.id: buffered-http
   queue.type: persisted
   config.string: |
-    input { pipeline { address => http } }
+    input { pipeline { address => "http" } }
     output { http { } }
 ----
 
@@ -201,15 +201,15 @@ Here is an example of the collector pattern.
 - pipeline.id: beats
   config.string: |
     input { beats { port => 5044 } }
-    output { pipeline { send_to => [commonOut] } }
+    output { pipeline { send_to => ["commonOut"] } }
 - pipeline.id: kafka
   config.string: |
     input { kafka { ... } }
-    output { pipeline { send_to => [commonOut] } }
+    output { pipeline { send_to => ["commonOut"] } }
 - pipeline.id: partner
   # This common pipeline enforces the same logic whether data comes from Kafka or Beats
   config.string: |
-    input { pipeline { address => commonOut } }
+    input { pipeline { address => "commonOut" } }
     filter {
       # Always remove sensitive data from all input sources
       mutate { remove_field => 'sensitive-data' }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## What does this PR do?

Fix [pipeline-to-pipeline documentation page](https://www.elastic.co/guide/en/logstash/current/pipeline-to-pipeline.html) examples.

Double quotes are required the if-clauses

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

## Why is it important/What is the impact to the user?

The distributor pattern example was straight triggering a `ConfigurationError`, fixed by this PR. It also helps for "copy-paste programming", so the users can directly use the examples and replace the pipeline addresses with their own names.

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Build the documentation locally, if needed:

```
./build_docs.pl --doc ../logstash/docs/index.asciidoc --chunk=1 -open
```

