### PR TITLE
Moved ModulesSettingArray from Ruby to Java.

### DIFF
--- a/logstash-core/lib/logstash/modules/settings_merger.rb
+++ b/logstash-core/lib/logstash/modules/settings_merger.rb
@@ -21,6 +21,8 @@ module LogStash module Modules module SettingsMerger
   include LogStash::Util::Loggable
   extend self
 
+  # cli_settings Array or LogStash::Util::ModulesSettingArray
+  # yml_settings Array or LogStash::Util::ModulesSettingArray
   def merge(cli_settings, yml_settings)
     # both args are arrays of hashes, e.g.
     # [{"name"=>"mod1", "var.input.tcp.port"=>"3333"}, {"name"=>"mod2"}]
@@ -28,6 +30,7 @@ module LogStash module Modules module SettingsMerger
     merged = []
     # union and group_by preserves order
     # union will also coalesce identical hashes
+    # this "|" operator is provided to Java List by RubyJavaIntegration
     union_of_settings = (cli_settings | yml_settings)
     grouped_by_name = union_of_settings.group_by{|e| e["name"]}
     grouped_by_name.each do |_, array|

--- a/logstash-core/lib/logstash/util/modules_setting_array.rb
+++ b/logstash-core/lib/logstash/util/modules_setting_array.rb
@@ -15,30 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-require "forwardable"
-require "logstash/util/password"
-
-module LogStash module Util class ModulesSettingArray
-  extend Forwardable
-  DELEGATED_METHODS = [].public_methods.reject{|symbol| symbol.to_s.end_with?('__')}
-
-  def_delegators :@original, *DELEGATED_METHODS
-
-  attr_reader :original
-  def initialize(value)
-    unless value.is_a?(Array)
-      raise ArgumentError.new("Module Settings must be an Array. Received: #{value.class}")
-    end
-    @original = value
-    # wrap passwords
-    @original.each do |hash|
-      hash.keys.select{|key| key.to_s.end_with?('password') && !hash[key].is_a?(LogStash::Util::Password)}.each do |key|
-        hash[key] = LogStash::Util::Password.new(hash[key])
-      end
-    end
-  end
-
-  def __class__
-    LogStash::Util::ModulesSettingArray
-  end
-end end end
+module LogStash; module Util
+    java_import org.logstash.util.ModulesSettingArray
+end; end

--- a/logstash-core/spec/logstash/modules/settings_merger_spec.rb
+++ b/logstash-core/spec/logstash/modules/settings_merger_spec.rb
@@ -20,6 +20,7 @@ require "logstash/util/cloud_setting_id"
 require "logstash/util/cloud_setting_auth"
 require "logstash/modules/settings_merger"
 require "logstash/util/password"
+require "logstash/util/modules_setting_array"
 
 class SubstituteSettingsForRSpec
   def initialize(hash = {}) @hash = hash; end
@@ -29,7 +30,7 @@ end
 
 describe LogStash::Modules::SettingsMerger do
   describe "#merge" do
-    let(:cli) {[{"name"=>"mod1", "var.input.tcp.port"=>"3333"}, {"name"=>"mod2"}]}
+    let(:cli) { LogStash::Util::ModulesSettingArray.new [{"name"=>"mod1", "var.input.tcp.port"=>"3333"}, {"name"=>"mod2"}] }
     let(:yml) {[{"name"=>"mod1", "var.input.tcp.port"=>2222, "var.kibana.username"=>"rupert", "var.kibana.password"=>"fotherington"}, {"name"=>"mod3", "var.input.tcp.port"=>4445}]}
     subject(:results) { described_class.merge(cli, yml) }
     it "merges cli overwriting any common fields in yml" do

--- a/logstash-core/spec/logstash/settings/modules_spec.rb
+++ b/logstash-core/spec/logstash/settings/modules_spec.rb
@@ -20,6 +20,7 @@ require "logstash/settings"
 require "logstash/util/cloud_setting_id"
 require "logstash/util/cloud_setting_auth"
 require "logstash/util/modules_setting_array"
+require "java"
 
 describe LogStash::Setting::Modules do
   describe "Modules.Cli" do
@@ -29,8 +30,8 @@ describe LogStash::Setting::Modules do
       it "should convert password Strings to Password" do
         source = [{"var.kibana.password" => secret}]
         setting = subject.set(source)
-        expect(setting).to be_a(Array)
-        expect(setting.__class__).to eq(LogStash::Util::ModulesSettingArray)
+        expect(setting).to be_a(java.util.ArrayList)
+        expect(setting.class).to eq(LogStash::Util::ModulesSettingArray)
         expect(setting.first.fetch("var.kibana.password")).to be_a(LogStash::Util::Password)
         expect(setting.first.fetch("var.kibana.password").value).to eq(secret)
       end
@@ -38,8 +39,8 @@ describe LogStash::Setting::Modules do
       it 'should not wrap values that are already passwords' do
         source = [{"var.kibana.password" => LogStash::Util::Password.new(secret)}]
         setting = subject.set(source)
-        expect(setting).to be_a(Array)
-        expect(setting.__class__).to eq(LogStash::Util::ModulesSettingArray)
+        expect(setting).to be_a(java.util.ArrayList)
+        expect(setting.class).to eq(LogStash::Util::ModulesSettingArray)
         expect(setting.first.fetch("var.kibana.password")).to be_a(LogStash::Util::Password)
         expect(setting.first.fetch("var.kibana.password").value).to eq(secret)
       end

--- a/logstash-core/src/main/java/org/logstash/util/ModulesSettingArray.java
+++ b/logstash-core/src/main/java/org/logstash/util/ModulesSettingArray.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.logstash.util;
+
+import co.elastic.logstash.api.Password;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+public final class ModulesSettingArray extends ArrayList<Map<String, Object>> {
+
+    private static final long serialVersionUID = 4094949366274116593L;
+
+    public ModulesSettingArray(Collection<? extends Map<String, Object>> original) {
+        super(wrapPasswords(original));
+    }
+
+    private static Collection<Map<String, Object>> wrapPasswords(Collection<? extends Map<String, Object>> original) {
+        return original.stream()
+                .map(ModulesSettingArray::wrapPasswordsInSettings)
+                .collect(Collectors.toList());
+    }
+
+    private static Map<String, Object> wrapPasswordsInSettings(Map<String, Object> settings) {
+        // Insertion order is important. The Map object passed into is usually a org.jruby.RubyHash, which preserves
+        // the insertion order, during the scan. Here we need to keep the same order, because tests on modules
+        // expects a precise order of keys. It's important to have stable tests.
+        final Map<String, Object> acc = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> entry : settings.entrySet()) {
+            if (entry.getKey().endsWith("password") && !(entry.getValue() instanceof Password)) {
+                acc.put(entry.getKey(), new Password((String) entry.getValue()));
+            } else {
+                acc.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return acc;
+    }
+
+    public Map<String, Object> getFirst() {
+        try {
+            return get(0);
+        } catch (IndexOutOfBoundsException ex) {
+            return null;
+        }
+    }
+
+    public Map<String, Object> getLast() {
+        try {
+            return get(size() - 1);
+        } catch (IndexOutOfBoundsException ex) {
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
Clean backport of #12458 to `7.x`

The ModulesSettingArray is responsible to obfuscate password in arrays of settings.
The test are still in Ruby to proove the interoperability with Ruby code that used the previous version.

Added method to mimic .first and .last methods of Ruby Array

(cherry picked from commit fa3891953d37353e75a0fdc85b5a98ae1926a72a)
