### PR TITLE
Update documentation around JVM usage to reflect changes

### DIFF
--- a/docs/static/jvm.asciidoc
+++ b/docs/static/jvm.asciidoc
@@ -18,8 +18,8 @@ for the official word on supported versions across releases.
 [NOTE]
 ===== 
 {ls} offers architecture-specific
-https://staging-website.elastic.co/downloads/logstash[downloads] that include
-Adoptium Eclipse Terumin 17, the latest long term support (LTS) release of the JDK.
+https://www.elastic.co/downloads/logstash[downloads] that include
+Adoptium Eclipse Temurin 17, the latest long term support (LTS) release of the JDK.
 
 Use the LS_JAVA_HOME environment variable if you want to use a JDK other than the
 version that is bundled. 

--- a/docs/static/troubleshoot/ts-logstash.asciidoc
+++ b/docs/static/troubleshoot/ts-logstash.asciidoc
@@ -39,7 +39,7 @@ Operation not permitted
 
 // https://github.com/elastic/logstash/issues/10496 and https://github.com/elastic/logstash/issues/10498
 
-After an upgrade from an earlier version of Logstash, running Logstash may result in warnings similar to these:
+After an upgrade, Logstash may show warnings similar to these:
 
 [source,sh]
 -----
@@ -67,7 +67,7 @@ Try adding these values to the `jvm.options` file.
 
 *Notes:*
 
-* These settings allow Logstash to start without warnings
+* These settings allow Logstash to start without warnings.
 * This workaround has been tested with simple pipelines. If you have experiences
 to share, please comment in the
 https://github.com/elastic/logstash/issues/10496[issue].


### PR DESCRIPTION
For Logstash `8.0`, java 8 will no longer be supported, and the documentation should
reflect that.

Update troubleshooting documentation - changes made in #13349 should remove the warnings
at startup for fresh installs of Logstash, but upgrading may still have the same issues.