### PR TITLE
Chore: fetch merge commit automatically with backport dev tool

### DIFF
--- a/devtools/backport
+++ b/devtools/backport
@@ -172,7 +172,7 @@ def create_pr(parser, args):
             title="Backport PR #{} to {}: {}".format(args.pr_number, args.to_branch, original_pr["title"]),
             head=remote_user + ":" + tmp_branch,
             base=args.to_branch,
-            body="Backport PR #{} to {} branch. Original message: \n\n{}"
+            body="**Backport PR #{} to {} branch, original message:**\n\n---\n\n{}"
             .format(args.pr_number, args.to_branch, original_pr["body"])
         ))
         if request.status_code > 299:

--- a/devtools/backport
+++ b/devtools/backport
@@ -68,9 +68,12 @@ def main():
 
     print(args)
 
-    create_pr(args)
+    create_pr(parser, args)
 
-def create_pr(args):
+def create_pr(parser, args):
+    info("Checking if GitHub API token is available in `~/.elastic/github.token`")
+    token = get_github_token()
+
     tmp_branch = "backport_{}_{}".format(args.pr_number, args.to_branch)
 
     if not vars(args)["continue"]:
@@ -96,9 +99,7 @@ def create_pr(args):
 
         commit_hashes = "{}".format(" ").join(args.commit_hashes)
         info("Cherry-picking {}".format(commit_hashes))
-        #if call("git cherry-pick -x {}".format(" ".join(args.commit_hashes)),
-        if call("git cherry-pick -x {}".format(commit_hashes),
-                shell=True) != 0:
+        if call("git cherry-pick -x {}".format(commit_hashes), shell=True) != 0:
             info("Looks like you have cherry-pick errors.")
             info("Fix them, then run: ")
             info("    git cherry-pick --continue")
@@ -128,16 +129,8 @@ def create_pr(args):
         remote = input("To which remote should I push? (your fork): ")
 
     info("Pushing branch {} to remote {}".format(tmp_branch, remote))
-    call("git push {} :{} > /dev/null".format(remote, tmp_branch),
-         shell=True)
-    check_call("git push --set-upstream {} {}"
-               .format(remote, tmp_branch), shell=True)
-
-    info("Checking if GitHub API token is available in `~/.elastic/github.token`")
-    try:
-        token = open(expanduser("~/.elastic/github.token"), "r").read().strip()
-    except:
-        token = False
+    call("git push {} :{} > /dev/null".format(remote, tmp_branch), shell=True)
+    check_call("git push --set-upstream {} {}".format(remote, tmp_branch), shell=True)
 
     if not token:
         info("GitHub API token not available.\n" +
@@ -147,15 +140,12 @@ def create_pr(args):
     else:
         info("Automatically creating a PR for you...")
 
+        session = github_session(token)
         base = "https://api.github.com/repos/elastic/logstash"
-        session = requests.Session()
-        session.headers.update({"Authorization": "token " + token})
-
         original_pr = session.get(base + "/pulls/" + args.pr_number).json()
 
         # get the github username from the remote where we pushed
-        remote_url = check_output("git remote get-url {}".format(remote),
-                                  shell=True)
+        remote_url = check_output("git remote get-url {}".format(remote), shell=True)
         remote_user = re.search("github.com[:/](.+)/logstash", str(remote_url)).group(1)
 
         # create PR
@@ -203,6 +193,18 @@ def get_version(base_dir):
             #match = pattern.match(line)
             #if match:
             #    return match.group('version')
+
+def get_github_token():
+    try:
+        token = open(expanduser("~/.elastic/github.token"), "r").read().strip()
+    except:
+        token = False
+    return token
+
+def github_session(token):
+    session = requests.Session()
+    session.headers.update({"Authorization": "token " + token})
+    return session
 
 def info(msg):
     print("\nINFO: {}".format(msg))

--- a/devtools/backport
+++ b/devtools/backport
@@ -47,7 +47,7 @@ def main():
                         help="To branch (e.g 7.x)")
     parser.add_argument("pr_number",
                         help="The PR number being merged (e.g. 2345)")
-    parser.add_argument("commit_hashes", metavar="hash", nargs="+",
+    parser.add_argument("commit_hashes", metavar="hash", nargs="*",
                         help="The commit hashes to cherry pick." +
                         " You can specify multiple.")
     parser.add_argument("--yes", action="store_true",

--- a/devtools/backport
+++ b/devtools/backport
@@ -10,6 +10,7 @@ from os.path import expanduser
 import re
 from subprocess import check_call, call, check_output
 import requests
+import json
 
 usage = """
     Example usage:
@@ -97,7 +98,25 @@ def create_pr(parser, args):
         call("git branch -D {} > /dev/null".format(tmp_branch), shell=True)
         check_call("git checkout -b {}".format(tmp_branch), shell=True)
 
-        commit_hashes = "{}".format(" ").join(args.commit_hashes)
+        if len(args.commit_hashes) == 0:
+            if token:
+                session = github_session(token)
+                base = "https://api.github.com/repos/elastic/logstash"
+                original_pr = session.get(base + "/pulls/" + args.pr_number).json()
+                merge_commit = original_pr['merge_commit_sha']
+                if not merge_commit:
+                    info("Could not auto resolve merge commit - PR isn't merged yet")
+                    return 1
+                info("Merge commit detected from PR: {}".format(merge_commit))
+                commit_hashes = merge_commit
+            else:
+                info("GitHub API token not available. " +
+                     "Please manually specify commit hash(es) argument(s)\n")
+                parser.print_help()
+                return 1
+        else:
+            commit_hashes = "{}".format(" ").join(args.commit_hashes)
+
         info("Cherry-picking {}".format(commit_hashes))
         if call("git cherry-pick -x {}".format(commit_hashes), shell=True) != 0:
             info("Looks like you have cherry-pick errors.")

--- a/devtools/backport
+++ b/devtools/backport
@@ -14,11 +14,11 @@ import json
 
 usage = """
     Example usage:
-        ./devtools/backport 5.0 2565 6490604aa0cf7fa61932a90700e6ca988fc8a527
+        ./devtools/backport 7.16 2565 6490604aa0cf7fa61932a90700e6ca988fc8a527
 
     In case of backporting errors, fix them, then run
         git cherry-pick --continue
-        ./devtools/backport 5.0 2565 6490604aa0cf7fa61932a90700e6ca988fc8a527 --continue
+        ./devtools/backport 7.16 2565 6490604aa0cf7fa61932a90700e6ca988fc8a527 --continue
 
     This script does the following:
         * cleanups both from_branch and to_branch (warning: drops local changes)


### PR DESCRIPTION
Some minor usability improvements I've been using for a while.
Please double check if anything got messed up, sample usage:

`devtools/backport 7.16 13481` (without having to copy and specify commits)

sample PR created (notice the updated formatting - to visually differentiate the "copied PR desc"): https://github.com/elastic/logstash/pull/13484

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]