### PR TITLE
Follow up PR of #14645, adds version qualifier to the plain version

### DIFF
--- a/ci/dra_upload.sh
+++ b/ci/dra_upload.sh
@@ -26,6 +26,7 @@ if [ -n "$VERSION_QUALIFIER_OPT" ]; then
   # in case of alpha or beta releases:
   # e.g: 8.0.0-alpha1
   STACK_VERSION="${STACK_VERSION}-${VERSION_QUALIFIER_OPT}"
+  RELEASE_VER="${RELEASE_VER}-${VERSION_QUALIFIER_OPT}"
 fi
 
 WORKFLOW="staging"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip] 

## What does this PR do?

This is a follow up PR #14645, adds the missed `version_qualifier` to the plain version variable

