### PR TITLE
PoC to add cgroup v2 support

### DIFF
--- a/logstash-core/lib/logstash/instrument/periodic_poller/cgroup.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/cgroup.rb
@@ -231,4 +231,130 @@ module LogStash module Instrument module PeriodicPoller
       end
     end
   end
+
+  ## cgroupv2 implementation
+  class CgroupV2
+    include LogStash::Util::Loggable
+
+    ## `/proc/self/cgroup` contents look like this
+    # 0::/
+    # CPU statistics are still located in
+    # - cpu.stat
+    # CPU Limit is set within
+    # - cpu.max
+    # Memory Limit is set within
+    # - memory.max
+    # Memory Usage is set within
+    # - memory.current
+
+    CGROUP_FILE = "/proc/self/cgroup"
+    BASE_PATH = "/sys/fs/cgroup"
+    CPUSTAT_FILE = "cpu.stat"
+    CPULIMIT_FILE = "cpu.max"
+    MEMORY_LIMIT_FILE = "memory.max"
+    MEMORY_USAGE_FILE = "memory.current"
+
+    # exclude cpu.max. This could be missing
+    CRITICAL_PATHS = [CPUSTAT_FILE, MEMORY_USAGE_FILE]
+
+    class CGroupResources
+      include LogStash::Util::Loggable
+
+      def initialize
+        @cgroup_path = "/"
+      end
+
+      def cgroup_available?
+        all_lines = IO.readlines(CGROUP_FILE)
+        if all_lines.size == 1 and all_lines[0][0,3] == "0::"
+          @cgroup_path = all_lines[0].split(":")[2].chomp
+          # CRITICAL_PATHS.each do |path|
+          #   full_path = ::File.join(BASE_PATH, @cgroup_path, path)
+          #   unless ::File.exists?(full_path)
+          #     logger.debug("File #{full_path} does not exist")
+          #   end
+          # end
+          CRITICAL_PATHS.all?{|path| ::File.exists?(::File.join(BASE_PATH, @cgroup_path, path))}
+        else
+          false
+        end
+      end
+
+      def get_cpu_stats
+        # read cpu.stat and cpu.max
+        lines = IO.readlines(::File.join(BASE_PATH, @cgroup_path, CPUSTAT_FILE))
+        stats = {}
+        lines.each do |line|
+          parts = line.chomp.split(/\s+/)
+          stats[parts[0]] = parts[1].to_i
+        end
+        # read cpu.max
+        if ::File.exists?(::File.join(BASE_PATH, @cgroup_path, CPULIMIT_FILE))
+          lines = IO.readlines(::File.join(BASE_PATH, @cgroup_path, CPULIMIT_FILE))
+          parts = lines[0].chomp.split(/\s+/)
+          stats["quota_us"] = parts[0].to_i
+          stats["period_us"] = parts[1].to_i
+        end
+        stats
+      end
+
+      def get_mem_stats
+        stats = {}
+        # read memory.current
+        lines = IO.readlines(::File.join(BASE_PATH, @cgroup_path, MEMORY_USAGE_FILE))
+        stats["memory_current"] = lines[0].chomp.to_i
+
+        # read memory.max
+        if ::File.exists?(::File.join(BASE_PATH, @cgroup_path, MEMORY_LIMIT_FILE))
+          lines = IO.readlines(::File.join(BASE_PATH, @cgroup_path, MEMORY_LIMIT_FILE))
+          stats["memory_limit"] = lines[0].chomp.to_i
+        end
+        stats
+      end
+
+      def get_stats(cpu_stats, memory_stats)
+        stats = {}
+        # we need to fake the final object to make the API compatible to cgroup v1 (and metricbeat)
+        stats["cpuacct"] = {
+          "control_group" => @cgroup_path,
+          "usage_nanos" => cpu_stats.fetch("usage_usec", -1)
+        }
+        stats["cpu"] = {
+          "control_group" => @cgroup_path,
+          "cfs_period_micros" => cpu_stats.fetch("period_us", -1),
+          "cfs_quota_micros" => cpu_stats.fetch("quota_us", -1),
+          "stat" => {
+            "number_of_elapsed_periods" => cpu_stats.fetch("nr_periods", -1),
+            "number_of_times_throttled" => cpu_stats.fetch("nr_throttled", -1),
+            "time_throttled_nanos" => cpu_stats.fetch("throttled_usec", -1)
+          }
+        }
+        stats
+      end
+    end
+
+    CGROUP_RESOURCES = CGroupResources.new
+
+    class << self
+      def get_all
+        unless CGROUP_RESOURCES.cgroup_available?
+          logger.debug("One or more required cgroup files or directories not found: #{CRITICAL_PATHS.join(', ')}")
+          return
+        end
+
+        cpu_stats = CGROUP_RESOURCES.get_cpu_stats
+        memory_stats = CGROUP_RESOURCES.get_mem_stats
+
+        cgroups_stats = CGROUP_RESOURCES.get_stats(cpu_stats, memory_stats)
+        cgroups_stats
+      rescue => e
+        logger.debug("Error, cannot retrieve cgroups information", :exception => e.class.name, :message => e.message, :backtrace => e.backtrace.take(4)) if logger.debug?
+        nil
+      end
+
+      def get
+        get_all
+      end
+    end
+  end
 end end end

--- a/logstash-core/lib/logstash/instrument/periodic_poller/os.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/os.rb
@@ -29,7 +29,10 @@ module LogStash module Instrument module PeriodicPoller
     end
 
     def collect_cgroup
-      if stats = Cgroup.get
+      # try cgroup v2 first and fallback to cgroup v1
+      if stats = CgroupV2.get
+        save_metric([:os], :cgroup, stats)
+      elsif stats = Cgroup.get
         save_metric([:os], :cgroup, stats)
       end
     end


### PR DESCRIPTION

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
 [rn:skip]

## What does this PR do?
Very rudimentary implementation to parse cgroup v2 information. This PR code should just be a PoC. It shows, that - at least - the CPU information of a process running in `cgroup v2` can be successfully retrieved and returned by logstash (and fix issue https://github.com/elastic/logstash/issues/14534)

## Why is it important/What is the impact to the user?
When running logstash on a VM or container, that is already using the `cgroup v2`, no metrics will be exposed by logstash and are therefore missing within `Stack Monitoring`

## Checklist
Nothing got checked on my side

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

## How to test this PR locally
- create a VM that uses `cgroup2fs`. You can verify this by running `stat -fc %T /sys/fs/cgroup`. When running `cgroup v2`, the result should be `cgroup2fs`. See example
```
logstash@in-beats-1:/opt$ stat -fc %T /sys/fs/cgroup/
cgroup2fs
logstash@in-beats-1:/opt$
```
- run logstash and check the API via `curl localhost:9600/_node/stats?pretty` . Results should contain an `os` object looking somehow like this 
```
{
  "host" : "in-beats-1",
  "version" : "8.5.0",
  "http_address" : "0.0.0.0:9600",
  "id" : "02e938c4-9a6a-4e38-8023-ca54b86d685c",
  "name" : "in-beats-1",
  "ephemeral_id" : "5343f7f9-093c-4031-aaa3-e24a6312588a",
  "status" : "green",
  "snapshot" : true,
  "pipeline" : {
    "workers" : 4,
    "batch_size" : 125,
    "batch_delay" : 50
  },
  "monitoring" : {
    "cluster_uuid" : "some_cluster_id"
  },
  "jvm" : {
    "threads" : {
      "count" : 206,
      "peak_count" : 208
    },
...
...
  "os" : {
    "cgroup" : {
      "cpuacct" : {
        "control_group" : "/",
        "usage_nanos" : 895076842
      },
      "cpu" : {
        "control_group" : "/",
        "cfs_period_micros" : 100000,
        "cfs_quota_micros" : 400000,
        "stat" : {
          "number_of_times_throttled" : 142,
          "number_of_elapsed_periods" : 58122,
          "time_throttled_nanos" : 65119181
        }
      }
    }
  },
  "queue" : {
    "events_count" : 0
  }
}
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Relates #14534 

## Use cases


## Screenshots
<img width="1191" alt="image" src="https://user-images.githubusercontent.com/12664472/190997588-69cd56ba-314d-4875-bfc2-e43bc1692c55.png">

And here from the running pod 
```
"os" : {
    "cgroup" : {
      "cpu" : {
        "stat" : {
          "time_throttled_nanos" : 70506861,
          "number_of_elapsed_periods" : 63733,
          "number_of_times_throttled" : 145
        },
        "cfs_quota_micros" : 400000,
        "control_group" : "/",
        "cfs_period_micros" : 100000
      },
      "cpuacct" : {
        "control_group" : "/",
        "usage_nanos" : 908588206
      }
    }
  }
```

Note: Still something is missing
Still, the `Stack Monitoring` does not fully work. It looks like the `cfs` values are exported by logstash, but they are _not picked up_ by `metricbeat` (the `node` and `node_stats` code of `logstash` module do not contain a JSON structure to use - at least - the `cfs_quota_micros` values returned.

<img width="1072" alt="image" src="https://user-images.githubusercontent.com/12664472/190998216-655c7dea-2431-4283-9c81-ac748d9833af.png">

<img width="700" alt="image" src="https://user-images.githubusercontent.com/12664472/190998491-d520deea-d0bf-453b-b373-2ddfab72d354.png">

## Logs

