### PR TITLE
Fix duplicate description for storage_policy in yaml config files

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -287,13 +287,6 @@
 #
 # dead_letter_queue.retain.age: 1d
 
-# If using dead_letter_queue.enable: true, defines the action to take when the dead_letter_queue.max_bytes is reached,
-# could be "drop_newer" or "drop_older".
-# With drop_newer, messages that were inserted most recently are dropped, logging an error line.
-# With drop_older setting, the oldest messages are dropped as new ones are inserted.
-# Default value is "drop_newer".
-# dead_letter_queue.storage_policy: drop_newer
-
 # If using dead_letter_queue.enable: true, the directory path where the data files will be stored.
 # Default is path.data/dead_letter_queue
 #

--- a/config/pipelines.yml
+++ b/config/pipelines.yml
@@ -88,11 +88,9 @@
 #
 #   dead_letter_queue.flush_interval: 5000
 
-#   If using dead_letter_queue.enable: true, defines the action to take when the dead_letter_queue.max_bytes is reached,
-#   could be "drop_newer" or "drop_older".
-#   With drop_newer, messages that were inserted most recently are dropped, logging an error line.
-#   With drop_older setting, the oldest messages are dropped as new ones are inserted.
-#   Default value is "drop_newer".
+#   If using dead_letter_queue.enable: true, controls which entries should be dropped to avoid exceeding the size limit.
+#   Set the value to `drop_newer` (default) to stop accepting new events that would push the DLQ size over the limit.
+#   Set the value to `drop_older` to remove queue pages containing the oldest events to make space for new ones.
 #
 #   dead_letter_queue.storage_policy: drop_newer
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

With PR #13923 was described how the DLQ `storage_policy` behaves. With PR #14261 was introduced a duplication of the description in logstash.yml.

This commit resolves the duplication and keeps the latest description that seems more direct expressive.


## Why is it important/What is the impact to the user?

It rationalize the description of a setting.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~



## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- relates #14261
- relates 13923
