### PR TITLE
[Backport PR#13728 to 8.0] [Test] Fix acceptance tests to deal with J…

### DIFF
--- a/qa/acceptance/spec/lib/artifact_operation_spec.rb
+++ b/qa/acceptance/spec/lib/artifact_operation_spec.rb
@@ -16,9 +16,7 @@
 # under the License.
 
 require_relative '../spec_helper'
-require_relative '../shared_examples/installed'
 require_relative '../shared_examples/installed_with_jdk'
-require_relative '../shared_examples/running'
 require_relative '../shared_examples/updated'
 
 # This tests verify that the generated artifacts could be used properly in a release, implements https://github.com/elastic/logstash/issues/5070
@@ -26,7 +24,6 @@ describe "artifacts operation" do
   config = ServiceTester.configuration
   config.servers.each do |address|
     logstash = ServiceTester::Artifact.new(address, config.lookup[address])
-    it_behaves_like "installable", logstash
     it_behaves_like "installable_with_jdk", logstash
     it_behaves_like "updated", logstash
   end

--- a/qa/acceptance/spec/lib/cli_operation_spec.rb
+++ b/qa/acceptance/spec/lib/cli_operation_spec.rb
@@ -31,6 +31,8 @@ describe "CLI operation" do
   config = ServiceTester.configuration
   config.servers.each do |address|
     logstash = ServiceTester::Artifact.new(address, config.lookup[address])
+    # Force tests to use bundled JDK
+    logstash.run_command("unset LS_JAVA_HOME")
     it_behaves_like "logstash version", logstash
     it_behaves_like "logstash install", logstash
     it_behaves_like "logstash list", logstash

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/list.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/list.rb
@@ -49,7 +49,7 @@ shared_examples "logstash list" do |logstash|
         stdout = StringIO.new(result.stdout)
         stdout.set_encoding(Encoding::UTF_8)
         while line = stdout.gets
-          next if line.match(/^Using system java:.*$/)
+          next if line.match(/^Using system java:.*$/) || line.match(/^Using bundled JDK:.*$/)
           match = line.match(/^#{plugin_name_with_version}$/)
           expect(match).to_not be_nil
 

--- a/qa/acceptance/spec/shared_examples/installed_with_jdk.rb
+++ b/qa/acceptance/spec/shared_examples/installed_with_jdk.rb
@@ -40,8 +40,8 @@ RSpec.shared_examples "installable_with_jdk" do |logstash|
   end
 
   it "is running on #{logstash.hostname}" do
-    with_running_logstash_service(logstash, "/usr/share/logstash/jdk/bin/java") do
-      expect(logstash).to be_running_with("/usr/share/logstash/jdk/bin/java")
+    with_running_logstash_service(logstash) do
+      expect(logstash).to be_running
     end
   end
 

--- a/qa/acceptance/spec/shared_examples/updated.rb
+++ b/qa/acceptance/spec/shared_examples/updated.rb
@@ -21,7 +21,11 @@ require          'logstash/version'
 # This test checks if the current package could used to update from the latest version released.
 RSpec.shared_examples "updated" do |logstash|
 
-  before(:all) { logstash.uninstall }
+  before(:all) {
+    #unset to force it using bundled JDK to run LS
+    logstash.run_command("unset LS_JAVA_HOME")
+    logstash.uninstall
+  }
   after(:all)  do
     logstash.stop_service # make sure the service is stopped
     logstash.uninstall #remove the package to keep uniform state
@@ -32,7 +36,8 @@ RSpec.shared_examples "updated" do |logstash|
     logstash.install(options) # make sure latest version is installed
   end
 
-  it "can be updated an run on #{logstash.hostname}" do
+  it "can be updated and run on #{logstash.hostname}" do
+    pending('Cannot install on OS') if logstash.hostname == 'oel-6'
     expect(logstash).to be_installed
     # Performing the update
     logstash.install({:version => LOGSTASH_VERSION})

--- a/qa/acceptance/spec/spec_helper.rb
+++ b/qa/acceptance/spec/spec_helper.rb
@@ -57,17 +57,12 @@ SpecsHelper.configure(selected_boxes)
 
 puts "[Acceptance specs] running on #{ServiceTester.configuration.hosts}" if !selected_boxes.empty?
 
-def with_running_logstash_service(logstash, jdk_path=nil)
+def with_running_logstash_service(logstash)
   begin
     logstash.start_service
     Stud.try(40.times, RSpec::Expectations::ExpectationNotMetError) do
-      if jdk_path
-        expect(logstash).to be_running_with(jdk_path)
-      else
-        expect(logstash).to be_running
-      end
+      expect(logstash).to be_running
     end
-
     yield
   ensure
     logstash.stop_service

--- a/qa/rspec/commands.rb
+++ b/qa/rspec/commands.rb
@@ -41,7 +41,6 @@ module ServiceTester
       @host    = host
       @options = options
       @client  = CommandsFactory.fetch(options["type"], options["host"])
-      @bundled_jdk = false
       @skip_jdk_infix = false
     end
 
@@ -75,10 +74,9 @@ module ServiceTester
 
     def install(options={})
       base      = options.fetch(:base, ServiceTester::Base::LOCATION)
-      @bundled_jdk = options.fetch(:bundled_jdk, false)
       @skip_jdk_infix = options.fetch(:skip_jdk_infix, false)
       filename = filename(options)
-      package   = client.package_for(filename, @skip_jdk_infix, @bundled_jdk, base)
+      package   = client.package_for(filename, @skip_jdk_infix, base)
       client.install(package, host)
     end
 

--- a/qa/rspec/commands/base.rb
+++ b/qa/rspec/commands/base.rb
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+require 'tempfile'
 require_relative "../../vagrant/helpers"
 require_relative "system_helpers"
 
@@ -106,21 +107,17 @@ module ServiceTester
       run_command("rm -rf #{path}", host)
     end
 
-    def package_for(filename, skip_jdk_infix, bundled_jdk, base=ServiceTester::Base::LOCATION)
-      jdk_arch_ext = jdk_architecture_extension(skip_jdk_infix, bundled_jdk)
+    def package_for(filename, skip_jdk_infix, base=ServiceTester::Base::LOCATION)
+      jdk_arch_ext = jdk_architecture_extension(skip_jdk_infix)
       File.join(base, "#{filename}#{jdk_arch_ext}.#{package_extension}")
     end
 
     private
-    def jdk_architecture_extension(skip_jdk_infix, bundled_jdk)
+    def jdk_architecture_extension(skip_jdk_infix)
       if skip_jdk_infix
         ""
       else
-        if bundled_jdk
-          "-" + architecture_extension
-        else
-          "-no-jdk"
-        end
+        "-" + architecture_extension
       end
     end
   end

--- a/qa/rspec/commands/redhat.rb
+++ b/qa/rspec/commands/redhat.rb
@@ -54,7 +54,7 @@ module ServiceTester
         errors << cmd.stderr unless cmd.stderr.empty?
       end
       if exit_status > 0 
-        raise InstallException.new(errors.join("\n"))
+        raise InstallException.new("Error installing #{package}, #{errors.join('\n')}")
       end
     end
 

--- a/qa/rspec/commands/system_helpers.rb
+++ b/qa/rspec/commands/system_helpers.rb
@@ -19,7 +19,7 @@ require_relative "base"
 
 module ServiceTester
   module SystemD
-    def running?(hosts, package, jdk_path='/usr/bin/java')
+    def running?(hosts, package, jdk_path='/usr/share/logstash/jdk/bin/java')
       stdout = ""
       at(hosts, {in: :serial}) do |host|
         cmd = sudo_exec!("service #{package} status")
@@ -42,7 +42,7 @@ module ServiceTester
   end
 
   module InitD
-    def running?(hosts, package, jdk_path='/usr/bin/java')
+    def running?(hosts, package, jdk_path='/usr/share/logstash/jdk/bin/java')
       stdout = ""
       at(hosts, {in: :serial}) do |host|
         cmd = sudo_exec!("initctl status #{package}")

--- a/qa/rspec/matchers/be_running.rb
+++ b/qa/rspec/matchers/be_running.rb
@@ -23,9 +23,3 @@ RSpec::Matchers.define :be_running do
     subject.running?(subject.hosts, subject.name)
   end
 end
-
-RSpec::Matchers.define :be_running_with do |expected_jdk_path|
-  match do |subject|
-    subject.running?(subject.hosts, subject.name, expected_jdk_path)
-  end
-end


### PR DESCRIPTION
…ava 8 removal

Backport PR#13728 to 8.0 branch. Original message:

[Test] Fix acceptance tests to deal with Java 8 removal

The acceptance tests are used to test a variety of scenarios installing, running and updating
logstash on a variety of Linux distributions.

The vagrant distributions we test on are old, and use java8 by default. This commit removes
the java8 tests and changes the tests to only test the jdk included distribution.
