### PR TITLE
Docs: Implement docs-root for shared files

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,8 +1,8 @@
 [[logstash-reference]]
 = Logstash Reference
 
-include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
-include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
+include::{docs-root}/shared/attributes.asciidoc[]
 
 :include-xpack:         true
 :lang:                  en


### PR DESCRIPTION
Employ the universal {docs-root} attribute to replace relative paths
