### PR TITLE
Doc: Keystore must be accessible to logstash user

### DIFF
--- a/docs/static/keystore.asciidoc
+++ b/docs/static/keystore.asciidoc
@@ -36,6 +36,12 @@ is not currently supported.
 NOTE: Referencing keystore data from {logstash-ref}/logstash-centralized-pipeline-management.html[centralized pipeline management]
 requires each Logstash deployment to have a local copy of the keystore.
 
+NOTE: The {ls} keystore needs to be protected, but the {ls} user must
+have access to the file. While most things in {ls} can be protected with
+`chown -R root:root <foo>`, the keystore itself must be accessible from the
+{ls} user. Use `chown logstash:root <keystore> && chmod 0600
+<keystore>`.
+
 When Logstash parses the settings (`logstash.yml`) or configuration
 (`/etc/logstash/conf.d/*.conf`), it resolves keys from the keystore before
 resolving environment variables.


### PR DESCRIPTION
Backports  #12775 to 7.12

## Release notes
[rn:skip]

