### PR TITLE
Pin JDK8 version in Docker to avoid KeyStore creation race condition 

### DIFF
--- a/docker/templates/Dockerfile.j2
+++ b/docker/templates/Dockerfile.j2
@@ -16,7 +16,10 @@ FROM centos:7
 
 # Install Java and the "which" command, which is needed by Logstash's shell
 # scripts.
-RUN yum update -y && yum install -y java-1.8.0-openjdk-devel which && \
+# NOTE: pinning jdk 1.8.0.282 as .292 has an issue creating keystores
+# Logstash issue: https://github.com/elastic/logstash/issues/12917
+# OpenJDK issue: https://bugs.openjdk.java.net/browse/JDK-8266261
+RUN yum update -y && yum install -y java-1.8.0-openjdk-devel-1.8.0.282.b08 java-1.8.0-openjdk-headless-1.8.0.282.b08 which && \
     yum clean all
 
 # Provide a non-root user to run the process.


### PR DESCRIPTION
JDK 1.8.0.292 has a race condition that impacts creating keystores.

Logstash issue: https://github.com/elastic/logstash/issues/12917
OpenJDK issue: https://bugs.openjdk.java.net/browse/JDK-8266261

For reviewers, to test this:
1. `rake artifact:docker`
2. `docker run -it docker.elastic.co/logstash/logstash-full:6.8.16-SNAPSHOT bash `
3. `echo y | LOGSTASH_KEYSTORE_PASS=hey bin/logstash-keystore create`

Fixes #12917 