### PR TITLE
Backport PR #13544 to 8.0: Bump log4j dependency to 2.17.0

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -30,7 +30,7 @@ String jrubyVersion = versionMap['jruby']['version']
 String jacksonVersion = versionMap['jackson']
 String jacksonDatabindVersion = versionMap['jackson-databind']
 
-String log4jVersion = '2.16.0'
+String log4jVersion = '2.17.0'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Backport PR #13544 to 8.0 branch. Original message: 

None