### PR TITLE
Updates license checker after inclusion of libs `et-orbi`, `fugit` and `raabro`.

### DIFF
--- a/tools/dependencies-report/src/main/resources/licenseMapping.csv
+++ b/tools/dependencies-report/src/main/resources/licenseMapping.csv
@@ -45,6 +45,7 @@ dependency,dependencyUrl,licenseOverride,copyright,sourceURL
 "elasticsearch-transport:",https://github.com/elastic/elasticsearch-ruby,Apache-2.0
 "elasticsearch:",https://github.com/elastic/elasticsearch-ruby,Apache-2.0
 "equalizer:",https://github.com/dkubb/equalizer,MIT
+"et-orbi:",https://github.com/floraison/et-orbi,MIT
 "faraday:",https://github.com/lostisland/faraday,MIT
 "faraday-em_http",https://github.com/lostisland/faraday,MIT
 "faraday-em_synchrony",https://github.com/lostisland/faraday,MIT
@@ -58,6 +59,7 @@ dependency,dependencyUrl,licenseOverride,copyright,sourceURL
 "faraday-retry",https://github.com/lostisland/faraday,MIT
 "ffi:",https://github.com/ffi/ffi,BSD-3-CLAUSE
 "filesize:",https://github.com/dominikh,MIT
+"fugit:",https://github.com/floraison/fugit,MIT
 "gelfd2:",https://github.com/ptqa/gelfd2,Apache-2.0
 "gems:",https://github.com/rubygems/gems,MIT
 "gene_pool:",https://github.com/bpardee/gene_pool,MIT
@@ -131,6 +133,7 @@ dependency,dependencyUrl,licenseOverride,copyright,sourceURL
 "pry:",http://pryrepl.org,MIT
 "public_suffix:",https://simonecarletti.com/code/publicsuffix-ruby,MIT
 "puma:",http://puma.io,BSD-3-Clause
+"raabro",https://github.com/floraison/raabro,MIT
 "racc:",https://github.com/ruby/rake,Ruby
 "rack-protection:",http://github.com/rkh/rack-protection,MIT
 "rack:",http://rack.github.io/,MIT

--- a/tools/dependencies-report/src/main/resources/notices/et-orbi-NOTICE.txt
+++ b/tools/dependencies-report/src/main/resources/notices/et-orbi-NOTICE.txt
@@ -1,0 +1,24 @@
+source: https://github.com/floraison/et-orbi/blob/v1.2.7/LICENSE.txt
+
+Copyright (c) 2017-2022, John Mettraux, jmettraux+flor@gmail.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+Made in Japan

--- a/tools/dependencies-report/src/main/resources/notices/fugit-NOTICE.txt
+++ b/tools/dependencies-report/src/main/resources/notices/fugit-NOTICE.txt
@@ -1,0 +1,24 @@
+source: https://github.com/floraison/fugit/blob/v1.5.2/LICENSE.txt
+
+Copyright (c) 2017-2021, John Mettraux, jmettraux+flor@gmail.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+Made in Japan

--- a/tools/dependencies-report/src/main/resources/notices/raabro-NOTICE.txt
+++ b/tools/dependencies-report/src/main/resources/notices/raabro-NOTICE.txt
@@ -1,0 +1,24 @@
+source: https://github.com/floraison/raabro/blob/v1.4.0/LICENSE.txt
+
+Copyright (c) 2015-2020, John Mettraux, jmettraux@gmail.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+Made in Japan.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip] 

## What does this PR do?
These dependencies are Rufus transitive deps, included by JDBC integration plugin v5.2.4
