### PR TITLE
Remove license header from settings.xml template

### DIFF
--- a/lib/pluginmanager/settings.xml.erb
+++ b/lib/pluginmanager/settings.xml.erb
@@ -1,20 +1,3 @@
-# Licensed to Elasticsearch B.V. under one or more contributor
-# license agreements. See the NOTICE file distributed with
-# this work for additional information regarding copyright
-# ownership. Elasticsearch B.V. licenses this file to you under
-# the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#  http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0


### PR DESCRIPTION
When using a proxy with the plugin manager, this template is written to `~/.m2/settings.xml`. The license header is also copied, which generates invalid XML which maven cannot parse.

Fixes: https://github.com/elastic/logstash/issues/15130