### PR TITLE
turn off data streams in internal monitoring collection

### DIFF
--- a/x-pack/lib/template.cfg.erb
+++ b/x-pack/lib/template.cfg.erb
@@ -27,6 +27,7 @@ output {
   <% if cloud_auth %>
     cloud_auth => "<%= cloud_auth %>"
   <% end %>
+    data_stream => false
     bulk_path => "<%= monitoring_endpoint %>"
     manage_template => false
     document_type => "%{[@metadata][document_type]}"


### PR DESCRIPTION
Since we default to data streams in 8.0.0, the internal collection for monitoring stops working due to the ES output trying to send data to the logs- data stream instead of the monitoring endpoint.
We can see this in the network traffic during the x-pack integration tests that are currently failing:

```
POST /_monitoring/bulk?system_id=logstash&system_api_version=7&interval=1s HTTP/1.1
Connection: Keep-Alive
Content-Type: application/json
Content-Length: 1870
Host: localhost:9200
User-Agent: Manticore 0.7.0
Accept-Encoding: gzip,deflate
 
{"create":{"_id":null,"_index":"logs-generic-default","routing":null}}
{"pipeline":...}
```

Reviewers can confirm that the tests no longer hang by running `./x-pack/ci/integration_tests.sh ` after applying this patch to the master branch