### PR TITLE
Doc: Fix formatting for bulleted list

### DIFF
--- a/docs/static/security/es-security.asciidoc
+++ b/docs/static/security/es-security.asciidoc
@@ -33,8 +33,8 @@ If you are running {es} on your own hardware and using the Elasticsearch cluster
 
 You need to:
 
-* Copy the self-signed CA certificate from {es} and save it to {ls}
-* Configure the elasticsearch-output plugin to use the certificate
+* Copy the self-signed CA certificate from {es} and save it to {ls}.
+* Configure the elasticsearch-output plugin to use the certificate.
 
 These steps are not necessary if your cluster is using public trusted certificates. 
 

--- a/docs/static/security/es-security.asciidoc
+++ b/docs/static/security/es-security.asciidoc
@@ -31,7 +31,8 @@ For more details, check out the
 
 If you are running {es} on your own hardware and using the Elasticsearch cluster's default self-signed certificates, you need to complete a few more steps to establish secure communication between {ls} and {es}.
 
-You need to: 
+You need to:
+
 * Copy the self-signed CA certificate from {es} and save it to {ls}
 * Configure the elasticsearch-output plugin to use the certificate
 


### PR DESCRIPTION
Bulleted list requires a return after into in order to render correctly. Otherwise, the whole list renders as a paragraph. 