### PR TITLE
Deps: upgrade jruby-openssl to 0.11.0

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -17,7 +17,7 @@ PATH
       gems (~> 1)
       i18n (~> 1)
       jrjackson (= 0.4.14)
-      jruby-openssl (= 0.10.5)
+      jruby-openssl (~> 0.11)
       manticore (~> 0.6)
       minitar (~> 0.8)
       mustermann (~> 1.0.3)
@@ -164,7 +164,7 @@ GEM
     jruby-jms (1.3.0-java)
       gene_pool
       semantic_logger
-    jruby-openssl (0.10.5-java)
+    jruby-openssl (0.11.0-java)
     jruby-stdin-channel (0.2.0-java)
     json (1.8.6-java)
     json-schema (2.8.1)

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "mustermann", '~> 1.0.3'
   gem.add_runtime_dependency "sinatra", '~> 2'
   gem.add_runtime_dependency 'puma', '~> 4'
-  gem.add_runtime_dependency "jruby-openssl", "= 0.10.5" # >= 0.9.13 Required to support TLSv1.2
+  gem.add_runtime_dependency "jruby-openssl", "~> 0.11"
   gem.add_runtime_dependency "chronic_duration", "~> 0.10"
 
   gem.add_runtime_dependency "treetop", "~> 1" #(MIT license)


### PR DESCRIPTION
to properly support alt-chain certificate verifications in plugins using the Ruby net/http stack (S3, RSS)

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes

The recent Let's Encrypt "DST Root CA X3" expiration has caused issues in Logstash plugins such as S3.
We're including the upstream fix to avoid these issues and support alternate chain TLS certificate verification.

## What does this PR do?

Dependency update. 

## Why is it important/What is the impact to the user?

This allows users to deal with alternate chain in their trust stores esp. when certificates expire.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- closes https://github.com/elastic/logstash/issues/13261