### PR TITLE
[backport 8.0]Publish CPU percentage also non Unix systems (#13727)

### DIFF
--- a/logstash-core/src/main/java/org/logstash/instrument/monitors/ProcessMonitor.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/monitors/ProcessMonitor.java
@@ -53,7 +53,7 @@ public class ProcessMonitor {
             this.isUnix = osMxBean instanceof UnixOperatingSystemMXBean;
             // Defaults are -1
             if (this.isUnix) {
-                UnixOperatingSystemMXBean unixOsBean = (UnixOperatingSystemMXBean) osMxBean;;
+                UnixOperatingSystemMXBean unixOsBean = (UnixOperatingSystemMXBean) osMxBean;
 
                 this.openFds = unixOsBean.getOpenFileDescriptorCount();
                 this.maxFds =  unixOsBean.getMaxFileDescriptorCount();
@@ -61,9 +61,19 @@ public class ProcessMonitor {
                     unixOsBean.getProcessCpuTime(), TimeUnit.NANOSECONDS
                 );
                 this.cpuProcessPercent = scaleLoadToPercent(unixOsBean.getProcessCpuLoad());
-                this.cpuSystemPercent = getSystemCpuLoad();
+                this.cpuSystemPercent = getSystemCpuLoad(unixOsBean);
 
                 this.memTotalVirtualInBytes = unixOsBean.getCommittedVirtualMemorySize();
+            } else {
+                com.sun.management.OperatingSystemMXBean otherOsBean = (com.sun.management.OperatingSystemMXBean) osMxBean;
+
+                this.cpuMillisTotal = TimeUnit.MILLISECONDS.convert(
+                        otherOsBean.getProcessCpuTime(), TimeUnit.NANOSECONDS
+                );
+                this.cpuProcessPercent = scaleLoadToPercent(otherOsBean.getProcessCpuLoad());
+                this.cpuSystemPercent = getSystemCpuLoad(otherOsBean);
+
+                this.memTotalVirtualInBytes = otherOsBean.getCommittedVirtualMemorySize();
             }
         }
 
@@ -86,12 +96,8 @@ public class ProcessMonitor {
         }
 
         private static short scaleLoadToPercent(double load) {
-            if (osMxBean instanceof UnixOperatingSystemMXBean) {
-                if (load >= 0) {
-                    return (short) (load * 100);
-                } else {
-                    return -1;
-                }
+            if (load >= 0) {
+                return (short) (load * 100);
             } else {
                 return -1;
             }
@@ -100,12 +106,12 @@ public class ProcessMonitor {
         // The method `getSystemCpuLoad` is deprecated in favour of `getCpuLoad` since JDK14
         // This method uses reflection to use the correct method depending on the version of
         // the JDK being used.
-        private short getSystemCpuLoad() {
+        private short getSystemCpuLoad(OperatingSystemMXBean mxBeanInstance) {
             if (CPU_LOAD_METHOD == null){
                 return -1;
             }
             try {
-                return scaleLoadToPercent((double)CPU_LOAD_METHOD.invoke(osMxBean));
+                return scaleLoadToPercent((double) CPU_LOAD_METHOD.invoke(mxBeanInstance));
             } catch (Exception e){
                 return -1;
             }

--- a/logstash-core/src/test/java/org/logstash/instruments/monitors/ProcessMonitorTest.java
+++ b/logstash-core/src/test/java/org/logstash/instruments/monitors/ProcessMonitorTest.java
@@ -45,7 +45,6 @@ public class ProcessMonitorTest {
     @SuppressWarnings("unchecked")
     public void testReportCpuStats(){
         Map<String, Object> processStats = ProcessMonitor.detect().toMap();
-        assumeTrue((Boolean) processStats.get("is_unix"));
         assertThat("cpu", processStats.get("cpu"), instanceOf(Map.class));
         Map<String, Object> cpuStats = (Map<String, Object>) processStats.get("cpu");
         assertThat("cpu.process_percent", (Short)cpuStats.get("process_percent") >= 0, is(true));


### PR DESCRIPTION
Clean backport of #13727 to branch `8.0.`

----
Original comment:

Use same technique for Unix system to extract the CPU percentage and publish to Logstash's metrics collector.
It doesn't retrieve the full set of metric of a Unix system, but the ones that are available from internal JDK class com.sun.management.OperatingSystemMXBean

(cherry picked from commit d8f4784d69ef5bda26c884e06e4c3ebec54ff6f7)
