### PR TITLE
Fix for QA test when Logstash with bundled JDK is verified to be installed

### DIFF
--- a/qa/rspec/commands/redhat.rb
+++ b/qa/rspec/commands/redhat.rb
@@ -29,7 +29,7 @@ module ServiceTester
         stdout = cmd.stdout
       end
       stdout.match(/^Installed Packages$/)
-      stdout.match(/^logstash.noarch/)
+      stdout.match(/^logstash.noarch/) || stdout.match(/^logstash.#{architecture_extension}/)
     end
 
     def package_extension


### PR DESCRIPTION
In QA test, when Logstash package with bundled JDK is installed on RedHat it has to check also the architecture

Fix failure like:
https://logstash-ci.elastic.co/job/elastic+logstash+master+multijob-acceptance/label=metal,suite=redhat/155/console