### PR TITLE
Test: resolve integration failure due ECS mode

### DIFF
--- a/x-pack/qa/integration/monitoring/geoip_metric_spec.rb
+++ b/x-pack/qa/integration/monitoring/geoip_metric_spec.rb
@@ -12,7 +12,9 @@ describe "GeoIP database service" do
   let(:config) { input + filter + output }
 
   context "monitoring API with geoip plugin" do
-    let(:filter) { "filter { json { source => \\\"message\\\" } geoip { source => \\\"host\\\" } } " }
+    let(:filter) do
+      "filter { json { source => \\\"message\\\" } geoip { source => \\\"host\\\" target => \\\"geoip\\\" } } "
+    end
 
     it "should have geoip" do
       start_logstash


### PR DESCRIPTION
otherwise the integration spec causes a LogStash::ConfigurationError (on master due ecs_compatibility on by default):
`GeoIP Filter in ECS-Compatiblity mode requires a target when source
is not an ip sub-field, eg. [client][ip]`