### PR TITLE
7x Fix sub second `config.reload.interval`

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -92,7 +92,9 @@ class LogStash::Agent
     end
 
     # Normalize time interval to seconds
-    @reload_interval = setting("config.reload.interval").to_seconds
+    # we can't do .to_seconds here as values under 1 seconds are rounded to 0
+    # so we get the nanos and convert to seconds instead.
+    @reload_interval = setting("config.reload.interval").to_nanos * 1e-9
 
     @collect_metric = setting("metric.collect")
 

--- a/logstash-core/spec/logstash/agent/converge_spec.rb
+++ b/logstash-core/spec/logstash/agent/converge_spec.rb
@@ -191,7 +191,9 @@ describe LogStash::Agent do
           end
 
           it "it will keep trying to converge" do
-            sleep(agent_settings.get("config.reload.interval").to_seconds * 20) # let the interval reload a few times
+            # we can't do .to_seconds here as values under 1 seconds are rounded to 0
+            # causing a race condition in the test. So we get the nanos and convert to seconds
+            sleep(agent_settings.get("config.reload.interval").to_nanos * 1e-9 * 20) # let the interval reload a few times
             expect(subject.pipelines_count).to eq(0)
             expect(source_loader.fetch_count).to be > 1
           end


### PR DESCRIPTION
Clean backport of #12589

Due to a change in #11803, using `to_seconds` to normalize values of `config.reload.interval`
would resolve to a value of 0 causing issues in tests where short reload intervals were desired.
This commit uses the `to_nanos` method to preserve the previous functionality.

Co-authored-by: João Duarte <jsvd@users.noreply.github.com>
