### PR TITLE
Fix Elasticsearch/DLQ integration test flakiness

### DIFF
--- a/qa/integration/services/elasticsearch_service.rb
+++ b/qa/integration/services/elasticsearch_service.rb
@@ -23,7 +23,6 @@ class ElasticsearchService < Service
   end
 
   def get_client
-    Elasticsearch::Client.new(:hosts => "localhost:9200")
+    @client ||= Elasticsearch::Client.new(:hosts => "localhost:9200")
   end
-
 end

--- a/qa/integration/specs/dlq_spec.rb
+++ b/qa/integration/specs/dlq_spec.rb
@@ -35,19 +35,21 @@ describe "Test Dead Letter Queue" do
 
   before(:all) {
     @fixture = Fixture.new(__FILE__)
+    es_allow_wildcard_deletes(@fixture.get_service("elasticsearch").get_client)
   }
 
   after(:all) {
-      @fixture.teardown
+    clean_es(@fixture.get_service("elasticsearch").get_client)
+    @fixture.teardown
   }
 
   before(:each) {
     IO.write(config_yaml_file, config_yaml)
+    clean_es(@fixture.get_service("elasticsearch").get_client)
   }
 
+
   after(:each) do
-    es_client = @fixture.get_service("elasticsearch").get_client
-    es_client.indices.delete(index: 'logstash-*') unless es_client.nil?
     logstash_service.teardown
   end
 
@@ -57,7 +59,6 @@ describe "Test Dead Letter Queue" do
       {
           "dead_letter_queue.enable" => true,
           "path.dead_letter_queue" => dlq_dir,
-          "log.level" => "debug"
       }
   }
   let!(:config_yaml) { dlq_config.to_yaml }
@@ -95,7 +96,7 @@ describe "Test Dead Letter Queue" do
 
     before :each do
       IO.write(pipelines_yaml_file, pipelines_yaml)
-      logstash_service.spawn_logstash("--path.settings", settings_dir, "--log.level=debug")
+      logstash_service.spawn_logstash("--path.settings", settings_dir)
     end
 
     context 'with multiple pipelines' do

--- a/qa/integration/specs/es_output_how_spec.rb
+++ b/qa/integration/specs/es_output_how_spec.rb
@@ -24,11 +24,11 @@ describe "Test Elasticsearch output" do
 
   before(:all) {
     @fixture = Fixture.new(__FILE__)
+    es_allow_wildcard_deletes(@fixture.get_service("elasticsearch").get_client)
   }
 
   after(:all) {
-    es_client = @fixture.get_service("elasticsearch").get_client
-    es_client.indices.delete(index: 'logstash-*')
+    clean_es(@fixture.get_service("elasticsearch").get_client)
     @fixture.teardown
   }
 


### PR DESCRIPTION
This commit fixes up some IT flakiness which has been presenting mostly
in recent DLQ test failures, it includes the following improvements:

 * A recent change to Elasticsearch has required the cluster setting
`action.destructive_requires_name` to be set to `false` to enable the use
of destruction actions with wildcards. This commit sets this before
tests on Elasticsearch and DLQ tests
 * Adds some extra safety to the `have_hits` rspec matcher
 * Makes the DLQ tests less noisy by removing debug flag
