### PR TITLE
jvm options: introduce override config for cli-based tools

### DIFF
--- a/bin/dependencies-report
+++ b/bin/dependencies-report
@@ -27,7 +27,7 @@ else
 fi
 
 . "$(cd `dirname ${SOURCEPATH}`/..; pwd)/bin/logstash.lib.sh"
-setup
+setup_cli_tool
 
 mkdir -p build
 ruby_exec "logstash-core/lib/logstash/dependency_report_runner.rb" "$@"

--- a/bin/logstash-keystore
+++ b/bin/logstash-keystore
@@ -2,7 +2,7 @@
 
 unset CDPATH
 . "$(cd `dirname $0`/..; pwd)/bin/logstash.lib.sh"
-setup
+setup_cli_tool
 
 # bin/logstash-keystore is a short lived ruby script thus we can use aggressive "faster starting JRuby options"
 # see https://github.com/jruby/jruby/wiki/Improving-startup-time

--- a/bin/logstash-plugin
+++ b/bin/logstash-plugin
@@ -2,7 +2,7 @@
 
 unset CDPATH
 . "$(cd `dirname $0`/..; pwd)/bin/logstash.lib.sh"
-setup
+setup_cli_tool
 
 # bin/logstash-plugin is a short lived ruby script thus we can use aggressive "faster starting JRuby options"
 # see https://github.com/jruby/jruby/wiki/Improving-startup-time

--- a/bin/pqcheck
+++ b/bin/pqcheck
@@ -26,7 +26,7 @@ else
 fi
 
 . "$(cd `dirname ${SOURCEPATH}`/..; pwd)/bin/logstash.lib.sh"
-setup
+setup_cli_tool
 
 unset CLASSPATH
 for J in $(cd "${LOGSTASH_JARS}"; ls *.jar); do

--- a/bin/pqrepair
+++ b/bin/pqrepair
@@ -26,7 +26,7 @@ else
 fi
 
 . "$(cd `dirname ${SOURCEPATH}`/..; pwd)/bin/logstash.lib.sh"
-setup
+setup_cli_tool
 
 unset CLASSPATH
 for J in $(cd "${LOGSTASH_JARS}"; ls *.jar); do

--- a/bin/system-install
+++ b/bin/system-install
@@ -2,7 +2,7 @@
 
 unset CDPATH
 . "$(cd `dirname $0`/..; pwd)/bin/logstash.lib.sh"
-setup
+setup_cli_tool
 
 if [ -z "$1" ]; then
   if [ -r /etc/logstash/startup.options ]; then

--- a/config/cli-jvm.options
+++ b/config/cli-jvm.options
@@ -1,0 +1,7 @@
+# JVM Options specified in this file are used when running command-line helper tools
+# and _override_ options specified in the adjacent `jvm.options` configuration file.
+
+# TODO: This file has no effect on Windows when invoking *.bat launchers
+
+-Xms1G
+-Xmx1G

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -564,6 +564,9 @@ namespace "artifact" do
     File.join(basedir, "config", "jvm.options").tap do |path|
       dir.input("#{path}=/etc/logstash")
     end
+    File.join(basedir, "config", "cli-jvm.options").tap do |path|
+      dir.input("#{path}=/etc/logstash")
+    end
     File.join(basedir, "config", "logstash.yml").tap do |path|
       dir.input("#{path}=/etc/logstash")
     end
@@ -589,6 +592,7 @@ namespace "artifact" do
         out.attributes[:rpm_os] = "linux"
         out.config_files << "/etc/logstash/startup.options"
         out.config_files << "/etc/logstash/jvm.options"
+        out.config_files << "/etc/logstash/cli-jvm.options"
         out.config_files << "/etc/logstash/log4j2.properties"
         out.config_files << "/etc/logstash/logstash.yml"
         out.config_files << "/etc/logstash/logstash-sample.conf"
@@ -605,6 +609,7 @@ namespace "artifact" do
         out.attributes[:deb_suggests] = "java8-runtime-headless" unless bundle_jdk
         out.config_files << "/etc/logstash/startup.options"
         out.config_files << "/etc/logstash/jvm.options"
+        out.config_files << "/etc/logstash/cli-jvm.options"
         out.config_files << "/etc/logstash/log4j2.properties"
         out.config_files << "/etc/logstash/logstash.yml"
         out.config_files << "/etc/logstash/logstash-sample.conf"


### PR DESCRIPTION
## What does this PR do?

This PR introduces a `cli-jvm.options` sibling to the existing `jvm.options` config, providing sane defaults for CLI-based tooling to _override_ the settings in the `jvm.options` file. In cases where the logstash service's HEAP was configured to use more than 50% of available memory in the system, a bare invocation of any of our command-line tools while the service was running could result in failure to allocate sufficient memory for the command-line tool.

While a user has long been able to override options specified in the `jvm.options` file with the `LS_JAVA_OPTS` environment variable, this is cumbersome to use in practice and hard to find. My prior workaround has been to export `LS_JAVA_OPTS` with production options only in my Logstash service definition, and to leave `jvm.options` unmodified, but this is an opaque solution that is harder to reason about than keeping config in dedicated files.

I extracted the options-file-finder into a separate shell function, and re-used it to find the sibling `cli-jvm.options` file. The CLI-based tooling then invokes `setup_cli_tool` which prepends the options specified in any found `cli-jvm.options` to the existing `LS_JAVA_OPTS` environment variable.

When invoking `bin/logstash`, precedence remains unchanged:
 * `$LS_JAVA_OPTS` - environment override
 * `jvm.options` - base

When invoking any of the command-line tooling, precedence becomes:
* `$LS_JAVA_OPTS` - environment override
* `cli-jvm.options` - CLI-tooling override
* `jvm.options` - base

## Why is it important/What is the impact to the user?

Real-world invocations of command-line tools are more likely to "just work" when configured on tuned production logstash instances, and the user has a clear path to overriding behaviour explicitly for these command-line tools

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [ ] equalize support for this pathway in `*.bat` helpers, which currently _only_ use `$LS_JAVA_OPTS` (only `bin/logstash.bat` currently consumes `jvm.options`)

## How to test this PR locally

 * Configure LS with an absurd heap requirement (e.g., `-Xms128G` `-Xmx128G` on a system with < 128GB RAM)
 * Launch Logstash (`bin/logstash -e '')
   * Observe that it allocates a huge amount for heap (e.g., `GET http://localhost:9600/_node/stats/`)
 * Launch a command line helper (`bin/logstash-plugin list --verbose`)
   * Observe that the helper executes without running out of memory.

## Related issues

- Related: https://github.com/elastic/logstash/issues/9217
