### PR TITLE
[backport 7.x] Fix Reflections stack traces when process yml files in ... (#12991)

### DIFF
--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
@@ -20,8 +20,10 @@
 
 package org.logstash.plugins.discovery;
 
+import com.google.common.base.Predicate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.logstash.plugins.AliasRegistry;
 import co.elastic.logstash.api.Codec;
 import co.elastic.logstash.api.Configuration;
@@ -32,6 +34,8 @@ import co.elastic.logstash.api.LogstashPlugin;
 import co.elastic.logstash.api.Output;
 import org.logstash.plugins.PluginLookup.PluginType;
 import org.reflections.Reflections;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
@@ -80,7 +84,12 @@ public final class PluginRegistry {
     private void discoverPlugins() {
         // the constructor of Reflection must be called only by one thread, else there is a
         // risk that the first thread that completes close the Zip files for the others.
-        Reflections reflections = new Reflections("org.logstash.plugins");
+        // scan all .class present in package classpath
+        final ConfigurationBuilder configurationBuilder = new ConfigurationBuilder()
+                .setUrls(ClasspathHelper.forPackage("org.logstash.plugins"))
+                .filterInputsBy(input -> input.endsWith(".class"));
+        Reflections reflections = new Reflections(configurationBuilder);
+
         Set<Class<?>> annotated = reflections.getTypesAnnotatedWith(LogstashPlugin.class);
         for (final Class<?> cls : annotated) {
             for (final Annotation annotation : cls.getAnnotations()) {


### PR DESCRIPTION
Fix Reflections stack traces when process yml files in classpath and debug is enabled (#12991)

Backport of #12991 to branch `7.x`

----

Adds a filter to Reflections library initialization so that when it scan "org.logstash.plugins" it includes only .class files and avoid to load and process AliasRegistry.yml and plugin_aliases.yml

Fixes #12992

(cherry picked from commit a6e9a6bcfd400377d0ceb1449f0cc8e18af60825)
