### PR TITLE
Crea pr-status-labels.yml action

### DIFF
--- a/.github/workflows/pr-status-labels.yml
+++ b/.github/workflows/pr-status-labels.yml
@@ -1,0 +1,27 @@
+name: [Test] Pull Request Label Status
+
+on: [pull_request, pull_request_review]
+
+jobs:
+  prhelper_job:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Label PR by status
+      id: runprhelper
+      uses: Matticusau/pr-helper@v1.2.6
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        enable-prmerge-automation: false
+        enable-prcomment-automation: false
+        enable-prlabel-automation: true
+        enable-prreviewer-frontmatter: false
+        enable-welcomemessage: false
+        welcome-message: "Thanks for opening an issue! Make sure you've followed CONTRIBUTING.md."
+        prmerge-requireallchecks: false
+        prmerge-requirereviewcount: 1
+        prmerge-method: 'merge'
+        prlabel-default: 'status:needs-triage'
+        prlabel-ready: 'status:approved'
+        prlabel-onhold: 'status:on-hold'
+        prlabel-reviewrequired: 'status:needs-review'
+        prlabel-automerge: 'auto-merge'


### PR DESCRIPTION
## What does this PR do?
Adds a new (test) action to automatically label PRs based on their review status, e.g.:

status:needs-triage
status:approved
status:on-hold
status:needs-review

## Why is it important/What is the impact to the user?
It does not impact the user but helps automatically label PR's based on their status.


## Checklist

- [ ] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
