### PR TITLE
Add `jdk.io.File.enableADS=true` to JVM options

### DIFF
--- a/config/jvm.options
+++ b/config/jvm.options
@@ -42,6 +42,9 @@
 # ensure UTF-8 encoding by default (e.g. filenames)
 -Dfile.encoding=UTF-8
 
+# Set enableADS to true to enable Logstash to run on certain versions of the JDK
+-Djdk.io.File.enableADS=true
+
 # use our provided JNA always versus the system one
 #-Djna.nosys=true
 


### PR DESCRIPTION
OpenJDK versions 11.0.15+10, 17.0.3+7 introduced new functionality to allow Java to enable
strict path checking. This included disallowing the use of : in any place other than directly
after the drive letter. Unfortunately, this check had the side effect of breaking compatibility
with special device paths, such as NUL:, which in turn, prevents Logstash from starting.
This feature was gated by the use of the jdk.io.File.enableADS property with a value of true
disabling the check.

This property was introduced with the default value of false, which prevents logstash
from starting in a Windows environment. While the next release is anticipated to set this
value to true, this commit explicitly sets that value to enable Logstash to be able
to start correctly.

Relates: #14066
