### PR TITLE
[backport 7.x] Change Gradle's :logstash-integration-tests:integrationTests task to depends on copyES (#12847)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -455,7 +455,6 @@ tasks.register("downloadEs", Download) {
     onlyIfNewer true
     retries 3
     inputs.file("${projectDir}/versions.yml")
-//    inputs.file("${projectDir}/build/${downloadedElasticsearchName}.tar.gz.SHA-512")
     outputs.file(project.ext.elasticsearchDownloadLocation)
     dest new File(project.ext.elasticsearchDownloadLocation)
 
@@ -477,7 +476,6 @@ tasks.register("copyEs", Copy) {
         file("./build/${project.ext.unpackedElasticsearchName}").renameTo('./build/elasticsearch')
         System.out.println "Unzipped ${project.ext.elasticsearchDownloadLocation} to ./build/elasticsearch"
         System.out.println "Deleting ${project.ext.elasticsearchDownloadLocation}"
-//        delete(project.ext.elasticsearchDownloadLocation)
     }
 }
 
@@ -490,12 +488,12 @@ project(":logstash-integration-tests") {
         environment "FEATURE_FLAG", System.getenv('FEATURE_FLAG')
         workingDir integrationTestPwd
         dependsOn installIntegrationTestGems
+        dependsOn copyEs
     }
 }
 
 tasks.register("runIntegrationTests"){
     dependsOn tasks.getByPath(":logstash-integration-tests:integrationTests")
-    dependsOn copyEs
     dependsOn copyFilebeat
     shouldRunAfter ":logstash-core:test"
 }


### PR DESCRIPTION
clean backport of #12847 
The integrationTests start instances of Elasticsearch so they need it to be present and unpacked in build/ folder before start.

(cherry picked from commit 149ee41a8b07b318eb17e1e72af5c743a5002468)
