### PR TITLE
Backport of #13471 to 8.0: Use $BUILD_JAVA_HOME to control JVMs used …

### DIFF
--- a/ci/acceptance_tests.sh
+++ b/ci/acceptance_tests.sh
@@ -9,6 +9,11 @@ export JRUBY_OPTS="-J-Xmx1g"
 export GRADLE_OPTS="-Xmx4g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info -Dfile.encoding=UTF-8"
 export OSS=true
 
+if [ -n "$BUILD_JAVA_HOME" ]; then
+  GRADLE_OPTS="$GRADLE_OPTS -Dorg.gradle.java.home=$BUILD_JAVA_HOME"
+fi
+
+
 SELECTED_TEST_SUITE=$1
 
 # The acceptance test in our CI infrastructure doesn't clear the workspace between run

--- a/ci/docker_acceptance_tests.sh
+++ b/ci/docker_acceptance_tests.sh
@@ -8,6 +8,10 @@ set -x
 export JRUBY_OPTS="-J-Xmx1g"
 export GRADLE_OPTS="-Xmx4g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info -Dfile.encoding=UTF-8"
 
+if [ -n "$BUILD_JAVA_HOME" ]; then
+  GRADLE_OPTS="$GRADLE_OPTS -Dorg.gradle.java.home=$BUILD_JAVA_HOME"
+fi
+
 # Can run either a specific flavor, or all flavors -
 # eg `ci/acceptance_tests.sh oss` will run tests for open source container
 #    `ci/acceptance_tests.sh full` will run tests for the default container


### PR DESCRIPTION
…with acceptance tests

Backport of #13471 to 8.0 branch. Original message:

* Use $BUILD_JAVA_HOME to control JVM builds on acceptance tests and docker acceptance tests
