### PR TITLE
Support env variable in condition

### DIFF
--- a/logstash-core/spec/logstash/compiler/compiler_spec.rb
+++ b/logstash-core/spec/logstash/compiler/compiler_spec.rb
@@ -52,6 +52,7 @@ describe LogStash::Compiler do
   describe "compiling imperative" do
     let(:source_id) { "fake_sourcefile" }
     let(:source_with_metadata) { org.logstash.common.SourceWithMetadata.new(source_protocol, source_id, 0, 0, source) }
+    let(:cve) { org.logstash.plugins.ConfigVariableExpander.without_secret(org.logstash.common.EnvironmentVariableProvider.default_provider()) }
     subject(:compiled) { described_class.compile_imperative(source_with_metadata, settings.get_value("config.support_escapes")) }
 
     context "when config.support_escapes" do
@@ -70,7 +71,7 @@ describe LogStash::Compiler do
       }
 
       let(:compiled_string) do
-        compiled[:input].toGraph.vertices.toArray.first.getPluginDefinition.arguments["bar"]
+        compiled[:input].toGraph(cve).vertices.toArray.first.getPluginDefinition.arguments["bar"]
       end
 
       before do

--- a/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
@@ -96,8 +96,6 @@ public final class CompiledPipeline {
      */
     private final RubyIntegration.PluginFactory pluginFactory;
 
-    private final Map<String, Expression> substitutedBoolExpCache;
-
     public CompiledPipeline(
             final PipelineIR pipelineIR,
             final RubyIntegration.PluginFactory pluginFactory)
@@ -118,7 +116,6 @@ public final class CompiledPipeline {
             inputs = setupInputs(cve);
             filters = setupFilters(cve);
             outputs = setupOutputs(cve);
-            substitutedBoolExpCache = buildBooleanExpressionCache(cve);
         } catch (Exception e) {
             throw new IllegalStateException("Unable to configure plugins: " + e.getMessage(), e);
         }
@@ -283,7 +280,7 @@ public final class CompiledPipeline {
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
-    private Map<String, Object> expandConfigVariables(ConfigVariableExpander cve, Map<String, Object> configArgs) {
+    public static Map<String, Object> expandConfigVariables(ConfigVariableExpander cve, Map<String, Object> configArgs) {
         Map<String, Object> expandedConfig = new HashMap<>();
         for (Map.Entry<String, Object> e : configArgs.entrySet()) {
             if (e.getValue() instanceof List) {
@@ -559,11 +556,9 @@ public final class CompiledPipeline {
                         // We know that it's an if vertex since the the input children are either
                         // output, filter or if in type.
                         final IfVertex ifvert = (IfVertex) dependency;
-                        final BooleanExpression substitutedBoolExp =
-                                (BooleanExpression) substitutedBoolExpCache.getOrDefault(ifvert.getId(), ifvert.getBooleanExpression());
                         final SplitDataset ifDataset = split(
                             datasets,
-                            conditionalCompiler.buildCondition(substitutedBoolExp),
+                            conditionalCompiler.buildCondition(ifvert.getBooleanExpression()),
                             dependency
                         );
                         // It is important that we double check that we are actually dealing with the

--- a/logstash-core/src/main/java/org/logstash/config/ir/PipelineIR.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/PipelineIR.java
@@ -24,11 +24,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.logstash.common.Util;
-import org.logstash.config.ir.graph.Graph;
-import org.logstash.config.ir.graph.PluginVertex;
-import org.logstash.config.ir.graph.QueueVertex;
-import org.logstash.config.ir.graph.Vertex;
-import org.logstash.config.ir.graph.SeparatorVertex;
+import org.logstash.config.ir.graph.*;
 
 public final class PipelineIR implements Hashable {
 
@@ -130,6 +126,12 @@ public final class PipelineIR implements Hashable {
         return graph.vertices()
                .filter(v -> v instanceof PluginVertex)
                .map(v -> (PluginVertex) v);
+    }
+
+    public Stream<IfVertex> ifVertices() {
+        return graph.vertices()
+                .filter(v -> v instanceof IfVertex)
+                .map(v -> (IfVertex) v);
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/config/ir/PipelineIR.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/PipelineIR.java
@@ -128,12 +128,6 @@ public final class PipelineIR implements Hashable {
                .map(v -> (PluginVertex) v);
     }
 
-    public Stream<IfVertex> ifVertices() {
-        return graph.vertices()
-                .filter(v -> v instanceof IfVertex)
-                .map(v -> (IfVertex) v);
-    }
-
     @Override
     public String uniqueHash() {
         return this.uniqueHash;

--- a/logstash-core/src/main/java/org/logstash/config/ir/expression/ExpressionSubstitution.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/expression/ExpressionSubstitution.java
@@ -1,5 +1,6 @@
 package org.logstash.config.ir.expression;
 
+import com.google.common.collect.ImmutableMap;
 import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.CompiledPipeline;
 import org.logstash.config.ir.InvalidIRException;
@@ -10,6 +11,13 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
 public class ExpressionSubstitution {
+    /**
+     * Replace ${VAR:defaultValue} in BinaryBooleanExpression, UnaryBooleanExpression and ValueExpression, excluding RegexValueExpression
+     * with the value in the following precedence: secret store, environment variable, default value
+     * @param cve The actual pattern matching take place
+     * @param expression The Expression to be substituted
+     * @return substituted Expression
+     */
     public static Expression substituteBoolExpression(ConfigVariableExpander cve, Expression expression) {
         try {
             if (expression instanceof BinaryBooleanExpression) {
@@ -28,8 +36,8 @@ public class ExpressionSubstitution {
                     return constructor.newInstance(unaryBoolExp.getSourceWithMetadata(), substitutedExp);
                 }
             } else if (expression instanceof ValueExpression && !(expression instanceof RegexValueExpression) && (((ValueExpression) expression).get() != null)) {
-                String key = "placeholder";
-                Map<String, Object> args = Map.of(key, ((ValueExpression) expression).get());
+                final String key = "placeholder";
+                Map<String, Object> args = ImmutableMap.of(key, ((ValueExpression) expression).get());
                 Map<String, Object> substitutedArgs = CompiledPipeline.expandConfigVariables(cve, args);
                 return new ValueExpression(expression.getSourceWithMetadata(), substitutedArgs.get(key));
             }

--- a/logstash-core/src/main/java/org/logstash/config/ir/expression/ExpressionSubstitution.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/expression/ExpressionSubstitution.java
@@ -1,0 +1,42 @@
+package org.logstash.config.ir.expression;
+
+import org.logstash.common.SourceWithMetadata;
+import org.logstash.config.ir.CompiledPipeline;
+import org.logstash.config.ir.InvalidIRException;
+import org.logstash.plugins.ConfigVariableExpander;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+
+public class ExpressionSubstitution {
+    public static Expression substituteBoolExpression(ConfigVariableExpander cve, Expression expression) {
+        try {
+            if (expression instanceof BinaryBooleanExpression) {
+                BinaryBooleanExpression binaryBoolExp = (BinaryBooleanExpression) expression;
+                Expression substitutedLeftExp = substituteBoolExpression(cve, binaryBoolExp.getLeft());
+                Expression substitutedRightExp = substituteBoolExpression(cve, binaryBoolExp.getRight());
+                if (substitutedLeftExp != binaryBoolExp.getLeft() || substitutedRightExp != binaryBoolExp.getRight()) {
+                    Constructor<? extends BinaryBooleanExpression> constructor = binaryBoolExp.getClass().getConstructor(SourceWithMetadata.class, Expression.class, Expression.class);
+                    return constructor.newInstance(binaryBoolExp.getSourceWithMetadata(), substitutedLeftExp, substitutedRightExp);
+                }
+            } else if (expression instanceof UnaryBooleanExpression) {
+                UnaryBooleanExpression unaryBoolExp = (UnaryBooleanExpression) expression;
+                Expression substitutedExp = substituteBoolExpression(cve, unaryBoolExp.getExpression());
+                if (substitutedExp != unaryBoolExp.getExpression()) {
+                    Constructor<? extends UnaryBooleanExpression> constructor = unaryBoolExp.getClass().getConstructor(SourceWithMetadata.class, Expression.class);
+                    return constructor.newInstance(unaryBoolExp.getSourceWithMetadata(), substitutedExp);
+                }
+            } else if (expression instanceof ValueExpression && !(expression instanceof RegexValueExpression) && (((ValueExpression) expression).get() != null)) {
+                String key = "placeholder";
+                Map<String, Object> args = Map.of(key, ((ValueExpression) expression).get());
+                Map<String, Object> substitutedArgs = CompiledPipeline.expandConfigVariables(cve, args);
+                return new ValueExpression(expression.getSourceWithMetadata(), substitutedArgs.get(key));
+            }
+
+            return expression;
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException | InvalidIRException e) {
+            throw new IllegalStateException("Unable to instantiate substituted condition expression", e);
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/config/ir/imperative/ComposedParallelStatement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/imperative/ComposedParallelStatement.java
@@ -23,6 +23,7 @@ package org.logstash.config.ir.imperative;
 import org.logstash.config.ir.InvalidIRException;
 import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.graph.Graph;
+import org.logstash.plugins.ConfigVariableExpander;
 
 import java.util.List;
 
@@ -37,11 +38,11 @@ public class ComposedParallelStatement extends ComposedStatement {
     }
 
     @Override
-    public Graph toGraph() throws InvalidIRException {
+    public Graph toGraph(ConfigVariableExpander cve) throws InvalidIRException {
         Graph g = Graph.empty();
 
         for (Statement s : getStatements()) {
-            g = Graph.combine(g, s.toGraph()).graph;
+            g = Graph.combine(g, s.toGraph(cve)).graph;
         }
 
         return g;

--- a/logstash-core/src/main/java/org/logstash/config/ir/imperative/ComposedSequenceStatement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/imperative/ComposedSequenceStatement.java
@@ -23,6 +23,7 @@ package org.logstash.config.ir.imperative;
 import org.logstash.config.ir.InvalidIRException;
 import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.graph.Graph;
+import org.logstash.plugins.ConfigVariableExpander;
 
 import java.util.List;
 
@@ -37,11 +38,11 @@ public class ComposedSequenceStatement extends ComposedStatement {
     }
 
     @Override
-    public Graph toGraph() throws InvalidIRException {
+    public Graph toGraph(ConfigVariableExpander cve) throws InvalidIRException {
         Graph g = Graph.empty();
 
         for (Statement statement : getStatements()) {
-            Graph sg = statement.toGraph();
+            Graph sg = statement.toGraph(cve);
             g = g.chain(sg);
         }
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/imperative/IfStatement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/imperative/IfStatement.java
@@ -23,11 +23,12 @@ package org.logstash.config.ir.imperative;
 import org.logstash.config.ir.SourceComponent;
 import org.logstash.config.ir.InvalidIRException;
 import org.logstash.common.SourceWithMetadata;
-import org.logstash.config.ir.expression.BooleanExpression;
+import org.logstash.config.ir.expression.*;
 import org.logstash.config.ir.graph.BooleanEdge;
 import org.logstash.config.ir.graph.Graph;
 import org.logstash.config.ir.graph.IfVertex;
 import org.logstash.config.ir.graph.Vertex;
+import org.logstash.plugins.ConfigVariableExpander;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
@@ -99,9 +100,9 @@ public class IfStatement extends Statement {
 
 
     @Override
-    public Graph toGraph() throws InvalidIRException {
-        Graph trueGraph = getTrueStatement().toGraph();
-        Graph falseGraph = getFalseStatement().toGraph();
+    public Graph toGraph(ConfigVariableExpander cve) throws InvalidIRException {
+        Graph trueGraph = getTrueStatement().toGraph(cve);
+        Graph falseGraph = getFalseStatement().toGraph(cve);
 
         // If there is nothing in the true or false sections of this if statement,
         // we can omit the if statement altogether!
@@ -114,7 +115,8 @@ public class IfStatement extends Statement {
         Collection<Vertex> trueRoots = trueGraph.roots().map(combination.oldToNewVertices::get).collect(Collectors.toList());
         Collection<Vertex> falseRoots = falseGraph.roots().map(combination.oldToNewVertices::get).collect(Collectors.toList());
 
-        IfVertex ifVertex = new IfVertex(this.getSourceWithMetadata(), this.booleanExpression);
+        IfVertex ifVertex = new IfVertex(this.getSourceWithMetadata(),
+                (BooleanExpression) ExpressionSubstitution.substituteBoolExpression(cve, this.booleanExpression));
         newGraph.addVertex(ifVertex);
 
         for (Vertex v : trueRoots) {

--- a/logstash-core/src/main/java/org/logstash/config/ir/imperative/NoopStatement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/imperative/NoopStatement.java
@@ -23,6 +23,7 @@ package org.logstash.config.ir.imperative;
 import org.logstash.config.ir.SourceComponent;
 import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.graph.Graph;
+import org.logstash.plugins.ConfigVariableExpander;
 
 public class NoopStatement extends Statement {
 
@@ -43,7 +44,7 @@ public class NoopStatement extends Statement {
     }
 
     @Override
-    public Graph toGraph() {
+    public Graph toGraph(ConfigVariableExpander cve) {
         return Graph.empty();
     }
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/imperative/PluginStatement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/imperative/PluginStatement.java
@@ -27,6 +27,7 @@ import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.graph.Graph;
 import org.logstash.config.ir.graph.PluginVertex;
 import org.logstash.config.ir.graph.Vertex;
+import org.logstash.plugins.ConfigVariableExpander;
 
 public class PluginStatement extends Statement {
     private final PluginDefinition pluginDefinition;
@@ -53,7 +54,7 @@ public class PluginStatement extends Statement {
     }
 
     @Override
-    public Graph toGraph() throws InvalidIRException {
+    public Graph toGraph(ConfigVariableExpander cve) throws InvalidIRException {
         Vertex pluginVertex = new PluginVertex(getSourceWithMetadata(), pluginDefinition);
         Graph g = Graph.empty();
         g.addVertex(pluginVertex);

--- a/logstash-core/src/main/java/org/logstash/config/ir/imperative/Statement.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/imperative/Statement.java
@@ -24,13 +24,14 @@ import org.logstash.config.ir.InvalidIRException;
 import org.logstash.config.ir.BaseSourceComponent;
 import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.graph.Graph;
+import org.logstash.plugins.ConfigVariableExpander;
 
 public abstract class Statement extends BaseSourceComponent {
     public Statement(SourceWithMetadata meta) {
         super(meta);
     }
 
-    public abstract Graph toGraph() throws InvalidIRException;
+    public abstract Graph toGraph(ConfigVariableExpander cve) throws InvalidIRException;
 
     public String toString() {
         return toString(2);

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -51,6 +51,7 @@ import org.logstash.ackedqueue.QueueFactoryExt;
 import org.logstash.ackedqueue.ext.JRubyAckedQueueExt;
 import org.logstash.ackedqueue.ext.JRubyWrappedAckedQueueExt;
 import org.logstash.common.DeadLetterQueueFactory;
+import org.logstash.common.EnvironmentVariableProvider;
 import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.ConfigCompiler;
 import org.logstash.config.ir.InvalidIRException;
@@ -62,6 +63,7 @@ import org.logstash.instrument.metrics.AbstractMetricExt;
 import org.logstash.instrument.metrics.AbstractNamespacedMetricExt;
 import org.logstash.instrument.metrics.MetricKeys;
 import org.logstash.instrument.metrics.NullMetricExt;
+import org.logstash.plugins.ConfigVariableExpander;
 import org.logstash.secret.store.SecretStore;
 import org.logstash.secret.store.SecretStoreExt;
 
@@ -183,8 +185,8 @@ public class AbstractPipelineExt extends RubyBasicObject {
             }
         }
         boolean supportEscapes = getSetting(context, "config.support_escapes").isTrue();
-        try {
-            lir = ConfigCompiler.configToPipelineIR(configParts, supportEscapes);
+        try (ConfigVariableExpander cve = new ConfigVariableExpander(getSecretStore(context), EnvironmentVariableProvider.defaultProvider())) {
+            lir = ConfigCompiler.configToPipelineIR(configParts, supportEscapes, cve);
         } catch (InvalidIRException iirex) {
             throw new IllegalArgumentException(iirex);
         }

--- a/logstash-core/src/test/java/org/logstash/config/ir/ConfigCompilerTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/ConfigCompilerTest.java
@@ -31,9 +31,11 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
+import org.logstash.common.EnvironmentVariableProvider;
 import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.graph.Graph;
 import org.logstash.config.ir.graph.PluginVertex;
+import org.logstash.plugins.ConfigVariableExpander;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -44,8 +46,9 @@ public class ConfigCompilerTest extends RubyEnvTestCase {
     @Test
     public void testConfigToPipelineIR() throws Exception {
         SourceWithMetadata swm = new SourceWithMetadata("proto", "path", 1, 1, "input {stdin{}} output{stdout{}}");
+        final ConfigVariableExpander cve = ConfigVariableExpander.withoutSecret(EnvironmentVariableProvider.defaultProvider());
         final PipelineIR pipelineIR =
-                ConfigCompiler.configToPipelineIR(Collections.singletonList(swm), false);
+                ConfigCompiler.configToPipelineIR(Collections.singletonList(swm), false, cve);
         assertThat(pipelineIR.getOutputPluginVertices().size(), is(1));
         assertThat(pipelineIR.getFilterPluginVertices().size(), is(0));
     }
@@ -95,7 +98,8 @@ public class ConfigCompilerTest extends RubyEnvTestCase {
 
     private static String graphHash(final String config) throws InvalidIRException {
         SourceWithMetadata swm = new SourceWithMetadata("proto", "path", 1, 1, config);
-        return ConfigCompiler.configToPipelineIR(Collections.singletonList(swm), false).uniqueHash();
+        final ConfigVariableExpander cve = ConfigVariableExpander.withoutSecret(EnvironmentVariableProvider.defaultProvider());
+        return ConfigCompiler.configToPipelineIR(Collections.singletonList(swm), false, cve).uniqueHash();
     }
 
     @Test
@@ -106,7 +110,7 @@ public class ConfigCompilerTest extends RubyEnvTestCase {
                 new SourceWithMetadata("str", "<empty>", 0, 0, "     ")
         );
 
-        PipelineIR pipeline = ConfigCompiler.compileSources(sourcesWithMetadata, false);
+        PipelineIR pipeline = ConfigCompiler.compileSources(sourcesWithMetadata, false, null);
 
         assertEquals("should compile only the text parts", 2L, pipeline.pluginVertices().count());
     }
@@ -119,7 +123,7 @@ public class ConfigCompilerTest extends RubyEnvTestCase {
                 new SourceWithMetadata("str","out_plugin",0,0,"output { output_0 {} } ")
         );
 
-        PipelineIR pipeline = ConfigCompiler.compileSources(sourcesWithMetadata, false);
+        PipelineIR pipeline = ConfigCompiler.compileSources(sourcesWithMetadata, false, null);
 
         assertEquals("should compile only non commented text parts", 2L, pipeline.pluginVertices().count());
     }
@@ -138,7 +142,7 @@ public class ConfigCompilerTest extends RubyEnvTestCase {
                 new SourceWithMetadata(sourceProtocol + "_" + 0, sourceId + "_" + 0, 0, 0, sources[0]),
                 new SourceWithMetadata(sourceProtocol + "_" + 1, sourceId + "_" + 1, 0, 0, sources[1]));
 
-        PipelineIR pipeline = ConfigCompiler.compileSources(sourcesWithMetadata, false);
+        PipelineIR pipeline = ConfigCompiler.compileSources(sourcesWithMetadata, false, null);
 
         assertFalse("should generate a hash", pipeline.uniqueHash().isEmpty());
         assertEquals("should provide the original source", String.join("\n", sources),
@@ -179,7 +183,8 @@ public class ConfigCompilerTest extends RubyEnvTestCase {
         PipelineIR pipelineIR = null;
         try {
             SourceWithMetadata sourceWithMetadata = new SourceWithMetadata("test_proto", "fake_sourcefile", 0, 0, source);
-            pipelineIR = ConfigCompiler.compileSources(Collections.singletonList(sourceWithMetadata), false);
+            ConfigVariableExpander cve = ConfigVariableExpander.withoutSecret(EnvironmentVariableProvider.defaultProvider());
+            pipelineIR = ConfigCompiler.compileSources(Collections.singletonList(sourceWithMetadata), false, cve);
         } catch (InvalidIRException iirex) {
             fail("error compiling " + configName + ": " + iirex.getMessage());
         }

--- a/logstash-core/src/test/java/org/logstash/config/ir/EventConditionTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/EventConditionTest.java
@@ -25,7 +25,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.logstash.RubyUtil;
+import org.logstash.common.EnvironmentVariableProvider;
 import org.logstash.ext.JrubyEventExtLibrary;
+import org.logstash.plugins.ConfigVariableExpander;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -74,6 +76,7 @@ public final class EventConditionTest extends RubyEnvTestCase {
     @Test
     @SuppressWarnings({"rawtypes", "unchecked"})
     public void testInclusionWithFieldInField() throws Exception {
+        final ConfigVariableExpander cve = ConfigVariableExpander.withoutSecret(EnvironmentVariableProvider.defaultProvider());
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
                 IRHelpers.toSourceWithMetadata("input {mockinput{}} filter { " +
                         "mockfilter {} } " +
@@ -81,8 +84,8 @@ public final class EventConditionTest extends RubyEnvTestCase {
                         "  if [left] in [right] { " +
                         "    mockoutput{}" +
                         "  } }"),
-                false
-        );
+                false,
+                cve);
 
         // left list values never match
         RubyEvent leftIsList = RubyEvent.newRubyEvent(RubyUtil.RUBY);
@@ -156,6 +159,7 @@ public final class EventConditionTest extends RubyEnvTestCase {
 
     @SuppressWarnings({"unchecked"})
     private void testConditionWithConstantValue(String condition, int expectedMatches) throws Exception {
+        final ConfigVariableExpander cve = ConfigVariableExpander.withoutSecret(EnvironmentVariableProvider.defaultProvider());
         final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
                 IRHelpers.toSourceWithMetadata("input {mockinput{}} filter { " +
                         "mockfilter {} } " +
@@ -163,8 +167,8 @@ public final class EventConditionTest extends RubyEnvTestCase {
                         "  if " + condition + " { " +
                         "    mockoutput{}" +
                         "  } }"),
-                false
-        );
+                false,
+                cve);
 
         new CompiledPipeline(
                 pipelineIR,

--- a/logstash-core/src/test/java/org/logstash/config/ir/PipelineIRTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/PipelineIRTest.java
@@ -21,8 +21,10 @@
 package org.logstash.config.ir;
 
 import org.junit.Test;
+import org.logstash.common.EnvironmentVariableProvider;
 import org.logstash.common.Util;
 import org.logstash.config.ir.graph.Graph;
+import org.logstash.plugins.ConfigVariableExpander;
 
 import static org.junit.Assert.assertEquals;
 import static org.logstash.config.ir.DSL.*;
@@ -31,13 +33,15 @@ import static org.logstash.config.ir.IRHelpers.randMeta;
 
 public class PipelineIRTest {
     public Graph makeInputSection() throws InvalidIRException {
-        return iComposeParallel(iPlugin(randMeta(), INPUT, "generator"), iPlugin(randMeta(), INPUT, "stdin")).toGraph();
+        return iComposeParallel(iPlugin(randMeta(), INPUT, "generator"), iPlugin(randMeta(), INPUT, "stdin"))
+                .toGraph(ConfigVariableExpander.withoutSecret(EnvironmentVariableProvider.defaultProvider()));
     }
 
     public Graph makeFilterSection() throws InvalidIRException {
         return iIf(randMeta(), eEq(eEventValue("[foo]"), eEventValue("[bar]")),
                                     iPlugin(randMeta(), FILTER, "grok"),
-                                    iPlugin(randMeta(), FILTER, "kv")).toGraph();
+                                    iPlugin(randMeta(), FILTER, "kv"))
+                .toGraph(ConfigVariableExpander.withoutSecret(EnvironmentVariableProvider.defaultProvider()));
     }
 
     public Graph makeOutputSection() throws InvalidIRException {
@@ -45,7 +49,8 @@ public class PipelineIRTest {
                                     iComposeParallel(
                                             iPlugin(randMeta(), OUTPUT, "s3"),
                                             iPlugin(randMeta(), OUTPUT, "elasticsearch")),
-                                    iPlugin(randMeta(), OUTPUT, "stdout")).toGraph();
+                                    iPlugin(randMeta(), OUTPUT, "stdout"))
+                .toGraph(ConfigVariableExpander.withoutSecret(EnvironmentVariableProvider.defaultProvider()));
     }
 
     @Test

--- a/logstash-core/src/test/java/org/logstash/config/ir/expression/ExpressionSubstitutionTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/expression/ExpressionSubstitutionTest.java
@@ -1,5 +1,6 @@
 package org.logstash.config.ir.expression;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import org.logstash.common.EnvironmentVariableProvider;
 import org.logstash.common.SourceWithMetadata;
@@ -81,7 +82,7 @@ public class ExpressionSubstitutionTest {
     }
 
     public Map<String, String> envVar() {
-        return Map.of("APP", "foobar", "SMALL", "1", "BIG", "100");
+        return ImmutableMap.of("APP", "foobar", "SMALL", "1", "BIG", "100");
     }
 
     public ConfigVariableExpander getConfigVariableExpander() {

--- a/logstash-core/src/test/java/org/logstash/config/ir/expression/ExpressionSubstitutionTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/expression/ExpressionSubstitutionTest.java
@@ -1,0 +1,90 @@
+package org.logstash.config.ir.expression;
+
+import org.junit.Test;
+import org.logstash.common.EnvironmentVariableProvider;
+import org.logstash.common.SourceWithMetadata;
+import org.logstash.config.ir.InvalidIRException;
+import org.logstash.config.ir.expression.binary.And;
+import org.logstash.config.ir.expression.binary.Eq;
+import org.logstash.config.ir.expression.binary.Or;
+import org.logstash.config.ir.expression.unary.Not;
+import org.logstash.plugins.ConfigVariableExpander;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class ExpressionSubstitutionTest {
+
+    @Test
+    public void basicBinaryBooleanSubstitution() throws InvalidIRException {
+        SourceWithMetadata swm = new SourceWithMetadata("proto", "path", 1, 8, "if \"${SMALL}\" == 1 { add_tag => \"pass\" }");
+        ValueExpression left = new ValueExpression(swm, "${SMALL}");
+        ValueExpression right = new ValueExpression(swm, "1");
+        BinaryBooleanExpression expression = new Eq(swm, left, right);
+
+        ConfigVariableExpander cve = getConfigVariableExpander();
+        BinaryBooleanExpression substituted = (BinaryBooleanExpression) ExpressionSubstitution.substituteBoolExpression(cve, expression);
+        assertEquals(((ValueExpression) substituted.getLeft()).get(), "1");
+    }
+
+    @Test
+    public void basicUnaryBooleanSubstitution() throws InvalidIRException {
+        SourceWithMetadata swm = new SourceWithMetadata("proto", "path", 1, 8, "if !(\"${BIG}\" == 100) { add_tag => \"not\" }");
+        ValueExpression valueExp = new ValueExpression(swm, "${BIG}");
+        UnaryBooleanExpression expression = new Not(swm, valueExp);
+
+        ConfigVariableExpander cve = getConfigVariableExpander();
+        UnaryBooleanExpression substituted = (UnaryBooleanExpression) ExpressionSubstitution.substituteBoolExpression(cve, expression);
+        assertEquals(((ValueExpression) substituted.getExpression()).get(), "100");
+    }
+
+    @Test
+    public void noRegexSubstitution() throws InvalidIRException {
+        SourceWithMetadata swm = new SourceWithMetadata("proto", "path", 1, 8, "if [version] =~ /${SMALL}/ { add_tag => \"regex\" }");
+        EventValueExpression left = new EventValueExpression(swm, "version");
+        RegexValueExpression right = new RegexValueExpression(swm, "${SMALL}");
+        BinaryBooleanExpression expression = new Eq(swm, left, right);
+
+        ConfigVariableExpander cve = getConfigVariableExpander();
+        BinaryBooleanExpression substituted = (BinaryBooleanExpression) ExpressionSubstitution.substituteBoolExpression(cve, expression);
+        assertEquals(substituted.getRight(), expression.getRight());
+    }
+
+    @Test
+    public void nestedBinaryBooleanSubstitution() throws InvalidIRException {
+        SourceWithMetadata swm = new SourceWithMetadata("proto", "path", 1, 8,
+                "if \"${SMALL}\" == 1 and 100 == \"${BIG}\" or [version] == 1 { add_tag => \"pass\" }");
+        ValueExpression smallLeft = new ValueExpression(swm, "${SMALL}");
+        ValueExpression smallRight = new ValueExpression(swm, "1");
+        BinaryBooleanExpression smallExp = new Eq(swm, smallLeft, smallRight);
+
+        ValueExpression bigLeft = new ValueExpression(swm, "100");
+        ValueExpression bigRight = new ValueExpression(swm, "${BIG}");
+        BinaryBooleanExpression bigExp = new Eq(swm, bigLeft, bigRight);
+
+        EventValueExpression versionLeft = new EventValueExpression(swm, "version");
+        ValueExpression versionRight = new ValueExpression(swm, "1");
+        BinaryBooleanExpression versionExp = new Eq(swm, versionLeft, versionRight);
+
+        And andExp = new And(swm, smallExp, bigExp);
+        Or orExp = new Or(swm, andExp, versionExp);
+
+        ConfigVariableExpander cve = getConfigVariableExpander();
+        BinaryBooleanExpression substituted = (BinaryBooleanExpression) ExpressionSubstitution.substituteBoolExpression(cve, orExp);
+        And subAnd = (And) substituted.getLeft();
+        BinaryBooleanExpression subSmallExp = (BinaryBooleanExpression) subAnd.getLeft();
+        BinaryBooleanExpression subBigExp = (BinaryBooleanExpression) subAnd.getRight();
+        assertEquals(((ValueExpression) subSmallExp.getLeft()).get(), "1");
+        assertEquals(((ValueExpression) subBigExp.getRight()).get(), "100");
+    }
+
+    public Map<String, String> envVar() {
+        return Map.of("APP", "foobar", "SMALL", "1", "BIG", "100");
+    }
+
+    public ConfigVariableExpander getConfigVariableExpander() {
+        return ConfigVariableExpander.withoutSecret(envVar()::get);
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/config/ir/imperative/IfStatementTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/imperative/IfStatementTest.java
@@ -25,15 +25,14 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import java.util.stream.Stream;
 
-import org.logstash.common.SourceWithMetadata;
+import org.logstash.common.EnvironmentVariableProvider;
 import org.logstash.config.ir.DSL;
 import org.logstash.config.ir.InvalidIRException;
 import org.logstash.config.ir.PluginDefinition;
 import org.logstash.config.ir.expression.BooleanExpression;
-import org.logstash.config.ir.expression.Expression;
 import org.logstash.config.ir.graph.*;
+import org.logstash.plugins.ConfigVariableExpander;
 
 import static org.logstash.config.ir.IRHelpers.*;
 
@@ -41,6 +40,7 @@ public class IfStatementTest {
 
     @Test
     public void testEmptyIf() throws InvalidIRException {
+        ConfigVariableExpander cve = ConfigVariableExpander.withoutSecret(EnvironmentVariableProvider.defaultProvider());
         Statement trueStatement = new NoopStatement(randMeta());
         Statement falseStatement = new NoopStatement(randMeta());
         IfStatement ifStatement = new IfStatement(
@@ -50,12 +50,13 @@ public class IfStatementTest {
                 falseStatement
         );
 
-        Graph ifStatementGraph = ifStatement.toGraph();
+        Graph ifStatementGraph = ifStatement.toGraph(cve);
         assertTrue(ifStatementGraph.isEmpty());
     }
 
     @Test
     public void testIfWithOneTrueStatement() throws InvalidIRException {
+        ConfigVariableExpander cve = ConfigVariableExpander.withoutSecret(EnvironmentVariableProvider.defaultProvider());
         PluginDefinition pluginDef = testPluginDefinition();
         Statement trueStatement = new PluginStatement(randMeta(), pluginDef);
         Statement falseStatement = new NoopStatement(randMeta());
@@ -67,7 +68,7 @@ public class IfStatementTest {
                 falseStatement
         );
 
-        Graph ifStatementGraph = ifStatement.toGraph();
+        Graph ifStatementGraph = ifStatement.toGraph(cve);
         assertFalse(ifStatementGraph.isEmpty());
         
         Graph expected = new Graph();
@@ -82,6 +83,7 @@ public class IfStatementTest {
 
     @Test
     public void testIfWithOneFalseStatement() throws InvalidIRException {
+        ConfigVariableExpander cve = ConfigVariableExpander.withoutSecret(EnvironmentVariableProvider.defaultProvider());
         PluginDefinition pluginDef = testPluginDefinition();
         Statement trueStatement = new NoopStatement(randMeta());
         Statement falseStatement = new PluginStatement(randMeta(), pluginDef);
@@ -93,7 +95,7 @@ public class IfStatementTest {
                 falseStatement
         );
 
-        Graph ifStatementGraph = ifStatement.toGraph();
+        Graph ifStatementGraph = ifStatement.toGraph(cve);
         assertFalse(ifStatementGraph.isEmpty());
 
         Graph expected = new Graph();
@@ -108,6 +110,7 @@ public class IfStatementTest {
 
     @Test
     public void testIfWithOneTrueOneFalseStatement() throws InvalidIRException {
+        ConfigVariableExpander cve = ConfigVariableExpander.withoutSecret(EnvironmentVariableProvider.defaultProvider());
         PluginDefinition pluginDef = testPluginDefinition();
         Statement trueStatement = new PluginStatement(randMeta(), pluginDef);
         Statement falseStatement = new PluginStatement(randMeta(), pluginDef);
@@ -119,7 +122,7 @@ public class IfStatementTest {
                 falseStatement
         );
 
-        Graph ifStatementGraph = ifStatement.toGraph();
+        Graph ifStatementGraph = ifStatement.toGraph(cve);
         assertFalse(ifStatementGraph.isEmpty());
 
         Graph expected = new Graph();

--- a/logstash-core/src/test/java/org/logstash/config/ir/imperative/ImperativeToGraphtest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/imperative/ImperativeToGraphtest.java
@@ -21,10 +21,12 @@
 package org.logstash.config.ir.imperative;
 
 import org.junit.Test;
+import org.logstash.common.EnvironmentVariableProvider;
 import org.logstash.config.ir.InvalidIRException;
 import org.logstash.config.ir.graph.Graph;
 import org.logstash.config.ir.graph.IfVertex;
 import org.logstash.config.ir.graph.PluginVertex;
+import org.logstash.plugins.ConfigVariableExpander;
 
 import static org.logstash.config.ir.DSL.*;
 import static org.logstash.config.ir.IRHelpers.assertSyntaxEquals;
@@ -35,7 +37,8 @@ public class ImperativeToGraphtest {
 
     @Test
     public void convertSimpleExpression() throws InvalidIRException {
-        Graph imperative =  iComposeSequence(randMeta(), iPlugin(randMeta(), FILTER, "json"), iPlugin(randMeta(), FILTER, "stuff")).toGraph();
+        ConfigVariableExpander cve = ConfigVariableExpander.withoutSecret(EnvironmentVariableProvider.defaultProvider());
+        Graph imperative =  iComposeSequence(randMeta(), iPlugin(randMeta(), FILTER, "json"), iPlugin(randMeta(), FILTER, "stuff")).toGraph(cve);
         imperative.validate(); // Verify this is a valid graph
 
         Graph regular = Graph.empty();
@@ -46,10 +49,11 @@ public class ImperativeToGraphtest {
 
     @Test
     public void testIdsDontAffectSourceComponentEquality() throws InvalidIRException {
+        ConfigVariableExpander cve = ConfigVariableExpander.withoutSecret(EnvironmentVariableProvider.defaultProvider());
         Graph imperative =  iComposeSequence(
                 iPlugin(randMeta(), FILTER, "json", "oneid"),
                 iPlugin(randMeta(), FILTER, "stuff", "anotherid")
-        ).toGraph();
+        ).toGraph(cve);
         imperative.validate(); // Verify this is a valid graph
 
         Graph regular = Graph.empty();
@@ -63,6 +67,7 @@ public class ImperativeToGraphtest {
 
     @Test
     public void convertComplexExpression() throws InvalidIRException {
+        ConfigVariableExpander cve = ConfigVariableExpander.withoutSecret(EnvironmentVariableProvider.defaultProvider());
         Graph imperative = iComposeSequence(
                 iPlugin(randMeta(), FILTER, "p1"),
                 iPlugin(randMeta(), FILTER, "p2"),
@@ -70,7 +75,7 @@ public class ImperativeToGraphtest {
                         iPlugin(randMeta(), FILTER, "p3"),
                         iComposeSequence(iPlugin(randMeta(), FILTER, "p4"), iPlugin(randMeta(), FILTER, "p5"))
                 )
-        ).toGraph();
+        ).toGraph(cve);
         imperative.validate(); // Verify this is a valid graph
 
         PluginVertex p1 = gPlugin(randMeta(), FILTER, "p1");
@@ -93,6 +98,7 @@ public class ImperativeToGraphtest {
     // partial leaves. This makes sure they all wire-up right
     @Test
     public void deepDanglingPartialLeaves() throws InvalidIRException {
+        ConfigVariableExpander cve = ConfigVariableExpander.withoutSecret(EnvironmentVariableProvider.defaultProvider());
         Graph imperative = iComposeSequence(
                  iPlugin(randMeta(), FILTER, "p0"),
                  iIf(randMeta(), eTruthy(eValue(1)),
@@ -106,7 +112,7 @@ public class ImperativeToGraphtest {
                  ),
                  iPlugin(randMeta(), FILTER, "pLast")
 
-         ).toGraph();
+         ).toGraph(cve);
         imperative.validate(); // Verify this is a valid graph
 
         IfVertex if1 = gIf(randMeta(), eTruthy(eValue(1)));
@@ -141,6 +147,7 @@ public class ImperativeToGraphtest {
     // single node
     @Test
     public void convertComplexExpressionWithTerminal() throws InvalidIRException {
+        ConfigVariableExpander cve = ConfigVariableExpander.withoutSecret(EnvironmentVariableProvider.defaultProvider());
         Graph imperative = iComposeSequence(
             iPlugin(randMeta(), FILTER, "p1"),
             iIf(randMeta(), eTruthy(eValue(1)),
@@ -154,7 +161,7 @@ public class ImperativeToGraphtest {
                 )
             ),
             iPlugin(randMeta(), FILTER, "terminal")
-        ).toGraph();
+        ).toGraph(cve);
         imperative.validate(); // Verify this is a valid graph
 
         PluginVertex p1 = gPlugin(randMeta(), FILTER,"p1");

--- a/logstash-core/src/test/java/org/logstash/plugins/factory/PluginFactoryExtTest.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/factory/PluginFactoryExtTest.java
@@ -25,12 +25,14 @@ import org.jruby.RubyString;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.junit.Test;
 import org.logstash.RubyUtil;
+import org.logstash.common.EnvironmentVariableProvider;
 import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.ConfigCompiler;
 import org.logstash.config.ir.InvalidIRException;
 import org.logstash.config.ir.PipelineIR;
 import org.logstash.config.ir.RubyEnvTestCase;
 import org.logstash.instrument.metrics.NamespacedMetricExt;
+import org.logstash.plugins.ConfigVariableExpander;
 import org.logstash.plugins.MetricTestCase;
 import org.logstash.plugins.PluginLookup;
 
@@ -106,7 +108,8 @@ public final class PluginFactoryExtTest extends RubyEnvTestCase {
     }
 
     private static PipelineIR compilePipeline(SourceWithMetadata sourceWithMetadata) throws InvalidIRException {
-        return ConfigCompiler.configToPipelineIR(Collections.singletonList(sourceWithMetadata), false);
+        final ConfigVariableExpander cve = ConfigVariableExpander.withoutSecret(EnvironmentVariableProvider.defaultProvider());
+        return ConfigCompiler.configToPipelineIR(Collections.singletonList(sourceWithMetadata), false, cve);
     }
 
     private static ExecutionContextFactoryExt createExecutionContextFactory() {

--- a/qa/integration/fixtures/env_variables_condition_spec.yml
+++ b/qa/integration/fixtures/env_variables_condition_spec.yml
@@ -1,0 +1,77 @@
+---
+services:
+  - logstash
+config: |-
+ input {
+    generator {
+      lines => ['{"app": "foobar", "amount": "100", "version": 1, "tag1": "mytag1"}']
+      count => 1
+    }
+  }
+  filter {
+    json {
+       source => "message"
+    }
+
+    if [tag1] == "${TAG1}" {
+       mutate { add_tag => ["${TAG1}"] }
+    }
+    if ("${APP}") {
+       mutate { add_tag => ["Truthy"] }
+    }
+    if !([version] == "${BIG}") {
+       mutate { add_tag => ["Not"] }
+    }
+    if "${BIG}" > "${SMALL}" {
+       mutate { add_tag => [">"] }
+    }
+    if "${BIG}" >= "100" {
+       mutate { add_tag => [">="] }
+    }
+    if "${SMALL}" < "${BIG}" {
+       mutate { add_tag => ["<"] }
+    }
+    if "${SMALL}" <= "1" {
+       mutate { add_tag => ["<="] }
+    }
+    if [app] == "${APP}" {
+       mutate { add_tag => ["=="] }
+    }
+    if "${SMALL}" != "${BIG}" {
+       mutate { add_tag => ["!="] }
+    }
+    if [amount] in ["${SMALL}", "${BIG}"] {
+       mutate { add_tag => ["in"] }
+    }
+    if [amount] not in ["${SMALL}", "2", "3"] {
+       mutate { add_tag => ["not in"] }
+    }
+    if [amount] =~ /\d+/ {
+       mutate { add_tag => ["=~"] }
+    }
+    if [amount] !~ /[a-z]+/ {
+       mutate { add_tag => ["!~"] }
+    }
+    if ([app] == "${APP}") and ([app] == "foobar") {
+       mutate { add_tag => ["and"] }
+    }
+    if ([app] == "${APP}") and ([amount] == "${BIG}") and ([version] == 1) and [tag1] == "${TAG1}" {
+       mutate { add_tag => ["more_and"] }
+    }
+    if (1 > 2) or ([app] == "${APP}") {
+       mutate { add_tag => ["or"] }
+    }
+    if ([app] == "${APP}") nand (1 > 2) {
+       mutate { add_tag => ["nand"] }
+    }
+    if (1 > 2) xor ([app] == "${APP}") {
+       mutate { add_tag => ["xor"] }
+    }
+  }
+  output {
+    file {
+      path => "${TEST_ENV_PATH}/env_variables_condition_output.log"
+      flush_interval => 0
+      codec => line { format => "%{message} %{tags}" }
+    }
+  }

--- a/qa/integration/fixtures/env_variables_condition_spec.yml
+++ b/qa/integration/fixtures/env_variables_condition_spec.yml
@@ -13,9 +13,6 @@ config: |-
        source => "message"
     }
 
-    if [tag1] == "${TAG1}" {
-       mutate { add_tag => ["${TAG1}"] }
-    }
     if ("${APP}") {
        mutate { add_tag => ["Truthy"] }
     }
@@ -48,6 +45,9 @@ config: |-
     }
     if [amount] =~ /\d+/ {
        mutate { add_tag => ["=~"] }
+    }
+    if [amount] =~ /${BIG}/ {
+       mutate { add_tag => ["wrong_regex_substitution"] }
     }
     if [amount] !~ /[a-z]+/ {
        mutate { add_tag => ["!~"] }

--- a/qa/integration/specs/env_variables_condition_spec.rb
+++ b/qa/integration/specs/env_variables_condition_spec.rb
@@ -1,0 +1,78 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require_relative '../framework/fixture'
+require_relative '../framework/settings'
+require_relative '../services/logstash_service'
+require_relative '../framework/helpers'
+require "logstash/devutils/rspec/spec_helper"
+
+### Logstash Keystore notes #############
+# The logstash.keystore password is `keystore_pa9454w3rd` and contains the following entries:
+# input.count = 10
+# output.path = mypath
+# pipeline.id = mypipeline
+# tag1 = mytag1
+# tag2 = mytag2
+# tag3 = mytag3
+####################################
+describe "Support environment variable in condition" do
+  before(:all) {
+    @fixture = Fixture.new(__FILE__)
+  }
+
+  before(:each) {
+    @logstash = @fixture.get_service("logstash")
+    IO.write(File.join(settings_dir, "logstash.yml"), YAML.dump(settings))
+    FileUtils.cp(File.expand_path("../../logstash.keystore", __FILE__), settings_dir)
+  }
+
+  after(:all) {
+    @fixture.teardown
+  }
+
+  after(:each) {
+    @logstash.teardown
+  }
+  
+  let(:num_retries) { 50 }
+  let(:test_path) { Stud::Temporary.directory }
+  let(:test_env) {
+    env = Hash.new
+    env["BIG"] = "100"
+    env["SMALL"] = "1"
+    env["APP"] = 'foobar'
+    env
+  }
+  let(:settings_dir) { Stud::Temporary.directory }
+  let(:settings) {{"pipeline.id" => "${pipeline.id}"}}
+  let(:logstash_keystore_passowrd) { "keystore_pa9454w3rd" }
+
+  it "expands environment variables in secret store, ENV" do
+    test_env["TEST_ENV_PATH"] = test_path
+    test_env["LOGSTASH_KEYSTORE_PASS"] = logstash_keystore_passowrd
+    test_env['TAG1'] = "wrong_tag" # secret store should take precedence
+
+    @logstash.env_variables = test_env
+    @logstash.start_background_with_config_settings(config_to_temp_file(@fixture.config), settings_dir)
+
+    Stud.try(num_retries.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
+      output = IO.read(File.join(test_path, "env_variables_condition_output.log")).gsub("\n", "")
+      expect(output).to match /mytag1,Truthy,Not,>,>=,<,<=,==,!=,in,not in,=~,!~,and,more_and,or,nand,xor/
+    end
+  end
+end  

--- a/qa/integration/specs/secret_store_spec.rb
+++ b/qa/integration/specs/secret_store_spec.rb
@@ -54,10 +54,11 @@ describe "Test that Logstash" do
   let(:test_env) {Hash.new}
   let(:settings_dir) {Stud::Temporary.directory}
   let(:settings) {{"pipeline.id" => "${pipeline.id}"}}
+  let(:logstash_keystore_passowrd) { "keystore_pa9454w3rd" }
 
   it "expands secret store variables from config" do
     test_env["TEST_ENV_PATH"] = test_path
-    test_env["LOGSTASH_KEYSTORE_PASS"] = "keystore_pa9454w3rd"
+    test_env["LOGSTASH_KEYSTORE_PASS"] = logstash_keystore_passowrd
     @logstash.env_variables = test_env
     @logstash.start_background_with_config_settings(config_to_temp_file(@fixture.config), settings_dir)
     Stud.try(num_retries.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
@@ -67,7 +68,7 @@ describe "Test that Logstash" do
   end
 
   it "expands secret store variables from settings" do
-    test_env["LOGSTASH_KEYSTORE_PASS"] = "keystore_pa9454w3rd"
+    test_env["LOGSTASH_KEYSTORE_PASS"] = logstash_keystore_passowrd
     @logstash.env_variables = test_env
     @logstash.spawn_logstash("-e", "input {heartbeat {}} output { }", "--path.settings", settings_dir)
     Stud.try(num_retries.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
@@ -77,6 +78,13 @@ describe "Test that Logstash" do
       mypipeline = result.fetch('pipelines').fetch('mypipeline')
       expect(mypipeline).not_to be_nil
     end
+  end
+
+  it "won't show secret value when pipeline definition is wrong" do
+    test_env["LOGSTASH_KEYSTORE_PASS"] = logstash_keystore_passowrd
+    logstash = @logstash.run_cmd(["bin/logstash","-e", "input { http { user => test password => \"${tag1}\" port = \"3333\" }}", "--path.settings", settings_dir], true, test_env)
+    expect(logstash.stderr_and_stdout).to match(/\[ERROR\]/)
+    expect(logstash.stderr_and_stdout).to match(/\\"\$\{tag1\}\\"/)
   end
 
   context "won't start" do
@@ -94,7 +102,7 @@ describe "Test that Logstash" do
   context "won't start " do
     let(:settings) {{"pipeline.id" => "${missing}"}}
     it "with correct password, but invalid variable " do
-      test_env["LOGSTASH_KEYSTORE_PASS"] = "keystore_pa9454w3rd"
+      test_env["LOGSTASH_KEYSTORE_PASS"] = logstash_keystore_passowrd
       @logstash.env_variables = test_env
       @logstash.spawn_logstash("-e", "input {stdin {}} output { }", "--path.settings", settings_dir)
       try(num_retries) do

--- a/x-pack/spec/monitoring/inputs/metrics/state_event/lir_serializer_spec.rb
+++ b/x-pack/spec/monitoring/inputs/metrics/state_event/lir_serializer_spec.rb
@@ -21,10 +21,11 @@ describe ::LogStash::Config::LIRSerializer do
     [org.logstash.common.SourceWithMetadata.new("string", "spec", config)]
   end
 
+  let(:cve) { org.logstash.plugins.ConfigVariableExpander.without_secret(org.logstash.common.EnvironmentVariableProvider.default_provider()) }
   let(:lir_pipeline) do
 #     ::LogStash::Compiler.compile_sources(config_source_with_metadata, true)
     java_import org.logstash.config.ir.ConfigCompiler
-    ConfigCompiler.compileSources(config_source_with_metadata, true)
+    ConfigCompiler.compileSources(config_source_with_metadata, true, cve)
   end
 
   describe "#serialize" do


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Support environment variable in condition.

## Motivation

Two substitutions in ruby side cause inconsistent precedence when resolving the variable.
In the past, `${VAR:default_value}` is resolved in the following precedence: secret store -> environment variable -> default value.
After two substitutions, (first substitute)  environment variable -> default value -> (second substitute) secret store
The inconsistency could confuse users.

To truly support `if` with value in secret store, this commit implement substitution in java side 

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

This PR substitutes ${VAR} in Expression, except RegexValueExpression, with the value in secret store, env. 
The substitution happens after syntax parsing and before graph execution.


## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

This PR allows users to use environment variable in condition, eg. `if [app] == "${VAR}"` 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- checked expressions. `()`, `!()`, `>`, `>=`, `<`, `<=`, `==`, `!=`, `in`, `not in`, `=~`, `!~`, `and`, `or`, `nand`, `xor`
- regex `/${VAR}/` is not expected to do substitution
- checked multiple `and`. () and () and ()
- secret value deso not show in plain text when the pipeline config has syntax error
- undefined env variable show error msg when Logstash start 

## Known Limitation
Substitution only evaluates ${VAR} to string.
`if [app] == "${VAR}"` is a valid statement. VAR is resolved as a string.
`if [app] == 1` is a valid statement, but `if [app] == ${VAR}` is a wrong syntax. VAR cannot be evaluated to a number, hence cannot do number comparison.
This is the same behavior as of now.  The following count is a string and cannot be a number
```
generator {
  count => "${count}"
}
```
## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
```
input {
	generator {
		lines => ['{"app": "foobar"}']
	}
}
filter {
	json {
		source => "message"
	}
	if [app] == "${VAR}" {
		mutate { add_tag => ["a_tag"] }
	}
}
output {
	stdout { codec => rubydebug }
}
```

run logstash with above config should see `tag` 
$ VAR=foobar bin/logstash 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
Fixed: #5115
## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
