### PR TITLE
Doc: Add link to pq info from troubleshooting topic

### DIFF
--- a/docs/static/troubleshoot/ts-logstash.asciidoc
+++ b/docs/static/troubleshoot/ts-logstash.asciidoc
@@ -79,7 +79,7 @@ https://github.com/elastic/logstash/issues/10496[issue].
 Symptoms of persistent queue problems include {ls} or one or more pipelines not starting successfully, accompanied by an error message similar to this one.
 
 ```
-message=>"java.io.IOException: Page file size is too small to hold elements
+message=>"java.io.IOException: Page file size is too small to hold elements"
 ```
 
 See the <<troubleshooting-pqs,troubleshooting information>> in the persistent


### PR DESCRIPTION
Adds sample error message and description to general Troubleshooting section, with a link back to the PQ topic for more info

Related: 
#13158 
#13173

**PREVIEW:** https://logstash_13320.docs-preview.app.elstc.co/guide/en/logstash/master/ts-logstash.html#ts-pqs

## Release notes
[rn:skip] 