### PR TITLE
[7.16] Bump log4j dependency to 2.17.1 (#13564)

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -30,7 +30,7 @@ String jrubyVersion = versionMap['jruby']['version']
 String jacksonVersion = versionMap['jackson']
 String jacksonDatabindVersion = versionMap['jackson-databind']
 
-String log4jVersion = '2.17.0'
+String log4jVersion = '2.17.1'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Bump log4j dependency to 2.17.1 (#13564)