### PR TITLE
Deps: drop old and unused gem dependencies

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -4,7 +4,6 @@
 source "https://rubygems.org"
 gem "logstash-core", :path => "./logstash-core"
 gem "logstash-core-plugin-api", :path => "./logstash-core-plugin-api"
-gem "atomic", "~> 1"
 gem "builder", "~> 3"
 gem "paquet", "~> 0.2"
 gem "pleaserun", "~>0.0.28"

--- a/Gemfile.template
+++ b/Gemfile.template
@@ -4,7 +4,7 @@
 source "https://rubygems.org"
 gem "logstash-core", :path => "./logstash-core"
 gem "logstash-core-plugin-api", :path => "./logstash-core-plugin-api"
-gem "builder", "~> 3"
+
 gem "paquet", "~> 0.2"
 gem "pleaserun", "~>0.0.28"
 gem "rake", "~> 12"
@@ -16,6 +16,7 @@ gem "gems", "~> 1", :group => :build
 gem "octokit", "~> 4", :group => :build
 gem "rubyzip", "~> 1", :group => :build
 gem "stud", "~> 0.0.22", :group => :build
+
 gem "belzebuth", :group => :development
 gem "benchmark-ips", :group => :development
 gem "ci_reporter_rspec", "~> 1", :group => :development


### PR DESCRIPTION
Remove dependencies that are no longer used and outdated.

- atomic gem was [manually pinned in LS](https://github.com/elastic/logstash/commit/cbbfcd42c2d68abbecbb292bc28723784b903f0e) despite being a plugin dependency
  * the issue it was supposed to resolve is no longer relevant (https://github.com/elastic/logstash/issues/9194)
  
- builder gem was introduced with the [plugin manager work](https://github.com/elastic/logstash/commit/12cfa69215e186bcdf39006e8964f6fcbe769942#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR10) ... yet wasn't used
  * unable to find any `Builder` usage in LS or plugins themselves

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

Removes unnecessary dependencies.

## Why is it important/What is the impact to the user?

No user impact.

## Author's Checklist

- [x] :coffee: 
