### PR TITLE
Refactor: avoid global mutex on ecs_compatibility

### DIFF
--- a/logstash-core/lib/logstash/plugins/ecs_compatibility_support.rb
+++ b/logstash-core/lib/logstash/plugins/ecs_compatibility_support.rb
@@ -7,11 +7,8 @@ module LogStash
                                         :attr_accessor => false)
       end
 
-      MUTEX = Mutex.new
-      private_constant :MUTEX
-
       def ecs_compatibility
-        @_ecs_compatibility || MUTEX.synchronize do
+        @_ecs_compatibility || LogStash::Util.synchronize(self) do
           @_ecs_compatibility ||= begin
             # use config_init-set value if present
             break @ecs_compatibility unless @ecs_compatibility.nil?


### PR DESCRIPTION
Minor code refactoring.

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

Changes locking on `plugin.ecs_compatibility` initialization to lock per plugin instead of globally.
The global lock is slightly confusing and should not be required, even a pipeline level lock would be an enhancement.