### PR TITLE
Ensure pipelines.yaml is loaded safely

### DIFF
--- a/logstash-core/lib/logstash/config/source/multi_local.rb
+++ b/logstash-core/lib/logstash/config/source/multi_local.rb
@@ -93,7 +93,7 @@ module LogStash module Config module Source
 
     def read_pipelines_from_yaml(yaml_location)
       logger.debug("Reading pipeline configurations from YAML", :location => pipelines_yaml_location)
-      ::YAML.load(IO.read(yaml_location))
+      ::YAML.safe_load(File.read(yaml_location))
     rescue => e
       raise ConfigurationError.new("Failed to read pipelines yaml file. Location: #{yaml_location}, Exception: #{e.inspect}")
     end

--- a/logstash-core/lib/logstash/config/source/multi_local.rb
+++ b/logstash-core/lib/logstash/config/source/multi_local.rb
@@ -93,7 +93,7 @@ module LogStash module Config module Source
 
     def read_pipelines_from_yaml(yaml_location)
       logger.debug("Reading pipeline configurations from YAML", :location => pipelines_yaml_location)
-      ::YAML.safe_load(File.read(yaml_location))
+      ::YAML.safe_load(::File.read(yaml_location))
     rescue => e
       raise ConfigurationError.new("Failed to read pipelines yaml file. Location: #{yaml_location}, Exception: #{e.inspect}")
     end


### PR DESCRIPTION
YAML.load should be avoided in favor of safe_load. Also IO.read accepts pipes which is an unnecessary capability, so it can be replaced by File.read:

```
irb(main):003:0> IO.read("| date")
=> "Thu Mar 10 15:18:11 WET 2022\n"
irb(main):004:0> File.read("| date")
Traceback (most recent call last):
       10: from /Users/joaoduarte/tools/jruby-9.3.3.0/bin/irb:23:in `<main>'
        9: from org/jruby/RubyKernel.java:1052:in `load'
        8: from /Users/joaoduarte/tools/jruby-9.3.3.0/lib/ruby/gems/shared/gems/irb-1.0.0/exe/irb:11:in `<main>'
        7: from org/jruby/RubyKernel.java:1237:in `catch'
        6: from org/jruby/RubyKernel.java:1237:in `catch'
        5: from org/jruby/RubyKernel.java:1507:in `loop'
        4: from org/jruby/RubyKernel.java:1091:in `eval'
        3: from (irb):4:in `evaluate'
        2: from org/jruby/RubyIO.java:3986:in `read'
        1: from org/jruby/RubyIO.java:1227:in `sysopen'
Errno::ENOENT (No such file or directory - | date)
```