### PR TITLE
fix: keep nano-precise timestamps in Java Event APIs

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -35,6 +35,7 @@ import org.logstash.plugins.BasicEventFactory;
 import java.io.IOException;
 import java.io.Serializable;
 import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -163,15 +164,15 @@ public final class Event implements Cloneable, Queueable, co.elastic.logstash.ap
     public Instant getEventTimestamp() {
         Timestamp t = getTimestamp();
         return (t != null)
-                ? Instant.ofEpochMilli(t.toEpochMilli())
+                ? t.toInstant()
                 : null;
     }
 
     @Override
-    public void setEventTimestamp(Instant timestamp) {
+    public void setEventTimestamp(final Instant timestamp) {
         setTimestamp(timestamp != null
-                ? new Timestamp(timestamp.toEpochMilli())
-                : new Timestamp(Instant.now().toEpochMilli()));
+                ? new Timestamp(timestamp)
+                : new Timestamp(Instant.now()));
     }
 
     public Timestamp getTimestamp() {
@@ -462,6 +463,10 @@ public final class Event implements Cloneable, Queueable, co.elastic.logstash.ap
                 return ((JrubyTimestampExtLibrary.RubyTimestamp) o).getTimestamp();
             } else if (o instanceof Timestamp) {
                 return (Timestamp) o;
+            } else if (o instanceof Instant) {
+                return new Timestamp((Instant) o);
+            } else if (o instanceof ZonedDateTime) {
+                return new Timestamp(((ZonedDateTime) o).toInstant());
             } else if (o instanceof DateTime) {
                 return new Timestamp((DateTime) o);
             } else if (o instanceof Date) {


### PR DESCRIPTION
## Release notes

Improves the Java Event API's `Event#getEventTimestamp()` and `Event#setEventTimestamp(Instant)` to retain the available precision.

## What does this PR do?

 - uses `Instant` directly to keep its nano-precision instead of routing through `Instant#toEpochMilli` which limits us to milli-precision
 - adds tests for observed behaviour
 - improves the Event constructor's ability to deal with modern `java.time` inputs in the `@timestamp` field (mirroring what was previously done with joda time)

## Why is it important/What is the impact to the user?

 - When plugins use the Java Event API, `Event#getEventTimestamp` should be just-as-precise as otherwise available using `Event#getField`:
   ~~~ java
   Optional.ofNullable(event.getField("@timestamp"))
       .map(Timestamp#toInstant)
       .orElse(null)
   ~~~
 - When plugins use the Java Event API, `Event#setEventTimestamp(Instant)` should retain the full precision of the provided `Instant`, as can also be done with `Event#setField(Timestamp)`:
   ~~~ java
   event.setField("@timestamp", new Timestamp(instant));
   ~~~

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

 - #12797
