### PR TITLE
Remove custom bundler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -290,18 +290,8 @@ def assemblyDeps = [downloadAndInstallJRuby, assemble] + subprojects.collect {
   it.tasks.findByName("assemble")
 }
 
-def bundlerVersion = "~> 2"
-
-tasks.register("installBundler") {
-    dependsOn assemblyDeps
-    outputs.files file("${projectDir}/vendor/bundle/jruby/3.1.0/bin/bundle")
-    doLast {
-      gem(projectDir, buildDir, "bundler", bundlerVersion, "${projectDir}/vendor/bundle/jruby/3.1.0")
-  }
-}
-
 tasks.register("bootstrap") {
-    dependsOn installBundler
+    dependsOn assemblyDeps
     doLast {
       setupJruby(projectDir, buildDir)
   }
@@ -417,19 +407,9 @@ tasks.register("unpackTarDistribution", Copy) {
 
 def qaBuildPath = "${buildDir}/qa/integration"
 def qaVendorPath = "${qaBuildPath}/vendor"
-def qaBundledGemPath = "${qaVendorPath}/jruby/3.1.0".toString()
-def qaBundleBin = "${qaBundledGemPath}/bin/bundle"
-
-tasks.register("installIntegrationTestBundler"){
-    dependsOn unpackTarDistribution
-    outputs.files file("${qaBundleBin}")
-  doLast {
-      gem(projectDir, buildDir, "bundler", bundlerVersion, qaBundledGemPath)
-  }
-}
 
 tasks.register("installIntegrationTestGems") {
-  dependsOn installIntegrationTestBundler
+  dependsOn unpackTarDistribution
   def gemfilePath = file("${projectDir}/qa/integration/Gemfile")
   inputs.files gemfilePath
   inputs.files file("${projectDir}/qa/integration/integration_tests.gemspec")
@@ -439,11 +419,7 @@ tasks.register("installIntegrationTestGems") {
   outputs.files fileTree("${qaVendorPath}")
   outputs.files file("${projectDir}/qa/integration/Gemfile.lock")
   doLast {
-      bundleWithEnv(
-        projectDir, buildDir,
-        qaBuildPath, qaBundleBin, ['install', '--path', qaVendorPath, '--gemfile', gemfilePath],
-        [ GEM_PATH: qaBundledGemPath, GEM_HOME: qaBundledGemPath ]
-      )
+      bundleQAGems(projectDir, qaBuildPath)
   }
 }
 

--- a/lib/bootstrap/bundler.rb
+++ b/lib/bootstrap/bundler.rb
@@ -163,7 +163,7 @@ module LogStash
           begin
             execute_bundler(options)
             break
-          rescue ::Bundler::SolveFailure => e
+          rescue ::Bundler::VersionConflict => e
             $stderr.puts("Plugin version conflict, aborting")
             raise(e)
           rescue ::Bundler::GemNotFound => e

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -99,11 +99,6 @@ namespace "artifact" do
     @exclude_paths << 'vendor/**/gems/**/Gemfile.lock'
     @exclude_paths << 'vendor/**/gems/**/Gemfile'
 
-    # jruby's bundler artifacts
-    @exclude_paths << 'vendor/jruby/bin/bundle*'
-    @exclude_paths << 'vendor/jruby/lib/ruby/stdlib/bundler*'
-    @exclude_paths << 'vendor/jruby/lib/ruby/gems/shared/specifications/default/bundler-*.gemspec'
-    @exclude_paths << 'vendor/jruby/lib/ruby/gems/shared/gems/bundler-*'
     @exclude_paths << 'vendor/jruby/lib/ruby/gems/shared/gems/rake-*'
 
     @exclude_paths

--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -46,6 +46,7 @@ import java.nio.file.Paths
 ext {
     bundle = this.&bundle
     bundleWithEnv = this.&bundleWithEnv
+    bundleQAGems = this.&bundleQAGems
     gem = this.&gem
     buildGem = this.&buildGem
     rake = this.&rake
@@ -84,6 +85,22 @@ void bundleWithEnv(File projectDir, File buildDir, String pwd, String bundleBin,
         jruby.currentDirectory = pwd
         jruby.argv = args.toList().toArray()
         jruby.runScriptlet(PathType.ABSOLUTE, bundleBin)
+    }
+}
+
+void bundleQAGems(File projectDir, String qaBuildPath) {
+    def jruby = new ScriptingContainer()
+    jruby.setLoadPaths(["${projectDir}/vendor/jruby/lib/ruby/stdlib".toString()])
+    try {
+        jruby.currentDirectory = qaBuildPath
+        jruby.runScriptlet("""
+                require "bundler"
+                require "bundler/cli"
+                Bundler::CLI.start(['install', '--path', "${qaBuildPath}/vendor", '--gemfile', "${projectDir}/qa/integration/Gemfile"])
+                """)
+    } finally {
+        jruby.terminate()
+        Ruby.clearGlobalRuntime()
     }
 }
 
@@ -169,7 +186,7 @@ Object executeJruby(File projectDir, File buildDir, Closure<?> /* Object*/ block
     def jruby = new ScriptingContainer()
     def env = jruby.environment
     def gemDir = "${projectDir}/vendor/bundle/jruby/3.1.0".toString()
-    jruby.setLoadPaths(["${projectDir}/vendor/bundle/jruby/3.1.0/gems/bundler-2.4.14/lib".toString(), "${projectDir}/vendor/jruby/lib/ruby/stdlib".toString()])
+    jruby.setLoadPaths(["${projectDir}/vendor/jruby/lib/ruby/stdlib".toString()])
     env.put "USE_RUBY", "1"
     env.put "GEM_HOME", gemDir
     env.put "GEM_SPEC_CACHE", "${buildDir}/cache".toString()

--- a/spec/unit/bootstrap/bundler_spec.rb
+++ b/spec/unit/bootstrap/bundler_spec.rb
@@ -88,8 +88,8 @@ describe LogStash::Bundler do
 
     context 'abort with an exception' do
       it 'gem conflict' do
-        allow(::Bundler::CLI).to receive(:start).with(bundler_args) { raise ::Bundler::SolveFailure.new('conflict') }
-        expect { subject }.to raise_error(::Bundler::SolveFailure)
+        allow(::Bundler::CLI).to receive(:start).with(bundler_args) { raise ::Bundler::VersionConflict.new('conflict') }
+        expect { subject }.to raise_error(::Bundler::VersionConflict)
       end
 
       it 'gem is not found' do


### PR DESCRIPTION
Instead of relying on external bundler because JRuby flutuated between including and not including bundler for a while, now that bundler is part of rubygems, unless there's a CVE afecting the shipped version of bundler there's no need to have a custom one any more.
This simplifies our code and bootstrapping tasks, so this PR removes the need to install bundler during bootstrap.

As side effect this PR reintroduces the older patches to not go OOM during plugin docs generation.

TODO: find a way to not require installing bundler for the QA tests. We can deal with that in a follow up PR