### PR TITLE
Fix version lock for Murmurhash3 to the gem for Java runtime

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -678,7 +678,7 @@ GEM
     msgpack (1.4.5-java)
     multi_json (1.15.0)
     multipart-post (2.1.1)
-    murmurhash3 (0.1.6)
+    murmurhash3 (0.1.6-java)
     mustache (0.99.8)
     mustermann (1.0.3)
     naught (1.1.0)


### PR DESCRIPTION
Fix PR after #14856 to ping the Murmurhash3 for version for Java.