### PR TITLE
api: avoid 5xx when stats/events not yet populated

### DIFF
--- a/logstash-core/lib/logstash/api/commands/node.rb
+++ b/logstash-core/lib/logstash/api/commands/node.rb
@@ -38,6 +38,8 @@ module LogStash
           pipeline_ids.each_with_object({}) do |pipeline_id, result|
             result[pipeline_id] = pipeline(pipeline_id, options)
           end
+        rescue Instrument::MetricStore::MetricNotFound
+          {}
         end
 
         def pipeline(pipeline_id, options={})

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -74,6 +74,9 @@ module LogStash
             [:stats, :events],
             :in, :filtered, :out, :duration_in_millis, :queue_push_duration_in_millis
           )
+        rescue Instrument::MetricStore::MetricNotFound
+          # if the stats/events metrics have not yet been populated, return an empty map
+          {}
         end
 
         def pipeline(pipeline_id = nil, opts={})

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -39,6 +39,8 @@ module LogStash
           end
 
           {:events_count => total_queued_events}
+        rescue Instrument::MetricStore::MetricNotFound
+          {}
         end
 
         def jvm


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes

 - Fixes an issue where querying the stats API before any pipelines had been started could result in an HTTP 500 response.

## What does this PR do?

Prevents an HTTP 500 response from being emitted when the event stats had not yet been populated, as is common during start-up, or when Logstash is configured to manage pipelines through Kibana Central Management and no pipelines have been defined.

## Why is it important/What is the impact to the user?

Provide useful stats API output even when no pipelines are yet running.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~

## How to test this PR locally

1. Start up Logstash with Central Management configured, without any (matching) pipelines, and without internal monitoring enabled.
2. Query the `/_node/stats` API endpoint
3. Observe a 2XX-level response and an empty map at top-level `events` key (a populated map indicates that the precondition that previously led to a 5XX was not met).


## Related issues

Fixes #13258
