### PR TITLE
GeoIP remove multiple databases copy in multiple instances

### DIFF
--- a/x-pack/lib/filters/geoip/database_manager.rb
+++ b/x-pack/lib/filters/geoip/database_manager.rb
@@ -33,11 +33,10 @@ module LogStash module Filters module Geoip class DatabaseManager
   #TODO remove vendor_path
   def initialize(geoip, database_path, database_type, vendor_path)
     @geoip = geoip
-    self.class.prepare_cc_db
     @mode = database_path.nil? ? :online : :offline
     @mode = :disabled # This is a temporary change that turns off the database manager until it is ready for general availability.
     @database_type = database_type
-    @database_path = patch_database_path(database_path)
+    @database_path = ::Dir.glob(::File.join(LogStash::Environment::LOGSTASH_HOME, "vendor", "**", "GeoLite2-#{database_type}.mmdb")).first
 
     if @mode == :online
       logger.info "By not manually configuring a database path with `database =>`, you accepted and agreed MaxMind EULA. "\


### PR DESCRIPTION
This is a disabled mode and is not required to copy databases to `path.data`
This PR points database path to the original vendor path.
`database_type` is either "ASN" or "City"

Fixed: #13072