### PR TITLE
Doc: Fileset must be enabled in module

### DIFF
--- a/docs/static/fb-ls-kafka-example.asciidoc
+++ b/docs/static/fb-ls-kafka-example.asciidoc
@@ -45,6 +45,9 @@ filebeat modules enable system
 You can further configure the module by editing the config file under the
 {filebeat} `modules.d` directory. For example, if the log files are not in the
 location expected by the module, you can set the `var.paths` option.
++
+NOTE: You must enable at least one fileset in the module.
+**Filesets are disabled by default.** 
 
 . Run the `setup` command with the `--pipelines` and `--modules` options
 specified to load ingest pipelines for the modules you've enabled. This step


### PR DESCRIPTION
Starting with 8.0.0, Filebeat modules no longer have a default fileset (system), and users must explicitly enable the filesets they want to use. 

Backport targets: 8.4, 8.3, 8.2, 8.1, 8.0

Related: https://github.com/elastic/observability-docs/pull/2053