### PR TITLE
Fix: make sure field ref cache is (LRU) bound

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -191,9 +191,9 @@ dependencies {
     }
     implementation 'org.javassist:javassist:3.26.0-GA'
     testImplementation "org.apache.logging.log4j:log4j-core:${log4jVersion}:tests"
-    testImplementation 'org.hamcrest:hamcrest:2.2'
-    testImplementation 'org.hamcrest:hamcrest-library:2.2'
-    testImplementation 'junit:junit:4.12'
+    //testImplementation 'org.hamcrest:hamcrest:2.2'
+    //testImplementation 'org.hamcrest:hamcrest-library:2.2'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.hamcrest:hamcrest:2.2'
     testImplementation 'net.javacrumbs.json-unit:json-unit:2.3.0'
     testImplementation 'org.elasticsearch:securemock:1.2'

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -191,10 +191,9 @@ dependencies {
     }
     implementation 'org.javassist:javassist:3.26.0-GA'
     testImplementation "org.apache.logging.log4j:log4j-core:${log4jVersion}:tests"
-    //testImplementation 'org.hamcrest:hamcrest:2.2'
-    //testImplementation 'org.hamcrest:hamcrest-library:2.2'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.hamcrest:hamcrest:2.2'
+    testImplementation 'org.hamcrest:hamcrest-library:2.2'
     testImplementation 'net.javacrumbs.json-unit:json-unit:2.3.0'
     testImplementation 'org.elasticsearch:securemock:1.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -194,6 +194,7 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest:2.2'
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
     testImplementation 'junit:junit:4.12'
+    testImplementation 'org.hamcrest:hamcrest:2.2'
     testImplementation 'net.javacrumbs.json-unit:json-unit:2.3.0'
     testImplementation 'org.elasticsearch:securemock:1.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'

--- a/logstash-core/src/main/java/org/logstash/FieldReference.java
+++ b/logstash-core/src/main/java/org/logstash/FieldReference.java
@@ -22,9 +22,7 @@ package org.logstash;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -65,11 +63,6 @@ public final class FieldReference {
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
 
     /**
-     * Holds all existing {@link FieldReference} instances for de-duplication.
-     */
-    private static final Map<FieldReference, FieldReference> DEDUP = new HashMap<>(64);
-
-    /**
      * The tokenizer that will be used when parsing field references
      */
     private static final StrictTokenizer TOKENIZER = new StrictTokenizer();
@@ -78,7 +71,7 @@ public final class FieldReference {
      * Unique {@link FieldReference} pointing at the timestamp field in a {@link Event}.
      */
     public static final FieldReference TIMESTAMP_REFERENCE =
-        deduplicate(new FieldReference(EMPTY_STRING_ARRAY, Event.TIMESTAMP, DATA_CHILD));
+            new FieldReference(EMPTY_STRING_ARRAY, Event.TIMESTAMP, DATA_CHILD);
 
     private static final FieldReference METADATA_PARENT_REFERENCE =
         new FieldReference(EMPTY_STRING_ARRAY, Event.METADATA, META_PARENT);
@@ -179,22 +172,6 @@ public final class FieldReference {
     }
 
     /**
-     * De-duplicates instances using {@link FieldReference#DEDUP}. This method must be
-     * {@code synchronized} since we are running non-atomic get-put sequence on
-     * {@link FieldReference#DEDUP}.
-     * @param parsed FieldReference to de-duplicate
-     * @return De-duplicated FieldReference
-     */
-    private static synchronized FieldReference deduplicate(final FieldReference parsed) {
-        FieldReference ret = DEDUP.get(parsed);
-        if (ret == null) {
-            DEDUP.put(parsed, parsed);
-            ret = parsed;
-        }
-        return ret;
-    }
-
-    /**
      * Effective hashcode implementation using knowledge of field types.
      * @param key Key Field
      * @param path Path Field
@@ -209,15 +186,6 @@ public final class FieldReference {
         }
         hash = prime * hash + key.hashCode();
         return prime * hash + type;
-    }
-
-    private static FieldReference parseToCache(final String reference) {
-        FieldReference result = parse(reference);
-        if (CACHE.size() < 10_000) {
-            result = deduplicate(result);
-            CACHE.put(reference, result);
-        }
-        return result;
     }
 
     private static FieldReference parse(final CharSequence reference) {

--- a/logstash-core/src/main/java/org/logstash/FieldReference.java
+++ b/logstash-core/src/main/java/org/logstash/FieldReference.java
@@ -215,7 +215,7 @@ public final class FieldReference {
     private static FieldReference parse(final CharSequence reference) {
         final List<String> path = TOKENIZER.tokenize(reference);
 
-        final String key = path.remove(path.size() - 1).intern();
+        final String key = path.remove(path.size() - 1);
         final boolean empty = path.isEmpty();
         if (empty && key.equals(Event.METADATA)) {
             return METADATA_PARENT_REFERENCE;

--- a/logstash-core/src/main/java/org/logstash/FieldReference.java
+++ b/logstash-core/src/main/java/org/logstash/FieldReference.java
@@ -89,7 +89,7 @@ public final class FieldReference {
             deduplicate(new FieldReference(EMPTY_STRING_ARRAY, Event.TIMESTAMP, DATA_CHILD));
 
     private static final FieldReference METADATA_PARENT_REFERENCE =
-            deduplicate(new FieldReference(EMPTY_STRING_ARRAY, Event.METADATA, META_PARENT));
+            new FieldReference(EMPTY_STRING_ARRAY, Event.METADATA, META_PARENT);
 
     static final int CACHE_MAXIMUM_SIZE = 10_000;
 

--- a/logstash-core/src/main/java/org/logstash/FieldReference.java
+++ b/logstash-core/src/main/java/org/logstash/FieldReference.java
@@ -53,17 +53,17 @@ public final class FieldReference {
 
     /**
      * This type indicates that the referenced that is the metadata of an {@link Event} found in
-     * {@link Event#metadata}.
+     * {@link Event#getMetadata()}.
      */
     public static final int META_PARENT = 0;
 
     /**
-     * This type indicates that the referenced data must be looked up from {@link Event#metadata}.
+     * This type indicates that the referenced data must be looked up from {@link Event#getMetadata()}.
      */
     public static final int META_CHILD = 1;
 
     /**
-     * This type indicates that the referenced data must be looked up from {@link Event#data}.
+     * This type indicates that the referenced data must be looked up from {@link Event#getData()}.
      */
     private static final int DATA_CHILD = -1;
 
@@ -200,6 +200,14 @@ public final class FieldReference {
     @Override
     public int hashCode() {
         return hash;
+    }
+
+    @Override
+    public String toString() {
+        List<String> fullPath = new ArrayList<>(Arrays.asList(path));
+        fullPath.add(key);
+        return getClass().getName() + "@" + Integer.toHexString(System.identityHashCode(this)) +
+                '{' + fullPath.stream().collect(Collectors.joining(".")) + '}';
     }
 
     /**

--- a/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
+++ b/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
@@ -78,31 +78,29 @@ public final class FieldReferenceTest {
         assertThat(cacheSize, greaterThan(FieldReference.CACHE_MAXIMUM_SIZE / 2));
     }
 
-//    @Test
-//    public void testDeduplicationWithWeakRefs() {
-//        for (int i = 0; i < FieldReference.CACHE_MAXIMUM_SIZE; ++i) {
-//            assertNotNull( FieldReference.from(String.format("[dedup][%d]", i)) );
-//        }
-//
-//        // NOTE: weak refs are hard to test - we just loosely assert map is not growing "too much"
-//
-//        // deduplication logic should not grow map indefinitely :
-//        System.gc();
-//        for (int i = 0; i < 10_000; ++i) {
-//            assertNotNull( FieldReference.from(String.format("[dedup1][%d]", i)) );
-//        }
-//        System.gc();
-//        for (int i = 0; i < 100_000; ++i) {
-//            assertNotNull( FieldReference.from(String.format("[dedup2][%d]", i)) );
-//        }
-//        System.gc(); System.gc();
-//        for (int i = 0; i < 1_000_000; ++i) { // TODO: depends on the heap size / gc used
-//            assertNotNull( FieldReference.from(String.format("[dedup3][%d]", i)) );
-//        }
-//        System.gc(); System.gc();
-//
-//        assertThat(FieldReference.DEDUP.size(), lessThan(1_000_000));
-//    }
+    @Test
+    public void testDeduplicationWithWeakRefs() {
+        for (int i = 0; i < FieldReference.CACHE_MAXIMUM_SIZE; ++i) {
+            assertNotNull( FieldReference.from(String.format("[dedup][%d]", i)) );
+        }
+
+        // NOTE: weak refs are hard to test - we just loosely assert map is not growing "too much"
+
+        for (int i = 0; i < 10_000; ++i) {
+            assertNotNull( FieldReference.from(String.format("[dedup1][%d]", i)) );
+        }
+        System.gc();
+        for (int i = 0; i < 100_000; ++i) {
+            assertNotNull( FieldReference.from(String.format("[dedup2][%d]", i)) );
+        }
+        System.gc();
+        for (int i = 0; i < 1_000_000; ++i) { // TODO: depends on the heap size / gc used
+            assertNotNull( FieldReference.from(String.format("[dedup3][%d]", i)) );
+        }
+        System.gc();
+
+        assertThat(FieldReference.DEDUP.size(), lessThan(1_000_000));
+    }
 
     @Test
     public void testParseSingleBareField() throws Exception {

--- a/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
+++ b/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.number.OrderingComparison.lessThanOrEqualTo;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertSame;
 
 public final class FieldReferenceTest {
 
@@ -43,7 +43,8 @@ public final class FieldReferenceTest {
 
     @Test
     public void deduplicatesTimestamp() {
-        assertTrue(FieldReference.from("@timestamp") == FieldReference.from("[@timestamp]"));
+        assertSame(FieldReference.TIMESTAMP_REFERENCE, FieldReference.from("@timestamp"));
+        assertSame(FieldReference.from("@timestamp"), FieldReference.from("[@timestamp]"));
     }
 
     @Test
@@ -59,7 +60,7 @@ public final class FieldReferenceTest {
     public void testCacheUpperBound() {
         final int initial = (int) FieldReference.CACHE.size();
         for (int i = 0; i < FieldReference.CACHE_MAXIMUM_SIZE - initial + 10; ++i) {
-            FieldReference.from(String.format("[array][%d]", i));
+            assertNotNull( FieldReference.from(String.format("[array][%d]", i)) );
         }
         final int cacheSize = (int) FieldReference.CACHE.size();
         assertThat(cacheSize, lessThanOrEqualTo(FieldReference.CACHE_MAXIMUM_SIZE));
@@ -69,7 +70,7 @@ public final class FieldReferenceTest {
     @Test
     public void testRubyCacheUpperBound() {
         for (int i = 0; i < FieldReference.CACHE_MAXIMUM_SIZE + 100; ++i) {
-            FieldReference.from(RubyUtil.RUBY.newString(String.format("[ruby_array][%d]", i)));
+            FieldReference.from(RubyUtil.RUBY.newString(String.format("[some_stuff][%d]", i)));
         }
         final int cacheSize = (int) FieldReference.RUBY_CACHE.size();
         assertThat(cacheSize, lessThanOrEqualTo(FieldReference.CACHE_MAXIMUM_SIZE));

--- a/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
+++ b/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
+import static org.hamcrest.number.OrderingComparison.lessThan;
 import static org.hamcrest.number.OrderingComparison.lessThanOrEqualTo;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -76,6 +77,32 @@ public final class FieldReferenceTest {
         assertThat(cacheSize, lessThanOrEqualTo(FieldReference.CACHE_MAXIMUM_SIZE));
         assertThat(cacheSize, greaterThan(FieldReference.CACHE_MAXIMUM_SIZE / 2));
     }
+
+//    @Test
+//    public void testDeduplicationWithWeakRefs() {
+//        for (int i = 0; i < FieldReference.CACHE_MAXIMUM_SIZE; ++i) {
+//            assertNotNull( FieldReference.from(String.format("[dedup][%d]", i)) );
+//        }
+//
+//        // NOTE: weak refs are hard to test - we just loosely assert map is not growing "too much"
+//
+//        // deduplication logic should not grow map indefinitely :
+//        System.gc();
+//        for (int i = 0; i < 10_000; ++i) {
+//            assertNotNull( FieldReference.from(String.format("[dedup1][%d]", i)) );
+//        }
+//        System.gc();
+//        for (int i = 0; i < 100_000; ++i) {
+//            assertNotNull( FieldReference.from(String.format("[dedup2][%d]", i)) );
+//        }
+//        System.gc(); System.gc();
+//        for (int i = 0; i < 1_000_000; ++i) { // TODO: depends on the heap size / gc used
+//            assertNotNull( FieldReference.from(String.format("[dedup3][%d]", i)) );
+//        }
+//        System.gc(); System.gc();
+//
+//        assertThat(FieldReference.DEDUP.size(), lessThan(1_000_000));
+//    }
 
     @Test
     public void testParseSingleBareField() throws Exception {

--- a/logstash-core/src/test/java/org/logstash/ValuefierTest.java
+++ b/logstash-core/src/test/java/org/logstash/ValuefierTest.java
@@ -34,12 +34,11 @@ import org.jruby.java.proxies.ConcreteJavaProxy;
 import org.jruby.java.proxies.MapJavaProxy;
 import org.jruby.javasupport.Java;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.logstash.ext.JrubyTimestampExtLibrary;
 
 import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class ValuefierTest {
     @Test
@@ -92,15 +91,12 @@ public class ValuefierTest {
         assertEquals(JrubyTimestampExtLibrary.RubyTimestamp.class, result.getClass());
     }
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
-    @Test
+    @Test()
     public void testUnhandledObject() {
-        RubyMatchData md = new RubyMatchData(RubyUtil.RUBY);
-        exception.expect(MissingConverterException.class);
-        exception.expectMessage("Missing Converter handling for full class name=org.jruby.RubyMatchData, simple name=RubyMatchData");
-        Valuefier.convert(md);
+        Exception e = assertThrows(MissingConverterException.class, () -> {
+            Valuefier.convert(new RubyMatchData(RubyUtil.RUBY));
+        });
+        assertEquals("Missing Converter handling for full class name=org.jruby.RubyMatchData, simple name=RubyMatchData", e.getMessage());
     }
 
     @Test

--- a/logstash-core/src/test/java/org/logstash/config/ir/PipelineConfigTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/PipelineConfigTest.java
@@ -33,7 +33,12 @@ import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PipelineConfigTest extends RubyEnvTestCase {
 

--- a/logstash-core/src/test/java/org/logstash/config/ir/graph/BooleanEdgeTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/graph/BooleanEdgeTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
 import org.logstash.config.ir.InvalidIRException;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.logstash.config.ir.IRHelpers.*;
 
 @RunWith(Theories.class)

--- a/logstash-core/src/test/java/org/logstash/config/ir/graph/EdgeTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/graph/EdgeTest.java
@@ -24,8 +24,8 @@ import org.junit.Test;
 import org.logstash.config.ir.IRHelpers;
 import org.logstash.config.ir.InvalidIRException;
 
-import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class EdgeTest {
     @Test

--- a/logstash-core/src/test/java/org/logstash/config/ir/graph/GraphTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/graph/GraphTest.java
@@ -30,7 +30,10 @@ import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.logstash.config.ir.IRHelpers.createTestExpression;
 import static org.logstash.config.ir.IRHelpers.createTestVertex;
 import static org.logstash.config.ir.IRHelpers.randMeta;

--- a/logstash-core/src/test/java/org/logstash/config/ir/graph/IfVertexTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/graph/IfVertexTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import org.logstash.config.ir.InvalidIRException;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.logstash.config.ir.IRHelpers.*;
 
 public class IfVertexTest {

--- a/logstash-core/src/test/java/org/logstash/config/ir/graph/PluginVertexTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/graph/PluginVertexTest.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.logstash.config.ir.IRHelpers.*;
 
 public class PluginVertexTest {

--- a/logstash-core/src/test/java/org/logstash/ext/JrubyEventExtLibraryTest.java
+++ b/logstash-core/src/test/java/org/logstash/ext/JrubyEventExtLibraryTest.java
@@ -38,6 +38,8 @@ import org.junit.Test;
 import org.logstash.ObjectMappers;
 import org.logstash.RubyUtil;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 /**
  * Tests for {@link JrubyEventExtLibrary.RubyEvent}.
  */
@@ -90,7 +92,7 @@ public final class JrubyEventExtLibraryTest {
         try {
             event.ruby_set_field(context, key, value);
         } catch (RuntimeError rubyRuntimeError) {
-            Assert.assertThat(rubyRuntimeError.getLocalizedMessage(), CoreMatchers.containsString("Invalid FieldReference"));
+            assertThat(rubyRuntimeError.getLocalizedMessage(), CoreMatchers.containsString("Invalid FieldReference"));
             return;
         }
         Assert.fail("expected ruby RuntimeError was not thrown.");
@@ -106,7 +108,7 @@ public final class JrubyEventExtLibraryTest {
         try {
             event.ruby_set_field(context, key, value);
         } catch (RuntimeError rubyRuntimeError) {
-            Assert.assertThat(rubyRuntimeError.getLocalizedMessage(), CoreMatchers.containsString("Invalid FieldReference"));
+            assertThat(rubyRuntimeError.getLocalizedMessage(), CoreMatchers.containsString("Invalid FieldReference"));
             return;
         }
         Assert.fail("expected ruby RuntimeError was not thrown.");

--- a/logstash-core/src/test/java/org/logstash/plugins/PluginValidatorTest.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/PluginValidatorTest.java
@@ -35,9 +35,6 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Enumeration;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 

--- a/logstash-core/src/test/java/org/logstash/secret/store/SecretStoreFactoryTest.java
+++ b/logstash-core/src/test/java/org/logstash/secret/store/SecretStoreFactoryTest.java
@@ -22,7 +22,6 @@ package org.logstash.secret.store;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.logstash.secret.SecretIdentifier;
 import org.logstash.secret.store.backend.JavaKeyStore;
@@ -49,9 +48,6 @@ public class SecretStoreFactoryTest {
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     private static final SecretStoreFactory secretStoreFactory = SecretStoreFactory.fromEnvironment();
 
     @Test
@@ -63,9 +59,8 @@ public class SecretStoreFactoryTest {
         validateMarker(secretStore);
     }
 
-    @Test
+    @Test(expected = SecretStoreException.ImplementationNotFoundException.class)
     public void testAlternativeImplementationInvalid() {
-        thrown.expect(SecretStoreException.ImplementationNotFoundException.class);
         SecureConfig secureConfig = new SecureConfig();
         secureConfig.add("keystore.classname", "junk".toCharArray());
         SecretStore secretStore = secretStoreFactory.load(secureConfig);
@@ -138,9 +133,8 @@ public class SecretStoreFactoryTest {
     /**
      * Ensures that load failure is the correct type.
      */
-    @Test
+    @Test(expected = SecretStoreException.LoadException.class)
     public void testErrorLoading() {
-        thrown.expect(SecretStoreException.LoadException.class);
         //default implementation requires a path
         secretStoreFactory.load(new SecureConfig());
     }

--- a/logstash-core/src/test/java/org/logstash/secret/store/backend/JavaKeyStoreTest.java
+++ b/logstash-core/src/test/java/org/logstash/secret/store/backend/JavaKeyStoreTest.java
@@ -25,7 +25,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.logstash.LogstashJavaCompat;
 import org.logstash.secret.SecretIdentifier;
@@ -70,8 +69,6 @@ public class JavaKeyStoreTest {
     private final static String EXTERNAL_TEST_WRITE = "test_external_write";
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
     private JavaKeyStore keyStore;
     private char[] keyStorePath;
     private SecureConfig withDefaultPassConfig;
@@ -210,9 +207,8 @@ public class JavaKeyStoreTest {
      *
      * @throws Exception when ever it wants to.
      */
-    @Test
+    @Test(expected = SecretStoreException.class)
     public void notLogstashKeystore() throws Exception {
-        thrown.expect(SecretStoreException.class);
         SecureConfig altConfig = new SecureConfig();
         Path altPath = folder.newFolder().toPath().resolve("alt.not.a.logstash.keystore");
         try (OutputStream out = Files.newOutputStream(altPath)) {
@@ -229,9 +225,8 @@ public class JavaKeyStoreTest {
      *
      * @throws Exception when ever it wants to.
      */
-    @Test
+    @Test(expected = SecretStoreException.LoadException.class)
     public void notLogstashKeystoreNoMarker() throws Exception {
-        thrown.expect(SecretStoreException.LoadException.class);
         withDefinedPassConfig.add("keystore.file", Paths.get(this.getClass().getClassLoader().getResource("not.a.logstash.keystore").toURI()).toString().toCharArray().clone());
         new JavaKeyStore().load(withDefinedPassConfig);
     }
@@ -313,9 +308,8 @@ public class JavaKeyStoreTest {
      *
      * @throws Exception when ever it wants to
      */
-    @Test
+    @Test(expected = SecretStoreException.AccessException.class)
     public void tamperedKeystore() throws Exception {
-        thrown.expect(SecretStoreException.class);
         byte[] keyStoreAsBytes = Files.readAllBytes(Paths.get(new String(keyStorePath)));
         //bump the middle byte by 1
         int tamperLocation = keyStoreAsBytes.length / 2;
@@ -332,9 +326,8 @@ public class JavaKeyStoreTest {
      *
      * @throws IOException when it goes boom.
      */
-    @Test
-    public void testAlreadyCreated() throws IOException {
-        thrown.expect(SecretStoreException.AlreadyExistsException.class);
+    @Test(expected = SecretStoreException.AlreadyExistsException.class)
+    public void testAlreadyCreated() {
         SecureConfig secureConfig = new SecureConfig();
         secureConfig.add("keystore.file", keyStorePath.clone());
         new JavaKeyStore().create(secureConfig);
@@ -362,9 +355,8 @@ public class JavaKeyStoreTest {
         }
     }
 
-    @Test
+    @Test(expected = SecretStoreException.LoadException.class)
     public void testDelete() throws IOException {
-        thrown.expect(SecretStoreException.LoadException.class);
         Path altPath = folder.newFolder().toPath().resolve("alt.logstash.keystore");
         SecureConfig altConfig = new SecureConfig();
         altConfig.add("keystore.file", altPath.toString().toCharArray());
@@ -383,9 +375,8 @@ public class JavaKeyStoreTest {
      *
      * @throws IOException when ever it wants to
      */
-    @Test
+    @Test(expected = SecretStoreException.CreateException.class)
     public void testEmptyNotAllowedOnCreate() throws IOException {
-        thrown.expect(SecretStoreException.CreateException.class);
         Path altPath = folder.newFolder().toPath().resolve("alt.logstash.keystore");
         SecureConfig altConfig = new SecureConfig();
         altConfig.add("keystore.file", altPath.toString().toCharArray());
@@ -398,9 +389,8 @@ public class JavaKeyStoreTest {
      *
      * @throws Exception when ever it wants to
      */
-    @Test
+    @Test(expected = SecretStoreException.AccessException.class)
     public void testEmptyNotAllowedOnExisting() throws Exception {
-        thrown.expect(SecretStoreException.AccessException.class);
         Path altPath = folder.newFolder().toPath().resolve("alt.logstash.keystore");
         SecureConfig altConfig = new SecureConfig();
         altConfig.add("keystore.file", altPath.toString().toCharArray());
@@ -583,18 +573,16 @@ public class JavaKeyStoreTest {
         keyStore.purgeSecret(id);
     }
 
-    @Test
+    @Test(expected = SecretStoreException.LoadException.class)
     public void testLoadNotCreated() throws IOException {
-        thrown.expect(SecretStoreException.LoadException.class);
         Path altPath = folder.newFolder().toPath().resolve("alt.logstash.keystore");
         SecureConfig secureConfig = new SecureConfig();
         secureConfig.add("keystore.file", altPath.toString().toCharArray());
         new JavaKeyStore().load(secureConfig.clone());
     }
 
-    @Test
+    @Test(expected = SecretStoreException.LoadException.class)
     public void testNoPathDefined() {
-        thrown.expect(SecretStoreException.LoadException.class);
         new JavaKeyStore().load(new SecureConfig());
     }
 
@@ -687,9 +675,8 @@ public class JavaKeyStoreTest {
      *
      * @throws Exception when ever it wants to
      */
-    @Test
-    public void wrongPassword() throws Exception {
-        thrown.expect(SecretStoreException.AccessException.class);
+    @Test(expected = SecretStoreException.AccessException.class)
+    public void wrongPassword() {
         withDefinedPassConfig.add(SecretStoreFactory.KEYSTORE_ACCESS_KEY, "wrongpassword".toCharArray());
         new JavaKeyStore().load(withDefinedPassConfig);
     }

--- a/logstash-core/src/test/java/org/logstash/util/CloudSettingAuthTest.java
+++ b/logstash-core/src/test/java/org/logstash/util/CloudSettingAuthTest.java
@@ -19,47 +19,40 @@
 
 package org.logstash.util;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.function.ThrowingRunnable;
 
+import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.*;
 
 public class CloudSettingAuthTest {
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void testThrowExceptionWhenGivenStringWithoutSeparatorOrPassword() {
-        exceptionRule.expect(org.jruby.exceptions.ArgumentError.class);
-        exceptionRule.expectMessage("Cloud Auth username and password format should be");
-
-        new CloudSettingAuth("foobarbaz");
+        assertArgumentError("Cloud Auth username and password format should be \"<username>:<password>\".", () -> {
+            new CloudSettingAuth("foobarbaz");
+        });
     }
 
     @Test
     public void testThrowExceptionWhenGivenStringWithoutPassword() {
-        exceptionRule.expect(org.jruby.exceptions.ArgumentError.class);
-        exceptionRule.expectMessage("Cloud Auth username and password format should be");
-
-        new CloudSettingAuth("foo:");
+        assertArgumentError("Cloud Auth username and password format should be \"<username>:<password>\".", () -> {
+            new CloudSettingAuth("foo:");
+        });
     }
 
     @Test
     public void testThrowExceptionWhenGivenStringWithoutUsername() {
-        exceptionRule.expect(org.jruby.exceptions.ArgumentError.class);
-        exceptionRule.expectMessage("Cloud Auth username and password format should be");
-
-        new CloudSettingAuth(":bar");
+        assertArgumentError("Cloud Auth username and password format should be \"<username>:<password>\".", () -> {
+            new CloudSettingAuth(":bar");
+        });
     }
 
     @Test
     public void testThrowExceptionWhenGivenStringWhichIsEmpty() {
-        exceptionRule.expect(org.jruby.exceptions.ArgumentError.class);
-        exceptionRule.expectMessage("Cloud Auth username and password format should be");
-
-        new CloudSettingAuth("");
+        assertArgumentError("Cloud Auth username and password format should be \"<username>:<password>\".", () -> {
+            new CloudSettingAuth("");
+        });
     }
 
     @Test
@@ -74,6 +67,11 @@ public class CloudSettingAuthTest {
         assertEquals("frodo", sut.getUsername());
         assertEquals("baggins", sut.getPassword().getValue());
         assertEquals("frodo:<password>", sut.toString());
+    }
+
+    private void assertArgumentError(final String withMessage, final ThrowingRunnable runnable) {
+        org.jruby.exceptions.ArgumentError e = assertThrows(org.jruby.exceptions.ArgumentError.class, runnable);
+        assertEquals(withMessage, e.getException().getMessage().toString());
     }
 
 }


### PR DESCRIPTION
Could be considered a bug fix, although due the fairly "static" nature of field references used within a given pipeline it would only get triggered on rare occasions. This only affected Ruby plugins.

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

Changes field reference caching logic to always have an upper bound.

## Why is it important/What is the impact to the user?

Ruby plugins, such as snmtrap, might generate a lot of field references -> eventually blowing the heap or significantly affecting LS performance as a lot of heap is kept for the cache.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- the Java `CACHE` was previously bounded to 10_000 entries but not the `RUBY_CACHE`
- `RUBY_CACHE` relied on caching the value (in `CACHE`) for the Java part as well -> no longer the case
  * `RUBY_CACHE` and Java `CACHE` instances are now completely separate
- the `DEDUP` map seem to have been growing indefinitely as well and is now removed

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- resolves https://github.com/elastic/logstash/issues/10112

