### PR TITLE
pqcheck pqrepair handle .tmp checkpoint

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/PqCheck.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/PqCheck.java
@@ -61,7 +61,7 @@ public final class PqCheck {
         }
         System.out.println(String.format("Checking queue dir: %s", path));
         try (
-            DirectoryStream<Path> checkpoints = Files.newDirectoryStream(path, "checkpoint.*")
+            DirectoryStream<Path> checkpoints = Files.newDirectoryStream(path, "checkpoint.{[0-9]*,head}")
         ) {
             StreamSupport.stream(
                 checkpoints.spliterator(), true

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/PqRepair.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/PqRepair.java
@@ -62,6 +62,9 @@ public final class PqRepair {
                 String.format("Given PQ path %s is not a directory.", path)
             );
         }
+
+        deleteTempCheckpoint(path);
+
         final Map<Integer, Path> pageFiles = new HashMap<>();
         try (final DirectoryStream<Path> pfs = Files.newDirectoryStream(path, "page.*")) {
             pfs.forEach(p -> pageFiles.put(
@@ -85,6 +88,14 @@ public final class PqRepair {
         fixMissingPages(pageFiles, checkpointFiles);
         fixZeroSizePages(pageFiles, checkpointFiles);
         fixMissingCheckpoints(pageFiles, checkpointFiles);
+    }
+
+    private static void deleteTempCheckpoint(final Path root) throws IOException {
+        try (final DirectoryStream<Path> cpTmp = Files.newDirectoryStream(root, "checkpoint.*.tmp")) {
+            for (Path cpTmpPath: cpTmp) {
+                Files.delete(cpTmpPath);
+            }
+        }
     }
 
     private static void deleteFullyAcked(final Path root, final Map<Integer, Path> pages,

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/PqRepair.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/PqRepair.java
@@ -93,6 +93,7 @@ public final class PqRepair {
     private static void deleteTempCheckpoint(final Path root) throws IOException {
         try (final DirectoryStream<Path> cpTmp = Files.newDirectoryStream(root, "checkpoint.*.tmp")) {
             for (Path cpTmpPath: cpTmp) {
+                LOGGER.info("Deleting temp checkpoint {}", cpTmpPath);
                 Files.delete(cpTmpPath);
             }
         }

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/PqRepairTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/PqRepairTest.java
@@ -98,6 +98,7 @@ public final class PqRepairTest {
     @Test
     public void testRemoveTempCheckPoint() throws Exception {
         Files.createFile(dataPath.resolve("checkpoint.head.tmp"));
+        Files.createFile(dataPath.resolve("checkpoint.1.tmp"));
         PqRepair.repair(dataPath);
         verifyQueue();
     }

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/PqRepairTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/PqRepairTest.java
@@ -95,6 +95,13 @@ public final class PqRepairTest {
         verifyQueue(0, 1, 4, 5);
     }
 
+    @Test
+    public void testRemoveTempCheckPoint() throws Exception {
+        Files.createFile(dataPath.resolve("checkpoint.head.tmp"));
+        PqRepair.repair(dataPath);
+        verifyQueue();
+    }
+
     private void verifyQueue() throws IOException {
         verifyQueue(IntStream.range(0, 6).toArray());
     }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->
Fixed: #11548
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

improve persistent queue tool to handle `.tmp` checkpoint

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

`pqcheck` skip checking `checkpoint.*.tmp` 
`pqrepair` delete `checkpoint.*.tmp` 

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

When Logstash shutdown unexpectedly, PQ could end in the middle of updating checkpoint file, and as a result, `checkpoint.*.tmp` left in the disk. Prior to the change, `pqcheck` and `pqrepair` crashed because of tmp file.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
https://github.com/elastic/logstash/pull/13166

Co-authored-by: Rob Bavey <rob.bavey@elastic.co>