### PR TITLE
plugin: adds `:validate => :field_reference`

### DIFF
--- a/docs/static/configuration.asciidoc
+++ b/docs/static/configuration.asciidoc
@@ -283,7 +283,7 @@ Example:
 ==== Field Reference
 
 A Field Reference is a special <<string>> value representing the path to a field in an event, such as `@timestamp` or `[@timestamp]` to reference a top-level field, or `[client][ip]` to access a nested field.
-The <<field-reference.asciidoc, Field Reference Deep Dive>> provides detailed information about the structure of Field References.
+The <<field-references-deepdive>> provides detailed information about the structure of Field References.
 When provided as a configuration option, Field References need to be quoted and special characters must be escaped following the same rules as <<string>>.
 
 [float]

--- a/docs/static/configuration.asciidoc
+++ b/docs/static/configuration.asciidoc
@@ -278,6 +278,14 @@ Example:
   name => 'It\'s a beautiful day'
 ----------------------------------
 
+[[field-reference]]
+[float]
+==== Field Reference
+
+A Field Reference is a special <<string>> value representing the path to a field in an event, such as `@timestamp` or `[@timestamp]` to reference a top-level field, or `[client][ip]` to access a nested field.
+The <<field-reference.asciidoc, Field Reference Deep Dive>> provides detailed information about the structure of Field References.
+When provided as a configuration option, Field References need to be quoted and special characters must be escaped following the same rules as <<string>>.
+
 [float]
 [[comments]]
 === Comments

--- a/logstash-core/src/main/java/org/logstash/FieldReference.java
+++ b/logstash-core/src/main/java/org/logstash/FieldReference.java
@@ -127,6 +127,15 @@ public final class FieldReference {
         return parseToCache(reference);
     }
 
+    public static boolean isValid(final String reference) {
+        try {
+            FieldReference.from(reference);
+            return true;
+        } catch (IllegalSyntaxException ise) {
+            return false;
+        }
+    }
+
     /**
      * Returns the type of this instance to allow for fast switch operations in
      * {@link Event#getUnconvertedField(FieldReference)} and


### PR DESCRIPTION
## What does this PR do?

Provide plugins a way of validating that an input is a literal field-reference.

This is useful for input plugins that implement a `target` or other
non-interpolated directive, and allows these plugins to reject invalid
configuration before start-up instead of at run-time.

~~~
  config "target", :validate => :field_reference
~~~

Plugins should not use this named validator directly, as doing so would cause
validation to fail with "Unknown validator" when the plugin is run on older
releases of Logstash. Instead, plugins should use a to-be-released
support adapter that provides back-ports when necessary.

## Why is it important/What is the impact to the user?

When a plugin can reject invalid configuration at startup instead of producing errors at runtime, users are less likely to get into situations that cannot be undone. A plugin that refuses to start in an invalid configuration is better than one that will defers the error to runtime where data is consumed incorrectly.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works
