### PR TITLE
[doc] Update example ES output configs to reflect DS being default

### DIFF
--- a/docs/static/filebeat-modules.asciidoc
+++ b/docs/static/filebeat-modules.asciidoc
@@ -92,13 +92,10 @@ output {
   }
 }
 -----
-<1> Set the `index` option to `%{[@metadata][beat]}-%{[@metadata][version]}-%{+YYYY.MM.dd}`
-if you are disabling the use of Data Streams in your configuration. Data Streams is
-enabled by default starting from 8.0.
+<1> If data streams are disabled in your configuration, set the `index` option to `%{[@metadata][beat]}-%{[@metadata][version]}-%{+YYYY.MM.dd}`. Data streams are enabled by default.
 <2> If you are disabling the use of Data Streams on your configuration, you can
 remove this setting, or set it to a different value as appropriate.
-<3> Set the `pipeline` option to `%{[@metadata][pipeline]}`. This setting
-configures {ls} to select the correct ingest pipeline based on metadata
+<3> Configures {ls} to select the correct ingest pipeline based on metadata
 passed in the event.
 
 See the {filebeat} {filebeat-ref}/filebeat-modules-overview.html[Modules]

--- a/docs/static/filebeat-modules.asciidoc
+++ b/docs/static/filebeat-modules.asciidoc
@@ -75,7 +75,8 @@ output {
       hosts => "https://061ab24010a2482e9d64729fdb0fd93a.us-east-1.aws.found.io:9243"
       manage_template => false
       index => "%{[@metadata][beat]}-%{[@metadata][version]}" <1>
-      pipeline => "%{[@metadata][pipeline]}" <2>
+      action => "create" <2>
+      pipeline => "%{[@metadata][pipeline]}" <3>
       user => "elastic"
       password => "secret"
     }
@@ -84,6 +85,7 @@ output {
       hosts => "https://061ab24010a2482e9d64729fdb0fd93a.us-east-1.aws.found.io:9243"
       manage_template => false
       index => "%{[@metadata][beat]}-%{[@metadata][version]}" <1>
+      action => "create"
       user => "elastic"
       password => "secret"
     }
@@ -93,7 +95,9 @@ output {
 <1> Set the `index` option to `%{[@metadata][beat]}-%{[@metadata][version]}-%{+YYYY.MM.dd}`
 if you are disabling the use of Data Streams in your configuration. Data Streams is
 enabled by default starting from 8.0.
-<2> Set the `pipeline` option to `%{[@metadata][pipeline]}`. This setting
+<2> If you are disabling the use of Data Streams on your configuration, you can
+remove this setting, or set it to a different value as appropriate.
+<3> Set the `pipeline` option to `%{[@metadata][pipeline]}`. This setting
 configures {ls} to select the correct ingest pipeline based on metadata
 passed in the event.
 

--- a/docs/static/filebeat-modules.asciidoc
+++ b/docs/static/filebeat-modules.asciidoc
@@ -83,14 +83,14 @@ output {
     elasticsearch {
       hosts => "https://061ab24010a2482e9d64729fdb0fd93a.us-east-1.aws.found.io:9243"
       manage_template => false
-      index => "%{[@metadata][beat]}-%{[@metadata][version]}" <3>
+      index => "%{[@metadata][beat]}-%{[@metadata][version]}" <1>
       user => "elastic"
       password => "secret"
     }
   }
 }
 -----
-<1><3> Set the `index` option to `%{[@metadata][beat]}-%{[@metadata][version]}-%{+YYYY.MM.dd}`
+<1> Set the `index` option to `%{[@metadata][beat]}-%{[@metadata][version]}-%{+YYYY.MM.dd}`
 if you are disabling the use of Data Streams in your configuration. Data Streams is
 enabled by default starting from 8.0.
 <2> Set the `pipeline` option to `%{[@metadata][pipeline]}`. This setting

--- a/docs/static/filebeat-modules.asciidoc
+++ b/docs/static/filebeat-modules.asciidoc
@@ -74,8 +74,8 @@ output {
     elasticsearch {
       hosts => "https://061ab24010a2482e9d64729fdb0fd93a.us-east-1.aws.found.io:9243"
       manage_template => false
-      index => "%{[@metadata][beat]}-%{[@metadata][version]}-%{+YYYY.MM.dd}"
-      pipeline => "%{[@metadata][pipeline]}" <1>
+      index => "%{[@metadata][beat]}-%{[@metadata][version]}" <1>
+      pipeline => "%{[@metadata][pipeline]}" <2>
       user => "elastic"
       password => "secret"
     }
@@ -83,14 +83,17 @@ output {
     elasticsearch {
       hosts => "https://061ab24010a2482e9d64729fdb0fd93a.us-east-1.aws.found.io:9243"
       manage_template => false
-      index => "%{[@metadata][beat]}-%{[@metadata][version]}-%{+YYYY.MM.dd}"
+      index => "%{[@metadata][beat]}-%{[@metadata][version]}" <3>
       user => "elastic"
       password => "secret"
     }
   }
 }
 -----
-<1> Set the `pipeline` option to `%{[@metadata][pipeline]}`. This setting
+<1><3> Set the `index` option to `%{[@metadata][beat]}-%{[@metadata][version]}-%{+YYYY.MM.dd}`
+if you are disabling the use of Data Streams in your configuration. Data Streams is
+enabled by default starting from 8.0.
+<2> Set the `pipeline` option to `%{[@metadata][pipeline]}`. This setting
 configures {ls} to select the correct ingest pipeline based on metadata
 passed in the event.
 


### PR DESCRIPTION
## What does this PR do?

Updates the example configuration in https://www.elastic.co/guide/en/logstash/current/use-ingest-pipelines.html, to reflect the fact that elasticsearch output now defaults to Datastreams.

## Why is it important/What is the impact to the user?

It is important because users using defaults, will incorrectly configure their pipeline by using a 'index' setting that can only be used when datastreams is disabled.

Fixes #14008
