### PR TITLE
temporarily revert jruby 9.4.5.0 to facilitate artifact building

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -13,8 +13,8 @@ bundled_jdk:
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time
 jruby:
-  version: 9.4.5.0
-  sha1: 9f2d039c975659a641d5002d0999aec73b963260
+  version: 9.4.2.0
+  sha1: c338c1d3846e51b651e31e248097fdee4920056a
 # jruby-runtime-override, if specified, will override the jruby version installed in vendor/jruby
 #jruby-runtime-override:
 #  url: https://oss.sonatype.org/content/repositories/snapshots/org/jruby/jruby-dist/9.3.0.0-SNAPSHOT/jruby-dist-9.3.0.0-20210723.214927-259-bin.tar.gz


### PR DESCRIPTION
This is due to ./gradlew bootstrap failing on a branch that has jruby 9.4.3.0+ and a template lock file.

We need more time to investigate, so for now the goal is to revert to 9.4.2.0 so a 8.12.0 artifact can be produced.