### PR TITLE
doc: add REE removal to 8.0 breaking changes

### DIFF
--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -33,6 +33,13 @@ Here are the breaking changes for 8.0.
 ==== Changes in Logstash Core
 
 [float]
+[[ruby-execution-engine]]
+===== Ruby Execution Engine removed
+The Execution Engine transforms pipeline definitions into executable code, and manages that code's execution.
+Since {ls} 7.0, the Java Execution Engine (JEE) has been the default, but users could still configure their installation to use the legacy Ruby Execution Engine (REE).
+The option to use REE is removed in 8.0.
+
+[float]
 [[field-reference-parser]]
 ===== Field Reference parser removed
 The Field Reference parser interprets references to fields in your pipelines and


### PR DESCRIPTION


## Release notes

[rn:skip]

## What does this PR do?

Adds an entry to the breaking changes doc for the 8.0 removal of the Ruby Execution Engine, which was merged in https://github.com/elastic/logstash/pull/12490

## Why is it important/What is the impact to the user?

Helps users considering upgrading to Logstash 8.0 understand the scope of changes.

## Checklist

- ~[ ] My code follows the style guidelines of this project~
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

Related: elastic/logstash#11236

