### PR TITLE
Update pr backporter workflow

### DIFF
--- a/.github/workflows/pr_backporter.yml
+++ b/.github/workflows/pr_backporter.yml
@@ -12,7 +12,7 @@ jobs:
     name: PR comment
     if: |
       (github.event.issue.pull_request && startsWith(github.event.comment.body, '@logstashmachine backport')) &&
-      (github.actor == 'jsvd' || github.actor == 'meh')
+      (github.actor == 'jsvd' || github.actor == 'roaksoax')
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo content

--- a/.github/workflows/pr_backporter.yml
+++ b/.github/workflows/pr_backporter.yml
@@ -1,16 +1,22 @@
 name: Backport PR to another branch
 on:
   issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+  contents: read
 
 jobs:
   pr_commented:
-    # This job only runs for pull request comments
     name: PR comment
-    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '@logstashmachine backport') }}
+    if: |
+      (github.event.issue.pull_request && startsWith(github.event.comment.body, '@logstashmachine backport')) &&
+      (github.actor == 'jsvd' || github.actor == 'meh')
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo content
-        uses: actions/checkout@v2 
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
           ref: 'main'
@@ -20,11 +26,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - run: |
-          echo "branch=$(echo "${{ github.event.comment.body }}" | cut -d " " -f 3)" >> $GITHUB_ENV
+      - env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          echo "branch=$(echo "$BODY" | cut -d " " -f 3)" >> $GITHUB_ENV
       - run: |
           mkdir ~/.elastic && echo ${{ github.token }} >> ~/.elastic/github.token
-      - name: install python dependencies
-        run: pip install requests
-      - name: execute py script # run the run.py to get the latest data
+      - run: pip install requests
+      - name: run backport
         run: python devtools/backport ${{ env.branch }} ${{ github.event.issue.number }} --remote=origin --yes

--- a/.github/workflows/pr_backporter.yml
+++ b/.github/workflows/pr_backporter.yml
@@ -11,10 +11,19 @@ jobs:
   pr_commented:
     name: PR comment
     if: |
-      (github.event.issue.pull_request && startsWith(github.event.comment.body, '@logstashmachine backport')) &&
-      (github.actor == 'jsvd' || github.actor == 'roaksoax')
+      (github.event.issue.pull_request && startsWith(github.event.comment.body, '@logstashmachine backport'))
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch logstash-core team member list
+        uses: tspascoal/get-user-teams-membership@v1
+        with: 
+          username: ${{ github.actor }}
+          organization: elastic
+          team: logstash
+          GITHUB_TOKEN: ${{ secrets.READ_ORG_SECRET_JSVD }}
+      - name: Is user a core team member?
+        if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
+        run: exit 1
       - name: checkout repo content
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
1. Explicitly deny content changes in the workflow
2. Move comment body to env var (GitHub's recommendation for user input sanitization https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable)
3. Restrict workflow to created comments (no updates/deletes)
4. Restrict workflow to an allowlist of users