### PR TITLE
[Test] Adds explicit unexpected JVM messages test, and simplifies regex in offline_spec

### DIFF
--- a/lib/bootstrap/rspec.rb
+++ b/lib/bootstrap/rspec.rb
@@ -30,6 +30,8 @@ end
 require "rspec/core"
 require "rspec"
 require 'ci/reporter/rake/rspec_loader'
+require "logstash/patches/polyglot"
+
 
 RSpec.clear_examples # if multiple rspec runs occur in a single process, the RSpec "world" state needs to be reset.
 

--- a/lib/bootstrap/rspec.rb
+++ b/lib/bootstrap/rspec.rb
@@ -30,8 +30,6 @@ end
 require "rspec/core"
 require "rspec"
 require 'ci/reporter/rake/rspec_loader'
-require "logstash/patches/polyglot"
-
 
 RSpec.clear_examples # if multiple rspec runs occur in a single process, the RSpec "world" state needs to be reset.
 

--- a/qa/integration/specs/cli/prepare_offline_pack_spec.rb
+++ b/qa/integration/specs/cli/prepare_offline_pack_spec.rb
@@ -86,7 +86,7 @@ describe "CLI > logstash-plugin prepare-offline-pack" do
       filters = @logstash_plugin.list(plugins_to_pack.first)
                                 .stderr_and_stdout.split("\n")
                                 .delete_if do |line|
-                                  line =~ /cext|├──|└──|logstash-integration|JAVA_OPT|fatal|^WARNING|^warning: ignoring JAVA_TOOL_OPTIONS|^OpenJDK 64-Bit Server VM warning|Option \w+ was deprecated|Using LS_JAVA_HOME defined java|Using system java: |\[\[: not found|^Warning: no jvm.options file found|^Processing jvm.options file at/
+                                  line !~ /^logstash-(codec|filter|input|output)-\w*$/
                                 end
 
       expect(unpacked.plugins.collect(&:name)).to include(*filters)

--- a/qa/integration/specs/command_line_spec.rb
+++ b/qa/integration/specs/command_line_spec.rb
@@ -36,4 +36,12 @@ describe "CLI >" do
     expect(execute.stderr_and_stdout).to include('--pipeline.id ID')
   end
 
+  it "starts without unexected warnings" do
+    execute = @logstash.run
+    lines = execute.stderr_and_stdout.split("\n")
+    expect(lines.shift).to match(/^(Using system java)|(Using bundled JDK)|(Using LS_JAVA_HOME defined java):/)
+    next_line = lines.shift
+    next_line = lines.shift if next_line['OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated']
+    expect(next_line).to match(/^Sending Logstash logs to/)
+  end
 end

--- a/qa/integration/specs/command_line_spec.rb
+++ b/qa/integration/specs/command_line_spec.rb
@@ -42,6 +42,7 @@ describe "CLI >" do
     expect(lines.shift).to match(/^(Using system java)|(Using bundled JDK)|(Using LS_JAVA_HOME defined java):/)
     next_line = lines.shift
     next_line = lines.shift if next_line['OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated']
+    next_line = lines.shift if next_line['warning: ignoring JAVA_TOOL_OPTIONS']
     expect(next_line).to match(/^Sending Logstash logs to/)
   end
 end

--- a/qa/integration/specs/command_line_spec.rb
+++ b/qa/integration/specs/command_line_spec.rb
@@ -40,11 +40,7 @@ describe "CLI >" do
     execute = @logstash.run
     lines = execute.stderr_and_stdout.split("\n")
     expect(lines.shift).to match(/^(Using system java)|(Using bundled JDK)|(Using LS_JAVA_HOME defined java):/)
-    next_line = lines.shift
-    loop do
-      break unless next_line.match(/OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated|warning: ignoring JAVA_TOOL_OPTIONS/)
-      next_line = lines.shift
-    end
-    expect(next_line).to match(/^Sending Logstash logs to/)
+    while (up_line = lines.shift).match(/OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated|warning: ignoring JAVA_TOOL_OPTIONS/) do end
+    expect(up_line).to match(/^Sending Logstash logs to/)
   end
 end

--- a/qa/integration/specs/command_line_spec.rb
+++ b/qa/integration/specs/command_line_spec.rb
@@ -41,8 +41,10 @@ describe "CLI >" do
     lines = execute.stderr_and_stdout.split("\n")
     expect(lines.shift).to match(/^(Using system java)|(Using bundled JDK)|(Using LS_JAVA_HOME defined java):/)
     next_line = lines.shift
-    next_line = lines.shift if next_line['OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated']
-    next_line = lines.shift if next_line['warning: ignoring JAVA_TOOL_OPTIONS']
+    loop do
+      break unless next_line.match(/OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated|warning: ignoring JAVA_TOOL_OPTIONS/)
+      next_line = lines.shift
+    end
     expect(next_line).to match(/^Sending Logstash logs to/)
   end
 end


### PR DESCRIPTION
The `prepare_offline_spec.rb` had essentially become a "canary" for discovering new JVM warnings and error messages, being the only test that would fail when they would appear due to the way the test was constructed.

This commit simplifies this regex to only test for what is expected in that test, and introduces an explicit test for discovering new JVM warnings and error messages.

## Release notes
[rn:skip]

