### PR TITLE
Build: update .lock.release with rake version:set

### DIFF
--- a/rakelib/version.rake
+++ b/rakelib/version.rake
@@ -39,6 +39,22 @@ def update_version_file(old_version, new_version)
   IO.write(VERSION_FILE, versions_as_text)
 end
 
+def update_lock_release_file(old_version, new_version)
+  lock_file = Dir.glob('Gemfile*.lock.release').first
+  unless lock_file
+    warn "Gemfile*.lock.release missing - skipping version update"
+    return
+  end
+  old_version = old_version['logstash-core']
+  new_version = new_version['logstash-core']
+  versions_as_text = IO.read(lock_file)
+  #      logstash-core (= 7.16.0)
+  versions_as_text.sub!(/logstash-core \(=\s?(#{old_version})\)/) { |m| m.sub(old_version, new_version) }
+  #    logstash-core (7.16.0-java)
+  versions_as_text.sub!(/logstash-core \((#{old_version})-java\)/) { |m| m.sub(old_version, new_version) }
+  IO.write(lock_file, versions_as_text)
+end
+
 def update_index_shared1(new_version)
   index_shared1 = IO.read(INDEX_SHARED1_FILE)
   old_version = index_shared1.match(':logstash_version:\s+(?<logstash_version>\d[.]\d[.]\d.*)')[:logstash_version]
@@ -78,6 +94,7 @@ namespace :version do
     old_version = YAML.safe_load(File.read(VERSION_FILE))
     update_readme(old_version, new_version)
     update_version_file(old_version, new_version)
+    update_lock_release_file(old_version, new_version)
   end
 
   desc "set stack version referenced in docs"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

Updates the post release `rake version:set[7.18.1]` task to also update the *Gemfile.lock.release* file
doing [the changes Bundler should pick up on next run](https://github.com/elastic/logstash/pull/13476/files#diff-127e1a3a65d315d86dbe640d9578a969da44e5226e5d9bf2de251b075c1d8b7aR5)