### PR TITLE
[7x backport] document system indices api privilege

### DIFF
--- a/docs/static/security/logstash.asciidoc
+++ b/docs/static/security/logstash.asciidoc
@@ -123,16 +123,9 @@ privileges  for the Logstash indices. You can create roles from the
 ---------------------------------------------------------------
 POST _xpack/security/role/logstash_reader
 {
-  "indices": [
-    {
-      "names": [ "logstash-*" ], <1>
-      "privileges": ["read","view_index_metadata"]
-    }
-  ]
+  "cluster": ["manage_logstash_pipelines"]
 }
 ---------------------------------------------------------------
-<1> If you use a custom Logstash index pattern, specify that pattern
-instead of the default `logstash-*` pattern.
 
 . Assign your Logstash users the `logstash_reader` role. If the Logstash user
 will be using
@@ -149,7 +142,7 @@ POST _xpack/security/user/logstash_user
   "full_name" : "Kibana User for Logstash"
 }
 ---------------------------------------------------------------
-<1> `logstash_admin` is a built-in role that provides access to `.logstash-*`
+<1> `logstash_admin` is a built-in role that provides access to system
 indices for managing configurations.
 
 [float]

--- a/docs/static/settings/configuration-management-settings.asciidoc
+++ b/docs/static/settings/configuration-management-settings.asciidoc
@@ -53,8 +53,10 @@ section in your Logstash configuration, or a different one. Defaults to
 If your {es} cluster is protected with basic authentication, these settings
 provide the username and password that the Logstash instance uses to
 authenticate for accessing the configuration data. The username you specify here
-should have the built-in `logstash_admin` role and the customized `logstash_writer` role, which provides access to `.logstash-*`
-indices for managing configurations. 
+should have the built-in `logstash_admin` role and the customized `logstash_writer` role, which provides access to system
+indices for managing configurations. Starting with Elasticsearch version 7.10.0, the
+`logstash_admin` role inherits the `manage_logstash_pipelines` cluster privilege for centralized pipeline management.
+If a user has created their own roles and granted them access to the .logstash index, those roles will continue to work in 7.x but will need to be updated for 8.0.
 
 `xpack.management.elasticsearch.proxy`::
 
@@ -98,7 +100,7 @@ This setting is an alternative to both `xpack.management.elasticsearch.username`
 and `xpack.management.elasticsearch.password`. If `cloud_auth` is configured,
 those settings should not be used.
 The credentials you specify here should be for a user with the `logstash_admin` role, which
-provides access to `.logstash-*` indices for managing configurations.
+provides access to system indices for managing configurations.
 
 `xpack.management.elasticsearch.api_key`::
 


### PR DESCRIPTION
remind users to set `manage_logstash_pipelines` to their role
https://github.com/elastic/logstash/issues/12291
https://github.com/elastic/logstash/pull/12388
https://github.com/elastic/logstash/pull/12391