### PR TITLE
add wildcard support in xpack pipeline id

### DIFF
--- a/x-pack/lib/config_management/bootstrap_check.rb
+++ b/x-pack/lib/config_management/bootstrap_check.rb
@@ -46,9 +46,9 @@ module LogStash
           raise LogStash::BootstrapCheckError, "You need to specify the ID of the pipelines with the `xpack.management.pipeline.id` options in your logstash.yml"
         end
 
-        invalid_pipeline_ids =  pipeline_ids.reject { |entry| PIPELINE_ID_PATTERN =~ entry }
-        if invalid_pipeline_ids.any?
-          raise LogStash::BootstrapCheckError, "Pipeline id in `xpack.management.pipeline.id` must begin with a letter or underscore and contain only letters, underscores, dashes, and numbers. The asterisk wildcard `*` can also be used. Invalid ids: #{invalid_pipeline_ids.join(', ')}"
+        invalid_patterns =  pipeline_ids.reject { |entry| PIPELINE_ID_PATTERN =~ entry }
+        if invalid_patterns.any?
+          raise LogStash::BootstrapCheckError, "Pipeline id in `xpack.management.pipeline.id` must begin with a letter or underscore and contain only letters, underscores, dashes, and numbers. The asterisk wildcard `*` can also be used. Invalid ids: #{invalid_patterns.join(', ')}"
         end
 
         duplicate_ids = find_duplicate_ids(pipeline_ids)

--- a/x-pack/lib/config_management/bootstrap_check.rb
+++ b/x-pack/lib/config_management/bootstrap_check.rb
@@ -14,6 +14,10 @@ module LogStash
     class BootstrapCheck
       include LogStash::Util::Loggable
 
+      # pipeline ID must begin with a letter or underscore and contain only letters, underscores, dashes, and numbers
+      # wildcard character `*` is also acceptable and follows globbing rules
+      PIPELINE_ID_PATTERN = %r{\A[a-z_*][a-z_\-0-9*]*\Z}i
+
       def self.check(settings)
         check_path_config(settings)
 
@@ -40,6 +44,11 @@ module LogStash
 
         if pipeline_ids.reject { |id| id.strip.empty? }.empty?
           raise LogStash::BootstrapCheckError, "You need to specify the ID of the pipelines with the `xpack.management.pipeline.id` options in your logstash.yml"
+        end
+
+        invalid_pipeline_ids =  pipeline_ids.reject { |entry| PIPELINE_ID_PATTERN =~ entry }
+        if invalid_pipeline_ids.any?
+          raise LogStash::BootstrapCheckError, "Pipeline id in `xpack.management.pipeline.id` must begin with a letter or underscore and contain only letters, underscores, dashes, and numbers. The asterisk wildcard `*` can also be used. Invalid ids: #{invalid_pipeline_ids.join(', ')}"
         end
 
         duplicate_ids = find_duplicate_ids(pipeline_ids)

--- a/x-pack/lib/config_management/elasticsearch_source.rb
+++ b/x-pack/lib/config_management/elasticsearch_source.rb
@@ -193,7 +193,7 @@ module LogStash
       def get_single_pipeline_setting(pipeline_id) end
 
       def log_pipeline_not_found(pipeline_ids)
-        logger.debug("Could not find a remote configuration for specific `pipeline_id` or the wildcard setting is not relevant", :pipeline_ids => pipeline_ids) if pipeline_ids.any?
+        logger.debug("Could not find a remote configuration for specific `pipeline_id`", :pipeline_ids => pipeline_ids) if pipeline_ids.any?
       end
     end
 
@@ -231,7 +231,7 @@ module LogStash
         wildcard_matched_patterns = Set.new
         wildcard_pipelines = response.keys.map { |id|
           found_pattern = wildcard_patterns.any? { |pattern|
-            matched = ::File::fnmatch?(pattern, id, ::File::FNM_EXTGLOB)
+            matched = ::File::fnmatch?(pattern, id)
             wildcard_matched_patterns << pattern if matched
             matched
           }

--- a/x-pack/lib/config_management/elasticsearch_source.rb
+++ b/x-pack/lib/config_management/elasticsearch_source.rb
@@ -231,7 +231,7 @@ module LogStash
         wildcard_matched_patterns = Set.new
         wildcard_pipelines = response.keys.map { |id|
           found_pattern = wildcard_patterns.any? { |pattern|
-            matched = ::File::fnmatch(pattern, id, ::File::FNM_EXTGLOB)
+            matched = ::File::fnmatch?(pattern, id, ::File::FNM_EXTGLOB)
             wildcard_matched_patterns << pattern if matched
             matched
           }

--- a/x-pack/lib/config_management/elasticsearch_source.rb
+++ b/x-pack/lib/config_management/elasticsearch_source.rb
@@ -265,6 +265,7 @@ module LogStash
 
         @pipelines = format_response(response)
 
+        log_wildcard_unsupported(pipeline_ids)
         log_pipeline_not_found(pipeline_ids - @pipelines.keys)
 
         @pipelines
@@ -281,6 +282,13 @@ module LogStash
           {pipeline["_id"] => pipeline} if pipeline.fetch("found", false)
         }.compact
         .reduce({}, :merge)
+      end
+
+      def log_wildcard_unsupported(pipeline_ids)
+        has_wildcard = pipeline_ids.any? { |id| id.include?("*") }
+        if has_wildcard
+          logger.info("wildcard '*' in xpack.management.pipeline.id is not supported in Elasticsearch version < 7.10")
+        end
       end
     end
 

--- a/x-pack/lib/config_management/elasticsearch_source.rb
+++ b/x-pack/lib/config_management/elasticsearch_source.rb
@@ -287,7 +287,7 @@ module LogStash
       def log_wildcard_unsupported(pipeline_ids)
         has_wildcard = pipeline_ids.any? { |id| id.include?("*") }
         if has_wildcard
-          logger.info("wildcard '*' in xpack.management.pipeline.id is not supported in Elasticsearch version < 7.10")
+          logger.warn("wildcard '*' in xpack.management.pipeline.id is not supported in Elasticsearch version < 7.10")
         end
       end
     end

--- a/x-pack/lib/config_management/elasticsearch_source.rb
+++ b/x-pack/lib/config_management/elasticsearch_source.rb
@@ -80,17 +80,12 @@ module LogStash
         fetcher = get_pipeline_fetcher
         fetcher.fetch_config(pipeline_ids, client)
 
-        @cached_pipelines = pipeline_ids.collect do |pid|
+        @cached_pipelines = fetcher.get_pipelines_key.collect do |pid|
           get_pipeline(pid, fetcher)
         end.compact
       end
 
       def get_pipeline(pipeline_id, fetcher)
-        unless fetcher.config_exist?(pipeline_id)
-          logger.debug("Could not find a remote configuration for a specific `pipeline_id`", :pipeline_id => pipeline_id)
-          return nil
-        end
-
         config_string = fetcher.get_single_pipeline_setting(pipeline_id)["pipeline"]
 
         raise RemoteConfigError, "Empty configuration for pipeline_id: #{pipeline_id}" if config_string.nil? || config_string.empty?
@@ -188,12 +183,18 @@ module LogStash
     end
 
     module Fetcher
-      def config_exist?(pipeline_id)
-        @response.has_key?(pipeline_id)
+      include LogStash::Util::Loggable
+
+      def get_pipelines_key
+        @pipelines.keys
       end
 
       def fetch_config(pipeline_ids, client) end
       def get_single_pipeline_setting(pipeline_id) end
+
+      def log_pipeline_not_found(pipeline_ids)
+        logger.debug("Could not find a remote configuration for specific `pipeline_id` or the wildcard setting is not relevant", :pipeline_ids => pipeline_ids) if pipeline_ids.any?
+      end
     end
 
     class SystemIndicesFetcher
@@ -202,18 +203,47 @@ module LogStash
       SYSTEM_INDICES_API_PATH = "_logstash/pipeline"
 
       def fetch_config(pipeline_ids, client)
-        path_ids = pipeline_ids.join(",")
-        response = client.get("#{SYSTEM_INDICES_API_PATH}/#{path_ids}")
+        response = client.get("#{SYSTEM_INDICES_API_PATH}/")
 
         if response["error"]
           raise ElasticsearchSource::RemoteConfigError, "Cannot find find configuration for pipeline_id: #{pipeline_ids}, server returned status: `#{response["status"]}`, message: `#{response["error"]}`"
         end
 
-        @response = response
+        @pipelines = get_wildcard_pipelines(pipeline_ids, response)
       end
 
       def get_single_pipeline_setting(pipeline_id)
-        @response.fetch(pipeline_id, {})
+        @pipelines.fetch(pipeline_id, {})
+      end
+
+      private
+      # get pipelines if pipeline_ids match wildcard patterns
+      # split user pipeline id setting into wildcard and non wildcard pattern
+      # take the non wildcard pipelines. transform user's wildcard pattern to valid regex pattern and do the matching
+      def get_wildcard_pipelines(pipeline_ids, response)
+        wildcard_patterns, fix_pids = pipeline_ids.partition { |pattern| pattern.include?("*")}
+
+        fix_id_pipelines = fix_pids.map { |id|
+          response.has_key?(id) ? {id => response[id]}: {}
+        }.reduce({}, :merge)
+        fix_id_pipelines.keys.map { |id| response.delete(id)}
+
+        wildcard_matched_patterns = Set.new
+        wildcard_pattern_regex = wildcard_patterns.map { |pattern|
+          {pattern => Regexp.new("^" + pattern.gsub("*", ".*") + "$")}
+        }.reduce({}, :merge)
+        wildcard_pipelines = response.keys.map { |id|
+          found_pattern = wildcard_pattern_regex.keys.any? { |pattern|
+            matched = id.match?(wildcard_pattern_regex[pattern])
+            wildcard_matched_patterns << pattern if matched
+            matched
+          }
+          found_pattern ? {id => response[id]}: {}
+        }.reduce({}, :merge)
+
+        log_pipeline_not_found((fix_pids - fix_id_pipelines.keys) + (wildcard_patterns - wildcard_matched_patterns.to_a))
+
+        fix_id_pipelines.merge(wildcard_pipelines)
       end
     end
 
@@ -236,11 +266,15 @@ module LogStash
           raise ElasticsearchSource::RemoteConfigError, "Elasticsearch returned an unknown or malformed document structure"
         end
 
-        @response = format_response(response)
+        @pipelines = format_response(response)
+
+        log_pipeline_not_found(pipeline_ids - @pipelines.keys)
+
+        @pipelines
       end
 
       def get_single_pipeline_setting(pipeline_id)
-        @response.fetch(pipeline_id, {}).fetch("_source", {})
+        @pipelines.fetch(pipeline_id, {}).fetch("_source", {})
       end
 
       private

--- a/x-pack/spec/config_management/bootstrap_check_spec.rb
+++ b/x-pack/spec/config_management/bootstrap_check_spec.rb
@@ -177,6 +177,40 @@ describe LogStash::ConfigManagement::BootstrapCheck do
         end
       end
 
+      context "when defining invalid patterns" do
+        let(:pipeline_ids) { ["pipeline1", "pipeline2", "@o@"] }
+        let(:settings) do
+          apply_settings(
+            {
+              "xpack.management.enabled" => true,
+              "xpack.management.pipeline.id" => pipeline_ids
+            },
+            system_settings
+          )
+        end
+
+        it "raises a `LogStash::BootstrapCheckError` with the invalid patterns" do
+          expect { subject.check(settings) }.to raise_error LogStash::BootstrapCheckError, /@o@/
+        end
+      end
+
+      context "when defining wildcard patterns" do
+        let(:pipeline_ids) { ["pipeline1", "pipeline2", "*pipeline*"] }
+        let(:settings) do
+          apply_settings(
+              {
+                  "xpack.management.enabled" => true,
+                  "xpack.management.pipeline.id" => pipeline_ids
+              },
+              system_settings
+          )
+        end
+
+        it "does not raise a `LogStash::BootstrapCheckError` error" do
+          expect { subject.check(settings) }.to_not raise_error
+        end
+      end
+
       context "when defining duplicate ids" do
         let(:pipeline_ids) { ["pipeline1", "pipeline2", "pipeline1"] }
         let(:settings) do

--- a/x-pack/spec/config_management/elasticsearch_source_spec.rb
+++ b/x-pack/spec/config_management/elasticsearch_source_spec.rb
@@ -324,6 +324,11 @@ describe LogStash::ConfigManagement::ElasticsearchSource do
         expect(result.has_key?(pipeline_id)).to be_truthy
         expect(result.has_key?(another_pipeline_id)).to be_truthy
       end
+
+      it "should log wildcard warning" do
+        result = subject.send(:log_wildcard_unsupported, [pipeline_id, another_pipeline_id, "*"])
+        expect(result).not_to be_nil
+      end
     end
   end
 

--- a/x-pack/spec/config_management/fixtures/pipelines.json
+++ b/x-pack/spec/config_management/fixtures/pipelines.json
@@ -1,0 +1,60 @@
+{
+  "super_generator": {
+    "pipeline": "input { generator { count => 100 } tcp { port => 6005 } } output { }}"
+  },
+  "another_generator": {
+    "pipeline": "input { generator { count => 100 } tcp { port => 6006 } } output { file { path => '/var/folders/8g/415b_scd6ql1vxc2p128kfn40000gn/T/studtmp-b0f4079ab3df20f7eb2389958a6568b6614b38fffec1fcbf1627c4e5edc3/another_generator_new' }}",
+    "username": "log.stash",
+    "pipeline_metadata": {
+      "version": "1"
+    },
+    "pipeline_settings": {
+      "pipeline.batch.delay": "50"
+    },
+    "last_modified": "2020-10-06T23:11:38Z"
+  },
+  "host1_pipeline1": {
+    "pipeline": "input { generator { count => 10000000 }} filter { sleep { time => \"1\" every => 10}} output { file { path  => '/var/folders/8g/415b_scd6ql1vxc2p128kfn40000gn/T/studtmp-b0f4079ab3df20f7eb2389958a6568b6614b38fffec1fcbf1627c4e5edc3/host1_generator1'}}",
+    "username": "log.stash",
+    "pipeline_metadata": {
+      "version": "3"
+    },
+    "pipeline_settings": {
+      "pipeline.batch.delay": "50"
+    },
+    "last_modified": "2020-10-01T15:42:30.229Z"
+  },
+  "host1_pipeline2": {
+    "pipeline": "input { generator { count => 10000000 }} filter { sleep { time => \"1\" every => 10}} output { file { path  => '/var/folders/8g/415b_scd6ql1vxc2p128kfn40000gn/T/studtmp-b0f4079ab3df20f7eb2389958a6568b6614b38fffec1fcbf1627c4e5edc3/host1_generator2'}}",
+    "username": "log.stash",
+    "pipeline_metadata": {
+      "version": "3"
+    },
+    "pipeline_settings": {
+      "pipeline.batch.delay": "50"
+    },
+    "last_modified": "2020-10-01T15:42:30.229Z"
+  },
+  "host2_pipeline1": {
+    "pipeline": "input { generator { count => 10000000 }} filter { sleep { time => \"1\" every => 10}} output { file { path  => '/var/folders/8g/415b_scd6ql1vxc2p128kfn40000gn/T/studtmp-b0f4079ab3df20f7eb2389958a6568b6614b38fffec1fcbf1627c4e5edc3/host2_generator1'}}",
+    "username": "log.stash",
+    "pipeline_metadata": {
+      "version": "3"
+    },
+    "pipeline_settings": {
+      "pipeline.batch.delay": "50"
+    },
+    "last_modified": "2020-10-01T15:42:30.229Z"
+  },
+  "host2_pipeline2": {
+    "pipeline": "input { generator { count => 10000000 }} filter { sleep { time => \"1\" every => 10}} output { file { path  => '/var/folders/8g/415b_scd6ql1vxc2p128kfn40000gn/T/studtmp-b0f4079ab3df20f7eb2389958a6568b6614b38fffec1fcbf1627c4e5edc3/host2_generator2'}}",
+    "username": "log.stash",
+    "pipeline_metadata": {
+      "version": "3"
+    },
+    "pipeline_settings": {
+      "pipeline.batch.delay": "50"
+    },
+    "last_modified": "2020-10-01T15:42:30.229Z"
+  }
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## What does this PR do?
allow `xpack.management.pipeline.id` to accept wildcard `*` setting to add/ update/ delete pipelines without restarting Logstash
add validation on `xpack.management.pipeline.id` to align with Kibana `pipeline ID must begin with a letter or underscore and contain only letters, underscores, dashes, and numbers`
add warning msg if wildcard is used with elasticsearch version < 7.10
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works



## How to test this PR locally
** will need elasticsearch 7.10+, at this moment elastic cloud is 7.9, so unable to test in cloud**
- Logstash enable xpack 
- in logstash.yml `xpack.management.pipeline.id: ["*"]`
- start a local elasticsearch
- add a new pipeline to Elasticsearch
```
curl -X PUT -v "localhost:9200/_logstash/pipeline/heartbeat"  -H 'Content-Type: application/json' -d '{
    "pipeline": "input { heartbeat { } } output { stdout {} }",
    "last_modified": "2020-10-01T15:42:30.229Z",
    "pipeline_metadata": { "version": "4"},
    "username": "log.stash",
    "pipeline_settings": {"pipeline.batch.delay": "50"}
}'
```
- Logstash should pick up the new pipeline and start processing it

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
https://github.com/elastic/logstash/issues/10558



