### PR TITLE
Doc: Add placeholder for proposed K8s docs

### DIFF
--- a/docs/k8sdocs/index.asciidoc
+++ b/docs/k8sdocs/index.asciidoc
@@ -1,0 +1,7 @@
+[[logstash-kubernetes]]
+= Logstash and Kubernetes
+
+include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
+include::{docs-root}/shared/attributes.asciidoc[]
+
+include::overview.asciidoc[]

--- a/docs/k8sdocs/overview.asciidoc
+++ b/docs/k8sdocs/overview.asciidoc
@@ -1,0 +1,4 @@
+[[overview]]
+== Overview
+
+This guide provides information about using {ls} with Kubernetes.

--- a/docs/k8sdocs/overview.asciidoc
+++ b/docs/k8sdocs/overview.asciidoc
@@ -1,4 +1,6 @@
 [[overview]]
 == Overview
 
+preview::[]
+
 This guide provides information about using {ls} with Kubernetes.


### PR DESCRIPTION
As a first step for adding docs about using Logstash with K8s, this adds an empty placeholder docs page.

Rel: https://github.com/elastic/docs/pull/2495