### PR TITLE
more precise declaration hint

### DIFF
--- a/docs/static/management/centralized-pipelines.asciidoc
+++ b/docs/static/management/centralized-pipelines.asciidoc
@@ -77,7 +77,7 @@ The internal queueing model for event buffering. Options are *memory* for
 in-memory queueing, or *persisted* for disk-based acknowledged queueing. 
 
 Queue max bytes::
-The total capacity of the queue.
+The total capacity of the queue when persistent queues are enabled.
 
 Queue checkpoint writes::
 The maximum number of events written before a checkpoint is forced when


### PR DESCRIPTION
clarify that queue max bytes only applies to persistent queues

Please tag as {doc}

## What does this PR do?

This is to improve documentation only. In a support case, it came to light that the setting "queue max bytes" only affects persistent queues, and I cannt understand why this is not mentioned here.

## Why is it important/What is the impact to the user?

The configuration site in Kibana is absolutely not intuitive when it puts the "Queue type picker list" next to the "Queue max bytes" picker while that queue max size has absolutely no effect if queue type memory is picked.

## Checklist


- [x] I have made  changes to the documentation


## Author's Checklist


## How to test this PR locally


## Related issues


## Use cases


## Screenshots



## Logs
