### PR TITLE
[ci] Backport Buildkite PR pipeline to 7.17

### DIFF
--- a/.buildkite/pull_request_pipeline.yml
+++ b/.buildkite/pull_request_pipeline.yml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+
+steps:
+  - label: ":passport_control: License check"
+    key: "license-check"
+    agents:
+      image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-logstash-ci"
+      cpu: "4"
+      memory: "6Gi"
+      ephemeralStorage: "100Gi"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/container-agent.sh
+      export JRUBY_OPTS="-J-Xmx1g"
+      export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info"
+      ci/license_check.sh -m 4G
+
+  - label: ":rspec: Ruby unit tests"
+    key: "ruby-unit-tests"
+    agents:
+      image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-logstash-ci"
+      cpu: "4"
+      memory: "8Gi"
+      ephemeralStorage: "100Gi"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/container-agent.sh
+      ci/unit_tests.sh ruby

--- a/.buildkite/scripts/common/container-agent.sh
+++ b/.buildkite/scripts/common/container-agent.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# ********************************************************
+# This file contains prerequisite bootstrap invocations
+# required for Logstash CI when using containerized agents
+# ********************************************************
+
+set -euo pipefail
+
+export PATH="/usr/local/rbenv/bin:$PATH"
+eval "$(rbenv init -)"


### PR DESCRIPTION
This is a backport of the initial Pull Request pipeline for Buildkite.

While currently we haven't migrated all PR jobs from Jenkins, this is needed so PRs against non `main` branches don't fail this step (also giving us the possibility to test functionality against non `main` branches).

Relates:

- #15402
- #15413
- #15415
- #15421
- https://github.com/elastic/ingest-dev/issues/1721

## Release notes
[rn:skip]
