### PR TITLE
[backport 7.x] Use LS_JAVA_HOME in favor of JAVA_HOME #12725

### DIFF
--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -15,7 +15,7 @@
 #   LS_GEM_HOME and LS_GEM_PATH to overwrite the path assigned to GEM_HOME and GEM_PATH
 #   LS_JAVA_OPTS to append extra options to the JVM options provided by logstash
 #   LS_JAVA_HOME to point to the java home (takes precedence over JAVA_HOME)
-#   JAVA_HOME to point to the java home
+#   (deprecated) JAVA_HOME to point to the java home
 
 unset CDPATH
 # This unwieldy bit of scripting is to try to catch instances where Logstash
@@ -111,6 +111,7 @@ setup_java() {
       else
         echo "Invalid JAVA_HOME, doesn't contain bin/java executable."
       fi
+      echo "DEPRECATION: The use of JAVA_HOME is now deprecated and will be removed starting from 8.0. Please configure LS_JAVA_HOME instead."
     elif [ -d "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}" -a -x "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}/bin/java" ]; then
       echo "Using bundled JDK: ${LOGSTASH_HOME}/${BUNDLED_JDK_PART}"
       JAVACMD="${LOGSTASH_HOME}/${BUNDLED_JDK_PART}/bin/java"

--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -14,6 +14,7 @@
 # The following env var will be used by this script if set:
 #   LS_GEM_HOME and LS_GEM_PATH to overwrite the path assigned to GEM_HOME and GEM_PATH
 #   LS_JAVA_OPTS to append extra options to the JVM options provided by logstash
+#   LS_JAVA_HOME to point to the java home (takes precedence over JAVA_HOME)
 #   JAVA_HOME to point to the java home
 
 unset CDPATH
@@ -90,15 +91,25 @@ setup_java() {
   if [ -z "$JAVACMD" ]; then
     setup_bundled_jdk_part
     JAVACMD_TEST=`command -v java`
-    if [ -n "$JAVA_HOME" ]; then
+    if [ -n "$LS_JAVA_HOME" ]; then
+      echo "Using LS_JAVA_HOME defined java: ${LS_JAVA_HOME}."
+      if [ -x "$LS_JAVA_HOME/bin/java" ]; then
+        JAVACMD="$LS_JAVA_HOME/bin/java"
+        if [ -d "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}" -a -x "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}/bin/java" ]; then
+          echo "WARNING: Using LS_JAVA_HOME while Logstash distribution comes with a bundled JDK."
+        fi
+      else
+        echo "Invalid LS_JAVA_HOME, doesn't contain bin/java executable."
+      fi
+    elif [ -n "$JAVA_HOME" ]; then
       echo "Using JAVA_HOME defined java: ${JAVA_HOME}"
       if [ -x "$JAVA_HOME/bin/java" ]; then
         JAVACMD="$JAVA_HOME/bin/java"
         if [ -d "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}" -a -x "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}/bin/java" ]; then
-          echo "WARNING, using JAVA_HOME while Logstash distribution comes with a bundled JDK"
+          echo "WARNING: Using JAVA_HOME while Logstash distribution comes with a bundled JDK."
         fi
       else
-        echo "Invalid JAVA_HOME, doesn't contain bin/java executable"
+        echo "Invalid JAVA_HOME, doesn't contain bin/java executable."
       fi
     elif [ -d "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}" -a -x "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}/bin/java" ]; then
       echo "Using bundled JDK: ${LOGSTASH_HOME}/${BUNDLED_JDK_PART}"
@@ -112,7 +123,7 @@ setup_java() {
   fi
 
   if [ ! -x "$JAVACMD" ]; then
-    echo "could not find java; set JAVA_HOME or ensure java is in PATH"
+    echo "Could not find java; set LS_JAVA_HOME or ensure java is in PATH."
     exit 1
   fi
 

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -20,19 +20,25 @@ for %%I in ("%LS_HOME%..") do set LS_HOME=%%~dpfI
 
 rem ### 2: set java
 
-if defined JAVA_HOME (
+if defined LS_JAVA_HOME (
+  set JAVA="%LS_JAVA_HOME%\bin\java.exe"
+  echo Using LS_JAVA_HOME defined java: %LS_JAVA_HOME%
+  if exist "%LS_HOME%\jdk" (
+    echo WARNING: Using LS_JAVA_HOME while Logstash distribution comes with a bundled JDK.
+  )
+) else if defined JAVA_HOME (
   set JAVA="%JAVA_HOME%\bin\java.exe"
   echo Using JAVA_HOME defined java: %JAVA_HOME%
   if exist "%LS_HOME%\jdk" (
-    echo WARNING, using JAVA_HOME while Logstash distribution comes with a bundled JDK
+    echo WARNING: Using JAVA_HOME while Logstash distribution comes with a bundled JDK.
   )
 ) else (
   if exist "%LS_HOME%\jdk" (
     set JAVA="%LS_HOME%\jdk\bin\java.exe"
-    echo "Using bundled JDK: %JAVA%""
+    echo "Using bundled JDK: %JAVA%."
   ) else (
     for %%I in (java.exe) do set JAVA="%%~$PATH:I"
-    echo "Using system java: %JAVA%"
+    echo "Using system java: %JAVA% ."
   )
 )
 

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -32,6 +32,7 @@ if defined LS_JAVA_HOME (
   if exist "%LS_HOME%\jdk" (
     echo WARNING: Using JAVA_HOME while Logstash distribution comes with a bundled JDK.
   )
+  echo DEPRECATION: The use of JAVA_HOME is now deprecated and will be removed starting from 8.0. Please configure LS_JAVA_HOME instead.
 ) else (
   if exist "%LS_HOME%\jdk" (
     set JAVA="%LS_HOME%\jdk\bin\java.exe"

--- a/docs/static/jvm.asciidoc
+++ b/docs/static/jvm.asciidoc
@@ -22,10 +22,10 @@ for the official word on supported versions across releases.
 https://staging-website.elastic.co/downloads/logstash[downloads] that include
 AdoptOpenJDK 11, the latest long term support (LTS) release of JDK.
 
-Use the JAVA_HOME environment variable if you want to use a JDK other than the
+Use the LS_JAVA_HOME environment variable if you want to use a JDK other than the
 version that is bundled. 
-If you have the JAVA_HOME environment variable set to use a custom JDK, Logstash
-will continue to use the JDK version you have specified, even after you upgrade. 
+If you have the LS_JAVA_HOME environment variable set to use a custom JDK, Logstash
+will continue to use the JDK version you have specified, even after you upgrade.
 =====
 
 [float]
@@ -47,17 +47,21 @@ Java HotSpot(TM) 64-Bit Server VM 18.9 (build 11.0.1+13-LTS, mixed mode)
 
 [float]
 [[java-home]]
-==== `JAVA_HOME`
+==== `LS_JAVA_HOME` and `JAVA_HOME`
 
-{ls} uses the Java version set in `JAVA_HOME`. The `JAVA_HOME` environment
-variable must be set for {ls} to operate correctly. 
+{ls} uses the Java version set in `LS_JAVA_HOME`. The `LS_JAVA_HOME` environment
+variable must be set for {ls} to operate correctly.
 
-On some Linux systems, you may need to have the `JAVA_HOME` environment
+If {ls} doesn't find `LS_JAVA_HOME` it tries to fall back to `JAVA_HOME`.
+Note that this fallback behavior is experimental and the usage of `JAVA_HOME`
+could be subject to removal in later releases.
+
+On some Linux systems, you may need to have the `LS_JAVA_HOME` environment
 exported before installing {ls}, particularly if you installed Java from
 a tarball. 
 {ls} uses Java during installation to automatically detect your environment and
 install the correct startup method (SysV init scripts, Upstart, or systemd). If
-{ls} is unable to find the `JAVA_HOME` environment variable during package
+{ls} is unable to find the `LS_JAVA_HOME` environment variable during package
 installation, you may get an error message, and {ls} will not start properly.
 
 [float]

--- a/docs/static/jvm.asciidoc
+++ b/docs/static/jvm.asciidoc
@@ -53,8 +53,7 @@ Java HotSpot(TM) 64-Bit Server VM 18.9 (build 11.0.1+13-LTS, mixed mode)
 variable must be set for {ls} to operate correctly.
 
 If {ls} doesn't find `LS_JAVA_HOME` it tries to fall back to `JAVA_HOME`.
-Note that this fallback behavior is experimental and the usage of `JAVA_HOME`
-could be subject to removal in later releases.
+The usage of `JAVA_HOME` is now considered deprecated in favor of `LS_JAVA_HOME`.
 
 On some Linux systems, you may need to have the `LS_JAVA_HOME` environment
 exported before installing {ls}, particularly if you installed Java from

--- a/qa/acceptance/spec/shared_examples/installed_with_jdk.rb
+++ b/qa/acceptance/spec/shared_examples/installed_with_jdk.rb
@@ -23,6 +23,7 @@ RSpec.shared_examples "installable_with_jdk" do |logstash|
 
   before(:all) do
     #unset to force it using bundled JDK to run LS
+    logstash.run_command("unset LS_JAVA_HOME")
     logstash.run_command("unset JAVA_HOME")
   end
 

--- a/qa/docker/shared_examples/container.rb
+++ b/qa/docker/shared_examples/container.rb
@@ -14,7 +14,7 @@ shared_examples_for 'the container is configured correctly' do |flavor|
       console_out = exec_in_container(@container, 'logstash --version')
       console_filtered = console_out.split("\n")
             .delete_if do |line|
-              line =~ /Using JAVA_HOME defined java|Using system java: /
+              line =~ /Using LS_JAVA_HOME defined java|Using JAVA_HOME defined java|Using system java: /
             end.join
       expect(console_filtered).to match /#{version}/
     end

--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -118,10 +118,10 @@ class LogstashService < Service
       @process.io.stdout = @process.io.stderr = out
       @process.duplex = true
       java_home = java.lang.System.getProperty('java.home')
-      @process.environment['JAVA_HOME'] = java_home
+      @process.environment['LS_JAVA_HOME'] = java_home
       @process.start
       wait_for_logstash
-      puts "Logstash started with PID #{@process.pid}, JAVA_HOME: #{java_home}" if alive?
+      puts "Logstash started with PID #{@process.pid}, LS_JAVA_HOME: #{java_home}" if alive?
     end
   end
 
@@ -137,10 +137,10 @@ class LogstashService < Service
       @process = build_child_process(*args)
       @env_variables.map { |k, v|  @process.environment[k] = v} unless @env_variables.nil?
       java_home = java.lang.System.getProperty('java.home')
-      @process.environment['JAVA_HOME'] = java_home
+      @process.environment['LS_JAVA_HOME'] = java_home
       @process.io.inherit!
       @process.start
-      puts "Logstash started with PID #{@process.pid}, JAVA_HOME: #{java_home}" if @process.alive?
+      puts "Logstash started with PID #{@process.pid}, LS_JAVA_HOME: #{java_home}" if @process.alive?
     end
   end
 

--- a/qa/integration/specs/cli/keystore_spec.rb
+++ b/qa/integration/specs/cli/keystore_spec.rb
@@ -44,7 +44,7 @@ describe "CLI > logstash-keystore" do
     it "works" do
       env = {'LOGSTASH_KEYSTORE_PASS' => 'PaSSWD'}
       if ENV['BUILD_JAVA_HOME']
-        env['JAVA_HOME'] = ENV['BUILD_JAVA_HOME']
+        env['LS_JAVA_HOME'] = ENV['BUILD_JAVA_HOME']
       end
       keystore_list = @logstash.run_cmd(['bin/logstash-keystore', 'create'], true, env)
       expect(keystore_list.stderr_and_stdout).to_not match(/ERROR/)
@@ -63,7 +63,7 @@ describe "CLI > logstash-keystore" do
     it "works" do
       env = {'LOGSTASH_KEYSTORE_PASS' => 'PaSSWD'}
       if ENV['BUILD_JAVA_HOME']
-        env['JAVA_HOME'] = ENV['BUILD_JAVA_HOME']
+        env['LS_JAVA_HOME'] = ENV['BUILD_JAVA_HOME']
       end
       keystore_list = @logstash.run_cmd(['bin/logstash-keystore', 'list'], true, env)
       expect(keystore_list.stderr_and_stdout).to_not match(/ERROR/)

--- a/qa/integration/specs/cli/prepare_offline_pack_spec.rb
+++ b/qa/integration/specs/cli/prepare_offline_pack_spec.rb
@@ -86,7 +86,7 @@ describe "CLI > logstash-plugin prepare-offline-pack" do
       filters = @logstash_plugin.list(plugins_to_pack.first)
                                 .stderr_and_stdout.split("\n")
                                 .delete_if do |line|
-                                  line =~ /cext|├──|└──|logstash-integration|JAVA_OPT|fatal|^WARNING|^warning: ignoring JAVA_TOOL_OPTIONS|^OpenJDK 64-Bit Server VM warning|Option \w+ was deprecated|Using JAVA_HOME defined java|Using system java: |\[\[: not found/ ||
+                                  line =~ /cext|├──|└──|logstash-integration|JAVA_OPT|fatal|^WARNING|^warning: ignoring JAVA_TOOL_OPTIONS|^OpenJDK 64-Bit Server VM warning|Option \w+ was deprecated|Using LS_JAVA_HOME defined java|Using JAVA_HOME defined java|Using system java: |\[\[: not found/ ||
                                   line =~ /warning: constant Gem::ConfigMap is deprecated/ # can be removed after upgrading Bundler from version 1.17
                                 end
 

--- a/x-pack/ci/integration_tests.sh
+++ b/x-pack/ci/integration_tests.sh
@@ -14,7 +14,7 @@ export CI=true
 
 if [ -n "$BUILD_JAVA_HOME" ]; then
   GRADLE_OPTS="$GRADLE_OPTS -Dorg.gradle.java.home=$BUILD_JAVA_HOME"
-  export JAVA_HOME="$BUILD_JAVA_HOME"
+  export LS_JAVA_HOME="$BUILD_JAVA_HOME"
 fi
 
 ./gradlew runXPackIntegrationTests


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Logstash's launch script support LS_JAVA_HOME as an override of environment variable over JAVA_HOME.
It's the path to an installed JDK to be used to launch Logstash's service and support tools.
JAVA_HOME is going to be removed, however if LS_JAVA_HOME is not specified then Logstash still looks for JAVA_HOME.

## What does this PR do?
Backport of #13204 #13207 to `7.x` branch

