### PR TITLE
disable failing secret_store_spec temporarily

### DIFF
--- a/qa/integration/specs/secret_store_spec.rb
+++ b/qa/integration/specs/secret_store_spec.rb
@@ -55,7 +55,8 @@ describe "Test that Logstash" do
   let(:settings_dir) {Stud::Temporary.directory}
   let(:settings) {{"pipeline.id" => "${pipeline.id}"}}
 
-  it "expands secret store variables from config" do
+  # disable test temporarily until https://github.com/elastic/logstash/issues/13281 is fixed
+  xit "expands secret store variables from config" do
     test_env["TEST_ENV_PATH"] = test_path
     test_env["LOGSTASH_KEYSTORE_PASS"] = "keystore_pa9454w3rd"
     @logstash.env_variables = test_env


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip] 

## What does this PR do?

disable the test failed in secret_store_spec