### PR TITLE
[backport 7.x] Fix/log4j routing to avoid create spurious file (#12965)

### DIFF
--- a/logstash-core/src/main/java/org/logstash/log/PipelineRoutingAppender.java
+++ b/logstash-core/src/main/java/org/logstash/log/PipelineRoutingAppender.java
@@ -2,6 +2,7 @@ package org.logstash.log;
 
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Core;
+import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.config.AppenderControl;
@@ -107,8 +108,11 @@ public class PipelineRoutingAppender extends AbstractAppender {
     private AppenderControl getControl(LogEvent event) {
         String key = event.getContextData().getValue("pipeline.id");
         if (key == null) {
-            error("Unable to find the pipeline.id in event's context data");
-            key = "sink";
+            LOGGER.debug("Unable to find the pipeline.id in event's context data in routing appender, skip it");
+            // this prevent to create an appender when log events are not fish-tagged with pipeline.id,
+            // avoid to create log file like "pipeline_${ctx:pipeline.id}.log" which contains duplicated
+            // logs from the logstash-* files
+            return null;
         }
 
         AppenderControl appenderControl = createdAppenders.get(key);

--- a/logstash-core/src/main/java/org/logstash/log/PipelineRoutingFilter.java
+++ b/logstash-core/src/main/java/org/logstash/log/PipelineRoutingFilter.java
@@ -13,7 +13,7 @@ import org.apache.logging.log4j.core.filter.AbstractFilter;
 @Plugin(name = "PipelineRoutingFilter", category = Core.CATEGORY_NAME, elementType = Appender.ELEMENT_TYPE, printObject = true)
 public final class PipelineRoutingFilter extends AbstractFilter {
 
-    private boolean isSeparateLogs;
+    private final boolean isSeparateLogs;
 
     /**
      * Factory method to instantiate the filter

--- a/qa/integration/build.gradle
+++ b/qa/integration/build.gradle
@@ -51,6 +51,8 @@ tasks.register("copyProductionLog4jConfiguration", Copy) {
                     'appender.rolling.policies.size.size = 1KB')
             .replace('appender.rolling.filePattern = ${sys:ls.logs}/logstash-plain-%d{yyyy-MM-dd}-%i.log.gz',
                     'appender.rolling.filePattern = ${sys:ls.logs}/logstash-plain-%d{yyyy-MM-dd}.log')
+            .replace('appender.routing.pipeline.policy.size = 100MB',
+                    'appender.routing.pipeline.policy.size = 1KB')
   }
 }
 


### PR DESCRIPTION
Clean backport of #12965 to branch `7.x`

Avoid the creation of log4j routing appender for log events without the `pipeline.id` fishtag.
In this way no spurious log file named "pipeline_${ctx:pipeline.id}.log" and logs are not duplicated with main Logstash log file.

(cherry picked from commit 1d6a3e4bb3705d43f94e3c0c939c9467237a5ace)