### PR TITLE
Flow metrics: initial implementation

### DIFF
--- a/logstash-core/lib/logstash/instrument/collector.rb
+++ b/logstash-core/lib/logstash/instrument/collector.rb
@@ -67,6 +67,19 @@ module LogStash module Instrument
       end
     end
 
+    def register?(namespaces_path, key, metric_instance)
+      registered = false
+
+      # Relies on MetricStore#fetch_or_store yielding the block
+      # EXACTLY ONCE to the winner in a race-condition.
+      @metric_store.fetch_or_store(namespaces_path, key) do
+        registered = true
+        metric_instance
+      end
+
+      registered
+    end
+
     # Snapshot the current Metric Store and return it immediately,
     # This is useful if you want to get access to the current metric store without
     # waiting for a periodic call.

--- a/logstash-core/lib/logstash/instrument/metric_store.rb
+++ b/logstash-core/lib/logstash/instrument/metric_store.rb
@@ -51,11 +51,20 @@ module LogStash module Instrument
 
     # This method use the namespace and key to search the corresponding value of
     # the hash, if it doesn't exist it will create the appropriate namespaces
-    # path in the hash and return `new_value`
-    #
-    # @param [Array] The path where the values should be located
-    # @param [Symbol] The metric key
-    # @return [Object] Return the new_value of the retrieve object in the tree
+    # path in the hash and return `new_value`.
+    # @overload fetch_or_store(namespaces, key, default_value)
+    #   @param [Array<Symbol>] namespaces: The path where the values should be located
+    #   @param [Symbol] key: The metric key
+    #   @param [Metric] default_value: if no metric exists at this address, the
+    #                                  provided default_value will be stored
+    #   @return [Metric] the value as it exists in the tree after this operation
+    # @overload fetch_or_store(namespaces, key, &default_value_generator)
+    #   @param [Array<Symbol>] namespaces: The path where the values should be located
+    #   @param [Symbol] key: The metric key
+    #   @yield EXACTLY ONCE to the provided block IFF the metric does not exist
+    #   @yieldreturn [Metric] if no metric exists at this address, the result of yielding
+    #                         to the provided default_value_generator block will be stored.
+    #   @return [Metric] the value as it exists in the tree after this operation
     def fetch_or_store(namespaces, key, default_value = nil)
 
       # We first check in the `@fast_lookup` store to see if we have already see that metrics before,

--- a/logstash-core/lib/logstash/instrument/metric_type/uptime.rb
+++ b/logstash-core/lib/logstash/instrument/metric_type/uptime.rb
@@ -15,26 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
-require "logstash/instrument/metric_type/counter"
-require "logstash/instrument/metric_type/gauge"
-require "logstash/instrument/metric_type/uptime"
+java_import org.logstash.instrument.metrics.UptimeMetric
 
-module LogStash module Instrument
-  module MetricType
-    METRIC_TYPE_LIST = {
-      :counter => LogStash::Instrument::MetricType::Counter,
-      :gauge => LogStash::Instrument::MetricType::Gauge,
-      :uptime => LogStash::Instrument::MetricType::Uptime,
-    }.freeze
+module LogStash module Instrument module MetricType
+  class Uptime < UptimeMetric
 
-    # Use the string to generate a concrete class for this metrics
-    #
-    # @param [String] The name of the class
-    # @param [Array] Namespaces list
-    # @param [String] The metric key
-    # @raise [NameError] If the class is not found
-    def self.create(type, namespaces, key)
-      METRIC_TYPE_LIST[type].new(namespaces, key)
+    def initialize(namespaces, key)
+      super(key.to_s)
     end
+
+    def execute(action, value = nil)
+      fail("Unsupported operation `action` on Uptime Metric")
+    end
+
   end
-end; end
+end; end; end

--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -121,6 +121,7 @@ module LogStash; class JavaPipeline < JavaBasePipeline
     # this is useful in the context of pipeline reloading
     collect_stats
     collect_dlq_stats
+    initialize_flow_metrics
 
     @logger.debug("Starting pipeline", default_logging_keys)
 
@@ -533,6 +534,7 @@ module LogStash; class JavaPipeline < JavaBasePipeline
       # we want to keep other metrics like reload counts and error messages
       collector.clear("stats/pipelines/#{pipeline_id}/plugins")
       collector.clear("stats/pipelines/#{pipeline_id}/events")
+      collector.clear("stats/pipelines/#{pipeline_id}/flow")
     end
   end
 

--- a/logstash-core/src/main/java/org/logstash/ext/JRubyWrappedWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JRubyWrappedWriteClientExt.java
@@ -44,7 +44,7 @@ public final class JRubyWrappedWriteClientExt extends RubyObject implements Queu
 
     private static final long serialVersionUID = 1L;
 
-    private static final RubySymbol PUSH_DURATION_KEY =
+    public static final RubySymbol PUSH_DURATION_KEY =
         RubyUtil.RUBY.newSymbol("queue_push_duration_in_millis");
 
     private JRubyAbstractQueueWriteClientExt writeClient;

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractMetric.java
@@ -23,6 +23,8 @@ package org.logstash.instrument.metrics;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.Objects;
+
 /**
  * Abstract implementation of a {@link Metric}. All metrics should subclass this.
  *
@@ -48,8 +50,7 @@ public abstract class AbstractMetric<T> implements Metric<T> {
 
     @Override
     public String toString() {
-        return String.format("%s -  name: %s value:%s", this.getClass().getName(), this.name, getValue() == null ? "null" :
-                getValue().toString());
+        return String.format("%s -  name: %s value:%s", this.getClass().getName(), this.name, Objects.requireNonNullElse(getValue(),"null"));
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowMetric.java
@@ -1,0 +1,83 @@
+package org.logstash.instrument.metrics;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class FlowMetric {
+
+    // metric sources
+    private final Metric<? extends Number> numeratorMetric;
+    private final Metric<? extends Number> denominatorMetric;
+
+    // useful capture nodes for calculation
+    private final Capture baseline;
+
+    private final AtomicReference<Capture> head;
+    private final AtomicReference<Capture> instant = new AtomicReference<>();
+
+    static final String LIFETIME_KEY = "lifetime";
+    static final String CURRENT_KEY = "current";
+
+    public FlowMetric(final Metric<? extends Number> numeratorMetric, final Metric<? extends Number> denominatorMetric) {
+        this.numeratorMetric = numeratorMetric;
+        this.denominatorMetric = denominatorMetric;
+
+        this.baseline = doCapture();
+        this.head = new AtomicReference<>(this.baseline);
+    }
+
+    public void capture() {
+        final Capture previousHead = head.getAndSet(doCapture());
+        instant.set(previousHead);
+    }
+
+    public Map<String,Double> getAvailableRates() {
+        final Capture headCapture = head.get();
+        if (Objects.isNull(headCapture)) {
+            return Map.of();
+        }
+
+        final Map<String, Double> rates = new HashMap<>();
+
+        final Double lifetimeRate = headCapture.calculateRate(baseline);
+
+        if (Objects.nonNull(lifetimeRate)) {
+            rates.put(LIFETIME_KEY, lifetimeRate);
+        }
+
+        final Capture instantCapture = instant.get();
+        final Double currentRate = headCapture.calculateRate(instantCapture);
+        if (Objects.nonNull(currentRate)) {
+            rates.put(CURRENT_KEY, currentRate);
+        }
+
+
+        return Map.copyOf(rates);
+    }
+
+    Capture doCapture() {
+        return new Capture(numeratorMetric.getValue(), denominatorMetric.getValue());
+    }
+
+    private static class Capture {
+        private final Number numerator;
+        private final Number denominator;
+
+        public Capture(final Number numerator, final Number denominator) {
+            this.numerator = numerator;
+            this.denominator = denominator;
+        }
+
+        Double calculateRate(final Capture baseline) {
+            if (Objects.isNull(baseline)) { return null; }
+            if (baseline == this) { return null; }
+
+            final double deltaNumerator = this.numerator.doubleValue() - baseline.numerator.doubleValue();
+            final double deltaDenominator = this.denominator.doubleValue() - baseline.denominator.doubleValue();
+
+            return deltaNumerator / deltaDenominator;
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricType.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricType.java
@@ -55,7 +55,13 @@ public enum MetricType {
     /**
      * A gauge backed by a {@link org.logstash.ext.JrubyTimestampExtLibrary.RubyTimestamp} type. Note - Java consumers should not use this, exist for legacy Ruby code.
      */
-    GAUGE_RUBYTIMESTAMP("gauge/rubytimestamp");
+    GAUGE_RUBYTIMESTAMP("gauge/rubytimestamp"),
+
+    /**
+     * A flow-rate {@link FlowMetric}, instantiated with one or more backing {@link Metric}{@code <Number>}.
+     */
+    FLOW_RATES("flow/rate"),
+    ;
 
     private final String type;
 

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/UptimeMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/UptimeMetric.java
@@ -1,0 +1,87 @@
+package org.logstash.instrument.metrics;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+
+/**
+ * The {@link UptimeMetric} is an auto-advancing {@link Metric} whose value
+ * represents the amount of time since instantiation. It can be made to track the
+ * advancement of the clock in one of several {@link TimeUnit}s.
+ */
+public class UptimeMetric extends AbstractMetric<Long> {
+    private final LongSupplier nanoTimeSupplier;
+    private final long startNanos;
+
+    private final TimeUnit timeUnit;
+
+    /**
+     * Constructs an {@link UptimeMetric} whose name is "uptime_in_millis" and whose units are milliseconds
+     */
+    public UptimeMetric() {
+        this("uptime_in_millis");
+    }
+
+    public UptimeMetric(final String name) {
+        this(name, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Constructs an {@link UptimeMetric} with the provided name and units.
+     * @param name the name of the metric, which is used by our metric store, API retrieval, etc.
+     * @param timeUnit the units in which to keep track of uptime (millis, seconds, etc.)
+     */
+    public UptimeMetric(final String name, final TimeUnit timeUnit) {
+        this(name, timeUnit, System::nanoTime);
+    }
+
+    UptimeMetric(final String name, final TimeUnit timeUnit, final LongSupplier nanoTimeSupplier) {
+        this(name, timeUnit, nanoTimeSupplier, nanoTimeSupplier.getAsLong());
+    }
+
+    UptimeMetric(final String name, final TimeUnit timeUnit, final LongSupplier nanoTimeSupplier, final long startNanos) {
+        super(Objects.requireNonNull(name, "name"));
+        this.nanoTimeSupplier = Objects.requireNonNull(nanoTimeSupplier, "nanoTimeSupplier");
+        this.timeUnit = Objects.requireNonNull(timeUnit, "timeUnit");
+        this.startNanos = Objects.requireNonNull(startNanos, "startNanos");
+    }
+
+    /**
+     * @return the number of {@link TimeUnit}s that have elapsed
+     *         since this {@link UptimeMetric} was instantiated
+     */
+    @Override
+    public Long getValue() {
+        final long elapsedNanos = this.nanoTimeSupplier.getAsLong() - this.startNanos;
+
+        return this.timeUnit.convert(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    /**
+     * @return the {@link MetricType}{@code .COUNTER_LONG} associated with
+     *         long-valued metrics that only-increment, for use in Monitoring data structuring.
+     */
+    @Override
+    public MetricType getType() {
+        return MetricType.COUNTER_LONG;
+    }
+
+    /**
+     * @return the {@link TimeUnit} associated with this {@link UptimeMetric}.
+     */
+    public TimeUnit getTimeUnit() {
+        return timeUnit;
+    }
+
+    /**
+     * Constructs a _copy_ of this {@link UptimeMetric} with a new name and timeUnit, but whose
+     * uptime is tracking from the same instant as this instance.
+     *
+     * @param name the new metric's name (typically includes units)
+     * @param timeUnit the new metric's units
+     * @return a _copy_ of this {@link UptimeMetric}.
+     */
+    public UptimeMetric withTimeUnit(final String name, final TimeUnit timeUnit) {
+        return new UptimeMetric(name, timeUnit, this.nanoTimeSupplier, this.startNanos);
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/FlowMetricTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/FlowMetricTest.java
@@ -1,0 +1,54 @@
+package org.logstash.instrument.metrics;
+
+import org.junit.Test;
+import org.logstash.instrument.metrics.counter.LongCounter;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+import static org.logstash.instrument.metrics.FlowMetric.CURRENT_KEY;
+import static org.logstash.instrument.metrics.FlowMetric.LIFETIME_KEY;
+
+public class FlowMetricTest {
+    @Test
+    public void testBaselineFunctionality() {
+        final ManualAdvanceClock clock = new ManualAdvanceClock(Instant.now());
+        final LongCounter numeratorMetric = new LongCounter("events");
+        final Metric<Long> denominatorMetric = new UptimeMetric("uptime", TimeUnit.SECONDS, clock::nanoTime);
+        final FlowMetric instance = new FlowMetric(numeratorMetric, denominatorMetric);
+
+        final Map<String, Double> ratesBeforeCaptures = instance.getAvailableRates();
+        assertTrue(ratesBeforeCaptures.isEmpty());
+
+        // 5 seconds pass, during which 1000 events are processed
+        clock.advance(Duration.ofSeconds(5));
+        numeratorMetric.increment(1000);
+        instance.capture();
+        final Map<String, Double> ratesAfterFirstCapture = instance.getAvailableRates();
+        assertFalse(ratesAfterFirstCapture.isEmpty());
+        assertEquals(Map.of(LIFETIME_KEY, 200.0, CURRENT_KEY, 200.0), ratesAfterFirstCapture);
+
+        // 5 more seconds pass, during which 2000 more events are processed
+        clock.advance(Duration.ofSeconds(5));
+        numeratorMetric.increment(2000);
+        instance.capture();
+        final Map<String, Double> ratesAfterSecondCapture = instance.getAvailableRates();
+        assertFalse(ratesAfterSecondCapture.isEmpty());
+        assertEquals(Map.of(LIFETIME_KEY, 300.0, CURRENT_KEY, 400.0), ratesAfterSecondCapture);
+
+        // 30 seconds pass, during which 11700 more events are seen by our numerator
+        for (Integer eventCount : List.of(1883, 2117, 1901, 2299, 1608, 1892)) {
+            clock.advance(Duration.ofSeconds(5));
+            numeratorMetric.increment(eventCount);
+            instance.capture();
+        }
+        final Map<String, Double> ratesAfterNthCapture = instance.getAvailableRates();
+        assertFalse(ratesAfterNthCapture.isEmpty());
+        assertEquals(Map.of(LIFETIME_KEY, 367.5, CURRENT_KEY, 378.4), ratesAfterNthCapture);
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/FlowMetricTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/FlowMetricTest.java
@@ -20,16 +20,16 @@ public class FlowMetricTest {
         final ManualAdvanceClock clock = new ManualAdvanceClock(Instant.now());
         final LongCounter numeratorMetric = new LongCounter("events");
         final Metric<Long> denominatorMetric = new UptimeMetric("uptime", TimeUnit.SECONDS, clock::nanoTime);
-        final FlowMetric instance = new FlowMetric(numeratorMetric, denominatorMetric);
+        final FlowMetric instance = new FlowMetric("flow", numeratorMetric, denominatorMetric);
 
-        final Map<String, Double> ratesBeforeCaptures = instance.getAvailableRates();
+        final Map<String, Double> ratesBeforeCaptures = instance.getValue();
         assertTrue(ratesBeforeCaptures.isEmpty());
 
         // 5 seconds pass, during which 1000 events are processed
         clock.advance(Duration.ofSeconds(5));
         numeratorMetric.increment(1000);
         instance.capture();
-        final Map<String, Double> ratesAfterFirstCapture = instance.getAvailableRates();
+        final Map<String, Double> ratesAfterFirstCapture = instance.getValue();
         assertFalse(ratesAfterFirstCapture.isEmpty());
         assertEquals(Map.of(LIFETIME_KEY, 200.0, CURRENT_KEY, 200.0), ratesAfterFirstCapture);
 
@@ -37,7 +37,7 @@ public class FlowMetricTest {
         clock.advance(Duration.ofSeconds(5));
         numeratorMetric.increment(2000);
         instance.capture();
-        final Map<String, Double> ratesAfterSecondCapture = instance.getAvailableRates();
+        final Map<String, Double> ratesAfterSecondCapture = instance.getValue();
         assertFalse(ratesAfterSecondCapture.isEmpty());
         assertEquals(Map.of(LIFETIME_KEY, 300.0, CURRENT_KEY, 400.0), ratesAfterSecondCapture);
 
@@ -47,7 +47,7 @@ public class FlowMetricTest {
             numeratorMetric.increment(eventCount);
             instance.capture();
         }
-        final Map<String, Double> ratesAfterNthCapture = instance.getAvailableRates();
+        final Map<String, Double> ratesAfterNthCapture = instance.getValue();
         assertFalse(ratesAfterNthCapture.isEmpty());
         assertEquals(Map.of(LIFETIME_KEY, 367.5, CURRENT_KEY, 378.4), ratesAfterNthCapture);
     }

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/ManualAdvanceClock.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/ManualAdvanceClock.java
@@ -1,0 +1,63 @@
+package org.logstash.instrument.metrics;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+class ManualAdvanceClock extends Clock {
+    private final ZoneId zoneId;
+    private final AtomicReference<Instant> currentInstant;
+    private final Instant zeroInstant;
+
+    public ManualAdvanceClock(final Instant currentInstant, final ZoneId zoneId) {
+        this(currentInstant, new AtomicReference<>(currentInstant), zoneId);
+    }
+
+    public ManualAdvanceClock(final Instant currentInstant) {
+        this(currentInstant, null);
+    }
+
+    private ManualAdvanceClock(final Instant zeroInstant, final AtomicReference<Instant> currentInstant, final ZoneId zoneId) {
+        this.zeroInstant = zeroInstant;
+        this.currentInstant = currentInstant;
+        this.zoneId = Objects.requireNonNullElseGet(zoneId, ZoneId::systemDefault);
+    }
+
+    @Override
+    public ZoneId getZone() {
+        return this.zoneId;
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+        return new ManualAdvanceClock(this.zeroInstant, this.currentInstant, zone);
+    }
+
+    @Override
+    public Instant instant() {
+        return currentInstant.get();
+    }
+
+    /**
+     * @return an only-incrementing long value, meant as a drop-in replacement
+     *         for {@link System#nanoTime()}, using this {@link ManualAdvanceClock}
+     *         as the time source, and carrying the same constraints.
+     */
+    public long nanoTime() {
+        return zeroInstant.until(instant(), ChronoUnit.NANOS);
+    }
+
+    public void advance(final Duration duration) {
+        if (duration.isZero()) {
+            return;
+        }
+        if (duration.isNegative()) {
+            throw new IllegalArgumentException("duration must not be negative");
+        }
+        this.currentInstant.updateAndGet(previous -> previous.plus(duration));
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/UptimeMetricTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/UptimeMetricTest.java
@@ -1,0 +1,63 @@
+package org.logstash.instrument.metrics;
+
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public class UptimeMetricTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        final UptimeMetric defaultConstructorUptimeMetric = new UptimeMetric();
+        assertEquals("uptime_in_millis", defaultConstructorUptimeMetric.getName());
+        assertEquals(TimeUnit.MILLISECONDS, defaultConstructorUptimeMetric.getTimeUnit());
+    }
+
+    @Test
+    public void getNameExplicit() {
+        final String customName = "custom_uptime_name";
+        assertEquals(customName, new UptimeMetric(customName, TimeUnit.MILLISECONDS).getName());
+    }
+
+    @Test
+    public void getType() {
+        assertEquals(MetricType.COUNTER_LONG, new UptimeMetric().getType());
+    }
+
+    @Test
+    public void getValue() {
+        final ManualAdvanceClock clock = new ManualAdvanceClock(Instant.now());
+        final UptimeMetric uptimeMetric = new UptimeMetric("up", TimeUnit.MILLISECONDS, clock::nanoTime);
+        assertEquals(Long.valueOf(0L), uptimeMetric.getValue());
+
+        clock.advance(Duration.ofMillis(123));
+        assertEquals(Long.valueOf(123L), uptimeMetric.getValue());
+
+        clock.advance(Duration.ofMillis(456));
+        assertEquals(Long.valueOf(579L), uptimeMetric.getValue());
+
+        clock.advance(Duration.ofMinutes(15));
+        assertEquals(Long.valueOf(900579L), uptimeMetric.getValue());
+
+        clock.advance(Duration.ofHours(712));
+        assertEquals(Long.valueOf(2564100579L), uptimeMetric.getValue());
+    }
+
+    @Test
+    public void withTemporalUnit() {
+        final ManualAdvanceClock clock = new ManualAdvanceClock(Instant.now());
+        final UptimeMetric uptimeMetric = new UptimeMetric("up_millis", TimeUnit.MILLISECONDS, clock::nanoTime);
+        clock.advance(Duration.ofMillis(1_000_000_000));
+
+        // set-up: ensure advancing nanos reflects in our milli-based uptime
+        assertEquals(Long.valueOf(1_000_000_000), uptimeMetric.getValue());
+
+        final UptimeMetric secondsBasedCopy = uptimeMetric.withTimeUnit("up_seconds", TimeUnit.SECONDS);
+        assertEquals(Long.valueOf(1_000_000), secondsBasedCopy.getValue());
+    }
+
+}


### PR DESCRIPTION

## Release notes

[rn:skip]

## What does this PR do?

This PR targets a _feature_ branch that is recently cut off of `main`, with the goal of coordinating contributions from @mashhurs and me as we iterate toward a value-providing solution for Phase 0 of #14463 (Pipeline Health API - Pipeline Flow Metrics). Our goal is to get the shared feature branch into shape and separately PR it, so the bar for accepting a partial like this one onto the feature branch is a little lower than the bar we hold for merging onto `main`. It is encouraged to merge PRs into the feature branch early, and to separately PR suggestions into the feature branch to accelerate iterating toward our goal.

This is _half_ of the implementation outlined in Phase 0, providing the `FlowMetric` data structure and UptimeMetric implementation, and registering the five outlined flow metrics for each pipeline upon pipeline startup. It does _not_ capture those metrics at a cadence, nor does it inject the metrics into the API response, as those will be tackled in a separate effort on this feature branch.

## Why is it important/What is the impact to the user?

As outlined in #14463 (Pipeline Health API - Pipeline Flow Metrics), providing users with visibility into the current and lifetime _flow_ rates of various pipeline-level metrics will help provide better visibility into how a pipeline is actively performing.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

A bit terribly hacky, but injecting the following into `AbstractPipelineExt#collectStats`, which is already hooked up to a timed execution running at a cadence, causes the flow values to be captured and printed to stdout at that cadence.

~~~ diff
--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -450,6 +452,11 @@ public class AbstractPipelineExt extends RubyBasicObject {
             dataMetrics.gauge(context, PATH, dirPath);
             pipelineMetric.gauge(context, MetricKeys.EVENTS_KEY, inner.ruby_unread_count(context));
         }
+
+        System.err.format("FLOWS(%s): %s\n", pipelineId.asJavaString(), this.flowMetrics.size());
+        this.collectFlowMetrics(context);
+        this.flowMetrics.forEach((flowMetric -> System.err.format("  FLOW(%s/%s): %s\n", pipelineId.asJavaString(), flowMetric.getName(), flowMetric.getValue())));
+
~~~

From there, it is as simple as running a pipeline that produces significant data for long enough to see the metrics change. This one produces jittery data, which is helpful for viewing changing rates.

~~~
ruby -e '100.times.map { |j| Thread.new(j) { |k| 100000.times { |i| $stdout.write("ok[#{k}/#{i}]\n"); (i%17).zero? && sleep(Random.rand(10)) } } }.map(&:join)' | bin/logstash -e 'input { stdin {} } output { sink {} }'
~~~
