### PR TITLE
Enable content write permission for pr backporter workflow

### DIFF
--- a/.github/workflows/pr_backporter.yml
+++ b/.github/workflows/pr_backporter.yml
@@ -5,7 +5,7 @@ on:
 
 permissions:
   pull-requests: write
-  contents: read
+  contents: write
 
 jobs:
   pr_commented:
@@ -21,7 +21,7 @@ jobs:
           organization: elastic
           team: logstash
           GITHUB_TOKEN: ${{ secrets.READ_ORG_SECRET_JSVD }}
-      - name: Is user a core team member?
+      - name: Is user not a core team member?
         if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
         run: exit 1
       - name: checkout repo content


### PR DESCRIPTION
PR backports need to create branches remotely which serve as target branches for the backport pull requests.
Safety is ensured by checking that only Logstash team members can trigger the workflow.
