### PR TITLE
[ci] Add 90min timeout for supported plugins test

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -464,6 +464,7 @@ spec:
     spec:
       repository: elastic/logstash
       pipeline_file: ".buildkite/supported_plugins_test_pipeline.yml"
+      maximum_timeout_in_minutes: 90
       skip_intermediate_builds: true
       provider_settings:
         trigger_mode: none


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit adds a global max timeout of 90min for the supported plugins Buildkite pipeline. This prevents hanging builds (for 24hrs, which is the default).

## Related issues

- #15380
- https://elasticco.atlassian.net/browse/ENGPRD-355
