### PR TITLE
Build: properly isolate integration (test) env setup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -316,8 +316,9 @@ tasks.register("unpackTarDistribution", Copy) {
   into {buildDir}
 }
 
-def qaVendorPath = "${buildDir}/qa/integration/vendor"
-def qaBundledGemPath = "${qaVendorPath}/jruby/2.5.0"
+def qaBuildPath = "${buildDir}/qa/integration"
+def qaVendorPath = "${qaBuildPath}/vendor"
+def qaBundledGemPath = "${qaVendorPath}/jruby/2.5.0".toString()
 def qaBundleBin = "${qaBundledGemPath}/bin/bundle"
 
 tasks.register("installIntegrationTestBundler"){
@@ -340,8 +341,11 @@ tasks.register("installIntegrationTestGems") {
   doLast {
       bundleWithEnv(
         projectDir, buildDir,
-        "${projectDir}/qa/integration", qaBundleBin, ['install', '--path', qaVendorPath],
-        [LS_GEM_PATH: qaBundledGemPath, LS_GEM_HOME: qaBundledGemPath]
+        qaBuildPath, qaBundleBin, ['install', '--path', qaVendorPath],
+        [
+                GEM_PATH: qaBundledGemPath, GEM_HOME: qaBundledGemPath,
+                LS_GEM_PATH: qaBundledGemPath, LS_GEM_HOME: qaBundledGemPath
+        ]
       )
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -342,10 +342,7 @@ tasks.register("installIntegrationTestGems") {
       bundleWithEnv(
         projectDir, buildDir,
         qaBuildPath, qaBundleBin, ['install', '--path', qaVendorPath],
-        [
-                GEM_PATH: qaBundledGemPath, GEM_HOME: qaBundledGemPath,
-                LS_GEM_PATH: qaBundledGemPath, LS_GEM_HOME: qaBundledGemPath
-        ]
+        [ GEM_PATH: qaBundledGemPath, GEM_HOME: qaBundledGemPath ]
       )
   }
 }

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "mustermann", '~> 1.0.3'
   gem.add_runtime_dependency "sinatra", '~> 2'
   gem.add_runtime_dependency 'puma', '~> 4'
-  gem.add_runtime_dependency "jruby-openssl", "= 0.10.4" # >= 0.9.13 Required to support TLSv1.2; 0.10.5 is causing dependency issue in integration test #12299
+  gem.add_runtime_dependency "jruby-openssl", "~> 0.10" # >= 0.9.13 Required to support TLSv1.2
 
   gem.add_runtime_dependency "treetop", "~> 1" #(MIT license)
 

--- a/qa/integration/integration_tests.gemspec
+++ b/qa/integration/integration_tests.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'stud', '~> 0.0.22'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec', '~> 3.5'
-  s.add_development_dependency 'logstash-devutils', '= 1.3.5'
+  s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'flores'
   s.add_development_dependency 'rubyzip'
 end


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## What does this PR do?

This PR 'properly' resolves LS failing on integration tests with a newer jruby-openssl release.
The failure LS run into was due to how gems where being install-ed for integration tests.
There's a detailed explanation on the [issue](https://github.com/elastic/logstash/issues/12299#issuecomment-711758291).

## How to test this PR locally

`./gradlew :logstash-integration-tests:integrationTests`

## Related issues

resolves GH-12299 (reverting GH-12300)


