### PR TITLE
Revert unnecessary commits for `7.10 BC3`

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -470,7 +470,7 @@ GEM
       elastic-app-search (~> 7.8.0)
       logstash-codec-plain
       logstash-core-plugin-api (~> 2.0)
-    logstash-output-elasticsearch (10.7.3-java)
+    logstash-output-elasticsearch (10.7.0-java)
       cabin (~> 0.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ecs_compatibility_support (~> 1.0)
@@ -577,7 +577,7 @@ GEM
       method_source (~> 1.0)
       spoon (~> 0.0)
     public_suffix (3.1.1)
-    puma (4.3.7-java)
+    puma (4.3.6-java)
       nio4r (~> 2.0)
     rack (2.2.3)
     rack-protection (2.1.0)

--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -320,7 +320,7 @@ module LogStash; class Pipeline < BasePipeline
       config_metric.gauge(:batch_size, batch_size)
       config_metric.gauge(:batch_delay, batch_delay)
       config_metric.gauge(:config_reload_automatic, settings.get("config.reload.automatic"))
-      config_metric.gauge(:config_reload_interval, settings.get("config.reload.interval").to_nanos)
+      config_metric.gauge(:config_reload_interval, settings.get("config.reload.interval"))
       config_metric.gauge(:dead_letter_queue_enabled, dlq_enabled?)
       config_metric.gauge(:dead_letter_queue_path, dlq_writer.get_path.to_absolute_path.to_s) if dlq_enabled?
 


### PR DESCRIPTION
Revert "Update (patch) gem versions for 7.10.1 again (#12488)"
This reverts commit a2c45e4c6f70c6b192b4eab7f81288029fde6c45.

Revert "REE: output reload interval as nanos instead of object"
This reverts commit 8ad108df2063ffb26f048d772f6ede7ea9a6badb.