### PR TITLE
Issue 11193 attempt

### DIFF
--- a/logstash-core/src/main/java/org/logstash/util/CloudSettingAuth.java
+++ b/logstash-core/src/main/java/org/logstash/util/CloudSettingAuth.java
@@ -21,6 +21,7 @@ package org.logstash.util;
 
 import co.elastic.logstash.api.Password;
 import org.logstash.RubyUtil;
+import java.util.HashMap;
 
 /**
  * Represents and decode credentials to access Elastic cloud instance.
@@ -30,6 +31,16 @@ public class CloudSettingAuth {
     private String original;
     private String username;
     private Password password;
+	private String specialCharacters = "=$;@";
+	private static HashMap <String, String> charMap;
+	static {	
+		charMap = new HashMap<>();
+		charMap.put("=", "%3D");
+		charMap.put("$", "%24");
+		charMap.put(";", "%3B");
+		charMap.put("@", "%40");
+		charMap.put("%", "%25");
+	}
 
     public CloudSettingAuth(String value) {
         if (value == null) {
@@ -40,9 +51,9 @@ public class CloudSettingAuth {
         if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
             throw RubyUtil.RUBY.newArgumentError("Cloud Auth username and password format should be \"<username>:<password>\".");
         }
-
+		
         this.username = parts[0];
-        this.password = new Password(parts[1]);
+        this.password = new Password(encodeSpecialCharacters(parts[1]));
     }
 
     public String getOriginal() {
@@ -61,4 +72,20 @@ public class CloudSettingAuth {
     public String toString() {
         return String.join(":", username, password.toString());
     }
+	
+	private String encodeSpecialCharacters(String value) {
+		StringBuffer buf = new StringBuffer();
+		for (int i = 0; i < value.length(); i++)
+		{
+			String check = Character.toString(value.charAt(i));
+			if (specialCharacters.contains(check)){
+				buf.append(charMap.get(check));
+			}
+			else {
+				buf.append(check);
+			}
+		}
+		return buf.toString();
+		
+	}
 }

--- a/logstash-core/src/main/java/org/logstash/util/CloudSettingAuth.java
+++ b/logstash-core/src/main/java/org/logstash/util/CloudSettingAuth.java
@@ -73,6 +73,7 @@ public class CloudSettingAuth {
         return String.join(":", username, password.toString());
     }
 	
+	//CS427 Issue Link: https://github.com/elastic/logstash/issues/11193
 	private String encodeSpecialCharacters(String value) {
 		StringBuffer buf = new StringBuffer();
 		for (int i = 0; i < value.length(); i++)

--- a/logstash-core/src/test/java/org/logstash/util/CloudSettingAuthTest.java
+++ b/logstash-core/src/test/java/org/logstash/util/CloudSettingAuthTest.java
@@ -75,5 +75,20 @@ public class CloudSettingAuthTest {
         assertEquals("baggins", sut.getPassword().getValue());
         assertEquals("frodo:<password>", sut.toString());
     }
+	
+	@Test
+	public void testSpecialCharactersPassword() {
+        final CloudSettingAuth sut = new CloudSettingAuth("frodo:=+$;@");
+        assertEquals("frodo", sut.getUsername());
+        assertEquals("%3D+%24%3B%40", sut.getPassword().getValue());
+        assertEquals("frodo:<password>", sut.toString());
+	}
 
+	@Test
+	public void testColonInPassword() {
+        final CloudSettingAuth sut = new CloudSettingAuth("frodo:bag:gins");
+        assertEquals("frodo", sut.getUsername());
+        assertEquals("bag%3Ains", sut.getPassword().getValue());
+        assertEquals("frodo:<password>", sut.toString());
+	}
 }

--- a/logstash-core/src/test/java/org/logstash/util/CloudSettingAuthTest.java
+++ b/logstash-core/src/test/java/org/logstash/util/CloudSettingAuthTest.java
@@ -78,17 +78,10 @@ public class CloudSettingAuthTest {
 	
 	@Test
 	public void testSpecialCharactersPassword() {
-        final CloudSettingAuth sut = new CloudSettingAuth("frodo:=+$;@");
+        final CloudSettingAuth sut = new CloudSettingAuth("frodo:=+$;@abcd");
         assertEquals("frodo", sut.getUsername());
-        assertEquals("%3D+%24%3B%40", sut.getPassword().getValue());
+        assertEquals("%3D+%24%3B%40abcd", sut.getPassword().getValue());
         assertEquals("frodo:<password>", sut.toString());
 	}
 
-	@Test
-	public void testColonInPassword() {
-        final CloudSettingAuth sut = new CloudSettingAuth("frodo:bag:gins");
-        assertEquals("frodo", sut.getUsername());
-        assertEquals("bag%3Ains", sut.getPassword().getValue());
-        assertEquals("frodo:<password>", sut.toString());
-	}
 }

--- a/logstash-core/src/test/java/org/logstash/util/CloudSettingAuthTest.java
+++ b/logstash-core/src/test/java/org/logstash/util/CloudSettingAuthTest.java
@@ -75,13 +75,13 @@ public class CloudSettingAuthTest {
         assertEquals("baggins", sut.getPassword().getValue());
         assertEquals("frodo:<password>", sut.toString());
     }
-	
-	@Test
-	public void testSpecialCharactersPassword() {
+    //CS 427 Issue Link: https://github.com/elastic/logstash/issues/11193
+    @Test
+    public void testSpecialCharactersPassword() {
         final CloudSettingAuth sut = new CloudSettingAuth("frodo:=+$;@abcd");
         assertEquals("frodo", sut.getUsername());
         assertEquals("%3D+%24%3B%40abcd", sut.getPassword().getValue());
         assertEquals("frodo:<password>", sut.toString());
-	}
+    }
 
 }


### PR DESCRIPTION
<!-- Type of change
- bug
-->

## Release notes
<![rn:skip] -->


## What does this PR do?

Added function to logstash-core/src/test/java/org/logstash/util/CloudSettingAuth.java to encode any special URL characters into their URL encodings. IE, @ to %40, or $ to %24. This is intended to fix issue 11193.

## Why is it important/What is the impact to the user?

This PR fixes issue 11193 where certain characters weren't able to be used in an elasticsearch password.

## Checklist


- [check ] My code follows the style guidelines of this project
- [ check] I have commented my code, particularly in hard-to-understand areas
-~~[ ] I have made corresponding changes to the documentation~~
-~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [check ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved

-->
- Unit tests

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Since elasticsearch no longer allows user-generated passwords or passwords with special characters, the issue is technically moot.

## Related issues


https://github.com/elastic/logstash/issues/11193
- Closes #11193


## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional

-->

## Logs

<!-- 
-->
