### PR TITLE
Backport #13494 to 8.0. bump log4j version to 2.15.0

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -30,7 +30,7 @@ String jrubyVersion = versionMap['jruby']['version']
 String jacksonVersion = versionMap['jackson']
 String jacksonDatabindVersion = versionMap['jackson-databind']
 
-String log4jVersion = '2.14.0'
+String log4jVersion = '2.15.0'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Backport #13494 to 8.0 branch.
