### PR TITLE
Backport PR #12421 to 7.x: doc: add pipeline.ecs_compatibility docs

### DIFF
--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -134,6 +134,22 @@ guaranteed, but you save the processing cost of preserving order.
 
 | `auto`
 
+| `pipeline.ecs_compatibility`
+a|
+Sets the pipeline's default value for `ecs_compatibility`, a setting that is available to plugins that implement an ECS compatibility mode for use with the Elastic Common Schema.
+Possible values are:
+
+* `disabled`
+* `v1`
+* `v8`
+
+This option allows the <<ecs-ls,early opt-in (or preemptive opt-out) of ECS compatibility>> modes in plugins,
+which is scheduled to be on-by-default in a future major release of {ls}.
+
+Values other than `disabled` are currently considered BETA, and may produce unintended consequences when upgrading {ls}.
+
+| `disabled`
+
 | `path.config`
 | The path to the Logstash config for the main pipeline. If you specify a directory or wildcard,
   config files are read from the directory in alphabetical order.


### PR DESCRIPTION
Backport PR #12421 to 7.x branch. Original message: 

## What does this PR do?

Adds doc section for `pipeline.ecs_compatibility` setting.

## Backport targets:

 - `7.10`
 - `7.x`

## Why is it important/What is the impact to the user?

While this copy already exists in the `--help` output for the logstash command-line executable, bringing it to the web documentation makes it more accessible.

## Checklist

- [ ] ~My code follows the style guidelines of this project~
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
- [ ] ~I have made corresponding change to the default configuration files (and/or docker env variables)~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~

## How to test this PR locally

Click through to [Docs Build](https://logstash_12421.docs-preview.app.elstc.co/guide/en/logstash/master/logstash-settings-file.html#logstash-settings-file), or observe this handy screenshot:

<img width="500" alt="Screen Shot 2020-11-06 at 6 53 41 PM" src="https://user-images.githubusercontent.com/210924/98430383-9940a800-2061-11eb-85b9-6dd7e45a202d.png">


## Related issues

#12305 
