### PR TITLE
Test: cleanup for every test (follow-up #12784)

### DIFF
--- a/qa/integration/specs/cli/keystore_spec.rb
+++ b/qa/integration/specs/cli/keystore_spec.rb
@@ -31,6 +31,10 @@ describe "CLI > logstash-keystore" do
     @logstash = @fixture.get_service("logstash")
   end
 
+  after do
+    FileUtils.rm_f File.join(@logstash.logstash_home, 'config', 'logstash.keystore')
+  end
+
   context 'create' do
 
     before do
@@ -50,10 +54,6 @@ describe "CLI > logstash-keystore" do
     before do
       keystore = File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "fixtures", "logstash.keystore"))
       FileUtils.cp keystore, File.join(@logstash.logstash_home, 'config')
-    end
-
-    after do
-      FileUtils.rm_f File.join(@logstash.logstash_home, 'config', 'logstash.keystore')
     end
 
     it "works" do


### PR DESCRIPTION
In #12784 the integration spec could leave the unpacked tar with a `config/logstash-keystore` file.
This causes :red_circle:  while backporting to 7.x / 7.12 due order of tests.


## What does this PR do?

Just a quick follow up on #12784 for a more stable test experience.

## Why is it important/What is the impact to the user?

Avoids potentially unexpected CI failures.