### PR TITLE
[7.13] Geoip disable database manager (#12905)

### DIFF
--- a/x-pack/lib/filters/geoip/database_manager.rb
+++ b/x-pack/lib/filters/geoip/database_manager.rb
@@ -35,6 +35,7 @@ module LogStash module Filters module Geoip class DatabaseManager
     @geoip = geoip
     self.class.prepare_cc_db
     @mode = database_path.nil? ? :online : :offline
+    @mode = :disabled # This is a temporary change that turns off the database manager until it is ready for general availability.
     @database_type = database_type
     @database_path = patch_database_path(database_path)
 
@@ -49,6 +50,8 @@ module LogStash module Filters module Geoip class DatabaseManager
       # check database update periodically. trigger `call` method
       @scheduler = Rufus::Scheduler.new({:max_work_threads => 1})
       @scheduler.every('24h', self)
+    elsif @mode == :disabled
+      # The plan is to use CC database in Logstash 7.x and enable EULA database in 8
     else
       logger.info "GeoIP database path is configured manually so the plugin will not check for update. "\
                   "Keep in mind that if you are not using the database shipped with this plugin, "\

--- a/x-pack/spec/filters/geoip/database_manager_spec.rb
+++ b/x-pack/spec/filters/geoip/database_manager_spec.rb
@@ -67,9 +67,12 @@ describe LogStash::Filters::Geoip do
         expect(mock_metadata).to receive(:updated_at).and_return((Time.now - (60 * 60 * 24 * 26)).to_i)
         expect(mock_metadata).to receive(:cc?).and_return(false)
         expect(mock_geoip_plugin).to receive(:terminate_filter).never
-        expect(LogStash::Filters::Geoip::DatabaseManager).to receive(:logger).at_least(:once).and_return(logger)
-        expect(logger).to receive(:warn)
-        expect(logger).to receive(:info)
+
+        if db_manager.instance_variable_get(:@mode) != :disabled
+          expect(LogStash::Filters::Geoip::DatabaseManager).to receive(:logger).at_least(:once).and_return(logger)
+          expect(logger).to receive(:warn)
+          expect(logger).to receive(:info)
+        end
 
         db_manager.send(:check_age)
       end


### PR DESCRIPTION
Backports the following commits to 7.13:
 - Geoip disable database manager (#12905)