### PR TITLE
[ci] Add yaml language server to pipelines (#15590)

### DIFF
--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+
 agents:
   provider: aws
   imagePrefix: platform-ingest-logstash-ubuntu-2204-aarch64

--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+
 steps:
   - input: "Test Parameters"
     if: build.source != "schedule"

--- a/.buildkite/scripts/dra/generatesteps.py
+++ b/.buildkite/scripts/dra/generatesteps.py
@@ -128,4 +128,4 @@ if __name__ == "__main__":
         yaml.safe_load(publish_dra_step(branch, workflow_type, depends_on=group_key)),
     )
 
-    print(yaml.dump(structure, Dumper=yaml.Dumper, sort_keys=False))
+    print('# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json\n' + yaml.dump(structure, Dumper=yaml.Dumper, sort_keys=False))

--- a/.buildkite/scripts/jdk-matrix-tests/generate-steps.py
+++ b/.buildkite/scripts/jdk-matrix-tests/generate-steps.py
@@ -309,5 +309,5 @@ if __name__ == "__main__":
             "key": slugify_bk_key(group_name),
             "steps": group_steps})
 
-
+    print('# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json')
     YAML().dump(structure, sys.stdout)

--- a/.buildkite/windows_jdk_matrix_pipeline.yml
+++ b/.buildkite/windows_jdk_matrix_pipeline.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+
 steps:
   - input: "Test Parameters"
     if: build.source != "schedule"


### PR DESCRIPTION
Add missing yaml-language-server definition to Buildkite pipeline files (static and dynamic generated) for consistency and to ease spotting errors with editors.

(cherry picked from commit cd01abb1c7cbcb3cfbbc1bc2e09e1e54b9f7d7dc)

Backport of #15590
