### PR TITLE
Timestamp#toString(): ensure a minimum of 3 decimal places

### DIFF
--- a/logstash-core/spec/logstash/legacy_ruby_timestamp_spec.rb
+++ b/logstash-core/spec/logstash/legacy_ruby_timestamp_spec.rb
@@ -76,8 +76,8 @@ describe LogStash::Timestamp do
       subject(:timestamp) { LogStash::Timestamp.parse_iso8601(time_string) }
       context 'with whole seconds' do
         let(:time_string) { "2014-09-23T00:00:00.000-0800" }
-        it 'serializes a 20-byte string' do
-          expect(timestamp.to_json).to eq('"2014-09-23T08:00:00Z"')
+        it 'serializes a 24-byte string' do
+          expect(timestamp.to_json).to eq('"2014-09-23T08:00:00.000Z"')
         end
       end
       context 'with excess millis' do
@@ -88,13 +88,13 @@ describe LogStash::Timestamp do
       end
       context 'with excess micros' do
         let(:time_string) { "2014-09-23T00:00:00.000100-0800" }
-        it 'serializes a 24-byte string' do
+        it 'serializes a 27-byte string' do
           expect(timestamp.to_json).to eq('"2014-09-23T08:00:00.000100Z"')
         end
       end
       context 'with excess nanos' do
         let(:time_string) { "2014-09-23T00:00:00.000000010-0800" }
-        it 'serializes a 24-byte string' do
+        it 'serializes a 30-byte string' do
           expect(timestamp.to_json).to eq('"2014-09-23T08:00:00.000000010Z"')
         end
       end
@@ -169,7 +169,7 @@ describe LogStash::Timestamp do
   context "at" do
     context "with integer epoch" do
       it "should convert to correct date" do
-        expect(LogStash::Timestamp.at(946702800).to_iso8601).to eq("2000-01-01T05:00:00Z")
+        expect(LogStash::Timestamp.at(946702800).to_iso8601).to eq("2000-01-01T05:00:00.000Z")
       end
 
       it "should return zero usec" do
@@ -177,7 +177,7 @@ describe LogStash::Timestamp do
       end
 
       it "should return prior to epoch date on negative input" do
-        expect(LogStash::Timestamp.at(-1).to_iso8601).to eq("1969-12-31T23:59:59Z")
+        expect(LogStash::Timestamp.at(-1).to_iso8601).to eq("1969-12-31T23:59:59.000Z")
       end
     end
 

--- a/logstash-core/src/main/java/org/logstash/Timestamp.java
+++ b/logstash-core/src/main/java/org/logstash/Timestamp.java
@@ -28,6 +28,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.ResolverStyle;
 import java.time.temporal.ChronoField;
 import java.util.Date;
 
@@ -45,6 +46,11 @@ public final class Timestamp implements Comparable<Timestamp>, Queueable {
     private transient org.joda.time.DateTime time;
 
     private final Instant instant;
+
+    private static final DateTimeFormatter ISO_INSTANT_MILLIS = new DateTimeFormatterBuilder()
+            .appendInstant(3)
+            .toFormatter()
+            .withResolverStyle(ResolverStyle.STRICT);
 
     public Timestamp() {
         this(Clock.systemDefaultZone());
@@ -99,7 +105,9 @@ public final class Timestamp implements Comparable<Timestamp>, Queueable {
     }
 
     public String toString() {
-        return instant.toString();
+        // ensure minimum precision of 3 decimal places by using our own 3-decimal-place formatter when we have no nanos.
+        final DateTimeFormatter formatter = (instant.getNano() == 0 ? ISO_INSTANT_MILLIS : DateTimeFormatter.ISO_INSTANT);
+        return formatter.format(instant);
     }
 
     public long toEpochMilli() {

--- a/logstash-core/src/test/java/org/logstash/TimestampTest.java
+++ b/logstash-core/src/test/java/org/logstash/TimestampTest.java
@@ -53,6 +53,12 @@ public class TimestampTest {
     }
 
     @Test
+    public void testToStringNoNanos() throws Exception {
+        Timestamp t = new Timestamp("2014-09-23T12:34:56.000000000-0800", OFFSET_CLOCK);
+        assertEquals("2014-09-23T20:34:56.000Z", t.toString());
+    }
+
+    @Test
     public void testParsingDateTimeNoOffset() throws Exception {
         final Timestamp t = new Timestamp("2014-09-23T12:34:56.789012345", OFFSET_CLOCK);
         assertEquals("2014-09-23T20:34:56.789012345Z", t.toString());
@@ -60,13 +66,13 @@ public class TimestampTest {
     @Test
     public void testParsingDateNoOffset() throws Exception {
         final Timestamp t = new Timestamp("2014-09-23", OFFSET_CLOCK);
-        assertEquals("2014-09-23T08:00:00Z", t.toString());
+        assertEquals("2014-09-23T08:00:00.000Z", t.toString());
     }
 
     @Test
     public void testParsingDateWithOffset() throws Exception {
         final Timestamp t = new Timestamp("2014-09-23-08:00", OFFSET_CLOCK);
-        assertEquals("2014-09-23T08:00:00Z", t.toString());
+        assertEquals("2014-09-23T08:00:00.000Z", t.toString());
     }
 
     @Test


### PR DESCRIPTION
Logstash 8 introduced internals for nano-precise timestamps, and began relying
on `java.time.format.DateTimeFormatter#ISO_INSTANT` to produce ISO8601-format
strings via `java.time.Instant#toString()`, resulting in a _variable length_
serialization that only includes sub-second digits when the Instant represents
a moment in time with fractional seconds.

By ensuring that a timestamp's serialization has a minimum of 3 decimal places,
we ensure that our output is backward-compatible with the equivalent timestamp
produced by Logstash 7.

## Release notes

Adds a backward-compatibility enhancement to ensure timestamp values are serialized with a _minimum_ of 3 decimal places, even if they refer to a whole second with no fractional part. This ensures our output for millisecond-precise timestamps is identical to the output from Logstash 7, while allowing us to continue supporting nanosecond-precise values introduced in Logstash 8.

## What does this PR do?

Ensures that Timestamps are serialized with a minimum of 3 decimal places so that downstream processors expecting decimal precision don't choke.

In https://github.com/elastic/logstash/pull/12797 we deemed the serialization of whole-second timestamps without an all-zeroes decimal fragment to be _equivalent_ to the output from Logstash 7, but failed to consider that downstream parsers may not fully implement the _optionality_ of zero-value fragments specified by ISO8601.

## Why is it important/What is the impact to the user?

Ensures downstream processors capable of handling millisecond-precise timestamps from Logstash 7 need no further adjustments to handle millisecond-precise timestamps from Logstash 8.

For example, an Elasticsearch `date` field's `date_time` formatter _requires_ that the input has a decimal and trailing digits:

> `date_time` or `strict_date_time`
>  A formatter that combines a full date and time, separated by a T: `yyyy-MM-dd'T'HH:mm:ss.SSSZ`.
> [Elasticsearch - Mapping - Date Format - `date_time`](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html#:~:text=date_time%20or%20strict_date_time,SSSZ%20.)

Workaround: without this patch, the Elasticsearch field's mapping would need to be adapted to _add_ `date_time_no_millis`, which accepts a value that does _not_ have fractional digits

~~~
date_time||date_time_no_millis
~~~

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

1. Run the following pipeline:
   ```
   input {
     generator {
       count => 1
       codec => json
       lines => [
         '{"@timestamp": "2022-06-24T01:23:45Z"}',
         '{"@timestamp": "2022-06-24T01:23:45.000Z"}',
         '{"@timestamp": "2022-06-24T01:23:45.000000000Z"}',
         '{"@timestamp": "2022-06-24T01:23:45.67Z"}',
         '{"@timestamp": "2022-06-24T01:23:45.678Z"}',
         '{"@timestamp": "2022-06-24T01:23:45.678901234Z"}'
       ]
     }
   }
   output {
     stdout {
       codec => json_lines
     }
   }
   ```

2. Observe that all of the serialized `@timestamp` on the events have a minimum of 3 digits precision, even those with `.000` or no sub-second precision in the `event.original`, and that additional sub-millisecond precision is preserved:
   ```
   {"@timestamp":"2022-06-24T01:23:45.000Z","@version":"1","event":{"sequence":0,"original":"{\"@timestamp\": \"2022-06-24T01:23:45.000Z\"}"},"host":{"name":"maybe.lan"}}
   {"@timestamp":"2022-06-24T01:23:45.670Z","@version":"1","event":{"sequence":0,"original":"{\"@timestamp\": \"2022-06-24T01:23:45.67Z\"}"},"host":{"name":"maybe.lan"}}
   {"@timestamp":"2022-06-24T01:23:45.000Z","@version":"1","event":{"sequence":0,"original":"{\"@timestamp\": \"2022-06-24T01:23:45Z\"}"},"host":{"name":"maybe.lan"}}
   {"@timestamp":"2022-06-24T01:23:45.678901234Z","@version":"1","event":{"sequence":0,"original":"{\"@timestamp\": \"2022-06-24T01:23:45.678901234Z\"}"},"host":{"name":"maybe.lan"}}
   {"@timestamp":"2022-06-24T01:23:45.678Z","@version":"1","event":{"sequence":0,"original":"{\"@timestamp\": \"2022-06-24T01:23:45.678Z\"}"},"host":{"name":"maybe.lan"}}
   {"@timestamp":"2022-06-24T01:23:45.000Z","@version":"1","event":{"sequence":0,"original":"{\"@timestamp\": \"2022-06-24T01:23:45.000000000Z\"}"},"host":{"name":"maybe.lan"}}
   ```

## Related issues

Relates: https://github.com/elastic/logstash/pull/12797

## Use cases

Downstream processors that are not tolerant to an accurate and valid ISO8601 timestamp with no sub-second precision.
