### PR TITLE
artifacts: use PY 3.11 for building docker artifacts

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 ELASTIC_REGISTRY ?= docker.elastic.co
-PY_VERSION ?= 3.6.13
+PY_VERSION ?= 3.11.5
 export PATH := ./bin:$(HOME)/.pyenv/bin:$(HOME)/.pyenv/shims:./venv/bin:$(PATH)
 
 # Determine the version to build.


### PR DESCRIPTION
PY 3.6 is EOL and attempts to build it on Ubuntu 22.04 with GCC-11 result in a segfault

## Release notes

[rn:skip]

## What does this PR do?

Attempts to ensure that docker artifacts build even if they get routed to an Ubuntu 22.04 host that can't install python 3.6.

## Why is it important/What is the impact to the user?

Not much impact on the user, but should simplify the process of getting a clean build regardless of which OS host our acceptance tests are routed to. I don't know if it is safe to jump all the way from Python 3.6 to 3.11, and presume that since it is just minor orchestration things will either fail in an obvious way or succeed.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~


## Author's Checklist

- [ ] green build of [`multijob-docker-acceptance`](https://logstash-ci.elastic.co/view/DRA/job/elastic+logstash+8.10+multijob-docker-acceptance/10/) in which at least one of the sub-job hosts is Ubuntu 22.04
- [ ] manual validation of built docker images 


