### PR TITLE
Remove ruby execution engine config

### DIFF
--- a/docker/data/logstash/env2yaml/env2yaml.go
+++ b/docker/data/logstash/env2yaml/env2yaml.go
@@ -56,7 +56,6 @@ func normalizeSetting(setting string) (string, error) {
 		"pipeline.batch.size",
 		"pipeline.batch.delay",
 		"pipeline.unsafe_shutdown",
-		"pipeline.java_execution",
 		"pipeline.ecs_compatibility",
 		"pipeline.plugin_classloaders",
 		"path.config",

--- a/docs/static/java-codec.asciidoc
+++ b/docs/static/java-codec.asciidoc
@@ -322,8 +322,6 @@ To test the plugin, start Logstash with:
 echo "foo,bar" | bin/logstash -e 'input { java_stdin { codec => java_codec_example } }'
 -----
 
-NOTE: The Java execution engine, the default execution engine since Logstash 7.0, is required
-as Java plugins are not supported in the Ruby execution engine.
 
 The expected Logstash output (excluding initialization) with the configuration above is:
 

--- a/docs/static/java-filter.asciidoc
+++ b/docs/static/java-filter.asciidoc
@@ -251,8 +251,6 @@ Start Logstash with:
 bin/logstash -f /path/to/java_filter.conf
 -----
 
-NOTE: The Java execution engine, the default execution engine since Logstash 7.0, is required
-as Java plugins are not supported in the Ruby execution engine.
 
 The expected Logstash output (excluding initialization) with the configuration
 above is:

--- a/docs/static/java-input.asciidoc
+++ b/docs/static/java-input.asciidoc
@@ -279,8 +279,6 @@ Start {ls} with:
 bin/logstash -f /path/to/java_input.conf
 -----
 
-NOTE: The Java execution engine, the default execution engine since Logstash 7.0, is required
-as Java plugins are not supported in the Ruby execution engine.
 
 The expected Logstash output (excluding initialization) with the configuration above is:
 

--- a/docs/static/java-output.asciidoc
+++ b/docs/static/java-output.asciidoc
@@ -261,8 +261,6 @@ Logstash should then be started with:
 bin/logstash -f /path/to/java_output.conf
 -----
 
-NOTE: The Java execution engine, the default execution engine since Logstash 7.0, is required
-as Java plugins are not supported in the Ruby execution engine.
 
 The expected Logstash output (excluding initialization) with the configuration
 above is:

--- a/docs/static/running-logstash-command-line.asciidoc
+++ b/docs/static/running-logstash-command-line.asciidoc
@@ -101,10 +101,6 @@ With this command, Logstash concatenates three config files, `/tmp/one`, `/tmp/t
   If you wish to use both defaults, please use the empty string for the `-e` flag.
   The default is nil.
 
-*`--java-execution`*::
-  Specify `false` for this option to revert to the legacy Ruby execution engine instead
-  of the default Java execution engine.
-
 *`--plugin-classloaders`*::
   (Beta) Load Java plugins in independent classloaders to isolate their dependencies.
 

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -81,10 +81,6 @@ The `logstash.yml` file includes the following settings.
 | The ID of the pipeline.
 | `main`
 
-| `pipeline.java_execution`
-| Use the Java execution engine.
-| true
-
 | `pipeline.workers` 
 | The number of workers that will, in parallel, execute the filter and output
 stages of the pipeline. This setting uses the

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -56,7 +56,6 @@ module LogStash
    Setting::PositiveInteger.new("pipeline.batch.size", 125),
            Setting::Numeric.new("pipeline.batch.delay", 50), # in milliseconds
            Setting::Boolean.new("pipeline.unsafe_shutdown", false),
-           Setting::Boolean.new("pipeline.java_execution", true),
            Setting::Boolean.new("pipeline.reloadable", true),
            Setting::Boolean.new("pipeline.plugin_classloaders", false),
            Setting::Boolean.new("pipeline.separate_logs", false),

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -124,11 +124,6 @@ class LogStash::Runner < Clamp::StrictCommand
     :attribute_name => "pipeline.ordered",
     :default => LogStash::SETTINGS.get_default("pipeline.ordered")
 
-  option ["--java-execution"], :flag,
-         I18n.t("logstash.runner.flag.java-execution"),
-         :attribute_name => "pipeline.java_execution",
-         :default => LogStash::SETTINGS.get_default("pipeline.java_execution")
-
   option ["--plugin-classloaders"], :flag,
          I18n.t("logstash.runner.flag.plugin-classloaders"),
          :attribute_name => "pipeline.plugin_classloaders",

--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -37,7 +37,6 @@ module LogStash
       "dead_letter_queue.flush_interval",
       "dead_letter_queue.max_bytes",
       "metric.collect",
-      "pipeline.java_execution",
       "pipeline.plugin_classloaders",
       "path.config",
       "path.dead_letter_queue",

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -285,8 +285,6 @@ en:
           from starting if there are multiple workers.
           Use `false` to disable any extra processing necessary for preserving
           ordering.
-        java-execution: |+
-          Use Java execution engine.
         plugin-classloaders: |+
           (Beta) Load Java plugins in independent classloaders to isolate their dependencies.
         pipeline-batch-size: |+


### PR DESCRIPTION
Fixed: #11236

This PR remove config `pipeline.java_execution`. Every pipeline is defaulted to java execution

- remove config
- remove doc