### PR TITLE
Doc: Restructure security content

### DIFF
--- a/docs/static/security/auth-es.asciidoc
+++ b/docs/static/security/auth-es.asciidoc
@@ -1,0 +1,16 @@
+[discrete]
+[[authentication-elasticsearch]]
+== Authentication with {es}
+
+{es} requires that {ls] authenticate itself before a connection can be established.
+{ls} can use any of these authentication methods to send data to a secured {es} cluster:
+
+* Basic authentication credentials (username and password)
+* Token-based API authentication
+* A client certificate
+
+include::basic-auth.asciidoc[]
+include::api-keys.asciidoc[]
+include::pki-auth.asciidoc[]
+
+

--- a/docs/static/security/basic-auth.asciidoc
+++ b/docs/static/security/basic-auth.asciidoc
@@ -5,7 +5,7 @@
 Logstash needs to be able to manage index templates, create indices,
 and write and delete documents in the indices it creates.
 
-To set up authentication credentials for Logstash:
+To set up basic authentication credentials for Logstash:
 
 . Use the the **Management > Roles** UI in {kib} or the `role` API to create a
 `logstash_writer` role. For *cluster* privileges, add `manage_index_templates` and `monitor`. 
@@ -52,9 +52,9 @@ POST _security/user/logstash_internal
 }
 ---------------------------------------------------------------
 
-. Configure Logstash to authenticate as the `logstash_internal` user you just
-created. You configure credentials separately for each of the {es} plugins in
-your Logstash `.conf` file. For example:
+. Configure Logstash to authenticate as the `logstash_internal` user you just created. 
+Configure credentials separately for each of the {es} plugins in your Logstash `.conf` file. 
+For example:
 +
 [source,js]
 --------------------------------------------------

--- a/docs/static/security/logstash.asciidoc
+++ b/docs/static/security/logstash.asciidoc
@@ -1,9 +1,5 @@
 [[ls-security]]
 == Secure your connection to {es} 
-[subs="attributes"]
-++++
-<titleabbrev>Secure your connection</titleabbrev>
-++++
 
 The Logstash {es} {logstash-ref}/plugins-outputs-elasticsearch.html[output],
 {logstash-ref}/plugins-inputs-elasticsearch.html[input], and
@@ -23,10 +19,8 @@ Security is enabled by default on the {es} cluster (starting in 8.0).
 You must enable TLS/SSL in the {es} output section of the Logstash configuration in order to allow Logstash to communicate with the {es} cluster.
 
 include::es-security.asciidoc[]
-include::basic-auth.asciidoc[]
+include::auth-es.asciidoc[]
 include::grant-access.asciidoc[]
 include::tls-encryption.asciidoc[]
-include::pki-auth.asciidoc[]
 include::ls-monitoring.asciidoc[]
 include::pipeline-mgmt.asciidoc[]
-include::api-keys.asciidoc[]


### PR DESCRIPTION
Restructure security content to group authentication options relative to each other. 

Next steps:  When content is nailed down, remove tags that force all security content onto one page so that individual topics appear in right nav. 

Related: #13573