### PR TITLE
Docs: Replace relative paths with docs-root attributes for 7.12

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,8 +1,8 @@
 [[logstash-reference]]
 = Logstash Reference
 
-include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
-include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
+include::{docs-root}/shared/attributes.asciidoc[]
 
 :include-xpack:         true
 :lang:                  en


### PR DESCRIPTION
Backports #12719