### PR TITLE
Avoid the wrapping of LogstashMessageFactory with log4j's MessageFactory adapter

### DIFF
--- a/logstash-core/src/main/java/org/logstash/log/LogstashMessageFactory.java
+++ b/logstash-core/src/main/java/org/logstash/log/LogstashMessageFactory.java
@@ -21,7 +21,7 @@
 package org.logstash.log;
 
 import org.apache.logging.log4j.message.Message;
-import org.apache.logging.log4j.message.MessageFactory;
+import org.apache.logging.log4j.message.MessageFactory2;
 import org.apache.logging.log4j.message.ObjectMessage;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.message.SimpleMessage;
@@ -30,8 +30,10 @@ import java.util.Map;
 
 /**
  * Used in Log4j configuration.
+ *
+ * Requires Log4j 2.6 and above.
  * */
-public final class LogstashMessageFactory implements MessageFactory {
+public final class LogstashMessageFactory implements MessageFactory2 {
 
     public static final LogstashMessageFactory INSTANCE = new LogstashMessageFactory();
 
@@ -52,5 +54,60 @@ public final class LogstashMessageFactory implements MessageFactory {
         } else {
             return new ParameterizedMessage(message, params);
         }
+    }
+
+    @Override
+    public Message newMessage(CharSequence charSequence) {
+        return new SimpleMessage(charSequence);
+    }
+
+    @Override
+    public Message newMessage(String message, Object p0) {
+        return newMessage(message, new Object[]{p0});
+    }
+
+    @Override
+    public Message newMessage(String message, Object p0, Object p1) {
+        return newMessage(message, new Object[]{p0, p1});
+    }
+
+    @Override
+    public Message newMessage(String message, Object p0, Object p1, Object p2) {
+        return newMessage(message, new Object[]{p0, p1, p2});
+    }
+
+    @Override
+    public Message newMessage(String message, Object p0, Object p1, Object p2, Object p3) {
+        return newMessage(message, new Object[]{p0, p1, p2, p3});
+    }
+
+    @Override
+    public Message newMessage(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        return newMessage(message, new Object[]{p0, p1, p2, p3, p4});
+    }
+
+    @Override
+    public Message newMessage(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        return newMessage(message, new Object[]{p0, p1, p2, p3, p4, p5});
+    }
+
+    @Override
+    public Message newMessage(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        return newMessage(message, new Object[]{p0, p1, p2, p3, p4, p5, p6});
+    }
+
+    @Override
+    public Message newMessage(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7) {
+        return newMessage(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7});
+    }
+
+    @Override
+    public Message newMessage(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7, Object p8) {
+        return newMessage(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8});
+    }
+
+    @Override
+    public Message newMessage(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7, Object p8, Object p9) {
+        return newMessage(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9});
     }
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Bugfix to avoid warning log from status log4j logger when new codecs are created by clone.


## What does this PR do?

Starting with Log4j2  2.6 if a subclass of MessageFactory associated with an Logger instance is not subclass of MessageFactory2, then it's wrapped with MessageFactory2Adapter.

This trigger a log4j warn log that, when a class subclasses LogStash::Plugin for example, is noisy and report about a Logger is not associated with the default MessagedFactory (LogstashMessageFactory) every time a subclass of Plugins is instantiated.

This commit adapt LogstashMessageFactory to implement the MessagedFactory2 instead of the older MessageFactory to avoid the wrapping with the adapter class.

## Why is it important/What is the impact to the user?

Avoid pollution of loggers when a the log4j status logger is set at `warn` level.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] run Logstash and reproducer code present in https://github.com/elastic/logstash/issues/14715#issuecomment-1301843528

## How to test this PR locally

- edit `config/log4j2.properties` and switch from
```
status = error
```
to
```
status = warn
```
- launch the following pipeline:
```
input {
  tcp {
    port => 1234
  }
}

output {
  stdout {
    codec => rubydebug
  }
}
```
- send a message with 
```sh
echo "test" | nc 127.0.0.1 1234
```
- without this PR every time a connection is opened and sent some content a log line similar to the following appears:
```
WARN The Logger slowlog.logstash.codecs.line was created with the message factory org.apache.logging.log4j.spi.MessageFactory2Adapter@eca4d0 and is now requested with a null message factory (defaults to org.logstash.log.LogstashMessageFactory), which may create log events with unexpected formatting.
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #14715

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
