### PR TITLE
Implement the management of the sincedb in the DLQ reader side

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReader.java
@@ -311,8 +311,21 @@ public final class DeadLetterQueueReader implements Closeable {
         return Optional.empty();
     }
 
+    /**
+     * @deprecated
+     * This method could throw NullPointerException when there isn't the linkage with a segment file.
+     * Use {@link #getCurrentSegmentPath()}
+     * */
+    @Deprecated
     public Path getCurrentSegment() {
         return currentReader.getPath();
+    }
+
+    public Optional<Path> getCurrentSegmentPath() {
+        if (currentReader == null) {
+            return Optional.empty();
+        }
+        return Optional.of(currentReader.getPath());
     }
 
     public long getCurrentPosition() {

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReader.java
@@ -183,14 +183,6 @@ public final class DeadLetterQueueReader implements Closeable {
         if (bytes == null) {
             return null;
         }
-        if (cleanConsumed) {
-            consumerPosition.updatePosition(this);
-            readEventsCounter++;
-
-            if (readEventsCounter > sinceDbFlushThreshold) {
-                consumerPosition.flush();
-            }
-        }
         return DLQEntry.deserialize(bytes);
     }
 
@@ -246,6 +238,16 @@ public final class DeadLetterQueueReader implements Closeable {
                     currentReader = optReader.get();
                     return pollEntryBytes(timeoutRemaining);
                 }
+            }
+        }
+
+        if (cleanConsumed) {
+            consumerPosition.updatePosition(this);
+            readEventsCounter++;
+
+            if (readEventsCounter > sinceDbFlushThreshold) {
+                consumerPosition.flush();
+                readEventsCounter = 0;
             }
         }
 

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueSinceDB.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueSinceDB.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.logstash.common.io;
 
 import org.apache.logging.log4j.LogManager;
@@ -102,9 +121,8 @@ public class DeadLetterQueueSinceDB {
     }
 
     public void updatePosition(DeadLetterQueueReader reader) {
-        Path currentSegment = reader.getCurrentSegment();
-        long offset = reader.getCurrentPosition();
-        updatePosition(currentSegment, offset);
+        reader.getCurrentSegmentPath()
+                .ifPresent(segment -> updatePosition(segment, reader.getCurrentPosition()));
     }
 
     public Path getCurrentSegment() {

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueSinceDB.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueSinceDB.java
@@ -1,0 +1,117 @@
+package org.logstash.common.io;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.Optional;
+
+import static org.logstash.common.io.DeadLetterQueueWriter.getSegmentPaths;
+
+public class DeadLetterQueueSinceDB {
+
+    private static final Logger logger = LogManager.getLogger(DeadLetterQueueSinceDB.class);
+
+    private final static char VERSION = '1';
+    private Path sinceDb;
+    private Path currentSegment;
+    private long offset;
+
+    private DeadLetterQueueSinceDB(Path sinceDb, Path currentSegment, long offset) {
+        this.sinceDb = sinceDb;
+        this.currentSegment = currentSegment;
+        this.offset = offset;
+    }
+
+    public static DeadLetterQueueSinceDB load(Path queuePath) throws IOException {
+        if (queuePath == null) {
+            throw new IllegalArgumentException("queuePath can't be null");
+        }
+        Path sinceDbPath = queuePath.resolve("sincedb");
+        if (!Files.exists(sinceDbPath)) {
+            return startSegment(sinceDbPath, queuePath);
+        }
+
+        byte[] bytes = Files.readAllBytes(sinceDbPath);
+        if (bytes.length == 0) {
+            return startSegment(sinceDbPath, queuePath);
+        }
+
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        verifyVersion(buffer);
+        Path segmentPath = decodePath(buffer);
+        long offset = buffer.getLong();
+        return new DeadLetterQueueSinceDB(sinceDbPath, segmentPath, offset);
+    }
+
+    private static void verifyVersion(ByteBuffer buffer) {
+        char version = buffer.getChar();
+        if (VERSION != version) {
+            throw new RuntimeException("Sincedb version:" + version + " does not match: " + VERSION);
+        }
+    }
+
+    private static Path decodePath(ByteBuffer buffer) {
+        int segmentPathStringLength = buffer.getInt();
+        byte[] segmentPathBytes = new byte[segmentPathStringLength];
+        buffer.get(segmentPathBytes);
+        return Paths.get(new String(segmentPathBytes));
+    }
+
+    /**
+     * Return sincedb instance pointing to the start of the first segment, is present.
+     * If no segment files are present, the DLQ is empty and is going to be populated by next {@link #flush() flush}.
+     * */
+    private static DeadLetterQueueSinceDB startSegment(Path sinceDbPath, Path queuePath) throws IOException {
+        Path firstSegment = findFirstSegment(queuePath)
+                .orElse(null);
+        return new DeadLetterQueueSinceDB(sinceDbPath, firstSegment, 0L);
+    }
+
+    private static Optional<Path> findFirstSegment(Path queuePath) throws IOException {
+        return getSegmentPaths(queuePath)
+                .min(Comparator.comparingInt(DeadLetterQueueUtils::extractSegmentId));
+    }
+
+    public void flush() {
+        if (currentSegment == null) {
+            return;
+        }
+        logger.debug("Flushing DLQ last read position");
+        String path = currentSegment.toAbsolutePath().toString();
+        ByteBuffer buffer = ByteBuffer.allocate(path.length() + 1 + 64);
+        buffer.putChar(VERSION);
+        buffer.putInt(path.length());
+        buffer.put(path.getBytes());
+        buffer.putLong(offset);
+        try {
+            Files.write(sinceDb, buffer.array());
+        } catch (IOException e) {
+            logger.error("failed to write DLQ offset state to " + sinceDb, e);
+        }
+    }
+
+    private void updatePosition(Path segment, long offset) {
+        this.currentSegment = segment;
+        this.offset = offset;
+    }
+
+    public void updatePosition(DeadLetterQueueReader reader) {
+        Path currentSegment = reader.getCurrentSegment();
+        long offset = reader.getCurrentPosition();
+        updatePosition(currentSegment, offset);
+    }
+
+    public Path getCurrentSegment() {
+        return currentSegment;
+    }
+
+    public long getOffset() {
+        return offset;
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderCompletedSegmentRemovalTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderCompletedSegmentRemovalTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.logstash.common.io;
+
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.logstash.common.io.RecordIOWriter.RECORD_HEADER_SIZE;
+import static org.logstash.common.io.RecordIOWriter.VERSION_SIZE;
+
+public class DeadLetterQueueReaderCompletedSegmentRemovalTest {
+    private Path dir;
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Before
+    public void setUp() throws Exception {
+        dir = temporaryFolder.newFolder().toPath();
+    }
+
+    @Test
+    public void testReaderWithoutSinceDbAndNonReadOperationDoneThenCloseDoesntCreateAnySinceDBFile() throws IOException {
+        DeadLetterQueueReader readManager = new DeadLetterQueueReader(dir, true, 10);
+        readManager.close();
+
+        Set<File> sincedbs = listSincedbFiles();
+        assertEquals("No sincedb file should be present", 0, sincedbs.size());
+    }
+
+    private Set<File> listSincedbFiles() throws IOException {
+        return Files.list(dir)
+                .filter(file -> file.getFileName().toString().equals("sincedb"))
+                .map(Path::toFile)
+                .collect(Collectors.toSet());
+    }
+
+    @Test
+    public void testReaderCreatesASinceDBFileOnCloseAfterReadSomeEvents() throws IOException, InterruptedException {
+        // write some data into a segment file
+        DeadLetterQueueTestUtils.writeSomeEventsInOneSegment(10, dir);
+
+        try (DeadLetterQueueReader readManager = new DeadLetterQueueReader(dir, true, 10)) {
+            byte[] rawStr = readManager.pollEntryBytes();
+            assertNotNull(rawStr);
+            assertEquals("0", new String(rawStr, StandardCharsets.UTF_8));
+        }
+
+        Set<File> sincedbs = listSincedbFiles();
+        assertEquals("Sincedb file must be present", 1, sincedbs.size());
+
+        DeadLetterQueueSinceDB sinceDB = DeadLetterQueueSinceDB.load(dir);
+        assertNotNull(sinceDB.getCurrentSegment());
+        assertEquals("0.log", sinceDB.getCurrentSegment().getFileName().toString());
+        assertEquals(VERSION_SIZE + RECORD_HEADER_SIZE + 1, sinceDB.getOffset());
+    }
+
+    @Test
+    public void testReaderFlushSinceDbEverytimePassesTheConfiguredThreshold() throws IOException, InterruptedException {
+        DeadLetterQueueTestUtils.writeSomeEventsInOneSegment(15, dir);
+
+        int thresholdLimit = 5;
+        try (DeadLetterQueueReader readManager = new DeadLetterQueueReader(dir, true, thresholdLimit)) {
+            // read 1 event more  the sinceDb flush threshold
+            for (int i = 0; i < thresholdLimit + 1; i++) {
+                byte[] payload = readManager.pollEntryBytes();
+                assertNotNull(payload);
+                assertEquals(Integer.toString(i), new String(payload, StandardCharsets.UTF_8));
+            }
+
+            // verify sinceDb file is created
+            DeadLetterQueueSinceDB sinceDB = DeadLetterQueueSinceDB.load(dir);
+            assertNotNull(sinceDB.getCurrentSegment());
+            assertEquals("0.log", sinceDB.getCurrentSegment().getFileName().toString());
+            assertEquals(VERSION_SIZE + (RECORD_HEADER_SIZE + 1) * (thresholdLimit + 1), sinceDB.getOffset());
+
+            for (int i = 0; i < thresholdLimit + 1; i++) {
+                byte[] payload = readManager.pollEntryBytes();
+                assertNotNull(payload);
+                assertEquals(Integer.toString(i + thresholdLimit + 1), new String(payload, StandardCharsets.UTF_8));
+            }
+
+            // verify sinceDb is updated
+            sinceDB = DeadLetterQueueSinceDB.load(dir);
+            assertNotNull(sinceDB.getCurrentSegment());
+            assertEquals("0.log", sinceDB.getCurrentSegment().getFileName().toString());
+            int doubleDigitsInts = 2; // 10 and 11 occupy 2 characters instead of one
+            assertEquals(VERSION_SIZE + (RECORD_HEADER_SIZE + 1) * 2 * (thresholdLimit + 1) + doubleDigitsInts, sinceDB.getOffset());
+        }
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
@@ -681,7 +681,7 @@ public class DeadLetterQueueReaderTest {
             byte[] rawStr = reader.pollEntryBytes();
             assertNotNull(rawStr);
             assertEquals("0", new String(rawStr, StandardCharsets.UTF_8));
-            currentSegment = reader.getCurrentSegment();
+            currentSegment = reader.getCurrentSegmentPath().get();
             currentPosition = reader.getCurrentPosition();
         }
 
@@ -729,7 +729,7 @@ public class DeadLetterQueueReaderTest {
             byte[] rawStr = reader.pollEntryBytes();
             assertNotNull(rawStr);
             assertEquals(stringOf(INTERNAL_FRAG_PAYLOAD_SIZE, 'A'), new String(rawStr, StandardCharsets.UTF_8));
-            currentSegment = reader.getCurrentSegment();
+            currentSegment = reader.getCurrentSegmentPath().get();
             currentPosition = reader.getCurrentPosition();
         }
 
@@ -766,7 +766,7 @@ public class DeadLetterQueueReaderTest {
             byte[] rawStr = reader.pollEntryBytes();
             assertNotNull(rawStr);
             assertEquals(stringOf(payloadSize, 'A'), new String(rawStr, StandardCharsets.UTF_8));
-            currentSegment = reader.getCurrentSegment();
+            currentSegment = reader.getCurrentSegmentPath().get();
             currentPosition = reader.getCurrentPosition();
         }
 

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueTestUtils.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueTestUtils.java
@@ -18,10 +18,28 @@
  */
 package org.logstash.common.io;
 
+import org.logstash.ackedqueue.StringElement;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
 import static org.logstash.common.io.RecordIOWriter.BLOCK_SIZE;
 
 public class DeadLetterQueueTestUtils {
     public static final int MB = 1024 * 1024;
     public static final int GB = 1024 * 1024 * 1024;
     public static final int FULL_SEGMENT_FILE_SIZE = 319 * BLOCK_SIZE + 1; // 319 records that fills completely a block plus the 1 byte header of the segment file
+
+    static void writeSomeEventsInOneSegment(int eventCount, Path outputDir) throws IOException {
+        Path segmentPath = outputDir.resolve(segmentFileName(0));
+        RecordIOWriter writer = new RecordIOWriter(segmentPath);
+        for (int j = 0; j < eventCount; j++) {
+            writer.writeEvent((new StringElement("" + j)).serialize());
+        }
+        writer.close();
+    }
+
+    static String segmentFileName(int i) {
+        return String.format(DeadLetterQueueWriter.SEGMENT_FILE_PATTERN, i);
+    }
 }


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->


## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
Introduces a sinceDB structure for DLQ reader, loading when the reader is created and flushing the information to disk when a segment is completely read or when an amount of threshold reads is done or on close of the reader.
When the reader is created it loads the last stored position present in sinceDB file and move the reader tail position accordingly.
Once a segment result as completely consumed it drops and removed the segments from filesystem and reader's internal data structure.

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
This PR permit the store, load and management of last saved point of the reader's tail and is functional to the implementation of the DLQ's remove consumed events feature.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #14173

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
