### PR TITLE
[7.x] Fix showing deprecation warning of command line flags (#12592)

### DIFF
--- a/logstash-core/lib/logstash/deprecation_message.rb
+++ b/logstash-core/lib/logstash/deprecation_message.rb
@@ -1,0 +1,31 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'singleton'
+
+###
+# This is a place for storing deprecation message which cannot deliver to user before log4j initialization.
+# eg. command line flags deprecation warning. `bin/logstash --debug`
+module LogStash
+  class DeprecationMessage < Array
+    include Singleton
+
+    def self.instance
+      @@instance ||= Array.new
+    end
+  end
+end

--- a/logstash-core/lib/logstash/patches/clamp.rb
+++ b/logstash-core/lib/logstash/patches/clamp.rb
@@ -17,6 +17,7 @@
 
 require 'clamp'
 require 'logstash/environment'
+require 'logstash/deprecation_message'
 
 module Clamp
   module Attribute
@@ -77,7 +78,7 @@ module Clamp
 
       def define_deprecated_writer_for(option, opts, &block)
         define_method(option.write_method) do |value|
-          self.class.logger.warn "DEPRECATION WARNING: The flag #{option.switches} has been deprecated, please use \"--#{opts[:new_flag]}=#{opts[:new_value]}\" instead."
+          LogStash::DeprecationMessage.instance << "DEPRECATION WARNING: The flag #{option.switches} has been deprecated, please use \"--#{opts[:new_flag]}=#{opts[:new_value]}\" instead."
           LogStash::SETTINGS.set(opts[:new_flag], opts[:new_value])
         end
       end

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -51,6 +51,7 @@ require "logstash/modules/util"
 require "logstash/bootstrap_check/default_config"
 require "logstash/bootstrap_check/persisted_queue_config"
 require "set"
+require 'logstash/deprecation_message'
 
 java_import 'org.logstash.FileLockFactory'
 
@@ -302,6 +303,10 @@ class LogStash::Runner < Clamp::StrictCommand
 
     if setting("config.debug") && !logger.debug?
       logger.warn("--config.debug was specified, but log.level was not set to \'debug\'! No config info will be logged.")
+    end
+
+    while(msg = LogStash::DeprecationMessage.instance.shift)
+      logger.warn msg
     end
 
     # Skip any validation and just return the version


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix showing deprecation warning of command line flags (#12592)