### PR TITLE
[Docs] Add pipeline.ecs_compatibility to the list

### DIFF
--- a/docs/static/running-logstash-command-line.asciidoc
+++ b/docs/static/running-logstash-command-line.asciidoc
@@ -155,9 +155,13 @@ With this command, Logstash concatenates three config files, `/tmp/one`, `/tmp/t
   to filters and outputs. The default is 50ms.
   
   *`--pipeline.ecs_compatibility MODE`*::
-  Sets the ECS compatibility mode for the whole Logstash process, see <<ecs-compatibility>>.
-  Can be an ECS version like `v8` or `disabled`.
-  The default depends on the individual plugins.
+  Sets the process default value for  ECS compatibility mode.
+  Can be an ECS version like `v1` or `v8`, or `disabled`.
+  The default is `v8`.
+  Pipelines defined before Logstash 8 operated without ECS in mind.
+  To ensure a migrated pipeline continues to operate as it did in older releases of Logstash, opt-OUT of ECS for the individual pipeline by setting `pipeline.ecs_compatibility: disabled` in its `pipelines.yml` definition.
+  Using the command-line flag will set the default for _all_ pipelines, including new ones.
+  See <<ecs-compatibility>> for more info.
 
 *`--pipeline.unsafe_shutdown`*::
   Force Logstash to exit during shutdown even if there are still inflight events

--- a/docs/static/running-logstash-command-line.asciidoc
+++ b/docs/static/running-logstash-command-line.asciidoc
@@ -153,6 +153,11 @@ With this command, Logstash concatenates three config files, `/tmp/one`, `/tmp/t
   When creating pipeline batches, how long to wait while polling for the next event. This option defines
   how long in milliseconds to wait while polling for the next event before dispatching an undersized batch
   to filters and outputs. The default is 50ms.
+  
+  *`--pipeline.ecs_compatibility MODE`*::
+  Sets the ECS compatibility mode for the whole Logstash process, see <<ecs-compatibility>>.
+  Can be an ECS version like `v8` or `disabled`.
+  The default depends on the individual plugins.
 
 *`--pipeline.unsafe_shutdown`*::
   Force Logstash to exit during shutdown even if there are still inflight events


### PR DESCRIPTION
Adding the `pipeline.ecs_compatibility` setting from https://www.elastic.co/guide/en/logstash/current/ecs-ls.html and https://github.com/elastic/logstash/blob/7.16/logstash-core/lib/logstash/runner.rb#L163 to the list of available command line options. This is important because with 7.16 this will lead to a lot of deprecation logging like 
````
Relying on default value of `pipeline.ecs_compatibility`, which may change in a future major release of Logstash. To avoid unexpected changes when upgrading Logstash, please explicitly declare your desired ECS Compatibility mode.
````
