### PR TITLE
Forward port of 8.6 and 8.5.3 release notes to main

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -40,8 +40,8 @@ This section summarizes the changes in the following releases:
 * Extends the flow rates introduced to the Node Stats API in 8.5.0 (which included windows for `current` and `lifetime`)
 to include a Technology Preview of several additional windows such as `last_15_minutes`, `last_24_hours`, etc..
 https://github.com/elastic/logstash/pull/14571[#14571]
-* Logstash introduced instance and pipeline level flow metrics, growth_bytes and growth_events for persisted queue
-to provide a better visibility about how fast pipeline queue is growing each single seconds.
+* Logstash introduced instance and pipeline level flow metrics, `growth_bytes` and `growth_events` for persisted queue
+to provide a better visibility about how fast pipeline queue is growing.
 https://github.com/elastic/logstash/pull/14554[#14554]
 
 [[notable-8.6.0]]

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -3,6 +3,8 @@
 
 This section summarizes the changes in the following releases:
 
+* <<logstash-8-6-0,Logstash 8.6.0>>
+* <<logstash-8-5-3,Logstash 8.5.3>>
 * <<logstash-8-5-2,Logstash 8.5.2>>
 * <<logstash-8-5-1,Logstash 8.5.1>>
 * <<logstash-8-5-0,Logstash 8.5.0>>
@@ -28,6 +30,72 @@ This section summarizes the changes in the following releases:
 * <<logstash-8-0-0-beta1,Logstash 8.0.0-beta1>>
 * <<logstash-8-0-0-alpha2,Logstash 8.0.0-alpha2>>
 * <<logstash-8-0-0-alpha1,Logstash 8.0.0-alpha1>>
+
+[[logstash-8-6-0]]
+=== Logstash 8.6.0 Release Notes
+
+[[features-8.6.0]]
+==== New features and enhancements
+
+* Extends the flow rates introduced to the Node Stats API in 8.5.0 (which included windows for `current` and `lifetime`)
+to include a Technology Preview of several additional windows such as `last_15_minutes`, `last_24_hours`, etc..
+https://github.com/elastic/logstash/pull/14571[#14571]
+* Logstash introduced instance and pipeline level flow metrics, growth_bytes and growth_events for persisted queue
+to provide a better visibility about how fast pipeline queue is growing each single seconds.
+https://github.com/elastic/logstash/pull/14554[#14554]
+
+[[notable-8.6.0]]
+==== Notable issues fixed
+* Adds new `close` method to Java's Filter API to be used to clean shutdown resources allocated by the filter during registration phase. https://github.com/elastic/logstash/pull/14485[#14485]
+* Improved JRuby runtime startup avoiding to compile ahead each Ruby code encountered. https://github.com/elastic/logstash/pull/14284[#14284]
+* Fixed issue in pipeline compilation. https://github.com/elastic/logstash/pull/13621[#13621]
+
+[[docs-8.6.0]]
+==== Documentation enhancements
+* Crafted a guide on how to configure and troubleshooting Logstash on Kubernetes.
+** Getting started https://github.com/elastic/logstash/pull/14655[#14655]
+** Persistent Storage https://github.com/elastic/logstash/pull/14714[#14714]
+** Stack Monitoring https://github.com/elastic/logstash/pull/14696[#14696]
+**  Securing Logstash https://github.com/elastic/logstash/pull/14737[#14737]
+
+[[plugins-8.6.0]]
+==== Plugin releases
+
+*Netflow Codec - 4.3.0*
+
+* Added Gigamon ipfix definitions https://github.com/logstash-plugins/logstash-codec-netflow/pull/199[#199]
+
+*Elasticsearch Filter - 3.13.0*
+
+* Added support for this plugin identifying itself to Elasticsearch with an SSL/TLS client certificate using a new `keystore` option https://github.com/logstash-plugins/logstash-filter-elasticsearch/pull/162[#162]
+
+*Jdbc Integration - 5.4.1*
+
+* Bugfix leak which happened in creating a new Database pool for every query. The pool is now crated on registration and closed on plugin's `stop` https://github.com/logstash-plugins/logstash-integration-jdbc/pull/119[#119]
+
+* Ambiguous Timestamp Support https://github.com/logstash-plugins/logstash-integration-jdbc/pull/92[#92]
+** FIX: when encountering an ambiguous timestamp, the JDBC Input no longer crashes
+** Added support for disambiguating timestamps in daylight saving time (DST) overlap periods
+
+*Elasticsearch Output - 11.12.1*
+
+* Log bulk request response body on error, not just when debug logging is enabled https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1096[#1096]
+
+* Add legacy template API support for Elasticsearch 8 https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1092[#1092]
+
+* When using an `api_key` along with either `cloud_id` or https `hosts`, you no longer need to also specify `ssl => true` https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/1065[#1065]
+
+* Feature: expose `dlq_routed` document metric to track the documents routed into DLQ https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1090[#1090]
+
+[[logstash-8-5-3]]
+=== Logstash 8.5.3 Release Notes
+
+No user-facing changes in Logstash core.
+
+[[plugins-8-5-3]]
+==== Plugins
+
+No user-facing changes in Logstash plugins.
 
 [[logstash-8-5-2]]
 === Logstash 8.5.2 Release Notes


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?
Update release notes to include recent changes for `8.6` and `8.5.3`

