### PR TITLE
Added Safer empty variable . Fixes #11729

### DIFF
--- a/bin/benchmark.bat
+++ b/bin/benchmark.bat
@@ -1,5 +1,6 @@
 @echo off
 setlocal enabledelayedexpansion
+setlocal enableextensions
 
 cd /d "%~dp0.."
 for /f %%i in ('cd') do set RESULT=%%i

--- a/bin/logstash-keystore.bat
+++ b/bin/logstash-keystore.bat
@@ -1,5 +1,6 @@
 @echo off
 setlocal enabledelayedexpansion
+setlocal enableextensions
 
 call "%~dp0setup.bat" || exit /b 1
 if errorlevel 1 (

--- a/bin/logstash-plugin.bat
+++ b/bin/logstash-plugin.bat
@@ -1,5 +1,6 @@
 @echo off
 setlocal enabledelayedexpansion
+setlocal enableextensions
 
 call "%~dp0setup.bat" || exit /b 1
 if errorlevel 1 (

--- a/bin/logstash.bat
+++ b/bin/logstash.bat
@@ -1,5 +1,6 @@
 @echo off
 setlocal enabledelayedexpansion
+setlocal enableextensions
 set params='%*'
 
 

--- a/bin/pqcheck.bat
+++ b/bin/pqcheck.bat
@@ -1,5 +1,6 @@
 @echo off
-setlocal enabledelayedexpansion 
+setlocal enabledelayedexpansion
+setlocal enableextensions
 
 call "%~dp0setup.bat" || exit /b 1
 if errorlevel 1 (

--- a/bin/pqrepair.bat
+++ b/bin/pqrepair.bat
@@ -1,5 +1,6 @@
 @echo off
-setlocal enabledelayedexpansion 
+setlocal enabledelayedexpansion
+setlocal enableextensions
 
 call "%~dp0setup.bat" || exit /b 1
 if errorlevel 1 (

--- a/bin/rspec.bat
+++ b/bin/rspec.bat
@@ -1,5 +1,6 @@
 @echo off
 setlocal enabledelayedexpansion
+setlocal enableextensions
 set params='%*'
 
 call "%~dp0setup.bat" || exit /b 1

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -47,14 +47,14 @@ if not exist "%JAVACMD%" (
 )
 
 rem do not let JAVA_TOOL_OPTIONS slip in (as the JVM does by default)
-if not "%JAVA_TOOL_OPTIONS%" == "" (
+if defined JAVA_TOOL_OPTIONS (
   echo "warning: ignoring JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
   set JAVA_TOOL_OPTIONS=
 )
 
 rem JAVA_OPTS is not a built-in JVM mechanism but some people think it is so we
 rem warn them that we are not observing the value of %JAVA_OPTS%
-if not "%JAVA_OPTS%" == "" (
+if defined JAVA_OPTS (
   echo|set /p="warning: ignoring JAVA_OPTS=%JAVA_OPTS%; "
   echo pass JVM parameters via LS_JAVA_OPTS
 )


### PR DESCRIPTION
We need to check if JAVA_TOOL_OPTIONS, and JAVA_OPTS are set. However, if these variables are defined and contain quotes, the current mechanism breaks. Instead, we should use safer mechanism for checking if these variable are defined or not.

Fixes #11729 