### PR TITLE
Fix window CI for PQ size checking

### DIFF
--- a/logstash-core/spec/logstash/persisted_queue_config_validator_spec.rb
+++ b/logstash-core/spec/logstash/persisted_queue_config_validator_spec.rb
@@ -18,6 +18,7 @@
 require "spec_helper"
 require "tmpdir"
 require "logstash/persisted_queue_config_validator"
+require 'securerandom'
 require_relative '../support/helpers'
 
 describe LogStash::PersistedQueueConfigValidator do
@@ -62,7 +63,9 @@ describe LogStash::PersistedQueueConfigValidator do
 
       before do
         # create a 2MB file
-        page_file.truncate(2 ** 21)
+        ::File.open(page_file, 'wb') do |f|
+          f.write( SecureRandom.random_bytes( 2 ** 21 ) )
+        end
       end
 
       it "should throw" do


### PR DESCRIPTION
Fixed: #13957

windows platform fails to generate desired file size with `#truncate()`, hence failing the test.
This branch passed [window test](https://logstash-ci.elastic.co/job/elastic+logstash+main+multijob-windows-compatibility/96/)