### PR TITLE
Revert "Unpin bundler to allow 2.4 (#14894)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -285,7 +285,7 @@ def assemblyDeps = [downloadAndInstallJRuby, assemble] + subprojects.collect {
   it.tasks.findByName("assemble")
 }
 
-def bundlerVersion = "~> 2"
+def bundlerVersion = "2.3.18"
 
 tasks.register("installBundler") {
     dependsOn assemblyDeps

--- a/lib/bootstrap/bundler.rb
+++ b/lib/bootstrap/bundler.rb
@@ -163,7 +163,7 @@ module LogStash
           begin
             execute_bundler(options)
             break
-          rescue ::Bundler::SolveFailure => e
+          rescue ::Bundler::VersionConflict => e
             $stderr.puts("Plugin version conflict, aborting")
             raise(e)
           rescue ::Bundler::GemNotFound => e

--- a/spec/unit/bootstrap/bundler_spec.rb
+++ b/spec/unit/bootstrap/bundler_spec.rb
@@ -88,8 +88,8 @@ describe LogStash::Bundler do
 
     context 'abort with an exception' do
       it 'gem conflict' do
-        allow(::Bundler::CLI).to receive(:start).with(bundler_args) { raise ::Bundler::SolveFailure.new('conflict') }
-        expect { subject }.to raise_error(::Bundler::SolveFailure)
+        allow(::Bundler::CLI).to receive(:start).with(bundler_args) { raise ::Bundler::VersionConflict.new('conflict') }
+        expect { subject }.to raise_error(::Bundler::VersionConflict)
       end
 
       it 'gem is not found' do


### PR DESCRIPTION
This reverts commit 6d08a7c1cd9657c4336367c2195fcc002ebefc9b and #14894

Bundler 2.4 is accumulating memory during the `generateDocsVersion` task outside of the known Bundler 2.3 DepProxy class.
Until the memory mitigation patch is adapted to Bundler 2.4 it's best to revert 6d08a7c1cd.