### PR TITLE
Forward port of release notes for 7.13.3 and 7.13.4 to 7.14

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -3,6 +3,8 @@
 
 This section summarizes the changes in the following releases:
 
+* <<logstash-7-13-4,Logstash 7.13.4>>
+* <<logstash-7-13-3,Logstash 7.13.3>>
 * <<logstash-7-13-2,Logstash 7.13.2>>
 * <<logstash-7-13-1,Logstash 7.13.1>>
 * <<logstash-7-13-0,Logstash 7.13.0>>
@@ -45,6 +47,42 @@ This section summarizes the changes in the following releases:
 * <<logstash-7-0-0-beta1,Logstash 7.0.0-beta1>>
 * <<logstash-7-0-0-alpha2,Logstash 7.0.0-alpha2>>
 * <<logstash-7-0-0-alpha1,Logstash 7.0.0-alpha1>>
+
+[[logstash-7-13-4]]
+=== Logstash 7.13.4 Release Notes
+
+==== Notable issues fixed
+
+**Geoip**
+
+Fixed an issue that sometimes happened when multiple pipelines with GeoIP filter tried to update the local database file https://github.com/elastic/logstash/issues/13072[#13072]
+
+
+[[logstash-7-13-3]]
+=== Logstash 7.13.3 Release Notes
+
+No user-facing changes in Logstash core.
+
+==== Plugins
+
+*Cef Codec - 6.2.2*
+
+* Fixed invalid Field Reference that could occur when ECS mode was enabled and the CEF field `fileHash` was parsed.
+* Added expanded mapping for numbered `deviceCustom*` and `deviceCustom*Label` fields so that all now include numbers 1 through 15. https://github.com/logstash-plugins/logstash-codec-cef/pull/89[#89]
+
+*Multiline Codec - 3.0.11*
+
+* Fix: avoid long thread sleeps on codec close https://github.com/logstash-plugins/logstash-codec-multiline/pull/67[#67]
+
+*Xml Filter - 4.1.2*
+
+* [DOC] Updated docs to correct name of parse_options config option https://github.com/logstash-plugins/logstash-filter-xml/pull/75[#75]
+
+*Beats Input - 6.1.5*
+
+* Changed jar dependencies to reflect newer versions https://github.com/logstash-plugins/logstash-input-beats/pull/425[#425]
+* Fix: reduce error logging on connection resets https://github.com/logstash-plugins/logstash-input-beats/pull/424[#424]
+
 
 [[logstash-7-13-2]]
 === Logstash 7.13.2 Release Notes


### PR DESCRIPTION
Forward port of release notes for 7.13.3 (#13031) and 7.13.4 (#13061) to branch `7.14`

