### PR TITLE
Fix pipelines yaml loading

### DIFF
--- a/logstash-core/lib/logstash/config/source/multi_local.rb
+++ b/logstash-core/lib/logstash/config/source/multi_local.rb
@@ -87,9 +87,9 @@ module LogStash module Config module Source
       when Array
         result
       when false
-        raise ConfigurationError.new("Pipelines YAML file is empty. Path: #{pipelines_yaml_location}")
+        raise ConfigurationError, I18n.t("logstash.runner.config-pipelines-empty", :path => pipelines_yaml_location)
       else
-        raise ConfigurationError.new("Pipelines YAML file must contain an array of pipeline configs. Found \"#{result.class}\" in #{pipelines_yaml_location}")
+        raise ConfigurationError, I18n.t("logstash.runner.config-pipelines-invalid", :invalid_class => result.class, :path => pipelines_yaml_location)
       end
     end
 
@@ -105,7 +105,7 @@ module LogStash module Config module Source
     def detect_duplicate_pipelines(pipelines)
       duplicate_ids = pipelines.group_by {|pipeline| pipeline.get("pipeline.id") }.select {|k, v| v.size > 1 }.map {|k, v| k}
       if duplicate_ids.any?
-        raise ConfigurationError.new("Pipelines YAML file contains duplicate pipeline ids: #{duplicate_ids.inspect}. Location: #{pipelines_yaml_location}")
+        raise ConfigurationError, I18n.t("logstash.runner.config-pipelines-duplicate-ids", :path => pipelines_yaml_location, duplicate_ids: duplicate_ids.inspect)
       end
     end
 

--- a/logstash-core/lib/logstash/config/source/multi_local.rb
+++ b/logstash-core/lib/logstash/config/source/multi_local.rb
@@ -94,10 +94,8 @@ module LogStash module Config module Source
     end
 
     def read_pipelines_from_yaml(yaml_location)
-      logger.debug("Reading pipeline configurations from YAML", :location => pipelines_yaml_location)
-      ::YAML.safe_load(::File.read(yaml_location), fallback: false)
-    rescue => e
-      raise ConfigurationError.new("Failed to read pipelines yaml file. Location: #{yaml_location}, Exception: #{e.inspect}")
+      yaml_contents = ::File.read(yaml_location) rescue fail(ConfigurationError, I18n.t("logstash.runner.config-pipelines-failed-read-with-exception", :path => yaml_location, exception: $!.inspect))
+      ::YAML.safe_load(yaml_contents, fallback: false) rescue fail(ConfigurationError, I18n.t("logstash.runner.config-pipelines-failed-parse-with-exception", :path => yaml_location, exception: $!.inspect))
     end
 
     def pipelines_yaml_location

--- a/logstash-core/lib/logstash/config/source/multi_local.rb
+++ b/logstash-core/lib/logstash/config/source/multi_local.rb
@@ -70,6 +70,8 @@ module LogStash module Config module Source
           @conflict_messages << I18n.t("logstash.runner.config-pipelines-empty", :path => pipelines_yaml_location)
         elsif @detected_marker.is_a?(Class)
           @conflict_messages << I18n.t("logstash.runner.config-pipelines-invalid", :invalid_class => @detected_marker, :path => pipelines_yaml_location)
+        elsif @detected_marker.kind_of?(ConfigurationError)
+          @conflict_messages << @detected_marker.message
         end
       else
         do_warning? && logger.warn("Ignoring the 'pipelines.yml' file because modules or command line options are specified")
@@ -110,7 +112,7 @@ module LogStash module Config module Source
     end
 
     def detect_pipelines
-      result = read_pipelines_from_yaml(pipelines_yaml_location) rescue nil
+      result = read_pipelines_from_yaml(pipelines_yaml_location)
       if result.is_a?(Array)
         @detected_marker = true
       elsif result.nil?
@@ -120,6 +122,9 @@ module LogStash module Config module Source
       else
         @detected_marker = result.class
       end
+    rescue ConfigurationError => cfg_error
+      @detected_marker = cfg_error
+    ensure
       @detect_pipelines_called = true
     end
 

--- a/logstash-core/lib/logstash/config/source/multi_local.rb
+++ b/logstash-core/lib/logstash/config/source/multi_local.rb
@@ -93,7 +93,7 @@ module LogStash module Config module Source
 
     def read_pipelines_from_yaml(yaml_location)
       logger.debug("Reading pipeline configurations from YAML", :location => pipelines_yaml_location)
-      ::YAML.safe_load(::File.read(yaml_location))
+      ::YAML.safe_load(::File.read(yaml_location), fallback: false)
     rescue => e
       raise ConfigurationError.new("Failed to read pipelines yaml file. Location: #{yaml_location}, Exception: #{e.inspect}")
     end

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -126,6 +126,10 @@ en:
         Using command-line module configuration to override logstash.yml module configuration.
       config-pipelines-failed-read: >-
         Failed to read pipelines yaml file. Location: %{path}
+      config-pipelines-failed-read-with-exception: >-
+        Failed to read pipelines yaml file. Location: %{path}, Exception: %{exception}
+      config-pipelines-failed-parse-with-exception: >-
+        Failed to parse contents of pipelines yaml file. Location: %{path}, Exception: %{exception}
       config-pipelines-empty: >-
         Pipelines YAML file is empty. Location: %{path}
       config-pipelines-invalid: >-

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -134,6 +134,8 @@ en:
         Pipelines YAML file is empty. Location: %{path}
       config-pipelines-invalid: >-
         Pipelines YAML file must contain an array of pipeline configs. Found "%{invalid_class}" in %{path}
+      config-pipelines-duplicate-ids: >-
+        Pipelines YAML file contains duplicate pipeline ids: #{duplicate_ids}. Location: #{path}
       reload-without-config-path: >-
         Configuration reloading also requires passing a configuration path with '-f yourlogstash.conf'
       reload-with-config-string: >-


### PR DESCRIPTION
## Release notes

Fixes the reporting of configuration errors in multiple-pipeline setup to make them more actionable

## What does this PR do?

Fixes several related issues with the loading of multiple pipelines in which useful context is lost before presenting the user with an error message:

1. in which a readable-but-unparseable yaml file produces a generic error about not being able to read the file (https://github.com/elastic/logstash/issues/14712)
2. in which a required-but-effectively-empty yaml file produces a generic error about not being able to read the file (unfiled; regression from https://github.com/elastic/logstash/pull/13883)
3. in which a required-but-unreadable yaml file produces a generic error about not being able to read the file (unfiled)

## Why is it important/What is the impact to the user?

In cases where the `pipelines.yml` is required (that is: neither command-line options nor modules are present), a pipelines.yml file must be readable by the Logstash user and must contain YAML representation of a top-level array.

We should provide the user with specific, actionable feedback.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

1. not valid YAML
   ~~~
   echo -e " - pipeline.id: my_id\n   pipeline.workers: 1\n  pipeline.ordered: true" > config/pipelines.yml
   ~~~
   ~~~
   ERROR: Failed to parse contents of pipelines yaml file. Location: REDACTED_LS_HOME/config/pipelines.yml, Exception: #<Psych::SyntaxError: (<unknown>): expected <block end>, but found '<block mapping start>' while parsing a block collection at line 3 column 3>
   ~~~

2. required-but-empty:
   ~~~
   echo -e "# only\n# comments" > config/pipelines.yml
   ~~~
   ~~~
   ERROR: Pipelines YAML file is empty. Location: REDACTED_LS_HOME/config/pipelines.yml
   ~~~

4. unreadable file:
    ~~~
    chmod 000 config/pipelines.yml
    ~~~
    ~~~
    ERROR: Failed to read pipelines yaml file. Location: REDACTED_LS_HOME/config/pipelines.yml, Exception: #<Errno::EACCES: Permission denied - REDACTED_LS_HOME/config/pipelines.yml>
    ~~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->

Closes: https://github.com/elastic/logstash/issues/14712
Related: https://github.com/elastic/logstash/pull/13883

