### PR TITLE
[Doc] expand the description of how to obtain the logger's names form Java and Ruby class names

### DIFF
--- a/docs/static/logging.asciidoc
+++ b/docs/static/logging.asciidoc
@@ -42,6 +42,12 @@ logger.elasticsearchoutput.name = logstash.outputs.elasticsearch
 logger.elasticsearchoutput.level = debug
 --------------------------------------------------
 
+The previous example defines a name and level for the logger `logstash.outputs.elasticsearch`.
+The logger is usually identified by a Java class name, such as
+`org.logstash.dissect.Dissector`, for example.  It can also be a partial package
+path as in `org.logstash.dissect`.  For Ruby classes, like `LogStash::Outputs::Elasticsearch`,
+the logger name is obtained by lowercasing the full class name and replacing double colons with a single dot.
+
 ==== Logging APIs
 
 For temporary logging changes, modifying the `log4j2.properties` file and restarting Logstash leads to unnecessary


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## What does this PR do?

Improves the description of how to grab the loggers names, for example for plugins, or other parts, like classes/libraries used by plugins. For example enabling logging on dissector plugin, which also uses some Java classes like `org.logstash.dissect.Dissector`, the user has to enable the logging also for that, to have a full picture of what's happening during dissect processing.

## Why is it important/What is the impact to the user?
Doesn't impact the user functionality, just documentation

## Checklist
- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] check the docs renders correctly

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
NA

## Related issues
NA

## Use cases
NA
