### PR TITLE
Use `aarch64` artifact arch for integration tests on Mac M1 (darwin) OS.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,24 +142,19 @@ String artifactVersionsApi = "https://artifacts-api.elastic.co/v1/versions"
 
 tasks.register("configureArchitecture") {
     String arch = System.properties['os.arch']
-    String osName = System.properties['os.name']
     String beatsArch = arch
     String esArch = arch
+    String osName = (System.properties['os.name'] ==~ /Mac OS X/) ? "darwin" : "linux"
 
     // For aarch64 architectures, beats and elasticsearch name their artifacts differently
     if (arch == "aarch64") {
-        beatsArch="arm64"
+        beatsArch=(osName == "darwin") ? "aarch64" : "arm64"
         esArch="aarch64"
     } else if (arch == "amd64") {
         beatsArch="x86_64"
         esArch="x86_64"
     }
 
-    if (osName ==~ /Mac OS X/) {
-        osName = "darwin"
-    } else {
-        osName = "linux"
-    }
     project.ext.set("beatsArchitecture", "${osName}-${beatsArch}")
     project.ext.set("esArchitecture", "${osName}-${esArch}")
 }


### PR DESCRIPTION

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn:skip] 

## What does this PR do?
Fixes the `fileBeat` artifact not found issue when running integration tests on Mac M1.

## Why is it important/What is the impact to the user?
Not impacted.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally
- Pull the changes
- Run `ci/integration_tests.sh specs/monitoring_api_spec.rb` to test single integration test.

## Related issues
- Closes #14753 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs
```
// issue case

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/mashhur/Dev/elastic/logstash/build.gradle' line: 464

* What went wrong:
Execution failed for task ':downloadFilebeat'.
> java.io.FileNotFoundException: https://artifacts-api.elastic.co/v1/versions/8.6.0-SNAPSHOT/builds/8.6.0-9a0f87a9/projects/beats/packages/filebeat-8.6.0-SNAPSHOT-darwin-arm64.tar.gz

```

```
// after fix
> Task :downloadFilebeat
Caching disabled for task ':downloadFilebeat' because:
  Build cache is disabled
Task ':downloadFilebeat' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
Download https://snapshots.elastic.co/8.6.0-9a0f87a9/downloads/beats/filebeat/filebeat-8.6.0-SNAPSHOT-darwin-aarch64.tar.gz
Downloaded to /Users/mashhur/Dev/elastic/logstash/build/filebeat-8.6.0-SNAPSHOT-darwin-aarch64.tar.gz
:downloadFilebeat (Thread[Execution worker Thread 7,5,main]) completed. Took 8.915 secs.
Resolve mutations for :copyFilebeat (Thread[Execution worker Thread 5,5,main]) started.
Resolve mutations for :copyFilebeat (Thread[Execution worker Thread 5,5,main]) completed. Took 0.0 secs.
:copyFilebeat (Thread[Execution worker Thread 7,5,main]) started.

> Task :copyFilebeat
Caching disabled for task ':copyFilebeat' because:
  Build cache is disabled
Task ':copyFilebeat' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
Unzipped /Users/mashhur/Dev/elastic/logstash/build/filebeat-8.6.0-SNAPSHOT-darwin-aarch64.tar.gz to ./build/filebeat
Deleting /Users/mashhur/Dev/elastic/logstash/build/filebeat-8.6.0-SNAPSHOT-darwin-aarch64.tar.gz
:copyFilebeat (Thread[Execution worker Thread 7,5,main]) completed. Took 1.549 secs.
Resolve mutations for :logstash-integration-tests:compileJava (Thread[Execution worker Thread 5,5,main]) started.
Resolve mutations for :logstash-integration-tests:compileJava (Thread[Execution worker Thread 5,5,main]) completed. Took 0.0 secs.
:logstash-integration-tests:compileJava (Thread[Execution worker Thread 7,5,main]) started.
```
