### PR TITLE
[8.1] fix pqrepair log4j setting (#13726)

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/PqRepair.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/PqRepair.java
@@ -63,6 +63,8 @@ public final class PqRepair {
             );
         }
 
+        LOGGER.info("Start repairing queue dir: {}", path.toString());
+
         deleteTempCheckpoint(path);
 
         final Map<Integer, Path> pageFiles = new HashMap<>();
@@ -88,6 +90,8 @@ public final class PqRepair {
         fixMissingPages(pageFiles, checkpointFiles);
         fixZeroSizePages(pageFiles, checkpointFiles);
         fixMissingCheckpoints(pageFiles, checkpointFiles);
+
+        LOGGER.info("Repair is done");
     }
 
     private static void deleteTempCheckpoint(final Path root) throws IOException {

--- a/logstash-core/src/test/resources/log4j2.properties
+++ b/logstash-core/src/test/resources/log4j2.properties
@@ -6,9 +6,6 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n
 
-rootLogger.level = error
+rootLogger.level = info
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.stdout.ref = STDOUT
-
-logger.pqrepair.name = org.logstash.ackedqueue.PqRepair
-logger.pqrepair.level = info


### PR DESCRIPTION
Backports the following commits to 8.1:
 - fix pqrepair log4j setting (#13726)