### PR TITLE
Fix broken link to image

### DIFF
--- a/docs/static/monitoring/monitoring-internal-legacy.asciidoc
+++ b/docs/static/monitoring/monitoring-internal-legacy.asciidoc
@@ -154,7 +154,7 @@ your Logstash nodes should be visible in the Logstash section. When security is
 enabled, to view the monitoring dashboards you must log in to {kib} as a user
 who has the `kibana_user` and `monitoring_user` roles.
 +
-image::images/monitoring-ui.png["Monitoring",link="monitoring/images/monitoring-ui.png"]
+image::images/monitoring-ui.png["Monitoring",link="images/monitoring-ui.png"]
 
 include::../settings/monitoring-settings-legacy.asciidoc[]
 


### PR DESCRIPTION
Supersedes https://github.com/elastic/logstash/pull/14317

## What does this PR do?
Fix broken link to image in docs.

## Steps to reproduce:
1. Go to https://www.elastic.co/guide/en/logstash/current/monitoring-internal-collection-legacy.html#configure-internal-collectors-legacy
2. In step 6, there's an image that illustrates the monitoring section. (That image is shown correctly)
3. Click on that image to get see it in original size

**Expected**: the link points to the image in original size and the reader can see it.
**Current**: the link is broken and clicking on the image sends the user to a 404 page

As the changes imply, if the link were 

https://www.elastic.co/guide/en/logstash/current/images/monitoring-ui.png

instead of

https://www.elastic.co/guide/en/logstash/current/monitoring/images/monitoring-ui.png

then the image would open correctly.

Thank you :)