### PR TITLE
[backport 8.1]Update the Upgrading Using a Direct Download guide section. (#13684)

### DIFF
--- a/docs/static/upgrading.asciidoc
+++ b/docs/static/upgrading.asciidoc
@@ -75,13 +75,16 @@ some Logstash plugins have changed in the 7.x release.
 
 This procedure downloads the relevant Logstash binaries directly from Elastic.
 
-1. Shut down your Logstash pipeline, including any inputs that send events to Logstash.
-2. Download the https://www.elastic.co/downloads/logstash[Logstash installation file] that matches your host environment.
-3. Unpack the installation file into your Logstash directory.
-4. Test your configuration file with the `logstash --config.test_and_exit -f <configuration-file>` command. 
+. Shut down your Logstash pipeline, including any inputs that send events to Logstash.
+. Download the https://www.elastic.co/downloads/logstash[Logstash installation file] that matches your host environment.
+. Backup your `config/` and `data/` folders in a temporary space.
+. Delete your Logstash directory.
+. Unpack the installation file into the folder that contained the Logstash directory that you just deleted.
+. Restore the `config/` and `data/` folders that were previously saved, overwriting the folders created during the unpack operation.
+. Test your configuration file with the `logstash --config.test_and_exit -f <configuration-file>` command.
 Configuration options for
-some Logstash plugins have changed in the 7.x release.
-5. Restart your Logstash pipeline after updating your configuration file.
+some Logstash plugins have changed.
+. Restart your Logstash pipeline after updating your configuration file.
 
 [[upgrading-minor-versions]]
 === Upgrading between minor versions


### PR DESCRIPTION
Clean backport of #13684 to branch `8.1`

----
Original comment

During the time Logstash switched from a set of Ruby files plus one fat jar to multiple jars, with configuration files
and shell scripts that also needs to be updated. It's not anymore sufficient to suggest to unpack a new distribution
over an existing one. This is problematic when we add jars from version to version because drive to the pollution
of the classpath.

This commit redefines to steps to do this, in a safer way, backing up data and config folders.

Co-authored-by: Karen Metts <35154725+karenzone@users.noreply.github.com
(cherry picked from commit 30b9ad88484c237ec8726fbcb81df63295c9628e)
