### PR TITLE
Backport PR #13345 to 8.1: pipeline-info: increase safety of transforming stats

### DIFF
--- a/logstash-core/lib/logstash/config/pipelines_info.rb
+++ b/logstash-core/lib/logstash/config/pipelines_info.rb
@@ -21,9 +21,9 @@ module LogStash; module Config;
       # It is important that we iterate via the agent's pipelines vs. the
       # metrics pipelines. This prevents race conditions as pipeline stats may be
       # populated before the agent has it in its own pipelines state
-      stats = metric_store.get_with_path("/stats/pipelines")[:stats][:pipelines]
+      stats = metric_store.get_with_path("/stats/pipelines").dig(:stats, :pipelines) || {}
       agent.running_pipelines.map do |pipeline_id, pipeline|
-        p_stats = stats[pipeline_id]
+        p_stats = stats.fetch(pipeline_id) { Hash.new }
         # Don't record stats for system pipelines
         next nil if pipeline.system?
         # Don't emit stats for pipelines that have not yet registered any metrics


### PR DESCRIPTION
Backport PR #13345 to 8.1 branch. Original message: 

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

Fixes an issue where an attempt to get pipeline info before a pipeline is fully-initialized can result in an opaque transient failure.

When a pipeline isn't fully initialized, we run the risk of attempting to
format pipeline info that isn't yet fully-shaped. By using safe-fallback
methods like `Hash#dig` and conditional-chaining, we can avoid the spurious
`NoMethodError` caused by sending `[]` to nil.

From what I can tell, there are three paths to access this:
 - via Monitoring API when the issue is hit, a single monitoring event during startup fails to be emitted but the next scheduled event will fire off normally.
 - via HTTP API when this  issue is hit, the request will likely result in an HTTP 500, but subsequent attempts once the pipeline has fully started will succeed.
 - in automated tests, this results in an occasionally-failed build

## Why is it important/What is the impact to the user?

Prevents broken builds

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~

## Logs

An example of a failed build caused by one of the issues resolved here.

~~~
12:18:22     Failures:
12:18:22 
12:18:22       1) LogStash::Inputs::Metrics::StatsEventFactory new model behaves like new model monitoring event with webserver setting should be valid
12:18:22          Failure/Error: "pipelines" => LogStash::Config::PipelinesInfo.format_pipelines_info(agent, @metric_store, extended_performance_collection),
12:18:22          
12:18:22          NoMethodError:
12:18:22            undefined method `[]' for nil:NilClass
12:18:22          Shared Example Group: "new model monitoring event with webserver setting" called from ./spec/monitoring/inputs/metrics/stats_event_factory_spec.rb:93
12:18:22          # /opt/logstash/logstash-core/lib/logstash/config/pipelines_info.rb:36:in `block in format_pipelines_info'
12:18:22          # /opt/logstash/logstash-core/lib/logstash/config/pipelines_info.rb:25:in `format_pipelines_info'
12:18:22          # ./lib/monitoring/inputs/metrics/stats_event_factory.rb:24:in `make'
12:18:22          # ./spec/monitoring/inputs/metrics/stats_event_factory_spec.rb:37:in `block in <main>'
12:18:22          # /opt/logstash/vendor/bundle/jruby/2.5.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block in <main>'
12:18:22          # /opt/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-devutils-2.2.1-java/lib/logstash/devutils/rspec/spec_helper.rb:51:in `block in <main>'
12:18:22          # /opt/logstash/lib/bootstrap/rspec.rb:31:in `<main>'
~~~