### PR TITLE
Skip dependency `Gemfile.lock` during the artifact creation.

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -95,8 +95,9 @@ namespace "artifact" do
     @exclude_paths << 'vendor/**/gems/*/test/**/*'
     @exclude_paths << 'vendor/**/gems/*/spec/**/*'
 
-    # dependency vulnerability scanners may pick unnecessary Gemfile.lock files
-    @exclude_paths << 'vendor/**/gems/*/Gemfile.lock'
+    # vulnerability scanners shouldn't pick dependency Gemfile(s)
+    @exclude_paths << 'vendor/**/gems/**/Gemfile.lock'
+    @exclude_paths << 'vendor/**/gems/**/Gemfile'
 
     # jruby's bundler artifacts
     @exclude_paths << 'vendor/jruby/bin/bundle*'

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -95,6 +95,9 @@ namespace "artifact" do
     @exclude_paths << 'vendor/**/gems/*/test/**/*'
     @exclude_paths << 'vendor/**/gems/*/spec/**/*'
 
+    # dependency vulnerability scanners may pick unnecessary Gemfile.lock files
+    @exclude_paths << 'vendor/**/gems/*/Gemfile.lock'
+
     # jruby's bundler artifacts
     @exclude_paths << 'vendor/jruby/bin/bundle*'
     @exclude_paths << 'vendor/jruby/lib/ruby/stdlib/bundler*'


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip] 

## What does this PR do?

Excludes dependency Gemfile.lock files (example `./vendor/bundle/jruby/2.6.0/gems/http_parser.rb-0.6.0-java/Gemfile.lock`) during the artifact creation. This will help vulnerability scanners not to pick up while scanning.

## Why is it important/What is the impact to the user?
N.A

## Checklist

- [x] My code follows the style guidelines of this project
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~

## Author's Checklist
- [ ]

## How to test this PR locally
- Clone current change and create any artifact (example: `./gradlew assembleTarDistribution`)
- Check that if created artifact contains vendor Gemfile.lock files (`find vendor -name Gemfile.lock`).

## Related issues

- Closes #14877 

## Use cases

## Screenshots

## Logs

