### PR TITLE
[doc] Add note to Logstash repo install

### DIFF
--- a/docs/static/getting-started-with-logstash.asciidoc
+++ b/docs/static/getting-started-with-logstash.asciidoc
@@ -70,7 +70,7 @@ to sign all our packages. It is available from https://pgp.mit.edu.
 When installing from a package repository (or from the DEB or RPM),
 you will need to run Logstash as a service. Please refer to
 {logstash-ref}/running-logstash.html[Running Logstash as a Service] for more
-information).
+information.
 
 For testing purposes, you may still run Logstash from the command line, but
 you may need to define the default setting options (described in

--- a/docs/static/getting-started-with-logstash.asciidoc
+++ b/docs/static/getting-started-with-logstash.asciidoc
@@ -67,7 +67,7 @@ to sign all our packages. It is available from https://pgp.mit.edu.
 
 [NOTE]
 --
-When installing from a package repository (or from the DEB or RPM),
+When installing from a package repository (or from the DEB or RPM installation file),
 you will need to run Logstash as a service. Please refer to
 {logstash-ref}/running-logstash.html[Running Logstash as a Service] for more
 information.

--- a/docs/static/getting-started-with-logstash.asciidoc
+++ b/docs/static/getting-started-with-logstash.asciidoc
@@ -65,6 +65,20 @@ Elastic's Signing Key, with fingerprint
 
 to sign all our packages. It is available from https://pgp.mit.edu.
 
+[NOTE]
+--
+When installing from a package repository (or from the DEB or RPM),
+you will need to run Logstash as a service. Please refer to
+{logstash-ref}/running-logstash.html[Running Logstash as a Service] for more
+information).
+
+For testing purposes, you may still run Logstash from the command line, but
+you may need to define the default setting options (described in
+{logstash-ref}/dir-layout.html[Logstash Directory Layout]) manually. Please
+refer to {logstash-ref}/running-logstash-command-line.html[Running Logstash from the Command Line]
+for more information.
+--
+
 [float]
 ==== APT
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- docs
-->

## What does this PR do?

Add a note to the documentation to clarify that Logstash needs to be run as a service when installing from a package repository or a deb or rpm.

## Why is it important/What is the impact to the user?

Attempts to clarify that if you install Logstash through this means, the way to manage it is as a service, and that you should only run it manually for testing purposes.

