### PR TITLE
Adapted install/uninstall/list PluginManager's command to respect the alised plugins

### DIFF
--- a/lib/pluginmanager/install.rb
+++ b/lib/pluginmanager/install.rb
@@ -129,8 +129,8 @@ class LogStash::PluginManager::Install < LogStash::PluginManager::Command
       puts("Validating #{[plugin, version].compact.join("-")}")
       next if validate_plugin(plugin, version, options)
       # if the plugin is alias fallback to the original name
-      if plugin == "logstash-input-elastic_agent"
-        aliased_plugin = "logstash-input-beats"
+      if LogStash::PluginManager::ALIASES.has_key?(plugin)
+        aliased_plugin = LogStash::PluginManager::ALIASES[plugin]
         if validate_plugin(aliased_plugin, version, options)
           puts "Remapping alias #{plugin} to #{aliased_plugin}"
           gems_swap[plugin] = aliased_plugin

--- a/lib/pluginmanager/install.rb
+++ b/lib/pluginmanager/install.rb
@@ -128,7 +128,10 @@ class LogStash::PluginManager::Install < LogStash::PluginManager::Command
     gems.each do |plugin, version|
       puts("Validating #{[plugin, version].compact.join("-")}")
       next if validate_plugin(plugin, version, options)
-      # if the plugin is alias fallback to the original name
+
+      signal_usage_error("Installs of an alias doesn't require version specification --version") if version
+
+      # if the plugin is an alias then fallback to the original name
       if LogStash::PluginManager::ALIASES.has_key?(plugin)
         resolved_plugin = LogStash::PluginManager::ALIASES[plugin]
         if validate_plugin(resolved_plugin, version, options)

--- a/lib/pluginmanager/install.rb
+++ b/lib/pluginmanager/install.rb
@@ -130,10 +130,10 @@ class LogStash::PluginManager::Install < LogStash::PluginManager::Command
       next if validate_plugin(plugin, version, options)
       # if the plugin is alias fallback to the original name
       if LogStash::PluginManager::ALIASES.has_key?(plugin)
-        aliased_plugin = LogStash::PluginManager::ALIASES[plugin]
-        if validate_plugin(aliased_plugin, version, options)
-          puts "Remapping alias #{plugin} to #{aliased_plugin}"
-          gems_swap[plugin] = aliased_plugin
+        resolved_plugin = LogStash::PluginManager::ALIASES[plugin]
+        if validate_plugin(resolved_plugin, version, options)
+          puts "Remapping alias #{plugin} to #{resolved_plugin}"
+          gems_swap[plugin] = resolved_plugin
           next
         end
       end

--- a/lib/pluginmanager/list.rb
+++ b/lib/pluginmanager/list.rb
@@ -39,8 +39,8 @@ class LogStash::PluginManager::List < LogStash::PluginManager::Command
     filtered_specs.sort_by{|spec| spec.name}.each do |spec|
       line = "#{spec.name}"
       line += " (#{spec.version})" if verbose?
-      if spec.name == "logstash-input-beats"
-        alias_plugin = "logstash-input-elastic_agent"
+      if LogStash::PluginManager::ALIASES.has_value?(spec.name)
+        alias_plugin = LogStash::PluginManager::ALIASES.key(spec.name)
         line += " ==> #{alias_plugin}" unless installed_plugin_names.include?(alias_plugin)
       end
       puts(line)

--- a/lib/pluginmanager/list.rb
+++ b/lib/pluginmanager/list.rb
@@ -34,9 +34,15 @@ class LogStash::PluginManager::List < LogStash::PluginManager::Command
 
     signal_error("No plugins found") if filtered_specs.empty?
 
+    installed_plugin_names = filtered_specs.collect {|spec| spec.name}
+
     filtered_specs.sort_by{|spec| spec.name}.each do |spec|
       line = "#{spec.name}"
       line += " (#{spec.version})" if verbose?
+      if spec.name == "logstash-input-beats"
+        alias_plugin = "logstash-input-elastic_agent"
+        line += " ==> #{alias_plugin}" unless installed_plugin_names.include?(alias_plugin)
+      end
       puts(line)
       if spec.metadata.fetch("logstash_group", "") == "integration"
         integration_plugins = spec.metadata.fetch("integration_plugins", "").split(",")

--- a/lib/pluginmanager/list.rb
+++ b/lib/pluginmanager/list.rb
@@ -39,11 +39,11 @@ class LogStash::PluginManager::List < LogStash::PluginManager::Command
     filtered_specs.sort_by{|spec| spec.name}.each do |spec|
       line = "#{spec.name}"
       line += " (#{spec.version})" if verbose?
+      puts(line)
       if LogStash::PluginManager::ALIASES.has_value?(spec.name)
         alias_plugin = LogStash::PluginManager::ALIASES.key(spec.name)
-        line += " ==> #{alias_plugin}" unless installed_plugin_names.include?(alias_plugin)
+        puts("└── #{alias_plugin} (alias)") unless installed_plugin_names.include?(alias_plugin)
       end
-      puts(line)
       if spec.metadata.fetch("logstash_group", "") == "integration"
         integration_plugins = spec.metadata.fetch("integration_plugins", "").split(",")
         integration_plugins.each_with_index do |integration_plugin, i|

--- a/lib/pluginmanager/remove.rb
+++ b/lib/pluginmanager/remove.rb
@@ -35,7 +35,7 @@ class LogStash::PluginManager::Remove < LogStash::PluginManager::Command
     if LogStash::PluginManager::ALIASES.has_key?(plugin)
       unless LogStash::PluginManager.installed_plugin?(plugin, gemfile)
         aliased_plugin = LogStash::PluginManager::ALIASES[plugin]
-        puts "Removing the alias #{plugin}, please remove the aliased plugin: #{aliased_plugin}"
+        puts "Cannot remove the alias #{plugin}, which is an alias for #{aliased_plugin}; if you wish to remove it, you must remove the aliased plugin instead."
         return
       end
     end

--- a/lib/pluginmanager/remove.rb
+++ b/lib/pluginmanager/remove.rb
@@ -32,9 +32,9 @@ class LogStash::PluginManager::Remove < LogStash::PluginManager::Command
     ##
     LogStash::Bundler.setup!({:without => [:build, :development]})
 
-    if plugin == "logstash-input-elastic_agent"
+    if LogStash::PluginManager::ALIASES.has_key?(plugin)
       unless LogStash::PluginManager.installed_plugin?(plugin, gemfile)
-        aliased_plugin = "logstash-input-beats"
+        aliased_plugin = LogStash::PluginManager::ALIASES[plugin]
         puts "Removing the alias #{plugin}, please remove the aliased plugin: #{aliased_plugin}"
         return
       end

--- a/lib/pluginmanager/remove.rb
+++ b/lib/pluginmanager/remove.rb
@@ -32,6 +32,14 @@ class LogStash::PluginManager::Remove < LogStash::PluginManager::Command
     ##
     LogStash::Bundler.setup!({:without => [:build, :development]})
 
+    if plugin == "logstash-input-elastic_agent"
+      unless LogStash::PluginManager.installed_plugin?(plugin, gemfile)
+        aliased_plugin = "logstash-input-beats"
+        puts "Removing the alias #{plugin}, please remove the aliased plugin: #{aliased_plugin}"
+        return
+      end
+    end
+
     # If a user is attempting to uninstall X-Pack, present helpful output to guide
     # them toward the OSS-only distribution of Logstash
     LogStash::PluginManager::XPackInterceptor::Remove.intercept!(plugin)

--- a/lib/pluginmanager/update.rb
+++ b/lib/pluginmanager/update.rb
@@ -111,9 +111,9 @@ class LogStash::PluginManager::Update < LogStash::PluginManager::Command
       # resolve aliases that doesn't correspond to a real gem
       plugins_to_update = plugins_arg.map do |plugin|
         if not_installed_aliases.include?(plugin)
-          plugin_alias = LogStash::PluginManager::ALIASES[plugin]
-          puts "Remapping alias #{plugin} to #{plugin_alias}"
-          plugin_alias
+          resolved_plugin = LogStash::PluginManager::ALIASES[plugin]
+          puts "Remapping alias #{plugin} to #{resolved_plugin}"
+          resolved_plugin
         else
           plugin
         end

--- a/lib/pluginmanager/update.rb
+++ b/lib/pluginmanager/update.rb
@@ -64,17 +64,6 @@ class LogStash::PluginManager::Update < LogStash::PluginManager::Command
     # calling update without requirements will remove any previous requirements
     plugins = plugins_to_update(previous_gem_specs_map)
 
-#     # remap aliased plugins to original
-#     plugins = plugins.map do |plugin|
-#                            if LogStash::PluginManager::ALIASES.has_key?(plugin)
-#                              plugin_alias = LogStash::PluginManager::ALIASES[plugin]
-#                              puts "Remapping alias #{plugin} to #{plugin_alias}"
-#                              plugin_alias
-#                            else
-#                              plugin
-#                            end
-#                          end
-
     # Skipping the major version validation when using a local cache as we can have situations
     # without internet connection.
     filtered_plugins = plugins.map { |plugin| gemfile.find(plugin) }

--- a/lib/pluginmanager/update.rb
+++ b/lib/pluginmanager/update.rb
@@ -63,6 +63,18 @@ class LogStash::PluginManager::Update < LogStash::PluginManager::Command
     # remove any version constrain from the Gemfile so the plugin(s) can be updated to latest version
     # calling update without requirements will remove any previous requirements
     plugins = plugins_to_update(previous_gem_specs_map)
+
+#     # remap aliased plugins to original
+#     plugins = plugins.map do |plugin|
+#                            if LogStash::PluginManager::ALIASES.has_key?(plugin)
+#                              plugin_alias = LogStash::PluginManager::ALIASES[plugin]
+#                              puts "Remapping alias #{plugin} to #{plugin_alias}"
+#                              plugin_alias
+#                            else
+#                              plugin
+#                            end
+#                          end
+
     # Skipping the major version validation when using a local cache as we can have situations
     # without internet connection.
     filtered_plugins = plugins.map { |plugin| gemfile.find(plugin) }
@@ -99,9 +111,25 @@ class LogStash::PluginManager::Update < LogStash::PluginManager::Command
       # If the plugins isn't available in the gemspec or in 
       # the gemfile defined with a local path, we assume the plugins is not
       # installed.
-      not_installed = plugins_arg.select{|plugin| !previous_gem_specs_map.has_key?(plugin.downcase) && !gemfile.find(plugin) }
+      not_installed = plugins_arg.select { |plugin| !previous_gem_specs_map.has_key?(plugin.downcase) && !gemfile.find(plugin) }
+
+      # find only the not installed that doesn't correspond to an alias
+      not_installed_aliases = not_installed.select { |plugin| LogStash::PluginManager::ALIASES.has_key?(plugin)}
+      not_installed -= not_installed_aliases
+
       signal_error("Plugin #{not_installed.join(', ')} is not installed so it cannot be updated, aborting") unless not_installed.empty?
-      plugins_arg
+
+      # resolve aliases that doesn't correspond to a real gem
+      plugins_to_update = plugins_arg.map do |plugin|
+        if not_installed_aliases.include?(plugin)
+          plugin_alias = LogStash::PluginManager::ALIASES[plugin]
+          puts "Remapping alias #{plugin} to #{plugin_alias}"
+          plugin_alias
+        else
+          plugin
+        end
+      end
+      plugins_to_update
     end
   end
 

--- a/lib/pluginmanager/util.rb
+++ b/lib/pluginmanager/util.rb
@@ -20,6 +20,9 @@ require_relative "../bootstrap/patches/remote_fetcher"
 
 module LogStash::PluginManager
 
+  # Defines the plugin alias, must be kept in synch with Java class org.logstash.plugins.AliasRegistry
+  ALIASES = {"logstash-input-elastic_agent" => "logstash-input-beats"}
+
   class ValidationError < StandardError; end
 
   # check for valid logstash plugin gem name & version or .gem file, logs errors to $stdout


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Let `bin/logstash-plugin` to `install` `uninstall` aliased plugin and shows the aliased plugin name near to the original during `list` command.

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

This PR is follow up on #12796 and adapt the `logstash-plugin` tool to manage aliased plugins.
It follow this behavior:
- if a real plugin corresponding to the alias exists then installs it, else resolves the alias to the original plugin and installs that, notifying the user.
- in listing of plugins it displays the alias name close to the unaliased real plugin unless it's installed a plugin with same of the alias.
- during removal of an alias if there isn't installed a real plugin with same name it asks the user to remove the unaliased plugin
- update: if a real plugin with same name of the alias is already installed then updates normally, else resolved the alias to the origin plugin and update that.

This PR has actually an hardcoded mapping between alias and real plugin, ~~after #12796 it should use the same mapping source~~ it can't share AliasRegistry class with `logstash-core` module


## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
Let the user to install an aliased plugin, and int he future when a real plugin with same name is released it permit to install the real plugin transparently

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] test `install` `uninstall` and `list` commands

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

From a local copy of this branch use the command `bin/logstah-plugin` to:
- `install logstash-input-elastic_agent` installing the aliased plugin and check that Beats input is installed
- `list` and check that near `logstash-input-beats` there is the indication of the aliased plugin
- `uninstall logstash-input-elastic_agent` and gets notified that to remove it is necessary to remove the original aliased plugin
- `update logstash-input-elastic_agent` and gets notified that the alias is resolved to beats and the beats plugin is updated

NB the usage of `elastic_agent` in configuration won't work till this PR is rebased on top of #12796 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #12793

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
#### installation
```
> bin/logstash-plugin install logstash-input-elastic_agent

Validating logstash-input-elastic_agent
Plugin logstash-input-elastic_agent does not exist
Remapping alias logstash-input-elastic_agent to logstash-input-beats
Installing logstash-input-beats
Installation successful
```

#### listing
```
> bin/logstash-plugin list
...
logstash-input-beats ==> logstash-input-elastic_agent
...
```

#### Removal
```
> bin/logstash-plugin uninstall logstash-input-elastic_agent

Removing the alias logstash-input-elastic_agent, please remove the aliased plugin: logstash-input-beats
```

#### Update
```
> bin/logstash-plugin update logstash-input-elastic_agent

Remapping alias logstash-input-elastic_agent to logstash-input-beats
Updating logstash-input-beats
Bundler attempted to update logstash-input-beats but its version stayed the same
No plugin updated
```

