### PR TITLE
[doc] Add Logstash to Logstash HTTP example configuration.

### DIFF
--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -10,7 +10,7 @@ For now, <<plugins-outputs-http,http output>> to <<plugins-inputs-http,http inpu
 
 ==== Configuration overview
 
-To use the HTTP protocol to connect two Logstash instance you will:
+To use the HTTP protocol to connect two Logstash instances:
 
 . Configure the downstream (server) Logstash to use HTTP input
 . Configure the upstream (client) Logstash to use HTTP ouput

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -91,7 +91,7 @@ input {
   }
 }
 ----
-
++
 . Configure the upstream (sending) Logstash to use SSL. You need to add the following settings to the HTTP Output configuration:
 +
  * `cacert`: Configures the Logstash client to trust any certificates signed by the specicied CA.

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -101,7 +101,7 @@ Add these settings to the HTTP output configuration:
 +
  * `cacert`: Configures the Logstash client to trust any certificates signed by the specified CA.
  * `client_key`: Specifies the key the Logstash client uses to authenticate with the Logstash server.
- * `client_cert`: Specifies the certificate that the Logstash client uses to authenticate to the logstash server.
+ * `client_cert`: Specifies the certificate that the Logstash client uses to authenticate to the Logstash server.
 +
 For example:
 +

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -63,14 +63,14 @@ output {
 
 Now that you have a Logstash to Logstash communication with HTTP, it is important that you secure the communication between Logstash instances. This is done with SSL/TLS mutual authentication, in order to ensure that the upstream Logstash instance sends encrypted data to a trusted downstream Logstash instance, and viceversa. In order to achieve this, you need the following:
 
-1. Create a certificate authority (CA) in order to sign the certificates that you plan to use between Logstash instances. Creating a correct SSL/TLS infrastructure is outside the scope of this document.
+. Create a certificate authority (CA) in order to sign the certificates that you plan to use between Logstash instances. Creating a correct SSL/TLS infrastructure is outside the scope of this document.
 
 [NOTE]
 -----
 We recommend you use the elasticsearch-certutil tool to generate your certificates.
 -----
 
-2. Configure the downstream (receiving) Logstash to use SSL. You need to add the following settings to the HTTP Input configuration:
+. Configure the downstream (receiving) Logstash to use SSL. You need to add the following settings to the HTTP Input configuration:
 
  * `ssl`: When set to `true`, it enables Logstash use of SSL/TLS
  * `ssl_key`: Specifies the key that Logstash uses to authenticate with the client.
@@ -95,7 +95,7 @@ input {
 }
 ----
 
-3. Configure the upstream (sending) Logstash to use SSL. You need to add the following settings to the HTTP Output configuration:
+. Configure the upstream (sending) Logstash to use SSL. You need to add the following settings to the HTTP Output configuration:
 
  * `cacert`: Configures the Logstash client to trust any certificates signed by the specicied CA.
  * `client_key`: Specicies the key the LOgstash client uses to authenticate with the Logstash server.

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -66,7 +66,7 @@ Now that you have a Logstash to Logstash communication with HTTP, it is importan
 . Create a certificate authority (CA) in order to sign the certificates that you plan to use between Logstash instances. Creating a correct SSL/TLS infrastructure is outside the scope of this document.
 +
 TIP: We recommend you use the {ref}/certutil.html[elasticsearch-certutil] tool to generate your certificates.
-+
+
 . Configure the downstream (receiving) Logstash to use SSL. You need to add the following settings to the HTTP Input configuration:
 +
  * `ssl`: When set to `true`, it enables Logstash use of SSL/TLS
@@ -91,7 +91,7 @@ input {
   }
 }
 ----
-+
+
 . Configure the upstream (sending) Logstash to use SSL. You need to add the following settings to the HTTP Output configuration:
 +
  * `cacert`: Configures the Logstash client to trust any certificates signed by the specicied CA.

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -68,7 +68,7 @@ Now that you have a Logstash to Logstash communication with HTTP, it is importan
 TIP: We recommend you use the {ref}/certutil.html[elasticsearch-certutil] tool to generate your certificates.
 +
 . Configure the downstream (receiving) Logstash to use SSL. You need to add the following settings to the HTTP Input configuration:
-
++
  * `ssl`: When set to `true`, it enables Logstash use of SSL/TLS
  * `ssl_key`: Specifies the key that Logstash uses to authenticate with the client.
  * `ssl_certificate`: Specicies the certificate that Logstash uses to authenticate with the client.

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -30,12 +30,6 @@ input {
     http {
         port => 8080
         additional_codecs => { "application/json" => "json_lines" }
-
-        ssl => true
-        ssl_key => "server.key.pk8"
-        ssl_certificate => "server.crt"
-        ssl_certificate_authorities => "ca.crt"
-        ssl_verify_mode => force_peer
     }
 }
 ----
@@ -60,10 +54,6 @@ output {
         retry_non_idempotent => true
         format => json_batch
         http_compression => true
-
-        cacert => "ca.crt"
-        client_key => "client.key.pk8"
-        client_cert => "client.crt"
     }
 }
 ----
@@ -75,15 +65,7 @@ Now that Logstash to Logstash communication is configured, you need to secure th
 
 1. Create a certificate authority (CA) in order to sign the certificates that you plan to use between Logstash instances. Creating a correct SSL/TLS infrastructure is outside the scope of this document, but we recommend you use the elasticsearch-certutil tool.
 
-2. Configure the upstream (sending) Logstash to use SSL. You need to add the following settings to the HTTP Output configuration:
-
- * `cacert`:
- * `client_key`:
- * `client_cert`:
-
- For example:
-
-3. Configure the downstream (receiving) Logstash to use SSL. You need to add the following settings to the HTTP Input configuration:
+2. Configure the downstream (receiving) Logstash to use SSL. You need to add the following settings to the HTTP Input configuration:
 
  * `ssl`:
  * `ssl_key`:
@@ -92,3 +74,39 @@ Now that Logstash to Logstash communication is configured, you need to secure th
  * `ssl_verify_mode`: 
 
  For example:
+
+[source,json]
+----
+input {
+    http {
+        [...]
+
+        ssl => true
+        ssl_key => "server.key.pk8"
+        ssl_certificate => "server.crt"
+        ssl_certificate_authorities => "ca.crt"
+        ssl_verify_mode => force_peer
+    }
+}
+----
+
+3. Configure the upstream (sending) Logstash to use SSL. You need to add the following settings to the HTTP Output configuration:
+
+ * `cacert`:
+ * `client_key`:
+ * `client_cert`:
+
+ For example:
+
+[source,json]
+----
+output {
+    http {
+        [...]
+
+        cacert => "ca.crt"
+        client_key => "client.key.pk8"
+        client_cert => "client.crt"
+    }
+}
+----

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -61,7 +61,7 @@ output {
 ----
 
 [[securing-logstash-to-logstash]]
-===== Securing Logstash to Logstash
+===== Secure Logstash to Logstash
 
 Now that you have a Logstash to Logstash communication with HTTP, it is important that you secure the communication between Logstash instances. This is done with SSL/TLS mutual authentication, in order to ensure that the upstream Logstash instance sends encrypted data to a trusted downstream Logstash instance, and viceversa. In order to achieve this, you need the following:
 

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -39,7 +39,7 @@ input {
 [[configure-upstream-logstash-http-output]]
 ===== Configure the upstream Logstash to use HTTP output
 
-In order to optain the best performance when sending data from one Logstash to another, it needs to be batched and compressed. As such, the upstream Logstash (the sending Logstash) needs to be configured with the following options:
+In order to obtain the best performance when sending data from one Logstash to another, the data needs to be batched and compressed. As such, the upstream Logstash (the sending Logstash) needs to be configured with these options:
 
 * `url` - The receiving Logstash.
 * `http_method` - Set to `post`.

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -45,7 +45,7 @@ In order to optain the best performance when sending data from one Logstash to a
 * `http_method` - Set to `post`.
 * `retry_non_idempotent` - Set to `true`, in order to retry failed events.
 * `format` - Set to `json_batch` to batch the data.
-* `http_compression` - Set to `true` ensures the data is compressed.
+* `http_compression` - Set to `true` to ensure the data is compressed.
 
 [source,json]
 ----

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -15,7 +15,7 @@ To use the HTTP protocol to connect two Logstash instances:
 
 . Configure the downstream (server) Logstash to use HTTP input
 . Configure the upstream (client) Logstash to use HTTP ouput
-. Securing the communication between HTTP input and HTTP output
+. Secure the communication between HTTP input and HTTP output
 
 [[configure-downstream-logstash-http-input]]
 ===== Configure the downstream Logstash to use HTTP input

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -8,6 +8,7 @@ NOTE: Check out these <<http-considerations,considerations>> before you implemen
 
 For now, <<plugins-outputs-http,http output>> to <<plugins-inputs-http,http input>> with manual configuration may be the best path forward if these limitations don't apply to your use case.
 
+[[overview-http-http]]
 ==== Configuration overview
 
 To use the HTTP protocol to connect two Logstash instances:

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -61,17 +61,22 @@ output {
 [[securing-logstash-to-logstash]]
 ===== Securing Logstash to Logstash
 
-Now that Logstash to Logstash communication is configured, you need to secure the communication between them. In this example, we will use SSL mutual authentication. This ensures that the upstream Logstash sends encrypted data to a trusted receiving Logstash, and viceversa. For this, you will need:
+Now that you have a Logstash to Logstash communication with HTTP, it is important that you secure the communication between Logstash instances. This is done with SSL/TLS mutual authentication, in order to ensure that the upstream Logstash instance sends encrypted data to a trusted downstream Logstash instance, and viceversa. In order to achieve this, you need the following:
 
-1. Create a certificate authority (CA) in order to sign the certificates that you plan to use between Logstash instances. Creating a correct SSL/TLS infrastructure is outside the scope of this document, but we recommend you use the elasticsearch-certutil tool.
+1. Create a certificate authority (CA) in order to sign the certificates that you plan to use between Logstash instances. Creating a correct SSL/TLS infrastructure is outside the scope of this document.
+
+[NOTE]
+--
+We recommend you use the elasticsearch-certutil tool to generate your certificates.
+--
 
 2. Configure the downstream (receiving) Logstash to use SSL. You need to add the following settings to the HTTP Input configuration:
 
- * `ssl`:
- * `ssl_key`:
- * `ssl_certificate`:
- * `ssl_certificate_authorities`:
- * `ssl_verify_mode`: 
+ * `ssl`: When set to `true`, it enables Logstash use of SSL/TLS
+ * `ssl_key`: Specifies the key that Logstash uses to authenticate with the client.
+ * `ssl_certificate`: Specicies the certificate that Logstash uses to authenticate with the client.
+ * `ssl_certificate_authorities`: Configures Logstash to trust any certificates signed by the specicied CA.
+ * `ssl_verify_mode`:  Specicies whether Logstash server verifies the client certificate against the CA.
 
  For example:
 
@@ -92,9 +97,9 @@ input {
 
 3. Configure the upstream (sending) Logstash to use SSL. You need to add the following settings to the HTTP Output configuration:
 
- * `cacert`:
- * `client_key`:
- * `client_cert`:
+ * `cacert`: Configures the Logstash client to trust any certificates signed by the specicied CA.
+ * `client_key`: Specicies the key the LOgstash client uses to authenticate with the Logstash server.
+ * `client_cert`: Specifies the certificate that the Logstash client uses to authenticate to the logstash server.
 
  For example:
 
@@ -109,4 +114,19 @@ output {
         client_cert => "client.crt"
     }
 }
+----
+
+4. If you would like an additional authentication step, you can also use basic user/password authentication in both Logstash instances:
+
+ * `user`: Sets the username to use for authentication.
+ * `password`: Sets the password to use for authentication.
+
+ For example, you would need to add the following to both Logstash instances:
+
+[source,json]
+----
+[...]
+        user => "your-user"
+        password => "your-secret"
+[...]
 ----

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -64,9 +64,9 @@ output {
 Now that you have a Logstash to Logstash communication with HTTP, it is important that you secure the communication between Logstash instances. This is done with SSL/TLS mutual authentication, in order to ensure that the upstream Logstash instance sends encrypted data to a trusted downstream Logstash instance, and viceversa. In order to achieve this, you need the following:
 
 . Create a certificate authority (CA) in order to sign the certificates that you plan to use between Logstash instances. Creating a correct SSL/TLS infrastructure is outside the scope of this document.
-
++
 TIP: We recommend you use the {ref}/certutil.html[elasticsearch-certutil] tool to generate your certificates.
-
++
 . Configure the downstream (receiving) Logstash to use SSL. You need to add the following settings to the HTTP Input configuration:
 
  * `ssl`: When set to `true`, it enables Logstash use of SSL/TLS

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -91,9 +91,9 @@ input {
   }
 }
 ----
-+
-. Configure the upstream (sending) Logstash to use SSL. You need to add the following settings to the HTTP Output configuration:
 
+. Configure the upstream (sending) Logstash to use SSL. You need to add the following settings to the HTTP Output configuration:
++
  * `cacert`: Configures the Logstash client to trust any certificates signed by the specicied CA.
  * `client_key`: Specicies the key the LOgstash client uses to authenticate with the Logstash server.
  * `client_cert`: Specifies the certificate that the Logstash client uses to authenticate to the logstash server.

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -96,7 +96,8 @@ input {
 }
 ----
 
-. Configure the upstream (sending) Logstash to use SSL. You need to add the following settings to the HTTP Output configuration:
+. Configure the upstream (sending) Logstash to use SSL. 
+Add these settings to the HTTP output configuration:
 +
  * `cacert`: Configures the Logstash client to trust any certificates signed by the specified CA.
  * `client_key`: Specifies the key the LOgstash client uses to authenticate with the Logstash server.

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -114,12 +114,12 @@ output {
 ----
 
 . If you would like an additional authentication step, you can also use basic user/password authentication in both Logstash instances:
-
++
  * `user`: Sets the username to use for authentication.
  * `password`: Sets the password to use for authentication.
-
++
 For example, you would need to add the following to both Logstash instances:
-
++
 [source,json]
 ----
 ...

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -74,7 +74,7 @@ TIP: We recommend you use the {ref}/certutil.html[elasticsearch-certutil] tool t
  * `ssl_certificate`: Specicies the certificate that Logstash uses to authenticate with the client.
  * `ssl_certificate_authorities`: Configures Logstash to trust any certificates signed by the specicied CA.
  * `ssl_verify_mode`:  Specicies whether Logstash server verifies the client certificate against the CA.
-
++
 For example:
 
 [source,json]

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -10,7 +10,7 @@ For now, <<plugins-outputs-http,http output>> to <<plugins-inputs-http,http inpu
 
 ==== Configuration overview
 
-To use the HTTP protocol to connect two Logstash instance we will:
+To use the HTTP protocol to connect two Logstash instance you will:
 
 . Configure the downstream (server) Logstash to use HTTP input
 . Configure the upstream (client) Logstash to use HTTP ouput

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -8,3 +8,87 @@ NOTE: Check out these <<http-considerations,considerations>> before you implemen
 
 For now, <<plugins-outputs-http,http output>> to <<plugins-inputs-http,http input>> with manual configuration may be the best path forward if these limitations don't apply to your use case.
 
+==== Configuration overview
+
+Use the Lumberjack protocol to connect two Logstash machines.
+
+. Configure the downstream (server) Logstash to use HTTP input
+. Configure the upstream (client) Logstash to use HTTP ouput
+. Securing the communication between HTTP input and HTTP output
+
+[[configure-downstream-logstash-http-input]]
+===== Configure the downstream Logstash to use HTTP input
+
+To configure the downstream Logstash (the receiving Logstash) you need to configure the HTTP input to receive connections. The minimum recommended configuration requires you to set the following options:
+
+* `port` - to set a custom port.
+* `additional_codecs` - To set `application/json` to be `json_lines`.
+
+[source,json]
+----
+input {
+    http {
+        port => 8080
+        additional_codecs => { "application/json" => "json_lines" }
+
+        ssl => true
+        ssl_key => "server.key.pk8"
+        ssl_certificate => "server.crt"
+        ssl_certificate_authorities => "ca.crt"
+        ssl_verify_mode => force_peer
+    }
+}
+----
+
+[[configure-upstream-logstash-http-output]]
+===== Configure the upstream Logstash to use HTTP output
+
+In order to optain the best performance when sending data from one Logstash to another, it needs to be batched and compressed. As such, the upstream Logstash (the sending Logstash) needs to be configured with the following options:
+
+* `url` - The receiving Logstash.
+* `http_method` - Set to `post`.
+* `retry_non_idempotent` - Set to `true`, in order to retry failed events.
+* `format` - Set to `json_batch` to batch the data.
+* `http_compression` - Set to `true` ensures the data is compressed.
+
+[source,json]
+----
+output {
+    http {
+        url => 'http://<upstream-logstash>:<port>'
+        http_method => post
+        retry_non_idempotent => true
+        format => json_batch
+        http_compression => true
+
+        cacert => "ca.crt"
+        client_key => "client.key.pk8"
+        client_cert => "client.crt"
+    }
+}
+----
+
+[[securing-logstash-to-logstash]]
+===== Securing Logstash to Logstash
+
+Now that Logstash to Logstash communication is configured, you need to secure the communication between them. In this example, we will use SSL mutual authentication. This ensures that the upstream Logstash sends encrypted data to a trusted receiving Logstash, and viceversa. For this, you will need:
+
+1. Create a certificate authority (CA) in order to sign the certificates that you plan to use between Logstash instances. Creating a correct SSL/TLS infrastructure is outside the scope of this document, but we recommend you use the elasticsearch-certutil tool.
+
+2. Configure the upstream (sending) Logstash to use SSL. You need to add the following settings to the HTTP Output configuration:
+
+ * `cacert`:
+ * `client_key`:
+ * `client_cert`:
+
+ For example:
+
+3. Configure the downstream (receiving) Logstash to use SSL. You need to add the following settings to the HTTP Input configuration:
+
+ * `ssl`:
+ * `ssl_key`:
+ * `ssl_certificate`:
+ * `ssl_certificate_authorities`:
+ * `ssl_verify_mode`: 
+
+ For example:

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -23,7 +23,7 @@ To use the HTTP protocol to connect two Logstash instances:
 Configure the HTTP input on the downstream (receiving) Logstash to receive connections. 
 The minimum configuration requires these options:
 
-* `port` - to set a custom port.
+* `port` - To set a custom port.
 * `additional_codecs` - To set `application/json` to be `json_lines`.
 
 [source,json]

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -65,10 +65,7 @@ Now that you have a Logstash to Logstash communication with HTTP, it is importan
 
 . Create a certificate authority (CA) in order to sign the certificates that you plan to use between Logstash instances. Creating a correct SSL/TLS infrastructure is outside the scope of this document.
 
-[NOTE]
------
-We recommend you use the elasticsearch-certutil tool to generate your certificates.
------
+TIP: We recommend you use the {elasticsearch-ref}/certutil.html[elasticsearch-certutil] tool to generate your certificates.
 
 . Configure the downstream (receiving) Logstash to use SSL. You need to add the following settings to the HTTP Input configuration:
 

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -116,7 +116,7 @@ output {
 }
 ----
 
-4. If you would like an additional authentication step, you can also use basic user/password authentication in both Logstash instances:
+. If you would like an additional authentication step, you can also use basic user/password authentication in both Logstash instances:
 
  * `user`: Sets the username to use for authentication.
  * `password`: Sets the password to use for authentication.

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -63,7 +63,8 @@ output {
 [[securing-logstash-to-logstash]]
 ===== Secure Logstash to Logstash
 
-Now that you have a Logstash to Logstash communication with HTTP, it is important that you secure the communication between Logstash instances. This is done with SSL/TLS mutual authentication, in order to ensure that the upstream Logstash instance sends encrypted data to a trusted downstream Logstash instance, and viceversa. In order to achieve this, you need the following:
+It is important that you secure the communication between Logstash instances. 
+Use SSL/TLS mutual authentication in order to ensure that the upstream Logstash instance sends encrypted data to a trusted downstream Logstash instance, and vice versa. 
 
 . Create a certificate authority (CA) in order to sign the certificates that you plan to use between Logstash instances. Creating a correct SSL/TLS infrastructure is outside the scope of this document.
 +

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -70,7 +70,8 @@ Use SSL/TLS mutual authentication in order to ensure that the upstream Logstash 
 +
 TIP: We recommend you use the {ref}/certutil.html[elasticsearch-certutil] tool to generate your certificates.
 
-. Configure the downstream (receiving) Logstash to use SSL. You need to add the following settings to the HTTP Input configuration:
+. Configure the downstream (receiving) Logstash to use SSL. 
+Add these settings to the HTTP Input configuration:
 +
  * `ssl`: When set to `true`, it enables Logstash use of SSL/TLS
  * `ssl_key`: Specifies the key that Logstash uses to authenticate with the client.

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -83,15 +83,15 @@ We recommend you use the elasticsearch-certutil tool to generate your certificat
 [source,json]
 ----
 input {
-    http {
-        [...]
+  http {
+    [...]
 
-        ssl => true
-        ssl_key => "server.key.pk8"
-        ssl_certificate => "server.crt"
-        ssl_certificate_authorities => "ca.crt"
-        ssl_verify_mode => force_peer
-    }
+    ssl => true
+    ssl_key => "server.key.pk8"
+    ssl_certificate => "server.crt"
+    ssl_certificate_authorities => "ca.crt"
+    ssl_verify_mode => force_peer
+  }
 }
 ----
 
@@ -106,13 +106,13 @@ input {
 [source,json]
 ----
 output {
-    http {
-        [...]
+  http {
+    [...]
 
-        cacert => "ca.crt"
-        client_key => "client.key.pk8"
-        client_cert => "client.crt"
-    }
+    cacert => "ca.crt"
+    client_key => "client.key.pk8"
+    client_cert => "client.crt"
+  }
 }
 ----
 
@@ -126,7 +126,7 @@ output {
 [source,json]
 ----
 [...]
-        user => "your-user"
-        password => "your-secret"
+    user => "your-user"
+    password => "your-secret"
 [...]
 ----

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -49,7 +49,7 @@ In order to optain the best performance when sending data from one Logstash to a
 ----
 output {
     http {
-        url => 'http://<upstream-logstash>:<port>'
+        url => '<protocol>://<downstream-logstash>:<port>'
         http_method => post
         retry_non_idempotent => true
         format => json_batch
@@ -71,9 +71,9 @@ TIP: We recommend you use the {ref}/certutil.html[elasticsearch-certutil] tool t
 +
  * `ssl`: When set to `true`, it enables Logstash use of SSL/TLS
  * `ssl_key`: Specifies the key that Logstash uses to authenticate with the client.
- * `ssl_certificate`: Specicies the certificate that Logstash uses to authenticate with the client.
- * `ssl_certificate_authorities`: Configures Logstash to trust any certificates signed by the specicied CA.
- * `ssl_verify_mode`:  Specicies whether Logstash server verifies the client certificate against the CA.
+ * `ssl_certificate`: Specifies the certificate that Logstash uses to authenticate with the client.
+ * `ssl_certificate_authorities`: Configures Logstash to trust any certificates signed by the specified CA.
+ * `ssl_verify_mode`:  Specifies whether Logstash server verifies the client certificate against the CA.
 +
 For example:
 +
@@ -94,8 +94,8 @@ input {
 
 . Configure the upstream (sending) Logstash to use SSL. You need to add the following settings to the HTTP Output configuration:
 +
- * `cacert`: Configures the Logstash client to trust any certificates signed by the specicied CA.
- * `client_key`: Specicies the key the LOgstash client uses to authenticate with the Logstash server.
+ * `cacert`: Configures the Logstash client to trust any certificates signed by the specified CA.
+ * `client_key`: Specifies the key the LOgstash client uses to authenticate with the Logstash server.
  * `client_cert`: Specifies the certificate that the Logstash client uses to authenticate to the logstash server.
 +
 For example:

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -76,7 +76,7 @@ TIP: We recommend you use the {ref}/certutil.html[elasticsearch-certutil] tool t
  * `ssl_verify_mode`:  Specicies whether Logstash server verifies the client certificate against the CA.
 +
 For example:
-
++
 [source,json]
 ----
 input {

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -20,7 +20,8 @@ To use the HTTP protocol to connect two Logstash instances:
 [[configure-downstream-logstash-http-input]]
 ===== Configure the downstream Logstash to use HTTP input
 
-To configure the downstream Logstash (the receiving Logstash) you need to configure the HTTP input to receive connections. The minimum recommended configuration requires you to set the following options:
+Configure the HTTP input on the downstream (receiving) Logstash to receive connections. 
+The minimum configuration requires these options:
 
 * `port` - to set a custom port.
 * `additional_codecs` - To set `application/json` to be `json_lines`.

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -100,7 +100,7 @@ input {
 Add these settings to the HTTP output configuration:
 +
  * `cacert`: Configures the Logstash client to trust any certificates signed by the specified CA.
- * `client_key`: Specifies the key the LOgstash client uses to authenticate with the Logstash server.
+ * `client_key`: Specifies the key the Logstash client uses to authenticate with the Logstash server.
  * `client_cert`: Specifies the certificate that the Logstash client uses to authenticate to the logstash server.
 +
 For example:

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -65,7 +65,7 @@ Now that you have a Logstash to Logstash communication with HTTP, it is importan
 
 . Create a certificate authority (CA) in order to sign the certificates that you plan to use between Logstash instances. Creating a correct SSL/TLS infrastructure is outside the scope of this document.
 
-TIP: We recommend you use the {elasticsearch-ref}/certutil.html[elasticsearch-certutil] tool to generate your certificates.
+TIP: We recommend you use the {ref}/certutil.html[elasticsearch-certutil] tool to generate your certificates.
 
 . Configure the downstream (receiving) Logstash to use SSL. You need to add the following settings to the HTTP Input configuration:
 
@@ -75,7 +75,7 @@ TIP: We recommend you use the {elasticsearch-ref}/certutil.html[elasticsearch-ce
  * `ssl_certificate_authorities`: Configures Logstash to trust any certificates signed by the specicied CA.
  * `ssl_verify_mode`:  Specicies whether Logstash server verifies the client certificate against the CA.
 
- For example:
+For example:
 
 [source,json]
 ----
@@ -98,7 +98,7 @@ input {
  * `client_key`: Specicies the key the LOgstash client uses to authenticate with the Logstash server.
  * `client_cert`: Specifies the certificate that the Logstash client uses to authenticate to the logstash server.
 
- For example:
+For example:
 
 [source,json]
 ----
@@ -118,7 +118,7 @@ output {
  * `user`: Sets the username to use for authentication.
  * `password`: Sets the password to use for authentication.
 
- For example, you would need to add the following to both Logstash instances:
+For example, you would need to add the following to both Logstash instances:
 
 [source,json]
 ----

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -97,9 +97,9 @@ input {
  * `cacert`: Configures the Logstash client to trust any certificates signed by the specicied CA.
  * `client_key`: Specicies the key the LOgstash client uses to authenticate with the Logstash server.
  * `client_cert`: Specifies the certificate that the Logstash client uses to authenticate to the logstash server.
-
++
 For example:
-
++
 [source,json]
 ----
 output {

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -91,7 +91,7 @@ input {
   }
 }
 ----
-
++
 . Configure the upstream (sending) Logstash to use SSL. You need to add the following settings to the HTTP Output configuration:
 
  * `cacert`: Configures the Logstash client to trust any certificates signed by the specicied CA.

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -84,7 +84,7 @@ We recommend you use the elasticsearch-certutil tool to generate your certificat
 ----
 input {
   http {
-    [...]
+    ...
 
     ssl => true
     ssl_key => "server.key.pk8"
@@ -107,7 +107,7 @@ input {
 ----
 output {
   http {
-    [...]
+    ...
 
     cacert => "ca.crt"
     client_key => "client.key.pk8"
@@ -125,8 +125,12 @@ output {
 
 [source,json]
 ----
-[...]
+...
+  http {
+    ...
+
     user => "your-user"
     password => "your-secret"
-[...]
+  }
+...
 ----

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -66,9 +66,9 @@ Now that you have a Logstash to Logstash communication with HTTP, it is importan
 1. Create a certificate authority (CA) in order to sign the certificates that you plan to use between Logstash instances. Creating a correct SSL/TLS infrastructure is outside the scope of this document.
 
 [NOTE]
---
+-----
 We recommend you use the elasticsearch-certutil tool to generate your certificates.
---
+-----
 
 2. Configure the downstream (receiving) Logstash to use SSL. You need to add the following settings to the HTTP Input configuration:
 

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -14,7 +14,7 @@ For now, <<plugins-outputs-http,http output>> to <<plugins-inputs-http,http inpu
 To use the HTTP protocol to connect two Logstash instances:
 
 . Configure the downstream (server) Logstash to use HTTP input
-. Configure the upstream (client) Logstash to use HTTP ouput
+. Configure the upstream (client) Logstash to use HTTP output
 . Secure the communication between HTTP input and HTTP output
 
 [[configure-downstream-logstash-http-input]]

--- a/docs/static/ls-ls-http.asciidoc
+++ b/docs/static/ls-ls-http.asciidoc
@@ -10,7 +10,7 @@ For now, <<plugins-outputs-http,http output>> to <<plugins-inputs-http,http inpu
 
 ==== Configuration overview
 
-Use the Lumberjack protocol to connect two Logstash machines.
+To use the HTTP protocol to connect two Logstash instance we will:
 
 . Configure the downstream (server) Logstash to use HTTP input
 . Configure the upstream (client) Logstash to use HTTP ouput


### PR DESCRIPTION
**PREVIEW:** https://logstash_13973.docs-preview.app.elstc.co/guide/en/logstash/master/ls-to-ls-http.html

## What does this PR do?
Adds documentation showing users how to configure Logstash to Logstash using HTTP.

## Why is it important/What is the impact to the user?
Because we have been recommending the use of HTTP as an alternative to using Lumberjack for Logstash to Logstash communication.

