### PR TITLE
Fix flaky test, the writer head segment is not a tail segment

### DIFF
--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
@@ -295,8 +295,6 @@ public class DeadLetterQueueWriterTest {
     @Test
     public void testRemoveSegmentsOrder() throws IOException {
         try (DeadLetterQueueWriter sut = new DeadLetterQueueWriter(dir, 10 * MB, 20 * MB, Duration.ofSeconds(1))) {
-            Files.delete(dir.resolve("1.log.tmp"));
-
             // create some segments files
             Files.createFile(dir.resolve("9.log"));
             Files.createFile(dir.resolve("10.log"));
@@ -308,6 +306,7 @@ public class DeadLetterQueueWriterTest {
             final Set<String> segments = Files.list(dir)
                     .map(Path::getFileName)
                     .map(Path::toString)
+                    .filter(s -> !s.endsWith(".tmp")) // skip current writer head file 1.log.tmp
                     .filter(s -> !".lock".equals(s)) // skip .lock file created by writer
                     .collect(Collectors.toSet());
             assertEquals(Collections.singleton("10.log"), segments);


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Fix the test checking condition, deletion of DLQ tail segments files already skips the head `log.tmp` file
