### PR TITLE
Fix stopped pipeline unable to be deleted in registry

### DIFF
--- a/logstash-core/lib/logstash/pipeline_action/stop_and_delete.rb
+++ b/logstash-core/lib/logstash/pipeline_action/stop_and_delete.rb
@@ -16,18 +16,27 @@
 # under the License.
 
 require "logstash/pipeline_action/base"
-require "logstash/pipeline_action/create"
-require "logstash/pipeline_action/stop"
-require "logstash/pipeline_action/reload"
-require "logstash/pipeline_action/delete"
-require "logstash/pipeline_action/stop_and_delete"
 
 module LogStash module PipelineAction
-  ORDERING = {
-    LogStash::PipelineAction::Create => 100,
-    LogStash::PipelineAction::Reload => 200,
-    LogStash::PipelineAction::Stop => 300,
-    LogStash::PipelineAction::StopAndDelete => 350,
-    LogStash::PipelineAction::Delete => 400
-  }
+  class StopAndDelete < Base
+    attr_reader :pipeline_id
+
+    def initialize(pipeline_id)
+      @pipeline_id = pipeline_id
+    end
+
+    def execute(agent, pipelines_registry)
+      pipelines_registry.terminate_pipeline(pipeline_id) do |pipeline|
+        pipeline.shutdown
+      end
+
+      success = pipelines_registry.delete_pipeline(@pipeline_id)
+
+      LogStash::ConvergeResult::ActionResult.create(self, success)
+    end
+
+    def to_s
+      "PipelineAction::StopAndDelete<#{pipeline_id}>"
+    end
+  end
 end end

--- a/logstash-core/lib/logstash/state_resolver.rb
+++ b/logstash-core/lib/logstash/state_resolver.rb
@@ -45,7 +45,7 @@ module LogStash
 
       # If one of the running pipeline is not in the pipeline_configs, we assume that we need to
       # stop it and delete it in registry.
-      pipelines_registry.running_pipelines.keys
+      pipelines_registry.running_pipelines(include_loading: true).keys
         .select { |pipeline_id| !configured_pipelines.include?(pipeline_id) }
         .each { |pipeline_id| actions << LogStash::PipelineAction::StopAndDelete.new(pipeline_id) }
 

--- a/logstash-core/lib/logstash/state_resolver.rb
+++ b/logstash-core/lib/logstash/state_resolver.rb
@@ -44,10 +44,10 @@ module LogStash
       configured_pipelines = pipeline_configs.each_with_object(Set.new) { |config, set| set.add(config.pipeline_id.to_sym) }
 
       # If one of the running pipeline is not in the pipeline_configs, we assume that we need to
-      # stop it.
+      # stop it and delete it in registry.
       pipelines_registry.running_pipelines.keys
         .select { |pipeline_id| !configured_pipelines.include?(pipeline_id) }
-        .each { |pipeline_id| actions << LogStash::PipelineAction::Stop.new(pipeline_id) }
+        .each { |pipeline_id| actions << LogStash::PipelineAction::StopAndDelete.new(pipeline_id) }
 
       # If one of the terminated pipeline is not in the pipeline_configs, delete it in registry.
       pipelines_registry.non_running_pipelines.keys

--- a/logstash-core/spec/logstash/agent/converge_spec.rb
+++ b/logstash-core/spec/logstash/agent/converge_spec.rb
@@ -289,7 +289,7 @@ describe LogStash::Agent do
           expect(subject.converge_state_and_update).to be_a_successful_converge
         }.not_to change { subject.running_pipelines_count }
         expect(subject).to have_running_pipeline?(modified_pipeline_config)
-        expect(subject).not_to have_pipeline?(pipeline_config)
+        expect(subject).to have_stopped_pipeline?(pipeline_config)
       end
     end
 

--- a/logstash-core/spec/logstash/state_resolver_spec.rb
+++ b/logstash-core/spec/logstash/state_resolver_spec.rb
@@ -51,7 +51,7 @@ describe LogStash::StateResolver do
 
       it "returns some actions" do
         expect(subject.resolve(pipelines, pipeline_configs)).to have_actions(
-          [:create, :hello_world],
+          [:Create, :hello_world],
         )
       end
     end
@@ -72,17 +72,17 @@ describe LogStash::StateResolver do
 
         it "creates the new one and keep the other one" do
           expect(subject.resolve(pipelines, pipeline_configs)).to have_actions(
-            [:create, :hello_world],
+            [:Create, :hello_world],
           )
         end
 
         context "when the pipeline config contains only the new one" do
           let(:pipeline_configs) { [mock_pipeline_config(:hello_world)] }
 
-          it "creates the new one and stop the old one one" do
+          it "creates the new one and stop and delete the old one one" do
             expect(subject.resolve(pipelines, pipeline_configs)).to have_actions(
-              [:create, :hello_world],
-              [:stop, :main]
+              [:Create, :hello_world],
+              [:StopAndDelete, :main]
             )
           end
         end
@@ -90,9 +90,9 @@ describe LogStash::StateResolver do
         context "when the pipeline config contains no pipeline" do
           let(:pipeline_configs) { [] }
 
-          it "stops the old one one" do
+          it "stops and delete the old one one" do
             expect(subject.resolve(pipelines, pipeline_configs)).to have_actions(
-              [:stop, :main]
+              [:StopAndDelete, :main]
             )
           end
         end
@@ -102,7 +102,7 @@ describe LogStash::StateResolver do
 
           it "reloads the old one one" do
             expect(subject.resolve(pipelines, pipeline_configs)).to have_actions(
-              [:reload, :main]
+              [:Reload, :main]
             )
           end
         end
@@ -134,13 +134,13 @@ describe LogStash::StateResolver do
 
         it "generates actions required to converge" do
           expect(subject.resolve(pipelines, pipeline_configs)).to have_actions(
-            [:create, :main7],
-            [:create, :main9],
-            [:reload, :main3],
-            [:reload, :main5],
-            [:stop, :main2],
-            [:stop, :main4],
-            [:stop, :main6]
+            [:Create, :main7],
+            [:Create, :main9],
+            [:Reload, :main3],
+            [:Reload, :main5],
+            [:StopAndDelete, :main2],
+            [:StopAndDelete, :main4],
+            [:StopAndDelete, :main6]
           )
         end
       end
@@ -159,14 +159,14 @@ describe LogStash::StateResolver do
 
         it "creates the system pipeline before user defined pipelines" do
           expect(subject.resolve(pipelines, pipeline_configs)).to have_actions(
-            [:create, :monitoring],
-            [:create, :main7],
-            [:create, :main9],
-            [:reload, :main3],
-            [:reload, :main5],
-            [:stop, :main2],
-            [:stop, :main4],
-            [:stop, :main6]
+            [:Create, :monitoring],
+            [:Create, :main7],
+            [:Create, :main9],
+            [:Reload, :main3],
+            [:Reload, :main5],
+            [:StopAndDelete, :main2],
+            [:StopAndDelete, :main4],
+            [:StopAndDelete, :main6]
           )
         end
       end
@@ -189,7 +189,7 @@ describe LogStash::StateResolver do
         let(:pipeline_configs) { [mock_pipeline_config(:hello_world), main_pipeline_config ] }
 
         it "creates the new one and keep the other one stop" do
-          expect(subject.resolve(pipelines, pipeline_configs)).to have_actions([:create, :hello_world])
+          expect(subject.resolve(pipelines, pipeline_configs)).to have_actions([:Create, :hello_world])
           expect(pipelines.non_running_pipelines.size).to eq(1)
         end
       end
@@ -198,7 +198,7 @@ describe LogStash::StateResolver do
         let(:pipeline_configs) { [mock_pipeline_config(:main, "input { generator {}}")] }
 
         it "should reload the stopped pipeline" do
-          expect(subject.resolve(pipelines, pipeline_configs)).to have_actions([:reload, :main])
+          expect(subject.resolve(pipelines, pipeline_configs)).to have_actions([:Reload, :main])
         end
       end
 
@@ -206,7 +206,7 @@ describe LogStash::StateResolver do
         let(:pipeline_configs) { [] }
 
         it "should delete the stopped one" do
-          expect(subject.resolve(pipelines, pipeline_configs)).to have_actions([:delete, :main])
+          expect(subject.resolve(pipelines, pipeline_configs)).to have_actions([:Delete, :main])
         end
       end
     end

--- a/logstash-core/spec/support/matchers.rb
+++ b/logstash-core/spec/support/matchers.rb
@@ -79,10 +79,24 @@ RSpec::Matchers.define :have_pipeline? do |pipeline_config|
     pipeline = nil
     try(30) do
       pipeline = agent.get_pipeline(pipeline_config.pipeline_id)
+      expect(pipeline).to be_nil
+    end
+  end
+end
+
+RSpec::Matchers.define :have_stopped_pipeline? do |pipeline_config|
+  match do |agent|
+    pipeline = nil
+    try(30) do
+      pipeline = agent.get_pipeline(pipeline_config.pipeline_id)
       expect(pipeline).to_not be_nil
     end
     # either the pipeline_id is not in the running pipelines OR it is but have different configurations
     expect(!agent.running_pipelines.keys.map(&:to_s).include?(pipeline_config.pipeline_id.to_s) ||  pipeline.config_str != pipeline_config.config_string).to be_truthy
+  end
+
+  match_when_negated do
+    raise "Not implemented"
   end
 end
 

--- a/logstash-core/spec/support/matchers.rb
+++ b/logstash-core/spec/support/matchers.rb
@@ -51,7 +51,7 @@ RSpec::Matchers.define :have_actions do |*expected|
     expect(actual.size).to eq(expected.size)
 
     expected_values = expected.each_with_object([]) do |i, obj|
-      klass_name = "LogStash::PipelineAction::#{i.first.capitalize}"
+      klass_name = "LogStash::PipelineAction::#{i.first}"
       obj << [klass_name, i.last]
     end
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->


## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
This commit makes the `stop` and `delete` pipeline action into a single action to make sure the running pipeline is deleted in registry if central pipeline management delete and recreate pipelines in short period of time

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

Prior to this change, when the source (central pipeline management / kibana) delete a pipeline, the Logstash pipeline state transforms from stop to delete in two converge cycles. If the source recreates the same pipeline between the cycles, the stop pipeline cannot be deleted in registry because Logstash see them as graceful finish.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

 1. In Kibana > Logstash pipelines, create a `test` pipeline
 2. Logstash start with xpack
 3. Delete `test` pipeline in Kibana. Logstash will delete `test` pipeline in the coming converge cycle. The log show `test ` in non_running_pipelines
 4. Before the next converge cycle (default 5s), recreate `test` in Kibana with the same definition
 5. Logstash show `test` in running_pipelines and the `test` pipeline is running

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
Fixed: #14017
Relates: #12414
## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
