### PR TITLE
Add value converters for java.time

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Valuefier.java
+++ b/logstash-core/src/main/java/org/logstash/Valuefier.java
@@ -22,6 +22,7 @@ package org.logstash;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.*;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -181,6 +182,21 @@ public final class Valuefier {
         );
         converters.put(
             RubyArray.class, input -> ConvertedList.newFromRubyArray((RubyArray) input)
+        );
+        converters.put(
+                LocalDate.class, input -> JrubyTimestampExtLibrary.RubyTimestamp.newRubyTimestamp(
+                        RubyUtil.RUBY, new Timestamp(((LocalDate) input).atStartOfDay().toInstant(ZoneOffset.UTC))
+                )
+        );
+        converters.put(
+                LocalDateTime.class, input -> JrubyTimestampExtLibrary.RubyTimestamp.newRubyTimestamp(
+                        RubyUtil.RUBY, new Timestamp(((LocalDateTime) input).toInstant(ZoneOffset.UTC))
+                )
+        );
+        converters.put(
+                ZonedDateTime.class, input -> JrubyTimestampExtLibrary.RubyTimestamp.newRubyTimestamp(
+                        RubyUtil.RUBY, new Timestamp(((ZonedDateTime) input).toInstant())
+                )
         );
         return converters;
     }

--- a/logstash-core/src/main/java/org/logstash/Valuefier.java
+++ b/logstash-core/src/main/java/org/logstash/Valuefier.java
@@ -22,7 +22,10 @@ package org.logstash;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.time.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;

--- a/logstash-core/src/test/java/org/logstash/ValuefierTest.java
+++ b/logstash-core/src/test/java/org/logstash/ValuefierTest.java
@@ -20,6 +20,10 @@
 
 package org.logstash;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -91,6 +95,29 @@ public class ValuefierTest extends RubyTestBase {
         Object result = Valuefier.convert(jo);
 
         assertEquals(JrubyTimestampExtLibrary.RubyTimestamp.class, result.getClass());
+    }
+
+    @Test
+    public void testLocalDate() {
+        LocalDate ld = LocalDate.now();
+        Object result = Valuefier.convert(ld);
+
+        assertEquals(JrubyTimestampExtLibrary.RubyTimestamp.class, result.getClass());
+    }
+
+    @Test
+    public void testLocalDateTime() {
+        LocalDateTime ldt = LocalDateTime.now();
+        Object result = Valuefier.convert(ldt);
+
+        assertEquals(JrubyTimestampExtLibrary.RubyTimestamp.class, result.getClass());
+    }
+
+    @Test
+    public void testZonedDateTime() {
+        ZonedDateTime zdt = ZonedDateTime.of(2022,4,4,5,6,13,123, ZoneId.of("Europe/London"));
+        JrubyTimestampExtLibrary.RubyTimestamp result = (JrubyTimestampExtLibrary.RubyTimestamp) Valuefier.convert(zdt);
+        assertEquals(zdt.toInstant().toEpochMilli(), result.getTimestamp().toEpochMilli());
     }
 
     @Rule


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->
## Type of change
enhancement

## What does this PR do?
This change allows Java logstash plugins to use `java.time.LocalDate`, `java.time.LocalDateTime` and `java.time.ZonedDateTime` objects in , `org.logstash.Event` classes. As the `java.time.Instant` class is already supported by `org.logstash.Timestamp`, there is no functional change required to the underlying classes. 


## Why is it important/What is the impact to the user?
This improves the usability of the logstash java api for contributing plugins as it means users do not need to manually serialize java.time objects to Strings in order to add to events and can simply utilise the already available Ruby Timestamps.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ x ] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ x ] I have added tests that prove my fix is effective or that my feature works


## How to test this PR locally
Tested with Unit tests, also, see use case below

## Related issues
- Relates #10525


## Use cases
```
public Collection<Event> filter(Collection<Event> events, FilterMatchListener matchListener) {
    for (Event e : events) {
        e.setField("myTimestamp", LocalDateTime.now());
    }
}
```
