### PR TITLE
Perf: use JRuby JIT defaults (improves startup)

### DIFF
--- a/config/jvm.options
+++ b/config/jvm.options
@@ -47,8 +47,6 @@
 
 # Turn on JRuby invokedynamic
 -Djruby.compile.invokedynamic=true
-# Force Compilation
--Djruby.jit.threshold=0
 
 ## heap dumps
 


### PR DESCRIPTION
Removing the `-Djruby.jit.threshold=0` flag, which seems to have been [introduced](https://github.com/elastic/logstash/pull/7783) due benchmarking.

Removing the force of AOT means a noticeably faster startup (we do not need to 'compile' every method we bump into). The JIT threshold default is `50` in JRuby 9.2/9.3, there might be other heuristics in the future to better determine hot methods.

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

Changes recommended default Logstash ships with.

## Why is it important/What is the impact to the user?

Faster startup time (shaving off > 2 seconds).

### before (with -Djruby.jit.threshold=0)
```
Using LS_JAVA_HOME defined java: /opt/java/jdk-11.

STARTING RUBY runtime: 1655801953974
Bundler.setup!: 1655801956522
Bundler.setup DONE: 1655801961484 - 4963
```
**7510 millis**
```
Using LS_JAVA_HOME defined java: /opt/java/jdk-17.

STARTING RUBY runtime: 1655801845518
Bundler.setup!: 1655801847945
Bundler.setup DONE: 1655801852594 - 4649
```
**7076 millis**

### after (removed -Djruby.jit.threshold=0)

```
Using LS_JAVA_HOME defined java: /opt/java/jdk-11.

STARTING RUBY runtime: 1655802111106
Bundler.setup!: 1655802113471
Bundler.setup DONE: 1655802116477 - 3006
```
**5371 millis**
```
Using LS_JAVA_HOME defined java: /opt/java/jdk-17.

STARTING RUBY runtime: 1655802139762
Bundler.setup!: 1655802142066
Bundler.setup DONE: 1655802144845 - 2779
```
**5083 millis**

*Tested with JRuby 9.3.4.0, the logged numbers only include the time it takes to `LogStash::Bundler.setup!`, there should be more saving since the next step (after Bundler is setup) is loading up/executing .rb files that LS needs during it's boot.*

related: https://github.com/elastic/logstash/issues/14285