### PR TITLE
[Backport 8.0]Fix Logstash cli tools to use the selected JDK under Windows (#13839)

### DIFF
--- a/bin/benchmark.bat
+++ b/bin/benchmark.bat
@@ -4,7 +4,7 @@ setlocal enabledelayedexpansion
 cd /d "%~dp0.."
 for /f %%i in ('cd') do set RESULT=%%i
 
-java -cp "!RESULT!\tools\benchmark-cli\build\libs\benchmark-cli.jar;*" ^
+%JAVACMD% -cp "!RESULT!\tools\benchmark-cli\build\libs\benchmark-cli.jar;*" ^
   org.logstash.benchmark.cli.Main %*
 
 endlocal

--- a/bin/ingest-convert.bat
+++ b/bin/ingest-convert.bat
@@ -4,7 +4,7 @@ setlocal enabledelayedexpansion
 cd /d "%~dp0\.."
 for /f %%i in ('cd') do set RESULT=%%i
 
-java -cp "!RESULT!\tools\ingest-converter\build\libs\ingest-converter.jar;*" ^
+%JAVACMD% -cp "!RESULT!\tools\ingest-converter\build\libs\ingest-converter.jar;*" ^
   org.logstash.ingest.Pipeline %*
 
 endlocal

--- a/bin/logstash.bat
+++ b/bin/logstash.bat
@@ -38,7 +38,7 @@ for %%i in ("%LS_HOME%\logstash-core\lib\jars\*.jar") do (
 )
 
 @setlocal
-for /F "usebackq delims=" %%a in (`CALL %JAVA% -cp "!CLASSPATH!" "org.logstash.launchers.JvmOptionsParser" "!LS_HOME!" "!LS_JVM_OPTS!" ^|^| echo jvm_options_parser_failed`) do set LS_JAVA_OPTS=%%a
+for /F "usebackq delims=" %%a in (`CALL %JAVACMD% -cp "!CLASSPATH!" "org.logstash.launchers.JvmOptionsParser" "!LS_HOME!" "!LS_JVM_OPTS!" ^|^| echo jvm_options_parser_failed`) do set LS_JAVA_OPTS=%%a
 @endlocal & set "MAYBE_JVM_OPTIONS_PARSER_FAILED=%LS_JAVA_OPTS%" & set LS_JAVA_OPTS=%LS_JAVA_OPTS%
 
 if "%MAYBE_JVM_OPTIONS_PARSER_FAILED%" == "jvm_options_parser_failed" (
@@ -47,7 +47,7 @@ if "%MAYBE_JVM_OPTIONS_PARSER_FAILED%" == "jvm_options_parser_failed" (
 )
 set JAVA_OPTS=%LS_JAVA_OPTS%
 
-%JAVA% %JAVA_OPTS% -cp "%CLASSPATH%" org.logstash.Logstash %*
+%JAVACMD% %JAVA_OPTS% -cp "%CLASSPATH%" org.logstash.Logstash %*
 
 goto :end
 

--- a/bin/pqcheck.bat
+++ b/bin/pqcheck.bat
@@ -16,7 +16,7 @@ for %%i in ("%LS_HOME%\logstash-core\lib\jars\*.jar") do (
 	call :concat "%%i"
 )
 
-%JAVA% %JAVA_OPTS% -cp "%CLASSPATH%" org.logstash.ackedqueue.PqCheck %*
+%JAVACMD% %JAVA_OPTS% -cp "%CLASSPATH%" org.logstash.ackedqueue.PqCheck %*
 
 :concat
 IF not defined CLASSPATH (

--- a/bin/pqrepair.bat
+++ b/bin/pqrepair.bat
@@ -16,7 +16,7 @@ for %%i in ("%LS_HOME%\logstash-core\lib\jars\*.jar") do (
 	call :concat "%%i"
 )
 
-%JAVA% %JAVA_OPTS% -cp "%CLASSPATH%" org.logstash.ackedqueue.PqRepair %*
+%JAVACMD% %JAVA_OPTS% -cp "%CLASSPATH%" org.logstash.ackedqueue.PqRepair %*
 
 :concat
 IF not defined CLASSPATH (

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -21,22 +21,22 @@ for %%I in ("%LS_HOME%..") do set LS_HOME=%%~dpfI
 rem ### 2: set java
 
 if defined LS_JAVA_HOME (
-  set JAVA="%LS_JAVA_HOME%\bin\java.exe"
+  set JAVACMD=%LS_JAVA_HOME%\bin\java.exe
   echo Using LS_JAVA_HOME defined java: %LS_JAVA_HOME%
   if exist "%LS_HOME%\jdk" (
     echo WARNING: Using LS_JAVA_HOME while Logstash distribution comes with a bundled JDK.
   )
 ) else (
   if exist "%LS_HOME%\jdk" (
-    set JAVA="%LS_HOME%\jdk\bin\java.exe"
-    echo "Using bundled JDK: %JAVA%."
+    set JAVACMD=%LS_HOME%\jdk\bin\java.exe
+    echo "Using bundled JDK: !JAVACMD!"
   ) else (
-    for %%I in (java.exe) do set JAVA="%%~$PATH:I"
-    echo "Using system java: %JAVA% ."
+    for %%I in (java.exe) do set JAVACMD="%%~$PATH:I"
+    echo "Using system java: !JAVACMD!"
   )
 )
 
-if not exist %JAVA% (
+if not exist %JAVACMD% (
   echo could not find java; set JAVA_HOME or ensure java is in PATH 1>&2
   exit /b 1
 )


### PR DESCRIPTION
Clean backport of #13839 to `8.0`

----

Some Logstash tools invokes directly the JRuby intepreter. The interpreter uses the JVM pointed by two environment variables:
- JAVACMD
- JAVA_HOME\bin\java.exe

The setup.bat script exported the selected JVM under the env var named JAVA, which isn't recognized by vendored jruby.
This commit fixes it renaming to JAVACMD.

(cherry picked from commit 0084492494c0629cf76aa8d955a13d01b66c84dc)
