### PR TITLE
Backport PR #12925 to 7.x: Add logstash-integration-elastic_enterpris…

### DIFF
--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -403,6 +403,10 @@
     "default-plugins": true,
     "skip-list": false
   },
+  "logstash-integration-elastic_enterprise_search": {
+    "default-plugins": true,
+    "skip-list": false
+  },
   "logstash-integration-jdbc": {
     "default-plugins": true,
     "skip-list": false
@@ -420,10 +424,6 @@
     "skip-list": false
   },
   "logstash-output-csv": {
-    "default-plugins": true,
-    "skip-list": false
-  },
-  "logstash-output-elastic_app_search": {
     "default-plugins": true,
     "skip-list": false
   },

--- a/tools/dependencies-report/src/main/resources/licenseMapping.csv
+++ b/tools/dependencies-report/src/main/resources/licenseMapping.csv
@@ -39,6 +39,7 @@ dependency,dependencyUrl,licenseOverride,copyright,sourceURL
 "dotenv:",https://github.com/bkeepers/dotenv,MIT
 "edn:",https://github.com/relevance/edn-ruby,MIT
 "elastic-app-search:",https://github.com/elastic/app-search-ruby,Apache-2.0
+"elastic-workplace-search:",https://github.com/elastic/workplace-search-ruby,Apache-2.0
 "elasticsearch-api:",https://github.com/elastic/elasticsearch-ruby,Apache-2.0
 "elasticsearch-transport:",https://github.com/elastic/elasticsearch-ruby,Apache-2.0
 "elasticsearch:",https://github.com/elastic/elasticsearch-ruby,Apache-2.0

--- a/tools/dependencies-report/src/main/resources/notices/elastic-workplace-search-NOTICE.txt
+++ b/tools/dependencies-report/src/main/resources/notices/elastic-workplace-search-NOTICE.txt
@@ -1,0 +1,5 @@
+source: https://github.com/elastic/workplace-search-ruby/blob/master/NOTICE.txt
+
+Elastic Workplace Search Ruby client.
+
+Copyright 2012-2020 Elasticsearch B.V.


### PR DESCRIPTION
…e_search to plugins-metadata.json

Backport PR #12925 to 7.x. Original Message:

* Add logstash-integration-elastic_enterprise_search to plugins-metadata.json
* Remove old elastic_app_search plugin and set integration as default
* Add license information for workplace search gem

(cherry picked from commit https://github.com/elastic/logstash/commit/a935261eeb9b96c89bc6bdd595bcc466f222d5cc)
