### PR TITLE
Backport PR #12791 to 7.x: Deps: update JRuby to 9.2.18.0

### DIFF
--- a/lib/bootstrap/bundler.rb
+++ b/lib/bootstrap/bundler.rb
@@ -16,6 +16,7 @@
 # under the License.
 
 require "fileutils"
+require "stringio"
 
 module LogStash
   module Bundler

--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -25,7 +25,7 @@ buildscript {
     dependencies {
         classpath 'org.yaml:snakeyaml:1.23'
         classpath "de.undercouch:gradle-download-task:4.0.4"
-        classpath "org.jruby:jruby-complete:9.2.16.0"
+        classpath "org.jruby:jruby-complete:9.2.18.0"
     }
 }
 

--- a/versions.yml
+++ b/versions.yml
@@ -13,8 +13,8 @@ bundled_jdk:
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time
 jruby:
-  version: 9.2.16.0
-  sha1: c04d45392da356405becb238d0d48cf32357ddfd
+  version: 9.2.18.0
+  sha1: 8c4ebea6e4231807775733f55c6ae873e0ca2a2e
 
 # jruby-runtime-override, if specified, will override the jruby version installed in vendor/jruby for logstash runtime only,
 # not for the compile-time jars


### PR DESCRIPTION
Backport PR #12791 to 7.x branch. Original message: 

Version bump of JRuby.

## Release notes

Includes upstream fixes for ARM64 support.

## What does this PR do?

Dependency update, release notes (since 9.2.16.0): 
https://www.jruby.org/2021/03/29/jruby-9-2-17-0.html
https://www.jruby.org/2021/06/08/jruby-9-2-18-0.html

JRuby 9.2.18.0 include JNR fixes for ARM64: https://github.com/jnr/jnr-ffi/issues/240 https://github.com/jnr/jnr-posix/pull/165 

## Checklist

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] a potential [blocker](https://github.com/jruby/jruby/pull/6638) due LS' reuse of `vendor/jruby/bin/jruby` e.g. from `bin/logstash-plugin`
  (present in 9.2.17.0 but resolved in 9.2.18.0)
- [x] ~~[another](https://github.com/jruby/jruby/issues/6640) suspicious issue with `String#split`~~

## Related issues

https://github.com/elastic/logstash/issues/12077 (unfortunately the auto-load fixes were not backported to RGs 3.1)

