### PR TITLE
Doc: Move shared region tags for breaking changes to 8.0.0 content

### DIFF
--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -29,6 +29,7 @@ See also <<releasenotes>>.
 === Breaking changes in 8.0
 Here are the breaking changes for 8.0.
 
+// tag::notable-breaking-changes[]
 [discrete]
 [[bc-core]]
 ==== Changes in Logstash Core
@@ -51,14 +52,13 @@ The Field Reference parser interprets references to fields in your pipelines and
 plugins. It was configurable in 7.x, with the default set to strict to reject
 inputs that are ambiguous or illegal. Configurability is removed in 8.0. Now
 {ls} rejects ambiguous and illegal inputs as standard behavior.
-
+// end::notable-breaking-changes[]
 
 [[breaking-7.0]]
 === Breaking changes in 7.0
 
 Here are the breaking changes for {ls} 7.0. 
 
-// tag::notable-breaking-changes[]
 [discrete]
 ==== Changes in Logstash Core
 
@@ -252,7 +252,6 @@ support multiple document types any more
 
 * Removed obsolete `message_format` option
 
-// end::notable-breaking-changes[]
 
 [[breaking-pq]]
 === Breaking change across PQ versions prior to Logstash 6.3.0


### PR DESCRIPTION
## Release notes
[rn:skip] 

## What does this PR do?
Relocates shared region tags to highlight 8.0.0 breaking changes
