### PR TITLE
Backport PR #13071 to 7.14: [Test] Fix Unix acceptance tests

### DIFF
--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/list.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/list.rb
@@ -30,7 +30,7 @@ shared_examples "logstash list" do |logstash|
     end
 
     let(:plugin_name) { /logstash-(?<type>\w+)-(?<name>\w+)/ }
-    let(:plugin_name_with_version) { /#{plugin_name}\s\(\d+\.\d+.\d+(.\w+)?\)/ }
+    let(:plugin_name_with_version) { /(\s*[├└]──\s*)?#{plugin_name}\s(\(\d+\.\d+.\d+(.\w+)?\)|\(alias\))/ }
 
     context "without a specific plugin" do
       it "display a list of plugins" do
@@ -61,7 +61,7 @@ shared_examples "logstash list" do |logstash|
           # ~~~
           if match[:type] == 'integration'
             while line = stdout.gets
-              match = line.match(/^(?: [├└]── )#{plugin_name}$/)
+              match = line.match(/^(?: [├└]──\s+)#{plugin_name}$/)
               expect(match).to_not be_nil
               break if line.start_with?(' └')
             end

--- a/qa/config/platforms.json
+++ b/qa/config/platforms.json
@@ -1,18 +1,17 @@
 { 
   "latest": "5.0.0-alpha3",
   "platforms" : {
-    "ubuntu-1204": { "box": "elastic/ubuntu-12.04-x86_64", "type": "debian" },
-    "ubuntu-1404": { "box": "elastic/ubuntu-14.04-x86_64", "type": "debian", "specific": true },
-    "ubuntu-1604": { "box": "elastic/ubuntu-16.04-x86_64", "type": "debian", "experimental": true },
-    "centos-6": { "box": "elastic/centos-6-x86_64", "type": "redhat" },
+    "ubuntu-1604": { "box": "elastic/ubuntu-16.04-x86_64", "type": "debian" },
+    "ubuntu-1804": { "box": "elastic/ubuntu-18.04-x86_64", "type": "debian" },
     "centos-7": { "box": "elastic/centos-7-x86_64", "type": "redhat" },
     "oel-6": { "box": "elastic/oraclelinux-6-x86_64", "type": "redhat" },
     "oel-7": { "box": "elastic/oraclelinux-7-x86_64", "type": "redhat" },
-    "fedora-22": { "box": "elastic/fedora-22-x86_64", "type": "redhat", "experimental": true },
-    "fedora-23": { "box": "elastic/fedora-23-x86_64", "type": "redhat", "experimental": true },
-    "debian-8": { "box": "elastic/debian-8-x86_64", "type": "debian", "specific":  true },
-    "opensuse-13": { "box": "elastic/opensuse-13-x86_64", "type": "suse" },
+    "fedora-28": { "box": "elastic/fedora-28-x86_64", "type": "redhat", "experimental": true },
+    "fedora-29": { "box": "elastic/fedora-29-x86_64", "type": "redhat", "experimental": true },
+    "debian-8": { "box": "elastic/debian-8-x86_64", "type": "debian" },
+    "debian-9": { "box": "elastic/debian-9-x86_64", "type": "debian" },
     "sles-11": { "box": "elastic/sles-11-x86_64", "type": "suse", "specific": true },
-    "sles-12": { "box": "elastic/sles-12-x86_64", "type": "suse", "specific": true }
+    "sles-12": { "box": "elastic/sles-12-x86_64", "type": "suse", "specific": true },
+    "opensuse-13": { "box": "elastic/opensuse-13-x86_64", "type": "suse" }
   }
 }

--- a/qa/vagrant/command.rb
+++ b/qa/vagrant/command.rb
@@ -62,7 +62,7 @@ module LogStash
       response = run(cmd, debug)
 
       unless response.success?
-        raise CommandError, "CMD: #{cmd} STDERR: #{response.stderr}"
+        raise CommandError, "CMD: #{cmd} STDERR: #{response.stderr}, stdout: #{response.stdout}"
       end
       response
     end


### PR DESCRIPTION
Backport PR #13071 to 7.14. Original message:

This PR contains commits attempting to fix the broken acceptance tests:

* Fix the set of test platforms used to run unix acceptance tests

Modernizes the list of OS's used in acceptance tests, to the most modern OS's available at https://app.vagrantup.com/elastic,. This removes the centos-6 platform from the build, which is past end-of-life and fails vagrant bootstrapping, causing the build to fail.

This is more of band-aid than anything - in the longer term, we should remove these vagrant based tests completely, and rely
on the build infrastructure to perform OS-based acceptance tests.

* Fix regexes for plugin list tests. …

Fixes tests to support the plugin alias feature. This introduced a new format for
entries emitted by `bin/logstash-plugin list`:

eg
```
└── logstash-input-elastic_agent (alias)
```

This commit fixes the test to account for this change, and whitespace variances.


## Release notes
[rn:skip]

