### PR TITLE
[backport 7.x] Fixes to build and run Logstah on JDK 17 (#13306)

### DIFF
--- a/config/jvm.options
+++ b/config/jvm.options
@@ -79,3 +79,6 @@
 
 # Copy the logging context from parent threads to children
 -Dlog4j2.isThreadContextMapInheritable=true
+
+17-:--add-opens java.base/sun.nio.ch=ALL-UNNAMED
+17-:--add-opens java.base/java.io=ALL-UNNAMED

--- a/logstash-core/src/main/java/org/logstash/Logstash.java
+++ b/logstash-core/src/main/java/org/logstash/Logstash.java
@@ -26,8 +26,6 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -128,24 +126,8 @@ public final class Logstash implements Runnable, AutoCloseable {
     }
 
     private static void halt(final int status) {
-        AccessController.doPrivileged(new PrivilegedHaltAction(status));
-    }
-
-    private static class PrivilegedHaltAction implements PrivilegedAction<Void> {
-
-        private final int status;
-
-        private PrivilegedHaltAction(final int status) {
-            this.status = status;
-        }
-
-        @Override
-        public Void run() {
-            // we halt to prevent shutdown hooks from running
-            Runtime.getRuntime().halt(status);
-            return null;
-        }
-
+        // we halt to prevent shutdown hooks from running
+        Runtime.getRuntime().halt(status);
     }
 
     /**

--- a/logstash-core/src/test/java/org/logstash/secret/store/backend/JavaKeyStoreTest.java
+++ b/logstash-core/src/test/java/org/logstash/secret/store/backend/JavaKeyStoreTest.java
@@ -27,6 +27,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
+import org.logstash.LogstashJavaCompat;
 import org.logstash.secret.SecretIdentifier;
 import org.logstash.secret.store.SecretStore;
 import org.logstash.secret.store.SecretStoreException;
@@ -314,7 +315,7 @@ public class JavaKeyStoreTest {
      */
     @Test
     public void tamperedKeystore() throws Exception {
-        thrown.expect(SecretStoreException.AccessException.class);
+        thrown.expect(SecretStoreException.class);
         byte[] keyStoreAsBytes = Files.readAllBytes(Paths.get(new String(keyStorePath)));
         //bump the middle byte by 1
         int tamperLocation = keyStoreAsBytes.length / 2;

--- a/qa/integration/build.gradle
+++ b/qa/integration/build.gradle
@@ -61,6 +61,9 @@ clean {
 }
 
 tasks.register("integrationTests", Test) {
+  if ((JavaVersion.current().getMajorVersion() as int) >= 17) {
+    jvmArgs = ['--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED', '--add-opens', 'java.base/java.io=ALL-UNNAMED']
+  }
   dependsOn copyProductionLog4jConfiguration
 
   inputs.files fileTree("${projectDir}/services")

--- a/x-pack/build.gradle
+++ b/x-pack/build.gradle
@@ -52,6 +52,9 @@ tasks.register("rubyTests", Test) {
 }
 
 tasks.register("rubyIntegrationTests", Test) {
+  if ((JavaVersion.current().getMajorVersion() as int) >= 17) {
+    jvmArgs = ['--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED', '--add-opens', 'java.base/java.io=ALL-UNNAMED']
+  }
   dependsOn (":copyEs")
   inputs.files fileTree("${projectDir}/qa")
   inputs.files fileTree("${projectDir}/lib")


### PR DESCRIPTION
Backport #13306 to branch `7.x`

This commit applies all the changes needed to run Logstash on JDK 17:
- opens access to module java.base for packages sun.nio.ch and java.io to run the application and to execute the tests
- removes SecurityManager classes used during Logstash startup
- fix exception type catched in JavaKeyStore tampering test

Related to meta issue #13306

(cherry picked from commit 7395641a43062ee100429b1dd34a27b83fb3695b)
