### PR TITLE
[Doc] add PQ page capacity limit

### DIFF
--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -45,7 +45,7 @@ TIP: If you want to define values for a specific pipeline, use <<multiple-pipeli
 `path.queue`:: The directory path where the data files will be stored. By default, the files are stored in `path.data/queue`.
 `queue.page_capacity`:: The queue data consists of append-only files called "pages." This value sets the maximum size of a queue page in bytes. 
 The default size of 64mb is a good value for most users, and changing this value is unlikely to have performance benefits. 
-If you change the page capacity of an existing queue, the new size applies only to the new page.
+If you change the page capacity of an existing queue, the new size applies only to the new page. The maximum size is 2147483647 bytes.
 `queue.drain`:: Specify `true` if you want Logstash to wait until the persistent queue is drained before shutting down. The amount of time it takes to drain the queue depends on the number of events that have accumulated in the queue. Therefore, you should avoid using this setting unless the queue, even when full, is relatively small and can be drained quickly. 
 `queue.max_events`:: The maximum number of events not yet read by the pipeline worker. The default is 0 (unlimited).
 We use this setting for internal testing. 


### PR DESCRIPTION
Relates: #14388

The maximum PQ page capacity is Integer.MAX_VALUE which is 2147483647 bytes. User cannot set `queue.page_capacity: 2gb`
