### PR TITLE
Docs: keep elastic_app_search output meta-data

### DIFF
--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -428,6 +428,10 @@
     "default-plugins": true,
     "skip-list": false
   },
+  "logstash-output-elastic_app_search": {
+    "default-plugins": false,
+    "skip-list": true
+  },
   "logstash-output-elasticsearch": {
     "default-plugins": true,
     "core-specs": true,


### PR DESCRIPTION
follow-up on https://github.com/elastic/logstash/pull/12925 which: 
- added the `logstash-integration-elastic_enterprise_search` into meta-data
- while removing `logstash-output-elastic_app_search`

believe the removal is problematic since when generating the **plugin_version_docs.json** we end up with:
```json
    // ...
    "logstash-output-appsearch": {
      "version": "1.0.0.beta1",
      "from": "missing"
    },
    "logstash-output-elastic_app_search": {
      "version": "1.2.0",
      "from": "missing"
    }
```

expected behavior is that the old **logstash-output-elastic_app_search** should not be in the generated json,
restoring the listing for logstash-output-elastic_app_search (this PR) makes the entry disappear in the generated json.
(note: restoring the listing with props flipped is how [integration plugins were introduced in the past](https://github.com/elastic/logstash/commit/a6369bce50a32f6d6afa77e5170b4337c622390e#diff-0cd002df633688839640f2e57da26036032c5f54f2cc7d640d37c344b3de4c69))

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

PR should resolve https://github.com/elastic/docs-tools/issues/57

## Why is it important/What is the impact to the user?

N/A - this is a documentation generation related issue.
