### PR TITLE
bump 7.15.1

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -2,12 +2,12 @@ PATH
   remote: logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 7.15.0)
+      logstash-core (= 7.15.1)
 
 PATH
   remote: logstash-core
   specs:
-    logstash-core (7.15.0-java)
+    logstash-core (7.15.1-java)
       chronic_duration (~> 0.10)
       clamp (~> 0.6)
       concurrent-ruby (~> 1)

--- a/versions.yml
+++ b/versions.yml
@@ -1,7 +1,7 @@
 ---
 # alpha and beta qualifiers are now added via VERSION_QUALIFIER environment var
-logstash: 7.15.0
-logstash-core: 7.15.0
+logstash: 7.15.1
+logstash-core: 7.15.1
 logstash-core-plugin-api: 2.1.16
 
 bundled_jdk:


### PR DESCRIPTION
## Release notes

[rn:skip]

## What does this PR do?

Bumps versions to the `7.15.1` on branch `7.15` 