### PR TITLE
Tested to fail with JRuby 9.4

### DIFF
--- a/bundler_error_simplified_reproducer.rb
+++ b/bundler_error_simplified_reproducer.rb
@@ -1,0 +1,24 @@
+# encoding: utf-8
+
+# Script to test Bundler leak
+# 
+# To run, copy script to Logstash folder and run:
+# 
+# bin/ruby bundler_error_simplified_reproducer.rb
+
+require_relative "lib/bootstrap/environment"
+require "bundler"
+
+lock_file = Pathname.new(::File.join(LogStash::Environment::LOGSTASH_HOME, "lockfiles", "Gemfile.lock"))
+puts "lock_file is: #{lock_file}"
+
+plugin = "logstash-input-cloudwatch"
+
+plugin_gemfile_path = ::File.join(LogStash::Environment::LOGSTASH_HOME, "lockfiles", plugin)  
+plugin_gemfile = ::File.new(plugin_gemfile_path, "r+").read
+puts "loaded content of #{plugin_gemfile_path}"
+
+builder = Bundler::Dsl.new
+builder.eval_gemfile("bundler file", plugin_gemfile)
+definition = builder.to_definition(lock_file, {})
+definition.resolve_remotely!

--- a/bundler_error_simplified_reproducer.rb
+++ b/bundler_error_simplified_reproducer.rb
@@ -5,20 +5,28 @@
 # To run, copy script to Logstash folder and run:
 # 
 # bin/ruby bundler_error_simplified_reproducer.rb
+# Util JRuby flags
+# -J-Xmx2g
+# -J-Djruby.compile.mode=JIT | FORCE | OFF
+# -J-Djruby.compile.invokedynamic=false | true
+# -J-Djruby.reify.classes=true
 
-require_relative "lib/bootstrap/environment"
 require "bundler"
 
-lock_file = Pathname.new(::File.join(LogStash::Environment::LOGSTASH_HOME, "lockfiles", "Gemfile.lock"))
+cwd = ::File.expand_path(::File.join(__FILE__, ".."))
+puts "current working dir: #{cwd}"
+
+lock_file = Pathname.new(::File.join(cwd, "lockfiles", "Gemfile.lock"))
 puts "lock_file is: #{lock_file}"
 
-plugin = "logstash-input-cloudwatch"
-
-plugin_gemfile_path = ::File.join(LogStash::Environment::LOGSTASH_HOME, "lockfiles", plugin)  
-plugin_gemfile = ::File.new(plugin_gemfile_path, "r+").read
-puts "loaded content of #{plugin_gemfile_path}"
+gemfile_path = ::File.join(cwd, "lockfiles", "logstash-input-cloudwatch")
+gemfile = ::File.new(gemfile_path, "r+").read
+puts "loaded content of #{gemfile_path}"
 
 builder = Bundler::Dsl.new
-builder.eval_gemfile("bundler file", plugin_gemfile)
+builder.eval_gemfile("bundler file", gemfile)
 definition = builder.to_definition(lock_file, {})
+
+# the following is the incriminated
+puts "Before resolve_remotely!"
 definition.resolve_remotely!

--- a/lockfiles/Gemfile.lock
+++ b/lockfiles/Gemfile.lock
@@ -1,0 +1,943 @@
+PATH
+  remote: logstash-core-plugin-api
+  specs:
+    logstash-core-plugin-api (2.1.16-java)
+      logstash-core (= 8.8.0)
+
+PATH
+  remote: logstash-core
+  specs:
+    logstash-core (8.8.0-java)
+      clamp (~> 1)
+      concurrent-ruby (~> 1, < 1.1.10)
+      down (~> 5.2.0)
+      elasticsearch (~> 7)
+      filesize (~> 0.2)
+      gems (~> 1)
+      i18n (~> 1)
+      jrjackson (= 0.4.17)
+      jruby-openssl (~> 0.11)
+      manticore (~> 0.6)
+      minitar (~> 0.8)
+      pry (~> 0.12)
+      puma (~> 5, >= 5.6.2)
+      racc (~> 1.5.2)
+      rack (~> 2)
+      rubyzip (~> 1)
+      sinatra (~> 2)
+      stud (~> 0.0.19)
+      thread_safe (~> 0.3.6)
+      thwait
+      treetop (~> 1)
+      tzinfo-data
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
+    amazing_print (1.4.0)
+    arr-pm (0.0.12)
+    atomic (1.1.101-java)
+    avl_tree (1.2.1)
+      atomic (~> 1.1)
+    avro (1.10.2)
+      multi_json (~> 1)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.736.0)
+    aws-sdk-cloudfront (1.76.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-cloudwatch (1.72.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-core (3.171.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.5)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.63.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-resourcegroups (1.48.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.119.2)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.4)
+    aws-sdk-sns (1.60.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-sqs (1.53.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.5.2)
+      aws-eventstream (~> 1, >= 1.0.2)
+    back_pressure (1.0.0)
+    backports (3.24.0)
+    belzebuth (0.2.3)
+      childprocess
+    benchmark-ips (2.12.0)
+    bindata (2.4.15)
+    buftok (0.2.0)
+    builder (3.2.4)
+    cabin (0.9.0)
+    childprocess (4.1.0)
+    ci_reporter (2.1.0)
+      builder (>= 2.1.2)
+      rexml
+    ci_reporter_rspec (1.0.0)
+      ci_reporter (~> 2.0)
+      rspec (>= 2.14, < 4)
+    clamp (1.0.1)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.9)
+    crack (0.4.5)
+      rexml
+    dalli (3.2.4)
+    diff-lcs (1.5.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.8.1)
+    down (5.2.4)
+      addressable (~> 2.8)
+    e2mmap (0.1.0)
+    edn (1.1.1)
+    elastic-app-search (7.8.0)
+      jwt (>= 1.5, < 3.0)
+    elastic-enterprise-search (7.16.0)
+      elasticsearch-transport (>= 7.11)
+      jwt (>= 1.5, < 3.0)
+    elastic-workplace-search (0.4.1)
+    elasticsearch (7.17.7)
+      elasticsearch-api (= 7.17.7)
+      elasticsearch-transport (= 7.17.7)
+    elasticsearch-api (7.17.7)
+      multi_json
+    elasticsearch-transport (7.17.7)
+      faraday (~> 1)
+      multi_json
+    equalizer (0.0.11)
+    et-orbi (1.2.7)
+      tzinfo
+    faraday (1.10.3)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0)
+      faraday-multipart (~> 1.0)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.0)
+      faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
+      faraday-retry (~> 1.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
+    faraday-retry (1.0.3)
+    ffi (1.15.5-java)
+    filesize (0.2.0)
+    fivemat (1.3.7)
+    flores (0.0.8)
+    fpm (1.15.1)
+      arr-pm (~> 0.0.11)
+      backports (>= 2.6.2)
+      cabin (>= 0.6.0)
+      clamp (~> 1.0.0)
+      pleaserun (~> 0.0.29)
+      rexml
+      stud
+    fugit (1.8.1)
+      et-orbi (~> 1, >= 1.2.7)
+      raabro (~> 1.4)
+    gelfd2 (0.4.1)
+    gem_publisher (1.5.0)
+    gems (1.2.0)
+    gene_pool (1.5.0)
+      concurrent-ruby (>= 1.0)
+    hashdiff (1.0.1)
+    hitimes (1.3.1-java)
+    http (3.3.0)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.0)
+      http_parser.rb (~> 0.6.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
+    http_parser.rb (0.6.0-java)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
+    insist (1.0.0)
+    jar-dependencies (0.4.1)
+    jls-grok (0.11.5)
+      cabin (>= 0.6.0)
+    jls-lumberjack (0.0.26)
+      concurrent-ruby
+    jmespath (1.6.2)
+    jrjackson (0.4.17-java)
+    jruby-jms (1.3.0-java)
+      gene_pool
+      semantic_logger
+    jruby-openssl (0.14.0-java)
+    jruby-stdin-channel (0.2.0-java)
+    json (2.6.3-java)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
+    jwt (2.7.0)
+    kramdown (1.14.0)
+    logstash-codec-avro (3.4.0-java)
+      avro (~> 1.10.2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-cef (6.2.6-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-collectd (3.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-dots (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-edn (3.1.0)
+      edn
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-edn_lines (3.1.0)
+      edn
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-es_bulk (3.1.0)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-fluent (3.4.1-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      msgpack (~> 1.1)
+    logstash-codec-graphite (3.0.6)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-json (3.1.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0, >= 1.0.1)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-json_lines (3.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0, >= 1.0.1)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-line (3.1.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-msgpack (3.1.0-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      msgpack (~> 1.1)
+    logstash-codec-multiline (3.1.1)
+      concurrent-ruby
+      jls-grok (~> 0.11.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-patterns-core
+    logstash-codec-netflow (4.3.0)
+      bindata (>= 1.5.0)
+      logstash-core-plugin-api (~> 2.0)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-plain (3.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-rubydebug (3.1.0)
+      amazing_print (~> 1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-devutils (2.4.0-java)
+      fivemat
+      gem_publisher
+      kramdown (= 1.14.0)
+      logstash-codec-plain
+      logstash-core (>= 6.3)
+      minitar
+      rake
+      rspec (~> 3.0)
+      rspec-wait
+      stud (>= 0.0.20)
+    logstash-filter-aggregate (2.10.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-anonymize (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      murmurhash3
+    logstash-filter-cidr (3.1.3-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-clone (4.2.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.1)
+    logstash-filter-csv (3.1.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-filter-date (3.1.15)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-de_dot (1.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-dissect (1.2.5)
+      jar-dependencies
+      logstash-core-plugin-api (>= 2.1.1, <= 2.99)
+    logstash-filter-dns (3.2.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      lru_redux (~> 1.1.0)
+    logstash-filter-drop (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-elasticsearch (3.15.0)
+      elasticsearch (>= 7.14.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ca_trusted_fingerprint_support (~> 1.0)
+      logstash-mixin-normalize_config_support (~> 1.0)
+      manticore (>= 0.7.1)
+    logstash-filter-fingerprint (3.4.2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      murmurhash3
+    logstash-filter-geoip (7.2.13-java)
+      logstash-core (>= 7.14.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+    logstash-filter-grok (4.4.3)
+      jls-grok (~> 0.11.3)
+      logstash-core (>= 5.6.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.0)
+      logstash-patterns-core (>= 4.3.0, < 5)
+      stud (~> 0.0.22)
+    logstash-filter-http (1.4.3)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      logstash-mixin-http_client (>= 7.2.0, < 9.0.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-filter-json (3.2.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-filter-kv (4.7.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-filter-memcached (1.2.0)
+      dalli (~> 3)
+      logstash-core-plugin-api (~> 2.0)
+    logstash-filter-metrics (4.0.7)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      metriks
+      thread_safe
+    logstash-filter-mutate (3.5.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-prune (3.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-ruby (3.1.8)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-sleep (3.0.7)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-split (3.1.8)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-syslog_pri (3.2.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+    logstash-filter-throttle (4.0.4)
+      atomic
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      thread_safe
+    logstash-filter-translate (3.4.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-deprecation_logger_support (~> 1.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      logstash-mixin-scheduler (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-filter-truncate (1.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-urldecode (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-useragent (3.3.4-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+    logstash-filter-uuid (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-xml (4.2.0)
+      logstash-core (>= 8.4.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      nokogiri (>= 1.13.8)
+      xml-simple
+    logstash-input-azure_event_hubs (1.4.4)
+      logstash-codec-json
+      logstash-codec-plain
+      logstash-core-plugin-api (~> 2.0)
+      stud (>= 0.0.22)
+    logstash-input-beats (6.5.0-java)
+      concurrent-ruby (~> 1.0)
+      jar-dependencies (~> 0.3, >= 0.3.4)
+      logstash-codec-multiline (>= 2.0.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-plugin_factory_support (~> 1.0)
+      thread_safe (~> 0.3.5)
+    logstash-input-couchdb_changes (3.1.6)
+      json
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (>= 0.0.22)
+    logstash-input-dead_letter_queue (2.0.0)
+      logstash-codec-plain
+      logstash-core (>= 8.4.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-input-elasticsearch (4.17.0)
+      elasticsearch (>= 7.17.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ca_trusted_fingerprint_support (~> 1.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-normalize_config_support (~> 1.0)
+      logstash-mixin-scheduler (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      manticore (>= 0.7.1)
+      tzinfo
+      tzinfo-data
+    logstash-input-exec (3.6.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-scheduler (~> 1.0)
+      stud (~> 0.0.22)
+    logstash-input-file (4.4.4)
+      addressable
+      concurrent-ruby (~> 1.0)
+      logstash-codec-multiline (~> 3.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+    logstash-input-ganglia (3.1.4)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (~> 0.0.22)
+    logstash-input-gelf (3.3.2)
+      gelfd2 (= 0.4.1)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (>= 0.0.22, < 0.1.0)
+    logstash-input-generator (3.1.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+    logstash-input-graphite (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-input-tcp
+    logstash-input-heartbeat (3.1.1)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-deprecation_logger_support (~> 1.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      logstash-mixin-event_support (~> 1.0)
+      stud
+    logstash-input-http (3.6.1-java)
+      jar-dependencies (~> 0.3, >= 0.3.4)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+    logstash-input-http_poller (5.4.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0, >= 1.0.1)
+      logstash-mixin-http_client (>= 7.2.0)
+      logstash-mixin-scheduler (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-input-imap (3.2.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-validator_support (~> 1.0)
+      mail (~> 2.6.3)
+      mime-types (= 2.6.2)
+      stud (~> 0.0.22)
+    logstash-input-jms (3.2.2-java)
+      jruby-jms (>= 1.2.0)
+      logstash-codec-json (~> 3.0)
+      logstash-codec-plain (~> 3.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      semantic_logger (< 4.0.0)
+    logstash-input-pipe (3.1.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      stud (~> 0.0.22)
+    logstash-input-redis (3.7.0)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      redis (>= 4.0.1, < 5)
+    logstash-input-snmp (1.3.1)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      stud (>= 0.0.22, < 0.1.0)
+    logstash-input-snmptrap (3.1.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      snmp
+    logstash-input-stdin (3.4.0)
+      jruby-stdin-channel
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+    logstash-input-syslog (3.6.0)
+      concurrent-ruby
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-filter-date
+      logstash-filter-grok (>= 4.4.1)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      stud (>= 0.0.22, < 0.1.0)
+    logstash-input-tcp (6.3.2-java)
+      jruby-openssl (>= 0.12.2)
+      logstash-codec-json
+      logstash-codec-json_lines
+      logstash-codec-line
+      logstash-codec-multiline
+      logstash-codec-plain
+      logstash-core (>= 8.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+    logstash-input-twitter (4.1.0)
+      http-form_data (~> 2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      public_suffix (~> 3)
+      stud (>= 0.0.22, < 0.1)
+      twitter (= 6.2.0)
+    logstash-input-udp (3.5.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      stud (~> 0.0.22)
+    logstash-input-unix (3.1.2)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+    logstash-integration-aws (7.1.0)
+      aws-sdk-cloudfront
+      aws-sdk-cloudwatch
+      aws-sdk-core (~> 3)
+      aws-sdk-resourcegroups
+      aws-sdk-s3
+      aws-sdk-sns
+      aws-sdk-sqs
+      concurrent-ruby
+      logstash-codec-json
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 2.1.12, <= 2.99)
+      rufus-scheduler (>= 3.0.9)
+      stud (~> 0.0.22)
+    logstash-integration-elastic_enterprise_search (2.2.1)
+      elastic-app-search (~> 7.8.0)
+      elastic-enterprise-search (~> 7.16.0)
+      elastic-workplace-search (~> 0.4.1)
+      logstash-codec-plain
+      logstash-core-plugin-api (~> 2.0)
+      logstash-mixin-deprecation_logger_support (~> 1.0)
+    logstash-integration-jdbc (5.4.1)
+      logstash-codec-plain
+      logstash-core (>= 6.5.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-scheduler (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      lru_redux
+      sequel
+      tzinfo
+      tzinfo-data
+    logstash-integration-kafka (11.2.1-java)
+      logstash-codec-json
+      logstash-codec-plain
+      logstash-core (>= 8.3.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-deprecation_logger_support (~> 1.0)
+      manticore (>= 0.5.4, < 1.0.0)
+      stud (>= 0.0.22, < 0.1.0)
+    logstash-integration-rabbitmq (7.3.1-java)
+      back_pressure (~> 1.0)
+      logstash-codec-json
+      logstash-core (>= 6.5.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      march_hare (~> 4.0)
+      stud (~> 0.0.22)
+    logstash-mixin-ca_trusted_fingerprint_support (1.0.1-java)
+      logstash-core (>= 6.8.0)
+    logstash-mixin-deprecation_logger_support (1.0.0-java)
+      logstash-core (>= 5.0.0)
+    logstash-mixin-ecs_compatibility_support (1.3.0-java)
+      logstash-core (>= 6.0.0)
+    logstash-mixin-event_support (1.0.1-java)
+      logstash-core (>= 6.8)
+    logstash-mixin-http_client (7.2.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      manticore (>= 0.8.0, < 1.0.0)
+    logstash-mixin-normalize_config_support (1.0.0-java)
+      logstash-core (>= 6.8.0)
+    logstash-mixin-plugin_factory_support (1.0.0-java)
+      logstash-core (>= 7.13.0)
+    logstash-mixin-scheduler (1.0.1-java)
+      logstash-core (>= 7.16)
+      rufus-scheduler (>= 3.0.9)
+    logstash-mixin-validator_support (1.0.2-java)
+      logstash-core (>= 6.8)
+    logstash-output-csv (3.0.8)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-filter-json
+      logstash-input-generator
+      logstash-output-file
+    logstash-output-elasticsearch (11.14.1-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ca_trusted_fingerprint_support (~> 1.0)
+      logstash-mixin-deprecation_logger_support (~> 1.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.0)
+      logstash-mixin-normalize_config_support (~> 1.0)
+      manticore (>= 0.8.0, < 1.0.0)
+      stud (~> 0.0, >= 0.0.17)
+    logstash-output-email (4.1.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      mail (~> 2.6.3)
+      mime-types (< 3)
+      mustache (>= 0.99.8)
+    logstash-output-file (4.3.0)
+      logstash-codec-json_lines
+      logstash-codec-line
+      logstash-core-plugin-api (>= 2.0.0, < 2.99)
+    logstash-output-graphite (3.1.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-http (5.5.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-http_client (>= 7.2.0, < 8.0.0)
+    logstash-output-lumberjack (3.1.9)
+      jls-lumberjack (>= 0.0.26)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud
+    logstash-output-nagios (3.0.6)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-null (3.0.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-pipe (3.0.6)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-redis (5.0.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      redis (~> 4)
+      stud
+    logstash-output-stdout (3.1.4)
+      logstash-codec-rubydebug
+      logstash-core-plugin-api (>= 1.60.1, < 2.99)
+    logstash-output-tcp (6.1.1)
+      jruby-openssl (>= 0.12.2)
+      logstash-codec-json
+      logstash-core (>= 8.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud
+    logstash-output-udp (3.2.0)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-webhdfs (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      snappy (= 0.0.12)
+      webhdfs
+    logstash-patterns-core (4.3.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    lru_redux (1.1.0)
+    mail (2.6.6)
+      mime-types (>= 1.16, < 4)
+    manticore (0.9.1-java)
+      openssl_pkcs8_pure
+    march_hare (4.5.0-java)
+    memoizable (0.4.2)
+      thread_safe (~> 0.3, >= 0.3.1)
+    method_source (1.0.0)
+    metriks (0.9.9.8)
+      atomic (~> 1.0)
+      avl_tree (~> 1.2.0)
+      hitimes (~> 1.1)
+    mime-types (2.6.2)
+    minitar (0.9)
+    msgpack (1.6.1-java)
+    multi_json (1.15.0)
+    multipart-post (2.3.0)
+    murmurhash3 (0.1.6-java)
+    mustache (0.99.8)
+    mustermann (2.0.2)
+      ruby2_keywords (~> 0.0.1)
+    naught (1.1.0)
+    nio4r (2.5.8-java)
+    nokogiri (1.14.2-java)
+      racc (~> 1.4)
+    octokit (4.25.1)
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
+    openssl_pkcs8_pure (0.0.0.2)
+    paquet (0.2.1)
+    pleaserun (0.0.32)
+      cabin (> 0)
+      clamp
+      dotenv
+      insist
+      mustache (= 0.99.8)
+      stud
+    polyglot (0.3.5)
+    pry (0.14.2-java)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+      spoon (~> 0.0)
+    public_suffix (3.1.1)
+    puma (5.6.5-java)
+      nio4r (~> 2.0)
+    raabro (1.4.0)
+    racc (1.5.2-java)
+    rack (2.2.6.4)
+    rack-protection (2.2.4)
+      rack
+    rack-test (2.1.0)
+      rack (>= 1.3)
+    rake (12.3.3)
+    redis (4.8.1)
+    rexml (3.2.5)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.1)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.4)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+    rspec-wait (0.0.9)
+      rspec (>= 3, < 4)
+    ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
+    rubyzip (1.3.0)
+    rufus-scheduler (3.8.2)
+      fugit (~> 1.1, >= 1.1.6)
+    sawyer (0.9.2)
+      addressable (>= 2.3.5)
+      faraday (>= 0.17.3, < 3)
+    semantic_logger (3.4.1)
+      concurrent-ruby (~> 1.0)
+    sequel (5.66.0)
+    simple_oauth (0.3.1)
+    sinatra (2.2.4)
+      mustermann (~> 2.0)
+      rack (~> 2.2)
+      rack-protection (= 2.2.4)
+      tilt (~> 2.0)
+    snappy (0.0.12-java)
+      snappy-jars (~> 1.1.0)
+    snappy-jars (1.1.0.1.2-java)
+    snmp (1.3.2)
+    spoon (0.0.6)
+      ffi
+    stud (0.0.23)
+    thread_safe (0.3.6-java)
+    thwait (0.2.0)
+      e2mmap
+    tilt (2.1.0)
+    treetop (1.6.12)
+      polyglot (~> 0.3)
+    twitter (6.2.0)
+      addressable (~> 2.3)
+      buftok (~> 0.2.0)
+      equalizer (~> 0.0.11)
+      http (~> 3.0)
+      http-form_data (~> 2.0)
+      http_parser.rb (~> 0.6.0)
+      memoizable (~> 0.4.0)
+      multipart-post (~> 2.0)
+      naught (~> 1.0)
+      simple_oauth (~> 0.3.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2023.2)
+      tzinfo (>= 1.0.0)
+    unf (0.1.4-java)
+    webhdfs (0.10.2)
+      addressable
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    xml-simple (1.1.9)
+      rexml
+
+PLATFORMS
+  java
+
+DEPENDENCIES
+  belzebuth
+  benchmark-ips
+  childprocess (~> 4)
+  ci_reporter_rspec (~> 1)
+  faraday (~> 1)
+  flores (~> 0.0.8)
+  fpm (~> 1, >= 1.14.1)
+  gems (~> 1)
+  jar-dependencies (= 0.4.1)
+  json-schema (~> 2)
+  logstash-codec-avro
+  logstash-codec-cef
+  logstash-codec-collectd
+  logstash-codec-dots
+  logstash-codec-edn
+  logstash-codec-edn_lines
+  logstash-codec-es_bulk
+  logstash-codec-fluent
+  logstash-codec-graphite
+  logstash-codec-json
+  logstash-codec-json_lines
+  logstash-codec-line
+  logstash-codec-msgpack
+  logstash-codec-multiline
+  logstash-codec-netflow
+  logstash-codec-plain
+  logstash-codec-rubydebug
+  logstash-core!
+  logstash-core-plugin-api!
+  logstash-devutils (~> 2)
+  logstash-filter-aggregate
+  logstash-filter-anonymize
+  logstash-filter-cidr
+  logstash-filter-clone
+  logstash-filter-csv
+  logstash-filter-date
+  logstash-filter-de_dot
+  logstash-filter-dissect
+  logstash-filter-dns
+  logstash-filter-drop
+  logstash-filter-elasticsearch
+  logstash-filter-fingerprint
+  logstash-filter-geoip
+  logstash-filter-grok
+  logstash-filter-http
+  logstash-filter-json
+  logstash-filter-kv
+  logstash-filter-memcached
+  logstash-filter-metrics
+  logstash-filter-mutate
+  logstash-filter-prune
+  logstash-filter-ruby
+  logstash-filter-sleep
+  logstash-filter-split
+  logstash-filter-syslog_pri
+  logstash-filter-throttle
+  logstash-filter-translate
+  logstash-filter-truncate
+  logstash-filter-urldecode
+  logstash-filter-useragent
+  logstash-filter-uuid
+  logstash-filter-xml
+  logstash-input-azure_event_hubs
+  logstash-input-beats
+  logstash-input-couchdb_changes
+  logstash-input-dead_letter_queue
+  logstash-input-elasticsearch
+  logstash-input-exec
+  logstash-input-file
+  logstash-input-ganglia
+  logstash-input-gelf
+  logstash-input-generator
+  logstash-input-graphite
+  logstash-input-heartbeat
+  logstash-input-http
+  logstash-input-http_poller
+  logstash-input-imap
+  logstash-input-jms
+  logstash-input-pipe
+  logstash-input-redis
+  logstash-input-snmp
+  logstash-input-snmptrap
+  logstash-input-stdin
+  logstash-input-syslog
+  logstash-input-tcp
+  logstash-input-twitter
+  logstash-input-udp
+  logstash-input-unix
+  logstash-integration-aws
+  logstash-integration-elastic_enterprise_search
+  logstash-integration-jdbc
+  logstash-integration-kafka
+  logstash-integration-rabbitmq
+  logstash-output-csv
+  logstash-output-elasticsearch (>= 11.6.0)
+  logstash-output-email
+  logstash-output-file
+  logstash-output-graphite
+  logstash-output-http
+  logstash-output-lumberjack
+  logstash-output-nagios
+  logstash-output-null
+  logstash-output-pipe
+  logstash-output-redis
+  logstash-output-stdout
+  logstash-output-tcp
+  logstash-output-udp
+  logstash-output-webhdfs
+  murmurhash3 (= 0.1.6)
+  octokit (~> 4.25)
+  paquet (~> 0.2)
+  pleaserun (~> 0.0.28)
+  polyglot
+  rack-test
+  rake (~> 12)
+  rspec (~> 3.5)
+  ruby-progressbar (~> 1)
+  rubyzip (~> 1)
+  stud (~> 0.0.22)
+  thwait
+  treetop
+  webmock (~> 3)
+
+BUNDLED WITH
+   2.4.10

--- a/lockfiles/logstash-input-cloudwatch
+++ b/lockfiles/logstash-input-cloudwatch
@@ -1,0 +1,127 @@
+# This is a Logstash generated Gemfile.
+# If you modify this file manually all comments and formatting will be lost.
+
+source "https://rubygems.org"
+gem "logstash-core", :path => "./logstash-core"
+gem "logstash-core-plugin-api", :path => "./logstash-core-plugin-api"
+gem "paquet", "~> 0.2"
+gem "pleaserun", "~>0.0.28", :require => false
+gem "rake", "~> 12", :require => false
+gem "ruby-progressbar", "~> 1", :require => false
+gem "logstash-output-elasticsearch", ">= 11.6.0"
+gem "polyglot", :require => false
+gem "treetop", :require => false
+gem "faraday", "~> 1", :require => false
+gem "childprocess", "~> 4", :group => :build
+gem "fpm", "~> 1", ">= 1.14.1", :group => :build
+gem "gems", "~> 1", :group => :build
+gem "octokit", "~> 4.25", :group => :build
+gem "rubyzip", "~> 1", :group => :build
+gem "stud", "~> 0.0.22", :group => :build
+gem "belzebuth", :group => :development
+gem "benchmark-ips", :group => :development
+gem "ci_reporter_rspec", "~> 1", :group => :development
+gem "flores", "~> 0.0.8", :group => :development
+gem "json-schema", "~> 2", :group => :development
+gem "logstash-devutils", "~> 2", :group => :development
+gem "rack-test", :require => "rack/test", :group => :development
+gem "rspec", "~> 3.5", :group => :development
+gem "webmock", "~> 3", :group => :development
+gem "jar-dependencies", "= 0.4.1"
+gem "murmurhash3", "= 0.1.6"
+gem "thwait"
+gem "logstash-codec-avro"
+gem "logstash-codec-cef"
+gem "logstash-codec-collectd"
+gem "logstash-codec-dots"
+gem "logstash-codec-edn"
+gem "logstash-codec-edn_lines"
+gem "logstash-codec-es_bulk"
+gem "logstash-codec-fluent"
+gem "logstash-codec-graphite"
+gem "logstash-codec-json"
+gem "logstash-codec-json_lines"
+gem "logstash-codec-line"
+gem "logstash-codec-msgpack"
+gem "logstash-codec-multiline"
+gem "logstash-codec-netflow"
+gem "logstash-codec-plain"
+gem "logstash-codec-rubydebug"
+gem "logstash-filter-aggregate"
+gem "logstash-filter-anonymize"
+gem "logstash-filter-cidr"
+gem "logstash-filter-clone"
+gem "logstash-filter-csv"
+gem "logstash-filter-date"
+gem "logstash-filter-de_dot"
+gem "logstash-filter-dissect"
+gem "logstash-filter-dns"
+gem "logstash-filter-drop"
+gem "logstash-filter-elasticsearch"
+gem "logstash-filter-fingerprint"
+gem "logstash-filter-geoip"
+gem "logstash-filter-grok"
+gem "logstash-filter-http"
+gem "logstash-filter-json"
+gem "logstash-filter-kv"
+gem "logstash-filter-memcached"
+gem "logstash-filter-metrics"
+gem "logstash-filter-mutate"
+gem "logstash-filter-prune"
+gem "logstash-filter-ruby"
+gem "logstash-filter-sleep"
+gem "logstash-filter-split"
+gem "logstash-filter-syslog_pri"
+gem "logstash-filter-throttle"
+gem "logstash-filter-translate"
+gem "logstash-filter-truncate"
+gem "logstash-filter-urldecode"
+gem "logstash-filter-useragent"
+gem "logstash-filter-uuid"
+gem "logstash-filter-xml"
+gem "logstash-input-azure_event_hubs"
+gem "logstash-input-beats"
+gem "logstash-input-couchdb_changes"
+gem "logstash-input-dead_letter_queue"
+gem "logstash-input-elasticsearch"
+gem "logstash-input-exec"
+gem "logstash-input-file"
+gem "logstash-input-ganglia"
+gem "logstash-input-gelf"
+gem "logstash-input-generator"
+gem "logstash-input-graphite"
+gem "logstash-input-heartbeat"
+gem "logstash-input-http"
+gem "logstash-input-http_poller"
+gem "logstash-input-imap"
+gem "logstash-input-jms"
+gem "logstash-input-pipe"
+gem "logstash-input-redis"
+gem "logstash-input-snmp"
+gem "logstash-input-snmptrap"
+gem "logstash-input-stdin"
+gem "logstash-input-syslog"
+gem "logstash-input-tcp"
+gem "logstash-input-twitter"
+gem "logstash-input-udp"
+gem "logstash-input-unix"
+gem "logstash-integration-elastic_enterprise_search"
+gem "logstash-integration-jdbc"
+gem "logstash-integration-kafka"
+gem "logstash-integration-rabbitmq"
+gem "logstash-integration-aws"
+gem "logstash-output-csv"
+gem "logstash-output-email"
+gem "logstash-output-file"
+gem "logstash-output-graphite"
+gem "logstash-output-http"
+gem "logstash-output-lumberjack"
+gem "logstash-output-nagios"
+gem "logstash-output-null"
+gem "logstash-output-pipe"
+gem "logstash-output-redis"
+gem "logstash-output-stdout"
+gem "logstash-output-tcp"
+gem "logstash-output-udp"
+gem "logstash-output-webhdfs"
+gem "logstash-input-cloudwatch"


### PR DESCRIPTION
**DO NOT MERGE INTENDED FOR DEBUG**

This PR exposes a reproducer to check that Bundler 2.4 goes in infinite loop with JRuby 9.4.x but not with CRuby 3.2.1

## How to test

Using system Ruby installed with `rvm`:

```bash
./gradlew clean installDefaultGems
ruby bundler_error_simplified_reproducer.rb
```