### PR TITLE
jruby-9.3 test fix for windows CI

### DIFF
--- a/logstash-core/lib/logstash/plugins/ca_trusted_fingerprint_support.rb
+++ b/logstash-core/lib/logstash/plugins/ca_trusted_fingerprint_support.rb
@@ -1,6 +1,8 @@
 module LogStash
   module Plugins
     module CATrustedFingerprintSupport
+      java_import "org.logstash.util.CATrustedFingerprintTrustStrategy"
+
       def self.included(base)
         fail(ArgumentError) unless base < LogStash::Plugin
 
@@ -12,7 +14,7 @@ module LogStash
       lazy_init_attr(:trust_strategy_for_ca_trusted_fingerprint,
                      variable: :@_trust_strategy_for_ca_trusted_fingerprint) do
         require 'logstash/patches/manticore/trust_strategies'
-        @ca_trusted_fingerprint && org.logstash.util.CATrustedFingerprintTrustStrategy.new(@ca_trusted_fingerprint)
+        @ca_trusted_fingerprint && CATrustedFingerprintTrustStrategy.new(@ca_trusted_fingerprint)
       end
     end
   end

--- a/logstash-core/spec/logstash/plugins/ca_trusted_fingerprint_support_spec.rb
+++ b/logstash-core/spec/logstash/plugins/ca_trusted_fingerprint_support_spec.rb
@@ -6,6 +6,7 @@ require 'logstash/inputs/base'
 require 'logstash/filters/base'
 require 'logstash/codecs/base'
 require 'logstash/outputs/base'
+java_import "org.logstash.util.CATrustedFingerprintTrustStrategy"
 
 describe LogStash::Plugins::CATrustedFingerprintSupport do
 
@@ -47,7 +48,7 @@ describe LogStash::Plugins::CATrustedFingerprintSupport do
           end
           context '#trust_strategy_for_ca_trusted_fingerprint' do
             it 'builds an appropriate trust strategy' do
-              expect(org.logstash.util.CATrustedFingerprintTrustStrategy).to receive(:new).with(normalized).and_call_original
+              expect(CATrustedFingerprintTrustStrategy).to receive(:new).with(normalized).and_call_original
               expect(plugin.trust_strategy_for_ca_trusted_fingerprint).to be_a_kind_of(org.apache.http.conn.ssl.TrustStrategy)
             end
           end


### PR DESCRIPTION
This test has been broken on Windows since the jruby 9.3 update, and is
similar to an issue we saw when referencing other classes in the
org.logstash.util namespace
