### PR TITLE
Backport PR #13715 to 8.1: artifacts: omit openssl_pkcs8_pure specs from built artifacts

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -84,8 +84,9 @@ namespace "artifact" do
     @exclude_paths << "bin/rspec"
     @exclude_paths << "bin/rspec.bat"
 
-    # vendored test artifacts from upstream
-    @exclude_paths << 'vendor/**/gems/rubyzip-*/test/**/*'
+    # vendored test/spec artifacts from upstream
+    @exclude_paths << 'vendor/**/gems/*/test/**/*'
+    @exclude_paths << 'vendor/**/gems/*/spec/**/*'
 
     @exclude_paths
   end


### PR DESCRIPTION
Backport PR #13715 to 8.1 branch. Original message: 

## Release notes

[rn:skip]


## What does this PR do?

The `openssl_pkcs8_pure` gem dependency is a library for transforming key formats, and includes spec artifacts for validating its ability to transform key formats that are not useful at runtime. The presence of theses keys causes false alarms, so this PR ensures they are excluded from our built artifacts.

## Why is it important/What is the impact to the user?

Allows our artifacts, or docker containers that import our artifacts, to not trigger false positives against some security policies.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
