### PR TITLE
Fix system unit TimeoutStopSec on older version. 

### DIFF
--- a/pkg/centos/after-install.sh
+++ b/pkg/centos/after-install.sh
@@ -7,5 +7,17 @@ sed -i \
   /etc/logstash/logstash.yml
 chmod 600 /etc/logstash/startup.options
 chmod 600 /etc/default/logstash
+
+# Starting from systemd 229, TimeouStopSec supports using
+# 'infinity' to disable not send a SIG Kill.
+#
+# Older versions need to use 0 instead.
+systemd_version=$(rpm -q systemd 2> /dev/null | cut -d '-' -f2)
+if  [ -n $systemd_version ] && [ $systemd_version -lt 229 ]; then
+    sed -i \
+      -e "s/^TimeoutStopSec=infinity/TimeoutStopSec=0/" \
+      /lib/systemd/system/logstash.service || true
+fi
+
 # Ensure the init script is picked up by systemd
 systemctl daemon-reload 2> /dev/null || true

--- a/pkg/centos/after-install.sh
+++ b/pkg/centos/after-install.sh
@@ -17,6 +17,12 @@ if  [ -n $systemd_version ] && [ $systemd_version -lt 229 ]; then
     sed -i \
       -e "s/^TimeoutStopSec=infinity/TimeoutStopSec=0/" \
       /lib/systemd/system/logstash.service || true
+else
+    # Ensure's an upgraded system has the right setting, if it
+    # wasn't automatically replaced by the OS.
+    sed -i \
+      -e "s/^TimeoutStopSec=0/TimeoutStopSec=infinity/" \
+      /lib/systemd/system/logstash.service || true
 fi
 
 # Ensure the init script is picked up by systemd

--- a/pkg/debian/after-install.sh
+++ b/pkg/debian/after-install.sh
@@ -11,3 +11,13 @@ sed -i \
 chmod 600 /etc/logstash/startup.options
 chmod 600 /etc/default/logstash
 
+# Starting from systemd 229, TimeouStopSec supports using
+# 'infinity' to disable not send a SIG Kill.
+#
+# Older versions need to use 0 instead.
+systemd_version=$(dpkg-query --showformat='${Version}' --show systemd 2> /dev/null)
+if  [ -n $systemd_version ] && dpkg --compare-versions "$systemd_version" lt 229 ; then
+    sed -i \
+      -e "s/^TimeoutStopSec=infinity/TimeoutStopSec=0/" \
+      /lib/systemd/system/logstash.service || true
+fi

--- a/pkg/debian/after-install.sh
+++ b/pkg/debian/after-install.sh
@@ -20,4 +20,10 @@ if  [ -n $systemd_version ] && dpkg --compare-versions "$systemd_version" lt 229
     sed -i \
       -e "s/^TimeoutStopSec=infinity/TimeoutStopSec=0/" \
       /lib/systemd/system/logstash.service || true
+else
+    # Ensure's an upgraded system has the right setting, if it
+    # wasn't automatically replaced by the OS.
+    sed -i \
+      -e "s/^TimeoutStopSec=0/TimeoutStopSec=infinity/" \
+      /lib/systemd/system/logstash.service || true
 fi

--- a/pkg/ubuntu/after-install.sh
+++ b/pkg/ubuntu/after-install.sh
@@ -9,3 +9,14 @@ sed -i \
   /etc/logstash/logstash.yml
 chmod 600 /etc/logstash/startup.options
 chmod 600 /etc/default/logstash
+
+# Starting from systemd 229, TimeouStopSec supports using
+# 'infinity' to disable not send a SIG Kill.
+#
+# Older versions need to use 0 instead.
+systemd_version=$(dpkg-query --showformat='${Version}' --show systemd 2> /dev/null)
+if  [ -n $systemd_version ] && dpkg --compare-versions "$systemd_version" lt 229 ; then
+    sed -i \
+      -e "s/^TimeoutStopSec=infinity/TimeoutStopSec=0/" \
+      /lib/systemd/system/logstash.service || true
+fi

--- a/pkg/ubuntu/after-install.sh
+++ b/pkg/ubuntu/after-install.sh
@@ -19,4 +19,10 @@ if  [ -n $systemd_version ] && dpkg --compare-versions "$systemd_version" lt 229
     sed -i \
       -e "s/^TimeoutStopSec=infinity/TimeoutStopSec=0/" \
       /lib/systemd/system/logstash.service || true
+else
+    # Ensure's an upgraded system has the right setting, if it
+    # wasn't automatically replaced by the OS.
+    sed -i \
+      -e "s/^TimeoutStopSec=0/TimeoutStopSec=infinity/" \
+      /lib/systemd/system/logstash.service || true
 fi


### PR DESCRIPTION
## What does this PR do?
Starting from systemd 229, `TimeoutStopSec` supports using 'infinity' to prevent the service manager from sending a SIG Kill when stopping the service. This effectively allows logstash to shutdown gracefully including possibly long-running operations such as draining the queue (or other operations).

However, on Operating Systems with older versions of Systemd, such as CentOS7 or Debian Jessie, the setting didn't support the infinity option, and instead used the number 0.

As such, this PR introduces a post-installation change in which it fixes the Systemd Unit in the event of it being installed in an older, soon to be deprecated operating system.


## Why is it important/What is the impact to the user?

This change is important because otherwise, users who stop the Logstash service using a very old service manager would potentially loose data.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

 - Build the package
 - Install the package or upgrade the package.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #12453
