### PR TITLE
Rubocop: Enable Layout/ArgumentAlignment with with_fixed_indentation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,12 @@ Lint/DeprecatedClassMethods:
 
 #################### Layout ###########################
 ##### Enabled Cops #####
+Layout/AccessModifierIndentation:
+  Enabled: true
+  EnforcedStyle: indent
+Layout/ArgumentAlignment:
+  Enabled: true
+  EnforcedStyle:  with_fixed_indentation
 Layout/TrailingWhitespace:
   Enabled: true
 Layout/TrailingEmptyLines:
@@ -39,12 +45,6 @@ Layout/SpaceAfterSemicolon:
   Enabled: true
 
 ##### Need review #####
-Layout/AccessModifierIndentation:
-  Enabled: true
-  EnforcedStyle: indent
-Layout/ArgumentAlignment:
-  Enabled: true
-  EnforcedStyle:  with_fixed_indentation
 Layout/ArrayAlignment:
   Enabled: false
 Layout/AssignmentIndentation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,9 +40,11 @@ Layout/SpaceAfterSemicolon:
 
 ##### Need review #####
 Layout/AccessModifierIndentation:
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: indent
 Layout/ArgumentAlignment:
-  Enabled: false
+  Enabled: true
+  EnforcedStyle:  with_fixed_indentation
 Layout/ArrayAlignment:
   Enabled: false
 Layout/AssignmentIndentation:

--- a/lib/pluginmanager/install.rb
+++ b/lib/pluginmanager/install.rb
@@ -192,8 +192,8 @@ class LogStash::PluginManager::Install < LogStash::PluginManager::Command
     if unlock_dependencies.any?
       puts "Updating mixin dependencies #{unlock_dependencies.join(', ')}"
       LogStash::Bundler.invoke! update: unlock_dependencies,
-                                rubygems_source: gemfile.gemset.sources,
-                                conservative: conservative?
+        rubygems_source: gemfile.gemset.sources,
+        conservative: conservative?
     end
 
     unlock_dependencies

--- a/lib/pluginmanager/update.rb
+++ b/lib/pluginmanager/update.rb
@@ -82,9 +82,9 @@ class LogStash::PluginManager::Update < LogStash::PluginManager::Command
     # Bundler cannot update and clean gems in one operation so we have to call the CLI twice.
     Bundler.settings.temporary(:frozen => false) do # Unfreeze the bundle when updating gems
       output = LogStash::Bundler.invoke! update: plugins,
-                                         rubygems_source: gemfile.gemset.sources,
-                                         local: local?,
-                                         conservative: conservative?
+        rubygems_source: gemfile.gemset.sources,
+        local: local?,
+        conservative: conservative?
       output << LogStash::Bundler.genericize_platform unless output.nil?
     end
 

--- a/lib/pluginmanager/utils/downloader.rb
+++ b/lib/pluginmanager/utils/downloader.rb
@@ -30,9 +30,9 @@ module LogStash module PluginManager module Utils
 
       def initialize(max)
         @progress_bar = ProgressBar.create(:title => TITLE,
-                                           :starting_at => 0,
-                                           :total => max,
-                                           :format => FORMAT)
+          :starting_at => 0,
+          :total => max,
+          :format => FORMAT)
       end
 
       def update(status)

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -193,10 +193,10 @@ class LogStash::Agent
     update_metrics(converge_result)
 
     logger.info(
-        "Pipelines running",
-        :count => running_pipelines.size,
-        :running_pipelines => running_pipelines.keys,
-        :non_running_pipelines => non_running_pipelines.keys
+      "Pipelines running",
+      :count => running_pipelines.size,
+      :running_pipelines => running_pipelines.keys,
+      :non_running_pipelines => non_running_pipelines.keys
     ) if converge_result.success? && converge_result.total > 0
 
     dispatch_events(converge_result)
@@ -245,25 +245,25 @@ class LogStash::Agent
         uuid = ::File.open(id_path) {|f| f.each_line.first.chomp }
       rescue => e
         logger.warn("Could not open persistent UUID file!",
-                    :path => id_path,
-                    :error => e.message,
-                    :class => e.class.name)
+          :path => id_path,
+          :error => e.message,
+          :class => e.class.name)
       end
     end
 
     if !uuid
       uuid = SecureRandom.uuid
       logger.info("No persistent UUID file found. Generating new UUID",
-                  :uuid => uuid,
-                  :path => id_path)
+        :uuid => uuid,
+        :path => id_path)
       begin
         ::File.open(id_path, 'w') {|f| f.write(uuid) }
       rescue => e
         logger.warn("Could not write persistent UUID file! Will use ephemeral UUID",
-                    :uuid => uuid,
-                    :path => id_path,
-                    :error => e.message,
-                    :class => e.class.name)
+          :uuid => uuid,
+          :path => id_path,
+          :error => e.message,
+          :class => e.class.name)
       end
     end
 

--- a/logstash-core/lib/logstash/compiler/lscl.rb
+++ b/logstash-core/lib/logstash/compiler/lscl.rb
@@ -150,9 +150,9 @@ module LogStashCompilerLSCLGrammar; module LogStash; module Compiler; module LSC
         if !codec_attribute.nil? && codec_attribute.kind_of?(::Array)
           raise ::LogStash::ConfigurationError.new(
             I18n.t("logstash.runner.configuration.invalid_plugin_settings_multiple_codecs",
-                   :plugin => plugin_name,
-                   :type => section_type,
-                   :line => input.line_of(interval.first)
+              :plugin => plugin_name,
+              :type => section_type,
+              :line => input.line_of(interval.first)
             )
           )
         end

--- a/logstash-core/lib/logstash/config/config_ast.rb
+++ b/logstash-core/lib/logstash/config/config_ast.rb
@@ -374,11 +374,11 @@ module LogStash; module Config; module AST
       if duplicate_values.size > 0
         raise ConfigurationError.new(
           I18n.t("logstash.runner.configuration.invalid_plugin_settings_duplicate_keys",
-                 :keys => duplicate_values.join(', '),
-                 :line => input.line_of(interval.first),
-                 :column => input.column_of(interval.first),
-                 :byte => interval.first + 1,
-                 :after => input[0..interval.first]
+            :keys => duplicate_values.join(', '),
+            :line => input.line_of(interval.first),
+            :column => input.column_of(interval.first),
+            :byte => interval.first + 1,
+            :after => input[0..interval.first]
                 )
         )
       end

--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -139,7 +139,7 @@ module LogStash::Config::Mixin
         extra.gsub!("%PLUGIN%", self.class.config_name)
         raise LogStash::ConfigurationError,
           I18n.t("logstash.runner.configuration.obsolete", :name => name,
-                 :plugin => self.class.config_name, :extra => extra)
+            :plugin => self.class.config_name, :extra => extra)
       end
     end
 
@@ -311,8 +311,8 @@ module LogStash::Config::Mixin
         value = params[config_key]
         if value.nil? || (config[:list] && Array(value).empty?)
           self.logger.error(I18n.t("logstash.runner.configuration.setting_missing",
-                               :setting => config_key, :plugin => @plugin_name,
-                               :type => @plugin_type))
+            :setting => config_key, :plugin => @plugin_name,
+            :type => @plugin_type))
           is_valid = false
         end
       end
@@ -361,10 +361,10 @@ module LogStash::Config::Mixin
             params[key] = processed_value
           else
             self.logger.error(I18n.t("logstash.runner.configuration.setting_invalid",
-                                 :plugin => @plugin_name, :type => @plugin_type,
-                                 :setting => key, :value => value.inspect,
-                                 :value_type => config_settings[:validate],
-                                 :note => processed_value))
+              :plugin => @plugin_name, :type => @plugin_type,
+              :setting => key, :value => value.inspect,
+              :value_type => config_settings[:validate],
+              :note => processed_value))
           end
 
           all_params_valid &&= is_valid
@@ -445,7 +445,7 @@ module LogStash::Config::Mixin
               # which ensure the inner plugin has access to the outer's execution context and metric store.
               # This deprecation exists to warn plugins that call `Config::Mixin::validate_value` directly.
               self.deprecation_logger.deprecated("Codec instantiated by `Config::Mixin::DSL::validate_value(String, :codec)` which cannot propagate parent plugin's execution context or metrics. ",
-                                                 self.logger.debug? ? {:backtrace => caller} : {})
+                self.logger.debug? ? {:backtrace => caller} : {})
               value = LogStash::Codecs::Delegator.new LogStash::Plugin.lookup("codec", value.first).new
               return true, value
             else

--- a/logstash-core/lib/logstash/config/modules_common.rb
+++ b/logstash-core/lib/logstash/config/modules_common.rb
@@ -100,8 +100,8 @@ module LogStash module Config
             if esconnected && kbnconnected
               current_module.add_kibana_version(kbnclient.version_parts)
               current_module.import(
-                  LogStash::Modules::ElasticsearchImporter.new(esclient),
-                  LogStash::Modules::KibanaImporter.new(kbnclient)
+                LogStash::Modules::ElasticsearchImporter.new(esclient),
+                LogStash::Modules::KibanaImporter.new(kbnclient)
                 )
             else
               connect_fail_args[:module_name] = module_name

--- a/logstash-core/lib/logstash/filters/base.rb
+++ b/logstash-core/lib/logstash/filters/base.rb
@@ -200,7 +200,7 @@ class LogStash::Filters::Base < LogStash::Plugin
     @remove_field.each do |field|
       field = event.sprintf(field)
       @logger.debug? and @logger.debug("filters/#{self.class.name}: removing field",
-                                       :field => field)
+        :field => field)
       event.remove(field)
     end
 

--- a/logstash-core/lib/logstash/instrument/collector.rb
+++ b/logstash-core/lib/logstash/instrument/collector.rb
@@ -55,12 +55,12 @@ module LogStash module Instrument
         logger.error("Collector: Cannot record metric", :exception => e)
       rescue NameError => e
         logger.error("Collector: Cannot create concrete class for this metric type",
-                     :type => type,
-                     :namespaces_path => namespaces_path,
-                     :key => key,
-                     :metrics_params => metric_type_params,
-                     :exception => e,
-                     :stacktrace => e.backtrace)
+          :type => type,
+          :namespaces_path => namespaces_path,
+          :key => key,
+          :metrics_params => metric_type_params,
+          :exception => e,
+          :stacktrace => e.backtrace)
       end
     end
 

--- a/logstash-core/lib/logstash/instrument/periodic_poller/base.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/base.rb
@@ -43,20 +43,20 @@ module LogStash module Instrument module PeriodicPoller
         # On a busy system this can happen, we just log it as a debug
         # event instead of an error, Some of the JVM calls can take a long time or block.
         logger.debug("Timeout exception",
-                :poller => self,
-                :result => result,
-                :polling_timeout => @options[:polling_timeout],
-                :polling_interval => @options[:polling_interval],
-                :exception => exception.class,
-                :executed_at => time)
+          :poller => self,
+          :result => result,
+          :polling_timeout => @options[:polling_timeout],
+          :polling_interval => @options[:polling_interval],
+          :exception => exception.class,
+          :executed_at => time)
       else
         logger.error("Exception",
-                :poller => self,
-                :result => result,
-                :exception => exception.class,
-                :polling_timeout => @options[:polling_timeout],
-                :polling_interval => @options[:polling_interval],
-                :executed_at => time)
+          :poller => self,
+          :result => result,
+          :exception => exception.class,
+          :polling_timeout => @options[:polling_timeout],
+          :polling_interval => @options[:polling_interval],
+          :executed_at => time)
       end
     end
 
@@ -66,8 +66,8 @@ module LogStash module Instrument module PeriodicPoller
 
     def start
       logger.debug("Starting",
-                   :polling_interval => @options[:polling_interval],
-                   :polling_timeout => @options[:polling_timeout]) if logger.debug?
+        :polling_interval => @options[:polling_interval],
+        :polling_timeout => @options[:polling_timeout]) if logger.debug?
 
       collect # Collect data right away if possible
       @task.execute

--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -51,7 +51,7 @@ module LogStash; class JavaPipeline < AbstractPipeline
     @worker_threads = []
 
     @worker_observer = org.logstash.execution.WorkerObserver.new(process_events_namespace_metric,
-                                                                 pipeline_events_namespace_metric)
+      pipeline_events_namespace_metric)
 
     @drain_queue =  settings.get_value("queue.drain") || settings.get("queue.type") == MEMORY
 
@@ -77,8 +77,8 @@ module LogStash; class JavaPipeline < AbstractPipeline
     @finished_run = Concurrent::AtomicBoolean.new(false)
 
     @logger.info(I18n.t('logstash.pipeline.effective_ecs_compatibility',
-                        :pipeline_id       => pipeline_id,
-                        :ecs_compatibility => settings.get('pipeline.ecs_compatibility')))
+      :pipeline_id       => pipeline_id,
+      :ecs_compatibility => settings.get('pipeline.ecs_compatibility')))
 
     @thread = nil
   end # def initialize
@@ -108,7 +108,7 @@ module LogStash; class JavaPipeline < AbstractPipeline
       # warn if the default is multiple
       if default > 1
         @logger.warn("Defaulting pipeline worker threads to 1 because there are some filters that might not work with multiple worker threads",
-                     default_logging_keys(:count_was => default, :filters => plugins))
+          default_logging_keys(:count_was => default, :filters => plugins))
         return 1 # can't allow the default value to propagate if there are unsafe filters
       end
     end
@@ -416,10 +416,10 @@ module LogStash; class JavaPipeline < AbstractPipeline
       if plugin.stop?
         @logger.debug(
           "Input plugin raised exception during shutdown, ignoring it.",
-           default_logging_keys(
-             :plugin => plugin.class.config_name,
-             :exception => e.message,
-             :backtrace => e.backtrace))
+          default_logging_keys(
+            :plugin => plugin.class.config_name,
+            :exception => e.message,
+            :backtrace => e.backtrace))
         return
       end
 

--- a/logstash-core/lib/logstash/plugin.rb
+++ b/logstash-core/lib/logstash/plugin.rb
@@ -71,9 +71,9 @@ class LogStash::Plugin
     # need to access settings statically because plugins are initialized in config_ast with no context.
     settings = LogStash::SETTINGS
     @slow_logger = self.slow_logger(settings.get("slowlog.threshold.warn").to_nanos,
-                                    settings.get("slowlog.threshold.info").to_nanos,
-                                    settings.get("slowlog.threshold.debug").to_nanos,
-                                    settings.get("slowlog.threshold.trace").to_nanos)
+      settings.get("slowlog.threshold.info").to_nanos,
+      settings.get("slowlog.threshold.debug").to_nanos,
+      settings.get("slowlog.threshold.trace").to_nanos)
     @params = LogStash::Util.deep_clone(params)
     # The id should always be defined normally, but in tests that might not be the case
     # In the future we may make this more strict in the Plugin API

--- a/logstash-core/lib/logstash/plugins/ca_trusted_fingerprint_support.rb
+++ b/logstash-core/lib/logstash/plugins/ca_trusted_fingerprint_support.rb
@@ -12,7 +12,7 @@ module LogStash
       extend LogStash::Util::ThreadSafeAttributes
 
       lazy_init_attr(:trust_strategy_for_ca_trusted_fingerprint,
-                     variable: :@_trust_strategy_for_ca_trusted_fingerprint) do
+        variable: :@_trust_strategy_for_ca_trusted_fingerprint) do
         require 'logstash/patches/manticore/trust_strategies'
         @ca_trusted_fingerprint && CATrustedFingerprintTrustStrategy.new(@ca_trusted_fingerprint)
       end

--- a/logstash-core/lib/logstash/plugins/ecs_compatibility_support.rb
+++ b/logstash-core/lib/logstash/plugins/ecs_compatibility_support.rb
@@ -4,7 +4,7 @@ module LogStash
       def self.included(base)
         base.extend(ArgumentValidator)
         base.config(:ecs_compatibility, :validate => :ecs_compatibility_argument,
-                                        :attr_accessor => false)
+          :attr_accessor => false)
       end
 
       def ecs_compatibility

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -70,9 +70,9 @@ class LogStash::Runner < Clamp::StrictCommand
     :default => LogStash::SETTINGS.get_default("node.name")
 
   option ["--enable-local-plugin-development"], :flag,
-         I18n.t("logstash.runner.flag.enable-local-plugin-development"),
-         :attribute_name => "enable-local-plugin-development",
-         :default => LogStash::SETTINGS.get_default("enable-local-plugin-development")
+    I18n.t("logstash.runner.flag.enable-local-plugin-development"),
+    :attribute_name => "enable-local-plugin-development",
+    :default => LogStash::SETTINGS.get_default("enable-local-plugin-development")
 
   # Config Settings
   option ["-f", "--path.config"], "CONFIG_PATH",
@@ -87,14 +87,14 @@ class LogStash::Runner < Clamp::StrictCommand
     :attribute_name => "config.string"
 
   option ["--field-reference-escape-style"], "STYLE",
-         I18n.t("logstash.runner.flag.field-reference-escape-style"),
-         :default => LogStash::SETTINGS.get_default("config.field_reference.escape_style"),
-         :attribute_name => "config.field_reference.escape_style"
+    I18n.t("logstash.runner.flag.field-reference-escape-style"),
+    :default => LogStash::SETTINGS.get_default("config.field_reference.escape_style"),
+    :attribute_name => "config.field_reference.escape_style"
 
   option ["--event_api.tags.illegal"], "STRING",
-         I18n.t("logstash.runner.flag.event_api.tags.illegal"),
-         :default => LogStash::SETTINGS.get_default("event_api.tags.illegal"),
-         :attribute_name => "event_api.tags.illegal"
+    I18n.t("logstash.runner.flag.event_api.tags.illegal"),
+    :default => LogStash::SETTINGS.get_default("event_api.tags.illegal"),
+    :attribute_name => "event_api.tags.illegal"
 
   # Module settings
   option ["--modules"], "MODULES",
@@ -137,9 +137,9 @@ class LogStash::Runner < Clamp::StrictCommand
     :default => LogStash::SETTINGS.get_default("pipeline.ordered")
 
   option ["--plugin-classloaders"], :flag,
-         I18n.t("logstash.runner.flag.plugin-classloaders"),
-         :attribute_name => "pipeline.plugin_classloaders",
-         :default => LogStash::SETTINGS.get_default("pipeline.plugin_classloaders")
+    I18n.t("logstash.runner.flag.plugin-classloaders"),
+    :attribute_name => "pipeline.plugin_classloaders",
+    :default => LogStash::SETTINGS.get_default("pipeline.plugin_classloaders")
 
   option ["-b", "--pipeline.batch.size"], "SIZE",
     I18n.t("logstash.runner.flag.pipeline-batch-size"),
@@ -311,7 +311,7 @@ class LogStash::Runner < Clamp::StrictCommand
 
     if JavaVersion::CURRENT < JavaVersion::JAVA_11
       logger.warn I18n.t("logstash.runner.java.version",
-                                             :java_home => java.lang.System.getProperty("java.home"))
+        :java_home => java.lang.System.getProperty("java.home"))
     end
 
     logger.warn I18n.t("logstash.runner.java.home") if ENV["JAVA_HOME"]

--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -842,15 +842,15 @@ module LogStash
 
       def set(value)
         deprecation_logger.deprecated(I18n.t("logstash.settings.deprecation.set",
-                                             deprecated_alias: name,
-                                             canonical_name: canonical_proxy.name))
+          deprecated_alias: name,
+          canonical_name: canonical_proxy.name))
         super
       end
 
       def value
         logger.warn(I18n.t("logstash.settings.deprecation.queried",
-                           deprecated_alias: name,
-                           canonical_name: canonical_proxy.name))
+          deprecated_alias: name,
+          canonical_name: canonical_proxy.name))
         @canonical_proxy.value
       end
 
@@ -916,8 +916,8 @@ module LogStash
       def validate_value
         if deprecated_alias.set? && canonical_setting.set?
           fail(ArgumentError, I18n.t("logstash.settings.deprecation.ambiguous",
-                                     canonical_name: canonical_setting.name,
-                                     deprecated_alias: deprecated_alias.name))
+            canonical_name: canonical_setting.name,
+            deprecated_alias: deprecated_alias.name))
         end
 
         super

--- a/logstash-core/lib/logstash/webserver.rb
+++ b/logstash-core/lib/logstash/webserver.rb
@@ -80,11 +80,11 @@ module LogStash
       end
 
       logger.debug("Initializing API WebServer",
-                   "api.http.host"        => options[:http_host],
-                   "api.http.port"        => settings.get("api.http.port"),
-                   "api.ssl.enabled"      => settings.get("api.ssl.enabled"),
-                   "api.auth.type"        => settings.get("api.auth.type"),
-                   "api.environment"      => settings.get("api.environment"))
+        "api.http.host"        => options[:http_host],
+        "api.http.port"        => settings.get("api.http.port"),
+        "api.ssl.enabled"      => settings.get("api.ssl.enabled"),
+        "api.auth.type"        => settings.get("api.auth.type"),
+        "api.environment"      => settings.get("api.environment"))
 
       new(logger, agent, options)
     end
@@ -256,7 +256,7 @@ module LogStash
 
       java.security.KeyStore.getInstance("JKS")
           .load(java.io.FileInputStream.new(@ssl_params.fetch(:keystore_path)),
-                @ssl_params.fetch(:keystore_password).value.chars&.to_java(:char))
+            @ssl_params.fetch(:keystore_password).value.chars&.to_java(:char))
     rescue => e
       raise ArgumentError.new("API Keystore could not be opened (#{e})")
     end

--- a/logstash-core/spec/logstash/agent_spec.rb
+++ b/logstash-core/spec/logstash/agent_spec.rb
@@ -615,7 +615,7 @@ describe LogStash::Agent do
   describe "using persisted queue" do
     it_behaves_like "all Agent tests" do
       let(:agent_settings) { mock_settings("queue.type" => "persisted", "queue.drain" => true,
-                                           "queue.page_capacity" => "8mb", "queue.max_bytes" => "64mb") }
+        "queue.page_capacity" => "8mb", "queue.max_bytes" => "64mb") }
     end
   end
 end

--- a/logstash-core/spec/logstash/api/commands/stats_spec.rb
+++ b/logstash-core/spec/logstash/api/commands/stats_spec.rb
@@ -81,11 +81,11 @@ describe LogStash::Api::Commands::Stats do
 
     it "should validate flow metric keys are exist" do
       expect(report.keys).to include(
-                               :input_throughput,
-                               :output_throughput,
-                               :filter_throughput,
-                               :queue_backpressure,
-                               :worker_concurrency)
+        :input_throughput,
+        :output_throughput,
+        :filter_throughput,
+        :queue_backpressure,
+        :worker_concurrency)
     end
   end
 
@@ -143,8 +143,8 @@ describe LogStash::Api::Commands::Stats do
 
     it "return reloads information" do
       expect(report.keys).to include(
-      :successes,
-      :failures,
+        :successes,
+        :failures,
       )
     end
   end
@@ -175,30 +175,30 @@ describe LogStash::Api::Commands::Stats do
       end
       it "returns flow metric information" do
         expect(report[:main][:flow].keys).to include(
-                                                 :output_throughput,
-                                                 :filter_throughput,
-                                                 :queue_backpressure,
-                                                 :worker_concurrency,
-                                                 :input_throughput,
-                                                 :queue_persisted_growth_bytes,
-                                                 :queue_persisted_growth_events
+          :output_throughput,
+          :filter_throughput,
+          :queue_backpressure,
+          :worker_concurrency,
+          :input_throughput,
+          :queue_persisted_growth_bytes,
+          :queue_persisted_growth_events
                                                )
       end
       it "returns queue metric information" do
         expect(report[:main][:queue].keys).to include(
-                                               :capacity,
-                                               :events,
-                                               :type,
-                                               :data)
+          :capacity,
+          :events,
+          :type,
+          :data)
         expect(report[:main][:queue][:capacity].keys).to include(
-                                                           :page_capacity_in_bytes,
-                                                           :max_queue_size_in_bytes,
-                                                           :queue_size_in_bytes,
-                                                           :max_unread_events)
+          :page_capacity_in_bytes,
+          :max_queue_size_in_bytes,
+          :queue_size_in_bytes,
+          :max_unread_events)
         expect(report[:main][:queue][:data].keys).to include(
-                                                           :storage_type,
-                                                           :path,
-                                                           :free_space_in_bytes)
+          :storage_type,
+          :path,
+          :free_space_in_bytes)
       end
     end
     context "when using multiple pipelines" do

--- a/logstash-core/spec/logstash/compiler/compiler_spec.rb
+++ b/logstash-core/spec/logstash/compiler/compiler_spec.rb
@@ -205,9 +205,9 @@ describe LogStash::Compiler do
         let(:plugin_source) { "generator { codec => plain codec => json }" }
         let(:expected_error_message) {
           I18n.t("logstash.runner.configuration.invalid_plugin_settings_multiple_codecs",
-                 :plugin => "generator",
-                 :type => "input",
-                 :line => "1"
+            :plugin => "generator",
+            :type => "input",
+            :line => "1"
           )
         }
 
@@ -234,9 +234,9 @@ describe LogStash::Compiler do
         let(:source) { "input { generator {} } output { stdout { codec => plain codec => json } }" }
         let(:expected_error_message) {
           I18n.t("logstash.runner.configuration.invalid_plugin_settings_multiple_codecs",
-                 :plugin => "stdout",
-                 :type => "output",
-                 :line => "1"
+            :plugin => "stdout",
+            :type => "output",
+            :line => "1"
           )
         }
 
@@ -379,8 +379,8 @@ describe LogStash::Compiler do
 
         it "should contain both inputs" do
           expect(input).to ir_eql(j.iComposeParallel(
-                                j.iPlugin(rand_meta, INPUT, "generator", {"count" => 1}),
-                                j.iPlugin(rand_meta, INPUT, "generator", {"count" => 2})
+            j.iPlugin(rand_meta, INPUT, "generator", {"count" => 1}),
+            j.iPlugin(rand_meta, INPUT, "generator", {"count" => 2})
                               ))
         end
       end
@@ -431,8 +431,8 @@ describe LogStash::Compiler do
 
         it "should contain both section declarations, in order" do
           expect(compiled_section).to ir_eql(compose(
-                                      splugin("aplugin", {"count" => 1}),
-                                        splugin("aplugin", {"count" => 2})
+            splugin("aplugin", {"count" => 1}),
+            splugin("aplugin", {"count" => 2})
                                       ))
                                     end
       end
@@ -450,8 +450,8 @@ describe LogStash::Compiler do
 
         it "should contain both" do
           expect(compiled_section).to ir_eql(compose(
-                                        splugin("aplugin", {"count" => 1}),
-                                        splugin("aplugin", {"count" => 2})
+            splugin("aplugin", {"count" => 1}),
+            splugin("aplugin", {"count" => 2})
                                       ))
         end
 
@@ -688,9 +688,9 @@ describe LogStash::Compiler do
 
           it "should compile correctly" do
             expect(compiled_section).to ir_eql(j.iIf(
-                                            rand_meta,
-                                            j.eEq(j.eEventValue("[foo]"), j.eEventValue("[bar]")),
-                                            splugin("grok")
+              rand_meta,
+              j.eEq(j.eEventValue("[foo]"), j.eEventValue("[bar]")),
+              splugin("grok")
                                           )
                                        )
           end
@@ -701,10 +701,10 @@ describe LogStash::Compiler do
 
           it "should compile correctly" do
             expect(compiled_section).to ir_eql(j.iIf(
-                                          rand_meta,
-                                          j.eEq(j.eEventValue("[foo]"), j.eEventValue("[bar]")),
-                                          j.noop,
-                                          splugin("fplugin"),
+              rand_meta,
+              j.eEq(j.eEventValue("[foo]"), j.eEventValue("[bar]")),
+              j.noop,
+              splugin("fplugin"),
                                         )
                                        )
           end
@@ -715,10 +715,10 @@ describe LogStash::Compiler do
 
           it "should compile correctly" do
             expect(compiled_section).to ir_eql(j.iIf(
-                                          rand_meta,
-                                          j.eEq(j.eEventValue("[foo]"), j.eEventValue("[bar]")),
-                                          j.noop,
-                                          j.noop
+              rand_meta,
+              j.eEq(j.eEventValue("[foo]"), j.eEventValue("[bar]")),
+              j.noop,
+              j.noop
                                         )
                                        )
           end
@@ -729,10 +729,10 @@ describe LogStash::Compiler do
 
           it "should compile correctly" do
             expect(compiled_section).to ir_eql(j.iIf(
-                                          rand_meta,
-                                          j.eEq(j.eEventValue("[foo]"), j.eEventValue("[bar]")),
-                                          splugin("tplugin"),
-                                          splugin("fplugin")
+              rand_meta,
+              j.eEq(j.eEventValue("[foo]"), j.eEventValue("[bar]")),
+              splugin("tplugin"),
+              splugin("fplugin")
                                         )
                                        )
           end
@@ -743,15 +743,15 @@ describe LogStash::Compiler do
 
           it "should compile correctly" do
             expect(compiled_section).to ir_eql(j.iIf(
-                                          rand_meta,
-                                          j.eEq(j.eEventValue("[foo]"), j.eEventValue("[bar]")),
-                                          splugin("tplugin"),
-                                          j.iIf(
-                                            rand_meta,
-                                            j.eEq(j.eEventValue("[bar]"), j.eEventValue("[baz]")),
-                                            splugin("eifplugin"),
-                                            splugin("fplugin")
-                                          )
+              rand_meta,
+              j.eEq(j.eEventValue("[foo]"), j.eEventValue("[bar]")),
+              splugin("tplugin"),
+              j.iIf(
+                rand_meta,
+                j.eEq(j.eEventValue("[bar]"), j.eEventValue("[baz]")),
+                splugin("eifplugin"),
+                splugin("fplugin")
+              )
                                         )
                                        )
           end
@@ -771,20 +771,20 @@ describe LogStash::Compiler do
 
           it "should compile correctly" do
             expect(compiled_section).to ir_eql(j.iIf(
-                                          rand_meta,
-                                          j.eEq(j.eEventValue("[foo]"), j.eEventValue("[bar]")),
-                                          splugin("tplugin"),
-                                          j.iIf(
-                                            rand_meta,
-                                            j.eEq(j.eEventValue("[bar]"), j.eEventValue("[baz]")),
-                                            splugin("eifplugin"),
-                                            j.iIf(
-                                              rand_meta,
-                                              j.eEq(j.eEventValue("[baz]"), j.eEventValue("[bot]")),
-                                              splugin("eeifplugin"),
-                                              splugin("fplugin")
-                                            )
-                                          )
+              rand_meta,
+              j.eEq(j.eEventValue("[foo]"), j.eEventValue("[bar]")),
+              splugin("tplugin"),
+              j.iIf(
+                rand_meta,
+                j.eEq(j.eEventValue("[bar]"), j.eEventValue("[baz]")),
+                splugin("eifplugin"),
+                j.iIf(
+                  rand_meta,
+                  j.eEq(j.eEventValue("[baz]"), j.eEventValue("[bot]")),
+                  splugin("eeifplugin"),
+                  splugin("fplugin")
+                )
+              )
                                         )
                                        )
           end
@@ -806,23 +806,23 @@ describe LogStash::Compiler do
 
           it "should compile correctly" do
             expect(compiled_section).to ir_eql(j.iIf(
-                                          rand_meta,
-                                          j.eEq(j.eEventValue("[foo]"), j.eEventValue("[bar]")),
-                                          j.iIf(rand_meta, j.eEq(j.eEventValue("[bar]"), j.eEventValue("[baz]")),
-                                                   splugin("aplugin"),
-                                                   j.noop
-                                                  ),
-                                          j.iIf(
-                                            rand_meta,
-                                            j.eEq(j.eEventValue("[bar]"), j.eEventValue("[baz]")),
-                                            splugin("bplugin"),
-                                            j.iIf(
-                                              rand_meta,
-                                              j.eEq(j.eEventValue("[baz]"), j.eEventValue("[bot]")),
-                                              splugin("cplugin"),
-                                              splugin("dplugin")
-                                            )
-                                          )
+              rand_meta,
+              j.eEq(j.eEventValue("[foo]"), j.eEventValue("[bar]")),
+              j.iIf(rand_meta, j.eEq(j.eEventValue("[bar]"), j.eEventValue("[baz]")),
+                splugin("aplugin"),
+                j.noop
+                      ),
+              j.iIf(
+                rand_meta,
+                j.eEq(j.eEventValue("[bar]"), j.eEventValue("[baz]")),
+                splugin("bplugin"),
+                j.iIf(
+                  rand_meta,
+                  j.eEq(j.eEventValue("[baz]"), j.eEventValue("[bot]")),
+                  splugin("cplugin"),
+                  splugin("dplugin")
+                )
+              )
                                         )
                                        )
           end

--- a/logstash-core/spec/logstash/filter_delegator_spec.rb
+++ b/logstash-core/spec/logstash/filter_delegator_spec.rb
@@ -46,7 +46,7 @@ describe LogStash::FilterDelegator do
 
   subject {
     LogStash::Plugins::PluginFactory.filter_delegator(
-        described_class, plugin_klass, config, metric, execution_context
+      described_class, plugin_klass, config, metric, execution_context
     )
   }
 

--- a/logstash-core/spec/logstash/instrument/collector_spec.rb
+++ b/logstash-core/spec/logstash/instrument/collector_spec.rb
@@ -36,7 +36,7 @@ describe LogStash::Instrument::Collector do
       it "logs an error but dont crash" do
         expect(subject.logger).to receive(:error)
           .with("Collector: Cannot create concrete class for this metric type",
-        hash_including({ :type => wrong_type, :namespaces_path => namespaces_path }))
+            hash_including({ :type => wrong_type, :namespaces_path => namespaces_path }))
 
           subject.push(namespaces_path, key, wrong_type, :increment)
       end
@@ -50,7 +50,7 @@ describe LogStash::Instrument::Collector do
 
         expect(subject.logger).to receive(:error)
           .with("Collector: Cannot record metric",
-          hash_including({ :exception => instance_of(LogStash::Instrument::MetricStore::NamespacesExpectedError) }))
+            hash_including({ :exception => instance_of(LogStash::Instrument::MetricStore::NamespacesExpectedError) }))
 
           subject.push(conflicting_namespaces, :random_key, :counter, :increment)
       end

--- a/logstash-core/spec/logstash/java_filter_delegator_spec.rb
+++ b/logstash-core/spec/logstash/java_filter_delegator_spec.rb
@@ -36,7 +36,7 @@ describe LogStash::FilterDelegator do
   end
   let(:metric) {
     LogStash::Instrument::NamespacedMetric.new(
-        LogStash::Instrument::Metric.new(LogStash::Instrument::Collector.new), [:filter]
+      LogStash::Instrument::Metric.new(LogStash::Instrument::Collector.new), [:filter]
     )
   }
   let(:counter_in) {
@@ -70,7 +70,7 @@ describe LogStash::FilterDelegator do
 
   subject {
     LogStash::Plugins::PluginFactory.filter_delegator(
-        described_class, plugin_klass, config, metric, execution_context
+      described_class, plugin_klass, config, metric, execution_context
     )
   }
 

--- a/logstash-core/spec/logstash/plugins/builtin/pipeline_input_output_spec.rb
+++ b/logstash-core/spec/logstash/plugins/builtin/pipeline_input_output_spec.rb
@@ -33,7 +33,7 @@ describe ::LogStash::Plugins::Builtin::Pipeline do
   let(:inputs) { [input] }
   let(:metric) {
     LogStash::Instrument::NamespacedMetric.new(
-        LogStash::Instrument::Metric.new(LogStash::Instrument::Collector.new), [:filter]
+      LogStash::Instrument::Metric.new(LogStash::Instrument::Collector.new), [:filter]
     )
   }
 

--- a/logstash-core/spec/support/helpers.rb
+++ b/logstash-core/spec/support/helpers.rb
@@ -111,8 +111,8 @@ end
 def mock_pipeline(pipeline_id, reloadable = true, config_hash = nil)
   config_string = "input { stdin { id => '#{pipeline_id}' }}"
   settings = mock_settings("pipeline.id" => pipeline_id.to_s,
-                           "config.string" => config_string,
-                           "config.reload.automatic" => reloadable)
+    "config.string" => config_string,
+    "config.reload.automatic" => reloadable)
   pipeline_config = mock_pipeline_config(pipeline_id, config_string, settings)
   LogStash::JavaPipeline.new(pipeline_config)
 end

--- a/qa/integration/specs/env_variables_condition_spec.rb
+++ b/qa/integration/specs/env_variables_condition_spec.rb
@@ -83,7 +83,7 @@ describe "Support environment variable in condition" do
                                     filter { if (\"${APP}\") { mutate { add_tag => \"${TAG1}\"} } }
                                     output { stdout{} }",
                                   "--path.settings", settings_dir],
-                                 true, test_env)
+      true, test_env)
     expect(logstash.stderr_and_stdout).to match(/mytag1/)
     expect(logstash.stderr_and_stdout).not_to match(/wrong_env/)
     expect(logstash.exit_code).to be(0)

--- a/qa/integration/specs/fatal_error_spec.rb
+++ b/qa/integration/specs/fatal_error_spec.rb
@@ -71,9 +71,9 @@ describe "uncaught exception" do
 
   def spawn_logstash_and_wait_for_exit!(config, timeout)
     @logstash.spawn_logstash('--pipeline.workers=1',
-                             '--path.logs', logs_dir,
-                             '--path.data', data_dir,
-                             '--config.string', config)
+      '--path.logs', logs_dir,
+      '--path.data', data_dir,
+      '--config.string', config)
 
     time = Time.now
     while (Time.now - time) < timeout

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -211,7 +211,7 @@ describe "Test Monitoring API" do
 
     #default
     logging_get_assert logstash_service, "INFO", "TRACE",
-                       skip: 'logstash.licensechecker.licensereader' #custom (ERROR) level to start with
+      skip: 'logstash.licensechecker.licensereader' #custom (ERROR) level to start with
 
     #root logger - does not apply to logger.slowlog
     logging_put_assert logstash_service.monitoring_api.logging_put({"logger." => "WARN"})
@@ -277,8 +277,8 @@ describe "Test Monitoring API" do
       )
       if logstash_service.settings.feature_flag == "persistent_queues"
         expect(flow_status).to include(
-                                 'queue_persisted_growth_bytes'  => hash_including('current' => a_kind_of(Numeric), 'lifetime' => a_kind_of(Numeric)),
-                                 'queue_persisted_growth_events' => hash_including('current' => a_kind_of(Numeric), 'lifetime' => a_kind_of(Numeric))
+          'queue_persisted_growth_bytes'  => hash_including('current' => a_kind_of(Numeric), 'lifetime' => a_kind_of(Numeric)),
+          'queue_persisted_growth_events' => hash_including('current' => a_kind_of(Numeric), 'lifetime' => a_kind_of(Numeric))
                                )
       else
         expect(flow_status).to_not include('queue_persisted_growth_bytes')
@@ -316,12 +316,12 @@ describe "Test Monitoring API" do
 
       expect(input_plugin_flow_status).to include('throughput' => hash_including('current' => a_value >= 0, 'lifetime' => a_value > 0))
       expect(filter_plugin_flow_status).to include(
-                                             'worker_utilization' => hash_including('current' => a_value >= 0, 'lifetime' => a_value >= 0),
-                                             'worker_millis_per_event' => hash_including('current' => a_value >= 0, 'lifetime' => a_value >= 0),
+        'worker_utilization' => hash_including('current' => a_value >= 0, 'lifetime' => a_value >= 0),
+        'worker_millis_per_event' => hash_including('current' => a_value >= 0, 'lifetime' => a_value >= 0),
                                            )
       expect(output_plugin_flow_status).to include(
-                                             'worker_utilization' => hash_including('current' => a_value >= 0, 'lifetime' => a_value >= 0),
-                                             'worker_millis_per_event' => hash_including('current' => a_value >= 0, 'lifetime' => a_value >= 0),
+        'worker_utilization' => hash_including('current' => a_value >= 0, 'lifetime' => a_value >= 0),
+        'worker_millis_per_event' => hash_including('current' => a_value >= 0, 'lifetime' => a_value >= 0),
                                            )
     end
   end

--- a/qa/integration/specs/reload_config_spec.rb
+++ b/qa/integration/specs/reload_config_spec.rb
@@ -127,8 +127,8 @@ describe "Test Logstash service when config reload is enabled" do
 
       if logstash_service.settings.feature_flag == "persistent_queues"
         expect(pipeline_flow_stats).to include(
-                                 'queue_persisted_growth_bytes'  => hash_including('current' => a_kind_of(Numeric), 'lifetime' => a_kind_of(Numeric)),
-                                 'queue_persisted_growth_events' => hash_including('current' => a_kind_of(Numeric), 'lifetime' => a_kind_of(Numeric))
+          'queue_persisted_growth_bytes'  => hash_including('current' => a_kind_of(Numeric), 'lifetime' => a_kind_of(Numeric)),
+          'queue_persisted_growth_events' => hash_including('current' => a_kind_of(Numeric), 'lifetime' => a_kind_of(Numeric))
                                )
       else
         expect(pipeline_flow_stats).to_not include('queue_persisted_growth_bytes')

--- a/qa/integration/specs/reserved_tags_field_spec.rb
+++ b/qa/integration/specs/reserved_tags_field_spec.rb
@@ -53,8 +53,8 @@ describe "Guard reserved tags field against incorrect use" do
     it "[#{mode}] update tags and _tags successfully" do
       @logstash.env_variables = test_env
       @logstash.spawn_logstash("-f", config_to_temp_file(@fixture.config(pipeline_fixture)),
-                               "--event_api.tags.illegal", "#{mode}",
-                               "--path.settings", settings_dir)
+        "--event_api.tags.illegal", "#{mode}",
+        "--path.settings", settings_dir)
 
       Stud.try(num_retries.times, [StandardError, RSpec::Expectations::ExpectationNotMetError]) do
         output = IO.read(File.join(test_path, "#{pipeline_fixture}.log"))
@@ -76,7 +76,7 @@ describe "Guard reserved tags field against incorrect use" do
     ['rename', 'warn'].each do |mode|
       logstash = @logstash.run_cmd(["bin/logstash", "-e", @fixture.config('set_illegal_tags').gsub("\n", ""),
                                     "--path.settings", settings_dir, "--event_api.tags.illegal", mode],
-                                   true, test_env)
+        true, test_env)
       expect(logstash.stderr_and_stdout).to match(/Ruby exception occurred/)
     end
   end

--- a/qa/platform_config.rb
+++ b/qa/platform_config.rb
@@ -41,7 +41,7 @@ class PlatformConfig
 
     def configure_bootstrap_scripts(data)
       @bootstrap = OpenStruct.new(:privileged     => "sys/#{type}/bootstrap.sh",
-                                  :non_privileged => "sys/#{type}/user_bootstrap.sh")
+        :non_privileged => "sys/#{type}/user_bootstrap.sh")
       ##
       # for now the only specific bootstrap scripts are ones need
       # with privileged access level, whenever others are also

--- a/spec/unit/bootstrap/bundler_spec.rb
+++ b/spec/unit/bootstrap/bundler_spec.rb
@@ -72,15 +72,15 @@ describe LogStash::Bundler do
       expect(::Bundler::CLI).to receive(:start).with(bundler_args)
       expect(ENV).to receive(:replace) do |args|
         expect(args).to include("BUNDLE_PATH" => LogStash::Environment::BUNDLE_DIR,
-                                                            "BUNDLE_GEMFILE" => LogStash::Environment::GEMFILE_PATH,
-                                                            "BUNDLE_SILENCE_ROOT_WARNING" => "true",
-                                                            "BUNDLE_WITHOUT" => "development")
+          "BUNDLE_GEMFILE" => LogStash::Environment::GEMFILE_PATH,
+          "BUNDLE_SILENCE_ROOT_WARNING" => "true",
+          "BUNDLE_WITHOUT" => "development")
       end
       expect(ENV).to receive(:replace) do |args|
         expect(args).not_to include(
-                                "BUNDLE_PATH" => LogStash::Environment::BUNDLE_DIR,
-                                "BUNDLE_SILENCE_ROOT_WARNING" => "true",
-                                "BUNDLE_WITHOUT" => "development")
+          "BUNDLE_PATH" => LogStash::Environment::BUNDLE_DIR,
+          "BUNDLE_SILENCE_ROOT_WARNING" => "true",
+          "BUNDLE_WITHOUT" => "development")
       end
 
       LogStash::Bundler.invoke!(options)

--- a/spec/unit/plugin_manager/update_spec.rb
+++ b/spec/unit/plugin_manager/update_spec.rb
@@ -31,8 +31,8 @@ describe LogStash::PluginManager::Update do
   it "pass all gem sources to the bundle update command" do
     sources = cmd.gemfile.gemset.sources
     expect_any_instance_of(LogStash::Bundler).to receive(:invoke!).with(
-        :update => [], :rubygems_source => sources,
-        :conservative => true, :local => false
+      :update => [], :rubygems_source => sources,
+      :conservative => true, :local => false
     )
     cmd.execute
   end

--- a/tools/logstash-docgen/lib/logstash/docgen/asciidoc_format.rb
+++ b/tools/logstash-docgen/lib/logstash/docgen/asciidoc_format.rb
@@ -42,9 +42,9 @@ module LogStash module Docgen
         erb
       else
         Asciidoctor.convert(erb,
-                            :header_footer => true,
-                            :stylesheet => CSS_FILE,
-                            :safe => 'safe')
+          :header_footer => true,
+          :stylesheet => CSS_FILE,
+          :safe => 'safe')
       end
     end
 

--- a/tools/logstash-docgen/lib/logstash/docgen/runner.rb
+++ b/tools/logstash-docgen/lib/logstash/docgen/runner.rb
@@ -41,9 +41,9 @@ module LogStash module Docgen
       end
 
       DocumentationGenerator.new(with_plugins,
-                                 target,
-                                 source,
-                                 YAML.load(File.read(config))).generate
+        target,
+        source,
+        YAML.load(File.read(config))).generate
     end
   end
 end end

--- a/x-pack/lib/config_management/elasticsearch_source.rb
+++ b/x-pack/lib/config_management/elasticsearch_source.rb
@@ -15,7 +15,7 @@ module LogStash
   module ConfigManagement
     class ElasticsearchSource < LogStash::Config::Source::Base
       include LogStash::Util::Loggable, LogStash::LicenseChecker::Licensed,
-              LogStash::Helpers::ElasticsearchOptions
+        LogStash::Helpers::ElasticsearchOptions
 
       class RemoteConfigError < LogStash::Error; end
 

--- a/x-pack/lib/filters/geoip/database_manager.rb
+++ b/x-pack/lib/filters/geoip/database_manager.rb
@@ -50,13 +50,13 @@ module LogStash module Filters module Geoip class DatabaseManager
     asn_database_path = @metadata.database_path(ASN)
 
     @states = { "#{CITY}" => DatabaseState.new(@metadata.is_eula(CITY),
-                                               Concurrent::Array.new,
-                                               city_database_path,
-                                               cc_city_database_path),
+      Concurrent::Array.new,
+      city_database_path,
+      cc_city_database_path),
                 "#{ASN}" => DatabaseState.new(@metadata.is_eula(ASN),
-                                              Concurrent::Array.new,
-                                              asn_database_path,
-                                              cc_asn_database_path) }
+                  Concurrent::Array.new,
+                  asn_database_path,
+                  cc_asn_database_path) }
 
     @download_manager = DownloadManager.new(@metadata)
 
@@ -112,7 +112,7 @@ module LogStash module Filters module Geoip class DatabaseManager
 
           notify_plugins(database_type, :update, new_database_path) do |db_type, ids|
             logger.info("geoip plugin will use database #{new_database_path}",
-                        :database_type => db_type, :pipeline_ids => ids) unless ids.empty?
+              :database_type => db_type, :pipeline_ids => ids) unless ids.empty?
           end
 
           success_cnt += 1
@@ -166,7 +166,7 @@ module LogStash module Filters module Geoip class DatabaseManager
               "which you can download from https://dev.maxmind.com/geoip/geoip2/geolite2/ ")
 
             logger.warn("geoip plugin will stop filtering and will tag all events with the '_geoip_expired_database' tag.",
-                        :database_type => db_type, :pipeline_ids => ids)
+              :database_type => db_type, :pipeline_ids => ids)
           end
         end
 

--- a/x-pack/lib/monitoring/inputs/metrics/stats_event_factory.rb
+++ b/x-pack/lib/monitoring/inputs/metrics/stats_event_factory.rb
@@ -60,7 +60,7 @@ module LogStash; module Inputs; class Metrics;
       result = stats.extract_metrics([:jvm], :uptime_in_millis)
 
       heap_stats = stats.extract_metrics([:jvm, :memory, :heap],
-                      :used_in_bytes, :used_percent, :max_in_bytes)
+        :used_in_bytes, :used_percent, :max_in_bytes)
 
       result["mem"] = {
         "heap_used_in_bytes" => heap_stats[:used_in_bytes],
@@ -71,9 +71,9 @@ module LogStash; module Inputs; class Metrics;
       result["gc"] = {
         "collectors" => {
           "old" => stats.extract_metrics([:jvm, :gc, :collectors, :old],
-                        :collection_time_in_millis, :collection_count),
+            :collection_time_in_millis, :collection_count),
           "young" => stats.extract_metrics([:jvm, :gc, :collectors, :young],
-                        :collection_time_in_millis, :collection_count)
+            :collection_time_in_millis, :collection_count)
         }
       }
 

--- a/x-pack/lib/monitoring/monitoring.rb
+++ b/x-pack/lib/monitoring/monitoring.rb
@@ -208,9 +208,9 @@ module LogStash
         end
         es_settings = es_options_from_settings_or_modules('monitoring', settings)
         data = TemplateData.new(LogStash::SETTINGS.get("node.uuid"), API_VERSION,
-                                es_settings,
-                                opt[:collection_interval], opt[:collection_timeout_interval],
-                                opt[:extended_performance_collection], opt[:config_collection])
+          es_settings,
+          opt[:collection_interval], opt[:collection_timeout_interval],
+          opt[:extended_performance_collection], opt[:config_collection])
 
         template_path = ::File.join(::File.dirname(__FILE__), "..", "template.cfg.erb")
         template = ::File.read(template_path)

--- a/x-pack/qa/integration/support/elasticsearch/api/actions/update_password.rb
+++ b/x-pack/qa/integration/support/elasticsearch/api/actions/update_password.rb
@@ -10,8 +10,8 @@ module Elasticsearch
       def update_password(arguments={})
         method = HTTP_PUT
         path   = Utils.__pathify '_security/user/',
-                                 Utils.__escape(arguments[:user]),
-                                 '/_password'
+          Utils.__escape(arguments[:user]),
+          '/_password'
         params = {}
         body   = {
             "password" => "#{arguments[:password]}"

--- a/x-pack/spec/config_management/bootstrap_check_spec.rb
+++ b/x-pack/spec/config_management/bootstrap_check_spec.rb
@@ -111,11 +111,11 @@ describe LogStash::ConfigManagement::BootstrapCheck do
     context "when `path.config` is given" do
       let(:settings) do
         apply_settings(
-            {
-                "xpack.management.enabled" => true,
-                "path.config" => config_location
-            },
-            system_settings
+          {
+              "xpack.management.enabled" => true,
+              "path.config" => config_location
+          },
+          system_settings
         )
       end
 
@@ -198,11 +198,11 @@ describe LogStash::ConfigManagement::BootstrapCheck do
         let(:pipeline_ids) { ["pipeline1", "pipeline2", "*pipeline*"] }
         let(:settings) do
           apply_settings(
-              {
-                  "xpack.management.enabled" => true,
-                  "xpack.management.pipeline.id" => pipeline_ids
-              },
-              system_settings
+            {
+                "xpack.management.enabled" => true,
+                "xpack.management.pipeline.id" => pipeline_ids
+            },
+            system_settings
           )
         end
 

--- a/x-pack/spec/filters/geoip/download_manager_spec.rb
+++ b/x-pack/spec/filters/geoip/download_manager_spec.rb
@@ -66,8 +66,8 @@ describe LogStash::Filters::Geoip do
       before(:each) do
         expect(download_manager).to receive(:uuid).and_return(SecureRandom.uuid)
         mock_resp = double("geoip_endpoint",
-                           :body => ::File.read(::File.expand_path("./fixtures/normal_resp.json", ::File.dirname(__FILE__))),
-                           :code => 200)
+          :body => ::File.read(::File.expand_path("./fixtures/normal_resp.json", ::File.dirname(__FILE__))),
+          :code => 200)
         allow(download_manager).to receive_message_chain("rest_client.get").and_return(mock_resp)
       end
 

--- a/x-pack/spec/helpers/elasticsearch_options_spec.rb
+++ b/x-pack/spec/helpers/elasticsearch_options_spec.rb
@@ -12,9 +12,9 @@ require 'monitoring/monitoring'
 shared_examples "elasticsearch options hash is populated without security" do
   it "with username, hosts and password" do
       expect(test_class.es_options_from_settings_or_modules('monitoring', system_settings)).to include(
-                                                                                                   "hosts" => expected_url,
-                                                                                                   "user" => expected_username,
-                                                                                                   "password" => expected_password
+        "hosts" => expected_url,
+        "user" => expected_username,
+        "password" => expected_password
                                                                                                )
   end
 end
@@ -26,11 +26,11 @@ shared_examples 'elasticsearch options hash is populated with secure options' do
 
     it "creates the elasticsearch output options hash" do
       expect(test_class.es_options_from_settings('monitoring', system_settings)).to include(
-                                                                                        "hosts" => elasticsearch_url,
-                                                                                        "user" => elasticsearch_username,
-                                                                                        "password" => elasticsearch_password,
-                                                                                        "ssl_enabled" => true,
-                                                                                        "ssl_certificate_authorities" => elasticsearch_ca
+        "hosts" => elasticsearch_url,
+        "user" => elasticsearch_username,
+        "password" => elasticsearch_password,
+        "ssl_enabled" => true,
+        "ssl_certificate_authorities" => elasticsearch_ca
                                                                                     )
     end
   end
@@ -41,11 +41,11 @@ shared_examples 'elasticsearch options hash is populated with secure options' do
 
     it "creates the elasticsearch output options hash" do
       expect(test_class.es_options_from_settings('monitoring', system_settings)).to include(
-                                                                                      "hosts" => elasticsearch_url,
-                                                                                      "user" => elasticsearch_username,
-                                                                                      "password" => elasticsearch_password,
-                                                                                      "ssl_enabled" => true,
-                                                                                      "ca_trusted_fingerprint" => ca_trusted_fingerprint
+        "hosts" => elasticsearch_url,
+        "user" => elasticsearch_username,
+        "password" => elasticsearch_password,
+        "ssl_enabled" => true,
+        "ca_trusted_fingerprint" => ca_trusted_fingerprint
                                                                                     )
     end
   end
@@ -62,12 +62,12 @@ shared_examples 'elasticsearch options hash is populated with secure options' do
 
     it "creates the elasticsearch output options hash" do
       expect(test_class.es_options_from_settings('monitoring', system_settings)).to include(
-                                                                                        "hosts" => elasticsearch_url,
-                                                                                        "user" => elasticsearch_username,
-                                                                                        "password" => elasticsearch_password,
-                                                                                        "ssl_enabled" => true,
-                                                                                        "ssl_truststore_path" => elasticsearch_truststore_path,
-                                                                                        "ssl_truststore_password" => elasticsearch_truststore_password
+        "hosts" => elasticsearch_url,
+        "user" => elasticsearch_username,
+        "password" => elasticsearch_password,
+        "ssl_enabled" => true,
+        "ssl_truststore_path" => elasticsearch_truststore_path,
+        "ssl_truststore_password" => elasticsearch_truststore_password
                                                                                     )
     end
   end
@@ -85,12 +85,12 @@ shared_examples 'elasticsearch options hash is populated with secure options' do
 
     it "creates the elasticsearch output options hash" do
       expect(test_class.es_options_from_settings('monitoring', system_settings)).to include(
-                                                                                        "hosts" => elasticsearch_url,
-                                                                                        "user" => elasticsearch_username,
-                                                                                        "password" => elasticsearch_password,
-                                                                                        "ssl_enabled" => true,
-                                                                                        "ssl_keystore_path" => elasticsearch_keystore_path,
-                                                                                        "ssl_keystore_password" => elasticsearch_keystore_password
+        "hosts" => elasticsearch_url,
+        "user" => elasticsearch_username,
+        "password" => elasticsearch_password,
+        "ssl_enabled" => true,
+        "ssl_keystore_path" => elasticsearch_keystore_path,
+        "ssl_keystore_password" => elasticsearch_keystore_password
                                                                                     )
     end
   end
@@ -108,12 +108,12 @@ shared_examples 'elasticsearch options hash is populated with secure options' do
 
     it "creates the elasticsearch output options hash" do
       expect(test_class.es_options_from_settings('monitoring', system_settings)).to include(
-                                                                                        "hosts" => elasticsearch_url,
-                                                                                        "user" => elasticsearch_username,
-                                                                                        "password" => elasticsearch_password,
-                                                                                        "ssl_enabled" => true,
-                                                                                        "ssl_certificate" => elasticsearch_certificate_path,
-                                                                                        "ssl_key" => elasticsearch_key_path
+        "hosts" => elasticsearch_url,
+        "user" => elasticsearch_username,
+        "password" => elasticsearch_password,
+        "ssl_enabled" => true,
+        "ssl_certificate" => elasticsearch_certificate_path,
+        "ssl_key" => elasticsearch_key_path
                                                                                       )
     end
   end
@@ -128,11 +128,11 @@ shared_examples 'elasticsearch options hash is populated with secure options' do
 
       it "creates the elasticsearch output options hash" do
         expect(test_class.es_options_from_settings('monitoring', system_settings)).to include(
-                                                                                          "hosts" => elasticsearch_url,
-                                                                                          "user" => elasticsearch_username,
-                                                                                          "password" => elasticsearch_password,
-                                                                                          "ssl_enabled" => true,
-                                                                                          "ssl_cipher_suites" => ["FOO", "BAR"],
+          "hosts" => elasticsearch_url,
+          "user" => elasticsearch_username,
+          "password" => elasticsearch_password,
+          "ssl_enabled" => true,
+          "ssl_cipher_suites" => ["FOO", "BAR"],
                                                                                         )
       end
     end


### PR DESCRIPTION
## What does this PR do?

Enable the following two cops. Only `ArgumentAlignment` yields changes.

```
Layout/AccessModifierIndentation:
  Enabled: true
  EnforcedStyle: indent
Layout/ArgumentAlignment:
  Enabled: true
  EnforcedStyle:  with_fixed_indentation
```