### PR TITLE
Improve safety of stats retrieval from queue

### DIFF
--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -35,7 +35,7 @@ module LogStash
             type = p_stats[:queue] && p_stats[:queue][:type].value
             pipeline = service.agent.get_pipeline(pipeline_id)
             next if pipeline.nil? || pipeline.system? || type != 'persisted'
-            total_queued_events += p_stats[:queue][:events].value
+            total_queued_events += p_stats.dig(:queue, :events)&.value || 0
           end
 
           {:events_count => total_queued_events}


### PR DESCRIPTION
This commit guards against reading a value from a stat that may not be
populated before an attempt is made to retrieve its value, potentially causing
a `undefined method `[]' for nil:NilClass`.


## Release notes
[rn:skip]


## What does this PR do?
This has resulted in some flaky tests lately, which should be fixed with this change
