### PR TITLE
Upgrade jruby to 9.3.8.0

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -30,4 +30,3 @@ gem "rack-test", :require => "rack/test", :group => :development
 gem "rspec", "~> 3.5", :group => :development
 gem "webmock", "~> 3", :group => :development
 gem "jar-dependencies", "= 0.4.1" # Gem::LoadError with jar-dependencies 0.4.2
-gem "csv", "~> 3" # Bundled version of CSV with jruby >=9.3.0.0 < 9.3.8.0 has a thread leak

--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -25,7 +25,7 @@ buildscript {
     dependencies {
         classpath 'org.yaml:snakeyaml:1.29'
         classpath "de.undercouch:gradle-download-task:4.0.4"
-        classpath "org.jruby:jruby-complete:9.3.7.0"
+        classpath "org.jruby:jruby-complete:9.3.8.0"
     }
 }
 

--- a/versions.yml
+++ b/versions.yml
@@ -13,8 +13,8 @@ bundled_jdk:
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time
 jruby:
-  version: 9.3.7.0
-  sha1: 51302029619bc39797b8d5fed5fa1919826b114e
+  version: 9.3.8.0
+  sha1: 9d90cce8ab9d406cdea5db81b28d630113190d88
 # jruby-runtime-override, if specified, will override the jruby version installed in vendor/jruby
 #jruby-runtime-override:
 #  url: https://oss.sonatype.org/content/repositories/snapshots/org/jruby/jruby-dist/9.3.0.0-SNAPSHOT/jruby-dist-9.3.0.0-20210723.214927-259-bin.tar.gz


### PR DESCRIPTION
Also remove the explicit CSV import added in #14507, jruby-9.3.8.0 includes the correct version by default

