### PR TITLE
Fix broken link to image on docs

### DIFF
--- a/docs/static/monitoring/monitoring-internal-legacy.asciidoc
+++ b/docs/static/monitoring/monitoring-internal-legacy.asciidoc
@@ -132,7 +132,7 @@ your Logstash nodes should be visible in the Logstash section. When security is
 enabled, to view the monitoring dashboards you must log in to {kib} as a user
 who has the `kibana_user` and `monitoring_user` roles.
 +
-image::images/monitoring-ui.png["Monitoring",link="monitoring/images/monitoring-ui.png"]
+image::images/monitoring-ui.png["Monitoring",link="images/monitoring-ui.png"]
 
 include::../settings/monitoring-settings-legacy.asciidoc[]
 


### PR DESCRIPTION
## What does this PR do?
Fix broken link to image in 7.17 docs.

