### PR TITLE
Add deprecation warnings for JAVA_HOME/older versions of Java

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -326,9 +326,9 @@ class LogStash::Runner < Clamp::StrictCommand
       deprecation_logger.deprecated msg
     end
 
-    if JavaVersion.compare(JavaVersion::CURRENT, JavaVersion::JAVA_11) < 0
+    if JavaVersion::CURRENT < JavaVersion::JAVA_11
         deprecation_logger.deprecated I18n.t("logstash.runner.java.version",
-                                             :java_version => java.lang.System.getProperty("java.home"))
+                                             :java_home => java.lang.System.getProperty("java.home"))
     end
 
     deprecation_logger.deprecated I18n.t("logstash.runner.java.home") if ENV["JAVA_HOME"]

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -435,13 +435,16 @@ en:
           DEPRECATED: use --log.level=info instead.
       java:
         home: >-
-          The use of JAVA_HOME is now deprecated. Starting from Logstash 8.0, this value will be ignored and the
-          bundled JDK will be used instead.
-          The recommended way to run Logstash is to use the bundled JDK. If you do need to provide your own JDK,
-          please configure it using LS_JAVA_HOME instead.
+          The use of JAVA_HOME has been deprecated. Logstash 8.0 and later ignores JAVA_HOME and uses the bundled JDK.
+          Running Logstash with the bundled JDK is recommended.
+          The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability.
+          If you have compelling reasons for using your own JDK (organizational-specific compliance requirements, for example), you can configure LS_JAVA_HOME to use that version instead.
         version: >-
           Starting from Logstash 8.0, the minimum required version of Java is Java 11; your Java version from
-          %{java_version} does not meet this requirement. Please reconfigure your version of Java to one that is supported.
+          %{java_home} does not meet this requirement. Please reconfigure your version of Java to one that is supported.
+          Running Logstash with the bundled JDK is recommended.
+          The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability.
+          If you have compelling reasons for using your own JDK (organizational-specific compliance requirements, for example), you can configure LS_JAVA_HOME to use that version instead.
     settings:
       deprecation:
         set: >-

--- a/logstash-core/src/main/java/org/logstash/util/JavaVersion.java
+++ b/logstash-core/src/main/java/org/logstash/util/JavaVersion.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Helper class to compare current version of JVM with a target version.
  * Based on JavaVersion class from elasticsearch java version checker tool
  */
-public class JavaVersion {
+public class JavaVersion implements Comparable<JavaVersion> {
 
     public static final JavaVersion CURRENT = parse(System.getProperty("java.specification.version"));
     public static final JavaVersion JAVA_11 = parse("11");
@@ -59,7 +59,7 @@ public class JavaVersion {
         }
     }
 
-    public static int compare(final JavaVersion leftVersion, final JavaVersion rightVersion) {
+    private static int compare(final JavaVersion leftVersion, final JavaVersion rightVersion) {
         List<Integer> left = leftVersion.version;
         List<Integer> right = rightVersion.version;
         // lexicographically compare two lists, treating missing entries as zeros
@@ -77,4 +77,8 @@ public class JavaVersion {
         return 0;
     }
 
+    @Override
+    public int compareTo(JavaVersion other) {
+        return compare(this, other);
+    }
 }


### PR DESCRIPTION
Logstash 8.0 will remove support for java versions before java 11, this commit
adds entries to the deprecation log warning against this.
Also adds use of `JAVA_HOME` to the deprecation log.


## Release notes
This commit adds information to the deprecation log stating that using `JAVA_HOME` and the use of java 1.8 has been deprecated and will be removed in the next major logstash release.

## What does this PR do?

Adds `JavaVersion` class, based on the `JavaVersion` class used in Elasticsearch. The intention is to use this class in `8.0` along with a `JavaVersionChecker` main class to verify Java version and provide a friendly error message when attempting to run Logstash with JDK < 11 in Logstash `8.0`

## Why is it important/What is the impact to the user?

The impact to the user for `7.16` is that they will be made aware of upcoming changes to withdraw support for Java `1.8` in the next major version of Logstash.

## Checklist


- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

Checkout out the PR, and run against various versions of Java, ensuring that 

- When running Logstash with Java versions below Java 11, Logstash will start, but an entry will appear in the deprecation log.
- When running Logstash with Java versions 11 and above, Logstash will start without an entry in the deprecation log.
- When running Logstash with `JAVA_HOME` set, Logstash will start, but an entry will appear in the deprecation log.
- When running Logstash without `JAVA_HOME` set, Logstash will start without an entry in the deprecation log.

