### PR TITLE
Backport PR#12626 to 6.8: use correct headers api for redirects in pl…

### DIFF
--- a/lib/pluginmanager/utils/http_client.rb
+++ b/lib/pluginmanager/utils/http_client.rb
@@ -36,7 +36,7 @@ module LogStash module PluginManager module Utils
         response = http.request(request)
 
         if response.code == "302"
-          new_uri = response.headers["location"]
+          new_uri = response["location"]
           remote_file_exist?(new_uri, redirect_count + 1)
         elsif response.code == "200"
           true

--- a/spec/unit/plugin_manager/utils/http_client_spec.rb
+++ b/spec/unit/plugin_manager/utils/http_client_spec.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require "pluginmanager/utils/http_client"
+require "net/http"
 require "uri"
 
 describe LogStash::PluginManager::Utils::HttpClient do
@@ -88,9 +89,13 @@ describe LogStash::PluginManager::Utils::HttpClient do
       end
 
       context "with redirects" do
-        let(:redirect_response) { instance_double("Net::HTTP::Response", :code => "302", :headers => { "location" => "https://localhost:8888/new_path" }) }
+        let(:location) { "https://localhost:8888/new_path" }
+        let(:redirect_response) { instance_double("Net::HTTP::Response", :code => "302", :headers => { "location" => location }) }
         let(:response_ok) { instance_double("Net::HTTP::Response", :code => "200") }
 
+        before(:each) do
+          allow(redirect_response).to receive(:[]).with("location").and_return(location)
+        end
         it "follow 1 level redirect" do
           expect(mock_http).to receive(:request).with(kind_of(Net::HTTP::Head)).and_return(redirect_response)
           expect(mock_http).to receive(:request).with(kind_of(Net::HTTP::Head)).and_return(response_ok)


### PR DESCRIPTION
…ugin manager http client (#12626)

Backport PR #12626 to 6.8 branch. Original message:

* fix plugin installation QA test
