### PR TITLE
Fix Java 8 compatibility issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,8 @@ allprojects {
       options.compilerArgs.add("-Xlint:all")
       options.compilerArgs.add("-Xlint:-processing")
       options.compilerArgs.add("-Werror")
+      // Ensure compilation/bytecode compatibility with the specified -target Java version (JEP-247)
+      options.release.set(project.targetCompatibility.getMajorVersion().toInteger())
   }
 
   tasks.withType(Javadoc).configureEach {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Fixed Java 8 compatibility issues

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

This PR adds the [--release](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.compile.CompileOptions.html#org.gradle.api.tasks.compile.CompileOptions:release) ([JEP 247](https://openjdk.org/jeps/247)) option to the Gradle's `CompileJava` task, with the same `targetCompatibility` major version value. 

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

The motivation to add this flag is to avoid compatibility issues when the code is compiled using a newer Java version but it's meant to be executed in older JVMs. This issue is explained well in the [blog post](https://www.morling.dev/blog/bytebuffer-and-the-dreaded-nosuchmethoderror/).

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Using this PR source code:
- Download the JDK 8 and set the `LS_JAVA_HOME` to its path
- Enabled the PQ in `config/logstash.yml` by setting the `queue.type: persisted`
- Compile the Java code and run: ```bin/logstash -e "input{stdin{}} output{stdout{}}"```

It should work with no errors.

Repeating all the steps using the `7.17` branch code should produce an error similar to: 
```
{:action=>LogStash::PipelineAction::Create/pipeline_id:main, :exception=>"Java::JavaLang::NoSuchMethodError", :message=>"java.nio.MappedByteBuffer.position(I)Ljava/nio/MappedByteBuffer;", :backtrace=>
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes https://github.com/elastic/logstash/issues/14883