### PR TITLE
[7.13] revert geoip plugin to 6.0.5

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -241,7 +241,7 @@ GEM
     logstash-filter-fingerprint (3.2.3)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       murmurhash3
-    logstash-filter-geoip (6.0.5-java)
+    logstash-filter-geoip (7.1.0-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-grok (4.4.0)
       jls-grok (~> 0.11.3)

--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -243,6 +243,7 @@ GEM
       murmurhash3
     logstash-filter-geoip (7.1.0-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.1)
     logstash-filter-grok (4.4.0)
       jls-grok (~> 0.11.3)
       logstash-core (>= 5.6.0)

--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -241,9 +241,8 @@ GEM
     logstash-filter-fingerprint (3.2.3)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       murmurhash3
-    logstash-filter-geoip (7.1.0-java)
+    logstash-filter-geoip (6.0.5-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-      logstash-mixin-ecs_compatibility_support (~> 1.1)
     logstash-filter-grok (4.4.0)
       jls-grok (~> 0.11.3)
       logstash-core (>= 5.6.0)


### PR DESCRIPTION
a [bug](https://github.com/elastic/logstash/issues/12856) is in `7.1.0`
before we fix it, pin it to an old version to avoid loading GeoIP service