### PR TITLE
Update release notes for 7.10.1

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in the following releases:
 
+* <<logstash-7-10-1,Logstash 7.10.1>>
 * <<logstash-7-10-0,Logstash 7.10.0>>
 * <<logstash-7-9-3,Logstash 7.9.3>>
 * <<logstash-7-9-2,Logstash 7.9.2>>
@@ -35,6 +36,40 @@ This section summarizes the changes in the following releases:
 * <<logstash-7-0-0-beta1,Logstash 7.0.0-beta1>>
 * <<logstash-7-0-0-alpha2,Logstash 7.0.0-alpha2>>
 * <<logstash-7-0-0-alpha1,Logstash 7.0.0-alpha1>>
+
+[[logstash-7-10-1]]
+=== Logstash 7.10.1 Release Notes
+
+==== Notable issues fixed
+
+===== Support recreation of same pipeline through centralized pipeline management
+When users attempted to delete and recreate a pipeline with the same identifier and configuration, Logstash was unable
+to pick up the new pipeline. https://github.com/elastic/logstash/issues/12387[#12387]
+
+==== Plugins
+
+*Azure_event_hubs Input - 1.2.3*
+
+* Fixed missing configuration of `prefetch_count` and `receive_timeout` https://github.com/logstash-plugins/logstash-input-azure_event_hubs/pull/61[#61]
+
+*Http Input - 3.3.6*
+
+* Fixes a regression introduced in **3.1.0** with the migration to the Netty back-end that broke
+   browser-based workflows for some users. When a plugin that is configured to require Basic authentication receives a request that does not
+   include authentication, it now appropriately includes an `WWW-Authenticate` header in its `401 Unauthorized` response,
+   allowing the browser to collect credentials before retrying the request. https://github.com/logstash-plugins/logstash-input-http/pull/129[#129]
+
+*Sqs Input - 3.1.3*
+
+* Fix: retry networking errors (with backoff) https://github.com/logstash-plugins/logstash-input-sqs/pull/57[#57]
+
+*Kafka Integration - 10.5.3*
+
+* Fix: set (optional) truststore when endpoint id check disabled. Since **10.1.0** disabling server host-name
+  verification (`ssl_endpoint_identification_algorithm => ""`) did not allow the (output) plugin to set
+  `ssl_truststore_location => "..."` https://github.com/logstash-plugins/logstash-integration-kafka/pull/60[#60]
+* Docs: explain group_id in case of multiple inputs https://github.com/logstash-plugins/logstash-integration-kafka/pull/59[#59]
+
 
 [[logstash-7-10-0]]
 === Logstash 7.10.0 Release Notes


### PR DESCRIPTION
Relevant Commits:

- 2cf15a163 - remove evaluation dir from JRuby bundled did_you_mean gem (https://github.com/elastic/logstash/pull/12460) :white_check_mark: 
- 5500235cb - [710_backport] Fix docker image metadata (#12451) :white_check_mark: 
- db4e11788 - delete pipeline in registry (#12414) :white_check_mark: 
- da7f5f5f6 - hash function of pipeline config  with metadata (#12389) :white_check_mark: 
- 36b8b8be3 - [Backport] Doc: Add bundled JDK info (#12418) :grey_question: 
