### PR TITLE
[7.x] fix plugin installation script (#13289)

### DIFF
--- a/lib/bootstrap/bundler.rb
+++ b/lib/bootstrap/bundler.rb
@@ -17,6 +17,7 @@
 
 require "fileutils"
 require "stringio"
+require 'set'
 
 module LogStash
   module Bundler


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fix plugin installation script (#13289)