### PR TITLE
Backport PR #13209 to 7.15: Added rexml notice to license list

### DIFF
--- a/tools/dependencies-report/src/main/resources/licenseMapping.csv
+++ b/tools/dependencies-report/src/main/resources/licenseMapping.csv
@@ -133,6 +133,7 @@ dependency,dependencyUrl,licenseOverride,copyright,sourceURL
 "rake:",https://github.com/ruby/rake,MIT
 "Red Hat Universal Base Image minimal:",https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,,https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz
 "redis:",https://github.com/redis/redis-rb,MIT
+"rexml:",https://github.com/ruby/rexml,MIT
 "ruby-progressbar:",https://github.com/jfelchner/ruby-progressbar,MIT
 "ruby2_keywords",https://github.com/ruby/ruby2_keywords,BSD-2-Clause
 "rubyzip:",https://github.com/rubyzip/rubyzip,BSD-2-Clause-FreeBSD

--- a/tools/dependencies-report/src/main/resources/notices/rexml-NOTICE.txt
+++ b/tools/dependencies-report/src/main/resources/notices/rexml-NOTICE.txt
@@ -1,0 +1,24 @@
+source: https://github.com/ruby/rexml/blob/v3.2.5/LICENSE.txt
+
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.


### PR DESCRIPTION
Backport PR #13209 to 7.15 branch. Original message: 

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
- Adds NOTICES files for `rexml` modules
- Align `licenseMapping.csv`

## Why is it important/What is the impact to the user?
No impact for final user

## Checklist
- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist
- [ ]

## How to test this PR locally
- checkout the branch
- run ` bin/dependencies-report --csv /tmp/deps.csv` is must be green, on `master` it currently fails