### PR TITLE
Avoid to pass SNAPSHOT particle to the version passed to release-manager

### DIFF
--- a/ci/dra_upload.sh
+++ b/ci/dra_upload.sh
@@ -10,6 +10,7 @@ export JRUBY_OPTS="-J-Xmx1g"
 # e.g.: 8.6.0
 # The suffix part like alpha1 etc is managed by the optional VERSION_QUALIFIER_OPT environment variable
 STACK_VERSION=`cat versions.yml | sed -n 's/^logstash\:[[:space:]]\([[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*\)$/\1/p'`
+PLAIN_STACK_VERSION=$STACK_VERSION
 
 # This is the branch selector that needs to be passed to the release-manager
 # It has to be the name of the branch which originates the artifacts.
@@ -120,5 +121,5 @@ docker run --rm \
       --branch ${RELEASE_BRANCH} \
       --commit "$(git rev-parse HEAD)" \
       --workflow "${WORKFLOW}" \
-      --version "${STACK_VERSION}" \
+      --version "${PLAIN_STACK_VERSION}" \
       --artifact-set main


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip] 

## What does this PR do?

The version passed to the `release-manager` doesn't need the SNAPSHOT particle because already handled by the `--workflow="snapshot"`, if inserted make the release manager to search for artifacts named as `8.5.0-SNAPSHOT-SNAPSHOT`
