### PR TITLE
[ci] re-enable Java unit tests on aarch64 pipeline

### DIFF
--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -20,7 +20,7 @@ steps:
         key: "java-unit-tests"
         env:
           # https://github.com/elastic/logstash/pull/15486 for background
-          ENABLE_SONARQUBE=false
+          ENABLE_SONARQUBE: "false"
         command: |
           set -euo pipefail
 

--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -16,15 +16,16 @@ steps:
           source .buildkite/scripts/common/vm-agent.sh
           ci/unit_tests.sh ruby
 
-      ### Temporarily disable since sonar scans imply pull request context
-      # - label: ":java: Java unit tests"
-      #   key: "java-unit-tests"
-      #   command: |
-      #     set -euo pipefail
+      - label: ":java: Java unit tests"
+        key: "java-unit-tests"
+        env:
+          # https://github.com/elastic/logstash/pull/15486 for background
+          ENABLE_SONARQUBE=false
+        command: |
+          set -euo pipefail
 
-      #     source .buildkite/scripts/common/vm-agent.sh
-      #     source .buildkite/scripts/pull-requests/sonar-env.sh
-      #     ci/unit_tests.sh java
+          source .buildkite/scripts/common/vm-agent.sh
+          ci/unit_tests.sh java
 
       - label: ":lab_coat: Integration Tests / part 1"
         key: "integration-tests-part-1"


### PR DESCRIPTION
## Release notes
[rn:skip]


## What does this PR do?

PR #15466 skipped the Java unit tests as on the `main` and `8.11` branches they attempted to run sonar scans (which are only meant to run for PRs).

This commit re-enables the Java unit tests, taking advantage of #15486, disabling the sonar scan part of the test suite.

## Why is it important/What is the impact to the user?

Java unit tests are an important part of the aarch64 suite and should not be disabled because sonar scans can't work outside PRs.

## Related issues

- #15466 
- #15486 
- https://github.com/elastic/ingest-dev/issues/1724#event-10551685937
