### PR TITLE
Backport PR#13248 to 7.x: Fix kafka download link for integration tests

### DIFF
--- a/qa/integration/services/kafka_setup.sh
+++ b/qa/integration/services/kafka_setup.sh
@@ -23,7 +23,7 @@ setup_kafka() {
     local version=$1
     if [ ! -d $KAFKA_HOME ]; then
         echo "Downloading Kafka version $version"
-        curl -s -o $INSTALL_DIR/kafka.tgz "https://downloads.apache.org/kafka/$version/kafka_2.13-$version.tgz"
+        curl -s -o $INSTALL_DIR/kafka.tgz "https://archive.apache.org/dist/kafka/$version/kafka_2.13-$version.tgz"
         mkdir $KAFKA_HOME && tar xzf $INSTALL_DIR/kafka.tgz -C $KAFKA_HOME --strip-components 1
         rm $INSTALL_DIR/kafka.tgz
         echo "dataDir=$ZOOKEEPER_DATA_DIR" >> $KAFKA_HOME/config/zookeeper.properties


### PR DESCRIPTION
Backport PR #13248 to 7.x branch. Original Message:

Fix kafka download link for integration tests

(cherry picked from commit aa1aa8e)