### PR TITLE
artifacts: exclude unused rubyzip test files from distributions

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -84,6 +84,9 @@ namespace "artifact" do
     @exclude_paths << "bin/rspec"
     @exclude_paths << "bin/rspec.bat"
 
+    # vendored test artifacts from upstream
+    @exclude_paths << 'vendor/**/gems/rubyzip-*/test/**/*'
+
     @exclude_paths
   end
 


### PR DESCRIPTION
## Release notes

[rn:skip]


## What does this PR do?

Excludes unused testing artifacts from vendored `rubyzip` dependency, slightly reducing the size and surface-area of distributed artifacts. 

Backport targets: `8.0`, `7.16`

## Why is it important/What is the impact to the user?

While the rubyzip testing fixtures are not on the load-path and inaccessible to the logstash process, some of the files they contain are occasionally picked up by automated scans. They are removed upstream in later releases of rubyzip (see: https://github.com/rubyzip/rubyzip/pull/405), but for now we can exclude them from propagating into our distributed artifacts.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~

## How to test this PR locally

1. run any of the `assemble*Distribution` gradle tasks, such as `./gradlew assembleZipDistribution`
2. expand the generated artifact
3. navigate to `vendor/bundle/jruby/2.5.0/gems/rubyzip-1.3.0`
4. observe no `test` directory
