### PR TITLE
[ci] Build 7.17 DRA using Ubuntu 20.04

### DIFF
--- a/.buildkite/scripts/dra/generatesteps.py
+++ b/.buildkite/scripts/dra/generatesteps.py
@@ -20,7 +20,7 @@ def package_x86_step(branch, workflow_type):
   agents:
     provider: gcp
     imageProject: elastic-images-prod
-    image: family/platform-ingest-logstash-ubuntu-2204
+    image: family/platform-ingest-logstash-ubuntu-2004
     machineType: "n2-standard-16"
     diskSizeGb: 200
   command: |
@@ -39,7 +39,7 @@ def package_x86_docker_step(branch, workflow_type):
   agents:
     provider: gcp
     imageProject: elastic-images-prod
-    image: family/platform-ingest-logstash-ubuntu-2204
+    image: family/platform-ingest-logstash-ubuntu-2004
     machineType: "n2-standard-16"
     diskSizeGb: 200
   command: |
@@ -58,7 +58,7 @@ def package_aarch64_docker_step(branch, workflow_type):
   key: "logstash_build_aarch64_docker_dra"
   agents:
     provider: aws
-    imagePrefix: platform-ingest-logstash-ubuntu-2204-aarch64
+    imagePrefix: platform-ingest-logstash-ubuntu-2004-aarch64
     instanceType: "m6g.4xlarge"
     diskSizeGb: 200
   command: |
@@ -79,7 +79,7 @@ def publish_dra_step(branch, workflow_type, depends_on):
   agents:
     provider: gcp
     imageProject: elastic-images-prod
-    image: family/platform-ingest-logstash-ubuntu-2204
+    image: family/platform-ingest-logstash-ubuntu-2004
     machineType: "n2-standard-16"
     diskSizeGb: 200
   command: |


### PR DESCRIPTION
We discovered[^1] that JRuby 9.2 and 9.3 have an issue when using FileUtils with Glibc >2.34 (e.g. on Ubuntu 22.04).

This commit switched to Ubuntu 20.04 VM images for building DRA artifacts with branch 7.17.

Relates: https://github.com/elastic/ingest-dev/issues/1720

[^1]: https://github.com/jruby/jruby/pull/7611#issuecomment-1750387837
