### PR TITLE
Negative ack of batch aborted by plugin

### DIFF
--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -604,7 +604,9 @@ module LogStash; class JavaPipeline < AbstractPipeline
 
   def maybe_setup_out_plugins
     if @outputs_registered.make_true
+#       outputs.each { |plugin| puts "DNADBG>> before register output plugin #{plugin.config_name} context: #{plugin.execution_context}" }
       register_plugins(outputs)
+#       outputs.each { |plugin| puts "DNADBG>> registered output plugin #{plugin.config_name} context: #{plugin.execution_context}" }
       register_plugins(filters)
     end
   end

--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -604,9 +604,7 @@ module LogStash; class JavaPipeline < AbstractPipeline
 
   def maybe_setup_out_plugins
     if @outputs_registered.make_true
-#       outputs.each { |plugin| puts "DNADBG>> before register output plugin #{plugin.config_name} context: #{plugin.execution_context}" }
       register_plugins(outputs)
-#       outputs.each { |plugin| puts "DNADBG>> registered output plugin #{plugin.config_name} context: #{plugin.execution_context}" }
       register_plugins(filters)
     end
   end

--- a/logstash-core/spec/logstash/java_pipeline_spec.rb
+++ b/logstash-core/spec/logstash/java_pipeline_spec.rb
@@ -57,16 +57,12 @@ class DummyManualInputGenerator < LogStash::Inputs::Base
 
   def run(queue)
     @queue = queue
-    puts "DNADBG>> iteration is: #{@iterations}"
     if @iterations
       @iterations.times do |i|
-        puts "dummymanualinputgenerator> iteration #{i}"
         queue << LogStash::Event.new
         sleep(0.5)
       end
-      puts "dummymanualinputgenerator> exiting run"
     else
-      puts "dummymanualinputgenerator> using flag loop"
       while !stop? || @keep_running.true?
         queue << LogStash::Event.new
         sleep(0.5)

--- a/logstash-core/spec/logstash/java_pipeline_spec.rb
+++ b/logstash-core/spec/logstash/java_pipeline_spec.rb
@@ -322,9 +322,6 @@ describe LogStash::JavaPipeline do
       # wait for inputs to terminate
       wait(5).for {subject.input_threads.any?(&:alive?)}.to be_falsey
 
-      survivors = subject.worker_threads.select(&:alive?)
-      puts "DNADBG>> survivor workers: #{survivors.map(&:name)}"
-
       # the exception raised by the aborting output should have stopped the pipeline
       wait(5).for {subject.worker_threads.any?(&:alive?)}.to be_falsey
 

--- a/logstash-core/src/main/java/org/logstash/execution/AbortedBatchException.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbortedBatchException.java
@@ -1,0 +1,7 @@
+package org.logstash.execution;
+
+public class AbortedBatchException extends Exception {
+
+    private static final long serialVersionUID = -2883406232121392458L;
+
+}

--- a/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
+++ b/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
@@ -103,7 +103,7 @@ public final class WorkerLoop implements Runnable {
                         }
                     }
                 }
-            } while (!isShutdown || isDraining() || !isNackBatch);
+            } while ((!isShutdown || isDraining()) && !isNackBatch);
 
             if (!isNackBatch) {
                 //we are shutting down, queue is drained if it was required, now  perform a final flush.

--- a/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
+++ b/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
@@ -114,7 +114,7 @@ public final class WorkerLoop implements Runnable {
         } catch (Exception ex) {
             if (ex instanceof AbortedBatchException) {
                 isNackBatch = true;
-                LOGGER.info("Signal to abort an exception received. Terminating pipeline worker {}", Thread.currentThread().getName());
+                LOGGER.info("Received signal to abort processing current batch. Terminating pipeline worker {}", Thread.currentThread().getName());
             } else {
                 // if not an abort batch, continue propagating
                 throw ex;

--- a/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
+++ b/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
@@ -76,26 +76,42 @@ public final class WorkerLoop implements Runnable {
     public void run() {
         try {
             boolean isShutdown = false;
+            boolean isNackBatch = false;
             do {
                 isShutdown = isShutdown || shutdownRequested.get();
                 final QueueBatch batch = readClient.readBatch();
                 final boolean isFlush = flushRequested.compareAndSet(true, false);
                 if (batch.filteredSize() > 0 || isFlush) {
                     consumedCounter.add(batch.filteredSize());
-                    execution.compute(batch, isFlush, false);
-                    filteredCounter.add(batch.filteredSize());
-                    readClient.closeBatch(batch);
+                    try {
+                        execution.compute(batch, isFlush, false);
+                    } catch (Exception ex) {
+                        if (ex instanceof AbortedBatchException) {
+                            isNackBatch = true;
+                            LOGGER.info("Worker loop notified of aborting a batch, isNackBatch: {}", isNackBatch);
+                        } else {
+                            // if not an abort batch, continue propagating in
+                            throw ex;
+                        }
+                    }
+                    if (!isNackBatch) {
+                        filteredCounter.add(batch.filteredSize());
+                        readClient.closeBatch(batch);
 
-                    if (isFlush) {
-                        flushing.set(false);
+                        if (isFlush) {
+                            flushing.set(false);
+                        }
                     }
                 }
-            } while (!isShutdown || isDraining());
-            //we are shutting down, queue is drained if it was required, now  perform a final flush.
-            //for this we need to create a new empty batch to contain the final flushed events
-            final QueueBatch batch = readClient.newBatch();
-            execution.compute(batch, true, true);
-            readClient.closeBatch(batch);
+            } while (!isShutdown || isDraining() || !isNackBatch);
+
+            if (!isNackBatch) {
+                //we are shutting down, queue is drained if it was required, now  perform a final flush.
+                //for this we need to create a new empty batch to contain the final flushed events
+                final QueueBatch batch = readClient.newBatch();
+                execution.compute(batch, true, true);
+                readClient.closeBatch(batch);
+            }
         } catch (final Exception ex) {
             throw new IllegalStateException(ex);
         }

--- a/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
+++ b/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
@@ -114,7 +114,7 @@ public final class WorkerLoop implements Runnable {
         } catch (Exception ex) {
             if (ex instanceof AbortedBatchException) {
                 isNackBatch = true;
-                LOGGER.info("Worker loop notified of aborting a batch");
+                LOGGER.info("Signal to abort an exception received. Terminating pipeline worker {}", Thread.currentThread().getName());
             } else {
                 // if not an abort batch, continue propagating
                 throw ex;


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Let worker threads be interrupted without consuming the in flight batch.

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
Modify the `WorkerLoop` to catch the newly introduced exception `org.logstash.execution.AbortedBatchException` so that an inflight batch could be negatively ACK-ed. This feature is used in combination with PQs to let exit plugins without completing the processing. Any filter and output already executed for the batch will be executed again next time the batch is picked by the persistent queue.

## Why is it important/What is the impact to the user?
In combination with some plugins that leverages its, let the plugins to restart without acknowledging the current batch. In cases, like api key expiration used by an Elasticsearch output, the pipeline can be restarted without forcing it and loosing events.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1119

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
