### PR TITLE
spec: fix NoMethodError on NilClass in spec precondition wait

### DIFF
--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -205,6 +205,7 @@ describe "Test Monitoring API" do
       # monitoring api can fail if the subsystem isn't ready
       result = logstash_service.monitoring_api.logging_get rescue nil
       expect(result).not_to be_nil
+      expect(result).to include("loggers")
       expect(result["loggers"].size).to be > 0
     end
 


### PR DESCRIPTION
## Release notes

[rn:skip]


## What does this PR do?

Fixes a flaky test failing its pre-condition:

~~~
12:45:36          Failure/Error: expect(result["loggers"].size).to be > 0
12:45:36          
12:45:36          NoMethodError:
12:45:36            undefined method `size' for nil:NilClass
12:45:36          # ./specs/monitoring_api_spec.rb:208:in `block in <main>'
12:45:36          # /opt/logstash/build/qa/integration/vendor/jruby/2.6.0/gems/stud-0.0.23/lib/stud/try.rb:79:in `block in try'
12:45:36          # /opt/logstash/build/qa/integration/vendor/jruby/2.6.0/gems/stud-0.0.23/lib/stud/try.rb:95:in `block in try'
12:45:36          # /opt/logstash/build/qa/integration/vendor/jruby/2.6.0/gems/stud-0.0.23/lib/stud/try.rb:91:in `try'
12:45:36          # /opt/logstash/build/qa/integration/vendor/jruby/2.6.0/gems/stud-0.0.23/lib/stud/try.rb:123:in `try'
12:45:36          # ./specs/monitoring_api_spec.rb:204:in `block in <main>'
12:45:36          # /opt/logstash/build/qa/integration/vendor/jruby/2.6.0/gems/logstash-devutils-2.4.0-java/lib/logstash/devutils/rspec/spec_helper.rb:61:in `block in <main>'
12:45:36          # ./rspec.rb:37:in `<main>'
~~~

## Why is it important/What is the impact to the user?

N/A

## Checklist


- [x] My code follows the style guidelines of this project
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~

