### PR TITLE
Restrict json to avoid 2.6.2 until upstream jruby issue is solved

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |gem|
 
   gem.platform = "java"
 
-  gem.add_runtime_dependency "json", "= 2.6.1" # pinned until https://github.com/flori/json/issues/497 is resolved
+  gem.add_runtime_dependency "json", "< 2.6.2" # pinned until https://github.com/flori/json/issues/497 is resolved
 
   gem.add_runtime_dependency "pry", "~> 0.12"  #(Ruby license)
   gem.add_runtime_dependency "stud", "~> 0.0.19" #(Apache 2.0 license)

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -47,6 +47,8 @@ Gem::Specification.new do |gem|
 
   gem.platform = "java"
 
+  gem.add_runtime_dependency "json", "= 2.6.1" # pinned until https://github.com/flori/json/issues/497 is resolved
+
   gem.add_runtime_dependency "pry", "~> 0.12"  #(Ruby license)
   gem.add_runtime_dependency "stud", "~> 0.0.19" #(Apache 2.0 license)
   gem.add_runtime_dependency "clamp", "~> 1" #(MIT license) for command line args/flags


### PR DESCRIPTION
Version 2.6.2 of json will not install under jruby - https://github.com/flori/json/issues/497
This commit pins to the previous version until the issue is resolved.
