### PR TITLE
Add additional description label

### DIFF
--- a/docker/templates/Dockerfile.j2
+++ b/docker/templates/Dockerfile.j2
@@ -94,6 +94,7 @@ LABEL  org.label-schema.schema-version="1.0" \
   org.label-schema.vcs-url="https://github.com/elastic/logstash" \
   org.label-schema.license="{{ license }}" \
   org.opencontainers.image.licenses="{{ license }}" \
+  org.opencontainers.image.description="Logstash is a free and open server-side data processing pipeline that ingests data from a multitude of sources, transforms it, and then sends it to your favorite 'stash.'" \
   org.label-schema.build-date={{ created_date }} \
   org.opencontainers.image.created={{ created_date }}
 

--- a/qa/docker/shared_examples/image_metadata.rb
+++ b/qa/docker/shared_examples/image_metadata.rb
@@ -29,6 +29,10 @@ shared_examples_for 'the metadata is set correctly' do |flavor|
     expect(@labels['org.opencontainers.image.vendor']).to eql "Elastic"
   end
 
+  it "should set the description label org.opencontainers.image.description correctly" do
+    expect(@labels['org.opencontainers.image.description']).to eql "Logstash is a free and open server-side data processing pipeline that ingests data from a multitude of sources, transforms it, and then sends it to your favorite 'stash.'"
+  end
+
   %w(org.label-schema.version org.opencontainers.image.version).each do |label|
     it "should set the version label #{label} correctly" do
       expect(@labels[label]).to eql qualified_version


### PR DESCRIPTION
Removing the freeform description labels left the container metadata without a description label. This commit adds a description under the "org.opencontainers.image.description" label.
