### PR TITLE
Bundle `logstash-integration-logstash` plugin.

### DIFF
--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -420,6 +420,10 @@
     "default-plugins": true,
     "skip-list": false
   },
+  "logstash-integration-logstash": {
+    "default-plugins": true,
+    "skip-list": false
+  },
   "logstash-integration-rabbitmq": {
     "default-plugins": true,
     "skip-list": false


### PR DESCRIPTION
### Description
We have developed [Logstash integration](https://github.com/logstash-plugins/logstash-integration-logstash) plugin which is recommended when using ls-to-ls communication. With this PR, we are embedding the plugin into the core that by default plugin will be available to use.

### Test
- Clean install with default gems will create a `Gemfile` which includes logstash integration plugin.
`./gradlew clean bootstrap assemble installDefaultGems`

- Closes #15335 