### PR TITLE
Backport PR #13576 to 7.17: docs: sprintf vs UTC nature of @timestamp field

### DIFF
--- a/docs/static/configuration.asciidoc
+++ b/docs/static/configuration.asciidoc
@@ -377,10 +377,10 @@ output {
 }
 ----------------------------------
 
-Similarly, you can convert the timestamp in the `@timestamp` field into a string. Instead of specifying a field name inside the curly braces, use the `+FORMAT` syntax where `FORMAT` is a http://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormat.html[time format].
+Similarly, you can convert the UTC timestamp in the `@timestamp` field into a string. Instead of specifying a field name inside the curly braces, use the `+FORMAT` syntax where `FORMAT` is a http://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormat.html[time format].
 
 For example, if you want to use the file output to write to logs based on the
-event's date and hour and the `type` field:
+event's UTC date and hour and the `type` field:
 
 [source,js]
 ----------------------------------
@@ -390,6 +390,8 @@ output {
   }
 }
 ----------------------------------
+
+NOTE: A Logstash timestamp represents an instant on the UTC-timeline, so using sprintf formatters will produce results that may not align with your machine-local timezone.
 
 [discrete]
 [[conditionals]]


### PR DESCRIPTION
Backport PR #13576 to 7.17 branch.

Cherry-pick was _NOT_ clean, since 8.x/main has modifications to support nano-granularity timestamps.

Effective word-diff applied manually.

Original message: 

## Release notes

[rn:skip]

## What does this PR do?

Add notes to the Event sprintf docs about timestamp formatting to call out the
UTC nature of the Timestamp object.

## Why is it important/What is the impact to the user?

Users can be surprised when using the sprintf timestamp formatter to route to Elasticsearch indices when the resulting indices don't align with their timezone.

By calling out that the Timestamp object represents an object on the UTC timeline, and that it may not align with their machine-local timezone, we hopefully reduce confusion.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~

## Related issues

Resolves: elastic/logstash#13112
Supersedes: elastic/logstash#13571
