### PR TITLE
pin bundler 2.3.18 to avoid bug in .19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -288,7 +288,7 @@ def assemblyDeps = [downloadAndInstallJRuby, assemble] + subprojects.collect {
   it.tasks.findByName("assemble")
 }
 
-def bundlerVersion = "~> 2"
+def bundlerVersion = "2.3.18"
 
 tasks.register("installBundler") {
     dependsOn assemblyDeps


### PR DESCRIPTION
When using Bundler 2.3.19, doing a "bin/logstash-plugin uninstall <plugin>"
will crash, failing to find gems in the :build group.

Until we know more about why, pin bundler to 2.3.19