### PR TITLE
Implement DLQ age retention policy

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -278,6 +278,15 @@
 #
 # dead_letter_queue.storage_policy: drop_newer
 
+# If using dead_letter_queue.enable: true, the interval that events have to be considered valid. After the interval has
+# expired the events could be automatically deleted from the DLQ.
+# The interval could be expressed in days, hours, minutes or seconds, using as postfix notation like 5d,
+# to represent a five days interval.
+# The available units are respectively d, h, m, s for day, hours and so on. If not specified it's considered to be seconds.
+# If not specified then the DLQ doesn't use any age policy for cleaning events.
+#
+# dead_letter_queue.retain.age: 1d
+
 # If using dead_letter_queue.enable: true, defines the action to take when the dead_letter_queue.max_bytes is reached,
 # could be "drop_newer" or "drop_older".
 # With drop_newer, messages that were inserted most recently are dropped, logging an error line.

--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -282,7 +282,7 @@
 # expired the events could be automatically deleted from the DLQ.
 # The interval could be expressed in days, hours, minutes or seconds, using as postfix notation like 5d,
 # to represent a five days interval.
-# The available units are respectively d, h, m, s for day, hours and so on. If not specified it's considered to be seconds.
+# The available units are respectively d, h, m, s for day, hours, minutes and seconds.
 # If not specified then the DLQ doesn't use any age policy for cleaning events.
 #
 # dead_letter_queue.retain.age: 1d

--- a/docker/data/logstash/env2yaml/env2yaml.go
+++ b/docker/data/logstash/env2yaml/env2yaml.go
@@ -84,6 +84,7 @@ func normalizeSetting(setting string) (string, error) {
 		"dead_letter_queue.max_bytes",
 		"dead_letter_queue.flush_interval",
 		"dead_letter_queue.storage_policy",
+		"dead_letter_queue.retain.age",
 		"path.dead_letter_queue",
 		"http.enabled",     // DEPRECATED: prefer `api.enabled`
 		"http.environment", // DEPRECATED: prefer `api.environment`

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -100,6 +100,7 @@ module LogStash
              Setting::Bytes.new("dead_letter_queue.max_bytes", "1024mb"),
            Setting::Numeric.new("dead_letter_queue.flush_interval", 5000),
             Setting::String.new("dead_letter_queue.storage_policy", "drop_newer", true, ["drop_newer", "drop_older"]),
+    Setting::NullableString.new("dead_letter_queue.retain.age"), # example 5d
          Setting::TimeValue.new("slowlog.threshold.warn", "-1"),
          Setting::TimeValue.new("slowlog.threshold.info", "-1"),
          Setting::TimeValue.new("slowlog.threshold.debug", "-1"),

--- a/logstash-core/src/main/java/org/logstash/common/DeadLetterQueueFactory.java
+++ b/logstash-core/src/main/java/org/logstash/common/DeadLetterQueueFactory.java
@@ -77,10 +77,28 @@ public class DeadLetterQueueFactory {
      *                     that would make the size of this dlq greater than this value
      * @param flushInterval Maximum duration between flushes of dead letter queue files if no data is sent.
      * @param storageType overwriting type in case of queue full: drop_older or drop_newer.
-     * @return The write manager for the specific id's dead-letter-queue context
+     * @return write manager for the specific id's dead-letter-queue context
      */
     public static DeadLetterQueueWriter getWriter(String id, String dlqPath, long maxQueueSize, Duration flushInterval, QueueStorageType storageType) {
         return REGISTRY.computeIfAbsent(id, key -> newWriter(key, dlqPath, maxQueueSize, flushInterval, storageType));
+    }
+
+    /**
+     * Like {@link #getWriter(String, String, long, Duration, QueueStorageType)} but also setting the age duration
+     * of the segments.
+     *
+     * @param id The identifier context for this dlq manager
+     * @param dlqPath The path to use for the queue's backing data directory. contains sub-directories
+     *                for each id
+     * @param maxQueueSize Maximum size of the dead letter queue (in bytes). No entries will be written
+     *                     that would make the size of this dlq greater than this value
+     * @param flushInterval Maximum duration between flushes of dead letter queue files if no data is sent.
+     * @param storageType overwriting type in case of queue full: drop_older or drop_newer.
+     * @param age the period that DLQ events should be considered as valid, before automatic removal.
+     * @return write manager for the specific id's dead-letter-queue context
+     * */
+    public static DeadLetterQueueWriter getWriter(String id, String dlqPath, long maxQueueSize, Duration flushInterval, QueueStorageType storageType, Duration age) {
+        return REGISTRY.computeIfAbsent(id, key -> newWriter(key, dlqPath, maxQueueSize, flushInterval, storageType, age));
     }
 
     public static DeadLetterQueueWriter release(String id) {
@@ -93,7 +111,19 @@ public class DeadLetterQueueFactory {
             return new DeadLetterQueueWriter(Paths.get(dlqPath, id), MAX_SEGMENT_SIZE_BYTES, maxQueueSize, flushInterval, storageType);
         } catch (IOException e) {
             logger.error("unable to create dead letter queue writer", e);
+            return null;
         }
-        return null;
+    }
+
+    private static DeadLetterQueueWriter newWriter(final String id, final String dlqPath, final long maxQueueSize,
+                                                   final Duration flushInterval, final QueueStorageType storageType,
+                                                   final Duration age) {
+        try {
+            return new DeadLetterQueueWriter(Paths.get(dlqPath, id), MAX_SEGMENT_SIZE_BYTES, maxQueueSize, flushInterval,
+                    storageType, age);
+        } catch (IOException e) {
+            logger.error("unable to create dead letter queue writer", e);
+            return null;
+        }
     }
 }

--- a/logstash-core/src/main/java/org/logstash/common/DeadLetterQueueFactory.java
+++ b/logstash-core/src/main/java/org/logstash/common/DeadLetterQueueFactory.java
@@ -108,7 +108,10 @@ public class DeadLetterQueueFactory {
     private static DeadLetterQueueWriter newWriter(final String id, final String dlqPath, final long maxQueueSize,
                                                    final Duration flushInterval, final QueueStorageType storageType) {
         try {
-            return new DeadLetterQueueWriter(Paths.get(dlqPath, id), MAX_SEGMENT_SIZE_BYTES, maxQueueSize, flushInterval, storageType);
+            return DeadLetterQueueWriter
+                    .newBuilder(Paths.get(dlqPath, id), MAX_SEGMENT_SIZE_BYTES, maxQueueSize, flushInterval)
+                    .storageType(storageType)
+                    .build();
         } catch (IOException e) {
             logger.error("unable to create dead letter queue writer", e);
             return null;
@@ -119,8 +122,11 @@ public class DeadLetterQueueFactory {
                                                    final Duration flushInterval, final QueueStorageType storageType,
                                                    final Duration age) {
         try {
-            return new DeadLetterQueueWriter(Paths.get(dlqPath, id), MAX_SEGMENT_SIZE_BYTES, maxQueueSize, flushInterval,
-                    storageType, age);
+            return DeadLetterQueueWriter
+                    .newBuilder(Paths.get(dlqPath, id), MAX_SEGMENT_SIZE_BYTES, maxQueueSize, flushInterval)
+                    .storageType(storageType)
+                    .retentionTime(age)
+                    .build();
         } catch (IOException e) {
             logger.error("unable to create dead letter queue writer", e);
             return null;

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -287,7 +287,7 @@ public final class DeadLetterQueueWriter implements Closeable {
         this.currentQueueSize.add(-segmentSize);
         try {
             Files.delete(segment);
-            logger.debug("Deleted exceeded retained age segment file {}", segment);
+            logger.debug("Removed segment file {} due to age retention policy", segment);
         } catch (NoSuchFileException nsfex) {
             // the last segment was deleted by another process, maybe the reader that's cleaning consumed segments
             logger.info("File not found {}, maybe removed by the reader pipeline", segment);

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -359,9 +359,9 @@ public final class DeadLetterQueueWriter implements Closeable {
                 .min(Comparator.comparingInt(DeadLetterQueueUtils::extractSegmentId));
         if (oldestSegment.isPresent()) {
             final Path beheadedSegment = oldestSegment.get();
-            deleteTailSegment(beheadedSegment, "exceeded retained size");
+            deleteTailSegment(beheadedSegment, "dead letter queue size exceeded dead_letter_queue.max_bytes size(" + maxQueueSize + ")");
         } else {
-            logger.info("Listing of DLQ segments resulted in empty set during storage policy size({}) check", maxQueueSize);
+            logger.info("Queue size {} exceeded, but no complete DLQ segments found", maxQueueSize);
         }
         this.currentQueueSize.set(computeQueueSize());
     }

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -302,7 +302,7 @@ public final class DeadLetterQueueWriter implements Closeable {
      * Extract the timestamp from the last DLQEntry it finds in the given segment.
      * Start from the end of the latest block, and going backward try to read the next event from its start.
      * */
-    private Timestamp readTimestampOfLastEventInSegment(Path segmentPath) throws IOException {
+    private static Timestamp readTimestampOfLastEventInSegment(Path segmentPath) throws IOException {
         final int lastBlockId = (int) Math.ceil(((Files.size(segmentPath) - VERSION_SIZE) / (double) BLOCK_SIZE)) - 1;
         byte[] eventBytes;
         try (RecordIOReader recordReader = new RecordIOReader(segmentPath)) {

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -307,7 +307,7 @@ public final class DeadLetterQueueWriter implements Closeable {
             logger.debug("Removed segment file {} due to age retention policy", segment);
         } catch (NoSuchFileException nsfex) {
             // the last segment was deleted by another process, maybe the reader that's cleaning consumed segments
-            logger.info("File not found {}, maybe removed by the reader pipeline", segment);
+            logger.debug("File not found {}, maybe removed by the reader pipeline", segment);
         }
     }
 

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -36,6 +36,7 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -324,10 +325,11 @@ public class AbstractPipelineExt extends RubyBasicObject {
     /**
      * Convert time strings like 3d or 4h or 5m to a duration
      * */
-    private Duration parseToDuration(String timeStr) {
+    @VisibleForTesting
+    static Duration parseToDuration(String timeStr) {
         final Matcher matcher = Pattern.compile("(?<value>\\d+)\\s*(?<time>[dhms])").matcher(timeStr);
         if (!matcher.matches()) {
-            throw new IllegalArgumentException("Cannot parse time specification [" + timeStr + "]");
+            throw new IllegalArgumentException("Expected a time specification in the form <number>[d,h,m,s], e.g. 3m, but found [" + timeStr + "]");
         }
         final int value = Integer.parseInt(matcher.group("value"));
         final String timeSpecifier = matcher.group("time");
@@ -336,7 +338,8 @@ public class AbstractPipelineExt extends RubyBasicObject {
             case "d": unit = ChronoUnit.DAYS; break;
             case "h": unit = ChronoUnit.HOURS; break;
             case "m": unit = ChronoUnit.MINUTES; break;
-            default: unit = ChronoUnit.SECONDS;
+            case "s": unit = ChronoUnit.SECONDS; break;
+            default: throw new IllegalStateException("Expected a time unit specification from d,h,m,s but found: [" + timeSpecifier + "]");
         }
         return Duration.of(value, unit);
     }

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -26,11 +26,16 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.apache.commons.codec.binary.Hex;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -53,6 +58,7 @@ import org.logstash.ackedqueue.ext.JRubyWrappedAckedQueueExt;
 import org.logstash.common.DeadLetterQueueFactory;
 import org.logstash.common.EnvironmentVariableProvider;
 import org.logstash.common.SourceWithMetadata;
+import org.logstash.common.io.DeadLetterQueueWriter;
 import org.logstash.common.io.QueueStorageType;
 import org.logstash.config.ir.ConfigCompiler;
 import org.logstash.config.ir.InvalidIRException;
@@ -289,22 +295,50 @@ public class AbstractPipelineExt extends RubyBasicObject {
     public final IRubyObject dlqWriter(final ThreadContext context) {
         if (dlqWriter == null) {
             if (dlqEnabled(context).isTrue()) {
-                final QueueStorageType storageType = QueueStorageType.parse(getSetting(context, "dead_letter_queue.storage_policy").asJavaString());
-
-                dlqWriter = JavaUtil.convertJavaToUsableRubyObject(
-                    context.runtime,
-                    DeadLetterQueueFactory.getWriter(
-                        pipelineId.asJavaString(),
-                        getSetting(context, "path.dead_letter_queue").asJavaString(),
-                        getSetting(context, "dead_letter_queue.max_bytes").convertToInteger().getLongValue(),
-                        Duration.ofMillis(getSetting(context, "dead_letter_queue.flush_interval").convertToInteger().getLongValue()),
-                        storageType)
-                    );
+                final DeadLetterQueueWriter javaDlqWriter = createDeadLetterQueueWriterFromSettings(context);
+                dlqWriter = JavaUtil.convertJavaToUsableRubyObject(context.runtime, javaDlqWriter);
             } else {
                 dlqWriter = RubyUtil.DUMMY_DLQ_WRITER_CLASS.callMethod(context, "new");
             }
         }
         return dlqWriter;
+    }
+
+    private DeadLetterQueueWriter createDeadLetterQueueWriterFromSettings(ThreadContext context) {
+        final QueueStorageType storageType = QueueStorageType.parse(getSetting(context, "dead_letter_queue.storage_policy").asJavaString());
+
+        String dlqPath = getSetting(context, "path.dead_letter_queue").asJavaString();
+        long dlqMaxBytes = getSetting(context, "dead_letter_queue.max_bytes").convertToInteger().getLongValue();
+        Duration dlqFlushInterval = Duration.ofMillis(getSetting(context, "dead_letter_queue.flush_interval").convertToInteger().getLongValue());
+
+        if (hasSetting(context, "dead_letter_queue.retain.age") && !getSetting(context, "dead_letter_queue.retain.age").isNil()) {
+            // convert to Duration
+            final Duration age = parseToDuration(getSetting(context, "dead_letter_queue.retain.age").convertToString().toString());
+            return DeadLetterQueueFactory.getWriter(pipelineId.asJavaString(), dlqPath, dlqMaxBytes,
+                    dlqFlushInterval, storageType, age);
+        }
+
+        return DeadLetterQueueFactory.getWriter(pipelineId.asJavaString(), dlqPath, dlqMaxBytes, dlqFlushInterval, storageType);
+    }
+
+    /**
+     * Convert time strings like 3d or 4h or 5m to a duration
+     * */
+    private Duration parseToDuration(String timeStr) {
+        final Matcher matcher = Pattern.compile("(?<value>\\d+)\\s*(?<time>[dhms])").matcher(timeStr);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Cannot parse time specification [" + timeStr + "]");
+        }
+        final int value = Integer.parseInt(matcher.group("value"));
+        final String timeSpecifier = matcher.group("time");
+        final TemporalUnit unit;
+        switch (timeSpecifier) {
+            case "d": unit = ChronoUnit.DAYS; break;
+            case "h": unit = ChronoUnit.HOURS; break;
+            case "m": unit = ChronoUnit.MINUTES; break;
+            default: unit = ChronoUnit.SECONDS;
+        }
+        return Duration.of(value, unit);
     }
 
     @JRubyMethod(name = "dlq_enabled?")

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
@@ -60,6 +60,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.logstash.common.io.DeadLetterQueueTestUtils.GB;
 import static org.logstash.common.io.DeadLetterQueueTestUtils.MB;
 import static org.logstash.common.io.RecordIOWriter.BLOCK_SIZE;
 import static org.logstash.common.io.RecordIOWriter.RECORD_HEADER_SIZE;
@@ -154,7 +155,9 @@ public class DeadLetterQueueReaderTest {
         event.setField("message", generateMessageContent(32495));
         long startTime = System.currentTimeMillis();
         int messageSize = 0;
-        try(DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(1))) {
+        try(DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
+                .newBuilder(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(1))
+                .build()) {
             for (int i = 0; i < 2; i++) {
                 DLQEntry entry = new DLQEntry(event, "", "", String.valueOf(i), constantSerializationLengthTimestamp(startTime++));
                 final int serializationLength = entry.serialize().length;
@@ -209,7 +212,9 @@ public class DeadLetterQueueReaderTest {
         long startTime = System.currentTimeMillis();
         DLQEntry templateEntry = new DLQEntry(event, "1", "1", String.valueOf(0), constantSerializationLengthTimestamp(startTime));
         int size = templateEntry.serialize().length + RecordIOWriter.RECORD_HEADER_SIZE + VERSION_SIZE;
-        try (DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, size, defaultDlqSize, Duration.ofSeconds(1))) {
+        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
+                .newBuilder(dir, size, defaultDlqSize, Duration.ofSeconds(1))
+                .build()) {
             for (int i = 1; i <= count; i++) {
                 writeManager.writeEntry(new DLQEntry(event, "1", "1", String.valueOf(i), constantSerializationLengthTimestamp(startTime++)));
             }
@@ -241,7 +246,9 @@ public class DeadLetterQueueReaderTest {
         event.setField("T", new String(field));
         Timestamp timestamp = constantSerializationLengthTimestamp();
 
-        try (DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(1))) {
+        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
+                .newBuilder(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(1))
+                .build()) {
             for (int i = 0; i < 2; i++) {
                 DLQEntry entry = new DLQEntry(event, "", "", "", timestamp);
                 assertThat(entry.serialize().length + RecordIOWriter.RECORD_HEADER_SIZE, is(BLOCK_SIZE));
@@ -264,7 +271,9 @@ public class DeadLetterQueueReaderTest {
         event.setField("message", new String(field));
         long startTime = System.currentTimeMillis();
         int messageSize = 0;
-        try (DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(1))) {
+        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
+                .newBuilder(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(1))
+                .build()) {
             for (int i = 1; i <= 5; i++) {
                 DLQEntry entry = new DLQEntry(event, "", "", "", constantSerializationLengthTimestamp(startTime++));
                 messageSize += entry.serialize().length;
@@ -287,7 +296,9 @@ public class DeadLetterQueueReaderTest {
         event.setField("T", generateMessageContent(PAD_FOR_BLOCK_SIZE_EVENT/8));
         Timestamp timestamp = new Timestamp();
 
-        try (DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, BLOCK_SIZE, defaultDlqSize, Duration.ofSeconds(1))) {
+        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
+                .newBuilder(dir, BLOCK_SIZE, defaultDlqSize, Duration.ofSeconds(1))
+                .build()) {
             for (int i = 0; i < 6; i++) {
                 DLQEntry entry = new DLQEntry(event, "", "", Integer.toString(i), timestamp);
                 writeManager.writeEntry(entry);
@@ -307,8 +318,9 @@ public class DeadLetterQueueReaderTest {
         final int EVENTS_BEFORE_FLUSH = randomBetween(1, 32);
         event.setField("T", generateMessageContent(PAD_FOR_BLOCK_SIZE_EVENT));
         Timestamp timestamp = new Timestamp();
-
-        try (DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, BLOCK_SIZE * EVENTS_BEFORE_FLUSH, defaultDlqSize, Duration.ofHours(1))) {
+        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
+                .newBuilder(dir, BLOCK_SIZE * EVENTS_BEFORE_FLUSH, defaultDlqSize, Duration.ofHours(1))
+                .build()) {
             for (int i = 1; i < EVENTS_BEFORE_FLUSH; i++) {
                 DLQEntry entry = new DLQEntry(event, "", "", Integer.toString(i), timestamp);
                 writeManager.writeEntry(entry);
@@ -341,7 +353,9 @@ public class DeadLetterQueueReaderTest {
         event.setField("T", generateMessageContent(PAD_FOR_BLOCK_SIZE_EVENT));
         Timestamp timestamp = new Timestamp();
 
-        try (DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, BLOCK_SIZE * eventsInSegment, defaultDlqSize, Duration.ofHours(1))) {
+        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
+                .newBuilder(dir, BLOCK_SIZE * eventsInSegment, defaultDlqSize, Duration.ofHours(1))
+                .build()) {
             for (int i = 1; i < totalEventsToWrite; i++) {
                 DLQEntry entry = new DLQEntry(event, "", "", Integer.toString(i), timestamp);
                 writeManager.writeEntry(entry);
@@ -382,7 +396,9 @@ public class DeadLetterQueueReaderTest {
 
         System.out.println("events per block= " + eventsPerBlock);
 
-        try(DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, BLOCK_SIZE, defaultDlqSize, Duration.ofSeconds(2))) {
+        try(DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
+                .newBuilder(dir, BLOCK_SIZE, defaultDlqSize, Duration.ofSeconds(2))
+                .build()) {
             for (int i = 1; i < eventsToWrite; i++) {
                 DLQEntry entry = new DLQEntry(event, "", "", Integer.toString(i), timestamp);
                 writeManager.writeEntry(entry);
@@ -414,7 +430,9 @@ public class DeadLetterQueueReaderTest {
         event.setField("T", generateMessageContent(PAD_FOR_BLOCK_SIZE_EVENT));
         Timestamp timestamp = constantSerializationLengthTimestamp();
 
-        try(DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, BLOCK_SIZE, defaultDlqSize, Duration.ofSeconds(1))) {
+        try(DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
+                .newBuilder(dir, BLOCK_SIZE, defaultDlqSize, Duration.ofSeconds(1))
+                .build()) {
             for (int i = 0; i < 2; i++) {
                 DLQEntry entry = new DLQEntry(event, "", "", "", timestamp);
                 assertThat(entry.serialize().length + RecordIOWriter.RECORD_HEADER_SIZE, is(BLOCK_SIZE));
@@ -435,7 +453,9 @@ public class DeadLetterQueueReaderTest {
         int eventCount = 1024; // max = 1000 * 64kb = 64mb
         long startTime = System.currentTimeMillis();
 
-        try(DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(1))) {
+        try(DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
+                .newBuilder(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(1))
+                .build()) {
             for (int i = 0; i < eventCount; i++) {
                 event.setField("message", generateMessageContent((int)(Math.random() * (maxEventSize))));
                 DLQEntry entry = new DLQEntry(event, "", "", String.valueOf(i), new Timestamp(startTime++));
@@ -536,7 +556,9 @@ public class DeadLetterQueueReaderTest {
             exec.submit(() -> {
                 final Event event = new Event();
                 long startTime = System.currentTimeMillis();
-                try (DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(10))) {
+                try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
+                        .newBuilder(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(10))
+                        .build()) {
                     for (int i = 0; i < eventCount; i++) {
                         event.setField(
                                 "message",
@@ -875,7 +897,9 @@ public class DeadLetterQueueReaderTest {
     }
 
     private void writeEntries(final Event event, int offset, final int numberOfEvents, long startTime) throws IOException {
-        try (DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(1))) {
+        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
+                .newBuilder(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(1))
+                .build()) {
             for (int i = offset; i <= offset + numberOfEvents; i++) {
                 DLQEntry entry = new DLQEntry(event, "foo", "bar", String.valueOf(i), new Timestamp(startTime++));
                 writeManager.writeEntry(entry);
@@ -896,7 +920,9 @@ public class DeadLetterQueueReaderTest {
 
         final int maxSegmentSize = 10 * MB;
         final int loopPerSegment = (int) Math.floor((maxSegmentSize - 1.0) / BLOCK_SIZE);
-        try (DeadLetterQueueWriter writer = new DeadLetterQueueWriter(dir, maxSegmentSize, defaultDlqSize, Duration.ofSeconds(1))) {
+        try (DeadLetterQueueWriter writer = DeadLetterQueueWriter
+                .newBuilder(dir, maxSegmentSize, defaultDlqSize, Duration.ofSeconds(1))
+                .build()) {
             final int loops = loopPerSegment * segments;
             for (int i = 0; i < loops; i++) {
                 entry = new DLQEntry(event, "", "", String.format("%05d", i), constantSerializationLengthTimestamp(start++));

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueTestUtils.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueTestUtils.java
@@ -19,9 +19,10 @@
 package org.logstash.common.io;
 
 import static org.logstash.common.io.RecordIOWriter.BLOCK_SIZE;
+import static org.logstash.common.io.RecordIOWriter.VERSION_SIZE;
 
 public class DeadLetterQueueTestUtils {
     public static final int MB = 1024 * 1024;
     public static final int GB = 1024 * 1024 * 1024;
-    public static final int FULL_SEGMENT_FILE_SIZE = 319 * BLOCK_SIZE + 1; // 319 records that fills completely a block plus the 1 byte header of the segment file
+    public static final int FULL_SEGMENT_FILE_SIZE = 319 * BLOCK_SIZE + VERSION_SIZE; // 319 records that fills completely a block plus the 1 byte header of the segment file
 }

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
@@ -1,0 +1,197 @@
+package org.logstash.common.io;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Collections;
+
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.logstash.DLQEntry;
+import org.logstash.Event;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertEquals;
+import static org.logstash.common.io.DeadLetterQueueTestUtils.FULL_SEGMENT_FILE_SIZE;
+import static org.logstash.common.io.DeadLetterQueueTestUtils.GB;
+import static org.logstash.common.io.DeadLetterQueueTestUtils.MB;
+import static org.logstash.common.io.RecordIOWriter.BLOCK_SIZE;
+import static org.logstash.common.io.RecordIOWriter.VERSION_SIZE;
+
+public class DeadLetterQueueWriterAgeRetentionTest {
+
+    static class ForwardableClock extends Clock {
+
+        private Clock currentClock;
+
+        ForwardableClock(Clock clock) {
+            this.currentClock = clock;
+        }
+
+        void forward(Duration period) {
+            currentClock = Clock.offset(currentClock, period);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return currentClock.getZone();
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return currentClock.withZone(zone);
+        }
+
+        @Override
+        public Instant instant() {
+            return currentClock.instant();
+        }
+    }
+
+    private Path dir;
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Before
+    public void setUp() throws Exception {
+        dir = temporaryFolder.newFolder().toPath();
+    }
+
+    @Test
+    public void testRemoveOldestSegmentsWhenRetainedAgeIsExceeded_reopeningWriterUseCase() throws IOException {
+        final Event event = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(Collections.emptyMap());
+        event.setField("message", DeadLetterQueueReaderTest.generateMessageContent(32479));
+
+        final Clock pointInTimeFixedClock = Clock.fixed(Instant.parse("2022-02-22T10:20:30.00Z"), ZoneId.of("Europe/Rome"));
+        final ForwardableClock fakeClock = new ForwardableClock(pointInTimeFixedClock);
+        prepareDLQWithFirstSegmentOlderThanRetainPeriod(event, fakeClock);
+
+        // Exercise
+        final long prevQueueSize;
+        final long beheadedQueueSize;
+
+        try (DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, 10 * MB, 1 * GB,
+                Duration.ofSeconds(1), Duration.ofDays(2), fakeClock)) {
+            prevQueueSize = writeManager.getCurrentQueueSize();
+            assertEquals("Queue size is composed of one just one empty file with version byte", VERSION_SIZE, prevQueueSize);
+
+            // write new entry that trigger clean of age retained segment
+            DLQEntry entry = new DLQEntry(event, "", "", String.format("%05d", 320), DeadLetterQueueReaderTest.constantSerializationLengthTimestamp(System.currentTimeMillis()));
+            writeManager.writeEntry(entry);
+            beheadedQueueSize = writeManager.getCurrentQueueSize();
+        }
+
+        assertEquals(VERSION_SIZE + BLOCK_SIZE, beheadedQueueSize);
+    }
+
+    private void prepareDLQWithFirstSegmentOlderThanRetainPeriod(Event event, ForwardableClock fakeClock) throws IOException {
+        Duration retainFor2Days = Duration.ofDays(2);
+        final Duration littleMore2Days = retainFor2Days.plusMinutes(1);
+        long startTime = fakeClock.instant().minus(littleMore2Days).toEpochMilli();
+        int messageSize = 0;
+
+        try (DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, 10 * MB, 1 * GB,
+                Duration.ofSeconds(1), retainFor2Days, fakeClock)) {
+
+            // 320 generates 10 Mb of data
+            for (int i = 0; i < 320 - 1; i++) {
+                DLQEntry entry = new DLQEntry(event, "", "", String.format("%05d", i), DeadLetterQueueReaderTest.constantSerializationLengthTimestamp(startTime++));
+                final int serializationLength = entry.serialize().length;
+                assertThat("setup: serialized entry size...", serializationLength, Matchers.is(lessThan(BLOCK_SIZE)));
+                messageSize += serializationLength;
+                writeManager.writeEntry(entry);
+            }
+            assertThat(messageSize, Matchers.is(greaterThan(BLOCK_SIZE)));
+        }
+    }
+
+    @Test
+    public void testRemoveOldestSegmentsWhenRetainedAgeIsExceeded_withContinuousWriterUseCase() throws IOException {
+        final Event event = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(Collections.emptyMap());
+        event.setField("message", DeadLetterQueueReaderTest.generateMessageContent(32479));
+        final Clock pointInTimeFixedClock = Clock.fixed(Instant.parse("2022-02-22T10:20:30.00Z"), ZoneId.of("Europe/Rome"));
+        final ForwardableClock fakeClock = new ForwardableClock(pointInTimeFixedClock);
+
+        long startTime = fakeClock.instant().toEpochMilli();
+        int messageSize = 0;
+
+        final Duration retention = Duration.ofDays(2);
+        try (DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, 10 * MB, 1 * GB,
+                Duration.ofSeconds(1), retention, fakeClock)) {
+
+            // 320 generates 10 Mb of data
+            for (int i = 0; i < 320 - 1; i++) {
+                DLQEntry entry = new DLQEntry(event, "", "", String.format("%05d", i), DeadLetterQueueReaderTest.constantSerializationLengthTimestamp(startTime++));
+                final int serializationLength = entry.serialize().length;
+                assertThat("setup: serialized entry size...", serializationLength, Matchers.is(lessThan(BLOCK_SIZE)));
+                messageSize += serializationLength;
+                writeManager.writeEntry(entry);
+            }
+            assertThat(messageSize, Matchers.is(greaterThan(BLOCK_SIZE)));
+
+            // Exercise
+            // write an event that goes in second segment
+            fakeClock.forward(retention.plusSeconds(1));
+            final long prevQueueSize = writeManager.getCurrentQueueSize();
+            assertEquals("Queue size is composed of one full segment files", FULL_SEGMENT_FILE_SIZE, prevQueueSize);
+
+            // write new entry that trigger clean of age retained segment
+            DLQEntry entry = new DLQEntry(event, "", "", String.format("%05d", 320), DeadLetterQueueReaderTest.constantSerializationLengthTimestamp(System.currentTimeMillis()));
+            writeManager.writeEntry(entry);
+            final long beheadedQueueSize = writeManager.getCurrentQueueSize();
+
+            assertEquals(VERSION_SIZE + BLOCK_SIZE, beheadedQueueSize);
+        }
+    }
+
+    @Test
+    public void testRemoveMultipleOldestSegmentsWhenRetainedAgeIsExceeded() throws IOException {
+        final Event event = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(Collections.emptyMap());
+        event.setField("message", DeadLetterQueueReaderTest.generateMessageContent(32479));
+
+        final Clock pointInTimeFixedClock = Clock.fixed(Instant.parse("2022-02-22T10:20:30.00Z"), ZoneId.of("Europe/Rome"));
+        final ForwardableClock fakeClock = new ForwardableClock(pointInTimeFixedClock);
+
+        long startTime = fakeClock.instant().toEpochMilli();
+        int messageSize = 0;
+
+        final Duration retention = Duration.ofDays(2);
+        try (DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, 10 * MB, 1 * GB,
+                Duration.ofSeconds(1), retention, fakeClock)) {
+
+            // 320 generates 10 Mb of data
+            for (int i = 0; i < 319 * 2; i++) {
+                DLQEntry entry = new DLQEntry(event, "", "", String.format("%05d", i), DeadLetterQueueReaderTest.constantSerializationLengthTimestamp(startTime++));
+                final int serializationLength = entry.serialize().length;
+                assertThat("setup: serialized entry size...", serializationLength, Matchers.is(lessThan(BLOCK_SIZE)));
+                messageSize += serializationLength;
+                writeManager.writeEntry(entry);
+            }
+            assertThat(messageSize, Matchers.is(greaterThan(BLOCK_SIZE)));
+
+            // make the retention age to pass for the first 2 full segments
+            fakeClock.forward(retention.plusSeconds(1));
+
+            // Exercise
+            // write an event that goes in second segment
+            final long prevQueueSize = writeManager.getCurrentQueueSize();
+            assertEquals("Queue size is composed of 2 full segment files", 2 * FULL_SEGMENT_FILE_SIZE, prevQueueSize);
+
+            // write new entry that trigger clean of age retained segment
+            DLQEntry entry = new DLQEntry(event, "", "", String.format("%05d", 320), DeadLetterQueueReaderTest.constantSerializationLengthTimestamp(System.currentTimeMillis()));
+            writeManager.writeEntry(entry);
+            final long beheadedQueueSize = writeManager.getCurrentQueueSize();
+
+            assertEquals(VERSION_SIZE + BLOCK_SIZE, beheadedQueueSize);
+        }
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
@@ -80,8 +80,11 @@ public class DeadLetterQueueWriterAgeRetentionTest {
         final long prevQueueSize;
         final long beheadedQueueSize;
 
-        try (DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, 10 * MB, 1 * GB,
-                Duration.ofSeconds(1), Duration.ofDays(2), fakeClock)) {
+        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
+                .newBuilder(dir, 10 * MB, 1 * GB, Duration.ofSeconds(1))
+                .retentionTime(Duration.ofDays(2))
+                .clock(fakeClock)
+                .build()) {
             prevQueueSize = writeManager.getCurrentQueueSize();
             assertEquals("Queue size is composed of one just one empty file with version byte", VERSION_SIZE, prevQueueSize);
 
@@ -100,9 +103,11 @@ public class DeadLetterQueueWriterAgeRetentionTest {
         final Duration littleMoreThanRetainedPeriod = retainedPeriod.plusMinutes(1);
         long startTime = fakeClock.instant().minus(littleMoreThanRetainedPeriod).toEpochMilli();
         int messageSize = 0;
-
-        try (DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, 10 * MB, 1 * GB,
-                Duration.ofSeconds(1), retainedPeriod, fakeClock)) {
+        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
+                .newBuilder(dir, 10 * MB, 1 * GB, Duration.ofSeconds(1))
+                .retentionTime(retainedPeriod)
+                .clock(fakeClock)
+                .build()) {
 
             // 320 generates 10 Mb of data
             for (int i = 0; i < 320 - 1; i++) {
@@ -127,8 +132,11 @@ public class DeadLetterQueueWriterAgeRetentionTest {
         int messageSize = 0;
 
         final Duration retention = Duration.ofDays(2);
-        try (DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, 10 * MB, 1 * GB,
-                Duration.ofSeconds(1), retention, fakeClock)) {
+        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
+                .newBuilder(dir, 10 * MB, 1 * GB, Duration.ofSeconds(1))
+                .retentionTime(retention)
+                .clock(fakeClock)
+                .build()) {
 
             // 320 generates 10 Mb of data
             for (int i = 0; i < 320 - 1; i++) {
@@ -169,8 +177,11 @@ public class DeadLetterQueueWriterAgeRetentionTest {
         int messageSize = 0;
 
         final Duration retention = Duration.ofDays(2);
-        try (DeadLetterQueueWriter writeManager = new DeadLetterQueueWriter(dir, 10 * MB, 1 * GB,
-                Duration.ofSeconds(1), retention, fakeClock)) {
+        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
+                .newBuilder(dir, 10 * MB, 1 * GB, Duration.ofSeconds(1))
+                .retentionTime(retention)
+                .clock(fakeClock)
+                .build()) {
 
             // given DLQ with a couple of segments filled of expired events
             // 320 generates 10 Mb of data

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
@@ -67,7 +67,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
     }
 
     @Test
-    public void testWriteOnReopenedQueueWithExpiredSegmentsRemovesTheOlderOnes() throws IOException {
+    public void testRemovesOlderSegmentsWhenWriteOnReopenedDLQContainingExpiredSegments() throws IOException {
         final Event event = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(Collections.emptyMap());
         event.setField("message", DeadLetterQueueReaderTest.generateMessageContent(32479));
 
@@ -117,7 +117,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
     }
 
     @Test
-    public void testWriteOnQueueWithExpiredSegmentsRemovesTheOlderOnes() throws IOException {
+    public void testRemovesOlderSegmentsWhenWritesIntoDLQContainingExpiredSegments() throws IOException {
         final Event event = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(Collections.emptyMap());
         event.setField("message", DeadLetterQueueReaderTest.generateMessageContent(32479));
         final Clock pointInTimeFixedClock = Clock.fixed(Instant.parse("2022-02-22T10:20:30.00Z"), ZoneId.of("Europe/Rome"));

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
@@ -314,7 +314,8 @@ public class DeadLetterQueueWriterTest {
         assertThat(afterBeheadSegmentFileNames, Matchers.not(Matchers.contains(fileToBeRemoved)));
         final long expectedQueueSize = prevQueueSize +
                 BLOCK_SIZE - // the space of the newly inserted message
-                FULL_SEGMENT_FILE_SIZE; //the size of the removed segment file
+                FULL_SEGMENT_FILE_SIZE - //the size of the removed segment file
+                VERSION_SIZE; // the size of a previous head file (n.log.tmp) that doesn't exist anymore.
         assertEquals("Total queue size must be decremented by the size of the first segment file",
                 expectedQueueSize, beheadedQueueSize);
         assertEquals("Last segment removal doesn't increment dropped events counter",

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
@@ -51,10 +51,11 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.logstash.common.io.DeadLetterQueueTestUtils.FULL_SEGMENT_FILE_SIZE;
+import static org.logstash.common.io.DeadLetterQueueTestUtils.MB;
 import static org.logstash.common.io.RecordIOWriter.BLOCK_SIZE;
 import static org.logstash.common.io.RecordIOWriter.RECORD_HEADER_SIZE;
 import static org.logstash.common.io.RecordIOWriter.VERSION_SIZE;
-import static org.logstash.common.io.DeadLetterQueueTestUtils.*;
 
 public class DeadLetterQueueWriterTest {
 

--- a/logstash-core/src/test/java/org/logstash/execution/AbstractPipelineExtTest.java
+++ b/logstash-core/src/test/java/org/logstash/execution/AbstractPipelineExtTest.java
@@ -1,0 +1,34 @@
+package org.logstash.execution;
+
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public class AbstractPipelineExtTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testParseToDurationWithBadDurationFormatThrowsAnError() {
+        AbstractPipelineExt.parseToDuration("+3m");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testParseToDurationWithUnrecognizedTimeUnitThrowsAnError() {
+        AbstractPipelineExt.parseToDuration("3y");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testParseToDurationWithUnspecifiedTimeUnitThrowsAnError() {
+        AbstractPipelineExt.parseToDuration("3");
+    }
+
+    @Test
+    public void testParseToDurationSuccessfullyParseExpectedFormats() {
+        assertEquals(Duration.of(4, ChronoUnit.DAYS), AbstractPipelineExt.parseToDuration("4d"));
+        assertEquals(Duration.of(3, ChronoUnit.HOURS), AbstractPipelineExt.parseToDuration("3h"));
+        assertEquals(Duration.of(2, ChronoUnit.MINUTES), AbstractPipelineExt.parseToDuration("2m"));
+        assertEquals(Duration.of(1, ChronoUnit.SECONDS), AbstractPipelineExt.parseToDuration("1s"));
+    }
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Added age retention policy for messages inserted in DLQ. After a configurable period of time, expired messages are considered for deletion.

## What does this PR do?

Updates DLQ writer's `writeEvent` method to clean the tail segments  older then the duration period. This happens only if setting `dead_letter_queue.retain.age` is configured.
To read the age of a segment it extract the timestamp of the last (youngest) message in the segment.
The age is defined as a `number` followed by one of `d`, `h`, `m`, `s` that stands for days, hours, minutes and seconds. If nothing is used then assumes seconds as default measure entity.

## Why is it important/What is the impact to the user?

Once configured `dead_letter_queue.retain.age`, permit to the user to discard events older a certain time boundary, without processing them.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x]  execute a real test as described in the next section

## How to test this PR locally

To test it need an Elasticsearch instance the return an error code that trigger DLQ, the DLQ feature needs to be enabled in `logstash.yml`.
- prepare the ES index to reject the inserts, create an index and close it:
```
PUT test_index/
POST test_index/_close
```
-  in `logstash.yml` enable this DLQ feature, say the events should lasts for 2 minutes:
```
dead_letter_queue.enable: true
dead_letter_queue.retain.age: 2m
```
- run a pipeline that produces events into DLQ:
```
input {
  generator {
    # this is some data
    message => '{"jvm" : {"threads" : {"count" : 49,"peak_count" : 50},"mem" : {"heap_used_percent" : 14,"heap_committed_in_bytes" : 309866496,"heap_max_in_bytes" : 1037959168,"heap_used_in_bytes" : 151686096,"non_heap_used_in_bytes" : 122486176,"non_heap_committed_in_bytes" : 133222400,"pools" : {"survivor" : {"peak_used_in_bytes" : 8912896,"used_in_bytes" : 288776,"peak_max_in_bytes" : 35782656,"max_in_bytes" : 35782656,"committed_in_bytes" : 8912896},"peak_used_in_bytes" : 148656848,"used_in_bytes" : 148656848,"peak_max_in_bytes" : 715849728,"max_in_bytes" : 715849728,"committed_in_bytes" : 229322752},"young" : {"peak_used_in_bytes" : 71630848,"used_in_bytes" : 2740472,"peak_max_in_bytes" : 286326784,"max_in_bytes" : 286326784,"committed_in_bytes" : 71630848}}},"gc" : {"collectors" : {"old" : {"collection_time_in_millis" : 607,"collection_count" : 12},"young" : {"collection_time_in_millis" : 4904,"collection_count" : 1033}}},"uptime_in_millis" : 1809643}'
    codec => json
  }
}

output {
  elasticsearch {
    index => "test_index"
    hosts => "http://localhost:9200"
    user => "elastic"
    password => "changeme"
  }
}
```
- after launched Logstash, verify that the tail dlq segments starts to be removed  after the 2 minutes period:
```sh
ll data/dead_letter_queue/dlq_upstream
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Superseeds #13808
- Relates #10493

## Use cases

As user with DLQ  enabled I want that events older a certain duration are expired and not processed, the space occupied must be freed.


