### PR TITLE
Docs: note on quoted field references

### DIFF
--- a/docs/static/field-reference.asciidoc
+++ b/docs/static/field-reference.asciidoc
@@ -44,9 +44,11 @@ fieldReferenceLiteral
 
 [float]
 
-NOTE: In Logstash 7.x and older `["foo"]` is considered a field reference and isn't treated as a single element array.
-This might cause confusion in conditional e.g `[message] in ["foo", "bar"]` vs `[message] in ["foo"]`.
-We do not recommend using names with quotes such as `"\"foo\""` since the `["foo"]` behavior might change in the future.
+NOTE: In Logstash 7.x and earlier, a quoted value (such as `["foo"]`) is
+considered a field reference and isn't treated as a single element array. This
+behavior might cause confusion in conditionals, such as `[message] in ["foo",
+"bar"]` compared to `[message] in ["foo"]`. We discourage using names with
+quotes, such as `"\"foo\""`, as this behavior might change in the future.
 
 [[formal-grammar-field-reference]]
 ==== Field Reference (Event APIs)

--- a/docs/static/field-reference.asciidoc
+++ b/docs/static/field-reference.asciidoc
@@ -42,14 +42,13 @@ fieldReferenceLiteral
   : ( pathFragment )+
   ;
 
-[float]
-
 NOTE: In Logstash 7.x and earlier, a quoted value (such as `["foo"]`) is
 considered a field reference and isn't treated as a single element array. This
 behavior might cause confusion in conditionals, such as `[message] in ["foo",
 "bar"]` compared to `[message] in ["foo"]`. We discourage using names with
 quotes, such as `"\"foo\""`, as this behavior might change in the future.
 
+[float]
 [[formal-grammar-field-reference]]
 ==== Field Reference (Event APIs)
 

--- a/docs/static/field-reference.asciidoc
+++ b/docs/static/field-reference.asciidoc
@@ -43,6 +43,11 @@ fieldReferenceLiteral
   ;
 
 [float]
+
+NOTE: In Logstash 7.x and older `["foo"]` is considered a field reference and isn't treated as a single element array.
+This might cause confusion in conditional e.g `[message] in ["foo", "bar"]` vs `[message] in ["foo"]`.
+We do not recommend using names with quotes such as `"\"foo\""` since the `["foo"]` behavior might change in the future.
+
 [[formal-grammar-field-reference]]
 ==== Field Reference (Event APIs)
 


### PR DESCRIPTION

## What does this PR do?

Field reference documentation update.

## Why is it important/What is the impact to the user?

Confusing behavior on `["foo"]` quoted field references.


## Related issues

- see GH-5591
