### PR TITLE
bump snakeyaml to 1.33 in logstash-core

### DIFF
--- a/logstash-core/benchmarks/build.gradle
+++ b/logstash-core/benchmarks/build.gradle
@@ -36,7 +36,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath 'org.yaml:snakeyaml:1.29'
+    classpath 'org.yaml:snakeyaml:1.33'
     classpath 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0'
   }
 }

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -39,7 +39,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.yaml:snakeyaml:1.29'
+        classpath 'org.yaml:snakeyaml:1.33'
     }
 }
 
@@ -181,6 +181,8 @@ dependencies {
     implementation 'org.codehaus.janino:janino:3.1.0'
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jacksonVersion}"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonVersion}"
+    // pin version of jackson-dataformat-yaml's transitive dependency "snakeyaml"
+    implementation "org.yaml:snakeyaml:1.33"
     implementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'
     implementation('com.google.googlejavaformat:google-java-format:1.15.0') {
         exclude group: 'com.google.guava', module: 'guava'

--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -23,7 +23,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.yaml:snakeyaml:1.29'
+        classpath 'org.yaml:snakeyaml:1.33'
         classpath "de.undercouch:gradle-download-task:4.0.4"
         classpath "org.jruby:jruby-complete:9.3.9.0"
     }

--- a/tools/benchmark-cli/build.gradle
+++ b/tools/benchmark-cli/build.gradle
@@ -37,7 +37,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath 'org.yaml:snakeyaml:1.29'
+    classpath 'org.yaml:snakeyaml:1.33'
     classpath 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0'
   }
 }

--- a/tools/dependencies-report/build.gradle
+++ b/tools/dependencies-report/build.gradle
@@ -36,7 +36,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath 'org.yaml:snakeyaml:1.29'
+    classpath 'org.yaml:snakeyaml:1.33'
     classpath 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0'
   }
 }

--- a/tools/ingest-converter/build.gradle
+++ b/tools/ingest-converter/build.gradle
@@ -36,7 +36,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath 'org.yaml:snakeyaml:1.29'
+    classpath 'org.yaml:snakeyaml:1.33'
     classpath 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0'
   }
 }


### PR DESCRIPTION
ensure logstash-core picks up 1.33 as well from jackson-dataformat-yaml's transititive dependency

Since the current version of jackson-dataformat-yaml has its own dependency of snakeyaml 1.30, logstash-core will have 1.30 instead of 1.33 unless it's overriden in `logstash-core/build.gradle`'s dependency section