### PR TITLE
[Doc] PQ and DLQ does not support NFS

### DIFF
--- a/docs/static/dead-letter-queues.asciidoc
+++ b/docs/static/dead-letter-queues.asciidoc
@@ -86,6 +86,8 @@ specify a different path for the files:
 path.dead_letter_queue: "path/to/data/dead_letter_queue"
 -------------------------------------------------------------------------------
 
+TIP: Use local filesystem for data integrity and performance. NFS is not supported.
+
 Dead letter queue entries are written to a temporary file, which is then renamed
  to a dead letter queue segment file, which is then eligible for ingestion. The rename
  happens either when this temporary file is considered 'full', or when a period

--- a/docs/static/dead-letter-queues.asciidoc
+++ b/docs/static/dead-letter-queues.asciidoc
@@ -86,7 +86,7 @@ specify a different path for the files:
 path.dead_letter_queue: "path/to/data/dead_letter_queue"
 -------------------------------------------------------------------------------
 
-TIP: Use local filesystem for data integrity and performance. NFS is not supported.
+TIP: Use the local filesystem for data integrity and performance. Network File System (NFS) is not supported.
 
 Dead letter queue entries are written to a temporary file, which is then renamed
  to a dead letter queue segment file, which is then eligible for ingestion. The rename

--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -29,7 +29,7 @@ Persistent queues do not solve these problems:
 * A persistent queue does not handle permanent machine failures such as disk corruption, disk failure, and machine loss. 
 The data persisted to disk is not replicated.
 
-TIP: Use local filesystem for data integrity and performance. NFS is not supported.
+TIP: Use the local filesystem for data integrity and performance. Network File System (NFS) is not supported.
 
 [[configuring-persistent-queues]]
 ==== Configuring persistent queues

--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -56,12 +56,6 @@ queue will be sized at the value of `queue.max_bytes` specified in
 `logstash.yml`. 
 The default is 1024mb (1gb).
 +
-Be sure that your disk has sufficient capacity to handle the cumulative total of `queue.max_bytes` across all persistent queues.
-The total of `queue.max_bytes` for _all_ queues should be
-lower than the capacity of your disk. 
-We do not check to see if the disk has enough capacity for `queue.max_bytes` for all queues. 
-The space check at startup only verifies that each queue has sufficient capacity to reach its `queue.max_bytes`.
-+
 TIP: If you are using persistent queues to protect against data loss, but don't
 require much buffering, you can set `queue.max_bytes` to a smaller value.
 A smaller value produces smaller queues and improves queue performance. 

--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -29,6 +29,7 @@ Persistent queues do not solve these problems:
 * A persistent queue does not handle permanent machine failures such as disk corruption, disk failure, and machine loss. 
 The data persisted to disk is not replicated.
 
+TIP: Use local filesystem for data integrity and performance. NFS is not supported.
 
 [[configuring-persistent-queues]]
 ==== Configuring persistent queues


### PR DESCRIPTION
- adds Tips to PQ and DLQ to suggest not to use NFS as storage
- remove `queue.max_bytes` part as size checking for multiple pipelines is released
Fixed: #12097