### PR TITLE
Doc: Add geoip database API to node stats

### DIFF
--- a/docs/static/monitoring/monitoring-apis.asciidoc
+++ b/docs/static/monitoring/monitoring-apis.asciidoc
@@ -1,4 +1,4 @@
-[float]
+[discrete]
 [[monitoring]]
 == APIs for monitoring {ls}
 
@@ -34,20 +34,20 @@ NOTE: By default, the monitoring API attempts to bind to `tcp:9600`. If this por
 instance, you need to launch Logstash with the `--http.port` flag specified to bind to a different port. See
 <<command-line-flags>> for more information.
 
-[float]
+[discrete]
 [[monitoring-common-options]]
-==== Common Options
+==== Common options
 
 The following options can be applied to all of the Logstash monitoring APIs.
 
-[float]
-===== Pretty Results
+[discrete]
+===== Pretty results
 
 When appending `?pretty=true` to any request made, the JSON returned
 will be pretty formatted (use it for debugging only!).
 
-[float]
-===== Human-Readable Output
+[discrete]
+===== Human-readable output
 
 NOTE: For Logstash {logstash_version}, the `human` option is supported for the <<hot-threads-api>>
 only. When you specify `human=true`, the results are returned in plain text instead of
@@ -88,9 +88,9 @@ Gets node-level JVM info, including info about threads.
 See <<monitoring-common-options, Common Options>> for a list of options that can be applied to all
 Logstash monitoring APIs.
 
-[float]
+[discrete]
 [[node-pipeline-info]]
-===== Pipeline Info
+===== Pipeline info
 
 The following request returns a JSON document that shows pipeline info, such as the number of workers,
 batch size, and batch delay:
@@ -152,9 +152,9 @@ Example response:
 
 If you specify an invalid pipeline ID, the request returns a 404 Not Found error.
 
-[float]
+[discrete]
 [[node-os-info]]
-==== OS Info
+==== OS info
 
 The following request returns a JSON document that shows the OS name, architecture, version, and
 available processors:
@@ -177,9 +177,9 @@ Example response:
   }
 --------------------------------------------------
 
-[float]
+[discrete]
 [[node-jvm-info]]
-==== JVM Info
+==== JVM info
 
 The following request returns a JSON document that shows node-level JVM stats, such as the JVM process id, version,
 VM info, memory usage, and info about garbage collectors:
@@ -217,7 +217,7 @@ Example response:
 
 
 [[plugins-api]]
-=== Plugins Info API
+=== Plugins info API
 
 The plugins info API gets information about all Logstash plugins that are currently installed.
 This API basically returns the output of running the `bin/logstash-plugin list --verbose` command.
@@ -291,13 +291,15 @@ Gets runtime stats about each Logstash pipeline.
 Gets runtime stats about config reload successes and failures.
 <<os-stats,`os`>>::
 Gets runtime stats about cgroups when Logstash is running in a container.
+<<geoip-database-stats,`geoip`>>::
+Gets stats for databases used with the <<plugins-filters-geoip, Geoip filter plugin>>.
 
 See <<monitoring-common-options, Common Options>> for a list of options that can be applied to all
 Logstash monitoring APIs.
 
-[float]
+[discrete]
 [[jvm-stats]]
-==== JVM Stats
+==== JVM stats
 
 The following request returns a JSON document containing JVM stats:
 
@@ -363,9 +365,9 @@ Example response:
   }
 --------------------------------------------------
 
-[float]
+[discrete]
 [[process-stats]]
-==== Process Stats
+==== Process stats
 
 The following request returns a JSON document containing process stats:
 
@@ -396,9 +398,9 @@ Example response:
   }
 --------------------------------------------------
 
-[float]
+[discrete]
 [[event-stats]]
-==== Event Stats
+==== Event stats
 
 The following request returns a JSON document containing event-related statistics
 for the Logstash instance:
@@ -422,9 +424,9 @@ Example response:
   }
 --------------------------------------------------
 
-[float]
+[discrete]
 [[pipeline-stats]]
-==== Pipeline Stats
+==== Pipeline stats
 
 The following request returns a JSON document containing pipeline stats,
 including:
@@ -624,9 +626,9 @@ Example response:
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 [[reload-stats]]
-==== Reload Stats
+==== Reload stats
 
 The following request returns a JSON document that shows info about config reload successes and failures.
 
@@ -647,9 +649,9 @@ Example response:
 }
 --------------------------------------------------
 
-[float]
+[discrete]
 [[os-stats]]
-==== OS Stats
+==== OS stats
 
 When Logstash is running in a container, the following request returns a JSON document that
 contains cgroup information to give you a more accurate view of CPU load, including whether
@@ -685,6 +687,18 @@ Example response:
   }
 --------------------------------------------------
 
+[discrete]
+[[geoip-database-stats]]
+==== Geoip database stats
+
+You can monitor stats for the geoip databases used with the <<plugins-filters-geoip, Geoip filter plugin>>.
+
+[source,js]
+--------------------------------------------------
+curl -XGET 'localhost:9600/_node/stats/geoip?pretty'
+--------------------------------------------------
+
+For more info, see <<plugins-filters-geoip, Geoip filter plugin>>.
 
 [[hot-threads-api]]
 === Hot Threads API

--- a/docs/static/monitoring/monitoring-apis.asciidoc
+++ b/docs/static/monitoring/monitoring-apis.asciidoc
@@ -291,7 +291,7 @@ Gets runtime stats about each Logstash pipeline.
 Gets runtime stats about config reload successes and failures.
 <<os-stats,`os`>>::
 Gets runtime stats about cgroups when Logstash is running in a container.
-<<geoip-database-stats,`geoip`>>::
+<<geoip-database-stats,`geoip_download_manager`>>::
 Gets stats for databases used with the <<plugins-filters-geoip, Geoip filter plugin>>.
 
 See <<monitoring-common-options, Common Options>> for a list of options that can be applied to all
@@ -695,10 +695,10 @@ You can monitor stats for the geoip databases used with the <<plugins-filters-ge
 
 [source,js]
 --------------------------------------------------
-curl -XGET 'localhost:9600/_node/stats/geoip?pretty'
+curl -XGET 'localhost:9600/_node/stats/geoip_download_manager?pretty'
 --------------------------------------------------
 
-For more info, see <<plugins-filters-geoip, Geoip filter plugin>>.
+For more info, see <<plugins-filters-geoip-metrics,Database Metrics>> in the Geoip filter plugin docs. 
 
 [[hot-threads-api]]
 === Hot Threads API


### PR DESCRIPTION
**PREVIEW:** https://logstash_13019.docs-preview.app.elstc.co/guide/en/logstash/master/node-stats-api.html
## Release notes
[rn:skip] 

## What does this PR do?
Adds geoip database API to node stats documentation with reference back to Geoip filter plugin docs. 
Updates topic to current documentation standards for tagging and capitalization. 

Related: https://github.com/logstash-plugins/logstash-filter-geoip/pull/187

**ToDo:**
Add deep link to Database Metrics section after https://github.com/logstash-plugins/logstash-filter-geoip/pull/187 has been merged and published. 