### PR TITLE
[7.x] Deps: update JRuby to 9.2.19.0 (#12989)

### DIFF
--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -25,7 +25,7 @@ buildscript {
     dependencies {
         classpath 'org.yaml:snakeyaml:1.23'
         classpath "de.undercouch:gradle-download-task:4.0.4"
-        classpath "org.jruby:jruby-complete:9.2.18.0"
+        classpath "org.jruby:jruby-complete:9.2.19.0"
     }
 }
 

--- a/versions.yml
+++ b/versions.yml
@@ -13,8 +13,8 @@ bundled_jdk:
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time
 jruby:
-  version: 9.2.18.0
-  sha1: 8c4ebea6e4231807775733f55c6ae873e0ca2a2e
+  version: 9.2.19.0
+  sha1: e61ac187d5e312a198a0b1767eb8c4f36c750749
 
 # jruby-runtime-override, if specified, will override the jruby version installed in vendor/jruby for logstash runtime only,
 # not for the compile-time jars


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Deps: update JRuby to 9.2.19.0 (#12989)