### PR TITLE
[Buildkite] Add pipeline max timeout property

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -241,6 +241,7 @@ spec:
     spec:
       repository: elastic/logstash
       pipeline_file: ".buildkite/pull_request_pipeline.yml"
+      maximum_timeout_in_minutes: 120
       provider_settings:
         build_pull_request_forks: false
         build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

Buildkite Build's `maximum_timeout_in_minutes` and `default_timeout_in_minutes` are available now through the **catalog-info.yaml** file. As this change was made manually before we implemented this in RRE/Terrazzo, they got reverted to the default value (0); thus, I am raising this PR to get it as it was specified before the upgrade ([120 mins.](https://buildkite.com/elastic/terrazzo/builds/30112#018bbb61-1140-42c2-a482-f4db1245f449/6-3480))

## Relates issues

- https://elasticco.atlassian.net/browse/ENGPRD-355 
- https://elasticco.atlassian.net/browse/CI-322
