### PR TITLE
8.9 Release notes updated.

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -59,12 +59,6 @@ This commit adds settings support for file-based certificates and cipher suites 
 ==== Updates to dependencies
 
 * Update Bundler to version 2.4 https://github.com/elastic/logstash/pull/14995[#14995]
-* Update snakeyaml to `2.0`
-* Update commons-io to `2.13.0`
-* Update commons-compress to `1.23.0`
-* Update jrjackson to `0.4.18`
-* Update jackson to `2.15.2`
-* Update databind to `2.15.2`
 
 ==== Plugins
 


### PR DESCRIPTION
8.9 release note mentions about `snakeyaml => 2.0` (similarly with `jackson` & `commons`) dependency update which will happen in 8.10 version.