### PR TITLE
Fixes a usage of deprecated 'http.enabled' to the new 'api.enabled'

### DIFF
--- a/x-pack/lib/monitoring/inputs/metrics/stats_event_factory.rb
+++ b/x-pack/lib/monitoring/inputs/metrics/stats_event_factory.rb
@@ -12,7 +12,7 @@ module LogStash; module Inputs; class Metrics;
       @snapshot = snapshot
       @metric_store = @snapshot.metric_store
       @cluster_uuid = cluster_uuid
-      @webserver_enabled = LogStash::SETTINGS.get_value("http.enabled")
+      @webserver_enabled = LogStash::SETTINGS.get_value("api.enabled")
     end
 
     def make(agent, extended_performance_collection=true, collection_interval=10)

--- a/x-pack/spec/monitoring/inputs/metrics/stats_event_factory_spec.rb
+++ b/x-pack/spec/monitoring/inputs/metrics/stats_event_factory_spec.rb
@@ -17,7 +17,7 @@ shared_examples_for("old model monitoring event with webserver setting") do
     global_stats = {"uuid" => "00001" }
     sut = described_class.new(global_stats, collector.snapshot_metric, nil)
     LogStash::SETTINGS.set_value("monitoring.enabled", false)
-    LogStash::SETTINGS.set_value("api.4enabled", webserver_enabled)
+    LogStash::SETTINGS.set_value("api.enabled", webserver_enabled)
 
     monitoring_evt = sut.make(agent, true)
     json = JSON.parse(monitoring_evt.to_json)

--- a/x-pack/spec/monitoring/inputs/metrics/stats_event_factory_spec.rb
+++ b/x-pack/spec/monitoring/inputs/metrics/stats_event_factory_spec.rb
@@ -17,7 +17,7 @@ shared_examples_for("old model monitoring event with webserver setting") do
     global_stats = {"uuid" => "00001" }
     sut = described_class.new(global_stats, collector.snapshot_metric, nil)
     LogStash::SETTINGS.set_value("monitoring.enabled", false)
-    LogStash::SETTINGS.set_value("api.http.enabled", webserver_enabled)
+    LogStash::SETTINGS.set_value("api.4enabled", webserver_enabled)
 
     monitoring_evt = sut.make(agent, true)
     json = JSON.parse(monitoring_evt.to_json)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip] 

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
With #13308 configuration namespace that started with `http.` was renamed to `api.`, this commit fix a usage left behind.
Use the new `api.enabled` setting in one place instead of the deprecated `http.enable`.

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
Avoid polluting Logstash logs with warning messages like:
```
[WARN ][logstash.settings        ] The value of setting `api.enabled` has been queried by its deprecated alias `http.enabled`. Code should be updated to query `api.enabled` instead
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
