### PR TITLE
Update dockerfile template to allow selection of architecture by env

### DIFF
--- a/docker/templates/Dockerfile.j2
+++ b/docker/templates/Dockerfile.j2
@@ -6,10 +6,10 @@
 {% endif -%}
 
 {% if image_flavor == 'oss' -%}
-  {% set tarball = 'logstash-oss-%s-linux-%s.tar.gz' % (elastic_version, arch) -%}
+  {% set tarball = 'logstash-oss-%s-linux-$(arch).tar.gz' % (elastic_version) -%}
   {% set license = 'Apache 2.0' -%}
 {% else -%}
-  {% set tarball = 'logstash-%s-linux-%s.tar.gz' % (elastic_version, arch) -%}
+  {% set tarball = 'logstash-%s-linux-$(arch).tar.gz' % (elastic_version) -%}
   {% set license = 'Elastic License' -%}
 {% endif -%}
 


### PR DESCRIPTION
This commit updates the dockerfile template to support environment
variables being used to retrieve the architecture appropriate logstash
build, in the same way as is currently done for the Elasticsearch docker build.
This is required to support the official dockerhub builds of Logstash.

Relates #12578
