### PR TITLE
Fix deprecation logging of password policy.

### DIFF
--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -560,7 +560,6 @@ module LogStash
         if validatedResult.length() > 0
           if @password_policies.fetch(:mode).eql?("WARN")
             logger.warn("Password #{validatedResult}.")
-            deprecation_logger.deprecated("Password policies may become more restrictive in future releases. Set the 'api.auth.basic.password_policy.mode' to 'ERROR' to enforce stricter password requirements now.")
           else
             raise(ArgumentError, "Password #{validatedResult}.")
           end

--- a/logstash-core/lib/logstash/webserver.rb
+++ b/logstash-core/lib/logstash/webserver.rb
@@ -24,6 +24,7 @@ require "thread"
 
 module LogStash
   class WebServer
+    include Util::Loggable
 
     attr_reader :logger, :config, :http_host, :http_ports, :http_environment, :agent, :port
 
@@ -53,7 +54,7 @@ module LogStash
         auth_basic[:password] = required_setting(settings, 'api.auth.basic.password', "api.auth.type")
 
         password_policies = {}
-        password_policies[:mode] = required_setting(settings, 'api.auth.basic.password_policy.mode', "api.auth.type")
+        password_policies[:mode] = required_setting_with_changing_default(settings, 'api.auth.basic.password_policy.mode', "api.auth.type", "ERROR")
         password_policies[:length] = {}
         password_policies[:length][:minimum] = required_setting(settings, 'api.auth.basic.password_policy.length.minimum', "api.auth.type")
         if !password_policies[:length][:minimum].between?(8, 1024)
@@ -103,6 +104,14 @@ module LogStash
     # @api internal
     def self.required_setting(settings, setting_name, trigger)
       settings.get(setting_name) || fail(ArgumentError, "Setting `#{setting_name}` is required when `#{trigger}` is set to `#{settings.get(trigger)}`. Please provide it in your `logstash.yml`")
+    end
+
+    def self.required_setting_with_changing_default(settings, name, trigger, future_value)
+      effective_value = required_setting(settings, name, trigger)
+      if !settings.set?(name)
+        deprecation_logger.deprecated("The default value of `#{name}` will change to `#{future_value}` in a future release of Logstash. Set it to `#{future_value}` to enforce future requirement now.")
+      end
+      effective_value
     end
 
     ##

--- a/logstash-core/lib/logstash/webserver.rb
+++ b/logstash-core/lib/logstash/webserver.rb
@@ -109,7 +109,7 @@ module LogStash
     def self.required_setting_with_changing_default(settings, name, trigger, future_value)
       effective_value = required_setting(settings, name, trigger)
       if !settings.set?(name)
-        deprecation_logger.deprecated("The default value of `#{name}` will change to `#{future_value}` in a future release of Logstash. Set it to `#{future_value}` to enforce future requirement now.")
+        deprecation_logger.deprecated("The default value of `#{name}` will change to `#{future_value}` in a future release of Logstash. Set it to `#{future_value}` to observe the future behavior early, or set it to `#{effective_value}` to lock in the current behavior.")
       end
       effective_value
     end


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

Fixes the deprecation logging of the password policy. The issue is, when we upgrade Logstash (eg. 8.3.0 to 8.3.1+) current deprecation logging will be produced even default value (`WARN`) of `api.auth.basic.password_policy.mode` changes to `ERROR`.

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

Does not produce the (wrong log) deprecation noise to end users.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

- Enable the basic auth type and provide credentials: `api.auth.type: basic`
- Run Logstash and find the deprecation log, outcome should look like:
```
[2022-05-24T15:52:39,996][WARN ][deprecation.logstash.webserver] The default value of `api.auth.basic.password_policy.mode` will change to `ERROR` in a future release of Logstash. Set it to `ERROR` to enforce future requirement now.
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- #13884

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
