### PR TITLE
Created release notes for v6.8.16

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -53,9 +53,10 @@ This section summarizes the changes in the following releases:
 
 Pin JDK 1.8.0.282 version in Docker image to avoid jdk bug https://github.com/elastic/logstash/pull/12918[#12918]
 
-JDK 1.8.0.292 has a race condition that impacts creating keystores
-Logstash issue: https://github.com/elastic/logstash/issues/12917
-OpenJDK issue: https://bugs.openjdk.java.net/browse/JDK-8266261
+==== Known issues
+
+JDK 1.8.0.292 has a race condition that impacts creating keystores.
+More information is available in the Logstash issue https://github.com/elastic/logstash/issues/12917[#12917] and the https://bugs.openjdk.java.net/browse/JDK-8266261[OpenJDK issue].
 
 [[logstash-6-8-15]]
 === Logstash 6.8.15 Release Notes

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -56,7 +56,7 @@ Pin JDK 1.8.0.282 version in Docker image to avoid jdk bug https://github.com/el
 ==== Known issues
 
 JDK 1.8.0.292 has a race condition that impacts creating keystores.
-More information is available in the Logstash issue https://github.com/elastic/logstash/issues/12917[#12917] and the https://bugs.openjdk.java.net/browse/JDK-8266261[OpenJDK issue].
+More information is available in Logstash issue https://github.com/elastic/logstash/issues/12917[#12917] and the https://bugs.openjdk.java.net/browse/JDK-8266261[OpenJDK issue].
 
 [[logstash-6-8-15]]
 === Logstash 6.8.15 Release Notes

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in the following releases:
 
+* <<logstash-6-8-16,Logstash 6.8.16>>
 * <<logstash-6-8-15,Logstash 6.8.15>>
 * <<logstash-6-8-14,Logstash 6.8.14>>
 * <<logstash-6-8-13,Logstash 6.8.13>>
@@ -46,6 +47,15 @@ This section summarizes the changes in the following releases:
 * <<logstash-6-1-2,Logstash 6.1.2>>
 * <<logstash-6-1-1,Logstash 6.1.1>>
 * <<logstash-6-1-0,Logstash 6.1.0>>
+
+[[logstash-6-8-16]]
+=== Logstash 6.8.16 Release Notes
+
+Pin JDK 1.8.0.282 version in Docker image to avoid jdk bug https://github.com/elastic/logstash/pull/12918[#12918]
+
+JDK 1.8.0.292 has a race condition that impacts creating keystores
+Logstash issue: https://github.com/elastic/logstash/issues/12917
+OpenJDK issue: https://bugs.openjdk.java.net/browse/JDK-8266261
 
 [[logstash-6-8-15]]
 === Logstash 6.8.15 Release Notes


### PR DESCRIPTION
Update Release Notes for version 6.8.16

**PREVIEW:** https://logstash_12922.docs-preview.app.elstc.co/guide/en/logstash/6.8/logstash-6-8-16.html