### PR TITLE
Backport PR #13784 to 7.17: Deps: pin sinatra due (2.2.0) incompatibilities

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "concurrent-ruby", "~> 1"
   gem.add_runtime_dependency "rack", '~> 2'
   gem.add_runtime_dependency "mustermann", '~> 1.0.3'
-  gem.add_runtime_dependency "sinatra", '~> 2'
+  gem.add_runtime_dependency "sinatra", '~> 2.1.0' # pinned until GH-13777 is resolved
   gem.add_runtime_dependency 'puma', '~> 5'
   gem.add_runtime_dependency "jruby-openssl", "~> 0.11"
   gem.add_runtime_dependency "chronic_duration", "~> 0.10"


### PR DESCRIPTION
Backport PR #13784 to 7.17 branch. Original message: 

Dependency lock.

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

Locks sinatra dependency due incompatibilities.
Sinatra is used for LS's HTTP API.

This concerns LS 8.0.0 whenever a plugin update is triggered (which updates sinatra). 
Report at: https://github.com/elastic/logstash/issues/13777

Sample failure (from CI while using sinatra 2.2.0):
```
ArgumentError: wrong number of arguments (given 3, expected 1..2)
  # /opt/logstash/logstash-core/lib/logstash/api/modules/base.rb:43:in `initialize'
  # /opt/logstash/vendor/bundle/jruby/2.5.0/gems/sinatra-2.2.0/lib/sinatra/base.rb:1537:in `new'
  # /opt/logstash/logstash-core/lib/logstash/api/rack_app.rb:113:in `block in app'
  # /opt/logstash/vendor/bundle/jruby/2.5.0/gems/rack-2.2.3/lib/rack/builder.rb:125:in `initialize'
  # /opt/logstash/logstash-core/lib/logstash/api/rack_app.rb:101:in `app'
  # /opt/logstash/logstash-core/lib/logstash/webserver.rb:123:in `initialize'
  # /opt/logstash/logstash-core/lib/logstash/webserver.rb:74:in `from_settings'
  # /opt/logstash/logstash-core/lib/logstash/agent.rb:69:in `initialize'
```

LS (`>=`) **8.0.1** should lock the version until the issue is resolved ...