### PR TITLE
Print bundled jdk's version in launch scripts when `LS_JAVA_HOME` is provided

### DIFF
--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -101,7 +101,7 @@ setup_java() {
         JAVACMD="$LS_JAVA_HOME/bin/java"
         if [ -d "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}" -a -x "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}/bin/java" ]; then
           BUNDLED_JDK_VERSION=`cat JDK_VERSION`
-          echo "WARNING: Using LS_JAVA_HOME while Logstash distribution comes with a bundled JDK(${BUNDLED_JDK_VERSION})."
+          echo "WARNING: Logstash distribution comes with a bundled JDK(${BUNDLED_JDK_VERSION}), which is a known-working and tested java distribution. You are recommended to use the bundled JDK."
         fi
       else
         echo "Invalid LS_JAVA_HOME, doesn't contain bin/java executable."

--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -101,7 +101,7 @@ setup_java() {
         JAVACMD="$LS_JAVA_HOME/bin/java"
         if [ -d "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}" -a -x "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}/bin/java" ]; then
           BUNDLED_JDK_VERSION=`cat JDK_VERSION`
-          echo "WARNING: Logstash distribution comes with a bundled JDK(${BUNDLED_JDK_VERSION}), which is a known-working and tested java distribution. You are recommended to use the bundled JDK."
+          echo "WARNING: Logstash comes bundled with the recommended JDK(${BUNDLED_JDK_VERSION}), but is overridden by the version defined in LS_JAVA_HOME. Consider clearing LS_JAVA_HOME to use the bundled JDK."
         fi
       else
         echo "Invalid LS_JAVA_HOME, doesn't contain bin/java executable."

--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -100,7 +100,8 @@ setup_java() {
       if [ -x "$LS_JAVA_HOME/bin/java" ]; then
         JAVACMD="$LS_JAVA_HOME/bin/java"
         if [ -d "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}" -a -x "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}/bin/java" ]; then
-          echo "WARNING: Using LS_JAVA_HOME while Logstash distribution comes with a bundled JDK."
+          BUNDLED_JDK_VERSION=`cat JDK_VERSION`
+          echo "WARNING: Using LS_JAVA_HOME while Logstash distribution comes with a bundled JDK(${BUNDLED_JDK_VERSION})."
         fi
       else
         echo "Invalid LS_JAVA_HOME, doesn't contain bin/java executable."

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -25,7 +25,7 @@ if defined LS_JAVA_HOME (
   echo Using LS_JAVA_HOME defined java: %LS_JAVA_HOME%
   if exist "%LS_HOME%\jdk" (
     set /p BUNDLED_JDK_VERSION=<JDK_VERSION
-    echo "WARNING: Logstash distribution comes with a bundled JDK(%BUNDLED_JDK_VERSION%), which is a known-working and tested java distribution. You are recommended to use the bundled JDK."
+    echo "WARNING: Logstash comes bundled with the recommended JDK(%BUNDLED_JDK_VERSION%), but is overridden by the version defined in LS_JAVA_HOME. Consider clearing LS_JAVA_HOME to use the bundled JDK."
   )
 ) else (
   if exist "%LS_HOME%\jdk" (

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -25,7 +25,7 @@ if defined LS_JAVA_HOME (
   echo Using LS_JAVA_HOME defined java: %LS_JAVA_HOME%
   if exist "%LS_HOME%\jdk" (
     set /p BUNDLED_JDK_VERSION=<JDK_VERSION
-    echo WARNING: Using LS_JAVA_HOME while Logstash distribution comes with a bundled JDK(%BUNDLED_JDK_VERSION%).
+    echo "WARNING: Using LS_JAVA_HOME while Logstash distribution comes with a bundled JDK(%BUNDLED_JDK_VERSION%)."
   )
 ) else (
   if exist "%LS_HOME%\jdk" (

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -25,7 +25,7 @@ if defined LS_JAVA_HOME (
   echo Using LS_JAVA_HOME defined java: %LS_JAVA_HOME%
   if exist "%LS_HOME%\jdk" (
     set /p BUNDLED_JDK_VERSION=<JDK_VERSION
-    echo "WARNING: Using LS_JAVA_HOME while Logstash distribution comes with a bundled JDK(%BUNDLED_JDK_VERSION%)."
+    echo "WARNING: Logstash distribution comes with a bundled JDK(%BUNDLED_JDK_VERSION%), which is a known-working and tested java distribution. You are recommended to use the bundled JDK."
   )
 ) else (
   if exist "%LS_HOME%\jdk" (

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -24,7 +24,8 @@ if defined LS_JAVA_HOME (
   set JAVACMD=%LS_JAVA_HOME%\bin\java.exe
   echo Using LS_JAVA_HOME defined java: %LS_JAVA_HOME%
   if exist "%LS_HOME%\jdk" (
-    echo WARNING: Using LS_JAVA_HOME while Logstash distribution comes with a bundled JDK.
+    set /p BUNDLED_JDK_VERSION=<JDK_VERSION
+    echo WARNING: Using LS_JAVA_HOME while Logstash distribution comes with a bundled JDK(%BUNDLED_JDK_VERSION%).
   )
 ) else (
   if exist "%LS_HOME%\jdk" (

--- a/build.gradle
+++ b/build.gradle
@@ -872,7 +872,7 @@ tasks.register("extractBundledJdkVersion", ExtractBundledJdkVersion) {
 }
 
 clean {
-    String jdkVersionFilename = tasks.findByName("extractBundledJdkVersion").outputFilename.get()
+    String jdkVersionFilename = tasks.findByName("extractBundledJdkVersion").outputFilename
     delete "${projectDir}/${jdkVersionFilename}"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ import de.undercouch.gradle.tasks.download.Download
 import groovy.json.JsonSlurper
 import org.logstash.gradle.tooling.ListProjectDependencies
 import org.logstash.gradle.tooling.ExtractBundledJdkVersion
+import org.logstash.gradle.tooling.ToolingUtils
 
 allprojects {
   group = 'org.logstash'
@@ -795,7 +796,7 @@ tasks.register("downloadJdk", Download) {
     project.ext.set("jdkDownloadLocation", "${projectDir}/build/${jdkDetails.localPackageName}")
     project.ext.set("jdkDirectory", "${projectDir}/build/${jdkDetails.unpackedJdkName}")
 
-    String jdkFolderName = osName == "darwin" ? "jdk.app" : "jdk"
+    String jdkFolderName = ToolingUtils.jdkFolderName(osName)
     project.ext.set("jdkBundlingDirectory", "${projectDir}/${jdkFolderName}")
 
     src project.ext.jdkURL
@@ -814,7 +815,7 @@ tasks.register("downloadJdk", Download) {
 tasks.register("deleteLocalJdk", Delete) {
     // CLI project properties: -Pjdk_bundle_os=[windows|linux|darwin]
     String osName = selectOsType()
-    String jdkFolderName = osName == "darwin" ? "jdk.app" : "jdk"
+    String jdkFolderName = ToolingUtils.jdkFolderName(osName)
     String jdkBundlingDirectory = "${projectDir}/${jdkFolderName}"
     delete jdkBundlingDirectory
 }
@@ -857,7 +858,7 @@ tasks.register("decompressJdk") {
 }
 
 tasks.register("copyJdk", Copy) {
-    dependsOn = [decompressJdk, bootstrap]
+    dependsOn = [extractBundledJdkVersion, decompressJdk, bootstrap]
     description = "Download, unpack and copy the JDK"
     // CLI project properties: -Pjdk_bundle_os=[windows|linux|darwin] -Pjdk_arch=[arm64|x86_64]
     doLast {
@@ -867,6 +868,12 @@ tasks.register("copyJdk", Copy) {
 
 tasks.register("extractBundledJdkVersion", ExtractBundledJdkVersion) {
     dependsOn "decompressJdk"
+    osName = selectOsType()
+}
+
+clean {
+    String jdkVersionFilename = tasks.findByName("extractBundledJdkVersion").outputFilename.get()
+    delete "${projectDir}/${jdkVersionFilename}"
 }
 
 if (System.getenv('OSS') != 'true') {

--- a/build.gradle
+++ b/build.gradle
@@ -179,6 +179,36 @@ tasks.register("configureArtifactInfo") {
     }
 }
 
+class ExtractBundleJdkVersion extends DefaultTask {
+
+    @InputFile
+    File jdkReleaseFile = project.file("${project.projectDir}/jdk/release")
+
+    @OutputFile
+    File jdkVersionFile = project.file("${project.projectDir}/JDK_VERSION")
+
+    ExtractBundleJdkVersion() {
+        description = "Extracts IMPLEMENTOR_VERSION from JDK's release file"
+        group = "org.logstash.tooling"
+    }
+
+    @TaskAction
+    def extractVersionFile() {
+        println "DNADBG>> extract invoked for file ${jdkReleaseFile} to ${jdkVersionFile}"
+        def sw = new StringWriter()
+        jdkReleaseFile.filterLine(sw) { it =~ /IMPLEMENTOR_VERSION=.*/ }
+        if (!sw.toString().empty) {
+            def groups = (sw.toString() =~ /^IMPLEMENTOR_VERSION=\"(.*)\"$/)
+            if (!groups.hasGroup()) {
+                throw new GradleException("Malformed IMPLEMENTOR_VERSION property in ${jdkReleaseFile}")
+            }
+            jdkVersionFile.write(groups[0][1])
+            println "DNADBG>> matching <<${groups[0][1]}>>"
+        }
+    }
+}
+
+
 abstract class SignAliasDefinitionsTask extends DefaultTask {
 
     /**
@@ -862,6 +892,10 @@ tasks.register("copyJdk", Copy) {
     doLast {
         System.out.println "Download location is ${project.ext.jdkDownloadLocation}, Decompressing ${project.ext.jdkDirectory} to \"${project.ext.jdkBundlingDirectory}\""
     }
+}
+
+tasks.register("extractBundledJdkVersion", ExtractBundleJdkVersion) {
+    dependsOn "copyJdk"
 }
 
 if (System.getenv('OSS') != 'true') {

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ import org.yaml.snakeyaml.Yaml
 import de.undercouch.gradle.tasks.download.Download
 import groovy.json.JsonSlurper
 import org.logstash.gradle.tooling.ListProjectDependencies
+import org.logstash.gradle.tooling.ExtractBundledJdkVersion
 
 allprojects {
   group = 'org.logstash'
@@ -179,32 +180,32 @@ tasks.register("configureArtifactInfo") {
     }
 }
 
-class ExtractBundleJdkVersion extends DefaultTask {
-
-    @InputFile
-    File jdkReleaseFile = project.file("${project.projectDir}/jdk/release")
-
-    @OutputFile
-    File jdkVersionFile = project.file("${project.projectDir}/JDK_VERSION")
-
-    ExtractBundleJdkVersion() {
-        description = "Extracts IMPLEMENTOR_VERSION from JDK's release file"
-        group = "org.logstash.tooling"
-    }
-
-    @TaskAction
-    def extractVersionFile() {
-        def sw = new StringWriter()
-        jdkReleaseFile.filterLine(sw) { it =~ /IMPLEMENTOR_VERSION=.*/ }
-        if (!sw.toString().empty) {
-            def groups = (sw.toString() =~ /^IMPLEMENTOR_VERSION=\"(.*)\"$/)
-            if (!groups.hasGroup()) {
-                throw new GradleException("Malformed IMPLEMENTOR_VERSION property in ${jdkReleaseFile}")
-            }
-            jdkVersionFile.write(groups[0][1])
-        }
-    }
-}
+//class ExtractBundleJdkVersion extends DefaultTask {
+//
+//    @InputFile
+//    File jdkReleaseFile = project.file("${project.projectDir}/jdk/release")
+//
+//    @OutputFile
+//    File jdkVersionFile = project.file("${project.projectDir}/JDK_VERSION")
+//
+//    ExtractBundleJdkVersion() {
+//        description = "Extracts IMPLEMENTOR_VERSION from JDK's release file"
+//        group = "org.logstash.tooling"
+//    }
+//
+//    @TaskAction
+//    def extractVersionFile() {
+//        def sw = new StringWriter()
+//        jdkReleaseFile.filterLine(sw) { it =~ /IMPLEMENTOR_VERSION=.*/ }
+//        if (!sw.toString().empty) {
+//            def groups = (sw.toString() =~ /^IMPLEMENTOR_VERSION=\"(.*)\"$/)
+//            if (!groups.hasGroup()) {
+//                throw new GradleException("Malformed IMPLEMENTOR_VERSION property in ${jdkReleaseFile}")
+//            }
+//            jdkVersionFile.write(groups[0][1])
+//        }
+//    }
+//}
 
 
 abstract class SignAliasDefinitionsTask extends DefaultTask {
@@ -892,7 +893,7 @@ tasks.register("copyJdk", Copy) {
     }
 }
 
-tasks.register("extractBundledJdkVersion", ExtractBundleJdkVersion) {
+tasks.register("extractBundledJdkVersion", ExtractBundledJdkVersion) {
     dependsOn "decompressJdk"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -180,34 +180,6 @@ tasks.register("configureArtifactInfo") {
     }
 }
 
-//class ExtractBundleJdkVersion extends DefaultTask {
-//
-//    @InputFile
-//    File jdkReleaseFile = project.file("${project.projectDir}/jdk/release")
-//
-//    @OutputFile
-//    File jdkVersionFile = project.file("${project.projectDir}/JDK_VERSION")
-//
-//    ExtractBundleJdkVersion() {
-//        description = "Extracts IMPLEMENTOR_VERSION from JDK's release file"
-//        group = "org.logstash.tooling"
-//    }
-//
-//    @TaskAction
-//    def extractVersionFile() {
-//        def sw = new StringWriter()
-//        jdkReleaseFile.filterLine(sw) { it =~ /IMPLEMENTOR_VERSION=.*/ }
-//        if (!sw.toString().empty) {
-//            def groups = (sw.toString() =~ /^IMPLEMENTOR_VERSION=\"(.*)\"$/)
-//            if (!groups.hasGroup()) {
-//                throw new GradleException("Malformed IMPLEMENTOR_VERSION property in ${jdkReleaseFile}")
-//            }
-//            jdkVersionFile.write(groups[0][1])
-//        }
-//    }
-//}
-
-
 abstract class SignAliasDefinitionsTask extends DefaultTask {
 
     /**

--- a/build.gradle
+++ b/build.gradle
@@ -194,7 +194,6 @@ class ExtractBundleJdkVersion extends DefaultTask {
 
     @TaskAction
     def extractVersionFile() {
-        println "DNADBG>> extract invoked for file ${jdkReleaseFile} to ${jdkVersionFile}"
         def sw = new StringWriter()
         jdkReleaseFile.filterLine(sw) { it =~ /IMPLEMENTOR_VERSION=.*/ }
         if (!sw.toString().empty) {
@@ -203,7 +202,6 @@ class ExtractBundleJdkVersion extends DefaultTask {
                 throw new GradleException("Malformed IMPLEMENTOR_VERSION property in ${jdkReleaseFile}")
             }
             jdkVersionFile.write(groups[0][1])
-            println "DNADBG>> matching <<${groups[0][1]}>>"
         }
     }
 }
@@ -895,7 +893,7 @@ tasks.register("copyJdk", Copy) {
 }
 
 tasks.register("extractBundledJdkVersion", ExtractBundleJdkVersion) {
-    dependsOn "copyJdk"
+    dependsOn "decompressJdk"
 }
 
 if (System.getenv('OSS') != 'true') {

--- a/buildSrc/src/main/groovy/org/logstash/gradle/tooling/ExtractBundledJdkVersion.groovy
+++ b/buildSrc/src/main/groovy/org/logstash/gradle/tooling/ExtractBundledJdkVersion.groovy
@@ -4,7 +4,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
@@ -16,8 +16,8 @@ abstract class ExtractBundledJdkVersion extends DefaultTask {
     @Input
     abstract Property<String> getOutputFilename()
 
-    @InputFile
-    File jdkReleaseFile = project.file("${project.projectDir}/jdk/release")
+    @Input
+    String osName
 
     @OutputFile
     File getJdkVersionFile() {
@@ -28,6 +28,12 @@ abstract class ExtractBundledJdkVersion extends DefaultTask {
         description = "Extracts IMPLEMENTOR_VERSION from JDK's release file"
         group = "org.logstash.tooling"
         outputFilename.convention("JDK_VERSION")
+    }
+
+    @Internal
+    File getJdkReleaseFile() {
+        String jdkReleaseFilePath = ToolingUtils.jdkReleaseFilePath(osName)
+        return project.file("${project.projectDir}/${jdkReleaseFilePath}/release")
     }
 
     @TaskAction

--- a/buildSrc/src/main/groovy/org/logstash/gradle/tooling/ExtractBundledJdkVersion.groovy
+++ b/buildSrc/src/main/groovy/org/logstash/gradle/tooling/ExtractBundledJdkVersion.groovy
@@ -39,6 +39,10 @@ abstract class ExtractBundledJdkVersion extends DefaultTask {
             if (!groups.hasGroup()) {
                 throw new GradleException("Malformed IMPLEMENTOR_VERSION property in ${jdkReleaseFile}")
             }
+
+            if (groups.size() < 1 || groups[0].size() < 2) {
+                throw new GradleException("Malformed IMPLEMENTOR_VERSION property in ${jdkReleaseFile}")
+            }
             jdkVersionFile.write(groups[0][1])
         }
     }

--- a/buildSrc/src/main/groovy/org/logstash/gradle/tooling/ExtractBundledJdkVersion.groovy
+++ b/buildSrc/src/main/groovy/org/logstash/gradle/tooling/ExtractBundledJdkVersion.groovy
@@ -2,21 +2,32 @@ package org.logstash.gradle.tooling
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
 abstract class ExtractBundledJdkVersion extends DefaultTask {
 
+    /**
+     * Defines the name of the output filename containing the JDK version.
+     * */
+    @Input
+    abstract Property<String> getOutputFilename()
+
     @InputFile
     File jdkReleaseFile = project.file("${project.projectDir}/jdk/release")
 
     @OutputFile
-    File jdkVersionFile = project.file("${project.projectDir}/JDK_VERSION")
+    File getJdkVersionFile() {
+        project.file("${project.projectDir}/${outputFilename.get()}")
+    }
 
     ExtractBundledJdkVersion() {
         description = "Extracts IMPLEMENTOR_VERSION from JDK's release file"
         group = "org.logstash.tooling"
+        outputFilename.convention("JDK_VERSION")
     }
 
     @TaskAction

--- a/buildSrc/src/main/groovy/org/logstash/gradle/tooling/ExtractBundledJdkVersion.groovy
+++ b/buildSrc/src/main/groovy/org/logstash/gradle/tooling/ExtractBundledJdkVersion.groovy
@@ -2,7 +2,6 @@ package org.logstash.gradle.tooling
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
-import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
@@ -14,20 +13,19 @@ abstract class ExtractBundledJdkVersion extends DefaultTask {
      * Defines the name of the output filename containing the JDK version.
      * */
     @Input
-    abstract Property<String> getOutputFilename()
+    String outputFilename = "JDK_VERSION"
 
     @Input
     String osName
 
     @OutputFile
     File getJdkVersionFile() {
-        project.file("${project.projectDir}/${outputFilename.get()}")
+        project.file("${project.projectDir}/${outputFilename}")
     }
 
     ExtractBundledJdkVersion() {
         description = "Extracts IMPLEMENTOR_VERSION from JDK's release file"
         group = "org.logstash.tooling"
-        outputFilename.convention("JDK_VERSION")
     }
 
     @Internal

--- a/buildSrc/src/main/groovy/org/logstash/gradle/tooling/ExtractBundledJdkVersion.groovy
+++ b/buildSrc/src/main/groovy/org/logstash/gradle/tooling/ExtractBundledJdkVersion.groovy
@@ -1,0 +1,34 @@
+package org.logstash.gradle.tooling
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+abstract class ExtractBundledJdkVersion extends DefaultTask {
+
+    @InputFile
+    File jdkReleaseFile = project.file("${project.projectDir}/jdk/release")
+
+    @OutputFile
+    File jdkVersionFile = project.file("${project.projectDir}/JDK_VERSION")
+
+    ExtractBundledJdkVersion() {
+        description = "Extracts IMPLEMENTOR_VERSION from JDK's release file"
+        group = "org.logstash.tooling"
+    }
+
+    @TaskAction
+    def extractVersionFile() {
+        def sw = new StringWriter()
+        jdkReleaseFile.filterLine(sw) { it =~ /IMPLEMENTOR_VERSION=.*/ }
+        if (!sw.toString().empty) {
+            def groups = (sw.toString() =~ /^IMPLEMENTOR_VERSION=\"(.*)\"$/)
+            if (!groups.hasGroup()) {
+                throw new GradleException("Malformed IMPLEMENTOR_VERSION property in ${jdkReleaseFile}")
+            }
+            jdkVersionFile.write(groups[0][1])
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/org/logstash/gradle/tooling/ToolingUtils.groovy
+++ b/buildSrc/src/main/groovy/org/logstash/gradle/tooling/ToolingUtils.groovy
@@ -7,10 +7,5 @@ class ToolingUtils {
 
     static String jdkReleaseFilePath(String osName) {
         jdkFolderName(osName) + (osName == "darwin" ? "/Contents/Home/" : "")
-//        if (osName == "darwin") {
-//            jdkFolderName(osName) + "/Contents/Home/"
-//        } else {
-//            jdkFolderName(osName)
-//        }
     }
 }

--- a/buildSrc/src/main/groovy/org/logstash/gradle/tooling/ToolingUtils.groovy
+++ b/buildSrc/src/main/groovy/org/logstash/gradle/tooling/ToolingUtils.groovy
@@ -1,0 +1,16 @@
+package org.logstash.gradle.tooling
+
+class ToolingUtils {
+    static String jdkFolderName(String osName) {
+        return osName == "darwin" ? "jdk.app" : "jdk"
+    }
+
+    static String jdkReleaseFilePath(String osName) {
+        jdkFolderName(osName) + (osName == "darwin" ? "/Contents/Home/" : "")
+//        if (osName == "darwin") {
+//            jdkFolderName(osName) + "/Contents/Home/"
+//        } else {
+//            jdkFolderName(osName)
+//        }
+    }
+}

--- a/buildSrc/src/test/groovy/org/logstash/gradle/tooling/ExtractBundledJdkVersionTest.groovy
+++ b/buildSrc/src/test/groovy/org/logstash/gradle/tooling/ExtractBundledJdkVersionTest.groovy
@@ -16,6 +16,7 @@ class ExtractBundledJdkVersionTest {
     void setUp() {
         Project project = ProjectBuilder.builder().build()
         task = project.task('extract', type: ExtractBundledJdkVersion)
+        task.osName = "linux"
 
         task.jdkReleaseFile.parentFile.mkdirs()
     }

--- a/buildSrc/src/test/groovy/org/logstash/gradle/tooling/ExtractBundledJdkVersionTest.groovy
+++ b/buildSrc/src/test/groovy/org/logstash/gradle/tooling/ExtractBundledJdkVersionTest.groovy
@@ -1,0 +1,51 @@
+package org.logstash.gradle.tooling
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.gradle.api.*
+import org.gradle.testfixtures.ProjectBuilder
+
+
+class ExtractBundledJdkVersionTest {
+
+    ExtractBundledJdkVersion task
+
+    @BeforeEach
+    void setUp() {
+        Project project = ProjectBuilder.builder().build()
+        task = project.task('extract', type: ExtractBundledJdkVersion)
+
+        task.jdkReleaseFile.parentFile.mkdirs()
+    }
+
+    @Test
+    void "decode correctly"() {
+        task.jdkReleaseFile << """
+            |IMPLEMENTOR="Eclipse Adoptium"
+            |IMPLEMENTOR_VERSION="Temurin-11.0.14.1+1"
+        """.stripMargin().stripIndent()
+
+        task.extractVersionFile()
+
+        assert task.jdkVersionFile.text == "Temurin-11.0.14.1+1"
+    }
+
+    // There is some interoperability problem with JUnit5 Assertions.assertThrows and Groovy's string method names,
+    // the catching of the exception generates an invalid method name error if it's in string form
+    @DisplayName("decode throws error with malformed jdk/release content")
+    @Test
+    void decodeThrowsErrorWithMalformedJdkOrReleaseContent() {
+        task.jdkReleaseFile << """
+            |IMPLEMENTOR="Eclipse Adoptium"
+            |IMPLEMENTOR_VERSION=
+        """.stripMargin().stripIndent()
+
+        def thrown = Assertions.assertThrows(GradleException.class, {
+            task.extractVersionFile()
+        })
+        assert thrown.message.startsWith("Malformed IMPLEMENTOR_VERSION property in")
+    }
+
+}

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -104,6 +104,7 @@ namespace "artifact" do
   end
 
   def files(excl=excludes)
+    puts "DNADBG>> files excl is: #{excl}"
     Rake::FileList.new(*package_files).exclude(*excl)
   end
 
@@ -161,7 +162,7 @@ namespace "artifact" do
 
   desc "Build a not JDK bundled tar.gz of default logstash plugins with all dependencies"
   task "no_bundle_jdk_tar" => ["prepare", "generate_build_metadata"] do
-    build_tar('ELASTIC-LICENSE')
+    build_tar('ELASTIC-LICENSE', nil, "JDK_VERSION")
   end
 
   desc "Build all (jdk bundled and not) OSS tar.gz and zip of default logstash plugins with all dependencies"

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -104,7 +104,6 @@ namespace "artifact" do
   end
 
   def files(excl=excludes)
-    puts "DNADBG>> files excl is: #{excl}"
     Rake::FileList.new(*package_files).exclude(*excl)
   end
 

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -30,6 +30,7 @@ namespace "artifact" do
     [
       "NOTICE.TXT",
       "CONTRIBUTORS",
+      "JDK_VERSION",
       "bin/**/*",
       "config/**/*",
       "data",


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Extracts the bundled JDK's version into a one-line text file which could easily read and printed from bash/batch scripts.
Updates Logstash's bash/batch launcher scripts to print the bundled JDK version when warn the user about his override.

## Why is it important/What is the impact to the user?

Give information about the JDK version that is bundled with distribution, so that he can immediately compare which environment's provided one.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] run under Bash and on Windows cmd
- [x]  verify `rake artifact:archives` generate packages containing the jdk version file
- [x] check the MacOS tar.gz pack, contains the jdk version file and setting `LS_JAVA_HOME` report the bundled version.
- [x] verifies packages with JDK contanis the "JDK version file" while the other doesn't.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
- checkout this branch
- build archives packs with: 
```
rake artifact:archives
```
- set an `LS_JAVA_HOME` to locally installed JDK
- unpack the archive for your OS and run 
```
bin/logstash -e "input{ stdin { } } output { stdout { codec => rubydebug } }"
```
- verify packages with JDK contains the JDK_VERSION file, and the one without doesn't.
```
tar -tvf build/logstash-8.2.0-SNAPSHOT-linux-x86_64.tar.gz | grep JDK*
```
- verify `deb`/`rpm` distribution packages with JDK contains the JDK_VERSION file, and the one without doesn't.
```
dpkg -c ./build/logstash-8.2.0-SNAPSHOT-amd64.deb | grep JDK*
rpm -qlp ./build/logstash-8.2.0-SNAPSHOT-amd64.deb | grep JDK*
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Fixes #13205

## Use cases

A user has customized `LS_JAVA_HOME` to be used from Logstash. When Logstash start prints a warning message about this, showing the version it would otherwise use.


