### PR TITLE
Create wrapper class to bridge the calls to Ruby codec and present it self as a Java codec

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/RubyIntegration.java
@@ -21,11 +21,10 @@
 package org.logstash.config.ir.compiler;
 
 import co.elastic.logstash.api.Codec;
+import org.jruby.RubyObject;
 import org.jruby.RubyString;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.common.SourceWithMetadata;
-
-import java.util.Map;
 
 /**
  * This class holds interfaces implemented by Ruby concrete classes.
@@ -51,5 +50,6 @@ public final class RubyIntegration {
 
         Codec buildDefaultCodec(String codecName);
 
+        Codec buildRubyCodecWrapper(RubyObject rubyCodec);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/plugins/ConfigurationImpl.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/ConfigurationImpl.java
@@ -24,7 +24,11 @@ import co.elastic.logstash.api.Configuration;
 import co.elastic.logstash.api.Password;
 import co.elastic.logstash.api.PluginConfigSpec;
 import co.elastic.logstash.api.Codec;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jruby.RubyObject;
 import org.logstash.config.ir.compiler.RubyIntegration;
+import org.logstash.plugins.factory.RubyCodecDelegator;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -35,6 +39,7 @@ import java.util.Map;
  * Configuration for Logstash Java plugins.
  */
 public final class ConfigurationImpl implements Configuration {
+    private static final Logger LOGGER = LogManager.getLogger(ConfigurationImpl.class);
 
     private final RubyIntegration.PluginFactory pluginFactory;
     private final Map<String, Object> rawSettings;
@@ -68,6 +73,9 @@ public final class ConfigurationImpl implements Configuration {
                 return configSpec.type().cast(Boolean.parseBoolean((String) o));
             } else if (configSpec.type() == Codec.class && o instanceof String && pluginFactory != null) {
                 Codec codec = pluginFactory.buildDefaultCodec((String) o);
+                return configSpec.type().cast(codec);
+            } else if (configSpec.type() == Codec.class && o instanceof RubyObject && RubyCodecDelegator.isRubyCodecSubclass((RubyObject) o)) {
+                Codec codec = pluginFactory.buildRubyCodecWrapper((RubyObject) o);
                 return configSpec.type().cast(codec);
             } else if (configSpec.type() == URI.class && o instanceof String) {
                 try {

--- a/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java
@@ -166,13 +166,20 @@ public final class PluginFactoryExt extends RubyBasicObject
 
     @Override
     public Codec buildDefaultCodec(String codecName) {
-        return (Codec) JavaUtil.unwrapJavaValue(plugin(
+        final IRubyObject pluginInstance = plugin(
                 RubyUtil.RUBY.getCurrentContext(),
                 PluginLookup.PluginType.CODEC,
                 codecName,
                 RubyHash.newHash(RubyUtil.RUBY),
                 null
-        ));
+        );
+        final Codec codec = (Codec) JavaUtil.unwrapJavaValue(pluginInstance);
+        if (codec != null) {
+            return codec;
+        }
+
+        // no unwrap is possible so this is a real Ruby instance
+        return new RubyCodecDelegator(RubyUtil.RUBY.getCurrentContext(), pluginInstance);
     }
 
     @SuppressWarnings("unchecked")

--- a/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java
@@ -182,6 +182,11 @@ public final class PluginFactoryExt extends RubyBasicObject
         return new RubyCodecDelegator(RubyUtil.RUBY.getCurrentContext(), pluginInstance);
     }
 
+    @Override
+    public Codec buildRubyCodecWrapper(RubyObject rubyCodec) {
+        return new RubyCodecDelegator(RubyUtil.RUBY.getCurrentContext(), rubyCodec);
+    }
+
     @SuppressWarnings("unchecked")
     @JRubyMethod(required = 3, optional = 1)
     public IRubyObject plugin(final ThreadContext context, final IRubyObject[] args) {

--- a/logstash-core/src/main/java/org/logstash/plugins/factory/RubyCodecDelegator.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/factory/RubyCodecDelegator.java
@@ -30,6 +30,7 @@ class RubyCodecDelegator implements Codec {
 
     private final ThreadContext currentContext;
     private final IRubyObject pluginInstance;
+    private final String wrappingId;
 
     public RubyCodecDelegator(ThreadContext currentContext, IRubyObject pluginInstance) {
         this.currentContext = currentContext;
@@ -37,6 +38,13 @@ class RubyCodecDelegator implements Codec {
 
         verifyCodecAncestry(pluginInstance);
         invokeRubyRegister(currentContext, pluginInstance);
+
+        wrappingId = "jw-" + wrappedPluginId();
+    }
+
+    private String wrappedPluginId() {
+        RubyString id = (RubyString) pluginInstance.callMethod(this.currentContext, "id");
+        return id.toString();
     }
 
     private void verifyCodecAncestry(IRubyObject pluginInstance) {
@@ -116,13 +124,14 @@ class RubyCodecDelegator implements Codec {
 
     @Override
     public Collection<PluginConfigSpec<?>> configSchema() {
-        // TODO bring configuration options from wrapped end convert to PluginConfigSpec
+        // this method is invoked only for real java codecs, the one that are configured
+        // in pipeline config that needs configuration validation. In this case the validation
+        // is already done on the Ruby codec.
         return null;
     }
 
     @Override
     public String getId() {
-        // TODO return the id of the plugin instance, maybe prepended with "jw-"
-        return null;
+        return wrappingId;
     }
 }

--- a/logstash-core/src/main/java/org/logstash/plugins/factory/RubyCodecDelegator.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/factory/RubyCodecDelegator.java
@@ -111,8 +111,8 @@ class RubyCodecDelegator implements Codec {
 
         // method return an nested array, the outer contains just one element
         // while the inner contains the original event and encoded event in form of String
-        final String result = (String) ((RubyArray) encoded.get(0)).get(1);
-        output.write(result.getBytes(StandardCharsets.UTF_8));
+        final RubyString result = ((RubyArray) encoded.eltInternal(0)).eltInternal(1).convertToString();
+        output.write(result.getByteList().getUnsafeBytes(), result.getByteList().getBegin(), result.getByteList().getRealSize());
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/plugins/factory/RubyCodecDelegator.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/factory/RubyCodecDelegator.java
@@ -1,0 +1,128 @@
+package org.logstash.plugins.factory;
+
+import co.elastic.logstash.api.Codec;
+import co.elastic.logstash.api.Event;
+import co.elastic.logstash.api.PluginConfigSpec;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jruby.RubyArray;
+import org.jruby.RubyClass;
+import org.jruby.RubyString;
+import org.jruby.runtime.Block;
+import org.jruby.runtime.JavaInternalBlockBody;
+import org.jruby.runtime.Signature;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.logstash.RubyUtil;
+import org.logstash.ext.JrubyEventExtLibrary;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Consumer;
+
+class RubyCodecDelegator implements Codec {
+
+    private static final Logger LOGGER = LogManager.getLogger(RubyCodecDelegator.class);
+
+    private final ThreadContext currentContext;
+    private final IRubyObject pluginInstance;
+
+    public RubyCodecDelegator(ThreadContext currentContext, IRubyObject pluginInstance) {
+        this.currentContext = currentContext;
+        this.pluginInstance = pluginInstance;
+
+        verifyCodecAncestry(pluginInstance);
+        invokeRubyRegister(currentContext, pluginInstance);
+    }
+
+    private void verifyCodecAncestry(IRubyObject pluginInstance) {
+        final RubyClass codecBaseClass = RubyUtil.RUBY.getModule("LogStash").getModule("Codecs").getClass("Base");
+//            final boolean isRubyCodec = codecBaseClass.subclasses(true).contains(pluginInstance.getType());
+        final boolean isRubyCodec = pluginInstance.getType().hasModuleInHierarchy(codecBaseClass);
+        if (!isRubyCodec) {
+            throw new IllegalStateException("Ruby wrapped codec is expected to subclass LogStash::Codecs::Base");
+        }
+    }
+
+    private void invokeRubyRegister(ThreadContext currentContext, IRubyObject pluginInstance) {
+        pluginInstance.callMethod(currentContext, "register");
+    }
+
+    @Override
+    public void decode(ByteBuffer buffer, Consumer<Map<String, Object>> eventConsumer) {
+        // invoke Ruby's codec #decode(data, block) and use a Block to capture the yielded LogStash::Event to
+        // back to Java and pass to the eventConsumer.
+        if (buffer.remaining() == 0) {
+            // no data to decode
+            return;
+        }
+
+        // setup the block callback bridge to invoke eventConsumer
+        final Block consumerWrapper = new Block(new JavaInternalBlockBody(currentContext.runtime, Signature.ONE_ARGUMENT) {
+            @Override
+            @SuppressWarnings("unchecked")
+            public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
+                // Expect only one argument, the LogStash::Event instantiated by the Ruby codec
+                final IRubyObject event = args[0];
+                // TODO should we check the type of the args[0] or assume it's always an RubyEvent?
+                final Map<String, Object> unwrappedEvent = ((JrubyEventExtLibrary.RubyEvent) event).ruby_to_hash(currentContext)
+                        .toJava(Map.class);
+                eventConsumer.accept(unwrappedEvent);
+                return event;
+            }
+        });
+
+        byte[] byteInput = new byte[buffer.remaining()];
+        buffer.get(byteInput);
+        final RubyString data = RubyUtil.RUBY.newString(new String(byteInput));
+        // this causes problem in passing data, it trigger an invocation to #force_encoding if the data is not
+        // already converted to RubyString before passing it
+//                final IRubyObject data = JavaUtil.convertJavaToRuby(RubyUtil.RUBY, byteInput);
+        IRubyObject[] methodParams = new IRubyObject[]{data};
+        pluginInstance.callMethod(this.currentContext, "decode", methodParams, consumerWrapper);
+    }
+
+    @Override
+    public void flush(ByteBuffer buffer, Consumer<Map<String, Object>> eventConsumer) {
+        decode(buffer, eventConsumer);
+    }
+
+    @Override
+    @SuppressWarnings({"uncheked", "rawtypes"})
+    public void encode(Event event, OutputStream output) throws IOException {
+        // convert co.elastic.logstash.api.Event to JrubyEventExtLibrary.RubyEvent
+        if (!(event instanceof org.logstash.Event)) {
+            throw new IllegalStateException("The object to encode must be of type org.logstash.Event");
+        }
+
+        final JrubyEventExtLibrary.RubyEvent rubyEvent = JrubyEventExtLibrary.RubyEvent.newRubyEvent(currentContext.runtime, (org.logstash.Event) event);
+        final RubyArray param = RubyArray.newArray(currentContext.runtime, rubyEvent);
+        final RubyArray encoded = (RubyArray) pluginInstance.callMethod(this.currentContext, "multi_encode", param);
+
+        // method return an nested array, the outer contains just one element
+        // while the inner contains the original event and encoded event in form of String
+        final String result = (String) ((RubyArray) encoded.get(0)).get(1);
+        output.write(result.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public Codec cloneCodec() {
+        return new RubyCodecDelegator(this.currentContext, this.pluginInstance);
+    }
+
+    @Override
+    public Collection<PluginConfigSpec<?>> configSchema() {
+        // TODO bring configuration options from wrapped end convert to PluginConfigSpec
+        return null;
+    }
+
+    @Override
+    public String getId() {
+        // TODO return the id of the plugin instance, maybe prepended with "jw-"
+        return null;
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/plugins/factory/RubyCodecDelegator.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/factory/RubyCodecDelegator.java
@@ -78,7 +78,6 @@ public class RubyCodecDelegator implements Codec {
             public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
                 // Expect only one argument, the LogStash::Event instantiated by the Ruby codec
                 final IRubyObject event = args[0];
-                // TODO should we check the type of the args[0] or assume it's always an RubyEvent?
                 eventConsumer.accept( ((JrubyEventExtLibrary.RubyEvent) event).getEvent().getData() );
                 return event;
             }
@@ -87,9 +86,6 @@ public class RubyCodecDelegator implements Codec {
         byte[] byteInput = new byte[buffer.remaining()];
         buffer.get(byteInput);
         final RubyString data = RubyUtil.RUBY.newString(new String(byteInput));
-        // this causes problem in passing data, it trigger an invocation to #force_encoding if the data is not
-        // already converted to RubyString before passing it
-//                final IRubyObject data = JavaUtil.convertJavaToRuby(RubyUtil.RUBY, byteInput);
         IRubyObject[] methodParams = new IRubyObject[]{data};
         pluginInstance.callMethod(this.currentContext, "decode", methodParams, consumerWrapper);
     }

--- a/logstash-core/src/main/java/org/logstash/plugins/factory/RubyCodecDelegator.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/factory/RubyCodecDelegator.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.function.Consumer;
 
-class RubyCodecDelegator implements Codec {
+public class RubyCodecDelegator implements Codec {
 
     private static final Logger LOGGER = LogManager.getLogger(RubyCodecDelegator.class);
 
@@ -47,13 +47,15 @@ class RubyCodecDelegator implements Codec {
         return id.toString();
     }
 
-    private void verifyCodecAncestry(IRubyObject pluginInstance) {
-        final RubyClass codecBaseClass = RubyUtil.RUBY.getModule("LogStash").getModule("Codecs").getClass("Base");
-//            final boolean isRubyCodec = codecBaseClass.subclasses(true).contains(pluginInstance.getType());
-        final boolean isRubyCodec = pluginInstance.getType().hasModuleInHierarchy(codecBaseClass);
-        if (!isRubyCodec) {
+    private static void verifyCodecAncestry(IRubyObject pluginInstance) {
+        if (!isRubyCodecSubclass(pluginInstance)) {
             throw new IllegalStateException("Ruby wrapped codec is expected to subclass LogStash::Codecs::Base");
         }
+    }
+
+    public static boolean isRubyCodecSubclass(IRubyObject pluginInstance) {
+        final RubyClass codecBaseClass = RubyUtil.RUBY.getModule("LogStash").getModule("Codecs").getClass("Base");
+        return pluginInstance.getType().hasModuleInHierarchy(codecBaseClass);
     }
 
     private void invokeRubyRegister(ThreadContext currentContext, IRubyObject pluginInstance) {

--- a/logstash-core/src/main/java/org/logstash/plugins/factory/RubyCodecDelegator.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/factory/RubyCodecDelegator.java
@@ -77,9 +77,7 @@ class RubyCodecDelegator implements Codec {
                 // Expect only one argument, the LogStash::Event instantiated by the Ruby codec
                 final IRubyObject event = args[0];
                 // TODO should we check the type of the args[0] or assume it's always an RubyEvent?
-                final Map<String, Object> unwrappedEvent = ((JrubyEventExtLibrary.RubyEvent) event).ruby_to_hash(currentContext)
-                        .toJava(Map.class);
-                eventConsumer.accept(unwrappedEvent);
+                eventConsumer.accept( ((JrubyEventExtLibrary.RubyEvent) event).getEvent().getData() );
                 return event;
             }
         });

--- a/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/CompiledPipelineTest.java
@@ -552,6 +552,11 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
             return null;
         }
 
+        @Override
+        public Codec buildRubyCodecWrapper(RubyObject rubyCodec) {
+            return null;
+        }
+
         private static <T> T setupPlugin(final RubyString name,
             final Map<String, Supplier<T>> suppliers) {
             final String key = name.asJavaString();
@@ -737,6 +742,11 @@ public final class CompiledPipelineTest extends RubyEnvTestCase {
 
         @Override
         public Codec buildDefaultCodec(String codecName) {
+            return null;
+        }
+
+        @Override
+        public Codec buildRubyCodecWrapper(RubyObject rubyCodec) {
             return null;
         }
     }

--- a/logstash-core/src/test/java/org/logstash/plugins/TestPluginFactory.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/TestPluginFactory.java
@@ -21,6 +21,7 @@
 package org.logstash.plugins;
 
 import co.elastic.logstash.api.Codec;
+import org.jruby.RubyObject;
 import org.jruby.RubyString;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.common.SourceWithMetadata;
@@ -59,5 +60,10 @@ public class TestPluginFactory implements RubyIntegration.PluginFactory {
     @Override
     public Codec buildDefaultCodec(String codecName) {
         return new Line(new ConfigurationImpl(Collections.emptyMap()), new ContextImpl(null, null));
+    }
+
+    @Override
+    public Codec buildRubyCodecWrapper(RubyObject rubyCodec) {
+        return null;
     }
 }

--- a/qa/integration/fixtures/mixed_codec_spec.yml
+++ b/qa/integration/fixtures/mixed_codec_spec.yml
@@ -16,6 +16,20 @@ config:
       }
     }
 
+  input_decode_configured: |-
+    input {
+      java_stdin {
+          codec => plain {
+            charset => "ASCII-8BIT"
+          }
+      }
+    }
+    output {
+      file {
+        path => "${PATH_TO_OUT}"
+      }
+    }    
+
   output_encode: |-
     input {
       generator {

--- a/qa/integration/fixtures/mixed_codec_spec.yml
+++ b/qa/integration/fixtures/mixed_codec_spec.yml
@@ -1,0 +1,29 @@
+
+---
+services:
+  - logstash
+
+config:
+  input_decode: |-
+    input {
+      java_stdin {
+          codec => json
+      }
+    }
+    output {
+      file {
+        path => "${PATH_TO_OUT}"
+      }
+    }
+
+  output_encode: |-
+    input {
+      generator {
+        count => 4
+      }
+    }
+    output {
+      java_stdout {
+        codec => json
+      }
+    }

--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -190,7 +190,6 @@ class LogstashService < Service
 
   # check REST API is responsive
   def is_rest_active?
-#     result = monitoring_api.event_stats
     result = monitoring_api.node_info
     started = !result.nil?
   end

--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -112,15 +112,16 @@ class LogstashService < Service
 
   # Can start LS in stdin and can send messages to stdin
   # Useful to test metrics and such
-  def start_with_stdin
-    puts "Starting Logstash #{@logstash_bin} -e #{STDIN_CONFIG}"
+  def start_with_stdin(pipeline_config = STDIN_CONFIG)
+    puts "Starting Logstash #{@logstash_bin} -e #{pipeline_config}"
     Bundler.with_unbundled_env do
       out = Tempfile.new("duplex")
       out.sync = true
-      @process = build_child_process("-e", STDIN_CONFIG)
+      @process = build_child_process("-e", pipeline_config)
       # pipe STDOUT and STDERR to a file
       @process.io.stdout = @process.io.stderr = out
       @process.duplex = true
+      @env_variables.map { |k, v|  @process.environment[k] = v} unless @env_variables.nil?
       java_home = java.lang.System.getProperty('java.home')
       @process.environment['LS_JAVA_HOME'] = java_home
       @process.start
@@ -138,7 +139,12 @@ class LogstashService < Service
   # Spawn LS as a child process
   def spawn_logstash(*args)
     Bundler.with_unbundled_env do
+      out = Tempfile.new("duplex")
+      out.sync = true
       @process = build_child_process(*args)
+      # pipe STDOUT and STDERR to a file
+      @process.io.stdout = @process.io.stderr = out
+      @process.duplex = true # enable stdin to be written
       @env_variables.map { |k, v|  @process.environment[k] = v} unless @env_variables.nil?
       java_home = java.lang.System.getProperty('java.home')
       @process.environment['LS_JAVA_HOME'] = java_home
@@ -182,6 +188,13 @@ class LogstashService < Service
     end
   end
 
+  # check REST API is responsive
+  def is_rest_active?
+#     result = monitoring_api.event_stats
+    result = monitoring_api.node_info
+    started = !result.nil?
+  end
+
   def monitoring_api
     raise "Logstash is not up, but you asked for monitoring API" unless alive?
     @monitoring_api
@@ -192,6 +205,20 @@ class LogstashService < Service
     tries = RETRY_ATTEMPTS
     while tries > 0
       if is_port_open?
+        return
+      else
+        sleep 1
+      end
+      tries -= 1
+    end
+    raise "Logstash REST API did not come up after #{RETRY_ATTEMPTS}s."
+  end
+
+  # wait until LS respond to REST HTTP API request
+  def wait_for_rest
+    tries = RETRY_ATTEMPTS
+    while tries > 0
+      if is_rest_active?
         return
       else
         sleep 1

--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -189,7 +189,7 @@ class LogstashService < Service
   end
 
   # check REST API is responsive
-  def is_rest_active?
+  def rest_active?
     result = monitoring_api.node_info
     started = !result.nil?
   end
@@ -214,10 +214,10 @@ class LogstashService < Service
   end
 
   # wait until LS respond to REST HTTP API request
-  def wait_for_rest
+  def wait_for_rest_api
     tries = RETRY_ATTEMPTS
     while tries > 0
-      if is_rest_active?
+      if rest_active?
         return
       else
         sleep 1

--- a/qa/integration/services/monitoring_api.rb
+++ b/qa/integration/services/monitoring_api.rb
@@ -50,12 +50,6 @@ class MonitoringAPI
     JSON.parse(resp)
   end
 
-#   def node_info_pipeline(pipeline_id)
-#     resp = Manticore.get("http://localhost:9600/_node/pipelines/#{pipeline_id}").body
-#     node_response = JSON.parse(resp)
-#     node_response.fetch("pipelines").fetch(pipeline_id)
-#   end
-
   def logging_get
     resp = Manticore.get("http://localhost:9600/_node/logging").body
     JSON.parse(resp)

--- a/qa/integration/services/monitoring_api.rb
+++ b/qa/integration/services/monitoring_api.rb
@@ -50,6 +50,12 @@ class MonitoringAPI
     JSON.parse(resp)
   end
 
+#   def node_info_pipeline(pipeline_id)
+#     resp = Manticore.get("http://localhost:9600/_node/pipelines/#{pipeline_id}").body
+#     node_response = JSON.parse(resp)
+#     node_response.fetch("pipelines").fetch(pipeline_id)
+#   end
+
   def logging_get
     resp = Manticore.get("http://localhost:9600/_node/logging").body
     JSON.parse(resp)

--- a/qa/integration/specs/mixed_codec_spec.rb
+++ b/qa/integration/specs/mixed_codec_spec.rb
@@ -57,21 +57,12 @@ describe "Ruby codec when used in" do
 
     it "should encode correctly to file and don't log any ERROR" do
       logstash_service.env_variables = {'PATH_TO_OUT' => out_capture.path}
-      logstash_service.spawn_logstash("-w", "1" , "-e", config)
-      logstash_service.wait_for_logstash
+#       logstash_service.spawn_logstash("-w", "1" , "-e", config)
+      logstash_service.start_with_stdin(config)
+#       logstash_service.wait_for_logstash
 
-      # TODO extract this busy loop in a utils method inside logstash_service
-      # wait for Logstash to start
-      started = false
-      while !started
-        begin
-          sleep(1)
-          result = @logstash.monitoring_api.event_stats
-          started = !result.nil?
-        rescue
-          retry
-        end
-      end
+      # wait for Logstash to fully start
+      logstash_service.wait_for_rest
 
       logstash_service.write_to_stdin('{"project": "Teleport"}')
       sleep(2)
@@ -95,11 +86,7 @@ describe "Ruby codec when used in" do
       logstash_service.env_variables = {'PATH_TO_OUT' => out_capture.path}
       logstash_service.spawn_logstash("-w", "1" , "-e", config)
       logstash_service.wait_for_logstash
-
-      #TODO: needs to verify something else to proof the LS process is up, just sleep is synonym of fragile testing.
-      # port opening check, like in wait_for_logstash, is not sufficient, maybe some HTTP API call with parsing of the
-      # response
-      sleep 30
+      logstash_service.wait_for_rest
 
       logstash_service.write_to_stdin('Teleport ray')
       sleep(2)
@@ -122,9 +109,7 @@ describe "Ruby codec when used in" do
     it "should encode correctly without any ERROR log" do
       logstash_service.spawn_logstash("-w", "1" , "-e", config)
       logstash_service.wait_for_logstash
-
-      #TODO: needs to verify something else to proof the LS process is up, just sleep is synonym of fragile testing
-      sleep 30
+      logstash_service.wait_for_rest
 
       logstash_service.teardown
 

--- a/qa/integration/specs/mixed_codec_spec.rb
+++ b/qa/integration/specs/mixed_codec_spec.rb
@@ -57,12 +57,10 @@ describe "Ruby codec when used in" do
 
     it "should encode correctly to file and don't log any ERROR" do
       logstash_service.env_variables = {'PATH_TO_OUT' => out_capture.path}
-#       logstash_service.spawn_logstash("-w", "1" , "-e", config)
       logstash_service.start_with_stdin(config)
-#       logstash_service.wait_for_logstash
 
       # wait for Logstash to fully start
-      logstash_service.wait_for_rest
+      logstash_service.wait_for_rest_api
 
       logstash_service.write_to_stdin('{"project": "Teleport"}')
       sleep(2)
@@ -86,7 +84,7 @@ describe "Ruby codec when used in" do
       logstash_service.env_variables = {'PATH_TO_OUT' => out_capture.path}
       logstash_service.spawn_logstash("-w", "1" , "-e", config)
       logstash_service.wait_for_logstash
-      logstash_service.wait_for_rest
+      logstash_service.wait_for_rest_api
 
       logstash_service.write_to_stdin('Teleport ray')
       sleep(2)
@@ -109,7 +107,7 @@ describe "Ruby codec when used in" do
     it "should encode correctly without any ERROR log" do
       logstash_service.spawn_logstash("-w", "1" , "-e", config)
       logstash_service.wait_for_logstash
-      logstash_service.wait_for_rest
+      logstash_service.wait_for_rest_api
 
       logstash_service.teardown
 

--- a/qa/integration/specs/mixed_codec_spec.rb
+++ b/qa/integration/specs/mixed_codec_spec.rb
@@ -1,0 +1,101 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require_relative '../framework/fixture'
+require_relative '../framework/settings'
+require "stud/temporary"
+require "stud/try"
+require "rspec/wait"
+require "yaml"
+require "fileutils"
+require "logstash/devutils/rspec/spec_helper"
+
+describe "Ruby codec when used in" do
+  before(:all) {
+    @fixture = Fixture.new(__FILE__)
+  }
+
+  after(:all) {
+    @fixture.teardown
+  }
+
+  before(:each) {
+    # backup the application settings file -- logstash.yml
+    FileUtils.cp(logstash_service.application_settings_file, "#{logstash_service.application_settings_file}.original")
+    IO.write(logstash_service.application_settings_file, settings.to_yaml)
+  }
+
+  after(:each) {
+    logstash_service.teardown
+    # restore the application settings file -- logstash.yml
+    FileUtils.mv("#{logstash_service.application_settings_file}.original", logstash_service.application_settings_file)
+  }
+
+  let(:temp_dir) { Stud::Temporary.directory("logstash-pipelinelog-test") }
+  let(:logstash_service) { @fixture.get_service("logstash") }
+  let(:out_capture) { Tempfile.new("file_out") }
+  let(:settings) do
+    {"path.logs" => temp_dir }
+  end
+
+  context "input Java plugin" do
+    let(:config) { @fixture.config("input_decode") }
+
+    it "should encode correctly to file and don't log any ERROR" do
+      logstash_service.env_variables = {'PATH_TO_OUT' => out_capture.path}
+      logstash_service.spawn_logstash("-w", "1" , "-e", config)
+      logstash_service.wait_for_logstash
+
+      #TODO: needs to verify something else to proof the LS process is up, just sleep is synonym of fragile testing.
+      # port opening check, like in wait_for_logstash, is not sufficient, maybe some HTTP API call with parsing of the
+      # response
+      sleep 30
+
+      logstash_service.write_to_stdin('{"project": "Teleport"}')
+      sleep(2)
+
+      logstash_service.teardown
+
+      plainlog_file = "#{temp_dir}/logstash-plain.log"
+      expect(File.exists?(plainlog_file)).to be true
+      logs = IO.read(plainlog_file)
+      expect(logs).to_not include("ERROR")
+
+      out_capture.rewind
+      expect(out_capture.read).to include("\"project\":\"Teleport\"")
+    end
+  end
+
+  context "output Java plugin" do
+    let(:config) { @fixture.config("output_encode") }
+
+    it "should encode correctly without any ERROR log" do
+      logstash_service.spawn_logstash("-w", "1" , "-e", config)
+      logstash_service.wait_for_logstash
+
+      #TODO: needs to verify something else to proof the LS process is up, just sleep is synonym of fragile testing
+      sleep 30
+
+      logstash_service.teardown
+
+      plainlog_file = "#{temp_dir}/logstash-plain.log"
+      expect(File.exists?(plainlog_file)).to be true
+      logs = IO.read(plainlog_file)
+      expect(logs).to_not include("ERROR")
+    end
+  end
+end


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Open the ability to use Ruby codec inside Java plugins.


## What does this PR do?

Java plugins need subclasses of Java `co.elastic.logstash.api.Codec`  class to properly work. This PR implements an adapter for Ruby codecs to be wrapped into a Java's Codec subclass.


## Why is it important/What is the impact to the user?

Permits to the user to configure a Ruby codec inside  a Java plugin, like in:
```
input {
  java_stdin {
   codec => json
  }
}
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [x] check with a Java input plugin:
```
input { java_stdin {codec => json} }
```
- [x] check with a Java output plugin:
```
input { generator {message => 'Test message' count => 1} } output {java_stdout { codec => json }}
```
- [x] check Java input with configured codec
```
input { java_stdin {codec => json {charset => 'UTF-8'}} }
```

## How to test this PR locally

Run Logstash with the different input/output codec configurations listed in the **Author's checklist** section.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #13155

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
