### PR TITLE
Backport PR #13244 to 8.1: i18n: alias logstash.runner.configuration.* under logstash.agent.configuration

### DIFF
--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -61,23 +61,6 @@ en:
         0-1-x: >-
          Using version 0.1.x %{type} plugin '%{name}'. This plugin isn't well
          supported by the community and likely has no maintainer.
-    agent:
-      sighup: >-
-        SIGHUP received.
-      sigint: >-
-        SIGINT received. Shutting down.
-      sigterm: >-
-        SIGTERM received. Shutting down.
-      slow_shutdown: |-
-        Received shutdown signal, but pipeline is still waiting for in-flight events
-        to be processed. Sending another ^C will force quit Logstash, but this may cause
-        data loss.
-      forced_sigint: >-
-        SIGINT received. Terminating immediately..
-      non_reloadable_config_reload: >-
-        Unable to reload configuration because it does not support dynamic reloading
-      non_reloadable_config_register: |-
-        Logstash is not able to start since configuration auto reloading was enabled but the configuration contains plugins that don't support it. Quitting...
     web_api:
       cant_bind_to_port: |-
         Logstash tried to bind to port %{port}, but the port is already in use. You can specify a new port by launching logstash with the --api.http.port option."
@@ -158,7 +141,9 @@ en:
       configtest-flag-information: |-
         You may be interested in the '--configtest' flag which you can use to validate
         logstash's configuration before you choose to restart a running system.
-      configuration:
+      # YAML named reference to the logstash.runner.configuration
+      # so we can later alias it from logstash.agent.configuration
+      configuration: &runner_configuration
         obsolete: >-
           The setting `%{name}` in plugin `%{plugin}` is obsolete and is no
           longer available. %{extra} If you have any questions about this, you
@@ -414,6 +399,27 @@ en:
           Running Logstash with the bundled JDK is recommended.
           The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability.
           If you have compelling reasons for using your own JDK (organizational-specific compliance requirements, for example), you can configure LS_JAVA_HOME to use that version instead.
+    agent:
+      sighup: >-
+        SIGHUP received.
+      sigint: >-
+        SIGINT received. Shutting down.
+      sigterm: >-
+        SIGTERM received. Shutting down.
+      slow_shutdown: |-
+        Received shutdown signal, but pipeline is still waiting for in-flight events
+        to be processed. Sending another ^C will force quit Logstash, but this may cause
+        data loss.
+      forced_sigint: >-
+        SIGINT received. Terminating immediately..
+      non_reloadable_config_reload: >-
+        Unable to reload configuration because it does not support dynamic reloading
+      non_reloadable_config_register: |-
+        Logstash is not able to start since configuration auto reloading was enabled but the configuration contains plugins that don't support it. Quitting...
+      # LEGACY: many plugins refer to logstash.agent.configuration.*
+      # so we alias the canonical logstash.runner.configuration.*
+      configuration:
+        <<: *runner_configuration
     settings:
       deprecation:
         set: >-
@@ -425,3 +431,4 @@ en:
         ambiguous: >-
           Both `%{canonical_name}` and its deprecated alias `%{deprecated_alias}` have been set.
           Please only set `%{canonical_name}`
+


### PR DESCRIPTION
Backport PR #13244 to 8.1 branch. Original message: 

A number of plugins reach into Logstash's i18n translations to "helpfully" communicate certain configuration errors, but rely on translations that were moved in #3872 from logstash.agent to logstash.runner. Since then, it is possible to hit obtuse error messages about failing to load a translation instead of the intended helpful message:

~~~
translation missing: en.logstash.agent.configuration.invalid_plugin_register
~~~

By moving the `logstash.agent` definition to _after_ the `logstash.runner` definition, we can use YAML tooling to name the `logstash.runner.configuration` node and then merge its contents into `logstash.agent.configuration`. This effectively allows us to keep a single definition of those translations while making them available at both addresses.

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Fixed an issue where some improperly-configured plugins would attempt to provide helpful guidance but fail to load the correct help-text.

## What does this PR do?

Aliases each of the translation keys in the `en.logstash.runner.configuration` into `en.logstash.agent.configuration` so that plugins that still rely on the old location of those help-texts will be able to find them.

## Why is it important/What is the impact to the user?

Turns an obtuse error like:

~~~
(ConfigurationError) translation missing: en.logstash.agent.configuration.invalid_plugin_register
~~~

Int a more helpful one like:

~~~
 (ConfigurationError) Cannot register filter FILTER_NAME plugin. The error reported is:\n  ERROR_DESCRIPTION"
~~~


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~


## How to test this PR locally

The Date Filter is one of many plugins that uses Logstash's i18n and [attempts to lookup the `logstash.agent.configuration. invalid_plugin_register` when provided incorrectly-shaped input](https://github.com/logstash-plugins/logstash-filter-date/blob/v3.1.9/lib/logstash/filters/date.rb#L159-L163). Looking into Logstash's `vendor` directory will yield many more. We can intentionally hit one of these like:

~~~
bin/logstash -e 'filter { date { match => "this_is_wrong" } }'
~~~

Without this patch, our error is an obtuse one about failing to look up a translation, and with this patch the error is marginally more helpful.