### PR TITLE
A structural change for aliased plugin declarations to support alias doc headers.

### DIFF
--- a/lib/pluginmanager/util.rb
+++ b/lib/pluginmanager/util.rb
@@ -38,8 +38,8 @@ module LogStash::PluginManager
     yaml = YAML.safe_load(yaml_body) || {}
     result = {}
     yaml.each do |type, alias_defs|
-      alias_defs.each do |alias_name, aliased|
-        result["logstash-#{type}-#{alias_name}"] = "logstash-#{type}-#{aliased}"
+      alias_defs.each do |alias_def|
+        result["logstash-#{type}-#{alias_def["alias_name"]}"] = "logstash-#{type}-#{alias_def["maps_to"]}"
       end
     end
     result

--- a/lib/pluginmanager/util.rb
+++ b/lib/pluginmanager/util.rb
@@ -39,7 +39,7 @@ module LogStash::PluginManager
     result = {}
     yaml.each do |type, alias_defs|
       alias_defs.each do |alias_def|
-        result["logstash-#{type}-#{alias_def["alias_name"]}"] = "logstash-#{type}-#{alias_def["maps_to"]}"
+        result["logstash-#{type}-#{alias_def["alias"]}"] = "logstash-#{type}-#{alias_def["from"]}"
       end
     end
     result

--- a/logstash-core/src/main/java/org/logstash/plugins/AliasRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/AliasRegistry.java
@@ -97,9 +97,9 @@ public class AliasRegistry {
         }
 
         @SuppressWarnings("unchecked")
-        private Map<String, List<AliasPlugin>> decodeYaml() throws IOException {
+        private Map<PluginType, List<AliasPlugin>> decodeYaml() throws IOException {
             ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-            return mapper.readValue(yamlContents, new TypeReference<Map<String, List<AliasPlugin>>>() {});
+            return mapper.readValue(yamlContents, new TypeReference<Map<PluginType, List<AliasPlugin>>>() {});
         }
 
         private String computeHashFromContent() {
@@ -141,7 +141,7 @@ public class AliasRegistry {
             }
 
             // decode yaml to Map<PluginType, List<AliasPlugin>> structure
-            final Map<String, List<AliasPlugin>> aliasedDescriptions;
+            final Map<PluginType, List<AliasPlugin>> aliasedDescriptions;
             try {
                 aliasedDescriptions = aliasYml.decodeYaml();
             } catch (IOException ioex) {
@@ -159,15 +159,15 @@ public class AliasRegistry {
         }
 
         private Map<PluginCoordinate, String> extractDefinitions(PluginType pluginType,
-                                                                 Map<String, List<AliasPlugin>> aliasesYamlDefinitions) {
-            final List<AliasPlugin> aliasedPlugins = aliasesYamlDefinitions.get(pluginType.name().toLowerCase());
+                                                                 Map<PluginType, List<AliasPlugin>> aliasesYamlDefinitions) {
+            final List<AliasPlugin> aliasedPlugins = aliasesYamlDefinitions.get(pluginType);
             if (Objects.isNull(aliasedPlugins)) {
                 return Collections.emptyMap();
             }
 
             Map<PluginCoordinate, String> defaultDefinitions = new HashMap<>();
             aliasedPlugins.forEach(aliasPlugin -> {
-                defaultDefinitions.put(new PluginCoordinate(pluginType, aliasPlugin.getAliasName()), aliasPlugin.getMapsTo());
+                defaultDefinitions.put(new PluginCoordinate(pluginType, aliasPlugin.getAliasName()), aliasPlugin.getFrom());
             });
             return defaultDefinitions;
         }

--- a/logstash-core/src/main/java/org/logstash/plugins/AliasRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/AliasRegistry.java
@@ -1,11 +1,13 @@
 package org.logstash.plugins;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.logstash.plugins.PluginLookup.PluginType;
+import org.logstash.plugins.aliases.AliasPlugin;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -95,9 +97,9 @@ public class AliasRegistry {
         }
 
         @SuppressWarnings("unchecked")
-        private Map<String, Map<String, String>> decodeYaml() throws IOException {
+        private Map<String, List<AliasPlugin>> decodeYaml() throws IOException {
             ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-            return mapper.readValue(yamlContents, Map.class);
+            return mapper.readValue(yamlContents, new TypeReference<Map<String, List<AliasPlugin>>>() {});
         }
 
         private String computeHashFromContent() {
@@ -138,8 +140,8 @@ public class AliasRegistry {
                 return Collections.emptyMap();
             }
 
-            // decode yaml to nested maps
-            final Map<String, Map<String, String>> aliasedDescriptions;
+            // decode yaml to Map<PluginType, List<AliasPlugin>> structure
+            final Map<String, List<AliasPlugin>> aliasedDescriptions;
             try {
                 aliasedDescriptions = aliasYml.decodeYaml();
             } catch (IOException ioex) {
@@ -157,15 +159,16 @@ public class AliasRegistry {
         }
 
         private Map<PluginCoordinate, String> extractDefinitions(PluginType pluginType,
-                                                                 Map<String, Map<String, String>> aliasesYamlDefinitions) {
-            Map<PluginCoordinate, String> defaultDefinitions = new HashMap<>();
-            final Map<String, String> pluginDefinitions = aliasesYamlDefinitions.get(pluginType.name().toLowerCase());
-            if (pluginDefinitions == null) {
+                                                                 Map<String, List<AliasPlugin>> aliasesYamlDefinitions) {
+            final List<AliasPlugin> aliasedPlugins = aliasesYamlDefinitions.get(pluginType.name().toLowerCase());
+            if (Objects.isNull(aliasedPlugins)) {
                 return Collections.emptyMap();
             }
-            for (Map.Entry<String, String> aliasDef : pluginDefinitions.entrySet()) {
-                defaultDefinitions.put(new PluginCoordinate(pluginType, aliasDef.getKey()), aliasDef.getValue());
-            }
+
+            Map<PluginCoordinate, String> defaultDefinitions = new HashMap<>();
+            aliasedPlugins.forEach(aliasPlugin -> {
+                defaultDefinitions.put(new PluginCoordinate(pluginType, aliasPlugin.getAliasName()), aliasPlugin.getMapsTo());
+            });
             return defaultDefinitions;
         }
     }

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginLookup.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginLookup.java
@@ -25,6 +25,7 @@ import co.elastic.logstash.api.Filter;
 import co.elastic.logstash.api.Input;
 import co.elastic.logstash.api.Output;
 import co.elastic.logstash.api.Plugin;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jruby.RubyClass;
 import org.jruby.RubyString;
 import org.jruby.java.proxies.JavaProxy;
@@ -42,6 +43,11 @@ import java.util.stream.Stream;
  * {@code LogStash::Plugin} class for the Ruby plugin lookup.
  */
 public final class PluginLookup implements PluginFactoryExt.PluginResolver {
+
+    private static final String INPUT_PLUGIN_TYPE_NAME = "input";
+    private static final String FILTER_PLUGIN_TYPE_NAME = "filter";
+    private static final String OUTPUT_PLUGIN_TYPE_NAME = "output";
+    private static final String CODEC_PLUGIN_TYPE_NAME = "codec";
 
     private static final IRubyObject RUBY_REGISTRY = RubyUtil.RUBY.executeScript(
             "require 'logstash/plugins/registry'\nrequire 'logstash/plugin'\nLogStash::Plugin",
@@ -134,10 +140,18 @@ public final class PluginLookup implements PluginFactoryExt.PluginResolver {
      * Enum all the plugins types used inside Logstash
      * */
     public enum PluginType {
-        INPUT("input", "inputs", Input.class),
-        FILTER("filter", "filters", Filter.class),
-        OUTPUT("output", "outputs", Output.class),
-        CODEC("codec", "codecs", Codec.class);
+
+        @JsonProperty(INPUT_PLUGIN_TYPE_NAME)
+        INPUT(INPUT_PLUGIN_TYPE_NAME, "inputs", Input.class),
+
+        @JsonProperty(FILTER_PLUGIN_TYPE_NAME)
+        FILTER(FILTER_PLUGIN_TYPE_NAME, "filters", Filter.class),
+
+        @JsonProperty(OUTPUT_PLUGIN_TYPE_NAME)
+        OUTPUT(OUTPUT_PLUGIN_TYPE_NAME, "outputs", Output.class),
+
+        @JsonProperty(CODEC_PLUGIN_TYPE_NAME)
+        CODEC(CODEC_PLUGIN_TYPE_NAME, "codecs", Codec.class);
 
         private final RubyString rubyLabel;
         private final String metricNamespace;

--- a/logstash-core/src/main/java/org/logstash/plugins/aliases/AliasDocumentReplace.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/aliases/AliasDocumentReplace.java
@@ -1,0 +1,29 @@
+package org.logstash.plugins.aliases;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A POJO class linked to {@link AliasPlugin} to map AliasRegistry.yml structure.
+ */
+public class AliasDocumentReplace {
+
+    /**
+     * A document entry need to be replaced.
+     */
+    @Nonnull
+    private String replace;
+
+    /**
+     * A value where document entry need to be replaced with.
+     */
+    @Nonnull
+    private String with;
+
+    public String getReplace() {
+        return this.replace;
+    }
+
+    public String getWith() {
+        return this.with;
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/plugins/aliases/AliasPlugin.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/aliases/AliasPlugin.java
@@ -1,0 +1,61 @@
+package org.logstash.plugins.aliases;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A POJO class to map AliasRegistry.yml structure.
+ */
+public class AliasPlugin {
+
+    /**
+     * Name of the aliased plugin.
+     */
+    @Nonnull
+    @JsonProperty("alias_name")
+    private String aliasName;
+
+    /**
+     * The plugin name where aliased plugin maps to.
+     */
+    @Nonnull
+    @JsonProperty("maps_to")
+    private String mapsTo;
+
+    /**
+     * List of <K,V> entries to replace when transforming artifact to aliased plugin.
+     */
+    @Nullable
+    private List<Map<String, String>> replaces;
+
+    @Nonnull
+    public String getAliasName() {
+        return aliasName;
+    }
+
+    public void setAliasName(@Nonnull String aliasName) {
+        this.aliasName = aliasName;
+    }
+
+    @Nonnull
+    public String getMapsTo() {
+        return mapsTo;
+    }
+
+    public void setMapsTo(@Nonnull String mapsTo) {
+        this.mapsTo = mapsTo;
+    }
+
+    @Nullable
+    public List<Map<String, String>> getReplaces() {
+        return replaces;
+    }
+
+    public void setReplaces(@Nullable List<Map<String, String>> replaces) {
+        this.replaces = replaces;
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/plugins/aliases/AliasPlugin.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/aliases/AliasPlugin.java
@@ -40,9 +40,4 @@ public class AliasPlugin {
     public String getFrom() {
         return from;
     }
-
-    @Nullable
-    public List<AliasDocumentReplace> getDocHeaderReplaces() {
-        return docHeaderReplaces;
-    }
 }

--- a/logstash-core/src/main/java/org/logstash/plugins/aliases/AliasPlugin.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/aliases/AliasPlugin.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Map;
 
 /**
  * A POJO class to map AliasRegistry.yml structure.
@@ -16,46 +15,34 @@ public class AliasPlugin {
      * Name of the aliased plugin.
      */
     @Nonnull
-    @JsonProperty("alias_name")
+    @JsonProperty("alias")
     private String aliasName;
 
     /**
-     * The plugin name where aliased plugin maps to.
+     * The plugin name where aliased plugin made from.
      */
     @Nonnull
-    @JsonProperty("maps_to")
-    private String mapsTo;
+    private String from;
 
     /**
-     * List of <K,V> entries to replace when transforming artifact to aliased plugin.
+     * List of replace entries when transforming artifact doc to aliased plugin doc.
      */
     @Nullable
-    private List<Map<String, String>> replaces;
+    @JsonProperty("docs")
+    private List<AliasDocumentReplace> docHeaderReplaces;
 
     @Nonnull
     public String getAliasName() {
         return aliasName;
     }
 
-    public void setAliasName(@Nonnull String aliasName) {
-        this.aliasName = aliasName;
-    }
-
     @Nonnull
-    public String getMapsTo() {
-        return mapsTo;
-    }
-
-    public void setMapsTo(@Nonnull String mapsTo) {
-        this.mapsTo = mapsTo;
+    public String getFrom() {
+        return from;
     }
 
     @Nullable
-    public List<Map<String, String>> getReplaces() {
-        return replaces;
-    }
-
-    public void setReplaces(@Nullable List<Map<String, String>> replaces) {
-        this.replaces = replaces;
+    public List<AliasDocumentReplace> getDocHeaderReplaces() {
+        return docHeaderReplaces;
     }
 }

--- a/logstash-core/src/main/resources/org/logstash/plugins/AliasRegistry.yml
+++ b/logstash-core/src/main/resources/org/logstash/plugins/AliasRegistry.yml
@@ -1,2 +1,7 @@
 input:
-  elastic_agent: beats
+  - alias_name: elastic_agent
+    maps_to: beats
+    replaces:
+      - ":plugin: beats": ":plugin: elastic_agent"
+      - ":plugin-uc: Beats": ":plugin-uc: Elastic Agent"
+      - ":plugin-singular: Beat": ":plugin-singular: Elastic Agent"

--- a/logstash-core/src/main/resources/org/logstash/plugins/AliasRegistry.yml
+++ b/logstash-core/src/main/resources/org/logstash/plugins/AliasRegistry.yml
@@ -1,7 +1,10 @@
 input:
-  - alias_name: elastic_agent
-    maps_to: beats
-    replaces:
-      - ":plugin: beats": ":plugin: elastic_agent"
-      - ":plugin-uc: Beats": ":plugin-uc: Elastic Agent"
-      - ":plugin-singular: Beat": ":plugin-singular: Elastic Agent"
+  - alias: elastic_agent
+    from: beats
+    docs:
+      - replace: ":plugin: beats"
+        with: ":plugin: elastic_agent"
+      - replace: ":plugin-uc: Beats"
+        with: ":plugin-uc: Elastic Agent"
+      - replace: ":plugin-singular: Beat"
+        with: ":plugin-singular: Elastic Agent"

--- a/logstash-core/src/test/resources/org/logstash/plugins/AliasRegistry.yml
+++ b/logstash-core/src/test/resources/org/logstash/plugins/AliasRegistry.yml
@@ -1,6 +1,13 @@
 input:
-  aliased_input1: beats
-  aliased_input2: tcp
+  - alias_name: aliased_input1
+    maps_to: beats
+    replaces:
+      - ":plugin: beats": ":plugin: elastic_agent"
+      - ":plugin-uc: Beats": ":plugin-uc: Elastic Agent"
+      - ":plugin-singular: Beat": ":plugin-singular: Elastic Agent"
+  - alias_name: aliased_input2
+    maps_to: tcp
 
 filter:
-  aliased_filter: json
+  - alias_name: aliased_filter
+    maps_to: json

--- a/logstash-core/src/test/resources/org/logstash/plugins/AliasRegistry.yml
+++ b/logstash-core/src/test/resources/org/logstash/plugins/AliasRegistry.yml
@@ -1,5 +1,5 @@
 input:
-  - alias: elastic_agent
+  - alias: aliased_input1
     from: beats
     docs:
       - replace: ":plugin: beats"

--- a/logstash-core/src/test/resources/org/logstash/plugins/AliasRegistry.yml
+++ b/logstash-core/src/test/resources/org/logstash/plugins/AliasRegistry.yml
@@ -1,13 +1,16 @@
 input:
-  - alias_name: aliased_input1
-    maps_to: beats
-    replaces:
-      - ":plugin: beats": ":plugin: elastic_agent"
-      - ":plugin-uc: Beats": ":plugin-uc: Elastic Agent"
-      - ":plugin-singular: Beat": ":plugin-singular: Elastic Agent"
-  - alias_name: aliased_input2
-    maps_to: tcp
+  - alias: elastic_agent
+    from: beats
+    docs:
+      - replace: ":plugin: beats"
+        with: ":plugin: elastic_agent"
+      - replace: ":plugin-uc: Beats"
+        with: ":plugin-uc: Elastic Agent"
+      - replace: ":plugin-singular: Beat"
+        with: ":plugin-singular: Elastic Agent"
+  - alias: aliased_input2
+    from: tcp
 
 filter:
-  - alias_name: aliased_filter
-    maps_to: json
+  - alias: aliased_filter
+    from: json

--- a/spec/unit/plugin_manager/util_spec.rb
+++ b/spec/unit/plugin_manager/util_spec.rb
@@ -88,7 +88,7 @@ describe LogStash::PluginManager do
   describe "process alias yaml definition" do
     let(:path) { File.expand_path('plugin_aliases.yml', __dir__) }
 
-    it "should decode correctly" do
+    it "decodes correctly" do
       aliases = subject.load_aliases_definitions(path)
       expect(aliases['logstash-input-aliased_input1']).to eq('logstash-input-beats')
       expect(aliases['logstash-input-aliased_input2']).to eq('logstash-input-tcp')


### PR DESCRIPTION


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
A structural change of aliased plugins declaration to support alias doc headers to replace.

## What does this PR do?
When plugin reference doc generator workflow runs it generates a document for artifact plugin but not for aliased plugins. Aliased plugin docs are copy of artifact plugins with different doc headers. This PR helps to define the doc header where doc generator can use to generate the doc for alised plugins. `replaces` field especially is helpful to create a aliased plugin doc header by replacing artifact doc entries.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally
- Unit tests
- Build Logstash, run and check

## Related issues
- Closes [#69 Add alias params declarations in logstash AliasRegistry.yml and manipulate in doc-tools](https://github.com/elastic/docs-tools/issues/69)

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
User logger to log the `extractDefinitions() -> aliasedPlugins & defaultDefinitions vars`:
```
[2022-04-01T10:16:29,260][WARN ][org.logstash.plugins.AliasRegistry] Aliased plugins size: 1
[2022-04-01T10:16:29,261][WARN ][org.logstash.plugins.AliasRegistry] Aliased plugins: [org.logstash.plugins.aliases.AliasPlugin@6c4112d6]
[2022-04-01T10:16:29,262][WARN ][org.logstash.plugins.AliasRegistry] Alias name: elastic_agent
[2022-04-01T10:16:29,262][WARN ][org.logstash.plugins.AliasRegistry] Alias maps to: beats
```