### PR TITLE
Backport PR #13447 to 7.16: Fix: patch Puma around a JRuby ARM64 bug

### DIFF
--- a/logstash-core/lib/logstash/patches/puma.rb
+++ b/logstash-core/lib/logstash/patches/puma.rb
@@ -73,3 +73,19 @@ module Puma
   STDERR = LogStash::IOWrappedLogger.new(LogStash::NullLogger)
   STDOUT = LogStash::IOWrappedLogger.new(LogStash::NullLogger)
 end
+
+# JRuby (>= 9.2.18.0) added support for getsockopt(Socket::IPPROTO_TCP, Socket::TCP_INFO)
+# however it isn't working correctly on ARM64 likely due an underlying issue in JNR/JFFI.
+#
+# Puma uses the TCP_INFO to detect a closed socket when handling a request and has a dummy
+# fallback in place when Socket constants :TCP_INFO && :IPPROTO_TCP are not defined, see:
+# https://github.com/puma/puma/blob/v5.5.2/lib/puma/server.rb#L169-L192
+#
+# Remove this patch once https://github.com/elastic/logstash/issues/13444 gets resolved!
+if ENV_JAVA['os.name'].match?(/Linux/i) && ENV_JAVA['os.arch'].eql?('aarch64')
+  Puma::Server.class_eval do
+    def closed_socket?(socket)
+      false
+    end
+  end
+end


### PR DESCRIPTION
**Backport PR #13447 to 7.16 branch.**

### Original message: 

Here we're emulating the [fallback logic](https://github.com/puma/puma/blob/v5.5.2/lib/puma/server.rb#L169-L192) just like it would happen on JRuby < 9.2.18.0.

The only consequence with the dummy `closed_socket?` implementation seems to be [stopping a request early](https://github.com/puma/puma/blob/v5.5.2/lib/puma/request.rb#L36).

Please note that the `closed_socket?` implementation [was slightly different](https://github.com/puma/puma/blob/4-3-stable/lib/puma/server.rb#L132) on Puma 4.x, however under JRuby, 4.x always uses the dummy fallback [due the `RUBY_PLATFORM =~ /linux/` check](https://github.com/puma/puma/blob/4-3-stable/lib/puma/server.rb#L105) (`RUBY_PLATFORM` returns `"java"` on JRuby).

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

Patches around an upstream (JNR) bug which surfaces under ARM64.

## Why is it important/What is the impact to the user?

Usable AARCH64 support (under Docker).

## Author's Checklist


- [x] confirm with ARM64 CI (Docker) tests

## Related issues

- first observed at https://github.com/elastic/logstash/pull/13442 (but the issue isn't related to the base image update)
- https://github.com/elastic/logstash/issues/13444 (this PR resolves the issue with a work-around)
- upstream cause: https://github.com/jruby/jruby/issues/6821
