### PR TITLE
read privilege missing for logstash_writer role

### DIFF
--- a/docs/static/security/logstash.asciidoc
+++ b/docs/static/security/logstash.asciidoc
@@ -51,7 +51,7 @@ POST _xpack/security/role/logstash_writer
   "indices": [
     {
       "names": [ "logstash-*" ], <2>
-      "privileges": ["write","create","create_index","manage","manage_ilm"]  <3>
+      "privileges": ["write","read","create","create_index","manage","manage_ilm"]  <3>
     }
   ]
 }


### PR DESCRIPTION
In order for logstash to work correctly I found it needs the **read** privilege as well.

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Fixed documentation to save other people a lot of time.

## Why is it important/What is the impact to the user?
To save other people a lot of time. And because I believe documentation should be correct and complete.

## Checklist

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ *] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Am I correct that the read privilege is needed for logstash to operate correcly

## How to test this PR locally
I was following the guide https://www.elastic.co/guide/en/logstash/current/ls-security.html
and https://www.elastic.co/blog/configuring-ssl-tls-and-https-to-secure-elasticsearch-kibana-beats-and-logstash
and got 403 unauthorized every time logstash was started. I figured the fix is this one extra read privilege.

When you leave the read privilege out with 6.17.2 you must be able to recreate the 403 unauthorized when logstash is starting with a pipeline that is using an elasticsearch output with the logstash_internal user account.

## Related issues
- 

## Use cases
It's just better documentation

## Logs

Here is a sample of the log message I tried to fix with the extra read privilege:
```
[2021-12-23T12:20:15,471][ERROR][logstash.outputs.elasticsearch][main][ce32a5e5a1968ccbc5e91167b16d45193094f8a384abf4d3ec6a0f1566e3cbb6] Elasticsearch setup did not complete normally, please review previously logged errors {:message=>"Got response code '403' contacting Elasticsearch at URL 'https://elastic:9200/logstash'", :exception=>LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError}
```
