### PR TITLE
[Backport 7.17] Fix/gems not found in integration test after plugin install (#13641)

### DIFF
--- a/qa/integration/specs/cli/install_spec.rb
+++ b/qa/integration/specs/cli/install_spec.rb
@@ -121,6 +121,15 @@ describe "CLI > logstash-plugin install" do
       let(:plugin_name) { "logstash-input-google_cloud_storage" }
       let(:install_command) { "bin/logstash-plugin install" }
 
+      after(:each) do
+         # cleanly remove the installed plugin to don't pollute
+         # the environment for other subsequent tests
+         removal = @logstash_plugin.run_raw("bin/logstash-plugin uninstall #{plugin_name}")
+
+         expect(removal.stderr_and_stdout).to match(/Successfully removed #{plugin_name}/)
+         expect(removal.exit_code).to eq(0)
+      end
+
       it "successfully install the plugin" do
         execute = @logstash_plugin.run_raw("#{install_command} #{plugin_name}")
 


### PR DESCRIPTION
Clean backport of #13641 to `7.17`

----
Original message:

Cleanly teardown an integration test that made fall other integration tests.
In some cases the CI integration tests fails because the launched Logstash can't find a gem named `mimemagic`. This gem is installed during a CLI plugin test (install of  `logstash-input-google_cloud_storage` plugins kicks in that `mimemagic`).

(cherry picked from commit 640ba8489f857e83e6f397b349379544f992b296)
