### PR TITLE
[backport 7.x]Update bundled JDK to 11.0.12+7 #13185

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -7,8 +7,8 @@ logstash-core-plugin-api: 2.1.16
 bundled_jdk:
   # for AdoptOpenJDK/OpenJDK jdk-14.0.1+7.1, the revision is 14.0.1 while the build is 7.1
   vendor: "adoptopenjdk"
-  revision: 11.0.11
-  build: 9
+  revision: 11.0.12
+  build: 7
 
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time


### PR DESCRIPTION
Clean backport of #13185 to branch `7.x`

(cherry picked from commit ebb9e04d14666bc2400bf548dba8e89f425d6aad)

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
check RN in #13185