### PR TITLE
Release: bump version to next 8.0.2 (dev)

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -2,12 +2,12 @@ PATH
   remote: logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 8.0.1)
+      logstash-core (= 8.0.2)
 
 PATH
   remote: logstash-core
   specs:
-    logstash-core (8.0.1-java)
+    logstash-core (8.0.2-java)
       clamp (~> 1)
       concurrent-ruby (~> 1)
       down (~> 5.2.0)

--- a/versions.yml
+++ b/versions.yml
@@ -1,7 +1,7 @@
 ---
 # alpha and beta qualifiers are now added via VERSION_QUALIFIER environment var
-logstash: 8.0.1
-logstash-core: 8.0.1
+logstash: 8.0.2
+logstash-core: 8.0.2
 logstash-core-plugin-api: 2.1.16
 
 bundled_jdk:


### PR DESCRIPTION
Bump version info to **8.0.2** (SNAPSHOT).

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]
