### PR TITLE
action: add docs preview link when docs change.

### DIFF
--- a/.github/workflows/add-docs-preview-link.yml
+++ b/.github/workflows/add-docs-preview-link.yml
@@ -8,11 +8,12 @@ jobs:
   docs-preview-link:
     runs-on: ubuntu-latest
     permissions:
-      issues: write
       pull-requests: write
     steps:
     - name: Add Docs Preview link in PR Comment
       uses: thollander/actions-comment-pull-request@v1
       with:
-        message: ':page_with_curl: **DOCS PREVIEW** :sparkles: https://logstash_${{ github.event.number }}.docs-preview.app.elstc.co/diff'
+        message: |
+          :page_with_curl: **DOCS PREVIEW** :sparkles: https://logstash_${{ github.event.number }}.docs-preview.app.elstc.co/diff
+          Note: if you get a "404!" please wait until the elasticsearch ci job finishes.
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add-docs-preview-link.yml
+++ b/.github/workflows/add-docs-preview-link.yml
@@ -1,0 +1,18 @@
+name: Docs Preview Link
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths: docs/**
+jobs:
+  docs-preview-link:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - name: Add Docs Preview link in PR Comment
+      uses: thollander/actions-comment-pull-request@v1
+      with:
+        message: ':page_with_curl: **DOCS PREVIEW** :sparkles: https://logstash_${{ github.event.number }}.docs-preview.app.elstc.co/diff'
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

## Release notes

[rn-skip]

## What does this PR do?

When a pull-request is opened, or when the HEAD of an existing pull-request is changed, and the changeset modifies the docs, add a comment to the PR with a link to our docs preview.

## Why is it important/What is the impact to the user?

No user impact.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works
