### PR TITLE
[Test] Remove 'shouldRunAfter' qualifier in gradle script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -513,7 +513,7 @@ bootstrap.dependsOn assemblyDeps
 // to compartimentalize failures is needed going forward
 //check.dependsOn runIntegrationTest
 
-runIntegrationTests.shouldRunAfter tasks.getByPath(":logstash-core:test")
+//runIntegrationTests.shouldRunAfter tasks.getByPath(":logstash-core:test")
 
 def selectOsType() {
     if (project.ext.has("jdk_bundle_os")) {


### PR DESCRIPTION
This is currently causing the `runIntegrationTests` task to be run for
all tests, which is causing all tests to fail if es artifacts are not
available
