### PR TITLE
Doc: Adding a plugin

### DIFF
--- a/docs/static/contributing-java-plugin.asciidoc
+++ b/docs/static/contributing-java-plugin.asciidoc
@@ -1,5 +1,5 @@
-[[contributing-java-plugin]]
-== Contributing a Java Plugin
+[[develop-java-plugin]]
+== Develop a java plugin
 
 Now you can write your own Java plugin for use with {ls}.
 We have provided instructions and GitHub examples to give

--- a/docs/static/contributing-to-logstash.asciidoc
+++ b/docs/static/contributing-to-logstash.asciidoc
@@ -1,7 +1,7 @@
-[[contributing-to-logstash]]
-== Contributing to Logstash
+[[develop-plugin]]
+== Develop a plugin
 
-You can add your own input, codec, filter, or output plugins to Logstash. 
+You can develop and add your own input, codec, filter, or output plugins to Logstash. 
 
 include::contrib-acceptance.asciidoc[]
 

--- a/docs/static/maintainer-guide.asciidoc
+++ b/docs/static/maintainer-guide.asciidoc
@@ -8,8 +8,8 @@ through Pull Requests and issues are strongly encouraged.
 [float]
 === Contribution Guidelines
 
-For general guidance around contributing to Logstash Plugins, see the
-https://www.elastic.co/guide/en/logstash/current/contributing-to-logstash.html[_Contributing to Logstash_] section.
+For general guidance around contributing to Logstash plugins, see the
+<<,Contributing to Logstash>>.
 
 [float]
 === Document Goals


### PR DESCRIPTION
Current documentation focuses on contributing plugins.  This PR updates the documentation to emphasize the users can create a plugin for their own use without having to contribute it back to the project. 