### PR TITLE
pin psych 5.1.0 due to ruby/psych#655

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -34,3 +34,4 @@ gem "jar-dependencies", "= 0.4.1" # Gem::LoadError with jar-dependencies 0.4.2
 gem "murmurhash3", "= 0.1.6" # Pins until version 0.1.7-java is released
 gem "thwait"
 gem "bigdecimal", "~> 3.1"
+gem "psych", "5.1.0" # pinned due to https://github.com/ruby/psych/issues/655


### PR DESCRIPTION
The new [psych 5.1.1 gem](https://rubygems.org/gems/psych/versions/5.1.1-java) seems to not work when installed in JRuby 9.4 (used in main).

This change pins the version back to 5.1.0 until ruby/psych#655 is sorted.

Closes #15427