### PR TITLE
[Backport 7.x]Update elasticsearch gem dependency requirements (#11258)

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -71,7 +71,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "jrjackson", "= #{ALL_VERSIONS.fetch('jrjackson')}" #(Apache 2.0 license)
 
-  gem.add_runtime_dependency "elasticsearch", "~> 5"
+  gem.add_runtime_dependency "elasticsearch", '~> 7'
   gem.add_runtime_dependency "manticore", '~> 0.6'
 
   # xpack geoip database service


### PR DESCRIPTION
Update Elasticsearch minimum version requirement to `~>7` also on the `7.x` branch.
Relates to #11258

(cherry picked from commit ef9b0d2db5f1a30cd0cef7920991b3b309323019)
