### PR TITLE
Fix `test_port_ruby` on build nodes with outdated system java

### DIFF
--- a/qa/integration/services/helpers.sh
+++ b/qa/integration/services/helpers.sh
@@ -35,20 +35,16 @@ test_port_nc() {
 }
 
 test_port_ruby() {
-  if command -v ruby 2>/dev/null; then
-    ruby -rsocket -e "TCPSocket.new('localhost', $1) rescue exit(1)"
-  else
-    if [[ -z $LS_RUBY_HOME ]]; then
-      if [[ -n $LS_HOME ]]; then
-        LS_RUBY_HOME=$LS_HOME
-      else
-        LS_RUBY_HOME=$current_dir/../../..
-      fi
-      echo "Setting logstash ruby home to $LS_RUBY_HOME"
+  if [[ -z $LS_RUBY_HOME ]]; then
+    if [[ -n $LS_HOME ]]; then
+      LS_RUBY_HOME=$LS_HOME
+    else
+      LS_RUBY_HOME=$current_dir/../../..
     fi
-    export LS_GEM_HOME="$GEM_HOME"
-    $LS_RUBY_HOME/bin/ruby -rsocket -e "TCPSocket.new('localhost', $1) rescue exit(1)"
+    echo "Setting logstash ruby home to $LS_RUBY_HOME"
   fi
+  export LS_GEM_HOME="$GEM_HOME"
+  $LS_RUBY_HOME/bin/ruby -rsocket -e "TCPSocket.new('localhost', $1) rescue exit(1)"
 }
 
 clean_install_dir() {


### PR DESCRIPTION
When running certain integration tests, a test against a given port is
performed to ensure that certain dependent services are up. Currently,
these are tests are done either via `nc` or `ruby` if no `nc` is provisioned
on the build nodes. The current `ruby` implenentation attempts to use a system
ruby before using the ruby script shipped with Logstash. This commit removes the
use of the system jruby - certain build boxes are still using java8 as their system
java, which causes builds to fail, as java 11 is expected