### PR TITLE
Deps: update JRuby to 9.2.19.0

### DIFF
--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -25,7 +25,7 @@ buildscript {
     dependencies {
         classpath 'org.yaml:snakeyaml:1.23'
         classpath "de.undercouch:gradle-download-task:4.0.4"
-        classpath "org.jruby:jruby-complete:9.2.18.0"
+        classpath "org.jruby:jruby-complete:9.2.19.0"
     }
 }
 

--- a/versions.yml
+++ b/versions.yml
@@ -13,8 +13,8 @@ bundled_jdk:
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time
 jruby:
-  version: 9.2.18.0
-  sha1: 8c4ebea6e4231807775733f55c6ae873e0ca2a2e
+  version: 9.2.19.0
+  sha1: e61ac187d5e312a198a0b1767eb8c4f36c750749
 
 # jruby-runtime-override, if specified, will override the jruby version installed in vendor/jruby for logstash runtime only,
 # not for the compile-time jars


### PR DESCRIPTION
Version bump of JRuby (following up on https://github.com/elastic/logstash/pull/12791)

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->


## What does this PR do?

Dependency update, release notes (since [9.2.18.0](https://github.com/elastic/logstash/pull/12791)):
https://www.jruby.org/2021/06/15/jruby-9-2-19-0.html

## Checklist

<!--
## Author's Checklist

- [ ]
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->