### PR TITLE
Revert "Bump to 8.6.2 (#14879)"

### DIFF
--- a/Gemfile.jruby-2.6.lock.release
+++ b/Gemfile.jruby-2.6.lock.release
@@ -2,12 +2,12 @@ PATH
   remote: logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 8.6.3)
+      logstash-core (= 8.6.2)
 
 PATH
   remote: logstash-core
   specs:
-    logstash-core (8.6.3-java)
+    logstash-core (8.6.2-java)
       clamp (~> 1)
       concurrent-ruby (~> 1, < 1.1.10)
       down (~> 5.2.0)

--- a/versions.yml
+++ b/versions.yml
@@ -1,7 +1,7 @@
 ---
 # alpha and beta qualifiers are now added via VERSION_QUALIFIER environment var
-logstash: 8.6.3
-logstash-core: 8.6.3
+logstash: 8.6.2
+logstash-core: 8.6.2
 logstash-core-plugin-api: 2.1.16
 
 bundled_jdk:


### PR DESCRIPTION
8.6 is currently at 8.6.3 but needs to be 8.6.2 until it's out.