### PR TITLE
Doc: Fix templating error in integration plugin header

### DIFF
--- a/docs/include/plugin_header-integration.asciidoc
+++ b/docs/include/plugin_header-integration.asciidoc
@@ -34,6 +34,6 @@ endif::[]
 ==== Getting Help
 
 For questions about the plugin, open a topic in the http://discuss.elastic.co[Discuss] forums. 
-For bugs or feature requests, open an issue in https://github.com/logstash-plugins/logstash-integration-{plugin}[Github].
+For bugs or feature requests, open an issue in https://github.com/logstash-plugins/logstash-integration-{integration}[Github].
 For the list of Elastic supported plugins, please consult the https://www.elastic.co/support/matrix#matrix_logstash_plugins[Elastic Support Matrix].
 


### PR DESCRIPTION
## Release notes
[rn:skip] 

Updates link to point integration repo.

**PREVIEW:** https://logstash_13324.docs-preview.app.elstc.co/diff

#### Notes
* This issue affected only integration plugins whose component plugin names don't match the integration name. That is,  `{plugin}`!=`{integration}`.
   * integration-elastic_enterprise_search 
      * output-elastic_app_search
      * output-elastic_workplace_search
   * integration-jdbc
      * filter-jdbc_static
      * filter-jdbc_streaming
      * Note that input-jdbc isn't affected because `{plugin}`=`{integration}`. 
      
   * Plugins in the kafka and rabbitmq integration aren't affected. That is,  `{plugin}`=`{integration}`.
  
* The corresponding integration header for the VPR is already correct, and so no change is needed. [Reference](https://github.com/elastic/logstash-docs/blame/versioned_plugin_docs/docs/versioned-plugins/include/6.x/plugin_header-integration.asciidoc#L37)

Thanks for the catch, @andsel 