### PR TITLE
Doc: Add anchor to bundled jdk info

### DIFF
--- a/docs/static/jvm.asciidoc
+++ b/docs/static/jvm.asciidoc
@@ -14,6 +14,7 @@ http://openjdk.java.net/[OpenJDK].
 See the https://www.elastic.co/support/matrix#matrix_jvm[Elastic Support Matrix]
 for the official word on supported versions across releases.
 
+[[bundled-jdk]]
 .Bundled JDK
 [NOTE]
 ===== 


### PR DESCRIPTION
Add an anchor to info on bundled JDK for easier linking and sharing