### PR TITLE
pin jruby-openssl to 0.11.0

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "mustermann", '~> 1.0.3'
   gem.add_runtime_dependency "sinatra", '~> 2.1.0' # pinned until GH-13777 is resolved
   gem.add_runtime_dependency 'puma', '~> 5'
-  gem.add_runtime_dependency "jruby-openssl", "~> 0.11"
+  gem.add_runtime_dependency "jruby-openssl", "= 0.11.0"
   gem.add_runtime_dependency "chronic_duration", "~> 0.10"
 
   gem.add_runtime_dependency "treetop", "~> 1" #(MIT license)


### PR DESCRIPTION
This is a backport of https://github.com/elastic/logstash/pull/13785
jruby-openssl 0.12.1 is causing gem load error when running `bin/logstash-plugin`
hence pin to 0.11.0