### PR TITLE
Fix DLQ fails to start due to read 1 byte file

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReader.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueReader.java
@@ -100,7 +100,9 @@ public final class DeadLetterQueueReader implements Closeable {
         this.segments = new ConcurrentSkipListSet<>(
                 Comparator.comparingInt(DeadLetterQueueUtils::extractSegmentId)
         );
-        segments.addAll(listSegmentPaths(queuePath).collect(Collectors.toList()));
+        segments.addAll(listSegmentPaths(queuePath)
+                .filter(p -> p.toFile().length() > 1) // take the files that have content to process
+                .collect(Collectors.toList()));
         this.cleanConsumed = cleanConsumed;
         if (cleanConsumed && segmentCallback == null) {
             throw new IllegalArgumentException("When cleanConsumed is enabled must be passed also a valid segment listener");

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueUtils.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueUtils.java
@@ -41,10 +41,9 @@ class DeadLetterQueueUtils {
     }
 
     static Stream<Path> listFiles(Path path, String suffix) throws IOException {
-        try(final Stream<Path> files = Files.list(path)) {
-            return files.filter(p -> p.toString().endsWith(suffix))
-                    .collect(Collectors.toList()).stream();
-        }
+        return Files.list(path)
+                .filter(p -> p.toString().endsWith(suffix))
+                .filter(p -> p.toFile().length() > 1); // take the files that have content to process
     }
 
     static Stream<Path> listSegmentPaths(Path path) throws IOException {

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueUtils.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueUtils.java
@@ -41,9 +41,7 @@ class DeadLetterQueueUtils {
     }
 
     static Stream<Path> listFiles(Path path, String suffix) throws IOException {
-        return Files.list(path)
-                .filter(p -> p.toString().endsWith(suffix))
-                .filter(p -> p.toFile().length() > 1); // take the files that have content to process
+        return Files.list(path).filter(p -> p.toString().endsWith(suffix));
     }
 
     static Stream<Path> listSegmentPaths(Path path) throws IOException {

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueUtils.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueUtils.java
@@ -41,7 +41,10 @@ class DeadLetterQueueUtils {
     }
 
     static Stream<Path> listFiles(Path path, String suffix) throws IOException {
-        return Files.list(path).filter(p -> p.toString().endsWith(suffix));
+        try(final Stream<Path> files = Files.list(path)) {
+            return files.filter(p -> p.toString().endsWith(suffix))
+                    .collect(Collectors.toList()).stream();
+        }
     }
 
     static Stream<Path> listSegmentPaths(Path path) throws IOException {

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
@@ -546,7 +546,7 @@ public class DeadLetterQueueReaderTest {
     @Test
     public void testSeekByTimestampWhenSegmentIs1Byte() throws IOException, InterruptedException {
         final long startTime = System.currentTimeMillis();
-        com.google.common.io.Files.touch(dir.resolve("1.log").toFile());
+        Files.write(dir.resolve("1.log"), "1".getBytes());
 
         try (DeadLetterQueueReader reader = new DeadLetterQueueReader(dir)) {
 

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
@@ -543,6 +543,23 @@ public class DeadLetterQueueReaderTest {
         }
     }
 
+    @Test
+    public void testSeekByTimestampWhenSegmentIs1Byte() throws IOException, InterruptedException {
+        final long startTime = System.currentTimeMillis();
+        com.google.common.io.Files.touch(dir.resolve("1.log").toFile());
+
+        try (DeadLetterQueueReader reader = new DeadLetterQueueReader(dir)) {
+
+            //Exercise
+            final Timestamp seekTarget = new Timestamp(startTime);
+            reader.seekToNextEvent(seekTarget);
+
+            // Verify, no entry is available, reader should seek without exception
+            DLQEntry readEntry = reader.pollEntry(100);
+            assertNull("No entry is available after all segments are deleted", readEntry);
+        }
+    }
+
     /**
      * Tests concurrently reading and writing from the DLQ.
      * @throws Exception On Failure


### PR DESCRIPTION


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Fix DLQ fails to start due to read 1 byte file

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

This commit ignores DLQ files that contain only the version number. These files have no content and should be skipped. 

## Why is it important/What is the impact to the user?

Mapping 1 byte DLQ files to buffer causes java.lang.IllegalArgumentException: newPosition < 0: (-1 < 0)
User is unable to start the pipeline using dead_letter_queue input

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] manually test the 1 byte file and can start Logstash 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

follow the reproducer of #14599

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Fixed: #14599

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
