### PR TITLE
Fix DLQ age retention policy to be applied also in case head segment is untouched

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -158,9 +158,8 @@ public final class DeadLetterQueueWriter implements Closeable {
     }
 
     @VisibleForTesting
-    static Builder newBuilderWithoutFlusher(final Path queuePath, final long maxSegmentSize, final long maxQueueSize,
-                              final Duration flushInterval) {
-        return new Builder(queuePath, maxSegmentSize, maxQueueSize, flushInterval, false);
+    static Builder newBuilderWithoutFlusher(final Path queuePath, final long maxSegmentSize, final long maxQueueSize) {
+        return new Builder(queuePath, maxSegmentSize, maxQueueSize, Duration.ZERO, false);
     }
 
     private DeadLetterQueueWriter(final Path queuePath, final long maxSegmentSize, final long maxQueueSize,

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -190,12 +190,6 @@ public final class DeadLetterQueueWriter implements Closeable {
         }
     }
 
-    private DeadLetterQueueWriter(final Path queuePath, final long maxSegmentSize, final long maxQueueSize,
-                          final Duration flushInterval, final QueueStorageType storageType, final Duration retentionTime,
-                          final Clock clock) throws IOException {
-        this(queuePath, maxSegmentSize, maxQueueSize, flushInterval, storageType, retentionTime, clock, true);
-    }
-
     public boolean isOpen() {
         return open.get();
     }

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
@@ -39,6 +39,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
@@ -846,6 +847,10 @@ public class DeadLetterQueueReaderTest {
         assertThat(String.format("pre-validation: expected timestamp to serialize to exactly 24 bytes, got `%s`", timestamp),
                    timestamp.serialize().length, is(24));
         return new Timestamp(millis);
+    }
+
+    static Timestamp constantSerializationLengthTimestamp(Clock clock) {
+        return constantSerializationLengthTimestamp(clock.instant().toEpochMilli());
     }
 
     private Timestamp constantSerializationLengthTimestamp() {

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
@@ -218,7 +218,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
     }
 
     @Test
-    public void testRemoveExpiredSegmentOnCloseWhenTheCurrentWriterIsUntouched() throws IOException {
+    public void testDLQWriterCloseRemovesExpiredSegmentWhenCurrentWriterIsUntouched() throws IOException {
         final Event event = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(Collections.emptyMap());
         event.setField("message", "Not so important content");
 
@@ -229,7 +229,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
         Duration retainedPeriod = Duration.ofDays(1);
         long startTime = fakeClock.instant().toEpochMilli();
         try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilderWithoutFlusher(dir, 10 * MB, 1 * GB, Duration.ofSeconds(1))
+                .newBuilderWithoutFlusher(dir, 10 * MB, 1 * GB)
                 .retentionTime(retainedPeriod)
                 .clock(fakeClock)
                 .build()) {
@@ -244,7 +244,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
         // move forward 3 days, so that the first segment becomes eligible to be deleted by the age retention policy
         fakeClock.forward(Duration.ofDays(3));
         try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilderWithoutFlusher(dir, 10 * MB, 1 * GB, Duration.ofSeconds(1))
+                .newBuilderWithoutFlusher(dir, 10 * MB, 1 * GB)
                 .retentionTime(retainedPeriod)
                 .clock(fakeClock)
                 .build()) {

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
@@ -11,7 +11,6 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -20,12 +19,18 @@ import org.logstash.DLQEntry;
 import org.logstash.Event;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.logstash.common.io.DeadLetterQueueTestUtils.FULL_SEGMENT_FILE_SIZE;
 import static org.logstash.common.io.DeadLetterQueueTestUtils.GB;
 import static org.logstash.common.io.DeadLetterQueueTestUtils.MB;
-import static org.logstash.common.io.RecordIOWriter.*;
+import static org.logstash.common.io.RecordIOWriter.BLOCK_SIZE;
+import static org.logstash.common.io.RecordIOWriter.RECORD_HEADER_SIZE;
+import static org.logstash.common.io.RecordIOWriter.VERSION_SIZE;
 
 public class DeadLetterQueueWriterAgeRetentionTest {
 
@@ -124,7 +129,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
                 messageSize += serializationLength;
                 writeManager.writeEntry(entry);
             }
-            assertThat(messageSize, Matchers.is(Matchers.greaterThan(BLOCK_SIZE)));
+            assertThat(messageSize, is(greaterThan(BLOCK_SIZE)));
         }
     }
 
@@ -151,7 +156,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
                 messageSize += serializationLength;
                 writeManager.writeEntry(entry);
             }
-            assertThat(messageSize, Matchers.is(Matchers.greaterThan(BLOCK_SIZE)));
+            assertThat(messageSize, is(greaterThan(BLOCK_SIZE)));
 
             // Exercise
             // write an event that goes in second segment
@@ -195,7 +200,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
                 messageSize += serializationLength;
                 writeManager.writeEntry(entry);
             }
-            assertThat(messageSize, Matchers.is(Matchers.greaterThan(BLOCK_SIZE)));
+            assertThat(messageSize, is(greaterThan(BLOCK_SIZE)));
 
             // when the age expires the retention and a write is done
             // make the retention age to pass for the first 2 full segments
@@ -219,8 +224,8 @@ public class DeadLetterQueueWriterAgeRetentionTest {
 
     @Test
     public void testDLQWriterCloseRemovesExpiredSegmentWhenCurrentWriterIsUntouched() throws IOException {
-        final Event event = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(Collections.emptyMap());
-        event.setField("message", "Not so important content");
+        final Event event = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(
+                Collections.singletonMap("message", "Not so important content"));
 
         // write some data in the new segment
         final Clock pointInTimeFixedClock = Clock.fixed(Instant.now(), ZoneId.of("Europe/Rome"));
@@ -251,11 +256,11 @@ public class DeadLetterQueueWriterAgeRetentionTest {
             // leave it untouched
             assertTrue(writeManager.isOpen());
 
-            // close so that it should clean the expired segments
+            // close so that it should clean the expired segments, close in implicitly invoked by try-with-resource statement
         }
 
         Set<String> actual = listFileNames(dir);
-        assertThat("Age expired is segment is removed", actual, Matchers.not(Matchers.hasItem("1.log")));
+        assertThat("Age expired segment is removed", actual, not(hasItem("1.log")));
     }
 
     private Set<String> listFileNames(Path path) throws IOException {
@@ -263,5 +268,51 @@ public class DeadLetterQueueWriterAgeRetentionTest {
                 .map(Path::getFileName)
                 .map(Path::toString)
                 .collect(Collectors.toSet());
+    }
+
+    @Test
+    public void testDLQWriterFlusherRemovesExpiredSegmentWhenCurrentWriterIsStale() throws IOException, InterruptedException {
+        final Event event = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(
+                Collections.singletonMap("message", "Not so important content"));
+
+        // write some data in the new segment
+        final Clock pointInTimeFixedClock = Clock.fixed(Instant.now(), ZoneId.of("Europe/Rome"));
+        final ForwardableClock fakeClock = new ForwardableClock(pointInTimeFixedClock);
+
+        Duration retainedPeriod = Duration.ofDays(1);
+        Duration flushInterval = Duration.ofSeconds(1);
+        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
+                .newBuilder(dir, 10 * MB, 1 * GB, flushInterval)
+                .retentionTime(retainedPeriod)
+                .clock(fakeClock)
+                .build()) {
+
+            DLQEntry entry = new DLQEntry(event, "", "", "00001", DeadLetterQueueReaderTest.constantSerializationLengthTimestamp(fakeClock));
+            writeManager.writeEntry(entry);
+        }
+
+        Set<String> segments = listFileNames(dir);
+        assertEquals("Once closed the just written segment, only 1 file must be present", Set.of("1.log"), segments);
+
+        // move forward 3 days, so that the first segment becomes eligible to be deleted by the age retention policy
+        fakeClock.forward(Duration.ofDays(3));
+        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
+                .newBuilder(dir, 10 * MB, 1 * GB, flushInterval)
+                .retentionTime(retainedPeriod)
+                .clock(fakeClock)
+                .build()) {
+            // write an element to make head segment stale
+            final Event anotherEvent = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(
+                    Collections.singletonMap("message", "Another not so important content"));
+            DLQEntry entry = new DLQEntry(anotherEvent, "", "", "00002", DeadLetterQueueReaderTest.constantSerializationLengthTimestamp(fakeClock));
+            writeManager.writeEntry(entry);
+
+            // wait a cycle of flusher schedule
+            Thread.sleep(flushInterval.toMillis());
+
+            // flusher should clean the expired segments
+            Set<String> actual = listFileNames(dir);
+            assertThat("Age expired segment is removed by flusher", actual, not(hasItem("1.log")));
+        }
     }
 }


### PR DESCRIPTION


## Release notes

Bugfix on DLQ age policy not executed if the current head segment haven't receives any write

## What does this PR do?

This PR fixes a bug on DLQ age policy not executed if the current head segment haven't receives any write.
The change update the `flushCheck` method, executed both on DLQ writer close and also by the scheduled flusher, so that the `executeAgeRetentionPolicy` is invoked also when the current writer hasn't received any writes.
Adds some test, and to separate the testing of the close from the scheduled flush a new constructor's parameter is added, and consequently updated builder utility.

## Why is it important/What is the impact to the user?

Fixes a  bug that prohibited the execution of the age retention policy when the current head segment doesn't receive any event.
This could happen if the DLQ ends in a situation that doesn't receive any event for long period and the expired segments aren't deleted, contrasting with the age retention policy requirement.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] test locally

## How to test this PR locally

The local test has to verify two conditions:
1. on  Logstash shutdown, the age expired segments are removed
2.  the DLQ scheduled flusher (which runs every 5 second by default) clean all expired segments *if* the current writer has been written.

#### Commons setup
- create an index (`test_index`) in Elasticsearch and close it, to generate DLQ eligible error codes
```
PUT test_index/
POST test_index/_close
```
- enable DLQ in Logstash, edit `config/logstash.yml` adding
```yaml
dead_letter_queue.enable: true
dead_letter_queue.retain.age: 1m
```
- create a test pipeline:
```
input {
  stdin {
    codec => json
  }
}

output {
  elasticsearch {
    index => "test_index"
    hosts => "http://localhost:9200"
    user => "<user>"
    password => "<secret>"
  }
```
#### 1. Verify on Logstash shutdown
- start Logstash with the previous pipeline
- type an event on `stdin` console
- verify that in `data/dead_letter_queue/main` there is a segment file with size > 1
- shutdown Logstash and restart so that is seal the current segment file and create a new a one (with `.tmp` postfix)
- wait a period greater than `dead_letter_queue.retain.age`
- stop Logstash
- *verify* that the old segment file is removed and exist only the empty one.

#### 2. Verify that the flusher clean age expired segments
The schedule flusher clean only segments that are stale, a stale segment is a current segment that hasn't been flushed in 5 seconds..
- start Logstash with the previous pipeline
- type an event on `stdin` console
- verify that in `data/dead_letter_queue/main` there is a segment file with size > 1
- shutdown Logstash and restart so that is seal the current segment file and create a new a one (with `.tmp` postfix)
- wait a period greater than `dead_letter_queue.retain.age`
- *verify* that the expired segment is still present
- type again something on the stdin, so that an event is written into current head segment and becomes stale
- *verify* the old segment is gone.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #14851 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
