### PR TITLE
Doc: Add topic and expand info for in-memory queue

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -178,6 +178,9 @@ include::static/filebeat-modules.asciidoc[]
 :edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/resiliency.asciidoc
 include::static/resiliency.asciidoc[]
 
+:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/mem-queue.asciidoc
+include::static/mem-queue.asciidoc[]
+
 :edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/persistent-queues.asciidoc
 include::static/persistent-queues.asciidoc[]
 

--- a/docs/static/mem-queue.asciidoc
+++ b/docs/static/mem-queue.asciidoc
@@ -30,6 +30,8 @@ Memory queue size is not configured directly.
 Multiply the `pipeline.batch.size` and `pipeline.workers` values to get the size of the memory queue.
 This value is called the "inflight count." 
 
+See <<tuning-logstash>> for more info on the effects of adjusting `pipeline.batch.size` and `pipeline.workers`.
+
 [[backpressure-mem-queue]]
 ==== Back pressure
 
@@ -38,14 +40,4 @@ flowing into Logstash.
 This mechanism helps Logstash control the rate of data flow at the input stage
 without overwhelming outputs like Elasticsearch.
 
-ToDo: Is the next paragraph accurate for MQ? 
-
 Each input handles back pressure independently. 
-For example, when the
-<<plugins-inputs-beats,beats input>> encounters back pressure, it no longer
-accepts new connections.
-It waits until the queue has space to accept more events. 
-After the filter and output stages finish processing existing
-events in the queue and ACKs them, Logstash automatically starts accepting new
-events.
-

--- a/docs/static/mem-queue.asciidoc
+++ b/docs/static/mem-queue.asciidoc
@@ -26,7 +26,7 @@ TIP: Consider using <<persistent-queues,persistent queues>> to avoid these limit
 ==== Memory queue size
 
 Memory queue size is not configured directly.
-It is defined by the number of events, which can vary greatly depending on the event payload. 
+It is defined by the number of events, the size of which can vary greatly depending on the event payload. 
 
 The maximum number of events that can be held in each memory queue is equal to
 the value of `pipeline.batch.size` multiplied by the value of

--- a/docs/static/mem-queue.asciidoc
+++ b/docs/static/mem-queue.asciidoc
@@ -19,7 +19,6 @@ The memory queue might be a good choice if you value throughput over data resili
 
 * Can lose data in abnormal termination
 * Don't do well handling sudden bursts of data, where extra capacity in needed for {ls} to catch up
-* Not a good choice for data you can't afford to lose
 
 TIP: Consider using <<persistent-queues,persistent queues>> to avoid these limitations. 
 
@@ -27,10 +26,29 @@ TIP: Consider using <<persistent-queues,persistent queues>> to avoid these limit
 ==== Memory queue size
 
 Memory queue size is not configured directly.
-Multiply the `pipeline.batch.size` and `pipeline.workers` values to get the size of the memory queue.
+It is defined by the number of events, which can vary greatly depending on the event payload. 
+
+The maximum number of events that can be held in each memory queue is equal to
+the value of `pipeline.batch.size` multiplied by the value of
+`pipeline.workers`.
 This value is called the "inflight count." 
 
+NOTE: Each pipeline has its own queue.
+
 See <<tuning-logstash>> for more info on the effects of adjusting `pipeline.batch.size` and `pipeline.workers`.
+
+[[mq-settings]]
+===== Settings that affect queue size
+
+These values can be configured in `logstash.yml` and `pipelines.yml`. 
+
+pipeline.batch.size::
+Number events to retrieve from inputs before sending to filters+workers
+The default is 125.
+
+pipelines.workers::
+Number of workers that will, in parallel, execute the filters+outputs stage of the pipeline.
+This value defaults to the number of the host's CPU cores.
 
 [[backpressure-mem-queue]]
 ==== Back pressure

--- a/docs/static/mem-queue.asciidoc
+++ b/docs/static/mem-queue.asciidoc
@@ -1,10 +1,51 @@
 [[memory-queue]]
-=== Memory queue
+=== Memory queue 
 
-By default, Logstash uses in-memory bounded queues between pipeline stages
-(inputs → pipeline workers) to buffer events. The size of these in-memory
-queues is fixed and not configurable. If Logstash experiences a temporary
-machine failure, the contents of the in-memory queue will be lost. Temporary machine
-failures are scenarios where Logstash or its host machine are terminated
-abnormally but are capable of being restarted. 
+By default, Logstash uses in-memory bounded queues between pipeline stages (inputs → pipeline workers) to buffer events. 
+If Logstash experiences a temporary machine failure, the contents of the memory queue will be lost. 
+Temporary machine failures are scenarios where Logstash or its host machine are terminated abnormally, but are capable of being restarted. 
+
+[[mem-queue-benefits]]
+==== Benefits of memory queues
+
+The memory queue might be a good choice if you value throughput over data resiliency. 
+
+* Easier configuration
+* Easier management and administration
+* Faster throughput
+
+[[mem-queue-limitations]]
+==== Limitations of memory queues
+
+* Can lose data in abnormal termination
+* Don't do well handling sudden bursts of data, where extra capacity in needed for {ls} to catch up
+* Not a good choice for data you can't afford to lose
+
+TIP: Consider using <<persistent-queues,persistent queues>> to avoid these limitations. 
+
+[[sizing-mem-queue]]
+==== Memory queue size
+
+Memory queue size is not configured directly.
+Multiply the `pipeline.batch.size` and `pipeline.workers` values to get the size of the memory queue.
+This value is called the "inflight count." 
+
+[[backpressure-mem-queue]]
+==== Back pressure
+
+When the queue is full, Logstash puts back pressure on the inputs to stall data
+flowing into Logstash. 
+This mechanism helps Logstash control the rate of data flow at the input stage
+without overwhelming outputs like Elasticsearch.
+
+ToDo: Is the next paragraph accurate for MQ? 
+
+Each input handles back pressure independently. 
+For example, when the
+<<plugins-inputs-beats,beats input>> encounters back pressure, it no longer
+accepts new connections.
+It waits until the queue has space to accept more events. 
+After the filter and output stages finish processing existing
+events in the queue and ACKs them, Logstash automatically starts accepting new
+events.
 

--- a/docs/static/mem-queue.asciidoc
+++ b/docs/static/mem-queue.asciidoc
@@ -1,0 +1,10 @@
+[[memory-queue]]
+=== Memory queue
+
+By default, Logstash uses in-memory bounded queues between pipeline stages
+(inputs → pipeline workers) to buffer events. The size of these in-memory
+queues is fixed and not configurable. If Logstash experiences a temporary
+machine failure, the contents of the in-memory queue will be lost. Temporary machine
+failures are scenarios where Logstash or its host machine are terminated
+abnormally but are capable of being restarted. 
+

--- a/docs/static/resiliency.asciidoc
+++ b/docs/static/resiliency.asciidoc
@@ -1,6 +1,28 @@
 [[resiliency]]
 == Data resiliency
 
+
+/////
+What happens when the queue is full?
+Input plugins push data into the queue, and filters pull out. If the queue (persistent or memory) is full then the input plugin thread blocks.
+
+See handling backpressure topic. Relocate this info for better visibility? 
+/////
+
+
+/////
+Settings in logstash.yml and pipelines.yml can interract in unintuitive ways
+
+A setting on a pipeline in pipelines.yml takes precedence, falling back to the value in logstash.yml if there is no setting present for the specific pipeline, falling back to the default if there is no value present in logstash.yml
+
+^^ This is true for any setting in both logstash.yml and pipelines.yml, but seems to trip people up in PQs.  Other queues, too? 
+/////
+
+
+//ToDo: Add MQ to discussion (for compare/constrast), even thought it's not really considered a "resiliency feature". Messaging will need to be updated. 
+
+
+
 As data flows through the event processing pipeline, Logstash may encounter
 situations that prevent it from delivering events to the configured
 output. For example, the data might contain unexpected data types, or

--- a/docs/static/resiliency.asciidoc
+++ b/docs/static/resiliency.asciidoc
@@ -1,27 +1,7 @@
 [[resiliency]]
 == Data resiliency
 
-
-/////
-What happens when the queue is full?
-Input plugins push data into the queue, and filters pull out. If the queue (persistent or memory) is full then the input plugin thread blocks.
-
-See handling backpressure topic. Relocate this info for better visibility? 
-/////
-
-
-/////
-Settings in logstash.yml and pipelines.yml can interract in unintuitive ways
-
-A setting on a pipeline in pipelines.yml takes precedence, falling back to the value in logstash.yml if there is no setting present for the specific pipeline, falling back to the default if there is no value present in logstash.yml
-
-^^ This is true for any setting in both logstash.yml and pipelines.yml, but seems to trip people up in PQs.  Other queues, too? 
-/////
-
-
-//ToDo: Add MQ to discussion (for compare/constrast), even thought it's not really considered a "resiliency feature". Messaging will need to be updated. 
-
-
+By default, Logstash uses <<memory-queue,in-memory bounded queues>> between pipeline stages (inputs → pipeline workers) to buffer events. 
 
 As data flows through the event processing pipeline, Logstash may encounter
 situations that prevent it from delivering events to the configured

--- a/docs/static/resiliency.asciidoc
+++ b/docs/static/resiliency.asciidoc
@@ -1,5 +1,5 @@
 [[resiliency]]
-== Data resiliency
+== Queues and data resiliency
 
 By default, Logstash uses <<memory-queue,in-memory bounded queues>> between pipeline stages (inputs → pipeline workers) to buffer events. 
 


### PR DESCRIPTION
## Release notes
[rn:skip] 

## What does this PR do?

Adds topic with considerations and config info related to in-memory queue. This approach facilitates easier comparison and makes info on par with PQ info. 

## Why is it important/What is the impact to the user?

Users need more info on sizing the internal memory queue and need to know that settings are per pipeline.

Related: #13232 

**PREVIEW:** https://logstash_13246.docs-preview.app.elstc.co/guide/en/logstash/master/memory-queue.html