### PR TITLE
Fix/dlq avoid to delete not segment files

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReader.java
@@ -331,7 +331,7 @@ public final class DeadLetterQueueReader implements Closeable {
         final Comparator<Path> fileTimeAndName = ((Comparator<Path>) this::compareByFileTimestamp)
                 .thenComparingInt(DeadLetterQueueUtils::extractSegmentId);
 
-        try (final Stream<Path> segmentFiles = Files.list(queuePath)) {
+        try (final Stream<Path> segmentFiles = DeadLetterQueueWriter.getSegmentPaths(queuePath)) {
             segmentFiles.filter(p -> fileTimeAndName.compare(p, validSegment) < 0)
                   .forEach(this::deleteSegment);
         }

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
@@ -37,7 +37,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -49,6 +51,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -980,7 +983,7 @@ public class DeadLetterQueueReaderTest {
     }
 
     private List<Path> listSegmentsSorted(Path dir) throws IOException {
-        return Files.list(dir)
+        return DeadLetterQueueWriter.getSegmentPaths(dir)
                 .sorted(Comparator.comparingInt(DeadLetterQueueUtils::extractSegmentId))
                 .collect(Collectors.toList());
     }
@@ -991,6 +994,13 @@ public class DeadLetterQueueReaderTest {
     @Test
     public void testReaderCleanMultipleConsumedSegmentsAfterMarkForDelete() throws IOException, InterruptedException {
         int eventPerSegment = prepareFilledSegmentFiles(3);
+        // insert also a .lock file, must be the oldest one
+        Path lockFile = Files.createFile(dir.resolve(".lock"));
+        FileTime oneSecondAgo = FileTime.from(Instant.now().minusMillis(1_000));
+        Files.setAttribute(lockFile, "basic:lastModifiedTime", oneSecondAgo); // this attribute is used in segments sorting
+        // simulate a writer's segment head
+        Files.createFile(dir.resolve("4.log.tmp"));
+
         try (DeadLetterQueueReader reader = new DeadLetterQueueReader(dir, true, this::silentCallback)) {
             verifySegmentFiles(listSegmentsSorted(dir), "1.log", "2.log", "3.log");
 
@@ -1004,6 +1014,15 @@ public class DeadLetterQueueReaderTest {
             reader.markForDelete();
 
             verifySegmentFiles(listSegmentsSorted(dir), "3.log");
+
+            // verify no other files are removed
+            try (Stream<Path> stream = Files.list(dir)) {
+                Set<String> files = stream
+                        .map(Path::getFileName)
+                        .map(Path::toString)
+                        .collect(Collectors.toSet());
+                assertTrue("No segments file remain untouched", files.containsAll(Arrays.asList(".lock", "4.log.tmp")));
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Restrict the DLQ segment deletion to only files that are considered segments.

## Why is it important/What is the impact to the user?

Avoid an exception in the down stream pipeline when the writer is actively pushing data.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] run it in a real environment

## How to test this PR locally

This bug emerged while testing https://github.com/logstash-plugins/logstash-input-dead_letter_queue/pull/43 so it's difficult to reproduce on command line, using just external interaction.
To prove it, checkout this and revert the line  https://github.com/elastic/logstash/pull/14274/files#diff-22e56a5df12549ecbf9622646f8aa68040a9d95cda37f5376f8d2f1dbe790358L334 and run the unit test.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #14188 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
