### PR TITLE
Bugfix for DLQ when writer is pushing data and reader consuming.

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -298,11 +298,13 @@ public final class DeadLetterQueueWriter implements Closeable {
         // that's already cleaning
         try {
             this.currentQueueSize.set(computeQueueSize());
-            if (!exceedMaxQueueSize(eventPayloadSize)) {
-                return false;
-            }
         } catch (IOException ex) {
             logger.warn("Unable to determine DLQ size, skipping storage policy check", ex);
+            return false;
+        }
+
+        // after reload verify the condition is still valid
+        if (!exceedMaxQueueSize(eventPayloadSize)) {
             return false;
         }
 

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -302,7 +302,8 @@ public final class DeadLetterQueueWriter implements Closeable {
                 return false;
             }
         } catch (IOException ex) {
-            logger.error("Can't read DLQ size from filesystem", ex);
+            logger.warn("Unable to determine DLQ size, skipping storage policy check", ex);
+            return false;
         }
 
         if (storageType == QueueStorageType.DROP_NEWER) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->


## What does this PR do?

Bugfix for DLQ when writer and reader with clean_consumed feature are working on same queue.

The writer side keeps the size of DLQ in memory veriable and when exceed it applies the storage policy, so essentially drop older or never events.
If on the opposite side of the DLQ there is a readed, with clean_consumed feature enabled, that delete the segments it processes then the writer side could have a not consistent information about the DLQ size.

This commit adds a filesystem check when it recognizes that "DLQ full" condition is reached, to avoid consider false positive as valid data.


## Why is it important/What is the impact to the user?

As a user with a DLQ writer and reader pipelines, when the reader is configured to clean consumed segments, then the writer side can't drop events if the queue full condition is effectively met.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Run it locally with DLQ input plugin `v2.0.0`, `clean_consumed` enabled and check that "queue full" is met effectively when the filesystem contains DLQ segments up to the DLQ size limit.

## How to test this PR locally
### build and install the plugin
- clone the `main` from https://github.com/logstash-plugins/logstash-input-dead_letter_queue/
- build the gem:
```
./gradlew vendor
gem build logstash-input-dead_letter_queue.gemspec
```
- install the gem on Logstash:
```
bin/logstash-plugin install --local ~/workspace/logstash_plugins/logstash-input-dead_letter_queue/logstash-input-dead_letter_queue-2.0.0.gem
```

### Test Logstash
- run logstash with `pipelines.yml` as:
```
- pipeline.id: dlq_upstream
  path.config: "/tmp/dlq_upstream_pipeline.conf"

- pipeline.id: dlq_downstream
  path.config: "/tmp/dlq_reader_pipeline.conf"
```
and  `logstash-yml` with:
```
dead_letter_queue.enable: true
```
- configure the 2 pipelines as:
#### `/tmp/dlq_upstream_pipeline.conf`
```
input {
  generator {
    message => '{"jvm" : {"threads" : {"count" : 49,"peak_count" : 50},"mem" : {"heap_used_percent" : 14,"heap_committed_in_bytes" : 309866496,"heap_max_in_bytes" : 1037959168,"heap_used_in_bytes" : 151686096,"non_heap_used_in_bytes" : 122486176,"non_heap_committed_in_bytes" : 133222400,"pools" : {"survivor" : {"peak_used_in_bytes" : 8912896,"used_in_bytes" : 288776,"peak_max_in_bytes" : 35782656,"max_in_bytes" : 35782656,"committed_in_bytes" : 8912896},"peak_used_in_bytes" : 148656848,"used_in_bytes" : 148656848,"peak_max_in_bytes" : 715849728,"max_in_bytes" : 715849728,"committed_in_bytes" : 229322752},"young" : {"peak_used_in_bytes" : 71630848,"used_in_bytes" : 2740472,"peak_max_in_bytes" : 286326784,"max_in_bytes" : 286326784,"committed_in_bytes" : 71630848}}},"gc" : {"collectors" : {"old" : {"collection_time_in_millis" : 607,"collection_count" : 12},"young" : {"collection_time_in_millis" : 4904,"collection_count" : 1033}}},"uptime_in_millis" : 1809643}'

    codec => json
  }
}

output {
  elasticsearch {
    index => "test_index"
    hosts => "http://localhost:9200"
    user => "elastic"
    password => "changeme"
  }
}
```
#### `/tmp/dlq_reader_pipeline.conf`
```
input {
  dead_letter_queue {
    path => "/<logstash clone>/data/dead_letter_queue/"
    pipeline_id => "dlq_upstream"
    clean_consumed => true
  }
}

output {
  stdout {
    codec => dots
  }
}
```
- verify that queue full condition on logs with:
```
Cannot write event to DLQ(path: /<logstash clone>/data/dead_letter_queue/dlq_upstream): reached maxQueueSize of 1073741824
```
happens seldom and if happens, then the filesystem occupation of segment files is effectively 1Gb


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #14173


## Logs

```
Cannot write event to DLQ(path: /<logstash clone>/data/dead_letter_queue/dlq_upstream): reached maxQueueSize of 1073741824
```
