### PR TITLE
Use the JVM specified in the CI matrix environment also to run spawned proccesses

### DIFF
--- a/qa/integration/specs/cli/keystore_spec.rb
+++ b/qa/integration/specs/cli/keystore_spec.rb
@@ -42,7 +42,11 @@ describe "CLI > logstash-keystore" do
     end
 
     it "works" do
-      keystore_list = @logstash.run_cmd(['bin/logstash-keystore', 'create'], true, 'LOGSTASH_KEYSTORE_PASS' => 'PaSSWD')
+      env = {'LOGSTASH_KEYSTORE_PASS' => 'PaSSWD'}
+      unless ENV['BUILD_JAVA_HOME']
+        env['JAVA_HOME'] = ENV['BUILD_JAVA_HOME']
+      end
+      keystore_list = @logstash.run_cmd(['bin/logstash-keystore', 'create'], true, env)
       expect(keystore_list.stderr_and_stdout).to_not match(/ERROR/)
       expect(keystore_list.stderr_and_stdout).to include('Created Logstash keystore')
     end
@@ -57,7 +61,11 @@ describe "CLI > logstash-keystore" do
     end
 
     it "works" do
-      keystore_list = @logstash.run_cmd(['bin/logstash-keystore', 'list'], true, 'LOGSTASH_KEYSTORE_PASS' => 'PaSSWD')
+      env = {'LOGSTASH_KEYSTORE_PASS' => 'PaSSWD'}
+      unless ENV['BUILD_JAVA_HOME']
+        env['JAVA_HOME'] = ENV['BUILD_JAVA_HOME']
+      end
+      keystore_list = @logstash.run_cmd(['bin/logstash-keystore', 'list'], true, env)
       expect(keystore_list.stderr_and_stdout).to_not match(/ERROR/)
       expect(keystore_list.stderr_and_stdout).to include('foo') # contains foo: bar
     end

--- a/qa/integration/specs/cli/keystore_spec.rb
+++ b/qa/integration/specs/cli/keystore_spec.rb
@@ -43,7 +43,7 @@ describe "CLI > logstash-keystore" do
 
     it "works" do
       env = {'LOGSTASH_KEYSTORE_PASS' => 'PaSSWD'}
-      unless ENV['BUILD_JAVA_HOME']
+      if ENV['BUILD_JAVA_HOME']
         env['JAVA_HOME'] = ENV['BUILD_JAVA_HOME']
       end
       keystore_list = @logstash.run_cmd(['bin/logstash-keystore', 'create'], true, env)

--- a/qa/integration/specs/cli/keystore_spec.rb
+++ b/qa/integration/specs/cli/keystore_spec.rb
@@ -62,7 +62,7 @@ describe "CLI > logstash-keystore" do
 
     it "works" do
       env = {'LOGSTASH_KEYSTORE_PASS' => 'PaSSWD'}
-      unless ENV['BUILD_JAVA_HOME']
+      if ENV['BUILD_JAVA_HOME']
         env['JAVA_HOME'] = ENV['BUILD_JAVA_HOME']
       end
       keystore_list = @logstash.run_cmd(['bin/logstash-keystore', 'list'], true, env)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
Use the JDK selected by the environment variable `BUILD_JAVA_HOME` also to run the `logstash_keystore` tool from integration test.

The CI runs JDK matrix tests selecting the JDK by setting path values into `BUILD_JAVA_HOME`. When the `ci/integration_test.sh` runs  `keystore_spec.rb` it forks a process to execute the `logstash-keystore` tool which selects the JDK giving precedence to JAVA_HOME. The problem is that the CI ships with JDK `1.8.292` as system's JDK which have problem with cypher algorithm.  This PR sets `JAVA_HOME` before forking the tool, in this way also the tool runs with same JDK as the rest of the build.

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
This doesn't impact directly the user but the CI system. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
- sets JDK 1.8.292 as system's JDK (maybe use `sdk install java 8.0.292.hs-adpt`)
- set `BUILD_JAVA_HOME` to a JDK11 path
- run `ci/integration_tests.sh`


## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
```
09:21:23     Failures:
09:21:23 
09:21:23       1) CLI > logstash-keystore create works
09:21:23          Failure/Error: expect(keystore_list.stderr_and_stdout).to_not match(/ERROR/)
09:21:23          
09:21:23            expected "Using JAVA_HOME defined java: /usr/lib/jvm/java-8-openjdk-amd64\nwarning: ignoring JAVA_TOOL_OPTIONS...org.jruby.Main.run(org/jruby/Main.java:234)\", \"org.jruby.Main.main(org/jruby/Main.java:206)\"]}\n" not to match /ERROR/
09:21:23            Diff:
09:21:23            @@ -1,4 +1,7 @@
09:21:23            -/ERROR/
09:21:23            +Using JAVA_HOME defined java: /usr/lib/jvm/java-8-openjdk-amd64
09:21:23            +warning: ignoring JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
09:21:23            +
09:21:23            +[ERROR] 2021-05-28 07:14:24.321 [main] secretstorecli - Failed to create Logstash keystore. {:cause=>java.security.KeyStoreException: Key protection  algorithm not found: java.security.NoSuchAlgorithmException: unrecognized algorithm name: PBEWithMD5AndDES, :backtrace=>["org.logstash.secret.store.backend.JavaKeyStore.create(org/logstash/secret/store/backend/JavaKeyStore.java:111)", "org.logstash.secret.store.backend.JavaKeyStore.create(org/logstash/secret/store/backend/JavaKeyStore.java:59)", "org.logstash.secret.store.SecretStoreFactory.doIt(org/logstash/secret/store/SecretStoreFactory.java:131)", "org.logstash.secret.store.SecretStoreFactory.create(org/logstash/secret/store/SecretStoreFactory.java:95)", "org.logstash.secret.cli.SecretStoreCli.deleteThenCreate(org/logstash/secret/cli/SecretStoreCli.java:208)", "org.logstash.secret.cli.SecretStoreCli.create(org/logstash/secret/cli/SecretStoreCli.java:202)", "org.logstash.secret.cli.SecretStoreCli.command(org/logstash/secret/cli/SecretStoreCli.java:87)", "java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)", "org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:426)", "org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:293)", "var.lib.jenkins.workspace.elastic_plus_logstash_plus_7_dot_13_plus_multijob_minus_matrix_minus_jdk_minus_unix_minus_integration_minus_2.LS_RUNTIME_JAVA.adoptopenjdk15.os.ubuntu_minus_20_dot_04_and_and_immutable.build.logstash_minus_7_dot_13_dot_1_minus_SNAPSHOT.lib.secretstore.cli.<module:SecretStoreCli>(/var/lib/jenkins/workspace/elastic+logstash+7.13+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptopenjdk15/os/ubuntu-20.04&&immutable/build/logstash-7.13.1-SNAPSHOT/lib/secretstore/cli.rb:52)", "var.lib.jenkins.workspace.elastic_plus_logstash_plus_7_dot_13_plus_multijob_minus_matrix_minus_jdk_minus_unix_minus_integration_minus_2.LS_RUNTIME_JAVA.adoptopenjdk15.os.ubuntu_minus_20_dot_04_and_and_immutable.build.logstash_minus_7_dot_13_dot_1_minus_SNAPSHOT.lib.secretstore.cli.<main>(/var/lib/jenkins/workspace/elastic+logstash+7.13+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptopenjdk15/os/ubuntu-20.04&&immutable/build/logstash-7.13.1-SNAPSHOT/lib/secretstore/cli.rb:33)", "java.lang.invoke.MethodHandle.invokeWithArguments(java/lang/invoke/MethodHandle.java:627)", "org.jruby.Ruby.runScript(org/jruby/Ruby.java:1205)", "org.jruby.Ruby.runNormally(org/jruby/Ruby.java:1128)", "org.jruby.Ruby.runNormally(org/jruby/Ruby.java:1146)", "org.jruby.Ruby.runFromMain(org/jruby/Ruby.java:958)", "org.jruby.Main.doRunFromMain(org/jruby/Main.java:400)", "org.jruby.Main.internalRun(org/jruby/Main.java:292)", "org.jruby.Main.run(org/jruby/Main.java:234)", "org.jruby.Main.main(org/jruby/Main.java:206)"]}
09:21:23            
09:21:23          # /var/lib/jenkins/workspace/elastic+logstash+7.13+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptopenjdk15/os/ubuntu-20.04&&immutable/qa/integration/specs/cli/keystore_spec.rb:46:in `block in <main>'
09:21:23          # /var/lib/jenkins/workspace/elastic+logstash+7.13+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptopenjdk15/os/ubuntu-20.04&&immutable/build/qa/integration/vendor/jruby/2.5.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block in <main>'
09:21:23          # /var/lib/jenkins/workspace/elastic+logstash+7.13+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptopenjdk15/os/ubuntu-20.04&&immutable/qa/integration/rspec.rb:32:in `<main>'
09:21:23 
```
