### PR TITLE
[7.17] Fix logstash-plugin install command to install non default plugin (#13405)

### DIFF
--- a/lib/bootstrap/bundler.rb
+++ b/lib/bootstrap/bundler.rb
@@ -55,7 +55,8 @@ module LogStash
       end
     end
 
-    def setup!(options = {})
+    # prepare bundler's environment variables, but do not invoke ::Bundler::setup
+    def prepare(options = {})
       options = {:without => [:development]}.merge(options)
       options[:without] = Array(options[:without])
 
@@ -76,6 +77,13 @@ module LogStash
       ::Bundler.settings.set_local(:gemfile, Environment::GEMFILE_PATH)
       ::Bundler.settings.set_local(:frozen, true) unless options[:allow_gemfile_changes]
       ::Bundler.reset!
+    end
+
+    # After +Bundler.setup+ call, all +load+ or +require+ of the gems would be allowed only if they are part of
+    # the Gemfile or Ruby's standard library
+    # To install a new plugin which is not part of Gemfile, DO NOT call setup!
+    def setup!(options = {})
+      prepare(options)
       ::Bundler.setup
     end
 

--- a/lib/pluginmanager/install.rb
+++ b/lib/pluginmanager/install.rb
@@ -184,7 +184,7 @@ class LogStash::PluginManager::Install < LogStash::PluginManager::Command
     return if !verify? || preserve? || development? || local? || local_gem?
 
     puts "Resolving mixin dependencies"
-    LogStash::Bundler.setup!
+    LogStash::Bundler.prepare
     plugins_to_update = install_list.map(&:first)
     unlock_dependencies = LogStash::Bundler.expand_logstash_mixin_dependencies(plugins_to_update) - plugins_to_update
 

--- a/qa/integration/specs/cli/install_spec.rb
+++ b/qa/integration/specs/cli/install_spec.rb
@@ -116,5 +116,20 @@ describe "CLI > logstash-plugin install" do
         end
       end
     end
+
+    context "install non bundle plugin" do
+      let(:plugin_name) { "logstash-input-google_cloud_storage" }
+      let(:install_command) { "bin/logstash-plugin install" }
+
+      it "successfully install the plugin" do
+        execute = @logstash_plugin.run_raw("#{install_command} #{plugin_name}")
+
+        expect(execute.stderr_and_stdout).to match(/Installation successful/)
+        expect(execute.exit_code).to eq(0)
+
+        installed = @logstash_plugin.list(plugin_name)
+        expect(installed.stderr_and_stdout).to match(/#{plugin_name}/)
+      end
+    end
   end
 end


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Fix logstash-plugin install command to install non default plugin (#13405)