### PR TITLE
deps: pin concurrent-ruby pending removal of TimerTask

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "clamp", "~> 1" #(MIT license) for command line args/flags
   gem.add_runtime_dependency "filesize", "~> 0.2" #(MIT license) for :bytes config validator
   gem.add_runtime_dependency "gems", "~> 1"  #(MIT license)
-  gem.add_runtime_dependency "concurrent-ruby", "~> 1"
+  gem.add_runtime_dependency "concurrent-ruby", "~> 1", "< 1.1.10" # pinned until https://github.com/elastic/logstash/issues/13956
   gem.add_runtime_dependency "rack", '~> 2'
   gem.add_runtime_dependency "mustermann", '~> 1.0.3'
   gem.add_runtime_dependency "sinatra", '~> 2.1.0' # pinned until GH-13777 is resolved


### PR DESCRIPTION
## Release notes

## What does this PR do?

Pins our dependency on ConcurrentRuby temporarily until usage of the now-removed TimerTask can be properly replaced.

## Why is it important/What is the impact to the user?

ConcurrentRuby's TimerTask is currently the method by which instrumentation and monitoring features enforce timeouts when querying unresponsive APIs, and its implementation has been removed from ConcurrentRuby v1.1.10. While we need to migrate to a different timeout solution, using a flawed TimerTask is better than no timeouts.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works`

## Related issues

 - Relates: https://github.com/elastic/logstash/issues/13956

## Backport Targets
 - `8.2` -> `8.2.1`
 