### PR TITLE
Deps: bump lock file for 7.16.1

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -124,7 +124,7 @@ GEM
     filesize (0.2.0)
     fivemat (1.3.7)
     flores (0.0.7)
-    fpm (1.13.1)
+    fpm (1.14.1)
       arr-pm (~> 0.0.11)
       backports (>= 2.6.2)
       cabin (>= 0.6.0)
@@ -152,7 +152,7 @@ GEM
       domain_name (~> 0.5)
     http-form_data (2.3.0)
     http_parser.rb (0.6.0-java)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     insist (1.0.0)
     jar-dependencies (0.4.1)
@@ -172,8 +172,8 @@ GEM
       addressable (>= 2.4)
     jwt (2.3.0)
     kramdown (1.14.0)
-    logstash-codec-avro (3.3.0-java)
-      avro
+    logstash-codec-avro (3.3.1-java)
+      avro (~> 1.10.2)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ecs_compatibility_support (~> 1.3)
       logstash-mixin-event_support (~> 1.0)
@@ -296,11 +296,11 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ecs_compatibility_support (~> 1.2)
       murmurhash3
-    logstash-filter-geoip (7.2.3-java)
+    logstash-filter-geoip (7.2.5-java)
       logstash-core (>= 7.14.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-      logstash-mixin-ecs_compatibility_support (~> 1.1)
-    logstash-filter-grok (4.4.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+    logstash-filter-grok (4.4.1)
       jls-grok (~> 0.11.3)
       logstash-core (>= 5.6.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -325,7 +325,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       metriks
       thread_safe
-    logstash-filter-mutate (3.5.4)
+    logstash-filter-mutate (3.5.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-prune (3.0.4)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -335,9 +335,9 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-split (3.1.8)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-syslog_pri (3.1.0)
+    logstash-filter-syslog_pri (3.1.1)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-      logstash-mixin-ecs_compatibility_support (~> 1.1)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
     logstash-filter-throttle (4.0.4)
       atomic
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -352,12 +352,12 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-urldecode (3.0.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-useragent (3.3.1-java)
+    logstash-filter-useragent (3.3.2-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-      logstash-mixin-ecs_compatibility_support (~> 1.1)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
     logstash-filter-uuid (3.0.5)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-xml (4.1.2)
+    logstash-filter-xml (4.1.3)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       nokogiri
       xml-simple
@@ -366,7 +366,7 @@ GEM
       logstash-codec-plain
       logstash-core-plugin-api (~> 2.0)
       stud (>= 0.0.22)
-    logstash-input-beats (6.2.1-java)
+    logstash-input-beats (6.2.2-java)
       concurrent-ruby (~> 1.0)
       jar-dependencies (~> 0.3, >= 0.3.4)
       logstash-codec-multiline (>= 2.0.5)
@@ -491,8 +491,8 @@ GEM
       logstash-filter-grok (>= 4.4.0)
       logstash-mixin-ecs_compatibility_support (~> 1.1)
       stud (>= 0.0.22, < 0.1.0)
-    logstash-input-tcp (6.2.1-java)
-      jruby-openssl (>= 0.10.2, < 0.12)
+    logstash-input-tcp (6.2.2-java)
+      jruby-openssl (>= 0.10.2)
       logstash-codec-json
       logstash-codec-json_lines
       logstash-codec-line
@@ -520,7 +520,7 @@ GEM
       elastic-workplace-search (~> 0.4.1)
       logstash-codec-plain
       logstash-core-plugin-api (~> 2.0)
-    logstash-integration-jdbc (5.1.6)
+    logstash-integration-jdbc (5.1.8)
       logstash-codec-plain
       logstash-core (>= 6.5.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -532,7 +532,7 @@ GEM
       sequel
       tzinfo
       tzinfo-data
-    logstash-integration-kafka (10.8.1-java)
+    logstash-integration-kafka (10.8.2-java)
       logstash-codec-json
       logstash-codec-plain
       logstash-core (>= 6.5.0)
@@ -562,7 +562,7 @@ GEM
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       manticore (>= 0.5.2, < 1.0.0)
-    logstash-mixin-validator_support (1.0.1-java)
+    logstash-mixin-validator_support (1.0.2-java)
       logstash-core (>= 6.8)
     logstash-output-cloudwatch (3.0.9)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -573,7 +573,7 @@ GEM
       logstash-filter-json
       logstash-input-generator
       logstash-output-file
-    logstash-output-elasticsearch (11.2.1-java)
+    logstash-output-elasticsearch (11.2.3-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ecs_compatibility_support (~> 1.0)
       manticore (>= 0.7.1, < 1.0.0)
@@ -614,7 +614,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-aws (>= 4.3.0)
       stud (~> 0.0.22)
-    logstash-output-sns (4.0.7)
+    logstash-output-sns (4.0.8)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-aws (>= 1.0.0)
     logstash-output-sqs (6.0.0)
@@ -704,7 +704,7 @@ GEM
     rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-support (3.10.2)
+    rspec-support (3.10.3)
     rspec-wait (0.0.9)
       rspec (>= 3, < 4)
     ruby-progressbar (1.11.0)
@@ -717,7 +717,7 @@ GEM
       faraday (> 0.8, < 2.0)
     semantic_logger (3.4.1)
       concurrent-ruby (~> 1.0)
-    sequel (5.49.0)
+    sequel (5.51.0)
     simple_oauth (0.3.1)
     sinatra (2.1.0)
       mustermann (~> 1.0)
@@ -748,7 +748,7 @@ GEM
       simple_oauth (~> 0.3.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2021.4)
+    tzinfo-data (1.2021.5)
       tzinfo (>= 1.0.0)
     unf (0.1.4-java)
     webhdfs (0.10.2)
@@ -897,4 +897,4 @@ DEPENDENCIES
   webmock (~> 3)
 
 BUNDLED WITH
-   2.2.29
+   2.2.33


### PR DESCRIPTION
Internal plugin update for 7.16.1

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

Gem/plugin updates for patch version.

## Why is it important/What is the impact to the user?

Having latest (patch) updates in LS.