### PR TITLE
Remove pinning of psych 5.1.0

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -34,4 +34,3 @@ gem "jar-dependencies", "= 0.4.1" # Gem::LoadError with jar-dependencies 0.4.2
 gem "murmurhash3", "= 0.1.6" # Pins until version 0.1.7-java is released
 gem "thwait"
 gem "bigdecimal", "~> 3.1"
-gem "psych", "5.1.0" # pinned due to https://github.com/ruby/psych/issues/655


### PR DESCRIPTION
https://github.com/ruby/psych/issues/655 has been fixed with the release of 5.1.1.1