### PR TITLE
Pin version of nokogiri to `1.10.0`

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -11,6 +11,7 @@ gem "paquet", "~> 0.2"
 gem "pleaserun", "~>0.0.28"
 gem "rake", "~> 12"
 gem "ruby-progressbar", "~> 1"
+#gem "nokogiri", "~> 1.10.10"
 gem "logstash-output-elasticsearch", ">= 10.4.2"
 gem "childprocess", "~> 0.9", :group => :build
 gem "fpm", "~> 1.3.3", :group => :build


### PR DESCRIPTION
Currently, the license check is failing due to nokogiri pulling in a different
version of `racc` than is included with `jruby`.

This commit pins nokogiri to `1.10.x` to unblock release builds
