### PR TITLE
stop inputs upon a worker error before terminating the pipeline

### DIFF
--- a/logstash-core/spec/logstash/java_pipeline_spec.rb
+++ b/logstash-core/spec/logstash/java_pipeline_spec.rb
@@ -23,6 +23,7 @@ require_relative "../support/helpers"
 require 'support/pipeline/pipeline_helpers'
 require "stud/try"
 require 'timeout'
+require "thread"
 
 class DummyInput < LogStash::Inputs::Base
   config_name "dummyinput"
@@ -38,18 +39,31 @@ class DummyInput < LogStash::Inputs::Base
   end
 end
 
-class DummyInputGenerator < LogStash::Inputs::Base
-  config_name "dummyinputgenerator"
+class DummyManualInputGenerator < LogStash::Inputs::Base
+  config_name "dummymanualinputgenerator"
   milestone 2
+
+  attr_accessor :keep_running
+
+  def initialize(*args)
+    super(*args)
+    @keep_running = Concurrent::AtomicBoolean.new(false)
+    @queue = nil
+  end
 
   def register
   end
 
   def run(queue)
-    queue << Logstash::Event.new while !stop?
+    @queue = queue
+    while !stop? || @keep_running.true?
+      queue << LogStash::Event.new
+      sleep(0.5)
+    end
   end
 
-  def close
+  def push_once
+    @queue << LogStash::Event.new
   end
 end
 
@@ -237,35 +251,83 @@ describe LogStash::JavaPipeline do
     end
   end
 
-  context "a crashing worker" do
+  context "a crashing worker terminates the pipeline and all inputs and workers" do
     subject { mock_java_pipeline_from_string(config, pipeline_settings_obj) }
-
-    let(:pipeline_settings) { { "pipeline.batch.size" => 1, "pipeline.workers" => 1 } }
     let(:config) do
       <<-EOS
-      input { generator {} }
+      input { dummymanualinputgenerator {} }
       filter { dummycrashingfilter {} }
       output { dummyoutput {} }
       EOS
     end
     let(:dummyoutput) { ::LogStash::Outputs::DummyOutput.new }
+    let(:dummyinput) { DummyManualInputGenerator.new }
 
     before :each do
       allow(::LogStash::Outputs::DummyOutput).to receive(:new).with(any_args).and_return(dummyoutput)
-      allow(LogStash::Plugin).to receive(:lookup).with("input", "generator").and_return(LogStash::Inputs::Generator)
+      allow(DummyManualInputGenerator).to receive(:new).with(any_args).and_return(dummyinput)
+
+      allow(LogStash::Plugin).to receive(:lookup).with("input", "dummymanualinputgenerator").and_return(DummyManualInputGenerator)
       allow(LogStash::Plugin).to receive(:lookup).with("codec", "plain").and_return(LogStash::Codecs::Plain)
       allow(LogStash::Plugin).to receive(:lookup).with("filter", "dummycrashingfilter").and_return(DummyCrashingFilter)
       allow(LogStash::Plugin).to receive(:lookup).with("output", "dummyoutput").and_return(::LogStash::Outputs::DummyOutput)
     end
 
-    after :each do
-      subject.shutdown
-    end
+  context "a crashing worker using memory queue" do
+    let(:pipeline_settings) { { "pipeline.batch.size" => 1, "pipeline.workers" => 1, "queue.type" => "memory"} }
 
     it "does not raise in the main thread, terminates the run thread and finishes execution" do
-      expect { subject.start && subject.thread.join }.to_not raise_error
+      # first make sure we keep the input plugin in the run method for now
+      dummyinput.keep_running.make_true
+
+      expect { subject.start }.to_not raise_error
+
+      # wait until there is no more worker thread since we have a single worker that should have died
+      wait(5).for {subject.worker_threads.any?(&:alive?)}.to be_falsey
+
+      # at this point the input plugin should have been asked to stop
+      wait(5).for {dummyinput.stop?}.to be_truthy
+
+      # allow the input plugin to exit the run method now
+      dummyinput.keep_running.make_false
+
+      # the pipeline thread should terminate normally
+      expect { subject.thread.join }.to_not raise_error
       expect(subject.finished_execution?).to be_truthy
+
+      # when the pipeline has exited, no input threads should be alive
+      wait(5).for {subject.input_threads.any?(&:alive?)}.to be_falsey
     end
+  end
+
+  context "a crashing worker using persisted queue" do
+    let(:pipeline_settings) { { "pipeline.batch.size" => 1, "pipeline.workers" => 1, "queue.type" => "persisted"} }
+
+    it "does not raise in the main thread, terminates the run thread and finishes execution" do
+      # first make sure we keep the input plugin in the run method for now
+      dummyinput.keep_running.make_true
+
+      expect { subject.start }.to_not raise_error
+
+      # wait until there is no more worker thread since we have a single worker that should have died
+      wait(5).for {subject.worker_threads.any?(&:alive?)}.to be_falsey
+
+      # at this point the input plugin should have been asked to stop
+      wait(5).for {dummyinput.stop?}.to be_truthy
+
+      # allow the input plugin to exit the run method now
+      dummyinput.keep_running.make_false
+
+      # the pipeline thread should terminate normally
+      expect { subject.thread.join }.to_not raise_error
+      expect(subject.finished_execution?).to be_truthy
+
+      # when the pipeline has exited, no input threads should be alive
+      wait(5).for {subject.input_threads.any?(&:alive?)}.to be_falsey
+
+      expect{dummyinput.push_once}.to raise_error(/Tried to write to a closed queue/)
+    end
+  end
   end
 
   describe "defaulting the pipeline workers based on thread safety" do


### PR DESCRIPTION
## What does this PR do?

This addresses an incomplete fix in #12019 starting in 7.8.1 where upon catching a worker exception (to avoid crashing the whole logstash per #12306) the input plugin(s) are **not terminated prior** to closing the pipeline leading to the input plugin(s) continuing execution and failing with `IllegalStateException` &  `Tried to write to a closed queue` since closing the pipeline also correctly closes the queue.

## Why is it important/What is the impact to the user?

This is a critical bug affecting users if logstash experiences a worker error.

## Checklist

- [x] Add tests
- [x] Still be an issue when using memory queue where `Queue.push` does not return upon closing the input

## How to test this PR locally

To reproduce the problem prior to this PR:
- setup 2 pipelines, one that works and another that uses a  local output or filter that raises an exception from its filter or receive method
- run logstash; prior to this PR, `IllegalStateException` &  `Tried to write to a closed queue` errors will be produced, with this PR, the original exception is reported and the pipeline is correctly terminated.

## Related issues

- Fixes #12306
- Relates #12306


