### PR TITLE
Refactor: drop java.util.Collection#inspect extension

### DIFF
--- a/logstash-core/spec/logstash/java_integration_spec.rb
+++ b/logstash-core/spec/logstash/java_integration_spec.rb
@@ -97,7 +97,7 @@ describe "Java integration" do
   context "Java::JavaUtil::Collection" do
     subject{Java::JavaUtil::ArrayList.new(initial_array)}
 
-    context "when inspecting" do
+    context "when inspecting a list" do
       let(:items) { [:a, {:b => :c}] }
       subject { java.util.ArrayList.new(items) }
 
@@ -107,6 +107,21 @@ describe "Java integration" do
 
       it "should include the class name" do
         expect(subject.inspect).to include("ArrayList")
+      end
+    end
+
+    context "when inspecting a set" do
+      let(:items) { [:foo, 'bar'] }
+      subject { java.util.HashSet.new(items) }
+
+      it "should include the contents" do
+        expect(subject.inspect).to include 'bar'
+      end
+
+      it "should include the class name" do
+        expect(subject.inspect).to include("HashSet")
+
+        expect(java.util.TreeSet.new.inspect).to include("TreeSet")
       end
     end
 

--- a/logstash-core/spec/logstash/java_integration_spec.rb
+++ b/logstash-core/spec/logstash/java_integration_spec.rb
@@ -108,10 +108,6 @@ describe "Java integration" do
       it "should include the class name" do
         expect(subject.inspect).to include("ArrayList")
       end
-
-      it "should include the hash code of the collection" do
-        expect(subject.inspect).to include(subject.hashCode.to_s)
-      end
     end
 
     context "when deleting a unique instance" do

--- a/logstash-core/src/main/java/org/logstash/RubyJavaIntegration.java
+++ b/logstash-core/src/main/java/org/logstash/RubyJavaIntegration.java
@@ -213,15 +213,6 @@ public final class RubyJavaIntegration {
             return JavaUtil.convertJavaToUsableRubyObject(context.runtime, dup);
         }
 
-        @JRubyMethod
-        public static IRubyObject inspect(final ThreadContext context, final IRubyObject self) {
-            return RubyString.newString(context.runtime, new StringBuilder("<")
-                .append(self.getMetaClass().name().asJavaString()).append(':')
-                .append(self.hashCode()).append(' ').append(self.convertToArray().inspect())
-                .append('>').toString()
-            );
-        }
-
         private static boolean removeNilAndNull(final Collection<?> collection) {
             final boolean res = collection.removeAll(NIL_COLLECTION);
             return collection.removeAll(NULL_COLLECTION) || res;


### PR DESCRIPTION
since JRuby 9.3 a useful inspect is provided out of the box

LS' inspect: `<Java::JavaUtil::ArrayList:3536147 ["some"]>`
JRuby 9.3's: `#<Java::JavaUtil::ArrayList: [\"some\"]>`

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

## Why is it important/What is the impact to the user?

Low impact, the issue might occur if a Java `Set` type is used with logging e.g.
`logged.debug "foo", bar: some_object_containing_a_set`

## How to test this PR locally

`bin/logstash -i irb` and try doing a `java.util.LinkedHashSet.new [1, 2]`

## Related issues

- actually fixes https://github.com/elastic/logstash/issues/14209