### PR TITLE
Reintroduce bundler 2.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -290,7 +290,7 @@ def assemblyDeps = [downloadAndInstallJRuby, assemble] + subprojects.collect {
   it.tasks.findByName("assemble")
 }
 
-def bundlerVersion = "2.3.18"
+def bundlerVersion = "~> 2"
 
 tasks.register("installBundler") {
     dependsOn assemblyDeps

--- a/lib/bootstrap/bundler.rb
+++ b/lib/bootstrap/bundler.rb
@@ -163,7 +163,7 @@ module LogStash
           begin
             execute_bundler(options)
             break
-          rescue ::Bundler::VersionConflict => e
+          rescue ::Bundler::SolveFailure => e
             $stderr.puts("Plugin version conflict, aborting")
             raise(e)
           rescue ::Bundler::GemNotFound => e

--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -424,6 +424,10 @@
     "default-plugins": true,
     "skip-list": false
   },
+  "logstash-input-cloudwatch": {
+    "default-plugins": false,
+    "skip-list": true
+  },
   "logstash-output-cloudwatch": {
     "default-plugins": false,
     "skip-list": true

--- a/rakelib/plugins_docs_dependencies.rake
+++ b/rakelib/plugins_docs_dependencies.rake
@@ -126,7 +126,6 @@ class PluginVersionWorking
   end
 
   def try_plugin(plugin, successful_dependencies)
-    Bundler::DepProxy.__clear!
     builder = Bundler::Dsl.new
     gemfile = LogStash::Gemfile.new(File.new(LogStash::Environment::GEMFILE_PATH, "r+")).load
     gemfile.update(plugin)
@@ -136,6 +135,8 @@ class PluginVersionWorking
     definition.resolve_remotely!
     from = PLUGIN_METADATA.fetch(plugin, {}).fetch("default-plugins", false) ? :default : :missing
     extract_versions(definition, successful_dependencies, from)
+    builder.instance_eval { @sources = [] }
+    builder.instance_eval { @dependencies = [] }
   end
 
   def extract_versions(definition, dependencies, from)
@@ -202,14 +203,6 @@ task :generate_plugins_version do
         Signal.trap(signal) do
           block.call
         end
-      end
-    end
-    DepProxy.class_eval do
-      # Bundler caches it's dep-proxy objects (which contain Gem::Dependency objects) from all resolutions.
-      # The Hash itself continues to grow between dependency resolutions and hold up a lot of memory, to avoid
-      # the issue we expose a way of clear-ing the cached objects before each plugin resolution.
-      def self.__clear!
-        @proxies.clear
       end
     end
 

--- a/spec/unit/bootstrap/bundler_spec.rb
+++ b/spec/unit/bootstrap/bundler_spec.rb
@@ -88,8 +88,8 @@ describe LogStash::Bundler do
 
     context 'abort with an exception' do
       it 'gem conflict' do
-        allow(::Bundler::CLI).to receive(:start).with(bundler_args) { raise ::Bundler::VersionConflict.new('conflict') }
-        expect { subject }.to raise_error(::Bundler::VersionConflict)
+        allow(::Bundler::CLI).to receive(:start).with(bundler_args) { raise ::Bundler::SolveFailure.new('conflict') }
+        expect { subject }.to raise_error(::Bundler::SolveFailure)
       end
 
       it 'gem is not found' do


### PR DESCRIPTION
1. reintroduce bundler 2.4 and remove tweaks for 2.3
2. avoid memory leak during generatePluginsVersion
3. skip logstash-input-cloudwatch to avoid bundler 2.4 struggling with dependency resolution