### PR TITLE
[doc] Remove references to sysv and upstart scripts when running logstash as a service.

### DIFF
--- a/docs/static/running-logstash.asciidoc
+++ b/docs/static/running-logstash.asciidoc
@@ -1,10 +1,10 @@
 [[running-logstash]]
 === Running Logstash as a Service on Debian or RPM
 
-Logstash is not started automatically after installation. How to start and stop Logstash depends on whether your system
-uses systemd, upstart, or SysV.
+Logstash is not started automatically after installation. Starting and stopping Logstash depends on the
+init system of the underlying Operating System, which as of today are all systemd.
 
-Here are some common operating systems and versions, and the corresponding
+Here are some common operating systems and versions with corresponding
 startup styles they use.  This list is intended to be informative, not exhaustive.
 
 |=======================================================================

--- a/docs/static/running-logstash.asciidoc
+++ b/docs/static/running-logstash.asciidoc
@@ -10,11 +10,8 @@ startup styles they use.  This list is intended to be informative, not exhaustiv
 |=======================================================================
 | Distribution | Service System |
 | Ubuntu 16.04 and newer | <<running-logstash-systemd,systemd>> |
-| Ubuntu 12.04 through 15.10 | <<running-logstash-upstart,upstart>> |
 | Debian 8 "jessie" and newer | <<running-logstash-systemd,systemd>> |
-| Debian 7 "wheezy" and older | <<running-logstash-sysv,sysv>> |
 | CentOS (and RHEL) 7 and newer | <<running-logstash-systemd,systemd>> |
-| CentOS (and RHEL) 6 | <<running-logstash-upstart,upstart>> |
 |=======================================================================
 
 [[running-logstash-systemd]]
@@ -28,26 +25,3 @@ Distributions like Debian Jessie, Ubuntu 15.10+, and many of the SUSE derivative
 sudo systemctl start logstash.service
 -------------------------------------------
 
-[[running-logstash-upstart]]
-==== Running Logstash by Using Upstart
-
-For systems that use upstart, you can start Logstash with:
-
-[source,sh]
--------------------------------------------
-sudo initctl start logstash
--------------------------------------------
-
-The auto-generated configuration file for upstart systems is `/etc/init/logstash.conf`.
-
-[[running-logstash-sysv]]
-==== Running Logstash by Using SysV
-
-For systems that use SysV, you can start Logstash with:
-
-[source,sh]
--------------------------------------------
-sudo /etc/init.d/logstash start
--------------------------------------------
-
-The auto-generated configuration file for SysV systems is `/etc/init.d/logstash`.

--- a/docs/static/running-logstash.asciidoc
+++ b/docs/static/running-logstash.asciidoc
@@ -2,10 +2,10 @@
 === Running Logstash as a Service on Debian or RPM
 
 Logstash is not started automatically after installation. Starting and stopping Logstash depends on the
-init system of the underlying Operating System, which as of today are all systemd.
+init system of the underlying operating system, which is now systemd.
 
-Here are some common operating systems and versions with corresponding
-startup styles they use.  This list is intended to be informative, not exhaustive.
+As systemd is now the de-facto init system, here are some common operating systems and versions that
+use it.  This list is intended to be informative, not exhaustive.
 
 |=======================================================================
 | Distribution | Service System |

--- a/docs/static/shutdown.asciidoc
+++ b/docs/static/shutdown.asciidoc
@@ -10,20 +10,6 @@ If you're running {ls} as a service, use one of the following commands to stop i
 systemctl stop logstash
 ----
 
-* On upstart, use: 
-+
-[source,shell]
-----
-initctl stop logstash
-----
-
-* On sysv, use: 
-+
-[source,shell]
-----
-/etc/init.d/logstash stop
-----
-
 If you're running {ls} directly in the console on a POSIX system, you can stop 
 it by sending SIGTERM to the {ls} process. For example:
 


### PR DESCRIPTION
## What does this PR do?

Updates the documentation to remove sys-v init and upstart references when running Logstash as a service, given that upstart and sys-v are no longer supported.


**PREVIEWS:**
* https://logstash_13953.docs-preview.app.elstc.co/guide/en/logstash/master/running-logstash.html
* https://logstash_13953.docs-preview.app.elstc.co/guide/en/logstash/master/shutdown.html

## Why is it important/What is the impact to the user?

Provides up to date information to the user.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Relates #13922

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->


