### PR TITLE
Deps: unpin jruby-openssl in logstash-core

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "mustermann", '~> 1.0.3'
   gem.add_runtime_dependency "sinatra", '~> 2.1.0' # pinned until GH-13777 is resolved
   gem.add_runtime_dependency 'puma', '~> 5'
-  gem.add_runtime_dependency "jruby-openssl", "= 0.12.1"
+  gem.add_runtime_dependency "jruby-openssl", "~> 0.11"
 
   gem.add_runtime_dependency "treetop", "~> 1" #(MIT license)
 


### PR DESCRIPTION
This reverts commit 887d9427d3ba7887760db1777f66c48333a1132c from #13866

Logstash 8.1.0 shipped with `~> 0.11.0` we should keep the dependency unlocked, if possible.

Keeping the version requirement non-strict allows to upgrade the jruby-openssl dependency with the 8.1.x bump gem lifecycle and also allows for manual plugin upgrades plugins with plugins that require specific versions of the library (such as TCP input).

---

The problem #13866 is trying to work-around should be resolved with https://github.com/elastic/logstash/pull/13823