### PR TITLE
Forward port 8.5.2 release notes

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in the following releases:
 
+* <<logstash-8-5-2,Logstash 8.5.2>>
 * <<logstash-8-5-1,Logstash 8.5.1>>
 * <<logstash-8-5-0,Logstash 8.5.0>>
 * <<logstash-8-4-2,Logstash 8.4.2>>
@@ -27,6 +28,16 @@ This section summarizes the changes in the following releases:
 * <<logstash-8-0-0-beta1,Logstash 8.0.0-beta1>>
 * <<logstash-8-0-0-alpha2,Logstash 8.0.0-alpha2>>
 * <<logstash-8-0-0-alpha1,Logstash 8.0.0-alpha1>>
+
+[[logstash-8-5-2]]
+=== Logstash 8.5.2 Release Notes
+
+No user-facing changes in Logstash core.
+
+[[plugins-8-5-2]]
+==== Plugins
+
+No user-facing changes in Logstash plugins.
 
 [[logstash-8-5-1]]
 === Logstash 8.5.1 Release Notes


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip] 

## What does this PR do?

Forward port `8.5.2` release notes to `main`