### PR TITLE
Backport PR #12728 to 7.x: [Build] Fix version script when VERSION_QU…

### DIFF
--- a/docker/bin/elastic-version
+++ b/docker/bin/elastic-version
@@ -12,7 +12,7 @@ end
 
 def qualify(version)
   qualifier = ENV['VERSION_QUALIFIER']
-  qualifier ? [version, qualifier].join("-") : version
+  qualifier.nil? || qualifier.empty? ? version : [version, qualifier].join("-")
 end
 
 def get_version


### PR DESCRIPTION
…ALIFIER is empty string

Backport PR #12728 to 7.x branch

Prior to this release a VERSION_QUALIFER env set to an empty string
would create versions looking like `8.0.0--SNAPSHOT` instead of
`8.0.0-SNAPSHOT`, causing the release manager builds to fail.
