### PR TITLE
[ci] Switch to Adoptium distro for JDK 11

### DIFF
--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -51,8 +51,8 @@ steps:
         options:
           - label: "Adoptium JDK 17 (Eclipse Temurin)"
             value: "adoptiumjdk_17"
-          - label: "Adopt OpenJDK 11"
-            value: "adoptopenjdk_11"
+          - label: "Adoptium JDK 11 (Eclipse Temurin)"
+            value: "adoptiumjdk_11"
           - label: "OpenJDK 17"
             value: "openjdk_17"
           - label: "OpenJDK 11"

--- a/.buildkite/windows_jdk_matrix_pipeline.yml
+++ b/.buildkite/windows_jdk_matrix_pipeline.yml
@@ -31,8 +31,8 @@ steps:
         options:
           - label: "Adoptium JDK 17 (Eclipse Temurin)"
             value: "adoptiumjdk_17"
-          - label: "Adopt OpenJDK 11"
-            value: "adoptopenjdk_11"
+          - label: "Adoptium JDK 11 (Eclipse Temurin)"
+            value: "adoptiumjdk_11"
           - label: "OpenJDK 17"
             value: "openjdk_17"
           - label: "OpenJDK 11"


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

AdoptOpenJDK is nowadays Adoptium, so we replace it in favor of the latter which is actively maintained.

## Related issues

- Relates https://github.com/elastic/logstash/pull/15628
