### PR TITLE
Doc: Group central mgmt and configuring central mgmt topics

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -97,8 +97,6 @@ include::static/glob-support.asciidoc[]
 
 include::static/ingest-convert.asciidoc[]
 
-include::static/management/configuring-centralized-pipelines.asciidoc[]
-
 include::static/field-reference.asciidoc[]
 
 //The `field-reference.asciidoc` file (included above) contains a
@@ -113,6 +111,8 @@ include::static/ls-ls-config.asciidoc[]
 
 // Centralized configuration managements
 include::static/config-management.asciidoc[]
+
+include::static/management/configuring-centralized-pipelines.asciidoc[]
 
 // Working with Logstash Modules
 include::static/modules.asciidoc[]

--- a/docs/static/management/configuring-centralized-pipelines.asciidoc
+++ b/docs/static/management/configuring-centralized-pipelines.asciidoc
@@ -1,8 +1,5 @@
 [[configuring-centralized-pipelines]]
-=== Configuring Centralized Pipeline Management
-++++
-<titleabbrev>Centralized Pipeline Management</titleabbrev>
-++++
+=== Configure Centralized Pipeline Management
 
 To configure
 {logstash-ref}/logstash-centralized-pipeline-management.html[centralized pipeline management]:


### PR DESCRIPTION
Our central management topics are split across two sections with links back and forth. The central management content needs some work (see meta issue #14049), but grouping these similar topics is a good first step. 

### Before
<img width="422" alt="Screen Shot 2022-04-28 at 5 08 33 PM" src="https://user-images.githubusercontent.com/35154725/165847503-38261037-bf5f-4ed5-be1b-db6dd2180a6b.png">
     And then two sections later...
<img width="418" alt="Screen Shot 2022-04-28 at 5 08 41 PM" src="https://user-images.githubusercontent.com/35154725/165847532-83241bfa-0683-46ec-96c7-c84ae3f3ef8a.png">


### After
<img width="427" alt="Screen Shot 2022-04-28 at 5 07 36 PM" src="https://user-images.githubusercontent.com/35154725/165847418-0151a3f7-0560-4ac4-b766-9dd7932f4c48.png">