### PR TITLE
REE: output reload interval as nanos instead of object

### DIFF
--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -320,7 +320,7 @@ module LogStash; class Pipeline < BasePipeline
       config_metric.gauge(:batch_size, batch_size)
       config_metric.gauge(:batch_delay, batch_delay)
       config_metric.gauge(:config_reload_automatic, settings.get("config.reload.automatic"))
-      config_metric.gauge(:config_reload_interval, settings.get("config.reload.interval"))
+      config_metric.gauge(:config_reload_interval, settings.get("config.reload.interval").to_nanos)
       config_metric.gauge(:dead_letter_queue_enabled, dlq_enabled?)
       config_metric.gauge(:dead_letter_queue_path, dlq_writer.get_path.to_absolute_path.to_s) if dlq_enabled?
 


### PR DESCRIPTION
fixes a warning about an unsupported gauge type, matches the behaviour
on JEE.

Reintroduces reverted commit 8ad108df2063ffb26f048d772f6ede7ea9a6badb