### PR TITLE
Fix the update of Puma

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -33,4 +33,3 @@ gem "webmock", "~> 3", :group => :development
 gem "jar-dependencies", "= 0.4.1" # Gem::LoadError with jar-dependencies 0.4.2
 gem "murmurhash3", "= 0.1.6" # Pins until version 0.1.7-java is released
 gem "thwait"
-gem "puma", ">= 6.3.1"

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "concurrent-ruby", "~> 1", "< 1.1.10" # pinned until https://github.com/elastic/logstash/issues/13956
   gem.add_runtime_dependency "rack", '~> 2'
   gem.add_runtime_dependency "sinatra", '~> 2'
-  gem.add_runtime_dependency 'puma', '~> 6.3', '>= 6.0.0'
+  gem.add_runtime_dependency 'puma', '~> 6.3', '>= 6.3.1'
   gem.add_runtime_dependency "jruby-openssl", "~> 0.11"
 
   gem.add_runtime_dependency "treetop", "~> 1" #(MIT license)


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?
Revert PR #15267 which updated Puma in Gemfile.template and correctly place it in logstash-core.gemspec, beeing a dependency of Logstash core.