### PR TITLE
Add addresses to p2pipeline input and output plugin metrics

### DIFF
--- a/config/pipelines.yml
+++ b/config/pipelines.yml
@@ -6,14 +6,13 @@
 #
 # Example of two pipelines:
 #
-- pipeline.id: one
-  path.config: "/Users/robbavey/sdh/ls2/logstash-7.9.2/pep/p1.cfg"
+# - pipeline.id: test
 #   pipeline.workers: 1
 #   pipeline.batch.size: 1
 #   config.string: "input { generator {} } filter { sleep { time => 1 } } output { stdout { codec => dots } }"
-- pipeline.id: another_test
+# - pipeline.id: another_test
 #   queue.type: persisted
-  path.config: "/Users/robbavey/sdh/ls2/logstash-7.9.2/pep/p2.cfg"
+#   path.config: "/tmp/logstash/*.config"
 #
 # Available options:
 #
@@ -71,6 +70,15 @@
 #   will be dropped if they would increase the size of the dead letter queue beyond this setting.
 #   Default is 1024mb
 #   dead_letter_queue.max_bytes: 1024mb
+#
+#   If using dead_letter_queue.enable: true, the interval in milliseconds where if no further events eligible for the DLQ
+#   have been created, a dead letter queue file will be written. A low value here will mean that more, smaller, queue files
+#   may be written, while a larger value will introduce more latency between items being "written" to the dead letter queue, and
+#   being available to be read by the dead_letter_queue input when items are are written infrequently.
+#   Default is 5000.
+#
+#   dead_letter_queue.flush_interval: 5000
+
 #
 #   If using dead_letter_queue.enable: true, the directory path where the data files will be stored.
 #   Default is path.data/dead_letter_queue

--- a/config/pipelines.yml
+++ b/config/pipelines.yml
@@ -6,13 +6,14 @@
 #
 # Example of two pipelines:
 #
-# - pipeline.id: test
+- pipeline.id: one
+  path.config: "/Users/robbavey/sdh/ls2/logstash-7.9.2/pep/p1.cfg"
 #   pipeline.workers: 1
 #   pipeline.batch.size: 1
 #   config.string: "input { generator {} } filter { sleep { time => 1 } } output { stdout { codec => dots } }"
-# - pipeline.id: another_test
+- pipeline.id: another_test
 #   queue.type: persisted
-#   path.config: "/tmp/logstash/*.config"
+  path.config: "/Users/robbavey/sdh/ls2/logstash-7.9.2/pep/p2.cfg"
 #
 # Available options:
 #
@@ -70,15 +71,6 @@
 #   will be dropped if they would increase the size of the dead letter queue beyond this setting.
 #   Default is 1024mb
 #   dead_letter_queue.max_bytes: 1024mb
-#
-#   If using dead_letter_queue.enable: true, the interval in milliseconds where if no further events eligible for the DLQ
-#   have been created, a dead letter queue file will be written. A low value here will mean that more, smaller, queue files
-#   may be written, while a larger value will introduce more latency between items being "written" to the dead letter queue, and
-#   being available to be read by the dead_letter_queue input when items are are written infrequently.
-#   Default is 5000.
-#
-#   dead_letter_queue.flush_interval: 5000
-
 #
 #   If using dead_letter_queue.enable: true, the directory path where the data files will be stored.
 #   Default is path.data/dead_letter_queue

--- a/logstash-core/lib/logstash/plugins/builtin/pipeline/input.rb
+++ b/logstash-core/lib/logstash/plugins/builtin/pipeline/input.rb
@@ -33,6 +33,9 @@ module ::LogStash; module Plugins; module Builtin; module Pipeline; class Input 
     if !listen_successful
       raise ::LogStash::ConfigurationError, "Internal input at '#{@address}' already bound! Addresses must be globally unique across pipelines."
     end
+    # add address to the plugin stats
+    metric.gauge(:address, address)
+
   end
 
   def run(queue)

--- a/logstash-core/lib/logstash/plugins/builtin/pipeline/output.rb
+++ b/logstash-core/lib/logstash/plugins/builtin/pipeline/output.rb
@@ -30,6 +30,8 @@ module ::LogStash; module Plugins; module Builtin; module Pipeline; class Output
 
   def register
     @pipeline_bus = execution_context.agent.pipeline_bus
+    # add list of pipelines to send to the plugin metrics
+    metric.gauge(:send_to, send_to)
     pipeline_bus.registerSender(self, @send_to)
   end
 


### PR DESCRIPTION
This commit adds context to the pipeline to pipeline input and output
plugins by adding a string containing the `address` field to the input
plugin, and an array containing the `send_to` field to the output plugin.
This helps gain a picture of how pipeline to pipeline enabled configurations
are communicating with each other, without having to refer back to the pipeline
definition


## What does this PR do?

This commit adds context to the pipeline to pipeline input and output
plugins by adding a string containing the `address` field to the input
plugin, and an array containing the `send_to` field to the output plugin.

## Why is it important/What is the impact to the user?

This helps gain a picture of how pipeline to pipeline enabled configurations
are communicating with each other, without having to refer back to the pipeline
definition

## Checklist

- [ ] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- [ ] I have added tests that prove my fix is effective or that my feature works



## How to test this PR locally

Run a p2p pipeline locally, observe the new fields returned by the [node stats API ](http://localhost:9600/_node/stats/?pretty=true)


Pipeline output now has `send_to` - ie pipeline destinations:
```
     "outputs" : [ {
          "id" : "5b90b7953bed1780ec696fe0798ecf949cba1c657fd2b0c154a01c83bb96d2a0",
          "events" : {
            "in" : 0,
            "duration_in_millis" : 1,
            "out" : 0
          },
          "name" : "pipeline",
          "send_to" : [ "the destination" ]
        } ]
```

Pipeline input now has an `address`:
```
      "inputs" : [ {
          "id" : "70bc842051433879ba7098c6ad6ec3f4c601a7024362617f503fda4970591932",
          "address" : "the destination",
          "events" : {
            "out" : 0,
            "queue_push_duration_in_millis" : 0
          },
          "name" : "pipeline"
        } ],
   
   ```

This should work for pipeline outputs that send to a single pipeline input, or multiple pipeline inputs.
