### PR TITLE
Refactor: report Java thread name in thread info

### DIFF
--- a/logstash-core/lib/logstash/util.rb
+++ b/logstash-core/lib/logstash/util.rb
@@ -24,6 +24,7 @@ module LogStash::Util
   end
 
   PR_SET_NAME = 15
+
   def self.set_thread_name(name)
     previous_name = Java::java.lang.Thread.currentThread.getName() if block_given?
 
@@ -34,7 +35,6 @@ module LogStash::Util
     if UNAME == "linux"
       require "logstash/util/prctl"
       # prctl PR_SET_NAME allows up to 16 bytes for a process name
-      # since MRI 1.9, JRuby, and Rubinius use system threads for this.
       LibC.prctl(PR_SET_NAME, name[0..16], 0, 0, 0)
     end
 
@@ -65,7 +65,7 @@ module LogStash::Util
 
     {
       "thread_id" => get_thread_id(thread), # might be nil for dead threads
-      "name" => thread[:name],
+      "name" => thread[:name] || get_thread_name(thread),
       "plugin" => (thread[:plugin] ? thread[:plugin].debug_info : nil),
       "backtrace" => backtrace,
       "blocked_on" => blocked_on,

--- a/logstash-core/src/main/java/org/logstash/util/UtilExt.java
+++ b/logstash-core/src/main/java/org/logstash/util/UtilExt.java
@@ -44,6 +44,17 @@ public class UtilExt {
         return javaThread == null ? context.nil : context.runtime.newFixnum(javaThread.getId());
     }
 
+    @JRubyMethod(module = true)
+    public static IRubyObject get_thread_name(final ThreadContext context, IRubyObject self, IRubyObject thread) {
+        if (!(thread instanceof RubyThread)) {
+            throw context.runtime.newTypeError(thread, context.runtime.getThread());
+        }
+        final Thread javaThread = ((RubyThread) thread).getNativeThread(); // weak-reference
+        // even if thread is dead the RubyThread instance might stick around while the Java thread
+        // instance already could have been garbage collected - let's return nil for dead meat :
+        return javaThread == null ? context.nil : context.runtime.newString(javaThread.getName());
+    }
+
     @JRubyMethod(module = true) // JRuby.reference(target).synchronized { ... }
     public static IRubyObject synchronize(final ThreadContext context, IRubyObject self, IRubyObject target, Block block) {
         synchronized (target) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

When reporting stalled threads (e.g. an input thread) they usually have a meaningful Java thread name, these changes will cause the Java thread name to be reported (on `PipelineRepoter#to_hash`).

## Why is it important/What is the impact to the user?

N/A
