### PR TITLE
Test fix, switch to plugin with less dependencies

### DIFF
--- a/qa/integration/specs/cli/install_spec.rb
+++ b/qa/integration/specs/cli/install_spec.rb
@@ -118,7 +118,7 @@ describe "CLI > logstash-plugin install" do
     end
 
     context "install non bundle plugin" do
-      let(:plugin_name) { "logstash-input-google_cloud_storage" }
+      let(:plugin_name) { "logstash-input-github" }
       let(:install_command) { "bin/logstash-plugin install" }
 
       after(:each) do


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Fixes an integration test that verifies the capabilities of CLI tool to install a not bundled plugin.
The test needs to peek a plugin that's not bundled with the Logstash distribution, the originally chosen plugin `logstash-input-google_cloud_storage` has a [dependency on](https://github.com/logstash-plugins/logstash-input-google_cloud_storage/blob/46ff388dd8c5470840b172eec92f8781aac786cb/logstash-input-google_cloud_storage.gemspec#L43) `mimemagic` gem. The required gem needs that on the target system is present the file `freedesktop.org.xml` which is shipped in OS packages named `shared-mime-info`, however this package is not present on Debian 10 used by CI, generating a test failure.

## Why is it important/What is the impact to the user?
Impact only the CI integration tests.

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Run `ci/integration-tests.sh split 1` on a Debian 10.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Logs
Error from the console:
```sh
1) CLI > logstash-plugin install pack install non bundle plugin successfully install the plugin
         Got 2 failures:

         1.1) Failure/Error: expect(execute.stderr_and_stdout).to match(/Installation successful/)
              
                expected "Using system java: /home/andsel/.sdkman/candidates/java/current/bin/java\nOpenJDK 64-Bit Server VM w...e:\n  logstash-input-google_cloud_storage was resolved to 0.11.1, which depends on\n    mimemagic\n" to match /Installation successful/
                Diff:
                @@ -1,599 +1,1197 @@
                -/Installation successful/
                +Using system java: /home/andsel/.sdkman/candidates/java/current/bin/java
                +OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.
                +Validating logstash-input-google_cloud_storage
                +Resolving mixin dependencies
                +Installing logstash-input-google_cloud_storage
                +Error Bundler::InstallError, retrying 1/10
                +Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
                +
                +    current directory: /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/gems/mimemagic-0.4.3/ext/mimemagic
                +/home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/jruby/bin/jruby -I/home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/jruby/lib/ruby/stdlib/rubygems -rrubygems /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/gems/rake-12.3.3/exe/rake RUBYARCHDIR\=/home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/extensions/universal-java-11/2.5.0/mimemagic-0.4.3 RUBYLIBDIR\=/home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/extensions/universal-java-11/2.5.0/mimemagic-0.4.3
                +OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.
                +rake aborted!
                +Could not find MIME type database in the following locations: ["/usr/local/share/mime/packages/freedesktop.org.xml", "/opt/homebrew/share/mime/packages/freedesktop.org.xml", "/opt/local/share/mime/packages/freedesktop.org.xml", "/usr/share/mime/packages/freedesktop.org.xml"]
                +
                +Ensure you have either installed the shared-mime-info package for your distribution, or
                +obtain a version of freedesktop.org.xml and set FREEDESKTOP_MIME_TYPES_PATH to the location
                +of that file.
                +/home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/gems/mimemagic-0.4.3/ext/mimemagic/Rakefile:15:in `locate_mime_database'
                +/home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/gems/mimemagic-0.4.3/ext/mimemagic/Rakefile:26:in `block in <main>'
                +/home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/gems/rake-12.3.3/exe/rake:27:in `<main>'
                +Tasks: TOP => default
                +(See full trace by running task with --trace)
                +
                +rake failed, exit code 1
                +
                +Gem files will remain installed in /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/gems/mimemagic-0.4.3 for inspection.
                +Results logged to /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/extensions/universal-java-11/2.5.0/mimemagic-0.4.3/gem_make.out
                +
                +  /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/jruby/lib/ruby/stdlib/rubygems/ext/builder.rb:99:in `run'
                +  /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/jruby/lib/ruby/stdlib/rubygems/ext/rake_builder.rb:30:in `build'
                +  /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/jruby/lib/ruby/stdlib/rubygems/ext/builder.rb:169:in `block in build_extension'
                +  /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/jruby/lib/ruby/stdlib/monitor.rb:237:in `block in mon_synchronize'
                +  org/jruby/RubyThread.java:759:in `handle_interrupt'
                +  /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/jruby/lib/ruby/stdlib/monitor.rb:236:in `block in mon_synchronize'
                +  org/jruby/RubyThread.java:759:in `handle_interrupt'
                +  /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/jruby/lib/ruby/stdlib/monitor.rb:233:in `mon_synchronize'
                +  /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/jruby/lib/ruby/stdlib/rubygems/ext/builder.rb:165:in `build_extension'
                +  /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/jruby/lib/ruby/stdlib/rubygems/ext/builder.rb:210:in `block in build_extensions'
                +  org/jruby/RubyArray.java:1821:in `each'
                +  /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/jruby/lib/ruby/stdlib/rubygems/ext/builder.rb:207:in `build_extensions'
                +  /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/jruby/lib/ruby/stdlib/rubygems/installer.rb:844:in `build_extensions'
                +  /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/rubygems_gem_installer.rb:71:in `build_extensions'
                +  /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/rubygems_gem_installer.rb:28:in `install'
                +  /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/source/rubygems.rb:194:in `install'
                +  /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/installer/gem_installer.rb:54:in `install'
                +  /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/installer/gem_installer.rb:16:in `install_from_spec'
                +  /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/installer/parallel_installer.rb:186:in `do_install'
                +  /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/installer/parallel_installer.rb:177:in `block in worker_pool'
                +  /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/worker.rb:62:in `apply_func'
                +  /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/worker.rb:57:in `block in process_queue'
                +  org/jruby/RubyKernel.java:1442:in `loop'
                +  /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/worker.rb:54:in `process_queue'
                +  /home/andsel/logstash/build/logstash-8.1.0-SNAPSHOT/vendor/bundle/jruby/2.5.0/gems/bundler-2.3.5/lib/bundler/worker.rb:91:in `block in create_threads'
                +
                +An error occurred while installing mimemagic (0.4.3), and Bundler cannot continue.


```
