### PR TITLE
Remove java 8 from setup readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Logstash core will continue to exist under this repository and all related issue
 
 ### Prerequisites
 
-* Install JDK version 8 or 11. Make sure to set the `JAVA_HOME` environment variable to the path to your JDK installation directory. For example `set JAVA_HOME=<JDK_PATH>`
+* Install JDK version 11. Make sure to set the `JAVA_HOME` environment variable to the path to your JDK installation directory. For example `set JAVA_HOME=<JDK_PATH>`
 * Install JRuby 9.2.x It is recommended to use a Ruby version manager such as [RVM](https://rvm.io/) or [rbenv](https://github.com/sstephenson/rbenv).
 * Install `rake` and `bundler` tool using `gem install rake` and `gem install bundler` respectively.
 


### PR DESCRIPTION
## Release notes

[rn:skip]

## What does this PR do?

Updates dev doc to only reference java 11.

## Why is it important/What is the impact to the user?

Attempting to `rake bootstrap` on java 8 just throws "The minimum required Java version is 11" for me.

## Checklist

- ~~My code follows the style guidelines of this project~~
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~I have added tests that prove my fix is effective or that my feature works~~

## How to test this PR locally

Try `rake bootstrap` on java 8, then on 11.

