### PR TITLE
Test: better logging reconfiguration asserts

### DIFF
--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -113,9 +113,6 @@ logger.slowlog.appenderRef.console_slowlog.ref = ${sys:ls.log.format}_console_sl
 logger.slowlog.appenderRef.rolling_slowlog.ref = ${sys:ls.log.format}_rolling_slowlog
 logger.slowlog.additivity = false
 
-logger.licensereader.name = logstash.licensechecker.licensereader
-logger.licensereader.level = error
-
 # Silence http-client by default
 logger.apache_http_client.name = org.apache.http
 logger.apache_http_client.level = fatal

--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -113,6 +113,9 @@ logger.slowlog.appenderRef.console_slowlog.ref = ${sys:ls.log.format}_console_sl
 logger.slowlog.appenderRef.rolling_slowlog.ref = ${sys:ls.log.format}_rolling_slowlog
 logger.slowlog.additivity = false
 
+logger.licensereader.name = logstash.licensechecker.licensereader
+logger.licensereader.level = error
+
 # Silence http-client by default
 logger.apache_http_client.name = org.apache.http
 logger.apache_http_client.level = fatal

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -150,9 +150,9 @@ describe "Test Monitoring API" do
       result["loggers"].each do | k, v |
         #since we explicitly set the logstash.agent logger above, the logger.logstash parent logger will not take precedence
         if !k.eql?("logstash.agent") && (k.start_with?("logstash") || k.start_with?("slowlog") || k.start_with?("deprecation"))
-          expect(v).to eq("ERROR")
+          expect(v).to eq("ERROR"), "logger '#{k}' has logging level: #{v} expected: ERROR"
         else
-          expect(v).to eq("INFO")
+          expect(v).to eq("INFO"), "logger '#{k}' has logging level: #{v} expected: INFO"
         end
       end
 
@@ -176,7 +176,7 @@ describe "Test Monitoring API" do
   end
 
   def logging_put_assert(result)
-    expect(result["acknowledged"]).to be(true)
+    expect(result['acknowledged']).to be(true), "result not acknowledged, got: #{result.inspect}"
   end
 
 end

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -149,7 +149,14 @@ describe "Test Monitoring API" do
     #deprecation package loggers
     logging_put_assert logstash_service.monitoring_api.logging_put({"logger.deprecation.logstash" => "ERROR"})
 
-    logging_get_assert logstash_service, "ERROR", "ERROR"
+    result = logstash_service.monitoring_api.logging_get
+    result["loggers"].each do | k, v |
+      next if k.eql?("logstash.agent")
+      #since we explicitly set the logstash.agent logger above, the logger.logstash parent logger will not take precedence
+      if k.start_with?("logstash") || k.start_with?("slowlog") || k.start_with?("deprecation")
+        expect(v).to eq("ERROR")
+      end
+    end
 
     # all log levels should be reset to original values
     logging_put_assert logstash_service.monitoring_api.logging_reset

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -170,9 +170,9 @@ describe "Test Monitoring API" do
     result["loggers"].each do | k, v |
       next if k.eql?(skip)
       if k.start_with? "logstash", "org.logstash" #logstash is the ruby namespace, and org.logstash for java
-        expect(v).to eq(logstash_level), "logger '#{k}' has logging level: #{v} expected: #{logstash_level}"
+        expect(v).to eq(logstash_level), "logstash logger '#{k}' has logging level: #{v} expected: #{logstash_level}"
       elsif k.start_with? "slowlog"
-        expect(v).to eq(slowlog_level), "logger '#{k}' has logging level: #{v} expected: #{slowlog_level}"
+        expect(v).to eq(slowlog_level), "slowlog logger '#{k}' has logging level: #{v} expected: #{slowlog_level}"
       end
     end
   end

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -43,10 +43,10 @@ describe "Test Monitoring API" do
     logstash_service.wait_for_logstash
     number_of_events.times { logstash_service.write_to_stdin("Hello world") }
 
-    Stud.try(max_retry.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
+    try(max_retry) do
       # event_stats can fail if the stats subsystem isn't ready
       result = logstash_service.monitoring_api.event_stats rescue nil
-      expect(result).not_to be_nil
+      expect(result).not_to be_nil; pp result
       expect(result["in"]).to eq(number_of_events)
     end
   end
@@ -56,7 +56,7 @@ describe "Test Monitoring API" do
     logstash_service.start_with_stdin
     logstash_service.wait_for_logstash
 
-    Stud.try(max_retry.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
+    try(max_retry) do
       # node_stats can fail if the stats subsystem isn't ready
       result = logstash_service.monitoring_api.node_stats rescue nil
       expect(result).not_to be_nil
@@ -69,7 +69,7 @@ describe "Test Monitoring API" do
     logstash_service = @fixture.get_service("logstash")
     logstash_service.start_with_stdin
     logstash_service.wait_for_logstash
-    Stud.try(max_retry.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
+    try(max_retry) do
       # node_stats can fail if the stats subsystem isn't ready
       result = logstash_service.monitoring_api.node_stats rescue nil
       expect(result).not_to be_nil
@@ -89,7 +89,7 @@ describe "Test Monitoring API" do
     logstash_service.start_with_stdin
     logstash_service.wait_for_logstash
 
-    Stud.try(max_retry.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
+    try(max_retry) do
       # node_stats can fail if the stats subsystem isn't ready
       result = logstash_service.monitoring_api.node_stats rescue nil
       expect(result).not_to be_nil
@@ -119,12 +119,11 @@ describe "Test Monitoring API" do
     logstash_service.start_with_stdin
     logstash_service.wait_for_logstash
 
-    Stud.try(max_retry.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
+    try(max_retry) do
       # monitoring api can fail if the subsystem isn't ready
       result = logstash_service.monitoring_api.logging_get rescue nil
       expect(result).not_to be_nil
       expect(result["loggers"].size).to be > 0
-      sleep(0.1)
     end
 
     #default

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -43,7 +43,7 @@ describe "Test Monitoring API" do
     logstash_service.wait_for_logstash
     number_of_events.times { logstash_service.write_to_stdin("Hello world") }
 
-    try(max_retry) do
+    Stud.try(max_retry.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
       # event_stats can fail if the stats subsystem isn't ready
       result = logstash_service.monitoring_api.event_stats rescue nil
       expect(result).not_to be_nil
@@ -69,7 +69,7 @@ describe "Test Monitoring API" do
     logstash_service = @fixture.get_service("logstash")
     logstash_service.start_with_stdin
     logstash_service.wait_for_logstash
-    try(max_retry) do
+    Stud.try(max_retry.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
       # node_stats can fail if the stats subsystem isn't ready
       result = logstash_service.monitoring_api.node_stats rescue nil
       expect(result).not_to be_nil
@@ -89,7 +89,7 @@ describe "Test Monitoring API" do
     logstash_service.start_with_stdin
     logstash_service.wait_for_logstash
 
-    try(max_retry) do
+    Stud.try(max_retry.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
       # node_stats can fail if the stats subsystem isn't ready
       result = logstash_service.monitoring_api.node_stats rescue nil
       expect(result).not_to be_nil
@@ -119,7 +119,7 @@ describe "Test Monitoring API" do
     logstash_service.start_with_stdin
     logstash_service.wait_for_logstash
 
-    try(max_retry) do
+    Stud.try(max_retry.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
       # monitoring api can fail if the subsystem isn't ready
       result = logstash_service.monitoring_api.logging_get rescue nil
       expect(result).not_to be_nil

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -168,7 +168,7 @@ describe "Test Monitoring API" do
   def logging_get_assert(logstash_service, logstash_level, slowlog_level, skip: '')
     result = logstash_service.monitoring_api.logging_get
     result["loggers"].each do | k, v |
-      next if k.eql?(skip)
+      next if !k.empty? && k.eql?(skip)
       if k.start_with? "logstash", "org.logstash" #logstash is the ruby namespace, and org.logstash for java
         expect(v).to eq(logstash_level), "logstash logger '#{k}' has logging level: #{v} expected: #{logstash_level}"
       elsif k.start_with? "slowlog"

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -149,7 +149,6 @@ describe "Test Monitoring API" do
     #deprecation package loggers
     logging_put_assert logstash_service.monitoring_api.logging_put({"logger.deprecation.logstash" => "ERROR"})
 
-    logging_put_assert logstash_service.monitoring_api.logging_get
     logging_get_assert logstash_service, "ERROR", "ERROR"
 
     # all log levels should be reset to original values

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -150,7 +150,10 @@ describe "Test Monitoring API" do
     logging_put_assert logstash_service.monitoring_api.logging_put({"logger.deprecation.logstash" => "ERROR"})
 
     result = logstash_service.monitoring_api.logging_get
+    puts "CAN_CONFIGURE_LOGGING:"
+    pp result
     result["loggers"].each do | k, v |
+      puts "> CAN_CONFIGURE_LOGGING: #{k} -> #{v.inspect}"
       #since we explicitly set the logstash.agent logger above, the logger.logstash parent logger will not take precedence
       if !k.eql?("logstash.agent") && (k.start_with?("logstash") || k.start_with?("slowlog") || k.start_with?("deprecation"))
         expect(v).to eq("ERROR"), "logger '#{k}' has logging level: #{v} expected: ERROR"

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -165,7 +165,7 @@ describe "Test Monitoring API" do
 
   private
 
-  def logging_get_assert(logstash_service, logstash_level, slowlog_level, skip: false)
+  def logging_get_assert(logstash_service, logstash_level, slowlog_level, skip: '')
     result = logstash_service.monitoring_api.logging_get
     result["loggers"].each do | k, v |
       next if k.eql?(skip)

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -46,7 +46,7 @@ describe "Test Monitoring API" do
     try(max_retry) do
       # event_stats can fail if the stats subsystem isn't ready
       result = logstash_service.monitoring_api.event_stats rescue nil
-      expect(result).not_to be_nil; pp result
+      expect(result).not_to be_nil
       expect(result["in"]).to eq(number_of_events)
     end
   end
@@ -149,18 +149,8 @@ describe "Test Monitoring API" do
     #deprecation package loggers
     logging_put_assert logstash_service.monitoring_api.logging_put({"logger.deprecation.logstash" => "ERROR"})
 
-    result = logstash_service.monitoring_api.logging_get
-    puts "CAN_CONFIGURE_LOGGING:"
-    pp result
-    result["loggers"].each do | k, v |
-      puts "> CAN_CONFIGURE_LOGGING: #{k} -> #{v.inspect}"
-      #since we explicitly set the logstash.agent logger above, the logger.logstash parent logger will not take precedence
-      if !k.eql?("logstash.agent") && (k.start_with?("logstash") || k.start_with?("slowlog") || k.start_with?("deprecation"))
-        expect(v).to eq("ERROR"), "logger '#{k}' has logging level: #{v} expected: ERROR"
-      else
-        expect(v).to eq("INFO"), "logger '#{k}' has logging level: #{v} expected: INFO"
-      end
-    end
+    logging_put_assert logstash_service.monitoring_api.logging_get
+    logging_get_assert logstash_service, "ERROR", "ERROR"
 
     # all log levels should be reset to original values
     logging_put_assert logstash_service.monitoring_api.logging_reset


### PR DESCRIPTION
LS' monitoring logging specs were failing, interestingly (initially) only one target failed.
After some adjusting to not assert stuff (log4j2 configuration) outside the specs' control both targets went :red_circle:.

The incriminating spec did not account for loading more libraries -> having more libraries explicitly configured e.g.
```properties
logger.apache_http_client.name = org.apache.http
logger.apache_http_client.level = fatal
```

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

Improves asserts in spec, resolved :red_circle: CI.

## Why is it important/What is the impact to the user?

N/A
