### PR TITLE
Relax fpm version constraint after bug fix fpm#1856

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -11,7 +11,7 @@ gem "rake", "~> 12"
 gem "ruby-progressbar", "~> 1"
 gem "logstash-output-elasticsearch", ">= 10.4.2"
 gem "childprocess", "~> 4", :group => :build
-gem "fpm", "~> 1.13.1", :group => :build # due https://github.com/jordansissel/fpm/issues/1854
+gem "fpm", "~> 1", ">= 1.14.1", :group => :build # compound due to bugfix https://github.com/jordansissel/fpm/pull/1856
 gem "gems", "~> 1", :group => :build
 gem "octokit", "~> 4", :group => :build
 gem "rubyzip", "~> 1", :group => :build


### PR DESCRIPTION
[rn:skip]

## What does this PR do?

fpm was pinned to 1.13.x since 1.14.0 didn't allow creating packages under certain conditions through the api (see more at https://github.com/jordansissel/fpm/issues/1854)

## Why is it important/What is the impact to the user?

This prevented our build from creating Logstash debian packages.

## How to test this PR locally

(with jruby 9k on the PATH)

`rake artifact:deb`

## Related issues

- Relates https://github.com/jordansissel/fpm/issues/1854
- Relates: https://github.com/elastic/logstash/pull/13400