### PR TITLE
[ci] aarch64 Buildkite pipeline part 2

### DIFF
--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -1,3 +1,84 @@
-steps:
-  - label: "Test aarch64"
-    command: "echo 'Hello world'"
+agents:
+  provider: aws
+  imagePrefix: platform-ingest-logstash-ubuntu-2204-aarch64
+  instanceType: "m6g.4xlarge"
+  diskSizeGb: 200
+
+group:
+  label: "Testing Phase"
+  key: "testing-phase"
+  steps:
+  - label: ":rspec: Ruby unit tests"
+    key: "ruby-unit-tests"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/vm-agent.sh
+      ci/unit_tests.sh ruby
+
+  - label: ":java: Java unit tests"
+    key: "java-unit-tests"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/vm-agent.sh
+      source .buildkite/scripts/pull-requests/sonar-env.sh
+      ci/unit_tests.sh java
+
+  - label: ":lab_coat: Integration Tests / part 1"
+    key: "integration-tests-part-1"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/vm-agent.sh
+      ci/integration_tests.sh split 0
+
+  - label: ":lab_coat: Integration Tests / part 2"
+    key: "integration-tests-part-2"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/vm-agent.sh
+      ci/integration_tests.sh split 1
+
+  - label: ":lab_coat: IT Persistent Queues / part 1"
+    key: "integration-tests-qa-part-1"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/vm-agent.sh
+      export FEATURE_FLAG=persistent_queues
+      ci/integration_tests.sh split 0
+
+  - label: ":lab_coat: IT Persistent Queues / part 2"
+    key: "integration-tests-qa-part-2"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/vm-agent.sh
+      export FEATURE_FLAG=persistent_queues
+      ci/integration_tests.sh split 1
+
+  - label: ":lab_coat: x-pack unit tests"
+    key: "x-pack-unit-tests"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/vm-agent.sh
+      x-pack/ci/unit_tests.sh
+
+  - label: ":lab_coat: x-pack integration"
+    key: "integration-tests-x-pack"
+    command: |
+      set -euo pipefail
+
+      source .buildkite/scripts/common/vm-agent.sh
+      x-pack/ci/integration_tests.sh
+
+group:
+  label: "Acceptance Phase"
+  depends: "testing-phase"
+  key: "acceptance-phase"
+  steps:
+    - label: "Acceptance tests will go here"
+      command: "echo 'Hello world'"

--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -5,87 +5,86 @@ agents:
   diskSizeGb: 200
 
 steps:
-  - group: "Testing Phase"
-    key: "testing-phase"
-    steps:
-      - label: ":rspec: Ruby unit tests"
-        key: "ruby-unit-tests"
-        command: |
-          set -euo pipefail
+  # - group: "Testing Phase"
+  #   key: "testing-phase"
+  #   steps:
+  #     - label: ":rspec: Ruby unit tests"
+  #       key: "ruby-unit-tests"
+  #       command: |
+  #         set -euo pipefail
 
-          source .buildkite/scripts/common/vm-agent.sh
-          ci/unit_tests.sh ruby
+  #         source .buildkite/scripts/common/vm-agent.sh
+  #         ci/unit_tests.sh ruby
 
-      ### Temporarily disable since sonar scans imply pull request context
-      # - label: ":java: Java unit tests"
-      #   key: "java-unit-tests"
-      #   command: |
-      #     set -euo pipefail
+  #     ### Temporarily disable since sonar scans imply pull request context
+  #     # - label: ":java: Java unit tests"
+  #     #   key: "java-unit-tests"
+  #     #   command: |
+  #     #     set -euo pipefail
 
-      #     source .buildkite/scripts/common/vm-agent.sh
-      #     source .buildkite/scripts/pull-requests/sonar-env.sh
-      #     ci/unit_tests.sh java
+  #     #     source .buildkite/scripts/common/vm-agent.sh
+  #     #     source .buildkite/scripts/pull-requests/sonar-env.sh
+  #     #     ci/unit_tests.sh java
 
-      - label: ":lab_coat: Integration Tests / part 1"
-        key: "integration-tests-part-1"
-        command: |
-          set -euo pipefail
+  #     - label: ":lab_coat: Integration Tests / part 1"
+  #       key: "integration-tests-part-1"
+  #       command: |
+  #         set -euo pipefail
 
-          source .buildkite/scripts/common/vm-agent.sh
-          ci/integration_tests.sh split 0
+  #         source .buildkite/scripts/common/vm-agent.sh
+  #         ci/integration_tests.sh split 0
 
-      - label: ":lab_coat: Integration Tests / part 2"
-        key: "integration-tests-part-2"
-        command: |
-          set -euo pipefail
+  #     - label: ":lab_coat: Integration Tests / part 2"
+  #       key: "integration-tests-part-2"
+  #       command: |
+  #         set -euo pipefail
 
-          source .buildkite/scripts/common/vm-agent.sh
-          ci/integration_tests.sh split 1
+  #         source .buildkite/scripts/common/vm-agent.sh
+  #         ci/integration_tests.sh split 1
 
-      - label: ":lab_coat: IT Persistent Queues / part 1"
-        key: "integration-tests-qa-part-1"
-        command: |
-          set -euo pipefail
+  #     - label: ":lab_coat: IT Persistent Queues / part 1"
+  #       key: "integration-tests-qa-part-1"
+  #       command: |
+  #         set -euo pipefail
 
-          source .buildkite/scripts/common/vm-agent.sh
-          export FEATURE_FLAG=persistent_queues
-          ci/integration_tests.sh split 0
+  #         source .buildkite/scripts/common/vm-agent.sh
+  #         export FEATURE_FLAG=persistent_queues
+  #         ci/integration_tests.sh split 0
 
-      - label: ":lab_coat: IT Persistent Queues / part 2"
-        key: "integration-tests-qa-part-2"
-        command: |
-          set -euo pipefail
+  #     - label: ":lab_coat: IT Persistent Queues / part 2"
+  #       key: "integration-tests-qa-part-2"
+  #       command: |
+  #         set -euo pipefail
 
-          source .buildkite/scripts/common/vm-agent.sh
-          export FEATURE_FLAG=persistent_queues
-          ci/integration_tests.sh split 1
+  #         source .buildkite/scripts/common/vm-agent.sh
+  #         export FEATURE_FLAG=persistent_queues
+  #         ci/integration_tests.sh split 1
 
-      - label: ":lab_coat: x-pack unit tests"
-        key: "x-pack-unit-tests"
-        command: |
-          set -euo pipefail
+  #     - label: ":lab_coat: x-pack unit tests"
+  #       key: "x-pack-unit-tests"
+  #       command: |
+  #         set -euo pipefail
 
-          source .buildkite/scripts/common/vm-agent.sh
-          x-pack/ci/unit_tests.sh
+  #         source .buildkite/scripts/common/vm-agent.sh
+  #         x-pack/ci/unit_tests.sh
 
-      - label: ":lab_coat: x-pack integration"
-        key: "integration-tests-x-pack"
-        command: |
-          set -euo pipefail
+  #     - label: ":lab_coat: x-pack integration"
+  #       key: "integration-tests-x-pack"
+  #       command: |
+  #         set -euo pipefail
 
-          source .buildkite/scripts/common/vm-agent.sh
-          x-pack/ci/integration_tests.sh
+  #         source .buildkite/scripts/common/vm-agent.sh
+  #         x-pack/ci/integration_tests.sh
 
   - group: "Acceptance Phase"
-    depends_on: "testing-phase"
+    #depends_on: "testing-phase"
     key: "acceptance-phase"
     steps:
       - label: "Docker [{{matrix}}] flavor acceptance"
         command:
           set -euo pipefail
-
-          source .buildkite/scripts/common/vm-agent.sh
-          ci/docker_acceptance_tests.sh {{matrix}}
+          
+          source .buildkite/scripts/common/vm-agent.sh && ci/docker_acceptance_tests.sh {{matrix}}
         matrix:
           - "full"
           - "oss"

--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -81,8 +81,6 @@ steps:
     key: "acceptance-phase"
     steps:
       - label: "Docker [{{matrix}}] flavor acceptance"
-        env:
-          JAVA_HOME: "/opt/buildkite-agent/.java"
         command:
           set -euo pipefail
           

--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -4,81 +4,80 @@ agents:
   instanceType: "m6g.4xlarge"
   diskSizeGb: 200
 
-group:
-  label: "Testing Phase"
-  key: "testing-phase"
-  steps:
-    - label: ":rspec: Ruby unit tests"
-      key: "ruby-unit-tests"
-      command: |
-        set -euo pipefail
+steps:
+  - group: "Testing Phase"
+    key: "testing-phase"
+    steps:
+      - label: ":rspec: Ruby unit tests"
+        key: "ruby-unit-tests"
+        command: |
+          set -euo pipefail
 
-        source .buildkite/scripts/common/vm-agent.sh
-        ci/unit_tests.sh ruby
+          source .buildkite/scripts/common/vm-agent.sh
+          ci/unit_tests.sh ruby
 
-    - label: ":java: Java unit tests"
-      key: "java-unit-tests"
-      command: |
-        set -euo pipefail
+      - label: ":java: Java unit tests"
+        key: "java-unit-tests"
+        command: |
+          set -euo pipefail
 
-        source .buildkite/scripts/common/vm-agent.sh
-        source .buildkite/scripts/pull-requests/sonar-env.sh
-        ci/unit_tests.sh java
+          source .buildkite/scripts/common/vm-agent.sh
+          source .buildkite/scripts/pull-requests/sonar-env.sh
+          ci/unit_tests.sh java
 
-    - label: ":lab_coat: Integration Tests / part 1"
-      key: "integration-tests-part-1"
-      command: |
-        set -euo pipefail
+      - label: ":lab_coat: Integration Tests / part 1"
+        key: "integration-tests-part-1"
+        command: |
+          set -euo pipefail
 
-        source .buildkite/scripts/common/vm-agent.sh
-        ci/integration_tests.sh split 0
+          source .buildkite/scripts/common/vm-agent.sh
+          ci/integration_tests.sh split 0
 
-    - label: ":lab_coat: Integration Tests / part 2"
-      key: "integration-tests-part-2"
-      command: |
-        set -euo pipefail
+      - label: ":lab_coat: Integration Tests / part 2"
+        key: "integration-tests-part-2"
+        command: |
+          set -euo pipefail
 
-        source .buildkite/scripts/common/vm-agent.sh
-        ci/integration_tests.sh split 1
+          source .buildkite/scripts/common/vm-agent.sh
+          ci/integration_tests.sh split 1
 
-    - label: ":lab_coat: IT Persistent Queues / part 1"
-      key: "integration-tests-qa-part-1"
-      command: |
-        set -euo pipefail
+      - label: ":lab_coat: IT Persistent Queues / part 1"
+        key: "integration-tests-qa-part-1"
+        command: |
+          set -euo pipefail
 
-        source .buildkite/scripts/common/vm-agent.sh
-        export FEATURE_FLAG=persistent_queues
-        ci/integration_tests.sh split 0
+          source .buildkite/scripts/common/vm-agent.sh
+          export FEATURE_FLAG=persistent_queues
+          ci/integration_tests.sh split 0
 
-    - label: ":lab_coat: IT Persistent Queues / part 2"
-      key: "integration-tests-qa-part-2"
-      command: |
-        set -euo pipefail
+      - label: ":lab_coat: IT Persistent Queues / part 2"
+        key: "integration-tests-qa-part-2"
+        command: |
+          set -euo pipefail
 
-        source .buildkite/scripts/common/vm-agent.sh
-        export FEATURE_FLAG=persistent_queues
-        ci/integration_tests.sh split 1
+          source .buildkite/scripts/common/vm-agent.sh
+          export FEATURE_FLAG=persistent_queues
+          ci/integration_tests.sh split 1
 
-    - label: ":lab_coat: x-pack unit tests"
-      key: "x-pack-unit-tests"
-      command: |
-        set -euo pipefail
+      - label: ":lab_coat: x-pack unit tests"
+        key: "x-pack-unit-tests"
+        command: |
+          set -euo pipefail
 
-        source .buildkite/scripts/common/vm-agent.sh
-        x-pack/ci/unit_tests.sh
+          source .buildkite/scripts/common/vm-agent.sh
+          x-pack/ci/unit_tests.sh
 
-    - label: ":lab_coat: x-pack integration"
-      key: "integration-tests-x-pack"
-      command: |
-        set -euo pipefail
+      - label: ":lab_coat: x-pack integration"
+        key: "integration-tests-x-pack"
+        command: |
+          set -euo pipefail
 
-        source .buildkite/scripts/common/vm-agent.sh
-        x-pack/ci/integration_tests.sh
+          source .buildkite/scripts/common/vm-agent.sh
+          x-pack/ci/integration_tests.sh
 
-group:
-  label: "Acceptance Phase"
-  depends: "testing-phase"
-  key: "acceptance-phase"
-  steps:
-    - label: "Acceptance tests will go here"
-      command: "echo 'Hello world'"
+  - group: "Acceptance Phase"
+    depends: "testing-phase"
+    key: "acceptance-phase"
+    steps:
+      - label: "Acceptance tests will go here"
+        command: "echo 'Hello world'"

--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -5,79 +5,79 @@ agents:
   diskSizeGb: 200
 
 steps:
-  # - group: "Testing Phase"
-  #   key: "testing-phase"
-  #   steps:
-  #     - label: ":rspec: Ruby unit tests"
-  #       key: "ruby-unit-tests"
-  #       command: |
-  #         set -euo pipefail
+  - group: "Testing Phase"
+    key: "testing-phase"
+    steps:
+      - label: ":rspec: Ruby unit tests"
+        key: "ruby-unit-tests"
+        command: |
+          set -euo pipefail
 
-  #         source .buildkite/scripts/common/vm-agent.sh
-  #         ci/unit_tests.sh ruby
+          source .buildkite/scripts/common/vm-agent.sh
+          ci/unit_tests.sh ruby
 
-  #     ### Temporarily disable since sonar scans imply pull request context
-  #     # - label: ":java: Java unit tests"
-  #     #   key: "java-unit-tests"
-  #     #   command: |
-  #     #     set -euo pipefail
+      ### Temporarily disable since sonar scans imply pull request context
+      # - label: ":java: Java unit tests"
+      #   key: "java-unit-tests"
+      #   command: |
+      #     set -euo pipefail
 
-  #     #     source .buildkite/scripts/common/vm-agent.sh
-  #     #     source .buildkite/scripts/pull-requests/sonar-env.sh
-  #     #     ci/unit_tests.sh java
+      #     source .buildkite/scripts/common/vm-agent.sh
+      #     source .buildkite/scripts/pull-requests/sonar-env.sh
+      #     ci/unit_tests.sh java
 
-  #     - label: ":lab_coat: Integration Tests / part 1"
-  #       key: "integration-tests-part-1"
-  #       command: |
-  #         set -euo pipefail
+      - label: ":lab_coat: Integration Tests / part 1"
+        key: "integration-tests-part-1"
+        command: |
+          set -euo pipefail
 
-  #         source .buildkite/scripts/common/vm-agent.sh
-  #         ci/integration_tests.sh split 0
+          source .buildkite/scripts/common/vm-agent.sh
+          ci/integration_tests.sh split 0
 
-  #     - label: ":lab_coat: Integration Tests / part 2"
-  #       key: "integration-tests-part-2"
-  #       command: |
-  #         set -euo pipefail
+      - label: ":lab_coat: Integration Tests / part 2"
+        key: "integration-tests-part-2"
+        command: |
+          set -euo pipefail
 
-  #         source .buildkite/scripts/common/vm-agent.sh
-  #         ci/integration_tests.sh split 1
+          source .buildkite/scripts/common/vm-agent.sh
+          ci/integration_tests.sh split 1
 
-  #     - label: ":lab_coat: IT Persistent Queues / part 1"
-  #       key: "integration-tests-qa-part-1"
-  #       command: |
-  #         set -euo pipefail
+      - label: ":lab_coat: IT Persistent Queues / part 1"
+        key: "integration-tests-qa-part-1"
+        command: |
+          set -euo pipefail
 
-  #         source .buildkite/scripts/common/vm-agent.sh
-  #         export FEATURE_FLAG=persistent_queues
-  #         ci/integration_tests.sh split 0
+          source .buildkite/scripts/common/vm-agent.sh
+          export FEATURE_FLAG=persistent_queues
+          ci/integration_tests.sh split 0
 
-  #     - label: ":lab_coat: IT Persistent Queues / part 2"
-  #       key: "integration-tests-qa-part-2"
-  #       command: |
-  #         set -euo pipefail
+      - label: ":lab_coat: IT Persistent Queues / part 2"
+        key: "integration-tests-qa-part-2"
+        command: |
+          set -euo pipefail
 
-  #         source .buildkite/scripts/common/vm-agent.sh
-  #         export FEATURE_FLAG=persistent_queues
-  #         ci/integration_tests.sh split 1
+          source .buildkite/scripts/common/vm-agent.sh
+          export FEATURE_FLAG=persistent_queues
+          ci/integration_tests.sh split 1
 
-  #     - label: ":lab_coat: x-pack unit tests"
-  #       key: "x-pack-unit-tests"
-  #       command: |
-  #         set -euo pipefail
+      - label: ":lab_coat: x-pack unit tests"
+        key: "x-pack-unit-tests"
+        command: |
+          set -euo pipefail
 
-  #         source .buildkite/scripts/common/vm-agent.sh
-  #         x-pack/ci/unit_tests.sh
+          source .buildkite/scripts/common/vm-agent.sh
+          x-pack/ci/unit_tests.sh
 
-  #     - label: ":lab_coat: x-pack integration"
-  #       key: "integration-tests-x-pack"
-  #       command: |
-  #         set -euo pipefail
+      - label: ":lab_coat: x-pack integration"
+        key: "integration-tests-x-pack"
+        command: |
+          set -euo pipefail
 
-  #         source .buildkite/scripts/common/vm-agent.sh
-  #         x-pack/ci/integration_tests.sh
+          source .buildkite/scripts/common/vm-agent.sh
+          x-pack/ci/integration_tests.sh
 
   - group: "Acceptance Phase"
-    # depends_on: "testing-phase"
+    depends_on: "testing-phase"
     key: "acceptance-phase"
     steps:
       - label: "Docker [{{matrix}}] flavor acceptance"
@@ -89,19 +89,20 @@ steps:
           - "full"
           - "oss"
 
-      - label: "Acceptance tests on {{matrix.distribution}}"
-        agents:
-          provider: aws
-          imagePrefix: platform-ingest-logstash-{{matrix.distribution}}-aarch64
-          instanceType: "m6g.4xlarge"
-          diskSizeGb: 200
-        command:
-          set -euo pipefail
+      # *** TODO: enable after clarifying if acceptance tests really need vagrant on aarch64
+      # - label: "Acceptance tests on {{matrix.distribution}}"
+      #   agents:
+      #     provider: aws
+      #     imagePrefix: platform-ingest-logstash-{{matrix.distribution}}-aarch64
+      #     instanceType: "m6g.4xlarge"
+      #     diskSizeGb: 200
+      #   command:
+      #     set -euo pipefail
           
-          source .buildkite/scripts/common/vm-agent.sh && ci/acceptance_tests.sh {{matrix.suite}}
-        matrix:
-          setup:
-            suite:
-              - "debian"
-            distribution:
-              - "ubuntu-2204"
+      #     source .buildkite/scripts/common/vm-agent.sh && ci/acceptance_tests.sh {{matrix.suite}}
+      #   matrix:
+      #     setup:
+      #       suite:
+      #         - "debian"
+      #       distribution:
+      #         - "ubuntu-2204"

--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -5,79 +5,79 @@ agents:
   diskSizeGb: 200
 
 steps:
-  # - group: "Testing Phase"
-  #   key: "testing-phase"
-  #   steps:
-  #     - label: ":rspec: Ruby unit tests"
-  #       key: "ruby-unit-tests"
-  #       command: |
-  #         set -euo pipefail
+  - group: "Testing Phase"
+    key: "testing-phase"
+    steps:
+      - label: ":rspec: Ruby unit tests"
+        key: "ruby-unit-tests"
+        command: |
+          set -euo pipefail
 
-  #         source .buildkite/scripts/common/vm-agent.sh
-  #         ci/unit_tests.sh ruby
+          source .buildkite/scripts/common/vm-agent.sh
+          ci/unit_tests.sh ruby
 
-  #     ### Temporarily disable since sonar scans imply pull request context
-  #     # - label: ":java: Java unit tests"
-  #     #   key: "java-unit-tests"
-  #     #   command: |
-  #     #     set -euo pipefail
+      ### Temporarily disable since sonar scans imply pull request context
+      # - label: ":java: Java unit tests"
+      #   key: "java-unit-tests"
+      #   command: |
+      #     set -euo pipefail
 
-  #     #     source .buildkite/scripts/common/vm-agent.sh
-  #     #     source .buildkite/scripts/pull-requests/sonar-env.sh
-  #     #     ci/unit_tests.sh java
+      #     source .buildkite/scripts/common/vm-agent.sh
+      #     source .buildkite/scripts/pull-requests/sonar-env.sh
+      #     ci/unit_tests.sh java
 
-  #     - label: ":lab_coat: Integration Tests / part 1"
-  #       key: "integration-tests-part-1"
-  #       command: |
-  #         set -euo pipefail
+      - label: ":lab_coat: Integration Tests / part 1"
+        key: "integration-tests-part-1"
+        command: |
+          set -euo pipefail
 
-  #         source .buildkite/scripts/common/vm-agent.sh
-  #         ci/integration_tests.sh split 0
+          source .buildkite/scripts/common/vm-agent.sh
+          ci/integration_tests.sh split 0
 
-  #     - label: ":lab_coat: Integration Tests / part 2"
-  #       key: "integration-tests-part-2"
-  #       command: |
-  #         set -euo pipefail
+      - label: ":lab_coat: Integration Tests / part 2"
+        key: "integration-tests-part-2"
+        command: |
+          set -euo pipefail
 
-  #         source .buildkite/scripts/common/vm-agent.sh
-  #         ci/integration_tests.sh split 1
+          source .buildkite/scripts/common/vm-agent.sh
+          ci/integration_tests.sh split 1
 
-  #     - label: ":lab_coat: IT Persistent Queues / part 1"
-  #       key: "integration-tests-qa-part-1"
-  #       command: |
-  #         set -euo pipefail
+      - label: ":lab_coat: IT Persistent Queues / part 1"
+        key: "integration-tests-qa-part-1"
+        command: |
+          set -euo pipefail
 
-  #         source .buildkite/scripts/common/vm-agent.sh
-  #         export FEATURE_FLAG=persistent_queues
-  #         ci/integration_tests.sh split 0
+          source .buildkite/scripts/common/vm-agent.sh
+          export FEATURE_FLAG=persistent_queues
+          ci/integration_tests.sh split 0
 
-  #     - label: ":lab_coat: IT Persistent Queues / part 2"
-  #       key: "integration-tests-qa-part-2"
-  #       command: |
-  #         set -euo pipefail
+      - label: ":lab_coat: IT Persistent Queues / part 2"
+        key: "integration-tests-qa-part-2"
+        command: |
+          set -euo pipefail
 
-  #         source .buildkite/scripts/common/vm-agent.sh
-  #         export FEATURE_FLAG=persistent_queues
-  #         ci/integration_tests.sh split 1
+          source .buildkite/scripts/common/vm-agent.sh
+          export FEATURE_FLAG=persistent_queues
+          ci/integration_tests.sh split 1
 
-  #     - label: ":lab_coat: x-pack unit tests"
-  #       key: "x-pack-unit-tests"
-  #       command: |
-  #         set -euo pipefail
+      - label: ":lab_coat: x-pack unit tests"
+        key: "x-pack-unit-tests"
+        command: |
+          set -euo pipefail
 
-  #         source .buildkite/scripts/common/vm-agent.sh
-  #         x-pack/ci/unit_tests.sh
+          source .buildkite/scripts/common/vm-agent.sh
+          x-pack/ci/unit_tests.sh
 
-  #     - label: ":lab_coat: x-pack integration"
-  #       key: "integration-tests-x-pack"
-  #       command: |
-  #         set -euo pipefail
+      - label: ":lab_coat: x-pack integration"
+        key: "integration-tests-x-pack"
+        command: |
+          set -euo pipefail
 
-  #         source .buildkite/scripts/common/vm-agent.sh
-  #         x-pack/ci/integration_tests.sh
+          source .buildkite/scripts/common/vm-agent.sh
+          x-pack/ci/integration_tests.sh
 
   - group: "Acceptance Phase"
-    #depends_on: "testing-phase"
+    depends_on: "testing-phase"
     key: "acceptance-phase"
     steps:
       - label: "Docker [{{matrix}}] flavor acceptance"

--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -80,5 +80,14 @@ steps:
     depends_on: "testing-phase"
     key: "acceptance-phase"
     steps:
-      - label: "Acceptance tests will go here"
-        command: "echo 'Hello world'"
+      - label: "Docker [{{matrix}}] flavor acceptance"
+        command:
+          set -euo pipefail
+
+          source .buildkite/scripts/common/vm-agent.sh
+          ci/docker_acceptance_tests.sh ${flavor}
+        env:
+          flavor: "{{matrix}}"
+        matrix:
+          - "full"
+          - "oss"

--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -82,7 +82,7 @@ steps:
     steps:
       - label: "Docker [{{matrix}}] flavor acceptance"
         env:
-          JAVA_HOME: "/opt/buildkite-agent/.java/bin/java"
+          JAVA_HOME: "/opt/buildkite-agent/.java"
         command:
           set -euo pipefail
           

--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -81,6 +81,8 @@ steps:
     key: "acceptance-phase"
     steps:
       - label: "Docker [{{matrix}}] flavor acceptance"
+        env:
+          JAVA_HOME: "/opt/buildkite-agent/.java/bin/java"
         command:
           set -euo pipefail
           

--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -85,9 +85,7 @@ steps:
           set -euo pipefail
 
           source .buildkite/scripts/common/vm-agent.sh
-          ci/docker_acceptance_tests.sh ${flavor}
-        env:
-          flavor: "{{matrix}}"
+          ci/docker_acceptance_tests.sh {{matrix}}
         matrix:
           - "full"
           - "oss"

--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -8,72 +8,72 @@ group:
   label: "Testing Phase"
   key: "testing-phase"
   steps:
-  - label: ":rspec: Ruby unit tests"
-    key: "ruby-unit-tests"
-    command: |
-      set -euo pipefail
+    - label: ":rspec: Ruby unit tests"
+      key: "ruby-unit-tests"
+      command: |
+        set -euo pipefail
 
-      source .buildkite/scripts/common/vm-agent.sh
-      ci/unit_tests.sh ruby
+        source .buildkite/scripts/common/vm-agent.sh
+        ci/unit_tests.sh ruby
 
-  - label: ":java: Java unit tests"
-    key: "java-unit-tests"
-    command: |
-      set -euo pipefail
+    - label: ":java: Java unit tests"
+      key: "java-unit-tests"
+      command: |
+        set -euo pipefail
 
-      source .buildkite/scripts/common/vm-agent.sh
-      source .buildkite/scripts/pull-requests/sonar-env.sh
-      ci/unit_tests.sh java
+        source .buildkite/scripts/common/vm-agent.sh
+        source .buildkite/scripts/pull-requests/sonar-env.sh
+        ci/unit_tests.sh java
 
-  - label: ":lab_coat: Integration Tests / part 1"
-    key: "integration-tests-part-1"
-    command: |
-      set -euo pipefail
+    - label: ":lab_coat: Integration Tests / part 1"
+      key: "integration-tests-part-1"
+      command: |
+        set -euo pipefail
 
-      source .buildkite/scripts/common/vm-agent.sh
-      ci/integration_tests.sh split 0
+        source .buildkite/scripts/common/vm-agent.sh
+        ci/integration_tests.sh split 0
 
-  - label: ":lab_coat: Integration Tests / part 2"
-    key: "integration-tests-part-2"
-    command: |
-      set -euo pipefail
+    - label: ":lab_coat: Integration Tests / part 2"
+      key: "integration-tests-part-2"
+      command: |
+        set -euo pipefail
 
-      source .buildkite/scripts/common/vm-agent.sh
-      ci/integration_tests.sh split 1
+        source .buildkite/scripts/common/vm-agent.sh
+        ci/integration_tests.sh split 1
 
-  - label: ":lab_coat: IT Persistent Queues / part 1"
-    key: "integration-tests-qa-part-1"
-    command: |
-      set -euo pipefail
+    - label: ":lab_coat: IT Persistent Queues / part 1"
+      key: "integration-tests-qa-part-1"
+      command: |
+        set -euo pipefail
 
-      source .buildkite/scripts/common/vm-agent.sh
-      export FEATURE_FLAG=persistent_queues
-      ci/integration_tests.sh split 0
+        source .buildkite/scripts/common/vm-agent.sh
+        export FEATURE_FLAG=persistent_queues
+        ci/integration_tests.sh split 0
 
-  - label: ":lab_coat: IT Persistent Queues / part 2"
-    key: "integration-tests-qa-part-2"
-    command: |
-      set -euo pipefail
+    - label: ":lab_coat: IT Persistent Queues / part 2"
+      key: "integration-tests-qa-part-2"
+      command: |
+        set -euo pipefail
 
-      source .buildkite/scripts/common/vm-agent.sh
-      export FEATURE_FLAG=persistent_queues
-      ci/integration_tests.sh split 1
+        source .buildkite/scripts/common/vm-agent.sh
+        export FEATURE_FLAG=persistent_queues
+        ci/integration_tests.sh split 1
 
-  - label: ":lab_coat: x-pack unit tests"
-    key: "x-pack-unit-tests"
-    command: |
-      set -euo pipefail
+    - label: ":lab_coat: x-pack unit tests"
+      key: "x-pack-unit-tests"
+      command: |
+        set -euo pipefail
 
-      source .buildkite/scripts/common/vm-agent.sh
-      x-pack/ci/unit_tests.sh
+        source .buildkite/scripts/common/vm-agent.sh
+        x-pack/ci/unit_tests.sh
 
-  - label: ":lab_coat: x-pack integration"
-    key: "integration-tests-x-pack"
-    command: |
-      set -euo pipefail
+    - label: ":lab_coat: x-pack integration"
+      key: "integration-tests-x-pack"
+      command: |
+        set -euo pipefail
 
-      source .buildkite/scripts/common/vm-agent.sh
-      x-pack/ci/integration_tests.sh
+        source .buildkite/scripts/common/vm-agent.sh
+        x-pack/ci/integration_tests.sh
 
 group:
   label: "Acceptance Phase"

--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -92,7 +92,7 @@ steps:
       - label: "Acceptance tests on {{matrix.distribution}}"
         agents:
           provider: aws
-          imagePrefix: platform-ingest-logstash-{{matrix.distribution}}
+          imagePrefix: platform-ingest-logstash-{{matrix.distribution}}-aarch64
           instanceType: "m6g.4xlarge"
           diskSizeGb: 200
         command:

--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -76,7 +76,7 @@ steps:
           x-pack/ci/integration_tests.sh
 
   - group: "Acceptance Phase"
-    depends: "testing-phase"
+    depends_on: "testing-phase"
     key: "acceptance-phase"
     steps:
       - label: "Acceptance tests will go here"

--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -5,79 +5,79 @@ agents:
   diskSizeGb: 200
 
 steps:
-  - group: "Testing Phase"
-    key: "testing-phase"
-    steps:
-      - label: ":rspec: Ruby unit tests"
-        key: "ruby-unit-tests"
-        command: |
-          set -euo pipefail
+  # - group: "Testing Phase"
+  #   key: "testing-phase"
+  #   steps:
+  #     - label: ":rspec: Ruby unit tests"
+  #       key: "ruby-unit-tests"
+  #       command: |
+  #         set -euo pipefail
 
-          source .buildkite/scripts/common/vm-agent.sh
-          ci/unit_tests.sh ruby
+  #         source .buildkite/scripts/common/vm-agent.sh
+  #         ci/unit_tests.sh ruby
 
-      ### Temporarily disable since sonar scans imply pull request context
-      # - label: ":java: Java unit tests"
-      #   key: "java-unit-tests"
-      #   command: |
-      #     set -euo pipefail
+  #     ### Temporarily disable since sonar scans imply pull request context
+  #     # - label: ":java: Java unit tests"
+  #     #   key: "java-unit-tests"
+  #     #   command: |
+  #     #     set -euo pipefail
 
-      #     source .buildkite/scripts/common/vm-agent.sh
-      #     source .buildkite/scripts/pull-requests/sonar-env.sh
-      #     ci/unit_tests.sh java
+  #     #     source .buildkite/scripts/common/vm-agent.sh
+  #     #     source .buildkite/scripts/pull-requests/sonar-env.sh
+  #     #     ci/unit_tests.sh java
 
-      - label: ":lab_coat: Integration Tests / part 1"
-        key: "integration-tests-part-1"
-        command: |
-          set -euo pipefail
+  #     - label: ":lab_coat: Integration Tests / part 1"
+  #       key: "integration-tests-part-1"
+  #       command: |
+  #         set -euo pipefail
 
-          source .buildkite/scripts/common/vm-agent.sh
-          ci/integration_tests.sh split 0
+  #         source .buildkite/scripts/common/vm-agent.sh
+  #         ci/integration_tests.sh split 0
 
-      - label: ":lab_coat: Integration Tests / part 2"
-        key: "integration-tests-part-2"
-        command: |
-          set -euo pipefail
+  #     - label: ":lab_coat: Integration Tests / part 2"
+  #       key: "integration-tests-part-2"
+  #       command: |
+  #         set -euo pipefail
 
-          source .buildkite/scripts/common/vm-agent.sh
-          ci/integration_tests.sh split 1
+  #         source .buildkite/scripts/common/vm-agent.sh
+  #         ci/integration_tests.sh split 1
 
-      - label: ":lab_coat: IT Persistent Queues / part 1"
-        key: "integration-tests-qa-part-1"
-        command: |
-          set -euo pipefail
+  #     - label: ":lab_coat: IT Persistent Queues / part 1"
+  #       key: "integration-tests-qa-part-1"
+  #       command: |
+  #         set -euo pipefail
 
-          source .buildkite/scripts/common/vm-agent.sh
-          export FEATURE_FLAG=persistent_queues
-          ci/integration_tests.sh split 0
+  #         source .buildkite/scripts/common/vm-agent.sh
+  #         export FEATURE_FLAG=persistent_queues
+  #         ci/integration_tests.sh split 0
 
-      - label: ":lab_coat: IT Persistent Queues / part 2"
-        key: "integration-tests-qa-part-2"
-        command: |
-          set -euo pipefail
+  #     - label: ":lab_coat: IT Persistent Queues / part 2"
+  #       key: "integration-tests-qa-part-2"
+  #       command: |
+  #         set -euo pipefail
 
-          source .buildkite/scripts/common/vm-agent.sh
-          export FEATURE_FLAG=persistent_queues
-          ci/integration_tests.sh split 1
+  #         source .buildkite/scripts/common/vm-agent.sh
+  #         export FEATURE_FLAG=persistent_queues
+  #         ci/integration_tests.sh split 1
 
-      - label: ":lab_coat: x-pack unit tests"
-        key: "x-pack-unit-tests"
-        command: |
-          set -euo pipefail
+  #     - label: ":lab_coat: x-pack unit tests"
+  #       key: "x-pack-unit-tests"
+  #       command: |
+  #         set -euo pipefail
 
-          source .buildkite/scripts/common/vm-agent.sh
-          x-pack/ci/unit_tests.sh
+  #         source .buildkite/scripts/common/vm-agent.sh
+  #         x-pack/ci/unit_tests.sh
 
-      - label: ":lab_coat: x-pack integration"
-        key: "integration-tests-x-pack"
-        command: |
-          set -euo pipefail
+  #     - label: ":lab_coat: x-pack integration"
+  #       key: "integration-tests-x-pack"
+  #       command: |
+  #         set -euo pipefail
 
-          source .buildkite/scripts/common/vm-agent.sh
-          x-pack/ci/integration_tests.sh
+  #         source .buildkite/scripts/common/vm-agent.sh
+  #         x-pack/ci/integration_tests.sh
 
   - group: "Acceptance Phase"
-    depends_on: "testing-phase"
+    # depends_on: "testing-phase"
     key: "acceptance-phase"
     steps:
       - label: "Docker [{{matrix}}] flavor acceptance"
@@ -88,3 +88,20 @@ steps:
         matrix:
           - "full"
           - "oss"
+
+      - label: "Acceptance tests on {{matrix.distribution}}"
+        agents:
+          provider: aws
+          imagePrefix: platform-ingest-logstash-{{matrix.distribution}}
+          instanceType: "m6g.4xlarge"
+          diskSizeGb: 200
+        command:
+          set -euo pipefail
+          
+          source .buildkite/scripts/common/vm-agent.sh && ci/acceptance_tests.sh {{matrix.suite}}
+        matrix:
+          setup:
+            suite:
+              - "debian"
+            distribution:
+              - "ubuntu-2204"

--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -16,14 +16,15 @@ steps:
           source .buildkite/scripts/common/vm-agent.sh
           ci/unit_tests.sh ruby
 
-      - label: ":java: Java unit tests"
-        key: "java-unit-tests"
-        command: |
-          set -euo pipefail
+      ### Temporarily disable since sonar scans imply pull request context
+      # - label: ":java: Java unit tests"
+      #   key: "java-unit-tests"
+      #   command: |
+      #     set -euo pipefail
 
-          source .buildkite/scripts/common/vm-agent.sh
-          source .buildkite/scripts/pull-requests/sonar-env.sh
-          ci/unit_tests.sh java
+      #     source .buildkite/scripts/common/vm-agent.sh
+      #     source .buildkite/scripts/pull-requests/sonar-env.sh
+      #     ci/unit_tests.sh java
 
       - label: ":lab_coat: Integration Tests / part 1"
         key: "integration-tests-part-1"

--- a/.buildkite/scripts/common/vm-agent.sh
+++ b/.buildkite/scripts/common/vm-agent.sh
@@ -7,5 +7,6 @@
 
 set -euo pipefail
 
-export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH"
+export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:/opt/buildkite-agent/.java/bin:$PATH"
+export JAVA_HOME="/opt/buildkite-agent/.java"
 eval "$(rbenv init -)"

--- a/.buildkite/scripts/common/vm-agent.sh
+++ b/.buildkite/scripts/common/vm-agent.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# ********************************************************
+# This file contains prerequisite bootstrap invocations
+# required for Logstash CI when using VM/baremetal agents
+# ********************************************************
+
+set -euo pipefail
+
+export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH"
+eval "$(rbenv init -)"

--- a/ci/docker_acceptance_tests.sh
+++ b/ci/docker_acceptance_tests.sh
@@ -36,44 +36,44 @@ echo "Building Logstash artifacts"
 cd $LS_HOME
 
 if [[ $SELECTED_TEST_SUITE == "oss" ]]; then
-  echo "building oss docker images"
+  echo "--- Building $SELECTED_TEST_SUITE docker images"
   cd $LS_HOME
   rake artifact:docker_oss
-  echo "Acceptance: Installing dependencies"
+  echo "--- Acceptance: Installing dependencies"
   cd $QA_DIR
   bundle install
 
-  echo "Acceptance: Running the tests"
+  echo "--- Acceptance: Running the tests"
   bundle exec rspec docker/spec/oss/*_spec.rb
 elif [[ $SELECTED_TEST_SUITE == "full" ]]; then
-  echo "building full docker images"
+  echo "--- Building $SELECTED_TEST_SUITE docker images"
   cd $LS_HOME
   rake artifact:docker
-  echo "Acceptance: Installing dependencies"
+  echo "--- Acceptance: Installing dependencies"
   cd $QA_DIR
   bundle install
 
-  echo "Acceptance: Running the tests"
+  echo "--- Acceptance: Running the tests"
   bundle exec rspec docker/spec/full/*_spec.rb
 elif [[ $SELECTED_TEST_SUITE == "ubi8" ]]; then
-  echo "building ubi8 docker images"
+  echo "--- Building $SELECTED_TEST_SUITE docker images"
   cd $LS_HOME
   rake artifact:docker_ubi8
-  echo "Acceptance: Installing dependencies"
+  echo "--- Acceptance: Installing dependencies"
   cd $QA_DIR
   bundle install
 
-  echo "Acceptance: Running the tests"
+  echo "--- Acceptance: Running the tests"
   bundle exec rspec docker/spec/ubi8/*_spec.rb
 else
-  echo "Building all docker images"
+  echo "--- Building all docker images"
   cd $LS_HOME
   rake artifact:docker_only
 
-  echo "Acceptance: Installing dependencies"
+  echo "--- Acceptance: Installing dependencies"
   cd $QA_DIR
   bundle install
 
-  echo "Acceptance: Running the tests"
+  echo "--- Acceptance: Running the tests"
   bundle exec rspec docker/spec/**/*_spec.rb
 fi


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit is the follow up PR after #15466, which migrates away
the remaining aarch64 acceptance test Jenkins jobs to Buildkite.

## Related issues

- #15466
- https://github.com/elastic/ingest-dev/issues/1724
