### PR TITLE
Test: handle a RGs warning from packing output

### DIFF
--- a/qa/integration/specs/cli/prepare_offline_pack_spec.rb
+++ b/qa/integration/specs/cli/prepare_offline_pack_spec.rb
@@ -86,7 +86,8 @@ describe "CLI > logstash-plugin prepare-offline-pack" do
       filters = @logstash_plugin.list(plugins_to_pack.first)
                                 .stderr_and_stdout.split("\n")
                                 .delete_if do |line|
-                                  line =~ /cext|├──|└──|logstash-integration|JAVA_OPT|fatal|^WARNING|^warning: ignoring JAVA_TOOL_OPTIONS|^OpenJDK 64-Bit Server VM warning|Option \w+ was deprecated|Using JAVA_HOME defined java|Using system java: |\[\[: not found/
+                                  line =~ /cext|├──|└──|logstash-integration|JAVA_OPT|fatal|^WARNING|^warning: ignoring JAVA_TOOL_OPTIONS|^OpenJDK 64-Bit Server VM warning|Option \w+ was deprecated|Using JAVA_HOME defined java|Using system java: |\[\[: not found/ ||
+                                  line =~ /warning: constant Gem::ConfigMap is deprecated/ # can be removed after upgrading Bundler from version 1.17
                                 end
 
       expect(unpacked.plugins.collect(&:name)).to include(*filters)


### PR DESCRIPTION
in preparation for JRuby 9.2.18.0 which includes a RGs update while 7.x is still using Bundler 1.17 (compared to master)

merging this would allow us for a clean backport in https://github.com/elastic/logstash/pull/12971
