### PR TITLE
Docfix Logstash monitoring with Metribeat

### DIFF
--- a/docs/static/monitoring/monitoring-mb.asciidoc
+++ b/docs/static/monitoring/monitoring-mb.asciidoc
@@ -101,7 +101,7 @@ The `modules.d/logstash-xpack.yml` file contains these settings:
     xpack.enabled: true
 ----------------------------------
  
-Set the `hosts`, `username`, and `password` to authenticate with {ls}.
+Set the `hosts` to connect with {ls}.
 For other module settings, it's recommended that you accept the
 defaults.
 
@@ -114,15 +114,12 @@ To monitor multiple {ls} instances, specify a list of hosts, for example:
 hosts: ["http://localhost:9601","http://localhost:9602","http://localhost:9603"]
 ----------------------------------
 
+*{ls} API security.* If the {ls} API is {ref}/monitoring-logstash.html#monitoring-api-security[secured] (it is not by default), provide a `username`
+and `password` so that {metricbeat} can authenticate successfully.
 
-*Elastic security.* If the Elastic {security-features} are enabled, provide a user 
-ID and password so that {metricbeat} can collect metrics successfully: 
+NOTE: Usage of Keystore or Environment or variable replacements is encouraged for password-type fields to avoid storing them in plain text.
+      For example, specifying the value `"${HTTP_PASS}"` will resolve to the value stored in the <<keystore,secure keystore's>> `HTTP_PASS` variable if present or the same variable from the <<environment-variables,environment>>)
 
-.. Create a user on the production cluster that has the 
-`remote_monitoring_collector` {ref}/built-in-roles.html[built-in role]. 
-
-.. Add the `username` and `password` settings to the module configuration 
-file (`logstash-xpack.yml`).
 --
 
 . Optional: Disable the system module in the {metricbeat}.


### PR DESCRIPTION


## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->


## What does this PR do?

This PR fixes the documentation wich is currently misleading:

The logstash metrics API can be optionally be secured and require a username/password to be specified, that is entirely separate from any users in ES

The logstash module is only concerned with communicating with logstash, and the username/password relates to authentication of logstash and is unrelated to metricbeat authenticating against elasticsearch.


## Why is it important/What is the impact to the user?

The current documentation is misleading. 
User can get lost trying to configure Logstash monitoring with Metricbeat.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] confirm Keystore or Environment can be use for password  fields


## Related issues

- Closes https://github.com/elastic/logstash/issues/14661


