### PR TITLE
[Backport 7.13][Build] On aarch64 docker build, install `noarch` vers…

### DIFF
--- a/docker/templates/Dockerfile.j2
+++ b/docker/templates/Dockerfile.j2
@@ -29,8 +29,30 @@ FROM {{ base_image }}
 # Install Java and the "which" command, which is needed by Logstash's shell
 # scripts.
 # Minimal distributions also require findutils tar gzip (procps for integration tests)
-RUN {{ package_manager }} update -y && {{ package_manager }} install -y procps findutils tar gzip which shadow-utils && \
-    {{ package_manager }} clean all
+
+# on aarch64, yum does not pick the right `bind-license` package for some reason
+# here we install a specific noarch RPM.
+{% if arch == 'aarch64' -%}
+RUN for iter in {1..10}; do {{ package_manager }} install -y http://mirror.centos.org/centos/7/updates/x86_64/Packages/bind-license-9.11.4-26.P2.el7_9.5.noarch.rpm && \
+    {{ package_manager }} clean all && \
+    {{ package_manager }} clean metadata && \
+    exit_code=0 && break || exit_code=$? && \
+    echo "packaging error: retry $iter in 10s" && \
+    {{ package_manager }} clean all && \
+    {{ package_manager }} clean metadata && sleep 10; done; \
+    (exit $exit_code)
+
+{% endif -%}
+
+RUN for iter in {1..10}; do {{ package_manager }} update -y && \
+    {{ package_manager }} install -y procps findutils tar gzip which shadow-utils && \
+    {{ package_manager }} clean all && \
+    {{ package_manager }} clean metadata && \
+    exit_code=0 && break || exit_code=$? && \
+    echo "packaging error: retry $iter in 10s" && \
+    {{ package_manager }} clean all && \
+    {{ package_manager }} clean metadata && sleep 10; done; \
+    (exit $exit_code)
 
 # Provide a non-root user to run the process.
 RUN groupadd --gid 1000 logstash && \


### PR DESCRIPTION
…ion of bind-license first (#12891)

Backport PR #12891 to 7.13 branch. Original message:

On aarch64, yum does not pick the correct 'bind-license' package,
this commit installs a specific noarch RPM

This commit also adds retry to the yum installs and updates.

