### PR TITLE
Deps: lock faraday to 1.x due elasticsearch-transport

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -10,6 +10,7 @@ gem "pleaserun", "~>0.0.28"
 gem "rake", "~> 12"
 gem "ruby-progressbar", "~> 1"
 gem "logstash-output-elasticsearch", ">= 10.4.2"
+gem "faraday", "~> 1", :require => false # due elasticsearch-transport (elastic-transport) depending faraday '~> 1'
 gem "childprocess", "~> 4", :group => :build
 gem "fpm", "~> 1", ">= 1.14.1", :group => :build # compound due to bugfix https://github.com/jordansissel/fpm/pull/1856
 gem "gems", "~> 1", :group => :build


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

Dependency restriction, due the *elasticsearch* dependency.
Elasticsearch client is used in *logstash-input-elasticsearch* and *logstash-filter-elasticsearch*.
The client has a transitive dependency on [faraday '-> 1'](https://rubygems.org/gems/elasticsearch-transport/versions/7.17.1) (even [in 8.x](https://rubygems.org/gems/elastic-transport/versions/8.0.1))

Avoids ruby unit test failures (such as [this](https://logstash-ci.elastic.co/job/elastic+logstash+pull-request+multijob-ruby-unit-tests/5508/console))

## Why is it important/What is the impact to the user?

Users would not end up with latest versions of the ES plugins if we're using latest Faraday 2.x.
This mostly concerns development and users checking out the main branch atm.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related

- https://github.com/elastic/logstash/pull/14184