### PR TITLE
[ci] Specify max timeout for supported plugin test

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -299,6 +299,7 @@ spec:
       repository: elastic/logstash
       pipeline_file: ".buildkite/supported_plugins_test_pipeline.yml"
       skip_intermediate_builds: true
+      maximum_timeout_in_minutes: 120  # https://registry.terraform.io/providers/buildkite/buildkite/latest/docs/resources/pipeline#optional
       provider_settings:
         trigger_mode: none
       teams:


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

Specify a global max timeout of 2 hours that applies to all steps related to the
supported plugin test Buildkite pipeline.

## Why is it important/What is the impact to the user?

Currently there is no timeout and hanging jobs will stay in this state until the agents get deleted.

## Related issues

- #15380
