### PR TITLE
Revert partial change in c99a7b2f4 that broke packaging builds

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -603,9 +603,6 @@ namespace "artifact" do
     File.join(basedir, "config", "log4j2.properties").tap do |path|
       dir.input("#{path}=/etc/logstash")
     end
-    File.join(basedir, "config", "log4j2.file.properties").tap do |path|
-      dir.input("#{path}=/etc/logstash")
-    end
 
     arch_suffix = bundle_jdk ? map_architecture_for_package_type(platform, jdk_arch) : "no-jdk"
 


### PR DESCRIPTION
## What does this PR do?
Reverts a partial change introduced in c99a7b2f4 that's breaking the package (deb and rpm) builds. c99a7b2f4 is mean to change docker builds, not package builds.

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
```
 Task :downloadPreviousJRuby UP-TO-DATE
Download https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.9.0/jruby-dist-9.3.9.0-bin.tar.gz

> Task :downloadJRuby UP-TO-DATE
Download https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.10.0/jruby-dist-9.3.10.0-bin.tar.gz

> Task :downloadJdk
Downloaded to /home/multipass/logstash/build/jdk-17.0.6-linux-x64.tar.gz

BUILD SUCCESSFUL in 47s
44 actionable tasks: 4 executed, 40 up-to-date
rake aborted!
FPM::InvalidPackageConfiguration: Cannot package the path '/home/multipass/logstash/rakelib/../config/log4j2.file.properties', does it exist?
/home/multipass/logstash/vendor/bundle/jruby/2.6.0/gems/fpm-1.15.1/lib/fpm/package/dir.rb:73:in `block in input'
/home/multipass/logstash/vendor/bundle/jruby/2.6.0/gems/fpm-1.15.1/lib/fpm/package/dir.rb:69:in `input'
/home/multipass/logstash/rakelib/artifacts.rake:607:in `block in package'
/home/multipass/logstash/rakelib/artifacts.rake:606:in `package'
/home/multipass/logstash/rakelib/artifacts.rake:544:in `package_with_jdk'
/home/multipass/logstash/rakelib/artifacts.rake:255:in `block in <main>'
org/jruby/ext/monitor/Monitor.java:82:in `synchronize'
/home/multipass/logstash/vendor/bundle/jruby/2.6.0/gems/rake-12.3.3/exe/rake:27:in `<main>'

Caused by:
Errno::ENOENT: No such file or directory - log4j2.file.properties
/home/multipass/logstash/vendor/bundle/jruby/2.6.0/gems/fpm-1.15.1/lib/fpm/package/dir.rb:138:in `clone'
/home/multipass/logstash/vendor/bundle/jruby/2.6.0/gems/fpm-1.15.1/lib/fpm/package/dir.rb:71:in `block in input'
/home/multipass/logstash/vendor/bundle/jruby/2.6.0/gems/fpm-1.15.1/lib/fpm/package/dir.rb:69:in `input'
/home/multipass/logstash/rakelib/artifacts.rake:607:in `block in package'
/home/multipass/logstash/rakelib/artifacts.rake:606:in `package'
/home/multipass/logstash/rakelib/artifacts.rake:544:in `package_with_jdk'
/home/multipass/logstash/rakelib/artifacts.rake:255:in `block in <main>'
org/jruby/ext/monitor/Monitor.java:82:in `synchronize'
/home/multipass/logstash/vendor/bundle/jruby/2.6.0/gems/rake-12.3.3/exe/rake:27:in `<main>'
Tasks: TOP => artifact:deb
(See full trace by running task with --trace)
```