### PR TITLE
 Fix: make sure LS exits when running into fatal errors

### DIFF
--- a/config/jvm.options
+++ b/config/jvm.options
@@ -52,9 +52,6 @@
 # Make sure joni regexp interruptability is enabled
 -Djruby.regexp.interruptible=true
 
-# make sure LS exits when running out of (heap) memory
--XX:+ExitOnOutOfMemoryError
-
 ## heap dumps
 
 # generate a heap dump when an allocation from the Java heap fails

--- a/config/jvm.options
+++ b/config/jvm.options
@@ -52,6 +52,9 @@
 # Make sure joni regexp interruptability is enabled
 -Djruby.regexp.interruptible=true
 
+# make sure LS exits when running out of (heap) memory
+-XX:+ExitOnOutOfMemoryError
+
 ## heap dumps
 
 # generate a heap dump when an allocation from the Java heap fails

--- a/logstash-core/src/main/java/org/logstash/Logstash.java
+++ b/logstash-core/src/main/java/org/logstash/Logstash.java
@@ -34,7 +34,6 @@ import org.apache.logging.log4j.Logger;
 import org.jruby.Ruby;
 import org.jruby.RubyException;
 import org.jruby.RubyInstanceConfig;
-import org.jruby.RubyNumeric;
 import org.jruby.RubySystemExit;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -124,7 +123,7 @@ public final class Logstash implements Runnable, AutoCloseable {
             halt(125);
         } else if (t instanceof IOError) {
             halt(124);
-        } else if (t instanceof AssertionError) {
+        } else if (t instanceof LinkageError) {
             halt(123);
         } else if (t instanceof Error) {
             halt(120);

--- a/logstash-core/src/main/java/org/logstash/Logstash.java
+++ b/logstash-core/src/main/java/org/logstash/Logstash.java
@@ -66,19 +66,18 @@ public final class Logstash implements Runnable, AutoCloseable {
         ) {
             logstash.run();
         } catch (final IllegalStateException e) {
-            String errorMessage[] = null;
+            String errorMessage = null;
             if (e.getMessage().contains("Could not load FFI Provider")) {
-                errorMessage = new String[] {
-                        "\nError accessing temp directory: " + System.getProperty("java.io.tmpdir"),
-                        "This often occurs because the temp directory has been mounted with NOEXEC or " +
-                        "the Logstash user has insufficient permissions on the directory. ",
+                errorMessage =
+                        "Error accessing temp directory: " + System.getProperty("java.io.tmpdir") +
+                        " this often occurs because the temp directory has been mounted with NOEXEC or" +
+                        " the Logstash user has insufficient permissions on the directory. \n" +
                         "Possible workarounds include setting the -Djava.io.tmpdir property in the jvm.options" +
-                        "file to an alternate directory or correcting the Logstash user's permissions."
-                };
+                        "file to an alternate directory or correcting the Logstash user's permissions.";
             }
-            handleCriticalError(e, errorMessage);
+            handleCriticalError("critical error", e, errorMessage);
         } catch (final Throwable t) {
-            handleCriticalError(t);
+            handleCriticalError("critical error", t, null);
         }
         System.exit(0);
     }
@@ -92,12 +91,10 @@ public final class Logstash implements Runnable, AutoCloseable {
         }
     }
 
-    private static void handleCriticalError(Throwable t, String... errorMessage) {
-        LOGGER.fatal((String) null, t);
-        if (errorMessage != null) {
-            for (String err : errorMessage) {
-                System.err.println(err);
-            }
+    private static void handleCriticalError(String message, Throwable t, String supplementaryErrorMessage) {
+        LOGGER.fatal(message, t);
+        if (supplementaryErrorMessage != null) {
+            LOGGER.error(supplementaryErrorMessage);
         }
         System.exit(1);
     }
@@ -193,4 +190,5 @@ public final class Logstash implements Runnable, AutoCloseable {
     private static void uncleanShutdown(final Exception ex) {
         throw new IllegalStateException("Logstash stopped processing because of an error: " + ex.getMessage(), ex);
     }
+
 }

--- a/logstash-core/src/main/java/org/logstash/Logstash.java
+++ b/logstash-core/src/main/java/org/logstash/Logstash.java
@@ -68,17 +68,17 @@ public final class Logstash implements Runnable, AutoCloseable {
         } catch (final IllegalStateException e) {
             String errorMessage[] = null;
             if (e.getMessage().contains("Could not load FFI Provider")) {
-                errorMessage = new String[]{
+                errorMessage = new String[] {
                         "\nError accessing temp directory: " + System.getProperty("java.io.tmpdir"),
-                        "This often occurs because the temp directory has been mounted with NOEXEC or",
-                        "the Logstash user has insufficient permissions on the directory. Possible",
-                        "workarounds include setting the -Djava.io.tmpdir property in the jvm.options",
+                        "This often occurs because the temp directory has been mounted with NOEXEC or " +
+                        "the Logstash user has insufficient permissions on the directory. ",
+                        "Possible workarounds include setting the -Djava.io.tmpdir property in the jvm.options" +
                         "file to an alternate directory or correcting the Logstash user's permissions."
                 };
             }
             handleCriticalError(e, errorMessage);
         } catch (final Throwable t) {
-            handleCriticalError(t, null);
+            handleCriticalError(t);
         }
         System.exit(0);
     }
@@ -92,8 +92,8 @@ public final class Logstash implements Runnable, AutoCloseable {
         }
     }
 
-    private static void handleCriticalError(Throwable t, String[] errorMessage) {
-        LOGGER.error(t);
+    private static void handleCriticalError(Throwable t, String... errorMessage) {
+        LOGGER.fatal((String) null, t);
         if (errorMessage != null) {
             for (String err : errorMessage) {
                 System.err.println(err);

--- a/qa/integration/fixtures/fatal_error_spec.yml
+++ b/qa/integration/fixtures/fatal_error_spec.yml
@@ -1,0 +1,3 @@
+---
+services:
+  - logstash

--- a/qa/integration/specs/fatal_error_spec.rb
+++ b/qa/integration/specs/fatal_error_spec.rb
@@ -1,0 +1,74 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require_relative '../framework/fixture'
+require_relative '../framework/helpers'
+require_relative '../framework/settings'
+require_relative '../services/logstash_service'
+require "logstash/devutils/rspec/spec_helper"
+
+describe "uncaught exception" do
+
+  before(:all) do
+    @fixture = Fixture.new(__FILE__)
+    @logstash = @fixture.get_service("logstash")
+  end
+
+  after(:each) { @logstash.teardown }
+
+  let(:timeout) { 90 } # seconds
+  let(:temp_dir) { Stud::Temporary.directory("logstash-error-test") }
+
+  it "halts LS on fatal error" do
+    config = "input { generator { count => 1 message => 'a fatal error' } } "
+    # inline Ruby filter seems to catch everything (including java.lang.Error) so we exercise a thread throwing
+    config += "filter { ruby { code => 'Thread.start { raise java.lang.AssertionError.new event.get(\"message\") }' } }"
+
+    spawn_logstash_and_wait_for_exit! config, timeout
+
+    expect(@logstash.exit_code).to be 120
+
+    log_file = "#{temp_dir}/logstash-plain.log"
+    expect( File.exists?(log_file) ).to be true
+    expect( File.read(log_file) ).to match /\[FATAL\]\[org.logstash.Logstash.*?java.lang.AssertionError: a fatal error/m
+  end
+
+  it "logs unexpected exception (from Java thread)" do
+    config = "input { generator { count => 1 message => 'unexpected' } } "
+    config += "filter { ruby { code => 'java.lang.Thread.new { sleep(1); raise java.io.EOFException.new event.get(\"message\") }.start' } }"
+
+    spawn_logstash_and_wait_for_exit! config, timeout
+
+    expect(@logstash.exit_code).to be 0 # normal exit
+
+    log_file = "#{temp_dir}/logstash-plain.log"
+    expect( File.exists?(log_file) ).to be true
+    expect( File.read(log_file) ).to match /\[ERROR\]\[org.logstash.Logstash.*?uncaught exception \(in thread .*?java.io.EOFException: unexpected/m
+  end
+
+  def spawn_logstash_and_wait_for_exit!(config, timeout)
+    @logstash.spawn_logstash('-w', '1', '--path.logs', temp_dir, '-e', config)
+
+    time = Time.now
+    while (Time.now - time) < timeout
+      sleep(0.1)
+      break if @logstash.exited?
+    end
+    raise 'LS process did not exit!' unless @logstash.exited?
+  end
+
+end

--- a/qa/integration/specs/fatal_error_spec.rb
+++ b/qa/integration/specs/fatal_error_spec.rb
@@ -49,7 +49,7 @@ describe "uncaught exception" do
 
   it "logs unexpected exception (from Java thread)" do
     config = "input { generator { count => 1 message => 'unexpected' } } "
-    config += "filter { ruby { code => 'java.lang.Thread.new { sleep(1); raise java.io.EOFException.new event.get(\"message\") }.start' } }"
+    config += "filter { ruby { code => 'java.lang.Thread.new { raise java.io.EOFException.new event.get(\"message\") }.start; sleep(1.5)' } }"
 
     spawn_logstash_and_wait_for_exit! config, timeout
 


### PR DESCRIPTION
Currently, LS does not respect fatal errors such as `java.lang.OutOfMemoryError` and continues executing.

This is dangerous since JVM errors are a legitimate reason to halt the process and not continue processing.

Additionally:
- make sure we log the full stack-trace on fatal errors
- halt the JVM wout executing finalizers/hook (:scissors: on how ES [handles uncaught exceptions](https://github.com/elastic/elasticsearch/blob/v7.10.0/server/src/main/java/org/elasticsearch/bootstrap/ElasticsearchUncaughtExceptionHandler.java#L35-L59))
- also, we should now be aware of a potentially unexpectedly dying thread

Sample set of logs on various failures: https://gist.github.com/kares/84d3dcfbaceef130781e457066342a06 
(there's room for improvement but at least we're not missing anything)

## Author's Checklist

- [x] could use a fast fail IT test-case

## Related issues

resolves https://github.com/elastic/logstash/issues/7987

## Logs

prior to the proposed changes fatal errors were easy to miss - if lucky LS logged an error (without stack-trace), such as:

```
[2020-11-19T03:10:57,824][ERROR][org.logstash.Logstash    ] java.lang.OutOfMemoryError: Java heap space
```
usually execution continued and than other errors start to pile up such as:
<details>
<summary>sample trace where logging is failing terribly</summary>
<pre><code>
[2020-11-19T03:10:55,979][WARN ][io.netty.channel.DefaultChannelPipeline][metricbeat-in][ed20c2f5355a4c9dba633cd572aa76a670bd785c7117d7d430cc14da2d57c1e8] An exceptionCaught() event was fired, and it reached at the tail of the pipeline. It usually means the last handler in the pipeline did not handle the exception.
java.lang.InternalError: BMH.reinvoke=Lambda(a0:L/SpeciesData<L>,a1:L,a2:L,a3:I)=>{
    t4:L=Species_L.argL0(a0:L);
    t5:L=MethodHandle.invokeBasic(t4:L,a1:L,a2:L);t5:L}
	at java.lang.invoke.MethodHandleStatics.newInternalError(MethodHandleStatics.java:127) ~[?:1.8.0_262]
	at java.lang.invoke.LambdaForm.compileToBytecode(LambdaForm.java:660) ~[?:1.8.0_262]
	at java.lang.invoke.LambdaForm.prepare(LambdaForm.java:635) ~[?:1.8.0_262]
	at java.lang.invoke.MethodHandle.<init>(MethodHandle.java:461) ~[?:1.8.0_262]
	at java.lang.invoke.BoundMethodHandle.<init>(BoundMethodHandle.java:58) ~[?:1.8.0_262]
	at java.lang.invoke.BoundMethodHandle$Species_L.<init>(BoundMethodHandle.java:211) ~[?:1.8.0_262]
	at java.lang.invoke.BoundMethodHandle$Species_L.copyWith(BoundMethodHandle.java:228) ~[?:1.8.0_262]
	at java.lang.invoke.MethodHandles.dropArguments(MethodHandles.java:2465) ~[?:1.8.0_262]
	at java.lang.invoke.MethodHandles.dropArguments(MethodHandles.java:2535) ~[?:1.8.0_262]
	at jdk.nashorn.internal.lookup.MethodHandleFactory$StandardMethodHandleFunctionality.dropArguments(MethodHandleFactory.java:407) ~[nashorn.jar:?]
	at jdk.nashorn.internal.runtime.CompiledFunction.createConstructorFromInvoker(CompiledFunction.java:266) ~[nashorn.jar:?]
	at jdk.nashorn.internal.runtime.CompiledFunction.createBuiltInConstructor(CompiledFunction.java:135) ~[nashorn.jar:?]
	at jdk.nashorn.internal.runtime.FinalScriptFunctionData.addInvoker(FinalScriptFunctionData.java:140) ~[nashorn.jar:?]
	at jdk.nashorn.internal.runtime.FinalScriptFunctionData.<init>(FinalScriptFunctionData.java:70) ~[nashorn.jar:?]
	at jdk.nashorn.internal.runtime.ScriptFunction.<init>(ScriptFunction.java:232) ~[nashorn.jar:?]
	at jdk.nashorn.internal.runtime.ScriptFunction.<init>(ScriptFunction.java:278) ~[nashorn.jar:?]
	at jdk.nashorn.internal.objects.NativeArray$Constructor.<init>(Unknown Source) ~[nashorn.jar:?]
	at sun.reflect.GeneratedConstructorAccessor35.newInstance(Unknown Source) ~[?:?]
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:1.8.0_262]
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423) ~[?:1.8.0_262]
	at java.lang.Class.newInstance(Class.java:442) ~[?:1.8.0_262]
	at jdk.nashorn.internal.objects.Global.initConstructor(Global.java:2567) ~[nashorn.jar:?]
	at jdk.nashorn.internal.objects.Global.initConstructorAndSwitchPoint(Global.java:2252) ~[nashorn.jar:?]
	at jdk.nashorn.internal.objects.Global.init(Global.java:2300) ~[nashorn.jar:?]
	at jdk.nashorn.internal.objects.Global.initBuiltinObjects(Global.java:1094) ~[nashorn.jar:?]
	at jdk.nashorn.internal.runtime.Context.initGlobal(Context.java:1150) ~[nashorn.jar:?]
	at jdk.nashorn.api.scripting.NashornScriptEngine.createNashornGlobal(NashornScriptEngine.java:360) ~[nashorn.jar:?]
	at jdk.nashorn.api.scripting.NashornScriptEngine.createGlobalMirror(NashornScriptEngine.java:340) ~[nashorn.jar:?]
	at jdk.nashorn.api.scripting.NashornScriptEngine.getNashornGlobalFrom(NashornScriptEngine.java:320) ~[nashorn.jar:?]
	at jdk.nashorn.api.scripting.NashornScriptEngine.access$100(NashornScriptEngine.java:73) ~[nashorn.jar:?]
	at jdk.nashorn.api.scripting.NashornScriptEngine$3.eval(NashornScriptEngine.java:507) ~[nashorn.jar:?]
	at javax.script.CompiledScript.eval(CompiledScript.java:92) ~[?:1.8.0_262]
	at org.apache.logging.log4j.core.script.ScriptManager$MainScriptRunner.execute(ScriptManager.java:232) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.script.ScriptManager$ThreadLocalScriptRunner.execute(ScriptManager.java:269) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.script.ScriptManager$1.run(ScriptManager.java:177) ~[log4j-core-2.13.3.jar:2.13.3]
	at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_262]
	at org.apache.logging.log4j.core.script.ScriptManager.execute(ScriptManager.java:174) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.filter.ScriptFilter.filter(ScriptFilter.java:115) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.filter.AbstractFilterable.isFiltered(AbstractFilterable.java:154) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.config.AppenderControl.isFilteredByAppender(AppenderControl.java:151) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.config.AppenderControl.callAppender0(AppenderControl.java:128) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.config.AppenderControl.callAppenderPreventRecursion(AppenderControl.java:120) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.config.AppenderControl.callAppender(AppenderControl.java:84) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.config.LoggerConfig.callAppenders(LoggerConfig.java:543) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.config.LoggerConfig.processLogEvent(LoggerConfig.java:502) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:485) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:460) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.config.AwaitCompletionReliabilityStrategy.log(AwaitCompletionReliabilityStrategy.java:82) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.core.Logger.log(Logger.java:161) ~[log4j-core-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.spi.AbstractLogger.tryLogMessage(AbstractLogger.java:2198) ~[log4j-api-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.spi.AbstractLogger.logMessageTrackRecursion(AbstractLogger.java:2152) ~[log4j-api-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.spi.AbstractLogger.logMessageSafely(AbstractLogger.java:2135) ~[log4j-api-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.spi.AbstractLogger.logMessage(AbstractLogger.java:2011) ~[log4j-api-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.spi.AbstractLogger.logIfEnabled(AbstractLogger.java:1983) ~[log4j-api-2.13.3.jar:2.13.3]
	at org.apache.logging.log4j.spi.AbstractLogger.debug(AbstractLogger.java:327) ~[log4j-api-2.13.3.jar:2.13.3]
	at org.logstash.beats.BeatsHandler.channelRead0(BeatsHandler.java:50) ~[logstash-input-beats-6.0.11.jar:?]
	at org.logstash.beats.BeatsHandler.channelRead0(BeatsHandler.java:12) ~[logstash-input-beats-6.0.11.jar:?]
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99) ~[netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324) ~[netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296) ~[netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.AbstractChannelHandlerContext.access$600(AbstractChannelHandlerContext.java:61) ~[netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.AbstractChannelHandlerContext$7.run(AbstractChannelHandlerContext.java:370) ~[netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.util.concurrent.DefaultEventExecutor.run(DefaultEventExecutor.java:66) ~[netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989) [netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [netty-all-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-all-4.1.49.Final.jar:4.1.49.Final]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_262]
Caused by: java.lang.OutOfMemoryError: Java heap space
</pre></code>
</summary>
