### PR TITLE
Fix Elasticsearch integration test to use specified JDK

### DIFF
--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -94,7 +94,7 @@ class LogstashService < Service
   # Given an input this pipes it to LS. Expects a stdin input in LS
   def start_with_input(config, input)
     Bundler.with_unbundled_env do
-      `cat #{Shellwords.escape(input)} | #{Shellwords.escape(@logstash_bin)} -e \'#{config}\'`
+      `cat #{Shellwords.escape(input)} | LS_JAVA_HOME=#{java.lang.System.getProperty('java.home')} #{Shellwords.escape(@logstash_bin)} -e \'#{config}\'`
     end
   end
 


### PR DESCRIPTION
Sets `LS_JAVA_HOME` of the spawned logstash to use the same `java.home`
that the test is running under, rather than default to the system JDK, which
would result in the spawned logstash running under a different JDK to that
intended in the test

