### PR TITLE
Fix error due to missing variable when listing gradle tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -532,6 +532,23 @@ def selectOsType() {
     }
 }
 
+def selectArch() {
+    if (project.ext.has("jdk_arch")) {
+        return project.ext.jdk_arch
+    }
+    String cpu_arch = System.properties["os.arch"]
+    switch (cpu_arch) {
+        case "amd64":
+        case "x86_64":
+            return "x86_64"
+        case "aarch64":
+        case "arm64":
+            return "arm64"
+        default:
+            throw new IllegalArgumentException("Can't handle os.arch of type $cpu_arch")
+    }
+}
+
 class JDKDetails {
     final String revision
     final String build
@@ -602,7 +619,7 @@ tasks.register("downloadJdk", Download) {
     String osName = selectOsType()
 
     def versionYml = new Yaml().load(new File("$projectDir/versions.yml").text)
-    String jdkArch = project.ext.jdk_arch
+    String jdkArch = selectArch()
     def jdkDetails = new JDKDetails(versionYml, osName, jdkArch)
 
     description "Download JDK ${jdkDetails.major}, OS: ${osName}"


### PR DESCRIPTION
Fix error due to missing variable when listing gradle tasks and no architecture is externally specified with -Pos_arch=

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## What does this PR do?
Sets a default value for cpu architecture type in `build.gradle` when no value is defined on command line through the `-Pos_arch` parameter.
Before this fix, importing the project in IlliJIDEA or running  `gradle tasks` reports an error, in particular for command line:
```
* Where:
Build file '/tmp/logstash/build.gradle' line: 599

* What went wrong:
Execution failed for task ':tasks'.
> Could not create task ':downloadJdk'.
   > Could not set unknown property 'cpu_arch' for root project 'logstash' of type org.gradle.api.Project.
```

## Why is it important/What is the impact to the user?
This issues impacted the developers opening the project into IntelliJIDEA and the ones that used Gradle management tasks, like `gradle tasks`

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Run `./gradlew tasks` on `master` and on this branch, in the second case verify no errors are present in console and effectively prints the task list _or_ create a temp fresh clone of the repository and try to open with IDEA.
