### PR TITLE
[backport 7x] add wildcard support in xpack pipeline id (#12370)

### DIFF
--- a/x-pack/lib/config_management/bootstrap_check.rb
+++ b/x-pack/lib/config_management/bootstrap_check.rb
@@ -14,6 +14,10 @@ module LogStash
     class BootstrapCheck
       include LogStash::Util::Loggable
 
+      # pipeline ID must begin with a letter or underscore and contain only letters, underscores, dashes, and numbers
+      # wildcard character `*` is also acceptable and follows globbing rules
+      PIPELINE_ID_PATTERN = %r{\A[a-z_*][a-z_\-0-9*]*\Z}i
+
       def self.check(settings)
         check_path_config(settings)
 
@@ -40,6 +44,11 @@ module LogStash
 
         if pipeline_ids.reject { |id| id.strip.empty? }.empty?
           raise LogStash::BootstrapCheckError, "You need to specify the ID of the pipelines with the `xpack.management.pipeline.id` options in your logstash.yml"
+        end
+
+        invalid_patterns =  pipeline_ids.reject { |entry| PIPELINE_ID_PATTERN =~ entry }
+        if invalid_patterns.any?
+          raise LogStash::BootstrapCheckError, "Pipeline id in `xpack.management.pipeline.id` must begin with a letter or underscore and contain only letters, underscores, dashes, and numbers. The asterisk wildcard `*` can also be used. Invalid ids: #{invalid_patterns.join(', ')}"
         end
 
         duplicate_ids = find_duplicate_ids(pipeline_ids)

--- a/x-pack/spec/config_management/bootstrap_check_spec.rb
+++ b/x-pack/spec/config_management/bootstrap_check_spec.rb
@@ -177,6 +177,40 @@ describe LogStash::ConfigManagement::BootstrapCheck do
         end
       end
 
+      context "when defining invalid patterns" do
+        let(:pipeline_ids) { ["pipeline1", "pipeline2", "@o@"] }
+        let(:settings) do
+          apply_settings(
+            {
+              "xpack.management.enabled" => true,
+              "xpack.management.pipeline.id" => pipeline_ids
+            },
+            system_settings
+          )
+        end
+
+        it "raises a `LogStash::BootstrapCheckError` with the invalid patterns" do
+          expect { subject.check(settings) }.to raise_error LogStash::BootstrapCheckError, /@o@/
+        end
+      end
+
+      context "when defining wildcard patterns" do
+        let(:pipeline_ids) { ["pipeline1", "pipeline2", "*pipeline*"] }
+        let(:settings) do
+          apply_settings(
+              {
+                  "xpack.management.enabled" => true,
+                  "xpack.management.pipeline.id" => pipeline_ids
+              },
+              system_settings
+          )
+        end
+
+        it "does not raise a `LogStash::BootstrapCheckError` error" do
+          expect { subject.check(settings) }.to_not raise_error
+        end
+      end
+
       context "when defining duplicate ids" do
         let(:pipeline_ids) { ["pipeline1", "pipeline2", "pipeline1"] }
         let(:settings) do

--- a/x-pack/spec/config_management/elasticsearch_source_spec.rb
+++ b/x-pack/spec/config_management/elasticsearch_source_spec.rb
@@ -202,16 +202,57 @@ describe LogStash::ConfigManagement::ElasticsearchSource do
       let(:config) { "input { generator { count => 100 } tcp { port => 6005 } } output { }}" }
       let(:pipeline_id) { "super_generator" }
       let(:elasticsearch_response) { {"#{pipeline_id}"=> {"pipeline"=> "#{config}"}} }
+      let(:all_pipelines) { JSON.parse(::File.read(::File.join(::File.dirname(__FILE__), "fixtures", "pipelines.json"))) }
 
       it "#fetch_config" do
-        expect(mock_client).to receive(:get).with("#{described_class::SYSTEM_INDICES_API_PATH}/#{pipeline_id}").and_return(elasticsearch_response)
+        expect(mock_client).to receive(:get).with("#{described_class::SYSTEM_INDICES_API_PATH}/").and_return(elasticsearch_response.clone)
         expect(subject.fetch_config([pipeline_id], mock_client)).to eq(elasticsearch_response)
-        expect(subject.get_single_pipeline_setting(pipeline_id)).to eq({"pipeline"=> "#{config}"})
+        expect(subject.get_single_pipeline_setting(pipeline_id)).to eq({"pipeline"=>"#{config}"})
       end
 
       it "#fetch_config should raise error" do
-        expect(mock_client).to receive(:get).with("#{described_class::SYSTEM_INDICES_API_PATH}/apache,nginx").and_return(elasticsearch_8_err_response)
+        expect(mock_client).to receive(:get).with("#{described_class::SYSTEM_INDICES_API_PATH}/").and_return(elasticsearch_8_err_response.clone)
         expect{ subject.fetch_config(["apache", "nginx"], mock_client) }.to raise_error(LogStash::ConfigManagement::ElasticsearchSource::RemoteConfigError)
+      end
+
+      describe "wildcard" do
+        it "should accept * " do
+          expect(mock_client).to receive(:get).with("#{described_class::SYSTEM_INDICES_API_PATH}/").and_return(all_pipelines.clone)
+          expect(subject).to receive(:logger).never
+          expect(subject.fetch_config(["*"], mock_client).keys.length).to eq(all_pipelines.keys.length)
+        end
+
+        it "should accept multiple * in one pattern " do
+          expect(mock_client).to receive(:get).with("#{described_class::SYSTEM_INDICES_API_PATH}/").and_return(all_pipelines.clone)
+          expect(subject).to receive(:logger).never
+          expect(subject.fetch_config(["host*_pipeline*"], mock_client).keys).to eq(["host1_pipeline1", "host1_pipeline2", "host2_pipeline1", "host2_pipeline2"])
+        end
+
+        it "should give unique pipeline with multiple wildcard patterns" do
+          expect(mock_client).to receive(:get).with("#{described_class::SYSTEM_INDICES_API_PATH}/").and_return(all_pipelines.clone)
+          expect(subject).to receive(:log_pipeline_not_found).with(["*pipeline*"]).exactly(1)
+          expect(subject.fetch_config(["host1_pipeline*", "host2_pipeline*","*pipeline*"], mock_client).keys).to eq(["host1_pipeline1", "host1_pipeline2", "host2_pipeline1", "host2_pipeline2"])
+        end
+
+        it "should accept a mix of wildcard and non wildcard pattern" do
+          expect(mock_client).to receive(:get).with("#{described_class::SYSTEM_INDICES_API_PATH}/").and_return(all_pipelines.clone)
+          expect(subject).to receive(:logger).never
+          expect(subject.fetch_config(["host1_pipeline*", "host2_pipeline*","super_generator"], mock_client).keys).to eq(["super_generator", "host1_pipeline1", "host1_pipeline2", "host2_pipeline1", "host2_pipeline2"])
+        end
+
+        it "should log unmatched pattern" do
+          pipeline_ids = ["very_awesome_pipeline", "*whatever*"]
+          expect(mock_client).to receive(:get).with("#{described_class::SYSTEM_INDICES_API_PATH}/").and_return(all_pipelines.clone)
+          expect(subject).to receive(:log_pipeline_not_found).with(pipeline_ids).exactly(1)
+          expect(subject.fetch_config(pipeline_ids, mock_client)).to eq({})
+        end
+
+        it "should log unmatched pattern and return matched pipeline" do
+          pipeline_ids = ["very_awesome_pipeline", "*whatever*"]
+          expect(mock_client).to receive(:get).with("#{described_class::SYSTEM_INDICES_API_PATH}/").and_return(all_pipelines.clone)
+          expect(subject).to receive(:log_pipeline_not_found).with(pipeline_ids).exactly(1)
+          expect(subject.fetch_config(pipeline_ids + [pipeline_id], mock_client)).to eq(elasticsearch_response)
+        end
       end
     end
   end
@@ -252,6 +293,7 @@ describe LogStash::ConfigManagement::ElasticsearchSource do
 
       it "#fetch_config" do
         expect(mock_client).to receive(:post).with("#{described_class::PIPELINE_INDEX}/_mget", {}, "{\"docs\":[{\"_id\":\"#{pipeline_id}\"},{\"_id\":\"#{another_pipeline_id}\"}]}").and_return(elasticsearch_response)
+        expect(subject).to receive(:logger).never
         expect(subject.fetch_config([pipeline_id, another_pipeline_id], mock_client).size).to eq(2)
         expect(subject.get_single_pipeline_setting(pipeline_id)).to eq({"pipeline" => "#{config}"})
         expect(subject.get_single_pipeline_setting(another_pipeline_id)).to eq({"pipeline" => "#{another_config}"})
@@ -259,6 +301,7 @@ describe LogStash::ConfigManagement::ElasticsearchSource do
 
       it "#fetch_config should raise error" do
         expect(mock_client).to receive(:post).with("#{described_class::PIPELINE_INDEX}/_mget", {}, "{\"docs\":[{\"_id\":\"#{pipeline_id}\"},{\"_id\":\"#{another_pipeline_id}\"}]}").and_return(elasticsearch_7_9_err_response)
+        expect(subject).to receive(:logger).never
         expect{ subject.fetch_config([pipeline_id, another_pipeline_id], mock_client) }.to raise_error(LogStash::ConfigManagement::ElasticsearchSource::RemoteConfigError)
       end
 
@@ -267,11 +310,24 @@ describe LogStash::ConfigManagement::ElasticsearchSource do
         expect{ subject.fetch_config([pipeline_id, another_pipeline_id], mock_client) }.to raise_error(LogStash::ConfigManagement::ElasticsearchSource::RemoteConfigError)
       end
 
+      it "#fetch_config should log unmatched pipeline id" do
+        expect(mock_client).to receive(:post).with("#{described_class::PIPELINE_INDEX}/_mget", {}, "{\"docs\":[{\"_id\":\"#{pipeline_id}\"},{\"_id\":\"#{another_pipeline_id}\"},{\"_id\":\"*\"}]}").and_return(elasticsearch_response)
+        expect(subject).to receive(:log_pipeline_not_found).with(["*"]).exactly(1)
+        expect(subject.fetch_config([pipeline_id, another_pipeline_id, "*"], mock_client).size).to eq(2)
+        expect(subject.get_single_pipeline_setting(pipeline_id)).to eq({"pipeline" => "#{config}"})
+        expect(subject.get_single_pipeline_setting(another_pipeline_id)).to eq({"pipeline" => "#{another_config}"})
+      end
+
       it "#format_response should return pipelines" do
         result = subject.send(:format_response, elasticsearch_response)
         expect(result.size).to eq(2)
         expect(result.has_key?(pipeline_id)).to be_truthy
         expect(result.has_key?(another_pipeline_id)).to be_truthy
+      end
+
+      it "should log wildcard warning" do
+        result = subject.send(:log_wildcard_unsupported, [pipeline_id, another_pipeline_id, "*"])
+        expect(result).not_to be_nil
       end
     end
   end

--- a/x-pack/spec/config_management/fixtures/pipelines.json
+++ b/x-pack/spec/config_management/fixtures/pipelines.json
@@ -1,0 +1,60 @@
+{
+  "super_generator": {
+    "pipeline": "input { generator { count => 100 } tcp { port => 6005 } } output { }}"
+  },
+  "another_generator": {
+    "pipeline": "input { generator { count => 100 } tcp { port => 6006 } } output { file { path => '/var/folders/8g/415b_scd6ql1vxc2p128kfn40000gn/T/studtmp-b0f4079ab3df20f7eb2389958a6568b6614b38fffec1fcbf1627c4e5edc3/another_generator_new' }}",
+    "username": "log.stash",
+    "pipeline_metadata": {
+      "version": "1"
+    },
+    "pipeline_settings": {
+      "pipeline.batch.delay": "50"
+    },
+    "last_modified": "2020-10-06T23:11:38Z"
+  },
+  "host1_pipeline1": {
+    "pipeline": "input { generator { count => 10000000 }} filter { sleep { time => \"1\" every => 10}} output { file { path  => '/var/folders/8g/415b_scd6ql1vxc2p128kfn40000gn/T/studtmp-b0f4079ab3df20f7eb2389958a6568b6614b38fffec1fcbf1627c4e5edc3/host1_generator1'}}",
+    "username": "log.stash",
+    "pipeline_metadata": {
+      "version": "3"
+    },
+    "pipeline_settings": {
+      "pipeline.batch.delay": "50"
+    },
+    "last_modified": "2020-10-01T15:42:30.229Z"
+  },
+  "host1_pipeline2": {
+    "pipeline": "input { generator { count => 10000000 }} filter { sleep { time => \"1\" every => 10}} output { file { path  => '/var/folders/8g/415b_scd6ql1vxc2p128kfn40000gn/T/studtmp-b0f4079ab3df20f7eb2389958a6568b6614b38fffec1fcbf1627c4e5edc3/host1_generator2'}}",
+    "username": "log.stash",
+    "pipeline_metadata": {
+      "version": "3"
+    },
+    "pipeline_settings": {
+      "pipeline.batch.delay": "50"
+    },
+    "last_modified": "2020-10-01T15:42:30.229Z"
+  },
+  "host2_pipeline1": {
+    "pipeline": "input { generator { count => 10000000 }} filter { sleep { time => \"1\" every => 10}} output { file { path  => '/var/folders/8g/415b_scd6ql1vxc2p128kfn40000gn/T/studtmp-b0f4079ab3df20f7eb2389958a6568b6614b38fffec1fcbf1627c4e5edc3/host2_generator1'}}",
+    "username": "log.stash",
+    "pipeline_metadata": {
+      "version": "3"
+    },
+    "pipeline_settings": {
+      "pipeline.batch.delay": "50"
+    },
+    "last_modified": "2020-10-01T15:42:30.229Z"
+  },
+  "host2_pipeline2": {
+    "pipeline": "input { generator { count => 10000000 }} filter { sleep { time => \"1\" every => 10}} output { file { path  => '/var/folders/8g/415b_scd6ql1vxc2p128kfn40000gn/T/studtmp-b0f4079ab3df20f7eb2389958a6568b6614b38fffec1fcbf1627c4e5edc3/host2_generator2'}}",
+    "username": "log.stash",
+    "pipeline_metadata": {
+      "version": "3"
+    },
+    "pipeline_settings": {
+      "pipeline.batch.delay": "50"
+    },
+    "last_modified": "2020-10-01T15:42:30.229Z"
+  }
+}


### PR DESCRIPTION
add wildcard support in xpack pipeline id
do the pattern matching with glob
add warning msg to wildcard with legacy api
check invalid pipeline in bootstrap
test cases for invalid checking
origin PR: https://github.com/elastic/logstash/pull/12370