### PR TITLE
Backport PR #12801 to 7.x: Docs: note on quoted field references

### DIFF
--- a/docs/static/field-reference.asciidoc
+++ b/docs/static/field-reference.asciidoc
@@ -42,6 +42,12 @@ fieldReferenceLiteral
   : ( pathFragment )+
   ;
 
+NOTE: In Logstash 7.x and earlier, a quoted value (such as `["foo"]`) is
+considered a field reference and isn't treated as a single element array. This
+behavior might cause confusion in conditionals, such as `[message] in ["foo",
+"bar"]` compared to `[message] in ["foo"]`. We discourage using names with
+quotes, such as `"\"foo\""`, as this behavior might change in the future.
+
 [float]
 [[formal-grammar-field-reference]]
 ==== Field Reference (Event APIs)


### PR DESCRIPTION
Backport PR #12801 to 7.x branch. Original message: 


## What does this PR do?

Field reference documentation update.

## Why is it important/What is the impact to the user?

Confusing behavior on `["foo"]` quoted field references.


## Related issues

- see GH-5591
