### PR TITLE
DRA: uploading missing docker-build-context files

### DIFF
--- a/ci/dra_common.sh
+++ b/ci/dra_common.sh
@@ -18,6 +18,7 @@ function save_docker_tarballs {
 function upload_to_bucket {
     local file="${1:?file required}"
     local version="${2:?stack-version required}"
+    info "Uploading ${file}..."
     gsutil cp "${file}" "gs://logstash-ci-artifacts/dra/${version}/"
 }
 

--- a/ci/dra_docker.sh
+++ b/ci/dra_docker.sh
@@ -72,8 +72,12 @@ for image in logstash logstash-oss logstash-ubi8; do
     upload_to_bucket "build/$image-${STACK_VERSION}-docker-image-${ARCH}.tar.gz" ${STACK_VERSION}
 done
 
+# Upload 'docker-build-context.tar.gz' files only when build x86_64, otherwise they will be
+# overwritten when building aarch64 (or viceversa).
 if [ "$ARCH" != "aarch64" ]; then
-    upload_to_bucket "build/logstash-ironbank-${STACK_VERSION}-docker-build-context.tar.gz" ${STACK_VERSION}
+    for image in logstash logstash-oss logstash-ubi8 logstash-ironbank; do
+        upload_to_bucket "build/${image}-${STACK_VERSION}-docker-build-context.tar.gz" ${STACK_VERSION}
+    done
 fi
 
 echo "####################################################################"


### PR DESCRIPTION
Uploads missing docker-build-context files when building x86_64 images only, otherwise this will be overwritten when the build processes aarch64.