### PR TITLE
winlogbeat-modules: add docs for interfacing winlogbeat with logstash

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -124,6 +124,9 @@ include::static/azure-module.asciidoc[]
 // Working with Filebeat Modules
 include::static/filebeat-modules.asciidoc[]
 
+// Working with Winlogbeat Modules
+include::static/winlogbeat-modules.asciidoc[]
+
 // Data resiliency
 include::static/resiliency.asciidoc[]
 

--- a/docs/static/winlogbeat-modules.asciidoc
+++ b/docs/static/winlogbeat-modules.asciidoc
@@ -1,0 +1,89 @@
+[[winlogbeat-modules]]
+
+== Working with {winlogbeat} Modules
+
+{winlogbeat} comes packaged with pre-built
+{winlogbeat-ref}/winlogbeat-modules.html[modules] that contain the configurations
+needed to collect, parse, enrich, and visualize data from various Windows logging
+providers. Each {winlogbeat} module consists of one or more filesets that contain
+ingest node pipelines, {es} templates, {winlogbeat} input configurations, and
+{kib} dashboards.
+
+You can use {winlogbeat} modules with {ls}, but you need to do some extra setup.
+The simplest approach is to <<use-ingest-pipelines,set up and use the ingest
+pipelines>> provided by {winlogbeat}.
+
+[[use-ingest-pipelines]]
+=== Use ingest pipelines for parsing
+
+When you use {winlogbeat} modules with {ls}, you can use the ingest pipelines
+provided by {winlogbeat} to parse the data. You need to load the pipelines
+into {es} and configure {ls} to use them.
+
+*To load the ingest pipelines:*
+
+On the system where {winlogbeat} is installed, run the `setup` command with the
+`--pipelines` option specified to load ingest pipelines for specific modules.
+For example, the following command loads ingest pipelines for the system and
+nginx modules:
+
+[source,shell]
+-----
+winlogbeat setup --pipelines --modules nginx,system
+-----
+
+A connection to {es} is required for this setup step because {winlogbeat} needs to
+load the ingest pipelines into {es}. If necessary, you can temporarily disable
+your configured output and enable the {es} output before running the command.
+
+*To configure {ls} to use the pipelines:*
+
+On the system where {ls} is installed, create a {ls} pipeline configuration
+that reads from a {ls} input, such as {beats} or Kafka, and sends events to an
+{es} output. Set the `pipeline` option in the {es} output to
+`%{[@metadata][pipeline]}` to use the ingest pipelines that you loaded
+previously.
+
+Here's an example configuration that reads data from the Beats input and uses
+{winlogbeat} ingest pipelines to parse data collected by modules:
+
+[source,yaml]
+-----
+input {
+  beats {
+    port => 5044
+  }
+}
+
+output {
+  if [@metadata][pipeline] {
+    elasticsearch {
+      hosts => "https://061ab24010a2482e9d64729fdb0fd93a.us-east-1.aws.found.io:9243"
+      manage_template => false
+      index => "%{[@metadata][beat]}-%{[@metadata][version]}" <1>
+      action => "create" <2>
+      pipeline => "%{[@metadata][pipeline]}" <3>
+      user => "elastic"
+      password => "secret"
+    }
+  } else {
+    elasticsearch {
+      hosts => "https://061ab24010a2482e9d64729fdb0fd93a.us-east-1.aws.found.io:9243"
+      manage_template => false
+      index => "%{[@metadata][beat]}-%{[@metadata][version]}" <1>
+      action => "create"
+      user => "elastic"
+      password => "secret"
+    }
+  }
+}
+-----
+<1> If data streams are disabled in your configuration, set the `index` option to `%{[@metadata][beat]}-%{[@metadata][version]}-%{+YYYY.MM.dd}`. Data streams are enabled by default.
+<2> If you are disabling the use of Data Streams on your configuration, you can
+remove this setting, or set it to a different value as appropriate.
+<3> Configures {ls} to select the correct ingest pipeline based on metadata
+passed in the event.
+
+See the {winlogbeat} {winlogbeat-ref}/winlogbeat-modules-overview.html[Modules]
+documentation for more information about setting up and running modules.
+

--- a/docs/static/winlogbeat-modules.asciidoc
+++ b/docs/static/winlogbeat-modules.asciidoc
@@ -84,6 +84,6 @@ remove this setting, or set it to a different value as appropriate.
 <3> Configures {ls} to select the correct ingest pipeline based on metadata
 passed in the event.
 
-See the {winlogbeat} {winlogbeat-ref}/winlogbeat-modules-overview.html[Modules]
+See the {winlogbeat} {winlogbeat-ref}/winlogbeat-modules.html[Modules]
 documentation for more information about setting up and running modules.
 

--- a/docs/static/winlogbeat-modules.asciidoc
+++ b/docs/static/winlogbeat-modules.asciidoc
@@ -24,12 +24,12 @@ into {es} and configure {ls} to use them.
 
 On the system where {winlogbeat} is installed, run the `setup` command with the
 `--pipelines` option specified to load ingest pipelines for specific modules.
-For example, the following command loads ingest pipelines for the system and
-nginx modules:
+For example, the following command loads ingest pipelines for the security and
+sysmon modules:
 
 [source,shell]
 -----
-winlogbeat setup --pipelines --modules nginx,system
+winlogbeat setup --pipelines --modules security,sysmon
 -----
 
 A connection to {es} is required for this setup step because {winlogbeat} needs to

--- a/docs/static/winlogbeat-modules.asciidoc
+++ b/docs/static/winlogbeat-modules.asciidoc
@@ -13,6 +13,7 @@ You can use {winlogbeat} modules with {ls}, but you need to do some extra setup.
 The simplest approach is to <<use-winlogbeat-ingest-pipelines,set up and use the ingest
 pipelines>> provided by {winlogbeat}.
 
+[discrete]
 [[use-winlogbeat-ingest-pipelines]]
 === Use ingest pipelines for parsing
 

--- a/docs/static/winlogbeat-modules.asciidoc
+++ b/docs/static/winlogbeat-modules.asciidoc
@@ -10,10 +10,10 @@ ingest node pipelines, {es} templates, {winlogbeat} input configurations, and
 {kib} dashboards.
 
 You can use {winlogbeat} modules with {ls}, but you need to do some extra setup.
-The simplest approach is to <<use-ingest-pipelines,set up and use the ingest
+The simplest approach is to <<use-winlogbeat-ingest-pipelines,set up and use the ingest
 pipelines>> provided by {winlogbeat}.
 
-[[use-ingest-pipelines]]
+[[use-winlogbeat-ingest-pipelines]]
 === Use ingest pipelines for parsing
 
 When you use {winlogbeat} modules with {ls}, you can use the ingest pipelines


### PR DESCRIPTION
These are taken from the filebeat-modules doc with minor changes to
localise to winlogbeat and to remove the fully worked example.

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip]

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

This adds documentation to help users understand how to interface winlogbeat with logstash.

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

Prior to Winlogbeat 8.0 processor pipelines were run internally within Winlogbeat as js, but now are ingest pipelines. This has caused issues for some users who were previously using logstash to process/forward the js-processed documents and are now in the position of needing to perform the enrichment steps that were previously done by the js code. The documentation here is intended to help these users understand how they can obtain the ingest pipelines needed to pre-process their existing logstash pipelines, or to directly forward the documents through logstash.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~ **docs**
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~ **docs**

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes elastic/beats#32531

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
