### PR TITLE
Retrive JVM_VERSION from Logstash's home directory

### DIFF
--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -100,7 +100,11 @@ setup_java() {
       if [ -x "$LS_JAVA_HOME/bin/java" ]; then
         JAVACMD="$LS_JAVA_HOME/bin/java"
         if [ -d "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}" -a -x "${LOGSTASH_HOME}/${BUNDLED_JDK_PART}/bin/java" ]; then
-          BUNDLED_JDK_VERSION=`cat JDK_VERSION`
+          if [ ! -e "${LOGSTASH_HOME}/JDK_VERSION" ]; then
+            echo "File ${LOGSTASH_HOME}/JDK_VERSION doesn't exists"
+            exit 1
+          fi
+          BUNDLED_JDK_VERSION=`cat "${LOGSTASH_HOME}/JDK_VERSION"`
           echo "WARNING: Logstash comes bundled with the recommended JDK(${BUNDLED_JDK_VERSION}), but is overridden by the version defined in LS_JAVA_HOME. Consider clearing LS_JAVA_HOME to use the bundled JDK."
         fi
       else

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -24,7 +24,11 @@ if defined LS_JAVA_HOME (
   set JAVACMD=%LS_JAVA_HOME%\bin\java.exe
   echo Using LS_JAVA_HOME defined java: %LS_JAVA_HOME%
   if exist "%LS_HOME%\jdk" (
-    set /p BUNDLED_JDK_VERSION=<JDK_VERSION
+    if not exist "%LS_HOME%\JDK_VERSION" (
+      echo "File %LS_HOME%\JDK_VERSION doesn't exists"
+      exit /b 1
+    )
+    set /p BUNDLED_JDK_VERSION=<"%LS_HOME%\JDK_VERSION"
     echo "WARNING: Logstash comes bundled with the recommended JDK(%BUNDLED_JDK_VERSION%), but is overridden by the version defined in LS_JAVA_HOME. Consider clearing LS_JAVA_HOME to use the bundled JDK."
   )
 ) else (


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]


## What does this PR do?

Set the full path to retrieve the `JVM_VERSION` file instead of relying on the `pwd`.


## Why is it important/What is the impact to the user?

A developer that would launch the some integration tests directly from his environment, for example with:
```
./gradlew clean runIntegrationTests -PrubyIntegrationSpecs=specs/es_output_how_spec.rb
```

would hit a problem in specs execution, which kept the process hang, and reporting on the console as:
```
cat: JDK_VERSION: No such file or directory
```

this is because the `pwd` is `<project checkout>/qa/integration` which obviously doesn't contain the expected file.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] run locally with the incriminating command.
- [x] test under windows.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Run the command
```
./gradlew clean runIntegrationTests -PrubyIntegrationSpecs=specs/es_output_how_spec.rb
```
and in the output should not appear the error message:
```
cat: JDK_VERSION: No such file or directory
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

```
+ echo 'Elasticsearch is Up !'
+ return 0
    elasticsearch service setup complete
cat: JDK_VERSION: No such file or directory
OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.
/home/andrea/workspace/logstash_andsel/build/logstash-8.7.0-SNAPSHOT/vendor/bundle/jruby/2.6.0/gems/manticore-0.9.1-java/lib/manticore/client.rb:284: warning: already initialized constant Manticore::Client::HttpPost
/home/andrea/workspace/logstash_andsel/build/logstash-8.7.0-SNAPSHOT/vendor/bundle/jruby/2.6.0/gems/manticore-0.9.1-java/lib/manticore/client.rb:284: warning: already initialized constant Manticore::Client::HttpPost
      can ingest 37K log lines of sample apache logs with default settings
cat: JDK_VERSION: No such file or directory
OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.
      can ingest 37K log lines of sample apache logs with ecs and data streams off
    Tearing down services
    Tearing down elasticsearch service
    elasticsearch service teardown complete

    Finished in 1 minute 6.9 seconds (files took 2.05 seconds to load)
    2 examples, 0 failures


org.logstash.integration.RSpecTests > rspecTests PASSED

```