### PR TITLE
Deps: update JRuby to 9.2.20.0

### DIFF
--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -25,7 +25,7 @@ buildscript {
     dependencies {
         classpath 'org.yaml:snakeyaml:1.29'
         classpath "de.undercouch:gradle-download-task:4.0.4"
-        classpath "org.jruby:jruby-complete:9.2.19.0"
+        classpath "org.jruby:jruby-complete:9.2.20.0"
     }
 }
 

--- a/versions.yml
+++ b/versions.yml
@@ -13,8 +13,8 @@ bundled_jdk:
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time
 jruby:
-  version: 9.2.19.0
-  sha1: e61ac187d5e312a198a0b1767eb8c4f36c750749
+  version: 9.2.20.0
+  sha1: 5359c32c3d43e2cbfd4310f11941174560f63bc9
 
 # jruby-runtime-override, if specified, will override the jruby version installed in vendor/jruby for logstash runtime only,
 # not for the compile-time jars


### PR DESCRIPTION
Version bump of JRuby to latest in 9.2 series.

## Release notes

Update JRuby to 9.2.20.0

## What does this PR do?

Dependency update, release notes: https://github.com/jruby/jruby/releases/tag/9.2.20.0

## Checklist

<!--
## Author's Checklist

- [ ]
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->