### PR TITLE
[7.x] Add geoip database metrics to /node/stats API (#13004)

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -107,6 +107,8 @@ class LogStash::Agent
     @instance_reload_metric = metric.namespace([:stats, :reloads])
     initialize_agent_metrics
 
+    initialize_geoip_database_metrics(metric)
+
     @dispatcher = LogStash::EventDispatcher.new(self)
     LogStash::PLUGIN_REGISTRY.hooks.register_emitter(self.class, dispatcher)
     dispatcher.fire(:after_initialize)
@@ -560,6 +562,30 @@ class LogStash::Agent
     @pipeline_reload_metric.namespace([action.pipeline_id, :reloads]).tap do |n|
       n.increment(:successes)
       n.gauge(:last_success_timestamp, action_result.executed_at)
+    end
+  end
+
+  def initialize_geoip_database_metrics(metric)
+    begin
+      require_relative ::File.join(LogStash::Environment::LOGSTASH_HOME, "x-pack", "lib", "filters", "geoip", "database_manager")
+      database_manager = LogStash::Filters::Geoip::DatabaseManager.instance
+      database_manager.metric = metric.namespace([:geoip_download_manager]).tap do |n|
+        db = n.namespace([:database])
+        [:ASN, :City].each do  |database_type|
+          db_type = db.namespace([database_type])
+          db_type.gauge(:status, nil)
+          db_type.gauge(:last_updated_at, nil)
+          db_type.gauge(:fail_check_in_days, 0)
+        end
+
+        dl = n.namespace([:download_stats])
+        dl.increment(:successes, 0)
+        dl.increment(:failures, 0)
+        dl.gauge(:last_checked_at, nil)
+        dl.gauge(:status, nil)
+      end
+    rescue LoadError => e
+      @logger.trace("DatabaseManager is not in classpath")
     end
   end
 end # class LogStash::Agent

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -132,6 +132,12 @@ module LogStash
           HotThreadsReport.new(self, options)
         end
 
+        def geoip
+          service.get_shallow(:geoip_download_manager)
+        rescue
+          {}
+        end
+
         private
         def plugins_stats_report(pipeline_id, extended_pipeline, opts={})
           stats = service.get_shallow(:stats, :pipelines, pipeline_id.to_sym)

--- a/logstash-core/lib/logstash/api/modules/node_stats.rb
+++ b/logstash-core/lib/logstash/api/modules/node_stats.rb
@@ -40,6 +40,10 @@ module LogStash
             :os => os_payload,
             :queue => queue
           }
+
+          geoip = geoip_payload
+          payload[:geoip_download_manager] = geoip unless geoip.empty? || geoip[:download_stats][:status].value.nil?
+
           respond_with(payload, {:filter => params["filter"]})
         end
 
@@ -77,6 +81,11 @@ module LogStash
           opts = {:vertices => as_boolean(params.fetch("vertices", false))}
           @stats.pipeline(val, opts)
         end
+
+        def geoip_payload
+          @stats.geoip
+        end
+
       end
     end
   end

--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -158,6 +158,7 @@
   },
   "logstash-filter-json": {
     "default-plugins": true,
+    "core-specs": true,
     "skip-list": false
   },
   "logstash-filter-kv": {

--- a/x-pack/qa/integration/monitoring/geoip_metric_spec.rb
+++ b/x-pack/qa/integration/monitoring/geoip_metric_spec.rb
@@ -1,0 +1,48 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+require_relative "../spec_helper"
+require_relative "../../../../qa/integration/services/monitoring_api"
+
+describe "GeoIP database service" do
+  let(:input) { "input { generator { lines => ['{\\\"host\\\": \\\"0.42.56.104\\\"}'] } } " }
+  let(:output) { "output { null {} }" }
+  let(:filter) { " " }
+  let(:config) { input + filter + output }
+
+  context "monitoring API with geoip plugin" do
+    let(:filter) { "filter { json { source => \\\"message\\\" } geoip { source => \\\"host\\\" } } " }
+
+    it "should have geoip" do
+      start_logstash
+      api = MonitoringAPI.new
+      stats = api.node_stats
+
+      expect(stats["geoip_download_manager"]).not_to be_nil
+    end
+  end
+
+  context "monitoring API without geoip plugin" do
+    it "should not have geoip" do
+      start_logstash
+      api = MonitoringAPI.new
+      stats = api.node_stats
+
+      expect(stats["geoip_download_manager"]).to be_nil
+    end
+  end
+
+  def start_logstash
+    @logstash_service = logstash("bin/logstash -e \"#{config}\" -w 1", {
+      :belzebuth => {
+        :wait_condition => /Pipelines running/, # Check for all pipeline started
+        :timeout => 5 * 60 # Fail safe, this mean something went wrong if we hit this before the wait_condition
+      }
+    })
+  end
+
+  after(:each) do
+    @logstash_service.stop unless @logstash_service.nil?
+  end
+end

--- a/x-pack/spec/filters/geoip/database_manager_spec.rb
+++ b/x-pack/spec/filters/geoip/database_manager_spec.rb
@@ -12,8 +12,11 @@ describe LogStash::Filters::Geoip do
     let(:mock_metadata)  { double("database_metadata") }
     let(:mock_download_manager)  { double("download_manager") }
     let(:mock_scheduler)  { double("scheduler") }
+    let(:agent_metric)  { LogStash::Instrument::Metric.new(LogStash::Instrument::Collector.new) }
     let(:db_manager) do
       manager = Class.new(LogStash::Filters::Geoip::DatabaseManager).instance
+      manager.metric = agent_metric
+      manager.send(:setup)
       manager.instance_variable_set(:@metadata, mock_metadata)
       manager.instance_variable_set(:@download_manager, mock_download_manager)
       manager.instance_variable_set(:@scheduler, mock_scheduler)
@@ -43,6 +46,13 @@ describe LogStash::Filters::Geoip do
         expect(states[ASN].is_eula).to be_falsey
         expect(states[ASN].database_path).to eql(states[ASN].cc_database_path)
         expect(::File.exist?(states[ASN].cc_database_path)).to be_truthy
+
+        c = db_manager.instance_variable_get(:@metric).collector
+        [ASN, CITY].each do |type|
+          expect(c.get([:database, type.to_sym], :status, :gauge).value).to eql(:init)
+          expect(c.get([:database, type.to_sym], :fail_check_in_days, :gauge).value).to be_nil
+        end
+        expect_initial_download_metric(c)
       end
 
       context "when metadata exists" do
@@ -55,11 +65,20 @@ describe LogStash::Filters::Geoip do
           states = db_manager.instance_variable_get(:@states)
           expect(states[CITY].is_eula).to be_truthy
           expect(states[CITY].database_path).to include second_dirname
+
+          c = db_manager.instance_variable_get(:@metric).collector
+          expect_second_database_metric(c)
+          expect_initial_download_metric(c)
         end
       end
 
       context "when metadata exists but database is deleted manually" do
-        let(:db_manager) { Class.new(LogStash::Filters::Geoip::DatabaseManager).instance }
+        let(:db_manager) do
+          manager = Class.new(LogStash::Filters::Geoip::DatabaseManager).instance
+          manager.metric = agent_metric
+          manager.send(:setup)
+          manager
+        end
 
         before do
           rewrite_temp_metadata(metadata_path, [city2_metadata])
@@ -69,7 +88,24 @@ describe LogStash::Filters::Geoip do
           states = db_manager.instance_variable_get(:@states)
           expect(states[CITY].is_eula).to be_truthy
           expect(states[CITY].database_path).to be_nil
+
+          c = db_manager.instance_variable_get(:@metric).collector
+          expect_second_database_metric(c)
+          expect_initial_download_metric(c)
         end
+      end
+
+      def expect_second_database_metric(c)
+        expect(c.get([:database, CITY.to_sym], :status, :gauge).value).to eql(:up_to_date)
+        expect(c.get([:database, CITY.to_sym], :last_updated_at, :gauge).value).to match /2020-02-20/
+        expect(c.get([:database, CITY.to_sym], :fail_check_in_days, :gauge).value).to eql(0)
+      end
+
+      def expect_initial_download_metric(c)
+        expect(c.get([:download_stats], :successes, :counter).value).to eql(0)
+        expect(c.get([:download_stats], :failures, :counter).value).to eql(0)
+        expect(c.get([:download_stats], :last_checked_at, :gauge).value).to match /#{now_in_ymd}/
+        expect(c.get([:download_stats], :status, :gauge).value).to be_nil
       end
     end
 
@@ -81,6 +117,8 @@ describe LogStash::Filters::Geoip do
       context "plugin is set" do
         let(:db_manager) do
           manager = Class.new(LogStash::Filters::Geoip::DatabaseManager).instance
+          manager.metric = agent_metric
+          manager.send(:setup)
           manager.instance_variable_set(:@metadata, mock_metadata)
           manager.instance_variable_set(:@download_manager, mock_download_manager)
           manager.instance_variable_set(:@scheduler, mock_scheduler)
@@ -103,6 +141,9 @@ describe LogStash::Filters::Geoip do
           db_manager.send(:execute_download_job)
           expect(db_manager.database_path(CITY)).to match /#{second_dirname}\/#{default_city_db_name}/
           expect(db_manager.database_path(ASN)).to match /#{second_dirname}\/#{default_asn_db_name}/
+
+          c = db_manager.instance_variable_get(:@metric).collector
+          expect_download_metric_success(c)
         end
       end
 
@@ -116,6 +157,9 @@ describe LogStash::Filters::Geoip do
         db_manager.send(:execute_download_job)
         expect(db_manager.database_path(CITY)).to match /#{CC}\/#{default_city_db_name}/
         expect(db_manager.database_path(ASN)).to match /#{second_dirname}\/#{default_asn_db_name}/
+
+        c = db_manager.instance_variable_get(:@metric).collector
+        expect_download_metric_fail(c)
       end
 
       it "should update single state and single metadata timestamp when one database got update" do
@@ -128,6 +172,9 @@ describe LogStash::Filters::Geoip do
         db_manager.send(:execute_download_job)
         expect(db_manager.database_path(CITY)).to match /#{CC}\/#{default_city_db_name}/
         expect(db_manager.database_path(ASN)).to match /#{second_dirname}\/#{default_asn_db_name}/
+
+        c = db_manager.instance_variable_get(:@metric).collector
+        expect_download_metric_success(c)
       end
 
       it "should update metadata timestamp for the unchange (no update)" do
@@ -140,6 +187,9 @@ describe LogStash::Filters::Geoip do
         db_manager.send(:execute_download_job)
         expect(db_manager.database_path(CITY)).to match /#{CC}\/#{default_city_db_name}/
         expect(db_manager.database_path(ASN)).to  match /#{CC}\/#{default_asn_db_name}/
+
+        c = db_manager.instance_variable_get(:@metric).collector
+        expect_download_metric_success(c)
       end
 
       it "should not update metadata when fetch database throw exception" do
@@ -149,6 +199,21 @@ describe LogStash::Filters::Geoip do
         expect(mock_metadata).to receive(:save_metadata).never
 
         db_manager.send(:execute_download_job)
+
+        c = db_manager.instance_variable_get(:@metric).collector
+        expect_download_metric_fail(c)
+      end
+      
+      def expect_download_metric_success(c)
+        expect(c.get([:download_stats], :last_checked_at, :gauge).value).to match /#{now_in_ymd}/
+        expect(c.get([:download_stats], :successes, :counter).value).to eql(1)
+        expect(c.get([:download_stats], :status, :gauge).value).to eql(:succeeded)
+      end
+
+      def expect_download_metric_fail(c)
+        expect(c.get([:download_stats], :last_checked_at, :gauge).value).to match /#{now_in_ymd}/
+        expect(c.get([:download_stats], :failures, :counter).value).to eql(1)
+        expect(c.get([:download_stats], :status, :gauge).value).to eql(:failed)
       end
     end
 
@@ -156,6 +221,8 @@ describe LogStash::Filters::Geoip do
       context "eula database" do
         let(:db_manager) do
           manager = Class.new(LogStash::Filters::Geoip::DatabaseManager).instance
+          manager.metric = agent_metric
+          manager.send(:setup)
           manager.instance_variable_set(:@metadata, mock_metadata)
           manager.instance_variable_set(:@download_manager, mock_download_manager)
           manager.instance_variable_set(:@scheduler, mock_scheduler)
@@ -167,20 +234,28 @@ describe LogStash::Filters::Geoip do
         end
 
         it "should give warning after 25 days" do
-          expect(mock_metadata).to receive(:check_at).and_return((Time.now - (60 * 60 * 24 * 26)).to_i).at_least(:twice)
+          mock_data = [['City', (Time.now - (60 * 60 * 24 * 26)).to_i, 'ANY', second_dirname, true]]
+          expect(mock_metadata).to receive(:get_metadata).and_return(mock_data).at_least(:twice)
           expect(mock_geoip_plugin).to receive(:update_filter).never
           allow(LogStash::Filters::Geoip::DatabaseManager).to receive(:logger).at_least(:once).and_return(logger)
           expect(logger).to receive(:warn).at_least(:twice)
 
           db_manager.send(:check_age)
+
+          c = db_manager.instance_variable_get(:@metric).collector
+          expect_database_metric(c, :to_be_expired, second_dirname_in_ymd, 26)
         end
 
         it "should log error and update plugin filter when 30 days has passed" do
-          expect(mock_metadata).to receive(:check_at).and_return((Time.now - (60 * 60 * 24 * 33)).to_i).at_least(:twice)
+          mock_data = [['City', (Time.now - (60 * 60 * 24 * 33)).to_i, 'ANY', second_dirname, true]]
+          expect(mock_metadata).to receive(:get_metadata).and_return(mock_data).at_least(:twice)
           allow(mock_geoip_plugin).to receive_message_chain('execution_context.pipeline_id').and_return('pipeline_1', 'pipeline_2')
           expect(mock_geoip_plugin).to receive(:update_filter).with(:expire).at_least(:twice)
 
           db_manager.send(:check_age)
+
+          c = db_manager.instance_variable_get(:@metric).collector
+          expect_database_metric(c, :expired, second_dirname_in_ymd, 33)
         end
       end
 
@@ -190,6 +265,9 @@ describe LogStash::Filters::Geoip do
           expect(logger).to receive(:warn).never
 
           db_manager.send(:check_age)
+
+          c = db_manager.instance_variable_get(:@metric).collector
+          expect_healthy_database_metric(c)
         end
 
         it "should not log error when 30 days has passed" do
@@ -197,7 +275,22 @@ describe LogStash::Filters::Geoip do
           expect(mock_geoip_plugin).to receive(:update_filter).never
 
           db_manager.send(:check_age)
+
+          c = db_manager.instance_variable_get(:@metric).collector
+          expect_healthy_database_metric(c)
         end
+      end
+
+      def expect_database_metric(c, status, download_at, days)
+        expect(c.get([:database, CITY.to_sym], :status, :gauge).value).to eql(status)
+        expect(c.get([:database, CITY.to_sym], :last_updated_at, :gauge).value).to match /#{download_at}/
+        expect(c.get([:database, CITY.to_sym], :fail_check_in_days, :gauge).value).to eql(days)
+      end
+
+      def expect_healthy_database_metric(c)
+        expect(c.get([:database, CITY.to_sym], :status, :gauge).value).to eql(:init)
+        expect(c.get([:database, CITY.to_sym], :last_updated_at, :gauge).value).to be_nil
+        expect(c.get([:database, CITY.to_sym], :fail_check_in_days, :gauge).value).to be_nil
       end
     end
 
@@ -245,6 +338,8 @@ describe LogStash::Filters::Geoip do
       context "when eula database is expired" do
         let(:db_manager) do
           manager = Class.new(LogStash::Filters::Geoip::DatabaseManager).instance
+          manager.metric = agent_metric
+          manager.send(:setup)
           manager.instance_variable_set(:@download_manager, mock_download_manager)
           manager.instance_variable_set(:@scheduler, mock_scheduler)
           manager
@@ -267,6 +362,8 @@ describe LogStash::Filters::Geoip do
     context "unsubscribe" do
       let(:db_manager) do
         manager = Class.new(LogStash::Filters::Geoip::DatabaseManager).instance
+        manager.metric = agent_metric
+        manager.send(:setup)
         manager.instance_variable_set(:@metadata, mock_metadata)
         manager.instance_variable_set(:@download_manager, mock_download_manager)
         manager.instance_variable_set(:@scheduler, mock_scheduler)

--- a/x-pack/spec/filters/geoip/test_helper.rb
+++ b/x-pack/spec/filters/geoip/test_helper.rb
@@ -55,7 +55,7 @@ module GeoipHelper
   end
 
   def second_dirname
-    "20200220"
+    "1582156922"
   end
 
   def create_default_city_gz
@@ -119,6 +119,14 @@ module GeoipHelper
       __FILE__))
     FileUtils.mkdir_p(dir_path)
     FileUtils.cp_r(cc_database_paths, dir_path)
+  end
+
+  def now_in_ymd
+    Time.now.strftime('%Y-%m-%d')
+  end
+
+  def second_dirname_in_ymd
+    Time.at(second_dirname.to_i).strftime('%Y-%m-%d')
   end
 end
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add geoip database metrics to /node/stats API (#13004)