### PR TITLE
ecs: on-by-default plus docs

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -64,7 +64,7 @@
 # if there are multiple workers.
 # "false" will disable any extra processing necessary for preserving ordering.
 #
-pipeline.ordered: auto
+# pipeline.ordered: auto
 #
 # ------------ Pipeline Configuration Settings --------------
 #

--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -66,6 +66,22 @@
 #
 # pipeline.ordered: auto
 #
+# Sets the pipeline's default value for `ecs_compatibility`, a setting that is
+# available to plugins that implement an ECS Compatibility mode for use with
+# the Elastic Common Schema.
+# Possible values are:
+# - disabled
+# - v1 (default)
+# - v2
+# CAVEAT: use of this configuration for anything other than `disabled` -- including
+# the default value -- is considered BETA until the General Availability of
+# Logstash 8.0.0. As we continue to release updated plugins with ECS-Compatibility
+# modes, opting into them at a pipeline or process level will cause you to
+# automatically consume breaking changes with each upgrade, which may change the
+# shape of data your pipeline produces.
+#
+# pipeline.ecs_compatibility: v1
+#
 # ------------ Pipeline Configuration Settings --------------
 #
 # Where to fetch the pipeline configuration for the main pipeline

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -55,6 +55,10 @@ include::static/advanced-pipeline.asciidoc[]
 :edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/life-of-an-event.asciidoc
 include::static/life-of-an-event.asciidoc[]
 
+// Elastic Common Schema (ECS)
+:editurl!:
+include::static/ecs-compatibility.asciidoc[]
+
 // Processing details
 
 :edit_url!:

--- a/docs/static/ecs-compatibility.asciidoc
+++ b/docs/static/ecs-compatibility.asciidoc
@@ -1,0 +1,96 @@
+[[ecs-ls]]
+=== ECS in Logstash
+
+// LS8 will ship with ECS v8, but until ECS v8 is ready we rely on ECS v1 as an approximation.
+:ls8-ecs-major-version: v1
+
+The {ecs-ref}/index.html[Elastic Common Schema (ECS)] is an open source specification, developed with support from the Elastic user community.
+ECS defines a common set of fields to be used for storing event data, such as logs and metrics, in {es}.
+With ECS, users can normalize event data to better analyze, visualize, and correlate the data represented in their events.
+
+[[ecs-compatibility]]
+==== ECS compatibility
+
+Many plugins implement an ECS-compatibility mode, which causes them to produce and manipulate events in a manner that is compatible with the Elastic Common Schema (ECS).
+
+Any plugin that supports this mode will also have an `ecs_compatibility` option, which allows you to configure which mode the individual plugin instance should operate in.
+If left unspecified for an individual plugin, the pipeline's `pipeline.ecs_compatibility` setting will be observed.
+This allows you to configure plugins to use ECS -- or to lock in your existing non-ECS behavior -- in advance of your {ls} 8.0 upgrade where ECS will be enabled by default.
+
+ECS Compatibility modes do not prevent you from explicitly configuring a plugin in a manner that conflicts with ECS.
+Instead, they ensure that _implicit_ configuration avoids conflicts.
+
+NOTE: Until {ls} 8.0 and the final 7.x are released, any value for `pipeline.ecs_compatibility` other than `disabled` are considered BETA and unsupported.
+      As we continue to release plugins with ECS Compatibility modes, having this flag set will cause even patch-level upgrades to _automatically_ consume breaking changes in the upgraded plugins, changing the shape of data the plugin produces.
+
+ifeval::["{ls8-ecs-major-version}"!="v8"]
+NOTE: ECS `v8` will be the default in the GA release of {ls} 8.0.0, and will be available at or before the final minor release of {ls} 7.
+      We expect the scope of breaking changes in ECS 8 to be limited, but progress toward the definition of ECS v8 can be tracked https://github.com/elastic/ecs/issues/839[here].
+endif::[]
+
+[[ecs-configuration]]
+===== Configuring ECS
+
+ECS will be on by default in {ls} 8, but you can begin using it now by configuring individual plugins with `ecs_compatibility`.
+You can also "lock in" the existing non-ECS behavior for an entire pipeline to ensure its behavior doesn't change when you perform your next major upgrade.
+
+====== Specific plugin instance
+
+Use a plugin's `ecs_compatibility` option to override the default value on the plugin instance.
+
+For example, if you want a specific instance of the GeoIP Filter to behave without ECS compatibility, you can adjust its definition in your pipeline without affecting any other plugin instances.
+
+[source,text]
+-----
+filter {
+  geoip {
+    source => "[host][ip]"
+    ecs_compatibility => disabled
+  }
+}
+-----
+
+Alternatively, if you had a UDP input with a CEF codec, and wanted both to use an ECS mode while still running {ls} 7, you can adjust their definitions to specify the major version of ECS to use.
+
+[source,text,subs="attributes"]
+-----
+input {
+  udp {
+    port => 1234
+    ecs_compatibility => {ls8-ecs-major-version}
+    codec => cef {
+      ecs_compatibility => {ls8-ecs-major-version}
+    }
+  }
+}
+-----
+
+[[ecs-configuration-pipeline]]
+====== All plugins in a given pipeline
+
+If you wish to provide a specific default value for `ecs_compatibility` to _all_ plugins in a pipeline, you can do so with the `pipeline.ecs_compatibility` setting in your pipeline definition in `config/pipelines.yml` or Central Management.
+This setting will be used unless overridden by a specific plugin instance.
+If unspecified for an individual pipeline, the global value will be used.
+
+[source,yaml,subs="attributes"]
+-----
+- pipeline.id: my-legacy-pipeline
+  path.config: "/etc/path/to/legacy-pipeline.config"
+  pipeline.ecs_compatibility: disabled
+- pipeline.id: my-ecs-pipeline
+  path.config: "/etc/path/to/ecs-pipeline.config"
+  pipeline.ecs_compatibility: {ls8-ecs-major-version}
+-----
+
+NOTE: Until the final minor release of {ls} 7 that coincides with the General Availability of {ls} 8.0.0, any value for `pipeline.ecs_compatibility` other than `disabled` is considered BETA and unsupported because it will produce undesireable consequences when performing upgrades.
+      As we continue to release updated plugins with ECS-Compatibility modes, opting into them at a pipeline or process level will cause the affected plugins to silently and automatically consume breaking changes with each upgrade, which may change the shape of data your pipeline produces.
+
+[[ecs-configuration-all]]
+====== All plugins in all pipelines
+
+Similarly, you can set the default value for the whole {ls} process by setting the `pipeline.ecs_compatibility` value in `config/logstash.yml`.
+
+[source,yaml]
+-----
+pipeline.ecs_compatibility: disabled
+-----

--- a/docs/static/ecs-compatibility.asciidoc
+++ b/docs/static/ecs-compatibility.asciidoc
@@ -15,24 +15,25 @@ Many plugins implement an ECS-compatibility mode, which causes them to produce a
 
 Any plugin that supports this mode will also have an `ecs_compatibility` option, which allows you to configure which mode the individual plugin instance should operate in.
 If left unspecified for an individual plugin, the pipeline's `pipeline.ecs_compatibility` setting will be observed.
-This allows you to configure plugins to use ECS -- or to lock in your existing non-ECS behavior -- in advance of your {ls} 8.0 upgrade where ECS will be enabled by default.
+This allows you to configure plugins to use their legacy non-ECS behavior: individually, per-pipeline, or globally.
 
 ECS Compatibility modes do not prevent you from explicitly configuring a plugin in a manner that conflicts with ECS.
 Instead, they ensure that _implicit_ configuration avoids conflicts.
 
-NOTE: Until {ls} 8.0 and the final 7.x are released, any value for `pipeline.ecs_compatibility` other than `disabled` are considered BETA and unsupported.
-      As we continue to release plugins with ECS Compatibility modes, having this flag set will cause even patch-level upgrades to _automatically_ consume breaking changes in the upgraded plugins, changing the shape of data the plugin produces.
+NOTE: Until {ls} 8.0 and the final 7.x are released, any value for `pipeline.ecs_compatibility` other than `disabled` -- _including the default value on pre-release builds_ -- are considered BETA and unsupported.
+      As we continue to release plugins with ECS Compatibility modes, having this flag set will cause upgrades to _automatically_ consume breaking changes from one snapshot to another, changing the shape of data the plugin produces.
+      If you require stability while testing against the unreleased {ls} 8, we encourage you to opt-out globally or per-pipeline as detailed below.
 
 ifeval::["{ls8-ecs-major-version}"!="v8"]
-NOTE: ECS `v8` will be the default in the GA release of {ls} 8.0.0, and will be available at or before the final minor release of {ls} 7.
+NOTE: This pre-release branch of {ls} 8 defaults to ECS {ls8-ecs-major-version}, but by the time {ls} 8 ships, it will point to ECS v8.
       We expect the scope of breaking changes in ECS 8 to be limited, but progress toward the definition of ECS v8 can be tracked https://github.com/elastic/ecs/issues/839[here].
 endif::[]
 
-[[ecs-configuration]]
-===== Configuring ECS
+[[ecs-optout]]
+===== Opting out of ECS
 
-ECS will be on by default in {ls} 8, but you can begin using it now by configuring individual plugins with `ecs_compatibility`.
-You can also "lock in" the existing non-ECS behavior for an entire pipeline to ensure its behavior doesn't change when you perform your next major upgrade.
+In {ls} 8, these plugins are run in ECS mode by default, but you can opt out at the plugin, pipeline, or system level to maintain legacy behavior.
+This can be helpful if you have very complex pipelines that were defined pre-ECS, to allow you to either upgrade them or to avoid doing so independently of your {ls} 8.x upgrade.
 
 ====== Specific plugin instance
 
@@ -50,22 +51,7 @@ filter {
 }
 -----
 
-Alternatively, if you had a UDP input with a CEF codec, and wanted both to use an ECS mode while still running {ls} 7, you can adjust their definitions to specify the major version of ECS to use.
-
-[source,text,subs="attributes"]
------
-input {
-  udp {
-    port => 1234
-    ecs_compatibility => {ls8-ecs-major-version}
-    codec => cef {
-      ecs_compatibility => {ls8-ecs-major-version}
-    }
-  }
-}
------
-
-[[ecs-configuration-pipeline]]
+[[ecs-optout-pipeline]]
 ====== All plugins in a given pipeline
 
 If you wish to provide a specific default value for `ecs_compatibility` to _all_ plugins in a pipeline, you can do so with the `pipeline.ecs_compatibility` setting in your pipeline definition in `config/pipelines.yml` or Central Management.
@@ -82,10 +68,10 @@ If unspecified for an individual pipeline, the global value will be used.
   pipeline.ecs_compatibility: {ls8-ecs-major-version}
 -----
 
-NOTE: Until the final minor release of {ls} 7 that coincides with the General Availability of {ls} 8.0.0, any value for `pipeline.ecs_compatibility` other than `disabled` is considered BETA and unsupported because it will produce undesireable consequences when performing upgrades.
+NOTE: Until the General Availability of {ls} 8.0.0, any value for `pipeline.ecs_compatibility` other than `disabled` -- including the default value `{ls8-ecs-major-version}` on this pre-release branch -- may have undesireable consequences when performing upgrades.
       As we continue to release updated plugins with ECS-Compatibility modes, opting into them at a pipeline or process level will cause the affected plugins to silently and automatically consume breaking changes with each upgrade, which may change the shape of data your pipeline produces.
 
-[[ecs-configuration-all]]
+[[ecs-optout-all]]
 ====== All plugins in all pipelines
 
 Similarly, you can set the default value for the whole {ls} process by setting the `pipeline.ecs_compatibility` value in `config/logstash.yml`.

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -60,7 +60,7 @@ module LogStash
            Setting::Boolean.new("pipeline.plugin_classloaders", false),
            Setting::Boolean.new("pipeline.separate_logs", false),
    Setting::CoercibleString.new("pipeline.ordered", "auto", true, ["auto", "true", "false"]),
-   Setting::CoercibleString.new("pipeline.ecs_compatibility", "disabled", true, %w(disabled v1 v2)),
+   Setting::CoercibleString.new("pipeline.ecs_compatibility", "v1", true, %w(disabled v1 v8)),
                     Setting.new("path.plugins", Array, []),
     Setting::NullableString.new("interactive", nil, false),
            Setting::Boolean.new("config.debug", false),

--- a/logstash-core/lib/logstash/plugins/ecs_compatibility_support.rb
+++ b/logstash-core/lib/logstash/plugins/ecs_compatibility_support.rb
@@ -20,11 +20,6 @@ module LogStash
             pipeline_settings = pipeline && pipeline.settings
             pipeline_settings ||= LogStash::SETTINGS
 
-            if !pipeline_settings.set?('pipeline.ecs_compatibility')
-              deprecation_logger.deprecated("Relying on default value of `pipeline.ecs_compatibility`, which may change in a future major release of Logstash. " +
-                                            "To avoid unexpected changes when upgrading Logstash, please explicitly declare your desired ECS Compatibility mode.")
-            end
-
             pipeline_settings.get_value('pipeline.ecs_compatibility').to_sym
           end
         end

--- a/logstash-core/spec/conditionals_spec.rb
+++ b/logstash-core/spec/conditionals_spec.rb
@@ -100,9 +100,10 @@ describe "conditionals in filter" do
     # this setting here for the sake of minimizing change
     # but unsure if this is actually required.
 
-    s = LogStash::SETTINGS.clone
-    s.set_value("pipeline.workers", 1)
-    s
+    LogStash::SETTINGS.clone.tap do |s|
+      s.set_value("pipeline.workers", 1)
+      s.set_value("pipeline.ordered", true)
+    end
   end
 
   describe "simple" do
@@ -518,6 +519,7 @@ describe "conditionals in filter" do
       filter {
         if [type] == "original" {
           clone {
+            ecs_compatibility => disabled # rely on legacy clone plugin behaviour
             clones => ["clone"]
           }
         }
@@ -548,6 +550,7 @@ describe "conditionals in filter" do
       filter {
         if [type] == "original" {
           clone {
+            ecs_compatibility => disabled # rely on legacy clone plugin behaviour
             clones => ["clone1", "clone2"]
           }
         }

--- a/logstash-core/spec/logstash/java_pipeline_spec.rb
+++ b/logstash-core/spec/logstash/java_pipeline_spec.rb
@@ -731,6 +731,7 @@ describe LogStash::JavaPipeline do
       config <<-CONFIG
         filter {
           clone {
+            ecs_compatibility => disabled
             clones => ["clone1", "clone2"]
           }
           mutate {

--- a/logstash-core/spec/logstash/plugin_spec.rb
+++ b/logstash-core/spec/logstash/plugin_spec.rb
@@ -461,16 +461,9 @@ describe LogStash::Plugin do
       end
 
       context 'and pipeline-level setting is not specified' do
-        it 'emits a deprecation warning about using the default which may change' do
-          instance.ecs_compatibility
-
-          expect(deprecation_logger_stub).to have_received(:deprecated) do |message|
-            expect(message).to include("Relying on default value of `pipeline.ecs_compatibility`")
-          end
-        end
-        it 'returns `disabled`' do
+        it 'returns `v1`' do
           # Default value of `pipeline.ecs_compatibility`
-          expect(instance.ecs_compatibility).to eq(:disabled)
+          expect(instance.ecs_compatibility).to eq(:v1)
         end
       end
     end

--- a/qa/integration/fixtures/es_output_how_spec.yml
+++ b/qa/integration/fixtures/es_output_how_spec.yml
@@ -4,7 +4,7 @@ services:
   - elasticsearch
 config: |-
   input {
-    stdin { }
+    stdin { ecs_compatibility => disabled }
   }
 
   filter {
@@ -19,15 +19,21 @@ config: |-
       locale => en
     }
     geoip {
+      ecs_compatibility => disabled
       source => "clientip"
     }
     useragent {
+      ecs_compatibility => disabled
       source => "agent"
       target => "useragent"
     }
   }
   output {
-    elasticsearch { data_stream => "false" index => "logstash-integration-test" }
+    elasticsearch {
+      data_stream => "false"
+      ecs_compatibility => disabled
+      index => "logstash-integration-test"
+    }
   }
 
 input: how_sample.input


### PR DESCRIPTION
**PREVIEW:** https://logstash_12830.docs-preview.app.elstc.co/guide/en/logstash/master/ecs-ls.html

## Release notes

Sets ECS to on-by-default (`v1`, for now). This setting will again change to `v8` when ECS v8 goes into public Alpha in advance of the Stack 8.0.0 release.

## What does this PR do?

This change makes ECS Compatibility modes on-by-default (as previously promised in https://github.com/elastic/logstash/issues/11623) and adds documentation about how to configure ECS Compatibility Modes at the plugin instance, pipeline, and global levels.

These docs are from the perspective of someone running (the unreleased, pre-alpha) Logstash 8, and a backport will need to be entirely re-worded from the perspective of Logstash 7.x to lead people _toward_ the upgrade.

If a user wants to "lock in" pre-ECS behaviour in 7.x, they can do at different levels so by:
1. declaring `ecs_compatibility => disabled` on each individual plugin; OR
2. declaring `pipeline.ecs_compatibility: disabled` in each pipeline's definition (`config/pipelines.yml` or Central Management)
3. declaring `pipeline.ecs_compatibility: disabled` in `config/logstash.yml` to provide a global default for pipelines.

## Why is it important/What is the impact to the user?

The transition to ECS being on-by-default with Logstash 8.0 is a potentially sharp edge, as the plugins that implement ECS Compatibility modes will operate differently than in their legacy versions when run in Logstash 8, unless specific effort is made to opt-out of the breaking change.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works
