### PR TITLE
Backport dra 7.17

### DIFF
--- a/ci/dra.sh
+++ b/ci/dra.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -ie
+#Note - ensure that the -e flag is set to properly set the $? status if any command fails
+
+# Since we are using the system jruby, we need to make sure our jvm process
+# uses at least 1g of memory, If we don't do this we can get OOM issues when
+# installing gems. See https://github.com/elastic/logstash/issues/5179
+export JRUBY_OPTS="-J-Xmx1g"
+
+if [ -z "$VERSION_QUALIFIER_OPT" ]; then
+  RELEASE=1 rake artifact:all
+else
+  VERSION_QUALIFIER="$VERSION_QUALIFIER_OPT" RELEASE=1 rake artifact:all
+fi
+echo "GENERATED ARTIFACTS"
+for file in build/logstash-*; do shasum $file;done
+
+STACK_VERSION=`cat versions.yml | sed -n 's/^logstash\:\s\([[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*\)$/\1/p'`
+
+echo "Creating dependencies report for ${STACK_VERSION}"
+mkdir -p build/reports/dependencies-reports/
+bin/dependencies-report --csv=build/reports/dependencies-reports/logstash-${STACK_VERSION}.csv
+
+echo "GENERATED DEPENDENCIES REPORT"
+shasum build/reports/dependencies-reports/logstash-${STACK_VERSION}.csv

--- a/ci/dra.sh
+++ b/ci/dra.sh
@@ -11,14 +11,20 @@ if [ -z "$VERSION_QUALIFIER_OPT" ]; then
 else
   VERSION_QUALIFIER="$VERSION_QUALIFIER_OPT" RELEASE=1 rake artifact:all
 fi
-echo "GENERATED ARTIFACTS"
-for file in build/logstash-*; do shasum $file;done
 
 STACK_VERSION=`cat versions.yml | sed -n 's/^logstash\:\s\([[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*\)$/\1/p'`
 
+echo "Saving tar.gz for docker images"
+docker save docker.elastic.co/logstash/logstash:${STACK_VERSION}-SNAPSHOT | gzip -c > build/logstash-${STACK_VERSION}-docker-image-x86_64.tar.gz
+docker save docker.elastic.co/logstash/logstash-oss:${STACK_VERSION}-SNAPSHOT | gzip -c > build/logstash-oss-${STACK_VERSION}-docker-image-x86_64.tar.gz
+docker save docker.elastic.co/logstash/logstash-ubi8:${STACK_VERSION}-SNAPSHOT | gzip -c > build/logstash-ubi8-${STACK_VERSION}-docker-image-x86_64.tar.gz
+
+echo "GENERATED ARTIFACTS"
+for file in build/logstash-*; do shasum $file;done
+
 echo "Creating dependencies report for ${STACK_VERSION}"
-mkdir -p build/reports/dependencies-reports/
-bin/dependencies-report --csv=build/reports/dependencies-reports/logstash-${STACK_VERSION}.csv
+mkdir -p build/distributions/dependencies-reports/
+bin/dependencies-report --csv=build/distributions/dependencies-reports/logstash-${STACK_VERSION}.csv
 
 echo "GENERATED DEPENDENCIES REPORT"
 shasum build/reports/dependencies-reports/logstash-${STACK_VERSION}.csv

--- a/ci/dra_aarch64.sh
+++ b/ci/dra_aarch64.sh
@@ -25,3 +25,9 @@ docker save docker.elastic.co/logstash/logstash-ubi8:${STACK_VERSION}-SNAPSHOT |
 
 echo "GENERATED ARTIFACTS"
 for file in build/logstash-*; do shasum $file;done
+
+echo "UPLOADING TO INTERMEDIATE BUCKET"
+# Note the deb, rpm tar.gz AARCH64 files generated has already been loaded by the dra_x86_64.sh
+gsutil cp build/logstash-${STACK_VERSION}-docker-image-aarch64.tar.gz gs://logstash-ci-artifacts/dra/${STACK_VERSION}/
+gsutil cp build/logstash-oss-${STACK_VERSION}-docker-image-aarch64.tar.gz gs://logstash-ci-artifacts/dra/${STACK_VERSION}/
+gsutil cp build/logstash-ubi8-${STACK_VERSION}-docker-image-aarch64.tar.gz gs://logstash-ci-artifacts/dra/${STACK_VERSION}/

--- a/ci/dra_aarch64.sh
+++ b/ci/dra_aarch64.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -ie
+#Note - ensure that the -e flag is set to properly set the $? status if any command fails
+
+# Since we are using the system jruby, we need to make sure our jvm process
+# uses at least 1g of memory, If we don't do this we can get OOM issues when
+# installing gems. See https://github.com/elastic/logstash/issues/5179
+export JRUBY_OPTS="-J-Xmx1g"
+
+if [ -z "$VERSION_QUALIFIER_OPT" ]; then
+  RELEASE=1 rake artifact:docker
+  RELEASE=1 rake artifact:docker_oss
+  rake artifact:dockerfiles
+else
+  VERSION_QUALIFIER="$VERSION_QUALIFIER_OPT" RELEASE=1 rake artifact:docker
+  VERSION_QUALIFIER="$VERSION_QUALIFIER_OPT" RELEASE=1 rake artifact:docker_oss
+  VERSION_QUALIFIER="$VERSION_QUALIFIER_OPT" rake artifact:dockerfiles
+fi
+
+STACK_VERSION=`cat versions.yml | sed -n 's/^logstash\:\s\([[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*\)$/\1/p'`
+
+echo "Saving tar.gz for docker images"
+docker save docker.elastic.co/logstash/logstash:${STACK_VERSION}-SNAPSHOT | gzip -c > build/logstash-${STACK_VERSION}-docker-image-aarch64.tar.gz
+docker save docker.elastic.co/logstash/logstash-oss:${STACK_VERSION}-SNAPSHOT | gzip -c > build/logstash-oss-${STACK_VERSION}-docker-image-aarch64.tar.gz
+docker save docker.elastic.co/logstash/logstash-ubi8:${STACK_VERSION}-SNAPSHOT | gzip -c > build/logstash-ubi8-${STACK_VERSION}-docker-image-aarch64.tar.gz
+
+echo "GENERATED ARTIFACTS"
+for file in build/logstash-*; do shasum $file;done

--- a/ci/dra_upload.sh
+++ b/ci/dra_upload.sh
@@ -1,0 +1,107 @@
+#!/bin/bash -ie
+#Note - ensure that the -e flag is set to properly set the $? status if any command fails
+
+# Since we are using the system jruby, we need to make sure our jvm process
+# uses at least 1g of memory, If we don't do this we can get OOM issues when
+# installing gems. See https://github.com/elastic/logstash/issues/5179
+export JRUBY_OPTS="-J-Xmx1g"
+
+STACK_VERSION=`cat versions.yml | sed -n 's/^logstash\:\s\([[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*\)$/\1/p'`
+RELEASE_BRANCH=`git rev-parse --abbrev-ref HEAD`
+
+echo "Download all the artifacts for version ${STACK_VERSION}"
+mkdir build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-${STACK_VERSION}-no-jdk.deb build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-${STACK_VERSION}.csv build/
+
+# no arch
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-${STACK_VERSION}-no-jdk.deb build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-${STACK_VERSION}-no-jdk.rpm build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-${STACK_VERSION}-no-jdk.tar.gz build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-${STACK_VERSION}-no-jdk.zip build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-oss-${STACK_VERSION}-no-jdk.deb build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-oss-${STACK_VERSION}-no-jdk.rpm build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-oss-${STACK_VERSION}-no-jdk.tar.gz build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-oss-${STACK_VERSION}-no-jdk.zip build/
+
+# windows
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-${STACK_VERSION}-windows-x86_64.zip build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-oss-${STACK_VERSION}-windows-x86_64.zip build/
+
+# unix x86
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-${STACK_VERSION}-amd64.deb build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-${STACK_VERSION}-x86_64.rpm build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-${STACK_VERSION}-linux-x86_64.tar.gz build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-${STACK_VERSION}-darwin-x86_64.tar.gz build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-oss-${STACK_VERSION}-amd64.deb build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-oss-${STACK_VERSION}-x86_64.rpm build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-oss-${STACK_VERSION}-linux-x86_64.tar.gz build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-oss-${STACK_VERSION}-darwin-x86_64.tar.gz build/
+
+# unix ARM
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-${STACK_VERSION}-arm64.deb build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-${STACK_VERSION}-aarch64.rpm build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-${STACK_VERSION}-linux-aarch64.tar.gz build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-${STACK_VERSION}-darwin-aarch64.tar.gz build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-oss-${STACK_VERSION}-arm64.deb build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-oss-${STACK_VERSION}-aarch64.rpm build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-oss-${STACK_VERSION}-linux-aarch64.tar.gz build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-oss-${STACK_VERSION}-darwin-aarch64.tar.gz build/
+
+# docker
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-${STACK_VERSION}-docker-build-context.tar.gz build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-ironbank-${STACK_VERSION}-docker-build-context.tar.gz build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-oss-${STACK_VERSION}-docker-build-context.tar.gz build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-ubi8-${STACK_VERSION}-docker-build-context.tar.gz build/
+
+# docker x86
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-${STACK_VERSION}-docker-image-x86_64.tar.gz build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-oss-${STACK_VERSION}-docker-image-x86_64.tar.gz build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-ubi8-${STACK_VERSION}-docker-image-x86_64.tar.gz build/
+
+# docker ARM
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-${STACK_VERSION}-docker-image-aarch64.tar.gz build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-oss-${STACK_VERSION}-docker-image-aarch64.tar.gz build/
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-ubi8-${STACK_VERSION}-docker-image-aarch64.tar.gz build/
+
+gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-${STACK_VERSION}.csv build/
+
+echo "Downloaded ARTIFACTS"
+for file in build/logstash-*; do shasum $file;done
+
+# reposition files as expected by the release-manager
+mv build/logstash-${STACK_VERSION}-docker-image-x86_64.tar.gz .
+mv build/logstash-oss-${STACK_VERSION}-docker-image-x86_64.tar.gz .
+mv build/logstash-ubi8-${STACK_VERSION}-docker-image-x86_64.tar.gz .
+mv build/logstash-${STACK_VERSION}-docker-image-aarch64.tar.gz .
+mv build/logstash-oss-${STACK_VERSION}-docker-image-aarch64.tar.gz .
+mv build/logstash-ubi8-${STACK_VERSION}-docker-image-aarch64.tar.gz .
+
+mkdir -p build/distributions/dependencies-reports/
+mv build/logstash-${STACK_VERSION}.csv build/distributions/dependencies-${STACK_VERSION}.csv
+
+# set required permissions on artifacts and directory
+chmod -R a+r build/*
+chmod -R a+w build
+
+chmod -R a+r $PWD/*
+chmod -R a+w $PWD
+
+# ensure the latest image has been pulled
+docker pull docker.elastic.co/infra/release-manager:latest
+
+# collect the artifacts for use with the unified build
+docker run --rm \
+  --name release-manager \
+  -e VAULT_ADDR \
+  -e VAULT_ROLE_ID \
+  -e VAULT_SECRET_ID \
+  --mount type=bind,readonly=false,src="$PWD",target=/artifacts \
+  docker.elastic.co/infra/release-manager:latest \
+    cli collect \
+      --project logstash \
+      --branch ${RELEASE_BRANCH} \
+      --commit "$(git rev-parse HEAD)" \
+      --workflow "staging" \
+      --version "${STACK_VERSION}" \
+      --artifact-set main

--- a/ci/dra_x86_64.sh
+++ b/ci/dra_x86_64.sh
@@ -27,4 +27,4 @@ mkdir -p build/distributions/dependencies-reports/
 bin/dependencies-report --csv=build/distributions/dependencies-reports/logstash-${STACK_VERSION}.csv
 
 echo "GENERATED DEPENDENCIES REPORT"
-shasum build/reports/dependencies-reports/logstash-${STACK_VERSION}.csv
+shasum build/distributions/dependencies-reports/logstash-${STACK_VERSION}.csv

--- a/ci/dra_x86_64.sh
+++ b/ci/dra_x86_64.sh
@@ -28,3 +28,13 @@ bin/dependencies-report --csv=build/distributions/dependencies-reports/logstash-
 
 echo "GENERATED DEPENDENCIES REPORT"
 shasum build/distributions/dependencies-reports/logstash-${STACK_VERSION}.csv
+
+echo "UPLOADING TO INTERMEDIATE BUCKET"
+for file in build/logstash-*; do
+  gsutil cp $file gs://logstash-ci-artifacts/dra/${STACK_VERSION}/
+done
+
+gsutil cp build/distributions/dependencies-reports/logstash-${STACK_VERSION}.csv gs://logstash-ci-artifacts/dra/${STACK_VERSION}/
+gsutil cp build/logstash-${STACK_VERSION}-docker-image-x86_64.tar.gz gs://logstash-ci-artifacts/dra/${STACK_VERSION}/
+gsutil cp build/logstash-oss-${STACK_VERSION}-docker-image-x86_64.tar.gz gs://logstash-ci-artifacts/dra/${STACK_VERSION}/
+gsutil cp build/logstash-ubi8-${STACK_VERSION}-docker-image-x86_64.tar.gz gs://logstash-ci-artifacts/dra/${STACK_VERSION}/


### PR DESCRIPTION
This is a **not clean backport** of the following PRs to `8.5` branch:

- Introduces a bash script to build all the artifacts and dependencies report. #14522
- Save docker images as tar.gz files move the CSV dependency report in the path that's expected by release-manager #14552 
- Split ci scripts into ARM and x86 ones #14567
- Uses the gsutil tool to upload all the generated artifacts into an intermediate collector bucket. #14568 
- Collect all artifacts created and upload to GCP with release-manager #14584