### PR TITLE
[7.15] update golang image to 1.17.1(#13260) (#13260)

### DIFF
--- a/docker/data/golang/Dockerfile
+++ b/docker/data/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8
-RUN go get gopkg.in/yaml.v2
+FROM golang:1.17.1
+RUN go env -w GO111MODULE=off && go get gopkg.in/yaml.v2
 WORKDIR /usr/local/src/env2yaml
 CMD ["go", "build"]

--- a/x-pack/spec/filters/geoip/download_manager_spec.rb
+++ b/x-pack/spec/filters/geoip/download_manager_spec.rb
@@ -25,7 +25,9 @@ describe LogStash::Filters::Geoip do
       allow(LogStash::SETTINGS).to receive(:get).with("xpack.geoip.download.endpoint").and_return(GEOIP_STAGING_ENDPOINT)
     end
 
-    context "rest client" do
+    # this is disabled until https://github.com/elastic/logstash/issues/13261 is solved
+    xcontext "rest client" do
+  
       it "can call endpoint" do
         conn = download_manager.send(:rest_client)
         res = conn.get("#{GEOIP_STAGING_ENDPOINT}?key=#{SecureRandom.uuid}&elastic_geoip_service_tos=agree")


### PR DESCRIPTION
Backports the following commits to 7.15:
 - update golang image to 1.17.1(#13260) (#13260)