### PR TITLE
Build: make sure lock is created in integration specs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -298,7 +298,7 @@ tasks.register("installBundler") {
   }
 }
 
-tasks.register("bootstrap"){
+tasks.register("bootstrap") {
     dependsOn installBundler
     doLast {
       setupJruby(projectDir, buildDir)
@@ -428,7 +428,8 @@ tasks.register("installIntegrationTestBundler"){
 
 tasks.register("installIntegrationTestGems") {
   dependsOn installIntegrationTestBundler
-  inputs.files file("${projectDir}/qa/integration/Gemfile")
+  def gemfilePath = file("${projectDir}/qa/integration/Gemfile")
+  inputs.files gemfilePath
   inputs.files file("${projectDir}/qa/integration/integration_tests.gemspec")
   inputs.files file("${logstashBuildDir}/Gemfile")
   inputs.files file("${logstashBuildDir}/Gemfile.lock")
@@ -438,7 +439,7 @@ tasks.register("installIntegrationTestGems") {
   doLast {
       bundleWithEnv(
         projectDir, buildDir,
-        qaBuildPath, qaBundleBin, ['install', '--path', qaVendorPath],
+        qaBuildPath, qaBundleBin, ['install', '--path', qaVendorPath, '--gemfile', gemfilePath],
         [ GEM_PATH: qaBundledGemPath, GEM_HOME: qaBundledGemPath ]
       )
   }


### PR DESCRIPTION
without these changes doing (an in-process) `bundle install`
did not generate a *Gemfile.lock*

this is than problematic, when using git sourced gem (locally)
those gems do not not get resolved properly when running the
*qa/integration/rspec.rb* script

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

Improves build for integration testing.

## How to test this PR locally

### before

run `./gradlew :logstash-integration-tests:integrationTests` 
check `cat qa/integration/Gemfile.lock` (`No such file or directory`)

### after (PR)

run `./gradlew :logstash-integration-tests:integrationTests` 
check `cat qa/integration/Gemfile.lock` exists and is not empty