### PR TITLE
Fix an API break in CloudSettingsAuth, a Ruby's ArgumentError should be raised

### DIFF
--- a/logstash-core/spec/logstash/settings/modules_spec.rb
+++ b/logstash-core/spec/logstash/settings/modules_spec.rb
@@ -97,4 +97,46 @@ describe LogStash::Setting::Modules do
       end
     end
   end
+
+  describe "Cloud.Auth" do
+    subject { described_class.new("mycloudauth", LogStash::Util::CloudSettingAuth) }
+    context "when given a string without a separator or a password" do
+      it "should raise an exception" do
+        expect { subject.set("foobarbaz") }.to raise_error(ArgumentError, /Cloud Auth username and password format should be/)
+      end
+    end
+
+    context "when given a string without a password" do
+      it "should raise an exception" do
+        expect { subject.set("foo:") }.to raise_error(ArgumentError, /Cloud Auth username and password format should be/)
+      end
+    end
+
+    context "when given a string without a username" do
+      it "should raise an exception" do
+        expect { subject.set(":bar") }.to raise_error(ArgumentError, /Cloud Auth username and password format should be/)
+      end
+    end
+
+    context "when given a string which is empty" do
+      it "should raise an exception" do
+        expect { subject.set("") }.to raise_error(ArgumentError, /Cloud Auth username and password format should be/)
+      end
+    end
+
+    context "when given a nil" do
+      it "should not raise an error" do
+        expect { subject.set(nil) }.to_not raise_error
+      end
+    end
+
+    context "when given a string which is a cloud auth" do
+      it "should set the string" do
+        expect { subject.set("frodo:baggins") }.to_not raise_error
+        expect(subject.value.username).to eq("frodo")
+        expect(subject.value.password.value).to eq("baggins")
+        expect(subject.value.to_s).to eq("frodo:<password>")
+      end
+    end
+  end
 end

--- a/logstash-core/src/main/java/org/logstash/util/CloudSettingAuth.java
+++ b/logstash-core/src/main/java/org/logstash/util/CloudSettingAuth.java
@@ -20,6 +20,7 @@
 package org.logstash.util;
 
 import co.elastic.logstash.api.Password;
+import org.logstash.RubyUtil;
 
 public class CloudSettingAuth {
 
@@ -34,7 +35,7 @@ public class CloudSettingAuth {
         this.original = value;
         final String[] parts = this.original.split(":");
         if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
-            throw new IllegalArgumentException("Cloud Auth username and password format should be \"<username>:<password>\".");
+            throw RubyUtil.RUBY.newArgumentError("Cloud Auth username and password format should be \"<username>:<password>\".");
         }
 
         this.username = parts[0];

--- a/logstash-core/src/test/java/org/logstash/util/CloudSettingAuthTest.java
+++ b/logstash-core/src/test/java/org/logstash/util/CloudSettingAuthTest.java
@@ -32,7 +32,7 @@ public class CloudSettingAuthTest {
 
     @Test
     public void testThrowExceptionWhenGivenStringWithoutSeparatorOrPassword() {
-        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expect(org.jruby.exceptions.ArgumentError.class);
         exceptionRule.expectMessage("Cloud Auth username and password format should be");
 
         new CloudSettingAuth("foobarbaz");
@@ -40,7 +40,7 @@ public class CloudSettingAuthTest {
 
     @Test
     public void testThrowExceptionWhenGivenStringWithoutPassword() {
-        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expect(org.jruby.exceptions.ArgumentError.class);
         exceptionRule.expectMessage("Cloud Auth username and password format should be");
 
         new CloudSettingAuth("foo:");
@@ -48,7 +48,7 @@ public class CloudSettingAuthTest {
 
     @Test
     public void testThrowExceptionWhenGivenStringWithoutUsername() {
-        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expect(org.jruby.exceptions.ArgumentError.class);
         exceptionRule.expectMessage("Cloud Auth username and password format should be");
 
         new CloudSettingAuth(":bar");
@@ -56,7 +56,7 @@ public class CloudSettingAuthTest {
 
     @Test
     public void testThrowExceptionWhenGivenStringWhichIsEmpty() {
-        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expect(org.jruby.exceptions.ArgumentError.class);
         exceptionRule.expectMessage("Cloud Auth username and password format should be");
 
         new CloudSettingAuth("");


### PR DESCRIPTION
Backport of #12463 to `7.x`
Bring back Ruby specs to double check the change also in Ruby context.

(cherry picked from commit 14570d5d86348924906fa09fdbb731d7b6bf557c)
