### PR TITLE
deps: pin rufus-scheduler to 3.7.x

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -82,4 +82,10 @@ Gem::Specification.new do |gem|
   # TEMPORARY: racc-1.6.0 doesn't have JAVA counterpart (yet)
   # SEE: https://github.com/ruby/racc/issues/172
   gem.add_runtime_dependency "racc", "~> 1.5.2" #(Ruby license)
+
+  # TEMPORARY: Modern Rufus Scheduler 3.x subtly breaks thread joining, which
+  # is done in several plugins to handle shutdowns.
+  # Pin pending migration to shared Scheduler Mixin that can mitigate this issue.
+  # https://github.com/logstash-plugins/logstash-mixin-scheduler/pull/1
+  gem.add_runtime_dependency 'rufus-scheduler', '~> 3.0.9'
 end

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -77,15 +77,13 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'logstash-filter-geoip', '>= 7.2.1' # breaking change of DatabaseManager
   gem.add_dependency 'down', '~> 5.2.0' #(MIT license)
   gem.add_dependency 'tzinfo-data' #(MIT license)
-  gem.add_dependency 'rufus-scheduler' #(MIT license)
-
-  # TEMPORARY: racc-1.6.0 doesn't have JAVA counterpart (yet)
-  # SEE: https://github.com/ruby/racc/issues/172
-  gem.add_runtime_dependency "racc", "~> 1.5.2" #(Ruby license)
-
   # TEMPORARY: Modern Rufus Scheduler 3.x subtly breaks thread joining, which
   # is done in several plugins to handle shutdowns.
   # Pin pending migration to shared Scheduler Mixin that can mitigate this issue.
   # https://github.com/logstash-plugins/logstash-mixin-scheduler/pull/1
-  gem.add_runtime_dependency 'rufus-scheduler', '~> 3.0.9'
+  gem.add_runtime_dependency 'rufus-scheduler', '~> 3.0.9' #(MIT license)
+
+  # TEMPORARY: racc-1.6.0 doesn't have JAVA counterpart (yet)
+  # SEE: https://github.com/ruby/racc/issues/172
+  gem.add_runtime_dependency "racc", "~> 1.5.2" #(Ruby license)
 end


### PR DESCRIPTION

## Release notes

[rn:skip]


## What does this PR do?

As recently as Logstash 8.2.0, we have effectively shipped with a well-aged Rufus Scheduler v3.0.9, but as things stand on snapshot builds we are pulling in a much more modern Rufus 3.8.x which causes specs for plugin shutdowns to fail throughout our plugins (example: [failing when unpinned](https://app.travis-ci.com/github/logstash-plugins/logstash-input-elasticsearch/builds/251011998), vs [succeeding when pinned](https://app.travis-ci.com/github/logstash-plugins/logstash-input-elasticsearch/builds/251022115))

I am very wary of pinning the dependency in the individual plugins, and only slightly less wary about doing so here on LS core because doing so will make it significantly more difficult to migrate those plugins in the future. But I also don't want to ship a broken-out-of-the-box release.

## Why is it important/What is the impact to the user?

When our plugin specs fail, we can't be confident in their behaviour. By pinning to a rufus that allows specs to succeed we can be more confident in the stability of the plugins as-bundled with Logtash

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
