### PR TITLE
Fix/avoid leak secrects in debug log of ifs

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Rubyfier.java
+++ b/logstash-core/src/main/java/org/logstash/Rubyfier.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import co.elastic.logstash.api.Password;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyBignum;
@@ -41,6 +40,7 @@ import org.jruby.ext.bigdecimal.RubyBigDecimal;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.ext.JrubyTimestampExtLibrary;
+import org.logstash.secret.SecretVariable;
 
 public final class Rubyfier {
 
@@ -132,7 +132,7 @@ public final class Rubyfier {
                 runtime, (Timestamp) input
             )
         );
-        converters.put(Password.class, JAVAUTIL_CONVERTER);
+        converters.put(SecretVariable.class, JAVAUTIL_CONVERTER);
         return converters;
     }
 

--- a/logstash-core/src/main/java/org/logstash/Rubyfier.java
+++ b/logstash-core/src/main/java/org/logstash/Rubyfier.java
@@ -25,6 +25,8 @@ import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
+import co.elastic.logstash.api.Password;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyBignum;
@@ -36,6 +38,7 @@ import org.jruby.RubyNil;
 import org.jruby.RubyString;
 import org.jruby.RubySymbol;
 import org.jruby.ext.bigdecimal.RubyBigDecimal;
+import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.ext.JrubyTimestampExtLibrary;
 
@@ -48,6 +51,9 @@ public final class Rubyfier {
 
     private static final Rubyfier.Converter LONG_CONVERTER =
         (runtime, input) -> runtime.newFixnum(((Number) input).longValue());
+
+    private static final Rubyfier.Converter JAVAUTIL_CONVERTER =
+            JavaUtil::convertJavaToRuby;
 
     private static final Map<Class<?>, Rubyfier.Converter> CONVERTER_MAP = initConverters();
 
@@ -126,6 +132,7 @@ public final class Rubyfier {
                 runtime, (Timestamp) input
             )
         );
+        converters.put(Password.class, JAVAUTIL_CONVERTER);
         return converters;
     }
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
@@ -243,32 +243,40 @@ public final class CompiledPipeline {
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
-    public static Map<String, Object> expandConfigVariables(ConfigVariableExpander cve, Map<String, Object> configArgs) {
+    public static Map<String, Object> expandConfigVariables(ConfigVariableExpander cve, Map<String, Object> configArgs, boolean keepSecrets) {
         Map<String, Object> expandedConfig = new HashMap<>();
         for (Map.Entry<String, Object> e : configArgs.entrySet()) {
-            expandedConfig.put(e.getKey(), expandConfigVariable(cve, e.getValue()));
+            expandedConfig.put(e.getKey(), expandConfigVariable(cve, e.getValue(), keepSecrets));
         }
         return expandedConfig;
     }
 
+    public static Map<String, Object> expandConfigVariables(ConfigVariableExpander cve, Map<String, Object> configArgs) {
+        return expandConfigVariables(cve, configArgs, false);
+    }
+
     @SuppressWarnings({"rawtypes", "unchecked"})
-    public static Object expandConfigVariable(ConfigVariableExpander cve, Object valueToExpand) {
+    public static Object expandConfigVariable(ConfigVariableExpander cve, Object valueToExpand, boolean keepSecrets) {
         if (valueToExpand instanceof List) {
             List list = (List) valueToExpand;
             List<Object> expandedObjects = new ArrayList<>();
             for (Object o : list) {
-                expandedObjects.add(cve.expand(o));
+                expandedObjects.add(cve.expand(o, keepSecrets));
             }
             return expandedObjects;
         }
         if (valueToExpand instanceof Map) {
             // hidden recursion here expandConfigVariables -> expandConfigVariable
-            return expandConfigVariables(cve, (Map<String, Object>) valueToExpand);
+            return expandConfigVariables(cve, (Map<String, Object>) valueToExpand, keepSecrets);
         }
         if (valueToExpand instanceof String) {
-            return cve.expand(valueToExpand);
+            return cve.expand(valueToExpand, keepSecrets);
         }
         return valueToExpand;
+    }
+
+    public static Object expandConfigVariable(ConfigVariableExpander cve, Object valueToExpand) {
+        return expandConfigVariable(cve, valueToExpand, false);
     }
 
     /**

--- a/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
@@ -531,7 +531,7 @@ public final class CompiledPipeline {
                     } else if (isOutput(dependency)) {
                         return outputDataset(dependency, datasets);
                     } else {
-                        // We know that it's an if vertex since the the input children are either
+                        // We know that it's an if vertex since the input children are either
                         // output, filter or if in type.
                         final IfVertex ifvert = (IfVertex) dependency;
                         final SplitDataset ifDataset = split(

--- a/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/CompiledPipeline.java
@@ -275,8 +275,8 @@ public final class CompiledPipeline {
         return valueToExpand;
     }
 
-    public static Object expandConfigVariable(ConfigVariableExpander cve, Object valueToExpand) {
-        return expandConfigVariable(cve, valueToExpand, false);
+    public static Object expandConfigVariableKeepingSecrets(ConfigVariableExpander cve, Object valueToExpand) {
+        return expandConfigVariable(cve, valueToExpand, true);
     }
 
     /**

--- a/logstash-core/src/main/java/org/logstash/config/ir/expression/ExpressionSubstitution.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/expression/ExpressionSubstitution.java
@@ -1,6 +1,5 @@
 package org.logstash.config.ir.expression;
 
-import com.google.common.collect.ImmutableMap;
 import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.CompiledPipeline;
 import org.logstash.config.ir.InvalidIRException;
@@ -8,7 +7,6 @@ import org.logstash.plugins.ConfigVariableExpander;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Map;
 
 public class ExpressionSubstitution {
     /**
@@ -36,10 +34,8 @@ public class ExpressionSubstitution {
                     return constructor.newInstance(unaryBoolExp.getSourceWithMetadata(), substitutedExp);
                 }
             } else if (expression instanceof ValueExpression && !(expression instanceof RegexValueExpression) && (((ValueExpression) expression).get() != null)) {
-                final String key = "placeholder";
-                Map<String, Object> args = ImmutableMap.of(key, ((ValueExpression) expression).get());
-                Map<String, Object> substitutedArgs = CompiledPipeline.expandConfigVariables(cve, args);
-                return new ValueExpression(expression.getSourceWithMetadata(), substitutedArgs.get(key));
+                Object expanded = CompiledPipeline.expandConfigVariable(cve, ((ValueExpression) expression).get());
+                return new ValueExpression(expression.getSourceWithMetadata(), expanded);
             }
 
             return expression;

--- a/logstash-core/src/main/java/org/logstash/config/ir/expression/ExpressionSubstitution.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/expression/ExpressionSubstitution.java
@@ -34,7 +34,7 @@ public class ExpressionSubstitution {
                     return constructor.newInstance(unaryBoolExp.getSourceWithMetadata(), substitutedExp);
                 }
             } else if (expression instanceof ValueExpression && !(expression instanceof RegexValueExpression) && (((ValueExpression) expression).get() != null)) {
-                Object expanded = CompiledPipeline.expandConfigVariable(cve, ((ValueExpression) expression).get());
+                Object expanded = CompiledPipeline.expandConfigVariable(cve, ((ValueExpression) expression).get(), true);
                 return new ValueExpression(expression.getSourceWithMetadata(), expanded);
             }
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/expression/ExpressionSubstitution.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/expression/ExpressionSubstitution.java
@@ -34,7 +34,7 @@ public class ExpressionSubstitution {
                     return constructor.newInstance(unaryBoolExp.getSourceWithMetadata(), substitutedExp);
                 }
             } else if (expression instanceof ValueExpression && !(expression instanceof RegexValueExpression) && (((ValueExpression) expression).get() != null)) {
-                Object expanded = CompiledPipeline.expandConfigVariable(cve, ((ValueExpression) expression).get(), true);
+                Object expanded = CompiledPipeline.expandConfigVariableKeepingSecrets(cve, ((ValueExpression) expression).get());
                 return new ValueExpression(expression.getSourceWithMetadata(), expanded);
             }
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/expression/ValueExpression.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/expression/ValueExpression.java
@@ -24,11 +24,11 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 
-import co.elastic.logstash.api.Password;
 import org.jruby.RubyHash;
 import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.InvalidIRException;
 import org.logstash.config.ir.SourceComponent;
+import org.logstash.secret.SecretVariable;
 
 public class ValueExpression extends Expression {
     protected final Object value;
@@ -47,7 +47,7 @@ public class ValueExpression extends Expression {
                 value instanceof List ||
                 value instanceof RubyHash ||
                 value instanceof Instant ||
-                value instanceof Password
+                value instanceof SecretVariable
         )) {
             // This *should* be caught by the treetop grammar, but we need this case just in case there's a bug
             // somewhere

--- a/logstash-core/src/main/java/org/logstash/config/ir/expression/ValueExpression.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/expression/ValueExpression.java
@@ -23,6 +23,8 @@ package org.logstash.config.ir.expression;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
+
+import co.elastic.logstash.api.Password;
 import org.jruby.RubyHash;
 import org.logstash.common.SourceWithMetadata;
 import org.logstash.config.ir.InvalidIRException;
@@ -44,7 +46,8 @@ public class ValueExpression extends Expression {
                 value instanceof String ||
                 value instanceof List ||
                 value instanceof RubyHash ||
-                value instanceof Instant
+                value instanceof Instant ||
+                value instanceof Password
         )) {
             // This *should* be caught by the treetop grammar, but we need this case just in case there's a bug
             // somewhere

--- a/logstash-core/src/main/java/org/logstash/plugins/ConfigVariableExpander.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/ConfigVariableExpander.java
@@ -20,10 +20,9 @@
 
 package org.logstash.plugins;
 
-import co.elastic.logstash.api.Password;
 import org.logstash.common.EnvironmentVariableProvider;
-import org.logstash.config.ir.expression.ValueExpression;
 import org.logstash.secret.SecretIdentifier;
+import org.logstash.secret.SecretVariable;
 import org.logstash.secret.store.SecretStore;
 
 import java.nio.charset.StandardCharsets;
@@ -91,7 +90,7 @@ public class ConfigVariableExpander implements AutoCloseable {
                 byte[] ssValue = secretStore.retrieveSecret(new SecretIdentifier(variableName));
                 if (ssValue != null) {
                     if (keepSecrets) {
-                        return new Password(new String(ssValue, StandardCharsets.UTF_8));
+                        return new SecretVariable(variableName, new String(ssValue, StandardCharsets.UTF_8));
                     } else {
                         return new String(ssValue, StandardCharsets.UTF_8);
                     }

--- a/logstash-core/src/main/java/org/logstash/plugins/ConfigVariableExpander.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/ConfigVariableExpander.java
@@ -20,6 +20,7 @@
 
 package org.logstash.plugins;
 
+import co.elastic.logstash.api.Password;
 import org.logstash.common.EnvironmentVariableProvider;
 import org.logstash.secret.SecretIdentifier;
 import org.logstash.secret.store.SecretStore;
@@ -87,7 +88,7 @@ public class ConfigVariableExpander implements AutoCloseable {
             if (secretStore != null) {
                 byte[] ssValue = secretStore.retrieveSecret(new SecretIdentifier(variableName));
                 if (ssValue != null) {
-                    return new String(ssValue, StandardCharsets.UTF_8);
+                    return new Password(new String(ssValue, StandardCharsets.UTF_8));
                 }
             }
 

--- a/logstash-core/src/main/java/org/logstash/secret/SecretVariable.java
+++ b/logstash-core/src/main/java/org/logstash/secret/SecretVariable.java
@@ -1,0 +1,36 @@
+package org.logstash.secret;
+
+/**
+ * Value clas to carry the secret key id and secret value.
+ *
+ * Used to avoid inadvertently leak of secrets.
+ * */
+public final class SecretVariable {
+
+    private final String key;
+    private final String secretValue;
+
+    public SecretVariable(String key, String secretValue) {
+        this.key = key;
+        this.secretValue = secretValue;
+    }
+
+    public String getSecretValue() {
+        return secretValue;
+    }
+
+    @Override
+    public String toString() {
+        return "${" +key + "}";
+    }
+
+    // Ruby code compatibility, value attribute
+    public String getValue() {
+        return getSecretValue();
+    }
+
+    // Ruby code compatibility, inspect method
+    public String inspect() {
+        return toString();
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/common/ConfigVariableExpanderTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/ConfigVariableExpanderTest.java
@@ -110,7 +110,8 @@ public class ConfigVariableExpanderTest {
         Assert.assertEquals(evVal, expandedValue);
     }
 
-    private static ConfigVariableExpander getFakeCve(
+    // to be used by test IfVertexTest
+    public static ConfigVariableExpander getFakeCve(
             final Map<String, Object> ssValues, final Map<String, String> envVarValues) {
 
         MemoryStore ms = new MemoryStore();

--- a/logstash-core/src/test/java/org/logstash/common/ConfigVariableExpanderTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/ConfigVariableExpanderTest.java
@@ -86,7 +86,7 @@ public class ConfigVariableExpanderTest {
     }
 
     @Test
-    public void testPrecedenceOfSecretStoreValue() {
+    public void testPrecedenceOfSecretStoreValue() throws Exception {
         String key = "foo";
         String ssVal = "ssbar";
         String evVal = "evbar";
@@ -95,7 +95,21 @@ public class ConfigVariableExpanderTest {
                 Collections.singletonMap(key, ssVal),
                 Collections.singletonMap(key, evVal));
 
-        Object expandedValue = cve.expand("${" + key + ":" + defaultValue + "}");
+        String expandedValue = (String) cve.expand("${" + key + ":" + defaultValue + "}");
+        Assert.assertEquals(ssVal, expandedValue);
+    }
+
+    @Test
+    public void testPrecedenceOfSecretStoreValueKeepingSecrets() {
+        String key = "foo";
+        String ssVal = "ssbar";
+        String evVal = "evbar";
+        String defaultValue = "defaultbar";
+        ConfigVariableExpander cve = getFakeCve(
+                Collections.singletonMap(key, ssVal),
+                Collections.singletonMap(key, evVal));
+
+        Object expandedValue = cve.expand("${" + key + ":" + defaultValue + "}", true);
         Assert.assertThat(expandedValue, instanceOf(Password.class));
         Assert.assertEquals(ssVal, ((Password) expandedValue).getPassword());
     }

--- a/logstash-core/src/test/java/org/logstash/common/ConfigVariableExpanderTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/ConfigVariableExpanderTest.java
@@ -20,6 +20,7 @@
 
 package org.logstash.common;
 
+import co.elastic.logstash.api.Password;
 import org.junit.Assert;
 import org.junit.Test;
 import org.logstash.plugins.ConfigVariableExpander;
@@ -29,6 +30,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.instanceOf;
 import static org.logstash.secret.store.SecretStoreFactoryTest.MemoryStore;
 
 public class ConfigVariableExpanderTest {
@@ -84,7 +86,7 @@ public class ConfigVariableExpanderTest {
     }
 
     @Test
-    public void testPrecedenceOfSecretStoreValue() throws Exception {
+    public void testPrecedenceOfSecretStoreValue() {
         String key = "foo";
         String ssVal = "ssbar";
         String evVal = "evbar";
@@ -93,8 +95,9 @@ public class ConfigVariableExpanderTest {
                 Collections.singletonMap(key, ssVal),
                 Collections.singletonMap(key, evVal));
 
-        String expandedValue = (String) cve.expand("${" + key + ":" + defaultValue + "}");
-        Assert.assertEquals(ssVal, expandedValue);
+        Object expandedValue = cve.expand("${" + key + ":" + defaultValue + "}");
+        Assert.assertThat(expandedValue, instanceOf(Password.class));
+        Assert.assertEquals(ssVal, ((Password) expandedValue).getPassword());
     }
 
     @Test
@@ -110,7 +113,7 @@ public class ConfigVariableExpanderTest {
         Assert.assertEquals(evVal, expandedValue);
     }
 
-    // to be used by test IfVertexTest
+    // used by tests IfVertexTest, EventConditionTest
     public static ConfigVariableExpander getFakeCve(
             final Map<String, Object> ssValues, final Map<String, String> envVarValues) {
 

--- a/logstash-core/src/test/java/org/logstash/common/ConfigVariableExpanderTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/ConfigVariableExpanderTest.java
@@ -20,11 +20,11 @@
 
 package org.logstash.common;
 
-import co.elastic.logstash.api.Password;
 import org.junit.Assert;
 import org.junit.Test;
 import org.logstash.plugins.ConfigVariableExpander;
 import org.logstash.secret.SecretIdentifier;
+import org.logstash.secret.SecretVariable;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -110,8 +110,8 @@ public class ConfigVariableExpanderTest {
                 Collections.singletonMap(key, evVal));
 
         Object expandedValue = cve.expand("${" + key + ":" + defaultValue + "}", true);
-        Assert.assertThat(expandedValue, instanceOf(Password.class));
-        Assert.assertEquals(ssVal, ((Password) expandedValue).getPassword());
+        Assert.assertThat(expandedValue, instanceOf(SecretVariable.class));
+        Assert.assertEquals(ssVal, ((SecretVariable) expandedValue).getSecretValue());
     }
 
     @Test

--- a/logstash-core/src/test/java/org/logstash/config/ir/EventConditionTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/EventConditionTest.java
@@ -21,11 +21,14 @@
 package org.logstash.config.ir;
 
 import org.jruby.RubyArray;
+import org.jruby.runtime.builtin.IRubyObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.logstash.RubyUtil;
+import org.logstash.common.ConfigVariableExpanderTest;
 import org.logstash.common.EnvironmentVariableProvider;
+import org.logstash.common.IncompleteSourceWithMetadataException;
 import org.logstash.ext.JrubyEventExtLibrary;
 import org.logstash.plugins.ConfigVariableExpander;
 
@@ -188,5 +191,44 @@ public final class EventConditionTest extends RubyEnvTestCase {
         return () -> events -> events.forEach(
                 event -> EVENT_SINKS.get(runId).add(event)
         );
+    }
+
+    private Supplier<IRubyObject> nullInputSupplier() {
+        return () -> null;
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void testConditionWithSecretStoreVariable() throws InvalidIRException {
+        ConfigVariableExpander cve = ConfigVariableExpanderTest.getFakeCve(
+                Collections.singletonMap("secret_key", "s3cr3t"), Collections.emptyMap());
+
+        final PipelineIR pipelineIR = ConfigCompiler.configToPipelineIR(
+                IRHelpers.toSourceWithMetadata("input {mockinput{}} " +
+                        "output { " +
+                        "  if [left] == \"${secret_key}\" { " +
+                        "    mockoutput{}" +
+                        "  } }"),
+                false,
+                cve);
+
+        // left and right string values match when right.contains(left)
+        RubyEvent leftIsString1 = RubyEvent.newRubyEvent(RubyUtil.RUBY);
+        leftIsString1.getEvent().setField("left", "s3cr3t");
+
+        RubyArray inputBatch = RubyUtil.RUBY.newArray(leftIsString1);
+
+        new CompiledPipeline(
+                pipelineIR,
+                new CompiledPipelineTest.MockPluginFactory(
+                        Collections.singletonMap("mockinput", nullInputSupplier()),
+                        Collections.emptyMap(), // no filters
+                        Collections.singletonMap("mockoutput", mockOutputSupplier())
+                )
+        ).buildExecution().compute(inputBatch, false, false);
+        final RubyEvent[] outputEvents = EVENT_SINKS.get(runId).toArray(new RubyEvent[0]);
+
+        assertThat(outputEvents.length, is(1));
+        assertThat(outputEvents[0], is(leftIsString1));
     }
 }

--- a/logstash-core/src/test/java/org/logstash/config/ir/EventConditionTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/EventConditionTest.java
@@ -28,7 +28,6 @@ import org.junit.Test;
 import org.logstash.RubyUtil;
 import org.logstash.common.ConfigVariableExpanderTest;
 import org.logstash.common.EnvironmentVariableProvider;
-import org.logstash.common.IncompleteSourceWithMetadataException;
 import org.logstash.ext.JrubyEventExtLibrary;
 import org.logstash.plugins.ConfigVariableExpander;
 

--- a/qa/integration/specs/env_variables_condition_spec.rb
+++ b/qa/integration/specs/env_variables_condition_spec.rb
@@ -60,11 +60,11 @@ describe "Support environment variable in condition" do
   }
   let(:settings_dir) { Stud::Temporary.directory }
   let(:settings) {{"pipeline.id" => "${pipeline.id}"}}
-  let(:logstash_keystore_passowrd) { "keystore_pa9454w3rd" }
+  let(:logstash_keystore_password) { "keystore_pa9454w3rd" }
 
   it "expands variables and evaluate expression successfully" do
     test_env["TEST_ENV_PATH"] = test_path
-    test_env["LOGSTASH_KEYSTORE_PASS"] = logstash_keystore_passowrd
+    test_env["LOGSTASH_KEYSTORE_PASS"] = logstash_keystore_password
 
     @logstash.env_variables = test_env
     @logstash.start_background_with_config_settings(config_to_temp_file(@fixture.config), settings_dir)
@@ -76,7 +76,7 @@ describe "Support environment variable in condition" do
   end
 
   it "expands variables in secret store" do
-    test_env["LOGSTASH_KEYSTORE_PASS"] = logstash_keystore_passowrd
+    test_env["LOGSTASH_KEYSTORE_PASS"] = logstash_keystore_password
     test_env['TAG1'] = "wrong_env" # secret store should take precedence
     logstash = @logstash.run_cmd(["bin/logstash", "-e",
                                   "input { generator { count => 1 } }
@@ -90,7 +90,7 @@ describe "Support environment variable in condition" do
   end
 
   it "exits with error when env variable is undefined" do
-    test_env["LOGSTASH_KEYSTORE_PASS"] = logstash_keystore_passowrd
+    test_env["LOGSTASH_KEYSTORE_PASS"] = logstash_keystore_password
     logstash = @logstash.run_cmd(["bin/logstash","-e", "filter { if \"${NOT_EXIST}\" { mutate {add_tag => \"oh no\"} } }", "--path.settings", settings_dir], true, test_env)
     expect(logstash.stderr_and_stdout).to match(/Cannot evaluate `\$\{NOT_EXIST\}`/)
     expect(logstash.exit_code).to be(1)


### PR DESCRIPTION
## Release notes
Fix the leak of secret store secrets when if statements are printed when started with debug log.

## What does this PR do?
Updates the `ConfigVariableExpander.expand` to selectively create `SecretVariable` instances for SecretStore resolved environment variables.
`SecretVariable` instances in if statements are decrypted during `eq` `EventCondition` compilation; bringing the secret value and using in the comparator.

## Why is it important/What is the impact to the user?
Permit the user to avoid leakage into debug log of secret stores's variables, when used in if conditions.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist
- [x] test with a pipeline and debug log enabled. No leak but the condition should work as expected

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
- create a local secret store
```
bin/logstash-keystore create and save into a variable named `SECRET`
bin/logstash-keystore add SECRET
```
- run Logstash in debug with a pipeline that uses the secret variable
```
input { http { } }

filter {
  if [@metadata][input][http][request][headers][auth] != "${SECRET}" {
    mutate {
      add_field => { "a_secre_field" => "${SECRET}" }
      add_tag => "${SECRET}"
    }
    drop {}
  } 
}


output {
  stdout {codec => rubydebug {metadata => true}}
}
```
- verify your secret isn't leak into the logs (run `bin/logstash -f <pipeline.conf> --debug`)
- verify the pipeline works as expected
```
curl -v  --header "auth: s3cr3t" "localhost:8080"
```
an event should be logged to the console.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Fixes #13685

## Use cases
A user would like to use secret store's resolved variables and avoid to leak in logs/console when Logstash is run with debug or trace levels.

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
Example of secret disclosure launching `bin/logstash --debug`:
```
[2022-04-14T15:40:21,845][INFO ][logstash.javapipeline    ][main] Starting pipeline {:pipeline_id=>"main", "pipeline.workers"=>12, "pipeline.batch.size"=>125, "pipeline.batch.delay"=>50, "pipeline.max_inflight"=>1500, "pipeline.sources"=>["/home/andrea/workspace/logstash_andsel/leak_secret_in_debug_pipeline.conf"], :thread=>"#<Thread:0xab4113a run>"}
[2022-04-14T15:40:22,249][DEBUG][org.logstash.config.ir.CompiledPipeline][main] Compiled conditional
 [if (event.getField('[@metadata][input][http][request][headers][auth]')!='s3cr3t')] 
 into 
 org.logstash.config.ir.compiler.ComputeStepSyntaxElement@9fb449bc
```