### PR TITLE
Update tests to allow integration tests to use the bundled JDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -342,7 +342,7 @@ tasks.register("assembleTarDistribution") {
   inputs.files fileTree("${projectDir}/x-pack")
   outputs.files file("${buildDir}/logstash-${project.version}-SNAPSHOT.tar.gz")
   doLast {
-      rake(projectDir, buildDir, 'artifact:no_bundle_jdk_tar')
+      rake(projectDir, buildDir, 'artifact:bundle_jdk_tar')
   }
 }
 

--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -146,11 +146,15 @@ class LogstashService < Service
       @process.io.stdout = @process.io.stderr = out
       @process.duplex = true # enable stdin to be written
       @env_variables.map { |k, v|  @process.environment[k] = v} unless @env_variables.nil?
-      java_home = java.lang.System.getProperty('java.home')
-      @process.environment['LS_JAVA_HOME'] = java_home
+      if ENV['RUNTIME_JAVA_HOME']
+        logstash_java = @process.environment['LS_JAVA_HOME'] = ENV['RUNTIME_JAVA_HOME']
+      else
+        ENV.delete('LS_JAVA_HOME') if ENV['LS_JAVA_HOME']
+        logstash_java = 'bundled java'
+      end
       @process.io.inherit!
       @process.start
-      puts "Logstash started with PID #{@process.pid}, LS_JAVA_HOME: #{java_home}" if @process.alive?
+      puts "Logstash started with PID #{@process.pid}, using java: #{logstash_java}" if @process.alive?
     end
   end
 

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -161,10 +161,23 @@ namespace "artifact" do
     system("./gradlew deleteLocalJdk -Pjdk_bundle_os=#{os_name}")
   end
 
+  # Create an archive pack using settings appropriate for the running machine
+  def create_local_archive_pack(bundle_jdk)
+    @bundles_jdk = bundle_jdk
+    system("./gradlew copyJdk") if bundle_jdk
+    build_tar('ELASTIC-LICENSE')
+    system("./gradlew deleteLocalJdk") if bundle_jdk
+  end
+
+
   desc "Build a not JDK bundled tar.gz of default logstash plugins with all dependencies"
   task "no_bundle_jdk_tar" => ["prepare", "generate_build_metadata"] do
-    @bundles_jdk = false
-    build_tar('ELASTIC-LICENSE')
+    create_local_archive_pack(false)
+  end
+
+  desc "Build a JDK bundled tar.gz of default logstash plugins with all dependencies"
+  task "bundle_jdk_tar" => ["prepare", "generate_build_metadata"] do
+    create_local_archive_pack(true)
   end
 
   desc "Build all (jdk bundled and not) OSS tar.gz and zip of default logstash plugins with all dependencies"


### PR DESCRIPTION
* Adds tasks to add bundled JDK to tar file used to run integration tests
* Uses `RUNTIME_JAVA_HOME` environment variable to control whether bundled JDK or
  alternative is to be used
* Updates logstash service helper to respect value of `RUNTIME_JAVA_HOME`
* Requires updates to jenkins repo to set `RUNTIME_JAVA_HOME` correctly only for
  integration tests that expect to use a custom version of Java, such as the JDK
  matrix tests.
