### PR TITLE
[8.9] doc: remove breaking change tags (#15231)

### DIFF
--- a/docs/static/breaking-changes-80.asciidoc
+++ b/docs/static/breaking-changes-80.asciidoc
@@ -1,13 +1,7 @@
 [[breaking-8.0]]
 === Breaking changes in 8.0
 Here are the breaking changes for 8.0.
-//NOTE: The notable-breaking-changes tagged regions are reused in the
-//Installation and Upgrade Guide.
-//Fully qualified links are required for reused content.
-//The anchor-only approach that works within a guide won't resolve
-//across guides.
 
-// tag::notable-breaking-changes[]
 [discrete]
 [[security-on-8.0]]
 ===== Secure communication with {es} 
@@ -63,5 +57,3 @@ The Field Reference parser interprets references to fields in your pipelines and
 Its behavior was configurable in 6.x, and 7.x allowed only a single option: `strict`.
 8.0 no longer recognizes the setting, but maintains the same behavior as the `strict` setting.
 {ls} rejects ambiguous and illegal inputs as standard behavior.
-// end::notable-breaking-changes[]
-

--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -26,8 +26,4 @@ include::breaking-changes-70.asciidoc[]
 include::breaking-changes-pre63.asciidoc[]
 include::breaking-changes-60.asciidoc[]
 
-Check out out <<releasenotes>> for additional release information. 
-
-//NOTE: The notable-breaking-changes tagged regions are re-used in the
-//Installation and Upgrade Guide
-
+Check out our <<releasenotes>> for additional release information.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [doc: remove breaking change tags (#15231)](https://github.com/elastic/logstash/pull/15231)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)