### PR TITLE
Lock jruby-openssl in logtash-core to 0.11.0

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "mustermann", '~> 1.0.3'
   gem.add_runtime_dependency "sinatra", '~> 2'
   gem.add_runtime_dependency 'puma', '~> 5'
-  gem.add_runtime_dependency "jruby-openssl", "~> 0.11"
+  gem.add_runtime_dependency "jruby-openssl", "= 0.11.0"
 
   gem.add_runtime_dependency "treetop", "~> 1" #(MIT license)
 


### PR DESCRIPTION
A recent update to jruby-openssl causes a gem load error when trying to
use `bin/logstash-plugin`. This commit pins the gemspec in the
`logstash-core.gemspec` to match that in the lockfile.
