### PR TITLE
Removed static part from PluginRegistry to avoid static initializer

### DIFF
--- a/logstash-core/src/main/java/org/logstash/plugins/PluginLookup.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginLookup.java
@@ -32,6 +32,7 @@ import org.jruby.javasupport.JavaClass;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.RubyUtil;
 import org.logstash.plugins.discovery.PluginRegistry;
+import org.logstash.plugins.factory.PluginFactoryExt;
 
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -40,20 +41,23 @@ import java.util.stream.Stream;
  * Java Implementation of the plugin that is implemented by wrapping the Ruby
  * {@code LogStash::Plugin} class for the Ruby plugin lookup.
  */
-public final class PluginLookup {
+public final class PluginLookup implements PluginFactoryExt.PluginResolver {
 
     private static final IRubyObject RUBY_REGISTRY = RubyUtil.RUBY.executeScript(
             "require 'logstash/plugins/registry'\nrequire 'logstash/plugin'\nLogStash::Plugin",
             ""
     );
 
-    private PluginLookup() {
-        // Utility Class
+    private final PluginRegistry pluginRegistry;
+
+    public PluginLookup(PluginRegistry pluginRegistry) {
+        this.pluginRegistry = pluginRegistry;
     }
 
     @SuppressWarnings("rawtypes")
-    public static PluginLookup.PluginClass lookup(final PluginLookup.PluginType type, final String name) {
-        Class<?> javaClass = PluginRegistry.getPluginClass(type, name);
+    @Override
+    public PluginClass resolve(PluginType type, String name) {
+        Class<?> javaClass = pluginRegistry.getPluginClass(type, name);
         if (javaClass != null) {
 
             if (!PluginValidator.validatePlugin(type, javaClass)) {

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
@@ -51,7 +51,7 @@ public final class PluginRegistry {
     private final Map<String, Class<Output>> outputs = new HashMap<>();
     private final Map<String, Class<Codec>> codecs = new HashMap<>();
     private static final Object lock = new Object();
-    private static PluginRegistry instance;
+    private static volatile PluginRegistry instance;
 
     private PluginRegistry() {
         discoverPlugins();

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
@@ -50,22 +50,22 @@ public final class PluginRegistry {
     private final Map<String, Class<Filter>> filters = new HashMap<>();
     private final Map<String, Class<Output>> outputs = new HashMap<>();
     private final Map<String, Class<Codec>> codecs = new HashMap<>();
-    private static final Object lock = new Object();
-    private static volatile PluginRegistry instance;
+    private static final Object LOCK = new Object();
+    private static volatile PluginRegistry INSTANCE;
 
     private PluginRegistry() {
         discoverPlugins();
     }
 
     public static PluginRegistry getInstance() {
-        if (instance == null) {
-            synchronized (lock) {
-                if (instance == null) {
-                    instance = new PluginRegistry();
+        if (INSTANCE == null) {
+            synchronized (LOCK) {
+                if (INSTANCE == null) {
+                    INSTANCE = new PluginRegistry();
                 }
             }
         }
-        return instance;
+        return INSTANCE;
     }
     
     @SuppressWarnings("unchecked")

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
@@ -41,19 +41,17 @@ import java.util.Set;
  */
 public final class PluginRegistry {
 
-    private static final Map<String, Class<Input>> INPUTS = new HashMap<>();
-    private static final Map<String, Class<Filter>> FILTERS = new HashMap<>();
-    private static final Map<String, Class<Output>> OUTPUTS = new HashMap<>();
-    private static final Map<String, Class<Codec>> CODECS = new HashMap<>();
+    private final Map<String, Class<Input>> inputs = new HashMap<>();
+    private final Map<String, Class<Filter>> filters = new HashMap<>();
+    private final Map<String, Class<Output>> outputs = new HashMap<>();
+    private final Map<String, Class<Codec>> codecs = new HashMap<>();
 
-    static {
+    public PluginRegistry() {
         discoverPlugins();
     }
-
-    private PluginRegistry() {} // utility class
-
+    
     @SuppressWarnings("unchecked")
-    private static void discoverPlugins() {
+    private void discoverPlugins() {
         Reflections reflections = new Reflections("org.logstash.plugins");
         Set<Class<?>> annotated = reflections.getTypesAnnotatedWith(LogstashPlugin.class);
         for (final Class<?> cls : annotated) {
@@ -61,16 +59,16 @@ public final class PluginRegistry {
                 if (annotation instanceof LogstashPlugin) {
                     String name = ((LogstashPlugin) annotation).name();
                     if (Filter.class.isAssignableFrom(cls)) {
-                        FILTERS.put(name, (Class<Filter>) cls);
+                        filters.put(name, (Class<Filter>) cls);
                     }
                     if (Output.class.isAssignableFrom(cls)) {
-                        OUTPUTS.put(name, (Class<Output>) cls);
+                        outputs.put(name, (Class<Output>) cls);
                     }
                     if (Input.class.isAssignableFrom(cls)) {
-                        INPUTS.put(name, (Class<Input>) cls);
+                        inputs.put(name, (Class<Input>) cls);
                     }
                     if (Codec.class.isAssignableFrom(cls)) {
-                        CODECS.put(name, (Class<Codec>) cls);
+                        codecs.put(name, (Class<Codec>) cls);
                     }
 
                     break;
@@ -79,7 +77,7 @@ public final class PluginRegistry {
         }
     }
 
-    public static Class<?> getPluginClass(PluginLookup.PluginType pluginType, String pluginName) {
+    public Class<?> getPluginClass(PluginLookup.PluginType pluginType, String pluginName) {
         if (pluginType == PluginLookup.PluginType.FILTER) {
             return getFilterClass(pluginName);
         }
@@ -97,31 +95,31 @@ public final class PluginRegistry {
 
     }
 
-    public static Class<Input> getInputClass(String name) {
-        return INPUTS.get(name);
+    public Class<Input> getInputClass(String name) {
+        return inputs.get(name);
     }
 
-    public static Class<Filter> getFilterClass(String name) {
-        return FILTERS.get(name);
+    public Class<Filter> getFilterClass(String name) {
+        return filters.get(name);
     }
 
-    public static Class<Codec> getCodecClass(String name) {
-        return CODECS.get(name);
+    public Class<Codec> getCodecClass(String name) {
+        return codecs.get(name);
     }
 
-    public static Class<Output> getOutputClass(String name) {
-        return OUTPUTS.get(name);
+    public Class<Output> getOutputClass(String name) {
+        return outputs.get(name);
     }
 
-    public static Codec getCodec(String name, Configuration configuration, Context context) {
-        if (name != null && CODECS.containsKey(name)) {
-            return instantiateCodec(CODECS.get(name), configuration, context);
+    public Codec getCodec(String name, Configuration configuration, Context context) {
+        if (name != null && codecs.containsKey(name)) {
+            return instantiateCodec(codecs.get(name), configuration, context);
         }
         return null;
     }
 
     @SuppressWarnings({"unchecked","rawtypes"})
-    private static Codec instantiateCodec(Class clazz, Configuration configuration, Context context) {
+    private Codec instantiateCodec(Class clazz, Configuration configuration, Context context) {
         try {
             Constructor<Codec> constructor = clazz.getConstructor(Configuration.class, Context.class);
             return constructor.newInstance(configuration, context);

--- a/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java
@@ -82,7 +82,7 @@ public final class PluginFactoryExt extends RubyBasicObject
     }
 
     public PluginFactoryExt(final Ruby runtime, final RubyClass metaClass) {
-        this(runtime, metaClass, new PluginLookup(new PluginRegistry()));
+        this(runtime, metaClass, new PluginLookup(PluginRegistry.getInstance()));
     }
 
     PluginFactoryExt(final Ruby runtime, final RubyClass metaClass, PluginResolver pluginResolver) {

--- a/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java
@@ -20,6 +20,7 @@ import org.logstash.instrument.metrics.AbstractNamespacedMetricExt;
 import org.logstash.instrument.metrics.MetricKeys;
 import org.logstash.plugins.ConfigVariableExpander;
 import org.logstash.plugins.PluginLookup;
+import org.logstash.plugins.discovery.PluginRegistry;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -81,7 +82,7 @@ public final class PluginFactoryExt extends RubyBasicObject
     }
 
     public PluginFactoryExt(final Ruby runtime, final RubyClass metaClass) {
-        this(runtime, metaClass, PluginLookup::lookup);
+        this(runtime, metaClass, new PluginLookup(new PluginRegistry()));
     }
 
     PluginFactoryExt(final Ruby runtime, final RubyClass metaClass, PluginResolver pluginResolver) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

- Removes the need of static initializer and static methods in `org.logstash.plugins.discovery.PluginRegistry`
- Changed `org.logstash.plugins.PluginLookup` to implement `org.logstash.plugins.factory.PluginFactoryExt.PluginResolver`

These changes are preparatory to adding an "alias resolver" during plugin lookup #12796

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

Static initializers and static method made test impossible when a dependency is static instead of customizable.
Other than this, the construction sequence is made explicit, describing better the chain of dependency of various services.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ x] Run Logstash to laod a pipeline configuration with and without Java native plugins. Java native plugins are those loaded by Java's PluginRegistry.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #12796
