### PR TITLE
Fix dependency on plugin_alias.yml during `rake artifacts:all`

### DIFF
--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -18,7 +18,6 @@
 # we need to call exit explicitly  in order to set the proper exit code, otherwise
 # most common CI systems can not know whats up with this tests.
 
-require "pluginmanager/util"
 require 'pathname'
 
 namespace "test" do
@@ -58,6 +57,10 @@ namespace "test" do
   desc "run all installed plugins specs"
   task "plugins"  => "bootstrap" do
     plugins_to_exclude = ENV.fetch("EXCLUDE_PLUGIN", "").split(",")
+    # the module LogStash::PluginManager requires the file `lib/pluginmanager/plugin_aliases.yml` is created
+    # that file is created during the bootstrap task
+    require "pluginmanager/util"
+
     # grab all spec files using the live plugins gem specs. this allows correctly also running the specs
     # of a local plugin dir added using the Gemfile :path option. before this, any local plugin spec would
     # not be run because they were not under the vendor/bundle/jruby/2.0/gems path

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -57,7 +57,7 @@ namespace "test" do
   desc "run all installed plugins specs"
   task "plugins"  => "bootstrap" do
     plugins_to_exclude = ENV.fetch("EXCLUDE_PLUGIN", "").split(",")
-    # the module LogStash::PluginManager requires the file `lib/pluginmanager/plugin_aliases.yml` is created
+    # the module LogStash::PluginManager requires the file `lib/pluginmanager/plugin_aliases.yml`,
     # that file is created during the bootstrap task
     require "pluginmanager/util"
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
The module LogStash::PluginManager requires the file `lib/pluginmanager/plugin_aliases.yml` is created,
which happens during the Gradle's 'copyPluginAlias' executed as part of Rake's 'bootstrap'.

This PR moves the require of the module close to its usage inside `plugins` tasks which already depends on `bootstrap` task.


## Why is it important/What is the impact to the user?
<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

Before this the `rake artifacts:all` failed

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] run `rake artifacts:all` locally after set JRuby `9.2.x` and JDK to 1.8.x and after remove of all `plugin_aliases.yml` files

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Same as Author's checklist

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->
```
andrea@kalispera logstash_andsel (master) $ rake artifact:all
rake aborted!
Errno::ENOENT: No such file or directory - /home/andrea/workspace/logstash_andsel/lib/pluginmanager/plugin_aliases.yml
/home/andrea/workspace/logstash_andsel/lib/pluginmanager/util.rb:25:in `load_aliases_definitions'
/home/andrea/workspace/logstash_andsel/lib/pluginmanager/util.rb:50:in `<module:PluginManager>'
/home/andrea/workspace/logstash_andsel/lib/pluginmanager/util.rb:22:in `<main>'
/home/andrea/workspace/logstash_andsel/rakelib/test.rake:21:in `<main>'
/home/andrea/.rvm/gems/jruby-9.2.13.0/gems/rake-13.0.3/exe/rake:27:in `<main>'
(See full trace by running task with --trace)
```

