### PR TITLE
Allow per-pipeline config of ECS Compatibility mode via Central Management

### DIFF
--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -281,6 +281,10 @@ module LogStash
       }
     end
 
+    def inspect
+      "<#{self.class.name}(#{name}): #{value.inspect}" + (@value_is_set ? '' : ' (DEFAULT)') + ">"
+    end
+
     def ==(other)
       self.to_hash == other.to_hash
     end

--- a/x-pack/lib/config_management/elasticsearch_source.rb
+++ b/x-pack/lib/config_management/elasticsearch_source.rb
@@ -26,6 +26,8 @@ module LogStash
         pipeline.workers
         pipeline.batch.size
         pipeline.batch.delay
+        pipeline.ecs_compatibility
+        pipeline.ordered
         queue.type
         queue.max_bytes
         queue.checkpoint.writes

--- a/x-pack/spec/config_management/elasticsearch_source_spec.rb
+++ b/x-pack/spec/config_management/elasticsearch_source_spec.rb
@@ -373,6 +373,8 @@ describe LogStash::ConfigManagement::ElasticsearchSource do
       {
         "pipeline.batch.delay"       => "50",
         "pipeline.workers"           => "99",
+        "pipeline.ordered"           => "false",
+        "pipeline.ecs_compatibility" => "v1",
 
         # invalid settings to be ignored...
         "pipeline.output.workers"    => "99",
@@ -462,6 +464,8 @@ describe LogStash::ConfigManagement::ElasticsearchSource do
                 # explicitly given settings
                 expect(pipeline_settings.get_setting("pipeline.workers")).to be_set.and(have_attributes(value: 99))
                 expect(pipeline_settings.get_setting("pipeline.batch.delay")).to be_set.and(have_attributes(value: 50))
+                expect(pipeline_settings.get_setting("pipeline.ordered")).to be_set.and(have_attributes(value: "false"))
+                expect(pipeline_settings.get_setting("pipeline.ecs_compatibility")).to be_set.and(have_attributes(value: "v1"))
 
                 # valid non-provided settings
                 expect(pipeline_settings.get_setting("queue.type")).to_not be_set


### PR DESCRIPTION
## Release notes

When using Kibana's Central Management for Logstash, values for `pipeline.ordered` and `pipeline.ecs_compatibility` settings are now supported.

## What does this PR do?

Brings `pipeline.ordered` and `pipeline.ecs_compatibility` settings into the supported set here on the Logstash side so that they will be respected when provided by a pipeline that is managed by Kibana's Central Management for Logstash. Currently, the Kibana UI does not support setting these in the pipeline editor, but allows unvalidated k/v settings through pipelines managed through its API.

This PR does _NOT_ include the necessary changes to Kibana's pipeline editor to make these UI-accessible (hint: [here?](https://github.com/elastic/kibana/blob/4a541883557bcee83baf09b2c0ddab702f780e45/x-pack/plugins/logstash/public/application/components/pipeline_editor/pipeline_editor.js#L55-L62)) or Kibana's API documentation (hint: [here](https://github.com/elastic/kibana/blob/4a541883557bcee83baf09b2c0ddab702f780e45/docs/api/logstash-configuration-management/create-logstash.asciidoc#path-parameters)).

## Why is it important/What is the impact to the user?

Allows a user to configure the ECS Compatibility or Strict Ordering settings of a pipeline when that pipeline is managed by Kibana's Central Management for Logstash.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [x] companion PR to Kibana for docs -> https://github.com/elastic/kibana/pull/98852
- [ ] companion PR to Kibana for UI/Editor

## How to test this PR locally

Using Kibana's API, persist a pipeline with the settings `pipeline.ordered` and/or `pipeline.ecs_compatibility`. Observe that without this PR they are ignored, but with this PR they are respected.