### PR TITLE
[ci] Support amazonlinux for JDK matrix pipeline

### DIFF
--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -25,8 +25,6 @@ steps:
             value: "rhel-9"
           - label: "RHEL 8"
             value: "rhel-8"
-          - label: "CentOS 8"
-            value: "centos-8"
           - label: "CentOS 7"
             value: "centos-7"
           - label: "Oracle Linux 8"

--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -35,7 +35,7 @@ steps:
             value: "oraclelinux-7"
           - label: "Rocky Linux 8"
             value: "rocky-linux-8"
-          - label: "Amazon Linux"
+          - label: "Amazon Linux (2023)"
             value: "amazonlinux-2023"
           - label: "OpenSUSE Leap 15"
             value: "opensuse-leap-15"

--- a/.buildkite/scripts/jdk-matrix-tests/generate-steps.py
+++ b/.buildkite/scripts/jdk-matrix-tests/generate-steps.py
@@ -327,7 +327,7 @@ if __name__ == "__main__":
         )
 
         awsAgent = AWSAgent(
-            imagePrefix=f"test-platform-ingest-logstash-multi-jdk-{matrix_os}",
+            imagePrefix=f"platform-ingest-logstash-multi-jdk-{matrix_os}",
             instanceType="m5.2xlarge",
             diskSizeGb=200,
         )

--- a/.buildkite/scripts/jdk-matrix-tests/generate-steps.py
+++ b/.buildkite/scripts/jdk-matrix-tests/generate-steps.py
@@ -19,12 +19,12 @@ class JobRetValues:
 
 
 class GCPAgent:
-    def __init__(self, image: str, machineType: str, disSizeGb: int = 200, diskType: str = "pd-ssd") -> None:
+    def __init__(self, image: str, machineType: str, diskSizeGb: int = 200, diskType: str = "pd-ssd") -> None:
         self.provider = "gcp"
         self.imageProject = "elastic-images-qa"
         self.image = image
         self.machineType = machineType
-        self.diskSizeGb = disSizeGb
+        self.diskSizeGb = diskSizeGb
         self.diskType = diskType
 
     def to_dict(self):
@@ -321,8 +321,8 @@ if __name__ == "__main__":
     for matrix_os in matrix_oses:
         gcpAgent = GCPAgent(
             image=f"family/platform-ingest-logstash-multi-jdk-{matrix_os}",
-            machineType="gcp",
-            disSizeGb=200,
+            machineType="n2-standard-4",
+            diskSizeGb=200,
             diskType="pd-ssd",
         )
 

--- a/.buildkite/scripts/jdk-matrix-tests/generate-steps.py
+++ b/.buildkite/scripts/jdk-matrix-tests/generate-steps.py
@@ -53,9 +53,9 @@ class AWSAgent:
             "diskSizeGb": self.diskSizeGb,   
         }
     
-class NoneAgent:
+class DefaultAgent:
     """
-    Represents an empty agent definition which makes Buildkite use the default i.e. a container
+    Represents an empty agent definition which makes Buildkite use the default agent i.e. a container
     """
 
     def __init__(self) -> None:
@@ -117,7 +117,7 @@ class Jobs(abc.ABC):
             command=LiteralScalarString(bk_annotate(body=body, context=self.group_key)),
             step_key=self.init_annotation_key,
             depends="",
-            agent=NoneAgent().to_json(),
+            agent=DefaultAgent().to_json(),
         )
 
     @abc.abstractmethod


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

The last part of the Logstash JDK matrix CI migration from Jenkins to Buildkite is AmazonLinux 2023.

While we have a working image[^1], this is the only step that requires a agent that runs on AWS.

This commit refactors the builder to support GCP or AWS agents depending on the OS.

[^1]: https://github.com/elastic/ci-agent-images/pull/441

## Related issues

- https://github.com/elastic/ingest-dev/issues/1725
