### PR TITLE
Backport PR #13002 to 7.x: ispec: fix cross-spec leak from fatal error integration specs

### DIFF
--- a/qa/integration/specs/fatal_error_spec.rb
+++ b/qa/integration/specs/fatal_error_spec.rb
@@ -28,10 +28,19 @@ describe "uncaught exception" do
     @logstash = @fixture.get_service("logstash")
   end
 
-  after(:each) { @logstash.teardown }
+  after(:each) do
+    @logstash.teardown
+    FileUtils.rm_rf(temp_dir)
+  end
 
   let(:timeout) { 90 } # seconds
   let(:temp_dir) { Stud::Temporary.directory("logstash-error-test") }
+  let(:logs_dir) { File.join(temp_dir, "logs") }
+
+  # ensure PQ data is isolated.
+  # We crash before ACK-ing events, so we need to make sure we don't
+  # leave those un-ACK'd events in the queue to poison a subsequent test.
+  let(:data_dir) { File.join(temp_dir, "data") }
 
   it "halts LS on fatal error" do
     config = "input { generator { count => 1 message => 'a fatal error' } } "
@@ -42,7 +51,7 @@ describe "uncaught exception" do
 
     expect(@logstash.exit_code).to be 120
 
-    log_file = "#{temp_dir}/logstash-plain.log"
+    log_file = "#{logs_dir}/logstash-plain.log"
     expect( File.exists?(log_file) ).to be true
     expect( File.read(log_file) ).to match /\[FATAL\]\[org.logstash.Logstash.*?java.lang.AssertionError: a fatal error/m
   end
@@ -55,13 +64,16 @@ describe "uncaught exception" do
 
     expect(@logstash.exit_code).to be 0 # normal exit
 
-    log_file = "#{temp_dir}/logstash-plain.log"
+    log_file = "#{logs_dir}/logstash-plain.log"
     expect( File.exists?(log_file) ).to be true
     expect( File.read(log_file) ).to match /\[ERROR\]\[org.logstash.Logstash.*?uncaught exception \(in thread .*?java.io.EOFException: unexpected/m
   end
 
   def spawn_logstash_and_wait_for_exit!(config, timeout)
-    @logstash.spawn_logstash('-w', '1', '--path.logs', temp_dir, '-e', config)
+    @logstash.spawn_logstash('--pipeline.workers=1',
+                             '--path.logs', logs_dir,
+                             '--path.data', data_dir,
+                             '--config.string', config)
 
     time = Time.now
     while (Time.now - time) < timeout


### PR DESCRIPTION
Backport PR #13002 to 7.x branch. Original message: 


## Release notes

[rn:skip]

## What does this PR do?

FIxes cross-spec leak from "fatal error" integration specs

Because the "Fatal Error" specs specifically inject fatal errors during
execution, and do so by reacting to a "poison" event, the fatal error prevents
the poison event from being ACK'd in the underlying queue.

By specifying a one-off temporary data directory in these specs and cleaning up
after ourselves, we ensure that a PQ containing un-ACK'd events isn't leaked to
the next spec to run.

## Why is it important/What is the impact to the user?

Resolves random flaky tests that were caused by being executed immediately after one of the "fatal error" tests.

In the following specific test run, the `Test Logstash configuration expands environment variables in all plugin blocks` spec immediately followed one of the "fatal error" specs, which had left a "poison" event containing the message `"a fatal error"`. Since only the "fatal error" spec knew how to convert this message into an actual fatal error, the event was processed "normally". Unfortunately, the spec being executed didn't expect it to be there and its assertions failed.

~~~
14:28:29       1) Test Logstash configuration expands environment variables in all plugin blocks
14:28:29          Failure/Error: Unable to find matching line from backtrace
14:28:29          
14:28:29            expected: "74.125.176.147 - - [11/Sep/2014:21:50:37 +0000] \"GET /?flav=rss20 HTTP/1.1\" 200 29941 \"-\" \"FeedBurner/1.0 (http://www.FeedBurner.com)\" blah,environment_variables_are_evil"
14:28:29                 got: "a fatal error blah,environment_variables_are_evil74.125.176.147 - - [11/Sep/2014:21:50:37 +0000] \"G... 200 29941 \"-\" \"FeedBurner/1.0 (http://www.FeedBurner.com)\" blah,environment_variables_are_evil"
14:28:29          
14:28:29            (compared using ==)
~~~

Depending on what the next test to run validated, this "leak" may or may not end up breaking one of its unrelated assertions.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [-] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

~~~
14:28:29       1) Test Logstash configuration expands environment variables in all plugin blocks
14:28:29          Failure/Error: Unable to find matching line from backtrace
14:28:29          
14:28:29            expected: "74.125.176.147 - - [11/Sep/2014:21:50:37 +0000] \"GET /?flav=rss20 HTTP/1.1\" 200 29941 \"-\" \"FeedBurner/1.0 (http://www.FeedBurner.com)\" blah,environment_variables_are_evil"
14:28:29                 got: "a fatal error blah,environment_variables_are_evil74.125.176.147 - - [11/Sep/2014:21:50:37 +0000] \"G... 200 29941 \"-\" \"FeedBurner/1.0 (http://www.FeedBurner.com)\" blah,environment_variables_are_evil"
14:28:29          
14:28:29            (compared using ==)
~~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
