### PR TITLE
Doc: Implement install widgets with platform tabs

### DIFF
--- a/docs/static/getting-started-with-logstash.asciidoc
+++ b/docs/static/getting-started-with-logstash.asciidoc
@@ -30,6 +30,8 @@ ZIP, or RPM.
 Unpack the file. Do not install Logstash into a directory path that
 contains colon (:) characters.
 
+include::../tab-widgets/install-binary/widget.asciidoc[]
+
 [NOTE]
 --
 These packages are free to use under the Elastic license. They contain open 

--- a/docs/static/getting-started-with-logstash.asciidoc
+++ b/docs/static/getting-started-with-logstash.asciidoc
@@ -30,6 +30,7 @@ ZIP, or RPM.
 Unpack the file. Do not install Logstash into a directory path that
 contains colon (:) characters.
 
+include::../tab-widgets/tab-widget-code/code.asciidoc[]
 include::../tab-widgets/install-binary/widget.asciidoc[]
 
 [NOTE]

--- a/docs/tab-widgets/install-binary/deb-aarch64.asciidoc
+++ b/docs/tab-widgets/install-binary/deb-aarch64.asciidoc
@@ -1,0 +1,15 @@
+ifeval::["{release-state}"=="unreleased"]
+
+Version {logstash_version} of Logstash has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+------------------------------------------------
+curl -L -O https://artifacts.elastic.co/downloads/logstash-{version}-amd64.deb
+sudo dpkg -i logstash-{version}-amd64.deb
+------------------------------------------------
+
+endif::[]

--- a/docs/tab-widgets/install-binary/deb-x86_64.asciidoc
+++ b/docs/tab-widgets/install-binary/deb-x86_64.asciidoc
@@ -1,0 +1,15 @@
+ifeval::["{release-state}"=="unreleased"]
+
+Version {logstash_version} of Logstash has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+------------------------------------------------
+curl -L -O https://artifacts.elastic.co/downloads/logstash-{version}-amd64.deb
+sudo dpkg -i logstash-{version}-amd64.deb
+------------------------------------------------
+
+endif::[]

--- a/docs/tab-widgets/install-binary/deb-x86_64.asciidoc
+++ b/docs/tab-widgets/install-binary/deb-x86_64.asciidoc
@@ -1,6 +1,25 @@
 ifeval::["{release-state}"=="unreleased"]
 
-Version {logstash_version} of Logstash has not yet been released.
+// Version {logstash_version} of Logstash has not yet been released.
+
+// Released content here for testing only
+// DO NOT MERGE THIS WAY
+
+**DEB x86_64**
+
+["source","sh",subs="attributes"]
+------------------------------------------------
+curl -L -O https://artifacts.elastic.co/downloads/logstash-{version}-amd64.deb
+sudo dpkg -i logstash-{version}-amd64.deb
+------------------------------------------------
+
+**DEB AARCH64**
+
+["source","sh",subs="attributes"]
+------------------------------------------------
+curl -L -O https://artifacts.elastic.co/downloads/logstash-{version}-amd64.deb
+sudo dpkg -i logstash-{version}-amd64.deb
+------------------------------------------------
 
 endif::[]
 

--- a/docs/tab-widgets/install-binary/linux-aarch64.asciidoc
+++ b/docs/tab-widgets/install-binary/linux-aarch64.asciidoc
@@ -1,0 +1,15 @@
+ifeval::["{release-state}"=="unreleased"]
+
+Version {logstash_version} of Logstash has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+------------------------------------------------
+curl -L -O https://artifacts.elastic.co/downloads/logstash-{version}-linux-aarch64.tar.gz
+tar xzvf logstash-linux-aarch64.tar.gz
+------------------------------------------------
+
+endif::[]

--- a/docs/tab-widgets/install-binary/linux-x86_64.asciidoc
+++ b/docs/tab-widgets/install-binary/linux-x86_64.asciidoc
@@ -1,0 +1,15 @@
+ifeval::["{release-state}"=="unreleased"]
+
+Version {logstash_version} of Logstash has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+------------------------------------------------
+curl -L -O https://artifacts.elastic.co/downloads/logstash-{version}-linux-x86_64.tar.gz
+tar xzvf logstash-linux-x86_64.tar.gz
+------------------------------------------------
+
+endif::[]

--- a/docs/tab-widgets/install-binary/macos.asciidoc
+++ b/docs/tab-widgets/install-binary/macos.asciidoc
@@ -1,0 +1,15 @@
+ifeval::["{release-state}"=="unreleased"]
+
+Version {logstash_version} of Logstash has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+------------------------------------------------
+curl -L -O https://artifacts.elastic.co/downloads/logstash-{version}-darwin-x86_64.tar.gz
+tar xzvf logstash-darwin-x86_64.tar.gz
+------------------------------------------------
+
+endif::[]

--- a/docs/tab-widgets/install-binary/rpm-aarch64.asciidoc
+++ b/docs/tab-widgets/install-binary/rpm-aarch64.asciidoc
@@ -1,0 +1,15 @@
+ifeval::["{release-state}"=="unreleased"]
+
+Version {logstash_version} of Logstash has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+------------------------------------------------
+curl -L -O https://artifacts.elastic.co/downloads/logstash/logstash-{version}-aarch64.rpm
+sudo rpm -vi logstash-{version}-aarch64.rpm
+------------------------------------------------
+
+endif::[]

--- a/docs/tab-widgets/install-binary/rpm-x86_64.asciidoc
+++ b/docs/tab-widgets/install-binary/rpm-x86_64.asciidoc
@@ -1,0 +1,15 @@
+ifeval::["{release-state}"=="unreleased"]
+
+Version {logstash_version} of Logstash has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+------------------------------------------------
+curl -L -O https://artifacts.elastic.co/downloads/logstash-{version}-x86_64.rpm
+sudo rpm -vi logstash-{version}-x86_64.rpm
+------------------------------------------------
+
+endif::[]

--- a/docs/tab-widgets/install-binary/widget.asciidoc
+++ b/docs/tab-widgets/install-binary/widget.asciidoc
@@ -1,0 +1,150 @@
+// The ??? defaults to visible.
+// Change with `aria-selected="false"` and `hidden=""`
+++++
+<div class="tabs" data-tab-group="apm-agent-kube">
+  <div role="tablist" aria-label="Install-kube">
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="go-tab-install-kube"
+            id="go-install-kube">
+      Linux X86_64
+    </button>
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="java-tab-install-kube"
+            id="java-install-kube"
+            tabindex="-1">
+      Linux AARCH64
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="net-tab-install-kube"
+            id="net-install-kube"
+            tabindex="-1">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="node-tab-install-kube"
+            id="node-install-kube"
+            tabindex="-1">
+      Windows
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="php-tab-install-kube"
+            id="php-install-kube"
+            tabindex="-1">
+      DEB X86_64
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="python-tab-install-kube"
+            id="python-install-kube"
+            tabindex="-1">
+      DEB AARCH64
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="ruby-tab-install-kube"
+            id="ruby-install-kube"
+            tabindex="-1">
+      RPM X86_64
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="ruby-tab-install-kube"
+            id="ruby-install-kube"
+            tabindex="-1">
+      RPM AARCH64
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="go-tab-install-kube"
+       aria-labelledby="go-install-kube"
+       hidden="">
+++++
+
+include::linux-x86_64.asciidoc[]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="java-tab-install-kube"
+       aria-labelledby="java-install-kube">
+++++
+
+include::linux-aarch64.asciidoc[]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="net-tab-install-kube"
+       aria-labelledby="net-install-kube"
+       hidden="">
+++++
+
+include::macos.asciidoc[]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="node-tab-install-kube"
+       aria-labelledby="node-install-kube"
+       hidden="">
+++++
+
+include::windows.asciidoc[]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="php-tab-install-kube"
+       aria-labelledby="php-install-kube"
+       hidden="">
+++++
+
+include::deb-x86_64.asciidoc[]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="python-tab-install-kube"
+       aria-labelledby="python-install-kube"
+       hidden="">
+++++
+
+include::deb-aarch64.asciidoc[]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="ruby-tab-install-kube"
+       aria-labelledby="ruby-install-kube"
+       hidden="">
+++++
+
+include::rpm-x86_64.asciidoc[]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="ruby-tab-install-kube"
+       aria-labelledby="ruby-install-kube"
+       hidden="">
+++++
+
+include::rpm-aarch64.asciidoc[]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/tab-widgets/install-binary/windows.asciidoc
+++ b/docs/tab-widgets/install-binary/windows.asciidoc
@@ -1,0 +1,35 @@
+// tag::win[]
+ifeval::["{release-state}"=="unreleased"]
+
+Version {logstash_version} of Logstash has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+. Download the {beatname_uc} Windows zip file from the
+https://www.elastic.co/downloads/beats/{beatname_lc}[downloads page].
+
+. Extract the contents of the zip file into `C:\Program Files`.
+
+. Rename the +{beatname_lc}-<version>-windows+ directory to +{beatname_uc}+.
+
+. Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
+and select *Run As Administrator*).
+
+. From the PowerShell prompt, run the following commands to install
+{beatname_uc} as a Windows service:
++
+["source","sh",subs="attributes"]
+----------------------------------------------------------------------
+PS > cd 'C:{backslash}Program Files{backslash}{beatname_uc}'
+PS C:{backslash}Program Files{backslash}{beatname_uc}> .{backslash}install-service-{beatname_lc}.ps1
+----------------------------------------------------------------------
+
+NOTE: If script execution is disabled on your system, you need to set the
+execution policy for the current session to allow the script to run. For
+example:
++PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-{beatname_lc}.ps1+.
+
+endif::[]
+// end::win[]

--- a/docs/tab-widgets/install-pkg/apt.asciidoc
+++ b/docs/tab-widgets/install-pkg/apt.asciidoc
@@ -1,0 +1,134 @@
+*Install the agent*
+
+Install the APM agent packages for Go.
+
+[source,go]
+----
+go get go.elastic.co/apm
+----
+
+*Instrument your application*
+
+Instrument your Go application by using one of the provided instrumentation modules or by using the tracer API directly.
+
+[source,go]
+----
+import (
+	"net/http"
+
+	"go.elastic.co/apm/module/apmhttp"
+)
+
+func main() {
+	mux := http.NewServeMux()
+	...
+	http.ListenAndServe(":8080", apmhttp.Wrap(mux))
+}
+----
+
+*Configure the agent*
+
+Configure the agent using environment variables:
+
+[source,yml]
+----
+        # ...
+        - name: ELASTIC_APM_SERVER_URL
+          value: "apm-server-url-goes-here" <1>
+        - name: ELASTIC_APM_SECRET_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: apm-secret
+              key: ELASTIC_APM_SECRET_TOKEN <2>
+        - name: ELASTIC_APM_SERVICE_NAME
+          value: "service-name-goes-here" <3>
+----
+<1> Defaults to `http://localhost:8200`
+<2> Pass in `ELASTIC_APM_SECRET_TOKEN` from the `apm-secret` keystore created previously
+<3> Allowed characters: a-z, A-Z, 0-9, -, _, and space
+
+
+
+
+=====
+
+
+[float]
+==== APT
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {logstash_version} of Logstash has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+Download and install the Public Signing Key:
+
+[source,sh]
+--------------------------------------------------
+wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
+--------------------------------------------------
+
+You may need to install the `apt-transport-https` package on Debian before proceeding:
+
+[source,sh]
+--------------------------------------------------
+sudo apt-get install apt-transport-https
+--------------------------------------------------
+
+// THIS IS A NESTED STATEMENT - This block executes if release-state != unreleased and release-state == released
+
+ifeval::["{release-state}"=="released"]
+
+Save the repository definition to  +/etc/apt/sources.list.d/elastic-{major-version}.list+:
+
+["source","sh",subs="attributes"]
+--------------------------------------------------
+echo "deb https://artifacts.elastic.co/packages/{major-version}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{major-version}.list
+--------------------------------------------------
+
+endif::[]
+
+// THIS IS A NESTED STATEMENT - This block executes if release-state != unreleased and release-state == prerelase
+
+ifeval::["{release-state}"=="prerelease"]
+
+Save the repository definition to  +/etc/apt/sources.list.d/elastic-{major-version}-prerelease.list+:
+
+["source","sh",subs="attributes"]
+--------------------------------------------------
+echo "deb https://artifacts.elastic.co/packages/{major-version}-prerelease/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{major-version}-prerelease.list
+--------------------------------------------------
+
+endif::[]
+
+[WARNING]
+==================================================
+Use the `echo` method described above to add the Logstash repository.  Do not
+use `add-apt-repository` as it will add a `deb-src` entry as well, but we do not
+provide a source package. If you have added the `deb-src` entry, you will see an
+error like the following:
+
+    Unable to find expected entry 'main/source/Sources' in Release file (Wrong sources.list entry or malformed file)
+
+Just delete the `deb-src` entry from the `/etc/apt/sources.list` file and the
+installation should work as expected.
+==================================================
+
+Run `sudo apt-get update` and the repository is ready for use. You can install
+it with:
+
+[source,sh]
+--------------------------------------------------
+sudo apt-get update && sudo apt-get install logstash
+--------------------------------------------------
+
+See {logstash-ref}/running-logstash.html[Running Logstash] for details about managing Logstash as a system service.
+
+endif::[]
+
+
+
+

--- a/docs/tab-widgets/install-pkg/content.asciidoc
+++ b/docs/tab-widgets/install-pkg/content.asciidoc
@@ -1,0 +1,438 @@
+// tag::go[]
+*Install the agent*
+
+Install the APM agent packages for Go.
+
+[source,go]
+----
+go get go.elastic.co/apm
+----
+
+*Configure the agent*
+
+Agents are libraries that run inside of your application process.
+APM services are created programmatically based on the executable file name, or the `ELASTIC_APM_SERVICE_NAME` environment variable.
+
+[source,go]
+----
+# Initialize using environment variables:
+
+# Set the service name. Allowed characters: # a-z, A-Z, 0-9, -, _, and space.
+# If ELASTIC_APM_SERVICE_NAME is not specified, the executable name will be used.
+export ELASTIC_APM_SERVICE_NAME=
+
+# Set custom APM Server URL (default: http://localhost:8200)
+export ELASTIC_APM_SERVER_URL=
+
+# Use if APM Server requires a token
+export ELASTIC_APM_SECRET_TOKEN=
+----
+
+*Instrument your application*
+
+Instrument your Go application by using one of the provided instrumentation modules or by using the tracer API directly.
+
+[source,go]
+----
+import (
+	"net/http"
+
+	"go.elastic.co/apm/module/apmhttp"
+)
+
+func main() {
+	mux := http.NewServeMux()
+	...
+	http.ListenAndServe(":8080", apmhttp.Wrap(mux))
+}
+----
+
+*Learn more in the agent reference*
+
+* {apm-go-ref-v}/supported-tech.html[Supported technologies]
+* {apm-go-ref-v}/configuration.html[Advanced configuration]
+* {apm-go-ref-v}/getting-started.html[Detailed guide to instrumenting Go source code]
+// end::go[]
+
+// ***************************************************
+// ***************************************************
+
+// tag::java[]
+
+*Download the APM agent*
+
+Download the agent jar from http://search.maven.org/#search%7Cga%7C1%7Ca%3Aelastic-apm-agent[Maven Central].
+Do not add the agent as a dependency to your application.
+
+*Start your application with the javaagent flag*
+
+Add the `-javaagent` flag and configure the agent with system properties.
+
+* Set required service name
+* Set custom APM Server URL (default: http://localhost:8200)
+* Set the base package of your application
+
+[source,java]
+----
+java -javaagent:/path/to/elastic-apm-agent-<version>.jar \
+     -Delastic.apm.service_name=my-application \
+     -Delastic.apm.server_urls=http://localhost:8200 \
+     -Delastic.apm.secret_token= \
+     -Delastic.apm.application_packages=org.example \
+     -jar my-application.jar
+----
+
+*Learn more in the agent reference*
+
+* {apm-java-ref-v}/supported-technologies-details.html[Supported technologies]
+* {apm-java-ref-v}/configuration.html[Advanced configuration]
+// end::java[]
+
+// ***************************************************
+// ***************************************************
+
+// tag::net[]
+*Download the APM agent*
+
+Add the agent packages from https://www.nuget.org/packages?q=Elastic.apm[NuGet] to your .NET application.
+There are multiple NuGet packages available for different use cases.
+
+For an ASP.NET Core application with Entity Framework Core, download the
+https://www.nuget.org/packages/Elastic.Apm.NetCoreAll[Elastic.Apm.NetCoreAll] package.
+This package will automatically add every agent component to your application.
+
+To minimize the number of dependencies, you can use the
+https://www.nuget.org/packages/Elastic.Apm.AspNetCore[Elastic.Apm.AspNetCore] package for just ASP.NET Core monitoring, or the
+https://www.nuget.org/packages/Elastic.Apm.EntityFrameworkCore[Elastic.Apm.EfCore] package for just Entity Framework Core monitoring.
+
+If you only want to use the public agent API for manual instrumentation, use the
+https://www.nuget.org/packages/Elastic.Apm[Elastic.Apm] package.
+
+*Add the agent to the application*
+
+For an ASP.NET Core application with the `Elastic.Apm.NetCoreAll` package,
+call the `UseAllElasticApm` method in the `Configure` method within the `Startup.cs` file:
+
+[source,dotnet]
+----
+public class Startup
+{
+  public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+  {
+    app.UseAllElasticApm(Configuration);
+    //…rest of the method
+  }
+  //…rest of the class
+}
+----
+
+Passing an `IConfiguration` instance is optional and by doing so,
+the agent will read config settings through this `IConfiguration` instance, for example,
+from the `appsettings.json` file:
+
+[source,json]
+----
+{
+    "ElasticApm": {
+    "SecretToken": "",
+    "ServerUrls": "http://localhost:8200", //Set custom APM Server URL (default: http://localhost:8200)
+    "ServiceName" : "MyApp", //allowed characters: a-z, A-Z, 0-9, -, _, and space. Default is the entry assembly of the application
+  }
+}
+----
+
+If you don’t pass an `IConfiguration` instance to the agent, for example, in a non-ASP.NET Core application,
+you can configure the agent with environment variables.
+See the agent reference for more information.
+
+*Learn more in the agent reference*
+
+* {apm-dotnet-ref-v}/supported-technologies.html[Supported technologies]
+* {apm-dotnet-ref-v}/configuration.html[Advanced configuration]
+// end::net[]
+
+// ***************************************************
+// ***************************************************
+
+// tag::node[]
+*Install the APM agent*
+
+Install the APM agent for Node.js as a dependency to your application.
+
+[source,js]
+----
+npm install elastic-apm-node --save
+----
+
+*Configure the agent*
+
+Agents are libraries that run inside of your application process. APM services are created programmatically based on the `serviceName`.
+This agent supports a variety of frameworks but can also be used with your custom stack.
+
+[source,js]
+----
+// Add this to the VERY top of the first file loaded in your app
+var apm = require('elastic-apm-node').start({
+  // Override service name from package.json
+  // Allowed characters: a-z, A-Z, 0-9, -, _, and space
+  serviceName: '',
+
+  // Use if APM Server requires a token
+  secretToken: '',
+
+  // Set custom APM Server URL (default: http://localhost:8200)
+  serverUrl: ''
+})
+----
+
+*Learn more in the agent reference*
+
+* {apm-node-ref-v}/supported-technologies.html[Supported technologies]
+* {apm-node-ref-v}/advanced-setup.html[Babel/ES Modules]
+* {apm-node-ref-v}/configuring-the-agent.html[Advanced configuration]
+
+// end::node[]
+
+// ***************************************************
+// ***************************************************
+
+// tag::python[]
+Django::
++
+*Install the APM agent*
++
+Install the APM agent for Python as a dependency.
++
+[source,python]
+----
+$ pip install elastic-apm
+----
++
+*Configure the agent*
++
+Agents are libraries that run inside of your application process.
+APM services are created programmatically based on the `SERVICE_NAME`.
++
+[source,python]
+----
+# Add the agent to the installed apps
+INSTALLED_APPS = (
+  'elasticapm.contrib.django',
+  # ...
+)
+
+ELASTIC_APM = {
+  # Set required service name. Allowed characters:
+  # a-z, A-Z, 0-9, -, _, and space
+  'SERVICE_NAME': '',
+
+  # Use if APM Server requires a token
+  'SECRET_TOKEN': '',
+
+  # Set custom APM Server URL (default: http://localhost:8200)
+  'SERVER_URL': '',
+}
+
+# To send performance metrics, add our tracing middleware:
+MIDDLEWARE = (
+  'elasticapm.contrib.django.middleware.TracingMiddleware',
+  #...
+)
+----
+
+Flask::
++
+*Install the APM agent*
++
+Install the APM agent for Python as a dependency.
++
+[source,python]
+----
+$ pip install elastic-apm[flask]
+----
++
+*Configure the agent*
++
+Agents are libraries that run inside of your application process.
+APM services are created programmatically based on the `SERVICE_NAME`.
++
+[source,python]
+----
+# initialize using environment variables
+from elasticapm.contrib.flask import ElasticAPM
+app = Flask(__name__)
+apm = ElasticAPM(app)
+
+# or configure to use ELASTIC_APM in your application's settings
+from elasticapm.contrib.flask import ElasticAPM
+app.config['ELASTIC_APM'] = {
+  # Set required service name. Allowed characters:
+  # a-z, A-Z, 0-9, -, _, and space
+  'SERVICE_NAME': '',
+
+  # Use if APM Server requires a token
+  'SECRET_TOKEN': '',
+
+  # Set custom APM Server URL (default: http://localhost:8200)
+  'SERVER_URL': '',
+}
+
+apm = ElasticAPM(app)
+----
+
+*Learn more in the agent reference*
+
+* {apm-py-ref-v}/supported-technologies.html[Supported technologies]
+* {apm-py-ref-v}/configuration.html[Advanced configuration]
+
+
+// end::python[]
+
+// tag::ruby[]
+*Install the APM agent*
+
+Add the agent to your Gemfile.
+
+[source,ruby]
+----
+gem 'elastic-apm'
+----
+*Configure the agent*
+
+Ruby on Rails::
++
+APM is automatically started when your app boots.
+Configure the agent by creating the config file `config/elastic_apm.yml`:
++
+[source,ruby]
+----
+# config/elastic_apm.yml:
+
+# Set service name - allowed characters: a-z, A-Z, 0-9, -, _ and space
+# Defaults to the name of your Rails app
+service_name: 'my-service'
+
+# Use if APM Server requires a token
+secret_token: ''
+
+# Set custom APM Server URL (default: http://localhost:8200)
+server_url: 'http://localhost:8200'
+----
+
+Rack::
++
+For Rack or a compatible framework, like Sinatra, include the middleware in your app and start the agent.
++
+[source,ruby]
+----
+# config.ru
+  require 'sinatra/base'
+
+  class MySinatraApp < Sinatra::Base
+    use ElasticAPM::Middleware
+
+    # ...
+  end
+
+  ElasticAPM.start(
+    app: MySinatraApp, # required
+    config_file: '' # optional, defaults to config/elastic_apm.yml
+  )
+
+  run MySinatraApp
+
+  at_exit { ElasticAPM.stop }
+----
++
+*Create a config file*
++
+Create a config file config/elastic_apm.yml:
++
+[source,ruby]
+----
+# config/elastic_apm.yml:
+
+# Set service name - allowed characters: a-z, A-Z, 0-9, -, _ and space
+# Defaults to the name of your Rack app's class.
+service_name: 'my-service'
+
+# Use if APM Server requires a token
+secret_token: ''
+
+# Set custom APM Server URL (default: http://localhost:8200)
+server_url: 'http://localhost:8200'
+----
+
+*Learn more in the agent reference*
+
+* {apm-ruby-ref-v}/supported-technologies.html[Supported technologies]
+* {apm-ruby-ref-v}/configuration.html[Advanced configuration]
+
+// end::ruby[]
+
+// ***************************************************
+// ***************************************************
+
+// tag::rum[]
+*Enable Real User Monitoring support in APM Server*
+
+APM Server disables RUM support by default.
+To enable it, set `apm-server.rum.enabled: true` in your APM Server configuration file.
+
+*Set up the agent*
+
+Once RUM support enabled, you can set up the RUM agent.
+There are two ways to do this: add the agent as a dependency,
+or set it up with `<script>` tags.
+
+*Set up the agent as a dependency*
+
+You can install the agent as a dependency to your application with `npm install @elastic/apm-rum --save`.
+
+The agent can then be initialized and configured in your application like this:
+
+[source,js]
+----
+import { init as initApm } from '@elastic/apm-rum'
+var apm = initApm({
+
+  // Set required service name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
+  serviceName: 'your-app-name',
+
+  // Set custom APM Server URL (default: http://localhost:8200)
+  serverUrl: '',
+
+  // Set service version (required for source map feature)
+  serviceVersion: ''
+})
+----
+
+Framework integrations, like React or Angular, have custom dependencies.
+See {apm-rum-ref-v}/framework-integrations.html[framework integrations] for more information.
+
+*Set up the agent with `<script>` tags*
+
+Alternatively, you can use `<script>` tags to set up and configure the agent.
+Add a `<script>` tag to the HTML page and use the `elasticApm` global object to load and initialize the agent.
+Don't forget to download the latest version of the RUM agent from
+https://github.com/elastic/apm-agent-rum-js/releases/latest[GitHub] or
+https://unpkg.com/@elastic/apm-rum/dist/bundles/elastic-apm-rum.umd.min.js[UNPKG],
+and host the file on your Server/CDN before deploying to production.
+
+[source,js]
+----
+<script src="https://your-cdn-host.com/path/to/elastic-apm-rum.umd.min.js" crossorigin></script>
+<script>
+  elasticApm.init({
+    serviceName: 'your-app-name',
+    serverUrl: 'http://localhost:8200',
+  })
+</script>
+----
+
+*Learn more in the agent reference*
+
+* {apm-rum-ref-v}/supported-technologies.html[Supported technologies]
+* {apm-rum-ref-v}/configuration.html[Advanced configuration]
+
+// end::rum[]

--- a/docs/tab-widgets/install-pkg/widget.asciidoc
+++ b/docs/tab-widgets/install-pkg/widget.asciidoc
@@ -1,0 +1,132 @@
+// The Java agent defaults to visible.
+// Change with `aria-selected="false"` and `hidden=""`
+++++
+<div class="tabs" data-tab-group="pkg-install">
+  <div role="tablist" aria-label="Install">
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="apt-tab-install"
+            id="go-install">
+      APT
+    </button>
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="yum-tab-install"
+            id="java-install"
+            tabindex="-1">
+      YUM
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="net-tab-install"
+            id="net-install"
+            tabindex="-1">
+      .NET
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="node-tab-install"
+            id="node-install"
+            tabindex="-1">
+      Node.js
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="python-tab-install"
+            id="python-install"
+            tabindex="-1">
+      Python
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="ruby-tab-install"
+            id="ruby-install"
+            tabindex="-1">
+      Ruby
+    </button>
+    <button role="tab"
+        aria-selected="false"
+        aria-controls="rum-tab-install"
+        id="rum-install"
+        tabindex="-1">
+      RUM
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="go-tab-install"
+       aria-labelledby="go-install"
+       hidden="">
+++++
+
+include::content.asciidoc[tag=apt]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="java-tab-install"
+       aria-labelledby="java-install">
+++++
+
+include::content.asciidoc[tag=yum]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="net-tab-install"
+       aria-labelledby="net-install"
+       hidden="">
+++++
+
+include::content.asciidoc[tag=net]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="node-tab-install"
+       aria-labelledby="node-install"
+       hidden="">
+++++
+
+include::content.asciidoc[tag=node]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="python-tab-install"
+       aria-labelledby="python-install"
+       hidden="">
+++++
+
+include::content.asciidoc[tag=python]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="ruby-tab-install"
+       aria-labelledby="ruby-install"
+       hidden="">
+++++
+
+include::content.asciidoc[tag=ruby]
+
+++++
+  </div>
+  <div tabindex="0"
+      role="tabpanel"
+      id="rum-tab-install"
+      aria-labelledby="rum-install"
+      hidden="">
+++++
+
+include::content.asciidoc[tag=rum]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/tab-widgets/tab-widget-code/code.asciidoc
+++ b/docs/tab-widgets/tab-widget-code/code.asciidoc
@@ -1,0 +1,166 @@
+// Defining styles and script here for simplicity.
+++++
+<style>
+.tabs {
+  width: 100%;
+}
+[role="tablist"] {
+  margin: 0 0 -0.1em;
+  overflow: visible;
+}
+[role="tab"] {
+  position: relative;
+  padding: 0.3em 0.5em 0.4em;
+  border: 1px solid hsl(219, 1%, 72%);
+  border-radius: 0.2em 0.2em 0 0;
+  overflow: visible;
+  font-family: inherit;
+  font-size: inherit;
+  background: hsl(220, 20%, 94%);
+}
+[role="tab"]:hover::before,
+[role="tab"]:focus::before,
+[role="tab"][aria-selected="true"]::before {
+  position: absolute;
+  bottom: 100%;
+  right: -1px;
+  left: -1px;
+  border-radius: 0.2em 0.2em 0 0;
+  border-top: 3px solid hsl(219, 1%, 72%);
+  content: '';
+}
+[role="tab"][aria-selected="true"] {
+  border-radius: 0;
+  background: hsl(220, 43%, 99%);
+  outline: 0;
+}
+[role="tab"][aria-selected="true"]:not(:focus):not(:hover)::before {
+  border-top: 5px solid hsl(218, 96%, 48%);
+}
+[role="tab"][aria-selected="true"]::after {
+  position: absolute;
+  z-index: 3;
+  bottom: -1px;
+  right: 0;
+  left: 0;
+  height: 0.3em;
+  background: hsl(220, 43%, 99%);
+  box-shadow: none;
+  content: '';
+}
+[role="tab"]:hover,
+[role="tab"]:focus,
+[role="tab"]:active {
+  outline: 0;
+  border-radius: 0;
+  color: inherit;
+}
+[role="tab"]:hover::before,
+[role="tab"]:focus::before {
+  border-color: hsl(218, 96%, 48%);
+}
+[role="tabpanel"] {
+  position: relative;
+  z-index: 2;
+  padding: 1em;
+  border: 1px solid hsl(219, 1%, 72%);
+  border-radius: 0 0.2em 0.2em 0.2em;
+  box-shadow: 0 0 0.2em hsl(219, 1%, 72%);
+  background: hsl(220, 43%, 99%);
+  margin-bottom: 1em;
+}
+[role="tabpanel"] p {
+  margin: 0;
+}
+[role="tabpanel"] * + p {
+  margin-top: 1em;
+}
+</style>
+
+<script>
+window.addEventListener("DOMContentLoaded", () => {
+  const tabs = document.querySelectorAll('[role="tab"]');
+  const tabList = document.querySelector('[role="tablist"]');
+  // Add a click event handler to each tab
+  tabs.forEach(tab => {
+    tab.addEventListener("click", changeTabs);
+  });
+  // Enable arrow navigation between tabs in the tab list
+  let tabFocus = 0;
+  tabList.addEventListener("keydown", e => {
+    // Move right
+    if (e.keyCode === 39 || e.keyCode === 37) {
+      tabs[tabFocus].setAttribute("tabindex", -1);
+      if (e.keyCode === 39) {
+        tabFocus++;
+        // If we're at the end, go to the start
+        if (tabFocus >= tabs.length) {
+          tabFocus = 0;
+        }
+        // Move left
+      } else if (e.keyCode === 37) {
+        tabFocus--;
+        // If we're at the start, move to the end
+        if (tabFocus < 0) {
+          tabFocus = tabs.length - 1;
+        }
+      }
+      tabs[tabFocus].setAttribute("tabindex", 0);
+      tabs[tabFocus].focus();
+    }
+  });
+});
+
+function setActiveTab(target) {
+  const parent = target.parentNode;
+  const grandparent = parent.parentNode;
+  // console.log(grandparent);
+  // Remove all current selected tabs
+  parent
+    .querySelectorAll('[aria-selected="true"]')
+    .forEach(t => t.setAttribute("aria-selected", false));
+  // Set this tab as selected
+  target.setAttribute("aria-selected", true);
+  // Hide all tab panels
+  grandparent
+    .querySelectorAll('[role="tabpanel"]')
+    .forEach(p => p.setAttribute("hidden", true));
+  // Show the selected panel
+  grandparent.parentNode
+    .querySelector(`#${target.getAttribute("aria-controls")}`)
+    .removeAttribute("hidden");
+}
+
+function changeTabs(e) {
+  // get the containing list of the tab that was just clicked
+  const tabList = e.target.parentNode;
+
+  // get all of the sibling tabs
+  const buttons = Array.apply(null, tabList.querySelectorAll('button'));
+
+  // loop over the siblings to discover which index thje clicked one was
+  const { index } = buttons.reduce(({ found, index }, button) => {
+    if (!found && buttons[index] === e.target) {
+      return { found: true, index };
+    } else if (!found) {
+      return { found, index: index + 1 };
+    } else {
+      return { found, index };
+    }
+  }, { found: false, index: 0 });
+
+  // get the tab container
+  const container = tabList.parentNode;
+  // read the data-tab-group value from the container, e.g. "os"
+  const { tabGroup } = container.dataset;
+  // get a list of all the tab groups that match this value on the page
+  const groups = document.querySelectorAll('[data-tab-group=' + tabGroup + ']');
+
+  // for each of the found tab groups, find the tab button at the previously discovered index and select it for each group
+  groups.forEach((group) => {
+    const target = group.querySelectorAll('button')[index];
+    setActiveTab(target);
+  });
+}
+</script>
+++++


### PR DESCRIPTION
## Release notes
[rn:skip]


## What does this PR do?
Adds tab widget infrastructure
Breaks up walls of text by added tabbed widgets to show installation instructions per platform
