### PR TITLE
Backport PR #13747 to 8.0: Docs remove homebrew

### DIFF
--- a/docs/static/getting-started-with-logstash.asciidoc
+++ b/docs/static/getting-started-with-logstash.asciidoc
@@ -24,7 +24,7 @@ include::jvm.asciidoc[]
 
 The {ls} binaries are available from 
 https://www.elastic.co/downloads/logstash[https://www.elastic.co/downloads].
-Download the Logstash installation file for your host environment--TARG.GZ, DEB,
+Download the Logstash installation file for your host environment--TAR.GZ, DEB,
 ZIP, or RPM. 
 
 Unpack the file. Do not install Logstash into a directory path that
@@ -227,49 +227,6 @@ See the {logstash-ref}/running-logstash.html[Running Logstash] document for mana
 endif::[]
 
 [float]
-[[brew]]
-=== Installing {ls} on macOS with Homebrew
-
-Elastic publishes Homebrew formulae so you can install {ls} with the
-https://brew.sh/[Homebrew] package manager.
-
-To install with Homebrew, you first need to tap the Elastic Homebrew repository:
-
-[source,sh]
--------------------------
-brew tap elastic/tap
--------------------------
-
-After you've tapped the Elastic Homebrew repo, you can use `brew install` to
-install the default distribution of {ls}:
-
-[source,sh]
--------------------------
-brew install elastic/tap/logstash-full
--------------------------
-
-This installs the most recently released default distribution of {ls}.
-To install the OSS distribution, specify `elastic/tap/logstash-oss`.
-
-
-[float]
-[[brew-start]]
-==== Starting {ls} with Homebrew
-
-To have launchd start elastic/tap/logstash-full now and restart at login, run:
-
-[source,sh]
------
-brew services start elastic/tap/logstash-full
------
-
-To run {ls}, in the foreground, run:
-
-[source,sh]
------
-logstash
------
-
 
 ==== Docker
 

--- a/docs/static/monitoring/monitoring-mb.asciidoc
+++ b/docs/static/monitoring/monitoring-mb.asciidoc
@@ -57,7 +57,7 @@ same server as {ls}.
 To enable the default configuration in the {metricbeat} `modules.d` directory, 
 run: 
 
-*deb, rpm, or brew:* +
+*deb or rpm:* +
 
 ["source","sh",subs="attributes"]
 ----

--- a/docs/static/redirects.asciidoc
+++ b/docs/static/redirects.asciidoc
@@ -27,3 +27,14 @@ If your use case involves reading files that contain multiline entries,
 {filebeat-ref}[{filebeat}] might be a better option.
 {filebeat} offers {filebeat-ref}/filebeat-modules.html[modules] for processing logs
 from many known apps, such as nginx or apache.
+
+[role="exclude",id="brew"]
+==== Installation via Homebrew (MacOS)
+
+// legacy anchor to prevent 404.
+[brew-start]
+
+As of Logstash 8.0, Elastic no longer maintains a homebrew cask containing formulae for installing the Elastic-licensed distribution of Logstash.
+If you want to run the full distribution of Logstash on a Mac, you are encouraged to <<installing-binary,install from a downloaded binary distribution>>.
+
+You can still install the Apache-licensed OSS distribution with homebrew using the formulae maintained by Homebrew.


### PR DESCRIPTION
Backport PR #13747 to 8.0 branch. Original message: 

## Release notes

[rn:skip]

## What does this PR do?

As of Stack 8.0, Elastic is no longer maintaining a separate homebrew cask
with Elastic-licensed artifacts for the MacOS package manager homebrew, due to
low usage, difficulty in maintaining multiple versions, lack of team expertise,
and an existing Apache-licensed formula.

As such, we are removing instructions about setting up and running Logstash
from these formulae that are no longer available.

## Why is it important/What is the impact to the user?

If the upstream casks don't exist, sending users down the path of trying to add them would be an unpleasant dead-end.

## Checklist

- ~[ ] My code follows the style guidelines of this project~
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
