### PR TITLE
Backport PR #13300 to 7.x: Add pipeline.ordered setting for docker image (env2yml)

### DIFF
--- a/docker/data/logstash/env2yaml/env2yaml.go
+++ b/docker/data/logstash/env2yaml/env2yaml.go
@@ -58,6 +58,7 @@ func normalizeSetting(setting string) (string, error) {
 		"pipeline.unsafe_shutdown",
 		"pipeline.java_execution",
 		"pipeline.ecs_compatibility",
+		"pipeline.ordered",
 		"pipeline.plugin_classloaders",
 		"pipeline.separate_logs",
 		"path.config",


### PR DESCRIPTION
Backport PR #13300 to 7.x branch. Original message: 

## What does this PR do?
Add's missing pipeline.ordered setting for docker image in env2yml file.

## Why is it important/What is the impact to the user?

Allows users to use pipeline.ordered setting with docker instances.

## Checklist
- [x] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
~- [ ] I have added tests that prove my fix is effective or that my feature works~

## Related issues

- Closes: #13293


