### PR TITLE
Doc: Update settings file doc to call out queue type

### DIFF
--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -199,7 +199,7 @@ Values other than `disabled` are currently considered BETA, and may produce unin
 | 0 (unlimited)
 
 | `queue.max_bytes`
-| The total capacity of the queue in number of bytes. Make sure the capacity of your disk drive is greater than the value you specify here. If both `queue.max_events` and `queue.max_bytes` are specified, Logstash uses whichever criteria is reached first.
+| The total capacity of the queue in number of bytes. Make sure the capacity of your disk drive is greater than the value you specify here. If both `queue.max_events` and `queue.max_bytes` are specified, Logstash uses whichever criteria is reached first. (`queue.type: persisted`)
 | 1024mb (1g)
 
 | `queue.checkpoint.acks`
@@ -211,11 +211,11 @@ Values other than `disabled` are currently considered BETA, and may produce unin
 | 1024
 
 | `queue.checkpoint.retry`
-| When enabled, Logstash will retry four times per attempted checkpoint write for any checkpoint writes that fail. Any subsequent errors are not retried. This is a workaround for failed checkpoint writes that have been seen only on Windows platform, filesystems with non-standard behavior such as SANs and is not recommended except in those specific circumstances.
+| When enabled, Logstash will retry four times per attempted checkpoint write for any checkpoint writes that fail. Any subsequent errors are not retried. This is a workaround for failed checkpoint writes that have been seen only on Windows platform, filesystems with non-standard behavior such as SANs and is not recommended except in those specific circumstances. (`queue.type: persisted`)
 | `true`
 
 | `queue.drain`
-| When enabled, Logstash waits until the persistent queue is drained before shutting down.
+| When enabled, Logstash waits until the persistent queue (`queue.type: persisted`) is drained before shutting down.
 | `false`
 
 | `dead_letter_queue.enable`

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -199,7 +199,7 @@ Values other than `disabled` are currently considered BETA, and may produce unin
 | 0 (unlimited)
 
 | `queue.max_bytes`
-| The total capacity of the queue in number of bytes. Make sure the capacity of your disk drive is greater than the value you specify here. If both `queue.max_events` and `queue.max_bytes` are specified, Logstash uses whichever criteria is reached first. (`queue.type: persisted`)
+| The total capacity of the queue (`queue.type: persisted`) in number of bytes. Make sure the capacity of your disk drive is greater than the value you specify here. If both `queue.max_events` and `queue.max_bytes` are specified, Logstash uses whichever criteria is reached first.
 | 1024mb (1g)
 
 | `queue.checkpoint.acks`


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

Adds a few missing "(`queue.type: persisted`)" from the [logstash.yml](https://www.elastic.co/guide/en/logstash/8.2/logstash-settings-file.html) documentation page

## Why is it important/What is the impact to the user?

Finish explicitly indicating which settings apply to persistent queues (PQs).

## Checklist

- [x] ~~My code follows the style guidelines of this project~~
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [x] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [x] ~~N/A~~

## How to test this PR locally

N/A

## Related issues
- Closes #12536

## Use cases

Removes confusion around which `queue.*` settings apply to memory or persisted queue types.

## Screenshots

N/A

## Logs

N/A
