### PR TITLE
Switch adoptopenjdk url to adoptium

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -728,19 +728,20 @@ class JDKDetails {
     }
 
     String createDownloadUrl() {
+        String releaseName = major > 8 ?
+                "jdk-${revision}+${build}":
+                "jdk${revision}u${build}"
+        String vendorOsName = vendorOsName(osName)
         switch (vendor) {
             case "adoptopenjdk":
-                String releaseName = major > 8 ?
-                        "jdk-${revision}+${build}":
-                        "jdk${revision}u${build}"
-                String adoptOsName = adaptOsName(osName)
-                return "https://api.adoptopenjdk.net/v3/binary/version/${releaseName}/${adoptOsName}/${arch}/jdk/hotspot/normal/${vendor}"
+            case "adoptium":
+                return "https://api.${vendor}.net/v3/binary/version/${releaseName}/${vendorOsName}/${arch}/jdk/hotspot/normal/${vendor}"
             default:
                 throw RuntimeException("Can't handle vendor: ${vendor}")
         }
     }
 
-    private String adaptOsName(String osName) {
+    private String vendorOsName(String osName) {
         if (osName == "darwin")
             return "mac"
         return osName

--- a/build.gradle
+++ b/build.gradle
@@ -733,9 +733,8 @@ class JDKDetails {
                 "jdk${revision}u${build}"
         String vendorOsName = vendorOsName(osName)
         switch (vendor) {
-            case "adoptopenjdk":
             case "adoptium":
-                return "https://api.${vendor}.net/v3/binary/version/${releaseName}/${vendorOsName}/${arch}/jdk/hotspot/normal/${vendor}"
+                return "https://api.adoptium.net/v3/binary/version/${releaseName}/${vendorOsName}/${arch}/jdk/hotspot/normal/adoptium"
             default:
                 throw RuntimeException("Can't handle vendor: ${vendor}")
         }

--- a/versions.yml
+++ b/versions.yml
@@ -6,7 +6,7 @@ logstash-core-plugin-api: 2.1.16
 
 bundled_jdk:
   # for AdoptOpenJDK/OpenJDK jdk-14.0.1+7.1, the revision is 14.0.1 while the build is 7.1
-  vendor: "adoptopenjdk"
+  vendor: "adoptium"
   revision: 11.0.14.1
   build: 1
 


### PR DESCRIPTION
Newer versions of the JDK are only available from api.adoptium.net, and not dual hosted on api.adoptopenjdk.net
This commit allows the use of adoptium versions of the JDK.

Relates: #14072

