### PR TITLE
Backport PR #12699 to 7.x: update jruby to 9.2.16.0

### DIFF
--- a/logstash-core/spec/logstash/plugin_spec.rb
+++ b/logstash-core/spec/logstash/plugin_spec.rb
@@ -297,7 +297,7 @@ describe LogStash::Plugin do
 
         context "When a user provide an ID for the plugin" do
           let(:id) { "ABC" }
-          let(:config) { super.merge("id" => id) }
+          let(:config) { super().merge("id" => id) }
 
           it "uses the user provided ID" do
             expect(subject.id).to eq(id)
@@ -346,7 +346,7 @@ describe LogStash::Plugin do
 
 
           context(desc) do
-            let(:config) { super.merge(config_override) }
+            let(:config) { super().merge(config_override) }
 
             it "has a PluginMetadata" do
               expect(plugin_instance.plugin_metadata).to be_a_kind_of(LogStash::PluginMetadata)
@@ -400,7 +400,7 @@ describe LogStash::Plugin do
 
     context "when the id is provided" do
       let(:my_id) { "mysuper-plugin" }
-      let(:config) { super.merge({ "id" => my_id })}
+      let(:config) { super().merge({ "id" => my_id })}
       subject { plugin.new(config) }
 
       it "return a human readable ID" do

--- a/logstash-core/spec/logstash/plugins/builtin/pipeline_input_output_spec.rb
+++ b/logstash-core/spec/logstash/plugins/builtin/pipeline_input_output_spec.rb
@@ -204,7 +204,7 @@ describe ::LogStash::Plugins::Builtin::Pipeline do
       end
 
       context "with ensure delivery set to false" do
-        let(:output_options) { super.merge("ensure_delivery" => false) }
+        let(:output_options) { super().merge("ensure_delivery" => false) }
         before(:each) do
           other_input.do_stop
           other_input.do_close

--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -25,7 +25,7 @@ buildscript {
     dependencies {
         classpath 'org.yaml:snakeyaml:1.23'
         classpath "de.undercouch:gradle-download-task:4.0.4"
-        classpath "org.jruby:jruby-complete:9.2.13.0"
+        classpath "org.jruby:jruby-complete:9.2.16.0"
     }
 }
 

--- a/versions.yml
+++ b/versions.yml
@@ -13,8 +13,8 @@ bundled_jdk:
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time
 jruby:
-  version: 9.2.13.0
-  sha1: 876bee4475c1d22b1acd437fcdf7f38b682f0e60
+  version: 9.2.16.0
+  sha1: c04d45392da356405becb238d0d48cf32357ddfd
 
 # jruby-runtime-override, if specified, will override the jruby version installed in vendor/jruby for logstash runtime only,
 # not for the compile-time jars

--- a/x-pack/spec/config_management/elasticsearch_source_spec.rb
+++ b/x-pack/spec/config_management/elasticsearch_source_spec.rb
@@ -366,7 +366,7 @@ describe LogStash::ConfigManagement::ElasticsearchSource do
   describe "#pipeline_configs" do
     let(:pipeline_id) { "apache" }
     let(:mock_client)  { double("http_client") }
-    let(:settings) { super.merge({ "xpack.management.pipeline.id" => pipeline_id }) }
+    let(:settings) { super().merge({ "xpack.management.pipeline.id" => pipeline_id }) }
     let(:config) { "input { generator {} } filter { mutate {} } output { }" }
     let(:elasticsearch_response) { elasticsearch_8_response }
     let(:elasticsearch_8_response) {

--- a/x-pack/spec/helpers/elasticsearch_options_spec.rb
+++ b/x-pack/spec/helpers/elasticsearch_options_spec.rb
@@ -22,7 +22,7 @@ end
 shared_examples 'elasticsearch options hash is populated with secure options' do
   context "with ca" do
     let(:elasticsearch_ca) { Stud::Temporary.file.path }
-    let(:settings) { super.merge({ "xpack.monitoring.elasticsearch.ssl.certificate_authority" => elasticsearch_ca })}
+    let(:settings) { super().merge({ "xpack.monitoring.elasticsearch.ssl.certificate_authority" => elasticsearch_ca })}
 
     it "creates the elasticsearch output options hash" do
       expect(test_class.es_options_from_settings('monitoring', system_settings)).to include(
@@ -39,7 +39,7 @@ shared_examples 'elasticsearch options hash is populated with secure options' do
     let(:elasticsearch_truststore_path) { Stud::Temporary.file.path }
     let(:elasticsearch_truststore_password) { "truststore_password" }
     let(:settings) do
-      super.merge({
+      super().merge({
                       "xpack.monitoring.elasticsearch.ssl.truststore.path" => elasticsearch_truststore_path,
                       "xpack.monitoring.elasticsearch.ssl.truststore.password" => elasticsearch_truststore_password,
                   })
@@ -62,7 +62,7 @@ shared_examples 'elasticsearch options hash is populated with secure options' do
     let(:elasticsearch_keystore_password) { "keystore_password" }
 
     let(:settings) do
-      super.merge({
+      super().merge({
                       "xpack.monitoring.elasticsearch.ssl.keystore.path" => elasticsearch_keystore_path,
                       "xpack.monitoring.elasticsearch.ssl.keystore.password" => elasticsearch_keystore_password,
                   })
@@ -120,7 +120,7 @@ describe LogStash::Helpers::ElasticsearchOptions do
         let(:cloud_auth) { "#{cloud_username}:#{cloud_password}" }
 
         let(:settings) do
-          super.merge(
+          super().merge(
             "xpack.monitoring.elasticsearch.cloud_auth" => cloud_auth,
           )
         end
@@ -135,7 +135,7 @@ describe LogStash::Helpers::ElasticsearchOptions do
 
       context "with api_key" do
         let(:settings) do
-          super.merge(
+          super().merge(
             "xpack.monitoring.elasticsearch.api_key" => 'foo:bar'
           )
         end
@@ -148,7 +148,7 @@ describe LogStash::Helpers::ElasticsearchOptions do
 
         context "and explicit password" do
           let(:settings) do
-            super.merge(
+            super().merge(
               "xpack.monitoring.elasticsearch.password" => elasticsearch_password
             )
           end
@@ -179,7 +179,7 @@ describe LogStash::Helpers::ElasticsearchOptions do
 
       context "with cloud_auth" do
         let(:settings) do
-          super.merge(
+          super().merge(
             "xpack.monitoring.elasticsearch.password" => "bar",
             "xpack.monitoring.elasticsearch.cloud_auth" => "foo:bar",
           )
@@ -194,7 +194,7 @@ describe LogStash::Helpers::ElasticsearchOptions do
 
       context "with api_key" do
         let(:settings) do
-          super.merge(
+          super().merge(
             "xpack.monitoring.elasticsearch.password" => "bar",
             "xpack.monitoring.elasticsearch.api_key" => 'foo:bar'
           )
@@ -237,7 +237,7 @@ describe LogStash::Helpers::ElasticsearchOptions do
 
       context 'hosts also set' do
         let(:settings) do
-          super.merge(
+          super().merge(
             "xpack.monitoring.elasticsearch.hosts" => 'https://localhost:9200'
           )
         end
@@ -254,7 +254,7 @@ describe LogStash::Helpers::ElasticsearchOptions do
         let(:cloud_password) { 'passw0rd'}
         let(:cloud_auth) { "#{cloud_username}:#{cloud_password}" }
         let(:settings) do
-          super.merge(
+          super().merge(
             "xpack.monitoring.elasticsearch.cloud_auth" => cloud_auth,
           )
         end
@@ -269,7 +269,7 @@ describe LogStash::Helpers::ElasticsearchOptions do
 
         context 'username also set' do
           let(:settings) do
-            super.merge(
+            super().merge(
                 "xpack.monitoring.elasticsearch.username" => 'elastic'
             )
           end
@@ -283,7 +283,7 @@ describe LogStash::Helpers::ElasticsearchOptions do
 
         context 'api_key also set' do
           let(:settings) do
-            super.merge(
+            super().merge(
                 "xpack.monitoring.elasticsearch.api_key" => 'foo:bar',
             )
           end
@@ -305,7 +305,7 @@ describe LogStash::Helpers::ElasticsearchOptions do
 
         context 'username and password set' do
           let(:settings) do
-            super.merge(
+            super().merge(
               "xpack.monitoring.elasticsearch.username" => 'foo',
               "xpack.monitoring.elasticsearch.password" => 'bar'
             )
@@ -320,7 +320,7 @@ describe LogStash::Helpers::ElasticsearchOptions do
 
         context 'api_key set' do
           let(:settings) do
-            super.merge(
+            super().merge(
               "xpack.monitoring.elasticsearch.api_key" => 'foo:bar'
             )
           end


### PR DESCRIPTION
Backport PR #12699 to 7.x branch. Original message: 

replaces #12519

The `super` to `super()` change comes from the changes in JRuby, that make it behave like CRuby:

```ruby
require 'rspec'

describe "calling super in a let" do
  let("object") { Hash.new }
  context "when adding something to that object" do
    let("object") { super.merge("hey" => "you") }
    it "should show the new object with a key and value" do
      expect(object).to include("hey")
      expect(object["hey"]).to eq("you")
    end
  end
end
```
```
/tmp
❯ ruby -v
ruby 2.6.3p62 (2019-04-16 revision 67580) [universal.x86_64-darwin19]

/tmp
❯ rspec test_rspec.rb                                                                                                                  
F

Failures:

  1) calling super in a let when adding something to that object should show the new object with a key and value
     Failure/Error: let("object") { super.merge("hey" => "you") }
     
     RuntimeError:
       implicit argument passing of super from method defined by define_method() is not supported. Specify all arguments explicitly.
     # ./test_rspec.rb:6:in `block (3 levels) in <top (required)>'
     # ./test_rspec.rb:8:in `block (3 levels) in <top (required)>'

Finished in 0.00189 seconds (files took 0.08356 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./test_rspec.rb:7 # calling super in a let when adding something to that object should show the new object with a key and value
```