### PR TITLE
remove CMS from jvm options for java 14

### DIFF
--- a/config/jvm.options
+++ b/config/jvm.options
@@ -17,9 +17,9 @@
 ################################################################
 
 ## GC configuration
-8-14:-XX:+UseConcMarkSweepGC
-8-14:-XX:CMSInitiatingOccupancyFraction=75
-8-14:-XX:+UseCMSInitiatingOccupancyOnly
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
 
 ## Locale
 # Set the locale language

--- a/docs/static/jvm.asciidoc
+++ b/docs/static/jvm.asciidoc
@@ -77,9 +77,9 @@ In the `config/jvm.options` file, replace all CMS related flags with:
 [source,shell]
 -----
 ## GC configuration
-8-14:-XX:+UseConcMarkSweepGC
-8-14:-XX:CMSInitiatingOccupancyFraction=75
-8-14:-XX:+UseCMSInitiatingOccupancyOnly
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
 -----
 
 For more information about how to use `jvm.options`, please refer to <<jvm-settings>>.


### PR DESCRIPTION
This PR is to remove CMS configuration in java 14

CMS collector is [no longer available](https://openjdk.java.net/jeps/363) in 14, however, the doc and jvm options are suggesting to use `-XX:+UseConcMarkSweepGC`
