### PR TITLE
Backport #13442 to 7.17. Update logstash docker to use ubuntu 20.04 b…

### DIFF
--- a/docker/templates/Dockerfile.j2
+++ b/docker/templates/Dockerfile.j2
@@ -19,35 +19,28 @@
   # Minimal distributions do not ship with en language packs.
   {% set locale = 'C.UTF-8' -%}
 {% else -%}
-  {% set base_image = 'centos:7'  -%}
-  {% set package_manager = 'yum' -%}
+  {% set base_image = 'ubuntu:20.04'  -%}
+  {% set package_manager = 'apt-get' -%}
   {% set locale = 'en_US.UTF-8' -%}
 {% endif -%}
 
 FROM {{ base_image }}
 
-# Install Java and the "which" command, which is needed by Logstash's shell
-# scripts.
-# Minimal distributions also require findutils tar gzip (procps for integration tests)
-
-# on aarch64, yum does not pick the right `bind-license` package for some reason
-# here we install a specific noarch RPM.
-{% if arch == 'aarch64' -%}
-RUN for iter in {1..10}; do {{ package_manager }} install -y http://mirror.centos.org/centos/7/updates/x86_64/Packages/bind-license-9.11.4-26.P2.el7_9.5.noarch.rpm && \
-    {{ package_manager }} clean all && \
-    {{ package_manager }} clean metadata && \
-    exit_code=0 && break || exit_code=$? && \
-    echo "packaging error: retry $iter in 10s" && \
-    {{ package_manager }} clean all && \
-    {{ package_manager }} clean metadata && sleep 10; done; \
-    (exit $exit_code)
-
+RUN for iter in {1..10}; do \
+{% if image_flavor != 'ubi8' -%}
+    export DEBIAN_FRONTEND=noninteractive && \
 {% endif -%}
-
-RUN for iter in {1..10}; do {{ package_manager }} update -y && \
-    {{ package_manager }} install -y procps findutils tar gzip which shadow-utils && \
+    {{ package_manager }} update -y && \
+    {{ package_manager }} upgrade -y && \
+    {{ package_manager }} install -y procps findutils tar gzip curl && \
+{% if image_flavor == 'ubi8' -%}
+    {{ package_manager }} install -y which shadow-utils && \
+{% else -%}
+    {{ package_manager }} install -y locales && \
+{% endif -%}
     {{ package_manager }} clean all && \
 {% if image_flavor != 'ubi8' -%}
+    locale-gen 'en_US.UTF-8' && \
     {{ package_manager }} clean metadata && \
 {% endif -%}
     exit_code=0 && break || exit_code=$? && \
@@ -62,7 +55,7 @@ RUN for iter in {1..10}; do {{ package_manager }} update -y && \
 # Provide a non-root user to run the process.
 RUN groupadd --gid 1000 logstash && \
     adduser --uid 1000 --gid 1000 \
-      --home-dir /usr/share/logstash --no-create-home \
+      --home /usr/share/logstash --no-create-home \
       logstash
 
 # Add Logstash itself.

--- a/qa/docker/shared_examples/container.rb
+++ b/qa/docker/shared_examples/container.rb
@@ -10,6 +10,10 @@ shared_examples_for 'the container is configured correctly' do |flavor|
   end
 
   context 'logstash' do
+    it 'does not warn cannot change locale' do
+      expect(@container.logs(stderr: true)).not_to match /cannot change locale/
+    end
+
     it 'should run with the correct version' do
       console_out = exec_in_container(@container, 'logstash --version')
       console_filtered = console_out.split("\n")

--- a/qa/docker/spec/full/container_spec.rb
+++ b/qa/docker/spec/full/container_spec.rb
@@ -9,4 +9,19 @@ describe 'A container running the full image' do
   it_behaves_like 'it runs with different configurations', 'full'
   it_behaves_like 'it applies settings correctly', 'full'
   it_behaves_like 'a container with xpack features', 'full'
+
+  context 'The running container' do
+    before do
+      @image = find_image('full')
+      @container = start_container(@image, {})
+    end
+
+    after do
+      cleanup_container(@container)
+    end
+
+    it 'has an Ubuntu 20.04 base image' do
+      expect(exec_in_container(@container, 'cat /etc/os-release').chomp).to match /Ubuntu 20.04/
+    end
+  end
 end

--- a/qa/docker/spec/oss/container_spec.rb
+++ b/qa/docker/spec/oss/container_spec.rb
@@ -7,4 +7,19 @@ describe 'A container running the oss image' do
   it_behaves_like 'the container is configured correctly', 'oss'
   it_behaves_like 'it applies settings correctly', 'oss'
   it_behaves_like 'it runs with different configurations', 'oss'
+
+  context 'The running container' do
+    before do
+      @image = find_image('oss')
+      @container = start_container(@image, {})
+    end
+
+    after do
+      cleanup_container(@container)
+    end
+
+    it 'has an Ubuntu 20.04 base image' do
+      expect(exec_in_container(@container, 'cat /etc/os-release').chomp).to match /Ubuntu 20.04/
+    end
+  end
 end


### PR DESCRIPTION
…ase image

Backport #13442 to 7.17 branch. Original message:

* Update logstash docker to use ubuntu 20.04 base image
* Correctly set locale for ubuntu docker image
* tiny typo fix: ubunto -> ubuntu

Co-authored-by: João Duarte <jsvd@users.noreply.github.com>