### PR TITLE
Update puma to version 6.3

### DIFF
--- a/logstash-core/lib/logstash/webserver.rb
+++ b/logstash-core/lib/logstash/webserver.rb
@@ -195,10 +195,7 @@ module LogStash
     private
 
     def _init_server
-      io_wrapped_logger = LogStash::IOWrappedLogger.new(logger)
-      events = LogStash::NonCrashingPumaEvents.new(io_wrapped_logger, io_wrapped_logger)
-
-      ::Puma::Server.new(@app, events)
+      ::Puma::Server.new(@app, nil, log_writer: LogStash::DelegatingLogWriter.new(logger))
     end
 
     def create_server_thread
@@ -232,7 +229,7 @@ module LogStash
             'keystore' => @ssl_params.fetch(:keystore_path),
             'keystore-pass' => @ssl_params.fetch(:keystore_password).value
         }
-        ssl_context = Puma::MiniSSL::ContextBuilder.new(unwrapped_ssl_params, @server.events).context
+        ssl_context = Puma::MiniSSL::ContextBuilder.new(unwrapped_ssl_params, @server.log_writer).context
         @server.add_ssl_listener(http_host, candidate_port, ssl_context)
       else
         @server.add_tcp_listener(http_host, candidate_port)

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "concurrent-ruby", "~> 1", "< 1.1.10" # pinned until https://github.com/elastic/logstash/issues/13956
   gem.add_runtime_dependency "rack", '~> 2'
   gem.add_runtime_dependency "sinatra", '~> 2'
-  gem.add_runtime_dependency 'puma', '~> 5', '>= 5.6.2'
+  gem.add_runtime_dependency 'puma', '~> 6.3', '>= 6.0.0'
   gem.add_runtime_dependency "jruby-openssl", "~> 0.11"
 
   gem.add_runtime_dependency "treetop", "~> 1" #(MIT license)

--- a/logstash-core/spec/logstash/patches/puma_spec.rb
+++ b/logstash-core/spec/logstash/patches/puma_spec.rb
@@ -1,0 +1,114 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+require "spec_helper"
+
+describe LogStash::DelegatingLogWriter do
+  let(:logger) { double("Logger") }
+  let(:text) { 'foo bar'}
+  let(:req) { { status: 200 } }
+  let(:error) do
+    Class.new(StandardError) do
+      def self.backtrace
+        %w[foo.rb bar.rb]
+      end
+    end
+  end
+
+  subject { LogStash::DelegatingLogWriter.new(logger) }
+
+  before(:each) do
+    allow(logger).to receive(:debug?).and_return(true)
+  end
+
+  context "#log" do
+    it "should log a :debug message" do
+      expect(logger).to receive(:debug).with(text)
+      subject.send(:log, text)
+    end
+  end
+
+  context "#write" do
+    it "should log a raw :debug message" do
+      expect(logger).to receive(:debug).with(1)
+      subject.send(:write, 1)
+    end
+  end
+
+  context "#debug" do
+    it "should log a :debug message" do
+      expect(logger).to receive(:debug).with(text)
+      subject.send(:debug, text)
+    end
+  end
+
+  context "#error" do
+    it "should log an :error message and raise LogStash::UnrecoverablePumaError" do
+      expect(logger).to receive(:error).with(text)
+      expect{ subject.send(:error, text) }.to raise_error(LogStash::UnrecoverablePumaError, text)
+    end
+  end
+
+  context "#connection_error" do
+    it "should log a :debug message" do
+      expect(logger).to receive(:debug).with(text, { error: error, req: req, backtrace: error.backtrace })
+      subject.send(:connection_error, error, req, text)
+    end
+  end
+
+  context "#parse_error" do
+    it "should log a :debug message" do
+      expect(logger).to receive(:debug).with(anything, { error: error, req: req })
+      subject.send(:parse_error, error, req)
+    end
+  end
+
+  context "#ssl_error" do
+    it "should log a :debug message with the peer certificate details" do
+      socket = double("Socket")
+      peercert = double("Peercert")
+
+      allow(socket).to receive(:peeraddr).and_return(%w[first second last])
+      allow(peercert).to receive(:subject).and_return("logstash")
+      allow(socket).to receive(:peercert).and_return(peercert)
+
+      expect(logger).to receive(:debug).with('SSL error, peer: last, peer cert: logstash', { error: error })
+      subject.send(:ssl_error, error, socket)
+    end
+  end
+
+  context "#unknown_error" do
+    it "should log an :error message" do
+      expect(logger).to receive(:error).with(text, { error: error, req: req, backtrace: error.backtrace })
+      subject.send(:unknown_error, error, req, text)
+    end
+
+    context 'when debug log level is disabled' do
+      it "should not include the :backtrace field on the :error log message" do
+        allow(logger).to receive(:debug?).and_return(false)
+        expect(logger).to receive(:error).with(text, { error: error, req: req })
+        subject.send(:unknown_error, error, req, text)
+      end
+    end
+  end
+
+  context "#debug_error" do
+    it "should log a :debug message" do
+      expect(logger).to receive(:debug).with(text, { error: error, req: req, backtrace: error.backtrace })
+      subject.send(:debug_error, error, req, text)
+    end
+  end
+end


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Updated the puma gem from version 5 to the latest version 6.3.

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

This PR updates the puma gem from version 5 to the latest version 6.3. 

A few breaking changes were introduced in Puma [6.0.0](https://github.com/puma/puma/releases/tag/v6.0.0), which required some refactoring on the Logstash side, especially to adapt it to the _Extracted LogWriter from Events_ [#2798](https://github.com/puma/puma/pull/2798) changes.

Before this PR, all the logs generated by Puma were using the `debug` level, even the ones that were actually errors and needed attention/action from the users. 

Log level changes:
- `#error` changed from `debug` to `error` 
- `#unknown_error` changed from `debug` to `error`


## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

In addition to other fixes and features, the latest puma versions >= `6` have added support to `TLSv1.3`, which is intended to be supported on the Logstash API endpoints due to security reasons.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

- Run a few requests against the Logstash API with and without SSL enabled (`api.ssl.enabled:false`)
- To ensure it now supports TLSV1.3:
```
openssl s_client -connect localhost:9600 -tls1_3
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->

- Closes https://github.com/elastic/logstash/issues/15155
