### PR TITLE
WiP: review bundler/setup and LS boot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -303,11 +303,13 @@ def assemblyDeps = [downloadAndInstallJRuby, assemble] + subprojects.collect {
   it.tasks.findByName("assemble")
 }
 
+def bundlerVersion = "~> 2"
+
 tasks.register("installBundler") {
     dependsOn assemblyDeps
     outputs.files file("${projectDir}/vendor/bundle/jruby/2.5.0/bin/bundle")
     doLast {
-      gem(projectDir, buildDir, "bundler", "~> 2", "${projectDir}/vendor/bundle/jruby/2.5.0")
+      gem(projectDir, buildDir, "bundler", bundlerVersion, "${projectDir}/vendor/bundle/jruby/2.5.0")
   }
 }
 
@@ -435,7 +437,7 @@ tasks.register("installIntegrationTestBundler"){
     dependsOn unpackTarDistribution
     outputs.files file("${qaBundleBin}")
   doLast {
-      gem(projectDir, buildDir, "bundler", "~> 2", qaBundledGemPath)
+      gem(projectDir, buildDir, "bundler", bundlerVersion, qaBundledGemPath)
   }
 }
 

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "mustermann", '~> 1.0.3'
   gem.add_runtime_dependency "sinatra", '~> 2.1.0' # pinned until GH-13777 is resolved
   gem.add_runtime_dependency 'puma', '~> 5'
-  gem.add_runtime_dependency "jruby-openssl", "= 0.11.0"
+  gem.add_runtime_dependency "jruby-openssl", "~> 0.11"
 
   gem.add_runtime_dependency "treetop", "~> 1" #(MIT license)
 

--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -27,10 +27,14 @@ namespace "vendor" do
   task "gems", [:bundle] do |task, args|
     require "bootstrap/environment"
 
-    puts("Invoking bundler install...")
-    output, exception = LogStash::Bundler.invoke!(:install => true)
-    puts(output)
-    raise(exception) if exception
+    if File.exists?('Gemfile.lock') # `./gradlew bootstrap` already run
+      puts("Skipping bundler install...")
+    else
+      puts("Invoking bundler install...")
+      output, exception = LogStash::Bundler.invoke!(:install => true)
+      puts(output)
+      raise(exception) if exception
+    end
   end # task gems
   task "all" => "gems"
 

--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -16,10 +16,6 @@
 # under the License.
 
 namespace "vendor" do
-  def vendor(*args)
-    return File.join("vendor", *args)
-  end
-
   task "jruby" do |task, args|
     system('./gradlew bootstrap') unless File.exists?(File.join("vendor", "jruby"))
   end # jruby
@@ -40,6 +36,6 @@ namespace "vendor" do
 
   desc "Clean the vendored files"
   task :clean do
-    rm_rf(vendor)
+    rm_rf('vendor')
   end
 end


### PR DESCRIPTION
Effectively fixed the double install-ing jruby-openssl: https://github.com/elastic/logstash/issues/13781
Once with the proper qualifier and once simply installing the default version.

The `require 'openssl'` is loaded early by Bundler thus having the latest around while locking a different version will lead to issues at runtime.

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

~~Fixes a :red_circle: CI when running integration tests.~~