### PR TITLE
Fix DeadLetterQueueWriter unable to finalize segment error

### DIFF
--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
@@ -29,6 +29,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -42,6 +43,7 @@ import org.junit.rules.TemporaryFolder;
 import org.logstash.DLQEntry;
 import org.logstash.Event;
 import org.logstash.LockException;
+import org.logstash.Timestamp;
 
 import static junit.framework.TestCase.assertFalse;
 import static org.hamcrest.CoreMatchers.is;
@@ -343,6 +345,90 @@ public class DeadLetterQueueWriterTest {
                     .collect(Collectors.toSet());
             assertEquals(Collections.singleton("10.log"), segments);
         }
+    }
+
+    @Test
+    public void testUpdateOldestSegmentReference() throws IOException {
+        try (DeadLetterQueueWriter sut = DeadLetterQueueWriter
+                .newBuilderWithoutFlusher(dir, 10 * MB, 20 * MB)
+                .build()) {
+
+            final byte[] eventBytes = new DLQEntry(new Event(), "", "", "").serialize();
+
+            try(RecordIOWriter writer = new RecordIOWriter(dir.resolve("9.log"))){
+                writer.writeEvent(eventBytes);
+            }
+
+            try(RecordIOWriter writer = new RecordIOWriter(dir.resolve("10.log"))){
+                writer.writeEvent(eventBytes);
+            }
+
+            try(RecordIOWriter writer = new RecordIOWriter(dir.resolve("8.log"))){
+                writer.writeEvent(eventBytes);
+            }
+
+            // Exercise
+            sut.updateOldestSegmentReference();
+
+            // Verify
+            final Optional<Path> oldestSegmentPath = sut.getOldestSegmentPath();
+            assertTrue(oldestSegmentPath.isPresent());
+            assertEquals("10.log", oldestSegmentPath.get().getFileName().toString());
+        }
+    }
+
+    @Test
+    public void testUpdateOldestSegmentReferenceWithDeletedSegment() throws IOException {
+        try (DeadLetterQueueWriter sut = DeadLetterQueueWriter
+                .newBuilderWithoutFlusher(dir, 10 * MB, 20 * MB)
+                .build()) {
+
+            final byte[] eventBytes = new DLQEntry(new Event(), "", "", "").serialize();
+            try(RecordIOWriter writer = new RecordIOWriter(dir.resolve("9.log"))){
+                writer.writeEvent(eventBytes);
+            }
+
+            try(RecordIOWriter writer = new RecordIOWriter(dir.resolve("10.log"))){
+                writer.writeEvent(eventBytes);
+            }
+
+            // Exercise
+            sut.updateOldestSegmentReference();
+
+            Files.delete(sut.getOldestSegmentPath().get());
+
+            sut.updateOldestSegmentReference();
+
+            // Verify
+            assertEquals("9.log",sut.getOldestSegmentPath().get().getFileName().toString());
+        }
+    }
+
+    @Test
+    public void testReadTimestampOfLastEventInSegment() throws IOException {
+        final Timestamp expectedTimestamp = Timestamp.now();
+        final byte[] eventBytes = new DLQEntry(new Event(), "", "", "", expectedTimestamp).serialize();
+
+        final Path segmentPath = dir.resolve("1.log");
+        try (RecordIOWriter writer = new RecordIOWriter(segmentPath)) {
+            writer.writeEvent(eventBytes);
+        }
+
+        // Exercise
+        Optional<Timestamp> timestamp = DeadLetterQueueWriter.readTimestampOfLastEventInSegment(segmentPath);
+
+        // Verify
+        assertTrue(timestamp.isPresent());
+        assertEquals(expectedTimestamp, timestamp.get());
+    }
+
+    @Test
+    public void testReadTimestampOfLastEventInSegmentWithDeletedSegment() throws IOException {
+        // Exercise
+        Optional<Timestamp> timestamp = DeadLetterQueueWriter.readTimestampOfLastEventInSegment(Path.of("non_existing_file.txt"));
+
+        // Verify
+        assertTrue(timestamp.isEmpty());
     }
 
     @Test

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
@@ -355,15 +355,15 @@ public class DeadLetterQueueWriterTest {
 
             final byte[] eventBytes = new DLQEntry(new Event(), "", "", "").serialize();
 
-            try(RecordIOWriter writer = new RecordIOWriter(dir.resolve("9.log"))){
+            try(RecordIOWriter writer = new RecordIOWriter(dir.resolve("1.log"))){
                 writer.writeEvent(eventBytes);
             }
 
-            try(RecordIOWriter writer = new RecordIOWriter(dir.resolve("10.log"))){
+            try(RecordIOWriter writer = new RecordIOWriter(dir.resolve("2.log"))){
                 writer.writeEvent(eventBytes);
             }
 
-            try(RecordIOWriter writer = new RecordIOWriter(dir.resolve("8.log"))){
+            try(RecordIOWriter writer = new RecordIOWriter(dir.resolve("3.log"))){
                 writer.writeEvent(eventBytes);
             }
 
@@ -373,7 +373,7 @@ public class DeadLetterQueueWriterTest {
             // Verify
             final Optional<Path> oldestSegmentPath = sut.getOldestSegmentPath();
             assertTrue(oldestSegmentPath.isPresent());
-            assertEquals("10.log", oldestSegmentPath.get().getFileName().toString());
+            assertEquals("1.log", oldestSegmentPath.get().getFileName().toString());
         }
     }
 
@@ -384,23 +384,24 @@ public class DeadLetterQueueWriterTest {
                 .build()) {
 
             final byte[] eventBytes = new DLQEntry(new Event(), "", "", "").serialize();
-            try(RecordIOWriter writer = new RecordIOWriter(dir.resolve("9.log"))){
+            try(RecordIOWriter writer = new RecordIOWriter(dir.resolve("1.log"))){
                 writer.writeEvent(eventBytes);
             }
 
-            try(RecordIOWriter writer = new RecordIOWriter(dir.resolve("10.log"))){
+            try(RecordIOWriter writer = new RecordIOWriter(dir.resolve("2.log"))){
                 writer.writeEvent(eventBytes);
             }
 
             // Exercise
             sut.updateOldestSegmentReference();
 
+            // Delete 1.log (oldest)
             Files.delete(sut.getOldestSegmentPath().get());
 
             sut.updateOldestSegmentReference();
 
             // Verify
-            assertEquals("9.log",sut.getOldestSegmentPath().get().getFileName().toString());
+            assertEquals("2.log",sut.getOldestSegmentPath().get().getFileName().toString());
         }
     }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Fixed `DeadLetterQueueWriter` unable to finalize segment - `java.nio.file.NoSuchFileException`

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

For more details about the error, please check the https://github.com/elastic/logstash/issues/15227.

This PR moves the `Files.size(...)` call into the try catch [block](https://github.com/elastic/logstash/pull/15233/files#diff-a0ee6ca8e72a830020520ea556f56e46ec1326e48593d9dfd1f252b70d3af45aR449), that way, when the oldest segment is deleted by the `DeadLetterQueueReader`, no `NoSuchFileException` will be thrown up, and the writter will gracefully  update the oldest segment on the next `updateOldestSegmentReference` invocation (scheduled flush, entry write, delete expired, etc).

It also adds the `volatile` keyword to the shared mutable variables, making sure that all the changes will be instantly visible among all the running threads (scheduler & writer).

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [X] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

- Set up the example pipeline posted here: https://github.com/elastic/logstash/issues/15227
- Change the `DeadLetterQueueWriter#createFlushScheduler` to run more oftetn, it's not mandatory but will make the problem happen much faster:
```diff
- flushScheduler.scheduleAtFixedRate(this::scheduledFlushCheck, 1L, 1L, TimeUnit.SECONDS);
+ flushScheduler.scheduleAtFixedRate(this::scheduledFlushCheck, 1L, 1L, TimeUnit.MILLISECONDS);
```
- Running with the `main` branch code, it should eventually throw a few `java.nio.file.NoSuchFileException`.
- Running with this PR changes, no errors should be raised.

## Related issues

- Closes https://github.com/elastic/logstash/issues/15227
- Closes #15078
