### PR TITLE
Remove conservative flag from version bump workflow

### DIFF
--- a/.github/workflows/version_bumps.yml
+++ b/.github/workflows/version_bumps.yml
@@ -49,7 +49,7 @@ jobs:
       - run: git config --global user.email "43502315+logstashmachine@users.noreply.github.com"
       - run: git config --global user.name "logstashmachine"
       - run: ./gradlew clean installDefaultGems
-      - run: ./vendor/jruby/bin/jruby -S bundle update --all --${{ github.event.inputs.bump }} --conservative
+      - run: ./vendor/jruby/bin/jruby -S bundle update --all --${{ github.event.inputs.bump }}
       - run: mv Gemfile.lock Gemfile.jruby-2.5.lock.release
       - run: echo "T=$(date +%s)" >> $GITHUB_ENV
       - run: echo "BRANCH=update_lock_${T}" >> $GITHUB_ENV


### PR DESCRIPTION
the conservative flag is preventing dependencies (both from Elastic and 3rd party) to be updated.
This causes unnecessary lag behind new dependency releases.
