### PR TITLE
[ci] Don't trigger BK PR jobs on pushes

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -243,7 +243,8 @@ spec:
       provider_settings:
         build_pull_request_forks: false
         build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
-        build_tags: true
+        build_branches: false
+        build_tags: false
         filter_enabled: true
         filter_condition: >-
           build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -247,7 +247,7 @@ spec:
         build_tags: false
         filter_enabled: true
         filter_condition: >-
-          build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
+          build.creator.name == 'elasticmachine' && build.pull_request.id != null
       cancel_intermediate_builds: true
       skip_intermediate_builds: true
       env:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
[rn:skip]

## What does this PR do?

Currently while PR jobs get triggered as expected in Buildkite via the bot, they also get re-triggered after something gets pushed, including e.g. the squash merge commit when the PR is merged.

This commit disables this behavior as documented in Buildkite[^1].

## Related issues

- #15402
- https://github.com/elastic/ingest-dev/issues/1721

[^1]: https://buildkite.com/docs/apis/rest-api/pipelines
