### PR TITLE
metric: register flow metrics only when we have a collector

### DIFF
--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -456,6 +456,8 @@ public class AbstractPipelineExt extends RubyBasicObject {
 
     @JRubyMethod(name = "initialize_flow_metrics")
     public final IRubyObject initializeFlowMetrics(final ThreadContext context) {
+        if (metric.collector(context).isNil()) { return context.nil; }
+
         final UptimeMetric uptimeInMillis = initOrGetUptimeMetric(context, buildNamespace(), context.runtime.newSymbol("uptime_in_millis"));
         final UptimeMetric uptimeInSeconds = uptimeInMillis.withTimeUnit("uptime_in_seconds", TimeUnit.SECONDS);
 


### PR DESCRIPTION
the collector is absent when the pipeline is run in test with a NullMetricExt, or when the pipeline is explicitly configured to
not collect metrics using `metric.collect: false`.

[rn:skip]

