### PR TITLE
Backport PR #12693 to 7.12: update jdk to 11.0.10+9

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -7,8 +7,8 @@ logstash-core-plugin-api: 2.1.16
 bundled_jdk:
   # for AdoptOpenJDK/OpenJDK jdk-14.0.1+7.1, the revision is 14.0.1 while the build is 7.1
   vendor: "adoptopenjdk"
-  revision: 11.0.8
-  build: 10
+  revision: 11.0.10
+  build: 9
 
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time


### PR DESCRIPTION
Backport PR #12693 to 7.12 branch. Original message: 

## What does this PR do?

Update adoptopenjdk version to 11.0.10+9