### PR TITLE
remove Bundler::DepProxy tweaks

### DIFF
--- a/rakelib/plugins_docs_dependencies.rake
+++ b/rakelib/plugins_docs_dependencies.rake
@@ -126,7 +126,6 @@ class PluginVersionWorking
   end
 
   def try_plugin(plugin, successful_dependencies)
-    Bundler::DepProxy.__clear!
     builder = Bundler::Dsl.new
     gemfile = LogStash::Gemfile.new(File.new(LogStash::Environment::GEMFILE_PATH, "r+")).load
     gemfile.update(plugin)
@@ -202,14 +201,6 @@ task :generate_plugins_version do
         Signal.trap(signal) do
           block.call
         end
-      end
-    end
-    DepProxy.class_eval do
-      # Bundler caches it's dep-proxy objects (which contain Gem::Dependency objects) from all resolutions.
-      # The Hash itself continues to grow between dependency resolutions and hold up a lot of memory, to avoid
-      # the issue we expose a way of clear-ing the cached objects before each plugin resolution.
-      def self.__clear!
-        @proxies.clear
       end
     end
 


### PR DESCRIPTION
since https://github.com/rubygems/rubygems/pull/5698 Bundler no longer has a DepProxy class, so we can remove the tweaks for it.

This fixes Logstash crash since bump to Bundler 2.4:

```
> Task :generatePluginsVersion FAILED

FAILURE: Build failed with an exception.

* Where:
Script '/Users/joaoduarte/elastic/logstash/rubyUtils.gradle' line: 143

* What went wrong:
Execution failed for task ':generatePluginsVersion'.
> (null) uninitialized constant Bundler::DepProxy


```



To test, run `./gradlew generatePluginsVersion`