### PR TITLE
[7x backport] env2yaml syntax error (#12320)

### DIFF
--- a/docker/data/logstash/env2yaml/env2yaml.go
+++ b/docker/data/logstash/env2yaml/env2yaml.go
@@ -57,7 +57,7 @@ func normalizeSetting(setting string) (string, error) {
 		"pipeline.batch.delay",
 		"pipeline.unsafe_shutdown",
 		"pipeline.java_execution",
-		"pipeline.ecs_compatibility"
+		"pipeline.ecs_compatibility",
 		"pipeline.plugin_classloaders",
 		"path.config",
 		"config.string",


### PR DESCRIPTION
Clean backport of #12320

`pipeline.ecs_compatibility` setting was missing a comma after its definition
