### PR TITLE
Backport PR #12617 to 7.11: fix url for kafka and bump to 2.7.0

### DIFF
--- a/qa/integration/services/kafka_setup.sh
+++ b/qa/integration/services/kafka_setup.sh
@@ -10,7 +10,7 @@ if [ -n "${KAFKA_VERSION+1}" ]; then
     echo "KAFKA_VERSION is $KAFKA_VERSION"
     version=$KAFKA_VERSION
 else
-    version=2.4.1
+    version=2.7.0
 fi
 
 KAFKA_HOME=$INSTALL_DIR/kafka
@@ -23,7 +23,7 @@ setup_kafka() {
     local version=$1
     if [ ! -d $KAFKA_HOME ]; then
         echo "Downloading Kafka version $version"
-        curl -s -o $INSTALL_DIR/kafka.tgz "https://mirrors.ocf.berkeley.edu/apache/kafka/$version/kafka_2.11-$version.tgz"
+        curl -s -o $INSTALL_DIR/kafka.tgz "https://downloads.apache.org/kafka/$version/kafka_2.13-$version.tgz"
         mkdir $KAFKA_HOME && tar xzf $INSTALL_DIR/kafka.tgz -C $KAFKA_HOME --strip-components 1
         rm $INSTALL_DIR/kafka.tgz
         echo "dataDir=$ZOOKEEPER_DATA_DIR" >> $KAFKA_HOME/config/zookeeper.properties


### PR DESCRIPTION
Backport PR #12617 to 7.11 branch. Original message: 

## What does this PR do?

Bump testing of kafka integration to 2.7.0 and also change location of kafka artifacts as berkeley mirror seems to be down.

## Logs

Test failure https://logstash-ci.elastic.co/job/elastic+logstash+master+multijob-integration-1/469/consoleFull

```
17:35:18 + echo 'Downloading Kafka version 2.4.1'
17:35:18 + curl -s -o /opt/logstash/qa/integration/services/installed/kafka.tgz https://mirrors.ocf.berkeley.edu/apache/kafka/2.4.1/kafka_2.11-2.4.1.tgz
17:35:18       can ingest 37 apache log lines from Kafka broker (FAILED - 1)
17:35:18 
17:35:18     CLI >
17:35:18 + mkdir /opt/logstash/qa/integration/services/installed/kafka
17:35:18 + tar xzf /opt/logstash/qa/integration/services/installed/kafka.tgz -C /opt/logstash/qa/integration/services/installed/kafka --strip-components 1
17:35:18 
17:35:18 gzip: stdin: not in gzip format
```