### PR TITLE
[ci] JDK matrix Buildkite pipelines (pt 2/Windows)

### DIFF
--- a/.buildkite/scripts/jdk-matrix-tests/generate-steps.py
+++ b/.buildkite/scripts/jdk-matrix-tests/generate-steps.py
@@ -88,7 +88,7 @@ class WindowsJobs(Jobs):
         ]
 
     def unit_tests(self) -> JobRetValues:
-        step_name_human = "Unit Test"
+        step_name_human = "Unit Test (Java/Ruby)"
         step_key = f"{self.group_key}-unit-test"
         test_command = rf'''.\\.buildkite\\scripts\\jdk-matrix-tests\\launch-command.ps1 -JDK "{self.jdk}" -StepNameHuman "{step_name_human}" -AnnotateContext "{self.group_key}" -CIScript ".\\ci\\unit_tests.bat" -Annotate
         '''

--- a/.buildkite/scripts/jdk-matrix-tests/generate-steps.py
+++ b/.buildkite/scripts/jdk-matrix-tests/generate-steps.py
@@ -1,5 +1,5 @@
 import abc
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import os
 import sys
 import typing
@@ -14,7 +14,9 @@ class JobRetValues:
     command: str
     step_key: str
     depends: str
+    artifact_paths: list = field(default_factory=list)
     default_agent: bool = False
+
 
 @dataclass
 class BuildkiteEmojis:
@@ -81,21 +83,24 @@ class WindowsJobs(Jobs):
 
     def all_jobs(self) -> list[typing.Callable[[], JobRetValues]]:
         return [
+          self.init_annotation,
           self.unit_tests,
         ]
 
     def unit_tests(self) -> JobRetValues:
-        step_name_human = "Java Unit Test"
-        test_command = "# TODO"
+        step_name_human = "Unit Test"
+        step_key = f"{self.group_key}-unit-test"
+        test_command = rf'''.\\.buildkite\\scripts\\jdk-matrix-tests\\launch-command.ps1 -JDK "{self.jdk}" -StepNameHuman "{step_name_human}" -AnnotateContext "{self.group_key}" -CIScript ".\\ci\\unit_tests.bat" -Annotate
+        '''
 
         return JobRetValues(
             step_label=step_name_human,
-            command=test_command,
-            step_key="java-unit-test",
-            depends="",
+            command=LiteralScalarString(test_command),
+            step_key=step_key,
+            depends=self.init_annotation_key,
+            artifact_paths=["build_reports.zip"],
         )
-        return step_name_human, test_command
-      
+
 
 class LinuxJobs(Jobs):
     def __init__(self, os: str, jdk: str, group_key: str):
@@ -274,7 +279,7 @@ if __name__ == "__main__":
             job_values = job()
 
             step = {
-              "label": f"{matrix_os} / {matrix_jdk} / {job_values.step_label}",
+              "label": f"{job_values.step_label}",
               "key": job_values.step_key,
             }
 
@@ -291,6 +296,8 @@ if __name__ == "__main__":
                     "diskType": "pd-ssd",
                 }
 
+            if job_values.artifact_paths:
+                step["artifact_paths"] = job_values.artifact_paths
 
             step["command"] = job_values.command
 

--- a/.buildkite/scripts/jdk-matrix-tests/launch-command.ps1
+++ b/.buildkite/scripts/jdk-matrix-tests/launch-command.ps1
@@ -1,0 +1,54 @@
+# ********************************************************
+# This file contains prerequisite bootstrap invocations
+# required for Logstash CI JDK matrix tests
+# ********************************************************
+
+param (
+    [string]$JDK,
+    [string]$CIScript,
+    [string]$StepNameHuman,
+    [string]$AnnotateContext,
+    [switch]$Annotate
+)
+
+# expand previous buildkite folded section (command invocation)
+Write-Host "^^^ +++"
+
+# the unit test script expects the WORKSPACE env var
+$env:WORKSPACE = $PWD.Path
+
+# unset generic JAVA_HOME
+if (Test-Path env:JAVA_HOME) {
+    Remove-Item -Path env:JAVA_HOME
+    Write-Host "--- Environment variable 'JAVA_HOME' has been unset."
+} else {
+    Write-Host "--- Environment variable 'JAVA_HOME' doesn't exist. Continuing."
+}
+
+# LS env vars for JDK matrix tests
+$JAVA_CUSTOM_DIR = "C:\Users\buildkite\.java\$JDK"
+$env:BUILD_JAVA_HOME = $JAVA_CUSTOM_DIR
+$env:RUNTIME_JAVA_HOME = $JAVA_CUSTOM_DIR
+$env:LS_JAVA_HOME = $JAVA_CUSTOM_DIR
+
+Write-Host "--- Running test: $CIScript"
+try {
+    Invoke-Expression $CIScript
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "Test script $CIScript failed with a non-zero code: $LASTEXITCODE"
+    }
+
+    if ($Annotate) {
+        C:\buildkite-agent\bin\buildkite-agent.exe annotate --context="$AnnotateContext" --append "| :bk-status-passed: | $StepNameHuman |`n"
+    }
+} catch {
+    # tests failed
+    Write-Host "^^^ +++"
+    if ($Annotate) {
+        C:\buildkite-agent\bin\buildkite-agent.exe annotate --context="$AnnotateContext" --append "| :bk-status-failed: | $StepNameHuman |`n"
+        Write-Host "--- Archiving test reports"
+        & "7z.exe" a -r .\build_reports.zip .\logstash-core\build\reports\tests
+    }
+    exit 1
+}

--- a/.buildkite/windows_jdk_matrix_pipeline.yml
+++ b/.buildkite/windows_jdk_matrix_pipeline.yml
@@ -1,3 +1,65 @@
 steps:
-  - label: "Test Windows JDK matrix pipeline"
-    command: "echo 'Hello world'"
+  - input: "Test Parameters"
+    if: build.source != "schedule"
+    fields:
+      - select: "Operating System"
+        key: "matrix-os"
+        hint: "The operating system variant(s) to run on:"
+        required: true
+        multiple: true
+        default: "windows-2022"
+        options:
+          - label: "Windows 2022"
+            value: "windows-2022"
+          - label: "Windows 2019"
+            value: "windows-2019"
+          - label: "Windows 2016"
+            value: "windows-2016"
+
+      - select: "Java"
+        key: "matrix-jdk"
+        hint: "The JDK to test with:"
+        required: true
+        multiple: true
+        default: "adoptiumjdk_17"
+        options:
+          - label: "Adoptium JDK 17 (Eclipse Temurin)"
+            value: "adoptiumjdk_17"
+          - label: "Adopt OpenJDK 11"
+            value: "adoptopenjdk_11"
+          - label: "OpenJDK 17"
+            value: "openjdk_17"
+          - label: "OpenJDK 11"
+            value: "openjdk_11"
+          - label: "Zulu 17"
+            value: "zulu_17"
+          - label: "Zulu 11"
+            value: "zulu_11"
+
+  - wait: ~
+    if: build.source != "schedule"
+
+  - command: |
+      set -euo pipefail
+
+      echo "--- Downloading prerequisites"
+      python3 -m pip install ruamel.yaml
+
+      echo "--- Printing generated dynamic steps"
+      export MATRIX_OSES="$(buildkite-agent meta-data get matrix-os)"
+      export MATRIX_JDKS="$(buildkite-agent meta-data get matrix-jdk)"
+      set +eo pipefail
+      python3 .buildkite/scripts/jdk-matrix-tests/generate-steps.py >pipeline_steps.yml
+      if [[ $$? -ne 0 ]]; then
+        echo "^^^ +++"
+        echo "There was a problem rendering the pipeline steps."
+        cat pipeline_steps.yml
+        echo "Exiting now."
+        exit 1
+      else
+        set -eo pipefail
+        cat pipeline_steps.yml
+      fi
+
+      echo "--- Uploading steps to buildkite"
+      cat pipeline_steps.yml | buildkite-agent pipeline upload

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
@@ -337,7 +337,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
 
             DLQEntry entry = new DLQEntry(event, "", "", "00001", DeadLetterQueueReaderTest.constantSerializationLengthTimestamp(fakeClock));
             writeManager.writeEntry(entry);
-            Thread.sleep(101);
+
             // wait the flush interval so that the current head segment is sealed
             Awaitility.await("After the flush interval head segment is sealed and a fresh empty head is created")
                     .atLeast(flushInterval)

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
@@ -337,7 +337,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
 
             DLQEntry entry = new DLQEntry(event, "", "", "00001", DeadLetterQueueReaderTest.constantSerializationLengthTimestamp(fakeClock));
             writeManager.writeEntry(entry);
-
+            Thread.sleep(101);
             // wait the flush interval so that the current head segment is sealed
             Awaitility.await("After the flush interval head segment is sealed and a fresh empty head is created")
                     .atLeast(flushInterval)


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit adds JDK matrix Buildkite pipelines for Windows 2022, 2019 and 2016.

It also makes the groups easier to read (on both Linux and Windows pipelines) by removing the os-jdk prefix from the job labels.

`testDLQWriterFlusherRemovesExpiredSegmentWhenCurrentHeadSegmentIsEmpty` fails on Windows Buildkite agents and it's a test issue tracked in https://github.com/elastic/logstash/issues/15562.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files (and/or docker env variables)~
- [x] I have added tests that prove my fix is effective or that my feature works:

#### Linux improved group views ([link](https://buildkite.com/elastic/logstash-linux-jdk-matrix-pipeline/builds/17)):

<details><summary>Screenshot</summary>

![image](https://github.com/elastic/logstash/assets/1754575/9e245c2f-8d73-49ea-8748-8a8df9444f14)

![image](https://github.com/elastic/logstash/assets/1754575/1169d687-87d4-4e6a-92b0-6a51c03ec832)

</details>

####  Windows run ([link](https://buildkite.com/elastic/logstash-windows-jdk-matrix-pipeline/builds/27)):

This run demonstrates two failures (Windows 2022 + 2019) due to https://github.com/elastic/logstash/issues/15562 , as well a success (Windows 2019).

<details><summary>Screenshot</summary>

![image](https://github.com/elastic/logstash/assets/1754575/fca21a07-c5ad-4a5d-acd7-93f301a4ee53)
</details>

Note that we also collect [archived build artifacts](https://buildkite.com/elastic/logstash-windows-jdk-matrix-pipeline/builds/27#018bb941-224f-46da-8107-15fe00e99fb2) to assist with troubleshooting:

<details><summary>Screenshot</summary>

![image](https://github.com/elastic/logstash/assets/1754575/4a5b73f8-54d6-43a4-af43-b4d1e86297aa)
</details>

## How to test this PR locally

Just kick off a build using https://buildkite.com/elastic/logstash-windows-jdk-matrix-pipeline#new and defining this PR i.e. `pull/15563/merge` in the `branch` field.

## Related issues

- https://github.com/elastic/logstash/pull/15539
- https://github.com/elastic/ingest-dev/issues/1725
- https://github.com/elastic/logstash/issues/15562

