### PR TITLE
8.4: DLQ dependencies

### DIFF
--- a/Gemfile.jruby-2.6.lock.release
+++ b/Gemfile.jruby-2.6.lock.release
@@ -405,6 +405,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       stud (>= 0.0.22)
     logstash-input-dead_letter_queue (2.0.0)
+      logstash-core (>= 8.4.0)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-input-elasticsearch (4.14.0)


### PR DESCRIPTION
## Release notes

[rn:skip]


## What does this PR do?

Pulls in the DLQ Input v2.0.0's transitive dependency on logstash-core 8.4.0 to prevent a build failure:


> `ERROR: Installation Aborted, message: Downloading logstash-input-dead_letter_queue-2.0.0 revealed dependencies not in the API or the lockfile (logstash-core (>= 8.4.0)).`

 - The DLQ Input added a _new_ [dependency on LS-core](https://github.com/logstash-plugins/logstash-input-dead_letter_queue/commit/5d0d230b5085d1ea38bca4d88564b5721ce6362d#diff-839465c3214d299c74529c837847c27af7e07fd2b4186aaf463192ee6f50e1e5R24) for its v2.0.0 release
 - We updated our lockfile to reference DLQ Input v2.0.0, but did not include the new transitive dependency declaration in https://github.com/elastic/logstash/pull/14401

## Why is it important/What is the impact to the user?

This hopes to fix our build failure for the in-flight 8.4.0 branch

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~

