### PR TITLE
Backport PR #12585 to 7.11: [windows] fix launch when folder contains spaces

### DIFF
--- a/bin/logstash.bat
+++ b/bin/logstash.bat
@@ -57,21 +57,21 @@ for %%i in ("%LS_HOME%\logstash-core\lib\jars\*.jar") do (
 goto :end
 
 :version
-set "LOGSTASH_VERSION_FILE1=%LS_HOME%\logstash-core\versions-gem-copy.yml"
-set "LOGSTASH_VERSION_FILE2=%LS_HOME%\versions.yml"
+set LOGSTASH_VERSION_FILE1="%LS_HOME%\logstash-core\versions-gem-copy.yml"
+set LOGSTASH_VERSION_FILE2="%LS_HOME%\versions.yml"
 
 set "LOGSTASH_VERSION=Version not detected"
 if exist !LOGSTASH_VERSION_FILE1! (
 	rem this file is present in zip, deb and rpm artifacts and after bundle install
 	rem but might not be for a git checkout type install
-	for /F "tokens=1,2 delims=: " %%a in (!LOGSTASH_VERSION_FILE1!) do (
+	for /F "tokens=1,2 delims=: " %%a in ('type !LOGSTASH_VERSION_FILE1!') do (
 		if "%%a"=="logstash" set LOGSTASH_VERSION=%%b
 	)
 ) else (
 	if exist !LOGSTASH_VERSION_FILE2! (
 		rem this file is present for a git checkout type install
 		rem but its not in zip, deb and rpm artifacts (and in integration tests)
-		for /F "tokens=1,2 delims=: " %%a in (!LOGSTASH_VERSION_FILE2!) do (
+		for /F "tokens=1,2 delims=: " %%a in ('type !LOGSTASH_VERSION_FILE2!') do (
 			if "%%a"=="logstash" set LOGSTASH_VERSION=%%b
 		)
 	)
@@ -81,9 +81,9 @@ goto :end
 
 :concat
 IF not defined CLASSPATH (
-  set CLASSPATH="%~1"
+  set CLASSPATH=%~1
 ) ELSE (
-  set CLASSPATH=%CLASSPATH%;"%~1"
+  set CLASSPATH=%CLASSPATH%;%~1
 )
 goto :eof
 


### PR DESCRIPTION
Backport PR #12585 to 7.11 branch. Original message: 

## What does this PR do?

Fix launching logstash with bundled JDK if folder has spaces.

## Why is it important/What is the impact to the user?

Currently starting logstash on windows without an external JDK causes logstash to crash.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [x] find places where spaces in a folder can break the launch script

## How to test this PR locally

1. On windows create a folder with spaces like "c:\this folder has spaces". 
2. Unzip logstash inside that folder.
3. Enter the logstash folder. e.g. "c:\this folder has spaces\logstash-7.10.2"
3. Run a few test commands:
a. `bin\logstash.bat -e ""`
b. `bin\logstash.bat -V`

NOTE TO REVIEWER: as we don't have acceptance tests dedicated to windows, I ask that you manually test this on windows using folders with and without spaces, and any other scenario you foresee where this could fail.

## Related issues

Fixes #6426

## Logs

```
C:\folder with spaces\logstash>bin\logstash.bat -V
"Using bundled JDK: ""
The system cannot find the file C:\folder.
logstash Version not detected

C:\folder with spaces\logstash>
```


```
C:\folder with spaces\logstash>bin\logstash.bat -e " "
"Using bundled JDK: ""
OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.
Error: Could not find or load main class with
Caused by: java.lang.ClassNotFoundException: with
```