### PR TITLE
[CPM] Fetch pipelines with wildcard IDs from ES and apply.

### DIFF
--- a/x-pack/lib/config_management/elasticsearch_source.rb
+++ b/x-pack/lib/config_management/elasticsearch_source.rb
@@ -53,21 +53,8 @@ module LogStash
       end
 
       # decide using system indices api (7.10+) or legacy api (< 7.10) base on elasticsearch server version
-      def get_pipeline_fetcher
-        retry_handler = ::LogStash::Helpers::LoggableTry.new(logger, 'fetch ES version from Central Management')
-        response = retry_handler.try(10.times, ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError) {
-          client.get("/")
-        }
-
-        if response["error"]
-          raise RemoteConfigError, "Cannot find elasticsearch version, server returned status: `#{response["status"]}`, message: `#{response["error"]}`"
-        end
-
-        logger.debug("Reading configuration from Elasticsearch version {}", response["version"]["number"])
-        version_number = response["version"]["number"].split(".")
-        first = version_number[0].to_i
-        second = version_number[1].to_i
-        (first >= 8 || (first == 7 && second >= 10))? SystemIndicesFetcher.new: LegacyHiddenIndicesFetcher.new
+      def get_pipeline_fetcher(es_version)
+        (es_version[:major] >= 8 || (es_version[:major] == 7 && es_version[:minor] >= 10))? SystemIndicesFetcher.new: LegacyHiddenIndicesFetcher.new
       end
 
       def pipeline_configs
@@ -82,13 +69,28 @@ module LogStash
             return @cached_pipelines
           end
         end
-
-        fetcher = get_pipeline_fetcher
-        fetcher.fetch_config(pipeline_ids, client)
+        es_version = get_es_version
+        fetcher = get_pipeline_fetcher(es_version)
+        fetcher.fetch_config(es_version, pipeline_ids, client)
 
         @cached_pipelines = fetcher.get_pipeline_ids.collect do |pid|
           get_pipeline(pid, fetcher)
         end.compact
+      end
+
+      def get_es_version
+        retry_handler = ::LogStash::Helpers::LoggableTry.new(logger, 'fetch ES version from Central Management')
+        response = retry_handler.try(10.times, ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError) {
+          client.get("/")
+        }
+
+        if response["error"]
+          raise RemoteConfigError, "Cannot find elasticsearch version, server returned status: `#{response["status"]}`, message: `#{response["error"]}`"
+        end
+
+        logger.debug("Reading configuration from Elasticsearch version {}", response["version"]["number"])
+        version_number = response["version"]["number"].split(".")
+        { major: version_number[0].to_i, minor: version_number[1].to_i }
       end
 
       def get_pipeline(pipeline_id, fetcher)
@@ -196,7 +198,7 @@ module LogStash
         @pipelines.keys
       end
 
-      def fetch_config(pipeline_ids, client) end
+      def fetch_config(es_version, pipeline_ids, client) end
       def get_single_pipeline_setting(pipeline_id) end
 
       def log_pipeline_not_found(pipeline_ids)
@@ -209,17 +211,23 @@ module LogStash
 
       SYSTEM_INDICES_API_PATH = "_logstash/pipeline"
 
-      def fetch_config(pipeline_ids, client)
+      def fetch_config(es_version, pipeline_ids, client)
+        does_es_support_wildcard_search = (es_version[:major] > 8) || (es_version[:major] == 8 && es_version[:minor] >= 3)
         retry_handler = ::LogStash::Helpers::LoggableTry.new(logger, 'fetch pipelines from Central Management')
         response = retry_handler.try(10.times, ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError) {
-          client.get("#{SYSTEM_INDICES_API_PATH}/")
+          path = does_es_support_wildcard_search ?
+                   "#{SYSTEM_INDICES_API_PATH}?id=#{pipeline_ids.join(",")}":
+                   "#{SYSTEM_INDICES_API_PATH}/"
+          client.get(path)
         }
 
         if response["error"]
           raise ElasticsearchSource::RemoteConfigError, "Cannot find find configuration for pipeline_id: #{pipeline_ids}, server returned status: `#{response["status"]}`, message: `#{response["error"]}`"
         end
 
-        @pipelines = get_wildcard_pipelines(pipeline_ids, response)
+        @pipelines = does_es_support_wildcard_search ?
+                       response :
+                       get_wildcard_pipelines(pipeline_ids, response)
       end
 
       def get_single_pipeline_setting(pipeline_id)
@@ -260,7 +268,7 @@ module LogStash
 
       PIPELINE_INDEX = ".logstash"
 
-      def fetch_config(pipeline_ids, client)
+      def fetch_config(es_version, pipeline_ids, client)
         request_body_string = LogStash::Json.dump({ "docs" => pipeline_ids.collect { |pipeline_id| { "_id" => pipeline_id } } })
         retry_handler = ::LogStash::Helpers::LoggableTry.new(logger, 'fetch pipelines from Central Management')
         response = retry_handler.try(10.times, ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError) {

--- a/x-pack/spec/config_management/elasticsearch_source_spec.rb
+++ b/x-pack/spec/config_management/elasticsearch_source_spec.rb
@@ -221,6 +221,9 @@ describe LogStash::ConfigManagement::ElasticsearchSource do
     describe "system indices api" do
       let(:mock_client)  { double("http_client") }
       let(:config) { "input { generator { count => 100 } tcp { port => 6005 } } output { }}" }
+      let(:es_version_8_2) { { major:8, minor: 2} }
+      let(:es_version_8_3) { { major:8, minor: 3} }
+      let(:es_version_9_0) { { major:9, minor: 0} }
       let(:pipeline_id) { "super_generator" }
       let(:elasticsearch_response) { {"#{pipeline_id}"=> {"pipeline"=> "#{config}"}} }
       let(:all_pipelines) { JSON.parse(::File.read(::File.join(::File.dirname(__FILE__), "fixtures", "pipelines.json"))) }
@@ -230,54 +233,66 @@ describe LogStash::ConfigManagement::ElasticsearchSource do
         allow(subject).to receive(:logger).and_return(mock_logger)
       }
 
-      it "#fetch_config" do
+      it "#fetch_config from ES v8.2" do
         expect(mock_client).to receive(:get).with("#{described_class::SYSTEM_INDICES_API_PATH}/").and_return(elasticsearch_response.clone)
-        expect(subject.fetch_config([pipeline_id], mock_client)).to eq(elasticsearch_response)
+        expect(subject.fetch_config(es_version_8_2, [pipeline_id], mock_client)).to eq(elasticsearch_response)
+        expect(subject.get_single_pipeline_setting(pipeline_id)).to eq({"pipeline"=>"#{config}"})
+      end
+
+      it "#fetch_config from ES v8.3" do
+        expect(mock_client).to receive(:get).with("#{described_class::SYSTEM_INDICES_API_PATH}?id=#{pipeline_id}").and_return(elasticsearch_response.clone)
+        expect(subject.fetch_config(es_version_8_3, [pipeline_id], mock_client)).to eq(elasticsearch_response)
+        expect(subject.get_single_pipeline_setting(pipeline_id)).to eq({"pipeline"=>"#{config}"})
+      end
+
+      it "#fetch_config from ES v9.0" do
+        expect(mock_client).to receive(:get).with("#{described_class::SYSTEM_INDICES_API_PATH}?id=#{pipeline_id}").and_return(elasticsearch_response.clone)
+        expect(subject.fetch_config(es_version_9_0, [pipeline_id], mock_client)).to eq(elasticsearch_response)
         expect(subject.get_single_pipeline_setting(pipeline_id)).to eq({"pipeline"=>"#{config}"})
       end
 
       it "#fetch_config should raise error" do
         expect(mock_client).to receive(:get).with("#{described_class::SYSTEM_INDICES_API_PATH}/").and_return(elasticsearch_8_err_response.clone)
-        expect{ subject.fetch_config(["apache", "nginx"], mock_client) }.to raise_error(LogStash::ConfigManagement::ElasticsearchSource::RemoteConfigError)
+        expect{ subject.fetch_config(es_version_8_2, ["apache", "nginx"], mock_client) }.to raise_error(LogStash::ConfigManagement::ElasticsearchSource::RemoteConfigError)
       end
 
       describe "wildcard" do
         it "should accept * " do
           expect(mock_client).to receive(:get).with("#{described_class::SYSTEM_INDICES_API_PATH}/").and_return(all_pipelines.clone)
           expect(mock_logger).to receive(:warn).never
-          expect(subject.fetch_config(["*"], mock_client).keys.length).to eq(all_pipelines.keys.length)
+          expect(subject.fetch_config(es_version_8_2, ["*"], mock_client).keys.length).to eq(all_pipelines.keys.length)
         end
 
         it "should accept multiple * in one pattern " do
           expect(mock_client).to receive(:get).with("#{described_class::SYSTEM_INDICES_API_PATH}/").and_return(all_pipelines.clone)
           expect(mock_logger).to receive(:warn).never
-          expect(subject.fetch_config(["host*_pipeline*"], mock_client).keys).to eq(["host1_pipeline1", "host1_pipeline2", "host2_pipeline1", "host2_pipeline2"])
+          expect(subject.fetch_config(es_version_8_2, ["host*_pipeline*"], mock_client).keys).to eq(["host1_pipeline1", "host1_pipeline2", "host2_pipeline1", "host2_pipeline2"])
         end
 
         it "should give unique pipeline with multiple wildcard patterns" do
           expect(mock_client).to receive(:get).with("#{described_class::SYSTEM_INDICES_API_PATH}/").and_return(all_pipelines.clone)
           expect(subject).to receive(:log_pipeline_not_found).with(["*pipeline*"]).exactly(1)
-          expect(subject.fetch_config(["host1_pipeline*", "host2_pipeline*","*pipeline*"], mock_client).keys).to eq(["host1_pipeline1", "host1_pipeline2", "host2_pipeline1", "host2_pipeline2"])
+          expect(subject.fetch_config(es_version_8_2, ["host1_pipeline*", "host2_pipeline*","*pipeline*"], mock_client).keys).to eq(["host1_pipeline1", "host1_pipeline2", "host2_pipeline1", "host2_pipeline2"])
         end
 
         it "should accept a mix of wildcard and non wildcard pattern" do
           expect(mock_client).to receive(:get).with("#{described_class::SYSTEM_INDICES_API_PATH}/").and_return(all_pipelines.clone)
           expect(mock_logger).to receive(:warn).never
-          expect(subject.fetch_config(["host1_pipeline*", "host2_pipeline*","super_generator"], mock_client).keys).to eq(["super_generator", "host1_pipeline1", "host1_pipeline2", "host2_pipeline1", "host2_pipeline2"])
+          expect(subject.fetch_config(es_version_8_2, ["host1_pipeline*", "host2_pipeline*","super_generator"], mock_client).keys).to eq(["super_generator", "host1_pipeline1", "host1_pipeline2", "host2_pipeline1", "host2_pipeline2"])
         end
 
         it "should log unmatched pattern" do
           pipeline_ids = ["very_awesome_pipeline", "*whatever*"]
           expect(mock_client).to receive(:get).with("#{described_class::SYSTEM_INDICES_API_PATH}/").and_return(all_pipelines.clone)
           expect(subject).to receive(:log_pipeline_not_found).with(pipeline_ids).exactly(1)
-          expect(subject.fetch_config(pipeline_ids, mock_client)).to eq({})
+          expect(subject.fetch_config(es_version_8_2, pipeline_ids, mock_client)).to eq({})
         end
 
         it "should log unmatched pattern and return matched pipeline" do
           pipeline_ids = ["very_awesome_pipeline", "*whatever*"]
           expect(mock_client).to receive(:get).with("#{described_class::SYSTEM_INDICES_API_PATH}/").and_return(all_pipelines.clone)
           expect(subject).to receive(:log_pipeline_not_found).with(pipeline_ids).exactly(1)
-          expect(subject.fetch_config(pipeline_ids + [pipeline_id], mock_client)).to eq(elasticsearch_response)
+          expect(subject.fetch_config(es_version_8_2, pipeline_ids + [pipeline_id], mock_client)).to eq(elasticsearch_response)
         end
       end
     end
@@ -290,6 +305,9 @@ describe LogStash::ConfigManagement::ElasticsearchSource do
       let(:mock_client)  { double("http_client") }
       let(:config) { "input { generator { count => 100 } tcp { port => 6005 } } output {  }}" }
       let(:another_config) { "input { generator { count => 100 } tcp { port => 6006 } } output {  }}" }
+      let(:empty_es_version) { {
+        # will not be used
+      } }
       let(:pipeline_id) { "super_generator" }
       let(:another_pipeline_id) { "another_generator" }
       let(:elasticsearch_response) {
@@ -327,7 +345,7 @@ describe LogStash::ConfigManagement::ElasticsearchSource do
       it "#fetch_config" do
         expect(mock_client).to receive(:post).with("#{described_class::PIPELINE_INDEX}/_mget", {}, "{\"docs\":[{\"_id\":\"#{pipeline_id}\"},{\"_id\":\"#{another_pipeline_id}\"}]}").and_return(elasticsearch_response)
         expect(mock_logger).to receive(:warn).never
-        expect(subject.fetch_config([pipeline_id, another_pipeline_id], mock_client).size).to eq(2)
+        expect(subject.fetch_config(empty_es_version, [pipeline_id, another_pipeline_id], mock_client).size).to eq(2)
         expect(subject.get_single_pipeline_setting(pipeline_id)).to eq({"pipeline" => "#{config}"})
         expect(subject.get_single_pipeline_setting(another_pipeline_id)).to eq({"pipeline" => "#{another_config}"})
       end
@@ -335,19 +353,19 @@ describe LogStash::ConfigManagement::ElasticsearchSource do
       it "#fetch_config should raise error" do
         expect(mock_client).to receive(:post).with("#{described_class::PIPELINE_INDEX}/_mget", {}, "{\"docs\":[{\"_id\":\"#{pipeline_id}\"},{\"_id\":\"#{another_pipeline_id}\"}]}").and_return(elasticsearch_7_9_err_response)
         expect(mock_logger).to receive(:warn).never
-        expect{ subject.fetch_config([pipeline_id, another_pipeline_id], mock_client) }.to raise_error(LogStash::ConfigManagement::ElasticsearchSource::RemoteConfigError)
+        expect{ subject.fetch_config(empty_es_version, [pipeline_id, another_pipeline_id], mock_client) }.to raise_error(LogStash::ConfigManagement::ElasticsearchSource::RemoteConfigError)
       end
 
       it "#fetch_config should raise error when response is empty" do
         expect(mock_client).to receive(:post).with("#{described_class::PIPELINE_INDEX}/_mget", {}, "{\"docs\":[{\"_id\":\"#{pipeline_id}\"},{\"_id\":\"#{another_pipeline_id}\"}]}").and_return(LogStash::Json.load("{}"))
-        expect{ subject.fetch_config([pipeline_id, another_pipeline_id], mock_client) }.to raise_error(LogStash::ConfigManagement::ElasticsearchSource::RemoteConfigError)
+        expect{ subject.fetch_config(empty_es_version, [pipeline_id, another_pipeline_id], mock_client) }.to raise_error(LogStash::ConfigManagement::ElasticsearchSource::RemoteConfigError)
       end
 
       it "#fetch_config should log unmatched pipeline id" do
         expect(mock_client).to receive(:post).with("#{described_class::PIPELINE_INDEX}/_mget", {}, "{\"docs\":[{\"_id\":\"#{pipeline_id}\"},{\"_id\":\"#{another_pipeline_id}\"},{\"_id\":\"*\"}]}").and_return(elasticsearch_response)
         expect(subject).to receive(:log_pipeline_not_found).with(["*"]).exactly(1)
         expect(mock_logger).to receive(:warn).with(/is not supported in Elasticsearch version < 7\.10/)
-        expect(subject.fetch_config([pipeline_id, another_pipeline_id, "*"], mock_client).size).to eq(2)
+        expect(subject.fetch_config(empty_es_version, [pipeline_id, another_pipeline_id, "*"], mock_client).size).to eq(2)
         expect(subject.get_single_pipeline_setting(pipeline_id)).to eq({"pipeline" => "#{config}"})
         expect(subject.get_single_pipeline_setting(another_pipeline_id)).to eq({"pipeline" => "#{another_config}"})
       end
@@ -696,23 +714,16 @@ describe LogStash::ConfigManagement::ElasticsearchSource do
     end
 
     describe "create pipeline fetcher by es version" do
-      before do
-        expect_any_instance_of(described_class).to receive(:build_client).and_return(mock_client)
-      end
-
       it "should give SystemIndicesFetcher in [8]" do
-        allow(mock_client).to receive(:get).with("/").and_return(es_version_response)
-        expect(subject.get_pipeline_fetcher).to be_an_instance_of LogStash::ConfigManagement::SystemIndicesFetcher
+        expect(subject.get_pipeline_fetcher({ major:8, minor:2 })).to be_an_instance_of LogStash::ConfigManagement::SystemIndicesFetcher
       end
 
       it "should give SystemIndicesFetcher in [7.10]" do
-        allow(mock_client).to receive(:get).with("/").and_return(generate_es_version_response("7.10.0-SNAPSHOT"))
-        expect(subject.get_pipeline_fetcher).to be_an_instance_of LogStash::ConfigManagement::SystemIndicesFetcher
+        expect(subject.get_pipeline_fetcher({ major:7, minor:10 })).to be_an_instance_of LogStash::ConfigManagement::SystemIndicesFetcher
       end
 
       it "should give LegacyHiddenIndicesFetcher in [7.9]" do
-        allow(mock_client).to receive(:get).with("/").and_return(es_version_7_9_response)
-        expect(subject.get_pipeline_fetcher).to be_an_instance_of LogStash::ConfigManagement::LegacyHiddenIndicesFetcher
+        expect(subject.get_pipeline_fetcher({ major:7, minor:9 })).to be_an_instance_of LogStash::ConfigManagement::LegacyHiddenIndicesFetcher
       end
     end
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Now Logstash is able to fetch pipelines from Central Pipeline Management based on its pipeline IDs, including wildcard ones.

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

Improves loading pipeline configurations from CPM where now Logstash loads only ROI configurations based on its pipeline IDs.

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Backward compatibility with any ES versions

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
- Unit tests
```
bin/rspec x-pack/spec/config_management/elasticsearch_source_spec.rb:418 x-pack/spec/support/helpers.rb
```
- Enable CPM management in `logstash.yml` file
```
xpack.management.enabled: true
xpack.management.pipeline.id: ["main", "exampleWildcardPipe*", "*agentsPipeline*"]
```
And run Logstash (`bin/logstash`). Logstash will load `main` and any pipelines starts with `exampleWildcardPipe` (eg: exampleWildcardPipeline1) from CPM (if exists).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #13868

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->
- ES is supposed to support wildcard search feature (see [the PR](https://github.com/elastic/elasticsearch/pull/85847)) from `8.3` version. So, Logstash should be a backward compatible with any ES versions.
- If greater than `8.3` pipelines ID will be queried against ES, otherwise Logstash will fetch all pipelines and filter locally as it is doing now.

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
```
[2022-05-06T19:52:13,208][WARN ][logstash.configmanagement.systemindicesfetcher] does_es_support_wildcard_search: true
[2022-05-06T19:52:13,274][WARN ][logstash.configmanagement.systemindicesfetcher] RESPONSE: {"mashhur1236"=>{"last_modified"=>"2022-05-06T14:23:43.066996", "username"=>"mashhurs", "pipeline_metadata"=>{"version"=>1, "type"=>"logstash_pipeline"}, "pipeline_settings"=>{"pipeline.workers"=>"1"}, "pipeline"=>"input { stdin { } } output { stdout {} }"}, "mashhur1237"=>{"last_modified"=>"2022-05-06T14:23:43.066997", "username"=>"mashhurs", "pipeline_metadata"=>{"version"=>1, "type"=>"logstash_pipeline"}, "pipeline_settings"=>{"pipeline.workers"=>"1"}, "pipeline"=>"input { stdin { } } output { stdout {} }"}, "mashhur1238"=>{"last_modified"=>"2022-05-06T14:23:43.066998", "username"=>"mashhurs", "pipeline_metadata"=>{"version"=>1, "type"=>"logstash_pipeline"}, "pipeline_settings"=>{"pipeline.workers"=>"1"}, "pipeline"=>"input { stdin { } } output { stdout {} }"}, "mashhur1239"=>{"last_modified"=>"2022-05-06T14:23:43.066998", "username"=>"mashhurs", "pipeline_metadata"=>{"version"=>1, "type"=>"logstash_pipeline"}, "pipeline_settings"=>{"pipeline.workers"=>"1"}, "pipeline"=>"input { stdin { } } output { stdout {} }"}, "mashhur1230"=>{"last_modified"=>"2022-05-06T14:23:43.066991", "username"=>"mashhurs", "pipeline_metadata"=>{"version"=>1, "type"=>"logstash_pipeline"}, "pipeline_settings"=>{"pipeline.workers"=>"1"}, "pipeline"=>"input { stdin { } } output { stdout {} }"}, "mashhur1231"=>{"last_modified"=>"2022-05-06T14:23:43.066991", "username"=>"mashhurs", "pipeline_metadata"=>{"version"=>1, "type"=>"logstash_pipeline"}, "pipeline_settings"=>{"pipeline.workers"=>"1"}, "pipeline"=>"input { stdin { } } output { stdout {} }"}, "mashhur1232"=>{"last_modified"=>"2022-05-06T14:23:43.066993", "username"=>"mashhurs", "pipeline_metadata"=>{"version"=>1, "type"=>"logstash_pipeline"}, "pipeline_settings"=>{"pipeline.workers"=>"1"}, "pipeline"=>"input { stdin { } } output { stdout {} }"}, "mashhur1233"=>{"last_modified"=>"2022-05-06T14:23:43.066994", "username"=>"mashhurs", "pipeline_metadata"=>{"version"=>1, "type"=>"logstash_pipeline"}, "pipeline_settings"=>{"pipeline.workers"=>"1"}, "pipeline"=>"input { stdin { } } output { stdout {} }"}, "mashhur1234"=>{"last_modified"=>"2022-05-06T14:23:43.066995", "username"=>"mashhurs", "pipeline_metadata"=>{"version"=>1, "type"=>"logstash_pipeline"}, "pipeline_settings"=>{"pipeline.workers"=>"1"}, "pipeline"=>"input { stdin { } } output { stdout {} }"}, "mashhur1235"=>{"last_modified"=>"2022-05-06T14:23:43.066996", "username"=>"mashhurs", "pipeline_metadata"=>{"version"=>1, "type"=>"logstash_pipeline"}, "pipeline_settings"=>{"pipeline.workers"=>"1"}, "pipeline"=>"input { stdin { } } output { stdout {} }"}, "mashhur123"=>{"last_modified"=>"2022-05-06T14:23:43.065823", "username"=>"mashhurs", "pipeline_metadata"=>{"version"=>1, "type"=>"logstash_pipeline"}, "pipeline_settings"=>{"pipeline.workers"=>"1"}, "pipeline"=>"input { stdin { } } output { stdout {} }"}}
```