### PR TITLE
[doc] Removes 'beta' from pipeline viewer doc

### DIFF
--- a/docs/static/monitoring/pipeline-viewer.asciidoc
+++ b/docs/static/monitoring/pipeline-viewer.asciidoc
@@ -2,7 +2,6 @@
 [[logstash-pipeline-viewer]]
 === Pipeline Viewer UI
 
-beta::[]
 
 The pipeline viewer UI offers additional visibility into the behavior and
 performance of complex pipeline configurations.


### PR DESCRIPTION
## What does this PR do?

Removes `beta` reference from pipeline viewer documentation as this feature will become GA

## Why is it important/What is the impact to the user?

This feature has been beta for a significant amount of time. We're now making this feature GA. This PR just updates the documentation removing the `beta` reference from it


## Checklist

- ~[ ] My code follows the style guidelines of this project~
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~


## Related issues

Relates [#130219](https://github.com/elastic/kibana/issues/130219)
