### PR TITLE
[Backport 7.17] Pin Murmursh3 to 0.1.6 #14832

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -678,7 +678,7 @@ GEM
     msgpack (1.4.5-java)
     multi_json (1.15.0)
     multipart-post (2.1.1)
-    murmurhash3 (0.1.7)
+    murmurhash3 (0.1.6)
     mustache (0.99.8)
     mustermann (1.0.3)
     naught (1.1.0)


### PR DESCRIPTION
Not clean backport of #14832 to `7.17`