### PR TITLE
Add support to add and remove multiple keystore keys in a single operation

### DIFF
--- a/docs/static/keystore.asciidoc
+++ b/docs/static/keystore.asciidoc
@@ -90,7 +90,7 @@ bin/logstash-keystore create
 
 This setup requires the user running Logstash to have the environment variable
 `LOGSTASH_KEYSTORE_PASS=mypassword` defined. If the environment variable is not defined,
-Logstash cannot access the the keystore.
+Logstash cannot access the keystore.
 
 When you run Logstash from an RPM or DEB package installation, the environment
 variables are sourced from `/etc/sysconfig/logstash`.
@@ -158,6 +158,8 @@ bin/logstash-keystore add ES_USER ES_PWD
 ----------------------------------------------------------------
 
 When prompted, enter a value for each key.
+
+NOTE: Key values are limited to ASCII characters. it includes digits, letters, and a few special symbols.
 
 [discrete]
 [[list-settings]]

--- a/docs/static/keystore.asciidoc
+++ b/docs/static/keystore.asciidoc
@@ -154,10 +154,10 @@ use the `add` command:
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------
-bin/logstash-keystore add ES_PWD
+bin/logstash-keystore add ES_USER ES_PWD
 ----------------------------------------------------------------
 
-When prompted, enter a value for the key.
+When prompted, enter a value for each key.
 
 [discrete]
 [[list-settings]]
@@ -174,9 +174,9 @@ bin/logstash-keystore list
 [[remove-settings]]
 === Remove keys
 
-To remove a key from the keystore, use:
+To remove keys from the keystore, use:
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------
-bin/logstash-keystore remove ES_PWD
+bin/logstash-keystore remove ES_USER ES_PWD
 ----------------------------------------------------------------

--- a/docs/static/keystore.asciidoc
+++ b/docs/static/keystore.asciidoc
@@ -159,7 +159,7 @@ bin/logstash-keystore add ES_USER ES_PWD
 
 When prompted, enter a value for each key.
 
-NOTE: Key values are limited to ASCII characters. it includes digits, letters, and a few special symbols.
+NOTE: Key values are limited to ASCII characters. It includes digits, letters, and a few special symbols.
 
 [discrete]
 [[list-settings]]

--- a/lib/secretstore/cli.rb
+++ b/lib/secretstore/cli.rb
@@ -49,7 +49,7 @@ class LogStash::SecretStoreCli
     LogStash::Util::SettingsHelper.post_process
     secure_config = SecretStoreExt.getConfig(LogStash::SETTINGS.get_setting("keystore.file").value, LogStash::SETTINGS.get_setting("keystore.classname").value)
     cli = SecretStoreCli.new(Terminal.new)
-    cli.command(ARGV[0], secure_config, ARGV[1])
+    cli.command(ARGV[0], secure_config, *ARGV[1, ARGV.length])
     exit 0
   rescue => e
     logger.error(e.message, :cause => e.cause, :backtrace => e.backtrace)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

- Added support to add and remove multiple keystore keys in a single operation
- Fixed the empty value validation for editing existing key values
- Added ASCII validation for key values

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

- Added support to add and remove multiple keys in a single operation, example:
  ```shell
  bin/logstash-keystore add FOO BAR
  bin/logstash-keystore remove FOO BAR 
  ```
- Fixed the empty value validation for editing existing key values
- Added ASCII validation for key values

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

Currently, adding keys to the keystore need to call [command](https://www.elastic.co/guide/en/logstash/current/keystore.html#add-keys-to-keystore) `logstash-keystore add YOUR_KEY` one by one for each key, which is very time-consuming because it starts and stops JVM each time.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

- Add and remove multiple keys

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes: https://github.com/elastic/logstash/issues/15186
- Closes: https://github.com/elastic/logstash/issues/15307