### PR TITLE
fix(env2yaml): Add monitoring.cluster_uuid

### DIFF
--- a/docker/data/logstash/env2yaml/env2yaml.go
+++ b/docker/data/logstash/env2yaml/env2yaml.go
@@ -106,6 +106,7 @@ func normalizeSetting(setting string) (string, error) {
 		"api.auth.basic.password_policy.include.digit",
 		"api.auth.basic.password_policy.include.symbol",
 		"allow_superuser",
+		"monitoring.cluster_uuid",
 		"xpack.monitoring.enabled",
 		"xpack.monitoring.collection.interval",
 		"xpack.monitoring.elasticsearch.hosts",


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
Fixed environment based configuration for monitoring.cluster_uuid

## What does this PR do?
This commit adds `monitoring.cluster_uuid` to the env2yaml configuration whitelist and enables the user to set this configuration option via environment variable. It fixes #12211.

## Why is it important/What is the impact to the user?
This PR makes the environment based configuration more usable.

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist
N/A

## How to test this PR locally
Build env2yaml and validate it by providing environment variables.

## Related issues

Closes #12211


## Use cases
N/A

## Screenshots
N/A

## Logs
N/A