### PR TITLE
[7.x backport] Added console prints in ingest-converter for not recognized processor definitions

### DIFF
--- a/tools/ingest-converter/src/main/resources/ingest-pipeline.js
+++ b/tools/ingest-converter/src/main/resources/ingest-pipeline.js
@@ -26,50 +26,63 @@ function ingest_pipeline_to_logstash(json, append_stdio) {
                 );
             }
         }
+        var processed = false;
         if (IngestDate.has_date(processor)) {
             filter_blocks.push(
                 IngestConverter.create_hash("date", IngestDate.date_hash(processor))
             )
+            processed = true;
         }
         if (IngestGeoIp.has_geoip(processor)) {
             filter_blocks.push(
                 IngestConverter.create_hash("geoip", IngestGeoIp.geoip_hash(processor))
             )
+            processed = true;
         }
         if (IngestConvert.has_convert(processor)) {
             filter_blocks.push(
                 IngestConverter.create_hash("mutate", IngestConvert.convert_hash(processor))
             );
+            processed = true;
         }
         if (IngestGsub.has_gsub(processor)) {
             filter_blocks.push(
                 IngestConverter.create_hash("mutate", IngestGsub.gsub_hash(processor))
             );
+            processed = true;
         }
         if (IngestAppend.has_append(processor)) {
             filter_blocks.push(
                 IngestConverter.create_hash("mutate", IngestAppend.append_hash(processor))
             );
+            processed = true;
         }
         if (IngestJson.has_json(processor)) {
             filter_blocks.push(
                 IngestConverter.create_hash("json", IngestJson.json_hash(processor))
             );
+            processed = true;
         }
         if (IngestRename.has_rename(processor)) {
             filter_blocks.push(
                 IngestConverter.create_hash("mutate", IngestRename.rename_hash(processor))
             );
+            processed = true;
         }
         if (IngestLowercase.has_lowercase(processor)) {
             filter_blocks.push(
                 IngestConverter.create_hash("mutate", IngestLowercase.lowercase_hash(processor))
             );
+            processed = true;
         }
         if (IngestSet.has_set(processor)) {
             filter_blocks.push(
                 IngestConverter.create_hash("mutate", IngestSet.set_hash(processor))
             );
+            processed = true;
+        }
+        if (!processed) {
+            print("WARN Found unrecognized processor named: " + Object.keys(processor)[0]);
         }
         return IngestConverter.join_hash_fields(filter_blocks);
     }

--- a/tools/ingest-converter/src/main/resources/ingest-set.js
+++ b/tools/ingest-converter/src/main/resources/ingest-set.js
@@ -11,6 +11,10 @@ var IngestSet = {
         } else {
             value_contents = value;
         }
+        var painless_condition = set_json["if"];
+        if (!!painless_condition) {
+          print("WARN Found in 'set' processor an 'if' painless condition not translated: " + painless_condition);
+        }
         var mutate_contents = IngestConverter.create_field(
             IngestConverter.quote_string(IngestConverter.dots_to_square_brackets(set_json["field"])),
             value_contents);


### PR DESCRIPTION
Backport to `7.x` of #12428 

The `ingest-converter ' tool, used to translate Elasticsearch ingest pipelines definitions to Logstash pipeline configuration, should print out some warning when it's not able to translate some attributes or doesn't recognize the processor.

This PR simply print on console if it find a set processor with if code or if it isn't able to translate a specific processor because not part of the recognized ones.
