### PR TITLE
[buildkite, DRA] Replicate Jenkins umask

### DIFF
--- a/.buildkite/scripts/dra/common.sh
+++ b/.buildkite/scripts/dra/common.sh
@@ -45,3 +45,5 @@ if [[ ! -z $DRA_DRY_RUN && $BUILDKITE_STEP_KEY == "logstash_publish_dra" ]]; the
     info "Release manager will run in dry-run mode [$DRA_DRY_RUN]"
 fi
 
+# Replicate same default umask used on Jenkins workers
+umask 0022


### PR DESCRIPTION
Jenkins workers have a different default umask (0022 vs 0002 on Buildkite) which affects the default permissions of some artifacts (e.g. .deb)

This commit explicitly sets the right umask so that Jenkins and Buildkite DRA artifacts are identical.

Example from a [Jenkins artifact](https://artifacts-snapshot.elastic.co/logstash/8.11.0-2c9314d9/summary-8.11.0-SNAPSHOT.html) built on Sep 27 2023::

```
# extract deb file
$ ar x logstash-8.11.0-SNAPSHOT-amd64.deb

$ tar tzvf data.tar.gz | grep aws-sdk-sqs-1.62.0.gemspec
-rw-r--r-- 0/0            1543 2023-09-27 02:18 ./usr/share/logstash/vendor/bundle/jruby/3.1.0/specifications/aws-sdk-sqs-1.62.0.gemspec
```

Example from a [BK artifact](https://artifacts-snapshot.elastic.co/logstash/8.11.0-5515183e/summary-8.11.0-SNAPSHOT.html) with an old umask:

```
$ tar tzvf data.tar.gz | grep aws-sdk-sqs-1.62.0.gemspec
-rw-rw-r-- 0/0            1543 2023-09-27 19:49 ./usr/share/logstash/vendor/bundle/jruby/3.1.0/specifications/aws-sdk-sqs-1.62.0.gemspec
```

Example with this PR (gem version changed in the mean time -- please ignore it -- but notice the permissions in the first column):

```
$ tar tzvf data.tar.gz | grep aws-sdk-sqs-1.63.0.gemspec
-rw-r--r-- 0/0            1543 2023-09-28 06:49 ./usr/share/logstash/vendor/bundle/jruby/3.1.0/specifications/aws-sdk-sqs-1.63.0.gemspec
```