### PR TITLE
Adds upload of missed docker docker-build-context.tar.gz artifacts

### DIFF
--- a/ci/dra_docker.sh
+++ b/ci/dra_docker.sh
@@ -58,6 +58,7 @@ info "UPLOADING TO INTERMEDIATE BUCKET"
 # Note the deb, rpm tar.gz AARCH64 files generated has already been loaded by the dra_x86_64.sh
 for image in logstash logstash-oss logstash-ubi8; do
     upload_to_bucket "build/$image-${STACK_VERSION}-docker-image-${ARCH}.tar.gz" ${STACK_VERSION}
+    upload_to_bucket "build/$image-${STACK_VERSION}-docker-build-context.tar.gz" ${STACK_VERSION}
 done
 
 echo "####################################################################"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
 [rn:skip] 

## What does this PR do?

Updates the `dra_docker.sh` script to upload also docker-build-context.tar.gz, like 
```
build/logstash-7.17.8-SNAPSHOT-docker-build-context.tar.gz
build/logstash-ironbank-7.17.8-SNAPSHOT-docker-build-context.tar.gz
build/logstash-oss-7.17.8-SNAPSHOT-docker-build-context.tar.gz
build/logstash-ubi8-7.17.8-SNAPSHOT-docker-build-context.tar.gz
```


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #14670

