### PR TITLE
Sonar integration with Java Tests code coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,9 @@ buildscript {
 plugins {
     id "de.undercouch.download" version "4.0.4"
     id "com.dorongold.task-tree" version "2.1.0"
+//    id "jacoco"
+//    id "org.sonarqube" version "4.3.0.3225"
 }
-
 
 apply plugin: 'de.undercouch.download'
 apply from: "rubyUtils.gradle"
@@ -57,7 +58,6 @@ allprojects {
   apply plugin: 'java'
   apply plugin: 'idea'
   apply plugin: 'java-library'
-
   project.sourceCompatibility = JavaVersion.VERSION_11
   project.targetCompatibility = JavaVersion.VERSION_11
 
@@ -860,7 +860,7 @@ if (System.getenv('OSS') != 'true') {
      dependsOn copyPluginTestAlias
      dependsOn ":logstash-xpack:rubyTests"
  }
- tasks.register("runXPackIntegrationTests"){
+ tasks.register("runXPackIntegrationTests") {
      dependsOn copyPluginTestAlias
      dependsOn ":logstash-xpack:rubyIntegrationTests"
  }

--- a/ci/docker_run.sh
+++ b/ci/docker_run.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 # Syntax is docker_run.sh IMAGE_NAME SCRIPT_NAME *EXTRA_DOCKER_OPTS
 
-set -x # We want verbosity here, this mostly runs on CI and we want to easily debug stuff
-
 #Note - ensure that the -e flag is NOT set, and explicitly check the $? status to allow for clean up
-
 REMOVE_IMAGE=false
 DOCKER_EXTERNAL_JDK=""
 if [ -z "$branch_specifier" ]; then
@@ -16,7 +13,7 @@ else
 fi
 
 if [ "$OSS" == "true" ]; then
-  DOCKER_ENV_OPTS="${DOCKER_ENV_OPTS} --env OSS=true"
+  DOCKER_ENV_OPTS="${DOCKER_ENV_OPTS} -e OSS=true"
 fi
 
 echo "Running Docker CI build for '$IMAGE_NAME' "

--- a/ci/docker_unit_tests.sh
+++ b/ci/docker_unit_tests.sh
@@ -1,2 +1,10 @@
 #!/bin/bash
-ci/docker_run.sh logstash-unit-tests ci/unit_tests.sh $@
+# Init vault
+VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+export VAULT_TOKEN
+unset VAULT_ROLE_ID VAULT_SECRET_ID
+
+SONAR_TOKEN=$(vault read -field=token secret/logstash-ci/sonar-creds)
+unset VAULT_TOKEN
+DOCKER_ENV_OPTS="-e SONAR_TOKEN=${SONAR_TOKEN} -e SOURCE_BRANCH=$ghprbSourceBranch -e TARGET_BRANCH=$ghprbTargetBranch -e PULL_ID=$ghprbPullId -e COMMIT_SHA=$branch_specifier" \
+ ci/docker_run.sh logstash-unit-tests ci/unit_tests.sh $@

--- a/ci/unit_tests.sh
+++ b/ci/unit_tests.sh
@@ -19,11 +19,19 @@ SELECTED_TEST_SUITE=$1
 
 if [[ $SELECTED_TEST_SUITE == $"java" ]]; then
   echo "Running Java Tests"
-  ./gradlew javaTests --console=plain --warning-mode all
+  ./gradlew javaTests jacocoTestReport sonar -Dsonar.token="${SONAR_TOKEN}" \
+    -Dsonar.host.url=https://sonar.elastic.dev \
+    -Dsonar.projectKey=elastic_logstash_AYm_nEbQaV3I-igkX1q9 \
+    -Dsonar.projectName=logstash \
+    -Dsonar.pullrequest.key=$PULL_ID \
+    -Dsonar.pullrequest.branch=$SOURCE_BRANCH \
+    -Dsonar.pullrequest.base=$TARGET_BRANCH \
+    -Dsonar.scm.revision=$COMMIT_SHA \
+    --console=plain --warning-mode all
 elif [[ $SELECTED_TEST_SUITE == $"ruby" ]]; then
   echo "Running Ruby unit tests"
   ./gradlew rubyTests --console=plain --warning-mode all
 else
   echo "Running Java and Ruby unit tests"
-  ./gradlew test --console=plain
+  ./gradlew test jacocoTestReport sonar -Dsonar.token="${SONAR_TOKEN}" --console=plain --warning-mode all
 fi

--- a/ci/unit_tests.sh
+++ b/ci/unit_tests.sh
@@ -33,5 +33,5 @@ elif [[ $SELECTED_TEST_SUITE == $"ruby" ]]; then
   ./gradlew rubyTests --console=plain --warning-mode all
 else
   echo "Running Java and Ruby unit tests"
-  ./gradlew test jacocoTestReport sonar -Dsonar.token="${SONAR_TOKEN}" --console=plain --warning-mode all
+  ./gradlew test --console=plain
 fi

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -17,6 +17,39 @@
  * under the License.
  */
 
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.yaml:snakeyaml:${snakeYamlVersion}"
+    }
+}
+
+plugins {
+    id "jacoco"
+    id "org.sonarqube" version "4.3.0.3225"
+}
+
+apply plugin: 'jacoco'
+apply plugin: "org.sonarqube"
+
+repositories {
+    mavenCentral()
+}
+
+sonarqube {
+    properties {
+        property 'sonar.coverage.jacoco.xmlReportPaths', "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"
+    }
+}
+
+jacoco {
+    toolVersion = "0.8.9"
+}
+
+
 import org.yaml.snakeyaml.Yaml
 
 // fetch version from Logstash's main versions.yml file
@@ -29,19 +62,6 @@ String jacksonDatabindVersion = versionMap['jackson-databind']
 String jrubyVersion = versionMap['jruby']['version']
 
 String log4jVersion = '2.17.1'
-
-repositories {
-    mavenCentral()
-}
-
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.yaml:snakeyaml:${snakeYamlVersion}"
-    }
-}
 
 tasks.register("sourcesJar", Jar) {
     dependsOn classes
@@ -102,7 +122,22 @@ tasks.register("javaTests", Test) {
     exclude '/org/logstash/plugins/CounterMetricImplTest.class'
     exclude '/org/logstash/plugins/factory/PluginFactoryExtTest.class'
     exclude '/org/logstash/execution/ObservedExecutionTest.class'
+
+    jacoco {
+        enabled = true
+        destinationFile = layout.buildDirectory.file('jacoco/test.exec').get().asFile
+        classDumpDir = layout.buildDirectory.dir('jacoco/classpathdumps').get().asFile
+    }
 }
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        html.enabled true
+    }
+}
+
+javaTests.finalizedBy(jacocoTestReport)
 
 tasks.register("rubyTests", Test) {
     inputs.files fileTree("${projectDir}/lib")


### PR DESCRIPTION

## What does this PR do?

Enables sonarqube code scanning and coverage reports for logstash-core. 
[Sonar project for logstash](https://sonar.elastic.dev/dashboard?id=elastic_logstash_AYm_nEbQaV3I-igkX1q9) is already created.

This configuration provides:

**Pull request analysis**: Analyses newly added code for a particular pull request
SonarQube automatically adds a comment with digest information. If no java files were changed in a pull request we will see “No coverage/duplication information” labels

**Branch analysis**: Runs on branches like main and analyzes the entire codebase. Associates received code coverage with the branch


## Why is it important?

Continuous static analysis and solid code coverage help us maintain well-designed and reliable code.

Furthermore we can setup desired quality gates for our [logstash sonar project](https://sonar.elastic.dev/dashboard?id=elastic_logstash_AYm_nEbQaV3I-igkX1q9), i.e. minimal coverage threshold for the new code and for branches analysis. 

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [ ] Sonarqube provides code coverage information on pull requests
- [ ] Sonarqube dashboard is properly setup and clearly represents branches and PR state
- [ ] Quality gate is set up and aligned with the team
- [ ] Quality profile is set up and aligned with the team

## How to test this PR locally

```
SONAR_TOKEN=$(vault read -field=token secret/ci/elastic-logstash/sonar-creds)
./gradlew javaTests jacocoTestReport sonar -Dsonar.token="${SONAR_TOKEN}" --console=plain --warning-mode all
```
## Related issues

- Closes https://github.com/elastic/ingest-dev/issues/2280
