### PR TITLE
bump jrjackson to 0.4.14 and jackson-databind to 2.9.10.8

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -27,6 +27,6 @@ jruby:
 # Note: this file is copied to the root of logstash-core because its gemspec needs it when
 #       bundler evaluates the gemspec via bin/logstash
 # Ensure Jackson version here is kept in sync with version used by jrjackson gem
-jrjackson: 0.4.13
+jrjackson: 0.4.14
 jackson: 2.9.10
-jackson-databind: 2.9.10.6
+jackson-databind: 2.9.10.8


### PR DESCRIPTION
Recurrent bump of jrjackson and databind to ensure latest Logstash uses the latest patch releases.