### PR TITLE
Clean up java plugin threadsafe/concurrency check

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java
@@ -107,11 +107,11 @@ public abstract class AbstractFilterDelegatorExt extends RubyObject {
     protected abstract IRubyObject reloadable(final ThreadContext context);
 
     @JRubyMethod(name = "threadsafe?")
-    public IRubyObject concurrency(final ThreadContext context) {
-        return getConcurrency(context);
+    public IRubyObject threadsafe(final ThreadContext context) {
+        return isThreadsafe(context);
     }
 
-    protected abstract IRubyObject getConcurrency(final ThreadContext context);
+    protected abstract IRubyObject isThreadsafe(final ThreadContext context);
 
     @JRubyMethod(name = "config_name")
     public IRubyObject configName(final ThreadContext context) {

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
@@ -109,7 +109,7 @@ public final class FilterDelegatorExt extends AbstractFilterDelegatorExt {
     }
 
     @Override
-    protected IRubyObject getConcurrency(final ThreadContext context) {
+    protected IRubyObject isThreadsafe(final ThreadContext context) {
         return filter.callMethod(context, "threadsafe?");
     }
 

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaFilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaFilterDelegatorExt.java
@@ -48,8 +48,6 @@ public class JavaFilterDelegatorExt extends AbstractFilterDelegatorExt {
 
     private static final long serialVersionUID = 1L;
 
-    private static final RubySymbol CONCURRENCY = RubyUtil.RUBY.newSymbol("java");
-
     private RubyString configName;
 
     private transient Filter filter;
@@ -128,8 +126,8 @@ public class JavaFilterDelegatorExt extends AbstractFilterDelegatorExt {
     }
 
     @Override
-    protected IRubyObject getConcurrency(final ThreadContext context) {
-        return CONCURRENCY;
+    protected IRubyObject isThreadsafe(final ThreadContext context) {
+        return context.tru;
     }
 
     @Override


### PR DESCRIPTION
Prior to this commit, the java filter delegator would return "java" to the
`#threadsafe?` call when determining whether a filter is considered thread safe.
This is correct for the _outputs_, where this prefix is used to construct the
appropriate delegator object, but not for filters, where a simple true/false is
required. This commit replaces the `getCurrency` call with a `isThreadsafe` call
to make it clearer that a boolean call is required.
