### PR TITLE
Use the OS separator to invoke gradlew from Rake script

### DIFF
--- a/rakelib/compile.rake
+++ b/rakelib/compile.rake
@@ -31,7 +31,8 @@ namespace "compile" do
 
   task "logstash-core-java" do
     puts("Building logstash-core using gradle")
-    sh("./gradlew assemble")
+    # this expansion is necessary to use the path separators of the hosting OS
+    sh(File.join(".", "gradlew"), "assemble")
   end
 
   desc "Build everything"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
Uses the OS defined path separator in Rake script to invoke the `gradlew` command. Without this the `sh('./gradlew assemble')` results in error when running `.\gradlew clean installDefaultGems`.


## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
This fixes a problem that Windows developers could find, starting from #12975

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] test on Windows

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
On a Windows host run `.\gradlew clean installDefaultGems`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
```
Use `bundle info [gemname]` to see where a bundled gem is installed.
Building logstash-core using gradle
./gradlew assemble

'.' is not recognized as an internal or external command,
operable program or batch file.

> Task :installDefaultGems FAILED
#<Class:0x3a7b8619>: Command failed with status (1): [./gradlew assemble...]
     create_shell_runner at C:/Users/andrea_selva/workspace/logstash/vendor/bundle/jruby/2.5.0/gems/rake-12.3.3/lib/rake/file_utils.rb:67
                      sh at C:/Users/andrea_selva/workspace/logstash/vendor/bundle/jruby/2.5.0/gems/rake-12.3.3/lib/rake/file_utils.rb:57
                  <main> at C:/Users/andrea_selva/workspace/logstash/rakelib/compile.rake:34
                 execute at C:/Users/andrea_selva/workspace/logstash/vendor/bundle/jruby/2.5.0/gems/rake-12.3.3/lib/rake/task.rb:273
                    each at org/jruby/RubyArray.java:1820
                 execute at C:/Users/andrea_selva/workspace/logstash/vendor/bundle/jruby/2.5.0/gems/rake-12.3.3/lib/rake/task.rb:273
  invoke_with_call_chain at C:/Users/andrea_selva/workspace/logstash/vendor/bundle/jruby/2.5.0/gems/rake-12.3.3/lib/rake/task.rb:214
         mon_synchronize at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/monitor.rb:237
        handle_interrupt at org/jruby/RubyThread.java:759
         mon_synchronize at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/monitor.rb:236
        handle_interrupt at org/jruby/RubyThread.java:759
         mon_synchronize at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/monitor.rb:233
  invoke_with_call_chain at C:/Users/andrea_selva/workspace/logstash/vendor/bundle/jruby/2.5.0/gems/rake-12.3.3/lib/rake/task.rb:194
    invoke_prerequisites at C:/Users/andrea_selva/workspace/logstash/vendor/bundle/jruby/2.5.0/gems/rake-12.3.3/lib/rake/task.rb:238
                    each at org/jruby/RubyArray.java:1820
    invoke_prerequisites at C:/Users/andrea_selva/workspace/logstash/vendor/bundle/jruby/2.5.0/gems/rake-12.3.3/lib/rake/task.rb:236
  invoke_with_call_chain at C:/Users/andrea_selva/workspace/logstash/vendor/bundle/jruby/2.5.0/gems/rake-12.3.3/lib/rake/task.rb:213
         mon_synchronize at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/monitor.rb:237
        handle_interrupt at org/jruby/RubyThread.java:759
         mon_synchronize at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/monitor.rb:236
        handle_interrupt at org/jruby/RubyThread.java:759
         mon_synchronize at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/monitor.rb:233
  invoke_with_call_chain at C:/Users/andrea_selva/workspace/logstash/vendor/bundle/jruby/2.5.0/gems/rake-12.3.3/lib/rake/task.rb:194
    invoke_prerequisites at C:/Users/andrea_selva/workspace/logstash/vendor/bundle/jruby/2.5.0/gems/rake-12.3.3/lib/rake/task.rb:238
                    each at org/jruby/RubyArray.java:1820
    invoke_prerequisites at C:/Users/andrea_selva/workspace/logstash/vendor/bundle/jruby/2.5.0/gems/rake-12.3.3/lib/rake/task.rb:236
  invoke_with_call_chain at C:/Users/andrea_selva/workspace/logstash/vendor/bundle/jruby/2.5.0/gems/rake-12.3.3/lib/rake/task.rb:213
         mon_synchronize at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/monitor.rb:237
        handle_interrupt at org/jruby/RubyThread.java:759
         mon_synchronize at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/monitor.rb:236
        handle_interrupt at org/jruby/RubyThread.java:759
         mon_synchronize at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/monitor.rb:233
  invoke_with_call_chain at C:/Users/andrea_selva/workspace/logstash/vendor/bundle/jruby/2.5.0/gems/rake-12.3.3/lib/rake/task.rb:194
    invoke_prerequisites at C:/Users/andrea_selva/workspace/logstash/vendor/bundle/jruby/2.5.0/gems/rake-12.3.3/lib/rake/task.rb:238
                    each at org/jruby/RubyArray.java:1820
    invoke_prerequisites at C:/Users/andrea_selva/workspace/logstash/vendor/bundle/jruby/2.5.0/gems/rake-12.3.3/lib/rake/task.rb:236
  invoke_with_call_chain at C:/Users/andrea_selva/workspace/logstash/vendor/bundle/jruby/2.5.0/gems/rake-12.3.3/lib/rake/task.rb:213
         mon_synchronize at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/monitor.rb:237
        handle_interrupt at org/jruby/RubyThread.java:759
         mon_synchronize at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/monitor.rb:236
        handle_interrupt at org/jruby/RubyThread.java:759
         mon_synchronize at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/monitor.rb:233
  invoke_with_call_chain at C:/Users/andrea_selva/workspace/logstash/vendor/bundle/jruby/2.5.0/gems/rake-12.3.3/lib/rake/task.rb:194
                  invoke at C:/Users/andrea_selva/workspace/logstash/vendor/bundle/jruby/2.5.0/gems/rake-12.3.3/lib/rake/task.rb:183
                  <main> at <script>:5

FAILURE: Build failed with an exception.

* Where:
Script 'C:\Users\andrea_selva\workspace\logstash\rubyUtils.gradle' line: 143

* What went wrong:
Execution failed for task ':installDefaultGems'.
> (null) Command failed with status (1): [./gradlew assemble...]
```