### PR TITLE
[7.17] Allow metrics update when PQ draining (#13935) | fix monitoring api integration test with draining queue (#14106)

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -235,9 +235,9 @@ class LogStash::Agent
     # in order of dependency.
     pipeline_bus.setBlockOnUnlisten(true)
 
-    stop_collecting_metrics
     transition_to_stopped
     converge_result = shutdown_pipelines
+    stop_collecting_metrics
     stop_webserver
     converge_result
   end

--- a/qa/integration/fixtures/monitoring_api_spec.yml
+++ b/qa/integration/fixtures/monitoring_api_spec.yml
@@ -40,7 +40,7 @@ config:
       tcp {
         port => '<%=options[:port]%>'
       }
-      generator { count => 5000 }
+      generator { count => 3000 }
     }
     filter {
       sleep { 

--- a/qa/integration/fixtures/monitoring_api_spec.yml
+++ b/qa/integration/fixtures/monitoring_api_spec.yml
@@ -35,3 +35,17 @@ config:
     output {
       stdout { }
     }
+  draining_events: |-
+    input {
+      tcp {
+        port => '<%=options[:port]%>'
+      }
+      generator { count => 5000 }
+    }
+    filter {
+      sleep { 
+       time => "1" 
+        every => 10
+      }
+      drop { }
+    }

--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -85,6 +85,10 @@ class LogstashService < Service
     @process.exit_code
   end
 
+  def pid
+    @process.pid
+  end
+
   # Starts a LS process in background with a given config file
   # and shuts it down after input is completely processed
   def start_background(config_file)

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -84,7 +84,6 @@ describe "Test Monitoring API" do
         second = logstash_service.monitoring_api.event_stats
         expect(second["filtered"].to_i > first["filtered"].to_i).to be_truthy
       end
-      Process.kill("KILL", logstash_service.pid)
     end
   end
 

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -52,6 +52,42 @@ describe "Test Monitoring API" do
     end
   end
 
+  context "queue draining" do
+    let(:tcp_port) { random_port }
+    let(:settings_dir) { Stud::Temporary.directory }
+    let(:queue_config) {
+      {
+        "queue.type" => "persisted",
+        "queue.drain" => true
+      }
+    }
+    let(:config_yaml) { queue_config.to_yaml }
+    let(:config_yaml_file) { ::File.join(settings_dir, "logstash.yml") }
+    let(:logstash_service) { @fixture.get_service("logstash") }
+    let(:config) { @fixture.config("draining_events", { :port => tcp_port }) }
+
+    before(:each) do
+      if logstash_service.settings.feature_flag == "persistent_queues"
+        IO.write(config_yaml_file, config_yaml)
+        logstash_service.spawn_logstash("-e", config, "--path.settings", settings_dir)
+      else
+        logstash_service.spawn_logstash("-e", config)
+      end
+      logstash_service.wait_for_logstash
+      wait_for_port(tcp_port, 60)
+    end
+
+    it "can update metrics" do
+      first = logstash_service.monitoring_api.event_stats
+      Process.kill("TERM", logstash_service.pid)
+      try(max_retry) do
+        second = logstash_service.monitoring_api.event_stats
+        expect(second["filtered"].to_i > first["filtered"].to_i).to be_truthy
+      end
+      Process.kill("KILL", logstash_service.pid)
+    end
+  end
+
   context "verify global event counters" do
     let(:tcp_port) { random_port }
     let(:sample_data) { 'Hello World!' }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Allow metrics update when PQ draining (#13935)](https://github.com/elastic/logstash/pull/13935)
 - [fix monitoring api integration test with draining queue (#14106)](https://github.com/elastic/logstash/pull/14106)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)