### PR TITLE
Fix dra_common sourcing

### DIFF
--- a/ci/dra_aarch64.sh
+++ b/ci/dra_aarch64.sh
@@ -4,7 +4,7 @@ echo "####################################################################"
 echo "##################### Starting $0"
 echo "####################################################################"
 
-source ./dra_common.sh
+source ./$(dirname "$0")/dra_common.sh
 
 # WORKFLOW_TYPE is a CI externally configured environment variable that could assume "snapshot" or "staging" values
 case "$WORKFLOW_TYPE" in

--- a/ci/dra_x86_64.sh
+++ b/ci/dra_x86_64.sh
@@ -4,7 +4,7 @@ echo "####################################################################"
 echo "##################### Starting $0"
 echo "####################################################################"
 
-source ./dra_common.sh
+source ./$(dirname "$0")/dra_common.sh
 
 # WORKFLOW_TYPE is a CI externally configured environment variable that could assume "snapshot" or "staging" values
 case "$WORKFLOW_TYPE" in


### PR DESCRIPTION
Fixes the source of dra_common.sh. It will now first check the directory of the file from which this dra_common.sh script is being called. This allows the common script to be sourced regardless of where the sourcing script is being called from.