### PR TITLE
bump version to 6.8.23

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -2,12 +2,12 @@ PATH
   remote: logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 6.8.22)
+      logstash-core (= 6.8.23)
 
 PATH
   remote: logstash-core
   specs:
-    logstash-core (6.8.22-java)
+    logstash-core (6.8.23-java)
       chronic_duration (= 0.10.6)
       clamp (~> 0.6.5)
       concurrent-ruby (~> 1.0, >= 1.0.5)

--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ These builds are created nightly and have undergone no formal QA, so they should
 | [deb-complete][]      | [deb-oss][]            |
 | [rpm-complete][]      | [rpm-oss][]            |
 
-[tar-complete]: https://snapshots.elastic.co/downloads/logstash/logstash-6.8.22-SNAPSHOT.tar.gz
-[zip-complete]: https://snapshots.elastic.co/downloads/logstash/logstash-6.8.22-SNAPSHOT.zip
-[deb-complete]: https://snapshots.elastic.co/downloads/logstash/logstash-6.8.22-SNAPSHOT.deb
-[rpm-complete]: https://snapshots.elastic.co/downloads/logstash/logstash-6.8.22-SNAPSHOT.rpm
-[tar-oss]: https://snapshots.elastic.co/downloads/logstash/logstash-oss-6.8.22-SNAPSHOT.tar.gz
-[zip-oss]: https://snapshots.elastic.co/downloads/logstash/logstash-oss-6.8.22-SNAPSHOT.zip
-[deb-oss]: https://snapshots.elastic.co/downloads/logstash/logstash-oss-6.8.22-SNAPSHOT.deb
-[rpm-oss]: https://snapshots.elastic.co/downloads/logstash/logstash-oss-6.8.22-SNAPSHOT.rpm
+[tar-complete]: https://snapshots.elastic.co/downloads/logstash/logstash-6.8.23-SNAPSHOT.tar.gz
+[zip-complete]: https://snapshots.elastic.co/downloads/logstash/logstash-6.8.23-SNAPSHOT.zip
+[deb-complete]: https://snapshots.elastic.co/downloads/logstash/logstash-6.8.23-SNAPSHOT.deb
+[rpm-complete]: https://snapshots.elastic.co/downloads/logstash/logstash-6.8.23-SNAPSHOT.rpm
+[tar-oss]: https://snapshots.elastic.co/downloads/logstash/logstash-oss-6.8.23-SNAPSHOT.tar.gz
+[zip-oss]: https://snapshots.elastic.co/downloads/logstash/logstash-oss-6.8.23-SNAPSHOT.zip
+[deb-oss]: https://snapshots.elastic.co/downloads/logstash/logstash-oss-6.8.23-SNAPSHOT.deb
+[rpm-oss]: https://snapshots.elastic.co/downloads/logstash/logstash-oss-6.8.23-SNAPSHOT.rpm
 
 ## Need Help?
 

--- a/versions.yml
+++ b/versions.yml
@@ -1,6 +1,6 @@
 ---
-logstash: 6.8.22
-logstash-core: 6.8.22
+logstash: 6.8.23
+logstash-core: 6.8.23
 logstash-core-plugin-api: 2.1.16
 
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

Bump version after 6.8.22 release
