### PR TITLE
[7.10 backport] Write DLQ entries to temp file first

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -211,6 +211,14 @@ pipeline.ordered: auto
 # Default is 1024mb
 # dead_letter_queue.max_bytes: 1024mb
 
+# If using dead_letter_queue.enable: true, the interval in milliseconds where if no further events eligible for the DLQ
+# have been created, a dead letter queue file will be written. A low value here will mean that more, smaller, queue files
+# may be written, while a larger value will introduce more latency between items being "written" to the dead letter queue, and
+# being available to be read by the dead_letter_queue input when items are are written infrequently.
+# Default is 5000.
+#
+# dead_letter_queue.flush_interval: 5000
+
 # If using dead_letter_queue.enable: true, the directory path where the data files will be stored.
 # Default is path.data/dead_letter_queue
 #

--- a/config/pipelines.yml
+++ b/config/pipelines.yml
@@ -71,6 +71,15 @@
 #   Default is 1024mb
 #   dead_letter_queue.max_bytes: 1024mb
 #
+#   If using dead_letter_queue.enable: true, the interval in milliseconds where if no further events eligible for the DLQ
+#   have been created, a dead letter queue file will be written. A low value here will mean that more, smaller, queue files
+#   may be written, while a larger value will introduce more latency between items being "written" to the dead letter queue, and
+#   being available to be read by the dead_letter_queue input when items are are written infrequently.
+#   Default is 5000.
+#
+#   dead_letter_queue.flush_interval: 5000
+
+#
 #   If using dead_letter_queue.enable: true, the directory path where the data files will be stored.
 #   Default is path.data/dead_letter_queue
 #

--- a/docker/data/logstash/env2yaml/env2yaml.go
+++ b/docker/data/logstash/env2yaml/env2yaml.go
@@ -77,6 +77,7 @@ func normalizeSetting(setting string) (string, error) {
 		"queue.drain",
 		"dead_letter_queue.enable",
 		"dead_letter_queue.max_bytes",
+		"dead_letter_queue.flush_interval",
 		"path.dead_letter_queue",
 		"http.host",
 		"http.port",

--- a/docs/static/dead-letter-queues.asciidoc
+++ b/docs/static/dead-letter-queues.asciidoc
@@ -72,6 +72,25 @@ specify a different path for the files:
 path.dead_letter_queue: "path/to/data/dead_letter_queue"
 -------------------------------------------------------------------------------
 
+Dead letter queue entries are written to a temporary file, which is then renamed
+ to a dead letter queue segment file, which is then eligible for ingestion. The rename
+ happens either when this temporary file is considered 'full', or when a period
+ of time has elapsed since the last dead letter queue eligible event was written
+ to the temporary file.
+
+This length of time can be set using the `dead_letter_queue.flush_interval` setting.
+ This setting is in milliseconds, and defaults to 5000ms. A low value here will mean
+ in the event of infrequent writes to the dead letter queue more, smaller, queue
+ files may be written, while a larger value will introduce more latency between
+ items being "written" to the dead letter queue, and being made available for
+ reading by the dead_letter_queue input.
+
+ Note that this value cannot be set to lower than 1000ms.
+
+[source,yaml]
+-------------------------------------------------------------------------------
+dead_letter_queue.flush_interval: 5000
+-------------------------------------------------------------------------------
 
 NOTE: You may not use the same `dead_letter_queue` path for two different
 Logstash instances.

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -85,6 +85,7 @@ module LogStash
             Setting::Boolean.new("queue.checkpoint.retry", false),
             Setting::Boolean.new("dead_letter_queue.enable", false),
             Setting::Bytes.new("dead_letter_queue.max_bytes", "1024mb"),
+            Setting::Numeric.new("dead_letter_queue.flush_interval", 5000),
             Setting::TimeValue.new("slowlog.threshold.warn", "-1"),
             Setting::TimeValue.new("slowlog.threshold.info", "-1"),
             Setting::TimeValue.new("slowlog.threshold.debug", "-1"),

--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -34,6 +34,7 @@ module LogStash
       "config.reload.interval",
       "config.string",
       "dead_letter_queue.enable",
+      "dead_letter_queue.flush_interval",
       "dead_letter_queue.max_bytes",
       "metric.collect",
       "pipeline.java_execution",

--- a/logstash-core/src/main/java/org/logstash/common/DeadLetterQueueFactory.java
+++ b/logstash-core/src/main/java/org/logstash/common/DeadLetterQueueFactory.java
@@ -44,6 +44,7 @@ import org.logstash.common.io.DeadLetterQueueWriter;
 
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -73,19 +74,20 @@ public class DeadLetterQueueFactory {
      *                for each id
      * @param maxQueueSize Maximum size of the dead letter queue (in bytes). No entries will be written
      *                     that would make the size of this dlq greater than this value
+     * @param flushInterval Maximum duration between flushes of dead letter queue files if no data is sent.
      * @return The write manager for the specific id's dead-letter-queue context
      */
-    public static DeadLetterQueueWriter getWriter(String id, String dlqPath, long maxQueueSize) {
-        return REGISTRY.computeIfAbsent(id, key -> newWriter(key, dlqPath, maxQueueSize));
+    public static DeadLetterQueueWriter getWriter(String id, String dlqPath, long maxQueueSize, Duration flushInterval) {
+        return REGISTRY.computeIfAbsent(id, key -> newWriter(key, dlqPath, maxQueueSize, flushInterval));
     }
 
     public static DeadLetterQueueWriter release(String id) {
         return REGISTRY.remove(id);
     }
 
-    private static DeadLetterQueueWriter newWriter(final String id, final String dlqPath, final long maxQueueSize) {
+    private static DeadLetterQueueWriter newWriter(final String id, final String dlqPath, final long maxQueueSize, final Duration flushInterval) {
         try {
-            return new DeadLetterQueueWriter(Paths.get(dlqPath, id), MAX_SEGMENT_SIZE_BYTES, maxQueueSize);
+            return new DeadLetterQueueWriter(Paths.get(dlqPath, id), MAX_SEGMENT_SIZE_BYTES, maxQueueSize, flushInterval);
         } catch (IOException e) {
             logger.error("unable to create dead letter queue writer", e);
         }

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -43,11 +43,19 @@ import java.io.IOException;
 import java.nio.channels.FileLock;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.logstash.DLQEntry;
@@ -57,88 +65,106 @@ import org.logstash.FileLockFactory;
 import org.logstash.Timestamp;
 
 import static org.logstash.common.io.RecordIOWriter.RECORD_HEADER_SIZE;
+import static org.logstash.common.io.RecordIOReader.SegmentStatus;
 
 public final class DeadLetterQueueWriter implements Closeable {
 
-    private static final Logger logger = LogManager.getLogger(DeadLetterQueueWriter.class);
-    private static final long MAX_SEGMENT_SIZE_BYTES = 10 * 1024 * 1024;
-
+    @VisibleForTesting
     static final String SEGMENT_FILE_PATTERN = "%d.log";
-    static final String LOCK_FILE = ".lock";
+    private static final Logger logger = LogManager.getLogger(DeadLetterQueueWriter.class);
+    private enum FinalizeWhen {ALWAYS, ONLY_IF_STALE};
+    private static final String TEMP_FILE_PATTERN = "%d.log.tmp";
+    private static final String LOCK_FILE = ".lock";
+    private final ReentrantLock lock = new ReentrantLock();
     private static final FieldReference DEAD_LETTER_QUEUE_METADATA_KEY =
         FieldReference.from(String.format("%s[dead_letter_queue]", Event.METADATA_BRACKETS));
     private final long maxSegmentSize;
     private final long maxQueueSize;
     private LongAdder currentQueueSize;
     private final Path queuePath;
-    private final FileLock lock;
+    private final FileLock fileLock;
     private volatile RecordIOWriter currentWriter;
     private int currentSegmentIndex;
     private Timestamp lastEntryTimestamp;
+    private Duration flushInterval;
+    private Instant lastWrite;
     private final AtomicBoolean open = new AtomicBoolean(true);
+    private ScheduledExecutorService flushScheduler;
 
-    public DeadLetterQueueWriter(Path queuePath, long maxSegmentSize, long maxQueueSize) throws IOException {
-        this.lock = FileLockFactory.obtainLock(queuePath, LOCK_FILE);
+    public DeadLetterQueueWriter(final Path queuePath, final long maxSegmentSize, final long maxQueueSize, final Duration flushInterval) throws IOException {
+        this.fileLock = FileLockFactory.obtainLock(queuePath, LOCK_FILE);
         this.queuePath = queuePath;
         this.maxSegmentSize = maxSegmentSize;
         this.maxQueueSize = maxQueueSize;
+        this.flushInterval = flushInterval;
         this.currentQueueSize = new LongAdder();
         this.currentQueueSize.add(getStartupQueueSize());
 
+        cleanupTempFiles();
         currentSegmentIndex = getSegmentPaths(queuePath)
                 .map(s -> s.getFileName().toString().split("\\.")[0])
                 .mapToInt(Integer::parseInt)
                 .max().orElse(0);
         nextWriter();
         this.lastEntryTimestamp = Timestamp.now();
+        createFlushScheduler();
     }
 
-    /**
-     * Constructor for Writer that uses defaults
-     *
-     * @param queuePath the path to the dead letter queue segments directory
-     * @throws IOException if the size of the file cannot be determined
-     */
-    public DeadLetterQueueWriter(String queuePath) throws IOException {
-        this(Paths.get(queuePath), MAX_SEGMENT_SIZE_BYTES, Long.MAX_VALUE);
+    public boolean isOpen() {
+        return open.get();
     }
 
-    private long getStartupQueueSize() throws IOException {
-        return getSegmentPaths(queuePath)
-                .mapToLong((p) -> {
-                    try {
-                        return Files.size(p);
-                    } catch (IOException e) {
-                        throw new IllegalStateException(e);
-                    }
-                } )
-                .sum();
+    public Path getPath(){
+        return queuePath;
     }
 
-    private void nextWriter() throws IOException {
-        currentWriter = new RecordIOWriter(queuePath.resolve(String.format(SEGMENT_FILE_PATTERN, ++currentSegmentIndex)));
-        currentQueueSize.increment();
+    public long getCurrentQueueSize() {
+        return currentQueueSize.longValue();
+    }
+
+    public void writeEntry(Event event, String pluginName, String pluginId, String reason) throws IOException {
+        writeEntry(new DLQEntry(event, pluginName, pluginId, reason));
+    }
+
+    @Override
+    public void close() {
+        if (open.compareAndSet(true, false)) {
+            try {
+                finalizeSegment(FinalizeWhen.ALWAYS);
+            } catch (Exception e) {
+                logger.warn("Unable to close dlq writer, ignoring", e);
+            }
+            try {
+                releaseFileLock();
+            } catch (Exception e) {
+                logger.warn("Unable to release fileLock, ignoring", e);
+            }
+
+            try {
+                flushScheduler.shutdown();
+            } catch (Exception e) {
+                logger.warn("Unable shutdown flush scheduler, ignoring", e);
+            }
+        }
     }
 
     static Stream<Path> getSegmentPaths(Path path) throws IOException {
-        try(final Stream<Path> files = Files.list(path)) {
-            return files.filter(p -> p.toString().endsWith(".log"))
-                .collect(Collectors.toList()).stream();
-        }
+        return listFiles(path, ".log");
     }
 
-    public synchronized void writeEntry(DLQEntry entry) throws IOException {
-        innerWriteEntry(entry);
-    }
-
-    public synchronized void writeEntry(Event event, String pluginName, String pluginId, String reason) throws IOException {
-        Timestamp entryTimestamp = Timestamp.now();
-        if (entryTimestamp.getTime().isBefore(lastEntryTimestamp.getTime())) {
-            entryTimestamp = lastEntryTimestamp;
+    @VisibleForTesting
+    void writeEntry(DLQEntry entry) throws IOException {
+        lock.lock();
+        try {
+            Timestamp entryTimestamp = Timestamp.now();
+            if (entryTimestamp.getTime().isBefore(lastEntryTimestamp.getTime())) {
+                entryTimestamp = lastEntryTimestamp;
+            }
+            innerWriteEntry(entry);
+            lastEntryTimestamp = entryTimestamp;
+        } finally {
+            lock.unlock();
         }
-        DLQEntry entry = new DLQEntry(event, pluginName, pluginId, reason);
-        innerWriteEntry(entry);
-        lastEntryTimestamp = entryTimestamp;
     }
 
     private void innerWriteEntry(DLQEntry entry) throws IOException {
@@ -154,10 +180,10 @@ public final class DeadLetterQueueWriter implements Closeable {
             logger.error("cannot write event to DLQ(path: " + this.queuePath + "): reached maxQueueSize of " + maxQueueSize);
             return;
         } else if (currentWriter.getPosition() + eventPayloadSize > maxSegmentSize) {
-            currentWriter.close();
-            nextWriter();
+            finalizeSegment(FinalizeWhen.ALWAYS);
         }
         currentQueueSize.add(currentWriter.writeEvent(record));
+        lastWrite = Instant.now();
     }
 
     /**
@@ -172,42 +198,131 @@ public final class DeadLetterQueueWriter implements Closeable {
         return event.includes(DEAD_LETTER_QUEUE_METADATA_KEY);
     }
 
-    @Override
-    public void close() {
-        if (open.compareAndSet(true, false)) {
-            if (currentWriter != null) {
-                try {
-                    currentWriter.close();
-                } catch (Exception e) {
-                    logger.debug("Unable to close dlq writer", e);
-                }
-            }
-            releaseLock();
+    private void flushCheck() {
+        try{
+            finalizeSegment(FinalizeWhen.ONLY_IF_STALE);
+        } catch (Exception e){
+            logger.warn("unable to finalize segment", e);
         }
     }
 
-    private void releaseLock() {
+    /**
+     * Determines whether the current writer is stale. It is stale if writes have been performed, but the
+     * last time it was written is further in the past than the flush interval.
+     * @return
+     */
+    private boolean isCurrentWriterStale(){
+        return currentWriter.isStale(flushInterval);
+    }
+
+    private void finalizeSegment(final FinalizeWhen finalizeWhen) throws IOException {
+        lock.lock();
         try {
-            FileLockFactory.releaseLock(lock);
+            if (!isCurrentWriterStale() && finalizeWhen == FinalizeWhen.ONLY_IF_STALE)
+                return;
+
+            if (currentWriter != null && currentWriter.hasWritten()) {
+                currentWriter.close();
+                Files.move(queuePath.resolve(String.format(TEMP_FILE_PATTERN, currentSegmentIndex)),
+                        queuePath.resolve(String.format(SEGMENT_FILE_PATTERN, currentSegmentIndex)),
+                        StandardCopyOption.ATOMIC_MOVE);
+                if (isOpen()) {
+                    nextWriter();
+                }
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void createFlushScheduler() {
+        flushScheduler = Executors.newScheduledThreadPool(1, r -> {
+            Thread t = new Thread(r);
+            //Allow this thread to die when the JVM dies
+            t.setDaemon(true);
+            //Set the name
+            t.setName("dlq-flush-check");
+            return t;
+        });
+        flushScheduler.scheduleAtFixedRate(this::flushCheck, 1L, 1L, TimeUnit.SECONDS);
+    }
+
+    private long getStartupQueueSize() throws IOException {
+        return getSegmentPaths(queuePath)
+                .mapToLong((p) -> {
+                    try {
+                        return Files.size(p);
+                    } catch (IOException e) {
+                        throw new IllegalStateException(e);
+                    }
+                } )
+                .sum();
+    }
+
+    private void releaseFileLock() {
+        try {
+            FileLockFactory.releaseLock(fileLock);
         } catch (IOException e) {
-            logger.debug("Unable to release lock", e);
+            logger.debug("Unable to release fileLock", e);
         }
         try {
             Files.deleteIfExists(queuePath.resolve(LOCK_FILE));
         } catch (IOException e){
-            logger.debug("Unable to delete lock file", e);
+            logger.debug("Unable to delete fileLock file", e);
         }
     }
 
-    public boolean isOpen() {
-        return open.get();
+    private void nextWriter() throws IOException {
+        currentWriter = new RecordIOWriter(queuePath.resolve(String.format(TEMP_FILE_PATTERN, ++currentSegmentIndex)));
+        currentQueueSize.increment();
     }
 
-    public Path getPath(){
-        return queuePath;
+    // Clean up existing temp files - files with an extension of .log.tmp. Either delete them if an existing
+    // segment file with the same base name exists, or rename the
+    // temp file to the segment file, which can happen when a process ends abnormally
+    private void cleanupTempFiles() throws IOException {
+        DeadLetterQueueWriter.listFiles(queuePath, ".log.tmp")
+                .forEach(this::cleanupTempFile);
     }
 
-    public long getCurrentQueueSize() {
-        return currentQueueSize.longValue();
+    private static Stream<Path> listFiles(Path path, String suffix) throws IOException {
+        try(final Stream<Path> files = Files.list(path)) {
+            return files.filter(p -> p.toString().endsWith(suffix))
+                    .collect(Collectors.toList()).stream();
+        }
+    }
+
+    // check if there is a corresponding .log file - if yes delete the temp file, if no atomic move the
+    // temp file to be a new segment file..
+    private void cleanupTempFile(final Path tempFile) {
+        String tempFilename = tempFile.getFileName().toString().split("\\.")[0];
+        Path segmentFile = queuePath.resolve(String.format("%s.log", tempFilename));
+        try {
+            if (Files.exists(segmentFile)) {
+                Files.delete(tempFile);
+            }
+            else {
+                SegmentStatus segmentStatus = RecordIOReader.getSegmentStatus(tempFile);
+                switch (segmentStatus){
+                    case VALID:
+                        logger.debug("Moving temp file {} to segment file {}", tempFilename, segmentFile);
+                        Files.move(tempFile, segmentFile, StandardCopyOption.ATOMIC_MOVE);
+                        break;
+                    case EMPTY:
+                        logger.debug("Removing unused temp file {}", tempFilename);
+                        Files.delete(tempFile);
+                        break;
+                    case INVALID:
+                        Path errorFile = queuePath.resolve(String.format("%s.err", tempFilename));
+                        logger.warn("Segment file {} is in an error state, saving as {}", tempFilename, errorFile);
+                        Files.move(tempFile, errorFile, StandardCopyOption.ATOMIC_MOVE);
+                        break;
+                    default:
+                        throw new IllegalStateException("Unexpected value: " + RecordIOReader.getSegmentStatus(tempFile));
+                }
+            }
+        } catch (IOException e){
+            throw new IllegalStateException("Unable to clean up temp file: " + tempFile, e);
+        }
     }
 }

--- a/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
@@ -38,6 +38,9 @@
  */
 package org.logstash.common.io;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -60,12 +63,14 @@ import static org.logstash.common.io.RecordIOWriter.VERSION_SIZE;
  */
 public final class RecordIOReader implements Closeable {
 
+    private static final Logger logger = LogManager.getLogger(RecordIOReader.class);
     private final FileChannel channel;
     private ByteBuffer currentBlock;
     private int currentBlockSizeReadFromChannel;
     private final Path path;
     private long channelPosition;
     private static final int UNSET = -1;
+    enum SegmentStatus { EMPTY, VALID, INVALID}
 
     public RecordIOReader(Path path) throws IOException {
         this.path = path;
@@ -78,7 +83,7 @@ public final class RecordIOReader implements Closeable {
         byte versionInFile = versionBuffer.get();
         if (versionInFile != VERSION) {
             this.channel.close();
-            throw new RuntimeException(String.format(
+            throw new IllegalStateException(String.format(
                     "Invalid version on DLQ data file %s. Expected version: %c. Version found on file: %c",
                     path, VERSION, versionInFile));
         }
@@ -238,7 +243,7 @@ public final class RecordIOReader implements Closeable {
         computedChecksum.update(currentBlock.array(), currentBlock.position(), header.getSize());
 
         if ((int) computedChecksum.getValue() != header.getChecksum()) {
-            throw new RuntimeException("invalid checksum of record");
+            throw new IllegalStateException("invalid checksum of record");
         }
 
         buffer.put(currentBlock.array(), currentBlock.position(), header.getSize());
@@ -343,4 +348,26 @@ public final class RecordIOReader implements Closeable {
             }
         }
     }
+
+    /**
+     * Verify whether a segment is valid and non-empty.
+     * @param path Path to segment
+     * @return SegmentStatus EMPTY if the segment is empty, VALID if it is valid, INVALID otherwise
+     */
+    static SegmentStatus getSegmentStatus(Path path) {
+        try (RecordIOReader ioReader = new RecordIOReader(path)) {
+            boolean moreEvents = true;
+            SegmentStatus segmentStatus = SegmentStatus.EMPTY;
+            while (moreEvents) {
+                // If all events in the segment can be read, then assume that this is a valid segment
+                moreEvents = (ioReader.readEvent() != null);
+                if (moreEvents) segmentStatus = SegmentStatus.VALID;
+            }
+            return segmentStatus;
+        } catch (IOException | IllegalStateException e){
+            logger.warn("Error reading segment file {}", path, e);
+            return SegmentStatus.INVALID;
+        }
+    }
+
 }

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -27,6 +27,7 @@ import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -277,10 +278,9 @@ public class AbstractPipelineExt extends RubyBasicObject {
                     DeadLetterQueueFactory.getWriter(
                         pipelineId.asJavaString(),
                         getSetting(context, "path.dead_letter_queue").asJavaString(),
-                        getSetting(context, "dead_letter_queue.max_bytes").convertToInteger()
-                            .getLongValue()
-                    )
-                );
+                        getSetting(context, "dead_letter_queue.max_bytes").convertToInteger().getLongValue(),
+                        Duration.ofMillis(getSetting(context, "dead_letter_queue.flush_interval").convertToInteger().getLongValue()))
+                    );
             } else {
                 dlqWriter = RubyUtil.DUMMY_DLQ_WRITER_CLASS.callMethod(context, "new");
             }

--- a/logstash-core/src/test/java/org/logstash/common/DeadLetterQueueFactoryTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/DeadLetterQueueFactoryTest.java
@@ -47,6 +47,7 @@ import org.logstash.common.io.DeadLetterQueueWriter;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 
 import static junit.framework.TestCase.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -67,9 +68,9 @@ public class DeadLetterQueueFactoryTest {
     public void testSameBeforeRelease() throws IOException {
         try {
             Path pipelineA = dir.resolve(PIPELINE_NAME);
-            DeadLetterQueueWriter writer = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000);
+            DeadLetterQueueWriter writer = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000, Duration.ofSeconds(1));
             assertTrue(writer.isOpen());
-            DeadLetterQueueWriter writer2 = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000);
+            DeadLetterQueueWriter writer2 = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000, Duration.ofSeconds(1));
             assertSame(writer, writer2);
             writer.close();
         } finally {
@@ -81,11 +82,11 @@ public class DeadLetterQueueFactoryTest {
     public void testOpenableAfterRelease() throws IOException {
         try {
             Path pipelineA = dir.resolve(PIPELINE_NAME);
-            DeadLetterQueueWriter writer = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000);
+            DeadLetterQueueWriter writer = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000, Duration.ofSeconds(1));
             assertTrue(writer.isOpen());
             writer.close();
             DeadLetterQueueFactory.release(PIPELINE_NAME);
-            writer = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000);
+            writer = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000, Duration.ofSeconds(1));
             assertTrue(writer.isOpen());
             writer.close();
         }finally{

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
@@ -1,24 +1,4 @@
 /*
- * Licensed to Elasticsearch B.V. under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch B.V. licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *	http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-
-/*
  * Licensed to Elasticsearch under one or more contributor
  * license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright
@@ -45,7 +25,10 @@ import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.time.Duration;
 import java.util.stream.Stream;
+
+import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,13 +36,16 @@ import org.junit.rules.TemporaryFolder;
 import org.logstash.DLQEntry;
 import org.logstash.Event;
 import org.logstash.LockException;
+import org.logstash.Timestamp;
 
 import static junit.framework.TestCase.assertFalse;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.logstash.common.io.RecordIOWriter.BLOCK_SIZE;
 import static org.logstash.common.io.RecordIOWriter.RECORD_HEADER_SIZE;
 import static org.logstash.common.io.RecordIOWriter.VERSION_SIZE;
 
@@ -79,7 +65,7 @@ public class DeadLetterQueueWriterTest {
     @Test
     public void testLockFileManagement() throws Exception {
         Path lockFile = dir.resolve(".lock");
-        DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 100000);
+        DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 100000, Duration.ofSeconds(1));
         assertTrue(Files.exists(lockFile));
         writer.close();
         assertFalse(Files.exists(lockFile));
@@ -87,9 +73,9 @@ public class DeadLetterQueueWriterTest {
 
     @Test
     public void testFileLocking() throws Exception {
-        DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 100000);
+        DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 100000, Duration.ofSeconds(1));
         try {
-            new DeadLetterQueueWriter(dir, 100, 1000);
+            new DeadLetterQueueWriter(dir, 100, 1000, Duration.ofSeconds(1));
             fail();
         } catch (LockException e) {
         } finally {
@@ -101,7 +87,7 @@ public class DeadLetterQueueWriterTest {
     public void testUncleanCloseOfPreviousWriter() throws Exception {
         Path lockFilePath = dir.resolve(".lock");
         boolean created = lockFilePath.toFile().createNewFile();
-        DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 100000);
+        DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 100000, Duration.ofSeconds(1));
 
         FileChannel channel = FileChannel.open(lockFilePath, StandardOpenOption.WRITE);
         try {
@@ -116,7 +102,7 @@ public class DeadLetterQueueWriterTest {
 
     @Test
     public void testWrite() throws Exception {
-        DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 100000);
+        DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 100000, Duration.ofSeconds(1));
         DLQEntry entry = new DLQEntry(new Event(), "type", "id", "reason");
         writer.writeEntry(entry);
         writer.close();
@@ -129,9 +115,9 @@ public class DeadLetterQueueWriterTest {
         DLQEntry entry = new DLQEntry(new Event(), "type", "id", "reason");
         DLQEntry dlqEntry = new DLQEntry(dlqEvent, "type", "id", "reason");
 
-        try (DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 100000);) {
+        try (DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 100000, Duration.ofSeconds(1));) {
             writer.writeEntry(entry);
-            long dlqLengthAfterEvent  = dlqLength();
+            long dlqLengthAfterEvent = dlqLength();
 
             assertThat(dlqLengthAfterEvent, is(not(EMPTY_DLQ)));
             writer.writeEntry(dlqEntry);
@@ -144,22 +130,73 @@ public class DeadLetterQueueWriterTest {
         DLQEntry entry = new DLQEntry(new Event(), "type", "id", "reason");
 
         int payloadLength = RECORD_HEADER_SIZE + VERSION_SIZE + entry.serialize().length;
-        final int MESSAGE_COUNT= 5;
+        final int MESSAGE_COUNT = 5;
         long MAX_QUEUE_LENGTH = payloadLength * MESSAGE_COUNT;
-        DeadLetterQueueWriter writer = null;
 
-        try{
-            writer = new DeadLetterQueueWriter(dir, payloadLength, MAX_QUEUE_LENGTH);
+
+        try (DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, payloadLength, MAX_QUEUE_LENGTH, Duration.ofSeconds(1))) {
+
             for (int i = 0; i < MESSAGE_COUNT; i++)
                 writer.writeEntry(entry);
 
+            // Sleep to allow flush to happen
+            Thread.sleep(2000);
             assertThat(dlqLength(), is(MAX_QUEUE_LENGTH));
             writer.writeEntry(entry);
+            Thread.sleep(2000);
             assertThat(dlqLength(), is(MAX_QUEUE_LENGTH));
-        } finally {
-            if (writer != null) {
-                writer.close();
+        }
+    }
+
+    @Test
+    public void testSlowFlush() throws Exception {
+        try (DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 1_000_000, Duration.ofSeconds(1))) {
+            DLQEntry entry = new DLQEntry(new Event(), "type", "id", "1");
+            writer.writeEntry(entry);
+            entry = new DLQEntry(new Event(), "type", "id", "2");
+            // Sleep to allow flush to happen\
+            Thread.sleep(2000);
+            writer.writeEntry(entry);
+            Thread.sleep(2000);
+            // Do not close here - make sure that the slow write is processed
+
+            try (DeadLetterQueueReader reader = new DeadLetterQueueReader(dir)) {
+                assertThat(reader.pollEntry(100).getReason(), is("1"));
+                assertThat(reader.pollEntry(100).getReason(), is("2"));
             }
+        }
+    }
+
+
+    @Test
+    public void testNotFlushed() throws Exception {
+        try (DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, BLOCK_SIZE, 1_000_000_000, Duration.ofSeconds(5))) {
+            for (int i = 0; i < 4; i++) {
+                DLQEntry entry = new DLQEntry(new Event(), "type", "id", "1");
+                writeManager.writeEntry(entry);
+            }
+
+            // Allow for time for scheduled flush check
+            Thread.sleep(1000);
+
+            try (DeadLetterQueueReader readManager = new DeadLetterQueueReader(dir)) {
+                for (int i = 0; i < 4; i++) {
+                    DLQEntry entry = readManager.pollEntry(100);
+                    assertThat(entry, is(CoreMatchers.nullValue()));
+                }
+            }
+        }
+    }
+
+
+    @Test
+    public void testCloseFlush() throws Exception {
+        try (DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, 1000, 1_000_000, Duration.ofHours(1))) {
+            DLQEntry entry = new DLQEntry(new Event(), "type", "id", "1");
+            writer.writeEntry(entry);
+        }
+        try (DeadLetterQueueReader reader = new DeadLetterQueueReader(dir)) {
+            assertThat(reader.pollEntry(100).getReason(), is("1"));
         }
     }
 

--- a/qa/integration/build.gradle
+++ b/qa/integration/build.gradle
@@ -46,4 +46,13 @@ tasks.register("integrationTests", Test) {
   inputs.files fileTree("${projectDir}/specs")
   systemProperty 'logstash.core.root.dir', projectDir.absolutePath
   include '/org/logstash/integration/RSpecTests.class'
+
+  outputs.upToDateWhen {
+    if (project.hasProperty('integrationTests.rerun')) {
+      println "Rerunning Integration Tests"
+      return false
+    } else {
+      return true
+    }
+  }
 }

--- a/qa/integration/specs/spec_helper.rb
+++ b/qa/integration/specs/spec_helper.rb
@@ -26,6 +26,10 @@ end
 RSpec::Matchers.define :have_hits do |expected|
   match do |actual|
     # For Elasticsearch versions 7+, the result is in a value field, just in total for > 6
-    expected == actual['hits']['total'].is_a?(Hash) ? actual['hits']['total']['value'] : actual['hits']['total']
+    if actual['hits']['total'].is_a?(Hash)
+      expected == actual['hits']['total']['value']
+    else
+      expected == actual['hits']['total']
+    end
   end
 end


### PR DESCRIPTION
Clean backport of #12304

This commit changes the DLQ writer to write to a temporary file
 which will be renamed on "completion", to avoid the possibility
 of the DLQ reader reading an incomplete DLQ segment. The temp file
 will be renamed and made available, either when the capacity of this
 segment is reached, or if a configurable 'flush interval' has elapsed
 since the last event reached the dead letter queue.

This commit fixes #8022, #10275, #10967
This commit replaces #11127
