### PR TITLE
Stop pinning mustermann in logstash-core.gemspec

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -54,7 +54,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "gems", "~> 1"  #(MIT license)
   gem.add_runtime_dependency "concurrent-ruby", "~> 1", "< 1.1.10" # pinned until https://github.com/elastic/logstash/issues/13956
   gem.add_runtime_dependency "rack", '~> 2'
-  gem.add_runtime_dependency "mustermann", '~> 1.0.3'
   gem.add_runtime_dependency "sinatra", '~> 2'
   gem.add_runtime_dependency 'puma', '~> 5', '>= 5.6.2'
   gem.add_runtime_dependency "jruby-openssl", "~> 0.11"


### PR DESCRIPTION
The pinning was added [a couple of years ago](https://github.com/elastic/logstash/pull/11549) but there's no reason I can find to keep the gem at 1.x.
This pinning was preventing us from using [sinatra 2.2.2](https://rubygems.org/gems/sinatra/versions/2.2.2) which depends on mustermann 2.x