### PR TITLE
bump jruby to 9.2.20.1 (#13468)

### DIFF
--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -25,7 +25,7 @@ buildscript {
     dependencies {
         classpath 'org.yaml:snakeyaml:1.29'
         classpath "de.undercouch:gradle-download-task:4.0.4"
-        classpath "org.jruby:jruby-complete:9.2.19.0"
+        classpath "org.jruby:jruby-complete:9.2.20.1"
     }
 }
 

--- a/versions.yml
+++ b/versions.yml
@@ -13,8 +13,8 @@ bundled_jdk:
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time
 jruby:
-  version: 9.2.19.0
-  sha1: e61ac187d5e312a198a0b1767eb8c4f36c750749
+  version: 9.2.20.1
+  sha1: 7f45f8a3d53d5f19f69952014abcb542b2670846
 
 # jruby-runtime-override, if specified, will override the jruby version installed in vendor/jruby for logstash runtime only,
 # not for the compile-time jars


### PR DESCRIPTION
backport of https://github.com/elastic/logstash/pull/13468 to 7.16