### PR TITLE
[ci] Initial aarch64 Buildkite pipeline

### DIFF
--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -1,0 +1,3 @@
+steps:
+  - label: "Test aarch64"
+    command: "echo 'Hello world'"


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit adds a skeleton Buildkite pipeline for aarch64 exhaustive tests.

## Related issues

- https://github.com/elastic/logstash/pull/15459
- https://github.com/elastic/ingest-dev/issues/1724
