### PR TITLE
Backport PR #12749 to 7.12: internal-monitoring: use configured ssl verification mode

### DIFF
--- a/x-pack/lib/monitoring/monitoring.rb
+++ b/x-pack/lib/monitoring/monitoring.rb
@@ -40,7 +40,7 @@ module LogStash
         @keystore_path = es_settings['keystore']
         @keystore_password = es_settings['keystore_password']
         @sniffing = es_settings['sniffing']
-        @ssl_certificate_verification = (es_settings['verification_mode'] == 'certificate')
+        @ssl_certificate_verification = es_settings.fetch('ssl_certificate_verification', true)
       end
 
       attr_accessor :system_api_version, :es_hosts, :user, :password, :node_uuid, :cloud_id, :cloud_auth, :api_key


### PR DESCRIPTION
Backport PR #12749 to 7.12 branch. Original message: 

## What does this PR do?

Fixes Internal Monitoring to correctly rely on the `monitoring.elasticsearch.ssl.verification_mode` setting.

## Why is it important/What is the impact to the user?

Ensures that explicitly-configured options are used.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~I have made corresponding changes to the documentation~
- [x] ~I have made corresponding change to the default configuration files (and/or docker env variables)~
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

 - Set up monitoring over SSL (e.g., with https host)
 - Start Logstash
 - Observe no warning about SSL being disabled

## Related issues

- Closes https://github.com/elastic/logstash/issues/10352
