### PR TITLE
Build: avoid doing a redundant bundle install

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -303,11 +303,13 @@ def assemblyDeps = [downloadAndInstallJRuby, assemble] + subprojects.collect {
   it.tasks.findByName("assemble")
 }
 
+def bundlerVersion = "~> 2"
+
 tasks.register("installBundler") {
     dependsOn assemblyDeps
     outputs.files file("${projectDir}/vendor/bundle/jruby/2.5.0/bin/bundle")
     doLast {
-      gem(projectDir, buildDir, "bundler", "~> 2", "${projectDir}/vendor/bundle/jruby/2.5.0")
+      gem(projectDir, buildDir, "bundler", bundlerVersion, "${projectDir}/vendor/bundle/jruby/2.5.0")
   }
 }
 
@@ -435,7 +437,7 @@ tasks.register("installIntegrationTestBundler"){
     dependsOn unpackTarDistribution
     outputs.files file("${qaBundleBin}")
   doLast {
-      gem(projectDir, buildDir, "bundler", "~> 2", qaBundledGemPath)
+      gem(projectDir, buildDir, "bundler", bundlerVersion, qaBundledGemPath)
   }
 }
 

--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -27,7 +27,7 @@ namespace "vendor" do
   task "gems", [:bundle] do |task, args|
     require "bootstrap/environment"
 
-    if File.exists?('Gemfile.lock') # `./gradlew bootstrap` already run
+    if File.exists?(LogStash::Environment::LOCKFILE) # gradlew already bootstrap-ed
       puts("Skipping bundler install...")
     else
       puts("Invoking bundler install...")

--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -27,10 +27,14 @@ namespace "vendor" do
   task "gems", [:bundle] do |task, args|
     require "bootstrap/environment"
 
-    puts("Invoking bundler install...")
-    output, exception = LogStash::Bundler.invoke!(:install => true)
-    puts(output)
-    raise(exception) if exception
+    if File.exists?('Gemfile.lock') # `./gradlew bootstrap` already run
+      puts("Skipping bundler install...")
+    else
+      puts("Invoking bundler install...")
+      output, exception = LogStash::Bundler.invoke!(:install => true)
+      puts(output)
+      raise(exception) if exception
+    end
   end # task gems
   task "all" => "gems"
 

--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -16,10 +16,6 @@
 # under the License.
 
 namespace "vendor" do
-  def vendor(*args)
-    return File.join("vendor", *args)
-  end
-
   task "jruby" do |task, args|
     system('./gradlew bootstrap') unless File.exists?(File.join("vendor", "jruby"))
   end # jruby
@@ -40,6 +36,6 @@ namespace "vendor" do
 
   desc "Clean the vendored files"
   task :clean do
-    rm_rf(vendor)
+    rm_rf('vendor')
   end
 end


### PR DESCRIPTION
Detect a *Gemfile.lock* present when calling the *vendor:gems* rake task.

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

When preparing for running integration tests, the `gradlew :assembleTarDistribution` gets run, right after the initial bootstraping has completed (dependencies `bundle install`-ed). However, the task in some scenarios failed to respect the (copied) *Gemfile.lock* for the jruby-openssl requirement and still installed the latest version, as seen here: https://github.com/elastic/logstash/issues/13781#issuecomment-1041407935

This seems to be a Bundler bug, since the issue no longer reproduces (w Bundler 2.3.8). 
In either case, running an extra `bundle install` (from the `vendor:gems` task) which is triggered from the `:assembleTarDistribution` doing a `rake artifact:no_bundle_jdk_tar` is unnecessary and speeds up the build.

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

Not a user facing issue.

## Related issues

- https://github.com/elastic/logstash/issues/13781
- https://github.com/elastic/logstash/pull/13785