### PR TITLE
[ci] Fix slack alerts for Linux JDK matrix pipeline

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -352,7 +352,7 @@ spec:
       cancel_intermediate_builds: true
       skip_intermediate_builds: true
       env:
-        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'false'  # disable during development
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
         SLACK_NOTIFICATIONS_CHANNEL: '#logstash-build'
         SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
       schedules:


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit enables slack alerts for the Linux part of the JDK matrix pipeline, which was missed in the previous PR#15593.

## Related issues

- #15593 
