### PR TITLE
Backport PR #13481 to 7.16: Fix: delegating from deprecated setting

### DIFF
--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -811,7 +811,7 @@ module LogStash
 
       def validate_value
         # bypass deprecation warning
-        validate(wrapped.value) if set?
+        wrapped.validate_value if set?
       end
     end
 

--- a/logstash-core/spec/logstash/settings/setting_with_deprecated_alias_spec.rb
+++ b/logstash-core/spec/logstash/settings/setting_with_deprecated_alias_spec.rb
@@ -56,12 +56,15 @@ describe LogStash::Setting::SettingWithDeprecatedAlias do
   end
 
   context "when only the deprecated alias is set" do
+
+    let(:value) { "crusty_value" }
+
     before(:each) do
-      settings.set(deprecated_setting_name, "crusty_value")
+      settings.set(deprecated_setting_name, value)
     end
 
     it 'resolves to the value provided for the deprecated alias' do
-      expect(settings.get(canonical_setting_name)).to eq("crusty_value")
+      expect(settings.get(canonical_setting_name)).to eq(value)
     end
 
     it 'logs a deprecation warning' do
@@ -69,6 +72,29 @@ describe LogStash::Setting::SettingWithDeprecatedAlias do
     end
 
     include_examples '#validate_value success'
+
+    it 'validates deprecated alias' do
+      expect { settings.get_setting(canonical_setting_name).deprecated_alias.validate_value }.to_not raise_error
+    end
+
+    context 'using a boolean setting' do
+
+      let(:value) { true }
+      let(:default_value) { false }
+
+      let(:canonical_setting) { LogStash::Setting::Boolean.new(canonical_setting_name, default_value, true) }
+
+      it 'resolves to the value provided for the deprecated alias' do
+        expect(settings.get(canonical_setting_name)).to eq(true)
+      end
+
+      include_examples '#validate_value success'
+
+      it 'validates deprecated alias' do
+        expect { settings.get_setting(canonical_setting_name).deprecated_alias.validate_value }.to_not raise_error
+      end
+
+    end
   end
 
   context "when only the canonical setting is set" do


### PR DESCRIPTION
**Backport PR #13481 to 7.16 branch, original message:**

---

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes

Fix Logstash unable to start when using deprecated setting `http.enabled`

## What does this PR do?

Fixes a regression introduced in https://github.com/elastic/logstash/pull/13308 when setting `http.enabled`.

## Why is it important/What is the impact to the user?

Users can rename the setting (`api.enabled`) and not use the deprecated one, however need to be aware and this impacts the expectation for a smooth upgrade process in 7.x

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- #13480 
