### PR TITLE
Fix: make sure LS exits when running out of memory

### DIFF
--- a/config/jvm.options
+++ b/config/jvm.options
@@ -52,6 +52,9 @@
 # Make sure joni regexp interruptability is enabled
 -Djruby.regexp.interruptible=true
 
+# make sure LS exits when running out of (heap) memory
+-XX:+ExitOnOutOfMemoryError
+
 ## heap dumps
 
 # generate a heap dump when an allocation from the Java heap fails


### PR DESCRIPTION
wout the introduced flag LS continues executing on `java.lang.OutOfMemoryError`,
due (common) exception retry logic and error catching in plugins as well as core.

This is dangerous since the error is a legitimate reason to halt the process and not continue processing.
User needs to increase memory or inspect why LS drained memory.

The JVM flag is available since JDK 8u92.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] do we need to update the official JVM [support matrix](https://www.elastic.co/support/matrix#matrix_jvm) to include the Java 8 patch (`>= 8u92`) level version?

## Related issues

resolves https://github.com/elastic/logstash/issues/7987

previous attempt was reverted: https://github.com/elastic/logstash/issues/8254 due the Java >= 8u92 requirement (3 years ago).

## Logs

if we're lucky LS logs an error (without stack-trace - thus easy to miss) such as:

```
[2020-11-19T03:10:57,824][ERROR][org.logstash.Logstash    ] java.lang.OutOfMemoryError: Java heap space
```
usually execution continues and than other errors start to pile up such as:
<details>
<summary>sample trace where logging is failing terribly</summary>
<pre><code>
[2020-11-19T03:10:55,979][WARN ][io.netty.channel.DefaultChannelPipeline][metricbeat-in][ed20c2f5355a4c9dba633cd572aa76a670bd785c7117d7d430cc14da2d57c1e8] An exceptionCaught() event was fired, and it reached at the tail of the pipeline. It usually means the last handler in the pipeline did not handle the exception.
java.lang.InternalError: BMH.reinvoke=Lambda(a0:L/SpeciesData<L>,a1:L,a2:L,a3:I)=>{
    t4:L=Species_L.argL0(a0:L);
    t5:L=MethodHandle.invokeBasic(t4:L,a1:L,a2:L);t5:L}
	at java.lang.invoke.MethodHandleStatics.newInternalError(MethodHandleStatics.java:127) ~[?:1.8.0_262]
	at java.lang.invoke.LambdaForm.compileToBytecode(LambdaForm.java:660) ~[?:1.8.0_262]
	at java.lang.invoke.LambdaForm.prepare(LambdaForm.java:635) ~[?:1.8.0_262]
	at java.lang.invoke.MethodHandle.<init>(MethodHandle.java:461) ~[?:1.8.0_262]
	at java.lang.invoke.BoundMethodHandle.<init>(BoundMethodHandle.java:58) ~[?:1.8.0_262]
	at java.lang.invoke.BoundMethodHandle$Species_L.<init>(BoundMethodHandle.java:211) ~[?:1.8.0_262]
	at java.lang.invoke.BoundMethodHandle$Species_L.copyWith(BoundMethodHandle.java:228) ~[?:1.8.0_262]
	at java.lang.invoke.MethodHandles.dropArguments(MethodHandles.java:2465) ~[?:1.8.0_262]
	at java.lang.invoke.MethodHandles.dropArguments(MethodHandles.java:2535) ~[?:1.8.0_262]
	at jdk.nashorn.internal.lookup.MethodHandleFactory$StandardMethodHandleFunctionality.dropArguments(MethodHandleFactory.java:407) ~[nashorn.jar:?]
	at jdk.nashorn.internal.runtime.CompiledFunction.createConstructorFromInvoker(CompiledFunction.java:266) ~[nashorn.jar:?]
	at jdk.nashorn.internal.runtime.CompiledFunction.createBuiltInConstructor(CompiledFunction.java:135) ~[nashorn.jar:?]
	at jdk.nashorn.internal.runtime.FinalScriptFunctionData.addInvoker(FinalScriptFunctionData.java:140) ~[nashorn.jar:?]
	at jdk.nashorn.internal.runtime.FinalScriptFunctionData.<init>(FinalScriptFunctionData.java:70) ~[nashorn.jar:?]
	at jdk.nashorn.internal.runtime.ScriptFunction.<init>(ScriptFunction.java:232) ~[nashorn.jar:?]
	at jdk.nashorn.internal.runtime.ScriptFunction.<init>(ScriptFunction.java:278) ~[nashorn.jar:?]
	at jdk.nashorn.internal.objects.NativeArray$Constructor.<init>(Unknown Source) ~[nashorn.jar:?]
	at sun.reflect.GeneratedConstructorAccessor35.newInstance(Unknown Source) ~[?:?]
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:1.8.0_262]
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423) ~[?:1.8.0_262]
	at java.lang.Class.newInstance(Class.java:442) ~[?:1.8.0_262]
	at jdk.nashorn.internal.objects.Global.initConstructor(Global.java:2567) ~[nashorn.jar:?]
	at jdk.nashorn.internal.objects.Global.initConstructorAndSwitchPoint(Global.java:2252) ~[nashorn.jar:?]
	at jdk.nashorn.internal.objects.Global.init(Global.java:2300) ~[nashorn.jar:?]
	at jdk.nashorn.internal.objects.Global.initBuiltinObjects(Global.java:1094) ~[nashorn.jar:?]
	at jdk.nashorn.internal.runtime.Context.initGlobal(Context.java:1150) ~[nashorn.jar:?]
	at jdk.nashorn.api.scripting.NashornScriptEngine.createNashornGlobal(NashornScriptEngine.java:360) ~[nashorn.jar:?]
	at jdk.nashorn.api.scripting.NashornScriptEngine.createGlobalMirror(NashornScriptEngine.java:340) ~[nashorn.jar:?]
	at jdk.nashorn.api.scripting.NashornScriptEngine.getNashornGlobalFrom(NashornScriptEngine.java:320) ~[nashorn.jar:?]
	at jdk.nashorn.api.scripting.NashornScriptEngine.access$100(NashornScriptEngine.java:73) ~[nashorn.jar:?]
	at jdk.nashorn.api.scripting.NashornScriptEngine$3.eval(NashornScriptEngine.java:507) ~[nashorn.jar:?]
	at javax.script.CompiledScript.eval(CompiledScript.java:92) ~[?:1.8.0_262]
	at org.apache.logging.log4j.core.script.ScriptManager$MainScriptRunner.execute(ScriptManager.java:232) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.script.ScriptManager$ThreadLocalScriptRunner.execute(ScriptManager.java:269) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.script.ScriptManager$1.run(ScriptManager.java:177) ~[log4j-core-2.13.3.jar:2.13.3]
	at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_262]
	at org.apache.logging.log4j.core.script.ScriptManager.execute(ScriptManager.java:174) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.filter.ScriptFilter.filter(ScriptFilter.java:115) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.filter.AbstractFilterable.isFiltered(AbstractFilterable.java:154) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.config.AppenderControl.isFilteredByAppender(AppenderControl.java:151) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.config.AppenderControl.callAppender0(AppenderControl.java:128) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.config.AppenderControl.callAppenderPreventRecursion(AppenderControl.java:120) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.config.AppenderControl.callAppender(AppenderControl.java:84) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.config.LoggerConfig.callAppenders(LoggerConfig.java:543) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.config.LoggerConfig.processLogEvent(LoggerConfig.java:502) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:485) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:460) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.config.AwaitCompletionReliabilityStrategy.log(AwaitCompletionReliabilityStrategy.java:82) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.Logger.log(Logger.java:161) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.spi.AbstractLogger.tryLogMessage(AbstractLogger.java:2198) ~[log4j-api-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.spi.AbstractLogger.logMessageTrackRecursion(AbstractLogger.java:2152) ~[log4j-api-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.spi.AbstractLogger.logMessageSafely(AbstractLogger.java:2135) ~[log4j-api-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.spi.AbstractLogger.logMessage(AbstractLogger.java:2011) ~[log4j-api-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.spi.AbstractLogger.logIfEnabled(AbstractLogger.java:1983) ~[log4j-api-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.spi.AbstractLogger.debug(AbstractLogger.java:327) ~[log4j-api-2.13.3.jar:2.13.3]
	at org.logstash.beats.BeatsHandler.channelRead0(BeatsHandler.java:50) ~[logstash-input-beats-6.0.11.jar:?]
	at org.logstash.beats.BeatsHandler.channelRead0(BeatsHandler.java:12) ~[logstash-input-beats-6.0.11.jar:?]
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99) ~[netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324) ~[netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296) ~[netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.AbstractChannelHandlerContext.access$600(AbstractChannelHandlerContext.java:61) ~[netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.AbstractChannelHandlerContext$7.run(AbstractChannelHandlerContext.java:370) ~[netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.util.concurrent.DefaultEventExecutor.run(DefaultEventExecutor.java:66) ~[netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989) [netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-all-4.1.49.Final.jar:4.1.49.Final]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_262]
Caused by: java.lang.OutOfMemoryError: Java heap space
</pre></code>
</summary>
