### PR TITLE
Backport PR #13525 to 8.0: fix: respect LS_JAVA_OPTS environment even when optionsfile missing

### DIFF
--- a/logstash-core/src/main/java/org/logstash/launchers/JvmOptionsParser.java
+++ b/logstash-core/src/main/java/org/logstash/launchers/JvmOptionsParser.java
@@ -68,16 +68,16 @@ public class JvmOptionsParser {
                     "Expected two arguments specifying path to LOGSTASH_HOME and an optional LS_JVM_OPTS, but was " + Arrays.toString(args)
             );
         }
+        final String lsJavaOpts = System.getenv("LS_JAVA_OPTS");
+        handleJvmOptions(args, lsJavaOpts);
+    }
 
+    static void handleJvmOptions(String[] args, String lsJavaOpts) {
         final JvmOptionsParser parser = new JvmOptionsParser(args[0]);
         final String jvmOpts = args.length == 2 ? args[1] : null;
         try {
             Optional<Path> jvmOptions = parser.lookupJvmOptionsFile(jvmOpts);
-            if (!jvmOptions.isPresent()) {
-                System.err.println("warning: no jvm.options file found");
-                return;
-            }
-            parser.parse(jvmOptions.get());
+            parser.parseAndInjectEnvironment(jvmOptions, lsJavaOpts);
         } catch (JvmOptionsFileParserException pex) {
             System.err.printf(Locale.ROOT,
                     "encountered [%d] error%s parsing [%s]",
@@ -112,31 +112,54 @@ public class JvmOptionsParser {
                 .findFirst();
     }
 
-    private void parse(Path jvmOptionsFile) throws IOException, JvmOptionsFileParserException {
-        final List<String> jvmOptionsContent = parseJvmOptions(jvmOptionsFile);
-        final String lsJavaOpts = System.getenv("LS_JAVA_OPTS");
+    private void parseAndInjectEnvironment(Optional<Path> jvmOptionsFile, String lsJavaOpts) throws IOException, JvmOptionsFileParserException {
+        final List<String> jvmOptionsContent = new ArrayList<>(parseJvmOptions(jvmOptionsFile));
+
         if (lsJavaOpts != null && !lsJavaOpts.isEmpty()) {
+            if (isDebugEnabled()) {
+                System.err.println("Appending jvm options from environment LS_JAVA_OPTS");
+            }
             jvmOptionsContent.add(lsJavaOpts);
         }
+
         System.out.println(String.join(" ", jvmOptionsContent));
     }
 
-    private List<String> parseJvmOptions(Path jvmOptionsFile) throws IOException, JvmOptionsFileParserException {
-        if (!jvmOptionsFile.toFile().exists()) {
+    private List<String> parseJvmOptions(Optional<Path> jvmOptionsFile) throws IOException, JvmOptionsFileParserException {
+        if (!jvmOptionsFile.isPresent()) {
+            System.err.println("Warning: no jvm.options file found.");
             return Collections.emptyList();
+        }
+        final Path optionsFilePath = jvmOptionsFile.get();
+        if (!optionsFilePath.toFile().exists()) {
+            System.err.format("Warning: jvm.options file does not exist or is not readable: `%s`\n", optionsFilePath);
+            return Collections.emptyList();
+        }
+
+        if (isDebugEnabled()) {
+            System.err.format("Processing jvm.options file at `%s`\n", optionsFilePath);
         }
         final int majorJavaVersion = javaMajorVersion();
 
-        try (InputStream is = Files.newInputStream(jvmOptionsFile);
+        try (InputStream is = Files.newInputStream(optionsFilePath);
              Reader reader = new InputStreamReader(is, StandardCharsets.UTF_8);
              BufferedReader br = new BufferedReader(reader)
         ) {
             final ParseResult parseResults = parse(majorJavaVersion, br);
             if (parseResults.hasErrors()) {
-                throw new JvmOptionsFileParserException(jvmOptionsFile, parseResults.getInvalidLines());
+                throw new JvmOptionsFileParserException(optionsFilePath, parseResults.getInvalidLines());
             }
             return parseResults.getJvmOptions();
         }
+    }
+
+    private boolean isDebugEnabled() {
+        final String debug = System.getenv("DEBUG");
+        if (debug == null) {
+            return false;
+        }
+
+        return "1".equals(debug) || Boolean.parseBoolean(debug);
     }
 
     /**

--- a/logstash-core/src/test/java/org/logstash/launchers/JvmOptionsParserTest.java
+++ b/logstash-core/src/test/java/org/logstash/launchers/JvmOptionsParserTest.java
@@ -1,14 +1,56 @@
 package org.logstash.launchers;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.io.StringReader;
+import java.lang.reflect.Field;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
 public class JvmOptionsParserTest {
+
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+
+    private final PrintStream standardOut = System.out;
+    private final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+
+    @Before
+    public void setUp() {
+        System.setOut(new PrintStream(outputStreamCaptor));
+    }
+
+    @After
+    public void tearDown() {
+        System.setOut(standardOut);
+    }
+
+    @Test
+    public void test_LS_JAVA_OPTS_isUsedWhenNoJvmOptionsIsAvailable() throws IOException, InterruptedException, ReflectiveOperationException {
+        JvmOptionsParser.handleJvmOptions(new String[] {temp.toString()}, "-Xblabla");
+
+        // Verify
+        final String output = outputStreamCaptor.toString();
+        assertEquals("Output MUST contains the options present in LS_JAVA_OPTS", "-Xblabla\n", output);
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    public static void updateEnv(String name, String val) throws ReflectiveOperationException {
+        Map<String, String> env = System.getenv();
+        Field field = env.getClass().getDeclaredField("m");
+        field.setAccessible(true);
+        ((Map<String, String>) field.get(env)).put(name, val);
+    }
+
 
     @Test
     public void testParseCommentLine() throws IOException {

--- a/qa/integration/specs/cli/prepare_offline_pack_spec.rb
+++ b/qa/integration/specs/cli/prepare_offline_pack_spec.rb
@@ -86,7 +86,7 @@ describe "CLI > logstash-plugin prepare-offline-pack" do
       filters = @logstash_plugin.list(plugins_to_pack.first)
                                 .stderr_and_stdout.split("\n")
                                 .delete_if do |line|
-                                  line =~ /cext|├──|└──|logstash-integration|JAVA_OPT|fatal|^WARNING|^warning: ignoring JAVA_TOOL_OPTIONS|^OpenJDK 64-Bit Server VM warning|Option \w+ was deprecated|Using LS_JAVA_HOME defined java|Using system java: |\[\[: not found/
+                                  line =~ /cext|├──|└──|logstash-integration|JAVA_OPT|fatal|^WARNING|^warning: ignoring JAVA_TOOL_OPTIONS|^OpenJDK 64-Bit Server VM warning|Option \w+ was deprecated|Using LS_JAVA_HOME defined java|Using system java: |\[\[: not found|^Warning: no jvm.options file found|^Processing jvm.options file at/
                                 end
 
       expect(unpacked.plugins.collect(&:name)).to include(*filters)


### PR DESCRIPTION
Backport PR #13525 to 8.0 branch. Original message: 

## Release notes

 - Fixes a regression introduced in 7.12, in which the LS_JAVA_OPTS is ignored when a readable `jvm.options` file cannot be found.

## What does this PR do?

As reported in https://github.com/elastic/logstash/issues/13472 Logstash since 7.12 has silently ignored the `LS_JAVA_OPTS` environment variable when it is unable to find a `jvm.options` file.

This change renames the relevant `JvmOptionsParser#parse(Path)` method to a more descriptive `parseAndInjectEnvironment(Optional<Path>)` and _always_ calls it, regardless of whether a `jvm.options` has been found. It also includes helpful messages to stderr so that the state can be reconstructed from logs.

## Why is it important/What is the impact to the user?

A common practice with docker deployments is to mount a volume to the config directory, stomping on the default files that are present there, passing relevant JVM config with the environment variable `LS_JAVA_OPTS`. When this is done, and the user does not include a `jvm.options` file, their LS_JAVA_OPTS` are ignored.

This change causes their supplied config to be respected, and for console output to include relevant information about how the JVM was configured.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Move the `config/jvm.options` out of its place, and run logstash with an `LS_JAVA_OPTS` containing a poison pill
~~~
mv config/jvm.options config/jvm.options.bu
LS_JAVA_OPTS='-Xoh=no' bin/logstash -e '' 
~~~

 - Without this patch in place, Logstash starts without including the `LS_JAVA_OPTS`.
 - With this patch, Logstash applies the `LS_JAVA_OPTS` and the STDERR channel includes helpful information about the source of the JVM configuration:

~~~
╭─{ yaauie@limbo:~/src/elastic/ls (✘ java-opts-from-environment-when-optionsfile-missing) }
╰─● LS_JAVA_OPTS='-Xoh=no' bin/logstash -e ''
Using system java: /usr/bin/java
Warning: no jvm.options file found.
Appending jvm options from environment LS_JAVA_OPTS
Unrecognized option: -Xoh=no
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
[error: 1]                                                                                                                                                                                                                                                                                                          
~~~

Additionally, when started _with_ a `jvm.options` file, the logs are more helpful.

~~~
╭─{ yaauie@limbo:~/src/elastic/ls (✔ java-opts-from-environment-when-optionsfile-missing) }
╰─● LS_JAVA_OPTS='-Xoh=no' bin/logstash -e ''  
Using system java: /usr/bin/java
Processing jvm.options file at `/Users/yaauie/src/elastic/ls/config/jvm.options`
Appending jvm options from environment LS_JAVA_OPTS
OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.
Unrecognized option: -Xoh=no
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
[error: 1]
~~~

## Related issues

Fixes: #13472
Cause: #12530