### PR TITLE
Update docker container tests to handle jvm option parser

### DIFF
--- a/qa/docker/shared_examples/container.rb
+++ b/qa/docker/shared_examples/container.rb
@@ -70,6 +70,10 @@ shared_examples_for 'the container is configured correctly' do |flavor|
   end
 
   context 'the java process' do
+    before do
+      wait_for_logstash(@container)
+    end
+
     it 'should be running under the logstash user' do
       expect(java_process(@container, "user")).to eql 'logstash'
     end


### PR DESCRIPTION
Docker container integration tests relating to the java process were
failing due to the introduction of the new JVM option parser. This
commit waits for logstash to start before testing that the logstash
java process is being run as expected

