### PR TITLE
[ci] Switch to Adoptium JDK 11 for Jenkins CI

### DIFF
--- a/.ci/java-versions.properties
+++ b/.ci/java-versions.properties
@@ -1,2 +1,2 @@
-LS_BUILD_JAVA=jdk11
-LS_RUNTIME_JAVA=jdk11
+LS_BUILD_JAVA=adoptopenjdk11
+LS_RUNTIME_JAVA=adoptopenjdk11


### PR DESCRIPTION
This commit is a manual backport of #15628 on the 7.17 branch. Since 7.17 uses Java 11, we switch to the adoptium variant, which is still receiving updates (latest available is `11.0.21+9` as of now.)
