### PR TITLE
disable xpack API and monitoring pipeline for serverless

### DIFF
--- a/x-pack/lib/config_management/elasticsearch_source.rb
+++ b/x-pack/lib/config_management/elasticsearch_source.rb
@@ -132,7 +132,7 @@ module LogStash
         es.build_client
       end
 
-      def populate_license_state(xpack_info)
+      def populate_license_state(xpack_info, is_serverless)
         if xpack_info.failed?
           {
               :state => :error,
@@ -171,7 +171,7 @@ module LogStash
           }
         else
           unless xpack_info.feature_enabled?(FEATURE_EXTERNAL)
-            logger.warn('Monitoring installed and enabled in Logstash, but not enabled in Elasticsearch')
+            logger.warn('Central Pipeline Management is enabled in Logstash, but not enabled in Elasticsearch')
           end
 
           { :state => :ok, :log_level => :info, :log_message => 'Configuration Management License OK' }

--- a/x-pack/lib/license_checker/license_manager.rb
+++ b/x-pack/lib/license_checker/license_manager.rb
@@ -21,11 +21,11 @@ module LogStash
         @license_reader = reader
         @feature = feature
 
-        fetch_xpack_info
+        fetch_license
 
         if @executor.nil?
             @executor = Executors.new_single_thread_scheduled_executor { |runnable| create_daemon_thread (runnable)}
-            @executor.schedule_at_fixed_rate(Proc.new {fetch_xpack_info}, refresh_period, refresh_period, refresh_unit)
+            @executor.schedule_at_fixed_rate(Proc.new {fetch_license}, refresh_period, refresh_period, refresh_unit)
         end
       end
 
@@ -39,6 +39,26 @@ module LogStash
         update_xpack_info(xpack_info)
       end
 
+      def fetch_cluster_info
+        @cluster_info = @license_reader.fetch_cluster_info
+      end
+
+      def build_flavor
+        @cluster_info&.dig('version', 'build_flavor')
+      end
+      def serverless?
+        build_flavor == 'serverless'
+      end
+
+      def fetch_license
+        fetch_cluster_info
+        if serverless?
+          update_xpack_info XPackInfo::SERVERLESS_20231031
+        else
+          fetch_xpack_info
+        end
+      end
+
       private
       def update_xpack_info(xpack_info)
         return if xpack_info == @xpack_info
@@ -46,7 +66,7 @@ module LogStash
         @xpack_info = xpack_info
         logger.debug('updating observers of xpack info change') if logger.debug?
         changed
-        notify_observers(current_xpack_info)
+        notify_observers(current_xpack_info, serverless?)
       end
 
       # Create a daemon thread for the license checker to stop this thread from keeping logstash running in the

--- a/x-pack/lib/license_checker/license_manager.rb
+++ b/x-pack/lib/license_checker/license_manager.rb
@@ -53,7 +53,7 @@ module LogStash
       def fetch_license
         fetch_cluster_info
         if serverless?
-          update_xpack_info XPackInfo::SERVERLESS_20231031
+          update_xpack_info XPackInfo.serverless_response
         else
           fetch_xpack_info
         end

--- a/x-pack/lib/license_checker/license_reader.rb
+++ b/x-pack/lib/license_checker/license_reader.rb
@@ -48,6 +48,20 @@ module LogStash
         XPackInfo.failed_to_fetch
       end
 
+      def fetch_cluster_info
+        retry_handler = ::LogStash::Helpers::LoggableTry.new(logger, 'fetch Elasticsearch cluster info')
+        begin
+          response = retry_handler.try(10.times, ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError) {
+            client.get("/")
+          }
+          return response
+        rescue => e
+          logger.error("Unable to retrieve Elasticsearch cluster info.", message: e.message, exception: e.class)
+        end
+
+        {}
+      end
+
       ##
       # @api private
       def client

--- a/x-pack/lib/license_checker/x_pack_info.rb
+++ b/x-pack/lib/license_checker/x_pack_info.rb
@@ -55,6 +55,7 @@ module LogStash
       end
 
       def feature_enabled?(feature)
+        return false if @features.nil?
         return false unless @features.include?(feature)
         return false unless @features[feature].fetch('available', false)
 
@@ -97,6 +98,141 @@ module LogStash
       def self.failed_to_fetch
         XPackInfo.new(nil, nil, false, true)
       end
+
+      # "Elastic-Api-Version": "2023-10-31" is the first API version available in serverless
+      SERVERLESS_20231031 = XPackInfo.from_es_response(
+        {
+          "license" =>
+            {
+              "type" => "enterprise",
+              "mode" => "enterprise",
+              "status" => "active"
+            },
+          "features" =>
+            {
+              "aggregate_metric" =>
+                {
+                  "available" => true,
+                  "enabled" => true
+                },
+              "analytics" =>
+                {
+                  "available" => true,
+                  "enabled" => true
+                },
+              "archive" =>
+                {
+                  "available" => true,
+                  "enabled" => true
+                },
+              "ccr" =>
+                {
+                  "available" => true,
+                  "enabled" => true
+                },
+              "cluster =>monitor/xpack/info/ilm" =>
+                {
+                  "available" => false,
+                  "enabled" => false
+                },
+              "cluster =>monitor/xpack/info/monitoring" =>
+                {
+                  "available" => false,
+                  "enabled" => false
+                },
+              "cluster =>monitor/xpack/info/searchable_snapshots" =>
+                {
+                  "available" => false,
+                  "enabled" => false
+                },
+              "cluster =>monitor/xpack/info/voting_only" =>
+                {
+                  "available" => false,
+                  "enabled" => false
+                },
+              "cluster =>monitor/xpack/info/watcher" =>
+                {
+                  "available" => false,
+                  "enabled" => false
+                },
+              "data_streams" =>
+                {
+                  "available" => true,
+                  "enabled" => true
+                },
+              "data_tiers" =>
+                {
+                  "available" => true,
+                  "enabled" => true
+                },
+              "enrich" =>
+                {
+                  "available" => true,
+                  "enabled" => true
+                },
+              "enterprise_search" =>
+                {
+                  "available" => true,
+                  "enabled" => true
+                },
+              "eql" =>
+                {
+                  "available" => true,
+                  "enabled" => true
+                },
+              "frozen_indices" =>
+                {
+                  "available" => true,
+                  "enabled" => true
+                },
+              "graph" =>
+                {
+                  "available" => true,
+                  "enabled" => true
+                },
+              "logstash" =>
+                {
+                  "available" => true,
+                  "enabled" => true
+                },
+              "ml" =>
+                {
+                  "available" => true,
+                  "enabled" => true
+                },
+              "rollup" =>
+                {
+                  "available" => true,
+                  "enabled" => true
+                },
+              "security" =>
+                {
+                  "available" => true,
+                  "enabled" => true
+                },
+              "slm" =>
+                {
+                  "available" => true,
+                  "enabled" => true
+                },
+              "spatial" =>
+                {
+                  "available" => true,
+                  "enabled" => true
+                },
+              "sql" =>
+                {
+                  "available" => true,
+                  "enabled" => true
+                },
+              "transform" =>
+                {
+                  "available" => true,
+                  "enabled" => true
+                }
+            }
+        }
+      ).freeze
     end
   end
 end

--- a/x-pack/lib/license_checker/x_pack_info.rb
+++ b/x-pack/lib/license_checker/x_pack_info.rb
@@ -99,6 +99,10 @@ module LogStash
         XPackInfo.new(nil, nil, false, true)
       end
 
+      def self.serverless_response
+        SERVERLESS_20231031
+      end
+
       # "Elastic-Api-Version": "2023-10-31" is the first API version available in serverless
       SERVERLESS_20231031 = XPackInfo.from_es_response(
         {

--- a/x-pack/lib/modules/module_license_checker.rb
+++ b/x-pack/lib/modules/module_license_checker.rb
@@ -36,7 +36,7 @@ module LogStash
         @setup = true
       end
 
-      def populate_license_state(xpack_info)
+      def populate_license_state(xpack_info, is_serverless)
         if xpack_info.failed?
           {
               :state => :error,

--- a/x-pack/lib/monitoring/internal_pipeline_source.rb
+++ b/x-pack/lib/monitoring/internal_pipeline_source.rb
@@ -78,7 +78,7 @@ module LogStash module Monitoring
           :state => :error,
           :log_level => :error,
           :log_message => "Internal collection for monitoring is enabled in Logstash, but is not supported in the configured version of Elasticsearch.\n"\
-            "Please configure Elastic Agent to monitor Logstash. Documentation can be found at: \n"\
+            "This instance of Logstash will NOT send its monitoring data to Elasticsearch. Please configure Elastic Agent to monitor Logstash. Documentation can be found at: \n"\
             "https://www.elastic.co/guide/en/logstash/current/monitoring-with-elastic-agent.html"
         }
       elsif !xpack_info.license_active?

--- a/x-pack/lib/monitoring/internal_pipeline_source.rb
+++ b/x-pack/lib/monitoring/internal_pipeline_source.rb
@@ -77,7 +77,10 @@ module LogStash module Monitoring
         {
           :state => :error,
           :log_level => :error,
-          :log_message => "Monitoring installed and enabled in Logstash, but not supported in Elasticsearch"
+          :log_message => "Monitoring installed and enabled in Logstash, but not supported in Elasticsearch.\n"\
+            "Internal collectors option for Logstash monitoring is deprecated and targeted for removal in the next major version.\n"\
+            "Please configure Metricbeat to monitor Logstash. Documentation can be found at: \n"\
+            "https://www.elastic.co/guide/en/logstash/current/monitoring-with-metricbeat.html"
         }
       elsif !xpack_info.license_active?
         {

--- a/x-pack/lib/monitoring/internal_pipeline_source.rb
+++ b/x-pack/lib/monitoring/internal_pipeline_source.rb
@@ -77,7 +77,7 @@ module LogStash module Monitoring
         {
           :state => :error,
           :log_level => :error,
-          :log_message => "Monitoring installed and enabled in Logstash, but not supported in Elasticsearch.\n"\
+          :log_message => "Internal collection for monitoring is enabled in Logstash, but is not supported in the configured version of Elasticsearch.\n"\
             "Please configure Elastic Agent to monitor Logstash. Documentation can be found at: \n"\
             "https://www.elastic.co/guide/en/logstash/current/monitoring-with-elastic-agent.html"
         }

--- a/x-pack/lib/monitoring/internal_pipeline_source.rb
+++ b/x-pack/lib/monitoring/internal_pipeline_source.rb
@@ -78,9 +78,8 @@ module LogStash module Monitoring
           :state => :error,
           :log_level => :error,
           :log_message => "Monitoring installed and enabled in Logstash, but not supported in Elasticsearch.\n"\
-            "Internal collectors option for Logstash monitoring is deprecated and targeted for removal in the next major version.\n"\
-            "Please configure Metricbeat to monitor Logstash. Documentation can be found at: \n"\
-            "https://www.elastic.co/guide/en/logstash/current/monitoring-with-metricbeat.html"
+            "Please configure Elastic Agent to monitor Logstash. Documentation can be found at: \n"\
+            "https://www.elastic.co/guide/en/logstash/current/monitoring-with-elastic-agent.html"
         }
       elsif !xpack_info.license_active?
         {

--- a/x-pack/lib/monitoring/monitoring.rb
+++ b/x-pack/lib/monitoring/monitoring.rb
@@ -139,8 +139,8 @@ module LogStash
 
         deprecation_logger.deprecated(
             "Internal collectors option for Logstash monitoring is deprecated and targeted for removal in the next major version.\n"\
-            "Please configure Metricbeat to monitor Logstash. Documentation can be found at: \n"\
-            "https://www.elastic.co/guide/en/logstash/current/monitoring-with-metricbeat.html"
+            "Please configure Elastic Agent to monitor Logstash. Documentation can be found at: \n"\
+            "https://www.elastic.co/guide/en/logstash/current/monitoring-with-elastic-agent.html"
             )
 
         logger.trace("registering the metrics pipeline")

--- a/x-pack/spec/modules/module_license_checker_spec.rb
+++ b/x-pack/spec/modules/module_license_checker_spec.rb
@@ -14,6 +14,7 @@ describe LogStash::LicenseChecker::ModuleLicenseChecker do
   shared_examples "can not get a license" do
     before(:each) {
       expect(subject).to receive(:license_reader).and_return(mock_reader)
+      expect(mock_reader).to receive(:fetch_cluster_info).and_return({})
       expect(mock_reader).to receive(:fetch_xpack_info).and_return(LogStash::LicenseChecker::XPackInfo.failed_to_fetch)
     }
     let(:mock_reader) {double("reader")}
@@ -26,6 +27,7 @@ describe LogStash::LicenseChecker::ModuleLicenseChecker do
   shared_examples "can get a license" do
     before(:each) {
       expect(subject).to receive(:license_reader).and_return(mock_reader)
+      expect(mock_reader).to receive(:fetch_cluster_info).and_return(cluster_info)
       expect(mock_reader).to receive(:fetch_xpack_info).and_return(xpack_info)
     }
     let(:mock_reader) {double("reader")}

--- a/x-pack/spec/support/helpers.rb
+++ b/x-pack/spec/support/helpers.rb
@@ -90,3 +90,20 @@ module LogStash
     end
   end
 end
+
+def cluster_info(version = LOGSTASH_VERSION, build_flavour = "default")
+  {"name" => "MacBook-Pro",
+   "cluster_name" => "elasticsearch",
+   "cluster_uuid" => "YgpKq8VkTJuGTSb9aidlIA",
+   "version" =>
+     {"number" => "#{version}",
+      "build_flavor" => "#{build_flavour}",
+      "build_type" => "tar",
+      "build_hash" => "26eb422dc55236a1c5625e8a73e5d866e54610a2",
+      "build_date" => "2020-09-24T09:37:06.459350Z",
+      "build_snapshot" => true,
+      "lucene_version" => "8.7.0",
+      "minimum_wire_compatibility_version" => "7.17.0",
+      "minimum_index_compatibility_version" => "7.0.0"},
+   "tagline" => "You Know, for Search"}
+end


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Added support for Elasticsearch serverless. 
* Added support for central pipeline management
* Disabled legacy monitoring pipeline as serverless does not support monitoring API

## What does this PR do?

Serverless made some changes to API
1. `/_xpack` is for internal users with service account. Logstash does not have permission to call it. xpack features are affected.
2. `/_monitoring/bulk?` is not available which causes Logstash legacy monitoring unable to send metrics

This commit adds a call to identify serverless cluster before fetching `/_xpack` to verify the license and supported features. 
When it is serverless, the license checker uses hardcoded xpack info instead of calling xpack API. The internal pipeline of monitoring is disabled and logs error when configured to use legacy monitoring.

One concern about the header `Elastic-Api-Version`. Logstash is using LogStash::Outputs::ElasticSearch to communicate with Elasticsearch, which is a dependency to es-output plugin. The http client is wrapped inside the plugin and the caller cannot add header to request or lookup header in response, which limits us to evolve with the project.

## Why is it important/What is the impact to the user?

This change allows Logstash to use central pipeline management in serverless and points user to monitor with metricbeat

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Suggest to test against qa serverless endpoint
take the endpoint and api_key from Vault `vault read secret/ci/elastic-logstash/serverless-test`
use `es_host` and `ls_plugin_api_key`
```
xpack.management.enabled: true
xpack.management.elasticsearch.hosts: 
xpack.management.elasticsearch.api_key: 

xpack.monitoring.enabled: true
xpack.monitoring.elasticsearch.hosts: 
xpack.monitoring.elasticsearch.api_key: 
```


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes: https://github.com/elastic/ingest-dev/issues/2303
- Closes: https://github.com/elastic/ingest-dev/issues/2284

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
