### PR TITLE
[Docs] Add instructions to verify Docker install images

### DIFF
--- a/docs/static/docker.asciidoc
+++ b/docs/static/docker.asciidoc
@@ -46,7 +46,7 @@ Although it's optional, we highly recommend verifying the signatures included wi
 Elastic images are signed with https://docs.sigstore.dev/cosign/overview/[Cosign] which is part of the https://www.sigstore.dev/[Sigstore] project. Cosign supports container signing, verification, and storage in an OCI registry. Install the appropriate https://docs.sigstore.dev/cosign/installation/[Cosign application]
 for your operating system.
 
-Run the following commands to verify the *elastic-agent* container image signature for {ls} v{version}:
+Run the following commands to verify the container image signature for {ls} v{version}:
 
 ifeval::["{release-state}"=="unreleased"]
 

--- a/docs/static/docker.asciidoc
+++ b/docs/static/docker.asciidoc
@@ -39,6 +39,53 @@ https://www.docker.elastic.co[www.docker.elastic.co].
 
 endif::[]
 
+==== Verifying the image
+
+Although it's optional, we highly recommend verifying the signatures included with your downloaded Docker images to ensure that the images are valid.
+
+Elastic images are signed with https://docs.sigstore.dev/cosign/overview/[Cosign] which is part of the https://www.sigstore.dev/[Sigstore] project. Cosign supports container signing, verification, and storage in an OCI registry. Install the appropriate https://docs.sigstore.dev/cosign/installation/[Cosign application]
+for your operating system.
+
+Run the following commands to verify the *elastic-agent* container image signature for {ls} v{version}:
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {logstash_version} of Logstash has not yet been
+released, so no Docker image is currently available for this version.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+--------------------------------------------
+wget https://artifacts.elastic.co/cosign.pub <1>
+cosign verify --key cosign.pub {docker-image} <2>
+--------------------------------------------
+<1> Download the Elastic public key to verify container signature
+<2> Verify the container against the Elastic public key
+
+The command prints the check results and the signature payload in JSON format, for example:
+
+["source","sh",subs="attributes"]
+--------------------------------------------
+Verification for {docker-image} --
+The following checks were performed on each of these signatures:
+  - The cosign claims were validated
+  - Existence of the claims in the transparency log was verified offline
+  - The signatures were verified against the specified public key
+--------------------------------------------
+
+endif::[]
+
+
+
+
+
+
+
+
+
 [[docker-config]]
 === Configuring Logstash for Docker
 

--- a/docs/static/docker.asciidoc
+++ b/docs/static/docker.asciidoc
@@ -78,14 +78,6 @@ The following checks were performed on each of these signatures:
 
 endif::[]
 
-
-
-
-
-
-
-
-
 [[docker-config]]
 === Configuring Logstash for Docker
 


### PR DESCRIPTION
This updates the [Running Logstash on Docker](https://www.elastic.co/guide/en/logstash/8.7/docker.html) page to add steps to verify the Docker image.

Rel: https://github.com/elastic/dev/issues/2002

Preview

---
![Screenshot 2023-05-23 at 4 19 07 PM](https://github.com/elastic/logstash/assets/41695641/e6a0dbe9-a95e-434b-853a-c425ef4257b5)

