### PR TITLE
fix plugin management when elastic.co is firewalled

### DIFF
--- a/lib/pluginmanager/pack_fetch_strategy/repository.rb
+++ b/lib/pluginmanager/pack_fetch_strategy/repository.rb
@@ -58,6 +58,14 @@ module LogStash module PluginManager module PackFetchStrategy
         PluginManager.ui.debug("Network error, skipping Elastic pack, exception: #{e}")
 
         return nil
+      rescue Net::OpenTimeout => e
+        PluginManager.ui.debug('Network timeout, skipping Elastic pack.')
+
+        return nil
+      rescue StandardError => e
+        PluginManager.ui.debug("Unknown error, skipping Elastic pack, exception: #{e}")
+
+        return nil
       end
     end
   end

--- a/lib/pluginmanager/utils/http_client.rb
+++ b/lib/pluginmanager/utils/http_client.rb
@@ -27,15 +27,10 @@ module LogStash module PluginManager module Utils
       proxy_url = ENV["https_proxy"] || ENV["HTTPS_PROXY"] || ""
       proxy_uri = URI(proxy_url)
 
-      Net::HTTP.start(uri.host, uri.port, proxy_uri.host, proxy_uri.port, proxy_uri.user, proxy_uri.password, http_options(uri)) { |http| yield http }
-    end
-
-    def self.http_options(uri)
-      ssl_enabled = uri.scheme == HTTPS_SCHEME
-
-      {
-        :use_ssl => ssl_enabled
-      }
+      http = Net::HTTP.new(uri.host, uri.port, proxy_uri.host, proxy_uri.port, proxy_uri.user, proxy_uri.password)
+      http.use_ssl(uri.scheme == HTTPS_SCHEME)
+      http.open_timeout(10)
+      http.start { |h| yield h }
     end
 
     # Do a HEAD request on the file to see if it exist before downloading it


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
-->

## Release notes
fix plugin management from remote repositories when elastic.co is firewalled

## What does this PR do?

Return nil instead of throwing an exception when Net::OpenTimeout or other issues occur in the `repository` pack fetch strategy.
Reduce the open timeout of Net::HTTP clients created by `pluginmanager/utils/http_client.rb` from the default of 60 seconds to 10 seconds.

## Why is it important/What is the impact to the user?

Without this change and elastic.co is firewalled but the ruby gems source specified in `$LOGSTASH_HOME/Gemfile` is available, plugin installation fails. Additionally, If the firewall method in use causes open timeouts, it takes over a minute to fail.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] I have added tests that prove my fix is effective or that my feature works


## How to test this PR locally

Firewall elastic.co but not rubygems.org and try to install a plugin. Do this without the patch and it'll take over a minute and then fail with `ERROR: Something went wrong when installing logstash-input-log4j, message: Net::OpenTimeout`. With the patch it will succeed in a reasonable amount of time.