### PR TITLE
[7.14] Test: improve monitoring api logging asserts (#13164)

### DIFF
--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -56,7 +56,7 @@ describe "Test Monitoring API" do
     logstash_service.start_with_stdin
     logstash_service.wait_for_logstash
 
-    Stud.try(max_retry.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
+    try(max_retry) do
       # node_stats can fail if the stats subsystem isn't ready
       result = logstash_service.monitoring_api.node_stats rescue nil
       expect(result).not_to be_nil
@@ -124,59 +124,61 @@ describe "Test Monitoring API" do
       result = logstash_service.monitoring_api.logging_get rescue nil
       expect(result).not_to be_nil
       expect(result["loggers"].size).to be > 0
-      #default
-      logging_get_assert logstash_service, "INFO", "TRACE"
-
-      #root logger - does not apply to logger.slowlog
-      logging_put_assert logstash_service.monitoring_api.logging_put({"logger." => "WARN"})
-      logging_get_assert logstash_service, "WARN", "TRACE"
-      logging_put_assert logstash_service.monitoring_api.logging_put({"logger." => "INFO"})
-      logging_get_assert logstash_service, "INFO", "TRACE"
-
-      #package logger
-      logging_put_assert logstash_service.monitoring_api.logging_put({"logger.logstash.agent" => "DEBUG"})
-      expect(logstash_service.monitoring_api.logging_get["loggers"]["logstash.agent"]).to eq ("DEBUG")
-      logging_put_assert logstash_service.monitoring_api.logging_put({"logger.logstash.agent" => "INFO"})
-      logging_get_assert logstash_service, "INFO", "TRACE"
-
-      #parent package loggers
-      logging_put_assert logstash_service.monitoring_api.logging_put({"logger.logstash" => "ERROR"})
-      logging_put_assert logstash_service.monitoring_api.logging_put({"logger.slowlog" => "ERROR"})
-
-      #deprecation package loggers
-      logging_put_assert logstash_service.monitoring_api.logging_put({"logger.deprecation.logstash" => "ERROR"})
-
-      result = logstash_service.monitoring_api.logging_get
-      result["loggers"].each do | k, v |
-        #since we explicitly set the logstash.agent logger above, the logger.logstash parent logger will not take precedence
-        if !k.eql?("logstash.agent") && (k.start_with?("logstash") || k.start_with?("slowlog") || k.start_with?("deprecation"))
-          expect(v).to eq("ERROR")
-        else
-          expect(v).to eq("INFO")
-        end
-      end
-
-      # all log levels should be reset to original values
-      logging_put_assert logstash_service.monitoring_api.logging_reset
-      logging_get_assert logstash_service, "INFO", "TRACE"
     end
+
+    #default
+    logging_get_assert logstash_service, "INFO", "TRACE",
+                       skip: 'logstash.licensechecker.licensereader' #custom (ERROR) level to start with
+
+    #root logger - does not apply to logger.slowlog
+    logging_put_assert logstash_service.monitoring_api.logging_put({"logger." => "WARN"})
+    logging_get_assert logstash_service, "WARN", "TRACE"
+    logging_put_assert logstash_service.monitoring_api.logging_put({"logger." => "INFO"})
+    logging_get_assert logstash_service, "INFO", "TRACE"
+
+    #package logger
+    logging_put_assert logstash_service.monitoring_api.logging_put({"logger.logstash.agent" => "DEBUG"})
+    expect(logstash_service.monitoring_api.logging_get["loggers"]["logstash.agent"]).to eq ("DEBUG")
+    logging_put_assert logstash_service.monitoring_api.logging_put({"logger.logstash.agent" => "INFO"})
+    expect(logstash_service.monitoring_api.logging_get["loggers"]["logstash.agent"]).to eq ("INFO")
+
+    #parent package loggers
+    logging_put_assert logstash_service.monitoring_api.logging_put({"logger.logstash" => "ERROR"})
+    logging_put_assert logstash_service.monitoring_api.logging_put({"logger.slowlog" => "ERROR"})
+
+    #deprecation package loggers
+    logging_put_assert logstash_service.monitoring_api.logging_put({"logger.deprecation.logstash" => "ERROR"})
+
+    result = logstash_service.monitoring_api.logging_get
+    result["loggers"].each do | k, v |
+      next if k.eql?("logstash.agent")
+      #since we explicitly set the logstash.agent logger above, the logger.logstash parent logger will not take precedence
+      if k.start_with?("logstash") || k.start_with?("slowlog") || k.start_with?("deprecation")
+        expect(v).to eq("ERROR")
+      end
+    end
+
+    # all log levels should be reset to original values
+    logging_put_assert logstash_service.monitoring_api.logging_reset
+    logging_get_assert logstash_service, "INFO", "TRACE"
   end
 
   private
 
-  def logging_get_assert(logstash_service, logstash_level, slowlog_level)
+  def logging_get_assert(logstash_service, logstash_level, slowlog_level, skip: '')
     result = logstash_service.monitoring_api.logging_get
     result["loggers"].each do | k, v |
+      next if !k.empty? && k.eql?(skip)
       if k.start_with? "logstash", "org.logstash" #logstash is the ruby namespace, and org.logstash for java
-        expect(v).to eq(logstash_level)
+        expect(v).to eq(logstash_level), "logstash logger '#{k}' has logging level: #{v} expected: #{logstash_level}"
       elsif k.start_with? "slowlog"
-        expect(v).to eq(slowlog_level)
+        expect(v).to eq(slowlog_level), "slowlog logger '#{k}' has logging level: #{v} expected: #{slowlog_level}"
       end
     end
   end
 
   def logging_put_assert(result)
-    expect(result["acknowledged"]).to be(true)
+    expect(result['acknowledged']).to be(true), "result not acknowledged, got: #{result.inspect}"
   end
 
 end


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Test: improve monitoring api logging asserts (#13164)