### PR TITLE
Move CloudSettingsAuth to java

### DIFF
--- a/logstash-core/lib/logstash/util/cloud_setting_auth.rb
+++ b/logstash-core/lib/logstash/util/cloud_setting_auth.rb
@@ -15,30 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-require "logstash/util/password"
-
-module LogStash module Util class CloudSettingAuth
-  attr_reader :original, :username, :password
-
-  def initialize(value)
-    return if value.nil?
-
-    unless value.is_a?(String)
-      raise ArgumentError.new("Cloud Auth must be String. Received: #{value.class}")
-    end
-    @original = value
-    @username, sep, password = @original.partition(":")
-    if @username.empty? || sep.empty? || password.empty?
-      raise ArgumentError.new("Cloud Auth username and password format should be \"<username>:<password>\".")
-    end
-    @password = LogStash::Util::Password.new(password)
-  end
-
-  def to_s
-    "#{@username}:#{@password}"
-  end
-
-  def inspect
-    to_s
-  end
-end end end
+module LogStash; module Util
+  java_import org.logstash.util.CloudSettingAuth
+end; end

--- a/logstash-core/spec/logstash/settings/modules_spec.rb
+++ b/logstash-core/spec/logstash/settings/modules_spec.rb
@@ -97,46 +97,4 @@ describe LogStash::Setting::Modules do
       end
     end
   end
-
-  describe "Cloud.Auth" do
-    subject { described_class.new("mycloudauth", LogStash::Util::CloudSettingAuth) }
-    context "when given a string without a separator or a password" do
-      it "should raise an exception" do
-        expect { subject.set("foobarbaz") }.to raise_error(ArgumentError, /Cloud Auth username and password format should be/)
-      end
-    end
-
-    context "when given a string without a password" do
-      it "should raise an exception" do
-        expect { subject.set("foo:") }.to raise_error(ArgumentError, /Cloud Auth username and password format should be/)
-      end
-    end
-
-    context "when given a string without a username" do
-      it "should raise an exception" do
-        expect { subject.set(":bar") }.to raise_error(ArgumentError, /Cloud Auth username and password format should be/)
-      end
-    end
-
-    context "when given a string which is empty" do
-      it "should raise an exception" do
-        expect { subject.set("") }.to raise_error(ArgumentError, /Cloud Auth username and password format should be/)
-      end
-    end
-
-    context "when given a nil" do
-      it "should not raise an error" do
-        expect { subject.set(nil) }.to_not raise_error
-      end
-    end
-
-    context "when given a string which is a cloud auth" do
-      it "should set the string" do
-        expect { subject.set("frodo:baggins") }.to_not raise_error
-        expect(subject.value.username).to eq("frodo")
-        expect(subject.value.password.value).to eq("baggins")
-        expect(subject.value.to_s).to eq("frodo:<password>")
-      end
-    end
-  end
 end

--- a/logstash-core/src/main/java/co/elastic/logstash/api/Password.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/Password.java
@@ -39,4 +39,8 @@ public class Password {
     public String toString() {
         return "<password>";
     }
+
+    public String getValue() {
+        return getPassword();
+    }
 }

--- a/logstash-core/src/main/java/org/logstash/util/CloudSettingAuth.java
+++ b/logstash-core/src/main/java/org/logstash/util/CloudSettingAuth.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.logstash.util;
+
+import co.elastic.logstash.api.Password;
+
+public class CloudSettingAuth {
+
+    private String original;
+    private String username;
+    private Password password;
+
+    public CloudSettingAuth(String value) {
+        if (value == null) {
+            return;
+        }
+        this.original = value;
+        final String[] parts = this.original.split(":");
+        if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
+            throw new IllegalArgumentException("Cloud Auth username and password format should be \"<username>:<password>\".");
+        }
+
+        this.username = parts[0];
+        this.password = new Password(parts[1]);
+    }
+
+    public String getOriginal() {
+        return original;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public Password getPassword() {
+        return password;
+    }
+
+    @Override
+    public String toString() {
+        return String.join(":", username, password.toString());
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/util/CloudSettingAuthTest.java
+++ b/logstash-core/src/test/java/org/logstash/util/CloudSettingAuthTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.logstash.util;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.*;
+
+public class CloudSettingAuthTest {
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Test
+    public void testThrowExceptionWhenGivenStringWithoutSeparatorOrPassword() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Cloud Auth username and password format should be");
+
+        new CloudSettingAuth("foobarbaz");
+    }
+
+    @Test
+    public void testThrowExceptionWhenGivenStringWithoutPassword() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Cloud Auth username and password format should be");
+
+        new CloudSettingAuth("foo:");
+    }
+
+    @Test
+    public void testThrowExceptionWhenGivenStringWithoutUsername() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Cloud Auth username and password format should be");
+
+        new CloudSettingAuth(":bar");
+    }
+
+    @Test
+    public void testThrowExceptionWhenGivenStringWhichIsEmpty() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Cloud Auth username and password format should be");
+
+        new CloudSettingAuth("");
+    }
+
+    @Test
+    public void testNullInputDoenstThrowAnException() {
+        new CloudSettingAuth(null);
+    }
+
+
+    @Test
+    public void testWhenGivenStringWhichIsCloudAuthSetTheString() {
+        final CloudSettingAuth sut = new CloudSettingAuth("frodo:baggins");
+        assertEquals("frodo", sut.getUsername());
+        assertEquals("baggins", sut.getPassword().getValue());
+        assertEquals("frodo:<password>", sut.toString());
+    }
+
+}


### PR DESCRIPTION
**What**
This PR moves the class CloudSettingsAuth from Ruby to Java code

**Why**
Moving CloudSettingsAuth to Java let then move all the Setting hierarchy to Java

**How**
This PR leverages the ability of JRuby to use Java classes in JRuby code
