### PR TITLE
Fix wildcards in pipeline IDs version

### DIFF
--- a/docs/static/settings/configuration-wildcard-pipeline-id.asciidoc
+++ b/docs/static/settings/configuration-wildcard-pipeline-id.asciidoc
@@ -14,6 +14,6 @@ xpack.management.pipeline.id: ["*logs", "*apache*", "tomcat_log"]
 
 In this example, `"*logs"` matches all IDs ending in `logs`. `"*apache*"` matches any IDs with `apache` in the name.
 
-Wildcard in pipeline IDs is available starting with Elasticsearch 7.10. Logstash can pick up new pipeline without a restart if the new pipeline ID matches the wildcard pattern.
+Wildcard in pipeline IDs is available starting with Elasticsearch 7.11. Logstash can pick up new pipeline without a restart if the new pipeline ID matches the wildcard pattern.
 
 


### PR DESCRIPTION
## What does this PR do?

The docs state that wildcards in the pipeline IDs are allowable from version 7.10 onwards. This is incorrect as the code to do this was only added in 7.11. This can be seen if you compare the files in question between the 7.10 and 7.11 branches - the function get_wildcard_pipelines does not exist in 7.10.

7.10 => https://github.com/elastic/logstash/blob/4344a874f6ace5e6bfb777cab46a93155eec7a22/x-pack/lib/config_management/elasticsearch_source.rb#L222

7.11 => https://github.com/elastic/logstash/blob/866633f2c3d230ceddbaf2b400753c95047d663b/x-pack/lib/config_management/elasticsearch_source.rb#L224

## Why is it important/What is the impact to the user?

Users will try and use wildcards in pipeline IDs and find that they do not work. This is a poor user experience

## Related issues
Original PR to allow wildcard file IDs - https://github.com/elastic/logstash/pull/12370


