### PR TITLE
pin geoip plugin to 7.1.1

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -241,8 +241,9 @@ GEM
     logstash-filter-fingerprint (3.2.3)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       murmurhash3
-    logstash-filter-geoip (6.0.5-java)
+    logstash-filter-geoip (7.1.1-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.1)
     logstash-filter-grok (4.4.0)
       jls-grok (~> 0.11.3)
       logstash-core (>= 5.6.0)


### PR DESCRIPTION
use the latest geoip plugin gem and bring back ECS dependency