### PR TITLE
Fix gradle stack version selection when a release is not yet published

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ ADD spec /opt/logstash/spec
 ADD qa /opt/logstash/qa
 ADD lib /opt/logstash/lib
 ADD pkg /opt/logstash/pkg
+ADD buildSrc /opt/logstash/buildSrc
 ADD tools /opt/logstash/tools
 ADD logstash-core /opt/logstash/logstash-core
 ADD logstash-core-plugin-api /opt/logstash/logstash-core-plugin-api

--- a/build.gradle
+++ b/build.gradle
@@ -166,6 +166,9 @@ tasks.register("configureArtifactInfo") {
 
     def versionSelector = new StackVersionSelector(artifactVersionsApi)
     String qualifiedVersion = versionSelector.selectClosestVersion(version)
+    if (qualifiedVersion != version) {
+        println "WARN version $version not yet published, swith automatically to $qualifiedVersion"
+    }
 
     // find latest reference to last build
     String buildsListApi = "${artifactVersionsApi}/${qualifiedVersion}/builds/"

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ apply from: "rubyUtils.gradle"
 import org.yaml.snakeyaml.Yaml
 import de.undercouch.gradle.tasks.download.Download
 import groovy.json.JsonSlurper
+import org.logstash.gradle.tooling.StackVersionSelector
 
 allprojects {
   group = 'org.logstash'
@@ -163,17 +164,12 @@ tasks.register("configureArtifactInfo") {
         version = "$version-$versionQualifier"
     }
 
-    def isReleaseBuild = System.getenv('RELEASE') == "1" || versionQualifier
-    String apiResponse = artifactVersionsApi.toURL().text
+    def versionSelector = new StackVersionSelector(artifactVersionsApi)
+    String qualifiedVersion = versionSelector.selectClosestVersion(version)
 
-    def dlVersions = new JsonSlurper().parseText(apiResponse)
-    String qualifiedVersion = dlVersions['versions'].grep(isReleaseBuild ? ~/^${version}$/ : ~/^${version}-SNAPSHOT/)[0]
-    if (qualifiedVersion == null) {
-        throw new GradleException("could not find the current artifact from the artifact-api ${artifactVersionsApi} for ${version}")
-    }
     // find latest reference to last build
     String buildsListApi = "${artifactVersionsApi}/${qualifiedVersion}/builds/"
-    apiResponse = buildsListApi.toURL().text
+    def apiResponse = buildsListApi.toURL().text
     def dlBuilds = new JsonSlurper().parseText(apiResponse)
     def stackBuildVersion = dlBuilds["builds"][0]
 

--- a/build.gradle
+++ b/build.gradle
@@ -167,7 +167,7 @@ tasks.register("configureArtifactInfo") {
     def versionSelector = new StackVersionSelector(artifactVersionsApi)
     String qualifiedVersion = versionSelector.selectClosestVersion(version)
     if (qualifiedVersion != version) {
-        println "WARN version $version not yet published, swith automatically to $qualifiedVersion"
+        println "WARN version $version does not yet exist or has not been published, switching to $qualifiedVersion"
     }
 
     // find latest reference to last build

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,8 @@
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'junit:junit:4.13'
+}
+

--- a/buildSrc/src/main/groovy/org/logstash/gradle/tooling/StackVersionSelector.groovy
+++ b/buildSrc/src/main/groovy/org/logstash/gradle/tooling/StackVersionSelector.groovy
@@ -5,11 +5,12 @@ import groovy.json.JsonSlurper
 
 class StackVersionSelector {
 
-   private final String artifactVersionsApi
+    private final String artifactVersionsApi
+    private final def versionComparator = new VersionComparator()
 
-   public StackVersionSelector(String artifactVersionsApi) {
-       this.artifactVersionsApi = artifactVersionsApi
-   }
+    public StackVersionSelector(String artifactVersionsApi) {
+        this.artifactVersionsApi = artifactVersionsApi
+    }
 
     def selectClosestVersion(String version) {
         String apiResponse = artifactVersionsApi.toURL().text
@@ -26,7 +27,85 @@ class StackVersionSelector {
         qualifiedVersion
     }
 
+    /**
+     * Suppose availableVersions is sorted in such a way that the SNAPSHOT version is before the release version,
+     * following the natural order of versions:
+     *  7.10.1-SNAPSHOT
+     *  7.10.1
+     *  7.11.0-SNAPSHOT
+     *  7.11.0
+     *  8.0.0-SNAPSHOT
+     *  8.0.0-alpha1
+     *  8.0.0-alpha2
+     *  8.0.0-rc1
+     *  8.0.0-rc2
+     *  8.0.0
+     * */
     protected def selectClosestInList(String version, List<String> availableVersions) {
-        availableVersions.grep( ~/^${version}/)[0]
+        for (int index = 0; index < availableVersions.size(); index++) {
+            String currentVersion = availableVersions[index]
+            if (currentVersion == version) {
+                return currentVersion
+            }
+            if (index == availableVersions.size() - 1) {
+                // last version
+                return currentVersion
+            }
+            if (versionComparator.compare(currentVersion, version) == -1 &&
+                    versionComparator.compare(availableVersions[index + 1], version) == 1) {
+                // 7.14.0 < 7.15.0 < 8.0.0-SNAPSHOT and 7.15.0 is not yet released
+                return currentVersion
+            }
+        }
+        throw new IllegalStateException("Never reach this point")
+    }
+
+    static class VersionComparator implements Comparator<String> {
+        private static final List<String> VERSION_SUFFIX_ORDER = ["SNAPSHOT", "alpha1", "alpha2", "rc1", "rc2"]
+
+        /**
+         * @return  1 s > t,
+         *          0 s == t,
+         *         -1 s < t
+         * */
+        @Override
+        int compare(String s, String t) {
+            if (!s.contains("-") && !t.contains("-"))
+                // no SNAPSHOT version, compare directly
+                return s <=> t
+            if (s.contains("-") && t.contains("-")) {
+                //both have a -SNAPSHOT or -alpha1 etc
+                String swd = s.split("-")[0]
+                String twd = t.split("-")[0]
+                if (swd == twd) {
+                    //for example 8.0.0-SNAPSHOT vs 8.0.0-alpha1
+                    String sSuffix = s.split("-")[1]
+                    String tSuffix = t.split("-")[1]
+                    int sSuffixOrder = VERSION_SUFFIX_ORDER.indexOf(sSuffix)
+                    int tSuffixOrder = VERSION_SUFFIX_ORDER.indexOf(tSuffix)
+                    if (sSuffixOrder < 0)
+                        throw new IllegalArgumentException("Found illegal version suffix for $s: [$sSuffix]")
+                    if (tSuffixOrder < 0)
+                        throw new IllegalArgumentException("Found illegal version suffix for $t: [$tSuffix]")
+
+                    return sSuffixOrder <=> tSuffixOrder
+                }
+                // different -SNAPSHOT versions, compare jus the version part
+                return swd <=> twd
+            }
+            // one between s and t has -SNAPSHOT
+            String swd = s.split("-")[0]
+            String twd = t.split("-")[0]
+            if (swd == twd) {
+                //both are same version
+                if (s.contains("-"))
+                    // the one with -SNAPSHOT has lower priority
+                    return -1
+                else
+                    return 1
+            }
+
+            return swd <=> twd
+        }
     }
 }

--- a/buildSrc/src/main/groovy/org/logstash/gradle/tooling/StackVersionSelector.groovy
+++ b/buildSrc/src/main/groovy/org/logstash/gradle/tooling/StackVersionSelector.groovy
@@ -58,15 +58,48 @@ class StackVersionSelector {
         throw new IllegalStateException("Never reach this point")
     }
 
+    static class Version implements Comparable<Version> {
+
+        final int major
+        final int minor
+        final int patch
+        private final String original
+
+        Version(String v) {
+            original = v
+            def splits = v.split("\\.")
+            major = splits[0] as int
+            minor = splits[1] as int
+            patch = splits[2] as int
+        }
+
+        @Override
+        int compareTo(Version version) {
+            if (major == version.major) {
+                if (minor == version.minor) {
+                    return patch <=> version.patch
+                } else {
+                    return minor <=> version.minor
+                }
+            } else {
+                return major <=> version.major
+            }
+        }
+
+        @Override
+        String toString() {
+            original
+        }
+    }
 
     static class StackVersion implements Comparable<StackVersion> {
-        final String version
+        final Version version
         final String suffix
         final def comparator = comparator()
 
         StackVersion(String fullVersion) {
             def splits = fullVersion.split("-")
-            version = splits[0]
+            version = new Version(splits[0])
             if (splits.length == 2) {
                 suffix = splits[1]
             }

--- a/buildSrc/src/main/groovy/org/logstash/gradle/tooling/StackVersionSelector.groovy
+++ b/buildSrc/src/main/groovy/org/logstash/gradle/tooling/StackVersionSelector.groovy
@@ -1,0 +1,32 @@
+package org.logstash.gradle.tooling
+
+import org.gradle.api.GradleException
+import groovy.json.JsonSlurper
+
+class StackVersionSelector {
+
+   private final String artifactVersionsApi
+
+   public StackVersionSelector(String artifactVersionsApi) {
+       this.artifactVersionsApi = artifactVersionsApi
+   }
+
+    def selectClosestVersion(String version) {
+        String apiResponse = artifactVersionsApi.toURL().text
+        def dlVersions = new JsonSlurper().parseText(apiResponse)
+        List<String> versions = dlVersions['versions']
+
+        def versionQualifier = System.getenv('VERSION_QUALIFIER')
+        def isReleaseBuild = System.getenv('RELEASE') == "1" || versionQualifier
+
+        String qualifiedVersion = selectClosestInList(isReleaseBuild ? version : "${version}-SNAPSHOT", versions)
+        if (qualifiedVersion == null) {
+            throw new GradleException("could not find the current artifact from the artifact-api ${artifactVersionsApi} for ${version}")
+        }
+        qualifiedVersion
+    }
+
+    protected def selectClosestInList(String version, List<String> availableVersions) {
+        availableVersions.grep( ~/^${version}/)[0]
+    }
+}

--- a/buildSrc/src/main/groovy/org/logstash/gradle/tooling/StackVersionSelector.groovy
+++ b/buildSrc/src/main/groovy/org/logstash/gradle/tooling/StackVersionSelector.groovy
@@ -75,15 +75,13 @@ class StackVersionSelector {
 
         @Override
         int compareTo(Version version) {
-            if (major == version.major) {
-                if (minor == version.minor) {
-                    return patch <=> version.patch
-                } else {
-                    return minor <=> version.minor
-                }
-            } else {
+            if (major != version.major) {
                 return major <=> version.major
             }
+            if (minor != version.minor) {
+                return minor <=> version.minor
+            }
+            return patch <=> version.patch
         }
 
         @Override

--- a/buildSrc/src/main/groovy/org/logstash/gradle/tooling/StackVersionSelector.groovy
+++ b/buildSrc/src/main/groovy/org/logstash/gradle/tooling/StackVersionSelector.groovy
@@ -21,7 +21,7 @@ class StackVersionSelector {
 
         String qualifiedVersion = selectClosestInList(StackVersion.asVersion(isReleaseBuild ? version : "${version}-SNAPSHOT"), versions)
         if (qualifiedVersion == null) {
-            throw new GradleException("could not find the current artifact from the artifact-api ${artifactVersionsApi} for ${version}")
+            throw new GradleException("Could not find Elastic Stack version ($version) in the artifact api (${artifactVersionsApi})")
         }
         qualifiedVersion
     }

--- a/buildSrc/src/test/groovy/org/logstash/gradle/tooling/StackVersionSelectorTest.groovy
+++ b/buildSrc/src/test/groovy/org/logstash/gradle/tooling/StackVersionSelectorTest.groovy
@@ -3,11 +3,6 @@ package org.logstash.gradle.tooling
 import org.junit.Test
 import org.junit.Before
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertFalse
-import static org.junit.Assert.assertNull
-import static org.junit.Assert.assertTrue
-
 class StackVersionSelectorTest {
 
     def versionsFixture = [
@@ -32,5 +27,41 @@ class StackVersionSelectorTest {
     @Test
     void "selectClosestInList should return the exact match when present"() {
         assert "7.14.0" == sut.selectClosestInList("7.14.0", versionsFixture)
+    }
+
+    @Test
+    void "selectClosestInList should return the previous closest version when exact match is not present"() {
+        assert "7.14.0" == sut.selectClosestInList("7.15.0", versionsFixture)
+    }
+
+    @Test
+    void "selectClosestInList should return the greatest version when the version is greater than the max"() {
+        assert "8.0.0-SNAPSHOT" == sut.selectClosestInList("8.0.0", versionsFixture)
+    }
+
+    @Test
+    void "versionComparator tests"() {
+        def versionComparator = new StackVersionSelector.VersionComparator()
+        assert -1 == versionComparator.compare("7.1.0", "7.2.1")
+        assert 1 == versionComparator.compare("7.2.1", "7.1.0")
+
+        assert 1 == versionComparator.compare("7.1.0", "7.1.0-SNAPSHOT")
+
+        assert 1 == versionComparator.compare("7.2.1-SNAPSHOT", "7.1.0-SNAPSHOT")
+
+        assert 1 == versionComparator.compare("7.2.1-SNAPSHOT", "7.1.0")
+
+        assert 1 == versionComparator.compare("7.2.1", "7.1.0-SNAPSHOT")
+
+        assert 1 == versionComparator.compare("8.0.0-alpha1", "7.1.0-SNAPSHOT")
+
+        assert 1 == versionComparator.compare("8.0.0-alpha1", "8.0.0-SNAPSHOT")
+
+        assert 1 == versionComparator.compare("8.0.0-rc1", "8.0.0-alpha2")
+
+        assert 1 == versionComparator.compare("8.0.0", "8.0.0-alpha2")
+
+        assert 1 == versionComparator.compare("8.0.0", "8.0.0-SNAPSHOT")
+
     }
 }

--- a/buildSrc/src/test/groovy/org/logstash/gradle/tooling/StackVersionSelectorTest.groovy
+++ b/buildSrc/src/test/groovy/org/logstash/gradle/tooling/StackVersionSelectorTest.groovy
@@ -49,6 +49,8 @@ class StackVersionSelectorTest {
 
         assert asVersion("7.1.0") > asVersion("7.1.0-SNAPSHOT")
 
+        assert asVersion("7.9.0") < asVersion("7.10.0")
+
         assert asVersion("7.2.1-SNAPSHOT") > asVersion("7.1.0-SNAPSHOT")
 
         assert asVersion("7.2.1-SNAPSHOT") > asVersion("7.1.0")

--- a/buildSrc/src/test/groovy/org/logstash/gradle/tooling/StackVersionSelectorTest.groovy
+++ b/buildSrc/src/test/groovy/org/logstash/gradle/tooling/StackVersionSelectorTest.groovy
@@ -1,0 +1,30 @@
+package org.logstash.gradle.tooling
+
+import org.junit.Test
+
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertNull
+import static org.junit.Assert.assertTrue
+
+class StackVersionSelectorTest {
+
+    @Test
+    void "selectClosestInList should return the exact match when present"() {
+        def sut = new StackVersionSelector("")
+
+        def result = sut.selectClosestInList("7.14.0", [
+                "6.8.17-SNAPSHOT",
+                "6.8.17",
+                "7.13.2-SNAPSHOT",
+                "7.13.2",
+                "7.13.3-SNAPSHOT",
+                "7.13.3",
+                "7.14.0-SNAPSHOT",
+                "7.14.0",
+                "8.0.0-SNAPSHOT"
+        ])
+
+        assert "7.14.0" == result
+    }
+}

--- a/buildSrc/src/test/groovy/org/logstash/gradle/tooling/StackVersionSelectorTest.groovy
+++ b/buildSrc/src/test/groovy/org/logstash/gradle/tooling/StackVersionSelectorTest.groovy
@@ -1,6 +1,7 @@
 package org.logstash.gradle.tooling
 
 import org.junit.Test
+import org.junit.Before
 
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertFalse
@@ -9,22 +10,27 @@ import static org.junit.Assert.assertTrue
 
 class StackVersionSelectorTest {
 
+    def versionsFixture = [
+            "6.8.17-SNAPSHOT",
+            "6.8.17",
+            "7.13.2-SNAPSHOT",
+            "7.13.2",
+            "7.13.3-SNAPSHOT",
+            "7.13.3",
+            "7.14.0-SNAPSHOT",
+            "7.14.0",
+            "8.0.0-SNAPSHOT"
+    ]
+
+    def sut
+
+    @Before
+    void setUp() {
+        sut = new StackVersionSelector("")
+    }
+
     @Test
     void "selectClosestInList should return the exact match when present"() {
-        def sut = new StackVersionSelector("")
-
-        def result = sut.selectClosestInList("7.14.0", [
-                "6.8.17-SNAPSHOT",
-                "6.8.17",
-                "7.13.2-SNAPSHOT",
-                "7.13.2",
-                "7.13.3-SNAPSHOT",
-                "7.13.3",
-                "7.14.0-SNAPSHOT",
-                "7.14.0",
-                "8.0.0-SNAPSHOT"
-        ])
-
-        assert "7.14.0" == result
+        assert "7.14.0" == sut.selectClosestInList("7.14.0", versionsFixture)
     }
 }

--- a/buildSrc/src/test/groovy/org/logstash/gradle/tooling/StackVersionSelectorTest.groovy
+++ b/buildSrc/src/test/groovy/org/logstash/gradle/tooling/StackVersionSelectorTest.groovy
@@ -3,18 +3,21 @@ package org.logstash.gradle.tooling
 import org.junit.Test
 import org.junit.Before
 
+import static org.logstash.gradle.tooling.StackVersionSelector.*
+import static org.logstash.gradle.tooling.StackVersionSelector.StackVersion.*
+
 class StackVersionSelectorTest {
 
     def versionsFixture = [
-            "6.8.17-SNAPSHOT",
-            "6.8.17",
-            "7.13.2-SNAPSHOT",
-            "7.13.2",
-            "7.13.3-SNAPSHOT",
-            "7.13.3",
-            "7.14.0-SNAPSHOT",
-            "7.14.0",
-            "8.0.0-SNAPSHOT"
+            asVersion("6.8.17-SNAPSHOT"),
+            asVersion("6.8.17"),
+            asVersion("7.13.2-SNAPSHOT"),
+            asVersion("7.13.2"),
+            asVersion("7.13.3-SNAPSHOT"),
+            asVersion("7.13.3"),
+            asVersion("7.14.0-SNAPSHOT"),
+            asVersion("7.14.0"),
+            asVersion("8.0.0-SNAPSHOT")
     ]
 
     def sut
@@ -26,42 +29,42 @@ class StackVersionSelectorTest {
 
     @Test
     void "selectClosestInList should return the exact match when present"() {
-        assert "7.14.0" == sut.selectClosestInList("7.14.0", versionsFixture)
+        assert "7.14.0" == sut.selectClosestInList(asVersion("7.14.0"), versionsFixture).toString()
     }
 
     @Test
     void "selectClosestInList should return the previous closest version when exact match is not present"() {
-        assert "7.14.0" == sut.selectClosestInList("7.15.0", versionsFixture)
+        assert "7.14.0" == sut.selectClosestInList(asVersion("7.15.0"), versionsFixture).toString()
     }
 
     @Test
     void "selectClosestInList should return the greatest version when the version is greater than the max"() {
-        assert "8.0.0-SNAPSHOT" == sut.selectClosestInList("8.0.0", versionsFixture)
+        assert "8.0.0-SNAPSHOT" == sut.selectClosestInList(asVersion("8.0.0"), versionsFixture).toString()
     }
 
     @Test
-    void "versionComparator tests"() {
-        def versionComparator = new StackVersionSelector.VersionComparator()
-        assert -1 == versionComparator.compare("7.1.0", "7.2.1")
-        assert 1 == versionComparator.compare("7.2.1", "7.1.0")
+    void "compare StackVersion tests"() {
+        def versionComparator = StackVersionSelector.StackVersion.comparator()
 
-        assert 1 == versionComparator.compare("7.1.0", "7.1.0-SNAPSHOT")
+        assert -1 == versionComparator.compare(asVersion("7.1.0"), asVersion("7.2.1"))
+        assert 1 == versionComparator.compare(asVersion("7.2.1"), asVersion("7.1.0"))
 
-        assert 1 == versionComparator.compare("7.2.1-SNAPSHOT", "7.1.0-SNAPSHOT")
+        assert 1 == versionComparator.compare(asVersion("7.1.0"), asVersion("7.1.0-SNAPSHOT"))
 
-        assert 1 == versionComparator.compare("7.2.1-SNAPSHOT", "7.1.0")
+        assert 1 == versionComparator.compare(asVersion("7.2.1-SNAPSHOT"), asVersion("7.1.0-SNAPSHOT"))
 
-        assert 1 == versionComparator.compare("7.2.1", "7.1.0-SNAPSHOT")
+        assert 1 == versionComparator.compare(asVersion("7.2.1-SNAPSHOT"), asVersion("7.1.0"))
 
-        assert 1 == versionComparator.compare("8.0.0-alpha1", "7.1.0-SNAPSHOT")
+        assert 1 == versionComparator.compare(asVersion("7.2.1"), asVersion("7.1.0-SNAPSHOT"))
 
-        assert 1 == versionComparator.compare("8.0.0-alpha1", "8.0.0-SNAPSHOT")
+        assert 1 == versionComparator.compare(asVersion("8.0.0-alpha1"), asVersion("7.1.0-SNAPSHOT"))
 
-        assert 1 == versionComparator.compare("8.0.0-rc1", "8.0.0-alpha2")
+        assert 1 == versionComparator.compare(asVersion("8.0.0-alpha1"), asVersion("8.0.0-SNAPSHOT"))
 
-        assert 1 == versionComparator.compare("8.0.0", "8.0.0-alpha2")
+        assert 1 == versionComparator.compare(asVersion("8.0.0-rc1"), asVersion("8.0.0-alpha2"))
 
-        assert 1 == versionComparator.compare("8.0.0", "8.0.0-SNAPSHOT")
+        assert 1 == versionComparator.compare(asVersion("8.0.0"), asVersion("8.0.0-alpha2"))
 
+        assert 1 == versionComparator.compare(asVersion("8.0.0"), asVersion("8.0.0-SNAPSHOT"))
     }
 }

--- a/buildSrc/src/test/groovy/org/logstash/gradle/tooling/StackVersionSelectorTest.groovy
+++ b/buildSrc/src/test/groovy/org/logstash/gradle/tooling/StackVersionSelectorTest.groovy
@@ -44,27 +44,25 @@ class StackVersionSelectorTest {
 
     @Test
     void "compare StackVersion tests"() {
-        def versionComparator = StackVersionSelector.StackVersion.comparator()
+        assert asVersion("7.1.0") < asVersion("7.2.1")
+        assert asVersion("7.2.1") > asVersion("7.1.0")
 
-        assert -1 == versionComparator.compare(asVersion("7.1.0"), asVersion("7.2.1"))
-        assert 1 == versionComparator.compare(asVersion("7.2.1"), asVersion("7.1.0"))
+        assert asVersion("7.1.0") > asVersion("7.1.0-SNAPSHOT")
 
-        assert 1 == versionComparator.compare(asVersion("7.1.0"), asVersion("7.1.0-SNAPSHOT"))
+        assert asVersion("7.2.1-SNAPSHOT") > asVersion("7.1.0-SNAPSHOT")
 
-        assert 1 == versionComparator.compare(asVersion("7.2.1-SNAPSHOT"), asVersion("7.1.0-SNAPSHOT"))
+        assert asVersion("7.2.1-SNAPSHOT") > asVersion("7.1.0")
 
-        assert 1 == versionComparator.compare(asVersion("7.2.1-SNAPSHOT"), asVersion("7.1.0"))
+        assert asVersion("7.2.1") > asVersion("7.1.0-SNAPSHOT")
 
-        assert 1 == versionComparator.compare(asVersion("7.2.1"), asVersion("7.1.0-SNAPSHOT"))
+        assert asVersion("8.0.0-alpha1") > asVersion("7.1.0-SNAPSHOT")
 
-        assert 1 == versionComparator.compare(asVersion("8.0.0-alpha1"), asVersion("7.1.0-SNAPSHOT"))
+        assert asVersion("8.0.0-alpha1") > asVersion("8.0.0-SNAPSHOT")
 
-        assert 1 == versionComparator.compare(asVersion("8.0.0-alpha1"), asVersion("8.0.0-SNAPSHOT"))
+        assert asVersion("8.0.0-rc1") > asVersion("8.0.0-alpha2")
 
-        assert 1 == versionComparator.compare(asVersion("8.0.0-rc1"), asVersion("8.0.0-alpha2"))
+        assert asVersion("8.0.0") > asVersion("8.0.0-alpha2")
 
-        assert 1 == versionComparator.compare(asVersion("8.0.0"), asVersion("8.0.0-alpha2"))
-
-        assert 1 == versionComparator.compare(asVersion("8.0.0"), asVersion("8.0.0-SNAPSHOT"))
+        assert asVersion("8.0.0") > asVersion("8.0.0-SNAPSHOT")
     }
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
Modifies the logic of stack version's selection. From the "exact version match" passes to the "closest version", this change is useful when new Logstash versions are inserted into `versions.yml` and those versions are not yet published as artifacts.
During the build Elasticsearch and Filebeat versions are downloaded, when the bump of a new version is happening and those artifacts aren't yet published the build would fail. To avoid the fail this PR implements a logic of best match, so for example is last published version is `7.14.2` and the `versions.yml` is update to build the version `7.15.0` which doesn't exists, the build script force the stack version to `7.14.2` in this way the integration tests are able to succeed.

In particular this PR adds in `buildSrc` a couple of support classes (`StackVersionSelector` and `StackVersionSelector.StackVersion`) to implement the version selection logic described above.

Fixes #13030

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
From the developer that's used to build Logstash from sources (and CI) this change fix a problem happening during versions bumps.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] try a full build changing `versions.yml` to a future not yet published version

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
- edit locally `versions.yml` changing the stack version to something next to be released, for example `7.15.0` something not present in [the artifacts registry](https://artifacts-api.elastic.co/v1/versions)
```
logstash: 7.15.0
logstash-core: 7.15.0
```
- try this on `master` and it fails, try it in this branch and success, logging the fact the version used is `7.14.0`, the previous closest version.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates to #13030

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
