### PR TITLE
Revert "Restrict json to avoid 2.6.2 until upstream jruby issue is so…

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -47,8 +47,6 @@ Gem::Specification.new do |gem|
 
   gem.platform = "java"
 
-  gem.add_runtime_dependency "json", "< 2.6.2" # pinned until https://github.com/flori/json/issues/497 is resolved
-
   gem.add_runtime_dependency "pry", "~> 0.12"  #(Ruby license)
   gem.add_runtime_dependency "stud", "~> 0.0.19" #(Apache 2.0 license)
   gem.add_runtime_dependency "clamp", "~> 1" #(MIT license) for command line args/flags


### PR DESCRIPTION
…lved (#14104)"

As a `json-2.6.2-java` has been released, the pin can be removed

This reverts commit e72515c871a2060ebf7602cccc4e60b85e714a31.
