### PR TITLE
Send monitoring information when LS pipelines is booting

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -114,9 +114,9 @@ class LogStash::Agent
 
     transition_to_running
 
-    converge_state_and_update
-
     start_webserver_if_enabled
+
+    converge_state_and_update
 
     if auto_reload?
       # `sleep_then_run` instead of firing the interval right away

--- a/x-pack/lib/monitoring/inputs/metrics/stats_event_factory.rb
+++ b/x-pack/lib/monitoring/inputs/metrics/stats_event_factory.rb
@@ -12,6 +12,7 @@ module LogStash; module Inputs; class Metrics;
       @snapshot = snapshot
       @metric_store = @snapshot.metric_store
       @cluster_uuid = cluster_uuid
+      @webserver_enabled = LogStash::SETTINGS.get_value("http.enabled")
     end
 
     def make(agent, extended_performance_collection=true, collection_interval=10)
@@ -124,8 +125,13 @@ module LogStash; module Inputs; class Metrics;
     end
 
     def fetch_node_stats(agent, stats)
+      if @webserver_enabled
+        http_addr = stats.get_shallow(:http_address).value
+      else
+        http_addr = nil
+      end
       @global_stats.merge({
-        "http_address" => stats.get_shallow(:http_address).value,
+        "http_address" => http_addr,
         "ephemeral_id" => agent.ephemeral_id
       })
     end

--- a/x-pack/spec/monitoring/schemas/monitoring_document_schema.json
+++ b/x-pack/spec/monitoring/schemas/monitoring_document_schema.json
@@ -71,7 +71,7 @@
       "type": "object",
       "required": ["http_address", "uuid", "ephemeral_id"],
       "properties": {
-        "http_address": { "type": "string" },
+        "http_address": { "type": ["string", "null"] },
         "uuid": { "type": "string" },
         "ephemeral_id": { "type": "string" }
       }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
This PR is a follow up related to the comment https://github.com/elastic/logstash/pull/12444#issuecomment-737297054

When Logstash is confiugred to use the internal monitoring *and* has a user pipeline that has a slow start (for example an init step with a sleep or the scheduler decides to switch context before), it happens that the monitoring pipeline fails to grab a metric, named `http_address`. That metric is created by the webserver, when it's started, and actually the webserver is started after all the pipeline creation tasks are executed. The same problem happens also if Logstash starts with `http.enabled=false` and uses the internal monitoring collector.

This PR proposes 2 changes:
- start the webserver before the execution of create pipeline tasks.
- expose a default metric for `http_address` when the webserver is disabled.

The second change is related to the fact that without that metric, the `stat` document created by the monitoring pipeline and passed to a Monitoring Elasticsearch, causes the erasure of a portion of the document under the path `logstash_stats.logstash` in the `.monitoring-logstash-7-yyyy.MM.dd` index. Kibana UI without that fragment is not able to show anything about the monitored Logstash instance.

Example of the portion eliminated:
```Javascript
"logstash": {
    "ephemeral_id": null,
    "host": "kalispera",
    "http_address": "127.0.0.1:9600",
    "name": "kalispera",
    "pipeline": {
        "batch_size": 125,
        "workers": 12
    },
    "snapshot": null,
    "status": "green",
    "uuid": "b102bf99-4b78-44fb-93cf-5f5ede731593",
    "version": "8.0.0"
}
```

## Why is it important/What is the impact to the user?
Avoid some errors in logs which could warn the user.
<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- relates #12444

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
- this is the log seen when webserver is disabled:
```
[2020-12-02T10:57:59,522][INFO ][logstash.agent           ] HTTP API is disabled (`http.enabled=false`); webserver will not be started.
.........[2020-12-02T10:58:09,392][ERROR][logstash.inputs.metrics  ] Failed to create monitoring event {:message=>"For path: http_address. Map keys: [:stats, :os, :jvm]", :error=>"LogStash::Instrument::MetricStore::MetricNotFound"}
```
- this is the log seen when the monitoring pipeline start collect data before the webserver is started:
```
[2020-11-26T11:50:04,045][INFO ][logstash.javapipeline    ][.monitoring-logstash] Starting pipeline {:pipeline_id=>".monitoring-logstash", "pipeline.workers"=>1, "pipeline.batch.size"=>2, "pipeline.batch.delay"=>50, "pipeline.max_inflight"=>2, "pipeline.sources"=>["monitoring pipeline"], :thread=>"#<Thread:0x5067a2f1 run>"}
[2020-11-26T11:50:04,678][INFO ][logstash.javapipeline    ][.monitoring-logstash] Pipeline Java execution initialization time {"seconds"=>0.63}
[2020-11-26T11:50:04,701][INFO ][logstash.javapipeline    ][.monitoring-logstash] Pipeline started {"pipeline.id"=>".monitoring-logstash"}
[2020-11-26T11:50:14,752][ERROR][logstash.inputs.metrics  ] Failed to create monitoring event {:message=>"For path: http_address. Map keys: [:stats, :jvm]", :error=>"LogStash::Instrument::MetricStore::MetricNotFound"}
[2020-11-26T11:50:24,792][ERROR][logstash.inputs.metrics  ] Failed to create monitoring event {:message=>"For path: http_address. Map keys: [:stats, :jvm]", :error=>"LogStash::Instrument::MetricStore::MetricNotFound"}
```
