### PR TITLE
Replace deprecated Ruby File.exists? method

### DIFF
--- a/lib/bootstrap/bundler.rb
+++ b/lib/bootstrap/bundler.rb
@@ -113,14 +113,14 @@ module LogStash
 
       require "fileutils"
       # create Gemfile from template iff it does not exist
-      unless ::File.exists?(Environment::GEMFILE_PATH)
+      unless ::File.exist?(Environment::GEMFILE_PATH)
         FileUtils.copy(
           ::File.join(Environment::LOGSTASH_HOME, "Gemfile.template"), Environment::GEMFILE_PATH
         )
       end
       # create Gemfile.jruby-1.9.lock from template iff a template exists it itself does not exist
       lock_template = ::File.join(ENV["LOGSTASH_HOME"], "Gemfile.jruby-2.6.lock.release")
-      if ::File.exists?(lock_template) && !::File.exists?(Environment::LOCKFILE)
+      if ::File.exist?(lock_template) && !::File.exist?(Environment::LOCKFILE)
         FileUtils.copy(lock_template, Environment::LOCKFILE)
       end
 

--- a/lib/bootstrap/environment.rb
+++ b/lib/bootstrap/environment.rb
@@ -54,7 +54,7 @@ module LogStash
     def oss_only?
       return true if ENV['OSS']=="true"
 
-      !File.exists?(File.join(LogStash::Environment::LOGSTASH_HOME, "x-pack"))
+      !File.exist?(File.join(LogStash::Environment::LOGSTASH_HOME, "x-pack"))
     end
 
     def win_platform?

--- a/lib/pluginmanager/generate.rb
+++ b/lib/pluginmanager/generate.rb
@@ -63,7 +63,7 @@ class LogStash::PluginManager::Generate < LogStash::PluginManager::Command
       target_entry = File.join(target, entry)
 
       if File.directory?(source_entry)
-        FileUtils.mkdir(target_entry) unless File.exists?(target_entry)
+        FileUtils.mkdir(target_entry) unless File.exist?(target_entry)
         transform_r(source_entry, target_entry)
       else
         # copy the new file, in case of being an .erb file should render first

--- a/lib/pluginmanager/prepare_offline_pack.rb
+++ b/lib/pluginmanager/prepare_offline_pack.rb
@@ -45,7 +45,7 @@ class LogStash::PluginManager::PrepareOfflinePack < LogStash::PluginManager::Com
         signal_error("Package creation cancelled: You must specify the zip extension for the provided filename: #{output}.")
       end
 
-      if ::File.exists?(output)
+      if ::File.exist?(output)
         if overwrite?
           File.delete(output)
         else

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -240,7 +240,7 @@ class LogStash::Agent
     return @id if @id
 
     uuid = nil
-    if ::File.exists?(id_path)
+    if ::File.exist?(id_path)
       begin
         uuid = ::File.open(id_path) {|f| f.each_line.first.chomp }
       rescue => e

--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -601,7 +601,7 @@ module LogStash::Config::Mixin
               #return false, "Require absolute path, got relative path #{value.first}?"
             #end
 
-            if !File.exists?(value.first) # Check if the file exists
+            if !File.exist?(value.first) # Check if the file exists
               return false, "File does not exist or cannot be opened #{value.first}"
             end
 

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -22,7 +22,7 @@ $DEBUGLIST = (ENV["DEBUG"] || "").split(",")
 require 'pathname'
 LogStash::ROOT = Pathname.new(File.join(File.expand_path(File.dirname(__FILE__)), "..", "..", "..")).cleanpath.to_s
 LogStash::XPACK_PATH = File.join(LogStash::ROOT, "x-pack")
-LogStash::OSS = ENV["OSS"] == "true" || !File.exists?(LogStash::XPACK_PATH)
+LogStash::OSS = ENV["OSS"] == "true" || !File.exist?(LogStash::XPACK_PATH)
 
 if !LogStash::OSS
   xpack_dir = File.join(LogStash::XPACK_PATH, "lib")

--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -613,7 +613,7 @@ module LogStash
     class ExistingFilePath < Setting
       def initialize(name, default=nil, strict=true)
         super(name, ::String, default, strict) do |file_path|
-          if !::File.exists?(file_path)
+          if !::File.exist?(file_path)
             raise ::ArgumentError.new("File \"#{file_path}\" must exist but was not found.")
           else
             true

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -457,7 +457,7 @@ describe LogStash::Agent do
 
           # wait for file existence otherwise it will raise exception on Windows
           wait(timeout)
-            .for { ::File.exists?(new_config_output) && !::File.read(new_config_output).chomp.empty? }
+            .for { ::File.exist?(new_config_output) && !::File.read(new_config_output).chomp.empty? }
             .to eq(true)
           # ensure the converge_state_and_update method has updated metrics by
           # invoking the mutex

--- a/qa/integration/services/service.rb
+++ b/qa/integration/services/service.rb
@@ -31,7 +31,7 @@ class Service
 
   def setup
     puts "Setting up #{@name} service"
-    if File.exists?(@setup_script)
+    if File.exist?(@setup_script)
       `#{Shellwords.escape(@setup_script)}`
       raise "#{@setup_script} FAILED with exit status #{$?}" unless $?.success?
     else
@@ -42,7 +42,7 @@ class Service
 
   def teardown
     puts "Tearing down #{@name} service"
-    if File.exists?(@teardown_script)
+    if File.exist?(@teardown_script)
       `#{Shellwords.escape(@teardown_script)}`
       raise "#{@teardown_script} FAILED with exit status #{$?}" unless $?.success?
     else

--- a/qa/integration/specs/deprecation_log_spec.rb
+++ b/qa/integration/specs/deprecation_log_spec.rb
@@ -60,7 +60,7 @@ describe "Test Logstash Pipeline id" do
     wait_logstash_process_terminate
 
     deprecation_log_file = "#{temp_dir}/logstash-deprecation.log"
-    expect(File.exists?(deprecation_log_file)).to be true
+    expect(File.exist?(deprecation_log_file)).to be true
     deprecation_log_content = IO.read(deprecation_log_file)
     expect(deprecation_log_content =~ /\[deprecation.logstash.filters.ruby\].*Teleport/).to be > 0
   end

--- a/qa/integration/specs/env_variables_config_spec.rb
+++ b/qa/integration/specs/env_variables_config_spec.rb
@@ -55,7 +55,7 @@ describe "Test Logstash configuration" do
     send_data(test_tcp_port, sample_data)
     output_file = File.join(test_path, "logstash_env_test.log")
     try(num_retries) do
-      expect(File.exists?(output_file)).to be true
+      expect(File.exist?(output_file)).to be true
     end
     # should have created the file using env variable with filters adding a tag based on env variable
     try(num_retries) do

--- a/qa/integration/specs/fatal_error_spec.rb
+++ b/qa/integration/specs/fatal_error_spec.rb
@@ -52,7 +52,7 @@ describe "uncaught exception" do
     expect(@logstash.exit_code).to be 120
 
     log_file = "#{logs_dir}/logstash-plain.log"
-    expect( File.exists?(log_file) ).to be true
+    expect( File.exist?(log_file) ).to be true
     expect( File.read(log_file) ).to match /\[FATAL\]\[org.logstash.Logstash.*?java.lang.AssertionError: a fatal error/m
   end
 
@@ -65,7 +65,7 @@ describe "uncaught exception" do
     expect(@logstash.exit_code).to be 0 # normal exit
 
     log_file = "#{logs_dir}/logstash-plain.log"
-    expect( File.exists?(log_file) ).to be true
+    expect( File.exist?(log_file) ).to be true
     expect( File.read(log_file) ).to match /\[ERROR\]\[org.logstash.Logstash.*?uncaught exception \(in thread .*?java.io.EOFException: unexpected/m
   end
 

--- a/qa/integration/specs/kafka_input_spec.rb
+++ b/qa/integration/specs/kafka_input_spec.rb
@@ -48,7 +48,7 @@ describe "Test Kafka Input" do
   end
 
   after do
-    File.delete(file_output_path) if File.exists?(file_output_path)
+    File.delete(file_output_path) if File.exist?(file_output_path)
   end
 
   it "can ingest 37 apache log lines from Kafka broker" do

--- a/qa/integration/specs/mixed_codec_spec.rb
+++ b/qa/integration/specs/mixed_codec_spec.rb
@@ -68,7 +68,7 @@ describe "Ruby codec when used in" do
       logstash_service.teardown
 
       plainlog_file = "#{temp_dir}/logstash-plain.log"
-      expect(File.exists?(plainlog_file)).to be true
+      expect(File.exist?(plainlog_file)).to be true
       logs = IO.read(plainlog_file)
       expect(logs).to_not include("ERROR")
 
@@ -92,7 +92,7 @@ describe "Ruby codec when used in" do
       logstash_service.teardown
 
       plainlog_file = "#{temp_dir}/logstash-plain.log"
-      expect(File.exists?(plainlog_file)).to be true
+      expect(File.exist?(plainlog_file)).to be true
       logs = IO.read(plainlog_file)
       expect(logs).to_not include("ERROR")
 
@@ -112,7 +112,7 @@ describe "Ruby codec when used in" do
       logstash_service.teardown
 
       plainlog_file = "#{temp_dir}/logstash-plain.log"
-      expect(File.exists?(plainlog_file)).to be true
+      expect(File.exist?(plainlog_file)).to be true
       logs = IO.read(plainlog_file)
       expect(logs).to_not include("ERROR")
     end

--- a/qa/integration/specs/pipeline_log_spec.rb
+++ b/qa/integration/specs/pipeline_log_spec.rb
@@ -59,7 +59,7 @@ describe "Test Logstash Pipeline id" do
     @ls.spawn_logstash("-w", "1" , "-e", config)
     wait_logstash_process_terminate(@ls)
     plainlog_file = "#{temp_dir}/logstash-plain.log"
-    expect(File.exists?(plainlog_file)).to be true
+    expect(File.exist?(plainlog_file)).to be true
     expect(IO.read(plainlog_file) =~ /\[logstash.javapipeline\s*\]\[#{pipeline_name}\]/).to be > 0
   end
 
@@ -73,7 +73,7 @@ describe "Test Logstash Pipeline id" do
     @ls.spawn_logstash("-w", "1" , "-e", config)
     wait_logstash_process_terminate(@ls)
     plainlog_file = "#{temp_dir}/logstash-plain.log"
-    expect(File.exists?(plainlog_file)).to be true
+    expect(File.exist?(plainlog_file)).to be true
     expect(IO.read(plainlog_file) =~ /Starting pipeline.*"pipeline.sources"=>\["config string"\]/).to be > 0
   end
 
@@ -87,7 +87,7 @@ describe "Test Logstash Pipeline id" do
     @ls.spawn_logstash("-w", "1", "-f", "#{initial_config_file}")
     wait_logstash_process_terminate(@ls)
     plainlog_file = "#{temp_dir}/logstash-plain.log"
-    expect(File.exists?(plainlog_file)).to be true
+    expect(File.exist?(plainlog_file)).to be true
     expect(IO.read(plainlog_file) =~ /Starting pipeline.*"pipeline.sources"=>\["#{initial_config_file}"\]/).to be > 0
   end
 
@@ -103,12 +103,12 @@ describe "Test Logstash Pipeline id" do
     wait_logstash_process_terminate(@ls)
 
     pipeline_log_file = "#{temp_dir}/pipeline_#{pipeline_name}.log"
-    expect(File.exists?(pipeline_log_file)).to be true
+    expect(File.exist?(pipeline_log_file)).to be true
     content = IO.read(pipeline_log_file)
     expect(content =~ /Pipeline started {"pipeline.id"=>"#{pipeline_name}"}/).to be > 0
 
     plainlog_file = "#{temp_dir}/logstash-plain.log"
-    expect(File.exists?(plainlog_file)).to be true
+    expect(File.exist?(plainlog_file)).to be true
     plainlog_content = IO.read(plainlog_file)
     expect(plainlog_content =~ /Pipeline started {"pipeline.id"=>"#{pipeline_name}"}/).to be_nil
   end
@@ -177,10 +177,10 @@ describe "Test Logstash Pipeline id" do
     wait_logstash_process_terminate(@ls)
 
     pipeline_log_file = "#{temp_dir}/pipeline_#{pipeline_name}.log"
-    expect(File.exists?(pipeline_log_file)).to be false
+    expect(File.exist?(pipeline_log_file)).to be false
 
     plainlog_file = "#{temp_dir}/logstash-plain.log"
-    expect(File.exists?(plainlog_file)).to be true
+    expect(File.exist?(plainlog_file)).to be true
     plaing_log_content = IO.read(plainlog_file)
     expect(plaing_log_content =~ /Pipeline started {"pipeline.id"=>"#{pipeline_name}"}/).to be > 0
   end

--- a/qa/integration/specs/plugin_name_log_spec.rb
+++ b/qa/integration/specs/plugin_name_log_spec.rb
@@ -56,7 +56,7 @@ describe "Test Logstash Pipeline id" do
     @ls.spawn_logstash("-w", "1" , "-e", config)
     wait_logstash_process_terminate()
     plainlog_file = "#{temp_dir}/logstash-plain.log"
-    expect(File.exists?(plainlog_file)).to be true
+    expect(File.exist?(plainlog_file)).to be true
     #We know taht sleep plugin log debug lines
     expect(IO.read(plainlog_file) =~ /\[sleep_filter_123\] Sleeping {:delay=>1}/).to be > 0
   end

--- a/qa/integration/specs/settings_spec.rb
+++ b/qa/integration/specs/settings_spec.rb
@@ -34,7 +34,7 @@ describe "Test Logstash instance whose default settings are overridden" do
   }
 
   before(:each) {
-    FileUtils.rm(@logstash_default_logs) if File.exists?(@logstash_default_logs)
+    FileUtils.rm(@logstash_default_logs) if File.exist?(@logstash_default_logs)
     # backup the application settings file -- logstash.yml
     FileUtils.cp(@logstash_service.application_settings_file, "#{@logstash_service.application_settings_file}.original")
   }
@@ -78,14 +78,14 @@ describe "Test Logstash instance whose default settings are overridden" do
     try(num_retries) do
       expect(is_port_open?(test_port)).to be true
     end
-    expect(File.exists?("#{temp_dir}/logstash-plain.log")).to be true
+    expect(File.exist?("#{temp_dir}/logstash-plain.log")).to be true
   end
 
   it "should read config from the specified dir in logstash.yml" do
     change_setting("path.config", temp_dir)
     test_config_path = File.join(temp_dir, "test.config")
     IO.write(test_config_path, tcp_config)
-    expect(File.exists?(test_config_path)).to be true
+    expect(File.exist?(test_config_path)).to be true
     @logstash_service.spawn_logstash
     @logstash_service.wait_for_logstash
     # check LS is up and running with new data path
@@ -97,7 +97,7 @@ describe "Test Logstash instance whose default settings are overridden" do
   it "should exit when config test_and_exit is set" do
     test_config_path = File.join(temp_dir, "test.config")
     IO.write(test_config_path, "#{tcp_config}")
-    expect(File.exists?(test_config_path)).to be true
+    expect(File.exist?(test_config_path)).to be true
     s = {}
     s["path.config"] = test_config_path
     s["config.test_and_exit"] = true
@@ -111,7 +111,7 @@ describe "Test Logstash instance whose default settings are overridden" do
 
     # now with bad config
     IO.write(test_config_path, "#{tcp_config} filters {} ")
-    expect(File.exists?(test_config_path)).to be true
+    expect(File.exist?(test_config_path)).to be true
     @logstash_service.spawn_logstash
     try(num_retries) do
       expect(@logstash_service.exited?).to be true
@@ -151,7 +151,7 @@ describe "Test Logstash instance whose default settings are overridden" do
       expect(is_port_open?(test_port)).to be true
     end
 
-    expect(File.exists?(@logstash_default_logs)).to be true
+    expect(File.exist?(@logstash_default_logs)).to be true
 
     resp = Manticore.get("http://localhost:#{http_port}/_node").body
     node_info = JSON.parse(resp)
@@ -176,6 +176,6 @@ describe "Test Logstash instance whose default settings are overridden" do
     expect(node_info["http_address"]).to eq("127.0.0.1:#{http_port}")
 
     # make sure we log to console and not to any file
-    expect(File.exists?(@logstash_default_logs)).to be false
+    expect(File.exist?(@logstash_default_logs)).to be false
   end
 end

--- a/qa/integration/specs/slowlog_spec.rb
+++ b/qa/integration/specs/slowlog_spec.rb
@@ -57,7 +57,7 @@ describe "Test Logstash Slowlog" do
     @ls.wait_for_logstash
     sleep 2 until @ls.exited?
     slowlog_file = "#{temp_dir}/logstash-slowlog-plain.log"
-    expect(File.exists?(slowlog_file)).to be true
+    expect(File.exist?(slowlog_file)).to be true
     expect(IO.read(slowlog_file).split("\n").size).to be >= 1
   end
 end

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -477,7 +477,7 @@ namespace "artifact" do
       end
 
       source_license_path = "licenses/#{license}.txt"
-      fail("Missing source license: #{source_license_path}") unless File.exists?(source_license_path)
+      fail("Missing source license: #{source_license_path}") unless File.exist?(source_license_path)
       write_to_tar(tar, source_license_path, "logstash-#{LOGSTASH_VERSION}#{PACKAGE_SUFFIX}/LICENSE.txt")
 
       # add build.rb to tar
@@ -514,7 +514,7 @@ namespace "artifact" do
     ensure_logstash_version_constant_defined
     zippath = "build/logstash#{zip_suffix}-#{LOGSTASH_VERSION}#{PACKAGE_SUFFIX}#{platform}.zip"
     puts("[artifact:zip] building #{zippath}")
-    File.unlink(zippath) if File.exists?(zippath)
+    File.unlink(zippath) if File.exist?(zippath)
     Zip::File.open(zippath, Zip::File::CREATE) do |zipfile|
       files(exclude_paths).each do |path|
         path_in_zip = "logstash-#{LOGSTASH_VERSION}#{PACKAGE_SUFFIX}/#{path}"
@@ -522,7 +522,7 @@ namespace "artifact" do
       end
 
       source_license_path = "licenses/#{license}.txt"
-      fail("Missing source license: #{source_license_path}") unless File.exists?(source_license_path)
+      fail("Missing source license: #{source_license_path}") unless File.exist?(source_license_path)
       zipfile.add("logstash-#{LOGSTASH_VERSION}#{PACKAGE_SUFFIX}/LICENSE.txt", source_license_path)
 
       # add build.rb to zip
@@ -677,7 +677,7 @@ namespace "artifact" do
         script = "#{stage}-#{action}" # like, "before-install"
         script_sym = script.gsub("-", "_").to_sym
         script_path = File.join(File.dirname(__FILE__), "..", "pkg", platform, "#{script}.sh")
-        next unless File.exists?(script_path)
+        next unless File.exist?(script_path)
 
         out.scripts[script_sym] = File.read(script_path)
       end

--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -17,7 +17,7 @@
 
 namespace "vendor" do
   task "jruby" do |task, args|
-    system('./gradlew bootstrap') unless File.exists?(File.join("vendor", "jruby"))
+    system('./gradlew bootstrap') unless File.exist?(File.join("vendor", "jruby"))
   end # jruby
 
   namespace "force" do
@@ -27,7 +27,7 @@ namespace "vendor" do
   task "gems", [:bundle] do |task, args|
     require "bootstrap/environment"
 
-    if File.exists?(LogStash::Environment::LOCKFILE) # gradlew already bootstrap-ed
+    if File.exist?(LogStash::Environment::LOCKFILE) # gradlew already bootstrap-ed
       puts("Skipping bundler install...")
     else
       puts("Invoking bundler install...")

--- a/x-pack/qa/integration/support/helpers.rb
+++ b/x-pack/qa/integration/support/helpers.rb
@@ -12,7 +12,7 @@ require "time"
 
 VERSIONS_YML_PATH = File.join(File.dirname(__FILE__), "..", "..", "..", "..", "versions.yml")
 VERSION_PATH = File.join(File.dirname(__FILE__), "..", "..", "..", "VERSION")
-VERSION = File.exists?(VERSIONS_YML_PATH) ? YAML.load_file(VERSIONS_YML_PATH)['logstash'] : File.read(VERSION_PATH).strip
+VERSION = File.exist?(VERSIONS_YML_PATH) ? YAML.load_file(VERSIONS_YML_PATH)['logstash'] : File.read(VERSION_PATH).strip
 
 def get_logstash_path
   ENV["LOGSTASH_PATH"] || File.join(File.dirname(__FILE__), "../../../../")


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->


## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

Ruby 3.2.0 deprecated `File.exists?` method. `File.exist?` is a replacement.

See: https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/

Found in: https://github.com/Homebrew/homebrew-core/pull/120243

## Why is it important/What is the impact to the user?

Building the project with Ruby 3.2.0 fails:

```
==> rake artifact:no_bundle_jdk_tar
rake aborted!
NoMethodError: undefined method `exists?' for File:Class
```

This PR should fix this.

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works


