### PR TITLE
[DRA] Avoid to loose err code on docker save

### DIFF
--- a/ci/dra_common.sh
+++ b/ci/dra_common.sh
@@ -11,7 +11,7 @@ function save_docker_tarballs {
     local arch="${1:?architecture required}"
     local version="${2:?stack-version required}"
     for image in logstash logstash-oss logstash-ubi8; do
-        docker save "docker.elastic.co/logstash/${image}:${version}" | gzip -c > "build/${image}-${version}-docker-image-${arch}.tar.gz"
+        docker save -o "build/${image}-${version}-docker-image-${arch}.tar.gz" "docker.elastic.co/logstash/${image}:${version}"
     done
 }
 

--- a/ci/dra_common.sh
+++ b/ci/dra_common.sh
@@ -11,10 +11,12 @@ function save_docker_tarballs {
     local arch="${1:?architecture required}"
     local version="${2:?stack-version required}"
     for image in logstash logstash-oss logstash-ubi8; do
-        docker save -o "build/${image}-${version}-docker-image-${arch}.tar.gz" "docker.elastic.co/logstash/${image}:${version}"
+        docker save -o "build/${image}-${version}-docker-image-${arch}.tar" "docker.elastic.co/logstash/${image}:${version}"
         if [ $? != 0 ]
             error "Hit a problem in saving the Docker image for ${image}"
         end
+        # NOTE: if docker save exited with non-zero the error log already exited the script
+        gzip "build/${image}-${version}-docker-image-${arch}.tar"
     done
 }
 

--- a/ci/dra_common.sh
+++ b/ci/dra_common.sh
@@ -12,6 +12,9 @@ function save_docker_tarballs {
     local version="${2:?stack-version required}"
     for image in logstash logstash-oss logstash-ubi8; do
         docker save -o "build/${image}-${version}-docker-image-${arch}.tar.gz" "docker.elastic.co/logstash/${image}:${version}"
+        if [ $? != 0 ]
+            error "Hit a problem in saving the Docker image for ${image}"
+        end
     done
 }
 

--- a/ci/dra_common.sh
+++ b/ci/dra_common.sh
@@ -11,10 +11,9 @@ function save_docker_tarballs {
     local arch="${1:?architecture required}"
     local version="${2:?stack-version required}"
     for image in logstash logstash-oss logstash-ubi8; do
-        docker save -o "build/${image}-${version}-docker-image-${arch}.tar" "docker.elastic.co/logstash/${image}:${version}"
-        if [ $? != 0 ]
+        docker save -o "build/${image}-${version}-docker-image-${arch}.tar" \
+            "docker.elastic.co/logstash/${image}:${version}" || \
             error "Hit a problem in saving the Docker image for ${image}"
-        end
         # NOTE: if docker save exited with non-zero the error log already exited the script
         gzip "build/${image}-${version}-docker-image-${arch}.tar"
     done


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip] 

## What does this PR do?

Avoid to pipe the output of `docker save` to `gzip` because if docker save terminates with error code 2 and its stdout has the value:
```
Error response from daemon: reference does not exist
```
This command generated a gzip file with the content above and error code set to 0.
This commit uses the `-o` option of `docker save` to avoid using stdout and in case of exit code other than 0, exit the bash script immediately.

## Why is it important/What is the impact to the user?

As a release manager I want that any intermediate command that has non zero exit code terminate immediately the bash script.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

With the command:
```bash
docker save "docker.elastic.co/logstash/logstash-ubi8:8.6.0" | gzip -c > "/tmp/logstash-ubi8-8.6.0-docker-image-x86.tar.gz"
```
the exit code `$?` is  0 and the file 
```
/tmp/logstash-ubi8-8.6.0-docker-image-x86.tar.gz
```
contains the zipped 
```
Error response from daemon: reference does not exist
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Fix #14776

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
