### PR TITLE
Doc: Logstash ingest pipelines

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -112,6 +112,21 @@ include::static/config-management.asciidoc[]
 
 include::static/management/configuring-centralized-pipelines.asciidoc[]
 
+// Data resiliency
+include::static/resiliency.asciidoc[]
+
+include::static/mem-queue.asciidoc[]
+
+include::static/persistent-queues.asciidoc[]
+
+include::static/dead-letter-queues.asciidoc[]
+
+// Transforming Data
+include::static/transforming-data.asciidoc[]
+
+// Ingest pipeline processing in Logstash
+include::static/ls-ingest-pipeline.asciidoc[]
+
 // Working with Logstash Modules
 include::static/modules.asciidoc[]
 
@@ -127,17 +142,6 @@ include::static/filebeat-modules.asciidoc[]
 // Working with Winlogbeat Modules
 include::static/winlogbeat-modules.asciidoc[]
 
-// Data resiliency
-include::static/resiliency.asciidoc[]
-
-include::static/mem-queue.asciidoc[]
-
-include::static/persistent-queues.asciidoc[]
-
-include::static/dead-letter-queues.asciidoc[]
-
-// Transforming Data
-include::static/transforming-data.asciidoc[]
 
 // Deploying & Scaling
 include::static/deploying.asciidoc[]

--- a/docs/static/ls-ingest-pipeline.asciidoc
+++ b/docs/static/ls-ingest-pipeline.asciidoc
@@ -1,0 +1,26 @@
+[[ls-ingest-pipeline]]
+== Enriching data using {ls} ingest pipelines
+
+Do you want to collect sensitive, important data from endpoints quickly, but you need to transform the data before it is indexed into {es}? 
+{ls} ingest pipelines can help.
+
+{ls} ingest pipelines bring the power of {ref}/ingest.html[{es} ingest pipelines] into {ls} so that you can transform data _before_ it is sent to {es}.
+Legal, regulatory, or privacy reasons are common use cases, creating the need to obfuscate or redact some data before it goes to {es} for storage.  
+ 
+[discrete]
+[[how-to-set]]
+=== Add {ls} ingest pipeline processing
+
+{ls} ingest pipeline functionality is implemented as a filter plugin, and is easy to integrate into new or existing {ls} pipeline configurations. 
+Add and configure the logstash-filter-elastic_integration filter as the _first_ filter in your {ls} pipeline. 
+
+// ToDo: Add code sample
+// ToDo: Add link to plugin doc for settings and additional instructions after those docs are published.
+// For now: https://github.com/elastic/logstash-filter-elastic_integration
+
+Can set at the logstash or pipeline level 
+
+As with other plugins, you can set up ingest pipelines at the {ls} level in {logstash-ref}/logstash-settings-file.html[`logstash.yml`], or at the pipeline level in {logstash-ref}/logstash-settings-file.html[`pipelines.yml`]. 
+
+TIP: Check out {integrations-docs}[{agent} integrations] to see the list of available integrations. 
+

--- a/docs/static/ls-ingest-pipeline.asciidoc
+++ b/docs/static/ls-ingest-pipeline.asciidoc
@@ -18,9 +18,3 @@ Add and configure the logstash-filter-elastic_integration filter as the _first_ 
 // ToDo: Add link to plugin doc for settings and additional instructions after those docs are published.
 // For now: https://github.com/elastic/logstash-filter-elastic_integration
 
-Can set at the logstash or pipeline level 
-
-As with other plugins, you can set up ingest pipelines at the {ls} level in {logstash-ref}/logstash-settings-file.html[`logstash.yml`], or at the pipeline level in {logstash-ref}/logstash-settings-file.html[`pipelines.yml`]. 
-
-TIP: Check out {integrations-docs}[{agent} integrations] to see the list of available integrations. 
-


### PR DESCRIPTION
Related: 
* Issue #15172

Adds initial conceptual and "how to" info for Logstash Ingest pipelines. This doc is the conceptual counterpart to the `logstash-filter-elastic_integration` docs that focus on configuration and settings. 

**PREVIEW:**  https://logstash_15225.docs-preview.app.elstc.co/guide/en/logstash/master/ls-ingest-pipeline.html