### PR TITLE
Extract the branch name passed to release-manager from version file

### DIFF
--- a/ci/dra_upload.sh
+++ b/ci/dra_upload.sh
@@ -7,7 +7,7 @@
 export JRUBY_OPTS="-J-Xmx1g"
 
 STACK_VERSION=`cat versions.yml | sed -n 's/^logstash\:\s\([[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*\)$/\1/p'`
-RELEASE_BRANCH=`cat versions.yml | sed -n 's/^logstash\:\s\([[:digit:]]*\.[[:digit:]]*\)\.[[:digit:]]*$/\1/p'`
+RELEASE_BRANCH=`cat versions.yml | sed -n 's/^logstash\:[[:space:]]\([[:digit:]]*\.[[:digit:]]*\)\.[[:digit:]]*$/\1/p'`
 
 echo "Download all the artifacts for version ${STACK_VERSION}"
 mkdir build/

--- a/ci/dra_upload.sh
+++ b/ci/dra_upload.sh
@@ -7,7 +7,7 @@
 export JRUBY_OPTS="-J-Xmx1g"
 
 STACK_VERSION=`cat versions.yml | sed -n 's/^logstash\:\s\([[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*\)$/\1/p'`
-RELEASE_BRANCH=`cat versions.yml | sed -n 's/^logstash\:\s\([[:digit:]]*\.[[:digit:]]*)\.[[:digit:]]*)$/\1/p'`
+RELEASE_BRANCH=`cat versions.yml | sed -n 's/^logstash\:\s\([[:digit:]]*\.[[:digit:]]*\)\.[[:digit:]]*$/\1/p'`
 
 echo "Download all the artifacts for version ${STACK_VERSION}"
 mkdir build/

--- a/ci/dra_upload.sh
+++ b/ci/dra_upload.sh
@@ -7,7 +7,7 @@
 export JRUBY_OPTS="-J-Xmx1g"
 
 STACK_VERSION=`cat versions.yml | sed -n 's/^logstash\:\s\([[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*\)$/\1/p'`
-RELEASE_BRANCH=`git rev-parse --abbrev-ref HEAD`
+RELEASE_BRANCH=`cat versions.yml | sed -n 's/^logstash\:\s\([[:digit:]]*\.[[:digit:]]*)\.[[:digit:]]*)$/\1/p'`
 
 echo "Download all the artifacts for version ${STACK_VERSION}"
 mkdir build/


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Extracts the branch release name from the `version.yml` and not from current `git`  branch

## How to test

Verify that, running the  regexp, like
```bash
cat versions.yml | sed -n 's/^logstash\:\s\([[:digit:]]*\.[[:digit:]]*\)\.[[:digit:]]*$/\1/p'
```
on console, it extracts the expected `major.minor` for the release branches and `main`