### PR TITLE
Revert commit for further testing

### DIFF
--- a/docs/static/keystore.asciidoc
+++ b/docs/static/keystore.asciidoc
@@ -36,8 +36,6 @@ is not currently supported.
 NOTE: Referencing keystore data from {logstash-ref}/logstash-centralized-pipeline-management.html[centralized pipeline management]
 requires each Logstash deployment to have a local copy of the keystore.
 
-NOTE: The logstash keystore needs to be protected, but the logstash user must have access to the file. While most things in logstash can be protected with `chown -R root:root <foo>`; the keystore itself must be accessible via the logstash user. To do so invoke: `chown logstash:root <keystore> && chmod 0600 <keystore>`
-
 When Logstash parses the settings (`logstash.yml`) or configuration
 (`/etc/logstash/conf.d/*.conf`), it resolves keys from the keystore before
 resolving environment variables.


### PR DESCRIPTION
## Release notes
[rn:skip] 

## What does this PR do?
Reverts a direct commit to keystore docs for further testing and investigation
