### PR TITLE
remove evaluation dir from JRuby bundled did_you_mean gem

### DIFF
--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -276,6 +276,7 @@ tasks.register("downloadAndInstallJRuby", Copy) {
     exclude "**/stdlib/bundler.rb"
     exclude "**/bundler-1.16.6/**"
     exclude "**/bundler-1.16.6.*"
+    exclude "**/did_you_mean-*/evaluation/**" // licensing issue https://github.com/jruby/jruby/issues/6471
 
     includeEmptyDirs = false
     into "${projectDir}/vendor/jruby"


### PR DESCRIPTION
Per https://github.com/jruby/jruby/issues/6471 the JRuby bundled gem `did_you_mean` contains files with non commercial licenses. 