### PR TITLE
[ci] Initial aarch64 Buildkite resource

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -272,6 +272,55 @@ spec:
 # SECTION END: Pull requests
 # ***********************************
 
+# *******************************
+# SECTION START: aarch64 pipeline
+# *******************************
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: logstash-aarch64-pipeline
+  description: 'Logstash aarch64 pipeline'
+  links:
+    - title: 'Logstash aarch64 pipeline'
+      url: https://buildkite.com/elastic/logstash-aarch64-pipeline
+spec:
+  type: buildkite-pipeline
+  owner: group:logstash
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: "Logstash aarch64 pipeline"
+      description: ':logstash: Exhaustive tests for the aarch64 architecture'
+    spec:
+      repository: elastic/logstash
+      pipeline_file: ".buildkite/aarch64_pipeline.yml"
+      provider_settings:
+        trigger_mode: none
+      cancel_intermediate_builds: true
+      skip_intermediate_builds: true
+      env:
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'false'  # disabled during development
+        SLACK_NOTIFICATIONS_CHANNEL: '#logstash-build'
+        SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
+      teams:
+        ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        logstash:
+          access_level: MANAGE_BUILD_AND_READ
+        ingest-eng-prod:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+
+# *****************************
+# SECTION END: aarch64 pipeline
+# *****************************
+
 # ********************************************
 # Declare supported plugin tests pipeline
 # ********************************************


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit adds an initial Buildkite resource definition for aarch64 exhaustive tests.

## Related issues

- https://github.com/elastic/ingest-dev/issues/1724

**NOTE**: The actual pipeline is committed separately in a follow up PR to facilitate easy backporting
via the logstashmachine PR bot.
