### PR TITLE
pin murmurhash3 to 0.1.6 until 0.1.7-java is out

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -27,3 +27,4 @@ gem "logstash-devutils", "~> 1", :group => :development
 gem "rack-test", :require => "rack/test", :group => :development
 gem "rspec", "~> 3.5", :group => :development
 gem "webmock", "~> 3", :group => :development
+gem "murmurhash3", "= 0.1.6" # Pins until version 0.1.7-java is released


### PR DESCRIPTION
follow up from https://github.com/elastic/logstash/pull/14856, that only edited the lock file but not the Gemfile.template