### PR TITLE
[7x backport] Remove redundant shouldRunAfter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -513,7 +513,6 @@ bootstrap.dependsOn assemblyDeps
 // to compartimentalize failures is needed going forward
 //check.dependsOn runIntegrationTest
 
-runIntegrationTests.shouldRunAfter tasks.getByPath(":logstash-core:test")
 
 def selectOsType() {
     if (project.ext.has("jdk_bundle_os")) {


### PR DESCRIPTION
Clean backport of #12314 

The `shouldRunAfter` specified in the main script body was causing the runIntegrationTests
task to be evaluated even when it should not have been, causing unnecessary failures
when artifacts required only for integration tests are unavailable.
This can be removed, because the `shouldRunAfter` relationship for the `runIntegrationTests`
task is already defined in the task body.
