### PR TITLE
Fix showing deprecation warning of command line flags

### DIFF
--- a/logstash-core/lib/logstash/deprecation_message.rb
+++ b/logstash-core/lib/logstash/deprecation_message.rb
@@ -1,0 +1,31 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'singleton'
+
+###
+# This is a place for storing deprecation message which cannot deliver to user before log4j initialization.
+# eg. command line flags deprecation warning. `bin/logstash --debug`
+module LogStash
+  class DeprecationMessage < Array
+    include Singleton
+
+    def self.instance
+      @@instance ||= Array.new
+    end
+  end
+end

--- a/logstash-core/lib/logstash/patches/clamp.rb
+++ b/logstash-core/lib/logstash/patches/clamp.rb
@@ -17,6 +17,7 @@
 
 require 'clamp'
 require 'logstash/environment'
+require 'logstash/deprecation_message'
 
 module Clamp
   module Attribute
@@ -77,7 +78,7 @@ module Clamp
 
       def define_deprecated_writer_for(option, opts, &block)
         define_method(option.write_method) do |value|
-          self.class.logger.warn "DEPRECATION WARNING: The flag #{option.switches} has been deprecated, please use \"--#{opts[:new_flag]}=#{opts[:new_value]}\" instead."
+          LogStash::DeprecationMessage.instance << "DEPRECATION WARNING: The flag #{option.switches} has been deprecated, please use \"--#{opts[:new_flag]}=#{opts[:new_value]}\" instead."
           LogStash::SETTINGS.set(opts[:new_flag], opts[:new_value])
         end
       end

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -275,9 +275,6 @@ class LogStash::Runner < Clamp::StrictCommand
       LogStash::Logging::Logger::reconfigure(URI.encode(file_schema + File.absolute_path(log4j_config_location)))
     end
 
-    # override log level that may have been introduced from a custom log4j config file
-    LogStash::Logging::Logger::configure_logging(setting("log.level"))
-
     super(*[args])
   end
 
@@ -287,6 +284,10 @@ class LogStash::Runner < Clamp::StrictCommand
     require "logstash/util"
     require "logstash/util/java_version"
     require "stud/task"
+
+    # override log level that may have been introduced from a custom log4j config file
+    LogStash::Logging::Logger::configure_logging(setting("log.level"))
+
 
     if log_configuration_contains_javascript_usage?
       logger.error("Logging configuration uses Script log appender or filter with Javascript, which is no longer supported.")

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -260,15 +260,6 @@ class LogStash::Runner < Clamp::StrictCommand
 
   def run(args)
     return 1 unless LogStash::Util::SettingsHelper.from_yaml(args)
-    super(*[args])
-  end
-
-  def execute
-    LogStash::Util::SettingsHelper.post_process
-
-    require "logstash/util"
-    require "logstash/util/java_version"
-    require "stud/task"
 
     # Configure Logstash logging facility, this need to be done before everything else to
     # make sure the logger has the correct settings and the log level is correctly defined.
@@ -283,8 +274,19 @@ class LogStash::Runner < Clamp::StrictCommand
       file_schema = "file://" + (LogStash::Environment.windows? ? "/" : "")
       LogStash::Logging::Logger::reconfigure(URI.encode(file_schema + File.absolute_path(log4j_config_location)))
     end
+
     # override log level that may have been introduced from a custom log4j config file
     LogStash::Logging::Logger::configure_logging(setting("log.level"))
+
+    super(*[args])
+  end
+
+  def execute
+    LogStash::Util::SettingsHelper.post_process
+
+    require "logstash/util"
+    require "logstash/util/java_version"
+    require "stud/task"
 
     if log_configuration_contains_javascript_usage?
       logger.error("Logging configuration uses Script log appender or filter with Javascript, which is no longer supported.")

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -228,17 +228,14 @@ class LogStash::Runner < Clamp::StrictCommand
   ### DEPRECATED FLAGS ###
   deprecated_option ["--verbose"], :flag,
     I18n.t("logstash.runner.flag.verbose"),
-    :attribute_name => "verbose",
     :new_flag => "log.level", :new_value => "info"
 
   deprecated_option ["--debug"], :flag,
     I18n.t("logstash.runner.flag.debug"),
-    :attribute_name => "debug",
     :new_flag => "log.level", :new_value => "debug"
 
   deprecated_option ["--quiet"], :flag,
     I18n.t("logstash.runner.flag.quiet"),
-    :attribute_name => "quiet",
     :new_flag => "log.level", :new_value => "error"
 
   # We configure the registry and load any plugin that can register hooks


### PR DESCRIPTION
This PR allows warning message from [clamp](https://github.com/elastic/logstash/blob/master/logstash-core/lib/logstash/patches/clamp.rb#L80) shows in log file. 
The reason of logger failed to log message is that logger is used before log4j setup. Putting log4j setup to an earlier stage, Runner#run, allows logger to function in clamp but this cause another problem of losing user config, `--path.log`, which is necessary for a proper log4j setup.

This PR proposes to store the deprecation message in memory and remove them once it shows to users.

Log should show
```
Sending Logstash logs to /Users/xxx/logstash/logs which is now configured via log4j2.properties
[2021-01-25T13:48:40,263][WARN ][logstash.runner          ] DEPRECATION WARNING: The flag ["--debug"] has been deprecated, please use "--log.level=debug" instead.
```

Fixed: https://github.com/elastic/logstash/issues/12587