### PR TITLE
[DRA] Remove wait step in buildkite

### DIFF
--- a/.buildkite/dra_pipeline.yml
+++ b/.buildkite/dra_pipeline.yml
@@ -1,28 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 
 steps:
-  - input: "Build parameters"
-    if: build.source != "schedule"
-    fields:
-      - text: "VERSION_QUALIFIER_OPT"
-        key: "VERSION_QUALIFIER_OPT"
-        default: ""
-        required: false
-        hint: "Optional version qualifier for built artifacts e.g.: alpha1,beta1"
-      - select: "DRA DRY-RUN"
-        key: "DRA_DRY_RUN"
-        required: false
-        default: ""
-        options:
-          - label: "True"
-            value: "--dry-run"
-          - label: "False"
-            value: ""
-        hint: "Whether the DRA release manager will actually publish artifacts, or run in dry-run mode."
-
-  - wait: ~
-    if: build.source != "schedule"
-
   - label: ":pipeline: Generate steps"
     command: |
       set -euo pipefail

--- a/.buildkite/scripts/dra/common.sh
+++ b/.buildkite/scripts/dra/common.sh
@@ -38,10 +38,9 @@ STACK_VERSION=`cat versions.yml | sed -n 's/^logstash\:[[:space:]]\([[:digit:]]*
 
 info "Agent is running on architecture [$(uname -i)]"
 
-export VERSION_QUALIFIER_OPT=$(buildkite-agent meta-data get VERSION_QUALIFIER_OPT --default "")
-export DRA_DRY_RUN=$(buildkite-agent meta-data get DRA_DRY_RUN --default "")
+export VERSION_QUALIFIER_OPT=${VERSION_QUALIFIER_OPT:-""}
+export DRA_DRY_RUN=${DRA_DRY_RUN:-""}
 
 if [[ ! -z $DRA_DRY_RUN && $BUILDKITE_STEP_KEY == "logstash_publish_dra" ]]; then
     info "Release manager will run in dry-run mode [$DRA_DRY_RUN]"
 fi
-


### PR DESCRIPTION
DRA artifact builds support two optional parameters `VERSION_QUALIFIER_OPT` and `DRA_DRY_RUN`.
The most important is `VERSION_QUALIFIER_OPT` which should be provided when `alpha1` or similar versions need to be built.

Currently, after clicking new build, the pipeline takes ~20s to assemble the steps and pauses the job waiting for these options to be filled (or just accept the empty defaults) and press continue.

I feel that this could be trappy behavior because the majority of the use cases don't need it, and it's likely that a user manually clicks build and forgets that they'd need to confirm these parameters later on, left with a hanging build.

This commit makes the parameters optional. If needed, they should be defined explicitly in the New Build prompt, after expanding the Options section.

The downside of this approach is that when needed, users need to consult the documentation about the environment variable names.
