### PR TITLE
Doc: Clarify use of queue max bytes setting

### DIFF
--- a/docs/static/management/centralized-pipelines.asciidoc
+++ b/docs/static/management/centralized-pipelines.asciidoc
@@ -77,7 +77,7 @@ The internal queueing model for event buffering. Options are *memory* for
 in-memory queueing, or *persisted* for disk-based acknowledged queueing. 
 
 Queue max bytes::
-The total capacity of the queue.
+The total capacity of the queue when persistent queues are enabled.
 
 Queue checkpoint writes::
 The maximum number of events written before a checkpoint is forced when


### PR DESCRIPTION
Queue max bytes only applies to persistent queues

Forwardports: #12334 to 7.x