### PR TITLE
Doc: Add breaking changes

### DIFF
--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -52,6 +52,15 @@ The Field Reference parser interprets references to fields in your pipelines and
 plugins. It was configurable in 7.x, with the default set to strict to reject
 inputs that are ambiguous or illegal. Configurability is removed in 8.0. Now
 {ls} rejects ambiguous and illegal inputs as standard behavior.
+
+[discrete]
+[[bc-java-home]]
+===== Removed support for JAVA_HOME
+Support for using `JAVA_HOME` to override the path to the JDK that Logstash runs
+with has been removed. 
+Users should set the value of `LS_JAVA_HOME` to the path of their preferred JDK
+if they need to use a version other than the bundled JDK. 
+The value of `JAVA_HOME` will be ignored.
 // end::notable-breaking-changes[]
 
 [[breaking-7.0]]

--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -42,8 +42,8 @@ performance and reliability.
 [[bc-java-home]]
 ===== Support for JAVA_HOME removed
 We've removed support for using `JAVA_HOME` to override the path to the JDK. 
-Users should set the value of `LS_JAVA_HOME` to the path of their preferred JDK
-if they need to use a version other than the bundled JDK. 
+Users who need to use a version other than the bundled JDK should set the value
+of `LS_JAVA_HOME` to the path of their preferred JDK. 
 The value of `JAVA_HOME` will be ignored.
 
 [discrete]

--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -31,8 +31,20 @@ Here are the breaking changes for 8.0.
 
 // tag::notable-breaking-changes[]
 [discrete]
-[[bc-core]]
-==== Changes in Logstash Core
+[[bc-java-11-minimum]]
+===== Java 11 minimum
+Logstash requires Java 11 or later.
+By default, Logstash will run with the bundled JDK, which has been verified to
+work with each specific version of Logstash, and generally provides the best
+performance and reliability.
+
+[discrete]
+[[bc-java-home]]
+===== Support for JAVA_HOME removed
+We've removed support for using `JAVA_HOME` to override the path to the JDK. 
+Users should set the value of `LS_JAVA_HOME` to the path of their preferred JDK
+if they need to use a version other than the bundled JDK. 
+The value of `JAVA_HOME` will be ignored.
 
 [discrete]
 [[bc-ruby-engine]]
@@ -52,15 +64,6 @@ The Field Reference parser interprets references to fields in your pipelines and
 plugins. It was configurable in 7.x, with the default set to strict to reject
 inputs that are ambiguous or illegal. Configurability is removed in 8.0. Now
 {ls} rejects ambiguous and illegal inputs as standard behavior.
-
-[discrete]
-[[bc-java-home]]
-===== Removed support for JAVA_HOME
-Support for using `JAVA_HOME` to override the path to the JDK that Logstash runs
-with has been removed. 
-Users should set the value of `LS_JAVA_HOME` to the path of their preferred JDK
-if they need to use a version other than the bundled JDK. 
-The value of `JAVA_HOME` will be ignored.
 // end::notable-breaking-changes[]
 
 [[breaking-7.0]]


### PR DESCRIPTION
Add removal of JAVA_HOME to 8.0 breaking changes
Add java 11 minimum to breaking changes

Backport target: 8.0

**PREVIEW:** https://logstash_13376.docs-preview.app.elstc.co/guide/en/logstash/master/breaking-8.0.html