### PR TITLE
document system indices api privilege

### DIFF
--- a/docs/static/settings/configuration-management-settings.asciidoc
+++ b/docs/static/settings/configuration-management-settings.asciidoc
@@ -53,8 +53,10 @@ section in your Logstash configuration, or a different one. Defaults to
 If your {es} cluster is protected with basic authentication, these settings
 provide the username and password that the Logstash instance uses to
 authenticate for accessing the configuration data. The username you specify here
-should have the built-in `logstash_admin` role and the customized `logstash_writer` role, which provides access to `.logstash-*`
-indices for managing configurations. 
+should have the built-in `logstash_admin` role and the customized `logstash_writer` role, which provides access to system
+indices for managing configurations. Starting from Elasticsearch version 7.10,
+`logstash_admin` inherit a cluster privilege `manage_logstash_pipelines` to manage centralized pipeline management.
+If a user has derived their own roles and manually granted access to the .logstash index, those roles will continue to work in 7.x but will need to be updated for 8
 
 `xpack.management.elasticsearch.proxy`::
 
@@ -98,7 +100,7 @@ This setting is an alternative to both `xpack.management.elasticsearch.username`
 and `xpack.management.elasticsearch.password`. If `cloud_auth` is configured,
 those settings should not be used.
 The credentials you specify here should be for a user with the `logstash_admin` role, which
-provides access to `.logstash-*` indices for managing configurations.
+provides access to system indices for managing configurations.
 
 `xpack.management.elasticsearch.api_key`::
 

--- a/docs/static/settings/configuration-management-settings.asciidoc
+++ b/docs/static/settings/configuration-management-settings.asciidoc
@@ -54,8 +54,8 @@ If your {es} cluster is protected with basic authentication, these settings
 provide the username and password that the Logstash instance uses to
 authenticate for accessing the configuration data. The username you specify here
 should have the built-in `logstash_admin` role and the customized `logstash_writer` role, which provides access to system
-indices for managing configurations. Starting from Elasticsearch version 7.10,
-`logstash_admin` inherit a cluster privilege `manage_logstash_pipelines` to manage centralized pipeline management.
+indices for managing configurations. Starting with Elasticsearch version 7.10.0, the
+`logstash_admin` role inherits the `manage_logstash_pipelines` cluster privilege for centralized pipeline management.
 If a user has derived their own roles and manually granted access to the .logstash index, those roles will continue to work in 7.x but will need to be updated for 8
 
 `xpack.management.elasticsearch.proxy`::

--- a/docs/static/settings/configuration-management-settings.asciidoc
+++ b/docs/static/settings/configuration-management-settings.asciidoc
@@ -56,7 +56,7 @@ authenticate for accessing the configuration data. The username you specify here
 should have the built-in `logstash_admin` role and the customized `logstash_writer` role, which provides access to system
 indices for managing configurations. Starting with Elasticsearch version 7.10.0, the
 `logstash_admin` role inherits the `manage_logstash_pipelines` cluster privilege for centralized pipeline management.
-If a user has derived their own roles and manually granted access to the .logstash index, those roles will continue to work in 7.x but will need to be updated for 8
+If a user has created their own roles and granted them access to the .logstash index, those roles will continue to work in 7.x but will need to be updated for 8.0.
 
 `xpack.management.elasticsearch.proxy`::
 


### PR DESCRIPTION
remind users to set `manage_logstash_pipelines` to their role
https://github.com/elastic/logstash/issues/12291

**PREVIEW:** https://logstash_12388.docs-preview.app.elstc.co/guide/en/logstash/master/configuring-centralized-pipelines.html#configuration-management-settings