### PR TITLE
Doc: Forwardport 7.16.2 and 7.16.1 release notes to 7.17

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -3,6 +3,8 @@
 
 This section summarizes the changes in the following releases:
 
+* <<logstash-7-16-3,Logstash 7.16.3>>
+* <<logstash-7-16-2,Logstash 7.16.2>>
 * <<logstash-7-16-1,Logstash 7.16.1>>
 * <<logstash-7-16-0,Logstash 7.16.0>>
 * <<logstash-7-15-2,Logstash 7.15.2>>
@@ -55,6 +57,92 @@ This section summarizes the changes in the following releases:
 * <<logstash-7-0-0-beta1,Logstash 7.0.0-beta1>>
 * <<logstash-7-0-0-alpha2,Logstash 7.0.0-alpha2>>
 * <<logstash-7-0-0-alpha1,Logstash 7.0.0-alpha1>>
+
+[[logstash-7-16-3]]
+=== Logstash 7.16.3 Release Notes
+
+* Bump log4j dependency to 2.17.1 https://github.com/elastic/logstash/pull/13567[#13567]
+
+==== Plugins
+
+*Date Filter - 3.1.14*
+
+* Update log4j to 2.17.1
+
+*Dissect Filter - 1.2.4*
+
+* Update log4j dependencies to 2.17.1
+
+*Geoip Filter - 7.2.9*
+
+* Update Log4j dependency to 2.17.1
+
+*Azure_event_hubs Input - 1.4.3*
+
+* Build: make log4j-api a provided dependency https://github.com/logstash-plugins/logstash-input-azure_event_hubs/pull/73[#73]
+
+*Beats Input - 6.2.5*
+
+* Build: do not package log4j-api dependency https://github.com/logstash-plugins/logstash-input-beats/pull/441[#441].
+   Logstash provides the log4j framework and the dependency is not needed except testing and compiling.
+
+*Dead_letter_queue Input - 1.1.8*
+
+* Update dependencies for log4j to 2.17.1
+
+*Http Input - 3.4.5*
+
+* Build: do not package log4j-api dependency https://github.com/logstash-plugins/logstash-input-http/pull/149[#149].
+   Logstash provides the log4j framework and the dependency is not needed except testing and compiling.
+
+*Tcp Input - 6.2.6*
+
+* [DOC] Fix incorrect pipeline code snippet https://github.com/logstash-plugins/logstash-input-tcp/pull/194[#194]
+* Update log4j dependency to 2.17.1 https://github.com/logstash-plugins/logstash-input-tcp/pull/196[#196]
+  
+
+[[logstash-7-16-2]]
+=== Logstash 7.16.2 Release Notes
+
+* Update to log4j 2.17.0 https://github.com/elastic/logstash/pull/13548[#13548]
+
+==== Plugins
+
+*Date Filter - 3.1.13*
+
+* Update log4j to 2.17.0
+* Ensure java 8 compatibility https://github.com/logstash-plugins/logstash-filter-date/pull/143[#143]
+
+*Dissect Filter - 1.2.3*
+
+* Update log4j dependencies to 2.17.0
+
+*Geoip Filter - 7.2.8*
+
+* Update Log4j dependency to 2.17.0
+* Ensure java 8 compatibility https://github.com/logstash-plugins/logstash-filter-geoip/pull/197[#197]
+
+*Azure_event_hubs Input - 1.4.2*
+
+* Update log4j dependencies to 2.17.0
+
+*Beats Input - 6.2.4*
+
+* Updated log4j dependency to 2.17.0
+
+*Dead_letter_queue Input - 1.1.7*
+
+* Further update dependencies for log4j (2.17.0) and jackson
+
+*Http Input - 3.4.4*
+
+* Update log4j dependency to 2.17.0
+
+*Tcp Input - 6.2.5*
+
+* Update log4j dependency to 2.17.0
+* Ensure this plugin's runtime relies only on log4j-api instead of providing its own log4j-core. https://github.com/logstash-plugins/logstash-input-tcp/pull/188[#188]
+
 
 [[logstash-7-16-1]]
 === Logstash 7.16.1 Release Notes


### PR DESCRIPTION
Forwardports release notes in #13600 to 7.17
Forwardports release notes in #13551 (through conflict resolution) to 7.17

**PREVIEW:** https://logstash_13611.docs-preview.app.elstc.co/guide/en/logstash/7.17/releasenotes.html