### PR TITLE
Mark all not serializable fields as transient

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyAckedQueueExt.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyAckedQueueExt.java
@@ -46,6 +46,7 @@ public final class JRubyAckedQueueExt extends RubyObject {
 
     private static final long serialVersionUID = 1L;
 
+    @SuppressWarnings("serial")
     private Queue queue;
 
     public JRubyAckedQueueExt(final Ruby runtime, final RubyClass metaClass) {

--- a/logstash-core/src/main/java/org/logstash/common/AbstractDeadLetterQueueWriterExt.java
+++ b/logstash-core/src/main/java/org/logstash/common/AbstractDeadLetterQueueWriterExt.java
@@ -139,13 +139,13 @@ public abstract class AbstractDeadLetterQueueWriterExt extends RubyObject {
 
         private static final long serialVersionUID = 1L;
 
-        private IRubyObject writerWrapper;
+        private transient IRubyObject writerWrapper;
 
-        private DeadLetterQueueWriter innerWriter;
+        private transient DeadLetterQueueWriter innerWriter;
 
-        private IRubyObject pluginId;
+        private transient IRubyObject pluginId;
 
-        private IRubyObject pluginType;
+        private transient IRubyObject pluginType;
 
         private String pluginIdString;
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java
@@ -48,11 +48,11 @@ public abstract class AbstractFilterDelegatorExt extends RubyObject {
 
     protected RubyString id;
 
-    protected LongCounter eventMetricOut;
+    protected transient LongCounter eventMetricOut;
 
-    protected LongCounter eventMetricIn;
+    protected transient LongCounter eventMetricIn;
 
-    protected LongCounter eventMetricTime;
+    protected transient LongCounter eventMetricTime;
 
     public AbstractFilterDelegatorExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java
@@ -53,11 +53,11 @@ public abstract class AbstractOutputDelegatorExt extends RubyObject {
 
     private RubyString id;
 
-    private LongCounter eventMetricOut;
+    private transient LongCounter eventMetricOut;
 
-    private LongCounter eventMetricIn;
+    private transient LongCounter eventMetricIn;
 
-    private LongCounter eventMetricTime;
+    private transient LongCounter eventMetricTime;
 
     public AbstractOutputDelegatorExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
@@ -48,9 +48,9 @@ public final class FilterDelegatorExt extends AbstractFilterDelegatorExt {
 
     private RubyClass filterClass;
 
-    private IRubyObject filter;
+    private transient IRubyObject filter;
 
-    private DynamicMethod filterMethod;
+    private transient DynamicMethod filterMethod;
 
     private boolean flushes;
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaFilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaFilterDelegatorExt.java
@@ -52,9 +52,9 @@ public class JavaFilterDelegatorExt extends AbstractFilterDelegatorExt {
 
     private RubyString configName;
 
-    private Filter filter;
+    private transient Filter filter;
 
-    private FilterMatchListener filterMatchListener;
+    private transient FilterMatchListener filterMatchListener;
 
     public JavaFilterDelegatorExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaInputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaInputDelegatorExt.java
@@ -47,9 +47,9 @@ public class JavaInputDelegatorExt extends RubyObject {
 
     private JavaBasePipelineExt pipeline;
 
-    private Input input;
+    private transient Input input;
 
-    private DecoratingQueueWriter decoratingQueueWriter;
+    private transient DecoratingQueueWriter decoratingQueueWriter;
 
     public JavaInputDelegatorExt(Ruby runtime, RubyClass metaClass) {
         super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaOutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaOutputDelegatorExt.java
@@ -47,13 +47,13 @@ public final class JavaOutputDelegatorExt extends AbstractOutputDelegatorExt {
 
     private RubyString configName;
 
-    private Consumer<Collection<JrubyEventExtLibrary.RubyEvent>> outputFunction;
+    private transient Consumer<Collection<JrubyEventExtLibrary.RubyEvent>> outputFunction;
 
-    private Runnable closeAction;
+    private transient Runnable closeAction;
 
-    private Runnable registerAction;
+    private transient Runnable registerAction;
 
-    private Output output;
+    private transient Output output;
 
     public JavaOutputDelegatorExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputDelegatorExt.java
@@ -43,7 +43,7 @@ OutputDelegatorExt extends AbstractOutputDelegatorExt {
 
     private static final long serialVersionUID = 1L;
 
-    private IRubyObject outputClass;
+    private transient IRubyObject outputClass;
 
     private OutputStrategyExt.AbstractOutputStrategyExt strategy;
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
@@ -117,7 +117,7 @@ public final class OutputStrategyExt {
 
         private static final long serialVersionUID = 1L;
 
-        private DynamicMethod outputMethod;
+        private transient DynamicMethod outputMethod;
 
         private RubyClass outputClass;
 
@@ -169,9 +169,9 @@ public final class OutputStrategyExt {
 
         private static final long serialVersionUID = 1L;
 
-        private BlockingQueue<IRubyObject> workerQueue;
+        private transient BlockingQueue<IRubyObject> workerQueue;
 
-        private IRubyObject workerCount;
+        private transient IRubyObject workerCount;
 
         private @SuppressWarnings({"rawtypes"}) RubyArray workers;
 
@@ -244,7 +244,7 @@ public final class OutputStrategyExt {
 
         private static final long serialVersionUID = 1L;
 
-        private IRubyObject output;
+        private transient IRubyObject output;
 
         protected SimpleAbstractOutputStrategyExt(final Ruby runtime, final RubyClass metaClass) {
             super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -122,6 +122,7 @@ public class AbstractPipelineExt extends RubyBasicObject {
         RubyUtil.RUBY, new IRubyObject[]{MetricKeys.STATS_KEY, MetricKeys.EVENTS_KEY}
     );
 
+    @SuppressWarnings("serial")
     protected PipelineIR lir;
 
     private final RubyString ephemeralId = RubyUtil.RUBY.newString(UUID.randomUUID().toString());
@@ -130,20 +131,20 @@ public class AbstractPipelineExt extends RubyBasicObject {
 
     private RubyString configString;
 
-    @SuppressWarnings("rawtypes")
+    @SuppressWarnings({"rawtypes", "serial"})
     private List<SourceWithMetadata> configParts;
 
     private RubyString configHash;
 
-    private IRubyObject settings;
+    private transient IRubyObject settings;
 
-    private IRubyObject pipelineSettings;
+    private transient IRubyObject pipelineSettings;
 
-    private IRubyObject pipelineId;
+    private transient IRubyObject pipelineId;
 
-    private AbstractMetricExt metric;
+    private transient AbstractMetricExt metric;
 
-    private IRubyObject dlqWriter;
+    private transient IRubyObject dlqWriter;
 
     private PipelineReporterExt reporter;
 

--- a/logstash-core/src/main/java/org/logstash/execution/ConvergeResultExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/ConvergeResultExt.java
@@ -41,7 +41,7 @@ public class ConvergeResultExt extends RubyObject {
 
     private static final long serialVersionUID = 1L;
 
-    private IRubyObject expectedActionsCount;
+    private transient IRubyObject expectedActionsCount;
     private ConcurrentHashMap<IRubyObject, ActionResultExt> actions;
 
     public ConvergeResultExt(Ruby runtime, RubyClass metaClass) {
@@ -113,7 +113,7 @@ public class ConvergeResultExt extends RubyObject {
 
         private static final long serialVersionUID = 1L;
 
-        private IRubyObject executedAt;
+        private transient IRubyObject executedAt;
 
         protected ActionResultExt(Ruby runtime, RubyClass metaClass) {
             super(runtime, metaClass);
@@ -167,8 +167,8 @@ public class ConvergeResultExt extends RubyObject {
 
         private static final long serialVersionUID = 1L;
 
-        private IRubyObject message;
-        private IRubyObject backtrace;
+        private transient IRubyObject message;
+        private transient IRubyObject backtrace;
 
         public FailedActionExt(Ruby runtime, RubyClass metaClass) {
             super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/execution/EventDispatcherExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/EventDispatcherExt.java
@@ -38,9 +38,9 @@ public final class EventDispatcherExt extends RubyBasicObject {
 
     private static final long serialVersionUID = 1L;
 
-    private final Collection<IRubyObject> listeners = new CopyOnWriteArraySet<>();
+    private final transient Collection<IRubyObject> listeners = new CopyOnWriteArraySet<>();
 
-    private IRubyObject emitter;
+    private transient IRubyObject emitter;
 
     public EventDispatcherExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/execution/ExecutionContextExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/ExecutionContextExt.java
@@ -42,9 +42,9 @@ public final class ExecutionContextExt extends RubyObject {
 
     private AbstractDeadLetterQueueWriterExt dlqWriter;
 
-    private IRubyObject agent;
+    private transient IRubyObject agent;
 
-    private IRubyObject pipeline;
+    private transient IRubyObject pipeline;
 
     public ExecutionContextExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/execution/JavaBasePipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/JavaBasePipelineExt.java
@@ -54,7 +54,7 @@ public final class JavaBasePipelineExt extends AbstractPipelineExt {
 
     private static final Logger LOGGER = LogManager.getLogger(JavaBasePipelineExt.class);
 
-    private CompiledPipeline lirExecution;
+    private transient CompiledPipeline lirExecution;
 
     private @SuppressWarnings("rawtypes") RubyArray inputs;
 

--- a/logstash-core/src/main/java/org/logstash/execution/PipelineReporterExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/PipelineReporterExt.java
@@ -81,9 +81,9 @@ public final class PipelineReporterExt extends RubyBasicObject {
     private static final RubyString DEAD_STATUS =
         RubyUtil.RUBY.newString("dead").newFrozen();
 
-    private IRubyObject logger;
+    private transient IRubyObject logger;
 
-    private IRubyObject pipeline;
+    private transient IRubyObject pipeline;
 
     public PipelineReporterExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBase.java
+++ b/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBase.java
@@ -51,16 +51,15 @@ public abstract class QueueReadClientBase extends RubyObject implements QueueRea
     protected long waitForNanos = 50 * 1000 * 1000; // 50 millis to nanos
     protected long waitForMillis = 50;
 
-    private final ConcurrentHashMap<Long, QueueBatch> inflightBatches =
-            new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Long, QueueBatch> inflightBatches = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<Long, Long> inflightClocks = new ConcurrentHashMap<>();
 
-    private LongCounter eventMetricOut;
-    private LongCounter eventMetricFiltered;
-    private LongCounter eventMetricTime;
-    private LongCounter pipelineMetricOut;
-    private LongCounter pipelineMetricFiltered;
-    private LongCounter pipelineMetricTime;
+    private transient LongCounter eventMetricOut;
+    private transient LongCounter eventMetricFiltered;
+    private transient LongCounter eventMetricTime;
+    private transient LongCounter pipelineMetricOut;
+    private transient LongCounter pipelineMetricFiltered;
+    private transient LongCounter pipelineMetricTime;
 
     protected QueueReadClientBase(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/execution/ShutdownWatcherExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/ShutdownWatcherExt.java
@@ -49,7 +49,7 @@ public final class ShutdownWatcherExt extends RubyBasicObject {
 
     private static final AtomicBoolean unsafeShutdown = new AtomicBoolean(false);
 
-    private final List<IRubyObject> reports = new ArrayList<>();
+    private final transient List<IRubyObject> reports = new ArrayList<>();
 
     private final AtomicInteger attemptsCount = new AtomicInteger(0);
 
@@ -61,7 +61,7 @@ public final class ShutdownWatcherExt extends RubyBasicObject {
 
     private int abortThreshold = 3;
 
-    private IRubyObject pipeline;
+    private transient IRubyObject pipeline;
 
     @JRubyMethod(name = "unsafe_shutdown?", meta = true)
     public static IRubyObject isUnsafeShutdown(final ThreadContext context,

--- a/logstash-core/src/main/java/org/logstash/ext/JRubyWrappedWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JRubyWrappedWriteClientExt.java
@@ -49,14 +49,14 @@ public final class JRubyWrappedWriteClientExt extends RubyObject implements Queu
 
     private JRubyAbstractQueueWriteClientExt writeClient;
 
-    private LongCounter eventsMetricsCounter;
-    private LongCounter eventsMetricsTime;
+    private transient LongCounter eventsMetricsCounter;
+    private transient LongCounter eventsMetricsTime;
 
-    private LongCounter pipelineMetricsCounter;
-    private LongCounter pipelineMetricsTime;
+    private transient LongCounter pipelineMetricsCounter;
+    private transient LongCounter pipelineMetricsTime;
 
-    private LongCounter pluginMetricsCounter;
-    private LongCounter pluginMetricsTime;
+    private transient LongCounter pluginMetricsCounter;
+    private transient LongCounter pluginMetricsTime;
 
     public JRubyWrappedWriteClientExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyEventExtLibrary.java
@@ -67,7 +67,7 @@ public final class JrubyEventExtLibrary {
          */
         private final int hash = nextHash();
 
-        private Event event;
+        private transient Event event;
 
         public RubyEvent(final Ruby runtime, final RubyClass klass) {
             super(runtime, klass);

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryReadClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryReadClientExt.java
@@ -39,7 +39,7 @@ public final class JrubyMemoryReadClientExt extends QueueReadClientBase {
 
     private static final long serialVersionUID = 1L;
 
-    @SuppressWarnings("rawtypes") private BlockingQueue queue;
+    @SuppressWarnings({"rawtypes", "serial"}) private BlockingQueue queue;
 
     public JrubyMemoryReadClientExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryWriteClientExt.java
@@ -36,7 +36,7 @@ public final class JrubyMemoryWriteClientExt extends JRubyAbstractQueueWriteClie
 
     private static final long serialVersionUID = 1L;
 
-    private BlockingQueue<JrubyEventExtLibrary.RubyEvent> queue;
+    private transient BlockingQueue<JrubyEventExtLibrary.RubyEvent> queue;
 
     public JrubyMemoryWriteClientExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyTimestampExtLibrary.java
@@ -48,7 +48,7 @@ public final class JrubyTimestampExtLibrary {
 
         private static final long serialVersionUID = 1L;
 
-        private Timestamp timestamp;
+        private transient Timestamp timestamp;
 
         public RubyTimestamp(Ruby runtime, RubyClass klass) {
             super(runtime, klass);

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyWrappedSynchronousQueueExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyWrappedSynchronousQueueExt.java
@@ -40,7 +40,7 @@ public final class JrubyWrappedSynchronousQueueExt extends AbstractWrappedQueueE
 
     private static final long serialVersionUID = 1L;
 
-    private BlockingQueue<JrubyEventExtLibrary.RubyEvent> queue;
+    private transient BlockingQueue<JrubyEventExtLibrary.RubyEvent> queue;
 
     public JrubyWrappedSynchronousQueueExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricExt.java
@@ -54,7 +54,7 @@ public final class MetricExt extends AbstractSimpleMetricExt {
 
     private static final RubySymbol SET = RubyUtil.RUBY.newSymbol("set");
 
-    private IRubyObject collector;
+    private transient IRubyObject collector;
 
     public MetricExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);
@@ -185,9 +185,9 @@ public final class MetricExt extends AbstractSimpleMetricExt {
 
         private MetricExt metric;
 
-        private IRubyObject namespace;
+        private transient IRubyObject namespace;
 
-        private IRubyObject key;
+        private transient IRubyObject key;
 
         public static MetricExt.TimedExecution create(final MetricExt metric,
             final IRubyObject namespace, final IRubyObject key) {

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/NullMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/NullMetricExt.java
@@ -37,7 +37,7 @@ public final class NullMetricExt extends AbstractSimpleMetricExt {
 
     private static final long serialVersionUID = 1L;
 
-    private IRubyObject collector;
+    private transient IRubyObject collector;
 
     public static NullMetricExt create() {
         return new NullMetricExt(

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/SnapshotExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/SnapshotExt.java
@@ -34,9 +34,9 @@ public final class SnapshotExt extends RubyBasicObject {
 
     private static final long serialVersionUID = 1L;
 
-    private IRubyObject metricStore;
+    private transient IRubyObject metricStore;
 
-    private RubyTime createdAt;
+    private transient RubyTime createdAt;
 
     public SnapshotExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/log/DeprecationLoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/DeprecationLoggerExt.java
@@ -37,7 +37,7 @@ public class DeprecationLoggerExt extends RubyObject {
 
     private static final long serialVersionUID = 1L;
 
-    private DeprecationLogger logger;
+    private transient DeprecationLogger logger;
 
     public DeprecationLoggerExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/log/LoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/LoggerExt.java
@@ -49,7 +49,7 @@ public class LoggerExt extends RubyObject {
     private static final long serialVersionUID = 1L;
 
     private static final Object CONFIG_LOCK = new Object();
-    private Logger logger;
+    private transient Logger logger;
 
     public LoggerExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/log/SlowLoggerExt.java
+++ b/logstash-core/src/main/java/org/logstash/log/SlowLoggerExt.java
@@ -48,7 +48,7 @@ public class SlowLoggerExt extends RubyObject {
     private static final RubySymbol EVENT = RubyUtil.RUBY.newSymbol("event");
     private static final RubyNumeric NANO_TO_MILLI = RubyUtil.RUBY.newFixnum(1000000);
 
-    private Logger slowLogger;
+    private transient Logger slowLogger;
     private long warnThreshold;
     private long infoThreshold;
     private long debugThreshold;

--- a/logstash-core/src/main/java/org/logstash/log/StructuredMessage.java
+++ b/logstash-core/src/main/java/org/logstash/log/StructuredMessage.java
@@ -35,7 +35,7 @@ public class StructuredMessage implements Message {
     private static final long serialVersionUID = 1L;
 
     private final String message;
-    private final Map<Object, Object> params;
+    private final transient Map<Object, Object> params;
 
     @SuppressWarnings({"unchecked","rawtypes"})
     public StructuredMessage(String message) {

--- a/logstash-core/src/main/java/org/logstash/plugins/factory/ExecutionContextFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/factory/ExecutionContextFactoryExt.java
@@ -27,11 +27,11 @@ public final class ExecutionContextFactoryExt extends RubyBasicObject {
 
     private static final long serialVersionUID = 1L;
 
-    private IRubyObject agent;
+    private transient IRubyObject agent;
 
-    private IRubyObject pipeline;
+    private transient IRubyObject pipeline;
 
-    private IRubyObject dlqWriter;
+    private transient IRubyObject dlqWriter;
 
     public ExecutionContextFactoryExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/factory/PluginFactoryExt.java
@@ -44,9 +44,9 @@ public final class PluginFactoryExt extends RubyBasicObject
 
     private static final RubyString ID_KEY = RubyUtil.RUBY.newString("id");
 
-    private final Collection<String> pluginsById = ConcurrentHashMap.newKeySet();
+    private final transient Collection<String> pluginsById = ConcurrentHashMap.newKeySet();
 
-    private PipelineIR lir;
+    private transient PipelineIR lir;
 
     private ExecutionContextFactoryExt executionContextFactory;
 
@@ -54,11 +54,11 @@ public final class PluginFactoryExt extends RubyBasicObject
 
     private RubyClass filterDelegatorClass;
 
-    private ConfigVariableExpander configVariables;
+    private transient ConfigVariableExpander configVariables;
 
-    private PluginResolver pluginResolver;
+    private transient PluginResolver pluginResolver;
 
-    private Map<PluginLookup.PluginType, AbstractPluginCreator<? extends Plugin>> pluginCreatorsRegistry = new HashMap<>(4);
+    private final transient Map<PluginLookup.PluginType, AbstractPluginCreator<? extends Plugin>> pluginCreatorsRegistry = new HashMap<>(4);
 
     @JRubyMethod(name = "filter_delegator", meta = true, required = 5)
     public static IRubyObject filterDelegator(final ThreadContext context,

--- a/logstash-core/src/main/java/org/logstash/secret/store/backend/JavaKeyStore.java
+++ b/logstash-core/src/main/java/org/logstash/secret/store/backend/JavaKeyStore.java
@@ -32,14 +32,24 @@ import org.logstash.secret.store.SecureConfig;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
-import java.io.*;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.channels.FileLock;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.*;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.security.KeyStore;
@@ -49,7 +59,11 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
-import java.util.*;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -158,14 +172,6 @@ public final class JavaKeyStore implements SecretStore {
             return false;
         }
         return new File(new String(path)).exists();
-    }
-
-    // Object#finalize() is deprecated, but `Cleaner` alternative did not ship until Java 9;
-    // since this project still supports Java 8, suppress the warning.
-    @SuppressWarnings("deprecation")
-    @Override
-    protected void finalize() throws Throwable {
-        SecretStoreUtil.clearChars(keyStorePass);
     }
 
     /**

--- a/tools/jvm-options-parser/src/main/java/org/logstash/launchers/JvmOptionsParser.java
+++ b/tools/jvm-options-parser/src/main/java/org/logstash/launchers/JvmOptionsParser.java
@@ -67,6 +67,7 @@ public class JvmOptionsParser {
     };
 
 
+    @SuppressWarnings("serial")
     static class JvmOptionsFileParserException extends Exception {
 
         private static final long serialVersionUID = 2446165130736962758L;


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip] 

## What does this PR do?

With JDK 18, the [Javac lint checking was expanded](https://bugs.openjdk.org/browse/JDK-8274336) to raise an error on serializable subclasses that contains instance fields which are not serializable themselves. 
```
/home/andrea/workspace/logstash_andsel/tools/jvm-options-parser/src/main/java/org/logstash/launchers/JvmOptionsParser.java:74: warning: [serial] non-transient instance field of a serializable class declared with a non-serializable type
        private final Path jvmOptionsFile;
```
This could be solved suppressing the warning or marking the field as `transient`. The majority of classes with this problem inherit transitively from `Serializable` but are not intended to be serialized (from Java's serialization mechanism) because has the `serialVersionUID = 1L` which is just a fix to make linter happy, but are not effectively used in a serialization context.

This commit also removes a `finalize` method, that could be safely be removed.

## Why is it important/What is the impact to the user?

Resolving the `javac:lint` warnings permit to run the tests and integration tests with JDK18

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] run build and test with JDK 18

## How to test this PR locally

- install a JDK 18 and set as default JDK. I used `sdkman`
```
sdk install java 18.0.1-tem
-or-
sdk install java 18.0.1.1-open
```
- run the build and verify it's ok
```
./gradlew clean installDefaultGems
``` 
- run unit and integration tests:
```
export BUILD_JAVA_HOME=/home/andrea/.sdkman/candidates/java/18.0.1-tem
ci/unit_tests.sh
ci/integration_tests.sh
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #14230

## Use cases

As a developer I want to build and test successfully with JDK 18 
