### PR TITLE
ArcSight Module Broken (Invalid Type), Fixed

### DIFF
--- a/logstash-core/lib/logstash/modules/logstash_config.rb
+++ b/logstash-core/lib/logstash/modules/logstash_config.rb
@@ -92,9 +92,9 @@ module LogStash module Modules class LogStashConfig
     @settings.fetch(name, default)
   end
 
-  def elasticsearch_output_config(type_string = nil, index_suffix = "%{+YYYY.MM.dd}")
+  def elasticsearch_output_config(type_string = nil, index_suffix = "-%{+YYYY.MM.dd}")
     hosts = array_to_string(get_setting(LogStash::Setting::SplittableStringArray.new("var.elasticsearch.hosts", String, ["localhost:9200"])))
-    index = "#{@name}-#{index_suffix}"
+    index = "#{@name}#{index_suffix}"
     user = @settings["var.elasticsearch.username"]
     password = @settings["var.elasticsearch.password"]
     lines = ["hosts => #{hosts}", "index => \"#{index}\""]

--- a/logstash-core/lib/logstash/modules/logstash_config.rb
+++ b/logstash-core/lib/logstash/modules/logstash_config.rb
@@ -92,9 +92,9 @@ module LogStash module Modules class LogStashConfig
     @settings.fetch(name, default)
   end
 
-  def elasticsearch_output_config(type_string = nil)
+  def elasticsearch_output_config(type_string = nil, index_suffix = "%{+YYYY.MM.dd}")
     hosts = array_to_string(get_setting(LogStash::Setting::SplittableStringArray.new("var.elasticsearch.hosts", String, ["localhost:9200"])))
-    index = "#{@name}-#{setting("var.elasticsearch.index_suffix", "%{+YYYY.MM.dd}")}"
+    index = "#{@name}-#{index_suffix}"
     user = @settings["var.elasticsearch.username"]
     password = @settings["var.elasticsearch.password"]
     lines = ["hosts => #{hosts}", "index => \"#{index}\""]

--- a/x-pack/modules/arcsight/configuration/logstash/arcsight.conf.erb
+++ b/x-pack/modules/arcsight/configuration/logstash/arcsight.conf.erb
@@ -21,7 +21,7 @@ input {
     bootstrap_servers => <%= csv_string(get_setting(LogStash::Setting::SplittableStringArray.new("var.input.kafka.bootstrap_servers", String, "localhost:39092"))) %>
     topics => <%= array_to_string(get_setting(LogStash::Setting::SplittableStringArray.new("var.input.kafka.topics", String, ["eb-cef"]))) %>
     <%= LogStash::Arcsight::ConfigHelper.kafka_input_ssl_sasl_config(self) %>
-    type => syslog
+    type => _doc
   }
   <% end %>
 
@@ -31,7 +31,7 @@ input {
     codec => cef { delimiter => "\r\n" }
     port => <%= setting("var.input.tcp.port", 5000) %>
     <%= LogStash::Arcsight::ConfigHelper.tcp_input_ssl_config(self) %>
-    type => syslog
+    type => _doc
   }
   <% end %>
 }
@@ -67,5 +67,5 @@ filter {
 }
 
 output {
-  <%= elasticsearch_output_config('syslog') %>
+  <%= elasticsearch_output_config('_doc') %>
 }

--- a/x-pack/modules/arcsight/configuration/logstash/arcsight.conf.erb
+++ b/x-pack/modules/arcsight/configuration/logstash/arcsight.conf.erb
@@ -67,5 +67,5 @@ filter {
 }
 
 output {
-  <%= elasticsearch_output_config('_doc') %>
+  <%= elasticsearch_output_config('_doc', "#{LOGSTASH_VERSION}-%{+YYYY.MM.dd}") %>
 }

--- a/x-pack/modules/arcsight/configuration/logstash/arcsight.conf.erb
+++ b/x-pack/modules/arcsight/configuration/logstash/arcsight.conf.erb
@@ -67,5 +67,5 @@ filter {
 }
 
 output {
-  <%= elasticsearch_output_config('_doc', "#{LOGSTASH_VERSION}-%{+YYYY.MM.dd}") %>
+  <%= elasticsearch_output_config('_doc', "-#{LOGSTASH_VERSION}-%{+YYYY.MM.dd}") %>
 }

--- a/x-pack/spec/modules/arcsight/arcsight_module_config_spec.rb
+++ b/x-pack/spec/modules/arcsight/arcsight_module_config_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../../../../x-pack/lib/x-pack/logstash_registry.rb'
+require 'logstash-core'
+require 'logstash/settings'
+require 'logstash/util/modules_setting_array'
+require 'logstash/modules/scaffold'
+require 'arcsight_module_config_helper'
+
+describe "ArcSight module" do 
+  let(:logstash_config_class) { LogStash::Modules::LogStashConfig  }
+  let(:module_name) { "arcsight" }
+  let(:module_path) { ::File.join(LogStash::Environment::LOGSTASH_HOME, "x-pack", "modules", module_name, "configuration") }
+  let(:mod) { instance_double("arcsight", :directory => module_path , :module_name => module_name) }
+  let(:settings) { {} }
+  subject { logstash_config_class.new(mod, settings) }
+
+  it "test" do
+    expect(subject.config_string).to include("index => \"arcsight-#{::LOGSTASH_VERSION}-%{+YYYY.MM.dd}\"")
+  end
+end
+
+


### PR DESCRIPTION
* index arcsight data with document type `_doc` so it works on ES 8.x
* include Logstash version in index names to allow different document types to facilitate upgrading
* remove dangling `var.elasticsearch.index_suffix` setting

For reviewers:
1. Install Kibana and ES 6.x
2. Run Logstash 7.x Arcsight Module like so:

```
❯ bin/logstash --modules arcsight --setup -M "arcsight.var.inputs=smartconnector"  -M "arcsight.var.input.smartconnector.port=5010" -M "arcsight.var.elasticsearch.hosts=localhost:9200"  -M "arcsight.var.kibana.host=localhost:5601" -M "arcsight.var.kibana.ssl.enabled=false"
```

3. Ingest data like so:

```
echo "CEF:0|FooBar|Web Gateway|1.2.3.45.67|200|Success|2|rt=Sep 07 2018 14:50:39 cat=Access Log dst=1.1.1.1 dhost=[foo.example.com](http://foo.example.com/) suser=redacted src=2.2.2.2 requestMethod=POST request='https://foo.example.com/bar/bingo/1' requestClientApplication='Foo-Bar/2018.1.7; Email:[user@example.com](mailto:user@example.com); Guid:test=' cs1= cs1Label=Foo Bar\r\n" | nc -v localhost 5010
```

4. Stop Logstash 6.x
5. Stop and Upgrade ES and Kibana to 7.x
6. Use Logstash 8.x with this PR to ingest data like steps 2 and 3
7. Observe that the ES cluster will ingest data correctly, with two indices:
  a. "arcsight-YYYY.MM.dd" for the data ingested in step 3
  b. "arcsight-8.4.0-YYYY.MM.dd" for data ingested in step 6
8. Observe that document type for the single document in "arcsight-YYYY.MM.dd" is "syslog"
9. Observe that document type for the single document in "arcsight-8.4.0-YYYY.MM.dd" is "_doc"


replaces #11504