### PR TITLE
Test: fix compatibility with (latest) Faraday 2.x

### DIFF
--- a/logstash-core/spec/logstash/webserver_spec.rb
+++ b/logstash-core/spec/logstash/webserver_spec.rb
@@ -183,7 +183,7 @@ describe LogStash::WebServer do
     context "and invalid basic auth is provided" do
       it 'emits an HTTP 401 with WWW-Authenticate header' do
         response = Faraday.new("http://#{api_host}:#{webserver.port}") do |conn|
-          conn.request :basic_auth, 'john-doe', 'open-sesame'
+          conn.request :authorization, :basic, 'john-doe', 'open-sesame'
         end.get('/')
         aggregate_failures do
           expect(response.status).to eq(401)
@@ -194,7 +194,7 @@ describe LogStash::WebServer do
     context "and valid auth is provided" do
       it "returns a relevant response" do
         response = Faraday.new("http://#{api_host}:#{webserver.port}") do |conn|
-          conn.request :basic_auth, 'a-user', 's3cur3dPas!'
+          conn.request :authorization, :basic, 'a-user', 's3cur3dPas!'
         end.get('/')
         aggregate_failures do
           expect(response.status).to eq(200)


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

Test fix - due recent upgrade to JRuby 9.3 (Ruby 2.6) we started using (latest) Faraday 2.x which changed the `conn.request :basic_auth` API and is failing:
```
12:54:14          Failure/Error: conn.request :basic_auth, 'john-doe', 'open-sesame'
12:54:14          
12:54:14          Faraday::Error:
12:54:14            :basic_auth is not registered on Faraday::Request
12:54:14          # ./vendor/bundle/jruby/2.6.0/gems/faraday-2.3.0/lib/faraday/middleware_registry.rb:57:in `lookup_middleware'
12:54:14          # ./vendor/bundle/jruby/2.6.0/gems/faraday-2.3.0/lib/faraday/rack_builder.rb:242:in `use_symbol'
12:54:14          # ./vendor/bundle/jruby/2.6.0/gems/faraday-2.3.0/lib/faraday/rack_builder.rb:103:in `request'
12:54:14          # ./logstash-core/spec/logstash/webserver_spec.rb:186:in `block in <main>'
12:54:14          # ./vendor/bundle/jruby/2.6.0/gems/faraday-2.3.0/lib/faraday/connection.rb:91:in `initialize'
12:54:14          # ./vendor/bundle/jruby/2.6.0/gems/faraday-2.3.0/lib/faraday.rb:98:in `new'
12:54:14          # ./logstash-core/spec/logstash/webserver_spec.rb:185:in `block in <main>'
12:54:14          # ./logstash-core/spec/logstash/webserver_spec.rb:155:in `block in <main>'
12:54:14          # ./vendor/bundle/jruby/2.6.0/gems/webmock-3.14.0/lib/webmock/rspec.rb:37:in `block in <main>'
12:54:14          # ./spec/spec_helper.rb:66:in `block in <main>'
12:54:14          # ./logstash-core/lib/logstash/util.rb:43:in `set_thread_name'
12:54:14          # ./spec/spec_helper.rb:65:in `block in <main>'
12:54:14          # ./spec/spec_helper.rb:58:in `block in <main>'
12:54:14          # ./vendor/bundle/jruby/2.6.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block in <main>'
12:54:14          # ./vendor/bundle/jruby/2.6.0/gems/logstash-devutils-2.4.0-java/lib/logstash/devutils/rspec/spec_helper.rb:61:in `block in <main>'
12:54:14          # ./lib/bootstrap/rspec.rb:36:in `<main>'
```

Upstream details on the issue:
- https://github.com/lostisland/faraday/blob/b2390ec2b3f35c2d9a1010527b139aefc85fcede/UPGRADING.md#authentication-helper-methods-in-connection-have-been-removed : 
> You were previously able to call `authorization`, `basic_auth` and `token_auth` against the Connection object, but this helper methods have now been dropped. Instead, you should be using the equivalent middleware, as explained in [this page](https://lostisland.github.io/faraday/middleware/authentication).
For more details, see https://github.com/lostisland/faraday/pull/1306

- https://github.com/lostisland/faraday/issues/1407
