### PR TITLE
Forward port of 7.13.4 release notes to 7.x

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -3,7 +3,7 @@
 
 This section summarizes the changes in the following releases:
 
-<<logstash-7-13-4,Logstash 7.13.4>>
+* <<logstash-7-13-4,Logstash 7.13.4>>
 * <<logstash-7-13-3,Logstash 7.13.3>>
 * <<logstash-7-13-2,Logstash 7.13.2>>
 * <<logstash-7-13-1,Logstash 7.13.1>>

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in the following releases:
 
+<<logstash-7-13-4,Logstash 7.13.4>>
 * <<logstash-7-13-3,Logstash 7.13.3>>
 * <<logstash-7-13-2,Logstash 7.13.2>>
 * <<logstash-7-13-1,Logstash 7.13.1>>
@@ -47,6 +48,16 @@ This section summarizes the changes in the following releases:
 * <<logstash-7-0-0-alpha2,Logstash 7.0.0-alpha2>>
 * <<logstash-7-0-0-alpha1,Logstash 7.0.0-alpha1>>
 
+[[logstash-7-13-4]]
+=== Logstash 7.13.4 Release Notes
+
+==== Notable issues fixed
+
+**Geoip**
+
+Fixed an issue that sometimes happened when multiple pipelines with GeoIP filter tried to update the local database file https://github.com/elastic/logstash/issues/13072[#13072]
+
+
 [[logstash-7-13-3]]
 === Logstash 7.13.3 Release Notes
 
@@ -71,6 +82,7 @@ No user-facing changes in Logstash core.
 
 * Changed jar dependencies to reflect newer versions https://github.com/logstash-plugins/logstash-input-beats/pull/425[#425]
 * Fix: reduce error logging on connection resets https://github.com/logstash-plugins/logstash-input-beats/pull/424[#424]
+
 
 [[logstash-7-13-2]]
 === Logstash 7.13.2 Release Notes


### PR DESCRIPTION
Forward port of 7.13.4 (#13061) release notes to branch `7.x`