### PR TITLE
Update JDK matrix to include JDK17: OpenJDK, AdoptiumJDK and Zulu

### DIFF
--- a/.ci/matrix-runtime-javas.yml
+++ b/.ci/matrix-runtime-javas.yml
@@ -7,8 +7,8 @@
 LS_RUNTIME_JAVA:
   - java8
   - openjdk11
-  - openjdk16
+  - openjdk17
   - adoptopenjdk11
-  - adoptopenjdk16
+  - adoptiumjdk17
   - zulu11
-  - zulu16
+  - zulu17


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Update testing infrastructure to include JDK 17

## What does this PR do?
Update JDK selector to run CI tasks also on JDK 17

## Why is it important/What is the impact to the user?
This PR verifies Logstash build can run with JDK 17