### PR TITLE
ecs_compatibility: revert breaking change; keep `disabled` as default for 8.0

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -70,17 +70,17 @@
 # available to plugins that implement an ECS Compatibility mode for use with
 # the Elastic Common Schema.
 # Possible values are:
-# - disabled
-# - v1 (default)
-# - v2
-# CAVEAT: use of this configuration for anything other than `disabled` -- including
-# the default value -- is considered BETA until the General Availability of
+# - disabled (default)
+# - v1
+# - v8
+# CAVEAT: use of this configuration for anything other than `disabled`
+# is considered BETA until the General Availability of
 # Logstash 8.0.0. As we continue to release updated plugins with ECS-Compatibility
 # modes, opting into them at a pipeline or process level will cause you to
 # automatically consume breaking changes with each upgrade, which may change the
 # shape of data your pipeline produces.
 #
-# pipeline.ecs_compatibility: v1
+# pipeline.ecs_compatibility: disabled
 #
 # ------------ Pipeline Configuration Settings --------------
 #

--- a/docs/static/ecs-compatibility.asciidoc
+++ b/docs/static/ecs-compatibility.asciidoc
@@ -15,25 +15,25 @@ Many plugins implement an ECS-compatibility mode, which causes them to produce a
 
 Any plugin that supports this mode will also have an `ecs_compatibility` option, which allows you to configure which mode the individual plugin instance should operate in.
 If left unspecified for an individual plugin, the pipeline's `pipeline.ecs_compatibility` setting will be observed.
-This allows you to configure plugins to use their legacy non-ECS behavior: individually, per-pipeline, or globally.
+This allows you to configure plugins to use ECS -- or to lock in your existing non-ECS behavior.
 
-ECS Compatibility modes do not prevent you from explicitly configuring a plugin in a manner that conflicts with ECS.
+ECS compatibility modes do not prevent you from explicitly configuring a plugin in a manner that conflicts with ECS.
 Instead, they ensure that _implicit_ configuration avoids conflicts.
 
-NOTE: Until {ls} 8.0 and the final 7.x are released, any value for `pipeline.ecs_compatibility` other than `disabled` -- _including the default value on pre-release builds_ -- are considered BETA and unsupported.
-      As we continue to release plugins with ECS Compatibility modes, having this flag set will cause upgrades to _automatically_ consume breaking changes from one snapshot to another, changing the shape of data the plugin produces.
-      If you require stability while testing against the unreleased {ls} 8, we encourage you to opt-out globally or per-pipeline as detailed below.
+NOTE: Until {ls} 8.0 and the final 7.x are released, any value for `pipeline.ecs_compatibility` other than `disabled` is considered BETA and unsupported.
+      As we continue to release plugins with ECS compatibility modes, having this flag set will cause even patch-level upgrades to _automatically_ consume breaking changes in the upgraded plugins, changing the shape of data the plugin produces.
 
 ifeval::["{ls8-ecs-major-version}"!="v8"]
-NOTE: This pre-release branch of {ls} 8 defaults to ECS {ls8-ecs-major-version}, but by the time {ls} 8 ships, it will point to ECS v8.
-      We expect the scope of breaking changes in ECS 8 to be limited, but progress toward the definition of ECS v8 can be tracked https://github.com/elastic/ecs/issues/839[here].
+NOTE: ECS `v8` will be available alongside the GA release of {ls} 8.0.0, and will be available at or before the final minor release of {ls} 7.
+      We expect the scope of breaking changes in ECS 8 to be limited.
+      We are https://github.com/elastic/ecs/issues/839[tracking progress toward ECS v8] in a GitHub issue.
 endif::[]
 
-[[ecs-optout]]
-===== Opting out of ECS
+[[ecs-configuration]]
+===== Configuring ECS
 
-In {ls} 8, these plugins are run in ECS mode by default, but you can opt out at the plugin, pipeline, or system level to maintain legacy behavior.
-This can be helpful if you have very complex pipelines that were defined pre-ECS, to allow you to either upgrade them or to avoid doing so independently of your {ls} 8.x upgrade.
+ECS will be on by default in a future release of {ls}, but you can begin using it now by configuring individual plugins with `ecs_compatibility`.
+You can also "lock in" the existing non-ECS behavior for an entire pipeline to ensure its behavior doesn't change when you perform future upgrades.
 
 ====== Specific plugin instance
 
@@ -51,7 +51,22 @@ filter {
 }
 -----
 
-[[ecs-optout-pipeline]]
+Alternatively, if you had a UDP input with a CEF codec, and wanted both to use an ECS mode while still running {ls} 7, you can adjust their definitions to specify the major version of ECS to use.
+
+[source,text,subs="attributes"]
+-----
+input {
+  udp {
+    port => 1234
+    ecs_compatibility => {ls8-ecs-major-version}
+    codec => cef {
+      ecs_compatibility => {ls8-ecs-major-version}
+    }
+  }
+}
+-----
+
+[[ecs-configuration-pipeline]]
 ====== All plugins in a given pipeline
 
 If you wish to provide a specific default value for `ecs_compatibility` to _all_ plugins in a pipeline, you can do so with the `pipeline.ecs_compatibility` setting in your pipeline definition in `config/pipelines.yml` or Central Management.
@@ -68,10 +83,10 @@ If unspecified for an individual pipeline, the global value will be used.
   pipeline.ecs_compatibility: {ls8-ecs-major-version}
 -----
 
-NOTE: Until the General Availability of {ls} 8.0.0, any value for `pipeline.ecs_compatibility` other than `disabled` -- including the default value `{ls8-ecs-major-version}` on this pre-release branch -- may have undesireable consequences when performing upgrades.
+NOTE: Until the General Availability of {ls} 8.0.0 that coincides with the final minor release of {ls} 7, any value for `pipeline.ecs_compatibility` other than `disabled` is considered BETA and unsupported because it will produce undesirable consequences when performing upgrades.
       As we continue to release updated plugins with ECS-Compatibility modes, opting into them at a pipeline or process level will cause the affected plugins to silently and automatically consume breaking changes with each upgrade, which may change the shape of data your pipeline produces.
 
-[[ecs-optout-all]]
+[[ecs-configuration-all]]
 ====== All plugins in all pipelines
 
 Similarly, you can set the default value for the whole {ls} process by setting the `pipeline.ecs_compatibility` value in `config/logstash.yml`.

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -60,7 +60,7 @@ module LogStash
            Setting::Boolean.new("pipeline.plugin_classloaders", false),
            Setting::Boolean.new("pipeline.separate_logs", false),
    Setting::CoercibleString.new("pipeline.ordered", "auto", true, ["auto", "true", "false"]),
-   Setting::CoercibleString.new("pipeline.ecs_compatibility", "v1", true, %w(disabled v1 v8)),
+   Setting::CoercibleString.new("pipeline.ecs_compatibility", "disabled", true, %w(disabled v1 v8)),
                     Setting.new("path.plugins", Array, []),
     Setting::NullableString.new("interactive", nil, false),
            Setting::Boolean.new("config.debug", false),

--- a/logstash-core/lib/logstash/plugins/ecs_compatibility_support.rb
+++ b/logstash-core/lib/logstash/plugins/ecs_compatibility_support.rb
@@ -20,6 +20,11 @@ module LogStash
             pipeline_settings = pipeline && pipeline.settings
             pipeline_settings ||= LogStash::SETTINGS
 
+            if !pipeline_settings.set?('pipeline.ecs_compatibility')
+              deprecation_logger.deprecated("Relying on default value of `pipeline.ecs_compatibility`, which may change in a future major release of Logstash. " +
+                                            "To avoid unexpected changes when upgrading Logstash, please explicitly declare your desired ECS Compatibility mode.")
+            end
+
             pipeline_settings.get_value('pipeline.ecs_compatibility').to_sym
           end
         end

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -350,7 +350,7 @@ en:
           Possible values are:
            - disabled (default)
            - v1
-           - v2
+           - v8
           This option allows the early opt-in (or preemptive opt-out)
           of ECS Compatibility modes in plugins, which is scheduled to
           be on-by-default in a future major release of Logstash.

--- a/logstash-core/spec/logstash/plugin_spec.rb
+++ b/logstash-core/spec/logstash/plugin_spec.rb
@@ -461,9 +461,16 @@ describe LogStash::Plugin do
       end
 
       context 'and pipeline-level setting is not specified' do
-        it 'returns `v1`' do
+        it 'emits a deprecation warning about using the default which may change' do
+          instance.ecs_compatibility
+
+          expect(deprecation_logger_stub).to have_received(:deprecated) do |message|
+            expect(message).to include("Relying on default value of `pipeline.ecs_compatibility`")
+          end
+        end
+        it 'returns `disabled`' do
           # Default value of `pipeline.ecs_compatibility`
-          expect(instance.ecs_compatibility).to eq(:v1)
+          expect(instance.ecs_compatibility).to eq(:disabled)
         end
       end
     end


### PR DESCRIPTION
## Release notes

REVERTS previously-merged breaking change in default value of `pipeline.ecs_compatibility`

## What does this PR do?

As we close in on the availability of 8.0.0 alphas, we are reassessing which
breaking changes are _necessary_, and which are merely _desired_. And while
we would love to be in a world where ECS was on by default, and have put
substantial effort into designing an upgrade path that would be as simple as
possible, we have determined that the time may not be right to change the
default value out of under our users.

This change restores the default value for `pipeline.ecs_compatibility` to
`disabled`, ensuring pipelines will continue running in Logstash 8 as they have
in Logstash 7 without modification. We will still encourage our users to be
explicit about which behaviour they desire, and will revisit making ECS on by
default at a later date.

## Why is it important/What is the impact to the user?

Prioritizes ease of upgrade to Logstash 8, while continuing to guide our users to be explicit about which behaviour they desire.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works
