### PR TITLE
Deps: update manticore due JRuby 9.3 issue

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -671,7 +671,7 @@ GEM
     lru_redux (1.1.0)
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
-    manticore (0.9.0-java)
+    manticore (0.9.1-java)
       openssl_pkcs8_pure
     march_hare (4.4.0-java)
     memoizable (0.4.2)


### PR DESCRIPTION
Manticore 0.9.1 includes a work-around for a JRuby 9.3 incompatibility.
Reproduced with http_poller's test suite, details: https://github.com/logstash-plugins/logstash-input-http_poller/issues/135

following up on the recent gem update: https://github.com/elastic/logstash/pull/14233

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]
