### PR TITLE
Doc: Fix typo in 7.17 release notes

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -65,7 +65,7 @@ This section summarizes the changes in the following releases:
 [[featured-7-17-0]]
 ==== New features and enhancements
 
-* Docker images for `full` and `oss` distributions are now is based on Ununtu 20.04 (`ubi8` image remains unchanged) https://github.com/elastic/logstash/pull/13529[#13529]
+* Docker images for `full` and `oss` distributions are now is based on Ubuntu 20.04 (`ubi8` image remains unchanged) https://github.com/elastic/logstash/pull/13529[#13529]
 //* Backport #13442 to 7.17. Update logstash docker to use ubuntu 20.04 b… https://github.com/elastic/logstash/pull/13529[#13529]
 
 [[notable-7-17-0]]


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->


## What does this PR do?

Fixed a typo (Ubuntu instead of Ununtu) in the 7.17 Release Notes for Logstash

## Why is it important/What is the impact to the user?

Typo, making new OS for images not searchable.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [ ]

## How to test this PR locally


## Related issues

- 

## Use cases


## Screenshots

![image](https://user-images.githubusercontent.com/36699845/152160238-43a2a037-15de-4460-b704-e40ebc869968.png)

## Logs
