### PR TITLE
Fix load custom java plugin

### DIFF
--- a/logstash-core/lib/logstash/plugins/registry.rb
+++ b/logstash-core/lib/logstash/plugins/registry.rb
@@ -152,7 +152,9 @@ module LogStash module Plugins
 
       GemRegistry.logstash_plugins.each do |plugin_context|
         if plugin_context.spec.metadata.key?('java_plugin')
+          # This jar_files is always be empty if user installed custom java plugin from rubygems.org
           jar_files = plugin_context.spec.files.select {|f| f =~ /.*\.jar/}
+          # if jar_files is empty, logstash will find *.jar files from ${LS_HOME}/vendor/bundle/jruby/2.5.0/gems/${CUSTOM_JAVA_PLUGIN_NAME}/vendor/jar-dependencies
           if jar_files.length == 0
             gem_home = Pathname.new(::File.join(LogStash::Environment::BUNDLE_DIR, "jruby", "2.5.0"))
             plugin_jar_dependencies = "#{gem_home}/gems/#{plugin_context.spec.name}-#{plugin_context.spec.version}/vendor/jar-dependencies"

--- a/logstash-core/lib/logstash/plugins/registry.rb
+++ b/logstash-core/lib/logstash/plugins/registry.rb
@@ -153,6 +153,12 @@ module LogStash module Plugins
       GemRegistry.logstash_plugins.each do |plugin_context|
         if plugin_context.spec.metadata.key?('java_plugin')
           jar_files = plugin_context.spec.files.select {|f| f =~ /.*\.jar/}
+          if jar_files.length == 0
+            gem_home = Pathname.new(::File.join(LogStash::Environment::BUNDLE_DIR, "jruby", "2.5.0"))
+            plugin_jar_dependencies = "#{gem_home}/gems/#{plugin_context.spec.name}-#{plugin_context.spec.version}/vendor/jar-dependencies"
+            jar_files = Dir.glob("#{plugin_jar_dependencies}/**/*.jar")
+          end
+
           expected_jar_name = plugin_context.spec.name + "-" + plugin_context.spec.version.to_s + ".jar"
           if (jar_files.length != 1 || !jar_files[0].end_with?(expected_jar_name))
             raise LoadError, "Java plugin '#{plugin_context.spec.name}' does not contain a single jar file with the plugin's name and version"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Solved the problem when user install custom java plugin from `rubygems.org` using `bin/logsatsh-plugin install ${CUSTOM_JAVA_PLUGIN_NAME}` and run Logstash.


## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->


check `jar_files` size and if empty(when user get custom java plugin from rubygems.org like `bin/logstash-install ${CUSTOM_JAVA_PLUGIN_NAME}`, it allways be empty), then load jar file names from `${LS_HOME}/vendor/bundle/jruby/2.5.0/gems/${CUSTOM_JAVA_PLUGIN_NAME}/vendor/jar-dependencies`.

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

When User Created Java Custom Plugin and publish them to `rubygems.org`
and install & run, It always failed because logstash expected `jar_files` from `plugin_context.spec.files.select {|f| f =~ /.*\.jar/}` is not empty if metadata's `java_plugin is true.

```
# -*- encoding: utf-8 -*-
# stub: logstash-filter-my_java_filter_example 0.0.8 ruby libvendor/jar-dependencies

Gem::Specification.new do |s|
  s.name = "logstash-filter-my_java_filter_example".freeze
  s.version = "0.0.8"

  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
  s.metadata = { "java_plugin" => "true", "logstash_group" => "filter", "logstash_plugin" => "true" } if s.respond_to? :metadata=
  s.require_paths = ["lib".freeze, "vendor/jar-dependencies".freeze]
  s.authors = ["Elasticsearch".freeze]
  s.date = "2022-03-13"
  s.description = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program".freeze
  s.email = ["info@elastic.co".freeze]
  s.homepage = "http://www.elastic.co/guide/en/logstash/current/index.html".freeze
  s.licenses = ["Apache-2.0".freeze]
  s.rubygems_version = "3.1.6".freeze
  s.summary = "Example Java filter implementation".freeze

  s.installed_by_version = "3.1.6" if s.respond_to? :installed_by_version

  if s.respond_to? :specification_version then
    s.specification_version = 4
  end

  if s.respond_to? :add_runtime_dependency then
    s.add_runtime_dependency(%q<logstash-core-plugin-api>.freeze, [">= 1.60", "<= 2.99"])
    s.add_runtime_dependency(%q<jar-dependencies>.freeze, [">= 0"])
    s.add_development_dependency(%q<logstash-devutils>.freeze, [">= 0"])
  else
    s.add_dependency(%q<logstash-core-plugin-api>.freeze, [">= 1.60", "<= 2.99"])
    s.add_dependency(%q<jar-dependencies>.freeze, [">= 0"])
    s.add_dependency(%q<logstash-devutils>.freeze, [">= 0"])
  end
end

```


this is gemspec file from `${LS_HOME}/vendor/bundle/jruby/2.5.0/specifications`
there is no `s.files`.


```
# AUTOGENERATED BY THE GRADLE SCRIPT. EDITS WILL BE OVERWRITTEN.
Gem::Specification.new do |s|
  s.name            = 'logstash-filter-my_java_filter_example'
  s.version         = ::File.read('VERSION').split('\n').first
  s.licenses        = ['Apache-2.0']
  s.summary         = 'Example Java filter implementation'
  s.description     = 'This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program'
  s.authors         = ['Elasticsearch']
  s.email           = ['info@elastic.co']
  s.homepage        = 'http://www.elastic.co/guide/en/logstash/current/index.html'
  s.require_paths = ['lib', 'vendor/jar-dependencies']

  s.files = Dir["lib/**/*","*.gemspec","*.md","CONTRIBUTORS","Gemfile","LICENSE","NOTICE.TXT", "vendor/jar-dependencies/**/*.jar", "vendor/jar-dependencies/**/*.rb", "VERSION", "docs/**/*"]

  # Special flag to let us know this is actually a logstash plugin
  s.metadata = { 'logstash_plugin' => 'true', 'logstash_group' => 'filter', 'java_plugin' => 'true'}

  # Gem dependencies
  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
  s.add_runtime_dependency 'jar-dependencies'
  s.add_development_dependency 'logstash-devutils'
end
```

and this is original gemspec file.
you can find s.files from this gemspec file.




## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
~- [ ] I have added tests that prove my fix is effective or that my feature works~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- Test on Local

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
# main branch test
git clone https://github.com/elastic/logstash.git

cd logstash

./gradlew clean assembleTarDistribution

./bin/logstash-plugin install logstash-filter-my_java_filter_example


# it will fail with "(LoadError) Java plugin 'logstash-filter-my_java_filter_example' does not contain a single jar file with the plugin's name and version"
./bin/logstash -e "input { generator { message => 'Hello world!' count => 1 } } filter { my_java_filter_example {} } output { stdout { codec => rubydebug } }" 

# init
cd ../
rm -rf logstash


# fix branch test. it will be success.
git clone https://github.com/twosom/logstash.git && cd logstash && git checkout fix-load-custom-java-plugin


./gradlew clean assembleTarDistribution

./bin/logstash-plugin install logstash-filter-my_java_filter_example


./bin/logstash -e "input { generator { message => 'Hello world!' count => 1 } } filter { my_java_filter_example {} } output { stdout { codec => rubydebug } }" 
```



## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->
