### PR TITLE
remove sinatra constraint

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "concurrent-ruby", "~> 1", "< 1.1.10" # pinned until https://github.com/elastic/logstash/issues/13956
   gem.add_runtime_dependency "rack", '~> 2'
   gem.add_runtime_dependency "mustermann", '~> 1.0.3'
-  gem.add_runtime_dependency "sinatra", '~> 2.1.0' # pinned until GH-13777 is resolved
+  gem.add_runtime_dependency "sinatra", '~> 2'
   gem.add_runtime_dependency 'puma', '~> 5', '>= 5.6.2'
   gem.add_runtime_dependency "jruby-openssl", "~> 0.11"
 


### PR DESCRIPTION
Sinatra 2.2.1 fixes #13777 through https://github.com/sinatra/sinatra/pull/1750:

> Fix JRuby regression by using ruby2_keywords for delegation. #1750 by Patrik Ragnarsson
