### PR TITLE
[backport #12444 7.11] Separate "not terminated" pipeline state into "running" and "loading".

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -288,6 +288,10 @@ class LogStash::Agent
     @pipelines_registry.running_pipelines
    end
 
+   def loading_pipelines
+    @pipelines_registry.loading_pipelines
+   end
+
   def non_running_pipelines
     @pipelines_registry.non_running_pipelines
   end

--- a/logstash-core/lib/logstash/pipelines_registry.rb
+++ b/logstash-core/lib/logstash/pipelines_registry.rb
@@ -35,6 +35,19 @@ module LogStash
       end
     end
 
+    def running?
+      @lock.synchronize do
+        # not terminated and not loading
+        @loading.false? && !@pipeline.finished_execution?
+      end
+    end
+
+    def loading?
+      @lock.synchronize do
+        @loading.true?
+      end
+    end
+
     def set_loading(is_loading)
       @lock.synchronize do
         @loading.value = is_loading
@@ -253,7 +266,11 @@ module LogStash
 
     # @return [Hash{String=>Pipeline}]
     def running_pipelines
-      select_pipelines { |state| !state.terminated? }
+      select_pipelines { |state| state.running? }
+    end
+
+    def loading_pipelines
+      select_pipelines { |state| state.loading? }
     end
 
     # @return [Hash{String=>Pipeline}]

--- a/logstash-core/spec/support/matchers.rb
+++ b/logstash-core/spec/support/matchers.rb
@@ -95,7 +95,7 @@ RSpec::Matchers.define :have_running_pipeline? do |pipeline_config|
       expect(pipeline.running?).to be_truthy
     end
     expect(pipeline.config_str).to eq(pipeline_config.config_string)
-    expect(agent.running_pipelines.keys.map(&:to_s)).to include(pipeline_config.pipeline_id.to_s)
+    expect(agent.running_pipelines.keys.map(&:to_s) + agent.loading_pipelines.keys.map(&:to_s)).to include(pipeline_config.pipeline_id.to_s)
   end
 
   failure_message do |agent|
@@ -108,6 +108,10 @@ RSpec::Matchers.define :have_running_pipeline? do |pipeline_config|
         "Found '#{pipeline_config.pipeline_id.to_s}' in the list of pipelines but its not running"
       elsif pipeline.config_str != pipeline_config.config_string
         "Found '#{pipeline_config.pipeline_id.to_s}' in the list of pipelines and running, but the config_string doesn't match,\nExpected:\n#{pipeline_config.config_string}\n\ngot:\n#{pipeline.config_str}"
+      elsif agent.running_pipelines.keys.map(&:to_s).include?(pipeline_config.pipeline_id.to_s)
+        "Found '#{pipeline_config.pipeline_id.to_s}' in running but not included in the list of agent.running_pipelines or agent.loading_pipelines"
+      else
+        "Unrecognized error condition, probably you missed to track properly a newly added expect in :have_running_pipeline?"
       end
     end
   end


### PR DESCRIPTION
Clean backport of #12444 to `7.11` branch

(cherry picked from commit 79d8f47437e07758096191b077a8818a29fd5d98)
