### PR TITLE
Field Reference: handle special characters

### DIFF
--- a/docs/static/field-reference.asciidoc
+++ b/docs/static/field-reference.asciidoc
@@ -4,7 +4,8 @@
 It is often useful to be able to refer to a field or collection of fields by name. To do this,
 you can use the Logstash field reference syntax.
 
-The syntax to access a field specifies the entire path to the field, with each fragment wrapped in square brackets.
+The syntax to access a field specifies the entire path to the field, with each fragment wrapped in square brackets;
+when a field name contains square brackets, they must be properly <<formal-grammar-escape-sequences, _escaped_>>.
 
 _Field References_ can be expressed literally within <<conditionals,_Conditional_>> statements in your pipeline configurations,
 as string arguments to your pipeline plugins, or within sprintf statements that will be used by your pipeline plugins:
@@ -133,3 +134,15 @@ embeddedFieldReference
   ;
 
 An _Embedded Field Reference_ is a _Field Reference_ that is itself wrapped in square brackets (`[` and `]`), and can be a component of a _Composite Field Reference_.
+
+[float]
+[[formal-grammar-escape-sequences]]
+=== Escape Sequences
+
+In order to reference a field whose name contains a character that has special meaning in the field reference grammar, it needs to be escaped.
+Logstash can be globally configured to use one of two field reference escape modes:
+
+ - `NONE` (default): no escape sequence processing is done; fields containing literal square brackets cannot be referenced by the Event API.
+ - `PERCENT`: URI-style percent encoding of UTF-8 bytes; the left square bracket (`[`) is expressed as `%5B`, and the right square bracket (`]`) is expressed as `%5D`.
+// NOTE: the following is _also_ HTML-escaped in the asciidoc source document so that browsers rendering the HTML will unwrap one escape and leave the remaining.
+ - `AMPERSAND`: HTML-style ampersand encoding (`&#` + decimal unicode codepoint + `;`); the left square bracket (`[`) is expressed as `&amp;#91;`, and the right square bracket (`]`) is expressed as `&amp;#93;`.

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -178,6 +178,17 @@ Values other than `disabled` are currently considered BETA, and may produce unin
 | When set to `true`, quoted strings will process the following escape sequences: `\n` becomes a literal newline (ASCII 10). `\r` becomes a literal carriage return (ASCII 13). `\t` becomes a literal tab (ASCII 9). `\\` becomes a literal backslash `\`. `\"` becomes a literal double quotation mark. `\'` becomes a literal quotation mark.
 | `false`
 
+| `config.field_reference.escape_style`
+a| _EXPERIMENTAL_ setting that provides a way to reference fields that contain <<formal-grammar-escape-sequences,field reference special characters>> `[` and `]`.
+
+Current options are:
+
+* `PERCENT`: URI-style `%`+`HH` hexadecimal encoding of UTF-8 bytes (`[` -> `%5B`; `]` -> `%5D`)
+* `AMPERSAND`: HTML-style `&#`+`DD`+`;` encoding of decimal Unicode code-points (`[` -> `&amp;#91;`; `]` -> `&amp;#91;`)
+* `NONE`: field names containing special characters _cannot_ be referenced.
+
+| `NONE`
+
 | `modules`
 | When configured, `modules` must be in the nested YAML structure described above this table.
 | None

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -66,6 +66,14 @@ class LogStash::Agent
     # Generate / load the persistent uuid
     id
 
+    field_reference_escape_style_setting = settings.get_setting('config.field_reference.escape_style')
+    if field_reference_escape_style_setting.set?
+      logger.warn(I18n.t("logstash.settings.experimental.set", canonical_name: field_reference_escape_style_setting.name))
+    end
+    field_reference_escape_style = field_reference_escape_style_setting.value
+    logger.debug("Setting global FieldReference escape style: #{field_reference_escape_style}")
+    org.logstash.FieldReference::set_escape_style(field_reference_escape_style)
+
     # Initialize, but do not start the webserver.
     @webserver = LogStash::WebServer.from_settings(@logger, self, settings)
 

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -49,6 +49,7 @@ module LogStash
            Setting::Boolean.new("config.reload.automatic", false),
            Setting::TimeValue.new("config.reload.interval", "3s"), # in seconds
            Setting::Boolean.new("config.support_escapes", false),
+            Setting::String.new("config.field_reference.escape_style", "NONE", true, %w(NONE PERCENT AMPERSAND)),
            Setting::Boolean.new("metric.collect", true),
             Setting::String.new("pipeline.id", "main"),
            Setting::Boolean.new("pipeline.system", false),

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -87,6 +87,11 @@ class LogStash::Runner < Clamp::StrictCommand
     :default => LogStash::SETTINGS.get_default("config.string"),
     :attribute_name => "config.string"
 
+  option ["--field-reference-escape-style"], "STYLE",
+         I18n.t("logstash.runner.flag.field-reference-escape-style"),
+         :default => LogStash::SETTINGS.get_default("config.field_reference.escape_style"),
+         :attribute_name => "config.field_reference.escape_style"
+
   # Module settings
   option ["--modules"], "MODULES",
     I18n.t("logstash.runner.flag.modules"),

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -219,6 +219,31 @@ en:
           "%{default_output}"
           If you wish to use both defaults, please use
           the empty string for the '-e' flag.
+        field-reference-escape-style: |+
+          Use the given STYLE when parsing field
+          references. This allows you to reference fields
+          whose name includes characters that are
+          meaningful in a field reference including square
+          brackets (`[` and `]`).
+
+          This feature is EXPERIMENTAL, and implementations
+          are subject to change.
+
+          Available escape styles are:
+           - `NONE`: escape sequences in field references
+             are not processed, which means fields that
+             contain special characters cannot be
+             referenced.
+           - `PERCENT`: characters may be encoded with
+             URI-style percent notation represeting UTF-8
+             bytes (`[` is `%5B`; `]` is `%5D`).
+             Unlike URI-encoding, literal percent characters
+             do not need to be escaped unless followed by a
+             sequence of 2 capital hexadecimal characters.
+           - `AMPERSAND`: characters may be encoded with
+             HTML-style ampersand-hash encoding notation
+             representing decimal unicode codepoints
+             (`[` is `&#91;`; `]` is `&#93;`).
         modules: |+
           Load Logstash modules.
           Modules can be defined using multiple instances
@@ -431,4 +456,8 @@ en:
         ambiguous: >-
           Both `%{canonical_name}` and its deprecated alias `%{deprecated_alias}` have been set.
           Please only set `%{canonical_name}`
+      experimental:
+        set: >-
+          The setting `%{canonical_name}` is EXPERIMENTAL and its implementation is subject to change
+          in a future release of Logstash
 

--- a/logstash-core/spec/logstash/event_spec.rb
+++ b/logstash-core/spec/logstash/event_spec.rb
@@ -192,6 +192,15 @@ describe LogStash::Event do
         expect { e.set('[', 'value') }.to raise_exception(::RuntimeError)
       end
     end
+
+    context 'with map value whose keys have FieldReference-special characters' do
+      let(:event) { LogStash::Event.new }
+      let(:value) { {"this[field]" => "okay"} }
+      it 'sets the value correctly' do
+        event.set('[some][field]', value.dup)
+        expect(event.get('[some][field]')).to eq(value)
+      end
+    end
   end
 
   context "timestamp" do
@@ -351,6 +360,11 @@ describe LogStash::Event do
       expect(e.timestamp.to_iso8601).to eq("2016-05-28T23:02:05.350Z")
     end
 
+    it 'accepts maps whose keys contain FieldReference-special characters' do
+      e = LogStash::Event.new({"nested" => {"i][egal" => "okay"}, "n[0]" => "bene"})
+      expect(e.get('nested')).to eq({"i][egal" => "okay"})
+      expect(e.to_hash).to include("n[0]" => "bene")
+    end
   end
 
   context "method missing exception messages" do

--- a/logstash-core/src/main/java/org/logstash/FieldReference.java
+++ b/logstash-core/src/main/java/org/logstash/FieldReference.java
@@ -27,8 +27,10 @@ import java.util.List;
 import java.util.Map;
 
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import org.jruby.RubyString;
+import org.logstash.util.EscapeHandler;
 
 /**
  * Represents a reference to another field of the event {@link Event}
@@ -45,19 +47,39 @@ public final class FieldReference {
         }
     }
 
+    private static EscapeHandler ESCAPE_HANDLER = EscapeHandler.NONE;
+
+    public static void setEscapeStyle(final String escapeStyleSpec) {
+        final EscapeHandler newEscapeHandler;
+        switch(escapeStyleSpec) {
+            case "NONE":
+                newEscapeHandler = EscapeHandler.NONE;
+                break;
+            case "PERCENT":
+                newEscapeHandler = EscapeHandler.PERCENT;
+                break;
+            case "AMPERSAND":
+                newEscapeHandler = EscapeHandler.AMPERSAND;
+                break;
+            default:
+                throw new IllegalArgumentException(String.format("Invalid escape style: `%s`", escapeStyleSpec));
+        }
+        ESCAPE_HANDLER = newEscapeHandler;
+    }
+
     /**
      * This type indicates that the referenced that is the metadata of an {@link Event} found in
-     * {@link Event#metadata}.
+     * {@link Event#getMetadata()}.
      */
     public static final int META_PARENT = 0;
 
     /**
-     * This type indicates that the referenced data must be looked up from {@link Event#metadata}.
+     * This type indicates that the referenced data must be looked up from {@link Event#getMetadata()}.
      */
     public static final int META_CHILD = 1;
 
     /**
-     * This type indicates that the referenced data must be looked up from {@link Event#data}.
+     * This type indicates that the referenced data must be looked up from {@link Event#getData()}.
      */
     private static final int DATA_CHILD = -1;
 
@@ -74,11 +96,6 @@ public final class FieldReference {
     private static final StrictTokenizer TOKENIZER = new StrictTokenizer();
 
     /**
-     * Unique {@link FieldReference} pointing at the timestamp field in a {@link Event}.
-     */
-    public static final FieldReference TIMESTAMP_REFERENCE = FieldReference.from(Event.TIMESTAMP);
-
-    /**
      * Cache of all existing {@link FieldReference} by their {@link RubyString} source.
      */
     private static final Map<RubyString, FieldReference> RUBY_CACHE =
@@ -89,6 +106,11 @@ public final class FieldReference {
      */
     private static final Map<String, FieldReference> CACHE =
         new ConcurrentHashMap<>(64, 0.2F, 1);
+
+    /**
+     * Unique {@link FieldReference} pointing at the timestamp field in a {@link Event}.
+     */
+    public static final FieldReference TIMESTAMP_REFERENCE = FieldReference.from(Event.TIMESTAMP);
 
     private final String[] path;
 
@@ -217,7 +239,9 @@ public final class FieldReference {
     }
 
     private static FieldReference parse(final CharSequence reference) {
-        final List<String> path = TOKENIZER.tokenize(reference);
+        final List<String> path = TOKENIZER.tokenize(reference).stream()
+                .map(ESCAPE_HANDLER::unescape)
+                .collect(Collectors.toList());
 
         final String key = path.remove(path.size() - 1);
         final boolean empty = path.isEmpty();

--- a/logstash-core/src/main/java/org/logstash/util/EscapeHandler.java
+++ b/logstash-core/src/main/java/org/logstash/util/EscapeHandler.java
@@ -1,0 +1,73 @@
+package org.logstash.util;
+
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
+
+public interface EscapeHandler {
+    String unescape(String escaped);
+    String escape(String unescaped);
+
+    EscapeHandler NONE = new EscapeHandler() {
+        @Override
+        public String unescape(final String escaped) {
+            return escaped;
+        }
+
+        @Override
+        public String escape(final String unescaped) {
+            return unescaped;
+        }
+    };
+
+    EscapeHandler PERCENT = new EscapeHandler() {
+        private final Pattern ESCAPE_REQUIRED_PERCENT_LITERAL = Pattern.compile("%(?=[0-9A-F]{2})");
+
+        @Override
+        public String escape(final String unescaped) {
+            // When a percent-literal is followed by a pair of hex digits, we must escape it.
+            return ESCAPE_REQUIRED_PERCENT_LITERAL.matcher(unescaped).replaceAll("%25")
+                    .replace("[", "%5B")
+                    .replace("]", "%5D");
+        }
+
+        private final Pattern PERCENT_ENCODED_SEQUENCE = Pattern.compile("%[0-9A-F]{2}");
+        private final Pattern UNESCAPED_PERCENT_LITERAL = Pattern.compile("%(?![0-9A-F]{2})");
+
+        public String unescape(String escaped) {
+            if (!PERCENT_ENCODED_SEQUENCE.matcher(escaped).find()) { return escaped; }
+
+            // In order to support unescaped percent-literals without implementing
+            // our own percent-decoder, we need to detect them and escape them before
+            // handing off to java's URLDecoder.
+            escaped = UNESCAPED_PERCENT_LITERAL.matcher(escaped).replaceAll("%25");
+
+            return URLDecoder.decode(escaped, StandardCharsets.UTF_8);
+        }
+    };
+
+    EscapeHandler AMPERSAND = new EscapeHandler() {
+        private final Pattern AMPERSAND_ENCODED_SEQUENCE = Pattern.compile("&#([0-9]{2,});");
+
+        @Override
+        public String escape(final String unescaped) {
+            return unescaped.replaceAll(AMPERSAND_ENCODED_SEQUENCE.pattern(), "&#38;#$1;")
+                    .replace("[", "&#91;")
+                    .replace("]", "&#93;");
+        }
+
+        @Override
+        public String unescape(final String escaped) {
+            if (!escaped.contains("&")) { return escaped; }
+
+            return AMPERSAND_ENCODED_SEQUENCE.matcher(escaped).replaceAll(matchResult -> {
+                final int codePoint = Integer.parseInt(matchResult.group(1));
+                final char[] chars = Character.toChars(codePoint);
+                return String.copyValueOf(chars);
+            });
+        }
+    };
+}

--- a/logstash-core/src/test/java/org/logstash/EventTest.java
+++ b/logstash-core/src/test/java/org/logstash/EventTest.java
@@ -157,6 +157,21 @@ public final class EventTest extends RubyTestBase {
     }
 
     @Test
+    public void testFieldThatIsNotAValidNestedFieldReference() throws Exception {
+        Map<String, Object> data = new HashMap<>();
+        data.put("this[key]", "value");
+        final Event e = new Event(data);
+        assertJsonEquals("{\"@timestamp\":\"" + e.getTimestamp().toString() + "\",\"this[key]\":\"value\",\"@version\":\"1\"}", e.toJson());
+    }
+    @Test
+    public void testFieldThatLooksLikeAValidNestedFieldReference() throws Exception {
+        Map<String, Object> data = new HashMap<>();
+        data.put("[deeply][nested][field]", "value");
+        final Event e = new Event(data);
+        assertJsonEquals("{\"@timestamp\":\"" + e.getTimestamp().toString() + "\",\"[deeply][nested][field]\":\"value\",\"@version\":\"1\"}", e.toJson());
+    }
+
+    @Test
     public void testSimpleIntegerFieldToJson() throws Exception {
         Map<String, Object> data = new HashMap<>();
         data.put("foo", 1);

--- a/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
+++ b/logstash-core/src/test/java/org/logstash/FieldReferenceTest.java
@@ -27,6 +27,8 @@ import org.jruby.RubyString;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -34,161 +36,260 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-public final class FieldReferenceTest extends RubyTestBase {
-    @Before
-    @After
-    public void clearInternalCaches() {
-        getInternalCache("CACHE").clear();
-        getInternalCache("DEDUP").clear();
-        getInternalCache("RUBY_CACHE").clear();
-    }
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        FieldReferenceTest.EscapeNone.class,
+        FieldReferenceTest.EscapePercent.class,
+        FieldReferenceTest.EscapeAmpersand.class,
+})
+public final class FieldReferenceTest {
+    private static abstract class Base extends RubyTestBase {
+        public abstract String getEscapeMode();
 
-    @Test
-    public void deduplicatesTimestamp() throws Exception {
-        assertTrue(FieldReference.from("@timestamp") == FieldReference.from("[@timestamp]"));
-    }
-
-    @Test
-    public void testParseEmptyString() {
-        final FieldReference emptyReference = FieldReference.from("");
-        assertNotNull(emptyReference);
-        assertEquals(
-                emptyReference, FieldReference.from(RubyUtil.RUBY.newString(""))
-        );
-    }
-
-    @Test
-    public void testCacheUpperBound() {
-        final Map<String, FieldReference> cache = getInternalCache("CACHE");
-        final int initial = cache.size();
-        for (int i = 0; i < 10_001 - initial; ++i) {
-            FieldReference.from(String.format("[array][%d]", i));
+        @Before
+        public void overrideGlobalEscapeMode() {
+            FieldReference.setEscapeStyle(getEscapeMode());
         }
-        assertThat(cache.size(), CoreMatchers.is(10_000));
-    }
-
-    @Test
-    public void testRubyCacheUpperBound() {
-        final Map<RubyString, FieldReference> cache = getInternalCache("RUBY_CACHE");
-        final int initial = cache.size();
-        for (int i = 0; i < 10_050 - initial; ++i) {
-            final RubyString rubyString = RubyUtil.RUBY.newString(String.format("[array][%d]", i));
-            FieldReference.from(rubyString);
+        @After
+        public void restoreGlobalEscapeMode() {
+            // Default value for `config.field_reference.escape_style`
+            FieldReference.setEscapeStyle("NONE");
         }
-        assertThat(cache.size(), CoreMatchers.is(10_000));
+
+        @Before
+        @After
+        public void clearInternalCaches() {
+            getInternalCache("CACHE").clear();
+            getInternalCache("DEDUP").clear();
+            getInternalCache("RUBY_CACHE").clear();
+        }
+
+        @Test
+        public void deduplicatesTimestamp() throws Exception {
+            assertTrue(FieldReference.from("@timestamp") == FieldReference.from("[@timestamp]"));
+        }
+
+        @Test
+        public void testParseEmptyString() {
+            final FieldReference emptyReference = FieldReference.from("");
+            assertNotNull(emptyReference);
+            assertEquals(
+                    emptyReference, FieldReference.from(RubyUtil.RUBY.newString(""))
+            );
+        }
+
+        @Test
+        public void testCacheUpperBound() {
+            final Map<String, FieldReference> cache = getInternalCache("CACHE");
+            final int initial = cache.size();
+            for (int i = 0; i < 10_001 - initial; ++i) {
+                FieldReference.from(String.format("[array][%d]", i));
+            }
+            assertThat(cache.size(), CoreMatchers.is(10_000));
+        }
+
+        @Test
+        public void testRubyCacheUpperBound() {
+            final Map<RubyString, FieldReference> cache = getInternalCache("RUBY_CACHE");
+            final int initial = cache.size();
+            for (int i = 0; i < 10_050 - initial; ++i) {
+                final RubyString rubyString = RubyUtil.RUBY.newString(String.format("[array][%d]", i));
+                FieldReference.from(rubyString);
+            }
+            assertThat(cache.size(), CoreMatchers.is(10_000));
+        }
+
+        @Test
+        public void testParseSingleBareField() throws Exception {
+            FieldReference f = FieldReference.from("foo");
+            assertEquals(0, f.getPath().length);
+            assertEquals("foo", f.getKey());
+        }
+
+        @Test
+        public void testParseSingleFieldPath() throws Exception {
+            FieldReference f = FieldReference.from("[foo]");
+            assertEquals(0, f.getPath().length);
+            assertEquals("foo", f.getKey());
+        }
+
+        @Test
+        public void testParse2FieldsPath() throws Exception {
+            FieldReference f = FieldReference.from("[foo][bar]");
+            assertArrayEquals(new String[]{"foo"}, f.getPath());
+            assertEquals("bar", f.getKey());
+        }
+
+        @Test
+        public void testParse3FieldsPath() throws Exception {
+            FieldReference f = FieldReference.from("[foo][bar][baz]");
+            assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
+            assertEquals("baz", f.getKey());
+        }
+
+        @Test
+        public void testEmbeddedSingleReference() throws Exception {
+            FieldReference f = FieldReference.from("[[foo]][bar]");
+            assertArrayEquals(new String[]{"foo"}, f.getPath());
+            assertEquals("bar", f.getKey());
+        }
+
+        @Test
+        public void testEmbeddedDeepReference() throws Exception {
+            FieldReference f = FieldReference.from("[[foo][bar]][baz]");
+            assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
+            assertEquals("baz", f.getKey());
+        }
+
+        @Test(expected = FieldReference.IllegalSyntaxException.class)
+        public void testParseInvalidEmbeddedDeepReference() throws Exception {
+            FieldReference f = FieldReference.from("[[foo][bar]nope][baz]");
+        }
+
+        @Test(expected = FieldReference.IllegalSyntaxException.class)
+        public void testParseInvalidEmbeddedDeepReference2() throws Exception {
+            FieldReference f = FieldReference.from("[nope[foo][bar]][baz]");
+        }
+
+        @Test(expected = FieldReference.IllegalSyntaxException.class)
+        public void testParseInvalidNoCloseBracket() throws Exception {
+            FieldReference.from("[foo][bar][baz");
+        }
+
+        @Test(expected = FieldReference.IllegalSyntaxException.class)
+        public void testParseInvalidNoInitialOpenBracket() throws Exception {
+            FieldReference.from("foo[bar][baz]");
+        }
+
+        @Test(expected = FieldReference.IllegalSyntaxException.class)
+        public void testParseInvalidMissingMiddleBracket() throws Exception {
+            FieldReference.from("[foo]bar[baz]");
+        }
+
+        @Test(expected = FieldReference.IllegalSyntaxException.class)
+        public void testParseInvalidOnlyOpenBracket() throws Exception {
+            FieldReference.from("[");
+        }
+
+        @Test(expected = FieldReference.IllegalSyntaxException.class)
+        public void testParseInvalidOnlyCloseBracket() throws Exception {
+            FieldReference.from("]");
+        }
+
+        @Test(expected = FieldReference.IllegalSyntaxException.class)
+        public void testParseInvalidLotsOfOpenBrackets() throws Exception {
+            FieldReference.from("[[[[[[[[[[[]");
+        }
+
+        @Test(expected = FieldReference.IllegalSyntaxException.class)
+        public void testParseInvalidDoubleCloseBrackets() throws Exception {
+            FieldReference.from("[foo]][bar]");
+        }
+
+        @Test(expected = FieldReference.IllegalSyntaxException.class)
+        public void testParseNestingSquareBrackets() throws Exception {
+            FieldReference.from("[this[is]terrible]");
+        }
+
+        @Test(expected = FieldReference.IllegalSyntaxException.class)
+        public void testParseChainedNestingSquareBrackets() throws Exception {
+            FieldReference.from("[this[is]terrible][and][it[should-not[work]]]");
+        }
+
+        @Test(expected = FieldReference.IllegalSyntaxException.class)
+        public void testParseLiteralSquareBrackets() throws Exception {
+            FieldReference.from("this[index]");
+        }
+
+        @SuppressWarnings("unchecked")
+        private <K, V> Map<K, V> getInternalCache(final String fieldName) {
+            final Field cacheField;
+            try {
+                cacheField = FieldReference.class.getDeclaredField(fieldName);
+                cacheField.setAccessible(true);
+                return (Map<K, V>) cacheField.get(null);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 
-    @Test
-    public void testParseSingleBareField() throws Exception {
-        FieldReference f = FieldReference.from("foo");
-        assertEquals(0, f.getPath().length);
-        assertEquals("foo", f.getKey());
+    public static class EscapeNone extends Base {
+
+        @Override
+        public String getEscapeMode() {
+            return "NONE";
+        }
     }
 
-    @Test
-    public void testParseSingleFieldPath() throws Exception {
-        FieldReference f = FieldReference.from("[foo]");
-        assertEquals(0, f.getPath().length);
-        assertEquals("foo", f.getKey());
+    public static class EscapePercent extends Base {
+
+        @Override
+        public String getEscapeMode() {
+            return "PERCENT";
+        }
+
+        @Test
+        public void testReadFieldWithSquareBracketLiteralsInPath() {
+            final FieldReference fr = FieldReference.from("[foo][bar%5Bbingo%5D][okay]");
+            assertEquals(2, fr.getPath().length);
+            assertEquals("foo", fr.getPath()[0]);
+            assertEquals("bar[bingo]", fr.getPath()[1]);
+            assertEquals("okay", fr.getKey());
+        }
+
+        @Test
+        public void testReadFieldWithSquareBracketLiteralsInKey() {
+            final FieldReference fr = FieldReference.from("[foo][okay][bar%5Bbingo%5D]");
+            assertEquals(2, fr.getPath().length);
+            assertEquals("foo", fr.getPath()[0]);
+            assertEquals("okay", fr.getPath()[1]);
+            assertEquals("bar[bingo]", fr.getKey());
+        }
+
+        @Test
+        public void testReadFieldWithPercentLiteralInKey() {
+            final FieldReference fr = FieldReference.from("[foo][bar][95%]");
+            assertEquals(2, fr.getPath().length);
+            assertEquals("foo", fr.getPath()[0]);
+            assertEquals("bar", fr.getPath()[1]);
+            assertEquals("95%", fr.getKey());
+        }
     }
 
-    @Test
-    public void testParse2FieldsPath() throws Exception {
-        FieldReference f = FieldReference.from("[foo][bar]");
-        assertArrayEquals(new String[]{"foo"}, f.getPath());
-        assertEquals("bar", f.getKey());
-    }
+    public static class EscapeAmpersand extends Base {
 
-    @Test
-    public void testParse3FieldsPath() throws Exception {
-        FieldReference f = FieldReference.from("[foo][bar][baz]");
-        assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
-        assertEquals("baz", f.getKey());
-    }
+        @Override
+        public String getEscapeMode() {
+            return "AMPERSAND";
+        }
 
-    @Test
-    public void testEmbeddedSingleReference() throws Exception {
-        FieldReference f = FieldReference.from("[[foo]][bar]");
-        assertArrayEquals(new String[]{"foo"}, f.getPath());
-        assertEquals("bar", f.getKey());
-    }
 
-    @Test
-    public void testEmbeddedDeepReference() throws Exception {
-        FieldReference f = FieldReference.from("[[foo][bar]][baz]");
-        assertArrayEquals(new String[]{"foo", "bar"}, f.getPath());
-        assertEquals("baz", f.getKey());
-    }
+        @Test
+        public void testReadFieldWithSquareBracketLiteralsInPath() {
+            final FieldReference fr = FieldReference.from("[foo][bar&#91;bingo&#93;][okay]");
+            assertEquals(2, fr.getPath().length);
+            assertEquals("foo", fr.getPath()[0]);
+            assertEquals("bar[bingo]", fr.getPath()[1]);
+            assertEquals("okay", fr.getKey());
+        }
 
-    @Test(expected=FieldReference.IllegalSyntaxException.class)
-    public void testParseInvalidEmbeddedDeepReference() throws Exception {
-        FieldReference f = FieldReference.from("[[foo][bar]nope][baz]");
-    }
+        @Test
+        public void testReadFieldWithSquareBracketLiteralsInKey() {
+            final FieldReference fr = FieldReference.from("[foo][okay][bar&#91;bingo&#93;]");
+            assertEquals(2, fr.getPath().length);
+            assertEquals("foo", fr.getPath()[0]);
+            assertEquals("okay", fr.getPath()[1]);
+            assertEquals("bar[bingo]", fr.getKey());
+        }
 
-    @Test(expected=FieldReference.IllegalSyntaxException.class)
-    public void testParseInvalidEmbeddedDeepReference2() throws Exception {
-        FieldReference f = FieldReference.from("[nope[foo][bar]][baz]");
-    }
-
-    @Test(expected=FieldReference.IllegalSyntaxException.class)
-    public void testParseInvalidNoCloseBracket() throws Exception {
-        FieldReference.from("[foo][bar][baz");
-    }
-
-    @Test(expected=FieldReference.IllegalSyntaxException.class)
-    public void testParseInvalidNoInitialOpenBracket() throws Exception {
-        FieldReference.from("foo[bar][baz]");
-    }
-
-    @Test(expected=FieldReference.IllegalSyntaxException.class)
-    public void testParseInvalidMissingMiddleBracket() throws Exception {
-        FieldReference.from("[foo]bar[baz]");
-    }
-
-    @Test(expected=FieldReference.IllegalSyntaxException.class)
-    public void testParseInvalidOnlyOpenBracket() throws Exception {
-        FieldReference.from("[");
-    }
-
-    @Test(expected=FieldReference.IllegalSyntaxException.class)
-    public void testParseInvalidOnlyCloseBracket() throws Exception {
-        FieldReference.from("]");
-    }
-
-    @Test(expected=FieldReference.IllegalSyntaxException.class)
-    public void testParseInvalidLotsOfOpenBrackets() throws Exception {
-        FieldReference.from("[[[[[[[[[[[]");
-    }
-
-    @Test(expected=FieldReference.IllegalSyntaxException.class)
-    public void testParseInvalidDoubleCloseBrackets() throws Exception {
-        FieldReference.from("[foo]][bar]");
-    }
-
-    @Test(expected=FieldReference.IllegalSyntaxException.class)
-    public void testParseNestingSquareBrackets() throws Exception {
-        FieldReference.from("[this[is]terrible]");
-    }
-
-    @Test(expected=FieldReference.IllegalSyntaxException.class)
-    public void testParseChainedNestingSquareBrackets() throws Exception {
-        FieldReference.from("[this[is]terrible][and][it[should-not[work]]]");
-    }
-
-    @Test(expected=FieldReference.IllegalSyntaxException.class)
-    public void testParseLiteralSquareBrackets() throws Exception {
-        FieldReference.from("this[index]");
-    }
-
-    @SuppressWarnings("unchecked")
-    private <K,V> Map<K,V> getInternalCache(final String fieldName) {
-        final Field cacheField;
-        try {
-            cacheField = FieldReference.class.getDeclaredField(fieldName);
-            cacheField.setAccessible(true);
-            return (Map<K, V>) cacheField.get(null);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new RuntimeException(e);
+        @Test
+        public void testReadFieldWithAmpersandLiteralInKey() {
+            final FieldReference fr = FieldReference.from("[foo][bar][this&that]");
+            assertEquals(2, fr.getPath().length);
+            assertEquals("foo", fr.getPath()[0]);
+            assertEquals("bar", fr.getPath()[1]);
+            assertEquals("this&that", fr.getKey());
         }
     }
 }


### PR DESCRIPTION
## Release notes

 - Fixes a long-standing issue where setting a field whose name includes characters that are reserved in the FieldReference syntax (`[` and `]`) had undefined behaviour that resulted in pipeline crashes or the silent truncation of the field name.
 - Introduces two experimental opt-in methods for referencing fields whose names include characters that are reserved in the FieldReference syntax

## What does this PR do?

This PR has three commits that tell a story:

1. Demonstrate previously-unvalidated edge-cases in which FieldReference-special characters in field names result in undesired behaviour:
   | Category | Behaviour | Example |
   | --- | ---- | ---- |
   | Valid field reference | truncate path, leaving only key | `[deeply][nested][square-brackets][field]` -> `field` |
   | Invalid field reference | rejected input, potentially crash | `log[WARN]` |
3. Fixes the Event API's `ConvertedMap` internals so that data structures with fields whose names include FieldReference-special characters (currently `[` and `]`) correctly behave as expected. This has the down-side of allowing fields on an event that _cannot_ be referenced using the FieldReference syntax.
4. Introduces two _EXPERIMENTAL_ opt-in ways of being able to reference fields with special characters in their names. 

## Why is it important/What is the impact to the user?

- Allows plugins that handle as-given data-structures (like the JSON codec) to correctly create events from the events as-given, even if those events contain FieldReference-special characters.
- Provides an experimental path forward for referencing fields whose names contain FieldReference-special characters

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

With the following `pipeline.conf`, we create an event from JSON data that contains a field named `[bracketed][field]`, and attempt to address that field in a variety of ways (field reference literals, sprintf):

~~~
input { generator { count => 1 codec => json message => '{"[bracketed][field]": "okay"}' } }
filter {
  if [bracketed][field] {
    mutate { add_tag => "MATCH-literal" }
  }
  if [%5Bbracketed%5D%5Bfield%5D] {
    mutate { add_tag => "MATCH-percent" }
  }
  if [&#91;bracketed&#93;&#91;field&#93;] {
    mutate { add_tag => "MATCH-ampersand" }
  }
  mutate {
    replace => {
      "sprintf" => "LITERAL:~%{[bracketed][field]}~ PERCENT:~%{%5Bbracketed%5D%5Bfield%5D}~ AMPERSAND:~%{&#91;bracketed&#93;&#91;field&#93;}~"
    }
  }
}
output { stdout { codec => rubydebug } }
~~~

Execute each of the following to observe behaviour:

~~~
bin/logstash -f pipeline.conf
~~~
~~~
bin/logstash -f pipeline.conf --field-reference-escape-style=PERCENT
~~~
~~~
bin/logstash -f pipeline.conf --field-reference-escape-style=AMPERSAND
~~~

## Related issues

Resolves: https://github.com/elastic/logstash/issues/13606
Resolves: https://github.com/elastic/logstash/issues/11608
Supersedes: https://github.com/elastic/logstash/pull/13479
