### PR TITLE
Doc: Remove hard-coded edit_url links where possible

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -54,13 +54,21 @@ include::static/processing-info.asciidoc[]
 
 // Logstash setup
 include::static/setting-up-logstash.asciidoc[]
+
 include::static/settings-file.asciidoc[]
+
 include::static/keystore.asciidoc[]
+
 include::static/running-logstash-command-line.asciidoc[]
+
 include::static/running-logstash.asciidoc[]
+
 include::static/docker.asciidoc[]
+
 include::static/running-logstash-windows.asciidoc[]
+
 include::static/logging.asciidoc[]
+
 include::static/shutdown.asciidoc[]
 
 // Upgrading Logstash
@@ -68,6 +76,7 @@ include::static/upgrading.asciidoc[]
 
 // Configuring Logstash
 include::static/configuration.asciidoc[]
+
 include::static/ls-to-cloud.asciidoc[]
 
 // Security
@@ -75,14 +84,23 @@ include::static/security/logstash.asciidoc[]
 
 // Advanced Logstash Configuration
 include::static/configuration-advanced.asciidoc[]
+
 include::static/multiple-pipelines.asciidoc[]
+
 include::static/pipeline-pipeline-config.asciidoc[]
+
 include::static/reloading-config.asciidoc[]
+
 include::static/managing-multiline-events.asciidoc[]
+
 include::static/glob-support.asciidoc[]
+
 include::static/ingest-convert.asciidoc[]
+
 include::static/ls-ls-config.asciidoc[]
+
 include::static/management/configuring-centralized-pipelines.asciidoc[]
+
 include::static/field-reference.asciidoc[]
 
 //The `field-reference.asciidoc` file (included above) contains a
@@ -97,8 +115,11 @@ include::static/config-management.asciidoc[]
 
 // Working with Logstash Modules
 include::static/modules.asciidoc[]
+
 include::static/arcsight-module.asciidoc[]
+
 include::static/netflow-module.asciidoc[]
+
 include::static/azure-module.asciidoc[]
 
 // Working with Filebeat Modules
@@ -106,8 +127,11 @@ include::static/filebeat-modules.asciidoc[]
 
 // Data resiliency
 include::static/resiliency.asciidoc[]
+
 include::static/mem-queue.asciidoc[]
+
 include::static/persistent-queues.asciidoc[]
+
 include::static/dead-letter-queues.asciidoc[]
 
 // Transforming Data
@@ -121,6 +145,7 @@ include::static/performance-checklist.asciidoc[]
 
 // Monitoring 
 include::static/monitoring/monitoring-overview.asciidoc[]
+
 include::static/monitoring/monitoring.asciidoc[]
 
 // Working with Plugins
@@ -129,23 +154,33 @@ include::static/plugin-manager.asciidoc[]
 // These files do their own pass blocks
 
 include::{plugins-repo-dir}/plugins/integrations.asciidoc[]
+
 include::{plugins-repo-dir}/plugins/inputs.asciidoc[]
+
 include::{plugins-repo-dir}/plugins/outputs.asciidoc[]
+
 include::{plugins-repo-dir}/plugins/filters.asciidoc[]
+
 include::{plugins-repo-dir}/plugins/codecs.asciidoc[]
 
 // FAQ and Troubleshooting
 :edit_url!:
 include::static/best-practice.asciidoc[]
+
 include::static/config-details.asciidoc[]
+
 include::static/troubleshoot/troubleshooting.asciidoc[]
 
 // Contributing to Logstash
 :edit_url:
 include::static/contributing-to-logstash.asciidoc[]
+
 include::static/input.asciidoc[]
+
 include::static/codec.asciidoc[]
+
 include::static/filter.asciidoc[]
+
 include::static/output.asciidoc[]
 
 // Logstash Community Maintainer Guide
@@ -156,8 +191,11 @@ include::static/doc-for-plugin.asciidoc[]
 
 // Submitting a Plugin 
 include::static/submitting-a-plugin.asciidoc[] 
+
 include::static/listing-a-plugin.asciidoc[] 
+
 include::static/contributing-patch.asciidoc[]
+
 include::static/contribute-core.asciidoc[]
 
 // Contributing to Logstash - JAVA EDITION

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -141,8 +141,8 @@ include::static/config-details.asciidoc[]
 include::static/troubleshoot/troubleshooting.asciidoc[]
 
 // Contributing to Logstash
+:edit_url:
 include::static/contributing-to-logstash.asciidoc[]
-
 include::static/input.asciidoc[]
 include::static/codec.asciidoc[]
 include::static/filter.asciidoc[]
@@ -161,9 +161,11 @@ include::static/contributing-patch.asciidoc[]
 include::static/contribute-core.asciidoc[]
 
 // Contributing to Logstash - JAVA EDITION
+:edit_url:
 include::static/contributing-java-plugin.asciidoc[]
 
 // Glossary of Terms
+:edit_url!:
 include::static/glossary.asciidoc[]
 
 // Breaking Changes

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -37,112 +37,52 @@ volume and variety of data.
 
 // Introduction
 
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/introduction.asciidoc
-include::static/introduction.asciidoc[]
-
-// Glossary and core concepts go here
-
 // Getting Started with Logstash
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/getting-started-with-logstash.asciidoc
 include::static/getting-started-with-logstash.asciidoc[]
 
 // Advanced LS Pipelines
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/advanced-pipeline.asciidoc
 include::static/advanced-pipeline.asciidoc[]
 
 // Processing Pipeline
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/life-of-an-event.asciidoc
 include::static/life-of-an-event.asciidoc[]
 
 // Elastic Common Schema (ECS)
-:editurl!:
 include::static/ecs-compatibility.asciidoc[]
 
 // Processing details
-
-:edit_url!:
 include::static/processing-info.asciidoc[]
 
 // Logstash setup
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/setting-up-logstash.asciidoc
 include::static/setting-up-logstash.asciidoc[]
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/settings-file.asciidoc
 include::static/settings-file.asciidoc[]
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/keystore.asciidoc
 include::static/keystore.asciidoc[]
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/running-logstash-command-line.asciidoc
 include::static/running-logstash-command-line.asciidoc[]
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/running-logstash.asciidoc
 include::static/running-logstash.asciidoc[]
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/docker.asciidoc
 include::static/docker.asciidoc[]
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/running-logstash-windows.asciidoc
 include::static/running-logstash-windows.asciidoc[]
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/logging.asciidoc
 include::static/logging.asciidoc[]
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/shutdown.asciidoc
 include::static/shutdown.asciidoc[]
 
 // Upgrading Logstash
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/upgrading.asciidoc
 include::static/upgrading.asciidoc[]
 
 // Configuring Logstash
-
-:edit_url!:
 include::static/configuration.asciidoc[]
-
-:edit_url!:
 include::static/ls-to-cloud.asciidoc[]
 
 // Security
-
-:edit_url!:
 include::static/security/logstash.asciidoc[]
 
 // Advanced Logstash Configuration
-
-:edit_url!:
 include::static/configuration-advanced.asciidoc[]
-
-:edit_url!:
 include::static/multiple-pipelines.asciidoc[]
-
-:edit_url!:
 include::static/pipeline-pipeline-config.asciidoc[]
-
-:edit_url!:
 include::static/reloading-config.asciidoc[]
-
-:edit_url!:
 include::static/managing-multiline-events.asciidoc[]
-
-:edit_url!:
 include::static/glob-support.asciidoc[]
-
-:edit_url!:
 include::static/ingest-convert.asciidoc[]
-
-:edit_url!:
 include::static/ls-ls-config.asciidoc[]
-
-:edit_url!:
 include::static/management/configuring-centralized-pipelines.asciidoc[]
-
-:edit_url!:
 include::static/field-reference.asciidoc[]
 
 //The `field-reference.asciidoc` file (included above) contains a
@@ -153,67 +93,37 @@ include::static/field-reference.asciidoc[]
 //`Advanced Logstash Configuration` heading.
 
 // Centralized configuration managements
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/config-management.asciidoc
 include::static/config-management.asciidoc[]
 
 // Working with Logstash Modules
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/modules.asciidoc
 include::static/modules.asciidoc[]
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/arcsight-module.asciidoc
 include::static/arcsight-module.asciidoc[]
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/netflow-module.asciidoc
 include::static/netflow-module.asciidoc[]
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/azure-module.asciidoc
 include::static/azure-module.asciidoc[]
 
 // Working with Filebeat Modules
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/filebeat-modules.asciidoc
 include::static/filebeat-modules.asciidoc[]
 
 // Data resiliency
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/resiliency.asciidoc
 include::static/resiliency.asciidoc[]
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/mem-queue.asciidoc
 include::static/mem-queue.asciidoc[]
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/persistent-queues.asciidoc
 include::static/persistent-queues.asciidoc[]
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/dead-letter-queues.asciidoc
 include::static/dead-letter-queues.asciidoc[]
 
 // Transforming Data
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/transforming-data.asciidoc
 include::static/transforming-data.asciidoc[]
 
 // Deploying & Scaling
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/deploying.asciidoc
 include::static/deploying.asciidoc[]
 
 // Troubleshooting performance
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/performance-checklist.asciidoc
 include::static/performance-checklist.asciidoc[]
 
-// X-Pack Monitoring 
-:edit_url!:
-include::static/monitoring/monitoring-overview.asciidoc[]
-
 // Monitoring 
-:edit_url!:
+include::static/monitoring/monitoring-overview.asciidoc[]
 include::static/monitoring/monitoring.asciidoc[]
 
 // Working with Plugins
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/plugin-manager.asciidoc
 include::static/plugin-manager.asciidoc[]
 
 // These files do their own pass blocks
@@ -225,20 +135,11 @@ include::{plugins-repo-dir}/plugins/filters.asciidoc[]
 include::{plugins-repo-dir}/plugins/codecs.asciidoc[]
 
 // FAQ and Troubleshooting
-
-:edit_url!:
 include::static/best-practice.asciidoc[]
-
-:edit_url!: 
 include::static/config-details.asciidoc[]
-
-:edit_url!:
 include::static/troubleshoot/troubleshooting.asciidoc[]
 
-:edit_url:
-
 // Contributing to Logstash
-
 include::static/contributing-to-logstash.asciidoc[]
 
 include::static/input.asciidoc[]
@@ -247,53 +148,30 @@ include::static/filter.asciidoc[]
 include::static/output.asciidoc[]
 
 // Logstash Community Maintainer Guide
-
-:edit_url!: 
 include::static/maintainer-guide.asciidoc[]
 
-// A space is necessary here ^^^
-
 // Plugin doc guidelines
-
-:edit_url: 
 include::static/doc-for-plugin.asciidoc[]
 
-// Submitting a Plugin
-
-:edit_url!: 
+// Submitting a Plugin 
 include::static/submitting-a-plugin.asciidoc[] 
-
-:edit_url!:
-include::static/listing-a-plugin.asciidoc[]
-
-:edit_url!: 
+include::static/listing-a-plugin.asciidoc[] 
 include::static/contributing-patch.asciidoc[]
-
-:edit_url!:
 include::static/contribute-core.asciidoc[]
 
 // Contributing to Logstash - JAVA EDITION
-
-:edit_url: 
 include::static/contributing-java-plugin.asciidoc[]
 
 // Glossary of Terms
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/glossary.asciidoc
 include::static/glossary.asciidoc[]
 
-// This is in the pluginbody.asciidoc itself
-//
-
 // Breaking Changes
-
-:edit_url: https://github.com/elastic/logstash/edit/{branch}/docs/static/breaking-changes.asciidoc
 include::static/breaking-changes.asciidoc[]
 
 // Release Notes
-
-:edit_url!:
 include::static/releasenotes.asciidoc[]
 
 :edit_url:
 include::static/redirects.asciidoc[]
+
+:edit_url!:

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -135,6 +135,7 @@ include::{plugins-repo-dir}/plugins/filters.asciidoc[]
 include::{plugins-repo-dir}/plugins/codecs.asciidoc[]
 
 // FAQ and Troubleshooting
+:edit_url!:
 include::static/best-practice.asciidoc[]
 include::static/config-details.asciidoc[]
 include::static/troubleshoot/troubleshooting.asciidoc[]


### PR DESCRIPTION
Improvements in Elastic.co docs tooling (approximately 2019) made the "Edit" links better at guessing the source URL for editing. Hard-coded links for Logstash core documentation are no longer required, and can potentially cause problems (as in the recent `master`->`main` branch renaming). Taking this opportunity to do more cleanup. 

Note that links to source files for plugin docs (in `logstash-docs`) must remain hard-coded because they live in their own repos. 

**PREVIEW:** https://logstash_13636.docs-preview.app.elstc.co/guide/en/logstash/master/introduction.html

Related: #13619 
