### PR TITLE
fix delete and recreate pipeline with same pipeline ID and config string

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/SourceWithMetadata.java
+++ b/logstash-core/src/main/java/org/logstash/common/SourceWithMetadata.java
@@ -39,6 +39,7 @@ public class SourceWithMetadata implements HashableWithSource {
     private final Integer column;
     private final String text;
     private int linesCount;
+    private final String metadata;
 
     public String getProtocol() {
         return this.protocol;
@@ -60,14 +61,17 @@ public class SourceWithMetadata implements HashableWithSource {
         return text;
     }
 
+    public String getMetadata() { return metadata; }
+
     private static final Pattern emptyString = Pattern.compile("^\\s*$");
 
-    public SourceWithMetadata(String protocol, String id, Integer line, Integer column, String text) throws IncompleteSourceWithMetadataException {
+    public SourceWithMetadata(String protocol, String id, Integer line, Integer column, String text, String metadata) throws IncompleteSourceWithMetadataException {
         this.protocol = protocol;
         this.id = id;
         this.line = line;
         this.column = column;
         this.text = text;
+        this.metadata = metadata;
 
         List<Object> badAttributes = this.attributes().stream().filter(a -> {
             if (a == null) return true;
@@ -82,8 +86,7 @@ public class SourceWithMetadata implements HashableWithSource {
         }
 
         if (!badAttributes.isEmpty()) {
-            String message = "Missing attributes in SourceWithMetadata: (" + badAttributes + ") "
-                    + this.toString();
+            String message = "Missing attributes in SourceWithMetadata: (" + badAttributes + ") " + this.toString();
             throw new IncompleteSourceWithMetadataException(message);
         }
 
@@ -91,7 +94,15 @@ public class SourceWithMetadata implements HashableWithSource {
     }
 
     public SourceWithMetadata(String protocol, String id, String text) throws IncompleteSourceWithMetadataException {
-        this(protocol, id, 0, 0, text);
+        this(protocol, id, 0, 0, text, "");
+    }
+
+    public SourceWithMetadata(String protocol, String id, String text, String metadata) throws IncompleteSourceWithMetadataException {
+        this(protocol, id, 0, 0, text, metadata);
+    }
+
+    public SourceWithMetadata(String protocol, String id, Integer line, Integer column, String text) throws IncompleteSourceWithMetadataException {
+        this(protocol, id, line, column, text, "");
     }
 
     public int hashCode() {

--- a/logstash-core/src/main/java/org/logstash/config/ir/PipelineConfig.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/PipelineConfig.java
@@ -60,6 +60,7 @@ public final class PipelineConfig {
     private LocalDateTime readAt;
     private String configHash;
     private volatile String configString;
+    private volatile String metadata;
     private List<LineToSource> sourceRefs;
 
     private static final String NEWLINE = "\n";
@@ -104,7 +105,7 @@ public final class PipelineConfig {
 
     public String configHash() {
         if (configHash == null) {
-            configHash = DigestUtils.sha1Hex(configString());
+            configHash = DigestUtils.sha1Hex(configString() + metadataString());
         }
         return configHash;
     }
@@ -127,6 +128,18 @@ public final class PipelineConfig {
             }
         }
         return this.configString;
+    }
+
+    public String metadataString() {
+        if (this.metadata == null) {
+            synchronized(this) {
+                if (this.metadata == null) {
+                    StringBuilder sb = confParts.stream().reduce(new StringBuilder(), (builder, item) -> builder.append(item.getMetadata()), StringBuilder::append);
+                    this.metadata = sb.toString();
+                }
+            }
+        }
+        return this.metadata;
     }
 
     public boolean isSystem() {

--- a/logstash-core/src/main/java/org/logstash/config/ir/PipelineConfig.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/PipelineConfig.java
@@ -134,8 +134,7 @@ public final class PipelineConfig {
         if (this.metadata == null) {
             synchronized(this) {
                 if (this.metadata == null) {
-                    StringBuilder sb = confParts.stream().reduce(new StringBuilder(), (builder, item) -> builder.append(item.getMetadata()), StringBuilder::append);
-                    this.metadata = sb.toString();
+                    this.metadata =  confParts.stream().map(SourceWithMetadata::getMetadata).collect(Collectors.joining());
                 }
             }
         }

--- a/logstash-core/src/test/java/org/logstash/config/ir/PipelineConfigTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/PipelineConfigTest.java
@@ -81,8 +81,8 @@ public class PipelineConfigTest extends RubyEnvTestCase {
         private final StringBuilder compositeSource = new StringBuilder();
         private final List<SourceWithMetadata> orderedConfigParts = new ArrayList<>();
 
-        void appendSource(final String protocol, final String id, final int line, final int column, final String text) throws IncompleteSourceWithMetadataException {
-            orderedConfigParts.add(new SourceWithMetadata(protocol, id, line, column, text));
+        void appendSource(final String protocol, final String id, final int line, final int column, final String text, final String metadata) throws IncompleteSourceWithMetadataException {
+            orderedConfigParts.add(new SourceWithMetadata(protocol, id, line, column, text, metadata));
 
             if (compositeSource.length() > 0 && !compositeSource.toString().endsWith("\n")) {
                 compositeSource.append("\n");
@@ -106,13 +106,13 @@ public class PipelineConfigTest extends RubyEnvTestCase {
         pipelineIdSym = RubySymbol.newSymbol(RubyUtil.RUBY, PIPELINE_ID);
 
         final SourceCollector sourceCollector = new SourceCollector();
-        sourceCollector.appendSource("file", "/tmp/1", 0, 0, "input { generator1 }\n");
-        sourceCollector.appendSource("file", "/tmp/2", 0, 0, "input { generator2 }");
-        sourceCollector.appendSource("file", "/tmp/3", 0, 0, "input { generator3 }\n");
-        sourceCollector.appendSource("file", "/tmp/4", 0, 0, "input { generator4 }");
-        sourceCollector.appendSource("file", "/tmp/5", 0, 0, "input { generator5 }\n");
-        sourceCollector.appendSource("file", "/tmp/6", 0, 0, "input { generator6 }");
-        sourceCollector.appendSource("string", "config_string", 0, 0, "input { generator1 }");
+        sourceCollector.appendSource("file", "/tmp/1", 0, 0, "input { generator1 }\n", "{\"version\": \"1\"}");
+        sourceCollector.appendSource("file", "/tmp/2", 0, 0, "input { generator2 }", "{\"version\": \"1\"}");
+        sourceCollector.appendSource("file", "/tmp/3", 0, 0, "input { generator3 }\n", "{\"version\": \"1\"}");
+        sourceCollector.appendSource("file", "/tmp/4", 0, 0, "input { generator4 }", "{\"version\": \"1\"}");
+        sourceCollector.appendSource("file", "/tmp/5", 0, 0, "input { generator5 }\n", "{\"version\": \"1\"}");
+        sourceCollector.appendSource("file", "/tmp/6", 0, 0, "input { generator6 }", "{\"version\": \"1\"}");
+        sourceCollector.appendSource("string", "config_string", 0, 0, "input { generator1 }", "{\"version\": \"1\"}");
 
         orderedConfigParts = sourceCollector.orderedConfigParts();
         configMerged = sourceCollector.compositeSource();
@@ -129,6 +129,7 @@ public class PipelineConfigTest extends RubyEnvTestCase {
         assertEquals("returns the source", source, sut.getSource());
         assertEquals("returns the pipeline id", PIPELINE_ID, sut.getPipelineId());
         assertNotNull("returns the config_hash", sut.configHash());
+        assertNotNull("returns the config_hash", sut.metadataString());
         assertEquals("returns the merged `ConfigPart#config_string`", configMerged, sut.configString());
         assertThat("records when the config was read", sut.getReadAt(), isBeforeOrSame(LocalDateTime.now()));
     }

--- a/x-pack/lib/config_management/elasticsearch_source.rb
+++ b/x-pack/lib/config_management/elasticsearch_source.rb
@@ -92,7 +92,7 @@ module LogStash
         end
 
         config_string = fetcher.get_single_pipeline_setting(pipeline_id)["pipeline"]
-        pipeline_metadata_str = fetcher.get_single_pipeline_setting(pipeline_id)["pipeline_metadata"].to_s
+        pipeline_metadata_str = (fetcher.get_single_pipeline_setting(pipeline_id)["pipeline_metadata"] || "").to_s
 
         raise RemoteConfigError, "Empty configuration for pipeline_id: #{pipeline_id}" if config_string.nil? || config_string.empty?
 

--- a/x-pack/lib/config_management/elasticsearch_source.rb
+++ b/x-pack/lib/config_management/elasticsearch_source.rb
@@ -92,10 +92,11 @@ module LogStash
         end
 
         config_string = fetcher.get_single_pipeline_setting(pipeline_id)["pipeline"]
+        pipeline_metadata_str = fetcher.get_single_pipeline_setting(pipeline_id)["pipeline_metadata"].to_s
 
         raise RemoteConfigError, "Empty configuration for pipeline_id: #{pipeline_id}" if config_string.nil? || config_string.empty?
 
-        config_part = org.logstash.common.SourceWithMetadata.new("x-pack-config-management", pipeline_id.to_s, config_string)
+        config_part = org.logstash.common.SourceWithMetadata.new("x-pack-config-management", pipeline_id.to_s, config_string, pipeline_metadata_str)
 
         # We don't support multiple pipelines, so use the global settings from the logstash.yml file
         settings = @settings.clone

--- a/x-pack/qa/integration/management/multiple_pipelines_spec.rb
+++ b/x-pack/qa/integration/management/multiple_pipelines_spec.rb
@@ -164,6 +164,29 @@ describe "Read configuration from elasticsearch" do
     end
   end
 
+  it "should pick up recreated pipeline with the same config string and different metadata" do
+    elasticsearch_client.indices.refresh
+
+    pipeline_id = @pipelines.keys[0]
+    config = @pipelines.values[0]
+    file = File.join(@temporary_directory, pipeline_id)
+
+    Stud.try(max_retry.times, [RSpec::Expectations::ExpectationNotMetError]) do
+      expect(File.exist?(file)).to be_truthy
+    end
+
+    cleanup_system_indices([pipeline_id])
+    File.delete(file)
+    expect(File.exist?(file)).to be_falsey
+
+    push_elasticsearch_config(pipeline_id, config, "2")
+    elasticsearch_client.indices.refresh
+
+    Stud.try(max_retry.times, [RSpec::Expectations::ExpectationNotMetError]) do
+      expect(File.exist?(file)).to be_truthy
+    end
+  end
+
   after :each do
     @logstash_service.stop if !!@logstash_service
     @elasticsearch_service.stop if !!@elasticsearch_service

--- a/x-pack/qa/integration/support/helpers.rb
+++ b/x-pack/qa/integration/support/helpers.rb
@@ -128,10 +128,11 @@ def cleanup_system_indices(pipeline_ids)
         puts ".logstash can be empty #{e.message}"
       end
     end
-    elasticsearch_client.indices.refresh
   else
     cleanup_elasticsearch(".logstash*")
   end
+
+  elasticsearch_client.indices.refresh
 end
 
 def logstash_command_append(cmd, argument, value)


### PR DESCRIPTION
To fix the issue described in https://github.com/elastic/logstash/issues/12387 ,  this PR modifies the hash function of the pipeline to include metadata and config string.

Users should be able to recreate the pipeline given that the metadata value has changed.

A follow-up Kibana task should update the version number for every change