### PR TITLE
Bump Gemfile lock for 8.0.0-rc2

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -89,35 +89,39 @@ GEM
     elastic-app-search (7.8.0)
       jwt (>= 1.5, < 3.0)
     elastic-workplace-search (0.4.1)
-    elasticsearch (7.16.1)
-      elasticsearch-api (= 7.16.1)
-      elasticsearch-transport (= 7.16.1)
-    elasticsearch-api (7.16.1)
+    elasticsearch (7.16.3)
+      elasticsearch-api (= 7.16.3)
+      elasticsearch-transport (= 7.16.3)
+    elasticsearch-api (7.16.3)
       multi_json
-    elasticsearch-transport (7.16.1)
+    elasticsearch-transport (7.16.3)
       faraday (~> 1)
       multi_json
     equalizer (0.0.11)
-    faraday (1.8.0)
+    faraday (1.9.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0.1)
+      faraday-httpclient (~> 1.0)
+      faraday-multipart (~> 1.0)
       faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.1)
+      faraday-net_http_persistent (~> 1.0)
       faraday-patron (~> 1.0)
       faraday-rack (~> 1.0)
-      multipart-post (>= 1.2, < 3)
+      faraday-retry (~> 1.0)
       ruby2_keywords (>= 0.0.4)
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
+    faraday-multipart (1.0.3)
+      multipart-post (>= 1.2, < 3)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
-    ffi (1.15.4-java)
+    faraday-retry (1.0.3)
+    ffi (1.15.5-java)
     filesize (0.2.0)
     fivemat (1.3.7)
     flores (0.0.7)
@@ -136,7 +140,7 @@ GEM
     gems (1.2.0)
     gene_pool (1.5.0)
       concurrent-ruby (>= 1.0)
-    git (1.10.1)
+    git (1.10.2)
       rchardet (~> 1.8)
     hashdiff (1.0.1)
     hitimes (1.3.1-java)
@@ -157,7 +161,7 @@ GEM
       cabin (>= 0.6.0)
     jls-lumberjack (0.0.26)
       concurrent-ruby
-    jmespath (1.4.0)
+    jmespath (1.5.0)
     jrjackson (0.4.14-java)
     jruby-jms (1.3.0-java)
       gene_pool
@@ -293,7 +297,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ecs_compatibility_support (~> 1.2)
       murmurhash3
-    logstash-filter-geoip (7.2.9-java)
+    logstash-filter-geoip (7.2.10-java)
       logstash-core (>= 7.14.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ecs_compatibility_support (~> 1.2)
@@ -468,7 +472,7 @@ GEM
       logstash-codec-json
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       redis (>= 4.0.1, < 5)
-    logstash-input-s3 (3.8.2)
+    logstash-input-s3 (3.8.3)
       logstash-core-plugin-api (>= 2.1.12, <= 2.99)
       logstash-mixin-aws (>= 4.3.0)
       logstash-mixin-ecs_compatibility_support (~> 1.2)
@@ -537,7 +541,7 @@ GEM
       elastic-workplace-search (~> 0.4.1)
       logstash-codec-plain
       logstash-core-plugin-api (~> 2.0)
-    logstash-integration-jdbc (5.2.1)
+    logstash-integration-jdbc (5.2.2)
       logstash-codec-plain
       logstash-core (>= 6.5.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -545,7 +549,7 @@ GEM
       logstash-mixin-event_support (~> 1.0)
       logstash-mixin-validator_support (~> 1.0)
       lru_redux
-      rufus-scheduler (< 3.5)
+      rufus-scheduler (~> 3.0.9)
       sequel
       tzinfo
       tzinfo-data
@@ -590,11 +594,11 @@ GEM
       logstash-filter-json
       logstash-input-generator
       logstash-output-file
-    logstash-output-elasticsearch (11.3.3-java)
+    logstash-output-elasticsearch (11.4.1-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-deprecation_logger_support (~> 1.0)
       logstash-mixin-ecs_compatibility_support (~> 1.0)
-      manticore (>= 0.7.1, < 1.0.0)
+      manticore (>= 0.8.0, < 1.0.0)
       stud (~> 0.0, >= 0.0.17)
     logstash-output-email (4.1.1)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -652,12 +656,12 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       snappy (= 0.0.12)
       webhdfs
-    logstash-patterns-core (4.3.1)
+    logstash-patterns-core (4.3.2)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     lru_redux (1.1.0)
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
-    manticore (0.7.1-java)
+    manticore (0.8.0-java)
       openssl_pkcs8_pure
     march_hare (4.4.0-java)
     memoizable (0.4.2)
@@ -669,7 +673,7 @@ GEM
       hitimes (~> 1.1)
     mime-types (2.6.2)
     minitar (0.9)
-    msgpack (1.4.2-java)
+    msgpack (1.4.4-java)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     murmurhash3 (0.1.6-java)
@@ -679,7 +683,7 @@ GEM
     nio4r (2.5.8-java)
     nokogiri (1.12.5-java)
       racc (~> 1.4)
-    octokit (4.21.0)
+    octokit (4.22.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     openssl_pkcs8_pure (0.0.0.2)
@@ -715,7 +719,7 @@ GEM
       rspec-mocks (~> 3.10.0)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.1)
+    rspec-expectations (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-mocks (3.10.2)
@@ -911,4 +915,4 @@ DEPENDENCIES
   webmock (~> 3)
 
 BUNDLED WITH
-   2.3.4
+   2.3.5


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip] 

## What does this PR do?
Bumps the Gemfile.lock for the `8.0.0-rc2`