### PR TITLE
Fix error due to missing variable when listing tasks and no cpu architecture provided

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -532,6 +532,23 @@ def selectOsType() {
     }
 }
 
+def selectArch() {
+    if (project.ext.has("jdk_arch")) {
+        return project.ext.jdk_arch
+    }
+    String cpu_arch = System.properties["os.arch"]
+    switch (cpu_arch) {
+        case "amd64":
+        case "x86_64":
+            return "x86_64"
+        case "aarch64":
+        case "arm64":
+            return "arm64"
+        default:
+            throw new IllegalArgumentException("Can't handle os.arch of type $cpu_arch")
+    }
+}
+
 class JDKDetails {
     final String revision
     final String build
@@ -602,7 +619,7 @@ tasks.register("downloadJdk", Download) {
     String osName = selectOsType()
 
     def versionYml = new Yaml().load(new File("$projectDir/versions.yml").text)
-    String jdkArch = project.ext.jdk_arch
+    String jdkArch = selectArch()
     def jdkDetails = new JDKDetails(versionYml, osName, jdkArch)
 
     description "Download JDK ${jdkDetails.major}, OS: ${osName}"


### PR DESCRIPTION
Fix error due to missing variable when listing tasks and no architecture is externally specified with -Pos_arch=

Backport of #12513 to `7.x`

(cherry picked from commit 7144a3f7cf9628a2ce397b29cbf6f65dcbf3e334)
