### PR TITLE
Build: lock fpm to 1.13.x to avoid dep packaging issues using 1.14.0

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -11,7 +11,7 @@ gem "rake", "~> 12"
 gem "ruby-progressbar", "~> 1"
 gem "logstash-output-elasticsearch", ">= 10.4.2"
 gem "childprocess", "~> 4", :group => :build
-gem "fpm", "~> 1.13", :group => :build
+gem "fpm", "~> 1.14", :group => :build
 gem "gems", "~> 1", :group => :build
 gem "octokit", "~> 4", :group => :build
 gem "rubyzip", "~> 1", :group => :build

--- a/Gemfile.template
+++ b/Gemfile.template
@@ -11,7 +11,7 @@ gem "rake", "~> 12"
 gem "ruby-progressbar", "~> 1"
 gem "logstash-output-elasticsearch", ">= 10.4.2"
 gem "childprocess", "~> 4", :group => :build
-gem "fpm", "~> 1.13.1", :group => :build
+gem "fpm", "~> 1.13.1", :group => :build # due https://github.com/jordansissel/fpm/issues/1854
 gem "gems", "~> 1", :group => :build
 gem "octokit", "~> 4", :group => :build
 gem "rubyzip", "~> 1", :group => :build

--- a/Gemfile.template
+++ b/Gemfile.template
@@ -11,7 +11,7 @@ gem "rake", "~> 12"
 gem "ruby-progressbar", "~> 1"
 gem "logstash-output-elasticsearch", ">= 10.4.2"
 gem "childprocess", "~> 4", :group => :build
-gem "fpm", "~> 1.14", :group => :build
+gem "fpm", "~> 1.13.1", :group => :build
 gem "gems", "~> 1", :group => :build
 gem "octokit", "~> 4", :group => :build
 gem "rubyzip", "~> 1", :group => :build


### PR DESCRIPTION
Fix a broken `rake artifact:deb` (due freshly minted :gem:  fpm 1.14.0)

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

Locks a build dependency - used for creating deb packages.

## Why is it important/What is the impact to the user?

N/A

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] reproduce using 1.14.0

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Upstream issue

- https://github.com/jordansissel/fpm/issues/1854 
