### PR TITLE
Add config.field_reference.escape_style to env2yaml

### DIFF
--- a/docker/data/logstash/env2yaml/env2yaml.go
+++ b/docker/data/logstash/env2yaml/env2yaml.go
@@ -71,6 +71,7 @@ func normalizeSetting(setting string) (string, error) {
 		"config.reload.interval",
 		"config.debug",
 		"config.support_escapes",
+		"config.field_reference.escape_style",
 		"queue.type",
 		"path.queue",
 		"queue.page_capacity",


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Add support for CONFIG_FIELD_REFERENCE_ESCAPE_STYLE environment variable within containers


## What does this PR do?
Adds support for CONFIG_FIELD_REFERENCE_ESCAPE_STYLE environment variable within containers


## Why is it important/What is the impact to the user?
It allows for the config.field_reference.escape_style setting to be used within containers without having to modify logstash.yml

## Checklist


- [/] My code follows the style guidelines of this project
- [/] I have commented my code, particularly in hard-to-understand areas
- [/] I have made corresponding changes to the documentation
- [/] I have made corresponding change to the default configuration files (and/or docker env variables)
- [/] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

NA

## How to test this PR locally

## Related issues

- 

## Use cases


## Screenshots

## Logs

