### PR TITLE
Removed JAVA_HOME using only LS_JAVA_HOME

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -36,7 +36,7 @@ If the affected version of Logstash is 7.9 (or earlier), or if it is NOT using t
 
 1. JVM version (`java -version`)
 2. JVM installation source (e.g. from the Operating System's package manager, from source, etc).
-3. Value of the `LS_JAVA_HOME`/`JAVA_HOME` environment variable if set.
+3. Value of the `LS_JAVA_HOME` environment variable if set.
 
 **OS version** (`uname -a` if on a Unix-like system):
 

--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -14,8 +14,7 @@
 # The following env var will be used by this script if set:
 #   LS_GEM_HOME and LS_GEM_PATH to overwrite the path assigned to GEM_HOME and GEM_PATH
 #   LS_JAVA_OPTS to append extra options to the JVM options provided by logstash
-#   LS_JAVA_HOME to point to the java home (takes precedence over JAVA_HOME)
-#   (deprecated) JAVA_HOME to point to the java home
+#   LS_JAVA_HOME to point to the java home
 
 unset CDPATH
 # This unwieldy bit of scripting is to try to catch instances where Logstash
@@ -101,17 +100,6 @@ setup_java() {
       else
         echo "Invalid LS_JAVA_HOME, doesn't contain bin/java executable."
       fi
-    elif [ -n "$JAVA_HOME" ]; then
-      echo "Using JAVA_HOME defined java: ${JAVA_HOME}"
-      if [ -x "$JAVA_HOME/bin/java" ]; then
-        JAVACMD="$JAVA_HOME/bin/java"
-        if [ -d "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}" -a -x "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}/bin/java" ]; then
-          echo "WARNING: Using JAVA_HOME while Logstash distribution comes with a bundled JDK."
-        fi
-      else
-        echo "Invalid JAVA_HOME, doesn't contain bin/java executable."
-      fi
-      echo "DEPRECATION: The use of JAVA_HOME is now deprecated and will be removed starting from 8.0. Please configure LS_JAVA_HOME instead."
     elif [ -d "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}" -a -x "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}/bin/java" ]; then
       echo "Using bundled JDK: ${LOGSTASH_HOME}/${BUNDLED_JDK_PART}"
       JAVACMD="${LOGSTASH_HOME}/${BUNDLED_JDK_PART}/bin/java"

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -26,13 +26,6 @@ if defined LS_JAVA_HOME (
   if exist "%LS_HOME%\jdk" (
     echo WARNING: Using LS_JAVA_HOME while Logstash distribution comes with a bundled JDK.
   )
-) else if defined JAVA_HOME (
-  set JAVA="%JAVA_HOME%\bin\java.exe"
-  echo Using JAVA_HOME defined java: %JAVA_HOME%
-  if exist "%LS_HOME%\jdk" (
-    echo WARNING: Using JAVA_HOME while Logstash distribution comes with a bundled JDK.
-  )
-  echo DEPRECATION: The use of JAVA_HOME is now deprecated and will be removed starting from 8.0. Please configure LS_JAVA_HOME instead.
 ) else (
   if exist "%LS_HOME%\jdk" (
     set JAVA="%LS_HOME%\jdk\bin\java.exe"

--- a/docs/static/jvm.asciidoc
+++ b/docs/static/jvm.asciidoc
@@ -47,13 +47,10 @@ Java HotSpot(TM) 64-Bit Server VM 18.9 (build 11.0.1+13-LTS, mixed mode)
 
 [float]
 [[java-home]]
-==== `LS_JAVA_HOME` and `JAVA_HOME`
+==== `LS_JAVA_HOME`
 
 {ls} uses the Java version set in `LS_JAVA_HOME`. The `LS_JAVA_HOME` environment
 variable must be set for {ls} to operate correctly.
-
-If {ls} doesn't find `LS_JAVA_HOME` it tries to fall back to `JAVA_HOME`.
-The usage of `JAVA_HOME` is now considered deprecated in favor of `LS_JAVA_HOME`.
 
 On some Linux systems, you may need to have the `LS_JAVA_HOME` environment
 exported before installing {ls}, particularly if you installed Java from

--- a/qa/acceptance/spec/shared_examples/installed_with_jdk.rb
+++ b/qa/acceptance/spec/shared_examples/installed_with_jdk.rb
@@ -24,7 +24,6 @@ RSpec.shared_examples "installable_with_jdk" do |logstash|
   before(:all) do
     #unset to force it using bundled JDK to run LS
     logstash.run_command("unset LS_JAVA_HOME")
-    logstash.run_command("unset JAVA_HOME")
   end
 
   before(:each) do

--- a/qa/docker/shared_examples/container.rb
+++ b/qa/docker/shared_examples/container.rb
@@ -14,7 +14,7 @@ shared_examples_for 'the container is configured correctly' do |flavor|
       console_out = exec_in_container(@container, 'logstash --version')
       console_filtered = console_out.split("\n")
             .delete_if do |line|
-              line =~ /Using LS_JAVA_HOME defined java|Using JAVA_HOME defined java|Using system java: /
+              line =~ /Using LS_JAVA_HOME defined java|Using system java: /
             end.join
       expect(console_filtered).to match /#{version}/
     end

--- a/qa/integration/specs/cli/prepare_offline_pack_spec.rb
+++ b/qa/integration/specs/cli/prepare_offline_pack_spec.rb
@@ -86,7 +86,7 @@ describe "CLI > logstash-plugin prepare-offline-pack" do
       filters = @logstash_plugin.list(plugins_to_pack.first)
                                 .stderr_and_stdout.split("\n")
                                 .delete_if do |line|
-                                  line =~ /cext|├──|└──|logstash-integration|JAVA_OPT|fatal|^WARNING|^warning: ignoring JAVA_TOOL_OPTIONS|^OpenJDK 64-Bit Server VM warning|Option \w+ was deprecated|Using LS_JAVA_HOME defined java|Using JAVA_HOME defined java|Using system java: |\[\[: not found/
+                                  line =~ /cext|├──|└──|logstash-integration|JAVA_OPT|fatal|^WARNING|^warning: ignoring JAVA_TOOL_OPTIONS|^OpenJDK 64-Bit Server VM warning|Option \w+ was deprecated|Using LS_JAVA_HOME defined java|Using system java: |\[\[: not found/
                                 end
 
       expect(unpacked.plugins.collect(&:name)).to include(*filters)


### PR DESCRIPTION
**Don't backport to 7.x**
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Logstash's launch script support LS_JAVA_HOME and abandon the JAVA_HOME.
It's the path to an installed JDK to be used to launch Logstash's service and support tools.
JAVA_HOME is not anymore looked at, only LS_JAVA_HOME.


## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
Removes the usage of JAVA_HOME completely, that environment variable is not anymore used for JDK path resolution.

Updated all the Logstash launching scripts to use only LS_JAVA_HOME as environment variable to
determine the JDK to use to launch Logstash. JAVA_HOME is abandoned for this job.

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
Already with PR #13204 `JAVA_HOME` was considered deprecated, this is important for the user because let them to separate JDKs for each JVM process, without implicit interference with the global `JAVA_HOME`.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Use same testing path described in #13204

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #12725

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
