### PR TITLE
Backport PR #13391 to 8.0: ECS on by default for Logstash 8, again

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -70,17 +70,15 @@
 # available to plugins that implement an ECS Compatibility mode for use with
 # the Elastic Common Schema.
 # Possible values are:
-# - disabled (default)
+# - disabled
 # - v1
-# - v8
-# CAVEAT: use of this configuration for anything other than `disabled`
-# is considered BETA until the General Availability of
-# Logstash 8.0.0. As we continue to release updated plugins with ECS-Compatibility
-# modes, opting into them at a pipeline or process level will cause you to
-# automatically consume breaking changes with each upgrade, which may change the
-# shape of data your pipeline produces.
+# - v8 (default)
+# Pipelines defined before Logstash 8 operated without ECS in mind. To ensure a
+# migrated pipeline continues to operate as it did before your upgrade, opt-OUT
+# of ECS for the individual pipeline in its `pipelines.yml` definition. Setting
+# it here will set the default for _all_ pipelines, including new ones.
 #
-# pipeline.ecs_compatibility: disabled
+# pipeline.ecs_compatibility: v8
 #
 # ------------ Pipeline Configuration Settings --------------
 #

--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -47,6 +47,15 @@ of `LS_JAVA_HOME` to the path of their preferred JDK.
 The value of `JAVA_HOME` will be ignored.
 
 [discrete]
+[[bc-ecs-compatibility]]
+===== ECS compatibility is now on by default
+Many plugins can now be run in a mode that avoids implicit conflict with the Elastic Common Schema.
+This mode is controlled individually with each plugin's `ecs_compatibility` option, which defaults to the value of the Logstash `pipeline.ecs_compatibility` setting.
+In Logstash 8, this compatibility mode will be on-by-default for all pipelines. https://github.com/elastic/logstash/issues/11623[#11623]
+
+If you wish to _lock in_ a pipeline's behaviour from Logstash 7.x before upgrading to Logstash 8, you can set  `pipeline.ecs_compatibility: disabled` to its definition in `pipelines.yml` (or globally in `logstash.yml`).
+
+[discrete]
 [[bc-ruby-engine]]
 ===== Ruby Execution Engine removed
 The Java Execution Engine has been the default engine since Logstash 7.0, and works with plugins written in either Ruby or Java.

--- a/docs/static/ecs-compatibility.asciidoc
+++ b/docs/static/ecs-compatibility.asciidoc
@@ -2,7 +2,7 @@
 === ECS in Logstash
 
 // LS8 will ship with ECS v8, but until ECS v8 is ready we rely on ECS v1 as an approximation.
-:ls8-ecs-major-version: v1
+:ls8-ecs-major-version: v8
 
 The {ecs-ref}/index.html[Elastic Common Schema (ECS)] is an open source specification, developed with support from the Elastic user community.
 ECS defines a common set of fields to be used for storing event data, such as logs and metrics, in {es}.
@@ -15,25 +15,16 @@ Many plugins implement an ECS-compatibility mode, which causes them to produce a
 
 Any plugin that supports this mode will also have an `ecs_compatibility` option, which allows you to configure which mode the individual plugin instance should operate in.
 If left unspecified for an individual plugin, the pipeline's `pipeline.ecs_compatibility` setting will be observed.
-This allows you to configure plugins to use ECS -- or to lock in your existing non-ECS behavior.
+This allows you to configure plugins to use a specific version of ECS or to use their legacy non-ECS behavior.
 
 ECS compatibility modes do not prevent you from explicitly configuring a plugin in a manner that conflicts with ECS.
 Instead, they ensure that _implicit_ configuration avoids conflicts.
 
-NOTE: Until {ls} 8.0 and the final 7.x are released, any value for `pipeline.ecs_compatibility` other than `disabled` is considered BETA and unsupported.
-      As we continue to release plugins with ECS compatibility modes, having this flag set will cause even patch-level upgrades to _automatically_ consume breaking changes in the upgraded plugins, changing the shape of data the plugin produces.
-
-ifeval::["{ls8-ecs-major-version}"!="v8"]
-NOTE: ECS `v8` will be available alongside the GA release of {ls} 8.0.0, and will be available at or before the final minor release of {ls} 7.
-      We expect the scope of breaking changes in ECS 8 to be limited.
-      We are https://github.com/elastic/ecs/issues/839[tracking progress toward ECS v8] in a GitHub issue.
-endif::[]
-
 [[ecs-configuration]]
 ===== Configuring ECS
 
-ECS will be on by default in a future release of {ls}, but you can begin using it now by configuring individual plugins with `ecs_compatibility`.
-You can also "lock in" the existing non-ECS behavior for an entire pipeline to ensure its behavior doesn't change when you perform future upgrades.
+In {ls} 8, all plugins are run in ECS compatibility {ls8-ecs-major-version} mode by default, but you can opt out at the plugin, pipeline, or system level to maintain legacy behavior.
+This can be helpful if you have very complex pipelines that were defined pre-ECS, to allow you to either upgrade them or to avoid doing so independently of your {ls} 8.x upgrade.
 
 ====== Specific plugin instance
 
@@ -73,6 +64,8 @@ If you wish to provide a specific default value for `ecs_compatibility` to _all_
 This setting will be used unless overridden by a specific plugin instance.
 If unspecified for an individual pipeline, the global value will be used.
 
+For example, setting `pipeline.ecs_compatibility: disabled` for a pipeline _locks in_ that pipeline's pre-{ls} 8 behavior.
+
 [source,yaml,subs="attributes"]
 -----
 - pipeline.id: my-legacy-pipeline
@@ -82,9 +75,6 @@ If unspecified for an individual pipeline, the global value will be used.
   path.config: "/etc/path/to/ecs-pipeline.config"
   pipeline.ecs_compatibility: {ls8-ecs-major-version}
 -----
-
-NOTE: Until the General Availability of {ls} 8.0.0 that coincides with the final minor release of {ls} 7, any value for `pipeline.ecs_compatibility` other than `disabled` is considered BETA and unsupported because it will produce undesirable consequences when performing upgrades.
-      As we continue to release updated plugins with ECS-Compatibility modes, opting into them at a pipeline or process level will cause the affected plugins to silently and automatically consume breaking changes with each upgrade, which may change the shape of data your pipeline produces.
 
 [[ecs-configuration-all]]
 ====== All plugins in all pipelines

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -65,14 +65,6 @@ class LogStash::Agent
     # Generate / load the persistent uuid
     id
 
-    if @settings.set?('pipeline.ecs_compatibility')
-      ecs_compatibility_value = settings.get('pipeline.ecs_compatibility')
-      if ecs_compatibility_value != 'disabled'
-        logger.warn("Setting `pipeline.ecs_compatibility` given as `#{ecs_compatibility_value}`; " +
-                    "values other than `disabled` are currently considered BETA and may have unintended consequences when upgrading minor versions of Logstash.")
-      end
-    end
-
     # Initialize, but do not start the webserver.
     @webserver = LogStash::WebServer.from_settings(@logger, self, settings)
 

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -60,7 +60,7 @@ module LogStash
            Setting::Boolean.new("pipeline.plugin_classloaders", false),
            Setting::Boolean.new("pipeline.separate_logs", false),
    Setting::CoercibleString.new("pipeline.ordered", "auto", true, ["auto", "true", "false"]),
-   Setting::CoercibleString.new("pipeline.ecs_compatibility", "disabled", true, %w(disabled v1 v8)),
+   Setting::CoercibleString.new("pipeline.ecs_compatibility", "v8", true, %w(disabled v1 v8)),
                     Setting.new("path.plugins", Array, []),
     Setting::NullableString.new("interactive", nil, false),
            Setting::Boolean.new("config.debug", false),

--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -72,6 +72,10 @@ module LogStash; class JavaPipeline < JavaBasePipeline
     # is by design and necessary for the wait_until_started semantic
     @finished_run = Concurrent::AtomicBoolean.new(false)
 
+    @logger.info(I18n.t('logstash.pipeline.effective_ecs_compatibility',
+                        :pipeline_id       => pipeline_id,
+                        :ecs_compatibility => settings.get('pipeline.ecs_compatibility')))
+
     @thread = nil
   end # def initialize
 

--- a/logstash-core/lib/logstash/plugins/ecs_compatibility_support.rb
+++ b/logstash-core/lib/logstash/plugins/ecs_compatibility_support.rb
@@ -17,11 +17,6 @@ module LogStash
             pipeline_settings = pipeline && pipeline.settings
             pipeline_settings ||= LogStash::SETTINGS
 
-            if !pipeline_settings.set?('pipeline.ecs_compatibility')
-              deprecation_logger.deprecated("Relying on default value of `pipeline.ecs_compatibility`, which may change in a future major release of Logstash. " +
-                                            "To avoid unexpected changes when upgrading Logstash, please explicitly declare your desired ECS Compatibility mode.")
-            end
-
             pipeline_settings.get_value('pipeline.ecs_compatibility').to_sym
           end
         end

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -45,6 +45,9 @@ en:
         %{plugin} output plugin: setting 'workers => %{worker_count}' is not
         supported by this plugin. I will continue working as if you had not set
         this setting. Reason: %{message}
+      effective_ecs_compatibility: >-
+        Pipeline `%{pipeline_id}` is configured with `pipeline.ecs_compatibility: %{ecs_compatibility}` setting.
+        All plugins in this pipeline will default to `ecs_compatibility => %{ecs_compatibility}` unless explicitly configured otherwise.
     plugin:
       deprecated_milestone: >-
         %{plugin} plugin is using the 'milestone' method to declare the version

--- a/logstash-core/spec/logstash/plugin_spec.rb
+++ b/logstash-core/spec/logstash/plugin_spec.rb
@@ -461,16 +461,9 @@ describe LogStash::Plugin do
       end
 
       context 'and pipeline-level setting is not specified' do
-        it 'emits a deprecation warning about using the default which may change' do
-          instance.ecs_compatibility
-
-          expect(deprecation_logger_stub).to have_received(:deprecated) do |message|
-            expect(message).to include("Relying on default value of `pipeline.ecs_compatibility`")
-          end
-        end
-        it 'returns `disabled`' do
+        it 'returns `v8`' do
           # Default value of `pipeline.ecs_compatibility`
-          expect(instance.ecs_compatibility).to eq(:disabled)
+          expect(instance.ecs_compatibility).to eq(:v8)
         end
       end
     end


### PR DESCRIPTION
Backport PR #13391 to 8.0 branch. Original message: 

## Release notes

[breaking] The `pipeline.ecs_compatibility` setting now defaults to `v8`, causing all plugins that implement an ECS compatibility mode to default to operating with `ecs_compatibility => v8`.

## What does this PR do?

Effectively reverts #13080, making the _default_ ECS compatibility mode `v8` for Logstash 8, and adds INFO-level logging for each pipeline to indicate in which mode its plugins will be run.

## Why is it important/What is the impact to the user?

This the final step of a large and ongoing effort to provide better support for the Elastic Common Schema, detailed in #11623. In #13080 we had back-tracked making the breaking change out of an abundance of caution, but have since decided to move forward with it.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

There are a number of plugins that ship with Logstash and have ECS modes, that do NOT yet have modes for v8. Because [the scope of changes for v1->v8 is so small](https://github.com/elastic/ecs/issues/839), I _think_ that all of these can provide a v8 implementation that simply aliases the existing v1 implementation.

- [x] geoip filter: https://github.com/logstash-plugins/logstash-filter-geoip/pull/193
- [x] grok filter: https://github.com/logstash-plugins/logstash-filter-grok/pull/175 (alias, but log warning; need to validate against v1->v8 scope changes in finer detail)
- [x] clone filter: https://github.com/logstash-plugins/logstash-filter-clone/pull/27
- [x] syslog_pri filter: https://github.com/logstash-plugins/logstash-filter-syslog_pri/pull/10
- [x] useragent filter: https://github.com/logstash-plugins/logstash-filter-useragent/pull/76
- [x] syslog input: https://github.com/logstash-plugins/logstash-input-syslog/pull/68

## How to test this PR locally

~~~ sh
bin/logstash -e ''
~~~

 - Observe an info-level log indicating that the pipeline is being run in ECS-compatibility mode.
 - Observe no deprecation log from the stdin input indicating that the default ecs_compatibility may change
 - Process one event, observe that the structure is ECS-compliant (`[host][hostname]`)

## Related issues

Resolves #11623 
Reverts #13080 

