### PR TITLE
fix geoip `database` path got overwritten

### DIFF
--- a/x-pack/lib/filters/geoip/database_manager.rb
+++ b/x-pack/lib/filters/geoip/database_manager.rb
@@ -36,7 +36,7 @@ module LogStash module Filters module Geoip class DatabaseManager
     @mode = database_path.nil? ? :online : :offline
     @mode = :disabled # This is a temporary change that turns off the database manager until it is ready for general availability.
     @database_type = database_type
-    @database_path = ::Dir.glob(::File.join(LogStash::Environment::LOGSTASH_HOME, "vendor", "**", "GeoLite2-#{database_type}.mmdb")).first
+    @database_path = patch_database_path(database_path)
 
     if @mode == :online
       logger.info "By not manually configuring a database path with `database =>`, you accepted and agreed MaxMind EULA. "\
@@ -115,7 +115,7 @@ module LogStash module Filters module Geoip class DatabaseManager
   # return a valid database path or default database path
   def patch_database_path(database_path)
     return database_path if file_exist?(database_path)
-    return database_path if database_path = get_file_path("#{DB_PREFIX}#{@database_type}.#{DB_EXT}") and file_exist?(database_path)
+    return database_path if database_path = ::Dir.glob(::File.join(LogStash::Environment::LOGSTASH_HOME, "vendor", "**", "GeoLite2-#{@database_type}.mmdb")).first and file_exist?(database_path)
     raise "You must specify 'database => ...' in your geoip filter (I looked for '#{database_path}')"
   end
 

--- a/x-pack/spec/filters/geoip/database_manager_spec.rb
+++ b/x-pack/spec/filters/geoip/database_manager_spec.rb
@@ -33,12 +33,34 @@ describe LogStash::Filters::Geoip do
 
       it "use CC license database as default" do
         path = db_manager.send(:patch_database_path, "")
-        expect(path).to eq(default_city_db_path)
+        expect(path).to eq(vendor_city_db_path)
       end
 
       it "failed when default database is missing" do
         expect(db_manager).to receive(:file_exist?).and_return(false, false)
         expect { db_manager.send(:patch_database_path, "") }.to raise_error /I looked for/
+      end
+    end
+
+    context "get database path" do
+      context "config static path" do
+        let(:db_manager) do
+          LogStash::Filters::Geoip::DatabaseManager.new(mock_geoip_plugin, default_asn_db_path, "ASN", get_vendor_path)
+        end
+
+        it "use input path" do
+          expect(db_manager.database_path).to eq(default_asn_db_path)
+        end
+      end
+
+      context "config nothing" do
+        let(:db_manager) do
+          LogStash::Filters::Geoip::DatabaseManager.new(mock_geoip_plugin, nil, "City", get_vendor_path)
+        end
+
+        it "use CC license database as default" do
+          expect(db_manager.database_path).to eq(vendor_city_db_path)
+        end
       end
     end
 
@@ -224,5 +246,6 @@ describe LogStash::Filters::Geoip do
         expect(filename).to match /#{default_city_db_name}/
       end
     end
+
   end
 end

--- a/x-pack/spec/filters/geoip/test_helper.rb
+++ b/x-pack/spec/filters/geoip/test_helper.rb
@@ -18,6 +18,14 @@ module GeoipHelper
     ::File.join(get_data_dir, filename)
   end
 
+  def vendor_asn_db_path
+    ::Dir.glob(::File.join(LogStash::Environment::LOGSTASH_HOME, "vendor", "**", "GeoLite2-ASN.mmdb")).first
+  end
+
+  def vendor_city_db_path
+    ::Dir.glob(::File.join(LogStash::Environment::LOGSTASH_HOME, "vendor", "**", "GeoLite2-City.mmdb")).first
+  end
+
   def md5(file_path)
     ::File.exist?(file_path) ? Digest::MD5.hexdigest(::File.read(file_path)) : ''
   end


### PR DESCRIPTION
Fixed: #13108

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Fix the configuration of  GeoIP `database` path that is overwritten to the default value in 7.13.4.

## What does this PR do?
The `database` path is overwritten in the [last](https://github.com/elastic/logstash/pull/13076/files#diff-ab6d19a69e9916bb6e9ffed07fba608bb7670d410d01f8dd51387ffbd612072bR39) version 7.13.4
This PR respects user input and pointed the default *.mmdb database to the original vendor directory (plugin gem bundled)

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author checklist
- [ ] checkout geoip filter plugin project v7.1.3. `jruby -rbundler/setup -S rspec -fd spec/filters/*_spec.rb` all tests should be green.

## How to test this PR locally

- [ ] test with a customize `database` path. The output should contain `as_org`

```
    input {
      heartbeat {
        message => '{"host": "55.159.212.43", "app": "barfoo", "amount": 82.95}'
        interval => 10
      }
    }
    filter {
      json {
        source => "message"
      }
      geoip {
        source => "[host]"
        target => "[server]"
        database => $LS_HOME/vendor/bundle/jruby/2.5.0/gems/logstash-filter-geoip-7.1.3-java/vendor/GeoLite2-ASN.mmdb
      }
    }
    output {
      stdout { codec => rubydebug }
    }
```
- [ ] test without `database` path. The default City database is loaded. The output should contain `continent_code`, `country_name`


