### PR TITLE
backport: always prefix the version number

### DIFF
--- a/devtools/backport
+++ b/devtools/backport
@@ -173,10 +173,10 @@ def create_pr(args):
 
         # add labels
         labels = ["backport"]
-        # get the version we are backported to
+        # get the version (vX.Y.Z) we are backporting to
         version = get_version(os.getcwd())
         if version:
-            labels.append("v" + version)
+            labels.append(version)
 
         session.post(
             base + "/issues/{}/labels".format(new_pr["number"]), json=labels)
@@ -189,7 +189,7 @@ def create_pr(args):
         # Set a version label on the original PR
         if version:
             session.post(
-                base + "/issues/{}/labels".format(args.pr_number), json=labels)
+                base + "/issues/{}/labels".format(args.pr_number), json=[version])
 
         info("Done. PR created: {}".format(new_pr["html_url"]))
         info("Please go and check it and add the review tags")
@@ -199,7 +199,7 @@ def get_version(base_dir):
     with open(os.path.join(base_dir, "versions.yml"), "r") as f:
         for line in f:
             if line.startswith('logstash:'):
-                return line.split(':')[-1].strip()
+                return "v" + line.split(':')[-1].strip()
             #match = pattern.match(line)
             #if match:
             #    return match.group('version')

--- a/devtools/backport
+++ b/devtools/backport
@@ -189,7 +189,7 @@ def create_pr(args):
         # Set a version label on the original PR
         if version:
             session.post(
-                base + "/issues/{}/labels".format(args.pr_number), json=[version])
+                base + "/issues/{}/labels".format(args.pr_number), json=labels)
 
         info("Done. PR created: {}".format(new_pr["html_url"]))
         info("Please go and check it and add the review tags")


### PR DESCRIPTION
Ensure we always prefix the version number with 'v', so it is added to both, the original and the backport PR.