### PR TITLE
Build: avoid leaking memory from generate_plugins_version

### DIFF
--- a/rakelib/plugins_docs_dependencies.rake
+++ b/rakelib/plugins_docs_dependencies.rake
@@ -126,6 +126,7 @@ class PluginVersionWorking
   end
 
   def try_plugin(plugin, successful_dependencies)
+    Bundler::DepProxy.__clear!
     builder = Bundler::Dsl.new
     gemfile = LogStash::Gemfile.new(File.new(LogStash::Environment::GEMFILE_PATH, "r+")).load
     gemfile.update(plugin)
@@ -201,6 +202,14 @@ task :generate_plugins_version do
         Signal.trap(signal) do
           block.call
         end
+      end
+    end
+    DepProxy.class_eval do
+      # Bundler caches it's dep-proxy objects (which contain Gem::Dependency objects) from all resolutions.
+      # The Hash itself continues to grow between dependency resolutions and hold up a lot of memory, to avoid
+      # the issue we expose a way of clear-ing the cached objects before each plugin resolution.
+      def self.__clear!
+        @proxies.clear
       end
     end
   end


### PR DESCRIPTION
## What does this PR do?

This PR handles memory leaks that exhibit when running the rake/gradle task.

NOTE: this is mostly a partial understanding what's going on by simply following the "huge" objects from memory dumps. 
There might be better ways to handle the issue - without the patches (e.g. rewrite plugin generation to put each `bundle` resolution into a disposable runtime or run as a process).

Details on why each patch is relevant are to be found in code comments.

## Why is it important/What is the impact to the user?

To be able to generate plugin docs we need to check available plugin versions.

## How to test this PR locally

`./gradlew generatePluginsVersion -Dorg.gradle.jvmargs="-XX:+HeapDumpOnOutOfMemoryError -Xmx2g"`
should no longer end up with an out of memory error

Tested with Bundler 2.2.14 as well as latest 2.2.15

## Related issues

resolves https://github.com/elastic/logstash/issues/12758
related: https://github.com/elastic/logstash/pull/10942
