### PR TITLE
Deps: bump lock file for 8.0.0

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -2,13 +2,12 @@ PATH
   remote: logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 7.16.0)
+      logstash-core (= 8.0.0)
 
 PATH
   remote: logstash-core
   specs:
-    logstash-core (7.16.0-java)
-      chronic_duration (~> 0.10)
+    logstash-core (8.0.0-java)
       clamp (~> 1)
       concurrent-ruby (~> 1)
       down (~> 5.2.0)
@@ -69,8 +68,6 @@ GEM
     builder (3.2.4)
     cabin (0.9.0)
     childprocess (4.1.0)
-    chronic_duration (0.10.6)
-      numerizer (~> 0.1.1)
     ci_reporter (2.0.0)
       builder (>= 2.1.2)
     ci_reporter_rspec (1.0.0)
@@ -124,7 +121,7 @@ GEM
     filesize (0.2.0)
     fivemat (1.3.7)
     flores (0.0.7)
-    fpm (1.13.1)
+    fpm (1.14.1)
       arr-pm (~> 0.0.11)
       backports (>= 2.6.2)
       cabin (>= 0.6.0)
@@ -152,7 +149,7 @@ GEM
       domain_name (~> 0.5)
     http-form_data (2.3.0)
     http_parser.rb (0.6.0-java)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     insist (1.0.0)
     jar-dependencies (0.4.1)
@@ -251,12 +248,12 @@ GEM
     logstash-codec-rubydebug (3.1.0)
       amazing_print (~> 1)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-devutils (1.3.6-java)
+    logstash-devutils (2.3.0-java)
       fivemat
       gem_publisher
-      insist (= 1.0.0)
       kramdown (= 1.14.0)
-      logstash-core-plugin-api (>= 2.0, <= 2.99)
+      logstash-codec-plain
+      logstash-core (>= 6.3)
       minitar
       rake
       rspec (~> 3.0)
@@ -269,7 +266,7 @@ GEM
       murmurhash3
     logstash-filter-cidr (3.1.3-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-clone (4.1.1)
+    logstash-filter-clone (4.2.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ecs_compatibility_support (~> 1.1)
     logstash-filter-csv (3.1.1)
@@ -296,11 +293,11 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ecs_compatibility_support (~> 1.2)
       murmurhash3
-    logstash-filter-geoip (7.2.3-java)
+    logstash-filter-geoip (7.2.5-java)
       logstash-core (>= 7.14.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-      logstash-mixin-ecs_compatibility_support (~> 1.1)
-    logstash-filter-grok (4.4.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+    logstash-filter-grok (4.4.1)
       jls-grok (~> 0.11.3)
       logstash-core (>= 5.6.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -325,7 +322,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       metriks
       thread_safe
-    logstash-filter-mutate (3.5.4)
+    logstash-filter-mutate (3.5.5)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-prune (3.0.4)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -335,9 +332,9 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-split (3.1.8)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-syslog_pri (3.1.0)
+    logstash-filter-syslog_pri (3.1.1)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-      logstash-mixin-ecs_compatibility_support (~> 1.1)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
     logstash-filter-throttle (4.0.4)
       atomic
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -352,9 +349,9 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-urldecode (3.0.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-useragent (3.3.1-java)
+    logstash-filter-useragent (3.3.2-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-      logstash-mixin-ecs_compatibility_support (~> 1.1)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
     logstash-filter-uuid (3.0.5)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-xml (4.1.2)
@@ -366,7 +363,7 @@ GEM
       logstash-codec-plain
       logstash-core-plugin-api (~> 2.0)
       stud (>= 0.0.22)
-    logstash-input-beats (6.2.1-java)
+    logstash-input-beats (6.2.2-java)
       concurrent-ruby (~> 1.0)
       jar-dependencies (~> 0.3, >= 0.3.4)
       logstash-codec-multiline (>= 2.0.5)
@@ -393,9 +390,10 @@ GEM
       rufus-scheduler
       tzinfo
       tzinfo-data
-    logstash-input-exec (3.3.3)
+    logstash-input-exec (3.4.0)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
       rufus-scheduler
       stud (~> 0.0.22)
     logstash-input-file (4.4.0)
@@ -414,9 +412,10 @@ GEM
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       stud (>= 0.0.22, < 0.1.0)
-    logstash-input-generator (3.0.6)
+    logstash-input-generator (3.1.0)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
     logstash-input-graphite (3.0.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-input-tcp
@@ -447,15 +446,19 @@ GEM
       mail (~> 2.6.3)
       mime-types (= 2.6.2)
       stud (~> 0.0.22)
-    logstash-input-jms (3.1.2-java)
+    logstash-input-jms (3.2.0-java)
       jruby-jms (>= 1.2.0)
       logstash-codec-json (~> 3.0)
       logstash-codec-plain (~> 3.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
       semantic_logger (< 4.0.0)
-    logstash-input-pipe (3.0.7)
+    logstash-input-pipe (3.1.0)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
       stud (~> 0.0.22)
     logstash-input-redis (3.7.0)
       logstash-codec-json
@@ -466,13 +469,19 @@ GEM
       logstash-mixin-aws (>= 4.3.0)
       logstash-mixin-ecs_compatibility_support (~> 1.2)
       stud (~> 0.0.18)
-    logstash-input-snmp (1.2.8)
+    logstash-input-snmp (1.3.0)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
       stud (>= 0.0.22, < 0.1.0)
-    logstash-input-snmptrap (3.0.6)
+    logstash-input-snmptrap (3.1.0)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
       snmp
     logstash-input-sqs (3.1.3)
       logstash-codec-json
@@ -483,16 +492,16 @@ GEM
       logstash-codec-line
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ecs_compatibility_support (~> 1.2)
-    logstash-input-syslog (3.5.0)
+    logstash-input-syslog (3.6.0)
       concurrent-ruby
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-filter-date
-      logstash-filter-grok (>= 4.4.0)
-      logstash-mixin-ecs_compatibility_support (~> 1.1)
+      logstash-filter-grok (>= 4.4.1)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
       stud (>= 0.0.22, < 0.1.0)
-    logstash-input-tcp (6.2.1-java)
-      jruby-openssl (>= 0.10.2, < 0.12)
+    logstash-input-tcp (6.2.2-java)
+      jruby-openssl (>= 0.10.2)
       logstash-codec-json
       logstash-codec-json_lines
       logstash-codec-line
@@ -501,9 +510,12 @@ GEM
       logstash-core (>= 6.7.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ecs_compatibility_support (~> 1.2)
-    logstash-input-twitter (4.0.3)
+    logstash-input-twitter (4.1.0)
       http-form_data (~> 2)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
       public_suffix (~> 3)
       stud (>= 0.0.22, < 0.1)
       twitter (= 6.2.0)
@@ -512,15 +524,16 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ecs_compatibility_support (~> 1.2)
       stud (~> 0.0.22)
-    logstash-input-unix (3.0.7)
+    logstash-input-unix (3.1.0)
       logstash-codec-line
       logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
     logstash-integration-elastic_enterprise_search (2.1.2)
       elastic-app-search (~> 7.8.0)
       elastic-workplace-search (~> 0.4.1)
       logstash-codec-plain
       logstash-core-plugin-api (~> 2.0)
-    logstash-integration-jdbc (5.1.6)
+    logstash-integration-jdbc (5.1.8)
       logstash-codec-plain
       logstash-core (>= 6.5.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -532,7 +545,7 @@ GEM
       sequel
       tzinfo
       tzinfo-data
-    logstash-integration-kafka (10.8.1-java)
+    logstash-integration-kafka (10.8.2-java)
       logstash-codec-json
       logstash-codec-plain
       logstash-core (>= 6.5.0)
@@ -573,8 +586,9 @@ GEM
       logstash-filter-json
       logstash-input-generator
       logstash-output-file
-    logstash-output-elasticsearch (11.2.1-java)
+    logstash-output-elasticsearch (11.3.1-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-deprecation_logger_support (~> 1.0)
       logstash-mixin-ecs_compatibility_support (~> 1.0)
       manticore (>= 0.7.1, < 1.0.0)
       stud (~> 0.0, >= 0.0.17)
@@ -661,7 +675,6 @@ GEM
     nio4r (2.5.8-java)
     nokogiri (1.12.5-java)
       racc (~> 1.4)
-    numerizer (0.1.1)
     octokit (4.21.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -704,7 +717,7 @@ GEM
     rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-support (3.10.2)
+    rspec-support (3.10.3)
     rspec-wait (0.0.9)
       rspec (>= 3, < 4)
     ruby-progressbar (1.11.0)
@@ -717,7 +730,7 @@ GEM
       faraday (> 0.8, < 2.0)
     semantic_logger (3.4.1)
       concurrent-ruby (~> 1.0)
-    sequel (5.49.0)
+    sequel (5.50.0)
     simple_oauth (0.3.1)
     sinatra (2.1.0)
       mustermann (~> 1.0)
@@ -748,7 +761,7 @@ GEM
       simple_oauth (~> 0.3.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2021.4)
+    tzinfo-data (1.2021.5)
       tzinfo (>= 1.0.0)
     unf (0.1.4-java)
     webhdfs (0.10.2)
@@ -764,16 +777,13 @@ PLATFORMS
   java
 
 DEPENDENCIES
-  atomic (~> 1)
   belzebuth
   benchmark-ips
-  builder (~> 3)
   childprocess (~> 4)
   ci_reporter_rspec (~> 1)
   flores (~> 0.0.6)
   fpm (~> 1.13)
   gems (~> 1)
-  json (~> 1)
   json-schema (~> 2)
   logstash-codec-avro
   logstash-codec-cef
@@ -794,7 +804,7 @@ DEPENDENCIES
   logstash-codec-rubydebug
   logstash-core!
   logstash-core-plugin-api!
-  logstash-devutils (~> 1)
+  logstash-devutils (~> 2)
   logstash-filter-aggregate
   logstash-filter-anonymize
   logstash-filter-cidr
@@ -897,4 +907,4 @@ DEPENDENCIES
   webmock (~> 3)
 
 BUNDLED WITH
-   2.2.29
+   2.2.32

--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -1,0 +1,900 @@
+PATH
+  remote: logstash-core-plugin-api
+  specs:
+    logstash-core-plugin-api (2.1.16-java)
+      logstash-core (= 7.16.0)
+
+PATH
+  remote: logstash-core
+  specs:
+    logstash-core (7.16.0-java)
+      chronic_duration (~> 0.10)
+      clamp (~> 1)
+      concurrent-ruby (~> 1)
+      down (~> 5.2.0)
+      elasticsearch (~> 7)
+      filesize (~> 0.2)
+      gems (~> 1)
+      i18n (~> 1)
+      jrjackson (= 0.4.14)
+      jruby-openssl (~> 0.11)
+      manticore (~> 0.6)
+      minitar (~> 0.8)
+      mustermann (~> 1.0.3)
+      pry (~> 0.12)
+      puma (~> 5)
+      racc (~> 1.5.2)
+      rack (~> 2)
+      rubyzip (~> 1)
+      rufus-scheduler
+      sinatra (~> 2)
+      stud (~> 0.0.19)
+      thread_safe (~> 0.3.6)
+      treetop (~> 1)
+      tzinfo-data
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    amazing_print (1.4.0)
+    arr-pm (0.0.11)
+      cabin (> 0)
+    atomic (1.1.101-java)
+    avl_tree (1.2.1)
+      atomic (~> 1.1)
+    avro (1.10.2)
+      multi_json (~> 1)
+    aws-eventstream (1.2.0)
+    aws-sdk (2.11.632)
+      aws-sdk-resources (= 2.11.632)
+    aws-sdk-core (2.11.632)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.11.632)
+      aws-sdk-core (= 2.11.632)
+    aws-sdk-v1 (1.67.0)
+      json (~> 1.4)
+      nokogiri (~> 1)
+    aws-sigv4 (1.4.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+    back_pressure (1.0.0)
+    backports (3.21.0)
+    belzebuth (0.2.3)
+      childprocess
+    benchmark-ips (2.9.2)
+    bindata (2.4.10)
+    buftok (0.2.0)
+    builder (3.2.4)
+    cabin (0.9.0)
+    childprocess (4.1.0)
+    chronic_duration (0.10.6)
+      numerizer (~> 0.1.1)
+    ci_reporter (2.0.0)
+      builder (>= 2.1.2)
+    ci_reporter_rspec (1.0.0)
+      ci_reporter (~> 2.0)
+      rspec (>= 2.14, < 4)
+    clamp (1.0.1)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.9)
+    crack (0.4.5)
+      rexml
+    dalli (2.7.11)
+    diff-lcs (1.4.4)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.7.6)
+    down (5.2.4)
+      addressable (~> 2.8)
+    edn (1.1.1)
+    elastic-app-search (7.8.0)
+      jwt (>= 1.5, < 3.0)
+    elastic-workplace-search (0.4.1)
+    elasticsearch (7.15.0)
+      elasticsearch-api (= 7.15.0)
+      elasticsearch-transport (= 7.15.0)
+    elasticsearch-api (7.15.0)
+      multi_json
+    elasticsearch-transport (7.15.0)
+      faraday (~> 1)
+      multi_json
+    equalizer (0.0.11)
+    faraday (1.8.0)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0.1)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
+      faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
+    ffi (1.15.4-java)
+    filesize (0.2.0)
+    fivemat (1.3.7)
+    flores (0.0.7)
+    fpm (1.13.1)
+      arr-pm (~> 0.0.11)
+      backports (>= 2.6.2)
+      cabin (>= 0.6.0)
+      clamp (~> 1.0.0)
+      git (>= 1.3.0, < 2.0)
+      json (>= 1.7.7, < 3.0)
+      pleaserun (~> 0.0.29)
+      rexml
+      stud
+    gelfd2 (0.4.1)
+    gem_publisher (1.5.0)
+    gems (1.2.0)
+    gene_pool (1.5.0)
+      concurrent-ruby (>= 1.0)
+    git (1.9.1)
+      rchardet (~> 1.8)
+    hashdiff (1.0.1)
+    hitimes (1.3.1-java)
+    http (3.3.0)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.0)
+      http_parser.rb (~> 0.6.0)
+    http-cookie (1.0.4)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
+    http_parser.rb (0.6.0-java)
+    i18n (1.8.10)
+      concurrent-ruby (~> 1.0)
+    insist (1.0.0)
+    jar-dependencies (0.4.1)
+    jls-grok (0.11.5)
+      cabin (>= 0.6.0)
+    jls-lumberjack (0.0.26)
+      concurrent-ruby
+    jmespath (1.4.0)
+    jrjackson (0.4.14-java)
+    jruby-jms (1.3.0-java)
+      gene_pool
+      semantic_logger
+    jruby-openssl (0.11.0-java)
+    jruby-stdin-channel (0.2.0-java)
+    json (1.8.6-java)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
+    jwt (2.3.0)
+    kramdown (1.14.0)
+    logstash-codec-avro (3.3.0-java)
+      avro
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-cef (6.2.3-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-collectd (3.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-dots (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-edn (3.1.0)
+      edn
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-edn_lines (3.1.0)
+      edn
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-es_bulk (3.1.0)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-fluent (3.4.1-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      msgpack (~> 1.1)
+    logstash-codec-graphite (3.0.6)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-json (3.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0, >= 1.0.1)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-json_lines (3.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0, >= 1.0.1)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-line (3.1.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-msgpack (3.1.0-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      msgpack (~> 1.1)
+    logstash-codec-multiline (3.1.1)
+      concurrent-ruby
+      jls-grok (~> 0.11.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-patterns-core
+    logstash-codec-netflow (4.2.2)
+      bindata (>= 1.5.0)
+      logstash-core-plugin-api (~> 2.0)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-plain (3.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-rubydebug (3.1.0)
+      amazing_print (~> 1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-devutils (1.3.6-java)
+      fivemat
+      gem_publisher
+      insist (= 1.0.0)
+      kramdown (= 1.14.0)
+      logstash-core-plugin-api (>= 2.0, <= 2.99)
+      minitar
+      rake
+      rspec (~> 3.0)
+      rspec-wait
+      stud (>= 0.0.20)
+    logstash-filter-aggregate (2.10.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-anonymize (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      murmurhash3
+    logstash-filter-cidr (3.1.3-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-clone (4.1.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.1)
+    logstash-filter-csv (3.1.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-filter-date (3.1.9)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-de_dot (1.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-dissect (1.2.1)
+      jar-dependencies
+      logstash-core-plugin-api (>= 2.1.1, <= 2.99)
+    logstash-filter-dns (3.1.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      lru_redux (~> 1.1.0)
+    logstash-filter-drop (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-elasticsearch (3.11.0)
+      elasticsearch (>= 7.14.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      manticore (>= 0.7.1)
+    logstash-filter-fingerprint (3.3.2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      murmurhash3
+    logstash-filter-geoip (7.2.3-java)
+      logstash-core (>= 7.14.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.1)
+    logstash-filter-grok (4.4.0)
+      jls-grok (~> 0.11.3)
+      logstash-core (>= 5.6.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.0)
+      logstash-patterns-core (>= 4.3.0, < 5)
+      stud (~> 0.0.22)
+    logstash-filter-http (1.0.2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-http_client (>= 5.0.0, < 9.0.0)
+    logstash-filter-json (3.2.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-filter-kv (4.5.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-filter-memcached (1.1.0)
+      dalli (~> 2.7)
+      logstash-core-plugin-api (~> 2.0)
+    logstash-filter-metrics (4.0.7)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      metriks
+      thread_safe
+    logstash-filter-mutate (3.5.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-prune (3.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-ruby (3.1.7)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-sleep (3.0.7)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-split (3.1.8)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-syslog_pri (3.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.1)
+    logstash-filter-throttle (4.0.4)
+      atomic
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      thread_safe
+    logstash-filter-translate (3.3.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-deprecation_logger_support (~> 1.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      logstash-mixin-validator_support (~> 1.0)
+      rufus-scheduler
+    logstash-filter-truncate (1.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-urldecode (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-useragent (3.3.1-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.1)
+    logstash-filter-uuid (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-xml (4.1.2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      nokogiri
+      xml-simple
+    logstash-input-azure_event_hubs (1.4.0)
+      logstash-codec-json
+      logstash-codec-plain
+      logstash-core-plugin-api (~> 2.0)
+      stud (>= 0.0.22)
+    logstash-input-beats (6.2.1-java)
+      concurrent-ruby (~> 1.0)
+      jar-dependencies (~> 0.3, >= 0.3.4)
+      logstash-codec-multiline (>= 2.0.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      thread_safe (~> 0.3.5)
+    logstash-input-couchdb_changes (3.1.6)
+      json
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (>= 0.0.22)
+    logstash-input-dead_letter_queue (1.1.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-input-elasticsearch (4.12.1)
+      elasticsearch (>= 7.14.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      manticore (>= 0.7.1)
+      rufus-scheduler
+      tzinfo
+      tzinfo-data
+    logstash-input-exec (3.3.3)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      rufus-scheduler
+      stud (~> 0.0.22)
+    logstash-input-file (4.4.0)
+      addressable
+      concurrent-ruby (~> 1.0)
+      logstash-codec-multiline (~> 3.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+    logstash-input-ganglia (3.1.4)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (~> 0.0.22)
+    logstash-input-gelf (3.3.0)
+      gelfd2 (= 0.4.1)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (>= 0.0.22, < 0.1.0)
+    logstash-input-generator (3.0.6)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-input-graphite (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-input-tcp
+    logstash-input-heartbeat (3.1.1)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-deprecation_logger_support (~> 1.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      logstash-mixin-event_support (~> 1.0)
+      stud
+    logstash-input-http (3.4.2-java)
+      jar-dependencies (~> 0.3, >= 0.3.4)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+    logstash-input-http_poller (5.1.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0, >= 1.0.1)
+      logstash-mixin-http_client (~> 7)
+      logstash-mixin-validator_support (~> 1.0)
+      rufus-scheduler (~> 3.0.9)
+      stud (~> 0.0.22)
+    logstash-input-imap (3.1.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      mail (~> 2.6.3)
+      mime-types (= 2.6.2)
+      stud (~> 0.0.22)
+    logstash-input-jms (3.1.2-java)
+      jruby-jms (>= 1.2.0)
+      logstash-codec-json (~> 3.0)
+      logstash-codec-plain (~> 3.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      semantic_logger (< 4.0.0)
+    logstash-input-pipe (3.0.7)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (~> 0.0.22)
+    logstash-input-redis (3.7.0)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      redis (>= 4.0.1, < 5)
+    logstash-input-s3 (3.8.1)
+      logstash-core-plugin-api (>= 2.1.12, <= 2.99)
+      logstash-mixin-aws (>= 4.3.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      stud (~> 0.0.18)
+    logstash-input-snmp (1.2.8)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (>= 0.0.22, < 0.1.0)
+    logstash-input-snmptrap (3.0.6)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      snmp
+    logstash-input-sqs (3.1.3)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-aws (>= 4.3.0)
+    logstash-input-stdin (3.4.0)
+      jruby-stdin-channel
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+    logstash-input-syslog (3.5.0)
+      concurrent-ruby
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-filter-date
+      logstash-filter-grok (>= 4.4.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.1)
+      stud (>= 0.0.22, < 0.1.0)
+    logstash-input-tcp (6.2.1-java)
+      jruby-openssl (>= 0.10.2, < 0.12)
+      logstash-codec-json
+      logstash-codec-json_lines
+      logstash-codec-line
+      logstash-codec-multiline
+      logstash-codec-plain
+      logstash-core (>= 6.7.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+    logstash-input-twitter (4.0.3)
+      http-form_data (~> 2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      public_suffix (~> 3)
+      stud (>= 0.0.22, < 0.1)
+      twitter (= 6.2.0)
+    logstash-input-udp (3.5.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      stud (~> 0.0.22)
+    logstash-input-unix (3.0.7)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-integration-elastic_enterprise_search (2.1.2)
+      elastic-app-search (~> 7.8.0)
+      elastic-workplace-search (~> 0.4.1)
+      logstash-codec-plain
+      logstash-core-plugin-api (~> 2.0)
+    logstash-integration-jdbc (5.1.6)
+      logstash-codec-plain
+      logstash-core (>= 6.5.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      lru_redux
+      rufus-scheduler (< 3.5)
+      sequel
+      tzinfo
+      tzinfo-data
+    logstash-integration-kafka (10.8.1-java)
+      logstash-codec-json
+      logstash-codec-plain
+      logstash-core (>= 6.5.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-deprecation_logger_support (~> 1.0)
+      manticore (>= 0.5.4, < 1.0.0)
+      stud (>= 0.0.22, < 0.1.0)
+    logstash-integration-rabbitmq (7.3.0-java)
+      back_pressure (~> 1.0)
+      logstash-codec-json
+      logstash-core (>= 6.5.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      march_hare (~> 4.0)
+      stud (~> 0.0.22)
+    logstash-mixin-aws (4.4.1)
+      aws-sdk (~> 2)
+      aws-sdk-v1 (>= 1.61.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-mixin-deprecation_logger_support (1.0.0-java)
+      logstash-core (>= 5.0.0)
+    logstash-mixin-ecs_compatibility_support (1.3.0-java)
+      logstash-core (>= 6.0.0)
+    logstash-mixin-event_support (1.0.1-java)
+      logstash-core (>= 6.8)
+    logstash-mixin-http_client (7.0.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      manticore (>= 0.5.2, < 1.0.0)
+    logstash-mixin-validator_support (1.0.1-java)
+      logstash-core (>= 6.8)
+    logstash-output-cloudwatch (3.0.9)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-aws (>= 1.0.0)
+      rufus-scheduler (~> 3.0.9)
+    logstash-output-csv (3.0.8)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-filter-json
+      logstash-input-generator
+      logstash-output-file
+    logstash-output-elasticsearch (11.2.1-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.0)
+      manticore (>= 0.7.1, < 1.0.0)
+      stud (~> 0.0, >= 0.0.17)
+    logstash-output-email (4.1.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      mail (~> 2.6.3)
+      mime-types (< 3)
+      mustache (>= 0.99.8)
+    logstash-output-file (4.3.0)
+      logstash-codec-json_lines
+      logstash-codec-line
+      logstash-core-plugin-api (>= 2.0.0, < 2.99)
+    logstash-output-graphite (3.1.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-http (5.2.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-http_client (>= 6.0.0, < 8.0.0)
+    logstash-output-lumberjack (3.1.9)
+      jls-lumberjack (>= 0.0.26)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud
+    logstash-output-nagios (3.0.6)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-null (3.0.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-pipe (3.0.6)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-redis (5.0.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      redis (~> 4)
+      stud
+    logstash-output-s3 (4.3.5)
+      concurrent-ruby
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-aws (>= 4.3.0)
+      stud (~> 0.0.22)
+    logstash-output-sns (4.0.7)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-aws (>= 1.0.0)
+    logstash-output-sqs (6.0.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-aws (>= 4.3.0)
+    logstash-output-stdout (3.1.4)
+      logstash-codec-rubydebug
+      logstash-core-plugin-api (>= 1.60.1, < 2.99)
+    logstash-output-tcp (6.0.0)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud
+    logstash-output-udp (3.2.0)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-webhdfs (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      snappy (= 0.0.12)
+      webhdfs
+    logstash-patterns-core (4.3.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    lru_redux (1.1.0)
+    mail (2.6.6)
+      mime-types (>= 1.16, < 4)
+    manticore (0.7.1-java)
+      openssl_pkcs8_pure
+    march_hare (4.4.0-java)
+    memoizable (0.4.2)
+      thread_safe (~> 0.3, >= 0.3.1)
+    method_source (1.0.0)
+    metriks (0.9.9.8)
+      atomic (~> 1.0)
+      avl_tree (~> 1.2.0)
+      hitimes (~> 1.1)
+    mime-types (2.6.2)
+    minitar (0.9)
+    msgpack (1.4.2-java)
+    multi_json (1.15.0)
+    multipart-post (2.1.1)
+    murmurhash3 (0.1.6-java)
+    mustache (0.99.8)
+    mustermann (1.0.3)
+    naught (1.1.0)
+    nio4r (2.5.8-java)
+    nokogiri (1.12.5-java)
+      racc (~> 1.4)
+    numerizer (0.1.1)
+    octokit (4.21.0)
+      faraday (>= 0.9)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    openssl_pkcs8_pure (0.0.0.2)
+    paquet (0.2.1)
+    pleaserun (0.0.32)
+      cabin (> 0)
+      clamp
+      dotenv
+      insist
+      mustache (= 0.99.8)
+      stud
+    polyglot (0.3.5)
+    pry (0.14.1-java)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+      spoon (~> 0.0)
+    public_suffix (3.1.1)
+    puma (5.5.2-java)
+      nio4r (~> 2.0)
+    racc (1.5.2-java)
+    rack (2.2.3)
+    rack-protection (2.1.0)
+      rack
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
+    rake (12.3.3)
+    rchardet (1.8.0)
+    redis (4.5.1)
+    rexml (3.2.5)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+    rspec-wait (0.0.9)
+      rspec (>= 3, < 4)
+    ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.5)
+    rubyzip (1.3.0)
+    rufus-scheduler (3.0.9)
+      tzinfo
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
+    semantic_logger (3.4.1)
+      concurrent-ruby (~> 1.0)
+    sequel (5.49.0)
+    simple_oauth (0.3.1)
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
+    snappy (0.0.12-java)
+      snappy-jars (~> 1.1.0)
+    snappy-jars (1.1.0.1.2-java)
+    snmp (1.3.2)
+    spoon (0.0.6)
+      ffi
+    stud (0.0.23)
+    thread_safe (0.3.6-java)
+    tilt (2.0.10)
+    treetop (1.6.11)
+      polyglot (~> 0.3)
+    twitter (6.2.0)
+      addressable (~> 2.3)
+      buftok (~> 0.2.0)
+      equalizer (~> 0.0.11)
+      http (~> 3.0)
+      http-form_data (~> 2.0)
+      http_parser.rb (~> 0.6.0)
+      memoizable (~> 0.4.0)
+      multipart-post (~> 2.0)
+      naught (~> 1.0)
+      simple_oauth (~> 0.3.0)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2021.4)
+      tzinfo (>= 1.0.0)
+    unf (0.1.4-java)
+    webhdfs (0.10.2)
+      addressable
+    webmock (3.14.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    xml-simple (1.1.9)
+      rexml
+
+PLATFORMS
+  java
+
+DEPENDENCIES
+  atomic (~> 1)
+  belzebuth
+  benchmark-ips
+  builder (~> 3)
+  childprocess (~> 4)
+  ci_reporter_rspec (~> 1)
+  flores (~> 0.0.6)
+  fpm (~> 1.13)
+  gems (~> 1)
+  json (~> 1)
+  json-schema (~> 2)
+  logstash-codec-avro
+  logstash-codec-cef
+  logstash-codec-collectd
+  logstash-codec-dots
+  logstash-codec-edn
+  logstash-codec-edn_lines
+  logstash-codec-es_bulk
+  logstash-codec-fluent
+  logstash-codec-graphite
+  logstash-codec-json
+  logstash-codec-json_lines
+  logstash-codec-line
+  logstash-codec-msgpack
+  logstash-codec-multiline
+  logstash-codec-netflow
+  logstash-codec-plain
+  logstash-codec-rubydebug
+  logstash-core!
+  logstash-core-plugin-api!
+  logstash-devutils (~> 1)
+  logstash-filter-aggregate
+  logstash-filter-anonymize
+  logstash-filter-cidr
+  logstash-filter-clone
+  logstash-filter-csv
+  logstash-filter-date
+  logstash-filter-de_dot
+  logstash-filter-dissect
+  logstash-filter-dns
+  logstash-filter-drop
+  logstash-filter-elasticsearch
+  logstash-filter-fingerprint
+  logstash-filter-geoip
+  logstash-filter-grok
+  logstash-filter-http
+  logstash-filter-json
+  logstash-filter-kv
+  logstash-filter-memcached
+  logstash-filter-metrics
+  logstash-filter-mutate
+  logstash-filter-prune
+  logstash-filter-ruby
+  logstash-filter-sleep
+  logstash-filter-split
+  logstash-filter-syslog_pri
+  logstash-filter-throttle
+  logstash-filter-translate
+  logstash-filter-truncate
+  logstash-filter-urldecode
+  logstash-filter-useragent
+  logstash-filter-uuid
+  logstash-filter-xml
+  logstash-input-azure_event_hubs
+  logstash-input-beats
+  logstash-input-couchdb_changes
+  logstash-input-dead_letter_queue
+  logstash-input-elasticsearch
+  logstash-input-exec
+  logstash-input-file
+  logstash-input-ganglia
+  logstash-input-gelf
+  logstash-input-generator
+  logstash-input-graphite
+  logstash-input-heartbeat
+  logstash-input-http
+  logstash-input-http_poller
+  logstash-input-imap
+  logstash-input-jms
+  logstash-input-pipe
+  logstash-input-redis
+  logstash-input-s3
+  logstash-input-snmp
+  logstash-input-snmptrap
+  logstash-input-sqs
+  logstash-input-stdin
+  logstash-input-syslog
+  logstash-input-tcp
+  logstash-input-twitter
+  logstash-input-udp
+  logstash-input-unix
+  logstash-integration-elastic_enterprise_search
+  logstash-integration-jdbc
+  logstash-integration-kafka
+  logstash-integration-rabbitmq
+  logstash-mixin-aws
+  logstash-mixin-deprecation_logger_support
+  logstash-mixin-ecs_compatibility_support
+  logstash-mixin-event_support
+  logstash-mixin-http_client
+  logstash-mixin-validator_support
+  logstash-output-cloudwatch
+  logstash-output-csv
+  logstash-output-elasticsearch
+  logstash-output-email
+  logstash-output-file
+  logstash-output-graphite
+  logstash-output-http
+  logstash-output-lumberjack
+  logstash-output-nagios
+  logstash-output-null
+  logstash-output-pipe
+  logstash-output-redis
+  logstash-output-s3
+  logstash-output-sns
+  logstash-output-sqs
+  logstash-output-stdout
+  logstash-output-tcp
+  logstash-output-udp
+  logstash-output-webhdfs
+  logstash-patterns-core
+  octokit (~> 4)
+  paquet (~> 0.2)
+  pleaserun (~> 0.0.28)
+  rack-test
+  rake (~> 12)
+  rspec (~> 3.5)
+  ruby-progressbar (~> 1)
+  rubyzip (~> 1)
+  stud (~> 0.0.22)
+  webmock (~> 3)
+
+BUNDLED WITH
+   2.2.29


### PR DESCRIPTION
### [DIFF from 7.16.0](https://github.com/elastic/logstash/pull/13450/files/b5f98e6f7b1a3078662e5813112ac71567ee49da..HEAD)

NOTE: there's 3 ECS related plugins updates pending that I am aware of (imap input, http filter, )

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

Updates all plugin dependencies

## Why is it important/What is the impact to the user?

This includes recent plugin pushes with ECS compatibility support (these were not part of beta1).
With the recent flip for 8.0 to have ECS on by default, this impacts the user xp in a positive way.

## Author's Checklist

- [ ] manual testing (e.g. snmp, snmptrap)
- [ ] wait for pending plugins?
