### PR TITLE
Make AliasRegistry a singleton

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -167,7 +167,7 @@ dependencies {
     runtimeOnly 'commons-logging:commons-logging:1.2'
     // also handle libraries relying on log4j 1.x to redirect their logs
     runtimeOnly "org.apache.logging.log4j:log4j-1.2-api:${log4jVersion}"
-    implementation('org.reflections:reflections:0.9.11') {
+    implementation('org.reflections:reflections:0.9.12') {
         exclude group: 'com.google.guava', module: 'guava'
     }
     implementation 'commons-codec:commons-codec:1.14'

--- a/logstash-core/lib/logstash/plugins/registry.rb
+++ b/logstash-core/lib/logstash/plugins/registry.rb
@@ -123,7 +123,7 @@ module LogStash module Plugins
       @registry = java.util.concurrent.ConcurrentHashMap.new
       @java_plugins = java.util.concurrent.ConcurrentHashMap.new
       @hooks = HooksRegistry.new
-      @alias_registry = alias_registry || Java::org.logstash.plugins.AliasRegistry.getInstance
+      @alias_registry = alias_registry || Java::org.logstash.plugins.AliasRegistry.instance
     end
 
     def setup!

--- a/logstash-core/lib/logstash/plugins/registry.rb
+++ b/logstash-core/lib/logstash/plugins/registry.rb
@@ -123,7 +123,7 @@ module LogStash module Plugins
       @registry = java.util.concurrent.ConcurrentHashMap.new
       @java_plugins = java.util.concurrent.ConcurrentHashMap.new
       @hooks = HooksRegistry.new
-      @alias_registry = alias_registry || Java::org.logstash.plugins.AliasRegistry.new
+      @alias_registry = alias_registry || Java::org.logstash.plugins.AliasRegistry.getInstance
     end
 
     def setup!

--- a/logstash-core/src/main/java/org/logstash/plugins/AliasRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/AliasRegistry.java
@@ -177,7 +177,15 @@ public class AliasRegistry {
     private final Map<PluginCoordinate, String> aliases = new HashMap<>();
     private final Map<PluginCoordinate, String> reversedAliases = new HashMap<>();
 
-    public AliasRegistry() {
+    private static final AliasRegistry INSTANCE = new AliasRegistry();
+    public static AliasRegistry getInstance() {
+        return INSTANCE;
+    }
+
+    // The Default implementation of AliasRegistry.
+    // This needs to be a singleton as multiple threads accessing may cause the first thread to close the jar file
+    // leading to issues with subsequent threads loading the yaml file.
+    private AliasRegistry() {
         final AliasYamlLoader loader = new AliasYamlLoader();
         final Map<PluginCoordinate, String> defaultDefinitions = loader.loadAliasesDefinitions();
         configurePluginAliases(defaultDefinitions);

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
@@ -20,7 +20,6 @@
 
 package org.logstash.plugins.discovery;
 
-import com.google.common.base.Predicate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.logstash.plugins.AliasRegistry;
@@ -61,18 +60,17 @@ public final class PluginRegistry {
     private final Map<String, Class<Codec>> codecs = new HashMap<>();
     private static final Object LOCK = new Object();
     private static volatile PluginRegistry INSTANCE;
-    private final AliasRegistry aliasRegistry;
+    private final AliasRegistry aliasRegistry = AliasRegistry.getInstance();
 
-    private PluginRegistry(AliasRegistry aliasRegistry) {
-        this.aliasRegistry = aliasRegistry;
+    private PluginRegistry() {
         discoverPlugins();
     }
 
-    public static PluginRegistry getInstance(AliasRegistry aliasRegistry) {
+    public static PluginRegistry getInstance() {
         if (INSTANCE == null) {
             synchronized (LOCK) {
                 if (INSTANCE == null) {
-                    INSTANCE = new PluginRegistry(aliasRegistry);
+                    INSTANCE = new PluginRegistry();
                 }
             }
         }

--- a/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java
@@ -18,7 +18,6 @@ import org.logstash.execution.ExecutionContextExt;
 import org.logstash.instrument.metrics.AbstractMetricExt;
 import org.logstash.instrument.metrics.AbstractNamespacedMetricExt;
 import org.logstash.instrument.metrics.MetricKeys;
-import org.logstash.plugins.AliasRegistry;
 import org.logstash.plugins.ConfigVariableExpander;
 import org.logstash.plugins.PluginLookup;
 import org.logstash.plugins.discovery.PluginRegistry;
@@ -83,7 +82,7 @@ public final class PluginFactoryExt extends RubyBasicObject
     }
 
     public PluginFactoryExt(final Ruby runtime, final RubyClass metaClass) {
-        this(runtime, metaClass, new PluginLookup(PluginRegistry.getInstance(new AliasRegistry())));
+        this(runtime, metaClass, new PluginLookup(PluginRegistry.getInstance()));
     }
 
     PluginFactoryExt(final Ruby runtime, final RubyClass metaClass, PluginResolver pluginResolver) {

--- a/logstash-core/src/test/java/org/logstash/plugins/AliasRegistryTest.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/AliasRegistryTest.java
@@ -16,7 +16,7 @@ public class AliasRegistryTest {
 
     @Test
     public void testLoadAliasesFromYAML() {
-        final AliasRegistry sut = new AliasRegistry();
+        final AliasRegistry sut = AliasRegistry.getInstance();
 
         assertEquals("aliased_input1 should be the alias for beats input",
                 "beats", sut.originalFromAlias(PluginType.INPUT, "aliased_input1"));


### PR DESCRIPTION
The current implementation of AliasRegistry will create an instance of the Alias Registry for each
pipeline, which appears to potentially result in situations, such as in #13996, where multiple pipelines
are simultaneously loading an alias registry from a yaml file in the jar file using getResourceAsStream, with
the potential of the first thread closing the jar file underneath subsequent threads, leading to errors when
reading the yaml file as the JarFile has been closed after the initial thread completed accessing.

This commit changes the AliasRegistry to be a singleton, as is the PluginRegistry.

Relates: #13996, #13666

