### PR TITLE
Deprecate JAVA_HOME preferring LS_JAVA_HOME

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -36,7 +36,7 @@ If the affected version of Logstash is 7.9 (or earlier), or if it is NOT using t
 
 1. JVM version (`java -version`)
 2. JVM installation source (e.g. from the Operating System's package manager, from source, etc).
-3. Value of the `JAVA_HOME`/`LS_JAVA_HOME` environment variable if set.
+3. Value of the `LS_JAVA_HOME`/`JAVA_HOME` environment variable if set.
 
 **OS version** (`uname -a` if on a Unix-like system):
 

--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -111,7 +111,7 @@ setup_java() {
       else
         echo "Invalid JAVA_HOME, doesn't contain bin/java executable."
       fi
-      echo "DEPRECATION: Using JAVA_HOME, please configure LS_JAVA_HOME instead."
+      echo "DEPRECATION: The use of JAVA_HOME is now deprecated and will be removed starting from 8.0. Please configure LS_JAVA_HOME instead."
     elif [ -d "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}" -a -x "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}/bin/java" ]; then
       echo "Using bundled JDK: ${LOGSTASH_HOME}/${BUNDLED_JDK_PART}"
       JAVACMD="${LOGSTASH_HOME}/${BUNDLED_JDK_PART}/bin/java"

--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -15,7 +15,7 @@
 #   LS_GEM_HOME and LS_GEM_PATH to overwrite the path assigned to GEM_HOME and GEM_PATH
 #   LS_JAVA_OPTS to append extra options to the JVM options provided by logstash
 #   LS_JAVA_HOME to point to the java home (takes precedence over JAVA_HOME)
-#   JAVA_HOME to point to the java home
+#   (deprecated) JAVA_HOME to point to the java home
 
 unset CDPATH
 # This unwieldy bit of scripting is to try to catch instances where Logstash
@@ -111,6 +111,7 @@ setup_java() {
       else
         echo "Invalid JAVA_HOME, doesn't contain bin/java executable."
       fi
+      echo "DEPRECATION: Using JAVA_HOME, please configure LS_JAVA_HOME instead."
     elif [ -d "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}" -a -x "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}/bin/java" ]; then
       echo "Using bundled JDK: ${LOGSTASH_HOME}/${BUNDLED_JDK_PART}"
       JAVACMD="${LOGSTASH_HOME}/${BUNDLED_JDK_PART}/bin/java"

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -32,7 +32,7 @@ if defined LS_JAVA_HOME (
   if exist "%LS_HOME%\jdk" (
     echo WARNING: Using JAVA_HOME while Logstash distribution comes with a bundled JDK.
   )
-  echo DEPRECATION: Using JAVA_HOME, please configure LS_JAVA_HOME instead.
+  echo DEPRECATION: The use of JAVA_HOME is now deprecated and will be removed starting from 8.0. Please configure LS_JAVA_HOME instead.
 ) else (
   if exist "%LS_HOME%\jdk" (
     set JAVA="%LS_HOME%\jdk\bin\java.exe"

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -32,6 +32,7 @@ if defined LS_JAVA_HOME (
   if exist "%LS_HOME%\jdk" (
     echo WARNING: Using JAVA_HOME while Logstash distribution comes with a bundled JDK.
   )
+  echo DEPRECATION: Using JAVA_HOME, please configure LS_JAVA_HOME instead.
 ) else (
   if exist "%LS_HOME%\jdk" (
     set JAVA="%LS_HOME%\jdk\bin\java.exe"

--- a/docs/static/jvm.asciidoc
+++ b/docs/static/jvm.asciidoc
@@ -53,7 +53,7 @@ Java HotSpot(TM) 64-Bit Server VM 18.9 (build 11.0.1+13-LTS, mixed mode)
 variable must be set for {ls} to operate correctly.
 
 If {ls} doesn't find `LS_JAVA_HOME` it tries to fall back to `JAVA_HOME`.
-The usage of `JAVA_HOME` is considered deprecated.
+The usage of `JAVA_HOME` is now considered deprecated in favor of `LS_JAVA_HOME`.
 
 On some Linux systems, you may need to have the `LS_JAVA_HOME` environment
 exported before installing {ls}, particularly if you installed Java from

--- a/docs/static/jvm.asciidoc
+++ b/docs/static/jvm.asciidoc
@@ -53,8 +53,7 @@ Java HotSpot(TM) 64-Bit Server VM 18.9 (build 11.0.1+13-LTS, mixed mode)
 variable must be set for {ls} to operate correctly.
 
 If {ls} doesn't find `LS_JAVA_HOME` it tries to fall back to `JAVA_HOME`.
-Note that this fallback behavior is experimental and the usage of `JAVA_HOME`
-could be subject to removal in later releases.
+The usage of `JAVA_HOME` is considered deprecated.
 
 On some Linux systems, you may need to have the `LS_JAVA_HOME` environment
 exported before installing {ls}, particularly if you installed Java from


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Deprecate the usage of `JAVA_HOME` preferring `LS_JAVA_HOME`


## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
Simply print deprecation notices on stdout when Logstash is starting with `JAVA_HOME` instead of `LS_JAVA_HOME`

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
Helps the user to migrate from `JAVA_HOME` to `JAVA_HOME`

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
