### PR TITLE
[ci] Initial jdk matrix Buildkite resource

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -28,6 +28,7 @@ spec:
     - resource:logstash-snyk-report
     - logstash-dra-snapshot-pipeline
     - logstash-dra-staging-pipeline
+    - logstash-jdk-matrix-pipeline
 
 # ***********************************
 # Declare serverless IT pipeline
@@ -320,6 +321,55 @@ spec:
 # *****************************
 # SECTION END: aarch64 pipeline
 # *****************************
+
+# ****************************************
+# SECTION START: JDK matrix tests pipeline
+# ****************************************
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: logstash-jdk-matrix-pipeline
+  description: 'Logstash JDK matrix pipeline'
+  links:
+    - title: 'Logstash JDK matrix pipeline'
+      url: https://buildkite.com/elastic/logstash-jdk-matrix-pipeline
+spec:
+  type: buildkite-pipeline
+  owner: group:logstash
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: "Logstash JDK matrix pipeline"
+      description: ':logstash: Test Logstash against a selected matrix of JDKs and Operating Systems'
+    spec:
+      repository: elastic/logstash
+      pipeline_file: ".buildkite/jdk_matrix_pipeline.yml"
+      provider_settings:
+        trigger_mode: none
+      cancel_intermediate_builds: true
+      skip_intermediate_builds: true
+      env:
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'false'  # disable during development
+        SLACK_NOTIFICATIONS_CHANNEL: '#logstash-build'
+        SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
+      teams:
+        ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        logstash:
+          access_level: MANAGE_BUILD_AND_READ
+        ingest-eng-prod:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+
+# ****************************************
+# SECTION END: JDK matrix tests pipeline
+# ****************************************
 
 # ********************************************
 # Declare supported plugin tests pipeline


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit adds an initial Buildkite resource definition for JDK matrix tests.

## Related issues

- https://github.com/elastic/ingest-dev/issues/1725

**NOTE**: The actual pipeline is committed separately in the follow up PR #15520 to facilitate easy backporting
via the logstashmachine PR bot.
