### PR TITLE
Doc: Replace missing intro file for eval/edit

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -21,21 +21,8 @@ include::./include/attributes-lsplugins.asciidoc[]
 :lsplugindocs:          https://www.elastic.co/guide/en/logstash-versioned-plugins/current
 
 
-[[introduction]]
-== Logstash Introduction
-
-Logstash is an open source data collection engine with real-time pipelining capabilities. Logstash can dynamically
-unify data from disparate sources and normalize the data into destinations of your choice. Cleanse and democratize all
-your data for diverse advanced downstream analytics and visualization use cases.
-
-While Logstash originally drove innovation in log collection, its capabilities extend well beyond that use case. Any
-type of event can be enriched and transformed with a broad array of input, filter, and output plugins, with many
-native codecs further simplifying the ingestion process. Logstash accelerates your insights by harnessing a greater
-volume and variety of data.
-
-// The pass blocks here point to the correct repository for the edit links in the guide.
-
 // Introduction
+include::static/introduction.asciidoc[]
 
 // Getting Started with Logstash
 include::static/getting-started-with-logstash.asciidoc[]

--- a/docs/static/introduction.asciidoc
+++ b/docs/static/introduction.asciidoc
@@ -1,6 +1,19 @@
+[[introduction]]
+== Logstash introduction
+
+Logstash is an open source data collection engine with real-time pipelining capabilities. Logstash can dynamically
+unify data from disparate sources and normalize the data into destinations of your choice. Cleanse and democratize all
+your data for diverse advanced downstream analytics and visualization use cases.
+
+While Logstash originally drove innovation in log collection, its capabilities extend well beyond that use case. Any
+type of event can be enriched and transformed with a broad array of input, filter, and output plugins, with many
+native codecs further simplifying the ingestion process. Logstash accelerates your insights by harnessing a greater
+volume and variety of data.
+
+
 [float]
 [[power-of-logstash]]
-== The Power of Logstash
+== The power of Logstash
 
 *The ingestion workhorse for Elasticsearch and more*
 
@@ -17,12 +30,12 @@ Over 200 plugins available, plus the flexibility of creating and contributing yo
 image:static/images/logstash.png[]
 
 [float]
-== Logstash Loves Data
+== Logstash loves data
 
 Collect more, so you can know more. Logstash welcomes data of all shapes and sizes.
 
 [float]
-=== Logs and Metrics
+=== Logs and metrics
 
 Where it all started.
 
@@ -49,7 +62,7 @@ Unlock the World Wide Web.
 ** Perfect for scenarios where the control of polling is preferred over receiving
 
 [float]
-=== Data Stores and Streams
+=== Data stores and streams
 
 Discover more value from the data you already own.
 
@@ -69,7 +82,7 @@ harnessing data from connected sensors.
 homes, connected vehicles, healthcare sensors, and many other industry specific applications.
 
 [float]
-== Easily Enrich Everything
+== Easily enrich everything
 
 The better the data, the better the knowledge. Clean and transform your data during ingestion to gain near real-time
 insights immediately at index or output time. Logstash comes out-of-box with many aggregations and mutations along
@@ -89,7 +102,7 @@ and {logstash-ref}/plugins-codecs-multiline.html[multiline] events.
 See {logstash-ref}/transformation.html[Transforming Data] for an overview of some of the popular data processing plugins.
 
 [float]
-== Choose Your Stash
+== Choose your stash
 
 Route your data where it matters most. Unlock various downstream analytical and operational use cases by storing,
 analyzing, and taking action on your data.


### PR DESCRIPTION
A source file with introductory content was removed from the Logstash Reference in error during a major overhaul. 
This PR:
* re-adds the file
* Moves additional introductory content out of index file and to the re-added file where it makes more sense. (The "other" introductory content floating loose in the index file is likely what led to this error.) 
* Fixed some headings to bring them up to standard wrt sentence capitalization (because I can't help myself) 

#### Objectives
Evaluate this content to see if we want to keep it. If so, update it to bring it inline with current product status/messaging and doc standards. 

Related: #14216. I discovered this issue when I was reworking introductory content in  #14220.

Note to self @karenzone: If we move forward with this PR, #14220 will need some rework (and conflict resolution) to remove duplicate changes. 

#### Preview: https://logstash_14221.docs-preview.app.elstc.co/guide/en/logstash/master/introduction.html

