### PR TITLE
Internal: Update messaging in release notes script

### DIFF
--- a/tools/release/generate_release_notes.rb
+++ b/tools/release/generate_release_notes.rb
@@ -48,7 +48,7 @@ report << "=== Logstash #{current_release} Release Notes\n"
 
 plugin_changes = {}
 
-report <<  "---------- DELETE FROM HERE ------------"
+report <<  "---------- GENERATED CONTENT STARTS HERE ------------"
 report <<  "=== Logstash Pull Requests with label v#{current_release}\n"
 
 uri = URI.parse("https://api.github.com/search/issues?q=repo:elastic/logstash+is:pr+is:closed+label:v#{current_release}&sort=created&order=asc")
@@ -81,7 +81,7 @@ result.each do |line|
 end
 report << "Changed plugin versions:"
 plugin_changes.each {|p, v| report << "#{p}: #{v.first} -> #{v.last}" }
-report << "---------- DELETE UP TO HERE ------------\n"
+report << "---------- GENERATED CONTENT ENDS HERE ------------\n"
 
 report << "==== Plugins\n"
 


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?
Our release notes script generates a list of changes that are the basis for our release notes.  The message text implies that the content should be deleted, and sometimes people do indeed delete it. :-) 

This PR updates the messaging to indicate that the content is generated. 