### PR TITLE
don't require mutate filter on remove_spec

### DIFF
--- a/qa/integration/specs/cli/remove_spec.rb
+++ b/qa/integration/specs/cli/remove_spec.rb
@@ -41,17 +41,21 @@ describe "CLI > logstash-plugin remove" do
         end
 
         context "when no other plugins depends on this plugin" do
+          let(:test_plugin) { "logstash-filter-qatest" }
+
+          before :each do
+            @logstash_plugin.install(File.join(File.dirname(__FILE__), "..", "..", "fixtures", "logstash-filter-qatest-0.1.1.gem"))
+          end
+
           it "successfully remove the plugin" do
-            execute = @logstash_plugin.run_raw("#{offline_wrapper_cmd} bin/logstash-plugin remove logstash-filter-mutate")
+            execute = @logstash_plugin.run_raw("#{offline_wrapper_cmd} bin/logstash-plugin remove #{test_plugin}")
 
             expect(execute.exit_code).to eq(0)
-            expect(execute.stderr_and_stdout).to match(/Successfully removed logstash-filter-mutate/)
+            expect(execute.stderr_and_stdout).to match(/Successfully removed #{test_plugin}/)
 
-            presence_check = @logstash_plugin.list("logstash-filter-mutate")
+            presence_check = @logstash_plugin.list(test_plugin)
             expect(presence_check.exit_code).to eq(1)
             expect(presence_check.stderr_and_stdout).to match(/ERROR: No plugins found/)
-
-            @logstash_plugin.install("logstash-filter-mutate")
           end
         end
 
@@ -74,17 +78,21 @@ describe "CLI > logstash-plugin remove" do
       end
     else
       context "when no other plugins depends on this plugin" do
+        let(:test_plugin) { "logstash-filter-qatest" }
+
+        before :each do
+          @logstash_plugin.install(File.join(File.dirname(__FILE__), "..", "..", "fixtures", "logstash-filter-qatest-0.1.1.gem"))
+        end
+
         it "successfully remove the plugin" do
-          execute = @logstash_plugin.remove("logstash-filter-mutate")
+          execute = @logstash_plugin.remove(test_plugin)
 
           expect(execute.exit_code).to eq(0)
-          expect(execute.stderr_and_stdout).to match(/Successfully removed logstash-filter-mutate/)
+          expect(execute.stderr_and_stdout).to match(/Successfully removed #{test_plugin}/)
 
-          presence_check = @logstash_plugin.list("logstash-filter-mutate")
+          presence_check = @logstash_plugin.list(test_plugin)
           expect(presence_check.exit_code).to eq(1)
           expect(presence_check.stderr_and_stdout).to match(/ERROR: No plugins found/)
-
-          @logstash_plugin.install("logstash-filter-mutate")
         end
       end
 


### PR DESCRIPTION
[rn:skip]

## What does this PR do?

Refactor the integration test for removing plugin to not depend on a bundled plugin, but a fixture filter plugin instead.
This removes the chances of messing with the build for other tests.

## Why is it important/What is the impact to the user?

No user facing impact, just less likelihood of failing specs.

## How to test this PR locally

`./gradlew runIntegrationTests -PrubyIntegrationSpecs="./specs/cli/remove_spec.rb"`