### PR TITLE
buildkite serverless test against main

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -45,7 +45,7 @@ spec:
           access_level: READ_ONLY
       schedules:
         Daily serverless test on core_serverless_test branch:
-          branch: core_serverless_test
+          branch: main
           cronline: "@daily"
           message: "Run the serverless integration test every day."
 

--- a/qa/integration/specs/dlq_spec.rb
+++ b/qa/integration/specs/dlq_spec.rb
@@ -66,7 +66,7 @@ describe "Test Dead Letter Queue" do
   let!(:settings_dir) { Stud::Temporary.directory }
   let(:serverless_es_config) do
     if serverless?
-      " hosts => '${ES_ENDPOINT}' api_key => '${LS_PLUGIN_API_KEY}'"
+      " hosts => '${ES_ENDPOINT}' api_key => '${PLUGIN_API_KEY}'"
     else
       ""
     end


### PR DESCRIPTION
switch the testing branch to `main` and fix variable name PLUGIN_API_KEY.
Tests are green locally and should be green on buildkite