### PR TITLE
Change deb/rpm specification to describe as replacement of noarch old…

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -620,6 +620,7 @@ namespace "artifact" do
         out.config_files << "/etc/logstash/pipelines.yml"
         out.config_files << "/lib/systemd/system/logstash.service"
         out.config_files << "/etc/default/logstash"
+        out.replaces << "logstash < 7.10.0"
       when "debian", "ubuntu"
         require "fpm/package/deb"
 
@@ -638,6 +639,8 @@ namespace "artifact" do
         out.config_files << "/etc/logstash/pipelines.yml"
         out.config_files << "/lib/systemd/system/logstash.service"
         out.config_files << "/etc/default/logstash"
+        out.conflicts << "logstash (<< 7.10.0)"
+        out.replaces << "logstash (<< 7.10.0)"
     end
 
     # Packaging install/removal scripts


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Updates deb/rpm packages architecture specific package to be the update of old Logstash noarch packages, like `< 7.10.0`

## What does this PR do?

Change deb/rpm specification to describe the architecture dependent packages as replacement of older noarch Logstash packages.

## Why is it important/What is the impact to the user?

With Logstash `7.10` the deb/rpm packages started to be CPU architecture dependent, because of the bundling of the JDK.
If  Logstash packages older than `7.10` are already installed on the host they hold on upgrading to version greater than `7.10`.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[[ ] I have made corresponding changes to the documentation~~[
- ~~[[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~[
- ~~[[ ] I have added tests that prove my fix is effective or that my feature works~~[

## Author's Checklist

- [x] test on Centos and Ubuntu

## How to test this PR locally

#### Centos
- create a virtual machine with a centos distribution
- check no Logstash installed
- download a `7.9.0` Logstash package 
```
wget https://artifacts.elastic.co/downloads/logstash/logstash-7.9.0.rpm
```
- install it
```
sudo yum install logstash-7.9.1.rpm
```
- build the new rpm from this PR and install it with
```
sudo rpm -Uvh ./build/logstash-8.4.0-SNAPSHOT-x86_64.rpm
```
- verify the new replaces the old
```
yum list logstash
```

#### Ubuntu
- create a virtual machine with a centos distribution
- check no Logstash installed
- download a `7.9.0` Logstash package 
```
wget https://artifacts.elastic.co/downloads/logstash/logstash-7.9.0.deb
```
- install it
```
sudo dpkg -i logstash-7.9.1.deb
```
- build the new rpm from this PR and install it with
```
sudo dpkg -i ./build/logstash-8.4.0-SNAPSHOT-x86_64.deb
```
- verify the new replaces the old
```
dpkg -l | grep logstash
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Fixes #14074

## Use cases

As a user with an installed `noarch` package I want to be able to upgrade to the latest without forcing the install. The updated version must replace the older.

