### PR TITLE
Backport PR #12626 to 7.11: use correct headers api for redirects in plugin manager http client

### DIFF
--- a/lib/pluginmanager/utils/http_client.rb
+++ b/lib/pluginmanager/utils/http_client.rb
@@ -52,7 +52,7 @@ module LogStash module PluginManager module Utils
         response = http.request(request)
 
         if response.code == "302"
-          new_uri = response.headers["location"]
+          new_uri = response["location"]
           remote_file_exist?(new_uri, redirect_count + 1)
         elsif response.code == "200"
           true

--- a/spec/unit/plugin_manager/utils/http_client_spec.rb
+++ b/spec/unit/plugin_manager/utils/http_client_spec.rb
@@ -16,6 +16,7 @@
 # under the License.
 
 require "pluginmanager/utils/http_client"
+require "net/http"
 require "uri"
 
 describe LogStash::PluginManager::Utils::HttpClient do
@@ -104,9 +105,13 @@ describe LogStash::PluginManager::Utils::HttpClient do
       end
 
       context "with redirects" do
-        let(:redirect_response) { instance_double("Net::HTTP::Response", :code => "302", :headers => { "location" => "https://localhost:8888/new_path" }) }
+        let(:location) { "https://localhost:8888/new_path" }
+        let(:redirect_response) { instance_double("Net::HTTP::Response", :code => "302", :headers => { "location" => location }) }
         let(:response_ok) { instance_double("Net::HTTP::Response", :code => "200") }
 
+        before(:each) do
+          allow(redirect_response).to receive(:[]).with("location").and_return(location)
+        end
         it "follow 1 level redirect" do
           expect(mock_http).to receive(:request).with(kind_of(Net::HTTP::Head)).and_return(redirect_response)
           expect(mock_http).to receive(:request).with(kind_of(Net::HTTP::Head)).and_return(response_ok)


### PR DESCRIPTION
Backport PR #12626 to 7.11 branch. Original message: 

## What does this PR do?

The plugin manager's http client was using an obsolete way to read headers, causing the plugin test to fail.

This PR changes to the right api: [`#[]`](https://www.rubydoc.info/stdlib/net/Net/HTTPHeader#[]-instance_method).