### PR TITLE
Doc: Add placeholder for release notes

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in the following releases:
 
+* <<logstash-6-8-18,Logstash 6.8.18>>
 * <<logstash-6-8-17,Logstash 6.8.17>>
 * <<logstash-6-8-16,Logstash 6.8.16>>
 * <<logstash-6-8-15,Logstash 6.8.15>>
@@ -48,6 +49,14 @@ This section summarizes the changes in the following releases:
 * <<logstash-6-1-2,Logstash 6.1.2>>
 * <<logstash-6-1-1,Logstash 6.1.1>>
 * <<logstash-6-1-0,Logstash 6.1.0>>
+
+[[logstash-6-8-18]]
+=== Logstash 6.8.18 Release Notes
+
+coming[6.8.18]
+
+==== Plugins
+
 
 [[logstash-6-8-17]]
 === Logstash 6.8.17 Release Notes


### PR DESCRIPTION
Placeholder for 6.8.18 release notes

**PREVIEW:** https://logstash_13110.docs-preview.app.elstc.co/guide/en/logstash/6.8/logstash-6-8-18.html