### PR TITLE
Remove /etc/s/s/logstash.service if previously installed by Logstash

### DIFF
--- a/pkg/centos/before-install.sh
+++ b/pkg/centos/before-install.sh
@@ -10,6 +10,9 @@ if ! getent passwd logstash >/dev/null; then
 fi
 
 # Handle upgrade: Check if old service unit exists and remove it
-if [ -f /etc/systemd/system/logstash.service ]; then
+# if the new one is not installed in the system. Otherwise, assume
+# the old one is user-created.
+if [ -f /etc/systemd/system/logstash.service ] && \
+   [ ! -f /lib/systemd/system/logstash.service ]; then
   rm -rf /etc/systemd/system/logstash.service || true
 fi

--- a/pkg/debian/before-install.sh
+++ b/pkg/debian/before-install.sh
@@ -12,6 +12,9 @@ if ! getent passwd logstash >/dev/null; then
 fi
 
 # Handle upgrade: Check if old service unit exists and remove it
-if [ -f /etc/systemd/system/logstash.service ]; then
+# if the new one is not installed in the system. Otherwise, assume
+# the old one is user-created.
+if [ -f /etc/systemd/system/logstash.service ] && \
+   [ ! -f /lib/systemd/system/logstash.service ]; then
   rm -rf /etc/systemd/system/logstash.service || true
 fi

--- a/pkg/ubuntu/before-install.sh
+++ b/pkg/ubuntu/before-install.sh
@@ -12,6 +12,9 @@ if ! getent passwd logstash >/dev/null; then
 fi
 
 # Handle upgrade: Check if old service unit exists and remove it
-if [ -f /etc/systemd/system/logstash.service ]; then
+# if the new one is not installed in the system. Otherwise, assume
+# the old one is user-created.
+if [ -f /etc/systemd/system/logstash.service ] && \
+   [ ! -f /lib/systemd/system/logstash.service ]; then
   rm -rf /etc/systemd/system/logstash.service || true
 fi


### PR DESCRIPTION
## What does this PR do?
 During upgrade, Logstash packaging removes `/etc/systemd/system/logstash.service` because Logstahs used to install the systemd unit there. However, this could have been modified by the user by overriding the systemd file. As such, the upgrade process should only remove if it is certain it wasn't installed by Logstash.

Unfortunately, there's no particular way to determine if Logstash installation process installed the file because it was done on the fly, by a script, on a postinst script of the package. 

As such, the best way to address this is to check if both the new and the old file exists. If the new one doesn't exist, we can assume we are upgrading (or installing afresh), and the old file should be removed. If the new one exists and the user-create one (old location) also exists, we assume it is user created, and as such, we don't remove it just to be safe.

## How to test?

### Case 1
1. Build a deb/rpm
2. Install latest 7.17.3. 
3. upgrade to built deb/rpm. 
4. The result is that new file (/lib/systemd/system/logstash.service) install and the old (/etc/systemd/system/logstash.service) would be removed.5. 

### Case 2
1. Build a deb/rpm
2. Install latest 8.2.* 
3. upgrade to built deb/rpm. 
4. Create an override systemd file in /etc/systemd/system/logstash.service
5. The result is that new file (/lib/systemd/system/logstash.service) will be installed and the user-created (/etc/systemd/system/logstash.service) as well.

## Related issues

Closes: #14198

