### PR TITLE
Fixed the DLQ writer to bypass 1 byte entry

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -388,7 +388,10 @@ public final class DeadLetterQueueWriter implements Closeable {
     }
 
     private void updateOldestSegmentReference() throws IOException {
-        oldestSegmentPath = listSegmentPaths(this.queuePath).sorted().findFirst();
+        oldestSegmentPath = listSegmentPaths(this.queuePath)
+                .filter(p -> p.toFile().length() > 1) // take the files that have content to process
+                .sorted()
+                .findFirst();
         if (!oldestSegmentPath.isPresent()) {
             oldestSegmentTimestamp = Optional.empty();
             return;

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -409,14 +409,14 @@ public final class DeadLetterQueueWriter implements Closeable {
      * */
     private static Optional<Timestamp> readTimestampOfLastEventInSegment(Path segmentPath) throws IOException {
         final int lastBlockId = (int) Math.ceil(((Files.size(segmentPath) - VERSION_SIZE) / (double) BLOCK_SIZE)) - 1;
-        byte[] eventBytes;
+        byte[] eventBytes = null;
         try (RecordIOReader recordReader = new RecordIOReader(segmentPath)) {
             int blockId = lastBlockId;
-            do {
+            while (eventBytes == null && blockId >= 0) { // no event present in last block, try with the one before
                 recordReader.seekToBlock(blockId);
                 eventBytes = recordReader.readEvent();
                 blockId--;
-            } while (eventBytes == null && blockId >= 0); // no event present in last block, try with the one before
+            }
         } catch (NoSuchFileException nsfex) {
             // the segment file may have been removed by the clean consumed feature on the reader side
             return Optional.empty();

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
@@ -398,4 +398,14 @@ public class DeadLetterQueueWriterTest {
             assertEquals(2, writeManager.getDroppedEvents());
         }
     }
+
+    @Test(expected = Test.None.class)
+    public void testInitializeWriterWith1ByteEntry() throws Exception {
+        Files.write(dir.resolve("1.log"), "1".getBytes());
+
+        DeadLetterQueueWriter writer = DeadLetterQueueWriter
+                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(1))
+                .build();
+        writer.close();
+    }
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes

Fixed the DLQ writer to bypass 1 byte entry during the search of the oldest segment timestamp

## What does this PR do?

When DLQ writer is initializing and the content of DLQ entry has only 1 byte (version number), the search of the oldest segment timestamp return `-1` [block](https://github.com/elastic/logstash/blob/v8.6.2/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java#L398), hence, [seek](https://github.com/elastic/logstash/blob/v8.6.2/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java#L403) the wrong position.

This PR skips 
- segments with size == 1 byte
- seeking the block if blockId < 0. Empty timestamp returns to the caller.

## Why is it important/What is the impact to the user?

Pipelines are unable to start when DLQ entry is 1 byte.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Fix #14969

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
