### PR TITLE
Shutdown DLQ segments flusher only if it has been started

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -254,7 +254,9 @@ public final class DeadLetterQueueWriter implements Closeable {
             }
 
             try {
-                flushScheduler.shutdown();
+                if (flushScheduler != null) {
+                    flushScheduler.shutdown();
+                }
             } catch (Exception e) {
                 logger.warn("Unable shutdown flush scheduler, ignoring", e);
             }

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -254,6 +254,7 @@ public final class DeadLetterQueueWriter implements Closeable {
             }
 
             try {
+                // flushScheduler is null only if it's not explicitly started, which happens only in tests.
                 if (flushScheduler != null) {
                     flushScheduler.shutdown();
                 }


### PR DESCRIPTION


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

In DLQ unit testing sometime the DLQ writer is started explicitly without starting the segments flushers. In such cases the test 's logs contains exceptions which could lead to think that the test fails silently.
 
Avoid to invoke scheduledFlusher's shutdown when it's not started (**such behaviour is present only in tests**).

## Why is it important/What is the impact to the user?

The developer that looks at unit test output is not fooled by unrelated exceptions.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Run the 
```
./gradlew :logstash-core:javaTests --tests "org.logstash.common.io.DeadLetterQueueWriterAgeRetentionTest"
```

and check no exceptions are present in output stream.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #15560

