### PR TITLE
[8.1] handle fully acked 0 byte PQ pages (#13692)

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/MmapPageIOV1.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/MmapPageIOV1.java
@@ -219,6 +219,13 @@ public final class MmapPageIOV1 implements PageIO {
         return this.head;
     }
 
+    @Override
+    public boolean isCorruptedPage() throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(this.file, "rw")) {
+            return raf.length() < MmapPageIOV2.MIN_CAPACITY;
+        }
+    }
+
     private int checksum(byte[] bytes) {
         checkSummer.reset();
         checkSummer.update(bytes, 0, bytes.length);

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/MmapPageIOV2.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/MmapPageIOV2.java
@@ -271,6 +271,13 @@ public final class MmapPageIOV2 implements PageIO {
         return this.head;
     }
 
+    @Override
+    public boolean isCorruptedPage() throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(this.file, "rw")) {
+            return raf.length() < MIN_CAPACITY;
+        }
+    }
+
     private int checksum(byte[] bytes) {
         checkSummer.reset();
         checkSummer.update(bytes, 0, bytes.length);
@@ -294,7 +301,8 @@ public final class MmapPageIOV2 implements PageIO {
             this.capacity = pageFileCapacity;
 
             if (this.capacity < MIN_CAPACITY) {
-                throw new IOException(String.format("Page file size is too small to hold elements"));
+                throw new IOException("Page file size is too small to hold elements. " +
+                        "This is potentially a queue corruption problem. Run `pqcheck` and `pqrepair` to repair the queue.");
             }
             this.buffer = raf.getChannel().map(FileChannel.MapMode.READ_WRITE, 0, this.capacity);
         }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/io/PageIO.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/io/PageIO.java
@@ -84,4 +84,7 @@ public interface PageIO extends Closeable {
 
     // @return the data container min sequence number
     long getMinSeqNum();
+
+    // check if the page size is < minimum size
+    boolean isCorruptedPage() throws IOException;
 }


### PR DESCRIPTION
Backports the following commits to 8.1:
 - handle fully acked 0 byte PQ pages (#13692)