### PR TITLE
Doc: Fix unresolved link from MB monitoring to user settings

### DIFF
--- a/docs/static/monitoring/monitoring-mb.asciidoc
+++ b/docs/static/monitoring/monitoring-mb.asciidoc
@@ -183,7 +183,7 @@ Alternatively, use the `remote_monitoring_user`
 +
 TIP: If you're using index lifecycle management, the remote monitoring user
 requires additional privileges to create and read indices. For more
-information, see `<<feature-roles>>`.
+information, see <<ls-monitoring-user>>.
 
 .. Add the `username` and `password` settings to the {es} output information in 
 the {metricbeat} configuration file.


### PR DESCRIPTION
Link to privileges info is incorrect and can't be resolved. Putting this PR up as a placeholder pending more research. 

The text in the TIP references extra permissions needed for ILM, so the new link might not be the right target. The monitoring user info doesn't have any info on ILM permissions.  Needs more research. 

>TIP: If you’re using index lifecycle management, the remote monitoring user requires additional privileges to create and read indices. For more information, see <<feature-roles>>.

Also, Security content is getting an overhaul (as tracked in issue #13573). That work might impact the best target as well.  
