### PR TITLE
pq: eliminate corruption by forcing version byte to be persisted

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/MmapPageIOV2.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/MmapPageIOV2.java
@@ -193,6 +193,7 @@ public final class MmapPageIOV2 implements PageIO {
         }
         buffer.position(0);
         buffer.put(VERSION_TWO);
+        buffer.force();
         this.head = 1;
         this.minSeqNum = 0L;
         this.elementCount = 0;


### PR DESCRIPTION
## What does this PR do?

Prevents PQ corruption that can occur when Logstash crashes
before events have been written to a newly-created page file.

When the PQ creates a new page and allocates a memory-mapped buffer, the
underlying file is zero'd out to full page capacity and the version byte is
written to the buffer, but (emphashis mine):

> Changes made to the resulting [`MemoryMappedBuffer`] will **_eventually_** be propagated to the file
> -- [`FileChannel#map` with `MapMode.READ_WRITE`](https://docs.oracle.com/javase/8/docs/api/java/nio/channels/FileChannel.html#map-java.nio.channels.FileChannel.MapMode-long-long-)

When writing a batch of events to the queue, we force the buffer to synchronize,
but if Logstash crashes or is killed before any elements have been pushed into
the queue page, we have no guarantees that the version marker has been
persisted to the storage device. A subsequent attempt to load an all-zeros
queue page will result in an obscure error message and failure to load:

~~~
AbstractPipelineExt - Logstash failed to create queue.
org.logstash.ackedqueue.io.MmapPageIOV2$PageIOInvalidVersionException: Expected page version=2 but found version=0
~~~

By sending `MappedByteBuffer#force()` immediately after the version has been
added to the buffer, we can shrink the window in which a crash can leave the
queue on disk in a corrupt state.

## Why is it important/What is the impact to the user?

Prevents scenario where a Logstash crash could leave queue in an unrecoverable state.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files (and/or docker env variables)~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~

## How to test this PR locally

While I can verify that a zero'd out page file causes the referenced failure to load the queue due to mismatched version, I have thus far been unable to reliably replicate the timing of a hard shutdown causing the zero'd out file in the first place. Since we only send `MappedByteBuffer#force()` when serializing events to the queue, forcing the sync after writing the version byte _theoretically_ closes the window in which we have a zero'd out page file on disk.

## Related issues

 - Related: #12507 Logstash failed to create queue after sudden poweroff
 - Related: #12040 persistent queue corruption on system hard reset
