### PR TITLE
Document JDK17 by default

### DIFF
--- a/docs/static/jvm.asciidoc
+++ b/docs/static/jvm.asciidoc
@@ -67,7 +67,7 @@ installation, you may get an error message, and {ls} will not start properly.
 [[jdk17-upgrade]]
 ==== Using JDK 17
 
-{ls} supports JDK 17, but you need to update settings in `jvm.options` and
+{ls} uses JDK 17 by default, but you need to update settings in `jvm.options` and
 `log4j2.properties` if you are upgrading from  {ls} 7.11.x (or earlier) to 7.12 or later.
 
 

--- a/docs/static/jvm.asciidoc
+++ b/docs/static/jvm.asciidoc
@@ -5,7 +5,7 @@
 {ls} requires one of these versions:
 
 * Java 11
-* Java 17 (default, see <<jdk17-upgrade>> for settings info)
+* Java 17 (default). Check out <<jdk17-upgrade>> for settings info.
 
 Use the
 http://www.oracle.com/technetwork/java/javase/downloads/index.html[official

--- a/docs/static/jvm.asciidoc
+++ b/docs/static/jvm.asciidoc
@@ -5,7 +5,7 @@
 {ls} requires one of these versions:
 
 * Java 11
-* Java 17 (see <<jdk17-upgrade>> for settings info)
+* Java 17 (default, see <<jdk17-upgrade>> for settings info)
 
 Use the
 http://www.oracle.com/technetwork/java/javase/downloads/index.html[official
@@ -20,7 +20,7 @@ for the official word on supported versions across releases.
 ===== 
 {ls} offers architecture-specific
 https://www.elastic.co/downloads/logstash[downloads] that include
-Adoptium Eclipse Temurin 11, the latest long term support (LTS) release of the JDK.
+Adoptium Eclipse Temurin 17, the latest long term support (LTS) release of the JDK.
 
 Use the LS_JAVA_HOME environment variable if you want to use a JDK other than the
 version that is bundled. 


### PR DESCRIPTION

## What does this PR do?

Updates the docs to correctly display JDK17 as the default JDK version.

## Why is it important/What is the impact to the user?

Current docs for 8.4 show that JDK11 is the default, however JDK17 was made default for 8.4

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works
