### PR TITLE
Fix inversion of pluginId and pluginType parameteres in DLQ entry creation

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/AbstractDeadLetterQueueWriterExt.java
+++ b/logstash-core/src/main/java/org/logstash/common/AbstractDeadLetterQueueWriterExt.java
@@ -198,7 +198,7 @@ public abstract class AbstractDeadLetterQueueWriterExt extends RubyObject {
                 try {
                     innerWriter.writeEntry(
                         ((JrubyEventExtLibrary.RubyEvent) event).getEvent(),
-                        pluginIdString, pluginTypeString, reason.asJavaString()
+                            pluginTypeString, pluginIdString, reason.asJavaString()
                     );
                 } catch (final IOException ex) {
                     throw new IllegalStateException(ex);

--- a/logstash-core/src/test/java/org/logstash/common/AbstractDeadLetterQueueWriterExtTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/AbstractDeadLetterQueueWriterExtTest.java
@@ -30,7 +30,7 @@ public class AbstractDeadLetterQueueWriterExtTest extends RubyTestBase {
     public TemporaryFolder tmpFolder = new TemporaryFolder();
 
     @Test
-    public void writeToDeadLetterQueue() throws IOException, InterruptedException {
+    public void testDLQWriterDoesntInvertPluginIdAndPluginTypeAttributes() throws IOException, InterruptedException {
         final Path dlqPath = tmpFolder.newFolder("dead_letter_queue").toPath();
         final String pluginId = "id_value";
         final String pluginType = "elasticsearch";

--- a/logstash-core/src/test/java/org/logstash/common/AbstractDeadLetterQueueWriterExtTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/AbstractDeadLetterQueueWriterExtTest.java
@@ -1,0 +1,79 @@
+package org.logstash.common;
+
+import org.jruby.RubyString;
+import org.jruby.javasupport.JavaUtil;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.logstash.DLQEntry;
+import org.logstash.RubyTestBase;
+import org.logstash.RubyUtil;
+import org.logstash.common.io.DeadLetterQueueReader;
+import org.logstash.common.io.DeadLetterQueueWriter;
+import org.logstash.common.io.QueueStorageType;
+import org.logstash.ext.JrubyEventExtLibrary;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+
+public class AbstractDeadLetterQueueWriterExtTest extends RubyTestBase {
+
+    static final int DLQ_VERSION_SIZE = 1;
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Test
+    public void writeToDeadLetterQueue() throws IOException, InterruptedException {
+        final Path dlqPath = tmpFolder.newFolder("dead_letter_queue").toPath();
+        final String pluginId = "id_value";
+        final String pluginType = "elasticsearch";
+        final String dlqName = "main";
+
+        writeAnEventIntoDLQ(dlqPath, pluginId, pluginType, dlqName);
+
+        String segment = "1.log";
+        DeadLetterQueueReader dlqReader = openDeadLetterQueueReader(dlqPath, dlqName, segment);
+
+        DLQEntry dlqEntry = dlqReader.pollEntry(1_000);
+        assertNotNull("A DLQEntry must be present in the queue", dlqEntry);
+        assertEquals(pluginId, dlqEntry.getPluginId());
+        assertEquals(pluginType, dlqEntry.getPluginType());
+    }
+
+    private DeadLetterQueueReader openDeadLetterQueueReader(Path dlqPath, String dlqName, String segment) throws IOException {
+        DeadLetterQueueReader dlqReader = new DeadLetterQueueReader(dlqPath);
+        Path currentSegmentFile = dlqPath.resolve(dlqName).resolve(segment);
+        dlqReader.setCurrentReaderAndPosition(currentSegmentFile, DLQ_VERSION_SIZE);
+        assertEquals(currentSegmentFile, dlqReader.getCurrentSegment());
+        return dlqReader;
+    }
+
+    private void writeAnEventIntoDLQ(Path dlqPath, String pluginId, String pluginType, String dlqName) {
+        final ThreadContext context = RubyUtil.RUBY.getCurrentContext();
+        RubyString id = RubyString.newString(RubyUtil.RUBY, pluginId);
+        RubyString classConfigName = RubyString.newString(RubyUtil.RUBY, pluginType);
+
+        final DeadLetterQueueWriter javaDlqWriter = DeadLetterQueueFactory.getWriter(dlqName, dlqPath.toString(), 1024 * 1024, Duration.ofHours(1), QueueStorageType.DROP_NEWER);
+        IRubyObject dlqWriter = JavaUtil.convertJavaToUsableRubyObject(context.runtime, javaDlqWriter);
+
+        final AbstractDeadLetterQueueWriterExt dlqWriterForInstance = new AbstractDeadLetterQueueWriterExt.PluginDeadLetterQueueWriterExt(
+                RubyUtil.RUBY, RubyUtil.PLUGIN_DLQ_WRITER_CLASS
+        ).initialize(context, dlqWriter, id, classConfigName);
+
+        // create a Logstash event to store into DLQ
+        JrubyEventExtLibrary.RubyEvent event = JrubyEventExtLibrary.RubyEvent.newRubyEvent(RubyUtil.RUBY);
+        event.getEvent().setField("name", "John");
+
+        dlqWriterForInstance.doWrite(context, event, RubyString.newString(RubyUtil.RUBY, "A reason to DLQ-ing"));
+
+        dlqWriterForInstance.close(context);
+    }
+
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Fixes a bug in the DLQ writer, which inverted the pluginId and pluginType attributes.


## What does this PR do?

Pass the argument in correct order when calls `DeadLetterQueueWriter.writeEntry` from `PluginDeadLetterQueueWriterExt`.
Adds a unit test to verify the DLQ writer-read interaction.

## Why is it important/What is the impact to the user?

When the DLQ input receives an event now `pluginId` and `pluginType` are properly valued.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] run real test
- [x] cover with test to avoid regression

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Executes the suggested steps in [original issue](https://github.com/logstash-plugins/logstash-input-dead_letter_queue/issues/48#issuecomment-1427687540).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Fixes #https://github.com/logstash-plugins/logstash-input-dead_letter_queue/issues/48

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
