### PR TITLE
Add bigdecimal > 3.1 dependency.

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -33,3 +33,4 @@ gem "webmock", "~> 3", :group => :development
 gem "jar-dependencies", "= 0.4.1" # Gem::LoadError with jar-dependencies 0.4.2
 gem "murmurhash3", "= 0.1.6" # Pins until version 0.1.7-java is released
 gem "thwait"
+gem "bigdecimal", "~> 3.1"


### PR DESCRIPTION
### Description
During the bump minor workflow run, somehow `bigdecimal` old `1.4.4` version is resolved it cannot be installed.
This PR adds proper `bigdecimal` dependency to template file make sure what version we need.

```
checking RUBY_BIGDECIMAL_VERSION... 1.4.4
checking for labs() in stdlib.h... *** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.
...
In Gemfile:
  logstash-integration-jdbc was resolved to 5.4.6, which depends on
    sequel was resolved to 5.73.0, which depends on
      bigdecimal
Error: Process completed with exit code 5.
```

### How to test locally
Run the following command which is same with workflow.
```
./gradlew clean installDefaultGems
./vendor/jruby/bin/jruby -S bundle update --all --minor --strict
```

```diff
   remote: logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 8.10.3)
+      logstash-core (= 8.11.0)
 
 PATH
   remote: logstash-core
   specs:
-    logstash-core (8.10.3-java)
+    logstash-core (8.11.0-java)
       cgi (~> 0.3.6)
       clamp (~> 1)
       concurrent-ruby (~> 1, < 1.1.10)
@@ -90,6 +90,7 @@
     belzebuth (0.2.3)
       childprocess
     benchmark-ips (2.12.0)
+    bigdecimal (3.1.4-java)
     bindata (2.4.15)
     buftok (0.2.0)
     builder (3.2.4)
@@ -350,10 +351,10 @@
       logstash-mixin-ecs_compatibility_support (~> 1.0)
       logstash-patterns-core (>= 4.3.0, < 5)
       stud (~> 0.0.22)
-    logstash-filter-http (1.4.3)
+    logstash-filter-http (1.5.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ecs_compatibility_support (~> 1.2)
-      logstash-mixin-http_client (>= 7.2.0, < 9.0.0)
+      logstash-mixin-http_client (>= 7.3.0, < 8.0.0)
       logstash-mixin-validator_support (~> 1.0)
     logstash-filter-json (3.2.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -494,12 +495,12 @@
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ecs_compatibility_support (~> 1.2)
       logstash-mixin-normalize_config_support (~> 1.0)
-    logstash-input-http_poller (5.4.0)
+    logstash-input-http_poller (5.5.0)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ecs_compatibility_support (~> 1.3)
       logstash-mixin-event_support (~> 1.0, >= 1.0.1)
-      logstash-mixin-http_client (>= 7.2.0)
+      logstash-mixin-http_client (>= 7.3.0, < 8.0.0)
       logstash-mixin-scheduler (~> 1.0)
       logstash-mixin-validator_support (~> 1.0)
     logstash-input-imap (3.2.0)
@@ -626,6 +627,13 @@
       logstash-mixin-deprecation_logger_support (~> 1.0)
       manticore (>= 0.5.4, < 1.0.0)
       stud (>= 0.0.22, < 0.1.0)
+    logstash-integration-logstash (0.0.5-java)
+      logstash-codec-json_lines (~> 3.1)
+      logstash-core-plugin-api (>= 2.1.12, <= 2.99)
+      logstash-input-http (>= 3.7.0)
+      logstash-mixin-plugin_factory_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.1)
+      logstash-output-http (>= 5.6.0)
     logstash-integration-rabbitmq (7.3.3-java)
       back_pressure (~> 1.0)
       logstash-codec-json
@@ -641,9 +649,10 @@
       logstash-core (>= 6.0.0)
     logstash-mixin-event_support (1.0.1-java)
       logstash-core (>= 6.8)
-    logstash-mixin-http_client (7.2.0)
+    logstash-mixin-http_client (7.3.0)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-normalize_config_support (~> 1.0)
       manticore (>= 0.8.0, < 1.0.0)
     logstash-mixin-normalize_config_support (1.0.0-java)
       logstash-core (>= 6.8.0)
@@ -652,7 +661,7 @@
     logstash-mixin-scheduler (1.0.1-java)
       logstash-core (>= 7.16)
       rufus-scheduler (>= 3.0.9)
-    logstash-mixin-validator_support (1.0.2-java)
+    logstash-mixin-validator_support (1.1.0-java)
       logstash-core (>= 6.8)
     logstash-output-csv (3.0.9)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -678,9 +687,9 @@
       logstash-core-plugin-api (>= 2.0.0, < 2.99)
     logstash-output-graphite (3.1.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-output-http (5.5.0)
+    logstash-output-http (5.6.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-      logstash-mixin-http_client (>= 7.2.0, < 8.0.0)
+      logstash-mixin-http_client (>= 7.3.0, < 8.0.0)
     logstash-output-lumberjack (3.1.9)
       jls-lumberjack (>= 0.0.26)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -770,7 +779,7 @@
     psych (5.1.0-java)
       jar-dependencies (>= 0.1.7)
     public_suffix (3.1.1)
-    puma (6.3.1-java)
+    puma (6.4.0-java)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.5.2-java)
@@ -783,7 +792,7 @@
     rake (13.0.6)
     redis (4.8.1)
     regexp_parser (2.8.1)
-    reline (0.3.8)
+    reline (0.3.9)
       io-console (~> 0.5)
     rexml (3.2.6)
     rspec (3.12.0)
@@ -842,7 +851,7 @@
     thread_safe (0.3.6-java)
     thwait (0.2.0)
       e2mmap
-    tilt (2.2.0)
+    tilt (2.3.0)
     time (0.2.2)
       date
     timeout (0.3.2)
@@ -881,6 +890,7 @@
 DEPENDENCIES
   belzebuth
   benchmark-ips
+  bigdecimal (~> 3.1)
   childprocess (~> 4)
   ci_reporter_rspec (~> 1)
   faraday (~> 1)
@@ -972,6 +982,7 @@
   logstash-integration-elastic_enterprise_search
   logstash-integration-jdbc
   logstash-integration-kafka
+  logstash-integration-logstash
   logstash-integration-rabbitmq
   logstash-output-csv
   logstash-output-elasticsearch (>= 11.14.0)
```