### PR TITLE
Refactor: improve plugin logging xp

### DIFF
--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -19,7 +19,6 @@ require "logstash/config/mixin"
 require "logstash/plugins/ecs_compatibility_support"
 require "concurrent"
 require "logstash/plugins/event_factory_support"
-require "securerandom"
 
 require_relative 'plugin_metadata'
 
@@ -76,7 +75,7 @@ class LogStash::Plugin
     @params = LogStash::Util.deep_clone(params)
     # The id should always be defined normally, but in tests that might not be the case
     # In the future we may make this more strict in the Plugin API
-    @params["id"] ||= "#{self.class.config_name}_#{SecureRandom.uuid}"
+    @params["id"] ||= LogStash::Plugins::PluginFactory.generate_plugin_id
   end
 
   # Return a uniq ID for this plugin configuration, by default

--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -64,18 +64,11 @@ class LogStash::Plugin
   end
 
   def initialize(params={})
-    @logger = self.logger
-    @deprecation_logger = self.deprecation_logger
-    # need to access settings statically because plugins are initialized in config_ast with no context.
-    settings = LogStash::SETTINGS
-    @slow_logger = self.slow_logger(settings.get("slowlog.threshold.warn").to_nanos,
-                                    settings.get("slowlog.threshold.info").to_nanos,
-                                    settings.get("slowlog.threshold.debug").to_nanos,
-                                    settings.get("slowlog.threshold.trace").to_nanos)
     @params = LogStash::Util.deep_clone(params)
     # The id should always be defined normally, but in tests that might not be the case
     # In the future we may make this more strict in the Plugin API
     @params["id"] ||= LogStash::Plugins::PluginFactory.generate_plugin_id
+    __initialize_logging # after id is generated
   end
 
   # Return a uniq ID for this plugin configuration, by default
@@ -190,4 +183,24 @@ class LogStash::Plugin
   def execution_context
     @execution_context || LogStash::ExecutionContext::Empty
   end
+
+  # override Loggable (self.class.logger) delegating methods :
+
+  attr_reader :logger
+  attr_reader :deprecation_logger
+  attr_reader :slow_logger
+
+  private
+
+  def __initialize_logging
+    @logger = self.class.logger
+    @deprecation_logger = self.class.deprecation_logger
+    # need to access settings statically because plugins are initialized in config_ast with no context.
+    settings = LogStash::SETTINGS
+    @slow_logger = self.class.slow_logger(settings.get("slowlog.threshold.warn").to_nanos,
+                                          settings.get("slowlog.threshold.info").to_nanos,
+                                          settings.get("slowlog.threshold.debug").to_nanos,
+                                          settings.get("slowlog.threshold.trace").to_nanos)
+  end
+
 end # class LogStash::Plugin

--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -203,4 +203,12 @@ class LogStash::Plugin
                                           settings.get("slowlog.threshold.trace").to_nanos)
   end
 
+  # TODO do we want to keep this around due plugin specs mocking logger through the class.logger call?!
+  # 
+  # @override LogStash::Util::Loggable.logger
+  # @private
+  # def self.logger(plugin = nil)
+  #   plugin.nil? ? super() : LogStash::Logging::PluginLogger.new(plugin)
+  # end
+
 end # class LogStash::Plugin

--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -193,7 +193,7 @@ class LogStash::Plugin
   private
 
   def __initialize_logging
-    @logger = self.class.logger
+    @logger = LogStash::Logging::PluginLogger.new(self)
     @deprecation_logger = self.class.deprecation_logger
     # need to access settings statically because plugins are initialized in config_ast with no context.
     settings = LogStash::SETTINGS

--- a/logstash-core/spec/logstash/config/mixin_spec.rb
+++ b/logstash-core/spec/logstash/config/mixin_spec.rb
@@ -37,7 +37,7 @@ describe LogStash::Config::Mixin do
     end
 
     it "should not log the password" do
-      expect(LogStash::Logging::Logger).to receive(:new).with(anything).and_return(double_logger)
+      expect(LogStash::Logging::PluginLogger).to receive(:new).with(anything).and_return(double_logger)
       expect(double_logger).to receive(:warn) do |arg1,arg2|
           message = 'You are using a deprecated config setting "old_opt" set in test_deprecated. Deprecated settings will continue to work, but are scheduled for removal from logstash in the future. this is old school If you have any questions about this, please visit the #logstash channel on freenode irc.'
           expect(arg1).to eq(message)

--- a/logstash-core/spec/logstash/java_pipeline_spec.rb
+++ b/logstash-core/spec/logstash/java_pipeline_spec.rb
@@ -507,10 +507,16 @@ describe LogStash::JavaPipeline do
       pipeline.close
     end
 
-    it "should use LIR provided IDs" do
-      expect(pipeline.inputs.first.id).to eq(pipeline.lir.input_plugin_vertices.first.id)
-      expect(pipeline.filters.first.id).to eq(pipeline.lir.filter_plugin_vertices.first.id)
-      expect(pipeline.outputs.first.id).to eq(pipeline.lir.output_plugin_vertices.first.id)
+    it "should generate plugin ids" do
+      input_id = pipeline.inputs.first.id
+      filter_id = pipeline.filters.first.id
+      output_id = pipeline.outputs.first.id
+      [ input_id, filter_id, output_id ].each do |plugin_id|
+        expect(plugin_id).to match /([0-9]|[a-f])+/
+      end
+      expect( input_id ).to_not eq filter_id
+      expect( input_id ).to_not eq output_id
+      expect( output_id ).to_not eq filter_id
     end
   end
 

--- a/logstash-core/spec/logstash/plugin_spec.rb
+++ b/logstash-core/spec/logstash/plugin_spec.rb
@@ -411,8 +411,8 @@ describe LogStash::Plugin do
     context "when the id is not provided provided" do
       subject { plugin.new(config) }
 
-      it "return a human readable ID" do
-        expect(subject.id).to match(/^simple_plugin_/)
+      it "generates an id" do
+        expect(subject.id).to match /([0-9]|[a-f])+/
       end
     end
   end

--- a/logstash-core/src/main/java/org/logstash/RubyUtil.java
+++ b/logstash-core/src/main/java/org/logstash/RubyUtil.java
@@ -72,6 +72,7 @@ import org.logstash.instrument.metrics.SnapshotExt;
 import org.logstash.log.DeprecationLoggerExt;
 import org.logstash.log.LoggableExt;
 import org.logstash.log.LoggerExt;
+import org.logstash.log.PluginLoggerExt;
 import org.logstash.log.SlowLoggerExt;
 import org.logstash.plugins.HooksRegistryExt;
 import org.logstash.plugins.UniversalPluginExt;
@@ -477,6 +478,8 @@ public final class RubyUtil {
         final RubyModule loggingModule = LOGSTASH_MODULE.defineOrGetModuleUnder("Logging");
         LOGGER = loggingModule.defineClassUnder("Logger", RUBY.getObject(), LoggerExt::new);
         LOGGER.defineAnnotatedMethods(LoggerExt.class);
+        final RubyClass pluginLoggerClass = loggingModule.defineClassUnder("PluginLogger", LOGGER, PluginLoggerExt::new);
+        pluginLoggerClass.defineAnnotatedMethods(PluginLoggerExt.class);
         SLOW_LOGGER = loggingModule.defineClassUnder(
             "SlowLogger", RUBY.getObject(), SlowLoggerExt::new);
         SLOW_LOGGER.defineAnnotatedMethods(SlowLoggerExt.class);

--- a/logstash-core/src/main/java/org/logstash/common/Util.java
+++ b/logstash-core/src/main/java/org/logstash/common/Util.java
@@ -20,6 +20,8 @@
 
 package org.logstash.common;
 
+import org.apache.commons.codec.digest.DigestUtils;
+
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -39,6 +41,14 @@ public class Util {
         MessageDigest digest = defaultMessageDigest();
         byte[] hash = digest.digest(base.getBytes(StandardCharsets.UTF_8));
         return bytesToHexString(hash);
+    }
+
+    /**
+     * Generates a short digest from bytes.
+     * @return a hex digest string (16 characters long)
+     */
+    public static String shortDigest(final byte[] bytes) { // using MD5 for speed
+        return new DigestUtils("MD5").digestAsHex(bytes).substring(0, 16);
     }
 
     public static String bytesToHexString(byte[] bytes) {

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java
@@ -46,7 +46,8 @@ public abstract class AbstractFilterDelegatorExt extends RubyObject {
 
     protected AbstractNamespacedMetricExt metricEvents;
 
-    protected RubyString id;
+    protected String id;
+    private transient RubyString idString;
 
     protected LongCounter eventMetricOut;
 
@@ -60,7 +61,7 @@ public abstract class AbstractFilterDelegatorExt extends RubyObject {
 
     protected void initMetrics(final String id, final AbstractNamespacedMetricExt namespacedMetric) {
         final ThreadContext context = RubyUtil.RUBY.getCurrentContext();
-        this.id = RubyString.newString(context.runtime, id);
+        this.setId(context, id);
         synchronized(namespacedMetric.getMetric()) {
             metricEvents = namespacedMetric.namespace(context, MetricKeys.EVENTS_KEY);
             eventMetricOut = LongCounter.fromRubyBase(metricEvents, MetricKeys.OUT_KEY);
@@ -120,9 +121,18 @@ public abstract class AbstractFilterDelegatorExt extends RubyObject {
 
     protected abstract IRubyObject getConfigName(ThreadContext context);
 
-    @JRubyMethod(name = "id")
-    public IRubyObject getId() {
+    public String getId() {
         return id;
+    }
+
+    void setId(ThreadContext context, String id) {
+        this.id = id;
+        this.idString = (RubyString) RubyString.newString(context.runtime, id).freeze(context);
+    }
+
+    @JRubyMethod(name = "id")
+    public IRubyObject id() {
+        return idString == null ? getRuntime().getNil() : idString;
     }
 
     @JRubyMethod(name = "multi_filter")

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java
@@ -77,7 +77,7 @@ public abstract class AbstractFilterDelegatorExt extends RubyObject {
         return context.nil;
     }
 
-    protected abstract void doRegister(final ThreadContext context);
+    protected abstract IRubyObject doRegister(final ThreadContext context);
 
     @JRubyMethod
     public IRubyObject close(final ThreadContext context) {

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java
@@ -51,7 +51,8 @@ public abstract class AbstractOutputDelegatorExt extends RubyObject {
 
     private AbstractNamespacedMetricExt metricEvents;
 
-    private RubyString id;
+    private String id;
+    private transient RubyString idString;
 
     private LongCounter eventMetricOut;
 
@@ -90,9 +91,18 @@ public abstract class AbstractOutputDelegatorExt extends RubyObject {
         return getConfigName(context);
     }
 
-    @JRubyMethod(name = "id")
-    public IRubyObject getId() {
+    public String getId() {
         return id;
+    }
+
+    private void setId(ThreadContext context, String id) {
+        this.id = id;
+        this.idString = (RubyString) RubyString.newString(context.runtime, id).freeze(context);
+    }
+
+    @JRubyMethod(name = "id")
+    public IRubyObject id() {
+        return idString == null ? getRuntime().getNil() : idString;
     }
 
     @JRubyMethod
@@ -125,9 +135,9 @@ public abstract class AbstractOutputDelegatorExt extends RubyObject {
     }
 
     protected void initMetrics(final String id, final AbstractMetricExt metric) {
-        this.metric = metric;
         final ThreadContext context = RubyUtil.RUBY.getCurrentContext();
-        this.id = RubyString.newString(context.runtime, id);
+        this.setId(context, id);
+        this.metric = metric;
         synchronized (metric) {
             namespacedMetric = metric.namespace(context, context.runtime.newSymbol(id));
             metricEvents = namespacedMetric.namespace(context, MetricKeys.EVENTS_KEY);

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
@@ -81,9 +81,8 @@ public final class FilterDelegatorExt extends AbstractFilterDelegatorExt {
         super(runtime, metaClass);
     }
 
-    @Override
-    protected void doRegister(final ThreadContext context) {
-        filter.callMethod(context, "register");
+    protected IRubyObject registerImpl(final ThreadContext context) {
+        return filter.callMethod(context, "register");
     }
 
     @Override
@@ -117,6 +116,16 @@ public final class FilterDelegatorExt extends AbstractFilterDelegatorExt {
     }
 
     @Override
+    public IRubyObject doRegister(final ThreadContext context) {
+        try {
+            org.apache.logging.log4j.ThreadContext.put("plugin.id", getId());
+            return registerImpl(context);
+        } finally {
+            org.apache.logging.log4j.ThreadContext.remove("plugin.id");
+        }
+    }
+
+    @Override
     @SuppressWarnings({"rawtypes"})
     protected RubyArray doMultiFilter(final RubyArray batch) {
         try {
@@ -133,18 +142,16 @@ public final class FilterDelegatorExt extends AbstractFilterDelegatorExt {
     protected IRubyObject doFlush(final ThreadContext context, final RubyHash options) {
         try {
             org.apache.logging.log4j.ThreadContext.put("plugin.id", getId());
-
             return filter.callMethod(context, "flush", options);
         } finally {
             org.apache.logging.log4j.ThreadContext.remove("plugin.id");
         }
     }
 
-    @Override // do_close
+    @Override
     public IRubyObject doClose(final ThreadContext context) {
         try {
             org.apache.logging.log4j.ThreadContext.put("plugin.id", getId());
-
             return doCloseImpl(context);
         } finally {
             org.apache.logging.log4j.ThreadContext.remove("plugin.id");

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
@@ -131,7 +131,24 @@ public final class FilterDelegatorExt extends AbstractFilterDelegatorExt {
 
     @Override
     protected IRubyObject doFlush(final ThreadContext context, final RubyHash options) {
-        return filter.callMethod(context, "flush", options);
+        try {
+            org.apache.logging.log4j.ThreadContext.put("plugin.id", getId());
+
+            return filter.callMethod(context, "flush", options);
+        } finally {
+            org.apache.logging.log4j.ThreadContext.remove("plugin.id");
+        }
+    }
+
+    @Override // do_close
+    public IRubyObject doClose(final ThreadContext context) {
+        try {
+            org.apache.logging.log4j.ThreadContext.put("plugin.id", getId());
+
+            return doCloseImpl(context);
+        } finally {
+            org.apache.logging.log4j.ThreadContext.remove("plugin.id");
+        }
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
@@ -34,8 +34,6 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.instrument.metrics.AbstractNamespacedMetricExt;
 import org.logstash.instrument.metrics.counter.LongCounter;
 
-import java.util.UUID;
-
 import static org.logstash.RubyUtil.RUBY;
 
 @JRubyClass(name = "FilterDelegator")
@@ -73,7 +71,7 @@ public final class FilterDelegatorExt extends AbstractFilterDelegatorExt {
         filterMethod = filter.getMetaClass().searchMethod(FILTER_METHOD_NAME);
         flushes = filter.respondsTo("flush");
         filterClass = configNameDouble.getType();
-        this.setId(filter.getRuntime().getCurrentContext(), UUID.randomUUID().toString());
+        this.setId(filter.getRuntime().getCurrentContext(), RubyIntegration.generatePluginId());
         return this;
     }
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaFilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaFilterDelegatorExt.java
@@ -89,7 +89,8 @@ public class JavaFilterDelegatorExt extends AbstractFilterDelegatorExt {
     }
 
     @Override
-    protected void doRegister(ThreadContext context) {
+    protected IRubyObject doRegister(ThreadContext context) {
+        return context.nil;
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaInputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaInputDelegatorExt.java
@@ -61,11 +61,12 @@ public class JavaInputDelegatorExt extends RubyObject {
     public static JavaInputDelegatorExt create(final JavaBasePipelineExt pipeline,
                                                final AbstractNamespacedMetricExt metric, final Input input,
                                                final Map<String, Object> pluginArgs) {
+        final ThreadContext context = RubyUtil.RUBY.getCurrentContext();
         final JavaInputDelegatorExt instance =
                 new JavaInputDelegatorExt(RubyUtil.RUBY, RubyUtil.JAVA_INPUT_DELEGATOR_CLASS);
-        AbstractNamespacedMetricExt scopedMetric = metric.namespace(RubyUtil.RUBY.getCurrentContext(), RubyUtil.RUBY.newSymbol(input.getId()));
-        scopedMetric.gauge(RubyUtil.RUBY.getCurrentContext(), MetricKeys.NAME_KEY, RubyUtil.RUBY.newString(input.getName()));
-        instance.setMetric(RubyUtil.RUBY.getCurrentContext(), scopedMetric);
+        AbstractNamespacedMetricExt scopedMetric = metric.namespace(context, RubyUtil.RUBY.newSymbol(input.getId()));
+        scopedMetric.gauge(context, MetricKeys.NAME_KEY, RubyUtil.RUBY.newString(input.getName()));
+        instance.setMetric(context, scopedMetric);
         instance.input = input;
         instance.pipeline = pipeline;
         instance.initializeQueueWriter(pluginArgs);

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputDelegatorExt.java
@@ -97,8 +97,7 @@ OutputDelegatorExt extends AbstractOutputDelegatorExt {
     @Override
     protected void doOutput(final Collection<JrubyEventExtLibrary.RubyEvent> batch) {
         try {
-            final IRubyObject pluginId = this.getId();
-            org.apache.logging.log4j.ThreadContext.put("plugin.id", pluginId.toString());
+            org.apache.logging.log4j.ThreadContext.put("plugin.id", getId());
             strategy.multiReceive(RUBY.getCurrentContext(), (IRubyObject) batch);
         } catch (final InterruptedException ex) {
             throw new IllegalStateException(ex);

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputDelegatorExt.java
@@ -108,7 +108,12 @@ OutputDelegatorExt extends AbstractOutputDelegatorExt {
 
     @Override
     protected void close(final ThreadContext context) {
-        strategy.doClose(context);
+        try {
+            org.apache.logging.log4j.ThreadContext.put("plugin.id", getId());
+            strategy.doClose(context);
+        } finally {
+            org.apache.logging.log4j.ThreadContext.remove("plugin.id");
+        }
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputDelegatorExt.java
@@ -118,7 +118,12 @@ OutputDelegatorExt extends AbstractOutputDelegatorExt {
 
     @Override
     protected void doRegister(final ThreadContext context) {
-        strategy.register(context);
+        try {
+            org.apache.logging.log4j.ThreadContext.put("plugin.id", getId());
+            strategy.register(context);
+        } finally {
+            org.apache.logging.log4j.ThreadContext.remove("plugin.id");
+        }
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
@@ -21,11 +21,12 @@
 package org.logstash.config.ir.compiler;
 
 import co.elastic.logstash.api.Codec;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.jruby.RubyString;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.common.SourceWithMetadata;
 
-import java.util.UUID;
+import java.util.Random;
 
 /**
  * This class holds interfaces implemented by Ruby concrete classes.
@@ -53,8 +54,16 @@ public final class RubyIntegration {
 
     }
 
+    /**
+     * Generates a plugin id.
+     * @return a (random) generated plugin identifier
+     */
     public static String generatePluginId() {
-        return UUID.randomUUID().toString();
+        // similar to UUID.randomUUID() but fast - we do not need "secure" random ids
+        byte[] randomBytes = new byte[16];
+        new Random().nextBytes(randomBytes); // seeded from System.nanoTime()
+        // for improved log readability we limit the HEX string to a shorter length
+        return new DigestUtils("MD5").digestAsHex(randomBytes).substring(0, 16);
     }
 
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
@@ -25,7 +25,7 @@ import org.jruby.RubyString;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.common.SourceWithMetadata;
 
-import java.util.Map;
+import java.util.UUID;
 
 /**
  * This class holds interfaces implemented by Ruby concrete classes.
@@ -52,4 +52,9 @@ public final class RubyIntegration {
         Codec buildDefaultCodec(String codecName);
 
     }
+
+    public static String generatePluginId() {
+        return UUID.randomUUID().toString();
+    }
+
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
@@ -25,6 +25,7 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.jruby.RubyString;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.common.SourceWithMetadata;
+import org.logstash.common.Util;
 
 import java.util.Random;
 
@@ -63,7 +64,7 @@ public final class RubyIntegration {
         byte[] randomBytes = new byte[16];
         new Random().nextBytes(randomBytes); // seeded from System.nanoTime()
         // for improved log readability we limit the HEX string to a shorter length
-        return new DigestUtils("MD5").digestAsHex(randomBytes).substring(0, 16);
+        return Util.shortDigest(randomBytes);
     }
 
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/Vertex.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/Vertex.java
@@ -20,6 +20,7 @@
 
 package org.logstash.config.ir.graph;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.logstash.common.SourceWithMetadata;
@@ -224,7 +225,8 @@ public abstract class Vertex implements SourceComponent, HashableWithSource {
         // they have no source metadata. This might also be used in the future by alternate config languages which are
         // willing to take the hit.
         if (this.getSourceWithMetadata() != null) {
-            generatedId = Util.digest(this.graph.uniqueHash() + "|" + this.getSourceWithMetadata().uniqueHash());
+            final String uniqueString = this.graph.uniqueHash() + "|" + this.getSourceWithMetadata().uniqueHash();
+            generatedId = Util.shortDigest(uniqueString.getBytes(StandardCharsets.UTF_8));
         } else {
             generatedId = this.uniqueHash();
         }

--- a/logstash-core/src/main/java/org/logstash/execution/JavaBasePipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/JavaBasePipelineExt.java
@@ -67,8 +67,7 @@ public final class JavaBasePipelineExt extends AbstractPipelineExt {
     }
 
     @JRubyMethod(required = 4)
-    public JavaBasePipelineExt initialize(final ThreadContext context, final IRubyObject[] args)
-        throws IncompleteSourceWithMetadataException, NoSuchAlgorithmException {
+    public JavaBasePipelineExt initialize(final ThreadContext context, final IRubyObject[] args) {
         initialize(context, args[0], args[1], args[2]);
         lirExecution = new CompiledPipeline(
             lir,

--- a/logstash-core/src/main/java/org/logstash/execution/PipelineReporterExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/PipelineReporterExt.java
@@ -193,7 +193,7 @@ public final class PipelineReporterExt extends RubyBasicObject {
             final AbstractOutputDelegatorExt delegator = (AbstractOutputDelegatorExt) output;
             final RubyHash hash = RubyHash.newHash(context.runtime);
             hash.op_aset(context, TYPE_KEY, delegator.configName(context));
-            hash.op_aset(context, ID_KEY, delegator.getId());
+            hash.op_aset(context, ID_KEY, delegator.id());
             hash.op_aset(context, CONCURRENCY_KEY, delegator.concurrency(context));
             result.add(hash);
         });

--- a/logstash-core/src/main/java/org/logstash/log/DeprecationLoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/DeprecationLoggerExt.java
@@ -61,9 +61,9 @@ public class DeprecationLoggerExt extends RubyObject {
     @JRubyMethod(name = "deprecated", required = 1, optional = 1)
     public IRubyObject rubyDeprecated(final ThreadContext context, final IRubyObject[] args) {
         if (args.length > 1) {
-            logger.deprecated(args[0].asJavaString(), args[1]);
+            logger.deprecated(args[0].toString(), args[1]);
         } else {
-            logger.deprecated(args[0].asJavaString());
+            logger.deprecated(args[0].toString());
         }
         return this;
     }

--- a/logstash-core/src/main/java/org/logstash/log/LoggableExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/LoggableExt.java
@@ -35,8 +35,8 @@ import static org.logstash.log.SlowLoggerExt.toLong;
 
 /**
  * JRuby extension, it's part of log4j wrapping for JRuby.
- * */
-@JRubyModule(name = "Loggable")
+ */
+@JRubyModule(name = "LogStash::Util::Loggable")
 public final class LoggableExt {
 
     private LoggableExt() {
@@ -67,7 +67,7 @@ public final class LoggableExt {
         return self.getMetaClass().callMethod(context, "deprecation_logger");
     }
 
-    private static String log4jName(final RubyModule self) {
+    static String log4jName(final RubyModule self) {
         String name;
         if (self.getBaseName() == null) { // anonymous module/class
             RubyModule real = self;

--- a/logstash-core/src/main/java/org/logstash/log/LoggableExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/LoggableExt.java
@@ -53,18 +53,18 @@ public final class LoggableExt {
 
     @JRubyMethod
     public static IRubyObject logger(final ThreadContext context, final IRubyObject self) {
-        return self.getSingletonClass().callMethod(context, "logger");
+        return self.getMetaClass().callMethod(context, "logger");
     }
 
     @JRubyMethod(name = "slow_logger", required = 4)
     public static IRubyObject slowLogger(final ThreadContext context, final IRubyObject self,
         final IRubyObject[] args) {
-        return self.getSingletonClass().callMethod(context, "slow_logger", args);
+        return self.getMetaClass().callMethod(context, "slow_logger", args);
     }
 
     @JRubyMethod(name= "deprecation_logger")
     public static IRubyObject deprecationLogger(final ThreadContext context, final IRubyObject self) {
-        return self.getSingletonClass().callMethod(context, "deprecation_logger");
+        return self.getMetaClass().callMethod(context, "deprecation_logger");
     }
 
     private static String log4jName(final RubyModule self) {

--- a/logstash-core/src/main/java/org/logstash/log/LoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/LoggerExt.java
@@ -93,73 +93,73 @@ public class LoggerExt extends RubyObject {
 
     @JRubyMethod
     public IRubyObject trace(final IRubyObject msg) {
-        if (logger.isTraceEnabled()) logger.trace(msg.asJavaString());
+        logger.trace(msg.asString());
         return this;
     }
 
     @JRubyMethod
     public IRubyObject trace(final IRubyObject msg, final IRubyObject data) {
-        if (logger.isTraceEnabled()) logger.trace(msg.asJavaString(), data);
+        if (logger.isTraceEnabled()) logger.trace(msg.toString(), data);
         return this;
     }
 
     @JRubyMethod
     public IRubyObject debug(final IRubyObject msg) {
-        if (logger.isDebugEnabled()) logger.debug(msg.asJavaString());
+        logger.debug(msg.asString());
         return this;
     }
 
     @JRubyMethod
     public IRubyObject debug(final IRubyObject msg, final IRubyObject data) {
-        if (logger.isDebugEnabled()) logger.debug(msg.asJavaString(), data);
+        if (logger.isDebugEnabled()) logger.debug(msg.toString(), data);
         return this;
     }
 
     @JRubyMethod
     public IRubyObject info(final IRubyObject msg) {
-        if (logger.isInfoEnabled()) logger.info(msg.asJavaString());
+        logger.info(msg.asString());
         return this;
     }
 
     @JRubyMethod
     public IRubyObject info(final IRubyObject msg, final IRubyObject data) {
-        if (logger.isInfoEnabled()) logger.info(msg.asJavaString(), data);
+        if (logger.isInfoEnabled()) logger.info(msg.toString(), data);
         return this;
     }
 
     @JRubyMethod
     public IRubyObject warn(final IRubyObject msg) {
-        logger.warn(msg.asJavaString());
+        logger.warn(msg.asString());
         return this;
     }
 
     @JRubyMethod
     public IRubyObject warn(final IRubyObject msg, final IRubyObject data) {
-        logger.warn(msg.asJavaString(), data);
+        logger.warn(msg.toString(), data);
         return this;
     }
 
     @JRubyMethod
     public IRubyObject error(final IRubyObject msg) {
-        logger.error(msg.asJavaString());
+        logger.error(msg.asString());
         return this;
     }
 
     @JRubyMethod
     public IRubyObject error(final IRubyObject msg, final IRubyObject data) {
-        logger.error(msg.asJavaString(), data);
+        logger.error(msg.toString(), data);
         return this;
     }
 
     @JRubyMethod
     public IRubyObject fatal(final IRubyObject msg) {
-        logger.fatal(msg.asJavaString());
+        logger.fatal(msg.asString());
         return this;
     }
 
     @JRubyMethod
     public IRubyObject fatal(final IRubyObject msg, final IRubyObject data) {
-        logger.fatal(msg.asJavaString(), data);
+        logger.fatal(msg.toString(), data);
         return this;
     }
 

--- a/logstash-core/src/main/java/org/logstash/log/LoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/LoggerExt.java
@@ -40,16 +40,16 @@ import java.io.File;
 import java.net.URI;
 
 /**
- * JRuby extension, it's part of log4j wrapping for JRuby.
- * Wrapper log4j Logger as Ruby like class
- * */
-@JRubyClass(name = "Logger")
+ * JRuby extension, that wraps a (native) log4j2 logger.
+ * Provides a Ruby logger interface for Logstash.
+ */
+@JRubyClass(name = "LogStash::Logging::Logger")
 public class LoggerExt extends RubyObject {
 
     private static final long serialVersionUID = 1L;
 
     private static final Object CONFIG_LOCK = new Object();
-    private Logger logger;
+    Logger logger;
 
     public LoggerExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);
@@ -57,106 +57,206 @@ public class LoggerExt extends RubyObject {
 
     @JRubyMethod
     public LoggerExt initialize(final ThreadContext context, final IRubyObject loggerName) {
-        logger = LogManager.getLogger(loggerName.asJavaString());
+        initializeLogger(loggerName.asJavaString());
         return this;
     }
 
+    void initializeLogger(final String name) {
+        this.logger = LogManager.getLogger(name);
+    }
+
+    /**
+     * {@code logger.trace?}
+     * @param context JRuby context
+     * @return true/false
+     */
     @JRubyMethod(name = "trace?")
     public RubyBoolean isTrace(final ThreadContext context) {
         return logger.isTraceEnabled() ? context.tru : context.fals;
     }
 
+    /**
+     * {@code logger.debug?}
+     * @param context JRuby context
+     * @return true/false
+     */
     @JRubyMethod(name = "debug?")
     public RubyBoolean isDebug(final ThreadContext context) {
         return logger.isDebugEnabled() ? context.tru : context.fals;
     }
 
+    /**
+     * {@code logger.info?}
+     * @param context JRuby context
+     * @return true/false
+     */
     @JRubyMethod(name = "info?")
     public RubyBoolean isInfo(final ThreadContext context) {
         return logger.isInfoEnabled() ? context.tru : context.fals;
     }
 
+    /**
+     * {@code logger.error?}
+     * @param context JRuby context
+     * @return true/false
+     */
     @JRubyMethod(name = "error?")
     public RubyBoolean isError(final ThreadContext context) {
         return logger.isErrorEnabled() ? context.tru : context.fals;
     }
 
+    /**
+     * {@code logger.warn?}
+     * @param context JRuby context
+     * @return true/false
+     */
     @JRubyMethod(name = "warn?")
     public RubyBoolean isWarn(final ThreadContext context) {
         return logger.isWarnEnabled() ? context.tru : context.fals;
     }
 
+    /**
+     * {@code logger.fatal?}
+     * @param context JRuby context
+     * @return true/false
+     */
     @JRubyMethod(name = "fatal?")
     public RubyBoolean isFatal(final ThreadContext context) {
         return logger.isDebugEnabled() ? context.tru : context.fals;
     }
 
+    /**
+     * {@code logger.trace(msg)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject trace(final IRubyObject msg) {
         logger.trace(msg.asString());
         return this;
     }
 
+    /**
+     * {@code logger.trace(msg, data)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @param data additional contextual data to be logged
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject trace(final IRubyObject msg, final IRubyObject data) {
         if (logger.isTraceEnabled()) logger.trace(msg.toString(), data);
         return this;
     }
 
+    /**
+     * {@code logger.debug(msg)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject debug(final IRubyObject msg) {
         logger.debug(msg.asString());
         return this;
     }
 
+    /**
+     * {@code logger.debug(msg, data)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @param data additional contextual data to be logged
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject debug(final IRubyObject msg, final IRubyObject data) {
         if (logger.isDebugEnabled()) logger.debug(msg.toString(), data);
         return this;
     }
 
+    /**
+     * {@code logger.info(msg)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject info(final IRubyObject msg) {
         logger.info(msg.asString());
         return this;
     }
 
+    /**
+     * {@code logger.info(msg, data)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @param data additional contextual data to be logged
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject info(final IRubyObject msg, final IRubyObject data) {
         if (logger.isInfoEnabled()) logger.info(msg.toString(), data);
         return this;
     }
 
+    /**
+     * {@code logger.warn(msg)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject warn(final IRubyObject msg) {
         logger.warn(msg.asString());
         return this;
     }
 
+    /**
+     * {@code logger.warn(msg, data)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @param data additional contextual data to be logged
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject warn(final IRubyObject msg, final IRubyObject data) {
         logger.warn(msg.toString(), data);
         return this;
     }
 
+    /**
+     * {@code logger.error(msg)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject error(final IRubyObject msg) {
         logger.error(msg.asString());
         return this;
     }
 
+    /**
+     * {@code logger.error(msg, data)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @param data additional contextual data to be logged
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject error(final IRubyObject msg, final IRubyObject data) {
         logger.error(msg.toString(), data);
         return this;
     }
 
+    /**
+     * {@code logger.fatal(msg)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject fatal(final IRubyObject msg) {
         logger.fatal(msg.asString());
         return this;
     }
 
+    /**
+     * {@code logger.fatal(msg, data)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @param data additional contextual data to be logged
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject fatal(final IRubyObject msg, final IRubyObject data) {
         logger.fatal(msg.toString(), data);

--- a/logstash-core/src/main/java/org/logstash/log/LoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/LoggerExt.java
@@ -61,6 +61,11 @@ public class LoggerExt extends RubyObject {
         return this;
     }
 
+    @JRubyMethod(name = "trace?")
+    public RubyBoolean isTrace(final ThreadContext context) {
+        return logger.isTraceEnabled() ? context.tru : context.fals;
+    }
+
     @JRubyMethod(name = "debug?")
     public RubyBoolean isDebug(final ThreadContext context) {
         return logger.isDebugEnabled() ? context.tru : context.fals;
@@ -86,68 +91,75 @@ public class LoggerExt extends RubyObject {
         return logger.isDebugEnabled() ? context.tru : context.fals;
     }
 
-    @JRubyMethod(name = "trace?")
-    public RubyBoolean isTrace(final ThreadContext context) {
-        return logger.isDebugEnabled() ? context.tru : context.fals;
-    }
-
-    @JRubyMethod(name = "debug", required = 1, optional = 1)
-    public IRubyObject rubyDebug(final ThreadContext context, final IRubyObject[] args) {
-        if (args.length > 1) {
-            logger.debug(args[0].asJavaString(), args[1]);
-        } else {
-            logger.debug(args[0].asJavaString());
-        }
+    @JRubyMethod
+    public IRubyObject trace(final IRubyObject msg) {
+        if (logger.isTraceEnabled()) logger.trace(msg.asJavaString());
         return this;
     }
 
-    @JRubyMethod(name = "warn", required = 1, optional = 1)
-    public IRubyObject rubyWarn(final ThreadContext context, final IRubyObject[] args) {
-        if (args.length > 1) {
-            logger.warn(args[0].asJavaString(), args[1]);
-        } else {
-            logger.warn(args[0].asJavaString());
-        }
+    @JRubyMethod
+    public IRubyObject trace(final IRubyObject msg, final IRubyObject data) {
+        if (logger.isTraceEnabled()) logger.trace(msg.asJavaString(), data);
         return this;
     }
 
-    @JRubyMethod(name = "info", required = 1, optional = 1)
-    public IRubyObject rubyInfo(final ThreadContext context, final IRubyObject[] args) {
-        if (args.length > 1) {
-            logger.info(args[0].asJavaString(), args[1]);
-        } else {
-            logger.info(args[0].asJavaString());
-        }
+    @JRubyMethod
+    public IRubyObject debug(final IRubyObject msg) {
+        if (logger.isDebugEnabled()) logger.debug(msg.asJavaString());
         return this;
     }
 
-    @JRubyMethod(name = "error", required = 1, optional = 1)
-    public IRubyObject rubyError(final ThreadContext context, final IRubyObject[] args) {
-        if (args.length > 1) {
-            logger.error(args[0].asJavaString(), args[1]);
-        } else {
-            logger.error(args[0].asJavaString());
-        }
+    @JRubyMethod
+    public IRubyObject debug(final IRubyObject msg, final IRubyObject data) {
+        if (logger.isDebugEnabled()) logger.debug(msg.asJavaString(), data);
         return this;
     }
 
-    @JRubyMethod(name = "fatal", required = 1, optional = 1)
-    public IRubyObject rubyFatal(final ThreadContext context, final IRubyObject[] args) {
-        if (args.length > 1) {
-            logger.fatal(args[0].asJavaString(), args[1]);
-        } else {
-            logger.fatal(args[0].asJavaString());
-        }
+    @JRubyMethod
+    public IRubyObject info(final IRubyObject msg) {
+        if (logger.isInfoEnabled()) logger.info(msg.asJavaString());
         return this;
     }
 
-    @JRubyMethod(name = "trace", required = 1, optional = 1)
-    public IRubyObject rubyTrace(final ThreadContext context, final IRubyObject[] args) {
-        if (args.length > 1) {
-            logger.trace(args[0].asJavaString(), args[1]);
-        } else {
-            logger.trace(args[0].asJavaString());
-        }
+    @JRubyMethod
+    public IRubyObject info(final IRubyObject msg, final IRubyObject data) {
+        if (logger.isInfoEnabled()) logger.info(msg.asJavaString(), data);
+        return this;
+    }
+
+    @JRubyMethod
+    public IRubyObject warn(final IRubyObject msg) {
+        logger.warn(msg.asJavaString());
+        return this;
+    }
+
+    @JRubyMethod
+    public IRubyObject warn(final IRubyObject msg, final IRubyObject data) {
+        logger.warn(msg.asJavaString(), data);
+        return this;
+    }
+
+    @JRubyMethod
+    public IRubyObject error(final IRubyObject msg) {
+        logger.error(msg.asJavaString());
+        return this;
+    }
+
+    @JRubyMethod
+    public IRubyObject error(final IRubyObject msg, final IRubyObject data) {
+        logger.error(msg.asJavaString(), data);
+        return this;
+    }
+
+    @JRubyMethod
+    public IRubyObject fatal(final IRubyObject msg) {
+        logger.fatal(msg.asJavaString());
+        return this;
+    }
+
+    @JRubyMethod
+    public IRubyObject fatal(final IRubyObject msg, final IRubyObject data) {
+        logger.fatal(msg.asJavaString(), data);
         return this;
     }
 

--- a/logstash-core/src/main/java/org/logstash/log/PluginLoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/PluginLoggerExt.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.logstash.log;
+
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.anno.JRubyModule;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+/**
+ * A specialized {@link LoggerExt} that injects logging context information.
+ *
+ * Ruby interface is exactly the same as with `LogStash::Logging::Logger`.
+ *
+ * @since 7.15
+ */
+@JRubyModule(name = "LogStash::Logging::PluginLogger")
+public class PluginLoggerExt extends LoggerExt {
+
+    private static final long serialVersionUID = 1L;
+
+    static final String PLUGIN_ID_KEY = "plugin.id";
+
+    private String pluginId;
+
+    public PluginLoggerExt(final Ruby runtime, final RubyClass metaClass) {
+        super(runtime, metaClass);
+    }
+
+    @JRubyMethod
+    public LoggerExt initialize(final ThreadContext context, final IRubyObject plugin) {
+        initializeLogger(LoggableExt.log4jName(plugin.getMetaClass()));
+        this.pluginId = plugin.callMethod(context, "id").asJavaString();
+        return this;
+    }
+
+    @Override
+    public IRubyObject trace(final IRubyObject msg) {
+        if (logger.isTraceEnabled()) {
+            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+            logger.trace(msg.asString());
+
+            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        }
+        return this;
+    }
+
+    @Override
+    public IRubyObject trace(final IRubyObject msg, final IRubyObject data) {
+        if (logger.isTraceEnabled()) {
+            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+            logger.trace(msg.toString(), data);
+
+            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        }
+        return this;
+    }
+
+    @Override
+    public IRubyObject debug(final IRubyObject msg) {
+        if (logger.isDebugEnabled()) {
+            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+            logger.debug(msg.asString());
+
+            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        }
+        return this;
+    }
+
+    @Override
+    public IRubyObject debug(final IRubyObject msg, final IRubyObject data) {
+        if (logger.isDebugEnabled()) {
+            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+            logger.debug(msg.toString(), data);
+
+            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        }
+        return this;
+    }
+
+    @Override
+    public IRubyObject info(final IRubyObject msg) {
+        if (logger.isInfoEnabled()) {
+            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+            logger.info(msg.asString());
+
+            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        }
+        return this;
+    }
+
+    @Override
+    public IRubyObject info(final IRubyObject msg, final IRubyObject data) {
+        if (logger.isInfoEnabled()) {
+            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+            logger.info(msg.toString(), data);
+
+            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        }
+        return this;
+    }
+
+    @Override
+    public IRubyObject warn(final IRubyObject msg) {
+        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+        logger.warn(msg.asString());
+
+        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+
+        return this;
+    }
+
+    @Override
+    public IRubyObject warn(final IRubyObject msg, final IRubyObject data) {
+        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+        logger.warn(msg.toString(), data);
+
+        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+
+        return this;
+    }
+
+    @Override
+    public IRubyObject error(final IRubyObject msg) {
+        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+        logger.error(msg.asString());
+
+        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+
+        return this;
+    }
+
+    @Override
+    public IRubyObject error(final IRubyObject msg, final IRubyObject data) {
+        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+        logger.error(msg.toString(), data);
+
+        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+
+        return this;
+    }
+
+    @Override
+    public IRubyObject fatal(final IRubyObject msg) {
+        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+        logger.fatal(msg.asString());
+
+        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+
+        return this;
+    }
+
+    @Override
+    public IRubyObject fatal(final IRubyObject msg, final IRubyObject data) {
+        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+        logger.fatal(msg.toString(), data);
+
+        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+
+        return this;
+    }
+
+}

--- a/logstash-core/src/main/java/org/logstash/log/PluginLoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/PluginLoggerExt.java
@@ -57,11 +57,11 @@ public class PluginLoggerExt extends LoggerExt {
     @Override
     public IRubyObject trace(final IRubyObject msg) {
         if (logger.isTraceEnabled()) {
-            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+            boolean didSet = setPluginId(pluginId);
 
             logger.trace(msg.asString());
 
-            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+            removePluginId(didSet);
         }
         return this;
     }
@@ -69,11 +69,11 @@ public class PluginLoggerExt extends LoggerExt {
     @Override
     public IRubyObject trace(final IRubyObject msg, final IRubyObject data) {
         if (logger.isTraceEnabled()) {
-            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+            boolean didSet = setPluginId(pluginId);
 
             logger.trace(msg.toString(), data);
 
-            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+            removePluginId(didSet);
         }
         return this;
     }
@@ -81,11 +81,11 @@ public class PluginLoggerExt extends LoggerExt {
     @Override
     public IRubyObject debug(final IRubyObject msg) {
         if (logger.isDebugEnabled()) {
-            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+            boolean didSet = setPluginId(pluginId);
 
             logger.debug(msg.asString());
 
-            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+            removePluginId(didSet);
         }
         return this;
     }
@@ -93,11 +93,11 @@ public class PluginLoggerExt extends LoggerExt {
     @Override
     public IRubyObject debug(final IRubyObject msg, final IRubyObject data) {
         if (logger.isDebugEnabled()) {
-            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+            boolean didSet = setPluginId(pluginId);
 
             logger.debug(msg.toString(), data);
 
-            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+            removePluginId(didSet);
         }
         return this;
     }
@@ -105,11 +105,11 @@ public class PluginLoggerExt extends LoggerExt {
     @Override
     public IRubyObject info(final IRubyObject msg) {
         if (logger.isInfoEnabled()) {
-            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+            boolean didSet = setPluginId(pluginId);
 
             logger.info(msg.asString());
 
-            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+            removePluginId(didSet);
         }
         return this;
     }
@@ -117,79 +117,90 @@ public class PluginLoggerExt extends LoggerExt {
     @Override
     public IRubyObject info(final IRubyObject msg, final IRubyObject data) {
         if (logger.isInfoEnabled()) {
-            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+            boolean didSet = setPluginId(pluginId);
 
             logger.info(msg.toString(), data);
 
-            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+            removePluginId(didSet);
         }
         return this;
     }
 
     @Override
     public IRubyObject warn(final IRubyObject msg) {
-        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+        boolean didSet = setPluginId(pluginId);
 
         logger.warn(msg.asString());
 
-        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        removePluginId(didSet);
 
         return this;
     }
 
     @Override
     public IRubyObject warn(final IRubyObject msg, final IRubyObject data) {
-        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+        boolean didSet = setPluginId(pluginId);
 
         logger.warn(msg.toString(), data);
 
-        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        removePluginId(didSet);
 
         return this;
     }
 
     @Override
     public IRubyObject error(final IRubyObject msg) {
-        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+        boolean didSet = setPluginId(pluginId);
 
         logger.error(msg.asString());
 
-        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        removePluginId(didSet);
 
         return this;
     }
 
     @Override
     public IRubyObject error(final IRubyObject msg, final IRubyObject data) {
-        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+        boolean didSet = setPluginId(pluginId);
 
         logger.error(msg.toString(), data);
 
-        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        removePluginId(didSet);
 
         return this;
     }
 
     @Override
     public IRubyObject fatal(final IRubyObject msg) {
-        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+        boolean didSet = setPluginId(pluginId);
 
         logger.fatal(msg.asString());
 
-        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        removePluginId(didSet);
 
         return this;
     }
 
     @Override
     public IRubyObject fatal(final IRubyObject msg, final IRubyObject data) {
-        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+        boolean didSet = setPluginId(pluginId);
 
         logger.fatal(msg.toString(), data);
 
-        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        removePluginId(didSet);
 
         return this;
+    }
+
+    private static boolean setPluginId(final String pluginId) {
+        boolean found = org.apache.logging.log4j.ThreadContext.containsKey(PLUGIN_ID_KEY);
+        if (found) return false;
+        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+        return false;
+    }
+
+    private static void removePluginId(final boolean didSet) {
+        if (didSet) org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
     }
 
 }

--- a/logstash-core/src/main/java/org/logstash/log/SlowLoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/SlowLoggerExt.java
@@ -100,7 +100,7 @@ public class SlowLoggerExt extends RubyObject {
 
     @JRubyMethod(name = "on_event", required = 4)
     public IRubyObject onEvent(final ThreadContext context, final IRubyObject[] args) {
-        String message = args[0].asJavaString();
+        String message = args[0].toString();
         long eventDurationNanos = ((RubyNumeric)args[3]).getLongValue();
 
         if (warnThreshold >= 0 && eventDurationNanos > warnThreshold) {

--- a/logstash-core/src/main/java/org/logstash/plugins/codecs/Dots.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/codecs/Dots.java
@@ -36,6 +36,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
 
+import static org.logstash.config.ir.compiler.RubyIntegration.generatePluginId;
+
 /**
  * Java implementation of the "dots" codec
  * */
@@ -45,11 +47,11 @@ public class Dots implements Codec {
     private final String id;
 
     public Dots(final String id, final Configuration configuration, final Context context) {
-        this((id != null && !id.isEmpty()) ? id : UUID.randomUUID().toString());
+        this((id != null && !id.isEmpty()) ? id : generatePluginId());
     }
 
     public Dots(final Configuration configuration, final Context context) {
-        this(UUID.randomUUID().toString());
+        this(generatePluginId());
     }
 
     private Dots(String id) {
@@ -73,7 +75,7 @@ public class Dots implements Codec {
 
     @Override
     public Codec cloneCodec() {
-        return new Dots(UUID.randomUUID().toString());
+        return new Dots(generatePluginId());
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/plugins/codecs/Line.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/codecs/Line.java
@@ -41,9 +41,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 import java.util.function.Consumer;
 
+import static org.logstash.config.ir.compiler.RubyIntegration.generatePluginId;
 import static org.logstash.ObjectMappers.JSON_MAPPER;
 
 /**
@@ -86,7 +86,7 @@ public class Line implements Codec {
      */
     public Line(final String id, final Configuration configuration, final Context context) {
         this(context, configuration.get(DELIMITER_CONFIG), configuration.get(CHARSET_CONFIG), configuration.get(FORMAT_CONFIG),
-                (id != null && !id.isEmpty()) ? id : UUID.randomUUID().toString());
+                (id != null && !id.isEmpty()) ? id : generatePluginId());
     }
 
     /*
@@ -178,6 +178,6 @@ public class Line implements Codec {
 
     @Override
     public Codec cloneCodec() {
-        return new Line(context, delimiter, charset.name(), format, UUID.randomUUID().toString());
+        return new Line(context, delimiter, charset.name(), format, null);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/plugins/codecs/Plain.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/codecs/Plain.java
@@ -39,8 +39,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 import java.util.function.Consumer;
+
+import static org.logstash.config.ir.compiler.RubyIntegration.generatePluginId;
 
 /**
  * The plain codec accepts input bytes as events with no decoding beyond the application of a specified
@@ -77,7 +78,7 @@ public class Plain implements Codec {
      */
     public Plain(final String id, final Configuration configuration, final Context context) {
         this(context, configuration.get(CHARSET_CONFIG), configuration.get(FORMAT_CONFIG),
-                (id != null && !id.isEmpty()) ? id : UUID.randomUUID().toString());
+                (id != null && !id.isEmpty()) ? id : generatePluginId());
     }
     /**
      * @param configuration Logstash Configuration
@@ -136,6 +137,6 @@ public class Plain implements Codec {
 
     @Override
     public Codec cloneCodec() {
-        return new Plain(context, charset.name(), format, UUID.randomUUID().toString());
+        return new Plain(context, charset.name(), format, null);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java
@@ -82,6 +82,11 @@ public final class PluginFactoryExt extends RubyBasicObject
         return filterDelegatorClass.newInstance(context, filterInstance, id, Block.NULL_BLOCK);
     }
 
+    @JRubyMethod(name = "generate_plugin_id", meta = true)
+    public static IRubyObject generate_plugin_id(final ThreadContext context, final IRubyObject recv) {
+        return context.runtime.newString(RubyIntegration.generatePluginId());
+    }
+
     public PluginFactoryExt(final Ruby runtime, final RubyClass metaClass) {
         this(runtime, metaClass, new PluginLookup(PluginRegistry.getInstance(new AliasRegistry())));
     }

--- a/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java
@@ -284,11 +284,11 @@ public final class PluginFactoryExt extends RubyBasicObject
         final Optional<String> unprocessedId;
         if (source == null) {
             unprocessedId = extractId(() -> extractIdFromArgs(args),
-                                      this::generateUUID);
+                                      PluginFactoryExt::generatePluginId);
         } else {
             unprocessedId = extractId(() -> extractIdFromLIR(source),
                                       () -> extractIdFromArgs(args),
-                                      () -> generateUUIDForCodecs(type));
+                                      () -> generateCodecId(type));
         }
 
         return unprocessedId
@@ -328,13 +328,13 @@ public final class PluginFactoryExt extends RubyBasicObject
         }
     }
 
-    private Optional<String> generateUUID() {
-        return Optional.of(UUID.randomUUID().toString());
+    private static Optional<String> generatePluginId() {
+        return Optional.of(RubyIntegration.generatePluginId());
     }
 
-    private Optional<String> generateUUIDForCodecs(final PluginLookup.PluginType pluginType) {
+    private static Optional<String> generateCodecId(final PluginLookup.PluginType pluginType) {
         if (pluginType == PluginLookup.PluginType.CODEC) {
-            return generateUUID();
+            return generatePluginId();
         }
         return Optional.empty();
     }

--- a/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java
@@ -218,14 +218,15 @@ public final class PluginFactoryExt extends RubyBasicObject
         final PluginLookup.PluginClass pluginClass = pluginResolver.resolve(type, name);
         if (pluginClass.language() == PluginLookup.PluginLanguage.RUBY) {
 
-            final Map<String, Object> newArgs = new HashMap<>(args);
-            newArgs.put("id", id);
+            final RubyHash rubyArgs = RubyHash.newHash(context.runtime);
+            rubyArgs.replace(context, args);
+            rubyArgs.put("id", id); // auto converts String -> RubyString
+
             final RubyClass klass = (RubyClass) pluginClass.klass();
             final ExecutionContextExt executionCntx = executionContextFactory.create(
                     context, RubyUtil.RUBY.newString(id), klass.callMethod(context, "config_name")
             );
-            final RubyHash rubyArgs = RubyHash.newHash(context.runtime);
-            rubyArgs.putAll(newArgs);
+
             if (type == PluginLookup.PluginType.OUTPUT) {
                 return new OutputDelegatorExt(context.runtime, RubyUtil.RUBY_OUTPUT_DELEGATOR_CLASS).initialize(
                         context,

--- a/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java
@@ -294,7 +294,7 @@ public final class PluginFactoryExt extends RubyBasicObject
         } else {
             unprocessedId = extractId(() -> extractIdFromLIR(source),
                                       () -> extractIdFromArgs(args),
-                                      () -> generatePluginId(type));
+                                      () -> generatePluginId(type)); // codecs might fall through down here
         }
 
         return unprocessedId
@@ -339,7 +339,7 @@ public final class PluginFactoryExt extends RubyBasicObject
                 .filter(v -> v.getSourceWithMetadata() != null
                         && v.getSourceWithMetadata().equalsWithoutText(source))
                 .findFirst()
-                .map(Vertex::getExplicitId);
+                .map(Vertex::getId); // explicit id if set by user or generates one based on AST
     }
 
     ExecutionContextFactoryExt getExecutionContextFactory() {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->


## What does this PR do?

Improves logging experience for the user (as a minor side effect LS should be faster to generated plugin ids).

- ~**generated ids won't be recycled** -> on a restart new ids are generated even if the configuration did not change
  previously, the id generation mechanism always fell back to walking the AST to generate an id by hashing the tree~ _(EDIT: stricken. We rely on recycled ids)_
- ~generated **plugin ids will be shorter** (16 characters) instead of 36 hex chars - logs should be easier to read~ _(EDIT: stricken. loosely a breaking change given above)_
- loosened `logger(msg)` contract allows for logging any (`to_s`) message not just strings - just like Log4j2 loggers do
- an internal **`PluginLogger` gets introduced** to always have a `plugin.id` logging context w `plugin.logger ...`
- a (single) explicit `generatePluginId` implementation
  there's a change to use the same logic in tests -> tested plugin will no longer have the `name_...` prefix

Other changes:
- fixed `logger.trace?` (previously delegated to `logger.isDebugEnabled()`)

Breaking changes:

- ~ very low impact
```ruby
class LogStash::Input::SomePlugin < ...

  def initialize(params)
    logger.info "this would no longer work - previously did but only if not using @logger.info ..."
    super(params)
    # logging after super works fine
  end
...
```

- potential plugin test failures ... mocking such as the following would need updating*:
```ruby
  expect(LogStash::Codecs::Multiline).to receive(:logger).and_return(Mlc::MultilineLogTracer.new).at_least(:once)
```
  * *or keeping `def class.logger(plugin = self)` functional in a backwards compatible way*

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

Logs are Logstash's primary way of communicating with the user, always having a plugin id logged greatly improves the user (debugging) experience.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] TODO do we need to worry about always generating a random id for a codec
  like [we did](https://github.com/elastic/logstash/blob/15e2fdca409819fe589dbfdcf1e440ad5c99f8bf/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java#L231-L233) before this [got refactored](https://github.com/elastic/logstash/pull/12305)

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- https://github.com/logstash-plugins/logstash-mixin-ecs_compatibility_support/issues/7

## Logs

Sample (artificial) logging session (just to demonstrate plugins always log with their id as context):
```
[2021-07-27T14:32:34,501][INFO ][logstash.codecs.plain    ][955460acfaa1d9f2] REGISTER
[2021-07-27T14:32:34,643][INFO ][logstash.inputs.file     ][0138d563e04582e3] INITIALIZE {"path"=>"/var/log/auth.log", "id"=>"0138d563e04582e3"}
[2021-07-27T14:32:34,746][INFO ][logstash.filters.ruby    ][f569244cde563334] INITIALIZE
[2021-07-27T14:32:37,211][INFO ][logstash.filters.ruby    ][main][f569244cde563334] REGISTER
[2021-07-27T14:32:37,355][INFO ][logstash.javapipeline    ][main] Starting pipeline {:pipeline_id=>"main", "pipeline.workers"=>16, "pipeline.batch.size"=>125, "pipeline.batch.delay"=>50, "pipeline.max_inflight"=>2000, "pipeline.sources"=>["config string"], :thread=>"#<Thread:0x163b0af1 run>"}
[2021-07-27T14:32:38,790][INFO ][logstash.javapipeline    ][main] Pipeline Java execution initialization time {"seconds"=>1.43}
[2021-07-27T14:32:38,840][INFO ][logstash.inputs.file     ][main][0138d563e04582e3] REGISTER
[2021-07-27T14:32:38,943][INFO ][logstash.inputs.file     ][main][0138d563e04582e3] No sincedb_path set, generating one based on the "path" setting {:sincedb_path=>"/home/kares/workspace/work/elastic/logstash/data/plugins/inputs/file/.sincedb_0776ae3d702d482a9bdd8900c6550225", :path=>["/var/log/auth.log"]}
[2021-07-27T14:32:38,974][INFO ][logstash.javapipeline    ][main] Pipeline started {"pipeline.id"=>"main"}
[2021-07-27T14:32:39,000][INFO ][logstash.inputs.file     ][main][0138d563e04582e3] RUN
[2021-07-27T14:32:39,090][INFO ][filewatch.observingtail  ][main] START, creating Discoverer, Watch with file and sincedb collections
[2021-07-27T14:32:39,097][INFO ][logstash.agent           ] Pipelines running {:count=>1, :running_pipelines=>[:main], :non_running_pipelines=>[]}
[2021-07-27T14:32:39,678][INFO ][logstash.codecs.plain    ][main][955460acfaa1d9f2] DECODE: Jul 27 14:32:38 precision sshd[442003]: Connection closed by 127.0.0.1 port 53520 [preauth]
[2021-07-27T14:32:39,858][INFO ][logstash.filters.ruby    ][main][f569244cde563334] FILTER {"@version"=>"1", "@timestamp"=>2021-07-27T12:32:39.702Z, "message"=>"Jul 27 14:32:38 precision sshd[442003]: Connection closed by 127.0.0.1 port 53520 [preauth]", "host"=>"precision", "path"=>"/var/log/auth.log"}

```
