### PR TITLE
[Backport 7.x] Plugin Manager adaptation to handle alias plugins

### DIFF
--- a/lib/pluginmanager/list.rb
+++ b/lib/pluginmanager/list.rb
@@ -34,10 +34,16 @@ class LogStash::PluginManager::List < LogStash::PluginManager::Command
 
     signal_error("No plugins found") if filtered_specs.empty?
 
+    installed_plugin_names = filtered_specs.collect {|spec| spec.name}
+
     filtered_specs.sort_by{|spec| spec.name}.each do |spec|
       line = "#{spec.name}"
       line += " (#{spec.version})" if verbose?
       puts(line)
+      if LogStash::PluginManager::ALIASES.has_value?(spec.name)
+        alias_plugin = LogStash::PluginManager::ALIASES.key(spec.name)
+        puts("└── #{alias_plugin} (alias)") unless installed_plugin_names.include?(alias_plugin)
+      end
       if spec.metadata.fetch("logstash_group", "") == "integration"
         integration_plugins = spec.metadata.fetch("integration_plugins", "").split(",")
         integration_plugins.each_with_index do |integration_plugin, i|

--- a/lib/pluginmanager/remove.rb
+++ b/lib/pluginmanager/remove.rb
@@ -32,6 +32,14 @@ class LogStash::PluginManager::Remove < LogStash::PluginManager::Command
     ##
     LogStash::Bundler.setup!({:without => [:build, :development]})
 
+    if LogStash::PluginManager::ALIASES.has_key?(plugin)
+      unless LogStash::PluginManager.installed_plugin?(plugin, gemfile)
+        aliased_plugin = LogStash::PluginManager::ALIASES[plugin]
+        puts "Cannot remove the alias #{plugin}, which is an alias for #{aliased_plugin}; if you wish to remove it, you must remove the aliased plugin instead."
+        return
+      end
+    end
+
     # If a user is attempting to uninstall X-Pack, present helpful output to guide
     # them toward the OSS-only distribution of Logstash
     LogStash::PluginManager::XPackInterceptor::Remove.intercept!(plugin)

--- a/lib/pluginmanager/util.rb
+++ b/lib/pluginmanager/util.rb
@@ -20,6 +20,9 @@ require_relative "../bootstrap/patches/remote_fetcher"
 
 module LogStash::PluginManager
 
+  # Defines the plugin alias, must be kept in synch with Java class org.logstash.plugins.AliasRegistry
+  ALIASES = {"logstash-input-elastic_agent" => "logstash-input-beats"}
+
   class ValidationError < StandardError; end
 
   # check for valid logstash plugin gem name & version or .gem file, logs errors to $stdout


### PR DESCRIPTION
Clean backport of #12821 to `7.x`

Adapted install/uninstall/list PluginManager's CLI commands to respect the alised plugins
- adapt install plugin to resolve an alias giving precedence on a real plugin
- changed list to mark alised plugins
- uninstall avoid to remove the alias and ask the user to remove the original plugin
- update update the original plugin in case of alias, else fallback on usual behavior

Co-authored-by: Ry Biesemeyer <ry.biesemeyer@elastic.co>
(cherry picked from commit 1e08341e1ea7e269182cd40e70d13bd95bd6e9b2)
