### PR TITLE
swap dataformat-yaml with snakeyaml

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -215,7 +215,7 @@ dependencies {
     api "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
     implementation 'org.codehaus.janino:janino:3.1.0'
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jacksonVersion}"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonVersion}"
+    implementation group: 'org.yaml', name: 'snakeyaml', version: '2.2'
     implementation group: 'com.google.guava', name: 'guava', version: '32.1.2-jre'
     implementation('com.google.googlejavaformat:google-java-format:1.15.0') {
         exclude group: 'com.google.guava', module: 'guava'

--- a/logstash-core/src/main/java/org/logstash/plugins/AliasRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/AliasRegistry.java
@@ -1,6 +1,9 @@
 package org.logstash.plugins;
 
 import java.util.Map;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -87,8 +90,8 @@ public class AliasRegistry {
 
         @SuppressWarnings("unchecked")
         private Map<PluginType, List<AliasPlugin>> decodeYaml() throws IOException {
-            Yaml yaml = new Yaml();
-            return (Map) yaml.load(yamlContents);
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readValue(yamlContents, new TypeReference<Map<PluginType, List<AliasPlugin>>>() {});
         }
 
         private String computeHashFromContent() {

--- a/logstash-core/src/main/java/org/logstash/plugins/AliasRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/AliasRegistry.java
@@ -108,8 +108,6 @@ public class AliasRegistry {
             Map<PluginType, List<AliasPlugin>> result = convertYamlMapToObject(yamlMap);
 
             return result;
-            //ObjectMapper mapper = new ObjectMapper();
-            //return mapper.readValue(yamlContents, new TypeReference<Map<PluginType, List<AliasPlugin>>>() {});
         }
 
         private String computeHashFromContent() {

--- a/logstash-core/src/main/java/org/logstash/plugins/AliasRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/AliasRegistry.java
@@ -15,7 +15,6 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -23,6 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Scanner;
+import java.util.stream.Collectors;
 
 import org.yaml.snakeyaml.Yaml;
 
@@ -154,7 +154,6 @@ public class AliasRegistry {
             String with = doc.get("with");
             return new AliasDocumentReplace(replace, with);
         }
-    }
     }
 
     static class AliasYamlLoader {

--- a/logstash-core/src/main/java/org/logstash/plugins/aliases/AliasDocumentReplace.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/aliases/AliasDocumentReplace.java
@@ -7,6 +7,10 @@ import javax.annotation.Nonnull;
  */
 public class AliasDocumentReplace {
 
+    public AliasDocumentReplace(String replace, String with) {
+        this.replace = replace;
+        this.with = with;
+    }
     /**
      * A document entry need to be replaced.
      */

--- a/logstash-core/src/main/java/org/logstash/plugins/aliases/AliasDocumentReplace.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/aliases/AliasDocumentReplace.java
@@ -7,10 +7,6 @@ import javax.annotation.Nonnull;
  */
 public class AliasDocumentReplace {
 
-    public AliasDocumentReplace(String replace, String with) {
-        this.replace = replace;
-        this.with = with;
-    }
     /**
      * A document entry need to be replaced.
      */
@@ -22,6 +18,11 @@ public class AliasDocumentReplace {
      */
     @Nonnull
     private String with;
+
+    public AliasDocumentReplace(String replace, String with) {
+        this.replace = replace;
+        this.with = with;
+    }
 
     public String getReplace() {
         return this.replace;

--- a/logstash-core/src/main/java/org/logstash/plugins/aliases/AliasPlugin.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/aliases/AliasPlugin.java
@@ -11,16 +11,10 @@ import java.util.List;
  */
 public class AliasPlugin {
 
-    public AliasPlugin(String aliasName, String from, List<AliasDocumentReplace> docHeaderReplaces) {
-        this.aliasName = aliasName;
-        this.from = from;
-        this.docHeaderReplaces = docHeaderReplaces;
-    }
     /**
      * Name of the aliased plugin.
      */
     @Nonnull
-    @JsonProperty("alias")
     private String aliasName;
 
     /**
@@ -29,11 +23,16 @@ public class AliasPlugin {
     @Nonnull
     private String from;
 
+    public AliasPlugin(String aliasName, String from, List<AliasDocumentReplace> docHeaderReplaces) {
+        this.aliasName = aliasName;
+        this.from = from;
+        this.docHeaderReplaces = docHeaderReplaces;
+    }
+
     /**
      * List of replace entries when transforming artifact doc to aliased plugin doc.
      */
     @Nullable
-    @JsonProperty("docs")
     private List<AliasDocumentReplace> docHeaderReplaces;
 
     @Nonnull

--- a/logstash-core/src/main/java/org/logstash/plugins/aliases/AliasPlugin.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/aliases/AliasPlugin.java
@@ -15,25 +15,25 @@ public class AliasPlugin {
      * Name of the aliased plugin.
      */
     @Nonnull
-    private String aliasName;
+    private final String aliasName;
 
     /**
      * The plugin name where aliased plugin made from.
      */
     @Nonnull
-    private String from;
-
-    public AliasPlugin(String aliasName, String from, List<AliasDocumentReplace> docHeaderReplaces) {
-        this.aliasName = aliasName;
-        this.from = from;
-        this.docHeaderReplaces = docHeaderReplaces;
-    }
+    private final String from;
 
     /**
      * List of replace entries when transforming artifact doc to aliased plugin doc.
      */
     @Nullable
     private List<AliasDocumentReplace> docHeaderReplaces;
+
+    public AliasPlugin(String aliasName, String from, List<AliasDocumentReplace> docHeaderReplaces) {
+        this.aliasName = aliasName;
+        this.from = from;
+        this.docHeaderReplaces = docHeaderReplaces;
+    }
 
     @Nonnull
     public String getAliasName() {

--- a/logstash-core/src/main/java/org/logstash/plugins/aliases/AliasPlugin.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/aliases/AliasPlugin.java
@@ -11,6 +11,11 @@ import java.util.List;
  */
 public class AliasPlugin {
 
+    public AliasPlugin(String aliasName, String from, List<AliasDocumentReplace> docHeaderReplaces) {
+        this.aliasName = aliasName;
+        this.from = from;
+        this.docHeaderReplaces = docHeaderReplaces;
+    }
     /**
      * Name of the aliased plugin.
      */


### PR DESCRIPTION
This removes the dependency on jackson's dataformat-yaml. Since there's only a single place where this library is used in core: to load the plugin alias definition, the code can be replaced by the underlying snakeyaml.