### PR TITLE
[Backport PR#13604 to 7.17] Fix 2 failing tests on Windows

### DIFF
--- a/logstash-core/spec/logstash/pipeline_pq_file_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_pq_file_spec.rb
@@ -117,6 +117,7 @@ describe LogStash::Pipeline do
     pipeline_settings.each {|k, v| pipeline_settings_obj.set(k, v) }
     pipeline_settings_obj.set("queue.page_capacity", page_capacity)
     pipeline_settings_obj.set("queue.max_bytes", max_bytes)
+    pipeline_settings_obj.set("queue.drain", true)
     times.push(Time.now.to_f)
 
     subject.start

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
@@ -365,7 +365,7 @@ public class DeadLetterQueueReaderTest {
 
         System.out.println("events per block= " + eventsPerBlock);
 
-        try(DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, BLOCK_SIZE, defaultDlqSize, Duration.ofSeconds(1))) {
+        try(DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, BLOCK_SIZE, defaultDlqSize, Duration.ofSeconds(2))) {
             for (int i = 1; i < eventsToWrite; i++) {
                 DLQEntry entry = new DLQEntry(event, "", "", Integer.toString(i), timestamp);
                 writeManager.writeEntry(entry);
@@ -378,7 +378,7 @@ public class DeadLetterQueueReaderTest {
                 }
             }
 
-            Thread.sleep(2000);
+            Thread.sleep(3000);
 
             try (DeadLetterQueueReader readManager = new DeadLetterQueueReader(dir)) {
                 for (int i = 1; i < eventsToWrite; i++) {


### PR DESCRIPTION
Backport PR#13604 to 7.17 branch. Original message:

This commit fixes 2 tests
- Set queue.drain to true in pipeline pq test
  - Under certain conditions the pipeline_pq_file_spec test would fail as the pipeline would exit once the generator had generated all of its events, but before the events were processed, leading to the test hanging. This commit adds `queue.drain:true` to the settings to ensure that all of the events are processed before the pipeline is shut down
- Increase the flush delay in dead letter quest testFlushAfterDelay test
  - Under certain conditions, the flush delay of 1 second was insufficient, and invalidated a pre-condition assertion that no events had been flushed before the expiry of that delay.
