### PR TITLE
metrics: live-timers

### DIFF
--- a/logstash-core/lib/logstash/instrument/metric_type.rb
+++ b/logstash-core/lib/logstash/instrument/metric_type.rb
@@ -17,6 +17,7 @@
 
 require "logstash/instrument/metric_type/counter"
 require "logstash/instrument/metric_type/gauge"
+require "logstash/instrument/metric_type/timer"
 require "logstash/instrument/metric_type/uptime"
 
 module LogStash module Instrument
@@ -25,6 +26,7 @@ module LogStash module Instrument
       :counter => LogStash::Instrument::MetricType::Counter,
       :gauge => LogStash::Instrument::MetricType::Gauge,
       :uptime => LogStash::Instrument::MetricType::Uptime,
+      :timer => LogStash::Instrument::MetricType::Timer,
     }.freeze
 
     # Use the string to generate a concrete class for this metrics

--- a/logstash-core/lib/logstash/instrument/metric_type/timer.rb
+++ b/logstash-core/lib/logstash/instrument/metric_type/timer.rb
@@ -1,0 +1,31 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+java_import org.logstash.instrument.metrics.timer.ExecutionMillisTimer
+
+module LogStash module Instrument module MetricType
+  class Timer < ExecutionMillisTimer
+
+    def initialize(namespaces, key)
+      super(key.to_s)
+    end
+
+    def execute(action, value = nil)
+      send(action, value)
+    end
+  end
+end; end; end

--- a/logstash-core/src/main/java/co/elastic/logstash/api/NamespacedMetric.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/NamespacedMetric.java
@@ -20,6 +20,8 @@
 
 package co.elastic.logstash.api;
 
+import org.logstash.instrument.metrics.timer.ExecutionMillisTimer;
+
 import java.util.function.Supplier;
 
 /**
@@ -42,6 +44,14 @@ public interface NamespacedMetric extends Metric {
      * @return an instance tracking a counter metric allowing easy incrementing and resetting
      */
     CounterMetric counter(String metric);
+
+    /**
+     * Creates a timer with the name {@code metric}.
+     *
+     * @param metric name of the timer
+     * @return an instance tracking a timer metric allowing easy execution timing
+     */
+    TimerMetric timer(String metric);
 
     /**
      * Increment the {@code metric} metric by 1.

--- a/logstash-core/src/main/java/co/elastic/logstash/api/TimerMetric.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/TimerMetric.java
@@ -1,0 +1,41 @@
+package co.elastic.logstash.api;
+
+import java.util.function.Supplier;
+
+/**
+ * A timer metric that tracks a single timer.
+ *
+ * You can retrieve an instance of this class using {@link NamespacedMetric#timer(String)}.
+ */
+public interface TimerMetric {
+    /**
+     * Execute the provided {@link Supplier}, timing its execution.
+     * @param supplier a block for execution
+     * @return the value of executing the {@code supplier} without modification
+     * @param <R> this method returns an object of the same type as the one supplied by {@code supplier}
+     */
+    <R> R time(Supplier<R> supplier);
+
+    /**
+     * For cases where it is NOT practical to use {@link TimerMetric#time(Supplier)},
+     * but IS practical to guarantee we can commit execution after completion with {@link Committer#commit()}.
+     *
+     * @return a {@link Committer}, which is used for stopping the timer.
+     *         when using {@link TimerMetric#begin()}, you <em>MUST</em> also send {@link Committer#commit()}.
+     */
+    Committer begin();
+
+    /**
+     * Report a number of milliseconds elapsed <em>without</em> tracking execution itself.
+     * This is significantly safer than {@link TimerMetric#begin()}+{@link Committer#commit()}.
+     * @param millisecondsElapsed
+     */
+    void reportUntracked(final long millisecondsElapsed);
+
+    interface Committer {
+        /**
+         * @return the number of milliseconds since instantiation
+         */
+        long commit();
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/FilterDelegatorExt.java
@@ -34,6 +34,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.instrument.metrics.AbstractNamespacedMetricExt;
 import org.logstash.instrument.metrics.counter.LongCounter;
+import org.logstash.instrument.metrics.timer.ExecutionMillisTimer;
 
 import java.util.UUID;
 
@@ -70,7 +71,7 @@ public final class FilterDelegatorExt extends AbstractFilterDelegatorExt {
     public FilterDelegatorExt initForTesting(final IRubyObject filter, RubyObject configNameDouble) {
         eventMetricOut = LongCounter.DUMMY_COUNTER;
         eventMetricIn = LongCounter.DUMMY_COUNTER;
-        eventMetricTime = LongCounter.DUMMY_COUNTER;
+        eventMetricTime = ExecutionMillisTimer.nullTimer();
         this.filter = filter;
         filterMethod = filter.getMetaClass().searchMethod(FILTER_METHOD_NAME);
         flushes = filter.respondsTo("flush");

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaCodecDelegator.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/JavaCodecDelegator.java
@@ -24,22 +24,16 @@ import co.elastic.logstash.api.Codec;
 import co.elastic.logstash.api.Context;
 import co.elastic.logstash.api.CounterMetric;
 import co.elastic.logstash.api.Event;
-import co.elastic.logstash.api.Metric;
 import co.elastic.logstash.api.NamespacedMetric;
 import co.elastic.logstash.api.PluginConfigSpec;
-import org.jruby.RubySymbol;
-import org.jruby.runtime.ThreadContext;
-import org.logstash.RubyUtil;
-import org.logstash.instrument.metrics.AbstractNamespacedMetricExt;
+import co.elastic.logstash.api.TimerMetric;
 import org.logstash.instrument.metrics.MetricKeys;
-import org.logstash.instrument.metrics.counter.LongCounter;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 public class JavaCodecDelegator implements Codec {
@@ -52,13 +46,13 @@ public class JavaCodecDelegator implements Codec {
 
     protected final CounterMetric encodeMetricIn;
 
-    protected final CounterMetric encodeMetricTime;
+    protected final TimerMetric encodeMetricTime;
 
     protected final CounterMetric decodeMetricIn;
 
     protected final CounterMetric decodeMetricOut;
 
-    protected final CounterMetric decodeMetricTime;
+    protected final TimerMetric decodeMetricTime;
 
 
     public JavaCodecDelegator(final Context context, final Codec codec) {
@@ -71,12 +65,12 @@ public class JavaCodecDelegator implements Codec {
 
             final NamespacedMetric encodeMetric = metric.namespace(ENCODE_KEY);
             encodeMetricIn = encodeMetric.counter(IN_KEY);
-            encodeMetricTime = encodeMetric.counter(MetricKeys.DURATION_IN_MILLIS_KEY.asJavaString());
+            encodeMetricTime = encodeMetric.timer(MetricKeys.DURATION_IN_MILLIS_KEY.asJavaString());
 
             final NamespacedMetric decodeMetric = metric.namespace(DECODE_KEY);
             decodeMetricIn = decodeMetric.counter(IN_KEY);
             decodeMetricOut = decodeMetric.counter(MetricKeys.OUT_KEY.asJavaString());
-            decodeMetricTime = decodeMetric.counter(MetricKeys.DURATION_IN_MILLIS_KEY.asJavaString());
+            decodeMetricTime = decodeMetric.timer(MetricKeys.DURATION_IN_MILLIS_KEY.asJavaString());
         }
     }
 
@@ -84,39 +78,41 @@ public class JavaCodecDelegator implements Codec {
     public void decode(final ByteBuffer buffer, final Consumer<Map<String, Object>> eventConsumer) {
         decodeMetricIn.increment();
 
-        final long start = System.nanoTime();
-
-        codec.decode(buffer, (event) -> {
-            decodeMetricOut.increment();
-            eventConsumer.accept(event);
+        decodeMetricTime.time(() -> {
+            codec.decode(buffer, (event) -> {
+                decodeMetricOut.increment();
+                eventConsumer.accept(event);
+            });
+            return null;
         });
-
-        decodeMetricTime.increment(TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS));
     }
 
     @Override
     public void flush(final ByteBuffer buffer, final Consumer<Map<String, Object>> eventConsumer) {
         decodeMetricIn.increment();
 
-        final long start = System.nanoTime();
-
-        codec.flush(buffer, (event) -> {
-            decodeMetricOut.increment();
-            eventConsumer.accept(event);
+        decodeMetricTime.time(() -> {
+            codec.flush(buffer, (event) -> {
+                decodeMetricOut.increment();
+                eventConsumer.accept(event);
+            });
+            return null;
         });
-
-        decodeMetricTime.increment(TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS));
     }
 
     @Override
     public void encode(final Event event, final OutputStream out) throws IOException {
         encodeMetricIn.increment();
 
-        final long start = System.nanoTime();
-
-        codec.encode(event, out);
-
-        decodeMetricTime.increment(TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS));
+        decodeMetricTime.time(() -> {
+            try {
+                codec.encode(event, out);
+            } catch (IOException e) {
+                // TODO: make TimerMetric#time handle/propagate checked exceptions
+                throw new RuntimeException(e);
+            }
+            return null;
+        });
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
+++ b/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
@@ -21,9 +21,13 @@ package org.logstash.execution;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Supplier;
+
+import co.elastic.logstash.api.TimerMetric;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.logstash.config.ir.CompiledPipeline;
+import org.logstash.instrument.metrics.timer.CombinedMillisTimer;
 
 /**
  * Pipeline execution worker, it's responsible to execute filters and output plugins for each {@link QueueBatch} that

--- a/logstash-core/src/main/java/org/logstash/ext/JRubyWrappedWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JRubyWrappedWriteClientExt.java
@@ -21,8 +21,14 @@
 package org.logstash.ext;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import co.elastic.logstash.api.TimerMetric;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyClass;
@@ -38,6 +44,7 @@ import org.logstash.instrument.metrics.AbstractMetricExt;
 import org.logstash.instrument.metrics.AbstractNamespacedMetricExt;
 import org.logstash.instrument.metrics.MetricKeys;
 import org.logstash.instrument.metrics.counter.LongCounter;
+import org.logstash.instrument.metrics.timer.ExecutionMillisTimer;
 
 @JRubyClass(name = "WrappedWriteClient")
 public final class JRubyWrappedWriteClientExt extends RubyObject implements QueueWriter {
@@ -50,13 +57,13 @@ public final class JRubyWrappedWriteClientExt extends RubyObject implements Queu
     private JRubyAbstractQueueWriteClientExt writeClient;
 
     private transient LongCounter eventsMetricsCounter;
-    private transient LongCounter eventsMetricsTime;
+    private transient TimerMetric eventsMetricsTime;
 
     private transient LongCounter pipelineMetricsCounter;
-    private transient LongCounter pipelineMetricsTime;
+    private transient TimerMetric pipelineMetricsTime;
 
     private transient LongCounter pluginMetricsCounter;
-    private transient LongCounter pluginMetricsTime;
+    private transient TimerMetric pluginMetricsTime;
 
     public JRubyWrappedWriteClientExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);
@@ -78,18 +85,18 @@ public final class JRubyWrappedWriteClientExt extends RubyObject implements Queu
             final AbstractNamespacedMetricExt eventsMetrics =
                 getMetric(metric, "stats", "events");
             eventsMetricsCounter = LongCounter.fromRubyBase(eventsMetrics, MetricKeys.IN_KEY);
-            eventsMetricsTime = LongCounter.fromRubyBase(eventsMetrics, PUSH_DURATION_KEY);
+            eventsMetricsTime = ExecutionMillisTimer.fromRubyBase(eventsMetrics, PUSH_DURATION_KEY);
             final AbstractNamespacedMetricExt pipelineMetrics =
                 getMetric(metric, "stats", "pipelines", pipelineId, "events");
             pipelineMetricsCounter = LongCounter.fromRubyBase(pipelineMetrics, MetricKeys.IN_KEY);
-            pipelineMetricsTime = LongCounter.fromRubyBase(pipelineMetrics, PUSH_DURATION_KEY);
+            pipelineMetricsTime = ExecutionMillisTimer.fromRubyBase(pipelineMetrics, PUSH_DURATION_KEY);
             final AbstractNamespacedMetricExt pluginMetrics = getMetric(
                 metric, "stats", "pipelines", pipelineId, "plugins", "inputs",
                 pluginId.asJavaString(), "events"
             );
             pluginMetricsCounter =
                 LongCounter.fromRubyBase(pluginMetrics, MetricKeys.OUT_KEY);
-            pluginMetricsTime = LongCounter.fromRubyBase(pluginMetrics, PUSH_DURATION_KEY);
+            pluginMetricsTime = ExecutionMillisTimer.fromRubyBase(pluginMetrics, PUSH_DURATION_KEY);
         }
         return this;
     }
@@ -97,24 +104,22 @@ public final class JRubyWrappedWriteClientExt extends RubyObject implements Queu
     @JRubyMethod(name = {"push", "<<"}, required = 1)
     public IRubyObject push(final ThreadContext context, final IRubyObject event)
         throws InterruptedException {
-        final long start = System.nanoTime();
-        incrementCounters(1L);
-        final IRubyObject res = writeClient.doPush(context, (JrubyEventExtLibrary.RubyEvent) event);
-        incrementTimers(start);
-        return res;
+        return executeWithTimers(() -> {
+            incrementCounters(1L);
+            return writeClient.doPush(context, (JrubyEventExtLibrary.RubyEvent) event);
+        });
     }
 
     @SuppressWarnings("unchecked")
     @JRubyMethod(name = "push_batch", required = 1)
     public IRubyObject pushBatch(final ThreadContext context, final IRubyObject batch)
         throws InterruptedException {
-        final long start = System.nanoTime();
-        incrementCounters((long) ((Collection<IRubyObject>) batch).size());
-        final IRubyObject res = writeClient.doPushBatch(
-            context, (Collection<JrubyEventExtLibrary.RubyEvent>) batch
-        );
-        incrementTimers(start);
-        return res;
+        return executeWithTimers(() -> {
+            incrementCounters((long) ((Collection<IRubyObject>) batch).size());
+            return writeClient.doPushBatch(
+                    context, (Collection<JrubyEventExtLibrary.RubyEvent>) batch
+            );
+        });
     }
 
     /**
@@ -135,13 +140,33 @@ public final class JRubyWrappedWriteClientExt extends RubyObject implements Queu
         pluginMetricsCounter.increment(count);
     }
 
+    @Deprecated
+    /**
+     * @param start the execution's starting System.nanotime
+     * @deprecated use {@link JRubyWrappedWriteClientExt.executeWithTimers}
+     */
     private void incrementTimers(final long start) {
         final long increment = TimeUnit.MILLISECONDS.convert(
             System.nanoTime() - start, TimeUnit.NANOSECONDS
         );
-        eventsMetricsTime.increment(increment);
-        pipelineMetricsTime.increment(increment);
-        pluginMetricsTime.increment(increment);
+        eventsMetricsTime.reportUntracked(increment);
+        pipelineMetricsTime.reportUntracked(increment);
+        pluginMetricsTime.reportUntracked(increment);
+    }
+
+    private <V,E extends Exception> V executeWithTimers(final ExceptionalSupplier<V,E> supplier) throws E {
+        final List<TimerMetric> timers = List.of(eventsMetricsTime, pipelineMetricsTime, pluginMetricsTime);
+        final List<TimerMetric.Committer> committers = timers.stream().map(TimerMetric::begin).collect(Collectors.toList());
+        try {
+            return supplier.get();
+        } finally {
+            committers.forEach(TimerMetric.Committer::commit);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ExceptionalSupplier<V,E extends Exception> {
+        V get() throws E;
     }
 
     private static AbstractNamespacedMetricExt getMetric(final AbstractMetricExt base,
@@ -159,9 +184,10 @@ public final class JRubyWrappedWriteClientExt extends RubyObject implements Queu
 
     @Override
     public void push(Map<String, Object> event) {
-        final long start = System.nanoTime();
-        incrementCounters(1L);
-        writeClient.push(event);
-        incrementTimers(start);
+        executeWithTimers(() -> {
+            incrementCounters(1L);
+            writeClient.push(event);
+            return null;
+        });
     }
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractNamespacedMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractNamespacedMetricExt.java
@@ -44,6 +44,11 @@ public abstract class AbstractNamespacedMetricExt extends AbstractMetricExt {
     }
 
     @JRubyMethod
+    public IRubyObject timer(final ThreadContext context, final IRubyObject key) {
+        return getTimer(context, key);
+    }
+
+    @JRubyMethod
     public IRubyObject gauge(final ThreadContext context, final IRubyObject key,
         final IRubyObject value) {
         return getGauge(context, key, value);
@@ -88,6 +93,8 @@ public abstract class AbstractNamespacedMetricExt extends AbstractMetricExt {
     protected abstract RubyArray getNamespaceName(ThreadContext context);
 
     protected abstract IRubyObject getCounter(ThreadContext context, IRubyObject key);
+
+    protected abstract IRubyObject getTimer(ThreadContext context, IRubyObject key);
 
     protected abstract IRubyObject doTime(ThreadContext context, IRubyObject key, Block block);
 

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/NamespacedMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/NamespacedMetricExt.java
@@ -78,6 +78,13 @@ public final class NamespacedMetricExt extends AbstractNamespacedMetricExt {
     }
 
     @Override
+    protected IRubyObject getTimer(ThreadContext context, IRubyObject key) {
+        return collector(context).callMethod(
+                context, "get", new IRubyObject[]{namespaceName, key, MetricExt.TIMER}
+        );
+    }
+
+    @Override
     protected IRubyObject getGauge(final ThreadContext context, final IRubyObject key,
         final IRubyObject value) {
         return metric.gauge(context, namespaceName, key, value);

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/NullNamespacedMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/NullNamespacedMetricExt.java
@@ -31,6 +31,7 @@ import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.RubyUtil;
+import org.logstash.instrument.metrics.timer.ExecutionMillisTimer;
 
 @JRubyClass(name = "NamespacedNullMetric", parent = "AbstractNamespacedMetric")
 public final class NullNamespacedMetricExt extends AbstractNamespacedMetricExt {
@@ -42,6 +43,8 @@ public final class NullNamespacedMetricExt extends AbstractNamespacedMetricExt {
     private @SuppressWarnings("rawtypes") RubyArray namespaceName;
 
     private NullMetricExt metric;
+
+    private static final IRubyObject NULL_TIMER = RubyUtil.toRubyObject(ExecutionMillisTimer.nullTimer());
 
     public static AbstractNamespacedMetricExt create(final NullMetricExt metric,
         final @SuppressWarnings("rawtypes") RubyArray namespaceName) {
@@ -124,6 +127,11 @@ public final class NullNamespacedMetricExt extends AbstractNamespacedMetricExt {
 
     @Override
     public AbstractMetricExt getMetric() { return this.metric; }
+
+    @Override
+    protected IRubyObject getTimer(ThreadContext context, IRubyObject key) {
+        return NULL_TIMER;
+    }
 
     @JRubyClass(name = "NullCounter")
     public static final class NullCounter extends RubyObject {

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/counter/LongCounter.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/counter/LongCounter.java
@@ -115,5 +115,4 @@ public class LongCounter extends AbstractMetric<Long> implements CounterMetric<L
         //replacing since LongAdder#reset "is only effective if there are no concurrent updates", we can not make that guarantee
         longAdder = new LongAdder();
     }
-
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/timer/CombinedMillisTimer.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/timer/CombinedMillisTimer.java
@@ -1,0 +1,60 @@
+package org.logstash.instrument.metrics.timer;
+
+import co.elastic.logstash.api.TimerMetric;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+public class CombinedMillisTimer implements TimerMetric {
+    private final TimerMetric[] wrappedTimerMetrics;
+
+    public static TimerMetric combine(final TimerMetric left, final TimerMetric right) {
+        System.err.format("%s::combine(%s, %s)\n", CombinedMillisTimer.class.getName(), left, right);
+        if (Objects.isNull(left) || Objects.equals(left, ExecutionMillisTimer.nullTimer())) { return Objects.requireNonNullElseGet(right, ExecutionMillisTimer::nullTimer); }
+        if (Objects.isNull(right) || Objects.equals(right, ExecutionMillisTimer.nullTimer())) { return Objects.requireNonNullElseGet(left, ExecutionMillisTimer::nullTimer); }
+
+        return new CombinedMillisTimer(new TimerMetric[]{left, right});
+    }
+
+    private CombinedMillisTimer(TimerMetric[] wrappedTimerMetrics) {
+        this.wrappedTimerMetrics = wrappedTimerMetrics;
+    }
+
+    @Override
+    public <R> R time(Supplier<R> supplier) {
+        final Committer committer = begin();
+        try {
+            return supplier.get();
+        } finally {
+            committer.commit();
+        }
+    }
+
+    @Override
+    public Committer begin() {
+        final Committer[] committers = Stream.of(this.wrappedTimerMetrics).map(TimerMetric::begin).toArray(Committer[]::new);
+        return new CombinedCommitter(committers);
+    }
+
+    @Override
+    public void reportUntracked(long millisecondsElapsed) {
+        Stream.of(wrappedTimerMetrics)
+                .forEach(timer -> timer.reportUntracked(millisecondsElapsed));
+    }
+
+    private class CombinedCommitter implements Committer {
+        private final Committer[] committers;
+        public CombinedCommitter(final Committer[] committers) {
+            this.committers = committers;
+        }
+
+        @Override
+        public long commit() {
+            return Stream.of(committers)
+                    .map(Committer::commit)
+                    .reduce(Math::max)
+                    .orElse(0L);
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/timer/ExecutionMillisTimer.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/timer/ExecutionMillisTimer.java
@@ -1,0 +1,244 @@
+package org.logstash.instrument.metrics.timer;
+
+import co.elastic.logstash.api.TimerMetric;
+import org.jruby.RubySymbol;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.logstash.RubyUtil;
+import org.logstash.instrument.metrics.AbstractMetric;
+import org.logstash.instrument.metrics.AbstractNamespacedMetricExt;
+import org.logstash.instrument.metrics.MetricType;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+/**
+ * An {@link ExecutionMillisTimer}'s value tracks the _cumulative_ execution time,
+ * including concurrent in-flight execution. The implementation is threadsafe and non-blocking.
+ *
+ * <p>It does so by keeping track of untracked and tracked elapsed time separately,
+ * with the tracked adjustment capable of calculating the elapsed time since its last checkpoint,
+ * during which it has had constant concurrency.
+ */
+public class ExecutionMillisTimer extends AbstractMetric<Long> implements TimerMetric {
+
+    private final LongAdder untrackedMillis = new LongAdder();
+    private final AtomicReference<MillisAdjustmentState> trackedMillisAdjustment;
+
+    // test-only dependency injection
+    private final LongSupplier nanoTimeSupplier;
+
+    private static final ExecutionMillisTimer NULL_TIMER = new ExecutionMillisTimer("null_timer"){
+        @Override public <R> R time(Supplier<R> supplier) { return supplier.get(); }
+        @Override public ExecutionCommitter begin() { return new ExecutionCommitter(System.nanoTime(), System::nanoTime); }
+        @Override public void reportUntracked(long millis) {}
+        @Override public Long getValue() { return 0L; }
+    };
+
+    public static ExecutionMillisTimer nullTimer() {
+        return NULL_TIMER;
+    }
+
+    public ExecutionMillisTimer(final String name) {
+        this(System::nanoTime, name);
+    }
+
+    ExecutionMillisTimer(final LongSupplier nanoTimeSupplier, final String name) {
+        super(name);
+        this.nanoTimeSupplier = Objects.requireNonNullElse(nanoTimeSupplier, System::nanoTime);
+        this.trackedMillisAdjustment = new AtomicReference<>(new StaticAdjustmentState());
+    }
+
+    @Override
+    public <R> R time(final Supplier<R> supplier){
+        final ExecutionCommitter executionCommitter = begin();
+        try {
+            return supplier.get();
+        } finally {
+            executionCommitter.commit();
+        }
+    }
+
+    @Override
+    public ExecutionCommitter begin() {
+        final long newCheckpointNanos = trackedMillisAdjustment.updateAndGet(MillisAdjustmentState::withIncrementedConcurrency).getCheckpointNanoTime();
+        return new ExecutionCommitter(newCheckpointNanos, () -> trackedMillisAdjustment.updateAndGet(MillisAdjustmentState::withDecrementedConcurrency).getCheckpointNanoTime());
+    }
+
+    @Override
+    public void reportUntracked(final long millis) {
+        untrackedMillis.add(millis);
+    }
+
+    @Override
+    public MetricType getType() {
+        return MetricType.COUNTER_LONG;
+    }
+
+    @Override
+    public Long getValue() {
+        return trackedMillisAdjustment.get().adjust(untrackedMillis.longValue());
+    }
+
+    public static ExecutionMillisTimer fromRubyBase(final AbstractNamespacedMetricExt metric,
+                                                    final RubySymbol key) {
+        final ThreadContext context = RubyUtil.RUBY.getCurrentContext();
+        final IRubyObject timer = metric.timer(context, key);
+
+        if (ExecutionMillisTimer.class.isAssignableFrom(timer.getJavaClass())) {
+            return timer.toJava(ExecutionMillisTimer.class);
+        } else {
+            return NULL_TIMER;
+        }
+    }
+
+    static class ExecutionCommitter implements Committer {
+        private final long startNanos;
+        private final LongSupplier atomicCommitAction;
+        private final AtomicBoolean committed = new AtomicBoolean(false);
+
+        /**
+         *
+         * @param startNanos a marker for the start time
+         * @param atomicCommitAction an action that will be executed exactly once,
+         *                           which returns the number of NANOSECONDS since the provided start time.
+         */
+        ExecutionCommitter(final long startNanos, final LongSupplier atomicCommitAction) {
+            this.startNanos = startNanos;
+            this.atomicCommitAction = atomicCommitAction;
+        }
+        @Override
+        public long commit() {
+            if (committed.compareAndSet(false, true)) {
+                final long commitNanos = atomicCommitAction.getAsLong();
+                return TimeUnit.NANOSECONDS.toMillis(commitNanos - this.startNanos);
+            } else {
+                return 0L;
+            }
+        }
+    }
+
+    interface MillisAdjustmentState {
+        long getCheckpointNanoTime();
+        MillisAdjustmentState withIncrementedConcurrency();
+        MillisAdjustmentState withDecrementedConcurrency();
+        long adjust(long externalMillis);
+    }
+
+    /**
+     * A {@link StaticAdjustmentState} is static, in that it is not tracking
+     * any concurrent executions, which makes calculations static and enables
+     * us to guard against negative concurrency.
+     */
+    private class StaticAdjustmentState implements MillisAdjustmentState {
+        private final long checkpointNanos;
+        private final long cumulativeMillis;
+        private final long excessNanos;
+
+        public StaticAdjustmentState(final long checkpointNanos, final long cumulativeMillis, final long excessNanos) {
+            this.checkpointNanos = checkpointNanos;
+            this.cumulativeMillis = cumulativeMillis + Math.floorDiv(excessNanos, 1_000_000);
+            this.excessNanos = Math.floorMod(excessNanos, 1_000_000);
+        }
+
+        public StaticAdjustmentState() {
+            this(nanoTimeSupplier.getAsLong(), 0L, 0L);
+        }
+
+        @Override
+        public DynamicAdjustmentState withIncrementedConcurrency() {
+            return new DynamicAdjustmentState(cumulativeMillis, excessNanos);
+        }
+
+        @Override
+        public MillisAdjustmentState withDecrementedConcurrency() {
+            throw new IllegalStateException("Timers cannot track negative concurrency");
+        }
+
+        @Override
+        public long adjust(final long externalMillis) {
+            return Math.addExact(externalMillis, this.cumulativeMillis);
+        }
+
+        @Override
+        public long getCheckpointNanoTime() {
+            return this.checkpointNanos;
+        }
+    }
+
+    /**
+     * An {@link DynamicAdjustmentState} is actively tracking execution with
+     * a non-zero concurrency. It holds sufficient information to mark a checkpoint,
+     * along with a known constant concurrency since that checkpoint, so that it can
+     * calculate the elapsed execution time of in-flight executions.
+     *
+     * <p>For example, if we are tracking N concurrent executions, our calculated value
+     * will be the value at our checkpoint plus N times the duration since that
+     * checkpoint.
+     */
+    private class DynamicAdjustmentState implements MillisAdjustmentState {
+        private final long checkpointNanoTime;
+        private final long committedMillis;
+        private final long committedExcessNanos;
+        private final int concurrency;
+        public DynamicAdjustmentState(final long committedMillis, final long committedExcessNanos) {
+            this(nanoTimeSupplier.getAsLong(), committedMillis, committedExcessNanos, 1);
+        }
+        private DynamicAdjustmentState(final long checkpointNanoTime,
+                                       final long committedMillis,
+                                       final long committedExcessNanos,
+                                       final int concurrency) {
+            this.checkpointNanoTime = checkpointNanoTime;
+            this.committedMillis = committedMillis + Math.floorDiv(committedExcessNanos, 1_000_000);
+            this.committedExcessNanos = Math.floorMod(committedExcessNanos, 1_000_000);
+            this.concurrency = concurrency;
+        }
+
+        @Override
+        public MillisAdjustmentState withIncrementedConcurrency() {
+            return adjustConcurrency(+1);
+        }
+
+        @Override
+        public MillisAdjustmentState withDecrementedConcurrency() {
+            return adjustConcurrency(-1);
+        }
+
+        @Override
+        public long getCheckpointNanoTime() {
+            return this.checkpointNanoTime;
+        }
+
+        @Override
+        public long adjust(final long externalMillis) {
+            final long excessNanos = calculateExcessNanos(nanoTimeSupplier.getAsLong());
+            final long excessMillis = TimeUnit.NANOSECONDS.toMillis(excessNanos);
+
+            final long dynamicMillis = Math.addExact(this.committedMillis, excessMillis);
+            return Math.addExact(externalMillis, dynamicMillis);
+        }
+
+        private MillisAdjustmentState adjustConcurrency(final int vector) {
+            final long newCheckpointNanoTime = nanoTimeSupplier.getAsLong();
+            final int newConcurrency = this.concurrency + vector;
+            final long excessNanos = calculateExcessNanos(newCheckpointNanoTime);
+
+            if (newConcurrency == 0) {
+                return new StaticAdjustmentState(newCheckpointNanoTime, this.committedMillis, excessNanos);
+            }
+            return new DynamicAdjustmentState(newCheckpointNanoTime, this.committedMillis, excessNanos, newConcurrency);
+        }
+
+        private long calculateExcessNanos(long proposedCheckpointNanoTime) {
+            final long deltaNanoTime = Math.subtractExact(proposedCheckpointNanoTime, this.checkpointNanoTime);
+            final long calculatedExcessNanos = Math.multiplyExact(deltaNanoTime, this.concurrency);
+
+            return Math.addExact(this.committedExcessNanos, calculatedExcessNanos);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Improves timer metrics to include in-progress execution, so that the effects of blocking operations are apparent _while_ they are blocking instead of only _after_ they are resolved.


## What does this PR do?

Introduces a first-class TimerMetric, and provides an implementation that is capable of tracking live concurrent execution _before_ that execution has completed.

## Why is it important/What is the impact to the user?

Incrementing timers after execution effectively makes it so that metrics tracking blocking operations _cannot_ accurately report how much time is being spent. Here we first introduce the timer as a first-class metric, and add an implementation that can calculate cumulative elapsed time using a checkpoint along with a wall-clock delta and a known-constant concurrency since that checkpoint.

This allows metrics for blocked or stuck operations to show just how much resources they are taking, instead of reporting zeroes while stuck. This is especially useful now that we are exposing "flow" metrics that show rate-of change; if a pipeline's workers are _all_ busy with long-running operations, we want to see our new `worker_concurrency` flow metric's `current` value be high and not zero.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Run a pipeline that blocks the workers during execution, and observe the node stats APIs flow metrics. Without this PR, our `current` `worker_concurrency` is frequently 0, but with it we get a more accurate view that we are using up all available resources.

```
bin/logstash -e 'input { generator {} } filter { ruby { code => "sleep(1)"} } output { sink {} }'
```

