### PR TITLE
Forward port releasenotes from `8.5.0` and `8.5.1`

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -3,6 +3,8 @@
 
 This section summarizes the changes in the following releases:
 
+* <<logstash-8-5-1,Logstash 8.5.1>>
+* <<logstash-8-5-0,Logstash 8.5.0>>
 * <<logstash-8-4-2,Logstash 8.4.2>>
 * <<logstash-8-4-1,Logstash 8.4.1>>
 * <<logstash-8-4-0,Logstash 8.4.0>>
@@ -25,6 +27,117 @@ This section summarizes the changes in the following releases:
 * <<logstash-8-0-0-beta1,Logstash 8.0.0-beta1>>
 * <<logstash-8-0-0-alpha2,Logstash 8.0.0-alpha2>>
 * <<logstash-8-0-0-alpha1,Logstash 8.0.0-alpha1>>
+
+[[logstash-8-5-1]]
+=== Logstash 8.5.1 Release Notes
+
+[[notable-8.5.1]]
+==== Notable issues fixed
+
+* Fixes the reporting of configuration errors when using multiple-pipelines to make them more actionable https://github.com/elastic/logstash/pull/14713[#14713]
+
+[[dependencies-8.5.1]]
+==== Updates to dependencies
+
+* The bundled JDK has been updated to 17.0.5+8 https://github.com/elastic/logstash/pull/14728[#14728]
+
+[[plugins-8-5-1]]
+==== Plugins
+
+*Cef Codec - 6.2.6*
+
+* Fix: when decoding, escaped newlines and carriage returns in extension values are now correctly decoded into literal newlines and carriage returns respectively https://github.com/logstash-plugins/logstash-codec-cef/pull/98[#98]
+* Fix: when decoding, non-CEF payloads are identified and intercepted to prevent data-loss and corruption. They now cause a descriptive log message to be emitted, and are emitted as their own `_cefparsefailure`-tagged event containing the original bytes in its `message` field https://github.com/logstash-plugins/logstash-codec-cef/issues/99[#99]
+* Fix: when decoding while configured with a `delimiter`, flushing this codec now correctly consumes the remainder of its internal buffer. This resolves an issue where bytes that are written without a trailing delimiter could be lost https://github.com/logstash-plugins/logstash-codec-cef/issues/100[#100]
+
+*Json Codec - 3.1.1*
+
+* Fix: when decoded JSON includes an `[event][original]` field, having `ecs_compatibility` enabled will no longer overwrite the decoded field https://github.com/logstash-plugins/logstash-codec-json/pull/43[#43]
+
+*Grok Filter - 4.4.3*
+
+* Minor typos in docs examples https://github.com/logstash-plugins/logstash-filter-grok/pull/176[#176]
+
+*Tcp Input - 6.3.1*
+
+* Fixes a regression in which the ssl_subject was missing for SSL-secured connections in server mode https://github.com/logstash-plugins/logstash-input-tcp/pull/199[#199]
+
+*Unix Input - 3.1.2*
+
+* Fix: eliminate high CPU usage when data timeout is disabled and no data is available on the socket https://github.com/logstash-plugins/logstash-input-unix/pull/30[#30]
+
+*Rabbitmq Integration - 7.3.1*
+
+* DOCS: clarify the availability and cost of using the `metadata_enabled` option https://github.com/logstash-plugins/logstash-integration-rabbitmq/pull/52[#52]
+
+*Elasticsearch Output - 11.9.3*
+
+* DOC: clarify that `http_compression` option only affects _requests_; compressed _responses_ have always been read independent of this setting https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1030[#1030]
+
+* Fix broken link to Logstash Reference https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1085[#1085]
+
+* Fixes a possible infinite-retry-loop that could occur when this plugin is configured with an `action` whose value contains a <<sprintf,sprintf-style placeholder>> that fails to be resolved for an individual event.
+Events in this state are routed to the pipeline's <<dead-letter-queues,dead letter queue (DLQ)>> if the DLQ is enabled.
+Otherwise, these events are logged-and-dropped so that the remaining events in the batch can be processed. https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1080[#1080]
+
+[[logstash-8-5-0]]
+=== Logstash 8.5.0 Release Notes
+
+[[known-issues-8.5.0]]
+==== Known issues
+
+Due to a recent change in the Red Hat scan verification process,
+this version of Logstash is not available in the Red Hat Ecosystem Catalog.
+This bug will be fixed in the next release.
+Please use the https://www.docker.elastic.co/r/logstash/logstash[Elastic docker registry] to download the 8.5.0 Logstash image.
+
+[[features-8.5.0]]
+==== New features and enhancements
+
+* It is often difficult to understand the health of a pipeline, including whether it is exerting or propagating back-pressure or otherwise staying reasonably “caught up” with its inputs. This release adds pipeline "flow" metrics to the node_stats API for each pipeline, which includes the current and lifetime rates for five key pipeline metrics: input_throughput, filter_throughput, output_throughput, queue_backpressure, and worker_concurrency. https://github.com/elastic/logstash/pull/14518[#14518]
+
+[[notable-8.5.0]]
+==== Notable issues fixed
+
+* Added missing "monitoring.cluster_uuid" to the env2yaml list of accepted configurations and enables the user to set this configuration option via environment variable https://github.com/elastic/logstash/pull/14425[#14425]
+* Use COPY instruction instead of ADD in Dockerfiles https://github.com/elastic/logstash/pull/14423[#14423]
+
+[[docs-8.5.0]]
+==== Documentation Improvements and Fixes
+
+* Add missing reference to full config of Logstash to Logstash over HTTP https://github.com/elastic/logstash/pull/14466[#14466]
+* Describe DLQ's age retention policy https://github.com/elastic/logstash/pull/14340[#14340]
+* Document the cleaning of consumed events from DLQ https://github.com/elastic/logstash/pull/14341[#14341]
+
+==== Plugins
+
+*Translate Filter - 3.4.0*
+
+* Refactor: leverage scheduler mixin https://github.com/logstash-plugins/logstash-filter-translate/pull/93[#93]
+
+*Elasticsearch Input - 4.16.0*
+
+* Added `ssl_certificate_verification` option to control SSL certificate verification https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/180[#180]
+* Feat: add `retries` option. allow retry for failing query https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/179[#179]
+
+*Exec Input - 3.6.0*
+
+* Refactor: start using scheduler mixin https://github.com/logstash-plugins/logstash-input-exec/pull/33[#33]
+* Fix: behavior incompatiblity between (standalone) LS and LS in Docker https://github.com/logstash-plugins/logstash-input-exec/pull/30[#30]
+
+*File Input - 4.4.4*
+
+* Fixes gzip file handling in read mode when run on JDK12+, including JDK17 that is bundled with Logstash 8.4+ https://github.com/logstash-plugins/logstash-input-file/pull/312[#312]
+
+*Http_poller Input - 5.4.0*
+
+* Refactor: start using scheduler mixin https://github.com/logstash-plugins/logstash-input-http_poller/pull/134[#134]
+
+*Elasticsearch Output - 11.9.0*
+
+* Feature: force unresolved dynamic index names to be sent into DLQ. This feature could be explicitly disabled using `dlq_on_failed_indexname_interpolation` setting https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1084[#1084]
+* Feature: Adds a new `dlq_custom_codes` option to customize DLQ codes https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1067[#1067]
+* Feature: deprecates the `failure_type_logging_whitelist` configuration option, renaming it `silence_errors_in_log` https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1068[#1068]
 
 [[logstash-8-4-2]]
 === Logstash 8.4.2 Release Notes


### PR DESCRIPTION
## Release notes
[rn:skip] 

## What does this PR do?
Forward port release notes from `8.5.0` and `8.5.1` to `main`