### PR TITLE
[ci] aarch64 Buildkite pipeline part 1

### DIFF
--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -1,3 +1,84 @@
-steps:
-  - label: "Test aarch64"
-    command: "echo 'Hello world'"
+agents:
+  provider: aws
+  imagePrefix: platform-ingest-logstash-ubuntu-2204-aarch64
+  instanceType: "m6g.4xlarge"
+  diskSizeGb: 200
+
+group:
+  label: "Testing Phase"
+  key: "testing-phase"
+  steps:
+  - label: ":rspec: Ruby unit tests"
+    key: "ruby-unit-tests"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/vm-agent.sh
+      ci/unit_tests.sh ruby
+
+  - label: ":java: Java unit tests"
+    key: "java-unit-tests"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/vm-agent.sh
+      source .buildkite/scripts/pull-requests/sonar-env.sh
+      ci/unit_tests.sh java
+
+  - label: ":lab_coat: Integration Tests / part 1"
+    key: "integration-tests-part-1"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/vm-agent.sh
+      ci/integration_tests.sh split 0
+
+  - label: ":lab_coat: Integration Tests / part 2"
+    key: "integration-tests-part-2"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/vm-agent.sh
+      ci/integration_tests.sh split 1
+
+  - label: ":lab_coat: IT Persistent Queues / part 1"
+    key: "integration-tests-qa-part-1"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/vm-agent.sh
+      export FEATURE_FLAG=persistent_queues
+      ci/integration_tests.sh split 0
+
+  - label: ":lab_coat: IT Persistent Queues / part 2"
+    key: "integration-tests-qa-part-2"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/vm-agent.sh
+      export FEATURE_FLAG=persistent_queues
+      ci/integration_tests.sh split 1
+
+  - label: ":lab_coat: x-pack unit tests"
+    key: "x-pack-unit-tests"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/vm-agent.sh
+      x-pack/ci/unit_tests.sh
+
+  - label: ":lab_coat: x-pack integration"
+    key: "integration-tests-x-pack"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/vm-agent.sh
+      x-pack/ci/integration_tests.sh
+
+group:
+  label: "Acceptance Phase"
+  depends: "testing-phase"
+  key: "acceptance-phase"
+  steps:
+    - label: "Acceptance tests will go here"
+      command: "echo 'Hello world'"

--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -4,81 +4,80 @@ agents:
   instanceType: "m6g.4xlarge"
   diskSizeGb: 200
 
-group:
-  label: "Testing Phase"
-  key: "testing-phase"
-  steps:
-    - label: ":rspec: Ruby unit tests"
-      key: "ruby-unit-tests"
-      command: |
-        set -euo pipefail
+steps:
+  - group: "Testing Phase"
+    key: "testing-phase"
+    steps:
+      - label: ":rspec: Ruby unit tests"
+        key: "ruby-unit-tests"
+        command: |
+          set -euo pipefail
 
-        source .buildkite/scripts/common/vm-agent.sh
-        ci/unit_tests.sh ruby
+          source .buildkite/scripts/common/vm-agent.sh
+          ci/unit_tests.sh ruby
 
-    - label: ":java: Java unit tests"
-      key: "java-unit-tests"
-      command: |
-        set -euo pipefail
+      - label: ":java: Java unit tests"
+        key: "java-unit-tests"
+        command: |
+          set -euo pipefail
 
-        source .buildkite/scripts/common/vm-agent.sh
-        source .buildkite/scripts/pull-requests/sonar-env.sh
-        ci/unit_tests.sh java
+          source .buildkite/scripts/common/vm-agent.sh
+          source .buildkite/scripts/pull-requests/sonar-env.sh
+          ci/unit_tests.sh java
 
-    - label: ":lab_coat: Integration Tests / part 1"
-      key: "integration-tests-part-1"
-      command: |
-        set -euo pipefail
+      - label: ":lab_coat: Integration Tests / part 1"
+        key: "integration-tests-part-1"
+        command: |
+          set -euo pipefail
 
-        source .buildkite/scripts/common/vm-agent.sh
-        ci/integration_tests.sh split 0
+          source .buildkite/scripts/common/vm-agent.sh
+          ci/integration_tests.sh split 0
 
-    - label: ":lab_coat: Integration Tests / part 2"
-      key: "integration-tests-part-2"
-      command: |
-        set -euo pipefail
+      - label: ":lab_coat: Integration Tests / part 2"
+        key: "integration-tests-part-2"
+        command: |
+          set -euo pipefail
 
-        source .buildkite/scripts/common/vm-agent.sh
-        ci/integration_tests.sh split 1
+          source .buildkite/scripts/common/vm-agent.sh
+          ci/integration_tests.sh split 1
 
-    - label: ":lab_coat: IT Persistent Queues / part 1"
-      key: "integration-tests-qa-part-1"
-      command: |
-        set -euo pipefail
+      - label: ":lab_coat: IT Persistent Queues / part 1"
+        key: "integration-tests-qa-part-1"
+        command: |
+          set -euo pipefail
 
-        source .buildkite/scripts/common/vm-agent.sh
-        export FEATURE_FLAG=persistent_queues
-        ci/integration_tests.sh split 0
+          source .buildkite/scripts/common/vm-agent.sh
+          export FEATURE_FLAG=persistent_queues
+          ci/integration_tests.sh split 0
 
-    - label: ":lab_coat: IT Persistent Queues / part 2"
-      key: "integration-tests-qa-part-2"
-      command: |
-        set -euo pipefail
+      - label: ":lab_coat: IT Persistent Queues / part 2"
+        key: "integration-tests-qa-part-2"
+        command: |
+          set -euo pipefail
 
-        source .buildkite/scripts/common/vm-agent.sh
-        export FEATURE_FLAG=persistent_queues
-        ci/integration_tests.sh split 1
+          source .buildkite/scripts/common/vm-agent.sh
+          export FEATURE_FLAG=persistent_queues
+          ci/integration_tests.sh split 1
 
-    - label: ":lab_coat: x-pack unit tests"
-      key: "x-pack-unit-tests"
-      command: |
-        set -euo pipefail
+      - label: ":lab_coat: x-pack unit tests"
+        key: "x-pack-unit-tests"
+        command: |
+          set -euo pipefail
 
-        source .buildkite/scripts/common/vm-agent.sh
-        x-pack/ci/unit_tests.sh
+          source .buildkite/scripts/common/vm-agent.sh
+          x-pack/ci/unit_tests.sh
 
-    - label: ":lab_coat: x-pack integration"
-      key: "integration-tests-x-pack"
-      command: |
-        set -euo pipefail
+      - label: ":lab_coat: x-pack integration"
+        key: "integration-tests-x-pack"
+        command: |
+          set -euo pipefail
 
-        source .buildkite/scripts/common/vm-agent.sh
-        x-pack/ci/integration_tests.sh
+          source .buildkite/scripts/common/vm-agent.sh
+          x-pack/ci/integration_tests.sh
 
-group:
-  label: "Acceptance Phase"
-  depends: "testing-phase"
-  key: "acceptance-phase"
-  steps:
-    - label: "Acceptance tests will go here"
-      command: "echo 'Hello world'"
+  - group: "Acceptance Phase"
+    depends: "testing-phase"
+    key: "acceptance-phase"
+    steps:
+      - label: "Acceptance tests will go here"
+        command: "echo 'Hello world'"

--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -8,72 +8,72 @@ group:
   label: "Testing Phase"
   key: "testing-phase"
   steps:
-  - label: ":rspec: Ruby unit tests"
-    key: "ruby-unit-tests"
-    command: |
-      set -euo pipefail
+    - label: ":rspec: Ruby unit tests"
+      key: "ruby-unit-tests"
+      command: |
+        set -euo pipefail
 
-      source .buildkite/scripts/common/vm-agent.sh
-      ci/unit_tests.sh ruby
+        source .buildkite/scripts/common/vm-agent.sh
+        ci/unit_tests.sh ruby
 
-  - label: ":java: Java unit tests"
-    key: "java-unit-tests"
-    command: |
-      set -euo pipefail
+    - label: ":java: Java unit tests"
+      key: "java-unit-tests"
+      command: |
+        set -euo pipefail
 
-      source .buildkite/scripts/common/vm-agent.sh
-      source .buildkite/scripts/pull-requests/sonar-env.sh
-      ci/unit_tests.sh java
+        source .buildkite/scripts/common/vm-agent.sh
+        source .buildkite/scripts/pull-requests/sonar-env.sh
+        ci/unit_tests.sh java
 
-  - label: ":lab_coat: Integration Tests / part 1"
-    key: "integration-tests-part-1"
-    command: |
-      set -euo pipefail
+    - label: ":lab_coat: Integration Tests / part 1"
+      key: "integration-tests-part-1"
+      command: |
+        set -euo pipefail
 
-      source .buildkite/scripts/common/vm-agent.sh
-      ci/integration_tests.sh split 0
+        source .buildkite/scripts/common/vm-agent.sh
+        ci/integration_tests.sh split 0
 
-  - label: ":lab_coat: Integration Tests / part 2"
-    key: "integration-tests-part-2"
-    command: |
-      set -euo pipefail
+    - label: ":lab_coat: Integration Tests / part 2"
+      key: "integration-tests-part-2"
+      command: |
+        set -euo pipefail
 
-      source .buildkite/scripts/common/vm-agent.sh
-      ci/integration_tests.sh split 1
+        source .buildkite/scripts/common/vm-agent.sh
+        ci/integration_tests.sh split 1
 
-  - label: ":lab_coat: IT Persistent Queues / part 1"
-    key: "integration-tests-qa-part-1"
-    command: |
-      set -euo pipefail
+    - label: ":lab_coat: IT Persistent Queues / part 1"
+      key: "integration-tests-qa-part-1"
+      command: |
+        set -euo pipefail
 
-      source .buildkite/scripts/common/vm-agent.sh
-      export FEATURE_FLAG=persistent_queues
-      ci/integration_tests.sh split 0
+        source .buildkite/scripts/common/vm-agent.sh
+        export FEATURE_FLAG=persistent_queues
+        ci/integration_tests.sh split 0
 
-  - label: ":lab_coat: IT Persistent Queues / part 2"
-    key: "integration-tests-qa-part-2"
-    command: |
-      set -euo pipefail
+    - label: ":lab_coat: IT Persistent Queues / part 2"
+      key: "integration-tests-qa-part-2"
+      command: |
+        set -euo pipefail
 
-      source .buildkite/scripts/common/vm-agent.sh
-      export FEATURE_FLAG=persistent_queues
-      ci/integration_tests.sh split 1
+        source .buildkite/scripts/common/vm-agent.sh
+        export FEATURE_FLAG=persistent_queues
+        ci/integration_tests.sh split 1
 
-  - label: ":lab_coat: x-pack unit tests"
-    key: "x-pack-unit-tests"
-    command: |
-      set -euo pipefail
+    - label: ":lab_coat: x-pack unit tests"
+      key: "x-pack-unit-tests"
+      command: |
+        set -euo pipefail
 
-      source .buildkite/scripts/common/vm-agent.sh
-      x-pack/ci/unit_tests.sh
+        source .buildkite/scripts/common/vm-agent.sh
+        x-pack/ci/unit_tests.sh
 
-  - label: ":lab_coat: x-pack integration"
-    key: "integration-tests-x-pack"
-    command: |
-      set -euo pipefail
+    - label: ":lab_coat: x-pack integration"
+      key: "integration-tests-x-pack"
+      command: |
+        set -euo pipefail
 
-      source .buildkite/scripts/common/vm-agent.sh
-      x-pack/ci/integration_tests.sh
+        source .buildkite/scripts/common/vm-agent.sh
+        x-pack/ci/integration_tests.sh
 
 group:
   label: "Acceptance Phase"

--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -76,7 +76,7 @@ steps:
           x-pack/ci/integration_tests.sh
 
   - group: "Acceptance Phase"
-    depends: "testing-phase"
+    depends_on: "testing-phase"
     key: "acceptance-phase"
     steps:
       - label: "Acceptance tests will go here"

--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -16,14 +16,15 @@ steps:
           source .buildkite/scripts/common/vm-agent.sh
           ci/unit_tests.sh ruby
 
-      - label: ":java: Java unit tests"
-        key: "java-unit-tests"
-        command: |
-          set -euo pipefail
+      ### Temporarily disable since sonar scans imply pull request context
+      # - label: ":java: Java unit tests"
+      #   key: "java-unit-tests"
+      #   command: |
+      #     set -euo pipefail
 
-          source .buildkite/scripts/common/vm-agent.sh
-          source .buildkite/scripts/pull-requests/sonar-env.sh
-          ci/unit_tests.sh java
+      #     source .buildkite/scripts/common/vm-agent.sh
+      #     source .buildkite/scripts/pull-requests/sonar-env.sh
+      #     ci/unit_tests.sh java
 
       - label: ":lab_coat: Integration Tests / part 1"
         key: "integration-tests-part-1"

--- a/.buildkite/scripts/common/vm-agent.sh
+++ b/.buildkite/scripts/common/vm-agent.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# ********************************************************
+# This file contains prerequisite bootstrap invocations
+# required for Logstash CI when using VM/baremetal agents
+# ********************************************************
+
+set -euo pipefail
+
+export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH"
+eval "$(rbenv init -)"


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit is the first part of migrating away the aarch64 Jenkins jobs to Buildkite. It adds a group of exhaustive steps in the aarch64 pipeline.

## Related issues

https://github.com/elastic/ingest-dev/issues/1724
