### PR TITLE
Allow usage of dead_letter_queue.retain.age in pipeline settings

### DIFF
--- a/config/pipelines.yml
+++ b/config/pipelines.yml
@@ -96,6 +96,15 @@
 #
 #   dead_letter_queue.storage_policy: drop_newer
 
+#   If using dead_letter_queue.enable: true, the interval that events have to be considered valid. After the interval has
+#   expired the events could be automatically deleted from the DLQ.
+#   The interval could be expressed in days, hours, minutes or seconds, using as postfix notation like 5d,
+#   to represent a five days interval.
+#   The available units are respectively d, h, m, s for day, hours, minutes and seconds.
+#   If not specified then the DLQ doesn't use any age policy for cleaning events.
+#
+#   dead_letter_queue.retain.age: 1d
+
 #
 #   If using dead_letter_queue.enable: true, the directory path where the data files will be stored.
 #   Default is path.data/dead_letter_queue

--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -52,6 +52,7 @@ module LogStash
       "dead_letter_queue.flush_interval",
       "dead_letter_queue.max_bytes",
       "dead_letter_queue.storage_policy",
+      "dead_letter_queue.retain.age",
       "metric.collect",
       "pipeline.plugin_classloaders",
       "path.config",

--- a/logstash-core/spec/logstash/config/source/multi_local_spec.rb
+++ b/logstash-core/spec/logstash/config/source/multi_local_spec.rb
@@ -181,6 +181,16 @@ describe LogStash::Config::Source::MultiLocal do
         expect { subject.pipeline_configs }.not_to raise_error(ArgumentError)
       end
 
+    context 'using dead letter queue settings with storage and retention policies' do
+      let(:retrieved_pipelines) do [
+          { "pipeline.id" => "main", "path.dead_letter_queue" => "/tmp", "dead_letter_queue.max_bytes" => 10000,
+            "dead_letter_queue.storage_policy" => "drop_newer", "dead_letter_queue.retain.age" => "5d" },
+      ]
+      end
+      it "should not raise an error" do
+        expect { subject.pipeline_configs }.not_to raise_error(ArgumentError)
+      end
+
     end
   end
 end

--- a/logstash-core/spec/logstash/config/source/multi_local_spec.rb
+++ b/logstash-core/spec/logstash/config/source/multi_local_spec.rb
@@ -180,6 +180,7 @@ describe LogStash::Config::Source::MultiLocal do
       it "should not raise an error" do
         expect { subject.pipeline_configs }.not_to raise_error(ArgumentError)
       end
+    end
 
     context 'using dead letter queue settings with storage and retention policies' do
       let(:retrieved_pipelines) do [
@@ -190,7 +191,6 @@ describe LogStash::Config::Source::MultiLocal do
       it "should not raise an error" do
         expect { subject.pipeline_configs }.not_to raise_error(ArgumentError)
       end
-
     end
   end
 end


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Fixes and issues that prevented the usage of `dead_letter_queue.retain.age` in pipelines.yml


## What does this PR do?

Allows the usage of `dead_letter_queue.retain.age` in pipelines.yml

## Why is it important/What is the impact to the user?

Its important because it prevented the user from using it per pipeline.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

 - Closes #14951
