### PR TITLE
Deps: update log4j2 to latest and ship log4j 1.2 bridge

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -30,7 +30,7 @@ String jrubyVersion = versionMap['jruby']['version']
 String jacksonVersion = versionMap['jackson']
 String jacksonDatabindVersion = versionMap['jackson-databind']
 
-String log4jVersion = '2.13.3'
+String log4jVersion = '2.14.0'
 
 repositories {
     mavenCentral()
@@ -165,7 +165,7 @@ dependencies {
     // for the log4j-jcl bridge to work commons-logging needs to be on the same class-path
     runtimeOnly 'commons-logging:commons-logging:1.2'
     // also handle libraries relying on log4j 1.x to redirect their logs
-    runtimeOnly "org.apache.logging.log4j-1.2-api:${log4jVersion}"
+    runtimeOnly "org.apache.logging.log4j:log4j-1.2-api:${log4jVersion}"
     implementation('org.reflections:reflections:0.9.11') {
         exclude group: 'com.google.guava', module: 'guava'
     }

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -164,6 +164,8 @@ dependencies {
     runtimeOnly "org.apache.logging.log4j:log4j-jcl:${log4jVersion}"
     // for the log4j-jcl bridge to work commons-logging needs to be on the same class-path
     runtimeOnly 'commons-logging:commons-logging:1.2'
+    // also handle libraries relying on log4j 1.x to redirect their logs
+    runtimeOnly "org.apache.logging.log4j-1.2-api:${log4jVersion}"
     implementation('org.reflections:reflections:0.9.11') {
         exclude group: 'com.google.guava', module: 'guava'
     }


### PR DESCRIPTION
Expected to improve logging experience for libraries stuck with Log4J 1.2 logging.

## What does this PR do?

Updates Log4j2 to latest [**1.4.0**](https://blogs.apache.org/logging/entry/log4j-2-14-0-released)
Adds a Log4j 1.2 API compatible bridge (1.4.0 [fixed](https://issues.apache.org/jira/browse/LOG4J2-2899) a bug in the bridge that might be relevant if we're to use the bridge).
A use-case for the bridge is debug logging with the input snmp plugin (capturing [SNMP4J library logs](https://doc.snmp.app/pages/viewpage.action?pageId=27459590)).

## Why is it important/What is the impact to the user?

Might impact plugins that ship with log4j 1.2 (in a "positive" way if the bridge is picked up - logging will end up redirected to LS).

none of the current logstash plugins are expected to be affected.

## Author's Checklist

- [x] logstash-input-log4j uses log4j 1.2 but is a defunct (unsupported) plugin
- [x] logstash-input-jms configuration "might" be affected e.g. if  `require_jars=> ['log4j12.jar', 'a-jms-impl.jar' ]`
- [x] logstash-input-kinesis' Java dependencies have an optional log4j dependency but log4j.jar isn't being vendored
  confusingly, the plugin deals with [`org.apache.log4j`](https://github.com/logstash-plugins/logstash-input-kinesis/blob/v2.1.2/lib/logstash/inputs/kinesis.rb#L83) API but that seems (legacy) dead code
  Confirmed, in case of Kinesis it's always the `org.apache.logging.log4jJcl::Log4jLog` wrapper, `org.apache.log4j` isn't being loaded from the plugin's jar files (and hasn't been provided by LS 7.x)

---   
resolves https://github.com/elastic/logstash/issues/12241