### PR TITLE
Added necessary spec require, removed instance variable usage of plugin_name

### DIFF
--- a/lib/pluginmanager/templates/filter-plugin/lib/logstash/filters/example.rb.erb
+++ b/lib/pluginmanager/templates/filter-plugin/lib/logstash/filters/example.rb.erb
@@ -1,17 +1,17 @@
 # encoding: utf-8
 require "logstash/filters/base"
 
-# This <%= @plugin_name %> filter will replace the contents of the default
+# This <%= plugin_name %> filter will replace the contents of the default
 # message field with whatever you specify in the configuration.
 #
-# It is only intended to be used as an <%= @plugin_name %>.
+# It is only intended to be used as an <%= plugin_name %>.
 class LogStash::Filters::<%= classify(plugin_name) %> < LogStash::Filters::Base
 
   # Setting the config_name here is required. This is how you
   # configure this filter from your Logstash config.
   #
   # filter {
-  #   <%= @plugin_name %> {
+  #   <%= plugin_name %> {
   #     message => "My message..."
   #   }
   # }

--- a/lib/pluginmanager/templates/input-plugin/lib/logstash/inputs/example.rb.erb
+++ b/lib/pluginmanager/templates/input-plugin/lib/logstash/inputs/example.rb.erb
@@ -8,7 +8,7 @@ require "socket" # for Socket.gethostname
 # This plugin is intented only as an example.
 
 class LogStash::Inputs::<%= classify(plugin_name) %> < LogStash::Inputs::Base
-  config_name "<%= @plugin_name %>"
+  config_name "<%= plugin_name %>"
 
   # If undefined, Logstash will complain, even if codec is unused.
   default :codec, "plain"

--- a/lib/pluginmanager/templates/input-plugin/spec/inputs/example_spec.rb.erb
+++ b/lib/pluginmanager/templates/input-plugin/spec/inputs/example_spec.rb.erb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require 'logstash/devutils/rspec/shared_examples'
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/inputs/<%= plugin_name %>"
 


### PR DESCRIPTION
# closes https://github.com/elastic/logstash/issues/14204

## Release notes
Fixes small issues when generating input and/or filter plugins to include the `plugin_name` rather than just `""`


## What does this PR do?

Two things.
1. switches usage in the `templates/*/example.rb.erb` files from using `@plugin_name` to just `plugin_name`, as the desired value is not available as an instance variable. Most usages were already using `plugin_name`, but a few were not.
2. adds `require 'logstash/devutils/rspec/shared_examples'` to the generated input plugin spec, which is necessary for the generated spec to pass.

## Why is it important/What is the impact to the user?

Without these changes, a user who generates an input plugin may think that the generation was faulty, as the tests do not pass right away, and the generated example cannot be referenced because the `config_name` ends up being `""` instead of `plugin_name`. This decreases confidence in Logstash for a first-time user.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works
  - I actually couldn't find any existing tests for the `bin/logstash-plugin generate` command? Is that right? I'm happy to augment existing tests, but I think it's out of scope for me to write a test suite from scratch.


## How to test this PR locally

* run `bin/logstash-plugin generate --type input --name xkcd --path ~/ws/elastic/plugins` and then verify that you can run `bundle exec rspec` on the generated code, and that the `config_name` is not the empty string.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes https://github.com/elastic/logstash/issues/14204


