### PR TITLE
Fix Reflections stack traces when process yml files in classpath and …

### DIFF
--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
@@ -20,8 +20,10 @@
 
 package org.logstash.plugins.discovery;
 
+import com.google.common.base.Predicate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.logstash.plugins.AliasRegistry;
 import co.elastic.logstash.api.Codec;
 import co.elastic.logstash.api.Configuration;
@@ -32,6 +34,8 @@ import co.elastic.logstash.api.LogstashPlugin;
 import co.elastic.logstash.api.Output;
 import org.logstash.plugins.PluginLookup.PluginType;
 import org.reflections.Reflections;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
@@ -80,7 +84,12 @@ public final class PluginRegistry {
     private void discoverPlugins() {
         // the constructor of Reflection must be called only by one thread, else there is a
         // risk that the first thread that completes close the Zip files for the others.
-        Reflections reflections = new Reflections("org.logstash.plugins");
+        // filter from processing all resources present in package classpath that are not classes.
+        final ConfigurationBuilder configurationBuilder = new ConfigurationBuilder()
+                .setUrls(ClasspathHelper.forPackage("org.logstash.plugins"))
+                .filterInputsBy(input -> input.endsWith(".class"));
+        Reflections reflections = new Reflections(configurationBuilder);
+
         Set<Class<?>> annotated = reflections.getTypesAnnotatedWith(LogstashPlugin.class);
         for (final Class<?> cls : annotated) {
             for (final Annotation annotation : cls.getAnnotations()) {

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
@@ -84,7 +84,7 @@ public final class PluginRegistry {
     private void discoverPlugins() {
         // the constructor of Reflection must be called only by one thread, else there is a
         // risk that the first thread that completes close the Zip files for the others.
-        // filter from processing all resources present in package classpath that are not classes.
+        // scan all .class present in package classpath
         final ConfigurationBuilder configurationBuilder = new ConfigurationBuilder()
                 .setUrls(ClasspathHelper.forPackage("org.logstash.plugins"))
                 .filterInputsBy(input -> input.endsWith(".class"));


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

Adds a filter to Reflections library when it scan `org.logstash.plugins` to include only `.class` files and avoid to load and process AliasRegistry.yml and plugin_aliases.yml. Fixes #12992 

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
Avoid to see stacktrace error when Logstash is run in debug

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] try a local run and see that not stacktraces heppears

## How to test this PR locally

Run Logstash with `bin/logstash -e "input {stdin{}} output{stdout{ codec => rubydebug}}" --log.level debug` and check no stacktraces are present in console.

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Fixes #12992 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

```
[2021-06-16T09:54:30,572][DEBUG][org.reflections.Reflections] could not scan file org/logstash/plugins/plugin_aliases.yml in url jar:file:/home/andrea/workspace/logstash_andsel/logstash-core/lib/jars/logstash-core.jar!/ with scanner SubTypesScanner
org.reflections.ReflectionsException: could not create class object from file org/logstash/plugins/plugin_aliases.yml
	at org.reflections.scanners.AbstractScanner.scan(AbstractScanner.java:32) ~[reflections-0.9.11.jar:?]
	at org.reflections.Reflections.scan(Reflections.java:253) [reflections-0.9.11.jar:?]
	at org.reflections.Reflections.scan(Reflections.java:202) [reflections-0.9.11.jar:?]
	at org.reflections.Reflections.<init>(Reflections.java:123) [reflections-0.9.11.jar:?]
	at org.reflections.Reflections.<init>(Reflections.java:168) [reflections-0.9.11.jar:?]
	at org.reflections.Reflections.<init>(Reflections.java:141) [reflections-0.9.11.jar:?]
	at org.logstash.plugins.discovery.PluginRegistry.discoverPlugins(PluginRegistry.java:83) [logstash-core.jar:?]
	at org.logstash.plugins.discovery.PluginRegistry.<init>(PluginRegistry.java:65) [logstash-core.jar:?]
	at org.logstash.plugins.discovery.PluginRegistry.getInstance(PluginRegistry.java:72) [logstash-core.jar:?]
	at org.logstash.plugins.factory.PluginFactoryExt.<init>(PluginFactoryExt.java:86) [logstash-core.jar:?]
	at org.logstash.execution.JavaBasePipelineExt.initialize(JavaBasePipelineExt.java:73) [logstash-core.jar:?]
	at org.logstash.execution.JavaBasePipelineExt$INVOKER$i$1$0$initialize.call(JavaBasePipelineExt$INVOKER$i$1$0$initialize.gen) [jruby-complete-9.2.19.0.jar:?]
	at org.jruby.internal.runtime.methods.JavaMethod$JavaMethodN.call(JavaMethod.java:837) [jruby-complete-9.2.19.0.jar:?]
	at org.jruby.ir.runtime.IRRuntimeHelpers.instanceSuper(IRRuntimeHelpers.java:1169) [jruby-complete-9.2.19.0.jar:?]
	at org.jruby.ir.runtime.IRRuntimeHelpers.instanceSuperSplatArgs(IRRuntimeHelpers.java:1156) [jruby-complete-9.2.19.0.jar:?]
	at org.jruby.ir.targets.InstanceSuperInvokeSite.invoke(InstanceSuperInvokeSite.java:39) [jruby-complete-9.2.19.0.jar:?]
	at home.andrea.workspace.logstash_andsel.logstash_minus_core.lib.logstash.java_pipeline.RUBY$method$initialize$0(/home/andrea/workspace/logstash_andsel/logstash-core/lib/logstash/java_pipeline.rb:47) [jruby-complete-9.2.19.0.jar:?]
Caused by: org.reflections.ReflectionsException: could not create class file from plugin_aliases.yml
	at org.reflections.adapters.JavassistAdapter.getOfCreateClassObject(JavassistAdapter.java:102) ~[reflections-0.9.11.jar:?]
	at org.reflections.adapters.JavassistAdapter.getOfCreateClassObject(JavassistAdapter.java:24) ~[reflections-0.9.11.jar:?]
	at org.reflections.scanners.AbstractScanner.scan(AbstractScanner.java:30) ~[reflections-0.9.11.jar:?]
	... 36 more
Caused by: java.io.IOException: bad magic number: 23434845
	at javassist.bytecode.ClassFile.read(ClassFile.java:790) ~[javassist-3.26.0-GA.jar:?]
	at javassist.bytecode.ClassFile.<init>(ClassFile.java:185) ~[javassist-3.26.0-GA.jar:?]
	at org.reflections.adapters.JavassistAdapter.getOfCreateClassObject(JavassistAdapter.java:100) ~[reflections-0.9.11.jar:?]
	at org.reflections.adapters.JavassistAdapter.getOfCreateClassObject(JavassistAdapter.java:24) ~[reflections-0.9.11.jar:?]
	at org.reflections.scanners.AbstractScanner.scan(AbstractScanner.java:30) ~[reflections-0.9.11.jar:?]
	... 36 more

```
