### PR TITLE
Update docker.asciidoc to fix monitoring setting issue

### DIFF
--- a/docs/static/docker.asciidoc
+++ b/docs/static/docker.asciidoc
@@ -192,7 +192,7 @@ Some example translations are shown here:
 **Environment Variable**:: **Logstash Setting**
 `PIPELINE_WORKERS`:: `pipeline.workers`
 `LOG_LEVEL`:: `log.level`
-`MONITORING_ENABLED`:: `monitoring.enabled`
+`XPACK_MONITORING_ENABLED`:: `xpack.monitoring.enabled`
 
 In general, any setting listed in the <<logstash-settings-file, settings
 documentation>> can be configured with this technique.
@@ -209,9 +209,9 @@ images:
 
 [horizontal]
 `http.host`:: `0.0.0.0`
-`monitoring.elasticsearch.hosts`:: `http://elasticsearch:9200`
+`xpack.monitoring.elasticsearch.hosts`:: `http://elasticsearch:9200`
 
-NOTE: The setting `monitoring.elasticsearch.hosts` is not
+NOTE: The setting `xpack.monitoring.elasticsearch.hosts` is not
 defined in the `-oss` image.
 
 These settings are defined in the default `logstash.yml`. They can be overridden


### PR DESCRIPTION
The monitoring settings in LS 8.8 are `xpack.monitoring.*` and not `monitoring.*`.
I believe this is a doc bug, as for example the setting `monitoring.enabled` doesn't exist in LS hence the env var `MONITORING_ENABLED` when running LS as a docker has no effect at all. On the other hand `XPACK_MONITORING_ENABLED` env var does the job.

 Also the following docs have references to wrong settings if i'm not mistaken.

- Monitoring with metricbeat: https://www.elastic.co/guide/en/logstash/master/monitoring-with-metricbeat.html
- Monitoring with Elastic Agent: https://www.elastic.co/guide/en/logstash/master/monitoring-with-elastic-agent.html

If you agree I could update the other docs too.