### PR TITLE
Add setting to disable the GeoIP database downloader

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -375,4 +375,4 @@
 # X-Pack GeoIP plugin
 # https://www.elastic.co/guide/en/logstash/current/plugins-filters-geoip.html#plugins-filters-geoip-manage_update
 #xpack.geoip.download.endpoint: "https://geoip.elastic.co/v1/database"
-#xpack.geoip.db.auto_update: true
+#xpack.geoip.downloader.enabled: true

--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -375,4 +375,4 @@
 # X-Pack GeoIP plugin
 # https://www.elastic.co/guide/en/logstash/current/plugins-filters-geoip.html#plugins-filters-geoip-manage_update
 #xpack.geoip.download.endpoint: "https://geoip.elastic.co/v1/database"
-#xpack.geoip.db.auto_update: false
+#xpack.geoip.db.auto_update: true

--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -375,3 +375,4 @@
 # X-Pack GeoIP plugin
 # https://www.elastic.co/guide/en/logstash/current/plugins-filters-geoip.html#plugins-filters-geoip-manage_update
 #xpack.geoip.download.endpoint: "https://geoip.elastic.co/v1/database"
+#xpack.geoip.db.auto_update: false

--- a/docker/data/logstash/env2yaml/env2yaml.go
+++ b/docker/data/logstash/env2yaml/env2yaml.go
@@ -145,7 +145,7 @@ func normalizeSetting(setting string) (string, error) {
 		"xpack.management.elasticsearch.ssl.keystore.path",
 		"xpack.management.elasticsearch.ssl.keystore.password",
 		"xpack.geoip.download.endpoint",
-		"xpack.geoip.db.auto_update",
+		"xpack.geoip.downloader.enabled",
 		"cloud.id",
 		"cloud.auth",
 	}

--- a/docker/data/logstash/env2yaml/env2yaml.go
+++ b/docker/data/logstash/env2yaml/env2yaml.go
@@ -145,6 +145,7 @@ func normalizeSetting(setting string) (string, error) {
 		"xpack.management.elasticsearch.ssl.keystore.path",
 		"xpack.management.elasticsearch.ssl.keystore.password",
 		"xpack.geoip.download.endpoint",
+		"xpack.geoip.db.auto_update",
 		"cloud.id",
 		"cloud.auth",
 	}

--- a/x-pack/lib/filters/geoip/database_manager.rb
+++ b/x-pack/lib/filters/geoip/database_manager.rb
@@ -214,6 +214,18 @@ module LogStash module Filters module Geoip class DatabaseManager
     end
   end
 
+  def check_auto_update_config(database_path)
+    if database_path.nil? && !database_auto_update?
+      raise LogStash::ConfigurationError,
+            "By setting `xpack.geoip.db.auto_update` in logstash.yml to `false` you must manually " \
+            "configure a valid database path with `database =>` for all geoip filter plugin usages."
+    end
+  end
+
+  def database_auto_update?
+    LogStash::SETTINGS.get("xpack.geoip.db.auto_update")
+  end
+
   public
 
   # @note this method is expected to execute on a separate thread
@@ -225,6 +237,8 @@ module LogStash module Filters module Geoip class DatabaseManager
   private :database_update_check
 
   def subscribe_database_path(database_type, database_path, geoip_plugin)
+    check_auto_update_config(database_path)
+
     if database_path.nil?
       trigger_download
 

--- a/x-pack/lib/filters/geoip/database_metadata.rb
+++ b/x-pack/lib/filters/geoip/database_metadata.rb
@@ -46,12 +46,6 @@ module LogStash module Filters module Geoip class DatabaseMetadata
     update(metadata)
   end
 
-  def remove_rows(&block)
-    all_rows = get_all
-    removed = all_rows.select{ |row| block.call(row) }
-    update(all_rows - removed) unless removed.empty?
-  end
-
   def update(metadata)
     metadata = metadata.sort_by { |row| row[Column::DATABASE_TYPE] }
     ::CSV.open @metadata_path, 'w' do |csv|
@@ -98,6 +92,10 @@ module LogStash module Filters module Geoip class DatabaseMetadata
   
   def exist?
     file_exist?(@metadata_path)
+  end
+
+  def delete
+    ::File.delete(@metadata_path) if exist?
   end
 
   class Column

--- a/x-pack/lib/filters/geoip/database_metadata.rb
+++ b/x-pack/lib/filters/geoip/database_metadata.rb
@@ -46,6 +46,12 @@ module LogStash module Filters module Geoip class DatabaseMetadata
     update(metadata)
   end
 
+  def remove_rows(&block)
+    all_rows = get_all
+    removed = all_rows.select{ |row| block.call(row) }
+    update(all_rows - removed) unless removed.empty?
+  end
+
   def update(metadata)
     metadata = metadata.sort_by { |row| row[Column::DATABASE_TYPE] }
     ::CSV.open @metadata_path, 'w' do |csv|

--- a/x-pack/lib/filters/geoip/extension.rb
+++ b/x-pack/lib/filters/geoip/extension.rb
@@ -12,6 +12,7 @@ module LogStash module Filters module Geoip
       require "logstash/runner"
       logger.trace("Registering additional geoip settings")
       settings.register(LogStash::Setting::NullableString.new("xpack.geoip.download.endpoint"))
+      settings.register(LogStash::Setting::Boolean.new("xpack.geoip.db.auto_update", true))
     rescue => e
       logger.error("Cannot register new settings", :message => e.message, :backtrace => e.backtrace)
       raise e

--- a/x-pack/lib/filters/geoip/extension.rb
+++ b/x-pack/lib/filters/geoip/extension.rb
@@ -12,7 +12,7 @@ module LogStash module Filters module Geoip
       require "logstash/runner"
       logger.trace("Registering additional geoip settings")
       settings.register(LogStash::Setting::NullableString.new("xpack.geoip.download.endpoint"))
-      settings.register(LogStash::Setting::Boolean.new("xpack.geoip.db.auto_update", true))
+      settings.register(LogStash::Setting::Boolean.new("xpack.geoip.downloader.enabled", true))
     rescue => e
       logger.error("Cannot register new settings", :message => e.message, :backtrace => e.backtrace)
       raise e

--- a/x-pack/spec/filters/geoip/database_manager_spec.rb
+++ b/x-pack/spec/filters/geoip/database_manager_spec.rb
@@ -368,6 +368,22 @@ describe LogStash::Filters::Geoip do
           expect(path).to be_nil
         end
       end
+
+      context "auto update setting" do
+        it "should raise a configuration error if database is nil" do
+          allow(LogStash::SETTINGS).to receive(:get).with("xpack.geoip.db.auto_update").and_return(false)
+          expect { db_manager.subscribe_database_path(CITY, nil, mock_geoip_plugin) }.to raise_error(LogStash::ConfigurationError)
+        end
+
+        it "should be enabled by default" do
+          expect { db_manager.subscribe_database_path(CITY, nil, mock_geoip_plugin) }.to_not raise_error
+        end
+
+        it "should not raise an error when value is `false` and database is set" do
+          allow(LogStash::SETTINGS).to receive(:get).with("xpack.geoip.db.auto_update").and_return(false)
+          expect { db_manager.subscribe_database_path(CITY, "/foo/bar/", mock_geoip_plugin) }.to_not raise_error
+        end
+      end
     end
 
     context "unsubscribe" do


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Added a `logstash.yml` setting `xpack.geoip.downloader.enabled` to disable the GeoIP databases auto-update feature.

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

This PR adds a config `xpack.geoip.downloader.enabled` to globally disable the database auto-update, applying the following rules:

auto_update: true, database: nil, same as current behavior trying to update the database.
auto_update: true, database: path, same as current behavior using the user-provided database.
auto_update: false, database: nil, use the CC database, and delete all EULA databases.
auto_update: false, database: path, same as current behavior using the user-provided database.

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

If users want to disable the GeoIP database auto-update, they need to set the geoip `database => "/PATH/TO/DB"` option to a file path. As this method is not very intuitive, providing a specific configuration to globally disable the feature, would improve the user experience. It also allows users to stick with the CC databases.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Update plugin documentation [#210](https://github.com/logstash-plugins/logstash-filter-geoip/pull/210)

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Pipeline config for testing:
```
input { 
  generator {
    count => 1
    message => '{ "ip": "8.8.8.8" }'
    codec => json
  } 
}

filter {
  geoip {
    source => "ip"
    target => "geoip"
  }
}

output {
  stdout {
  }
}
```

**Test 1**:
 - Start Logstash with the test pipeline.
 - The plugin should work the same way it does today, downloading the EULA databases and using them.

**Test 2**:
- Change the `logstash.yml` file and set the config `xpack.geoip.downloader.enabled` to `false`.
- Start Logstash with the test pipeline.
- Logstash should display an info message about deleting EULA database copies, removing them, and using the CC databases instead.
- Repeat the same test setting the `xpack.geoip.downloader.enabled` config to `true`. It should download the EULA databases and work as it does today.

**Test 3**:
- Change the `logstash.yml` file and set the config `xpack.geoip.downloader.enabled` to `false`.
- Change the test pipeline by adding the `database => "path/to/db"` option on the `geoip` filter.
- Start Logstash, it should use the user-provided database.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
Closes [#14724](https://github.com/elastic/logstash/issues/14724)
