### PR TITLE
[ci] Test PR buildkite failures

### DIFF
--- a/logstash-core/spec/logstash/inputs/base_spec.rb
+++ b/logstash-core/spec/logstash/inputs/base_spec.rb
@@ -171,6 +171,6 @@ describe "LogStash::Inputs::Base#fix_streaming_codecs" do
     tcp = LogStash::Inputs::Tcp.new("codec" => "json", "port" => 0)
     tcp.register
 
-    expect(tcp.codec.class.name).to eq("LogStash::Codecs::JSONLines")
+    expect(tcp.codec.class.name).to eq("LogStash::Codecs::JSONLinesTYPOHERE")
   end
 end

--- a/logstash-core/src/test/java/org/logstash/config/ir/compiler/CommonActionsTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/compiler/CommonActionsTest.java
@@ -49,7 +49,7 @@ public class CommonActionsTest {
         CommonActions.addField(e, Collections.singletonMap(testField, testStringValue));
         Object value = e.getField(testField);
         Assert.assertTrue(value instanceof List);
-        Assert.assertEquals(2, ((List) value).size());
+        Assert.assertEquals(3, ((List) value).size());  // deliberate test bug here
         Assert.assertEquals(testStringValue, ((List) value).get(0));
         Assert.assertEquals(testStringValue, ((List) value).get(1));
 


### PR DESCRIPTION
This commit introduces a deliberate bug in ruby and java unit tests to ensure that PR checks fail on Buildkite (and the same ones should fail on Jenkins too).
