### PR TITLE
Pin jar-dependencies 0.4.1

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -29,4 +29,4 @@ gem "logstash-devutils", "~> 2", :group => :development
 gem "rack-test", :require => "rack/test", :group => :development
 gem "rspec", "~> 3.5", :group => :development
 gem "webmock", "~> 3", :group => :development
-gem "jar-dependencies", "= 0.4.1" # until we find a way to ship with JRuby
+gem "jar-dependencies", "= 0.4.1" # Gem::LoadError with jar-dependencies 0.4.2

--- a/Gemfile.template
+++ b/Gemfile.template
@@ -29,3 +29,4 @@ gem "logstash-devutils", "~> 2", :group => :development
 gem "rack-test", :require => "rack/test", :group => :development
 gem "rspec", "~> 3.5", :group => :development
 gem "webmock", "~> 3", :group => :development
+gem "jar-dependencies", "= 0.4.1" # until we find a way to ship with JRuby


### PR DESCRIPTION
CI [failed](https://internal-ci.elastic.co/blue/organizations/jenkins/elastic%2Bunified-release%2Bmaster%2Bsnapshot-build-logstash-arm-master/detail/elastic%2Bunified-release%2Bmaster%2Bsnapshot-build-logstash-arm-master/1124/pipeline/) with `bin/dependencies-report`
```

Using LS_JAVA_HOME defined java: /var/lib/jenkins/.java/adoptopenjdk11.

warning: ignoring JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8 -Dsun.jnu.encoding=UTF8

OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.

Gem::LoadError: You have already activated jar-dependencies 0.4.1, but your Gemfile requires jar-dependencies 0.4.2. Since jar-dependencies is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports jar-dependencies as a default gem.

  check_for_activated_spec! at /var/lib/jenkins/workspace/elastic+unified-release+master+snapshot-build-logstash-arm-master/cd/release/release-manager/project-configs/master/build/projects/logstash/vendor/bundle/jruby/2.6.0/gems/bundler-2.3.18/lib/bundler/runtime.rb:308

                      setup at /var/lib/jenkins/workspace/elastic+unified-release+master+snapshot-build-logstash-arm-master/cd/release/release-manager/project-configs/master/build/projects/logstash/vendor/bundle/jruby/2.6.0/gems/bundler-2.3.18/lib/bundler/runtime.rb:25

                       each at org/jruby/RubyArray.java:1865

                       each at /var/lib/jenkins/workspace/elastic+unified-release+master+snapshot-build-logstash-arm-master/cd/release/release-manager/project-configs/master/build/projects/logstash/vendor/bundle/jruby/2.6.0/gems/bundler-2.3.18/lib/bundler/spec_set.rb:140

                        map at org/jruby/RubyEnumerable.java:799

                      setup at /var/lib/jenkins/workspace/elastic+unified-release+master+snapshot-build-logstash-arm-master/cd/release/release-manager/project-configs/master/build/projects/logstash/vendor/bundle/jruby/2.6.0/gems/bundler-2.3.18/lib/bundler/runtime.rb:24

                      setup at /var/lib/jenkins/workspace/elastic+unified-release+master+snapshot-build-logstash-arm-master/cd/release/release-manager/project-configs/master/build/projects/logstash/vendor/bundle/jruby/2.6.0/gems/bundler-2.3.18/lib/bundler.rb:162

                     setup! at /var/lib/jenkins/workspace/elastic+unified-release+master+snapshot-build-logstash-arm-master/cd/release/release-manager/project-configs/master/build/projects/logstash/lib/bootstrap/bundler.rb:83

                     <main> at logstash-core/lib/logstash/dependency_report_runner.rb:22
```

pin jar-dependencies to 0.4.1 until  we find a way to properly play with the version that ships with JRuby