### PR TITLE
use real queue path of individual pipelines within PQ validator

### DIFF
--- a/logstash-core/lib/logstash/persisted_queue_config_validator.rb
+++ b/logstash-core/lib/logstash/persisted_queue_config_validator.rb
@@ -47,7 +47,7 @@ module LogStash
         max_bytes = config.settings.get("queue.max_bytes").to_i
         page_capacity = config.settings.get("queue.page_capacity").to_i
         pipeline_id = config.settings.get("pipeline.id")
-        queue_path = config.settings.get("path.queue")
+        queue_path = Paths.get(config.settings.get("path.queue"), pipeline_id).toString()
         pq_page_glob = ::File.join(queue_path, pipeline_id, "page.*")
         used_bytes = get_page_size(pq_page_glob)
         file_system = get_file_system(queue_path)


### PR DESCRIPTION
## Release notes

## What does this PR do?

This PR fixes the PQ validator implemented by https://github.com/elastic/logstash/pull/13877

It gets the "filesystem" of the real, final queue directory (in case, this is a mounted filesystem)

## Why is it important/What is the impact to the user?

Logstash does not start because the filesystem, where `path.queue` is pointing to, might not have enough disk capacity for all pipelines. It is not verifying, if the final queue directory of the individual pipeline (`path.queue` + `pipeline_id`) is a mounted filesystem.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [ ] Unable to check it **without** additionally mounted disks
- [ ] Not sure, at what point in time the validator starts. Before or after the queue directory should be setup via https://github.com/elastic/logstash/blob/8d01b1649dc848588357d27617c12584753de32f/logstash-core/src/main/java/org/logstash/ackedqueue/QueueFactoryExt.java#L60

## How to test this PR locally

## Related issues

## Use cases

## Screenshots

## Logs

Example setup

`path.queue` is set to `/opt/logstash/queue`

```
$ ls -l /opt/logstash/queue
total 24
drwxrwsr-x. 3 root logstash 4096 Apr 12 11:48 pipeline1
drwxrwsr-x. 3 root logstash 4096 Apr 12 11:48 pipeline2
drwxrwsr-x. 3 root logstash 4096 Apr 12 11:48 pipeline3
$ df -h

Filesystem      Size  Used Avail Use% Mounted on
overlay          60G   12G   46G  21% /
tmpfs            64M     0   64M   0% /dev
/dev/sda9        60G   12G   46G  21% /etc/hosts
shm              64M     0   64M   0% /dev/shm
tmpfs           8.0G   68K  8.0G   1% /opt/logstash/config/certs
/dev/sdl         49G   36K   49G   1% /opt/logstash/queue/pipeline1
/dev/sdk        2.0G   36K  1.9G   1% /opt/logstash/queue/pipeline2
/dev/sdj         49G   36K   49G   1% /opt/logstash/queue/pipeline3
tmpfs            32G     0   32G   0% /proc/acpi
tmpfs            32G     0   32G   0% /proc/scsi
tmpfs            32G     0   32G   0% /sys/firmware
$
```

Before this PR, if you have multiple pipelines running, you can see this error
```
{"level":"ERROR","loggerName":"logstash.agent","timeMillis":1653995699128,"thread":"Agent thread","logEvent":{"message":"An exception happened when converging configuration","exception":{"metaClass":{"metaClass":{"exception":"LogStash::BootstrapCheckError","message":"Persistent queue path /opt/logstash/queue is unable to allocate 101669928960 more bytes on top of its current usage."}}}}}
```
