### PR TITLE
Feat: event factory support

### DIFF
--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -18,6 +18,7 @@
 require "logstash/config/mixin"
 require "logstash/plugins/ecs_compatibility_support"
 require "concurrent"
+require "logstash/plugins/event_factory_support"
 require "securerandom"
 
 require_relative 'plugin_metadata'
@@ -31,6 +32,7 @@ class LogStash::Plugin
 
   include LogStash::Config::Mixin
   include LogStash::Plugins::ECSCompatibilitySupport
+  include LogStash::Plugins::EventFactorySupport
 
   # Disable or enable metric logging for this specific plugin instance
   # by default we record all the metrics we can, but you can disable metrics collection

--- a/logstash-core/lib/logstash/plugins/event_factory_support.rb
+++ b/logstash-core/lib/logstash/plugins/event_factory_support.rb
@@ -1,0 +1,70 @@
+module LogStash
+  module Plugins
+    module EventFactorySupport
+
+      def event_factory
+        @event_factory ||= default_event_factory
+      end
+      attr_writer :event_factory
+
+      def default_event_factory
+        DefaultEventFactory::INSTANCE
+      end
+
+      def event_factory_builder
+        Builder.new self, default_event_factory
+      end
+
+      class Builder
+
+        def initialize(plugin, factory)
+          @plugin = plugin
+          @factory = factory
+        end
+
+        # @return an event factory
+        def build
+          @plugin.event_factory = @factory
+        end
+
+        # @return [Builder] self
+        def with_target(target)
+          unless target.nil?
+            @factory = TargetedEventFactory.new(@factory, target)
+          end
+          self
+        end
+
+      end
+
+      class DefaultEventFactory
+        INSTANCE = new
+
+        # @param payload [Hash]
+        # @return [LogStash::Event]
+        def new_event(payload)
+          LogStash::Event.new(payload)
+        end
+
+      end
+      private_constant :DefaultEventFactory
+
+      class TargetedEventFactory
+
+        def initialize(inner, target)
+          @delegate = inner
+          @target = target
+        end
+
+        # @param payload [Hash]
+        # @return [LogStash::Event]
+        def new_event(payload)
+          @delegate.new_event(@target => payload)
+        end
+
+      end
+      private_constant :TargetedEventFactory
+
+    end
+  end
+end

--- a/logstash-core/lib/logstash/plugins/event_factory_support.rb
+++ b/logstash-core/lib/logstash/plugins/event_factory_support.rb
@@ -12,19 +12,18 @@ module LogStash
       end
 
       def event_factory_builder
-        Builder.new self, default_event_factory
+        EventFactoryBuilder.new default_event_factory
       end
 
-      class Builder
+      class EventFactoryBuilder
 
-        def initialize(plugin, factory)
-          @plugin = plugin
+        def initialize(factory)
           @factory = factory
         end
 
         # @return an event factory
-        def build
-          @plugin.event_factory = @factory
+        def event_factory
+          @factory
         end
 
         # @return [Builder] self

--- a/logstash-core/lib/logstash/util/thread_safe_attributes.rb
+++ b/logstash-core/lib/logstash/util/thread_safe_attributes.rb
@@ -1,0 +1,51 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module LogStash
+  module Util
+    module ThreadSafeAttributes
+
+      def self.included(base)
+        base.extend ClassMethods
+      end
+
+      module ClassMethods
+
+        def lazy_init_attr(attribute, &block)
+          raise ArgumentError.new("invalid attribute name: #{attribute}") unless attribute.match? /^[_A-Za-z]\w*$/
+          raise ArgumentError.new('no block given') unless block_given?
+          var_name = "@#{attribute}".to_sym
+          send(:define_method, attribute.to_sym) do
+            if instance_variable_defined?(var_name)
+              instance_variable_get(var_name)
+            else
+              LogStash::Util.synchronize(self) do
+                if instance_variable_defined?(var_name)
+                  instance_variable_get(var_name)
+                else
+                  instance_variable_set(var_name, instance_eval(&block))
+                end
+              end
+            end
+          end
+        end
+
+      end
+
+    end
+  end
+end

--- a/logstash-core/spec/logstash/event_spec.rb
+++ b/logstash-core/spec/logstash/event_spec.rb
@@ -319,10 +319,8 @@ describe LogStash::Event do
     end
 
     it "should consistently handle nil" do
-      blank_strings.each do |s|
-        expect{LogStash::Event.from_json(nil)}.to raise_error
-        expect{LogStash::Event.new(LogStash::Json.load(nil))}.to raise_error
-      end
+      expect{LogStash::Event.from_json(nil)}.to raise_error # TypeError
+      expect{LogStash::Event.new(LogStash::Json.load(nil))}.to raise_error # java.lang.ClassCastException
     end
 
     it "should consistently handle bare string" do
@@ -330,6 +328,12 @@ describe LogStash::Event do
         expect{LogStash::Event.from_json(s)}.to raise_error LogStash::Json::ParserError
         expect{LogStash::Event.new(LogStash::Json.load(s))}.to raise_error LogStash::Json::ParserError
        end
+    end
+
+    it "should allow to pass a block that acts as an event factory" do
+      events = LogStash::Event.from_json(source_json) { |data| LogStash::Event.new(data).tap { |e| e.set('answer', 42) } }
+      expect( events.size ).to eql 1
+      expect( events.first.get('answer') ).to eql 42
     end
   end
 

--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -252,6 +252,12 @@ public final class Event implements Cloneable, Queueable, co.elastic.logstash.ap
 
     private static final Event[] NULL_ARRAY = new Event[0];
 
+    /**
+     * Map a JSON string into events.
+     * @param json input string
+     * @return events
+     * @throws IOException when (JSON) parsing fails
+     */
     @SuppressWarnings("unchecked")
     public static Event[] fromJson(final String json) throws IOException {
         // empty/blank json string does not generate an event
@@ -265,21 +271,17 @@ public final class Event implements Cloneable, Queueable, co.elastic.logstash.ap
             return new Event[] { new Event((Map<String, Object>) o) };
         }
         if (o instanceof List) { // Jackson returns an ArrayList
-            return mapFromList((List<Map<String, Object>>) o);
+            return fromList((List<Map<String, Object>>) o);
         }
 
         throw new IOException("incompatible json object type=" + o.getClass().getName() + " , only hash map or arrays are supported");
     }
 
-    private static Event[] mapFromList(final List<Map<String, Object>> list) throws IOException {
+    private static Event[] fromList(final List<Map<String, Object>> list) throws ClassCastException {
         final int len = list.size();
         Event[] result = new Event[len];
         for (int i = 0; i < len; i++) {
-            try {
-                result[i] = new Event(list.get(i));
-            } catch (ClassCastException e) {
-                throw new IOException("incompatible json object type=" + list.get(i).getClass().getName() + " , only hash map is supported", e);
-            }
+            result[i] = new Event(list.get(i));
         }
         return result;
     }

--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -252,36 +252,51 @@ public final class Event implements Cloneable, Queueable, co.elastic.logstash.ap
 
     private static final Event[] NULL_ARRAY = new Event[0];
 
+    private static Object parseJson(final String json) throws IOException {
+        return JSON_MAPPER.readValue(json, Object.class);
+    }
+
     /**
      * Map a JSON string into events.
      * @param json input string
      * @return events
      * @throws IOException when (JSON) parsing fails
      */
-    @SuppressWarnings("unchecked")
     public static Event[] fromJson(final String json) throws IOException {
+        return fromJson(json, EventFactory.DEFAULT);
+    }
+
+    /**
+     * Map a JSON string into events.
+     * @param json input string
+     * @param factory event factory
+     * @return events
+     * @throws IOException when (JSON) parsing fails
+     */
+    @SuppressWarnings("unchecked")
+    public static Event[] fromJson(final String json, final EventFactory factory) throws IOException {
         // empty/blank json string does not generate an event
         if (json == null || isBlank(json)) {
             return NULL_ARRAY;
         }
 
-        Object o = JSON_MAPPER.readValue(json, Object.class);
+        Object o = parseJson(json);
         // we currently only support Map or Array json objects
         if (o instanceof Map) {
-            return new Event[] { new Event((Map<String, Object>) o) };
+            return new Event[] { factory.newEvent((Map<String, Object>) o) };
         }
         if (o instanceof List) { // Jackson returns an ArrayList
-            return fromList((List<Map<String, Object>>) o);
+            return fromList((List<Map<String, Object>>) o, factory);
         }
 
         throw new IOException("incompatible json object type=" + o.getClass().getName() + " , only hash map or arrays are supported");
     }
 
-    private static Event[] fromList(final List<Map<String, Object>> list) throws ClassCastException {
+    private static Event[] fromList(final List<Map<String, Object>> list, final EventFactory factory) {
         final int len = list.size();
         Event[] result = new Event[len];
         for (int i = 0; i < len; i++) {
-            result[i] = new Event(list.get(i));
+            result[i] = factory.newEvent(list.get(i));
         }
         return result;
     }

--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -253,11 +253,9 @@ public final class Event implements Cloneable, Queueable, co.elastic.logstash.ap
     private static final Event[] NULL_ARRAY = new Event[0];
 
     @SuppressWarnings("unchecked")
-    public static Event[] fromJson(String json)
-            throws IOException
-    {
+    public static Event[] fromJson(final String json) throws IOException {
         // empty/blank json string does not generate an event
-        if (json == null || json.trim().isEmpty()) {
+        if (json == null || isBlank(json)) {
             return NULL_ARRAY;
         }
 
@@ -357,6 +355,17 @@ public final class Event implements Cloneable, Queueable, co.elastic.logstash.ap
         return t != null
                 ? t.toString() + " " + hostMessageString
                 : hostMessageString;
+    }
+
+    private static boolean isBlank(final String str) {
+        final int len = str.length();
+        if (len == 0) return true;
+        for (int i = 0; i < len; i++) {
+            if (!Character.isWhitespace(str.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static Timestamp initTimestamp(Object o) {

--- a/logstash-core/src/main/java/org/logstash/EventFactory.java
+++ b/logstash-core/src/main/java/org/logstash/EventFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.logstash;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * A factory for events.
+ */
+@FunctionalInterface
+public interface EventFactory {
+
+    Event newEvent(Map<String, Object> data);
+
+    default Event newEvent() {
+        return newEvent(Collections.emptyMap());
+    }
+
+    /**
+     * A default event factory implementation.
+     */
+    EventFactory DEFAULT = (data) -> new Event(data);
+
+}

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/Utils.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/Utils.java
@@ -20,6 +20,7 @@
 
 package org.logstash.config.ir.compiler;
 
+import org.jruby.RubyArray;
 import org.logstash.ext.JrubyEventExtLibrary;
 
 import java.util.Collection;
@@ -44,6 +45,19 @@ public class Utils {
     public static void filterEvents(Collection<JrubyEventExtLibrary.RubyEvent> input, EventCondition filter,
                                     List fulfilled, List unfulfilled) {
         for (JrubyEventExtLibrary.RubyEvent e : input) {
+            if (filter.fulfilled(e)) {
+                fulfilled.add(e);
+            } else {
+                unfulfilled.add(e);
+            }
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static void filterEvents(RubyArray<JrubyEventExtLibrary.RubyEvent> input, EventCondition filter,
+                                    List fulfilled, List unfulfilled) {
+        for (int i=0; i<input.size(); i++) {
+            JrubyEventExtLibrary.RubyEvent e = input.eltInternal(i);
             if (filter.fulfilled(e)) {
                 fulfilled.add(e);
             } else {

--- a/logstash-core/src/main/java/org/logstash/util/UtilExt.java
+++ b/logstash-core/src/main/java/org/logstash/util/UtilExt.java
@@ -23,6 +23,7 @@ package org.logstash.util;
 import org.jruby.RubyThread;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyModule;
+import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
@@ -41,6 +42,13 @@ public class UtilExt {
         // even if thread is dead the RubyThread instance might stick around while the Java thread
         // instance already could have been garbage collected - let's return nil for dead meat :
         return javaThread == null ? context.nil : context.runtime.newFixnum(javaThread.getId());
+    }
+
+    @JRubyMethod(module = true) // JRuby.reference(target).synchronized { ... }
+    public static IRubyObject synchronize(final ThreadContext context, IRubyObject self, IRubyObject target, Block block) {
+        synchronized (target) {
+            return block.yieldSpecific(context);
+        }
     }
 
 }


### PR DESCRIPTION
<!-- ### Release notes
Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->


### What does this PR do?

This PR is motivated by having a way of re-using `LogStash::Event.from_json` with `target => [namespace]` (e.g. in the JSON codec). We [benchmarked](https://gist.github.com/kares/03fee52a0618e4b94a8dc4fcdd52b68d#file-_results-out) the generic `LogStash::Json` parsing (which has JRuby parsing hooks) and found it noticeably slower compared to the Java native `Event.fromJson`.

A clean way forward would be to introduce a notion of an `EventFactory` with a `newEvent` (`new_event`) interface.
The factory is meant to be later re-used/extended with ECS compatibility (`new_event` behaving slightly differently in legacy vs ecs mode), this is out-of-scope here, still something to keep in mind.


### Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] I have added tests that prove my fix is effective or that my feature works

### How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

### Related

follow-up adapter mixin: https://github.com/logstash-plugins/logstash-mixin-event_support/pull/2

