### PR TITLE
[backport 8.0] Avoid to increment `event.out` conter for dropped events (#13593)

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ConvertedMap.java
+++ b/logstash-core/src/main/java/org/logstash/ConvertedMap.java
@@ -28,7 +28,6 @@ import org.jruby.RubyHash;
 import org.jruby.RubyString;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.logstash.execution.WorkerLoop;
 
 /**
  * <p>This class is an internal API and behaves very different from a standard {@link Map}.</p>

--- a/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
+++ b/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
@@ -84,10 +84,10 @@ public final class WorkerLoop implements Runnable {
                 if (batch.filteredSize() > 0 || isFlush) {
                     consumedCounter.add(batch.filteredSize());
                     readClient.startMetrics(batch);
-                    execution.compute(batch, isFlush, false);
+                    final int outputCount = execution.compute(batch, isFlush, false);
                     int filteredCount = batch.filteredSize();
                     filteredCounter.add(filteredCount);
-                    readClient.addOutputMetrics(filteredCount);
+                    readClient.addOutputMetrics(outputCount);
                     readClient.addFilteredMetrics(filteredCount);
                     readClient.closeBatch(batch);
                     if (isFlush) {

--- a/logstash-core/src/test/java/org/logstash/ext/JrubyMemoryReadClientExtTest.java
+++ b/logstash-core/src/test/java/org/logstash/ext/JrubyMemoryReadClientExtTest.java
@@ -27,7 +27,6 @@ import org.jruby.RubyHash;
 import org.jruby.runtime.ThreadContext;
 import org.junit.Test;
 import org.logstash.execution.QueueBatch;
-import org.logstash.execution.WorkerLoop;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/qa/integration/fixtures/monitoring_api_spec.yml
+++ b/qa/integration/fixtures/monitoring_api_spec.yml
@@ -2,3 +2,36 @@
 name: Metrics test
 services:
   - logstash
+config:
+  dropping_events: |-
+    input {
+      tcp {
+        port => '<%=options[:port]%>'
+        type => 'type1'
+      }
+    }
+
+    filter {
+      drop { }
+    }
+
+    output {
+      stdout { }
+    }
+  cloning_events: |-
+    input {
+      tcp {
+        port => '<%=options[:port]%>'
+        type => 'type1'
+      }
+    }
+
+    filter {
+      clone {
+        clones => ["sun", "moon"]
+      }
+    }
+
+    output {
+      stdout { }
+    }

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -17,6 +17,7 @@
 
 require_relative '../framework/fixture'
 require_relative '../framework/settings'
+require_relative '../framework/helpers'
 require_relative '../services/logstash_service'
 require "logstash/devutils/rspec/spec_helper"
 require "stud/try"
@@ -48,6 +49,52 @@ describe "Test Monitoring API" do
       result = logstash_service.monitoring_api.event_stats rescue nil
       expect(result).not_to be_nil
       expect(result["in"]).to eq(number_of_events)
+    end
+  end
+
+  context "verify global event counters" do
+    let(:tcp_port) { random_port }
+    let(:sample_data) { 'Hello World!' }
+    let(:logstash_service) { @fixture.get_service("logstash") }
+
+    before(:each) do
+      logstash_service.spawn_logstash("-w", "1" , "-e", config)
+      logstash_service.wait_for_logstash
+      wait_for_port(tcp_port, 60)
+
+      send_data(tcp_port, sample_data)
+    end
+
+    context "when a drop filter is in the pipeline" do
+      let(:config) { @fixture.config("dropping_events", { :port => tcp_port } ) }
+
+      it 'expose the correct output counter' do
+        try(max_retry) do
+          # node_stats can fail if the stats subsystem isn't ready
+          result = logstash_service.monitoring_api.node_stats rescue nil
+          expect(result).not_to be_nil
+          expect(result["events"]).not_to be_nil
+          expect(result["events"]["in"]).to eq(1)
+          expect(result["events"]["filtered"]).to eq(1)
+          expect(result["events"]["out"]).to eq(0)
+        end
+      end
+    end
+
+    context "when a clone filter is in the pipeline" do
+      let(:config) { @fixture.config("cloning_events", { :port => tcp_port } ) }
+
+      it 'expose the correct output counter' do
+        try(max_retry) do
+          # node_stats can fail if the stats subsystem isn't ready
+          result = logstash_service.monitoring_api.node_stats rescue nil
+          expect(result).not_to be_nil
+          expect(result["events"]).not_to be_nil
+          expect(result["events"]["in"]).to eq(1)
+          expect(result["events"]["filtered"]).to eq(1)
+          expect(result["events"]["out"]).to eq(3)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Clean backport of #13593 to `8.0`

----

Fixes the issue #8752 in event.out counter. When a pipeline contains a drop filter the total out events counter should count only the events that reached the out stage.

This PR changes CompiledExecution.compute() interface to return the number of events that effectively reached the end of the pipeline. This change is used in WorkerLoop to update correctly the event.out metric, instead of relying on the batch's size.

(cherry picked from commit b6da829f4f4cda450855a1f7918887ceb80bf593)
