### PR TITLE
CI: try different version of GH action

### DIFF
--- a/.github/workflows/add-docs-preview-link.yml
+++ b/.github/workflows/add-docs-preview-link.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
     steps:
     - name: Add Docs Preview link in PR Comment
-      uses: thollander/actions-comment-pull-request@v1
+      uses: thollander/actions-comment-pull-request@v1.0.5
       with:
         message: |
           :page_with_curl: **DOCS PREVIEW** :sparkles: https://logstash_${{ github.event.number }}.docs-preview.app.elstc.co/diff


### PR DESCRIPTION
v1 seems to have started failing with: 
```
Run thollander/actions-comment-pull-request@v1
  with:
    message: :page_with_curl: **DOCS PREVIEW** :sparkles: https://logstash_14019.docs-preview.app.elstc.co/diff
  Note: if you get a "404!" please wait until the elasticsearch ci job finishes.
  
    GITHUB_TOKEN: ***
Error: Resource not accessible by integration
```

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]


TESTED AT https://github.com/elastic/logstash/pull/14037 (the PR has the preview link), seems to back to :green_heart: 