### PR TITLE
[backport 7.x] Removed OpenJDK15 in CI matrix testing #12649

### DIFF
--- a/.ci/matrix-runtime-javas.yml
+++ b/.ci/matrix-runtime-javas.yml
@@ -7,8 +7,10 @@
 LS_RUNTIME_JAVA:
   - java8
   - openjdk11
-  - openjdk15
+  - openjdk14
   - adoptopenjdk11
   - adoptopenjdk14
+  - adoptopenjdk15
   - zulu11
   - zulu14
+  - zulu15


### PR DESCRIPTION
Add AdoptOpenJDK15 and Zulu15 to CI matrix

Backport of #12649

(cherry picked from commit 0d6666b1da8cf415630ce12701ded78f4a3fbf21)
