### PR TITLE
enable converging state with predefined pipeline actions

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -206,6 +206,10 @@ class LogStash::Agent
     logger.error("An exception happened when converging configuration", attributes)
   end
 
+  ##
+  # Shut down a pipeline and wait for it to fully stop.
+  # WARNING: Calling from `Plugin#initialize` or `Plugin#register` will result in deadlock.
+  # @param pipeline_id [String]
   def stop_pipeline(pipeline_id)
     action = LogStash::PipelineAction::Stop.new(pipeline_id.to_sym)
     converge_state_with_resolved_actions([action])
@@ -328,7 +332,7 @@ class LogStash::Agent
   end
 
   # Beware the usage with #resolve_actions_and_converge_state
-  # Calling this method in plugin #register causes deadlock.
+  # Calling this method in `Plugin#register` causes deadlock.
   # For example, resolve_actions_and_converge_state -> pipeline reload_action -> plugin register -> converge_state_with_resolved_actions
   def converge_state_with_resolved_actions(pipeline_actions)
     @convergence_lock.synchronize do

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -331,8 +331,6 @@ class LogStash::Agent
     end
   end
 
-
-
   # We depends on a series of task derived from the internal state and what
   # need to be run, theses actions are applied to the current pipelines to converge to
   # the desired state.

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -206,6 +206,15 @@ class LogStash::Agent
     logger.error("An exception happened when converging configuration", attributes)
   end
 
+  # Beware the usage with #resolve_actions_and_converge_state
+  # Calling this method in plugin #register causes deadlock.
+  # For example, resolve_actions_and_converge_state -> pipeline reload_action -> plugin register -> converge_state_with_resolved_actions
+  def converge_state_with_resolved_actions(pipeline_actions)
+    @convergence_lock.synchronize do
+      converge_state(pipeline_actions)
+    end
+  end
+
   # Calculate the Logstash uptime in milliseconds
   #
   # @return [Integer] Uptime in milliseconds
@@ -321,6 +330,8 @@ class LogStash::Agent
       converge_state(pipeline_actions)
     end
   end
+
+
 
   # We depends on a series of task derived from the internal state and what
   # need to be run, theses actions are applied to the current pipelines to converge to

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -333,7 +333,7 @@ describe LogStash::Agent do
       end
     end
 
-    describe "#resolve_actions_and_converge_state" do
+    describe "#stop_pipeline" do
       let(:config_string) { "input { generator { id => 'old'} } output { }" }
       let(:mock_config_pipeline) { mock_pipeline_config(:main, config_string, pipeline_settings) }
       let(:source_loader) { TestSourceLoader.new(mock_config_pipeline) }
@@ -348,10 +348,9 @@ describe LogStash::Agent do
         subject.shutdown
       end
 
-      context "when the upgrade succeeds" do
-        it "starts the pipeline" do
-          action = LogStash::PipelineAction::Stop.new(:main)
-          converge_result = subject.converge_state_with_resolved_actions([action])
+      context "when agent stops the pipeline" do
+        it "should stop successfully", :aggregate_failures do
+          converge_result = subject.stop_pipeline('main')
 
           expect(converge_result).to be_a_successful_converge
           expect(subject.get_pipeline('main').stopped?).to be_truthy

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -333,6 +333,33 @@ describe LogStash::Agent do
       end
     end
 
+    describe "#resolve_actions_and_converge_state" do
+      let(:config_string) { "input { generator { id => 'old'} } output { }" }
+      let(:mock_config_pipeline) { mock_pipeline_config(:main, config_string, pipeline_settings) }
+      let(:source_loader) { TestSourceLoader.new(mock_config_pipeline) }
+      subject { described_class.new(agent_settings, source_loader) }
+
+      before(:each) do
+        expect(subject.converge_state_and_update).to be_a_successful_converge
+        expect(subject.get_pipeline('main').running?).to be_truthy
+      end
+
+      after(:each) do
+        subject.shutdown
+      end
+
+      context "when the upgrade succeeds" do
+        it "starts the pipeline" do
+          action = LogStash::PipelineAction::Stop.new(:main)
+          converge_result = subject.converge_state_with_resolved_actions([action])
+
+          expect(converge_result).to be_a_successful_converge
+          expect(subject.get_pipeline('main').stopped?).to be_truthy
+        end
+      end
+    end
+
+
     context "#started_at" do
       it "return the start time when the agent is started" do
         expect(described_class::STARTED_AT).to be_kind_of(Time)


### PR DESCRIPTION
This PR allows the agent to converge state with predefined pipeline actions instead of fetching the full set of pipelines from elasticsearch and compute the pipeline actions internally. This opens a way for plugins to trigger pipeline reload. A usage is [logstash-filter-geoip](https://github.com/logstash-plugins/logstash-filter-geoip/pull/172/commits/badfc81d9c289c44c9ad817e3e8261e9ea6afbf7#diff-5421cf35b684cca803ff336c23f52918df0809819ae2bd6d36a4a4ec8250ddf1R129) which needs to shut down its own pipeline in certain conditions.

Related: https://github.com/logstash-plugins/logstash-filter-geoip/pull/172
Meta: #12560