### PR TITLE
Removed CMS GC flags to run tests successfully on JDK15

### DIFF
--- a/bin/logstash
+++ b/bin/logstash
@@ -56,9 +56,6 @@ if [ "$1" = "-V" ] || [ "$1" = "--version" ]; then
   fi
   echo "logstash $LOGSTASH_VERSION"
 else
-  unset CLASSPATH
-  for J in $(cd "${LOGSTASH_JARS}"; ls *.jar); do
-    CLASSPATH=${CLASSPATH}${CLASSPATH:+:}${LOGSTASH_JARS}/${J}
-  done
+  CLASSPATH="$(setup_classpath $LOGSTASH_JARS)"
   exec "${JAVACMD}" ${JAVA_OPTS} -cp "${CLASSPATH}" org.logstash.Logstash "$@"
 fi

--- a/config/jvm.options
+++ b/config/jvm.options
@@ -17,9 +17,9 @@
 ################################################################
 
 ## GC configuration
--XX:+UseConcMarkSweepGC
--XX:CMSInitiatingOccupancyFraction=75
--XX:+UseCMSInitiatingOccupancyOnly
+8-14:-XX:+UseConcMarkSweepGC
+8-14:-XX:CMSInitiatingOccupancyFraction=75
+8-14:-XX:+UseCMSInitiatingOccupancyOnly
 
 ## Locale
 # Set the locale language

--- a/docs/static/config-details.asciidoc
+++ b/docs/static/config-details.asciidoc
@@ -2,6 +2,52 @@
 === JVM settings
 
 Configure the jvm settings in the `jvm.options` <<settings-files,settings file>>.
+This file contains a line-delimited list of JVM arguments following a special syntax:
+
+* lines consisting of whitespace only are ignored
+* lines beginning with `#` are treated as comments and are ignored
++
+[source,text]
+-------------------------------------
+# this is a comment
+-------------------------------------
+
+* lines beginning with a `-` are treated as a JVM option that applies
+independent of the version of the JVM
++
+[source,text]
+-------------------------------------
+-Xmx2g
+-------------------------------------
+
+* lines beginning with a number followed by a `:` followed by a `-` are treated
+as a JVM option that applies only if the version of the JVM matches the number
++
+[source,text]
+-------------------------------------
+8:-Xmx2g
+-------------------------------------
+
+* lines beginning with a number followed by a `-` followed by a `:` are treated
+as a JVM option that applies only if the version of the JVM is greater than or
+equal to the number
++
+[source,text]
+-------------------------------------
+8-:-Xmx2g
+-------------------------------------
+
+* lines beginning with a number followed by a `-` followed by a number followed
+by a `:` are treated as a JVM option that applies only if the version of the
+JVM falls in the inclusive range of the two numbers
++
+[source,text]
+-------------------------------------
+8-9:-Xmx2g
+-------------------------------------
+
+* all other lines are rejected
+
 
 [[heap-size]]
 ==== Setting the JVM heap size

--- a/logstash-core/src/main/java/org/logstash/launchers/JvmOptionsParser.java
+++ b/logstash-core/src/main/java/org/logstash/launchers/JvmOptionsParser.java
@@ -1,0 +1,303 @@
+package org.logstash.launchers;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+/**
+ * Parse jvm.options file applying version conditional logic. Heavily inspired by same functionality in Elasticsearch.
+ * */
+public class JvmOptionsParser {
+
+    static class JvmOptionsFileParserException extends Exception {
+
+        private static final long serialVersionUID = 2446165130736962758L;
+
+        private final Path jvmOptionsFile;
+
+        Path jvmOptionsFile() {
+            return jvmOptionsFile;
+        }
+
+        private final SortedMap<Integer, String> invalidLines;
+
+        SortedMap<Integer, String> invalidLines() {
+            return invalidLines;
+        }
+
+        JvmOptionsFileParserException(final Path jvmOptionsFile, final SortedMap<Integer, String> invalidLines) {
+            this.jvmOptionsFile = jvmOptionsFile;
+            this.invalidLines = invalidLines;
+        }
+
+    }
+
+    private final String logstashHome;
+
+    JvmOptionsParser(String logstashHome) {
+        this.logstashHome = logstashHome;
+    }
+
+    /**
+     * The main entry point. The exit code is 0 if the JVM options were successfully parsed, otherwise the exit code is 1. If an improperly
+     * formatted line is discovered, the line is output to standard error.
+     *
+     * @param args the args to the program which should consist of a single option, the path to LOGSTASH_HOME
+     */
+    public static void main(final String[] args) throws InterruptedException, IOException {
+        if (args.length < 1 || args.length > 2) {
+            throw new IllegalArgumentException(
+                    "Expected two arguments specifying path to LOGSTASH_HOME and an optional LS_JVM_OPTS, but was " + Arrays.toString(args)
+            );
+        }
+
+        final JvmOptionsParser parser = new JvmOptionsParser(args[0]);
+        final String jvmOpts = args.length == 2 ? args[1] : null;
+        try {
+            Optional<Path> jvmOptions = parser.lookupJvmOptionsFile(jvmOpts);
+            if (!jvmOptions.isPresent()) {
+                System.err.println("warning: no jvm.options file found");
+                return;
+            }
+            parser.parse(jvmOptions.get());
+        } catch (JvmOptionsFileParserException pex) {
+            System.err.printf(Locale.ROOT,
+                    "encountered [%d] error%s parsing [%s]",
+                    pex.invalidLines().size(),
+                    pex.invalidLines().size() == 1 ? "" : "s",
+                    pex.jvmOptionsFile());
+            int errorCounter = 0;
+            for (final Map.Entry<Integer, String> entry : pex.invalidLines().entrySet()) {
+                errorCounter++;
+                System.err.printf(Locale.ROOT,
+                        "[%d]: encountered improperly formatted JVM option in [%s] on line number [%d]: [%s]",
+                        errorCounter,
+                        pex.jvmOptionsFile(),
+                        entry.getKey(),
+                        entry.getValue());
+            }
+        } catch (IOException ex) {
+            System.err.println("Error accessing jvm.options file");
+            System.exit(1);
+        }
+    }
+
+    private Optional<Path> lookupJvmOptionsFile(String jvmOpts) {
+        if (jvmOpts != null && !jvmOpts.isEmpty()) {
+            return Optional.of(Paths.get(jvmOpts));
+        }
+        // Set the initial JVM options from the jvm.options file. Look in
+        // /etc/logstash first, and break if that file is found readable there.
+        return Arrays.stream(new Path[] { Paths.get("/etc/logstash/jvm.options"),
+                                          Paths.get(logstashHome, "config/jvm.options") })
+                .filter(p -> p.toFile().canRead())
+                .findFirst();
+    }
+
+    private void parse(Path jvmOptionsFile) throws IOException, JvmOptionsFileParserException {
+        final List<String> jvmOptionsContent = parseJvmOptions(jvmOptionsFile);
+        final String lsJavaOpts = System.getenv("LS_JAVA_OPTS");
+        if (lsJavaOpts != null && !lsJavaOpts.isEmpty()) {
+            jvmOptionsContent.add(lsJavaOpts);
+        }
+        System.out.println(String.join(" ", jvmOptionsContent));
+    }
+
+    private List<String> parseJvmOptions(Path jvmOptionsFile) throws IOException, JvmOptionsFileParserException {
+        if (!jvmOptionsFile.toFile().exists()) {
+            return Collections.emptyList();
+        }
+        final int majorJavaVersion = javaMajorVersion();
+
+        try (InputStream is = Files.newInputStream(jvmOptionsFile);
+             Reader reader = new InputStreamReader(is, StandardCharsets.UTF_8);
+             BufferedReader br = new BufferedReader(reader)
+        ) {
+            final ParseResult parseResults = parse(majorJavaVersion, br);
+            if (parseResults.hasErrors()) {
+                throw new JvmOptionsFileParserException(jvmOptionsFile, parseResults.getInvalidLines());
+            }
+            return parseResults.getJvmOptions();
+        }
+    }
+
+    /**
+     * Collector of parsed lines and errors.
+     * */
+    static final class ParseResult {
+        private final List<String> jvmOptions = new ArrayList<>();
+        private final SortedMap<Integer, String> invalidLines = new TreeMap<>();
+
+        void appendOption(String option) {
+            jvmOptions.add(option);
+        }
+
+        void appendError(int lineNumber, String malformedLine) {
+            invalidLines.put(lineNumber, malformedLine);
+        }
+
+        public boolean hasErrors() {
+            return !invalidLines.isEmpty();
+        }
+
+        public SortedMap<Integer, String> getInvalidLines() {
+            return invalidLines;
+        }
+
+        public List<String> getJvmOptions() {
+            return jvmOptions;
+        }
+    }
+
+    private static final Pattern OPTION_DEFINITION = Pattern.compile("((?<start>\\d+)(?<range>-)?(?<end>\\d+)?:)?(?<option>-.*)$");
+
+    /**
+     * Parse the line-delimited JVM options from the specified buffered reader for the specified Java major version.
+     * Valid JVM options are:
+     * <ul>
+     *     <li>
+     *         a line starting with a dash is treated as a JVM option that applies to all versions
+     *     </li>
+     *     <li>
+     *         a line starting with a number followed by a colon is treated as a JVM option that applies to the matching Java major version
+     *         only
+     *     </li>
+     *     <li>
+     *         a line starting with a number followed by a dash followed by a colon is treated as a JVM option that applies to the matching
+     *         Java specified major version and all larger Java major versions
+     *     </li>
+     *     <li>
+     *         a line starting with a number followed by a dash followed by a number followed by a colon is treated as a JVM option that
+     *         applies to the specified range of matching Java major versions
+     *     </li>
+     * </ul>
+     *
+     * For example, if the specified Java major version is 8, the following JVM options will be accepted:
+     * <ul>
+     *     <li>
+     *         {@code -XX:+PrintGCDateStamps}
+     *     </li>
+     *     <li>
+     *         {@code 8:-XX:+PrintGCDateStamps}
+     *     </li>
+     *     <li>
+     *         {@code 8-:-XX:+PrintGCDateStamps}
+     *     </li>
+     *     <li>
+     *         {@code 7-8:-XX:+PrintGCDateStamps}
+     *     </li>
+     * </ul>
+     * and the following JVM options will be skipped:
+     * <ul>
+     *     <li>
+     *         {@code 9:-Xlog:age*=trace,gc*,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m}
+     *     </li>
+     *     <li>
+     *         {@code 9-:-Xlog:age*=trace,gc*,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m}
+     *     </li>
+     *     <li>
+     *         {@code 9-10:-Xlog:age*=trace,gc*,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m}
+     *     </li>
+     * </ul>
+     *
+     * If the version syntax specified on a line matches the specified JVM options, the JVM option callback will be invoked with the JVM
+     * option. If the line does not match the specified syntax for the JVM options, the invalid line callback will be invoked with the
+     * contents of the entire line.
+     *
+     * @param javaMajorVersion the Java major version to match JVM options against
+     * @param br the buffered reader to read line-delimited JVM options from
+     * @return the admitted options lines respecting the javaMajorVersion and the error lines
+     * @throws IOException if an I/O exception occurs reading from the buffered reader
+     */
+    static ParseResult parse(final int javaMajorVersion, final BufferedReader br) throws IOException {
+        final ParseResult result = new ParseResult();
+        int lineNumber = 0;
+        while (true) {
+            final String line = br.readLine();
+            lineNumber++;
+            if (line == null) {
+                break;
+            }
+            if (line.startsWith("#")) {
+                // lines beginning with "#" are treated as comments
+                continue;
+            }
+            if (line.matches("\\s*")) {
+                // skip blank lines
+                continue;
+            }
+            final Matcher matcher = OPTION_DEFINITION.matcher(line);
+            if (matcher.matches()) {
+                final String start = matcher.group("start");
+                final String end = matcher.group("end");
+                if (start == null) {
+                    // no range present, unconditionally apply the JVM option
+                    result.appendOption(line);
+                } else {
+                    final int lower;
+                    try {
+                        lower = Integer.parseInt(start);
+                    } catch (final NumberFormatException e) {
+                        result.appendError(lineNumber, line);
+                        continue;
+                    }
+                    final int upper;
+                    if (matcher.group("range") == null) {
+                        // no range is present, apply the JVM option to the specified major version only
+                        upper = lower;
+                    } else if (end == null) {
+                        // a range of the form \\d+- is present, apply the JVM option to all major versions larger than the specified one
+                        upper = Integer.MAX_VALUE;
+                    } else {
+                        // a range of the form \\d+-\\d+ is present, apply the JVM option to the specified range of major versions
+                        try {
+                            upper = Integer.parseInt(end);
+                        } catch (final NumberFormatException e) {
+                            result.appendError(lineNumber, line);
+                            continue;
+                        }
+                        if (upper < lower) {
+                            result.appendError(lineNumber, line);
+                            continue;
+                        }
+                    }
+                    if (lower <= javaMajorVersion && javaMajorVersion <= upper) {
+                        result.appendOption(matcher.group("option"));
+                    }
+                }
+            } else {
+                result.appendError(lineNumber, line);
+            }
+        }
+        return result;
+    }
+
+    private static final Pattern JAVA_VERSION = Pattern.compile("^(?:1\\.)?(?<javaMajorVersion>\\d+)(?:\\.\\d+)?$");
+
+    private int javaMajorVersion() {
+        final String specVersion = System.getProperty("java.specification.version");
+        final Matcher specVersionMatcher = JAVA_VERSION.matcher(specVersion);
+        if (!specVersionMatcher.matches()) {
+            throw new IllegalStateException(String.format("Failed to extract Java major version from specification `%s`", specVersion));
+        }
+        return Integer.parseInt(specVersionMatcher.group("javaMajorVersion"));
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/launchers/JvmOptionsParserTest.java
+++ b/logstash-core/src/test/java/org/logstash/launchers/JvmOptionsParserTest.java
@@ -1,0 +1,70 @@
+package org.logstash.launchers;
+
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+
+import static org.junit.Assert.*;
+
+public class JvmOptionsParserTest {
+
+    @Test
+    public void testParseCommentLine() throws IOException {
+        final BufferedReader options = asReader("# this is a comment\n-XX:+UseConcMarkSweepGC");
+        final JvmOptionsParser.ParseResult res = JvmOptionsParser.parse(11, options);
+
+        assertTrue("no invalid lines can be present", res.getInvalidLines().isEmpty());
+        verifyOptions("Uncommented lines must be present", "-XX:+UseConcMarkSweepGC", res);
+    }
+
+    @Test
+    public void testParseOptionWithFixedVersion() throws IOException {
+        JvmOptionsParser.ParseResult res = JvmOptionsParser.parse(11, asReader("8:-XX:+UseConcMarkSweepGC"));
+
+        assertTrue("No option match for Java 11", res.getJvmOptions().isEmpty());
+
+        res = JvmOptionsParser.parse(8, asReader("8:-XX:+UseConcMarkSweepGC"));
+        verifyOptions("Option must be present for Java 8", "-XX:+UseConcMarkSweepGC", res);
+    }
+
+    @Test
+    public void testParseOptionGreaterThanVersion() throws IOException {
+        JvmOptionsParser.ParseResult res = JvmOptionsParser.parse(11, asReader("8-:-XX:+UseConcMarkSweepGC"));
+        verifyOptions("Option must be present for Java 11", "-XX:+UseConcMarkSweepGC", res);
+
+        res = JvmOptionsParser.parse(8, asReader("8-:-XX:+UseConcMarkSweepGC"));
+        verifyOptions("Option must be present also for Java 8", "-XX:+UseConcMarkSweepGC", res);
+    }
+
+    @Test
+    public void testParseOptionVersionRange() throws IOException {
+        JvmOptionsParser.ParseResult res = JvmOptionsParser.parse(11, asReader("10-11:-XX:+UseConcMarkSweepGC"));
+        verifyOptions("Option must be present for Java 11", "-XX:+UseConcMarkSweepGC", res);
+
+        res = JvmOptionsParser.parse(14, asReader("10-11:-XX:+UseConcMarkSweepGC"));
+        assertTrue("No option match outside the range [10-11]", res.getJvmOptions().isEmpty());
+    }
+
+    @Test
+    public void testErrorLinesAreReportedCorrectly() throws IOException {
+        final String jvmOptionsContent = "10-11:-XX:+UseConcMarkSweepGC\n" +
+                "invalidOption\n" +
+                "-Duser.country=US\n" +
+                "anotherInvalidOption";
+        JvmOptionsParser.ParseResult res = JvmOptionsParser.parse(11, asReader(jvmOptionsContent));
+        verifyOptions("Option must be present for Java 11", "-XX:+UseConcMarkSweepGC\n-Duser.country=US", res);
+
+        assertEquals("invalidOption", res.getInvalidLines().get(2));
+        assertEquals("anotherInvalidOption", res.getInvalidLines().get(4));
+    }
+
+    private void verifyOptions(String message, String expected, JvmOptionsParser.ParseResult res) {
+        assertEquals(message, expected, String.join("\n", res.getJvmOptions()));
+    }
+
+    private BufferedReader asReader(String s) {
+        return new BufferedReader(new StringReader(s));
+    }
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->
reviewable after rebase on top of #12512

## What does this PR do?
Introduces the conditional behavior in `jvm.options` to define some options as usable with only certain versions of JVM. This feature is based on what Elasticsearch already does https://www.elastic.co/guide/en/elasticsearch/reference/master/jvm-options.html

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

## Why is it important/What is the impact to the user?
This feature permit the user to define different options for different JVM versions, for example in we can configure CMS GC only for Java in versions range 8..14 and avoid it in JDK 15. This is available for any option in `jvm.options` file.
<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Run on Windows OS checking the options passes to the Logstash process

## How to test this PR locally
Use a jdk 15 for example, using sdkman
```
sdk install java 15.0.1.hs-adpt
sdk use java java 15.0.1.hs-adpt
```

then run `./gradlew build`, the build must be green
<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases
A user want to enable certain JVM options based on JVM version.
<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->
