### PR TITLE
Bump 7.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ These builds are created nightly and have undergone no formal QA, so they should
 | [deb-complete][]      | [deb-oss][]            |
 | [rpm-complete][]      | [rpm-oss][]            |
 
-[tar-complete]: https://snapshots.elastic.co/downloads/logstash/logstash-7.11.0-SNAPSHOT.tar.gz
-[zip-complete]: https://snapshots.elastic.co/downloads/logstash/logstash-7.11.0-SNAPSHOT.zip
-[deb-complete]: https://snapshots.elastic.co/downloads/logstash/logstash-7.11.0-SNAPSHOT.deb
-[rpm-complete]: https://snapshots.elastic.co/downloads/logstash/logstash-7.11.0-SNAPSHOT.rpm
-[tar-oss]: https://snapshots.elastic.co/downloads/logstash/logstash-oss-7.11.0-SNAPSHOT.tar.gz
-[zip-oss]: https://snapshots.elastic.co/downloads/logstash/logstash-oss-7.11.0-SNAPSHOT.zip
-[deb-oss]: https://snapshots.elastic.co/downloads/logstash/logstash-oss-7.11.0-SNAPSHOT.deb
-[rpm-oss]: https://snapshots.elastic.co/downloads/logstash/logstash-oss-7.11.0-SNAPSHOT.rpm
+[tar-complete]: https://snapshots.elastic.co/downloads/logstash/logstash-7.12.0-SNAPSHOT.tar.gz
+[zip-complete]: https://snapshots.elastic.co/downloads/logstash/logstash-7.12.0-SNAPSHOT.zip
+[deb-complete]: https://snapshots.elastic.co/downloads/logstash/logstash-7.12.0-SNAPSHOT.deb
+[rpm-complete]: https://snapshots.elastic.co/downloads/logstash/logstash-7.12.0-SNAPSHOT.rpm
+[tar-oss]: https://snapshots.elastic.co/downloads/logstash/logstash-oss-7.12.0-SNAPSHOT.tar.gz
+[zip-oss]: https://snapshots.elastic.co/downloads/logstash/logstash-oss-7.12.0-SNAPSHOT.zip
+[deb-oss]: https://snapshots.elastic.co/downloads/logstash/logstash-oss-7.12.0-SNAPSHOT.deb
+[rpm-oss]: https://snapshots.elastic.co/downloads/logstash/logstash-oss-7.12.0-SNAPSHOT.rpm
 
 ## Need Help?
 

--- a/versions.yml
+++ b/versions.yml
@@ -1,7 +1,7 @@
 ---
 # alpha and beta qualifiers are now added via VERSION_QUALIFIER environment var
-logstash: 7.11.0
-logstash-core: 7.11.0
+logstash: 7.12.0
+logstash-core: 7.12.0
 logstash-core-plugin-api: 2.1.16
 
 bundled_jdk:


### PR DESCRIPTION
## What does this PR do?

Bumps the version on the 7.x branch to 7.12 to differentiate it from the 7.11 branch that has just been cut.