### PR TITLE
Update failing policy in Central Management fetcher and license checker if hit ES down node

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -1,7 +1,7 @@
 ---
 # alpha and beta qualifiers are now added via VERSION_QUALIFIER environment var
-logstash: 8.1.0
-logstash-core: 8.1.0
+logstash: 8.2.0
+logstash-core: 8.2.0
 logstash-core-plugin-api: 2.1.16
 
 bundled_jdk:

--- a/versions.yml
+++ b/versions.yml
@@ -1,7 +1,7 @@
 ---
 # alpha and beta qualifiers are now added via VERSION_QUALIFIER environment var
-logstash: 8.2.0
-logstash-core: 8.2.0
+logstash: 8.1.0
+logstash-core: 8.1.0
 logstash-core-plugin-api: 2.1.16
 
 bundled_jdk:

--- a/x-pack/lib/helpers/loggable_try.rb
+++ b/x-pack/lib/helpers/loggable_try.rb
@@ -1,0 +1,18 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+require 'stud/try'
+
+module LogStash module Helpers
+  class LoggableTry < Stud::Try
+    def initialize(logger, name)
+      @logger = logger
+      @name = name
+    end
+
+    def log_failure(exception, fail_count, message)
+      @logger.warn("Attempt to #{@name} failed. #{message}", fail_count: fail_count, exception: exception.message)
+    end
+  end
+end end

--- a/x-pack/qa/integration/management/read_configuration_spec.rb
+++ b/x-pack/qa/integration/management/read_configuration_spec.rb
@@ -40,7 +40,7 @@ describe "Read configuration from elasticsearch" do
 
     stdout_lines = @logstash_service.stdout_lines
     res = stdout_lines.any?(/Could not fetch all the sources/)
-    if !res
+    if res
       puts "DNADBG>> lines: \n\n #{stdout_lines} \n\n"
     end
     expect(res).to be false

--- a/x-pack/qa/integration/management/read_configuration_spec.rb
+++ b/x-pack/qa/integration/management/read_configuration_spec.rb
@@ -38,8 +38,8 @@ describe "Read configuration from elasticsearch" do
 
     @logstash_service = logstash("bin/logstash -w 1", logstash_options)
 
-    stdout_lines = @logstash_service.stdout_lines
-    expect(stdout_lines.any?(/Could not fetch all the sources/)).to be false
+    full_log = @logstash_service.stdout_lines.join("\n")
+    expect(full_log).not_to match(/Could not fetch all the sources/)
   end
 
   def stop_services

--- a/x-pack/qa/integration/management/read_configuration_spec.rb
+++ b/x-pack/qa/integration/management/read_configuration_spec.rb
@@ -15,7 +15,7 @@ describe "Read configuration from elasticsearch" do
         "xpack.management.enabled" => true,
         "xpack.management.pipeline.id" => pipeline_id,
         "xpack.management.logstash.poll_interval" => "1s",
-        "xpack.management.elasticsearch.hosts" => ["http://localhost:9200"],
+        "xpack.management.elasticsearch.hosts" => ["http://localhost:9200", "http://localhost:19200"],
         "xpack.management.elasticsearch.username" => "elastic",
         "xpack.management.elasticsearch.password" => elastic_password,
         "xpack.monitoring.elasticsearch.username" => "elastic",
@@ -37,6 +37,10 @@ describe "Read configuration from elasticsearch" do
     push_elasticsearch_config(PIPELINE_ID, config)
 
     @logstash_service = logstash("bin/logstash -w 1", logstash_options)
+    cls = @logstash_service.stdout_lines.class
+    puts "DNADBG>> stdout_lines.class: #{cls}\n\n #{@logstash_service.stdout_lines} \n\n"
+
+    expect(@logstash_service.stdout_lines.any?(/Could not fetch all the sources/)).to be false
   end
 
   def stop_services
@@ -53,6 +57,7 @@ describe "Read configuration from elasticsearch" do
       stop_services
     end
 
+# [ERROR][logstash.config.sourceloader] Could not fetch all the sources....HostUnreachableError
     it "fetches the configuration from elasticsearch" do
       temporary_file = File.join(Stud::Temporary.directory, "hello.log")
       new_config = "input { generator { count => 10000 }} output { file { path => '#{temporary_file}' } }"
@@ -81,7 +86,7 @@ describe "Read configuration from elasticsearch" do
     end
   end
 
-  context "security is disabled" do
+  xcontext "security is disabled" do
     before(:all) do
       elasticsearch_options = {
         :settings => {

--- a/x-pack/qa/integration/management/read_configuration_spec.rb
+++ b/x-pack/qa/integration/management/read_configuration_spec.rb
@@ -38,7 +38,12 @@ describe "Read configuration from elasticsearch" do
 
     @logstash_service = logstash("bin/logstash -w 1", logstash_options)
 
-    expect(@logstash_service.stdout_lines.any?(/Could not fetch all the sources/)).to be false
+    stdout_lines = @logstash_service.stdout_lines
+    res = stdout_lines.any?(/Could not fetch all the sources/)
+    if !res
+      puts "DNADBG>> lines: \n\n #{stdout_lines} \n\n"
+    end
+    expect(res).to be false
   end
 
   def stop_services

--- a/x-pack/qa/integration/management/read_configuration_spec.rb
+++ b/x-pack/qa/integration/management/read_configuration_spec.rb
@@ -37,8 +37,6 @@ describe "Read configuration from elasticsearch" do
     push_elasticsearch_config(PIPELINE_ID, config)
 
     @logstash_service = logstash("bin/logstash -w 1", logstash_options)
-    cls = @logstash_service.stdout_lines.class
-    puts "DNADBG>> stdout_lines.class: #{cls}\n\n #{@logstash_service.stdout_lines} \n\n"
 
     expect(@logstash_service.stdout_lines.any?(/Could not fetch all the sources/)).to be false
   end
@@ -57,7 +55,6 @@ describe "Read configuration from elasticsearch" do
       stop_services
     end
 
-# [ERROR][logstash.config.sourceloader] Could not fetch all the sources....HostUnreachableError
     it "fetches the configuration from elasticsearch" do
       temporary_file = File.join(Stud::Temporary.directory, "hello.log")
       new_config = "input { generator { count => 10000 }} output { file { path => '#{temporary_file}' } }"
@@ -86,7 +83,7 @@ describe "Read configuration from elasticsearch" do
     end
   end
 
-  xcontext "security is disabled" do
+  context "security is disabled" do
     before(:all) do
       elasticsearch_options = {
         :settings => {

--- a/x-pack/qa/integration/management/read_configuration_spec.rb
+++ b/x-pack/qa/integration/management/read_configuration_spec.rb
@@ -39,11 +39,7 @@ describe "Read configuration from elasticsearch" do
     @logstash_service = logstash("bin/logstash -w 1", logstash_options)
 
     stdout_lines = @logstash_service.stdout_lines
-    res = stdout_lines.any?(/Could not fetch all the sources/)
-    if res
-      puts "DNADBG>> lines: \n\n #{stdout_lines} \n\n"
-    end
-    expect(res).to be false
+    expect(stdout_lines.any?(/Could not fetch all the sources/)).to be false
   end
 
   def stop_services

--- a/x-pack/spec/license_checker/license_reader_spec.rb
+++ b/x-pack/spec/license_checker/license_reader_spec.rb
@@ -72,7 +72,7 @@ describe LogStash::LicenseChecker::LicenseReader do
       let(:host_not_reachable) { LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError.new(StandardError.new("original error"), "http://localhost:19200") }
       before(:each) do
         # set up expectation of single failure
-        expect(license_reader.logger).to receive(:warn).with(a_string_including "Attempt to validate Elasticsearch license failed.")
+        expect(subject.logger).to receive(:warn).with(a_string_starting_with("Attempt to validate Elasticsearch license failed."), any_args)
         expect(mock_client).to receive(:get).with('_xpack').and_raise(host_not_reachable).once
         
         # ensure subsequent success

--- a/x-pack/spec/license_checker/license_reader_spec.rb
+++ b/x-pack/spec/license_checker/license_reader_spec.rb
@@ -71,9 +71,6 @@ describe LogStash::LicenseChecker::LicenseReader do
     context 'and receives HostUnreachableError' do
       let(:host_not_reachable) { LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError.new(StandardError.new("original error"), "http://localhost:19200") }
       before(:each) do
-         #This seems to do not work
-#         allow(mock_client).to receive(:get).with('_xpack').once.and_raise(host_not_reachable)
-#         allow(mock_client).to receive(:get).with('_xpack').once.and_return(xpack_info)
         first_call = true
         allow(mock_client).to receive(:get) do
           if first_call
@@ -85,11 +82,6 @@ describe LogStash::LicenseChecker::LicenseReader do
       end
       it 'continues to fetch and return an XPackInfo' do
         expect(subject.fetch_xpack_info.failed?).to be false
-      end
-
-      it "DBG test multiple calls" do
-        expect{ subject.client.get('_xpack') }.to raise_error(LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError)
-        expect(mock_client.get('_xpack')).to eq(xpack_info)
       end
     end
     context 'when client raises a ConnectionError' do

--- a/x-pack/spec/license_checker/license_reader_spec.rb
+++ b/x-pack/spec/license_checker/license_reader_spec.rb
@@ -51,7 +51,7 @@ describe LogStash::LicenseChecker::LicenseReader do
   describe '#fetch_xpack_info' do
     let(:xpack_info_class) { LogStash::LicenseChecker::XPackInfo }
     let(:mock_client) { double('Client') }
-    before(:each) { expect(subject).to receive(:client).and_return(mock_client) }
+    before(:each) { expect(subject).to receive(:client).and_return(mock_client).at_most(:twice) }
     let(:xpack_info) do
       {
           "license" => {},
@@ -72,7 +72,8 @@ describe LogStash::LicenseChecker::LicenseReader do
       let(:host_not_reachable) { LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError.new(StandardError.new("original error"), "http://localhost:19200") }
       before(:each) do
         first_call = true
-        allow(mock_client).to receive(:get) do
+        allow(mock_client).to receive(:get) do |path|
+          expect(path).to eq('_xpack')
           if first_call
             first_call = false
             raise host_not_reachable


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Fix bug in retrieving pipeline configuration from central management and license validation which make Logstash process crash if a configured node of the Elasticsearch cluster is down.

## What does this PR do?
Wraps the calls to the central management Elasticsearch cluster with the utility class `Stud::Try` to handle the remote  host error when the client used to connect hit a not available node.


## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
Central Management Elasticsearch node list is configured in `logstash.yml` file. If any of those Elasticsearch nodes is down when Logstash starts and hits one of down nodes then it could be that the license check fails and crash Logstash or that the not handled host error exception avoid to receive the pipelines updates.
With this fix the maintenance of an configuration cluster node doesn't prevent the Logstash start.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Test the PR as described in the issue it resolves.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Follow the instructions provided in the resolved issue #12776.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Fixes #12776 

