### PR TITLE
Fix/flaky error tests in missed retries to central management

### DIFF
--- a/x-pack/lib/config_management/elasticsearch_source.rb
+++ b/x-pack/lib/config_management/elasticsearch_source.rb
@@ -54,7 +54,7 @@ module LogStash
 
       # decide using system indices api (7.10+) or legacy api (< 7.10) base on elasticsearch server version
       def get_pipeline_fetcher
-        retry_handler = ::LogStash::Helpers::LoggableTry.new(logger, 'fetch pipelines from Central Management')
+        retry_handler = ::LogStash::Helpers::LoggableTry.new(logger, 'fetch ES version from Central Management')
         response = retry_handler.try(10.times, ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError) {
           client.get("/")
         }
@@ -210,7 +210,10 @@ module LogStash
       SYSTEM_INDICES_API_PATH = "_logstash/pipeline"
 
       def fetch_config(pipeline_ids, client)
-        response = client.get("#{SYSTEM_INDICES_API_PATH}/")
+        retry_handler = ::LogStash::Helpers::LoggableTry.new(logger, 'fetch pipelines from Central Management')
+        response = retry_handler.try(10.times, ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError) {
+          client.get("#{SYSTEM_INDICES_API_PATH}/")
+        }
 
         if response["error"]
           raise ElasticsearchSource::RemoteConfigError, "Cannot find find configuration for pipeline_id: #{pipeline_ids}, server returned status: `#{response["status"]}`, message: `#{response["error"]}`"
@@ -259,7 +262,10 @@ module LogStash
 
       def fetch_config(pipeline_ids, client)
         request_body_string = LogStash::Json.dump({ "docs" => pipeline_ids.collect { |pipeline_id| { "_id" => pipeline_id } } })
-        response = client.post("#{PIPELINE_INDEX}/_mget", {}, request_body_string)
+        retry_handler = ::LogStash::Helpers::LoggableTry.new(logger, 'fetch pipelines from Central Management')
+        response = retry_handler.try(10.times, ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError) {
+          client.post("#{PIPELINE_INDEX}/_mget", {}, request_body_string)
+        }
 
         if response["error"]
           raise ElasticsearchSource::RemoteConfigError, "Cannot find find configuration for pipeline_id: #{pipeline_ids}, server returned status: `#{response["status"]}`, message: `#{response["error"]}`"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
This PR is the forward port of #13925. The errors are due to missed retries when accessing the ES indices to poll pipeline configurations.
While the failure is not deterministic, nor it's clear why sometimes it happens and sometimes not. The point is that the first `GET /` removes the offending ES node, so the following `GET`s shouldn't find the offending node, but sometimes they hit.
My suspect is that there is some bad synchronization in accessing the pool of http endpoints in Manticore, but wasn't able to spot it.
This PR, however, cover the access to the client with the expected retry policy.

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
It's a follow up of PR #13689, and enforces the retries to access  ES nodes while retrieve the pipelines configuartion without crashing LS if some ES node is not available.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] run locally with `./gradlew clean --rerun-tasks :logstash-xpack:rubyIntegrationTest`

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Execute a couple of runs of
```
./gradlew clean --rerun-tasks :logstash-xpack:rubyIntegrationTest
```
 on the `main` and check that they eventually fail with an error similar to:
```
Failures:

      1) Read configuration from elasticsearch security is enabled fetches the configuration from elasticsearch
         Failure/Error: expect(full_log).not_to match(/Could not fetch all the sources/)
         
           expected "Using bundled JDK: /home/andrea/workspace/logstash_andsel/jdk\n\nSending Logstash logs to /home/andr...running_pipelines=>[:\".monitoring-logstash\", :\"super-generator\"], :non_running_pipelines=>[]}\n" not to match /Could not fetch all the sources/
           Diff:
           @@ -1,83 +1,165 @@
           -/Could not fetch all the sources/
           +Using bundled JDK: /home/andrea/workspace/logstash_andsel/jdk
           +
           +Sending Logstash logs to /home/andrea/workspace/logstash_andsel/logs which is now configured via log4j2.properties
           +
           +[2022-03-28T13:57:06,395][INFO ][logstash.runner          ] Log4j configuration path used is: /tmp/studtmp-d81aeec5136512f0fa9d947699234fcc29887613d8605377143764d943d5/log4j2.properties
           +
           +[2022-03-28T13:57:06,402][WARN ][logstash.runner          ] The use of JAVA_HOME has been deprecated. Logstash 8.0 and later ignores JAVA_HOME and uses the bundled JDK. Running Logstash with the bundled JDK is recommended. The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability. If you have compelling reasons for using your own JDK (organizational-specific compliance requirements, for example), you can configure LS_JAVA_HOME to use that version instead.
           +
           +[2022-03-28T13:57:06,403][INFO ][logstash.runner          ] Starting Logstash {"logstash.version"=>"8.2.0", "jruby.version"=>"jruby 9.2.20.1 (2.5.8) 2021-11-30 2a2962fbd1 OpenJDK 64-Bit Server VM 11.0.14.1+1 on 11.0.14.1+1 +indy +jit [linux-x86_64]"}
           +
           +[2022-03-28T13:57:06,404][INFO ][logstash.runner          ] JVM bootstrap flags: [-Xms1g, -Xmx1g, -XX:+UseConcMarkSweepGC, -XX:CMSInitiatingOccupancyFraction=75, -XX:+UseCMSInitiatingOccupancyOnly, -Djava.awt.headless=true, -Dfile.encoding=UTF-8, -Djruby.compile.invokedynamic=true, -Djruby.jit.threshold=0, -XX:+HeapDumpOnOutOfMemoryError, -Djava.security.egd=file:/dev/urandom, -Dlog4j2.isThreadContextMapInheritable=true, -Djruby.regexp.interruptible=true, --add-opens=java.base/java.security=ALL-UNNAMED, --add-opens=java.base/java.io=ALL-UNNAMED, --add-opens=java.base/java.nio.channels=ALL-UNNAMED, --add-opens=java.base/sun.nio.ch=ALL-UNNAMED, --add-opens=java.management/sun.management=ALL-UNNAMED]
           +
           +[2022-03-28T13:57:06,425][INFO ][logstash.settings        ] Creating directory {:setting=>"path.queue", :path=>"/tmp/studtmp-38786532c11e01b0ec98402b6a55c9cd04f932636adaf1a49361f0ec2106/queue"}
           +
           +[2022-03-28T13:57:06,432][INFO ][logstash.settings        ] Creating directory {:setting=>"path.dead_letter_queue", :path=>"/tmp/studtmp-38786532c11e01b0ec98402b6a55c9cd04f932636adaf1a49361f0ec2106/dead_letter_queue"}
           +
           +[2022-03-28T13:57:06,455][INFO ][logstash.configmanagement.bootstrapcheck] Using Elasticsearch as config store {:pipeline_id=>["super-generator"], :poll_interval=>"TimeValue{duration=1, timeUnit=SECONDS}ns"}
           +
           +[2022-03-28T13:57:07,314][INFO ][logstash.configmanagement.elasticsearchsource] Configuration Management License OK
           +
           +[2022-03-28T13:57:07,501][INFO ][logstash.agent           ] No persistent UUID file found. Generating new UUID {:uuid=>"287590f5-ef54-4609-93e6-493f481254f1", :path=>"/tmp/studtmp-38786532c11e01b0ec98402b6a55c9cd04f932636adaf1a49361f0ec2106/uuid"}
           +
           +[2022-03-28T13:57:08,694][INFO ][logstash.monitoring.internalpipelinesource] Monitoring License OK
           +
           +[2022-03-28T13:57:08,695][INFO ][logstash.monitoring.internalpipelinesource] Validated license for monitoring. Enabling monitoring pipeline.
           +
           +[2022-03-28T13:57:08,816][INFO ][logstash.configmanagement.elasticsearchsource] Elasticsearch pool URLs updated {:changes=>{:removed=>[], :added=>[http://elastic:xxxxxx@localhost:9200/, http://elastic:xxxxxx@localhost:19200/]}}
           +
           +[2022-03-28T13:57:08,835][WARN ][logstash.configmanagement.elasticsearchsource] Restored connection to ES instance {:url=>"http://elastic:xxxxxx@localhost:9200/"}
           +
           +[2022-03-28T13:57:08,837][INFO ][logstash.agent           ] Successfully started Logstash API endpoint {:port=>9600, :ssl_enabled=>false}
           +
           +[2022-03-28T13:57:08,842][INFO ][logstash.configmanagement.elasticsearchsource] Elasticsearch version determined (8.2.0-SNAPSHOT) {:es_version=>8}
           +
           +[2022-03-28T13:57:08,842][WARN ][logstash.configmanagement.elasticsearchsource] Detected a 6.x and above cluster: the `type` event field won't be used to determine the document _type {:es_version=>8}
           +
           +[2022-03-28T13:57:08,850][INFO ][logstash.configmanagement.elasticsearchsource] Failed to perform request {:message=>"Connect to localhost:19200 [localhost/127.0.0.1] failed: Connection refused (Connection refused)", :exception=>Manticore::SocketException, :cause=>org.apache.http.conn.HttpHostConnectException: Connect to localhost:19200 [localhost/127.0.0.1] failed: Connection refused (Connection refused)}
           +
           +[2022-03-28T13:57:08,852][WARN ][logstash.configmanagement.elasticsearchsource] Attempted to resurrect connection to dead ES instance, but got an error {:url=>"http://elastic:xxxxxx@localhost:19200/", :exception=>LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError, :message=>"Elasticsearch Unreachable: [http://localhost:19200/][Manticore::SocketException] Connect to localhost:19200 [localhost/127.0.0.1] failed: Connection refused (Connection refused)"}
           +
           +[2022-03-28T13:57:08,875][INFO ][logstash.configmanagement.elasticsearchsource] Failed to perform request {:message=>"Connect to localhost:19200 [localhost/127.0.0.1] failed: Connection refused (Connection refused)", :exception=>Manticore::SocketException, :cause=>org.apache.http.conn.HttpHostConnectException: Connect to localhost:19200 [localhost/127.0.0.1] failed: Connection refused (Connection refused)}
           +
           +[2022-03-28T13:57:08,881][WARN ][logstash.configmanagement.elasticsearchsource] Marking url as dead. Last error: [LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError] Elasticsearch Unreachable: [http://localhost:19200/_logstash/pipeline/][Manticore::SocketException] Connect to localhost:19200 [localhost/127.0.0.1] failed: Connection refused (Connection refused) {:url=>http://elastic:xxxxxx@localhost:19200/, :error_message=>"Elasticsearch Unreachable: [http://localhost:19200/_logstash/pipeline/][Manticore::SocketException] Connect to localhost:19200 [localhost/127.0.0.1] failed: Connection refused (Connection refused)", :error_class=>"LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError"}
           +
           +[2022-03-28T13:57:08,885][ERROR][logstash.config.sourceloader] Could not fetch all the sources {:exception=>LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError, :message=>"Elasticsearch Unreachable: [http://localhost:19200/_logstash/pipeline/][Manticore::SocketException] Connect to localhost:19200 [localhost/127.0.0.1] failed: Connection refused (Connection refused)", :backtrace=>["/home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.5.0/gems/logstash-output-elasticsearch-11.4.1-java/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb:76:in `perform_request'", "/home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.5.0/gems/logstash-output-elasticsearch-11.4.1-java/lib/logstash/outputs/elasticsearch/http_client/pool.rb:324:in `perform_request_to_url'", "/home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.5.0/gems/logstash-output-elasticsearch-11.4.1-java/lib/logstash/outputs/elasticsearch/http_client/pool.rb:311:in `block in perform_request'", "/home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.5.0/gems/logstash-output-elasticsearch-11.4.1-java/lib/logstash/outputs/elasticsearch/http_client/pool.rb:398:in `with_connection'", "/home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.5.0/gems/logstash-output-elasticsearch-11.4.1-java/lib/logstash/outputs/elasticsearch/http_client/pool.rb:310:in `perform_request'", "/home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.5.0/gems/logstash-output-elasticsearch-11.4.1-java/lib/logstash/outputs/elasticsearch/http_client/pool.rb:318:in `block in Pool'", "/home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.5.0/gems/logstash-output-elasticsearch-11.4.1-java/lib/logstash/outputs/elasticsearch/http_client.rb:204:in `get'", "/home/andrea/workspace/logstash_andsel/x-pack/lib/config_management/elasticsearch_source.rb:213:in `fetch_config'", "/home/andrea/workspace/logstash_andsel/x-pack/lib/config_management/elasticsearch_source.rb:87:in `pipeline_configs'", "/home/andrea/workspace/logstash_andsel/logstash-core/lib/logstash/config/source_loader.rb:76:in `block in fetch'", "org/jruby/RubyArray.java:2584:in `collect'", "/home/andrea/workspace/logstash_andsel/logstash-core/lib/logstash/config/source_loader.rb:75:in `fetch'", "/home/andrea/workspace/logstash_andsel/logstash-core/lib/logstash/agent.rb:178:in `converge_state_and_update'", "/home/andrea/workspace/logstash_andsel/logstash-core/lib/logstash/agent.rb:116:in `execute'", "/home/andrea/workspace/logstash_andsel/logstash-core/lib/logstash/runner.rb:403:in `block in execute'", "/home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.5.0/gems/stud-0.0.23/lib/stud/task.rb:24:in `block in initialize'"]}
           +
           +[2022-03-28T13:57:10,476][INFO ][org.reflections.Reflections] Reflections took 77 ms to scan 1 urls, producing 120 keys and 419 values 

...

         # ./qa/integration/management/read_configuration_spec.rb:42:in `start_services'
         # ./qa/integration/management/read_configuration_spec.rb:52:in `block in <main>'
         # /home/andrea/workspace/logstash_andsel/lib/bootstrap/rspec.rb:36:in `<main>'           
           
```
then check that with this branch it never happens.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #13689,  #13925

