### PR TITLE
[DOC] Remove reference to Logstash auth in Metricbeat Logstash module

### DIFF
--- a/docs/static/monitoring/monitoring-mb.asciidoc
+++ b/docs/static/monitoring/monitoring-mb.asciidoc
@@ -101,7 +101,7 @@ The `modules.d/logstash-xpack.yml` file contains these settings:
     xpack.enabled: true
 ----------------------------------
  
-Set the `hosts`, `username`, and `password` to authenticate with {ls}.
+Configure the `hosts` to point to the Logstash API endpoint.
 For other module settings, it's recommended that you accept the
 defaults.
 


### PR DESCRIPTION
## Type of change
- doc

## What does this PR do?

We suggest to provide credentials for Logstash monitoring, but it is misleading as we do not have authentication for the Logstash API.
We have an open issue to add such functionality (https://github.com/elastic/logstash/pull/13342) but it is really recent.

I would just keep the `username` and `password` commented and once https://github.com/elastic/logstash/pull/13342 is released, add a statement to provide credentials, if enabled.

## Maintainers' Checklist

- [ ] Review the content
- [ ] Eventually backport this change to all previous versions
- [ ] Once secure monitoring API is released, add the credentials statement (clarifying it's not enabled by default)
