### PR TITLE
[backport 7.x]Use the OS separator to invoke gradlew from Rake script (#13000)

### DIFF
--- a/rakelib/compile.rake
+++ b/rakelib/compile.rake
@@ -31,7 +31,8 @@ namespace "compile" do
 
   task "logstash-core-java" do
     puts("Building logstash-core using gradle")
-    sh("./gradlew assemble")
+    # this expansion is necessary to use the path separators of the hosting OS
+    sh(File.join(".", "gradlew"), "assemble")
   end
 
   desc "Build everything"


### PR DESCRIPTION
Clean backport of #13000 to branhc `7.x`

Uses the OS defined path separator in Rake script to invoke the gradlew command. Without this the sh('./gradlew assemble') results in error when running .\gradlew clean installDefaultGems.

(cherry picked from commit d2c68fc0f928cecb119b3ec417088ee192e558fe)