### PR TITLE
Bump version to 8.4.2 for next development cycle

### DIFF
--- a/Gemfile.jruby-2.6.lock.release
+++ b/Gemfile.jruby-2.6.lock.release
@@ -2,12 +2,12 @@ PATH
   remote: logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 8.4.1)
+      logstash-core (= 8.4.2)
 
 PATH
   remote: logstash-core
   specs:
-    logstash-core (8.4.1-java)
+    logstash-core (8.4.2-java)
       clamp (~> 1)
       concurrent-ruby (~> 1, < 1.1.10)
       down (~> 5.2.0)

--- a/versions.yml
+++ b/versions.yml
@@ -1,7 +1,7 @@
 ---
 # alpha and beta qualifiers are now added via VERSION_QUALIFIER environment var
-logstash: 8.4.1
-logstash-core: 8.4.1
+logstash: 8.4.2
+logstash-core: 8.4.2
 logstash-core-plugin-api: 2.1.16
 
 bundled_jdk:


### PR DESCRIPTION
**Merge after `8.4.1` release**

Bump version for `8.4.2`