### PR TITLE
[ci] Add missing repository in Buildkite PR

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -238,6 +238,7 @@ spec:
       name: logstash-pull-request-pipeline
       description: ':logstash: Testing for Logstash Pull Requests'
     spec:
+      repository: elastic/logstash
       pipeline_file: ".buildkite/pull_request_pipeline.yml"
       provider_settings:
         build_pull_request_forks: false


### PR DESCRIPTION
## Release notes
[rn:skip]


## What does this PR do?

PR #15402 missed the required repository property for the Buildkite pull request resource.

## Related issues

- #15402

