### PR TITLE
[710_backport] Fix docker image metadata

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -27,7 +27,6 @@ HTTPD ?= logstash-docker-artifact-server
 FIGLET := pyfiglet -w 160 -f puffy
 
 all: build-from-local-artifacts build-from-local-oss-artifacts public-dockerfiles
-DATE:= $(shell date -u +'%Y-%m-%dT%H:%M:%S.%sZ')
 
 lint: venv
 	flake8 tests
@@ -89,7 +88,7 @@ public-dockerfiles: public-dockerfiles_oss public_dockerfiles_full public_docker
 
 public-dockerfiles_full: venv templates/Dockerfile.j2 docker_paths $(COPY_FILES)
 	jinja2 \
-	  -D created_date='$(DATE)' \
+	  -D created_date='$(BUILD_DATE)' \
 	  -D elastic_version='$(ELASTIC_VERSION)' \
 	  -D arch='${ARCHITECTURE}' \
 	  -D version_tag='$(VERSION_TAG)' \
@@ -103,7 +102,7 @@ public-dockerfiles_full: venv templates/Dockerfile.j2 docker_paths $(COPY_FILES)
 
 public-dockerfiles_oss: venv templates/Dockerfile.j2 docker_paths $(COPY_FILES)
 	jinja2 \
-	  -D created_date='$(DATE)' \
+	  -D created_date='$(BUILD_DATE)' \
 	  -D elastic_version='$(ELASTIC_VERSION)' \
 	  -D arch='${ARCHITECTURE}' \
 	  -D version_tag='$(VERSION_TAG)' \
@@ -117,7 +116,7 @@ public-dockerfiles_oss: venv templates/Dockerfile.j2 docker_paths $(COPY_FILES)
 
 public-dockerfiles_ubi8: venv templates/Dockerfile.j2 docker_paths $(COPY_FILES)
 	jinja2 \
-	  -D created_date='$(DATE)' \
+	  -D created_date='$(BUILD_DATE)' \
 	  -D elastic_version='$(ELASTIC_VERSION)' \
 	  -D arch='${ARCHITECTURE}' \
 	  -D version_tag='$(VERSION_TAG)' \
@@ -173,7 +172,7 @@ env2yaml: golang
 dockerfile: venv templates/Dockerfile.j2
 	$(foreach FLAVOR, $(IMAGE_FLAVORS), \
 	  jinja2 \
-	    -D created_date='$(DATE)' \
+	    -D created_date='$(BUILD_DATE)' \
 	    -D elastic_version='$(ELASTIC_VERSION)' \
 	    -D arch='${ARCHITECTURE}' \
 	    -D version_tag='$(VERSION_TAG)' \

--- a/docker/templates/Dockerfile.j2
+++ b/docker/templates/Dockerfile.j2
@@ -92,16 +92,11 @@ LABEL  org.label-schema.schema-version="1.0" \
   org.opencontainers.image.version="{{ elastic_version }}" \
   org.label-schema.url="https://www.elastic.co/products/logstash" \
   org.label-schema.vcs-url="https://github.com/elastic/logstash" \
-  license="{{ license }}" \
   org.label-schema.license="{{ license }}" \
   org.opencontainers.image.licenses="{{ license }}" \
+  org.opencontainers.image.description="Logstash is a free and open server-side data processing pipeline that ingests data from a multitude of sources, transforms it, and then sends it to your favorite 'stash.'" \
   org.label-schema.build-date={{ created_date }} \
-  org.opencontainers.image.created={{ created_date }} \
-  description="Logstash is a free and open server-side data processing pipeline that ingests data from a multitude of sources, transforms it, and then sends it to your favorite 'stash.'" \
-  name="logstash" \
-  maintainer="info@elastic.co" \
-  summary="Logstash is a free and open server-side data processing pipeline that ingests data from a multitude of sources, transforms it, and then sends it to your favorite 'stash.'" \
-  vendor="Elastic"
+  org.opencontainers.image.created={{ created_date }}
 
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]

--- a/qa/docker/shared_examples/image_metadata.rb
+++ b/qa/docker/shared_examples/image_metadata.rb
@@ -13,34 +13,24 @@ shared_examples_for 'the metadata is set correctly' do |flavor|
     expect(@image.json['Architecture']).to have_correct_architecture
   end
 
-  %w(license org.label-schema.license org.opencontainers.image.licenses).each do |label|
+  %w(org.label-schema.license org.opencontainers.image.licenses).each do |label|
     it "should set the license label #{label} correctly" do
       expect(@labels[label]).to have_correct_license_label(flavor)
     end
   end
 
-  %w(name org.label-schema.name org.opencontainers.image.title).each do |label|
+  %w(org.label-schema.name org.opencontainers.image.title).each do |label|
     it "should set the name label #{label} correctly" do
       expect(@labels[label]).to eql "logstash"
     end
   end
 
-  %w(maintainer).each do |label|
-    it "should set the name label #{label} correctly" do
-      expect(@labels[label]).to eql "info@elastic.co"
-    end
+  it "should set the vendor label org.opencontainers.image.vendor correctly" do
+    expect(@labels['org.opencontainers.image.vendor']).to eql "Elastic"
   end
 
-  %w(description summary).each do |label|
-    it "should set the name label #{label} correctly" do
-      expect(@labels[label]).to eql "Logstash is a free and open server-side data processing pipeline that ingests data from a multitude of sources, transforms it, and then sends it to your favorite 'stash.'"
-    end
-  end
-
-  %w(vendor org.opencontainers.image.vendor).each do |label|
-    it "should set the vendor label #{label} correctly" do
-      expect(@labels[label]).to eql "Elastic"
-    end
+  it "should set the description label org.opencontainers.image.description correctly" do
+    expect(@labels['org.opencontainers.image.description']).to eql "Logstash is a free and open server-side data processing pipeline that ingests data from a multitude of sources, transforms it, and then sends it to your favorite 'stash.'"
   end
 
   %w(org.label-schema.version org.opencontainers.image.version).each do |label|

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -336,14 +336,21 @@ namespace "artifact" do
     Rake::Task["artifact:dockerfile_oss"].invoke
   end
 
+  task "build_docker_ubi8" => [:generate_build_metadata] do
+    Rake::Task["artifact:docker_ubi8"].invoke
+    Rake::Task["artifact:dockerfile_ubi8"].invoke
+  end
+
   task "generate_build_metadata" do
     return if defined?(BUILD_METADATA_FILE)
     BUILD_METADATA_FILE = Tempfile.new('build.rb')
+    BUILD_DATE=Time.now.iso8601
     build_info = {
-      "build_date" => Time.now.iso8601,
+      "build_date" => BUILD_DATE,
       "build_sha" => `git rev-parse HEAD`.chomp,
       "build_snapshot" => SNAPSHOT_BUILD
     }
+
     metadata = [ "# encoding: utf-8", "BUILD_INFO = #{build_info}" ]
     IO.write(BUILD_METADATA_FILE.path, metadata.join("\n"))
   end
@@ -690,7 +697,8 @@ namespace "artifact" do
     env = {
       "ARTIFACTS_DIR" => ::File.join(Dir.pwd, "build"),
       "RELEASE" => ENV["RELEASE"],
-      "VERSION_QUALIFIER" => VERSION_QUALIFIER
+      "VERSION_QUALIFIER" => VERSION_QUALIFIER,
+      "BUILD_DATE" => BUILD_DATE
     }
     Dir.chdir("docker") do |dir|
         system(env, "make build-from-local-#{flavor}-artifacts")
@@ -701,7 +709,8 @@ namespace "artifact" do
     env = {
       "ARTIFACTS_DIR" => ::File.join(Dir.pwd, "build"),
       "RELEASE" => ENV["RELEASE"],
-      "VERSION_QUALIFIER" => VERSION_QUALIFIER
+      "VERSION_QUALIFIER" => VERSION_QUALIFIER,
+      "BUILD_DATE" => BUILD_DATE
     }
     Dir.chdir("docker") do |dir|
       system(env, "make public-dockerfiles_#{flavor}")


### PR DESCRIPTION
Clean backport of #12447

This commit fixes two issues with the docker metadata:

Removes non-OCI compliant freeform metadata labels
Uses a consistent build date for all the docker images and dockerfiles

Additionally, this commit adds a `build_docker_ubi8` rake task to enable
`ci/docker_acceptance_tests.sh` to run with no options to build all
docker images for the architecture.

