### PR TITLE
[7.x] unlock ecs_compatibility_support version in plugin update (#13218)

### DIFF
--- a/lib/bootstrap/bundler.rb
+++ b/lib/bootstrap/bundler.rb
@@ -196,6 +196,44 @@ module LogStash
       ENV["DEBUG"]
     end
 
+    # @param plugin_names [Array] logstash plugin names that are going to update
+    # @return [Array] gem names that plugins depend on, including logstash plugins
+    def expand_logstash_mixin_dependencies(plugin_names)
+      plugin_names = Array(plugin_names) if plugin_names.is_a?(String)
+
+      # get gem names in Gemfile.lock. If file doesn't exist, it will be generated
+      lockfile_gems = ::Bundler::definition.specs.to_a.map { |stub_spec| stub_spec.name }.to_set
+
+      # get the array of dependencies which are eligible to update. Bundler unlock these gems in update process
+      # exclude the gems which are not in lock file. They should not be part of unlock gems.
+      # The core libs, logstash-core logstash-core-plugin-api, are not expected to update when user do plugins update
+      # constraining the transitive dependency updates to only those Logstash maintain
+      unlock_libs = plugin_names.flat_map { |plugin_name| fetch_plugin_dependencies(plugin_name) }
+                                .uniq
+                                .select { |lib_name| lockfile_gems.include?(lib_name) }
+                                .select { |lib_name| lib_name.start_with?("logstash-mixin-") }
+
+      unlock_libs + plugin_names
+    end
+
+    # get all dependencies of a single plugin, considering all versions >= current
+    # @param plugin_name [String] logstash plugin name
+    # @return [Array] gem names that plugin depends on
+    def fetch_plugin_dependencies(plugin_name)
+      old_spec = ::Gem::Specification.find_all_by_name(plugin_name).last
+      require_version = old_spec ? ">= #{old_spec.version}": nil
+      dep = ::Gem::Dependency.new(plugin_name, require_version)
+      new_specs, errors = ::Gem::SpecFetcher.fetcher.spec_for_dependency(dep)
+
+      raise(errors.first.error) if errors.length > 0
+
+      new_specs.map { |spec, source| spec }
+               .flat_map(&:dependencies)
+               .select {|spec| spec.type == :runtime }
+               .map(&:name)
+               .uniq
+    end
+
     # build Bundler::CLI.start arguments array from the given options hash
     # @param option [Hash] the invoke! options hash
     # @return [Array<String>] Bundler::CLI.start string arguments array
@@ -210,7 +248,7 @@ module LogStash
         end
       elsif options[:update]
         arguments << "update"
-        arguments << options[:update]
+        arguments << expand_logstash_mixin_dependencies(options[:update])
         arguments << "--local" if options[:local]
       elsif options[:clean]
         arguments << "clean"

--- a/spec/unit/plugin_manager/install_spec.rb
+++ b/spec/unit/plugin_manager/install_spec.rb
@@ -26,8 +26,9 @@ describe LogStash::PluginManager::Install do
     let(:sources) { ["https://rubygems.org", "http://localhost:9292"] }
 
     before(:each) do
-      expect(cmd).to receive(:validate_cli_options!).and_return(nil)
+      expect(cmd).to receive(:validate_cli_options!).at_least(:once).and_return(nil)
       expect(cmd).to receive(:plugins_gems).and_return([["dummy", nil]])
+      expect(cmd).to receive(:update_logstash_mixin_dependencies).and_return(nil)
       expect(cmd).to receive(:install_gems_list!).and_return(nil)
       expect(cmd).to receive(:remove_unused_locally_installed_gems!).and_return(nil)
       cmd.verify = true
@@ -47,6 +48,7 @@ describe LogStash::PluginManager::Install do
       expect(cmd).to receive(:validate_cli_options!).and_return(nil)
       # used to pass indirect input to the command under test
       expect(cmd).to receive(:plugins_gems).and_return([["logstash-input-elastic_agent", nil]])
+      expect(cmd).to receive(:update_logstash_mixin_dependencies).and_return(nil)
       # used to skip Bundler interaction
       expect(cmd).to receive(:install_gems_list!).and_return(nil)
       # avoid to clean gemfile folder
@@ -73,6 +75,7 @@ describe LogStash::PluginManager::Install do
     let(:cmd) { LogStash::PluginManager::Install.new("install my-super-pack") }
     before do
       expect(cmd).to receive(:plugins_arg).and_return(["my-super-pack"]).at_least(:once)
+      allow(cmd).to receive(:update_logstash_mixin_dependencies).and_return(nil)
     end
 
     it "reports `FileNotFoundError` exception" do

--- a/spec/unit/plugin_manager/util_spec.rb
+++ b/spec/unit/plugin_manager/util_spec.rb
@@ -61,7 +61,7 @@ describe LogStash::PluginManager do
     let(:plugin)  { "foo" }
     let(:version) { "9.0.0.0" }
 
-    let(:sources) { ["http://source.01", "http://source.02"] }
+    let(:sources) { ["https://rubygems.org", "http://source.02"] }
     let(:options) { {:rubygems_source => sources} }
 
     let(:gemset)  { double("gemset") }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - unlock ecs_compatibility_support version in plugin update (#13218)