### PR TITLE
Backport PR #12782 to 7.12: Set correct permissions for /usr/share/logstash on pkg installs

### DIFF
--- a/pkg/centos/after-install.sh
+++ b/pkg/centos/after-install.sh
@@ -1,4 +1,4 @@
-chown -R logstash:logstash /usr/share/logstash
+chown -R root:root /usr/share/logstash
 chown -R logstash /var/log/logstash
 chown logstash:logstash /var/lib/logstash
 sed -i \

--- a/pkg/debian/after-install.sh
+++ b/pkg/debian/after-install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-chown -R logstash:logstash /usr/share/logstash
+chown -R root:root /usr/share/logstash
 chown -R logstash /var/log/logstash
 chown logstash:logstash /var/lib/logstash
 chmod 755 /etc/logstash

--- a/pkg/ubuntu/after-install.sh
+++ b/pkg/ubuntu/after-install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-chown -R logstash:logstash /usr/share/logstash
+chown -R root:root /usr/share/logstash
 chown -R logstash /var/log/logstash
 chown logstash:logstash /var/lib/logstash
 sed -i \


### PR DESCRIPTION
Backport PR #12782 to 7.12 branch. Original message: 

## Release notes
Fix package install permissions of /usr/share/logstash

## What does this PR do?
This PR fixes the the permissions of (RPM, DEB) for /usr/share/logstash.

## Why is it important/What is the impact to the user?
Ensures /usr/share/logstash has the appropriate ownership as per the FHS. Also ensures the daemon cannot modify files it needs to run.

## Checklist
- [x] My code follows the style guidelines of this project
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

1. Create a debian or RPM package.
2. Manually install it
3. Check /usr/share/logstash is owned by root:root

## Related issues

- Closes #12771

