### PR TITLE
Pin jruby-openssl in logstash-core to 0.12.1

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "mustermann", '~> 1.0.3'
   gem.add_runtime_dependency "sinatra", '~> 2.1.0' # pinned until GH-13777 is resolved
   gem.add_runtime_dependency 'puma', '~> 5'
-  gem.add_runtime_dependency "jruby-openssl", "~> 0.11"
+  gem.add_runtime_dependency "jruby-openssl", "= 0.12.1"
 
   gem.add_runtime_dependency "treetop", "~> 1" #(MIT license)
 


### PR DESCRIPTION
Similarly to #13875, a recent update to jruby-openssl to 0.12.2 causes a
gem load error when trying to use `bin/logstash-plugin`. This commit pins the
gemspec in `logstash-core.gemspec` to match that in the lockfile.
