### PR TITLE
Feat: conservative plugin (dependency) updates by default

### DIFF
--- a/lib/bootstrap/bundler.rb
+++ b/lib/bootstrap/bundler.rb
@@ -268,6 +268,7 @@ module LogStash
         arguments << "update"
         arguments << expand_logstash_mixin_dependencies(options[:update])
         arguments << "--local" if options[:local]
+        arguments << "--conservative" if options[:conservative]
       elsif options[:clean]
         arguments << "clean"
       elsif options[:package]

--- a/lib/pluginmanager/install.rb
+++ b/lib/pluginmanager/install.rb
@@ -30,6 +30,7 @@ class LogStash::PluginManager::Install < LogStash::PluginManager::Command
   option "--preserve", :flag, "preserve current gem options", :default => false
   option "--development", :flag, "install all development dependencies of currently installed plugins", :default => false
   option "--local", :flag, "force local-only plugin installation. see bin/logstash-plugin package|unpack", :default => false
+  option "--[no-]conservative", :flag, "do a conservative update of plugin's dependencies", :default => true
 
   # the install logic below support installing multiple plugins with each a version specification
   # but the argument parsing does not support it for now so currently if specifying --version only
@@ -190,8 +191,9 @@ class LogStash::PluginManager::Install < LogStash::PluginManager::Command
 
     if unlock_dependencies.any?
       puts "Updating mixin dependencies #{unlock_dependencies.join(', ')}"
-      options = {:update => unlock_dependencies, :rubygems_source => gemfile.gemset.sources}
-      LogStash::Bundler.invoke!(options)
+      LogStash::Bundler.invoke! update: unlock_dependencies,
+                                rubygems_source: gemfile.gemset.sources,
+                                conservative: conservative?
     end
 
     unlock_dependencies

--- a/lib/pluginmanager/update.rb
+++ b/lib/pluginmanager/update.rb
@@ -27,6 +27,7 @@ class LogStash::PluginManager::Update < LogStash::PluginManager::Command
   parameter "[PLUGIN] ...", "Plugin name(s) to upgrade to latest version", :attribute_name => :plugins_arg
   option "--[no-]verify", :flag, "verify plugin validity before installation", :default => true
   option "--local", :flag, "force local-only plugin update. see bin/logstash-plugin package|unpack", :default => false
+  option "--[no-]conservative", :flag, "do a conservative update of plugin's dependencies", :default => true
 
   def execute
     # Turn off any jar dependencies lookup when running with `--local`
@@ -78,12 +79,11 @@ class LogStash::PluginManager::Update < LogStash::PluginManager::Command
 
     # any errors will be logged to $stderr by invoke!
     # Bundler cannot update and clean gems in one operation so we have to call the CLI twice.
-    options = {:update => plugins, :rubygems_source => gemfile.gemset.sources}
-    options[:local] = true if local?
-    output=nil
-    # Unfreeze the bundle when updating gems
-    Bundler.settings.temporary({:frozen => false}) do
-      output = LogStash::Bundler.invoke!(options)
+    Bundler.settings.temporary(:frozen => false) do # Unfreeze the bundle when updating gems
+      output = LogStash::Bundler.invoke! update: plugins,
+                                         rubygems_source: gemfile.gemset.sources,
+                                         local: local?,
+                                         conservative: conservative?
       output << LogStash::Bundler.genericize_platform unless output.nil?
     end
 

--- a/lib/pluginmanager/update.rb
+++ b/lib/pluginmanager/update.rb
@@ -77,6 +77,7 @@ class LogStash::PluginManager::Update < LogStash::PluginManager::Command
 
     puts("Updating #{filtered_plugins.collect(&:name).join(", ")}") unless filtered_plugins.empty?
 
+    output = nil
     # any errors will be logged to $stderr by invoke!
     # Bundler cannot update and clean gems in one operation so we have to call the CLI twice.
     Bundler.settings.temporary(:frozen => false) do # Unfreeze the bundle when updating gems

--- a/spec/unit/plugin_manager/update_spec.rb
+++ b/spec/unit/plugin_manager/update_spec.rb
@@ -30,7 +30,10 @@ describe LogStash::PluginManager::Update do
 
   it "pass all gem sources to the bundle update command" do
     sources = cmd.gemfile.gemset.sources
-    expect_any_instance_of(LogStash::Bundler).to receive(:invoke!).with(:update => [], :rubygems_source => sources)
+    expect_any_instance_of(LogStash::Bundler).to receive(:invoke!).with(
+        :update => [], :rubygems_source => sources,
+        :conservative => true, :local => false
+    )
     cmd.execute
   end
 
@@ -42,7 +45,9 @@ describe LogStash::PluginManager::Update do
       expect(cmd.gemfile).to receive(:find).with(plugin).and_return(plugin)
       expect(cmd.gemfile).to receive(:save).and_return(nil)
       expect(cmd).to receive(:plugins_to_update).and_return([plugin])
-      expect_any_instance_of(LogStash::Bundler).to receive(:invoke!).with(:update => [plugin], :rubygems_source => sources).and_return(nil)
+      expect_any_instance_of(LogStash::Bundler).to receive(:invoke!).with(
+          hash_including(:update => [plugin], :rubygems_source => sources)
+      ).and_return(nil)
     end
 
     it "skips version verification when ask for it" do


### PR DESCRIPTION
`bin/logstash-plugin install logstash-input-s3-sns-sqs`

#### New behavior (`--conservative` default) :
```patch
diff --git Gemfile.lock Gemfile.lock
index b3d2b0b89..5c7742fd0 100644
--- Gemfile.lock
+++ Gemfile.lock
@@ -476,6 +476,10 @@ GEM
       logstash-mixin-aws (>= 5.1.0)
       logstash-mixin-ecs_compatibility_support (~> 1.2)
       stud (~> 0.0.18)
+    logstash-input-s3-sns-sqs (2.1.3)
+      logstash-codec-json (~> 3.0)
+      logstash-core-plugin-api (>= 2.1.12, <= 2.99)
+      logstash-mixin-aws (>= 4.3)
     logstash-input-snmp (1.3.1)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -864,6 +868,7 @@ DEPENDENCIES
   logstash-input-pipe
   logstash-input-redis
   logstash-input-s3
+  logstash-input-s3-sns-sqs
   logstash-input-snmp
   logstash-input-snmptrap
   logstash-input-sqs

```
#### Previous behavior (`--no-conservative`) :

```patch
diff --git Gemfile.lock Gemfile.lock
index 054a98970..877284c1c 100644
--- Gemfile.lock
+++ Gemfile.lock
@@ -166,7 +166,7 @@ GEM
     jruby-jms (1.3.0-java)
       gene_pool
       semantic_logger
-    jruby-openssl (0.11.0-java)
+    jruby-openssl (0.12.1-java)
     jruby-stdin-channel (0.2.0-java)
     json (2.6.1-java)
     json-schema (2.8.1)
@@ -476,6 +476,10 @@ GEM
       logstash-mixin-aws (>= 5.1.0)
       logstash-mixin-ecs_compatibility_support (~> 1.2)
       stud (~> 0.0.18)
+    logstash-input-s3-sns-sqs (2.1.3)
+      logstash-codec-json (~> 3.0)
+      logstash-core-plugin-api (>= 2.1.12, <= 2.99)
+      logstash-mixin-aws (>= 4.3)
     logstash-input-snmp (1.3.1)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -705,7 +709,7 @@ GEM
       nio4r (~> 2.0)
     racc (1.5.2-java)
     rack (2.2.3)
-    rack-protection (2.1.0)
+    rack-protection (2.2.0)
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -740,10 +744,10 @@ GEM
       concurrent-ruby (~> 1.0)
     sequel (5.53.0)
     simple_oauth (0.3.1)
-    sinatra (2.1.0)
+    sinatra (2.2.0)
       mustermann (~> 1.0)
       rack (~> 2.2)
-      rack-protection (= 2.1.0)
+      rack-protection (= 2.2.0)
       tilt (~> 2.0)
     snappy (0.0.12-java)
       snappy-jars (~> 1.1.0)
@@ -864,6 +868,7 @@ DEPENDENCIES
   logstash-input-pipe
   logstash-input-redis
   logstash-input-s3
+  logstash-input-s3-sns-sqs
   logstash-input-snmp
   logstash-input-snmptrap
   logstash-input-sqs

```

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

The `bin/logstash-plugin` utility will, by default, behave more conservatively when updating plugin dependencies.

## What does this PR do?

Introduces `--conservative` (default) / `--no-conservative` flag for plugin install and update.

## Why is it important/What is the impact to the user?

The user will end up less surprised when running `bin/logstash-plugin update` or `install` (when dependencies such as a mixin needs an update to install the plugin).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

Run `bin/logstash-plugin install logstash-input-s3-sns-sqs` and compare the **Gemfile.lock** changes.

## Related issues

Pretty much avoids surprise updates of a dependency such as https://github.com/elastic/logstash/issues/13777