### PR TITLE
[7.x] avoid duplication of heading and index entry in release notes (#13192)

### DIFF
--- a/tools/release/generate_release_notes.rb
+++ b/tools/release/generate_release_notes.rb
@@ -39,12 +39,15 @@ current_release_dashes = current_release.tr(".", "-")
 
 release_notes = IO.read(RELEASE_NOTES_PATH).split("\n")
 
-release_notes.insert(5, "* <<logstash-#{current_release_dashes},Logstash #{current_release}>>")
+current_release_heading = "* <<logstash-#{current_release_dashes},Logstash #{current_release}>>"
+release_notes.insert(5, current_release_heading) unless release_notes[5].eql?(current_release_heading)
 
-release_notes_entry_index = release_notes.find_index {|line| line.match(/^\[\[logstash/) }
+coming_tag_index = release_notes.find_index {|line| line.match(/^coming\[#{current_release}\]/) }
+coming_tag_index += 1 if coming_tag_index
+release_notes_entry_index = coming_tag_index || release_notes.find_index {|line| line.match(/^\[\[logstash/) }
 
-report << "[[logstash-#{current_release_dashes}]]"
-report << "=== Logstash #{current_release} Release Notes\n"
+report << "[[logstash-#{current_release_dashes}]]" unless release_notes.any? { |line| line.match(/^\[\[logstash-#{current_release_dashes}/) }
+report << "=== Logstash #{current_release} Release Notes\n" unless release_notes.any? { |line| line.match(/^=== Logstash #{current_release}/)}
 
 plugin_changes = {}
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - avoid duplication of heading and index entry in release notes (#13192)