### PR TITLE
[DRA, buildkite] Use GCP vms for package build step

### DIFF
--- a/.buildkite/scripts/dra/generatesteps.py
+++ b/.buildkite/scripts/dra/generatesteps.py
@@ -26,7 +26,6 @@ def package_x86_step(branch, workflow_type):
   command: |
     export WORKFLOW_TYPE="{workflow_type}"
     export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH"
-    export ARCH="x86_64"
     eval "$(rbenv init -)"
     .buildkite/scripts/dra/build_packages.sh
 '''

--- a/.buildkite/scripts/dra/generatesteps.py
+++ b/.buildkite/scripts/dra/generatesteps.py
@@ -18,13 +18,15 @@ def package_x86_step(branch, workflow_type):
 - label: ":package: Build packages / {branch}-{workflow_type.upper()} DRA artifacts"
   key: "logstash_build_packages_dra"
   agents:
-    image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-logstash-ci:0.2"
-    cpu: "8"
-    memory: "16Gi"
-    ephemeralStorage: "200Gi"
+    provider: gcp
+    imageProject: elastic-images-qa
+    image: family/platform-ingest-logstash-ubuntu-2204
+    machineType: "n2-standard-16"
+    diskSizeGb: 200
   command: |
     export WORKFLOW_TYPE="{workflow_type}"
-    export PATH="/usr/local/rbenv/bin:$PATH"
+    export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH"
+    export ARCH="x86_64"
     eval "$(rbenv init -)"
     .buildkite/scripts/dra/build_packages.sh
 '''


### PR DESCRIPTION
We seem to be hitting a weird issue with the psych gem when running in a container:

```

> Task :bootstrap
2023-09-27T15:13:23.844Z [Execution worker Thread 5] WARN FilenoUtil : Native subprocess control requires open access to the JDK IO subsystem
Pass '--add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED' to enable.
Error Errno::ENOENT, retrying 1/10
No such file or directory - /buildkite/builds/bk-agent-prod-k8s-1695827479442731913/elastic/logstash-dra-pipeline-ci/vendor/bundle/jruby/3.1.0/gems/psych-5.1.0-java/deps.lst
```

This commit works around this problem by running inside a VM. The underlying root cause (and that gradle should be erroring in this case) will be investigated separately.
