### PR TITLE
Doc: Add placeholder and coming tag for 7.10.0 release notes

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in the following releases:
 
+* <<logstash-7-10-0,Logstash 7.10.0>>
 * <<logstash-7-9-2,Logstash 7.9.2>>
 * <<logstash-7-9-1,Logstash 7.9.1>>
 * <<logstash-7-9-0,Logstash 7.9.0>>
@@ -33,6 +34,11 @@ This section summarizes the changes in the following releases:
 * <<logstash-7-0-0-beta1,Logstash 7.0.0-beta1>>
 * <<logstash-7-0-0-alpha2,Logstash 7.0.0-alpha2>>
 * <<logstash-7-0-0-alpha1,Logstash 7.0.0-alpha1>>
+
+[[logstash-7-10-0]]
+=== Logstash 7.10.0 Release Notes
+
+coming[7.10.0]
 
 [[logstash-7-9-2]]
 === Logstash 7.9.2 Release Notes


### PR DESCRIPTION
Adds placeholder and "coming" tag so that we have a page to link to from 7.10.0 staging.
Note: We don't always put up a page in advance.  This time we'll need a live link for the updated download pages. 