### PR TITLE
[ci] Initial JDK matrix Buildkite pipeline

### DIFF
--- a/.buildkite/jdk_matrix_pipeline.yml
+++ b/.buildkite/jdk_matrix_pipeline.yml
@@ -1,0 +1,3 @@
+steps:
+  - label: "Test JDK matrix pipeline"
+    command: "echo 'Hello world'"


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit adds a skeleton Buildkite pipeline for the JDK matrix tests.

## Related issues

- https://github.com/elastic/logstash/pull/15519
- https://github.com/elastic/ingest-dev/issues/1725
