### PR TITLE
Adds DLQ drop counter and last error metrics into management API

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -40,13 +40,10 @@ package org.logstash.common.io;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Comparator;
@@ -71,9 +68,7 @@ import org.logstash.FileLockFactory;
 import org.logstash.Timestamp;
 
 import static org.logstash.common.io.RecordIOReader.SegmentStatus;
-import static org.logstash.common.io.RecordIOWriter.BLOCK_SIZE;
 import static org.logstash.common.io.RecordIOWriter.RECORD_HEADER_SIZE;
-import static org.logstash.common.io.RecordIOWriter.VERSION_SIZE;
 
 public final class DeadLetterQueueWriter implements Closeable {
 
@@ -144,7 +139,7 @@ public final class DeadLetterQueueWriter implements Closeable {
         return storageType.name().toLowerCase(Locale.ROOT);
     }
 
-    public long getDiscardedEvents() {
+    public long getDroppedEvents() {
         return droppedEvents.longValue();
     }
 
@@ -236,64 +231,8 @@ public final class DeadLetterQueueWriter implements Closeable {
         final Path beheadedSegment = oldestSegment.get();
         final long segmentSize = Files.size(beheadedSegment);
         currentQueueSize.add(-segmentSize);
-        try {
-            final long deletedEvents = countEventsInSegment(beheadedSegment);
-            droppedEvents.add(deletedEvents);
-        } finally {
-            Files.delete(beheadedSegment);
-        }
+        Files.delete(beheadedSegment);
         logger.debug("Deleted exceeded retained size segment file {}", beheadedSegment);
-    }
-
-    /**
-     * Count the number of 'c' and 's' records in segment.
-     * An event can't be bigger than the segments so in case of records split across multiple event blocks,
-     * the segment has to contain both the start 's' record, all the middle 'm' up to the end 'e' records.
-     * */
-    @SuppressWarnings("fallthrough")
-    long countEventsInSegment(Path segment) throws IOException {
-        FileChannel channel = FileChannel.open(segment, StandardOpenOption.READ);
-        long countedEvents = 0;
-
-        // verify minimal segment size
-        if (channel.size() < VERSION_SIZE + RECORD_HEADER_SIZE) {
-            return 0L;
-        }
-
-        // skip the DLQ version byte
-        channel.position(1);
-        int posInBlock = 0;
-        int currentBlockIdx = 0;
-        do {
-            ByteBuffer headerBuffer = ByteBuffer.allocate(RECORD_HEADER_SIZE);
-            long startPosition = channel.position();
-            // if record header can't be fully contained in the block, align to the next
-            if (posInBlock + RECORD_HEADER_SIZE + 1 > BLOCK_SIZE) {
-                channel.position((++currentBlockIdx) * BLOCK_SIZE + VERSION_SIZE);
-                posInBlock = 0;
-            }
-
-            channel.read(headerBuffer);
-            headerBuffer.flip();
-            RecordHeader recordHeader = RecordHeader.get(headerBuffer);
-            if (recordHeader == null) {
-                logger.error("Can't decode record header, position {} current post {} current events count {}", startPosition, channel.position(), countedEvents);
-                throw new IllegalStateException("Can't decode record header at position " + startPosition);
-            }
-
-            switch (recordHeader.getType()) {
-                case START:
-                case COMPLETE:
-                    countedEvents++;
-                case MIDDLE:
-                case END: {
-                    channel.position(channel.position() + recordHeader.getSize());
-                    posInBlock += RECORD_HEADER_SIZE + recordHeader.getSize();
-                }
-            }
-        } while (channel.position() < channel.size());
-
-        return countedEvents;
     }
 
     /**

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -203,8 +203,8 @@ public final class DeadLetterQueueWriter implements Closeable {
         int eventPayloadSize = RECORD_HEADER_SIZE + record.length;
         if (currentQueueSize.longValue() + eventPayloadSize > maxQueueSize) {
             if (storageType == QueueStorageType.DROP_NEWER) {
-                logger.error(lastError);
                 lastError = String.format("Cannot write event to DLQ(path: %s): reached maxQueueSize of %d", queuePath, maxQueueSize);
+                logger.error(lastError);
                 droppedEvents.add(1L);
                 return;
             } else {

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -208,6 +208,7 @@ public final class DeadLetterQueueWriter implements Closeable {
         int eventPayloadSize = RECORD_HEADER_SIZE + record.length;
         if (currentQueueSize.longValue() + eventPayloadSize > maxQueueSize) {
             if (storageType == QueueStorageType.DROP_NEWER) {
+                logger.error(lastError);
                 lastError = String.format("Cannot write event to DLQ(path: %s): reached maxQueueSize of %d", queuePath, maxQueueSize);
                 droppedEvents.add(1L);
                 return;
@@ -241,7 +242,7 @@ public final class DeadLetterQueueWriter implements Closeable {
         } finally {
             Files.delete(beheadedSegment);
         }
-        lastError = String.format("Deleted exceeded retained size segment file %s", beheadedSegment);
+        logger.debug("Deleted exceeded retained size segment file {}", beheadedSegment);
     }
 
     /**

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -112,8 +112,8 @@ public class AbstractPipelineExt extends RubyBasicObject {
     private static final RubySymbol STORAGE_POLICY =
             RubyUtil.RUBY.newSymbol("storage_policy");
 
-    private static final RubySymbol DROPPED_EVENTS =
-            RubyUtil.RUBY.newSymbol("dropped_events");
+    private static final RubySymbol DISCARDED_EVENTS =
+            RubyUtil.RUBY.newSymbol("discarded_events");
 
     private static final RubySymbol LAST_ERROR =
             RubyUtil.RUBY.newSymbol("last_error");
@@ -340,8 +340,8 @@ public class AbstractPipelineExt extends RubyBasicObject {
                     context, MAX_QUEUE_SIZE_IN_BYTES,
                     getSetting(context, "dead_letter_queue.max_bytes").convertToInteger());
             getDlqMetric(context).gauge(
-                    context, DROPPED_EVENTS,
-                    dlqWriter(context).callMethod(context, "get_dropped_events")
+                    context, DISCARDED_EVENTS,
+                    dlqWriter(context).callMethod(context, "get_discarded_events")
             );
             getDlqMetric(context).gauge(
                     context, LAST_ERROR,

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -112,8 +112,8 @@ public class AbstractPipelineExt extends RubyBasicObject {
     private static final RubySymbol STORAGE_POLICY =
             RubyUtil.RUBY.newSymbol("storage_policy");
 
-    private static final RubySymbol DISCARDED_EVENTS =
-            RubyUtil.RUBY.newSymbol("discarded_events");
+    private static final RubySymbol DROPPED_EVENTS =
+            RubyUtil.RUBY.newSymbol("dropped_events");
 
     private static final RubySymbol LAST_ERROR =
             RubyUtil.RUBY.newSymbol("last_error");
@@ -340,8 +340,8 @@ public class AbstractPipelineExt extends RubyBasicObject {
                     context, MAX_QUEUE_SIZE_IN_BYTES,
                     getSetting(context, "dead_letter_queue.max_bytes").convertToInteger());
             getDlqMetric(context).gauge(
-                    context, DISCARDED_EVENTS,
-                    dlqWriter(context).callMethod(context, "get_discarded_events")
+                    context, DROPPED_EVENTS,
+                    dlqWriter(context).callMethod(context, "get_dropped_events")
             );
             getDlqMetric(context).gauge(
                     context, LAST_ERROR,

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -115,6 +115,9 @@ public class AbstractPipelineExt extends RubyBasicObject {
     private static final RubySymbol DROPPED_EVENTS =
             RubyUtil.RUBY.newSymbol("dropped_events");
 
+    private static final RubySymbol LAST_ERROR =
+            RubyUtil.RUBY.newSymbol("last_error");
+
     private static final @SuppressWarnings("rawtypes") RubyArray EVENTS_METRIC_NAMESPACE = RubyArray.newArray(
         RubyUtil.RUBY, new IRubyObject[]{MetricKeys.STATS_KEY, MetricKeys.EVENTS_KEY}
     );
@@ -340,7 +343,10 @@ public class AbstractPipelineExt extends RubyBasicObject {
                     context, DROPPED_EVENTS,
                     dlqWriter(context).callMethod(context, "get_dropped_events")
             );
-            // TODO put also the other metrics
+            getDlqMetric(context).gauge(
+                    context, LAST_ERROR,
+                    dlqWriter(context).callMethod(context, "get_last_error")
+            );
         }
         return context.nil;
     }

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -112,6 +112,9 @@ public class AbstractPipelineExt extends RubyBasicObject {
     private static final RubySymbol STORAGE_POLICY =
             RubyUtil.RUBY.newSymbol("storage_policy");
 
+    private static final RubySymbol DROPPED_EVENTS =
+            RubyUtil.RUBY.newSymbol("dropped_events");
+
     private static final @SuppressWarnings("rawtypes") RubyArray EVENTS_METRIC_NAMESPACE = RubyArray.newArray(
         RubyUtil.RUBY, new IRubyObject[]{MetricKeys.STATS_KEY, MetricKeys.EVENTS_KEY}
     );
@@ -330,6 +333,14 @@ public class AbstractPipelineExt extends RubyBasicObject {
                     context, STORAGE_POLICY,
                     dlqWriter(context).callMethod(context, "get_storage_policy")
             );
+            getDlqMetric(context).gauge(
+                    context, MAX_QUEUE_SIZE_IN_BYTES,
+                    getSetting(context, "dead_letter_queue.max_bytes").convertToInteger());
+            getDlqMetric(context).gauge(
+                    context, DROPPED_EVENTS,
+                    dlqWriter(context).callMethod(context, "get_dropped_events")
+            );
+            // TODO put also the other metrics
         }
         return context.nil;
     }

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
@@ -299,6 +299,8 @@ public class DeadLetterQueueWriterTest {
     @Test
     public void testRemoveSegmentsOrder() throws IOException {
         try (DeadLetterQueueWriter sut = new DeadLetterQueueWriter(dir, 10 * MB, 20 * MB, Duration.ofSeconds(1))) {
+            Files.delete(dir.resolve("1.log.tmp"));
+
             // create some segments files
             Files.createFile(dir.resolve("9.log"));
             Files.createFile(dir.resolve("10.log"));
@@ -310,7 +312,6 @@ public class DeadLetterQueueWriterTest {
             final Set<String> segments = Files.list(dir)
                     .map(Path::getFileName)
                     .map(Path::toString)
-                    .filter(s -> !s.endsWith(".tmp")) // skip current writer head file 1.log.tmp
                     .filter(s -> !".lock".equals(s)) // skip .lock file created by writer
                     .collect(Collectors.toSet());
             assertEquals(Collections.singleton("10.log"), segments);

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
@@ -299,8 +299,6 @@ public class DeadLetterQueueWriterTest {
     @Test
     public void testRemoveSegmentsOrder() throws IOException {
         try (DeadLetterQueueWriter sut = new DeadLetterQueueWriter(dir, 10 * MB, 20 * MB, Duration.ofSeconds(1))) {
-            Files.delete(dir.resolve("1.log.tmp"));
-
             // create some segments files
             Files.createFile(dir.resolve("9.log"));
             Files.createFile(dir.resolve("10.log"));
@@ -312,6 +310,7 @@ public class DeadLetterQueueWriterTest {
             final Set<String> segments = Files.list(dir)
                     .map(Path::getFileName)
                     .map(Path::toString)
+                    .filter(s -> !s.endsWith(".tmp")) // skip current writer head file 1.log.tmp
                     .filter(s -> !".lock".equals(s)) // skip .lock file created by writer
                     .collect(Collectors.toSet());
             assertEquals(Collections.singleton("10.log"), segments);

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
@@ -275,7 +275,7 @@ public class DeadLetterQueueWriterTest {
             DLQEntry entry = new DLQEntry(event, "", "", String.format("%05d", (320 * 2) - 1), DeadLetterQueueReaderTest.constantSerializationLengthTimestamp(startTime));
             writeManager.writeEntry(entry);
             beheadedQueueSize = writeManager.getCurrentQueueSize();
-            droppedEvents = writeManager.getDroppedEvents();
+            droppedEvents = writeManager.getDiscardedEvents();
         }
 
         // 1.log with 319
@@ -357,7 +357,7 @@ public class DeadLetterQueueWriterTest {
             // 1.log with 2 events
             // 2.log with 319
             // 3.log with 319
-            assertEquals(2, writeManager.getDroppedEvents());
+            assertEquals(2, writeManager.getDiscardedEvents());
         }
     }
 }

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
@@ -48,6 +48,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -262,6 +263,7 @@ public class DeadLetterQueueWriterTest {
         // with another 32Kb message write we go to write the third file and trigger the 20Mb limit of retained store
         final long prevQueueSize;
         final long beheadedQueueSize;
+        long droppedEvents;
         try (DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, 10 * MB, 20 * MB,
                 Duration.ofSeconds(1), QueueStorageType.DROP_OLDER)) {
             prevQueueSize = writeManager.getCurrentQueueSize();
@@ -274,6 +276,7 @@ public class DeadLetterQueueWriterTest {
             DLQEntry entry = new DLQEntry(event, "", "", String.format("%05d", (320 * 2) - 1), DeadLetterQueueReaderTest.constantSerializationLengthTimestamp(startTime));
             writeManager.writeEntry(entry);
             beheadedQueueSize = writeManager.getCurrentQueueSize();
+            droppedEvents = writeManager.getDroppedEvents();
         }
 
         // 1.log with 319
@@ -290,6 +293,8 @@ public class DeadLetterQueueWriterTest {
                 FULL_SEGMENT_FILE_SIZE; //the size of the removed segment file
         assertEquals("Total queue size must be decremented by the size of the first segment file",
                 expectedQueueSize, beheadedQueueSize);
+        assertEquals("Last events should push off the older segment, incrementing appropriately the drop counter",
+                319, droppedEvents);
     }
 
     @Test
@@ -311,6 +316,47 @@ public class DeadLetterQueueWriterTest {
                     .filter(s -> !".lock".equals(s)) // skip .lock file created by writer
                     .collect(Collectors.toSet());
             assertEquals(Collections.singleton("10.log"), segments);
+        }
+    }
+
+    @Test
+    public void testDropEventCountCorrectlyWithRecordFitEventsAndMultiRecordSpanEvents() throws IOException {
+        Event smallEvent = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(Collections.emptyMap());
+        smallEvent.setField("message", "Hello world!");
+
+        Event bigEvent = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(Collections.emptyMap());
+        bigEvent.setField("message", DeadLetterQueueReaderTest.generateMessageContent(2 * BLOCK_SIZE));
+
+        try (DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, 10 * MB, 20 * MB, Duration.ofSeconds(1))) {
+            // enqueue a record with size smaller than BLOCK_SIZE
+            DLQEntry entry = new DLQEntry(smallEvent, "", "", "00001", DeadLetterQueueReaderTest.constantSerializationLengthTimestamp(System.currentTimeMillis()));
+            assertThat("Serialized entry fills is totally contained in one block", entry.serialize().length, is(lessThan(BLOCK_SIZE)));
+            writeManager.writeEntry(entry);
+
+            // enqueue a record bigger than BLOCK_SIZE
+            entry = new DLQEntry(bigEvent, "", "", "00002", DeadLetterQueueReaderTest.constantSerializationLengthTimestamp(System.currentTimeMillis()));
+            assertThat("Serialized entry has to split in multiple blocks", entry.serialize().length, is(greaterThan(2 * BLOCK_SIZE)));
+            writeManager.writeEntry(entry);
+        }
+
+        // fill the queue to push out the segment with the 2 previous events
+        Event event = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(Collections.emptyMap());
+        event.setField("message", DeadLetterQueueReaderTest.generateMessageContent(32479));
+        try (DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, 10 * MB, 20 * MB, Duration.ofSeconds(1), QueueStorageType.DROP_OLDER)) {
+
+            long startTime = System.currentTimeMillis();
+            // 319 events of 32K generates almost 2 segments of 10 Mb of data
+            for (int i = 0; i < (320 * 2) - 2; i++) {
+                DLQEntry entry = new DLQEntry(event, "", "", String.format("%05d", i), DeadLetterQueueReaderTest.constantSerializationLengthTimestamp(startTime));
+                final int serializationLength = entry.serialize().length;
+                assertEquals("Serialized entry fills block payload", BLOCK_SIZE - RECORD_HEADER_SIZE, serializationLength);
+                writeManager.writeEntry(entry);
+            }
+
+            // 1.log with 2 events
+            // 2.log with 319
+            // 3.log with 319
+            assertEquals(2, writeManager.getDroppedEvents());
         }
     }
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Exposes the counter of events dropped from the DLQ, and the last error reason.

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
Adds some metrics to the dead_letter_queue part of the monitoring endpoint `_node/stats/pipelines/`, precisely under the path `pipelines.<pipeline name>.dead_letter_queue`. The metrics added are:
- `dropped_events`: count the number of dropped events caused by "queue full condition", when `drop_newer` storage policy is enabled, happened to this DLQ since the last restart of Logstash process.
- `last_error`: a string reporting the last error registered for DLQ dropping condition.
-  `max_queue_size`: like for PQ it's the maximum size that the DLQ can reach.

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
The user can monitor the size of the DLQ, the counter of dropped events and the last error message string.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Run a DLQ Logstash pipeline against an always rejecting ES and check with HTTP API the data.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Enable DLQ on `logstash.yml`, use an ES with a closed index (to trigger 404 errors) and use a pipeline to push data into ES closed index. Monitor the HTTP endpoint.

- Enable DLQ in `logstash.yml` with:
```
dead_letter_queue.enable: true
dead_letter_queue.storage_policy: drop_older
dead_letter_queue.max_bytes: 50mb
```
- close an index (`test_index`) in an ES instance
```
POST test_index/_close
```
to reopen:
```
POST test_index/_open
```
- create the sender pipeline:
```
input {
  generator {
    message => '{"name": "John", "surname": "Doe"}'
    codec => json
  }
}

output {
  elasticsearch {
    index => "test_index"
    hosts => "http://localhost:9200"
    user => "elastic"
    password => "changeme"
  }
}
```
- set `pipeline.yml` with
```
- pipeline.id: test_dlq_upstream
  path.config: "/tmp/dlq_upstream.conf"
```
- run logstash `bin/logstash`
- check the monitoring endpoint:
```
curl 'localhost:9600/_node/stats/pipelines/test_dlq_upstream' | jq .pipelines.test_dlq_upstream.dead_letter_queue
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Fixes #14010

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->
A user which enabled DLQ needs to monitor the behavior of the queue to understand when eventually the messages are dropped, and lost without possibility to reprocess.

