### PR TITLE
Backport PR #13369 to 6.8. Add java version parameterization to Logst…

### DIFF
--- a/.ci/java-versions.properties
+++ b/.ci/java-versions.properties
@@ -1,0 +1,2 @@
+LS_BUILD_JAVA=openjdk11
+LS_RUNTIME_JAVA=openjdk11


### PR DESCRIPTION
…ash builds

Backport PR #13369 to 6.8 branch. Original message:

Add ability to pull the version used to build java from the logstash repo, rather
than rely on system Java. Previously, builds would use JAVA_HOME, now this setting
is ignored in Logstash (and by extension, parts of the Logstash build), which was causing
variations in the version of Java used to build Logstash, including the use of Java 8,
which the Logstash team would like to remove support for.

Relates: https://github.com/elastic/infra/pull/32818