### PR TITLE
Docs: Event and Plugin api docs

### DIFF
--- a/docs/static/codec.asciidoc
+++ b/docs/static/codec.asciidoc
@@ -1,6 +1,7 @@
 :register_method:	true
 :encode_method:		true
 :decode_method:		true
+:event_factory_method: true
 :plugintype:    	codec
 :pluginclass:   	Codecs
 :pluginname:    	example

--- a/docs/static/event-api.asciidoc
+++ b/docs/static/event-api.asciidoc
@@ -1,31 +1,31 @@
 [[event-api]]
 === Event API
 
-This section is targeted for plugin developers and users of Logstash's Ruby filter. Below we document recent 
-changes (starting with version 5.0) in the way users have been accessing Logstash's event based data in 
-custom plugins and in the Ruby filter. Note that <<event-dependent-configuration>> 
-data flow in Logstash's config files -- using <<logstash-config-field-references>> -- is 
-not affected by this change, and will continue to use existing syntax.
+This section is targeted for plugin developers and users of {ls}'s Ruby filter.
+
+Event is the main object that encapsulates data flow internally in {ls} and provides an API for the plugin developers to interact with the event's content.
+Typically, this API is used in plugins and in a Ruby filter to retrieve data and use it for transformations.
+Event objects contain the original data sent to {ls} and any additional fields created during {ls}'s filter stages.
+
+==== Creating new Events with `Event.new`
+
+
+To create a new `Event` object, simply:
+
+[source,ruby]
+---------------------------------
+  event = LogStash::Event.new
+---------------------------------
+
+If you wish for the event to be pre-constructed with data, you may pass a ruby Hash:
+
+[source,ruby]
+---------------------------------
+  event = LogStash::Event.new("message" => "hello, world!")
+---------------------------------
 
 [float]
-==== Event Object
-
-Event is the main object that encapsulates data flow internally in Logstash and provides an API for the plugin 
-developers to interact with the event's content. Typically, this API is used in plugins and in a Ruby filter to 
-retrieve data and use it for transformations. Event object contains the original data sent to Logstash and any additional 
-fields created during Logstash's filter stages.
-
-In 5.0, we've re-implemented the Event class and its supporting classes in pure Java. Since Event is a critical component 
-in data processing,  a rewrite in Java improves performance and provides efficient serialization when storing data on disk. For the most part, this change aims at keeping backward compatibility and is transparent to the users. To this extent we've updated and published most of the plugins in Logstash's ecosystem to adhere to the new API changes. However, if you are maintaining a custom plugin, or have a Ruby filter, this change will affect you. The aim of this guide is to describe the new API and provide examples to migrate to the new changes.
-
-[float]
-==== Event API
-
-Prior to version 5.0, developers could access and manipulate event data by directly using Ruby hash syntax. For 
-example, `event[field] = foo`. While this is powerful, our goal is to abstract the internal implementation details 
-and provide well-defined getter and setter APIs.
-
-**Get API**
+==== Getting the current value of a field with `Event#get`
 
 The getter is a read-only access of field-based data in an Event.
 
@@ -34,8 +34,8 @@ The getter is a read-only access of field-based data in an Event.
 **Returns:** Value for this field or nil if the field does not exist. Returned values could be a string, 
 numeric or timestamp scalar value.
 
-`field` is a structured field sent to Logstash or created after the transformation process. `field` can also 
-be a nested <<field-references-deepdive,field reference>> such as `[field][bar]`.
+`field` is a structured field sent to Logstash or created after the transformation process.
+`field` can also be a nested <<field-references-deepdive,field reference>> such as `[field][bar]`.
 
 Examples:
 
@@ -57,13 +57,14 @@ Accessing @metadata
 event.get("[@metadata][foo]") # => "baz"
 --------------------------------------------------
 
-**Set API**
+[float]
+==== Setting fields with `Event#set`
 
 This API can be used to mutate data in an Event. 
 
 **Syntax:** `event.set(field, value)`
 
-**Returns:**  The current Event  after the mutation, which can be used for chainable calls.
+**Returns:** The value that was set.
 
 Examples:
 
@@ -80,6 +81,7 @@ event.set("[@metadata][foo]", "baz")
 --------------------------------------------------
 
 Mutating a collection after setting it in the Event has an undefined behaviour and is not allowed.
+After mutating a retrieved field, you must set the field with the result.
 
 [source,ruby]
 --------------------------------------------------
@@ -102,10 +104,92 @@ event.set("[foo][bar][c]", [3, 4])
 --------------------------------------------------
 
 [float]
+==== Removing a field with `Event#remove`
+
+This API can be used to remove a field entirely.
+
+**Syntax:** `event.remove(field)`
+
+**Returns:** The value of the field prior to its removal.
+
+Examples:
+
+[source,ruby]
+--------------------------------------------------
+event.set("[foo]", "zab")
+event.include?("[foo]") # => true
+event.include?("[bar]") # => false
+--------------------------------------------------
+
+[float]
+==== Testing a field's presence with `Event#include?`
+
+This API can be used to determine whether a field has been set.
+
+**Syntax:** `event.include?(field)`
+
+**Returns:**  `true` if the field has been set; otherwise `false`.
+
+Examples:
+
+[source,ruby]
+--------------------------------------------------
+event.set("[foo]", "zab")
+event.include?("[foo]") # => true
+event.remove("[foo]")   # => "zab"
+event.include?("[foo]") # => false
+--------------------------------------------------
+
+[float]
+==== Cancelling an event with `Event#cancel`
+
+An Event that has been cancelled will not be routed to additional filters or outputs.
+
+**Syntax:** `event.cancel`
+
+**Returns:**  `true`.
+
+[source,ruby]
+--------------------------------------------------
+event.cancel # => true
+--------------------------------------------------
+
+[float]
+==== Un-cancelling an event with `Event#uncancel`
+
+An Event that has been cancelled can be un-cancelled to ensure that it _is_ processed by subsequent filters and outputs.
+
+**Syntax:** `event.cancel`
+
+**Returns:**  `false`.
+
+[source,ruby]
+--------------------------------------------------
+event.uncancel # => false
+--------------------------------------------------
+
+[float]
+==== Determining cancellation status with `Event#cancelled?`
+
+An Event's cancellation status can be queried to determine whether it will be processed by subsequent filters and outputs.
+
+**Syntax:** `event.cancelled?`
+
+**Returns:**  `true` or `false`.
+
+[source,ruby]
+--------------------------------------------------
+event.cancel #=> true
+event.cancelled? # => true
+event.uncancel # => false
+event.cancelled? # => false
+--------------------------------------------------
+
+[float]
 ==== Ruby Filter
 
-The <<plugins-filters-ruby,Ruby Filter>> can be used to execute any ruby code and manipulate event data using the 
-API described above. For example, using the new API:
+The <<plugins-filters-ruby,Ruby Filter>> can be used to execute any ruby code and manipulate event data using the API described above.
+For example, using the API:
 
 [source,ruby]
 --------------------------------------------------

--- a/docs/static/event-api.asciidoc
+++ b/docs/static/event-api.asciidoc
@@ -7,21 +7,33 @@ Event is the main object that encapsulates data flow internally in {ls} and prov
 Typically, this API is used in plugins and in a Ruby filter to retrieve data and use it for transformations.
 Event objects contain the original data sent to {ls} and any additional fields created during {ls}'s filter stages.
 
-==== Creating new Events with `Event.new`
+[[event-api-event-factory]]
+==== Creating new Events with `EventFactory`
 
+Beginning with {ls} 7.14, the `EventFactory` is the preferred method of creating Events.
+An `EventFactory` is made available to plugins with the `Plugin#event_factory` API.
+
+NOTE: Plugins that need to run on older versions of Logstash can use the https://github.com/logstash-plugins/logstash-mixin-event_support[Event Support mixin], which provides a fallback implementation when run on older {ls} releases.
+
+NOTE: Prior to {ls} 7.14, events were created directly with `LogStash::Event.new`.
+      This direct usage is deprecated and may not continue to work in future releases of {ls}.
+
+===== `EventFactory#new_event`
+
+The plugin APIs provide an `event_factory` method, which provides an `EventFactory`.
 
 To create a new `Event` object, simply:
 
 [source,ruby]
 ---------------------------------
-  event = LogStash::Event.new
+  event = event_factory.new_event
 ---------------------------------
 
 If you wish for the event to be pre-constructed with data, you may pass a ruby Hash:
 
 [source,ruby]
 ---------------------------------
-  event = LogStash::Event.new("message" => "hello, world!")
+  event = event_factory.new_event("message" => "hello, world!")
 ---------------------------------
 
 [float]

--- a/docs/static/filter.asciidoc
+++ b/docs/static/filter.asciidoc
@@ -1,5 +1,6 @@
 :register_method:	true
 :filter_method:		true
+:event_factory_method: true
 :plugintype:    	filter
 :pluginclass:   	Filters
 :pluginname:    	example

--- a/docs/static/include/pluginbody.asciidoc
+++ b/docs/static/include/pluginbody.asciidoc
@@ -136,7 +136,7 @@ class LogStash::{pluginclass}::{pluginnamecap} < LogStash::{pluginclass}::Base
 
   def run(queue)
     Stud.interval(@interval) do
-      event = LogStash::Event.new("message" => @message, "host" => @host)
+      event = event_factory.new_event("message" => @message, "host" => @host)
       decorate(event)
       queue << event
     end # loop
@@ -191,7 +191,7 @@ class LogStash::{pluginclass}::{pluginnamecap} < LogStash::{pluginclass}::Base
   def decode(data)
     @lines.decode(data) do |line|
       replace = { "message" => line["message"].to_s + @append }
-      yield LogStash::Event.new(replace)
+      yield event_factory.new_event(replace)
     end
   end # def decode
 
@@ -522,7 +522,7 @@ ifndef::blockcodec[]
   def decode(data)
     @lines.decode(data) do |line|
       replace = { "message" => line["message"].to_s + @append }
-      yield LogStash::Event.new(replace)
+      yield event_factory.new_event(replace)
     end
   end # def decode
 ----------------------------------
@@ -579,7 +579,7 @@ The {pluginname} input plugin has the following `run` Method:
 ----------------------------------
   def run(queue)
     Stud.interval(@interval) do
-      event = LogStash::Event.new("message" => @message, "host" => @host)
+      event = event_factory.new_event("message" => @message, "host" => @host)
       decorate(event)
       queue << event
     end # loop
@@ -696,6 +696,20 @@ codec by including code similar to this:
 For more examples of output plugins, see the https://github.com/logstash-plugins?query=logstash-output[logstash-plugin github repository].
 
 endif::receive_method[]
+
+ifdef::event_factory_method[]
+
+===== `event_factory` Method
+
+Beginning with {ls} 7.14, we introduced an <<event-api-event-factory>> and deprecated direct access to `LogStash::Event.new`.
+A plugin's `EventFactory` can be accessed with the `event_factory` method, and can be used to create new events.
+
+===== `targeted_event_factory` Method
+
+Similarly, plugins that provide a `target` option can get a targeted `EventFactory` using the `targeted_event_factory` method.
+A targeted event factory will create events by setting the target field to the provided mapping instead of populating root-level fields.
+
+ifdef::event_factory_method[]
 
 ===== `logger` Method
 

--- a/docs/static/include/pluginbody.asciidoc
+++ b/docs/static/include/pluginbody.asciidoc
@@ -697,6 +697,43 @@ For more examples of output plugins, see the https://github.com/logstash-plugins
 
 endif::receive_method[]
 
+===== `logger` Method
+
+Plugins have access to a logger, which can be used to emit structured logs.
+Plugins can emit logs at one of 5 different levels:
+ - `trace`: very low-level messages to assist with complex debugging
+ - `debug`: low-level messages to assist with simple debugging
+ - `info`: informational messages requring no action from the user
+ - `warn`: warning messages indicating that action may be required
+ - `error`: error messages indicating that the desired task could not be completed
+
+To use the logger, first retrieve it with the plugin's `logger` method, and then send it a message with the appropriate level:
+
+[source,ruby]
+------------------------------
+logger.info("widgets acquired")
+logger.warn("taking the slow route")
+------------------------------
+
+Additional context can be provided as a second argument key/value map:
+
+[source,ruby]
+------------------------------
+logger.info("widgets acquired", count: 17)
+logger.warn("Exception handled, will try again", exception: e.message, backtrace: e.backtrace)
+------------------------------
+
+===== `deprecation_logger` Method
+
+Plugins have access to a deprecation logger, which can be used to provide structured logs about behavior that is subject to change in a future release of your plugin.
+
+To use the deprecation logger, first retrieve it with the plugin's `deprecation_logger` method, and then send it a message:
+
+[source,ruby]
+------------------------------
+deprecation_logger.deprecated("Feature X will be removed in a future release. Please use feature Y instead.")
+------------------------------
+
 // Teardown is now in the base class... can be pruned?
 // /////////////////////////////////////////////////////////////////////////////
 // If close_method is defined (should only be for input or output plugin page)

--- a/docs/static/input.asciidoc
+++ b/docs/static/input.asciidoc
@@ -1,5 +1,6 @@
 :register_method:	true
 :run_method:		true
+:event_factory_method: true
 :plugintype:    	input
 :pluginclass:   	Inputs
 :pluginname:    	example

--- a/docs/static/output.asciidoc
+++ b/docs/static/output.asciidoc
@@ -1,5 +1,6 @@
 :register_method:	true
 :multi_receive_method:	true
+:event_factory_method: false
 :plugintype:    	output
 :pluginclass:   	Outputs
 :pluginname:    	example


### PR DESCRIPTION

## Release notes
[rn:skip]

## What does this PR do?

Improves documentation about the APIs we expose to plugins:
 - Plugin APIs:
   - adds docs for `logger` and `deprecation_logger`, which have been present for a while.
   - adds docs for `event_factory` (and its sister `targeted_event_factory`), which plugins should use for creating new events
 - Event API:
   - adds docs for several methods that were previously undocumented, and corrects factual errors in existing docs.
   - adds info about using the `EventFactory` to create events instead of `Event.new`

## Why is it important/What is the impact to the user?

Improving these docs reduces the frustration developers face when writing plugins that are implemented against these APIs. It makes clear what we promise, so that they don't have to rely on implementation details that may be accidentally changed.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- ~[ ] My code follows the style guidelines of this project~
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

Documents EventFactory introduced in https://github.com/elastic/logstash/pull/13017
Documents DeprecationLogger introduced in https://github.com/elastic/logstash/pull/11260
