### PR TITLE
timestamp nanos: emulate appendOffset's `+HHmmss` for JDK8

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Timestamp.java
+++ b/logstash-core/src/main/java/org/logstash/Timestamp.java
@@ -151,7 +151,8 @@ public final class Timestamp implements Comparable<Timestamp>, Queueable {
             .optionalStart().appendLiteral('T').append(DateTimeFormatter.ISO_LOCAL_TIME).optionalEnd()
             // Timezone is optional, and may land in one of a couple different formats.
             .optionalStart().appendZoneOrOffsetId().optionalEnd()
-            .optionalStart().appendOffset("+HHmmss", "Z").optionalEnd()
+            .optionalStart().appendOffset("+HHMMss", "Z").optionalEnd()
+            .optionalStart().appendOffset("+HH", "Z").optionalEnd()
             .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
             .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
             .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)

--- a/logstash-core/src/test/java/org/logstash/TimestampTest.java
+++ b/logstash-core/src/test/java/org/logstash/TimestampTest.java
@@ -70,6 +70,24 @@ public class TimestampTest {
     }
 
     @Test
+    public void testParsingDateWithHoursOnlyOffset() throws Exception {
+        final Timestamp t = new Timestamp("2014-09-23-08", OFFSET_CLOCK);
+        assertEquals("2014-09-23T08:00:00Z", t.toString());
+    }
+
+    @Test
+    public void testParsingDateWithHoursMinutesOffset() throws Exception {
+        final Timestamp t = new Timestamp("2014-09-23-0800", OFFSET_CLOCK);
+        assertEquals("2014-09-23T08:00:00Z", t.toString());
+    }
+
+    @Test
+    public void testParsingDateWithHoursMinutesSecondsOffset() throws Exception {
+        final Timestamp t = new Timestamp("2014-09-23-080000", OFFSET_CLOCK);
+        assertEquals("2014-09-23T08:00:00Z", t.toString());
+    }
+
+    @Test
     public void testParsingDateTimeWithZOffset() throws Exception {
         final Timestamp t = new Timestamp("2014-09-23T13:49:52.987654321Z", OFFSET_CLOCK);
         assertEquals("2014-09-23T13:49:52.987654321Z", t.toString());


### PR DESCRIPTION
## Release notes

[rn:skip] (fixes unreleased feature on JDK8)

## What does this PR do?

Fixes a regression introduced in #12797 when run on JDK8, since it uses a timestamp offset formatter pattern `+HHmmss` that was introduced in JDK9.

**DO NOT MERGE IF DROPPING SUPPORT FOR JDK8 in Logstash 8.**

## Why is it important/What is the impact to the user?

JDK8's `DateTimeFormatterBuilder#appendOffset` not support the `+HHmmss` format introduced in JDK9
(required hours, optional minutes, optional seconds), so if we are going to continue supporting JDK8, we need to emulate it
with a series of optional offsets.

Here we use the hungriest matcher first

 - `+HHMMss`: (required hour, required minutes, optional seconds),
              matches `-0800` and `-080000`
 - `+HH`: (required hour), matches `-08`

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Run Logstash with Java 8, observe `IllegalArgumentException` is no longer thrown when `Timestamp` class is initialized.
