### PR TITLE
REE: gauge reload interval

### DIFF
--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -320,7 +320,7 @@ module LogStash; class Pipeline < BasePipeline
       config_metric.gauge(:batch_size, batch_size)
       config_metric.gauge(:batch_delay, batch_delay)
       config_metric.gauge(:config_reload_automatic, settings.get("config.reload.automatic"))
-      config_metric.gauge(:config_reload_interval, settings.get("config.reload.interval"))
+      config_metric.gauge(:config_reload_interval, settings.get("config.reload.interval").to_nanos)
       config_metric.gauge(:dead_letter_queue_enabled, dlq_enabled?)
       config_metric.gauge(:dead_letter_queue_path, dlq_writer.get_path.to_absolute_path.to_s) if dlq_enabled?
 


### PR DESCRIPTION
## What does this PR do?

Correctly outputs the config reload interval as an integer number of nanoseconds.

This fixes a regression introduced in https://github.com/elastic/logstash/pull/11803, in which the _internal representation_ of the pipeline's reload interval was changed to a full-fledged object that carries time units. The PR correctly externalized this representation back to nanoseconds in the Java Execution Engine, but failed to do so in the legacy Ruby Execution engine.

In turn, this eliminates a warning encountered when running Logstash under REE with `--java-execution=false`:

~~~
[2020-12-02T17:26:12,997][WARN ][org.logstash.instrument.metrics.gauge.LazyDelegatingGauge][empty] A gauge metric of an unknown type (org.jruby.gen.RubyObject3) has been created for key: config_reload_interval. This may result in invalid serialization.  It is recommended to log an issue to the responsible developer/development team.
~~~

## Why is it important/What is the impact to the user?

Users running Logstash with the non-default Ruby Execution Engine will no longer see the above warning, and the API response for node data will correctly include the number of nanoseconds for the pipeline.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files (and/or docker env variables)~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~

## How to test this PR locally

> ~~~ yml
> pipeline.java_execution: false
> ~~~
> -- `logstash.yml`

> ~~~ yml
> - pipeline.id empty
>   path.config: "${LOGSTASH_HOME}/config/empty.conf"
> ~~~
> -- `pipelines.yml`

> ~~~
> input {}
> filter {}
> output {}
> ~~~
> -- `empty.conf`

