### PR TITLE
don't retrieve the secret before purging

### DIFF
--- a/logstash-core/src/main/java/org/logstash/secret/cli/SecretStoreCli.java
+++ b/logstash-core/src/main/java/org/logstash/secret/cli/SecretStoreCli.java
@@ -149,13 +149,11 @@ public class SecretStoreCli {
                 SecretIdentifier id = new SecretIdentifier(argument);
 
                 SecretStore secretStore = secretStoreFactory.load(config);
-                byte[] s = secretStore.retrieveSecret(id);
-                if (s == null) {
-                    terminal.writeLine(String.format("ERROR: '%s' does not exist in the Logstash keystore.", argument));
-                } else {
-                    SecretStoreUtil.clearBytes(s);
+                if (secretStore.containsSecret(id)) {
                     secretStore.purgeSecret(id);
                     terminal.writeLine(String.format("Removed '%s' from the Logstash keystore.", id.getKey()));
+                } else {
+                    terminal.writeLine(String.format("ERROR: '%s' does not exist in the Logstash keystore.", argument));
                 }
                 break;
             }

--- a/logstash-core/src/main/java/org/logstash/secret/store/SecretStore.java
+++ b/logstash-core/src/main/java/org/logstash/secret/store/SecretStore.java
@@ -94,4 +94,11 @@ public interface SecretStore {
      */
     byte[] retrieveSecret(SecretIdentifier id);
 
+    /**
+     * Check if a secret exists in the store.
+     *
+     * @param id The {@link SecretIdentifier} to identify the secret to find
+     * @return true if a secret exists, false otherwise
+     */
+    boolean containsSecret(SecretIdentifier id);
 }

--- a/logstash-core/src/main/java/org/logstash/secret/store/backend/JavaKeyStore.java
+++ b/logstash-core/src/main/java/org/logstash/secret/store/backend/JavaKeyStore.java
@@ -352,6 +352,17 @@ public final class JavaKeyStore implements SecretStore {
         }
     }
 
+    @Override
+    public boolean containsSecret(SecretIdentifier identifier) {
+        try {
+            loadKeyStore();
+            return keyStore.containsAlias(identifier.toExternalForm());
+        } catch (Exception e) {
+            throw new SecretStoreException.LoadException(String.format("Found a keystore at %s, but failed to load it.",
+                    keyStorePath.toAbsolutePath().toString()));
+        }
+    }
+
     private void releaseLock(Lock lock) {
         if (lock != null) {
             lock.unlock();

--- a/logstash-core/src/test/java/org/logstash/secret/store/SecretStoreFactoryTest.java
+++ b/logstash-core/src/test/java/org/logstash/secret/store/SecretStoreFactoryTest.java
@@ -197,6 +197,9 @@ public class SecretStoreFactoryTest {
         }
 
         @Override
+        public boolean containsSecret(SecretIdentifier id) { return secrets.containsKey(id); }
+
+        @Override
         public byte[] retrieveSecret(SecretIdentifier id) {
             ByteBuffer bb = secrets.get(id);
             return bb != null ? bb.array() : null;


### PR DESCRIPTION
It's possible that directly editing the keystore can cause secrets to become corrupted. If so, removing them is difficult if it's first necessary to retrieve the secret before purging.

This PR changes the purge action to only check if a secret exists instead of retrieving it.