### PR TITLE
Doc Forwardport 8.0 release notes to 8.1

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -1,14 +1,207 @@
 [[releasenotes]]
 == Release Notes
 
-coming[8.0.0]
-
 This section summarizes the changes in the following releases:
 
+* <<logstash-8-0-0,Logstash 8.0.0>>
+* <<logstash-8-0-0-rc2,Logstash 8.0.0-rc2>>
 * <<logstash-8-0-0-rc1,Logstash 8.0.0-rc1>>
 * <<logstash-8-0-0-beta1,Logstash 8.0.0-beta1>>
 * <<logstash-8-0-0-alpha2,Logstash 8.0.0-alpha2>>
 * <<logstash-8-0-0-alpha1,Logstash 8.0.0-alpha1>>
+
+[[logstash-8-0-0]]
+=== Logstash 8.0.0 Release Notes
+
+The following list are changes in 8.0.0 as compared to 7.17.0, and combines release notes from the 8.0.0-alpha1, -alpha2, -beta1, -rc1 and -rc2 releases.
+
+[[breaking-8.0.0]]
+==== Breaking changes
+* Many plugins can now be run in a mode that avoids implicit conflict with the Elastic Common Schema (ECS).
+  This mode is controlled individually with each plugin’s ecs_compatibility option, which defaults to the value of the Logstash pipeline.ecs_compatibility setting.
+  In Logstash 8, this compatibility mode will be on-by-default for all pipelines.
+  If you wish to lock in a pipeline’s behavior from Logstash 7.x before upgrading to Logstash 8,
+  you can set `pipeline.ecs_compatibility: disabled` to its definition in `pipelines.yml` (or globally in `logstash.yml`).
+* Starting from Logstash 8.0, the minimum required version of Java to run Logstash is Java 11.
+  By default, Logstash will run with the bundled JDK, which has been verified to work with each specific version of Logstash,
+  and generally provides the best performance and reliability.
+* Support for using `JAVA_HOME` to override the path to the JDK that Logstash runs with has been removed for this release.
+  In the `8.x` release, users should set the value of `LS_JAVA_HOME` to the path of their preferred JDK if they
+  wish to use a version other than the bundled JDK. The value of `JAVA_HOME` will be ignored.
+* The Java Execution Engine has been the default engine since Logstash 7.0, and works with plugins written in either Ruby or Java.
+  Removal of the Ruby Execution Engine will not affect the ability to run existing pipelines. https://github.com/elastic/logstash/pull/12517[#12517]
+* We have added support for UTF-16 and other multi-byte-character when reading log files. https://github.com/elastic/logstash/pull/9702[#9702]
+* Setting `config.field_reference.parser` has been removed.
+  The Field Reference parser interprets references to fields in your pipelines and plugins.
+  Its behavior was configurable in 6.x, and since 7.0 allowed only a single option: `strict`.
+  8.0 no longer recognizes the setting, but maintains the same behavior as the `strict` setting.
+  {ls} rejects ambiguous and illegal inputs as standard behavior. https://github.com/elastic/logstash/pull/12466[#12466]
+
+For a more detailed view of these changes please check <<breaking-8.0>>.
+
+[[features-8.0.0]]
+==== New features and enhancements
+* As processing times speed up, millisecond granularity is not always enough. Inbound data increasingly has sub-millisecond granularity timestamps.
+  The pull request https://github.com/elastic/logstash/pull/12797[#12797] allows the internal mechanisms of
+  Logstash that hold moment-in-time data - such as the Logstash Event, the Persistent Queue, the Dead Letter Queue and JSON encoding/decoding - to have nanosecond granularity.
+* We have added another flag to the Benchmark CLI to allow passing a data file with previously captured data to the custom test case.
+  This feature allows users to run the Benchmark CLI in a custom test case with a custom config and a custom dataset. https://github.com/elastic/logstash/pull/12437[#12437]
+
+==== Plugins
+
+Logstash 8.0.0 includes the same versions of all bundled plugins as Logstash 7.17.0.
+If you upgrade to 7.17 before upgrading to 8.0 (as recommended), you won't see any changes to plugin versions.
+
+*Clone Filter - 4.2.0*
+
+* Added support for ECS v8 as alias for ECS v1 https://github.com/logstash-plugins/logstash-filter-clone/pull/27[#27]
+
+*Geoip Filter - 7.2.11*
+
+* Improved compatibility with the Elastic Common Schema https://github.com/logstash-plugins/logstash-filter-geoip/pull/206[#206]
+** Added support for ECS's composite `region_iso_code` (`US-WA`), which _replaces_ the non-ECS `region_code` (`WA`) as a default field with City databases.
+To get the stand-alone `region_code` in ECS mode, you must include it in the `fields` directive
+** [DOC] Improve ECS-related documentation
+* [DOC] Air-gapped environment requires both ASN and City databases https://github.com/logstash-plugins/logstash-filter-geoip/pull/204[#204]
+
+*Http Filter - 1.2.1*
+
+* Fix: do not set content-type if provided by user https://github.com/logstash-plugins/logstash-filter-http/pull/36[#36]
+* Feat: improve ECS compatibility https://github.com/logstash-plugins/logstash-filter-http/pull/35[#35]
+* Add support for PUT requests https://github.com/logstash-plugins/logstash-filter-http/pull/34[#34]
+
+*Ruby Filter - 3.1.8*
+
+* [DOC] Added doc to describe the option `tag_with_exception_message`https://github.com/logstash-plugins/logstash-filter-ruby/pull/62[#62]
+* Fix SyntaxError handling so other pipelines can shut down gracefully https://github.com/logstash-plugins/logstash-filter-ruby/pull/64[#64]
+
+*Useragent Filter - 3.3.3*
+
+* Docs: mention added fields in 3.3 with a note https://github.com/logstash-plugins/logstash-filter-useragent/pull/78[#78]
+
+*Exec Input - 3.4.0*
+
+* Feat: adjust fields for ECS compatibility https://github.com/logstash-plugins/logstash-input-exec/pull/28[#28]
+* Plugin will no longer override fields if they exist in the decoded payload (It no longer sets the `host` field if decoded from the command's output)
+
+*Gelf Input - 3.3.1*
+
+* Fix: safely coerce the value of `_@timestamp` to avoid crashing the plugin https://github.com/logstash-plugins/logstash-input-gelf/pull/67[#67]
+
+*Generator Input - 3.1.0*
+
+* Feat: adjusted fields for ECS compatibility https://github.com/logstash-plugins/logstash-input-generator/pull/22[#22]
+* Fix: do not override the host field if it's present in the generator line (after decoding)
+* Fix: codec flushing when closing input
+
+*Imap Input - 3.2.0*
+
+* Feat: ECS compatibility https://github.com/logstash-plugins/logstash-input-imap/pull/55[#55]
+* added (optional) `headers_target` configuration option
+* added (optional) `attachments_target` configuration option
+* Fix: plugin should not close `$stdin`, while being stopped
+
+*Jms Input - 3.2.1*
+
+* Fix: improve compatibility with MessageConsumer implementations https://github.com/logstash-plugins/logstash-input-jms/pull/51[#51],
+such as IBM MQ.
+* Test: Fix test failures due to ECS compatibility default changes in `8.x` of logstash https://github.com/logstash-plugins/logstash-input-jms/pull/53[#53]
+* Feat: event_factory support + targets to aid ECS https://github.com/logstash-plugins/logstash-input-jms/pull/49[#49]
+* Fix: when configured to add JMS headers to the event, headers whose value is not set no longer result in nil entries on the event
+* Fix: when adding the `jms_reply_to` header to an event, a string representation is set instead of an opaque object.
+
+*Pipe Input - 3.1.0*
+
+*  Feat: adjust fields for ECS compatibility https://github.com/logstash-plugins/logstash-input-pipe/pull/19[#19]
+
+*S3 Input - 3.8.3*
+
+* Fix missing `metadata` and `type` of the last event https://github.com/logstash-plugins/logstash-input-s3/pull/223[#223]
+* Refactor: read sincedb time once per bucket listing https://github.com/logstash-plugins/logstash-input-s3/pull/233[#233]
+
+*Snmp Input - 1.3.1*
+
+* Refactor: handle no response(s) wout error logging https://github.com/logstash-plugins/logstash-input-snmp/pull/105[#105]
+* Feat: ECS compliance + optional target https://github.com/logstash-plugins/logstash-input-snmp/pull/99[#99]
+* Internal: update to Gradle 7 https://github.com/logstash-plugins/logstash-input-snmp/pull/102[#102]
+
+*Snmptrap Input - 3.1.0*
+
+* Feat: ecs_compatiblity support + (optional) target https://github.com/logstash-plugins/logstash-input-snmptrap/pull/37[#37]
+
+*Syslog Input - 3.6.0*
+
+* Add support for ECS v8 as alias to v1 implementation https://github.com/logstash-plugins/logstash-input-syslog/pull/68[#68]
+
+*Twitter Input - 4.1.0*
+
+* Feat: optional target + ecs_compatibility https://github.com/logstash-plugins/logstash-input-twitter/pull/72[#72]
+
+*Unix Input - 3.1.1*
+
+* Fix: unable to stop plugin (on LS 6.x) https://github.com/logstash-plugins/logstash-input-unix/pull/29[#29]
+* Refactor: plugin internals got reviewed for `data_timeout => ...` to work reliably
+* Feat: adjust fields for ECS compatibility https://github.com/logstash-plugins/logstash-input-unix/pull/28[#28]
+
+*Jdbc Integration - 5.2.2*
+
+* Feat: name scheduler threads + redirect error logging https://github.com/logstash-plugins/logstash-integration-jdbc/pull/102[#102]
+* Refactor: isolate paginated normal statement algorithm in a separate handler https://github.com/logstash-plugins/logstash-integration-jdbc/pull/101[#101]
+* Added `jdbc_paging_mode` option to choose if use `explicit` pagination in statements and avoid the initial count
+query or use `auto` to delegate to the underlying library https://github.com/logstash-plugins/logstash-integration-jdbc/pull/95[#95]
+* Several improvements to Java driver loading
+** Refactor: to explicit Java (driver) class name loading https://github.com/logstash-plugins/logstash-integration-jdbc/pull/96[#96].
+The change is expected to provide a more robust fix for the driver loading issue https://github.com/logstash-plugins/logstash-integration-jdbc/issues/83[#83].
+
+    NOTE: A fatal driver error will no longer keep reloading the pipeline and now leads to a system exit.
+
+** Fix: regression due returning the Java driver class https://github.com/logstash-plugins/logstash-integration-jdbc/pull/98[#98]
+
+*Kafka Integration - 10.9.0*
+
+* Refactor: leverage codec when using schema registry
+Previously using `schema_registry_url` parsed the payload as JSON even if `codec => 'plain'` was explicitly set, this is no longer the case.
+https://github.com/logstash-plugins/logstash-integration-kafka/pull/106[#106]
+
+*Cloudwatch Output - 3.0.10*
+
+* Fix: an old undefined method error which would surface with load (as queue fills up)
+* Deps: unpin rufus scheduler https://github.com/logstash-plugins/logstash-output-cloudwatch/pull/20[#20]
+
+*Elasticsearch Output - 11.4.1*
+
+* Feat: upgrade manticore (http-client) library https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1063[#1063]
+** the underlying changes include latest HttpClient (4.5.13)
+** resolves an old issue with `ssl_certificate_verification => false` still doing some verification logic
+* Updates ECS templates https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1062[#1062]
+** Updates v1 templates to 1.12.1 for use with Elasticsearch 7.x and 8.x
+** Updates BETA preview of ECS v8 templates for Elasticsearch 7.x and 8.x
+* Feat: add support for 'traces' data stream type https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1057[#1057]
+* Refactor: review manticore error handling/logging, logging originating cause in case of connection related error when debug level is enabled.
+Java causes on connection related exceptions will now be extra logged when plugin is logging at debug level
+https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1029[#1029]
+* ECS-related fixes https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1046[#1046]
+** Data Streams requirement on ECS is properly enforced when running on Logstash 8, and warned about when running on Logstash 7.
+** ECS Compatibility v8 can now be selected
+
+*Core Patterns - 4.3.2*
+
+- Fix: typo in `BIN9_QUERYLOG` pattern (in ECS mode) https://github.com/logstash-plugins/logstash-patterns-core/pull/307[#307]
+
+
+[[logstash-8-0-0-rc2]]
+=== Logstash 8.0.0-rc2 Release Notes
+
+[[notable-8.0.0-rc2]]
+==== Notable issues fixed
+* Fixed long-standing issue in which the `events.out` count incorrectly included events that had been dropped with the drop filter.
+Now the total out event count includes only events that reach the out stage. https://github.com/elastic/logstash/pull/13593[#13593]
+* Reduced scope and impact of a memory leak that can be caused by using UUIDs or other high-cardinality field names https://github.com/elastic/logstash/pull/13642[#13642]
+* Fixed an issue with the Azure input plugin that caused Logstash to crash when the input was used in a pipeline. https://github.com/elastic/logstash/pull/13603[#13603]
+
+==== Plugin releases
+Plugins align with release 7.17.0
+
 
 [[logstash-8-0-0-rc1]]
 === Logstash 8.0.0-rc1 Release Notes


### PR DESCRIPTION
Forwardports #13711 to 8.1 
Includes release notes for 8.0.0-rc2 and 8.0.0-GA.

PREVIEW: https://logstash_13751.docs-preview.app.elstc.co/guide/en/logstash/8.1/releasenotes.html

Co-authored-by: andsel <selva.andre@gmail.com>
Co-authored-by: Ry Biesemeyer <ry.biesemeyer@elastic.co>
Co-authored-by: Karen Metts <35154725+karenzone@users.noreply.github.com>