### PR TITLE
[backport 7.x] Fix acceptance test when run artifact:all (#12975)

### DIFF
--- a/rakelib/compile.rake
+++ b/rakelib/compile.rake
@@ -29,18 +29,9 @@ namespace "compile" do
     logstash-core/lib/logstash/compiler/lscl/lscl_grammar.rb
   )
 
-  def safe_system(*args)
-    if !system(*args)
-      status = $?
-      raise "Got exit status #{status.exitstatus} attempting to execute #{args.inspect}!"
-    end
-  end
-
   task "logstash-core-java" do
-    unless File.exists?(File.join("logstash-core", "lib", "jars", "logstash-core.jar"))
-      puts("Building logstash-core using gradle")
-      safe_system("./gradlew", "assemble")
-    end
+    puts("Building logstash-core using gradle")
+    sh("./gradlew assemble")
   end
 
   desc "Build everything"


### PR DESCRIPTION
Clean backport of #12975 to `7.x`

This commit avoid to check for existence of jar files to decide if run or not Gradle assemble,
basically because the outputs of assemble task are not only jars but also others files, for example plugin-aliases.yml.
In this way the decision to execute or not is left the Gradle logic.

(cherry picked from commit 3eaff3612d633f3f832a98ab654d906ce0aef39a)
