### PR TITLE
Backport PR #12615 to 7.x: replace with_clean_env with with_unbundled_env

### DIFF
--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -94,7 +94,7 @@ class LogstashService < Service
 
   # Given an input this pipes it to LS. Expects a stdin input in LS
   def start_with_input(config, input)
-    Bundler.with_clean_env do
+    Bundler.with_unbundled_env do
       `cat #{Shellwords.escape(input)} | #{Shellwords.escape(@logstash_bin)} -e \'#{config}\'`
     end
   end
@@ -111,7 +111,7 @@ class LogstashService < Service
   # Useful to test metrics and such
   def start_with_stdin
     puts "Starting Logstash #{@logstash_bin} -e #{STDIN_CONFIG}"
-    Bundler.with_clean_env do
+    Bundler.with_unbundled_env do
       out = Tempfile.new("duplex")
       out.sync = true
       @process = build_child_process("-e", STDIN_CONFIG)
@@ -134,7 +134,7 @@ class LogstashService < Service
 
   # Spawn LS as a child process
   def spawn_logstash(*args)
-    Bundler.with_clean_env do
+    Bundler.with_unbundled_env do
       @process = build_child_process(*args)
       @env_variables.map { |k, v|  @process.environment[k] = v} unless @env_variables.nil?
       java_home = java.lang.System.getProperty('java.home')
@@ -245,7 +245,7 @@ class LogstashService < Service
     end
     process.io.stdout = process.io.stderr = out
 
-    Bundler.with_clean_env do
+    Bundler.with_unbundled_env do
       if change_dir
         Dir.chdir(@logstash_home) do
           process.start

--- a/qa/vagrant/command.rb
+++ b/qa/vagrant/command.rb
@@ -40,7 +40,7 @@ module LogStash
     def self.run(cmd, debug=false)
       # This block is require to be able to launch a ruby subprocess
       # that use bundler.
-      Bundler.with_clean_env do
+      Bundler.with_unbundled_env do
         stdin, stdout, stderr, wait_thr = Open3.popen3(cmd)
         stdout_acc, stderr_acc = "", ""
         stdout_reporter = reporter(stdout, wait_thr) do |c|

--- a/tools/logstash-docgen/lib/logstash/docgen/github_generator.rb
+++ b/tools/logstash-docgen/lib/logstash/docgen/github_generator.rb
@@ -120,7 +120,7 @@ module LogStash module Docgen
 
     def run_in_directory(cmd = nil, &block)
       Dir.chdir(path) do
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           stdin, stdout, stderr, wait_thr = Open3.popen3(cmd)
           if wait_thr.value.success?
             return stdout

--- a/tools/paquet/spec/integration/paquet_spec.rb
+++ b/tools/paquet/spec/integration/paquet_spec.rb
@@ -41,7 +41,7 @@ describe "Pack the dependencies", :integration => true do
       FileUtils.rm_rf(bundler_config)
       FileUtils.rm_rf(vendor_path)
 
-      Bundler.with_clean_env do
+      Bundler.with_unbundled_env do
         Dir.chdir(path) do
           system(bundler_cmd)
           system(rake_cmd)
@@ -69,7 +69,7 @@ describe "Pack the dependencies", :integration => true do
       FileUtils.rm_rf(bundler_config)
       FileUtils.rm_rf(vendor_path)
 
-      Bundler.with_clean_env do
+      Bundler.with_unbundled_env do
         Dir.chdir(path) do
           system(bundler_cmd)
           system(rake_cmd)


### PR DESCRIPTION
Backport PR #12615 to 7.x branch. Original message: 

> 13:41:15     [DEPRECATED] `Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env` (called at /opt/logstash/qa/integration/services/logstash_service.rb:248)


## What does this PR do?

Replace instances of `with_clean_env` with `with_unbundled_env`