### PR TITLE
Fix hang bug on DLQ test

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReader.java
@@ -101,8 +101,18 @@ public final class DeadLetterQueueReader implements Closeable {
         }
     }
 
+    /**
+     * Opens the segment reader for the given path.
+     * Side effect: Will attempt to remove the given segment from the list of active
+     *              segments if segment is not found.
+     * @param segment Path to segment File
+     * @return Optional containing a RecordIOReader if the segment exists
+     * @throws IOException
+     */
     private Optional<RecordIOReader> openSegmentReader(Path segment) throws IOException {
         if (!Files.exists(segment)) {
+            // file was deleted by upstream process and segments list wasn't yet updated
+            segments.remove(segment);
             return Optional.empty();
         }
 


### PR DESCRIPTION
The recent commit #14079 to the DLQ would cause the `testSeekByTimestampWhenAllSegmentsAreDeleted`
to intermittently hang. This is due to files being deleted from the file system in the test,
but not from the internal list of segments. This would cause `pollEntryBytes` to loop indefinitely
looking for a deleted segments file. This commit also removes the segment path from the internal
segment list when a File is not found initially, and not just when a `NoFileException` is thrown

