### PR TITLE
Refactor: use Java API for RubyString#split

### DIFF
--- a/logstash-core/spec/logstash/util/buftok_spec.rb
+++ b/logstash-core/spec/logstash/util/buftok_spec.rb
@@ -43,4 +43,22 @@ describe  FileWatch::BufferedTokenizer  do
     expect(subject.extract("\n")).to eq([""])
     expect(subject.extract("\n\n\n")).to eq(["", "", ""])
   end
+
+  context 'with delimiter' do
+
+    subject { FileWatch::BufferedTokenizer.new(delimiter) }
+
+    let(:delimiter) { "||" }
+
+    it "should tokenize multiple token" do
+      expect(subject.extract("foo||b|r||")).to eq(["foo", "b|r"])
+    end
+
+    it "should ignore empty payload" do
+      expect(subject.extract("")).to eq([])
+      expect(subject.extract("foo||bar")).to eq(["foo"])
+    end
+
+  end
+
 end

--- a/logstash-core/src/main/java/org/logstash/common/BufferedTokenizerExt.java
+++ b/logstash-core/src/main/java/org/logstash/common/BufferedTokenizerExt.java
@@ -36,10 +36,11 @@ public class BufferedTokenizerExt extends RubyObject {
 
     private static final long serialVersionUID = 1L;
 
-    private static final IRubyObject MINUS_ONE = RubyUtil.RUBY.newFixnum(-1);
+    private static final RubyString NEW_LINE = (RubyString) RubyUtil.RUBY.newString("\n").
+                                                                freeze(RubyUtil.RUBY.getCurrentContext());
 
     private @SuppressWarnings("rawtypes") RubyArray input = RubyUtil.RUBY.newArray();
-    private IRubyObject delimiter = RubyUtil.RUBY.newString("\n");
+    private RubyString delimiter = NEW_LINE;
     private int sizeLimit;
     private boolean hasSizeLimit;
     private int inputSize;
@@ -51,7 +52,7 @@ public class BufferedTokenizerExt extends RubyObject {
     @JRubyMethod(name = "initialize", optional = 2)
     public IRubyObject init(final ThreadContext context, IRubyObject[] args) {
         if (args.length >= 1) {
-            this.delimiter = args[0];
+            this.delimiter = args[0].convertToString();
         }
         if (args.length == 2) {
             this.sizeLimit = args[1].convertToInteger().getIntValue();
@@ -75,7 +76,7 @@ public class BufferedTokenizerExt extends RubyObject {
     @JRubyMethod
     @SuppressWarnings("rawtypes")
     public RubyArray extract(final ThreadContext context, IRubyObject data) {
-        final RubyArray entities = ((RubyString) data).split(context, delimiter, MINUS_ONE);
+        final RubyArray entities = data.convertToString().split(delimiter, -1);
         if (hasSizeLimit) {
             final int entitiesSize = ((RubyString) entities.first()).size();
             if (inputSize + entitiesSize > sizeLimit) {


### PR DESCRIPTION

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

The issue avoids using the 'interal' JRuby (Ruby method) impl API for doing a `String#split`.
This is expected to be safer - the Java equivalent is not expected to have side effects with global variables.

Also clarified the use-case - we never used `BufferedTokenizer.new delimiter = /regex/` which might have had consequences depending on the caller frame (e.g. setting the `$~` last match).

## Why is it important/What is the impact to the user?

No impact expected.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] check `FileWatch::BufferedTokenizer.new(delimiter)` - plugins always pass a `String` delimiter

## How to test this PR locally


## Related issues

- follow-up on the JRuby upgrade (#14114) as the API is only available with JRuby 9.3
