### PR TITLE
Pins murmurhash3 to last version with java library

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -30,3 +30,4 @@ gem "rack-test", :require => "rack/test", :group => :development
 gem "rspec", "~> 3.5", :group => :development
 gem "webmock", "~> 3", :group => :development
 gem "jar-dependencies", "= 0.4.1" # Gem::LoadError with jar-dependencies 0.4.2
+gem "murmurhash3", "= 0.1.6"

--- a/Gemfile.template
+++ b/Gemfile.template
@@ -30,4 +30,4 @@ gem "rack-test", :require => "rack/test", :group => :development
 gem "rspec", "~> 3.5", :group => :development
 gem "webmock", "~> 3", :group => :development
 gem "jar-dependencies", "= 0.4.1" # Gem::LoadError with jar-dependencies 0.4.2
-gem "murmurhash3", "= 0.1.6"
+gem "murmurhash3", "= 0.1.6" # Pins until version 0.1.7-java is released


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]


## What does this PR do?

Pins the  `murmurhash3` to the last version that provided Java version

## Why is it important/What is the impact to the user?

Avoid errors in compiling latest `main`

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Fixes #14831

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs
```
Error Bundler::InstallError, retrying 1/10
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.6.0/gems/murmurhash3-0.1.7/ext/murmurhash3
/home/andrea/.sdkman/candidates/java/11.0.15-tem/bin/java -cp :/home/andrea/.gradle/caches/jars-9/4b7ea7ee921889f32773847de07d0ab6/snakeyaml-1.29.jar:/home/andrea/.gradle/caches/jars-9/466e6dbe9ac6d19b03a1f3c7e06e9799/gradle-download-task-4.0.4.jar:/home/andrea/.gradle/caches/jars-9/e47ff9aeec92c7ee54aefd6c530ecbae/jruby-complete-9.3.9.0.jar org.jruby.Main -I uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib -r ./siteconf20230109-99722-vy7131.rb extconf.rb
Exception in thread "main" java.lang.NoClassDefFoundError: org/gradle/internal/classpath/Instrumented
        at com.headius.options.Option.loadProperty(Option.java:400)
        at com.headius.options.IntegerOption.reloadValue(IntegerOption.java:38)
        at com.headius.options.IntegerOption.reloadValue(IntegerOption.java:20)
        at com.headius.options.Option.reload(Option.java:431)
        at com.headius.options.Option.load(Option.java:422)
        at org.jruby.util.cli.Options.<clinit>(Options.java:95)
        at org.jruby.util.log.LoggerFactory.<clinit>(LoggerFactory.java:36)
        at org.jruby.Main.<clinit>(Main.java:86)
Caused by: java.lang.ClassNotFoundException: org.gradle.internal.classpath.Instrumented
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        ... 8 more

extconf failed, exit code 1

Gem files will remain installed in /home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.6.0/gems/murmurhash3-0.1.7 for inspection.
Results logged to /home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.6.0/extensions/universal-java-11/2.6.0/murmurhash3-0.1.7/gem_make.out

  uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/ext/builder.rb:93:in `run'
  uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/ext/ext_conf_builder.rb:47:in `block in build'
  org/jruby/ext/tempfile/Tempfile.java:242:in `open'
  uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/ext/ext_conf_builder.rb:26:in `build'
  uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/ext/builder.rb:159:in `build_extension'
  uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/ext/builder.rb:193:in `block in build_extensions'
  org/jruby/RubyArray.java:1865:in `each'
  uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/ext/builder.rb:190:in `build_extensions'
  uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/installer.rb:837:in `build_extensions'
  /home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.6.0/gems/bundler-2.3.18/lib/bundler/rubygems_gem_installer.rb:71:in `build_extensions'
  /home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.6.0/gems/bundler-2.3.18/lib/bundler/rubygems_gem_installer.rb:28:in `install'
  /home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.6.0/gems/bundler-2.3.18/lib/bundler/source/rubygems.rb:207:in `install'
  /home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.6.0/gems/bundler-2.3.18/lib/bundler/installer/gem_installer.rb:54:in `install'
  /home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.6.0/gems/bundler-2.3.18/lib/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.6.0/gems/bundler-2.3.18/lib/bundler/installer/parallel_installer.rb:186:in `do_install'
  /home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.6.0/gems/bundler-2.3.18/lib/bundler/installer/parallel_installer.rb:177:in `block in worker_pool'
  /home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.6.0/gems/bundler-2.3.18/lib/bundler/worker.rb:62:in `apply_func'
  /home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.6.0/gems/bundler-2.3.18/lib/bundler/worker.rb:57:in `block in process_queue'
  org/jruby/RubyKernel.java:1507:in `loop'
  /home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.6.0/gems/bundler-2.3.18/lib/bundler/worker.rb:54:in `process_queue'
  /home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.6.0/gems/bundler-2.3.18/lib/bundler/worker.rb:91:in `block in create_threads'

An error occurred while installing murmurhash3 (0.1.7), and Bundler cannot continue.

In Gemfile:
  logstash-filter-anonymize was resolved to 3.0.6, which depends on
    murmurhash3
```
