### PR TITLE
Benchmark CLI: Fixes exception in metrics collection in LS 7.3.0 and higher

### DIFF
--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/LsMetricsMonitor.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/LsMetricsMonitor.java
@@ -109,9 +109,10 @@ public final class LsMetricsMonitor implements Callable<EnumMap<LsMetricStats, L
             }
             final Map<String, Object> data = LsBenchJsonUtil.deserializeMetrics(baos.toByteArray());
             final long count;
-            if (data.containsKey("pipeline")) {
+            if (data.containsKey("pipelines")) {    
+                count = readNestedLong(data, "pipelines", "main", "events", "filtered");
+            } else if (data.containsKey("pipeline")) {
                 count = readNestedLong(data, "pipeline", "events", "filtered");
-
             } else if (data.containsKey("events")) {
                 count = readNestedLong(data, "events", "filtered");
             } else {
@@ -140,6 +141,9 @@ public final class LsMetricsMonitor implements Callable<EnumMap<LsMetricStats, L
         Map<String, Object> nested = map;
         for (int i = 0; i < path.length - 1; ++i) {
             nested = (Map<String, Object>) nested.get(path[i]);
+        }
+        if (nested == null) {
+            return -1L;
         }
         return ((Number) nested.get(path[path.length - 1])).longValue();
     }


### PR DESCRIPTION
## What does this PR do?
The Benchmark CLI did not work for releases 7.3.0 and higher. I believe the issue is a different structure of the json which includes the filtered events.
I used the baseline test to see where it stopped working and from my tests 7.2.0 was the last logstash version the cli is working against.
`java -cp 'benchmark-cli.jar:*' org.logstash.benchmark.cli.Main --workdir=/tmp/benchmark2 --testcase=baseline --distribution-version=7.3.0`

I have attached the exception to the logs section.


Looking into was is done at that point is the lookup of the nested field _pipeline.events.filtered_.

I dumped the data to stdout and it seemed that the structure is a different one.
`pipeline={workers=2, batch_size=128, batch_delay=50}, pipelines={main={events={in=1025, filtered=512, out=512, duration_in_millis=1184, queue_push_duration_in_millis=1253},` such as _pipelines.main.events.filtered_

I have added this as an additional nested metric to the IF-ELSE logic in LsMetricsMonitor.java. With this change the CLI can be run against releases 7.3.0 and higher of logstash.

## Why is it important/What is the impact to the user?
The benchmark runs through but during the parsing of the result an error is thrown. This happens for logstash releases higher than 7.2.0. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
~-[ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
~- [ ] I have added tests that prove my fix is effective or that my feature works~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Double check that this really is the cause for the exception 

## How to test this PR locally

With the current master release this `java -cp 'benchmark-cli.jar:*' org.logstash.benchmark.cli.Main --workdir=/tmp/benchmark2 --testcase=baseline --distribution-version=7.3.0` will result in an error and `java -cp 'benchmark-cli.jar:*' org.logstash.benchmark.cli.Main --workdir=/tmp/benchmark2 --testcase=baseline --distribution-version=7.2.0` will work as expected.

WIth the fix both should display the results.

## Related issues
- 

## Use cases


## Screenshots


## Logs
`Exception in thread "main" java.lang.IllegalStateException: java.util.concurrent.ExecutionException: java.lang.NullPointerException: Cannot invoke "java.util.Map.get(Object)" because "nested" is null
	at org.logstash.benchmark.cli.cases.GeneratorToStdout.run(GeneratorToStdout.java:73)
	at org.logstash.benchmark.cli.cases.GeneratorToStdout.run(GeneratorToStdout.java:39)
	at org.logstash.benchmark.cli.Main.execute(Main.java:219)
	at org.logstash.benchmark.cli.Main.main(Main.java:161)
Caused by: java.util.concurrent.ExecutionException: java.lang.NullPointerException: Cannot invoke "java.util.Map.get(Object)" because "nested" is null
	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:205)
	at org.logstash.benchmark.cli.LsMetricsMonitor$MonitorExecution.stopAndGet(LsMetricsMonitor.java:179)
	at org.logstash.benchmark.cli.cases.GeneratorToStdout.run(GeneratorToStdout.java:71)
	... 3 more
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.Map.get(Object)" because "nested" is null
	at org.logstash.benchmark.cli.LsMetricsMonitor.readNestedLong(LsMetricsMonitor.java:144)
	at org.logstash.benchmark.cli.LsMetricsMonitor.getCounts(LsMetricsMonitor.java:113)
	at org.logstash.benchmark.cli.LsMetricsMonitor.call(LsMetricsMonitor.java:68)
	at org.logstash.benchmark.cli.LsMetricsMonitor.call(LsMetricsMonitor.java:42)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)`


