### PR TITLE
Remove obsolete plugin version notice

### DIFF
--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -54,9 +54,6 @@ module LogStash::Config::Mixin
   attr_accessor :config
   attr_accessor :original_params
 
-  PLUGIN_VERSION_1_0_0 = LogStash::Util::PluginVersion.new(1, 0, 0)
-  PLUGIN_VERSION_0_9_0 = LogStash::Util::PluginVersion.new(0, 9, 0)
-
   # This method is called when someone does 'include LogStash::Config'
   def self.included(base)
     # Add the DSL methods to the 'base' given.

--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -257,7 +257,6 @@ module LogStash::Config::Mixin
         end
       end
       subclass.instance_variable_set("@config", subconfig)
-      @@version_notice_given = false
     end # def inherited
 
     def validate(params)

--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -265,43 +265,12 @@ module LogStash::Config::Mixin
       @plugin_type = ancestors.find { |a| a.name =~ /::Base$/ }.config_name
       is_valid = true
 
-      print_version_notice
-
       is_valid &&= validate_check_invalid_parameter_names(params)
       is_valid &&= validate_check_required_parameter_names(params)
       is_valid &&= validate_check_parameter_values(params)
 
       return is_valid
     end # def validate
-
-    # TODO: Remove in 6.0
-    def print_version_notice
-      return if @@version_notice_given
-
-      begin
-        plugin_version = LogStash::Util::PluginVersion.find_plugin_version!(@plugin_type, @config_name)
-
-        if plugin_version < PLUGIN_VERSION_1_0_0
-          if plugin_version < PLUGIN_VERSION_0_9_0
-            self.logger.info(I18n.t("logstash.plugin.version.0-1-x",
-                                :type => @plugin_type,
-                                :name => @config_name,
-                                :LOGSTASH_VERSION => LOGSTASH_VERSION))
-          else
-            self.logger.info(I18n.t("logstash.plugin.version.0-9-x",
-                                :type => @plugin_type,
-                                :name => @config_name,
-                                :LOGSTASH_VERSION => LOGSTASH_VERSION))
-          end
-        end
-      rescue LogStash::PluginNoVersionError
-        # This can happen because of one of the following:
-        # - The plugin is loaded from the plugins.path and contains no gemspec.
-        # - The plugin is defined in a universal plugin, so the loaded plugin doesn't correspond to an actual gemspec.
-      ensure
-        @@version_notice_given = true
-      end
-    end
 
     def validate_check_invalid_parameter_names(params)
       invalid_params = params.keys

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -53,14 +53,6 @@ en:
         %{plugin} plugin is using the 'milestone' method to declare the version
         of the plugin this method is deprecated in favor of declaring the
         version inside the gemspec.
-      version:
-        0-9-x:
-         Using version 0.9.x %{type} plugin '%{name}'. This plugin should work but
-         would benefit from use by folks like you. Please let us know if you
-         find bugs or have suggestions on how to improve this plugin.
-        0-1-x: >-
-         Using version 0.1.x %{type} plugin '%{name}'. This plugin isn't well
-         supported by the community and likely has no maintainer.
     web_api:
       cant_bind_to_port: |-
         Logstash tried to bind to port %{port}, but the port is already in use. You can specify a new port by launching logstash with the --api.http.port option."

--- a/logstash-core/spec/logstash/plugin_spec.rb
+++ b/logstash-core/spec/logstash/plugin_spec.rb
@@ -155,27 +155,9 @@ describe LogStash::Plugin do
       subject.validate({})
     end
 
-    it "doesnt show the version notice more than once" do
-      one_notice = Class.new(LogStash::Filters::Base) do
-        config_name "stromae"
-      end
-
-      allow(Gem::Specification).to receive(:find_by_name)
-        .with(plugin_name)
-        .and_return(double(:version => Gem::Version.new('1.0.1')))
-
-      expect_any_instance_of(LogStash::Logging::Logger).to receive(:info)
-        .once
-        .with(/Using version 1.0.x/)
-
-      one_notice.validate({})
-      one_notice.validate({})
-    end
-
     it "doesn't raise an exception if no version is found" do
       expect { subject.validate({}) }.not_to raise_error
     end
-
 
     it 'logs a warning if the plugin use the milestone option' do
       expect_any_instance_of(LogStash::Logging::Logger).to receive(:debug)

--- a/logstash-core/spec/logstash/plugin_spec.rb
+++ b/logstash-core/spec/logstash/plugin_spec.rb
@@ -155,27 +155,6 @@ describe LogStash::Plugin do
       subject.validate({})
     end
 
-    it 'warns the user if the plugin version is between 0.9.x and 1.0.0' do
-      allow(Gem::Specification).to receive(:find_by_name)
-        .with(plugin_name)
-        .and_return(double(:version => Gem::Version.new('0.9.1')))
-
-      expect_any_instance_of(LogStash::Logging::Logger).to receive(:info)
-        .with(/Using version 0.9.x/)
-
-      subject.validate({})
-    end
-
-    it 'warns the user if the plugin version is inferior to 0.9.x' do
-      allow(Gem::Specification).to receive(:find_by_name)
-        .with(plugin_name)
-        .and_return(double(:version => Gem::Version.new('0.1.1')))
-
-      expect_any_instance_of(LogStash::Logging::Logger).to receive(:info)
-        .with(/Using version 0.1.x/)
-      subject.validate({})
-    end
-
     it "doesnt show the version notice more than once" do
       one_notice = Class.new(LogStash::Filters::Base) do
         config_name "stromae"
@@ -183,11 +162,11 @@ describe LogStash::Plugin do
 
       allow(Gem::Specification).to receive(:find_by_name)
         .with(plugin_name)
-        .and_return(double(:version => Gem::Version.new('0.1.1')))
+        .and_return(double(:version => Gem::Version.new('1.0.1')))
 
       expect_any_instance_of(LogStash::Logging::Logger).to receive(:info)
         .once
-        .with(/Using version 0.1.x/)
+        .with(/Using version 1.0.x/)
 
       one_notice.validate({})
       one_notice.validate({})


### PR DESCRIPTION
## What does this PR do?
Removes obsolete plug-in version notice that conveys a plugin under 1.0.0 is badly or not supported.

Closes #15012