### PR TITLE
Simplified config mount: readonly over permissions

### DIFF
--- a/docs/static/docker.asciidoc
+++ b/docs/static/docker.asciidoc
@@ -108,13 +108,8 @@ Alternatively, a single file can be mounted:
 
 ["source","sh",subs="attributes"]
 --------------------------------------------
-docker run --rm -it -v ~/settings/logstash.yml:/usr/share/logstash/config/logstash.yml {docker-image}
+docker run --rm -it -v ~/settings/logstash.yml:/usr/share/logstash/config/logstash.yml:ro {docker-image}
 --------------------------------------------
-
-NOTE: Bind-mounted configuration files will retain the same permissions and
-ownership within the container that they have on the host system. Be sure
-to set permissions such that the files will be readable and, ideally, not
-writeable by the container's +logstash+ user (UID 1000).
 
 ===== Custom Images
 


### PR DESCRIPTION
## What does this PR do?

Simplifies docker usage. It's easier to mount the config file as read-only instead of taking care about permissions.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works
