### PR TITLE
Backport PR #12749 to 6.8: internal-monitoring: use configured ssl verification mode

### DIFF
--- a/x-pack/lib/helpers/elasticsearch_options.rb
+++ b/x-pack/lib/helpers/elasticsearch_options.rb
@@ -25,6 +25,8 @@ module LogStash module Helpers
       opts['sniffing'] = settings.get("xpack.#{feature}.elasticsearch.sniffing")
       opts['ssl_certificate_verification'] = settings.get("xpack.#{feature}.elasticsearch.ssl.verification_mode") == 'certificate'
 
+      opts['ssl'] = true if Array(opts['hosts']).all? { |h| h.start_with?('https://') }
+
       if cacert = settings.get("xpack.#{feature}.elasticsearch.ssl.certificate_authority")
         opts['cacert'] = cacert
         opts['ssl'] = true

--- a/x-pack/lib/monitoring/monitoring.rb
+++ b/x-pack/lib/monitoring/monitoring.rb
@@ -35,7 +35,7 @@ module LogStash
         @keystore_path = es_settings['keystore']
         @keystore_password = es_settings['keystore_password']
         @sniffing = es_settings['sniffing']
-        @ssl_certificate_verification = (es_settings['verification_mode'] == 'certificate')
+        @ssl_certificate_verification = es_settings.fetch('ssl_certificate_verification', true)
       end
 
       attr_accessor :system_api_version, :es_hosts, :user, :password, :node_uuid

--- a/x-pack/lib/monitoring/monitoring.rb
+++ b/x-pack/lib/monitoring/monitoring.rb
@@ -29,6 +29,7 @@ module LogStash
         @es_hosts = es_settings['hosts']
         @user = es_settings['user']
         @password = es_settings['password']
+        @ssl = es_settings['ssl']
         @ca_path = es_settings['cacert']
         @truststore_path = es_settings['truststore']
         @truststore_password = es_settings['truststore_password']
@@ -41,6 +42,8 @@ module LogStash
       attr_accessor :system_api_version, :es_hosts, :user, :password, :node_uuid
       attr_accessor :ca_path, :truststore_path, :truststore_password
       attr_accessor :keystore_path, :keystore_password, :sniffing, :ssl_certificate_verification
+
+      attr_reader :ssl
 
       def collection_interval
         TimeUnit::SECONDS.convert(@collection_interval, TimeUnit::NANOSECONDS)
@@ -55,7 +58,7 @@ module LogStash
       end
 
       def ssl?
-        ca_path || (truststore_path && truststore_password) || (keystore_path && keystore_password)
+        ssl || ca_path || (truststore_path && truststore_password) || (keystore_path && keystore_password)
       end
 
       def truststore?

--- a/x-pack/spec/monitoring/pipeline_register_hook_spec.rb
+++ b/x-pack/spec/monitoring/pipeline_register_hook_spec.rb
@@ -1,0 +1,52 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+require 'monitoring/monitoring'
+
+describe LogStash::MonitoringExtension::PipelineRegisterHook do
+
+  subject { described_class.new }
+
+  before(:all) {
+    @extension = LogStash::MonitoringExtension.new
+    # used to register monitoring xpack's settings
+    @sys_settings = LogStash::Runner::SYSTEM_SETTINGS.clone
+    @extension.additionals_settings(@sys_settings)
+  }
+
+  context 'validate monitoring settings' do
+    it "work with xpack-namespaced settings" do
+      settings = @sys_settings.clone
+      settings.set_value("xpack.monitoring.enabled", true)
+      settings.set_value("xpack.monitoring.elasticsearch.hosts", "http://localhost:9200")
+      settings.set_value("xpack.monitoring.elasticsearch.username", "elastic")
+      settings.set_value("xpack.monitoring.elasticsearch.password", "changeme")
+      expect(subject.generate_pipeline_config(settings)).to be_truthy
+    end
+
+    context 'ssl certificate verification setting' do
+      {
+        'certificate' => 'true',
+        'none'        => 'false',
+        nil           => 'true', # unset, uses default
+      }.each do |setting_value, expected_result|
+        context "with `xpack.monitoring.elasticsearch.ssl.verification_mode` #{setting_value ? "set to `#{setting_value}`" : 'unset'}" do
+          it "the generated pipeline includes `ssl_certificate_verification => #{expected_result}`" do
+            settings = @sys_settings.clone.tap(&:reset)
+            settings.set_value("xpack.monitoring.enabled", true)
+            settings.set_value("xpack.monitoring.elasticsearch.hosts", "https://localhost:9200")
+            settings.set_value("xpack.monitoring.elasticsearch.username", "elastic")
+            settings.set_value("xpack.monitoring.elasticsearch.password", "changeme")
+
+            settings.set_value("xpack.monitoring.elasticsearch.ssl.verification_mode", setting_value) unless setting_value.nil?
+
+            generated_pipeline_config = subject.generate_pipeline_config(settings)
+
+            expect(generated_pipeline_config).to include("ssl_certificate_verification => #{expected_result}")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Backport PR #12749 to 6.8 branch. Original message: 

## What does this PR do?

Fixes Internal Monitoring to correctly rely on the `monitoring.elasticsearch.ssl.verification_mode` setting.

## Why is it important/What is the impact to the user?

Ensures that explicitly-configured options are used.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~I have made corresponding changes to the documentation~
- [x] ~I have made corresponding change to the default configuration files (and/or docker env variables)~
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

 - Set up monitoring over SSL (e.g., with https host)
 - Start Logstash
 - Observe no warning about SSL being disabled

## Related issues

- Closes https://github.com/elastic/logstash/issues/10352
