### PR TITLE
Add rake lint correct

### DIFF
--- a/rakelib/lint.rake
+++ b/rakelib/lint.rake
@@ -32,7 +32,7 @@ namespace "lint" do
     RuboCLI.run!("--lint")
   end
 
-  # Tasks automatically fixes a Cop passed as a parameter (e.g. Lint/DeprecatedConstants)
+  # Tasks automatically fixes a Cop passed as a parameter (e.g. Lint/DeprecatedClassMethods)
   # TODO: Add a way to autocorrect all cops, and not just the one passed as parameter
   desc "Automatically fix all instances of a Cop passed as a parameter"
   task "correct", [:cop] do |t, args|

--- a/rakelib/lint.rake
+++ b/rakelib/lint.rake
@@ -27,11 +27,26 @@ namespace "lint" do
   end
 
   # task that runs lint report
+  desc "Report all Lint Cops"
   task "report" do
     RuboCLI.run!("--lint")
   end
 
+  # Tasks automatically fixes a Cop passed as a parameter (e.g. Lint/DeprecatedConstants)
+  # TODO: Add a way to autocorrect all cops, and not just the one passed as parameter
+  desc "Automatically fix all instances of a Cop passed as a parameter"
+  task "correct", [:cop] do |t, args|
+    if args[:cop].to_s.empty?
+      puts "No Cop has been provided, aborting..."
+      exit(0)
+    else
+      puts "Attempting to correct Lint issues for: #{args[:cop].to_s}"
+      RuboCLI.run!("--autocorrect-all", "--only", args[:cop].to_s)
+    end
+  end
+
   # task that automatically fixes code formatting
+  desc "Automatically fix Layout Cops"
   task "format" do
     RuboCLI.run!("--fix-layout")
   end


### PR DESCRIPTION
## What does this PR do?

Adds a rake task that allows users to autocorrect an enabled Cop. This can be any type of code.

`rake lint:correct["Lint/DeprecatedClassMethods"]`