### PR TITLE
Flow metrics global

### DIFF
--- a/docs/static/monitoring/monitoring-apis.asciidoc
+++ b/docs/static/monitoring/monitoring-apis.asciidoc
@@ -315,6 +315,9 @@ Gets process stats, including stats about file descriptors, memory consumption, 
 <<event-stats,`events`>>::
 Gets event-related statistics for the Logstash instance (regardless of how many
 pipelines were created and destroyed).
+<<event-stats,`flow`>>::
+Gets flow-related statistics for the Logstash instance (regardless of how many
+pipelines were created and destroyed).
 <<pipeline-stats,`pipelines`>>::
 Gets runtime stats about each Logstash pipeline.
 <<reload-stats,`reloads`>>::
@@ -455,6 +458,82 @@ Example response:
 --------------------------------------------------
 
 [discrete]
+[[flow-stats]]
+==== Flow stats
+
+The following request returns a JSON document containing flow-rates
+for the Logstash instance:
+
+[source,js]
+--------------------------------------------------
+curl -XGET 'localhost:9600/_node/stats/flow?pretty'
+--------------------------------------------------
+
+Example response:
+
+[source,js]
+--------------------------------------------------
+{
+  "flow" : {
+    "input_throughput" : {
+      "current": 189.720,
+      "lifetime": 201.841
+    },
+    "filter_throughput" : {
+      "current": 187.810,
+      "lifetime": 201.799
+    },
+    "output_throughput" : {
+      "current": 191.087,
+      "lifetime": 201.761
+    },
+    "queue_backpressure" : {
+      "current": 0.277,
+      "lifetime": 0.031
+    },
+    "worker_concurrency" : {
+      "current": 1.973,
+      "lifetime": 1.721
+    }
+  }
+}
+--------------------------------------------------
+
+[%autowidth.stretch]
+|===
+|Flow Rate | Definition
+
+| `input_throughput` |
+This metric is expressed in events-per-second, and is the rate of events being pushed into the pipeline(s) queue(s) relative to wall-clock time (`events.in` / second).
+It includes events that are blocked by the queue and not yet accepted.
+
+| `filter_throughput` |
+This metric is expressed in events-per-second, and is the rate of events flowing through the filter phase of the pipeline(s) relative to wall-clock time (`events.filtered` / second).
+
+| `output_throughput` |
+This metric is expressed in events-per-second, and is the rate of events flowing through the output phase of the pipeline(s) relative to wall-clock time (`events.out` / second).
+
+| `worker_concurrency` |
+This is a unitless metric representing the cumulative time spent by all workers relative to wall-clock time (`duration_in_millis` / millisecond).
+
+A pipeline is considered "saturated" when its `worker_concurrency` flow metric approaches its available `pipeline.workers`, because it indicates that all of its available workers are being kept busy.
+Tuning a saturated pipeline to have more workers can often work to increase that pipeline's throughput and decrease back-pressure to its queue, unless the pipeline is experiencing back-pressure from its outputs.
+
+A process is also considered "saturated" when its top-level `worker_concurrency` flow metric approaches the _cumulative_ `pipeline.workers` across _all_ pipelines, and similarly can be addressed by tuning the <<pipeline-stats,individual pipelines>> that are saturated.
+
+| `queue_backpressure` |
+This is a unitless metric representing the cumulative time spent by all inputs blocked pushing events into their pipeline's queue, relative to wall-clock time (`queue_push_duration_in_millis` / millisecond).
+It is typically most useful when looking at the stats for an <<pipeline-stats,individual pipeline>>.
+
+While a "zero" value indicates no back-pressure to the queue, the magnitude of this metric is highly dependent on the _shape_ of the pipelines and their inputs.
+It cannot be used to compare one pipeline to another or even one process to _itself_ if the quantity or shape of its pipelines changes.
+A pipeline with only one single-threaded input may contribute up to 1.00, a pipeline whose inputs have hundreds of inbound connections may contribute much higher numbers to this combined value.
+
+Additionally, some amount of back-pressure is both _normal_ and _expected_ for pipelines that are _pulling_ data, as this back-pressure allows them to slow down and pull data at a rate its downstream pipeline can tolerate.
+
+|===
+
+[discrete]
 [[pipeline-stats]]
 ==== Pipeline stats
 
@@ -462,6 +541,7 @@ The following request returns a JSON document containing pipeline stats,
 including:
 
 * the number of events that were input, filtered, or output by each pipeline
+* the current and lifetime <<flow-stats,_flow_ rates>> for each pipeline
 * stats for each configured filter or output stage
 * info about config reload successes and failures
 (when <<reloading-config,config reload>> is enabled)
@@ -486,6 +566,28 @@ Example response:
         "filtered" : 216485,
         "out" : 216485,
         "queue_push_duration_in_millis" : 342466
+      },
+      "flow" : {
+        "input_throughput" : {
+          "current": 189.720,
+          "lifetime": 201.841
+        },
+        "filter_throughput" : {
+          "current": 187.810,
+          "lifetime": 201.799
+        },
+        "output_throughput" : {
+          "current": 191.087,
+          "lifetime": 201.761
+        },
+        "queue_backpressure" : {
+          "current": 0.277,
+          "lifetime": 0.031
+        },
+        "worker_concurrency" : {
+          "current": 1.973,
+          "lifetime": 1.721
+        }
       },
       "plugins" : {
         "inputs" : [ {
@@ -546,6 +648,28 @@ Example response:
         "out" : 87247,
         "queue_push_duration_in_millis" : 1532
       },
+      "flow" : {
+        "input_throughput" : {
+          "current": 189.720,
+          "lifetime": 201.841
+        },
+        "filter_throughput" : {
+          "current": 187.810,
+          "lifetime": 201.799
+        },
+        "output_throughput" : {
+          "current": 191.087,
+          "lifetime": 201.761
+        },
+        "queue_backpressure" : {
+          "current": 0.871,
+          "lifetime": 0.031
+        },
+        "worker_concurrency" : {
+          "current": 4.71,
+          "lifetime": 1.201
+        }
+      },
       "plugins" : {
         "inputs" : [ {
           "id" : "d7ea8941c0fc48ac58f89c84a9da482107472b82-1",
@@ -600,6 +724,28 @@ Example response:
         "filtered" : 216485,
         "out" : 216485,
         "queue_push_duration_in_millis" : 342466
+      },
+      "flow" : {
+        "input_throughput" : {
+          "current": 189.720,
+          "lifetime": 201.841
+        },
+        "filter_throughput" : {
+          "current": 187.810,
+          "lifetime": 201.799
+        },
+        "output_throughput" : {
+          "current": 191.087,
+          "lifetime": 201.761
+        },
+        "queue_backpressure" : {
+          "current": 0.277,
+          "lifetime": 0.031
+        },
+        "worker_concurrency" : {
+          "current": 1.973,
+          "lifetime": 1.721
+        }
       },
       "plugins" : {
         "inputs" : [ {

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -81,6 +81,16 @@ module LogStash
           {}
         end
 
+        def flow
+          extract_metrics(
+            [:stats,:flow],
+            :input_throughput, :filter_throughput, :output_throughput, :queue_backpressure, :worker_concurrency
+          )
+        rescue LogStash::Instrument::MetricStore::MetricNotFound
+          # if the stats/events metrics have not yet been populated, return an empty map
+          {}
+        end
+
         def pipeline(pipeline_id = nil, opts={})
           extended_stats = LogStash::Config::PipelinesInfo.format_pipelines_info(
             service.agent,

--- a/logstash-core/lib/logstash/api/modules/node_stats.rb
+++ b/logstash-core/lib/logstash/api/modules/node_stats.rb
@@ -35,6 +35,7 @@ module LogStash
             :jvm => jvm_payload,
             :process => process_payload,
             :events => events_payload,
+            :flow => flow_payload,
             :pipelines => pipeline_payload,
             :reloads => reloads_payload,
             :os => os_payload,
@@ -59,6 +60,10 @@ module LogStash
 
         def events_payload
           @stats.events
+        end
+
+        def flow_payload
+          @stats.flow
         end
 
         def jvm_payload

--- a/logstash-core/lib/logstash/instrument/periodic_poller/flow_rate.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/flow_rate.rb
@@ -26,10 +26,10 @@ module LogStash module Instrument module PeriodicPoller
     end
 
     def collect
+      @agent.capture_flow_metrics
+
       pipelines = @agent.running_user_defined_pipelines
-      pipelines.each_value do |pipeline|
-        pipeline.collect_flow_metrics unless pipeline.nil?
-      end
+      pipelines.values.compact.each(&:collect_flow_metrics)
     end
   end
 end end end


### PR DESCRIPTION

## Release notes

[rn:skip]

## What does this PR do?

 - adds flow metrics to the global top-level namespace, based on the same counterparts in the per-pipeline namespace
 - adds docs for flow metrics in the API documentation for the endpoints where they will be consumed

## Why is it important/What is the impact to the user?

While the top-level `flow` was not defined as in-scope for #14463, I believe users will be surprised by its absence. The metrics themselves are _more_ useful and understandable in the per-pipeline view, but they provide some high-level utility at showing a user _that_ they need to drill down to the pipelines to see what is happening and provide tuning.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally


1. Run a pipeline that produces significant jittery data
    ~~~
    ruby -e '100.times.map { |j| Thread.new(j) { |k| 100000.times { |i| $stdout.write("ok[#{k}/#{i}]\n"); (i%17).zero? && sleep(Random.rand(10)) } } }.map(&:join)' | bin/logstash -e 'input { stdin {} } output { sink {} }'
    ~~~

2. While it is running, query the node stats API and observe presence of top-level `flow`. Note, because the agent is started before its pipelines, the delta between the uptime of the agent and the uptime of its pipeline(s) will play an outsized role on the lifetime rates of global metrics in the first few seconds, but as that delta becomes insignificant relative to the uptime the lifetime rates will converge.

    ~~~
    curl -XGET 'localhost:9600/_node/stats' | jq
    ~~~

3. Additionally, query with type filter(s)

    ~~~
    curl -XGET 'localhost:9600/_node/stats/flow' | jq
    ~~~
    ~~~
    curl -XGET 'localhost:9600/_node/stats/events,flow' | jq
    ~~~


## Related issues

- Extends #14463 
- Superseeds #14533

