### PR TITLE
Migrate remaining PR jobs to Buildkite

### DIFF
--- a/.buildkite/pull_request_pipeline.yml
+++ b/.buildkite/pull_request_pipeline.yml
@@ -42,3 +42,96 @@ steps:
       source .buildkite/scripts/common/container-agent.sh
       source .buildkite/scripts/pull-requests/sonar-env.sh
       ci/unit_tests.sh java
+
+  # Steps below use a no-root variant of the image because they invoke Elasticsearch which doesn't start as root.
+  - label: ":lab_coat: Integration Tests / part 1"
+    key: "integration-tests-part-1"
+    agents:
+      image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-logstash-ci-no-root"
+      cpu: "8"
+      memory: "16Gi"
+      ephemeralStorage: "100Gi"
+      # Run as non root (logstash) user. UID is hardcoded in image.
+      imageUID: "1002"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/container-agent.sh
+      ci/integration_tests.sh split 0
+
+  - label: ":lab_coat: Integration Tests / part 2"
+    key: "integration-tests-part-2"
+    agents:
+      image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-logstash-ci-no-root"
+      cpu: "8"
+      memory: "16Gi"
+      ephemeralStorage: "100Gi"
+      # Run as non root (logstash) user. UID is hardcoded in image.
+      imageUID: "1002"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/container-agent.sh
+      ci/integration_tests.sh split 1
+
+  - label: ":lab_coat: IT Persistent Queues / part 1"
+    key: "integration-tests-qa-part-1"
+    agents:
+      image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-logstash-ci-no-root"
+      cpu: "8"
+      memory: "16Gi"
+      ephemeralStorage: "100Gi"
+      # Run as non root (logstash) user. UID is hardcoded in image.
+      imageUID: "1002"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/container-agent.sh
+      export FEATURE_FLAG=persistent_queues
+      ci/integration_tests.sh split 0
+
+  - label: ":lab_coat: IT Persistent Queues / part 2"
+    key: "integration-tests-qa-part-2"
+    agents:
+      image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-logstash-ci-no-root"
+      cpu: "8"
+      memory: "16Gi"
+      ephemeralStorage: "100Gi"
+      # Run as non root (logstash) user. UID is hardcoded in image.
+      imageUID: "1002"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/container-agent.sh
+      export FEATURE_FLAG=persistent_queues
+      ci/integration_tests.sh split 1
+
+  - label: ":lab_coat: x-pack unit tests"
+    key: "x-pack-unit-tests"
+    agents:
+      image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-logstash-ci-no-root"
+      cpu: "8"
+      memory: "16Gi"
+      ephemeralStorage: "100Gi"
+      # Run as non root (logstash) user. UID is hardcoded in image.
+      imageUID: "1002"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/container-agent.sh
+      x-pack/ci/unit_tests.sh
+
+  - label: ":lab_coat: x-pack integration"
+    key: "integration-tests-x-pack"
+    agents:
+      image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-logstash-ci-no-root"
+      cpu: "8"
+      memory: "16Gi"
+      ephemeralStorage: "100Gi"
+      # Run as non root (logstash) user. UID is hardcoded in image.
+      imageUID: "1002"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/container-agent.sh
+      x-pack/ci/integration_tests.sh

--- a/.buildkite/scripts/common/container-agent.sh
+++ b/.buildkite/scripts/common/container-agent.sh
@@ -7,5 +7,11 @@
 
 set -euo pipefail
 
-export PATH="/usr/local/rbenv/bin:$PATH"
-eval "$(rbenv init -)"
+if [[ $(whoami) == "logstash" ]]
+then
+    export PATH="/home/logstash/.rbenv/bin:$PATH"
+    eval "$(rbenv init -)"
+else
+    export PATH="/usr/local/rbenv/bin:$PATH"
+    eval "$(rbenv init -)"
+fi


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit adds the remaining steps for the Buildkite pull request pipeline i.e.

- `IT Persistent Queues / part 1`
- `IT Persistent Queues / part 2`
- `x-pack unit tests`
- `x-pack integration`

Once merged we will be able to retire the corresponding Logstash pull request multijob.

## Related issues

- https://github.com/elastic/logstash/pull/15438
- https://github.com/elastic/logstash/pull/15437
- https://github.com/elastic/ingest-dev/issues/1721
- https://github.com/elastic/logstash/pull/15279
