### PR TITLE
[WIP]Rought idea of translating Ruby setting into Java using a Ruby shell to immutable Java implementation

### DIFF
--- a/logstash-core/src/main/java/org/logstash/settings/Setting.java
+++ b/logstash-core/src/main/java/org/logstash/settings/Setting.java
@@ -1,0 +1,20 @@
+package org.logstash.settings;
+
+public class Setting<T> {
+
+    private final T value;
+    private final SettingSpecification<T> settingSpecification;
+
+    public Setting(T value, SettingSpecification<T> specification) {
+        this.value = value;
+        this.settingSpecification = specification;
+
+        if (settingSpecification.isStrict()) {
+            settingSpecification.validate(getValue());
+        }
+    }
+
+    public T getValue() {
+        return value;
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/settings/SettingSpecification.java
+++ b/logstash-core/src/main/java/org/logstash/settings/SettingSpecification.java
@@ -1,0 +1,44 @@
+package org.logstash.settings;
+
+import java.util.function.Predicate;
+
+public class SettingSpecification<T> {
+
+    private final String name;
+    private final T defaultValue;
+    private final Predicate<T> validator;
+    private final boolean strict;
+
+    public SettingSpecification(String name, T defaultValue, Predicate<T> validator) {
+        this.name = name;
+        this.defaultValue = defaultValue;
+        this.validator = validator;
+        this.strict = true;
+
+        if (isStrict()) {
+            validate(getDefaultValue());
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public T getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void validate(T value) {
+        if (!this.validator.test(value)) {
+            throw new IllegalArgumentException(String.format("Failed to validate setting \"%s\" with value: %s", name, value));
+        }
+    }
+
+    public boolean isStrict() {
+        return strict;
+    }
+    
+    public Class<?> getKlass() {
+        return defaultValue.getClass();
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/settings/StringSetting.java
+++ b/logstash-core/src/main/java/org/logstash/settings/StringSetting.java
@@ -1,0 +1,14 @@
+package org.logstash.settings;
+
+import java.util.List;
+
+public final class StringSetting extends Setting<String> {
+
+    public StringSetting(String value, SettingSpecification<String> settingOption) {
+        super(value, settingOption);
+    }
+
+    public static SettingSpecification<String> spec(String name, String defaultValue, List<String> possibleStrings) {
+        return new SettingSpecification<>(name, defaultValue, value -> possibleStrings.isEmpty() || possibleStrings.contains(value));
+    }
+}


### PR DESCRIPTION
## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
This PR is POC related to #12531 where it prove the feasibility to keep the existing Ruby setting classes as shell to effectively proxy calls to a Java immutable versions. The Java version has a specification class, that contain validator, default value and such, while proper setting class (always immutable) keep the value and uses the specification to validate it; It's based on the [considerations](https://github.com/elastic/logstash/pull/12531#discussion_r550300299). However there still some part not captured, for example the base Ruby Setting class accepts a code block used to validate the setting, this code is Ruby code and it should be used by the Java immutable class as validator, but looking at Logstash code base the only usage of that block as validator seem to be in [unit tests](https://github.com/elastic/logstash/blob/622c5107ced7990b64c24df4efda53b5762ab6aa/logstash-core/spec/logstash/setting_spec.rb#L146), so it could be thought as "internal usage" and not leveraged by other plugins (this needs confirmation)

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
