### PR TITLE
Updates i18n.t method calls to avoid deprecated synthax

### DIFF
--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -426,7 +426,7 @@ module LogStash; class JavaPipeline < AbstractPipeline
       # otherwise, report error and restart
       @logger.error(I18n.t(
         "logstash.pipeline.worker-error-debug",
-        default_logging_keys(
+        **default_logging_keys(
           :plugin => plugin.inspect,
           :error => e.message,
           :exception => e.class,

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -336,7 +336,7 @@ class LogStash::Runner < Clamp::StrictCommand
 
     field_reference_escape_style_setting = settings.get_setting('config.field_reference.escape_style')
     if field_reference_escape_style_setting.set?
-      logger.warn(I18n.t("logstash.settings.technical_preview.set", canonical_name: field_reference_escape_style_setting.name))
+      logger.warn(I18n.t("logstash.settings.technical_preview.set", :canonical_name => field_reference_escape_style_setting.name))
     end
     field_reference_escape_style = field_reference_escape_style_setting.value
     logger.debug("Setting global FieldReference escape style: #{field_reference_escape_style}")

--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -840,15 +840,15 @@ module LogStash
 
       def set(value)
         deprecation_logger.deprecated(I18n.t("logstash.settings.deprecation.set",
-                                             deprecated_alias: name,
-                                             canonical_name: canonical_proxy.name))
+                                             :deprecated_alias => name,
+                                             :canonical_name => canonical_proxy.name))
         super
       end
 
       def value
         logger.warn(I18n.t("logstash.settings.deprecation.queried",
-                           deprecated_alias: name,
-                           canonical_name: canonical_proxy.name))
+                           :deprecated_alias => name,
+                           :canonical_name => canonical_proxy.name))
         @canonical_proxy.value
       end
 
@@ -914,8 +914,8 @@ module LogStash
       def validate_value
         if deprecated_alias.set? && canonical_setting.set?
           fail(ArgumentError, I18n.t("logstash.settings.deprecation.ambiguous",
-                                     canonical_name: canonical_setting.name,
-                                     deprecated_alias: deprecated_alias.name))
+                                     :canonical_name => canonical_setting.name,
+                                     :deprecated_alias => deprecated_alias.name))
         end
 
         super


### PR DESCRIPTION
t

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Updates callsites synthax for i18n.t method to avoid deprecated and prohibited forma

## What does this PR do?

Updates invocations of `i18n.t` method which are leftovers and missed in the original Ruby 3.1 update PR #14861

## Why is it important/What is the impact to the user?

Without this, some error reporting logs are hidden by the mismatch of arguments error in translate the error message.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
-~~ [ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
