### PR TITLE
delete pipeline in registry

### DIFF
--- a/logstash-core/lib/logstash/pipeline_action/delete.rb
+++ b/logstash-core/lib/logstash/pipeline_action/delete.rb
@@ -16,16 +16,23 @@
 # under the License.
 
 require "logstash/pipeline_action/base"
-require "logstash/pipeline_action/create"
-require "logstash/pipeline_action/stop"
-require "logstash/pipeline_action/reload"
-require "logstash/pipeline_action/delete"
 
 module LogStash module PipelineAction
-  ORDERING = {
-    LogStash::PipelineAction::Create => 100,
-    LogStash::PipelineAction::Reload => 200,
-    LogStash::PipelineAction::Stop => 300,
-    LogStash::PipelineAction::Delete => 400
-  }
+  class Delete < Base
+    attr_reader :pipeline_id
+
+    def initialize(pipeline_id)
+      @pipeline_id = pipeline_id
+    end
+
+    def execute(agent, pipelines_registry)
+      pipelines_registry.delete_pipeline(@pipeline_id)
+
+      LogStash::ConvergeResult::SuccessfulAction.new
+    end
+
+    def to_s
+      "PipelineAction::Delete<#{pipeline_id}>"
+    end
+  end
 end end

--- a/logstash-core/lib/logstash/pipeline_action/delete.rb
+++ b/logstash-core/lib/logstash/pipeline_action/delete.rb
@@ -26,9 +26,9 @@ module LogStash module PipelineAction
     end
 
     def execute(agent, pipelines_registry)
-      pipelines_registry.delete_pipeline(@pipeline_id)
+      success = pipelines_registry.delete_pipeline(@pipeline_id)
 
-      LogStash::ConvergeResult::SuccessfulAction.new
+      LogStash::ConvergeResult::ActionResult.create(self, success)
     end
 
     def to_s

--- a/logstash-core/lib/logstash/pipelines_registry.rb
+++ b/logstash-core/lib/logstash/pipelines_registry.rb
@@ -209,6 +209,11 @@ module LogStash
       lock.unlock
     end
 
+    def delete_pipeline(pipeline_id)
+      success = @states.remove(pipeline_id)
+      logger.info("Removed pipeline from registry successfully", :pipeline_id => pipeline_id) if success
+    end
+
     # @param pipeline_id [String, Symbol] the pipeline id
     # @return [Pipeline] the pipeline object or nil if none for pipeline_id
     def get_pipeline(pipeline_id)

--- a/logstash-core/lib/logstash/pipelines_registry.rb
+++ b/logstash-core/lib/logstash/pipelines_registry.rb
@@ -76,7 +76,6 @@ module LogStash
     def remove(pipeline_id)
       @lock.synchronize do
         @states.delete(pipeline_id)
-        @locks.delete(pipeline_id)
       end
     end
 
@@ -209,9 +208,30 @@ module LogStash
       lock.unlock
     end
 
+    # Delete the pipeline that is terminated
+    # @param pipeline_id [String, Symbol] the pipeline id
+    # @return [Boolean] pipeline delete success
     def delete_pipeline(pipeline_id)
-      success = @states.remove(pipeline_id)
-      logger.info("Removed pipeline from registry successfully", :pipeline_id => pipeline_id) if success
+      lock = @states.get_lock(pipeline_id)
+      lock.lock
+
+      state = @states.get(pipeline_id)
+
+      if state.nil?
+        logger.error("Attempted to delete a pipeline that does not exists", :pipeline_id => pipeline_id)
+        return false
+      end
+
+      if state.terminated?
+        @states.remove(pipeline_id)
+        logger.info("Removed pipeline from registry successfully", :pipeline_id => pipeline_id)
+        return true
+      else
+        logger.info("Attempted to delete a pipeline that is not terminated", :pipeline_id => pipeline_id)
+        return false
+      end
+    ensure
+      lock.unlock
     end
 
     # @param pipeline_id [String, Symbol] the pipeline id

--- a/logstash-core/lib/logstash/state_resolver.rb
+++ b/logstash-core/lib/logstash/state_resolver.rb
@@ -41,9 +41,7 @@ module LogStash
         end
       end
 
-      configured_pipelines = pipeline_configs.each_with_object(Set.new) { |config, set|
-        set.add(config.pipeline_id.to_sym)
-      }
+      configured_pipelines = pipeline_configs.each_with_object(Set.new) { |config, set| set.add(config.pipeline_id.to_sym) }
 
       # If one of the running pipeline is not in the pipeline_configs, we assume that we need to
       # stop it.

--- a/logstash-core/lib/logstash/state_resolver.rb
+++ b/logstash-core/lib/logstash/state_resolver.rb
@@ -41,7 +41,9 @@ module LogStash
         end
       end
 
-      configured_pipelines = pipeline_configs.map { |config| config.pipeline_id.to_sym }.to_set
+      configured_pipelines = pipeline_configs.each_with_object(Set.new) { |config, set|
+        set.add(config.pipeline_id.to_sym)
+      }
 
       # If one of the running pipeline is not in the pipeline_configs, we assume that we need to
       # stop it.

--- a/logstash-core/lib/logstash/state_resolver.rb
+++ b/logstash-core/lib/logstash/state_resolver.rb
@@ -49,8 +49,7 @@ module LogStash
         .select { |pipeline_id| !configured_pipelines.include?(pipeline_id) }
         .each { |pipeline_id| actions << LogStash::PipelineAction::Stop.new(pipeline_id) }
 
-      # If one of the stopping pipeline is not in the pipeline_configs, we assume that we need to
-      # delete it in registry.
+      # If one of the terminated pipeline is not in the pipeline_configs, delete it in registry.
       pipelines_registry.non_running_pipelines.keys
         .select { |pipeline_id| !configured_pipelines.include?(pipeline_id) }
         .each { |pipeline_id| actions << LogStash::PipelineAction::Delete.new(pipeline_id)}

--- a/logstash-core/spec/logstash/pipelines_registry_spec.rb
+++ b/logstash-core/spec/logstash/pipelines_registry_spec.rb
@@ -249,6 +249,16 @@ describe LogStash::PipelinesRegistry do
         expect(subject.delete_pipeline(pipeline_id)).to be_truthy
         expect(subject.get_pipeline(pipeline_id)).to be_nil
       end
+
+      it "should recreate pipeline if pipeline is delete and create again" do
+        expect(pipeline).to receive(:finished_execution?).and_return(true)
+        expect(LogStash::PipelinesRegistry).to receive(:logger).and_return(logger)
+        expect(logger).to receive(:info)
+        expect(subject.delete_pipeline(pipeline_id)).to be_truthy
+        expect(subject.get_pipeline(pipeline_id)).to be_nil
+        subject.create_pipeline(pipeline_id, pipeline) { true }
+        expect(subject.get_pipeline(pipeline_id)).not_to be_nil
+      end
     end
 
     context "when pipeline is not in registry" do

--- a/logstash-core/spec/logstash/pipelines_registry_spec.rb
+++ b/logstash-core/spec/logstash/pipelines_registry_spec.rb
@@ -228,6 +228,38 @@ describe LogStash::PipelinesRegistry do
     end
   end
 
+  context "deleting a pipeline" do
+    context "when pipeline is in registry" do
+      before :each do
+        subject.create_pipeline(pipeline_id, pipeline) { true }
+      end
+
+      it "should not delete pipeline if pipeline is not terminated" do
+        expect(pipeline).to receive(:finished_execution?).and_return(false)
+        expect(LogStash::PipelinesRegistry).to receive(:logger).and_return(logger)
+        expect(logger).to receive(:info)
+        expect(subject.delete_pipeline(pipeline_id)).to be_falsey
+        expect(subject.get_pipeline(pipeline_id)).not_to be_nil
+      end
+
+      it "should delete pipeline if pipeline is terminated" do
+        expect(pipeline).to receive(:finished_execution?).and_return(true)
+        expect(LogStash::PipelinesRegistry).to receive(:logger).and_return(logger)
+        expect(logger).to receive(:info)
+        expect(subject.delete_pipeline(pipeline_id)).to be_truthy
+        expect(subject.get_pipeline(pipeline_id)).to be_nil
+      end
+    end
+
+    context "when pipeline is not in registry" do
+      it "should log error" do
+        expect(LogStash::PipelinesRegistry).to receive(:logger).and_return(logger)
+        expect(logger).to receive(:error)
+        expect(subject.delete_pipeline(pipeline_id)).to be_falsey
+      end
+    end
+  end
+
   context "pipelines collections" do
     context "with a non terminated pipelines" do
       before :each do


### PR DESCRIPTION
Users cannot delete a pipeline and recreate it with the same configuration string in Kibana. Logstash store all pipelines in pipeline_registry and never remove them. Logstash takes actions by comparing the source and registry. It causes difficulties to distinguish if a pipeline is finished or be terminated due to removal in the source(elasticsearch). 

The flow of the issue
1. Users deleted a pipeline in Kibana
2. Logstash stops the pipeline instead of deleting it
3. Users recreate the pipeline with the same setting in Kibana
4. Logstash compares the hash value of the new pipeline with the old pipeline that stays in the registry
5. The hash value is the same. Logstash keeps the old pipeline in terminated status. Users cannot see the pipeline running

This PR deletes the pipeline in the pipelines_registry if it is terminated and is removed in the source.

