### PR TITLE
Update ls-to-cloud.asciidoc

### DIFF
--- a/docs/static/ls-to-cloud.asciidoc
+++ b/docs/static/ls-to-cloud.asciidoc
@@ -21,6 +21,8 @@ If you have several Cloud IDs, you can add a label, which is ignored
 internally, to help you tell them apart. To add a label you should prefix your
 Cloud ID with a label and a `:` separator in this format "<label>:<cloud-id>"
 
+IMPORTANT: Do not explicitly use `ssl => true` when using Cloud ID while all communication to Cloud should use HTTPS protocol and it is already included.
+
 [[cloud-auth]]
 ==== Cloud Auth
 Cloud Auth is optional. Construct this value by following this format "<username>:<password>".


### PR DESCRIPTION
If the user add `ssl => true` with Cloud ID, it will cause error as below:

> #<Manticore::ResolutionFailure: https: Name or service not known>" when ssl => "true"

This important will help user avoid unnecessary additional configuration for SSL. Feel free to modify the content.