### PR TITLE
Improve error message for non-existing settings

### DIFF
--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -85,7 +85,7 @@ module LogStash
 
     def get_setting(setting_name)
       setting = @settings[setting_name]
-      raise ArgumentError.new("Setting \"#{setting_name}\" doesn't exist") if setting.nil?
+      raise ArgumentError.new("Setting \"#{setting_name}\" doesn't exist. Please check if you haven't made a typo.") if setting.nil?
       setting
     end
 

--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -85,7 +85,7 @@ module LogStash
 
     def get_setting(setting_name)
       setting = @settings[setting_name]
-      raise ArgumentError.new("Setting \"#{setting_name}\" hasn't been registered") if setting.nil?
+      raise ArgumentError.new("Setting \"#{setting_name}\" doesn't exist") if setting.nil?
       setting
     end
 


### PR DESCRIPTION
Currently, when referencing a setting that doesn't exist, we log the following error:

`Setting "xpack.monitoring.enable" hasn't been registered`

This can be confusing and lead user to think they need to do something else, as opposed to make sure they're using a "real" setting.

This PR changes this to log instead:

```
[2020-10-29T15:09:24,147][FATAL][logstash.runner] An unexpected error occurred! {:error=>#<ArgumentError: Setting "xpack.monitoring.enable" doesn't exist>, :backtrace=>[..]}
```