### PR TITLE
Fix deprecated ERB and BigDecimal instances

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,10 @@ AllCops:
 ##### Enabled Cops #####
 Lint/DeprecatedClassMethods:
   Enabled: true
+Lint/ErbNewArguments:
+  Enabled: true
+Lint/BigDecimalNew:
+  Enabled: true
 
 #################### Layout ###########################
 ##### Enabled Cops #####

--- a/lib/pluginmanager/proxy_support.rb
+++ b/lib/pluginmanager/proxy_support.rb
@@ -113,7 +113,7 @@ def configure_proxy
     FileUtils.mkdir_p(SETTINGS_TARGET)
     target = ::File.join(SETTINGS_TARGET, "settings.xml")
     template = ::File.read(SETTINGS_TEMPLATE)
-    template_content = ERB.new(template, 3).result(ProxyTemplateData.new(proxies).get_binding)
+    template_content = ERB.new(template).result(ProxyTemplateData.new(proxies).get_binding)
 
     if ::File.exist?(target)
       if template_content != ::File.read(target)

--- a/logstash-core/spec/logstash/event_spec.rb
+++ b/logstash-core/spec/logstash/event_spec.rb
@@ -151,9 +151,9 @@ describe LogStash::Event do
     # BigDecimal is now natively converted by JRuby, see https://github.com/elastic/logstash/pull/4838
     it "should set BigDecimal" do
       e = LogStash::Event.new()
-      e.set("[foo]", BigDecimal.new(1))
+      e.set("[foo]", BigDecimal(1))
       expect(e.get("foo")).to be_kind_of(BigDecimal)
-      expect(e.get("foo")).to eq(BigDecimal.new(1))
+      expect(e.get("foo")).to eq(BigDecimal(1))
     end
 
     it "should set RubyInteger" do

--- a/logstash-core/spec/logstash/legacy_ruby_timestamp_spec.rb
+++ b/logstash-core/spec/logstash/legacy_ruby_timestamp_spec.rb
@@ -193,11 +193,11 @@ describe LogStash::Timestamp do
 
     context "with BigDecimal epoch" do
       it "should convert to correct date" do
-        expect(LogStash::Timestamp.at(BigDecimal.new("946702800.123456789")).to_iso8601).to eq("2000-01-01T05:00:00.123456789Z")
+        expect(LogStash::Timestamp.at(BigDecimal("946702800.123456789")).to_iso8601).to eq("2000-01-01T05:00:00.123456789Z")
       end
 
       it "should return usec with a minimum of millisec precision" do
-        expect(LogStash::Timestamp.at(BigDecimal.new("946702800.123456789")).usec).to be_within(1000).of(123456)
+        expect(LogStash::Timestamp.at(BigDecimal("946702800.123456789")).usec).to be_within(1000).of(123456)
       end
     end
 

--- a/qa/integration/framework/fixture.rb
+++ b/qa/integration/framework/fixture.rb
@@ -56,7 +56,7 @@ class Fixture
     end
 
     if options != nil
-      ERB.new(config, nil, "-").result(TemplateContext.new(options).get_binding)
+      ERB.new(config, trim_mode: "-").result(TemplateContext.new(options).get_binding)
     else
       config
     end

--- a/tools/logstash-docgen/lib/logstash/docgen/asciidoc_format.rb
+++ b/tools/logstash-docgen/lib/logstash/docgen/asciidoc_format.rb
@@ -54,7 +54,7 @@ module LogStash module Docgen
 
     private
     def read_template(file)
-      ERB.new(::File.read(file), nil, "-")
+      ERB.new(::File.read(file), trim_mode: "-")
     end
 
     def post_process!(context, erb)

--- a/tools/logstash-docgen/lib/logstash/docgen/index.rb
+++ b/tools/logstash-docgen/lib/logstash/docgen/index.rb
@@ -80,7 +80,7 @@ module LogStash module Docgen
             .sort
             .collect { |file| ::File.basename(file, ASCIIDOC_EXTENSION) }
 
-        template = ERB.new(TEMPLATES[type.to_sym], nil, "-")
+        template = ERB.new(TEMPLATES[type.to_sym], trim_mode: "-")
         save(type, template.result(IndexContext.new(type, plugins).get_binding))
       end
     end

--- a/x-pack/lib/monitoring/monitoring.rb
+++ b/x-pack/lib/monitoring/monitoring.rb
@@ -214,7 +214,7 @@ module LogStash
 
         template_path = ::File.join(::File.dirname(__FILE__), "..", "template.cfg.erb")
         template = ::File.read(template_path)
-        ERB.new(template, 3).result(data.get_binding)
+        ERB.new(template).result(data.get_binding)
       end
 
       private


### PR DESCRIPTION

## What does this PR do?

Fixes deprecated instances of ERB.new( <params> ) and deprecated use of BigDecimal.new