### PR TITLE
Fix releasenotes.asciidoc for 8.10.1

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -47,9 +47,7 @@ This section summarizes the changes in the following releases:
 [[logstash-8-10-1]]
 === Logstash 8.10.1 Release Notes
 
-[[notable-8.10.1]]
-==== Notable issues fixed
-* Fix Null Pointer Exception (NPE) when getting a native thread's id during shutdown https://github.com/elastic/logstash/pull/15321[#15321]
+No user-facing changes in Logstash core and plugins.
 
 [[logstash-8-10-0]]
 === Logstash 8.10.0 Release Notes


### PR DESCRIPTION
Since the DRA build for 8.10.1 was made with 82daae80bbaf8b1e62cde93bcf518b88a417193c , this fix didn't get in.