### PR TITLE
Fix/gems not found in integration test after plugin install

### DIFF
--- a/qa/integration/specs/cli/install_spec.rb
+++ b/qa/integration/specs/cli/install_spec.rb
@@ -117,9 +117,18 @@ describe "CLI > logstash-plugin install" do
       end
     end
 
-    xcontext "install non bundle plugin" do
+    context "install non bundle plugin" do
       let(:plugin_name) { "logstash-input-google_cloud_storage" }
       let(:install_command) { "bin/logstash-plugin install" }
+
+      after(:each) do
+         # cleanly remove the installed plugin to don't pollute
+         # the environment for other subsequent tests
+         removal = @logstash_plugin.run_raw("bin/logstash-plugin uninstall #{plugin_name}")
+
+         expect(removal.stderr_and_stdout).to match(/Successfully removed #{plugin_name}/)
+         expect(removal.exit_code).to eq(0)
+      end
 
       it "successfully install the plugin" do
         execute = @logstash_plugin.run_raw("#{install_command} #{plugin_name}")

--- a/qa/integration/specs/cli/install_spec.rb
+++ b/qa/integration/specs/cli/install_spec.rb
@@ -117,7 +117,7 @@ describe "CLI > logstash-plugin install" do
       end
     end
 
-    context "install non bundle plugin" do
+    xcontext "install non bundle plugin" do
       let(:plugin_name) { "logstash-input-google_cloud_storage" }
       let(:install_command) { "bin/logstash-plugin install" }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
Cleanly teardown an integration test that made fall other integration tests.
In some cases the CI integration tests fails because the launched Logstash can't find a gem named `mimemagic`.
<details>
  <summary> CI logs </summary>
  <p>
  
```
19:09:01     [FATAL] 2022-01-18 18:09:01.198 [main] Logstash - Logstash stopped processing because of an error: (GemNotFound) Could not find mimemagic-0.4.3 in any of the sources

19:09:01     org.jruby.exceptions.StandardError: (GemNotFound) Could not find mimemagic-0.4.3 in any of the sources

19:09:01        at var.lib.jenkins.workspace.elastic_plus_logstash_plus_main_plus_multijob_minus_matrix_minus_jdk_minus_unix_minus_integration_minus_2.LS_RUNTIME_JAVA.adoptiumjdk17.os.ubuntu_minus_20_dot_04_and_and_immutable.build.logstash_minus_8_dot_1_dot_0_minus_SNAPSHOT.vendor.bundle.jruby.$2_dot_5_dot_0.gems.bundler_minus_2_dot_3_dot_5.lib.bundler.definition.materialize(/var/lib/jenkins/workspace/elastic+logstash+main+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptiumjdk17/os/ubuntu-20.04&&immutable/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/definition.rb:481) ~[?:?]

19:09:01        at var.lib.jenkins.workspace.elastic_plus_logstash_plus_main_plus_multijob_minus_matrix_minus_jdk_minus_unix_minus_integration_minus_2.LS_RUNTIME_JAVA.adoptiumjdk17.os.ubuntu_minus_20_dot_04_and_and_immutable.build.logstash_minus_8_dot_1_dot_0_minus_SNAPSHOT.vendor.bundle.jruby.$2_dot_5_dot_0.gems.bundler_minus_2_dot_3_dot_5.lib.bundler.definition.specs(/var/lib/jenkins/workspace/elastic+logstash+main+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptiumjdk17/os/ubuntu-20.04&&immutable/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/definition.rb:190) ~[?:?]

19:09:01        at var.lib.jenkins.workspace.elastic_plus_logstash_plus_main_plus_multijob_minus_matrix_minus_jdk_minus_unix_minus_integration_minus_2.LS_RUNTIME_JAVA.adoptiumjdk17.os.ubuntu_minus_20_dot_04_and_and_immutable.build.logstash_minus_8_dot_1_dot_0_minus_SNAPSHOT.vendor.bundle.jruby.$2_dot_5_dot_0.gems.bundler_minus_2_dot_3_dot_5.lib.bundler.definition.specs_for(/var/lib/jenkins/workspace/elastic+logstash+main+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptiumjdk17/os/ubuntu-20.04&&immutable/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/definition.rb:238) ~[?:?]

19:09:01        at var.lib.jenkins.workspace.elastic_plus_logstash_plus_main_plus_multijob_minus_matrix_minus_jdk_minus_unix_minus_integration_minus_2.LS_RUNTIME_JAVA.adoptiumjdk17.os.ubuntu_minus_20_dot_04_and_and_immutable.build.logstash_minus_8_dot_1_dot_0_minus_SNAPSHOT.vendor.bundle.jruby.$2_dot_5_dot_0.gems.bundler_minus_2_dot_3_dot_5.lib.bundler.runtime.setup(/var/lib/jenkins/workspace/elastic+logstash+main+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptiumjdk17/os/ubuntu-20.04&&immutable/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/runtime.rb:18) ~[?:?]

19:09:01        at var.lib.jenkins.workspace.elastic_plus_logstash_plus_main_plus_multijob_minus_matrix_minus_jdk_minus_unix_minus_integration_minus_2.LS_RUNTIME_JAVA.adoptiumjdk17.os.ubuntu_minus_20_dot_04_and_and_immutable.build.logstash_minus_8_dot_1_dot_0_minus_SNAPSHOT.vendor.bundle.jruby.$2_dot_5_dot_0.gems.bundler_minus_2_dot_3_dot_5.lib.bundler.setup(/var/lib/jenkins/workspace/elastic+logstash+main+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptiumjdk17/os/ubuntu-20.04&&immutable/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler.rb:151) ~[?:?]

19:09:01        at var.lib.jenkins.workspace.elastic_plus_logstash_plus_main_plus_multijob_minus_matrix_minus_jdk_minus_unix_minus_integration_minus_2.LS_RUNTIME_JAVA.adoptiumjdk17.os.ubuntu_minus_20_dot_04_and_and_immutable.build.logstash_minus_8_dot_1_dot_0_minus_SNAPSHOT.lib.bootstrap.bundler.setup!(/var/lib/jenkins/workspace/elastic+logstash+main+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptiumjdk17/os/ubuntu-20.04&&immutable/build/logstash-8.1.0-SNAPSHOT/lib/bootstrap/bundler.rb:87) ~[?:?]

19:09:01        at var.lib.jenkins.workspace.elastic_plus_logstash_plus_main_plus_multijob_minus_matrix_minus_jdk_minus_unix_minus_integration_minus_2.LS_RUNTIME_JAVA.adoptiumjdk17.os.ubuntu_minus_20_dot_04_and_and_immutable.build.logstash_minus_8_dot_1_dot_0_minus_SNAPSHOT.lib.bootstrap.environment.<main>(/var/lib/jenkins/workspace/elastic+logstash+main+multijob-matrix-jdk-unix-integration-2/LS_RUNTIME_JAVA/adoptiumjdk17/os/ubuntu-20.04&&immutable/build/logstash-8.1.0-SNAPSHOT/lib/bootstrap/environment.rb:89) ~[?:?]

19:09:03       should not create separate pipelines log files if not enabled (FAILED - 8)
```

  </p>
</details>



The `mimemagic` gem is installed as dependency of the `logstash-input-google_cloud_storage` which is installed by the `install non bundle plugin` [spec](https://github.com/elastic/logstash/blob/4f96a947138be728dea10a2127aca5475366094b/qa/integration/specs/cli/install_spec.rb#L121-L122).

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
It doesn't impact directly the user, only the CI

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
