### PR TITLE
spike: migrate org.logstash.Timestamp to wrap java.time.Instant

### DIFF
--- a/logstash-core/src/main/java/org/logstash/StringInterpolation.java
+++ b/logstash-core/src/main/java/org/logstash/StringInterpolation.java
@@ -22,8 +22,10 @@ package org.logstash;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
 
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
@@ -72,13 +74,11 @@ public final class StringInterpolation {
             }
             if (template.regionMatches(open + 2, "+%s", 0, close - open - 2)) {
                 Timestamp t = event.getTimestamp();
-                builder.append(t == null ? "" : t.getTime().getMillis() / 1000L);
+                builder.append(t == null ? "" : t.getInstant().getEpochSecond());
             } else if (template.charAt(open + 2) == '+') {
                 Timestamp t = event.getTimestamp();
                 builder.append(t != null
-                        ? event.getTimestamp().getTime().toString(
-                                DateTimeFormat.forPattern(template.substring(open + 3, close))
-                                        .withZone(DateTimeZone.UTC))
+                        ? DateTimeFormatter.ofPattern(template.substring(open + 3, close)).withZone(ZoneOffset.UTC).format(t.getInstant())
                         : ""
                     );
             } else {

--- a/logstash-core/src/main/java/org/logstash/Timestamp.java
+++ b/logstash-core/src/main/java/org/logstash/Timestamp.java
@@ -22,62 +22,60 @@ package org.logstash;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import java.time.Instant;
 import java.util.Date;
-import org.joda.time.Chronology;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.joda.time.Duration;
-import org.joda.time.LocalDateTime;
-import org.joda.time.chrono.ISOChronology;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 import org.logstash.ackedqueue.Queueable;
 
 /**
- * Wrapper around a {@link DateTime} with Logstash specific serialization behaviour.
- * This class is immutable and thread-safe since its only state is held in a final {@link DateTime}
- * reference and {@link DateTime} which itself is immutable and thread-safe.
+ * Wrapper around a {@link Instant} with Logstash specific serialization behaviour.
+ * This class is immutable and thread-safe since its only state is held in a final {@link Instant}
+ * reference and {@link Instant} which itself is immutable and thread-safe.
  */
 @JsonSerialize(using = ObjectMappers.TimestampSerializer.class)
 @JsonDeserialize(using = ObjectMappers.TimestampDeserializer.class)
 public final class Timestamp implements Comparable<Timestamp>, Queueable {
 
-    // all methods setting the time object must set it in the UTC timezone
-    private final DateTime time;
+    private transient DateTime time;
 
-    private static final DateTimeFormatter iso8601Formatter = ISODateTimeFormat.dateTime();
-
-    private static final LocalDateTime JAN_1_1970 = new LocalDateTime(1970, 1, 1, 0, 0);
-
-    /**
-     * {@link Chronology} for UTC timezone, cached here to avoid lookup of it when constructing
-     * {@link DateTime} instances.
-     */
-    private static final Chronology UTC_CHRONOLOGY = ISOChronology.getInstance(DateTimeZone.UTC);
+    private final Instant instant;
 
     public Timestamp() {
-        this.time = new DateTime(UTC_CHRONOLOGY);
+        this(Instant.now());
     }
 
     public Timestamp(String iso8601) {
-        this.time =
-            ISODateTimeFormat.dateTimeParser().parseDateTime(iso8601).toDateTime(UTC_CHRONOLOGY);
+        this(Instant.parse(iso8601));
     }
 
     public Timestamp(long epoch_milliseconds) {
-        this.time = new DateTime(epoch_milliseconds, UTC_CHRONOLOGY);
+        this(Instant.ofEpochMilli(epoch_milliseconds));
     }
 
-    public Timestamp(Date date) {
-        this.time = new DateTime(date, UTC_CHRONOLOGY);
+    public Timestamp(final Date date) {
+        this(date.toInstant());
     }
 
-    public Timestamp(DateTime date) {
-        this.time = date.toDateTime(UTC_CHRONOLOGY);
+    public Timestamp(final DateTime date) {
+        this(date.getMillis());
     }
 
+    public Timestamp(final Instant instant) {
+        this.instant = instant;
+    }
+
+    @Deprecated // use Timestamp#getInstant()
     public DateTime getTime() {
+        if (time == null) {
+            time = new DateTime(instant.toEpochMilli(), DateTimeZone.UTC);
+        }
         return time;
+    }
+
+    public Instant getInstant() {
+        return this.getInstant();
     }
 
     public static Timestamp now() {
@@ -85,33 +83,31 @@ public final class Timestamp implements Comparable<Timestamp>, Queueable {
     }
 
     public String toString() {
-        return iso8601Formatter.print(this.time);
+        return instant.toString();
     }
 
     public long toEpochMilli() {
-        return time.getMillis();
+        return instant.toEpochMilli();
     }
 
     // returns the fraction of a second as microseconds, not the number of microseconds since epoch
     public long usec() {
-        // JodaTime only supports milliseconds precision we can only return usec at millisec precision.
-        // note that getMillis() return millis since epoch
-        return (new Duration(JAN_1_1970.toDateTime(DateTimeZone.UTC), this.time).getMillis() % 1000) * 1000;
+        return instant.getNano() / 1000;
     }
 
     @Override
     public int compareTo(Timestamp other) {
-        return time.compareTo(other.time);
+        return instant.compareTo(other.instant);
     }
     
     @Override
     public boolean equals(final Object other) {
-        return other instanceof Timestamp && time.equals(((Timestamp) other).time);
+        return other instanceof Timestamp && instant.equals(((Timestamp) other).instant);
     }
 
     @Override
     public int hashCode() {
-        return time.hashCode();
+        return instant.hashCode();
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -157,7 +157,7 @@ public final class DeadLetterQueueWriter implements Closeable {
         lock.lock();
         try {
             Timestamp entryTimestamp = Timestamp.now();
-            if (entryTimestamp.getTime().isBefore(lastEntryTimestamp.getTime())) {
+            if (entryTimestamp.getInstant().isBefore(lastEntryTimestamp.getInstant())) {
                 entryTimestamp = lastEntryTimestamp;
             }
             innerWriteEntry(entry);

--- a/logstash-core/src/test/java/org/logstash/TimestampTest.java
+++ b/logstash-core/src/test/java/org/logstash/TimestampTest.java
@@ -37,6 +37,7 @@ public class TimestampTest {
         Timestamp t1 = new Timestamp();
         Timestamp t2 = new Timestamp(t1.toString());
         assertEquals(t1.getTime(), t2.getTime());
+        assertEquals(t1.getInstant(), t2.getInstant());
     }
 
     @Test
@@ -46,6 +47,7 @@ public class TimestampTest {
     }
 
     // Timestamp should always be in a UTC representation
+    // TODO: remove spec, since `Instant` is UTC by default.
     @Test
     public void testUTC() throws Exception {
         Timestamp t;
@@ -82,4 +84,11 @@ public class TimestampTest {
         Assert.assertEquals(i.toEpochMilli(), millis);
     }
 
+    @Test
+    public void testNanoPrecision() {
+        final String input = "2021-04-02T00:28:17.987654321Z";
+        final Timestamp t1 = new Timestamp(input);
+
+        assertEquals(987654321, t1.getInstant().getNano());
+    }
 }


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Adds initial support for nanosecond-precision timestamps on events.

## What does this PR do?

Changes our `org.logstash.Timestamp` to wrap Java 8+'s `java.time.Instant`, which allows us to maintain nanosecond-precision timestamps during some stages of processing. Access to an equivalent `org.joda.time.DateTime` is still available via the existing `org.logstash.Timestamp#getTime()` method, but has been deprecated in favor of `org.logstash.Timestamp#getInstant()`

## Why is it important/What is the impact to the user?

As processing times speed up, millisecond granularity is not always enough. Inbound data increasingly has sub-millisecond granularity timestamps, and as long as we wrap `org.joda.time.DateTime` this granularity is truncated. This change-set allows at least one of the internal mechanisms that holds moment-in-time data to have nanosecond granularity.

It is meant as a proof-of-concept to run initially against CI, and to be carried forward as planning allows.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

It is unclear just yet if changing `org.logstash.Timestamp` is enough.

- [ ] serializing: do we serialize nanoseconds by default?
- [ ] downstream: can downstream services handle nanosecond precision ISO8601 strings gracefully (whether by maintaining precision or losing it), or do they reject the input?
  - [ ] elasticsearch time fields
  - [ ] others?
- [ ] does precision survive being serialised into the PQ and deserialised back out by the workers? 

