### PR TITLE
Backport PR#13014 to 7.16: Docker integration tests stability improve…

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,7 +1,7 @@
 SHELL=/bin/bash
 ELASTIC_REGISTRY ?= docker.elastic.co
-
-export PATH := ./bin:./venv/bin:$(PATH)
+PY_VERSION ?= 3.6.13
+export PATH := ./bin:$(HOME)/.pyenv/bin:$(HOME)/.pyenv/shims:./venv/bin:$(PATH)
 
 # Determine the version to build.
 ELASTIC_VERSION := $(shell ../vendor/jruby/bin/jruby bin/elastic-version)
@@ -142,20 +142,14 @@ push:
 
 # The tests are written in Python. Make a virtualenv to handle the dependencies.
 venv: requirements.txt
-	@if [ -z $$PYTHON3 ]; then\
-	    PY3_MINOR_VER=`python3 --version 2>&1 | cut -d " " -f 2 | cut -d "." -f 2`;\
-	    if (( $$PY3_MINOR_VER < 5 )); then\
-		echo "Couldn't find python3 in \$PATH that is >=3.5";\
-		echo "Please install python3.5 or later or explicity define the python3 executable name with \$PYTHON3";\
-		echo "Exiting here";\
-		exit 1;\
-	    else\
-		export PYTHON3="python3.$$PY3_MINOR_VER";\
-	   fi;\
-	fi;\
-	test -d venv || virtualenv --python=$$PYTHON3 venv;\
-	pip install -r requirements.txt;\
-	touch venv;\
+	LOCAL_PY_VER=`python3 --version 2>&1`&&\
+	echo "Was using $$LOCAL_PY_VER" &&\
+	eval "$$(pyenv init -)" && eval "$$(pyenv init --path)" &&\
+	pyenv install --skip-existing $(PY_VERSION) &&\
+	pyenv local $(PY_VERSION) &&\
+	python3 -mvenv venv && \
+	pip install -r requirements.txt &&\
+	touch venv
 
 # Make a Golang container that can compile our env2yaml tool.
 golang:

--- a/qa/docker/fixtures/multiple_pipelines/pipelines/basic2.cfg
+++ b/qa/docker/fixtures/multiple_pipelines/pipelines/basic2.cfg
@@ -1,7 +1,6 @@
 input {
-beats {
-id => 'multi_pipeline2'
-port => 5044
-}
+  stdin {
+    id => 'multi_pipeline2'
+  }
 }
 output { stdout {} }

--- a/qa/docker/patches/excon/unix_socket.rb
+++ b/qa/docker/patches/excon/unix_socket.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+module Excon
+  class UnixSocket < Excon::Socket
+    private
+    def connect
+      @socket = ::UNIXSocket.new(@data[:socket])
+    end
+  end
+end

--- a/qa/docker/shared_examples/container.rb
+++ b/qa/docker/shared_examples/container.rb
@@ -40,15 +40,15 @@ shared_examples_for 'the container is configured correctly' do |flavor|
     end
 
     it 'should have the correct user' do
-      expect(exec_in_container(@container, 'whoami').chomp).to eql 'logstash'
+      expect(exec_in_container(@container, 'whoami')).to eql 'logstash'
     end
 
     it 'should have the correct home directory' do
-      expect(exec_in_container(@container, 'printenv HOME').chomp).to eql '/usr/share/logstash'
+      expect(exec_in_container(@container, 'printenv HOME')).to eql '/usr/share/logstash'
     end
 
     it 'should link /opt/logstash to /usr/share/logstash' do
-      expect(exec_in_container(@container, 'readlink /opt/logstash').chomp).to eql '/usr/share/logstash'
+      expect(exec_in_container(@container, 'readlink /opt/logstash')).to eql '/usr/share/logstash'
     end
 
     it 'should have all files owned by the logstash user' do
@@ -57,11 +57,11 @@ shared_examples_for 'the container is configured correctly' do |flavor|
     end
 
     it 'should have a logstash user with uid 1000' do
-      expect(exec_in_container(@container, 'id -u logstash').chomp).to eql '1000'
+      expect(exec_in_container(@container, 'id -u logstash')).to eql '1000'
     end
 
     it 'should have a logstash user with gid 1000' do
-      expect(exec_in_container(@container, 'id -g logstash').chomp).to eql '1000'
+      expect(exec_in_container(@container, 'id -g logstash')).to eql '1000'
     end
 
     it 'should not have a RollingFile appender' do

--- a/qa/docker/shared_examples/container_config.rb
+++ b/qa/docker/shared_examples/container_config.rb
@@ -13,7 +13,8 @@ shared_examples_for 'it runs with different configurations' do |flavor|
     let(:options) { {"HostConfig" => { "Binds" => ["#{FIXTURES_DIR}/simple_pipeline/:/usr/share/logstash/pipeline/"] } } }
 
     it 'should show the stats for that pipeline' do
-      expect(get_node_stats(@container)['pipelines']['main']['plugins']['inputs'][0]['id']).to eq 'simple_pipeline'
+      wait_for_pipeline(@container)
+      expect(get_plugin_info(@container, 'inputs', 'simple_pipeline')).not_to be nil
     end
   end
 
@@ -22,8 +23,10 @@ shared_examples_for 'it runs with different configurations' do |flavor|
                                                    "#{FIXTURES_DIR}/multiple_pipelines/config/pipelines.yml:/usr/share/logstash/config/pipelines.yml"] } } }
 
     it "should show stats for both pipelines" do
-      expect(get_node_stats(@container)['pipelines']['pipeline_one']['plugins']['inputs'][0]['id']).to eq 'multi_pipeline1'
-      expect(get_node_stats(@container)['pipelines']['pipeline_two']['plugins']['inputs'][0]['id']).to eq 'multi_pipeline2'
+      wait_for_pipeline(@container, 'pipeline_one')
+      wait_for_pipeline(@container, 'pipeline_two')
+      expect(get_plugin_info(@container, 'inputs', 'multi_pipeline1', 'pipeline_one')).not_to be nil
+      expect(get_plugin_info(@container, 'inputs', 'multi_pipeline2', 'pipeline_two')).not_to be nil
     end
   end
 
@@ -31,7 +34,8 @@ shared_examples_for 'it runs with different configurations' do |flavor|
     let(:options) { {"HostConfig" => { "Binds" => ["#{FIXTURES_DIR}/custom_logstash_yml/logstash.yml:/usr/share/logstash/config/logstash.yml"] } } }
 
     it 'should change the value of pipeline.batch.size' do
-      expect(get_node_info(@container)['pipelines']['main']['batch_size']).to eq 200
+      wait_for_pipeline(@container)
+      expect(get_pipeline_setting(@container, 'batch_size')).to eq 200
     end
   end
 end

--- a/qa/docker/shared_examples/container_options.rb
+++ b/qa/docker/shared_examples/container_options.rb
@@ -3,6 +3,7 @@ shared_examples_for 'it applies settings correctly' do |flavor|
   before do
     @image = find_image(flavor)
     @container = start_container(@image, options)
+    wait_for_pipeline(@container)
   end
 
   after do
@@ -13,7 +14,7 @@ shared_examples_for 'it applies settings correctly' do |flavor|
     let(:options) { { 'ENV' => ['PIPELINE_WORKERS=32'] } }
 
     it "should correctly set the number of pipeline workers" do
-      expect(get_node_info(@container)['pipelines']['main']['workers']).to eql 32
+      expect(get_pipeline_setting(@container, 'workers')).to eql 32
     end
   end
 
@@ -21,7 +22,7 @@ shared_examples_for 'it applies settings correctly' do |flavor|
     let(:options) { { 'ENV' => ['pipeline.workers=64'] } }
 
     it "should correctly set the number of pipeline workers" do
-      expect(get_node_info(@container)['pipelines']['main']['workers']).to eql 64
+      expect(get_pipeline_setting(@container, 'workers')).to eql 64
     end
   end
 
@@ -29,7 +30,7 @@ shared_examples_for 'it applies settings correctly' do |flavor|
     let(:options) { { 'ENV' => ['pipeline.batch.size=123'] } }
 
     it "should correctly set the batch size" do
-      expect(get_node_info(@container)['pipelines']['main']['batch_size']).to eql 123
+      expect(get_pipeline_setting(@container, 'batch_size')).to eql 123
     end
   end
 
@@ -37,7 +38,7 @@ shared_examples_for 'it applies settings correctly' do |flavor|
     let(:options) { { 'ENV' => ['pipeline.batch.delay=36'] } }
 
     it 'should correctly set batch delay' do
-      expect(get_node_info(@container)['pipelines']['main']['batch_delay']).to eql 36
+      expect(get_pipeline_setting(@container, 'batch_delay')).to eql 36
     end
   end
 

--- a/qa/docker/spec/ubi8/container_spec.rb
+++ b/qa/docker/spec/ubi8/container_spec.rb
@@ -21,7 +21,7 @@ describe 'A container running the ubi8 image' do
     end
 
     it 'should be based on Red Hat Enterprise Linux' do
-      expect(exec_in_container(@container, 'cat /etc/redhat-release').chomp).to match /Red Hat Enterprise Linux/
+      expect(exec_in_container(@container, 'cat /etc/redhat-release')).to match /Red Hat Enterprise Linux/
     end
   end
 end


### PR DESCRIPTION
…ments

Backport PR#13014 to 7.16 branch. Original message:

* Docker integration tests stability improvements

This commit contains numerous fixes to improve the stability of the docker integration tests

* Patch Excon::UnixSocket

Socket.new running on arm64 on Ubuntu 18.04, causes an immediate SIGSEGV error and crash on
that OS, and, as far as I can tell, only that OS. `TCPSocket.new`,`UDPSocket.new` and
`UNIXSocket.new` do not. This commit patches the UnixSocket of the Excon library to
do the absolute simplest thing possible to avoid this error.

* Ensure that container is deleted even if #kill fails

* Add extra waits to handle the incremental way the payload returned by the monitoring
API increases as logstash starts up and pipelines load.

* Use pyenv to ensure the same version of python is used across different jenkins workers

* Add container logs to help diagnose failed test.

* Update the pipeline definition on multi-pipeline integration test

This was causing a pipeline to halt after startup causing intermittent test failures.

* Remove `;` to ensure failures are propagated appropriately

Co-authored-by: João Duarte <jsvd@users.noreply.github.com>
