### PR TITLE
[buildkite, DRA] Replicate Jenkins umask

### DIFF
--- a/.buildkite/scripts/dra/build_packages.sh
+++ b/.buildkite/scripts/dra/build_packages.sh
@@ -6,6 +6,8 @@ echo "####################################################################"
 
 source ./$(dirname "$0")/common.sh
 
+info "umask value is [$(umask)]"
+
 # WORKFLOW_TYPE is a CI externally configured environment variable that could assume "snapshot" or "staging" values
 case "$WORKFLOW_TYPE" in
     snapshot)

--- a/.buildkite/scripts/dra/common.sh
+++ b/.buildkite/scripts/dra/common.sh
@@ -44,6 +44,3 @@ export DRA_DRY_RUN=$(buildkite-agent meta-data get DRA_DRY_RUN --default "")
 if [[ ! -z $DRA_DRY_RUN && $BUILDKITE_STEP_KEY == "logstash_publish_dra" ]]; then
     info "Release manager will run in dry-run mode [$DRA_DRY_RUN]"
 fi
-
-# Replicate same default umask used on Jenkins workers
-umask 0022

--- a/.buildkite/scripts/dra/common.sh
+++ b/.buildkite/scripts/dra/common.sh
@@ -45,3 +45,5 @@ if [[ ! -z $DRA_DRY_RUN && $BUILDKITE_STEP_KEY == "logstash_publish_dra" ]]; the
     info "Release manager will run in dry-run mode [$DRA_DRY_RUN]"
 fi
 
+# Replicate same default umask used on Jenkins workers
+umask 0022

--- a/.buildkite/scripts/dra/generatesteps.py
+++ b/.buildkite/scripts/dra/generatesteps.py
@@ -24,10 +24,12 @@ def package_x86_step(branch, workflow_type):
     machineType: "n2-standard-16"
     diskSizeGb: 200
   command: |
+    umask 0022
+    echo "--- umask is [$(umask)]"
     export WORKFLOW_TYPE="{workflow_type}"
     export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH"
     eval "$(rbenv init -)"
-    .buildkite/scripts/dra/build_packages.sh
+    umask 0022; .buildkite/scripts/dra/build_packages.sh
 '''
 
     return step

--- a/.buildkite/scripts/dra/generatesteps.py
+++ b/.buildkite/scripts/dra/generatesteps.py
@@ -24,12 +24,11 @@ def package_x86_step(branch, workflow_type):
     machineType: "n2-standard-16"
     diskSizeGb: 200
   command: |
-    umask 0022
     echo "--- umask is [$(umask)]"
     export WORKFLOW_TYPE="{workflow_type}"
     export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH"
     eval "$(rbenv init -)"
-    umask 0022; .buildkite/scripts/dra/build_packages.sh
+    .buildkite/scripts/dra/build_packages.sh
 '''
 
     return step


### PR DESCRIPTION
Jenkins workers have a different default umask (0022 vs 0002 on Buildkite) which affects the default permissions of some artifacts (e.g. .deb)

This commit explicitly sets the right umask so that Jenkins and Buildkite DRA artifacts are identical.

Example from a [Jenkins artifact](https://artifacts-snapshot.elastic.co/logstash/8.11.0-2c9314d9/summary-8.11.0-SNAPSHOT.html) built on Sep 27 2023::

```
# extract deb file
$ ar x logstash-8.11.0-SNAPSHOT-amd64.deb

$ tar tzvf data.tar.gz | grep aws-sdk-sqs-1.62.0.gemspec
-rw-r--r-- 0/0            1543 2023-09-27 02:18 ./usr/share/logstash/vendor/bundle/jruby/3.1.0/specifications/aws-sdk-sqs-1.62.0.gemspec
```

Example from a [BK artifact](https://artifacts-snapshot.elastic.co/logstash/8.11.0-5515183e/summary-8.11.0-SNAPSHOT.html) with an old umask:

```
$ tar tzvf data.tar.gz | grep aws-sdk-sqs-1.62.0.gemspec
-rw-rw-r-- 0/0            1543 2023-09-27 19:49 ./usr/share/logstash/vendor/bundle/jruby/3.1.0/specifications/aws-sdk-sqs-1.62.0.gemspec
```

Example with this PR (gem version changed in the mean time -- please ignore it -- but notice the permissions in the first column):

```
$ tar tzvf data.tar.gz | grep aws-sdk-sqs-1.63.0.gemspec
-rw-r--r-- 0/0            1543 2023-09-28 06:49 ./usr/share/logstash/vendor/bundle/jruby/3.1.0/specifications/aws-sdk-sqs-1.63.0.gemspec
```