### PR TITLE
Snyk scans Logstash container vulnerabilities.

### DIFF
--- a/.buildkite/scripts/snyk/report.sh
+++ b/.buildkite/scripts/snyk/report.sh
@@ -54,7 +54,7 @@ report() {
   echo "Reporting to Snyk..."
   cd logstash
   REMOTE_REPO_URL=$1
-  if [ "$REMOTE_REPO_URL" != "$MAIN_BRANCH" ]; then
+  if [ "$REMOTE_REPO_URL" != "main" ]; then
     MAJOR_VERSION=$(echo "$REMOTE_REPO_URL"| cut -d'.' -f 1)
     REMOTE_REPO_URL="$MAJOR_VERSION".latest
     echo "Using '$REMOTE_REPO_URL' remote repo url."

--- a/.buildkite/scripts/snyk/report.sh
+++ b/.buildkite/scripts/snyk/report.sh
@@ -62,7 +62,7 @@ report() {
 
   # adding git commit hash to Snyk tag to improve visibility
   GIT_HEAD=$(git rev-parse --short HEAD 2> /dev/null)
-  ./snyk monitor --all-projects --org=logstash --remote-repo-url="$REMOTE_REPO_URL" --target-reference="$REMOTE_REPO_URL" --detection-depth=6 --exclude=requirements.txt --project-tags=branch="$TARGET_BRANCH",git_head="$GIT_HEAD" && true
+  ./snyk monitor --all-projects --org=logstash --remote-repo-url="$REMOTE_REPO_URL" --target-reference="$REMOTE_REPO_URL" --detection-depth=6 --exclude=qa,tools,devtools,requirements.txt --project-tags=branch="$TARGET_BRANCH",git_head="$GIT_HEAD" && true
   cd ..
 }
 

--- a/.buildkite/scripts/snyk/report.sh
+++ b/.buildkite/scripts/snyk/report.sh
@@ -128,18 +128,8 @@ resolve_version_and_report_docker_images() {
 
   # parse version (ex: 8.8.2 from 8.8 branch, or 8.9.0 from main branch)
   versions_file="$PWD/versions.yml"
-  while IFS= read -r line
-  do
-    if [[ $line =~ ^logstash:.* ]]; then
-      line_split_parts=("${line//logstash:/}")
-      version=$(echo "${line_split_parts[0]}" | xargs)
-
-      if [[ $version != null ]]; then
-        report_docker_images "$version"
-        break
-      fi
-    fi
-  done < "$versions_file"
+  version=$(awk '/logstash:/ { print $2 }' "$versions_file")
+  report_docker_images "$version"
   cd ..
 }
 

--- a/.buildkite/scripts/snyk/resolve_stack_version.sh
+++ b/.buildkite/scripts/snyk/resolve_stack_version.sh
@@ -10,16 +10,10 @@ VERSION_URL="https://raw.githubusercontent.com/elastic/logstash/main/ci/logstash
 
 echo "Fetching versions from $VERSION_URL"
 VERSIONS=$(curl --silent $VERSION_URL)
-SNAPSHOTS=$(echo $VERSIONS | jq '.snapshots' | jq 'keys | .[]')
-IFS=$'\n' read -d "\034" -r -a SNAPSHOT_KEYS <<<"${SNAPSHOTS}\034"
+SNAPSHOT_KEYS=$(echo "$VERSIONS" | jq -r '.snapshots | .[]')
 
 SNAPSHOT_VERSIONS=()
-for KEY in "${SNAPSHOT_KEYS[@]}"
-do
-  # remove starting and trailing double quotes
-  KEY="${KEY%\"}"
-  KEY="${KEY#\"}"
-  SNAPSHOT_VERSION=$(echo $VERSIONS | jq '.snapshots."'"$KEY"'"')
-  echo "Resolved snapshot version: $SNAPSHOT_VERSION"
-  SNAPSHOT_VERSIONS+=("$SNAPSHOT_VERSION")
-done
+while IFS= read -r line; do
+  SNAPSHOT_VERSIONS+=("$line")
+  echo "Resolved snapshot version: $line"
+done <<< "$SNAPSHOT_KEYS"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -48,3 +48,40 @@ spec:
           branch: core_serverless_test
           cronline: "@daily"
           message: "Run the serverless integration test every day."
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: logstash-snyk-report
+  description: 'The logstash-snyk-report pipeline.'
+spec:
+  type: buildkite-pipeline
+  owner: group:ingest-fp
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: logstash-snyk-report-ci
+      description: ':logstash: The logstash-snyk-report :pipeline:'
+    spec:
+      repository: elastic/logstash
+      pipeline_file: ".buildkite/snyk_report_pipeline.yml"
+      provider_settings:
+        trigger_mode: none # don't trigger jobs
+      env:
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
+        SLACK_NOTIFICATIONS_CHANNEL: '#logstash-build'
+        SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
+      teams:
+        ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+      schedules:
+        Daily Snyk scan:
+          branch: main
+          cronline: "@daily"
+          message: "Run the Logstash Snyk report every day."


### PR DESCRIPTION
## Description
This change mainly focuses on two things:
- utilizes Snyk CLI to scan and report docker container vulnerabilities;
  - docker images are pulled from https://www.docker.elastic.co/r/logstash. Sometimes the process may fail due to image miss. It happens when DRA didn't run but release planned with new branch.
- simplifies the script. Some part of simplification is suggested by https://github.com/elastic/logstash/pull/15098 and this swallows the suggested PR to test and edits.

- Closes #15165