### PR TITLE
[ci] Commit PR based Java unit tests for Buildkite

### DIFF
--- a/.buildkite/pull_request_pipeline.yml
+++ b/.buildkite/pull_request_pipeline.yml
@@ -28,3 +28,17 @@ steps:
 
       source .buildkite/scripts/common/container-agent.sh
       ci/unit_tests.sh ruby
+
+  - label: ":java: Java unit tests"
+    key: "java-unit-tests"
+    agents:
+      image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-logstash-ci"
+      cpu: "8"
+      memory: "16Gi"
+      ephemeralStorage: "100Gi"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/container-agent.sh
+      source .buildkite/scripts/pull-requests/sonar-env.sh
+      ci/unit_tests.sh java

--- a/.buildkite/scripts/pull-requests/sonar-env.sh
+++ b/.buildkite/scripts/pull-requests/sonar-env.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+SONAR_TOKEN_PATH="kv/ci-shared/platform-ingest/elastic/logstash/sonar-creds"
+export SONAR_TOKEN=$(retry -t 5 -- vault kv get -field=token ${SONAR_TOKEN_PATH})
+
+export SOURCE_BRANCH=$GITHUB_PR_BRANCH
+export TARGET_BRANCH=$GITHUB_PR_TARGET_BRANCH
+export PULL_ID=$GITHUB_PR_NUMBER
+export COMMIT_SHA=$BUILDKITE_COMMIT


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit adds Java unit tests (including sonar scans) to the Buildkite pull request pipeline.

## Related issues

- https://github.com/elastic/ingest-dev/issues/1721
- https://github.com/elastic/logstash/pull/15279
