### PR TITLE
Add geoip database metrics to /node/stats API

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -100,6 +100,8 @@ class LogStash::Agent
     @instance_reload_metric = metric.namespace([:stats, :reloads])
     initialize_agent_metrics
 
+    initialize_geoip_database_metrics(metric)
+
     @dispatcher = LogStash::EventDispatcher.new(self)
     LogStash::PLUGIN_REGISTRY.hooks.register_emitter(self.class, dispatcher)
     dispatcher.fire(:after_initialize)
@@ -553,6 +555,30 @@ class LogStash::Agent
     @pipeline_reload_metric.namespace([action.pipeline_id, :reloads]).tap do |n|
       n.increment(:successes)
       n.gauge(:last_success_timestamp, action_result.executed_at)
+    end
+  end
+
+  def initialize_geoip_database_metrics(metric)
+    begin
+      require_relative ::File.join(LogStash::Environment::LOGSTASH_HOME, "x-pack", "lib", "filters", "geoip", "database_manager")
+      database_manager = LogStash::Filters::Geoip::DatabaseManager.instance
+      database_manager.metric = metric.namespace([:geoip]).tap do |n|
+        db = n.namespace([:database])
+        [:ASN, :City].each do  |database_type|
+          db_type = db.namespace([database_type])
+          db_type.gauge(:status, nil)
+          db_type.gauge(:download_at, nil)
+          db_type.gauge(:fail_check_in_days, 0)
+        end
+
+        dl = n.namespace([:download])
+        dl.increment(:successes, 0)
+        dl.increment(:failures, 0)
+        dl.gauge(:last_check_at, nil)
+        dl.gauge(:status, nil)
+      end
+    rescue LoadError => e
+      @logger.trace("DatabaseManager is not in classpath")
     end
   end
 end # class LogStash::Agent

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -562,19 +562,19 @@ class LogStash::Agent
     begin
       require_relative ::File.join(LogStash::Environment::LOGSTASH_HOME, "x-pack", "lib", "filters", "geoip", "database_manager")
       database_manager = LogStash::Filters::Geoip::DatabaseManager.instance
-      database_manager.metric = metric.namespace([:geoip]).tap do |n|
+      database_manager.metric = metric.namespace([:geoip_download_manager]).tap do |n|
         db = n.namespace([:database])
         [:ASN, :City].each do  |database_type|
           db_type = db.namespace([database_type])
           db_type.gauge(:status, nil)
-          db_type.gauge(:download_at, nil)
+          db_type.gauge(:last_updated_at, nil)
           db_type.gauge(:fail_check_in_days, 0)
         end
 
-        dl = n.namespace([:download])
+        dl = n.namespace([:download_stats])
         dl.increment(:successes, 0)
         dl.increment(:failures, 0)
-        dl.gauge(:last_check_at, nil)
+        dl.gauge(:last_checked_at, nil)
         dl.gauge(:status, nil)
       end
     rescue LoadError => e

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -133,7 +133,7 @@ module LogStash
         end
 
         def geoip
-          service.get_shallow(:geoip)
+          service.get_shallow(:geoip_download_manager)
         rescue
           {}
         end

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -132,6 +132,12 @@ module LogStash
           HotThreadsReport.new(self, options)
         end
 
+        def geoip
+          service.get_shallow(:geoip)
+        rescue
+          {}
+        end
+
         private
         def plugins_stats_report(pipeline_id, extended_pipeline, opts={})
           stats = service.get_shallow(:stats, :pipelines, pipeline_id.to_sym)

--- a/logstash-core/lib/logstash/api/modules/node_stats.rb
+++ b/logstash-core/lib/logstash/api/modules/node_stats.rb
@@ -40,6 +40,10 @@ module LogStash
             :os => os_payload,
             :queue => queue
           }
+
+          geoip = geoip_payload
+          payload[:geoip] = geoip unless geoip.empty?
+
           respond_with(payload, {:filter => params["filter"]})
         end
 
@@ -72,6 +76,10 @@ module LogStash
         def pipeline_payload(val = nil)
           opts = {:vertices => as_boolean(params.fetch("vertices", false))}
           @stats.pipeline(val, opts)
+        end
+
+        def geoip_payload
+          @stats.geoip
         end
       end
     end

--- a/logstash-core/lib/logstash/api/modules/node_stats.rb
+++ b/logstash-core/lib/logstash/api/modules/node_stats.rb
@@ -42,7 +42,7 @@ module LogStash
           }
 
           geoip = geoip_payload
-          payload[:geoip] = geoip unless geoip.empty? || geoip[:download][:status].value.nil?
+          payload[:geoip_download_manager] = geoip unless geoip.empty? || geoip[:download_stats][:status].value.nil?
 
           respond_with(payload, {:filter => params["filter"]})
         end

--- a/logstash-core/lib/logstash/api/modules/node_stats.rb
+++ b/logstash-core/lib/logstash/api/modules/node_stats.rb
@@ -42,7 +42,7 @@ module LogStash
           }
 
           geoip = geoip_payload
-          payload[:geoip] = geoip unless geoip.empty?
+          payload[:geoip] = geoip unless geoip.empty? || geoip[:download][:status].value.nil?
 
           respond_with(payload, {:filter => params["filter"]})
         end
@@ -81,6 +81,7 @@ module LogStash
         def geoip_payload
           @stats.geoip
         end
+
       end
     end
   end

--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -158,6 +158,7 @@
   },
   "logstash-filter-json": {
     "default-plugins": true,
+    "core-specs": true,
     "skip-list": false
   },
   "logstash-filter-kv": {

--- a/x-pack/lib/filters/geoip/database_manager.rb
+++ b/x-pack/lib/filters/geoip/database_manager.rb
@@ -102,7 +102,7 @@ module LogStash module Filters module Geoip class DatabaseManager
       pipeline_id = ThreadContext.get("pipeline.id")
       ThreadContext.put("pipeline.id", nil)
 
-      @metric.namespace([:download]).gauge(:status, :checking)
+      update_download_status(:checking)
 
       updated_db = @download_manager.fetch_database
       updated_db.each do |database_type, valid_download, dirname, new_database_path|
@@ -131,7 +131,7 @@ module LogStash module Filters module Geoip class DatabaseManager
     ensure
       check_age
       clean_up_database
-      set_download_metric(success_cnt)
+      update_download_metric(success_cnt)
 
       ThreadContext.put("pipeline.id", pipeline_id)
     end
@@ -244,7 +244,7 @@ module LogStash module Filters module Geoip class DatabaseManager
     end
   end
 
-  def set_download_metric(success_cnt)
+  def update_download_metric(success_cnt)
     @metric.namespace([:download]).tap do |n|
       n.gauge(:last_check_at, Time.now.iso8601)
 
@@ -256,6 +256,10 @@ module LogStash module Filters module Geoip class DatabaseManager
         n.gauge(:status, :failed)
       end
     end
+  end
+
+  def update_download_status(status)
+    @metric.namespace([:download]).gauge(:status, status)
   end
 
   public

--- a/x-pack/lib/filters/geoip/database_manager.rb
+++ b/x-pack/lib/filters/geoip/database_manager.rb
@@ -15,6 +15,7 @@ require "rufus/scheduler"
 require "date"
 require "singleton"
 require "concurrent"
+require "time"
 require "thread"
 java_import org.apache.logging.log4j.ThreadContext
 
@@ -37,6 +38,11 @@ module LogStash module Filters module Geoip class DatabaseManager
 
   private
   def initialize
+    @triggered = false
+    @trigger_lock = Mutex.new
+  end
+
+  def setup
     prepare_cc_db
     cc_city_database_path = get_db_path(CITY, CC)
     cc_asn_database_path = get_db_path(ASN, CC)
@@ -45,8 +51,6 @@ module LogStash module Filters module Geoip class DatabaseManager
     city_database_path = @metadata.database_path(CITY)
     asn_database_path = @metadata.database_path(ASN)
 
-    @triggered = false
-    @trigger_lock = Mutex.new
     @states = { "#{CITY}" => DatabaseState.new(@metadata.is_eula(CITY),
                                                Concurrent::Array.new,
                                                city_database_path,
@@ -57,6 +61,8 @@ module LogStash module Filters module Geoip class DatabaseManager
                                               cc_asn_database_path) }
 
     @download_manager = DownloadManager.new(@metadata)
+
+    initialize_metrics
   end
 
   protected
@@ -90,9 +96,13 @@ module LogStash module Filters module Geoip class DatabaseManager
   # update metadata timestamp for those dbs that has no update or a valid update
   # do daily check and clean up
   def execute_download_job
+    success_cnt = 0
+
     begin
       pipeline_id = ThreadContext.get("pipeline.id")
       ThreadContext.put("pipeline.id", nil)
+
+      @metric.namespace([:download]).gauge(:status, :checking)
 
       updated_db = @download_manager.fetch_database
       updated_db.each do |database_type, valid_download, dirname, new_database_path|
@@ -106,16 +116,23 @@ module LogStash module Filters module Geoip class DatabaseManager
             logger.info("geoip plugin will use database #{new_database_path}",
                         :database_type => db_type, :pipeline_ids => ids) unless ids.empty?
           end
+
+          success_cnt += 1
         end
       end
 
       updated_types = updated_db.map { |database_type, valid_download, dirname, new_database_path| database_type }
-      (DB_TYPES - updated_types).each { |unchange_type| @metadata.update_timestamp(unchange_type) }
+      (DB_TYPES - updated_types).each do |unchange_type|
+        @metadata.update_timestamp(unchange_type)
+        success_cnt += 1
+      end
     rescue => e
       logger.error(e.message, error_details(e, logger))
     ensure
       check_age
       clean_up_database
+      set_download_metric(success_cnt)
+
       ThreadContext.put("pipeline.id", pipeline_id)
     end
   end
@@ -132,7 +149,9 @@ module LogStash module Filters module Geoip class DatabaseManager
     database_types.map do |database_type|
       next unless @states[database_type].is_eula
 
-      days_without_update = (::Date.today - ::Time.at(@metadata.check_at(database_type)).to_date).to_i
+      metadata = @metadata.get_metadata(database_type).last
+      check_at = metadata[DatabaseMetadata::Column::CHECK_AT].to_i
+      days_without_update = time_diff_in_days(check_at)
 
       case
       when days_without_update >= 30
@@ -152,14 +171,32 @@ module LogStash module Filters module Geoip class DatabaseManager
                         :database_type => db_type, :pipeline_ids => ids)
           end
         end
+
+        database_status = :expired
       when days_without_update >= 25
         logger.warn("The MaxMind database hasn't been updated for last #{days_without_update} days. "\
           "Logstash will fail the GeoIP plugin in #{30 - days_without_update} days. "\
           "Please check the network settings and allow Logstash accesses the internet to download the latest database ")
+        database_status = :to_be_expired
       else
         logger.trace("passed age check", :days_without_update => days_without_update)
+        database_status = :healthy
+      end
+
+      @metric.namespace([:database, database_type.to_sym]).tap do |n|
+        n.gauge(:status, database_status)
+        n.gauge(:download_at, unix_time_to_iso8601(metadata[DatabaseMetadata::Column::DIRNAME]))
+        n.gauge(:fail_check_in_days, days_without_update)
       end
     end
+  end
+
+  def time_diff_in_days(timestamp)
+    (::Date.today - ::Time.at(timestamp.to_i).to_date).to_i
+  end
+
+  def unix_time_to_iso8601(timestamp)
+    Time.at(timestamp.to_i).iso8601
   end
 
   # Clean up directories which are not mentioned in metadata and not CC database
@@ -179,11 +216,43 @@ module LogStash module Filters module Geoip class DatabaseManager
     return if @triggered
     @trigger_lock.synchronize do
       return if @triggered
+      setup
       execute_download_job
       # check database update periodically. trigger `call` method
       @scheduler = Rufus::Scheduler.new({:max_work_threads => 1})
       @scheduler.every('24h', self)
       @triggered = true
+    end
+  end
+
+  def initialize_metrics
+    metadatas = @metadata.get_all
+    metadatas.each do |row|
+      type = row[DatabaseMetadata::Column::DATABASE_TYPE]
+      @metric.namespace([:database, type.to_sym]).tap do |n|
+        n.gauge(:status, @states[type].is_eula ? :healthy : :init)
+        n.gauge(:download_at, unix_time_to_iso8601(row[DatabaseMetadata::Column::DIRNAME])) if @states[type].is_eula
+        n.gauge(:fail_check_in_days, time_diff_in_days(row[DatabaseMetadata::Column::CHECK_AT]))
+      end
+    end
+
+    @metric.namespace([:download]).tap do |n|
+      check_at = metadatas.map { |row| row[DatabaseMetadata::Column::CHECK_AT].to_i }.max
+      n.gauge(:last_check_at, unix_time_to_iso8601(check_at))
+    end
+  end
+
+  def set_download_metric(success_cnt)
+    @metric.namespace([:download]).tap do |n|
+      n.gauge(:last_check_at, Time.now.iso8601)
+
+      if success_cnt == DB_TYPES.size
+        n.increment(:successes, 1)
+        n.gauge(:status, :succeeded)
+      else
+        n.increment(:failures, 1)
+        n.gauge(:status, :failed)
+      end
     end
   end
 
@@ -221,6 +290,10 @@ module LogStash module Filters module Geoip class DatabaseManager
 
   def database_path(database_type)
     @states[database_type].database_path
+  end
+
+  def metric=(metric)
+    @metric = metric
   end
 
   class DatabaseState

--- a/x-pack/lib/filters/geoip/database_manager.rb
+++ b/x-pack/lib/filters/geoip/database_manager.rb
@@ -102,7 +102,7 @@ module LogStash module Filters module Geoip class DatabaseManager
       pipeline_id = ThreadContext.get("pipeline.id")
       ThreadContext.put("pipeline.id", nil)
 
-      update_download_status(:checking)
+      update_download_status(:updating)
 
       updated_db = @download_manager.fetch_database
       updated_db.each do |database_type, valid_download, dirname, new_database_path|
@@ -180,12 +180,12 @@ module LogStash module Filters module Geoip class DatabaseManager
         database_status = :to_be_expired
       else
         logger.trace("passed age check", :days_without_update => days_without_update)
-        database_status = :healthy
+        database_status = :up_to_date
       end
 
       @metric.namespace([:database, database_type.to_sym]).tap do |n|
         n.gauge(:status, database_status)
-        n.gauge(:download_at, unix_time_to_iso8601(metadata[DatabaseMetadata::Column::DIRNAME]))
+        n.gauge(:last_updated_at, unix_time_to_iso8601(metadata[DatabaseMetadata::Column::DIRNAME]))
         n.gauge(:fail_check_in_days, days_without_update)
       end
     end
@@ -230,23 +230,23 @@ module LogStash module Filters module Geoip class DatabaseManager
     metadatas.each do |row|
       type = row[DatabaseMetadata::Column::DATABASE_TYPE]
       @metric.namespace([:database, type.to_sym]).tap do |n|
-        n.gauge(:status, @states[type].is_eula ? :healthy : :init)
+        n.gauge(:status, @states[type].is_eula ? :up_to_date : :init)
         if @states[type].is_eula
-          n.gauge(:download_at, unix_time_to_iso8601(row[DatabaseMetadata::Column::DIRNAME]))
+          n.gauge(:last_updated_at, unix_time_to_iso8601(row[DatabaseMetadata::Column::DIRNAME]))
           n.gauge(:fail_check_in_days, time_diff_in_days(row[DatabaseMetadata::Column::CHECK_AT]))
         end
       end
     end
 
-    @metric.namespace([:download]).tap do |n|
+    @metric.namespace([:download_stats]).tap do |n|
       check_at = metadatas.map { |row| row[DatabaseMetadata::Column::CHECK_AT].to_i }.max
-      n.gauge(:last_check_at, unix_time_to_iso8601(check_at))
+      n.gauge(:last_checked_at, unix_time_to_iso8601(check_at))
     end
   end
 
   def update_download_metric(success_cnt)
-    @metric.namespace([:download]).tap do |n|
-      n.gauge(:last_check_at, Time.now.iso8601)
+    @metric.namespace([:download_stats]).tap do |n|
+      n.gauge(:last_checked_at, Time.now.iso8601)
 
       if success_cnt == DB_TYPES.size
         n.increment(:successes, 1)
@@ -259,7 +259,7 @@ module LogStash module Filters module Geoip class DatabaseManager
   end
 
   def update_download_status(status)
-    @metric.namespace([:download]).gauge(:status, status)
+    @metric.namespace([:download_stats]).gauge(:status, status)
   end
 
   public

--- a/x-pack/lib/filters/geoip/database_manager.rb
+++ b/x-pack/lib/filters/geoip/database_manager.rb
@@ -231,8 +231,10 @@ module LogStash module Filters module Geoip class DatabaseManager
       type = row[DatabaseMetadata::Column::DATABASE_TYPE]
       @metric.namespace([:database, type.to_sym]).tap do |n|
         n.gauge(:status, @states[type].is_eula ? :healthy : :init)
-        n.gauge(:download_at, unix_time_to_iso8601(row[DatabaseMetadata::Column::DIRNAME])) if @states[type].is_eula
-        n.gauge(:fail_check_in_days, time_diff_in_days(row[DatabaseMetadata::Column::CHECK_AT]))
+        if @states[type].is_eula
+          n.gauge(:download_at, unix_time_to_iso8601(row[DatabaseMetadata::Column::DIRNAME]))
+          n.gauge(:fail_check_in_days, time_diff_in_days(row[DatabaseMetadata::Column::CHECK_AT]))
+        end
       end
     end
 

--- a/x-pack/qa/integration/monitoring/geoip_metric_spec.rb
+++ b/x-pack/qa/integration/monitoring/geoip_metric_spec.rb
@@ -1,0 +1,37 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+require_relative "../spec_helper"
+require_relative "../../../../qa/integration/services/monitoring_api"
+
+describe "GeoIP database service" do
+  before :all do
+
+    input = "input { generator { lines => ['{\\\"host\\\": \\\"0.42.56.104\\\"}'] } } "
+    filter = "filter { json { source => \\\"message\\\" } geoip { source => \\\"host\\\" } } "
+    output = "output { null {} }"
+    config = input + filter + output
+
+    @logstash_service = logstash("bin/logstash -e \"#{config}\" -w 1", {
+      :belzebuth => {
+        :wait_condition => /Pipelines running/, # Check for all pipeline started
+        :timeout => 5 * 60 # Fail safe, this mean something went wrong if we hit this before the wait_condition
+      }
+    })
+  end
+
+  context "monitoring API" do
+    it "should has geoip" do
+      api = MonitoringAPI.new
+      stats = api.node_stats
+      expect(stats["geoip"]["database"]["City"]["fail_check_in_days"]).to eq(0)
+      expect(stats["geoip"]["download"]["successes"]).to eq(1)
+      expect(stats["geoip"]["download"]["status"]).to eq("succeeded")
+    end
+  end
+
+  after :all do
+    @logstash_service.stop unless @logstash_service.nil?
+  end
+end

--- a/x-pack/qa/integration/monitoring/geoip_metric_spec.rb
+++ b/x-pack/qa/integration/monitoring/geoip_metric_spec.rb
@@ -19,7 +19,7 @@ describe "GeoIP database service" do
       api = MonitoringAPI.new
       stats = api.node_stats
 
-      expect(stats["geoip"]).not_to be_nil
+      expect(stats["geoip_download_manager"]).not_to be_nil
     end
   end
 
@@ -29,7 +29,7 @@ describe "GeoIP database service" do
       api = MonitoringAPI.new
       stats = api.node_stats
 
-      expect(stats["geoip"]).to be_nil
+      expect(stats["geoip_download_manager"]).to be_nil
     end
   end
 

--- a/x-pack/spec/filters/geoip/database_manager_spec.rb
+++ b/x-pack/spec/filters/geoip/database_manager_spec.rb
@@ -50,7 +50,7 @@ describe LogStash::Filters::Geoip do
         c = db_manager.instance_variable_get(:@metric).collector
         [ASN, CITY].each do |type|
           expect(c.get([:database, type.to_sym], :status, :gauge).value).to eql(:init)
-          expect(c.get([:database, type.to_sym], :fail_check_in_days, :gauge).value).to eql(0)
+          expect(c.get([:database, type.to_sym], :fail_check_in_days, :gauge).value).to be_nil
         end
         expect_initial_download_metric(c)
       end
@@ -290,7 +290,7 @@ describe LogStash::Filters::Geoip do
       def expect_healthy_database_metric(c)
         expect(c.get([:database, CITY.to_sym], :status, :gauge).value).to eql(:init)
         expect(c.get([:database, CITY.to_sym], :download_at, :gauge).value).to be_nil
-        expect(c.get([:database, CITY.to_sym], :fail_check_in_days, :gauge).value).to eql(0)
+        expect(c.get([:database, CITY.to_sym], :fail_check_in_days, :gauge).value).to be_nil
       end
     end
 

--- a/x-pack/spec/filters/geoip/database_manager_spec.rb
+++ b/x-pack/spec/filters/geoip/database_manager_spec.rb
@@ -96,16 +96,16 @@ describe LogStash::Filters::Geoip do
       end
 
       def expect_second_database_metric(c)
-        expect(c.get([:database, CITY.to_sym], :status, :gauge).value).to eql(:healthy)
-        expect(c.get([:database, CITY.to_sym], :download_at, :gauge).value).to match /2020-02-20/
+        expect(c.get([:database, CITY.to_sym], :status, :gauge).value).to eql(:up_to_date)
+        expect(c.get([:database, CITY.to_sym], :last_updated_at, :gauge).value).to match /2020-02-20/
         expect(c.get([:database, CITY.to_sym], :fail_check_in_days, :gauge).value).to eql(0)
       end
 
       def expect_initial_download_metric(c)
-        expect(c.get([:download], :successes, :counter).value).to eql(0)
-        expect(c.get([:download], :failures, :counter).value).to eql(0)
-        expect(c.get([:download], :last_check_at, :gauge).value).to match /#{now_in_ymd}/
-        expect(c.get([:download], :status, :gauge).value).to be_nil
+        expect(c.get([:download_stats], :successes, :counter).value).to eql(0)
+        expect(c.get([:download_stats], :failures, :counter).value).to eql(0)
+        expect(c.get([:download_stats], :last_checked_at, :gauge).value).to match /#{now_in_ymd}/
+        expect(c.get([:download_stats], :status, :gauge).value).to be_nil
       end
     end
 
@@ -205,15 +205,15 @@ describe LogStash::Filters::Geoip do
       end
       
       def expect_download_metric_success(c)
-        expect(c.get([:download], :last_check_at, :gauge).value).to match /#{now_in_ymd}/
-        expect(c.get([:download], :successes, :counter).value).to eql(1)
-        expect(c.get([:download], :status, :gauge).value).to eql(:succeeded)
+        expect(c.get([:download_stats], :last_checked_at, :gauge).value).to match /#{now_in_ymd}/
+        expect(c.get([:download_stats], :successes, :counter).value).to eql(1)
+        expect(c.get([:download_stats], :status, :gauge).value).to eql(:succeeded)
       end
 
       def expect_download_metric_fail(c)
-        expect(c.get([:download], :last_check_at, :gauge).value).to match /#{now_in_ymd}/
-        expect(c.get([:download], :failures, :counter).value).to eql(1)
-        expect(c.get([:download], :status, :gauge).value).to eql(:failed)
+        expect(c.get([:download_stats], :last_checked_at, :gauge).value).to match /#{now_in_ymd}/
+        expect(c.get([:download_stats], :failures, :counter).value).to eql(1)
+        expect(c.get([:download_stats], :status, :gauge).value).to eql(:failed)
       end
     end
 
@@ -283,13 +283,13 @@ describe LogStash::Filters::Geoip do
 
       def expect_database_metric(c, status, download_at, days)
         expect(c.get([:database, CITY.to_sym], :status, :gauge).value).to eql(status)
-        expect(c.get([:database, CITY.to_sym], :download_at, :gauge).value).to match /#{download_at}/
+        expect(c.get([:database, CITY.to_sym], :last_updated_at, :gauge).value).to match /#{download_at}/
         expect(c.get([:database, CITY.to_sym], :fail_check_in_days, :gauge).value).to eql(days)
       end
 
       def expect_healthy_database_metric(c)
         expect(c.get([:database, CITY.to_sym], :status, :gauge).value).to eql(:init)
-        expect(c.get([:database, CITY.to_sym], :download_at, :gauge).value).to be_nil
+        expect(c.get([:database, CITY.to_sym], :last_updated_at, :gauge).value).to be_nil
         expect(c.get([:database, CITY.to_sym], :fail_check_in_days, :gauge).value).to be_nil
       end
     end

--- a/x-pack/spec/filters/geoip/test_helper.rb
+++ b/x-pack/spec/filters/geoip/test_helper.rb
@@ -55,7 +55,7 @@ module GeoipHelper
   end
 
   def second_dirname
-    "20200220"
+    "1582153200"
   end
 
   def create_default_city_gz
@@ -119,6 +119,14 @@ module GeoipHelper
       __FILE__))
     FileUtils.mkdir_p(dir_path)
     FileUtils.cp_r(cc_database_paths, dir_path)
+  end
+
+  def now_in_ymd
+    Time.now.strftime('%Y-%m-%d')
+  end
+
+  def second_dirname_in_ymd
+    Time.at(second_dirname.to_i).strftime('%Y-%m-%d')
   end
 end
 

--- a/x-pack/spec/filters/geoip/test_helper.rb
+++ b/x-pack/spec/filters/geoip/test_helper.rb
@@ -55,7 +55,7 @@ module GeoipHelper
   end
 
   def second_dirname
-    "1582153200"
+    "1582156922"
   end
 
   def create_default_city_gz


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Add geoip database metrics to /node/stats 

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

This PR exposes geoip database metrics to Logstash localhost:9600/node/stats API

Sample output
```
"geoip" : {
    "database" : {
       “ASN”: {
          "status" : "healthy",
          "fail_check_in_days" : 0,
          "download_at" : "2021-06-21T16:06:54+02:00"
       },
       “City”: {
          "status" : "healthy",
          "fail_check_in_days" : 0,
          "download_at" : "2021-06-21T16:06:54+02:00"
       }
    },
    "download" : {
        "successes" : 15,
        "failures" : 1,
        "last_check_at" : "2021-06-21T16:07:03+02:00",
        "status" : "succeeded"
    }
}
```

Schema
```
geoip
  database
    ASN/CIty
      status:
        - init, initial CC database status
        - healthy, using up-to-date EULA database
        - to_be_expired, 25 days without calling service
        - expired, 30 days without calling service
      fail_check_in_days: nr. of days LS fail to call service since the last success
      download_at: the timestamp of the last database download
  download
    successes: the number of successful checks and downloads. When all databases are updated or pass the check, the counter +1
    failures: the number of failed attempts. When one of the databases fails to check or update, the counter +1
    last_check_at: the timestamp of last check
    status:
      - checking, check and download at the moment
      - succeeded, last download succeed
      - failed, last download failed
```

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

It allows system administrators to monitor database status through metric API instead of scanning the log.
When they see database status `to_be_expired`, they should allow Logstash to access the internet to download the latest database to prevent the `expired` status that fails the plugin

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

please check the `geoip` session of  `curl -XGET 'localhost:9600/_node/stats'` 

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
