### PR TITLE
Fix logstash.bat not setting exit code

### DIFF
--- a/bin/logstash.bat
+++ b/bin/logstash.bat
@@ -84,3 +84,4 @@ goto :eof
 
 :end
 endlocal
+exit /B %ERRORLEVEL%


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes

Fixed Windows logstash.bat not setting exit code

## What does this PR do?

This PR makes the Windows logstash.bat exit with the last `%ERRORLEVEL%` at the end, so that any error in running Logstash will get propagated back to the command line.

Before this change, logstash.bat would always exit with code 0 - success (when doing `cmd.exe /C logstash.bat`), even if the java.exe process exited with a non-zero code (e.g. due to Logstash throwing an error at runtime).

## Why is it important/What is the impact to the user?

Without this change, abnormal exits from Logstash are not detected as such by an owning process (such as service wrappers NSSM or WinSW, or the Windows Task Scheduler). This means recovery actions (like restarting the process or sending a notification) will not get triggered.

_I use WinSW as a service wrapper to "cmd.exe /C logstash.bat", and it was blissfully accepting of a runtime Logstash error that caused the process to exit, because the exit code being returned was 0. With this change added locally, it can now trigger its recovery actions when the error happens._

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Does the label `bug` fit with this change, or should it be `enhancement`?
- [ ] Consider should this have tests added?

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

This is a Windows-only change.

1. Open `cmd.exe` to the `bin` folder
2. Enter `cmd.exe /C logstash.bat` (This invokes the script as an external process)
3. In another command prompt window, type `taskkill /F /IM java.exe` (or target the PID with `/PID` if you don't want to disrupt other java.exe processes)(`/F` is not optional)
4. In the original command prompt window, observe that the command has now ended
5. In the original command prompt window, enter `echo %ERRORLEVEL%`

Before the change in this PR, the last step would print out `0`. With the change in this PR, the last step prints out `1` instead.

## Logs

**Before PR:**

```
C:\Elastic\logstash\bin>cmd.exe /C logstash.bat
Using JAVA_HOME defined java: C:\Program Files\Java\jre1.8.0_171\
WARNING, using JAVA_HOME while Logstash distribution comes with a bundled JDK

~~java.exe is manually killed here~~~

C:\Elastic\logstash\bin>echo %errorlevel%
0
```

**After PR:**

```
C:\Elastic\logstash\bin>cmd.exe /C logstash.bat
Using JAVA_HOME defined java: C:\Program Files\Java\jre1.8.0_171\
WARNING, using JAVA_HOME while Logstash distribution comes with a bundled JDK

~~java.exe is manually killed here~~~

C:\Elastic\logstash\bin>echo %errorlevel%
1
```