### PR TITLE
[7.x] Docs: keep elastic_app_search output meta-data (#13048)

### DIFF
--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -428,6 +428,10 @@
     "default-plugins": true,
     "skip-list": false
   },
+  "logstash-output-elastic_app_search": {
+    "default-plugins": false,
+    "skip-list": true
+  },
   "logstash-output-elasticsearch": {
     "default-plugins": true,
     "core-specs": true,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Docs: keep elastic_app_search output meta-data (#13048)