### PR TITLE
Fixup password policy deprecations

### DIFF
--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -560,7 +560,6 @@ module LogStash
         if validatedResult.length() > 0
           if @password_policies.fetch(:mode).eql?("WARN")
             logger.warn("Password #{validatedResult}.")
-            deprecation_logger.deprecated("Password policies may become more restrictive in future releases. Set the 'api.auth.basic.password_policy.mode' to 'ERROR' to enforce stricter password requirements now.")
           else
             raise(ArgumentError, "Password #{validatedResult}.")
           end

--- a/logstash-core/lib/logstash/webserver.rb
+++ b/logstash-core/lib/logstash/webserver.rb
@@ -66,8 +66,8 @@ module LogStash
         password_policies[:include][:lower] = required_setting(settings, 'api.auth.basic.password_policy.include.lower', "api.auth.type")
         password_policies[:include][:digit] = required_setting(settings, 'api.auth.basic.password_policy.include.digit', "api.auth.type")
         password_policies[:include][:symbol] = required_setting(settings, 'api.auth.basic.password_policy.include.symbol', "api.auth.type")
+        Setting::ValidatedPassword.new("api.auth.basic.password", password, password_policies) # TODO: doesn't need to be a Setting, relies on `strict = true` force-validating the default
 
-        auth_basic[:password_policies] = password_policies
         options[:auth_basic] = auth_basic.freeze
       else
         warn_ignored(logger, settings, "api.auth.basic.", "api.auth.type")
@@ -150,9 +150,7 @@ module LogStash
       if options.include?(:auth_basic)
         username = options[:auth_basic].fetch(:username)
         password = options[:auth_basic].fetch(:password)
-        password_policies = options[:auth_basic].fetch(:password_policies)
-        validated_password = Setting::ValidatedPassword.new("api.auth.basic.password", password, password_policies).freeze
-        app = Rack::Auth::Basic.new(app, "logstash-api") { |u, p| u == username && p == validated_password.value.value }
+        app = Rack::Auth::Basic.new(app, "logstash-api") { |u, p| u == username && p == password.value }
       end
 
       @app = app


### PR DESCRIPTION

This is a WIP PR, and is a stub for future work.

## Release notes

[rn:skip]

## What does this PR do?

1. relying on the _default_ value of the `api.auth.basic.password_policy.mode` is deprecated; an explicitly-supplied `WARN` will continue to work even after we change the default to `ERROR` at some point in the future. Adjust the deprecation log to only occur when the user doesn't provide the value, fixing a minor bug in a feature that is set to release in Logstash 8.3.0
2. we can safely do password policy validation before instantiating the rack app, so we should.

## Why is it important/What is the impact to the user?

1. provides better guidance for locking in existing behaviour if and only if the user hasn't done so already.
2. fail faster :)


