### PR TITLE
Doc: Expand PQ content for pipeline-pipeline

### DIFF
--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -107,13 +107,34 @@ In a situation where Logstash is terminated or there is a hardware-level
 failure, any data that has not been checkpointed, is lost. 
 See <<durability-persistent-queues>> to better understand the trade-offs.
 
+
+[[pq-pline-pline]]
+===== PQs and pipeline-to-pipeline communication
+
+Persistent queues can play an important role in your <<pipeline-to-pipeline,pipeline-to-pipeline>> configuration. 
+
+[[uc-isolator]]
+====== Use case: PQs and output isolator pattern
+
+Here is a real world use case described by a Logstash user.
+
+"_In our deployment, we use one pipeline per output, and each pipeline has a
+large PQ. This configuration allows a single output to stall without blocking
+the input (and thus all other outputs), until the operator can restore flow to
+the stalled output and let the queue drain._"
+
+"_Our real-time outputs must be low-latency, and our bulk outputs must be
+consistent. We use PQs to protect against stalling the real-time outputs, not
+to protect against data loss in the bulk outputs. (Although that's nice, too)._"
+
+
 [[troubleshooting-pqs]]
 ==== Troubleshooting persistent queues
 
 Symptoms of persistent queue problems include {ls} or one or more pipelines not starting successfully, accompanied by an error message similar to this one.
 
 ```
-message=>"java.io.IOException: Page file size is too small to hold elements
+message=>"java.io.IOException: Page file size is too small to hold elements"
 ```
 
 This error indicates that the head page (the oldest in a directory and the one with lowest page id) has a size < 18 bytes, the size of a page header.

--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -124,8 +124,7 @@ the input (and thus all other outputs), until the operator can restore flow to
 the stalled output and let the queue drain._"
 
 "_Our real-time outputs must be low-latency, and our bulk outputs must be
-consistent. We use PQs to protect against stalling the real-time outputs, not
-to protect against data loss in the bulk outputs. (Although that's nice, too)._"
+consistent. We use PQs to protect against stalling the real-time outputs more so than to protect against data loss in the bulk outputs. (Although the protection is nice, too)._"
 
 
 [[troubleshooting-pqs]]

--- a/docs/static/pipeline-pipeline-config.asciidoc
+++ b/docs/static/pipeline-pipeline-config.asciidoc
@@ -1,9 +1,13 @@
 [[pipeline-to-pipeline]]
-=== Pipeline-to-Pipeline Communication
+=== Pipeline-to-pipeline communication
 
 When using the multiple pipeline feature of Logstash, you may want to connect multiple pipelines within the same Logstash instance. This configuration can be useful to isolate the execution of these pipelines, as well as to help break-up the logic of complex pipelines. The `pipeline` input/output enables a number of advanced architectural patterns discussed later in this document.
 
 If you need to set up communication _between_ Logstash instances, use either {logstash-ref}/ls-to-ls.html[Logstash-to-Logstash] communications, or an intermediary queue, such as Kafka or Redis.
+
+TIP: Persistent queues (PQs) can help keep data moving through pipelines.  
+See <<pq-pline-pline>> to learn how PQs can enhance your
+pipeline-to-pipeline communication strategy. 
 
 [[pipeline-to-pipeline-overview]]
 ==== Configuration overview


### PR DESCRIPTION
## Release notes
[rn:skip]

Expands persistent queue doc to explain how pipeline-to-pipeline configurations can benefit from PQs. 
Adds link from pipeline-to-pipeline doc to PQ doc

Related: #13173

**PREVIEW:** https://logstash_13319.docs-preview.app.elstc.co/guide/en/logstash/master/persistent-queues.html#pq-pline-pline