### PR TITLE
Deps: fix broken gem lock due puma requirement

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -22,7 +22,8 @@ PATH
       minitar (~> 0.8)
       mustermann (~> 1.0.3)
       pry (~> 0.12)
-      puma (~> 4)
+      puma (~> 5)
+      racc (~> 1.5.2)
       rack (~> 2)
       rubyzip (~> 1)
       rufus-scheduler
@@ -679,7 +680,7 @@ GEM
       method_source (~> 1.0)
       spoon (~> 0.0)
     public_suffix (3.1.1)
-    puma (4.3.10-java)
+    puma (5.5.2-java)
       nio4r (~> 2.0)
     racc (1.5.2-java)
     rack (2.2.3)


### PR DESCRIPTION
A lock update was merged to 7.16: https://github.com/elastic/logstash/pull/13337
the lock changes did not account for a previous requirement [change on `puma '~> 5'`](https://github.com/elastic/logstash/pull/13342/files#diff-db8735f3fd64e29befb30510d77ab93ae863feba2a3349f048dfc50c57df73ecR59),
same for the recently added `racc (~> 1.5.2)` requirement ...

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

Resolves a LS build failure after merging 2 PRs.

## Why is it important/What is the impact to the user?

N/A