### PR TITLE
[7.17] Fix unknown type warning of geoip metrics (#13382)

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -557,9 +557,11 @@ class LogStash::Agent
 
   def initialize_geoip_database_metrics(metric)
     begin
-      require_relative ::File.join(LogStash::Environment::LOGSTASH_HOME, "x-pack", "lib", "filters", "geoip", "database_manager")
-      database_manager = LogStash::Filters::Geoip::DatabaseManager.instance
-      database_manager.metric = metric.namespace([:geoip_download_manager]).tap do |n|
+      relative_path = ::File.join(LogStash::Environment::LOGSTASH_HOME, "x-pack", "lib", "filters", "geoip")
+      require_relative ::File.join(relative_path, "database_manager")
+      require_relative ::File.join(relative_path, "database_metric")
+
+      geoip_metric = metric.namespace([:geoip_download_manager]).tap do |n|
         db = n.namespace([:database])
         [:ASN, :City].each do  |database_type|
           db_type = db.namespace([database_type])
@@ -574,6 +576,10 @@ class LogStash::Agent
         dl.gauge(:last_checked_at, nil)
         dl.gauge(:status, nil)
       end
+
+      database_metric = LogStash::Filters::Geoip::DatabaseMetric.new(geoip_metric)
+      database_manager = LogStash::Filters::Geoip::DatabaseManager.instance
+      database_manager.database_metric = database_metric
     rescue LoadError => e
       @logger.trace("DatabaseManager is not in classpath")
     end

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-java_import 'org.logstash.util.JavaVersion'
+
 Thread.abort_on_exception = true
 Encoding.default_external = Encoding::UTF_8
 $DEBUGLIST = (ENV["DEBUG"] || "").split(",")
@@ -54,6 +54,7 @@ require "set"
 require 'logstash/deprecation_message'
 
 java_import 'org.logstash.FileLockFactory'
+java_import 'org.logstash.util.JavaVersion'
 
 class LogStash::Runner < Clamp::StrictCommand
   include LogStash::Util::Loggable

--- a/x-pack/lib/filters/geoip/database_metric.rb
+++ b/x-pack/lib/filters/geoip/database_metric.rb
@@ -1,0 +1,74 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+require "logstash/util/loggable"
+require_relative "util"
+require_relative "database_metadata"
+require_relative "download_manager"
+require "date"
+require "time"
+
+module LogStash module Filters module Geoip class DatabaseMetric
+  include LogStash::Util::Loggable
+  include LogStash::Filters::Geoip::Util
+
+  DATABASE_INIT = "init".freeze
+  DATABASE_UP_TO_DATE = "up_to_date".freeze
+  DATABASE_TO_BE_EXPIRED = "to_be_expired".freeze
+  DATABASE_EXPIRED = "expired".freeze
+
+  DOWNLOAD_SUCCEEDED = "succeeded".freeze
+  DOWNLOAD_FAILED = "failed".freeze
+  DOWNLOAD_UPDATING = "updating".freeze
+
+  def initialize(metric)
+    # Fallback when testing plugin and no metric collector are correctly configured.
+    @metric = metric || LogStash::Instrument::NamespacedNullMetric.new
+  end
+
+  def initialize_metrics(metadatas, states)
+    metadatas.each do |row|
+      type = row[DatabaseMetadata::Column::DATABASE_TYPE]
+      @metric.namespace([:database, type.to_sym]).tap do |n|
+        n.gauge(:status, states[type].is_eula ? DATABASE_UP_TO_DATE : DATABASE_INIT)
+        if states[type].is_eula
+          n.gauge(:last_updated_at, unix_time_to_iso8601(row[DatabaseMetadata::Column::DIRNAME]))
+          n.gauge(:fail_check_in_days, time_diff_in_days(row[DatabaseMetadata::Column::CHECK_AT]))
+        end
+      end
+    end
+
+    @metric.namespace([:download_stats]).tap do |n|
+      check_at = metadatas.map { |row| row[DatabaseMetadata::Column::CHECK_AT].to_i }.max
+      n.gauge(:last_checked_at, unix_time_to_iso8601(check_at))
+    end
+  end
+
+  def update_download_stats(success_cnt)
+    @metric.namespace([:download_stats]).tap do |n|
+      n.gauge(:last_checked_at, Time.now.iso8601)
+
+      if success_cnt == DB_TYPES.size
+        n.increment(:successes, 1)
+        n.gauge(:status, DOWNLOAD_SUCCEEDED)
+      else
+        n.increment(:failures, 1)
+        n.gauge(:status, DOWNLOAD_FAILED)
+      end
+    end
+  end
+
+  def set_download_status_updating
+    @metric.namespace([:download_stats]).gauge(:status, DOWNLOAD_UPDATING)
+  end
+
+  def update_database_status(database_type, database_status, metadata, days_without_update)
+    @metric.namespace([:database, database_type.to_sym]).tap do |n|
+      n.gauge(:status, database_status)
+      n.gauge(:last_updated_at, unix_time_to_iso8601(metadata[DatabaseMetadata::Column::DIRNAME]))
+      n.gauge(:fail_check_in_days, days_without_update)
+    end
+  end
+
+end end end end

--- a/x-pack/lib/filters/geoip/util.rb
+++ b/x-pack/lib/filters/geoip/util.rb
@@ -3,7 +3,8 @@
 # you may not use this file except in compliance with the Elastic License.
 
 require "digest"
-
+require "date"
+require "time"
 
 module LogStash module Filters
   module Geoip
@@ -47,6 +48,14 @@ module LogStash module Filters
         error_details = { :cause => e.cause }
         error_details[:backtrace] = e.backtrace if logger.debug?
         error_details
+      end
+
+      def time_diff_in_days(timestamp)
+        (::Date.today - ::Time.at(timestamp.to_i).to_date).to_i
+      end
+
+      def unix_time_to_iso8601(timestamp)
+        Time.at(timestamp.to_i).iso8601
       end
     end
   end


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Fix unknown type warning of geoip metrics (#13382)