### PR TITLE
handle fully acked 0 byte PQ pages

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -324,6 +324,7 @@ public final class Queue implements Closeable {
                 if (headCheckpoint.maxSeqNum() > this.seqNum) {
                     this.seqNum = headCheckpoint.maxSeqNum();
                 }
+
                 newCheckpointedHeadpage(headCheckpoint.getPageNum() + 1);
 
                 pqSizeBytes += (long) pageIO.getHead();

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -324,10 +324,8 @@ public final class Queue implements Closeable {
                 if (headCheckpoint.maxSeqNum() > this.seqNum) {
                     this.seqNum = headCheckpoint.maxSeqNum();
                 }
-                newCheckpointedHeadpage(headCheckpoint.getPageNum() + 1);
 
-                pqSizeBytes += (long) pageIO.getHead();
-                ensureDiskAvailable(this.maxBytes, pqSizeBytes);
+                newCheckpointedHeadpage(headCheckpoint.getPageNum() + 1);
                 return true;
             }
         }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -324,8 +324,10 @@ public final class Queue implements Closeable {
                 if (headCheckpoint.maxSeqNum() > this.seqNum) {
                     this.seqNum = headCheckpoint.maxSeqNum();
                 }
-
                 newCheckpointedHeadpage(headCheckpoint.getPageNum() + 1);
+
+                pqSizeBytes += (long) pageIO.getHead();
+                ensureDiskAvailable(this.maxBytes, pqSizeBytes);
                 return true;
             }
         }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/MmapPageIOV1.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/MmapPageIOV1.java
@@ -219,6 +219,13 @@ public final class MmapPageIOV1 implements PageIO {
         return this.head;
     }
 
+    @Override
+    public boolean isCorruptedPage() throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(this.file, "rw")) {
+            return raf.length() < MmapPageIOV2.MIN_CAPACITY;
+        }
+    }
+
     private int checksum(byte[] bytes) {
         checkSummer.reset();
         checkSummer.update(bytes, 0, bytes.length);

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/MmapPageIOV2.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/MmapPageIOV2.java
@@ -271,6 +271,13 @@ public final class MmapPageIOV2 implements PageIO {
         return this.head;
     }
 
+    @Override
+    public boolean isCorruptedPage() throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(this.file, "rw")) {
+            return raf.length() < MIN_CAPACITY;
+        }
+    }
+
     private int checksum(byte[] bytes) {
         checkSummer.reset();
         checkSummer.update(bytes, 0, bytes.length);

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/MmapPageIOV2.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/MmapPageIOV2.java
@@ -301,7 +301,7 @@ public final class MmapPageIOV2 implements PageIO {
             this.capacity = pageFileCapacity;
 
             if (this.capacity < MIN_CAPACITY) {
-                throw new IOException(String.format("Page file size is too small to hold elements"));
+                throw new IOException(String.format("Page file size is too small to hold elements. Persistent queue found corrupted page. Run `pqcheck` and `pqrepair` to repair the queue."));
             }
             this.buffer = raf.getChannel().map(FileChannel.MapMode.READ_WRITE, 0, this.capacity);
         }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/MmapPageIOV2.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/MmapPageIOV2.java
@@ -301,7 +301,8 @@ public final class MmapPageIOV2 implements PageIO {
             this.capacity = pageFileCapacity;
 
             if (this.capacity < MIN_CAPACITY) {
-                throw new IOException(String.format("Page file size is too small to hold elements. Persistent queue found corrupted page. Run `pqcheck` and `pqrepair` to repair the queue."));
+                throw new IOException("Page file size is too small to hold elements. " +
+                        "This is potentially a queue corruption problem. Run `pqcheck` and `pqrepair` to repair the queue.");
             }
             this.buffer = raf.getChannel().map(FileChannel.MapMode.READ_WRITE, 0, this.capacity);
         }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/PageIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/PageIO.java
@@ -84,4 +84,7 @@ public interface PageIO extends Closeable {
 
     // @return the data container min sequence number
     long getMinSeqNum();
+
+    // check if the page size is < minimum size
+    boolean isCorruptedPage() throws IOException;
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->
Fixed: #10855 #8480

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Fix zero bytes persistent queue page which cause "Page file size is too small to hold elements" exception that block Logstash from start

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

When PQ is fully acked and the page size is zero byte, this PR deleted the corrupted page file and recreated checkpoint file. Also, rephase the error message to point user to `pqrepair`

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

The corrupted page files cause `java.io.IOException: Page file size is too small to hold elements` exception, which block Logstash start process. Prior to this change, users need to manually delete page file and check point file in order to pass the persistent queue check.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
enable persistent queue and run pipeline
```
    input {
      heartbeat {
        interval => 1
      }
    }
    output {
        stdout { codec => rubydebug }
    }
```
stop logstash and remove page file `page.0`
create a zero byte page file by `touch page.0`
run logstash again should have no error

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
