### PR TITLE
[ci] Fix image name for Rocky Linux 8

### DIFF
--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -32,7 +32,7 @@ steps:
           - label: "Oracle Linux 7"
             value: "oraclelinux-7"
           - label: "Rocky Linux 8"
-            value: "rocky-8"
+            value: "rocky-linux-8"
           - label: "Amazon Linux"
             value: "amazonlinux-2023"
           - label: "OpenSUSE Leap 15"


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

Fix typo for image name of Rocky Linux 8 for JDK matrix jobs.

## Related issues

- https://github.com/elastic/ingest-dev/issues/1725#event-10694112459
