### PR TITLE
placeholder for serverless test in buildkite

### DIFF
--- a/.buildkite/serverless_pipeline.yml
+++ b/.buildkite/serverless_pipeline.yml
@@ -1,0 +1,8 @@
+agents:
+  provider: "gcp"
+  machineType: "n1-standard-16"
+  image: family/elasticsearch-ubuntu-2022
+
+steps:
+  - label: "Dummy E2E Test pipeline"
+    command: echo "Hello!"

--- a/.buildkite/serverless_pipeline.yml
+++ b/.buildkite/serverless_pipeline.yml
@@ -1,7 +1,3 @@
-agents:
-  provider: "gcp"
-  machineType: "n1-standard-16"
-  image: family/elasticsearch-ubuntu-2022
 
 steps:
   - label: "Dummy E2E Test pipeline"


### PR DESCRIPTION
Create a placeholder for serverless test in buildkite

https://github.com/elastic/ci/pull/2081 PR to create serverless pipeline is merged in CI repo. Buildkite is expecting `serverless_pipeline.yml`. This commit fixes the red CI due to missing the yml file.

Relates: #https://github.com/elastic/ingest-dev/issues/2158
