### PR TITLE
Add basic ruby linter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,3 +19,204 @@ AllCops:
     - 'config/**/*'
   DisplayCopNames: true
   UseCache: false
+#################### Layout ###########################
+Layout/AccessModifierIndentation:
+  Enabled: false
+Layout/ArgumentAlignment:
+  Enabled: false
+Layout/ArrayAlignment:
+  Enabled: false
+Layout/AssignmentIndentation:
+  Enabled: false
+Layout/BeginEndAlignment:
+  Enabled: false
+Layout/BlockAlignment:
+  Enabled: false
+Layout/BlockEndNewline:
+  Enabled: false
+Layout/CaseIndentation:
+  Enabled: false
+Layout/ClassStructure:
+  Enabled: false
+Layout/ClosingHeredocIndentation:
+  Enabled: false
+Layout/ClosingParenthesisIndentation:
+  Enabled: false
+Layout/CommentIndentation:
+  Enabled: false
+Layout/ConditionPosition:
+  Enabled: false
+Layout/DefEndAlignment:
+  Enabled: false
+Layout/DotPosition:
+  Enabled: false
+Layout/ElseAlignment:
+  Enabled: false
+Layout/EmptyComment:
+  Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+Layout/EmptyLineAfterMultilineCondition:
+  Enabled: false
+Layout/EmptyLineBetweenDefs:
+  Enabled: false
+Layout/EmptyLines:
+  Enabled: false
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: false
+Layout/EmptyLinesAroundArguments:
+  Enabled: false
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: false
+Layout/EmptyLinesAroundBeginBody:
+  Enabled: false
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: false
+Layout/EmptyLinesAroundClassBody:
+  Enabled: false
+Layout/EmptyLinesAroundExceptionHandlingKeywords:
+  Enabled: false
+Layout/EmptyLinesAroundMethodBody:
+  Enabled: false
+Layout/EmptyLinesAroundModuleBody:
+  Enabled: false
+Layout/EndAlignment:
+  Enabled: false
+Layout/EndOfLine:
+  Enabled: false
+Layout/ExtraSpacing:
+  Enabled: false
+Layout/FirstArgumentIndentation:
+  Enabled: false
+Layout/FirstArrayElementIndentation:
+  Enabled: false
+Layout/FirstArrayElementLineBreak:
+  Enabled: false
+Layout/FirstHashElementIndentation:
+  Enabled: false
+Layout/FirstHashElementLineBreak:
+  Enabled: false
+Layout/FirstMethodArgumentLineBreak:
+  Enabled: false
+Layout/FirstMethodParameterLineBreak:
+  Enabled: false
+Layout/FirstParameterIndentation:
+  Enabled: false
+Layout/HashAlignment:
+  Enabled: false
+Layout/HeredocArgumentClosingParenthesis:
+  Enabled: false
+Layout/HeredocIndentation:
+  Enabled: false
+Layout/IndentationConsistency:
+  Enabled: false
+Layout/IndentationStyle:
+  Enabled: false
+Layout/IndentationWidth:
+  Enabled: false
+Layout/InitialIndentation:
+  Enabled: false
+Layout/LeadingCommentSpace:
+  Enabled: false
+Layout/LeadingEmptyLines:
+  Enabled: false
+Layout/LineContinuationLeadingSpace:
+  Enabled: false
+Layout/LineContinuationSpacing:
+  Enabled: false
+Layout/LineEndStringConcatenationIndentation:
+  Enabled: false
+Layout/LineLength:
+  Enabled: false
+Layout/MultilineArrayBraceLayout:
+  Enabled: false
+Layout/MultilineArrayLineBreaks:
+  Enabled: false
+Layout/MultilineAssignmentLayout:
+  Enabled: false
+Layout/MultilineBlockLayout:
+  Enabled: false
+Layout/MultilineHashBraceLayout:
+  Enabled: false
+Layout/MultilineHashKeyLineBreaks:
+  Enabled: false
+Layout/MultilineMethodArgumentLineBreaks:
+  Enabled: false
+Layout/MultilineMethodCallBraceLayout:
+  Enabled: false
+Layout/MultilineMethodCallIndentation:
+  Enabled: false
+Layout/MultilineMethodDefinitionBraceLayout:
+  Enabled: false
+Layout/MultilineMethodParameterLineBreaks:
+  Enabled: false
+Layout/MultilineOperationIndentation:
+  Enabled: false
+Layout/ParameterAlignment:
+  Enabled: false
+Layout/RedundantLineBreak:
+  Enabled: false
+Layout/RescueEnsureAlignment:
+  Enabled: false
+Layout/SingleLineBlockChain:
+  Enabled: false
+Layout/SpaceAfterColon:
+  Enabled: false
+Layout/SpaceAfterComma:
+  Enabled: false
+Layout/SpaceAfterMethodName:
+  Enabled: false
+Layout/SpaceAfterNot:
+  Enabled: false
+Layout/SpaceAfterSemicolon:
+  Enabled: false
+Layout/SpaceAroundBlockParameters:
+  Enabled: false
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: false
+Layout/SpaceAroundKeyword:
+  Enabled: false
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: false
+Layout/SpaceAroundOperators:
+  Enabled: false
+Layout/SpaceBeforeBlockBraces:
+  Enabled: false
+Layout/SpaceBeforeBrackets:
+  Enabled: false
+Layout/SpaceBeforeComma:
+  Enabled: false
+Layout/SpaceBeforeComment:
+  Enabled: false
+Layout/SpaceBeforeFirstArg:
+  Enabled: false
+Layout/SpaceBeforeSemicolon:
+  Enabled: false
+Layout/SpaceInLambdaLiteral:
+  Enabled: false
+Layout/SpaceInsideArrayLiteralBrackets:
+  Enabled: false
+Layout/SpaceInsideArrayPercentLiteral:
+  Enabled: false
+Layout/SpaceInsideBlockBraces:
+  Enabled: false
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: false
+Layout/SpaceInsideParens:
+  Enabled: false
+Layout/SpaceInsidePercentLiteralDelimiters:
+  Enabled: false
+Layout/SpaceInsideRangeLiteral:
+  Enabled: false
+Layout/SpaceInsideReferenceBrackets:
+  Enabled: false
+Layout/SpaceInsideStringInterpolation:
+  Enabled: false
+Layout/TrailingEmptyLines:
+  Enabled: false
+Layout/TrailingWhitespace:
+  Enabled: false
+Lint/ElseLayout:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -218,5 +218,3 @@ Layout/TrailingEmptyLines:
   Enabled: false
 Layout/TrailingWhitespace:
   Enabled: false
-Lint/ElseLayout:
-  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,21 @@
+AllCops:
+  RubyInterpreters:
+    - ruby
+    - rake
+    - jruby
+  Include:
+    - '**/*.rb'
+    - '**/*.gemfile'
+    - '**/*.gemspec'
+    - '**/*.rake'
+    - '**/Gemfile'
+    - '**/Rakefile'
+  Exclude:
+    - 'node_modules/**/*'
+    - 'tmp/**/*'
+    - 'vendor/**/*'
+    - '.git/**/*'
+    - 'build/**/*'
+    - 'config/**/*'
+  DisplayCopNames: true
+  UseCache: false

--- a/Gemfile.template
+++ b/Gemfile.template
@@ -20,6 +20,7 @@ gem "octokit", "~> 4.25", :group => :build
 gem "rubyzip", "~> 1", :group => :build
 gem "stud", "~> 0.0.22", :group => :build
 
+gem "rubocop", :group => :development
 gem "belzebuth", :group => :development
 gem "benchmark-ips", :group => :development
 gem "ci_reporter_rspec", "~> 1", :group => :development

--- a/Rakefile
+++ b/Rakefile
@@ -34,5 +34,7 @@ Developing?
   `rake test:install-core`  installs any dependencies for testing Logstash core
   `rake test:core`          to run Logstash core tests
   `rake vendor:clean`       clean vendored dependencies used for Logstash development
+  `rake lint:report`        to run the Rubocop linter
+  `rake lint:format`        to automatically format the code
 HELP
 end

--- a/build.gradle
+++ b/build.gradle
@@ -739,6 +739,14 @@ class JDKDetails {
     }
 }
 
+tasks.register("lint") {
+    // Calls rake's 'lint' task
+    dependsOn installDevelopmentGems
+    doLast {
+        rake(projectDir, buildDir, 'rubocop')
+    }
+}
+
 tasks.register("downloadJdk", Download) {
     // CLI project properties: -Pjdk_bundle_os=[windows|linux|darwin] -Pjdk_arch=[arm64|x86_64]
 

--- a/build.gradle
+++ b/build.gradle
@@ -743,7 +743,7 @@ tasks.register("lint") {
     // Calls rake's 'lint' task
     dependsOn installDevelopmentGems
     doLast {
-        rake(projectDir, buildDir, 'rubocop')
+        rake(projectDir, buildDir, 'lint:report')
     }
 }
 

--- a/rakelib/lint.rake
+++ b/rakelib/lint.rake
@@ -17,7 +17,7 @@
 
 namespace "lint" do
 
-  module RubocopCLI
+  module RuboCLI
     def self.run!(*args)
       require "rubocop"
       cli = RuboCop::CLI.new
@@ -28,12 +28,12 @@ namespace "lint" do
 
   # task that runs lint report
   task "report" do
-    require 'rubocop'
-    cli = RuboCop::CLI.new
+    #require 'rubocop'
+    #cli = RuboCop::CLI.new
     # cli.run(["--display-cop-names", "--force-exclusion", "--fail-level", "autocorrect"])
     #cli.run(["--display-cop-names", "--force-exclusion", "--lint"])
     #cli.run(["--lint"])
-    RubocopCLI.run!("--lint")
+    RuboCLI.run!("--lint")
   end
 
   # task that automatically fixes code formatting
@@ -41,6 +41,6 @@ namespace "lint" do
     #require 'rubocop'
     #cli = RuboCop::CLI.new
     #cli.run(["--fix-layout"])
-    RubocopCLI.run!("--fix-layout")
+    RuboCLI.run!("--fix-layout")
   end
 end

--- a/rakelib/lint.rake
+++ b/rakelib/lint.rake
@@ -1,0 +1,21 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+task "rubocop" do
+  require 'rubocop'
+  cli = RuboCop::CLI.new
+  cli.run(["--display-cop-names", "--force-exclusion", "--fail-level", "autocorrect"])
+end

--- a/rakelib/lint.rake
+++ b/rakelib/lint.rake
@@ -21,7 +21,6 @@ namespace "lint" do
     def self.run!(*args)
       require "rubocop"
       cli = RuboCop::CLI.new
-      #result = cli.run(["--display-cop-names", "--force-exclusion", "--fail-level", "autocorrect", *args])
       #Disabling cache ensures that execution doesn't fail after a re-run
       result = cli.run(["--display-cop-names", "--force-exclusion", "--cache", "false", *args])
       raise "Linting failed." if result.nonzero?

--- a/rakelib/lint.rake
+++ b/rakelib/lint.rake
@@ -21,8 +21,7 @@ namespace "lint" do
     def self.run!(*args)
       require "rubocop"
       cli = RuboCop::CLI.new
-      #Disabling cache ensures that execution doesn't fail after a re-run
-      result = cli.run(["--display-cop-names", "--force-exclusion", "--cache", "false", *args])
+      result = cli.run(["--force-exclusion", *args])
       raise "Linting failed." if result.nonzero?
     end
   end

--- a/rakelib/lint.rake
+++ b/rakelib/lint.rake
@@ -14,8 +14,20 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-task "rubocop" do
-  require 'rubocop'
-  cli = RuboCop::CLI.new
-  cli.run(["--display-cop-names", "--force-exclusion", "--fail-level", "autocorrect"])
+
+namespace "lint" do
+  # task that runs lint report
+  task "report" do
+    require 'rubocop'
+    cli = RuboCop::CLI.new
+    # cli.run(["--display-cop-names", "--force-exclusion", "--fail-level", "autocorrect"])
+    cli.run(["--display-cop-names", "--force-exclusion", "--lint"])
+  end
+
+  # task that automatically fixes code formatting
+  task "format" do
+    require 'rubocop'
+    cli = RuboCop::CLI.new
+    cli.run(["--fix-layout"])
+  end
 end

--- a/rakelib/lint.rake
+++ b/rakelib/lint.rake
@@ -16,18 +16,31 @@
 # under the License.
 
 namespace "lint" do
+
+  module RubocopCLI
+    def self.run!(*args)
+      require "rubocop"
+      cli = RuboCop::CLI.new
+      result = cli.run(["--display-cop-names", "--force-exclusion", "--fail-level", "autocorrect", *args])
+      raise "Linting failed." if result.nonzero?
+    end
+  end
+
   # task that runs lint report
   task "report" do
     require 'rubocop'
     cli = RuboCop::CLI.new
     # cli.run(["--display-cop-names", "--force-exclusion", "--fail-level", "autocorrect"])
-    cli.run(["--display-cop-names", "--force-exclusion", "--lint"])
+    #cli.run(["--display-cop-names", "--force-exclusion", "--lint"])
+    #cli.run(["--lint"])
+    RubocopCLI.run!("--lint")
   end
 
   # task that automatically fixes code formatting
   task "format" do
-    require 'rubocop'
-    cli = RuboCop::CLI.new
-    cli.run(["--fix-layout"])
+    #require 'rubocop'
+    #cli = RuboCop::CLI.new
+    #cli.run(["--fix-layout"])
+    RubocopCLI.run!("--fix-layout")
   end
 end

--- a/rakelib/lint.rake
+++ b/rakelib/lint.rake
@@ -21,26 +21,20 @@ namespace "lint" do
     def self.run!(*args)
       require "rubocop"
       cli = RuboCop::CLI.new
-      result = cli.run(["--display-cop-names", "--force-exclusion", "--fail-level", "autocorrect", *args])
+      #result = cli.run(["--display-cop-names", "--force-exclusion", "--fail-level", "autocorrect", *args])
+      #Disabling cache ensures that execution doesn't fail after a re-run
+      result = cli.run(["--display-cop-names", "--force-exclusion", "--cache", "false", *args])
       raise "Linting failed." if result.nonzero?
     end
   end
 
   # task that runs lint report
   task "report" do
-    #require 'rubocop'
-    #cli = RuboCop::CLI.new
-    # cli.run(["--display-cop-names", "--force-exclusion", "--fail-level", "autocorrect"])
-    #cli.run(["--display-cop-names", "--force-exclusion", "--lint"])
-    #cli.run(["--lint"])
     RuboCLI.run!("--lint")
   end
 
   # task that automatically fixes code formatting
   task "format" do
-    #require 'rubocop'
-    #cli = RuboCop::CLI.new
-    #cli.run(["--fix-layout"])
     RuboCLI.run!("--fix-layout")
   end
 end


### PR DESCRIPTION
## What does this PR do?

This PR adds BASIC integration with a Ruby Linter (Rubycop), and adds a Gradle task and two rake tasks.


Usage:

Running the linter with Gradle will install the required dependencies and run a listing report rake task.

`./gradlew lint `

We can also run the linter report with rake.

`rake lint:report`

Lastly, you can also ask Rubocop to automatically update the code for FORMAT changes only with:

`rake lint:format`

Please note: I've intentionally disable all Style formatters, as they will need to be reviewed on case by case basis and enabled as we make the code changes.