### PR TITLE
[Build] On aarch64 docker build, install `noarch` version of bind-license first

### DIFF
--- a/docker/templates/Dockerfile.j2
+++ b/docker/templates/Dockerfile.j2
@@ -30,6 +30,8 @@ FROM {{ base_image }}
 # scripts.
 # Minimal distributions also require findutils tar gzip (procps for integration tests)
 
+# on aarch64, yum does not pick the right `bind-license` package for some reason
+# here we install a specific noarch RPM.
 {% if arch == 'aarch64' -%}
 RUN for iter in {1..10}; do {{ package_manager }} install -y http://mirror.centos.org/centos/7/updates/x86_64/Packages/bind-license-9.11.4-26.P2.el7_9.5.noarch.rpm && \
     {{ package_manager }} clean all && \

--- a/docker/templates/Dockerfile.j2
+++ b/docker/templates/Dockerfile.j2
@@ -24,12 +24,19 @@
   {% set locale = 'en_US.UTF-8' -%}
 {% endif -%}
 
+
+{% if arch == 'aarch64' -%}
+  {% set packages = 'http://mirror.centos.org/centos/7/updates/x86_64/Packages/bind-license-9.11.4-26.P2.el7_9.5.noarch.rpm procps findutils tar gzip which shadow-utils' -%}
+{% else -%}
+  {% set packages = 'procps findutils tar gzip which shadow-utils' -%}
+{% endif -%}
+
 FROM {{ base_image }}
 
 # Install Java and the "which" command, which is needed by Logstash's shell
 # scripts.
 # Minimal distributions also require findutils tar gzip (procps for integration tests)
-RUN {{ package_manager }} update -y && {{ package_manager }} install -y procps findutils tar gzip which shadow-utils && \
+RUN {{ package_manager }} update -y && {{ package_manager }} install -y {{ packages }} && \
     {{ package_manager }} clean all
 
 # Provide a non-root user to run the process.

--- a/docker/templates/Dockerfile.j2
+++ b/docker/templates/Dockerfile.j2
@@ -32,17 +32,23 @@ FROM {{ base_image }}
 
 {% if arch == 'aarch64' -%}
 RUN for iter in {1..10}; do {{ package_manager }} install -y http://mirror.centos.org/centos/7/updates/x86_64/Packages/bind-license-9.11.4-26.P2.el7_9.5.noarch.rpm && \
-    {{ package_manager }} clean all && exit_code=0 && break || \
-    exit_code=$? && echo "yum error: retry $iter in 10s" && {{ package_manager }} clean all && {{ package_manager }} clean metadata && sleep 10; done; \
+    {{ package_manager }} clean all && \
+    {{ package_manager }} clean metadata && \
+    exit_code=0 && break || exit_code=$? && \
+    echo "packaging error: retry $iter in 10s" && \
+    {{ package_manager }} clean all && \
+    {{ package_manager }} clean metadata && sleep 10; done; \
     (exit $exit_code)
 
 {% endif -%}
 
 RUN for iter in {1..10}; do {{ package_manager }} update -y && \
     {{ package_manager }} install -y procps findutils tar gzip which shadow-utils && \
+    {{ package_manager }} clean all && \
     {{ package_manager }} clean metadata && \
-    exit_code=0 && \
-    break || exit_code=$? && echo "packaging error error: retry $iter in 10s" && \
+    exit_code=0 && break || exit_code=$? && \
+    echo "packaging error: retry $iter in 10s" && \
+    {{ package_manager }} clean all && \
     {{ package_manager }} clean metadata && sleep 10; done; \
     (exit $exit_code)
 

--- a/docker/templates/Dockerfile.j2
+++ b/docker/templates/Dockerfile.j2
@@ -24,20 +24,27 @@
   {% set locale = 'en_US.UTF-8' -%}
 {% endif -%}
 
-
-{% if arch == 'aarch64' -%}
-  {% set packages = 'http://mirror.centos.org/centos/7/updates/x86_64/Packages/bind-license-9.11.4-26.P2.el7_9.5.noarch.rpm procps findutils tar gzip which shadow-utils' -%}
-{% else -%}
-  {% set packages = 'procps findutils tar gzip which shadow-utils' -%}
-{% endif -%}
-
 FROM {{ base_image }}
 
 # Install Java and the "which" command, which is needed by Logstash's shell
 # scripts.
 # Minimal distributions also require findutils tar gzip (procps for integration tests)
-RUN {{ package_manager }} update -y && {{ package_manager }} install -y {{ packages }} && \
-    {{ package_manager }} clean all
+
+{% if arch == 'aarch64' -%}
+RUN for iter in {1..10}; do {{ package_manager }} install -y http://mirror.centos.org/centos/7/updates/x86_64/Packages/bind-license-9.11.4-26.P2.el7_9.5.noarch.rpm && \
+    {{ package_manager }} clean all && exit_code=0 && break || \
+    exit_code=$? && echo "yum error: retry $iter in 10s" && {{ package_manager }} clean all && {{ package_manager }} clean metadata && sleep 10; done; \
+    (exit $exit_code)
+
+{% endif -%}
+
+RUN for iter in {1..10}; do {{ package_manager }} update -y && \
+    {{ package_manager }} install -y procps findutils tar gzip which shadow-utils && \
+    {{ package_manager }} clean metadata && \
+    exit_code=0 && \
+    break || exit_code=$? && echo "packaging error error: retry $iter in 10s" && \
+    {{ package_manager }} clean metadata && sleep 10; done; \
+    (exit $exit_code)
 
 # Provide a non-root user to run the process.
 RUN groupadd --gid 1000 logstash && \


### PR DESCRIPTION
When building the aarch64 docker artifacts, the initial `yum update` would fail with the following error:

```
http://d36uatko69830t.cloudfront.net/altarch/7/updates/aarch64/Packages/bind-license-9.11.4-26.P2.el7_9.5.noarch.rpm: [Errno -1] Package does not match intended download. Suggestion: run yum --enablerepo=updates clean metadata
```

This is currently blocking the unified release builds. This commit fixes the creation of the docker images. But does not fix the issue in https://github.com/elastic/logstash/issues/12898, which is currently failing CI on aarch64 nodes.

## Release notes

No user-facing changes in this commit


## What does this PR do?

When building the aarch64 docker artifacts, the initial `yum update` would attempt to update the `bind-license` package from a location where it does not exist and fail with the following error:

```
http://d36uatko69830t.cloudfront.net/altarch/7/updates/aarch64/Packages/bind-license-9.11.4-26.P2.el7_9.5.noarch.rpm: [Errno -1] Package does not match intended download. Suggestion: run yum --enablerepo=updates clean metadata
```

This commit adds a specific install of the `noarch` version of the `bind-license` rpm from a known location before `yum update` is run to ensure that this update will work correctly.

This commit also adds re-try to the yum installs and updates.

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

Currently, unified release snapshot builds are failing


## How to test this PR locally

This is currently failing in CI due to https://github.com/elastic/logstash/issues/12898, but building "locally" on an AWS graviton2 image, the tests run successfully.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.
It can be seen at https://logstash-ci.elastic.co/job/elastic+logstash+master+multijob-aarch64-docker-acceptance/flavor=full,nodes=aarch64/18/console that the building of the images is working ok, but the tests are failing due to the issue referenced above
- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
