### PR TITLE
[ci] Enable Buildkite PR comments

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -254,6 +254,7 @@ spec:
       cancel_intermediate_builds: true
       skip_intermediate_builds: true
       env:
+        ELASTIC_PR_COMMENTS_ENABLED: 'true'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'false' # don't alert during development
         SLACK_NOTIFICATIONS_CHANNEL: '#logstash-build'
         SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit enables automatically updated comments from Buildkite for PRs. It posts comments to PRs whenever a Buildkite build finishes or encounters its first failing step and keeps the comment updated.

## Related issues

https://github.com/elastic/ingest-dev/issues/1721

## Screenshots

The result will be a commit in every PR like this ([internal link](https://github.com/elastic/package-storage-infra/pull/573#issuecomment-1764082444)):

![image](https://github.com/elastic/logstash/assets/1754575/74e89c3a-c46f-4747-80a2-e13b08f29b35)

including a cc to the author of the PR
