### PR TITLE
Doc: Update monitoring to use agent

### DIFF
--- a/docs/static/monitoring/monitoring-agent.asciidoc
+++ b/docs/static/monitoring/monitoring-agent.asciidoc
@@ -1,28 +1,27 @@
 [role="xpack"]
-[[monitoring-with-metricbeat]]
-=== Collect {ls} monitoring data with {metricbeat}
+[[monitoring-with-agent]]
+=== Collect {ls} monitoring data with {agent}
 [subs="attributes"]
 ++++
-<titleabbrev>{metricbeat} collection</titleabbrev>
+<titleabbrev>{agent} collection</titleabbrev>
 ++++
 
-You can use {metricbeat} to collect data about {ls} and ship it to the
-monitoring cluster. The benefit of Metricbeat collection is that the monitoring
+You can use {agent} to collect data about {ls} and ship it to the
+monitoring cluster. The benefit of {agent} collection is that the monitoring
 agent remains active even if the {ls} instance does not. 
 
 To collect and ship monitoring data:
 
 . <<disable-default,Disable default collection of monitoring metrics>>
 . <<define-cluster__uuid,Specify the target `cluster_uuid` (optional)>>
-. <<configure-metricbeat,Install and configure {metricbeat} to collect monitoring data>>
+. <<configure-agent,Install and configure {agent} to collect monitoring data>>
 
 [float]
 [[disable-default]]
 ==== Disable default collection of {ls} monitoring metrics
 
 --
-The `monitoring` setting is in the {ls} configuration file (logstash.yml), but is
-commented out: 
+The `monitoring` setting is in the {ls} configuration file (logstash.yml), but is commented out: 
 
 [source,yaml]
 ----------------------------------
@@ -45,16 +44,15 @@ monitoring.cluster_uuid: PRODUCTION_ES_CLUSTER_UUID
 ----------------------------------
 
 [float]
-[[configure-metricbeat]]
-==== Install and configure {metricbeat}
+[[configure-agent]]
+==== Install and configure {agent}
 
-. {metricbeat-ref}/metricbeat-installation-configuration.html[Install {metricbeat}] on the
-same server as {ls}. 
+. {fleet-guide}/elastic-agent-installation.html[Install {agent}] on the same server as {ls}. 
 
-. Enable the `logstash-xpack` module in {metricbeat}. +
+. EVALUATE STEP: Enable the `logstash-xpack` module in {agent}. +
 +
 --
-To enable the default configuration in the {metricbeat} `modules.d` directory, 
+To enable the default configuration in the {agent} `modules.d` directory, 
 run: 
 
 *deb, rpm, or brew:* +
@@ -83,7 +81,7 @@ For more information, see
 {metricbeat-ref}/metricbeat-module-beat.html[beat module]. 
 --
 
-. Configure the `logstash-xpack` module in {metricbeat}. +
+. EVALUATE STEP: Configure the `logstash-xpack` module in {agent}. +
 +
 --
 The `modules.d/logstash-xpack.yml` file contains these settings:
@@ -114,9 +112,8 @@ To monitor multiple {ls} instances, specify a list of hosts, for example:
 hosts: ["http://localhost:9601","http://localhost:9602","http://localhost:9603"]
 ----------------------------------
 
-
 *Elastic security.* If the Elastic {security-features} are enabled, provide a user 
-ID and password so that {metricbeat} can collect metrics successfully: 
+ID and password so that {agent} can collect metrics successfully: 
 
 .. Create a user on the production cluster that has the 
 `remote_monitoring_collector` {ref}/built-in-roles.html[built-in role]. 
@@ -125,7 +122,7 @@ ID and password so that {metricbeat} can collect metrics successfully:
 file (`logstash-xpack.yml`).
 --
 
-. Optional: Disable the system module in the {metricbeat}.
+. EVALUATE STEP: Optional: Disable the system module in the {agent}.
 +
 --
 By default, the {metricbeat-ref}/metricbeat-module-system.html[system module] is
@@ -148,7 +145,7 @@ monitoring cluster prevents production cluster outages from impacting your
 ability to access your monitoring data. It also prevents monitoring activities 
 from impacting the performance of your production cluster.
 
-For example, specify the {es} output information in the {metricbeat} 
+For example, specify the {es} output information in the {agent} 
 configuration file (`metricbeat.yml`):
 
 [source,yaml]
@@ -173,7 +170,7 @@ IMPORTANT: The {es} {monitor-features} use ingest pipelines, therefore the
 cluster that stores the monitoring data must have at least one ingest node.
 
 If the {es} {security-features} are enabled on the monitoring cluster, you 
-must provide a valid user ID and password so that {metricbeat} can send metrics 
+must provide a valid user ID and password so that {agent} can send metrics 
 successfully: 
 
 .. Create a user on the monitoring cluster that has the 
@@ -186,14 +183,17 @@ requires additional privileges to create and read indices. For more
 information, see `<<feature-roles>>`.
 
 .. Add the `username` and `password` settings to the {es} output information in 
-the {metricbeat} configuration file.
+the {agent} configuration file.
 
-For more information about these configuration options, see 
-{metricbeat-ref}/elasticsearch-output.html[Configure the {es} output].
+//ToDo: Validate that this is the best link and link text
+For more information about these configuration options, see {fleet-guide}
+/elastic-agent-configuration.html[Configure the {agent} output].
 --
 
-. {metricbeat-ref}/metricbeat-starting.html[Start {metricbeat}] to begin
-collecting monitoring data. 
+. To begin collecting monitoring data, start {agent} using the approach you prefer:
+** {fleet-guide}/run-elastic-agent-standalone.html[Run {agent} standalone (advanced users)]
+** {fleet-guide}/running-on-kubernetes.html[Run {agent} on Kubernetes]
+** {fleet-guide}/running-on-kubernetes-standalone.html[Run {agent} standalone on Kubernete]
 
 . {kibana-ref}/monitoring-data.html[View the monitoring data in {kib}]. 
 

--- a/docs/static/monitoring/monitoring-output-legacy.asciidoc
+++ b/docs/static/monitoring/monitoring-output-legacy.asciidoc
@@ -33,8 +33,7 @@ cluster by using the `.monitoring-logstash` template, which is managed by the
 {ref}/es-monitoring-exporters.html[exporters] within {es}. 
 
 If you are working with a cluster that has {security} enabled, extra steps are 
-necessary to properly configure Logstash. For more information, see 
-<<configuring-logstash>>. 
+necessary to properly configure Logstash.. 
 
 IMPORTANT: When discussing security relative to the `elasticsearch` output, it
 is critical to remember that all users are managed on the production cluster, 

--- a/docs/static/monitoring/monitoring-overview.asciidoc
+++ b/docs/static/monitoring/monitoring-overview.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[configuring-logstash]]
+[[stack-monitoring-logstash]]
 == Monitoring {ls}
 
 Use the {stack} {monitor-features} to gain insight into the health of
@@ -16,15 +16,15 @@ For an introduction to monitoring your Elastic stack, see
 Make sure monitoring is enabled on your {es} cluster. Then configure *one* of
 these methods to collect {ls} metrics:
 
-* <<monitoring-with-metricbeat, {metricbeat} collection>>. Metricbeat collects
+* <<monitoring-with-agent,{agent} collection>>. {agent} collects
 monitoring data from your {ls} instance and sends it directly to your monitoring
-cluster. The benefit of Metricbeat collection is that the monitoring
+cluster. The benefit of {agent} collection is that the monitoring
 agent remains active even if the {ls} instance does not.
 
 * <<monitoring-internal-collection-legacy,Legacy collection (deprecated)>>. 
 Legacy collectors send monitoring data to your production cluster.
 
-include::monitoring-mb.asciidoc[]
+include::monitoring-agent.asciidoc[]
 include::monitoring-internal-legacy.asciidoc[]
 include::monitoring-ui.asciidoc[]
 include::pipeline-viewer.asciidoc[]

--- a/docs/static/monitoring/monitoring-ui.asciidoc
+++ b/docs/static/monitoring/monitoring-ui.asciidoc
@@ -18,7 +18,7 @@ is written to the <<logstash-settings-file,`path.data`>> directory when the node
 starts.
 
 Before you can use the monitoring UI,
-<<configuring-logstash, configure Logstash monitoring>>.
+<<monitoring-logstash, configure Logstash monitoring>>.
 
 For information about using the Monitoring UI, see
 {kibana-ref}/xpack-monitoring.html[{monitoring} in {kib}].

--- a/docs/static/monitoring/monitoring.asciidoc
+++ b/docs/static/monitoring/monitoring.asciidoc
@@ -16,7 +16,7 @@ You can use <<monitoring,monitoring APIs>> provided by Logstash
 to retrieve these metrics. These APIs are available by default without
 requiring any extra configuration.
 
-Alternatively, you can <<configuring-logstash,configure {monitoring}>> to send
+Alternatively, you can <<monitoring-logstash,configure {monitoring}>> to send
 data to a monitoring cluster.
 
 NOTE: Monitoring is a feature under the Basic License and is therefore

--- a/docs/static/redirects.asciidoc
+++ b/docs/static/redirects.asciidoc
@@ -27,3 +27,15 @@ If your use case involves reading files that contain multiline entries,
 {filebeat-ref}[{filebeat}] might be a better option.
 {filebeat} offers {filebeat-ref}/filebeat-modules.html[modules] for processing logs
 from many known apps, such as nginx or apache.
+
+
+[role="exclude",id="configuring-logstash"]
+== Monitoring Logstash
+
+See <<monitoring-logstash,Monitoring Logstash>>.
+
+
+[role="exclude",id="monitoring-with-metricbeat"]
+=== Collect {ls} monitoring data with {metricbeat}
+
+<<monitoring-with-agent,Elastic Agent>> is the recommended approach for monitoring Logstash. 


### PR DESCRIPTION
**PREVIEW:** https://logstash_12970.docs-preview.app.elstc.co/guide/en/logstash/master/stack-monitoring-logstash.html

## Release notes
[Doc] Replace metricbeat with Elastic Agent as preferred approach for Logstash monitoring

## What does this PR do?
Replaces recommendation for metricbeat with Elastic Agent for Logstash monitoring 

## To Do
- [x] Set up initial file structure, linking, renaming
- [x] Set up redirects to monitoring topic
- [ ] See if we can remove shared regions
- [ ] Switch out content from mb to agent (WIP)
- [ ] Evaluate steps and add, remove, adjust as needed (WIP)
- [ ] Update instructions with new links

Replaces #12970