### PR TITLE
Ensuring COPY instruction is used instead of ADD in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,29 +30,29 @@ WORKDIR /opt/logstash
 RUN for iter in `seq 1 10`; do ./gradlew wrapper --warning-mode all && exit_code=0 && break || exit_code=$? && echo "gradlew error: retry $iter in 10s" && sleep 10; done; exit $exit_code
 WORKDIR /home/logstash
 
-ADD versions.yml /opt/logstash/versions.yml
-ADD LICENSE.txt /opt/logstash/LICENSE.txt
-ADD NOTICE.TXT /opt/logstash/NOTICE.TXT
-ADD licenses /opt/logstash/licenses
-ADD CONTRIBUTORS /opt/logstash/CONTRIBUTORS
-ADD Gemfile.template Gemfile.jruby-2.6.lock.* /opt/logstash/
-ADD Rakefile /opt/logstash/Rakefile
-ADD build.gradle /opt/logstash/build.gradle
-ADD rubyUtils.gradle /opt/logstash/rubyUtils.gradle
-ADD rakelib /opt/logstash/rakelib
-ADD config /opt/logstash/config
-ADD spec /opt/logstash/spec
-ADD qa /opt/logstash/qa
-ADD lib /opt/logstash/lib
-ADD pkg /opt/logstash/pkg
-ADD buildSrc /opt/logstash/buildSrc
-ADD tools /opt/logstash/tools
-ADD logstash-core /opt/logstash/logstash-core
-ADD logstash-core-plugin-api /opt/logstash/logstash-core-plugin-api
-ADD bin /opt/logstash/bin
-ADD modules /opt/logstash/modules
-ADD x-pack /opt/logstash/x-pack
-ADD ci /opt/logstash/ci
+COPY versions.yml /opt/logstash/versions.yml
+COPY LICENSE.txt /opt/logstash/LICENSE.txt
+COPY NOTICE.TXT /opt/logstash/NOTICE.TXT
+COPY licenses /opt/logstash/licenses
+COPY CONTRIBUTORS /opt/logstash/CONTRIBUTORS
+COPY Gemfile.template Gemfile.jruby-2.6.lock.* /opt/logstash/
+COPY Rakefile /opt/logstash/Rakefile
+COPY build.gradle /opt/logstash/build.gradle
+COPY rubyUtils.gradle /opt/logstash/rubyUtils.gradle
+COPY rakelib /opt/logstash/rakelib
+COPY config /opt/logstash/config
+COPY spec /opt/logstash/spec
+COPY qa /opt/logstash/qa
+COPY lib /opt/logstash/lib
+COPY pkg /opt/logstash/pkg
+COPY buildSrc /opt/logstash/buildSrc
+COPY tools /opt/logstash/tools
+COPY logstash-core /opt/logstash/logstash-core
+COPY logstash-core-plugin-api /opt/logstash/logstash-core-plugin-api
+COPY bin /opt/logstash/bin
+COPY modules /opt/logstash/modules
+COPY x-pack /opt/logstash/x-pack
+COPY ci /opt/logstash/ci
 
 USER root
 RUN rm -rf build && \

--- a/docker/templates/Dockerfile.j2
+++ b/docker/templates/Dockerfile.j2
@@ -136,20 +136,20 @@ ENV PATH=/usr/share/logstash/bin:$PATH
 # Provide a minimal configuration, so that simple invocations will provide
 # a good experience.
 {% if image_flavor != 'ironbank' -%}
-ADD config/pipelines.yml config/pipelines.yml
+COPY config/pipelines.yml config/pipelines.yml
 {% if image_flavor == 'oss' -%}
-ADD config/logstash-oss.yml config/logstash.yml
+COPY config/logstash-oss.yml config/logstash.yml
 {% else -%}
-ADD config/logstash-full.yml config/logstash.yml
+COPY config/logstash-full.yml config/logstash.yml
 {% endif -%}
-ADD config/log4j2.properties config/
-ADD pipeline/default.conf pipeline/logstash.conf
+COPY config/log4j2.properties config/
+COPY pipeline/default.conf pipeline/logstash.conf
 RUN chown --recursive logstash:root config/ pipeline/
 # Ensure Logstash gets the correct locale by default.
 ENV LANG={{ locale }} LC_ALL={{ locale }}
-ADD env2yaml/env2yaml /usr/local/bin/
+COPY env2yaml/env2yaml /usr/local/bin/
 # Place the startup wrapper script.
-ADD bin/docker-entrypoint /usr/local/bin/
+COPY bin/docker-entrypoint /usr/local/bin/
 {% else -%}
 COPY scripts/config/pipelines.yml config/pipelines.yml
 COPY scripts/config/logstash.yml config/logstash.yml

--- a/docs/static/docker.asciidoc
+++ b/docs/static/docker.asciidoc
@@ -127,8 +127,8 @@ like this one:
 --------------------------------------------
 FROM {docker-image}
 RUN rm -f /usr/share/logstash/pipeline/logstash.conf
-ADD pipeline/ /usr/share/logstash/pipeline/
-ADD config/ /usr/share/logstash/config/
+COPY pipeline/ /usr/share/logstash/pipeline/
+COPY config/ /usr/share/logstash/config/
 --------------------------------------------
 
 Be sure to replace or delete `logstash.conf` in your custom image, so


### PR DESCRIPTION
## Release notes
[rn:skip]


## What does this PR do?
Ensuring COPY instruction is used instead of ADD in all Dockerfiles (and related docs)

## Why is it important/What is the impact to the user?
TL;DR - As a security best practice, COPY instruction should be used instead of ADD whenever possible

The COPY instruction simply copies files from the local host machine to the container file system.
The ADD instruction could potentially retrieve files from remote URLs and perform operations such as unpacking them. The ADD instruction, therefore, introduces security risks. For example, malicious files may be directly accessed from URLs without scanning, or there may be vulnerabilities associated with decompressing them.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ]  ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
