### PR TITLE
[ci] Remove 8.10 scheduled builds for DRA

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -143,10 +143,6 @@ spec:
           branch: '7.17'
           cronline: 30 02 * * *
           message: Daily SNAPSHOT build for 7.17
-        Daily 8_10:
-          branch: '8.10'
-          cronline: 30 02 * * *
-          message: Daily SNAPSHOT build for 8.10
         Daily 8_11:
           branch: '8.11'
           cronline: 30 02 * * *


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit removes 8.10 from the automated builds of DRA artifacts, and should be merged once 8.11.0 is out.

## Related issues

- https://github.com/elastic/ingest-dev/blob/main/.github/ISSUE_TEMPLATE/logstash-release-checklist-minor.md#post-release-tasks