### PR TITLE
[7.15] fix geoip external DB shutdown nil exception (#13224)

### DIFF
--- a/x-pack/lib/filters/geoip/database_manager.rb
+++ b/x-pack/lib/filters/geoip/database_manager.rb
@@ -291,7 +291,7 @@ module LogStash module Filters module Geoip class DatabaseManager
   end
 
   def unsubscribe_database_path(database_type, geoip_plugin)
-    @states[database_type].plugins.delete(geoip_plugin) if geoip_plugin
+    @states[database_type].plugins.delete(geoip_plugin) if geoip_plugin && @states
   end
 
   def database_path(database_type)

--- a/x-pack/spec/filters/geoip/database_manager_spec.rb
+++ b/x-pack/spec/filters/geoip/database_manager_spec.rb
@@ -378,5 +378,13 @@ describe LogStash::Filters::Geoip do
       end
     end
 
+    context "shutdown" do
+      let(:db_manager) { manager = Class.new(LogStash::Filters::Geoip::DatabaseManager).instance }
+
+      it "should unsubscribe gracefully" do
+        db_manager.subscribe_database_path(CITY, default_city_db_path, mock_geoip_plugin)
+        expect { db_manager.unsubscribe_database_path(CITY, mock_geoip_plugin) }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
**Do not merge until 7.15 release**

Backports the following commits to 7.15:
 - fix geoip external DB shutdown nil exception (#13224)