### PR TITLE
Prevent Logstash from running as root.

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -281,6 +281,9 @@
 #
 # ------------ Other Settings --------------
 #
+# Run Logstash with superuser
+# on_superuser: BLOCK, WARN(default), ALLOW
+#
 # Where to find custom plugins
 # path.plugins: []
 #

--- a/docker/data/logstash/env2yaml/env2yaml.go
+++ b/docker/data/logstash/env2yaml/env2yaml.go
@@ -93,6 +93,7 @@ func normalizeSetting(setting string) (string, error) {
 		"modules",
 		"path.logs",
 		"path.plugins",
+		"on_superuser",
 		"xpack.monitoring.enabled",
 		"xpack.monitoring.collection.interval",
 		"xpack.monitoring.elasticsearch.hosts",

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -313,4 +313,7 @@ separating each log lines per pipeline could be helpful in case you need to trou
   and `NAME` is the name of the plugin.
 | Platform-specific. See <<dir-layout>>.
 
+| `on_superuser`
+| Flag to indicate properly utilizing superuser potentials when running Logstash. Offered options are `WARN`, `BLOCK` and `ALLOW`.
+| `WARN`
 |=======================================================================

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -34,6 +34,7 @@ module LogStash
   end
 
   [
+            Setting::String.new("on_superuser", "WARN", true, ["WARN", "BLOCK", "ALLOW"]),
             Setting::String.new("node.name", Socket.gethostname),
     Setting::NullableString.new("path.config", nil, false),
  Setting::WritableDirectory.new("path.data", ::File.join(LogStash::Environment::LOGSTASH_HOME, "data")),

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -26,6 +26,7 @@ require "logstash/config/modules_common"
 require "logstash/modules/util"
 require "logstash/elasticsearch_client"
 require "json"
+require "webmock/rspec"
 require_relative "../support/helpers"
 require_relative "../support/matchers"
 
@@ -641,6 +642,51 @@ describe LogStash::Runner do
         it "should show help" do
           expect { subject.run(args) }.to raise_error(Clamp::HelpWanted)
         end
+      end
+    end
+  end
+
+  describe "on_superuser" do
+    subject { LogStash::Runner.new("") }
+    let(:args) { ["-e", "input {} output {}"] }
+    let(:deprecation_logger_stub) { double("DeprecationLogger").as_null_object }
+    before(:each) { allow(runner).to receive(:deprecation_logger).and_return(deprecation_logger_stub) }
+
+    context "unintentionally running logstash as root" do
+      before do
+        expect(Process).to receive(:euid).and_return(0)
+      end
+      it "fails with bad exit" do
+        LogStash::SETTINGS.set("on_superuser", "BLOCK")
+        expect(logger).to receive(:fatal) do |msg, hash|
+          expect(msg).to eq("An unexpected error occurred!")
+          expect(hash[:error].to_s).to match("Logstash cannot be run as root.")
+        end
+        expect(subject.run(args)).to eq(1)
+      end
+    end
+
+    context "intentionally running logstash as root " do
+      before do
+        expect(Process).to receive(:euid).and_return(0)
+      end
+      it "runs successfully with warning message" do
+        LogStash::SETTINGS.set("on_superuser", "WARN")
+        expect(logger).not_to receive(:fatal)
+        expect(deprecation_logger_stub).to receive(:deprecated).with(/NOTICE: Running Logstash as root is not recommended and won't be allowed in the future. Set 'on_superuser' to 'BLOCK' to avoid startup errors in future releases./)
+        expect { subject.run(args) }.not_to raise_error
+      end
+    end
+
+    context "running logstash as non-root " do
+      before do
+        expect(Process).to receive(:euid).and_return(100)
+      end
+      it "runs successfully without any messages" do
+        LogStash::SETTINGS.set("on_superuser", "BLOCK")
+        expect(logger).not_to receive(:fatal)
+        expect(deprecation_logger_stub).not_to receive(:deprecated).with(/NOTICE: Running Logstash as root is not recommended and won't be allowed in the future. Set 'on_superuser' to 'BLOCK' to avoid startup errors in future releases./)
+        expect { subject.run(args) }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

## Communication
Please refer to #14019 PR for the history. Upstream rebase merge operation messed the commits, so closed and creating this PR.

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [Docker acceptance tests]: [CI job run succeeded](https://logstash-ci.elastic.co/job/elastic+logstash+main+multijob-docker-acceptance/76/console)
- [Windows acceptance tests]: [CI job run succeeded](https://logstash-ci.elastic.co/job/elastic+logstash+main+multijob-windows-compatibility/115/console)

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Cases:
1. Unintentionally running Logstash as a root
 - `on_superuser: BLOCK` in `logstash.yaml`
 - run with `sudo ./bin/logstash`
 - Output: `[2022-04-26T17:24:52,058][FATAL][logstash.runner          ] An unexpected error occurred! {:error=>#<RuntimeError: Logstash cannot be run as root.>, ...`

2. Intentionally running Logstash as a root
 - `on_superuser: WARN` in `logstash.yaml`
 - run with `sudo ./bin/logstash`
 - Output: `[2022-04-26T17:22:04,373][WARN ][logstash.runner          ] NOTICE: Running logstash as root is not recommended because of security reasons. This will be deprecated in the future.`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #13882

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
```
// unintentionally run as root
[2022-04-26T17:24:52,058][FATAL][logstash.runner] An unexpected error occurred! {:error=>#<RuntimeError: Logstash cannot be run as root.>, ...
```
```
// intentionally run as root, we can see following log in the logstash-deprecation.log file.
[2022-04-27T12:54:07,149][WARN ][deprecation.logstash.runner] NOTICE: Running Logstash as root is not recommended and won't be allowed in the future. Set 'on_superuser' to 'BLOCK' to avoid startup errors in future releases.
```

```
// unit tests
command: $bin/rspec logstash-core/spec/logstash/runner_spec.rb:649
outcome: Finished in 1.78 seconds (files took 11.06 seconds to load)
3 examples, 0 failures
```