### PR TITLE
Pipeline to pipeline communication acked queue improvements.

### DIFF
--- a/logstash-core/lib/logstash/plugins/builtin/pipeline/input.rb
+++ b/logstash-core/lib/logstash/plugins/builtin/pipeline/input.rb
@@ -69,9 +69,7 @@ module ::LogStash; module Plugins; module Builtin; module Pipeline; class Input 
       end)
       ReceiveResponse.completed()
     rescue java.lang.InterruptedException, org.logstash.ackedqueue.QueueRuntimeException, IOError => e
-      # WARN is intentional, if ensure_delivery disabled we lose warnings in PipelineBus.java caused by ReceiveResponse.failed_at(stream_position, e)
-      logger.warn('queueing event failed', message: e.message, exception: e.class)
-      logger.debug? && logger.debug('queueing event failed trace', message: e.message, exception: e.class, backtrace: e.backtrace)
+      logger.debug? && logger.debug('queueing event failed', message: e.message, exception: e.class, backtrace: e.backtrace)
       ReceiveResponse.failed_at(stream_position, e)
     end
   end

--- a/logstash-core/lib/logstash/plugins/builtin/pipeline/input.rb
+++ b/logstash-core/lib/logstash/plugins/builtin/pipeline/input.rb
@@ -68,7 +68,7 @@ module ::LogStash; module Plugins; module Builtin; module Pipeline; class Input 
         stream_position = stream_position + 1
       end)
       ReceiveResponse.completed()
-    rescue org.logstash.ackedqueue.QueueRuntimeException, java.io.IOException, IOError => e
+    rescue java.lang.InterruptedException, org.logstash.ackedqueue.QueueRuntimeException, java.io.IOException, IOError => e
       # maybe an IOException in enqueueing, majority of IOExceptions are not wrapped with Ruby IOError
       # WARN is intentional, if ensure_delivery disabled we lose warnings in PipelineBus.java caused by ReceiveResponse.failed_at(stream_position, e)
       logger.warn('queueing event failed', message: e.message, exception: e.class)

--- a/logstash-core/lib/logstash/plugins/builtin/pipeline/input.rb
+++ b/logstash-core/lib/logstash/plugins/builtin/pipeline/input.rb
@@ -68,8 +68,7 @@ module ::LogStash; module Plugins; module Builtin; module Pipeline; class Input 
         stream_position = stream_position + 1
       end)
       ReceiveResponse.completed()
-    rescue java.lang.InterruptedException, org.logstash.ackedqueue.QueueRuntimeException, java.io.IOException, IOError => e
-      # maybe an IOException in enqueueing, majority of IOExceptions are not wrapped with Ruby IOError
+    rescue java.lang.InterruptedException, org.logstash.ackedqueue.QueueRuntimeException, IOError => e
       # WARN is intentional, if ensure_delivery disabled we lose warnings in PipelineBus.java caused by ReceiveResponse.failed_at(stream_position, e)
       logger.warn('queueing event failed', message: e.message, exception: e.class)
       logger.debug? && logger.debug('queueing event failed trace', message: e.message, exception: e.class, backtrace: e.backtrace)

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/AckedReadBatch.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/AckedReadBatch.java
@@ -25,6 +25,7 @@ import org.logstash.ackedqueue.ext.JRubyAckedQueueExt;
 import org.logstash.execution.MemoryReadBatch;
 import org.logstash.execution.QueueBatch;
 import org.logstash.ext.JrubyEventExtLibrary.RubyEvent;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,18 +34,17 @@ import static org.logstash.RubyUtil.RUBY;
 
 /**
  * Persistent queue collection of events implementation
- * */
+ */
 public final class AckedReadBatch implements QueueBatch {
 
-    private AckedBatch ackedBatch;
+    private final AckedBatch ackedBatch;
 
-    private Collection<RubyEvent> events;
+    private final Collection<RubyEvent> events;
 
     public static AckedReadBatch create(
-        final JRubyAckedQueueExt queue,
-        final int size,
-        final long timeout)
-    {
+            final JRubyAckedQueueExt queue,
+            final int size,
+            final long timeout) {
         try {
             final AckedBatch batch = queue.readBatch(size, timeout);
             return (batch == null) ? new AckedReadBatch() : new AckedReadBatch(batch);
@@ -69,7 +69,7 @@ public final class AckedReadBatch implements QueueBatch {
 
     @Override
     public RubyArray<RubyEvent> to_a() {
-        @SuppressWarnings({"unchecked"})  final RubyArray<RubyEvent> result = RUBY.newArray(events.size());
+        @SuppressWarnings({"unchecked"}) final RubyArray<RubyEvent> result = RUBY.newArray(events.size());
         for (final RubyEvent e : events) {
             if (!MemoryReadBatch.isCancelled(e)) {
                 result.append(e);

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -806,13 +806,13 @@ public final class Queue implements Closeable {
     }
 
     /**
-     * return the {@link Page} for the next read operation.
+     * Return the {@link Page} for the next read operation.
+     * Caller <em>MUST</em> have exclusive access to the lock.
      * @return {@link Page} will be either a read-only tail page or the head page.
-     * @throws QueueRuntimeException if other thread acquired lock
      */
     private Page nextReadPage() {
         if (!lock.isHeldByCurrentThread()) {
-            throw new QueueRuntimeException(QueueExceptionMessages.CANNOT_READ_PAGE);
+            throw new IllegalStateException(QueueExceptionMessages.CANNOT_READ_PAGE);
         }
 
         return (this.unreadTailPages.isEmpty()) ?  this.headPage : this.unreadTailPages.get(0);

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -419,10 +419,8 @@ public final class Queue implements Closeable {
 
         lock.lock();
         try {
-            // a safety net if in case we reach this point with `headPage` null
-            // the possibility of headPage being null is either Queue is created but not opened (`open()` not called) or queue is closed
-            // we have high level safeguard with `this.closed.get()` but in case make sure we are not producing NPE since we don't handle
-            if (Objects.isNull(this.headPage)) {
+            // ensure that the queue is still open now that this thread has acquired the lock.
+            if (this.closed.get()) {
                 throw new QueueRuntimeException(QueueExceptionMessages.WRITE_TO_CLOSED_QUEUE);
             }
 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -99,7 +99,7 @@ public final class Queue implements Closeable {
             }
             this.dirPath = queueDir.toRealPath();
         } catch (final IOException ex) {
-            throw new IllegalStateException(QueueExceptionMessages.CREATING_QUEUE_DIR_ERROR, ex);
+            throw new IllegalStateException(QueueExceptionMessages.CANNOT_CREATE_QUEUE_DIR, ex);
         }
 
         this.pageCapacity = settings.getCapacity();
@@ -405,7 +405,7 @@ public final class Queue implements Closeable {
         // pre-check before incurring serialization overhead;
         // we must check again after acquiring the lock.
         if (this.closed.get()) {
-            throw new QueueRuntimeException(QueueExceptionMessages.WRITE_TO_CLOSED_QUEUE);
+            throw new QueueRuntimeException(QueueExceptionMessages.CANNOT_WRITE_TO_CLOSED_QUEUE);
         }
 
         byte[] data = element.serialize();
@@ -421,7 +421,7 @@ public final class Queue implements Closeable {
         try {
             // ensure that the queue is still open now that this thread has acquired the lock.
             if (this.closed.get()) {
-                throw new QueueRuntimeException(QueueExceptionMessages.WRITE_TO_CLOSED_QUEUE);
+                throw new QueueRuntimeException(QueueExceptionMessages.CANNOT_WRITE_TO_CLOSED_QUEUE);
             }
 
             if (!this.headPage.hasCapacity(data.length)) {
@@ -810,11 +810,11 @@ public final class Queue implements Closeable {
      */
     private Page nextReadPage() {
         if (!lock.isHeldByCurrentThread()) {
-            throw new IllegalStateException(QueueExceptionMessages.CANNOT_READ_PAGE);
+            throw new IllegalStateException(QueueExceptionMessages.CANNOT_READ_PAGE_WITHOUT_LOCK);
         }
 
         if (isClosed()) {
-            throw new QueueRuntimeException(QueueExceptionMessages.WHILE_READING);
+            throw new QueueRuntimeException(QueueExceptionMessages.CANNOT_READ_FROM_CLOSED_QUEUE);
         }
 
 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -403,6 +403,8 @@ public final class Queue implements Closeable {
      * @throws IOException if an IO error occurs
      */
     public long write(Queueable element) throws IOException {
+        // pre-check before incurring serialization overhead;
+        // we must check again after acquiring the lock.
         if (this.closed.get()) {
             throw new QueueRuntimeException(QueueExceptionMessages.WRITE_TO_CLOSED_QUEUE);
         }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -613,11 +613,11 @@ public final class Queue implements Closeable {
      * @throws IOException if an IO error occurs
      */
     public synchronized Batch readBatch(int limit, long timeout) throws IOException {
+        lock.lock();
         if (isClosed()) {
             throw new QueueRuntimeException(QueueExceptionMessages.WHILE_READING);
         }
 
-        lock.lock();
         try {
             return readPageBatch(nextReadPage(), limit, timeout);
         } finally {
@@ -809,11 +809,7 @@ public final class Queue implements Closeable {
      * @return {@link Page} will be either a read-only tail page or the head page.
      * @throws QueueRuntimeException if queue is closed
      */
-    public Page nextReadPage() {
-        if (isClosed()) {
-            throw new QueueRuntimeException(QueueExceptionMessages.WHILE_READING_NEXT_PAGE);
-        }
-
+    private Page nextReadPage() {
         lock.lock();
         try {
             // look at head page if no unreadTailPages

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -615,9 +615,6 @@ public final class Queue implements Closeable {
      */
     public synchronized Batch readBatch(int limit, long timeout) throws IOException {
         lock.lock();
-        if (isClosed()) {
-            throw new QueueRuntimeException(QueueExceptionMessages.WHILE_READING);
-        }
 
         try {
             return readPageBatch(nextReadPage(), limit, timeout);
@@ -809,11 +806,17 @@ public final class Queue implements Closeable {
      * Return the {@link Page} for the next read operation.
      * Caller <em>MUST</em> have exclusive access to the lock.
      * @return {@link Page} will be either a read-only tail page or the head page.
+     * @throws QueueRuntimeException if queue is closed
      */
     private Page nextReadPage() {
         if (!lock.isHeldByCurrentThread()) {
             throw new IllegalStateException(QueueExceptionMessages.CANNOT_READ_PAGE);
         }
+
+        if (isClosed()) {
+            throw new QueueRuntimeException(QueueExceptionMessages.WHILE_READING);
+        }
+
 
         return (this.unreadTailPages.isEmpty()) ?  this.headPage : this.unreadTailPages.get(0);
     }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/QueueExceptionMessages.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/QueueExceptionMessages.java
@@ -35,4 +35,8 @@ public class QueueExceptionMessages {
 
     public final static String CANNOT_DESERIALIZE = "cannot find deserialize method on class ";
 
+    public final static String WHILE_WRITING = "Unhandleable error occurred while writing to queue.";
+
+    public final static String WHILE_READING_NEXT_PAGE = "Attempted to read next page on a closed acked queue.";
+
 }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/QueueExceptionMessages.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/QueueExceptionMessages.java
@@ -21,17 +21,17 @@
 package org.logstash.ackedqueue;
 
 /**
- * Runtime exception specialization for persistent queue related runtime errors.
- * */
-public class QueueRuntimeException extends RuntimeException {
+ * A public class holds number of descriptive messages are used during the interaction with acked queue.
+ */
+public class QueueExceptionMessages {
 
-    private static final long serialVersionUID = 1L;
+    public final static String WHILE_INSERTING = "Received an exception while inserting to a queue.";
 
-    public QueueRuntimeException(String message, Throwable cause) {
-        super(message, cause);
-    }
+    public final static String WHILE_WRITING = "Received an exception while writing to an acked queue.";
 
-    public QueueRuntimeException(String message) {
-        super(message);
-    }
+    public final static String WHILE_READING = "Attempted to read on a closed acked queue.";
+
+    public final static String WRITE_TO_CLOSED_QUEUE = "Tried to write to a closed queue.";
+
+    public final static String BIGGER_DATA_THAN_PAGE_SIZE = "data to be written is bigger than page capacity";
 }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/QueueExceptionMessages.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/QueueExceptionMessages.java
@@ -25,13 +25,18 @@ package org.logstash.ackedqueue;
  */
 public class QueueExceptionMessages {
 
-    public final static String WHILE_INSERTING = "Received an exception while inserting to a queue.";
+    public final static String WHILE_INSERTING_SINGLE_ELEMENT = "Received an exception while inserting an element to an acked queue.";
 
-    public final static String WHILE_WRITING = "Received an exception while writing to an acked queue.";
+    public final static String WHILE_INSERTING_ULTIPLE_ELEMENTS = "Received an exception while writing multiple elements to an acked queue.";
 
     public final static String WHILE_READING = "Attempted to read on a closed acked queue.";
 
     public final static String WRITE_TO_CLOSED_QUEUE = "Tried to write to a closed queue.";
 
     public final static String BIGGER_DATA_THAN_PAGE_SIZE = "data to be written is bigger than page capacity";
+
+    public final static String CREATING_QUEUE_DIR_ERROR = "Error creating queue directories.";
+
+    public final static String CANNOT_DESERIALIZE = "cannot find deserialize method on class ";
+
 }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/QueueExceptionMessages.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/QueueExceptionMessages.java
@@ -25,18 +25,18 @@ package org.logstash.ackedqueue;
  */
 public class QueueExceptionMessages {
 
-    public final static String WHILE_READING = "Attempted to read on a closed acked queue.";
+    public final static String CANNOT_READ_FROM_CLOSED_QUEUE = "Attempted to read on a closed acked queue.";
 
-    public final static String WRITE_TO_CLOSED_QUEUE = "Tried to write to a closed queue.";
+    public final static String CANNOT_WRITE_TO_CLOSED_QUEUE = "Tried to write to a closed queue.";
 
     public final static String BIGGER_DATA_THAN_PAGE_SIZE = "data to be written is bigger than page capacity";
 
-    public final static String CREATING_QUEUE_DIR_ERROR = "Error creating queue directories.";
+    public final static String CANNOT_CREATE_QUEUE_DIR = "Error creating queue directories.";
 
     public final static String CANNOT_DESERIALIZE = "cannot find deserialize method on class ";
 
-    public final static String WHILE_WRITING = "Unhandleable error occurred while writing to queue.";
+    public final static String UNHANDLED_ERROR_WRITING_TO_QUEUE = "Unhandleable error occurred while writing to queue.";
 
-    public final static String CANNOT_READ_PAGE = "Cannot get next read page without first acquiring the lock.";
+    public final static String CANNOT_READ_PAGE_WITHOUT_LOCK = "Cannot get next read page without first acquiring the lock.";
 
 }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/QueueExceptionMessages.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/QueueExceptionMessages.java
@@ -37,6 +37,6 @@ public class QueueExceptionMessages {
 
     public final static String WHILE_WRITING = "Unhandleable error occurred while writing to queue.";
 
-    public final static String WHILE_READING_NEXT_PAGE = "Attempted to read next page on a closed acked queue.";
+    public final static String CANNOT_READ_PAGE = "Cannot get next read page without first acquiring the lock.";
 
 }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/QueueExceptionMessages.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/QueueExceptionMessages.java
@@ -25,10 +25,6 @@ package org.logstash.ackedqueue;
  */
 public class QueueExceptionMessages {
 
-    public final static String WHILE_INSERTING_SINGLE_ELEMENT = "Received an exception while inserting an element to an acked queue.";
-
-    public final static String WHILE_INSERTING_ULTIPLE_ELEMENTS = "Received an exception while writing multiple elements to an acked queue.";
-
     public final static String WHILE_READING = "Attempted to read on a closed acked queue.";
 
     public final static String WRITE_TO_CLOSED_QUEUE = "Tried to write to a closed queue.";

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyAckedQueueExt.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyAckedQueueExt.java
@@ -139,7 +139,7 @@ public final class JRubyAckedQueueExt extends RubyObject {
         try {
             this.queue.write(event);
         } catch (IOException e) {
-            throw new IllegalStateException(QueueExceptionMessages.WHILE_WRITING, e);
+            throw new IllegalStateException(QueueExceptionMessages.UNHANDLED_ERROR_WRITING_TO_QUEUE, e);
         }
     }
 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyAckedQueueExt.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyAckedQueueExt.java
@@ -161,6 +161,10 @@ public final class JRubyAckedQueueExt extends RubyObject {
         return queue.isEmpty();
     }
 
+    public boolean isClosed() {
+        return queue.isClosed();
+    }
+
     public void close() throws IOException {
         queue.close();
     }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyWrappedAckedQueueExt.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyWrappedAckedQueueExt.java
@@ -89,10 +89,7 @@ public final class JRubyWrappedAckedQueueExt extends AbstractWrappedQueueExt {
 
     @JRubyMethod(name = "read_batch")
     public IRubyObject rubyReadBatch(ThreadContext context, IRubyObject size, IRubyObject wait) {
-        if (queue.isClosed()) {
-            throw new QueueRuntimeException(QueueExceptionMessages.WHILE_READING);
-        }
-        return queue.ruby_read_batch(context, size, wait);
+        return queue.rubyReadBatch(context, size, wait);
     }
 
     @JRubyMethod(name = "is_empty?")

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyWrappedAckedQueueExt.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyWrappedAckedQueueExt.java
@@ -21,7 +21,7 @@
 package org.logstash.ackedqueue.ext;
 
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.jruby.Ruby;
 import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
@@ -31,10 +31,7 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.Arity;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.logstash.LockException;
 import org.logstash.RubyUtil;
-import org.logstash.ackedqueue.QueueExceptionMessages;
-import org.logstash.ackedqueue.QueueRuntimeException;
 import org.logstash.execution.AbstractWrappedQueueExt;
 import org.logstash.execution.QueueReadClientBase;
 import org.logstash.ext.JRubyAbstractQueueWriteClientExt;
@@ -44,7 +41,7 @@ import org.logstash.ext.JrubyEventExtLibrary;
 
 /**
  * JRuby extension
- * */
+ */
 @JRubyClass(name = "WrappedAckedQueue")
 public final class JRubyWrappedAckedQueueExt extends AbstractWrappedQueueExt {
 
@@ -59,7 +56,7 @@ public final class JRubyWrappedAckedQueueExt extends AbstractWrappedQueueExt {
         int maxEvents = RubyFixnum.num2int(args[2]);
         int checkpointMaxWrites = RubyFixnum.num2int(args[3]);
         int checkpointMaxAcks = RubyFixnum.num2int(args[4]);
-        boolean checkpointRetry = !((RubyBoolean)args[6]).isFalse();
+        boolean checkpointRetry = !((RubyBoolean) args[6]).isFalse();
         long queueMaxBytes = RubyFixnum.num2long(args[7]);
 
         this.queue = JRubyAckedQueueExt.create(args[0].asJavaString(), capacity, maxEvents,

--- a/logstash-core/src/main/java/org/logstash/ext/JRubyAbstractQueueWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JRubyAbstractQueueWriteClientExt.java
@@ -21,6 +21,7 @@
 package org.logstash.ext;
 
 import java.util.Collection;
+
 import org.jruby.Ruby;
 import org.jruby.RubyBasicObject;
 import org.jruby.RubyClass;
@@ -28,7 +29,6 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.logstash.ackedqueue.QueueRuntimeException;
 import org.logstash.execution.queue.QueueWriter;
 
 @JRubyClass(name = "AbstractQueueWriteClient")
@@ -42,7 +42,7 @@ public abstract class JRubyAbstractQueueWriteClientExt extends RubyBasicObject i
 
     @JRubyMethod(name = {"push", "<<"}, required = 1)
     public final JRubyAbstractQueueWriteClientExt rubyPush(final ThreadContext context,
-        final IRubyObject event) throws QueueRuntimeException {
+                                                           final IRubyObject event) throws InterruptedException {
         doPush(context, (JrubyEventExtLibrary.RubyEvent) event);
         return this;
     }
@@ -50,14 +50,14 @@ public abstract class JRubyAbstractQueueWriteClientExt extends RubyBasicObject i
     @SuppressWarnings("unchecked")
     @JRubyMethod(name = "push_batch", required = 1)
     public final JRubyAbstractQueueWriteClientExt rubyPushBatch(final ThreadContext context,
-        final IRubyObject batch) throws QueueRuntimeException {
+                                                                final IRubyObject batch) throws InterruptedException {
         doPushBatch(context, (Collection<JrubyEventExtLibrary.RubyEvent>) batch);
         return this;
     }
 
     protected abstract JRubyAbstractQueueWriteClientExt doPush(ThreadContext context,
-        JrubyEventExtLibrary.RubyEvent event) throws QueueRuntimeException;
+                                                               JrubyEventExtLibrary.RubyEvent event) throws InterruptedException;
 
     protected abstract JRubyAbstractQueueWriteClientExt doPushBatch(ThreadContext context,
-        Collection<JrubyEventExtLibrary.RubyEvent> batch) throws QueueRuntimeException;
+                                                                    Collection<JrubyEventExtLibrary.RubyEvent> batch) throws InterruptedException;
 }

--- a/logstash-core/src/main/java/org/logstash/ext/JRubyAbstractQueueWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JRubyAbstractQueueWriteClientExt.java
@@ -28,6 +28,7 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.logstash.ackedqueue.QueueRuntimeException;
 import org.logstash.execution.queue.QueueWriter;
 
 @JRubyClass(name = "AbstractQueueWriteClient")
@@ -41,7 +42,7 @@ public abstract class JRubyAbstractQueueWriteClientExt extends RubyBasicObject i
 
     @JRubyMethod(name = {"push", "<<"}, required = 1)
     public final JRubyAbstractQueueWriteClientExt rubyPush(final ThreadContext context,
-        final IRubyObject event) throws InterruptedException {
+        final IRubyObject event) throws QueueRuntimeException {
         doPush(context, (JrubyEventExtLibrary.RubyEvent) event);
         return this;
     }
@@ -49,14 +50,14 @@ public abstract class JRubyAbstractQueueWriteClientExt extends RubyBasicObject i
     @SuppressWarnings("unchecked")
     @JRubyMethod(name = "push_batch", required = 1)
     public final JRubyAbstractQueueWriteClientExt rubyPushBatch(final ThreadContext context,
-        final IRubyObject batch) throws InterruptedException {
+        final IRubyObject batch) throws QueueRuntimeException {
         doPushBatch(context, (Collection<JrubyEventExtLibrary.RubyEvent>) batch);
         return this;
     }
 
     protected abstract JRubyAbstractQueueWriteClientExt doPush(ThreadContext context,
-        JrubyEventExtLibrary.RubyEvent event) throws InterruptedException;
+        JrubyEventExtLibrary.RubyEvent event) throws QueueRuntimeException;
 
     protected abstract JRubyAbstractQueueWriteClientExt doPushBatch(ThreadContext context,
-        Collection<JrubyEventExtLibrary.RubyEvent> batch) throws InterruptedException;
+        Collection<JrubyEventExtLibrary.RubyEvent> batch) throws QueueRuntimeException;
 }

--- a/logstash-core/src/main/java/org/logstash/ext/JRubyWrappedWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JRubyWrappedWriteClientExt.java
@@ -32,7 +32,6 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.logstash.ackedqueue.QueueRuntimeException;
 import org.logstash.execution.queue.QueueWriter;
 import org.logstash.instrument.metrics.AbstractMetricExt;
 import org.logstash.instrument.metrics.AbstractNamespacedMetricExt;
@@ -107,7 +106,7 @@ public final class JRubyWrappedWriteClientExt extends RubyObject implements Queu
 
     @JRubyMethod(name = {"push", "<<"}, required = 1)
     public IRubyObject push(final ThreadContext context,
-                            final IRubyObject event) throws QueueRuntimeException {
+                            final IRubyObject event) throws InterruptedException {
         final JrubyEventExtLibrary.RubyEvent rubyEvent = (JrubyEventExtLibrary.RubyEvent) event;
 
         incrementCounters(1L);
@@ -117,7 +116,7 @@ public final class JRubyWrappedWriteClientExt extends RubyObject implements Queu
     @SuppressWarnings("unchecked")
     @JRubyMethod(name = "push_batch", required = 1)
     public IRubyObject pushBatch(final ThreadContext context,
-                                 final IRubyObject batch) throws QueueRuntimeException {
+                                 final IRubyObject batch) throws InterruptedException {
         final Collection<JrubyEventExtLibrary.RubyEvent> rubyEvents = (Collection<JrubyEventExtLibrary.RubyEvent>) batch;
 
         incrementCounters(rubyEvents.size());

--- a/logstash-core/src/main/java/org/logstash/ext/JRubyWrappedWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JRubyWrappedWriteClientExt.java
@@ -32,6 +32,7 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.logstash.ackedqueue.QueueRuntimeException;
 import org.logstash.execution.queue.QueueWriter;
 import org.logstash.instrument.metrics.AbstractMetricExt;
 import org.logstash.instrument.metrics.AbstractNamespacedMetricExt;
@@ -106,7 +107,7 @@ public final class JRubyWrappedWriteClientExt extends RubyObject implements Queu
 
     @JRubyMethod(name = {"push", "<<"}, required = 1)
     public IRubyObject push(final ThreadContext context,
-                            final IRubyObject event) throws InterruptedException {
+                            final IRubyObject event) throws QueueRuntimeException {
         final JrubyEventExtLibrary.RubyEvent rubyEvent = (JrubyEventExtLibrary.RubyEvent) event;
 
         incrementCounters(1L);
@@ -116,7 +117,7 @@ public final class JRubyWrappedWriteClientExt extends RubyObject implements Queu
     @SuppressWarnings("unchecked")
     @JRubyMethod(name = "push_batch", required = 1)
     public IRubyObject pushBatch(final ThreadContext context,
-                                 final IRubyObject batch) throws InterruptedException {
+                                 final IRubyObject batch) throws QueueRuntimeException {
         final Collection<JrubyEventExtLibrary.RubyEvent> rubyEvents = (Collection<JrubyEventExtLibrary.RubyEvent>) batch;
 
         incrementCounters(rubyEvents.size());

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyAckedWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyAckedWriteClientExt.java
@@ -40,15 +40,6 @@ public final class JrubyAckedWriteClientExt extends JRubyAbstractQueueWriteClien
 
     private JRubyAckedQueueExt queue;
 
-    @JRubyMethod(meta = true, required = 2)
-    public static JrubyAckedWriteClientExt create(final ThreadContext context, final IRubyObject recv,
-                                                  final IRubyObject queue, final IRubyObject closed) {
-        return new JrubyAckedWriteClientExt(
-                context.runtime, RubyUtil.ACKED_WRITE_CLIENT_CLASS,
-                queue.toJava(JRubyAckedQueueExt.class)
-        );
-    }
-
     public static JrubyAckedWriteClientExt create(final JRubyAckedQueueExt queue) {
         return new JrubyAckedWriteClientExt(RubyUtil.RUBY, RubyUtil.ACKED_WRITE_CLIENT_CLASS, queue);
     }

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyAckedWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyAckedWriteClientExt.java
@@ -20,7 +20,6 @@
 
 package org.logstash.ext;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 
@@ -32,8 +31,6 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.Event;
 import org.logstash.RubyUtil;
-import org.logstash.ackedqueue.QueueExceptionMessages;
-import org.logstash.ackedqueue.QueueRuntimeException;
 import org.logstash.ackedqueue.ext.JRubyAckedQueueExt;
 
 @JRubyClass(name = "AckedWriteClient")
@@ -84,11 +81,7 @@ public final class JrubyAckedWriteClientExt extends JRubyAbstractQueueWriteClien
 
     @Override
     public void push(Map<String, Object> event) {
-        try {
-            queue.write(new Event(event));
-        } catch (IOException e) {
-            throw new QueueRuntimeException(QueueExceptionMessages.WRITE_TO_CLOSED_QUEUE, e);
-        }
+        queue.write(new Event(event));
     }
 
 }

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyAckedWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyAckedWriteClientExt.java
@@ -23,7 +23,7 @@ package org.logstash.ext;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.anno.JRubyClass;
@@ -45,10 +45,10 @@ public final class JrubyAckedWriteClientExt extends JRubyAbstractQueueWriteClien
 
     @JRubyMethod(meta = true, required = 2)
     public static JrubyAckedWriteClientExt create(final ThreadContext context, final IRubyObject recv,
-        final IRubyObject queue, final IRubyObject closed) {
+                                                  final IRubyObject queue, final IRubyObject closed) {
         return new JrubyAckedWriteClientExt(
-            context.runtime, RubyUtil.ACKED_WRITE_CLIENT_CLASS,
-            queue.toJava(JRubyAckedQueueExt.class)
+                context.runtime, RubyUtil.ACKED_WRITE_CLIENT_CLASS,
+                queue.toJava(JRubyAckedQueueExt.class)
         );
     }
 
@@ -61,21 +61,21 @@ public final class JrubyAckedWriteClientExt extends JRubyAbstractQueueWriteClien
     }
 
     private JrubyAckedWriteClientExt(final Ruby runtime, final RubyClass metaClass,
-        final JRubyAckedQueueExt queue) {
+                                     final JRubyAckedQueueExt queue) {
         super(runtime, metaClass);
         this.queue = queue;
     }
 
     @Override
     protected JRubyAbstractQueueWriteClientExt doPush(final ThreadContext context,
-        final JrubyEventExtLibrary.RubyEvent event) {
+                                                      final JrubyEventExtLibrary.RubyEvent event) {
         queue.rubyWrite(context, event.getEvent());
         return this;
     }
 
     @Override
     protected JRubyAbstractQueueWriteClientExt doPushBatch(final ThreadContext context,
-        final Collection<JrubyEventExtLibrary.RubyEvent> batch) {
+                                                           final Collection<JrubyEventExtLibrary.RubyEvent> batch) {
         for (final IRubyObject event : batch) {
             queue.rubyWrite(context, ((JrubyEventExtLibrary.RubyEvent) event).getEvent());
         }

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryWriteClientExt.java
@@ -29,6 +29,8 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.runtime.ThreadContext;
 import org.logstash.Event;
 import org.logstash.RubyUtil;
+import org.logstash.ackedqueue.QueueExceptionMessages;
+import org.logstash.ackedqueue.QueueRuntimeException;
 import org.logstash.common.LsQueueUtils;
 
 @JRubyClass(name = "MemoryWriteClient")
@@ -56,16 +58,24 @@ public final class JrubyMemoryWriteClientExt extends JRubyAbstractQueueWriteClie
 
     @Override
     protected JRubyAbstractQueueWriteClientExt doPush(final ThreadContext context,
-        final JrubyEventExtLibrary.RubyEvent event)
-        throws InterruptedException {
-        queue.put(event);
+                                                      final JrubyEventExtLibrary.RubyEvent event) throws QueueRuntimeException {
+        try {
+            queue.put(event);
+        } catch (InterruptedException exception) {
+            throw new QueueRuntimeException(QueueExceptionMessages.WHILE_INSERTING, exception);
+        }
+
         return this;
     }
 
     @Override
     public JRubyAbstractQueueWriteClientExt doPushBatch(final ThreadContext context,
-        final Collection<JrubyEventExtLibrary.RubyEvent> batch) throws InterruptedException {
-        LsQueueUtils.addAll(queue, batch);
+                                                        final Collection<JrubyEventExtLibrary.RubyEvent> batch) throws QueueRuntimeException {
+        try {
+            LsQueueUtils.addAll(queue, batch);
+        } catch (InterruptedException exception) {
+            throw new QueueRuntimeException(QueueExceptionMessages.WHILE_INSERTING, exception);
+        }
         return this;
     }
 

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryWriteClientExt.java
@@ -23,6 +23,7 @@ package org.logstash.ext;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
+
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.anno.JRubyClass;
@@ -45,15 +46,15 @@ public final class JrubyMemoryWriteClientExt extends JRubyAbstractQueueWriteClie
     }
 
     private JrubyMemoryWriteClientExt(final Ruby runtime, final RubyClass metaClass,
-        final BlockingQueue<JrubyEventExtLibrary.RubyEvent> queue) {
+                                      final BlockingQueue<JrubyEventExtLibrary.RubyEvent> queue) {
         super(runtime, metaClass);
         this.queue = queue;
     }
 
     public static JrubyMemoryWriteClientExt create(
-        final BlockingQueue<JrubyEventExtLibrary.RubyEvent> queue) {
+            final BlockingQueue<JrubyEventExtLibrary.RubyEvent> queue) {
         return new JrubyMemoryWriteClientExt(RubyUtil.RUBY,
-            RubyUtil.MEMORY_WRITE_CLIENT_CLASS, queue);
+                RubyUtil.MEMORY_WRITE_CLIENT_CLASS, queue);
     }
 
     @Override
@@ -62,7 +63,7 @@ public final class JrubyMemoryWriteClientExt extends JRubyAbstractQueueWriteClie
         try {
             queue.put(event);
         } catch (InterruptedException exception) {
-            throw new QueueRuntimeException(QueueExceptionMessages.WHILE_INSERTING, exception);
+            throw new QueueRuntimeException(QueueExceptionMessages.WHILE_INSERTING_SINGLE_ELEMENT, exception);
         }
 
         return this;
@@ -74,7 +75,7 @@ public final class JrubyMemoryWriteClientExt extends JRubyAbstractQueueWriteClie
         try {
             LsQueueUtils.addAll(queue, batch);
         } catch (InterruptedException exception) {
-            throw new QueueRuntimeException(QueueExceptionMessages.WHILE_INSERTING, exception);
+            throw new QueueRuntimeException(QueueExceptionMessages.WHILE_INSERTING_ULTIPLE_ELEMENTS, exception);
         }
         return this;
     }

--- a/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryWriteClientExt.java
+++ b/logstash-core/src/main/java/org/logstash/ext/JrubyMemoryWriteClientExt.java
@@ -30,8 +30,6 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.runtime.ThreadContext;
 import org.logstash.Event;
 import org.logstash.RubyUtil;
-import org.logstash.ackedqueue.QueueExceptionMessages;
-import org.logstash.ackedqueue.QueueRuntimeException;
 import org.logstash.common.LsQueueUtils;
 
 @JRubyClass(name = "MemoryWriteClient")
@@ -59,24 +57,15 @@ public final class JrubyMemoryWriteClientExt extends JRubyAbstractQueueWriteClie
 
     @Override
     protected JRubyAbstractQueueWriteClientExt doPush(final ThreadContext context,
-                                                      final JrubyEventExtLibrary.RubyEvent event) throws QueueRuntimeException {
-        try {
-            queue.put(event);
-        } catch (InterruptedException exception) {
-            throw new QueueRuntimeException(QueueExceptionMessages.WHILE_INSERTING_SINGLE_ELEMENT, exception);
-        }
-
+                                                      final JrubyEventExtLibrary.RubyEvent event) throws InterruptedException {
+        queue.put(event);
         return this;
     }
 
     @Override
     public JRubyAbstractQueueWriteClientExt doPushBatch(final ThreadContext context,
-                                                        final Collection<JrubyEventExtLibrary.RubyEvent> batch) throws QueueRuntimeException {
-        try {
-            LsQueueUtils.addAll(queue, batch);
-        } catch (InterruptedException exception) {
-            throw new QueueRuntimeException(QueueExceptionMessages.WHILE_INSERTING_ULTIPLE_ELEMENTS, exception);
-        }
+                                                        final Collection<JrubyEventExtLibrary.RubyEvent> batch) throws InterruptedException {
+        LsQueueUtils.addAll(queue, batch);
         return this;
     }
 

--- a/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineBus.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineBus.java
@@ -33,7 +33,7 @@ import java.util.stream.Stream;
 
 /**
  * This class is the communication bus for the `pipeline` inputs and outputs to talk to each other.
- *
+ * <p>
  * This class is threadsafe.
  */
 public class PipelineBus {
@@ -83,10 +83,8 @@ public class PipelineBus {
                             // fail position to avoid reprocessing of some events in the downstream.
                             // we get 0~clones.length position on failure, keep tracking failed position to correctly copy from original orderedEvents
                             lastFailedPosition += lastResponse.getSequencePosition();
-
-                            logger.warn("Attempted to send event to '{}' but that address reached error condition. " +
-                                    "Will Retry. Root cause {} Failed at {} position.", address, lastResponse.getCauseMessage(), lastFailedPosition);
-
+                            logger.warn("Attempted to send events to '{}' but that address reached error condition with {} events remaining. " +
+                                    "Will Retry. Root cause {}", address, orderedEvents.length - lastFailedPosition, lastResponse.getCauseMessage());
                         } else {
                             logger.warn("Attempted to send event to '{}' but that address was unavailable. " +
                                     "Maybe the destination pipeline is down or stopping? Will Retry.", address);
@@ -99,7 +97,7 @@ public class PipelineBus {
                             logger.error("Sleep unexpectedly interrupted in bus retry loop", e);
                         }
                     }
-                } while(partialProcessing);
+                } while (partialProcessing);
             });
         }
     }
@@ -217,7 +215,7 @@ public class PipelineBus {
      * Stop listening on the given address with the given listener. Blocks until upstream outputs have
      * stopped.
      *
-     * @param input Input that should stop listening
+     * @param input   Input that should stop listening
      * @param address Address on which to stop listening
      * @throws InterruptedException if interrupted while attempting to stop listening
      */
@@ -276,6 +274,4 @@ public class PipelineBus {
     public void setBlockOnUnlisten(boolean blockOnUnlisten) {
         this.blockOnUnlisten = blockOnUnlisten;
     }
-
-
 }

--- a/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineBus.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineBus.java
@@ -79,9 +79,9 @@ public class PipelineBus {
                     partialProcessing = ensureDelivery && !sendWasSuccess;
                     if (partialProcessing) {
                         if (lastResponse != null && lastResponse.getStatus() == PipelineInput.ReceiveStatus.FAIL) {
-                            // when last call to internalReceive generated a fail, restart from the
-                            // fail position to avoid reprocessing of some events in the downstream.
-                            // we get 0~clones.length position on failure, keep tracking failed position to correctly copy from original orderedEvents
+                            // when last call to internalReceive generated a fail for the subset of the orderedEvents
+                            // it is handling, restart from the cumulative last-failed position of the batch so that
+                            // the next attempt will operate on a subset that excludes those successfully received.
                             lastFailedPosition += lastResponse.getSequencePosition();
                             logger.warn("Attempted to send events to '{}' but that address reached error condition with {} events remaining. " +
                                     "Will Retry. Root cause {}", address, orderedEvents.length - lastFailedPosition, lastResponse.getCauseMessage());

--- a/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineBus.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineBus.java
@@ -81,10 +81,11 @@ public class PipelineBus {
                         if (lastResponse != null && lastResponse.getStatus() == PipelineInput.ReceiveStatus.FAIL) {
                             // when last call to internalReceive generated a fail, restart from the
                             // fail position to avoid reprocessing of some events in the downstream.
-                            lastFailedPosition = lastResponse.getSequencePosition();
+                            // we get 0~clones.length position on failure, keep tracking failed position to correctly copy from original orderedEvents
+                            lastFailedPosition += lastResponse.getSequencePosition();
 
                             logger.warn("Attempted to send event to '{}' but that address reached error condition. " +
-                                    "Will Retry. Root cause {}", address, lastResponse.getCauseMessage());
+                                    "Will Retry. Root cause {} Failed at {} position.", address, lastResponse.getCauseMessage(), lastFailedPosition);
 
                         } else {
                             logger.warn("Attempted to send event to '{}' but that address was unavailable. " +

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
@@ -41,7 +41,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.hamcrest.CoreMatchers;
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -59,6 +58,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 import static org.logstash.ackedqueue.QueueTestHelpers.computeCapacityForMmapPageIO;
+import static org.logstash.util.ExceptionMatcher.assertThrows;
 
 public class QueueTest {
 
@@ -1159,6 +1159,6 @@ public class QueueTest {
         final QueueRuntimeException qre = assertThrows(QueueRuntimeException.class, () -> {
             queue.write(new StringElement("Third test string to be REJECTED to write in queue."));
         });
-        assertThat(qre.getMessage(), containsString("Tried to write to a closed queue."));
+        assertThat(qre.getMessage(), CoreMatchers.containsString("Tried to write to a closed queue."));
     }
 }

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
@@ -1145,4 +1145,19 @@ public class QueueTest {
             assertFalse("Dangling page's checkpoint file should be removed", cp0.exists());
         }
     }
+
+    @Test
+    public void writeToClosedQueueException() throws Exception {
+        Settings settings = TestSettings.persistedQueueSettings(100, dataPath);
+        try {
+            Queue queue = new Queue(settings);
+            queue.open();
+            queue.write(new StringElement("First test string to be written in queue."));
+            queue.write(new StringElement("Second test string to be written in queue."));
+            queue.close();
+            queue.write(new StringElement("Third test string to be REJECTED to write in queue."));
+        } catch (QueueRuntimeException e) {
+            assertThat(e.getMessage(), CoreMatchers.containsString("Tried to write to a closed queue."));
+        }
+    }
 }

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
@@ -40,7 +40,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -49,6 +48,7 @@ import org.junit.Ignore;
 import org.junit.rules.TemporaryFolder;
 import org.logstash.ackedqueue.io.MmapPageIOV2;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -1098,7 +1098,7 @@ public class QueueTest {
             queue.open();
             fail("expected queue.open() to throws when not enough disk free");
         } catch (IOException e) {
-            assertThat(e.getMessage(), CoreMatchers.containsString("Unable to allocate"));
+            assertThat(e.getMessage(), containsString("Unable to allocate"));
         }
 
         // at this point the Queue lock should be released and Queue.open should not throw a LockException
@@ -1159,6 +1159,6 @@ public class QueueTest {
         final QueueRuntimeException qre = assertThrows(QueueRuntimeException.class, () -> {
             queue.write(new StringElement("Third test string to be REJECTED to write in queue."));
         });
-        assertThat(qre.getMessage(), CoreMatchers.containsString("Tried to write to a closed queue."));
+        assertThat(qre.getMessage(), containsString("Tried to write to a closed queue."));
     }
 }

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/QueueTest.java
@@ -1149,15 +1149,16 @@ public class QueueTest {
     @Test
     public void writeToClosedQueueException() throws Exception {
         Settings settings = TestSettings.persistedQueueSettings(100, dataPath);
-        try {
-            Queue queue = new Queue(settings);
-            queue.open();
-            queue.write(new StringElement("First test string to be written in queue."));
-            queue.write(new StringElement("Second test string to be written in queue."));
-            queue.close();
+        Queue queue = new Queue(settings);
+
+        queue.open();
+        queue.write(new StringElement("First test string to be written in queue."));
+        queue.write(new StringElement("Second test string to be written in queue."));
+        queue.close();
+
+        final QueueRuntimeException qre = assertThrows(QueueRuntimeException.class, () -> {
             queue.write(new StringElement("Third test string to be REJECTED to write in queue."));
-        } catch (QueueRuntimeException e) {
-            assertThat(e.getMessage(), CoreMatchers.containsString("Tried to write to a closed queue."));
-        }
+        });
+        assertThat(qre.getMessage(), containsString("Tried to write to a closed queue."));
     }
 }

--- a/logstash-core/src/test/java/org/logstash/plugins/pipeline/PipelineBusTest.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/pipeline/PipelineBusTest.java
@@ -136,7 +136,7 @@ public class PipelineBusTest {
 
     @Test
     public void sendingEmptyListToNowhereStillReturns() {
-        bus.registerSender(output, Arrays.asList("not_an_address"));
+        bus.registerSender(output, List.of("not_an_address"));
         bus.sendEvents(output, Collections.emptyList(), true);
     }
 

--- a/logstash-core/src/test/java/org/logstash/util/ExceptionMatcher.java
+++ b/logstash-core/src/test/java/org/logstash/util/ExceptionMatcher.java
@@ -1,0 +1,20 @@
+package org.logstash.util;
+
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+
+@FunctionalInterface
+public interface ExceptionMatcher {
+    void execute() throws Throwable;
+
+    static <T extends Throwable> T assertThrows(Class<T> expectedType, ExceptionMatcher executable) {
+        try {
+            executable.execute();
+        } catch (Throwable actual) {
+            Assert.assertThat(actual, Matchers.instanceOf(expectedType));
+            return expectedType.cast(actual);
+        }
+
+        throw new AssertionError(String.format("Expected %s to be thrown, but nothing was thrown.", expectedType.getName()));
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/util/SetOnceReferenceTest.java
+++ b/logstash-core/src/test/java/org/logstash/util/SetOnceReferenceTest.java
@@ -1,6 +1,5 @@
 package org.logstash.util;
 
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.util.NoSuchElementException;
@@ -14,7 +13,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.logstash.util.ExceptionMatcher.assertThrows;
 
 public class SetOnceReferenceTest {
     @Test
@@ -250,17 +249,6 @@ public class SetOnceReferenceTest {
         assertThat(consumed.getValue(), is(sameInstance(expectedValue)));
 
         checkExpectedValue(immutable, expectedValue);
-    }
-
-    @SuppressWarnings("SameParameterValue")
-    void assertThrows(final Class<? extends Throwable> expectedThrowable, final Runnable runnable) {
-        try {
-            runnable.run();
-        } catch (Exception e) {
-            assertThat("wrong exception thrown", e, Matchers.instanceOf(expectedThrowable));
-            return;
-        }
-        fail(String.format("expected exception %s but nothing was thrown", expectedThrowable.getSimpleName()));
     }
 
     private static class MutableReference<T> {


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Resolves upstream pipeline termination when using pipeline to pipeline communication if writing to a closed queue.

## What does this PR do?
Adresses number of Pipeline to Pipeline upstream issues including abnormal termination issues:
  - `"Tried to write to a closed queue." IllegalStateException` exception, terminates upstream pipeline
    Resolution: ideally locking `input` in the pipeline bus while sending the inflight event would be a synchronized task to prevent such cases and we have [this option](https://gist.github.com/yaauie/5bf4db9f7f7bd17d6b0b84741940a9a1) (big thanks @yaauie) to consider. However, blocking mechanism would be an expensive and expected behavior is to catch exception (failed inflight send position) and let process retry as we have a logic in pipeline bus.

  - Inflight events duplicate while sending
    Issue: when sending inflight events to terminated downstream pipeline, we retry from the failed position we lastly sent. However, we have a bug that we copy the events to send from the point where cloned event's failed position.
    Resolution: the failed position should be a cumulative number, should correspond origin event's position as `lastFailedPosition += lastResponse.getSequencePosition();`

  - `"Cannot invoke "org.logstash.ackedqueue.Page.hasCapacity(int)" because "this.headPage" is null"`
      `NullPointerException` exception. It happens when `ensure_delivery => true`, the situation where queue is closed but input is trying to write into it.
    (reproduce with 3 upstream pipeline workers, single downstream pipeline with 1000 batch)
    Resolution: use atomic `Queue->isClosed()` and check for null to prevent headPage NPE
    Note: when `ensure_delivery => false`, pipeline ignores failed inflight events, means it doesn't write to queue.

  - Queue closed check improvements
    `JRubyWrappedAckedQueueExt` implemented its own `isClosed` atomic variable to identify if queue is closed. However, since `input` is a volatile in pipeline bus (even if not), aligned on actual `closed` variable of original `Queue` is an accurate.


## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [ ]

## How to test this PR locally
- See https://github.com/elastic/logstash/issues/15159 how to test `Tried to write to a closed queue.` the issue.
- Inflight events lost issue is hard to test.
- `Cannot invoke "org.logstash.ackedqueue.Page.hasCapacity(int)" because "this.headPage" is null` NPE test also hard. There is 1% percent of possibility to make it happen when using multiple upstream workers and single downstream worker with small (ex: up to 100) batch size.

## Related issues

- Closes #15159 

## Use cases

Please see the description for the use-case and details of resolution

## Screenshots

## Logs after change, see issue description for before change logs.
```
[2023-08-02T11:51:29,367][INFO ][logstash.pipelineaction.reload] Reloading pipeline {"pipeline.id"=>:downstream}
[2023-08-02T11:51:33,814][INFO ][logstash.javapipeline    ][downstream] Pipeline terminated {"pipeline.id"=>"downstream"}
[2023-08-02T11:51:33,815][WARN ][org.logstash.plugins.pipeline.PipelineBus][upstream][c28fc23a0d8a4f050c8fd52237d2d161521029e2ebd918ed033ba8725cb5886a] Attempted to send events to 'myDownstreamPipeline' but that address reached error condition with 35 events remaining. Will Retry. Root cause Tried to write to a closed queue.
[2023-08-02T11:51:34,448][INFO ][logstash.javapipeline    ] Pipeline `downstream` is configured with `pipeline.ecs_compatibility: v8` setting. All plugins in this pipeline will default to `ecs_compatibility => v8` unless explicitly configured otherwise.
[2023-08-02T11:51:34,450][WARN ][logstash.javapipeline    ][downstream] 'pipeline.ordered' is enabled and is likely less efficient, consider disabling if preserving event order is not necessary
[2023-08-02T11:51:34,451][INFO ][logstash.javapipeline    ][downstream] Starting pipeline {:pipeline_id=>"downstream", "pipeline.workers"=>1, "pipeline.batch.size"=>100, "pipeline.batch.delay"=>50, "pipeline.max_inflight"=>100, "pipeline.sources"=>["central pipeline management"], :thread=>"#<Thread:0x2e3fbf20 /Users/mashhur/Dev/elastic/logstash/logstash-core/lib/logstash/java_pipeline.rb:134 run>"}
[2023-08-02T11:51:34,459][INFO ][logstash.javapipeline    ][downstream] Pipeline Java execution initialization time {"seconds"=>0.01}
[2023-08-02T11:51:34,460][INFO ][logstash.javapipeline    ][downstream] Pipeline started {"pipeline.id"=>"downstream"}
[2023-08-02T11:51:34,466][INFO ][logstash.agent           ] Pipelines running {:count=>2, :running_pipelines=>[:downstream, :upstream], :non_running_pipelines=>[]}
```