### PR TITLE
Doc: Improve formatting and readability for pipeline ordering [8.0]

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -53,16 +53,16 @@
 # events in memory. By default, logstash will refuse to quit until all
 # received events have been pushed to the outputs.
 #
-# WARNING: enabling this can lead to data loss during shutdown
+# WARNING: Enabling this can lead to data loss during shutdown
 #
 # pipeline.unsafe_shutdown: false
 #
 # Set the pipeline event ordering. Options are "auto" (the default), "true" or "false".
-# "auto" will  automatically enable ordering if the 'pipeline.workers' setting
-# is also set to '1'.
-# "true" will enforce ordering on the pipeline and prevent logstash from starting
+# "auto" automatically enables ordering if the 'pipeline.workers' setting
+# is also set to '1', and disables otherwise.
+# "true" enforces ordering on the pipeline and prevent logstash from starting
 # if there are multiple workers.
-# "false" will disable any extra processing necessary for preserving ordering.
+# "false" disables any extra processing necessary for preserving ordering.
 #
 # pipeline.ordered: auto
 #

--- a/config/pipelines.yml
+++ b/config/pipelines.yml
@@ -35,6 +35,15 @@
 #   # before dispatching an undersized batch to filters+outputs
 #   pipeline.batch.delay: 50
 #
+#   Set the pipeline event ordering. Options are "auto" (the default), "true" # #   or "false".
+#   "auto" automatically enables ordering if the 'pipeline.workers' setting
+#   is also set to '1', and disables otherwise.
+#   "true" enforces ordering on a pipeline and prevents logstash from starting
+#   a pipeline with multiple workers allocated.
+#   "false" disable any extra processing necessary for preserving ordering.
+#
+#   pipeline.ordered: auto
+#
 #   # Internal queuing model, "memory" for legacy in-memory based queuing and
 #   # "persisted" for disk-based acked queueing. Defaults is memory
 #   queue.type: memory

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -116,16 +116,12 @@ increasing this number to better utilize machine processing power.
 
 | `pipeline.ordered`
 a|
-Set the pipeline event ordering.Valid options are:
+Set the pipeline event ordering. Valid options are:
 
-* `auto`
-* `true`
-* `false`
-
-`auto` will  automatically enable ordering if the `pipeline.workers` setting is also set to `1`.
-`true` will enforce ordering on the pipeline and prevent logstash from starting
+* `auto`. Automatically enables ordering if the `pipeline.workers` setting is `1`, and disables otherwise.
+* `true`. Enforces ordering on the pipeline and prevents Logstash from starting
 if there are multiple workers.
-`false` will disable the processing required to preserve order. Ordering will not be
+* `false`. Disables the processing required to preserve order. Ordering will not be
 guaranteed, but you save the processing cost of preserving order.
 
 | `auto`


### PR DESCRIPTION
Add pipelines.ordered entry to pipelines.yml
Backports #13084 to 8.0

Co-authored-by: Rob Bavey <rob.bavey@elastic.co>

