### PR TITLE
Backport PR #12902 to 7.13: fix ubi8 docker image creation by skipping yum clean metadata

### DIFF
--- a/docker/templates/Dockerfile.j2
+++ b/docker/templates/Dockerfile.j2
@@ -47,11 +47,16 @@ RUN for iter in {1..10}; do {{ package_manager }} install -y http://mirror.cento
 RUN for iter in {1..10}; do {{ package_manager }} update -y && \
     {{ package_manager }} install -y procps findutils tar gzip which shadow-utils && \
     {{ package_manager }} clean all && \
+{% if image_flavor != 'ubi8' -%}
     {{ package_manager }} clean metadata && \
+{% endif -%}
     exit_code=0 && break || exit_code=$? && \
     echo "packaging error: retry $iter in 10s" && \
     {{ package_manager }} clean all && \
-    {{ package_manager }} clean metadata && sleep 10; done; \
+{% if image_flavor != 'ubi8' -%}
+    {{ package_manager }} clean metadata && \
+{% endif -%}
+    sleep 10; done; \
     (exit $exit_code)
 
 # Provide a non-root user to run the process.


### PR DESCRIPTION
Backport PR #12902 to 7.13 branch. Original message: 

ubi8 image uses microdnf as a package manager, and microdnf does
not support the "yum clean metadata" command. This commit adds
the logic to skip this command if the image_flavor is ubi8

To test this, you can use the following command to generate the Dockerfiles and compare them:

```
jinja2 -D created_date='2021-05-12T09:36:42Z' -D elastic_version='7.13.0-SNAPSHOT' -D arch='x86_64' -D version_tag='7.13.0-SNAPSHOT' -D image_flavor='oss' -D local_artifacts='true' docker/templates/Dockerfile.j2 > Dockerfile-oss
jinja2 -D created_date='2021-05-12T09:36:42Z' -D elastic_version='7.13.0-SNAPSHOT' -D arch='x86_64' -D version_tag='7.13.0-SNAPSHOT' -D image_flavor='full' -D local_artifacts='true' docker/templates/Dockerfile.j2 > Dockerfile-full
jinja2 -D created_date='2021-05-12T09:36:42Z' -D elastic_version='7.13.0-SNAPSHOT' -D arch='x86_64' -D version_tag='7.13.0-SNAPSHOT' -D image_flavor='ubi8' -D local_artifacts='true' docker/templates/Dockerfile.j2 > Dockerfile-ubi8
```