### PR TITLE
[ci] Explicit maximum timeout for pipelines

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,7 +2,7 @@
 # Declare Backstage Component that represents the Logstash tool
 # *************************************************************
 ---
-# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
@@ -35,7 +35,7 @@ spec:
 # Declare serverless IT pipeline
 # ***********************************
 ---
-# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
@@ -53,6 +53,7 @@ spec:
     spec:
       repository: elastic/logstash
       pipeline_file: ".buildkite/serverless_integration_pipeline.yml"
+      maximum_timeout_in_minutes: 90
       provider_settings:
         trigger_mode: none # don't trigger jobs from github activity
       env:
@@ -75,7 +76,7 @@ spec:
 # Declare snyk-repo pipeline
 # ***********************************
 ---
-# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
@@ -94,6 +95,7 @@ spec:
     spec:
       repository: elastic/logstash
       pipeline_file: ".buildkite/snyk_report_pipeline.yml"
+      maximum_timeout_in_minutes: 60
       provider_settings:
         trigger_mode: none # don't trigger jobs
       env:
@@ -116,7 +118,7 @@ spec:
 # ***********************************
 
 ---
-# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
@@ -138,6 +140,7 @@ spec:
     spec:
       repository: elastic/logstash
       pipeline_file: ".buildkite/dra_pipeline.yml"
+      maximum_timeout_in_minutes: 120
       schedules:
         Daily 7_17:
           branch: '7.17'
@@ -170,7 +173,7 @@ spec:
           access_level: READ_ONLY
 
 ---
-# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
@@ -192,6 +195,7 @@ spec:
     spec:
       repository: elastic/logstash
       pipeline_file: ".buildkite/dra_pipeline.yml"
+      maximum_timeout_in_minutes: 120
       skip_intermediate_builds: true
       provider_settings:
         trigger_mode: none
@@ -219,7 +223,7 @@ spec:
 # ***********************************
 
 ---
-# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
@@ -276,7 +280,7 @@ spec:
 # *******************************
 
 ---
-# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
@@ -298,6 +302,7 @@ spec:
     spec:
       repository: elastic/logstash
       pipeline_file: ".buildkite/aarch64_pipeline.yml"
+      maximum_timeout_in_minutes: 90
       provider_settings:
         trigger_mode: none
       cancel_intermediate_builds: true
@@ -325,7 +330,7 @@ spec:
 # *************************************************************
 
 ---
-# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
@@ -347,6 +352,7 @@ spec:
     spec:
       repository: elastic/logstash
       pipeline_file: ".buildkite/linux_jdk_matrix_pipeline.yml"
+      maximum_timeout_in_minutes: 120
       provider_settings:
         trigger_mode: none
       cancel_intermediate_builds: true
@@ -380,7 +386,7 @@ spec:
           access_level: READ_ONLY
 
 ---
-# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
@@ -402,6 +408,7 @@ spec:
     spec:
       repository: elastic/logstash
       pipeline_file: ".buildkite/windows_jdk_matrix_pipeline.yml"
+      maximum_timeout_in_minutes: 120
       provider_settings:
         trigger_mode: none
       cancel_intermediate_builds: true
@@ -442,7 +449,7 @@ spec:
 # Declare supported plugin tests pipeline
 # ********************************************
 ---
-# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit adds a maximum default (global) timeout for every pipeline definition (now that it's possible to define this programmatically in an RRE).

The default values have been chosen arbitrarily based on intuition about how much (in the worst case) we should wait for each job to run until we consider them stuck/failed.

While at it, we update the yaml schema for RREs to point to the latest commit (rather than a pinned commit that doesn't reflect the latest changes, e.g. `maximum_default_timeout`).

## Related issues

Relates #15380
