### PR TITLE
only use --add-opens flags on java 11+

### DIFF
--- a/config/jvm.options
+++ b/config/jvm.options
@@ -75,8 +75,8 @@
 # Copy the logging context from parent threads to children
 -Dlog4j2.isThreadContextMapInheritable=true
 
---add-opens=java.base/java.security=ALL-UNNAMED
---add-opens=java.base/java.io=ALL-UNNAMED
---add-opens=java.base/java.nio.channels=ALL-UNNAMED
---add-opens=java.base/sun.nio.ch=ALL-UNNAMED
---add-opens=java.management/sun.management=ALL-UNNAMED
+11-:--add-opens=java.base/java.security=ALL-UNNAMED
+11-:--add-opens=java.base/java.io=ALL-UNNAMED
+11-:--add-opens=java.base/java.nio.channels=ALL-UNNAMED
+11-:--add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+11-:--add-opens=java.management/sun.management=ALL-UNNAMED


### PR DESCRIPTION
otherwise using Java 8 for building or running is not possible.

Once java 8 is officially deprecated gradle and logstash should terminate early and not reach this failure.