### PR TITLE
Fix offline packcreation integration test due to LOCALE error

### DIFF
--- a/qa/integration/specs/cli/prepare_offline_pack_spec.rb
+++ b/qa/integration/specs/cli/prepare_offline_pack_spec.rb
@@ -88,6 +88,8 @@ describe "CLI > logstash-plugin prepare-offline-pack" do
                                 .delete_if do |line|
                                   line =~ /cext|├──|└──|logstash-integration|JAVA_OPT|fatal|^WARNING|^warning: ignoring JAVA_TOOL_OPTIONS|^OpenJDK 64-Bit Server VM warning|Option \w+ was deprecated|Using LS_JAVA_HOME defined java|Using system java: |\[\[: not found|^Warning: no jvm.options file found|^Processing jvm.options file at/
                                 end
+                                # TODO remove following line on infra issue 35116 is resolved
+                                .delete_if {|line| line =~ /bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)/}
 
       expect(unpacked.plugins.collect(&:name)).to include(*filters)
       expect(unpacked.plugins.size).to eq(filters.size)


### PR DESCRIPTION


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Integration test to check Logstash plugins pack resort to command line utilities to list plugins.
When the system they runnig on has some problems with LOCALE, then the every command line tool
report as first line the error:
"-bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8): No such file or directory"
this could be fixed with:
export LC_ALL=C
but the integration test can't force suth requirement, so it simply filter this line when analize the stdout of the "bin/logstash-plugin list".

## Why is it important/What is the impact to the user?

Fixes integration test on some Linux platforms.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] run the `ci/integration_tests.sh split 1` without any problem. Tested on Debian 11.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Logs
```
13:04:04     Failures:
13:04:04 
13:04:04       1) CLI > logstash-plugin prepare-offline-pack create a pack from a wildcard successfully create a pack
13:04:04          Failure/Error: expect(unpacked.plugins.collect(&:name)).to include(*filters)
13:04:04            expected ["logstash-filter-grok", "logstash-filter-geoip", "logstash-filter-urldecode", "logstash-filter-cidr"...sh-filter-aggregate", "logstash-filter-split", "logstash-filter-json", "logstash-filter-syslog_pri"] to include "bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)"
13:04:04          # /var/lib/jenkins/workspace/elastic+logstash+8.1+multijob-matrix-jdk-unix-integration-pq-2/LS_RUNTIME_JAVA/adoptopenjdk11/os/debian-11&&immutable/qa/integration/specs/cli/prepare_offline_pack_spec.rb:92:in `block in <main>'
13:04:04          # /var/lib/jenkins/workspace/elastic+logstash+8.1+multijob-matrix-jdk-unix-integration-pq-2/LS_RUNTIME_JAVA/adoptopenjdk11/os/debian-11&&immutable/build/qa/integration/vendor/jruby/2.5.0/gems/logstash-devutils-2.3.0-java/lib/logstash/devutils/rspec/spec_helper.rb:61:in `block in <main>'
13:04:04          # /var/lib/jenkins/workspace/elastic+logstash+8.1+multijob-matrix-jdk-unix-integration-pq-2/LS_RUNTIME_JAVA/adoptopenjdk11/os/debian-11&&immutable/qa/integration/rspec.rb:37:in `<main>'
13:04:04 
13:04:04     Finished in 20 minutes 0 seconds (files took 4.69 seconds to load)
13:04:04     51 examples, 1 failure
13:04:04 
13:04:04     Failed examples:
13:04:04 
13:04:04     rspec /var/lib/jenkins/workspace/elastic+logstash+8.1+multijob-matrix-jdk-unix-integration-pq-2/LS_RUNTIME_JAVA/adoptopenjdk11/os/debian-11&&immutable/qa/integration/specs/cli/prepare_offline_pack_spec.rb:77 # CLI > logstash-plugin prepare-offline-pack create a pack from a wildcard successfully create a pack
13:04:04 
13:04:04     Randomized with seed 41629
13:04:04 
```
