### PR TITLE
Improvements: exclude folders from scanning, move pipeline definition and script improvements.

### DIFF
--- a/.buildkite/scripts/snyk/report.sh
+++ b/.buildkite/scripts/snyk/report.sh
@@ -18,8 +18,6 @@ resolve_latest_branches() {
     IFS='.'
     read -a versions <<< "$SNAPSHOT_VERSION"
     version=${versions[0]}.${versions[1]}
-    version="${version%\"}"
-    version="${version#\"}"
     TARGET_BRANCHES+=("$version")
   done
 }
@@ -56,7 +54,7 @@ report() {
   echo "Reporting to Snyk..."
   cd logstash
   REMOTE_REPO_URL=$1
-  if [ "$REMOTE_REPO_URL" != "$MAIN_BRANCH" ]; then
+  if [ "$REMOTE_REPO_URL" != "main" ]; then
     MAJOR_VERSION=$(echo "$REMOTE_REPO_URL"| cut -d'.' -f 1)
     REMOTE_REPO_URL="$MAJOR_VERSION".latest
     echo "Using '$REMOTE_REPO_URL' remote repo url."
@@ -64,7 +62,7 @@ report() {
 
   # adding git commit hash to Snyk tag to improve visibility
   GIT_HEAD=$(git rev-parse --short HEAD 2> /dev/null)
-  ./snyk monitor --all-projects --org=logstash --remote-repo-url="$REMOTE_REPO_URL" --target-reference="$REMOTE_REPO_URL" --detection-depth=6 --exclude=requirements.txt --project-tags=branch="$TARGET_BRANCH",git_head="$GIT_HEAD" && true
+  ./snyk monitor --all-projects --org=logstash --remote-repo-url="$REMOTE_REPO_URL" --target-reference="$REMOTE_REPO_URL" --detection-depth=6 --exclude=qa,tools,devtools,requirements.txt --project-tags=branch="$TARGET_BRANCH",git_head="$GIT_HEAD" && true
   cd ..
 }
 

--- a/.buildkite/scripts/snyk/resolve_stack_version.sh
+++ b/.buildkite/scripts/snyk/resolve_stack_version.sh
@@ -10,16 +10,10 @@ VERSION_URL="https://raw.githubusercontent.com/elastic/logstash/main/ci/logstash
 
 echo "Fetching versions from $VERSION_URL"
 VERSIONS=$(curl --silent $VERSION_URL)
-SNAPSHOTS=$(echo $VERSIONS | jq '.snapshots' | jq 'keys | .[]')
-IFS=$'\n' read -d "\034" -r -a SNAPSHOT_KEYS <<<"${SNAPSHOTS}\034"
+SNAPSHOT_KEYS=$(echo "$VERSIONS" | jq -r '.snapshots | .[]')
 
 SNAPSHOT_VERSIONS=()
-for KEY in "${SNAPSHOT_KEYS[@]}"
-do
-  # remove starting and trailing double quotes
-  KEY="${KEY%\"}"
-  KEY="${KEY#\"}"
-  SNAPSHOT_VERSION=$(echo $VERSIONS | jq '.snapshots."'"$KEY"'"')
-  echo "Resolved snapshot version: $SNAPSHOT_VERSION"
-  SNAPSHOT_VERSIONS+=("$SNAPSHOT_VERSION")
-done
+while IFS= read -r line; do
+  SNAPSHOT_VERSIONS+=("$line")
+  echo "Resolved snapshot version: $line"
+done <<< "$SNAPSHOT_KEYS"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -48,3 +48,40 @@ spec:
           branch: core_serverless_test
           cronline: "@daily"
           message: "Run the serverless integration test every day."
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: logstash-snyk-report
+  description: 'The logstash-snyk-report pipeline.'
+spec:
+  type: buildkite-pipeline
+  owner: group:ingest-fp
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: logstash-snyk-report-ci
+      description: ':logstash: The logstash-snyk-report :pipeline:'
+    spec:
+      repository: elastic/logstash
+      pipeline_file: ".buildkite/snyk_report_pipeline.yml"
+      provider_settings:
+        trigger_mode: none # don't trigger jobs
+      env:
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
+        SLACK_NOTIFICATIONS_CHANNEL: '#logstash-build'
+        SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
+      teams:
+        ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+      schedules:
+        Daily Snyk scan:
+          branch: main
+          cronline: "@daily"
+          message: "Run the Logstash Snyk report every day."


### PR DESCRIPTION
### Description

~~This PR takes parts from existing https://github.com/elastic/logstash/pull/15117. We are going to come back and address docker container scans in the future but for now some notable improvement would be good to align:~~
- for the long term, we need to define pipeline definitions in backstage;
- our focus to scan only customer facing distribution source section. It is hard to achieve all since Snyk has a limitations such as `--exclude` only excludes folder, the gradle projects under that folder still get scanned but still we can still exclude the `qa`, `devtools` and `tools` folders.
- some other script improvements
