### PR TITLE
Make integration test fail if 'offline' tool can't be compiled

### DIFF
--- a/qa/integration/specs/cli/install_spec.rb
+++ b/qa/integration/specs/cli/install_spec.rb
@@ -22,6 +22,7 @@ require_relative "../../framework/helpers"
 require "logstash/devutils/rspec/spec_helper"
 require "stud/temporary"
 require "fileutils"
+require "open3"
 
 def gem_in_lock_file?(pattern, lock_file)
   content =  File.read(lock_file)
@@ -51,7 +52,13 @@ describe "CLI > logstash-plugin install" do
         before do
           Dir.chdir(offline_wrapper_path) do
             system("make clean")
-            system("make")
+            stdout_str, stderr_str, status = Open3.capture3("make")
+            unless status.success?
+              puts "ERROR in compiling 'offline' tool"
+              puts "STDOUT: #{stdout_str}"
+              puts "STDERR: #{stderr_str}"
+            end
+            expect(status.success?).to be(true)
           end
         end
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## What does this PR do?
On certain instances of centos6 on the ci (https://logstash-ci.elastic.co/job/elastic+logstash+master+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA=adoptopenjdk15,os=centos&&immutable/23/consoleFull)  the build fails with:
```
09:36:18       1) CLI > logstash-plugin install pack when the command is run outside of the `$LOGSTASH_HOME` without internet connection (linux seccomp wrapper) successfully install the pack
09:36:18          Failure/Error: execute = @logstash_plugin.run_raw("#{offline_wrapper_cmd} #{install_command} #{pack}", change_dir)
09:36:18          
09:36:18          ChildProcess::LaunchError:
09:36:18            Cannot run program "/var/lib/jenkins/workspace/elastic+logstash+master+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptopenjdk15/os/centos&&immutable/qa/integration/fixtures/offline_wrapper/offline" (in directory "/tmp/studtmp-c85f61b981777c669691bf8d7d66d7df08a43e001c3e08074e9b08a21d71"): error=2, No such file or directory
09:36:18          Shared Example Group: "install from a pack" called from /var/lib/jenkins/workspace/elastic+logstash+master+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptopenjdk15/os/centos&&immutable/qa/integration/specs/cli/install_spec.rb:96
09:36:18          # /var/lib/jenkins/workspace/elastic+logstash+master+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptopenjdk15/os/centos&&immutable/build/qa/integration/vendor/jruby/2.5.0/gems/childprocess-0.9.0/lib/childprocess/jruby/process.rb:80:in `launch_process'
09:36:18          # /var/lib/jenkins/workspace/elastic+logstash+master+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptopenjdk15/os/centos&&immutable/build/qa/integration/vendor/jruby/2.5.0/gems/childprocess-0.9.0/lib/childprocess/abstract_process.rb:81:in `start'
09:36:18          # /var/lib/jenkins/workspace/elastic+logstash+master+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptopenjdk15/os/centos&&immutable/qa/integration/services/logstash_service.rb:254:in `block in run_cmd'
09:36:18          # /var/lib/jenkins/workspace/elastic+logstash+master+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptopenjdk15/os/centos&&immutable/build/qa/integration/vendor/jruby/2.5.0/gems/bundler-2.2.10/lib/bundler.rb:395:in `block in with_unbundled_env'
09:36:18          # /var/lib/jenkins/workspace/elastic+logstash+master+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptopenjdk15/os/centos&&immutable/build/qa/integration/vendor/jruby/2.5.0/gems/bundler-2.2.10/lib/bundler.rb:701:in `with_env'
09:36:18          # /var/lib/jenkins/workspace/elastic+logstash+master+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptopenjdk15/os/centos&&immutable/build/qa/integration/vendor/jruby/2.5.0/gems/bundler-2.2.10/lib/bundler.rb:395:in `with_unbundled_env'
09:36:18          # /var/lib/jenkins/workspace/elastic+logstash+master+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptopenjdk15/os/centos&&immutable/qa/integration/services/logstash_service.rb:248:in `run_cmd'
09:36:18          # /var/lib/jenkins/workspace/elastic+logstash+master+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptopenjdk15/os/centos&&immutable/qa/integration/services/logstash_service.rb:305:in `run_raw'
09:36:18          # /var/lib/jenkins/workspace/elastic+logstash+master+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptopenjdk15/os/centos&&immutable/qa/integration/specs/cli/install_spec.rb:61:in `block in <main>'
09:36:18          # /var/lib/jenkins/workspace/elastic+logstash+master+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptopenjdk15/os/centos&&immutable/build/qa/integration/vendor/jruby/2.5.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block in <main>'
09:36:18          # /var/lib/jenkins/workspace/elastic+logstash+master+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptopenjdk15/os/centos&&immutable/qa/integration/rspec.rb:32:in `<main>'
09:36:18          # ------------------
09:36:18          # --- Caused by: ---
09:36:18          # Java::JavaIo::IOException:
09:36:18          #   error=2, No such file or directory
09:36:18          #   java.base/java.lang.ProcessImpl.forkAndExec(Native Method)
```

The reason is due to not existence of the `offline` executable under `qa/integration/fixtures/offline_wrapper/`.
The `offline` is built during the test executing `make` https://github.com/elastic/logstash/blob/0d6666b1da8cf415630ce12701ded78f4a3fbf21/qa/integration/specs/cli/install_spec.rb#L52-L55.
The problem is that if the `make` fails we don't know it.

This PR in case of failed `make` fails the test, printing on the console the stderr of the make command.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

## Why is it important/What is the impact to the user?
It's useful for the developer or the CI because in case of copilation problems it make the test fails early and print usefull logs about the problem.

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## How to test this PR locally
Use a centos6 with the kernel compiled without `seccomp` or a centos6 without kernel-devel and kernel-headers and run:
```
./gradlew runIntegrationTests -PrubyIntegrationSpecs=specs/cli/install_spec.rb
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


