### PR TITLE
fix missing method in ruby pipeline

### DIFF
--- a/logstash-core/lib/logstash/pipeline.rb
+++ b/logstash-core/lib/logstash/pipeline.rb
@@ -659,6 +659,13 @@ module LogStash; class Pipeline < BasePipeline
     }
   end
 
+  # This is for backward compatibility of ruby engine. ShutdownWatcherExt.start() requires this method
+  # In java pipeline, the return boolean indicates if PQ is draining
+  # By giving false, log msg works in the same way prior to queue drain log msg improvement #13934
+  def worker_threads_draining?
+    false
+  end
+
   private
 
   def close_plugin_and_ignore(plugin)


### PR DESCRIPTION


## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Fixed ruby engine pipeline crash during shutdown

## What does this PR do?

This PR adds the missing method `worker_threads_draining?` to ruby pipeline which is added in #13934 to java pipeline for log msg improvement.

As ruby engine is deprecated in Logstash 8, this method is added for backward compatibility.

## Why is it important/What is the impact to the user?

Logstash runs in ruby engine and enables `queue.drain` got `NoMethodError` during shutdown. The ruby pipeline crashes.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] test it manually

## How to test this PR locally


 1. logstash.yml
queue.type: persisted
queue.drain: true

 2. run the pipeline with ruby engine `bin/logstash --java-execution false`
```
input { stdin {} }
output {
  tcp {
    host => "localhost"
    port => "3000"
    ssl_enable => false
  }
}
```
 3. no need to start tcp server
 4. send event to stdin, eg "asdf" to accumulate events in PQ
 5. send `SIGINT` to shutdown logstash
 6. Logstash should not show `NoMethodError`

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Fixed: #15010
- Relates https://github.com/elastic/logstash/pull/13934

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
