### PR TITLE
Doc:Fix typo and adjust keystore text

### DIFF
--- a/docs/static/keystore.asciidoc
+++ b/docs/static/keystore.asciidoc
@@ -16,11 +16,23 @@ The syntax for referencing keys is identical to the syntax for
 
 Where KEY is the name of the key.
 
-For example, imagine that the keystore contains a key called `ES_PWD` with the
-value `yourelasticsearchpassword`:
+**Example**
+ 
+Imagine that the keystore contains a key called `ES_PWD` with the value `yourelasticsearchpassword`.
 
-* In configuration files, use: `output { elasticsearch {...password => "${ES_PWD}" } } }`
-* In `logstash.yml`, use: `xpack.management.elasticsearch.password: ${ES_PWD}`
+In configuration files, use: 
+
+[source,shell]
+-----
+output { elasticsearch {...password => "${ES_PWD}" } } } 
+-----
+
+In `logstash.yml`, use:
+
+[source,shell]
+-----
+xpack.management.elasticsearch.password: ${ES_PWD}
+-----  
 
 Notice that the Logstash keystore differs from the Elasticsearch keystore.
 Whereas the Elasticsearch keystore lets you store `elasticsearch.yml` values by

--- a/docs/static/keystore.asciidoc
+++ b/docs/static/keystore.asciidoc
@@ -39,8 +39,8 @@ Whereas the Elasticsearch keystore lets you store `elasticsearch.yml` values by
 name, the Logstash keystore lets you specify arbitrary names that you
 can reference in the Logstash configuration.
 
-NOTE: There are some configuration fields that have no secret meaning, so not every field could leverage
-the secret store for variables substitution. Plugin's `id` field is a field of this kind
+NOTE: Some configuration fields that have no secret meaning, so not every field can use
+the secret store for variables substitution. Plugin `id` field is a an example.
 
 NOTE: Referencing keystore data from `pipelines.yml` or the command line (`-e`)
 is not currently supported.
@@ -126,7 +126,7 @@ as the `logstash.yml`.
 [[creating-keystore]]
 === Create a keystore
 
-To create a secrets keystore, use the `create`:
+The `create` command creates (or overwrites an existing) keystore:
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------
@@ -134,7 +134,9 @@ bin/logstash-keystore create
 ----------------------------------------------------------------
 
 Creates the keystore in the directory defined in the `path.settings` setting.
-This command also overrides an existing keystore setting. 
+
+IMPORTANT: If a keystore already exists, the `create` command can overwrite it (after a Y/N prompt).
+Selecting `Y` clears all keys and secrets that were previously stored.  
 
 TIP: Set a <<keystore-password,keystore password>> when you create the keystore.
 

--- a/docs/static/keystore.asciidoc
+++ b/docs/static/keystore.asciidoc
@@ -12,7 +12,10 @@ place of the secret value when you configure sensitive settings.
 The syntax for referencing keys is identical to the syntax for
 <<environment-variables, environment variables>>:
 
+[source,txt]
+-----
 `${KEY}`
+-----
 
 Where KEY is the name of the key.
 
@@ -52,12 +55,8 @@ When Logstash parses the settings (`logstash.yml`) or configuration
 (`/etc/logstash/conf.d/*.conf`), it resolves keys from the keystore before
 resolving environment variables.
 
-// TODO: add keystore-command to running-logstash-command-line.asciidoc
-// To create and manage keys, use the `keystore` command. See the
-// <<keystore-command,command reference>> for the full command syntax, including
-// optional flags.
 
-[float]
+[discrete]
 [[keystore-password]]
 === Keystore password
 
@@ -100,11 +99,11 @@ runtime environment (Windows, Docker, etc) to learn how to set the
 environment variable for the user that runs Logstash. Ensure that the
 environment variable (and thus the password) is only accessible to that user.
 
-[float]
+[discrete]
 [[keystore-location]]
 === Keystore location
 
-The keystore must be located in Logstash's `path.settings` directory. This is
+The keystore must be located in the Logstash `path.settings` directory. This is
 the same directory that contains the `logstash.yml` file. When performing any
 operation against the keystore, it is recommended to set `path.settings` for the
 keystore command. For example, to create a keystore on a RPM/DEB installation:
@@ -122,11 +121,11 @@ See <<dir-layout>> for more about the default directory locations.
 NOTE: You will see a warning if the `path.settings` is not pointed to the same directory
 as the `logstash.yml`.
 
-[float]
+[discrete]
 [[creating-keystore]]
-=== Create a keystore
+=== Create or overwrite a keystore
 
-The `create` command creates (or overwrites an existing) keystore:
+The `create` command creates a new keystore or overwrites an existing keystore:
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------
@@ -140,7 +139,7 @@ Selecting `Y` clears all keys and secrets that were previously stored.
 
 TIP: Set a <<keystore-password,keystore password>> when you create the keystore.
 
-[float]
+[discrete]
 [[add-keys-to-keystore]]
 === Add keys
 
@@ -154,7 +153,7 @@ bin/logstash-keystore add ES_PWD
 
 When prompted, enter a value for the key.
 
-[float]
+[discrete]
 [[list-settings]]
 === List keys
 
@@ -165,7 +164,7 @@ To list the keys defined in the keystore, use:
 bin/logstash-keystore list
 ----------------------------------------------------------------
 
-[float]
+[discrete]
 [[remove-settings]]
 === Remove keys
 

--- a/docs/static/keystore.asciidoc
+++ b/docs/static/keystore.asciidoc
@@ -121,11 +121,10 @@ To create a secrets keystore, use the `create`:
 bin/logstash-keystore create
 ----------------------------------------------------------------
 
-Creates the keystore in the directory defined by the `path.settings`
-configuration setting. This will also override an existing keystor setting. 
+Creates the keystore in the directory defined in the `path.settings` setting.
+This command also overrides an existing keystore setting. 
 
-NOTE: It is recommended that you set a <<keystore-password,keystore password>>
-when creating the keystore.
+TIP: Set a <<keystore-password,keystore password>> when you create the keystore.
 
 [float]
 [[add-keys-to-keystore]]

--- a/docs/static/keystore.asciidoc
+++ b/docs/static/keystore.asciidoc
@@ -42,8 +42,8 @@ Whereas the Elasticsearch keystore lets you store `elasticsearch.yml` values by
 name, the Logstash keystore lets you specify arbitrary names that you
 can reference in the Logstash configuration.
 
-NOTE: Some configuration fields that have no secret meaning, so not every field can use
-the secret store for variables substitution. Plugin `id` field is a an example.
+NOTE: There are some configuration fields that have no secret meaning, so not every field could leverage
+the secret store for variables substitution. Plugin's `id` field is a field of this kind
 
 NOTE: Referencing keystore data from `pipelines.yml` or the command line (`-e`)
 is not currently supported.

--- a/docs/static/keystore.asciidoc
+++ b/docs/static/keystore.asciidoc
@@ -14,7 +14,7 @@ The syntax for referencing keys is identical to the syntax for
 
 [source,txt]
 -----
-`${KEY}`
+${KEY}
 -----
 
 Where KEY is the name of the key.


### PR DESCRIPTION
**PREVIEW:** https://logstash_12779.docs-preview.app.elstc.co/guide/en/logstash/master/keystore.html

## Release notes
[rn:skip] 


## What does this PR do?
Fixes typo and adjusts wording for keystore doc introduced in a direct commit
General formatting and content cleanup
