### PR TITLE
Improve integrationTests task checking local ES fingerprint before full download

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -398,9 +398,46 @@ tasks.register("copyFilebeat", Copy){
     }
 }
 
+tasks.register("checkEsSHA") {
+    dependsOn  configureArtifactInfo
+
+    description "Download ES version remote's fingerprint file"
+
+    String downloadedElasticsearchName = "elasticsearch-${project.ext.get("stackArtifactSuffix")}-${project.ext.get("esArchitecture")}"
+    outputs.file("${projectDir}/build/${downloadedElasticsearchName}.tar.gz.SHA-512")
+
+    // find url of build artifact
+    String artifactApiUrl = "${project.ext.get("artifactApiVersionedBuildUrl")}/projects/elasticsearch/packages/${downloadedElasticsearchName}.tar.gz"
+    String apiResponse = artifactApiUrl.toURL().text
+    def buildUrls = new JsonSlurper().parseText(apiResponse)
+    String remoteSHA = buildUrls.package.sha_url.toURL().text
+
+    def localESArchive = new File("${projectDir}/build/${downloadedElasticsearchName}.tar.gz")
+    if (localESArchive.exists()) {
+        // this create a file named localESArchive with ".SHA-512" postfix
+        ant.checksum(file: localESArchive, algorithm: "SHA-512", forceoverwrite: true)
+
+        File localESCalculatedSHAFile = new File("${projectDir}/build/${downloadedElasticsearchName}.tar.gz.SHA-512")
+        String localESCalculatedSHA = localESCalculatedSHAFile.text.trim()
+        def splitted = remoteSHA.split(' ')
+        String remoteSHACode = splitted[0]
+        if (localESCalculatedSHA != remoteSHACode) {
+            println "ES package calculated fingerprint is different from remote, deleting local archive"
+            delete(localESArchive)
+            delete(localESCalculatedSHA)
+        }
+    } else {
+        mkdir project.buildDir
+        // touch the SHA file else downloadEs task doesn't start, this file his input for the other task
+        new File("${projectDir}/build/${downloadedElasticsearchName}.tar.gz.SHA-512").withWriter {w ->
+            w << "${downloadedElasticsearchName} not yet downloaded"
+            w.close()
+        }
+    }
+}
 
 tasks.register("downloadEs", Download) {
-    dependsOn  configureArtifactInfo
+    dependsOn  = [configureArtifactInfo, checkEsSHA]
     description "Download ES Snapshot for current branch version: ${version}"
 
     String downloadedElasticsearchName = "elasticsearch-${project.ext.get("stackArtifactSuffix")}-${project.ext.get("esArchitecture")}"
@@ -418,6 +455,7 @@ tasks.register("downloadEs", Download) {
     onlyIfNewer true
     retries 3
     inputs.file("${projectDir}/versions.yml")
+//    inputs.file("${projectDir}/build/${downloadedElasticsearchName}.tar.gz.SHA-512")
     outputs.file(project.ext.elasticsearchDownloadLocation)
     dest new File(project.ext.elasticsearchDownloadLocation)
 
@@ -439,7 +477,7 @@ tasks.register("copyEs", Copy) {
         file("./build/${project.ext.unpackedElasticsearchName}").renameTo('./build/elasticsearch')
         System.out.println "Unzipped ${project.ext.elasticsearchDownloadLocation} to ./build/elasticsearch"
         System.out.println "Deleting ${project.ext.elasticsearchDownloadLocation}"
-        delete(project.ext.elasticsearchDownloadLocation)
+//        delete(project.ext.elasticsearchDownloadLocation)
     }
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
Introduces a new Gradle task to be executed before `downloadEs` task, that checks the local ES package fingerprint (if already present) against the one remote retrieved remotely. If the the two fingerprints differ or the local package is not present that permit the download, else avoid it.

This PR saves the sha512 of ES package to a local file in `build/` directory. In builds which require Elastisearch package download this file content is checked to avoid the unseful download of Elastisearch where the remote sha doesn't change

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
This PR makes faster the dev cycle in every task that require the integration with Elasticsearch, for example subsequent runs of `:logstash-xpack:rubyIntegrationTests` task downloads repeatedly the ES package which waste time.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] run 2 consecutive builds and check the second doesn't download if the SHA is not changed


