### PR TITLE
[Doc] Add monitoring/management SSL regression note on release 8.8.0

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -120,6 +120,42 @@ This section summarizes the changes in the following releases:
 [[logstash-8-8-0]]
 === Logstash 8.8.0 Release Notes
 
+[[known-issues-8.8.0]]
+==== Known issues
+
+Due to a recent change in the `logstash-output-elasticserach` plugin,
+this and any other version of Logstash using the Elasticsearch output plugin version `>= 11.14.0` and `< 11.15.8`,
+may fail to start due to a monitoring and central management SSL/TLS settings regression.
+When impacted by this issue, Logstash fails to start and log an error similar to the following:
+```
+[logstash.licensechecker.licensereader] Failed to perform request {:message=>"PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target", :exception=>Manticore::ClientProtocolException, :cause=>#<Java::JavaxNetSsl::SSLHandshakeException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target>}
+```
+
+**Resolution**
+
+A successful Elasticsearch output plugin update to version `11.15.8` or higher will
+resolve this issue:
+
+```
+bin/logstash-plugin update logstash-output-elasticsearch
+```
+
+OR
+
+Specify the `ca_trusted_fingerprint` setting in the `logstash.yml`.
+The certificate fingerprint can be extract with:
+
+```
+cat your_ca.cert | openssl x509 -outform der | sha256sum | awk '{print $1}'
+```
+
+Then set the following on `logstash.yml` using the output from the previous command:
+
+```
+xpack.monitoring.elasticsearch.ssl.ca_trusted_fingerprint: "<value>"
+xpack.management.elasticsearch.ssl.ca_trusted_fingerprint: "<value>"
+```
+
 [[notable-8.8.0]]
 ==== Notable issues fixed
 

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -123,10 +123,10 @@ This section summarizes the changes in the following releases:
 [[known-issues-8.8.0]]
 ==== Known issues
 
-Due to a recent change in the `logstash-output-elasticserach` plugin,
-this and any other version of Logstash using the Elasticsearch output plugin version `>= 11.14.0` and `< 11.15.8`,
-may fail to start due to a monitoring and central management SSL/TLS settings regression.
-When impacted by this issue, Logstash fails to start and log an error similar to the following:
+Logstash 8.8.0 may fail to start when SSL/TLS is enabled
+in monitoring and/or central management, due to a change introduced in version 11.14.0 of the https://github.com/logstash-plugins/logstash-output-elasticsearch[logstash-output-elasticsearch] plugin. 
+When impacted by this issue, Logstash fails to start and logs an error similar to the following:
+
 ```
 [logstash.licensechecker.licensereader] Failed to perform request {:message=>"PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target", :exception=>Manticore::ClientProtocolException, :cause=>#<Java::JavaxNetSsl::SSLHandshakeException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target>}
 ```


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

Add a release note explaining the monitoring/management xpack SSL regression fixed by: https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1142 

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works


