### PR TITLE
Fix logstash.bat not setting exit code (#12948)

### DIFF
--- a/bin/logstash.bat
+++ b/bin/logstash.bat
@@ -84,3 +84,4 @@ goto :eof
 
 :end
 endlocal
+exit /B %ERRORLEVEL%


### PR DESCRIPTION
Clean backport #12948 to branch `7.x`

This PR makes the Windows logstash.bat exit with the last %ERRORLEVEL% at the end, so that any error in running Logstash will get propagated back to the command line.

Before this change, logstash.bat would always exit with code 0 - success (when doing cmd.exe /C logstash.bat), even if the java.exe process exited with a non-zero code (e.g. due to Logstash throwing an error at runtime).

(cherry picked from commit 1f9ef978364a2dfc0d3126679d72eb7dc4f0ae9d)