### PR TITLE
Hide Shutdown Watcher stall message when PQ draining

### DIFF
--- a/logstash-core/lib/logstash/worker_loop_thread.rb
+++ b/logstash-core/lib/logstash/worker_loop_thread.rb
@@ -1,0 +1,30 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require "thread"
+
+module LogStash
+  class WorkerLoopThread < Thread
+    attr_reader :worker_loop
+
+    def initialize(worker_loop)
+      super
+      @worker_loop = worker_loop
+    end
+
+  end
+end

--- a/logstash-core/src/main/java/org/logstash/execution/ShutdownWatcherExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/ShutdownWatcherExt.java
@@ -154,8 +154,7 @@ public final class ShutdownWatcherExt extends RubyBasicObject {
             while (true) {
                 TimeUnit.SECONDS.sleep(cyclePeriod);
                 attemptsCount.incrementAndGet();
-                if (stopped(context).isTrue() ||
-                    pipeline.callMethod(context, "finished_execution?").isTrue()) {
+                if (stopped(context).isTrue() || pipeline.callMethod(context, "finished_execution?").isTrue()) {
                     break;
                 }
                 reports.add(pipelineReportSnapshot(context));
@@ -163,8 +162,10 @@ public final class ShutdownWatcherExt extends RubyBasicObject {
                     reports.remove(0);
                 }
                 if (cycleNumber == reportEvery - 1) {
-                    LOGGER.warn(reports.get(reports.size() - 1).callMethod(context, "to_s")
-                        .asJavaString());
+                    if (!pipeline.callMethod(context, "worker_threads_draining?").isTrue()) {
+                        LOGGER.warn(reports.get(reports.size() - 1).callMethod(context, "to_s").asJavaString());
+                    }
+
                     if (shutdownStalled(context).isTrue()) {
                         if (stalledCount == 0) {
                             LOGGER.error(
@@ -172,8 +173,7 @@ public final class ShutdownWatcherExt extends RubyBasicObject {
                             );
                         }
                         ++stalledCount;
-                        if (isUnsafeShutdown(context, null).isTrue() &&
-                            abortThreshold == stalledCount) {
+                        if (isUnsafeShutdown(context, null).isTrue() && abortThreshold == stalledCount) {
                             LOGGER.fatal("Forcefully quitting Logstash ...");
                             forceExit(context);
                         }

--- a/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
+++ b/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
@@ -106,7 +106,7 @@ public final class WorkerLoop implements Runnable {
         }
     }
 
-    private boolean isDraining() {
+    public boolean isDraining() {
         return drainQueue && !readClient.isEmpty();
     }
 }


### PR DESCRIPTION
Fixed: #9544

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Hide stall info when PQ is draining

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

When the PQ `queue.drain` set to `true`, hide warning message from ShutdownWatcher that reporting stall status

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
Draining could be a long process. Currently, the output message is full of stalling info which is not useful

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
