### PR TITLE
Update catalog-info.yaml to include testing for 8.12 branch

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -154,6 +154,10 @@ spec:
           branch: '8.11'
           cronline: 30 02 * * *
           message: Daily SNAPSHOT build for 8.11
+        Daily 8_12:
+          branch: '8.12'
+          cronline: 30 02 * * *
+          message: Daily SNAPSHOT build for 8.12
         Daily main:
           branch: main
           cronline: 30 02 * * *


### PR DESCRIPTION
Don't remove 8.11 yet as we may have 8.11.x maintenance releases until 8.12.0 is GA.