### PR TITLE
Doc: Add shared attribute for messaging ecs default info

### DIFF
--- a/docs/include/attributes-ls.asciidoc
+++ b/docs/include/attributes-ls.asciidoc
@@ -1,8 +1,10 @@
 /////
- These settings control attributes in the LSR only. 
-They correspond to the VPR settings in logstash-docs/docs/versioned-plugins/include/attributes-ls-vpr.asciidoc
-When we update one, we must update settings in the other location
+These settings control attributes for Logstash core content 
+in the Logstash Reference (LSR) only.
+ 
+Shared attributes for the plugin docs (in the LSR and VPR) should
+go in /docs/include/attributes-lsplugins.asciidoc instead 
+with a corresponding change to the VPR settings in 
+logstash-docs/docs/versioned-plugins/include/attributes-ls-vpr.asciidoc
 /////
-
-:ecs-default:   Any value in {logstash-ref}/logstash-settings-file.html[`logstash.yml`] for pipeline.ecs_compatibility other than disabled is considered BETA and unsupported until Logstash 8.0 and the final 7.x version are released. Having this pipeline level flag set will cause even patch-level upgrades to automatically consume breaking changes in the upgraded plugins, changing the shape of data the plugin produces.
 

--- a/docs/include/attributes-ls.asciidoc
+++ b/docs/include/attributes-ls.asciidoc
@@ -1,2 +1,8 @@
+/////
+ These settings control attributes in the LSR only. 
+They correspond to the VPR settings in logstash-docs/docs/versioned-plugins/include/attributes-ls-vpr.asciidoc
+When we update one, we must update settings in the other location
+/////
+
 :ecs-default:   Any value in {logstash-ref}/logstash-settings-file.html[`logstash.yml`] for pipeline.ecs_compatibility other than disabled is considered BETA and unsupported until Logstash 8.0 and the final 7.x version are released. Having this pipeline level flag set will cause even patch-level upgrades to automatically consume breaking changes in the upgraded plugins, changing the shape of data the plugin produces.
 

--- a/docs/include/attributes-ls.asciidoc
+++ b/docs/include/attributes-ls.asciidoc
@@ -1,0 +1,2 @@
+:ecs-default:   Any value in {logstash-ref}/logstash-settings-file.html[`logstash.yml`] for pipeline.ecs_compatibility other than disabled is considered BETA and unsupported until Logstash 8.0 and the final 7.x version are released. Having this pipeline level flag set will cause even patch-level upgrades to automatically consume breaking changes in the upgraded plugins, changing the shape of data the plugin produces.
+

--- a/docs/include/attributes-lsplugins.asciidoc
+++ b/docs/include/attributes-lsplugins.asciidoc
@@ -1,0 +1,8 @@
+/////
+ These settings control attributes in the LSR only. 
+They correspond to the VPR settings in logstash-docs/docs/versioned-plugins/include/attributes-ls-vpr.asciidoc
+When we update one, we must update settings in the other location
+/////
+
+:ecs-default:   Any value in {logstash-ref}/logstash-settings-file.html[`logstash.yml`] for pipeline.ecs_compatibility other than disabled is considered BETA and unsupported until Logstash 8.0 and the final 7.x version are released. Having this pipeline level flag set will cause even patch-level upgrades to automatically consume breaking changes in the upgraded plugins, changing the shape of data the plugin produces.
+

--- a/docs/include/attributes-lsplugins.asciidoc
+++ b/docs/include/attributes-lsplugins.asciidoc
@@ -1,8 +1,12 @@
 /////
 These settings control attributes in the LSR only. 
 They correspond to the VPR settings in logstash-docs/docs/versioned-plugins/include/attributes-ls-vpr.asciidoc
-When we update one, we must update settings in the other location
+When we update one, we must update settings in the other location,
+
+Attribute text formatted without hard wrap is deliberate. 
+Otherwise, text breaks at return and content isn't displayed in its entirety. 
 /////
 
-:ecs-default:   Any value in {logstash-ref}/logstash-settings-file.html[`logstash.yml`] for pipeline.ecs_compatibility other than `disabled` is considered BETA and unsupported until Logstash 8.0 and the final 7.x version are released. Having this pipeline level flag set will cause even patch-level upgrades to automatically consume breaking changes in the upgraded plugins, changing the shape of data the plugin produces.
+
+:ecs-default: The `pipeline.ecs_compatibility` setting is available in {logstash-ref}/logstash-settings-file.html[`logstash.yml`] and `pipelines.yml`. Any value in `pipeline.ecs_compatibility` other than `disabled` is considered BETA and unsupported until Logstash 8.0 and the final 7.x version are released. Having this pipeline level flag set will cause even patch-level upgrades to automatically consume breaking changes in the upgraded plugins, changing the shape of data the plugin produces.
 

--- a/docs/include/attributes-lsplugins.asciidoc
+++ b/docs/include/attributes-lsplugins.asciidoc
@@ -1,8 +1,8 @@
 /////
- These settings control attributes in the LSR only. 
+These settings control attributes in the LSR only. 
 They correspond to the VPR settings in logstash-docs/docs/versioned-plugins/include/attributes-ls-vpr.asciidoc
 When we update one, we must update settings in the other location
 /////
 
-:ecs-default:   Any value in {logstash-ref}/logstash-settings-file.html[`logstash.yml`] for pipeline.ecs_compatibility other than disabled is considered BETA and unsupported until Logstash 8.0 and the final 7.x version are released. Having this pipeline level flag set will cause even patch-level upgrades to automatically consume breaking changes in the upgraded plugins, changing the shape of data the plugin produces.
+:ecs-default:   Any value in {logstash-ref}/logstash-settings-file.html[`logstash.yml`] for pipeline.ecs_compatibility other than `disabled` is considered BETA and unsupported until Logstash 8.0 and the final 7.x version are released. Having this pipeline level flag set will cause even patch-level upgrades to automatically consume breaking changes in the upgraded plugins, changing the shape of data the plugin produces.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -3,6 +3,7 @@
 
 include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 include::{docs-root}/shared/attributes.asciidoc[]
+include::./include/attributes-ls.asciidoc[]
 
 :include-xpack:         true
 :lang:                  en

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -4,6 +4,7 @@
 include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 include::{docs-root}/shared/attributes.asciidoc[]
 include::./include/attributes-ls.asciidoc[]
+include::./include/attributes-lsplugins.asciidoc[]
 
 :include-xpack:         true
 :lang:                  en


### PR DESCRIPTION
## Release notes
[rn:skip] 

## What does this PR do?
Adds and links shared attribute file for accurately stating ecs default status.

### Design intent/usage
We can add/update text related to ecs defaults (or other info we want to write once and use multiple places). Then, we can  reference it by calling the attribute. In this case `{ecs-default}`.

**Important:** This work requires a corresponding change for the Versioned Plugin Reference. 

### To do (in this order): 
- [ ] Merge and backport this PR.
- [ ] Add shared attribute `include` file to the Versioned Plugin Reference guide, and test.
- [ ] Implement the attribute in plugin docs.  We can't start implementing the attribute in plugin docs until the framework is fully implemented. Otherwise, we will break the doc build. 
