### PR TITLE
metric: add ScaledView with sub-unit precision to UptimeMetric

### DIFF
--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowMetric.java
@@ -2,10 +2,12 @@ package org.logstash.instrument.metrics;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongSupplier;
 
 public class FlowMetric extends AbstractMetric<Map<String,Double>> {
 
@@ -19,13 +21,23 @@ public class FlowMetric extends AbstractMetric<Map<String,Double>> {
     private final AtomicReference<Capture> head;
     private final AtomicReference<Capture> instant = new AtomicReference<>();
 
+    private final LongSupplier nanoTimeSupplier;
+
     static final String LIFETIME_KEY = "lifetime";
     static final String CURRENT_KEY = "current";
 
     public FlowMetric(final String name,
                       final Metric<? extends Number> numeratorMetric,
                       final Metric<? extends Number> denominatorMetric) {
+        this(System::nanoTime, name, numeratorMetric, denominatorMetric);
+    }
+
+    FlowMetric(final LongSupplier nanoTimeSupplier,
+               final String name,
+               final Metric<? extends Number> numeratorMetric,
+               final Metric<? extends Number> denominatorMetric) {
         super(name);
+        this.nanoTimeSupplier = nanoTimeSupplier;
         this.numeratorMetric = numeratorMetric;
         this.denominatorMetric = denominatorMetric;
 
@@ -34,8 +46,13 @@ public class FlowMetric extends AbstractMetric<Map<String,Double>> {
     }
 
     public void capture() {
-        final Capture previousHead = head.getAndSet(doCapture());
-        instant.set(previousHead);
+        final Capture newestHead = doCapture();
+        final Capture previousHead = head.getAndSet(newestHead);
+        // rotate our instant forward only
+        instant.getAndAccumulate(previousHead, (current, given) -> {
+            // keep our current value if the given one is less than ~1s older than our newestHead
+            return (newestHead.calculateCapturePeriod(given).toMillis() > 900) ? given : current;
+        });
     }
 
     public Map<String, Double> getValue() {
@@ -62,7 +79,7 @@ public class FlowMetric extends AbstractMetric<Map<String,Double>> {
     }
 
     Capture doCapture() {
-        return new Capture(numeratorMetric.getValue(), denominatorMetric.getValue());
+        return new Capture(numeratorMetric.getValue(), denominatorMetric.getValue(), nanoTimeSupplier.getAsLong());
     }
 
     @Override
@@ -74,14 +91,20 @@ public class FlowMetric extends AbstractMetric<Map<String,Double>> {
         private final Number numerator;
         private final Number denominator;
 
-        public Capture(final Number numerator, final Number denominator) {
+        private final long nanoTimestamp;
+
+        public Capture(final Number numerator, final Number denominator, final long nanoTimestamp) {
             this.numerator = numerator;
             this.denominator = denominator;
+            this.nanoTimestamp = nanoTimestamp;
         }
 
         Double calculateRate(final Capture baseline) {
             if (Objects.isNull(baseline)) { return null; }
             if (baseline == this) { return null; }
+
+            // divide-by-zero safeguard
+            if (this.denominator.doubleValue() == baseline.denominator.doubleValue()) { return null; }
 
             final double deltaNumerator = this.numerator.doubleValue() - baseline.numerator.doubleValue();
             final double deltaDenominator = this.denominator.doubleValue() - baseline.denominator.doubleValue();
@@ -93,6 +116,10 @@ public class FlowMetric extends AbstractMetric<Map<String,Double>> {
             return BigDecimal.valueOf(deltaNumerator)
                     .divide(BigDecimal.valueOf(deltaDenominator), 3, RoundingMode.HALF_UP)
                     .doubleValue();
+        }
+
+        Duration calculateCapturePeriod(final Capture baseline) {
+            return Duration.ofNanos(Math.subtractExact(this.nanoTimestamp, baseline.nanoTimestamp));
         }
     }
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricType.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricType.java
@@ -32,6 +32,11 @@ public enum MetricType {
      * A counter backed by a {@link Long} type
      */
     COUNTER_LONG("counter/long"),
+
+    /**
+     * A counter backed by a {@link Number} type that includes decimal precision
+     */
+    COUNTER_DECIMAL("counter/decimal"),
     /**
      * A gauge backed by a {@link String} type
      */

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/FlowMetricTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/FlowMetricTest.java
@@ -5,10 +5,8 @@ import org.logstash.instrument.metrics.counter.LongCounter;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.*;
 import static org.logstash.instrument.metrics.FlowMetric.CURRENT_KEY;
@@ -19,7 +17,7 @@ public class FlowMetricTest {
     public void testBaselineFunctionality() {
         final ManualAdvanceClock clock = new ManualAdvanceClock(Instant.now());
         final LongCounter numeratorMetric = new LongCounter(MetricKeys.EVENTS_KEY.asJavaString());
-        final Metric<Long> denominatorMetric = new UptimeMetric("uptime", TimeUnit.SECONDS, clock::nanoTime);
+        final Metric<Number> denominatorMetric = new UptimeMetric("uptime", clock::nanoTime).withUnitsPrecise(UptimeMetric.ScaleUnits.SECONDS);
         final FlowMetric instance = new FlowMetric("flow", numeratorMetric, denominatorMetric);
 
         final Map<String, Double> ratesBeforeCaptures = instance.getValue();
@@ -50,5 +48,16 @@ public class FlowMetricTest {
         final Map<String, Double> ratesAfterNthCapture = instance.getValue();
         assertFalse(ratesAfterNthCapture.isEmpty());
         assertEquals(Map.of(LIFETIME_KEY, 367.5, CURRENT_KEY, 378.4), ratesAfterNthCapture);
+
+        // less than half a second passes, during which 0 events are seen by our numerator.
+        // when our two most recent captures are very close together, we want to make sure that
+        // we continue to provide _meaningful_ metrics, namely that:
+        // (a) our CURRENT_KEY and LIFETIME_KEY account for newest capture, and
+        // (b) our CURRENT_KEY does not report _only_ the delta since the very-recent capture
+        clock.advance(Duration.ofMillis(10));
+        instance.capture();
+        final Map<String, Double> ratesAfterSmallAdvanceCapture = instance.getValue();
+        assertFalse(ratesAfterNthCapture.isEmpty());
+        assertEquals(Map.of(LIFETIME_KEY, 367.408, CURRENT_KEY, 377.645), ratesAfterSmallAdvanceCapture);
     }
 }

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/FlowMetricTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/FlowMetricTest.java
@@ -18,7 +18,7 @@ public class FlowMetricTest {
         final ManualAdvanceClock clock = new ManualAdvanceClock(Instant.now());
         final LongCounter numeratorMetric = new LongCounter(MetricKeys.EVENTS_KEY.asJavaString());
         final Metric<Number> denominatorMetric = new UptimeMetric("uptime", clock::nanoTime).withUnitsPrecise(UptimeMetric.ScaleUnits.SECONDS);
-        final FlowMetric instance = new FlowMetric("flow", numeratorMetric, denominatorMetric);
+        final FlowMetric instance = new FlowMetric(clock::nanoTime, "flow", numeratorMetric, denominatorMetric);
 
         final Map<String, Double> ratesBeforeCaptures = instance.getValue();
         assertTrue(ratesBeforeCaptures.isEmpty());

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/MetricTypeTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/MetricTypeTest.java
@@ -42,6 +42,7 @@ public class MetricTypeTest {
     public void ensurePassivity(){
         Map<MetricType, String> nameMap = new HashMap<>(EnumSet.allOf(MetricType.class).size());
         nameMap.put(MetricType.COUNTER_LONG, "counter/long");
+        nameMap.put(MetricType.COUNTER_DECIMAL, "counter/decimal");
         nameMap.put(MetricType.GAUGE_TEXT, "gauge/text");
         nameMap.put(MetricType.GAUGE_BOOLEAN, "gauge/boolean");
         nameMap.put(MetricType.GAUGE_NUMBER, "gauge/number");

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/UptimeMetricTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/UptimeMetricTest.java
@@ -2,6 +2,7 @@ package org.logstash.instrument.metrics;
 
 import org.junit.Test;
 
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
@@ -20,7 +21,7 @@ public class UptimeMetricTest {
     @Test
     public void getNameExplicit() {
         final String customName = "custom_uptime_name";
-        assertEquals(customName, new UptimeMetric(customName, TimeUnit.MILLISECONDS).getName());
+        assertEquals(customName, new UptimeMetric(customName).getName());
     }
 
     @Test
@@ -31,7 +32,7 @@ public class UptimeMetricTest {
     @Test
     public void getValue() {
         final ManualAdvanceClock clock = new ManualAdvanceClock(Instant.now());
-        final UptimeMetric uptimeMetric = new UptimeMetric("up", TimeUnit.MILLISECONDS, clock::nanoTime);
+        final UptimeMetric uptimeMetric = new UptimeMetric("up", clock::nanoTime);
         assertEquals(Long.valueOf(0L), uptimeMetric.getValue());
 
         clock.advance(Duration.ofMillis(123));
@@ -50,7 +51,7 @@ public class UptimeMetricTest {
     @Test
     public void withTemporalUnit() {
         final ManualAdvanceClock clock = new ManualAdvanceClock(Instant.now());
-        final UptimeMetric uptimeMetric = new UptimeMetric("up_millis", TimeUnit.MILLISECONDS, clock::nanoTime);
+        final UptimeMetric uptimeMetric = new UptimeMetric("up_millis", clock::nanoTime);
         clock.advance(Duration.ofMillis(1_000_000_000));
 
         // set-up: ensure advancing nanos reflects in our milli-based uptime
@@ -58,6 +59,37 @@ public class UptimeMetricTest {
 
         final UptimeMetric secondsBasedCopy = uptimeMetric.withTimeUnit("up_seconds", TimeUnit.SECONDS);
         assertEquals(Long.valueOf(1_000_000), secondsBasedCopy.getValue());
+
+        clock.advance(Duration.ofMillis(1_999));
+        assertEquals(Long.valueOf(1_000_001_999), uptimeMetric.getValue());
+        assertEquals(Long.valueOf(1_000_001), secondsBasedCopy.getValue());
+    }
+
+    @Test
+    public void withUnitsPrecise() {
+        final ManualAdvanceClock clock = new ManualAdvanceClock(Instant.now());
+        final UptimeMetric uptimeMetric = new UptimeMetric("up_millis", clock::nanoTime);
+        clock.advance(Duration.ofNanos(123_456_789_987L)); // 123.xx seconds
+
+        // set-up: ensure advancing nanos reflects in our milli-based uptime
+        assertEquals(Long.valueOf(123_456L), uptimeMetric.getValue());
+
+        final UptimeMetric.ScaledView secondsBasedView = uptimeMetric.withUnitsPrecise("up_seconds", UptimeMetric.ScaleUnits.SECONDS);
+        final UptimeMetric.ScaledView millisecondsBasedView = uptimeMetric.withUnitsPrecise("up_millis", UptimeMetric.ScaleUnits.MILLISECONDS);
+        final UptimeMetric.ScaledView microsecondsBasedView = uptimeMetric.withUnitsPrecise("up_micros", UptimeMetric.ScaleUnits.MICROSECONDS);
+        final UptimeMetric.ScaledView nanosecondsBasedView = uptimeMetric.withUnitsPrecise("up_nanos", UptimeMetric.ScaleUnits.NANOSECONDS);
+
+        assertEquals(new BigDecimal("123.456789987"), secondsBasedView.getValue());
+        assertEquals(new BigDecimal("123456.789987"), millisecondsBasedView.getValue());
+        assertEquals(new BigDecimal("123456789.987"), microsecondsBasedView.getValue());
+        assertEquals(new BigDecimal("123456789987"), nanosecondsBasedView.getValue());
+
+        clock.advance(Duration.ofMillis(1_999));
+        assertEquals(Long.valueOf(125_455L), uptimeMetric.getValue());
+        assertEquals(new BigDecimal("125.455789987"), secondsBasedView.getValue());
+        assertEquals(new BigDecimal("125455.789987"), millisecondsBasedView.getValue());
+        assertEquals(new BigDecimal("125455789.987"), microsecondsBasedView.getValue());
+        assertEquals(new BigDecimal("125455789987"), nanosecondsBasedView.getValue());
     }
 
 }


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes

[rn:skip]


## What does this PR do?

add `ScaledView` with sub-unit precision to `UptimeMetric`

By presenting a _view_ of our metric that maintains sub-unit precision, we prevent jitter that can be caused by our periodic poller not running at exactly our configured cadence.

The `UptimeMetric.ScaledView` implements `Metric<Number>`, so its full lossless `BigDecimal` value is accessible to our `FlowMetric` at query time.

## Why is it important/What is the impact to the user?

This is especially important as the UptimeMetric is used as the _denominator_ of several flow metrics, and a capture at 4.999s that truncates to 4s, causes the rate to be over-reported by ~25%.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works
