### PR TITLE
[backport 7.x] Update Snakeyaml version to 1.29 (#13129)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'org.yaml:snakeyaml:1.17'
+        classpath 'org.yaml:snakeyaml:1.29'
         classpath "gradle.plugin.com.github.jk1:gradle-license-report:0.7.1"
     }
 }

--- a/logstash-core/benchmarks/build.gradle
+++ b/logstash-core/benchmarks/build.gradle
@@ -37,7 +37,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'org.yaml:snakeyaml:1.17'
+    classpath 'org.yaml:snakeyaml:1.29'
     classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.4'
   }
 }

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -41,7 +41,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.yaml:snakeyaml:1.17'
+        classpath 'org.yaml:snakeyaml:1.29'
     }
 }
 

--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -23,7 +23,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.yaml:snakeyaml:1.23'
+        classpath 'org.yaml:snakeyaml:1.29'
         classpath "de.undercouch:gradle-download-task:4.0.4"
         classpath "org.jruby:jruby-complete:9.2.19.0"
     }

--- a/tools/benchmark-cli/build.gradle
+++ b/tools/benchmark-cli/build.gradle
@@ -38,7 +38,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'org.yaml:snakeyaml:1.17'
+    classpath 'org.yaml:snakeyaml:1.29'
     classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.4'
   }
 }

--- a/tools/dependencies-report/build.gradle
+++ b/tools/dependencies-report/build.gradle
@@ -37,7 +37,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'org.yaml:snakeyaml:1.17'
+    classpath 'org.yaml:snakeyaml:1.29'
     classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.4'
   }
 }

--- a/tools/ingest-converter/build.gradle
+++ b/tools/ingest-converter/build.gradle
@@ -36,7 +36,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'org.yaml:snakeyaml:1.17'
+    classpath 'org.yaml:snakeyaml:1.29'
     classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.4'
   }
 }


### PR DESCRIPTION
Clean backport of #13129 to branch `7.x`

----

Snakeyaml is used only in the build chain, and it's not packaged with Logstash

(cherry picked from commit a7f6c01a3a8ba960233c4f7437964de67605ea92)
