### PR TITLE
Move retrieval of Stack version from Gradle's configuration to execution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -473,9 +473,8 @@ tasks.register("copyFilebeat") {
         copy {
             from tarTree(resources.gzip(project.ext.filebeatDownloadLocation))
             into "./build/"
-
-            file("./build/${project.ext.unpackedFilebeatName}").renameTo('./build/filebeat')
         }
+        file("./build/${project.ext.unpackedFilebeatName}").renameTo('./build/filebeat')
         System.out.println "Unzipped ${project.ext.filebeatDownloadLocation} to ./build/filebeat"
         System.out.println "Deleting ${project.ext.filebeatDownloadLocation}"
         delete(project.ext.filebeatDownloadLocation)
@@ -561,13 +560,15 @@ tasks.register("deleteLocalEs", Delete) {
 tasks.register("copyEs"/*, Copy*/) {
     dependsOn = [downloadEs, deleteLocalEs]
     doLast {
+        println "copyEs executing.."
         copy {
             from tarTree(resources.gzip(project.ext.elasticsearchDownloadLocation))
             into "./build/"
-            file("./build/${project.ext.unpackedElasticsearchName}").renameTo('./build/elasticsearch')
-            System.out.println "Unzipped ${project.ext.elasticsearchDownloadLocation} to ./build/elasticsearch"
-            System.out.println "Deleting ${project.ext.elasticsearchDownloadLocation}"
         }
+
+        file("./build/${project.ext.unpackedElasticsearchName}").renameTo('./build/elasticsearch')
+        System.out.println "Unzipped ${project.ext.elasticsearchDownloadLocation} to ./build/elasticsearch"
+        System.out.println "Deleting ${project.ext.elasticsearchDownloadLocation}"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -158,27 +158,31 @@ tasks.register("configureArchitecture") {
 
 tasks.register("configureArtifactInfo") {
     dependsOn configureArchitecture
-    def versionQualifier = System.getenv('VERSION_QUALIFIER')
-    if (versionQualifier) {
-        version = "$version-$versionQualifier"
+    description "Set the url to download stack artifacts for select stack version"
+
+    doLast {
+        def versionQualifier = System.getenv('VERSION_QUALIFIER')
+        if (versionQualifier) {
+            version = "$version-$versionQualifier"
+        }
+
+        def isReleaseBuild = System.getenv('RELEASE') == "1" || versionQualifier
+        String apiResponse = artifactVersionsApi.toURL().text
+
+        def dlVersions = new JsonSlurper().parseText(apiResponse)
+        String qualifiedVersion = dlVersions['versions'].grep(isReleaseBuild ? ~/^${version}$/ : ~/^${version}-SNAPSHOT/)[0]
+        if (qualifiedVersion == null) {
+            throw new GradleException("could not find the current artifact from the artifact-api ${artifactVersionsApi} for ${version}")
+        }
+        // find latest reference to last build
+        String buildsListApi = "${artifactVersionsApi}/${qualifiedVersion}/builds/"
+        apiResponse = buildsListApi.toURL().text
+        def dlBuilds = new JsonSlurper().parseText(apiResponse)
+        def stackBuildVersion = dlBuilds["builds"][0]
+
+        project.ext.set("artifactApiVersionedBuildUrl", "${artifactVersionsApi}/${qualifiedVersion}/builds/${stackBuildVersion}")
+        project.ext.set("stackArtifactSuffix", qualifiedVersion)
     }
-
-    def isReleaseBuild = System.getenv('RELEASE') == "1" || versionQualifier
-    String apiResponse = artifactVersionsApi.toURL().text
-
-    def dlVersions = new JsonSlurper().parseText(apiResponse)
-    String qualifiedVersion = dlVersions['versions'].grep(isReleaseBuild ? ~/^${version}$/ : ~/^${version}-SNAPSHOT/)[0]
-    if (qualifiedVersion == null) {
-        throw new GradleException("could not find the current artifact from the artifact-api ${artifactVersionsApi} for ${version}")
-    }
-    // find latest reference to last build
-    String buildsListApi = "${artifactVersionsApi}/${qualifiedVersion}/builds/"
-    apiResponse = buildsListApi.toURL().text
-    def dlBuilds = new JsonSlurper().parseText(apiResponse)
-    def stackBuildVersion = dlBuilds["builds"][0]
-
-    project.ext.set("artifactApiVersionedBuildUrl", "${artifactVersionsApi}/${qualifiedVersion}/builds/${stackBuildVersion}")
-    project.ext.set("stackArtifactSuffix", qualifiedVersion)
 }
 
 abstract class SignAliasDefinitionsTask extends DefaultTask {
@@ -428,31 +432,33 @@ tasks.register("installIntegrationTestGems") {
   }
 }
 
-tasks.register("downloadFilebeat", Download) {
+tasks.register("downloadFilebeat"/*, Download*/) {
     dependsOn  configureArtifactInfo
     description "Download Filebeat Snapshot for current branch version: ${version}"
 
     project.ext.set("versionFound", true)
-
-    String downloadedFilebeatName = "filebeat-${project.ext.get("stackArtifactSuffix")}-${project.ext.get("beatsArchitecture")}"
-    project.ext.set("unpackedFilebeatName", downloadedFilebeatName)
-
-    // find url of build artifact
-    String artifactApiUrl = "${project.ext.get("artifactApiVersionedBuildUrl")}/projects/beats/packages/${downloadedFilebeatName}.tar.gz"
-    String apiResponse = artifactApiUrl.toURL().text
-    def buildUrls = new JsonSlurper().parseText(apiResponse)
-
-    project.ext.set("filebeatSnapshotUrl", System.getenv("FILEBEAT_SNAPSHOT_URL") ?: buildUrls["package"]["url"])
-    project.ext.set("filebeatDownloadLocation", "${projectDir}/build/${downloadedFilebeatName}.tar.gz")
-
-
-    src project.ext.filebeatSnapshotUrl
-    onlyIfNewer true
     inputs.file("${projectDir}/versions.yml")
-    outputs.file(project.ext.filebeatDownloadLocation)
-    dest new File(project.ext.filebeatDownloadLocation)
-    retries 3
+//    outputs.file(project.ext.filebeatDownloadLocation)
+
     doLast {
+        download {
+            String downloadedFilebeatName = "filebeat-${project.ext.get("stackArtifactSuffix")}-${project.ext.get("beatsArchitecture")}"
+            project.ext.set("unpackedFilebeatName", downloadedFilebeatName)
+
+            // find url of build artifact
+            String artifactApiUrl = "${project.ext.get("artifactApiVersionedBuildUrl")}/projects/beats/packages/${downloadedFilebeatName}.tar.gz"
+            String apiResponse = artifactApiUrl.toURL().text
+            def buildUrls = new JsonSlurper().parseText(apiResponse)
+
+            project.ext.set("filebeatSnapshotUrl", System.getenv("FILEBEAT_SNAPSHOT_URL") ?: buildUrls["package"]["url"])
+            project.ext.set("filebeatDownloadLocation", "${projectDir}/build/${downloadedFilebeatName}.tar.gz")
+
+            src project.ext.filebeatSnapshotUrl
+            onlyIfNewer true
+
+            dest new File(project.ext.filebeatDownloadLocation)
+            retries 3
+        }
         System.out.println "Downloaded to ${project.ext.filebeatDownloadLocation}"
     }
 }
@@ -461,12 +467,15 @@ tasks.register("deleteLocalFilebeat", Delete) {
     delete ('./build/filebeat')
 }
 
-tasks.register("copyFilebeat", Copy){
+tasks.register("copyFilebeat") {
     dependsOn = [downloadFilebeat, deleteLocalFilebeat]
-    from tarTree(resources.gzip(project.ext.filebeatDownloadLocation))
-    into "./build/"
     doLast {
-        file("./build/${project.ext.unpackedFilebeatName}").renameTo('./build/filebeat')
+        copy {
+            from tarTree(resources.gzip(project.ext.filebeatDownloadLocation))
+            into "./build/"
+
+            file("./build/${project.ext.unpackedFilebeatName}").renameTo('./build/filebeat')
+        }
         System.out.println "Unzipped ${project.ext.filebeatDownloadLocation} to ./build/filebeat"
         System.out.println "Deleting ${project.ext.filebeatDownloadLocation}"
         delete(project.ext.filebeatDownloadLocation)
@@ -477,64 +486,69 @@ tasks.register("checkEsSHA") {
     dependsOn  configureArtifactInfo
 
     description "Download ES version remote's fingerprint file"
+//  outputs.file("${projectDir}/build/${downloadedElasticsearchName}.tar.gz.SHA-512")
 
-    String downloadedElasticsearchName = "elasticsearch-${project.ext.get("stackArtifactSuffix")}-${project.ext.get("esArchitecture")}"
-    outputs.file("${projectDir}/build/${downloadedElasticsearchName}.tar.gz.SHA-512")
+    doLast {
+        String downloadedElasticsearchName = "elasticsearch-${project.ext.get("stackArtifactSuffix")}-${project.ext.get("esArchitecture")}"
 
-    // find url of build artifact
-    String artifactApiUrl = "${project.ext.get("artifactApiVersionedBuildUrl")}/projects/elasticsearch/packages/${downloadedElasticsearchName}.tar.gz"
-    String apiResponse = artifactApiUrl.toURL().text
-    def buildUrls = new JsonSlurper().parseText(apiResponse)
-    String remoteSHA = buildUrls.package.sha_url.toURL().text
 
-    def localESArchive = new File("${projectDir}/build/${downloadedElasticsearchName}.tar.gz")
-    if (localESArchive.exists()) {
-        // this create a file named localESArchive with ".SHA-512" postfix
-        ant.checksum(file: localESArchive, algorithm: "SHA-512", forceoverwrite: true)
+        // find url of build artifact
+        String artifactApiUrl = "${project.ext.get("artifactApiVersionedBuildUrl")}/projects/elasticsearch/packages/${downloadedElasticsearchName}.tar.gz"
+        String apiResponse = artifactApiUrl.toURL().text
+        def buildUrls = new JsonSlurper().parseText(apiResponse)
+        String remoteSHA = buildUrls.package.sha_url.toURL().text
 
-        File localESCalculatedSHAFile = new File("${projectDir}/build/${downloadedElasticsearchName}.tar.gz.SHA-512")
-        String localESCalculatedSHA = localESCalculatedSHAFile.text.trim()
-        def splitted = remoteSHA.split(' ')
-        String remoteSHACode = splitted[0]
-        if (localESCalculatedSHA != remoteSHACode) {
-            println "ES package calculated fingerprint is different from remote, deleting local archive"
-            delete(localESArchive)
-            delete(localESCalculatedSHA)
-        }
-    } else {
-        mkdir project.buildDir
-        // touch the SHA file else downloadEs task doesn't start, this file his input for the other task
-        new File("${projectDir}/build/${downloadedElasticsearchName}.tar.gz.SHA-512").withWriter {w ->
-            w << "${downloadedElasticsearchName} not yet downloaded"
-            w.close()
+        def localESArchive = new File("${projectDir}/build/${downloadedElasticsearchName}.tar.gz")
+        if (localESArchive.exists()) {
+            // this create a file named localESArchive with ".SHA-512" postfix
+            ant.checksum(file: localESArchive, algorithm: "SHA-512", forceoverwrite: true)
+
+            File localESCalculatedSHAFile = new File("${projectDir}/build/${downloadedElasticsearchName}.tar.gz.SHA-512")
+            String localESCalculatedSHA = localESCalculatedSHAFile.text.trim()
+            def splitted = remoteSHA.split(' ')
+            String remoteSHACode = splitted[0]
+            if (localESCalculatedSHA != remoteSHACode) {
+                println "ES package calculated fingerprint is different from remote, deleting local archive"
+                delete(localESArchive)
+                delete(localESCalculatedSHA)
+            }
+        } else {
+            mkdir project.buildDir
+            // touch the SHA file else downloadEs task doesn't start, this file his input for the other task
+            new File("${projectDir}/build/${downloadedElasticsearchName}.tar.gz.SHA-512").withWriter { w ->
+                w << "${downloadedElasticsearchName} not yet downloaded"
+                w.close()
+            }
         }
     }
 }
 
-tasks.register("downloadEs", Download) {
+tasks.register("downloadEs") {
     dependsOn  = [configureArtifactInfo, checkEsSHA]
     description "Download ES Snapshot for current branch version: ${version}"
 
-    String downloadedElasticsearchName = "elasticsearch-${project.ext.get("stackArtifactSuffix")}-${project.ext.get("esArchitecture")}"
-    project.ext.set("unpackedElasticsearchName", "elasticsearch-${project.ext.get("stackArtifactSuffix")}")
-
-    // find url of build artifact
-    String artifactApiUrl = "${project.ext.get("artifactApiVersionedBuildUrl")}/projects/elasticsearch/packages/${downloadedElasticsearchName}.tar.gz"
-    String apiResponse = artifactApiUrl.toURL().text
-    def buildUrls = new JsonSlurper().parseText(apiResponse)
-
-    project.ext.set("elasticsearchSnapshotURL", System.getenv("ELASTICSEARCH_SNAPSHOT_URL") ?: buildUrls["package"]["url"])
-    project.ext.set("elasticsearchDownloadLocation", "${projectDir}/build/${downloadedElasticsearchName}.tar.gz")
-
-    src project.ext.elasticsearchSnapshotURL
-    onlyIfNewer true
-    retries 3
     inputs.file("${projectDir}/versions.yml")
-//    inputs.file("${projectDir}/build/${downloadedElasticsearchName}.tar.gz.SHA-512")
-    outputs.file(project.ext.elasticsearchDownloadLocation)
-    dest new File(project.ext.elasticsearchDownloadLocation)
+//    outputs.file(project.ext.elasticsearchDownloadLocation)
 
     doLast {
+        download {
+            String downloadedElasticsearchName = "elasticsearch-${project.ext.get("stackArtifactSuffix")}-${project.ext.get("esArchitecture")}"
+            project.ext.set("unpackedElasticsearchName", "elasticsearch-${project.ext.get("stackArtifactSuffix")}")
+
+            // find url of build artifact
+            String artifactApiUrl = "${project.ext.get("artifactApiVersionedBuildUrl")}/projects/elasticsearch/packages/${downloadedElasticsearchName}.tar.gz"
+            String apiResponse = artifactApiUrl.toURL().text
+            def buildUrls = new JsonSlurper().parseText(apiResponse)
+
+            project.ext.set("elasticsearchSnapshotURL", System.getenv("ELASTICSEARCH_SNAPSHOT_URL") ?: buildUrls["package"]["url"])
+            project.ext.set("elasticsearchDownloadLocation", "${projectDir}/build/${downloadedElasticsearchName}.tar.gz")
+
+            src project.ext.elasticsearchSnapshotURL
+            onlyIfNewer true
+            retries 3
+            dest new File(project.ext.elasticsearchDownloadLocation)
+        }
+
         System.out.println "Downloaded to ${project.ext.elasticsearchDownloadLocation}"
     }
 }
@@ -544,15 +558,16 @@ tasks.register("deleteLocalEs", Delete) {
     delete ('./build/elasticsearch')
 }
 
-tasks.register("copyEs", Copy) {
+tasks.register("copyEs"/*, Copy*/) {
     dependsOn = [downloadEs, deleteLocalEs]
-    from tarTree(resources.gzip(project.ext.elasticsearchDownloadLocation))
-    into "./build/"
     doLast {
-        file("./build/${project.ext.unpackedElasticsearchName}").renameTo('./build/elasticsearch')
-        System.out.println "Unzipped ${project.ext.elasticsearchDownloadLocation} to ./build/elasticsearch"
-        System.out.println "Deleting ${project.ext.elasticsearchDownloadLocation}"
-//        delete(project.ext.elasticsearchDownloadLocation)
+        copy {
+            from tarTree(resources.gzip(project.ext.elasticsearchDownloadLocation))
+            into "./build/"
+            file("./build/${project.ext.unpackedElasticsearchName}").renameTo('./build/elasticsearch')
+            System.out.println "Unzipped ${project.ext.elasticsearchDownloadLocation} to ./build/elasticsearch"
+            System.out.println "Deleting ${project.ext.elasticsearchDownloadLocation}"
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -432,13 +432,12 @@ tasks.register("installIntegrationTestGems") {
   }
 }
 
-tasks.register("downloadFilebeat"/*, Download*/) {
+tasks.register("downloadFilebeat") {
     dependsOn  configureArtifactInfo
     description "Download Filebeat Snapshot for current branch version: ${version}"
 
     project.ext.set("versionFound", true)
     inputs.file("${projectDir}/versions.yml")
-//    outputs.file(project.ext.filebeatDownloadLocation)
 
     doLast {
         download {
@@ -485,7 +484,6 @@ tasks.register("checkEsSHA") {
     dependsOn  configureArtifactInfo
 
     description "Download ES version remote's fingerprint file"
-//  outputs.file("${projectDir}/build/${downloadedElasticsearchName}.tar.gz.SHA-512")
 
     doLast {
         String downloadedElasticsearchName = "elasticsearch-${project.ext.get("stackArtifactSuffix")}-${project.ext.get("esArchitecture")}"
@@ -509,16 +507,15 @@ tasks.register("checkEsSHA") {
             if (localESCalculatedSHA != remoteSHACode) {
                 println "ES package calculated fingerprint is different from remote, deleting local archive"
                 delete(localESArchive)
-                delete(localESCalculatedSHA)
             }
-        } else {
+        }/* else {
             mkdir project.buildDir
             // touch the SHA file else downloadEs task doesn't start, this file his input for the other task
             new File("${projectDir}/build/${downloadedElasticsearchName}.tar.gz.SHA-512").withWriter { w ->
                 w << "${downloadedElasticsearchName} not yet downloaded"
                 w.close()
             }
-        }
+        }*/
     }
 }
 
@@ -527,7 +524,6 @@ tasks.register("downloadEs") {
     description "Download ES Snapshot for current branch version: ${version}"
 
     inputs.file("${projectDir}/versions.yml")
-//    outputs.file(project.ext.elasticsearchDownloadLocation)
 
     doLast {
         download {
@@ -557,7 +553,7 @@ tasks.register("deleteLocalEs", Delete) {
     delete ('./build/elasticsearch')
 }
 
-tasks.register("copyEs"/*, Copy*/) {
+tasks.register("copyEs") {
     dependsOn = [downloadEs, deleteLocalEs]
     doLast {
         println "copyEs executing.."
@@ -567,8 +563,8 @@ tasks.register("copyEs"/*, Copy*/) {
         }
 
         file("./build/${project.ext.unpackedElasticsearchName}").renameTo('./build/elasticsearch')
-        System.out.println "Unzipped ${project.ext.elasticsearchDownloadLocation} to ./build/elasticsearch"
-        System.out.println "Deleting ${project.ext.elasticsearchDownloadLocation}"
+        println "Unzipped ${project.ext.elasticsearchDownloadLocation} to ./build/elasticsearch"
+        println "Deleting ${project.ext.elasticsearchDownloadLocation}"
     }
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
This PR moves the downloading of Elasticsearch and Filebeat artifacts, used in integration tests, to happen at Gradle's execution phase instead of configuration time. This let the configuration step to work also it the requested integration artifacts aren't yet published.

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
It has to be possible to run Gradle tasks related to package creation and running unit test also if the stack version defined in `versions.yml` is not yet available. In this case integration tests is admitted to fail.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] verify ruby and java unit tests works without downloading external dependencies
- [x] verify `rake artifact:all` build artifacts without downloading ES or Filebeat artifacts

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Modify `versions.yml` locally to a version not yet published, for example `7.15.0` and try to run the unit tests `./gradlew :logstash-core:unitTests` and  `./gradlew :logstash-core:rubyTests`. Those should  work without downloading any Elasticserach package, check `build/` folder. Run integration tests `./gradlew runIntegrationTest` and it should fail to find `7.15.0`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates to #13030
- Superseeds #13051

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
