### PR TITLE
 Deps: unpin jruby-openssl in logstash-core (for real)

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "mustermann", '~> 1.0.3'
   gem.add_runtime_dependency "sinatra", '~> 2.1.0' # pinned until GH-13777 is resolved
   gem.add_runtime_dependency 'puma', '~> 5'
-  gem.add_runtime_dependency "jruby-openssl", "~> 0.11.0"
+  gem.add_runtime_dependency "jruby-openssl", "~> 0.11"
   gem.add_runtime_dependency "chronic_duration", "~> 0.10"
 
   gem.add_runtime_dependency "treetop", "~> 1" #(MIT license)


### PR DESCRIPTION
**DE-JA-VU of https://github.com/elastic/logstash/pull/13903 as I messed up the unpinning** (~> 0.11.0 does not allow to install 0.12.x)

JOSSL pinning was introduced at https://github.com/elastic/logstash/pull/13806 ... the cause being https://github.com/elastic/logstash/pull/13785

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

Unlocks the jruby-openssl dependency in order to allow manual updates of plugins that require the gem.
Also, JRuby is tested/shipped with latest JOSSL, given the security nature of the library it makes sense to keep updating.

## Why is it important/What is the impact to the user?

User should be able to update plugins that require newer jruby-openssl version (such as the TCP input).

