### PR TITLE
update golang image

### DIFF
--- a/docker/data/golang/Dockerfile
+++ b/docker/data/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8
-RUN go get gopkg.in/yaml.v2
+FROM golang:1.17.1
+RUN go env -w GO111MODULE=off && go get gopkg.in/yaml.v2
 WORKDIR /usr/local/src/env2yaml
 CMD ["go", "build"]


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip] 
## What does this PR do?

Update golang image from 1.8 to 1.17.1 to get rid of SSL verification issue
Disable geoip download manager test to silent Faraday::SSLError certificate verify failed

A follow issue will replace Faraday lib with Manticore in download_manager

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

Allow jenkins to build snapshot image


original PR: https://github.com/elastic/logstash/pull/13260