### PR TITLE
Backport PR #13008 to 7.x: Fix UBI source URL

### DIFF
--- a/logstash-core/lib/logstash/dependency_report.rb
+++ b/logstash-core/lib/logstash/dependency_report.rb
@@ -31,7 +31,7 @@ class LogStash::DependencyReport < Clamp::Command
 
   OTHER_DEPENDENCIES = [
     ["jruby", "", "http://jruby.org", "EPL-2.0"],
-    ["Red Hat Universal Base Image minimal","8","https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8","Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf","","https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz"]
+    ["Red Hat Universal Base Image minimal","8","https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8","Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf","","https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz"]
   ]
 
   def execute

--- a/tools/dependencies-report/src/main/resources/licenseMapping.csv
+++ b/tools/dependencies-report/src/main/resources/licenseMapping.csv
@@ -123,7 +123,7 @@ dependency,dependencyUrl,licenseOverride,copyright,sourceURL
 "rack-protection:",http://github.com/rkh/rack-protection,MIT
 "rack:",http://rack.github.io/,MIT
 "rake:",https://github.com/ruby/rake,MIT
-"Red Hat Universal Base Image minimal:",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz
+"Red Hat Universal Base Image minimal:",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz
 "redis:",https://github.com/redis/redis-rb,MIT
 "ruby-progressbar:",https://github.com/jfelchner/ruby-progressbar,MIT
 "rubyzip:",https://github.com/rubyzip/rubyzip,BSD-2-Clause-FreeBSD

--- a/tools/dependencies-report/src/test/resources/expectedOutput.txt
+++ b/tools/dependencies-report/src/test/resources/expectedOutput.txt
@@ -1,5 +1,5 @@
 name,version,revision,url,license,copyright,sourceURL
-Red Hat Universal Base Image minimal,8,,https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz
+Red Hat Universal Base Image minimal,8,,https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz
 bundler,1.16.1,,https://rubygems.org/gems/bundler/versions/1.16.0,UnacceptableLicense|MIT,,
 com.fasterxml.jackson.core:jackson-core,2.7.3,,https://github.com/FasterXML/jackson-core/tree/jackson-core-2.7.3,Apache-2.0,,
 com.google.errorprone:javac-shaded,9-dev-r4023-3,,http://repo1.maven.org/maven2/com/google/errorprone/javac-shaded/9-dev-r4023-3/,EPL-1.0,,

--- a/tools/dependencies-report/src/test/resources/licenseMapping-conflicting.csv
+++ b/tools/dependencies-report/src/test/resources/licenseMapping-conflicting.csv
@@ -61,4 +61,4 @@ dependency,dependencyUrl,licenseOverride
 "junit:junit:4.12",https://github.com/junit-team/junit4,Apache-2.0
 "json-generator",https://github.com/flori/json,Ruby
 "tzinfo:",https://github.com/tzinfo/tzinfo,MIT,Philip Ross
-"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz
+"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz

--- a/tools/dependencies-report/src/test/resources/licenseMapping-good.csv
+++ b/tools/dependencies-report/src/test/resources/licenseMapping-good.csv
@@ -59,4 +59,4 @@ dependency,dependencyUrl,licenseOverride,copyright,sourceURL
 "junit:junit:4.12",https://github.com/junit-team/junit4,Apache-2.0
 "json-generator",https://github.com/flori/json,Ruby
 "tzinfo:",https://github.com/tzinfo/tzinfo,MIT,Philip Ross
-"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz
+"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz

--- a/tools/dependencies-report/src/test/resources/licenseMapping-missing.csv
+++ b/tools/dependencies-report/src/test/resources/licenseMapping-missing.csv
@@ -60,4 +60,4 @@ dependency,dependencyUrl,licenseOverride,copyright,sourceURL
 "junit:junit:4.12",https://github.com/junit-team/junit4,Apache-2.0
 "json-generator",https://github.com/flori/json,Ruby
 "tzinfo:",https://github.com/tzinfo/tzinfo,MIT,Philip Ross
-"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz
+"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz

--- a/tools/dependencies-report/src/test/resources/licenseMapping-missingNotices.csv
+++ b/tools/dependencies-report/src/test/resources/licenseMapping-missingNotices.csv
@@ -62,5 +62,4 @@ dependency,dependencyUrl,licenseOverride,copyright,sourceURL
 "junit:junit:4.12",https://github.com/junit-team/junit4,Apache-2.0
 "json-generator",https://github.com/flori/json,Ruby
 "tzinfo:",https://github.com/tzinfo/tzinfo,MIT,Philip Ross
-"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz
-
+"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz

--- a/tools/dependencies-report/src/test/resources/licenseMapping-missingUrls.csv
+++ b/tools/dependencies-report/src/test/resources/licenseMapping-missingUrls.csv
@@ -60,4 +60,4 @@ dependency,dependencyUrl,licenseOverride
 "junit:junit:4.12",https://github.com/junit-team/junit4,Apache-2.0
 "json-generator",https://github.com/flori/json,Ruby
 "tzinfo:",https://github.com/tzinfo/tzinfo,MIT,Philip Ross
-"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz
+"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz

--- a/tools/dependencies-report/src/test/resources/licenseMapping-unacceptable.csv
+++ b/tools/dependencies-report/src/test/resources/licenseMapping-unacceptable.csv
@@ -57,4 +57,4 @@ dependency,dependencyUrl,licenseOverride
 "junit:junit:4.12",https://github.com/junit-team/junit4,Apache-2.0
 "json-generator",https://github.com/flori/json,Ruby
 "tzinfo:",https://github.com/tzinfo/tzinfo,MIT,Philip Ross
-"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz
+"Red Hat Universal Base Image minimal:8",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz

--- a/tools/dependencies-report/src/test/resources/rubyDependencies.csv
+++ b/tools/dependencies-report/src/test/resources/rubyDependencies.csv
@@ -14,4 +14,4 @@ control.js,,,MIT,,
 json-generator,,https://github.com/flori/json,Ruby,,
 json-parser,,https://github.com/flori/json,Ruby,,
 tzinfo,,https://github.com/tzinfo/tzinfo,MIT,Philip Ross,
-Red Hat Universal Base Image minimal,8,https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz
+Red Hat Universal Base Image minimal,8,https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz


### PR DESCRIPTION
Backport PR #13008 to 7.x branch. Original message:

This commit fix the source URL for UBI image to ensure that it stays
consistent with the URL generated in
https://artifacts.elastic.co/reports/dependencies/dependencies-current.html
