### PR TITLE
Fix Ruby port check execution in kafka_setup.sh

### DIFF
--- a/qa/integration/services/helpers.sh
+++ b/qa/integration/services/helpers.sh
@@ -46,6 +46,7 @@ test_port_ruby() {
       fi
       echo "Setting logstash ruby home to $LS_RUBY_HOME"
     fi
+    export LS_GEM_HOME="$GEM_HOME"
     $LS_RUBY_HOME/bin/ruby -rsocket -e "TCPSocket.new('localhost', $1) rescue exit(1)"
   fi
 }


### PR DESCRIPTION
When the Bash script executes the vendored Ruby it has to use to proper `GEM_HOME` avoid the overwrite that happens inside the logstash.lib.sh
https://github.com/elastic/logstash/blob/3064f7d0c3374ec0c0ff9a9b14064b7fed66309e/bin/logstash.lib.sh#L161-L165

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip] 

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
Kafka integration tests uses port check function to look if a port is available or less.
This function is implemented in `bash` using `netcat` or falling back to Ruby `TCPSocket.new('localhost', $1) rescue exit(1)` [script](https://github.com/elastic/logstash/blob/3064f7d0c3374ec0c0ff9a9b14064b7fed66309e/qa/integration/services/helpers.sh#L37-L51).

In OSes without `netcat` installed and without a default Ruby, the Kafka integration test uses the vendored ruby, which uses the bad `GEM_HOME` resulting in gems not found problem.

This PR fixes this, defining the `LS_GEM_HOME` to that the l[ogstash.lib.sh](https://github.com/elastic/logstash/blob/3064f7d0c3374ec0c0ff9a9b14064b7fed66309e/bin/logstash.lib.sh#L161-L165) doesn't redefine it.


## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
Helps to keep green the CI

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] verify on centos8

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Checkout this branch and comment some parts of the bash script so that it it doesn't use the `netcat` utility nor the system's  Ruby.
```diff
diff --git a/qa/integration/services/helpers.sh b/qa/integration/services/helpers.sh
index 5b788102d..34a0ec04b 100644
--- a/qa/integration/services/helpers.sh
+++ b/qa/integration/services/helpers.sh
@@ -23,11 +23,11 @@ wait_for_port() {
 }
 
 test_port() {
-    if command -v nc 2>/dev/null; then
-      test_port_nc "$1"
-    else
+#    if command -v nc 2>/dev/null; then
+#      test_port_nc "$1"
+#    else
       test_port_ruby "$1"
-    fi
+#    fi
 }
 
 test_port_nc() {
@@ -35,9 +35,9 @@ test_port_nc() {
 }
 
 test_port_ruby() {
-  if command -v ruby 2>/dev/null; then
-    ruby -rsocket -e "TCPSocket.new('localhost', $1) rescue exit(1)"
-  else
+#  if command -v ruby 2>/dev/null; then
+#    ruby -rsocket -e "TCPSocket.new('localhost', $1) rescue exit(1)"
+#  else
     if [[ -z $LS_RUBY_HOME ]]; then
       if [[ -n $LS_HOME ]]; then
         LS_RUBY_HOME=$LS_HOME
@@ -48,7 +48,7 @@ test_port_ruby() {
     fi
     export LS_GEM_HOME="$GEM_HOME"
     $LS_RUBY_HOME/bin/ruby -rsocket -e "TCPSocket.new('localhost', $1) rescue exit(1)"
-  fi
+#  fi
 }
 
 clean_install_dir() {
```

Then launch the integration tests:
```sh
ci/integration_tests.sh split
```


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
```sh
+ sleep 0.5
+ test_port 2181
+ test_port_ruby 2181
+ [[ -z /home/andrea/workspace/logstash_andsel/qa/integration/services/../../.. ]]
+ echo 'DNADBG>> before the call to /home/andrea/workspace/logstash_andsel/qa/integration/services/../../../bin/ruby'
+ echo 'DNADBG>> GEM_HOME:/home/andrea/workspace/logstash_andsel/build/qa/integration/vendor/jruby/2.5.0, GEM_PATH:/home/andrea/workspace/logstash_andsel/build/qa/integration/vendor/jruby/2.5.0'
+ echo 'DNADBG>> LS_GEM_HOME:, LS_GEM_PATH:'
+ /home/andrea/workspace/logstash_andsel/qa/integration/services/../../../bin/ruby -rsocket -e 'TCPSocket.new('\''localhost'\'', 2181) rescue exit(1)'
Picked up _JAVA_OPTIONS: -Djava.net.preferIPv4Stack=true
Picked up _JAVA_OPTIONS: -Djava.net.preferIPv4Stack=true
Picked up _JAVA_OPTIONS: -Djava.net.preferIPv4Stack=true
OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.
Bundler::GemNotFound: Could not find rspec-wait-0.0.9, rspec-3.10.0, logstash-devutils-2.3.0-java, flores-0.0.7, rspec-core-3.10.1, rspec-expectations-3.10.2, rspec-mocks-3.10.2, fivemat-1.3.7, gem_publisher-1.5.0, kramdown-1.14.0, rspec-support-3.10.3, diff-lcs-1.5.0 in any of the sources
  materialize at /home/andrea/workspace/logstash_andsel/build/qa/integration/vendor/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/definition.rb:481
        specs at /home/andrea/workspace/logstash_andsel/build/qa/integration/vendor/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/definition.rb:190
    specs_for at /home/andrea/workspace/logstash_andsel/build/qa/integration/vendor/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/definition.rb:238
        setup at /home/andrea/workspace/logstash_andsel/build/qa/integration/vendor/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/runtime.rb:18
        setup at /home/andrea/workspace/logstash_andsel/build/qa/integration/vendor/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler.rb:151
       <main> at /home/andrea/workspace/logstash_andsel/build/qa/integration/vendor/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/setup.rb:20
   with_level at /home/andrea/workspace/logstash_andsel/build/qa/integration/vendor/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/ui/shell.rb:136
      silence at /home/andrea/workspace/logstash_andsel/build/qa/integration/vendor/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/ui/shell.rb:88
       <main> at /home/andrea/workspace/logstash_andsel/build/qa/integration/vendor/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/setup.rb:20
      require at org/jruby/RubyKernel.java:974
      require at /home/andrea/workspace/logstash_andsel/vendor/jruby/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:83
```
