### PR TITLE
Fix mismatched Java versions in integration tests

### DIFF
--- a/qa/integration/services/helpers.sh
+++ b/qa/integration/services/helpers.sh
@@ -22,29 +22,8 @@ wait_for_port() {
     test_port "$1"
 }
 
-test_port() {
-    if command -v nc 2>/dev/null; then
-      test_port_nc "$1"
-    else
-      test_port_ruby "$1"
-    fi
-}
-
-test_port_nc() {
-  nc -z localhost $1
-}
-
-test_port_ruby() {
-  if [[ -z $LS_RUBY_HOME ]]; then
-    if [[ -n $LS_HOME ]]; then
-      LS_RUBY_HOME=$LS_HOME
-    else
-      LS_RUBY_HOME=$current_dir/../../..
-    fi
-    echo "Setting logstash ruby home to $LS_RUBY_HOME"
-  fi
-  export LS_GEM_HOME="$GEM_HOME"
-  $LS_RUBY_HOME/bin/ruby -rsocket -e "TCPSocket.new('localhost', $1) rescue exit(1)"
+test_port(){
+  /bin/bash -c "(echo >/dev/tcp/localhost/$1) >/dev/null 2>&1"
 }
 
 clean_install_dir() {

--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -235,7 +235,7 @@ class LogstashService < Service
   end
 
   def get_version
-    `#{Shellwords.escape(@logstash_bin)} --version`.split("\n").last
+    `LS_JAVA_HOME=#{java.lang.System.getProperty('java.home')} #{Shellwords.escape(@logstash_bin)} --version`.split("\n").last
   end
 
   def get_version_yml


### PR DESCRIPTION
This PR fixes up some integration test issues where system java was being picked up, rather than the expected version of Java.

* Add `LS_JAVA_HOME` to the request to retrieve the version of logstash
* Use bash `/dev/tcp` to test ports rather than attempting to use `nc` and `ruby`, which may not be installed on CI nodes