### PR TITLE
Refactor: make sure plugin logger sets context

### DIFF
--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -65,18 +65,11 @@ class LogStash::Plugin
   end
 
   def initialize(params={})
-    @logger = self.logger
-    @deprecation_logger = self.deprecation_logger
-    # need to access settings statically because plugins are initialized in config_ast with no context.
-    settings = LogStash::SETTINGS
-    @slow_logger = self.slow_logger(settings.get("slowlog.threshold.warn").to_nanos,
-                                    settings.get("slowlog.threshold.info").to_nanos,
-                                    settings.get("slowlog.threshold.debug").to_nanos,
-                                    settings.get("slowlog.threshold.trace").to_nanos)
     @params = LogStash::Util.deep_clone(params)
     # The id should always be defined normally, but in tests that might not be the case
     # In the future we may make this more strict in the Plugin API
     @params["id"] ||= "#{self.class.config_name}_#{SecureRandom.uuid}"
+    __initialize_logging # after id is generated
   end
 
   # Return a uniq ID for this plugin configuration, by default
@@ -191,4 +184,24 @@ class LogStash::Plugin
   def execution_context
     @execution_context || LogStash::ExecutionContext::Empty
   end
+
+  # override Loggable (self.class.logger) delegating methods :
+
+  attr_reader :logger
+  attr_reader :deprecation_logger
+  attr_reader :slow_logger
+
+  private
+
+  def __initialize_logging
+    @logger = self.class.logger
+    @deprecation_logger = self.class.deprecation_logger
+    # need to access settings statically because plugins are initialized in config_ast with no context.
+    settings = LogStash::SETTINGS
+    @slow_logger = self.class.slow_logger(settings.get("slowlog.threshold.warn").to_nanos,
+                                          settings.get("slowlog.threshold.info").to_nanos,
+                                          settings.get("slowlog.threshold.debug").to_nanos,
+                                          settings.get("slowlog.threshold.trace").to_nanos)
+  end
+
 end # class LogStash::Plugin

--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -194,7 +194,7 @@ class LogStash::Plugin
   private
 
   def __initialize_logging
-    @logger = self.class.logger
+    @logger = LogStash::Logging::PluginLogger.new(self)
     @deprecation_logger = self.class.deprecation_logger
     # need to access settings statically because plugins are initialized in config_ast with no context.
     settings = LogStash::SETTINGS

--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -204,4 +204,12 @@ class LogStash::Plugin
                                           settings.get("slowlog.threshold.trace").to_nanos)
   end
 
+  # TODO do we want to keep this around due plugin specs mocking logger through the class.logger call?!
+  # 
+  # @override LogStash::Util::Loggable.logger
+  # @private
+  # def self.logger(plugin = nil)
+  #   plugin.nil? ? super() : LogStash::Logging::PluginLogger.new(plugin)
+  # end
+
 end # class LogStash::Plugin

--- a/logstash-core/spec/logstash/config/mixin_spec.rb
+++ b/logstash-core/spec/logstash/config/mixin_spec.rb
@@ -37,7 +37,7 @@ describe LogStash::Config::Mixin do
     end
 
     it "should not log the password" do
-      expect(LogStash::Logging::Logger).to receive(:new).with(anything).and_return(double_logger)
+      expect(LogStash::Logging::PluginLogger).to receive(:new).with(anything).and_return(double_logger)
       expect(double_logger).to receive(:warn) do |arg1,arg2|
           message = 'You are using a deprecated config setting "old_opt" set in test_deprecated. Deprecated settings will continue to work, but are scheduled for removal from logstash in the future. this is old school If you have any questions about this, please visit the #logstash channel on freenode irc.'
           expect(arg1).to eq(message)

--- a/logstash-core/src/main/java/org/logstash/RubyUtil.java
+++ b/logstash-core/src/main/java/org/logstash/RubyUtil.java
@@ -72,6 +72,7 @@ import org.logstash.instrument.metrics.SnapshotExt;
 import org.logstash.log.DeprecationLoggerExt;
 import org.logstash.log.LoggableExt;
 import org.logstash.log.LoggerExt;
+import org.logstash.log.PluginLoggerExt;
 import org.logstash.log.SlowLoggerExt;
 import org.logstash.plugins.HooksRegistryExt;
 import org.logstash.plugins.UniversalPluginExt;
@@ -477,6 +478,8 @@ public final class RubyUtil {
         final RubyModule loggingModule = LOGSTASH_MODULE.defineOrGetModuleUnder("Logging");
         LOGGER = loggingModule.defineClassUnder("Logger", RUBY.getObject(), LoggerExt::new);
         LOGGER.defineAnnotatedMethods(LoggerExt.class);
+        final RubyClass pluginLoggerClass = loggingModule.defineClassUnder("PluginLogger", LOGGER, PluginLoggerExt::new);
+        pluginLoggerClass.defineAnnotatedMethods(PluginLoggerExt.class);
         SLOW_LOGGER = loggingModule.defineClassUnder(
             "SlowLogger", RUBY.getObject(), SlowLoggerExt::new);
         SLOW_LOGGER.defineAnnotatedMethods(SlowLoggerExt.class);

--- a/logstash-core/src/main/java/org/logstash/log/DeprecationLoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/DeprecationLoggerExt.java
@@ -61,9 +61,9 @@ public class DeprecationLoggerExt extends RubyObject {
     @JRubyMethod(name = "deprecated", required = 1, optional = 1)
     public IRubyObject rubyDeprecated(final ThreadContext context, final IRubyObject[] args) {
         if (args.length > 1) {
-            logger.deprecated(args[0].asJavaString(), args[1]);
+            logger.deprecated(args[0].toString(), args[1]);
         } else {
-            logger.deprecated(args[0].asJavaString());
+            logger.deprecated(args[0].toString());
         }
         return this;
     }

--- a/logstash-core/src/main/java/org/logstash/log/LoggableExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/LoggableExt.java
@@ -35,8 +35,8 @@ import static org.logstash.log.SlowLoggerExt.toLong;
 
 /**
  * JRuby extension, it's part of log4j wrapping for JRuby.
- * */
-@JRubyModule(name = "Loggable")
+ */
+@JRubyModule(name = "LogStash::Util::Loggable")
 public final class LoggableExt {
 
     private LoggableExt() {
@@ -67,7 +67,7 @@ public final class LoggableExt {
         return self.getMetaClass().callMethod(context, "deprecation_logger");
     }
 
-    private static String log4jName(final RubyModule self) {
+    static String log4jName(final RubyModule self) {
         String name;
         if (self.getBaseName() == null) { // anonymous module/class
             RubyModule real = self;

--- a/logstash-core/src/main/java/org/logstash/log/LoggableExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/LoggableExt.java
@@ -53,18 +53,18 @@ public final class LoggableExt {
 
     @JRubyMethod
     public static IRubyObject logger(final ThreadContext context, final IRubyObject self) {
-        return self.getSingletonClass().callMethod(context, "logger");
+        return self.getMetaClass().callMethod(context, "logger");
     }
 
     @JRubyMethod(name = "slow_logger", required = 4)
     public static IRubyObject slowLogger(final ThreadContext context, final IRubyObject self,
         final IRubyObject[] args) {
-        return self.getSingletonClass().callMethod(context, "slow_logger", args);
+        return self.getMetaClass().callMethod(context, "slow_logger", args);
     }
 
     @JRubyMethod(name= "deprecation_logger")
     public static IRubyObject deprecationLogger(final ThreadContext context, final IRubyObject self) {
-        return self.getSingletonClass().callMethod(context, "deprecation_logger");
+        return self.getMetaClass().callMethod(context, "deprecation_logger");
     }
 
     private static String log4jName(final RubyModule self) {

--- a/logstash-core/src/main/java/org/logstash/log/LoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/LoggerExt.java
@@ -93,73 +93,73 @@ public class LoggerExt extends RubyObject {
 
     @JRubyMethod
     public IRubyObject trace(final IRubyObject msg) {
-        if (logger.isTraceEnabled()) logger.trace(msg.asJavaString());
+        logger.trace(msg.asString());
         return this;
     }
 
     @JRubyMethod
     public IRubyObject trace(final IRubyObject msg, final IRubyObject data) {
-        if (logger.isTraceEnabled()) logger.trace(msg.asJavaString(), data);
+        if (logger.isTraceEnabled()) logger.trace(msg.toString(), data);
         return this;
     }
 
     @JRubyMethod
     public IRubyObject debug(final IRubyObject msg) {
-        if (logger.isDebugEnabled()) logger.debug(msg.asJavaString());
+        logger.debug(msg.asString());
         return this;
     }
 
     @JRubyMethod
     public IRubyObject debug(final IRubyObject msg, final IRubyObject data) {
-        if (logger.isDebugEnabled()) logger.debug(msg.asJavaString(), data);
+        if (logger.isDebugEnabled()) logger.debug(msg.toString(), data);
         return this;
     }
 
     @JRubyMethod
     public IRubyObject info(final IRubyObject msg) {
-        if (logger.isInfoEnabled()) logger.info(msg.asJavaString());
+        logger.info(msg.asString());
         return this;
     }
 
     @JRubyMethod
     public IRubyObject info(final IRubyObject msg, final IRubyObject data) {
-        if (logger.isInfoEnabled()) logger.info(msg.asJavaString(), data);
+        if (logger.isInfoEnabled()) logger.info(msg.toString(), data);
         return this;
     }
 
     @JRubyMethod
     public IRubyObject warn(final IRubyObject msg) {
-        logger.warn(msg.asJavaString());
+        logger.warn(msg.asString());
         return this;
     }
 
     @JRubyMethod
     public IRubyObject warn(final IRubyObject msg, final IRubyObject data) {
-        logger.warn(msg.asJavaString(), data);
+        logger.warn(msg.toString(), data);
         return this;
     }
 
     @JRubyMethod
     public IRubyObject error(final IRubyObject msg) {
-        logger.error(msg.asJavaString());
+        logger.error(msg.asString());
         return this;
     }
 
     @JRubyMethod
     public IRubyObject error(final IRubyObject msg, final IRubyObject data) {
-        logger.error(msg.asJavaString(), data);
+        logger.error(msg.toString(), data);
         return this;
     }
 
     @JRubyMethod
     public IRubyObject fatal(final IRubyObject msg) {
-        logger.fatal(msg.asJavaString());
+        logger.fatal(msg.asString());
         return this;
     }
 
     @JRubyMethod
     public IRubyObject fatal(final IRubyObject msg, final IRubyObject data) {
-        logger.fatal(msg.asJavaString(), data);
+        logger.fatal(msg.toString(), data);
         return this;
     }
 

--- a/logstash-core/src/main/java/org/logstash/log/LoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/LoggerExt.java
@@ -40,16 +40,16 @@ import java.io.File;
 import java.net.URI;
 
 /**
- * JRuby extension, it's part of log4j wrapping for JRuby.
- * Wrapper log4j Logger as Ruby like class
- * */
-@JRubyClass(name = "Logger")
+ * JRuby extension, that wraps a (native) log4j2 logger.
+ * Provides a Ruby logger interface for Logstash.
+ */
+@JRubyClass(name = "LogStash::Logging::Logger")
 public class LoggerExt extends RubyObject {
 
     private static final long serialVersionUID = 1L;
 
     private static final Object CONFIG_LOCK = new Object();
-    private Logger logger;
+    Logger logger;
 
     public LoggerExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);
@@ -57,106 +57,206 @@ public class LoggerExt extends RubyObject {
 
     @JRubyMethod
     public LoggerExt initialize(final ThreadContext context, final IRubyObject loggerName) {
-        logger = LogManager.getLogger(loggerName.asJavaString());
+        initializeLogger(loggerName.asJavaString());
         return this;
     }
 
+    void initializeLogger(final String name) {
+        this.logger = LogManager.getLogger(name);
+    }
+
+    /**
+     * {@code logger.trace?}
+     * @param context JRuby context
+     * @return true/false
+     */
     @JRubyMethod(name = "trace?")
     public RubyBoolean isTrace(final ThreadContext context) {
         return logger.isTraceEnabled() ? context.tru : context.fals;
     }
 
+    /**
+     * {@code logger.debug?}
+     * @param context JRuby context
+     * @return true/false
+     */
     @JRubyMethod(name = "debug?")
     public RubyBoolean isDebug(final ThreadContext context) {
         return logger.isDebugEnabled() ? context.tru : context.fals;
     }
 
+    /**
+     * {@code logger.info?}
+     * @param context JRuby context
+     * @return true/false
+     */
     @JRubyMethod(name = "info?")
     public RubyBoolean isInfo(final ThreadContext context) {
         return logger.isInfoEnabled() ? context.tru : context.fals;
     }
 
+    /**
+     * {@code logger.error?}
+     * @param context JRuby context
+     * @return true/false
+     */
     @JRubyMethod(name = "error?")
     public RubyBoolean isError(final ThreadContext context) {
         return logger.isErrorEnabled() ? context.tru : context.fals;
     }
 
+    /**
+     * {@code logger.warn?}
+     * @param context JRuby context
+     * @return true/false
+     */
     @JRubyMethod(name = "warn?")
     public RubyBoolean isWarn(final ThreadContext context) {
         return logger.isWarnEnabled() ? context.tru : context.fals;
     }
 
+    /**
+     * {@code logger.fatal?}
+     * @param context JRuby context
+     * @return true/false
+     */
     @JRubyMethod(name = "fatal?")
     public RubyBoolean isFatal(final ThreadContext context) {
         return logger.isDebugEnabled() ? context.tru : context.fals;
     }
 
+    /**
+     * {@code logger.trace(msg)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject trace(final IRubyObject msg) {
         logger.trace(msg.asString());
         return this;
     }
 
+    /**
+     * {@code logger.trace(msg, data)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @param data additional contextual data to be logged
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject trace(final IRubyObject msg, final IRubyObject data) {
         if (logger.isTraceEnabled()) logger.trace(msg.toString(), data);
         return this;
     }
 
+    /**
+     * {@code logger.debug(msg)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject debug(final IRubyObject msg) {
         logger.debug(msg.asString());
         return this;
     }
 
+    /**
+     * {@code logger.debug(msg, data)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @param data additional contextual data to be logged
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject debug(final IRubyObject msg, final IRubyObject data) {
         if (logger.isDebugEnabled()) logger.debug(msg.toString(), data);
         return this;
     }
 
+    /**
+     * {@code logger.info(msg)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject info(final IRubyObject msg) {
         logger.info(msg.asString());
         return this;
     }
 
+    /**
+     * {@code logger.info(msg, data)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @param data additional contextual data to be logged
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject info(final IRubyObject msg, final IRubyObject data) {
         if (logger.isInfoEnabled()) logger.info(msg.toString(), data);
         return this;
     }
 
+    /**
+     * {@code logger.warn(msg)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject warn(final IRubyObject msg) {
         logger.warn(msg.asString());
         return this;
     }
 
+    /**
+     * {@code logger.warn(msg, data)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @param data additional contextual data to be logged
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject warn(final IRubyObject msg, final IRubyObject data) {
         logger.warn(msg.toString(), data);
         return this;
     }
 
+    /**
+     * {@code logger.error(msg)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject error(final IRubyObject msg) {
         logger.error(msg.asString());
         return this;
     }
 
+    /**
+     * {@code logger.error(msg, data)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @param data additional contextual data to be logged
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject error(final IRubyObject msg, final IRubyObject data) {
         logger.error(msg.toString(), data);
         return this;
     }
 
+    /**
+     * {@code logger.fatal(msg)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject fatal(final IRubyObject msg) {
         logger.fatal(msg.asString());
         return this;
     }
 
+    /**
+     * {@code logger.fatal(msg, data)}
+     * @param msg a message to log (will be `to_s` converted)
+     * @param data additional contextual data to be logged
+     * @return self
+     */
     @JRubyMethod
     public IRubyObject fatal(final IRubyObject msg, final IRubyObject data) {
         logger.fatal(msg.toString(), data);

--- a/logstash-core/src/main/java/org/logstash/log/LoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/LoggerExt.java
@@ -30,6 +30,7 @@ import org.jruby.Ruby;
 import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyObject;
+import org.jruby.RubyString;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.javasupport.JavaUtil;
@@ -333,6 +334,16 @@ public class LoggerExt extends RubyObject {
                 loggerContext.updateLoggers();
             }
         }
+    }
+
+    /**
+     * Retrieve this logger's name.
+     * @param context current context
+     * @return the name
+     */
+    @JRubyMethod(name = "name")
+    public RubyString name(final ThreadContext context) {
+        return context.runtime.newString(logger.getName());
     }
 
 }

--- a/logstash-core/src/main/java/org/logstash/log/LoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/LoggerExt.java
@@ -61,6 +61,11 @@ public class LoggerExt extends RubyObject {
         return this;
     }
 
+    @JRubyMethod(name = "trace?")
+    public RubyBoolean isTrace(final ThreadContext context) {
+        return logger.isTraceEnabled() ? context.tru : context.fals;
+    }
+
     @JRubyMethod(name = "debug?")
     public RubyBoolean isDebug(final ThreadContext context) {
         return logger.isDebugEnabled() ? context.tru : context.fals;
@@ -86,68 +91,75 @@ public class LoggerExt extends RubyObject {
         return logger.isDebugEnabled() ? context.tru : context.fals;
     }
 
-    @JRubyMethod(name = "trace?")
-    public RubyBoolean isTrace(final ThreadContext context) {
-        return logger.isDebugEnabled() ? context.tru : context.fals;
-    }
-
-    @JRubyMethod(name = "debug", required = 1, optional = 1)
-    public IRubyObject rubyDebug(final ThreadContext context, final IRubyObject[] args) {
-        if (args.length > 1) {
-            logger.debug(args[0].asJavaString(), args[1]);
-        } else {
-            logger.debug(args[0].asJavaString());
-        }
+    @JRubyMethod
+    public IRubyObject trace(final IRubyObject msg) {
+        if (logger.isTraceEnabled()) logger.trace(msg.asJavaString());
         return this;
     }
 
-    @JRubyMethod(name = "warn", required = 1, optional = 1)
-    public IRubyObject rubyWarn(final ThreadContext context, final IRubyObject[] args) {
-        if (args.length > 1) {
-            logger.warn(args[0].asJavaString(), args[1]);
-        } else {
-            logger.warn(args[0].asJavaString());
-        }
+    @JRubyMethod
+    public IRubyObject trace(final IRubyObject msg, final IRubyObject data) {
+        if (logger.isTraceEnabled()) logger.trace(msg.asJavaString(), data);
         return this;
     }
 
-    @JRubyMethod(name = "info", required = 1, optional = 1)
-    public IRubyObject rubyInfo(final ThreadContext context, final IRubyObject[] args) {
-        if (args.length > 1) {
-            logger.info(args[0].asJavaString(), args[1]);
-        } else {
-            logger.info(args[0].asJavaString());
-        }
+    @JRubyMethod
+    public IRubyObject debug(final IRubyObject msg) {
+        if (logger.isDebugEnabled()) logger.debug(msg.asJavaString());
         return this;
     }
 
-    @JRubyMethod(name = "error", required = 1, optional = 1)
-    public IRubyObject rubyError(final ThreadContext context, final IRubyObject[] args) {
-        if (args.length > 1) {
-            logger.error(args[0].asJavaString(), args[1]);
-        } else {
-            logger.error(args[0].asJavaString());
-        }
+    @JRubyMethod
+    public IRubyObject debug(final IRubyObject msg, final IRubyObject data) {
+        if (logger.isDebugEnabled()) logger.debug(msg.asJavaString(), data);
         return this;
     }
 
-    @JRubyMethod(name = "fatal", required = 1, optional = 1)
-    public IRubyObject rubyFatal(final ThreadContext context, final IRubyObject[] args) {
-        if (args.length > 1) {
-            logger.fatal(args[0].asJavaString(), args[1]);
-        } else {
-            logger.fatal(args[0].asJavaString());
-        }
+    @JRubyMethod
+    public IRubyObject info(final IRubyObject msg) {
+        if (logger.isInfoEnabled()) logger.info(msg.asJavaString());
         return this;
     }
 
-    @JRubyMethod(name = "trace", required = 1, optional = 1)
-    public IRubyObject rubyTrace(final ThreadContext context, final IRubyObject[] args) {
-        if (args.length > 1) {
-            logger.trace(args[0].asJavaString(), args[1]);
-        } else {
-            logger.trace(args[0].asJavaString());
-        }
+    @JRubyMethod
+    public IRubyObject info(final IRubyObject msg, final IRubyObject data) {
+        if (logger.isInfoEnabled()) logger.info(msg.asJavaString(), data);
+        return this;
+    }
+
+    @JRubyMethod
+    public IRubyObject warn(final IRubyObject msg) {
+        logger.warn(msg.asJavaString());
+        return this;
+    }
+
+    @JRubyMethod
+    public IRubyObject warn(final IRubyObject msg, final IRubyObject data) {
+        logger.warn(msg.asJavaString(), data);
+        return this;
+    }
+
+    @JRubyMethod
+    public IRubyObject error(final IRubyObject msg) {
+        logger.error(msg.asJavaString());
+        return this;
+    }
+
+    @JRubyMethod
+    public IRubyObject error(final IRubyObject msg, final IRubyObject data) {
+        logger.error(msg.asJavaString(), data);
+        return this;
+    }
+
+    @JRubyMethod
+    public IRubyObject fatal(final IRubyObject msg) {
+        logger.fatal(msg.asJavaString());
+        return this;
+    }
+
+    @JRubyMethod
+    public IRubyObject fatal(final IRubyObject msg, final IRubyObject data) {
+        logger.fatal(msg.asJavaString(), data);
         return this;
     }
 

--- a/logstash-core/src/main/java/org/logstash/log/PluginLoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/PluginLoggerExt.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.logstash.log;
+
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.anno.JRubyModule;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+/**
+ * A specialized {@link LoggerExt} that injects logging context information.
+ *
+ * Ruby interface is exactly the same as with `LogStash::Logging::Logger`.
+ *
+ * @since 7.15
+ */
+@JRubyModule(name = "LogStash::Logging::PluginLogger")
+public class PluginLoggerExt extends LoggerExt {
+
+    private static final long serialVersionUID = 1L;
+
+    static final String PLUGIN_ID_KEY = "plugin.id";
+
+    private String pluginId;
+
+    public PluginLoggerExt(final Ruby runtime, final RubyClass metaClass) {
+        super(runtime, metaClass);
+    }
+
+    @JRubyMethod
+    public LoggerExt initialize(final ThreadContext context, final IRubyObject plugin) {
+        initializeLogger(LoggableExt.log4jName(plugin.getMetaClass()));
+        this.pluginId = plugin.callMethod(context, "id").asJavaString();
+        return this;
+    }
+
+    @Override
+    public IRubyObject trace(final IRubyObject msg) {
+        if (logger.isTraceEnabled()) {
+            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+            logger.trace(msg.asString());
+
+            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        }
+        return this;
+    }
+
+    @Override
+    public IRubyObject trace(final IRubyObject msg, final IRubyObject data) {
+        if (logger.isTraceEnabled()) {
+            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+            logger.trace(msg.toString(), data);
+
+            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        }
+        return this;
+    }
+
+    @Override
+    public IRubyObject debug(final IRubyObject msg) {
+        if (logger.isDebugEnabled()) {
+            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+            logger.debug(msg.asString());
+
+            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        }
+        return this;
+    }
+
+    @Override
+    public IRubyObject debug(final IRubyObject msg, final IRubyObject data) {
+        if (logger.isDebugEnabled()) {
+            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+            logger.debug(msg.toString(), data);
+
+            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        }
+        return this;
+    }
+
+    @Override
+    public IRubyObject info(final IRubyObject msg) {
+        if (logger.isInfoEnabled()) {
+            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+            logger.info(msg.asString());
+
+            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        }
+        return this;
+    }
+
+    @Override
+    public IRubyObject info(final IRubyObject msg, final IRubyObject data) {
+        if (logger.isInfoEnabled()) {
+            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+            logger.info(msg.toString(), data);
+
+            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        }
+        return this;
+    }
+
+    @Override
+    public IRubyObject warn(final IRubyObject msg) {
+        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+        logger.warn(msg.asString());
+
+        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+
+        return this;
+    }
+
+    @Override
+    public IRubyObject warn(final IRubyObject msg, final IRubyObject data) {
+        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+        logger.warn(msg.toString(), data);
+
+        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+
+        return this;
+    }
+
+    @Override
+    public IRubyObject error(final IRubyObject msg) {
+        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+        logger.error(msg.asString());
+
+        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+
+        return this;
+    }
+
+    @Override
+    public IRubyObject error(final IRubyObject msg, final IRubyObject data) {
+        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+        logger.error(msg.toString(), data);
+
+        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+
+        return this;
+    }
+
+    @Override
+    public IRubyObject fatal(final IRubyObject msg) {
+        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+        logger.fatal(msg.asString());
+
+        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+
+        return this;
+    }
+
+    @Override
+    public IRubyObject fatal(final IRubyObject msg, final IRubyObject data) {
+        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+
+        logger.fatal(msg.toString(), data);
+
+        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+
+        return this;
+    }
+
+}

--- a/logstash-core/src/main/java/org/logstash/log/PluginLoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/PluginLoggerExt.java
@@ -57,11 +57,11 @@ public class PluginLoggerExt extends LoggerExt {
     @Override
     public IRubyObject trace(final IRubyObject msg) {
         if (logger.isTraceEnabled()) {
-            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+            boolean didSet = setPluginId(pluginId);
 
             logger.trace(msg.asString());
 
-            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+            removePluginId(didSet);
         }
         return this;
     }
@@ -69,11 +69,11 @@ public class PluginLoggerExt extends LoggerExt {
     @Override
     public IRubyObject trace(final IRubyObject msg, final IRubyObject data) {
         if (logger.isTraceEnabled()) {
-            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+            boolean didSet = setPluginId(pluginId);
 
             logger.trace(msg.toString(), data);
 
-            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+            removePluginId(didSet);
         }
         return this;
     }
@@ -81,11 +81,11 @@ public class PluginLoggerExt extends LoggerExt {
     @Override
     public IRubyObject debug(final IRubyObject msg) {
         if (logger.isDebugEnabled()) {
-            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+            boolean didSet = setPluginId(pluginId);
 
             logger.debug(msg.asString());
 
-            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+            removePluginId(didSet);
         }
         return this;
     }
@@ -93,11 +93,11 @@ public class PluginLoggerExt extends LoggerExt {
     @Override
     public IRubyObject debug(final IRubyObject msg, final IRubyObject data) {
         if (logger.isDebugEnabled()) {
-            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+            boolean didSet = setPluginId(pluginId);
 
             logger.debug(msg.toString(), data);
 
-            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+            removePluginId(didSet);
         }
         return this;
     }
@@ -105,11 +105,11 @@ public class PluginLoggerExt extends LoggerExt {
     @Override
     public IRubyObject info(final IRubyObject msg) {
         if (logger.isInfoEnabled()) {
-            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+            boolean didSet = setPluginId(pluginId);
 
             logger.info(msg.asString());
 
-            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+            removePluginId(didSet);
         }
         return this;
     }
@@ -117,79 +117,90 @@ public class PluginLoggerExt extends LoggerExt {
     @Override
     public IRubyObject info(final IRubyObject msg, final IRubyObject data) {
         if (logger.isInfoEnabled()) {
-            org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+            boolean didSet = setPluginId(pluginId);
 
             logger.info(msg.toString(), data);
 
-            org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+            removePluginId(didSet);
         }
         return this;
     }
 
     @Override
     public IRubyObject warn(final IRubyObject msg) {
-        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+        boolean didSet = setPluginId(pluginId);
 
         logger.warn(msg.asString());
 
-        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        removePluginId(didSet);
 
         return this;
     }
 
     @Override
     public IRubyObject warn(final IRubyObject msg, final IRubyObject data) {
-        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+        boolean didSet = setPluginId(pluginId);
 
         logger.warn(msg.toString(), data);
 
-        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        removePluginId(didSet);
 
         return this;
     }
 
     @Override
     public IRubyObject error(final IRubyObject msg) {
-        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+        boolean didSet = setPluginId(pluginId);
 
         logger.error(msg.asString());
 
-        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        removePluginId(didSet);
 
         return this;
     }
 
     @Override
     public IRubyObject error(final IRubyObject msg, final IRubyObject data) {
-        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+        boolean didSet = setPluginId(pluginId);
 
         logger.error(msg.toString(), data);
 
-        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        removePluginId(didSet);
 
         return this;
     }
 
     @Override
     public IRubyObject fatal(final IRubyObject msg) {
-        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+        boolean didSet = setPluginId(pluginId);
 
         logger.fatal(msg.asString());
 
-        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        removePluginId(didSet);
 
         return this;
     }
 
     @Override
     public IRubyObject fatal(final IRubyObject msg, final IRubyObject data) {
-        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+        boolean didSet = setPluginId(pluginId);
 
         logger.fatal(msg.toString(), data);
 
-        org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
+        removePluginId(didSet);
 
         return this;
+    }
+
+    private static boolean setPluginId(final String pluginId) {
+        boolean found = org.apache.logging.log4j.ThreadContext.containsKey(PLUGIN_ID_KEY);
+        if (found) return false;
+        org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
+        return false;
+    }
+
+    private static void removePluginId(final boolean didSet) {
+        if (didSet) org.apache.logging.log4j.ThreadContext.remove(PLUGIN_ID_KEY);
     }
 
 }

--- a/logstash-core/src/main/java/org/logstash/log/PluginLoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/PluginLoggerExt.java
@@ -196,7 +196,7 @@ public class PluginLoggerExt extends LoggerExt {
         boolean found = org.apache.logging.log4j.ThreadContext.containsKey(PLUGIN_ID_KEY);
         if (found) return false;
         org.apache.logging.log4j.ThreadContext.put(PLUGIN_ID_KEY, pluginId);
-        return false;
+        return true;
     }
 
     private static void removePluginId(final boolean didSet) {

--- a/logstash-core/src/main/java/org/logstash/log/SlowLoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/SlowLoggerExt.java
@@ -100,7 +100,7 @@ public class SlowLoggerExt extends RubyObject {
 
     @JRubyMethod(name = "on_event", required = 4)
     public IRubyObject onEvent(final ThreadContext context, final IRubyObject[] args) {
-        String message = args[0].asJavaString();
+        String message = args[0].toString();
         long eventDurationNanos = ((RubyNumeric)args[3]).getLongValue();
 
         if (warnThreshold >= 0 && eventDurationNanos > warnThreshold) {


### PR DESCRIPTION
Improves logging experience for the user (commits extracted from https://github.com/elastic/logstash/pull/13038).

- loosened `logger(msg)` contract allows for logging any (`to_s`) message not just strings - just like Log4j2 loggers do
- an internal **`PluginLogger` gets introduced** to always have a `plugin.id` logging context 
  (with `logger.debug ...` etc.)

Other changes:

- fixed `logger.trace?` (previously delegated to `logger.isDebugEnabled()`)

Breaking changes:

- ~ low impact
```ruby
class LogStash::Input::SomePlugin < ...

  def initialize(params)
    logger.info "this would no longer work - previously did but only if not using @logger.info ..."
    super(params)
    # logging after super works fine
  end
...
```

- potential plugin test failures ... mocking such as the following would need updating*:
```ruby
  expect(LogStash::Codecs::Multiline).to receive(:logger).and_return(Mlc::MultilineLogTracer.new).at_least(:once)
```
  * *or keeping `def class.logger(plugin = self)` functional in a backwards compatible way*

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

Logs are Logstash's primary way of communicating with the user, always having a plugin id logged greatly improves the user (debugging) experience.


## Release notes

We improved logging from plugins to always include contextual information (plugin's id) in logs.


## What does this PR do?

A new `PluginLogger` is introduced, which is now unique per plugin instance.

## Why is it important/What is the impact to the user?

Users will have better context when going through logs - as they should see the plugin id (which might be user set) more often.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] **codec ids** (which we care about) **use a different format than other plugins** e.g.
  `[DEBUG][logstash.codecs.line     ][line_cec86de4-b9b7-44ce-95c4-63423b9f92c3]`
  to resolve this we we need to do further changes, either:
    - align the [default id generation in the `Plugin` base class](https://github.com/elastic/logstash/pull/13038/files#diff-a1ff864ff0c1a866c4395a73478bdcc17c0cd3e8f1fcf651ca21f88dcdc945b7L79) (concerns testing)
    - or change contextualizer to handle [`CodecClass.new` instantiation](https://github.com/elastic/logstash/blob/a4712291d51bb5f9cc32d689d6bc8c43e479a40a/logstash-core/src/main/java/org/logstash/plugins/factory/ContextualizerExt.java#L80) with an explicit id param

## How to test this PR locally

e.g. `bin/logstash --log.level debug -e ""` will do

## Related issues

- https://github.com/logstash-plugins/logstash-mixin-ecs_compatibility_support/issues/7

## Logs

```
[2021-09-02T13:11:35,570][DEBUG][logstash.plugins.registry] On demand adding plugin to the registry {:name=>"stdin", :type=>"input", :class=>LogStash::Inputs::Stdin}
[2021-09-02T13:11:35,797][DEBUG][logstash.plugins.registry] On demand adding plugin to the registry {:name=>"line", :type=>"codec", :class=>LogStash::Codecs::Line}
[2021-09-02T13:11:36,116][DEBUG][logstash.instrument.periodicpoller.jvm] collector name {:name=>"ParNew"}
[2021-09-02T13:11:36,118][DEBUG][logstash.codecs.line     ][line_cec86de4-b9b7-44ce-95c4-63423b9f92c3] config LogStash::Codecs::Line/@id = "line_cec86de4-b9b7-44ce-95c4-63423b9f92c3"
[2021-09-02T13:11:36,120][DEBUG][logstash.instrument.periodicpoller.jvm] collector name {:name=>"ConcurrentMarkSweep"}
[2021-09-02T13:11:36,120][DEBUG][logstash.codecs.line     ][line_cec86de4-b9b7-44ce-95c4-63423b9f92c3] config LogStash::Codecs::Line/@enable_metric = true
[2021-09-02T13:11:36,120][DEBUG][logstash.codecs.line     ][line_cec86de4-b9b7-44ce-95c4-63423b9f92c3] config LogStash::Codecs::Line/@charset = "UTF-8"
[2021-09-02T13:11:36,120][DEBUG][logstash.codecs.line     ][line_cec86de4-b9b7-44ce-95c4-63423b9f92c3] config LogStash::Codecs::Line/@delimiter = "\n"
[2021-09-02T13:11:36,219][DEBUG][logstash.inputs.stdin    ][78126271ac5bff73f6bf0184af4762dae07fc37550e7518c65e53f4a5304e914] config LogStash::Inputs::Stdin/@type = "stdin"
[2021-09-02T13:11:36,220][DEBUG][logstash.inputs.stdin    ][78126271ac5bff73f6bf0184af4762dae07fc37550e7518c65e53f4a5304e914] config LogStash::Inputs::Stdin/@id = "78126271ac5bff73f6bf0184af4762dae07fc37550e7518c65e53f4a5304e914"
[2021-09-02T13:11:36,220][DEBUG][logstash.inputs.stdin    ][78126271ac5bff73f6bf0184af4762dae07fc37550e7518c65e53f4a5304e914] config LogStash::Inputs::Stdin/@enable_metric = true
[2021-09-02T13:11:36,234][DEBUG][logstash.inputs.stdin    ][78126271ac5bff73f6bf0184af4762dae07fc37550e7518c65e53f4a5304e914] config LogStash::Inputs::Stdin/@codec = <LogStash::Codecs::Line id=>"line_cec86de4-b9b7-44ce-95c4-63423b9f92c3", enable_metric=>true, charset=>"UTF-8", delimiter=>"\n">
[2021-09-02T13:11:36,236][DEBUG][logstash.inputs.stdin    ][78126271ac5bff73f6bf0184af4762dae07fc37550e7518c65e53f4a5304e914] config LogStash::Inputs::Stdin/@add_field = {}
[2021-09-02T13:11:36,303][DEBUG][logstash.plugins.registry] On demand adding plugin to the registry {:name=>"stdout", :type=>"output", :class=>LogStash::Outputs::Stdout}
[2021-09-02T13:11:36,326][DEBUG][logstash.plugins.registry] On demand adding plugin to the registry {:name=>"rubydebug", :type=>"codec", :class=>LogStash::Codecs::RubyDebug}
[2021-09-02T13:11:36,347][DEBUG][logstash.codecs.rubydebug][rubydebug_ca944dc6-b28f-4c71-a31f-b3d7ac7d5009] config LogStash::Codecs::RubyDebug/@id = "rubydebug_ca944dc6-b28f-4c71-a31f-b3d7ac7d5009"
[2021-09-02T13:11:36,347][DEBUG][logstash.codecs.rubydebug][rubydebug_ca944dc6-b28f-4c71-a31f-b3d7ac7d5009] config LogStash::Codecs::RubyDebug/@enable_metric = true
[2021-09-02T13:11:36,348][DEBUG][logstash.codecs.rubydebug][rubydebug_ca944dc6-b28f-4c71-a31f-b3d7ac7d5009] config LogStash::Codecs::RubyDebug/@metadata = false
[2021-09-02T13:11:39,524][DEBUG][logstash.outputs.stdout  ][d1bd143ca9c0117499c20d8bac3ca9cfc73bb5eee5fbc5f5246d5862d956a109] config LogStash::Outputs::Stdout/@codec = <LogStash::Codecs::RubyDebug id=>"rubydebug_ca944dc6-b28f-4c71-a31f-b3d7ac7d5009", enable_metric=>true, metadata=>false>
[2021-09-02T13:11:39,525][DEBUG][logstash.outputs.stdout  ][d1bd143ca9c0117499c20d8bac3ca9cfc73bb5eee5fbc5f5246d5862d956a109] config LogStash::Outputs::Stdout/@id = "d1bd143ca9c0117499c20d8bac3ca9cfc73bb5eee5fbc5f5246d5862d956a109"
[2021-09-02T13:11:39,525][DEBUG][logstash.outputs.stdout  ][d1bd143ca9c0117499c20d8bac3ca9cfc73bb5eee5fbc5f5246d5862d956a109] config LogStash::Outputs::Stdout/@enable_metric = true
[2021-09-02T13:11:39,526][DEBUG][logstash.outputs.stdout  ][d1bd143ca9c0117499c20d8bac3ca9cfc73bb5eee5fbc5f5246d5862d956a109] config LogStash::Outputs::Stdout/@workers = 1
[2021-09-02T13:11:39,643][DEBUG][logstash.javapipeline    ] Starting pipeline {:pipeline_id=>"main"}

```
