### PR TITLE
Fix integration test to allow wildcard deletion in elasticsearch

### DIFF
--- a/x-pack/qa/integration/support/helpers.rb
+++ b/x-pack/qa/integration/support/helpers.rb
@@ -35,7 +35,8 @@ def elasticsearch(options = {})
     "path.data" => temporary_path_data,
 
     "xpack.monitoring.collection.enabled" => true,
-    "xpack.security.enabled" => true
+    "xpack.security.enabled" => true,
+    "action.destructive_requires_name" => false
   }
   settings = default_settings.merge(options.fetch(:settings, {}))
   settings_arguments = settings.collect { |k, v| "-E#{k}=#{v}" }


### PR DESCRIPTION
Elasticsearch [change](https://github.com/elastic/elasticsearch/pull/66908) the default behavior to not accept wildcard in DELETE 
This PR set the `action.destructive_requires_name` to false in integration test