### PR TITLE
Backport of #12614 [Doc] added instruction on how to update log and jvm files

### DIFF
--- a/docs/static/jvm.asciidoc
+++ b/docs/static/jvm.asciidoc
@@ -6,7 +6,7 @@
 
 * Java 8
 * Java 11
-* Java 14
+* Java 15 (see <<jdk15-upgrade>> for settings info)
 
 Use the
 http://www.oracle.com/technetwork/java/javase/downloads/index.html[official
@@ -59,3 +59,63 @@ a tarball.
 install the correct startup method (SysV init scripts, Upstart, or systemd). If
 {ls} is unable to find the `JAVA_HOME` environment variable during package
 installation, you may get an error message, and {ls} will not start properly.
+
+[float]
+[[jdk15-upgrade]]
+==== Using JDK 15
+
+{ls} supports JDK 15, but you need to update settings in `jvm.options` and
+`log4j2.properties` if: 
+
+* you are upgrading from  {ls} 7.11.x (or earlier) to 7.12 or later, and
+* you are using JDK 15 or later.
+
+[float]
+===== Updates to `jvm.options`
+In the `config/jvm.options` file, replace all CMS related flags with:
+
+[source,shell]
+-----
+## GC configuration
+8-14:-XX:+UseConcMarkSweepGC
+8-14:-XX:CMSInitiatingOccupancyFraction=75
+8-14:-XX:+UseCMSInitiatingOccupancyOnly
+-----
+
+For more information about how to use `jvm.options`, please refer to <<jvm-settings>>.
+
+[float]
+===== Updates to `log4j2.properties`
+In the `config/log4j2.properties`:
+
+* Replace properties that start with `appender.rolling.avoid_pipelined_filter.*` with: 
++
+[source,shell]
+-----
+appender.rolling.avoid_pipelined_filter.type = PipelineRoutingFilter
+-----
+
+* Replace properties that start with `appender.json_rolling.avoid_pipelined_filter.*` with:
+[source,shell]
++
+-----
+appender.json_rolling.avoid_pipelined_filter.type = PipelineRoutingFilter
+-----
+
+* Replace properties that start with `appender.routing.*` with:
+[source,shell]
++
+-----
+appender.routing.type = PipelineRouting
+appender.routing.name = pipeline_routing_appender
+appender.routing.pipeline.type = RollingFile
+appender.routing.pipeline.name = appender-${ctx:pipeline.id}
+appender.routing.pipeline.fileName = ${sys:ls.logs}/pipeline_${ctx:pipeline.id}.log
+appender.routing.pipeline.filePattern = ${sys:ls.logs}/pipeline_${ctx:pipeline.id}.%i.log.gz
+appender.routing.pipeline.layout.type = PatternLayout
+appender.routing.pipeline.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %m%n
+appender.routing.pipeline.policy.type = SizeBasedTriggeringPolicy
+appender.routing.pipeline.policy.size = 100MB
+appender.routing.pipeline.strategy.type = DefaultRolloverStrategy
+appender.routing.pipeline.strategy.max = 30
+-----


### PR DESCRIPTION
Backport of #12614 to `7.x` without the accidental removals fixed with #12631