### PR TITLE
[backport 8.0]Fixes a usage of deprecated 'http.enabled' #13380

### DIFF
--- a/x-pack/lib/monitoring/inputs/metrics/stats_event_factory.rb
+++ b/x-pack/lib/monitoring/inputs/metrics/stats_event_factory.rb
@@ -12,7 +12,7 @@ module LogStash; module Inputs; class Metrics;
       @snapshot = snapshot
       @metric_store = @snapshot.metric_store
       @cluster_uuid = cluster_uuid
-      @webserver_enabled = LogStash::SETTINGS.get_value("http.enabled")
+      @webserver_enabled = LogStash::SETTINGS.get_value("api.enabled")
     end
 
     def make(agent, extended_performance_collection=true, collection_interval=10)

--- a/x-pack/spec/monitoring/inputs/metrics/stats_event_factory_spec.rb
+++ b/x-pack/spec/monitoring/inputs/metrics/stats_event_factory_spec.rb
@@ -17,7 +17,7 @@ shared_examples_for("old model monitoring event with webserver setting") do
     global_stats = {"uuid" => "00001" }
     sut = described_class.new(global_stats, collector.snapshot_metric, nil)
     LogStash::SETTINGS.set_value("monitoring.enabled", false)
-    LogStash::SETTINGS.set_value("api.http.enabled", webserver_enabled)
+    LogStash::SETTINGS.set_value("api.enabled", webserver_enabled)
 
     monitoring_evt = sut.make(agent, true)
     json = JSON.parse(monitoring_evt.to_json)


### PR DESCRIPTION
Clean backport to `8.0` of #13380 