### PR TITLE
Upgrade `snakeyaml` dependency to 1.33 version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'org.yaml:snakeyaml:1.30'
+        classpath 'org.yaml:snakeyaml:1.33'
     }
 }
 

--- a/logstash-core/benchmarks/build.gradle
+++ b/logstash-core/benchmarks/build.gradle
@@ -36,7 +36,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath 'org.yaml:snakeyaml:1.29'
+    classpath 'org.yaml:snakeyaml:1.33'
     classpath 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0'
   }
 }

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -39,7 +39,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.yaml:snakeyaml:1.29'
+        classpath 'org.yaml:snakeyaml:1.33'
     }
 }
 

--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -23,7 +23,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.yaml:snakeyaml:1.29'
+        classpath 'org.yaml:snakeyaml:1.33'
         classpath "de.undercouch:gradle-download-task:4.0.4"
         classpath "org.jruby:jruby-complete:9.3.9.0"
     }

--- a/tools/benchmark-cli/build.gradle
+++ b/tools/benchmark-cli/build.gradle
@@ -37,7 +37,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath 'org.yaml:snakeyaml:1.29'
+    classpath 'org.yaml:snakeyaml:1.33'
     classpath 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0'
   }
 }

--- a/tools/dependencies-report/build.gradle
+++ b/tools/dependencies-report/build.gradle
@@ -36,7 +36,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath 'org.yaml:snakeyaml:1.29'
+    classpath 'org.yaml:snakeyaml:1.33'
     classpath 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0'
   }
 }

--- a/tools/ingest-converter/build.gradle
+++ b/tools/ingest-converter/build.gradle
@@ -36,7 +36,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath 'org.yaml:snakeyaml:1.29'
+    classpath 'org.yaml:snakeyaml:1.33'
     classpath 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0'
   }
 }


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Upgrades the `snameyaml` dependency which Logstash is using to load/parse `.yml` files, example `versions.yml`.

## Why is it important/What is the impact to the user?
Current `snakeyaml` versions have CVEs and this change mitigates the issues.

## Checklist
- ~[ ] My code follows the style guidelines of this project~
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally
- unite test cases run with `./ci/unit_test.sh`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #14843

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

```
BUILD SUCCESSFUL in 10m 53s
58 actionable tasks: 23 executed, 35 up-to-date
```