### PR TITLE
DRA - Fix docker image build

### DIFF
--- a/ci/dra_docker.sh
+++ b/ci/dra_docker.sh
@@ -11,7 +11,7 @@ case "$WORKFLOW_TYPE" in
     snapshot)
         info "Building artifacts for the $WORKFLOW_TYPE workflow..."
         if [ -z "$VERSION_QUALIFIER_OPT" ]; then
-            rake artifact:docker || error "artifact:docker_oss build failed."
+            rake artifact:docker || error "artifact:docker build failed."
             rake artifact:docker_oss || error "artifact:docker_oss build failed."
             rake artifact:dockerfiles || error "artifact:dockerfiles build failed."
 	    if [ "$ARCH" != "aarch64" ]; then rake artifact:docker_ubi8 || error "artifact:docker_ubi8 build failed."; fi

--- a/ci/dra_docker.sh
+++ b/ci/dra_docker.sh
@@ -14,12 +14,16 @@ case "$WORKFLOW_TYPE" in
             rake artifact:docker || error "artifact:docker build failed."
             rake artifact:docker_oss || error "artifact:docker_oss build failed."
             rake artifact:dockerfiles || error "artifact:dockerfiles build failed."
-	    if [ "$ARCH" != "aarch64" ]; then rake artifact:docker_ubi8 || error "artifact:docker_ubi8 build failed."; fi
+            if [ "$ARCH" != "aarch64" ]; then
+                rake artifact:docker_ubi8 || error "artifact:docker_ubi8 build failed."
+            fi
         else
             VERSION_QUALIFIER="$VERSION_QUALIFIER_OPT" rake artifact:docker || error "artifact:docker build failed."
             VERSION_QUALIFIER="$VERSION_QUALIFIER_OPT" rake artifact:docker_oss || error "artifact:docker_oss build failed."
             VERSION_QUALIFIER="$VERSION_QUALIFIER_OPT" rake artifact:dockerfiles || error "artifact:dockerfiles build failed."
-	    if [ "$ARCH" != "aarch64" ]; then VERSION_QUALIFIER="$VERSION_QUALIFIER_OPT" rake artifact:docker_ubi8 || error "artifact:docker_ubi8 build failed."; fi
+            if [ "$ARCH" != "aarch64" ]; then
+                VERSION_QUALIFIER="$VERSION_QUALIFIER_OPT" rake artifact:docker_ubi8 || error "artifact:docker_ubi8 build failed."
+            fi
             # Qualifier is passed from CI as optional field and specify the version postfix
             # in case of alpha or beta releases:
             # e.g: 8.0.0-alpha1
@@ -34,12 +38,16 @@ case "$WORKFLOW_TYPE" in
             RELEASE=1 rake artifact:docker || error "artifact:docker build failed."
             RELEASE=1 rake artifact:docker_oss || error "artifact:docker_oss build failed."
             rake artifact:dockerfiles || error "artifact:dockerfiles build failed."
-	    if [ "$ARCH" != "aarch64" ]; then RELEASE=1 rake artifact:docker_ubi8 || error "artifact:docker_ubi8 build failed."; fi
+            if [ "$ARCH" != "aarch64" ]; then
+                RELEASE=1 rake artifact:docker_ubi8 || error "artifact:docker_ubi8 build failed."
+            fi
         else
             VERSION_QUALIFIER="$VERSION_QUALIFIER_OPT" RELEASE=1 rake artifact:docker || error "artifact:docker build failed."
             VERSION_QUALIFIER="$VERSION_QUALIFIER_OPT" RELEASE=1 rake artifact:docker_oss || error "artifact:docker_oss build failed."
             VERSION_QUALIFIER="$VERSION_QUALIFIER_OPT" rake artifact:dockerfiles || error "artifact:dockerfiles build failed."
-	    if [ "$ARCH" != "aarch64" ]; then VERSION_QUALIFIER="$VERSION_QUALIFIER_OPT" RELEASE=1 rake artifact:docker_ubi8 || error "artifact:docker_ubi8 build failed."; fi
+            if [ "$ARCH" != "aarch64" ]; then
+                VERSION_QUALIFIER="$VERSION_QUALIFIER_OPT" RELEASE=1 rake artifact:docker_ubi8 || error "artifact:docker_ubi8 build failed."
+            fi
             # Qualifier is passed from CI as optional field and specify the version postfix
             # in case of alpha or beta releases:
             # e.g: 8.0.0-alpha1

--- a/ci/dra_upload.sh
+++ b/ci/dra_upload.sh
@@ -94,7 +94,11 @@ gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-ubi8-${STACK_
 # docker ARM
 gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-${STACK_VERSION}-docker-image-aarch64.tar.gz build/
 gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-oss-${STACK_VERSION}-docker-image-aarch64.tar.gz build/
-gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-ubi8-${STACK_VERSION}-docker-image-aarch64.tar.gz build/
+# Commenting out ubi8 for aarch64 for the time being. This image itself is not being built, and it is not expected
+# by the release manager.
+# See https://github.com/elastic/infra/blob/master/cd/release/release-manager/project-configs/8.5/logstash.gradle
+# for more details.
+#gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-ubi8-${STACK_VERSION}-docker-image-aarch64.tar.gz build/
 
 gsutil cp gs://logstash-ci-artifacts/dra/${STACK_VERSION}/logstash-${STACK_VERSION}.csv build/
 


### PR DESCRIPTION
Fixes the docker image build process and ensure that:
 * Builds and uploads ubi8 for x86_64 only.
 * Uploads the ironbank context when running x86_64 builds only.