### PR TITLE
Fix LS benchmarking tool to work with releases >= 7.10.0

### DIFF
--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/LogstashInstallation.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/LogstashInstallation.java
@@ -114,12 +114,73 @@ public interface LogstashInstallation {
 
         private static void download(final File pwd, final String version)
             throws IOException, NoSuchAlgorithmException {
-            LsBenchDownloader.downloadDecompress(
-                pwd,
-                String.format(
-                    "https://artifacts.elastic.co/downloads/logstash/logstash-%s.zip", version
-                )
-            );
+
+            final String arch = retrieveCPUArchitecture();
+            final String os = retrieveOS();
+            final String extension = "windows".equals(os) ? "zip" : "tar.gz";
+
+            final String downloadUrl;
+            if (compareVersions(version, "7.10.0") >= 0) {
+                // version >= 7.10.0 url format
+                downloadUrl = String.format(
+                        "https://artifacts.elastic.co/downloads/logstash/logstash-%s-%s-%s.%s", version, os, arch, extension
+                );
+            } else {
+                // version < 7.10.0 url format
+                downloadUrl = String.format(
+                        "https://artifacts.elastic.co/downloads/logstash/logstash-%s.%s", version, extension
+                );
+            }
+
+            LsBenchDownloader.downloadDecompress(pwd, downloadUrl);
+        }
+
+        private static int compareVersions(String s, String t) {
+            final String[] sSplits = s.split("\\.");
+            final int sMajor = Integer.parseInt(sSplits[0]);
+            final int sMinor = Integer.parseInt(sSplits[1]);
+            final int sPatch = Integer.parseInt(sSplits[2]);
+
+            final String[] tSplits = t.split("\\.");
+            final int tMajor = Integer.parseInt(tSplits[0]);
+            final int tMinor = Integer.parseInt(tSplits[1]);
+            final int tPatch = Integer.parseInt(tSplits[2]);
+
+            if (sMajor == tMajor) {
+                if (sMinor == tMinor) {
+                    return Integer.compare(sPatch, tPatch);
+                } else {
+                    return Integer.compare(sMinor, tMinor);
+                }
+            } else {
+                return Integer.compare(sMajor, tMajor);
+            }
+        }
+
+        private static String retrieveOS() {
+            String osName = System.getProperty("os.name");
+            if (osName.matches("Mac OS X")) {
+                return "darwin";
+            }
+            if (osName.matches("[Ll]inux")) {
+                return "linux";
+            }
+            if (osName.matches("Windows")) {
+                return "windows";
+            }
+            throw new IllegalArgumentException("Unrecognized OS: " + osName);
+        }
+
+        private static String retrieveCPUArchitecture() {
+            final String arch = System.getProperty("os.arch");
+            switch (arch) {
+                case "aarch64":
+                    return "aarch64";
+                case "amd64":
+                    return "x86_64";
+                default:
+                    return arch;
+            }
         }
 
         private static LogstashInstallation setup(final Path location) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Fixes the Logstash benchmarking tool to work with Logstash versions above 7.10.0

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
Starting with version 7.10.0 the name of LS packages changed, adding os and CPU architecture in the name. This change broke the downloading of those from the benchmarking tool. This commit fixes it, composing correctly the name, based on the version it has to download


## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
Let the user to be able to launch the benchmark tool with any Logstash version

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] try to run the tool with `java -cp 'build/libs/benchmark-cli.jar:build/libs/*' org.logstash.benchmark.cli.Main --workdir=/tmp/benchmark --testcase=baseline --distribution-version=7.12.0` from `tools/benchmark-cli` directory

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
- create the jars for the tool `./gradlew assemble`
- `cd tools/benchmark-cli`
- run `java -cp 'build/libs/benchmark-cli.jar:build/libs/*' org.logstash.benchmark.cli.Main --workdir=/tmp/benchmark --testcase=baseline --distribution-version=7.12.0` and check the tool completes successfully

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
Failure example:
```
andrea@kalispera benchmark-cli (master) $ java -cp 'build/libs/benchmark-cli.jar:build/libs/*' org.logstash.benchmark.cli.Main --workdir=/tmp/benchmark2 --testcase=baseline --distribution-version=7.12.0
Logstash Benchmark
------------------------------------------
Benchmarking Version: 7.12.0
Logstash Parameters: -w 2 -b 128
Running Test Case: baseline (x1)
------------------------------------------
Downloading Logstash 7.12.0.
Finished downloading Logstash.
Exception in thread "main" java.lang.IllegalStateException: Failed to set /tmp/benchmark2/ls-release-7.12.0/logstash-7.12.0/vendor/jruby/bin/jruby executable
	at org.logstash.benchmark.cli.util.LsBenchFileUtil.ensureExecutable(LsBenchFileUtil.java:53)
	at org.logstash.benchmark.cli.LogstashInstallation$FromLocalPath.<init>(LogstashInstallation.java:149)
	at org.logstash.benchmark.cli.LogstashInstallation$FromRelease.setup(LogstashInstallation.java:126)
	at org.logstash.benchmark.cli.LogstashInstallation$FromRelease.<init>(LogstashInstallation.java:88)
	at org.logstash.benchmark.cli.util.LsBenchLsSetup.setupLS(LsBenchLsSetup.java:55)
	at org.logstash.benchmark.cli.Main.execute(Main.java:213)
```
