### PR TITLE
8.5 - Update bundled JDK to 17.0.5+8

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -7,7 +7,7 @@ logstash-core-plugin-api: 2.1.16
 bundled_jdk:
   # for AdoptOpenJDK/OpenJDK jdk-14.0.1+7.1, the revision is 14.0.1 while the build is 7.1
   vendor: "adoptium"
-  revision: 17.0.4
+  revision: 17.0.5
   build: 8
 
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip] 

## What does this PR do?
Updates `8.5` and `main` branches to the latest JDK.

## Related issues
- Closes #14734