### PR TITLE
Load a plugin by alias name.

### DIFF
--- a/logstash-core/lib/logstash/plugins/registry.rb
+++ b/logstash-core/lib/logstash/plugins/registry.rb
@@ -123,7 +123,7 @@ module LogStash module Plugins
       @registry = java.util.concurrent.ConcurrentHashMap.new
       @java_plugins = java.util.concurrent.ConcurrentHashMap.new
       @hooks = HooksRegistry.new
-      @alias_registry = alias_registry ? alias_registry : Java::org.logstash.plugins.AliasRegistry.new
+      @alias_registry = alias_registry || Java::org.logstash.plugins.AliasRegistry.new
     end
 
     def setup!

--- a/logstash-core/lib/logstash/plugins/registry.rb
+++ b/logstash-core/lib/logstash/plugins/registry.rb
@@ -198,6 +198,7 @@ module LogStash module Plugins
     def legacy_lookup(type, plugin_name)
       begin
         has_alias = org.logstash.plugins.discovery.PluginRegistry.alias?(plugin_name)
+        path = "logstash/#{type}s/#{plugin_name}"
 
         klass = begin
           load_plugin_class(type, plugin_name)
@@ -209,6 +210,7 @@ module LogStash module Plugins
           alias_name = plugin_name
           plugin_name = org.logstash.plugins.discovery.PluginRegistry.original_from_alias(plugin_name)
           logger.debug("Plugin name #{alias_name} is aliased as #{plugin_name}")
+          path = "logstash/#{type}s/#{plugin_name}"
           begin
             load_plugin_class(type, plugin_name)
           rescue LoadError => e

--- a/logstash-core/lib/logstash/plugins/registry.rb
+++ b/logstash-core/lib/logstash/plugins/registry.rb
@@ -199,11 +199,11 @@ module LogStash module Plugins
     def legacy_lookup(type, plugin_name)
       klass = load_plugin_class(type, plugin_name)
 
-      has_alias = @alias_registry.alias?(type.to_java, plugin_name)
-      if !klass && has_alias
+      if !klass && @alias_registry.alias?(type.to_java, plugin_name)
         resolved_plugin_name = @alias_registry.original_from_alias(type.to_java, plugin_name)
         logger.debug("Loading #{type} plugin #{resolved_plugin_name} via its alias #{plugin_name}...")
         klass = load_plugin_class(type, resolved_plugin_name)
+        lazy_add(type, resolved_plugin_name, klass) if klass
       end
 
       unless klass
@@ -211,13 +211,7 @@ module LogStash module Plugins
         raise LoadError, "Unable to load the requested plugin named #{plugin_name} of type #{type}. The plugin is not installed."
       end
 
-      plugin = lazy_add(type, plugin_name, klass)
-
-      if has_alias
-        @registry[key_for(type, resolved_plugin_name)] = plugin
-      end
-
-      plugin
+      lazy_add(type, plugin_name, klass)
     end
 
     # load a plugin's class, or return nil if the plugin cannot be loaded.

--- a/logstash-core/lib/logstash/plugins/registry.rb
+++ b/logstash-core/lib/logstash/plugins/registry.rb
@@ -113,7 +113,7 @@ module LogStash module Plugins
 
     attr_reader :hooks
 
-    def initialize
+    def initialize(alias_registry = nil)
       @mutex = Mutex.new
       # We need a threadsafe class here because we may perform
       # get/set operations concurrently despite the fact we don't use
@@ -123,7 +123,7 @@ module LogStash module Plugins
       @registry = java.util.concurrent.ConcurrentHashMap.new
       @java_plugins = java.util.concurrent.ConcurrentHashMap.new
       @hooks = HooksRegistry.new
-      @alias_registry = Java::org.logstash.plugins.AliasRegistry.new
+      @alias_registry = alias_registry ? alias_registry : Java::org.logstash.plugins.AliasRegistry.new
     end
 
     def setup!

--- a/logstash-core/lib/logstash/plugins/registry.rb
+++ b/logstash-core/lib/logstash/plugins/registry.rb
@@ -242,15 +242,11 @@ module LogStash module Plugins
 
     private
     def load_plugin_class(type, plugin_name)
-      path = "logstash/#{type}s/#{plugin_name}"
-
-      klass = begin
-        namespace_lookup(type, plugin_name)
-      rescue UnknownPlugin => e
-        # Plugin not registered. Try to load it.
-        require path
-        namespace_lookup(type, plugin_name)
-      end
+      namespace_lookup(type, plugin_name)
+    rescue UnknownPlugin
+      # Plugin not registered. Try to load it.
+      require "logstash/#{type}s/#{plugin_name}"
+      namespace_lookup(type, plugin_name)
     end
 
     public

--- a/logstash-core/lib/logstash/plugins/registry.rb
+++ b/logstash-core/lib/logstash/plugins/registry.rb
@@ -197,7 +197,7 @@ module LogStash module Plugins
     # plugin with the appropriate type.
     def legacy_lookup(type, plugin_name)
       begin
-        has_alias = org.logstash.plugins.discovery.PluginRegistry.alias?(plugin_name)
+        has_alias = org.logstash.plugins.PluginLookup.alias?(plugin_name)
         path = "logstash/#{type}s/#{plugin_name}"
 
         klass = begin
@@ -208,7 +208,7 @@ module LogStash module Plugins
             raise
           end
           alias_name = plugin_name
-          plugin_name = org.logstash.plugins.discovery.PluginRegistry.original_from_alias(plugin_name)
+          plugin_name = org.logstash.plugins.PluginLookup.original_from_alias(plugin_name)
           logger.debug("Plugin name #{alias_name} is aliased as #{plugin_name}")
           path = "logstash/#{type}s/#{plugin_name}"
           begin
@@ -316,7 +316,7 @@ module LogStash module Plugins
       (klass.class == Java::JavaLang::Class && klass.simple_name.downcase == name.gsub('_','')) ||
       (klass.class == Java::JavaClass && klass.simple_name.downcase == name.gsub('_','')) ||
       (klass.ancestors.include?(LogStash::Plugin) && klass.respond_to?(:config_name) &&
-            klass.config_name == org.logstash.plugins.discovery.PluginRegistry.resolve_alias(name))
+            klass.config_name == org.logstash.plugins.PluginLookup.resolve_alias(name))
     end
 
     def add_plugin(type, name, klass)

--- a/logstash-core/lib/logstash/plugins/registry.rb
+++ b/logstash-core/lib/logstash/plugins/registry.rb
@@ -210,7 +210,7 @@ module LogStash module Plugins
           end
           alias_name = plugin_name
           plugin_name = @alias_registry.original_from_alias(plugin_name)
-          logger.debug("Plugin name #{alias_name} is aliased as #{plugin_name}")
+#           logger.info("Plugin name #{alias_name} is aliased as #{plugin_name}")
           path = "logstash/#{type}s/#{plugin_name}"
           begin
             load_plugin_class(type, plugin_name)

--- a/logstash-core/spec/logstash/java_pipeline_spec.rb
+++ b/logstash-core/spec/logstash/java_pipeline_spec.rb
@@ -199,6 +199,15 @@ describe LogStash::JavaPipeline do
     end
   end
 
+  describe "aliased plugin instantiation" do
+    it "should create the pipeline as if it's using the original plugin" do
+      alias_registry = Java::org.logstash.plugins.AliasRegistry.new({"alias_input" => "generator"})
+      LogStash::PLUGIN_REGISTRY = LogStash::Plugins::Registry.new alias_registry
+      pipeline = mock_java_pipeline_from_string("input { alias_input { count => 1 } } output { null {} }")
+      expect(pipeline.ephemeral_id).to_not be_nil
+      pipeline.close
+    end
+  end
 
   describe "event cancellation" do
     # test harness for https://github.com/elastic/logstash/issues/6055

--- a/logstash-core/spec/logstash/java_pipeline_spec.rb
+++ b/logstash-core/spec/logstash/java_pipeline_spec.rb
@@ -201,9 +201,9 @@ describe LogStash::JavaPipeline do
 
   describe "aliased plugin instantiation" do
     it "should create the pipeline as if it's using the original plugin" do
-      alias_registry = Java::org.logstash.plugins.AliasRegistry.new({"alias_input" => "generator"})
+      alias_registry = Java::org.logstash.plugins.AliasRegistry.new({["input", "alias"] => "generator"})
       LogStash::PLUGIN_REGISTRY = LogStash::Plugins::Registry.new alias_registry
-      pipeline = mock_java_pipeline_from_string("input { alias_input { count => 1 } } output { null {} }")
+      pipeline = mock_java_pipeline_from_string("input { alias { count => 1 } } output { null {} }")
       expect(pipeline.ephemeral_id).to_not be_nil
       pipeline.close
     end

--- a/logstash-core/spec/logstash/plugins/registry_spec.rb
+++ b/logstash-core/spec/logstash/plugins/registry_spec.rb
@@ -34,13 +34,21 @@ class LogStash::Inputs::NewPlugin < LogStash::Inputs::Base
 end
 
 describe LogStash::Plugins::Registry do
-  let(:registry) { described_class.new }
+  let(:alias_registry) { nil }
+  let(:registry) { described_class.new alias_registry }
 
   context "when loading installed plugins" do
+    let(:alias_registry) { Java::org.logstash.plugins.AliasRegistry.new({"alias_std_input" => "stdin"}) }
     let(:plugin) { double("plugin") }
+#     let(:registry) { described_class.new alias_registry }
 
     it "should return the expected class" do
       klass = registry.lookup("input", "stdin")
+      expect(klass).to eq(LogStash::Inputs::Stdin)
+    end
+
+    it "should load an aliased ruby plugin" do
+      klass = registry.lookup("input", "alias_std_input")
       expect(klass).to eq(LogStash::Inputs::Stdin)
     end
 
@@ -56,9 +64,16 @@ describe LogStash::Plugins::Registry do
   end
 
   context "when loading code defined plugins" do
+    let(:alias_registry) { Java::org.logstash.plugins.AliasRegistry.new({"alias_input" => "new_plugin"}) }
+
     it "should return the expected class" do
       klass = registry.lookup("input", "dummy")
       expect(klass).to eq(LogStash::Inputs::Dummy)
+    end
+
+    it "should return the expected class also for aliased plugins" do
+      klass = registry.lookup("input", "alias_input")
+      expect(klass).to eq(LogStash::Inputs::NewPlugin)
     end
   end
 

--- a/logstash-core/spec/logstash/plugins/registry_spec.rb
+++ b/logstash-core/spec/logstash/plugins/registry_spec.rb
@@ -38,7 +38,7 @@ describe LogStash::Plugins::Registry do
   let(:registry) { described_class.new alias_registry }
 
   context "when loading installed plugins" do
-    let(:alias_registry) { Java::org.logstash.plugins.AliasRegistry.new({"alias_std_input" => "stdin"}) }
+    let(:alias_registry) { Java::org.logstash.plugins.AliasRegistry.new({["input", "alias_std_input"] => "stdin"}) }
     let(:plugin) { double("plugin") }
 
     it "should return the expected class" do
@@ -63,7 +63,7 @@ describe LogStash::Plugins::Registry do
   end
 
   context "when loading code defined plugins" do
-    let(:alias_registry) { Java::org.logstash.plugins.AliasRegistry.new({"alias_input" => "new_plugin"}) }
+    let(:alias_registry) { Java::org.logstash.plugins.AliasRegistry.new({["input", "alias_input"] => "new_plugin"}) }
 
     it "should return the expected class" do
       klass = registry.lookup("input", "dummy")

--- a/logstash-core/spec/logstash/plugins/registry_spec.rb
+++ b/logstash-core/spec/logstash/plugins/registry_spec.rb
@@ -60,6 +60,15 @@ describe LogStash::Plugins::Registry do
       expect { registry.lookup("input", "new_plugin") }.to change { registry.size }.by(1)
       expect { registry.lookup("input", "new_plugin") }.not_to change { registry.size }
     end
+
+    context "when loading installed plugin that overrides an alias" do
+      let(:alias_registry) { Java::org.logstash.plugins.AliasRegistry.new({["input", "dummy"] => "new_plugin"}) }
+
+      it 'should load the concrete implementation instead of resolving the alias' do
+        klass = registry.lookup("input", "dummy")
+        expect(klass).to eq(LogStash::Inputs::Dummy)
+      end
+    end
   end
 
   context "when loading code defined plugins" do
@@ -72,6 +81,11 @@ describe LogStash::Plugins::Registry do
 
     it "should return the expected class also for aliased plugins" do
       klass = registry.lookup("input", "alias_input")
+      expect(klass).to eq(LogStash::Inputs::NewPlugin)
+    end
+
+    it "should return the expected class also for alias-targeted plugins" do
+      klass = registry.lookup("input", "new_plugin")
       expect(klass).to eq(LogStash::Inputs::NewPlugin)
     end
   end

--- a/logstash-core/spec/logstash/plugins/registry_spec.rb
+++ b/logstash-core/spec/logstash/plugins/registry_spec.rb
@@ -40,7 +40,6 @@ describe LogStash::Plugins::Registry do
   context "when loading installed plugins" do
     let(:alias_registry) { Java::org.logstash.plugins.AliasRegistry.new({"alias_std_input" => "stdin"}) }
     let(:plugin) { double("plugin") }
-#     let(:registry) { described_class.new alias_registry }
 
     it "should return the expected class" do
       klass = registry.lookup("input", "stdin")

--- a/logstash-core/src/main/java/org/logstash/plugins/AliasRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/AliasRegistry.java
@@ -1,0 +1,47 @@
+package org.logstash.plugins;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AliasRegistry {
+    private final Map<String, String> ALIASES = new HashMap<>();
+    private final Map<String, String> REVERSE_ALIASES = new HashMap<>();
+
+    public AliasRegistry() {
+        configurePluginAliases();
+    }
+
+    private void configurePluginAliases() {
+        ALIASES.put("elastic_agent", "beats");
+        ALIASES.put("dna_java_generator", "java_generator");
+        for (Map.Entry<String, String> e : ALIASES.entrySet()) {
+            if (REVERSE_ALIASES.containsKey(e.getValue())) {
+                throw new IllegalStateException("Found plugin " + e.getValue() + " aliased more than one time");
+            }
+            REVERSE_ALIASES.put(e.getValue(), e.getKey());
+        }
+    }
+
+    public boolean isAlias(String pluginName) {
+        return ALIASES.containsKey(pluginName);
+    }
+
+    public boolean isAliased(String realPluginName) {
+        return ALIASES.containsValue(realPluginName);
+    }
+
+    public String originalFromAlias(String pluginAlias) {
+        return ALIASES.get(pluginAlias);
+    }
+
+    public String aliasFromOriginal(String realPluginName) {
+        return REVERSE_ALIASES.get(realPluginName);
+    }
+
+    /**
+     * if pluginName is an alias then return the real plugin name else return it unchanged
+     */
+    public String resolveAlias(String pluginName) {
+        return ALIASES.getOrDefault(pluginName, pluginName);
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/plugins/AliasRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/AliasRegistry.java
@@ -34,6 +34,9 @@ public class AliasRegistry {
         return aliases.containsKey(pluginName);
     }
 
+    /**
+     * Dual operation of isAlias
+     * */
     public boolean isAliased(String realPluginName) {
         return aliases.containsValue(realPluginName);
     }

--- a/logstash-core/src/main/java/org/logstash/plugins/AliasRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/AliasRegistry.java
@@ -4,44 +4,52 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class AliasRegistry {
-    private final Map<String, String> ALIASES = new HashMap<>();
-    private final Map<String, String> REVERSE_ALIASES = new HashMap<>();
+    private final Map<String, String> aliases = new HashMap<>();
+    private final Map<String, String> reversedAliases = new HashMap<>();
 
     public AliasRegistry() {
-        configurePluginAliases();
+        Map<String, String> defaultDefinitions = new HashMap<>();
+        defaultDefinitions.put("elastic_agent", "beats");
+        configurePluginAliases(defaultDefinitions);
     }
 
-    private void configurePluginAliases() {
-        ALIASES.put("elastic_agent", "beats");
-        ALIASES.put("dna_java_generator", "java_generator");
-        for (Map.Entry<String, String> e : ALIASES.entrySet()) {
-            if (REVERSE_ALIASES.containsKey(e.getValue())) {
+    /**
+     * Constructor used in tests to customize the plugins renames
+     * */
+    public AliasRegistry(Map<String, String> aliasDefinitions) {
+        configurePluginAliases(aliasDefinitions);
+    }
+
+    private void configurePluginAliases(Map<String, String> aliases) {
+        this.aliases.putAll(aliases);
+        for (Map.Entry<String, String> e : this.aliases.entrySet()) {
+            if (reversedAliases.containsKey(e.getValue())) {
                 throw new IllegalStateException("Found plugin " + e.getValue() + " aliased more than one time");
             }
-            REVERSE_ALIASES.put(e.getValue(), e.getKey());
+            reversedAliases.put(e.getValue(), e.getKey());
         }
     }
 
     public boolean isAlias(String pluginName) {
-        return ALIASES.containsKey(pluginName);
+        return aliases.containsKey(pluginName);
     }
 
     public boolean isAliased(String realPluginName) {
-        return ALIASES.containsValue(realPluginName);
+        return aliases.containsValue(realPluginName);
     }
 
     public String originalFromAlias(String pluginAlias) {
-        return ALIASES.get(pluginAlias);
+        return aliases.get(pluginAlias);
     }
 
     public String aliasFromOriginal(String realPluginName) {
-        return REVERSE_ALIASES.get(realPluginName);
+        return reversedAliases.get(realPluginName);
     }
 
     /**
      * if pluginName is an alias then return the real plugin name else return it unchanged
      */
     public String resolveAlias(String pluginName) {
-        return ALIASES.getOrDefault(pluginName, pluginName);
+        return aliases.getOrDefault(pluginName, pluginName);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/plugins/AliasRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/AliasRegistry.java
@@ -1,58 +1,117 @@
 package org.logstash.plugins;
 
+import org.logstash.plugins.PluginLookup.PluginType;
+
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 public class AliasRegistry {
-    private final Map<String, String> aliases = new HashMap<>();
-    private final Map<String, String> reversedAliases = new HashMap<>();
+
+    private final static class PluginCoordinate {
+        private final PluginType type;
+        private final String name;
+
+        public PluginCoordinate(PluginType type, String name) {
+            this.type = type;
+            this.name = name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            PluginCoordinate that = (PluginCoordinate) o;
+            return type == that.type && Objects.equals(name, that.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(type, name);
+        }
+
+        PluginCoordinate withName(String name) {
+            return new PluginCoordinate(this.type, name);
+        }
+    }
+
+
+    private final Map<PluginCoordinate, String> aliases = new HashMap<>();
+    private final Map<PluginCoordinate, String> reversedAliases = new HashMap<>();
 
     public AliasRegistry() {
-        Map<String, String> defaultDefinitions = new HashMap<>();
-        defaultDefinitions.put("elastic_agent", "beats");
+        Map<PluginCoordinate, String> defaultDefinitions = new HashMap<>();
+        defaultDefinitions.put(new PluginCoordinate(PluginType.INPUT, "elastic_agent"), "beats");
         configurePluginAliases(defaultDefinitions);
     }
 
     /**
-     * Constructor used in tests to customize the plugins renames
+     * Constructor used in tests to customize the plugins renames.
+     * The input map's key are tuples of (type, name)
      * */
-    public AliasRegistry(Map<String, String> aliasDefinitions) {
-        configurePluginAliases(aliasDefinitions);
+    public AliasRegistry(Map<List<String>, String> aliasDefinitions) {
+        Map<PluginCoordinate, String> aliases = new HashMap<>();
+
+        // transform the (tye, name) into PluginCoordinate
+        for (Map.Entry<List<String>, String> e : aliasDefinitions.entrySet()) {
+            final List<String> tuple = e.getKey();
+            final PluginCoordinate key = mapTupleToCoordinate(tuple);
+            aliases.put(key, e.getValue());
+        }
+
+        configurePluginAliases(aliases);
     }
 
-    private void configurePluginAliases(Map<String, String> aliases) {
+    private PluginCoordinate mapTupleToCoordinate(List<String> tuple) {
+        if (tuple.size() != 2) {
+            throw new IllegalArgumentException("Expected a tuple of 2 elements, but found: " + tuple);
+        }
+        final PluginType type = PluginType.valueOf(tuple.get(0).toUpperCase());
+        final String name = tuple.get(1);
+        final PluginCoordinate key = new PluginCoordinate(type, name);
+        return key;
+    }
+
+    private void configurePluginAliases(Map<PluginCoordinate, String> aliases) {
         this.aliases.putAll(aliases);
-        for (Map.Entry<String, String> e : this.aliases.entrySet()) {
-            if (reversedAliases.containsKey(e.getValue())) {
+        for (Map.Entry<PluginCoordinate, String> e : this.aliases.entrySet()) {
+            final PluginCoordinate reversedAlias = e.getKey().withName(e.getValue());
+            if (reversedAliases.containsKey(reversedAlias)) {
                 throw new IllegalStateException("Found plugin " + e.getValue() + " aliased more than one time");
             }
-            reversedAliases.put(e.getValue(), e.getKey());
+            reversedAliases.put(reversedAlias, e.getKey().name);
         }
     }
 
-    public boolean isAlias(String pluginName) {
-        return aliases.containsKey(pluginName);
+    public boolean isAlias(String type, String pluginName) {
+        final PluginType pluginType = PluginType.valueOf(type.toUpperCase());
+
+        return isAlias(pluginType, pluginName);
     }
 
-    /**
-     * Dual operation of isAlias
-     * */
-    public boolean isAliased(String realPluginName) {
-        return aliases.containsValue(realPluginName);
+    public boolean isAlias(PluginType type, String pluginName) {
+        return aliases.containsKey(new PluginCoordinate(type, pluginName));
     }
 
-    public String originalFromAlias(String pluginAlias) {
-        return aliases.get(pluginAlias);
+    public String originalFromAlias(PluginType type, String alias) {
+        return aliases.get(new PluginCoordinate(type, alias));
     }
 
-    public String aliasFromOriginal(String realPluginName) {
-        return reversedAliases.get(realPluginName);
+    public String originalFromAlias(String type, String alias) {
+        return originalFromAlias(PluginType.valueOf(type.toUpperCase()), alias);
+    }
+
+    public Optional<String> aliasFromOriginal(PluginType type, String realPluginName) {
+        return Optional.ofNullable(reversedAliases.get(new PluginCoordinate(type, realPluginName)));
     }
 
     /**
      * if pluginName is an alias then return the real plugin name else return it unchanged
      */
-    public String resolveAlias(String pluginName) {
-        return aliases.getOrDefault(pluginName, pluginName);
+    public String resolveAlias(String type, String pluginName) {
+        final PluginCoordinate pluginCoord = new PluginCoordinate(PluginType.valueOf(type.toUpperCase()), pluginName);
+        return aliases.getOrDefault(pluginCoord, pluginName);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginLookup.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginLookup.java
@@ -45,9 +45,6 @@ import java.util.stream.Stream;
  */
 public final class PluginLookup implements PluginFactoryExt.PluginResolver {
 
-    private static final Map<String, String> ALIASES = new HashMap<>();
-    private static final Map<String, String> REVERSE_ALIASES = new HashMap<>();
-
     private static final IRubyObject RUBY_REGISTRY = RubyUtil.RUBY.executeScript(
             "require 'logstash/plugins/registry'\nrequire 'logstash/plugin'\nLogStash::Plugin",
             ""
@@ -57,40 +54,6 @@ public final class PluginLookup implements PluginFactoryExt.PluginResolver {
 
     public PluginLookup(PluginRegistry pluginRegistry) {
         this.pluginRegistry = pluginRegistry;
-    }
-
-    private static void configurePluginAliases() {
-        ALIASES.put("elastic_agent", "beats");
-        ALIASES.put("dna_java_generator", "java_generator");
-        for (Map.Entry<String, String> e : ALIASES.entrySet()) {
-            if (REVERSE_ALIASES.containsKey(e.getValue())) {
-                throw new IllegalStateException("Found plugin " + e.getValue() + " aliased more than one time");
-            }
-            REVERSE_ALIASES.put(e.getValue(), e.getKey());
-        }
-    }
-
-    public static boolean isAlias(String pluginName) {
-        return ALIASES.containsKey(pluginName);
-    }
-
-    public static boolean isAliased(String realPluginName) {
-        return ALIASES.containsValue(realPluginName);
-    }
-
-    public static String originalFromAlias(String pluginAlias) {
-        return ALIASES.get(pluginAlias);
-    }
-
-    public static String aliasFromOriginal(String realPluginName) {
-        return REVERSE_ALIASES.get(realPluginName);
-    }
-
-    /**
-     * if pluginName is an alias then return the real plugin name else return it unchanged
-     * */
-    public static String resolveAlias(String pluginName) {
-        return ALIASES.getOrDefault(pluginName, pluginName);
     }
 
     @SuppressWarnings("rawtypes")

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginLookup.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginLookup.java
@@ -34,8 +34,6 @@ import org.logstash.RubyUtil;
 import org.logstash.plugins.discovery.PluginRegistry;
 import org.logstash.plugins.factory.PluginFactoryExt;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
@@ -20,6 +20,8 @@
 
 package org.logstash.plugins.discovery;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.logstash.plugins.AliasRegistry;
 import org.logstash.plugins.PluginLookup;
 import co.elastic.logstash.api.Codec;
@@ -46,6 +48,8 @@ import java.util.Set;
  * </ul>
  * */
 public final class PluginRegistry {
+
+    private static final Logger LOGGER = LogManager.getLogger(PluginRegistry.class);
 
     private final Map<String, Class<Input>> inputs = new HashMap<>();
     private final Map<String, Class<Filter>> filters = new HashMap<>();
@@ -124,6 +128,12 @@ public final class PluginRegistry {
     }
 
     public Class<?> getPluginClass(PluginLookup.PluginType pluginType, String pluginName) {
+        if (aliasRegistry.isAlias(pluginName)) {
+            final String typeStr = pluginType.name().toLowerCase();
+            LOGGER.info("Plugin {} is aliased as {}", typeStr + "-" + pluginName,
+                    typeStr + "-" + aliasRegistry.originalFromAlias(pluginName));
+        }
+
         if (pluginType == PluginLookup.PluginType.FILTER) {
             return getFilterClass(pluginName);
         }

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
@@ -115,17 +115,16 @@ public final class PluginRegistry {
         final Map<String, Class<T>> aliasesToAdd = new HashMap<>();
         for (Map.Entry<String, Class<T>> e : pluginCache.entrySet()) {
             final String realPluginName = e.getKey();
-                final Optional<String> alias = aliasRegistry.aliasFromOriginal(type, realPluginName);
-                if (alias.isPresent()) {
-                    final String aliasName = alias.get();
-                    if (!pluginCache.containsKey(aliasName)) {
-                        // no real plugin with same alias name was found
-                        aliasesToAdd.put(aliasName, e.getValue());
-                        final String typeStr = pluginType.name().toLowerCase();
-                        LOGGER.info("Plugin {}-{} is aliased as {}-{}", typeStr, realPluginName, typeStr, aliasName);
-        }
-                    }
+            final Optional<String> alias = aliasRegistry.aliasFromOriginal(type, realPluginName);
+            if (alias.isPresent()) {
+                final String aliasName = alias.get();
+                if (!pluginCache.containsKey(aliasName)) {
+                    // no real plugin with same alias name was found
+                    aliasesToAdd.put(aliasName, e.getValue());
+                    final String typeStr = type.name().toLowerCase();
+                    LOGGER.info("Plugin {}-{} is aliased as {}-{}", typeStr, realPluginName, typeStr, aliasName);
                 }
+            }
         }
         for (Map.Entry<String, Class<T>> e : aliasesToAdd.entrySet()) {
             pluginCache.put(e.getKey(), e.getValue());

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
@@ -52,12 +52,10 @@ public final class PluginRegistry {
     private final Map<String, Class<Codec>> codecs = new HashMap<>();
     private static final Object LOCK = new Object();
     private static volatile PluginRegistry INSTANCE;
-    private final Map<String, String> ALIASES = new HashMap<>();
-    private final Map<String, String> REVERSE_ALIASES = new HashMap<>();
 
     private PluginRegistry() {
         //order is important here, alias is used by lookup in discoverPlugins
-        configurePluginAliases();
+//        configurePluginAliases();
         discoverPlugins();
     }
 
@@ -72,40 +70,6 @@ public final class PluginRegistry {
         return INSTANCE;
     }
     
-    private void configurePluginAliases() {
-        ALIASES.put("elastic_agent", "beats");
-        ALIASES.put("dna_java_generator", "java_generator");
-        for (Map.Entry<String, String> e : ALIASES.entrySet()) {
-            if (REVERSE_ALIASES.containsKey(e.getValue())) {
-                throw new IllegalStateException("Found plugin " + e.getValue() + " aliased more than one time");
-            }
-            REVERSE_ALIASES.put(e.getValue(), e.getKey());
-        }
-    }
-
-    public boolean isAlias(String pluginName) {
-        return ALIASES.containsKey(pluginName);
-    }
-
-    private boolean isAliased(String realPluginName) {
-        return ALIASES.containsValue(realPluginName);
-    }
-
-    public String originalFromAlias(String pluginAlias) {
-        return ALIASES.get(pluginAlias);
-    }
-
-    public String aliasFromOriginal(String realPluginName) {
-        return REVERSE_ALIASES.get(realPluginName);
-    }
-
-    /**
-     * if pluginName is an alias then return the real plugin name else return it unchanged
-     * */
-    public String resolveAlias(String pluginName) {
-        return ALIASES.getOrDefault(pluginName, pluginName);
-    }
-
     @SuppressWarnings("unchecked")
     private void discoverPlugins() {
         // the constructor of Reflection must be called only by one thread, else there is a
@@ -145,8 +109,8 @@ public final class PluginRegistry {
         final Map<String, Class<T>> aliasesToAdd = new HashMap<>();
         for (Map.Entry<String, Class<T>> e : pluginCache.entrySet()) {
             final String realPluginName = e.getKey();
-            if (isAliased(realPluginName)) {
-                final String alias = aliasFromOriginal(realPluginName);
+            if (PluginLookup.isAliased(realPluginName)) {
+                final String alias = PluginLookup.aliasFromOriginal(realPluginName);
                 if (!inputs.containsKey(alias)) {
                     // no real plugin with same alias name was found
                     aliasesToAdd.put(alias, e.getValue());

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
@@ -130,11 +130,6 @@ public final class PluginRegistry {
     }
 
     public Class<?> getPluginClass(PluginType pluginType, String pluginName) {
-        if (aliasRegistry.isAlias(pluginType, pluginName)) {
-            final String typeStr = pluginType.name().toLowerCase();
-            LOGGER.info("Plugin {} is aliased as {}", typeStr + "-" + pluginName,
-                    typeStr + "-" + aliasRegistry.originalFromAlias(pluginType, pluginName));
-        }
         
         switch (pluginType) {
             case FILTER:

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
@@ -121,6 +121,9 @@ public final class PluginRegistry {
                     if (!pluginCache.containsKey(aliasName)) {
                         // no real plugin with same alias name was found
                         aliasesToAdd.put(aliasName, e.getValue());
+                        final String typeStr = pluginType.name().toLowerCase();
+                        LOGGER.info("Plugin {}-{} is aliased as {}-{}", typeStr, realPluginName, typeStr, aliasName);
+        }
                     }
                 }
         }

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
@@ -135,22 +135,19 @@ public final class PluginRegistry {
             LOGGER.info("Plugin {} is aliased as {}", typeStr + "-" + pluginName,
                     typeStr + "-" + aliasRegistry.originalFromAlias(pluginType, pluginName));
         }
-
-        if (pluginType == PluginType.FILTER) {
-            return getFilterClass(pluginName);
+        
+        switch (pluginType) {
+            case FILTER:
+                return getFilterClass(pluginName);
+            case OUTPUT:
+                return getOutputClass(pluginName);
+            case INPUT:
+                return getInputClass(pluginName);
+            case CODEC:
+                return getCodecClass(pluginName);
+            default:
+                throw new IllegalStateException("Unknown plugin type: " + pluginType);
         }
-        if (pluginType == PluginType.OUTPUT) {
-            return getOutputClass(pluginName);
-        }
-        if (pluginType == PluginType.INPUT) {
-            return getInputClass(pluginName);
-        }
-        if (pluginType == PluginType.CODEC) {
-            return getCodecClass(pluginName);
-        }
-
-        throw new IllegalStateException("Unknown plugin type: " + pluginType);
-
     }
 
     public Class<Input> getInputClass(String name) {

--- a/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java
@@ -18,6 +18,7 @@ import org.logstash.execution.ExecutionContextExt;
 import org.logstash.instrument.metrics.AbstractMetricExt;
 import org.logstash.instrument.metrics.AbstractNamespacedMetricExt;
 import org.logstash.instrument.metrics.MetricKeys;
+import org.logstash.plugins.AliasRegistry;
 import org.logstash.plugins.ConfigVariableExpander;
 import org.logstash.plugins.PluginLookup;
 import org.logstash.plugins.discovery.PluginRegistry;
@@ -82,7 +83,7 @@ public final class PluginFactoryExt extends RubyBasicObject
     }
 
     public PluginFactoryExt(final Ruby runtime, final RubyClass metaClass) {
-        this(runtime, metaClass, new PluginLookup(PluginRegistry.getInstance()));
+        this(runtime, metaClass, new PluginLookup(PluginRegistry.getInstance(new AliasRegistry())));
     }
 
     PluginFactoryExt(final Ruby runtime, final RubyClass metaClass, PluginResolver pluginResolver) {


### PR DESCRIPTION
If the plugin name is an alias and no other plugin exists with same name then load the alised one

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Introduce the concept of aliased plugin, to let a plugin be renamed easily

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

An alias for a plugin is a just a rename of an existing plugin, in this way the alias can be used in pipeline configuration. If later a real plugin with same name of the alias is released then that plugin takes precedence over the alias name. 
Suppose we a plugin filter named `teleport` and we also alias it as `teleport_over_fiber`, the `teleport_over_fiber` alias can be used in interchangeable way as `teleport` with same parameters and behavior. In a future when a real plugin that leverage fiber transmission for teleport a plugin `teleport_over_fiber` name is effectively released, this real plugin takes precedence to over the alias.

The changes to `logstash-plugin` tool used to manage the installation, listing and removal of aliased plugin is handled by the PR #12821

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
It lets the user to star using today plugins names that will be released as independent plugin in near future.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] try a local run

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Use an alias in a pipeline config, for example:
```ruby
input {
  elastic_agent { # beats alias
     port => 5044
   }
}
output { stdout {} }
```
check that it runs correctly with `bin/logstash -f pipeline.conf`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
