### PR TITLE
Backport PR #13221 to 7.17: logging: move init into environment's settings post-processor

### DIFF
--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -112,6 +112,23 @@ module LogStash
   default_dlq_file_path = ::File.join(SETTINGS.get("path.data"), "dead_letter_queue")
   SETTINGS.register Setting::WritableDirectory.new("path.dead_letter_queue", default_dlq_file_path)
 
+  SETTINGS.on_post_process do |settings|
+    # Configure Logstash logging facility. This needs to be done as early as possible to
+    # make sure the logger has the correct settings tnd the log level is correctly defined.
+    java.lang.System.setProperty("ls.logs", settings.get("path.logs"))
+    java.lang.System.setProperty("ls.log.format", settings.get("log.format"))
+    java.lang.System.setProperty("ls.log.level", settings.get("log.level"))
+    java.lang.System.setProperty("ls.pipeline.separate_logs", settings.get("pipeline.separate_logs").to_s)
+    unless java.lang.System.getProperty("log4j.configurationFile")
+      log4j_config_location = ::File.join(settings.get("path.settings"), "log4j2.properties")
+
+      # Windows safe way to produce a file: URI.
+      file_schema = "file://" + (LogStash::Environment.windows? ? "/" : "")
+      LogStash::Logging::Logger::reconfigure(::URI.encode(file_schema + ::File.absolute_path(log4j_config_location)))
+    end
+    # override log level that may have been introduced from a custom log4j config file
+    LogStash::Logging::Logger::configure_logging(settings.get("log.level"))
+  end
 
   SETTINGS.on_post_process do |settings|
     # If the data path is overridden but the queue path isn't recompute the queue path

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -299,22 +299,6 @@ class LogStash::Runner < Clamp::StrictCommand
     require "logstash/util/java_version"
     require "stud/task"
 
-    # Configure Logstash logging facility, this need to be done before everything else to
-    # make sure the logger has the correct settings and the log level is correctly defined.
-    java.lang.System.setProperty("ls.logs", setting("path.logs"))
-    java.lang.System.setProperty("ls.log.format", setting("log.format"))
-    java.lang.System.setProperty("ls.log.level", setting("log.level"))
-    java.lang.System.setProperty("ls.pipeline.separate_logs", setting("pipeline.separate_logs").to_s)
-    unless java.lang.System.getProperty("log4j.configurationFile")
-      log4j_config_location = ::File.join(setting("path.settings"), "log4j2.properties")
-
-      # Windows safe way to produce a file: URI.
-      file_schema = "file://" + (LogStash::Environment.windows? ? "/" : "")
-      LogStash::Logging::Logger::reconfigure(URI.encode(file_schema + File.absolute_path(log4j_config_location)))
-    end
-    # override log level that may have been introduced from a custom log4j config file
-    LogStash::Logging::Logger::configure_logging(setting("log.level"))
-
     if log_configuration_contains_javascript_usage?
       logger.warn("Logging configuration uses appender or filter with scripting language JavaScript, which will be removed in a future major release of Logstash.")
     end


### PR DESCRIPTION
Backport PR #13221 to 7.17 branch. Original message: 

Ensures that the non-runner command line utilities like `bin/logstash-keystore`
correctly initialize the logger as-configured.

## Release notes

Fixed an issue where invoking the Logstash Keystore Utility (`bin/logstash-keystore`) incorrectly set up a logging directory to the literal `${sys:ls.logs}` and produced noise to the console about routing logs. This utility now correctly configures its logger using the provided settings file.

## What does this PR do?

Moves logger configuration "up" into the settings post-processor, which is invoked by both the normal pipeline runner _and_ the keystore utility `bin/logstash-keystore`. Now invoking either will correctly pick up logging configuration.

## Why is it important/What is the impact to the user?

Fixes an issue where invoking the Logstash Keystore Utility (`bin/logstash-keystore`) didn't route its logs correctly. Now the logs are where we expect them to be.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~

## How to test this PR locally

1. check out and assemble
2. Invoke `bin/logstash-keystore create`
3. Observe that the literal directory `${sys:ls.logs}` was not created in the current working directory
4. Optionally configure `path.logs`, `log.format` and/or `log.level` in your `config/logstash.yml`, and re-invoke the keystore utility. Observe that preferences are observed.
