### PR TITLE
This commit adds `http_proxy` to geoip database download option to re…

### DIFF
--- a/x-pack/lib/filters/geoip/download_manager.rb
+++ b/x-pack/lib/filters/geoip/download_manager.rb
@@ -93,7 +93,9 @@ module LogStash module Filters module Geoip class DownloadManager
       actual_url = download_url(db_info['url'])
       logger.debug? && logger.debug("download #{actual_url}")
 
-      Down.download(actual_url, destination: zip_path)
+      options = { destination: zip_path }
+      options.merge!({proxy: ENV['http_proxy']}) if ENV.include?('http_proxy')
+      Down.download(actual_url, options)
       raise "the new download has wrong checksum" if md5(zip_path) != db_info['md5_hash']
 
       logger.debug("new database downloaded in ", :path => zip_path)


### PR DESCRIPTION


Fixed: #14047

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Fix geoip database download does not respect `http_proxy` setting

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

add proxy setting to Down lib

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

User can access geoip service via proxy but cannot download because the download action does not respect the proxy setting

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally
1. Start a local proxy with logging enabled. I used `tinyproxy -d -c tinyproxy.conf` with the following config:
    > ~~~
    > Port 1234
    > LogLevel Connect
    > BasicAuth someuser s3cur3cr3dent1als
    > ~~~
    > -- `tinyproxy.conf`

2. Set the `http_proxy` environment variable to point at your local proxy
    > ~~~
    > export http_proxy="http://someuser:s3cur3cr3dent1als@127.0.0.1:1234"
    > ~~~

3. Observe proxy connection in proxy logs:
    > ~~~
    > CONNECT   Apr 28 12:34:07.167 [91904]: Connect (file descriptor 7): 127.0.0.1
    > CONNECT   Apr 28 12:34:07.176 [91904]: Request (file descriptor 7): CONNECT geoip.elastic.co:443 HTTP/1.1
    > CONNECT   Apr 28 12:34:07.183 [91904]: Connect (file descriptor 7): 127.0.0.1
    > CONNECT   Apr 28 12:34:07.193 [91904]: Request (file descriptor 7): CONNECT geoip.elastic.co:443 HTTP/1.1
    > CONNECT   Apr 28 12:34:07.330 [91904]: Established connection to host "geoip.elastic.co" using file descriptor 10.
    > CONNECT   Apr 28 12:35:51.488 [91904]: Connect (file descriptor 7): 127.0.0.1
    > CONNECT   Apr 28 12:35:51.492 [91904]: Request (file descriptor 7): CONNECT geoip.elastic.co:443 HTTP/1.1
    > CONNECT   Apr 28 12:35:51.498 [91904]: Connect (file descriptor 7): 127.0.0.1
    > CONNECT   Apr 28 12:35:51.500 [91904]: Request (file descriptor 7): CONNECT geoip.elastic.co:443 HTTP/1.1
    > CONNECT   Apr 28 12:35:51.615 [91904]: Established connection to host "geoip.elastic.co" using file descriptor 10.
    > CONNECT   Apr 28 12:36:01.012 [91904]: Connect (file descriptor 11): 127.0.0.1
    > CONNECT   Apr 28 12:36:01.014 [91904]: Request (file descriptor 11): CONNECT storage.googleapis.com:443 HTTP/1.1
    > CONNECT   Apr 28 12:36:01.031 [91904]: Established connection to host "storage.googleapis.com" using file descriptor 12.
    > CONNECT   Apr 28 12:36:05.412 [91904]: Connect (file descriptor 11): 127.0.0.1
    > CONNECT   Apr 28 12:36:05.413 [91904]: Request (file descriptor 11): CONNECT storage.googleapis.com:443 HTTP/1.1
    > CONNECT   Apr 28 12:36:05.430 [91904]: Established connection to host "storage.googleapis.com" using file descriptor 12.
    > ~~~
 4. Observe successful lookup in logs:
    > ~~~
    > [2022-04-28T12:38:04,611][INFO ][logstash.filters.geoip   ][[heartbeat_geoip_stdout]-pipeline-manager] Using geoip database {:path=>"/YOUR_LOGSTASH_HOME/data/plugins/filters/geoip/1651145877/GeoLite2-City.mmdb"}
    > ~~~
<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->

Relates: #13410
Fix: #14047

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
