### PR TITLE
Expose DLQ deleted events count on reader side

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReader.java
@@ -40,7 +40,6 @@ package org.logstash.common.io;
 
 import java.io.Closeable;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.logstash.DLQEntry;
@@ -289,7 +288,7 @@ public final class DeadLetterQueueReader implements Closeable {
 
         // delete segment file only after current reader is closed.
         // closing happens in pollEntryBytes method when it identifies the reader is at end of stream
-        final long deletedEvents = deleteSegment(lastConsumedSegmentPath).orElse(0L);
+        final long deletedEvents = deleteSegment(lastConsumedSegmentPath);
 
         // update consumed metrics
         consumedEvents.add(deletedEvents);
@@ -359,9 +358,7 @@ public final class DeadLetterQueueReader implements Closeable {
 
         try (final Stream<Path> segmentFiles = listSegmentPaths(queuePath)) {
             LongSummaryStatistics deletionStats = segmentFiles.filter(p -> fileTimeAndName.compare(p, validSegment) < 0)
-                    .map(this::deleteSegment)
-                    .map(o -> o.orElse(0L))
-                    .mapToLong(Long::longValue)
+                    .mapToLong(this::deleteSegment)
                     .summaryStatistics();
 
             // update consumed metrics
@@ -395,18 +392,18 @@ public final class DeadLetterQueueReader implements Closeable {
      * Remove the segment from internal tracking data structures and physically delete the corresponding
      * file from filesystem.
      *
-     * @return the number events contained in the removed segment, empty if a problem happened during delete.
+     * @return the number events contained in the removed segment, 0 if a problem happened during delete.
      * */
-    private Optional<Long> deleteSegment(Path segment) {
+    private long deleteSegment(Path segment) {
         segments.remove(segment);
         try {
             long eventsInSegment = DeadLetterQueueUtils.countEventsInSegment(segment);
             Files.delete(segment);
             logger.debug("Deleted segment {}", segment);
-            return Optional.of(eventsInSegment);
+            return eventsInSegment;
         } catch (IOException ex) {
             logger.warn("Problem occurred in cleaning the segment {} after a repositioning", segment, ex);
-            return Optional.empty();
+            return 0L;
         }
     }
 

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReader.java
@@ -289,11 +289,12 @@ public final class DeadLetterQueueReader implements Closeable {
 
         // delete segment file only after current reader is closed.
         // closing happens in pollEntryBytes method when it identifies the reader is at end of stream
-        final long deletedEvents = deleteSegment(lastConsumedSegmentPath).orElse(0L);
-
-        // update consumed metrics
-        consumedEvents.add(deletedEvents);
-        consumedSegments.increment();
+        final Optional<Long> deletedEvents = deleteSegment(lastConsumedSegmentPath);
+        if (deletedEvents.isPresent()) {
+            // update consumed metrics
+            consumedEvents.add(deletedEvents.get());
+            consumedSegments.increment();
+        }
 
         // publish the metrics to the listener
         segmentCallback.segmentsDeleted(consumedSegments.intValue(), consumedEvents.longValue());

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueUtils.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueUtils.java
@@ -18,13 +18,23 @@
  */
 package org.logstash.common.io;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.logstash.common.io.RecordIOWriter.*;
+
 class DeadLetterQueueUtils {
+
+    private static final Logger logger = LogManager.getLogger(DeadLetterQueueUtils.class);
 
     static int extractSegmentId(Path p) {
         return Integer.parseInt(p.getFileName().toString().split("\\.log")[0]);
@@ -39,5 +49,56 @@ class DeadLetterQueueUtils {
 
     static Stream<Path> listSegmentPaths(Path path) throws IOException {
         return listFiles(path, ".log");
+    }
+
+    /**
+     * Count the number of 'c' and 's' records in segment.
+     * An event can't be bigger than the segments so in case of records split across multiple event blocks,
+     * the segment has to contain both the start 's' record, all the middle 'm' up to the end 'e' records.
+     * */
+    @SuppressWarnings("fallthrough")
+    static long countEventsInSegment(Path segment) throws IOException {
+        try (FileChannel channel = FileChannel.open(segment, StandardOpenOption.READ)) {
+            // verify minimal segment size
+            if (channel.size() < VERSION_SIZE + RECORD_HEADER_SIZE) {
+                return 0L;
+            }
+
+            // skip the DLQ version byte
+            channel.position(1);
+            int posInBlock = 0;
+            int currentBlockIdx = 0;
+            long countedEvents = 0;
+            do {
+                ByteBuffer headerBuffer = ByteBuffer.allocate(RECORD_HEADER_SIZE);
+                long startPosition = channel.position();
+                // if record header can't be fully contained in the block, align to the next
+                if (posInBlock + RECORD_HEADER_SIZE + 1 > BLOCK_SIZE) {
+                    channel.position((++currentBlockIdx) * BLOCK_SIZE + VERSION_SIZE);
+                    posInBlock = 0;
+                }
+
+                channel.read(headerBuffer);
+                headerBuffer.flip();
+                RecordHeader recordHeader = RecordHeader.get(headerBuffer);
+                if (recordHeader == null) {
+                    // continue with next record, skipping this
+                    logger.error("Can't decode record header, position {} current post {} current events count {}", startPosition, channel.position(), countedEvents);
+                } else {
+                    switch (recordHeader.getType()) {
+                        case START:
+                        case COMPLETE:
+                            countedEvents++;
+                        case MIDDLE:
+                        case END: {
+                            channel.position(channel.position() + recordHeader.getSize());
+                            posInBlock += RECORD_HEADER_SIZE + recordHeader.getSize();
+                        }
+                    }
+                }
+            } while (channel.position() < channel.size());
+
+            return countedEvents;
+        }
     }
 }

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -374,60 +374,6 @@ public final class DeadLetterQueueWriter implements Closeable {
         }
     }
 
-//<<<<<<< HEAD
-//    /**
-//     * Count the number of 'c' and 's' records in segment.
-//     * An event can't be bigger than the segments so in case of records split across multiple event blocks,
-//     * the segment has to contain both the start 's' record, all the middle 'm' up to the end 'e' records.
-//     * */
-//    @SuppressWarnings("fallthrough")
-//    private long countEventsInSegment(Path segment) throws IOException {
-//        try (FileChannel channel = FileChannel.open(segment, StandardOpenOption.READ)) {
-//            // verify minimal segment size
-//            if (channel.size() < VERSION_SIZE + RECORD_HEADER_SIZE) {
-//                return 0L;
-//            }
-//
-//            // skip the DLQ version byte
-//            channel.position(1);
-//            int posInBlock = 0;
-//            int currentBlockIdx = 0;
-//            long countedEvents = 0;
-//            do {
-//                ByteBuffer headerBuffer = ByteBuffer.allocate(RECORD_HEADER_SIZE);
-//                long startPosition = channel.position();
-//                // if record header can't be fully contained in the block, align to the next
-//                if (posInBlock + RECORD_HEADER_SIZE + 1 > BLOCK_SIZE) {
-//                    channel.position((++currentBlockIdx) * BLOCK_SIZE + VERSION_SIZE);
-//                    posInBlock = 0;
-//                }
-//
-//                channel.read(headerBuffer);
-//                headerBuffer.flip();
-//                RecordHeader recordHeader = RecordHeader.get(headerBuffer);
-//                if (recordHeader == null) {
-//                    // continue with next record, skipping this
-//                    logger.error("Can't decode record header, position {} current post {} current events count {}", startPosition, channel.position(), countedEvents);
-//                } else {
-//                    switch (recordHeader.getType()) {
-//                        case START:
-//                        case COMPLETE:
-//                            countedEvents++;
-//                        case MIDDLE:
-//                        case END: {
-//                            channel.position(channel.position() + recordHeader.getSize());
-//                            posInBlock += RECORD_HEADER_SIZE + recordHeader.getSize();
-//                        }
-//                    }
-//                }
-//            } while (channel.position() < channel.size());
-//
-//            return countedEvents;
-//        }
-//    }
-//
-//=======
-//>>>>>>> da20361e8... Introduced consumed events and segments counters and published through SegmentListener
     private void updateOldestSegmentReference() throws IOException {
         oldestSegmentPath = listSegmentPaths(this.queuePath).sorted().findFirst();
         if (!oldestSegmentPath.isPresent()) {

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -40,14 +40,11 @@ package org.logstash.common.io;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -366,7 +363,7 @@ public final class DeadLetterQueueWriter implements Closeable {
      * */
     private long deleteTailSegment(Path segment, String motivation) throws IOException {
         try {
-            long eventsInSegment = countEventsInSegment(segment);
+            long eventsInSegment = DeadLetterQueueUtils.countEventsInSegment(segment);
             Files.delete(segment);
             logger.debug("Removed segment file {} due to {}", motivation, segment);
             return eventsInSegment;
@@ -377,57 +374,60 @@ public final class DeadLetterQueueWriter implements Closeable {
         }
     }
 
-    /**
-     * Count the number of 'c' and 's' records in segment.
-     * An event can't be bigger than the segments so in case of records split across multiple event blocks,
-     * the segment has to contain both the start 's' record, all the middle 'm' up to the end 'e' records.
-     * */
-    @SuppressWarnings("fallthrough")
-    private long countEventsInSegment(Path segment) throws IOException {
-        try (FileChannel channel = FileChannel.open(segment, StandardOpenOption.READ)) {
-            // verify minimal segment size
-            if (channel.size() < VERSION_SIZE + RECORD_HEADER_SIZE) {
-                return 0L;
-            }
-
-            // skip the DLQ version byte
-            channel.position(1);
-            int posInBlock = 0;
-            int currentBlockIdx = 0;
-            long countedEvents = 0;
-            do {
-                ByteBuffer headerBuffer = ByteBuffer.allocate(RECORD_HEADER_SIZE);
-                long startPosition = channel.position();
-                // if record header can't be fully contained in the block, align to the next
-                if (posInBlock + RECORD_HEADER_SIZE + 1 > BLOCK_SIZE) {
-                    channel.position((++currentBlockIdx) * BLOCK_SIZE + VERSION_SIZE);
-                    posInBlock = 0;
-                }
-
-                channel.read(headerBuffer);
-                headerBuffer.flip();
-                RecordHeader recordHeader = RecordHeader.get(headerBuffer);
-                if (recordHeader == null) {
-                    // continue with next record, skipping this
-                    logger.error("Can't decode record header, position {} current post {} current events count {}", startPosition, channel.position(), countedEvents);
-                } else {
-                    switch (recordHeader.getType()) {
-                        case START:
-                        case COMPLETE:
-                            countedEvents++;
-                        case MIDDLE:
-                        case END: {
-                            channel.position(channel.position() + recordHeader.getSize());
-                            posInBlock += RECORD_HEADER_SIZE + recordHeader.getSize();
-                        }
-                    }
-                }
-            } while (channel.position() < channel.size());
-
-            return countedEvents;
-        }
-    }
-
+//<<<<<<< HEAD
+//    /**
+//     * Count the number of 'c' and 's' records in segment.
+//     * An event can't be bigger than the segments so in case of records split across multiple event blocks,
+//     * the segment has to contain both the start 's' record, all the middle 'm' up to the end 'e' records.
+//     * */
+//    @SuppressWarnings("fallthrough")
+//    private long countEventsInSegment(Path segment) throws IOException {
+//        try (FileChannel channel = FileChannel.open(segment, StandardOpenOption.READ)) {
+//            // verify minimal segment size
+//            if (channel.size() < VERSION_SIZE + RECORD_HEADER_SIZE) {
+//                return 0L;
+//            }
+//
+//            // skip the DLQ version byte
+//            channel.position(1);
+//            int posInBlock = 0;
+//            int currentBlockIdx = 0;
+//            long countedEvents = 0;
+//            do {
+//                ByteBuffer headerBuffer = ByteBuffer.allocate(RECORD_HEADER_SIZE);
+//                long startPosition = channel.position();
+//                // if record header can't be fully contained in the block, align to the next
+//                if (posInBlock + RECORD_HEADER_SIZE + 1 > BLOCK_SIZE) {
+//                    channel.position((++currentBlockIdx) * BLOCK_SIZE + VERSION_SIZE);
+//                    posInBlock = 0;
+//                }
+//
+//                channel.read(headerBuffer);
+//                headerBuffer.flip();
+//                RecordHeader recordHeader = RecordHeader.get(headerBuffer);
+//                if (recordHeader == null) {
+//                    // continue with next record, skipping this
+//                    logger.error("Can't decode record header, position {} current post {} current events count {}", startPosition, channel.position(), countedEvents);
+//                } else {
+//                    switch (recordHeader.getType()) {
+//                        case START:
+//                        case COMPLETE:
+//                            countedEvents++;
+//                        case MIDDLE:
+//                        case END: {
+//                            channel.position(channel.position() + recordHeader.getSize());
+//                            posInBlock += RECORD_HEADER_SIZE + recordHeader.getSize();
+//                        }
+//                    }
+//                }
+//            } while (channel.position() < channel.size());
+//
+//            return countedEvents;
+//        }
+//    }
+//
+//=======
+//>>>>>>> da20361e8... Introduced consumed events and segments counters and published through SegmentListener
     private void updateOldestSegmentReference() throws IOException {
         oldestSegmentPath = listSegmentPaths(this.queuePath).sorted().findFirst();
         if (!oldestSegmentPath.isPresent()) {

--- a/logstash-core/src/main/java/org/logstash/common/io/SegmentListener.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/SegmentListener.java
@@ -1,9 +1,21 @@
 package org.logstash.common.io;
 
 /**
- * Callback interface to receive notification when a DLQ segment is completely read and is going to be removed.
+ * Listener interface to receive notification when a DLQ segment is completely read and when are removed.
  * */
-@FunctionalInterface
 public interface SegmentListener {
+    /**
+     * Notifies the listener about the complete consumption of a bunch of segments.
+     * */
     void segmentCompleted();
+
+    /**
+     * Notifies the listener about the deletion of consumed segments.
+     * It reports the number of deleted segments and number of events contained in those segments.
+     *
+     * @param numberOfSegments the number of deleted segment files.
+     *
+     * @param numberOfEvents total number of events that were present in the deleted segments.
+     * */
+    void segmentsDeleted(int numberOfSegments, long numberOfEvents);
 }

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
@@ -952,6 +952,8 @@ public class DeadLetterQueueReaderTest {
 
     private static class MockSegmentListener implements SegmentListener {
         boolean notified = false;
+        long events = 0L;
+        int segments = 0;
 
         @Override
         public void segmentCompleted() {
@@ -960,7 +962,8 @@ public class DeadLetterQueueReaderTest {
 
         @Override
         public void segmentsDeleted(int numberOfSegments, long numberOfEvents) {
-            // no-op
+            events += numberOfEvents;
+            segments += numberOfSegments;
         }
     }
 
@@ -968,9 +971,9 @@ public class DeadLetterQueueReaderTest {
     public void testReaderWithCleanConsumedIsEnabledDeleteFullyConsumedSegmentsAfterBeingAcknowledged() throws IOException, InterruptedException {
         final int eventsPerSegment = prepareFilledSegmentFiles(2);
 
-        MockSegmentListener callback = new MockSegmentListener();
+        MockSegmentListener listener = new MockSegmentListener();
 
-        try (DeadLetterQueueReader reader = new DeadLetterQueueReader(dir, true, callback)) {
+        try (DeadLetterQueueReader reader = new DeadLetterQueueReader(dir, true, listener)) {
             // to reach endOfStream on the first segment, a read more than the size has to be done.
             for (int i = 0; i < eventsPerSegment + 1; i++) {
                 reader.pollEntry(1_000);
@@ -983,12 +986,14 @@ public class DeadLetterQueueReaderTest {
                     .map(Path::toString)
                     .collect(Collectors.toSet());
             assertEquals("Only head segment file MUST be present", Set.of("2.log"), segments);
-            assertTrue("Reader's client must be notified of the segment deletion", callback.notified);
+            assertTrue("Reader's client must be notified of the segment deletion", listener.notified);
+            assertEquals("Must report the deletion of 1 segment", 1, listener.segments);
+            assertEquals("Must report the correct number of deleted events", eventsPerSegment, listener.events);
         }
     }
 
     @Test
-    public void testReaderWithCleanConsumedIsEnabledWhenSetCurrentPositionCleanupTrashedSegments() throws IOException {
+    public void testReaderWithCleanConsumedIsEnabledWhenSetCurrentPositionThenCleanupTrashedSegments() throws IOException {
         prepareFilledSegmentFiles(2);
 
         try (DeadLetterQueueReader reader = new DeadLetterQueueReader(dir, true, new MockSegmentListener())) {
@@ -1001,6 +1006,7 @@ public class DeadLetterQueueReaderTest {
             // verify
             Set<Path> segmentFiles = DeadLetterQueueUtils.listSegmentPaths(dir).collect(Collectors.toSet());
             assertEquals(Set.of(lastSegmentPath), segmentFiles);
+            assertEquals("Just the 1.log segment should be marked as consumed", 1, reader.getConsumedSegments());
         }
     }
 
@@ -1021,7 +1027,7 @@ public class DeadLetterQueueReaderTest {
 
     @Test
     public void testReaderCleanMultipleConsumedSegmentsAfterMarkForDelete() throws IOException, InterruptedException {
-        int eventPerSegment = prepareFilledSegmentFiles(3);
+        int eventsPerSegment = prepareFilledSegmentFiles(3);
         // insert also a .lock file, must be the oldest one
         Path lockFile = Files.createFile(dir.resolve(".lock"));
         FileTime oneSecondAgo = FileTime.from(Instant.now().minusMillis(1_000));
@@ -1029,11 +1035,12 @@ public class DeadLetterQueueReaderTest {
         // simulate a writer's segment head
         Files.createFile(dir.resolve("4.log.tmp"));
 
-        try (DeadLetterQueueReader reader = new DeadLetterQueueReader(dir, true, new MockSegmentListener())) {
+        MockSegmentListener listener = new MockSegmentListener();
+        try (DeadLetterQueueReader reader = new DeadLetterQueueReader(dir, true, listener)) {
             verifySegmentFiles(listSegmentsSorted(dir), "1.log", "2.log", "3.log");
 
             // consume fully two segments plus one more event to trigger the endOfStream on the second segment
-            for (int i = 0; i < (2 * eventPerSegment) + 1; i++) {
+            for (int i = 0; i < (2 * eventsPerSegment) + 1; i++) {
                 reader.pollEntry(100L);
             }
 
@@ -1042,6 +1049,9 @@ public class DeadLetterQueueReaderTest {
             reader.markForDelete();
 
             verifySegmentFiles(listSegmentsSorted(dir), "3.log");
+
+            assertEquals("Must report the deletion of 2 segments", 2, listener.segments);
+            assertEquals("Must report the correct number of deleted events", eventsPerSegment * listener.segments, listener.events);
 
             // verify no other files are removed
             try (Stream<Path> stream = Files.list(dir)) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Increments the counters of consumed events and consumed events every time a segment is completely read from the reader side.
Publish the collected data to the input plugin through the newly added method ` segmentsDeleted(numberOfSegments, numberOfEvents)` to `SegmentListener`.

## Why is it important/What is the impact to the user?

Provides the base functionality to expose the consumed metrics from the DLQ input plugin.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] verify with a local build of https://github.com/logstash-plugins/logstash-input-dead_letter_queue/pull/45

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #14173
- Relates #10493

## Use cases

As a user of `clean_consumed` DLQ feature I want to monitor the number of events and segments that are cleaned.


