### PR TITLE
rename references of master branch to main branch

### DIFF
--- a/devtools/backport
+++ b/devtools/backport
@@ -54,7 +54,7 @@ def main():
                         help="Assume yes. Warning: discards local changes.")
     parser.add_argument("--continue", action="store_true",
                         help="Continue after fixing merging errors.")
-    parser.add_argument("--from_branch", default="master",
+    parser.add_argument("--from_branch", default="main",
                         help="From branch")
     parser.add_argument("--diff", action="store_true",
                         help="Display the diff before pushing the PR")

--- a/devtools/create_pr
+++ b/devtools/create_pr
@@ -17,7 +17,7 @@ usage = """
 
     This script does the following:
         * cleanups local_branch (warning: drops local changes)
-        * rebases the branch against master
+        * rebases the branch against main
         * it will attempt to create a PR for you using the GitHub API, but requires
           the GitHub token, with the public_repo scope, available in `~/.elastic/github.token`.
           Keep in mind this token has to also be authorized to the Elastic organization as
@@ -38,7 +38,7 @@ def main():
         epilog=usage)
     parser.add_argument("local_branch",
                         help="Branch to Create a PR for")
-    parser.add_argument("--to_branch", default="master",
+    parser.add_argument("--to_branch", default="main",
                         help="Which remote to push the backport branch to")
     parser.add_argument("--yes", action="store_true",
                         help="Assume yes. Warning: discards local changes.")

--- a/lib/pluginmanager/templates/codec-plugin/README.md
+++ b/lib/pluginmanager/templates/codec-plugin/README.md
@@ -83,4 +83,4 @@ Programming is not a required skill. Whatever you've seen about open source and 
 
 It is more important to the community that you are able to contribute.
 
-For more information about contributing, see the [CONTRIBUTING](https://github.com/elastic/logstash/blob/master/CONTRIBUTING.md) file.
+For more information about contributing, see the [CONTRIBUTING](https://github.com/elastic/logstash/blob/main/CONTRIBUTING.md) file.

--- a/lib/pluginmanager/templates/filter-plugin/README.md
+++ b/lib/pluginmanager/templates/filter-plugin/README.md
@@ -83,4 +83,4 @@ Programming is not a required skill. Whatever you've seen about open source and 
 
 It is more important to the community that you are able to contribute.
 
-For more information about contributing, see the [CONTRIBUTING](https://github.com/elastic/logstash/blob/master/CONTRIBUTING.md) file.
+For more information about contributing, see the [CONTRIBUTING](https://github.com/elastic/logstash/blob/main/CONTRIBUTING.md) file.

--- a/lib/pluginmanager/templates/input-plugin/README.md
+++ b/lib/pluginmanager/templates/input-plugin/README.md
@@ -83,4 +83,4 @@ Programming is not a required skill. Whatever you've seen about open source and 
 
 It is more important to the community that you are able to contribute.
 
-For more information about contributing, see the [CONTRIBUTING](https://github.com/elastic/logstash/blob/master/CONTRIBUTING.md) file.
+For more information about contributing, see the [CONTRIBUTING](https://github.com/elastic/logstash/blob/main/CONTRIBUTING.md) file.

--- a/lib/pluginmanager/templates/output-plugin/README.md
+++ b/lib/pluginmanager/templates/output-plugin/README.md
@@ -83,4 +83,4 @@ Programming is not a required skill. Whatever you've seen about open source and 
 
 It is more important to the community that you are able to contribute.
 
-For more information about contributing, see the [CONTRIBUTING](https://github.com/elastic/logstash/blob/master/CONTRIBUTING.md) file.
+For more information about contributing, see the [CONTRIBUTING](https://github.com/elastic/logstash/blob/main/CONTRIBUTING.md) file.

--- a/logstash-core-plugin-api/lib/logstash-core-plugin-api/version.rb
+++ b/logstash-core-plugin-api/lib/logstash-core-plugin-api/version.rb
@@ -17,7 +17,7 @@
 
 # The version of logstash core plugin api gem.
 #
-# sourced from a copy of the master versions.yml file, see logstash-core/logstash-core.gemspec
+# sourced from a copy of the main versions.yml file, see logstash-core/logstash-core.gemspec
 if !defined?(ALL_VERSIONS)
   require 'yaml'
   ALL_VERSIONS = YAML.load_file(File.expand_path("../../versions-gem-copy.yml", File.dirname(__FILE__)))

--- a/logstash-core/benchmarks/build.gradle
+++ b/logstash-core/benchmarks/build.gradle
@@ -19,7 +19,7 @@
 
 import org.yaml.snakeyaml.Yaml
 
-// fetch version from Logstash's master versions.yml file
+// fetch version from Logstash's main versions.yml file
 def versionMap = (Map) (new Yaml()).load(new File("$projectDir/../../versions.yml").text)
 
 description = """Logstash Core Java Benchmarks"""

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -21,7 +21,7 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import org.yaml.snakeyaml.Yaml
 
-// fetch version from Logstash's master versions.yml file
+// fetch version from Logstash's main versions.yml file
 def versionMap = (Map) (new Yaml()).load(new File("$projectDir/../versions.yml").text)
 
 description = """Logstash Core Java"""

--- a/logstash-core/lib/logstash-core/version.rb
+++ b/logstash-core/lib/logstash-core/version.rb
@@ -17,7 +17,7 @@
 
 # The version of logstash core gem.
 #
-# sourced from a copy of the master versions.yml file, see logstash-core/logstash-core.gemspec
+# sourced from a copy of the main versions.yml file, see logstash-core/logstash-core.gemspec
 if !defined?(ALL_VERSIONS)
   require 'yaml'
   ALL_VERSIONS = YAML.load_file(File.expand_path("../../versions-gem-copy.yml", File.dirname(__FILE__)))

--- a/logstash-core/lib/logstash/version.rb
+++ b/logstash-core/lib/logstash/version.rb
@@ -17,7 +17,7 @@
 
 # The version of the logstash package (not the logstash-core gem version).
 #
-# sourced from a copy of the master versions.yml file, see logstash-core/logstash-core.gemspec
+# sourced from a copy of the main versions.yml file, see logstash-core/logstash-core.gemspec
 if !defined?(ALL_VERSIONS)
   require 'yaml'
   ALL_VERSIONS = YAML.load_file(File.expand_path("../../versions-gem-copy.yml", File.dirname(__FILE__)))

--- a/tools/benchmark-cli/README.md
+++ b/tools/benchmark-cli/README.md
@@ -31,7 +31,7 @@ Option                           Description
                                    'ab1cfe8cf7e20114df58bcc6c996abcb2b0650d7',
                                  'user-
                                    name#ab1cfe8cf7e20114df58bcc6c996abcb2b0650d7'
-                                   or 'master'
+                                   or 'main'
 --local-path <String>            Path to the root of a local Logstash
                                    distribution.
                                   E.g. `/opt/logstash`

--- a/tools/benchmark-cli/build.gradle
+++ b/tools/benchmark-cli/build.gradle
@@ -19,7 +19,7 @@
 
 import org.yaml.snakeyaml.Yaml
 
-// fetch version from Logstash's master versions.yml file
+// fetch version from Logstash's main versions.yml file
 def versionMap = (Map) (new Yaml()).load(new File("$projectDir/../../versions.yml").text)
 
 description = """Logstash End to End Benchmarking Utility"""

--- a/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/ui/UserInput.java
+++ b/tools/benchmark-cli/src/main/java/org/logstash/benchmark/cli/ui/UserInput.java
@@ -86,7 +86,7 @@ public final class UserInput {
         "Either a git tree (tag/branch or commit hash), optionally prefixed by a Github username,",
         "if ran against forks.",
         "E.g. 'ab1cfe8cf7e20114df58bcc6c996abcb2b0650d7',",
-        "'user-name#ab1cfe8cf7e20114df58bcc6c996abcb2b0650d7' or 'master'"
+        "'user-name#ab1cfe8cf7e20114df58bcc6c996abcb2b0650d7' or 'main'"
     );
 
     public static final String LOCAL_VERSION_PARAM = "local-path";

--- a/tools/benchmark-cli/src/test/java/org/logstash/benchmark/cli/MainTest.java
+++ b/tools/benchmark-cli/src/test/java/org/logstash/benchmark/cli/MainTest.java
@@ -45,7 +45,7 @@ public final class MainTest {
     public void downloadsDependenciesForGithub() throws Exception {
         final File pwd = temp.newFolder();
         Main.main(String.format("--workdir=%s", pwd.getAbsolutePath()));
-        final Path logstash = pwd.toPath().resolve("logstash").resolve("logstash-master");
+        final Path logstash = pwd.toPath().resolve("logstash").resolve("logstash-main");
         assertThat(logstash.toFile().exists(), is(true));
         final File jruby = pwd.toPath().resolve("jruby").toFile();
         assertThat(jruby.exists(), is(true));

--- a/tools/dependencies-report/README.md
+++ b/tools/dependencies-report/README.md
@@ -2,11 +2,11 @@
 
 The dependency audit tool automates the verification of the following criteria for all
 third-party dependencies that are shipped as part of either Logstash core or the [default Logstash 
-plugins](https://github.com/elastic/logstash/blob/master/rakelib/plugins-metadata.json):
-* The dependency has been added to the [dependency list file](https://github.com/elastic/logstash/blob/master/tools/dependencies-report/src/main/resources/licenseMapping.csv)
+plugins](https://github.com/elastic/logstash/blob/main/rakelib/plugins-metadata.json):
+* The dependency has been added to the [dependency list file](https://github.com/elastic/logstash/blob/main/tools/dependencies-report/src/main/resources/licenseMapping.csv)
 with an appropriate project URL and [SPDX license identifier](https://spdx.org/licenses/). 
-* The license for the dependency is among those [approved for distribution](https://github.com/elastic/logstash/blob/master/tools/dependencies-report/src/main/resources/acceptableLicenses.csv).
-* There is a corresponding `NOTICE.txt` file in the [notices folder](https://github.com/elastic/logstash/tree/master/tools/dependencies-report/src/main/resources/notices)
+* The license for the dependency is among those [approved for distribution](https://github.com/elastic/logstash/blob/main/tools/dependencies-report/src/main/resources/acceptableLicenses.csv).
+* There is a corresponding `NOTICE.txt` file in the [notices folder](https://github.com/elastic/logstash/tree/main/tools/dependencies-report/src/main/resources/notices)
 containing the appropriate notices or license information for the dependency. These individual 
 notice files will be combined to form the notice file shipped with Logstash.
 

--- a/tools/dependencies-report/build.gradle
+++ b/tools/dependencies-report/build.gradle
@@ -19,7 +19,7 @@
 
 import org.yaml.snakeyaml.Yaml
 
-// fetch version from Logstash's master versions.yml file
+// fetch version from Logstash's main versions.yml file
 def versionMap = (Map) (new Yaml()).load(new File("$projectDir/../../versions.yml").text)
 
 description = """Logstash Dependency Reporting Utility"""

--- a/tools/ingest-converter/build.gradle
+++ b/tools/ingest-converter/build.gradle
@@ -19,7 +19,7 @@
 
 import org.yaml.snakeyaml.Yaml
 
-// fetch version from Logstash's master versions.yml file
+// fetch version from Logstash's main versions.yml file
 def versionMap = (Map) (new Yaml()).load(new File("$projectDir/../../versions.yml").text)
 
 description = """Ingest JSON to Logstash Grok Config Converter"""

--- a/tools/logstash-docgen/README.md
+++ b/tools/logstash-docgen/README.md
@@ -33,7 +33,7 @@ you can interrupt the process and it will output the current errors before exiti
 
 ## Generating the documentation for all the plugins from the organization
 
-You can now generate the documentation from master for all the plugin in the *logstash-plugins* organization.
+You can now generate the documentation from main for all the plugin in the *logstash-plugins* organization.
 
 *prerequisite*
 
@@ -47,7 +47,7 @@ You can now generate the documentation from master for all the plugin in the *lo
  bundle install
  ```
 
-You can use the the `bin/logstash-docgen` command to generate any plugin that you want, this executable can generate all the plugins or specific one from their master branch.
+You can use the the `bin/logstash-docgen` command to generate any plugin that you want, this executable can generate all the plugins or specific one from their main branch.
 
 Usages:
 

--- a/tools/logstash-docgen/lib/logstash/docgen/github_generator.rb
+++ b/tools/logstash-docgen/lib/logstash/docgen/github_generator.rb
@@ -86,7 +86,7 @@ module LogStash module Docgen
         g = Git.init(path)
         g.reset
         g.fetch
-        g.merge("origin/master")
+        g.merge("origin/main")
       else
         g = Git.clone(repository, path, :depth => 1 )
       end

--- a/tools/logstash-docgen/lib/logstash/docgen/parser.rb
+++ b/tools/logstash-docgen/lib/logstash/docgen/parser.rb
@@ -30,14 +30,14 @@ module LogStash module Docgen
 
     class << self
       def default_plugins_list
-        @default_plugins_list ||= from_master_json
+        @default_plugins_list ||= from_main_json
       end
 
       def include?(name)
         default_plugins_list.include?(name)
       end
 
-      def from_master_json
+      def from_main_json
         response = open(DEFAULT_PLUGINS_LIST_JSON)
         JSON.parse(response.read).select { |_, values| values["default-plugins"] == true }.keys
       end
@@ -150,8 +150,8 @@ module LogStash module Docgen
     alias_method :sorted_attributes, :config
 
     def changelog_url
-      # https://github.com/logstash-plugins/logstash-input-beats/blob/master/CHANGELOG.md#310beta3
-      "#{LOGSTASH_PLUGINS_ORGANIZATION}/#{canonical_name}/blob/master/CHANGELOG.md##{anchor_version}"
+      # https://github.com/logstash-plugins/logstash-input-beats/blob/main/CHANGELOG.md#310beta3
+      "#{LOGSTASH_PLUGINS_ORGANIZATION}/#{canonical_name}/blob/main/CHANGELOG.md##{anchor_version}"
     end
 
     def anchor_version

--- a/x-pack/spec/filters/geoip/download_manager_spec.rb
+++ b/x-pack/spec/filters/geoip/download_manager_spec.rb
@@ -82,7 +82,7 @@ describe LogStash::Filters::Geoip do
           "name" => filename,
           "provider" => "maxmind",
           "updated" => 1609891257,
-          "url" => "https://github.com/logstash-plugins/logstash-filter-geoip/archive/master.zip"
+          "url" => "https://github.com/logstash-plugins/logstash-filter-geoip/archive/main.zip"
         }
       end
       let(:md5_hash) { SecureRandom.hex }


### PR DESCRIPTION
This PR changes all references of the "master" branch to "main", but only for logstash related repos, and outside of the "docs" repo (which will be handled in a separate PR.

More on this effort can be read here: https://github.com/elastic/logstash/issues/12052