### PR TITLE
Fix/log4j routing to avoid create spurious file

### DIFF
--- a/logstash-core/src/main/java/org/logstash/log/LogstashConfigurationFactory.java
+++ b/logstash-core/src/main/java/org/logstash/log/LogstashConfigurationFactory.java
@@ -21,17 +21,23 @@
 package org.logstash.log;
 
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationException;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
 import org.apache.logging.log4j.core.config.Order;
+import org.apache.logging.log4j.core.config.builder.api.Component;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.properties.PropertiesConfiguration;
 import org.apache.logging.log4j.core.config.properties.PropertiesConfigurationBuilder;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 /**
  * Logstash configuration factory customization used to remove the routing appender from log4j configuration
@@ -50,25 +56,90 @@ public class LogstashConfigurationFactory extends ConfigurationFactory {
     }
 
     @Override
-    public PropertiesConfiguration getConfiguration(final LoggerContext loggerContext, final ConfigurationSource source) {
+    public Configuration getConfiguration(final LoggerContext loggerContext, final ConfigurationSource source) {
         final Properties properties = new Properties();
         try (final InputStream configStream = source.getInputStream()) {
             properties.load(configStream);
         } catch (final IOException ioe) {
             throw new ConfigurationException("Unable to load " + source.toString(), ioe);
         }
+
+        if (System.getProperty(PIPELINE_SEPARATE_LOGS, "false").equals("false")) {
+            final String routingAppenderPrefix = findAppenderPrefixWithName(properties, PIPELINE_ROUTING_APPENDER_NAME);
+            if (!routingAppenderPrefix.isEmpty()) {
+                removeAllPropertiesWithPrefix(properties, routingAppenderPrefix);
+            }
+        }
+
         PropertiesConfiguration propertiesConfiguration = new PropertiesConfigurationBuilder()
                 .setConfigurationSource(source)
                 .setRootProperties(properties)
                 .setLoggerContext(loggerContext)
                 .build();
 
-        if (System.getProperty(PIPELINE_SEPARATE_LOGS, "false").equals("false")) {
-            // force init to avoid overwrite of appenders section
-            propertiesConfiguration.initialize();
-            propertiesConfiguration.removeAppender(PIPELINE_ROUTING_APPENDER_NAME);
-        }
+//        if (System.getProperty(PIPELINE_SEPARATE_LOGS, "false").equals("false")) {
+//            // force init to avoid overwrite of appenders section
+//            propertiesConfiguration.initialize();
+//            propertiesConfiguration.removeAppender(PIPELINE_ROUTING_APPENDER_NAME);
+//        }
 
         return propertiesConfiguration;
+
+//        final Component root = new Component();
+//        final List<Component> components = root.getComponents();
+//
+//        components.add(new Component("Properties"));
+//        components.add(new Component("Scripts"));
+//        components.add(new Component("CustomLevels"));
+//        components.add(new Component("Filters"));
+//        components.add(new Component("Appenders"));
+//        components.add(new Component("Loggers"));
+//
+//        return new LogstashPropertiesConfiguration(loggerContext, source,  root);
+    }
+
+    private void removeAllPropertiesWithPrefix(Properties properties, String prefix) {
+        Set<String> keysToRemove = new HashSet<>(12);
+        for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+            if (((String) entry.getKey()).startsWith(prefix)) {
+                keysToRemove.add((String) entry.getKey());
+            }
+        }
+
+        //remove the collected keys
+        for (String keyToDelete : keysToRemove) {
+            properties.remove(keyToDelete);
+        }
+    }
+
+    private String findAppenderPrefixWithName(Properties properties, String appenderName) {
+        if (!properties.containsValue(appenderName)) {
+            return "";
+        }
+        for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+            if (appenderName.equals(entry.getValue())) {
+                final String key = (String) entry.getKey();
+                if (key.endsWith(".name")) {
+                    return key.substring(0 ,key.lastIndexOf(".name"));
+                }
+            }
+        }
+        return "";
+    }
+
+    public class LogstashPropertiesConfiguration extends PropertiesConfiguration {
+
+        public LogstashPropertiesConfiguration(LoggerContext loggerContext, ConfigurationSource source, Component root) {
+            super(loggerContext, source, root);
+        }
+
+        @Override
+        protected void doConfigure() {
+            super.doConfigure();
+
+            if (System.getProperty(PIPELINE_SEPARATE_LOGS, "false").equals("false")) {
+                removeAppender(PIPELINE_ROUTING_APPENDER_NAME);
+            }
+        }
     }
 }

--- a/logstash-core/src/main/java/org/logstash/log/LogstashConfigurationFactory.java
+++ b/logstash-core/src/main/java/org/logstash/log/LogstashConfigurationFactory.java
@@ -21,23 +21,17 @@
 package org.logstash.log;
 
 import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationException;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
 import org.apache.logging.log4j.core.config.Order;
-import org.apache.logging.log4j.core.config.builder.api.Component;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.properties.PropertiesConfiguration;
 import org.apache.logging.log4j.core.config.properties.PropertiesConfigurationBuilder;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 
 /**
  * Logstash configuration factory customization used to remove the routing appender from log4j configuration
@@ -56,90 +50,25 @@ public class LogstashConfigurationFactory extends ConfigurationFactory {
     }
 
     @Override
-    public Configuration getConfiguration(final LoggerContext loggerContext, final ConfigurationSource source) {
+    public PropertiesConfiguration getConfiguration(final LoggerContext loggerContext, final ConfigurationSource source) {
         final Properties properties = new Properties();
         try (final InputStream configStream = source.getInputStream()) {
             properties.load(configStream);
         } catch (final IOException ioe) {
             throw new ConfigurationException("Unable to load " + source.toString(), ioe);
         }
-
-        if (System.getProperty(PIPELINE_SEPARATE_LOGS, "false").equals("false")) {
-            final String routingAppenderPrefix = findAppenderPrefixWithName(properties, PIPELINE_ROUTING_APPENDER_NAME);
-            if (!routingAppenderPrefix.isEmpty()) {
-                removeAllPropertiesWithPrefix(properties, routingAppenderPrefix);
-            }
-        }
-
         PropertiesConfiguration propertiesConfiguration = new PropertiesConfigurationBuilder()
                 .setConfigurationSource(source)
                 .setRootProperties(properties)
                 .setLoggerContext(loggerContext)
                 .build();
 
-//        if (System.getProperty(PIPELINE_SEPARATE_LOGS, "false").equals("false")) {
-//            // force init to avoid overwrite of appenders section
-//            propertiesConfiguration.initialize();
-//            propertiesConfiguration.removeAppender(PIPELINE_ROUTING_APPENDER_NAME);
-//        }
+        if (System.getProperty(PIPELINE_SEPARATE_LOGS, "false").equals("false")) {
+            // force init to avoid overwrite of appenders section
+            propertiesConfiguration.initialize();
+            propertiesConfiguration.removeAppender(PIPELINE_ROUTING_APPENDER_NAME);
+        }
 
         return propertiesConfiguration;
-
-//        final Component root = new Component();
-//        final List<Component> components = root.getComponents();
-//
-//        components.add(new Component("Properties"));
-//        components.add(new Component("Scripts"));
-//        components.add(new Component("CustomLevels"));
-//        components.add(new Component("Filters"));
-//        components.add(new Component("Appenders"));
-//        components.add(new Component("Loggers"));
-//
-//        return new LogstashPropertiesConfiguration(loggerContext, source,  root);
-    }
-
-    private void removeAllPropertiesWithPrefix(Properties properties, String prefix) {
-        Set<String> keysToRemove = new HashSet<>(12);
-        for (Map.Entry<Object, Object> entry : properties.entrySet()) {
-            if (((String) entry.getKey()).startsWith(prefix)) {
-                keysToRemove.add((String) entry.getKey());
-            }
-        }
-
-        //remove the collected keys
-        for (String keyToDelete : keysToRemove) {
-            properties.remove(keyToDelete);
-        }
-    }
-
-    private String findAppenderPrefixWithName(Properties properties, String appenderName) {
-        if (!properties.containsValue(appenderName)) {
-            return "";
-        }
-        for (Map.Entry<Object, Object> entry : properties.entrySet()) {
-            if (appenderName.equals(entry.getValue())) {
-                final String key = (String) entry.getKey();
-                if (key.endsWith(".name")) {
-                    return key.substring(0 ,key.lastIndexOf(".name"));
-                }
-            }
-        }
-        return "";
-    }
-
-    public class LogstashPropertiesConfiguration extends PropertiesConfiguration {
-
-        public LogstashPropertiesConfiguration(LoggerContext loggerContext, ConfigurationSource source, Component root) {
-            super(loggerContext, source, root);
-        }
-
-        @Override
-        protected void doConfigure() {
-            super.doConfigure();
-
-            if (System.getProperty(PIPELINE_SEPARATE_LOGS, "false").equals("false")) {
-                removeAppender(PIPELINE_ROUTING_APPENDER_NAME);
-            }
-        }
     }
 }

--- a/logstash-core/src/main/java/org/logstash/log/PipelineRoutingAppender.java
+++ b/logstash-core/src/main/java/org/logstash/log/PipelineRoutingAppender.java
@@ -109,6 +109,9 @@ public class PipelineRoutingAppender extends AbstractAppender {
         String key = event.getContextData().getValue("pipeline.id");
         if (key == null) {
             LOGGER.debug("Unable to find the pipeline.id in event's context data in routing appender, skip it");
+            // this prevent to create an appender when log events are not fish-tagged with pipeline.id,
+            // avoid to create log file like "pipeline_${ctx:pipeline.id}.log" which contains duplicated
+            // logs from the logstash-* files
             return null;
         }
 

--- a/logstash-core/src/main/java/org/logstash/log/PipelineRoutingAppender.java
+++ b/logstash-core/src/main/java/org/logstash/log/PipelineRoutingAppender.java
@@ -2,6 +2,7 @@ package org.logstash.log;
 
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Core;
+import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.config.AppenderControl;
@@ -107,8 +108,8 @@ public class PipelineRoutingAppender extends AbstractAppender {
     private AppenderControl getControl(LogEvent event) {
         String key = event.getContextData().getValue("pipeline.id");
         if (key == null) {
-            error("Unable to find the pipeline.id in event's context data");
-            key = "sink";
+            LOGGER.debug("Unable to find the pipeline.id in event's context data in routing appender, skip it");
+            return null;
         }
 
         AppenderControl appenderControl = createdAppenders.get(key);

--- a/logstash-core/src/main/java/org/logstash/log/PipelineRoutingFilter.java
+++ b/logstash-core/src/main/java/org/logstash/log/PipelineRoutingFilter.java
@@ -13,7 +13,7 @@ import org.apache.logging.log4j.core.filter.AbstractFilter;
 @Plugin(name = "PipelineRoutingFilter", category = Core.CATEGORY_NAME, elementType = Appender.ELEMENT_TYPE, printObject = true)
 public final class PipelineRoutingFilter extends AbstractFilter {
 
-    private boolean isSeparateLogs;
+    private final boolean isSeparateLogs;
 
     /**
      * Factory method to instantiate the filter

--- a/qa/integration/build.gradle
+++ b/qa/integration/build.gradle
@@ -51,6 +51,8 @@ tasks.register("copyProductionLog4jConfiguration", Copy) {
                     'appender.rolling.policies.size.size = 1KB')
             .replace('appender.rolling.filePattern = ${sys:ls.logs}/logstash-plain-%d{yyyy-MM-dd}-%i.log.gz',
                     'appender.rolling.filePattern = ${sys:ls.logs}/logstash-plain-%d{yyyy-MM-dd}.log')
+            .replace('appender.routing.pipeline.policy.size = 100MB',
+                    'appender.routing.pipeline.policy.size = 1KB')
   }
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->


## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
This PR avoid to create pipeline log appender when the log event doesn't contain the `pipeline.id`


## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
Avoid that the user see files name like `'pipeline_${ctx:pipeline.id}.log'` which are empty


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

- in `config/log4j2.properties` find the line https://github.com/elastic/logstash/blob/cafbf0315876d9cf5b796a88a50600700b107ae1/config/log4j2.properties#L57
- change the size from `100MB` to `1KB`
- enable `pipeline.separate_logs` in `config/logstash.yml`
- run Logstash with following pipeline.conf `bin/logstash -f pipeline.conf --debug`
- check in `logs/` directory the not existence of  a file named `pipeline_${ctx:pipeline.id}.log`. On `master` it's present before this PR, in the branch of this PR that file is not created.

**pipeline.conf**
```
input {
  java_generator {
    lines => [
      "line 1",
      "line 2",
      "line 3"
    ]
    eps => 1
  }
}

output {
  stdout {
    codec => rubydebug
  }

```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
