### PR TITLE
GeoIP clean up database after new download

### DIFF
--- a/x-pack/lib/filters/geoip/database_manager.rb
+++ b/x-pack/lib/filters/geoip/database_manager.rb
@@ -78,6 +78,7 @@ module LogStash module Filters module Geoip class DatabaseManager
     begin
       if execute_download_job
         @geoip.setup_filter(database_path)
+        clean_up_database
       end
     rescue DatabaseExpiryError => e
       logger.error(e.message, :cause => e.cause, :backtrace => e.backtrace)

--- a/x-pack/lib/filters/geoip/database_metadata.rb
+++ b/x-pack/lib/filters/geoip/database_metadata.rb
@@ -28,13 +28,11 @@ module LogStash module Filters module Geoip class DatabaseMetadata
       metadata.each { |row| csv << row }
     end
 
-    @cache = metadata
     logger.debug("metadata updated", :metadata => metadata)
   end
 
   def get_all
-    @cache ||= file_exist?(@metadata_path)?
-                 ::CSV.read(@metadata_path, headers: false) : Array.new
+    file_exist?(@metadata_path)? ::CSV.read(@metadata_path, headers: false) : Array.new
   end
 
   # Give rows of metadata in default database type, or empty array

--- a/x-pack/lib/filters/geoip/database_metadata.rb
+++ b/x-pack/lib/filters/geoip/database_metadata.rb
@@ -28,11 +28,13 @@ module LogStash module Filters module Geoip class DatabaseMetadata
       metadata.each { |row| csv << row }
     end
 
+    @cache = metadata
     logger.debug("metadata updated", :metadata => metadata)
   end
 
   def get_all
-    file_exist?(@metadata_path)? ::CSV.read(@metadata_path, headers: false) : Array.new
+    @cache ||= file_exist?(@metadata_path)?
+                 ::CSV.read(@metadata_path, headers: false) : Array.new
   end
 
   # Give rows of metadata in default database type, or empty array

--- a/x-pack/lib/filters/geoip/download_manager.rb
+++ b/x-pack/lib/filters/geoip/download_manager.rb
@@ -82,8 +82,8 @@ module LogStash module Filters module Geoip class DownloadManager
 
   def rest_client
     @client ||= Faraday.new do |conn|
-      conn.adapter :net_http
       conn.use Faraday::Response::RaiseError
+      conn.adapter :net_http
     end
   end
 

--- a/x-pack/spec/filters/geoip/database_manager_spec.rb
+++ b/x-pack/spec/filters/geoip/database_manager_spec.rb
@@ -22,6 +22,11 @@ module LogStash module Filters module Geoip
     let(:logger) { double("Logger") }
 
     context "patch database" do
+      it "use input path" do
+        path = db_manager.send(:patch_database_path, DEFAULT_ASN_DB_PATH)
+        expect(path).to eq(DEFAULT_ASN_DB_PATH)
+      end
+
       it "use CC license database as default" do
         path = db_manager.send(:patch_database_path, "")
         expect(path).to eq(DEFAULT_CITY_DB_PATH)

--- a/x-pack/spec/filters/geoip/download_manager_spec.rb
+++ b/x-pack/spec/filters/geoip/download_manager_spec.rb
@@ -105,15 +105,15 @@ module LogStash module Filters module Geoip
       end
     end
 
-    # context "assert database" do
-    #   it "should raise error if file is invalid" do
-    #     expect{ download_manager.send(:assert_database!, "Gemfile") }.to raise_error /failed to load database/
-    #   end
-    #
-    #   it "should pass validation" do
-    #     expect(download_manager.send(:assert_database!, DEFAULT_CITY_DB_PATH)).to be_nil
-    #   end
-    # end
+    context "assert database" do
+      it "should raise error if file is invalid" do
+        expect{ download_manager.send(:assert_database!, "Gemfile") }.to raise_error /failed to load database/
+      end
+
+      it "should pass validation" do
+        expect(download_manager.send(:assert_database!, DEFAULT_CITY_DB_PATH)).to be_nil
+      end
+    end
 
     context "fetch database" do
       it "should be false if no update" do


### PR DESCRIPTION
This PR adds a clean-up step after a new GeoIP database download.
After pointing to new database, database_manager removes .gz and .mmdb which is not in the metadata.

- add clean-up database
- improve log

#### Related issues
Logstash PR https://github.com/elastic/logstash/pull/12675
Meta https://github.com/elastic/logstash/issues/12560