### PR TITLE
fix monitoring api integration test with draining queue

### DIFF
--- a/qa/integration/fixtures/monitoring_api_spec.yml
+++ b/qa/integration/fixtures/monitoring_api_spec.yml
@@ -40,7 +40,7 @@ config:
       tcp {
         port => '<%=options[:port]%>'
       }
-      generator { count => 5000 }
+      generator { count => 3000 }
     }
     filter {
       sleep { 

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -84,7 +84,6 @@ describe "Test Monitoring API" do
         second = logstash_service.monitoring_api.event_stats
         expect(second["filtered"].to_i > first["filtered"].to_i).to be_truthy
       end
-      Process.kill("KILL", logstash_service.pid)
     end
   end
 


### PR DESCRIPTION
This commit ends the integration test with teardown instead of sending a signal to kill

Tested in https://github.com/elastic/logstash/pull/14103 https://github.com/elastic/logstash/pull/14102
Related: #13935
CI: https://logstash-ci.elastic.co/job/elastic+logstash+pull-request+multijob-integration-pq-1/5362/console

**Log**
20:17:06       1) Test Monitoring API verify global event counters when a drop filter is in the pipeline expose the correct output counter
20:17:06          Failure/Error: Unable to find matching line from backtrace
20:17:06          
20:17:06            expected: 1
20:17:06                 got: 5001
20:17:06          
20:17:06            (compared using ==)
20:17:06 
20:17:06     Finished in 26 minutes 3 seconds (files took 5.21 seconds to load)
20:17:06     35 examples, 1 failure
20:17:06 
20:17:07     Failed examples:
20:17:07 
20:17:07     rspec ./specs/monitoring_api_spec.rb:107 # Test Monitoring API verify global event counters when a drop filter is in the pipeline expose the correct output counter