### PR TITLE
[ci] Switch to Adoptium JDK 17 for Jenkins CI

### DIFF
--- a/.ci/java-versions.properties
+++ b/.ci/java-versions.properties
@@ -1,2 +1,3 @@
-LS_BUILD_JAVA=jdk17
-LS_RUNTIME_JAVA=jdk17
+LS_BUILD_JAVA=adoptiumjdk17
+LS_RUNTIME_JAVA=adoptiumjdk17
+


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

The last remaining Jenkins job prior to BK migration is for exhaustive tests. The compatibility phase seems to be failing since https://github.com/elastic/logstash/commits/57dc14c92 with Java 17.0.2

This commit switches from OpenJDK 17 (whose last release was 17.0.2) to AdoptiumJDK 17 which actively receives updates and is bundled in the custom images used by Jenkins. With this change compatibility tests should work again.

The issue with Java 17.0.2 can also be replicated with the JDK matrix BK pipeline: https://buildkite.com/elastic/logstash-linux-jdk-matrix-pipeline/builds/57

## Related issues

- https://github.com/elastic/logstash/commits/57dc14c92
- https://github.com/elastic/ingest-dev/issues/1722
