### PR TITLE
[backport 7.17] Adds license definitions for faraday-multipart and faraday-retry (#13592)

### DIFF
--- a/tools/dependencies-report/src/main/resources/licenseMapping.csv
+++ b/tools/dependencies-report/src/main/resources/licenseMapping.csv
@@ -50,10 +50,12 @@ dependency,dependencyUrl,licenseOverride,copyright,sourceURL
 "faraday-em_synchrony",https://github.com/lostisland/faraday,MIT
 "faraday-excon",https://github.com/lostisland/faraday,MIT
 "faraday-httpclient",https://github.com/lostisland/faraday,MIT
+"faraday-multipart",https://github.com/lostisland/faraday,MIT
 "faraday-net_http",https://github.com/lostisland/faraday,MIT
 "faraday-net_http_persistent",https://github.com/lostisland/faraday,MIT
 "faraday-patron",https://github.com/lostisland/faraday,MIT
 "faraday-rack",https://github.com/lostisland/faraday,MIT
+"faraday-retry",https://github.com/lostisland/faraday,MIT
 "ffi:",https://github.com/ffi/ffi,BSD-3-CLAUSE
 "filesize:",https://github.com/dominikh,MIT
 "gelfd2:",https://github.com/ptqa/gelfd2,Apache-2.0

--- a/tools/dependencies-report/src/main/resources/notices/faraday-multipart-NOTICE.txt
+++ b/tools/dependencies-report/src/main/resources/notices/faraday-multipart-NOTICE.txt
@@ -1,0 +1,13 @@
+source: https://github.com/lostisland/faraday-multipart/blob/v1.0.3/LICENSE.md
+
+
+The MIT License (MIT)
+
+Copyright (c) 2020 Jan van der Pas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/tools/dependencies-report/src/main/resources/notices/faraday-retry-NOTICE.txt
+++ b/tools/dependencies-report/src/main/resources/notices/faraday-retry-NOTICE.txt
@@ -1,0 +1,13 @@
+source: https://github.com/lostisland/faraday-retry/blob/v1.0.3/LICENSE.md
+
+
+The MIT License (MIT)
+
+Copyright (c) 2020 Jan van der Pas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+


### PR DESCRIPTION
Clean backport of #13592 to `7.17`

(cherry picked from commit bc760c5c073c3162201286d42211a5c3c0448187)
