### PR TITLE
Revert accidental

### DIFF
--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -560,6 +560,7 @@ module LogStash
         if validatedResult.length() > 0
           if @password_policies.fetch(:mode).eql?("WARN")
             logger.warn("Password #{validatedResult}.")
+            deprecation_logger.deprecated("Password policies may become more restrictive in future releases. Set the 'api.auth.basic.password_policy.mode' to 'ERROR' to enforce stricter password requirements now.")
           else
             raise(ArgumentError, "Password #{validatedResult}.")
           end

--- a/logstash-core/lib/logstash/webserver.rb
+++ b/logstash-core/lib/logstash/webserver.rb
@@ -109,7 +109,7 @@ module LogStash
     def self.required_setting_with_changing_default(settings, name, trigger, future_value)
       effective_value = required_setting(settings, name, trigger)
       if !settings.set?(name)
-        deprecation_logger.deprecated("The default value of `#{name}` will change to `#{future_value}` in a future release of Logstash. Set it to `#{future_value}` to enforce future requirement now.")
+        deprecation_logger.deprecated("The default value of `#{name}` will change to `#{future_value}` in a future release of Logstash. Set the `#{name}` to `#{effective_value}` to enforce future requirement now.")
       end
       effective_value
     end

--- a/logstash-core/lib/logstash/webserver.rb
+++ b/logstash-core/lib/logstash/webserver.rb
@@ -24,7 +24,6 @@ require "thread"
 
 module LogStash
   class WebServer
-    include Util::Loggable
 
     attr_reader :logger, :config, :http_host, :http_ports, :http_environment, :agent, :port
 
@@ -54,7 +53,7 @@ module LogStash
         auth_basic[:password] = required_setting(settings, 'api.auth.basic.password', "api.auth.type")
 
         password_policies = {}
-        password_policies[:mode] = required_setting_with_changing_default(settings, 'api.auth.basic.password_policy.mode', "api.auth.type", "ERROR")
+        password_policies[:mode] = required_setting(settings, 'api.auth.basic.password_policy.mode', "api.auth.type")
         password_policies[:length] = {}
         password_policies[:length][:minimum] = required_setting(settings, 'api.auth.basic.password_policy.length.minimum', "api.auth.type")
         if !password_policies[:length][:minimum].between?(8, 1024)
@@ -104,14 +103,6 @@ module LogStash
     # @api internal
     def self.required_setting(settings, setting_name, trigger)
       settings.get(setting_name) || fail(ArgumentError, "Setting `#{setting_name}` is required when `#{trigger}` is set to `#{settings.get(trigger)}`. Please provide it in your `logstash.yml`")
-    end
-
-    def self.required_setting_with_changing_default(settings, name, trigger, future_value)
-      effective_value = required_setting(settings, name, trigger)
-      if !settings.set?(name)
-        deprecation_logger.deprecated("The default value of `#{name}` will change to `#{future_value}` in a future release of Logstash. Set the `#{name}` to `#{effective_value}` to enforce future requirement now.")
-      end
-      effective_value
     end
 
     ##


### PR DESCRIPTION
Reverts 2 accidental commits that were pushed directly to `main`:

~~~
╭─{ yaauie@maybe:~/src/elastic/ls (✔ revert-accidental) }
╰─● git revert 67cdbb050 46b71b1cd
[revert-accidental 145379737] Revert "Improve log readability and remove extra logging."
 2 files changed, 2 insertions(+), 1 deletion(-)
[revert-accidental 679ef3f93] Revert "Password policy deprecation log fixup."
 1 file changed, 1 insertion(+), 10 deletions(-)
[success (00:00:12)] 
~~~