### PR TITLE
Reduce the amount of memory required by gradle for integration tests

### DIFF
--- a/ci/integration_tests.sh
+++ b/ci/integration_tests.sh
@@ -5,7 +5,7 @@
 # uses at least 1g of memory, If we don't do this we can get OOM issues when
 # installing gems. See https://github.com/elastic/logstash/issues/5179
 export JRUBY_OPTS="-J-Xmx1g"
-export GRADLE_OPTS="-Xmx4g -Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info -Dfile.encoding=UTF-8"
+export GRADLE_OPTS="-Xmx2g -Dorg.gradle.jvmargs=-Xmx2g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info -Dfile.encoding=UTF-8"
 
 export SPEC_OPTS="--order rand --format documentation"
 export CI=true


### PR DESCRIPTION
A new class of build node has recently been added which appears to have fewer
memory resources than previous nodes, causing integration test failures. The
gradle task for integration tests doesn't appear to require 4gb, so this commit
reduces the -Xmx setting to 4gb

