### PR TITLE
Manually import CSV gem to work around thread leak

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -30,3 +30,4 @@ gem "rack-test", :require => "rack/test", :group => :development
 gem "rspec", "~> 3.5", :group => :development
 gem "webmock", "~> 3", :group => :development
 gem "jar-dependencies", "= 0.4.1" # Gem::LoadError with jar-dependencies 0.4.2
+gem "csv", "~> 3" # Bundled version of CSV with jruby >=9.3.0.0 < 9.3.8.0 has a thread leak

--- a/NOTICE.TXT
+++ b/NOTICE.TXT
@@ -5266,6 +5266,43 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE. 
 
 ==========
+Notice for: csv-3.2.5
+----------
+
+Copyright (C) 2005-2016 James Edward Gray II. All rights reserved.
+Copyright (C) 2007-2017 Yukihiro Matsumoto. All rights reserved.
+Copyright (C) 2017 SHIBATA Hiroshi. All rights reserved.
+Copyright (C) 2017 Olivier Lacan. All rights reserved.
+Copyright (C) 2017 Espartaco Palma. All rights reserved.
+Copyright (C) 2017 Marcus Stollsteimer. All rights reserved.
+Copyright (C) 2017 pavel. All rights reserved.
+Copyright (C) 2017-2018 Steven Daniels. All rights reserved.
+Copyright (C) 2018 Tomohiro Ogoke. All rights reserved.
+Copyright (C) 2018 Kouhei Sutou. All rights reserved.
+Copyright (C) 2018 Mitsutaka Mimura. All rights reserved.
+Copyright (C) 2018 Vladislav. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+==========
 Notice for: dalli-2.7.11
 ----------
 

--- a/tools/dependencies-report/src/main/resources/licenseMapping.csv
+++ b/tools/dependencies-report/src/main/resources/licenseMapping.csv
@@ -39,6 +39,7 @@ dependency,dependencyUrl,licenseOverride,copyright,sourceURL
 "commons-codec:commons-codec:",http://commons.apache.org/proper/commons-codec/,Apache-2.0
 "commons-logging:commons-logging:",http://commons.apache.org/proper/commons-logging/,Apache-2.0
 "concurrent-ruby:",http://www.concurrent-ruby.com,MIT
+"csv:",https://github.com/ruby/csv,BSD-2-Clause
 "dalli:",https://github.com/petergoldstein/dalli,MIT
 "domain_name:",https://github.com/knu/ruby-domain_name,BSD-2-Clause
 "dotenv:",https://github.com/bkeepers/dotenv,MIT

--- a/tools/dependencies-report/src/main/resources/notices/csv-NOTICE.txt
+++ b/tools/dependencies-report/src/main/resources/notices/csv-NOTICE.txt
@@ -1,0 +1,33 @@
+Copyright (C) 2005-2016 James Edward Gray II. All rights reserved.
+Copyright (C) 2007-2017 Yukihiro Matsumoto. All rights reserved.
+Copyright (C) 2017 SHIBATA Hiroshi. All rights reserved.
+Copyright (C) 2017 Olivier Lacan. All rights reserved.
+Copyright (C) 2017 Espartaco Palma. All rights reserved.
+Copyright (C) 2017 Marcus Stollsteimer. All rights reserved.
+Copyright (C) 2017 pavel. All rights reserved.
+Copyright (C) 2017-2018 Steven Daniels. All rights reserved.
+Copyright (C) 2018 Tomohiro Ogoke. All rights reserved.
+Copyright (C) 2018 Kouhei Sutou. All rights reserved.
+Copyright (C) 2018 Mitsutaka Mimura. All rights reserved.
+Copyright (C) 2018 Vladislav. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.


### PR DESCRIPTION
The version of CSV included in jruby distributions >= `9.3.0.0` and < `9.3.8.0` include a bug that triggers a thread leak when calling `parse_line` in CSV files.

This commit updates the version of the CSV gem to the latest version, which includes fixes, and remains compatible with ruby 2.6

Relates: https://github.com/jruby/jruby/issues/7346
Fixes: #14498 
