### PR TITLE
Doc: Add unix command for running basic pipeline

### DIFF
--- a/docs/static/getting-started-with-logstash.asciidoc
+++ b/docs/static/getting-started-with-logstash.asciidoc
@@ -307,7 +307,7 @@ bin/logstash -e 'input { stdin { } } output { stdout {} }'
 ["source","sh",subs="attributes"]
 --------------------------------------------------
 cd logstash-{logstash_version}
-\bin\logstash.bat -e "input { stdin { } } output { stdout {} }"
+.\bin\logstash.bat -e "input { stdin { } } output { stdout {} }"
 --------------------------------------------------
 
 The command might vary slightly, depending on the terminal or shell you

--- a/docs/static/getting-started-with-logstash.asciidoc
+++ b/docs/static/getting-started-with-logstash.asciidoc
@@ -292,17 +292,30 @@ the data to a destination.
 
 image::static/images/basic_logstash_pipeline.png[]
 
-To test your Logstash installation, run the most basic Logstash pipeline. For
-example:
+To test your Logstash installation, run the most basic Logstash pipeline. 
+
+**MacOS, Linux**
 
 ["source","sh",subs="attributes"]
 --------------------------------------------------
 cd logstash-{logstash_version}
-bin/logstash -e "input { stdin { } } output { stdout {} }"
+bin/logstash -e 'input { stdin { } } output { stdout {} }'
 --------------------------------------------------
 
-NOTE: The location of the `bin` directory varies by platform. See {logstash-ref}/dir-layout.html[Directory layout]
-to find the location of `bin\logstash` on your system.
+**Windows**
+
+["source","sh",subs="attributes"]
+--------------------------------------------------
+cd logstash-{logstash_version}
+\bin\logstash.bat -e "input { stdin { } } output { stdout {} }"
+--------------------------------------------------
+
+The command might vary slightly, depending on the terminal or shell you
+are using.
+
+NOTE: The location of the `bin` directory varies by platform. See
+{logstash-ref}/dir-layout.html[Directory layout] to find the location of
+`bin\logstash` on your system.
 
 [IMPORTANT]
 .macOS Gatekeeper warnings


### PR DESCRIPTION
PR #12706 added the windows command.  This PR adds the framework for showing both windows and unix examples. 

**PREVIEW:**  https://logstash_12714.docs-preview.app.elstc.co/guide/en/logstash/master/first-event.html