### PR TITLE
Fix Windows scripts

### DIFF
--- a/bin/logstash-keystore.bat
+++ b/bin/logstash-keystore.bat
@@ -9,7 +9,7 @@ if errorlevel 1 (
 	exit /B %ERRORLEVEL%
 )
 
-%JRUBY_BIN% %JAVA_OPTS% "%LS_HOME%\lib\secretstore\cli.rb" %*
+%JRUBY_BIN% "%LS_HOME%\lib\secretstore\cli.rb" %*
 if errorlevel 1 (
   exit /B 1
 )

--- a/bin/logstash-plugin.bat
+++ b/bin/logstash-plugin.bat
@@ -9,7 +9,7 @@ if errorlevel 1 (
 	exit /B %ERRORLEVEL%
 )
 
-%JRUBY_BIN% %JAVA_OPTS% "%LS_HOME%\lib\pluginmanager\main.rb" %*
+%JRUBY_BIN% "%LS_HOME%\lib\pluginmanager\main.rb" %*
 if errorlevel 1 (
   exit /B 1
 )


### PR DESCRIPTION
The work done in #14355 to fix the keystore and plugin scripts erroneously included %JAVA_OPTS% in the command to invoke `jruby`, rather than as an environment variable, which prevented these scripts from operating correctly, due to `jruby.exe` not handling Java options, causing the scripts to crash on invocation.

This commit removes the %JAVA_OPTS% - this is already set as an environment variable, and allows the scripts to operate correctly

