### PR TITLE
[DOC] Remove reference to puppet LS module

### DIFF
--- a/docs/static/config-management.asciidoc
+++ b/docs/static/config-management.asciidoc
@@ -6,8 +6,7 @@ manage updates to your configuration over time.
 
 The topics in this section describe Logstash configuration management features
 only. For information about other config management tools, such as Puppet and
-Chef, see the documentation for those projects. Also take a look at the
-https://forge.puppet.com/elastic/logstash[Logstash Puppet module documentation].
+Chef, see the documentation for those projects.
 
 :edit_url!:
 include::management/centralized-pipelines.asciidoc[]


### PR DESCRIPTION
As the module is not maintained since 2018 and it was community supported, I would like to remove it from the documentation.
If possible, please backport it to previous versions.

FYI @karenzone please reach me out if you have any question.