### PR TITLE
Make version bump github action work with future JRuby versions

### DIFF
--- a/.github/workflows/version_bumps.yml
+++ b/.github/workflows/version_bumps.yml
@@ -5,7 +5,7 @@ on:
       branch:
         description: 'Release Branch'     
         required: true
-        default: '8.3'
+        default: '8.4'
         type: string
       bump:
         description: 'Bump type'     
@@ -45,7 +45,7 @@ jobs:
       - run: git config --global user.name "logstashmachine"
       - run: ./gradlew clean installDefaultGems
       - run: ./vendor/jruby/bin/jruby -S bundle update --all --${{ github.event.inputs.bump }} --strict
-      - run: mv Gemfile.lock Gemfile.jruby-2.5.lock.release
+      - run: mv Gemfile.lock Gemfile.jruby-*.lock.release
       - run: echo "T=$(date +%s)" >> $GITHUB_ENV
       - run: echo "BRANCH=update_lock_${T}" >> $GITHUB_ENV
       - run: |


### PR DESCRIPTION
Release branches are expected to have a lock file whose name is `Gemfile.jruby-X.Y.lock.release`, where `X.Y` is the Ruby language version.
This Ruby language version differs from JRuby version: for example, JRuby 9.2 is compatible with Ruby 2.5, while JRuby 9.3 is compatible with Ruby 2.6.
This commit makes the version bump agnostic to the version. Since there will be a lock file already present when the action is run, we only need to replace it, so there's no need to know the exact file name.