### PR TITLE
[backport 7.x] #12945 Use the JVM specified in the CI matrix environment also to run spawned proccesses

### DIFF
--- a/qa/integration/specs/cli/keystore_spec.rb
+++ b/qa/integration/specs/cli/keystore_spec.rb
@@ -42,7 +42,11 @@ describe "CLI > logstash-keystore" do
     end
 
     it "works" do
-      keystore_list = @logstash.run_cmd(['bin/logstash-keystore', 'create'], true, 'LOGSTASH_KEYSTORE_PASS' => 'PaSSWD')
+      env = {'LOGSTASH_KEYSTORE_PASS' => 'PaSSWD'}
+      if ENV['BUILD_JAVA_HOME']
+        env['JAVA_HOME'] = ENV['BUILD_JAVA_HOME']
+      end
+      keystore_list = @logstash.run_cmd(['bin/logstash-keystore', 'create'], true, env)
       expect(keystore_list.stderr_and_stdout).to_not match(/ERROR/)
       expect(keystore_list.stderr_and_stdout).to include('Created Logstash keystore')
     end
@@ -57,7 +61,11 @@ describe "CLI > logstash-keystore" do
     end
 
     it "works" do
-      keystore_list = @logstash.run_cmd(['bin/logstash-keystore', 'list'], true, 'LOGSTASH_KEYSTORE_PASS' => 'PaSSWD')
+      env = {'LOGSTASH_KEYSTORE_PASS' => 'PaSSWD'}
+      if ENV['BUILD_JAVA_HOME']
+        env['JAVA_HOME'] = ENV['BUILD_JAVA_HOME']
+      end
+      keystore_list = @logstash.run_cmd(['bin/logstash-keystore', 'list'], true, env)
       expect(keystore_list.stderr_and_stdout).to_not match(/ERROR/)
       expect(keystore_list.stderr_and_stdout).to include('foo') # contains foo: bar
     end


### PR DESCRIPTION
Clean backport of #12945 to `7.x` branch
Use the JVM specified in the CI matrix environment also to run spawned proccesses

logstash-keystore integration tests spawn a Java process, which by default uses the system JDK generally exposed with JAVA_HOME environment variable. It could be that this JDK is not the one selected with the build system variable BUILD_JAVA_HOME.
This commit uses the JDK defined in BUILD_JAVA_HOME if present.

(cherry picked from commit fa9adb4b864966ca1aa218e1bad9fa03a5047e32)
