### PR TITLE
Handle Windows delete pending files

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -295,8 +295,8 @@ public final class DeadLetterQueueWriter implements Closeable {
     // check if there is a corresponding .log file - if yes delete the temp file, if no atomic move the
     // temp file to be a new segment file..
     private void cleanupTempFile(final Path tempFile) {
-        String tempFilename = tempFile.getFileName().toString().split("\\.")[0];
-        Path segmentFile = queuePath.resolve(String.format("%s.log", tempFilename));
+        String segmentName = tempFile.getFileName().toString().split("\\.")[0];
+        Path segmentFile = queuePath.resolve(String.format("%s.log", segmentName));
         try {
             if (Files.exists(segmentFile)) {
                 Files.delete(tempFile);
@@ -305,16 +305,15 @@ public final class DeadLetterQueueWriter implements Closeable {
                 SegmentStatus segmentStatus = RecordIOReader.getSegmentStatus(tempFile);
                 switch (segmentStatus){
                     case VALID:
-                        logger.debug("Moving temp file {} to segment file {}", tempFilename, segmentFile);
+                        logger.debug("Moving temp file {} to segment file {}", tempFile, segmentFile);
                         Files.move(tempFile, segmentFile, StandardCopyOption.ATOMIC_MOVE);
                         break;
                     case EMPTY:
-                        logger.debug("Removing unused temp file {}", tempFilename);
-                        Files.delete(tempFile);
+                        deleteTemporaryFile(tempFile, segmentName);
                         break;
                     case INVALID:
-                        Path errorFile = queuePath.resolve(String.format("%s.err", tempFilename));
-                        logger.warn("Segment file {} is in an error state, saving as {}", tempFilename, errorFile);
+                        Path errorFile = queuePath.resolve(String.format("%s.err", segmentName));
+                        logger.warn("Segment file {} is in an error state, saving as {}", segmentFile, errorFile);
                         Files.move(tempFile, errorFile, StandardCopyOption.ATOMIC_MOVE);
                         break;
                     default:
@@ -324,5 +323,26 @@ public final class DeadLetterQueueWriter implements Closeable {
         } catch (IOException e){
             throw new IllegalStateException("Unable to clean up temp file: " + tempFile, e);
         }
+    }
+
+    // Windows can leave files in a "Delete pending" state, where the file presents as existing to certain
+    // methods, and not to others, and actively prevents a new file being created with the same file name,
+    // throwing AccessDeniedException. This method moves the temporary file to a .del file before
+    // deletion, enabling a new temp file to be created in its place.
+    private void deleteTemporaryFile(Path tempFile, String segmentName) throws IOException {
+        Path deleteTarget;
+        if (isWindows()) {
+            Path deletedFile = queuePath.resolve(String.format("%s.del", segmentName));
+            logger.debug("Moving temp file {} to {}", tempFile, deletedFile);
+            deleteTarget = deletedFile;
+            Files.move(tempFile, deletedFile, StandardCopyOption.ATOMIC_MOVE);
+        } else {
+            deleteTarget = tempFile;
+        }
+        Files.delete(deleteTarget);
+    }
+
+    private static boolean isWindows(){
+        return System.getProperty("os.name").startsWith("Windows");
     }
 }


### PR DESCRIPTION
When deleting temporary files created by the DLQ writer to store data before moving to their
final location, Windows may leave these files in a "delete pending" state, where the files
are somewhat in a state of limbo, where they result of `Files.exist(filename)` is `false`,
but the result of `filename.toFile().exists()` is true. When files are in this state, a new
file with the same name cannot be created, which causes the DLQ test used to ensure that
closing and reopening the DLQ (in such events as a pipeline restart) to fail.


## What does this PR do?


This commit moves the temporary file to an alternative location before deletion, ensuring that
the "pending delete" status does not interrupt with the DLQ startup

## Why is it important/What is the impact to the user?

This commit fixes integration tests on the Windows platform, which were impacted by the delete pending state of the temporary file stopping new temporary files from being created. This potentially could impact Windows users utilizing the DLQ and reloading pipelines

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works. _This fixes previously broken tests_

This is a link to the Windows compatibility test run using this commit:

https://logstash-ci.elastic.co/job/elastic+logstash+master+multijob-windows-compatibility/228/