### PR TITLE
Fix UBI source URL

### DIFF
--- a/logstash-core/lib/logstash/dependency_report.rb
+++ b/logstash-core/lib/logstash/dependency_report.rb
@@ -31,7 +31,7 @@ class LogStash::DependencyReport < Clamp::Command
 
   OTHER_DEPENDENCIES = [
     ["jruby", "", "http://jruby.org", "EPL-2.0"],
-    ["Red Hat Universal Base Image minimal","8","https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8","Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf","","https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz"]
+    ["Red Hat Universal Base Image minimal","8","https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8","Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf","","https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz"]
   ]
 
   def execute

--- a/tools/dependencies-report/src/main/resources/licenseMapping.csv
+++ b/tools/dependencies-report/src/main/resources/licenseMapping.csv
@@ -121,7 +121,7 @@ dependency,dependencyUrl,licenseOverride,copyright,sourceURL
 "rack-protection:",http://github.com/rkh/rack-protection,MIT
 "rack:",http://rack.github.io/,MIT
 "rake:",https://github.com/ruby/rake,MIT
-"Red Hat Universal Base Image minimal:",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz
+"Red Hat Universal Base Image minimal:",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz
 "redis:",https://github.com/redis/redis-rb,MIT
 "ruby-progressbar:",https://github.com/jfelchner/ruby-progressbar,MIT
 "rubyzip:",https://github.com/rubyzip/rubyzip,BSD-2-Clause-FreeBSD

--- a/tools/dependencies-report/src/test/resources/expectedOutput.txt
+++ b/tools/dependencies-report/src/test/resources/expectedOutput.txt
@@ -1,5 +1,5 @@
 name,version,revision,url,license,copyright,sourceURL
-Red Hat Universal Base Image minimal,8,,https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz
+Red Hat Universal Base Image minimal,8,,https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz
 bundler,1.16.1,,https://rubygems.org/gems/bundler/versions/1.16.0,UnacceptableLicense|MIT,,
 com.fasterxml.jackson.core:jackson-core,2.7.3,,https://github.com/FasterXML/jackson-core/tree/jackson-core-2.7.3,Apache-2.0,,
 com.google.errorprone:javac-shaded,9-dev-r4023-3,,http://repo1.maven.org/maven2/com/google/errorprone/javac-shaded/9-dev-r4023-3/,EPL-1.0,,

--- a/tools/dependencies-report/src/test/resources/licenseMapping-conflicting.csv
+++ b/tools/dependencies-report/src/test/resources/licenseMapping-conflicting.csv
@@ -61,4 +61,4 @@ dependency,dependencyUrl,licenseOverride
 "junit:junit:4.12",https://github.com/junit-team/junit4,Apache-2.0
 "json-generator",https://github.com/flori/json,Ruby
 "tzinfo:",https://github.com/tzinfo/tzinfo,MIT,Philip Ross
-"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz
+"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz

--- a/tools/dependencies-report/src/test/resources/licenseMapping-good.csv
+++ b/tools/dependencies-report/src/test/resources/licenseMapping-good.csv
@@ -59,4 +59,4 @@ dependency,dependencyUrl,licenseOverride,copyright,sourceURL
 "junit:junit:4.12",https://github.com/junit-team/junit4,Apache-2.0
 "json-generator",https://github.com/flori/json,Ruby
 "tzinfo:",https://github.com/tzinfo/tzinfo,MIT,Philip Ross
-"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz
+"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz

--- a/tools/dependencies-report/src/test/resources/licenseMapping-missing.csv
+++ b/tools/dependencies-report/src/test/resources/licenseMapping-missing.csv
@@ -60,4 +60,4 @@ dependency,dependencyUrl,licenseOverride,copyright,sourceURL
 "junit:junit:4.12",https://github.com/junit-team/junit4,Apache-2.0
 "json-generator",https://github.com/flori/json,Ruby
 "tzinfo:",https://github.com/tzinfo/tzinfo,MIT,Philip Ross
-"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz
+"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz

--- a/tools/dependencies-report/src/test/resources/licenseMapping-missingNotices.csv
+++ b/tools/dependencies-report/src/test/resources/licenseMapping-missingNotices.csv
@@ -62,5 +62,4 @@ dependency,dependencyUrl,licenseOverride,copyright,sourceURL
 "junit:junit:4.12",https://github.com/junit-team/junit4,Apache-2.0
 "json-generator",https://github.com/flori/json,Ruby
 "tzinfo:",https://github.com/tzinfo/tzinfo,MIT,Philip Ross
-"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz
-
+"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz

--- a/tools/dependencies-report/src/test/resources/licenseMapping-missingUrls.csv
+++ b/tools/dependencies-report/src/test/resources/licenseMapping-missingUrls.csv
@@ -60,4 +60,4 @@ dependency,dependencyUrl,licenseOverride
 "junit:junit:4.12",https://github.com/junit-team/junit4,Apache-2.0
 "json-generator",https://github.com/flori/json,Ruby
 "tzinfo:",https://github.com/tzinfo/tzinfo,MIT,Philip Ross
-"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz
+"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz

--- a/tools/dependencies-report/src/test/resources/licenseMapping-unacceptable.csv
+++ b/tools/dependencies-report/src/test/resources/licenseMapping-unacceptable.csv
@@ -57,4 +57,4 @@ dependency,dependencyUrl,licenseOverride
 "junit:junit:4.12",https://github.com/junit-team/junit4,Apache-2.0
 "json-generator",https://github.com/flori/json,Ruby
 "tzinfo:",https://github.com/tzinfo/tzinfo,MIT,Philip Ross
-"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz
+"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz

--- a/tools/dependencies-report/src/test/resources/rubyDependencies.csv
+++ b/tools/dependencies-report/src/test/resources/rubyDependencies.csv
@@ -14,4 +14,4 @@ control.js,,,MIT,,
 json-generator,,https://github.com/flori/json,Ruby,,
 json-parser,,https://github.com/flori/json,Ruby,,
 tzinfo,,https://github.com/tzinfo/tzinfo,MIT,Philip Ross,
-Red Hat Universal Base Image minimal,8,https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz
+Red Hat Universal Base Image minimal,8,https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz


### PR DESCRIPTION
## What does this PR do?

This commit fix the source URL for UBI image to ensure that it stays
consistent with the URL generated in
https://artifacts.elastic.co/reports/dependencies/dependencies-current.html

## Why is it important/What is the impact to the user?

The `sourceURL` column contains a pointer to the source code, which is optional for most dependencies,
but a requirement for some, such as the Red Hat Universal Base Image.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files (and/or docker env variables)~
- [x] I have amended existing tests that include `sourceURL`

## How to test this PR locally

Run `ci/license_check.sh` and verify that `report.csv` includes the good URL