### PR TITLE
Backport PR #13687 to 8.1: bump jdk to 11.0.14.1+1

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -7,8 +7,8 @@ logstash-core-plugin-api: 2.1.16
 bundled_jdk:
   # for AdoptOpenJDK/OpenJDK jdk-14.0.1+7.1, the revision is 14.0.1 while the build is 7.1
   vendor: "adoptopenjdk"
-  revision: 11.0.13
-  build: 8
+  revision: 11.0.14.1
+  build: 1
 
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time


### PR DESCRIPTION
**Backport PR #13687 to 8.1 branch, original message:**

---

https://www.oracle.com/java/technologies/javase/11-0-14-relnotes.html