### PR TITLE
CI: docs preview comment working, for real

### DIFF
--- a/.github/workflows/add-docs-preview-link.yml
+++ b/.github/workflows/add-docs-preview-link.yml
@@ -14,10 +14,12 @@ jobs:
         uses: autotelic/action-wait-for-status-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          owner: elastic
           statusName: "elasticsearch-ci/docs"
           # https://elasticsearch-ci.elastic.co/job/elastic+logstash+pull-request+build-docs
           # usually finishes in ~ 10 minutes
           timeoutSeconds: 900
+          intervalSeconds: 30
       - name: Add Docs Preview link in PR Comment
         if: steps.wait-for-status.outputs.state == 'success'
         uses: thollander/actions-comment-pull-request@v1

--- a/.github/workflows/add-docs-preview-link.yml
+++ b/.github/workflows/add-docs-preview-link.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           owner: elastic
+          # when running with on: pull_request_target we get the PR base ref by default
+          ref: github.head_ref
           statusName: "elasticsearch-ci/docs"
           # https://elasticsearch-ci.elastic.co/job/elastic+logstash+pull-request+build-docs
           # usually finishes in ~ 10 minutes

--- a/.github/workflows/add-docs-preview-link.yml
+++ b/.github/workflows/add-docs-preview-link.yml
@@ -16,7 +16,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           owner: elastic
           # when running with on: pull_request_target we get the PR base ref by default
-          ref: github.head_ref
+          ref: ${{ github.event.pull_request.head.sha }}
           statusName: "elasticsearch-ci/docs"
           # https://elasticsearch-ci.elastic.co/job/elastic+logstash+pull-request+build-docs
           # usually finishes in ~ 10 minutes

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -318,7 +318,7 @@ separating each log lines per pipeline could be helpful in case you need to trou
 | Platform-specific. See <<dir-layout>>.
 
 | `on_superuser`
-| Setting to `BLOCK` or `ALLOW` running Logstash as a superuser.
+| Setting to `BLOCK` or `ALLOW` running Logstash as a ZUUUPERUUUUSER.
 | `ALLOW`
 
 | `password_policy.mode`

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -318,7 +318,7 @@ separating each log lines per pipeline could be helpful in case you need to trou
 | Platform-specific. See <<dir-layout>>.
 
 | `on_superuser`
-| Setting to `BLOCK` or `ALLOW` running Logstash as a ZUUUPERUUUUSER.
+| Setting to `BLOCK` or `ALLOW` running Logstash as a superuser.
 | `ALLOW`
 
 | `password_policy.mode`


### PR DESCRIPTION
following up on https://github.com/elastic/logstash/pull/14067

this gets the wait work-flow polling the proper commit ref status -> and than (when docs CI finishes) triggers the comment action as expected!

demonstration that things worked at: https://github.com/elastic/logstash/pull/14096
(the URL does not have the docs diff and gives a 404 but that is smt with Jenkins CI)