### PR TITLE
set rpm_digest to sha256 instead of default md5

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -640,6 +640,7 @@ namespace "artifact" do
         out.attributes[:rpm_user] = "root"
         out.attributes[:rpm_group] = "root"
         out.attributes[:rpm_os] = "linux"
+        out.attributes[:rpm_digest] = "sha256"
         out.config_files << "/etc/logstash/startup.options"
         out.config_files << "/etc/logstash/jvm.options"
         out.config_files << "/etc/logstash/log4j2.properties"


### PR DESCRIPTION
## Release notes

set rpm_digest to sha256 instead of default md5 to allow installation on FIPS enabled OS

## What does this PR do?

Set "rpm_digest" in fpm to SHA256 instead of the default MD5. This effectively sets `_binary_filedigest_algorithm` `_build_binary_file_digest_algo` to "8" in the rpm spec for building Logstash RPM packages.

## Why is it important/What is the impact to the user?

This allows FIPS enabled Operating Systems to validate the RPM package. 
On RHEL w/ FIPS enabled, without this PR:

```
[joaoduarte@jsvd-fips ~]$ sudo rpm -Uvh logstash-8.6.1-x86_64.rpm 
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
Updating / installing...
   1:logstash-1:8.6.1-1               ################################# [100%]
error: unpacking of archive failed on file /etc/default/logstash;63da885d: cpio: Digest mismatch
error: logstash-1:8.6.1-1.x86_64: install failed
```
with this PR:
```
[joaoduarte@jsvd-fips ~]$ sudo rpm -Uvh logstash-8.6.2-SNAPSHOT-x86_64.rpm 
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
Updating / installing...
   1:logstash-1:8.6.2~SNAPSHOT-1      ################################# [100%]
```


## Author's Checklist

- [ ] check in older supported operating systems that the RPM packages is still installable (is any supported OS not able to do SHA256 checksum validation?)

## How to test this PR locally

1. `rake artifact:rpm` on a x64 machine
2. start a RHEL 9 VM
3. switch system to FIPS by running `fips-mode-setup --enable`
4. reboot
5. copy RPM over the machine
6. run `rpm -Uvh <rpm_file.rpm> `

## Related issues

closes https://github.com/elastic/logstash/issues/12597

## Use cases

One step towards FIPS compliance, but more is needed (e.g. using certified cryptographic modules, avoiding use of tmp, etc).
