### PR TITLE
DRA - refactor docker build to make the code re-usable

### DIFF
--- a/ci/dra_aarch64.sh
+++ b/ci/dra_aarch64.sh
@@ -11,13 +11,11 @@ case "$WORKFLOW_TYPE" in
     snapshot)
         info "Building artifacts for the $WORKFLOW_TYPE workflow..."
         if [ -z "$VERSION_QUALIFIER_OPT" ]; then
-            rake artifact:docker
-            rake artifact:docker_oss
-            rake artifact:dockerfiles
+            build_docker_images
+            build_docker_files
         else
-            VERSION_QUALIFIER="$VERSION_QUALIFIER_OPT" rake artifact:docker
-            VERSION_QUALIFIER="$VERSION_QUALIFIER_OPT" rake artifact:docker_oss
-            VERSION_QUALIFIER="$VERSION_QUALIFIER_OPT" rake artifact:dockerfiles
+            build_docker_images "VERSION_QUALIFIER=$VERSION_QUALIFIER_OPT"
+            build_docker_files "VERSION_QUALIFIER=$VERSION_QUALIFIER_OPT"
             # Qualifier is passed from CI as optional field and specify the version postfix
             # in case of alpha or beta releases:
             # e.g: 8.0.0-alpha1
@@ -29,13 +27,11 @@ case "$WORKFLOW_TYPE" in
     staging)
         info "Building artifacts for the $WORKFLOW_TYPE workflow..."
         if [ -z "$VERSION_QUALIFIER_OPT" ]; then
-            RELEASE=1 rake artifact:docker
-            RELEASE=1 rake artifact:docker_oss
-            rake artifact:dockerfiles
+            build_docker_images "RELEASE=1"
+            build_docker_files
         else
-            VERSION_QUALIFIER="$VERSION_QUALIFIER_OPT" RELEASE=1 rake artifact:docker
-            VERSION_QUALIFIER="$VERSION_QUALIFIER_OPT" RELEASE=1 rake artifact:docker_oss
-            VERSION_QUALIFIER="$VERSION_QUALIFIER_OPT" rake artifact:dockerfiles
+            build_docker_images "VERSION_QUALIFIER=$VERSION_QUALIFIER_OPT RELEASE=1"
+            build_docker_files "VERSION_QUALIFIER=$VERSION_QUALIFIER_OPT"
             # Qualifier is passed from CI as optional field and specify the version postfix
             # in case of alpha or beta releases:
             # e.g: 8.0.0-alpha1

--- a/ci/dra_common.sh
+++ b/ci/dra_common.sh
@@ -21,6 +21,17 @@ function upload_to_bucket {
     gsutil cp "${file}" "gs://logstash-ci-artifacts/dra/${version}/"
 }
 
+function build_docker_images {
+    local env_vars="${1:-}"
+    eval "${env_vars} rake artifact:docker"
+    eval "${env_vars} rake artifact:docker_oss"
+}
+
+function build_docker_files {
+    local env_vars="${1:-}"
+    eval "${env_vars} rake artifact:dockerfiles"
+}
+
 # Since we are using the system jruby, we need to make sure our jvm process
 # uses at least 1g of memory, If we don't do this we can get OOM issues when
 # installing gems. See https://github.com/elastic/logstash/issues/5179


### PR DESCRIPTION
Refactors the docker build part of DRA to make the code more reusable. This will allow to be able to use similar code path to  when building other artifacture docker images.