### PR TITLE
Fix unit test under Windows

### DIFF
--- a/logstash-core/src/test/java/org/logstash/launchers/JvmOptionsParserTest.java
+++ b/logstash-core/src/test/java/org/logstash/launchers/JvmOptionsParserTest.java
@@ -40,7 +40,7 @@ public class JvmOptionsParserTest {
 
         // Verify
         final String output = outputStreamCaptor.toString();
-        assertEquals("Output MUST contains the options present in LS_JAVA_OPTS", "-Xblabla\n", output);
+        assertEquals("Output MUST contains the options present in LS_JAVA_OPTS", "-Xblabla" + System.lineSeparator(), output);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -54,7 +54,7 @@ public class JvmOptionsParserTest {
 
     @Test
     public void testParseCommentLine() throws IOException {
-        final BufferedReader options = asReader("# this is a comment\n-XX:+UseConcMarkSweepGC");
+        final BufferedReader options = asReader("# this is a comment" + System.lineSeparator() + "-XX:+UseConcMarkSweepGC");
         final JvmOptionsParser.ParseResult res = JvmOptionsParser.parse(11, options);
 
         assertTrue("no invalid lines can be present", res.getInvalidLines().isEmpty());
@@ -91,19 +91,19 @@ public class JvmOptionsParserTest {
 
     @Test
     public void testErrorLinesAreReportedCorrectly() throws IOException {
-        final String jvmOptionsContent = "10-11:-XX:+UseConcMarkSweepGC\n" +
-                "invalidOption\n" +
-                "-Duser.country=US\n" +
+        final String jvmOptionsContent = "10-11:-XX:+UseConcMarkSweepGC" + System.lineSeparator() +
+                "invalidOption" + System.lineSeparator() +
+                "-Duser.country=US" + System.lineSeparator() +
                 "anotherInvalidOption";
         JvmOptionsParser.ParseResult res = JvmOptionsParser.parse(11, asReader(jvmOptionsContent));
-        verifyOptions("Option must be present for Java 11", "-XX:+UseConcMarkSweepGC\n-Duser.country=US", res);
+        verifyOptions("Option must be present for Java 11", "-XX:+UseConcMarkSweepGC" + System.lineSeparator() + "-Duser.country=US", res);
 
         assertEquals("invalidOption", res.getInvalidLines().get(2));
         assertEquals("anotherInvalidOption", res.getInvalidLines().get(4));
     }
 
     private void verifyOptions(String message, String expected, JvmOptionsParser.ParseResult res) {
-        assertEquals(message, expected, String.join("\n", res.getJvmOptions()));
+        assertEquals(message, expected, String.join(System.lineSeparator(), res.getJvmOptions()));
     }
 
     private BufferedReader asReader(String s) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
Replaces the `\n` characters with System's line separator in unit tests to be portable across various OSes.

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
Make the unit test green under Windows OS.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] run on local Windows with:
```sh
set GRADLE_OPTS=-Dorg.gradle.java.home="C:\Program Files\AdoptOpenJDK\jdk-11.0.11.9-hotspot"
.\gradlew.bat test --console=plain --no-daemon --info
```

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
Failure example from the CI:
```
15:51:33 org.logstash.launchers.JvmOptionsParserTest > test_LS_JAVA_OPTS_isUsedWhenNoJvmOptionsIsAvailable STARTED
15:51:33 
15:51:33 org.logstash.launchers.JvmOptionsParserTest > test_LS_JAVA_OPTS_isUsedWhenNoJvmOptionsIsAvailable STANDARD_ERROR
15:51:33     Warning: no jvm.options file found.
15:51:33 
15:51:33 org.logstash.launchers.JvmOptionsParserTest > test_LS_JAVA_OPTS_isUsedWhenNoJvmOptionsIsAvailable FAILED
15:51:33     org.junit.ComparisonFailure: Output MUST contains the options present in LS_JAVA_OPTS expected:<-Xblabla[]
15:51:33     > but was:<-Xblabla[
15:51:33 ]
15:51:33     >
15:51:33         at org.junit.Assert.assertEquals(Assert.java:115)
15:51:33         at org.logstash.launchers.JvmOptionsParserTest.test_LS_JAVA_OPTS_isUsedWhenNoJvmOptionsIsAvailable(JvmOptionsParserTest.java:43)
```