### PR TITLE
[Doc] add off-heap memory session

### DIFF
--- a/docs/static/config-details.asciidoc
+++ b/docs/static/config-details.asciidoc
@@ -80,9 +80,11 @@ info, see <<profiling-the-heap>>.
 [[off-heap-size]]
 ==== Setting the off-heap size
 
-Besides heap, others like OS, persistent queue mmap pages and direct memory need memory in addition of heap memory.
-By default, a JVM's off-heap direct memory limit is the same as the heap size, see <<plugins-inputs-beats#plugins-inputs-beats-memory, beats input memory usage>>.
-Consider setting `-XX:MaxDirectMemorySize` to half of the heap size.
+The operating system, persistent queue mmap pages, direct memory, and other processes require memory in addition to memory allocated to heap size.
+Keep the overall memory requirements in mind when you allocate memory.
+
+By default, a JVM's off-heap direct memory limit is the same as the heap size, check out <<plugins-inputs-beats-memory,beats input memory usage>>.
+Consider setting `-XX:MaxDirectMemorySize` to half of the heap size.```
 
 
 [[stacks-size]]

--- a/docs/static/config-details.asciidoc
+++ b/docs/static/config-details.asciidoc
@@ -83,8 +83,8 @@ info, see <<profiling-the-heap>>.
 The operating system, persistent queue mmap pages, direct memory, and other processes require memory in addition to memory allocated to heap size.
 Keep the overall memory requirements in mind when you allocate memory.
 
-By default, a JVM's off-heap direct memory limit is the same as the heap size, check out <<plugins-inputs-beats-memory,beats input memory usage>>.
-Consider setting `-XX:MaxDirectMemorySize` to half of the heap size.```
+By default, a JVM's off-heap direct memory limit is the same as the heap size. Check out <<plugins-inputs-beats-memory,beats input memory usage>>.
+Consider setting `-XX:MaxDirectMemorySize` to half of the heap size.
 
 
 [[stacks-size]]

--- a/docs/static/config-details.asciidoc
+++ b/docs/static/config-details.asciidoc
@@ -76,6 +76,15 @@ process.
 info, see <<profiling-the-heap>>.
 // end::heap-size-tips[]
 
+
+[[off-heap-size]]
+==== Setting the off-heap size
+
+Besides heap, others like OS, persistent queue mmap pages and direct memory need memory in addition of heap memory.
+By default, a JVM's off-heap direct memory limit is the same as the heap size, see <<plugins-inputs-beats#plugins-inputs-beats-memory, beats input memory usage>>.
+Consider setting `-XX:MaxDirectMemorySize` to half of the heap size.
+
+
 [[stacks-size]]
 ==== Setting the JVM stack size
 


### PR DESCRIPTION
Relates: https://github.com/elastic/logstash/issues/12622

Add a link to beats-input doc (https://github.com/logstash-plugins/logstash-input-beats/pull/454)
Suggest to set `-XX:MaxDirectMemorySize` to half of the heap size