### PR TITLE
clean jruby tmp directory

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -30,6 +30,7 @@ require "stud/trap"
 require "uri"
 require "socket"
 require "securerandom"
+require 'tmpdir'
 
 LogStash::Environment.load_locale!
 
@@ -283,11 +284,12 @@ class LogStash::Agent
     begin
       if ::File.exists?(pid_path)
         pid = ::File.read(pid_path).chomp.strip
-        tmp_path = ::File.join("/tmp", "jruby-#{pid}")
+        tmp_path = ::File.join(Dir.tmpdir(), "jruby-#{pid}")
         FileUtils.remove_dir(tmp_path) if ::File.exists?(tmp_path)
       end
     rescue => e
-      logger.warn("Cannot remove /tmp/jruby directory", :error => e.message, :exception => e.class)
+      tmp_path ||= "jruby dir in OS temp dir" 
+      logger.warn("Cannot remove #{tmp_path}", :error => e.message, :exception => e.class)
     end
 
 


### PR DESCRIPTION
Fixed: #11051

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

clean up jruby jar files in tmp directory

## What does this PR do?

This commit writes the pid of logstash process to path.data/pid
During the startup, it removes directory /tmp/jruby-$pid which contains jar files from the last run.

## Why is it important/What is the impact to the user?

When logstash shutdown ungracefully/ SIGKILL, /tmp/jruby-$pid remains in the disk.
After several ungrateful restarts, jar files occupy a certain amount of space and could run out of space of the container.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] tested in ubuntu

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Test in ubuntu
- run logstash 
- send SIGKILL to shutdown logstash
- run logstash again
- check /tmp should have one jruby-* directory
- shutdown logstash gracefully
- check /tmp should have no jruby-* directory 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
