### PR TITLE
Drop Password Ruby class to use only the Java version

### DIFF
--- a/logstash-core/lib/logstash/util/password.rb
+++ b/logstash-core/lib/logstash/util/password.rb
@@ -17,21 +17,7 @@
 
 # This class exists to quietly wrap a password string so that, when printed or
 # logged, you don't accidentally print the password itself.
-module LogStash module Util class Password
-  attr_reader :value
 
-  public
-  def initialize(password)
-    @value = password
-  end # def initialize
-
-  public
-  def to_s
-    return "<password>"
-  end # def to_s
-
-  public
-  def inspect
-    return to_s
-  end # def inspect
-end end end # class LogStash::Util::Password
+module LogStash; module Util
+    java_import "co.elastic.logstash.api.Password"
+end; end # class LogStash::Util::Password

--- a/logstash-core/src/main/java/co/elastic/logstash/api/Password.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/Password.java
@@ -20,10 +20,14 @@
 
 package co.elastic.logstash.api;
 
+import java.io.Serializable;
+
 /**
  * Wraps a password string so that it is not inadvertently printed or logged.
  */
-public class Password {
+public class Password implements Serializable {
+
+    private static final long serialVersionUID = -8683271728417419530L;
 
     private String password;
 
@@ -40,7 +44,13 @@ public class Password {
         return "<password>";
     }
 
+    // Ruby code compatibility, value attribute
     public String getValue() {
         return getPassword();
+    }
+
+    // Ruby code compatibility, inspect method
+    public String inspect() {
+        return toString();
     }
 }


### PR DESCRIPTION
clean backport of #12455 

There is two Password classes that almost does the same thing. One in Ruby (LogStash::Util::Password) and one in Java (co.elastic.logstash.api.Password).
This commit drop the the Ruby implementation to import the Java version in the LogStash::Util so that existing Ruby code haven't to be changed, works as it is.

(cherry picked from commit ca81a8f4a32457a7c100a4712c7c5a4c9b5c2faa)
