### PR TITLE
[Backport 8.0]Add info log of JVM flags used to configure Logstash (#13531)

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -331,6 +331,8 @@ class LogStash::Runner < Clamp::StrictCommand
     end
 
     logger.info("Starting Logstash", "logstash.version" => LOGSTASH_VERSION, "jruby.version" => RUBY_DESCRIPTION)
+    jvmArgs = ManagementFactory.getRuntimeMXBean().getInputArguments()
+    logger.info "JVM bootstrap flags: #{jvmArgs}"
 
     # Add local modules to the registry before everything else
     LogStash::Modules::Util.register_local_modules(LogStash::Environment::LOGSTASH_HOME)


### PR DESCRIPTION
Clean backport of #13531 to branch `8.0`

Logs the JVM flags and options used to launch Logstash.

(cherry picked from commit d4bdcc936d3f23045a4d463b3ce4902cfc8260cd)
