### PR TITLE
Backport PR #13753 to 8.1: Pin bundler to 2.3.6 to fix builder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -307,7 +307,7 @@ tasks.register("installBundler") {
     dependsOn assemblyDeps
     outputs.files file("${projectDir}/vendor/bundle/jruby/2.5.0/bin/bundle")
     doLast {
-      gem(projectDir, buildDir, "bundler", "~> 2", "${projectDir}/vendor/bundle/jruby/2.5.0")
+      gem(projectDir, buildDir, "bundler", "= 2.3.6", "${projectDir}/vendor/bundle/jruby/2.5.0")
   }
 }
 
@@ -435,7 +435,7 @@ tasks.register("installIntegrationTestBundler"){
     dependsOn unpackTarDistribution
     outputs.files file("${qaBundleBin}")
   doLast {
-      gem(projectDir, buildDir, "bundler", "~> 2", qaBundledGemPath)
+      gem(projectDir, buildDir, "bundler", "= 2.3.6", qaBundledGemPath)
   }
 }
 


### PR DESCRIPTION
Backport PR #13753 to 8.1 branch. Original message: 

Build has been failing since the release of 2.3.7, this commit pins
bundler to 2.3.6 to get the build green again while the cause can be
investigated
