### PR TITLE
Updates the clauses used to filter out from stderr captured messages

### DIFF
--- a/qa/integration/specs/cli/prepare_offline_pack_spec.rb
+++ b/qa/integration/specs/cli/prepare_offline_pack_spec.rb
@@ -87,6 +87,7 @@ describe "CLI > logstash-plugin prepare-offline-pack" do
                                 .stderr_and_stdout.split("\n")
                                 .delete_if do |line|
                                   line =~ /cext|├──|└──|logstash-integration|JAVA_OPT|fatal|^WARNING|^warning: ignoring JAVA_TOOL_OPTIONS|^OpenJDK 64-Bit Server VM warning|Option \w+ was deprecated|Using LS_JAVA_HOME defined java|Using JAVA_HOME defined java|Using system java: |\[\[: not found/ ||
+                                  line =~ /DEPRECATION: The use of JAVA_HOME is now deprecated and will be removed/ ||
                                   line =~ /warning: constant Gem::ConfigMap is deprecated/ # can be removed after upgrading Bundler from version 1.17
                                 end
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Fixes an integration test that expects some output on the `stderr`.
With PR #13207 was added a deprecation notice to inform the user about the removal of support  for `JAVA_HOME`. This notice is present only on `7.x` and that console output needs to be removed in a test that verify installation of plugins.

This problem is not present on `master` because on that branch the usage of `JAVA_HOME` has been completely removed and doesn't print the deprecation notice.

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->



## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates to #13207 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

```
19:14:43       1) CLI > logstash-plugin prepare-offline-pack create a pack from a wildcard successfully create a pack
19:14:43          Failure/Error: expect(unpacked.plugins.collect(&:name)).to include(*filters)
19:14:43            expected ["logstash-filter-aggregate", "logstash-filter-anonymize", "logstash-filter-cidr", "logstash-filter-c...stash-filter-urldecode", "logstash-filter-useragent", "logstash-filter-uuid", "logstash-filter-xml"] to include "DEPRECATION: The use of JAVA_HOME is now deprecated and will be removed starting from 8.0. Please configure LS_JAVA_HOME instead."
19:14:43          # /var/lib/jenkins/workspace/elastic+logstash+7.x+multijob-matrix-jdk-unix-integration-pq-2/LS_RUNTIME_JAVA/adoptiumjdk17/os/centos-8&&immutable/qa/integration/specs/cli/prepare_offline_pack_spec.rb:93:in `block in <main>'
19:14:43          # /var/lib/jenkins/workspace/elastic+logstash+7.x+multijob-matrix-jdk-unix-integration-pq-2/LS_RUNTIME_JAVA/adoptiumjdk17/os/centos-8&&immutable/build/qa/integration/vendor/jruby/2.5.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block in <main>'
19:14:43          # /var/lib/jenkins/workspace/elastic+logstash+7.x+multijob-matrix-jdk-unix-integration-pq-2/LS_RUNTIME_JAVA/adoptiumjdk17/os/centos-8&&immutable/qa/integration/rspec.rb:32:in `<main>'
```
