### PR TITLE
Fix plugin classloading

### DIFF
--- a/logstash-core/lib/logstash/plugins/registry.rb
+++ b/logstash-core/lib/logstash/plugins/registry.rb
@@ -151,9 +151,9 @@ module LogStash module Plugins
       require "logstash/plugins/builtin"
 
       GemRegistry.logstash_plugins.each do |plugin_context|
-        if plugin_context.spec.metadata.key?('java_plugin') && LogStash::SETTINGS.get_value('pipeline.plugin_classloaders')
+        if plugin_context.spec.metadata.key?('java_plugin')
           # Find *.jar file from the require path
-          jar_files = Dir.glob(plugin_context.spec.full_require_paths.map{|path| "#{path}/**/*.jar"})
+          jar_files = plugin_context.spec.matches_for_glob("**/*.jar")
           expected_jar_name = plugin_context.spec.name + "-" + plugin_context.spec.version.to_s + ".jar"
           if jar_files.length != 1 || !jar_files.first.end_with?(expected_jar_name)
             raise LoadError, "Java plugin '#{plugin_context.spec.name}' does not contain a single jar file with the plugin's name and version"

--- a/logstash-core/lib/logstash/plugins/registry.rb
+++ b/logstash-core/lib/logstash/plugins/registry.rb
@@ -152,7 +152,9 @@ module LogStash module Plugins
 
       GemRegistry.logstash_plugins.each do |plugin_context|
         if plugin_context.spec.metadata.key?('java_plugin')
+          # This jar_files is always be empty if user installed custom java plugin from rubygems.org
           jar_files = plugin_context.spec.files.select {|f| f =~ /.*\.jar/}
+          # if jar_files is empty, logstash will find *.jar files from ${LS_HOME}/vendor/bundle/jruby/2.5.0/gems/${CUSTOM_JAVA_PLUGIN_NAME}/vendor/jar-dependencies
           if jar_files.length == 0
             gem_home = Pathname.new(::File.join(LogStash::Environment::BUNDLE_DIR, "jruby", "2.5.0"))
             plugin_jar_dependencies = "#{gem_home}/gems/#{plugin_context.spec.name}-#{plugin_context.spec.version}/vendor/jar-dependencies"

--- a/logstash-core/lib/logstash/plugins/registry.rb
+++ b/logstash-core/lib/logstash/plugins/registry.rb
@@ -153,6 +153,12 @@ module LogStash module Plugins
       GemRegistry.logstash_plugins.each do |plugin_context|
         if plugin_context.spec.metadata.key?('java_plugin')
           jar_files = plugin_context.spec.files.select {|f| f =~ /.*\.jar/}
+          if jar_files.length == 0
+            gem_home = Pathname.new(::File.join(LogStash::Environment::BUNDLE_DIR, "jruby", "2.5.0"))
+            plugin_jar_dependencies = "#{gem_home}/gems/#{plugin_context.spec.name}-#{plugin_context.spec.version}/vendor/jar-dependencies"
+            jar_files = Dir.glob("#{plugin_jar_dependencies}/**/*.jar")
+          end
+
           expected_jar_name = plugin_context.spec.name + "-" + plugin_context.spec.version.to_s + ".jar"
           if (jar_files.length != 1 || !jar_files[0].end_with?(expected_jar_name))
             raise LoadError, "Java plugin '#{plugin_context.spec.name}' does not contain a single jar file with the plugin's name and version"

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginClassLoader.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginClassLoader.java
@@ -44,18 +44,15 @@ public class PluginClassLoader extends URLClassLoader {
 
     /**
      * Creates an instance of the plugin classloader.
-     * @param gemPath Path to the Ruby gem containing the Java plugin as reported by
-     *                <code>Gem::BasicSpecification#loaded_from</code>.
      * @param jarPath Path to the Java plugin's JAR file relative to {@code gemPath}.
      * @param appClassLoader Application classloader to be used for classes not found
      *                       in the plugin's JAR file.
      * @return New instance of the plugin classloader.
      */
-    public static PluginClassLoader create(String gemPath, String jarPath, ClassLoader appClassLoader) {
-        String pluginPath = gemPath.substring(0, gemPath.lastIndexOf(File.separator)) + File.separator + jarPath;
-        Path pluginJar = Paths.get(pluginPath);
+    public static PluginClassLoader create(String jarPath, ClassLoader appClassLoader) {
+        Path pluginJar = Paths.get(jarPath);
         if (!Files.exists(pluginJar)) {
-            throw new IllegalStateException("PluginClassLoader unable to locate jar file: " + pluginPath);
+            throw new IllegalStateException("PluginClassLoader unable to locate jar file: " + jarPath);
         }
         try {
             URL[] pluginJarUrl = new URL[]{pluginJar.toUri().toURL()};

--- a/logstash-core/src/main/java/org/logstash/plugins/PluginClassLoader.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/PluginClassLoader.java
@@ -44,7 +44,7 @@ public class PluginClassLoader extends URLClassLoader {
 
     /**
      * Creates an instance of the plugin classloader.
-     * @param jarPath Path to the Java plugin's JAR file relative to {@code gemPath}.
+     * @param jarPath Full path to the Java plugin's JAR file.
      * @param appClassLoader Application classloader to be used for classes not found
      *                       in the plugin's JAR file.
      * @return New instance of the plugin classloader.

--- a/qa/integration/fixtures/install_java_plugin_spec.yml
+++ b/qa/integration/fixtures/install_java_plugin_spec.yml
@@ -1,0 +1,13 @@
+---
+services:
+  - logstash
+config: |-
+ input {
+    java_input_example {
+      count => 4
+    }
+    stdin{}
+ }
+ output {
+   null {}
+ }

--- a/qa/integration/specs/install_java_plugin_spec.rb
+++ b/qa/integration/specs/install_java_plugin_spec.rb
@@ -1,0 +1,80 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require_relative '../framework/fixture'
+require_relative '../framework/settings'
+require_relative '../framework/helpers'
+require "logstash/devutils/rspec/spec_helper"
+require "stud/temporary"
+
+describe "Install and run java plugin" do
+
+  before(:all) do
+    @fixture = Fixture.new(__FILE__)
+    @logstash = @fixture.get_service("logstash")
+    @logstash_plugin = @logstash.plugin_cli
+  end
+
+  after(:all) {
+    @logstash.teardown
+    @fixture.teardown
+  }
+
+  after(:each) {
+    # cleanly remove the installed plugin to don't pollute
+    # the environment for other subsequent tests
+    removal = @logstash_plugin.run_raw("bin/logstash-plugin uninstall #{plugin_name}")
+
+    expect(removal.stderr_and_stdout).to match(/Successfully removed #{plugin_name}/)
+    expect(removal.exit_code).to eq(0)
+  }
+
+  let(:max_retry) { 120 }
+  let!(:settings_dir) { Stud::Temporary.directory }
+  let(:plugin_name) { "logstash-input-java_input_example" }
+  let(:install_command) { "bin/logstash-plugin install" }
+
+  it "successfully runs a pipeline with an installed Java plugins" do
+    execute = @logstash_plugin.run_raw("#{install_command} #{plugin_name}")
+
+    expect(execute.stderr_and_stdout).to match(/Installation successful/)
+    expect(execute.exit_code).to eq(0)
+
+    installed = @logstash_plugin.list(plugin_name)
+    expect(installed.stderr_and_stdout).to match(/#{plugin_name}/)
+
+    @logstash.start_background_with_config_settings(config_to_temp_file(@fixture.config), settings_dir)
+
+    # wait for Logstash to start
+    started = false
+    while !started
+      begin
+        sleep(1)
+        result = @logstash.monitoring_api.event_stats
+        started = !result.nil?
+      rescue
+        retry
+      end
+    end
+
+    Stud.try(max_retry.times, RSpec::Expectations::ExpectationNotMetError) do
+      result = @logstash.monitoring_api.event_stats
+      expect(result["in"]).to eq(4)
+    end
+
+  end
+end


### PR DESCRIPTION
Prior to this commit, attempting to use a custom java plugin installed from rubygems would
fail as the `files` field used to find jar files in the gem is not populated for such gems

This commit uses the `full_require_path` to find the jar file for a native jar plugin,
which should work regardless of where the gem was installed from, locally or via rubygems

Additionally, this commit will only attempt to locate the jar file inside the gem when it
is required (only when the experimental separate plugin class loader is used)

This commit builds on the work done in https://github.com/elastic/logstash/pull/13888

Relates: https://github.com/elastic/logstash/pull/13888, https://github.com/elastic/logstash/issues/11305

## Release notes
- Fixes an issue where custom java plugins were unable to be installed and run correctly when retrieved from rubygems.org


## Why is it important/What is the impact to the user?

This PR fixes an issue where custom java plugins from rubygems.org were not able to be installed and used

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

* This requires testing with a custom java plugin published to rubygems, plus a locally installed one
* For my testing of a published gem, I used:

```
./bin/logstash-plugin install logstash-filter-my_java_filter_example        
./bin/logstash -e "input { java_generator { message => 'Hello world!' count => 1 } } filter { my_java_filter_example {} } output { stdout { codec => rubydebug } }" 
```

* For the testing of a local Gem, I pulled down https://github.com/logstash-plugins/logstash-filter-java_filter_example and built locally, and then installed and ran:
```
./bin/logstash-plugin install --no-verify --local ../plugins/logstash-filter-java_filter_example/logstash-filter-java_filter_example-1.0.1.gem
./bin/logstash -e "input { java_generator { message => 'Hello world!' count => 1 } } filter { java_filter_example {} } output { stdout { codec => rubydebug } }" 
``` 

## Related issues

Closes #13888, #11305