### PR TITLE
Fix reload of pipelines via `SIGHUP`

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -314,7 +314,7 @@ class LogStash::Agent
   end
 
   def no_pipeline?
-    @pipelines_registry.running_pipelines.empty?
+    @pipelines_registry.running_pipelines.empty? && @pipelines_registry.loading_pipelines.empty?
   end
 
   private

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -176,7 +176,7 @@ describe LogStash::Agent do
 
             let(:source_loader) { TestSequenceSourceLoader.new(mock_config_pipeline, mock_second_pipeline_config)}
 
-            it "does upgrade the new config" do
+            it "updates to the new config without stopping logstash" do
               t = Thread.new { subject.execute }
               Timeout.timeout(timeout) do
                 sleep(0.1) until subject.running_pipelines_count > 0 && subject.running_pipelines.values.first.ready?
@@ -185,9 +185,13 @@ describe LogStash::Agent do
               expect(subject.converge_state_and_update).to be_a_successful_converge
               expect(subject).to have_running_pipeline?(mock_second_pipeline_config)
 
+              # Previously `transition_to_stopped` would be called - the loading pipeline would
+              # not be detected in the `while !Stud.stop?` loop in agent#execute, and the method would
+              # exit prematurely
+              joined = t.join(1)
+              expect(joined).to be(nil)
               Stud.stop!(t)
               t.join
-              subject.shutdown
             end
           end
 


### PR DESCRIPTION
When logstash is run without automatic reloading, it is still possible to reload configurations
by using 'SIGHUP'. This functionality was broken in #12444, which split non-terminated pipelines
into "loading" and "running" states. The call `no_pipelines?` in agent#execute would no longer
find pipelines in a "loading" state, causing the loop to exit, and logstash to shutdown. This
commit tests for pipelines in a "loading" state to restore functionality


## Release notes
Fix support for reload of pipelines via `SIGHUP`


## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works


## How to test this PR locally

- Run Logstash with `config.reload.automatic` set to `false
- Update pipeline configuration
- `kill -1 <pid>`
- Note that pipeline reloads and logstash stays running

## Related issues

- Closes #13993 
