### PR TITLE
[7.17] expose shutdown request state of pipeline (#13811)

### DIFF
--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -548,6 +548,10 @@ module LogStash; class JavaPipeline < JavaBasePipeline
     }
   end
 
+  def shutdown_requested?
+    @shutdownRequested.get
+  end
+
   private
 
   def close_plugin_and_ignore(plugin)

--- a/logstash-core/lib/logstash/outputs/base.rb
+++ b/logstash-core/lib/logstash/outputs/base.rb
@@ -135,6 +135,10 @@ class LogStash::Outputs::Base < LogStash::Plugin
     context
   end
 
+  def pipeline_shutdown_requested?
+    execution_context.pipeline&.shutdown_requested?
+  end
+
   private
   def output?(event)
     # TODO: noop for now, remove this once we delete this call from all plugins

--- a/logstash-core/src/main/java/org/logstash/execution/JavaBasePipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/JavaBasePipelineExt.java
@@ -143,6 +143,11 @@ public final class JavaBasePipelineExt extends AbstractPipelineExt {
         return result;
     }
 
+    @JRubyMethod(name = "shutdown_requested?")
+    public IRubyObject isShutdownRequested(final ThreadContext context) {
+        throw new IllegalStateException("Pipeline implementation does not provide `shutdown_requested?`, which is a Logstash internal error.");
+    }
+
     public QueueWriter getQueueWriter(final String inputName) {
         return new JRubyWrappedWriteClientExt(RubyUtil.RUBY, RubyUtil.WRAPPED_WRITE_CLIENT_CLASS)
             .initialize(


### PR DESCRIPTION
Backports the following commits to 7.17:
 - expose shutdown request state of pipeline (#13811)