### PR TITLE
Change text to use Elastic Cloud

### DIFF
--- a/docs/static/ls-to-cloud.asciidoc
+++ b/docs/static/ls-to-cloud.asciidoc
@@ -1,7 +1,8 @@
 [[connecting-to-cloud]]
-=== Sending data to Elasticsearch Service
+=== Sending data to Elastic Cloud
 
-Our hosted Elasticsearch Service is available on AWS, GCP, and Azure.
+Elastic Cloud is our our hosted Elasticsearch Service, and it is
+available on AWS, GCP, and Azure.
 {ess-trial}[You can try the Elasticsearch Service for free].
 
 Logstash comes with two settings that simplify sending data to

--- a/docs/static/ls-to-cloud.asciidoc
+++ b/docs/static/ls-to-cloud.asciidoc
@@ -1,5 +1,5 @@
 [[connecting-to-cloud]]
-=== Sending data to Elastic Cloud
+=== Sending data to Elastic Cloud (hosted Elasticsearch Service)
 
 Elastic Cloud is our our hosted Elasticsearch Service, and it is
 available on AWS, GCP, and Azure.


### PR DESCRIPTION
Start making use of the term 'Elastic Cloud' as this is the term being used to refer to the service we provide.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## What does this PR do?

This PR changes uses the term of 'Elastic Cloud' instead of solely referring to ESS as Elasticsearch Service, as it is the term that's being used to promote the service.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

## Why is it important/What is the impact to the user?

Allows the user to related 'Elastic Cloud' term used widely to relate to the Elasticsearch Service.

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have made corresponding changes to the documentation
