### PR TITLE
Fix env2yaml syntax error

### DIFF
--- a/docker/data/logstash/env2yaml/env2yaml.go
+++ b/docker/data/logstash/env2yaml/env2yaml.go
@@ -57,7 +57,7 @@ func normalizeSetting(setting string) (string, error) {
 		"pipeline.batch.delay",
 		"pipeline.unsafe_shutdown",
 		"pipeline.java_execution",
-		"pipeline.ecs_compatibility"
+		"pipeline.ecs_compatibility",
 		"pipeline.plugin_classloaders",
 		"path.config",
 		"config.string",


### PR DESCRIPTION
`pipeline.ecs_compatibility` setting was missing a comma after its definition. This was breaking the docker build.

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

Will run docker ci test and paste results before commit.
