### PR TITLE
Fix security docs to not get 'response code '403' contacting Elastics…

### DIFF
--- a/docs/static/security/logstash.asciidoc
+++ b/docs/static/security/logstash.asciidoc
@@ -49,7 +49,7 @@ POST _security/role/logstash_writer
   "cluster": ["manage_index_templates", "monitor", "manage_ilm"], <1>
   "indices": [
     {
-      "names": [ "logstash-*" ], <2>
+      "names": [ "logstash*" ], <2>
       "privileges": ["write","create","delete","create_index","manage","manage_ilm"]  <3>
     }
   ]


### PR DESCRIPTION
…earch' as supposed in #10722.

- doc

## What does this PR do?

This PR fixes the indice name of the role 'logstash_writer' in the security docs from `logstash-*` to `logstash*`.

## Why is it important/What is the impact to the user?

This PR now allows the user to properly set up "Configuring Security in Logstash" role and user configurations.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->
- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Related issues

- Relates #10722
