### PR TITLE
[Java17] Add `--add-export` settings to restore JDK17 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,13 @@ allprojects {
 
   //https://stackoverflow.com/questions/3963708/gradle-how-to-display-test-results-in-the-console-in-real-time
   tasks.withType(Test) {
+    jvmArgs = [
+      "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+      "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+      "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+      "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+      "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
+    ]
     testLogging {
       // set options for log level LIFECYCLE
       events "passed", "skipped", "failed", "standardOut"

--- a/build.gradle
+++ b/build.gradle
@@ -81,8 +81,8 @@ allprojects {
       delete "${projectDir}/out/"
   }
 
-  //https://stackoverflow.com/questions/3963708/gradle-how-to-display-test-results-in-the-console-in-real-time
   tasks.withType(Test) {
+    // Add Exports to enable tests to run in JDK17
     jvmArgs = [
       "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
       "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
@@ -90,7 +90,8 @@ allprojects {
       "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
       "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
     ]
-    testLogging {
+      //https://stackoverflow.com/questions/3963708/gradle-how-to-display-test-results-in-the-console-in-real-time
+      testLogging {
       // set options for log level LIFECYCLE
       events "passed", "skipped", "failed", "standardOut"
       showExceptions true

--- a/config/jvm.options
+++ b/config/jvm.options
@@ -49,8 +49,6 @@
 -Djruby.compile.invokedynamic=true
 # Force Compilation
 -Djruby.jit.threshold=0
-# Make sure joni regexp interruptability is enabled
--Djruby.regexp.interruptible=true
 
 ## heap dumps
 
@@ -74,15 +72,3 @@
 
 # Copy the logging context from parent threads to children
 -Dlog4j2.isThreadContextMapInheritable=true
-
-11-:--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
-11-:--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
-11-:--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
-11-:--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
-11-:--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-
-11-:--add-opens=java.base/java.security=ALL-UNNAMED
-11-:--add-opens=java.base/java.io=ALL-UNNAMED
-11-:--add-opens=java.base/java.nio.channels=ALL-UNNAMED
-11-:--add-opens=java.base/sun.nio.ch=ALL-UNNAMED
-11-:--add-opens=java.management/sun.management=ALL-UNNAMED

--- a/config/jvm.options
+++ b/config/jvm.options
@@ -75,6 +75,12 @@
 # Copy the logging context from parent threads to children
 -Dlog4j2.isThreadContextMapInheritable=true
 
+11-:--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+11-:--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+11-:--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+11-:--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+11-:--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+
 11-:--add-opens=java.base/java.security=ALL-UNNAMED
 11-:--add-opens=java.base/java.io=ALL-UNNAMED
 11-:--add-opens=java.base/java.nio.channels=ALL-UNNAMED

--- a/logstash-core/src/main/java/org/logstash/launchers/JvmOptionsParser.java
+++ b/logstash-core/src/main/java/org/logstash/launchers/JvmOptionsParser.java
@@ -167,7 +167,7 @@ public class JvmOptionsParser {
           return Arrays.stream(MANDATORY_JVM_OPTIONS)
                   .map(option -> jvmOptionFromLine(javaMajorVersion, option))
                   .flatMap(Optional::stream)
-                  .collect(Collectors.toList());
+                  .collect(Collectors.toUnmodifiableList());
     }
 
     private List<String> getJvmOptionsFromFile(final Optional<Path> jvmOptionsFile, final int javaMajorVersion) throws IOException, JvmOptionsFileParserException {

--- a/logstash-core/src/main/java/org/logstash/launchers/JvmOptionsParser.java
+++ b/logstash-core/src/main/java/org/logstash/launchers/JvmOptionsParser.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -163,7 +164,12 @@ public class JvmOptionsParser {
         System.out.println(String.join(" ", jvmOptionsContent));
     }
 
-     static List<String> getMandatoryJvmOptions(int javaMajorVersion){
+    /**
+     * Returns the list of mandatory JVM options for the given version of Java.
+     * @param javaMajorVersion
+     * @return Collection of mandatory options
+     */
+     static Collection<String> getMandatoryJvmOptions(int javaMajorVersion){
           return Arrays.stream(MANDATORY_JVM_OPTIONS)
                   .map(option -> jvmOptionFromLine(javaMajorVersion, option))
                   .flatMap(Optional::stream)
@@ -357,7 +363,7 @@ public class JvmOptionsParser {
 
     private static final Pattern JAVA_VERSION = Pattern.compile("^(?:1\\.)?(?<javaMajorVersion>\\d+)(?:\\.\\d+)?$");
 
-    public static int javaMajorVersion() {
+    private static int javaMajorVersion() {
         final String specVersion = System.getProperty("java.specification.version");
         final Matcher specVersionMatcher = JAVA_VERSION.matcher(specVersion);
         if (!specVersionMatcher.matches()) {

--- a/logstash-core/src/test/java/org/logstash/launchers/JvmOptionsParserTest.java
+++ b/logstash-core/src/test/java/org/logstash/launchers/JvmOptionsParserTest.java
@@ -92,13 +92,13 @@ public class JvmOptionsParserTest {
     @Test
     public void testMandatoryJvmOptionApplicableJvmPresent() throws IOException{
         assertTrue("Contains add-exports value for Java 17",
-                JvmOptionsParser.getMandatoryJvmOptions(17).contains("--add-exports=jdk.compiler/com.sun.tools.javac.api==ALL-UNNAMED"));
+                JvmOptionsParser.getMandatoryJvmOptions(17).contains("--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED"));
     }
 
     @Test
     public void testMandatoryJvmOptionNonApplicableJvmNotPresent() throws IOException{
         assertFalse("Does not contains add-exports value for Java 11",
-                JvmOptionsParser.getMandatoryJvmOptions(11).contains("--add-exports=jdk.compiler/com.sun.tools.javac.api==ALL-UNNAMED"));
+                JvmOptionsParser.getMandatoryJvmOptions(11).contains("--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED"));
     }
 
     @Test

--- a/logstash-core/src/test/java/org/logstash/launchers/JvmOptionsParserTest.java
+++ b/logstash-core/src/test/java/org/logstash/launchers/JvmOptionsParserTest.java
@@ -40,7 +40,7 @@ public class JvmOptionsParserTest {
 
         // Verify
         final String output = outputStreamCaptor.toString();
-        assertEquals("Output MUST contains the options present in LS_JAVA_OPTS", "-Xblabla" + System.lineSeparator(), output);
+        assertTrue("Output MUST contains the options present in LS_JAVA_OPTS", output.contains("-Xblabla"));
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -87,6 +87,27 @@ public class JvmOptionsParserTest {
 
         res = JvmOptionsParser.parse(14, asReader("10-11:-XX:+UseConcMarkSweepGC"));
         assertTrue("No option match outside the range [10-11]", res.getJvmOptions().isEmpty());
+    }
+
+    @Test
+    public void testMandatoryJvmOptionApplicableJvmPresent() throws IOException{
+        assertTrue("Contains add-exports value for Java 17",
+                JvmOptionsParser.getMandatoryJvmOptions(17).contains("--add-exports=jdk.compiler/com.sun.tools.javac.api==ALL-UNNAMED"));
+    }
+
+    @Test
+    public void testMandatoryJvmOptionNonApplicableJvmNotPresent() throws IOException{
+        assertFalse("Does not contains add-exports value for Java 11",
+                JvmOptionsParser.getMandatoryJvmOptions(11).contains("--add-exports=jdk.compiler/com.sun.tools.javac.api==ALL-UNNAMED"));
+    }
+
+    @Test
+    public void testAlwaysMandatoryJvmPresent() {
+        assertTrue("Contains regexp interruptible for Java 11",
+                JvmOptionsParser.getMandatoryJvmOptions(11).contains("-Djruby.regexp.interruptible=true"));
+        assertTrue("Contains regexp interruptible for Java 17",
+                JvmOptionsParser.getMandatoryJvmOptions(17).contains("-Djruby.regexp.interruptible=true"));
+
     }
 
     @Test


### PR DESCRIPTION
After #13700 updated google-java-format dependency, it is now required to add a number of `--add-export` flags in order to run on JDK17. This commit adds these flags to the jvm options for a running logstash, and to the tests running on gradle to enable tests to still work

## Release notes
Note: If you use custom `jvm.options`, you will need to add the following settings to `config.jvm.options` to allow Logstash to start:

```
11-:--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
11-:--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
11-:--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
11-:--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
11-:--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
```



## Why is it important/What is the impact to the user?

Without these additional settings, logstash will not start, and tests will fail.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [ ] This should be tested using the JDK matrix test - however, until https://github.com/elastic/infra/pull/34918 is committed, tests will incorrectly pass

## How to test this PR locally

- [ ] Ensure that JDK17 is installed and set using `LS_JAVA_HOME`
- [ ] Run `bin/logstash` with a simple pipeline including at least one filter
- [ ] Also run unit and integration tests, ensuring that JDK17 is being used

## Related issues

Closes #13819
Relates #13700 
Relates https://github.com/logstash-plugins/logstash-filter-kv/issues/98 

