### PR TITLE
doc: remove breaking change tags

### DIFF
--- a/docs/static/breaking-changes-80.asciidoc
+++ b/docs/static/breaking-changes-80.asciidoc
@@ -1,13 +1,7 @@
 [[breaking-8.0]]
 === Breaking changes in 8.0
 Here are the breaking changes for 8.0.
-//NOTE: The notable-breaking-changes tagged regions are reused in the
-//Installation and Upgrade Guide.
-//Fully qualified links are required for reused content.
-//The anchor-only approach that works within a guide won't resolve
-//across guides.
 
-// tag::notable-breaking-changes[]
 [discrete]
 [[security-on-8.0]]
 ===== Secure communication with {es} 
@@ -63,5 +57,3 @@ The Field Reference parser interprets references to fields in your pipelines and
 Its behavior was configurable in 6.x, and 7.x allowed only a single option: `strict`.
 8.0 no longer recognizes the setting, but maintains the same behavior as the `strict` setting.
 {ls} rejects ambiguous and illegal inputs as standard behavior.
-// end::notable-breaking-changes[]
-

--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -26,4 +26,4 @@ include::breaking-changes-70.asciidoc[]
 include::breaking-changes-pre63.asciidoc[]
 include::breaking-changes-60.asciidoc[]
 
-Check out out <<releasenotes>> for additional release information.
+Check out our <<releasenotes>> for additional release information.

--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -26,8 +26,4 @@ include::breaking-changes-70.asciidoc[]
 include::breaking-changes-pre63.asciidoc[]
 include::breaking-changes-60.asciidoc[]
 
-Check out out <<releasenotes>> for additional release information. 
-
-//NOTE: The notable-breaking-changes tagged regions are re-used in the
-//Installation and Upgrade Guide
-
+Check out out <<releasenotes>> for additional release information.


### PR DESCRIPTION
## Release notes
[rn:skip]


## What does this PR do?

Removes tags for notable breaking changes and related comments.

## Why is it important/What is the impact to the user?

With https://github.com/elastic/stack-docs/pull/2495 merged, we no longer need tags to reuse breaking changes in the Stack Install/Upgrade guide.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Related issues

https://github.com/elastic/platform-docs-team/issues/143
