### PR TITLE
[ci] Slack notifications for aarch64 pipeline

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -304,7 +304,7 @@ spec:
       cancel_intermediate_builds: true
       skip_intermediate_builds: true
       env:
-        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'false'  # disabled during development
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
         SLACK_NOTIFICATIONS_CHANNEL: '#logstash-build'
         SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
       teams:


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit enables slack notifications for aarch64 Buildkite pipeline failures.

## Related issues

https://github.com/elastic/ingest-dev/issues/1724#event-10551685937
