### PR TITLE
Separate "not terminated" state in "loading" and "running"

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -290,6 +290,10 @@ class LogStash::Agent
     @pipelines_registry.running_pipelines
    end
 
+   def loading_pipelines
+    @pipelines_registry.loading_pipelines
+   end
+
   def non_running_pipelines
     @pipelines_registry.non_running_pipelines
   end

--- a/logstash-core/lib/logstash/pipelines_registry.rb
+++ b/logstash-core/lib/logstash/pipelines_registry.rb
@@ -35,6 +35,19 @@ module LogStash
       end
     end
 
+    def running?
+      @lock.synchronize do
+        # not terminated and not loading
+        @loading.false? && !@pipeline.finished_execution?
+      end
+    end
+
+    def loading?
+      @lock.synchronize do
+        @loading.true?
+      end
+    end
+
     def set_loading(is_loading)
       @lock.synchronize do
         @loading.value = is_loading
@@ -253,7 +266,11 @@ module LogStash
 
     # @return [Hash{String=>Pipeline}]
     def running_pipelines
-      select_pipelines { |state| !state.terminated? }
+      select_pipelines { |state| state.running? }
+    end
+
+    def loading_pipelines
+      select_pipelines { |state| state.loading? }
     end
 
     # @return [Hash{String=>Pipeline}]

--- a/logstash-core/spec/support/matchers.rb
+++ b/logstash-core/spec/support/matchers.rb
@@ -95,7 +95,7 @@ RSpec::Matchers.define :have_running_pipeline? do |pipeline_config|
       expect(pipeline.running?).to be_truthy
     end
     expect(pipeline.config_str).to eq(pipeline_config.config_string)
-    expect(agent.running_pipelines.keys.map(&:to_s)).to include(pipeline_config.pipeline_id.to_s)
+    expect(agent.running_pipelines.keys.map(&:to_s) + agent.loading_pipelines.keys.map(&:to_s)).to include(pipeline_config.pipeline_id.to_s)
   end
 
   failure_message do |agent|
@@ -108,6 +108,10 @@ RSpec::Matchers.define :have_running_pipeline? do |pipeline_config|
         "Found '#{pipeline_config.pipeline_id.to_s}' in the list of pipelines but its not running"
       elsif pipeline.config_str != pipeline_config.config_string
         "Found '#{pipeline_config.pipeline_id.to_s}' in the list of pipelines and running, but the config_string doesn't match,\nExpected:\n#{pipeline_config.config_string}\n\ngot:\n#{pipeline.config_str}"
+      elsif agent.running_pipelines.keys.map(&:to_s).include?(pipeline_config.pipeline_id.to_s)
+        "Found '#{pipeline_config.pipeline_id.to_s}' in running but not included in the list of agent.running_pipelines or agent.loading_pipelines"
+      else
+        "Unrecognized error condition, probably you missed to track properly a newly added expect in :have_running_pipeline?"
       end
     end
   end


### PR DESCRIPTION
## What does this PR do?
Actually the pipelines (from the PipelineRegistry) point of view are in 2 states `terminated` and `running` where `running` is simply obtained as `not terminated`. This drive to a problem that also pipelines in `loading` status are considered as `running` and so are eligible to be queried for metrics while still building its metrics structure, and so generates a Nil access.
This commit separate the "not terminated" state explicitly in "running" and "loading" to avoid some pipelines in loading state to be defined as "running".

## Why is it important/What is the impact to the user?
This PR fixes a bug that manifests on automatic reloading

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [x] run the reproducer

## How to test this PR locally
Use this reproducer https://github.com/elastic/logstash/issues/12190#issuecomment-733070149 and verify that no errors like:
```
[ERROR][logstash.inputs.metrics  ] Failed to create monitoring event {:message=>"undefined method `[]' for nil:NilClass", :error=>"NoMethodError"}
```
are present in logs.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #12190

~~## Use cases~~

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

~~## Screenshots~~

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

~~## Logs~~

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->