### PR TITLE
timestamp: respect locale's decimal-style when parsing

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Timestamp.java
+++ b/logstash-core/src/main/java/org/logstash/Timestamp.java
@@ -28,10 +28,16 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DecimalStyle;
 import java.time.format.ResolverStyle;
 import java.time.temporal.ChronoField;
 import java.util.Date;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.logstash.ackedqueue.Queueable;
 
 /**
@@ -42,6 +48,8 @@ import org.logstash.ackedqueue.Queueable;
 @JsonSerialize(using = ObjectMappers.TimestampSerializer.class)
 @JsonDeserialize(using = ObjectMappers.TimestampDeserializer.class)
 public final class Timestamp implements Comparable<Timestamp>, Queueable {
+
+    private static final Logger LOGGER = LogManager.getLogger(Timestamp.class);
 
     private transient org.joda.time.DateTime time;
 
@@ -57,11 +65,11 @@ public final class Timestamp implements Comparable<Timestamp>, Queueable {
     }
 
     public Timestamp(String iso8601) {
-        this(iso8601, Clock.systemDefaultZone());
+        this(iso8601, Clock.systemDefaultZone(), Locale.getDefault());
     }
 
-    Timestamp(final String iso8601, final Clock clock) {
-        this.instant = tryParse(iso8601, clock);
+    Timestamp(final String iso8601, final Clock clock, final Locale locale) {
+        this.instant = tryParse(iso8601, clock, locale);
     }
 
     Timestamp(final Clock clock) {
@@ -164,13 +172,47 @@ public final class Timestamp implements Comparable<Timestamp>, Queueable {
             .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
             .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
             .parseDefaulting(ChronoField.NANO_OF_SECOND, 0)
-            .toFormatter().withZone(ZoneId.systemDefault());
+            .toFormatter()
+            .withZone(ZoneId.systemDefault())
+            .withDecimalStyle(DecimalStyle.ofDefaultLocale());
 
-    private static Instant tryParse(final String iso8601, final Clock clock) {
+    private static Instant tryParse(final String iso8601, final Clock clock, final Locale locale) {
+        final DateTimeFormatter configuredFormatter = LENIENT_ISO_DATE_TIME_FORMATTER.withLocale(locale)
+                                                                                     .withDecimalStyle(DecimalStyle.of(locale))
+                                                                                     .withZone(clock.getZone());
+        return tryParse(iso8601, configuredFormatter)
+                .or(() -> tryFallbackParse(iso8601, configuredFormatter, (f) -> f.withDecimalStyle(DecimalStyle.STANDARD)))
+                .orElseThrow(() -> new IllegalArgumentException(String.format("Invalid ISO8601 input `%s`", iso8601)));
+    }
+
+    private static Optional<Instant> tryParse(final String iso8601,
+                                              final DateTimeFormatter configuredFormatter) {
         try {
-            return LENIENT_ISO_DATE_TIME_FORMATTER.withZone(clock.getZone()).parse(iso8601, Instant::from);
+            return Optional.of(configuredFormatter.parse(iso8601, Instant::from));
         } catch (java.time.format.DateTimeParseException e) {
-            throw new IllegalArgumentException(String.format("Invalid ISO8601 input `%s`", iso8601), e);
+            LOGGER.trace(String.format("Failed to parse `%s` with locale:`%s` and decimal_style:`%s`", iso8601, configuredFormatter.getLocale(), configuredFormatter.getDecimalStyle()), e);
+            return Optional.empty();
         }
+    }
+
+    /**
+     * Attempts to parse the input if-and-only-if the provided {@code formatterTransformer}
+     * effectively transforms the provided {@code baseFormatter}. This is intended to be a
+     * fallback method for a maybe-modified formatter to prevent re-parsing the same input
+     * with the same formatter multiple times.
+     *
+     * @param iso8601 an ISO8601-ish string
+     * @param baseFormatter the base formatter
+     * @param formatterTransformer a transformation operator (such as using DateTimeFormat#withDecimalStyle)
+     * @return an {@code Optional}, which contains a value if-and-only-if the effective format is different
+     *         from the base format and successfully parsed the input
+     */
+    private static Optional<Instant> tryFallbackParse(final String iso8601,
+                                                      final DateTimeFormatter baseFormatter,
+                                                      final UnaryOperator<DateTimeFormatter> formatterTransformer) {
+        final DateTimeFormatter modifiedFormatter = formatterTransformer.apply(baseFormatter);
+        if (modifiedFormatter.equals(baseFormatter)) { return Optional.empty(); }
+
+        return tryParse(iso8601, modifiedFormatter);
     }
 }

--- a/logstash-core/src/test/java/org/logstash/TimestampTest.java
+++ b/logstash-core/src/test/java/org/logstash/TimestampTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.Locale;
 
 import static org.junit.Assert.*;
 
@@ -35,6 +36,7 @@ public class TimestampTest {
 
 
     static final Clock OFFSET_CLOCK = Clock.systemUTC().withZone(ZoneId.of("-08:00"));
+    static final Locale LOCALE = Locale.US;
 
     @Test
     @SuppressWarnings({"deprecation"})
@@ -48,37 +50,51 @@ public class TimestampTest {
 
     @Test
     public void testToString() throws Exception {
-        Timestamp t = new Timestamp("2014-09-23T12:34:56.789012345-0800", OFFSET_CLOCK);
+        Timestamp t = new Timestamp("2014-09-23T12:34:56.789012345-0800", OFFSET_CLOCK, LOCALE);
         assertEquals("2014-09-23T20:34:56.789012345Z", t.toString());
     }
 
     @Test
     public void testToStringNoNanos() throws Exception {
-        Timestamp t = new Timestamp("2014-09-23T12:34:56.000000000-0800", OFFSET_CLOCK);
+        Timestamp t = new Timestamp("2014-09-23T12:34:56.000000000-0800", OFFSET_CLOCK, LOCALE);
         assertEquals("2014-09-23T20:34:56.000Z", t.toString());
     }
 
     @Test
     public void testParsingDateTimeNoOffset() throws Exception {
-        final Timestamp t = new Timestamp("2014-09-23T12:34:56.789012345", OFFSET_CLOCK);
+        final Timestamp t = new Timestamp("2014-09-23T12:34:56.789012345", OFFSET_CLOCK, LOCALE);
         assertEquals("2014-09-23T20:34:56.789012345Z", t.toString());
     }
     @Test
     public void testParsingDateNoOffset() throws Exception {
-        final Timestamp t = new Timestamp("2014-09-23", OFFSET_CLOCK);
+        final Timestamp t = new Timestamp("2014-09-23", OFFSET_CLOCK, LOCALE);
         assertEquals("2014-09-23T08:00:00.000Z", t.toString());
     }
 
     @Test
     public void testParsingDateWithOffset() throws Exception {
-        final Timestamp t = new Timestamp("2014-09-23-08:00", OFFSET_CLOCK);
+        final Timestamp t = new Timestamp("2014-09-23-08:00", OFFSET_CLOCK, LOCALE);
         assertEquals("2014-09-23T08:00:00.000Z", t.toString());
     }
 
     @Test
     public void testParsingDateTimeWithZOffset() throws Exception {
-        final Timestamp t = new Timestamp("2014-09-23T13:49:52.987654321Z", OFFSET_CLOCK);
+        final Timestamp t = new Timestamp("2014-09-23T13:49:52.987654321Z", OFFSET_CLOCK, LOCALE);
         assertEquals("2014-09-23T13:49:52.987654321Z", t.toString());
+    }
+
+    @Test
+    public void testParsingDateTimeWithCommaDecimalStyleLocale() throws Exception {
+        final Locale germanLocale = Locale.GERMANY;
+        final Clock germanClock = Clock.systemUTC().withZone(ZoneId.of("+02:00")); // DST doesn't matter
+
+        // comma-decimal
+        final Timestamp t1 = new Timestamp("2014-09-23T13:49:52,987654321Z", germanClock, germanLocale);
+        assertEquals("2014-09-23T13:49:52.987654321Z", t1.toString());
+
+        // fallback to stop-decimal
+        final Timestamp t2 = new Timestamp("2014-09-23T13:49:52.987654321Z", germanClock, germanLocale);
+        assertEquals("2014-09-23T13:49:52.987654321Z", t2.toString());
     }
 
     // Timestamp should always be in a UTC representation


### PR DESCRIPTION
Uses the locale-defined decimal style first.

When encountering a failure and the locale-defined decimal style is NOT the "standard" decimal style, retry the parse operation with the "standard" decimal style.

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes

Fixes a locale-related issue where timestamps that included comma-style decimals could not be parsed even when Logstash was configured to run in a locale that supported comma-style decimals. The timestamp-parser now correctly attempts the locale-defined decimal style first, and falls back to the "standard" decimal style.

## What does this PR do?

Java's `DateTimeFormatterBuilder#toFormatter` always uses the "standard" decimal style, ignoring the one that is provided by the locale. In order to get it to correctly parse with a specific decimal-style, we need to get a modified formatter with that decimal style.

With this PR, we default to using the locale-supplied decimal style, and fall back to the "standard" decimal style if-and-only-if the locale-supplied decimal style is not "standard".

To do this _efficiently_, we

1. We create a `static final DateTimeFormatter` with the system default locale _and_ decimal-style, along with all of our parsing rules (no change)
2. when parsing, we use the `DateTimeFormatter#with*` helpers to get a formatter with a specific locale and decimal style, which is a no-op in production code because both `locale` and `decimalStyle` will be the same as their system-defaults.
3. we try to parse, returning the result on success
4. on failure, we fall back to a modified formatter with the "standard" decimal style (to ensure backward compatibility), but only actually parse if this standard-decimal-style formatter is _different_ than the one we just failed to parse with
5. if we still don't have a parsed time object, we throw the relevant exception.


## Why is it important/What is the impact to the user?

Users parse logs that have perfectly-legal ISO8601 timestamps. Logstash 7.x was able to handle this due to joda-time's localization loading, but we effectively break with the move to more-precise timestamps using native `java.time` in Logstash 8.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- [x] I have added tests that prove my fix is effective or that my feature works


## How to test this PR locally

~~~
echo '{"@timestamp":"2022-10-10T15:06:48,397Z"}' | LS_JAVA_OPTS="-Duser.country=DE -Duser.language=de" bin/logstash -e 'input { stdin { codec => json } }'
~~~

## Related issues

Closes: https://github.com/elastic/logstash/issues/14627