### PR TITLE
[backport 7.x] Avoid hard-coded plugin alias definitions (#12841)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ logstash-core/versions-gem-copy.yml
 logstash-core-plugin-api/versions-gem-copy.yml
 config/logstash.keystore
 html_docs
+lib/pluginmanager/plugin_aliases.yml
+logstash-core/src/main/resources/org/logstash/plugins/plugin_aliases.yml
+spec/unit/plugin_manager/plugin_aliases.yml
+logstash-core/src/test/resources/org/logstash/plugins/plugin_aliases.yml 

--- a/build.gradle
+++ b/build.gradle
@@ -181,6 +181,73 @@ tasks.register("configureArtifactInfo") {
     project.ext.set("stackArtifactSuffix", qualifiedVersion)
 }
 
+abstract class SignAliasDefinitionsTask extends DefaultTask {
+
+    String registryPath = "logstash-core/src/main/resources/org/logstash/plugins/AliasRegistry.yml"
+    String hashedFileName = 'plugin_aliases_hashed.yml'
+
+    @InputFile
+    File aliasPath = project.file("${project.projectDir}/${registryPath}")
+
+    @OutputFile
+    File hashedFile = project.file("${project.buildDir}/${hashedFileName}")
+
+    @TaskAction
+    def sign() {
+        String aliases_defs = new File("${project.projectDir}/${registryPath}").text
+        String hash = aliases_defs.digest('SHA-256')
+        new File(project.buildDir, hashedFileName).withWriter('utf-8') { writer ->
+            writer.writeLine "#CHECKSUM: ${hash}"
+            writer.writeLine "# DON'T EDIT THIS FILE, PLEASE REFER TO ${registryPath}"
+            writer.write aliases_defs
+        }
+    }
+}
+
+tasks.register("markAliasDefinitions", SignAliasDefinitionsTask) {
+    description "Create an hashes aliases file from original aliases yml definition"
+}
+
+tasks.register("markTestAliasDefinitions", SignAliasDefinitionsTask) {
+    description "Create an hashes aliases file for testing aliases yml definition"
+    registryPath = 'logstash-core/src/test/resources/org/logstash/plugins/AliasRegistry.yml'
+    hashedFileName = 'plugin_aliases_hashed_test.yml'
+}
+
+tasks.register("copyPluginAlias", Copy) {
+    description "Copy the marked plugin_aliases.yml file to destination folders"
+    dependsOn "markAliasDefinitions"
+
+    inputs.file("${buildDir}/plugin_aliases_hashed.yml")
+    destinationDir = projectDir
+    from("${buildDir}/plugin_aliases_hashed.yml") {
+        into "lib/pluginmanager/"
+        rename "plugin_aliases_hashed.yml", "plugin_aliases.yml"
+    }
+    from("${buildDir}/plugin_aliases_hashed.yml") {
+        into "logstash-core/src/main/resources/org/logstash/plugins/"
+        rename "plugin_aliases_hashed.yml", "plugin_aliases.yml"
+    }
+}
+
+tasks.register("copyPluginTestAlias", Copy) {
+    description "Copy the marked test plugin_aliases.yml file to destination folders"
+    dependsOn "markTestAliasDefinitions"
+
+    inputs.file("${buildDir}/plugin_aliases_hashed_test.yml")
+    destinationDir = projectDir
+    from("${buildDir}/plugin_aliases_hashed_test.yml") {
+        into "spec/unit/plugin_manager/"
+        rename "plugin_aliases_hashed_test.yml", "plugin_aliases.yml"
+    }
+    from("${buildDir}/plugin_aliases_hashed_test.yml") {
+        into "logstash-core/src/test/resources/org/logstash/plugins/"
+        rename "plugin_aliases_hashed_test.yml", "plugin_aliases.yml"
+    }
+}
+
+processResources.dependsOn(copyPluginAlias)
+tasks.findByPath(':logstash-core:processTestResources').dependsOn(copyPluginTestAlias)
 
 
 // Tasks

--- a/lib/pluginmanager/util.rb
+++ b/lib/pluginmanager/util.rb
@@ -16,12 +16,38 @@
 # under the License.
 
 require "rubygems/package"
+require "yaml"
 require_relative "../bootstrap/patches/remote_fetcher"
 
 module LogStash::PluginManager
 
+  def self.load_aliases_definitions(path = File.expand_path('plugin_aliases.yml', __dir__))
+    content = IO.read(path)
+
+    #Verify header
+    header = content.lines[0]
+    if !header.start_with?('#CHECKSUM:')
+      raise ValidationError.new "Bad header format, expected '#CHECKSUM: ...' but found #{header}"
+    end
+    yaml_body = content.lines[2..-1].join
+    extracted_sha = header.delete_prefix('#CHECKSUM:').chomp.strip
+    sha256_hex = Digest::SHA256.hexdigest(yaml_body)
+    if sha256_hex != extracted_sha
+      raise ValidationError.new "Bad checksum value, expected #{sha256_hex} but found #{extracted_sha}"
+    end
+
+    yaml = YAML.safe_load(yaml_body) || {}
+    result = {}
+    yaml.each do |type, alias_defs|
+      alias_defs.each do |alias_name, aliased|
+        result["logstash-#{type}-#{alias_name}"] = "logstash-#{type}-#{aliased}"
+      end
+    end
+    result
+  end
+
   # Defines the plugin alias, must be kept in synch with Java class org.logstash.plugins.AliasRegistry
-  ALIASES = {"logstash-input-elastic_agent" => "logstash-input-beats"}
+  ALIASES = load_aliases_definitions()
 
   class ValidationError < StandardError; end
 

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -176,6 +176,7 @@ dependencies {
     api "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
     implementation 'org.codehaus.janino:janino:3.1.0'
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jacksonVersion}"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonVersion}"
     if (customJRubyDir == "") {
         api "org.jruby:jruby-complete:${jrubyVersion}"
     } else {

--- a/logstash-core/src/main/resources/org/logstash/plugins/AliasRegistry.yml
+++ b/logstash-core/src/main/resources/org/logstash/plugins/AliasRegistry.yml
@@ -1,0 +1,2 @@
+input:
+  elastic_agent: beats

--- a/logstash-core/src/test/java/org/logstash/plugins/AliasRegistryTest.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/AliasRegistryTest.java
@@ -1,0 +1,21 @@
+package org.logstash.plugins;
+
+import org.junit.Test;
+import org.logstash.plugins.PluginLookup.PluginType;
+
+import static org.junit.Assert.*;
+
+public class AliasRegistryTest {
+
+    @Test
+    public void testLoadAliasesFromYAML() {
+        final AliasRegistry sut = new AliasRegistry();
+
+        assertEquals("aliased_input1 should be the alias for beats input",
+                "beats", sut.originalFromAlias(PluginType.INPUT, "aliased_input1"));
+        assertEquals("aliased_input2 should be the alias for tcp input",
+                "tcp", sut.originalFromAlias(PluginType.INPUT, "aliased_input2"));
+        assertEquals("aliased_filter should be the alias for json filter",
+                "json", sut.originalFromAlias(PluginType.FILTER, "aliased_filter"));
+    }
+}

--- a/logstash-core/src/test/resources/org/logstash/plugins/AliasRegistry.yml
+++ b/logstash-core/src/test/resources/org/logstash/plugins/AliasRegistry.yml
@@ -1,0 +1,6 @@
+input:
+  aliased_input1: beats
+  aliased_input2: tcp
+
+filter:
+  aliased_filter: json

--- a/spec/unit/plugin_manager/util_spec.rb
+++ b/spec/unit/plugin_manager/util_spec.rb
@@ -84,4 +84,15 @@ describe LogStash::PluginManager do
       expect(Gem.sources.map { |source| source }).to eq(sources)
     end
   end
+
+  describe "process alias yaml definition" do
+    let(:path) { File.expand_path('plugin_aliases.yml', __dir__) }
+
+    it "should decode correctly" do
+      aliases = subject.load_aliases_definitions(path)
+      expect(aliases['logstash-input-aliased_input1']).to eq('logstash-input-beats')
+      expect(aliases['logstash-input-aliased_input2']).to eq('logstash-input-tcp')
+      expect(aliases['logstash-filter-aliased_filter']).to eq('logstash-filter-json')
+    end
+  end
 end


### PR DESCRIPTION
Clean backport of #12841 to branch `7.x`

(cherry picked from commit 446dc7d906d74b2aaa900d3772d9433cc65c8bc8)

----
 
Remove hard coded alias definitions in favor of yaml descriptor file.

Introduce a single point of aliases definition (logstash-core/src/main/resources/org/logstash/plugins/AliasRegistry.yml),  checksum and copy it around to be used by Logstash and by Logstash's plugin management tool.

The descriptor yml file contains a checksum to verify it's not changed accidentally in a deployment of Logstash, if the verification phase fail Logstash avoid to start and plugin management tool avoid to operate.
The signing and copying around is managed by a specific Gradle task invoked during the build.

Co-authored-by: Ry Biesemeyer <yaauie@users.noreply.github.com>

Fixes #12831

