### PR TITLE
[backport #12571 7.11]Fix Logstash pipelines management in case of slow loading pipelines

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -121,9 +121,9 @@ class LogStash::Agent
 
     transition_to_running
 
-    converge_state_and_update
-
     start_webserver_if_enabled
+
+    converge_state_and_update
 
     if auto_reload?
       # `sleep_then_run` instead of firing the interval right away

--- a/x-pack/lib/monitoring/inputs/metrics/stats_event_factory.rb
+++ b/x-pack/lib/monitoring/inputs/metrics/stats_event_factory.rb
@@ -12,6 +12,7 @@ module LogStash; module Inputs; class Metrics;
       @snapshot = snapshot
       @metric_store = @snapshot.metric_store
       @cluster_uuid = cluster_uuid
+      @webserver_enabled = LogStash::SETTINGS.get_value("http.enabled")
     end
 
     def make(agent, extended_performance_collection=true, collection_interval=10)
@@ -124,8 +125,13 @@ module LogStash; module Inputs; class Metrics;
     end
 
     def fetch_node_stats(agent, stats)
+      if @webserver_enabled
+        http_addr = stats.get_shallow(:http_address).value
+      else
+        http_addr = nil
+      end
       @global_stats.merge({
-        "http_address" => stats.get_shallow(:http_address).value,
+        "http_address" => http_addr,
         "ephemeral_id" => agent.ephemeral_id
       })
     end

--- a/x-pack/spec/monitoring/schemas/monitoring_document_schema.json
+++ b/x-pack/spec/monitoring/schemas/monitoring_document_schema.json
@@ -71,7 +71,7 @@
       "type": "object",
       "required": ["http_address", "uuid", "ephemeral_id"],
       "properties": {
-        "http_address": { "type": "string" },
+        "http_address": { "type": ["string", "null"] },
         "uuid": { "type": "string" },
         "ephemeral_id": { "type": "string" }
       }


### PR DESCRIPTION
Clean backport of #12571 to `7.11` branch

(cherry picked from commit 91996cf2a2b2b7cd9b11c8f003830874deab67f9)
