### PR TITLE
[backport 7.13]Update bundled JDK to 11.0.11+9 (#12881)

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -7,7 +7,7 @@ logstash-core-plugin-api: 2.1.16
 bundled_jdk:
   # for AdoptOpenJDK/OpenJDK jdk-14.0.1+7.1, the revision is 14.0.1 while the build is 7.1
   vendor: "adoptopenjdk"
-  revision: 11.0.10
+  revision: 11.0.11
   build: 9
 
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url


### PR DESCRIPTION
Clean backport of PR #12881 to `7.13` branch
(cherry picked from commit 4f63701d6d15d2e094f76c49804070f097414071)

----
**WARN**
to be merged after 7.13.0 is released
