### PR TITLE
[backport 7.x] Fix Date class clash when used in pipelines with Date filter and GeoIP and pin open-ssl to 0.10.5 (#12811)

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "mustermann", '~> 1.0.3'
   gem.add_runtime_dependency "sinatra", '~> 2'
   gem.add_runtime_dependency 'puma', '~> 4'
-  gem.add_runtime_dependency "jruby-openssl", "~> 0.10" # >= 0.9.13 Required to support TLSv1.2
+  gem.add_runtime_dependency "jruby-openssl", "= 0.10.5" # >= 0.9.13 Required to support TLSv1.2
   gem.add_runtime_dependency "chronic_duration", "~> 0.10"
 
   gem.add_runtime_dependency "treetop", "~> 1" #(MIT license)

--- a/x-pack/lib/filters/geoip/database_manager.rb
+++ b/x-pack/lib/filters/geoip/database_manager.rb
@@ -106,7 +106,7 @@ module LogStash module Filters module Geoip class DatabaseManager
   end
 
   def check_age
-    days_without_update = (Date.today - Time.at(@metadata.updated_at).to_date).to_i
+    days_without_update = (::Date.today - ::Time.at(@metadata.updated_at).to_date).to_i
 
     case
     when days_without_update >= 30


### PR DESCRIPTION
Clean backport of #12811 to `7.x`

This commit contains two fixes
* Fix Date class clash when used in pipelines with Date filter and GeoIP
* Pinned jruby-openssl version 0.10.5 to avoid SSL errors

(cherry picked from commit 6f55066b17bc795d07d629b5292258d1541171cc)
