### PR TITLE
[doc] Add example to cross-plugin-concepts

### DIFF
--- a/docs/static/cross-plugin-concepts.asciidoc
+++ b/docs/static/cross-plugin-concepts.asciidoc
@@ -10,8 +10,15 @@ List-type URI parameters will automatically expand strings that contain multiple
 whitespace-delimited URIs into separate entries. This behaviour enables the expansion
 of an arbitrary list of URIs from a single Environment- or Keystore-variable.
 
-Examples of plugins and options that support this functionality:
+The following plugins and options support this functionality:
 
 * <<plugins-inputs-elasticsearch-hosts,Elasticsearch input plugin - `hosts`>>
 * <<plugins-outputs-elasticsearch-hosts,Elasticsearch output plugin - `hosts`>>
 * <<plugins-filters-elasticsearch-hosts,Elasticsearch filter plugin - `hosts`>>
+
+For example, this functionality allows users to define an environment variable
+multiple whitespace-delimited URIs to define the hosts the plugins will use:
+
+```
+ES_HOSTS="es1.example.com es2.example.com:9201 es3.example.com:9201"
+```

--- a/docs/static/cross-plugin-concepts.asciidoc
+++ b/docs/static/cross-plugin-concepts.asciidoc
@@ -10,7 +10,7 @@ List-type URI parameters will automatically expand strings that contain multiple
 whitespace-delimited URIs into separate entries. This behaviour enables the expansion
 of an arbitrary list of URIs from a single Environment- or Keystore-variable.
 
-The following plugins and options support this functionality:
+These plugins and options support this functionality:
 
 * <<plugins-inputs-elasticsearch-hosts,Elasticsearch input plugin - `hosts`>>
 * <<plugins-outputs-elasticsearch-hosts,Elasticsearch output plugin - `hosts`>>

--- a/docs/static/cross-plugin-concepts.asciidoc
+++ b/docs/static/cross-plugin-concepts.asciidoc
@@ -20,3 +20,7 @@ You can use this functionality to define an environment variable with
 multiple whitespace-delimited URIs and use it for the options above.
 
 **Example**
+
+```
+ES_HOSTS="es1.example.com es2.example.com:9201 es3.example.com:9201"
+```

--- a/docs/static/cross-plugin-concepts.asciidoc
+++ b/docs/static/cross-plugin-concepts.asciidoc
@@ -16,8 +16,8 @@ The following plugins and options support this functionality:
 * <<plugins-outputs-elasticsearch-hosts,Elasticsearch output plugin - `hosts`>>
 * <<plugins-filters-elasticsearch-hosts,Elasticsearch filter plugin - `hosts`>>
 
-For example, this functionality allows users to define an environment variable
-multiple whitespace-delimited URIs to define the hosts the plugins will use:
+For example, users use this functionality to define an environment variable with
+multiple whitespace-delimited URIs to use it for the options above, e.g.:
 
 ```
 ES_HOSTS="es1.example.com es2.example.com:9201 es3.example.com:9201"

--- a/docs/static/cross-plugin-concepts.asciidoc
+++ b/docs/static/cross-plugin-concepts.asciidoc
@@ -16,9 +16,7 @@ These plugins and options support this functionality:
 * <<plugins-outputs-elasticsearch-hosts,Elasticsearch output plugin - `hosts`>>
 * <<plugins-filters-elasticsearch-hosts,Elasticsearch filter plugin - `hosts`>>
 
-For example, users use this functionality to define an environment variable with
-multiple whitespace-delimited URIs to use it for the options above, e.g.:
+You can use this functionality to define an environment variable with
+multiple whitespace-delimited URIs and use it for the options above.
 
-```
-ES_HOSTS="es1.example.com es2.example.com:9201 es3.example.com:9201"
-```
+**Example**


### PR DESCRIPTION
Adds an example showing users how to use the environment variable to define multiple whitespace-delimited URIs

## What does this PR do?

Adds an example of how to use this functionality in an environment variable.

## Why is it important/What is the impact to the user?

It is important because the current documentation is not clear enough and is confusing users as to how to use this behavior.

## Checklist

- [ ] ~My code follows the style guidelines of this project~
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] I have made corresponding changes to the documentation
- [ ] ~I have made corresponding change to the default configuration files (and/or docker env variables)~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~

## Related issues

Closes #12661

