### PR TITLE
[ci] Initial pull request jobs for buildkite

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -1,0 +1,20 @@
+{
+    "jobs": [
+      {
+        "enabled": true,
+        "pipeline_slug": "logstash-pull-request-pipeline",
+        "allow_org_users": true,
+        "allowed_repo_permissions": ["admin", "write"],
+        "allowed_list": ["github-actions[bot]"],
+        "set_commit_status": true,
+        "build_on_commit": true,
+        "build_on_comment": true,
+        "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
+        "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
+        "skip_ci_labels": [ ],
+        "skip_target_branches": [ ],
+        "skip_ci_on_only_changed": [ ],
+        "always_require_ci_on_changed": [ ]
+      }
+    ]
+  }

--- a/.buildkite/pull_request_pipeline.yml
+++ b/.buildkite/pull_request_pipeline.yml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+
+steps:
+  - label: ":passport_control: The Logstash pull request license check"
+    key: "license-check"
+    agent:
+      image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-logstash-ci"
+      cpu: "4"
+      memory: "6Gi"
+      ephemeralStorage: "100Gi"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/container-agent.sh
+      export JRUBY_OPTS="-J-Xmx1g"
+      export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info"
+      ci/license_check.sh -m 4G
+
+  - label: ":rspec: The Logstash pull request unit tests"
+    key: "ruby-unit-tests"
+    agent:
+      image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-logstash-ci"
+      cpu: "4"
+      memory: "8Gi"
+      ephemeralStorage: "100Gi"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/container-agent.sh
+      ci/unit_tests.sh ruby

--- a/.buildkite/scripts/common/container-agent.sh
+++ b/.buildkite/scripts/common/container-agent.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# ********************************************************
+# This file contains prerequisite bootstrap invocations
+# required for Logstash CI when using containerized agents
+# ********************************************************
+
+set -euo pipefail
+
+export PATH="/usr/local/rbenv/bin:$PATH"
+eval "$(rbenv init -)"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -213,6 +213,62 @@ spec:
 # SECTION END: DRA pipelines
 # ***********************************
 
+# ***********************************
+# SECTION START: Pull requests
+# ***********************************
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: logstash-pull-request-pipeline
+  description: 'Logstash Pull Request pipeline'
+  links:
+    - title: 'Logstash Pull Request pipeline'
+      url: https://buildkite.com/elastic/logstash-pull-request-pipeline
+spec:
+  type: buildkite-pipeline
+  owner: group:logstash
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: logstash-pull-request-pipeline
+      description: ':logstash: Testing for Logstash Pull Requests'
+    spec:
+      pipeline_file: ".buildkite/pull_request_pipeline.yml"
+      branch_configuration: "main 7.* 8.* v7.* v8.* feature/.*"
+      provider_settings:
+        build_pull_request_forks: false
+        build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
+        build_tags: true
+        filter_enabled: true
+        filter_condition: >-
+          build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
+      cancel_intermediate_builds: true
+      cancel_intermediate_builds_branch_filter: '!main !7.* !8.*'
+      skip_intermediate_builds: true
+      skip_intermediate_builds_branch_filter: '!main !7.* !8.*'
+      env:
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'false' # don't alert during development
+        SLACK_NOTIFICATIONS_CHANNEL: '#logstash-build'
+        SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
+      teams:
+        ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        logstash:
+          access_level: MANAGE_BUILD_AND_READ
+        ingest-eng-prod:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+
+# ***********************************
+# SECTION END: Pull requests
+# ***********************************
+
 # ********************************************
 # Declare supported plugin tests pipeline
 # ********************************************

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -239,7 +239,6 @@ spec:
       description: ':logstash: Testing for Logstash Pull Requests'
     spec:
       pipeline_file: ".buildkite/pull_request_pipeline.yml"
-      branch_configuration: "main 7.* 8.* v7.* v8.* feature/.*"
       provider_settings:
         build_pull_request_forks: false
         build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
@@ -248,9 +247,7 @@ spec:
         filter_condition: >-
           build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
       cancel_intermediate_builds: true
-      cancel_intermediate_builds_branch_filter: '!main !7.* !8.*'
       skip_intermediate_builds: true
-      skip_intermediate_builds_branch_filter: '!main !7.* !8.*'
       env:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'false' # don't alert during development
         SLACK_NOTIFICATIONS_CHANNEL: '#logstash-build'


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit adds a Buildkite resource for pull requests and associated the first two jobs, license checking and ruby unit tests.

As this is WiP, slack notifications aren't enabled.

## Related issues

https://github.com/elastic/ingest-dev/issues/1721

