### PR TITLE
Fix windows scripts to also pull settings from JvmOptionsParser

### DIFF
--- a/bin/logstash-keystore.bat
+++ b/bin/logstash-keystore.bat
@@ -9,7 +9,7 @@ if errorlevel 1 (
 	exit /B %ERRORLEVEL%
 )
 
-%JRUBY_BIN% "%LS_HOME%\lib\secretstore\cli.rb" %*
+%JRUBY_BIN% %JAVA_OPTS% "%LS_HOME%\lib\secretstore\cli.rb" %*
 if errorlevel 1 (
   exit /B 1
 )

--- a/bin/logstash-plugin.bat
+++ b/bin/logstash-plugin.bat
@@ -9,7 +9,7 @@ if errorlevel 1 (
 	exit /B %ERRORLEVEL%
 )
 
-%JRUBY_BIN% "%LS_HOME%\lib\pluginmanager\main.rb" %*
+%JRUBY_BIN% %JAVA_OPTS% "%LS_HOME%\lib\pluginmanager\main.rb" %*
 if errorlevel 1 (
   exit /B 1
 )

--- a/bin/logstash.bat
+++ b/bin/logstash.bat
@@ -2,6 +2,10 @@
 setlocal enabledelayedexpansion
 set params='%*'
 
+
+if "%1" == "-V" goto version
+if "%1" == "--version" goto version
+
 call "%~dp0setup.bat" || exit /b 1
 if errorlevel 1 (
 	if not defined nopauseonerror (
@@ -9,47 +13,6 @@ if errorlevel 1 (
 	)
 	exit /B %ERRORLEVEL%
 )
-
-if "%1" == "-V" goto version
-if "%1" == "--version" goto version
-
-rem iterate over the command line args and look for the argument
-rem after --path.settings to see if the jvm.options file is in
-rem that path and set LS_JVM_OPTS accordingly
-:loop
-for /F "usebackq tokens=1-2* delims= " %%A in (!params!) do (
-    set current=%%A
-    set next=%%B
-    set params='%%B %%C'
-
-    if "!current!" == "--path.settings" (
-    	if exist !next!\jvm.options (
-    	  set "LS_JVM_OPTS=!next!\jvm.options"
-    	)
-    )
-
-    if not "x!params!" == "x" (
-		goto loop
-	)
-)
-
-rem setup CLASSPATH for Java process
-set "JRUBY_HOME=%LS_HOME%\vendor\jruby"
-
-set "CLASSPATH=%JRUBY_HOME%\lib\jruby.jar"
-for %%i in ("%LS_HOME%\logstash-core\lib\jars\*.jar") do (
-	call :concat "%%i"
-)
-
-@setlocal
-for /F "usebackq delims=" %%a in (`CALL "%JAVACMD%" -cp "!CLASSPATH!" "org.logstash.launchers.JvmOptionsParser" "!LS_HOME!" "!LS_JVM_OPTS!" ^|^| echo jvm_options_parser_failed`) do set LS_JAVA_OPTS=%%a
-@endlocal & set "MAYBE_JVM_OPTIONS_PARSER_FAILED=%LS_JAVA_OPTS%" & set LS_JAVA_OPTS=%LS_JAVA_OPTS%
-
-if "%MAYBE_JVM_OPTIONS_PARSER_FAILED%" == "jvm_options_parser_failed" (
-  echo "error: jvm options parser failed; exiting"
-  exit /b 1
-)
-set JAVA_OPTS=%LS_JAVA_OPTS%
 
 "%JAVACMD%" %JAVA_OPTS% -cp "%CLASSPATH%" org.logstash.Logstash %*
 
@@ -77,14 +40,6 @@ if exist !LOGSTASH_VERSION_FILE1! (
 )
 echo logstash !LOGSTASH_VERSION!
 goto :end
-
-:concat
-IF not defined CLASSPATH (
-  set CLASSPATH=%~1
-) ELSE (
-  set CLASSPATH=%CLASSPATH%;%~1
-)
-goto :eof
 
 :end
 endlocal

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -62,5 +62,49 @@ if not exist %JRUBY_BIN% (
   echo "could not find jruby in %LS_HOME%\vendor\jruby" 1>&2
   exit /b 1
 )
+rem iterate over the command line args and look for the argument
+rem after --path.settings to see if the jvm.options file is in
+rem that path and set LS_JVM_OPTS accordingly
+:loop
+for /F "usebackq tokens=1-2* delims= " %%A in (!params!) do (
+    set current=%%A
+    set next=%%B
+    set params='%%B %%C'
+
+    if "!current!" == "--path.settings" (
+    	if exist !next!\jvm.options (
+    	  set "LS_JVM_OPTS=!next!\jvm.options"
+    	)
+    )
+
+    if not "x!params!" == "x" (
+		goto loop
+	)
+)
+
+rem setup CLASSPATH for Java process
+set "JRUBY_HOME=%LS_HOME%\vendor\jruby"
+
+set "CLASSPATH=%JRUBY_HOME%\lib\jruby.jar"
+for %%i in ("%LS_HOME%\logstash-core\lib\jars\*.jar") do (
+	call :concat "%%i"
+)
+
+@setlocal
+for /F "usebackq delims=" %%a in (`CALL "%JAVACMD%" -cp "!CLASSPATH!" "org.logstash.launchers.JvmOptionsParser" "!LS_HOME!" "!LS_JVM_OPTS!" ^|^| echo jvm_options_parser_failed`) do set LS_JAVA_OPTS=%%a
+@endlocal & set "MAYBE_JVM_OPTIONS_PARSER_FAILED=%LS_JAVA_OPTS%" & set LS_JAVA_OPTS=%LS_JAVA_OPTS%
+
+if "%MAYBE_JVM_OPTIONS_PARSER_FAILED%" == "jvm_options_parser_failed" (
+  echo "error: jvm options parser failed; exiting"
+  exit /b 1
+)
+set JAVA_OPTS=%LS_JAVA_OPTS%
+
+:concat
+IF not defined CLASSPATH (
+  set CLASSPATH=%~1
+) ELSE (
+  set CLASSPATH=%CLASSPATH%;%~1
+)
 
 set RUBYLIB=%LS_HOME%\lib


### PR DESCRIPTION
Prior to this commit, the windows version of the keystore and plugin scripts
diverged from the bash version of these scripts, as they did not pick up Jvm Options
from the JvmOptionsParser, leading to certain mandatory settings not being picked up,
breaking compatibility with Windows on certain versions of the JDK. This PR ensures
that these scripts also use the JvmOptionsParser.

This does not resolve the issue described in #14176, which will be looked at in a future
PR

Relates: #14354

