### PR TITLE
create output plugin instances per pipeline worker in legacy concurrency

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
@@ -185,7 +185,9 @@ public final class OutputStrategyExt {
             final IRubyObject metric = args[1];
             final ExecutionContextExt executionContext = (ExecutionContextExt) args[2];
             final RubyHash pluginArgs = (RubyHash) args[3];
-            workerCount = pluginArgs.op_aref(context, context.runtime.newString("workers"));
+            IRubyObject pipeline = executionContext.callMethod(context, "pipeline");
+            IRubyObject settings = pipeline.callMethod(context, "settings");
+            workerCount = settings.callMethod(context, "get_value", context.runtime.newString("pipeline.workers"));
             if (workerCount.isNil()) {
                 workerCount = RubyFixnum.one(context.runtime);
             }


### PR DESCRIPTION
With the output "legacy" concurrency strategy there was an expectation that the number of workers would be passed to the plugin output delegator, which would then execute the concurrency strategy. However this is not passed to the `pluginArgs`, thus "nil" is retrieved, causing the default number of instances to be 1.

This change fixes the issue. The fix can be observed by tweaking an output plugin like the ["null" output](https://github.com/logstash-plugins/logstash-output-null/blob/master/lib/logstash/outputs/null.rb#L11-L12) and adding a debug statement in the register method such as:

```ruby
  public
  def register
    puts "instance #{self.object_id}"
  end
```

One should see the difference with this patch, where N prints of "instance <number> happen instead of just 1 (before the patch). E.g.:

```
❯ bin/logstash -e "output { null{} }"                                              
Using system java: /Users/joaoduarte/.jenv/shims/java
Sending Logstash logs to /Users/joaoduarte/elastic/logstash/logs which is now configured via log4j2.properties
[2020-12-17T14:36:42,057][INFO ][logstash.runner          ] Starting Logstash {"logstash.version"=>"8.0.0", "jruby.version"=>"jruby 9.2.13.0 (2.5.7) 2020-08-03 9a89c94bcc OpenJDK 64-Bit Server VM 11.0.9+11 on 11.0.9+11 +indy +jit [darwin-x86_64]"}
instance 2048
instance 2050
instance 2052
instance 2054
instance 2056
instance 2058
instance 2060
instance 2062
```