### PR TITLE
CI: improve doc-preview action

### DIFF
--- a/.github/workflows/add-docs-preview-link.yml
+++ b/.github/workflows/add-docs-preview-link.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
     steps:
     - name: Add Docs Preview link in PR Comment
-      uses: thollander/actions-comment-pull-request@v1.0.5
+      uses: thollander/actions-comment-pull-request@v1.3.0
       with:
         message: |
           :page_with_curl: **DOCS PREVIEW** :sparkles: https://logstash_${{ github.event.number }}.docs-preview.app.elstc.co/diff

--- a/.github/workflows/add-docs-preview-link.yml
+++ b/.github/workflows/add-docs-preview-link.yml
@@ -10,10 +10,10 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-    - name: Add Docs Preview link in PR Comment
-      uses: thollander/actions-comment-pull-request@v1
-      with:
-        message: |
-          :page_with_curl: **DOCS PREVIEW** :sparkles: https://logstash_${{ github.event.number }}.docs-preview.app.elstc.co/diff
-          Note: if you get a "404!" please wait until the elasticsearch ci job finishes.
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Add Docs Preview link in PR Comment
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+          message: |
+            :page_with_curl: **DOCS PREVIEW** :sparkles: https://logstash_${{ github.event.number }}.docs-preview.app.elstc.co/diff
+            Note: if you get a "404!" please wait until the elasticsearch ci job finishes.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add-docs-preview-link.yml
+++ b/.github/workflows/add-docs-preview-link.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
     steps:
     - name: Add Docs Preview link in PR Comment
-      uses: thollander/actions-comment-pull-request@v1.3.0
+      uses: thollander/actions-comment-pull-request@v1
       with:
         message: |
           :page_with_curl: **DOCS PREVIEW** :sparkles: https://logstash_${{ github.event.number }}.docs-preview.app.elstc.co/diff

--- a/.github/workflows/add-docs-preview-link.yml
+++ b/.github/workflows/add-docs-preview-link.yml
@@ -10,10 +10,18 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - id: wait-for-status
+        uses: autotelic/action-wait-for-status-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          statusName: "elasticsearch-ci/docs"
+          # https://elasticsearch-ci.elastic.co/job/elastic+logstash+pull-request+build-docs
+          # usually finishes in ~ 10 minutes
+          timeoutSeconds: 900
       - name: Add Docs Preview link in PR Comment
+        if: steps.wait-for-status.outputs.state == 'success'
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
             :page_with_curl: **DOCS PREVIEW** :sparkles: https://logstash_${{ github.event.number }}.docs-preview.app.elstc.co/diff
-            NOTE: if you get a "404!" please wait until the elasticsearch ci job finishes.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add-docs-preview-link.yml
+++ b/.github/workflows/add-docs-preview-link.yml
@@ -1,7 +1,7 @@
 name: Docs Preview Link
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
     paths: docs/**
 jobs:
@@ -15,5 +15,5 @@ jobs:
         with:
           message: |
             :page_with_curl: **DOCS PREVIEW** :sparkles: https://logstash_${{ github.event.number }}.docs-preview.app.elstc.co/diff
-            Note: if you get a "404!" please wait until the elasticsearch ci job finishes.
+            NOTE: if you get a "404!" please wait until the elasticsearch ci job finishes.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -318,7 +318,7 @@ separating each log lines per pipeline could be helpful in case you need to trou
 | Platform-specific. See <<dir-layout>>.
 
 | `on_superuser`
-| Setting to `BLOCK` or `ALLOW` running Logstash as a superuser.
+| Setting to `BLOCK` or `ALLOW` running Logstash as a ZUUUPERUUUUSER.
 | `ALLOW`
 
 | `password_policy.mode`

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -318,7 +318,7 @@ separating each log lines per pipeline could be helpful in case you need to trou
 | Platform-specific. See <<dir-layout>>.
 
 | `on_superuser`
-| Setting to `BLOCK` or `ALLOW` running Logstash as a ZUUUPERUUUUSER.
+| Setting to `BLOCK` or `ALLOW` running Logstash as a superuser.
 | `ALLOW`
 
 | `password_policy.mode`


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

The simple idea here is to use `on: pull_request_target` instead of `on: pull_request` - meaning the action will run with credentials as if the PR is opened from the origin (even if the source is from a fork) - the only downside should be that the *workflow.yml* will be always taken from the origin (elastic/logstash) repo, even if updated in the PR!

Second I've added a step to wait till the docs-preview CI finishes on the PR and the comment is only posted afterwards.