### PR TITLE
[DRA,buildkite] Use AWS aarch64 instance type

### DIFF
--- a/.buildkite/scripts/dra/generatesteps.py
+++ b/.buildkite/scripts/dra/generatesteps.py
@@ -57,7 +57,7 @@ def package_aarch64_docker_step(branch, workflow_type):
   key: "logstash_build_aarch64_docker_dra"
   agents:
     provider: aws
-    imagePrefix: platform-ingest-logstash-linux-arm64-ubuntu-2204-aarch64
+    image: ami-01605dfc76c2bee47
     instanceType: "m6g.4xlarge"
     diskSizeGb: 200
   command: |

--- a/.buildkite/scripts/dra/generatesteps.py
+++ b/.buildkite/scripts/dra/generatesteps.py
@@ -56,14 +56,10 @@ def package_aarch64_docker_step(branch, workflow_type):
 - label: ":package: Build aarch64 Docker / {branch}-{workflow_type.upper()} DRA artifacts"
   key: "logstash_build_aarch64_docker_dra"
   agents:
-    provider: gcp
-    imageProject: elastic-images-qa
-    image: family/platform-ingest-logstash-ubuntu-2204-aarch64
-    machineType: "t2a-standard-8"
+    provider: aws
+    imagePrefix: platform-ingest-logstash-linux-arm64-ubuntu-2204-aarch64
+    instanceType: "m6g.4xlarge"
     diskSizeGb: 200
-    region: 'us-central1'
-    # so far only these regions support t2a instance types
-    zones: "us-central1-a,us-central1-b,us-central1-f"
   command: |
     export WORKFLOW_TYPE="{workflow_type}"
     export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH"

--- a/.buildkite/scripts/dra/generatesteps.py
+++ b/.buildkite/scripts/dra/generatesteps.py
@@ -57,7 +57,7 @@ def package_aarch64_docker_step(branch, workflow_type):
   key: "logstash_build_aarch64_docker_dra"
   agents:
     provider: aws
-    image: ami-01605dfc76c2bee47
+    imagePrefix: platform-ingest-logstash-ubuntu-2204-aarch64
     instanceType: "m6g.4xlarge"
     diskSizeGb: 200
   command: |


### PR DESCRIPTION
We've spotted network flakiness downloading artifacts with gradle (connection resets) when using GCP/t2a on us-central1.
This commit switches to AWS Graviton instance types for building the aarch64 artifacts.
