### PR TITLE
Add template for creating documentation issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/doc-request.md
+++ b/.github/ISSUE_TEMPLATE/doc-request.md
@@ -1,0 +1,26 @@
+---
+name: Documentation
+about: Report a documentation issue
+labels: "docs,status:needs-triage"
+
+---
+<!--
+Please search existing issues. The issue may already exist.
+-->
+
+#### Tell us about the issue
+<!--
+What's the problem? Is information missing? Inaccurate? Just not clear?
+Please include a link to the page (if applicable).
+
+-->
+**Description:**  
+
+
+**URL:** 
+
+Example: https://www.elastic.co/guide/en/logstash/current/introduction.html
+
+
+**Anything else?** 
+

--- a/.github/ISSUE_TEMPLATE/doc-request.md
+++ b/.github/ISSUE_TEMPLATE/doc-request.md
@@ -5,7 +5,7 @@ labels: "docs,status:needs-triage"
 
 ---
 <!--
-Please search existing issues. The issue may already exist.
+Please search [existing issues](https://github.com/elastic/logstash/issues?q=is%3Aopen+is%3Aissue+label%3Adocs). The issue may already exist.
 -->
 
 #### Tell us about the issue


### PR DESCRIPTION
When users open issues in the logstash repo, they can choose from several issue templates. Even though there is an option to open a blank issue at the bottom of the page, it can be easily overlooked. This PR adds a github template for adding a documentation issue. 

Added benefit: We can automatically assign a `docs` label to fast track triage. 

**ToDo**
- [ ] If we move forward with this approach, we'll need to make a corresponding change for plugins.