### PR TITLE
[Backport 7.17] Test fix, switch to plugin with less dependencies (#13672)

### DIFF
--- a/qa/integration/specs/cli/install_spec.rb
+++ b/qa/integration/specs/cli/install_spec.rb
@@ -118,7 +118,7 @@ describe "CLI > logstash-plugin install" do
     end
 
     context "install non bundle plugin" do
-      let(:plugin_name) { "logstash-input-google_cloud_storage" }
+      let(:plugin_name) { "logstash-input-github" }
       let(:install_command) { "bin/logstash-plugin install" }
 
       after(:each) do


### PR DESCRIPTION
Clean backport of #13672 to `7.17` branch

----

Fixes an integration test that verifies the capabilities of CLI tool to install a not bundled plugin.
Move away from logstash-input-google_cloud_storage which depends indirectly to OS's package named shared-mime-info, which is not always available.

(cherry picked from commit 7bb56e46dd0cccf9b4fc55e6d8dcc99ca325370f)
