### PR TITLE
Fix of DLQ stream position retrieval

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/RecordIOReader.java
@@ -118,7 +118,8 @@ public final class RecordIOReader implements Closeable {
     public <T> byte[] seekToNextEventPosition(T target, Function<byte[], T> keyExtractor, Comparator<T> keyComparator) throws IOException {
         int matchingBlock = UNSET;
         int lowBlock = 0;
-        int highBlock = (int) (channel.size() - VERSION_SIZE) / BLOCK_SIZE;
+        // blocks are 0-based so the highest is the number of blocks - 1
+        int highBlock = ((int) (channel.size() - VERSION_SIZE) / BLOCK_SIZE) - 1;
 
         while (lowBlock < highBlock) {
             int middle = (int) Math.ceil((highBlock + lowBlock) / 2.0);

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
@@ -31,6 +31,7 @@ import org.logstash.Timestamp;
 import org.logstash.ackedqueue.StringElement;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -42,8 +43,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 import static org.logstash.common.io.DeadLetterQueueTestUtils.MB;
 import static org.logstash.common.io.RecordIOWriter.BLOCK_SIZE;
 import static org.logstash.common.io.RecordIOWriter.VERSION_SIZE;
@@ -643,7 +643,6 @@ public class DeadLetterQueueReaderTest {
         }
     }
 
-
     @Test
     public void testStoreReaderPositionAndRestart() throws IOException, InterruptedException {
         // write some data into a segment file
@@ -657,7 +656,7 @@ public class DeadLetterQueueReaderTest {
         // read the first event and save read position
         Path currentSegment;
         long currentPosition;
-        try (DeadLetterQueueReader reader = new DeadLetterQueueReader(dir, true, 10)) {
+        try (DeadLetterQueueReader reader = new DeadLetterQueueReader(dir)) {
             byte[] rawStr = reader.pollEntryBytes();
             assertNotNull(rawStr);
             assertEquals("0", new String(rawStr, StandardCharsets.UTF_8));
@@ -665,9 +664,8 @@ public class DeadLetterQueueReaderTest {
             currentPosition = reader.getCurrentPosition();
         }
 
-
         // reopen the reader from the last saved position and read next element
-        try (DeadLetterQueueReader reader = new DeadLetterQueueReader(dir, true, 10)) {
+        try (DeadLetterQueueReader reader = new DeadLetterQueueReader(dir)) {
             reader.setCurrentReaderAndPosition(currentSegment, currentPosition);
 
             byte[] rawStr = reader.pollEntryBytes();
@@ -675,7 +673,6 @@ public class DeadLetterQueueReaderTest {
             assertEquals("1", new String(rawStr, StandardCharsets.UTF_8));
         }
     }
-
 
     /**
      * Produces a {@link Timestamp} whose epoch milliseconds is _near_ the provided value

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
@@ -35,20 +35,35 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.logstash.common.io.DeadLetterQueueTestUtils.MB;
 import static org.logstash.common.io.RecordIOWriter.BLOCK_SIZE;
+import static org.logstash.common.io.RecordIOWriter.RECORD_HEADER_SIZE;
 import static org.logstash.common.io.RecordIOWriter.VERSION_SIZE;
 
 public class DeadLetterQueueReaderTest {
+    public static final int INTERNAL_FRAG_PAYLOAD_SIZE = BLOCK_SIZE - RECORD_HEADER_SIZE - 5;
     private Path dir;
     private int defaultDlqSize = 100_000_000; // 100mb
 
@@ -675,25 +690,39 @@ public class DeadLetterQueueReaderTest {
     }
 
     @Test
+    public void testReaderWithBlockInternalFragmentation() throws IOException, InterruptedException {
+        writeSegmentWithFirstBlockContainingInternalFragmentation();
+
+        try (DeadLetterQueueReader reader = new DeadLetterQueueReader(dir)) {
+            byte[] rawStr = reader.pollEntryBytes();
+            assertNotNull(rawStr);
+            assertEquals(stringOf(INTERNAL_FRAG_PAYLOAD_SIZE, 'A'), new String(rawStr, StandardCharsets.UTF_8));
+
+            rawStr = reader.pollEntryBytes();
+            assertNotNull(rawStr);
+            assertEquals("BBBBBBBBBB", new String(rawStr, StandardCharsets.UTF_8));
+        }
+    }
+
+    private static String stringOf(int length, char ch) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+            sb.append(ch);
+        }
+        return sb.toString();
+    }
+
+    @Test
     public void testStoreReaderPositionWithBlocksWithInternalFragmentation() throws IOException, InterruptedException {
-        // 32 Kb - 13b - 5(fragmentation) = 32750
-        writeEventOnSegment(32750, 'A', segmentFileName(0));
-        // write a second segment with small payload
-        writeEventOnSegment(10, 'B', segmentFileName(1));
+        writeSegmentWithFirstBlockContainingInternalFragmentation();
 
         // read the first event and save read position
         Path currentSegment;
         long currentPosition;
         try (DeadLetterQueueReader reader = new DeadLetterQueueReader(dir)) {
             byte[] rawStr = reader.pollEntryBytes();
-
             assertNotNull(rawStr);
-            StringBuilder sb = new StringBuilder();
-            for (int i = 0; i < 32750; i++) {
-                sb.append('A');
-            }
-
-            assertEquals(sb.toString(), new String(rawStr, StandardCharsets.UTF_8));
+            assertEquals(stringOf(INTERNAL_FRAG_PAYLOAD_SIZE, 'A'), new String(rawStr, StandardCharsets.UTF_8));
             currentSegment = reader.getCurrentSegment();
             currentPosition = reader.getCurrentPosition();
         }
@@ -708,12 +737,18 @@ public class DeadLetterQueueReaderTest {
         }
     }
 
-    private void writeEventOnSegment(int payloadSize, char fillingChar, String segment) throws IOException {
-        byte[] payload = new byte[payloadSize];
-        Arrays.fill(payload, (byte) fillingChar);
-        Path segmentPath = dir.resolve(segment);
+    private void writeSegmentWithFirstBlockContainingInternalFragmentation() throws IOException {
+        byte[] almostFullBlockPayload = new byte[INTERNAL_FRAG_PAYLOAD_SIZE];
+        Arrays.fill(almostFullBlockPayload, (byte) 'A');
+        Path segmentPath = dir.resolve(segmentFileName(0));
         RecordIOWriter writer = new RecordIOWriter(segmentPath);
-        writer.writeEvent(payload);
+        writer.writeEvent(almostFullBlockPayload);
+
+        // write a second segment with small payload
+        byte[] smallPayload = new byte[10];
+        Arrays.fill(smallPayload, (byte) 'B');
+        writer.writeEvent(smallPayload);
+
         writer.close();
     }
 

--- a/logstash-core/src/test/java/org/logstash/common/io/RecordIOReaderTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/RecordIOReaderTest.java
@@ -93,7 +93,6 @@ public class RecordIOReaderTest {
 
         RecordIOReader reader = new RecordIOReader(file);
         reader.seekToBlock(1);
-        reader.consumeBlock(true);
         assertThat(reader.seekToStartOfEventInBlock(), equalTo(1026));
 
         reader.close();


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Bugfix a seek problem into the dead letter queue reader when asked to restart consuming from specific point.

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
Adds some tests to proof that the offset position retrieved from the `RecordIOReader` effectively point to the start of the next available event and not to the last channel position retrieved.
Adds fixes for the problem, moving the concept of `channelPosition` to `streamPosition` differentiating the position on the stream from the position on the channel. However the already published interface (method `getChannelPosition`) is not renamed to avoid the introduction of a breaking  change.

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
Dead letter queue input plugin stores the position of the DLQ at [`close`](https://github.com/logstash-plugins/logstash-input-dead_letter_queue/blob/9f80a84fef48a62bd0602d467cbeb02faba59c61/src/main/java/org/logstash/input/DeadLetterQueueInputPlugin.java#L128) and retrieve with `setCurrentReaderAndPosition` during the [queue reader initialization](https://github.com/logstash-plugins/logstash-input-dead_letter_queue/blob/9f80a84fef48a62bd0602d467cbeb02faba59c61/src/main/java/org/logstash/input/DeadLetterQueueInputPlugin.java#L100).

The saved offset refer to the channel's position and not to the effectively consumed stream position. This makes to drop some events.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] test locally with real use case

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
- create a DLQ to be consumed:
  - enable `dead_letter_queue.enable: true` in `config/logstash.yml`
  - close an index into an Elasticsearch instance
  - run Logstash to generate a DLQ, for example with:
```
input {
  generator {
    message => '{"name": "Andrea"}'
    count => 10000
    codec => json
  }
}

output {
  elasticsearch {
    index => "test_index"
    hosts => "http://localhost:9200"
    user => "elastic"
    password => "changeme"
  }
}
```

- run a DLQ consumer pipeline with `commit_offsets => true` and exit Logstash as soon as possible after first writes.
  - example pipeline to store events in another index:
```
input {
  dead_letter_queue {
  	path => "/<LS HOME>/data/dead_letter_queue/"
    commit_offsets => true
  }
}

output {
  stdout {
  }
  elasticsearch {
    index => "test_backup_index"
    hosts => "http://localhost:9200"
    user => "elastic"
    password => "changeme"
  }
}
```
- check the count of inserted docs into ES index `GET test_backup_index/_count ` (should be a number << 10000)
- restart Logstash with same pipeline, and wait it finishes
- the ES count query **MUST** be 10000 to proof DLQ didnt' lost any event.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
