### PR TITLE
fix PipelineIR.getPostQueue by accounting for vertex copies

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/PipelineIR.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/PipelineIR.java
@@ -41,7 +41,7 @@ public final class PipelineIR implements Hashable {
 
     private final Graph graph;
 
-    private QueueVertex queue;
+    private final QueueVertex queue;
 
     // Temporary until we have LIR execution
     // Then we will no longer need this property here
@@ -70,12 +70,7 @@ public final class PipelineIR implements Hashable {
         // Finally, connect the filter out node to all the outputs
         this.graph = tempGraph.chain(outputSection);
 
-        try {
-            queue = (QueueVertex) this.graph.getVertexById(tempQueue.getId());
-        } catch(NoSuchElementException e) {
-            // it's a pipeline without a queue
-            queue = tempQueue;
-        }
+        this.queue = selectQueueVertex(this.graph, tempQueue);
 
         this.graph.validate();
 
@@ -140,5 +135,14 @@ public final class PipelineIR implements Hashable {
     @Override
     public String uniqueHash() {
         return this.uniqueHash;
+    }
+
+    private static QueueVertex selectQueueVertex(final Graph graph, final QueueVertex tempQueue) {
+        try {
+            return (QueueVertex) graph.getVertexById(tempQueue.getId());
+        } catch(NoSuchElementException e) {
+            // it's a pipeline without a queue
+            return tempQueue;
+        }
     }
 }

--- a/logstash-core/src/main/java/org/logstash/config/ir/PipelineIR.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/PipelineIR.java
@@ -56,8 +56,9 @@ public final class PipelineIR implements Hashable {
         Graph tempGraph = inputSection.copy(); // The input section are our roots, so we can import that wholesale
 
         // Connect all the input vertices out to the queue
-        queue = new QueueVertex();
-        tempGraph = tempGraph.chain(queue);
+        QueueVertex tempQueue = new QueueVertex();
+
+        tempGraph = tempGraph.chain(tempQueue);
 
         // Now we connect the queue to the root of the filter section
         tempGraph = tempGraph.chain(filterSection);
@@ -67,6 +68,8 @@ public final class PipelineIR implements Hashable {
 
         // Finally, connect the filter out node to all the outputs
         this.graph = tempGraph.chain(outputSection);
+
+        queue = (QueueVertex) this.graph.getVertexById(tempQueue.getId());
 
         this.graph.validate();
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/PipelineIR.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/PipelineIR.java
@@ -21,6 +21,7 @@
 package org.logstash.config.ir;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.logstash.common.Util;
@@ -40,7 +41,7 @@ public final class PipelineIR implements Hashable {
 
     private final Graph graph;
 
-    private final QueueVertex queue;
+    private QueueVertex queue;
 
     // Temporary until we have LIR execution
     // Then we will no longer need this property here
@@ -69,7 +70,12 @@ public final class PipelineIR implements Hashable {
         // Finally, connect the filter out node to all the outputs
         this.graph = tempGraph.chain(outputSection);
 
-        queue = (QueueVertex) this.graph.getVertexById(tempQueue.getId());
+        try {
+            queue = (QueueVertex) this.graph.getVertexById(tempQueue.getId());
+        } catch(NoSuchElementException e) {
+            // it's a pipeline without a queue
+            queue = tempQueue;
+        }
 
         this.graph.validate();
 

--- a/logstash-core/src/test/java/org/logstash/config/ir/PipelineIRTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/PipelineIRTest.java
@@ -25,8 +25,13 @@ import org.logstash.common.EnvironmentVariableProvider;
 import org.logstash.common.Util;
 import org.logstash.config.ir.graph.Graph;
 import org.logstash.plugins.ConfigVariableExpander;
+import org.logstash.config.ir.graph.QueueVertex;
 
+import static org.hamcrest.Matchers.any;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.logstash.config.ir.DSL.*;
 import static org.logstash.config.ir.PluginDefinition.Type.*;
 import static org.logstash.config.ir.IRHelpers.randMeta;
@@ -72,5 +77,12 @@ public class PipelineIRTest {
         String source = "input { stdin {} } output { stdout {} }";
         PipelineIR pipelineIR = new PipelineIR(makeInputSection(), makeFilterSection(), makeOutputSection(), source);
         assertEquals(pipelineIR.uniqueHash(), Util.digest(source));
+    }
+
+    @Test
+    public void testGetPostQueue() throws InvalidIRException {
+        String source = "input { stdin {} } output { stdout {} }";
+        PipelineIR pipelineIR = new PipelineIR(makeInputSection(), makeFilterSection(), makeOutputSection(), source);
+        assertThat(pipelineIR.getPostQueue(), not(hasItem(any(QueueVertex.class))));
     }
 }


### PR DESCRIPTION
During graph composition vertices may be copied. This caused
getPostQueue to malfunction as the QueueVertex object stored in the
PipelineIR isn't the one present in the graph once it's fully generated.

This object mismatch caused Graph.getSortedVerticesBetween to not find
the QueueVertex since it takes Objects instead of ids.

This commit waits for the graph to be built and then retrieves the
QueueVertex from the graph and sets it in PipelineIR.

#### How to test:

```
❯ git pr 13621
❯ ./gradlew assemble javaTests --tests org.logstash.config.ir.PipelineIRTest.testGetPostQueue

--------------------------------------------------------------------
|  Results: SUCCESS (1 tests, 1 successes, 0 failures, 0 skipped)  |
--------------------------------------------------------------------

❯ git co main logstash-core/src/main/
Updated 1 path from 6e039f5b8

❯ ./gradlew assemble javaTests --tests org.logstash.config.ir.PipelineIRTest.testGetPostQueue

--------------------------------------------------------------------
|  Results: FAILURE (1 tests, 0 successes, 1 failures, 0 skipped)  |
--------------------------------------------------------------------
```