### PR TITLE
[Doc] added instruction on how to update LS to 7.12+ running on JDK15+

### DIFF
--- a/docs/static/jvm.asciidoc
+++ b/docs/static/jvm.asciidoc
@@ -6,7 +6,7 @@
 
 * Java 8
 * Java 11
-* Java 14
+* Java 15 (see <<jdk15-upgrade>> for settings info)
 
 Use the
 http://www.oracle.com/technetwork/java/javase/downloads/index.html[official
@@ -59,3 +59,63 @@ a tarball.
 install the correct startup method (SysV init scripts, Upstart, or systemd). If
 {ls} is unable to find the `JAVA_HOME` environment variable during package
 installation, you may get an error message, and {ls} will not start properly.
+
+[float]
+[[jdk15-upgrade]]
+==== Using JDK 15
+
+{ls} supports JDK 15, but you need to update settings in `jvm.options` and
+`log4j2.properties` if: 
+
+* you are upgrading from  {ls} 7.11.x (or earlier) to 7.12 or later, and
+* you are using JDK 15 or later.
+
+[float]
+===== Updates to `jvm.options`
+In the `config/jvm.options` file, replace all CMS related flags with:
+
+[source,shell]
+-----
+## GC configuration
+8-14:-XX:+UseConcMarkSweepGC
+8-14:-XX:CMSInitiatingOccupancyFraction=75
+8-14:-XX:+UseCMSInitiatingOccupancyOnly
+-----
+
+For more information about how to use `jvm.options`, please refer to <<jvm-settings>>.
+
+[float]
+===== Updates to `log4j2.properties`
+In the `config/log4j2.properties`:
+
+* Replace properties that start with `appender.rolling.avoid_pipelined_filter.*` with: 
++
+[source,shell]
+-----
+appender.rolling.avoid_pipelined_filter.type = PipelineRoutingFilter
+-----
+
+* Replace properties that start with `appender.json_rolling.avoid_pipelined_filter.*` with:
+[source,shell]
++
+-----
+appender.json_rolling.avoid_pipelined_filter.type = PipelineRoutingFilter
+-----
+
+* Replace properties that start with `appender.routing.*` with:
+[source,shell]
++
+-----
+appender.routing.type = PipelineRouting
+appender.routing.name = pipeline_routing_appender
+appender.routing.pipeline.type = RollingFile
+appender.routing.pipeline.name = appender-${ctx:pipeline.id}
+appender.routing.pipeline.fileName = ${sys:ls.logs}/pipeline_${ctx:pipeline.id}.log
+appender.routing.pipeline.filePattern = ${sys:ls.logs}/pipeline_${ctx:pipeline.id}.%i.log.gz
+appender.routing.pipeline.layout.type = PatternLayout
+appender.routing.pipeline.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %m%n
+appender.routing.pipeline.policy.type = SizeBasedTriggeringPolicy
+appender.routing.pipeline.policy.size = 100MB
+appender.routing.pipeline.strategy.type = DefaultRolloverStrategy
+appender.routing.pipeline.strategy.max = 30
+-----

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -208,15 +208,6 @@ class LogStash::Agent
     logger.error("An exception happened when converging configuration", attributes)
   end
 
-  ##
-  # Shut down a pipeline and wait for it to fully stop.
-  # WARNING: Calling from `Plugin#initialize` or `Plugin#register` will result in deadlock.
-  # @param pipeline_id [String]
-  def stop_pipeline(pipeline_id)
-    action = LogStash::PipelineAction::Stop.new(pipeline_id.to_sym)
-    converge_state_with_resolved_actions([action])
-  end
-
   # Calculate the Logstash uptime in milliseconds
   #
   # @return [Integer] Uptime in milliseconds
@@ -329,15 +320,6 @@ class LogStash::Agent
   def resolve_actions_and_converge_state(pipeline_configs)
     @convergence_lock.synchronize do
       pipeline_actions = resolve_actions(pipeline_configs)
-      converge_state(pipeline_actions)
-    end
-  end
-
-  # Beware the usage with #resolve_actions_and_converge_state
-  # Calling this method in `Plugin#register` causes deadlock.
-  # For example, resolve_actions_and_converge_state -> pipeline reload_action -> plugin register -> converge_state_with_resolved_actions
-  def converge_state_with_resolved_actions(pipeline_actions)
-    @convergence_lock.synchronize do
       converge_state(pipeline_actions)
     end
   end

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -333,32 +333,6 @@ describe LogStash::Agent do
       end
     end
 
-    describe "#stop_pipeline" do
-      let(:config_string) { "input { generator { id => 'old'} } output { }" }
-      let(:mock_config_pipeline) { mock_pipeline_config(:main, config_string, pipeline_settings) }
-      let(:source_loader) { TestSourceLoader.new(mock_config_pipeline) }
-      subject { described_class.new(agent_settings, source_loader) }
-
-      before(:each) do
-        expect(subject.converge_state_and_update).to be_a_successful_converge
-        expect(subject.get_pipeline('main').running?).to be_truthy
-      end
-
-      after(:each) do
-        subject.shutdown
-      end
-
-      context "when agent stops the pipeline" do
-        it "should stop successfully", :aggregate_failures do
-          converge_result = subject.stop_pipeline('main')
-
-          expect(converge_result).to be_a_successful_converge
-          expect(subject.get_pipeline('main').stopped?).to be_truthy
-        end
-      end
-    end
-
-
     context "#started_at" do
       it "return the start time when the agent is started" do
         expect(described_class::STARTED_AT).to be_kind_of(Time)


### PR DESCRIPTION
**PREVIEW:** https://logstash_12614.docs-preview.app.elstc.co/guide/en/logstash/master/getting-started-with-logstash.html#ls-jvm

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## What does this PR do?
Updates documentation of getting started explaining what to do when an existing LS installation is upgraded to 7.12+ and runs on JDK15+

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
Describe how to change existing `log4j2.properties` and `jvm.options` to run with JDK15 after an update to Logstash `7.12+`
