### PR TITLE
mention the elasticsearch host variable for logstash docker container in docs

### DIFF
--- a/docs/static/docker.asciidoc
+++ b/docs/static/docker.asciidoc
@@ -177,7 +177,9 @@ defined in the `-oss` image.
 
 These settings are defined in the default `logstash.yml`. They can be overridden
 with a <<docker-bind-mount-settings,custom `logstash.yml`>> or via
-<<docker-env-config,environment variables>>.
+<<docker-env-config,environment variables>>. When setting the Elasticsearch host
+address via an environment variable, the relevant variable is 
+`XPACK_MONITORING_ELASTICSEARCH_HOST`.
 
 IMPORTANT: If replacing `logstash.yml` with a custom version, be sure to copy the
 above defaults to the custom file if you want to retain them. If not, they will


### PR DESCRIPTION
## What does this PR do?

Change the documentation describing how to configure the  XPACK_MONITORING_ELASTICSEARCH_HOST setting/variable for docker.

## Why is it important/What is the impact to the user?

The information is important and not available on the page yet.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~


## Logs

Without changing the elasticsearch host address, these error messages keep occurring in the logs.

logstash         | [2023-02-15T15:34:50,477][INFO ][logstash.licensechecker.licensereader] Elasticsearch pool URLs updated {:changes=>{:removed=>[], :added=>[http://elasticsearch:9200/]}}
logstash         | [2023-02-15T15:34:52,707][INFO ][logstash.licensechecker.licensereader] Failed to perform request {:message=>"elasticsearch: Name or service not known", :exception=>Manticore::ResolutionFailure, :cause=>java.net.UnknownHostException: elasticsearch: Name or service not known}
logstash         | [2023-02-15T15:34:52,717][WARN ][logstash.licensechecker.licensereader] Attempted to resurrect connection to dead ES instance, but got an error {:url=>"http://elasticsearch:9200/", :exception=>LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError, :message=>"Elasticsearch Unreachable: [http://elasticsearch:9200/][Manticore::ResolutionFailure] elasticsearch: Name or service not known"}
logstash         | [2023-02-15T15:34:52,791][INFO ][logstash.licensechecker.licensereader] Failed to perform request {:message=>"elasticsearch", :exception=>Manticore::ResolutionFailure, :cause=>java.net.UnknownHostException: elasticsearch}
logstash         | [2023-02-15T15:34:52,802][WARN ][logstash.licensechecker.licensereader] Marking url as dead. Last error: [LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError] Elasticsearch Unreachable: [http://elasticsearch:9200/_xpack][Manticore::ResolutionFailure] elasticsearch {:url=>http://elasticsearch:9200/, :error_message=>"Elasticsearch Unreachable: [http://elasticsearch:9200/_xpack][Manticore::ResolutionFailure] elasticsearch", :error_class=>"LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError"}
logstash         | [2023-02-15T15:34:52,820][WARN ][logstash.licensechecker.licensereader] Attempt to validate Elasticsearch license failed. Sleeping for 0.02 {:fail_count=>1, :exception=>"Elasticsearch Unreachable: [http://elasticsearch:9200/_xpack][Manticore::ResolutionFailure] elasticsearch"}
logstash         | [2023-02-15T15:34:52,847][ERROR][logstash.licensechecker.licensereader] Unable to retrieve license information from license server {:message=>"No Available connections"}