### PR TITLE
[WIP] support single database update in geoip service endpoint

### DIFF
--- a/x-pack/lib/filters/geoip/download_manager.rb
+++ b/x-pack/lib/filters/geoip/download_manager.rb
@@ -74,7 +74,7 @@ module LogStash module Filters module Geoip class DownloadManager
 
     updated_db = DB_TYPES.map do |database_type|
       db_info = service_resp.find { |db| db['name'].eql?("#{GEOLITE}#{database_type}.#{GZ_EXT}") }
-      has_update = @metadata.gz_md5(database_type) != db_info['md5_hash']
+      has_update = db_info && (@metadata.gz_md5(database_type) != db_info['md5_hash'])
       [database_type, has_update, db_info]
     end
     .select { |database_type, has_update, db_info| has_update }

--- a/x-pack/spec/filters/geoip/download_manager_spec.rb
+++ b/x-pack/spec/filters/geoip/download_manager_spec.rb
@@ -42,34 +42,78 @@ describe LogStash::Filters::Geoip do
     end
 
     context "check update" do
+      let(:city_md5) { 'a195a73d4651a2bd02e5edd680f6703c' }
+      let(:asn_md5) { '8d57aec1958070f01042ac1ecd8ec2ab' }
+      let(:old_city_md5) { '01234567890aaa2bd02e5edd680f6703c'}
+
       before(:each) do
         expect(download_manager).to receive(:uuid).and_return(SecureRandom.uuid)
         mock_resp = double("geoip_endpoint",
-                           :body => ::File.read(::File.expand_path("./fixtures/normal_resp.json", ::File.dirname(__FILE__))),
+                           :body => ::File.read(::File.expand_path(response, ::File.dirname(__FILE__))),
                            :code => 200)
         allow(download_manager).to receive_message_chain("rest_client.get").and_return(mock_resp)
       end
 
-      it "should return City db info when City md5 does not match" do
-        expect(mock_metadata).to receive(:gz_md5).and_return("8d57aec1958070f01042ac1ecd8ec2ab", "a123a45d67890a2bd02e5edd680f6703c")
+      shared_examples "single database update" do
+        it "should return City db info when City md5 does not match" do
+          updated_db = download_manager.send(:check_update)
+          expect(updated_db.size).to eql(1)
 
-        updated_db = download_manager.send(:check_update)
-        expect(updated_db.size).to eql(1)
-
-        type, info = updated_db[0]
-        expect(info).to have_key("md5_hash")
-        expect(info).to have_key("name")
-        expect(info).to have_key("provider")
-        expect(info).to have_key("updated")
-        expect(info).to have_key("url")
-        expect(type).to eql(database_type)
+          type, info = updated_db[0]
+          expect(info).to have_key("md5_hash")
+          expect(info).to have_key("name")
+          expect(info).to have_key("provider")
+          expect(info).to have_key("updated")
+          expect(info).to have_key("url")
+          expect(type).to eql(database_type)
+        end
       end
 
-      it "should return empty array when md5 are the same" do
-        expect(mock_metadata).to receive(:gz_md5).and_return("8d57aec1958070f01042ac1ecd8ec2ab", "a195a73d4651a2bd02e5edd680f6703c")
+      shared_examples "no database update" do
+        it "should return empty array when md5 are the same" do
+          updated_db = download_manager.send(:check_update)
+          expect(updated_db.size).to eql(0)
+        end
+      end
 
-        updated_db = download_manager.send(:check_update)
-        expect(updated_db.size).to eql(0)
+      context "call geoip endpoint service" do
+        let(:response) { './fixtures/normal_resp.json' }
+
+        context "metadata has an old md5" do
+          before do
+            expect(mock_metadata).to receive(:gz_md5).and_return(asn_md5, old_city_md5)
+          end
+
+          it_behaves_like "single database update"
+        end
+
+        context "metadata has updated md5" do
+          before do
+            expect(mock_metadata).to receive(:gz_md5).and_return(asn_md5, city_md5)
+          end
+
+          it_behaves_like "no database update"
+        end
+      end
+
+      context "call air-gapped endpoint" do
+        let(:response) { './fixtures/single_city_resp.json' }
+
+        context "metadata has an old md5" do
+          before do
+            expect(mock_metadata).to receive(:gz_md5).and_return(old_city_md5)
+          end
+
+          it_behaves_like "single database update"
+        end
+
+        context "metadata has updated md5" do
+          before do
+            expect(mock_metadata).to receive(:gz_md5).and_return(city_md5)
+          end
+
+          it_behaves_like "no database update"
+        end
       end
 
     end

--- a/x-pack/spec/filters/geoip/fixtures/single_city_resp.json
+++ b/x-pack/spec/filters/geoip/fixtures/single_city_resp.json
@@ -1,0 +1,9 @@
+[
+  {
+    "md5_hash": "a195a73d4651a2bd02e5edd680f6703c",
+    "name": "GeoLite2-City.tgz",
+    "provider": "maxmind",
+    "updated": 1619740834,
+    "url": "GeoLite2-City.tgz"
+  }
+]


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
geoip air-gapped endpoint support single database update

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

This commit accepts a single database update from geoip service endpoint. In past, the update is always with all types of databases. 

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

This PR frees users from downloading all types of databases for air-gapped setup. User may interest to one type of database only. Prior to this change, the script `./bin/elasticsearch-geoip` can generate a mock response with single database but Logstash fail to process it as the geoip service always provide a full set of database.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

- download latest elasticsearch
- copy $ES_HOME/modules/ingest-geoip/GeoLite2-City.mmdb to YOUR_DB_DIR
- generate mock response,  `./bin/elasticsearch-geoip -s YOUR_DB_DIR`, `overview.json` file is generated
- in `logstash.yml`, set `xpack.geoip.download.endpoint: "http://localhost:8080/overview.json"`
- start mock server nginx, `docker run -d --name=nginx_geoip -p 8080:80 -v YOUR_DB_DIR:/usr/share/nginx/html:ro nginx`
- start Logstash with geoip. You should see no error in log and see database download in $LS_HOME/data/plugins/filters/geoip
```
    input {
      heartbeat {
        message => '{"host": "55.159.212.43", "app": "barfoo", "amount": 82.95}'
        interval => 10
      }
    }
    filter {
      json {
        source => "message"
      }
      geoip {
        source => "[host]"
        target => "[server]"
      }
    }
    output {
      stdout { codec => rubydebug }
    }
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #13577

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
