### PR TITLE
Increase Gradle network timeouts and retries to increment resiliancy to network issues

### DIFF
--- a/logstash-core/gradle.properties
+++ b/logstash-core/gradle.properties
@@ -1,2 +1,12 @@
 isDistributedArtifact=true
 
+# from default 30 secs to 2 minutes network timeouts
+org.gradle.internal.http.connectionTimeout=120000
+org.gradle.internal.http.socketTimeout=120000
+org.gradle.internal.http.idleConnectionTimeout=120000
+
+# from default 3 tentatives to 5
+org.gradle.internal.repository.max.tentatives=5
+
+# from default 125 ms to 500 ms
+org.gradle.internal.repository.initial.backoff=500


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

When an external repository reaches IO error or generates network timeouts the build fails in resolving external dependencies (plugins or libraries used by the project).
This commits increase a little bit those limits.


## Why is it important/What is the impact to the user?
No direct user impact.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 


## Logs

```
* What went wrong:

Error resolving plugin [id: 'de.undercouch.download', version: '4.0.4']
> Could not resolve all dependencies for configuration 'detachedConfiguration1'.
   > Could not determine artifacts for de.undercouch.download:de.undercouch.download.gradle.plugin:4.0.4
      > Could not get resource 'https://plugins.gradle.org/m2/de/undercouch/download/de.undercouch.download.gradle.plugin/4.0.4/de.undercouch.download.gradle.plugin-4.0.4.jar'.
         > Could not HEAD 'https://plugins.gradle.org/m2/de/undercouch/download/de.undercouch.download.gradle.plugin/4.0.4/de.undercouch.download.gradle.plugin-4.0.4.jar'.
            > Read timed out
```
