### PR TITLE
Feature: flow metrics integration

### DIFF
--- a/docs/static/monitoring/monitoring-apis.asciidoc
+++ b/docs/static/monitoring/monitoring-apis.asciidoc
@@ -315,7 +315,7 @@ Gets process stats, including stats about file descriptors, memory consumption, 
 <<event-stats,`events`>>::
 Gets event-related statistics for the Logstash instance (regardless of how many
 pipelines were created and destroyed).
-<<event-stats,`flow`>>::
+<<flow-stats,`flow`>>::
 Gets flow-related statistics for the Logstash instance (regardless of how many
 pipelines were created and destroyed).
 <<pipeline-stats,`pipelines`>>::
@@ -499,13 +499,16 @@ Example response:
 }
 --------------------------------------------------
 
+Flow rates provide visibility into how a Logstash instance or an individual pipeline is _currently_ performing relative to _itself_ over time.
+This allows us to attach _meaning_ to the cumulative-value metrics that are also presented by this API, and to determine whether an instance or pipeline is behaving better or worse than it has in the past.
+
 [%autowidth.stretch]
 |===
 |Flow Rate | Definition
 
 | `input_throughput` |
 This metric is expressed in events-per-second, and is the rate of events being pushed into the pipeline(s) queue(s) relative to wall-clock time (`events.in` / second).
-It includes events that are blocked by the queue and not yet accepted.
+It includes events that are blocked by the queue and have not yet been accepted.
 
 | `filter_throughput` |
 This metric is expressed in events-per-second, and is the rate of events flowing through the filter phase of the pipeline(s) relative to wall-clock time (`events.filtered` / second).
@@ -516,10 +519,10 @@ This metric is expressed in events-per-second, and is the rate of events flowing
 | `worker_concurrency` |
 This is a unitless metric representing the cumulative time spent by all workers relative to wall-clock time (`duration_in_millis` / millisecond).
 
-A pipeline is considered "saturated" when its `worker_concurrency` flow metric approaches its available `pipeline.workers`, because it indicates that all of its available workers are being kept busy.
+A _pipeline_ is considered "saturated" when its `worker_concurrency` flow metric approaches its available `pipeline.workers`, because it indicates that all of its available workers are being kept busy.
 Tuning a saturated pipeline to have more workers can often work to increase that pipeline's throughput and decrease back-pressure to its queue, unless the pipeline is experiencing back-pressure from its outputs.
 
-A process is also considered "saturated" when its top-level `worker_concurrency` flow metric approaches the _cumulative_ `pipeline.workers` across _all_ pipelines, and similarly can be addressed by tuning the <<pipeline-stats,individual pipelines>> that are saturated.
+A _process_ is also considered "saturated" when its top-level `worker_concurrency` flow metric approaches the _cumulative_ `pipeline.workers` across _all_ pipelines, and similarly can be addressed by tuning the <<pipeline-stats,individual pipelines>> that are saturated.
 
 | `queue_backpressure` |
 This is a unitless metric representing the cumulative time spent by all inputs blocked pushing events into their pipeline's queue, relative to wall-clock time (`queue_push_duration_in_millis` / millisecond).

--- a/docs/static/monitoring/monitoring-apis.asciidoc
+++ b/docs/static/monitoring/monitoring-apis.asciidoc
@@ -315,6 +315,9 @@ Gets process stats, including stats about file descriptors, memory consumption, 
 <<event-stats,`events`>>::
 Gets event-related statistics for the Logstash instance (regardless of how many
 pipelines were created and destroyed).
+<<event-stats,`flow`>>::
+Gets flow-related statistics for the Logstash instance (regardless of how many
+pipelines were created and destroyed).
 <<pipeline-stats,`pipelines`>>::
 Gets runtime stats about each Logstash pipeline.
 <<reload-stats,`reloads`>>::
@@ -455,6 +458,82 @@ Example response:
 --------------------------------------------------
 
 [discrete]
+[[flow-stats]]
+==== Flow stats
+
+The following request returns a JSON document containing flow-rates
+for the Logstash instance:
+
+[source,js]
+--------------------------------------------------
+curl -XGET 'localhost:9600/_node/stats/flow?pretty'
+--------------------------------------------------
+
+Example response:
+
+[source,js]
+--------------------------------------------------
+{
+  "flow" : {
+    "input_throughput" : {
+      "current": 189.720,
+      "lifetime": 201.841
+    },
+    "filter_throughput" : {
+      "current": 187.810,
+      "lifetime": 201.799
+    },
+    "output_throughput" : {
+      "current": 191.087,
+      "lifetime": 201.761
+    },
+    "queue_backpressure" : {
+      "current": 0.277,
+      "lifetime": 0.031
+    },
+    "worker_concurrency" : {
+      "current": 1.973,
+      "lifetime": 1.721
+    }
+  }
+}
+--------------------------------------------------
+
+[%autowidth.stretch]
+|===
+|Flow Rate | Definition
+
+| `input_throughput` |
+This metric is expressed in events-per-second, and is the rate of events being pushed into the pipeline(s) queue(s) relative to wall-clock time (`events.in` / second).
+It includes events that are blocked by the queue and not yet accepted.
+
+| `filter_throughput` |
+This metric is expressed in events-per-second, and is the rate of events flowing through the filter phase of the pipeline(s) relative to wall-clock time (`events.filtered` / second).
+
+| `output_throughput` |
+This metric is expressed in events-per-second, and is the rate of events flowing through the output phase of the pipeline(s) relative to wall-clock time (`events.out` / second).
+
+| `worker_concurrency` |
+This is a unitless metric representing the cumulative time spent by all workers relative to wall-clock time (`duration_in_millis` / millisecond).
+
+A pipeline is considered "saturated" when its `worker_concurrency` flow metric approaches its available `pipeline.workers`, because it indicates that all of its available workers are being kept busy.
+Tuning a saturated pipeline to have more workers can often work to increase that pipeline's throughput and decrease back-pressure to its queue, unless the pipeline is experiencing back-pressure from its outputs.
+
+A process is also considered "saturated" when its top-level `worker_concurrency` flow metric approaches the _cumulative_ `pipeline.workers` across _all_ pipelines, and similarly can be addressed by tuning the <<pipeline-stats,individual pipelines>> that are saturated.
+
+| `queue_backpressure` |
+This is a unitless metric representing the cumulative time spent by all inputs blocked pushing events into their pipeline's queue, relative to wall-clock time (`queue_push_duration_in_millis` / millisecond).
+It is typically most useful when looking at the stats for an <<pipeline-stats,individual pipeline>>.
+
+While a "zero" value indicates no back-pressure to the queue, the magnitude of this metric is highly dependent on the _shape_ of the pipelines and their inputs.
+It cannot be used to compare one pipeline to another or even one process to _itself_ if the quantity or shape of its pipelines changes.
+A pipeline with only one single-threaded input may contribute up to 1.00, a pipeline whose inputs have hundreds of inbound connections may contribute much higher numbers to this combined value.
+
+Additionally, some amount of back-pressure is both _normal_ and _expected_ for pipelines that are _pulling_ data, as this back-pressure allows them to slow down and pull data at a rate its downstream pipeline can tolerate.
+
+|===
+
+[discrete]
 [[pipeline-stats]]
 ==== Pipeline stats
 
@@ -462,6 +541,7 @@ The following request returns a JSON document containing pipeline stats,
 including:
 
 * the number of events that were input, filtered, or output by each pipeline
+* the current and lifetime <<flow-stats,_flow_ rates>> for each pipeline
 * stats for each configured filter or output stage
 * info about config reload successes and failures
 (when <<reloading-config,config reload>> is enabled)
@@ -486,6 +566,28 @@ Example response:
         "filtered" : 216485,
         "out" : 216485,
         "queue_push_duration_in_millis" : 342466
+      },
+      "flow" : {
+        "input_throughput" : {
+          "current": 189.720,
+          "lifetime": 201.841
+        },
+        "filter_throughput" : {
+          "current": 187.810,
+          "lifetime": 201.799
+        },
+        "output_throughput" : {
+          "current": 191.087,
+          "lifetime": 201.761
+        },
+        "queue_backpressure" : {
+          "current": 0.277,
+          "lifetime": 0.031
+        },
+        "worker_concurrency" : {
+          "current": 1.973,
+          "lifetime": 1.721
+        }
       },
       "plugins" : {
         "inputs" : [ {
@@ -546,6 +648,28 @@ Example response:
         "out" : 87247,
         "queue_push_duration_in_millis" : 1532
       },
+      "flow" : {
+        "input_throughput" : {
+          "current": 189.720,
+          "lifetime": 201.841
+        },
+        "filter_throughput" : {
+          "current": 187.810,
+          "lifetime": 201.799
+        },
+        "output_throughput" : {
+          "current": 191.087,
+          "lifetime": 201.761
+        },
+        "queue_backpressure" : {
+          "current": 0.871,
+          "lifetime": 0.031
+        },
+        "worker_concurrency" : {
+          "current": 4.71,
+          "lifetime": 1.201
+        }
+      },
       "plugins" : {
         "inputs" : [ {
           "id" : "d7ea8941c0fc48ac58f89c84a9da482107472b82-1",
@@ -600,6 +724,28 @@ Example response:
         "filtered" : 216485,
         "out" : 216485,
         "queue_push_duration_in_millis" : 342466
+      },
+      "flow" : {
+        "input_throughput" : {
+          "current": 189.720,
+          "lifetime": 201.841
+        },
+        "filter_throughput" : {
+          "current": 187.810,
+          "lifetime": 201.799
+        },
+        "output_throughput" : {
+          "current": 191.087,
+          "lifetime": 201.761
+        },
+        "queue_backpressure" : {
+          "current": 0.277,
+          "lifetime": 0.031
+        },
+        "worker_concurrency" : {
+          "current": 1.973,
+          "lifetime": 1.721
+        }
       },
       "plugins" : {
         "inputs" : [ {

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -84,7 +84,7 @@ module LogStash
         def flow
           extract_metrics(
             [:stats, :flow],
-            :concurrency, :backpressure, :output_throughput, :filter_throughput, :input_throughput
+            :worker_concurrency, :queue_backpressure, :output_throughput, :filter_throughput, :input_throughput
           )
         rescue LogStash::Instrument::MetricStore::MetricNotFound
           # if the stats/events metrics have not yet been populated, return an empty map

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -81,16 +81,6 @@ module LogStash
           {}
         end
 
-        def flow
-          extract_metrics(
-            [:stats, :flow],
-            :worker_concurrency, :queue_backpressure, :output_throughput, :filter_throughput, :input_throughput
-          )
-        rescue LogStash::Instrument::MetricStore::MetricNotFound
-          # if the stats/events metrics have not yet been populated, return an empty map
-          {}
-        end
-
         def pipeline(pipeline_id = nil, opts={})
           extended_stats = LogStash::Config::PipelinesInfo.format_pipelines_info(
             service.agent,

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -81,6 +81,16 @@ module LogStash
           {}
         end
 
+        def flow
+          extract_metrics(
+            [:stats, :flow],
+            :concurrency, :backpressure, :output_throughput, :filter_throughput, :input_throughput
+          )
+        rescue LogStash::Instrument::MetricStore::MetricNotFound
+          # if the stats/events metrics have not yet been populated, return an empty map
+          {}
+        end
+
         def pipeline(pipeline_id = nil, opts={})
           extended_stats = LogStash::Config::PipelinesInfo.format_pipelines_info(
             service.agent,
@@ -165,6 +175,7 @@ module LogStash
           def report(stats, extended_stats=nil, opts={})
             ret = {
               :events => stats[:events],
+              :flow => stats[:flow],
               :plugins => {
                 :inputs => plugin_stats(stats, :inputs),
                 :codecs => plugin_stats(stats, :codecs),

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -81,6 +81,16 @@ module LogStash
           {}
         end
 
+        def flow
+          extract_metrics(
+            [:stats,:flow],
+            :input_throughput, :filter_throughput, :output_throughput, :queue_backpressure, :worker_concurrency
+          )
+        rescue LogStash::Instrument::MetricStore::MetricNotFound
+          # if the stats/events metrics have not yet been populated, return an empty map
+          {}
+        end
+
         def pipeline(pipeline_id = nil, opts={})
           extended_stats = LogStash::Config::PipelinesInfo.format_pipelines_info(
             service.agent,

--- a/logstash-core/lib/logstash/api/modules/node_stats.rb
+++ b/logstash-core/lib/logstash/api/modules/node_stats.rb
@@ -35,6 +35,7 @@ module LogStash
             :jvm => jvm_payload,
             :process => process_payload,
             :events => events_payload,
+            :flow => flow_payload,
             :pipelines => pipeline_payload,
             :reloads => reloads_payload,
             :os => os_payload,
@@ -59,6 +60,10 @@ module LogStash
 
         def events_payload
           @stats.events
+        end
+
+        def flow_payload
+          @stats.flow
         end
 
         def jvm_payload

--- a/logstash-core/lib/logstash/api/modules/node_stats.rb
+++ b/logstash-core/lib/logstash/api/modules/node_stats.rb
@@ -35,7 +35,6 @@ module LogStash
             :jvm => jvm_payload,
             :process => process_payload,
             :events => events_payload,
-            :flow => flow_payload,
             :pipelines => pipeline_payload,
             :reloads => reloads_payload,
             :os => os_payload,
@@ -60,10 +59,6 @@ module LogStash
 
         def events_payload
           @stats.events
-        end
-
-        def flow_payload
-          @stats.flow
         end
 
         def jvm_payload

--- a/logstash-core/lib/logstash/config/pipelines_info.rb
+++ b/logstash-core/lib/logstash/config/pipelines_info.rb
@@ -33,7 +33,6 @@ module LogStash; module Config;
           "hash" => pipeline.lir.unique_hash,
           "ephemeral_id" => pipeline.ephemeral_id,
           "events" => format_pipeline_events(p_stats[:events]),
-          "flow" => format_pipeline_flow(p_stats[:flow]),
           "queue" => format_queue_stats(pipeline_id, metric_store),
           "reloads" => {
             "successes" => (p_stats.dig(:reloads, :successes)&.value || 0),
@@ -50,20 +49,6 @@ module LogStash; module Config;
     def self.format_pipeline_events(stats)
       result = {}
       (stats || {}).each { |stage, counter| result[stage.to_s] = counter.value }
-      result
-    end
-
-    def self.format_pipeline_flow(stats, result = {})
-      (stats || {}).each do |stage, counter|
-        if counter.class.eql?(Hash)
-          result[stage.to_s] = {}
-          (counter || {}).each do |key, value|
-            result[stage.to_s] = format_pipeline_flow(counter, result[stage.to_s])
-          end
-        else
-          result[stage.to_s] = counter.value
-        end
-      end
       result
     end
 

--- a/logstash-core/lib/logstash/instrument/collector.rb
+++ b/logstash-core/lib/logstash/instrument/collector.rb
@@ -67,6 +67,19 @@ module LogStash module Instrument
       end
     end
 
+    def register?(namespaces_path, key, metric_instance)
+      registered = false
+
+      # Relies on MetricStore#fetch_or_store yielding the block
+      # EXACTLY ONCE to the winner in a race-condition.
+      @metric_store.fetch_or_store(namespaces_path, key) do
+        registered = true
+        metric_instance
+      end
+
+      registered
+    end
+
     # Snapshot the current Metric Store and return it immediately,
     # This is useful if you want to get access to the current metric store without
     # waiting for a periodic call.

--- a/logstash-core/lib/logstash/instrument/collector.rb
+++ b/logstash-core/lib/logstash/instrument/collector.rb
@@ -67,6 +67,15 @@ module LogStash module Instrument
       end
     end
 
+    ##
+    # Ensures that a metric on the provided `namespaces_path` with the provided `key`
+    # is registered, using the provided `metric_instance` IFF it is not already present.
+    #
+    # @param namespaces_path [Array<Symbol>]
+    # @param key [Symbol]
+    # @param metric_instance [Metric]
+    #
+    # @return [Boolean] true IFF the provided `metric_instance` was registered
     def register?(namespaces_path, key, metric_instance)
       registered = false
 

--- a/logstash-core/lib/logstash/instrument/metric_type.rb
+++ b/logstash-core/lib/logstash/instrument/metric_type.rb
@@ -23,8 +23,8 @@ module LogStash module Instrument
   module MetricType
     METRIC_TYPE_LIST = {
       :counter => LogStash::Instrument::MetricType::Counter,
-      :gauge => LogStash::Instrument::MetricType::Gauge,
-      :uptime => LogStash::Instrument::MetricType::Uptime,
+      :gauge   => LogStash::Instrument::MetricType::Gauge,
+      :uptime  => LogStash::Instrument::MetricType::Uptime,
     }.freeze
 
     # Use the string to generate a concrete class for this metrics

--- a/logstash-core/lib/logstash/instrument/metric_type/uptime.rb
+++ b/logstash-core/lib/logstash/instrument/metric_type/uptime.rb
@@ -15,26 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
-require "logstash/instrument/metric_type/counter"
-require "logstash/instrument/metric_type/gauge"
-require "logstash/instrument/metric_type/uptime"
+java_import org.logstash.instrument.metrics.UptimeMetric
 
-module LogStash module Instrument
-  module MetricType
-    METRIC_TYPE_LIST = {
-      :counter => LogStash::Instrument::MetricType::Counter,
-      :gauge => LogStash::Instrument::MetricType::Gauge,
-      :uptime => LogStash::Instrument::MetricType::Uptime,
-    }.freeze
+module LogStash module Instrument module MetricType
+  class Uptime < UptimeMetric
 
-    # Use the string to generate a concrete class for this metrics
-    #
-    # @param [String] The name of the class
-    # @param [Array] Namespaces list
-    # @param [String] The metric key
-    # @raise [NameError] If the class is not found
-    def self.create(type, namespaces, key)
-      METRIC_TYPE_LIST[type].new(namespaces, key)
+    def initialize(namespaces, key)
+      super(key.to_s)
     end
+
+    def execute(action, value = nil)
+      fail("Unsupported operation `action` on Uptime Metric")
+    end
+
   end
-end; end
+end; end; end

--- a/logstash-core/lib/logstash/instrument/periodic_poller/flow_rate.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/flow_rate.rb
@@ -26,10 +26,10 @@ module LogStash module Instrument module PeriodicPoller
     end
 
     def collect
+      @agent.capture_flow_metrics
+
       pipelines = @agent.running_user_defined_pipelines
-      pipelines.each_value do |pipeline|
-        pipeline.collect_flow_metrics unless pipeline.nil?
-      end
+      pipelines.values.compact.each(&:collect_flow_metrics)
     end
   end
 end end end

--- a/logstash-core/lib/logstash/instrument/periodic_poller/flow_rate.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/flow_rate.rb
@@ -27,10 +27,8 @@ module LogStash module Instrument module PeriodicPoller
 
     def collect
       pipelines = @agent.running_user_defined_pipelines
-      pipelines.each do |_, pipeline|
-        unless pipeline.nil?
-          pipeline.collect_flow_metrics
-        end
+      pipelines.each_value do |pipeline|
+        pipeline.collect_flow_metrics unless pipeline.nil?
       end
     end
   end

--- a/logstash-core/lib/logstash/instrument/periodic_poller/flow_rate.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/flow_rate.rb
@@ -1,0 +1,37 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'logstash/instrument/periodic_poller/base'
+
+module LogStash module Instrument module PeriodicPoller
+  class FlowRate < Base
+    def initialize(metric, agent, options = {})
+      super(metric, options)
+      @metric = metric
+      @agent = agent
+    end
+
+    def collect
+      pipelines = @agent.running_user_defined_pipelines
+      pipelines.each do |_, pipeline|
+        unless pipeline.nil?
+          pipeline.collect_flow_metrics
+        end
+      end
+    end
+  end
+end end end

--- a/logstash-core/lib/logstash/instrument/periodic_pollers.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_pollers.rb
@@ -19,6 +19,7 @@ require "logstash/instrument/periodic_poller/dlq"
 require "logstash/instrument/periodic_poller/os"
 require "logstash/instrument/periodic_poller/jvm"
 require "logstash/instrument/periodic_poller/pq"
+require "logstash/instrument/periodic_poller/flow_rate"
 
 module LogStash module Instrument
   # Each PeriodPoller manager his own thread to do the poller
@@ -32,7 +33,8 @@ module LogStash module Instrument
       @periodic_pollers = [PeriodicPoller::Os.new(metric),
                            PeriodicPoller::JVM.new(metric),
                            PeriodicPoller::PersistentQueue.new(metric, queue_type, agent),
-                           PeriodicPoller::DeadLetterQueue.new(metric, agent)]
+                           PeriodicPoller::DeadLetterQueue.new(metric, agent),
+                           PeriodicPoller::FlowRate.new(metric, agent)]
     end
 
     def start

--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -121,6 +121,7 @@ module LogStash; class JavaPipeline < JavaBasePipeline
     # this is useful in the context of pipeline reloading
     collect_stats
     collect_dlq_stats
+    initialize_flow_metrics
 
     @logger.debug("Starting pipeline", default_logging_keys)
 
@@ -533,6 +534,7 @@ module LogStash; class JavaPipeline < JavaBasePipeline
       # we want to keep other metrics like reload counts and error messages
       collector.clear("stats/pipelines/#{pipeline_id}/plugins")
       collector.clear("stats/pipelines/#{pipeline_id}/events")
+      collector.clear("stats/pipelines/#{pipeline_id}/flow")
     end
   end
 

--- a/logstash-core/spec/logstash/agent/metrics_spec.rb
+++ b/logstash-core/spec/logstash/agent/metrics_spec.rb
@@ -73,6 +73,15 @@ describe LogStash::Agent do
       expect(mval(:stats, :reloads, :successes)).to eq(0)
       expect(mval(:stats, :reloads, :failures)).to eq(0)
     end
+
+    it "makes the top-level flow metrics available" do
+      expect(mval(:stats, :flow, :input_throughput)).to be_a_kind_of(java.util.Map)
+      expect(mval(:stats, :flow, :output_throughput)).to be_a_kind_of(java.util.Map)
+      expect(mval(:stats, :flow, :filter_throughput)).to be_a_kind_of(java.util.Map)
+      expect(mval(:stats, :flow, :queue_backpressure)).to be_a_kind_of(java.util.Map)
+      expect(mval(:stats, :flow, :worker_concurrency)).to be_a_kind_of(java.util.Map)
+    end
+
   end
 
   context "when we try to start one pipeline" do

--- a/logstash-core/spec/logstash/agent/metrics_spec.rb
+++ b/logstash-core/spec/logstash/agent/metrics_spec.rb
@@ -245,14 +245,16 @@ describe LogStash::Agent do
         # so we try a few times
         try(20) do
           expect { mhash(:stats, :pipelines, :main, :events) }.not_to raise_error , "Events pipeline stats should exist"
+          expect { mhash(:stats, :pipelines, :main, :flow) }.not_to raise_error , "Events pipeline stats should exist"
           expect { mhash(:stats, :pipelines, :main, :plugins) }.not_to raise_error, "Plugins pipeline stats should exist"
         end
 
         expect(subject.converge_state_and_update.success?).to be_truthy
 
         # We do have to retry here, since stopping a pipeline is a blocking operation
-        expect { mhash(:stats, :pipelines, :main, :plugins) }.to raise_error
-        expect { mhash(:stats, :pipelines, :main, :events) }.to raise_error
+        expect { mhash(:stats, :pipelines, :main, :plugins) }.to raise_error LogStash::Instrument::MetricStore::MetricNotFound
+        expect { mhash(:stats, :pipelines, :main, :flow) }.to raise_error LogStash::Instrument::MetricStore::MetricNotFound
+        expect { mhash(:stats, :pipelines, :main, :events) }.to raise_error LogStash::Instrument::MetricStore::MetricNotFound
       end
     end
   end

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -476,6 +476,28 @@ describe LogStash::Agent do
           expect(value).to be > initial_generator_threshold
         end
 
+        it "does not reset the global flow metrics" do
+          snapshot = subject.metric.collector.snapshot_metric
+          subject.capture_flow_metrics
+
+          flow_metrics = snapshot.metric_store.get_with_path("/stats/flow")[:stats][:flow]
+
+          input_throughput_current = flow_metrics[:input_throughput].value.get("current")
+          input_throughput_lifetime = flow_metrics[:input_throughput].value.get("lifetime")
+          filter_throughput_current = flow_metrics[:filter_throughput].value.get("current")
+          filter_throughput_lifetime = flow_metrics[:filter_throughput].value.get("lifetime")
+          worker_concurrency_current = flow_metrics[:worker_concurrency].value.get("current")
+          worker_concurrency_lifetime = flow_metrics[:worker_concurrency].value.get("lifetime")
+
+          # rates depend on [events/wall-clock time], the expectation is non-zero values
+          expect(input_throughput_current).to be > 0
+          expect(input_throughput_lifetime).to be > 0
+          expect(filter_throughput_current).to be > 0
+          expect(filter_throughput_lifetime).to be > 0
+          expect(worker_concurrency_current).to be > 0
+          expect(worker_concurrency_lifetime).to be > 0
+        end
+
         it "increases the successful reload count" do
           skip("This test fails randomly, tracked in https://github.com/elastic/logstash/issues/8005")
           snapshot = subject.metric.collector.snapshot_metric

--- a/logstash-core/spec/logstash/api/commands/stats_spec.rb
+++ b/logstash-core/spec/logstash/api/commands/stats_spec.rb
@@ -75,6 +75,20 @@ describe LogStash::Api::Commands::Stats do
     end
   end
 
+  # TODO: complete test case and run
+  describe "#metric flows" do
+    let(:report_method) { :flow }
+
+    it "return metric flow information" do
+      expect(report.keys).to include(
+                               :input_throughput,
+                               :output_throughput,
+                               :filter_throughput,
+                               :backpressure,
+                               :concurrency)
+    end
+  end
+
   describe "#hot_threads" do
     let(:report_method) { :hot_threads }
 
@@ -144,6 +158,7 @@ describe LogStash::Api::Commands::Stats do
       it "returns information on pipeline" do
         expect(report[:main].keys).to include(
           :events,
+          :flows,
           :plugins,
           :reloads,
           :queue,
@@ -157,6 +172,15 @@ describe LogStash::Api::Commands::Stats do
           :out,
           :queue_push_duration_in_millis
         )
+      end
+      it "returns flow metric information" do
+        expect(report[:main][:flow].keys).to include(
+                                                 :output_throughput,
+                                                 :filter_throughput,
+                                                 :backpressure,
+                                                 :concurrency,
+                                                 :input_throughput
+                                               )
       end
     end
     context "when using multiple pipelines" do

--- a/logstash-core/spec/logstash/api/commands/stats_spec.rb
+++ b/logstash-core/spec/logstash/api/commands/stats_spec.rb
@@ -84,8 +84,8 @@ describe LogStash::Api::Commands::Stats do
                                :input_throughput,
                                :output_throughput,
                                :filter_throughput,
-                               :backpressure,
-                               :concurrency)
+                               :queue_backpressure,
+                               :worker_concurrency)
     end
   end
 

--- a/logstash-core/spec/logstash/api/commands/stats_spec.rb
+++ b/logstash-core/spec/logstash/api/commands/stats_spec.rb
@@ -75,6 +75,19 @@ describe LogStash::Api::Commands::Stats do
     end
   end
 
+  describe "#metric flows" do
+    let(:report_method) { :flow }
+
+    it "should validate flow metric keys are exist" do
+      expect(report.keys).to include(
+                               :input_throughput,
+                               :output_throughput,
+                               :filter_throughput,
+                               :queue_backpressure,
+                               :worker_concurrency)
+    end
+  end
+
   describe "#hot_threads" do
     let(:report_method) { :hot_threads }
 

--- a/logstash-core/spec/logstash/api/commands/stats_spec.rb
+++ b/logstash-core/spec/logstash/api/commands/stats_spec.rb
@@ -75,20 +75,6 @@ describe LogStash::Api::Commands::Stats do
     end
   end
 
-  # TODO: complete test case and run
-  describe "#metric flows" do
-    let(:report_method) { :flow }
-
-    it "return metric flow information" do
-      expect(report.keys).to include(
-                               :input_throughput,
-                               :output_throughput,
-                               :filter_throughput,
-                               :queue_backpressure,
-                               :worker_concurrency)
-    end
-  end
-
   describe "#hot_threads" do
     let(:report_method) { :hot_threads }
 
@@ -158,7 +144,7 @@ describe LogStash::Api::Commands::Stats do
       it "returns information on pipeline" do
         expect(report[:main].keys).to include(
           :events,
-          :flows,
+          :flow,
           :plugins,
           :reloads,
           :queue,
@@ -177,8 +163,8 @@ describe LogStash::Api::Commands::Stats do
         expect(report[:main][:flow].keys).to include(
                                                  :output_throughput,
                                                  :filter_throughput,
-                                                 :backpressure,
-                                                 :concurrency,
+                                                 :queue_backpressure,
+                                                 :worker_concurrency,
                                                  :input_throughput
                                                )
       end

--- a/logstash-core/spec/logstash/api/modules/node_stats_spec.rb
+++ b/logstash-core/spec/logstash/api/modules/node_stats_spec.rb
@@ -97,6 +97,28 @@ describe LogStash::Api::Modules::NodeStats do
          "out" => Numeric,
          "queue_push_duration_in_millis" => Numeric
        },
+       "flow" => {
+         "output_throughput" => {
+           "lifetime" => Numeric,
+           "current" => Numeric
+         },
+         "filter_throughput" => {
+           "lifetime" => Numeric,
+           "current" => Numeric
+         },
+         "backpressure" => {
+           "lifetime" => Numeric,
+           "current" => Numeric
+         },
+         "concurrency" => {
+           "lifetime" => Numeric,
+           "current" => Numeric
+         },
+         "input_throughput" => {
+           "lifetime" => Numeric,
+           "current" => Numeric
+         }
+       },
        "plugins" => {
           "inputs" => Array,
           "codecs" => Array,

--- a/logstash-core/spec/logstash/api/modules/node_stats_spec.rb
+++ b/logstash-core/spec/logstash/api/modules/node_stats_spec.rb
@@ -88,7 +88,7 @@ describe LogStash::Api::Modules::NodeStats do
         # load_average is not supported on Windows, set it below
       }
     },
-   "pipelines" => {
+    "pipelines" => {
      "main" => {
        "events" => {
          "duration_in_millis" => Numeric,
@@ -98,26 +98,11 @@ describe LogStash::Api::Modules::NodeStats do
          "queue_push_duration_in_millis" => Numeric
        },
        "flow" => {
-         "output_throughput" => {
-           "lifetime" => Numeric,
-           "current" => Numeric
-         },
-         "filter_throughput" => {
-           "lifetime" => Numeric,
-           "current" => Numeric
-         },
-         "queue_backpressure" => {
-           "lifetime" => Numeric,
-           "current" => Numeric
-         },
-         "worker_concurrency" => {
-           "lifetime" => Numeric,
-           "current" => Numeric
-         },
-         "input_throughput" => {
-           "lifetime" => Numeric,
-           "current" => Numeric
-         }
+         "output_throughput" => Hash,
+         "filter_throughput" => Hash,
+         "queue_backpressure" => Hash,
+         "worker_concurrency" => Hash,
+         "input_throughput" => Hash
        },
        "plugins" => {
           "inputs" => Array,

--- a/logstash-core/spec/logstash/api/modules/node_stats_spec.rb
+++ b/logstash-core/spec/logstash/api/modules/node_stats_spec.rb
@@ -87,8 +87,22 @@ describe LogStash::Api::Modules::NodeStats do
         "percent"=>Numeric,
         # load_average is not supported on Windows, set it below
       }
-    },
-    "pipelines" => {
+   },
+   "events" => {
+      "duration_in_millis" => Numeric,
+      "in" => Numeric,
+      "filtered" => Numeric,
+      "out" => Numeric,
+      "queue_push_duration_in_millis" => Numeric
+   },
+   "flow" => {
+      "output_throughput" => Hash,
+      "filter_throughput" => Hash,
+      "queue_backpressure" => Hash,
+      "worker_concurrency" => Hash,
+      "input_throughput" => Hash
+   },
+   "pipelines" => {
      "main" => {
        "events" => {
          "duration_in_millis" => Numeric,

--- a/logstash-core/spec/logstash/api/modules/node_stats_spec.rb
+++ b/logstash-core/spec/logstash/api/modules/node_stats_spec.rb
@@ -106,11 +106,11 @@ describe LogStash::Api::Modules::NodeStats do
            "lifetime" => Numeric,
            "current" => Numeric
          },
-         "backpressure" => {
+         "queue_backpressure" => {
            "lifetime" => Numeric,
            "current" => Numeric
          },
-         "concurrency" => {
+         "worker_concurrency" => {
            "lifetime" => Numeric,
            "current" => Numeric
          },

--- a/logstash-core/spec/logstash/instrument/wrapped_write_client_spec.rb
+++ b/logstash-core/spec/logstash/instrument/wrapped_write_client_spec.rb
@@ -110,29 +110,6 @@ describe LogStash::WrappedWriteClient do
           expect(snapshot_metric[:pipelines][:main][:plugins][:inputs][myid][:events][:queue_push_duration_in_millis].value).to be_kind_of(Integer)
         end
       end
-
-      context "with flow metrics" do
-        it "records input throughput metrics" do
-          expect(snapshot_metric[:flow][:input_throughput][:current].value).to be_kind_of(Numeric)
-          expect(snapshot_metric[:flow][:input_throughput][:lifetime].value).to be_kind_of(Numeric)
-        end
-        it "records output throughput metrics" do
-          expect(snapshot_metric[:flow][:output_throughput][:current].value).to be_kind_of(Numeric)
-          expect(snapshot_metric[:flow][:output_throughput][:lifetime].value).to be_kind_of(Numeric)
-        end
-        it "records filter throughput metrics" do
-          expect(snapshot_metric[:flow][:filter_throughput][:current].value).to be_kind_of(Numeric)
-          expect(snapshot_metric[:flow][:filter_throughput][:lifetime].value).to be_kind_of(Numeric)
-        end
-        it "records queue_backpressure metrics" do
-          expect(snapshot_metric[:flow][:queue_backpressure][:current].value).to be_kind_of(Numeric)
-          expect(snapshot_metric[:flow][:queue_backpressure][:lifetime].value).to be_kind_of(Numeric)
-        end
-        it "records worker_concurrency metrics" do
-          expect(snapshot_metric[:flow][:worker_concurrency][:current].value).to be_kind_of(Numeric)
-          expect(snapshot_metric[:flow][:worker_concurrency][:lifetime].value).to be_kind_of(Numeric)
-        end
-      end
     end
   end
 

--- a/logstash-core/spec/logstash/instrument/wrapped_write_client_spec.rb
+++ b/logstash-core/spec/logstash/instrument/wrapped_write_client_spec.rb
@@ -110,6 +110,29 @@ describe LogStash::WrappedWriteClient do
           expect(snapshot_metric[:pipelines][:main][:plugins][:inputs][myid][:events][:queue_push_duration_in_millis].value).to be_kind_of(Integer)
         end
       end
+
+      context "with flow metrics" do
+        it "records input throughput metrics" do
+          expect(snapshot_metric[:flow][:input_throughput][:current].value).to be_kind_of(Numeric)
+          expect(snapshot_metric[:flow][:input_throughput][:lifetime].value).to be_kind_of(Numeric)
+        end
+        it "records output throughput metrics" do
+          expect(snapshot_metric[:flow][:output_throughput][:current].value).to be_kind_of(Numeric)
+          expect(snapshot_metric[:flow][:output_throughput][:lifetime].value).to be_kind_of(Numeric)
+        end
+        it "records filter throughput metrics" do
+          expect(snapshot_metric[:flow][:filter_throughput][:current].value).to be_kind_of(Numeric)
+          expect(snapshot_metric[:flow][:filter_throughput][:lifetime].value).to be_kind_of(Numeric)
+        end
+        it "records backpressure metrics" do
+          expect(snapshot_metric[:flow][:backpressure][:current].value).to be_kind_of(Numeric)
+          expect(snapshot_metric[:flow][:backpressure][:lifetime].value).to be_kind_of(Numeric)
+        end
+        it "records concurrency metrics" do
+          expect(snapshot_metric[:flow][:concurrency][:current].value).to be_kind_of(Numeric)
+          expect(snapshot_metric[:flow][:concurrency][:lifetime].value).to be_kind_of(Numeric)
+        end
+      end
     end
   end
 

--- a/logstash-core/spec/logstash/instrument/wrapped_write_client_spec.rb
+++ b/logstash-core/spec/logstash/instrument/wrapped_write_client_spec.rb
@@ -124,13 +124,13 @@ describe LogStash::WrappedWriteClient do
           expect(snapshot_metric[:flow][:filter_throughput][:current].value).to be_kind_of(Numeric)
           expect(snapshot_metric[:flow][:filter_throughput][:lifetime].value).to be_kind_of(Numeric)
         end
-        it "records backpressure metrics" do
-          expect(snapshot_metric[:flow][:backpressure][:current].value).to be_kind_of(Numeric)
-          expect(snapshot_metric[:flow][:backpressure][:lifetime].value).to be_kind_of(Numeric)
+        it "records queue_backpressure metrics" do
+          expect(snapshot_metric[:flow][:queue_backpressure][:current].value).to be_kind_of(Numeric)
+          expect(snapshot_metric[:flow][:queue_backpressure][:lifetime].value).to be_kind_of(Numeric)
         end
-        it "records concurrency metrics" do
-          expect(snapshot_metric[:flow][:concurrency][:current].value).to be_kind_of(Numeric)
-          expect(snapshot_metric[:flow][:concurrency][:lifetime].value).to be_kind_of(Numeric)
+        it "records worker_concurrency metrics" do
+          expect(snapshot_metric[:flow][:worker_concurrency][:current].value).to be_kind_of(Numeric)
+          expect(snapshot_metric[:flow][:worker_concurrency][:lifetime].value).to be_kind_of(Numeric)
         end
       end
     end

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -456,6 +456,8 @@ public class AbstractPipelineExt extends RubyBasicObject {
 
     @JRubyMethod(name = "initialize_flow_metrics")
     public final IRubyObject initializeFlowMetrics(final ThreadContext context) {
+        if (metric.collector(context).isNil()) { return context.nil; }
+
         final UptimeMetric uptimeInMillis = initOrGetUptimeMetric(context, buildNamespace(), context.runtime.newSymbol("uptime_in_millis"));
         final UptimeMetric uptimeInSeconds = uptimeInMillis.withTimeUnit("uptime_in_seconds", TimeUnit.SECONDS);
 

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -31,9 +31,7 @@ import java.time.temporal.TemporalUnit;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -345,35 +343,24 @@ public class AbstractPipelineExt extends RubyBasicObject {
     @JRubyMethod(name = "collect_dlq_stats")
     public final IRubyObject collectDlqStats(final ThreadContext context) {
         if (dlqEnabled(context).isTrue()) {
-            getDlqMetric(context).gauge(
-                    context,
-                    QUEUE_SIZE_IN_BYTES_KEY,
-                    dlqWriter(context).callMethod(context, "get_current_queue_size")
-            );
-            getDlqMetric(context).gauge(
-                    context,
-                    STORAGE_POLICY_KEY,
-                    dlqWriter(context).callMethod(context, "get_storage_policy")
-            );
-            getDlqMetric(context).gauge(
-                    context,
-                    MAX_QUEUE_SIZE_IN_BYTES_KEY,
-                    getSetting(context, "dead_letter_queue.max_bytes").convertToInteger());
-            getDlqMetric(context).gauge(
-                    context,
-                    DROPPED_EVENTS_KEY,
-                    dlqWriter(context).callMethod(context, "get_dropped_events")
-            );
-            getDlqMetric(context).gauge(
-                    context,
-                    LAST_ERROR_KEY,
-                    dlqWriter(context).callMethod(context, "get_last_error")
-            );
-            getDlqMetric(context).gauge(
-                    context,
-                    EXPIRED_EVENTS_KEY,
-                    dlqWriter(context).callMethod(context, "get_expired_events")
-            );
+            getDlqMetric(context).gauge(context,
+                                        QUEUE_SIZE_IN_BYTES_KEY,
+                                        dlqWriter(context).callMethod(context, "get_current_queue_size"));
+            getDlqMetric(context).gauge(context,
+                                        STORAGE_POLICY_KEY,
+                                        dlqWriter(context).callMethod(context, "get_storage_policy"));
+            getDlqMetric(context).gauge(context,
+                                        MAX_QUEUE_SIZE_IN_BYTES_KEY,
+                                        getSetting(context, "dead_letter_queue.max_bytes").convertToInteger());
+            getDlqMetric(context).gauge(context,
+                                        DROPPED_EVENTS_KEY,
+                                        dlqWriter(context).callMethod(context, "get_dropped_events"));
+            getDlqMetric(context).gauge(context,
+                                        LAST_ERROR_KEY,
+                                        dlqWriter(context).callMethod(context, "get_last_error"));
+            getDlqMetric(context).gauge(context,
+                                        EXPIRED_EVENTS_KEY,
+                                        dlqWriter(context).callMethod(context, "get_expired_events"));
         }
         return context.nil;
     }
@@ -390,15 +377,8 @@ public class AbstractPipelineExt extends RubyBasicObject {
 
     @JRubyMethod(name = "collect_stats")
     public final IRubyObject collectStats(final ThreadContext context) throws IOException {
-        final AbstractNamespacedMetricExt pipelineMetric = metric.namespace(
-            context,
-            RubyArray.newArray(
-                context.runtime,
-                Arrays.asList(
-                        STATS_KEY,
-                        PIPELINES_KEY,
-                        pipelineId.asString().intern(),
-                        QUEUE_KEY)));
+        final AbstractNamespacedMetricExt pipelineMetric =
+                metric.namespace(context, pipelineNamespacedPath(QUEUE_KEY));
 
         pipelineMetric.gauge(context, TYPE_KEY, getSetting(context, "queue.type"));
         if (queue instanceof JRubyWrappedAckedQueueExt) {
@@ -406,28 +386,19 @@ public class AbstractPipelineExt extends RubyBasicObject {
             final RubyString dirPath = inner.ruby_dir_path(context);
             final AbstractNamespacedMetricExt capacityMetrics =
                 pipelineMetric.namespace(context, CAPACITY_NAMESPACE);
-            capacityMetrics.gauge(
-                context, PAGE_CAPACITY_IN_BYTES_KEY, inner.ruby_page_capacity(context)
-            );
-            capacityMetrics.gauge(
-                context, MAX_QUEUE_SIZE_IN_BYTES_KEY, inner.ruby_max_size_in_bytes(context)
-            );
-            capacityMetrics.gauge(
-                context, MAX_QUEUE_UNREAD_EVENTS_KEY, inner.ruby_max_unread_events(context)
-            );
-            capacityMetrics.gauge(
-                context, QUEUE_SIZE_IN_BYTES_KEY, inner.ruby_persisted_size_in_bytes(context)
-            );
+
+            capacityMetrics.gauge(context, PAGE_CAPACITY_IN_BYTES_KEY, inner.ruby_page_capacity(context));
+            capacityMetrics.gauge(context, MAX_QUEUE_SIZE_IN_BYTES_KEY, inner.ruby_max_size_in_bytes(context));
+            capacityMetrics.gauge(context, MAX_QUEUE_UNREAD_EVENTS_KEY, inner.ruby_max_unread_events(context));
+            capacityMetrics.gauge(context, QUEUE_SIZE_IN_BYTES_KEY, inner.ruby_persisted_size_in_bytes(context));
+
             final AbstractNamespacedMetricExt dataMetrics =
                 pipelineMetric.namespace(context, DATA_NAMESPACE);
             final FileStore fileStore = Files.getFileStore(Paths.get(dirPath.asJavaString()));
-            dataMetrics.gauge(
-                context,
-                FREE_SPACE_IN_BYTES_KEY,
-                context.runtime.newFixnum(fileStore.getUnallocatedSpace())
-            );
+            dataMetrics.gauge(context, FREE_SPACE_IN_BYTES_KEY, context.runtime.newFixnum(fileStore.getUnallocatedSpace()));
             dataMetrics.gauge(context, STORAGE_TYPE_KEY, context.runtime.newString(fileStore.type()));
             dataMetrics.gauge(context, PATH_KEY, dirPath);
+
             pipelineMetric.gauge(context, EVENTS_KEY, inner.ruby_unread_count(context));
         }
         return context.nil;
@@ -438,7 +409,7 @@ public class AbstractPipelineExt extends RubyBasicObject {
     public final IRubyObject initializeFlowMetrics(final ThreadContext context) {
         if (metric.collector(context).isNil()) { return context.nil; }
 
-        final UptimeMetric uptimeMetric = initOrGetUptimeMetric(context, buildNamespace(), context.runtime.newSymbol("uptime_in_millis"));
+        final UptimeMetric uptimeMetric = initOrGetUptimeMetric(context, buildNamespace(), UPTIME_IN_MILLIS_KEY);
         final Metric<Number> uptimeInPreciseMillis = uptimeMetric.withUnitsPrecise(MILLISECONDS);
         final Metric<Number> uptimeInPreciseSeconds = uptimeMetric.withUnitsPrecise(SECONDS);
 
@@ -485,31 +456,31 @@ public class AbstractPipelineExt extends RubyBasicObject {
         return new FlowMetric(name.asJavaString(), numeratorMetric, denominatorMetric);
     }
 
-    LongCounter initOrGetCounterMetric(final ThreadContext context,
-                                       final RubySymbol[] subPipelineNamespacePath,
-                                       final RubySymbol metricName) {
+    private LongCounter initOrGetCounterMetric(final ThreadContext context,
+                                               final RubySymbol[] subPipelineNamespacePath,
+                                               final RubySymbol metricName) {
         final IRubyObject collector = this.metric.collector(context);
-        final IRubyObject fullNamespace = RubyArray.newArray(context.runtime, fullNamespacePath(subPipelineNamespacePath));
+        final IRubyObject fullNamespace = pipelineNamespacedPath(subPipelineNamespacePath);
 
         final IRubyObject retrievedMetric = collector.callMethod(context, "get", new IRubyObject[]{fullNamespace, metricName, context.runtime.newSymbol("counter")});
         return retrievedMetric.toJava(LongCounter.class);
     }
 
-    UptimeMetric initOrGetUptimeMetric(final ThreadContext context,
-                                       final RubySymbol[] subPipelineNamespacePath,
-                                       final RubySymbol uptimeMetricName) {
+    private UptimeMetric initOrGetUptimeMetric(final ThreadContext context,
+                                               final RubySymbol[] subPipelineNamespacePath,
+                                               final RubySymbol uptimeMetricName) {
         final IRubyObject collector = this.metric.collector(context);
-        final IRubyObject fullNamespace = RubyArray.newArray(context.runtime, fullNamespacePath(subPipelineNamespacePath));
+        final IRubyObject fullNamespace = pipelineNamespacedPath(subPipelineNamespacePath);
 
         final IRubyObject retrievedMetric = collector.callMethod(context, "get", new IRubyObject[]{fullNamespace, uptimeMetricName, context.runtime.newSymbol("uptime")});
         return retrievedMetric.toJava(UptimeMetric.class);
     }
 
-    <T> void storeMetric(final ThreadContext context,
-                         final RubySymbol[] subPipelineNamespacePath,
-                         final Metric<T> metric) {
+    private <T> void storeMetric(final ThreadContext context,
+                                 final RubySymbol[] subPipelineNamespacePath,
+                                 final Metric<T> metric) {
         final IRubyObject collector = this.metric.collector(context);
-        final IRubyObject fullNamespace = RubyArray.newArray(context.runtime, fullNamespacePath(subPipelineNamespacePath));
+        final IRubyObject fullNamespace = pipelineNamespacedPath(subPipelineNamespacePath);
         final IRubyObject metricKey = context.runtime.newSymbol(metric.getName());
 
         final IRubyObject wasRegistered = collector.callMethod(context, "register?", new IRubyObject[]{fullNamespace, metricKey, JavaUtil.convertJavaToUsableRubyObject(context.runtime, metric)});
@@ -520,17 +491,23 @@ public class AbstractPipelineExt extends RubyBasicObject {
         }
     }
 
-    RubySymbol[] fullNamespacePath(RubySymbol... subPipelineNamespacePath) {
+    private RubyArray<RubySymbol> pipelineNamespacedPath(final RubySymbol... subPipelineNamespacePath) {
         final RubySymbol[] pipelineNamespacePath = new RubySymbol[] { STATS_KEY, PIPELINES_KEY, pipelineId.asString().intern() };
         if (subPipelineNamespacePath.length == 0) {
-            return pipelineNamespacePath;
+            return rubySymbolArray(pipelineNamespacePath);
         }
         final RubySymbol[] fullNamespacePath = Arrays.copyOf(pipelineNamespacePath, pipelineNamespacePath.length + subPipelineNamespacePath.length);
         System.arraycopy(subPipelineNamespacePath, 0, fullNamespacePath, pipelineNamespacePath.length, subPipelineNamespacePath.length);
-        return fullNamespacePath;
+
+        return rubySymbolArray(fullNamespacePath);
     }
 
-    RubySymbol[] buildNamespace(final RubySymbol... namespace) {
+    @SuppressWarnings("unchecked")
+    private RubyArray<RubySymbol> rubySymbolArray(final RubySymbol[] symbols) {
+        return getRuntime().newArray(symbols);
+    }
+
+    private RubySymbol[] buildNamespace(final RubySymbol... namespace) {
         return namespace;
     }
 
@@ -608,14 +585,7 @@ public class AbstractPipelineExt extends RubyBasicObject {
 
     private AbstractNamespacedMetricExt getDlqMetric(final ThreadContext context) {
         if (dlqMetric == null) {
-            dlqMetric = metric.namespace(
-                context, RubyArray.newArray(
-                    context.runtime,
-                    Arrays.asList(
-                            STATS_KEY,
-                            PIPELINES_KEY,
-                            pipelineId.asString().intern(),
-                            DLQ_KEY)));
+            dlqMetric = metric.namespace(context, pipelineNamespacedPath(DLQ_KEY));
         }
         return dlqMetric;
     }

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -72,13 +72,14 @@ import org.logstash.instrument.metrics.AbstractMetricExt;
 import org.logstash.instrument.metrics.AbstractNamespacedMetricExt;
 import org.logstash.instrument.metrics.FlowMetric;
 import org.logstash.instrument.metrics.Metric;
-import org.logstash.instrument.metrics.MetricKeys;
 import org.logstash.instrument.metrics.NullMetricExt;
 import org.logstash.instrument.metrics.UptimeMetric;
 import org.logstash.instrument.metrics.counter.LongCounter;
 import org.logstash.plugins.ConfigVariableExpander;
 import org.logstash.secret.store.SecretStore;
 import org.logstash.secret.store.SecretStoreExt;
+
+import static org.logstash.instrument.metrics.MetricKeys.*;
 
 /**
  * JRuby extension to provide ancestor class for Ruby's Pipeline and JavaPipeline classes.
@@ -96,45 +97,8 @@ public class AbstractPipelineExt extends RubyBasicObject {
     private static final @SuppressWarnings("rawtypes") RubyArray DATA_NAMESPACE =
         RubyArray.newArray(RubyUtil.RUBY, RubyUtil.RUBY.newSymbol("data"));
 
-    private static final RubySymbol PAGE_CAPACITY_IN_BYTES =
-        RubyUtil.RUBY.newSymbol("page_capacity_in_bytes");
-
-    private static final RubySymbol MAX_QUEUE_SIZE_IN_BYTES =
-        RubyUtil.RUBY.newSymbol("max_queue_size_in_bytes");
-
-    private static final RubySymbol MAX_QUEUE_UNREAD_EVENTS =
-        RubyUtil.RUBY.newSymbol("max_unread_events");
-
-    private static final RubySymbol QUEUE_SIZE_IN_BYTES =
-        RubyUtil.RUBY.newSymbol("queue_size_in_bytes");
-
-    private static final RubySymbol FREE_SPACE_IN_BYTES =
-        RubyUtil.RUBY.newSymbol("free_space_in_bytes");
-
-    private static final RubySymbol STORAGE_TYPE = RubyUtil.RUBY.newSymbol("storage_type");
-
-    private static final RubySymbol PATH = RubyUtil.RUBY.newSymbol("path");
-
-    private static final RubySymbol TYPE_KEY = RubyUtil.RUBY.newSymbol("type");
-
-    private static final RubySymbol QUEUE_KEY = RubyUtil.RUBY.newSymbol("queue");
-
-    private static final RubySymbol DLQ_KEY = RubyUtil.RUBY.newSymbol("dlq");
-
-    private static final RubySymbol STORAGE_POLICY =
-            RubyUtil.RUBY.newSymbol("storage_policy");
-
-    private static final RubySymbol DROPPED_EVENTS =
-            RubyUtil.RUBY.newSymbol("dropped_events");
-
-    private static final RubySymbol EXPIRED_EVENTS =
-            RubyUtil.RUBY.newSymbol("expired_events");
-
-    private static final RubySymbol LAST_ERROR =
-            RubyUtil.RUBY.newSymbol("last_error");
-
     private static final @SuppressWarnings("rawtypes") RubyArray EVENTS_METRIC_NAMESPACE = RubyArray.newArray(
-        RubyUtil.RUBY, new IRubyObject[]{MetricKeys.STATS_KEY, MetricKeys.EVENTS_KEY}
+        RubyUtil.RUBY, new IRubyObject[]{STATS_KEY, EVENTS_KEY}
     );
 
     @SuppressWarnings("serial")
@@ -222,7 +186,7 @@ public class AbstractPipelineExt extends RubyBasicObject {
     }
 
     /**
-     * queue opening needs to happen out of the the initialize method because the
+     * queue opening needs to happen out of the initialize method because the
      * AbstractPipeline is used for pipeline config validation and the queue
      * should not be opened for this. This should be called only in the actual
      * Pipeline/JavaPipeline initialisation.
@@ -247,8 +211,10 @@ public class AbstractPipelineExt extends RubyBasicObject {
                 RubyArray.newArray(
                     context.runtime,
                     new IRubyObject[]{
-                        MetricKeys.STATS_KEY, MetricKeys.PIPELINES_KEY,
-                        pipelineId.convertToString().intern(), MetricKeys.EVENTS_KEY
+                            STATS_KEY,
+                            PIPELINES_KEY,
+                            pipelineId.convertToString().intern(),
+                            EVENTS_KEY
                     }
                 )
             )
@@ -377,26 +343,32 @@ public class AbstractPipelineExt extends RubyBasicObject {
     public final IRubyObject collectDlqStats(final ThreadContext context) {
         if (dlqEnabled(context).isTrue()) {
             getDlqMetric(context).gauge(
-                context, QUEUE_SIZE_IN_BYTES,
-                dlqWriter(context).callMethod(context, "get_current_queue_size")
+                    context,
+                    QUEUE_SIZE_IN_BYTES_KEY,
+                    dlqWriter(context).callMethod(context, "get_current_queue_size")
             );
             getDlqMetric(context).gauge(
-                    context, STORAGE_POLICY,
+                    context,
+                    STORAGE_POLICY_KEY,
                     dlqWriter(context).callMethod(context, "get_storage_policy")
             );
             getDlqMetric(context).gauge(
-                    context, MAX_QUEUE_SIZE_IN_BYTES,
+                    context,
+                    MAX_QUEUE_SIZE_IN_BYTES_KEY,
                     getSetting(context, "dead_letter_queue.max_bytes").convertToInteger());
             getDlqMetric(context).gauge(
-                    context, DROPPED_EVENTS,
+                    context,
+                    DROPPED_EVENTS_KEY,
                     dlqWriter(context).callMethod(context, "get_dropped_events")
             );
             getDlqMetric(context).gauge(
-                    context, LAST_ERROR,
+                    context,
+                    LAST_ERROR_KEY,
                     dlqWriter(context).callMethod(context, "get_last_error")
             );
             getDlqMetric(context).gauge(
-                    context, EXPIRED_EVENTS,
+                    context,
+                    EXPIRED_EVENTS_KEY,
                     dlqWriter(context).callMethod(context, "get_expired_events")
             );
         }
@@ -419,9 +391,12 @@ public class AbstractPipelineExt extends RubyBasicObject {
             context,
             RubyArray.newArray(
                 context.runtime,
-                Arrays.asList(MetricKeys.STATS_KEY, MetricKeys.PIPELINES_KEY, pipelineId.asString().intern(), QUEUE_KEY)
-            )
-        );
+                Arrays.asList(
+                        STATS_KEY,
+                        PIPELINES_KEY,
+                        pipelineId.asString().intern(),
+                        QUEUE_KEY)));
+
         pipelineMetric.gauge(context, TYPE_KEY, getSetting(context, "queue.type"));
         if (queue instanceof JRubyWrappedAckedQueueExt) {
             final JRubyAckedQueueExt inner = ((JRubyWrappedAckedQueueExt) queue).rubyGetQueue();
@@ -429,27 +404,28 @@ public class AbstractPipelineExt extends RubyBasicObject {
             final AbstractNamespacedMetricExt capacityMetrics =
                 pipelineMetric.namespace(context, CAPACITY_NAMESPACE);
             capacityMetrics.gauge(
-                context, PAGE_CAPACITY_IN_BYTES, inner.ruby_page_capacity(context)
+                context, PAGE_CAPACITY_IN_BYTES_KEY, inner.ruby_page_capacity(context)
             );
             capacityMetrics.gauge(
-                context, MAX_QUEUE_SIZE_IN_BYTES, inner.ruby_max_size_in_bytes(context)
+                context, MAX_QUEUE_SIZE_IN_BYTES_KEY, inner.ruby_max_size_in_bytes(context)
             );
             capacityMetrics.gauge(
-                context, MAX_QUEUE_UNREAD_EVENTS, inner.ruby_max_unread_events(context)
+                context, MAX_QUEUE_UNREAD_EVENTS_KEY, inner.ruby_max_unread_events(context)
             );
             capacityMetrics.gauge(
-                context, QUEUE_SIZE_IN_BYTES, inner.ruby_persisted_size_in_bytes(context)
+                context, QUEUE_SIZE_IN_BYTES_KEY, inner.ruby_persisted_size_in_bytes(context)
             );
             final AbstractNamespacedMetricExt dataMetrics =
                 pipelineMetric.namespace(context, DATA_NAMESPACE);
             final FileStore fileStore = Files.getFileStore(Paths.get(dirPath.asJavaString()));
             dataMetrics.gauge(
-                context, FREE_SPACE_IN_BYTES,
+                context,
+                FREE_SPACE_IN_BYTES_KEY,
                 context.runtime.newFixnum(fileStore.getUnallocatedSpace())
             );
-            dataMetrics.gauge(context, STORAGE_TYPE, context.runtime.newString(fileStore.type()));
-            dataMetrics.gauge(context, PATH, dirPath);
-            pipelineMetric.gauge(context, MetricKeys.EVENTS_KEY, inner.ruby_unread_count(context));
+            dataMetrics.gauge(context, STORAGE_TYPE_KEY, context.runtime.newString(fileStore.type()));
+            dataMetrics.gauge(context, PATH_KEY, dirPath);
+            pipelineMetric.gauge(context, EVENTS_KEY, inner.ruby_unread_count(context));
         }
         return context.nil;
     }
@@ -458,36 +434,41 @@ public class AbstractPipelineExt extends RubyBasicObject {
     public final IRubyObject initializeFlowMetrics(final ThreadContext context) {
         if (metric.collector(context).isNil()) { return context.nil; }
 
-        final UptimeMetric uptimeInMillis = initOrGetUptimeMetric(context, buildNamespace(), context.runtime.newSymbol("uptime_in_millis"));
-        final UptimeMetric uptimeInSeconds = uptimeInMillis.withTimeUnit("uptime_in_seconds", TimeUnit.SECONDS);
+        final UptimeMetric uptimeInMillis = initOrGetUptimeMetric(context, buildNamespace(),
+                RubyUtil.RUBY.newSymbol(UPTIME_IN_MILLIS_KEY.asJavaString()));
+        final UptimeMetric uptimeInSeconds = uptimeInMillis.withTimeUnit(UPTIME_IN_SECONDS_KEY.asJavaString(),
+                TimeUnit.SECONDS);
 
-        final RubySymbol flowKey = context.runtime.newSymbol("flow");
-        final RubySymbol[] flowNamespace = buildNamespace(flowKey);
+        final RubySymbol[] flowNamespace = buildNamespace(FLOW_KEY);
+        final RubySymbol[] eventsNamespace = buildNamespace(EVENTS_KEY);
 
-        final RubySymbol[] eventsNamespace = buildNamespace(MetricKeys.EVENTS_KEY);
-
-        final LongCounter eventsInCounter = initOrGetCounterMetric(context, eventsNamespace, MetricKeys.IN_KEY);
-        final FlowMetric inputThroughput = new FlowMetric("input_throughput", eventsInCounter, uptimeInSeconds);
+        final LongCounter eventsInCounter = initOrGetCounterMetric(context, eventsNamespace, IN_KEY);
+        final FlowMetric inputThroughput = new FlowMetric(INPUT_THROUGHPUT_KEY.asJavaString(),
+                eventsInCounter, uptimeInSeconds);
         this.flowMetrics.add(inputThroughput);
         storeMetric(context, flowNamespace, inputThroughput);
 
-        final LongCounter eventsFilteredCounter = initOrGetCounterMetric(context, eventsNamespace, MetricKeys.FILTERED_KEY);
-        final FlowMetric filterThroughput = new FlowMetric("filter_throughput", eventsFilteredCounter, uptimeInSeconds);
+        final LongCounter eventsFilteredCounter = initOrGetCounterMetric(context, eventsNamespace, FILTERED_KEY);
+        final FlowMetric filterThroughput = new FlowMetric(FILTER_THROUGHPUT_KEY.asJavaString(),
+                eventsFilteredCounter, uptimeInSeconds);
         this.flowMetrics.add(filterThroughput);
         storeMetric(context, flowNamespace, filterThroughput);
 
-        final LongCounter eventsOutCounter = initOrGetCounterMetric(context, eventsNamespace, MetricKeys.OUT_KEY);
-        final FlowMetric outputThroughput = new FlowMetric("output_throughput", eventsOutCounter, uptimeInSeconds);
+        final LongCounter eventsOutCounter = initOrGetCounterMetric(context, eventsNamespace, OUT_KEY);
+        final FlowMetric outputThroughput = new FlowMetric(OUTPUT_THROUGHPUT_KEY.asJavaString(),
+                eventsOutCounter, uptimeInSeconds);
         this.flowMetrics.add(outputThroughput);
         storeMetric(context, flowNamespace, outputThroughput);
 
-        final LongCounter queuePushWaitInMillis = initOrGetCounterMetric(context, eventsNamespace, JRubyWrappedWriteClientExt.PUSH_DURATION_KEY);
-        final FlowMetric backpressureFlow = new FlowMetric("queue_backpressure", queuePushWaitInMillis, uptimeInMillis);
+        final LongCounter queuePushWaitInMillis = initOrGetCounterMetric(context, eventsNamespace, PUSH_DURATION_KEY);
+        final FlowMetric backpressureFlow = new FlowMetric(QUEUE_BACKPRESSURE_KEY.asJavaString(),
+                queuePushWaitInMillis, uptimeInMillis);
         this.flowMetrics.add(backpressureFlow);
         storeMetric(context, flowNamespace, backpressureFlow);
 
-        final LongCounter durationInMillis = initOrGetCounterMetric(context, eventsNamespace, MetricKeys.DURATION_IN_MILLIS_KEY);
-        final FlowMetric concurrencyFlow = new FlowMetric("worker_concurrency", durationInMillis, uptimeInMillis);
+        final LongCounter durationInMillis = initOrGetCounterMetric(context, eventsNamespace, DURATION_IN_MILLIS_KEY);
+        final FlowMetric concurrencyFlow = new FlowMetric(WORKER_CONCURRENCY_KEY.asJavaString(),
+                durationInMillis, uptimeInMillis);
         this.flowMetrics.add(concurrencyFlow);
         storeMetric(context, flowNamespace, concurrencyFlow);
 
@@ -520,7 +501,6 @@ public class AbstractPipelineExt extends RubyBasicObject {
         return retrievedMetric.toJava(UptimeMetric.class);
     }
 
-
     <T> void storeMetric(final ThreadContext context,
                          final RubySymbol[] subPipelineNamespacePath,
                          final Metric<T> metric) {
@@ -534,11 +514,10 @@ public class AbstractPipelineExt extends RubyBasicObject {
         } else {
             LOGGER.debug(String.format("Flow metric registered: `%s` in namespace `%s`", metricKey, fullNamespace));
         }
-
     }
 
-    RubySymbol[] fullNamespacePath(RubySymbol... subPipelineNamespacePath){
-        final RubySymbol[] pipelineNamespacePath = new RubySymbol[] { MetricKeys.STATS_KEY, MetricKeys.PIPELINES_KEY, pipelineId.asString().intern() };
+    RubySymbol[] fullNamespacePath(RubySymbol... subPipelineNamespacePath) {
+        final RubySymbol[] pipelineNamespacePath = new RubySymbol[] { STATS_KEY, PIPELINES_KEY, pipelineId.asString().intern() };
         if (subPipelineNamespacePath.length == 0) {
             return pipelineNamespacePath;
         }
@@ -550,7 +529,6 @@ public class AbstractPipelineExt extends RubyBasicObject {
     RubySymbol[] buildNamespace(final RubySymbol... namespace) {
         return namespace;
     }
-
 
     @JRubyMethod(name = "input_queue_client")
     public final JRubyAbstractQueueWriteClientExt inputQueueClient() {
@@ -630,11 +608,10 @@ public class AbstractPipelineExt extends RubyBasicObject {
                 context, RubyArray.newArray(
                     context.runtime,
                     Arrays.asList(
-                        MetricKeys.STATS_KEY, MetricKeys.PIPELINES_KEY,
-                        pipelineId.asString().intern(), DLQ_KEY
-                    )
-                )
-            );
+                            STATS_KEY,
+                            PIPELINES_KEY,
+                            pipelineId.asString().intern(),
+                            DLQ_KEY)));
         }
         return dlqMetric;
     }

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -480,12 +480,12 @@ public class AbstractPipelineExt extends RubyBasicObject {
         storeMetric(context, flowNamespace, outputThroughput);
 
         final LongCounter queuePushWaitInMillis = initOrGetCounterMetric(context, eventsNamespace, JRubyWrappedWriteClientExt.PUSH_DURATION_KEY);
-        final FlowMetric backpressureFlow = new FlowMetric("backpressure", queuePushWaitInMillis, uptimeInMillis);
+        final FlowMetric backpressureFlow = new FlowMetric("queue_backpressure", queuePushWaitInMillis, uptimeInMillis);
         this.flowMetrics.add(backpressureFlow);
         storeMetric(context, flowNamespace, backpressureFlow);
 
         final LongCounter durationInMillis = initOrGetCounterMetric(context, eventsNamespace, MetricKeys.DURATION_IN_MILLIS_KEY);
-        final FlowMetric concurrencyFlow = new FlowMetric("concurrency", durationInMillis, uptimeInMillis);
+        final FlowMetric concurrencyFlow = new FlowMetric("worker_concurrency", durationInMillis, uptimeInMillis);
         this.flowMetrics.add(concurrencyFlow);
         storeMetric(context, flowNamespace, concurrencyFlow);
 

--- a/logstash-core/src/main/java/org/logstash/ext/JRubyWrappedWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JRubyWrappedWriteClientExt.java
@@ -44,7 +44,7 @@ public final class JRubyWrappedWriteClientExt extends RubyObject implements Queu
 
     private static final long serialVersionUID = 1L;
 
-    private static final RubySymbol PUSH_DURATION_KEY =
+    public static final RubySymbol PUSH_DURATION_KEY =
         RubyUtil.RUBY.newSymbol("queue_push_duration_in_millis");
 
     private JRubyAbstractQueueWriteClientExt writeClient;

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractMetric.java
@@ -23,6 +23,8 @@ package org.logstash.instrument.metrics;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.Objects;
+
 /**
  * Abstract implementation of a {@link Metric}. All metrics should subclass this.
  *
@@ -48,8 +50,7 @@ public abstract class AbstractMetric<T> implements Metric<T> {
 
     @Override
     public String toString() {
-        return String.format("%s -  name: %s value:%s", this.getClass().getName(), this.name, getValue() == null ? "null" :
-                getValue().toString());
+        return String.format("%s -  name: %s value:%s", this.getClass().getName(), this.name, Objects.requireNonNullElse(getValue(),"null"));
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowMetric.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.logstash.instrument.metrics;
 
 import java.math.BigDecimal;
@@ -6,8 +25,11 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalDouble;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 
 public class FlowMetric extends AbstractMetric<Map<String,Double>> {
 
@@ -57,6 +79,9 @@ public class FlowMetric extends AbstractMetric<Map<String,Double>> {
         });
     }
 
+    /**
+     * @return a map containing all available finite rates (see {@link Capture#calculateRate(Capture)})
+     */
     public Map<String, Double> getValue() {
         final Capture headCapture = head.get();
         if (Objects.isNull(headCapture)) {
@@ -65,17 +90,8 @@ public class FlowMetric extends AbstractMetric<Map<String,Double>> {
 
         final Map<String, Double> rates = new HashMap<>();
 
-        final Double lifetimeRate = headCapture.calculateRate(baseline);
-
-        if (Objects.nonNull(lifetimeRate)) {
-            rates.put(LIFETIME_KEY, lifetimeRate);
-        }
-
-        final Capture instantCapture = instant.get();
-        final Double currentRate = headCapture.calculateRate(instantCapture);
-        if (Objects.nonNull(currentRate)) {
-            rates.put(CURRENT_KEY, currentRate);
-        }
+        headCapture.calculateRate(baseline).ifPresent((rate) -> rates.put(LIFETIME_KEY, rate));
+        headCapture.calculateRate(instant::get).ifPresent((rate) -> rates.put(CURRENT_KEY,  rate));
 
         return Map.copyOf(rates);
     }
@@ -101,20 +117,37 @@ public class FlowMetric extends AbstractMetric<Map<String,Double>> {
             this.nanoTimestamp = nanoTimestamp;
         }
 
-        Double calculateRate(final Capture baseline) {
-            if (Objects.isNull(baseline)) { return null; }
-            if (baseline == this) { return null; }
+        /**
+         *
+         * @param baseline a non-null {@link Capture} from which to compare.
+         * @return an {@link OptionalDouble} that will be non-empty IFF we have sufficient information
+         *         to calculate a finite rate of change of the numerator relative to the denominator.
+         */
+        OptionalDouble calculateRate(final Capture baseline) {
+            Objects.requireNonNull(baseline, "baseline");
+            if (baseline == this) { return OptionalDouble.empty(); }
 
             final double deltaNumerator = this.numerator.doubleValue() - baseline.numerator.doubleValue();
             final double deltaDenominator = this.denominator.doubleValue() - baseline.denominator.doubleValue();
 
             // divide-by-zero safeguard
-            if (deltaDenominator == 0.0) { return null; }
+            if (deltaDenominator == 0.0) { return OptionalDouble.empty(); }
 
             // To prevent the appearance of false-precision, we round to 3 decimal places.
-            return BigDecimal.valueOf(deltaNumerator)
-                    .divide(BigDecimal.valueOf(deltaDenominator), 3, RoundingMode.HALF_UP)
-                    .doubleValue();
+            return OptionalDouble.of(BigDecimal.valueOf(deltaNumerator)
+                                               .divide(BigDecimal.valueOf(deltaDenominator), 3, RoundingMode.HALF_UP)
+                                               .doubleValue());
+        }
+
+        /**
+         * @param possibleBaseline a {@link Supplier<Capture>} that may return null
+         * @return an {@link OptionalDouble} that will be non-empty IFF we have sufficient information
+         *         to calculate a finite rate of change of the numerator relative to the denominator.
+         */
+        OptionalDouble calculateRate(final Supplier<Capture> possibleBaseline) {
+            return Optional.ofNullable(possibleBaseline.get())
+                           .map(this::calculateRate)
+                           .orElseGet(OptionalDouble::empty);
         }
 
         Duration calculateCapturePeriod(final Capture baseline) {

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowMetric.java
@@ -67,7 +67,7 @@ public class FlowMetric extends AbstractMetric<Map<String,Double>> {
 
     @Override
     public MetricType getType() {
-        return MetricType.FLOW_RATES;
+        return MetricType.FLOW_RATE;
     }
 
     private static class Capture {

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowMetric.java
@@ -38,7 +38,7 @@ public class FlowMetric extends AbstractMetric<Map<String,Double>> {
         instant.set(previousHead);
     }
 
-    public Map<String,Double> getValue() {
+    public Map<String, Double> getValue() {
         final Capture headCapture = head.get();
         if (Objects.isNull(headCapture)) {
             return Map.of();
@@ -85,6 +85,9 @@ public class FlowMetric extends AbstractMetric<Map<String,Double>> {
 
             final double deltaNumerator = this.numerator.doubleValue() - baseline.numerator.doubleValue();
             final double deltaDenominator = this.denominator.doubleValue() - baseline.denominator.doubleValue();
+
+            // divide-by-zero safeguard
+            if (deltaDenominator == 0.0) { return null; }
 
             // To prevent the appearance of false-precision, we round to 3 decimal places.
             return BigDecimal.valueOf(deltaNumerator)

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowMetric.java
@@ -1,0 +1,95 @@
+package org.logstash.instrument.metrics;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class FlowMetric extends AbstractMetric<Map<String,Double>> {
+
+    // metric sources
+    private final Metric<? extends Number> numeratorMetric;
+    private final Metric<? extends Number> denominatorMetric;
+
+    // useful capture nodes for calculation
+    private final Capture baseline;
+
+    private final AtomicReference<Capture> head;
+    private final AtomicReference<Capture> instant = new AtomicReference<>();
+
+    static final String LIFETIME_KEY = "lifetime";
+    static final String CURRENT_KEY = "current";
+
+    public FlowMetric(final String name,
+                      final Metric<? extends Number> numeratorMetric,
+                      final Metric<? extends Number> denominatorMetric) {
+        super(name);
+        this.numeratorMetric = numeratorMetric;
+        this.denominatorMetric = denominatorMetric;
+
+        this.baseline = doCapture();
+        this.head = new AtomicReference<>(this.baseline);
+    }
+
+    public void capture() {
+        final Capture previousHead = head.getAndSet(doCapture());
+        instant.set(previousHead);
+    }
+
+    public Map<String,Double> getValue() {
+        final Capture headCapture = head.get();
+        if (Objects.isNull(headCapture)) {
+            return Map.of();
+        }
+
+        final Map<String, Double> rates = new HashMap<>();
+
+        final Double lifetimeRate = headCapture.calculateRate(baseline);
+
+        if (Objects.nonNull(lifetimeRate)) {
+            rates.put(LIFETIME_KEY, lifetimeRate);
+        }
+
+        final Capture instantCapture = instant.get();
+        final Double currentRate = headCapture.calculateRate(instantCapture);
+        if (Objects.nonNull(currentRate)) {
+            rates.put(CURRENT_KEY, currentRate);
+        }
+
+        return Map.copyOf(rates);
+    }
+
+    Capture doCapture() {
+        return new Capture(numeratorMetric.getValue(), denominatorMetric.getValue());
+    }
+
+    @Override
+    public MetricType getType() {
+        return MetricType.FLOW_RATES;
+    }
+
+    private static class Capture {
+        private final Number numerator;
+        private final Number denominator;
+
+        public Capture(final Number numerator, final Number denominator) {
+            this.numerator = numerator;
+            this.denominator = denominator;
+        }
+
+        Double calculateRate(final Capture baseline) {
+            if (Objects.isNull(baseline)) { return null; }
+            if (baseline == this) { return null; }
+
+            final double deltaNumerator = this.numerator.doubleValue() - baseline.numerator.doubleValue();
+            final double deltaDenominator = this.denominator.doubleValue() - baseline.denominator.doubleValue();
+
+            // To prevent the appearance of false-precision, we round to 3 decimal places.
+            return BigDecimal.valueOf(deltaNumerator)
+                    .divide(BigDecimal.valueOf(deltaDenominator), 3, RoundingMode.HALF_UP)
+                    .doubleValue();
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricKeys.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricKeys.java
@@ -39,10 +39,60 @@ public final class MetricKeys {
 
     public static final RubySymbol IN_KEY = RubyUtil.RUBY.newSymbol("in");
 
-    public static final RubySymbol DURATION_IN_MILLIS_KEY =
-        RubyUtil.RUBY.newSymbol("duration_in_millis");
+    public static final RubySymbol PLUGINS_KEY = RubyUtil.RUBY.newSymbol("plugins");
+
+    public static final RubySymbol INPUTS_KEY = RubyUtil.RUBY.newSymbol("inputs");
+
+    public static final RubySymbol DURATION_IN_MILLIS_KEY = RubyUtil.RUBY.newSymbol("duration_in_millis");
+
+    public static final RubySymbol PUSH_DURATION_KEY = RubyUtil.RUBY.newSymbol("queue_push_duration_in_millis");
+
+    public static final RubySymbol PAGE_CAPACITY_IN_BYTES_KEY = RubyUtil.RUBY.newSymbol("page_capacity_in_bytes");
+
+    public static final RubySymbol MAX_QUEUE_SIZE_IN_BYTES_KEY = RubyUtil.RUBY.newSymbol("max_queue_size_in_bytes");
+
+    public static final RubySymbol MAX_QUEUE_UNREAD_EVENTS_KEY = RubyUtil.RUBY.newSymbol("max_unread_events");
+
+    public static final RubySymbol QUEUE_SIZE_IN_BYTES_KEY = RubyUtil.RUBY.newSymbol("queue_size_in_bytes");
+
+    public static final RubySymbol FREE_SPACE_IN_BYTES_KEY = RubyUtil.RUBY.newSymbol("free_space_in_bytes");
+
+    public static final RubySymbol STORAGE_TYPE_KEY = RubyUtil.RUBY.newSymbol("storage_type");
+
+    public static final RubySymbol PATH_KEY = RubyUtil.RUBY.newSymbol("path");
+
+    public static final RubySymbol TYPE_KEY = RubyUtil.RUBY.newSymbol("type");
+
+    public static final RubySymbol QUEUE_KEY = RubyUtil.RUBY.newSymbol("queue");
+
+    public static final RubySymbol DLQ_KEY = RubyUtil.RUBY.newSymbol("dlq");
+
+    public static final RubySymbol STORAGE_POLICY_KEY = RubyUtil.RUBY.newSymbol("storage_policy");
+
+    public static final RubySymbol DROPPED_EVENTS_KEY = RubyUtil.RUBY.newSymbol("dropped_events");
+
+    public static final RubySymbol EXPIRED_EVENTS_KEY = RubyUtil.RUBY.newSymbol("expired_events");
+
+    public static final RubySymbol LAST_ERROR_KEY = RubyUtil.RUBY.newSymbol("last_error");
 
     public static final RubySymbol FILTERED_KEY = RubyUtil.RUBY.newSymbol("filtered");
 
     public static final RubySymbol STATS_KEY = RubyUtil.RUBY.newSymbol("stats");
+
+    // Flow metric keys
+    public static final RubySymbol FLOW_KEY = RubyUtil.RUBY.newSymbol("flow");
+
+    public static final RubySymbol INPUT_THROUGHPUT_KEY = RubyUtil.RUBY.newSymbol("input_throughput");
+
+    public static final RubySymbol OUTPUT_THROUGHPUT_KEY = RubyUtil.RUBY.newSymbol("output_throughput");
+
+    public static final RubySymbol FILTER_THROUGHPUT_KEY = RubyUtil.RUBY.newSymbol("filter_throughput");
+
+    public static final RubySymbol QUEUE_BACKPRESSURE_KEY = RubyUtil.RUBY.newSymbol("queue_backpressure");
+
+    public static final RubySymbol WORKER_CONCURRENCY_KEY = RubyUtil.RUBY.newSymbol("worker_concurrency");
+
+    public static final RubySymbol UPTIME_IN_SECONDS_KEY = RubyUtil.RUBY.newSymbol("uptime_in_seconds");
+
+    public static final RubySymbol UPTIME_IN_MILLIS_KEY = RubyUtil.RUBY.newSymbol("uptime_in_millis");
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricType.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricType.java
@@ -55,7 +55,13 @@ public enum MetricType {
     /**
      * A gauge backed by a {@link org.logstash.ext.JrubyTimestampExtLibrary.RubyTimestamp} type. Note - Java consumers should not use this, exist for legacy Ruby code.
      */
-    GAUGE_RUBYTIMESTAMP("gauge/rubytimestamp");
+    GAUGE_RUBYTIMESTAMP("gauge/rubytimestamp"),
+
+    /**
+     * A flow-rate {@link FlowMetric}, instantiated with one or more backing {@link Metric}{@code <Number>}.
+     */
+    FLOW_RATES("flow/rate"),
+    ;
 
     private final String type;
 

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricType.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricType.java
@@ -60,7 +60,7 @@ public enum MetricType {
     /**
      * A flow-rate {@link FlowMetric}, instantiated with one or more backing {@link Metric}{@code <Number>}.
      */
-    FLOW_RATES("flow/rate"),
+    FLOW_RATE("flow/rate"),
     ;
 
     private final String type;

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricType.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricType.java
@@ -32,6 +32,11 @@ public enum MetricType {
      * A counter backed by a {@link Long} type
      */
     COUNTER_LONG("counter/long"),
+
+    /**
+     * A counter backed by a {@link Number} type that includes decimal precision
+     */
+    COUNTER_DECIMAL("counter/decimal"),
     /**
      * A gauge backed by a {@link String} type
      */

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/UptimeMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/UptimeMetric.java
@@ -19,7 +19,7 @@ public class UptimeMetric extends AbstractMetric<Long> {
      * Constructs an {@link UptimeMetric} whose name is "uptime_in_millis" and whose units are milliseconds
      */
     public UptimeMetric() {
-        this("uptime_in_millis");
+        this(MetricKeys.UPTIME_IN_MILLIS_KEY.asJavaString());
     }
 
     public UptimeMetric(final String name) {

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/UptimeMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/UptimeMetric.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.logstash.instrument.metrics;
 
 import java.math.BigDecimal;

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/UptimeMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/UptimeMetric.java
@@ -1,0 +1,87 @@
+package org.logstash.instrument.metrics;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+
+/**
+ * The {@link UptimeMetric} is an auto-advancing {@link Metric} whose value
+ * represents the amount of time since instantiation. It can be made to track the
+ * advancement of the clock in one of several {@link TimeUnit}s.
+ */
+public class UptimeMetric extends AbstractMetric<Long> {
+    private final LongSupplier nanoTimeSupplier;
+    private final long startNanos;
+
+    private final TimeUnit timeUnit;
+
+    /**
+     * Constructs an {@link UptimeMetric} whose name is "uptime_in_millis" and whose units are milliseconds
+     */
+    public UptimeMetric() {
+        this("uptime_in_millis");
+    }
+
+    public UptimeMetric(final String name) {
+        this(name, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Constructs an {@link UptimeMetric} with the provided name and units.
+     * @param name the name of the metric, which is used by our metric store, API retrieval, etc.
+     * @param timeUnit the units in which to keep track of uptime (millis, seconds, etc.)
+     */
+    public UptimeMetric(final String name, final TimeUnit timeUnit) {
+        this(name, timeUnit, System::nanoTime);
+    }
+
+    UptimeMetric(final String name, final TimeUnit timeUnit, final LongSupplier nanoTimeSupplier) {
+        this(name, timeUnit, nanoTimeSupplier, nanoTimeSupplier.getAsLong());
+    }
+
+    UptimeMetric(final String name, final TimeUnit timeUnit, final LongSupplier nanoTimeSupplier, final long startNanos) {
+        super(Objects.requireNonNull(name, "name"));
+        this.nanoTimeSupplier = Objects.requireNonNull(nanoTimeSupplier, "nanoTimeSupplier");
+        this.timeUnit = Objects.requireNonNull(timeUnit, "timeUnit");
+        this.startNanos = Objects.requireNonNull(startNanos, "startNanos");
+    }
+
+    /**
+     * @return the number of {@link TimeUnit}s that have elapsed
+     *         since this {@link UptimeMetric} was instantiated
+     */
+    @Override
+    public Long getValue() {
+        final long elapsedNanos = this.nanoTimeSupplier.getAsLong() - this.startNanos;
+
+        return this.timeUnit.convert(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    /**
+     * @return the {@link MetricType}{@code .COUNTER_LONG} associated with
+     *         long-valued metrics that only-increment, for use in Monitoring data structuring.
+     */
+    @Override
+    public MetricType getType() {
+        return MetricType.COUNTER_LONG;
+    }
+
+    /**
+     * @return the {@link TimeUnit} associated with this {@link UptimeMetric}.
+     */
+    public TimeUnit getTimeUnit() {
+        return timeUnit;
+    }
+
+    /**
+     * Constructs a _copy_ of this {@link UptimeMetric} with a new name and timeUnit, but whose
+     * uptime is tracking from the same instant as this instance.
+     *
+     * @param name the new metric's name (typically includes units)
+     * @param timeUnit the new metric's units
+     * @return a _copy_ of this {@link UptimeMetric}.
+     */
+    public UptimeMetric withTimeUnit(final String name, final TimeUnit timeUnit) {
+        return new UptimeMetric(name, timeUnit, this.nanoTimeSupplier, this.startNanos);
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/plugins/factory/PluginMetricsFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/factory/PluginMetricsFactoryExt.java
@@ -21,8 +21,6 @@ public final class PluginMetricsFactoryExt extends RubyBasicObject {
 
     private static final long serialVersionUID = 1L;
 
-    private static final RubySymbol PLUGINS = RubyUtil.RUBY.newSymbol("plugins");
-
     private RubySymbol pipelineId;
 
     private AbstractMetricExt metric;
@@ -49,10 +47,10 @@ public final class PluginMetricsFactoryExt extends RubyBasicObject {
             RubyArray.newArray(
                 context.runtime,
                 Arrays.asList(
-                    MetricKeys.STATS_KEY, MetricKeys.PIPELINES_KEY, pipelineId, PLUGINS
-                )
-            )
-        );
+                        MetricKeys.STATS_KEY,
+                        MetricKeys.PIPELINES_KEY,
+                        pipelineId,
+                        MetricKeys.PLUGINS_KEY)));
     }
 
     @JRubyMethod

--- a/logstash-core/src/main/java/org/logstash/plugins/factory/PluginMetricsFactoryExt.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/factory/PluginMetricsFactoryExt.java
@@ -8,10 +8,11 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.RubyUtil;
 import org.logstash.instrument.metrics.AbstractMetricExt;
 import org.logstash.instrument.metrics.AbstractNamespacedMetricExt;
-import org.logstash.instrument.metrics.MetricKeys;
 import org.logstash.instrument.metrics.NullMetricExt;
 
 import java.util.Arrays;
+
+import static org.logstash.instrument.metrics.MetricKeys.*;
 
 /**
  * JRuby extension to implement a factory class for Plugin's metrics
@@ -46,11 +47,7 @@ public final class PluginMetricsFactoryExt extends RubyBasicObject {
             context,
             RubyArray.newArray(
                 context.runtime,
-                Arrays.asList(
-                        MetricKeys.STATS_KEY,
-                        MetricKeys.PIPELINES_KEY,
-                        pipelineId,
-                        MetricKeys.PLUGINS_KEY)));
+                Arrays.asList(STATS_KEY, PIPELINES_KEY, pipelineId, PLUGINS_KEY)));
     }
 
     @JRubyMethod

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/OutputDelegatorTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/OutputDelegatorTest.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.logstash.RubyUtil.RUBY;
 import static org.logstash.RubyUtil.RUBY_OUTPUT_DELEGATOR_CLASS;
+import static org.logstash.instrument.metrics.MetricKeys.EVENTS_KEY;
 
 @SuppressWarnings("rawtypes")
 @NotThreadSafe
@@ -203,7 +204,7 @@ public class OutputDelegatorTest extends PluginDelegatorTestCase {
     }
 
     private RubyHash getMetricStore() {
-        return getMetricStore(new String[]{"output", "foo", MetricKeys.EVENTS_KEY.asJavaString()});
+        return getMetricStore(new String[]{"output", "foo", EVENTS_KEY.asJavaString()});
     }
 
     private long getMetricLongValue(String symbolName) {

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/OutputDelegatorTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/OutputDelegatorTest.java
@@ -32,6 +32,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.logstash.Event;
+import org.logstash.instrument.metrics.MetricKeys;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -202,7 +203,7 @@ public class OutputDelegatorTest extends PluginDelegatorTestCase {
     }
 
     private RubyHash getMetricStore() {
-        return getMetricStore(new String[]{"output", "foo", "events"});
+        return getMetricStore(new String[]{"output", "foo", MetricKeys.EVENTS_KEY.asJavaString()});
     }
 
     private long getMetricLongValue(String symbolName) {

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/FlowMetricTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/FlowMetricTest.java
@@ -18,7 +18,7 @@ public class FlowMetricTest {
     @Test
     public void testBaselineFunctionality() {
         final ManualAdvanceClock clock = new ManualAdvanceClock(Instant.now());
-        final LongCounter numeratorMetric = new LongCounter("events");
+        final LongCounter numeratorMetric = new LongCounter(MetricKeys.EVENTS_KEY.asJavaString());
         final Metric<Long> denominatorMetric = new UptimeMetric("uptime", TimeUnit.SECONDS, clock::nanoTime);
         final FlowMetric instance = new FlowMetric("flow", numeratorMetric, denominatorMetric);
 

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/FlowMetricTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/FlowMetricTest.java
@@ -1,0 +1,54 @@
+package org.logstash.instrument.metrics;
+
+import org.junit.Test;
+import org.logstash.instrument.metrics.counter.LongCounter;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+import static org.logstash.instrument.metrics.FlowMetric.CURRENT_KEY;
+import static org.logstash.instrument.metrics.FlowMetric.LIFETIME_KEY;
+
+public class FlowMetricTest {
+    @Test
+    public void testBaselineFunctionality() {
+        final ManualAdvanceClock clock = new ManualAdvanceClock(Instant.now());
+        final LongCounter numeratorMetric = new LongCounter("events");
+        final Metric<Long> denominatorMetric = new UptimeMetric("uptime", TimeUnit.SECONDS, clock::nanoTime);
+        final FlowMetric instance = new FlowMetric("flow", numeratorMetric, denominatorMetric);
+
+        final Map<String, Double> ratesBeforeCaptures = instance.getValue();
+        assertTrue(ratesBeforeCaptures.isEmpty());
+
+        // 5 seconds pass, during which 1000 events are processed
+        clock.advance(Duration.ofSeconds(5));
+        numeratorMetric.increment(1000);
+        instance.capture();
+        final Map<String, Double> ratesAfterFirstCapture = instance.getValue();
+        assertFalse(ratesAfterFirstCapture.isEmpty());
+        assertEquals(Map.of(LIFETIME_KEY, 200.0, CURRENT_KEY, 200.0), ratesAfterFirstCapture);
+
+        // 5 more seconds pass, during which 2000 more events are processed
+        clock.advance(Duration.ofSeconds(5));
+        numeratorMetric.increment(2000);
+        instance.capture();
+        final Map<String, Double> ratesAfterSecondCapture = instance.getValue();
+        assertFalse(ratesAfterSecondCapture.isEmpty());
+        assertEquals(Map.of(LIFETIME_KEY, 300.0, CURRENT_KEY, 400.0), ratesAfterSecondCapture);
+
+        // 30 seconds pass, during which 11700 more events are seen by our numerator
+        for (Integer eventCount : List.of(1883, 2117, 1901, 2299, 1608, 1892)) {
+            clock.advance(Duration.ofSeconds(5));
+            numeratorMetric.increment(eventCount);
+            instance.capture();
+        }
+        final Map<String, Double> ratesAfterNthCapture = instance.getValue();
+        assertFalse(ratesAfterNthCapture.isEmpty());
+        assertEquals(Map.of(LIFETIME_KEY, 367.5, CURRENT_KEY, 378.4), ratesAfterNthCapture);
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/ManualAdvanceClock.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/ManualAdvanceClock.java
@@ -1,0 +1,63 @@
+package org.logstash.instrument.metrics;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+class ManualAdvanceClock extends Clock {
+    private final ZoneId zoneId;
+    private final AtomicReference<Instant> currentInstant;
+    private final Instant zeroInstant;
+
+    public ManualAdvanceClock(final Instant currentInstant, final ZoneId zoneId) {
+        this(currentInstant, new AtomicReference<>(currentInstant), zoneId);
+    }
+
+    public ManualAdvanceClock(final Instant currentInstant) {
+        this(currentInstant, null);
+    }
+
+    private ManualAdvanceClock(final Instant zeroInstant, final AtomicReference<Instant> currentInstant, final ZoneId zoneId) {
+        this.zeroInstant = zeroInstant;
+        this.currentInstant = currentInstant;
+        this.zoneId = Objects.requireNonNullElseGet(zoneId, ZoneId::systemDefault);
+    }
+
+    @Override
+    public ZoneId getZone() {
+        return this.zoneId;
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+        return new ManualAdvanceClock(this.zeroInstant, this.currentInstant, zone);
+    }
+
+    @Override
+    public Instant instant() {
+        return currentInstant.get();
+    }
+
+    /**
+     * @return an only-incrementing long value, meant as a drop-in replacement
+     *         for {@link System#nanoTime()}, using this {@link ManualAdvanceClock}
+     *         as the time source, and carrying the same constraints.
+     */
+    public long nanoTime() {
+        return zeroInstant.until(instant(), ChronoUnit.NANOS);
+    }
+
+    public void advance(final Duration duration) {
+        if (duration.isZero()) {
+            return;
+        }
+        if (duration.isNegative()) {
+            throw new IllegalArgumentException("duration must not be negative");
+        }
+        this.currentInstant.updateAndGet(previous -> previous.plus(duration));
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/MetricTypeTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/MetricTypeTest.java
@@ -48,6 +48,7 @@ public class MetricTypeTest {
         nameMap.put(MetricType.GAUGE_UNKNOWN, "gauge/unknown");
         nameMap.put(MetricType.GAUGE_RUBYHASH, "gauge/rubyhash");
         nameMap.put(MetricType.GAUGE_RUBYTIMESTAMP, "gauge/rubytimestamp");
+        nameMap.put(MetricType.FLOW_RATE, "flow/rate");
 
         //ensure we are testing all of the enumerations
         assertThat(EnumSet.allOf(MetricType.class).size()).isEqualTo(nameMap.size());

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/MetricTypeTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/MetricTypeTest.java
@@ -42,6 +42,7 @@ public class MetricTypeTest {
     public void ensurePassivity(){
         Map<MetricType, String> nameMap = new HashMap<>(EnumSet.allOf(MetricType.class).size());
         nameMap.put(MetricType.COUNTER_LONG, "counter/long");
+        nameMap.put(MetricType.COUNTER_DECIMAL, "counter/decimal");
         nameMap.put(MetricType.GAUGE_TEXT, "gauge/text");
         nameMap.put(MetricType.GAUGE_BOOLEAN, "gauge/boolean");
         nameMap.put(MetricType.GAUGE_NUMBER, "gauge/number");

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/UptimeMetricTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/UptimeMetricTest.java
@@ -13,7 +13,7 @@ public class UptimeMetricTest {
     @Test
     public void testDefaultConstructor() {
         final UptimeMetric defaultConstructorUptimeMetric = new UptimeMetric();
-        assertEquals("uptime_in_millis", defaultConstructorUptimeMetric.getName());
+        assertEquals(MetricKeys.UPTIME_IN_MILLIS_KEY.asJavaString(), defaultConstructorUptimeMetric.getName());
         assertEquals(TimeUnit.MILLISECONDS, defaultConstructorUptimeMetric.getTimeUnit());
     }
 

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/UptimeMetricTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/UptimeMetricTest.java
@@ -1,0 +1,63 @@
+package org.logstash.instrument.metrics;
+
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public class UptimeMetricTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        final UptimeMetric defaultConstructorUptimeMetric = new UptimeMetric();
+        assertEquals("uptime_in_millis", defaultConstructorUptimeMetric.getName());
+        assertEquals(TimeUnit.MILLISECONDS, defaultConstructorUptimeMetric.getTimeUnit());
+    }
+
+    @Test
+    public void getNameExplicit() {
+        final String customName = "custom_uptime_name";
+        assertEquals(customName, new UptimeMetric(customName, TimeUnit.MILLISECONDS).getName());
+    }
+
+    @Test
+    public void getType() {
+        assertEquals(MetricType.COUNTER_LONG, new UptimeMetric().getType());
+    }
+
+    @Test
+    public void getValue() {
+        final ManualAdvanceClock clock = new ManualAdvanceClock(Instant.now());
+        final UptimeMetric uptimeMetric = new UptimeMetric("up", TimeUnit.MILLISECONDS, clock::nanoTime);
+        assertEquals(Long.valueOf(0L), uptimeMetric.getValue());
+
+        clock.advance(Duration.ofMillis(123));
+        assertEquals(Long.valueOf(123L), uptimeMetric.getValue());
+
+        clock.advance(Duration.ofMillis(456));
+        assertEquals(Long.valueOf(579L), uptimeMetric.getValue());
+
+        clock.advance(Duration.ofMinutes(15));
+        assertEquals(Long.valueOf(900579L), uptimeMetric.getValue());
+
+        clock.advance(Duration.ofHours(712));
+        assertEquals(Long.valueOf(2564100579L), uptimeMetric.getValue());
+    }
+
+    @Test
+    public void withTemporalUnit() {
+        final ManualAdvanceClock clock = new ManualAdvanceClock(Instant.now());
+        final UptimeMetric uptimeMetric = new UptimeMetric("up_millis", TimeUnit.MILLISECONDS, clock::nanoTime);
+        clock.advance(Duration.ofMillis(1_000_000_000));
+
+        // set-up: ensure advancing nanos reflects in our milli-based uptime
+        assertEquals(Long.valueOf(1_000_000_000), uptimeMetric.getValue());
+
+        final UptimeMetric secondsBasedCopy = uptimeMetric.withTimeUnit("up_seconds", TimeUnit.SECONDS);
+        assertEquals(Long.valueOf(1_000_000), secondsBasedCopy.getValue());
+    }
+
+}

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/UptimeMetricTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/UptimeMetricTest.java
@@ -2,6 +2,7 @@ package org.logstash.instrument.metrics;
 
 import org.junit.Test;
 
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
@@ -20,7 +21,7 @@ public class UptimeMetricTest {
     @Test
     public void getNameExplicit() {
         final String customName = "custom_uptime_name";
-        assertEquals(customName, new UptimeMetric(customName, TimeUnit.MILLISECONDS).getName());
+        assertEquals(customName, new UptimeMetric(customName).getName());
     }
 
     @Test
@@ -31,7 +32,7 @@ public class UptimeMetricTest {
     @Test
     public void getValue() {
         final ManualAdvanceClock clock = new ManualAdvanceClock(Instant.now());
-        final UptimeMetric uptimeMetric = new UptimeMetric("up", TimeUnit.MILLISECONDS, clock::nanoTime);
+        final UptimeMetric uptimeMetric = new UptimeMetric("up", clock::nanoTime);
         assertEquals(Long.valueOf(0L), uptimeMetric.getValue());
 
         clock.advance(Duration.ofMillis(123));
@@ -50,7 +51,7 @@ public class UptimeMetricTest {
     @Test
     public void withTemporalUnit() {
         final ManualAdvanceClock clock = new ManualAdvanceClock(Instant.now());
-        final UptimeMetric uptimeMetric = new UptimeMetric("up_millis", TimeUnit.MILLISECONDS, clock::nanoTime);
+        final UptimeMetric uptimeMetric = new UptimeMetric("up_millis", clock::nanoTime);
         clock.advance(Duration.ofMillis(1_000_000_000));
 
         // set-up: ensure advancing nanos reflects in our milli-based uptime
@@ -58,6 +59,37 @@ public class UptimeMetricTest {
 
         final UptimeMetric secondsBasedCopy = uptimeMetric.withTimeUnit("up_seconds", TimeUnit.SECONDS);
         assertEquals(Long.valueOf(1_000_000), secondsBasedCopy.getValue());
+
+        clock.advance(Duration.ofMillis(1_999));
+        assertEquals(Long.valueOf(1_000_001_999), uptimeMetric.getValue());
+        assertEquals(Long.valueOf(1_000_001), secondsBasedCopy.getValue());
+    }
+
+    @Test
+    public void withUnitsPrecise() {
+        final ManualAdvanceClock clock = new ManualAdvanceClock(Instant.now());
+        final UptimeMetric uptimeMetric = new UptimeMetric("up_millis", clock::nanoTime);
+        clock.advance(Duration.ofNanos(123_456_789_987L)); // 123.xx seconds
+
+        // set-up: ensure advancing nanos reflects in our milli-based uptime
+        assertEquals(Long.valueOf(123_456L), uptimeMetric.getValue());
+
+        final UptimeMetric.ScaledView secondsBasedView = uptimeMetric.withUnitsPrecise("up_seconds", UptimeMetric.ScaleUnits.SECONDS);
+        final UptimeMetric.ScaledView millisecondsBasedView = uptimeMetric.withUnitsPrecise("up_millis", UptimeMetric.ScaleUnits.MILLISECONDS);
+        final UptimeMetric.ScaledView microsecondsBasedView = uptimeMetric.withUnitsPrecise("up_micros", UptimeMetric.ScaleUnits.MICROSECONDS);
+        final UptimeMetric.ScaledView nanosecondsBasedView = uptimeMetric.withUnitsPrecise("up_nanos", UptimeMetric.ScaleUnits.NANOSECONDS);
+
+        assertEquals(new BigDecimal("123.456789987"), secondsBasedView.getValue());
+        assertEquals(new BigDecimal("123456.789987"), millisecondsBasedView.getValue());
+        assertEquals(new BigDecimal("123456789.987"), microsecondsBasedView.getValue());
+        assertEquals(new BigDecimal("123456789987"), nanosecondsBasedView.getValue());
+
+        clock.advance(Duration.ofMillis(1_999));
+        assertEquals(Long.valueOf(125_455L), uptimeMetric.getValue());
+        assertEquals(new BigDecimal("125.455789987"), secondsBasedView.getValue());
+        assertEquals(new BigDecimal("125455.789987"), millisecondsBasedView.getValue());
+        assertEquals(new BigDecimal("125455789.987"), microsecondsBasedView.getValue());
+        assertEquals(new BigDecimal("125455789987"), nanosecondsBasedView.getValue());
     }
 
 }

--- a/qa/integration/specs/reload_config_spec.rb
+++ b/qa/integration/specs/reload_config_spec.rb
@@ -25,6 +25,9 @@ require "json"
 require "logstash/util"
 
 describe "Test Logstash service when config reload is enabled" do
+
+  define_negated_matcher :exclude, :include
+
   before(:all) {
     @fixture = Fixture.new(__FILE__)
   }
@@ -44,6 +47,8 @@ describe "Test Logstash service when config reload is enabled" do
   let(:initial_config_file) { config_to_temp_file(@fixture.config("initial", { :port => initial_port, :file => output_file1 })) }
   let(:reload_config_file) { config_to_temp_file(@fixture.config("reload", { :port => reload_port, :file => output_file2 })) }
 
+  let(:max_retry) { 30 }
+
   it "can reload when changes are made to TCP port and grok pattern" do
     logstash_service = @fixture.get_service("logstash")
     logstash_service.spawn_logstash("-f", "#{initial_config_file}", "--config.reload.automatic", "true")
@@ -60,7 +65,13 @@ describe "Test Logstash service when config reload is enabled" do
     result = logstash_service.monitoring_api.event_stats
     expect(result["in"]).to eq(1)
     expect(result["out"]).to eq(1)
-    
+
+    # make sure the pipeline flow has non-zero input throughput after receiving data
+    Stud.try(max_retry.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
+      pipeline_flow_stats = logstash_service.monitoring_api.pipeline_stats("main")["flow"]
+      expect(pipeline_flow_stats['input_throughput']).to include('lifetime' => (a_value >  0))
+    end
+
     # do a reload
     logstash_service.reload_config(initial_config_file, reload_config_file)
 
@@ -69,7 +80,20 @@ describe "Test Logstash service when config reload is enabled" do
     
     # make sure old socket is closed
     expect(is_port_open?(initial_port)).to be false
-    
+
+    # check pipeline flow metrics. They should be both present and reset.
+    # since we have processed zero events since the reload, we expect their rates to be either unavailable or zero.
+    pipeline_flow_stats = logstash_service.monitoring_api.pipeline_stats("main")["flow"]
+    expect(pipeline_flow_stats).to_not be_nil
+    expect(pipeline_flow_stats).to include('input_throughput', 'queue_backpressure')
+    aggregate_failures do
+      expect(pipeline_flow_stats['input_throughput']).to exclude('lifetime').or(include('lifetime' => 0))
+      expect(pipeline_flow_stats['input_throughput']).to exclude('current').or(include('current' => 0))
+      expect(pipeline_flow_stats['queue_backpressure']).to exclude('lifetime').or(include('lifetime' => 0))
+      expect(pipeline_flow_stats['queue_backpressure']).to exclude('current').or(include('current' => 0))
+    end
+
+    # send data, and wait for at least some of the events to make it through the output.
     send_data(reload_port, sample_data)
     Stud.try(retry_attempts.times, RSpec::Expectations::ExpectationNotMetError) do
       expect(LogStash::Util.blank?(IO.read(output_file2))).to be false
@@ -84,7 +108,24 @@ describe "Test Logstash service when config reload is enabled" do
     pipeline_event_stats = logstash_service.monitoring_api.pipeline_stats("main")["events"]
     expect(pipeline_event_stats["in"]).to eq(1)
     expect(pipeline_event_stats["out"]).to eq(1)
-    
+
+    # make sure the pipeline flow has non-zero input/output throughput after receiving data
+    Stud.try(max_retry.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
+      pipeline_flow_stats = logstash_service.monitoring_api.pipeline_stats("main")["flow"]
+      expect(pipeline_flow_stats).to_not be_nil
+      expect(pipeline_flow_stats).to include(
+        # due to three-decimal-place rounding, it is easy for our worker_concurrency and queue_backpressure
+        # to be zero, so we are just looking for these to be _populated_
+        'worker_concurrency' => hash_including('current' => a_value >= 0, 'lifetime' => a_value >= 0),
+        'queue_backpressure' => hash_including('current' => a_value >= 0, 'lifetime' => a_value >= 0),
+        # depending on flow capture interval, our current rate can easily be zero, but our lifetime rates
+        # should be non-zero so long as pipeline uptime is less than ~10 minutes.
+        'input_throughput'   => hash_including('current' => a_value >= 0, 'lifetime' => a_value >  0),
+        'filter_throughput'  => hash_including('current' => a_value >= 0, 'lifetime' => a_value >  0),
+        'output_throughput'  => hash_including('current' => a_value >= 0, 'lifetime' => a_value >  0)
+      )
+    end
+
     # check reload stats
     pipeline_reload_stats = logstash_service.monitoring_api.pipeline_stats("main")["reloads"]
     instance_reload_stats = logstash_service.monitoring_api.node_stats["reloads"]

--- a/tools/benchmark-cli/src/test/resources/org/logstash/benchmark/cli/metrics.json
+++ b/tools/benchmark-cli/src/test/resources/org/logstash/benchmark/cli/metrics.json
@@ -102,11 +102,11 @@
           "lifetime": 0.231,
           "current": 4.0
         },
-        "backpressure": {
+        "queue_backpressure": {
           "lifetime": 0.0,
           "current": 0.0
         },
-        "concurrency": {
+        "worker_concurrency": {
           "lifetime": 0.018,
           "current": 0.288
         },

--- a/tools/benchmark-cli/src/test/resources/org/logstash/benchmark/cli/metrics.json
+++ b/tools/benchmark-cli/src/test/resources/org/logstash/benchmark/cli/metrics.json
@@ -93,6 +93,28 @@
         "out" : 357125,
         "duration_in_millis" : 168492
       },
+      "flow": {
+        "output_throughput": {
+          "lifetime": 0.231,
+          "current": 4.0
+        },
+        "filter_throughput": {
+          "lifetime": 0.231,
+          "current": 4.0
+        },
+        "backpressure": {
+          "lifetime": 0.0,
+          "current": 0.0
+        },
+        "concurrency": {
+          "lifetime": 0.018,
+          "current": 0.288
+        },
+        "input_throughput": {
+          "lifetime": 0.25,
+          "current": 4.4
+        }
+      },
       "plugins" : {
         "inputs" : [ {
           "id" : "3ca119230f5eaf03a261b674ee2f2dfe1491894c1b2b8f21e1d9a02b656b36f1",


### PR DESCRIPTION
## Release notes

Adds pipeline "flow" metrics to the node_stats API for each pipeline, which includes the `current` and `lifetime` rates for five key pipeline metrics: `input_throughput`, `filter_throughput`, `output_throughput`, `queue_backpressure`, and `worker_concurrency`.

## What does this PR do?

Implements Phase `0` and `1.A` of https://github.com/elastic/logstash/issues/14463, providing each pipeline's `current` and `lifetime` rates for 5 key metrics:
 - `input_throughput`: `pipelines.*.events.in` / second of pipeline uptime
 - `filter_throughput`: `pipelines.*.events.filtered` / second of pipeline uptime
 - `output_throughput`: `pipelines.*.events.out` / second of pipeline uptime
 - `queue_backpressure`: `pipelines.*.queue_push_duration` / second of pipeline uptime
 - `worker_concurrency`: `duration` / second of pipeline uptime

This Pull-Request is a combination of the efforts reviewed at a high-level in #14509 and #14514 for inclusion into this feature branch, and is a place for us to further review and document the now-integrated components.

## Why is it important/What is the impact to the user?

As described in https://github.com/elastic/logstash/issues/14463, notably:

> ## Problem Statement
> It is often difficult to understand the health of a pipeline, including whether it is exerting or propagating back-pressure or otherwise staying reasonably “caught up” with its inputs. The cumulative-value metrics exposed by the API are not typically useful on their own, and when we are debugging a pipeline we often require a _pair_ of captures and manual math in order to see the _flow_ of events through the pipeline.
> 
> We want to provide better visibility into the _flow_ of events through a Logstash pipeline in order to easier pinpoint the source of degraded status.
> 
> ## Scope and Goals
> We will provide visibility into the current, recent, and lifetime flow rates of pipeline-level metrics in the `/_node/stats` API, so that our users can have more contextual information when analyzing the throughput of a pipeline.



<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [ ] periodic poller warns if it is unable to keep up with configured polling frequency
- [ ] expose our pipeline's new `uptime_in_millis` to the API response.

## How to test this PR locally

1. Run a pipeline that handles jittery input data.
   ~~~
   ruby -e '100.times.map { |j| Thread.new(j) { |k| 100000.times { |i| $stdout.write("ok[#{k}/#{i}]\n"); (i%17).zero? && sleep(Random.rand(10)) } } }.map(&:join)' | bin/logstash -e 'input { stdin {} } output { sink {} }'
   ~~~
2. once the pipeline is started, query the node stats API, and observe the new `pipelines.main.flow` metrics, and how they relate to the cumulative-value numbers they are tracking.
