### PR TITLE
Download of JDK from the Elastic catalog instead of Adoptium

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -707,8 +707,35 @@ class JDKDetails {
     }
 
     String createDownloadUrl() {
+        return createElasticCatalogDownloadUrl()
+    }
+
+    private String createElasticCatalogDownloadUrl() {
+        // Ask details to catalog https://jvm-catalog.elastic.co/jdk/latest_adoptiumjdk_17_windows
+        // and return the url to download the JDK
+
+        // arch x86_64 never used, only aarch64 if macos
+        def url = "https://jvm-catalog.elastic.co/jdk/latest_adoptiumjdk_${major}_${osName}"
+
+        // Append the cpu's arch only if Mac on aarch64, all the other OSes doesn't have CPU extension
+        if (osName == "darwin" && arch == "aarch64") {
+            url += "_${arch}"
+        }
+        def catalogMetadataUrl = new URL(url)
+        def catalogConnection = catalogMetadataUrl.openConnection()
+        catalogConnection.requestMethod = 'GET'
+        assert catalogConnection.responseCode == 200
+
+        def metadataRetrieved = catalogConnection.content.text
+        println "Retrieved!"
+
+        def catalogMetadata = new JsonSlurper().parseText(metadataRetrieved)
+        return catalogMetadata.url
+    }
+
+    private String createAdoptDownloadUrl() {
         String releaseName = major > 8 ?
-                "jdk-${revision}+${build}":
+                "jdk-${revision}+${build}" :
                 "jdk${revision}u${build}"
         String vendorOsName = vendorOsName(osName)
         switch (vendor) {
@@ -761,6 +788,8 @@ tasks.register("downloadJdk", Download) {
 
     // find url of build artifact
     String artifactApiUrl = jdkDetails.createDownloadUrl()
+
+    println "DNADBG>> artifactApiUrl $artifactApiUrl}"
 
     project.ext.set("jdkURL", System.getenv("JDK_URL") ?: artifactApiUrl)
     project.ext.set("jdkDownloadLocation", "${projectDir}/build/${jdkDetails.localPackageName}")

--- a/build.gradle
+++ b/build.gradle
@@ -711,14 +711,13 @@ class JDKDetails {
     }
 
     private String createElasticCatalogDownloadUrl() {
-        // Ask details to catalog https://jvm-catalog.elastic.co/jdk/latest_adoptiumjdk_17_windows
-        // and return the url to download the JDK
+        // Ask details to catalog https://jvm-catalog.elastic.co/jdk and return the url to download the JDK
 
         // arch x86_64 never used, only aarch64 if macos
         def url = "https://jvm-catalog.elastic.co/jdk/latest_adoptiumjdk_${major}_${osName}"
 
         // Append the cpu's arch only if Mac on aarch64, all the other OSes doesn't have CPU extension
-        if (osName == "darwin" && arch == "aarch64") {
+        if (arch == "aarch64") {
             url += "_${arch}"
         }
         def catalogMetadataUrl = new URL(url)
@@ -788,8 +787,6 @@ tasks.register("downloadJdk", Download) {
 
     // find url of build artifact
     String artifactApiUrl = jdkDetails.createDownloadUrl()
-
-    println "DNADBG>> artifactApiUrl $artifactApiUrl}"
 
     project.ext.set("jdkURL", System.getenv("JDK_URL") ?: artifactApiUrl)
     project.ext.set("jdkDownloadLocation", "${projectDir}/build/${jdkDetails.localPackageName}")

--- a/build.gradle
+++ b/build.gradle
@@ -720,6 +720,7 @@ class JDKDetails {
         if (arch == "aarch64") {
             url += "_${arch}"
         }
+        println "Retrieving JDK from catalog..."
         def catalogMetadataUrl = new URL(url)
         def catalogConnection = catalogMetadataUrl.openConnection()
         catalogConnection.requestMethod = 'GET'
@@ -798,6 +799,7 @@ tasks.register("downloadJdk", Download) {
     src project.ext.jdkURL
     onlyIfNewer true
     overwrite false
+    quiet true
     inputs.file("${projectDir}/versions.yml")
     outputs.file(project.ext.jdkDownloadLocation)
     dest new File(project.ext.jdkDownloadLocation)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?


Adapted the JDK's download URL creation to intereact with Elastic catalog to get metadata, and return the catalog download link instead of directly pointing to Adoptium API


## Why is it important/What is the impact to the user?

Let the CI work smoothly, using the unified source of JDKs.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


Use Gradle task:
```sh
./gradlew copyJdk -Pjdk_bundle_os=windows -Pjdk_arch=x86_64
```
using differn OSes (`windows`, `linux`, `darwin`) and different CPU architectures (`x86_64`,`arm64`).
`arm64` is valid only for MacOS (Darwin).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #15513 

