### PR TITLE
Make version bump action "branch" parameter free form

### DIFF
--- a/.github/workflows/version_bumps.yml
+++ b/.github/workflows/version_bumps.yml
@@ -5,13 +5,8 @@ on:
       branch:
         description: 'Release Branch'     
         required: true
-        default: '8.2'
-        type: choice
-        options:
-        - "7.17"
-        - "8.0"
-        - "8.1"
-        - "8.2"
+        default: '8.3'
+        type: string
       bump:
         description: 'Bump type'     
         required: true


### PR DESCRIPTION
Being a "choice" type parameter required frequent PRs every time there's a new minor. This commit changes the field to take a string instead.