### PR TITLE
make retries in pip and go get extra shell compatible

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -148,7 +148,7 @@ venv: requirements.txt
 	pyenv install --skip-existing $(PY_VERSION) &&\
 	pyenv local $(PY_VERSION) &&\
 	python3 -mvenv venv && \
-	for i in $(seq 0 5); do sleep "$i"; pip install -r requirements.txt && break; done &&\
+	for i in 0 1 2 3 4 5; do sleep "$i"; pip install -r requirements.txt && break; done &&\
 	touch venv
 
 # Make a Golang container that can compile our env2yaml tool.

--- a/docker/data/golang/Dockerfile
+++ b/docker/data/golang/Dockerfile
@@ -1,4 +1,4 @@
 FROM golang:1
-RUN go env -w GO111MODULE=off && (for i in $(seq 0 5); do sleep "$i"; go get gopkg.in/yaml.v2 && break; done)
+RUN go env -w GO111MODULE=off && (for i in 0 1 2 3 4 5; do sleep "$i"; go get gopkg.in/yaml.v2 && break; done)
 WORKDIR /usr/local/src/env2yaml
 CMD ["go", "build"]


### PR DESCRIPTION
the use of ranges (e.g. {0..5}) or seq (e.g. $(seq 0 5)) may not
correctly in some systems, so let's just have a plain list of elements
for the loop to go through.

Follow up to #14239