### PR TITLE
Update the CI release definition to cover main and current minor snapshot versions.

### DIFF
--- a/ci/logstash_releases.json
+++ b/ci/logstash_releases.json
@@ -7,6 +7,7 @@
   },
   "snapshots": {
     "7.x": "7.17.16-SNAPSHOT",
-    "8.x": "8.12.0-SNAPSHOT"
+    "8.x": "8.11.2-SNAPSHOT",
+    "main": "8.12.0-SNAPSHOT"
   }
 }


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Introduces to add `main` into snapshot section of the CI release definition and updates `8.x` to current minor.

## Why is it important/What is the impact to the user?
N.A

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist
- [ ]

## How to test this PR locally

## Related issues
- Closes #15630 

## Use cases

## Screenshots

## Logs
