### PR TITLE
Updates installDefaultGems task to replace Xerces

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -325,9 +325,17 @@ tasks.register("bootstrap"){
 
 tasks.register("installDefaultGems") {
     dependsOn bootstrap
-  doLast {
+    doLast {
       rake(projectDir, buildDir, 'plugin:install-default')
-  }
+
+      // overwrites Xerces bundled with nokogiri 1.12.5
+      String xercesDownloadUrl = "https://repo1.maven.org/maven2/xerces/xercesImpl/2.12.2/xercesImpl-2.12.2.jar"
+      download {
+          description "Download Xerces from ${xercesDownloadUrl}"
+          src xercesDownloadUrl
+          dest new File("${projectDir}/vendor/bundle/jruby/2.5.0/gems/nokogiri-1.12.5-java/lib/", "xercesImpl.jar")
+      }
+    }
 }
 
 tasks.register("installTestGems") {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Replaces the Xerces version shipped with Nokogiri

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Run the `installDefaultGems` and verify the version `xercesImpl`:
```sh 
./gradlew clean installDefaultGems
cp vendor/bundle/jruby/2.5.0/gems/nokogiri-1.12.5-java/lib/xercesImpl.jar /tmp
cd /tmp
jar xf xercesImpl.jar
grep -B1 "org.apache.xerces.impl.Version" META-INF/MANIFEST.MF
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #15325 
