### PR TITLE
Fix Bundled JDK docs to reflect JDK 11

### DIFF
--- a/docs/static/jvm.asciidoc
+++ b/docs/static/jvm.asciidoc
@@ -20,7 +20,7 @@ for the official word on supported versions across releases.
 ===== 
 {ls} offers architecture-specific
 https://www.elastic.co/downloads/logstash[downloads] that include
-Adoptium Eclipse Temurin 17, the latest long term support (LTS) release of the JDK.
+Adoptium Eclipse Temurin 11, the latest long term support (LTS) release of the JDK.
 
 Use the LS_JAVA_HOME environment variable if you want to use a JDK other than the
 version that is bundled. 


### PR DESCRIPTION
## What does this PR do?
Fixes a typo in the docs indicating users the bundled JDK is 17, not JDK 11.

## Why is it important/What is the impact to the user?

Because it is leading them to believe that 8.1 and earlier has bundled JDK17 (and not 11 as it currently is).
