### PR TITLE
update google java format dependency

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -178,7 +178,7 @@ dependencies {
     implementation 'org.codehaus.janino:janino:3.1.0'
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jacksonVersion}"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonVersion}"
-    //implementation group: 'com.google.guava', name: 'guava', version: '24.1.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     implementation('com.google.googlejavaformat:google-java-format:1.13.0') {
         exclude group: 'com.google.guava', module: 'guava'
     }

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -178,11 +178,8 @@ dependencies {
     implementation 'org.codehaus.janino:janino:3.1.0'
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jacksonVersion}"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonVersion}"
-    implementation group: 'com.google.guava', name: 'guava', version: '24.1.1-jre'
-    // WARNING: DO NOT UPGRADE "google-java-format"
-    // later versions require GPL licensed code in javac-shaded that is
-    // Apache2 incompatible
-    implementation('com.google.googlejavaformat:google-java-format:1.1') {
+    //implementation group: 'com.google.guava', name: 'guava', version: '24.1.1-jre'
+    implementation('com.google.googlejavaformat:google-java-format:1.13.0') {
         exclude group: 'com.google.guava', module: 'guava'
     }
     implementation 'org.javassist:javassist:3.26.0-GA'

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
@@ -23,7 +23,6 @@ package org.logstash.plugins.discovery;
 import com.google.common.base.Predicate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.logstash.plugins.AliasRegistry;
 import co.elastic.logstash.api.Codec;
 import co.elastic.logstash.api.Configuration;


### PR DESCRIPTION
Versions of google-java-format 1.8 and above no longer depend on the gpl2 javac-shaded jar, so we can upgrade.