### PR TITLE
Deps: bump update gems for 7.16.0

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -2,12 +2,12 @@ PATH
   remote: logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 7.15.2)
+      logstash-core (= 7.16.0)
 
 PATH
   remote: logstash-core
   specs:
-    logstash-core (7.15.2-java)
+    logstash-core (7.16.0-java)
       chronic_duration (~> 0.10)
       clamp (~> 1)
       concurrent-ruby (~> 1)
@@ -62,7 +62,7 @@ GEM
     backports (3.21.0)
     belzebuth (0.2.3)
       childprocess
-    benchmark-ips (2.9.1)
+    benchmark-ips (2.9.2)
     bindata (2.4.10)
     buftok (0.2.0)
     builder (3.2.4)
@@ -171,9 +171,12 @@ GEM
       addressable (>= 2.4)
     jwt (2.3.0)
     kramdown (1.14.0)
-    logstash-codec-avro (3.2.4-java)
+    logstash-codec-avro (3.3.0-java)
       avro
       logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
     logstash-codec-cef (6.2.3-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ecs_compatibility_support (~> 1.3)
@@ -195,9 +198,12 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-event_support (~> 1.0)
       logstash-mixin-validator_support (~> 1.0)
-    logstash-codec-es_bulk (3.0.8)
+    logstash-codec-es_bulk (3.1.0)
       logstash-codec-line
       logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
     logstash-codec-fluent (3.4.1-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-event_support (~> 1.0)
@@ -255,7 +261,7 @@ GEM
       rspec (~> 3.0)
       rspec-wait
       stud (>= 0.0.20)
-    logstash-filter-aggregate (2.9.2)
+    logstash-filter-aggregate (2.10.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-anonymize (3.0.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -281,8 +287,8 @@ GEM
       lru_redux (~> 1.1.0)
     logstash-filter-drop (3.0.5)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-elasticsearch (3.9.5)
-      elasticsearch (>= 5.0.5)
+    logstash-filter-elasticsearch (3.11.0)
+      elasticsearch (>= 7.14.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       manticore (>= 0.7.1)
     logstash-filter-fingerprint (3.3.2)
@@ -354,12 +360,12 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       nokogiri
       xml-simple
-    logstash-input-azure_event_hubs (1.3.0)
+    logstash-input-azure_event_hubs (1.4.0)
       logstash-codec-json
       logstash-codec-plain
       logstash-core-plugin-api (~> 2.0)
       stud (>= 0.0.22)
-    logstash-input-beats (6.2.0-java)
+    logstash-input-beats (6.2.1-java)
       concurrent-ruby (~> 1.0)
       jar-dependencies (~> 0.3, >= 0.3.4)
       logstash-codec-multiline (>= 2.0.5)
@@ -376,14 +382,14 @@ GEM
     logstash-input-dead_letter_queue (1.1.5)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-input-elasticsearch (4.9.3)
-      elasticsearch (>= 5.0.5)
-      logstash-codec-json
+    logstash-input-elasticsearch (4.12.1)
+      elasticsearch (>= 7.14.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
       logstash-mixin-validator_support (~> 1.0)
       manticore (>= 0.7.1)
       rufus-scheduler
-      sequel
       tzinfo
       tzinfo-data
     logstash-input-exec (3.3.3)
@@ -425,10 +431,13 @@ GEM
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ecs_compatibility_support (~> 1.2)
-    logstash-input-http_poller (5.0.2)
+    logstash-input-http_poller (5.1.0)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0, >= 1.0.1)
       logstash-mixin-http_client (~> 7)
+      logstash-mixin-validator_support (~> 1.0)
       rufus-scheduler (~> 3.0.9)
       stud (~> 0.0.22)
     logstash-input-imap (3.1.0)
@@ -451,7 +460,7 @@ GEM
       logstash-codec-json
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       redis (>= 4.0.1, < 5)
-    logstash-input-s3 (3.8.0)
+    logstash-input-s3 (3.8.1)
       logstash-core-plugin-api (>= 2.1.12, <= 2.99)
       logstash-mixin-aws (>= 4.3.0)
       logstash-mixin-ecs_compatibility_support (~> 1.2)
@@ -510,7 +519,7 @@ GEM
       elastic-workplace-search (~> 0.4.1)
       logstash-codec-plain
       logstash-core-plugin-api (~> 2.0)
-    logstash-integration-jdbc (5.1.5)
+    logstash-integration-jdbc (5.1.6)
       logstash-codec-plain
       logstash-core (>= 6.5.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -563,7 +572,7 @@ GEM
       logstash-filter-json
       logstash-input-generator
       logstash-output-file
-    logstash-output-elasticsearch (11.0.5-java)
+    logstash-output-elasticsearch (11.2.1-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ecs_compatibility_support (~> 1.0)
       manticore (>= 0.7.1, < 1.0.0)
@@ -631,7 +640,7 @@ GEM
       mime-types (>= 1.16, < 4)
     manticore (0.7.1-java)
       openssl_pkcs8_pure
-    march_hare (4.3.0-java)
+    march_hare (4.4.0-java)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     method_source (1.0.0)
@@ -670,7 +679,7 @@ GEM
       method_source (~> 1.0)
       spoon (~> 0.0)
     public_suffix (3.1.1)
-    puma (4.3.8-java)
+    puma (4.3.10-java)
       nio4r (~> 2.0)
     racc (1.5.2-java)
     rack (2.2.3)
@@ -680,7 +689,7 @@ GEM
       rack (>= 1.0, < 3)
     rake (12.3.3)
     rchardet (1.8.0)
-    redis (4.4.0)
+    redis (4.5.1)
     rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -738,7 +747,7 @@ GEM
       simple_oauth (~> 0.3.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2021.3)
+    tzinfo-data (1.2021.4)
       tzinfo (>= 1.0.0)
     unf (0.1.4-java)
     webhdfs (0.10.2)
@@ -887,4 +896,4 @@ DEPENDENCIES
   webmock (~> 3)
 
 BUNDLED WITH
-   2.2.28
+   2.2.29


### PR DESCRIPTION
**NOTE: targeting 7.x - should be changed to 7.16 (auto-magically once the branch gets renamed).**

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

Bump gems for new major **7.16**.

Change set (from 7.15.1): **https://github.com/elastic/logstash/pull/13337/commits/e89e391d71f7416480326dc9ddcc8a91695e63f2**

## Why is it important/What is the impact to the user?

N/A