### PR TITLE
Backport PR #13642 to 8.0: field-reference: cap RUBY_CACHE to 10k entries

### DIFF
--- a/logstash-core/src/main/java/org/logstash/FieldReference.java
+++ b/logstash-core/src/main/java/org/logstash/FieldReference.java
@@ -118,7 +118,13 @@ public final class FieldReference {
         if (result != null) {
             return result;
         }
-        return RUBY_CACHE.computeIfAbsent(reference.newFrozen(), ref -> from(ref.asJavaString()));
+
+        final FieldReference parsed = from(reference.asJavaString());
+        // exact size in a race condition is not important
+        if (RUBY_CACHE.size() < 10_000) {
+            RUBY_CACHE.put(reference.newFrozen(), parsed);
+        }
+        return parsed;
     }
 
     public static FieldReference from(final String reference) {

--- a/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
+++ b/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
@@ -23,6 +23,8 @@ package org.logstash;
 import java.lang.reflect.Field;
 import java.util.Map;
 import org.hamcrest.CoreMatchers;
+import org.jruby.RubyString;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,25 +35,12 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public final class FieldReferenceTest {
-
-    @SuppressWarnings("unchecked")
     @Before
-    public void clearParsingCache() throws Exception {
-        final Field cacheField = FieldReference.class.getDeclaredField("CACHE");
-        cacheField.setAccessible(true);
-        final Map<CharSequence, FieldReference> cache =
-                (Map<CharSequence, FieldReference>) cacheField.get(null);
-        cache.clear();
-    }
-
-    @SuppressWarnings("unchecked")
-    @Before
-    public void clearDedupCache() throws Exception  {
-        final Field cacheField = FieldReference.class.getDeclaredField("DEDUP");
-        cacheField.setAccessible(true);
-        final Map<CharSequence, FieldReference> cache =
-                (Map<CharSequence, FieldReference>) cacheField.get(null);
-        cache.clear();
+    @After
+    public void clearInternalCaches() {
+        getInternalCache("CACHE").clear();
+        getInternalCache("DEDUP").clear();
+        getInternalCache("RUBY_CACHE").clear();
     }
 
     @Test
@@ -68,16 +57,23 @@ public final class FieldReferenceTest {
         );
     }
 
-    @SuppressWarnings("unchecked")
     @Test
-    public void testCacheUpperBound() throws NoSuchFieldException, IllegalAccessException {
-        final Field cacheField = FieldReference.class.getDeclaredField("CACHE");
-        cacheField.setAccessible(true);
-        final Map<CharSequence, FieldReference> cache =
-                (Map<CharSequence, FieldReference>) cacheField.get(null);
+    public void testCacheUpperBound() {
+        final Map<String, FieldReference> cache = getInternalCache("CACHE");
         final int initial = cache.size();
         for (int i = 0; i < 10_001 - initial; ++i) {
             FieldReference.from(String.format("[array][%d]", i));
+        }
+        assertThat(cache.size(), CoreMatchers.is(10_000));
+    }
+
+    @Test
+    public void testRubyCacheUpperBound() {
+        final Map<RubyString, FieldReference> cache = getInternalCache("RUBY_CACHE");
+        final int initial = cache.size();
+        for (int i = 0; i < 10_050 - initial; ++i) {
+            final RubyString rubyString = RubyUtil.RUBY.newString(String.format("[array][%d]", i));
+            FieldReference.from(rubyString);
         }
         assertThat(cache.size(), CoreMatchers.is(10_000));
     }
@@ -182,5 +178,17 @@ public final class FieldReferenceTest {
     @Test(expected=FieldReference.IllegalSyntaxException.class)
     public void testParseLiteralSquareBrackets() throws Exception {
         FieldReference.from("this[index]");
+    }
+
+    @SuppressWarnings("unchecked")
+    private <K,V> Map<K,V> getInternalCache(final String fieldName) {
+        final Field cacheField;
+        try {
+            cacheField = FieldReference.class.getDeclaredField(fieldName);
+            cacheField.setAccessible(true);
+            return (Map<K, V>) cacheField.get(null);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
Backport PR #13642 to 8.0 branch. Original message: 

Reduces the scope of a memory leak that can be caused by using UUIDs or other
high-cardinality field names by preventing the ruby string _keys_ from being
held by the cache indefinitely.

Note: this may not solve the problem entirely, but certainly limits its impact.
      Because ConvertedMap requires individual field names to be interned into
      the global String intern pool, their eligibility for GC is JVM-specific
      and high-cardinality field names should still be avoided.

## Release notes

Reduces the scope of a memory leak that can be caused by using UUIDs or other high-cardinality field names.

## What does this PR do?

Ports the same naïve limits to caching the `FieldReference.RUBY_CACHE` (`Map<RubyString,FieldReference>`) that we have on the `FieldReference.CACHE` (`Map<String,FieldReference>`). Once the 10k limit is reached, additional entries are not cached. There is no eviction strategy in place for either cache, and the `DEDUP` cache is effectively guarded by the size of the `CACHE` to prevent unbounded growth.

Because FieldReferences intern path fragments to the global String intern pool, and ConvertedMap relies on identity matching of keys, using UUIDs as keys can still be problematic and those field names eligibility for GC will depend on the JVM implementation.

## Why is it important/What is the impact to the user?

Prevents unbounded memory growth when using high-cardinality keys

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

Relates: #13079
Resolves: #10112

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 
