### PR TITLE
[Backport #13941 to 8.1]Fix/flaky error tests in missed retries to central management

### DIFF
--- a/x-pack/lib/config_management/elasticsearch_source.rb
+++ b/x-pack/lib/config_management/elasticsearch_source.rb
@@ -53,7 +53,10 @@ module LogStash
 
       # decide using system indices api (7.10+) or legacy api (< 7.10) base on elasticsearch server version
       def get_pipeline_fetcher
-        response = client.get("/")
+        retry_handler = ::LogStash::Helpers::LoggableTry.new(logger, 'fetch ES version from Central Management')
+        response = retry_handler.try(10.times, ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError) {
+          client.get("/")
+        }
 
         if response["error"]
           raise RemoteConfigError, "Cannot find elasticsearch version, server returned status: `#{response["status"]}`, message: `#{response["error"]}`"
@@ -206,7 +209,10 @@ module LogStash
       SYSTEM_INDICES_API_PATH = "_logstash/pipeline"
 
       def fetch_config(pipeline_ids, client)
-        response = client.get("#{SYSTEM_INDICES_API_PATH}/")
+        retry_handler = ::LogStash::Helpers::LoggableTry.new(logger, 'fetch pipelines from Central Management')
+        response = retry_handler.try(10.times, ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError) {
+          client.get("#{SYSTEM_INDICES_API_PATH}/")
+        }
 
         if response["error"]
           raise ElasticsearchSource::RemoteConfigError, "Cannot find find configuration for pipeline_id: #{pipeline_ids}, server returned status: `#{response["status"]}`, message: `#{response["error"]}`"
@@ -255,7 +261,10 @@ module LogStash
 
       def fetch_config(pipeline_ids, client)
         request_body_string = LogStash::Json.dump({ "docs" => pipeline_ids.collect { |pipeline_id| { "_id" => pipeline_id } } })
-        response = client.post("#{PIPELINE_INDEX}/_mget", {}, request_body_string)
+        retry_handler = ::LogStash::Helpers::LoggableTry.new(logger, 'fetch pipelines from Central Management')
+        response = retry_handler.try(10.times, ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError) {
+          client.post("#{PIPELINE_INDEX}/_mget", {}, request_body_string)
+        }
 
         if response["error"]
           raise ElasticsearchSource::RemoteConfigError, "Cannot find find configuration for pipeline_id: #{pipeline_ids}, server returned status: `#{response["status"]}`, message: `#{response["error"]}`"


### PR DESCRIPTION
Backport of #13941 to branch `8.1`

----

This commit is a forward port of #13925.
Covered all calls to ES with retryable when accessing the central management to query the pipelines configurations.

(cherry picked from commit 916ddf2c8d72f9d6ba9302eb852fda8640ed6cfd)
