### PR TITLE
Make integration test fail if 'offline' tool can't be compiled

### DIFF
--- a/qa/integration/specs/cli/install_spec.rb
+++ b/qa/integration/specs/cli/install_spec.rb
@@ -22,6 +22,7 @@ require_relative "../../framework/helpers"
 require "logstash/devutils/rspec/spec_helper"
 require "stud/temporary"
 require "fileutils"
+require "open3"
 
 def gem_in_lock_file?(pattern, lock_file)
   content =  File.read(lock_file)
@@ -51,7 +52,13 @@ describe "CLI > logstash-plugin install" do
         before do
           Dir.chdir(offline_wrapper_path) do
             system("make clean")
-            system("make")
+            stdout_str, stderr_str, status = Open3.capture3("make")
+            unless status.success?
+              puts "ERROR in compiling 'offline' tool"
+              puts "STDOUT: #{stdout_str}"
+              puts "STDERR: #{stderr_str}"
+            end
+            expect(status.success?).to be(true)
           end
         end
 


### PR DESCRIPTION
Clean backport of #12678 to `7.x`

(cherry picked from commit 042d0d466b11122339e24fac7d24bb43259a7277)

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->
