### PR TITLE
improve resiliency of make venv with retrying pip install

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -148,7 +148,7 @@ venv: requirements.txt
 	pyenv install --skip-existing $(PY_VERSION) &&\
 	pyenv local $(PY_VERSION) &&\
 	python3 -mvenv venv && \
-	for i in $(seq 0 5); do sleep $i; pip install -r requirements.txt && break; done &&\
+	for i in $(seq 0 5); do sleep "$i"; pip install -r requirements.txt && break; done &&\
 	touch venv
 
 # Make a Golang container that can compile our env2yaml tool.

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -148,7 +148,7 @@ venv: requirements.txt
 	pyenv install --skip-existing $(PY_VERSION) &&\
 	pyenv local $(PY_VERSION) &&\
 	python3 -mvenv venv && \
-	for i in {0..5}; do sleep $i; pip install -r requirements.txt && break; done &&\
+	for i in $(seq 0 5); do sleep $i; pip install -r requirements.txt && break; done &&\
 	touch venv
 
 # Make a Golang container that can compile our env2yaml tool.

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -148,7 +148,7 @@ venv: requirements.txt
 	pyenv install --skip-existing $(PY_VERSION) &&\
 	pyenv local $(PY_VERSION) &&\
 	python3 -mvenv venv && \
-	pip install -r requirements.txt &&\
+	for i in {0..5}; do sleep $i; pip install -r requirements.txt && break; done &&\
 	touch venv
 
 # Make a Golang container that can compile our env2yaml tool.

--- a/docker/data/golang/Dockerfile
+++ b/docker/data/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.1
-RUN go env -w GO111MODULE=off && go get gopkg.in/yaml.v2
+FROM golang:1
+RUN go env -w GO111MODULE=off && (for i in $(seq 0 5); do sleep "$i"; go get gopkg.in/yaml.v2 && break; done)
 WORKDIR /usr/local/src/env2yaml
 CMD ["go", "build"]


### PR DESCRIPTION
Sometimes during a build the `make venv` task can fail while executing `pip install` if there's a network issue.

This change introduces 5 retries to the pip install command, each spaced by 5 seconds, in case of error.