### PR TITLE
[7.13] update ES output plugin to latest

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -492,7 +492,6 @@ GEM
       logstash-codec-plain
       logstash-core-plugin-api (~> 2.0)
     logstash-output-elasticsearch (11.0.2-java)
-      cabin (~> 0.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ecs_compatibility_support (~> 1.0)
       manticore (>= 0.5.4, < 1.0.0)

--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -491,7 +491,7 @@ GEM
       elastic-app-search (~> 7.8.0)
       logstash-codec-plain
       logstash-core-plugin-api (~> 2.0)
-    logstash-output-elasticsearch (11.0.1-java)
+    logstash-output-elasticsearch (11.0.2-java)
       cabin (~> 0.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ecs_compatibility_support (~> 1.0)


### PR DESCRIPTION
Validates that required functionality in ES is available, upon initial connection.
Changes: https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1015/files

Also, the previous diff update seems to have been done manually as there was a left-over dependency.
Here's a different attempt to update ES output [from 7.12.1 on 7.13](https://github.com/elastic/logstash/pull/12828/files/9eabd0491e6448ea19dc6f80f33eb4fff73d2c6a..c02a5846b1d2eeae0cbfc021a5b23b90209b9cee#diff-127e1a3a65d315d86dbe640d9578a969da44e5226e5d9bf2de251b075c1d8b7aL484-L485) (cabin dependency removed w the 11.0 plugin update)
