### PR TITLE
Refactor: avoid futile attempt to gc a string quickly

### DIFF
--- a/logstash-core/src/main/java/org/logstash/secret/store/SecretStoreFactory.java
+++ b/logstash-core/src/main/java/org/logstash/secret/store/SecretStoreFactory.java
@@ -160,8 +160,5 @@ public class SecretStoreFactory {
             secureConfig.add(KEYSTORE_ACCESS_KEY, keystore_pass.toCharArray());
             keystore_pass = null;
         }
-
-        //futile attempt to remove the original pass from memory
-        System.gc();
     }
 }


### PR DESCRIPTION
which causes a redundant Full GC while Logstash is starting

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

Internal cleanup - avoid triggering GC manually.

## Why is it important/What is the impact to the user?

N/A
