### PR TITLE
fix DLQ integration tests

### DIFF
--- a/qa/integration/fixtures/dlq_spec.yml
+++ b/qa/integration/fixtures/dlq_spec.yml
@@ -5,7 +5,7 @@ services:
 config:
   input {
     generator{
-      message => '{"test":"one"}'
+      message => '{"ip":1}'
       codec => "json"
       count => 1000
     }
@@ -17,22 +17,16 @@ config:
   }
 
   filter {
-    if ([geoip]) {
+    if ([ip]) {
         mutate {
-            remove_field => ["geoip"]
+            remove_field => ["ip"]
             add_field => {
               "mutated" => "true"
             }
         }
-    }else{
-      mutate {
-        add_field => {
-          "geoip" => "somewhere"
-        }
-      }
     }
   }
   output {
-    elasticsearch {}
+    elasticsearch { index => "test-index" }
   }
 teardown_script:

--- a/qa/integration/services/elasticsearch_setup.sh
+++ b/qa/integration/services/elasticsearch_setup.sh
@@ -8,7 +8,7 @@ ES_HOME="$current_dir/../../../build/elasticsearch"
 
 start_es() {
   es_args=$@
-  JAVA_HOME= $ES_HOME/bin/elasticsearch -Epath.data=/tmp/ls_integration/es-data -Epath.logs=/tmp/ls_integration/es-logs $es_args -p $ES_HOME/elasticsearch.pid > /tmp/elasticsearch.log 2>/dev/null &
+  JAVA_HOME= $ES_HOME/bin/elasticsearch -Epath.data=/tmp/ls_integration/es-data -Ediscovery.type=single-node -Epath.logs=/tmp/ls_integration/es-logs $es_args -p $ES_HOME/elasticsearch.pid > /tmp/elasticsearch.log 2>/dev/null &
   count=120
   echo "Waiting for elasticsearch to respond..."
   while ! curl --silent localhost:9200 && [[ $count -ne 0 ]]; do


### PR DESCRIPTION
This PR changes the DLQ integration tests to not rely on default names of indices for writing data to ES.
Also ensures ES is started in a single node mode.

These changes remove some of the magic of the integration test, where we relied on a index having a template with a geoip field with geo data types already. In these commits we explicitly push a template and then use a message that clearly clashes with that template.