### PR TITLE
tools: allow version bump to use local lockfile as baseline

### DIFF
--- a/tools/release/bump_plugin_versions.rb
+++ b/tools/release/bump_plugin_versions.rb
@@ -24,7 +24,14 @@ require 'optparse'
 
 options = {pr: true}
 OptionParser.new do |opts|
-  opts.banner = "Usage: bump_plugin_versions.rb base_branch last_release allow_for --[no-]pr"
+  opts.banner = <<~EOBANNER
+   Usage: bump_plugin_versions.rb base_branch last_release allow_for --[no-]pr
+
+   If you have a local lockfile, you can specify "LOCAL" for last_release to
+   use it as your baseline. This allows you to consume patch releases on a
+   minor release after feature freeze and the initial minor updates.
+
+  EOBANNER
 
   opts.on("--[no-]pr", "Create Pull Request") do |v|
     options[:pr] = v
@@ -56,12 +63,22 @@ end
 
 puts "Computing #{allow_bump_for} plugin dependency bump from #{base_logstash_version}.."
 
-puts "Fetching lock file for #{base_logstash_version}.."
-uri = URI.parse("https://raw.githubusercontent.com/elastic/logstash/v#{base_logstash_version}/Gemfile.jruby-2.5.lock.release")
-result = Net::HTTP.get(uri)
-if result.match(/404/)
-  puts "Lock file or git tag for #{base_logstash_version} not found. Aborting"
-  exit(1)
+if base_logstash_version == "LOCAL"
+  puts "Using local lockfile..."
+  begin
+    result = File.read("Gemfile.jruby-2.5.lock.release")
+  rescue => e
+    puts "Failed to read local lockfile #{e}"
+    exit(1)
+  end
+else
+  puts "Fetching lock file for #{base_logstash_version}.."
+  uri = URI.parse("https://raw.githubusercontent.com/elastic/logstash/v#{base_logstash_version}/Gemfile.jruby-2.5.lock.release")
+  result = Net::HTTP.get(uri)
+  if result.match(/404/)
+    puts "Lock file or git tag for #{base_logstash_version} not found. Aborting"
+    exit(1)
+  end
 end
 
 base_plugin_versions = {}


### PR DESCRIPTION

## Release notes
[rn:skip]

## What does this PR do?

Adds support for using a local lockfile when bumping plugin versions.

In the time between a minor release's feature freeze and its final build candidate, it is helpful to be able to bump plugin _patches_, in order to constrain the changes that go into the in-flight release, but to do so requires using the in-flight lockfile as a baseline.

This changeset empowers the release manager to use that local lockfile as a baseline, instead of the published artifact of a prior release. It was used to create #13680 and #13681

## Why is it important/What is the impact to the user?

Reduces risk during release cycle, improving our confidence in releases

## Checklist


- [x] My code follows the style guidelines of this project
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

On an in-flight major or minor release branch that has a lockfile, run:

~~~
ruby tools/release/bump_plugin_versions.rb 8.0 LOCAL patch --no-pr
~~~

