### PR TITLE
[ci] Use GCP prod image for JDK matrix jobs

### DIFF
--- a/.buildkite/scripts/jdk-matrix-tests/generate-steps.py
+++ b/.buildkite/scripts/jdk-matrix-tests/generate-steps.py
@@ -21,7 +21,7 @@ class JobRetValues:
 class GCPAgent:
     def __init__(self, image: str, machineType: str, diskSizeGb: int = 200, diskType: str = "pd-ssd") -> None:
         self.provider = "gcp"
-        self.imageProject = "elastic-images-qa"
+        self.imageProject = "elastic-images-prod"
         self.image = image
         self.machineType = machineType
         self.diskSizeGb = diskSizeGb


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

So far we've been using images from the -qa GCP image project throughput the development of the Logstash Linux + Windows JDK matrix pipeline for quicker iteration.

As we have scheduled weekly builds of those images that promote to prod[^1] we can now switch to the prod version of the GCP images.

## Related issues

- https://github.com/elastic/ingest-dev/issues/1725#event-10694112459

[^1]: https://buildkite.com/elastic/ci-vm-images/builds/2888
