### PR TITLE
Document event.remove API

### DIFF
--- a/docs/static/event-api.asciidoc
+++ b/docs/static/event-api.asciidoc
@@ -101,6 +101,28 @@ event.set("[foo][bar]", h)
 event.set("[foo][bar][c]", [3, 4]) 
 --------------------------------------------------
 
+**Remove API**
+
+This API can be used to remove a field in an Event.
+
+**Syntax:** `event.remove(field)`
+
+**Returns:** Value for this field or nil if the field does not exist. Returned values could be a string, 
+numeric or timestamp scalar value.
+
+`field` is a structured field sent to Logstash or created after the transformation process. `field` can also 
+be a nested <<field-references-deepdive,field reference>> such as `[field][bar]`.
+
+Examples:
+
+[source,ruby]
+--------------------------------------------------
+event.remove("foo" ) # => "baz"
+event.remove("[foo]") # => "zab"
+event.remove("[foo][bar]") # => 1
+event.remove("[inexistent][field]") # => nil
+--------------------------------------------------
+
 [float]
 ==== Ruby Filter
 


### PR DESCRIPTION
- we document `event.get` and `event.set` but were missing `event.remove`, this PR adds this to the event API documentation

## Why is it important/What is the impact to the user?

`event.remove` allows to remove a field with `ruby` filter plugin

## Author's Checklist

- I used this pipeline to verify returned values is same as `event.get` : 
```
input
{
 heartbeat
  {
 id => "hb1" 
 message => '{"foo":12, "fields" : { "app" : "my_app", "image": "my_image" } }'
 interval => 10 }
}
filter {
    json {
        id => "json1"
        source => "message"
      }
    ruby {
    id => "ruby1"
    code => '
        result = event.remove("foo") #returns 12
        event.set("console_remove_foo", result)
        result = event.remove("[inexistent][field]") #returns nil
        event.set("console_remove_inexistent_field", result)
        result = event.remove("[fields][image]") #returns "my_image"
        event.set("console_remove_fields_image", result)
    '
    }

    mutate {
    id => "mutate1"
    remove_field => [ "message" , "host" , "@timestamp", "@version"]
    }
}
output
{
 stdout {
 id => "stdout1" 
 }
}
```

The output (latest `8.8.1`) is : 
```
{
    "console_remove_inexistent_field" => nil,
                 "console_remove_foo" => 12,
        "console_remove_fields_image" => "my_image",
                             "fields" => {
        "app" => "my_app"
    }
}
```