### PR TITLE
Backport PR #13410 to 7.17: geoip-db: support `http_proxy` environment variable

### DIFF
--- a/x-pack/lib/filters/geoip/download_manager.rb
+++ b/x-pack/lib/filters/geoip/download_manager.rb
@@ -118,7 +118,14 @@ module LogStash module Filters module Geoip class DownloadManager
   end
 
   def rest_client
-    @client ||= Manticore::Client.new(request_timeout: 15, connect_timeout: 5)
+    @client ||= begin
+                  client_options = {
+                    request_timeout: 15,
+                    connect_timeout: 5
+                  }
+                  client_options[:proxy]=ENV['http_proxy'] if ENV.include?('http_proxy')
+                  Manticore::Client.new(client_options)
+                end
   end
 
   def uuid

--- a/x-pack/spec/filters/geoip/download_manager_spec.rb
+++ b/x-pack/spec/filters/geoip/download_manager_spec.rb
@@ -39,6 +39,18 @@ describe LogStash::Filters::Geoip do
         expect(download_manager).to receive(:service_endpoint).and_return(bad_uri).twice
         expect { download_manager.send(:check_update) }.to raise_error(LogStash::Filters::Geoip::DownloadManager::BadResponseCodeError, /404/)
       end
+
+      context "when ENV['http_proxy'] is set" do
+        let(:proxy_url) { 'http://user:pass@example.com:1234' }
+
+        around(:each) { |example| with_environment('http_proxy' => proxy_url, &example) }
+
+        it "initializes the client with the proxy" do
+          expect(::Manticore::Client).to receive(:new).with(a_hash_including(:proxy => proxy_url)).and_call_original
+
+          download_manager.send(:rest_client)
+        end
+      end
     end
 
     context "check update" do

--- a/x-pack/spec/support/helpers.rb
+++ b/x-pack/spec/support/helpers.rb
@@ -47,6 +47,32 @@ def apply_settings(settings_values, settings = nil)
   settings
 end
 
+##
+# yields to the provided block with the ENV modified by
+# the provided overrides. Values given as `nil` will be deleted
+# if present in the base ENV.
+#
+# @param replacement [Hash{String=>[String,nil]}]
+def with_environment(overrides)
+  replacement = ENV.to_hash
+                   .merge(overrides)
+                   .reject { |_,v| v.nil? }
+
+  with_environment!(replacement) { yield }
+end
+
+##
+# yields to the provided block with the ENV replaced
+# @param replacement [Hash{String=>String}]
+def with_environment!(replacement)
+  original = ENV.to_hash.dup.freeze
+  ENV.replace(replacement)
+
+  yield
+ensure
+  ENV.replace(original)
+end
+
 def start_agent(agent)
   agent_task = Stud::Task.new do
     begin


### PR DESCRIPTION
Backport PR #13410 to 7.17 branch. Original message: 

## Release notes

 - The GeoIP database lookup will respect a proxy defined with the `http_proxy` environment variable.

## What does this PR do?

When instantiating the REST client for GeoIP database update lookups, a proxy specified with the `http_proxy` environment variable will now be propagated to Manticore, ensuring that the lookup traffic routes over the configured proxy. This mirrors old behavior that we got "for free" in previous releases of Logstash when we were using Faraday as our REST client, and lost when we swapped out our internals to use Manticore in #13273 

## Why is it important/What is the impact to the user?

When running on a host whose outbound HTTP traffic must be routed through a proxy, the database manager now works as expected.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

1. Start a local proxy with logging enabled. I used `tinyproxy -d -c tinyproxy.conf` with the following config:
    > ~~~
    > Port 1234
    > LogLevel Connect
    > BasicAuth someuser s3cur3cr3dent1als
    > ~~~
    > -- `tinyproxy.conf`

2. Set the `http_proxy` environment variable to point at your local proxy
    > ~~~
    > export http_proxy="http://someuser:s3cur3cr3dent1als@127.0.0.1:1234"
    > ~~~

3. Observe proxy connection in proxy logs:
    > ~~~
    > CONNECT   Nov 16 19:53:40.695 [73080]: Connect (file descriptor 6): 127.0.0.1
    > CONNECT   Nov 16 19:53:40.702 [73080]: Request (file descriptor 6): CONNECT geoip.elastic.co:443 HTTP/1.1
    > CONNECT   Nov 16 19:53:40.708 [73080]: Connect (file descriptor 6): 127.0.0.1
    > CONNECT   Nov 16 19:53:40.710 [73080]: Request (file descriptor 6): CONNECT geoip.elastic.co:443 HTTP/1.1
    > CONNECT   Nov 16 19:53:40.811 [73080]: Established connection to host "geoip.elastic.co" using file descriptor 9.
    > ~~~

4. Observe succesful lookup in Logstash logs:
    > ~~~
    > [2021-11-16T19:53:41,261][DEBUG][logstash.filters.geoip.downloadmanager] check update {:endpoint=>"https://geoip.elastic.co/v1/database?key=REDACTED&elastic_geoip_service_tos=agree", :response=>200}
    > ~~~
## Related issues

- Resolves: #13392 
