### PR TITLE
Exclude jruby's bundler from artifacts

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -95,6 +95,13 @@ namespace "artifact" do
     @exclude_paths << 'vendor/**/gems/*/test/**/*'
     @exclude_paths << 'vendor/**/gems/*/spec/**/*'
 
+    # jruby's bundler artifacts
+    @exclude_paths << 'vendor/jruby/bin/bundle*'
+    @exclude_paths << 'vendor/jruby/lib/ruby/stdlib/bundler*'
+    @exclude_paths << 'vendor/jruby/lib/ruby/gems/shared/specifications/default/bundler-*.spec'
+    @exclude_paths << 'vendor/jruby/lib/ruby/gems/bundler-*'
+    @exclude_paths << 'vendor/jruby/lib/ruby/gems/rake-*'
+
     @exclude_paths
   end
 

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -99,8 +99,8 @@ namespace "artifact" do
     @exclude_paths << 'vendor/jruby/bin/bundle*'
     @exclude_paths << 'vendor/jruby/lib/ruby/stdlib/bundler*'
     @exclude_paths << 'vendor/jruby/lib/ruby/gems/shared/specifications/default/bundler-*.spec'
-    @exclude_paths << 'vendor/jruby/lib/ruby/gems/bundler-*'
-    @exclude_paths << 'vendor/jruby/lib/ruby/gems/rake-*'
+    @exclude_paths << 'vendor/jruby/lib/ruby/gems/shared/gems/bundler-*'
+    @exclude_paths << 'vendor/jruby/lib/ruby/gems/shared/gems/rake-*'
 
     @exclude_paths
   end

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -98,7 +98,7 @@ namespace "artifact" do
     # jruby's bundler artifacts
     @exclude_paths << 'vendor/jruby/bin/bundle*'
     @exclude_paths << 'vendor/jruby/lib/ruby/stdlib/bundler*'
-    @exclude_paths << 'vendor/jruby/lib/ruby/gems/shared/specifications/default/bundler-*.spec'
+    @exclude_paths << 'vendor/jruby/lib/ruby/gems/shared/specifications/default/bundler-*.gemspec'
     @exclude_paths << 'vendor/jruby/lib/ruby/gems/shared/gems/bundler-*'
     @exclude_paths << 'vendor/jruby/lib/ruby/gems/shared/gems/rake-*'
 


### PR DESCRIPTION
## What does this PR do?

Exclude's all bundler that come from Jruby, from the artifacts, as we install our own.

## Why is it important/What is the impact to the user?

User shouldn't have any impact.

Closes #14666