### PR TITLE
devtools/label: Add initial script that can label issues/PRs

### DIFF
--- a/devtools/label
+++ b/devtools/label
@@ -30,9 +30,9 @@ def main():
 
     print(args)
 
-    create_pr(parser, args)
+    create_label(parser, args)
 
-def create_pr(parser, args):
+def create_label(parser, args):
     info("Checking if GitHub API token is available in `~/.elastic/github.token`")
     token = get_github_token()
 

--- a/devtools/label
+++ b/devtools/label
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Cherry pick and backport a PR"""
+from __future__ import print_function
+
+from builtins import input
+import sys
+import os
+import argparse
+from os.path import expanduser
+import re
+from subprocess import check_call, call, check_output
+import requests
+import json
+
+usage = """
+    Example usage:
+        ./devtools/label <pr_number>
+"""
+
+
+def main():
+    """Main"""
+    parser = argparse.ArgumentParser(
+        description="Adds a label to a pull request",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=usage)
+    parser.add_argument("pr_number",
+                        help="The PR number being merged (e.g. 2345)")
+    args = parser.parse_args()
+
+    print(args)
+
+    create_pr(parser, args)
+
+def create_pr(parser, args):
+    info("Checking if GitHub API token is available in `~/.elastic/github.token`")
+    token = get_github_token()
+
+    if not token:
+        info("GitHub API token not available.\n" +
+             "Manually create a PR by following this URL: \n\t" +
+             "https://github.com/elastic/logstash/compare/{}...{}:{}?expand=1"
+              .format(args.to_branch, remote, tmp_branch))
+    else:
+        # initialize github
+        session = github_session(token)
+        base = "https://api.github.com/repos/elastic/logstash"
+
+        # add labels
+        labels = []
+
+        # get the version (vX.Y.Z) we are merging to
+        version = get_version(os.getcwd())
+        if version:
+            labels.append(version)
+
+        session.post(
+            base + "/issues/{}/labels".format(args.pr_number), json=labels)
+
+def get_version(base_dir):
+    with open(os.path.join(base_dir, "versions.yml"), "r") as f:
+        for line in f:
+            if line.startswith('logstash:'):
+                return "v" + line.split(':')[-1].strip()
+
+def get_github_token():
+    try:
+        token = open(expanduser("~/.elastic/github.token"), "r").read().strip()
+    except:
+        token = False
+    return token
+
+def github_session(token):
+    session = requests.Session()
+    session.headers.update({"Authorization": "token " + token})
+    return session
+
+def info(msg):
+    print("\nINFO: {}".format(msg))
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/devtools/label
+++ b/devtools/label
@@ -37,10 +37,7 @@ def create_label(parser, args):
     token = get_github_token()
 
     if not token:
-        info("GitHub API token not available.\n" +
-             "Manually create a PR by following this URL: \n\t" +
-             "https://github.com/elastic/logstash/compare/{}...{}:{}?expand=1"
-              .format(args.to_branch, remote, tmp_branch))
+        info("GitHub API token not available.")
     else:
         # initialize github
         session = github_session(token)


### PR DESCRIPTION
Adds an initial script that allows to add labels to issues/PRs. The first iteration of this script only allows users to add a version label based on the local branch version.yml.