### PR TITLE
Backport PR #13645 to 8.0: stats api: startup resilience when stats are partially formed

### DIFF
--- a/logstash-core/lib/logstash/config/pipelines_info.rb
+++ b/logstash-core/lib/logstash/config/pipelines_info.rb
@@ -26,6 +26,8 @@ module LogStash; module Config;
         p_stats = stats[pipeline_id]
         # Don't record stats for system pipelines
         next nil if pipeline.system?
+        # Don't emit stats for pipelines that have not yet registered any metrics
+        next nil if p_stats.nil?
         res = {
           "id" => pipeline_id.to_s,
           "hash" => pipeline.lir.unique_hash,
@@ -33,8 +35,8 @@ module LogStash; module Config;
           "events" => format_pipeline_events(p_stats[:events]),
           "queue" => format_queue_stats(pipeline_id, metric_store),
           "reloads" => {
-            "successes" => p_stats[:reloads][:successes].value,
-            "failures" => p_stats[:reloads][:failures].value
+            "successes" => (p_stats.dig(:reloads, :successes)&.value || 0),
+            "failures" => (p_stats.dig(:reloads, :failures)&.value || 0)
           }
         }
         if extended_performance_collection


### PR DESCRIPTION
Backport PR #13645 to 8.0 branch. Original message: 

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes

[rn:skip]


## What does this PR do?

Minor resilience improvements to pipeline stats, to resolve an edge-case where we are asked to report stats while a pipeline is in the process of starting up. There are three situations where this is relevant:
 - querying pipeline stats API: could result in a 500 response, but an immediate retry would be back to a 200 OK response.
 - Monitoring pipeline could fail to capture a stats snapshot, but the next tick would succeed
 - test assertions could fail in not-quite relevant ways, requiring a rebuild:
   > ~~~
   > 13:41:46     Failures:
   > 13:41:46 
   > 13:41:46       1) LogStash::Inputs::Metrics::StatsEventFactory new model behaves like new model monitoring event with webserver setting should be valid
   > 13:41:46          Failure/Error: "pipelines" => LogStash::Config::PipelinesInfo.format_pipelines_info(agent, @metric_store, extended_performance_collection),
   > 13:41:46          
   > 13:41:46          NoMethodError:
    > 13:41:46            undefined method `[]' for nil:NilClass
    > 13:41:46          Shared Example Group: "new model monitoring event with webserver setting" called from ./spec/monitoring/inputs/metrics/stats_event_factory_spec.rb:90
   > 13:41:46          # /opt/logstash/logstash-core/lib/logstash/config/pipelines_info.rb:36:in `block in format_pipelines_info'
   > 13:41:46          # /opt/logstash/logstash-core/lib/logstash/config/pipelines_info.rb:25:in `format_pipelines_info'
   > 13:41:46          # ./lib/monitoring/inputs/metrics/stats_event_factory.rb:24:in `make'
   > 13:41:46          # ./spec/monitoring/inputs/metrics/stats_event_factory_spec.rb:37:in `block in <main>'
   > 13:41:46          # /opt/logstash/vendor/bundle/jruby/2.5.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block in /opt/logstash/vendor/bundle/jruby/2.5.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb'
   > 13:41:46          # /opt/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-devutils-2.3.0-java/lib/logstash/devutils/rspec/spec_helper.rb:61:in `block in /opt/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-devutils-2.3.0-java/lib/logstash/devutils/rspec/spec_helper.rb'
   > 13:41:46          # /opt/logstash/lib/bootstrap/rspec.rb:31:in `<main>'
   > 13:41:46 
   > 13:41:46     Finished in 38.52 seconds (files took 5.82 seconds to load)
   > 13:41:46     267 examples, 1 failure, 4 pending
   > ~~~

## Why is it important/What is the impact to the user?

Prevents a transient and rare error, reduces rare but unnecessary log noise, and improves stability of CI builds

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~

