### PR TITLE
Remove DepProxy patch

### DIFF
--- a/rakelib/plugins_docs_dependencies.rake
+++ b/rakelib/plugins_docs_dependencies.rake
@@ -125,7 +125,6 @@ class PluginVersionWorking
   end
 
   def try_plugin(plugin, successful_dependencies)
-    Bundler::DepProxy.__clear!
     builder = Bundler::Dsl.new
     gemfile = LogStash::Gemfile.new(File.new(LogStash::Environment::GEMFILE_PATH, "r+")).load
     gemfile.update(plugin)
@@ -201,14 +200,6 @@ task :generate_plugins_version do
         Signal.trap(signal) do
           block.call
         end
-      end
-    end
-    DepProxy.class_eval do
-      # Bundler caches it's dep-proxy objects (which contain Gem::Dependency objects) from all resolutions.
-      # The Hash itself continues to grow between dependency resolutions and hold up a lot of memory, to avoid
-      # the issue we expose a way of clear-ing the cached objects before each plugin resolution.
-      def self.__clear!
-        @proxies.clear
       end
     end
 


### PR DESCRIPTION
As `Bundler::DepProxy` is removed in [Bundler 2.4.0](https://github.com/rubygems/rubygems/commit/eb697fb827db8e280f2b43bc06e4cc0aa3dc1bbd), this commit removes the patch.

Fixes https://github.com/elastic/docs-tools/issues/91
