### PR TITLE
Change on_superuser to run_as_superuser to clear a confusion.

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -299,8 +299,8 @@
 #
 # ------------ Other Settings --------------
 #
-# Allow or block running Logstash as superuser (default: ALLOW)
-# run_as_superuser: BLOCK, ALLOW
+# Allow or block running Logstash as superuser (default: true)
+allow_superuser: false
 #
 # Where to find custom plugins
 # path.plugins: []

--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -299,8 +299,8 @@
 #
 # ------------ Other Settings --------------
 #
-# Run Logstash with superuser (default: ALLOW)
-# on_superuser: BLOCK, ALLOW
+# Allow or block running Logstash as superuser (default: ALLOW)
+# run_as_superuser: BLOCK, ALLOW
 #
 # Where to find custom plugins
 # path.plugins: []

--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -300,7 +300,7 @@
 # ------------ Other Settings --------------
 #
 # Allow or block running Logstash as superuser (default: true)
-allow_superuser: false
+# allow_superuser: false
 #
 # Where to find custom plugins
 # path.plugins: []

--- a/docker/data/logstash/env2yaml/env2yaml.go
+++ b/docker/data/logstash/env2yaml/env2yaml.go
@@ -100,7 +100,7 @@ func normalizeSetting(setting string) (string, error) {
 		"password_policy.include.lower",
 		"password_policy.include.digit",
 		"password_policy.include.symbol",
-		"run_as_superuser",
+		"allow_superuser",
 		"xpack.monitoring.enabled",
 		"xpack.monitoring.collection.interval",
 		"xpack.monitoring.elasticsearch.hosts",

--- a/docker/data/logstash/env2yaml/env2yaml.go
+++ b/docker/data/logstash/env2yaml/env2yaml.go
@@ -100,7 +100,7 @@ func normalizeSetting(setting string) (string, error) {
 		"password_policy.include.lower",
 		"password_policy.include.digit",
 		"password_policy.include.symbol",
-		"on_superuser",
+		"run_as_superuser",
 		"xpack.monitoring.enabled",
 		"xpack.monitoring.collection.interval",
 		"xpack.monitoring.elasticsearch.hosts",

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -317,9 +317,9 @@ separating each log lines per pipeline could be helpful in case you need to trou
   and `NAME` is the name of the plugin.
 | Platform-specific. See <<dir-layout>>.
 
-| `run_as_superuser`
-| Setting to `BLOCK` or `ALLOW` running Logstash as a superuser.
-| `ALLOW`
+| `allow_superuser`
+| Setting to `true` to allow or `false` to block running Logstash as a superuser.
+| `true`
 
 | `password_policy.mode`
 | Raises either `WARN` or `ERROR` message when password requirements are not met.

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -317,7 +317,7 @@ separating each log lines per pipeline could be helpful in case you need to trou
   and `NAME` is the name of the plugin.
 | Platform-specific. See <<dir-layout>>.
 
-| `on_superuser`
+| `run_as_superuser`
 | Setting to `BLOCK` or `ALLOW` running Logstash as a superuser.
 | `ALLOW`
 

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -34,7 +34,7 @@ module LogStash
   end
 
   [
-            Setting::String.new("on_superuser", "ALLOW", true, ["BLOCK", "ALLOW"]),
+            Setting::String.new("run_as_superuser", "ALLOW", true, ["BLOCK", "ALLOW"]),
             Setting::String.new("node.name", Socket.gethostname),
     Setting::NullableString.new("path.config", nil, false),
  Setting::WritableDirectory.new("path.data", ::File.join(LogStash::Environment::LOGSTASH_HOME, "data")),

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -34,7 +34,7 @@ module LogStash
   end
 
   [
-            Setting::String.new("run_as_superuser", "ALLOW", true, ["BLOCK", "ALLOW"]),
+           Setting::Boolean.new("allow_superuser", true),
             Setting::String.new("node.name", Socket.gethostname),
     Setting::NullableString.new("path.config", nil, false),
  Setting::WritableDirectory.new("path.data", ::File.join(LogStash::Environment::LOGSTASH_HOME, "data")),

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -443,10 +443,9 @@ class LogStash::Runner < Clamp::StrictCommand
   end # def self.main
 
   def running_as_superuser
-    run_as_superuser_setting = setting("run_as_superuser")
     if Process.euid() == 0
-      if run_as_superuser_setting.eql?("ALLOW")
-        deprecation_logger.deprecated("NOTICE: Running Logstash as superuser is not recommended and won't be allowed in the future. Set 'run_as_superuser' to 'BLOCK' to avoid startup errors in future releases.")
+      if setting("allow_superuser")
+        deprecation_logger.deprecated("NOTICE: Running Logstash as superuser is not recommended and won't be allowed in the future. Set 'allow_superuser' to 'false' to avoid startup errors in future releases.")
       else
         raise(RuntimeError, "Logstash cannot be run as superuser.")
       end

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -446,9 +446,9 @@ class LogStash::Runner < Clamp::StrictCommand
     run_as_superuser_setting = setting("run_as_superuser")
     if Process.euid() == 0
       if run_as_superuser_setting.eql?("ALLOW")
-        deprecation_logger.deprecated("NOTICE: Running Logstash as root is not recommended and won't be allowed in the future. Set 'run_as_superuser' to 'BLOCK' to avoid startup errors in future releases.")
+        deprecation_logger.deprecated("NOTICE: Running Logstash as superuser is not recommended and won't be allowed in the future. Set 'run_as_superuser' to 'BLOCK' to avoid startup errors in future releases.")
       else
-        raise(RuntimeError, "Logstash cannot be run as root.")
+        raise(RuntimeError, "Logstash cannot be run as superuser.")
       end
     end
   end

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -285,7 +285,7 @@ class LogStash::Runner < Clamp::StrictCommand
     require "logstash/util/java_version"
     require "stud/task"
 
-    running_as_root
+    running_as_superuser
 
     if log_configuration_contains_javascript_usage?
       logger.error("Logging configuration uses Script log appender or filter with Javascript, which is no longer supported.")
@@ -442,11 +442,11 @@ class LogStash::Runner < Clamp::StrictCommand
     @log_fd.close if @log_fd
   end # def self.main
 
-  def running_as_root
-    on_superuser_setting = setting("on_superuser")
+  def running_as_superuser
+    run_as_superuser_setting = setting("run_as_superuser")
     if Process.euid() == 0
-      if on_superuser_setting.eql?("ALLOW")
-        deprecation_logger.deprecated("NOTICE: Running Logstash as root is not recommended and won't be allowed in the future. Set 'on_superuser' to 'BLOCK' to avoid startup errors in future releases.")
+      if run_as_superuser_setting.eql?("ALLOW")
+        deprecation_logger.deprecated("NOTICE: Running Logstash as root is not recommended and won't be allowed in the future. Set 'run_as_superuser' to 'BLOCK' to avoid startup errors in future releases.")
       else
         raise(RuntimeError, "Logstash cannot be run as root.")
       end

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -652,7 +652,7 @@ describe LogStash::Runner do
     let(:deprecation_logger_stub) { double("DeprecationLogger").as_null_object }
     before(:each) { allow(runner).to receive(:deprecation_logger).and_return(deprecation_logger_stub) }
 
-    context "unintentionally running logstash as root" do
+    context "unintentionally running logstash as superuser" do
       before do
         expect(Process).to receive(:euid).and_return(0)
       end
@@ -660,20 +660,20 @@ describe LogStash::Runner do
         LogStash::SETTINGS.set("run_as_superuser", "BLOCK")
         expect(logger).to receive(:fatal) do |msg, hash|
           expect(msg).to eq("An unexpected error occurred!")
-          expect(hash[:error].to_s).to match("Logstash cannot be run as root.")
+          expect(hash[:error].to_s).to match("Logstash cannot be run as superuser.")
         end
         expect(subject.run(args)).to eq(1)
       end
     end
 
-    context "intentionally running logstash as root " do
+    context "intentionally running logstash as superuser " do
       before do
         expect(Process).to receive(:euid).and_return(0)
       end
       it "runs successfully with warning message" do
         LogStash::SETTINGS.set("run_as_superuser", "ALLOW")
         expect(logger).not_to receive(:fatal)
-        expect(deprecation_logger_stub).to receive(:deprecated).with(/NOTICE: Running Logstash as root is not recommended and won't be allowed in the future. Set 'run_as_superuser' to 'BLOCK' to avoid startup errors in future releases./)
+        expect(deprecation_logger_stub).to receive(:deprecated).with(/NOTICE: Running Logstash as superuser is not recommended and won't be allowed in the future. Set 'run_as_superuser' to 'BLOCK' to avoid startup errors in future releases./)
         expect { subject.run(args) }.not_to raise_error
       end
     end
@@ -685,7 +685,7 @@ describe LogStash::Runner do
       it "runs successfully without any messages" do
         LogStash::SETTINGS.set("run_as_superuser", "BLOCK")
         expect(logger).not_to receive(:fatal)
-        expect(deprecation_logger_stub).not_to receive(:deprecated).with(/NOTICE: Running Logstash as root is not recommended and won't be allowed in the future. Set 'run_as_superuser' to 'BLOCK' to avoid startup errors in future releases./)
+        expect(deprecation_logger_stub).not_to receive(:deprecated).with(/NOTICE: Running Logstash as superuser is not recommended and won't be allowed in the future. Set 'run_as_superuser' to 'BLOCK' to avoid startup errors in future releases./)
         expect { subject.run(args) }.not_to raise_error
       end
     end

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -646,7 +646,7 @@ describe LogStash::Runner do
     end
   end
 
-  describe "run_as_superuser" do
+  describe "allow_superuser" do
     subject { LogStash::Runner.new("") }
     let(:args) { ["-e", "input {} output {}"] }
     let(:deprecation_logger_stub) { double("DeprecationLogger").as_null_object }
@@ -657,7 +657,7 @@ describe LogStash::Runner do
         expect(Process).to receive(:euid).and_return(0)
       end
       it "fails with bad exit" do
-        LogStash::SETTINGS.set("run_as_superuser", "BLOCK")
+        LogStash::SETTINGS.set("allow_superuser", false)
         expect(logger).to receive(:fatal) do |msg, hash|
           expect(msg).to eq("An unexpected error occurred!")
           expect(hash[:error].to_s).to match("Logstash cannot be run as superuser.")
@@ -671,9 +671,9 @@ describe LogStash::Runner do
         expect(Process).to receive(:euid).and_return(0)
       end
       it "runs successfully with warning message" do
-        LogStash::SETTINGS.set("run_as_superuser", "ALLOW")
+        LogStash::SETTINGS.set("allow_superuser", true)
         expect(logger).not_to receive(:fatal)
-        expect(deprecation_logger_stub).to receive(:deprecated).with(/NOTICE: Running Logstash as superuser is not recommended and won't be allowed in the future. Set 'run_as_superuser' to 'BLOCK' to avoid startup errors in future releases./)
+        expect(deprecation_logger_stub).to receive(:deprecated).with(/NOTICE: Running Logstash as superuser is not recommended and won't be allowed in the future. Set 'allow_superuser' to 'false' to avoid startup errors in future releases./)
         expect { subject.run(args) }.not_to raise_error
       end
     end
@@ -683,9 +683,9 @@ describe LogStash::Runner do
         expect(Process).to receive(:euid).and_return(100)
       end
       it "runs successfully without any messages" do
-        LogStash::SETTINGS.set("run_as_superuser", "BLOCK")
+        LogStash::SETTINGS.set("allow_superuser", false)
         expect(logger).not_to receive(:fatal)
-        expect(deprecation_logger_stub).not_to receive(:deprecated).with(/NOTICE: Running Logstash as superuser is not recommended and won't be allowed in the future. Set 'run_as_superuser' to 'BLOCK' to avoid startup errors in future releases./)
+        expect(deprecation_logger_stub).not_to receive(:deprecated).with(/NOTICE: Running Logstash as superuser is not recommended and won't be allowed in the future. Set 'allow_superuser' to 'false' to avoid startup errors in future releases./)
         expect { subject.run(args) }.not_to raise_error
       end
     end

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -646,7 +646,7 @@ describe LogStash::Runner do
     end
   end
 
-  describe "on_superuser" do
+  describe "run_as_superuser" do
     subject { LogStash::Runner.new("") }
     let(:args) { ["-e", "input {} output {}"] }
     let(:deprecation_logger_stub) { double("DeprecationLogger").as_null_object }
@@ -657,7 +657,7 @@ describe LogStash::Runner do
         expect(Process).to receive(:euid).and_return(0)
       end
       it "fails with bad exit" do
-        LogStash::SETTINGS.set("on_superuser", "BLOCK")
+        LogStash::SETTINGS.set("run_as_superuser", "BLOCK")
         expect(logger).to receive(:fatal) do |msg, hash|
           expect(msg).to eq("An unexpected error occurred!")
           expect(hash[:error].to_s).to match("Logstash cannot be run as root.")
@@ -671,9 +671,9 @@ describe LogStash::Runner do
         expect(Process).to receive(:euid).and_return(0)
       end
       it "runs successfully with warning message" do
-        LogStash::SETTINGS.set("on_superuser", "ALLOW")
+        LogStash::SETTINGS.set("run_as_superuser", "ALLOW")
         expect(logger).not_to receive(:fatal)
-        expect(deprecation_logger_stub).to receive(:deprecated).with(/NOTICE: Running Logstash as root is not recommended and won't be allowed in the future. Set 'on_superuser' to 'BLOCK' to avoid startup errors in future releases./)
+        expect(deprecation_logger_stub).to receive(:deprecated).with(/NOTICE: Running Logstash as root is not recommended and won't be allowed in the future. Set 'run_as_superuser' to 'BLOCK' to avoid startup errors in future releases./)
         expect { subject.run(args) }.not_to raise_error
       end
     end
@@ -683,9 +683,9 @@ describe LogStash::Runner do
         expect(Process).to receive(:euid).and_return(100)
       end
       it "runs successfully without any messages" do
-        LogStash::SETTINGS.set("on_superuser", "BLOCK")
+        LogStash::SETTINGS.set("run_as_superuser", "BLOCK")
         expect(logger).not_to receive(:fatal)
-        expect(deprecation_logger_stub).not_to receive(:deprecated).with(/NOTICE: Running Logstash as root is not recommended and won't be allowed in the future. Set 'on_superuser' to 'BLOCK' to avoid startup errors in future releases./)
+        expect(deprecation_logger_stub).not_to receive(:deprecated).with(/NOTICE: Running Logstash as root is not recommended and won't be allowed in the future. Set 'run_as_superuser' to 'BLOCK' to avoid startup errors in future releases./)
         expect { subject.run(args) }.not_to raise_error
       end
     end


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->


## What does this PR do?

Some of Logstash members missed to review the [`running Logstash as superuser` feature PR](https://github.com/elastic/logstash/pull/14046) and at a glance configuration flag for this feature brought a confusion. Changing `on_superuser` to `allow_superuser` seems better to clear the confusion as well as gives a clear message to end users.

## Why is it important/What is the impact to the user?

Gives a clear message to customer with descriptive variable name.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [ ]

## How to test this PR locally

Cases:
1. Running Logstash as a superuser with block mode
 - `allow_superuser: false` in `logstash.yaml`
 - run with `sudo ./bin/logstash`
 - Output: `[2022-05-11T11:40:22,324][FATAL][logstash.runner] An unexpected error occurred! {:error=>#<RuntimeError: Logstash cannot be run as superuser.>, ....`

2. Running Logstash as a superuser with allow mode
 - `allow_superuser: true` in `logstash.yaml`
 - run with `sudo ./bin/logstash`
 - Output in the deprecation log: `[2022-05-11T11:32:55,438][WARN ][deprecation.logstash.runner] NOTICE: Running Logstash as superuser is not recommended and won't be allowed in the future. Set 'allow_superuser' to 'false' to avoid startup errors in future releases.`

## Related issues

- #13882

## Use cases

## Screenshots

## Logs

