### PR TITLE
Make update strict in version bump github workflow

### DIFF
--- a/.github/workflows/version_bumps.yml
+++ b/.github/workflows/version_bumps.yml
@@ -49,7 +49,7 @@ jobs:
       - run: git config --global user.email "43502315+logstashmachine@users.noreply.github.com"
       - run: git config --global user.name "logstashmachine"
       - run: ./gradlew clean installDefaultGems
-      - run: ./vendor/jruby/bin/jruby -S bundle update --all --${{ github.event.inputs.bump }}
+      - run: ./vendor/jruby/bin/jruby -S bundle update --all --${{ github.event.inputs.bump }} --strict
       - run: mv Gemfile.lock Gemfile.jruby-2.5.lock.release
       - run: echo "T=$(date +%s)" >> $GITHUB_ENV
       - run: echo "BRANCH=update_lock_${T}" >> $GITHUB_ENV


### PR DESCRIPTION
Without --strict, Bundler may decide to ignore the major/minor/patch flag, as we can see in https://github.com/elastic/logstash/pull/13960/files#diff-127e1a3a65d315d86dbe640d9578a969da44e5226e5d9bf2de251b075c1d8b7aR481

This is expected behavior according to [Bundler docs](https://bundler.io/man/bundle-update.1.html#PATCH-LEVEL-OPTIONS):

> Note that versions outside the stated patch level could still be resolved to if necessary to find a suitable dependency graph.

and:

> Combining the --strict option with any of the patch level options will remove any versions beyond the scope of the patch level option, to ensure that no gem is updated that far.

