### PR TITLE
Plugin Tests: Exit 1 on error

### DIFF
--- a/ci/test_plugins.rb
+++ b/ci/test_plugins.rb
@@ -260,7 +260,7 @@ end
 # restore original git status to avoid to accidentally commit build artifacts
 cleanup_logstash_snapshot
 
-if failed_plugins
+if !failed_plugins.empty?
   puts "########################################"
   puts " Failed plugins:"
   puts "----------------------------------------"

--- a/ci/test_plugins.rb
+++ b/ci/test_plugins.rb
@@ -266,6 +266,7 @@ if failed_plugins
   puts "----------------------------------------"
   failed_plugins.each {|failure| puts "- #{failure}"}
   puts "########################################"
+  exit 1
 else
   puts "NO ERROR ON PLUGINS!"
 end


### PR DESCRIPTION
Properly exit 1 on error. This would properly allow the buildkite pipeline to fail.