### PR TITLE
Add Github Action workflow for release notes generation

### DIFF
--- a/.github/workflows/gen_release_notes.yml
+++ b/.github/workflows/gen_release_notes.yml
@@ -1,0 +1,35 @@
+name: Release Notes Draft generator
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        type: string
+        required: true
+        default: "8.2"
+      last_release:
+        type: string
+        required: true
+        default: "8.2.2"
+
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.0'
+    - run: git config --global user.email "43502315+logstashmachine@users.noreply.github.com"
+    - run: git config --global user.name "logstashmachine"
+    - name: Create Release Notes Draft
+      run:  ./tools/release/generate_release_notes.rb ${{ github.event.inputs.branch }} ${{ github.event.inputs.last_release }} ${{ github.actor }} ${{ secrets.GITHUB_TOKEN }}

--- a/tools/release/generate_release_notes.rb
+++ b/tools/release/generate_release_notes.rb
@@ -122,13 +122,13 @@ branch_name = "update_release_notes_#{Time.now.to_i}"
 
 
 puts "Pushing commit.."
-`git remote set-url origin https://x-access-token:#{token}@github.com/jsvd/logstash.git`
+`git remote set-url origin https://x-access-token:#{token}@github.com/elastic/logstash.git`
 `git push origin #{branch_name}`
 
 puts "Creating Pull Request"
 pr_title = "Release notes for #{current_release}"
-result = `curl -H "Authorization: token #{token}" -d '{"title":"#{pr_title}","base":"#{release_branch}", "head":"#{branch_name}", "draft": true}' https://api.github.com/repos/jsvd/logstash/pulls`
+result = `curl -H "Authorization: token #{token}" -d '{"title":"#{pr_title}","base":"#{release_branch}", "head":"#{branch_name}", "draft": true}' https://api.github.com/repos/elastic/logstash/pulls`
 puts result
 pr_number = JSON.parse(result)["number"]
-puts `curl -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token #{token}" https://api.github.com/repos/jsvd/logstash/issues/#{pr_number}/assignees -d '{"assignees":["#{user}"]}'`
+puts `curl -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token #{token}" https://api.github.com/repos/elastic/logstash/issues/#{pr_number}/assignees -d '{"assignees":["#{user}"]}'`
 puts "Done"

--- a/tools/release/generate_release_notes.rb
+++ b/tools/release/generate_release_notes.rb
@@ -30,6 +30,8 @@ require 'net/http'
 RELEASE_NOTES_PATH = "docs/static/releasenotes.asciidoc"
 release_branch = ARGV[0]
 previous_release_tag = ARGV[1]
+user = ARGV[2]
+token = ARGV[3]
 report = []
 
 `git checkout #{release_branch}`
@@ -118,12 +120,15 @@ branch_name = "update_release_notes_#{Time.now.to_i}"
 `git checkout -b #{branch_name}`
 `git commit docs/static/releasenotes.asciidoc -m "Update release notes for #{current_release}"`
 
+
 puts "Pushing commit.."
-`git remote add upstream git@github.com:elastic/logstash.git`
-`git push upstream #{branch_name}`
+`git remote set-url origin https://x-access-token:#{token}@github.com/jsvd/logstash.git`
+`git push origin #{branch_name}`
 
 puts "Creating Pull Request"
-pr_title = "Release notes draft for #{current_release}"
-`curl -H "Authorization: token #{ENV['GITHUB_TOKEN']}" -d '{"title":"#{pr_title}","base":"#{ENV['branch_specifier']}", "head":"#{branch_name}"}' https://api.github.com/repos/elastic/logstash/pulls`
-
+pr_title = "Release notes for #{current_release}"
+result = `curl -H "Authorization: token #{token}" -d '{"title":"#{pr_title}","base":"#{release_branch}", "head":"#{branch_name}", "draft": true}' https://api.github.com/repos/jsvd/logstash/pulls`
+puts result
+pr_number = JSON.parse(result)["number"]
+puts `curl -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token #{token}" https://api.github.com/repos/jsvd/logstash/issues/#{pr_number}/assignees -d '{"assignees":["#{user}"]}'`
 puts "Done"


### PR DESCRIPTION
This change takes the existing release notes draft generator script and wraps it into a GH action workflow.

The workflow just runs the script, which is responsible for computing the draft and creating a Pull Request.

The remaining changes are niceties:
1. instead of creating a PR titled "Release notes draft", create a "Release notes" draft PR
2. assign the PR to the person that executed the workflow, to facilitate tracking

Example: https://github.com/jsvd/logstash/pull/6