### PR TITLE
[7.x] remove CMS from jvm options in java 14 (#12638)

### DIFF
--- a/config/jvm.options
+++ b/config/jvm.options
@@ -17,9 +17,9 @@
 ################################################################
 
 ## GC configuration
-8-14:-XX:+UseConcMarkSweepGC
-8-14:-XX:CMSInitiatingOccupancyFraction=75
-8-14:-XX:+UseCMSInitiatingOccupancyOnly
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
 
 ## Locale
 # Set the locale language

--- a/docs/static/jvm.asciidoc
+++ b/docs/static/jvm.asciidoc
@@ -77,9 +77,9 @@ In the `config/jvm.options` file, replace all CMS related flags with:
 [source,shell]
 -----
 ## GC configuration
-8-14:-XX:+UseConcMarkSweepGC
-8-14:-XX:CMSInitiatingOccupancyFraction=75
-8-14:-XX:+UseCMSInitiatingOccupancyOnly
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
 -----
 
 For more information about how to use `jvm.options`, please refer to <<jvm-settings>>.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - remove CMS from jvm options in java 14 (#12638)