### PR TITLE
[backport 7.17]Avoid to itereate with each_index (#13603)

### DIFF
--- a/logstash-core/lib/logstash/util/substitution_variables.rb
+++ b/logstash-core/lib/logstash/util/substitution_variables.rb
@@ -37,8 +37,9 @@ module ::LogStash::Util::SubstitutionVariables
       end
     else
       if value.is_a?(Array)
-        value.each_index do | valueArrayIndex|
-          value[valueArrayIndex] = deep_replace(value[valueArrayIndex])
+        value_array_index = 0
+        value.each_with_index do |single_value, i|
+          value[i] = deep_replace(single_value)
         end
       else
         return replace_placeholders(value)


### PR DESCRIPTION
Clean backport of #13603 to branch `7.17`
(cherry picked from commit e27fdeb25221419ffd2051f77ae3e7240e6378a7)
