### PR TITLE
Docs: Add attribute to single source banner text

### DIFF
--- a/docsk8s/index.asciidoc
+++ b/docsk8s/index.asciidoc
@@ -4,6 +4,8 @@
 include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 include::{docs-root}/shared/attributes.asciidoc[]
 
+:lsplugindocs:  IMPORTANT: This documentation is still in development. This feature may be changed or removed in a future release.
+
 [[introduction]]
 == Introduction
 


### PR DESCRIPTION
Related: #14759 
Add and implement an attribute to refine banner text and to re-use it rather than repeating

Note:  Mainly this PR is intended to test access and github workflows