### PR TITLE
[DRA] Support Buildkite builds from fork PRs

### DIFF
--- a/.buildkite/dra_pipeline.yml
+++ b/.buildkite/dra_pipeline.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 env:
-  BUILDKITE_REFSPEC: '+refs/pull/*/head:refs/remotes/origin/pr/*'
+  BUILDKITE_REFSPEC: '+refs/pull/*:refs/remotes/origin/pr/*'
 
 steps:
   - input: "Build parameters"

--- a/.buildkite/dra_pipeline.yml
+++ b/.buildkite/dra_pipeline.yml
@@ -1,4 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+env:
+  BUILDKITE_REFSPEC: '+refs/pull/*/head:refs/remotes/origin/pr/*'
 
 steps:
   - input: "Build parameters"

--- a/.buildkite/dra_pipeline.yml
+++ b/.buildkite/dra_pipeline.yml
@@ -1,7 +1,4 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
-env:
-  BUILDKITE_REFSPEC: '+refs/pull/*:refs/remotes/origin/pr/*'
-
 steps:
   - input: "Build parameters"
     if: build.source != "schedule"


### PR DESCRIPTION
Currently we can't test PRs created out of a PR from forks (PRs from branches in upstream work) getting "Checkout failed! getting/updating git mirror: exit status 128".

The reason is that the git refspec doesn't know about that and there are a couple of solutions including [agent hooks](https://buildkite.com/docs/agent/v3/hooks#hook-locations) where `BUILDKITE_GIT_FETCH_FLAGS` (experimental for now) can be defined.

In this commit we take the approach of overriding
`BUILDKITE_REFSPEC`[^1] at the pipeline level.

[^1]: https://buildkite.com/docs/pipelines/environment-variables#BUILDKITE_REFSPEC
