### PR TITLE
[ci] Initial Exhaustive tests Buildkite resource

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -436,6 +436,55 @@ spec:
 # SECTION END: JDK matrix tests (Linux and Windows) pipelines
 # ***********************************************************
 
+# ****************************************
+# SECTION START: Exhaustive tests pipeline
+# ****************************************
+
+---
+# yaml-language-server: $schema=# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: logstash-exhaustive-tests-pipeline
+  description: 'Logstash Exhaustive tests pipeline'
+  links:
+    - title: 'Logstash Exhaustive tests pipeline'
+      url: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline
+spec:
+  type: buildkite-pipeline
+  owner: group:logstash
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: "Logstash Exhaustive tests pipeline"
+      description: '🔍 Run exhaustive tests against Logstash using different operating systems'
+    spec:
+      repository: elastic/logstash
+      pipeline_file: ".buildkite/exhaustive_tests_pipeline.yml"
+      provider_settings:
+        trigger_mode: none
+      cancel_intermediate_builds: true
+      skip_intermediate_builds: true
+      env:
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'false'  # disable during development
+        SLACK_NOTIFICATIONS_CHANNEL: '#logstash-build'
+        SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
+      teams:
+        ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        logstash:
+          access_level: MANAGE_BUILD_AND_READ
+        ingest-eng-prod:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+
+# **************************************
+# SECTION END: Exhaustive tests pipeline
+# **************************************
+
 # ********************************************
 # Declare supported plugin tests pipeline
 # ********************************************


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit adds a new resource for the Exhaustive tests Buildkite pipeline.

## Related issues

- https://github.com/elastic/ingest-dev/issues/1722
- https://github.com/elastic/logstash/pull/15607