### PR TITLE
[Backport 8.0] Fix Ruby port check execution in kafka_setup.sh (#13631)

### DIFF
--- a/qa/integration/services/helpers.sh
+++ b/qa/integration/services/helpers.sh
@@ -46,6 +46,7 @@ test_port_ruby() {
       fi
       echo "Setting logstash ruby home to $LS_RUBY_HOME"
     fi
+    export LS_GEM_HOME="$GEM_HOME"
     $LS_RUBY_HOME/bin/ruby -rsocket -e "TCPSocket.new('localhost', $1) rescue exit(1)"
   fi
 }


### PR DESCRIPTION
Clean backport of #13631 to `8.0`

----
Original message:

When the Bash script executes the vendored Ruby it has to use proper `GEM_HOME` to avoid the overwrite that happens inside the logstash.lib.sh
https://github.com/elastic/logstash/blob/3064f7d0c3374ec0c0ff9a9b14064b7fed66309e/bin/logstash.lib.sh#L161-L165

(cherry picked from commit 93f37b96099328b6376a5c332cea7042d82e7974)
