### PR TITLE
Add initial PQ sizing doc

### DIFF
--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -96,7 +96,7 @@ principle, you should consider the following formula to size your Persistent Que
 
 Total Event Size per second = Input EPS * Size of each Event
 Total Received Per Hour = Total Event Size per Second * 3600s
-Tolerated Downtime = (Total Received Per Hour * X hours) * 1.10
+Tolerated Downtime = (Total Received Per Hour * X hours) * Multiplication Factor
 
 -----
 EXAMPLE

--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -100,7 +100,7 @@ Bytes Received Per Second = Incoming Events Per Second * Raw Event Byte Size
 Bytes Received Per Hour = Bytes Received per Second * 3600s
 Required Queue Capacity = (Bytes Received Per Hour * Tolerated Hours of Downtime) * Multiplication Factor <1>
 ------
-<1> To start, you can set the `Multiplication Factor` to `1.10`, but for better accuracy, see below.
+<1> To start, you can set the `Multiplication Factor` to `1.10`, and then refine it for specific data types as indicated in the tables below. 
 
 After Logstash receives an event, and before it is stored in the queue, it gets serialized.
 This process results in added overhead to the event inside Logstash. This overhead depends

--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -113,7 +113,7 @@ These tables show examples of overhead by event type and how that affects the mu
 *Raw string message*
 [cols="<h,<,<m,<m,<m",options="header",]
 |=======================================================================
-| Plaintext size (bytes) | Serialized logstash event size (bytes) | Overhead (bytes) | Overhead (%) | Multiplication Factor
+| Plaintext size (bytes) | Serialized {ls} event size (bytes) | Overhead (bytes) | Overhead (%) | Multiplication Factor
 | 11 | 213 | 202 | 1836% | 19.4
 | 1212 | 1416 | 204 | 17% | 1.17
 | 10240 | 10452 | 212 | 2% | 1.02

--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -104,7 +104,7 @@ Required Queue Capacity = (Bytes Received Per Hour * Tolerated Hours of Downtime
 [[sizing-by-type]]
 ====== Queue size by data type
 
-After Logstash receives an event, and before it is stored in the queue, it gets serialized.
+{ls} serializes the events it receives before they are stored in the queue.
 This process results in added overhead to the event inside Logstash. This overhead depends
 on the type and the size of the `Original Event Size`. As such, the `Multiplication Factor`
 will change depending on your use case. The following tables show a few examples of the

--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -105,10 +105,10 @@ Required Queue Capacity = (Bytes Received Per Hour * Tolerated Hours of Downtime
 ====== Queue size by data type
 
 {ls} serializes the events it receives before they are stored in the queue.
-This process results in added overhead to the event inside Logstash. This overhead depends
-on the type and the size of the `Original Event Size`. As such, the `Multiplication Factor`
-will change depending on your use case. The following tables show a few examples of the
-overhead by the type of event, and the multiplication factor.
+This process results in added overhead to the event inside {ls}. 
+This overhead depends on the type and the size of the `Original Event Size`.
+As such, the `Multiplication Factor` changes depending on your use case. 
+These tables show examples of overhead by event type and how that affects the multiplication factor.
 
 *Raw string message*
 [cols="<h,<,<m,<m,<m",options="header",]

--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -101,6 +101,8 @@ Bytes Received Per Hour = Bytes Received per Second * 3600s
 Required Queue Capacity = (Bytes Received Per Hour * Tolerated Hours of Downtime) * Multiplication Factor <1>
 ------
 <1> To start, you can set the `Multiplication Factor` to `1.10`, and then refine it for specific data types as indicated in the tables below. 
+[[sizing-by-type]]
+====== Queue size by data type
 
 After Logstash receives an event, and before it is stored in the queue, it gets serialized.
 This process results in added overhead to the event inside Logstash. This overhead depends

--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -123,7 +123,7 @@ JSON document
 
 -----
 EXAMPLE
-If Logstash receives 1000 EPS, and each event is 1kb, then Logstash receives about 3.6gb every hour.
+If Logstash receives 1000 EPS, and each event is 1kb (with 1.10 multiplication factor), then Logstash receives about 3.6gb every hour.
 So if Logstash needs to tolerate one of the downstream components being down for 12h, they need a Persistent Queue
 of about 50GB in size.
 -----

--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -108,8 +108,8 @@ on the type and the size of the `Original Event Size`. As such, the `Multiplicat
 will change depending on your use case. The following tables show a few examples of the
 overhead by the type of event, and the multiplication factor.
 
-Raw string message
-[cols="<h,<,<m,<m",options="header",]
+*Raw string message*
+[cols="<h,<,<m,<m,<m",options="header",]
 |=======================================================================
 | Plaintext size (bytes) | Serialized logstash event size (bytes) | Overhead (bytes) | Overhead (%) | Multiplication Factor
 | 11 | 213 | 202 | 1836% | 19.4
@@ -117,8 +117,8 @@ Raw string message
 | 10240 | 10452 | 212 | 2% | 1.02
 |=======================================================================
 
-JSON document
-[cols="<h,<,<m,<m",options="header",]
+*JSON document*
+[cols="<h,<,<m,<m,<m",options="header",]
 |=======================================================================
 | JSON document size (bytes) | Serialized logstash event size (bytes) | Overhead (bytes) | Overhead (%) | Multiplication Factor
 | 947 | 1133 | 186 | 20% | 1.20
@@ -127,8 +127,8 @@ JSON document
 | 58901 | 59693 | 792 | 1% | 1.1
 |=======================================================================
 
+*Example*
 -----
-EXAMPLE
 Let's consider a Logstash instance that receives 1000 EPS and each event is 1KB, or 3.5GB every hour.
 In order to tolerate a downstream component being unavailable for 12h without Logstash exerting back-pressure upstream, the Persistent Queue's `max_bytes` would have to be set to 3.6*12*1.10 = 47.25GB, or about 50GB.
 -----

--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -128,10 +128,10 @@ overhead by the type of event, and the multiplication factor.
 |=======================================================================
 
 *Example*
------
-Let's consider a Logstash instance that receives 1000 EPS and each event is 1KB, or 3.5GB every hour.
-In order to tolerate a downstream component being unavailable for 12h without Logstash exerting back-pressure upstream, the Persistent Queue's `max_bytes` would have to be set to 3.6*12*1.10 = 47.25GB, or about 50GB.
------
+Let's consider a Logstash instance that receives 1000 EPS and each event is 1KB,
+or 3.5GB every hour. In order to tolerate a downstream component being unavailable
+for 12h without Logstash exerting back-pressure upstream, the Persistent Queue's
+`max_bytes` would have to be set to 3.6*12*1.10 = 47.25GB, or about 50GB.
 
 [[pq-lower-max_bytes]]
 ===== Smaller queue size

--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -90,7 +90,21 @@ If both settings are specified, Logstash uses whichever criteria is reached
 first. 
 See <<backpressure-persistent-queue>> for behavior when queue limits are
 reached.
++
+TIP: Calculating the queue size will vary depending on the use-case. As a general guiding
+principle, you should consider the following formula to size your Persistent Queue
 
+Total Event Size per second = Input EPS * Size of each Event
+Total Received Per Hour = Total Event Size per Second * 3600s
+Tolerated Downtime = (Total Received Per Hour * X hours) * 1.10
+
+-----
+EXAMPLE
+For example, if Logstash receives 1000 EPS, and each event is 1kb, then Logstash receives about 3.6gb every hour.
+So if Logstash needs to tolerate one of the downstream components being down for 12h, they need a Persistent Queue
+of about 50GB in size.
+-----
++
 [[pq-lower-max_bytes]]
 ===== Smaller queue size
 If you are using persistent queues to protect against data loss, but don't

--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -122,7 +122,7 @@ These tables show examples of overhead by event type and how that affects the mu
 *JSON document*
 [cols="<h,<,<m,<m,<m",options="header",]
 |=======================================================================
-| JSON document size (bytes) | Serialized logstash event size (bytes) | Overhead (bytes) | Overhead (%) | Multiplication Factor
+| JSON document size (bytes) | Serialized {ls} event size (bytes) | Overhead (bytes) | Overhead (%) | Multiplication Factor
 | 947 | 1133 | 186 | 20% | 1.20
 | 2707 | 3206 | 499 | 18% | 1.18
 | 6751 | 7388 | 637 | 9% | 1.9

--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -130,9 +130,10 @@ These tables show examples of overhead by event type and how that affects the mu
 |=======================================================================
 
 *Example*
-Let's consider a Logstash instance that receives 1000 EPS and each event is 1KB,
+
+Let's consider a {ls} instance that receives 1000 EPS and each event is 1KB,
 or 3.5GB every hour. In order to tolerate a downstream component being unavailable
-for 12h without Logstash exerting back-pressure upstream, the Persistent Queue's
+for 12h without {ls} exerting back-pressure upstream, the persistent queue's
 `max_bytes` would have to be set to 3.6*12*1.10 = 47.25GB, or about 50GB.
 
 [[pq-lower-max_bytes]]

--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -94,11 +94,12 @@ reached.
 Calculating the queue size will vary depending on the use-case. As a general guiding
 principle, you should consider the following formula to size your Persistent Queue.
 
--------
-Total Event Size per second = Input EPS * Original Event Size
-Total Received Per Hour = Total Event Size per Second * 3600s
-Tolerated Downtime = (Total Received Per Hour * Number of hours) * Multiplication Factor <1>
--------
+[source,txt]
+------
+Bytes Received Per Second = Incoming Events Per Second * Raw Event Byte Size
+Bytes Received Per Hour = Bytes Received per Second * 3600s
+Required Queue Capacity = (Bytes Received Per Hour * Tolerated Hours of Downtime) * Multiplication Factor <1>
+------
 <1> To start, you can set the `Multiplication Factor` to `1.10`, but for better accuracy, see below.
 
 After Logstash receives an event, and before it is stored in the queue, it gets serialized.
@@ -108,26 +109,30 @@ will change depending on your use case. The following tables show a few examples
 overhead by the type of event, and the multiplication factor.
 
 Raw string message
-| Plaintext size (bytes) | Serialized logstash event size (bytes) | Overhead (bytes) | Overhead (%) | Multiplication Factor |
-| ---- | ---- | ---- | ---- | ---- |
-| 11 | 213 | 202 | 1836% | 1836 |
-| 1212 | 1416 | 204 | 17% | 1.17 |
+[cols="<h,<,<m,<m",options="header",]
+|=======================================================================
+| Plaintext size (bytes) | Serialized logstash event size (bytes) | Overhead (bytes) | Overhead (%) | Multiplication Factor
+| 11 | 213 | 202 | 1836% | 19.4
+| 1212 | 1416 | 204 | 17% | 1.17
+| 10240 | 10452 | 212 | 2% | 1.02
+|=======================================================================
 
 JSON document
-| JSON document size (bytes) | Serialized logstash event size (bytes) | Overhead (bytes) | Overhead (%) | Multiplication Factor |
-| ---- | ---- | ---- | ---- | ---- |
-| 947 | 1133 | 186 | 20% | 1.20 |
-| 2707 | 3206 | 499 | 18% | 1.18 |
-| 6751 | 7388 | 637 | 9% | 1.9 |
-| 58901 | 59693 | 792 | 1% | 1.1 |
+[cols="<h,<,<m,<m",options="header",]
+|=======================================================================
+| JSON document size (bytes) | Serialized logstash event size (bytes) | Overhead (bytes) | Overhead (%) | Multiplication Factor
+| 947 | 1133 | 186 | 20% | 1.20
+| 2707 | 3206 | 499 | 18% | 1.18
+| 6751 | 7388 | 637 | 9% | 1.9
+| 58901 | 59693 | 792 | 1% | 1.1
+|=======================================================================
 
 -----
 EXAMPLE
-If Logstash receives 1000 EPS, and each event is 1kb (with 1.10 multiplication factor), then Logstash receives about 3.6gb every hour.
-So if Logstash needs to tolerate one of the downstream components being down for 12h, they need a Persistent Queue
-of about 50GB in size.
+Let's consider a Logstash instance that receives 1000 EPS and each event is 1KB, or 3.5GB every hour.
+In order to tolerate a downstream component being unavailable for 12h without Logstash exerting back-pressure upstream, the Persistent Queue's `max_bytes` would have to be set to 3.6*12*1.10 = 47.25GB, or about 50GB.
 -----
-+
+
 [[pq-lower-max_bytes]]
 ===== Smaller queue size
 If you are using persistent queues to protect against data loss, but don't

--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -91,8 +91,8 @@ first.
 See <<backpressure-persistent-queue>> for behavior when queue limits are
 reached.
 
-Calculating the queue size will vary depending on the use-case. As a general guiding
-principle, you should consider the following formula to size your Persistent Queue.
+Appropriate sizing for the queue depends on the use-case. 
+As a general guiding principle, consider this formula to size your persistent queue.
 
 [source,txt]
 ------

--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -90,17 +90,40 @@ If both settings are specified, Logstash uses whichever criteria is reached
 first. 
 See <<backpressure-persistent-queue>> for behavior when queue limits are
 reached.
-+
-TIP: Calculating the queue size will vary depending on the use-case. As a general guiding
-principle, you should consider the following formula to size your Persistent Queue
 
-Total Event Size per second = Input EPS * Size of each Event
+Calculating the queue size will vary depending on the use-case. As a general guiding
+principle, you should consider the following formula to size your Persistent Queue.
+
+-------
+Total Event Size per second = Input EPS * Original Event Size
 Total Received Per Hour = Total Event Size per Second * 3600s
-Tolerated Downtime = (Total Received Per Hour * X hours) * Multiplication Factor
+Tolerated Downtime = (Total Received Per Hour * Number of hours) * Multiplication Factor <1>
+-------
+<1> To start, you can set the `Multiplication Factor` to `1.10`, but for better accuracy, see below.
+
+After Logstash receives an event, and before it is stored in the queue, it gets serialized.
+This process results in added overhead to the event inside Logstash. This overhead depends
+on the type and the size of the `Original Event Size`. As such, the `Multiplication Factor`
+will change depending on your use case. The following tables show a few examples of the
+overhead by the type of event, and the multiplication factor.
+
+Raw string message
+| Plaintext size (bytes) | Serialized logstash event size (bytes) | Overhead (bytes) | Overhead (%) | Multiplication Factor |
+| ---- | ---- | ---- | ---- | ---- |
+| 11 | 213 | 202 | 1836% | 1836 |
+| 1212 | 1416 | 204 | 17% | 1.17 |
+
+JSON document
+| JSON document size (bytes) | Serialized logstash event size (bytes) | Overhead (bytes) | Overhead (%) | Multiplication Factor |
+| ---- | ---- | ---- | ---- | ---- |
+| 947 | 1133 | 186 | 20% | 1.20 |
+| 2707 | 3206 | 499 | 18% | 1.18 |
+| 6751 | 7388 | 637 | 9% | 1.9 |
+| 58901 | 59693 | 792 | 1% | 1.1 |
 
 -----
 EXAMPLE
-For example, if Logstash receives 1000 EPS, and each event is 1kb, then Logstash receives about 3.6gb every hour.
+If Logstash receives 1000 EPS, and each event is 1kb, then Logstash receives about 3.6gb every hour.
 So if Logstash needs to tolerate one of the downstream components being down for 12h, they need a Persistent Queue
 of about 50GB in size.
 -----


### PR DESCRIPTION
## What does this PR do?
Adds documentation with general guidance in sizing a Persistent Queue.

## Why is it important/What is the impact to the user?

Users don't have a general mechanism to guide them on how to size their persistent queues. Providing one will allow them to better size and serve their use cases.

Closes #14871