### PR TITLE
Deps: temp lock elasticsearch to 7.14.1.pre

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -26,3 +26,8 @@ gem "logstash-devutils", "~> 2", :group => :development
 gem "rack-test", :require => "rack/test", :group => :development
 gem "rspec", "~> 3.5", :group => :development
 gem "webmock", "~> 3", :group => :development
+
+# hopefully temporary - till 7.14.1 is released (31.8.2021)
+gem 'elasticsearch', '7.14.1.pre'
+gem 'elasticsearch-api', '7.14.1.pre'
+gem 'elasticsearch-transport', '7.14.1.pre'


### PR DESCRIPTION

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

- due https://github.com/elastic/logstash/issues/13136
- and https://github.com/elastic/logstash/issues/13122