### PR TITLE
fix: calculated inflight_count from in-flight batches

### DIFF
--- a/logstash-core/spec/logstash/pipeline_reporter_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_reporter_spec.rb
@@ -29,10 +29,14 @@ shared_examples "a pipeline reporter" do |pipeline_setup|
   let(:pipeline) { Kernel.send(pipeline_setup, config)}
   let(:reporter) { pipeline.reporter }
 
-  before do
+  let(:do_setup_plugin_registry) do
     allow(LogStash::Plugin).to receive(:lookup).with("output", "dummyoutput").and_return(::LogStash::Outputs::DummyOutput)
     allow(LogStash::Plugin).to receive(:lookup).with("input", "generator").and_call_original
     allow(LogStash::Plugin).to receive(:lookup).with("codec", "plain").and_call_original
+  end
+
+  before do
+    do_setup_plugin_registry
 
     @pre_snapshot = reporter.snapshot
 
@@ -49,7 +53,7 @@ shared_examples "a pipeline reporter" do |pipeline_setup|
     end
 
     it "should end with no stalled threads" do
-      expect(@pre_snapshot.stalling_threads_info).to eql([])
+      expect(@post_snapshot.stalling_threads_info).to eql([])
     end
   end
 
@@ -80,6 +84,40 @@ shared_examples "a pipeline reporter" do |pipeline_setup|
 
     it "should be zero after running" do
       expect(@post_snapshot.inflight_count).to eql(0)
+    end
+
+    # We provide a hooked filter that captures a new reporter snapshot with each event.
+    # Since the event being processed is by-definition part of a batch that is in-flight,
+    # we expect all of the resulting reporter snapshots to have non-zero inflight_event-s
+    context "while running" do
+      let!(:report_queue) { Queue.new }
+      let(:hooked_dummy_filter_class) do
+        ::LogStash::Filters::DummyFilter.with_hook do |event|
+          report_queue << reporter.snapshot
+        end
+      end
+      let(:hooked_dummy_filter_name) { hooked_dummy_filter_class.config_name }
+
+      let(:config) do
+        <<~EOCONFIG
+          input  { generator { count => #{generator_count} } }
+          filter { #{hooked_dummy_filter_name} {} }
+          output { dummyoutput {} }
+        EOCONFIG
+      end
+
+      let(:do_setup_plugin_registry) do
+        super()
+        allow(LogStash::Plugin).to receive(:lookup).with("filter", hooked_dummy_filter_name)
+                                                   .and_return(hooked_dummy_filter_class)
+      end
+
+      it 'captures inflight counts that are non-zero ' do
+        inflight_reports = Array.new(report_queue.size) { report_queue.pop }
+
+        expect(inflight_reports).to_not be_empty
+        expect(inflight_reports).to all(have_attributes(inflight_count: (a_value > 0)))
+      end
     end
   end
 end

--- a/logstash-core/spec/support/mocks_classes.rb
+++ b/logstash-core/spec/support/mocks_classes.rb
@@ -59,6 +59,18 @@ module LogStash
       def filter(event)
         # noop
       end
+
+      ##
+      # Returns a one-off subclass of the DummyFilter that
+      # executes the provided hook with each event it receives
+      def self.with_hook(&block)
+        Class.new(self) do
+          config_name "dummyfilter_#{__id__}"
+          define_method(:filter) do |event|
+            block.call(event)
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION

## Release notes

 - fixes an issue during process shutdown in which the stalled shutdown watcher incorrectly reports `inflight_count` as `0` even when there are events in-flight.

## What does this PR do?

During stalled shutdowns after inputs have been closed and while waiting for in-flight batches to complete, our shutdown watcher emits helpful information about what work is in flight, including the actual threads and plugins that are still executing.

Since ~6.3.0, the `inflight_count` metric in this log message has always been `0`, in part because of two somewhat-overlapping bugs:

 - elastic/logstash#8987 and elastic/logstash#9056 (7.0, back-ported to 6.3) changed the `inflight_batches` map provided by the queue read clients to index batches by native thread id, but pipeline reporter continued to attempt to extract by ruby thread object. Because it does not find the thread in the "batch map", it reports zero.
 - elastic/logstash#9111 (7.0, back-ported to 6.3) changed the _value_ stored in the same `inflight_batches` map from an object responding to ruby-`Object#size` to a java `QueueBatch` (which does not respond to ruby-`Object#size`). If our pipeline reporter had been able to look up the queue batch, it would have failed with a `NoMethodError`.

We resolve the issue by (1) extracting the batch from our "batch map" using the native thread id and (2) safely extracting the value from a `QueueBatch` before falling through to `Object#size` or 0.

I am unsure if the fallback to `Object#size` is necessary, as I _believe_ we can only ever have actual `QueueBatch` objects, but we do not have type-safety helping us and I haven't been able to do a full analysis of possible code-paths across the ruby/jruby/java bridge.

## Why is it important/What is the impact to the user?

A user whose Logstash is taking longer than normal to shut down should have visibility into how many events are in-flight.

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

 - [ ] backport to 7.17
 - [ ] backport to 6.6

## How to test this PR locally

Start a process with a pipeline that will block for a while (such as one that generates a lot of events, but takes 10s to process each of them), then send `SIGINT` to initiate shutdown:

~~~
input { java_generator { } }
# randomized selection + randomized duration ensures enough possible
# movement in workers to allow inputs to push their blocked batches.
filter { ruby { code => "sleep(2.0 ** Random.rand(4.0))) if Random.rand(1000) <= 1" } }
output { sink { } }
~~~

Observe helpful shutdown watcher logs with non-zero `inflight_count`:

~~~
[2022-11-16T23:02:11,714][WARN ][org.logstash.execution.ShutdownWatcherExt] {"inflight_count"=>250, "stalling_threads_info"=>{["LogStash::Filters::Ruby", {"code"=>"sleep(2.0 ** Random.rand(4.0)) if Random.rand(1000) <= 1", "id"=>"63d43800309aa133f3ec0f247297e2bb78555888722d7c3a72a13e21072f026f"}]=>[{"thread_id"=>40, "name"=>"[main]>worker4", "current_call"=>"(ruby filter code):2:in `block in sleep'"}, {"thread_id"=>42, "name"=>"[main]>worker6", "current_call"=>"(ruby filter code):2:in `block in sleep'"}]}}
~~~

## Related issues

Relates: https://github.com/elastic/logstash/issues/14332

## Logs

Spec output without the required changes:

~~~
      1) LogStash::PipelineReporter with java execution behaves like a pipeline reporter inflight count while running captures inflight counts that are non-zero 
         Failure/Error: expect(inflight_reports).to all(have_attributes(inflight_count: (a_value > 0)))
         
           expected [#<LogStash::PipelineReporter::Snapshot:0x23dbd676>, #<LogStash::PipelineReporter::Snapshot:0x36db2ef...ogStash::PipelineReporter::Snapshot:0x2063d1c8>, #<LogStash::PipelineReporter::Snapshot:0x7852d8ed>] to all have attributes {:inflight_count => (a value > 0)}
         
              object at index 0 failed to match:
                 expected #<LogStash::PipelineReporter::Snapshot:0x23dbd676> to have attributes {:inflight_count => (a value > 0)} but had attributes {:inflight_count => 0}
         
              object at index 1 failed to match:
                 expected #<LogStash::PipelineReporter::Snapshot:0x36db2ef8> to have attributes {:inflight_count => (a value > 0)} but had attributes {:inflight_count => 0}
         
              object at index 2 failed to match:
                 expected #<LogStash::PipelineReporter::Snapshot:0x64f8ef03> to have attributes {:inflight_count => (a value > 0)} but had attributes {:inflight_count => 0}
         
              object at index 3 failed to match:
                 expected #<LogStash::PipelineReporter::Snapshot:0x2063d1c8> to have attributes {:inflight_count => (a value > 0)} but had attributes {:inflight_count => 0}
         
              object at index 4 failed to match:
                 expected #<LogStash::PipelineReporter::Snapshot:0x7852d8ed> to have attributes {:inflight_count => (a value > 0)} but had attributes {:inflight_count => 0}

~~~

Similarly without this patch, the ShutdownWatcherExt's `WARN` always includes a 0 value for `inflight_count`, even when the same log message indicates multiple stalled threads that are stalled processing in-flight events:

~~~
[2022-11-16T23:02:11,714][WARN ][org.logstash.execution.ShutdownWatcherExt] {"inflight_count"=>0, "stalling_threads_info"=>{["LogStash::Filters::Ruby", {"code"=>"sleep(2.0 ** Random.rand(4.0)) if Random.rand(1000) <= 1", "id"=>"63d43800309aa133f3ec0f247297e2bb78555888722d7c3a72a13e21072f026f"}]=>[{"thread_id"=>40, "name"=>"[main]>worker4", "current_call"=>"(ruby filter code):2:in `block in sleep'"}, {"thread_id"=>42, "name"=>"[main]>worker6", "current_call"=>"(ruby filter code):2:in `block in sleep'"}]}}
~~~
