### PR TITLE
[Backport #13881 7.17]Quotes java executable path in case it contains spaces

### DIFF
--- a/bin/benchmark.bat
+++ b/bin/benchmark.bat
@@ -4,7 +4,7 @@ setlocal enabledelayedexpansion
 cd /d "%~dp0.."
 for /f %%i in ('cd') do set RESULT=%%i
 
-%JAVACMD% -cp "!!RESULT!!\tools\benchmark-cli\build\libs\benchmark-cli.jar;*" ^
+"%JAVACMD%" -cp "!!RESULT!!\tools\benchmark-cli\build\libs\benchmark-cli.jar;*" ^
   org.logstash.benchmark.cli.Main %*
 
 endlocal

--- a/bin/ingest-convert.bat
+++ b/bin/ingest-convert.bat
@@ -4,7 +4,7 @@ setlocal enabledelayedexpansion
 cd /d "%~dp0\.."
 for /f %%i in ('cd') do set RESULT=%%i
 
-%JAVACMD% -cp "!!RESULT!!\tools\ingest-converter\build\libs\ingest-converter.jar;*" ^
+"%JAVACMD%" -cp "!!RESULT!!\tools\ingest-converter\build\libs\ingest-converter.jar;*" ^
   org.logstash.ingest.Pipeline %*
 
 endlocal

--- a/bin/logstash.bat
+++ b/bin/logstash.bat
@@ -38,7 +38,7 @@ for %%i in ("%LS_HOME%\logstash-core\lib\jars\*.jar") do (
 )
 
 @setlocal
-for /F "usebackq delims=" %%a in (`CALL %JAVACMD% -cp "!CLASSPATH!" "org.logstash.launchers.JvmOptionsParser" "!LS_HOME!" "!LS_JVM_OPTS!" ^|^| echo jvm_options_parser_failed`) do set LS_JAVA_OPTS=%%a
+for /F "usebackq delims=" %%a in (`CALL "%JAVACMD%" -cp "!CLASSPATH!" "org.logstash.launchers.JvmOptionsParser" "!LS_HOME!" "!LS_JVM_OPTS!" ^|^| echo jvm_options_parser_failed`) do set LS_JAVA_OPTS=%%a
 @endlocal & set "MAYBE_JVM_OPTIONS_PARSER_FAILED=%LS_JAVA_OPTS%" & set LS_JAVA_OPTS=%LS_JAVA_OPTS%
 
 if "%MAYBE_JVM_OPTIONS_PARSER_FAILED%" == "jvm_options_parser_failed" (
@@ -47,7 +47,7 @@ if "%MAYBE_JVM_OPTIONS_PARSER_FAILED%" == "jvm_options_parser_failed" (
 )
 set JAVA_OPTS=%LS_JAVA_OPTS%
 
-%JAVACMD% %JAVA_OPTS% -cp "%CLASSPATH%" org.logstash.Logstash %*
+"%JAVACMD%" %JAVA_OPTS% -cp "%CLASSPATH%" org.logstash.Logstash %*
 
 goto :end
 

--- a/bin/pqcheck.bat
+++ b/bin/pqcheck.bat
@@ -16,7 +16,7 @@ for %%i in ("%LS_HOME%\logstash-core\lib\jars\*.jar") do (
 	call :concat "%%i"
 )
 
-%JAVACMD% %JAVA_OPTS% -cp "%CLASSPATH%" org.logstash.ackedqueue.PqCheck %*
+"%JAVACMD%" %JAVA_OPTS% -cp "%CLASSPATH%" org.logstash.ackedqueue.PqCheck %*
 
 :concat
 IF not defined CLASSPATH (

--- a/bin/pqrepair.bat
+++ b/bin/pqrepair.bat
@@ -16,7 +16,7 @@ for %%i in ("%LS_HOME%\logstash-core\lib\jars\*.jar") do (
 	call :concat "%%i"
 )
 
-%JAVACMD% %JAVA_OPTS% -cp "%CLASSPATH%" org.logstash.ackedqueue.PqRepair %*
+"%JAVACMD%" %JAVA_OPTS% -cp "%CLASSPATH%" org.logstash.ackedqueue.PqRepair %*
 
 :concat
 IF not defined CLASSPATH (

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -43,7 +43,7 @@ if defined LS_JAVA_HOME (
   )
 )
 
-if not exist %JAVACMD% (
+if not exist "%JAVACMD%" (
   echo could not find java; set JAVA_HOME or ensure java is in PATH 1>&2
   exit /b 1
 )


### PR DESCRIPTION
Clean backport of #13881 to `7.17`


----

Updates all Windows batch scripts used as CLI tools to quotes the %JAVACMD% to avoid path problems when the path contains spaces.

(cherry picked from commit a8bd90c22de451514940cdddcd60ae4f19d80405)
