### PR TITLE
[7.x] Fix plugin manager test that fail to fetch dependency (#13270)

### DIFF
--- a/spec/unit/plugin_manager/util_spec.rb
+++ b/spec/unit/plugin_manager/util_spec.rb
@@ -61,7 +61,7 @@ describe LogStash::PluginManager do
     let(:plugin)  { "foo" }
     let(:version) { "9.0.0.0" }
 
-    let(:sources) { ["https://rubygems.org", "http://source.02"] }
+    let(:sources) { ["https://rubygems.org"] }
     let(:options) { {:rubygems_source => sources} }
 
     let(:gemset)  { double("gemset") }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix plugin manager test that fail to fetch dependency (#13270)