### PR TITLE
[backport 7.x] Update JDK matrix to include JDK17: OpenJDK, AdoptiumJDK and Zulu (#13307)

### DIFF
--- a/.ci/matrix-runtime-javas.yml
+++ b/.ci/matrix-runtime-javas.yml
@@ -7,10 +7,8 @@
 LS_RUNTIME_JAVA:
   - java8
   - openjdk11
-  - openjdk14
+  - openjdk17
   - adoptopenjdk11
-  - adoptopenjdk14
-  - adoptopenjdk15
+  - adoptiumjdk17
   - zulu11
-  - zulu14
-  - zulu15
+  - zulu17


### PR DESCRIPTION
Clean backport of #13307 to branch `7.x`

(cherry picked from commit 949b4a0cefcf5041064515b3b122f46b7dba0c48)
