### PR TITLE
Fix Logstash cli tools to use the selected JDK under Windows

### DIFF
--- a/bin/benchmark.bat
+++ b/bin/benchmark.bat
@@ -4,7 +4,7 @@ setlocal enabledelayedexpansion
 cd /d "%~dp0.."
 for /f %%i in ('cd') do set RESULT=%%i
 
-java -cp "!RESULT!\tools\benchmark-cli\build\libs\benchmark-cli.jar;*" ^
+%JAVACMD% -cp "!RESULT!\tools\benchmark-cli\build\libs\benchmark-cli.jar;*" ^
   org.logstash.benchmark.cli.Main %*
 
 endlocal

--- a/bin/ingest-convert.bat
+++ b/bin/ingest-convert.bat
@@ -4,7 +4,7 @@ setlocal enabledelayedexpansion
 cd /d "%~dp0\.."
 for /f %%i in ('cd') do set RESULT=%%i
 
-java -cp "!RESULT!\tools\ingest-converter\build\libs\ingest-converter.jar;*" ^
+%JAVACMD% -cp "!RESULT!\tools\ingest-converter\build\libs\ingest-converter.jar;*" ^
   org.logstash.ingest.Pipeline %*
 
 endlocal

--- a/bin/logstash.bat
+++ b/bin/logstash.bat
@@ -42,7 +42,7 @@ for %%i in ("%LS_HOME%\logstash-core\lib\jars\*.jar") do (
 )
 
 @setlocal
-for /F "usebackq delims=" %%a in (`CALL %JAVA% -cp "!CLASSPATH!" "org.logstash.launchers.JvmOptionsParser" "!LS_HOME!" "!LS_JVM_OPTS!" ^|^| echo jvm_options_parser_failed`) do set LS_JAVA_OPTS=%%a
+for /F "usebackq delims=" %%a in (`CALL %JAVACMD% -cp "!CLASSPATH!" "org.logstash.launchers.JvmOptionsParser" "!LS_HOME!" "!LS_JVM_OPTS!" ^|^| echo jvm_options_parser_failed`) do set LS_JAVA_OPTS=%%a
 @endlocal & set "MAYBE_JVM_OPTIONS_PARSER_FAILED=%LS_JAVA_OPTS%" & set LS_JAVA_OPTS=%LS_JAVA_OPTS%
 
 if "%MAYBE_JVM_OPTIONS_PARSER_FAILED%" == "jvm_options_parser_failed" (
@@ -51,7 +51,7 @@ if "%MAYBE_JVM_OPTIONS_PARSER_FAILED%" == "jvm_options_parser_failed" (
 )
 set JAVA_OPTS=%LS_JAVA_OPTS%
 
-%JAVA% %JAVA_OPTS% -cp "%CLASSPATH%" org.logstash.Logstash %*
+%JAVACMD% %JAVA_OPTS% -cp "%CLASSPATH%" org.logstash.Logstash %*
 
 goto :end
 

--- a/bin/pqcheck.bat
+++ b/bin/pqcheck.bat
@@ -16,7 +16,7 @@ for %%i in ("%LS_HOME%\logstash-core\lib\jars\*.jar") do (
 	call :concat "%%i"
 )
 
-%JAVA% %JAVA_OPTS% -cp "%CLASSPATH%" org.logstash.ackedqueue.PqCheck %*
+%JAVACMD% %JAVA_OPTS% -cp "%CLASSPATH%" org.logstash.ackedqueue.PqCheck %*
 
 :concat
 IF not defined CLASSPATH (

--- a/bin/pqrepair.bat
+++ b/bin/pqrepair.bat
@@ -16,7 +16,7 @@ for %%i in ("%LS_HOME%\logstash-core\lib\jars\*.jar") do (
 	call :concat "%%i"
 )
 
-%JAVA% %JAVA_OPTS% -cp "%CLASSPATH%" org.logstash.ackedqueue.PqRepair %*
+%JAVACMD% %JAVA_OPTS% -cp "%CLASSPATH%" org.logstash.ackedqueue.PqRepair %*
 
 :concat
 IF not defined CLASSPATH (

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -29,10 +29,10 @@ if defined LS_JAVA_HOME (
 ) else (
   if exist "%LS_HOME%\jdk" (
     set JAVACMD=%LS_HOME%\jdk\bin\java.exe
-    echo "Using bundled JDK: !JAVACMD!."
+    echo "Using bundled JDK: !JAVACMD!"
   ) else (
     for %%I in (java.exe) do set JAVACMD="%%~$PATH:I"
-    echo "Using system java: %JAVACMD% ."
+    echo "Using system java: !JAVACMD!"
   )
 )
 

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -21,22 +21,22 @@ for %%I in ("%LS_HOME%..") do set LS_HOME=%%~dpfI
 rem ### 2: set java
 
 if defined LS_JAVA_HOME (
-  set JAVA="%LS_JAVA_HOME%\bin\java.exe"
+  set JAVACMD=%LS_JAVA_HOME%\bin\java.exe
   echo Using LS_JAVA_HOME defined java: %LS_JAVA_HOME%
   if exist "%LS_HOME%\jdk" (
     echo WARNING: Using LS_JAVA_HOME while Logstash distribution comes with a bundled JDK.
   )
 ) else (
   if exist "%LS_HOME%\jdk" (
-    set JAVA="%LS_HOME%\jdk\bin\java.exe"
-    echo "Using bundled JDK: %JAVA%."
+    set JAVACMD=%LS_HOME%\jdk\bin\java.exe
+    echo "Using bundled JDK: !JAVACMD!."
   ) else (
-    for %%I in (java.exe) do set JAVA="%%~$PATH:I"
-    echo "Using system java: %JAVA% ."
+    for %%I in (java.exe) do set JAVACMD="%%~$PATH:I"
+    echo "Using system java: %JAVACMD% ."
   )
 )
 
-if not exist %JAVA% (
+if not exist %JAVACMD% (
   echo could not find java; set JAVA_HOME or ensure java is in PATH 1>&2
   exit /b 1
 )


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Fix JVM path for Logstash CLI tools that used the JRuby launcher.

## What does this PR do?

The JRuby interpreter accepts JVM selection through two environment variables:
- `JAVACMD` which points to the JVM executable
- `JAVA_HOME` which point to JDK home directory
Logstash CLI (command line) tools, like `bin\logstash-keystore.bat`, launches the JRuby interpreter directly, but while they setup the environment calling `setup.bat` the variable configured by the script is not the one expected by JRuby.
The `setup.bat` populate `JAVA` while JRuby expects `JAVACMD`.  
This PR does the rename, miming what's already done in `bash` scripts, which configures `JAVACMD`.  

## Why is it important/What is the impact to the user?

Now the users that doesn't have any JVM installed, can run the CLI tools using the bundled JDK.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] test on a Windows instance with various JDK installs (system/ no system, LS_JAVA_HOME/no LS_JAVA_HOME)

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
On a Windows machine (with a JVM to run Gradle) checkout the branch and build with 
```
.\gradlew assemble
.\gradlew copyJdk -Pjdk_bundle_os=windows -Pjdk_arch=x86_64
``` 

then run one or more of the CLI tools, for example:
```
logstash-keystore.bat
```
or the plugin manager. 
Then  test after setting `LS_JAVA_HOME` to a proper installed JDK, for example:
```
set LS_JAVA_HOME=C:\Users\andrea_selva\JDKs\jdk-11.0.12+7
```
and verify it's used but with a warning that the distribution is shipped with a JDK


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Fixes #13796

## Use cases

A Windows user, without any JDK installed must be able to run logstash CLI tools.
