### PR TITLE
Convert Exception during converge to a failed action

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -391,7 +391,7 @@ class LogStash::Agent
           end
         rescue SystemExit, Exception => e
           logger.error("Failed to execute action", :action => action, :exception => e.class.name, :message => e.message, :backtrace => e.backtrace)
-          converge_result.add(action, e)
+          converge_result.add(action, LogStash::ConvergeResult::FailedAction.from_exception(e))
         end
       end
     end.each(&:join)


### PR DESCRIPTION
Certain errors during pipeline converge will emit an IllegalStateException - for example attempting
to reference an environment variable that does not exist. Attempting to add a java exception to the
converge result would result in an uncaught exception in a pipeline thread leading to an unclean
shutdown.

This had the effect of, prior to this commit, Logstash behaviour varying depending on the class of
error that caused a pipeline not to start - an invalid pipeline configuration would still enable
logstash to start other pipelines in a multiple pipeline configuration, or automatic reloading
enabling changes to the configuration to allow the pipeline to start(in multi- and single pipeline
configurations).
However, a missing environment variable would cause Logstash to crash hard no matter what.

This was discovered when updating to jruby-9.3.3.0, when new clean up code joining existing
threads to perform a graceful shutdown was stuck indefinitely, due to the webserver shutdown
code not being called, due to the unclean shutdown.


## Release notes

<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Improves consistency of behavior when handling error conditions in pipeline creation when multiple pipelines and pipeline reloading is used.

## What does this PR do?

This PR creates a failure action from any exceptions caught during converge to standardize the behaviour regardless of failure mode.

## Why is it important/What is the impact to the user?

- Standardizes behaviour when a pipeline cannot start
- Removes obfuscating log entries

## Checklist


- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist


## How to test this PR locally

Test single and multiple pipeline startup when

- Pipeline configuration is incorrect
- Environment variables referenced in configuration are missing
- Files references in configuration are missing
- Other pipeline failure modes 

## Related issues

Relates #13968

