### PR TITLE
[ci] Skip Logstash PR checks when docs change

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -13,7 +13,9 @@
         "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
         "skip_ci_labels": [ ],
         "skip_target_branches": [ ],
-        "skip_ci_on_only_changed": [ ],
+        "skip_ci_on_only_changed": [
+          "^docs/"
+        ],
         "always_require_ci_on_changed": [ ]
       }
     ]


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

Changes made under `docs/` are unrelated to the PR tests triggered from this repo[^1]

Note that the current docs-specific Jenkins Job is getting migrated at an org level[^2] and this change will be merged soon.

[^1]: via `.buildkite/pull_requests_pipeline.yml`
[^2]: https://github.com/elastic/docs/blob/master/.buildkite/pull-requests.org-wide.json

## Related issues

- https://github.com/elastic/ingest-dev/issues/2703
