### PR TITLE
Update rubyUtils.gradle to use bundler 2.4.15

### DIFF
--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -169,7 +169,7 @@ Object executeJruby(File projectDir, File buildDir, Closure<?> /* Object*/ block
     def jruby = new ScriptingContainer()
     def env = jruby.environment
     def gemDir = "${projectDir}/vendor/bundle/jruby/2.6.0".toString()
-    jruby.setLoadPaths(["${projectDir}/vendor/bundle/jruby/2.6.0/gems/bundler-2.4.14/lib".toString(), "${projectDir}/vendor/jruby/lib/ruby/stdlib".toString()])
+    jruby.setLoadPaths(["${projectDir}/vendor/bundle/jruby/2.6.0/gems/bundler-2.4.15/lib".toString(), "${projectDir}/vendor/jruby/lib/ruby/stdlib".toString()])
     env.put "USE_RUBY", "1"
     env.put "GEM_HOME", gemDir
     env.put "GEM_SPEC_CACHE", "${buildDir}/cache".toString()


### PR DESCRIPTION
This will no longer be necessary in main (8.10) since it relies on the bundler from jruby.