### PR TITLE
fix dependency issue, jruby-openssl, of integration test

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "mustermann", '~> 1.0.3'
   gem.add_runtime_dependency "sinatra", '~> 2'
   gem.add_runtime_dependency 'puma', '~> 4'
-  gem.add_runtime_dependency "jruby-openssl", "~> 0.10.4" # >= 0.9.13 Required to support TLSv1.2
+  gem.add_runtime_dependency "jruby-openssl", "= 0.10.4" # >= 0.9.13 Required to support TLSv1.2
 
   gem.add_runtime_dependency "treetop", "~> 1" #(MIT license)
 

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "mustermann", '~> 1.0.3'
   gem.add_runtime_dependency "sinatra", '~> 2'
   gem.add_runtime_dependency 'puma', '~> 4'
-  gem.add_runtime_dependency "jruby-openssl", "~> 0.10" # >= 0.9.13 Required to support TLSv1.2
+  gem.add_runtime_dependency "jruby-openssl", "~> 0.10.4" # >= 0.9.13 Required to support TLSv1.2
 
   gem.add_runtime_dependency "treetop", "~> 1" #(MIT license)
 

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "mustermann", '~> 1.0.3'
   gem.add_runtime_dependency "sinatra", '~> 2'
   gem.add_runtime_dependency 'puma', '~> 4'
-  gem.add_runtime_dependency "jruby-openssl", "= 0.10.4" # >= 0.9.13 Required to support TLSv1.2
+  gem.add_runtime_dependency "jruby-openssl", "= 0.10.4" # >= 0.9.13 Required to support TLSv1.2; 0.10.5 is causing dependency issue in integration test #12299
 
   gem.add_runtime_dependency "treetop", "~> 1" #(MIT license)
 


### PR DESCRIPTION
fix https://github.com/elastic/logstash/issues/12299
pin jruby-openssl to 0.10.4