### PR TITLE
Bump 7.14.3

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -2,12 +2,12 @@ PATH
   remote: logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 7.14.2)
+      logstash-core (= 7.14.3)
 
 PATH
   remote: logstash-core
   specs:
-    logstash-core (7.14.2-java)
+    logstash-core (7.14.3-java)
       chronic_duration (~> 0.10)
       clamp (~> 0.6)
       concurrent-ruby (~> 1)

--- a/versions.yml
+++ b/versions.yml
@@ -1,7 +1,7 @@
 ---
 # alpha and beta qualifiers are now added via VERSION_QUALIFIER environment var
-logstash: 7.14.2
-logstash-core: 7.14.2
+logstash: 7.14.3
+logstash-core: 7.14.3
 logstash-core-plugin-api: 2.1.16
 
 bundled_jdk:


### PR DESCRIPTION
## Release notes

[rn:skip]

## What does this PR do?

Bumps versions to the 7.14.3 on branch 7.4 so that future snapshot builds will indicate the correct next patch-level release version.