### PR TITLE
Pipeline->pipeline workaround for jruby-9.3.4.0 bug

### DIFF
--- a/logstash-core/lib/logstash/plugins/builtin/pipeline/input.rb
+++ b/logstash-core/lib/logstash/plugins/builtin/pipeline/input.rb
@@ -62,11 +62,11 @@ module ::LogStash; module Plugins; module Builtin; module Pipeline; class Input 
     # buys us some efficiency
     begin
       stream_position = 0
-      events.forEach do |event|
+      events.forEach (lambda do |event|
         decorate(event)
         @queue << event
         stream_position = stream_position + 1
-      end
+      end)
       ReceiveResponse.completed()
     rescue java.lang.InterruptedException, IOError => e
       # maybe an IOException in enqueueing

--- a/qa/integration/specs/multiple_pipeline_spec.rb
+++ b/qa/integration/specs/multiple_pipeline_spec.rb
@@ -74,18 +74,15 @@ describe "Test Logstash service when multiple pipelines are used" do
   end
 
   describe "inter-pipeline communication" do
+    let(:count) { 2 }
     let(:pipelines) do 
       [
         {
           "pipeline.id" => "test",
-          "pipeline.workers" => 1,
-          "pipeline.batch.size" => 1,
-          "config.string" => "input { generator { count => 1 } } output { pipeline { send_to => testaddr } }"
+          "config.string" => "input { generator { count => #{count} } } output { pipeline { send_to => testaddr } }"
         },
         {
           "pipeline.id" => "test2",
-          "pipeline.workers" => 1,
-          "pipeline.batch.size" => 1,
           "config.string" => "input { pipeline { address => testaddr } } output { file { path => \"#{temporary_out_file_1}\" flush_interval => 0} }"
         }
       ]
@@ -97,12 +94,12 @@ describe "Test Logstash service when multiple pipelines are used" do
 
       # Wait for LS to come up
       i = 0
-      until File.exist?(temporary_out_file_1) && IO.readlines(temporary_out_file_1).size >= 1
+      until File.exist?(temporary_out_file_1) && IO.readlines(temporary_out_file_1).size >= count
         i += 1
         sleep 1
         break if i > 30
       end
-      expect(IO.readlines(temporary_out_file_1).size).to eq(1)
+      expect(IO.readlines(temporary_out_file_1).size).to eq(count)
 
       puts "Done"
     end


### PR DESCRIPTION
This commit replaces the use of a block with a lambda as an argument for Stream.forEach.
This is to work around the jruby issue identified in https://github.com/jruby/jruby/issues/7246.

This commit also updates the multiple_pipeline_spec to update the test case for pipeline->pipeline
communication to trigger the issue - it only occurs with Streams with more than one event in it.
