### PR TITLE
Backport PR #13339 to 7.15: Temporarily pin `racc` to `1.5.2` to fix …

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -79,4 +79,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'down', '~> 5.2.0' #(MIT license)
   gem.add_dependency 'tzinfo-data' #(MIT license)
   gem.add_dependency 'rufus-scheduler' #(MIT license)
+
+  # TEMPORARY: racc-1.6.0 doesn't have JAVA counterpart (yet)
+  # SEE: https://github.com/ruby/racc/issues/172
+  gem.add_runtime_dependency "racc", "~> 1.5.2" #(Ruby license)
 end


### PR DESCRIPTION
…build

Backport PR #13339 to 7.15 branch. Original message:

Pin `racc` to `1.5.2` as racc-1.6.0 doesn't have JAVA counterpart (yet)
SEE: https://github.com/ruby/racc/issues/172

