### PR TITLE
[ci] Split JDK matrix resources per OS

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -28,7 +28,8 @@ spec:
     - resource:logstash-snyk-report
     - logstash-dra-snapshot-pipeline
     - logstash-dra-staging-pipeline
-    - logstash-jdk-matrix-pipeline
+    - logstash-linux-jdk-matrix-pipeline
+    - logstash-windows-jdk-matrix-pipeline
 
 # ***********************************
 # Declare serverless IT pipeline
@@ -322,20 +323,20 @@ spec:
 # SECTION END: aarch64 pipeline
 # *****************************
 
-# ****************************************
-# SECTION START: JDK matrix tests pipeline
-# ****************************************
+# *************************************************************
+# SECTION START: JDK matrix tests (Linux and Windows) pipelines
+# *************************************************************
 
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: logstash-jdk-matrix-pipeline
-  description: 'Logstash JDK matrix pipeline'
+  name: logstash-linux-jdk-matrix-pipeline
+  description: 'Logstash Linux JDK matrix pipeline'
   links:
-    - title: 'Logstash JDK matrix pipeline'
-      url: https://buildkite.com/elastic/logstash-jdk-matrix-pipeline
+    - title: 'Logstash Linux JDK matrix pipeline'
+      url: https://buildkite.com/elastic/logstash-linux-jdk-matrix-pipeline
 spec:
   type: buildkite-pipeline
   owner: group:logstash
@@ -344,11 +345,11 @@ spec:
     apiVersion: buildkite.elastic.dev/v1
     kind: Pipeline
     metadata:
-      name: "Logstash JDK matrix pipeline"
-      description: ':logstash: Test Logstash against a selected matrix of JDKs and Operating Systems'
+      name: "Logstash Linux JDK matrix pipeline"
+      description: ':java: :linux: Test Logstash against a matrix of JDKs and Linux Distributions'
     spec:
       repository: elastic/logstash
-      pipeline_file: ".buildkite/jdk_matrix_pipeline.yml"
+      pipeline_file: ".buildkite/linux_jdk_matrix_pipeline.yml"
       provider_settings:
         trigger_mode: none
       cancel_intermediate_builds: true
@@ -357,6 +358,20 @@ spec:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'false'  # disable during development
         SLACK_NOTIFICATIONS_CHANNEL: '#logstash-build'
         SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
+      ## disable during development
+      # schedules:
+      #   Weekly 7_17:
+      #     branch: '7.17'
+      #     cronline: 0 1 * * 2
+      #     message: Weekly Linux JDK matrix tests for 7.17
+      #   Weekly 8_11:
+      #     branch: '8.11'
+      #     cronline: 0 1 * * 2
+      #     message: Weekly Linux JDK matrix tests for 7.17
+      #   Daily main:
+      #     branch: main
+      #     cronline: 0 1 * * 2
+      #     message: Weekly Linux JDK matrix tests for main
       teams:
         ingest-fp:
           access_level: MANAGE_BUILD_AND_READ
@@ -367,9 +382,64 @@ spec:
         everyone:
           access_level: READ_ONLY
 
-# ****************************************
-# SECTION END: JDK matrix tests pipeline
-# ****************************************
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: logstash-windows-jdk-matrix-pipeline
+  description: 'Logstash Windows JDK matrix pipeline'
+  links:
+    - title: 'Logstash Windows JDK matrix pipeline'
+      url: https://buildkite.com/elastic/logstash-windows-jdk-matrix-pipeline
+spec:
+  type: buildkite-pipeline
+  owner: group:logstash
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: "Logstash Windows JDK matrix pipeline"
+      description: ':java: :windows: Test Logstash against a matrix of JDKs and Windows releases'
+    spec:
+      repository: elastic/logstash
+      pipeline_file: ".buildkite/windows_jdk_matrix_pipeline.yml"
+      provider_settings:
+        trigger_mode: none
+      cancel_intermediate_builds: true
+      skip_intermediate_builds: true
+      env:
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'false'  # disable during development
+        SLACK_NOTIFICATIONS_CHANNEL: '#logstash-build'
+        SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
+      ## disable during development
+      # schedules:
+      #   Weekly 7_17:
+      #     branch: '7.17'
+      #     cronline: 0 1 * * 2
+      #     message: Weekly Windows JDK matrix tests for 7.17
+      #   Weekly 8_11:
+      #     branch: '8.11'
+      #     cronline: 0 1 * * 2
+      #     message: Weekly Windows JDK matrix tests for 7.17
+      #   Daily main:
+      #     branch: main
+      #     cronline: 0 1 * * 2
+      #     message: Weekly Windows JDK matrix tests for main
+      teams:
+        ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        logstash:
+          access_level: MANAGE_BUILD_AND_READ
+        ingest-eng-prod:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+
+# ***********************************************************
+# SECTION END: JDK matrix tests (Linux and Windows) pipelines
+# ***********************************************************
 
 # ********************************************
 # Declare supported plugin tests pipeline


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
[rn:skip]

## What does this PR do?

This commit splits the generic Buildkite catalog resource introduced in #15519 for JDK tests to separate resources for Linux and Windows.

## Related issues

- https://github.com/elastic/ingest-dev/issues/1725
- https://github.com/elastic/logstash/pull/15520
